### PR TITLE
fix(galgame): Dart 侧读写 v2 Luna hook-code profile（补 options 列）

### DIFF
--- a/hibiki/lib/src/mining/galgame_hook_code_profile.dart
+++ b/hibiki/lib/src/mining/galgame_hook_code_profile.dart
@@ -6,8 +6,26 @@ import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/storage/app_paths.dart';
 
-const String _profileHeader =
+/// v1 六列（无 `options`）。旧文件与旧 Hibiki 版本仍在用，读写两侧都必须继续认它。
+const String _profileHeaderV1 =
     'exe_sha256\tmodule_name\tmodule_sha256\tcodepage\thook_code\tlabel';
+
+/// v2 七列，尾列 `options` 是分号分隔的开关，与 native 侧
+/// `native/galgame_hook/include/luna_hook_config.h` 的 schema 一致：
+/// `pc-hooks` / `block=<hook-code>` / `block-name=<Luna 名>` / `prefer=<hook-code>` /
+/// `defer-ms=<毫秒>`。Dart 侧只做逐字保真搬运（解析/生效在 native），不解释语义——
+/// 解释一遍等于开第二个真相源。
+const String _profileHeaderV2 = '$_profileHeaderV1\toptions';
+
+/// 行首前缀判表头：v1 六列头与 v2 七列头都命中，与 native 的
+/// `line.rfind("exe_sha256\t", 0) == 0` 同一判据。数据行首列只可能是 64 位 hex 或空，
+/// 不会误伤。
+const String _profileHeaderPrefix = 'exe_sha256\t';
+
+/// 最少列数。多出来的列（未来 v3）按 native 的做法忽略——v1/v2/v3 互为前缀子集，
+/// 这才是「不崩」的真正来源。
+const int _profileMinColumns = 6;
+
 final RegExp _sha256Pattern = RegExp(r'^[0-9a-f]{64}$');
 
 class LunaHookCodeProfile {
@@ -18,6 +36,7 @@ class LunaHookCodeProfile {
     required this.codepage,
     required this.hookCode,
     required this.label,
+    this.options = '',
   });
 
   final String executableSha256;
@@ -27,8 +46,12 @@ class LunaHookCodeProfile {
   final String hookCode;
   final String label;
 
+  /// v2 尾列，原样保存的分号分隔开关串。v1 行 / 未使用时为空串。
+  final String options;
+
   String get identityKey =>
-      '$executableSha256|${moduleName.toLowerCase()}|$moduleSha256|$hookCode';
+      '$executableSha256|${moduleName.toLowerCase()}|$moduleSha256|$hookCode'
+      '|$options';
 
   void validate() {
     if (executableSha256.isEmpty && moduleSha256.isEmpty) {
@@ -43,23 +66,27 @@ class LunaHookCodeProfile {
         (!_sha256Pattern.hasMatch(moduleSha256) || moduleName.isEmpty)) {
       throw const FormatException('A module hash needs a valid hash and name.');
     }
-    if (codepage <= 0 || hookCode.trim().isEmpty) {
+    // v2 允许「只带 options、不带 hook code」的行（block=/prefer=/defer-ms= 这类
+    // 只约束自动探测的 profile，native 侧 `fields[4]` 为空是合法的）；但一行既没有
+    // hook code 又没有 options 就什么都没说，仍然是错的。
+    if (codepage <= 0 || (hookCode.trim().isEmpty && options.trim().isEmpty)) {
       throw const FormatException('Invalid codepage or empty Hook Code.');
     }
-    if (<String>[moduleName, hookCode, label].any((value) =>
+    if (<String>[moduleName, hookCode, label, options].any((value) =>
         value.contains('\t') || value.contains('\n') || value.contains('\r'))) {
       throw const FormatException(
           'Profile fields cannot contain tabs or lines.');
     }
   }
 
-  String toTsvRow() => <Object>[
+  String toTsvRow({bool includeOptions = true}) => <Object>[
         executableSha256,
         moduleName,
         moduleSha256,
         codepage,
         hookCode,
         label,
+        if (includeOptions) options,
       ].join('\t');
 }
 
@@ -67,12 +94,15 @@ List<LunaHookCodeProfile> parseLunaHookCodeProfiles(String input) {
   final List<LunaHookCodeProfile> result = <LunaHookCodeProfile>[];
   for (final String rawLine in const LineSplitter().convert(input)) {
     final String line = rawLine.trimRight();
-    if (line.isEmpty || line.startsWith('#') || line == _profileHeader) {
+    if (line.isEmpty ||
+        line.startsWith('#') ||
+        line.startsWith(_profileHeaderPrefix)) {
       continue;
     }
     final List<String> fields = line.split('\t');
-    if (fields.length != 6) {
-      throw const FormatException('Hook Code profile rows need six columns.');
+    if (fields.length < _profileMinColumns) {
+      throw const FormatException(
+          'Hook Code profile rows need at least six columns.');
     }
     final LunaHookCodeProfile profile = LunaHookCodeProfile(
       executableSha256: fields[0].toLowerCase(),
@@ -81,6 +111,7 @@ List<LunaHookCodeProfile> parseLunaHookCodeProfiles(String input) {
       codepage: int.tryParse(fields[3]) ?? 0,
       hookCode: fields[4],
       label: fields[5],
+      options: fields.length > 6 ? fields[6] : '',
     );
     profile.validate();
     result.add(profile);
@@ -91,10 +122,16 @@ List<LunaHookCodeProfile> parseLunaHookCodeProfiles(String input) {
 String encodeLunaHookCodeProfiles(Iterable<LunaHookCodeProfile> profiles) {
   final List<LunaHookCodeProfile> sorted = profiles.toList()
     ..sort((a, b) => a.identityKey.compareTo(b.identityKey));
+  // 没有任何一行用到 options 就照旧写 v1：绝大多数用户表按字节不变，旧版本 Hibiki
+  // （只认六列）读自己的表不会炸。真有 options 要存时才升 v2——native 的解析器本来
+  // 就同时吃 v1/v2。
+  final bool needsOptions =
+      sorted.any((LunaHookCodeProfile profile) => profile.options.isNotEmpty);
   return <String>[
-    '# Hibiki Luna hook-code profiles v1. UTF-8, tab separated.',
-    _profileHeader,
-    ...sorted.map((profile) => profile.toTsvRow()),
+    '# Hibiki Luna hook-code profiles ${needsOptions ? 'v2' : 'v1'}. '
+        'UTF-8, tab separated.',
+    needsOptions ? _profileHeaderV2 : _profileHeaderV1,
+    ...sorted.map((profile) => profile.toTsvRow(includeOptions: needsOptions)),
     '',
   ].join('\n');
 }

--- a/hibiki/test/mining/galgame_hook_code_profile_test.dart
+++ b/hibiki/test/mining/galgame_hook_code_profile_test.dart
@@ -76,4 +76,115 @@ ${repeated('c')}\t\t\t932\tHQ@1234\tfirst
       throwsFormatException,
     );
   });
+
+  // ── v2（options 尾列）────────────────────────────────────────────────────
+  // native 侧 `native/galgame_hook/config/luna_hook_profiles.tsv` +
+  // `include/luna_hook_config.h` 已是 v2；Dart 侧曾只认六列，读到 v2 表直接抛
+  // FormatException（连 v2 表头行都过不去），导出还会把 options 静默丢掉。
+
+  test('v2 seven-column rows parse and keep the options column verbatim', () {
+    const String options =
+        'block=EXHQXN8@1647F4;block-name=Krkr2wcs;prefer=HQXN-C@1D2F80;'
+        'defer-ms=8000';
+    final List<LunaHookCodeProfile> parsed = parseLunaHookCodeProfiles('''
+# Hibiki Luna hook-code profiles v2. UTF-8, tab separated.
+exe_sha256\tmodule_name\tmodule_sha256\tcodepage\thook_code\tlabel\toptions
+${repeated('a')}\t\t\t932\tHQ@1234\twith options\t$options
+''');
+    expect(parsed, hasLength(1));
+    expect(parsed.single.options, options);
+  });
+
+  test('v2 round-trips through encode without losing options', () {
+    const String options = 'pc-hooks;defer-ms=8000';
+    final String encoded = encodeLunaHookCodeProfiles(<LunaHookCodeProfile>[
+      LunaHookCodeProfile(
+        executableSha256: repeated('a'),
+        moduleName: '',
+        moduleSha256: '',
+        codepage: 932,
+        hookCode: 'HQ@1234',
+        label: 'with options',
+        options: options,
+      ),
+    ]);
+    expect(encoded, contains('profiles v2.'));
+    expect(
+        encoded,
+        contains('exe_sha256\tmodule_name\tmodule_sha256\tcodepage\t'
+            'hook_code\tlabel\toptions'));
+    expect(parseLunaHookCodeProfiles(encoded).single.options, options);
+  });
+
+  test('an options-only row (no hook code) is valid, as native accepts it', () {
+    final List<LunaHookCodeProfile> parsed = parseLunaHookCodeProfiles(
+      'exe_sha256\tmodule_name\tmodule_sha256\tcodepage\thook_code\tlabel'
+      '\toptions\n'
+      '${repeated('a')}\t\t\t932\t\tsafe profile\tblock=EXHQXN8@1647F4\n',
+    );
+    expect(parsed.single.hookCode, isEmpty);
+    expect(parsed.single.options, 'block=EXHQXN8@1647F4');
+  });
+
+  test('a row with neither hook code nor options is still rejected', () {
+    expect(
+      () => parseLunaHookCodeProfiles(
+        'exe_sha256\tmodule_name\tmodule_sha256\tcodepage\thook_code\tlabel'
+        '\toptions\n'
+        '${repeated('a')}\t\t\t932\t\tempty\t\n',
+      ),
+      throwsFormatException,
+    );
+  });
+
+  test('the shipped native v2 profile table parses', () async {
+    final File shipped =
+        File('../native/galgame_hook/config/luna_hook_profiles.tsv');
+    // 真相源就在本仓：直接拿它当 fixture，Dart 侧与 native 侧的列定义漂开时必红。
+    expect(await shipped.exists(), isTrue,
+        reason: 'native 侧 profile 真相源应存在于 ${shipped.absolute.path}');
+    final List<LunaHookCodeProfile> parsed =
+        parseLunaHookCodeProfiles(await shipped.readAsString());
+    expect(parsed, isNotEmpty);
+    expect(parsed.any((LunaHookCodeProfile p) => p.options.isNotEmpty), isTrue,
+        reason: 'v2 表里应至少有一行带 options');
+  });
+
+  // ── 向后兼容：v1 不能被 v2 改动破坏 ─────────────────────────────────────
+
+  test('a v1-only profile set still encodes as v1 six columns', () {
+    final String encoded = encodeLunaHookCodeProfiles(<LunaHookCodeProfile>[
+      LunaHookCodeProfile(
+        executableSha256: repeated('a'),
+        moduleName: '',
+        moduleSha256: '',
+        codepage: 932,
+        hookCode: 'HQ@1234',
+        label: 'plain',
+      ),
+    ]);
+    // 没人用 options 就别升版本：旧 Hibiki（只认六列）读自己的表不会炸。
+    expect(encoded, contains('profiles v1.'));
+    expect(encoded, isNot(contains('\toptions')));
+    expect(encoded, contains('${repeated('a')}\t\t\t932\tHQ@1234\tplain'));
+  });
+
+  test('unknown extra columns are ignored (v1/v2/v3 are prefix subsets)', () {
+    final List<LunaHookCodeProfile> parsed = parseLunaHookCodeProfiles(
+      'exe_sha256\tmodule_name\tmodule_sha256\tcodepage\thook_code\tlabel'
+      '\toptions\tfuture\n'
+      '${repeated('a')}\t\t\t932\tHQ@1234\tv3 row\tpc-hooks\twhatever\n',
+    );
+    expect(parsed.single.options, 'pc-hooks');
+  });
+
+  test('rows shorter than six columns are still rejected', () {
+    expect(
+      () => parseLunaHookCodeProfiles(
+        'exe_sha256\tmodule_name\tmodule_sha256\tcodepage\thook_code\tlabel\n'
+        '${repeated('a')}\t\t\t932\tHQ@1234\n',
+      ),
+      throwsFormatException,
+    );
+  });
 }


### PR DESCRIPTION
## 现状核实（与派单描述有出入，以代码为准）

在 **当前 develop（`46d2db543`）** 上核过：

| 说法 | 实况 |
|---|---|
| native 侧 tsv 已升 v2、多了 `options` 列 | ✅ 属实。`native/galgame_hook/config/luna_hook_profiles.tsv` 是 `v2` + 7 列，且已有一行真实带 options（Fate KiriKiri 的 `block=/block-name=/prefer=/defer-ms=`）。`python native/galgame_hook/tools/generate_luna_profiles.py --check` 退出码 **0**，`.tsv` 与生成的 `.inc` 同步 |
| Dart 导出端没跟上（9-10、95 行） | ✅ 属实，行号也对 |
| **「不崩」（v1 是 v2 的前缀子集）** | ❌ **不成立**。前缀子集是 **native 解析器**的性质（`fields.size() < 6 continue`、`>= 7` 才读 options、表头按 `exe_sha256\t` 前缀跳过）。**Dart 解析器比 native 严得多**：`fields.length != 6` 直接抛 `FormatException`，表头还是**精确串比对** —— 导入任何 v2 表**第一行表头就炸**，UI 只弹一个无区分度的失败 toast。所以这不只是「导出表达不了 options」，**导入方向是硬失败** |

（另注：如果只看落后的主 checkout 会看到「`.tsv` 还是 v1、`--check` 红」的假象 —— 那是主 checkout 落后 develop，不是真实状态。）

## 修法

让 Dart 侧对齐 native 的宽容度，而不是各写一套：

- 表头按 `exe_sha256\t` **前缀**跳过 → v1 六列头与 v2 七列头都认（与 native 的 `line.rfind("exe_sha256\t", 0) == 0` 同判据）
- 列数改为**至少** 6 列；`options` 在有第 7 列时读入，**更多列直接忽略**（v1/v2/v3 互为前缀子集 —— 这才是「不崩」的真正来源）
- `options` **逐字保真搬运**，Dart 不解释语义。解析/生效留在 native，解释一遍等于开第二个真相源
- `validate()`：v2 允许「只带 options、不带 hook code」的行（`block=/prefer=/defer-ms=` 只约束自动探测，native 的 `fields[4]` 为空是合法的）；既没有 hook code 又没有 options 的行仍然拒绝

## 无损兼容（做到了，两个方向都是）

- **读 v1**：六列表照旧解析，`options` 为空串。既有测试未改一行仍绿
- **写 v1**：`encodeLunaHookCodeProfiles` **只有在真有 profile 带 options 时才升 v2 表头 + 七列**；否则原样输出 v1 六列。当前所有用户表（无人用 options）导出后**逐字节不变**，旧版本 Hibiki（只认六列）读自己的表不会炸
- **native 两边都吃**：v1/v2 都走同一个宽容解析器
- `LunaHookCodeProfile.options` 是带默认值 `''` 的可选具名参数，唯一的构造点 `texthooker_page.dart:754` 与既有测试零改动

## 测试

`hibiki/test/mining/galgame_hook_code_profile_test.dart` 新增 7 例：v2 七列解析 + options 保真、v2 encode 往返不丢 options、options-only 行合法、无 hook code 也无 options 仍拒绝、**直接拿本仓 native 真相源 `../native/galgame_hook/config/luna_hook_profiles.tsv` 当 fixture**（两侧列定义再漂开必红）、v1-only 集合仍输出六列 v1、未知多余列被忽略、少于六列仍拒绝。

**负向验证**：把 `options: fields.length > 6 ? fields[6] : ''` 退回 `options: ''` 后 `FLUTTER TEST VERDICT: FAILED`，5 个用例转红（含 native 真相源那条）；还原后 12 tests 全绿。

## 验证

- `flutter analyze`（含 test 目录）→ `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/mining/` → `PASSED - 868 tests ran`

范围：仅 Dart 侧序列化，未改 native、未改 IPC 契约、未动 `engine-support.yaml`，不涉及平台范围变更（galgame 仍只 Windows）。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb