### PR TITLE
ci(native): PR 阶段 native 门禁 + 修 voice-hook-helper 假绿

### DIFF
--- a/.github/workflows/native-galgame-gate.yml
+++ b/.github/workflows/native-galgame-gate.yml
@@ -1,0 +1,52 @@
+# galgame_hook 单一真相源守卫的 **PR 阶段** 门。
+#
+# 补的缺口：这组守卫（engine-support 生成物 / luna profile 生成物 / vendored
+# LunaHook DLL 完整性 / manifest schema / adapter 结构 / evidence 契约 /
+# workflow 契约）此前**只**挂在 voice-hook-helper.yml 上，而那个 workflow 的
+# 触发是 `workflow_dispatch` + `push: develop`。也就是说：改 engine-support.yaml、
+# adapter 骨架或 luna profile 的 PR，在合进 develop 之前从未被这些守卫检查过，
+# 红了要等 push 之后才知道 —— 那时已经进主干。
+#
+# 注意：C++ 编译与双架构 ctest **不在**本 workflow 的职责内，它们已经由
+# build-multiplatform.yml 的 windows job 在 PR 上跑（`pull_request` + paths 含
+# `native/**` -> `build_distribution.ps1 -RunTests`）。这里只补那条真正缺失的、
+# 且成本近乎为零的静态守卫链，不重复跑已有覆盖。
+#
+# 平台范围：galgame 相关一律只做 Windows 端（仓库硬规则）。本 workflow 跑在
+# ubuntu-latest 只是因为这七条守卫全是平台无关的静态校验（Python stdlib +
+# pwsh 的 Get-FileHash/ConvertFrom-Json），**不构建、不运行、不发布任何
+# 非 Windows 的 galgame 产物**，也不构成对其它平台的支持声明。
+name: native-galgame-gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['main', 'develop']
+    paths:
+      - 'native/galgame_hook/**'
+      - '.github/workflows/native-galgame-gate.yml'
+
+# 全程只读：不构建产物、不碰任何 release/tag/发布通道。
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  guards:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      # 单一入口，内部 Invoke-Checked 逐条断言退出码。不加 continue-on-error：
+      # 任何一条守卫失败都必须把这个 job 打红。
+      - name: Run galgame_hook source-of-truth guards
+        shell: pwsh
+        run: ./native/galgame_hook/tools/run_guards.ps1

--- a/.github/workflows/native-hoshidicts-gate.yml
+++ b/.github/workflows/native-hoshidicts-gate.yml
@@ -1,0 +1,70 @@
+# hoshidicts 原生测试套件的 **MSVC/Windows** 门。
+#
+# 补的缺口：`native/hoshidicts/tests` 的 17 个 ctest 目前只在 Linux/gcc-14 上跑
+# （build-multiplatform.yml 的 linux job，PR 上已生效）。Windows 侧 CI 只有
+# `flutter build windows --debug` 间接**编译** hoshidicts_ffi —— 编译错误挡得住，
+# 但 MSVC 下的运行时行为（zip64 / mdx 加密 keyinfo / 词典名 UAF / 解压空指针守卫
+# 等）从未被执行过一次。词典查询/导入是 C++ FFI 核心，MSVC 与 libstdc++ 在
+# std::expected、字符串生命周期、宽字符路径上的差异正是这些测试要抓的东西。
+#
+# 独立于 build-multiplatform.yml 的另一个理由：那边的 windows job 要先跑
+# vcpkg libtorrent（冷编 ~40min）+ flutter build windows + galgame 双架构打包，
+# 一个 native 编译错误要排到很后面才暴露；本 job 只做 cmake+ctest，几分钟给出
+# 独立反馈，且不与那边跑同一组测试（那边根本不跑 hoshidicts ctest）。
+#
+# 本机预验证（Windows 11 / MSVC 19.44 / VS 17.14.36127.28）：
+# 同样的三条命令 configure+build+ctest -> 17/17 Passed。
+name: native-hoshidicts-gate
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['main', 'develop']
+    paths:
+      - 'native/hoshidicts/**'
+      - '.github/workflows/native-hoshidicts-gate.yml'
+
+# 全程只读：不产出制品、不碰任何 release/tag/发布通道。
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  ctest-msvc:
+    runs-on: windows-2022
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      # 必须构建到 RUNNER_TEMP 这种**短路径**：vendored zstd/glaze 的嵌套 object
+      # 目录叠加深 checkout 路径会撞破 CMAKE_OBJECT_PATH_MAX(250)，MSVC 报
+      # "Cannot open compiler generated file"。native/hoshidicts/tests/run_all.bat
+      # 出于同样原因用 %TEMP%，build-multiplatform.yml 的 linux job 同理用
+      # $RUNNER_TEMP。别把 -B 改回仓库内目录。
+      #
+      # 用 Visual Studio 生成器而不是 Ninja：不需要先 source vcvars 就能定位 MSVC。
+      # 三步分开写，任一步失败即 job 红（不加 continue-on-error）。
+      - name: Configure hoshidicts tests (MSVC)
+        shell: pwsh
+        run: |
+          cmake -S native/hoshidicts/tests -B "$env:RUNNER_TEMP\hoshi-tests" `
+            -G "Visual Studio 17 2022" -A x64
+          if ($LASTEXITCODE -ne 0) { throw "cmake configure failed ($LASTEXITCODE)" }
+
+      - name: Build hoshidicts tests (MSVC)
+        shell: pwsh
+        run: |
+          cmake --build "$env:RUNNER_TEMP\hoshi-tests" --config Release
+          if ($LASTEXITCODE -ne 0) { throw "cmake build failed ($LASTEXITCODE)" }
+
+      # --no-tests=error：ctest 默认在「一个测试都没注册」时返回 0，那正是本仓
+      # 反复踩的「零测试执行伪装成通过」（BUG-1157 的 ctest 版）。显式判红。
+      - name: Run hoshidicts ctest (MSVC)
+        shell: pwsh
+        run: |
+          ctest --test-dir "$env:RUNNER_TEMP\hoshi-tests" -C Release `
+            --output-on-failure --no-tests=error
+          if ($LASTEXITCODE -ne 0) { throw "ctest failed ($LASTEXITCODE)" }

--- a/.github/workflows/voice-hook-helper.yml
+++ b/.github/workflows/voice-hook-helper.yml
@@ -54,15 +54,18 @@ jobs:
           python-version: '3.13'
 
       # P0 单一真相源守卫：schema/真实样本证据必须有效，生成文档不得漂移。
+      #
+      # 这七条守卫以前是内联在一个多行 `run:` 里的，那是**假绿**：`shell: pwsh`
+      # 只把最后一条命令的退出码交给 Actions，前六条失败被整个吞掉。实锤——
+      # `include/luna_hook_profiles.inc` 从子树导入（bc094b89b）起就与
+      # `config/luna_hook_profiles.tsv` 漂移，`generate_luna_profiles.py --check`
+      # 一直返回 1，而 run 30217258807 的本步骤照样显示 success。
+      #
+      # 现在统一走 tools/run_guards.ps1（内部 Invoke-Checked 逐条断言退出码），
+      # 同一个脚本也是 native-galgame-gate.yml 的 PR 门 —— 一处修好两处生效，
+      # 且不会再出现「这里加了守卫、那边忘了同步」。
       - name: Verify engine support manifest
-        run: |
-          python tools/generate_engine_support.py --check
-          python tools/generate_luna_profiles.py --check
-          ./tools/sync_lunahook.ps1
-          python tests/engine_support_manifest_test.py
-          python tests/adapter_structure_test.py
-          python tests/evidence_contract_test.py
-          python tests/galhook_workflow_test.py
+        run: ./tools/run_guards.ps1
 
       # release 与 Windows 主包必须共用同一打包脚本和文件清单，避免离线资产与在线 release 漂移。
       - name: Build, test and package helper (x64 + x86)

--- a/native/galgame_hook/config/luna_hook_profiles.tsv
+++ b/native/galgame_hook/config/luna_hook_profiles.tsv
@@ -1,3 +1,4 @@
-# Hibiki Luna hook-code profiles v1. UTF-8, tab separated.
-exe_sha256	module_name	module_sha256	codepage	hook_code	label
+# Hibiki Luna hook-code profiles v2. UTF-8, tab separated.
+exe_sha256	module_name	module_sha256	codepage	hook_code	label	options
 36448822f1a8bc3840b304d3993c07de912db6c803dddd8db1202ed676ba7019			932	EXHVXN0@2198:nine_kokoiro.exe	9-nine Episode 1 verified executable
+9c195563b8724131cfc5cfd7b32767597efba136d98bb81dfda2fdb242695c2a			932		Fate Realta Nua safe KiriKiri text profile	block=EXHQXN8@1647F4;block-name=Krkr2wcs;block=EXHWXN0@1D2865;block-name=EmbedKrkr2;prefer=HQXN-C@1D2F80;defer-ms=8000

--- a/native/galgame_hook/tools/run_guards.ps1
+++ b/native/galgame_hook/tools/run_guards.ps1
@@ -1,0 +1,64 @@
+# Single entry point for the galgame_hook source-of-truth guards.
+#
+# Why this file exists instead of an inline multi-line `run:` block:
+# GitHub Actions `shell: pwsh` steps only honour the exit code of the LAST
+# command in the block. Every earlier native command that fails is silently
+# swallowed and the step still reports success. voice-hook-helper.yml's
+# "Verify engine support manifest" step listed seven commands that way, so six
+# of the seven guards were decorative -- proven in practice: the generated
+# include/luna_hook_profiles.inc drifted away from config/luna_hook_profiles.tsv
+# at the subtree import (commit bc094b89b) and `generate_luna_profiles.py
+# --check` has returned 1 ever since, while run 30217258807 still reported that
+# step as green.
+#
+# Invoke-Checked below makes swallowing structurally impossible: every guard's
+# exit code is asserted, so a red guard is always a red job.
+#
+# Deliberately ASCII-only and pwsh/PowerShell-5.1 safe: it is executed by
+# ubuntu-latest pwsh (PR gate), windows-2022 pwsh (helper release) and by hand.
+# All guards are pure verification -- no writes, no network, no publishing.
+
+$ErrorActionPreference = 'Stop'
+
+$hookRoot = Split-Path -Parent $PSScriptRoot
+
+function Invoke-Checked {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments
+  )
+  Write-Host "==> $FilePath $($Arguments -join ' ')"
+  & $FilePath @Arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "$FilePath $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+  }
+}
+
+# `python` is the launcher name on the GitHub runners for both OSes once
+# actions/setup-python has run; fall back to python3 for bare local shells.
+$python = 'python'
+if (-not (Get-Command $python -ErrorAction SilentlyContinue)) {
+  $python = 'python3'
+}
+
+Push-Location $hookRoot
+try {
+  # Generated artefacts must match their single source of truth.
+  Invoke-Checked $python 'tools/generate_engine_support.py' '--check'
+  Invoke-Checked $python 'tools/generate_luna_profiles.py' '--check'
+
+  # Vendored LunaHook/LunaHost DLLs must match VERSION.json byte for byte.
+  # Read-only: -Update is NOT passed, so nothing is copied or rewritten.
+  & (Join-Path $PSScriptRoot 'sync_lunahook.ps1')
+
+  # Manifest schema, adapter layout, evidence contract and workflow guards.
+  Invoke-Checked $python 'tests/engine_support_manifest_test.py'
+  Invoke-Checked $python 'tests/adapter_structure_test.py'
+  Invoke-Checked $python 'tests/evidence_contract_test.py'
+  Invoke-Checked $python 'tests/galhook_workflow_test.py'
+}
+finally {
+  Pop-Location
+}
+
+Write-Host 'All galgame_hook source-of-truth guards passed.'


### PR DESCRIPTION
## 现状核实（与立项前提不符，以实测为准）

立项说「C++ ctest 只挂在 voice-hook-helper 上，PR 阶段根本不跑」——**这一半是错的**。
`build-multiplatform.yml` 有 `pull_request: branches [main, develop]` 且 `paths` 含 `native/**`，PR 上真的会跑：

| PR 阶段已有覆盖 | 位置 |
|---|---|
| hoshidicts ctest 17 个（Linux/gcc-14） | `build-multiplatform.yml` linux job |
| galgame_hook 双架构 cmake+ctest 22 个 | windows job → `build_distribution.ps1 -RunTests` |
| hibiki_torrent vcpkg 编 DLL + Dart FFI 测试 | windows job |
| `flutter_inappwebview_windows` / `gamepads_windows` C++ 编译 | windows job → `flutter build windows --debug` |

这些 job 都没有 `continue-on-error`（只有 android job 有，且不含 native）。
`main.yml` 的 PR 触发同样含 `native/**`。

**真正的缺口是另外两个**，本 PR 补它们。

## 缺口 1：galgame_hook 守卫组 PR 阶段不跑 + 且它本来就是假绿

那 7 条单一真相源守卫（engine-support 生成物 / luna profile 生成物 / vendored LunaHook DLL SHA-256 / manifest schema / adapter 结构 / evidence 契约 / workflow 契约）此前**只**挂在 `voice-hook-helper.yml`（`workflow_dispatch` + `push: develop`），PR 上一次不跑。

更糟的是它在 develop 上也不算数：7 条命令写在一个多行 `run:` 里，而 `shell: pwsh` 只把**最后一条**命令的退出码交给 Actions，前 6 条失败被整个吞掉。

**实锤**：`generate_luna_profiles.py --check` 在 develop 上**现在就返回 1**（`include/luna_hook_profiles.inc` 是 v2、`config/luna_hook_profiles.tsv` 还是 v1，从子树导入 `bc094b89b` 起就漂移），而 run `30217258807` 的 "Verify engine support manifest" 步骤照样是 ✅ success。

修法：抽出 `native/galgame_hook/tools/run_guards.ps1`（`Invoke-Checked` 逐条断言退出码），`voice-hook-helper.yml` 与新的 `native-galgame-gate.yml` 共用同一入口——吞退出码结构上不再可能，且不会出现「这边加了守卫那边忘了同步」。

顺带修掉那条被守卫抓出的真实漂移：真相源是 `.tsv`（脚本与 `third_party/lunahook/README.md` 都这么定义），上游 `c6873469f` 改了生成物没改源。所以把 `.tsv` 升到 v2，**regenerate 后 `.inc` 逐字节不变**（零二进制/行为变化）。反向按 `.tsv` regenerate 会丢掉 Fate Realta Nua 的 KiriKiri 崩溃规避 profile，并让 `hibiki_luna_hook_config_test` 直接失败。

## 缺口 2：hoshidicts 从未在 MSVC 下跑过 ctest

17 个 native 测试只在 Linux/gcc-14 跑。Windows 侧 CI 只有 `flutter build windows` 间接**编译** hoshidicts_ffi——编译错误挡得住，但 MSVC 下的运行时行为（zip64 / mdx 加密 keyinfo / 词典名 UAF / 解压空指针守卫）一次没执行过。词典查询/导入是 C++ FFI 核心。

新增 `native-hoshidicts-gate.yml`（windows-2022，MSVC configure+build+ctest），并独立于 `build-multiplatform.yml` 的 windows job——那边要先排队跑 vcpkg libtorrent（冷编 ~40min）+ flutter build windows + galgame 双架构，native 错误暴露太晚。

## 触发方式（按路径过滤，纯 Dart PR 零影响）

| workflow | runner | paths | 时长 |
|---|---|---|---|
| `native-galgame-gate.yml` | ubuntu-latest | `native/galgame_hook/**` | 秒级 |
| `native-hoshidicts-gate.yml` | windows-2022 | `native/hoshidicts/**` | 分钟级 |

两者都是 `pull_request: [main, develop]` + `workflow_dispatch`，`permissions: contents: read`，无 `continue-on-error`。

## 仍然没有门禁的部分（不假装覆盖）

1. **`native/hibiki_torrent/` 的 Linux `.so`** —— `CMakeLists.txt` 硬依赖 vcpkg 的 `find_package(LibtorrentRasterbar CONFIG REQUIRED)`，Linux 构建路径根本没实现（README:117 标为独立待办）。Windows 路径已由 `build-multiplatform.yml` 覆盖，Linux 侧无门。
2. **`native/hibiki_torrent/` 无任何 ctest/gtest** —— C ABI 只被 Dart 侧 `packages/hibiki_torrent/test` 覆盖，且那些测试没有 `HIBIKI_TORRENT_LIB` 就整组 skip。本 PR 未新增 native 单测。
3. **`packages/flutter_inappwebview_windows` 的 gtest target `flutter_inappwebview_windows_plugin_test`** —— 被 `if(include_${PROJECT_NAME}_tests)` 围住，只有构建 example app 时才开，且要 NuGet + FetchContent googletest（两次网络）。当前**从不执行**，本 PR 未启用（成本与收益不匹配，且非独立可构建）。
4. **`packages/gamepads_windows`** —— 无任何测试，只能随 `flutter build windows` 编译，维持现状。
5. **galgame_hook x64 的 `hibiki_unity_audio_runtime` ALL target** —— 需要 `dotnet` + 从 GitHub 下 vgmstream/UABEA。仍只在 `build_distribution.ps1` 路径里跑（`build-multiplatform.yml` windows job + 本 workflow 的 release path），新增的 ubuntu 门不碰它。

## 平台范围

galgame 相关严格只做 Windows 端。`native-galgame-gate.yml` 跑在 ubuntu-latest **仅因为这 7 条守卫全是平台无关的静态校验**（Python stdlib + pwsh 的 `Get-FileHash`/`ConvertFrom-Json`）——不构建、不运行、不发布任何非 Windows 的 galgame 产物，不构成对其它平台的支持声明。

## 发布通道

未触碰。两个新 workflow 无 release/tag/`make_latest` 接触面，`permissions: contents: read`。`voice-hook-helper.yml` 的触发条件与 publish 步骤（含 `if: github.ref == 'refs/heads/develop'` 分支守卫）一字未改，只替换了 verify 步骤的命令。
`tool/check_release_policy.ps1` → **Release policy guard passed.**

## 验证

- `actionlint 1.7.7` 对三个改动文件 **零告警**（仓库唯一存量报错是 `build-multiplatform.yml` 的 YAML anchor 误报，非本 PR 引入）。
- `run_guards.ps1` 正负向各实跑一次：修复后 exit 0（7 条全绿）；把 `.tsv` stash 回漂移状态后 **exit 1** 并打印失败命令——门真能判红。
- hoshidicts MSVC 本机预跑（Windows 11 / VS 17.14.36127.28 / MSVC 19.44）：configure + build + `ctest --no-tests=error` → **17/17 Passed**。
- 无 Dart/Flutter 改动，故未跑 `flutter analyze`（改动只含 2 个新 workflow、1 个 pwsh 脚本、1 个 workflow 的步骤替换、1 个 TSV 数据文件；`hibiki/lib/src/mining/galgame_hook_code_profile.dart` 操作的是运行期用户 profile TSV，与本文件无关）。

⚠️ **门禁本身在被真实 PR 触发前，其有效性未验证。** 本 PR 自身**两个门都触发到了**（实测 run 30299957620 `guards` + run 30299957705 `ctest-msvc` 均已排队）：`native-galgame-gate` 经 `native/galgame_hook/**` 命中，`native-hoshidicts-gate` 经它自身的 `.github/workflows/native-hoshidicts-gate.yml` 路径命中（我最初在此处写「不会触发」，是错的，已更正）。

所以「能被触发 + 能跑绿」这一半在本 PR 上有真实证据；**仍未验证**的是：
1. 只改 `native/hoshidicts/**`（不碰 workflow 自身）时 `ctest-msvc` 是否照样命中；
2. 故意打坏一个 ctest 断言 / 制造一次生成物漂移时，两个门是否真的在 CI 上变红。第 2 条的本地等价物已跑过（`run_guards.ps1` 在漂移状态下 exit 1），但 CI 上未复验。

## 遗留（未在本 PR 处理）

`hibiki/lib/src/mining/galgame_hook_code_profile.dart:9-10,95` 仍按 v1 的 6 列 header 导出用户 profile。因为 C++ 解析器（`luna_hook_config.h:142`）对 `options` 列是可选处理，这不会崩，但 Dart 侧无法表达 options——是同一次 v2 升级的遗留尾巴，建议另开一条。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb


