### PR TITLE
test(reader): 守住「JS 子载荷真的被拼进注入脚本」这层装配完整性

### DIFF
--- a/hibiki/test/focus/webview_key_bridge_test.dart
+++ b/hibiki/test/focus/webview_key_bridge_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/focus/webview_key_bridge.dart';
 

--- a/hibiki/test/pages/reader_hibiki_page_source_corpus.dart
+++ b/hibiki/test/pages/reader_hibiki_page_source_corpus.dart
@@ -6,26 +6,44 @@ import 'dart:io';
 ///
 /// part 文件里的方法仍是 2 空格缩进的 `extension on _ReaderHibikiPageState` 成员，主壳
 /// 顶层 class / 常量 / 其它方法照搬不动，所以基于方法签名 / 字符串切片的守卫逻辑零改写，
-/// 只把数据源从「单文件」换成「合并语料」。新增 part 文件时补进 [_readerHibikiPageFiles]。
+/// 只把数据源从「单文件」换成「合并语料」。
 ///
-/// 批1（lyrics）只列主壳 + lyrics.part；后续批往里追加 part 路径即可。
-const List<String> _readerHibikiPageFiles = <String>[
-  'lib/src/pages/implementations/reader_hibiki_page.dart',
-  'lib/src/pages/implementations/reader_hibiki/lyrics.part.dart',
-  'lib/src/pages/implementations/reader_hibiki/mining.part.dart',
-  'lib/src/pages/implementations/reader_hibiki/lookup.part.dart',
-  'lib/src/pages/implementations/reader_hibiki/navigation.part.dart',
-  'lib/src/pages/implementations/reader_hibiki/audiobook.part.dart',
-  'lib/src/pages/implementations/reader_hibiki/caret.part.dart',
-  'lib/src/pages/implementations/reader_hibiki/chrome.part.dart',
-  'lib/src/pages/implementations/reader_hibiki/webview.part.dart',
-];
+/// **part 清单是从磁盘枚举出来的，不是手写常量**：清单一旦手写，新增/改名一个 part 就
+/// 意味着它的内容不在语料里，而 90+ 个消费方里那些 `isNot(contains(...))` 的**负向**断言
+/// 会因此「真空通过」——不是符号真的没了，是根本没读到那个文件。枚举 + 排序（确定性）
+/// 让新 part 自动进语料，负向断言不可能因为漏登记而假绿。
+const String _readerHibikiShell =
+    'lib/src/pages/implementations/reader_hibiki_page.dart';
+const String _readerHibikiPartDir =
+    'lib/src/pages/implementations/reader_hibiki';
+
+/// 主壳 + 磁盘上全部 `*.part.dart`（按路径排序，保证跨机器/跨次运行顺序确定）。
+List<String> readerHibikiPageFiles() {
+  final Directory dir = Directory(_readerHibikiPartDir);
+  if (!dir.existsSync()) {
+    throw StateError('$_readerHibikiPartDir 不存在——阅读器页 part 目录被搬走了，'
+        '本语料（及其 90+ 个消费方守卫）需同步更新');
+  }
+  final List<String> parts = dir
+      .listSync()
+      .whereType<File>()
+      .map((File f) => f.path.replaceAll(r'\', '/'))
+      .where((String p) => p.endsWith('.part.dart'))
+      .toList()
+    ..sort();
+  if (parts.isEmpty) {
+    throw StateError('$_readerHibikiPartDir 下一个 *.part.dart 都没有——'
+        '要么目录结构变了，要么工作目录不是 hibiki/；此时语料只剩主壳，'
+        '所有落在 part 里的守卫（含负向断言）都会真空通过');
+  }
+  return <String>[_readerHibikiShell, ...parts];
+}
 
 /// 读「阅读器页合并语料」：主壳 + 全部 part 文件拼成单个字符串，供静态守卫切片/断言。
 /// 统一把 CRLF 归一成 LF，与逐文件守卫此前的隐式假设一致。
 String readReaderPageSource() {
   final StringBuffer buffer = StringBuffer();
-  for (final String path in _readerHibikiPageFiles) {
+  for (final String path in readerHibikiPageFiles()) {
     buffer.writeln(File(path).readAsStringSync().replaceAll('\r\n', '\n'));
   }
   return buffer.toString();

--- a/hibiki/test/pages/reader_hibiki_page_source_corpus_test.dart
+++ b/hibiki/test/pages/reader_hibiki_page_source_corpus_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reader_hibiki_page_source_corpus.dart';
+
+/// 「合并语料」自身的守卫。
+///
+/// 90+ 个静态守卫读 [readReaderPageSource]，其中 25 个文件里带 `isNot(contains(...))`
+/// 这类**负向**断言。负向断言有个天然弱点：语料少读一个文件，它照样绿——不是符号真的
+/// 没了，是根本没扫到。清单以前是手写常量，新增 / 改名一个 part 就正好制造这种真空。
+///
+/// 清单已改成从磁盘枚举，本文件锁住这条契约：磁盘上每个 part 都必须真的进语料。
+void main() {
+  group('阅读器页合并语料覆盖磁盘上的全部 part', () {
+    test('主壳 + 每个 *.part.dart 都在清单里，且顺序确定', () {
+      final List<String> files = readerHibikiPageFiles();
+      expect(
+          files.first, 'lib/src/pages/implementations/reader_hibiki_page.dart');
+      final List<String> parts = files.skip(1).toList();
+      expect(parts, isNotEmpty);
+      expect(parts, orderedEquals(<String>[...parts]..sort()),
+          reason: '清单必须按路径排序，否则语料内容随文件系统枚举顺序漂移');
+
+      final Set<String> onDisk =
+          Directory('lib/src/pages/implementations/reader_hibiki')
+              .listSync()
+              .whereType<File>()
+              .map((File f) => f.path.replaceAll(r'\', '/'))
+              .where((String p) => p.endsWith('.part.dart'))
+              .toSet();
+      expect(parts.toSet(), onDisk,
+          reason: '磁盘上的 part 与语料清单必须一一对应——漏一个，'
+              '落在它里面的负向断言（isNot(contains(...))）就会真空通过');
+    });
+
+    test('每个 part 的内容真的进了语料（不只是路径进了清单）', () {
+      final String corpus = readReaderPageSource();
+      for (final String path in readerHibikiPageFiles()) {
+        final String body = File(path).readAsStringSync().replaceAll(
+              '\r\n',
+              '\n',
+            );
+        // 取该文件里最长的一行当指纹：跨文件重复的概率可以忽略，且不需要人工维护。
+        final String fingerprint = body
+            .split('\n')
+            .reduce((String a, String b) => b.length > a.length ? b : a);
+        expect(fingerprint.trim(), isNotEmpty, reason: '$path 是空文件？');
+        expect(corpus, contains(fingerprint),
+            reason: '$path 的内容不在合并语料里——读取环节把它丢了');
+      }
+    });
+  });
+}

--- a/hibiki/test/pages/reader_sasayaki_payload_source_guard_test.dart
+++ b/hibiki/test/pages/reader_sasayaki_payload_source_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/chapter_jump_late_load_reanchor_test.dart
+++ b/hibiki/test/reader/chapter_jump_late_load_reanchor_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/continuous_favorite_jump_scroll_test.dart
+++ b/hibiki/test/reader/continuous_favorite_jump_scroll_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/continuous_swipe_axis_test.dart
+++ b/hibiki/test/reader/continuous_swipe_axis_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/continuous_wheel_boundary_confirm_test.dart
+++ b/hibiki/test/reader/continuous_wheel_boundary_confirm_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/continuous_wheel_boundary_test.dart
+++ b/hibiki/test/reader/continuous_wheel_boundary_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/image_chapter_lazy_load_guard_test.dart
+++ b/hibiki/test/reader/image_chapter_lazy_load_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/page_turn_direction_intent_test.dart
+++ b/hibiki/test/reader/page_turn_direction_intent_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/paged_chapter_jump_bounds_test.dart
+++ b/hibiki/test/reader/paged_chapter_jump_bounds_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/paged_cross_chapter_limit_test.dart
+++ b/hibiki/test/reader/paged_cross_chapter_limit_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/prev_chapter_landing_guard_test.dart
+++ b/hibiki/test/reader/prev_chapter_landing_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/reader_caret_scripts_test.dart
+++ b/hibiki/test/reader/reader_caret_scripts_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_caret_scripts.dart';
 

--- a/hibiki/test/reader/reader_context_selection_regression_guard_test.dart
+++ b/hibiki/test/reader/reader_context_selection_regression_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/reader_longpress_drag_select_guard_test.dart
+++ b/hibiki/test/reader/reader_longpress_drag_select_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki_core/hibiki_core.dart';

--- a/hibiki/test/reader/reader_longpress_selection_menu_guard_test.dart
+++ b/hibiki/test/reader/reader_longpress_selection_menu_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/reader_native_selection_text_test.dart
+++ b/hibiki/test/reader/reader_native_selection_text_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 

--- a/hibiki/test/reader/reader_paginate_step_test.dart
+++ b/hibiki/test/reader/reader_paginate_step_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/reader_pagination_scripts_test.dart
+++ b/hibiki/test/reader/reader_pagination_scripts_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';

--- a/hibiki/test/reader/reader_script_compactor_test.dart
+++ b/hibiki/test/reader/reader_script_compactor_test.dart
@@ -18,6 +18,12 @@ import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 /// 3. 用 node `--check` 真解析：把 `webview.part.dart` 里那份**最终拼装脚本**按真实
 ///    组件重建出来（821 行外壳 + 各真实载荷），压缩前后都必须是合法 JS。这才是生产上
 ///    真正被 compact 的东西，此前一行测试都没有。
+/// 4. **装配完整性**（见 group「setup 装配完整性」）：reader 侧还有约 100 条守卫只断言
+///    某个生成函数**返回的字符串**里含某符号——它们证明不了这个串真的被拼进最终注入的
+///    脚本。压缩器的插值替身表 [_setupSubstitutions] 对**新增**插值会抛 StateError（响
+///    亮），但对**删除**插值（例如从模板里抹掉 `$caretJs`）完全静默：整个 caret 载荷不
+///    再注入，那 100 条照样全绿。本层堵的正是这个单向漏洞：替换时收集命中的插值键，断言
+///    每个替身都被用上；再对最终产物断言各子载荷的运行时哨兵同时在场。
 void main() {
   group('ReaderScriptCompactor.compact', () {
     test('剥掉整行注释与空行', () {
@@ -159,6 +165,7 @@ tail`;
           'selection',
           'longPressDrag',
           'caret',
+          'keyBridge.space',
           'pagination.paginated',
           'pagination.continuous',
           'pagination.vn',
@@ -211,6 +218,72 @@ tail`;
     });
   });
 
+  // 单向漏洞的封口：模板里**删掉**一个插值（整个子载荷不再注入）此前完全静默——
+  // 那约 100 条只断言「生成函数返回的串里含某符号」的守卫照样全绿。
+  // 本组是「被注入」这件事的唯一集中证据，不要求那 100 条各自再证一遍。
+  group('setup 装配完整性（子载荷真的被拼进最终脚本）', () {
+    final _AssembledSetup assembled = _assembleSetupScript(
+        _stripScriptTags(ReaderPaginationScripts.shellScript()));
+
+    test('替身表里的每个插值都在模板里被真正用上（删掉任一子载荷即红）', () {
+      expect(assembled.hitKeys, containsAll(assembled.subKeys),
+          reason: 'setup 模板不再引用这些插值：'
+              '${assembled.subKeys.difference(assembled.hitKeys).join(', ')}。'
+              '要么该子载荷被漏拼（= 线上整块功能失效，而单载荷守卫全绿看不出来），'
+              '要么它已被有意移除——后者请同步删掉替身表里的对应项。');
+    });
+
+    // 插值是**字面**插入，所以每个子载荷必须整段原样出现在产物里。这是「被拼进去」
+    // 最强的直接证据：哨兵符号会因为外壳/兄弟载荷里也出现同名符号而假绿（实测删掉
+    // `$caretJs` 后 `window.hoshiCaret` 仍在——它由 `$caretInit` 带进来），整段比对不会。
+    test('最终脚本里各子载荷整段原样在场', () {
+      final Map<String, String> payloads = <String, String>{
+        'selection': ReaderSelectionScripts.source(),
+        'caret': ReaderCaretScripts.source(),
+        'longPressDrag': ReaderSelectionScripts.longPressDragGestureScript(),
+        'pagination': _stripScriptTags(ReaderPaginationScripts.shellScript()),
+        'keyBridge': webViewKeyBridgeScript(
+          handlerName: 'onSpaceKey',
+          keys: const <String>[' '],
+        ),
+      };
+      for (final MapEntry<String, String> entry in payloads.entries) {
+        expect(assembled.script, contains(entry.value),
+            reason: '${entry.key} 载荷没有整段出现在最终注入脚本里——'
+                '它没被拼进 setup 脚本，注入后整块功能是死的');
+      }
+    });
+
+    test('最终脚本里各子载荷的运行时哨兵同时在场', () {
+      const Map<String, String> sentinels = <String, String>{
+        'selection': 'window.hoshiSelection',
+        'pagination': 'window.hoshiReader',
+        'caret': 'window.hoshiCaret',
+        'longPressDrag': '__hoshiTextSelectDragActive',
+        'keyBridge': "'onSpaceKey'",
+      };
+      for (final MapEntry<String, String> entry in sentinels.entries) {
+        expect(assembled.script, contains(entry.value),
+            reason: '最终注入脚本里找不到 ${entry.key} 的哨兵 ${entry.value}——'
+                '该载荷没被拼进 setup 脚本，注入后整块功能是死的');
+      }
+    });
+
+    test('压缩之后哨兵依然在场（压缩不得吃掉任何子载荷）', () {
+      final String compacted = ReaderScriptCompactor.compact(assembled.script);
+      for (final String sentinel in <String>[
+        'window.hoshiSelection',
+        'window.hoshiReader',
+        'window.hoshiCaret',
+        '__hoshiTextSelectDragActive',
+        "'onSpaceKey'",
+      ]) {
+        expect(compacted, contains(sentinel),
+            reason: '压缩后 $sentinel 消失 = 压缩器剥掉了真代码');
+      }
+    });
+  });
+
   group('压缩后仍是合法 JS（node --check 真解析）', () {
     final String? nodeExe = _resolveNode();
     final Map<String, String> payloads = _realPayloads();
@@ -250,20 +323,48 @@ Map<String, String> _realPayloads() {
     'selection': ReaderSelectionScripts.source(),
     'longPressDrag': ReaderSelectionScripts.longPressDragGestureScript(),
     'caret': ReaderCaretScripts.source(),
+    // PR#480 的裸 Space 键盘桥：它同样被拼进 setup 脚本后一起压缩，必须有独立的
+    // scansCleanly / 幂等 / node --check 覆盖，不能只靠 setupScript 顺带带过。
+    'keyBridge.space': webViewKeyBridgeScript(
+      handlerName: 'onSpaceKey',
+      keys: const <String>[' '],
+    ),
     'pagination.paginated': paginated,
     'pagination.continuous': _stripScriptTags(
         ReaderPaginationScripts.shellScript(continuousMode: true)),
     'pagination.vn':
         _stripScriptTags(ReaderPaginationScripts.shellScript(vnMode: true)),
-    'setupScript': _assembledSetupScript(paginated),
+    'setupScript': _assembleSetupScript(paginated).script,
   };
+}
+
+/// [_assembleSetupScript] 的产物：最终拼装脚本 + 「哪些替身插值真的被用上了」。
+///
+/// [hitKeys] 是装配完整性的唯一证据：模板里少写一个 `$xxx`，它就少一个键。
+class _AssembledSetup {
+  const _AssembledSetup({
+    required this.script,
+    required this.hitKeys,
+    required this.subKeys,
+  });
+
+  /// 替换全部插值后的最终脚本（= 生产上真正交给压缩器的那份）。
+  final String script;
+
+  /// 在模板里真实出现并被替换掉的插值键。
+  final Set<String> hitKeys;
+
+  /// 替身表登记的全部插值键。
+  final Set<String> subKeys;
 }
 
 /// 从 `webview.part.dart` 抠出 `_buildReaderSetupScript` 的那段 Dart 三引号模板，把每个
 /// 插值换成真实子载荷（或语法上等价的标量替身），还原成生产上真正被压缩的整份脚本。
 ///
-/// 插值一旦新增/改名，[_setupPlaceholders] 里没有对应替身就直接 fail——不会静默漏覆盖。
-String _assembledSetupScript(String paginationJs) {
+/// 插值一旦新增/改名，[_setupSubstitutions] 里没有对应替身就直接 fail——不会静默漏覆盖。
+/// 反方向（模板里**删掉**某个插值，例如整个 `$caretJs`）不会抛异常，由返回值的
+/// [_AssembledSetup.hitKeys] 交给「setup 装配完整性」那组测试断言。
+_AssembledSetup _assembleSetupScript(String paginationJs) {
   final File part = File(
     'lib/src/pages/implementations/reader_hibiki/webview.part.dart',
   );
@@ -293,7 +394,29 @@ String _assembledSetupScript(String paginationJs) {
   }
   body = body.replaceAll(r'\.', '.');
 
-  final Map<String, String> subs = <String, String>{
+  final Map<String, String> subs = _setupSubstitutions(paginationJs);
+  final Set<String> hit = <String>{};
+  final RegExp placeholder = RegExp(r'\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*');
+  final String script = body.replaceAllMapped(placeholder, (Match m) {
+    final String key = m.group(0)!;
+    final String? value = subs[key];
+    if (value == null) {
+      throw StateError('setup 模板新增插值 $key，请在本守卫里给出替身，'
+          '否则最终拼装脚本的压缩就没有覆盖');
+    }
+    hit.add(key);
+    return value;
+  });
+  return _AssembledSetup(
+    script: script,
+    hitKeys: hit,
+    subKeys: subs.keys.toSet(),
+  );
+}
+
+/// setup 模板里每个插值对应的真实子载荷（或语法上等价的标量替身）。
+Map<String, String> _setupSubstitutions(String paginationJs) {
+  return <String, String>{
     r'$selectionJs': ReaderSelectionScripts.source(),
     r'$paginationJs': paginationJs,
     r'$caretJs': ReaderCaretScripts.source(),
@@ -322,16 +445,6 @@ String _assembledSetupScript(String paginationJs) {
     r'${ReaderHibikiSource.instance.highlightOnTap}': 'false',
     r'${appModel.scanNonJapaneseText}': 'false',
   };
-  final RegExp placeholder = RegExp(r'\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*');
-  return body.replaceAllMapped(placeholder, (Match m) {
-    final String key = m.group(0)!;
-    final String? value = subs[key];
-    if (value == null) {
-      throw StateError('setup 模板新增插值 $key，请在本守卫里给出替身，'
-          '否则最终拼装脚本的压缩就没有覆盖');
-    }
-    return value;
-  });
 }
 
 String _stripScriptTags(String js) => js

--- a/hibiki/test/reader/reader_selection_handles_guard_test.dart
+++ b/hibiki/test/reader/reader_selection_handles_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 

--- a/hibiki/test/reader/reader_selection_scripts_test.dart
+++ b/hibiki/test/reader/reader_selection_scripts_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 

--- a/hibiki/test/reader/reader_style_reanchor_both_shells_guard_test.dart
+++ b/hibiki/test/reader/reader_style_reanchor_both_shells_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/reader_surrounding_sentences_cross_block_guard_test.dart
+++ b/hibiki/test/reader/reader_surrounding_sentences_cross_block_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 

--- a/hibiki/test/reader/reader_svg_cover_block_image_guard_test.dart
+++ b/hibiki/test/reader/reader_svg_cover_block_image_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';

--- a/hibiki/test/reader/reveal_anchor_start_edge_test.dart
+++ b/hibiki/test/reader/reveal_anchor_start_edge_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/reveal_viewport_visible_no_flip_test.dart
+++ b/hibiki/test/reader/reveal_viewport_visible_no_flip_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/sasayaki_cue_mapping_drift_test.dart
+++ b/hibiki/test/reader/sasayaki_cue_mapping_drift_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/scroll_cross_chapter_try_scroll_test.dart
+++ b/hibiki/test/reader/scroll_cross_chapter_try_scroll_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/sparse_chapter_landing_guard_test.dart
+++ b/hibiki/test/reader/sparse_chapter_landing_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/todo1289_image_reveal_persist_guard_test.dart
+++ b/hibiki/test/reader/todo1289_image_reveal_persist_guard_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/hibiki/test/reader/vertical_scroll_smoothness_test.dart
+++ b/hibiki/test/reader/vertical_scroll_smoothness_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 

--- a/hibiki/test/reader/vn_shell_smoke_test.dart
+++ b/hibiki/test/reader/vn_shell_smoke_test.dart
@@ -1,3 +1,9 @@
+// 覆盖边界（勿误读）：本文件只验 reader 侧 JS 载荷的**语义**——生成函数返回的那个字符串
+// 里有什么、行为契约对不对。它证明不了这个载荷真的被拼进最终注入 WebView 的 setup 脚本。
+// 「装配完整性」（每个子载荷都被拼进去、压缩后还在）由
+// test/reader/reader_script_compactor_test.dart 的「setup 装配完整性」一组集中守——
+// 那里删掉模板中的 $caretJs / $selectionJs / $longPressDragJs 会立刻转红，本文件不会。
+// 改这里前先分清你要锁的是语义还是注入，别在本文件里重造装配断言。
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## 缺口

reader 侧约 100 条 JS 守卫只断言某生成函数**返回的字符串**里含某符号，**从不验证这个串真的被拼进最终注入 WebView 的 setup 脚本**。压缩器的插值替身表是查表：**新增**插值会抛 `StateError`（响亮），但**删除**插值（例如从 `webview.part.dart` 的三引号模板里抹掉 `$caretJs`）**完全静默**——整个 caret 载荷不再注入，那 100 条照样全绿。

## 改动

### ① 装配产物含全部子 payload（`test/reader/reader_script_compactor_test.dart`）

`_assembleSetupScript` 改为返回 `_AssembledSetup`（最终脚本 + 命中的插值键 `hitKeys` + 替身表键 `subKeys`），新增 group「setup 装配完整性」三条：

1. `expect(hitKeys, containsAll(subKeys))` —— 模板里少写一个 `$xxx` 立刻红。
2. **各子载荷整段原样在场**：插值是字面插入，所以 `ReaderCaretScripts.source()` 等必须整段是产物的子串。这条比哨兵强——实测删掉 `$caretJs` 后 `window.hoshiCaret` **仍在**（由 `$caretInit` 带进来），哨兵假绿，整段比对不会。
3. 哨兵（`window.hoshiSelection` / `window.hoshiReader` / `window.hoshiCaret` / `__hoshiTextSelectDragActive` / `'onSpaceKey'`）同时在场，且**压缩之后仍在**。

**负向验证**：分别从模板删掉 `$caretJs` / `$selectionJs` / `$longPressDragJs` —— **三次都红**（每次命中上述第 1、2 条），逐一还原后 48 例全绿。

### ② PR#480 的裸 Space 键盘桥纳入压缩覆盖

`_realPayloads()` 加 `keyBridge.space`，并同步扩同文件那个自指的硬编码期望键集，使这座桥拿到独立的 `scansCleanly` / 幂等 / `node --check` 覆盖。

### ③ 消灭 corpus 负向断言的真空通过

`test/pages/reader_hibiki_page_source_corpus.dart` 的 part 清单由手写常量改为 `Directory.listSync()` 枚举 `*.part.dart` + **路径排序**（确定性）。手写清单下新增一个 part，93 个消费方里那 25 个带 `isNot(contains(...))` 的**负向**断言会真空通过——不是符号真的没了，是根本没扫到。

新增 `reader_hibiki_page_source_corpus_test.dart` 锁死「磁盘上每个 part 都真的进语料 + 内容确实进了语料」。

**负向验证**：造一个含 `Color _infoTextColor()` 的探针 part ——
- 旧硬编码清单：`reader_top_progress_frosted_guard_test`（`expect(src, isNot(contains('Color _infoTextColor()')))`）**仍绿** → 真空坐实；
- 改成枚举后：**转红**；移除探针恢复绿。

### ④ 那约 100 例的处置：不删，标注定位

它们是有价值的 JS 语义契约测试，病不在「内容错」而在「不证明被注入」。给 **32** 个只验载荷语义的文件统一加了覆盖边界注释，指明装配完整性由 `reader_script_compactor_test` 集中守。

## 与规格不符、照实报告的两点

1. **`reader_headless_shell_dump_test.dart` 没删。** 规格说它「无任何断言，是纯证据脚本」——**不成立**：它有两条断言（`expect(paginated.contains('window.hoshiReader'), isTrue)` 及 continuous 同款），且 `docs/bugs/BUG-594-chapter-jump-illustration-skip.md` 明确把它列为 `tool/reader_pitch_headless/chapter_start_reanchor_probe.mjs` 的**配套 shell dump**（该 harness 不入库，是本地/用户复测法证工具）。删掉会打断已归档的复现路径，故保留。
2. **③ 的负向验证换了目标文件。** 规格点名 `reader_progress_save_wiring_guard_test.dart` 里「9 处 `isNot(contains('onReaderUserInput'))` 负向断言」——该文件**不消费 corpus**（它直接 `File(...).readAsStringSync()` 逐文件读 `navigation` / `chrome` / `page` / `webview`），且 `onReaderUserInput` 只出现 1 处。故改用真正消费 corpus 的 `reader_top_progress_frosted_guard_test.dart` 做真空验证，结论同样成立。

另：本轮**没有**发现生产代码漏拼 payload（`webViewKeyBridgeScript` 确实已拼进 setup 脚本），三次负向验证的红/绿全部符合预期，**未发现真 bug，未建 BUG 档**。

## 验证

- `flutter analyze`（含 test）：`No issues found!`
- `test/reader` + `test/pages` + `test/focus`：`PASSED - 3601 tests ran`
- `test/anki` + `test/media` + `test/settings` + `test/startup` + `test/shortcuts` + `test/utils` + `test/tools`（corpus 消费方全覆盖）：`PASSED - 5542 tests ran`

（判绿均走 `dart run tool/flutter_test_failures.dart --no-pub`。）

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
