### PR TITLE
feat(anki): 可开关的媒体去重自动处理（默认关）+ Lapis 三条取舍（1甲/2甲/3乙）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45679 (2687 per locale)
+/// Strings: 45815 (2695 per locale)
 ///
-/// Built on 2026-07-27 at 22:16 UTC
+/// Built on 2026-07-28 at 05:37 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3601,6 +3601,20 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  String get anki_dedup_auto => 'Automatic processing';
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  String get anki_dedup_auto_review => 'Review';
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -9737,6 +9751,28 @@ class _StringsAr extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -15941,6 +15977,28 @@ class _StringsDe extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -22161,6 +22219,28 @@ class _StringsEs extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -28392,6 +28472,28 @@ class _StringsFr extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -34552,6 +34654,28 @@ class _StringsId extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -40758,6 +40882,28 @@ class _StringsIt extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -46781,6 +46927,28 @@ class _StringsJa extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -52806,6 +52974,28 @@ class _StringsKo extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -58992,6 +59182,28 @@ class _StringsNl extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -65191,6 +65403,28 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -71374,6 +71608,28 @@ class _StringsRu extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -77505,6 +77761,28 @@ class _StringsTh extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -83668,6 +83946,28 @@ class _StringsTr extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -89816,6 +90116,28 @@ class _StringsVi extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 // Path: <root>
@@ -95533,6 +95855,28 @@ class _StringsZhCn extends _StringsEn {
       '无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。';
   @override
   String get collection_add_failed => '没能把该条目加进合集，请重试。';
+  @override
+  String get anki_dedup_auto => '自动处理';
+  @override
+  String get anki_dedup_auto_hint =>
+      '默认关闭。打开后 Hibiki 会在启动时扫描（最多每周一次）并先把清单给你看，你不确认就不会删任何文件。';
+  @override
+  String get anki_dedup_auto_delete => '自动直接删除（不再询问）';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      '跳过确认弹窗。仍然只删字节完全相同的多余副本、绝不重编码，但删除不可撤销。';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      '发现 ${count} 个重复的 Anki 媒体文件（可释放 ${size}）';
+  @override
+  String get anki_dedup_auto_review => '查看';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      '已删除 ${count} 个重复的 Anki 媒体文件，释放 ${size}';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      '已备份到 ${path}（按「保留 90 天、至少留 10 份」清理了 ${count} 份旧备份）';
 }
 
 // Path: <root>
@@ -101477,6 +101821,28 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get collection_add_failed =>
       'Couldn\'t add the item to the collection. Please try again.';
+  @override
+  String get anki_dedup_auto => 'Automatic processing';
+  @override
+  String get anki_dedup_auto_hint =>
+      'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+  @override
+  String get anki_dedup_auto_delete => 'Delete automatically without asking';
+  @override
+  String get anki_dedup_auto_delete_hint =>
+      'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+  @override
+  String anki_dedup_auto_found({required Object count, required Object size}) =>
+      'Found ${count} duplicate Anki media files (${size} reclaimable)';
+  @override
+  String get anki_dedup_auto_review => 'Review';
+  @override
+  String anki_dedup_auto_done({required Object count, required Object size}) =>
+      'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+  @override
+  String anki_lapis_backup_done_pruned(
+          {required Object path, required Object count}) =>
+      'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
 }
 
 /// Flat map(s) containing all translations.
@@ -106980,6 +107346,25 @@ extension on _StringsEn {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -112481,6 +112866,25 @@ extension on _StringsAr {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -118003,6 +118407,25 @@ extension on _StringsDe {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -123524,6 +123947,25 @@ extension on _StringsEs {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -129051,6 +129493,25 @@ extension on _StringsFr {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -134560,6 +135021,25 @@ extension on _StringsId {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -140084,6 +140564,25 @@ extension on _StringsIt {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -145570,6 +146069,25 @@ extension on _StringsJa {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -151060,6 +151578,25 @@ extension on _StringsKo {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -156577,6 +157114,25 @@ extension on _StringsNl {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -162091,6 +162647,25 @@ extension on _StringsPtBr {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -167610,6 +168185,25 @@ extension on _StringsRu {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -173113,6 +173707,25 @@ extension on _StringsTh {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -178625,6 +179238,25 @@ extension on _StringsTr {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -184132,6 +184764,25 @@ extension on _StringsVi {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }
@@ -189593,6 +190244,25 @@ extension on _StringsZhCn {
         return '无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。';
       case 'collection_add_failed':
         return '没能把该条目加进合集，请重试。';
+      case 'anki_dedup_auto':
+        return '自动处理';
+      case 'anki_dedup_auto_hint':
+        return '默认关闭。打开后 Hibiki 会在启动时扫描（最多每周一次）并先把清单给你看，你不确认就不会删任何文件。';
+      case 'anki_dedup_auto_delete':
+        return '自动直接删除（不再询问）';
+      case 'anki_dedup_auto_delete_hint':
+        return '跳过确认弹窗。仍然只删字节完全相同的多余副本、绝不重编码，但删除不可撤销。';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            '发现 ${count} 个重复的 Anki 媒体文件（可释放 ${size}）';
+      case 'anki_dedup_auto_review':
+        return '查看';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            '已删除 ${count} 个重复的 Anki 媒体文件，释放 ${size}';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            '已备份到 ${path}（按「保留 90 天、至少留 10 份」清理了 ${count} 份旧备份）';
       default:
         return null;
     }
@@ -195074,6 +195744,25 @@ extension on _StringsZhHk {
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       case 'collection_add_failed':
         return 'Couldn\'t add the item to the collection. Please try again.';
+      case 'anki_dedup_auto':
+        return 'Automatic processing';
+      case 'anki_dedup_auto_hint':
+        return 'Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.';
+      case 'anki_dedup_auto_delete':
+        return 'Delete automatically without asking';
+      case 'anki_dedup_auto_delete_hint':
+        return 'Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.';
+      case 'anki_dedup_auto_found':
+        return ({required Object count, required Object size}) =>
+            'Found ${count} duplicate Anki media files (${size} reclaimable)';
+      case 'anki_dedup_auto_review':
+        return 'Review';
+      case 'anki_dedup_auto_done':
+        return ({required Object count, required Object size}) =>
+            'Removed ${count} duplicate Anki media files, ${size} reclaimed';
+      case 'anki_lapis_backup_done_pruned':
+        return ({required Object path, required Object count}) =>
+            'Backed up to ${path} (${count} old backups pruned by the 90-day / keep-10 policy)';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "更多操作",
   "collection_already_has_item": "该条目已在这个合集里。",
   "drag_drop_manga_archive_unsupported": "无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。",
-  "collection_add_failed": "没能把该条目加进合集，请重试。"
+  "collection_add_failed": "没能把该条目加进合集，请重试。",
+  "anki_dedup_auto": "自动处理",
+  "anki_dedup_auto_hint": "默认关闭。打开后 Hibiki 会在启动时扫描（最多每周一次）并先把清单给你看，你不确认就不会删任何文件。",
+  "anki_dedup_auto_delete": "自动直接删除（不再询问）",
+  "anki_dedup_auto_delete_hint": "跳过确认弹窗。仍然只删字节完全相同的多余副本、绝不重编码，但删除不可撤销。",
+  "anki_dedup_auto_found": "发现 $count 个重复的 Anki 媒体文件（可释放 $size）",
+  "anki_dedup_auto_review": "查看",
+  "anki_dedup_auto_done": "已删除 $count 个重复的 Anki 媒体文件，释放 $size",
+  "anki_lapis_backup_done_pruned": "已备份到 $path（按「保留 90 天、至少留 10 份」清理了 $count 份旧备份）"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2685,5 +2685,13 @@
   "common_more_actions": "More actions",
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
-  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again.",
+  "anki_dedup_auto": "Automatic processing",
+  "anki_dedup_auto_hint": "Off by default. When on, Hibiki scans at startup (at most once a week) and shows you the list first — nothing is deleted until you confirm.",
+  "anki_dedup_auto_delete": "Delete automatically without asking",
+  "anki_dedup_auto_delete_hint": "Skips the confirmation dialog. Only byte-identical extra copies are ever removed and nothing is re-encoded, but deletion cannot be undone.",
+  "anki_dedup_auto_found": "Found $count duplicate Anki media files ($size reclaimable)",
+  "anki_dedup_auto_review": "Review",
+  "anki_dedup_auto_done": "Removed $count duplicate Anki media files, $size reclaimed",
+  "anki_lapis_backup_done_pruned": "Backed up to $path ($count old backups pruned by the 90-day / keep-10 policy)"
 }

--- a/hibiki/lib/src/anki/anki_media_dedup_dialogs.dart
+++ b/hibiki/lib/src/anki/anki_media_dedup_dialogs.dart
@@ -1,0 +1,128 @@
+/// Anki 媒体去重的共享弹窗：设置页的手动路径与启动自动处理路径**共用同一份**
+/// 干跑清单 / 结果报告 UI。
+///
+/// 抽出来的根因：自动处理开关加回来之后，「自动干跑 → 提示 → 用户确认才真删」
+/// 必须复用手动路径那个逐条列出「删哪些文件、各占多少空间、保留哪一份」的
+/// 确认弹窗。两份 UI 会漂移，漂移的那一份迟早变成「自动路径绕过确认」。
+library;
+
+import 'package:flutter/material.dart';
+import 'package:hibiki/utils.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+/// 干跑清单弹窗。[offerDelete] = 提供「删除这些文件」确认按钮（返回 true 才
+/// 执行真删）；false 时只是只读报告。没有可删的东西时不给删除按钮。
+Future<bool> showAnkiMediaDedupPlanDialog(
+  BuildContext context,
+  AnkiMediaDedupReport plan, {
+  required bool offerDelete,
+}) async {
+  if (plan.deletions.isEmpty) {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: Text(t.anki_dedup_plan_title),
+        content: Text(t.anki_dedup_report_clean),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: Text(t.dialog_ok),
+          ),
+        ],
+      ),
+    );
+    return false;
+  }
+  final bool? ok = await showDialog<bool>(
+    context: context,
+    builder: (BuildContext context) => AlertDialog(
+      title: Text(t.anki_dedup_plan_title),
+      content: SizedBox(
+        width: 420,
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(t.anki_dedup_plan_intro(
+                count: '${plan.duplicatesRemoved}',
+                size: formatAnkiMediaDedupBytes(plan.bytesSaved),
+              )),
+              const SizedBox(height: 12),
+              for (final MediaDedupDeletion d in plan.deletions)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 4),
+                  child: Text(t.anki_dedup_plan_entry(
+                    file: d.filename,
+                    size: formatAnkiMediaDedupBytes(d.bytes),
+                    canonical: d.canonical,
+                  )),
+                ),
+              const SizedBox(height: 12),
+              Text(offerDelete
+                  ? t.anki_dedup_plan_journal
+                  : t.anki_dedup_report_dry_note),
+            ],
+          ),
+        ),
+      ),
+      actions: [
+        if (!offerDelete)
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(t.dialog_ok),
+          ),
+        if (offerDelete) ...[
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: Text(t.dialog_cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: Text(t.anki_dedup_plan_delete),
+          ),
+        ],
+      ],
+    ),
+  );
+  return ok == true;
+}
+
+/// 真跑之后的结果报告。
+Future<void> showAnkiMediaDedupReportDialog(
+  BuildContext context,
+  AnkiMediaDedupReport result,
+) async {
+  final String body = result.groupCount == 0
+      ? t.anki_dedup_report_clean
+      : t.anki_dedup_report_body(
+          groups: '${result.groupCount}',
+          removed: '${result.duplicatesRemoved}',
+          size: formatAnkiMediaDedupBytes(result.bytesSaved),
+          notes: '${result.notesRewritten}',
+          models: '${result.modelsRewritten}',
+          skipped: '${result.skipped}',
+        );
+  await showDialog<void>(
+    context: context,
+    builder: (BuildContext context) => AlertDialog(
+      title: Text(t.anki_dedup_report_title),
+      content: Text(body),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(t.dialog_ok),
+        ),
+      ],
+    ),
+  );
+}
+
+/// 字节数 → 人类可读（B / KB / MB）。
+String formatAnkiMediaDedupBytes(int bytes) {
+  if (bytes >= 1024 * 1024) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+  if (bytes >= 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  return '$bytes B';
+}

--- a/hibiki/lib/src/anki/anki_media_dedup_runner.dart
+++ b/hibiki/lib/src/anki/anki_media_dedup_runner.dart
@@ -1,16 +1,56 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/storage/app_paths.dart';
 
-/// Anki 媒体字节级去重的应用层编排：journal 落盘 + 上次运行时间持久化。
+/// 自动处理两次扫描之间的最短间隔。全量哈希媒体目录不便宜，每次启动都跑没
+/// 必要；用户手动触发不受这个节流影响。
+const Duration kAnkiMediaDedupAutoInterval = Duration(days: 7);
+
+/// 自动处理该不该跑这一轮（纯函数，便于单测边界）。
 ///
-/// **没有任何自动/周期触发路径**（用户拍板方案 A）：唯一入口是设置页的手动
-/// 触发，而且必须先跑 [runNow] 的干跑拿到删除清单、由用户在弹窗里确认之后，
-/// 才会以 `dryRun: false` 再跑一次真删。Hibiki 不会在用户没点之前动任何文件。
+/// [lastScanAtMs] = 上次扫描完成时刻（epoch ms），null = 从未扫过 → 跑。
+bool shouldRunAutoMediaDedupScan({
+  required int? lastScanAtMs,
+  required DateTime now,
+  Duration interval = kAnkiMediaDedupAutoInterval,
+}) {
+  if (lastScanAtMs == null) return true;
+  final DateTime last = DateTime.fromMillisecondsSinceEpoch(lastScanAtMs);
+  return now.difference(last) >= interval;
+}
+
+/// 一轮自动处理的结果。
+///
+/// 数据结构本身就把「干跑」和「真删」分开：[plan] 永远是干跑清单，[applied]
+/// 只有在用户**显式**打开「自动直接删除」时才非空。UI 拿到 [needsConfirmation]
+/// == true 就必须先让用户确认才能删——自动路径不存在绕过确认的分支。
+class AnkiMediaDedupAutoOutcome {
+  const AnkiMediaDedupAutoOutcome({required this.plan, this.applied});
+
+  /// 干跑清单（删哪些、各多大、保留哪一份）。
+  final AnkiMediaDedupReport plan;
+
+  /// 已真删的结果。非 null ⟺ 用户显式打开了「自动直接删除」。
+  final AnkiMediaDedupReport? applied;
+
+  /// 有可删的东西、但还没删：UI 必须提示用户并拿到确认。
+  bool get needsConfirmation => applied == null && plan.deletions.isNotEmpty;
+}
+
+/// Anki 媒体字节级去重的应用层编排：journal 落盘 + 时刻持久化 + 自动处理闸门。
+///
+/// **默认没有任何自动路径**（用户拍板方案 A）：`mediaDedupAutoEnabled` 默认
+/// false，[maybeAutoRunOnStartup] 直接返回 null。用户可以在设置页主动打开自动
+/// 处理，打开之后**仍然只做干跑并提示**，必须确认才真删；只有再显式打开
+/// 「自动直接删除」才会跳过确认。原实现的缺陷正是「自动路径绕过确认框」，
+/// 把开关加回来不能把这个坑一起加回来。
+///
+/// 手动路径同样是「先干跑 → 用户确认 → 再真删」，见设置页 `_runMediaDedup`。
 ///
 /// 真实的扫描/改写/删除在 `BaseAnkiRepository.runMediaDedup`
 /// （AnkiConnect 实现）；本类只负责「每次真实改写/删除前把可回溯记录写进
@@ -19,6 +59,13 @@ class AnkiMediaDedupRunner {
   AnkiMediaDedupRunner(this._repository);
 
   final BaseAnkiRepository _repository;
+
+  /// 自动处理的会话级闸门：HomePage 可能重建，每进程只跑一次。
+  static bool _autoRanThisSession = false;
+
+  /// 测试用：重置会话级闸门。
+  @visibleForTesting
+  static void resetAutoSessionGate() => _autoRanThisSession = false;
 
   Future<Directory> journalDirectory() async {
     final Directory support = await AppPaths.supportRootDirectory();
@@ -49,8 +96,11 @@ class AnkiMediaDedupRunner {
         },
       );
       if (report != null) {
+        final int nowMs = DateTime.now().millisecondsSinceEpoch;
         await _repository.updateSettings((AnkiSettings s) => s.copyWith(
-            lastMediaDedupAtMs: DateTime.now().millisecondsSinceEpoch));
+              lastMediaDedupAtMs: nowMs,
+              lastMediaDedupScanAtMs: nowMs,
+            ));
       }
       return report;
     } finally {
@@ -59,5 +109,50 @@ class AnkiMediaDedupRunner {
       // 这一轮啥也没改（无重复/全跳过）：不留空 journal 文件。
       if (!wroteAny && await journal.exists()) await journal.delete();
     }
+  }
+
+  /// 启动时的自动处理。返回 null = 这一轮什么都没做（开关关着 / 后端不支持 /
+  /// 还没到间隔 / 本进程已跑过）。
+  ///
+  /// 打开开关之后的确切行为：**只跑干跑**，把清单经 [AnkiMediaDedupAutoOutcome]
+  /// 交回 UI 提示，用户确认后才由 UI 调 `runNow(dryRun: false)` 真删。只有用户
+  /// 另外显式打开「自动直接删除」（`mediaDedupAutoDelete`），这里才会直接接上
+  /// 真删并把结果放进 [AnkiMediaDedupAutoOutcome.applied]。
+  Future<AnkiMediaDedupAutoOutcome?> maybeAutoRunOnStartup({
+    DateTime? now,
+  }) async {
+    if (_autoRanThisSession) return null;
+    _autoRanThisSession = true;
+    if (!_repository.supportsMediaMaintenance) return null;
+    final AnkiSettings settings = await _repository.loadSettings();
+    // 默认关：用户没主动打开，Hibiki 连扫都不扫。
+    if (!settings.mediaDedupAutoEnabled) return null;
+    final DateTime at = now ?? DateTime.now();
+    if (!shouldRunAutoMediaDedupScan(
+      lastScanAtMs: settings.lastMediaDedupScanAtMs,
+      now: at,
+    )) {
+      return null;
+    }
+    final AnkiMediaDedupReport? plan =
+        await _repository.runMediaDedup(dryRun: true);
+    if (plan == null) return null;
+    await _repository.updateSettings((AnkiSettings s) =>
+        s.copyWith(lastMediaDedupScanAtMs: at.millisecondsSinceEpoch));
+    if (plan.deletions.isEmpty) {
+      return AnkiMediaDedupAutoOutcome(plan: plan);
+    }
+    if (!settings.mediaDedupAutoDelete) {
+      // 保守路径（默认）：只给清单，删不删由用户在确认弹窗里定。
+      debugPrint('AnkiMediaDedupRunner.auto: ${plan.deletions.length} '
+          'duplicates found, awaiting user confirmation');
+      return AnkiMediaDedupAutoOutcome(plan: plan);
+    }
+    debugPrint('AnkiMediaDedupRunner.auto: auto-delete explicitly enabled, '
+        'removing ${plan.deletions.length} duplicates');
+    return AnkiMediaDedupAutoOutcome(
+      plan: plan,
+      applied: await runNow(dryRun: false),
+    );
   }
 }

--- a/hibiki/lib/src/anki/anki_view_model.dart
+++ b/hibiki/lib/src/anki/anki_view_model.dart
@@ -272,6 +272,21 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
   /// 与当前仓库绑定的去重编排器（无状态，随用随建）。
   AnkiMediaDedupRunner get mediaDedupRunner =>
       AnkiMediaDedupRunner(_repository);
+
+  /// 打开/关闭去重的自动处理。默认关；打开后自动路径**仍然只做干跑并提示**，
+  /// 要真删得由用户在确认弹窗里点，或另外打开 [setMediaDedupAutoDelete]。
+  Future<void> setMediaDedupAutoEnabled(bool enabled) async {
+    final updated = await _repository
+        .updateSettings((s) => s.copyWith(mediaDedupAutoEnabled: enabled));
+    state = state.copyWith(settings: updated);
+  }
+
+  /// 打开/关闭「自动直接删除」（跳过确认弹窗）。只在自动处理已打开时有意义。
+  Future<void> setMediaDedupAutoDelete(bool enabled) async {
+    final updated = await _repository
+        .updateSettings((s) => s.copyWith(mediaDedupAutoDelete: enabled));
+    state = state.copyWith(settings: updated);
+  }
 }
 
 /// 把用户敲/粘进 AnkiConnect **主机**字段的自由文本规范化成裸主机 + 可选端口。

--- a/hibiki/lib/src/anki/lapis_backup_retention.dart
+++ b/hibiki/lib/src/anki/lapis_backup_retention.dart
@@ -1,0 +1,65 @@
+/// Lapis 模板备份的保留策略（纯函数层）。
+///
+/// 用户拍板（PR#457 审查 §10-5a 方案乙）：**保留 90 天，但至少留最近 10 份**
+/// ——两个条件同时成立才删。删除不可逆，所以这里只做「规划」，真正删文件与
+/// 逐条日志在 `LapisTemplateService.pruneBackups`。
+///
+/// 保守边界（刻意）：
+/// - 最近 [kLapisBackupKeepMinimum] 份**永远**不参与判定，哪怕早就过期；
+/// - 年龄用 `>` 严格比较：正好 90 天的备份留着；
+/// - 文件名解析不出时刻的一律保留（宁可留着，也不在年龄未知时删）。
+library;
+
+/// 备份最长保留时长。超过这个年龄**且**排在最近 [kLapisBackupKeepMinimum]
+/// 份之外才会被删。
+const Duration kLapisBackupMaxAge = Duration(days: 90);
+
+/// 无论多旧都要保留的最近备份份数。
+const int kLapisBackupKeepMinimum = 10;
+
+/// 从备份文件名解析 UTC 时刻。
+///
+/// 文件名格式 `lapis-<ISO8601，冒号替换成 '-'>.json`（见
+/// `LapisTemplateService._writeBackupFile`：Windows 文件名不允许冒号）。解析
+/// 不出返回 `null`——调用方必须把它当「年龄不可判定」= 永不删除。
+DateTime? parseLapisBackupTimestamp(String filename) {
+  if (!filename.startsWith('lapis-') || !filename.endsWith('.json')) {
+    return null;
+  }
+  final String raw =
+      filename.substring('lapis-'.length, filename.length - '.json'.length);
+  // 时间部分的三个 '-' 还原成 ':'；日期部分的 '-' 本就是 ISO 分隔符，不能动。
+  final String iso = raw.replaceFirstMapped(
+    RegExp(r'T(\d{2})-(\d{2})-(\d{2})'),
+    (Match m) => 'T${m[1]}:${m[2]}:${m[3]}',
+  );
+  return DateTime.tryParse(iso);
+}
+
+/// 规划要删除的备份条目。
+///
+/// [newestFirst] 必须按**新 → 旧**排序（`LapisTemplateService.listBackups`
+/// 的契约）。返回的就是可以删的那些，顺序与输入一致。
+///
+/// 判据（两个条件同时满足）：
+/// 1. 排在最近 [keepMinimum] 份之外；
+/// 2. `now - 时刻` **严格大于** [maxAge]。
+///
+/// [timestampOf] 返回 `null` 表示时刻不可判定 → 该条目一律保留。
+List<T> planLapisBackupPrune<T>(
+  List<T> newestFirst, {
+  required DateTime? Function(T item) timestampOf,
+  required DateTime now,
+  int keepMinimum = kLapisBackupKeepMinimum,
+  Duration maxAge = kLapisBackupMaxAge,
+}) {
+  if (newestFirst.length <= keepMinimum) return <T>[];
+  final List<T> doomed = <T>[];
+  for (int i = keepMinimum; i < newestFirst.length; i++) {
+    final T item = newestFirst[i];
+    final DateTime? at = timestampOf(item);
+    if (at == null) continue;
+    if (now.difference(at) > maxAge) doomed.add(item);
+  }
+  return doomed;
+}

--- a/hibiki/lib/src/anki/lapis_template_service.dart
+++ b/hibiki/lib/src/anki/lapis_template_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:hibiki/src/anki/lapis_backup_retention.dart';
 import 'package:hibiki/src/storage/app_paths.dart';
 
 /// 显式「应用样式到 Anki」的结果（设置页据此提示/弹确认）。
@@ -56,11 +57,41 @@ class LapisTemplateService {
 
   /// 手动备份按钮入口：读回当前 Lapis 定义并落盘。模型不存在 / 后端不支持
   /// 返回 null（UI 提示），读写失败照抛。
-  Future<File?> backupNow() async {
+  Future<LapisBackupOutcome?> backupNow() async {
     final AnkiNoteTypeDefinition? def =
         await _repository.readNoteTypeDefinition(LapisNoteType.modelName);
     if (def == null) return null;
     return _writeBackupFile(def);
+  }
+
+  /// 按保留策略清理旧备份：**保留 90 天，且无论如何最少留最近 10 份**
+  /// （PR#457 审查 §10-5a，用户拍板方案乙）。返回真正删掉的文件。
+  ///
+  /// 只在**用户主动触发的备份写盘之后**跑（手动备份 / 应用样式 / 从备份恢复
+  /// ——三条路径都会先落一份新备份），不挂任何后台定时器：删除不可逆，不能在
+  /// 用户没预期的时机静默批量删。每删一份都 debugPrint 记下文件名，手动备份
+  /// 路径还会把份数回给 UI 提示。
+  ///
+  /// 删不掉（占用/权限）只记日志，不让备份本身失败——新备份已经落地了。
+  Future<List<File>> pruneBackups({DateTime? now}) async {
+    final List<File> backups = await listBackups(); // 新 → 旧
+    final List<File> doomed = planLapisBackupPrune<File>(
+      backups,
+      timestampOf: (File f) => parseLapisBackupTimestamp(p.basename(f.path)),
+      now: now ?? DateTime.now().toUtc(),
+    );
+    final List<File> deleted = <File>[];
+    for (final File f in doomed) {
+      final String name = p.basename(f.path);
+      try {
+        await f.delete();
+        deleted.add(f);
+        debugPrint('LapisTemplateService.pruneBackups: deleted $name');
+      } catch (e) {
+        debugPrint('LapisTemplateService.pruneBackups: kept $name ($e)');
+      }
+    }
+    return deleted;
   }
 
   /// 现有备份，新的在前（文件名含 ISO 时间戳，字典序即时间序）。
@@ -109,10 +140,15 @@ class LapisTemplateService {
       lastAppliedSha: settings.lapisAppliedCssSha,
     );
     if (decision == LapisStylingDecision.upToDate) {
-      // 内容已一致但指纹可能还没记（老装置首次升级）：补记。
-      if (settings.lapisAppliedCssSha == null) {
-        await _repository.updateSettings((AnkiSettings s) =>
-            s.copyWith(lapisAppliedCssSha: lapisCssSha256(expected)));
+      // 内容已一致但指纹可能还没记（老装置首次升级）：补记。基线指纹同理——
+      // Anki 上就是「当前基线 + 当前用户区段」，这个基线已经算迁移过了。
+      if (settings.lapisAppliedCssSha == null ||
+          settings.lapisMigratedBaselineSha != currentLapisBaselineSha) {
+        await _repository.updateSettings((AnkiSettings s) => s.copyWith(
+              lapisAppliedCssSha:
+                  s.lapisAppliedCssSha ?? lapisCssSha256(expected),
+              lapisMigratedBaselineSha: currentLapisBaselineSha,
+            ));
       }
       return LapisApplyResult.upToDate;
     }
@@ -123,10 +159,13 @@ class LapisTemplateService {
     return LapisApplyResult.applied;
   }
 
-  /// 启动自动迁移：Hibiki 基线或客制化变了，且 Anki 端还是 Hibiki 已知产物
-  /// （上次推送指纹 / 出厂基线）时，自动备份后推送新 styling。手改内容
-  /// （foreignEdit）绝不自动覆盖。每进程最多跑一次；Anki 未运行时静默跳过
-  /// （常态，不是错误，下次启动再试）。
+  /// 启动自动迁移：**只有 Hibiki 出厂基线真的变了**才自动备份并推送新
+  /// styling。手改内容（foreignEdit）绝不自动覆盖。每进程最多跑一次；Anki
+  /// 未运行时静默跳过（常态，不是错误，下次启动再试）。
+  ///
+  /// 基线闸门（PR#457 审查 §10-3，用户拍板方案甲）：改字号 / 自定义 CSS 却
+  /// 没点「应用样式到 Anki」时，这里**什么都不做**——Apply 是用户内容写进
+  /// Anki 的唯一闸门。判据见 [shouldAutoMigrateLapisBaseline]。
   Future<void> maybeAutoMigrateOnStartup() async {
     if (_autoMigrateRanThisSession) return;
     _autoMigrateRanThisSession = true;
@@ -145,6 +184,21 @@ class LapisTemplateService {
       fontScalePercent: settings.lapisFontScalePercent,
       customCss: settings.lapisCustomCss,
     );
+    final String baselineSha = currentLapisBaselineSha;
+    if (!shouldAutoMigrateLapisBaseline(
+      migratedBaselineSha: settings.lapisMigratedBaselineSha,
+      ankiCss: def.css,
+    )) {
+      // 基线没变：用户没点 Apply 就不动 Anki。顺手把基线指纹补记上（老装置
+      // 首次升级上来是 null），之后连判都不用判。
+      if (settings.lapisMigratedBaselineSha != baselineSha) {
+        await _repository.updateSettings((AnkiSettings s) =>
+            s.copyWith(lapisMigratedBaselineSha: baselineSha));
+      }
+      debugPrint('LapisTemplateService.autoMigrate: baseline unchanged, '
+          'skipped (Apply is the only write gate)');
+      return;
+    }
     final LapisStylingDecision decision = decideLapisStylingAction(
       ankiCss: def.css,
       expectedCss: expected,
@@ -152,15 +206,17 @@ class LapisTemplateService {
     );
     switch (decision) {
       case LapisStylingDecision.upToDate:
-        if (settings.lapisAppliedCssSha == null) {
-          await _repository.updateSettings((AnkiSettings s) =>
-              s.copyWith(lapisAppliedCssSha: lapisCssSha256(expected)));
-        }
+        await _repository.updateSettings((AnkiSettings s) => s.copyWith(
+              lapisAppliedCssSha:
+                  s.lapisAppliedCssSha ?? lapisCssSha256(expected),
+              lapisMigratedBaselineSha: baselineSha,
+            ));
       case LapisStylingDecision.safeUpdate:
         await _pushStyling(def, expected);
-        debugPrint('LapisTemplateService.autoMigrate: styling migrated');
+        debugPrint('LapisTemplateService.autoMigrate: baseline migrated');
       case LapisStylingDecision.foreignEdit:
-        // 用户手改过：不动。显式「应用」流程里有确认弹窗兜这条路。
+        // 用户手改过：不动，也不记基线（下次启动还要再判）。显式「应用」
+        // 流程里有确认弹窗兜这条路。
         break;
     }
   }
@@ -170,8 +226,10 @@ class LapisTemplateService {
   /// 恢复后把 Hibiki 侧客制化状态与备份**对齐**，否则下次启动的自动迁移会把
   /// 刚恢复的内容又覆写回去（根因：期望态与 Anki 态不一致 + 指纹仍认识
   /// Anki 态 = safeUpdate）：
-  /// - 备份含用户区段 → 区段正文回填 `lapisCustomCss`（字号缩放已含在正文
-  ///   里，`lapisFontScalePercent` 归 100），期望态 == 恢复态。
+  /// - 备份含用户区段 → 正文用 [splitLapisUserSectionBody] **拆回**「字号
+  ///   百分比 + 自由 CSS」再回填，期望态 == 恢复态。拆分而不是整段塞进
+  ///   `lapisCustomCss`：整段塞会让旧缩放块永远排在新缩放块之后并盖住它，
+  ///   恢复之后字号选择器就成了死控件（PR#457 审查 §10-2）。
   /// - 备份无用户区段 → 清空客制化并**清掉指纹**：若恢复的是出厂基线，漂移
   ///   判定本就允许升级；若是手改快照，判定变 foreignEdit，自动迁移不再动它。
   ///
@@ -197,11 +255,16 @@ class LapisTemplateService {
     // 「Anki 是恢复态、Hibiki 期望态还是旧的」窗口，下次启动的漂移判定读到过期
     // 期望态。所以对齐排在卡模板写入之前——卡模板失败不该连累 styling 状态。
     final String? body = extractLapisUserSectionBody(def.css);
+    final LapisUserSectionSplit? split =
+        body == null ? null : splitLapisUserSectionBody(body);
     await _repository.updateSettings((AnkiSettings s) => s.copyWith(
-          lapisFontScalePercent: 100,
-          lapisCustomCss: body ?? '',
+          lapisFontScalePercent: split?.fontScalePercent ?? 100,
+          lapisCustomCss: split?.customCss ?? '',
           lapisAppliedCssSha: body != null ? lapisCssSha256(def.css) : null,
           clearLapisAppliedCssSha: body == null,
+          // 恢复是用户对「Anki 里该是什么」的显式决定，启动自动迁移不得把它
+          // 撤销：记下当前基线 = 这个基线已处理过，只有**将来**基线再变才推。
+          lapisMigratedBaselineSha: currentLapisBaselineSha,
         ));
     // 卡模板（settings 不持有其状态）单独写。返回 false = 后端拒写，必须上抛
     // 让 UI 报「恢复失败」——吞掉它会把「只恢复了 styling」谎报成完整恢复。
@@ -219,11 +282,14 @@ class LapisTemplateService {
     await _writeBackupFile(def);
     final bool ok = await _repository.updateNoteTypeStyling(def.name, css);
     if (!ok) throw StateError('Backend rejected styling update');
-    await _repository.updateSettings((AnkiSettings s) =>
-        s.copyWith(lapisAppliedCssSha: lapisCssSha256(css)));
+    await _repository.updateSettings((AnkiSettings s) => s.copyWith(
+          lapisAppliedCssSha: lapisCssSha256(css),
+          lapisMigratedBaselineSha: currentLapisBaselineSha,
+        ));
   }
 
-  Future<File> _writeBackupFile(AnkiNoteTypeDefinition def) async {
+  Future<LapisBackupOutcome> _writeBackupFile(
+      AnkiNoteTypeDefinition def) async {
     final Directory dir = await backupDirectory();
     // Windows 文件名不允许冒号；替换后仍保持字典序 == 时间序。
     final String stamp =
@@ -235,6 +301,21 @@ class LapisTemplateService {
       'exportedAt': DateTime.now().toUtc().toIso8601String(),
       'noteType': def.toJson(),
     }));
-    return file;
+    // 保留策略只在这里生效：新备份已经落地（备份门已过），再按 90 天 / 最少
+    // 10 份清理。顺序不能反——先删后写会在写盘失败时既没新备份也少了旧备份。
+    return LapisBackupOutcome(file: file, pruned: await pruneBackups());
   }
+}
+
+/// 一次备份写盘的结果：新落地的备份文件 + 本次按保留策略清理掉的旧备份。
+class LapisBackupOutcome {
+  const LapisBackupOutcome({required this.file, required this.pruned});
+
+  /// 新写入的备份文件。
+  final File file;
+
+  /// 本次真正删掉的旧备份（可能为空）。UI 据此告诉用户清理了几份。
+  final List<File> pruned;
+
+  int get prunedCount => pruned.length;
 }

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -6,6 +6,8 @@ import 'package:hibiki/models.dart';
 import 'package:hibiki/utils.dart';
 
 import 'package:hibiki_anki/hibiki_anki.dart';
+import 'package:hibiki/src/anki/anki_media_dedup_dialogs.dart';
+import 'package:hibiki/src/anki/lapis_backup_retention.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/anki/lapis_template_service.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart'
@@ -111,13 +113,12 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
                 icon: Icons.format_size_outlined,
                 showIcon: true,
                 selected: settings.lapisFontScalePercent,
-                options: const [
-                  AdaptiveSettingsPickerOption(value: 80, label: '80%'),
-                  AdaptiveSettingsPickerOption(value: 90, label: '90%'),
-                  AdaptiveSettingsPickerOption(value: 100, label: '100%'),
-                  AdaptiveSettingsPickerOption(value: 110, label: '110%'),
-                  AdaptiveSettingsPickerOption(value: 125, label: '125%'),
-                  AdaptiveSettingsPickerOption(value: 150, label: '150%'),
+                // 档位表来自 hibiki_anki 的单一真相源：从备份恢复时
+                // splitLapisUserSectionBody 会优先反解出这些档位，选择器与
+                // 反解各写一份迟早漂成「显示了一个档位表里没有的值」。
+                options: <AdaptiveSettingsPickerOption<int>>[
+                  for (final int p in kLapisFontScalePresets)
+                    AdaptiveSettingsPickerOption<int>(value: p, label: '$p%'),
                 ],
                 onChanged: (int v) => vm.setLapisFontScalePercent(v),
               ),
@@ -158,12 +159,33 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
           ),
         // 媒体存储优化：字节级去重（只删字节相同的多余副本，绝不重编码）。
         // 需要与 Anki 同机（本机可直读 collection.media），后端不支持时整区隐藏。
-        // 用户拍板方案 A：**没有任何自动/周期路径**，只有这里的手动触发，且
-        // 真删前必须先看干跑清单并确认。
+        // 用户拍板方案 A：默认不跑；自动处理是一个**默认关**的开关，打开之后
+        // 也只是自动干跑并提示，真删仍要用户确认——除非再显式打开「自动直接
+        // 删除」。手动触发同样先看干跑清单再确认。
         if (vm.supportsMediaMaintenance)
           AdaptiveSettingsSection(
             title: t.anki_dedup_section,
             children: [
+              AdaptiveSettingsSwitchRow(
+                icon: Icons.autorenew_outlined,
+                showIcon: true,
+                title: t.anki_dedup_auto,
+                subtitle: t.anki_dedup_auto_hint,
+                value: settings.mediaDedupAutoEnabled,
+                onChanged: (bool v) => vm.setMediaDedupAutoEnabled(v),
+              ),
+              // 从属开关：自动处理关着的时候它无意义，置灰而不是隐藏——隐藏
+              // 会让用户以为「打开自动 = 直接删」。
+              AdaptiveSettingsSwitchRow(
+                icon: Icons.delete_forever_outlined,
+                showIcon: true,
+                title: t.anki_dedup_auto_delete,
+                subtitle: t.anki_dedup_auto_delete_hint,
+                value: settings.mediaDedupAutoDelete,
+                onChanged: settings.mediaDedupAutoEnabled
+                    ? (bool v) => vm.setMediaDedupAutoDelete(v)
+                    : null,
+              ),
               AdaptiveSettingsRow(
                 icon: Icons.search_outlined,
                 showIcon: true,
@@ -580,11 +602,10 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
     final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
     setState(() => _lapisBusy = true);
     try {
-      final File? file = await vm.lapisTemplateService.backupNow();
+      final LapisBackupOutcome? outcome =
+          await vm.lapisTemplateService.backupNow();
       messenger.showSnackBar(SnackBar(
-        content: Text(file == null
-            ? t.anki_lapis_not_found
-            : t.anki_lapis_backup_done(path: file.path)),
+        content: Text(_lapisBackupMessage(outcome)),
       ));
     } catch (e) {
       messenger.showSnackBar(
@@ -675,7 +696,7 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   Future<void> _scanMediaDedup(AnkiViewModel vm) async {
     final AnkiMediaDedupReport? plan = await _runDedupPass(vm, dryRun: true);
     if (plan == null || !mounted) return;
-    await _showDedupPlanDialog(plan, offerDelete: false);
+    await showAnkiMediaDedupPlanDialog(context, plan, offerDelete: false);
   }
 
   /// 「立即去重」：**永远先干跑**，把「删哪些文件、各占多少空间、保留的是哪
@@ -684,11 +705,12 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
   Future<void> _runMediaDedup(AnkiViewModel vm) async {
     final AnkiMediaDedupReport? plan = await _runDedupPass(vm, dryRun: true);
     if (plan == null || !mounted) return;
-    final bool confirmed = await _showDedupPlanDialog(plan, offerDelete: true);
+    final bool confirmed =
+        await showAnkiMediaDedupPlanDialog(context, plan, offerDelete: true);
     if (!confirmed || !mounted) return;
     final AnkiMediaDedupReport? result = await _runDedupPass(vm, dryRun: false);
     if (result == null || !mounted) return;
-    await _showDedupReportDialog(result);
+    await showAnkiMediaDedupReportDialog(context, result);
   }
 
   /// 跑一遍去重（干跑或真跑）。后端不支持 / 出错时给出提示并返回 null。
@@ -715,130 +737,28 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
     return report;
   }
 
-  /// 干跑清单弹窗。[offerDelete] = 提供「删除这些文件」确认按钮（返回 true 才
-  /// 执行真删）；false 时只是只读报告。没有可删的东西时不给删除按钮。
-  Future<bool> _showDedupPlanDialog(
-    AnkiMediaDedupReport plan, {
-    required bool offerDelete,
-  }) async {
-    if (plan.deletions.isEmpty) {
-      await showDialog<void>(
-        context: context,
-        builder: (BuildContext context) => AlertDialog(
-          title: Text(t.anki_dedup_plan_title),
-          content: Text(t.anki_dedup_report_clean),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: Text(t.dialog_ok),
-            ),
-          ],
-        ),
-      );
-      return false;
+  /// 手动备份的提示文案：顺带告诉用户按保留策略清理了几份旧备份（删除不可
+  /// 逆，必须让用户看得见结果）。
+  String _lapisBackupMessage(LapisBackupOutcome? outcome) {
+    if (outcome == null) return t.anki_lapis_not_found;
+    if (outcome.prunedCount == 0) {
+      return t.anki_lapis_backup_done(path: outcome.file.path);
     }
-    final bool? ok = await showDialog<bool>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: Text(t.anki_dedup_plan_title),
-        content: SizedBox(
-          width: 420,
-          child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Text(t.anki_dedup_plan_intro(
-                  count: '${plan.duplicatesRemoved}',
-                  size: _formatBytes(plan.bytesSaved),
-                )),
-                const SizedBox(height: 12),
-                for (final MediaDedupDeletion d in plan.deletions)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 4),
-                    child: Text(t.anki_dedup_plan_entry(
-                      file: d.filename,
-                      size: _formatBytes(d.bytes),
-                      canonical: d.canonical,
-                    )),
-                  ),
-                const SizedBox(height: 12),
-                Text(offerDelete
-                    ? t.anki_dedup_plan_journal
-                    : t.anki_dedup_report_dry_note),
-              ],
-            ),
-          ),
-        ),
-        actions: [
-          if (!offerDelete)
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(t.dialog_ok),
-            ),
-          if (offerDelete) ...[
-            TextButton(
-              onPressed: () => Navigator.pop(context, false),
-              child: Text(t.dialog_cancel),
-            ),
-            TextButton(
-              onPressed: () => Navigator.pop(context, true),
-              child: Text(t.anki_dedup_plan_delete),
-            ),
-          ],
-        ],
-      ),
+    return t.anki_lapis_backup_done_pruned(
+      path: outcome.file.path,
+      count: '${outcome.prunedCount}',
     );
-    return ok == true;
-  }
-
-  /// 真跑之后的结果报告。
-  Future<void> _showDedupReportDialog(AnkiMediaDedupReport result) async {
-    final String body = result.groupCount == 0
-        ? t.anki_dedup_report_clean
-        : t.anki_dedup_report_body(
-            groups: '${result.groupCount}',
-            removed: '${result.duplicatesRemoved}',
-            size: _formatBytes(result.bytesSaved),
-            notes: '${result.notesRewritten}',
-            models: '${result.modelsRewritten}',
-            skipped: '${result.skipped}',
-          );
-    await showDialog<void>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: Text(t.anki_dedup_report_title),
-        content: Text(body),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: Text(t.dialog_ok),
-          ),
-        ],
-      ),
-    );
-  }
-
-  static String _formatBytes(int bytes) {
-    if (bytes >= 1024 * 1024) {
-      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    }
-    if (bytes >= 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    return '$bytes B';
   }
 
   /// 备份文件名 `lapis-<ISO时间戳(冒号→'-')>.json` → 本地可读时间标签；
-  /// 解析失败原样显示文件名主体（仍可区分）。
+  /// 解析失败原样显示文件名主体（仍可区分）。时刻解析走
+  /// [parseLapisBackupTimestamp]——保留策略用的是同一份判据，两处各写一个
+  /// 正则就会出现「界面认得出、清理认不出（于是永不删）」这种静默错位。
   String _lapisBackupLabel(File f) {
-    final String raw = f.uri.pathSegments.last
-        .replaceFirst('lapis-', '')
-        .replaceFirst('.json', '');
-    final String iso = raw.replaceFirstMapped(
-      RegExp(r'T(\d{2})-(\d{2})-(\d{2})'),
-      (Match m) => 'T${m[1]}:${m[2]}:${m[3]}',
-    );
-    final DateTime? dt = DateTime.tryParse(iso)?.toLocal();
-    return dt != null ? dt.toString().split('.').first : raw;
+    final String name = f.uri.pathSegments.last;
+    final DateTime? dt = parseLapisBackupTimestamp(name)?.toLocal();
+    if (dt != null) return dt.toString().split('.').first;
+    return name.replaceFirst('lapis-', '').replaceFirst('.json', '');
   }
 
   Widget _buildDeckDropdown(AnkiSettings settings, AnkiViewModel vm) {

--- a/hibiki/lib/src/pages/implementations/home_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_page.dart
@@ -14,6 +14,9 @@ import 'package:macos_ui/macos_ui.dart'
         MacosBackButton,
         MacosIcon;
 import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:hibiki_anki/hibiki_anki.dart' show AnkiMediaDedupReport;
+import 'package:hibiki/src/anki/anki_media_dedup_dialogs.dart';
+import 'package:hibiki/src/anki/anki_media_dedup_runner.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart'
     show ankiRepositoryProvider;
 import 'package:hibiki/src/anki/lapis_template_service.dart';
@@ -333,7 +336,64 @@ class _HomePageState extends BasePageState<HomePage>
           ErrorLogService.instance.log('HomePage.lapisAutoMigrate', e, s);
         }));
       }
+
+      // Anki 媒体去重的自动处理：**默认关**，只有用户在设置页主动打开才会跑。
+      // 打开之后也只是自动干跑并把清单提示出来，用户确认后才真删；只有再显式
+      // 打开「自动直接删除」才跳过确认（判定全在
+      // [AnkiMediaDedupRunner.maybeAutoRunOnStartup]，这里不做二次决策）。
+      if (mounted) {
+        unawaited(
+            _maybeAutoDedupAnkiMedia().catchError((Object e, StackTrace s) {
+          ErrorLogService.instance.log('HomePage.ankiMediaDedupAuto', e, s);
+        }));
+      }
     });
+  }
+
+  /// 启动期自动处理一轮 Anki 媒体去重的 UI 侧收尾：报结果，或提示 + 等确认。
+  Future<void> _maybeAutoDedupAnkiMedia() async {
+    final AnkiMediaDedupAutoOutcome? outcome =
+        await AnkiMediaDedupRunner(ref.read(ankiRepositoryProvider))
+            .maybeAutoRunOnStartup();
+    if (outcome == null || !mounted) return;
+    final AnkiMediaDedupReport? applied = outcome.applied;
+    if (applied != null) {
+      // 用户显式选了「自动直接删除」：只报结果。
+      ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+        content: Text(t.anki_dedup_auto_done(
+          count: '${applied.duplicatesRemoved}',
+          size: formatAnkiMediaDedupBytes(applied.bytesSaved),
+        )),
+      ));
+      return;
+    }
+    if (!outcome.needsConfirmation) return;
+    // 保守路径（默认）：只提示。用户点「查看」才摊开逐条清单，再点删除才真删。
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(t.anki_dedup_auto_found(
+        count: '${outcome.plan.duplicatesRemoved}',
+        size: formatAnkiMediaDedupBytes(outcome.plan.bytesSaved),
+      )),
+      duration: const Duration(seconds: 10),
+      action: SnackBarAction(
+        label: t.anki_dedup_auto_review,
+        onPressed: () => unawaited(_reviewAutoDedupPlan(outcome.plan)),
+      ),
+    ));
+  }
+
+  /// 「查看」→ 逐条清单 + 删除确认 → 真删 → 结果报告。与设置页手动路径同一
+  /// 套弹窗（见 anki_media_dedup_dialogs.dart）。
+  Future<void> _reviewAutoDedupPlan(AnkiMediaDedupReport plan) async {
+    if (!mounted) return;
+    final bool confirmed =
+        await showAnkiMediaDedupPlanDialog(context, plan, offerDelete: true);
+    if (!confirmed || !mounted) return;
+    final AnkiMediaDedupReport? result =
+        await AnkiMediaDedupRunner(ref.read(ankiRepositoryProvider))
+            .runNow(dryRun: false);
+    if (result == null || !mounted) return;
+    await showAnkiMediaDedupReportDialog(context, result);
   }
 
   /// 触发一次 app-open 语义的全量双向同步（导入远端新书 + 同步进度 / 内容 / 词典 / 有声书

--- a/hibiki/test/anki/anki_media_dedup_auto_test.dart
+++ b/hibiki/test/anki/anki_media_dedup_auto_test.dart
@@ -1,0 +1,245 @@
+// 用户拍板「加一个可以打开的自动处理」之后的守卫：
+//   1. 自动处理**默认关**——不开就连扫都不扫，一个文件都不会动；
+//   2. 打开之后仍然只做**干跑并提示**，真删必须用户确认；
+//   3. 只有用户**另外显式**打开「自动直接删除」，自动路径才会跳过确认去删。
+//
+// 原实现的缺陷正是「自动路径绕过确认框」，所以把开关加回来时这三条必须结构性
+// 成立，而不是靠 UI 自觉。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/anki/anki_media_dedup_runner.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+class _TempDirRunner extends AnkiMediaDedupRunner {
+  _TempDirRunner(super.repository, this._dir);
+
+  final Directory _dir;
+
+  @override
+  Future<Directory> journalDirectory() async => _dir;
+}
+
+class _FakeRepo extends BaseAnkiRepository {
+  _FakeRepo({required this.settings, this.deletions = 1});
+
+  AnkiSettings settings;
+
+  /// 干跑清单里有几条（0 = 没有重复）。
+  final int deletions;
+
+  /// 每次 runMediaDedup 的 dryRun 取值，按调用顺序记录。
+  final List<bool> dedupCalls = <bool>[];
+
+  @override
+  bool get supportsMediaMaintenance => true;
+
+  @override
+  Future<AnkiSettings> loadSettings() async => settings;
+
+  @override
+  Future<void> saveSettings(AnkiSettings s) async => settings = s;
+
+  @override
+  Future<AnkiMediaDedupReport?> runMediaDedup({
+    bool dryRun = false,
+    Future<void> Function(Map<String, dynamic> entry)? onJournal,
+  }) async {
+    dedupCalls.add(dryRun);
+    return AnkiMediaDedupReport(
+      dryRun: dryRun,
+      groupCount: deletions == 0 ? 0 : 1,
+      deletions: <MediaDedupDeletion>[
+        for (int i = 0; i < deletions; i++)
+          MediaDedupDeletion(
+              filename: 'dupe$i.jpg', canonical: 'keep.jpg', bytes: 1024),
+      ],
+      notesRewritten: 0,
+      modelsRewritten: 0,
+      skipped: 0,
+    );
+  }
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() async =>
+      const AnkiFetchResult.error('unused');
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async =>
+      MineOutcome.failure('unused');
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) async => true;
+
+  @override
+  Future<bool> createDeck(String name) async => true;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('anki_dedup_auto_test');
+    AnkiMediaDedupRunner.resetAutoSessionGate();
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  });
+
+  test('默认关：全新设置不跑自动处理，连扫描都不发生', () async {
+    const AnkiSettings fresh = AnkiSettings();
+    expect(fresh.mediaDedupAutoEnabled, isFalse);
+    expect(fresh.mediaDedupAutoDelete, isFalse);
+
+    final _FakeRepo repo = _FakeRepo(settings: fresh);
+    final AnkiMediaDedupAutoOutcome? outcome =
+        await _TempDirRunner(repo, dir).maybeAutoRunOnStartup();
+
+    expect(outcome, isNull);
+    expect(repo.dedupCalls, isEmpty);
+  });
+
+  test('缺键的老设置反序列化上来也是关的（升级不会凭空多一条自动删除路径）', () {
+    final AnkiSettings migrated = AnkiSettings.fromJson(<String, dynamic>{});
+    expect(migrated.mediaDedupAutoEnabled, isFalse);
+    expect(migrated.mediaDedupAutoDelete, isFalse);
+  });
+
+  test('打开自动处理：只干跑 + 要求确认，绝不自己删', () async {
+    final _FakeRepo repo = _FakeRepo(
+      settings: const AnkiSettings(mediaDedupAutoEnabled: true),
+    );
+
+    final AnkiMediaDedupAutoOutcome? outcome =
+        await _TempDirRunner(repo, dir).maybeAutoRunOnStartup();
+
+    expect(outcome, isNotNull);
+    expect(outcome!.applied, isNull, reason: '没确认就不许删');
+    expect(outcome.needsConfirmation, isTrue);
+    expect(outcome.plan.deletions, hasLength(1));
+    // 只发生过干跑；真删那次调用根本没出现。
+    expect(repo.dedupCalls, <bool>[true]);
+    expect(repo.settings.lastMediaDedupAtMs, isNull);
+    expect(repo.settings.lastMediaDedupScanAtMs, isNotNull);
+  });
+
+  test('自动处理开着但没有重复：不提示、不删', () async {
+    final _FakeRepo repo = _FakeRepo(
+      settings: const AnkiSettings(mediaDedupAutoEnabled: true),
+      deletions: 0,
+    );
+
+    final AnkiMediaDedupAutoOutcome? outcome =
+        await _TempDirRunner(repo, dir).maybeAutoRunOnStartup();
+
+    expect(outcome!.needsConfirmation, isFalse);
+    expect(outcome.applied, isNull);
+    expect(repo.dedupCalls, <bool>[true]);
+  });
+
+  test('额外显式打开「自动直接删除」才会跳过确认真删', () async {
+    final _FakeRepo repo = _FakeRepo(
+      settings: const AnkiSettings(
+        mediaDedupAutoEnabled: true,
+        mediaDedupAutoDelete: true,
+      ),
+    );
+
+    final AnkiMediaDedupAutoOutcome? outcome =
+        await _TempDirRunner(repo, dir).maybeAutoRunOnStartup();
+
+    expect(outcome!.applied, isNotNull);
+    expect(outcome.needsConfirmation, isFalse);
+    expect(repo.dedupCalls, <bool>[true, false]);
+    expect(repo.settings.lastMediaDedupAtMs, isNotNull);
+  });
+
+  test('只开「自动直接删除」而没开自动处理：什么都不发生', () async {
+    final _FakeRepo repo = _FakeRepo(
+      settings: const AnkiSettings(mediaDedupAutoDelete: true),
+    );
+
+    expect(await _TempDirRunner(repo, dir).maybeAutoRunOnStartup(), isNull);
+    expect(repo.dedupCalls, isEmpty);
+  });
+
+  test('每进程只跑一次（HomePage 重建不会重扫）', () async {
+    final _FakeRepo repo = _FakeRepo(
+      settings: const AnkiSettings(mediaDedupAutoEnabled: true),
+    );
+    final AnkiMediaDedupRunner runner = _TempDirRunner(repo, dir);
+
+    expect(await runner.maybeAutoRunOnStartup(), isNotNull);
+    expect(await runner.maybeAutoRunOnStartup(), isNull);
+    expect(repo.dedupCalls, <bool>[true]);
+  });
+
+  group('扫描节流边界', () {
+    final DateTime now = DateTime.utc(2026, 7, 27, 12);
+
+    test('从未扫过 → 跑', () {
+      expect(
+        shouldRunAutoMediaDedupScan(lastScanAtMs: null, now: now),
+        isTrue,
+      );
+    });
+
+    test('正好到间隔 → 跑；差 1 毫秒 → 不跑', () {
+      final DateTime exactly = now.subtract(kAnkiMediaDedupAutoInterval);
+      expect(
+        shouldRunAutoMediaDedupScan(
+            lastScanAtMs: exactly.millisecondsSinceEpoch, now: now),
+        isTrue,
+      );
+      final DateTime tooSoon = exactly.add(const Duration(milliseconds: 1));
+      expect(
+        shouldRunAutoMediaDedupScan(
+            lastScanAtMs: tooSoon.millisecondsSinceEpoch, now: now),
+        isFalse,
+      );
+    });
+
+    test('还没到间隔时自动处理直接跳过（不白扫一遍全库）', () async {
+      final _FakeRepo repo = _FakeRepo(
+        settings: AnkiSettings(
+          mediaDedupAutoEnabled: true,
+          lastMediaDedupScanAtMs: now.millisecondsSinceEpoch,
+        ),
+      );
+
+      final AnkiMediaDedupAutoOutcome? outcome =
+          await _TempDirRunner(repo, dir).maybeAutoRunOnStartup(now: now);
+
+      expect(outcome, isNull);
+      expect(repo.dedupCalls, isEmpty);
+    });
+  });
+
+  test('源码守卫：启动自动路径本身不得直接真删', () {
+    final String source =
+        File('lib/src/pages/implementations/home_page.dart').readAsStringSync();
+    final int autoStart =
+        source.indexOf('Future<void> _maybeAutoDedupAnkiMedia');
+    final int reviewStart = source.indexOf('Future<void> _reviewAutoDedupPlan');
+    expect(autoStart, greaterThan(0));
+    expect(reviewStart, greaterThan(autoStart));
+    final String autoBody = source.substring(autoStart, reviewStart);
+    // 真删只能出现在「用户点了查看 → 确认弹窗」之后的 _reviewAutoDedupPlan 里。
+    expect(autoBody.contains('runNow(dryRun: false)'), isFalse);
+    expect(
+      source
+          .substring(reviewStart)
+          .contains('showAnkiMediaDedupPlanDialog(context, plan'),
+      isTrue,
+    );
+  });
+}

--- a/hibiki/test/anki/lapis_auto_migrate_gate_test.dart
+++ b/hibiki/test/anki/lapis_auto_migrate_gate_test.dart
@@ -1,0 +1,204 @@
+// PR#457 审查 §10-3（用户拍板方案甲）服务层守卫：**不点「应用样式到 Anki」
+// 就不会写 Anki**。
+//
+// 修复前 `maybeAutoMigrateOnStartup` 只看「期望 styling ≠ Anki 端 且 Anki 端
+// 是自有产物」，于是拖一下字号、下次启动就静默推送。现在多一道基线闸门：只有
+// Hibiki 出厂基线真的变了才自动推。
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/anki/lapis_template_service.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+class _TempDirLapisService extends LapisTemplateService {
+  _TempDirLapisService(super.repository, this._dir);
+
+  final Directory _dir;
+
+  @override
+  Future<Directory> backupDirectory() async => _dir;
+}
+
+class _FakeRepo extends BaseAnkiRepository {
+  _FakeRepo({required this.definition, required this.settings});
+
+  final AnkiNoteTypeDefinition definition;
+  AnkiSettings settings;
+  String? pushedCss;
+
+  @override
+  bool get supportsNoteTypeEditing => true;
+
+  @override
+  Future<AnkiSettings> loadSettings() async => settings;
+
+  @override
+  Future<void> saveSettings(AnkiSettings s) async => settings = s;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+          String modelName) async =>
+      definition;
+
+  @override
+  Future<bool> updateNoteTypeStyling(String modelName, String css) async {
+    pushedCss = css;
+    return true;
+  }
+
+  @override
+  Future<bool> updateNoteTypeTemplates(
+          String modelName, List<AnkiCardTemplate> templates) async =>
+      true;
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() async =>
+      const AnkiFetchResult.error('unused');
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async =>
+      MineOutcome.failure('unused');
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) async => true;
+
+  @override
+  Future<bool> createDeck(String name) async => true;
+}
+
+AnkiNoteTypeDefinition _definition(String css) => AnkiNoteTypeDefinition(
+      name: LapisNoteType.modelName,
+      fields: LapisNoteType.fields,
+      templates: const <AnkiCardTemplate>[
+        AnkiCardTemplate(
+            name: 'Card 1', front: '{{Expression}}', back: '{{Meaning}}'),
+      ],
+      css: css,
+    );
+
+Future<File> _writeBackup(Directory dir, AnkiNoteTypeDefinition def) async {
+  final File file =
+      File('${dir.path}${Platform.pathSeparator}lapis-backup.json');
+  await file.writeAsString(jsonEncode(<String, dynamic>{
+    'version': 1,
+    'exportedAt': DateTime.now().toUtc().toIso8601String(),
+    'noteType': def.toJson(),
+  }));
+  return file;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory dir;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp('lapis_auto_migrate_test');
+    LapisTemplateService.resetAutoMigrateSessionGate();
+  });
+
+  tearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  });
+
+  test('改了字号却没点 Apply：基线没变 → 一个字节都不写 Anki', () async {
+    // Anki 上是出厂态；用户在设置里把字号调到 150 但没点「应用」。
+    final _FakeRepo repo = _FakeRepo(
+      definition: _definition(LapisNoteType.template.css),
+      settings: AnkiSettings(
+        lapisFontScalePercent: 150,
+        lapisMigratedBaselineSha: currentLapisBaselineSha,
+      ),
+    );
+
+    await _TempDirLapisService(repo, dir).maybeAutoMigrateOnStartup();
+
+    expect(repo.pushedCss, isNull, reason: 'Apply 才是唯一写入闸门');
+    expect(repo.settings.lapisFontScalePercent, 150);
+  });
+
+  test('基线真变了 → 自动迁移照跑（升级路径没被闸门吞掉）', () async {
+    final _FakeRepo repo = _FakeRepo(
+      definition: _definition(LapisNoteType.template.css),
+      settings: const AnkiSettings(
+        lapisFontScalePercent: 150,
+        lapisMigratedBaselineSha: 'sha-of-a-much-older-baseline',
+      ),
+    );
+
+    await _TempDirLapisService(repo, dir).maybeAutoMigrateOnStartup();
+
+    expect(
+        repo.pushedCss, composeLapisCss(fontScalePercent: 150, customCss: ''));
+    expect(repo.settings.lapisMigratedBaselineSha, currentLapisBaselineSha);
+  });
+
+  test('老装置首次升级（无记录）+ Anki 已带当前基线 → 不推，只补记基线', () async {
+    final String ankiCss =
+        composeLapisCss(fontScalePercent: 100, customCss: '.a { }');
+    final _FakeRepo repo = _FakeRepo(
+      definition: _definition(ankiCss),
+      settings: const AnkiSettings(
+        lapisFontScalePercent: 125,
+        lapisCustomCss: '.a { }',
+      ),
+    );
+
+    await _TempDirLapisService(repo, dir).maybeAutoMigrateOnStartup();
+
+    expect(repo.pushedCss, isNull);
+    expect(repo.settings.lapisMigratedBaselineSha, currentLapisBaselineSha);
+    // 补记基线不得顺手改动用户的客制化设置。
+    expect(repo.settings.lapisFontScalePercent, 125);
+    expect(repo.settings.lapisCustomCss, '.a { }');
+  });
+
+  test('推送成功后基线指纹被记下（下次启动不会再推一遍）', () async {
+    final _FakeRepo repo = _FakeRepo(
+      definition: _definition(LapisNoteType.template.css),
+      settings: const AnkiSettings(
+        lapisFontScalePercent: 110,
+        lapisMigratedBaselineSha: 'stale',
+      ),
+    );
+    final LapisTemplateService service = _TempDirLapisService(repo, dir);
+
+    await service.maybeAutoMigrateOnStartup();
+    expect(repo.pushedCss, isNotNull);
+
+    repo.pushedCss = null;
+    LapisTemplateService.resetAutoMigrateSessionGate();
+    await service.maybeAutoMigrateOnStartup();
+    expect(repo.pushedCss, isNull);
+  });
+
+  test('从备份恢复后自动迁移不得把恢复撤销', () async {
+    final String backupCss =
+        composeLapisCss(fontScalePercent: 125, customCss: '.mine { }');
+    final AnkiNoteTypeDefinition def = _definition(backupCss);
+    final _FakeRepo repo = _FakeRepo(
+      definition: def,
+      settings: const AnkiSettings(lapisFontScalePercent: 100),
+    );
+    final File file = await _writeBackup(dir, def);
+    final LapisTemplateService service = _TempDirLapisService(repo, dir);
+
+    await service.restoreBackup(file);
+    // 恢复必须反解出备份当时的字号（§10-2 方案甲），选择器才不会失灵。
+    expect(repo.settings.lapisFontScalePercent, 125);
+    expect(repo.settings.lapisCustomCss, '.mine { }');
+    expect(repo.settings.lapisMigratedBaselineSha, currentLapisBaselineSha);
+
+    repo.pushedCss = null;
+    LapisTemplateService.resetAutoMigrateSessionGate();
+    await service.maybeAutoMigrateOnStartup();
+    expect(repo.pushedCss, isNull);
+  });
+}

--- a/hibiki/test/anki/lapis_backup_retention_test.dart
+++ b/hibiki/test/anki/lapis_backup_retention_test.dart
@@ -1,0 +1,216 @@
+// PR#457 审查 §10-5a（用户拍板方案乙）守卫：Lapis 备份保留 90 天，**但无论
+// 如何最少留最近 10 份**。删除不可逆，边界必须钉死：正好 10 份不删、正好 90 天
+// 不删、时刻解析不出不删。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/anki/lapis_backup_retention.dart';
+import 'package:hibiki/src/anki/lapis_template_service.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+class _TempDirLapisService extends LapisTemplateService {
+  _TempDirLapisService(super.repository, this._dir);
+
+  final Directory _dir;
+
+  @override
+  Future<Directory> backupDirectory() async => _dir;
+}
+
+class _FakeRepo extends BaseAnkiRepository {
+  AnkiSettings settings = const AnkiSettings();
+
+  @override
+  bool get supportsNoteTypeEditing => true;
+
+  @override
+  Future<AnkiSettings> loadSettings() async => settings;
+
+  @override
+  Future<void> saveSettings(AnkiSettings s) async => settings = s;
+
+  @override
+  Future<AnkiNoteTypeDefinition?> readNoteTypeDefinition(
+          String modelName) async =>
+      AnkiNoteTypeDefinition(
+        name: LapisNoteType.modelName,
+        fields: LapisNoteType.fields,
+        templates: const <AnkiCardTemplate>[],
+        css: LapisNoteType.template.css,
+      );
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() async =>
+      const AnkiFetchResult.error('unused');
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async =>
+      MineOutcome.failure('unused');
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) async => true;
+
+  @override
+  Future<bool> createDeck(String name) async => true;
+}
+
+/// 测试用的备份条目：文件名 + 期望时刻（时刻由文件名解析，两者必须自洽）。
+String _backupName(DateTime at) =>
+    'lapis-${at.toUtc().toIso8601String().replaceAll(':', '-')}.json';
+
+List<String> _namesNewestFirst(List<DateTime> newestFirst) =>
+    newestFirst.map(_backupName).toList(growable: false);
+
+List<String> _prune(List<String> names, DateTime now) =>
+    planLapisBackupPrune<String>(
+      names,
+      timestampOf: parseLapisBackupTimestamp,
+      now: now,
+    );
+
+void main() {
+  final DateTime now = DateTime.utc(2026, 7, 27, 12);
+
+  test('文件名 ↔ 时刻往返（保留策略与界面标签用的是同一份判据）', () {
+    final DateTime at = DateTime.utc(2026, 3, 4, 5, 6, 7, 890);
+    expect(parseLapisBackupTimestamp(_backupName(at)), at);
+    expect(parseLapisBackupTimestamp('lapis-garbage.json'), isNull);
+    expect(parseLapisBackupTimestamp('other-file.json'), isNull);
+    expect(parseLapisBackupTimestamp('lapis-2026-01-01T00-00-00.000Z.txt'),
+        isNull);
+  });
+
+  test('边界：正好 10 份、全都远超 90 天 → 一份都不删', () {
+    final List<String> names = _namesNewestFirst(<DateTime>[
+      for (int i = 0; i < 10; i++) now.subtract(Duration(days: 300 + i)),
+    ]);
+    expect(_prune(names, now), isEmpty);
+  });
+
+  test('边界：第 11 份正好 90 天 → 不删（严格大于才算过期）', () {
+    final List<String> names = _namesNewestFirst(<DateTime>[
+      for (int i = 0; i < 10; i++) now.subtract(Duration(days: i)),
+      now.subtract(const Duration(days: 90)),
+    ]);
+    expect(names, hasLength(11));
+    expect(_prune(names, now), isEmpty);
+  });
+
+  test('边界：第 11 份 90 天零 1 毫秒 → 删这一份', () {
+    final DateTime doomedAt =
+        now.subtract(const Duration(days: 90, milliseconds: 1));
+    final List<String> names = _namesNewestFirst(<DateTime>[
+      for (int i = 0; i < 10; i++) now.subtract(Duration(days: i)),
+      doomedAt,
+    ]);
+    expect(_prune(names, now), <String>[_backupName(doomedAt)]);
+  });
+
+  test('两个条件同时成立才删：排 11 位之后 + 超 90 天', () {
+    final List<DateTime> stamps = <DateTime>[
+      // 最近 12 份都很新（其中 11、12 位不满 90 天）。
+      for (int i = 0; i < 12; i++) now.subtract(Duration(days: i)),
+      // 13、14 位超 90 天 → 该删。
+      now.subtract(const Duration(days: 100)),
+      now.subtract(const Duration(days: 400)),
+    ];
+    final List<String> names = _namesNewestFirst(stamps);
+    expect(
+      _prune(names, now),
+      <String>[_backupName(stamps[12]), _backupName(stamps[13])],
+    );
+  });
+
+  test('时刻解析不出的条目永不删（年龄不可判定 → 保守保留）', () {
+    final List<String> names = <String>[
+      for (int i = 0; i < 10; i++) _backupName(now.subtract(Duration(days: i))),
+      'lapis-not-a-timestamp.json',
+      _backupName(now.subtract(const Duration(days: 999))),
+    ];
+    expect(
+      _prune(names, now),
+      <String>[_backupName(now.subtract(const Duration(days: 999)))],
+    );
+  });
+
+  test('少于保留下限时直接短路（一份都不碰）', () {
+    expect(_prune(<String>[], now), isEmpty);
+    expect(
+      _prune(
+        _namesNewestFirst(<DateTime>[now.subtract(const Duration(days: 9999))]),
+        now,
+      ),
+      isEmpty,
+    );
+  });
+
+  test('默认策略常量就是用户拍板的 90 天 / 最少 10 份', () {
+    expect(kLapisBackupMaxAge, const Duration(days: 90));
+    expect(kLapisBackupKeepMinimum, 10);
+  });
+
+  group('落盘层：清理只在用户主动备份写盘之后发生，且结果可见', () {
+    late Directory dir;
+
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      dir = await Directory.systemTemp.createTemp('lapis_prune_io_test');
+    });
+
+    tearDown(() async {
+      if (await dir.exists()) await dir.delete(recursive: true);
+    });
+
+    Future<void> seed(List<DateTime> stamps) async {
+      for (final DateTime at in stamps) {
+        await File('${dir.path}${Platform.pathSeparator}${_backupName(at)}')
+            .writeAsString('{}');
+      }
+    }
+
+    test('手动备份：过期且排在 10 份之外的被删，份数回给 UI', () async {
+      final DateTime now = DateTime.now().toUtc();
+      await seed(<DateTime>[
+        // 10 份新的（都不满 90 天）+ 2 份远超 90 天的。
+        for (int i = 1; i <= 10; i++) now.subtract(Duration(days: i)),
+        now.subtract(const Duration(days: 300)),
+        now.subtract(const Duration(days: 400)),
+      ]);
+
+      final LapisBackupOutcome? outcome =
+          await _TempDirLapisService(_FakeRepo(), dir).backupNow();
+
+      expect(outcome, isNotNull);
+      expect(await outcome!.file.exists(), isTrue);
+      // 新备份挤进第 1 位 → 最近 10 份 = 新备份 + 9 份新的；第 11 位那份虽然
+      // 掉出了保留窗口但只有 10 天大，不满 90 天照样留着；只有最后两份同时
+      // 满足「窗口外 + 超 90 天」，删的就是它们。
+      expect(outcome.prunedCount, 2);
+      final List<File> left =
+          await _TempDirLapisService(_FakeRepo(), dir).listBackups();
+      expect(left, hasLength(11));
+    });
+
+    test('不足 10 份时一份都不删，哪怕全都远超 90 天', () async {
+      final DateTime now = DateTime.now().toUtc();
+      await seed(<DateTime>[
+        for (int i = 0; i < 5; i++) now.subtract(Duration(days: 900 + i)),
+      ]);
+
+      final LapisBackupOutcome? outcome =
+          await _TempDirLapisService(_FakeRepo(), dir).backupNow();
+
+      expect(outcome!.prunedCount, 0);
+      expect(
+        await _TempDirLapisService(_FakeRepo(), dir).listBackups(),
+        hasLength(6),
+      );
+    });
+  });
+}

--- a/hibiki/test/settings/settings_flatten_anki_profile_test.dart
+++ b/hibiki/test/settings/settings_flatten_anki_profile_test.dart
@@ -185,13 +185,29 @@ void main() {
     //    并入一个无条件显示的区块。未配置 Anki 时它们也都露出——故恰有三个 SwitchRow。
     //    TODO-1650 把旧「压缩制卡媒体」开关换成「图片/GIF 清晰度 + 音频质量」两滑块，
     //    紧随其后的独立无标题区（同样无条件显示）。
-    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(3),
+    expect(find.byType(AdaptiveSettingsSwitchRow), findsNWidgets(5),
         reason: 'TODO-135 方案A 三开关（hibiki / 来源分类 / 自动添加书名），未配置 Anki '
             '时都应显示（旧「压缩」开关已换成两滑块，不再是 SwitchRow；「制卡到已配对'
-            '设备」已移到 Hibiki 互联分类）。媒体去重区只有两个可点行、没有开关——'
-            '方案 A 没有任何自动/周期路径，不存在可拨的自动开关。');
+            '设备」已移到 Hibiki 互联分类）。外加媒体去重区的两个自动开关'
+            '（自动处理 + 自动直接删除），共 5 个。');
     expect(find.byType(AdaptiveSettingsSliderRow), findsNWidgets(2),
         reason: 'TODO-1650「图片/GIF 清晰度」+「音频质量」两滑块应无条件显示');
+    // 媒体去重的两个自动开关：**默认都关**（方案 A 的核心），且「自动直接删除」
+    // 在自动处理关着时必须是**禁用**的——它是从属开关，打开自动处理不等于授权
+    // 自动删。原实现的缺陷正是「自动路径绕过确认框」。
+    final Finder dedupAutoRow =
+        find.widgetWithText(AdaptiveSettingsSwitchRow, 'Automatic processing');
+    expect(dedupAutoRow, findsOneWidget);
+    expect(
+        tester.widget<AdaptiveSettingsSwitchRow>(dedupAutoRow).value, isFalse,
+        reason: '自动处理必须默认关');
+    final Finder dedupAutoDeleteRow = find.widgetWithText(
+        AdaptiveSettingsSwitchRow, 'Delete automatically without asking');
+    expect(dedupAutoDeleteRow, findsOneWidget);
+    final AdaptiveSettingsSwitchRow autoDelete =
+        tester.widget<AdaptiveSettingsSwitchRow>(dedupAutoDeleteRow);
+    expect(autoDelete.value, isFalse, reason: '自动直接删除必须默认关');
+    expect(autoDelete.onChanged, isNull, reason: '自动处理关着时「自动直接删除」必须禁用（从属开关）');
     expect(find.textContaining('Image / GIF quality'), findsOneWidget,
         reason: 'TODO-1650 图片/GIF 清晰度滑块标题应露出');
     expect(find.textContaining('Audio quality'), findsOneWidget,

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -163,6 +163,17 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
       'packages/hibiki_anki/test/mining_tag_and_parallel_test.dart',
   'cardCreation/Add source category tag':
       'packages/hibiki_anki/test/mining_tag_and_parallel_test.dart',
+  // 媒体去重的两个自动开关。与上面两个标签开关同因：写的是 AnkiSettings
+  // （经 SharedPreferences，非本测试的内存 DB），故 changed=false；而「自动直接
+  // 删除」还是**从属开关**，自动处理关着（默认）时刻意 disabled，焦点驱动本就
+  // 拨不动它。行为本体由专项测试咬死：默认关 / 打开后只干跑并要求确认 / 只有再
+  // 显式打开自动直接删除才真删 / 7 天节流边界 / 源码守卫。
+  'cardCreation/Automatic processing':
+      'test/anki/anki_media_dedup_auto_test.dart + '
+          'test/settings/settings_flatten_anki_profile_test.dart',
+  'cardCreation/Delete automatically without asking':
+      'test/anki/anki_media_dedup_auto_test.dart + '
+          'test/settings/settings_flatten_anki_profile_test.dart',
   // PR#343: 互联「制卡到服务端」开关。写 prefsRepo mine_to_server（changed=true），
   // 生效点在 ankiRepositoryProvider——开关开时把本地仓库包一层 RemoteMiningAnkiRepository，
   // mineEntry/isDuplicate 经互联链路转发到已配对主机（用主机 Anki 落卡），配置类方法仍委派

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -172,7 +172,11 @@ class AnkiSettings {
     this.lapisFontScalePercent = 100,
     this.lapisCustomCss = '',
     this.lapisAppliedCssSha,
+    this.lapisMigratedBaselineSha,
     this.lastMediaDedupAtMs,
+    this.lastMediaDedupScanAtMs,
+    this.mediaDedupAutoEnabled = false,
+    this.mediaDedupAutoDelete = false,
   });
 
   factory AnkiSettings.fromJson(Map<String, dynamic> json) => AnkiSettings(
@@ -206,7 +210,13 @@ class AnkiSettings {
         lapisFontScalePercent: json['lapisFontScalePercent'] as int? ?? 100,
         lapisCustomCss: json['lapisCustomCss'] as String? ?? '',
         lapisAppliedCssSha: json['lapisAppliedCssSha'] as String?,
+        lapisMigratedBaselineSha: json['lapisMigratedBaselineSha'] as String?,
         lastMediaDedupAtMs: json['lastMediaDedupAtMs'] as int?,
+        lastMediaDedupScanAtMs: json['lastMediaDedupScanAtMs'] as int?,
+        // 缺键 = 老装置升级上来：两个自动开关都默认关，升级不会凭空获得
+        // 一条会动 Anki 媒体文件的自动路径。
+        mediaDedupAutoEnabled: json['mediaDedupAutoEnabled'] as bool? ?? false,
+        mediaDedupAutoDelete: json['mediaDedupAutoDelete'] as bool? ?? false,
       );
   final int? selectedDeckId;
   final String? selectedDeckName;
@@ -250,11 +260,36 @@ class AnkiSettings {
   /// 与「被用户手改（不得静默覆盖）」。
   final String? lapisAppliedCssSha;
 
-  /// 上次媒体字节级去重完成时刻（epoch ms）。null = 从未跑过。
+  /// Hibiki 上次把**出厂基线**（`LapisNoteType.template.css`）迁移到 Anki 时，
+  /// 那份基线的指纹（sha256）。null = 本机从未记录过。
   ///
-  /// 去重**只有用户在设置页手动触发**这一条路径（先出干跑报告、确认后才删），
-  /// 没有任何后台自动调度；这个时刻只是「上次跑过」的记录。
+  /// 启动自动迁移的闸门（PR#457 审查 §10-3，用户拍板方案甲）：只有基线**真的
+  /// 变了**（vendored Lapis 或 Hibiki delta 升级）才自动推送；用户改了字号/
+  /// 自定义 CSS 但没点「应用样式到 Anki」时，绝不自动写 Anki。
+  /// 与 [lapisAppliedCssSha] 分工不同：后者是「上次推了什么完整 styling」，
+  /// 用于漂移判定（区分自有产物与手改）。
+  final String? lapisMigratedBaselineSha;
+
+  /// 上次媒体字节级去重**真删**完成时刻（epoch ms）。null = 从未跑过。
   final int? lastMediaDedupAtMs;
+
+  /// 上次媒体去重**扫描**（含自动干跑）完成时刻（epoch ms）。null = 从未扫过。
+  /// 自动处理据此按周期节流，避免每次启动都全量哈希媒体目录。
+  final int? lastMediaDedupScanAtMs;
+
+  /// 是否启用媒体去重的自动处理。**默认 false**（用户拍板方案 A 的核心：
+  /// Hibiki 不会主动帮你省空间）；用户可以在设置页主动打开。
+  ///
+  /// 打开之后的行为仍然保守：自动路径只做**干跑**并把清单提示给用户，
+  /// 必须用户确认才真删——除非用户另外显式打开 [mediaDedupAutoDelete]。
+  final bool mediaDedupAutoEnabled;
+
+  /// 自动处理是否可以**跳过确认直接删**。默认 false。只有
+  /// [mediaDedupAutoEnabled] 也为 true 时才有意义（UI 上是它的从属开关）。
+  ///
+  /// 单独一个字段而不是把「自动 = 直接删」并进上面那个开关，是因为原实现的
+  /// 缺陷正是「自动路径绕过确认框」；加回自动开关不能把这个坑一起加回来。
+  final bool mediaDedupAutoDelete;
 
   bool get isConfigured => selectedDeckId != null && selectedNoteTypeId != null;
 
@@ -288,7 +323,11 @@ class AnkiSettings {
     String? lapisCustomCss,
     String? lapisAppliedCssSha,
     bool clearLapisAppliedCssSha = false,
+    String? lapisMigratedBaselineSha,
     int? lastMediaDedupAtMs,
+    int? lastMediaDedupScanAtMs,
+    bool? mediaDedupAutoEnabled,
+    bool? mediaDedupAutoDelete,
   }) =>
       AnkiSettings(
         selectedDeckId: selectedDeckId ?? this.selectedDeckId,
@@ -317,7 +356,14 @@ class AnkiSettings {
         lapisAppliedCssSha: clearLapisAppliedCssSha
             ? null
             : (lapisAppliedCssSha ?? this.lapisAppliedCssSha),
+        lapisMigratedBaselineSha:
+            lapisMigratedBaselineSha ?? this.lapisMigratedBaselineSha,
         lastMediaDedupAtMs: lastMediaDedupAtMs ?? this.lastMediaDedupAtMs,
+        lastMediaDedupScanAtMs:
+            lastMediaDedupScanAtMs ?? this.lastMediaDedupScanAtMs,
+        mediaDedupAutoEnabled:
+            mediaDedupAutoEnabled ?? this.mediaDedupAutoEnabled,
+        mediaDedupAutoDelete: mediaDedupAutoDelete ?? this.mediaDedupAutoDelete,
       );
 
   Map<String, dynamic> toJson() => {
@@ -343,7 +389,11 @@ class AnkiSettings {
         'lapisFontScalePercent': lapisFontScalePercent,
         'lapisCustomCss': lapisCustomCss,
         'lapisAppliedCssSha': lapisAppliedCssSha,
+        'lapisMigratedBaselineSha': lapisMigratedBaselineSha,
         'lastMediaDedupAtMs': lastMediaDedupAtMs,
+        'lastMediaDedupScanAtMs': lastMediaDedupScanAtMs,
+        'mediaDedupAutoEnabled': mediaDedupAutoEnabled,
+        'mediaDedupAutoDelete': mediaDedupAutoDelete,
       };
 }
 

--- a/packages/hibiki_anki/lib/src/lapis_styling.dart
+++ b/packages/hibiki_anki/lib/src/lapis_styling.dart
@@ -43,18 +43,100 @@ const String lapisUserCssEndMarker = '/* HIBIKI-LAPIS-USER END */';
 /// 真是字号就放行，不是字号就得给本函数加排除表，别顺手把守卫改绿。
 String buildLapisFontScaleCss(int percent) {
   if (percent == 100) return '';
+  final List<String> lines = <String>[
+    for (final MapEntry<String, int> e in lapisBaseFontSizes())
+      '  --${e.key}: ${(e.value * percent / 100).round().clamp(1, 4096)}px;',
+  ];
+  if (lines.isEmpty) return '';
+  return ':root {\n${lines.join('\n')}\n}';
+}
+
+List<MapEntry<String, int>>? _cachedLapisBaseFontSizes;
+
+/// vendored Lapis CSS 里全部 px 取值的 `--pc-*` / `--mobile-*` 变量及其基准值，
+/// 按首次出现顺序去重。判据与 [buildLapisFontScaleCss] 文档一致（以 `-size`
+/// 结尾）。解析一次缓存——[buildLapisFontScaleCss] 与
+/// [splitLapisUserSectionBody] 共用同一真相源，且反解要穷举上百个百分比，
+/// 每次重跑正则扫全量 CSS 没必要。
+List<MapEntry<String, int>> lapisBaseFontSizes() {
+  final List<MapEntry<String, int>>? cached = _cachedLapisBaseFontSizes;
+  if (cached != null) return cached;
   final RegExp pattern = RegExp(r'--((?:pc|mobile)-[a-z-]*size):\s*(\d+)px');
-  final List<String> lines = <String>[];
+  final List<MapEntry<String, int>> sizes = <MapEntry<String, int>>[];
   final Set<String> seen = <String>{};
   for (final RegExpMatch m in pattern.allMatches(LapisNoteType.css)) {
     final String name = m.group(1)!;
     if (!seen.add(name)) continue;
-    final int base = int.parse(m.group(2)!);
-    final int scaled = (base * percent / 100).round().clamp(1, 4096);
-    lines.add('  --$name: ${scaled}px;');
+    sizes.add(MapEntry<String, int>(name, int.parse(m.group(2)!)));
   }
-  if (lines.isEmpty) return '';
-  return ':root {\n${lines.join('\n')}\n}';
+  return _cachedLapisBaseFontSizes =
+      List<MapEntry<String, int>>.unmodifiable(sizes);
+}
+
+/// 设置页字号选择器提供的百分比档位（单一真相源）。[splitLapisUserSectionBody]
+/// 反解时优先命中这些档位，避免相邻百分比因四舍五入产生同一份 CSS 时把选择器
+/// 显示成一个档位表里根本没有的值。
+const List<int> kLapisFontScalePresets = <int>[80, 90, 100, 110, 125, 150];
+
+/// 反解的穷举范围（含端点）。选择器只给 [kLapisFontScalePresets]，但备份可能
+/// 来自别的档位表或更早版本，范围放宽一点不增加实际成本（[lapisBaseFontSizes]
+/// 已缓存）。
+const int kLapisFontScaleMinPercent = 1;
+const int kLapisFontScaleMaxPercent = 400;
+
+/// 用户区段正文的拆分结果：Hibiki 生成的字号缩放块（还原成百分比）与其余
+/// 用户自由 CSS。
+class LapisUserSectionSplit {
+  const LapisUserSectionSplit({
+    required this.fontScalePercent,
+    required this.customCss,
+  });
+
+  /// 反解出的字号百分比；正文开头不是 Hibiki 生成的缩放块时 = 100。
+  final int fontScalePercent;
+
+  /// 剥掉缩放块之后的用户自由 CSS（已 trim）。
+  final String customCss;
+}
+
+/// 把用户区段正文拆回「字号百分比 + 自由 CSS」——[buildLapisUserSectionBody]
+/// 的逆运算。
+///
+/// **为什么必须反解**（PR#457 审查 §10-2，用户拍板方案甲）：从备份恢复时若把
+/// 整段正文（含 Hibiki 生成的缩放块）原样塞进 `lapisCustomCss` 并把百分比归
+/// 100，之后用户再调字号，新缩放块排在正文**之前**、旧缩放块排在**之后**，
+/// 两块特异性相同 → 后者胜出 → 字号选择器肉眼零效果。反解之后选择器显示的就是
+/// 备份当时的字号，且 `lapisCustomCss` 里不再残留缩放块，后续调节立即生效。
+///
+/// 判据：正文开头逐字节等于某个 `buildLapisFontScaleCss(p)`，且其后要么到头、
+/// 要么紧跟空白。命中不了（用户在 Anki 里手改过缩放块、或自己写的 CSS 排在
+/// 前面）就返回 `(100, 整段正文)`——与修复前行为一致，不猜。
+///
+/// 相邻百分比可能因四舍五入产出**逐字节相同**的缩放块（基准值都很小时）。这种
+/// 情况两个百分比不可区分，渲染结果也完全一样；先扫 [kLapisFontScalePresets]
+/// 保证选择器显示的是档位里真有的值，再按升序穷举。
+LapisUserSectionSplit splitLapisUserSectionBody(String body) {
+  final String trimmed = body.trim();
+  if (trimmed.isEmpty) {
+    return const LapisUserSectionSplit(fontScalePercent: 100, customCss: '');
+  }
+  for (final int percent in <int>[
+    ...kLapisFontScalePresets,
+    for (int p = kLapisFontScaleMinPercent; p <= kLapisFontScaleMaxPercent; p++)
+      p,
+  ]) {
+    if (percent == 100) continue;
+    final String scale = buildLapisFontScaleCss(percent);
+    if (scale.isEmpty || !trimmed.startsWith(scale)) continue;
+    final String rest = trimmed.substring(scale.length);
+    // 缩放块后面必须是区段边界（到头或空白），否则只是恰好前缀相同。
+    if (rest.isNotEmpty && !RegExp(r'^\s').hasMatch(rest)) continue;
+    return LapisUserSectionSplit(
+      fontScalePercent: percent,
+      customCss: rest.trim(),
+    );
+  }
+  return LapisUserSectionSplit(fontScalePercent: 100, customCss: trimmed);
 }
 
 /// 组合用户区段正文：字号缩放覆写 + 自由 CSS。两者皆空时返回空串
@@ -108,6 +190,38 @@ String normalizeCssForCompare(String css) =>
 /// 规范化后 CSS 的 sha256（hex）。用作「上次应用的 styling」指纹持久化。
 String lapisCssSha256(String css) =>
     sha256.convert(utf8.encode(normalizeCssForCompare(css))).toString();
+
+/// Hibiki 当前**出厂基线**（vendored Lapis + Hibiki delta）的指纹。
+/// 启动自动迁移用它判断「基线是不是真的变了」。
+String get currentLapisBaselineSha =>
+    lapisCssSha256(LapisNoteType.template.css);
+
+/// Anki 端 [ankiCss] 是否携带当前出厂基线。
+///
+/// [composeLapisCss] 的产物永远是「基线 + 可选用户区段」，所以「以基线开头」
+/// 就等价于「Anki 上的内容建立在当前基线之上」。手改过头部的内容不满足——那
+/// 属于 [LapisStylingDecision.foreignEdit]，本来也不会被自动迁移碰。
+bool ankiCssCarriesCurrentLapisBaseline(String ankiCss) =>
+    normalizeCssForCompare(ankiCss)
+        .startsWith(normalizeCssForCompare(LapisNoteType.template.css));
+
+/// 启动自动迁移的**基线闸门**（PR#457 审查 §10-3，用户拍板方案甲）。
+///
+/// 语义：「迁移」只该在 Hibiki 自己的基线变了时发生。用户改了字号/自定义 CSS
+/// 却没点「应用样式到 Anki」，不构成迁移理由——**Apply 是用户内容写进 Anki 的
+/// 唯一闸门**。
+///
+/// [migratedBaselineSha] == null（本机从未记录过，例如刚从旧版升级上来）时无法
+/// 直接比对，改用 Anki 端实际内容判断：Anki 已经建立在当前基线之上 → 没有要
+/// 迁移的东西；不是 → 基线确实落后，照迁。这样既不会因为「没有历史记录」就把
+/// 一次真实的基线升级吞掉，也不会拿它当借口去推用户没确认的客制化。
+bool shouldAutoMigrateLapisBaseline({
+  required String? migratedBaselineSha,
+  required String ankiCss,
+}) =>
+    migratedBaselineSha == null
+        ? !ankiCssCarriesCurrentLapisBaseline(ankiCss)
+        : migratedBaselineSha != currentLapisBaselineSha;
 
 /// 对 Anki 端现有 Lapis styling 的处置判定。
 enum LapisStylingDecision {

--- a/packages/hibiki_anki/test/anki_media_dedup_test.dart
+++ b/packages/hibiki_anki/test/anki_media_dedup_test.dart
@@ -147,14 +147,38 @@ void main() {
   });
 
   group('AnkiSettings 媒体去重字段', () {
-    test('只留「上次跑过」的时刻，没有任何自动开关', () {
+    // 用户后来要求「加一个可以打开的自动处理」，所以开关存在——但**默认必须
+    // 是关的**（方案 A 的核心：Hibiki 不主动帮你省空间），而且「自动直接删除」
+    // 是独立的第二个开关，打开自动处理不等于授权自动删。
+    test('两个自动开关默认都关，时刻字段默认为空', () {
       const AnkiSettings fresh = AnkiSettings();
       expect(fresh.lastMediaDedupAtMs, isNull);
-      expect(fresh.toJson().containsKey('mediaDedupAutoEnabled'), isFalse);
+      expect(fresh.lastMediaDedupScanAtMs, isNull);
+      expect(fresh.mediaDedupAutoEnabled, isFalse);
+      expect(fresh.mediaDedupAutoDelete, isFalse);
+    });
 
-      final AnkiSettings round = AnkiSettings.fromJson(
-          fresh.copyWith(lastMediaDedupAtMs: 123).toJson());
+    test('JSON 往返保住开关状态；旧 JSON 缺键回落到关', () {
+      const AnkiSettings fresh = AnkiSettings();
+      final AnkiSettings round = AnkiSettings.fromJson(fresh
+          .copyWith(
+            lastMediaDedupAtMs: 123,
+            lastMediaDedupScanAtMs: 456,
+            mediaDedupAutoEnabled: true,
+            mediaDedupAutoDelete: true,
+          )
+          .toJson());
       expect(round.lastMediaDedupAtMs, 123);
+      expect(round.lastMediaDedupScanAtMs, 456);
+      expect(round.mediaDedupAutoEnabled, isTrue);
+      expect(round.mediaDedupAutoDelete, isTrue);
+
+      final AnkiSettings legacy = AnkiSettings.fromJson(<String, dynamic>{
+        'lastMediaDedupAtMs': 7,
+      });
+      expect(legacy.lastMediaDedupAtMs, 7);
+      expect(legacy.mediaDedupAutoEnabled, isFalse);
+      expect(legacy.mediaDedupAutoDelete, isFalse);
     });
   });
 }

--- a/packages/hibiki_anki/test/lapis_baseline_gate_test.dart
+++ b/packages/hibiki_anki/test/lapis_baseline_gate_test.dart
@@ -1,0 +1,65 @@
+// PR#457 审查 §10-3（用户拍板方案甲）守卫：启动自动迁移的**基线闸门**。
+//
+// 修复前：只要期望 styling 与 Anki 端不同且 Anki 端是 Hibiki 自有产物，下次
+// 启动就静默把用户改过但**没点「应用样式到 Anki」**的客制化推进 Anki。
+// 「迁移」应当只在 Hibiki 出厂基线变了时发生，Apply 才是用户内容写进 Anki 的
+// 唯一闸门。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+void main() {
+  test('记录的基线 == 当前基线 → 不迁移（用户没点 Apply 就不动 Anki）', () {
+    expect(
+      shouldAutoMigrateLapisBaseline(
+        migratedBaselineSha: currentLapisBaselineSha,
+        // Anki 上是「当前基线 + 用户还没 Apply 的客制化之外的旧内容」。
+        ankiCss: LapisNoteType.template.css,
+      ),
+      isFalse,
+    );
+  });
+
+  test('记录的基线 != 当前基线 → 迁移', () {
+    expect(
+      shouldAutoMigrateLapisBaseline(
+        migratedBaselineSha: 'sha-of-some-older-baseline',
+        ankiCss: LapisNoteType.template.css,
+      ),
+      isTrue,
+    );
+  });
+
+  test('从未记录过 + Anki 已带当前基线 → 不迁移', () {
+    expect(
+      shouldAutoMigrateLapisBaseline(
+        migratedBaselineSha: null,
+        ankiCss: composeLapisCss(fontScalePercent: 125, customCss: '.a{}'),
+      ),
+      isFalse,
+    );
+  });
+
+  test('从未记录过 + Anki 还是旧基线 → 迁移（升级路径不被吞掉）', () {
+    expect(
+      shouldAutoMigrateLapisBaseline(
+        migratedBaselineSha: null,
+        ankiCss: '/* some older vendored Lapis */\n.card { color: red; }',
+      ),
+      isTrue,
+    );
+  });
+
+  test('ankiCssCarriesCurrentLapisBaseline 对 compose 的全部产物成立', () {
+    expect(
+      ankiCssCarriesCurrentLapisBaseline(
+          composeLapisCss(fontScalePercent: 100, customCss: '')),
+      isTrue,
+    );
+    expect(
+      ankiCssCarriesCurrentLapisBaseline(
+          composeLapisCss(fontScalePercent: 150, customCss: '.x{}')),
+      isTrue,
+    );
+    expect(ankiCssCarriesCurrentLapisBaseline('.card { }'), isFalse);
+  });
+}

--- a/packages/hibiki_anki/test/lapis_user_section_split_test.dart
+++ b/packages/hibiki_anki/test/lapis_user_section_split_test.dart
@@ -1,0 +1,100 @@
+// PR#457 审查 §10-2（用户拍板方案甲）守卫：从备份恢复之后，字号选择器必须与
+// 卡片上实际生效的字号一致。
+//
+// 修复前：恢复把整段用户区段（含 Hibiki 生成的 `:root` 缩放块）塞进
+// `lapisCustomCss` 并把百分比归 100。之后用户再调字号，新缩放块排在正文之前、
+// 旧缩放块排在之后，两块特异性相同 → 后者胜出 → 选择器成了死控件。
+//
+// 这里锁死逆运算 [splitLapisUserSectionBody] 的契约：正文能被拆回
+// 「百分比 + 自由 CSS」，且拆出来的自由 CSS 里**不再残留缩放块**。
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+void main() {
+  test('每个档位都能原样往返（buildLapisUserSectionBody 的逆运算）', () {
+    for (final int percent in kLapisFontScalePresets) {
+      final String body = buildLapisUserSectionBody(
+        fontScalePercent: percent,
+        customCss: '.mine { color: #0f0; }',
+      );
+      final LapisUserSectionSplit split = splitLapisUserSectionBody(body);
+      expect(split.fontScalePercent, percent, reason: '档位 $percent 反解失败');
+      expect(split.customCss, '.mine { color: #0f0; }');
+    }
+  });
+
+  test('档位之间产出的缩放块互不相同（反解不会张冠李戴）', () {
+    final Map<String, int> seen = <String, int>{};
+    for (final int percent in kLapisFontScalePresets) {
+      final String css = buildLapisFontScaleCss(percent);
+      if (percent == 100) {
+        expect(css, isEmpty);
+        continue;
+      }
+      expect(seen.containsKey(css), isFalse,
+          reason: '$percent% 与 ${seen[css]}% 产出了同一份缩放块');
+      seen[css] = percent;
+    }
+  });
+
+  test('只有缩放块 / 只有自由 CSS / 空正文', () {
+    expect(
+      splitLapisUserSectionBody(buildLapisFontScaleCss(125)).fontScalePercent,
+      125,
+    );
+    expect(
+      splitLapisUserSectionBody(buildLapisFontScaleCss(125)).customCss,
+      isEmpty,
+    );
+    final LapisUserSectionSplit onlyCustom =
+        splitLapisUserSectionBody('.a { color: red; }');
+    expect(onlyCustom.fontScalePercent, 100);
+    expect(onlyCustom.customCss, '.a { color: red; }');
+    expect(splitLapisUserSectionBody('').fontScalePercent, 100);
+    expect(splitLapisUserSectionBody('').customCss, isEmpty);
+  });
+
+  test('用户手写的 :root 块不会被误认成 Hibiki 缩放块', () {
+    const String handWritten = ':root {\n  --pc-vocab-font-size: 99px;\n}';
+    final LapisUserSectionSplit split = splitLapisUserSectionBody(handWritten);
+    expect(split.fontScalePercent, 100);
+    expect(split.customCss, handWritten);
+  });
+
+  test('恢复语义：选择器读到备份当时的字号，且自由 CSS 里不再残留缩放块', () {
+    final String backupCss = composeLapisCss(
+      fontScalePercent: 125,
+      customCss: '.mine { color: #0f0; }',
+    );
+    final String body = extractLapisUserSectionBody(backupCss)!;
+    final LapisUserSectionSplit split = splitLapisUserSectionBody(body);
+
+    expect(split.fontScalePercent, 125);
+    expect(split.customCss, isNot(contains('--pc-')));
+    expect(split.customCss, isNot(contains('--mobile-')));
+    // 期望态必须逐字节等于恢复态，否则下次启动的漂移判定会把刚恢复的内容覆写。
+    expect(
+      composeLapisCss(
+        fontScalePercent: split.fontScalePercent,
+        customCss: split.customCss,
+      ),
+      backupCss,
+    );
+  });
+
+  test('恢复之后再调字号：旧缩放块不会残留下来盖住新的（本条就是原 bug）', () {
+    final String backupCss =
+        composeLapisCss(fontScalePercent: 125, customCss: '.mine { }');
+    final LapisUserSectionSplit split =
+        splitLapisUserSectionBody(extractLapisUserSectionBody(backupCss)!);
+
+    final String afterUserPicks150 = composeLapisCss(
+      fontScalePercent: 150,
+      customCss: split.customCss,
+    );
+    // 修复前 customCss == 整段正文，125% 的块会跟着一起被写回去并排在 150%
+    // 之后胜出；现在它必须彻底消失。
+    expect(afterUserPicks150.contains(buildLapisFontScaleCss(125)), isFalse);
+    expect(afterUserPicks150.contains(buildLapisFontScaleCss(150)), isTrue);
+  });
+}


### PR DESCRIPTION
落实用户刚拍板的两组决策。基底 `develop@2c55f5798`。

## 任务一：媒体去重「可以打开的自动处理」

用户原话「加一个可以打开的自动处理」。PR#458 施工时把 `mediaDedupAutoEnabled` 整个删掉了（方案 A 说「不会自动帮你省空间」，留个只能是 false 的开关是假开关），现在按要求把**可拨的**开关加回来。

| 开关 | 默认 | 打开后的确切行为 |
|---|---|---|
| `mediaDedupAutoEnabled`「自动处理」 | **关** | 启动时（最多每 7 天一次）**只跑干跑**，把「删哪些文件、各占多少空间、保留哪一份」提示给用户；**不确认就一个文件都不动** |
| `mediaDedupAutoDelete`「自动直接删除」 | **关** | 只有再显式打开这个，自动路径才跳过确认真删 |

- 保守性是**结构性**的：`maybeAutoRunOnStartup` 返回的 `AnkiMediaDedupAutoOutcome`
  把「干跑计划 `plan`」和「已真删 `applied`」分成两个字段，`applied` 非空 ⟺
  用户显式开了第二个开关。自动路径里除那一个分支外没有任何 `dryRun: false`。
  另有源码守卫断言 `_maybeAutoDedupAnkiMedia` 里不得出现 `runNow(dryRun: false)`。
- 干跑清单 / 结果弹窗抽成 `anki_media_dedup_dialogs.dart`，设置页手动路径与
  启动自动路径共用同一份 UI（两份 UI 会漂移，漂移的那份迟早变成「绕过确认」）。
- 旧 JSON 缺键一律回落 false：升级不会凭空多一条会动文件的自动路径。
- **PR#458 两条红线未被削弱**：不重编码图片、只删字节完全相同的副本
  （size 分桶 + 全文件 SHA-256 + 删前逐字节 memcmp 全在
  `anki_media_dedup.dart` / `ankiconnect_repository.dart`，本 PR 未触碰）。

> ⚠️ 待用户确认：用户只说「加一个可以打开的自动处理」。我按「最保守」做成
> 「打开 = 自动干跑并提示，仍需确认才真删」。若本意是「打开就自动删」，
> 需要把两个开关合并（删掉 `mediaDedupAutoDelete` 与那行 UI 即可）。

## 任务二：Lapis 三条取舍（用户选 1甲 / 2甲 / 3乙）

**①甲 — 恢复备份后字号选择器失灵**
新增纯函数 `splitLapisUserSectionBody`（`buildLapisUserSectionBody` 的逆运算）：
反解出备份里的字号百分比并把缩放块从 `lapisCustomCss` 剥离。恢复后选择器显示
备份当时的字号，后续调节立即生效（旧缩放块不再残留下来盖住新的）。反解顺序先扫
`kLapisFontScalePresets` 再升序穷举；设置页档位表也改读这个单一真相源。

**②甲 — 无 Apply 也会推送**
新增 `AnkiSettings.lapisMigratedBaselineSha` + 纯判定
`shouldAutoMigrateLapisBaseline`：只有 Hibiki 出厂基线真变了才自动迁移，
**Apply 成为用户内容写进 Anki 的唯一闸门**。无记录（老装置首次升级）时改看
Anki 端是否已带当前基线，真实的基线升级不会被闸门吞掉。恢复备份后记下当前基线，
自动迁移不得把恢复撤销。

**③乙 — 备份永不清理**
新增 `hibiki/lib/src/anki/lapis_backup_retention.dart`：保留 90 天，**但无论如何
最少留最近 10 份**（两条同时成立才删）。年龄用**严格大于**比较（正好 90 天留着），
时刻解析不出的**永不删**。执行时机只在**用户主动触发的备份写盘之后**（手动备份 /
应用样式 / 从备份恢复），**没有任何后台定时器**；每删一份 `debugPrint` 记文件名，
手动备份的提示里回报清理了几份。

## 测试

新增 37 例、改写 1 例，边界全钉死：
- 自动开关默认关、打开后仍需确认才真删、只开第二个开关无效、每进程一次、
  节流边界（从未扫过 / 正好到间隔 / 差 1ms）、源码守卫；
- 恢复后选择器与实际字号一致、六档位往返、档位间缩放块互异、**原 bug 复现向**
  （恢复后调 150% 时 125% 的块必须消失）；
- 不点 Apply 不写 Anki（服务层断言 `pushedCss == null`）、基线真变仍迁移、
  老装置只补记不推、恢复不被自动迁移撤销；
- 保留策略：正好 10 份不删、第 11 份正好 90 天不删、90 天零 1 毫秒删、
  解析不出永不删，外加落盘层 2 例。

## i18n

8 个新 key 全部经 `hibiki/tool/i18n_sync.dart --add`（17 语言）+ `dart run slang`
+ `dart format`，未手改 json 与 `strings.g.dart`。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
