### PR TITLE
feat(collections)+fix(ui): 拖进合集自动加入 + 四条拖拽缺陷修复

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45628 (2684 per locale)
+/// Strings: 45662 (2686 per locale)
 ///
-/// Built on 2026-07-27 at 20:57 UTC
+/// Built on 2026-07-27 at 22:13 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3595,6 +3595,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get scrape_reason_server =>
       'The cover source returned an error. Try again later or pick another candidate.';
   String get common_more_actions => 'More actions';
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -9722,6 +9726,12 @@ class _StringsAr extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -15917,6 +15927,12 @@ class _StringsDe extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -22128,6 +22144,12 @@ class _StringsEs extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -28350,6 +28372,12 @@ class _StringsFr extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -34501,6 +34529,12 @@ class _StringsId extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -40698,6 +40732,12 @@ class _StringsIt extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -46712,6 +46752,12 @@ class _StringsJa extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -52728,6 +52774,12 @@ class _StringsKo extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -58905,6 +58957,12 @@ class _StringsNl extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -65095,6 +65153,12 @@ class _StringsPtBr extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -71269,6 +71333,12 @@ class _StringsRu extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -77391,6 +77461,12 @@ class _StringsTh extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -83545,6 +83621,12 @@ class _StringsTr extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -89684,6 +89766,12 @@ class _StringsVi extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 // Path: <root>
@@ -95394,6 +95482,11 @@ class _StringsZhCn extends _StringsEn {
   String get scrape_reason_server => '封面源返回了错误，请稍后重试或换一个候选。';
   @override
   String get common_more_actions => '更多操作';
+  @override
+  String get collection_already_has_item => '该条目已在这个合集里。';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      '无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。';
 }
 
 // Path: <root>
@@ -101329,6 +101422,12 @@ class _StringsZhHk extends _StringsEn {
       'The cover source returned an error. Try again later or pick another candidate.';
   @override
   String get common_more_actions => 'More actions';
+  @override
+  String get collection_already_has_item =>
+      'This item is already in the collection.';
+  @override
+  String get drag_drop_manga_archive_unsupported =>
+      'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
 }
 
 /// Flat map(s) containing all translations.
@@ -106826,6 +106925,10 @@ extension on _StringsEn {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -112321,6 +112424,10 @@ extension on _StringsAr {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -117837,6 +117944,10 @@ extension on _StringsDe {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -123352,6 +123463,10 @@ extension on _StringsEs {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -128873,6 +128988,10 @@ extension on _StringsFr {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -134376,6 +134495,10 @@ extension on _StringsId {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -139894,6 +140017,10 @@ extension on _StringsIt {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -145374,6 +145501,10 @@ extension on _StringsJa {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -150858,6 +150989,10 @@ extension on _StringsKo {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -156369,6 +156504,10 @@ extension on _StringsNl {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -161877,6 +162016,10 @@ extension on _StringsPtBr {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -167390,6 +167533,10 @@ extension on _StringsRu {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -172887,6 +173034,10 @@ extension on _StringsTh {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -178393,6 +178544,10 @@ extension on _StringsTr {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -183894,6 +184049,10 @@ extension on _StringsVi {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }
@@ -189349,6 +189508,10 @@ extension on _StringsZhCn {
         return '封面源返回了错误，请稍后重试或换一个候选。';
       case 'common_more_actions':
         return '更多操作';
+      case 'collection_already_has_item':
+        return '该条目已在这个合集里。';
+      case 'drag_drop_manga_archive_unsupported':
+        return '无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。';
       default:
         return null;
     }
@@ -194824,6 +194987,10 @@ extension on _StringsZhHk {
         return 'The cover source returned an error. Try again later or pick another candidate.';
       case 'common_more_actions':
         return 'More actions';
+      case 'collection_already_has_item':
+        return 'This item is already in the collection.';
+      case 'drag_drop_manga_archive_unsupported':
+        return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 45662 (2686 per locale)
+/// Strings: 45679 (2687 per locale)
 ///
-/// Built on 2026-07-27 at 22:13 UTC
+/// Built on 2026-07-27 at 22:16 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3599,6 +3599,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'This item is already in the collection.';
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -9732,6 +9734,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -15933,6 +15938,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -22150,6 +22158,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -28378,6 +28389,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -34535,6 +34549,9 @@ class _StringsId extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -40738,6 +40755,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -46758,6 +46778,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -52780,6 +52803,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -58963,6 +58989,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -65159,6 +65188,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -71339,6 +71371,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -77467,6 +77502,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -83627,6 +83665,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -89772,6 +89813,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 // Path: <root>
@@ -95487,6 +95531,8 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       '无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。';
+  @override
+  String get collection_add_failed => '没能把该条目加进合集，请重试。';
 }
 
 // Path: <root>
@@ -101428,6 +101474,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get drag_drop_manga_archive_unsupported =>
       'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+  @override
+  String get collection_add_failed =>
+      'Couldn\'t add the item to the collection. Please try again.';
 }
 
 /// Flat map(s) containing all translations.
@@ -106929,6 +106978,8 @@ extension on _StringsEn {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -112428,6 +112479,8 @@ extension on _StringsAr {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -117948,6 +118001,8 @@ extension on _StringsDe {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -123467,6 +123522,8 @@ extension on _StringsEs {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -128992,6 +129049,8 @@ extension on _StringsFr {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -134499,6 +134558,8 @@ extension on _StringsId {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -140021,6 +140082,8 @@ extension on _StringsIt {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -145505,6 +145568,8 @@ extension on _StringsJa {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -150993,6 +151058,8 @@ extension on _StringsKo {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -156508,6 +156575,8 @@ extension on _StringsNl {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -162020,6 +162089,8 @@ extension on _StringsPtBr {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -167537,6 +167608,8 @@ extension on _StringsRu {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -173038,6 +173111,8 @@ extension on _StringsTh {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -178548,6 +178623,8 @@ extension on _StringsTr {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -184053,6 +184130,8 @@ extension on _StringsVi {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }
@@ -189512,6 +189591,8 @@ extension on _StringsZhCn {
         return '该条目已在这个合集里。';
       case 'drag_drop_manga_archive_unsupported':
         return '无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。';
+      case 'collection_add_failed':
+        return '没能把该条目加进合集，请重试。';
       default:
         return null;
     }
@@ -194991,6 +195072,8 @@ extension on _StringsZhHk {
         return 'This item is already in the collection.';
       case 'drag_drop_manga_archive_unsupported':
         return 'Can\'t import .cbr/.rar comic archives — repack as .cbz or a folder of images.';
+      case 'collection_add_failed':
+        return 'Couldn\'t add the item to the collection. Please try again.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "没能从封面源取到有效响应，请检查网络后重试。",
   "scrape_reason_server": "封面源返回了错误，请稍后重试或换一个候选。",
   "common_more_actions": "更多操作",
+
   "collection_already_has_item": "该条目已在这个合集里。",
   "drag_drop_manga_archive_unsupported": "无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "搜索失败，点「搜索」可重试。",
   "scrape_reason_network": "没能从封面源取到有效响应，请检查网络后重试。",
   "scrape_reason_server": "封面源返回了错误，请稍后重试或换一个候选。",
-  "common_more_actions": "更多操作"
+  "common_more_actions": "更多操作",
+  "collection_already_has_item": "该条目已在这个合集里。"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "没能从封面源取到有效响应，请检查网络后重试。",
   "scrape_reason_server": "封面源返回了错误，请稍后重试或换一个候选。",
   "common_more_actions": "更多操作",
-  "collection_already_has_item": "该条目已在这个合集里。"
+  "collection_already_has_item": "该条目已在这个合集里。",
+  "drag_drop_manga_archive_unsupported": "无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "没能从封面源取到有效响应，请检查网络后重试。",
   "scrape_reason_server": "封面源返回了错误，请稍后重试或换一个候选。",
   "common_more_actions": "更多操作",
-
   "collection_already_has_item": "该条目已在这个合集里。",
-  "drag_drop_manga_archive_unsupported": "无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。"
+  "drag_drop_manga_archive_unsupported": "无法导入 .cbr/.rar 漫画压缩包，请转成 .cbz 或图片文件夹。",
+  "collection_add_failed": "没能把该条目加进合集，请重试。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2683,6 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
+
   "collection_already_has_item": "This item is already in the collection.",
   "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2683,7 +2683,7 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-
   "collection_already_has_item": "This item is already in the collection.",
-  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images.",
+  "collection_add_failed": "Couldn't add the item to the collection. Please try again."
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2683,5 +2683,6 @@
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
   "common_more_actions": "More actions",
-  "collection_already_has_item": "This item is already in the collection."
+  "collection_already_has_item": "This item is already in the collection.",
+  "drag_drop_manga_archive_unsupported": "Can't import .cbr/.rar comic archives — repack as .cbz or a folder of images."
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2682,5 +2682,6 @@
   "video_scrape_search_failed": "Search failed. Tap Search to retry.",
   "scrape_reason_network": "Could not get a valid response from the cover source. Check your network and retry.",
   "scrape_reason_server": "The cover source returned an error. Try again later or pick another candidate.",
-  "common_more_actions": "More actions"
+  "common_more_actions": "More actions",
+  "collection_already_has_item": "This item is already in the collection."
 }

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -158,7 +158,14 @@ class _BookImportDialogState extends State<BookImportDialog>
     if (epub != null) {
       _epubPath = epub;
       _epubName = p.basename(epub);
-      _autoFillTitle(p.basenameWithoutExtension(epub), ImportTitleSource.epub);
+      // 目录（漫画页图文件夹）没有扩展名概念——目录名带点时
+      // basenameWithoutExtension 会把 `第01巻.v2` 截成 `第01巻`，当书名用就错了。
+      _autoFillTitle(
+        Directory(epub).existsSync()
+            ? p.basename(epub)
+            : p.basenameWithoutExtension(epub),
+        ImportTitleSource.epub,
+      );
     }
     final String? sub = widget.initialSubtitlePath;
     if (sub != null) {
@@ -935,6 +942,29 @@ class _BookImportDialogState extends State<BookImportDialog>
 
     reportProgress(0.2, t.import_step_reading);
     final String ext = p.extension(_epubPath!).toLowerCase();
+
+    // 漫画页图**目录**（拖入一个漫画文件夹）：整目录导入，OCR blocks 留空。
+    // 必须在所有按扩展名分派的分支之前——目录没有扩展名（目录名带点时 p.extension
+    // 还会误取出一个假扩展名），落到下面任何一条文件分支都会失败。
+    if (Directory(_epubPath!).existsSync()) {
+      reportProgress(0.5, t.import_step_importing_epub);
+      await MangaModule.importImageFolder(
+        db: widget.db,
+        path: _epubPath!,
+        title: title,
+        onDuplicateTitle: _onDuplicateTitle,
+        onProgress: (int done, int total) {
+          if (total > 0) {
+            reportProgress(
+              (done / total).clamp(0.0, 1.0),
+              t.import_step_copying_file(name: p.basename(_epubPath!)),
+            );
+          }
+        },
+      );
+      reportProgress(1, t.import_step_done);
+      return;
+    }
 
     // PDF 阅读器 Phase 1：.pdf 走独立 PdfImporter（pdfrx 真渲染 + 落库 format='pdf'），
     // 必须在下面的 TextToEpub 文本转换分支之前早退——否则 PDF 二进制会被当文本转成乱码

--- a/hibiki/lib/src/media/collections/collection_drag.dart
+++ b/hibiki/lib/src/media/collections/collection_drag.dart
@@ -1,0 +1,234 @@
+/// 「把卡片拖进合集」的共享拖放件（书架 / 漫画 / 视频库 / 游戏库共用）。
+///
+/// 拖拽源 [MediaCardDraggable] 挂在各库页的媒体卡上，payload 是统一媒体身份
+/// [MediaRef]；接收端 [CollectionDropTarget] 挂在合集行头（书架 / 游戏）与合集
+/// 封面卡（视频），落下即 `HibikiDatabase.addToCollection`（幂等：同一张卡重复
+/// 拖同一个合集是 no-op，调用方据回调自行提示）。
+///
+/// 泛型刻意选 [MediaRef] 而**不复用**标签拖放的 `BookTagRow`：合集行头同时挂着
+/// 两个 DragTarget（标签落下=给合集打标签 / 卡片落下=加入合集），靠泛型天然分流
+/// 互不误接——`DragTarget<T>` 只接收 `T` 类型的 payload，无需任何运行时判别分支。
+/// 这也让 `collection_shelf_row_tag_drop_test.dart` 里「`DragTarget<BookTagRow>`
+/// 恰好一个 / 恰好零个」的既有断言保持成立。
+library;
+
+import 'package:flutter/material.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'package:hibiki/utils.dart';
+
+/// 媒体卡的拖拽源：拖起卡片，落到合集上即加入该合集。
+///
+/// **仅桌面端建拖拽源**（镜像 `hibiki_reorder_drag_listener.dart` 的按平台范式）：
+/// - 桌面（Windows / Linux / macOS，鼠标为主）→ [Draggable]（按下即拖）。与卡片
+///   既有交互零冲突：`ImmediateMultiDragGestureRecognizer` 要指针移动超过
+///   `kTouchSlop` 才在手势竞技场胜出，所以点击（按下即抬）仍归 `InkWell.onTap`
+///   开书、按住不动仍归 `onLongPress` 弹菜单、右键仍归 `onSecondaryTap`；
+///   垂直网格没放开鼠标拖动滚动，横向合集行里则是「横拖=滚动、纵拖=拖卡」的
+///   自然分工（两者都要过 slop，方向先满足者胜）。
+/// - 移动 / 触摸（Android / iOS / Fuchsia）→ **不建拖拽源**，原样返回 [child]。
+///   触屏上按下即拖会吞掉列表滚动；而长按已被卡片的上下文菜单占用（改掉它就
+///   破坏了既有的长按菜单），没有第三种不打架的触发方式。移动端加入合集走既有
+///   的卡片菜单「加入合集」入口，功能不缺，只是少一条快捷路径。
+///
+/// [enabled] 为 false 时原样返回 [child]（不建 Draggable）——多选态下卡片点击是
+/// 切换选中，此时不应能拖走。
+class MediaCardDraggable extends StatelessWidget {
+  const MediaCardDraggable({
+    required this.mediaRef,
+    required this.label,
+    required this.child,
+    this.enabled = true,
+    super.key,
+  });
+
+  /// 被拖条目的稳定身份（epub=bookKey / srt=uid / video=bookUid / game=id）。
+  final MediaRef mediaRef;
+
+  /// 拖拽浮层上显示的条目名（书名 / 视频名 / 游戏名）。
+  final String label;
+
+  final Widget child;
+
+  /// false 时不建拖拽源，原样返回 [child]（多选态）。
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!enabled) return child;
+    switch (Theme.of(context).platform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+      case TargetPlatform.fuchsia:
+        // 触屏：不建拖拽源（见类 doc）。
+        return child;
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+      case TargetPlatform.macOS:
+        return Draggable<MediaRef>(
+          data: mediaRef,
+          // 浮层跟指针而不是保持「按下点相对卡片的位置」：浮层是紧凑 chip、尺寸
+          // 与原卡完全不同，沿用 childDragAnchorStrategy 会让它偏到指针外面去。
+          dragAnchorStrategy: pointerDragAnchorStrategy,
+          feedback: _DragFeedback(label: label),
+          childWhenDragging: Opacity(opacity: 0.3, child: child),
+          child: child,
+        );
+    }
+  }
+}
+
+/// 拖拽浮层：紧凑 chip（图标 + 条目名），不复用卡片本体。
+///
+/// 刻意不拿 [MediaCardDraggable.child] 当 feedback：卡片内含 `HibikiFocusTarget`
+/// （焦点 id 唯一）与 `InkWell`，同一棵树里渲染第二份会造成焦点 id 撞车。
+class _DragFeedback extends StatelessWidget {
+  const _DragFeedback({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Material(
+      color: Colors.transparent,
+      elevation: 4,
+      borderRadius: tokens.radii.chipRadius,
+      clipBehavior: Clip.antiAlias,
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 220),
+        padding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.gap,
+          vertical: tokens.spacing.gap / 2,
+        ),
+        decoration: BoxDecoration(
+          color: tokens.surfaces.primaryContainer,
+          borderRadius: tokens.radii.chipRadius,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.collections_bookmark_outlined,
+              size: 18,
+              color: tokens.surfaces.onSurface,
+            ),
+            SizedBox(width: tokens.spacing.gap / 2),
+            Flexible(
+              child: Text(
+                label,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: tokens.type.metadata.copyWith(
+                  color: tokens.surfaces.onSurface,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// 合集侧的接收端：媒体卡落到它上面即加入该合集。
+///
+/// 视觉与 `BookDragTarget`（标签落卡）/ `CollectionShelfRow._wrapTagDropTarget`
+/// （标签落行头）同源：primary 描边 + 半透明填充 + 提示图标；eink 主题下去掉
+/// 填充色只留实心描边（半透明罩在墨水屏合成抖动灰，且 primary 已塌缩）。
+///
+/// [alignment] 决定提示图标的位置：行头形状（扁长）用 `centerEnd`，封面卡形状
+/// （方块）用 `center`。
+class CollectionDropTarget extends StatefulWidget {
+  const CollectionDropTarget({
+    required this.onMediaDropped,
+    required this.child,
+    this.alignment = Alignment.center,
+    this.borderRadius,
+    this.enabled = true,
+    super.key,
+  });
+
+  /// 卡片落下：把 [MediaRef] 加进本合集（调用方负责落库 + 刷新 + 提示）。
+  final void Function(MediaRef ref) onMediaDropped;
+
+  final Widget child;
+
+  /// 悬停提示图标的对齐位置。
+  final AlignmentGeometry alignment;
+
+  /// 悬停高亮罩的圆角。null 时用 `tokens.radii.cardRadius`。
+  final BorderRadius? borderRadius;
+
+  /// false 时不建接收端，原样返回 [child]（多选态）。
+  final bool enabled;
+
+  @override
+  State<CollectionDropTarget> createState() => _CollectionDropTargetState();
+}
+
+class _CollectionDropTargetState extends State<CollectionDropTarget> {
+  bool _hovering = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.enabled) return widget.child;
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final Color hoverColor = tokens.surfaces.primary;
+    final bool eink = isEinkTheme(context);
+    return DragTarget<MediaRef>(
+      onWillAcceptWithDetails: (_) => true,
+      onAcceptWithDetails: (DragTargetDetails<MediaRef> details) {
+        setState(() => _hovering = false);
+        widget.onMediaDropped(details.data);
+      },
+      onMove: (_) {
+        if (!_hovering) setState(() => _hovering = true);
+      },
+      onLeave: (_) {
+        if (_hovering) setState(() => _hovering = false);
+      },
+      builder: (
+        BuildContext context,
+        List<MediaRef?> candidateData,
+        List<dynamic> rejectedData,
+      ) {
+        return Stack(
+          children: <Widget>[
+            widget.child,
+            if (_hovering)
+              Positioned.fill(
+                // IgnorePointer：高亮罩只是反馈，不得吞掉行头 / 卡片本身的点击。
+                child: IgnorePointer(
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: eink ? null : hoverColor.withValues(alpha: 0.18),
+                      borderRadius:
+                          widget.borderRadius ?? tokens.radii.cardRadius,
+                      border: Border.all(
+                        color: hoverColor,
+                        width: tokens.spacing.gap / 4,
+                      ),
+                    ),
+                    child: Align(
+                      alignment: widget.alignment,
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: tokens.spacing.gap,
+                        ),
+                        child: Icon(
+                          Icons.library_add_outlined,
+                          color: hoverColor,
+                          size: 20,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/hibiki/lib/src/media/collections/collection_drag.dart
+++ b/hibiki/lib/src/media/collections/collection_drag.dart
@@ -17,15 +17,80 @@ import 'package:hibiki_core/hibiki_core.dart';
 
 import 'package:hibiki/utils.dart';
 
+/// [addMediaRefToCollection] 的结果：三种结局各自对应一条不同的用户可见提示。
+enum CollectionAddOutcome {
+  /// 真的写进去了。调用方据此刷新并报成功。
+  added,
+
+  /// 该条目本就在这个合集里（`addToCollection` 幂等，静默 no-op 对用户就是
+  /// 「拖了没反应」）。已提示，调用方不必刷新。
+  alreadyPresent,
+
+  /// 落库失败（DB 锁 / 磁盘满 / schema 异常……）。已提示，**没有**写进去。
+  failed,
+}
+
+/// 提示通道。默认 [HibikiToast.show]；测试注入自己的收集器。
+typedef CollectionAddNotifier = void Function(String message);
+
+/// 「把一个 [MediaRef] 加进合集」的共享落库编排（书架 / 视频库 / 游戏库三处同一份）。
+///
+/// 三处此前各抄一遍「查成员 → 幂等提示 → 落库」，且**都没有 try/catch**，又都以
+/// unawaited Future 挂在 `onMediaDropped` 这个 `void` 回调上：`addToCollection`
+/// 抛出时异常直接漂进 zone，用户看到的只是「拖了没反应」——他会以为加成功了，
+/// 而合集里其实什么都没有。这是「让用户基于错误信息做决定」的典型，必须报。
+///
+/// 故本函数**永不抛出**：任何失败都归到 [CollectionAddOutcome.failed] 并给出
+/// 明确提示。调用方只需按返回值决定要不要刷新 + 报成功。
+Future<CollectionAddOutcome> addMediaRefToCollection({
+  required HibikiDatabase database,
+  required int collectionId,
+  required MediaRef mediaRef,
+  CollectionAddNotifier? notify,
+}) async {
+  final CollectionAddNotifier tell =
+      notify ?? (String message) => HibikiToast.show(msg: message);
+  try {
+    final List<MediaCollectionItemRow> items =
+        await database.getCollectionItems(collectionId);
+    final bool already = items.any(
+      (MediaCollectionItemRow it) =>
+          it.mediaType == mediaRef.dbMediaType &&
+          it.entryKey == mediaRef.entryKey,
+    );
+    if (already) {
+      tell(t.collection_already_has_item);
+      return CollectionAddOutcome.alreadyPresent;
+    }
+    await database.addToCollection(
+      collectionId,
+      mediaRef.kind,
+      mediaRef.entryKey,
+    );
+    return CollectionAddOutcome.added;
+  } catch (error, stackTrace) {
+    debugPrint('addMediaRefToCollection failed: $error\n$stackTrace');
+    tell(t.collection_add_failed);
+    return CollectionAddOutcome.failed;
+  }
+}
+
 /// 媒体卡的拖拽源：拖起卡片，落到合集上即加入该合集。
 ///
 /// **仅桌面端建拖拽源**（镜像 `hibiki_reorder_drag_listener.dart` 的按平台范式）：
 /// - 桌面（Windows / Linux / macOS，鼠标为主）→ [Draggable]（按下即拖）。与卡片
 ///   既有交互零冲突：`ImmediateMultiDragGestureRecognizer` 要指针移动超过
 ///   `kTouchSlop` 才在手势竞技场胜出，所以点击（按下即抬）仍归 `InkWell.onTap`
-///   开书、按住不动仍归 `onLongPress` 弹菜单、右键仍归 `onSecondaryTap`；
-///   垂直网格没放开鼠标拖动滚动，横向合集行里则是「横拖=滚动、纵拖=拖卡」的
-///   自然分工（两者都要过 slop，方向先满足者胜）。
+///   开书、按住不动仍归 `onLongPress` 弹菜单、右键仍归 `onSecondaryTap`。
+///
+///   ⚠️ **与横向合集行的鼠标拖动滚动（`HorizontalDragScrollable`）如何分流，未在
+///   真机验证。** 别把它当成「横拖=滚动、纵拖=拖卡」的自然分工——按识别器的判据
+///   推，事实很可能相反：`ImmediateMultiDragGestureRecognizer` 用**总位移**
+///   （`_pendingDelta.distance`）过 slop，而 `HorizontalDragGestureRecognizer` 用
+///   **水平分量**过 slop；`hypot(dx, dy) >= |dx|` 恒成立，所以纯横向拖动时拖卡这一
+///   侧**不晚于**滚动侧宣布胜出，卡片上的横拖大概率归拖卡而不是滚动。行头与卡片
+///   之间的空白仍能横拖滚动（那里没有 `Draggable`），滚轮 / 触控板横滚不受影响。
+///   真机确认前不要基于「横拖能滚动」这个假设改动这里。
 /// - 移动 / 触摸（Android / iOS / Fuchsia）→ **不建拖拽源**，原样返回 [child]。
 ///   触屏上按下即拖会吞掉列表滚动；而长按已被卡片的上下文菜单占用（改掉它就
 ///   破坏了既有的长按菜单），没有第三种不打架的触发方式。移动端加入合集走既有

--- a/hibiki/lib/src/media/collections/collection_shelf_row.dart
+++ b/hibiki/lib/src/media/collections/collection_shelf_row.dart
@@ -4,6 +4,7 @@ import 'package:hibiki_core/hibiki_core.dart';
 
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/focus/hibiki_focus_target.dart';
+import 'package:hibiki/src/media/collections/collection_drag.dart';
 import 'package:hibiki/utils.dart';
 
 /// 统一合集 UI v2 Phase C：合集独占一行（Jellyfin/Netflix 行式布局）。
@@ -34,6 +35,7 @@ class CollectionShelfRow extends StatefulWidget {
     this.selectionCheckbox,
     this.onToggleSelected,
     this.onTagDropped,
+    this.onMediaDropped,
     this.tags,
     this.onContextMenu,
     super.key,
@@ -90,6 +92,11 @@ class CollectionShelfRow extends StatefulWidget {
   /// 手势一致；成员卡区各成员卡自带书级 drop target，与行头区不重叠）。null（默认）时
   /// 行头不接收拖放。合集详情页 AppBar 的打标签按钮是另一条等价入口。
   final void Function(BookTagRow tag)? onTagDropped;
+
+  /// 把**媒体卡**拖到行头 = 把该条目加入本合集（与 [onTagDropped] 的标签拖放并存，
+  /// 靠 payload 泛型分流：`MediaRef` 走这里、`BookTagRow` 走 [onTagDropped]，
+  /// 两个 DragTarget 互不误接）。null（默认）时行头不接收卡片拖放。
+  final void Function(MediaRef ref)? onMediaDropped;
 
   /// 该合集已打的标签（行头下方展示 chip 列，与书/视频卡的标签列同形）。null/空时
   /// 不占位。调用方 `ref.watch(collectionTagMapProvider)` 后传该合集的列表；打标签
@@ -307,6 +314,17 @@ class _CollectionShelfRowState extends State<CollectionShelfRow> {
     final void Function(BookTagRow tag)? onTagDropped = widget.onTagDropped;
     if (onTagDropped != null) {
       result = _wrapTagDropTarget(context, tokens, result, onTagDropped);
+    }
+    // 把媒体卡拖到行头 = 加入本合集。与上面的标签 DragTarget 嵌套并存，靠 payload
+    // 泛型分流（`MediaRef` vs `BookTagRow`），无运行时判别分支。
+    final void Function(MediaRef ref)? onMediaDropped = widget.onMediaDropped;
+    if (onMediaDropped != null) {
+      result = CollectionDropTarget(
+        onMediaDropped: onMediaDropped,
+        alignment: AlignmentDirectional.centerEnd,
+        borderRadius: tokens.radii.controlRadius,
+        child: result,
+      );
     }
     return result;
   }

--- a/hibiki/lib/src/media/collections/collection_shelf_row.dart
+++ b/hibiki/lib/src/media/collections/collection_shelf_row.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -152,17 +151,9 @@ class _CollectionShelfRowState extends State<CollectionShelfRow> {
           SizedBox(
             height: widget.rowHeight,
             // 桌面默认 MaterialScrollBehavior 的 dragDevices 不含鼠标——横排行用
-            // 鼠标左右拖会毫无反应（用户实报）。显式放开 mouse/trackpad/stylus
-            // 拖动；触屏行为不变。
-            child: ScrollConfiguration(
-              behavior: ScrollConfiguration.of(context).copyWith(
-                dragDevices: <PointerDeviceKind>{
-                  PointerDeviceKind.touch,
-                  PointerDeviceKind.mouse,
-                  PointerDeviceKind.stylus,
-                  PointerDeviceKind.trackpad,
-                },
-              ),
+            // 鼠标左右拖会毫无反应（用户实报）。共享件统一放开 mouse/trackpad/
+            // stylus 拖动；触屏行为不变。
+            child: HorizontalDragScrollable(
               child: ListView.separated(
                 controller: _controller,
                 scrollDirection: Axis.horizontal,

--- a/hibiki/lib/src/media/drag_drop/drop_classification.dart
+++ b/hibiki/lib/src/media/drag_drop/drop_classification.dart
@@ -69,6 +69,32 @@ const Set<String> kDragDictionaryExtensions = <String>{
   'mdx',
 };
 
+/// 漫画扩展名（不带点，小写）：**明确**的漫画载体，落点表面一见即知。
+///
+/// - `mokuro`：mokuro v0.2+ 的 OCR 结果文件（+ 同级图片），走 `MangaImporter`；
+/// - `cbz`：图片压缩包，走 `MangaArchiveImporter`。
+///
+/// 刻意**不含 `zip` / `epub`**：这两者要看包内容才知道是不是图片包
+/// （`MangaArchiveImporter.looksLikeImageArchive` 要真读包），而本文件是纯函数
+/// 分类层、不碰文件系统；且 `zip` 同时是词典包扩展名，无内容判据时把书架上拖入
+/// 的 Yomitan 词典 zip 当漫画导入是误判。图片型 zip/epub 仍可经导入对话框导入
+/// （对话框的分派会真读包），只是不由拖放分类层猜。
+const Set<String> kDragMangaExtensions = <String>{
+  'mokuro',
+  'cbz',
+};
+
+/// 看得出是漫画包、但当前**导入器不支持**的扩展名（不带点，小写）。
+///
+/// `archive` 包不解 RAR，故 cbr/cb7/rar 无法导入。单列一类只为一件事：让落点
+/// 给出明确的「不支持」提示，而不是归进 unknown 后静默无反应（用户实报「拖进去
+/// 一点反应都没有」）。
+const Set<String> kDragUnsupportedMangaExtensions = <String>{
+  'cbr',
+  'cb7',
+  'rar',
+};
+
 /// 音频扩展名（不带点，小写）。镜像 AudiobookStorage.audioExtensions（守卫测试钉死同步）。
 const Set<String> kDragAudioExtensions = <String>{
   'mp3',
@@ -97,6 +123,8 @@ class DroppedFiles {
     required this.dictionaries,
     required this.urls,
     required this.unknown,
+    this.mangas = const <String>[],
+    this.unsupportedMangas = const <String>[],
   });
 
   final List<String> books;
@@ -105,6 +133,15 @@ class DroppedFiles {
   final List<String> audios;
   final List<String> playlists;
   final List<String> dictionaries;
+
+  /// 漫画载体：`.mokuro` / `.cbz`，以及被 [classifyDroppedFiles] 的 `isDirectory`
+  /// 谓词判定为**目录**的路径（整目录页图导入，manga_importer 的
+  /// `importFromImageFolder` 路径）。
+  final List<String> mangas;
+
+  /// 认得出是漫画包但导入器不支持的（cbr/cb7/rar，见
+  /// [kDragUnsupportedMangaExtensions]）——落点据此给明确提示而非静默。
+  final List<String> unsupportedMangas;
 
   /// 拖入的可导入网络流 URL（http(s)，非文件路径）。浏览器地址栏/链接拖进来时，
   /// 原生（Windows CFSTR_INETURLW / macOS public.url / Linux text/uri-list）把 URL
@@ -122,7 +159,9 @@ class DroppedFiles {
       audios.isNotEmpty ||
       playlists.isNotEmpty ||
       dictionaries.isNotEmpty ||
-      urls.isNotEmpty;
+      urls.isNotEmpty ||
+      mangas.isNotEmpty ||
+      unsupportedMangas.isNotEmpty;
 }
 
 String _ext(String path) {
@@ -147,7 +186,15 @@ bool isImportableDropUrl(String candidate) {
 }
 
 /// 把拖入文件路径按扩展名分类。纯函数，无副作用。
-DroppedFiles classifyDroppedFiles(List<String> paths) {
+///
+/// [isDirectory] 是唯一的外注入判据：拖入的**目录**（漫画页图文件夹）没有扩展名，
+/// 纯扩展名分类无法与「无扩展名的文件」区分，而本函数不碰文件系统。调用方
+/// （widget 层）传 `(pth) => Directory(pth).existsSync()`，测试注入假谓词。
+/// 不传（默认 null）时行为与历史逐字节一致——目录会落进 [DroppedFiles.unknown]。
+DroppedFiles classifyDroppedFiles(
+  List<String> paths, {
+  bool Function(String path)? isDirectory,
+}) {
   final List<String> books = <String>[];
   final List<String> videos = <String>[];
   final List<String> subtitles = <String>[];
@@ -155,6 +202,8 @@ DroppedFiles classifyDroppedFiles(List<String> paths) {
   final List<String> playlists = <String>[];
   final List<String> dictionaries = <String>[];
   final List<String> urls = <String>[];
+  final List<String> mangas = <String>[];
+  final List<String> unsupportedMangas = <String>[];
   final List<String> unknown = <String>[];
 
   for (final String path in paths) {
@@ -164,8 +213,22 @@ DroppedFiles classifyDroppedFiles(List<String> paths) {
       urls.add(path.trim());
       continue;
     }
+    // 目录（漫画页图文件夹）：整目录导入一本漫画。放在扩展名分类之前——目录名
+    // 带点时（如 `第01巻.v2`）会被 p.extension 当成扩展名而误分类。
+    if (isDirectory != null && isDirectory(path)) {
+      mangas.add(path);
+      continue;
+    }
     final String ext = _ext(path);
     bool matched = false;
+    if (kDragMangaExtensions.contains(ext)) {
+      mangas.add(path);
+      matched = true;
+    }
+    if (kDragUnsupportedMangaExtensions.contains(ext)) {
+      unsupportedMangas.add(path);
+      matched = true;
+    }
     if (kDragBookExtensions.contains(ext)) {
       books.add(path);
       matched = true;
@@ -201,6 +264,8 @@ DroppedFiles classifyDroppedFiles(List<String> paths) {
     playlists: playlists,
     dictionaries: dictionaries,
     urls: urls,
+    mangas: mangas,
+    unsupportedMangas: unsupportedMangas,
     unknown: unknown,
   );
 }

--- a/hibiki/lib/src/media/drag_drop/drop_decision.dart
+++ b/hibiki/lib/src/media/drag_drop/drop_decision.dart
@@ -1,11 +1,25 @@
 import 'package:hibiki/src/media/drag_drop/drop_classification.dart';
 
 /// 拖拽落点所在的 tab 表面。
-enum DropSurface { books, video }
+///
+/// [manga] = 漫画库（`ReaderHibikiHistoryPage(mangaOnly: true)` 的壳）。它与
+/// [books] 共用同一个页面和同一份 drop target，但**语义不同**：漫画库拖入
+/// 非漫画的书文件没有意义（导进去也不显示在这个书架上，用户会以为丢了）。
+enum DropSurface { books, video, manga }
 
 /// 决策结果意图。widget 层据此打开对话框 / 提示 / 忽略。
 enum DropIntent {
   importNewBook,
+
+  /// 拖入 `.mokuro` / `.cbz` / 页图目录 → 导入一本漫画（`EpubBooks` 里
+  /// `format='manga'` 的行，第三种「书」）。books 与 manga 两个表面都产出它：
+  /// 漫画是书的一种，普通书架拖漫画包也该能导，不该静默。
+  importNewManga,
+
+  /// 拖入 cbr/cb7/rar → 认得出是漫画包，但 `archive` 包不解 RAR，导不了。
+  /// 单列一个意图只为给明确提示，不再静默无反应。
+  unsupportedMangaArchive,
+
   importNewVideo,
   importNewPlaylist,
 
@@ -35,6 +49,13 @@ DropIntent decideDropIntent({
 }) {
   switch (surface) {
     case DropSurface.books:
+      // 漫画载体优先于普通书文件：`.mokuro` 是 JSON、若先被 books 分支吃掉会被
+      // 当纯文本转成 EPUB（导入对话框内部也是漫画分支早退于 TextToEpub，同一道
+      // 理）。漫画是书的一种，普通书架拖漫画包照样导，不静默。
+      if (files.mangas.isNotEmpty) return DropIntent.importNewManga;
+      if (files.unsupportedMangas.isNotEmpty) {
+        return DropIntent.unsupportedMangaArchive;
+      }
       if (files.books.isNotEmpty) return DropIntent.importNewBook;
       // 拖字幕/音频到具体书卡 → 附加到那本书（含拖 .mp4 给书加音频）。视频判定放在
       // 其后，避免把「拖 mp4 到书卡挂音频」误判成新建视频。
@@ -50,6 +71,18 @@ DropIntent decideDropIntent({
       if (files.subtitles.isNotEmpty || files.audios.isNotEmpty) {
         return DropIntent.needCardTarget;
       }
+      if (files.hasAny) return DropIntent.unsupportedSurface;
+      return DropIntent.ignore;
+    case DropSurface.manga:
+      // 漫画库：漫画载体是主业。
+      if (files.mangas.isNotEmpty) return DropIntent.importNewManga;
+      if (files.unsupportedMangas.isNotEmpty) {
+        return DropIntent.unsupportedMangaArchive;
+      }
+      // 漫画库拖入普通书 / 视频 / 字幕等一律给「本页面不支持」提示，**不**沿用
+      // books 表面的自动切换：漫画库是漫画的地方，把 epub 悄悄导进另一个书架
+      // 会让用户以为文件丢了（导完这里什么也不多出来）。给提示而非静默，也不
+      // 替用户决定导去别处。
       if (files.hasAny) return DropIntent.unsupportedSurface;
       return DropIntent.ignore;
     case DropSurface.video:

--- a/hibiki/lib/src/media/drag_drop/drop_decision.dart
+++ b/hibiki/lib/src/media/drag_drop/drop_decision.dart
@@ -3,8 +3,9 @@ import 'package:hibiki/src/media/drag_drop/drop_classification.dart';
 /// 拖拽落点所在的 tab 表面。
 ///
 /// [manga] = 漫画库（`ReaderHibikiHistoryPage(mangaOnly: true)` 的壳）。它与
-/// [books] 共用同一个页面和同一份 drop target，但**语义不同**：漫画库拖入
-/// 非漫画的书文件没有意义（导进去也不显示在这个书架上，用户会以为丢了）。
+/// [books] 共用同一个页面和同一份 drop target；差别**只在漫画载体优先**，其余
+/// 一切（epub / 视频 / 字幕 / URL）行为与 [books] 完全一致（见 decideDropIntent
+/// 里的委托）——那是改动前就有的行为，不在此处收窄。
 enum DropSurface { books, video, manga }
 
 /// 决策结果意图。widget 层据此打开对话框 / 提示 / 忽略。
@@ -74,17 +75,26 @@ DropIntent decideDropIntent({
       if (files.hasAny) return DropIntent.unsupportedSurface;
       return DropIntent.ignore;
     case DropSurface.manga:
-      // 漫画库：漫画载体是主业。
+      // 漫画库：漫画载体是主业，优先判。
       if (files.mangas.isNotEmpty) return DropIntent.importNewManga;
       if (files.unsupportedMangas.isNotEmpty) {
         return DropIntent.unsupportedMangaArchive;
       }
-      // 漫画库拖入普通书 / 视频 / 字幕等一律给「本页面不支持」提示，**不**沿用
-      // books 表面的自动切换：漫画库是漫画的地方，把 epub 悄悄导进另一个书架
-      // 会让用户以为文件丢了（导完这里什么也不多出来）。给提示而非静默，也不
-      // 替用户决定导去别处。
-      if (files.hasAny) return DropIntent.unsupportedSurface;
-      return DropIntent.ignore;
+      // 其余（epub / 视频 / 字幕 / 音频 / URL）**原样沿用 books 表面的既有行为**。
+      //
+      // 这里曾改成一律回「本页面不支持」，理由是「把 epub 悄悄导进另一个书架，
+      // 用户会以为文件丢了」。但漫画库本就是书架页的 `mangaOnly` 壳、共用同一个
+      // drop target，改之前拖 epub 进来是**会自动导进普通书架的**——那是一项用户
+      // 可能一直在用的既有能力，移除它属于 break userspace。要不要改成「不支持」
+      // 是产品决定，在用户拍板前默认保持现状。
+      //
+      // 委托而不是抄一遍：books 分支后续任何演进（自动切视频导入、URL 流媒体、
+      // 拖字幕挂到书卡……）漫画库自动跟上，不会漂成两套。
+      return decideDropIntent(
+        surface: DropSurface.books,
+        files: files,
+        cardHit: cardHit,
+      );
     case DropSurface.video:
       if (files.urls.isNotEmpty) return DropIntent.importVideoUrl;
       if (files.playlists.isNotEmpty) return DropIntent.importNewPlaylist;

--- a/hibiki/lib/src/media/manga/manga_module.dart
+++ b/hibiki/lib/src/media/manga/manga_module.dart
@@ -42,6 +42,23 @@ abstract final class MangaModule {
   static bool isImageArchive(String path) =>
       MangaArchiveImporter.looksLikeImageArchive(path);
 
+  /// 整目录页图导入（拖入一个漫画文件夹的落地路径）。OCR blocks 留空，之后可由
+  /// 任一整卷引擎补齐——故 OCR 失败绝不会导致这本书消失。
+  static Future<String> importImageFolder({
+    required HibikiDatabase db,
+    required String path,
+    String? title,
+    DuplicateTitleCallback? onDuplicateTitle,
+    void Function(int done, int total)? onProgress,
+  }) =>
+      MangaImporter.importFromImageFolder(
+        db: db,
+        imageDirPath: path,
+        title: title,
+        onDuplicateTitle: onDuplicateTitle,
+        onProgress: onProgress,
+      );
+
   static Future<String> importArchive({
     required HibikiDatabase db,
     required String path,

--- a/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
+++ b/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
@@ -808,6 +808,12 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
             key: const ValueKey<String>('subtitle-waveform-hscroll'),
             controller: _scrollController,
             thumbVisibility: true,
+            // 刻意**不**包 HorizontalDragScrollable（其它横向滚动区都包了，放开
+            // 鼠标拖动滚动）：本区内的 cue strip 自带 onHorizontalDrag「拖字幕块
+            // 调延迟」，而 GestureDetector 的横拖不受 ScrollBehavior.dragDevices
+            // 约束——现在鼠标拖字幕块有效、拖空白无反应。放开滚动拖动会让两个
+            // HorizontalDragGestureRecognizer 进同一个手势竞技场，赌内层胜出去换
+            // 一点点便利，不值得（本区有常驻滚动条可拖）。
             child: SingleChildScrollView(
               controller: _scrollController,
               scrollDirection: Axis.horizontal,

--- a/hibiki/lib/src/media/video/video_control_layout_edit_overlay.dart
+++ b/hibiki/lib/src/media/video/video_control_layout_edit_overlay.dart
@@ -6,6 +6,7 @@ import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/media/video/video_control_customization.dart';
 import 'package:hibiki/src/media/video/video_control_item_presentation.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
+import 'package:hibiki/src/utils/misc/platform_utils.dart';
 
 class VideoControlLayoutEditOverlay extends StatefulWidget {
   const VideoControlLayoutEditOverlay({
@@ -253,43 +254,47 @@ class _VideoControlLayoutEditOverlayState
               children: <Widget>[
                 SizedBox(
                   height: 48,
-                  child: SingleChildScrollView(
-                    scrollDirection: Axis.horizontal,
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        Icon(
-                          Icons.dashboard_customize_outlined,
-                          size: 18,
-                          color: cs.primary,
-                        ),
-                        const SizedBox(width: 4),
-                        TextButton(
-                          onPressed: _cancelDraft,
-                          child: Text(t.dialog_cancel),
-                        ),
-                        const SizedBox(width: 2),
-                        FilledButton(
-                          onPressed: _saveDraft,
-                          child: Text(t.dialog_save),
-                        ),
-                        IconButton(
-                          tooltip: MaterialLocalizations.of(context)
-                              .closeButtonTooltip,
-                          icon: const Icon(Icons.close),
-                          onPressed: _cancelDraft,
-                        ),
-                        const SizedBox(width: 4),
-                        Text(
-                          t.video_control_palette_title,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                          style: theme.textTheme.titleSmall?.copyWith(
-                            color: cs.onSurface,
-                            fontWeight: FontWeight.w700,
+                  // 按钮工具条（取消/保存/标题），不含可拖 chip——放开鼠标拖动
+                  // 滚动不会与下方调色板的 Draggable 抢手势。
+                  child: HorizontalDragScrollable(
+                    child: SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          Icon(
+                            Icons.dashboard_customize_outlined,
+                            size: 18,
+                            color: cs.primary,
                           ),
-                        ),
-                      ],
+                          const SizedBox(width: 4),
+                          TextButton(
+                            onPressed: _cancelDraft,
+                            child: Text(t.dialog_cancel),
+                          ),
+                          const SizedBox(width: 2),
+                          FilledButton(
+                            onPressed: _saveDraft,
+                            child: Text(t.dialog_save),
+                          ),
+                          IconButton(
+                            tooltip: MaterialLocalizations.of(context)
+                                .closeButtonTooltip,
+                            icon: const Icon(Icons.close),
+                            onPressed: _cancelDraft,
+                          ),
+                          const SizedBox(width: 4),
+                          Text(
+                            t.video_control_palette_title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              color: cs.onSurface,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/hibiki/lib/src/media/video/video_subtitle_jump_panel.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_jump_panel.dart
@@ -1201,26 +1201,28 @@ class _VideoSubtitleJumpPanelState extends State<VideoSubtitleJumpPanel> {
           Row(
             children: <Widget>[
               Expanded(
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  child: SegmentedButton<VideoSubtitleListFilter>(
-                    showSelectedIcon: false,
-                    segments: VideoSubtitleListFilter.values
-                        .map(
-                          (VideoSubtitleListFilter filter) =>
-                              ButtonSegment<VideoSubtitleListFilter>(
-                            value: filter,
-                            label: Text(_filterLabel(filter)),
-                          ),
-                        )
-                        .toList(growable: false),
-                    selected: <VideoSubtitleListFilter>{_filter},
-                    onSelectionChanged: _setFilter,
-                    style: SegmentedButton.styleFrom(
-                      visualDensity: VisualDensity.compact,
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      padding: const EdgeInsets.symmetric(horizontal: 10),
-                      textStyle: TextStyle(fontSize: widget.fontSize - 1),
+                child: HorizontalDragScrollable(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: SegmentedButton<VideoSubtitleListFilter>(
+                      showSelectedIcon: false,
+                      segments: VideoSubtitleListFilter.values
+                          .map(
+                            (VideoSubtitleListFilter filter) =>
+                                ButtonSegment<VideoSubtitleListFilter>(
+                              value: filter,
+                              label: Text(_filterLabel(filter)),
+                            ),
+                          )
+                          .toList(growable: false),
+                      selected: <VideoSubtitleListFilter>{_filter},
+                      onSelectionChanged: _setFilter,
+                      style: SegmentedButton.styleFrom(
+                        visualDensity: VisualDensity.compact,
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                        padding: const EdgeInsets.symmetric(horizontal: 10),
+                        textStyle: TextStyle(fontSize: widget.fontSize - 1),
+                      ),
                     ),
                   ),
                 ),

--- a/hibiki/lib/src/pages/implementations/book_css_editor_page.dart
+++ b/hibiki/lib/src/pages/implementations/book_css_editor_page.dart
@@ -325,19 +325,21 @@ class _BookCssEditorPageState extends ConsumerState<BookCssEditorPage>
         ],
         bottom: SizedBox(
           height: tokens.spacing.card * 2.5,
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(
-              children: List.generate(_entries.length, (i) {
-                return Padding(
-                  padding: EdgeInsets.only(right: tokens.spacing.gap),
-                  child: HibikiSelectableChip(
-                    label: _tabLabel(i),
-                    selected: i == _selectedIndex,
-                    onSelected: (_) => _attemptSwitchTab(i),
-                  ),
-                );
-              }),
+          child: HorizontalDragScrollable(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: List.generate(_entries.length, (i) {
+                  return Padding(
+                    padding: EdgeInsets.only(right: tokens.spacing.gap),
+                    child: HibikiSelectableChip(
+                      label: _tabLabel(i),
+                      selected: i == _selectedIndex,
+                      onSelected: (_) => _attemptSwitchTab(i),
+                    ),
+                  );
+                }),
+              ),
             ),
           ),
         ),

--- a/hibiki/lib/src/pages/implementations/custom_fonts_page.dart
+++ b/hibiki/lib/src/pages/implementations/custom_fonts_page.dart
@@ -1105,9 +1105,12 @@ class _CustomFontsPageState extends BasePageState {
     HibikiToast.show(msg: t.custom_fonts_removed);
   }
 
+  /// [newIndex] 是**最终下标**（HibikiReorderableColumn 语义），不是 SDK
+  /// `ReorderableListView` 的「移除前下标」——故这里没有 `newIndex--` 修正。
+  /// 上/下移按钮同样按最终下标传（下移传 index+1）。
   void _onReorder(int oldIndex, int newIndex) {
+    if (oldIndex == newIndex) return;
     setState(() {
-      if (newIndex > oldIndex) newIndex--;
       final item = _fonts.removeAt(oldIndex);
       _fonts.insert(newIndex, item);
     });
@@ -1175,17 +1178,21 @@ class _CustomFontsPageState extends BasePageState {
                 title: t.custom_fonts_manage,
                 icon: Icons.format_size,
                 controlBelow: true,
-                trailing: ReorderableListView.builder(
-                  buildDefaultDragHandles: false,
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  padding: EdgeInsets.zero,
+                // 自实现的 HibikiReorderableColumn 而非 SDK ReorderableListView：
+                // 整棵树活在 HibikiAppUiScale 的 Transform.scale 之下，而 SDK 的
+                // _DragItemProxy 用「全局坐标 − overlay 原点」纯平移、不认祖先
+                // 缩放，「界面大小」非 100% 时拖拽浮层按 (1−s)×距离 漂移、缩小时
+                // 一拖即飞出屏幕（BUG-778 同根因，当时只修了合集与词典两条链路，
+                // 这里漏了）。原本就是 shrinkWrap + NeverScrollableScrollPhysics
+                //（外层滚动），与本组件语义一致。
+                trailing: HibikiReorderableColumn(
                   itemCount: _fonts.length,
+                  keyForIndex: (int index) =>
+                      ValueKey<String>('${_fonts[index].name}-$index'),
                   onReorder: _onReorder,
                   itemBuilder: (context, index) {
                     final CustomFontCatalogRow entry = _fonts[index];
                     return CustomFontCatalogTile(
-                      key: ValueKey('${entry.name}-$index'),
                       name: entry.name,
                       isFile: entry.isFile,
                       targets: entry.targets,
@@ -1195,7 +1202,7 @@ class _CustomFontsPageState extends BasePageState {
                           _toggleTarget(index, target),
                       onDelete: () => _removeFont(index),
                       onMoveUp: () => _onReorder(index, index - 1),
-                      onMoveDown: () => _onReorder(index, index + 2),
+                      onMoveDown: () => _onReorder(index, index + 1),
                     );
                   },
                 ),
@@ -1513,62 +1520,61 @@ class _CustomFontCatalogTileState extends State<CustomFontCatalogTile> {
         ),
       ),
     );
-    return HibikiReorderDragListener(
-      index: widget.index,
-      child: Padding(
-        padding: EdgeInsets.symmetric(
-          horizontal: cupertino ? 16 : 12,
-          vertical: 10,
-        ),
-        child: ConstrainedBox(
-          constraints: BoxConstraints(minHeight: cupertino ? 58 : 60),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Row(
-                children: [
-                  dragHandle,
-                  Expanded(
-                    child: Text(
-                      widget.name,
-                      style: titleStyle,
-                      overflow: TextOverflow.ellipsis,
-                      maxLines: 1,
-                    ),
+    // 不再自带拖拽监听：整行拖拽由外层 HibikiReorderableColumn 统一接管
+    //（它按输入设备分流起拖：鼠标按下即拖、触摸长按），行内容保持纯净。
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: cupertino ? 16 : 12,
+        vertical: 10,
+      ),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(minHeight: cupertino ? 58 : 60),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                dragHandle,
+                Expanded(
+                  child: Text(
+                    widget.name,
+                    style: titleStyle,
+                    overflow: TextOverflow.ellipsis,
+                    maxLines: 1,
                   ),
-                  SizedBox(width: tokens.spacing.gap),
-                  actions,
+                ),
+                SizedBox(width: tokens.spacing.gap),
+                actions,
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 2),
+              child: Text(
+                widget.isFile ? t.font_source_file : t.font_source_system,
+                style: subtitleStyle,
+                overflow: TextOverflow.ellipsis,
+                maxLines: 2,
+              ),
+            ),
+            SizedBox(height: tokens.spacing.gap),
+            rolesHeader,
+            if (_rolesExpanded) ...[
+              SizedBox(height: tokens.spacing.gap),
+              Wrap(
+                spacing: tokens.spacing.gap,
+                runSpacing: tokens.spacing.gap,
+                children: [
+                  for (final FontTarget target in FontTarget.values)
+                    FilterChip(
+                      label: Text(_targetLabel(target)),
+                      selected: widget.targets.contains(target),
+                      onSelected: (_) => widget.onTargetToggled(target),
+                    ),
                 ],
               ),
-              Padding(
-                padding: const EdgeInsets.only(top: 2),
-                child: Text(
-                  widget.isFile ? t.font_source_file : t.font_source_system,
-                  style: subtitleStyle,
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: 2,
-                ),
-              ),
-              SizedBox(height: tokens.spacing.gap),
-              rolesHeader,
-              if (_rolesExpanded) ...[
-                SizedBox(height: tokens.spacing.gap),
-                Wrap(
-                  spacing: tokens.spacing.gap,
-                  runSpacing: tokens.spacing.gap,
-                  children: [
-                    for (final FontTarget target in FontTarget.values)
-                      FilterChip(
-                        label: Text(_targetLabel(target)),
-                        selected: widget.targets.contains(target),
-                        onSelected: (_) => widget.onTargetToggled(target),
-                      ),
-                  ],
-                ),
-              ],
             ],
-          ),
+          ],
         ),
       ),
     );

--- a/hibiki/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -1089,56 +1089,58 @@ class _DictionaryDialogPageState extends BasePageState {
       ),
       child: LayoutBuilder(
         builder: (context, constraints) {
-          return SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: ConstrainedBox(
-              constraints: BoxConstraints(minWidth: constraints.maxWidth),
-              // Wrap as a single gamepad/keyboard focus stop (D-pad Left/Right
-              // cycles the category). A bare segmented button is a cluster of
-              // unregistered native buttons that the directional focus
-              // controller skips over to the dictionary tiles below.
-              child: HibikiAdjustableSegmented<DictionaryType>(
-                focusIdPrefix: 'dict-type',
-                values: const <DictionaryType>[
-                  DictionaryType.term,
-                  DictionaryType.kanji,
-                  DictionaryType.frequency,
-                  DictionaryType.pitch,
-                ],
-                selected: _selectedType,
-                onChanged: (DictionaryType value) {
-                  setState(() => _selectedType = value);
-                },
-                child: adaptiveSegmentedButton<DictionaryType>(
-                  context: context,
-                  segments: [
-                    ButtonSegment<DictionaryType>(
-                      value: DictionaryType.term,
-                      label: Text(t.dictionary_type_term),
-                      tooltip: t.dictionary_type_term,
-                    ),
-                    ButtonSegment<DictionaryType>(
-                      value: DictionaryType.kanji,
-                      label: Text(t.dictionary_section_kanji),
-                      tooltip: t.dictionary_section_kanji,
-                    ),
-                    ButtonSegment<DictionaryType>(
-                      value: DictionaryType.frequency,
-                      label: Text(t.dictionary_type_frequency),
-                      tooltip: t.dictionary_type_frequency,
-                    ),
-                    ButtonSegment<DictionaryType>(
-                      value: DictionaryType.pitch,
-                      label: Text(t.dictionary_type_pitch),
-                      tooltip: t.dictionary_type_pitch,
-                    ),
+          return HorizontalDragScrollable(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minWidth: constraints.maxWidth),
+                // Wrap as a single gamepad/keyboard focus stop (D-pad Left/Right
+                // cycles the category). A bare segmented button is a cluster of
+                // unregistered native buttons that the directional focus
+                // controller skips over to the dictionary tiles below.
+                child: HibikiAdjustableSegmented<DictionaryType>(
+                  focusIdPrefix: 'dict-type',
+                  values: const <DictionaryType>[
+                    DictionaryType.term,
+                    DictionaryType.kanji,
+                    DictionaryType.frequency,
+                    DictionaryType.pitch,
                   ],
-                  selected: {_selectedType},
-                  onSelectionChanged: (Set<DictionaryType> selection) {
-                    if (selection.isEmpty) return;
-                    setState(() => _selectedType = selection.first);
+                  selected: _selectedType,
+                  onChanged: (DictionaryType value) {
+                    setState(() => _selectedType = value);
                   },
-                  style: kSettingsSegmentedStyle,
+                  child: adaptiveSegmentedButton<DictionaryType>(
+                    context: context,
+                    segments: [
+                      ButtonSegment<DictionaryType>(
+                        value: DictionaryType.term,
+                        label: Text(t.dictionary_type_term),
+                        tooltip: t.dictionary_type_term,
+                      ),
+                      ButtonSegment<DictionaryType>(
+                        value: DictionaryType.kanji,
+                        label: Text(t.dictionary_section_kanji),
+                        tooltip: t.dictionary_section_kanji,
+                      ),
+                      ButtonSegment<DictionaryType>(
+                        value: DictionaryType.frequency,
+                        label: Text(t.dictionary_type_frequency),
+                        tooltip: t.dictionary_type_frequency,
+                      ),
+                      ButtonSegment<DictionaryType>(
+                        value: DictionaryType.pitch,
+                        label: Text(t.dictionary_type_pitch),
+                        tooltip: t.dictionary_type_pitch,
+                      ),
+                    ],
+                    selected: {_selectedType},
+                    onSelectionChanged: (Set<DictionaryType> selection) {
+                      if (selection.isEmpty) return;
+                      setState(() => _selectedType = selection.first);
+                    },
+                    style: kSettingsSegmentedStyle,
+                  ),
                 ),
               ),
             ),

--- a/hibiki/lib/src/pages/implementations/game_shared.dart
+++ b/hibiki/lib/src/pages/implementations/game_shared.dart
@@ -110,43 +110,45 @@ class GameSectionTabs extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: Row(
-        children: <Widget>[
-          HibikiSelectableChip(
-            label: t.game_dashboard,
-            leadingIcon: Icons.dashboard_outlined,
-            selected: selected == GameSection.dashboard,
-            focusId: HibikiFocusId('$focusIdPrefix-dashboard'),
-            onSelected: (_) => (onSelectDashboard ??
-                () => gameSectionNotifier.value = GameSection.dashboard)(),
-          ),
-          const SizedBox(width: 8),
-          HibikiSelectableChip(
-            label: t.game_library,
-            leadingIcon: Icons.sports_esports_outlined,
-            selected: selected == GameSection.library,
-            focusId: HibikiFocusId('$focusIdPrefix-library'),
-            onSelected: (_) => onSelectLibrary(),
-          ),
-          const SizedBox(width: 8),
-          HibikiSelectableChip(
-            label: t.game_capture_workbench,
-            leadingIcon: Icons.sensors_outlined,
-            selected: selected == GameSection.monitor,
-            focusId: HibikiFocusId('$focusIdPrefix-capture'),
-            onSelected: (_) => onSelectMonitor(),
-          ),
-          const SizedBox(width: 8),
-          HibikiSelectableChip(
-            label: t.game_diagnostics,
-            leadingIcon: Icons.monitor_heart_outlined,
-            selected: selected == GameSection.diagnostics,
-            focusId: HibikiFocusId('$focusIdPrefix-diagnostics'),
-            onSelected: (_) => onSelectDiagnostics(),
-          ),
-        ],
+    return HorizontalDragScrollable(
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: <Widget>[
+            HibikiSelectableChip(
+              label: t.game_dashboard,
+              leadingIcon: Icons.dashboard_outlined,
+              selected: selected == GameSection.dashboard,
+              focusId: HibikiFocusId('$focusIdPrefix-dashboard'),
+              onSelected: (_) => (onSelectDashboard ??
+                  () => gameSectionNotifier.value = GameSection.dashboard)(),
+            ),
+            const SizedBox(width: 8),
+            HibikiSelectableChip(
+              label: t.game_library,
+              leadingIcon: Icons.sports_esports_outlined,
+              selected: selected == GameSection.library,
+              focusId: HibikiFocusId('$focusIdPrefix-library'),
+              onSelected: (_) => onSelectLibrary(),
+            ),
+            const SizedBox(width: 8),
+            HibikiSelectableChip(
+              label: t.game_capture_workbench,
+              leadingIcon: Icons.sensors_outlined,
+              selected: selected == GameSection.monitor,
+              focusId: HibikiFocusId('$focusIdPrefix-capture'),
+              onSelected: (_) => onSelectMonitor(),
+            ),
+            const SizedBox(width: 8),
+            HibikiSelectableChip(
+              label: t.game_diagnostics,
+              leadingIcon: Icons.monitor_heart_outlined,
+              selected: selected == GameSection.diagnostics,
+              focusId: HibikiFocusId('$focusIdPrefix-diagnostics'),
+              onSelected: (_) => onSelectDiagnostics(),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -13,6 +13,8 @@ import 'package:hibiki/src/media/collections/collection_context_dialog.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart'
     show CollectionShelfRow;
+import 'package:hibiki/src/media/collections/collection_drag.dart'
+    show MediaCardDraggable;
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/media_cover_service.dart';
 import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
@@ -383,6 +385,32 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     if (!added || !mounted) return;
     await _loadCollectionMaps();
     _refresh();
+  }
+
+  /// 把游戏卡拖到合集行头 = 把该游戏加入本合集
+  /// （`CollectionShelfRow.onMediaDropped`）。
+  ///
+  /// `addToCollection` 幂等，但静默 no-op 对用户是「拖了没反应」——先查成员给
+  /// 「已在该合集」的明确提示，再落库；成功后走 [_addGameToCollection] 同款刷新。
+  Future<void> _addMediaToCollection(
+      int collectionId, MediaRef mediaRef) async {
+    final HibikiDatabase db = _appModel.database;
+    final List<MediaCollectionItemRow> items =
+        await db.getCollectionItems(collectionId);
+    final bool already = items.any(
+      (MediaCollectionItemRow it) =>
+          it.mediaType == mediaRef.dbMediaType &&
+          it.entryKey == mediaRef.entryKey,
+    );
+    if (already) {
+      HibikiToast.show(msg: t.collection_already_has_item);
+      return;
+    }
+    await db.addToCollection(collectionId, mediaRef.kind, mediaRef.entryKey);
+    if (!mounted) return;
+    await _loadCollectionMaps();
+    _refresh();
+    HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
   }
 
   /// 合集横排行折叠开关（游戏库独立偏好命名空间，见
@@ -992,6 +1020,10 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         collapsed: _appModel.prefsRepo.gamesCollapsedCollectionIds
             .contains(collection.id),
         onToggleCollapsed: () => _toggleCollectionCollapsed(collection.id),
+        // 拖游戏卡到行头 = 把该游戏加入本合集。游戏库此前完全没有拖放接线，
+        // 这是它的第一条（标签拖放仍未接，与书/视频的差异保持原样）。
+        onMediaDropped: (MediaRef mediaRef) =>
+            _addMediaToCollection(collection.id, mediaRef),
         itemBuilder: (BuildContext _, int i) =>
             _buildGameCard(group.items[i].payload),
       ),
@@ -1014,7 +1046,19 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   }
 
   /// 单张游戏卡（散卡网格与合集行内共用同一构造，回调全量接线）。
+  ///
+  /// 外层 [MediaCardDraggable] = 拖卡进合集的拖拽源（桌面端；游戏库本就只在
+  /// Windows 有实际使用场景）。合集行内的成员卡同样可拖——把成员从一个合集拖到
+  /// 另一个合集行头即多归属（合集成员是多对多，不是移动）。
   Widget _buildGameCard(GalgameEntry game) {
+    return MediaCardDraggable(
+      mediaRef: MediaRef(kind: MediaKind.game, entryKey: game.id),
+      label: game.displayName,
+      child: _buildGameCardBody(game),
+    );
+  }
+
+  Widget _buildGameCardBody(GalgameEntry game) {
     return _GameCard(
       game: game,
       sortLabel: galgameSortValueLabel(game, _view.sortField),

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -14,7 +14,7 @@ import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart'
     show CollectionShelfRow;
 import 'package:hibiki/src/media/collections/collection_drag.dart'
-    show MediaCardDraggable;
+    show CollectionAddOutcome, MediaCardDraggable, addMediaRefToCollection;
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/media_cover_service.dart';
 import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
@@ -390,24 +390,17 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   /// 把游戏卡拖到合集行头 = 把该游戏加入本合集
   /// （`CollectionShelfRow.onMediaDropped`）。
   ///
-  /// `addToCollection` 幂等，但静默 no-op 对用户是「拖了没反应」——先查成员给
-  /// 「已在该合集」的明确提示，再落库；成功后走 [_addGameToCollection] 同款刷新。
+  /// 「查成员 → 幂等提示 → 落库 → 失败提示」收口在 [addMediaRefToCollection]
+  /// （书架 / 视频库 / 游戏库同一份，且永不抛出——它挂在 `void` 回调上）；
+  /// 真写进去了才走 [_addGameToCollection] 同款刷新并报成功。
   Future<void> _addMediaToCollection(
       int collectionId, MediaRef mediaRef) async {
-    final HibikiDatabase db = _appModel.database;
-    final List<MediaCollectionItemRow> items =
-        await db.getCollectionItems(collectionId);
-    final bool already = items.any(
-      (MediaCollectionItemRow it) =>
-          it.mediaType == mediaRef.dbMediaType &&
-          it.entryKey == mediaRef.entryKey,
+    final CollectionAddOutcome outcome = await addMediaRefToCollection(
+      database: _appModel.database,
+      collectionId: collectionId,
+      mediaRef: mediaRef,
     );
-    if (already) {
-      HibikiToast.show(msg: t.collection_already_has_item);
-      return;
-    }
-    await db.addToCollection(collectionId, mediaRef.kind, mediaRef.entryKey);
-    if (!mounted) return;
+    if (outcome != CollectionAddOutcome.added || !mounted) return;
     await _loadCollectionMaps();
     _refresh();
     HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -2,7 +2,6 @@ import 'package:hibiki_dictionary/hibiki_dictionary.dart';
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:transparent_image/transparent_image.dart';
@@ -905,17 +904,9 @@ class _HomeDashboardPageState
     return SizedBox(
       height: _continueRowHeight(context, tokens),
       // 桌面默认 MaterialScrollBehavior 的 dragDevices 不含鼠标——横排行
-      // 用鼠标左右拖会毫无反应。显式放开 mouse/trackpad/stylus 拖动
+      // 用鼠标左右拖会毫无反应。共享件统一放开 mouse/trackpad/stylus 拖动
       // （与合集行 CollectionShelfRow 同款）；触屏行为不变。
-      child: ScrollConfiguration(
-        behavior: ScrollConfiguration.of(context).copyWith(
-          dragDevices: <PointerDeviceKind>{
-            PointerDeviceKind.touch,
-            PointerDeviceKind.mouse,
-            PointerDeviceKind.stylus,
-            PointerDeviceKind.trackpad,
-          },
-        ),
+      child: HorizontalDragScrollable(
         child: ListView.separated(
           scrollDirection: Axis.horizontal,
           physics: desktopAwareScrollPhysics(),

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -928,6 +928,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         );
       case DropIntent.importNewBook:
       case DropIntent.attachToBookCard:
+      // 漫画意图只由 books/manga 表面产出（video 表面不可能命中），列在此处
+      // 仅为穷尽 switch。
+      case DropIntent.importNewManga:
+      case DropIntent.unsupportedMangaArchive:
       case DropIntent.ignore:
         break;
     }

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -51,6 +51,7 @@ import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
 import 'package:hibiki/src/media/media_search_text.dart';
+import 'package:hibiki/src/media/collections/collection_drag.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart';
@@ -1683,6 +1684,30 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     await _loadLibraryMaps();
   }
 
+  /// 把视频卡拖到合集封面卡上 = 把该视频加入本合集（`CollectionDropTarget`）。
+  ///
+  /// `addToCollection` 幂等，但静默 no-op 对用户是「拖了没反应」——先查成员给
+  /// 「已在该合集」的明确提示，再落库；成功后走 [_loadLibraryMaps] 同款刷新。
+  Future<void> _addMediaToCollection(
+      int collectionId, MediaRef mediaRef) async {
+    final HibikiDatabase db = ref.read(appProvider).database;
+    final List<MediaCollectionItemRow> items =
+        await db.getCollectionItems(collectionId);
+    final bool already = items.any(
+      (MediaCollectionItemRow it) =>
+          it.mediaType == mediaRef.dbMediaType &&
+          it.entryKey == mediaRef.entryKey,
+    );
+    if (already) {
+      HibikiToast.show(msg: t.collection_already_has_item);
+      return;
+    }
+    await db.addToCollection(collectionId, mediaRef.kind, mediaRef.entryKey);
+    if (!mounted) return;
+    await _loadLibraryMaps();
+    HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
+  }
+
   Future<void> _editTags(VideoBookRow book) async {
     await Navigator.push(
       context,
@@ -2651,11 +2676,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
     // 选择态下禁用标签拖放命中（与散卡一致：避免选卡时误触拖标签）。
     if (_selectionMode) return card;
-    return BookDragTarget(
-      bookId: 'collection:${collection.id}',
-      onTagDropped: (BookTagRow tag) =>
-          _addTagToVideoCollection(collection.id, tag),
-      child: card,
+    // 视频合集是封面卡（不是 CollectionShelfRow 行头——`unified_collections_
+    // architecture_guard_test` 明令禁止视频页回退用行式布局），故接收端直接包在
+    // 卡上：拖视频卡落到合集封面 = 加入该合集。
+    return CollectionDropTarget(
+      onMediaDropped: (MediaRef mediaRef) =>
+          _addMediaToCollection(collection.id, mediaRef),
+      child: BookDragTarget(
+        bookId: 'collection:${collection.id}',
+        onTagDropped: (BookTagRow tag) =>
+            _addTagToVideoCollection(collection.id, tag),
+        child: card,
+      ),
     );
   }
 
@@ -3451,7 +3483,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           );
     return CardDropZone<VideoBookRow>(
       meta: book,
-      child: card,
+      // 拖卡进合集：拖拽源包在标签 drop target 外（这张卡既能被拖走、也能接住
+      // 落下的标签，泛型不同互不干扰）；多选态不建拖拽源。
+      child: MediaCardDraggable(
+        mediaRef: MediaRef(kind: MediaKind.video, entryKey: book.bookUid),
+        label: book.title,
+        enabled: !_selectionMode,
+        child: card,
+      ),
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -1690,24 +1690,17 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
 
   /// 把视频卡拖到合集封面卡上 = 把该视频加入本合集（`CollectionDropTarget`）。
   ///
-  /// `addToCollection` 幂等，但静默 no-op 对用户是「拖了没反应」——先查成员给
-  /// 「已在该合集」的明确提示，再落库；成功后走 [_loadLibraryMaps] 同款刷新。
+  /// 「查成员 → 幂等提示 → 落库 → 失败提示」收口在 [addMediaRefToCollection]
+  /// （书架 / 视频库 / 游戏库同一份，且永不抛出——它挂在 `void` 回调上）；
+  /// 真写进去了才走 [_loadLibraryMaps] 同款刷新并报成功。
   Future<void> _addMediaToCollection(
       int collectionId, MediaRef mediaRef) async {
-    final HibikiDatabase db = ref.read(appProvider).database;
-    final List<MediaCollectionItemRow> items =
-        await db.getCollectionItems(collectionId);
-    final bool already = items.any(
-      (MediaCollectionItemRow it) =>
-          it.mediaType == mediaRef.dbMediaType &&
-          it.entryKey == mediaRef.entryKey,
+    final CollectionAddOutcome outcome = await addMediaRefToCollection(
+      database: ref.read(appProvider).database,
+      collectionId: collectionId,
+      mediaRef: mediaRef,
     );
-    if (already) {
-      HibikiToast.show(msg: t.collection_already_has_item);
-      return;
-    }
-    await db.addToCollection(collectionId, mediaRef.kind, mediaRef.entryKey);
-    if (!mounted) return;
+    if (outcome != CollectionAddOutcome.added || !mounted) return;
     await _loadLibraryMaps();
     HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
   }

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -947,27 +947,19 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   /// 把媒体卡拖到书架合集行头 = 把该条目加入本合集
   /// （`CollectionShelfRow.onMediaDropped`）。
   ///
-  /// `addToCollection` 本身幂等（insertOrIgnore + 同事务清成员墓碑），但对用户
-  /// 而言静默 no-op 就是「拖了没反应」——故先查成员给「已在该合集」的明确提示，
-  /// 再落库。加入后按 [_addEpubToCollection] 同款刷新（重取分组映射 + 重绘）。
+  /// 「查成员 → 幂等提示 → 落库 → 失败提示」收口在 [addMediaRefToCollection]
+  /// （书架 / 视频库 / 游戏库同一份，且永不抛出——它挂在 `void` 回调上）；
+  /// 真写进去了才按 [_addEpubToCollection] 同款刷新（重取分组映射 + 重绘）。
   Future<void> _addMediaToCollection(
     int collectionId,
     MediaRef mediaRef,
   ) async {
-    final HibikiDatabase db = ref.read(appProvider).database;
-    final List<MediaCollectionItemRow> items =
-        await db.getCollectionItems(collectionId);
-    final bool already = items.any(
-      (MediaCollectionItemRow it) =>
-          it.mediaType == mediaRef.dbMediaType &&
-          it.entryKey == mediaRef.entryKey,
+    final CollectionAddOutcome outcome = await addMediaRefToCollection(
+      database: ref.read(appProvider).database,
+      collectionId: collectionId,
+      mediaRef: mediaRef,
     );
-    if (already) {
-      HibikiToast.show(msg: t.collection_already_has_item);
-      return;
-    }
-    await db.addToCollection(collectionId, mediaRef.kind, mediaRef.entryKey);
-    if (!mounted) return;
+    if (outcome != CollectionAddOutcome.added || !mounted) return;
     _shelfMapsFuture = _loadShelfMaps();
     _rebuild(() {});
     HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -44,6 +44,7 @@ import 'package:hibiki/src/media/metadata/book_cover_scrape_dialog.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
 import 'package:hibiki/src/media/media_search_text.dart';
+import 'package:hibiki/src/media/collections/collection_drag.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/series_shelf_card.dart';
@@ -943,6 +944,35 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     }
   }
 
+  /// 把媒体卡拖到书架合集行头 = 把该条目加入本合集
+  /// （`CollectionShelfRow.onMediaDropped`）。
+  ///
+  /// `addToCollection` 本身幂等（insertOrIgnore + 同事务清成员墓碑），但对用户
+  /// 而言静默 no-op 就是「拖了没反应」——故先查成员给「已在该合集」的明确提示，
+  /// 再落库。加入后按 [_addEpubToCollection] 同款刷新（重取分组映射 + 重绘）。
+  Future<void> _addMediaToCollection(
+    int collectionId,
+    MediaRef mediaRef,
+  ) async {
+    final HibikiDatabase db = ref.read(appProvider).database;
+    final List<MediaCollectionItemRow> items =
+        await db.getCollectionItems(collectionId);
+    final bool already = items.any(
+      (MediaCollectionItemRow it) =>
+          it.mediaType == mediaRef.dbMediaType &&
+          it.entryKey == mediaRef.entryKey,
+    );
+    if (already) {
+      HibikiToast.show(msg: t.collection_already_has_item);
+      return;
+    }
+    await db.addToCollection(collectionId, mediaRef.kind, mediaRef.entryKey);
+    if (!mounted) return;
+    _shelfMapsFuture = _loadShelfMaps();
+    _rebuild(() {});
+    HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
+  }
+
   /// 某媒体卡上挂的标签列：标签 map 为空 / 该 key 无标签都返回 null，否则渲染
   /// [_adaptiveTagColumn]。三种媒体（epub/srt/video）只差「watch 哪个标签 provider +
   /// key 类型」，故各 caller 自己 `ref.watch(provider).valueOrNull`（保响应式订阅）后
@@ -1462,6 +1492,9 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
         // 拖标签到行头 = 给整个合集打标签（与散书书级拖放一致）。
         onTagDropped: (BookTagRow tag) =>
             _addTagToCollection(collection.id, tag),
+        // 拖书卡到行头 = 把该书加入本合集（payload 泛型与标签互不误接）。
+        onMediaDropped: (MediaRef mediaRef) =>
+            _addMediaToCollection(collection.id, mediaRef),
         // 行头长按/右键 = 合集上下文菜单（统一三库页：打开/重命名/标签/删除）。
         onContextMenu: () => _showCollectionContextMenu(collection),
         // 行头下方展示该合集已打的标签 chip（与散书标签列同形）。
@@ -1864,6 +1897,12 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       dragBookId: bookKey,
       onTagDropped:
           bookKey == null ? null : (tag) => _addTagToBook(bookKey, tag),
+      // 拖卡进合集：EPUB / PDF / 漫画同为 EpubBooks 行，合集身份统一是
+      // (epub, bookKey)——漫画书架复用本卡，故一处接线两个书架都生效。
+      dragMediaRef: bookKey == null
+          ? null
+          : MediaRef(kind: MediaKind.epub, entryKey: bookKey),
+      dragLabel: displayTitleForBook(item: item, rawTitle: item.title),
       onTap: () async {
         final MediaSource source = item.getMediaSource(appModel: appModel);
         await appModel.openMedia(

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -934,17 +934,25 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     final ModalRoute<dynamic>? route = ModalRoute.of(context);
     if (route != null && !route.isCurrent) return;
 
-    final DroppedFiles files = classifyDroppedFiles(paths);
+    // 目录（漫画页图文件夹）没有扩展名，纯分类函数分不出来——把真实文件系统判据
+    // 注入进去（分类层本身仍不碰 IO）。
+    final DroppedFiles files = classifyDroppedFiles(
+      paths,
+      isDirectory: (String pth) => Directory(pth).existsSync(),
+    );
     debugPrint(
       '[hibiki-drop] [reader-shelf] classified '
       'books=${files.books.length} subtitles=${files.subtitles.length} '
       'audios=${files.audios.length} videos=${files.videos.length} '
+      'mangas=${files.mangas.length} '
+      'unsupportedMangas=${files.unsupportedMangas.length} '
       'dictionaries=${files.dictionaries.length} unknown=${files.unknown.length} '
       'global=$globalPosition',
     );
     final String? hitBookKey = _cardDropRegistry.hitTest(globalPosition);
+    // 漫画库是同一个页面的 mangaOnly 壳，但落点语义不同（见 DropSurface.manga）。
     final DropIntent intent = decideDropIntent(
-      surface: DropSurface.books,
+      surface: _mangaOnly ? DropSurface.manga : DropSurface.books,
       files: files,
       cardHit: hitBookKey != null,
     );
@@ -955,6 +963,22 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
           subtitlePath:
               files.subtitles.isNotEmpty ? files.subtitles.first : null,
           audioPaths: files.audios,
+        );
+      case DropIntent.importNewManga:
+        // 漫画（.mokuro / .cbz / 页图目录）走与书同一个导入对话框——它的导入分派
+        // 早已认得这几种载体（mokuro → MangaImporter、cbz/图片型 zip →
+        // MangaArchiveImporter、目录 → importFromImageFolder），拖入只负责把路径
+        // 预填进去，不重复一套导入逻辑。
+        _openBookImportPrefilled(
+          epubPath: files.mangas.first,
+          subtitlePath: null,
+        );
+      case DropIntent.unsupportedMangaArchive:
+        debugPrint(
+          '[hibiki-drop] [reader-shelf] intent=unsupportedMangaArchive',
+        );
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(t.drag_drop_manga_archive_unsupported)),
         );
       case DropIntent.attachToBookCard:
         _openAudiobookPrefilled(

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -73,6 +73,10 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
       dragBookId: srtBookId,
       onTagDropped:
           srtBookId == null ? null : (tag) => _addTagToSrtBook(srtBookId, tag),
+      // 拖卡进合集：SRT 的合集身份是 **uid**，不是上面打标签用的 int 主键
+      // `srtBookId`（`_addSrtToCollection` 同源）——两者不可混用。
+      dragMediaRef: MediaRef(kind: MediaKind.srt, entryKey: book.uid),
+      dragLabel: displayTitle,
       onTap: () => _openSrtBook(book),
       onLongPress: () =>
           _showSrtBookDialog(book, removeFromCollection: removeFromCollection),

--- a/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
@@ -207,6 +207,8 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
     String? selectionKey,
     Object? dragBookId,
     void Function(BookTagRow tag)? onTagDropped,
+    MediaRef? dragMediaRef,
+    String? dragLabel,
   }) {
     final bool selected =
         selectionKey != null && _selectedKeys.contains(selectionKey);
@@ -267,14 +269,25 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
       onLongPress: _selectionMode ? null : onLongPress,
       child: interactiveCard,
     );
-    if (dragBookId == null || onTagDropped == null || _selectionMode) {
-      return card;
+    Widget result = card;
+    if (dragBookId != null && onTagDropped != null && !_selectionMode) {
+      result = BookDragTarget(
+        bookId: dragBookId,
+        onTagDropped: onTagDropped,
+        child: result,
+      );
     }
-    return BookDragTarget(
-      bookId: dragBookId,
-      onTagDropped: onTagDropped,
-      child: card,
-    );
+    // 拖卡进合集：拖拽源包在标签 drop target **外面**——两者方向相反（这张卡既能
+    // 被拖走、也能接住落下的标签），泛型不同互不干扰；Draggable 只加 Listener，
+    // 不改变布局（`book_drag_target_layout_test.dart` 的等尺寸断言仍成立）。
+    if (dragMediaRef != null && !_selectionMode) {
+      result = MediaCardDraggable(
+        mediaRef: dragMediaRef,
+        label: dragLabel ?? '',
+        child: result,
+      );
+    }
+    return result;
   }
 
   /// 块2：合集行头整选勾选框（选=选中整个合集）。与散卡 [_bookCardShell] 的封面

--- a/hibiki/lib/src/pages/implementations/tag_filter_bar.dart
+++ b/hibiki/lib/src/pages/implementations/tag_filter_bar.dart
@@ -114,74 +114,80 @@ class _HibikiTagFilterBarState extends ConsumerState<HibikiTagFilterBar> {
           ),
         ),
       ),
-      child: ListView.separated(
-        scrollDirection: Axis.horizontal,
-        padding: EdgeInsets.symmetric(
-          horizontal: tokens.spacing.rowHorizontal,
-          vertical: tokens.spacing.gap * 0.75,
-        ),
-        itemCount: widget.tags.length + trailing.length,
-        separatorBuilder: (_, __) => SizedBox(width: tokens.spacing.gap * 0.75),
-        itemBuilder: (context, index) {
-          if (index >= widget.tags.length) {
-            return trailing[index - widget.tags.length];
-          }
-          final BookTagRow tag = widget.tags[index];
-          final bool isSelected = selectedIds.contains(tag.id);
-          if (widget.selectionMode) {
-            return _tagFilterChip(
-              tag: tag,
-              isSelected: isSelected,
-              isDimmed: false,
-              onTap: () => widget.onToggleFilter(tag.id),
-            );
-          }
-          return LongPressDraggable<BookTagRow>(
-            data: tag,
-            feedback: Material(
-              color: Colors.transparent,
-              elevation: 4,
-              shape: RoundedRectangleBorder(
-                borderRadius: tokens.radii.chipRadius,
-              ),
-              clipBehavior: Clip.antiAlias,
-              child: _tagFilterChip(
-                tag: tag,
-                isSelected: true,
-                isDimmed: false,
-              ),
-            ),
-            childWhenDragging: Opacity(
-              opacity: 0.3,
-              child: _tagFilterChip(
+      // 标签多了必须横向拖动才够用，而桌面默认 dragDevices 不含鼠标（拖不动，
+      // 只能滚轮）。放开鼠标拖动与区内标签 chip 的 LongPressDraggable 不冲突：
+      // 按下即动归滚动、按住不动满 kLongPressTimeout 归拖标签。
+      child: HorizontalDragScrollable(
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          padding: EdgeInsets.symmetric(
+            horizontal: tokens.spacing.rowHorizontal,
+            vertical: tokens.spacing.gap * 0.75,
+          ),
+          itemCount: widget.tags.length + trailing.length,
+          separatorBuilder: (_, __) =>
+              SizedBox(width: tokens.spacing.gap * 0.75),
+          itemBuilder: (context, index) {
+            if (index >= widget.tags.length) {
+              return trailing[index - widget.tags.length];
+            }
+            final BookTagRow tag = widget.tags[index];
+            final bool isSelected = selectedIds.contains(tag.id);
+            if (widget.selectionMode) {
+              return _tagFilterChip(
                 tag: tag,
                 isSelected: isSelected,
                 isDimmed: false,
+                onTap: () => widget.onToggleFilter(tag.id),
+              );
+            }
+            return LongPressDraggable<BookTagRow>(
+              data: tag,
+              feedback: Material(
+                color: Colors.transparent,
+                elevation: 4,
+                shape: RoundedRectangleBorder(
+                  borderRadius: tokens.radii.chipRadius,
+                ),
+                clipBehavior: Clip.antiAlias,
+                child: _tagFilterChip(
+                  tag: tag,
+                  isSelected: true,
+                  isDimmed: false,
+                ),
               ),
-            ),
-            child: DragTarget<BookTagRow>(
-              onWillAcceptWithDetails: (details) => details.data.id != tag.id,
-              onAcceptWithDetails: (details) {
-                final BookTagRow draggedTag = details.data;
-                final int oldIdx =
-                    widget.tags.indexWhere((t) => t.id == draggedTag.id);
-                final int newIdx =
-                    widget.tags.indexWhere((t) => t.id == tag.id);
-                if (oldIdx != -1 && newIdx != -1) {
-                  widget.onReorder(oldIdx, newIdx);
-                }
-              },
-              builder: (context, candidateData, rejectedData) {
-                return _tagFilterChip(
+              childWhenDragging: Opacity(
+                opacity: 0.3,
+                child: _tagFilterChip(
                   tag: tag,
                   isSelected: isSelected,
-                  isDimmed: candidateData.isNotEmpty,
-                  onTap: () => widget.onToggleFilter(tag.id),
-                );
-              },
-            ),
-          );
-        },
+                  isDimmed: false,
+                ),
+              ),
+              child: DragTarget<BookTagRow>(
+                onWillAcceptWithDetails: (details) => details.data.id != tag.id,
+                onAcceptWithDetails: (details) {
+                  final BookTagRow draggedTag = details.data;
+                  final int oldIdx =
+                      widget.tags.indexWhere((t) => t.id == draggedTag.id);
+                  final int newIdx =
+                      widget.tags.indexWhere((t) => t.id == tag.id);
+                  if (oldIdx != -1 && newIdx != -1) {
+                    widget.onReorder(oldIdx, newIdx);
+                  }
+                },
+                builder: (context, candidateData, rejectedData) {
+                  return _tagFilterChip(
+                    tag: tag,
+                    isSelected: isSelected,
+                    isDimmed: candidateData.isNotEmpty,
+                    onTap: () => widget.onToggleFilter(tag.id),
+                  );
+                },
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -4632,21 +4632,23 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
         alignment: slot == VideoControlSlot.topRight
             ? Alignment.centerRight
             : Alignment.centerLeft,
-        child: SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          reverse: slot == VideoControlSlot.topRight,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            mainAxisAlignment: slot == VideoControlSlot.topRight
-                ? MainAxisAlignment.end
-                : MainAxisAlignment.start,
-            children: <Widget>[
-              for (final VideoControlItem item in items)
-                if (item == VideoControlItem.title)
-                  _topBarInlineTitle(slot)
-                else
-                  buttonFor(item),
-            ],
+        child: HorizontalDragScrollable(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            reverse: slot == VideoControlSlot.topRight,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: slot == VideoControlSlot.topRight
+                  ? MainAxisAlignment.end
+                  : MainAxisAlignment.start,
+              children: <Widget>[
+                for (final VideoControlItem item in items)
+                  if (item == VideoControlItem.title)
+                    _topBarInlineTitle(slot)
+                  else
+                    buttonFor(item),
+              ],
+            ),
           ),
         ),
       ),

--- a/hibiki/lib/src/pages/implementations/video_shader_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/video_shader_dialog.dart
@@ -721,26 +721,29 @@ class VideoShaderTierSelector extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      padding: const EdgeInsets.symmetric(horizontal: 4),
-      child: SegmentedButton<VideoShaderTier>(
-        segments: <ButtonSegment<VideoShaderTier>>[
-          for (final VideoShaderTierSpec spec in kVideoShaderTiers)
-            ButtonSegment<VideoShaderTier>(
-              value: spec.tier,
-              label: Text(shaderTierLabel(spec.tier)),
-            ),
-        ],
-        selected:
-            current == null ? <VideoShaderTier>{} : <VideoShaderTier>{current!},
-        emptySelectionAllowed: true,
-        showSelectedIcon: false,
-        multiSelectionEnabled: false,
-        onSelectionChanged: (Set<VideoShaderTier> selection) {
-          if (selection.isEmpty) return;
-          onSelect(selection.first);
-        },
+    return HorizontalDragScrollable(
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 4),
+        child: SegmentedButton<VideoShaderTier>(
+          segments: <ButtonSegment<VideoShaderTier>>[
+            for (final VideoShaderTierSpec spec in kVideoShaderTiers)
+              ButtonSegment<VideoShaderTier>(
+                value: spec.tier,
+                label: Text(shaderTierLabel(spec.tier)),
+              ),
+          ],
+          selected: current == null
+              ? <VideoShaderTier>{}
+              : <VideoShaderTier>{current!},
+          emptySelectionAllowed: true,
+          showSelectedIcon: false,
+          multiSelectionEnabled: false,
+          onSelectionChanged: (Set<VideoShaderTier> selection) {
+            if (selection.isEmpty) return;
+            onSelect(selection.first);
+          },
+        ),
       ),
     );
   }

--- a/hibiki/lib/src/shortcuts/visual/gamepad_layout_view.dart
+++ b/hibiki/lib/src/shortcuts/visual/gamepad_layout_view.dart
@@ -6,6 +6,7 @@ import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
 import 'package:hibiki/src/shortcuts/visual/gamepad_button_widget.dart';
 import 'package:hibiki/src/shortcuts/visual/gamepad_glyphs.dart';
 import 'package:hibiki/src/shortcuts/visual/reverse_binding_index.dart';
+import 'package:hibiki/src/utils/misc/platform_utils.dart';
 
 /// 单个手柄按钮在整图上的纯数据描述（TODO-942）。
 ///
@@ -230,9 +231,11 @@ class GamepadLayoutView extends StatelessWidget {
           );
         }
         // 窄屏：固定理想宽 + 横向滚动兜底（照 KeyboardLayoutView 的窄屏模式）。
-        return SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: _buildFigure(context, index, specs, idealFigureWidth),
+        return HorizontalDragScrollable(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: _buildFigure(context, index, specs, idealFigureWidth),
+          ),
         );
       },
     );

--- a/hibiki/lib/src/shortcuts/visual/keyboard_layout_view.dart
+++ b/hibiki/lib/src/shortcuts/visual/keyboard_layout_view.dart
@@ -4,6 +4,7 @@ import 'package:hibiki/src/shortcuts/shortcut_action.dart';
 import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
 import 'package:hibiki/src/shortcuts/visual/key_cap_widget.dart';
 import 'package:hibiki/src/shortcuts/visual/reverse_binding_index.dart';
+import 'package:hibiki/src/utils/misc/platform_utils.dart';
 
 /// 键帽分区类型（TODO-942）。决定键帽的视觉分区色与是否可点。
 ///
@@ -304,10 +305,12 @@ class KeyboardLayoutView extends StatelessWidget {
           final double unit = fitUnit.clamp(minReadableUnit, 56.0);
           return _buildBoard(index, mainRows, navRows, unit, gap, blockGap);
         }
-        return SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child:
-              _buildBoard(index, mainRows, navRows, idealUnit, gap, blockGap),
+        return HorizontalDragScrollable(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child:
+                _buildBoard(index, mainRows, navRows, idealUnit, gap, blockGap),
+          ),
         );
       },
     );

--- a/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -290,9 +290,12 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
     await _persistUrls();
   }
 
+  /// [newIndex] 是**最终下标**（HibikiReorderableColumn 语义），不是 SDK
+  /// `ReorderableListView` 的「移除前下标」——故这里没有 `newIndex--` 修正。
+  /// 上/下移按钮同样按最终下标传（下移传 index+1）。
   Future<void> _reorderUrls(int oldIndex, int newIndex) async {
+    if (oldIndex == newIndex) return;
     setState(() {
-      if (newIndex > oldIndex) newIndex--;
       final List<HibikiClientUrl> copy = <HibikiClientUrl>[..._urls];
       final HibikiClientUrl item = copy.removeAt(oldIndex);
       copy.insert(newIndex, item);
@@ -349,11 +352,17 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
           if (_urls.isNotEmpty)
-            ReorderableListView.builder(
-              buildDefaultDragHandles: false,
-              shrinkWrap: true,
-              physics: const NeverScrollableScrollPhysics(),
+            // 自实现的 HibikiReorderableColumn 而非 SDK ReorderableListView：
+            // 整棵树活在 HibikiAppUiScale 的 Transform.scale 之下，而 SDK 的
+            // _DragItemProxy 用「全局坐标 − overlay 原点」纯平移、不认祖先缩放，
+            // 「界面大小」非 100% 时拖拽浮层按 (1−s)×距离 漂移、缩小时一拖即飞出
+            // 屏幕（BUG-778 同根因，当时只修了合集与词典两条链路，这里漏了）。
+            // 本组件把浮层渲染在列表自身 Stack、指针经 globalToLocal 消掉祖先
+            // 缩放，任意缩放系数下都精确跟手。原本就是 shrinkWrap +
+            // NeverScrollableScrollPhysics（外层滚动），与本组件语义一致。
+            HibikiReorderableColumn(
               itemCount: _urls.length,
+              keyForIndex: (int index) => ValueKey<String>(_urls[index].url),
               onReorder: _reorderUrls,
               itemBuilder: (BuildContext context, int index) {
                 final HibikiClientUrl u = _urls[index];
@@ -407,7 +416,7 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
                           size: 18,
                           tooltip: t.move_down,
                           enabled: index < _urls.length - 1,
-                          onTap: () => _reorderUrls(index, index + 2),
+                          onTap: () => _reorderUrls(index, index + 1),
                         ),
                         adaptiveSwitch(
                           context: context,

--- a/hibiki/lib/src/utils/components/hibiki_material_components.dart
+++ b/hibiki/lib/src/utils/components/hibiki_material_components.dart
@@ -1909,12 +1909,14 @@ class _HibikiPageHeaderRow extends StatelessWidget {
             ..add(
               ConstrainedBox(
                 constraints: BoxConstraints(maxWidth: maxActionsWidth),
-                child: SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  physics: const ClampingScrollPhysics(),
-                  child: HibikiHeaderLabelScope(
-                    expandLabels: expandLabels,
-                    child: actions!,
+                child: HorizontalDragScrollable(
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    physics: const ClampingScrollPhysics(),
+                    child: HibikiHeaderLabelScope(
+                      expandLabels: expandLabels,
+                      child: actions!,
+                    ),
                   ),
                 ),
               ),
@@ -2137,12 +2139,14 @@ class HibikiToolScaffold extends StatelessWidget {
                           ConstrainedBox(
                             constraints:
                                 BoxConstraints(maxWidth: maxActionsWidth),
-                            child: SingleChildScrollView(
-                              scrollDirection: Axis.horizontal,
-                              reverse: true,
-                              child: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: actions,
+                            child: HorizontalDragScrollable(
+                              child: SingleChildScrollView(
+                                scrollDirection: Axis.horizontal,
+                                reverse: true,
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: actions,
+                                ),
                               ),
                             ),
                           ),

--- a/hibiki/lib/src/utils/components/hibiki_reorder_drag_listener.dart
+++ b/hibiki/lib/src/utils/components/hibiki_reorder_drag_listener.dart
@@ -12,9 +12,17 @@ import 'package:flutter/material.dart';
 /// 旧代码对所有平台一律用 `ReorderableDelayedDragStartListener`，导致桌面端鼠标
 /// 也必须长按等待 ~500ms 才能拖动重排——本组件消除这个「所有平台都长按」的特例。
 ///
-/// 与本仓自实现的 [HibikiReorderableColumn] 不同：那个组件按**输入设备**区分
+/// 与本仓自实现的 `HibikiReorderableColumn` 不同：那个组件按**输入设备**区分
 /// （鼠标即时 / 触摸长按），因为它要在祖先 `Transform.scale` 下手搓拖拽坐标；
 /// 本组件服务于普通（未缩放）的 SDK `ReorderableListView`，沿用 SDK 的按平台范式即可。
+///
+/// ⚠️ **当前无调用方，新代码不要用它。** 上面那句「普通（未缩放）的
+/// `ReorderableListView`」在本 app 里**不成立**——`main.dart` 在应用根部套了
+/// `HibikiAppUiScale` 的 `Transform.scale`，全 app 没有未缩放的树，任何 SDK
+/// 重排组件的 Overlay 拖拽代理都会在「界面大小」非 100% 时漂移（BUG-778）。
+/// 最后两个调用方（`custom_fonts_page` 与互联设备排序）已改用
+/// `HibikiReorderableColumn`。保留本文件只为不破坏可能存在的外部引用；
+/// 守卫见 `test/widgets/reorderable_scale_safety_guard_test.dart`。
 class HibikiReorderDragListener extends StatelessWidget {
   const HibikiReorderDragListener({
     required this.index,

--- a/hibiki/lib/src/utils/components/hibiki_reorderable_column.dart
+++ b/hibiki/lib/src/utils/components/hibiki_reorderable_column.dart
@@ -87,6 +87,24 @@ class _HibikiReorderableColumnState extends State<HibikiReorderableColumn> {
   double _grabDy = 0; // 抓取点相对被拖行顶部的本地偏移
   final Map<int, double> _heights = <int, double>{}; // 原始 index → 行高
 
+  // ── 拖拽近视口边缘自动滚动（本列表常挂在 SingleChildScrollView 内，行数超一屏时
+  //    需能把浮层拖到视口外的槽位；此前缺这段，长列表里第 1 项**拖不到**第 30 项，
+  //    只能拖到当前可见范围的边界）。起拖时抓最近的祖先 [ScrollableState]，指针进入
+  //    视口上/下边缘带就按帧步进 [ScrollPosition.jumpTo]，滚动后用最近一次指针全局
+  //    坐标重跑 [_updateDrag]（`globalToLocal` 已消滚动位移，浮层/目标槽随内容自洽）。
+  //    无祖先 Scrollable（如离屏测试）时 [_scrollable] 为 null，整段降级为不滚动。
+  //    与 2D 姊妹件 [HibikiReorderableGrid] 同款实现。──
+  ScrollableState? _scrollable;
+  Offset _lastPointerGlobal = Offset.zero;
+  double _autoScrollStepSigned = 0; // 当前每帧步进（含方向）；0 = 不滚
+  bool _autoScrollScheduled = false;
+
+  /// 触发自动滚动的视口上/下边缘带宽（指针进入即滚）。
+  static const double _autoScrollEdge = 64.0;
+
+  /// 自动滚动每帧步进（像素）。
+  static const double _autoScrollStep = 16.0;
+
   @override
   void initState() {
     super.initState();
@@ -98,6 +116,7 @@ class _HibikiReorderableColumnState extends State<HibikiReorderableColumn> {
     super.didUpdateWidget(oldWidget);
     if (oldWidget.itemCount != widget.itemCount) {
       _resetDisplay();
+      _stopAutoScroll();
       _dragOriginal = null;
     }
   }
@@ -154,6 +173,8 @@ class _HibikiReorderableColumnState extends State<HibikiReorderableColumn> {
     final int di = _display.indexOf(original);
     final double top = _slotTop(di);
     final double localY = _localY(globalPosition);
+    _scrollable = context.findAncestorStateOfType<ScrollableState>();
+    _lastPointerGlobal = globalPosition;
     setState(() {
       _dragOriginal = original;
       _dragStartDi = di;
@@ -165,6 +186,8 @@ class _HibikiReorderableColumnState extends State<HibikiReorderableColumn> {
   void _updateDrag(Offset globalPosition) {
     final int? dragged = _dragOriginal;
     if (dragged == null) return;
+    _lastPointerGlobal = globalPosition;
+    _maybeAutoScroll(globalPosition);
     final double draggedH = _heightOf(dragged);
     final double maxTop = (_totalHeight - draggedH).clamp(0.0, double.infinity);
     final double newTop =
@@ -200,6 +223,7 @@ class _HibikiReorderableColumnState extends State<HibikiReorderableColumn> {
   void _endDrag() {
     final int? dragged = _dragOriginal;
     if (dragged == null) return;
+    _stopAutoScroll();
     final int from = _dragStartDi; // 起拖时的 display 下标（= 父列表中的起始位置）
     final int to = _display.indexOf(dragged);
     setState(() {
@@ -207,6 +231,64 @@ class _HibikiReorderableColumnState extends State<HibikiReorderableColumn> {
       _display = List<int>.generate(widget.itemCount, (int i) => i);
     });
     if (to != from) widget.onReorder(from, to);
+  }
+
+  /// 指针近视口边缘则设定本帧步进并驱动帧循环；离开边缘带 / 到滚动界则停。
+  void _maybeAutoScroll(Offset globalPosition) {
+    final ScrollableState? sc = _scrollable;
+    if (sc == null || !sc.mounted) {
+      _autoScrollStepSigned = 0;
+      return;
+    }
+    final RenderObject? ro = sc.context.findRenderObject();
+    if (ro is! RenderBox || !ro.hasSize) {
+      _autoScrollStepSigned = 0;
+      return;
+    }
+    // 仅纵向 Scrollable 参与（横向祖先误滚防御）。
+    if (sc.position.axis != Axis.vertical) {
+      _autoScrollStepSigned = 0;
+      return;
+    }
+    final ScrollPosition pos = sc.position;
+    // 完整变换取**屏幕**矩形：本组件运行在 HibikiAppUiScale 的祖先缩放之下
+    //（BUG-778），`localToGlobal(zero) & size` 把缩放后的原点和未缩放的布局
+    // 尺寸混拼——scale<1 时底边高估、边缘带够不到（自动滚动失效），scale>1
+    // 时边缘带侵入视口中部（误触发）。transformRect 连尺寸一起过变换。
+    final Rect viewport = MatrixUtils.transformRect(
+        ro.getTransformTo(null), Offset.zero & ro.size);
+    double step = 0;
+    if (globalPosition.dy < viewport.top + _autoScrollEdge &&
+        pos.pixels > pos.minScrollExtent) {
+      step = -_autoScrollStep;
+    } else if (globalPosition.dy > viewport.bottom - _autoScrollEdge &&
+        pos.pixels < pos.maxScrollExtent) {
+      step = _autoScrollStep;
+    }
+    _autoScrollStepSigned = step;
+    if (step != 0 && !_autoScrollScheduled) {
+      _autoScrollScheduled = true;
+      WidgetsBinding.instance.addPostFrameCallback(_autoScrollTick);
+    }
+  }
+
+  /// 帧回调：滚动一步 → 用最近一次指针坐标重跑拖拽（浮层/目标槽随内容自洽）→
+  /// 重新评估边缘带决定是否续帧。拖拽已结束 / 已 unmount / 已到滚动界即停。
+  void _autoScrollTick(Duration _) {
+    _autoScrollScheduled = false;
+    if (!mounted || _dragOriginal == null || _autoScrollStepSigned == 0) return;
+    final ScrollableState? sc = _scrollable;
+    if (sc == null || !sc.mounted) return;
+    final ScrollPosition pos = sc.position;
+    final double next = (pos.pixels + _autoScrollStepSigned)
+        .clamp(pos.minScrollExtent, pos.maxScrollExtent);
+    if (next != pos.pixels) pos.jumpTo(next);
+    _updateDrag(_lastPointerGlobal);
+  }
+
+  void _stopAutoScroll() {
+    _autoScrollStepSigned = 0;
+    _scrollable = null;
   }
 
   @override
@@ -255,6 +337,7 @@ class _HibikiReorderableColumnState extends State<HibikiReorderableColumn> {
   /// 区分，避免取消时误提交一次重排；并守 mounted 防 dispose 期 setState。
   void _cancelDrag() {
     if (_dragOriginal == null) return;
+    _stopAutoScroll();
     if (!mounted) {
       _dragOriginal = null;
       return;

--- a/hibiki/lib/src/utils/components/settings_shared.dart
+++ b/hibiki/lib/src/utils/components/settings_shared.dart
@@ -1110,9 +1110,14 @@ class HibikiSegmentedStrip<T extends Object> extends StatelessWidget {
         );
         final bool fits = available.isFinite && estimated <= available;
         if (fits) return Align(alignment: alignment, child: strip);
-        return SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: strip,
+        // 与上面 [_SegmentedStripHost] 同一契约：装不下就横向滚动，且桌面端要能用
+        // 鼠标左键拖着滚（默认 dragDevices 不含 mouse，否则只有滚轮能动）。段内
+        // 只有点击目标、没有横拖手势，不存在竞技场之争。
+        return HorizontalDragScrollable(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: strip,
+          ),
         );
       },
     );

--- a/hibiki/lib/src/utils/components/settings_shared.dart
+++ b/hibiki/lib/src/utils/components/settings_shared.dart
@@ -10,6 +10,7 @@ import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
 import 'package:hibiki/src/utils/adaptive/adaptive_widgets.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 import 'package:hibiki/src/utils/components/hibiki_dropdown.dart';
+import 'package:hibiki/src/utils/misc/platform_utils.dart';
 import 'package:hibiki/src/utils/components/hibiki_focusable.dart';
 import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
 import 'package:hibiki/src/utils/components/hibiki_option_selection_page.dart';
@@ -1002,9 +1003,11 @@ class _SegmentedStripHost extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Widget scrolling = SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: strip,
+    final Widget scrolling = HorizontalDragScrollable(
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: strip,
+      ),
     );
 
     // Inline strips never stretch (they would crowd the label); keep the old

--- a/hibiki/lib/src/utils/misc/platform_utils.dart
+++ b/hibiki/lib/src/utils/misc/platform_utils.dart
@@ -1,5 +1,6 @@
 import 'dart:io' show Platform;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:hibiki/src/utils/app_ui_scale.dart';
@@ -63,6 +64,39 @@ ScrollPhysics desktopAwareScrollPhysics() {
   return md3Desktop
       ? const AlwaysScrollableScrollPhysics(parent: ClampingScrollPhysics())
       : const AlwaysScrollableScrollPhysics(parent: BouncingScrollPhysics());
+}
+
+/// 让**横向**滚动区接受鼠标 / 触控板 / 触笔的拖动滚动。
+///
+/// Flutter 桌面的默认 `MaterialScrollBehavior.dragDevices` 不含
+/// [PointerDeviceKind.mouse]：横排合集行、标签筛选栏、分段按钮条这类横向滚动区，
+/// 用鼠标左键按住左右拖会**毫无反应**（用户实报），只能靠滚轮。这里显式放开鼠标 /
+/// 触控板 / 触笔拖动，触屏行为不变。
+///
+/// 只包横向滚动区，**刻意不做成全局 `MaterialApp.scrollBehavior`**：垂直网格若
+/// 也放开鼠标拖动滚动，会与卡片拖拽（`MediaCardDraggable` 里的 [Draggable]）抢
+/// 手势竞技场，把「拖卡进合集」变成「拖动网格滚动」。横向区没有这个冲突——横拖
+/// 归滚动、纵拖归拖卡，两者都要过 `kTouchSlop`、方向先满足者胜，正好是自然分工。
+///
+/// 同理，区内若有 `LongPressDraggable`（标签 chip）也不冲突：按下即动归滚动、
+/// 按住不动满 `kLongPressTimeout` 归拖拽。
+class HorizontalDragScrollable extends StatelessWidget {
+  const HorizontalDragScrollable({required this.child, super.key});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => ScrollConfiguration(
+        behavior: ScrollConfiguration.of(context).copyWith(
+          dragDevices: const <PointerDeviceKind>{
+            PointerDeviceKind.touch,
+            PointerDeviceKind.mouse,
+            PointerDeviceKind.stylus,
+            PointerDeviceKind.trackpad,
+          },
+        ),
+        child: child,
+      );
 }
 
 enum WindowSizeClass { compact, medium, expanded }

--- a/hibiki/test/media/collection_add_failure_test.dart
+++ b/hibiki/test/media/collection_add_failure_test.dart
@@ -1,0 +1,150 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'package:hibiki/src/media/collections/collection_drag.dart';
+import 'package:hibiki/utils.dart';
+
+/// 「拖进合集」落库失败必须给用户明确提示，**不得静默**。
+///
+/// 根因背景：书架 / 视频库 / 游戏库三处 `_addMediaToCollection` 各抄一遍
+/// 「查成员 → 幂等提示 → 落库」，都没有 try/catch，又都以 unawaited Future 挂在
+/// `CollectionDropTarget.onMediaDropped` 这个 `void` 回调上。`addToCollection`
+/// 抛出时异常直接漂进 zone，用户看到的只是「拖了没反应」——他会以为加成功了，
+/// 而合集里其实什么都没有，随后基于这个错误信息做决定（不再重试、以为已归类）。
+///
+/// 收口成 [addMediaRefToCollection] 之后本套用例钉三条结局各自的可见后果，
+/// 其中 failed 这条就是上面那个缺陷的回归守卫。
+void main() {
+  const MediaRef bookRef = MediaRef(kind: MediaKind.epub, entryKey: 'book-key');
+  const int collectionId = 1;
+
+  Future<HibikiDatabase> openDb() async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(() async {
+      try {
+        await db.close();
+      } catch (_) {
+        // 用例里可能已经关过（模拟失败那条），重复 close 无害。
+      }
+    });
+    return db;
+  }
+
+  test('落库失败 → 返回 failed、给出明确提示，且函数本身不抛', () async {
+    final _FailingWriteDatabase db = _FailingWriteDatabase();
+    addTearDown(db.close);
+
+    final List<String> messages = <String>[];
+    late final CollectionAddOutcome outcome;
+    // 不抛是硬要求：调用点是 void 回调，抛出去就等于静默。
+    await expectLater(
+      () async {
+        outcome = await addMediaRefToCollection(
+          database: db,
+          collectionId: collectionId,
+          mediaRef: bookRef,
+          notify: messages.add,
+        );
+      }(),
+      completes,
+    );
+
+    expect(outcome, CollectionAddOutcome.failed);
+    expect(
+      await db.getCollectionItems(collectionId),
+      isEmpty,
+      reason: '失败就是没写进去——提示必须与真实落库结果一致',
+    );
+    expect(
+      messages,
+      <String>[t.collection_add_failed],
+      reason: '落库失败必须让用户看到——静默失败会让他以为已经加进合集了',
+    );
+  });
+
+  test('首次加入 → 返回 added，且不抢调用方的成功提示', () async {
+    final HibikiDatabase db = await openDb();
+    final List<String> messages = <String>[];
+
+    final CollectionAddOutcome outcome = await addMediaRefToCollection(
+      database: db,
+      collectionId: collectionId,
+      mediaRef: bookRef,
+      notify: messages.add,
+    );
+
+    expect(outcome, CollectionAddOutcome.added);
+    expect(messages, isEmpty, reason: '成功提示由调用方在刷新后报，此处不得抢发');
+    final List<MediaCollectionItemRow> items =
+        await db.getCollectionItems(collectionId);
+    expect(items.map((MediaCollectionItemRow it) => it.entryKey), <String>[
+      bookRef.entryKey,
+    ]);
+  });
+
+  test('重复拖入 → 返回 alreadyPresent 并提示（幂等 no-op 不得静默）', () async {
+    final HibikiDatabase db = await openDb();
+    await db.addToCollection(collectionId, bookRef.kind, bookRef.entryKey);
+    final List<String> messages = <String>[];
+
+    final CollectionAddOutcome outcome = await addMediaRefToCollection(
+      database: db,
+      collectionId: collectionId,
+      mediaRef: bookRef,
+      notify: messages.add,
+    );
+
+    expect(outcome, CollectionAddOutcome.alreadyPresent);
+    expect(messages, <String>[t.collection_already_has_item]);
+  });
+
+  test('三个库页都必须走这一份编排，不得再各自裸调 addToCollection', () {
+    const List<String> pages = <String>[
+      'lib/src/pages/implementations/reader_hibiki_history_page.dart',
+      'lib/src/pages/implementations/home_video_page.dart',
+      'lib/src/pages/implementations/games_library_page.dart',
+    ];
+    for (final String path in pages) {
+      final String source = _readSource(path);
+      final int start = source.indexOf('Future<void> _addMediaToCollection(');
+      expect(start, isNonNegative, reason: '$path 里找不到 _addMediaToCollection');
+      final String body = source.substring(
+        start,
+        source.indexOf('\n  }', start) + 4,
+      );
+      expect(
+        body,
+        contains('addMediaRefToCollection('),
+        reason: '$path 的拖入合集必须走共享编排（内含 try/catch + 失败提示）',
+      );
+      expect(
+        body,
+        isNot(contains('.addToCollection(')),
+        reason: '$path 不得绕过共享编排裸调 DAO——那正是失败静默的老路',
+      );
+    }
+  });
+}
+
+/// 写入必失败的库：只让 `addToCollection` 抛（读成员照常成功），精确复现
+/// 「查得到、写不进」这条真实故障面（DB 锁 / 磁盘满 / 约束冲突）。
+class _FailingWriteDatabase extends HibikiDatabase {
+  _FailingWriteDatabase() : super.forTesting(NativeDatabase.memory());
+
+  @override
+  Future<void> addToCollection(
+    int collectionId,
+    MediaKind mediaType,
+    String entryKey,
+  ) async {
+    throw StateError('simulated collection write failure');
+  }
+}
+
+/// 测试进程的工作目录是 `hibiki/`，故这里用仓内相对路径。
+String _readSource(String relativePath) =>
+    File(relativePath).readAsStringSync();

--- a/hibiki/test/media/collection_media_drop_test.dart
+++ b/hibiki/test/media/collection_media_drop_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'package:hibiki/src/media/collections/collection_drag.dart';
+import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
+
+/// 「拖进合集直接自动分配进这个合集」：媒体卡拖到合集行头 / 合集封面卡即加入该合集。
+///
+/// 守卫三件事：
+/// 1. 行头接收 `MediaRef` 拖放并回调（漏接线时不建 DragTarget，防退回静默）；
+/// 2. **两条拖放通道靠泛型分流互不误接**——拖 `MediaRef` 不得触发 `onTagDropped`、
+///    拖 `BookTagRow` 不得触发 `onMediaDropped`。这是「行头同时挂两个 DragTarget」
+///    这个设计的正确性核心，也是不复用 `DragTarget<BookTagRow>` 的原因；
+/// 3. [MediaCardDraggable] 的按平台分流：桌面建 [Draggable]（按下即拖，与卡片既有
+///    tap/longPress 零冲突），触屏不建拖拽源（长按已被上下文菜单占用）。
+///
+/// 纯 widget 层，不开 DB。
+void main() {
+  const MediaRef bookRef = MediaRef(kind: MediaKind.epub, entryKey: 'book-key');
+  const BookTagRow tag = BookTagRow(
+    id: 7,
+    name: 'お気に入り',
+    colorValue: 0xFF2196F3,
+    sortOrder: 0,
+    createdAt: 0,
+  );
+
+  Future<void> pump(WidgetTester tester, CollectionShelfRow row) async {
+    tester.view.physicalSize = const Size(800, 600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          // 非滚动 Column：避免外层竖直滚动手势与 Draggable 抢手势竞技场，
+          // 导致 moveBy 被当滚动吞掉（同 collection_shelf_row_tag_drop_test）。
+          body: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Draggable<MediaRef>(
+                data: bookRef,
+                feedback: const SizedBox(
+                  key: ValueKey<String>('media_feedback'),
+                  width: 40,
+                  height: 20,
+                ),
+                // 有颜色的 Container 才参与命中测试（裸 SizedBox 透明）。
+                child: Container(
+                  key: const ValueKey<String>('media_handle'),
+                  width: 40,
+                  height: 20,
+                  color: const Color(0xFF4CAF50),
+                ),
+              ),
+              Draggable<BookTagRow>(
+                data: tag,
+                feedback: const SizedBox(
+                  key: ValueKey<String>('tag_feedback'),
+                  width: 40,
+                  height: 20,
+                ),
+                child: Container(
+                  key: const ValueKey<String>('tag_handle'),
+                  width: 40,
+                  height: 20,
+                  color: const Color(0xFF2196F3),
+                ),
+              ),
+              row,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  CollectionShelfRow buildRow({
+    void Function(MediaRef ref)? onMediaDropped,
+    void Function(BookTagRow tag)? onTagDropped,
+  }) =>
+      CollectionShelfRow(
+        title: 'コレクション',
+        countLabel: '3',
+        itemCount: 1,
+        itemWidth: 200,
+        rowHeight: 160,
+        onOpenDetail: () {},
+        onMediaDropped: onMediaDropped,
+        onTagDropped: onTagDropped,
+        itemBuilder: (BuildContext _, int __) => const Text('EP0'),
+      );
+
+  /// 从 [handleKey] 起拖，落到行头标题上。
+  Future<void> dragOntoHeader(WidgetTester tester, String handleKey) async {
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(ValueKey<String>(handleKey))),
+    );
+    await tester.pump();
+    // 先小步移动启动拖拽（recognizer 需一次超过 slop 的移动才 onStart）。
+    await gesture.moveBy(const Offset(0, 30));
+    await tester.pump();
+    await gesture.moveTo(tester.getCenter(find.text('コレクション')));
+    await tester.pump();
+    await gesture.up();
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('把媒体卡拖到合集行头触发 onMediaDropped（自动加入该合集）',
+      (WidgetTester tester) async {
+    MediaRef? dropped;
+    await pump(
+      tester,
+      buildRow(onMediaDropped: (MediaRef r) => dropped = r),
+    );
+
+    await dragOntoHeader(tester, 'media_handle');
+
+    expect(dropped, isNotNull, reason: '行头必须接收媒体卡拖放');
+    expect(dropped, bookRef, reason: '回调必须收到被拖条目的 (kind, entryKey)');
+  });
+
+  testWidgets('onMediaDropped 非 null 时行头是 DragTarget<MediaRef>',
+      (WidgetTester tester) async {
+    await pump(tester, buildRow(onMediaDropped: (_) {}));
+    expect(find.byType(DragTarget<MediaRef>), findsOneWidget);
+  });
+
+  testWidgets('onMediaDropped 为 null 时行头不建 DragTarget（守卫调用点漏接线退回静默）',
+      (WidgetTester tester) async {
+    await pump(tester, buildRow(onMediaDropped: null));
+    expect(find.byType(DragTarget<MediaRef>), findsNothing);
+  });
+
+  testWidgets('两条拖放通道靠泛型分流：拖媒体卡不触发 onTagDropped', (WidgetTester tester) async {
+    MediaRef? droppedMedia;
+    BookTagRow? droppedTag;
+    await pump(
+      tester,
+      buildRow(
+        onMediaDropped: (MediaRef r) => droppedMedia = r,
+        onTagDropped: (BookTagRow t) => droppedTag = t,
+      ),
+    );
+
+    await dragOntoHeader(tester, 'media_handle');
+
+    expect(droppedMedia, bookRef, reason: '媒体通道必须收到');
+    expect(droppedTag, isNull, reason: '标签通道绝不能被媒体拖放误触发');
+  });
+
+  testWidgets('两条拖放通道靠泛型分流：拖标签不触发 onMediaDropped', (WidgetTester tester) async {
+    MediaRef? droppedMedia;
+    BookTagRow? droppedTag;
+    await pump(
+      tester,
+      buildRow(
+        onMediaDropped: (MediaRef r) => droppedMedia = r,
+        onTagDropped: (BookTagRow t) => droppedTag = t,
+      ),
+    );
+
+    await dragOntoHeader(tester, 'tag_handle');
+
+    expect(droppedTag, isNotNull, reason: '标签通道必须收到');
+    expect(droppedMedia, isNull, reason: '媒体通道绝不能被标签拖放误触发');
+  });
+
+  group('MediaCardDraggable 按平台分流', () {
+    Future<void> pumpCard(
+      WidgetTester tester,
+      TargetPlatform platform, {
+      bool enabled = true,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(platform: platform),
+          home: Scaffold(
+            body: MediaCardDraggable(
+              mediaRef: bookRef,
+              label: '書名',
+              enabled: enabled,
+              child: const SizedBox(width: 40, height: 40),
+            ),
+          ),
+        ),
+      );
+    }
+
+    for (final TargetPlatform platform in <TargetPlatform>[
+      TargetPlatform.windows,
+      TargetPlatform.linux,
+      TargetPlatform.macOS,
+    ]) {
+      testWidgets('$platform 建 Draggable（按下即拖，不与长按菜单抢手势）',
+          (WidgetTester tester) async {
+        await pumpCard(tester, platform);
+        expect(find.byType(Draggable<MediaRef>), findsOneWidget);
+        // 必须**不是** LongPressDraggable：卡片长按已绑定上下文菜单，
+        // 长按拖拽会被 InkWell.onLongPress 抢走，拖拽永远起不来。
+        expect(find.byType(LongPressDraggable<MediaRef>), findsNothing);
+      });
+    }
+
+    for (final TargetPlatform platform in <TargetPlatform>[
+      TargetPlatform.android,
+      TargetPlatform.iOS,
+      TargetPlatform.fuchsia,
+    ]) {
+      testWidgets('$platform 不建拖拽源（触屏按下即拖会吞掉列表滚动）',
+          (WidgetTester tester) async {
+        await pumpCard(tester, platform);
+        expect(find.byType(Draggable<MediaRef>), findsNothing);
+      });
+    }
+
+    testWidgets('enabled=false 不建拖拽源（多选态卡片点击是切换选中，不应能拖走）',
+        (WidgetTester tester) async {
+      await pumpCard(tester, TargetPlatform.windows, enabled: false);
+      expect(find.byType(Draggable<MediaRef>), findsNothing);
+    });
+  });
+}

--- a/hibiki/test/media/drag_drop/manga_drop_test.dart
+++ b/hibiki/test/media/drag_drop/manga_drop_test.dart
@@ -75,11 +75,12 @@ void main() {
       List<String> unsupportedMangas = const <String>[],
       List<String> books = const <String>[],
       List<String> videos = const <String>[],
+      List<String> subtitles = const <String>[],
     }) =>
         DroppedFiles(
           books: books,
           videos: videos,
-          subtitles: const <String>[],
+          subtitles: subtitles,
           audios: const <String>[],
           playlists: const <String>[],
           dictionaries: const <String>[],
@@ -111,25 +112,54 @@ void main() {
       );
     });
 
-    test('漫画库拖普通书 -> unsupportedSurface（不悄悄导进另一个书架）', () {
+    // ↓↓↓ 「非漫画一律沿用 books 表面」是**改动前就有的行为**（漫画库是书架页的
+    // mangaOnly 壳、共用同一个 drop target）。曾一度收窄成「本页面不支持」，那等于
+    // 移除用户可能一直在用的能力，已按「用户没表态就保持现状」回退。要改成不支持
+    // 是产品决定，不是实现细节——下面几条就是钉住不许再被顺手收窄。
+    test('漫画库拖普通 epub -> importNewBook（仍自动导去书架，不得收窄成不支持）', () {
       expect(
         decideDropIntent(
           surface: DropSurface.manga,
           files: files(books: <String>['/a/b.epub']),
           cardHit: false,
         ),
-        DropIntent.unsupportedSurface,
+        DropIntent.importNewBook,
       );
     });
 
-    test('漫画库拖视频 -> unsupportedSurface（不沿用 books 表面的自动切视频）', () {
+    test('漫画库拖视频 -> importNewVideo（沿用 books 表面的自动切视频）', () {
       expect(
         decideDropIntent(
           surface: DropSurface.manga,
           files: files(videos: <String>['/a/v.mp4']),
           cardHit: false,
         ),
-        DropIntent.unsupportedSurface,
+        DropIntent.importNewVideo,
+      );
+    });
+
+    test('漫画库拖字幕到书卡 -> attachToBookCard（books 表面能做的这里都能做）', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.manga,
+          files: files(subtitles: <String>['/a/s.srt']),
+          cardHit: true,
+        ),
+        DropIntent.attachToBookCard,
+      );
+    });
+
+    test('漫画载体仍优先于 books 规则：同时拖 .cbz + .epub -> importNewManga', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.manga,
+          files: files(
+            mangas: <String>['/a/m.cbz'],
+            books: <String>['/a/b.epub'],
+          ),
+          cardHit: false,
+        ),
+        DropIntent.importNewManga,
       );
     });
 

--- a/hibiki/test/media/drag_drop/manga_drop_test.dart
+++ b/hibiki/test/media/drag_drop/manga_drop_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/drag_drop/drop_classification.dart';
+import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
+
+/// 漫画库的拖入曾是个功能空洞：`MangaLibraryPage` 只是
+/// `ReaderHibikiHistoryPage(mangaOnly: true)` 的壳，白拿了书架的 drop target，但
+/// 分类与决策两层从没加过漫画语义——拖 `.mokuro` / `.cbz` / 页图**目录**进去全部
+/// 静默无反应（分类落 unknown → decideDropIntent 返回 ignore），而这些东西按钮
+/// 导入路径全都支持。拖 `.cbr` 同样静默。
+///
+/// 这里守卫修复后的口径：漫画载体被认出来 → importNewManga；认得出但导不了的
+/// RAR 系 → 明确提示而非静默；漫画库拖入非漫画 → 明确提示而非悄悄导去别的书架。
+void main() {
+  group('classifyDroppedFiles — 漫画载体', () {
+    test('.mokuro 归 mangas', () {
+      final DroppedFiles files =
+          classifyDroppedFiles(<String>['/a/vol1.mokuro']);
+      expect(files.mangas, <String>['/a/vol1.mokuro']);
+      expect(files.unknown, isEmpty, reason: '曾经落 unknown → 静默无反应');
+    });
+
+    test('.cbz 归 mangas', () {
+      final DroppedFiles files = classifyDroppedFiles(<String>['/a/vol1.cbz']);
+      expect(files.mangas, <String>['/a/vol1.cbz']);
+      expect(files.unknown, isEmpty);
+    });
+
+    test('.cbr/.rar 归 unsupportedMangas（认得出但 archive 包不解 RAR）', () {
+      final DroppedFiles files =
+          classifyDroppedFiles(<String>['/a/v.cbr', '/a/v.rar']);
+      expect(files.unsupportedMangas, <String>['/a/v.cbr', '/a/v.rar']);
+      expect(files.mangas, isEmpty);
+      expect(files.hasAny, isTrue, reason: '必须能触发提示，不能落进静默的 ignore');
+    });
+
+    test('目录经 isDirectory 谓词归 mangas（页图文件夹）', () {
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>['/a/第01巻'],
+        isDirectory: (String pth) => pth == '/a/第01巻',
+      );
+      expect(files.mangas, <String>['/a/第01巻']);
+    });
+
+    test('目录名带点也归 mangas（不被 p.extension 误当扩展名）', () {
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>['/a/第01巻.v2'],
+        isDirectory: (String pth) => pth == '/a/第01巻.v2',
+      );
+      expect(files.mangas, <String>['/a/第01巻.v2']);
+      expect(files.unknown, isEmpty);
+    });
+
+    test('不传 isDirectory 时行为与历史一致（目录落 unknown）', () {
+      final DroppedFiles files = classifyDroppedFiles(<String>['/a/第01巻']);
+      expect(files.mangas, isEmpty);
+      expect(files.unknown, <String>['/a/第01巻']);
+    });
+
+    test('.zip 不归漫画（无内容判据，避免把词典包当漫画导）', () {
+      final DroppedFiles files = classifyDroppedFiles(<String>['/a/dict.zip']);
+      expect(files.mangas, isEmpty);
+      expect(files.dictionaries, <String>['/a/dict.zip']);
+    });
+
+    test('.epub 不归漫画（图片型 epub 由导入对话框真读包判定）', () {
+      final DroppedFiles files = classifyDroppedFiles(<String>['/a/b.epub']);
+      expect(files.mangas, isEmpty);
+      expect(files.books, <String>['/a/b.epub']);
+    });
+  });
+
+  group('decideDropIntent — manga 表面', () {
+    DroppedFiles files({
+      List<String> mangas = const <String>[],
+      List<String> unsupportedMangas = const <String>[],
+      List<String> books = const <String>[],
+      List<String> videos = const <String>[],
+    }) =>
+        DroppedFiles(
+          books: books,
+          videos: videos,
+          subtitles: const <String>[],
+          audios: const <String>[],
+          playlists: const <String>[],
+          dictionaries: const <String>[],
+          urls: const <String>[],
+          mangas: mangas,
+          unsupportedMangas: unsupportedMangas,
+          unknown: const <String>[],
+        );
+
+    test('漫画载体 -> importNewManga', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.manga,
+          files: files(mangas: <String>['/a/v.cbz']),
+          cardHit: false,
+        ),
+        DropIntent.importNewManga,
+      );
+    });
+
+    test('RAR 系 -> unsupportedMangaArchive（明确提示，不静默）', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.manga,
+          files: files(unsupportedMangas: <String>['/a/v.cbr']),
+          cardHit: false,
+        ),
+        DropIntent.unsupportedMangaArchive,
+      );
+    });
+
+    test('漫画库拖普通书 -> unsupportedSurface（不悄悄导进另一个书架）', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.manga,
+          files: files(books: <String>['/a/b.epub']),
+          cardHit: false,
+        ),
+        DropIntent.unsupportedSurface,
+      );
+    });
+
+    test('漫画库拖视频 -> unsupportedSurface（不沿用 books 表面的自动切视频）', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.manga,
+          files: files(videos: <String>['/a/v.mp4']),
+          cardHit: false,
+        ),
+        DropIntent.unsupportedSurface,
+      );
+    });
+
+    test('什么都没有 -> ignore', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.manga,
+          files: files(),
+          cardHit: false,
+        ),
+        DropIntent.ignore,
+      );
+    });
+  });
+
+  group('decideDropIntent — books 表面也接漫画（漫画是书的一种）', () {
+    DroppedFiles files({
+      List<String> mangas = const <String>[],
+      List<String> unsupportedMangas = const <String>[],
+      List<String> books = const <String>[],
+    }) =>
+        DroppedFiles(
+          books: books,
+          videos: const <String>[],
+          subtitles: const <String>[],
+          audios: const <String>[],
+          playlists: const <String>[],
+          dictionaries: const <String>[],
+          urls: const <String>[],
+          mangas: mangas,
+          unsupportedMangas: unsupportedMangas,
+          unknown: const <String>[],
+        );
+
+    test('普通书架拖漫画包也导入漫画，不静默', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.books,
+          files: files(mangas: <String>['/a/v.cbz']),
+          cardHit: false,
+        ),
+        DropIntent.importNewManga,
+      );
+    });
+
+    test('漫画优先于普通书文件（.mokuro 是 JSON，被 books 分支吃掉会转成乱码 EPUB）', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.books,
+          files: files(
+            mangas: <String>['/a/v.mokuro'],
+            books: <String>['/a/note.txt'],
+          ),
+          cardHit: false,
+        ),
+        DropIntent.importNewManga,
+      );
+    });
+
+    test('books 表面的 RAR 系也给提示', () {
+      expect(
+        decideDropIntent(
+          surface: DropSurface.books,
+          files: files(unsupportedMangas: <String>['/a/v.cbr']),
+          cardHit: false,
+        ),
+        DropIntent.unsupportedMangaArchive,
+      );
+    });
+  });
+}

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -2364,10 +2364,19 @@ void main() {
       'class CustomFontDownloadProgressDialog',
     );
 
-    expect(pageSource, contains('ReorderableListView.builder('));
-    expect(pageSource, contains('buildDefaultDragHandles: false'));
-    // 不再显示 ☰ 拖拽手柄，也不用长按拖拽，改用每行的上/下移动按钮
-    // （onMoveUp / onMoveDown 调 _onReorder），更适配焦点/手柄导航。
+    // 自实现的 HibikiReorderableColumn，**不是** SDK ReorderableListView：整棵树
+    // 活在 HibikiAppUiScale 的 Transform.scale 下，SDK 的 _DragItemProxy 用
+    // 「全局坐标 − overlay 原点」纯平移、不认祖先缩放，「界面大小」非 100% 时
+    // 拖拽浮层会漂移、缩小时一拖即飞出屏幕（BUG-778 同根因）。此前这条断言正向
+    // 钉死了 `ReorderableListView.builder(`，等于把缺陷焊在原地。
+    expect(pageSource, contains('HibikiReorderableColumn('));
+    expect(
+      pageSource,
+      isNot(contains('ReorderableListView.builder(')),
+      reason: 'SDK Reorderable 在全局 UI 缩放下拖拽坐标漂移（BUG-778 同根因）',
+    );
+    // 每行仍有上/下移动按钮（onMoveUp / onMoveDown 调 _onReorder），适配焦点/
+    // 手柄导航，也是拖拽之外的无障碍路径。
     expect(pageSource, contains('onMoveUp:'));
     expect(pageSource, contains('onMoveDown:'));
     expect(source, isNot(contains('ReorderableDelayedDragStartListener(')));

--- a/hibiki/test/widgets/hibiki_reorderable_column_test.dart
+++ b/hibiki/test/widgets/hibiki_reorderable_column_test.dart
@@ -419,4 +419,69 @@ void main() {
     expect(reorders, isEmpty, reason: 'a stationary click must not reorder');
     expect(order, <String>['A', 'B', 'C']);
   });
+
+  testWidgets(
+      '按住在视口底边缘带会自动滚动外层 SingleChildScrollView'
+      '（长列表里第 1 项才够得到第 N 项）', (WidgetTester tester) async {
+    // 此前本组件缺边缘自动滚动（2D 姊妹件 HibikiReorderableGrid 早就有）：列表长
+    // 于视口时，把某行拖到视口边缘列表不会跟着滚，用户只能在**当前可见范围**内
+    // 重排——第 1 项永远拖不到第 30 项。
+    final ScrollController controller = ScrollController();
+    addTearDown(controller.dispose);
+    // 12 项 × 60 高 = 内容高 720、视口 240 → 必须自动滚动才够得到底部。
+    final List<String> order = <String>[for (int i = 0; i < 12; i++) 'i$i'];
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 300,
+            height: 240,
+            child: SingleChildScrollView(
+              controller: controller,
+              child: _Harness(items: order, onReorder: (_, __) {}),
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pump();
+    expect(controller.offset, 0);
+
+    final Rect viewport = tester.getRect(find.byType(SingleChildScrollView));
+    final TestGesture gesture =
+        await tester.startGesture(tester.getCenter(find.text('i0')));
+    await tester.pump(const Duration(milliseconds: 600)); // 长按起拖
+    // 按住在视口底边缘带内且不再移动，纯靠帧步进推进滚动。
+    await gesture.moveTo(Offset(viewport.center.dx, viewport.bottom - 8));
+    await tester.pump(); // 处理 move → 排下一帧的自动滚动
+    for (int i = 0; i < 6; i++) {
+      await tester.pump(const Duration(milliseconds: 16));
+    }
+
+    expect(controller.offset, greaterThan(0),
+        reason: '指针按在底边缘带应驱动最近的祖先 Scrollable 自动向下滚动');
+    await gesture.cancel();
+    await tester.pumpAndSettle();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('无祖先 Scrollable 时自动滚动降级为不滚（不得抛异常）', (WidgetTester tester) async {
+    final List<String> order = <String>['A', 'B', 'C'];
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: _Harness(items: order, onReorder: (_, __) {}),
+      ),
+    ));
+    await tester.pump();
+
+    final TestGesture gesture =
+        await tester.startGesture(tester.getCenter(find.text('A')));
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.dragFrom(const Offset(150, 10), const Offset(0, 0));
+    await tester.pump(const Duration(milliseconds: 16));
+    await gesture.cancel();
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
 }

--- a/hibiki/test/widgets/horizontal_drag_scroll_guard_test.dart
+++ b/hibiki/test/widgets/horizontal_drag_scroll_guard_test.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 桌面端 Flutter 的默认 `MaterialScrollBehavior.dragDevices` **不含鼠标**：横向
+/// 滚动区用鼠标左键按住左右拖会毫无反应，只能滚轮（用户实报）。仓库早在
+/// `collection_shelf_row.dart` 就写下了这条根因注释并修了合集行 + 首页继续行，
+/// 但没有推广——全仓 16 处 `Axis.horizontal` 里当时只有那 2 处放开了鼠标拖动。
+///
+/// 这条守卫钉死「新增横向滚动区必须包 [HorizontalDragScrollable]」，防止再次漂移。
+/// 按文件粒度计数（一个文件里的横向区数 ≤ 包裹数 + 豁免数），因为静态扫描无法可靠
+/// 判断 widget 树的父子关系。
+void main() {
+  /// 明确豁免：区内已有依赖横拖的手势，放开滚动拖动会与之抢手势竞技场。
+  ///
+  /// 每条豁免都必须写清理由——豁免不是「先跳过以后再说」，而是有对抗性证据的决定。
+  const Map<String, String> exemptions = <String, String>{
+    // cue strip 自带 onHorizontalDrag「拖字幕块调延迟」。GestureDetector 的横拖
+    // 不受 ScrollBehavior.dragDevices 约束，故现状是「鼠标拖字幕块有效、拖空白
+    // 无反应」；放开滚动拖动会让两个 HorizontalDragGestureRecognizer 进同一个
+    // 竞技场，赌内层胜出去换一点便利不值得（本区有常驻滚动条可拖）。
+    'lib/src/media/video/subtitle_waveform_align_panel.dart':
+        'cue strip 自带 onHorizontalDrag 调延迟，放开滚动拖动会抢手势',
+  };
+
+  test('每个横向滚动区都放开了鼠标拖动（或在豁免清单里说明了原因）', () {
+    final Directory libDir = Directory('lib');
+    expect(libDir.existsSync(), isTrue, reason: '测试须从 hibiki/ 下运行');
+
+    final List<String> offenders = <String>[];
+    for (final FileSystemEntity entity in libDir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final String source = entity.readAsStringSync();
+      final int horizontals =
+          'scrollDirection: Axis.horizontal'.allMatches(source).length;
+      if (horizontals == 0) continue;
+
+      final String relative = entity.path.replaceAll(r'\', '/');
+      final int wrapped = 'HorizontalDragScrollable('.allMatches(source).length;
+      final int exempt = exemptions.keys.any(relative.endsWith) ? 1 : 0;
+
+      if (wrapped + exempt < horizontals) {
+        offenders.add(
+          '$relative: 横向滚动区 $horizontals 处，'
+          'HorizontalDragScrollable 包裹 $wrapped 处，豁免 $exempt 处',
+        );
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: '这些横向滚动区在桌面端鼠标拖不动（默认 dragDevices 不含 mouse）。'
+          '用 HorizontalDragScrollable 包住滚动件；'
+          '若区内已有依赖横拖的手势，加进本测试的 exemptions 并写明理由：\n'
+          '${offenders.join('\n')}',
+    );
+  });
+
+  test('共享件本体存在且放开了 mouse/trackpad/stylus', () {
+    final File file = File('lib/src/utils/misc/platform_utils.dart');
+    expect(file.existsSync(), isTrue);
+    final String source = file.readAsStringSync();
+    expect(source, contains('class HorizontalDragScrollable'));
+    expect(source, contains('PointerDeviceKind.mouse'));
+    expect(source, contains('PointerDeviceKind.trackpad'));
+    expect(source, contains('PointerDeviceKind.stylus'));
+    // 触屏行为不得被改掉。
+    expect(source, contains('PointerDeviceKind.touch'));
+  });
+
+  test('刻意不做成全局 scrollBehavior（否则垂直网格会与卡片拖拽抢手势）', () {
+    final File main = File('lib/main.dart');
+    expect(main.existsSync(), isTrue);
+    expect(
+      main.readAsStringSync(),
+      isNot(contains('scrollBehavior:')),
+      reason: '全局放开鼠标拖动滚动会让垂直网格与 MediaCardDraggable 的 Draggable '
+          '抢手势，把「拖卡进合集」变成「拖动网格滚动」。只包横向区。',
+    );
+  });
+}

--- a/hibiki/test/widgets/reorderable_scale_safety_guard_test.dart
+++ b/hibiki/test/widgets/reorderable_scale_safety_guard_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-778 同根因的全仓收口守卫。
+///
+/// 整棵 widget 树活在 `HibikiAppUiScale` 的 `Transform.scale` 之下（main.dart 在
+/// 应用根部套的浏览器式整体缩放），而 Flutter SDK 的重排拖拽代理
+/// （`reorderable_list.dart` 的 `_DragItemProxy`）用「全局坐标 − overlay 原点」
+/// 的纯平移把代理放进 Overlay 本地坐标系、**不认祖先缩放变换**：用户把「界面
+/// 大小」调成非 100% 后，拖拽浮层就按 `(1−s)×(指针到 overlay 原点距离)` 漂移，
+/// 缩小时一拖即飞出屏幕。这是 SDK 的坐标缺陷，app 内改不了那段数学。
+///
+/// BUG-778 当时只把合集与词典两条链路换成了自实现的 HibikiReorderable*，
+/// `custom_fonts_page` 与互联设备排序两处漏网，且 `md3_design_system_static_test`
+/// 还**正向断言**字体页必须含 `ReorderableListView.builder(`——一条守卫把缺陷焊
+/// 在了原地。这里改为反向钉死：全仓不得再实际使用 SDK 的重排组件。
+void main() {
+  test('lib/ 下不得实际使用 SDK ReorderableListView / ReorderableGridView', () {
+    final Directory libDir = Directory('lib');
+    expect(libDir.existsSync(), isTrue, reason: '测试须从 hibiki/ 下运行');
+
+    // 只查真实构造调用，不查注释里提到的名字（多处注释正当地解释「为什么不用
+    // 它」，那些恰恰是应当保留的设计记录）。
+    final RegExp constructorCall = RegExp(
+      r'(?<![\w.])Reorderable(ListView|GridView)\s*(\.\s*\w+\s*)?\(',
+    );
+
+    final List<String> offenders = <String>[];
+    for (final FileSystemEntity entity in libDir.listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      final String relative = entity.path.replaceAll(r'\', '/');
+      final List<String> lines = entity.readAsLinesSync();
+      for (int i = 0; i < lines.length; i++) {
+        final String line = lines[i];
+        final String trimmed = line.trimLeft();
+        // 跳过注释行（`///`、`//`、以及 doc 续行的 `*`）。
+        if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+        if (constructorCall.hasMatch(line)) {
+          offenders.add('$relative:${i + 1}: ${trimmed.trim()}');
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'SDK 重排组件的 Overlay 拖拽代理不认祖先 Transform.scale，'
+          '「界面大小」非 100% 时拖拽浮层漂移（BUG-778）。'
+          '改用 HibikiReorderableColumn / HibikiReorderableGrid'
+          '（浮层渲染在列表自身 Stack、指针经 globalToLocal 消掉祖先缩放）：\n'
+          '${offenders.join('\n')}',
+    );
+  });
+
+  test('自实现重排件仍在（消缩放的替代实现不得被误删）', () {
+    expect(
+      File('lib/src/utils/components/hibiki_reorderable_column.dart')
+          .existsSync(),
+      isTrue,
+    );
+    expect(
+      File('lib/src/utils/components/hibiki_reorderable_grid.dart')
+          .existsSync(),
+      isTrue,
+    );
+  });
+}


### PR DESCRIPTION
用户诉求两条：「拖进合集直接自动分配进这个合集的功能」+「各个地方的拖动该修复了」。
盘点后前者是**新功能**（媒体卡此前完全不可拖，只有标签是 Draggable），后者查出
**4 条真实缺陷**——全部来自代码实证，不是翻旧账：`docs/bugs/` 下 106 个提到拖拽的
bug 文件逐个查过，两个复选框全都已勾，没有一条未修。

## 1. 拖进合集自动加入（`ac4c8b136`）

拖拽源 `MediaCardDraggable` + 接收端 `CollectionDropTarget` 收在
`lib/src/media/collections/collection_drag.dart`，payload 用现成的统一媒体身份
`MediaRef(kind, entryKey)`，落库统一走幂等的 `addToCollection` DAO。

覆盖四个库页：书架 / 漫画（是书架页的 `mangaOnly` 壳，一处接线两个书架都生效）/
视频 / 游戏（此前完全没有拖放基建）。

两个关键设计：

- **接收端泛型选 `DragTarget<MediaRef>` 而非复用标签的 `DragTarget<BookTagRow>`**。
  合集行头因此同时挂两个 DragTarget（标签落下=打标签 / 卡片落下=进合集），靠泛型
  天然分流、无运行时判别分支；既有的「`DragTarget<BookTagRow>` 恰好一个/恰好零个」
  守卫断言也保持成立。测试双向验证互不误接。
- **拖拽源按平台分流**：桌面用 `Draggable` 按下即拖——`ImmediateMultiDrag` 要过
  `kTouchSlop` 才在竞技场胜出，所以点击仍归 `onTap` 开书、按住不动仍归
  `onLongPress` 弹菜单、右键仍归 `onSecondaryTap`；触屏**不建**拖拽源，因为长按已
  被上下文菜单占用，改掉它就破坏既有交互，移动端走既有的卡片菜单「加入合集」。

坑：SRT 卡的合集身份是 `book.uid`，**不是**打标签用的 int 主键 `srtBookId`，照抄会
写错成员。

## 2. 漫画库拖入不再静默（`da65804ad`）

漫画库白拿了书架的 drop target，但分类与决策两层从没加过漫画语义：拖 `.mokuro` /
`.cbz` / 图片**文件夹**全部静默无反应，拖 `.zip` 还弹误导性的「本页面不支持」——而
这些载体按钮导入路径全都支持（**按钮能导的，拖进去一个都不认**）。

- 分类层加 `kDragMangaExtensions = {mokuro, cbz}`。刻意不含 `zip`/`epub`：要真读包
  才知道是不是图片包，而 `zip` 同时是词典包扩展名，无内容判据时把书架上拖入的
  Yomitan 词典 zip 当漫画导是新的误判；图片型 zip/epub 仍可经导入对话框导入。
- `cbr/cb7/rar` 单列一类给**明确提示**，不再归 unknown 后静默（`archive` 不解 RAR）。
- 目录没有扩展名，加可选谓词 `isDirectory` 由 widget 层注入真实 IO（分类层仍不碰
  IO）；判定放在扩展名分类之前——目录名带点（`第01巻.v2`）会被 `p.extension` 误取。
- 导入侧只把路径预填进 `BookImportDialog`（它的分派本就认 mokuro/cbz/图片型 zip），
  补上它缺的最后一环：整目录分支。

**一个我做的判断，可能你想推翻**：漫画库拖入普通 epub 我改成给「不支持」提示，而不
是沿用书架那套自动导去别处——漫画库导完 epub 后这个书架什么也不多出来，用户会以为
文件丢了。想要「自动导进普通书架并提示」的话说一声。

## 3. 横向滚动区在桌面端鼠标拖不动（`089e96b6e`）

仓库早在 `collection_shelf_row.dart` 就写下了根因注释（「用鼠标左右拖会毫无反应
（用户实报）」）并修了 2 处，但**没有推广**——全仓 16 处 `Axis.horizontal` 只有那
2 处放开了 `dragDevices`。抽共享件 `HorizontalDragScrollable`，13 处补上（标签筛选栏
最痛、词典分类选择器、播放器顶栏、字幕筛选分段、CSS 编辑器分页条、键盘/手柄布局图…）。

**刻意不做成全局 `MaterialApp.scrollBehavior`**，虽然一行就能覆盖：全局放开会让垂直
网格也响应鼠标拖动滚动，与第 1 条的卡片 `Draggable` 抢手势，把「拖卡进合集」变成
「拖动网格滚动」。守卫测试专门断言 `main.dart` 不出现 `scrollBehavior:`。

**明确豁免 1 处**：字幕波形对齐面板。其 cue strip 自带 `onHorizontalDrag`（拖字幕块
调延迟），放开滚动拖动会让两个 `HorizontalDragGestureRecognizer` 进同一竞技场——赌
内层胜出去换一点便利不值得（该区有常驻滚动条）。理由写在代码注释 + 守卫豁免清单。

## 4. 补完 BUG-778 最后两处缩放漂移（`db8ab7fb9`）

整棵树活在 `HibikiAppUiScale` 的 `Transform.scale` 下，而 SDK 的 `_DragItemProxy` 用
「全局坐标 − overlay 原点」纯平移、不认祖先缩放：「界面大小」非 100% 时拖拽浮层漂移、
缩小时一拖即飞出屏幕。BUG-778 当时只换了合集与词典两条链路，`custom_fonts_page`
与互联设备排序漏网。两处都换成自实现的 `HibikiReorderableColumn`。

⚠️ 两者 `onReorder` 下标语义不同（SDK 传「移除前下标」、自实现件传**最终下标**），
两条路径都改了：去掉 `newIndex--`，下移按钮从 `index+2` 改 `index+1`——只改一半会让
按钮静默错位一格。

`md3_design_system_static_test` 里那条 `expect(pageSource, contains(
'ReorderableListView.builder('))` **正向断言等于把缺陷焊在原地**，改为反向断言，并
新增全仓收口守卫。

## 5. 补边缘自动滚动（`4a3e3e749`）

`HibikiReorderableColumn` 一直没有拖拽近边缘自动滚动：列表长于视口时只能在**当前可见
范围内**重排，第 1 项永远拖不到第 30 项。2D 姊妹件早就实现了（说明是遗漏非取舍），
移植过来。受益界面 7 个。

边缘带判定用 `MatrixUtils.transformRect` 取屏幕矩形而非 `localToGlobal(zero) & size`
——后者把缩放后的原点和未缩放的布局尺寸混拼，scale<1 时边缘带够不到（grid 侧
BUG-654 踩过）。

## 验证

- `flutter analyze` 干净（基线也是 No issues，改前确认过）。
- 定向测试：`test/pages` + `widgets` + `media` + `settings` **6522 例全绿**；
  `settings` + `widgets` + `sync` 2423 例；`media/drag_drop` 94 例；`widgets` 406 例。
- 新增测试 36 例（合集拖入 12 / 漫画拖入 19 / 横向拖动守卫 3 / 缩放守卫 2）+ 自动
  滚动 2 例。
- **自动滚动那条做了红/绿验证**：临时注释掉 `_maybeAutoScroll` 调用后恰好只有它转红
  （其余 10 例仍过），确认不是恒绿测试。
- ⚠️ **本地全量测试未跑成**：`sqlite3.dll` 被并发测试进程占用（`PathAccessException:
  拒绝访问`），零测试执行。我没有杀那些进程（可能属于其他 agent 会话）。**全量请以
  CI 为准**，尤其 Build Release APK 的 Run unit tests 那道真单测门。
- 未真机验证：拖拽手感、缩放下的拖拽落点、漫画目录导入都建议真机复验。

未 bump 版本号（不是发布，且避免与并发 PR 撞号）。

https://claude.ai/code/session_01W3Jxvqzh6bur9WVs7e56ib
