### PR TITLE
fix(storage): close data-root migration path-rewrite gaps (BUG-1174)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1136 条。点号进各自文件。
+> 共 1137 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1174](bugs/BUG-1174-docroot-migrator-path-gaps.md) | ✅ | ✅ | 数据根迁移漏改 6 处路径 + 非幂等 + 无事务 |
 | [BUG-1173](bugs/BUG-1173-manga-ocr-cache-model-identity.md) | ✅ | ✅ | 漫画本地 OCR 缓存不含模型身份 |
 | [BUG-1172](bugs/BUG-1172-manga-lens-rotated-hit-aspect.md) | ✅ | ✅ | 漫画 Lens 旋转命中区在非方形页上算错 |
 | [BUG-1171](bugs/BUG-1171-manga-reader-progress-after-dispose.md) | ✅ | ✅ | 漫画阅读器销毁后仍写页码通知器并挂 10 秒 |

--- a/docs/bugs/BUG-1174-docroot-migrator-path-gaps.md
+++ b/docs/bugs/BUG-1174-docroot-migrator-path-gaps.md
@@ -1,0 +1,63 @@
+## BUG-1174 · 数据根迁移漏改 6 处路径 + 非幂等 + 无事务
+- **报告**：2026-07-27（用户：内部审计，走「设置 → 数据存储位置 → 选目录」即可触发）
+- **真实性**：✅ 真 bug（四组独立缺陷，均在 develop `5af29b2da` 上存在）
+  1. **漏改的持久化路径**（迁移后指向已搬空的旧位置）：
+     - `galgames.cover_path`（`tables.dart:1201`，落盘 `galgame_cover_resolver.dart:300-320`
+       → `<documents>/game_covers`）—— 迁移器全文无 `galgames` 字样，整个游戏库封面退化成默认手柄图标。
+       与 TODO-1255 修过的 `video_books.cover_path` **完全同型**。
+     - `video_books.subtitle_source` / `secondary_subtitle_source`（`tables.dart:487,492`）——
+       四态编码的「外挂绝对路径」态落 `<documents>/video_subtitles`，该目录在搬移白名单里
+       （`app_paths.dart:389-406`）会被物理搬走；旧迁移器的 UPDATE 只有
+       `video_path,playlist_json,cover_path` 三列 → 所有外挂字幕失效，查词与双字幕一并失效。
+     - `media_items.image_url`（`tables.dart:13`）—— 本地书封面存 `file://<绝对路径>`
+       （`reader_hibiki_source.dart` 的 `Uri.file(candidate)`）→ 书架/首页「最近」卡片封面全空白。
+     - pref `galgame_library`（v55 legacy JSON 的 `coverPath`）、`video_remote_subtitle`
+       （远端视频手选字幕 map，**原调研清单未列出、本次实查补入**）、`download_save_root`
+       与 `download_save_root_history`、`local_audio_db_path`。
+  2. **`profile_settings` 快照回滚（最阴的一条）**：`profile_repository.dart:129-140`
+     把**每一条**非排除 Drift pref 原样复制进 `profile_settings`，`:243-249` 的
+     `applyProfile` 再原样 `setPref` 写回。迁移只改 `preferences` → 用户切一次 Profile
+     就把刚 rebase 好的路径整体退回旧值。**迁移当天一切正常，几天后突然坏**。
+  3. **路径改写非幂等**：判据是 `startsWith(oldRoot)`（`backup_service.dart:98-114`）。
+     新根落在旧根**内部**时（`<Documents>` → `<Documents>/Hibiki/data`，BUG-1115 之后
+     `isSafeNestedTargetInSharedDocuments` 明确放行这种目标），跑第二遍产出
+     `Documents/Hibiki/data/Hibiki/data/…`，**不抛任何异常、静默毁全库**。
+     同型坑在 iOS 容器重定位上已踩过一次（BUG-1115）。
+     ⚠️ 修的过程中**幂等测试真实抓到一条旁路**：字体目录 pref 走
+     `rebaseFontCatalogJson` / `rebaseFontListJson`（`backup_service.dart:126,150`），
+     那两个函数内部直接调裸 `rebasePath`，绕过了新加的作用域谓词 → 字体路径仍被改写两遍。
+  4. **DB 路径改写无事务**：旧 `_rebaseDatabasePaths` 是逐行 `UPDATE`，中途失败留下
+     「一半指新根、一半指旧根」的库，而外层回滚只把**文件**搬回旧位置，救不了半改的 DB。
+
+- **[x] ① 已修复** — `fix(storage): close data-root migration path-rewrite gaps`
+  - 新增 `hibiki/lib/src/storage/path_rebase_coverage.dart`：把「哪些列/pref 承载绝对路径、
+    迁移要不要改写、为什么」变成**声明式单一真相源**（55 列 + 17 个 pref key，逐条带理由）。
+  - `data_root_migrator.dart` 补齐上述全部漏项，并按表拆成 `_rebase<Table>` 入口。
+  - **③ 幂等**：新增 `DocumentsPathRebaser`，判据从 `startsWith(oldRoot)` 收窄为
+    **「相对旧根的首段 ∈ 本次搬移真正会动的顶层项集合」**（与
+    `DataRootMigrationRequest.documentsTopLevelIncludeNames` 同源）。已改写过的路径首段是
+    `Hibiki`（不在白名单里）→ 天然跳过，函数**本质幂等**，「跑没跑过」这个问题消失而不是被
+    条件判断掩盖。字体旁路从根上修：给 `rebaseFontCatalogJson` / `rebaseFontListJson` 加
+    可选 `rewritePath` 注入点，迁移侧传作用域改写器，**备份恢复侧不传、行为逐字节不变**。
+  - **② profile_settings**：迁移时用与 `preferences` **同一个**纯函数
+    `rebaseMigratedPrefValue(key, value, ...)` 改写**所有 Profile** 的快照行。
+    选这条而不是「让路径 pref 不进快照」，是因为后者会改掉 Profile 的既有语义
+    （字体目录/发音库配置现在确实是每 Profile 的），为修迁移去动无关功能契约，爆炸半径大得多。
+  - **④ 事务化**：整段 DB 改写包进 `db.transaction()`；`wal_checkpoint(TRUNCATE)` 留在事务外
+    （SQLite 不允许在活动事务里 checkpoint）。
+  - 未触碰：`anime_downloads` 的搬移/fast-resume/活跃句柄逻辑（另议）、一键整理按钮、
+    BUG-1115 文档给老用户的指引、备份恢复侧的同源漏项（R8，另立项）。
+
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/storage/data_root_migrator_path_gaps_test.dart`（行为）：
+    ① 全漏项改写 + 外部路径纹丝不动；② **迁移后真正跑一次 `ProfileRepository.applyProfile`
+    （= 用户切 Profile），断言路径仍是新值**；③ 同一改写**连跑两次**逐字节 no-op +
+    显式断言不出现 `Hibiki/data/Hibiki/data`；③b/③c 作用域谓词边界（前缀撞名、大小写、
+    整树模式）；④ 事务中途失败整体回滚。
+  - `hibiki/test/storage/path_rebase_coverage_guard_test.dart`（源码守卫）：
+    tables.dart 里路径形 TextColumn 必须登记（双向，含陈旧声明）+ 每条声明必须有理由 +
+    must-rebase 列必须真的接进迁移器 + **每张表必须有 `_rebase<Table>` 入口且在事务里被调用** +
+    pref key 侧同规则 + 字体 key 字面值与 `dbSourcePrefKey` 编码器一致 +
+    **「所有 documents 路径改写必须过同一个作用域谓词（无旁路）」**。
+  - 负向验证（改回旧逻辑 → 对应用例转红 → 还原）：①③④ 与四条守卫全部确认可转红。
+- **备注**：`schema` 未改动；持久化 key 未改名。

--- a/hibiki/lib/src/storage/data_root_migrator.dart
+++ b/hibiki/lib/src/storage/data_root_migrator.dart
@@ -5,15 +5,25 @@ import 'package:flutter/foundation.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:path/path.dart' as p;
 
+import 'package:drift/drift.dart' show QueryRow, Variable;
+
 import 'package:hibiki/src/media/media_source.dart' show dbSourcePrefKey;
+import 'package:hibiki/src/media/video/video_subtitle_source.dart'
+    show SubtitleSource;
+import 'package:hibiki/src/models/local_audio_manager.dart'
+    show LocalAudioManager;
+import 'package:hibiki/src/profile/profile_keys.dart' show ProfileKeys;
 import 'package:hibiki/src/storage/app_paths.dart';
+import 'package:hibiki/src/storage/path_rebase_coverage.dart';
 import 'package:hibiki/src/sync/backup_service.dart'
     show
+        joinPrefTag,
         normalizeAudioSourceConfigsJson,
         normalizeLocalAudioDbsJson,
         rebaseFontCatalogJson,
         rebaseFontListJson,
-        rebasePath;
+        rebasePath,
+        splitPrefTag;
 
 /// TODO-935 E1：把应用「数据存储位置」整目录迁到新 dataRoot 的引擎（仅桌面）。
 ///
@@ -102,6 +112,11 @@ class DataRootMigrator {
   @visibleForTesting
   static bool debugForceCopyFallback = false;
 
+  /// 仅供单测（BUG-1174 ④）：在 DB 路径改写事务里、改完 video_books 之后抛错，用来
+  /// 确定性验证「整段改写在单事务里，中途失败整体回滚、不留半改状态」。生产恒 false。
+  @visibleForTesting
+  static bool debugFailMidRebase = false;
+
   /// SharedPreferences 落盘文件的**文件名前缀**族。桌面默认根迁移时，`oldSupportRoot`
   /// 恰好等于平台固定落点 `getApplicationSupportDirectory()`，`shared_preferences_windows`
   /// 插件把 `shared_preferences.json` 就存这个目录（见 `app_paths.dart:65-70` 的鸡生蛋
@@ -113,20 +128,10 @@ class DataRootMigrator {
     'shared_preferences',
   ];
 
-  /// 持久化的字体目录配置 pref 键（含 ReaderSettings 前缀）。与 `backup_service.dart`
-  /// 的同名常量同一组值（那边因 const 上下文保留字面量并由
-  /// `db_source_pref_key_test` 锁一致）；这里经单一真相编码器 [dbSourcePrefKey]
-  /// 生成，不再硬编码 `src:reader_ttu:` 格式。
-  static final String _fontCatalogPrefKey =
-      dbSourcePrefKey('reader_ttu', 'font_catalog');
-  static final List<String> _legacyFontPrefKeys = <String>[
-    dbSourcePrefKey('reader_ttu', 'custom_fonts'),
-    dbSourcePrefKey('reader_ttu', 'app_ui_fonts'),
-    dbSourcePrefKey('reader_ttu', 'dict_fonts'),
-    dbSourcePrefKey('reader_ttu', 'video_sub_fonts'),
-  ];
-  static const String _localAudioDbsPrefKey = 'local_audio_dbs';
-  static const String _audioSourceConfigsPrefKey = 'audio_source_configs';
+  /// BUG-1174：所有承载路径的 pref key（含它们的值形态与改写理由）已收敛到
+  /// `path_rebase_coverage.dart` 的 [kPathRebasePrefs]，这里不再重复声明。字体 key 的
+  /// 字面值与单一真相编码器 [dbSourcePrefKey] 的一致性由
+  /// `path_rebase_coverage_guard_test.dart` 锁定（与 `backup_service.dart` 同款做法）。
 
   /// 执行迁移。成功返回新 dataRoot 派生的 (documents, support) 根。
   ///
@@ -199,8 +204,8 @@ class DataRootMigrator {
         dbDirectory: newSupport.path,
         oldDocumentsRoot: req.oldDocumentsRoot.path,
         newDocumentsRoot: newDocs.path,
-        oldSupportRoot: req.oldSupportRoot.path,
         newSupportRoot: newSupport.path,
+        documentsScopeEntries: req.documentsTopLevelIncludeNames,
       );
     } catch (e) {
       // DB 改写失败：把已搬目录搬回旧根、只清迁移自建子树（不删用户选定的 newRoot 本体）。
@@ -221,8 +226,8 @@ class DataRootMigrator {
           dbDirectory: newSupport.path,
           oldDocumentsRoot: newDocs.path,
           newDocumentsRoot: req.oldDocumentsRoot.path,
-          oldSupportRoot: newSupport.path,
           newSupportRoot: req.oldSupportRoot.path,
+          documentsScopeEntries: req.documentsTopLevelIncludeNames,
         );
       } catch (rollbackError) {
         debugPrint(
@@ -719,169 +724,276 @@ class DataRootMigrator {
     return false;
   }
 
-  /// 在 [dbDirectory] 的 `hibiki.db` 上把所有绝对路径列从旧根 rebase 到新根。复用
-  /// `backup_service.dart` 的纯函数（[rebasePath] / [normalizeLocalAudioDbsJson] /
-  /// 字体 JSON rebaser）+ Drift CRUD，逐行改写 epub / audiobook / srt / video_books，
-  /// 以及 prefs 里的字体目录与本地音频库 JSON。改完 checkpoint(TRUNCATE) 落盘。
+  /// 在 [dbDirectory] 的 `hibiki.db` 上把所有数据根内绝对路径从旧根 rebase 到新根。
   ///
-  /// `MediaSources.rootPath` **不**改写：它是用户自选的外部素材文件夹（用户把 Hibiki
-  /// 指向去扫描），不在应用数据根内、不随数据根迁移，动它会让外部库失联。
+  /// 覆盖清单的**单一真相源**是 `path_rebase_coverage.dart`（[kPathRebaseColumns] /
+  /// [kPathRebasePrefs]），守卫测试 `path_rebase_coverage_guard_test.dart` 双向比对
+  /// 源码与声明——新增一列存路径而忘了这里，CI 会红。
+  ///
+  /// 三条 BUG-1174 的铁律：
+  ///  1. **作用域谓词 = 搬移作用域**（[DocumentsPathRebaser]）。判据不是「以旧根开头」
+  ///     而是「相对旧根的首段命中本次真正会被搬走的顶层项集合」。新根落在旧根内部
+  ///     （`<Documents>` → `<Documents>/Hibiki/data`）时，已改写过的路径首段是
+  ///     `Hibiki`（不在白名单里）→ 天然跳过，函数**本质幂等**，跑几遍结果一样。
+  ///  2. **单事务**：整段改写包在 `db.transaction()` 里，中途失败整体回滚，绝不留
+  ///     「一半指新根、一半指旧根」的半状态（外层回滚只搬文件，救不了半改的 DB）。
+  ///  3. **prefs 与 profile_settings 共用同一个改写函数**（[rebaseMigratedPrefValue]）。
+  ///     `profile_settings` 是每 Profile 的 pref 全量副本，只改 `preferences` 的话用户
+  ///     切一次 Profile 就把旧根路径整体写回来。
+  ///
+  /// `MediaSources.rootPath` / `Galgames.exePath` 等**外部**路径不改写（理由逐列写在
+  /// [kPathRebaseColumns] 里）。
   Future<void> _rebaseDatabasePaths({
     required String dbDirectory,
     required String oldDocumentsRoot,
     required String newDocumentsRoot,
-    required String oldSupportRoot,
     required String newSupportRoot,
+    required Set<String>? documentsScopeEntries,
   }) async {
+    final DocumentsPathRebaser docs = DocumentsPathRebaser(
+      oldRoot: oldDocumentsRoot,
+      newRoot: newDocumentsRoot,
+      scopeTopLevelNames: documentsScopeEntries,
+    );
     final HibikiDatabase db = HibikiDatabase(dbDirectory);
     try {
-      // ── epub_books：epubPath / extractDir / coverPath（coverPath 双语义：导入存的
-      //    相对 href 不该被当绝对路径 rebase；rebasePath 只在 startsWith(oldRoot/) 时
-      //    改写，相对 href 不以旧根开头故天然跳过）。
-      for (final EpubBookRow b in await db.getAllEpubBooks()) {
-        await db.updateEpubBookContentPaths(
-          b.bookKey,
-          epubPath: rebasePath(b.epubPath, oldDocumentsRoot, newDocumentsRoot),
-          extractDir:
-              rebasePath(b.extractDir, oldDocumentsRoot, newDocumentsRoot),
-          coverPath: b.coverPath == null
-              ? null
-              : rebasePath(b.coverPath!, oldDocumentsRoot, newDocumentsRoot),
-        );
-      }
-
-      // ── audiobooks：audioRoot / audioPathsJson(列表) / alignmentPath。
-      for (final AudiobookRow a in await db.getAllAudiobooks()) {
-        await db.updateAudiobookPaths(
-          a.bookKey,
-          audioRoot: a.audioRoot == null
-              ? null
-              : rebasePath(a.audioRoot!, oldDocumentsRoot, newDocumentsRoot),
-          audioPathsJson: _rebaseJsonStringList(
-              a.audioPathsJson, oldDocumentsRoot, newDocumentsRoot),
-          alignmentPath:
-              rebasePath(a.alignmentPath, oldDocumentsRoot, newDocumentsRoot),
-        );
-      }
-
-      // ── srt_books（独立 SRT/有声书，无 epub 背书）：audioRoot / audioPathsJson /
-      //    srtPath / coverPath 都在 documents 根下，随数据根迁移。
-      for (final SrtBookRow s in await db.getAllSrtBooks()) {
-        await db.customStatement(
-          'UPDATE srt_books SET '
-          'audio_root = ?, audio_paths_json = ?, srt_path = ?, cover_path = ? '
-          'WHERE id = ?',
-          <Object?>[
-            s.audioRoot == null
-                ? null
-                : rebasePath(s.audioRoot!, oldDocumentsRoot, newDocumentsRoot),
-            _rebaseJsonStringList(
-                s.audioPathsJson, oldDocumentsRoot, newDocumentsRoot),
-            rebasePath(s.srtPath, oldDocumentsRoot, newDocumentsRoot),
-            s.coverPath == null
-                ? null
-                : rebasePath(s.coverPath!, oldDocumentsRoot, newDocumentsRoot),
-            s.id,
-          ],
-        );
-      }
-
-      // ── video_books：video_path / playlist_json / cover_path。video_path 与
-      //    playlist_json 仅当原本指向 documents 根下的内部副本时才改写（用户原位外部
-      //    视频不以旧根开头 → rebasePath 天然跳过）；cover_path 是应用自有资产，恒落
-      //    `<documents>/video_covers`，随数据根整树搬移，必须 rebase——TODO-1255：
-      //    历史上此处漏改 cover_path（epub_books / srt_books 都改了，只有 video_books
-      //    落下），迁移把 `video_covers/*` 物理搬到新根后，DB 里的旧封面绝对路径指向
-      //    已空的旧 Documents，导致视频库封面全占位。
-      for (final VideoBookRow v in await db.allVideoBooks()) {
-        final String newVideoPath =
-            rebasePath(v.videoPath, oldDocumentsRoot, newDocumentsRoot);
-        final String? newPlaylist = _rebasePlaylistJson(
-            v.playlistJson, oldDocumentsRoot, newDocumentsRoot);
-        final String? newCover = v.coverPath == null
-            ? null
-            : rebasePath(v.coverPath!, oldDocumentsRoot, newDocumentsRoot);
-        if (newVideoPath == v.videoPath &&
-            newPlaylist == v.playlistJson &&
-            newCover == v.coverPath) {
-          continue;
+      await db.transaction(() async {
+        await _rebaseEpubBooks(db, docs);
+        await _rebaseAudiobooks(db, docs);
+        await _rebaseSrtBooks(db, docs);
+        await _rebaseVideoBooks(db, docs);
+        if (debugFailMidRebase) {
+          throw StateError('debugFailMidRebase');
         }
-        await db.customStatement(
-          'UPDATE video_books SET video_path = ?, playlist_json = ?, '
-          'cover_path = ? WHERE book_uid = ?',
-          <Object?>[newVideoPath, newPlaylist, newCover, v.bookUid],
-        );
-      }
-
-      // ── prefs：字体目录配置（catalog + 旧 shadow 列表）走 documents 根；本地音频库
-      //    JSON（local_audio_*.db 内部副本）走 support 根。
-      final Map<String, String> prefs = await db.getAllPrefs();
-      final String? catalog = prefs[_fontCatalogPrefKey];
-      if (catalog != null) {
-        final String rebased =
-            rebaseFontCatalogJson(catalog, oldDocumentsRoot, newDocumentsRoot);
-        if (rebased != catalog) await db.setPref(_fontCatalogPrefKey, rebased);
-      }
-      for (final String key in _legacyFontPrefKeys) {
-        final String? raw = prefs[key];
-        if (raw == null) continue;
-        final String rebased =
-            rebaseFontListJson(raw, oldDocumentsRoot, newDocumentsRoot);
-        if (rebased != raw) await db.setPref(key, rebased);
-      }
-      // TODO-1171: local-audio internal copies (`local_audio_<ts>.db`) are
-      // re-homed by FILENAME onto the new support root (tag-aware; the pref is
-      // PrefCodec-tagged so the pre-1171 raw json-decode silently no-op'd here
-      // too). Also re-home the typed `audio_source_configs` localAudio paths so
-      // the two prefs stay joined after a data-root move.
-      final String? localAudio = prefs[_localAudioDbsPrefKey];
-      if (localAudio != null) {
-        final String rebased =
-            normalizeLocalAudioDbsJson(localAudio, newSupportRoot);
-        if (rebased != localAudio) {
-          await db.setPref(_localAudioDbsPrefKey, rebased);
-        }
-      }
-      final String? audioConfigs = prefs[_audioSourceConfigsPrefKey];
-      if (audioConfigs != null) {
-        final String rebased =
-            normalizeAudioSourceConfigsJson(audioConfigs, newSupportRoot);
-        if (rebased != audioConfigs) {
-          await db.setPref(_audioSourceConfigsPrefKey, rebased);
-        }
-      }
-
+        await _rebaseGalgames(db, docs);
+        await _rebaseMediaItems(db, docs);
+        await _rebasePreferences(db, docs, newSupportRoot);
+        await _rebaseProfileSettings(db, docs, newSupportRoot);
+      });
+      // checkpoint 必须在事务**外**：SQLite 不允许在活动事务里 wal_checkpoint。
       await db.customStatement('PRAGMA wal_checkpoint(TRUNCATE)');
     } finally {
       await db.close();
     }
   }
 
+  /// epub_books：epubPath / extractDir / coverPath。前者与 coverPath 按声明其实不是
+  /// 数据根内路径（裸文件名 / 相对 href），改写是防御性 no-op，保留调用与历史行为一致。
+  static Future<void> _rebaseEpubBooks(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+  ) async {
+    for (final EpubBookRow b in await db.getAllEpubBooks()) {
+      await db.updateEpubBookContentPaths(
+        b.bookKey,
+        epubPath: docs.rebase(b.epubPath),
+        extractDir: docs.rebase(b.extractDir),
+        coverPath: docs.rebaseNullable(b.coverPath),
+      );
+    }
+  }
+
+  /// audiobooks：audioRoot / audioPathsJson（列表）/ alignmentPath。
+  static Future<void> _rebaseAudiobooks(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+  ) async {
+    for (final AudiobookRow a in await db.getAllAudiobooks()) {
+      await db.updateAudiobookPaths(
+        a.bookKey,
+        audioRoot: docs.rebaseNullable(a.audioRoot),
+        audioPathsJson: _rebaseJsonStringList(a.audioPathsJson, docs),
+        alignmentPath: docs.rebase(a.alignmentPath),
+      );
+    }
+  }
+
+  /// srt_books（独立 SRT/有声书，无 epub 背书）：四列都在 documents 根下。
+  static Future<void> _rebaseSrtBooks(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+  ) async {
+    for (final SrtBookRow s in await db.getAllSrtBooks()) {
+      await db.customStatement(
+        'UPDATE srt_books SET '
+        'audio_root = ?, audio_paths_json = ?, srt_path = ?, cover_path = ? '
+        'WHERE id = ?',
+        <Object?>[
+          docs.rebaseNullable(s.audioRoot),
+          _rebaseJsonStringList(s.audioPathsJson, docs),
+          docs.rebase(s.srtPath),
+          docs.rebaseNullable(s.coverPath),
+          s.id,
+        ],
+      );
+    }
+  }
+
+  /// video_books：video_path / playlist_json / cover_path / subtitle_source ×2。
+  ///
+  /// - cover_path 是应用自有资产（`<documents>/video_covers`），TODO-1255 补的漏项。
+  /// - **subtitle_source / secondary_subtitle_source 是 BUG-1174 补的漏项**：四态编码
+  ///   里只有「外挂绝对路径」态该改写，`embedded:<n>` / `off:` 两个哨兵显式判掉。
+  ///   `video_subtitles/` 在搬移白名单里，不改写 = 所有外挂字幕失联。
+  static Future<void> _rebaseVideoBooks(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+  ) async {
+    for (final VideoBookRow v in await db.allVideoBooks()) {
+      final String newVideoPath = docs.rebase(v.videoPath);
+      final String? newPlaylist = _rebasePlaylistJson(v.playlistJson, docs);
+      final String? newCover = docs.rebaseNullable(v.coverPath);
+      final String? newSubtitle = rebaseSubtitleSource(v.subtitleSource, docs);
+      final String? newSecondary =
+          rebaseSubtitleSource(v.secondarySubtitleSource, docs);
+      if (newVideoPath == v.videoPath &&
+          newPlaylist == v.playlistJson &&
+          newCover == v.coverPath &&
+          newSubtitle == v.subtitleSource &&
+          newSecondary == v.secondarySubtitleSource) {
+        continue;
+      }
+      await db.customStatement(
+        'UPDATE video_books SET video_path = ?, playlist_json = ?, '
+        'cover_path = ?, subtitle_source = ?, secondary_subtitle_source = ? '
+        'WHERE book_uid = ?',
+        <Object?>[
+          newVideoPath,
+          newPlaylist,
+          newCover,
+          newSubtitle,
+          newSecondary,
+          v.bookUid,
+        ],
+      );
+    }
+  }
+
+  /// galgames：cover_path（`<documents>/game_covers/<id>.<ext>`）。BUG-1174 漏项，与
+  /// TODO-1255 的 video_books.cover_path 完全同型 —— 不改写 = 整个游戏库封面退化成默认
+  /// 手柄图标。exe_path / workdir / launch_args 是用户外部安装位置，**绝不**改写。
+  static Future<void> _rebaseGalgames(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+  ) async {
+    for (final GalgameRow g in await db.getAllGalgames()) {
+      final String? newCover = docs.rebaseNullable(g.coverPath);
+      if (newCover == g.coverPath) continue;
+      await db.customStatement(
+        'UPDATE galgames SET cover_path = ? WHERE id = ?',
+        <Object?>[newCover, g.id],
+      );
+    }
+  }
+
+  /// media_items：image_url（本地书封面存 `file://<绝对路径>` URI）。BUG-1174 漏项 ——
+  /// 不改写 = 书架/首页「最近」卡片封面全空白，直到该书被重新打开刷新。远端源的
+  /// http(s) URL scheme 非 file，[DocumentsPathRebaser.rebaseFileUri] 原样返回。
+  static Future<void> _rebaseMediaItems(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+  ) async {
+    for (final MediaItemRow m in await db.getAllMediaItems()) {
+      final String? url = m.imageUrl;
+      if (url == null) continue;
+      final String rebased = docs.rebaseFileUri(url);
+      if (rebased == url) continue;
+      await db.customStatement(
+        'UPDATE media_items SET image_url = ? WHERE id = ?',
+        <Object?>[rebased, m.id],
+      );
+    }
+  }
+
+  /// preferences：按 [kPathRebasePrefs] 声明逐 key 改写（字体目录 / 本地发音库 /
+  /// 游戏库 legacy JSON / 远端字幕 map / 下载根与历史）。
+  static Future<void> _rebasePreferences(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+    String newSupportRoot,
+  ) async {
+    final Map<String, String> prefs = await db.getAllPrefs();
+    for (final PathRebasePref spec in kPathRebasePrefs) {
+      if (!spec.mustRebase) continue;
+      final String? raw = prefs[spec.key];
+      if (raw == null) continue;
+      final String rebased = rebaseMigratedPrefValue(
+        spec.key,
+        raw,
+        documents: docs,
+        newSupportRoot: newSupportRoot,
+      );
+      if (rebased != raw) await db.setPref(spec.key, rebased);
+    }
+  }
+
+  /// profile_settings：每个 Profile 的 pref 快照副本。**必须覆盖所有 Profile**，用与
+  /// [_rebasePreferences] 完全相同的改写函数。
+  ///
+  /// 为什么选「迁移时一起改」而不是「让路径 pref 不进快照」：后者会改掉 Profile 的既有
+  /// 语义（字体目录、发音库配置现在确实是**每 Profile** 的），等于为了修迁移去动一个与
+  /// 迁移无关的功能契约——爆炸半径大得多，且会破坏已按 Profile 分别配字体的用户。
+  /// 迁移时一起改是纯增量、零语义变更。
+  static Future<void> _rebaseProfileSettings(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+    String newSupportRoot,
+  ) async {
+    final List<QueryRow> rows = await db.customSelect(
+      'SELECT id, key, value FROM profile_settings WHERE category = ?',
+      variables: <Variable<Object>>[
+        Variable<String>(ProfileKeys.categoryPref),
+      ],
+    ).get();
+    for (final QueryRow row in rows) {
+      final String key = row.read<String>('key');
+      final String value = row.read<String>('value');
+      final String rebased = rebaseMigratedPrefValue(
+        key,
+        value,
+        documents: docs,
+        newSupportRoot: newSupportRoot,
+      );
+      if (rebased == value) continue;
+      await db.customStatement(
+        'UPDATE profile_settings SET value = ? WHERE id = ?',
+        <Object?>[rebased, row.read<int>('id')],
+      );
+    }
+  }
+
+  /// 仅供单测（BUG-1174 ③）：直接驱动 DB 路径改写，用来验证**幂等性**（同一改写连跑
+  /// 两次，第二次必须是 no-op）。生产走 [migrate]，不经此入口。
+  @visibleForTesting
+  Future<void> rebaseDatabasePathsForTesting({
+    required String dbDirectory,
+    required String oldDocumentsRoot,
+    required String newDocumentsRoot,
+    required String newSupportRoot,
+    required Set<String>? documentsScopeEntries,
+  }) =>
+      _rebaseDatabasePaths(
+        dbDirectory: dbDirectory,
+        oldDocumentsRoot: oldDocumentsRoot,
+        newDocumentsRoot: newDocumentsRoot,
+        newSupportRoot: newSupportRoot,
+        documentsScopeEntries: documentsScopeEntries,
+      );
+
   /// rebase 一个「JSON 字符串数组」里每个绝对路径（如 audioPathsJson）。非 JSON 列表
   /// 原样返回（一个坏行不该中断整次迁移）。
   static String? _rebaseJsonStringList(
     String? json,
-    String oldRoot,
-    String newRoot,
+    DocumentsPathRebaser docs,
   ) {
     if (json == null) return null;
-    try {
-      final dynamic decoded = jsonDecode(json);
-      if (decoded is! List) return json;
-      return jsonEncode(decoded
-          .whereType<String>()
-          .map((String s) => rebasePath(s, oldRoot, newRoot))
-          .toList());
-    } catch (_) {
-      return json;
-    }
+    return rebaseJsonStringListWith(json, docs);
   }
 
   /// rebase 视频 playlist JSON 里每个 `path`。结构同 backup_service 的同名逻辑。
   static String? _rebasePlaylistJson(
     String? playlistJson,
-    String oldRoot,
-    String newRoot,
+    DocumentsPathRebaser docs,
   ) {
     if (playlistJson == null || playlistJson.isEmpty) return playlistJson;
     try {
@@ -893,7 +1005,7 @@ class DataRootMigrator {
         final Map<String, dynamic> row = Map<String, dynamic>.from(entry);
         final Object? path = row['path'];
         if (path is! String) return row;
-        final String rebased = rebasePath(path, oldRoot, newRoot);
+        final String rebased = docs.rebase(path);
         if (rebased != path) {
           row['path'] = rebased;
           changed = true;
@@ -958,4 +1070,215 @@ class _CopyProgress {
     _copied++;
     _onProgress?.call(_copied, _total);
   }
+}
+
+/// BUG-1174 ③：数据根迁移期的 documents 根路径改写器。**本质幂等**。
+///
+/// 旧写法的判据是 `startsWith(oldRoot)`。当新根落在旧根**内部**时（正是
+/// `<Documents>` → `<Documents>/Hibiki/data` 这种形态），一条已经改写过的路径**仍然**
+/// 以旧根开头，再跑一次就变成 `Documents/Hibiki/data/Hibiki/data/...` —— 全库路径当场
+/// 作废、且不抛任何异常，**静默毁库**。同型的坑在 iOS 容器重定位上已经踩过一次
+/// （BUG-1115）。
+///
+/// 这里不靠「保证只跑一次」的流程来回避（那是把正确性押在流程上），而是**把判据改对**：
+/// 作用域谓词收窄为「相对旧根的**首段**命中 [scopeTopLevelNames]」，也就是**本次搬移
+/// 真正会动的那些顶层项**。`Hibiki` 不在白名单里（`isSafeNestedTargetInSharedDocuments`
+/// 靠的就是这一点），所以已改写过的路径首段是 `Hibiki` → 天然跳过。「跑没跑过」这个
+/// 问题因此**消失**，而不是被判断掩盖。
+///
+/// [scopeTopLevelNames] 必须与 `DataRootMigrationRequest.documentsTopLevelIncludeNames`
+/// **同源**：改写作用域与搬移作用域一旦漂开，就会出现「文件搬走了但路径没改」或反过来
+/// 「路径改了但文件还在旧位置」。`null`（Hibiki 专属根的整树搬移语义）= 无首段限制；
+/// 那条路径上 `_validateTarget` 已禁止新根落在旧根内部，故同样幂等。
+@immutable
+class DocumentsPathRebaser {
+  const DocumentsPathRebaser({
+    required this.oldRoot,
+    required this.newRoot,
+    required this.scopeTopLevelNames,
+  });
+
+  final String oldRoot;
+  final String newRoot;
+
+  /// 本次搬移真正会动的顶层项基名集合；null = 整树搬移（无首段限制）。
+  final Set<String>? scopeTopLevelNames;
+
+  static String _stripTrailingSeparator(String value) =>
+      (value.endsWith('/') || value.endsWith('\\'))
+          ? value.substring(0, value.length - 1)
+          : value;
+
+  /// [path] 是否落在本次改写的作用域内。分隔符归一与边界判据与
+  /// `backup_service.dart` 的 `rebasePath` 逐字节一致（`/a/books_extra` 不算在
+  /// `/a/books` 下）。首段比较**大小写不敏感**——`p.canonicalize` 在 Windows 上转小写，
+  /// 原样比对会让 `hibikiExport` 漏网（它会被搬走、路径却不改 = 数据分家）。在 Linux 上
+  /// 大小写不敏感只会更宽松几个名字，而那些名字下本来就没有别人写的 DB 路径。
+  bool isInScope(String path) {
+    final String root = _stripTrailingSeparator(oldRoot.replaceAll('\\', '/'));
+    final String normalized = path.replaceAll('\\', '/');
+    if (normalized == root) return true;
+    if (!normalized.startsWith('$root/')) return false;
+    final Set<String>? scope = scopeTopLevelNames;
+    if (scope == null) return true;
+    final String first =
+        normalized.substring(root.length + 1).split('/').first.toLowerCase();
+    return scope.any((String owned) => owned.toLowerCase() == first);
+  }
+
+  /// 作用域内 → rebase 到新根；作用域外（用户外部路径 / 已改写过的路径）→ 原样返回。
+  String rebase(String path) =>
+      isInScope(path) ? rebasePath(path, oldRoot, newRoot) : path;
+
+  String? rebaseNullable(String? path) => path == null ? null : rebase(path);
+
+  /// 改写 `file://<绝对路径>` URI（`media_items.image_url`）。必须先解码成文件路径再
+  /// 改写、再重新编码：对 URI 字符串直接做前缀替换，分隔符与百分号编码都不对。
+  /// 非 `file:` scheme（远端源的 http(s) 封面）原样返回。
+  String rebaseFileUri(String value) {
+    final Uri? uri = Uri.tryParse(value);
+    if (uri == null || uri.scheme != 'file') return value;
+    final String filePath;
+    try {
+      filePath = uri.toFilePath();
+    } catch (_) {
+      return value; // 畸形 file URI：不猜、不动。
+    }
+    final String rebased = rebase(filePath);
+    if (rebased == filePath) return value;
+    return Uri.file(rebased).toString();
+  }
+}
+
+/// 改写一个 `subtitleSource` 四态编码值（`video_books.subtitle_source` /
+/// `secondary_subtitle_source` 列，以及 `video_remote_subtitle` pref map 的 value）。
+///
+/// 只有「外挂绝对路径」态参与改写；`embedded:<n>` 与 `off:` 两个哨兵**显式**判掉。
+/// 它们本来也不以旧根开头（作用域谓词天然跳过），但那是巧合——显式判掉才是契约。
+String? rebaseSubtitleSource(String? stored, DocumentsPathRebaser docs) {
+  if (stored == null || stored.isEmpty) return stored;
+  if (SubtitleSource.isOff(stored)) return stored;
+  if (SubtitleSource.isEmbeddedPersisted(stored)) return stored;
+  return docs.rebase(stored);
+}
+
+/// 改写一个「JSON 字符串数组」里每个绝对路径。非 JSON 列表原样返回（一个坏值不该中断
+/// 整次迁移）。
+String rebaseJsonStringListWith(String json, DocumentsPathRebaser docs) {
+  try {
+    final dynamic decoded = jsonDecode(json);
+    if (decoded is! List) return json;
+    return jsonEncode(decoded.whereType<String>().map(docs.rebase).toList());
+  } catch (_) {
+    return json;
+  }
+}
+
+/// 改写一个 `{key: subtitleSource 四态编码}` JSON map（`video_remote_subtitle`）。
+String rebaseSubtitleSourceMapJson(String json, DocumentsPathRebaser docs) {
+  try {
+    final dynamic decoded = jsonDecode(json);
+    if (decoded is! Map) return json;
+    return jsonEncode(decoded.map<String, String>((dynamic k, dynamic v) =>
+        MapEntry<String, String>(
+            k.toString(), rebaseSubtitleSource(v.toString(), docs)!)));
+  } catch (_) {
+    return json;
+  }
+}
+
+/// 改写 v55 legacy `galgame_library` JSON 里每条的 `coverPath`。
+/// 同条目的 `exePath` / `workdir` 是用户外部安装位置，**绝不**改写。
+String rebaseLegacyGalgameLibraryJson(String json, DocumentsPathRebaser docs) {
+  try {
+    final dynamic decoded = jsonDecode(json);
+    if (decoded is! List) return json;
+    bool changed = false;
+    final List<dynamic> out = decoded.map<dynamic>((dynamic entry) {
+      if (entry is! Map) return entry;
+      final Map<String, dynamic> row = Map<String, dynamic>.from(entry);
+      final Object? cover = row['coverPath'];
+      if (cover is! String) return row;
+      final String rebased = docs.rebase(cover);
+      if (rebased != cover) {
+        row['coverPath'] = rebased;
+        changed = true;
+      }
+      return row;
+    }).toList();
+    return changed ? jsonEncode(out) : json;
+  } catch (_) {
+    return json;
+  }
+}
+
+/// BUG-1174 ②：给定 (pref key, 原始值) 返回改写后的值。**纯函数**。
+///
+/// `preferences` 与 `profile_settings` 两条路都必须调它。历史教训：把改写逻辑抄两份
+/// （备份恢复侧与迁移侧）迟早漂开，`srt_books` 四列与 `video_books.cover_path` 就是这么
+/// 漂开的。这里只留一份。
+///
+/// 未登记（[pathRebasePrefFor] 返回 null）或登记为不改写的 key 一律原样返回——
+/// `profile_settings` 里躺着**全部**非排除 pref，绝不能对不认识的 key 乱动。
+String rebaseMigratedPrefValue(
+  String key,
+  String value, {
+  required DocumentsPathRebaser documents,
+  required String newSupportRoot,
+}) {
+  final PathRebasePref? spec = pathRebasePrefFor(key);
+  if (spec == null || !spec.mustRebase) return value;
+  switch (spec.shape) {
+    // 字体 JSON 复用 backup_service 的遍历器，但**必须注入作用域改写器**：那两个函数
+    // 默认走裸 rebasePath（startsWith 判据），新根落在旧根内部时会把已改写过的 path 再
+    // 改一遍 → `.../Hibiki/data/Hibiki/data/custom_fonts/a.ttf`。这是本次被幂等测试
+    // **真实抓到**的旁路（BUG-1174 ③）。备份恢复侧不传 rewritePath，行为逐字节不变。
+    case PathValueShape.fontCatalogJson:
+      return rebaseFontCatalogJson(
+        value,
+        documents.oldRoot,
+        documents.newRoot,
+        rewritePath: documents.rebase,
+      );
+    case PathValueShape.fontListJson:
+      return rebaseFontListJson(
+        value,
+        documents.oldRoot,
+        documents.newRoot,
+        rewritePath: documents.rebase,
+      );
+    case PathValueShape.localAudioDbsJson:
+      return normalizeLocalAudioDbsJson(value, newSupportRoot);
+    case PathValueShape.audioSourceConfigsJson:
+      return normalizeAudioSourceConfigsJson(value, newSupportRoot);
+    case PathValueShape.legacyGalgameLibraryJson:
+      return _withPrefTag(value,
+          (String body) => rebaseLegacyGalgameLibraryJson(body, documents));
+    case PathValueShape.subtitleSourceMapJson:
+      return _withPrefTag(
+          value, (String body) => rebaseSubtitleSourceMapJson(body, documents));
+    case PathValueShape.jsonStringList:
+      return _withPrefTag(
+          value, (String body) => rebaseJsonStringListWith(body, documents));
+    case PathValueShape.bare:
+      // support 根下的旧单库路径按**文件名**重挂（与 local_audio_dbs 同款、天然幂等）；
+      // documents 根下的裸路径走作用域改写器。
+      return _withPrefTag(
+        value,
+        (String body) => spec.kind == PathRebaseKind.supportRooted
+            ? LocalAudioManager.resolveInternalPath(body, newSupportRoot)
+            : documents.rebase(body),
+      );
+    case PathValueShape.none:
+      return value;
+  }
+}
+
+/// 剥掉 PrefCodec tag（`s:` / `j:`）改写 body 再贴回去。低层 `db.setPref` 写的裸值
+/// tag 为空，[joinPrefTag] 原样返回，两种写法都安全。空值直接返回（空串 = 未设置）。
+String _withPrefTag(String raw, String Function(String body) rewrite) {
+  if (raw.isEmpty) return raw;
+  final ({String tag, String body}) split = splitPrefTag(raw);
+  if (split.body.isEmpty) return raw;
+  return joinPrefTag(split.tag, rewrite(split.body));
 }

--- a/hibiki/lib/src/storage/path_rebase_coverage.dart
+++ b/hibiki/lib/src/storage/path_rebase_coverage.dart
@@ -1,0 +1,422 @@
+/// BUG-1174：数据根迁移「哪些持久化字段承载绝对路径、迁移要不要改写」的**单一真相源**。
+///
+/// 历史上这份知识只活在 [DataRootMigrator] 的一串 UPDATE 语句里，于是每加一列存路径的
+/// 字段就漏一次：TODO-1255 漏了 video_books.cover_path（迁移后视频封面全占位），
+/// BUG-1174 又一次性发现漏了 galgames.cover_path、video_books.subtitle_source ×2、
+/// media_items.image_url、整张 profile_settings 和 5 个 pref key。注释拦不住这种遗漏
+/// ——注释不会红。把清单**声明化**并由源码扫描守卫
+/// （test/storage/path_rebase_coverage_guard_test.dart）比对：新增路径列而忘了登记就在
+/// CI 上红，而不是等用户数据坏了才发现。
+///
+/// 与 sync/pref_redaction_policy.dart 同款骨架：一份声明 + 一个谓词 + 多处消费。
+library;
+
+import 'package:flutter/foundation.dart';
+
+/// 一个持久化字段在数据根迁移里的处置。
+enum PathRebaseKind {
+  /// 落在 **documents（内容/书库）根**下的绝对路径 —— 迁移必须 rebase 到新 documents 根。
+  documentsRooted,
+
+  /// 落在 **support（数据库）根**下的绝对路径 —— 迁移必须重挂到新 support 根
+  /// （按文件名，见 LocalAudioManager.resolveInternalPath）。
+  supportRooted,
+
+  /// 用户自选的**外部**绝对路径（外部素材目录 / 游戏安装位置 / 系统工具 / 文件选择器
+  /// 上次目录）—— 不在数据根内，迁移**绝不能**动它，动了就让外部资源失联。
+  externalUserPath,
+
+  /// 不是文件系统绝对路径：相对 href、裸文件名、成员引用、远端 URL、枚举/编码值、
+  /// 与路径无关的结构化 JSON。
+  notAPath,
+}
+
+/// 一列 Drift 列的迁移处置声明。
+///
+/// [table] / [column] 用 packages/hibiki_core/lib/src/database/tables.dart 里的
+/// **Dart 名**（表类名 + 列 getter 名），因为守卫测试扫的就是那份源码；SQL 名由 drift
+/// 从它派生（全仓无 named() 显式改名），两者一一对应。
+@immutable
+class PathRebaseColumn {
+  const PathRebaseColumn(this.table, this.column, this.kind, this.reason);
+
+  /// tables.dart 里的 Dart 表类名（如 VideoBooks）。
+  final String table;
+
+  /// tables.dart 里的 Dart 列 getter 名（如 coverPath）。
+  final String column;
+
+  final PathRebaseKind kind;
+
+  /// 为什么是这个处置。**必填**：豁免一列必须给得出理由，否则下一个人无从判断该不该
+  /// 改判。守卫测试断言非空。
+  final String reason;
+
+  /// 迁移是否必须改写这一列。
+  bool get mustRebase =>
+      kind == PathRebaseKind.documentsRooted ||
+      kind == PathRebaseKind.supportRooted;
+
+  /// drift 默认的 snake_case SQL 列名。守卫据此断言 must-rebase 列真的出现在迁移器里。
+  String get sqlColumn => column.replaceAllMapped(
+      RegExp('[A-Z]'), (Match m) => '_${m[0]!.toLowerCase()}');
+
+  @override
+  String toString() => '$table.$column($kind)';
+}
+
+/// pref 值承载路径的形态（决定用哪个改写器）。
+enum PathValueShape {
+  /// 裸绝对路径（空串 = 未设置）。
+  bare,
+
+  /// JSON 字符串数组，每个元素是绝对路径。
+  jsonStringList,
+
+  /// JSON map，value 是 subtitleSource 四态编码（本地已下载 = 绝对路径）。
+  subtitleSourceMapJson,
+
+  /// 字体 catalog：{version, fonts:[{id,name,path}]}。
+  fontCatalogJson,
+
+  /// 字体列表：[{name,path,enabled}]。
+  fontListJson,
+
+  /// 本地发音库列表（PrefCodec s: tag + JSON 对象数组，按**文件名**重挂）。
+  localAudioDbsJson,
+
+  /// typed 音频来源配置（PrefCodec j: tag + JSON 对象数组，仅 localAudio 条目带 path）。
+  audioSourceConfigsJson,
+
+  /// v55 legacy 游戏库 JSON 数组，仅 coverPath 字段是数据根内路径。
+  legacyGalgameLibraryJson,
+
+  /// 不承载数据根内路径。
+  none,
+}
+
+/// 一个 Drift preferences / profile_settings KV 键的迁移处置声明。
+@immutable
+class PathRebasePref {
+  const PathRebasePref(this.key, this.kind, this.shape, this.reason);
+
+  /// pref key 的**字面值**。经编码器生成的键（dbSourcePrefKey('reader_ttu', ...)）
+  /// 也写展开后的字面值，守卫按字面值比对。
+  final String key;
+
+  final PathRebaseKind kind;
+  final PathValueShape shape;
+  final String reason;
+
+  bool get mustRebase =>
+      kind == PathRebaseKind.documentsRooted ||
+      kind == PathRebaseKind.supportRooted;
+
+  @override
+  String toString() => '$key($kind/$shape)';
+}
+
+/// tables.dart 里**所有**名字带 path|dir|root|url|source|file|json 的 TextColumn 的
+/// 处置声明，外加几列名字看不出、但确实承载路径 / KV 的列（preferences.value、
+/// profile_settings.value、galgames.launchArgs）。
+///
+/// 守卫双向比对：路径形列漏声明红、声明了但列已不存在也红。
+/// 按 tables.dart 出现顺序排列，便于人工对照。
+const List<PathRebaseColumn> kPathRebaseColumns = <PathRebaseColumn>[
+  // ── media_items（媒体历史）─────────────────────────────────────────
+  PathRebaseColumn('MediaItems', 'mediaSourceIdentifier',
+      PathRebaseKind.notAPath, '媒体源标识（MediaSource.uniqueKey），不是路径。'),
+  PathRebaseColumn(
+      'MediaItems',
+      'imageUrl',
+      PathRebaseKind.documentsRooted,
+      '本地书封面存 file://<绝对路径> URI（reader_hibiki_source.dart 的 '
+          'Uri.file(candidate)，候选全在 <documents>/hoshi_books 下；SRT 书同款）。'
+          '远端源存 http(s) URL，scheme 非 file 时改写器原样跳过。'),
+  PathRebaseColumn('MediaItems', 'audioUrl', PathRebaseKind.notAPath,
+      '历史 MediaItem 的远端音频 URL 字段；生产代码无写入点（jidoujisho 血统遗留）。'),
+  PathRebaseColumn('MediaItems', 'extraUrl', PathRebaseKind.notAPath,
+      '同 audioUrl：生产代码无写入点，只被历史仓库原样搬运。'),
+  PathRebaseColumn('MediaItems', 'sourceMetadata', PathRebaseKind.notAPath,
+      '每章字符数 JSON（jsonEncode(sectionChars)），无路径。'),
+
+  // ── anki_mappings ─────────────────────────────────────────────────
+  PathRebaseColumn('AnkiMappings', 'exportFieldKeysJson',
+      PathRebaseKind.notAPath, '字段 key 列表 JSON，无路径。'),
+  PathRebaseColumn('AnkiMappings', 'creatorFieldKeysJson',
+      PathRebaseKind.notAPath, '字段 key 列表 JSON，无路径。'),
+  PathRebaseColumn('AnkiMappings', 'creatorCollapsedFieldKeysJson',
+      PathRebaseKind.notAPath, '字段 key 列表 JSON，无路径。'),
+  PathRebaseColumn(
+      'AnkiMappings', 'tagsJson', PathRebaseKind.notAPath, '标签字符串列表 JSON，无路径。'),
+  PathRebaseColumn('AnkiMappings', 'enhancementsJson', PathRebaseKind.notAPath,
+      '增强功能 key 映射 JSON，无路径。'),
+  PathRebaseColumn('AnkiMappings', 'actionsJson', PathRebaseKind.notAPath,
+      '快捷操作 key 列表 JSON，无路径。'),
+
+  // ── preferences / profile_settings（KV 承载列）──────────────────────
+  PathRebaseColumn('Preferences', 'value', PathRebaseKind.documentsRooted,
+      'KV 承载列：逐 key 的处置见 [kPathRebasePrefs]。documents / support 两族都有。'),
+  PathRebaseColumn(
+      'ProfileSettings',
+      'value',
+      PathRebaseKind.documentsRooted,
+      'BUG-1174 最阴的一处：ProfileRepository.snapshotCurrentSettings 把**每一条**非'
+          '排除 Drift pref 原样复制进来（category=pref），applyProfile 再原样写回 '
+          'preferences。迁移只改 preferences 的话，用户切一次 Profile 就把刚 rebase 好的'
+          '路径整体回滚回旧值——迁移当天一切正常、几天后突然坏，极难归因。'
+          '必须与 preferences 用**同一个**改写函数、覆盖**所有** Profile 的快照。'),
+
+  // ── audiobooks ────────────────────────────────────────────────────
+  PathRebaseColumn(
+      'Audiobooks',
+      'audioRoot',
+      PathRebaseKind.documentsRooted,
+      '复制导入模式 = <documents>/audiobooks/<hash>；folder 模式的外部目录（遗留、当前'
+          '无写入点）不以旧根开头 → 天然跳过。'),
+  PathRebaseColumn(
+      'Audiobooks',
+      'audioPathsJson',
+      PathRebaseKind.documentsRooted,
+      'JSON 字符串数组；复制模式是持久目录内绝对路径，「引用原文件」模式是外部路径（天然跳过）。'),
+  PathRebaseColumn(
+      'Audiobooks',
+      'alignmentPath',
+      PathRebaseKind.documentsRooted,
+      '<documents>/audiobooks/<hash>/ 下的字幕副本绝对路径。'),
+
+  // ── srt_books ─────────────────────────────────────────────────────
+  PathRebaseColumn('SrtBooks', 'audioRoot', PathRebaseKind.documentsRooted,
+      '同 Audiobooks.audioRoot。'),
+  PathRebaseColumn('SrtBooks', 'audioPathsJson', PathRebaseKind.documentsRooted,
+      '同 Audiobooks.audioPathsJson。'),
+  PathRebaseColumn('SrtBooks', 'srtPath', PathRebaseKind.documentsRooted,
+      '持久目录内 SRT 副本绝对路径。'),
+  PathRebaseColumn('SrtBooks', 'coverPath', PathRebaseKind.documentsRooted,
+      '<documents>/audiobooks/<hash>/cover.<ext> 绝对路径。'),
+
+  // ── dictionary_metadata / dictionary_history ──────────────────────
+  PathRebaseColumn('DictionaryMetadata', 'metadataJson',
+      PathRebaseKind.notAPath, '词典元数据 JSON（标题/版本/作者），无路径。'),
+  PathRebaseColumn('DictionaryMetadata', 'hiddenLanguagesJson',
+      PathRebaseKind.notAPath, '语言代码列表 JSON，无路径。'),
+  PathRebaseColumn('DictionaryMetadata', 'collapsedLanguagesJson',
+      PathRebaseKind.notAPath, '语言代码列表 JSON，无路径。'),
+  PathRebaseColumn('DictionaryHistory', 'resultJson', PathRebaseKind.notAPath,
+      '查询结果快照 JSON（词条文本），无路径。'),
+
+  // ── epub_books ────────────────────────────────────────────────────
+  PathRebaseColumn(
+      'EpubBooks',
+      'coverPath',
+      PathRebaseKind.notAPath,
+      '**相对 href**（相对 extractDir）/ PDF 的 cover.png / 漫画的相对路径。迁移器仍把'
+          '它送进改写器，是防御性 no-op（不以旧根开头 → 原样返回）。'),
+  PathRebaseColumn(
+      'EpubBooks',
+      'epubPath',
+      PathRebaseKind.notAPath,
+      '多语义：普通导入 = 裸 basename / PDF = document.pdf / 漫画 = manga.json / '
+          '来源库扫描 = **外部**绝对路径。四种都不是数据根内路径，改写恒 no-op；调用'
+          '保留作防御。'),
+  PathRebaseColumn('EpubBooks', 'extractDir', PathRebaseKind.documentsRooted,
+      '<documents>/hoshi_books/<bookKey> 绝对目录。'),
+  PathRebaseColumn('EpubBooks', 'chaptersJson', PathRebaseKind.notAPath,
+      '书内相对 href 列表，无绝对路径。'),
+  PathRebaseColumn(
+      'EpubBooks', 'tocJson', PathRebaseKind.notAPath, '书内相对 href 目录树，无绝对路径。'),
+  PathRebaseColumn('EpubBooks', 'sourceMetadata', PathRebaseKind.notAPath,
+      '来源库扫描元数据 JSON，无本机数据根路径。'),
+
+  // ── video_books ───────────────────────────────────────────────────
+  PathRebaseColumn(
+      'VideoBooks',
+      'videoPath',
+      PathRebaseKind.documentsRooted,
+      '三态：数据根内下载副本（<documents>/remote_videos、videos）/ 用户原位外部视频 / '
+          'http(s) 流 URL。后两态不以旧根开头 → 天然跳过。'),
+  PathRebaseColumn(
+      'VideoBooks',
+      'subtitleSource',
+      PathRebaseKind.documentsRooted,
+      'BUG-1174 漏项。四态编码（video_subtitle_source.dart:362-430）：外挂 = 裸绝对'
+          '路径（多为 <documents>/video_subtitles/<basename> 内部副本）/ 内嵌 = '
+          'embedded:<n> / 关闭 = off: / 无偏好 = null。**只有绝对路径态**参与改写，'
+          '另两个哨兵显式判掉（不靠「不以旧根开头」这个巧合）。video_subtitles 在搬移'
+          '白名单里 → 不改写 = 所有外挂字幕失联，查词与双字幕一并失效。'),
+  PathRebaseColumn(
+      'VideoBooks',
+      'secondarySubtitleSource',
+      PathRebaseKind.documentsRooted,
+      'BUG-1174 漏项，与 subtitleSource 同款四态编码，处置相同。'),
+  PathRebaseColumn('VideoBooks', 'coverPath', PathRebaseKind.documentsRooted,
+      '<documents>/video_covers/<sanitize(bookUid)>.jpg（TODO-1255 补的漏项）。'),
+  PathRebaseColumn('VideoBooks', 'playlistJson', PathRebaseKind.documentsRooted,
+      'JSON 对象数组 [{title,path}]，path 与 videoPath 同语义。'),
+  PathRebaseColumn(
+      'VideoBooks',
+      'streamSpecJson',
+      PathRebaseKind.notAPath,
+      'TODO-1157 流媒体加载凭据 {subtitleUrl,subtitleFileName,referer,userAgent}，'
+          '全是远端 URL / HTTP header，无本机路径。'),
+
+  // ── 统计 / 收藏 ────────────────────────────────────────────────────
+  PathRebaseColumn('FavoriteWords', 'sourceType', PathRebaseKind.notAPath,
+      '统计桶枚举值（book/video/...），不是路径。'),
+  PathRebaseColumn('MiningStatistics', 'sourceType', PathRebaseKind.notAPath,
+      '统计桶枚举值，不是路径。'),
+  PathRebaseColumn('LookupMiningCounters', 'sourceType',
+      PathRebaseKind.notAPath, '统计桶枚举值，不是路径。'),
+  PathRebaseColumn('MinedSentences', 'source', PathRebaseKind.notAPath,
+      '跳转/统计来源标识（book | video | audiobook | lyrics），不是路径。'),
+  PathRebaseColumn('StatisticsTombstones', 'sourceType',
+      PathRebaseKind.notAPath, '统计桶枚举值，不是路径。'),
+
+  // ── media_sources（来源库扫描根）────────────────────────────────────
+  PathRebaseColumn(
+      'MediaSources',
+      'rootPath',
+      PathRebaseKind.externalUserPath,
+      '用户自选的**外部**扫描目录 / 带 scheme 的远端根，不在数据根内。改写它会让整个'
+          '外部库失联（迁移器 :727-728 已显式声明跳过）。'),
+  PathRebaseColumn('MediaSources', 'configJson', PathRebaseKind.notAPath,
+      '远端来源连接参数 JSON（host/port/user/tls），无本机路径。'),
+
+  // ── 合集 / 系列封面来源 ─────────────────────────────────────────────
+  PathRebaseColumn('Series', 'coverSource', PathRebaseKind.notAPath,
+      '成员引用 <mediaType>|<entryKey>，不是路径。'),
+  PathRebaseColumn('MediaCollections', 'coverSource', PathRebaseKind.notAPath,
+      '成员引用 <mediaType>|<entryKey>，不是路径。'),
+
+  // ── book_custom_css ───────────────────────────────────────────────
+  PathRebaseColumn('BookCustomCss', 'relativePath', PathRebaseKind.notAPath,
+      '相对 extractDir 的相对路径，不是绝对路径。'),
+
+  // ── video_scrape_meta（刮削快照）───────────────────────────────────
+  PathRebaseColumn('VideoScrapeMeta', 'source', PathRebaseKind.notAPath,
+      'ScrapeSource 枚举名（bangumi/tmdb/...），不是路径。'),
+  PathRebaseColumn('VideoScrapeMeta', 'tagsJson', PathRebaseKind.notAPath,
+      '标签 JSON 数组，无路径。'),
+  PathRebaseColumn('VideoScrapeMeta', 'infoboxJson', PathRebaseKind.notAPath,
+      'infobox JSON 数组，无路径。'),
+  PathRebaseColumn('VideoScrapeMeta', 'detailUrl', PathRebaseKind.notAPath,
+      '远端条目详情页 URL，不是本机路径。'),
+
+  // ── galgames ──────────────────────────────────────────────────────
+  PathRebaseColumn('Galgames', 'exePath', PathRebaseKind.externalUserPath,
+      '用户外部游戏安装位置（hook 注入目标），不在数据根内。'),
+  PathRebaseColumn('Galgames', 'workdir', PathRebaseKind.externalUserPath,
+      '游戏工作目录（默认取 exe 所在目录），外部路径。'),
+  PathRebaseColumn(
+      'Galgames',
+      'launchArgs',
+      PathRebaseKind.externalUserPath,
+      '用户原样输入的命令行整行，可能内嵌外部绝对路径（如 --save="D:\\My Saves"）。'
+          '**绝不能** rebase：它不是单一路径，切分/改写都会毁掉用户的启动参数。'),
+  PathRebaseColumn(
+      'Galgames',
+      'coverPath',
+      PathRebaseKind.documentsRooted,
+      'BUG-1174 漏项：<documents>/game_covers/<id>.<ext>（AppPaths.gameCoversDirectory，'
+          '落盘唯一入口 galgame_cover_resolver.dart:300-320）。与 TODO-1255 的 '
+          'video_books.cover_path 完全同型 → 不改写 = 整个游戏库封面退化成默认手柄图标。'),
+  PathRebaseColumn('Galgames', 'primarySource', PathRebaseKind.notAPath,
+      '主展示源枚举（bgm/vndb/mixed/custom），不是路径。'),
+  PathRebaseColumn('Galgames', 'customDataJson', PathRebaseKind.notAPath,
+      '用户覆盖层 JSON；其中 coverSource 是**刮削源枚举 key**（bgm/vndb）而非本机文件路径。'),
+  PathRebaseColumn('GalgameSources', 'source', PathRebaseKind.notAPath,
+      '元数据源 key（bgm/vndb），不是路径。'),
+  PathRebaseColumn('GalgameSources', 'dataJson', PathRebaseKind.notAPath,
+      '刮削快照 JSON（远端字段，含远端封面 URL），无本机路径。'),
+];
+
+/// Drift preferences（以及它在 profile_settings 里的每 Profile 快照副本）中承载路径的
+/// 键。守卫比对 preferences_repository.dart 里的路径形 key 字面量。
+const List<PathRebasePref> kPathRebasePrefs = <PathRebasePref>[
+  PathRebasePref(
+      'src:reader_ttu:font_catalog',
+      PathRebaseKind.documentsRooted,
+      PathValueShape.fontCatalogJson,
+      '自定义字体 catalog，path 落 <documents>/custom_fonts。无 PrefCodec tag。'),
+  PathRebasePref('src:reader_ttu:custom_fonts', PathRebaseKind.documentsRooted,
+      PathValueShape.fontListJson, '旧影子字体列表，path 落 <documents>/custom_fonts。'),
+  PathRebasePref('src:reader_ttu:app_ui_fonts', PathRebaseKind.documentsRooted,
+      PathValueShape.fontListJson, '同上（App UI 字体）。'),
+  PathRebasePref('src:reader_ttu:dict_fonts', PathRebaseKind.documentsRooted,
+      PathValueShape.fontListJson, '同上（词典字体）。'),
+  PathRebasePref(
+      'src:reader_ttu:video_sub_fonts',
+      PathRebaseKind.documentsRooted,
+      PathValueShape.fontListJson,
+      '同上（视频字幕字体）。'),
+  PathRebasePref(
+      'local_audio_dbs',
+      PathRebaseKind.supportRooted,
+      PathValueShape.localAudioDbsJson,
+      '内部副本 local_audio_<ts>.db 落 support 根；按**文件名**重挂（天然幂等），外部'
+          '引用（BUG-483）原样保留。'),
+  PathRebasePref(
+      'audio_source_configs',
+      PathRebaseKind.supportRooted,
+      PathValueShape.audioSourceConfigsJson,
+      'typed 音频来源配置，仅 localAudio 条目带 path；必须与 local_audio_dbs 同步重挂，'
+          '否则 AppModel 的 path 相等匹配会断（TODO-1171）。'),
+  PathRebasePref(
+      'local_audio_db_path',
+      PathRebaseKind.supportRooted,
+      PathValueShape.bare,
+      'BUG-1174 漏项：旧单库绝对路径。只要用户从未调过 setEntries，local_audio_dbs 为空'
+          '时它仍被当回退读（local_audio_manager.dart:140-146）。与 local_audio_dbs 同款'
+          '按文件名重挂。'),
+  PathRebasePref(
+      'galgame_library',
+      PathRebaseKind.documentsRooted,
+      PathValueShape.legacyGalgameLibraryJson,
+      'BUG-1174 漏项：v55 legacy 游戏库 JSON，其中 coverPath 指 <documents>/game_covers。'
+          'v55 迁移刻意只读不删（回滚兜底，database.dart:1523-1526），所以存量数据里它'
+          '还在。同条目的 exePath / workdir 是外部路径，作用域谓词天然跳过。'),
+  PathRebasePref(
+      'video_remote_subtitle',
+      PathRebaseKind.documentsRooted,
+      PathValueShape.subtitleSourceMapJson,
+      'BUG-1174 漏项（原调研清单未列出，实查补入）：远端/流媒体视频手选字幕来源 map，'
+          'value 是 subtitleSource 四态编码，本地已下载态是 <documents>/video_subtitles '
+          '下的绝对路径（jimaku_batch_dialog.dart:268 等）。与 video_books.subtitle_source '
+          '同型，只是落在 KV 而非列上。'),
+  PathRebasePref(
+      'download_save_root',
+      PathRebaseKind.documentsRooted,
+      PathValueShape.bare,
+      'BUG-1174 漏项：下载保存根。空串 = 用默认 <documents>/anime_downloads/content；'
+          '用户第一次改设置时那个 documents 派生的默认值会被显式写进来。anime_downloads '
+          '在搬移白名单里（会被物理搬走），不改写就指向不存在的旧位置。用户挑的外部盘不在'
+          '旧根下 → 作用域谓词天然跳过。'),
+  PathRebasePref(
+      'download_save_root_history',
+      PathRebaseKind.documentsRooted,
+      PathValueShape.jsonStringList,
+      'BUG-1174 漏项：下载根历史（JSON 字符串数组），含被压栈的旧默认根；不改写 → 迁移后'
+          '这些历史根下的老任务在下载页整批失认。'),
+  PathRebasePref('video_mpv_shader_dir', PathRebaseKind.externalUserPath,
+      PathValueShape.none, '用户本机 mpv 着色器目录，外部路径，不随数据根走。'),
+  PathRebasePref('manga_external_mokuro_path', PathRebaseKind.externalUserPath,
+      PathValueShape.none, '系统安装的 mokuro 可执行文件路径，外部路径。'),
+  PathRebasePref(
+      'manga_reading_direction',
+      PathRebaseKind.notAPath,
+      PathValueShape.none,
+      '阅读方向枚举（dir 是 direction 不是 directory）。守卫的 key 正则刻意宽松、宁可'
+          '多要求几条声明，也不放过一个真路径 key。'),
+  PathRebasePref('active_profile_id', PathRebaseKind.notAPath,
+      PathValueShape.none, '当前 Profile 的自增 id（撞正则是因为 profile 里含 file）。不是路径。'),
+  PathRebasePref('local_audio_db_display_name', PathRebaseKind.notAPath,
+      PathValueShape.none, '旧单库显示名（与 local_audio_db_path 同族），不是路径。'),
+];
+
+/// 按 key 查处置；未登记返回 null。
+PathRebasePref? pathRebasePrefFor(String key) {
+  for (final PathRebasePref pref in kPathRebasePrefs) {
+    if (pref.key == key) return pref;
+  }
+  return null;
+}

--- a/hibiki/lib/src/storage/path_rebase_coverage.dart
+++ b/hibiki/lib/src/storage/path_rebase_coverage.dart
@@ -13,6 +13,8 @@ library;
 
 import 'package:flutter/foundation.dart';
 
+import 'package:hibiki/src/media/media_source.dart' show dbSourcePrefKey;
+
 /// 一个持久化字段在数据根迁移里的处置。
 enum PathRebaseKind {
   /// 落在 **documents（内容/书库）根**下的绝对路径 —— 迁移必须 rebase 到新 documents 根。
@@ -332,20 +334,28 @@ const List<PathRebaseColumn> kPathRebaseColumns = <PathRebaseColumn>[
 
 /// Drift preferences（以及它在 profile_settings 里的每 Profile 快照副本）中承载路径的
 /// 键。守卫比对 preferences_repository.dart 里的路径形 key 字面量。
-const List<PathRebasePref> kPathRebasePrefs = <PathRebasePref>[
+/// **不是 const**：字体 key 必须经单一真相编码器 [dbSourcePrefKey] 生成，绝不硬编码
+/// media_source 的私有 key 前缀格式（守卫 `test/media/db_source_pref_key_test.dart`）。
+final List<PathRebasePref> kPathRebasePrefs = <PathRebasePref>[
   PathRebasePref(
-      'src:reader_ttu:font_catalog',
+      dbSourcePrefKey('reader_ttu', 'font_catalog'),
       PathRebaseKind.documentsRooted,
       PathValueShape.fontCatalogJson,
       '自定义字体 catalog，path 落 <documents>/custom_fonts。无 PrefCodec tag。'),
-  PathRebasePref('src:reader_ttu:custom_fonts', PathRebaseKind.documentsRooted,
-      PathValueShape.fontListJson, '旧影子字体列表，path 落 <documents>/custom_fonts。'),
-  PathRebasePref('src:reader_ttu:app_ui_fonts', PathRebaseKind.documentsRooted,
-      PathValueShape.fontListJson, '同上（App UI 字体）。'),
-  PathRebasePref('src:reader_ttu:dict_fonts', PathRebaseKind.documentsRooted,
-      PathValueShape.fontListJson, '同上（词典字体）。'),
   PathRebasePref(
-      'src:reader_ttu:video_sub_fonts',
+      dbSourcePrefKey('reader_ttu', 'custom_fonts'),
+      PathRebaseKind.documentsRooted,
+      PathValueShape.fontListJson,
+      '旧影子字体列表，path 落 <documents>/custom_fonts。'),
+  PathRebasePref(
+      dbSourcePrefKey('reader_ttu', 'app_ui_fonts'),
+      PathRebaseKind.documentsRooted,
+      PathValueShape.fontListJson,
+      '同上（App UI 字体）。'),
+  PathRebasePref(dbSourcePrefKey('reader_ttu', 'dict_fonts'),
+      PathRebaseKind.documentsRooted, PathValueShape.fontListJson, '同上（词典字体）。'),
+  PathRebasePref(
+      dbSourcePrefKey('reader_ttu', 'video_sub_fonts'),
       PathRebaseKind.documentsRooted,
       PathValueShape.fontListJson,
       '同上（视频字幕字体）。'),

--- a/hibiki/lib/src/sync/backup_service.dart
+++ b/hibiki/lib/src/sync/backup_service.dart
@@ -123,7 +123,11 @@ String rebasePath(String oldPath, String oldRoot, String newRoot) {
 /// importing device's root differs, so the stored absolute paths would not
 /// resolve and the fonts (shown as imported & enabled) would silently never
 /// apply (BUG-183). Import rebases them so the reader/AppFontLoader find them.
-String rebaseFontListJson(String json, String oldRoot, String newRoot) {
+String rebaseFontListJson(String json, String oldRoot, String newRoot,
+    {String Function(String path)? rewritePath}) {
+  String rewrite(String path) => rewritePath == null
+      ? rebasePath(path, oldRoot, newRoot)
+      : rewritePath(path);
   try {
     final dynamic decoded = jsonDecode(json);
     if (decoded is! List) return json;
@@ -133,7 +137,7 @@ String rebaseFontListJson(String json, String oldRoot, String newRoot) {
       if (path is! String) return e; // system font (null) or odd shape
       return <String, dynamic>{
         ...Map<String, dynamic>.from(e),
-        'path': rebasePath(path, oldRoot, newRoot),
+        'path': rewrite(path),
       };
     }).toList();
     return jsonEncode(out);
@@ -147,7 +151,11 @@ String rebaseFontListJson(String json, String oldRoot, String newRoot) {
 /// Target rows (`font_targets`) refer to catalog entries by id and do not carry
 /// paths, so preserving ids while rebasing catalog paths keeps targets valid.
 /// Malformed values are returned verbatim so a corrupt pref never aborts import.
-String rebaseFontCatalogJson(String json, String oldRoot, String newRoot) {
+String rebaseFontCatalogJson(String json, String oldRoot, String newRoot,
+    {String Function(String path)? rewritePath}) {
+  String rewrite(String path) => rewritePath == null
+      ? rebasePath(path, oldRoot, newRoot)
+      : rewritePath(path);
   try {
     final dynamic decoded = jsonDecode(json);
     if (decoded is! Map) return json;
@@ -161,7 +169,7 @@ String rebaseFontCatalogJson(String json, String oldRoot, String newRoot) {
       if (path is! String) return row;
       return <String, dynamic>{
         ...row,
-        'path': rebasePath(path, oldRoot, newRoot),
+        'path': rewrite(path),
       };
     }).toList();
     return jsonEncode(root);

--- a/hibiki/test/media/db_source_pref_key_test.dart
+++ b/hibiki/test/media/db_source_pref_key_test.dart
@@ -58,7 +58,9 @@ void main() {
       final String pr =
           File('lib/src/profile/profile_repository.dart').readAsStringSync();
       final String dm =
-          File('lib/src/storage/data_root_migrator.dart').readAsStringSync();
+          // BUG-1174：字体 key 组连同其余承载路径的 pref 一起搬进了声明式覆盖表；
+          // data_root_migrator 现在只消费 kPathRebasePrefs，不再自持 key 常量。
+          File('lib/src/storage/path_rebase_coverage.dart').readAsStringSync();
       expect(rs, contains("dbSourcePrefKey('reader_ttu', '')"),
           reason: 'ReaderSettings._prefix 应转调编码器');
       expect(rs.contains("'src:reader_ttu:'"), isFalse,

--- a/hibiki/test/storage/data_root_migrator_path_gaps_test.dart
+++ b/hibiki/test/storage/data_root_migrator_path_gaps_test.dart
@@ -1,0 +1,498 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show QueryRow, Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/profile/profile_repository.dart';
+import 'package:hibiki/src/storage/app_paths.dart';
+import 'package:hibiki/src/storage/data_root_migrator.dart';
+import 'package:hibiki/src/storage/path_rebase_coverage.dart';
+
+/// BUG-1174：数据根迁移的**路径改写**四处存量缺陷的行为守卫。
+///
+///  ① 漏改的列 / pref：galgames.cover_path、video_books.subtitle_source ×2、
+///     media_items.image_url、profile_settings.value、galgame_library /
+///     video_remote_subtitle / download_save_root(+history) / local_audio_db_path。
+///  ② profile_settings 快照会把刚 rebase 好的路径整体退回旧值（切一次 Profile 就中招）。
+///  ③ 新根落在旧根内部时，`startsWith(oldRoot)` 判据会把路径改写两遍 → 静默毁库。
+///  ④ 改写必须在单事务里，中途失败整体回滚。
+class _FakeAnkiRepository extends BaseAnkiRepository {
+  AnkiSettings _settings = const AnkiSettings();
+
+  @override
+  Future<AnkiSettings> loadSettings() async => _settings;
+
+  @override
+  Future<void> saveSettings(AnkiSettings settings) async =>
+      _settings = settings;
+
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() => throw UnimplementedError();
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) async => false;
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) =>
+      throw UnimplementedError();
+
+  @override
+  Future<bool> createDeck(String name) => throw UnimplementedError();
+}
+
+void main() {
+  late Directory tmp;
+  late Directory oldDocs;
+  late Directory oldSupport;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('hibiki_pathgap_');
+    oldDocs = Directory(p.join(tmp.path, 'Documents'))
+      ..createSync(recursive: true);
+    oldSupport = Directory(p.join(tmp.path, 'support'))
+      ..createSync(recursive: true);
+  });
+
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  String docs(List<String> segments) =>
+      p.joinAll(<String>[oldDocs.path, ...segments]);
+
+  /// 铺一份「每个漏项各有一条数据」的旧库。返回外部路径常量供断言复用。
+  Future<void> seed(String dbDir) async {
+    for (final String rel in <String>[
+      p.join('game_covers', 'g1.jpg'),
+      p.join('video_covers', 'v1.jpg'),
+      p.join('video_subtitles', 'ep01.ass'),
+      p.join('hoshi_books', 'Bk', 'cover.jpg'),
+      p.join('anime_downloads', 'content', '.keep'),
+      p.join('custom_fonts', 'a.ttf'),
+    ]) {
+      File(docs(<String>[rel]))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('x');
+    }
+    final HibikiDatabase db = HibikiDatabase(dbDir);
+    try {
+      await db.upsertGalgame(GalgamesCompanion.insert(
+        id: 'g1',
+        name: 'Game One',
+        exePath: p.join('E:', 'Games', 'g1', 'g1.exe'),
+        workdir: p.join('E:', 'Games', 'g1'),
+        addedAt: 1,
+        coverPath: Value(docs(<String>['game_covers', 'g1.jpg'])),
+      ));
+      await db.upsertVideoBook(VideoBooksCompanion.insert(
+        bookUid: 'video/V1',
+        title: 'V1',
+        videoPath: p.join('E:', 'anime', 'V1.mkv'),
+        coverPath: Value(docs(<String>['video_covers', 'v1.jpg'])),
+        subtitleSource: Value(docs(<String>['video_subtitles', 'ep01.ass'])),
+        secondarySubtitleSource: const Value('embedded:2'),
+      ));
+      await db.upsertVideoBook(VideoBooksCompanion.insert(
+        bookUid: 'video/V2',
+        title: 'V2',
+        videoPath: p.join('E:', 'anime', 'V2.mkv'),
+        subtitleSource: const Value('off:'),
+      ));
+      await db.upsertMediaItem(MediaItemsCompanion.insert(
+        mediaIdentifier: 'Bk',
+        title: 'Bk',
+        mediaTypeIdentifier: 'reader_media_type',
+        mediaSourceIdentifier: 'reader_hibiki',
+        uniqueKey: 'reader/Bk',
+        imageUrl: Value(
+            Uri.file(docs(<String>['hoshi_books', 'Bk', 'cover.jpg']))
+                .toString()),
+        position: 0,
+        duration: 0,
+        canDelete: true,
+        canEdit: true,
+      ));
+      await db.upsertMediaItem(MediaItemsCompanion.insert(
+        mediaIdentifier: 'Remote',
+        title: 'Remote',
+        mediaTypeIdentifier: 'reader_media_type',
+        mediaSourceIdentifier: 'remote',
+        uniqueKey: 'reader/Remote',
+        imageUrl: const Value('https://example.com/cover.jpg'),
+        position: 0,
+        duration: 0,
+        canDelete: true,
+        canEdit: true,
+      ));
+      await db.setPref(
+        'galgame_library',
+        jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'id': 'g1',
+            'exePath': p.join('E:', 'Games', 'g1', 'g1.exe'),
+            'coverPath': docs(<String>['game_covers', 'g1.jpg']),
+          }
+        ]),
+      );
+      await db.setPref(
+        'video_remote_subtitle',
+        jsonEncode(<String, String>{
+          'remote/1#ep0': docs(<String>['video_subtitles', 'ep01.ass']),
+          'remote/2#ep0': 'embedded:1',
+          'remote/3#ep0': 'off:',
+        }),
+      );
+      await db.setPref(
+          'download_save_root', docs(<String>['anime_downloads', 'content']));
+      await db.setPref(
+        'download_save_root_history',
+        jsonEncode(<String>[
+          docs(<String>['anime_downloads', 'content']),
+          p.join('F:', 'downloads'),
+        ]),
+      );
+      await db.setPref(
+          'local_audio_db_path', p.join(dbDir, 'local_audio_1.db'));
+      await db.setPref('video_mpv_shader_dir', p.join('G:', 'mpv', 'shaders'));
+      await db.setPref(
+        'src:reader_ttu:font_catalog',
+        jsonEncode(<String, dynamic>{
+          'version': 1,
+          'fonts': <Map<String, dynamic>>[
+            <String, dynamic>{
+              'id': 'f1',
+              'name': 'A',
+              'path': docs(<String>['custom_fonts', 'a.ttf']),
+            }
+          ],
+        }),
+      );
+    } finally {
+      await db.close();
+    }
+  }
+
+  /// 读回一份「路径快照」：所有被改写的字段的当前值，用来做等值断言与幂等断言。
+  Future<Map<String, String?>> snapshot(String dbDir) async {
+    final HibikiDatabase db = HibikiDatabase(dbDir);
+    try {
+      final Map<String, String?> out = <String, String?>{};
+      final GalgameRow g = (await db.getAllGalgames()).single;
+      out['galgames.coverPath'] = g.coverPath;
+      out['galgames.exePath'] = g.exePath;
+      for (final VideoBookRow v in await db.allVideoBooks()) {
+        out['video.${v.bookUid}.cover'] = v.coverPath;
+        out['video.${v.bookUid}.sub'] = v.subtitleSource;
+        out['video.${v.bookUid}.sub2'] = v.secondarySubtitleSource;
+        out['video.${v.bookUid}.path'] = v.videoPath;
+      }
+      for (final MediaItemRow m in await db.getAllMediaItems()) {
+        out['media.${m.uniqueKey}.image'] = m.imageUrl;
+      }
+      final Map<String, String> prefs = await db.getAllPrefs();
+      for (final String key in <String>[
+        'galgame_library',
+        'video_remote_subtitle',
+        'download_save_root',
+        'download_save_root_history',
+        'local_audio_db_path',
+        'video_mpv_shader_dir',
+        'src:reader_ttu:font_catalog',
+      ]) {
+        out['pref.$key'] = prefs[key];
+      }
+      final List<QueryRow> rows = await db
+          .customSelect(
+              "SELECT key, value FROM profile_settings WHERE category = 'pref'")
+          .get();
+      for (final QueryRow r in rows) {
+        out['profile.${r.read<String>('key')}'] = r.read<String>('value');
+      }
+      return out;
+    } finally {
+      await db.close();
+    }
+  }
+
+  /// 断言快照里的每个数据根内路径都指向 [newDocs]，且外部路径纹丝不动。
+  void expectRebasedOnto(Map<String, String?> snap, String newDocs) {
+    String at(List<String> segments) =>
+        p.joinAll(<String>[newDocs, ...segments]);
+
+    expect(snap['galgames.coverPath'],
+        equals(at(<String>['game_covers', 'g1.jpg'])));
+    expect(
+        snap['galgames.exePath'], equals(p.join('E:', 'Games', 'g1', 'g1.exe')),
+        reason: '外部游戏安装位置绝不能被改写');
+    expect(snap['video.video/V1.cover'],
+        equals(at(<String>['video_covers', 'v1.jpg'])));
+    expect(snap['video.video/V1.sub'],
+        equals(at(<String>['video_subtitles', 'ep01.ass'])));
+    expect(snap['video.video/V1.sub2'], equals('embedded:2'),
+        reason: 'embedded: 哨兵必须原样保留');
+    expect(snap['video.video/V2.sub'], equals('off:'), reason: 'off: 哨兵必须原样保留');
+    expect(snap['video.video/V1.path'], equals(p.join('E:', 'anime', 'V1.mkv')),
+        reason: '用户原位外部视频不该被改写');
+    expect(
+        snap['media.reader/Bk.image'],
+        equals(Uri.file(at(<String>['hoshi_books', 'Bk', 'cover.jpg']))
+            .toString()));
+    expect(snap['media.reader/Remote.image'],
+        equals('https://example.com/cover.jpg'),
+        reason: '远端 http 封面不是 file: URI，必须原样返回');
+
+    final List<dynamic> games =
+        jsonDecode(snap['pref.galgame_library']!) as List<dynamic>;
+    expect((games.single as Map<String, dynamic>)['coverPath'],
+        equals(at(<String>['game_covers', 'g1.jpg'])));
+    expect((games.single as Map<String, dynamic>)['exePath'],
+        equals(p.join('E:', 'Games', 'g1', 'g1.exe')));
+
+    final Map<String, dynamic> remote =
+        jsonDecode(snap['pref.video_remote_subtitle']!) as Map<String, dynamic>;
+    expect(remote['remote/1#ep0'],
+        equals(at(<String>['video_subtitles', 'ep01.ass'])));
+    expect(remote['remote/2#ep0'], equals('embedded:1'));
+    expect(remote['remote/3#ep0'], equals('off:'));
+
+    expect(snap['pref.download_save_root'],
+        equals(at(<String>['anime_downloads', 'content'])));
+    final List<dynamic> history =
+        jsonDecode(snap['pref.download_save_root_history']!) as List<dynamic>;
+    expect(history.first, equals(at(<String>['anime_downloads', 'content'])));
+    expect(history.last, equals(p.join('F:', 'downloads')),
+        reason: '外部盘的历史根不该被改写');
+
+    expect(snap['pref.video_mpv_shader_dir'],
+        equals(p.join('G:', 'mpv', 'shaders')),
+        reason: '用户外部 mpv 目录绝不能被改写');
+
+    final Map<String, dynamic> catalog =
+        jsonDecode(snap['pref.src:reader_ttu:font_catalog']!)
+            as Map<String, dynamic>;
+    expect((catalog['fonts'] as List<dynamic>).single['path'],
+        equals(at(<String>['custom_fonts', 'a.ttf'])));
+  }
+
+  test('① 迁移改写了全部漏项，外部路径纹丝不动', () async {
+    await seed(oldSupport.path);
+    final String newDataRoot = p.join(tmp.path, 'newroot');
+    final List<String> prefWrites = <String>[];
+    final (Directory newDocs, Directory newSupport) =
+        await const DataRootMigrator().migrate(DataRootMigrationRequest(
+      oldDocumentsRoot: oldDocs,
+      oldSupportRoot: oldSupport,
+      newDataRoot: newDataRoot,
+      closeResources: () async {},
+      writeDataRootPref: (String root) async => prefWrites.add(root),
+      documentsTopLevelIncludeNames: AppPaths.hibikiOwnedDocumentsEntries,
+    ));
+    expect(prefWrites, equals(<String>[newDataRoot]));
+    expectRebasedOnto(await snapshot(newSupport.path), newDocs.path);
+  });
+
+  test('② 迁移后「切 Profile」不会把路径退回旧值', () async {
+    await seed(oldSupport.path);
+    // 先造一个 Profile 并快照当前（旧根）prefs —— 这正是用户迁移前的真实状态。
+    final HibikiDatabase pre = HibikiDatabase(oldSupport.path);
+    late int profileId;
+    try {
+      final ProfileRepository repo =
+          ProfileRepository(pre, _FakeAnkiRepository());
+      profileId = await repo.createProfile('P1');
+      await repo.snapshotCurrentSettings(profileId);
+      // 前提：快照里确实存着旧根绝对路径。用 video_remote_subtitle（会进快照）；
+      // download_save_root* 被 ProfileKeys.isExcludedPref 挡在快照外（设备本地键），
+      // 所以它们只需改 preferences，不会被切 Profile 写回——这一点一并钉死。
+      final List<QueryRow> rows = await pre
+          .customSelect(
+              "SELECT key, value FROM profile_settings WHERE category = 'pref' "
+              "AND key IN ('video_remote_subtitle', 'src:reader_ttu:font_catalog', "
+              "'download_save_root')")
+          .get();
+      final Map<String, String> snapshotted = <String, String>{
+        for (final QueryRow r in rows)
+          r.read<String>('key'): r.read<String>('value'),
+      };
+      expect(
+          snapshotted.keys.toSet(),
+          equals(
+              <String>{'video_remote_subtitle', 'src:reader_ttu:font_catalog'}),
+          reason: 'download_save_root 是设备本地键，按设计不进 Profile 快照');
+      expect(jsonDecode(snapshotted['video_remote_subtitle']!)['remote/1#ep0'],
+          equals(docs(<String>['video_subtitles', 'ep01.ass'])),
+          reason: '前提：快照里确实存着旧根绝对路径');
+    } finally {
+      await pre.close();
+    }
+
+    final String newDataRoot = p.join(tmp.path, 'newroot');
+    final (Directory newDocs, Directory newSupport) =
+        await const DataRootMigrator().migrate(DataRootMigrationRequest(
+      oldDocumentsRoot: oldDocs,
+      oldSupportRoot: oldSupport,
+      newDataRoot: newDataRoot,
+      closeResources: () async {},
+      writeDataRootPref: (String root) async {},
+      documentsTopLevelIncludeNames: AppPaths.hibikiOwnedDocumentsEntries,
+    ));
+
+    // 真正走一次 applyProfile（= 用户切 Profile），再看 live prefs 有没有被写回旧根。
+    final HibikiDatabase post = HibikiDatabase(newSupport.path);
+    try {
+      final ProfileRepository repo =
+          ProfileRepository(post, _FakeAnkiRepository());
+      await repo.applyProfile(profileId);
+      final Map<String, String> prefs = await post.getAllPrefs();
+      expect(
+        prefs['download_save_root'],
+        equals(p.join(newDocs.path, 'anime_downloads', 'content')),
+        reason: '设备本地键不进快照，切 Profile 后仍是迁移后的新值',
+      );
+      expect(
+        (jsonDecode(prefs['src:reader_ttu:font_catalog']!)
+            as Map<String, dynamic>)['fonts'][0]['path'],
+        equals(p.join(newDocs.path, 'custom_fonts', 'a.ttf')),
+      );
+      expect(
+        jsonDecode(prefs['video_remote_subtitle']!)['remote/1#ep0'],
+        equals(p.join(newDocs.path, 'video_subtitles', 'ep01.ass')),
+        reason: 'BUG-1174 ②：切 Profile 把 profile_settings 快照原样写回 preferences，'
+            '快照没被 rebase 的话刚迁好的路径会整体回滚到旧根——迁移当天一切正常，'
+            '几天后用户切一次 Profile 才突然坏，极难归因',
+      );
+      expect(
+        jsonDecode(prefs['galgame_library']!).single['coverPath'],
+        equals(p.join(newDocs.path, 'game_covers', 'g1.jpg')),
+      );
+    } finally {
+      await post.close();
+    }
+  });
+
+  test('③ 新根落在旧根内部时，同一改写连跑两次是 no-op（不会 Hibiki/data/Hibiki/data）', () async {
+    await seed(oldSupport.path);
+    // 正是 BUG-1115 的形态：newDocs 就在 oldDocs 里面。旧的 startsWith(oldRoot) 判据
+    // 会把已改写过的路径再改一遍，产出 .../Hibiki/data/Hibiki/data/...，静默毁全库。
+    final String newDocs = p.joinAll(
+        <String>[oldDocs.path, ...AppPaths.defaultDocumentsChildSegments]);
+    Future<void> runOnce() =>
+        const DataRootMigrator().rebaseDatabasePathsForTesting(
+          dbDirectory: oldSupport.path,
+          oldDocumentsRoot: oldDocs.path,
+          newDocumentsRoot: newDocs,
+          newSupportRoot: oldSupport.path,
+          documentsScopeEntries: AppPaths.hibikiOwnedDocumentsEntries,
+        );
+
+    await runOnce();
+    final Map<String, String?> first = await snapshot(oldSupport.path);
+    expectRebasedOnto(first, newDocs);
+
+    await runOnce();
+    final Map<String, String?> second = await snapshot(oldSupport.path);
+    expect(second, equals(first), reason: '第二遍必须是逐字节 no-op');
+    expectRebasedOnto(second, newDocs);
+
+    // 显式钉死「双重嵌套」这个具体症状。
+    final String doubled = p.joinAll(<String>[
+      newDocs,
+      ...AppPaths.defaultDocumentsChildSegments,
+    ]);
+    for (final MapEntry<String, String?> e in second.entries) {
+      expect(e.value ?? '', isNot(contains(doubled)), reason: e.key);
+    }
+  });
+
+  test('③b 作用域谓词：首段不在白名单里的路径不参与改写', () {
+    const DocumentsPathRebaser rebaser = DocumentsPathRebaser(
+      oldRoot: '/home/u/Documents',
+      newRoot: '/home/u/Documents/Hibiki/data',
+      scopeTopLevelNames: AppPaths.hibikiOwnedDocumentsEntries,
+    );
+    expect(rebaser.rebase('/home/u/Documents/audiobooks/a.mp3'),
+        equals('/home/u/Documents/Hibiki/data/audiobooks/a.mp3'));
+    // 已改写过的路径：首段是 Hibiki（不在白名单）→ 原样返回 = 幂等。
+    expect(rebaser.rebase('/home/u/Documents/Hibiki/data/audiobooks/a.mp3'),
+        equals('/home/u/Documents/Hibiki/data/audiobooks/a.mp3'));
+    // 用户自己的文件：不搬也不改。
+    expect(rebaser.rebase('/home/u/Documents/thesis.docx'),
+        equals('/home/u/Documents/thesis.docx'));
+    // 白名单项的前缀撞名不算命中（边界必须是分隔符）。
+    expect(rebaser.rebase('/home/u/Documents/videos_backup/x.mkv'),
+        equals('/home/u/Documents/videos_backup/x.mkv'));
+    // 大小写不敏感：hibikiExport 在 Windows 上会被搬走，路径必须一起改。
+    expect(rebaser.rebase('/home/u/Documents/HibikiExport/card.jpg'),
+        equals('/home/u/Documents/Hibiki/data/HibikiExport/card.jpg'));
+    // 根本体本身。
+    expect(rebaser.rebase('/home/u/Documents'),
+        equals('/home/u/Documents/Hibiki/data'));
+  });
+
+  test('③c 整树搬移（无白名单）仍改写全部子路径', () {
+    const DocumentsPathRebaser rebaser = DocumentsPathRebaser(
+      oldRoot: '/old/documents',
+      newRoot: '/new/documents',
+      scopeTopLevelNames: null,
+    );
+    expect(rebaser.rebase('/old/documents/anything/deep/x'),
+        equals('/new/documents/anything/deep/x'));
+    expect(rebaser.rebase('/elsewhere/x'), equals('/elsewhere/x'));
+  });
+
+  test('④ 改写中途失败：整段回滚，不留半改状态', () async {
+    await seed(oldSupport.path);
+    final Map<String, String?> before = await snapshot(oldSupport.path);
+    DataRootMigrator.debugFailMidRebase = true;
+    try {
+      await expectLater(
+        const DataRootMigrator().rebaseDatabasePathsForTesting(
+          dbDirectory: oldSupport.path,
+          oldDocumentsRoot: oldDocs.path,
+          newDocumentsRoot: p.join(tmp.path, 'newroot', 'documents'),
+          newSupportRoot: oldSupport.path,
+          documentsScopeEntries: AppPaths.hibikiOwnedDocumentsEntries,
+        ),
+        throwsA(isA<StateError>()),
+      );
+    } finally {
+      DataRootMigrator.debugFailMidRebase = false;
+    }
+    expect(await snapshot(oldSupport.path), equals(before),
+        reason: 'BUG-1174 ④：改写必须在单事务里，中途失败整体回滚。逐行 UPDATE 的旧写法'
+            '会留下「一半指新根、一半指旧根」的库，而外层回滚只搬文件、救不了半改的 DB');
+  });
+
+  test('rebaseMigratedPrefValue 不动未登记的 key（profile_settings 里躺着全部 pref）', () {
+    const DocumentsPathRebaser rebaser = DocumentsPathRebaser(
+      oldRoot: '/home/u/Documents',
+      newRoot: '/home/u/Documents/Hibiki/data',
+      scopeTopLevelNames: AppPaths.hibikiOwnedDocumentsEntries,
+    );
+    for (final String key in <String>[
+      'theme_mode',
+      'video_mpv_shader_dir',
+      'manga_external_mokuro_path',
+    ]) {
+      expect(
+        rebaseMigratedPrefValue(
+            key, '/home/u/Documents/audiobooks/looks_like_a_path',
+            documents: rebaser, newSupportRoot: '/support'),
+        equals('/home/u/Documents/audiobooks/looks_like_a_path'),
+        reason: key,
+      );
+    }
+    expect(pathRebasePrefFor('theme_mode'), isNull);
+  });
+}

--- a/hibiki/test/storage/path_rebase_coverage_guard_test.dart
+++ b/hibiki/test/storage/path_rebase_coverage_guard_test.dart
@@ -1,0 +1,235 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/media/media_source.dart' show dbSourcePrefKey;
+import 'package:hibiki/src/storage/path_rebase_coverage.dart';
+
+/// BUG-1174 守卫：**路径 rebase 覆盖率**。
+///
+/// 「加了新列/新 pref，忘了改数据根迁移器」这件事已经发生过三轮：TODO-1255
+/// （`video_books.cover_path`）、BUG-1174（`galgames.cover_path` +
+/// `video_books.subtitle_source`×2 + `media_items.image_url` + 整张 `profile_settings`
+/// + 5 个 pref key）。人的记忆靠不住，把它变成 CI。
+///
+/// 本测试扫源码、与 `path_rebase_coverage.dart` 的声明**双向**比对：
+///  1. tables.dart 里名字形似路径的 TextColumn 必须在 [kPathRebaseColumns] 里登记；
+///  2. 登记的列必须真实存在（删了列就要删声明，杜绝陈旧豁免）；
+///  3. 每条声明必须给出非空理由（豁免要说得出为什么）；
+///  4. 标了「必须 rebase」的列，其列名必须真的出现在 `data_root_migrator.dart` 里；
+///  5. pref 侧同规则：lib/ 里名字形似路径的 pref key 字面量必须登记；
+///  6. 字体 key 的硬编码字面值必须与单一真相编码器 [dbSourcePrefKey] 一致。
+///
+/// **正则刻意宽松**（`path|dir|root|url|source|file|json`）：宁可多要求几条
+/// `notAPath` 声明，也不放过一个真的存绝对路径的新列。
+void main() {
+  final String tablesPath = p.join(
+      '..', 'packages', 'hibiki_core', 'lib', 'src', 'database', 'tables.dart');
+  final String migratorPath =
+      p.join('lib', 'src', 'storage', 'data_root_migrator.dart');
+
+  final RegExp tableDecl = RegExp(r'^\s*class\s+(\w+)\s+extends\s+Table\b');
+  final RegExp textColumnDecl = RegExp(r'^\s*TextColumn\s+get\s+(\w+)');
+  final RegExp pathLikeName =
+      RegExp('path|dir|root|url|source|file|json', caseSensitive: false);
+  final RegExp pathLikePrefKey =
+      RegExp('path|dir|root|file', caseSensitive: false);
+  final RegExp prefCall = RegExp(r"(?:get|set)Pref\(\s*'([^']+)'");
+
+  /// tables.dart 里的 (表类名, 列 getter 名) 全集。
+  Set<String> allTextColumns() {
+    final File file = File(tablesPath);
+    expect(file.existsSync(), isTrue,
+        reason: '本测试假定 cwd 为 hibiki/（flutter test 默认）：$tablesPath');
+    final Set<String> out = <String>{};
+    String? table;
+    for (final String line in file.readAsLinesSync()) {
+      final RegExpMatch? t = tableDecl.firstMatch(line);
+      if (t != null) table = t.group(1);
+      final RegExpMatch? c = textColumnDecl.firstMatch(line);
+      if (c != null && table != null) out.add('$table.${c.group(1)}');
+    }
+    expect(out, isNotEmpty);
+    return out;
+  }
+
+  test('tables.dart 里每个路径形 TextColumn 都在 kPathRebaseColumns 里登记', () {
+    final Set<String> declared = kPathRebaseColumns
+        .map((PathRebaseColumn c) => '${c.table}.${c.column}')
+        .toSet();
+    final List<String> missing = allTextColumns()
+        .where((String id) => pathLikeName.hasMatch(id.split('.').last))
+        .where((String id) => !declared.contains(id))
+        .toList()
+      ..sort();
+    expect(
+      missing,
+      isEmpty,
+      reason: '这些列名形似路径却没在 kPathRebaseColumns 登记。请判定它是否存数据根内'
+          '绝对路径：是 → 在 DataRootMigrator 里补改写并声明 documentsRooted/'
+          'supportRooted；否 → 声明 notAPath/externalUserPath 并写清理由。'
+          '漏改的代价是用户换数据位置后这一列指向的内容全部失效：$missing',
+    );
+  });
+
+  test('kPathRebaseColumns 里没有陈旧声明（列必须真实存在）', () {
+    final Set<String> actual = allTextColumns();
+    final List<String> stale = kPathRebaseColumns
+        .map((PathRebaseColumn c) => '${c.table}.${c.column}')
+        .where((String id) => !actual.contains(id))
+        .toList()
+      ..sort();
+    expect(stale, isEmpty,
+        reason: '这些声明指向 tables.dart 里已不存在的列，删列时请一并删声明：$stale');
+  });
+
+  test('每条列声明都给出了非空理由', () {
+    for (final PathRebaseColumn c in kPathRebaseColumns) {
+      expect(c.reason.trim(), isNotEmpty, reason: '$c 缺理由');
+    }
+    final Set<String> ids = kPathRebaseColumns
+        .map((PathRebaseColumn c) => '${c.table}.${c.column}')
+        .toSet();
+    expect(ids.length, equals(kPathRebaseColumns.length), reason: '有重复声明');
+  });
+
+  test('标为必须 rebase 的列，列名真的出现在 data_root_migrator.dart 里', () {
+    final String src = File(migratorPath).readAsStringSync();
+    final List<String> notWired = <String>[];
+    for (final PathRebaseColumn c in kPathRebaseColumns) {
+      if (!c.mustRebase) continue;
+      // 迁移器有的走裸 SQL（snake_case 列名），有的走 drift 生成的具名参数（Dart 名），
+      // 两种写法都算已接线。
+      if (src.contains(c.sqlColumn) || src.contains(c.column)) continue;
+      notWired.add(c.toString());
+    }
+    expect(notWired, isEmpty,
+        reason: '这些列声明为必须 rebase，但迁移器源码里根本没提到它们：$notWired');
+  });
+
+  test('每张含必须 rebase 列的表，迁移器都有 _rebase<Table> 入口且在事务里被调用', () {
+    final String src = File(migratorPath).readAsStringSync();
+    // 命名约定：一张表一个 `_rebase<Dart 表类名>` 静态方法，全部在 db.transaction 里
+    // 依次调用。上一条按列名比对的守卫抓不到「整张表的改写被整段删掉」（列名会与别的
+    // 表撞名而侥幸通过）——这一条抓得到。
+    final Set<String> tables = kPathRebaseColumns
+        .where((PathRebaseColumn c) => c.mustRebase)
+        .map((PathRebaseColumn c) => c.table)
+        .toSet();
+    final List<String> missing = <String>[];
+    for (final String table in tables) {
+      // Preferences 表的 KV 入口按语义命名为 _rebasePreferences。
+      final String entry = '_rebase$table';
+      final int declared = 'static Future<void> $entry('.allMatches(src).length;
+      final int called = 'await $entry(db, docs'.allMatches(src).length;
+      if (declared != 1 || called != 1) {
+        missing.add('$entry(declared=$declared, called=$called)');
+      }
+    }
+    expect(missing, isEmpty,
+        reason: '这些表声明了必须 rebase 的列，但迁移器缺少对应的 _rebase<Table> 入口，'
+            '或该入口没有在 DB 改写事务里被调用：$missing');
+  });
+
+  test('lib/ 里每个路径形 pref key 字面量都在 kPathRebasePrefs 里登记', () {
+    final Set<String> declared =
+        kPathRebasePrefs.map((PathRebasePref s) => s.key).toSet();
+    final Map<String, String> missing = <String, String>{};
+    for (final FileSystemEntity e
+        in Directory('lib').listSync(recursive: true, followLinks: false)) {
+      if (e is! File || !e.path.endsWith('.dart')) continue;
+      final String src = e.readAsStringSync();
+      for (final RegExpMatch m in prefCall.allMatches(src)) {
+        final String key = m.group(1)!;
+        // 插值键（`${type.uniqueKey}/last_picked_file`）不是字面量，另行声明在
+        // kPathRebasePrefs 的注释里；这里只管字面量。
+        if (key.contains(r'$')) continue;
+        if (!pathLikePrefKey.hasMatch(key)) continue;
+        if (declared.contains(key)) continue;
+        missing[key] = e.path;
+      }
+    }
+    expect(
+      missing,
+      isEmpty,
+      reason: '这些 pref key 名字形似路径却没在 kPathRebasePrefs 登记。若它承载数据根内'
+          '绝对路径，DataRootMigrator 不改写它 = 用户换数据位置后该配置失效（且会经 '
+          'profile_settings 快照被写回来）。请补声明并给理由：$missing',
+    );
+  });
+
+  test('kPathRebasePrefs 里的 key 都还在 lib/ 里被真实使用（无陈旧声明）', () {
+    final StringBuffer all = StringBuffer();
+    for (final FileSystemEntity e
+        in Directory('lib').listSync(recursive: true, followLinks: false)) {
+      if (e is! File || !e.path.endsWith('.dart')) continue;
+      all.write(e.readAsStringSync());
+    }
+    final String src = all.toString();
+    final List<String> stale = <String>[];
+    for (final PathRebasePref spec in kPathRebasePrefs) {
+      // 字体 key 由 dbSourcePrefKey 生成，源码里只出现 body 段（'font_catalog' 等）。
+      final String needle =
+          spec.key.startsWith('src:') ? spec.key.split(':').last : spec.key;
+      if (!src.contains(needle)) stale.add(spec.key);
+    }
+    expect(stale, isEmpty, reason: '这些 pref 声明在 lib/ 里已无任何引用，请删声明：$stale');
+  });
+
+  test('每条 pref 声明都给出了非空理由，且 key 不重复', () {
+    for (final PathRebasePref spec in kPathRebasePrefs) {
+      expect(spec.reason.trim(), isNotEmpty, reason: '$spec 缺理由');
+    }
+    final Set<String> keys =
+        kPathRebasePrefs.map((PathRebasePref s) => s.key).toSet();
+    expect(keys.length, equals(kPathRebasePrefs.length), reason: '有重复声明');
+  });
+
+  test('字体 pref key 的硬编码字面值与 dbSourcePrefKey 编码器一致', () {
+    // 声明里必须写展开后的字面值（守卫按字面值比对源码），所以字面值与编码器的一致性
+    // 要在这里钉死——与 backup_service.dart 的同款做法一致。
+    for (final String body in <String>[
+      'font_catalog',
+      'custom_fonts',
+      'app_ui_fonts',
+      'dict_fonts',
+      'video_sub_fonts',
+    ]) {
+      final String expected = dbSourcePrefKey('reader_ttu', body);
+      expect(
+        pathRebasePrefFor(expected),
+        isNotNull,
+        reason: 'dbSourcePrefKey(reader_ttu, $body) = $expected 未在 '
+            'kPathRebasePrefs 里登记（编码格式改了？）',
+      );
+    }
+  });
+
+  test('迁移器里所有 documents 路径改写都必须过同一个作用域谓词（无旁路）', () {
+    final String src = File(migratorPath).readAsStringSync();
+
+    // ① 裸 rebasePath（startsWith 判据）在迁移器里只准出现一次：就是
+    //    DocumentsPathRebaser.rebase 里那次，且必须被 isInScope 守住。多一次就是旁路。
+    final List<String> bare = RegExp(r'^.*\brebasePath\(.*$', multiLine: true)
+        .allMatches(src)
+        .map((RegExpMatch m) => m.group(0)!.trim())
+        .toList();
+    expect(bare.length, equals(1),
+        reason: '迁移器里出现了 ${bare.length} 处裸 rebasePath 调用：$bare');
+    expect(bare.single, contains('isInScope(path)'),
+        reason: '唯一那处 rebasePath 必须由 DocumentsPathRebaser.isInScope 守住');
+
+    // ② 复用 backup_service 的字体 JSON 遍历器时**必须**注入 rewritePath —— 它们默认
+    //    走裸 rebasePath。这正是 BUG-1174 被幂等测试抓到的那条旁路：新根落在旧根内部
+    //    时字体路径被改写两遍，产出 .../Hibiki/data/Hibiki/data/custom_fonts/...。
+    final int fontCalls =
+        RegExp(r'rebaseFontCatalogJson\(').allMatches(src).length +
+            RegExp(r'rebaseFontListJson\(').allMatches(src).length;
+    final int injected =
+        RegExp(r'rewritePath: documents.rebase').allMatches(src).length;
+    expect(injected, equals(fontCalls),
+        reason: '$fontCalls 处字体 JSON 改写调用里只有 $injected 处注入了作用域改写器；'
+            '漏注入的那些会绕过作用域谓词、在新根嵌套于旧根时把路径改写两遍（静默毁库）');
+  });
+}

--- a/hibiki/test/storage/path_rebase_coverage_guard_test.dart
+++ b/hibiki/test/storage/path_rebase_coverage_guard_test.dart
@@ -186,9 +186,10 @@ void main() {
     expect(keys.length, equals(kPathRebasePrefs.length), reason: '有重复声明');
   });
 
-  test('字体 pref key 的硬编码字面值与 dbSourcePrefKey 编码器一致', () {
-    // 声明里必须写展开后的字面值（守卫按字面值比对源码），所以字面值与编码器的一致性
-    // 要在这里钉死——与 backup_service.dart 的同款做法一致。
+  test('字体 pref key 由 dbSourcePrefKey 编码器生成且已登记', () {
+    // BUG-1174：声明表用编码器生成 key（不硬编码 media_source 私有前缀格式，见
+    // db_source_pref_key_test）。这里断言编码器产出的 5 个字体 key 确实都在表里——
+    // 编码格式若变化，两侧会同步变化而不会静默漏登记。
     for (final String body in <String>[
       'font_catalog',
       'custom_fonts',


### PR DESCRIPTION
修 develop 上**当前就存在**的四组数据根迁移缺陷 —— 用户现在走「设置 → 数据存储位置 → 选目录」就会踩到。与「要不要做一键整理按钮」那个待定项无关。

## ① 漏改的持久化路径（6 处）

实查 53 张表 / 194 个 `TextColumn` + 全部 pref key 后确认的真实缺口：

| 漏项 | 症状 |
|---|---|
| `galgames.cover_path` | 整个游戏库封面退化成默认手柄图标（与 TODO-1255 修过的 `video_books.cover_path` 完全同型） |
| `video_books.subtitle_source` / `secondary_subtitle_source` | 所有外挂字幕失效，查词与双字幕一并失效 |
| `media_items.image_url`（`file://` URI） | 书架 / 首页「最近」卡片封面全空白 |
| pref `galgame_library`（v55 legacy JSON 的 `coverPath`） | 老数据的游戏封面失联 |
| pref `video_remote_subtitle` | 远端视频手选字幕失效 |
| pref `download_save_root` + `download_save_root_history` / `local_audio_db_path` | 下载根指向不存在的旧位置 / 老任务整批失认 / 旧单库发音失效 |

**与调研清单的出入（1 处）**：`video_remote_subtitle` 是本次实查补入的，原清单没列。它与 `video_books.subtitle_source` 同型，只是落在 KV 而非列上。

四列外部路径（`media_sources.root_path`、`galgames.exe_path` / `workdir` / `launch_args`）确认**不该改写**，已逐条写清理由。

## ② `profile_settings` 快照回滚（最阴的一条）

`ProfileRepository.snapshotCurrentSettings` 把**每一条**非排除 pref 原样复制进 `profile_settings`，`applyProfile` 再原样 `setPref` 写回。迁移只改 `preferences` → 用户切一次 Profile 就把刚 rebase 好的路径整体退回旧值。**迁移当天一切正常，几天后突然坏。**

**修法选择**：迁移时用与 `preferences` 完全相同的纯函数 `rebaseMigratedPrefValue` 改写**所有 Profile** 的快照行。
不选「让路径 pref 不进快照」，因为那会改掉 Profile 的既有语义（字体目录 / 发音库配置现在确实是每 Profile 的），等于为修迁移去动一个与迁移无关的功能契约，爆炸半径大得多，还会破坏已按 Profile 分别配字体的用户。

## ③ 幂等：把判据改对，而不是保证只跑一次

旧判据 `startsWith(oldRoot)`。新根落在旧根**内部**时（正是 `<Documents>` → `<Documents>/Hibiki/data`，BUG-1115 之后 `isSafeNestedTargetInSharedDocuments` 明确放行这种目标），跑第二遍产出 `Documents/Hibiki/data/Hibiki/data/…` —— **不抛异常、静默毁全库**。同型坑在 iOS 容器重定位上已踩过一次。

新增 `DocumentsPathRebaser`：判据收窄为「**相对旧根的首段 ∈ 本次搬移真正会动的顶层项集合**」（与 `documentsTopLevelIncludeNames` 同源）。已改写过的路径首段是 `Hibiki`（不在白名单里）→ 天然跳过。「跑没跑过」这个问题因此**消失**，而不是被条件判断掩盖。

> ⚠️ **新写的幂等测试真实抓到一条旁路**：字体目录 pref 走 `rebaseFontCatalogJson` / `rebaseFontListJson`，那两个函数内部直接调裸 `rebasePath`，绕过了新加的作用域谓词，字体路径仍被改写两遍。
> **从根上修**：给这两个函数加可选 `rewritePath` 注入点 —— 迁移侧传作用域改写器，**备份恢复侧不传、行为逐字节不变**。
> 修完扫了一遍：迁移器里 `rebasePath(` 现在只剩一处，就在 `DocumentsPathRebaser.rebase` 里被 `isInScope` 守着；并把这条不变量做成了源码守卫（见下）。

## ④ 事务化

整段 DB 路径改写包进 `db.transaction()`，中途失败整体回滚 —— 外层回滚只把**文件**搬回旧位置，救不了半改的 DB。`wal_checkpoint(TRUNCATE)` 留在事务外（SQLite 不允许在活动事务里 checkpoint）。

## 防复发：覆盖率守卫

新增 `hibiki/lib/src/storage/path_rebase_coverage.dart` —— 把「哪些列 / pref 承载绝对路径、迁移要不要改写、**为什么**」从注释变成**声明式单一真相源**（55 列 + 17 个 pref key，逐条带理由；豁免必须写理由）。

`hibiki/test/storage/path_rebase_coverage_guard_test.dart` 扫源码双向比对：
- tables.dart 里路径形 `TextColumn` 必须登记（漏登记红 / 陈旧声明也红）
- 每条声明必须有非空理由
- must-rebase 列必须真的接进迁移器
- **每张含 must-rebase 列的表必须有 `_rebase<Table>` 入口且在事务里被调用**（上一条按列名比对抓不到「整张表被删掉」，这条抓得到）
- pref key 侧同规则 + 字体 key 字面值与 `dbSourcePrefKey` 编码器一致
- **「所有 documents 路径改写必须过同一个作用域谓词（无旁路）」**

## 验证

- `flutter analyze`（含 test）→ **No issues found**
- `test/storage` + `test/profile` 154 例、`test/sync` 1705 例全绿；全量套件另附
- **负向验证**（改回旧逻辑 → 对应用例转红 → 还原）：①③④ 与四条守卫全部确认可转红

## 明确未触碰

- `anime_downloads` 的搬移 / fast-resume `save_path` / 活跃写句柄逻辑（三重风险，另议）
- 一键整理按钮（等用户拍板）
- BUG-1115 文档里给老用户的指引
- 备份恢复侧的同源漏项（`srt_books` 四列等，R8，另立项）
- schema 未改动，持久化 key 未改名

BUG 文档：`docs/bugs/BUG-1174-docroot-migrator-path-gaps.md`

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
