### PR TITLE
fix(sync): 远端查重不再把认证失败吞成「不重复」(BUG-1185)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1147 条。点号进各自文件。
+> 共 1148 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1185](bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md) | ✅ | ✅ | 远端制卡查重吞掉认证失败，静默答「不重复」 |
 | [BUG-1183](bugs/BUG-1183-restore-auth-invalidates-session.md) | ✅ | ✅ | restoreAuth 无条件作废已解析地址，每次切页面重跑全候选探测 |
 | [BUG-1182](bugs/BUG-1182-show-remote-entries-gate-too-late.md) | ✅ | ✅ | 关闭「显示远端条目」仍全额拉取远端列表后丢弃 |
 | [BUG-1181](bugs/BUG-1181-manga-shelf-fetches-remote-books.md) | ✅ | ✅ | 漫画书架实例误拉远端书，切到书架触发双倍网络 |

--- a/docs/bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md
+++ b/docs/bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md
@@ -16,7 +16,7 @@
     查重答案会直接决定用户「要不要再制一张卡」→ 该报。可重试失败（超时/连接被拒/非 2xx）
     继续 fail-soft 降级是有意设计，不在本 bug 范围内。
 
-- **[x] ① 已修复** — commit `6cb31d5bd`
+- **[x] ① 已修复** — commit `ade4b7c11`
   - `hibiki/lib/src/sync/hibiki_remote_mining_client.dart`：新增三态 `RemoteDuplicateCheck`
     （`duplicate` / `notDuplicate` / `authRejected`），`RemoteMineSender.isDuplicate` 返回值
     由 `bool` 升为三态。`SyncAuthError` 单独走 `on SyncAuthError → authRejected`，其余异常
@@ -34,7 +34,7 @@
     做好并就此走开。若谎报 `true` 或直接抛异常，异常会被 `_guardJsBridge<bool>` 再吞回 `false`
     且用户依然看不到——所以抛异常在这里解决不了问题。
 
-- **[x] ② 已加自动化测试** — commit `6cb31d5bd`
+- **[x] ② 已加自动化测试** — commit `ade4b7c11`
   - `hibiki/test/sync/hibiki_remote_mining_client_duplicate_test.dart`（新增，最强可落地层：
     用 `MockClient` 真实驱动 HTTP 状态码 + 内存 Drift `SyncRepository`）：401 → `authRejected`；
     200 `duplicate:true/false` → `duplicate`/`notDuplicate`；503 / 传输层异常 / 无候选 →

--- a/docs/bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md
+++ b/docs/bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md
@@ -16,7 +16,7 @@
     查重答案会直接决定用户「要不要再制一张卡」→ 该报。可重试失败（超时/连接被拒/非 2xx）
     继续 fail-soft 降级是有意设计，不在本 bug 范围内。
 
-- **[x] ① 已修复** — commit `<A-COMMIT>`
+- **[x] ① 已修复** — commit `6cb31d5bd`
   - `hibiki/lib/src/sync/hibiki_remote_mining_client.dart`：新增三态 `RemoteDuplicateCheck`
     （`duplicate` / `notDuplicate` / `authRejected`），`RemoteMineSender.isDuplicate` 返回值
     由 `bool` 升为三态。`SyncAuthError` 单独走 `on SyncAuthError → authRejected`，其余异常
@@ -34,7 +34,7 @@
     做好并就此走开。若谎报 `true` 或直接抛异常，异常会被 `_guardJsBridge<bool>` 再吞回 `false`
     且用户依然看不到——所以抛异常在这里解决不了问题。
 
-- **[x] ② 已加自动化测试** — commit `<A-COMMIT>`
+- **[x] ② 已加自动化测试** — commit `6cb31d5bd`
   - `hibiki/test/sync/hibiki_remote_mining_client_duplicate_test.dart`（新增，最强可落地层：
     用 `MockClient` 真实驱动 HTTP 状态码 + 内存 Drift `SyncRepository`）：401 → `authRejected`；
     200 `duplicate:true/false` → `duplicate`/`notDuplicate`；503 / 传输层异常 / 无候选 →

--- a/docs/bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md
+++ b/docs/bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md
@@ -1,0 +1,50 @@
+## BUG-1185 · 远端制卡查重吞掉认证失败，静默答「不重复」
+
+- **报告**：2026-07-28（用户：巡检发现，互联「制卡到已配对设备」查重路径）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/sync/hibiki_remote_mining_client.dart:79-85`（修复前）——
+  `HibikiRemoteMiningClient.isDuplicate` 用裸 `catch (_) { return false; }` 把 `_post` 抛出的
+  `SyncAuthError`（主机 401 拒绝互联 token，同文件 `:120` 抛出）连同可重试失败一起吞掉，
+  统一压成 `false`。
+  - 数据流：popup.js `duplicateCheck` → `dictionary_popup_webview._guardJsBridge<bool>` →
+    `dictionary_page_mixin.checkDuplicate` / `base_source_page.onDuplicateCheck` →
+    `ankiRepositoryProvider`（开关开时是 `RemoteMiningAnkiRepository`）→
+    `RemoteMiningAnkiRepository.isDuplicate` → `RemoteMineSender.isDuplicate`。
+  - 后果：token 被对端拒绝时**查重根本没执行**，用户却看到 ➕（可制卡），以为这张卡没做过。
+    「答错」比「报错」更糟——同一条链路上 `mineForward` 早就把 401 当成 `SyncAuthError` 上抛
+    并渲染成明确失败（`remote_mining_anki_repository.dart:74`），只有查重这一处在说谎。
+  - 判据（与 PR#488 同族）：`catch` 该报还是该吞，看这个失败会不会让用户基于错误信息做决定。
+    查重答案会直接决定用户「要不要再制一张卡」→ 该报。可重试失败（超时/连接被拒/非 2xx）
+    继续 fail-soft 降级是有意设计，不在本 bug 范围内。
+
+- **[x] ① 已修复** — commit `<A-COMMIT>`
+  - `hibiki/lib/src/sync/hibiki_remote_mining_client.dart`：新增三态 `RemoteDuplicateCheck`
+    （`duplicate` / `notDuplicate` / `authRejected`），`RemoteMineSender.isDuplicate` 返回值
+    由 `bool` 升为三态。`SyncAuthError` 单独走 `on SyncAuthError → authRejected`，其余异常
+    仍降级 `notDuplicate`（fail-soft 语义零变化）。
+  - `hibiki/lib/src/anki/remote_mining_anki_repository.dart`：`isDuplicate` 收到 `authRejected`
+    时经注入的 `RemoteMiningAuthReporter` **上报给用户**（同实例只报一次，避免每次查词刷屏），
+    并复用与 `mineEntry` 同一句 `tokenRejectedMessage`。
+  - `hibiki/lib/src/anki/anki_view_model.dart`：`ankiRepositoryProvider` 把 reporter 接到
+    `HibikiToast.showMine(status: failed)`。
+  - **保留 bool 的理由**（不是妥协的借口，是范围判断）：`BaseAnkiRepository.isDuplicate` 的
+    `Future<bool>` 契约一路铺到 popup.js 的 ✓/➕ **两态**按钮（还有 3 份 popup 镜像 + 静态守卫
+    测试），把第三态推到 UI 属于另一个量级的改动。本修复把「静默答错」降级为「答 false 但
+    明确告诉用户配对已失效、查重不可信」；返回 `false` 而非 `true` 是刻意的——用户真按 ➕ 时
+    `mineEntry` 会用同一句话明确失败，不会悄悄多出重复卡；谎报 `true` 反而会让用户以为卡已
+    做好并就此走开。若谎报 `true` 或直接抛异常，异常会被 `_guardJsBridge<bool>` 再吞回 `false`
+    且用户依然看不到——所以抛异常在这里解决不了问题。
+
+- **[x] ② 已加自动化测试** — commit `<A-COMMIT>`
+  - `hibiki/test/sync/hibiki_remote_mining_client_duplicate_test.dart`（新增，最强可落地层：
+    用 `MockClient` 真实驱动 HTTP 状态码 + 内存 Drift `SyncRepository`）：401 → `authRejected`；
+    200 `duplicate:true/false` → `duplicate`/`notDuplicate`；503 / 传输层异常 / 无候选 →
+    `notDuplicate`（fail-soft 不回归）。
+  - `hibiki/test/anki/remote_mining_anki_repository_test.dart`：`authRejected` → 上报用户且
+    只报一次、返回 `false`；`notDuplicate` → 不误报鉴权失败。
+  - **负向验证**：把 `on SyncAuthError → authRejected` 摘掉（回到裸 `catch` 吞掉）后
+    `FLUTTER TEST VERDICT: FAILED`，`BUG-1185 主机 401 → authRejected` 转红
+    （`Expected: authRejected / Actual: notDuplicate`）；还原后 15 tests 全绿。
+
+- **备注**：`tokenRejectedMessage` 沿用同文件既有的硬编码英文（`mineEntry` 401 分支原本就是
+  硬编码英文，本次把两处合并成同一个常量）。若要 i18n 化应连同 `mineEntry` 那句一起做，属
+  独立跟进项，不在本 bug 范围内。

--- a/hibiki/lib/src/anki/anki_view_model.dart
+++ b/hibiki/lib/src/anki/anki_view_model.dart
@@ -339,6 +339,12 @@ final ankiRepositoryProvider = Provider<BaseAnkiRepository>((ref) {
   return RemoteMiningAnkiRepository(
     local: local,
     client: appModel.createRemoteMiningClient(),
+    // BUG-1185：主机拒绝互联 token 时查重根本没跑成。bool 契约表达不了「不知道」，
+    // 所以在这里把它变成用户可见的失败提示，而不是让用户收到一个静默的「不重复」。
+    onAuthRejected: (String message) => HibikiToast.showMine(
+      msg: message,
+      status: MineToastStatus.failed,
+    ),
   );
 });
 

--- a/hibiki/lib/src/anki/remote_mining_anki_repository.dart
+++ b/hibiki/lib/src/anki/remote_mining_anki_repository.dart
@@ -16,6 +16,10 @@ typedef DictMediaByteLoader = Uint8List? Function(
 /// 读取本地文件字节（封面/音频临时文件）。默认走 `dart:io File`；文件缺失返回 null。
 typedef LocalFileByteLoader = Future<Uint8List?> Function(String path);
 
+/// BUG-1185：把「已配对主机拒绝了互联 token」上报给用户可见的通道（toast）。
+/// 注入而非直接调 UI，是为了让 repository 保持无 Flutter 依赖、可纯 Dart 单测。
+typedef RemoteMiningAuthReporter = void Function(String message);
+
 /// 「制卡到服务端」的 Anki 仓库包装：把 [mineEntry]/[isDuplicate] 经互联链路转发给已配对
 /// 主机（主机用它自己的 Anki 后端 + 字段映射/牌组落卡），其余**配置类**方法
 /// （[fetchConfiguration]/[createDeck]/[createNoteType]）委派给包装的本地仓库 [_local]，
@@ -36,15 +40,27 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
     required RemoteMineSender client,
     DictMediaByteLoader? dictMediaLoader,
     LocalFileByteLoader? fileByteLoader,
+    RemoteMiningAuthReporter? onAuthRejected,
   })  : _local = local,
         _client = client,
         _dictMediaLoader = dictMediaLoader ?? _defaultDictMediaLoader,
-        _fileByteLoader = fileByteLoader ?? _defaultFileByteLoader;
+        _fileByteLoader = fileByteLoader ?? _defaultFileByteLoader,
+        _onAuthRejected = onAuthRejected;
+
+  /// 主机拒绝互联 token 时给用户看的话。制卡失败与查重失败共用同一句，
+  /// 因为它们是同一个 token 被同一台主机拒绝。
+  static const String tokenRejectedMessage =
+      'The paired device rejected the interconnect token. Re-pair the device.';
 
   final BaseAnkiRepository _local;
   final RemoteMineSender _client;
   final DictMediaByteLoader _dictMediaLoader;
   final LocalFileByteLoader _fileByteLoader;
+  final RemoteMiningAuthReporter? _onAuthRejected;
+
+  /// 同一个 repository 实例只报一次「token 被拒」——查重是每次查词都跑的高频路径，
+  /// 逐次弹 toast 会刷屏。provider 在开关/配对变化时会重建实例，届时自然重新提示。
+  bool _authRejectedReported = false;
 
   static Uint8List? _defaultDictMediaLoader(String dictionary, String path) =>
       HoshiDicts.instance.getMediaFile(dictionary, path);
@@ -73,7 +89,7 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
       return _outcomeFromResponse(json);
     } on SyncAuthError {
       return MineOutcome.failure(
-        'The paired device rejected the interconnect token. Re-pair the device.',
+        tokenRejectedMessage,
         errorCode: AnkiErrorCode.connectionUnknown,
       );
     } catch (e, st) {
@@ -86,10 +102,30 @@ class RemoteMiningAnkiRepository extends BaseAnkiRepository {
     }
   }
 
+  /// BUG-1185：远端查重。可重试失败仍 fail-soft（client 层已降级为
+  /// [RemoteDuplicateCheck.notDuplicate]），绝不让远端抖动阻断查词。
+  ///
+  /// token 被主机拒绝时查重**根本没执行**：这不是「不重复」，是「不知道」。基类
+  /// [BaseAnkiRepository.isDuplicate] 的 `Future<bool>` 契约（一路铺到 popup.js 的
+  /// ✓/➕ 两态按钮）表达不了第三态，所以在这一层把它**报给用户**——用户至少知道
+  /// 「配对已失效、查重结果不可信」，而不是静默收到一个错误答案。返回值仍取 false
+  /// （保持 ➕ 可点）：用户真按下去时 [mineEntry] 会用同一句话明确失败，不会悄悄多出
+  /// 一张重复卡；若反过来谎报 true，用户只会以为卡已做好并就此走开。
   @override
-  Future<bool> isDuplicate(String expression, String reading) {
-    // fail-soft：客户端已在 client 层吞异常回 false，绝不让远端查重阻断查词。
-    return _client.isDuplicate(expression: expression, reading: reading);
+  Future<bool> isDuplicate(String expression, String reading) async {
+    final RemoteDuplicateCheck check =
+        await _client.isDuplicate(expression: expression, reading: reading);
+    if (check == RemoteDuplicateCheck.authRejected) {
+      _reportAuthRejectedOnce();
+      return false;
+    }
+    return check == RemoteDuplicateCheck.duplicate;
+  }
+
+  void _reportAuthRejectedOnce() {
+    if (_authRejectedReported) return;
+    _authRejectedReported = true;
+    _onAuthRejected?.call(tokenRejectedMessage);
   }
 
   Future<ForwardedMinePayload> _buildForwardedPayload({

--- a/hibiki/lib/src/sync/hibiki_remote_mining_client.dart
+++ b/hibiki/lib/src/sync/hibiki_remote_mining_client.dart
@@ -4,6 +4,23 @@ import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:http/http.dart' as http;
 
+/// BUG-1185：远端查重的三态结果。查重是「用户据此决定要不要再制一张卡」的信息，
+/// 所以**「没查成」必须与「查过了、不重复」分开**：token 被对端拒绝时把结果压成
+/// 「不重复」，用户看到的是 ➕（可制卡）——他会以为这张卡没做过，而实际上根本没查。
+///
+/// 可重试的失败（无可达候选 / 超时 / 连接被拒 / 坏响应体）仍按既有 fail-soft 语义
+/// 降级为 [notDuplicate]，绝不让远端抖动阻断查词——那是有意的降级，不是错误答案。
+enum RemoteDuplicateCheck {
+  /// 主机确认已有同词卡。
+  duplicate,
+
+  /// 主机确认没有同词卡，**或**可重试失败后的 fail-soft 降级。
+  notDuplicate,
+
+  /// token 被主机拒绝（401）——查重根本没执行，答案未知，不得当成 [notDuplicate]。
+  authRejected,
+}
+
 /// 「制卡到服务端」发送器的窄接口（供 [RemoteMiningAnkiRepository] 依赖，便于单测注入假实现，
 /// 不必拉起真实 HTTP + SyncRepository）。生产实现是 [HibikiRemoteMiningClient]。
 abstract class RemoteMineSender {
@@ -11,8 +28,9 @@ abstract class RemoteMineSender {
   /// token 被拒抛 [SyncAuthError]。
   Future<Map<String, dynamic>?> mineForward(ForwardedMinePayload payload);
 
-  /// 远端查重（fail-soft，异常/无候选回 false）。
-  Future<bool> isDuplicate({
+  /// 远端查重。三态：命中 / 未命中 / token 被拒（见 [RemoteDuplicateCheck]）。
+  /// 可重试失败仍 fail-soft 降级为 [RemoteDuplicateCheck.notDuplicate]。
+  Future<RemoteDuplicateCheck> isDuplicate({
     required String expression,
     required String reading,
   });
@@ -63,9 +81,14 @@ class HibikiRemoteMiningClient implements RemoteMineSender {
     );
   }
 
-  /// 查重（`+`→`✓`）：命中主机 Anki 后端。fail-soft，异常/无候选一律回 false。
+  /// 查重（`+`→`✓`）：命中主机 Anki 后端。
+  ///
+  /// BUG-1185：可重试失败（无可达候选 / 超时 / 非 2xx / 坏 JSON）仍 fail-soft 降级为
+  /// [RemoteDuplicateCheck.notDuplicate]，绝不让远端抖动阻断查词；但 token 被主机拒绝
+  /// （[SyncAuthError]，与 [mineForward] 同一条 401 契约）时**不再压成「不重复」**——
+  /// 那是把「没查成」冒充成「查过了、没有」，用户会据此重复制卡。
   @override
-  Future<bool> isDuplicate({
+  Future<RemoteDuplicateCheck> isDuplicate({
     required String expression,
     required String reading,
   }) async {
@@ -75,9 +98,13 @@ class HibikiRemoteMiningClient implements RemoteMineSender {
         body: <String, dynamic>{'expression': expression, 'reading': reading},
         timeout: _duplicateTimeout,
       );
-      return json?['duplicate'] == true;
+      return json?['duplicate'] == true
+          ? RemoteDuplicateCheck.duplicate
+          : RemoteDuplicateCheck.notDuplicate;
+    } on SyncAuthError {
+      return RemoteDuplicateCheck.authRejected;
     } catch (_) {
-      return false;
+      return RemoteDuplicateCheck.notDuplicate;
     }
   }
 

--- a/hibiki/test/anki/remote_mining_anki_repository_test.dart
+++ b/hibiki/test/anki/remote_mining_anki_repository_test.dart
@@ -17,7 +17,7 @@ class _FakeSender implements RemoteMineSender {
   final bool throwAuth;
   ForwardedMinePayload? captured;
   final List<List<String>> dupCalls = <List<String>>[];
-  bool dupResult = false;
+  RemoteDuplicateCheck dupResult = RemoteDuplicateCheck.notDuplicate;
 
   @override
   Future<Map<String, dynamic>?> mineForward(
@@ -28,7 +28,7 @@ class _FakeSender implements RemoteMineSender {
   }
 
   @override
-  Future<bool> isDuplicate(
+  Future<RemoteDuplicateCheck> isDuplicate(
       {required String expression, required String reading}) async {
     dupCalls.add(<String>[expression, reading]);
     return dupResult;
@@ -175,11 +175,46 @@ void main() {
     });
 
     test('isDuplicate 走远端发送器', () async {
-      final _FakeSender sender = _FakeSender(null)..dupResult = true;
+      final _FakeSender sender = _FakeSender(null)
+        ..dupResult = RemoteDuplicateCheck.duplicate;
       final RemoteMiningAnkiRepository repo =
           RemoteMiningAnkiRepository(local: _FakeLocal(), client: sender);
       expect(await repo.isDuplicate('猫', 'ねこ'), isTrue);
       expect(sender.dupCalls.single, <String>['猫', 'ねこ']);
+    });
+
+    // BUG-1185：token 被主机拒绝 = 查重根本没跑成。旧实现把它压成「不重复」静默
+    // 交给用户；现在必须报出来（bool 契约仍回 false，但用户看得见失败提示）。
+    test('BUG-1185 查重遇 token 被拒 → 上报用户，不静默', () async {
+      final _FakeSender sender = _FakeSender(null)
+        ..dupResult = RemoteDuplicateCheck.authRejected;
+      final List<String> reported = <String>[];
+      final RemoteMiningAnkiRepository repo = RemoteMiningAnkiRepository(
+        local: _FakeLocal(),
+        client: sender,
+        onAuthRejected: reported.add,
+      );
+
+      expect(await repo.isDuplicate('猫', 'ねこ'), isFalse);
+      expect(reported.single, RemoteMiningAnkiRepository.tokenRejectedMessage);
+
+      // 查重是每次查词都跑的高频路径：同一实例只提示一次，不刷屏。
+      await repo.isDuplicate('犬', 'いぬ');
+      expect(reported.length, 1);
+    });
+
+    // 可重试失败（client 已降级成 notDuplicate）不该被误报成鉴权失败。
+    test('BUG-1185 可重试失败仍 fail-soft，不误报 token 被拒', () async {
+      final _FakeSender sender = _FakeSender(null)
+        ..dupResult = RemoteDuplicateCheck.notDuplicate;
+      final List<String> reported = <String>[];
+      final RemoteMiningAnkiRepository repo = RemoteMiningAnkiRepository(
+        local: _FakeLocal(),
+        client: sender,
+        onAuthRejected: reported.add,
+      );
+      expect(await repo.isDuplicate('猫', 'ねこ'), isFalse);
+      expect(reported, isEmpty);
     });
 
     test('配置类方法委派本地（设置页仍能配置本地 Anki）', () async {

--- a/hibiki/test/sync/hibiki_remote_mining_client_duplicate_test.dart
+++ b/hibiki/test/sync/hibiki_remote_mining_client_duplicate_test.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/hibiki_remote_mining_client.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// BUG-1185：`HibikiRemoteMiningClient.isDuplicate` 曾用裸 `catch (_) => false`
+/// 把主机的 401 一起吞掉，于是「token 被拒、根本没查成」被冒充成「查过了、不重复」。
+/// 用户看到 ➕ 会以为这张卡没做过。本组用真实 HTTP 状态码驱动，锁死三态映射。
+HibikiDatabase _testDb() {
+  return HibikiDatabase.forTesting(
+    DatabaseConnection(NativeDatabase.memory()),
+  );
+}
+
+Future<SyncRepository> _repo(HibikiDatabase db) async {
+  final SyncRepository repo = SyncRepository(db);
+  await repo.setHibikiClientUrls(
+      const <HibikiClientUrl>[HibikiClientUrl(url: 'http://host:8765')]);
+  await repo.setHibikiClientToken('tok');
+  return repo;
+}
+
+Future<RemoteDuplicateCheck> _check(
+  HibikiDatabase db,
+  http.Response Function(http.Request request) respond,
+) async {
+  final HibikiRemoteMiningClient client = HibikiRemoteMiningClient(
+    repo: await _repo(db),
+    httpClient: MockClient((http.Request request) async => respond(request)),
+  );
+  return client.isDuplicate(expression: '猫', reading: 'ねこ');
+}
+
+http.Response _json(Map<String, dynamic> body, int status) =>
+    http.Response.bytes(
+      utf8.encode(jsonEncode(body)),
+      status,
+      headers: const <String, String>{
+        'content-type': 'application/json; charset=utf-8',
+      },
+    );
+
+void main() {
+  test('BUG-1185 主机 401 → authRejected（绝不冒充 notDuplicate）', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    expect(
+      await _check(db, (http.Request _) => http.Response('nope', 401)),
+      RemoteDuplicateCheck.authRejected,
+    );
+  });
+
+  test('主机确认命中 → duplicate', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    expect(
+      await _check(db,
+          (http.Request _) => _json(<String, dynamic>{'duplicate': true}, 200)),
+      RemoteDuplicateCheck.duplicate,
+    );
+  });
+
+  test('主机确认未命中 → notDuplicate', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    expect(
+      await _check(
+          db,
+          (http.Request _) =>
+              _json(<String, dynamic>{'duplicate': false}, 200)),
+      RemoteDuplicateCheck.notDuplicate,
+    );
+  });
+
+  test('可重试失败（503）仍 fail-soft → notDuplicate，不阻断查词', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    expect(
+      await _check(db, (http.Request _) => http.Response('down', 503)),
+      RemoteDuplicateCheck.notDuplicate,
+    );
+  });
+
+  test('传输层失败（连接被拒）仍 fail-soft → notDuplicate', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final HibikiRemoteMiningClient client = HibikiRemoteMiningClient(
+      repo: await _repo(db),
+      httpClient: MockClient(
+          (http.Request _) async => throw http.ClientException('boom')),
+    );
+    expect(
+      await client.isDuplicate(expression: '猫', reading: 'ねこ'),
+      RemoteDuplicateCheck.notDuplicate,
+    );
+  });
+
+  test('未配置可达候选 → notDuplicate（不误报鉴权失败）', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final HibikiRemoteMiningClient client = HibikiRemoteMiningClient(
+      repo: SyncRepository(db),
+      httpClient: MockClient(
+          (http.Request _) async => throw StateError('must not be called')),
+    );
+    expect(
+      await client.isDuplicate(expression: '猫', reading: 'ねこ'),
+      RemoteDuplicateCheck.notDuplicate,
+    );
+  });
+}


### PR DESCRIPTION
## 问题

`hibiki/lib/src/sync/hibiki_remote_mining_client.dart:79`（修复前）的 `isDuplicate` 用裸 `catch (_) { return false; }`，把同文件 `:120` 为 401 抛出的 `SyncAuthError` 和可重试失败一起吞掉。

结果：已配对主机拒绝互联 token 时，**查重根本没执行**，用户却看到 ➕（可制卡）——以为这张卡没做过。同一条链路上 `mineForward` 早就把 401 上抛并渲染成明确失败，只有查重这一处在静默给错误答案。

判据（PR#488 同族）：`catch` 该报还是该吞，看这个失败会不会让用户基于错误信息做决定。查重答案直接决定「要不要再制一张卡」→ 该报。

## 修法

- **`RemoteMineSender.isDuplicate` 升三态** `RemoteDuplicateCheck { duplicate, notDuplicate, authRejected }`。只把认证失败单独拎出来；超时 / 连接被拒 / 非 2xx / 坏 JSON / 无可达候选**仍降级 `notDuplicate`**，fail-soft 语义零变化。
- **`RemoteMiningAnkiRepository.isDuplicate`** 收到 `authRejected` 时经注入的 `RemoteMiningAuthReporter` 上报给用户（同实例只报一次，查重是每次查词都跑的高频路径，不能刷屏），文案与 `mineEntry` 401 分支合并成同一个 `tokenRejectedMessage` 常量。
- **`ankiRepositoryProvider`** 把 reporter 接到 `HibikiToast.showMine(status: failed)`。

### 为什么 bool 返回值保持 `false`（先看调用方再定形状）

`BaseAnkiRepository.isDuplicate` 的 `Future<bool>` 一路铺到 popup.js 的 ✓/➕ **两态**按钮（3 份 popup 镜像 + 静态守卫测试），把第三态推到 UI 是另一个量级的改动，本 PR 不做。

- **抛异常解决不了问题**：上面第一个调用点是 `dictionary_popup_webview._guardJsBridge<bool>`，它会把异常记日志后再吞回 `false` —— 用户依然什么都看不到。这正是「不要为了让类型好看就抛给一个没准备处理它的调用点」。
- **返回 `false` 而非 `true` 是刻意的**：用户真按 ➕ 时 `mineEntry` 会用同一句话明确失败，不会悄悄多出重复卡；谎报 `true` 反而让用户以为卡已做好并就此走开。

本 PR 把「静默答错」变成「答 false + 明确告诉用户配对已失效、查重结果不可信」。

## 测试

新增 `hibiki/test/sync/hibiki_remote_mining_client_duplicate_test.dart`（最强可落地层：`MockClient` 真实驱动 HTTP 状态码 + 内存 Drift `SyncRepository`）：
- 401 → `authRejected`
- 200 `duplicate:true/false` → `duplicate` / `notDuplicate`
- 503 / 传输层异常 / 无可达候选 → `notDuplicate`（fail-soft 不回归）

`hibiki/test/anki/remote_mining_anki_repository_test.dart` 补：`authRejected` → 上报且只报一次、返回 `false`；`notDuplicate` → 不误报鉴权失败。

**负向验证**：摘掉 `on SyncAuthError → authRejected` 后 `FLUTTER TEST VERDICT: FAILED`，401 用例转红（`Expected: authRejected / Actual: notDuplicate`）；还原后 15 tests 全绿。

## 验证

- `flutter analyze`（含 test 目录）→ `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub` 定向：目标 2 个套件 `PASSED - 15 tests ran`；相邻守卫 5 个套件 `PASSED - 19 tests ran`
- `dart run tool/bug.dart check` → 通过，1144 条，号唯一

## 跟进（不在本 PR 范围）

`tokenRejectedMessage` 沿用同文件既有硬编码英文（`mineEntry` 401 分支原本就是），要 i18n 化应连同那句一起做。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb