### PR TITLE
fix(test): wait on real completion signals instead of timing assumptions (BUG-1177/1178/1179)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1140 条。点号进各自文件。
+> 共 1143 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1179](bugs/BUG-1179-updater-diagnostics-before-validation.md) | ✅ | ✅ | Windows 更新器在校验安装包前就全机枚举进程，坏包也要等十几秒 |
+| [BUG-1178](bugs/BUG-1178-manifest-race-test-cascade.md) | ✅ | ✅ | update-manifest 竞态测试超时会级联带红兄弟用例 |
+| [BUG-1177](bugs/BUG-1177-ankimobile-end-task-timing.md) | ✅ | ✅ | AnkiMobile 制卡测试用 10ms 定时假设等真实 I/O，36% 概率红 |
 | [BUG-1176](bugs/BUG-1176-cover-scrape-silent-catch.md) | ✅ | ✅ | 封面刮削/匹配失败被静默吞掉，用户只看到「无结果」 |
 | [BUG-1175](bugs/BUG-1175-gal-embedkrkrz-ruby-repeat-text.md) | ✅ | ✅ | EmbedKrkrZ ruby 双写产生重复台词，折叠只认精确二倍全部漏过 |
 | [BUG-1174](bugs/BUG-1174-docroot-migrator-path-gaps.md) | ✅ | ✅ | 数据根迁移漏改 6 处路径 + 非幂等 + 无事务 |

--- a/docs/bugs/BUG-1177-ankimobile-end-task-timing.md
+++ b/docs/bugs/BUG-1177-ankimobile-end-task-timing.md
@@ -1,0 +1,9 @@
+## BUG-1177 · AnkiMobile 制卡测试用 10ms 定时假设等真实 I/O，36% 概率红
+- **报告**：2026-07-28（用户：）
+- **真实性**：✅ 真 bug（测试自身缺陷，非产品缺陷）。根因 `hibiki/test/anki/ankimobile_repository_test.dart:269`（原）：用 `await Future<void>.delayed(const Duration(milliseconds: 10))` 当同步原语，睡 10ms 就断言 `end-background-task` 已入列。该事件的真实路径是 `hibiki/lib/src/anki/ankimobile_repository.dart:267` `Timer.run(closeLater)` → `:242 await server?.close()` → `:509-523` `_server.close(force: true)` **加 `_tempDir.delete(recursive: true)`（真删一个含 4 个媒体文件的 Windows 临时目录）** → `:244` 才 `await _endMediaImportBackgroundTask()`。这段是真实 socket + 文件系统 I/O，冷路径或机器有负载时轻易 >10ms，断言拿到的 `events` 就只有前两项。同文件 `:355` 是同型第二处：`Future.delayed(550ms)` 猜 `mediaServerLifetime(500ms)` 定时器加 close + 删目录能在 50ms 内跑完。
+- **复现**：空载机器 20/20 全绿（复现不出）；**10 个 `flutter test` 并发施压后 2/10 红**，报错正是 `Actual: ['begin-background-task', 'open-ankimobile']`（缺 `end-background-task`）。即这是负载相关的竞态，用户观测到的 36% 属实，只是需要负载才暴露。
+- **[x] ① 已修复** — 不改大 10ms（那是补丁式绕过），改为等**真实完成信号**：测试注入的 `endMediaImportBackgroundTask` 回调里 complete 一个 `Completer<void>`，断言前 `await backgroundTaskEnded.future`。两处（`:269` / `:355`）同一改法。该回调就是被断言的那个事件本身，等它 = 等真实完成，零时间常数。
+- **[x] ② 已加自动化测试** — `hibiki/test/anki/ankimobile_repository_test.dart`（`mineEntry exposes local media as downloadable URLs for AnkiMobile` / `media URLs survive source temp cleanup until AnkiMobile fetches`）。这两条测试自身就是最强可落地层：改后若完成信号回归，它们**确定性**变红，而不是像以前那样按机器负载概率性变红。
+- **验证**：修复后目标用例 `--plain-name` 单跑 20/20 绿；10 并发施压下断言失败 0 次（对照组同条件 2/10 红）。负向验证：把 `await backgroundTaskEnded.future` 换回 `Future.delayed(10ms)`，同一并发条件复现原症状。
+- **备注**：与 BUG-1178 / BUG-1179 同批 —— 都属「在真实 I/O 上做定时假设」这一类模式。
+</content>

--- a/docs/bugs/BUG-1178-manifest-race-test-cascade.md
+++ b/docs/bugs/BUG-1178-manifest-race-test-cascade.md
@@ -1,0 +1,13 @@
+## BUG-1178 · update-manifest 竞态测试超时会级联带红兄弟用例
+- **报告**：2026-07-28（用户：）
+- **真实性**：✅ 真 bug（测试夹具缺陷）。两处根因：
+  1. **级联** `hibiki/test/tools/update_manifest_publish_race_test.dart`（原 `_Fixture.publish` 用 `Process.run` / 原 `_Fixture.dispose` 无保护地 `root.delete(recursive: true)`）：`publish` 以 `workingDirectory: root.path` 起 bash。用例一旦超时，`test` 包只是放弃 `await`，**OS 进程还活着**；Windows 上任何进程的 CWD 目录不可删，于是 `addTearDown(fx.dispose)` 直接抛 `PathAccessException: Deletion failed ... 另一个程序正在使用此文件`，把一次超时变成额外的 tearDown 报错，同时遗留的 bash/git 子进程继续抢 CPU 拖慢后续用例。
+  2. **逼近超时线** `tool/publish_update_manifest.sh:196`（原）`sleep $((attempt * 3))`：竞态用例里输的一方固定真睡 3 秒。对真 GitHub remote 这是正确的礼貌退避，但本测试推的是本地裸库，没有任何需要退避的对象。
+- **纠正用户前提**：「单独跑要 42 秒」不成立。实测整个文件**测试执行只 14 秒**（`concurrent` 用例 5 秒最慢），42~48 秒里的大头是 `flutter test` 的编译，每个测试文件都一样，与本文件无关。真正贴近 30 秒线的场景是全量并发跑时本文件抢不到 CPU（实测争用下整文件涨到 34 秒）。
+- **[x] ① 已修复** — 两处都改：
+  - 夹具改用 `Process.start` 并把 `Process` 句柄存进 `_Fixture._running`，只有真正 `await exitCode` 拿到退出码后才摘句柄；`dispose()` 先 `kill(SIGKILL)` 所有幸存进程再删目录，且删除失败只吞 `FileSystemException`（systemTemp 由 OS 回收），保证一个用例的失败绝不外溢成兄弟用例/组级失败。
+  - 脚本退避抽成 `MANIFEST_RETRY_BACKOFF_MS`（**生产默认仍是 3000**）+ `backoff_sleep()` 纯 bash 整数运算；测试传 `50`。竞态**语义**（重新 fetch live tip、重新 merge、绝不 clobber）分毫未动，只去掉与语义无关的等待时长。
+- **[x] ② 已加自动化测试** — `hibiki/test/tools/update_manifest_publish_race_test.dart::production retry backoff stays polite to the real GitHub remote`：扫脚本源码断言默认退避仍为 `3000`，防止有人拿这个 seam 去「加速 CI」变成对 github.com 的高频重试。级联本身由夹具结构消除（`_running` + 容错 dispose），并已用临时 probe 用例做过正负对照验证。
+- **验证**：修复后整文件跑 22 次全绿，`concurrent` 用例 5s → 2s，整文件 14s → 10s。负向验证：把 `publish`/`dispose` 还原成 `Process.run` + 硬删，插入「起了 publish 不 await 就走」的 probe 用例，立刻复现 `PathAccessException: Deletion failed ... 另一个程序正在使用此文件` 且指向 `_Fixture.dispose`；换回修复版同一 probe 通过。
+- **备注**：与 BUG-1177 / BUG-1179 同批。
+</content>

--- a/docs/bugs/BUG-1179-updater-diagnostics-before-validation.md
+++ b/docs/bugs/BUG-1179-updater-diagnostics-before-validation.md
@@ -1,0 +1,9 @@
+## BUG-1179 · Windows 更新器在校验安装包前就全机枚举进程，坏包也要等十几秒
+- **报告**：2026-07-28（用户：）
+- **真实性**：✅ 真 bug（**产品缺陷**，不只是测试问题）。根因 `hibiki/lib/src/utils/misc/platform_updater.dart:516-534`（原）：`WindowsInstaller.runAndExit()` 在函数最开头无条件收集诊断——`collectDiagnostics == null` 且 `Platform.isWindows` 时走 `collectWindowsInstallerDiagnostics()`，它真起 4~5 个外部进程：`Process.run('reg')` ×2（`:852`）、`powershell Get-CimInstance Win32_Process`（`:947`）、`tasklist /M libmpv-2.dll`（`:962`，要枚举全机进程的模块表）、再一次 powershell CIM 补 PID（`:999`）。而安装包的存在性检查（`:563`）与 MZ 头校验（`:567`）排在**这之后**。结果：代理返回 HTML 的损坏下载，用户要先干等十几秒全机进程枚举，才被告知「更新失败」；顺带 `hibiki/test/utils/misc/platform_updater_test.dart:426-456` 两个 `runAndExit` 用例（不注入 seam，直接调真实实现）在忙机器上会顶到 `test` 包默认 30s 超时而红。Linux CI 走 `:524-534` 的合成分支不碰进程，所以只在本机 Windows 表现为 flaky。
+- **与「定时假设」模式的关系**：**不同族**，如实记录。这里没有 `sleep` / `Future.delayed` / 轮询去猜 I/O 完成——`Process.run` 的 `exitCode` 本来就是被正确 await 的真实完成信号。真实机制是「产品代码在必然失败的路径上先做不可控的重活，而把固定 30s 测试预算当成了它的上界」。
+- **[x] ① 已修复** — 把存在性 + MZ 头校验整块上提到诊断收集**之前**（`platform_updater.dart` 中 `hasInjectedDiagnostics` 之后紧接的新 try 块）。坏包/缺包立刻抛 `UpdateInstallerException`，一个外部进程都不起；顺带 handoff marker 也不再为一个根本起不来的安装器写 pending 记录。失败仍走 `_markLaunchFailed`（该函数对 `handoffMarkerFile == null` 与写入异常都已容错），行为兼容。
+- **[x] ② 已加自动化测试** — `hibiki/test/utils/misc/platform_updater_test.dart::never collects diagnostics for a download that fails validation`：注入计数版 `collectDiagnostics`，对「损坏下载」与「文件不存在」两条路径都断言 `diagnosticsCalls == 0`。这是最强可落地层——直接钉住「校验先于枚举」这个顺序契约。
+- **验证**：修复后 `platform_updater_test.dart` 整文件跑 22 次全绿。负向验证：`git apply -R` 撤掉这次产品侧改动后，新守卫用例立刻红在 `Expected: <0> Actual: <1>`（诊断确实在校验前被调用），恢复后转绿。
+- **备注**：与 BUG-1177 / BUG-1178 同批。诊断顺序修正同时消除了生产路径上「坏包也要等 tasklist」的真实卡顿，不只是让测试变快。
+</content>

--- a/hibiki/lib/src/utils/misc/platform_updater.dart
+++ b/hibiki/lib/src/utils/misc/platform_updater.dart
@@ -513,6 +513,33 @@ class WindowsInstaller {
         currentExecutablePath ?? Platform.resolvedExecutable;
     final Directory currentInstallDir = File(resolvedExecutablePath).parent;
     final bool hasInjectedDiagnostics = collectDiagnostics != null;
+
+    // Validate the downloaded file BEFORE collecting diagnostics. Diagnostics
+    // shell out to `reg`, `powershell Get-CimInstance` and `tasklist /M` (a
+    // whole-machine module enumeration that costs seconds); spending that on a
+    // download we are about to delete is pure waste, and it made the user wait
+    // ~10s just to be told "update failed". Failing fast here also means the
+    // handoff marker is never written for an installer that can never launch.
+    final File installer = File(installerPath);
+    try {
+      if (!installer.existsSync()) {
+        throw UpdateInstallerException('installer not found: $installerPath');
+      }
+      final List<int> header = await _readHeaderBytes(installer);
+      if (!isWindowsExecutableHeader(header)) {
+        // 下载的不是真正的安装器（多半是代理返回的 HTML/损坏文件）：删掉脏文件，
+        // 抛错让上层提示「更新失败」并保留 app 存活，而不是硬启动一个坏 exe。
+        try {
+          installer.deleteSync();
+        } catch (_) {/* best-effort cleanup */}
+        throw UpdateInstallerException(
+            'downloaded file is not a Windows executable: $installerPath');
+      }
+    } catch (e, stack) {
+      await _markLaunchFailed(handoffMarkerFile, e, clock(), stack);
+      rethrow;
+    }
+
     final WindowsInstallerDiagnostics rawDiagnostics =
         collectDiagnostics != null
             ? await collectDiagnostics()
@@ -558,21 +585,7 @@ class WindowsInstaller {
       );
     }
 
-    final File installer = File(installerPath);
     try {
-      if (!installer.existsSync()) {
-        throw UpdateInstallerException('installer not found: $installerPath');
-      }
-      final List<int> header = await _readHeaderBytes(installer);
-      if (!isWindowsExecutableHeader(header)) {
-        // 下载的不是真正的安装器（多半是代理返回的 HTML/损坏文件）：删掉脏文件，
-        // 抛错让上层提示「更新失败」并保留 app 存活，而不是硬启动一个坏 exe。
-        try {
-          installer.deleteSync();
-        } catch (_) {/* best-effort cleanup */}
-        throw UpdateInstallerException(
-            'downloaded file is not a Windows executable: $installerPath');
-      }
       if (Platform.isWindows) {
         await ensureWindowsInstallTargetWritable(Directory(targetInstallDir));
       }

--- a/hibiki/test/anki/ankimobile_repository_test.dart
+++ b/hibiki/test/anki/ankimobile_repository_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -181,6 +182,11 @@ void main() {
 
     final events = <String>[];
     final launched = <Uri>[];
+    // The media server teardown is asynchronous (`Timer.run` -> HttpServer.close
+    // -> recursive delete of a real temp dir), so its duration is real I/O and
+    // cannot be predicted. Await the end-of-background-task callback itself --
+    // that IS the completion signal we are asserting on.
+    final Completer<void> backgroundTaskEnded = Completer<void>();
     final repo = AnkiMobileRepository(
       openUrl: (uri) async {
         expect(events, contains('begin-background-task'));
@@ -195,6 +201,7 @@ void main() {
       },
       endMediaImportBackgroundTask: () async {
         events.add('end-background-task');
+        if (!backgroundTaskEnded.isCompleted) backgroundTaskEnded.complete();
       },
     );
     await repo.saveSettings(const AnkiSettings(
@@ -266,7 +273,7 @@ void main() {
       expect(value, isNot(contains(temp.path)));
       expect(value, isNot(contains('hoshi_dict_0.svg')));
     }
-    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await backgroundTaskEnded.future;
     expect(events, <String>[
       'begin-background-task',
       'open-ankimobile',
@@ -287,6 +294,10 @@ void main() {
     });
 
     final launched = <Uri>[];
+    // Same rule as above: wait for the real "server torn down" signal instead of
+    // guessing a duration that must exceed lifetime + HttpServer.close +
+    // recursive temp-dir delete.
+    final Completer<void> backgroundTaskEnded = Completer<void>();
     final repo = AnkiMobileRepository(
       openUrl: (uri) async {
         launched.add(uri);
@@ -295,7 +306,9 @@ void main() {
       readInfoForAddingJson: () async => null,
       mediaServerLifetime: const Duration(milliseconds: 500),
       beginMediaImportBackgroundTask: () async {},
-      endMediaImportBackgroundTask: () async {},
+      endMediaImportBackgroundTask: () async {
+        if (!backgroundTaskEnded.isCompleted) backgroundTaskEnded.complete();
+      },
     );
     await repo.saveSettings(const AnkiSettings(
       selectedDeckId: 0,
@@ -352,7 +365,7 @@ void main() {
     expect(statusLine, startsWith('HTTP/1.1 200'));
     expect(responseBytes, bytes);
 
-    await Future<void>.delayed(const Duration(milliseconds: 550));
+    await backgroundTaskEnded.future;
   });
 }
 

--- a/hibiki/test/tools/update_manifest_publish_race_test.dart
+++ b/hibiki/test/tools/update_manifest_publish_race_test.dart
@@ -183,6 +183,19 @@ void main() {
     );
     expect(assets.length, 2);
   });
+
+  test('production retry backoff stays polite to the real GitHub remote', () {
+    // BUG-1178 guard: this suite lowers MANIFEST_RETRY_BACKOFF_MS so a local
+    // bare repo is not slept on for 3s per race. That seam must never be used
+    // to make CI "faster" by hammering github.com -- the DEFAULT stays 3000ms.
+    final String source = File(
+      p.join(
+          Directory.current.parent.path, 'tool', 'publish_update_manifest.sh'),
+    ).readAsStringSync();
+    expect(source,
+        contains(r'RETRY_BACKOFF_MS="${MANIFEST_RETRY_BACKOFF_MS:-3000}"'),
+        reason: 'default publish retry backoff must remain 3000ms');
+  });
 }
 
 String _io(ProcessResult r) =>
@@ -195,6 +208,16 @@ class _Fixture {
   final Directory root;
   final File script;
   final String originUrl;
+
+  /// Publish subprocesses that have been started but not yet reaped.
+  ///
+  /// A test that times out abandons its `await` but NOT the OS process: bash
+  /// keeps running with [root] as its working directory. On Windows a
+  /// directory that is any live process's CWD cannot be deleted, so the
+  /// abandoned child used to make [dispose] throw and keep burning CPU while
+  /// sibling tests ran -- one timeout cascaded into a spray of unrelated
+  /// failures. Owning the handles lets [dispose] kill survivors instead.
+  final Set<Process> _running = <Process>{};
 
   static const String defaultTag = 'v0.11.1-debug.5633+3cf5905';
   static const String defaultVersion = '0.11.1-debug.5633';
@@ -238,8 +261,12 @@ class _Fixture {
     String tag = defaultTag,
     String version = defaultVersion,
     int releaseSequence = defaultSeq,
-  }) {
+  }) async {
     final Map<String, String> env = <String, String>{
+      // The script's 3s production backoff is politeness toward a real GitHub
+      // remote; this fixture pushes to a local bare repo. Keep the retry
+      // semantics (re-fetch tip, re-merge, never clobber) and drop the wait.
+      'MANIFEST_RETRY_BACKOFF_MS': '50',
       'CHANNEL': 'debug',
       'TAG': tag,
       'PRERELEASE': 'true',
@@ -257,14 +284,20 @@ class _Fixture {
       'GIT_COMMITTER_NAME': 'Test',
       'GIT_COMMITTER_EMAIL': 'test@example.com',
     };
-    return Process.run(
+    final Process process = await Process.start(
       'bash',
       <String>[script.path],
       environment: env,
       workingDirectory: root.path,
-      stdoutEncoding: utf8,
-      stderrEncoding: utf8,
     );
+    _running.add(process);
+    final Future<String> out = process.stdout.transform(utf8.decoder).join();
+    final Future<String> err = process.stderr.transform(utf8.decoder).join();
+    final int exitCode = await process.exitCode;
+    // Only drop the handle once the process has really exited; if this test is
+    // killed by a timeout mid-await, `dispose` must still find it.
+    _running.remove(process);
+    return ProcessResult(process.pid, exitCode, await out, await err);
   }
 
   Future<Map<String, dynamic>> _finalManifest() async {
@@ -305,8 +338,18 @@ class _Fixture {
   }
 
   Future<void> dispose() async {
-    if (root.existsSync()) {
+    for (final Process process in _running.toList(growable: false)) {
+      process.kill(ProcessSignal.sigkill);
+    }
+    _running.clear();
+    if (!root.existsSync()) return;
+    try {
       await root.delete(recursive: true);
+    } on FileSystemException {
+      // Best effort. A grandchild git process can still hold a handle for a
+      // moment on Windows; systemTemp is reaped by the OS anyway. Throwing here
+      // would convert one test's failure into a tearDown error that also fails
+      // the surrounding group -- exactly the cascade this fixture must not have.
     }
   }
 }

--- a/hibiki/test/utils/misc/platform_updater_test.dart
+++ b/hibiki/test/utils/misc/platform_updater_test.dart
@@ -453,6 +453,46 @@ void main() {
         throwsA(isA<UpdateInstallerException>()),
       );
     });
+
+    test('never collects diagnostics for a download that fails validation',
+        () async {
+      // BUG-1179: diagnostics shell out to `reg`, `powershell Get-CimInstance`
+      // and `tasklist /M libmpv-2.dll` (a whole-machine module enumeration that
+      // costs seconds). Running that BEFORE the exists/MZ-header checks made
+      // real users wait ~10s just to be told the download was corrupt, and made
+      // the two tests above race the 30s default test timeout on a busy box.
+      // Validation must come first, so diagnostics are never collected at all.
+      final Directory tmp =
+          await Directory.systemTemp.createTemp('hibiki-update-nodiag');
+      addTearDown(() async {
+        if (tmp.existsSync()) await tmp.delete(recursive: true);
+      });
+      final File bogus = File('${tmp.path}/hibiki-0.4.2-windows-setup.exe');
+      await bogus.writeAsString('<html>rate limited</html>');
+
+      var diagnosticsCalls = 0;
+      Future<WindowsInstallerDiagnostics> collect() async {
+        diagnosticsCalls++;
+        return const WindowsInstallerDiagnostics();
+      }
+
+      await expectLater(
+        WindowsInstaller.runAndExit(bogus.path, collectDiagnostics: collect),
+        throwsA(isA<UpdateInstallerException>()),
+      );
+      expect(diagnosticsCalls, 0,
+          reason: 'a corrupt download must be rejected before any '
+              'whole-machine process enumeration');
+
+      await expectLater(
+        WindowsInstaller.runAndExit(
+          'Z:/nope/does-not-exist-installer.exe',
+          collectDiagnostics: collect,
+        ),
+        throwsA(isA<UpdateInstallerException>()),
+      );
+      expect(diagnosticsCalls, 0);
+    });
   });
 
   group('Windows installer diagnostics parsers', () {

--- a/tool/publish_update_manifest.sh
+++ b/tool/publish_update_manifest.sh
@@ -52,6 +52,20 @@ PLATFORM_LABEL="${PLATFORM_LABEL:-platform}"
 # asset URLs resolve on the single reused release even though `tag` keeps the
 # per-push seq for version comparison (TODO-1049).
 DOWNLOAD_TAG="${DOWNLOAD_TAG:-$TAG}"
+# Linear backoff base between publish retries, in milliseconds. 3000ms is the
+# right politeness interval for a real GitHub remote. The offline race test
+# drives a local bare repo where there is nothing to be polite to, so it lowers
+# this -- the retry SEMANTICS (re-fetch live tip, re-merge, never clobber) are
+# what the test asserts; the wait length is orthogonal to them.
+RETRY_BACKOFF_MS="${MANIFEST_RETRY_BACKOFF_MS:-3000}"
+
+# Linear backoff: attempt * base. bash has no float math, so format the
+# millisecond total as `<s>.<mmm>` for sleep(1) (fractions are fine in the
+# coreutils / BSD sleep this script runs under).
+backoff_sleep() {
+  local total=$(( $1 * RETRY_BACKOFF_MS ))
+  sleep "$(( total / 1000 )).$(printf '%03d' $(( total % 1000 )))"
+}
 
 # Map channel -> manifest filename. Only managed channels get a manifest;
 # github-release events publish through the Release UI directly and are skipped.
@@ -147,7 +161,7 @@ while :; do
         exit 1
       fi
       echo "Fetch of existing update-manifest failed (attempt $attempt); retrying..."
-      sleep $((attempt * 3))
+      backoff_sleep "$attempt"
       continue
     fi
     git -C "$WORK_DIR" checkout -q -B update-manifest FETCH_HEAD
@@ -193,5 +207,5 @@ while :; do
   # re-fetch the new live tip and re-merge onto it (preserving their assets).
   echo "Push raced/failed (attempt $attempt); re-fetching live tip and re-merging..."
   git -C "$WORK_DIR" reset -q --hard
-  sleep $((attempt * 3))
+  backoff_sleep "$attempt"
 done


### PR DESCRIPTION
一类 flaky 的共同根因：**在真实 I/O 上做定时假设**。三处实例，全部改成「等真实完成信号」，无一处靠调大超时/重试/sleep 掩盖。

## BUG-1177 · ankimobile_repository_test（真 bug）
`Future.delayed(10ms)` 当同步原语，等的却是 `Timer.run` → `HttpServer.close(force:true)` → **递归删一个含 4 个媒体文件的 Windows 临时目录** 之后才发的 `end-background-task`。
**修法**：测试注入的 `endMediaImportBackgroundTask` 回调里 complete 一个 `Completer<void>`，断言前 await 它——那个回调就是被断言的事件本身。同文件 `550ms` 猜 media-server lifetime 的第二处同样处理。

⚠️ **纠正前提**：空载机器上原代码 20/20 全绿，36% 复现不出。**10 个 `flutter test` 并发施压后 2/10 红**，报错正是 `Actual: ['begin-background-task', 'open-ankimobile']`。是负载相关竞态，不是无条件红。
**验证**：修复后目标用例 20/20 绿；同并发条件断言失败 0 次。负向：换回 `Future.delayed(10ms)` 立刻复现原症状。

## BUG-1178 · update_manifest_publish_race_test（真 bug，两处）
1. **级联**：`publish` 以 `workingDirectory: root.path` 起 bash。用例超时时 `test` 包只放弃 `await`，**OS 进程还活着**；Windows 上任何进程的 CWD 不可删 → `dispose()` 抛 `PathAccessException`，一次超时变成额外 tearDown 报错，遗留子进程继续抢 CPU 拖慢后续用例。
   **修法**：改 `Process.start` + `_running` 持有句柄，`dispose()` 先 SIGKILL 幸存进程再删，删除失败只吞 `FileSystemException`。
2. **逼近超时线**：`publish_update_manifest.sh` 的 `sleep $((attempt * 3))`——输的一方固定真睡 3 秒。抽成 `MANIFEST_RETRY_BACKOFF_MS`（**生产默认仍 3000**），测试传 50。竞态语义（重 fetch live tip、重 merge、绝不 clobber）分毫未动，只去掉与语义无关的等待时长。加了守卫测试钉住生产默认值。

⚠️ **纠正前提**：「单独跑要 42 秒」不成立。整文件**测试执行只 14 秒**（concurrent 用例 5 秒最慢），42~48 秒的大头是 `flutter test` 编译，每个测试文件都一样。真正贴近 30 秒线的是全量并发争用（实测涨到 34 秒）。
**验证**：修复后整文件 22 次全绿，concurrent 5s→2s，整文件 14s→10s。负向：还原 `Process.run` + 硬删并插入 probe 用例，立刻复现 `PathAccessException: Deletion failed ... 另一个程序正在使用此文件` 指向 `_Fixture.dispose`。

## BUG-1179 · platform_updater（**不同族**，且是产品缺陷）
如实报告：**这里没有定时假设**，`Process.run` 的 `exitCode` 本就是被正确 await 的真实完成信号。真实机制是 `runAndExit` 在**存在性 + MZ 头校验之前**无条件收集诊断——`reg` ×2 + `powershell Get-CimInstance` ×2 + `tasklist /M libmpv-2.dll`（全机进程模块表枚举）。坏包用户要干等十几秒才被告知「更新失败」，测试则顶到 30s 默认超时。
**修法**：校验上提到诊断之前。坏包/缺包立刻抛，一个外部进程都不起，handoff marker 也不再为起不来的安装器写 pending。
**验证**：整文件 22 次全绿。负向：`git apply -R` 撤掉产品侧改动，新守卫用例立刻红在 `Expected: <0> Actual: <1>`。

## 其他
- **无任何一处靠时间兜底**。三处都拿到了真实信号（Completer / 进程句柄+exitCode / 顺序契约）。
- `flutter analyze`（含 test）：**No issues found!**
- 按要求未跑全量套件。