### PR TITLE
ci: 全仓清理退出码吞没（TODO-2117，#489 后续）

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -77,8 +77,9 @@ jobs:
         run: |
           dst=hibiki/lib/src/sync/google_oauth_secret.dart
           if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
             printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+              "$oauth_secret_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -99,9 +100,11 @@ jobs:
         run: |
           dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
           if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
             printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+              "$log_endpoint_literal" \
+              "$log_token_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
@@ -220,7 +223,10 @@ jobs:
           cmake -S native/hoshidicts/tests -B "$RUNNER_TEMP/hoshi-tests" -G Ninja \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build "$RUNNER_TEMP/hoshi-tests" --config Release
-          ctest --test-dir "$RUNNER_TEMP/hoshi-tests" --output-on-failure -C Release
+          # --no-tests=error：ctest 在「一个测试都没注册」时默认返回 0，于是一次
+          # CMake 回归让 tests/CMakeLists.txt 的 add_test 列表变空就会读成通过。
+          # 与 BUG-1157 同族的「零测试执行伪装成绿」。对齐 native-hoshidicts-gate.yml。
+          ctest --test-dir "$RUNNER_TEMP/hoshi-tests" --output-on-failure -C Release --no-tests=error
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.44.0'
@@ -235,8 +241,9 @@ jobs:
         run: |
           dst=hibiki/lib/src/sync/google_oauth_secret.dart
           if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
             printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+              "$oauth_secret_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -257,9 +264,11 @@ jobs:
         run: |
           dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
           if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
             printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+              "$log_endpoint_literal" \
+              "$log_token_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
@@ -394,8 +403,9 @@ jobs:
         run: |
           dst=hibiki/lib/src/sync/google_oauth_secret.dart
           if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
             printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+              "$oauth_secret_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -416,9 +426,11 @@ jobs:
         run: |
           dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
           if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
             printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+              "$log_endpoint_literal" \
+              "$log_token_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
@@ -525,8 +537,9 @@ jobs:
         run: |
           dst=hibiki/lib/src/sync/google_oauth_secret.dart
           if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
             printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+              "$oauth_secret_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -542,9 +555,11 @@ jobs:
         run: |
           dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
           if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
             printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+              "$log_endpoint_literal" \
+              "$log_token_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
@@ -635,8 +650,9 @@ jobs:
         run: |
           dst=hibiki/lib/src/sync/google_oauth_secret.dart
           if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
             printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+              "$oauth_secret_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -657,9 +673,11 @@ jobs:
         run: |
           dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
           if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
             printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+              "$log_endpoint_literal" \
+              "$log_token_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
@@ -746,7 +764,12 @@ jobs:
           if (-not (Test-Path -LiteralPath $env:HIBIKI_TORRENT_LIB)) {
             throw "DLL not found at $env:HIBIKI_TORRENT_LIB — the build step above should have produced it"
           }
+          # 两条都是 native 命令，所以 `dart pub get` 的退出码会被紧随其后的
+          # `dart test` 覆盖，末尾那句断言只管得到 `dart test`。pub get 挂掉时
+          # 通常靠 dart test 也挂来自愈成红，但报错指向的是「测试失败」而不是
+          # 「依赖没解析出来」，排查方向被带偏。逐条断言。
           dart pub get
+          if ($LASTEXITCODE -ne 0) { throw "dart pub get failed ($LASTEXITCODE)" }
           dart test
           if ($LASTEXITCODE -ne 0) { throw "hibiki_torrent FFI tests failed" }
       # Windows is the ONLY platform that renders EPUB via the forked
@@ -759,7 +782,11 @@ jobs:
       - name: Build and bundle galgame helper archives
         shell: pwsh
         run: |
+          # 同 release-desktop.yml 的孪生副本：这段今天是「意外安全」的（块内只有
+          # 这一条 native 命令，后面全是不重置 $LASTEXITCODE 的 cmdlet），但只要
+          # 有人插入第二条 native 命令，双架构 ctest 的判决就被静默顶掉。显式断言。
           powershell -NoProfile -ExecutionPolicy Bypass -File native/galgame_hook/tools/build_distribution.ps1 -RunTests
+          if ($LASTEXITCODE -ne 0) { throw "build_distribution.ps1 -RunTests failed ($LASTEXITCODE)" }
           $sourceDir = Join-Path $PWD 'native\galgame_hook\dist'
           $targetDir = Join-Path $PWD 'hibiki\build\windows\x64\runner\Debug\galgame_helper'
           New-Item -ItemType Directory -Force -Path $targetDir | Out-Null

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,8 +98,9 @@ jobs:
       run: |
         dst=hibiki/lib/src/sync/google_oauth_secret.dart
         if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+          oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
           printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-            "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+            "$oauth_secret_literal" \
             > "$dst"
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -226,8 +226,9 @@ jobs:
         run: |
           dst=hibiki/lib/src/sync/google_oauth_secret.dart
           if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
             printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+              "$oauth_secret_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -248,9 +249,11 @@ jobs:
         run: |
           dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
           if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
             printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+              "$log_endpoint_literal" \
+              "$log_token_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
@@ -330,7 +333,16 @@ jobs:
       - name: Build and bundle galgame helper archives
         shell: pwsh
         run: |
+          # 这句断言是把「意外安全」变成「显式安全」，不是在修一个当前的漏红。
+          # 准确的 pwsh 规则是：$LASTEXITCODE 只被 **native 命令** 写，cmdlet
+          # （Join-Path / New-Item / Test-Path / Copy-Item）不会重置它。下面整段
+          # 只有这一条 native 命令，所以块尾 GitHub 追加的 `exit $LASTEXITCODE`
+          # 今天确实拿到的是 build_distribution.ps1 的退出码 —— 它是对的。
+          # 但这份正确性完全依赖「后面没有第二条 native 命令」：任何人在下方插入
+          # 一条 git / 7z / certutil，`-RunTests` 里双架构 22 个 ctest 的判决就会
+          # 被静默顶掉。显式断言后这个隐性前提消失。
           powershell -NoProfile -ExecutionPolicy Bypass -File native/galgame_hook/tools/build_distribution.ps1 -RunTests
+          if ($LASTEXITCODE -ne 0) { throw "build_distribution.ps1 -RunTests failed ($LASTEXITCODE)" }
           $sourceDir = Join-Path $PWD 'native\galgame_hook\dist'
           $targetDir = Join-Path $PWD 'hibiki\build\windows\x64\runner\Release\galgame_helper'
           New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
@@ -722,8 +734,9 @@ jobs:
         run: |
           dst=hibiki/lib/src/sync/google_oauth_secret.dart
           if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
             printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+              "$oauth_secret_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -736,9 +749,11 @@ jobs:
         run: |
           dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
           if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
             printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+              "$log_endpoint_literal" \
+              "$log_token_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
@@ -988,8 +1003,9 @@ jobs:
         run: |
           dst=hibiki/lib/src/sync/google_oauth_secret.dart
           if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+            oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
             printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+              "$oauth_secret_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -1002,9 +1018,11 @@ jobs:
         run: |
           dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
           if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+            log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+            log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
             printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-              "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+              "$log_endpoint_literal" \
+              "$log_token_literal" \
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,8 +320,9 @@ jobs:
       run: |
         dst=hibiki/lib/src/sync/google_oauth_secret.dart
         if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+          oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
           printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-            "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+            "$oauth_secret_literal" \
             > "$dst"
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -342,9 +343,11 @@ jobs:
       run: |
         dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
         if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+          log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+          log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
           printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-            "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-            "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+            "$log_endpoint_literal" \
+            "$log_token_literal" \
             > "$dst"
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"
@@ -799,8 +802,9 @@ jobs:
       run: |
         dst=hibiki/lib/src/sync/google_oauth_secret.dart
         if [ -n "$GOOGLE_OAUTH_CLIENT_SECRET" ]; then
+          oauth_secret_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')"
           printf 'const String kGoogleOAuthClientSecret =\n    %s;\n' \
-            "$(python3 -c 'import json,os; print(json.dumps(os.environ["GOOGLE_OAUTH_CLIENT_SECRET"]))')" \
+            "$oauth_secret_literal" \
             > "$dst"
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/sync/google_oauth_secret.example.dart "$dst"
@@ -819,9 +823,11 @@ jobs:
       run: |
         dst=hibiki/lib/src/utils/misc/log_upload_secret.dart
         if [ -n "$LOG_UPLOAD_ENDPOINT" ]; then
+          log_endpoint_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')"
+          log_token_literal="$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')"
           printf 'const String kLogUploadEndpoint = %s;\nconst String kLogUploadToken = %s;\n' \
-            "$(python3 -c 'import json,os; print(json.dumps(os.environ["LOG_UPLOAD_ENDPOINT"]))')" \
-            "$(python3 -c 'import json,os; print(json.dumps(os.environ.get("LOG_UPLOAD_TOKEN","")))')" \
+            "$log_endpoint_literal" \
+            "$log_token_literal" \
             > "$dst"
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/utils/misc/log_upload_secret.example.dart "$dst"

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -40,8 +40,16 @@ jobs:
             --out docs/assets/star-history.svg
 
       - name: Commit refreshed chart
+        shell: bash
         run: |
-          if [ -z "$(git status --porcelain docs/assets/star-history.svg)" ]; then
+          # `set -euo pipefail` + 先把 git status 的结果落到变量再判空。
+          # 原写法是 `if [ -z "$(git status --porcelain ...)" ]; then exit 0`：
+          # git status 一旦失败会返回非零 + 空 stdout，`[ -z "" ]` 为真，于是
+          # 「查不出来」被翻译成「没有变化」并**主动 exit 0 判绿**。这是把失败
+          # 翻译成一个错误的成功结论，比单纯吞退出码更坏。
+          set -euo pipefail
+          status="$(git status --porcelain docs/assets/star-history.svg)"
+          if [ -z "$status" ]; then
             echo "Star history SVG unchanged; nothing to commit."
             exit 0
           fi

--- a/native/galgame_hook/tools/build_distribution.ps1
+++ b/native/galgame_hook/tools/build_distribution.ps1
@@ -64,8 +64,13 @@ foreach ($config in @(
     '--build', $buildDir, '--config', 'Release'
   )
   if ($RunTests) {
+    # --no-tests=error: ctest defaults to returning 0 when NO test is registered,
+    # so a CMakeLists refactor that stops registering the suite would read as a
+    # pass. Same "zero tests executed masquerades as green" family as BUG-1157.
+    # Matches .github/workflows/native-hoshidicts-gate.yml.
     Invoke-Checked -FilePath ctest -Arguments @(
-      '--test-dir', $buildDir, '-C', 'Release', '--output-on-failure'
+      '--test-dir', $buildDir, '-C', 'Release', '--output-on-failure',
+      '--no-tests=error'
     )
   }
 }

--- a/native/galgame_hook/tools/run_guards.ps1
+++ b/native/galgame_hook/tools/run_guards.ps1
@@ -49,7 +49,19 @@ try {
 
   # Vendored LunaHook/LunaHost DLLs must match VERSION.json byte for byte.
   # Read-only: -Update is NOT passed, so nothing is copied or rewritten.
+  #
+  # The $LASTEXITCODE reset + assert is not redundant. `& script.ps1` returns to
+  # THIS scope, so if sync_lunahook.ps1 ever reports failure via `exit 1` instead
+  # of `throw`, execution would simply continue here, the four unittests below
+  # would reset $LASTEXITCODE to 0, and the DLL integrity check would silently
+  # stop counting -- the exact failure mode this whole file exists to prevent.
+  # Today it only throws, and $ErrorActionPreference='Stop' catches that; this
+  # keeps the guard correct if that ever changes.
+  $global:LASTEXITCODE = 0
   & (Join-Path $PSScriptRoot 'sync_lunahook.ps1')
+  if ($LASTEXITCODE -ne 0) {
+    throw "sync_lunahook.ps1 failed with exit code $LASTEXITCODE"
+  }
 
   # Manifest schema, adapter layout, evidence contract and workflow guards.
   Invoke-Checked $python 'tests/engine_support_manifest_test.py'


### PR DESCRIPTION
接 #489。那个 PR 修掉了 `voice-hook-helper.yml` 里「pwsh 多行 `run:` 只认最后一条退出码」的假绿；本 PR 把**同一族形态**在全部 9 个 workflow + `ci/` 脚本 + 被调用的 `native/galgame_hook/tools/*.ps1` 里扫了一遍并修完。

## 先更正一处我在 #489 讨论里说错的规则

我先前的判定规则是「pwsh 多行里只有**最后一行**的退出码被采信」。**这是错的**，准确规则是：

> `$LASTEXITCODE` **只被 native 命令写**，cmdlet（`Join-Path` / `New-Item` / `Test-Path` / `Copy-Item`）**不会重置它**。所以被采信的是**最后一条 native 命令**的退出码，不管它在第几行。

已本机实测确认（`cmd /c "exit 42"` 后连跑一串 cmdlet，`$LASTEXITCODE` 仍是 42）。

这条修正直接改变了两处判定：`release-desktop.yml` 与 `build-multiplatform.yml` 里的 `build_distribution.ps1 -RunTests` 块，**今天其实是安全的**（块内只有那一条 native 命令）。我一度把它们判成「正在吞掉双架构 22 个 ctest 的判决」，那是误判，本 PR 里不按「修漏红」处理，只按「消除隐性前提」处理。

## 类 1：真吞，已修

### 31 处 `printf ... "$(python3 -c ...)"` 秘钥 stub
分布：`build-multiplatform.yml` 15 / `release-desktop.yml` 9 / `release.yml` 6 / `main.yml` 1。

**参数位的命令替换不触发 `set -e`**——整条命令的退出码是 `printf` 的。python3 挂掉会写出 `const String kGoogleOAuthClientSecret =\n    ;` 这种非法 Dart，而**该步骤照样绿**，红被推迟到下游编译并以一个完全无关的错误爆出来。

实测对照：
```
旧写法：python3 退 3 → 步骤退 0，产物 "X "        ← 吞了
新写法：python3 退 3 → 步骤退 3                    ← 传播
```
修法是先赋值再 `printf`（赋值位的命令替换会传播 `-e`）。已验证正常路径下**产物字节完全一致**，用例含引号与反斜杠（`GOCSPX-ab"c\d` → `"GOCSPX-ab\"c\d"`）。

### `build-multiplatform.yml` 的 `dart pub get`
`dart pub get` 与 `dart test` 都是 native 命令，前者的退出码被后者覆盖，末尾那句 `if ($LASTEXITCODE -ne 0) { throw }` 只管得到 `dart test`。pub get 挂掉时通常靠 dart test 也挂来自愈成红，但报错指向「测试失败」而非「依赖没解析出来」。改为逐条断言。

### `star-history.yml` —— 本次唯一「把失败翻译成错误的成功」
```bash
if [ -z "$(git status --porcelain docs/assets/star-history.svg)" ]; then
  echo "Star history SVG unchanged; nothing to commit."
  exit 0
```
`git status` 一旦失败会返回非零 **+ 空 stdout**，`[ -z "" ]` 为真 → 走「无变化」分支并**主动 `exit 0` 判绿**。这比单纯吞退出码更坏：它不是漏报，是误报成功。改为先赋值 + `set -euo pipefail`。

## 类 2：零测试伪装成绿（BUG-1157 的 ctest 版），已修

`build-multiplatform.yml` 的 hoshidicts ctest 与 `build_distribution.ps1` 的双架构 ctest **都缺 `--no-tests=error`**。ctest 在「一个测试都没注册」时默认返回 0。

这一条尤其要紧：#489 新加的 `native-hoshidicts-gate.yml` 已经显式堵了它并在注释里点名 BUG-1157，**老路径没堵，标准不一致**；而 `native-galgame-gate.yml` 里「双架构 ctest 已由 build-multiplatform 在 PR 上覆盖、故不重复跑」这条声明，恰好就建立在这个不设防的 ctest 上。

## 类 3：意外安全但脆弱，改为显式安全

- 两处 `build_distribution.ps1 -RunTests`：正确性完全依赖「后面没有第二条 native 命令」。任何人在下方插入一条 `git` / `7z` / `certutil`，双架构 22 个 ctest 的判决就会被静默顶掉。补显式断言。
- `run_guards.ps1` 里 `& sync_lunahook.ps1` 是整份脚本唯一没走 `Invoke-Checked` 的一条；现在安全只是因为它用 `throw` 而非 `exit 1`（`& script.ps1` 是返回调用方继续执行的语义）。补断言 + 前置归零。

## 复核为 SAFE、未改动的部分

- **所有测试调用**都走 `dart run tool/flutter_test_failures.dart`，全仓 workflow 里**没有**裸 `flutter test` 接管道——BUG-1157 的原始形态不存在。包装器自身也可信（`flutter_test_failures.dart:75` 强制把 0 转非零）。
- `av-selfscan.yml` 的 9 个 pwsh 步骤是本仓写 pwsh 的**正面范本**：每条 native 调用后立刻把 `$LASTEXITCODE` 捕获到变量，还堵了「扫到 0 个文件 = 干净」。未动。
- `ci/apply-patches.sh`、`ci/comprehensive-test.sh`、`ci/anki-integration-test.sh`、`ci/emulator-test.sh` 均有 `set -euo pipefail`；`ci/comprehensive-test.ps1` 对两次 `& $Dart` 都传播 `$LASTEXITCODE`。未动。
- `release.yml` 的 bash 侧全线干净（要么显式 `shell: bash` 拿到 `-eo pipefail`，要么自写 `set -euo pipefail`）。
- `contributors.yml` 无任何 `run:` 步骤。

## 已知但**本 PR 未改**的项（如实列出）

1. **`build-multiplatform.yml` 的 macOS `Verify macOS hoshidicts dylib bundle` 步骤**未写 `shell: bash`（= `bash -e`，无 pipefail），其中两条 `otool | ...` 管道当前靠脚本首行自写的 `set -euo pipefail` 兜住。**当前 SAFE**，但删掉那一行就立刻退化成 PIPE-SWALLOWS。属纵深防御，未改。
2. **`build-multiplatform.yml` 的 `android` job 整体 `continue-on-error: true`**（TODO-624，emulator boot flake）。这是有意为之且有注释，但它意味着**唯一跑 appSmoke-android 契约的地方永远不阻塞 workflow**。未动，属产品决策。
3. **`release-desktop.yml` 的 `choco install ffmpeg`**（吸收 chocolatey 504 抖动）与 **`choco install innosetup`**：前者是注释明确记录的设计降级，后者被紧随的 `& $iscc` 找不到路径时抛终止性错误接住。未动。
4. **`release.yml` 空 keystore**：`echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d` 在 secret 为空时**正常返回 0**，产出 0 字节 `.jks`，失败推迟到 gradle 签名阶段。缺的是尺寸断言而不是 pipefail，属另一族问题，未改。
5. **`release.yml` 的 `packages/hibiki_dictionary` 无 `test/` 目录**，走 else 分支只发 `::warning`。是诚实告警而非伪装成功，但效果上该包在 release 路径上零测试执行。未改。

## 发布通道

**未触碰。** 已 grep 核对：本 PR 对 `release.yml` / `release-desktop.yml` 的改动**不含**任何 `on:` / `push:` / `pull_request:` / `branches` / `tag_name` / `make_latest` / `prerelease` / `softprops` 行，全部局限在 `run:` 步骤内部的退出码传播。
`tool/check_release_policy.ps1` → **Release policy guard passed.**

## 验证

- `actionlint 1.7.7` 全仓：仅剩 `build-multiplatform.yml:29` 的 YAML anchor 存量误报（`paths: *multiplatform_paths`，GitHub 支持文件内 anchor，actionlint 已知限制）。该报错在本 PR 之前就存在，非本 PR 引入。
- **116 个 bash `run:` 块逐块 `bash -n`：零语法错**（脚本按 job 的 `runs-on` / `defaults.run.shell` 推断实际 shell，只挑 bash/sh 的检）。
- 全部 workflow YAML 可解析。
- `run_guards.ps1` 正向 exit 0（七条守卫全跑）。
- 秘钥 stub 变换做了正/负向 + 字节一致性三重验证（见类 1）。

⚠️ **未验证**：这些改动在真实 CI 上的行为尚未跑过。本 PR 改了 `.github/workflows/**`，会触发 `main.yml`（其 paths 含 `.github/workflows/**`）与 `build-multiplatform.yml`（paths 含 `.github/workflows/build-multiplatform.yml`），可借此观察秘钥 stub 与 ctest 改动是否正常。但**「改完之后这些门真的能红」在 CI 上仍然零证据**——同 #489 里我已经写明的那条：绿只证明能过。

## 相关

- 前序：#489（`native-galgame-gate` / `native-hoshidicts-gate` + voice-hook-helper 假绿修复），已合入 `develop` @ `e63103a33`。
- 本 PR base 即 `e63103a33`。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
