### PR TITLE
refactor(reader): per-nav 参数剥成 ReaderEngineConfig + 压缩器守卫直取生产拼装脚本

### DIFF
--- a/docs/bugs/BUG-1140-cross-chapter-turn-latency.md
+++ b/docs/bugs/BUG-1140-cross-chapter-turn-latency.md
@@ -157,10 +157,16 @@ load 回调分派顺序）、`test/reader/reader_image_lazy_pipeline_guard_test.
 
 ### 仍未做（下一步，风险与收益都更大）
 
-- `evalSetupScript` 剩余 ~24ms 是**每次跨章重新编译整份引擎 JS**：`evaluateJavascript` 的字符串没有 V8 code
-  cache。正解是把引擎改成 `<script src>` 外链（走 hoshi.local 拦截器 + 强缓存）或 UserScript 注册一次，
-  让 WebView 复用编译结果。阻碍：`initialize` 的参数化程度很高（insets / pageWidth / progress / charOffset /
-  fragment / sasayakiCues 每次导航都可能不同），要先把 per-nav 参数从脚本里剥成运行时读取。
+- ~~`evalSetupScript` 剩余 ~24ms 是每次跨章重新编译整份引擎 JS~~ —— **这条机理经探针实测为假，已作废**。
+  拆开测的结果：**平台通道固定往返 ~7.5ms**（发 2 字符 7.5ms vs 发 147459 字符 9.0ms —— 载荷相关成本只有
+  ~1.5ms）、**JS 编译 ~1.0ms**、**执行 ~6ms**。也就是说这段耗时的大头是**一次跨进程往返**，不是编译，
+  更不是字节数。
+  推论：任何「让 WebView 复用编译结果」的方案（`<script src>` 外链 / UserScript 注册一次）**收益上限只有
+  1.5~2.5ms**，占跨章总时长的 1~2%——不值得为它引入外链资源、强缓存与失效约定这套复杂度。
+  另有一条平台事实：`CustomSchemeResponse` 只有 `data` / `contentType` / `contentEncoding` 三个字段、
+  **没有 headers**，本仓 `_loadResourceWithCustomScheme` 正是把带 `Cache-Control` 的 `response.headers`
+  整个丢掉——**iOS/macOS 上强缓存在类型层面就无法表达**，那条路在移动端必然每章 cache miss。
+  真正值得下手的是**减少每次跨章 `evaluateJavascript` 的往返次数**，以及 `docLoad`。
 - `docLoad` 32ms 里有相当一部分是在等 `window.load`（含全部子资源）：`nav.dcl` 中位数 13ms vs `nav.load` 19ms。
   引擎若能在 DOMContentLoaded 就位，这段可与子资源加载并行。
 - 更彻底的方案是「下一章预渲染」（双 WebView 交替），可把顺序阅读的跨章压到一帧，但内存与状态同步成本高。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -3,7 +3,7 @@ part of '../reader_hibiki_page.dart';
 
 /// webview (EPUB WebView 构建 / hoshi.local 资源拦截 + 净化 / 单 IIFE setup 脚本)
 /// 域 helper，经 part-of 抽出（TODO-589 batch8·最后一批）；与主壳共享私有作用域。
-/// 行为保持：方法体逐字搬运（含 _buildReaderSetupScript 整段内联 JS 模板字符串的
+/// 行为保持：方法体逐字搬运（含引擎源码构造器整段内联 JS 模板字符串的
 /// 反引号/转义/缩进/$ 插值，做过提取前后字节级对比自证），仅做下列扩展不可直接
 /// 表达的等价转发改写：
 ///   (a) `_buildWebView`/`_onChapterLoadComplete` 里两处 `setState(` 改走主壳的
@@ -529,133 +529,162 @@ extension _ReaderWebView on _ReaderHibikiPageState {
 
   static bool _isValidFontData(Uint8List data) => isValidFontData(data);
 
-  static String _buildFuriganaJs(String mode) {
-    switch (mode) {
-      case 'partial':
-        return '''
-  document.addEventListener('click', function(e) {
-    var sel = window.getSelection();
-    if (sel && !sel.isCollapsed) return;
-    var node = e.target;
-    while (node && node !== document.body) {
-      if (node.tagName === 'RUBY') {
-        node.classList.toggle('show-rt');
-        return;
+  /// BUG-1140 第二阶段①：三种 furigana 模式的监听器全部随引擎发一份，运行时按
+  /// `C.furiganaMode` 选一个装（旧实现在 Dart 侧按 `s.furiganaMode` 三选一插值，
+  /// 那会让引擎源码随设置变化 → 外链缓存与编译复用同时失效）。
+  ///
+  /// 值域与分支判据逐条对齐旧的 `switch (mode)`：`partial` 装 click 切换单个 ruby、
+  /// `toggle` 装 dblclick 切换整页、其余（含 `off`）什么都不装。
+  static String _buildFuriganaJs() {
+    return '''
+  if (C.furiganaMode === 'partial') {
+    document.addEventListener('click', function(e) {
+      var sel = window.getSelection();
+      if (sel && !sel.isCollapsed) return;
+      var node = e.target;
+      while (node && node !== document.body) {
+        if (node.tagName === 'RUBY') {
+          node.classList.toggle('show-rt');
+          return;
+        }
+        node = node.parentElement;
       }
-      node = node.parentElement;
-    }
-  }, true);''';
-      case 'toggle':
-        return '''
-  document.addEventListener('dblclick', function() {
-    var sel = window.getSelection();
-    if (sel && !sel.isCollapsed) return;
-    document.body.classList.toggle('show-all-rt');
-  });''';
-      default:
-        return '';
-    }
+    }, true);
+  } else if (C.furiganaMode === 'toggle') {
+    document.addEventListener('dblclick', function() {
+      var sel = window.getSelection();
+      if (sel && !sel.isCollapsed) return;
+      document.body.classList.toggle('show-all-rt');
+    });
+  }''';
   }
 
   // ── Single IIFE setup script (mirrors Hoshi Android's readerSetupScript) ──
 
-  String _buildReaderSetupScript({String? sasayakiCuesJson}) {
+  /// BUG-1140 第二阶段①：本次导航的引擎参数。
+  ///
+  /// 这里聚齐的就是**改动前逐个插进脚本源码的那些值**——现在改成一份小 JSON 随
+  /// boot 下发，引擎运行时读取。新增 per-nav 参数一律加在这里，不得回到脚本里插值。
+  ReaderEngineConfig _buildReaderEngineConfig({String? sasayakiCuesJson}) {
     final ReaderSettings s = _settings!;
     // TODO-113: 滑动翻页距离阈值随灵敏度系数缩放。基础值 44px（纯距离触发）/ 22px
     // （配合速度的快速短滑触发），系数 1.0 = 默认「轻快」手感，越大越迟钝（需滑得更远）。
     final ({int dist, int fastDist}) swipeThresholds =
         ReaderSettings.swipePageTurnDistThresholds(s.swipePageTurnSensitivity);
-    final int swipeDistThreshold = swipeThresholds.dist;
-    final int swipeFastDistThreshold = swipeThresholds.fastDist;
-    // 查词「原地轻点」的完整触摸轨迹半径（固定，不随灵敏度缩放）：与翻页距离阈值
-    // 解耦；任一 move 越界后本次手势永久归为 pan，不能因松手回到起点又变回查词 tap。
-    const int tapSlop = ReaderSettings.tapSlopPx;
     // BUG-239: 连续模式靠原生滚动（滚动轴 = 书写轴），章间切换走边界手势 IIFE。
     // _gestureEnd 的 onSwipe（90% 整屏跳页）只在分页模式有意义；连续模式回传会与
     // 原生滚动产生轴向冲突，故注入 continuousMode 标志在 _gestureEnd 内门控。
     final bool continuousMode = s.isContinuousMode;
+    // TODO-909: select the VN shell when view-mode == 'vn'. VN is mutually
+    // exclusive with continuous (it is a page-flip stage, not native scroll),
+    // so continuousMode stays false here.
+    final bool vnMode = s.isVnMode;
     // TODO-909 M0: VN blank-tap advance. hoshi default clickAdvance=false
     // (commit `42c0bab`); M0 force-enables the tap binding so the device Gate
     // can verify click-to-advance. M1 falls back to s.visualNovelClickAdvance.
-    final bool vnMode = s.isVnMode;
     const bool vnClickAdvanceM0ForceOn = true; // M1: s.visualNovelClickAdvance
-    final bool vnClickAdvance = vnMode && vnClickAdvanceM0ForceOn;
     // TODO-909 M0: reveal（打字渐显）是 M1 功能。在 M0 强制 revealSpeed=0，使每屏
     // renderScreen 即 revealComplete=true、paginate 只返 "scrolled"/"limit"。否则
     // revealSpeed>0 时新屏停在 revealComplete=false，forward 翻屏会命中 paginate 的
     // `if(!revealComplete) completeCurrentReveal(); return "revealed"` 分支，而
     // Dart 的 _didScroll（chrome.part.dart）只认 "scrolled" 为真 → 误判章节边界
-    // 触发 _handlePageTurnLimit 跨章。M1 去掉本强制、改走 s.visualNovelRevealSpeed
-    // 即可放开渐显。
+    // 触发 _handlePageTurnLimit 跨章。M1 去掉本强制、改走 s.visualNovelRevealSpeed。
     const int vnRevealSpeedM0ForceZero = 0; // M1: s.visualNovelRevealSpeed
-    final int vnRevealSpeed = vnMode ? vnRevealSpeedM0ForceZero : 0;
-    // TODO-756b：是否“鼠标悬停即自动查词”。注入为 JS 全局初值，mousemove 监听器
-    // 据此跳过 Shift 门控（纯悬停查词）。live 变更经 _applyHoverAutoLookupLive
-    // 改同一全局，无需整章重注入。
-    final bool hoverAutoLookup = ReaderHibikiSource.instance.hoverAutoLookup;
-    final String selectionJs = ReaderSelectionScripts.source();
-    // TODO-1317: mobile long-press drag-select gesture IIFE (own touch
-    // listeners, coordinates via window.__hoshiTextSelectDragActive).
-    final String longPressDragJs =
-        ReaderSelectionScripts.longPressDragGestureScript();
     final Size screenSize = MediaQuery.of(context).size;
     // BUG-111: 这就是 JS 分页用的权威宽高（dartPageWidth/Height）。记下来作为
     // content-ready 后的「已分页基线」，供 _syncPageSize 与 settle 后的真实视口比对。
     _paginatedWidth = screenSize.width;
     _paginatedHeight = screenSize.height;
+    return ReaderEngineConfig(
+      continuousMode: continuousMode,
+      vnMode: vnMode,
+      vnClickAdvance: vnMode && vnClickAdvanceM0ForceOn,
+      scanNonJapaneseText: appModel.scanNonJapaneseText,
+      // TODO-756b：是否“鼠标悬停即自动查词”。live 变更经 _applyHoverAutoLookupLive
+      // 改同一个 JS 全局，无需整章重注入。
+      hoverAutoLookup: ReaderHibikiSource.instance.hoverAutoLookup,
+      highlightOnTap: ReaderHibikiSource.instance.highlightOnTap,
+      showChrome: _showChrome,
+      debugLogging: DebugLogService.instance.enabled,
+      swipeDistThreshold: swipeThresholds.dist,
+      swipeFastDistThreshold: swipeThresholds.fastDist,
+      furiganaMode: s.furiganaMode,
+      caretColor: _caretRingColorCss(),
+      caretInsetTop: _readerTopOffset,
+      // TODO-975：与 chromeBottomInset 同源 _readerBottomReserve（悬浮 0 / 挤压含底栏）。
+      caretInsetBottom: _readerBottomReserve,
+      initialProgress: _initialProgress,
+      initialCharOffset: _initialCharOffset,
+      // BUG-461: 收藏句跳转的句尾锚（连续模式横排整句对齐进可见区）；非跳转/无句长 = -1。
+      initialCharOffsetEnd: _initialCharOffsetEnd,
+      initialFragment: _initialFragment,
+      chromeTopInset: _readerTopOffset,
+      // TODO-975：单一真相源 _readerBottomReserve（悬浮态 0 / 挤压态含底栏高 + 系统
+      // inset），取代旧 `_showChrome ? height+inset : inset` 三元式。
+      chromeBottomInset: _readerBottomReserve,
+      dartPageWidth: screenSize.width,
+      dartPageHeight: screenSize.height,
+      blurImages: s.blurImages,
+      // TODO-1289：把本次会话已揭开的防剧透图 key 下发，重载时不再重新遮罩。
+      revealedKeys: _revealedImageKeys.toList(),
+      // TODO-perf（跨章）：JS 侧埋点与 Dart 侧同一个开关。生产下恒 false，
+      // perfMark / perfSnapshot 在 JS 里直接 early-return。
+      perfTraceEnabled: ReaderChapterPerfTrace.enabled,
+      vnRevealSpeed: vnMode ? vnRevealSpeedM0ForceZero : 0,
+      vnScreenMode: s.visualNovelScreenMode,
+      vnSentencesPerScreen: s.visualNovelSentencesPerScreen,
+      vnPreserveDialogue: s.visualNovelPreserveDialogueBubbles,
+      vnMergeCrossScreenSasayakiCues: s.visualNovelMergeCrossScreenSasayakiCues,
+      sasayakiCuesJson: sasayakiCuesJson,
+    );
+  }
+
+  /// 阅读器引擎的**静态**源码（零 per-nav 插值），按 view-mode 分三份。
+  ///
+  /// 原名 `_buildReaderSetupScript({sasayakiCuesJson})`——每次跨章把 insets /
+  /// pageWidth / progress / charOffset / fragment / cue 列表逐个插进源码，于是**每次
+  /// 导航都要重新拼装近万行、再整份过一遍 [ReaderScriptCompactor]**（实测
+  /// `buildSetupScript` 中位数 9ms，纯 Dart 侧固定开销，与章节体量无关）。
+  ///
+  /// 现在整段 body 是 `window.__hoshiEngine.install(C)` 的函数体，per-nav 参数一律
+  /// 运行时读 `C`（[ReaderEngineConfig]）。源码只依赖 view-mode 与编译期常量，一个
+  /// 进程里逐字不变，于是可以按模式 memoize（[readerEngineSource]）：拼装 + 压缩从
+  /// 每章一次降为每模式一次。
+  ///
+  /// **注入方式与执行时刻都没变**：仍是 Dart 在 `onLoadStop` 之后一次
+  /// `evaluateJavascript(引擎源码 + boot)`，同一时刻、同一同步执行序、同一次平台通道
+  /// 往返。本改动**不碰**注入通道本身——实测那条通道的固定往返约 7.5ms、与载荷大小
+  /// 几乎无关（发 2 字符 7.5ms vs 发 147459 字符 9.0ms），要压它得减少往返次数而不是
+  /// 减少字节数，属另一件事。
+  ///
+  /// 因为不再读任何实例状态，本方法是 static + memoized。
+  static String _buildReaderEngineSource({
+    required bool vnMode,
+    required bool continuousMode,
+  }) {
+    const int tapSlop = ReaderSettings.tapSlopPx;
+    final String selectionJs = ReaderSelectionScripts.source();
+    // TODO-1317: mobile long-press drag-select gesture IIFE (own touch
+    // listeners, coordinates via window.__hoshiTextSelectDragActive).
+    final String longPressDragJs =
+        ReaderSelectionScripts.longPressDragGestureScript();
+    // 只嵌当前 view-mode 那一份 shell（注入体量与改动前一致）；运行时分流点仍在 JS
+    // 侧读 C，Dart 不再把 per-nav 值插值进 shell。
     final String paginationJs = _stripScriptTags(
-      ReaderPaginationScripts.shellScript(
-        initialProgress: _initialProgress,
-        initialCharOffset: _initialCharOffset,
-        // BUG-461: 收藏句跳转的句尾锚（连续模式横排整句对齐进可见区）；非跳转/无句长 = -1。
-        initialCharOffsetEnd: _initialCharOffsetEnd,
-        continuousMode: s.isContinuousMode,
-        // TODO-909: select the VN shell when view-mode == 'vn'. VN is mutually
-        // exclusive with continuous (it is a page-flip stage, not native
-        // scroll), so continuousMode stays false here.
-        vnMode: s.isVnMode,
-        fontSize: s.fontSize.round(),
-        initialFragment: _initialFragment,
-        sasayakiCuesJson: sasayakiCuesJson,
-        chromeTopInset: _readerTopOffset,
-        // TODO-975：单一真相源 _readerBottomReserve（悬浮态 0 / 挤压态含底栏高 + 系统
-        // inset），取代旧 `_showChrome ? height+inset : inset` 三元式。
-        chromeBottomInset: _readerBottomReserve,
-        dartPageWidth: screenSize.width,
-        dartPageHeight: screenSize.height,
-        blurImages: s.blurImages,
-        // TODO-1289：把本次会话已揭开的防剧透图 key 嵌入分页脚本，重载时不再重新遮罩。
-        revealedKeysJson: jsonEncode(_revealedImageKeys.toList()),
-        vnRevealSpeed: vnRevealSpeed,
-        vnScreenMode: s.visualNovelScreenMode,
-        vnSentencesPerScreen: s.visualNovelSentencesPerScreen,
-        vnPreserveDialogue: s.visualNovelPreserveDialogueBubbles,
-        vnMergeCrossScreenSasayakiCues:
-            s.visualNovelMergeCrossScreenSasayakiCues,
-        // TODO-perf（跨章）：JS 侧埋点与 Dart 侧同一个开关。生产下恒 false，
-        // perfMark / perfSnapshot 在 JS 里直接 early-return（不读 performance、不
-        // stringify），不在热路径上留无条件开销。
-        perfTraceEnabled: ReaderChapterPerfTrace.enabled,
+      ReaderPaginationScripts.engineShell(
+        vnMode: vnMode,
+        continuousMode: continuousMode,
       ),
     );
 
-    final String furiganaJs = _buildFuriganaJs(s.furiganaMode);
+    // 三种 furigana 模式的监听器全部随引擎发，运行时按 C.furiganaMode 选一个装。
+    final String furiganaJs = _buildFuriganaJs();
 
     final String caretJs = ReaderCaretScripts.source();
-    // TODO-975：与 chromeBottomInset 同源 _readerBottomReserve（悬浮 0 / 挤压含底栏）。
-    final double caretBottomInset = _readerBottomReserve;
-    final String caretInit = ReaderCaretScripts.initInvocation(
-      color: _caretRingColorCss(),
-      insetTop: _readerTopOffset,
-      insetBottom: caretBottomInset,
-    );
 
-    // TODO-perf（跨章）：整段 setup 脚本每次跨章都要跨 platform channel 传给 WebView 再
-    // 解析执行（实测 evalSetupScript 中位数 25~40ms，与章节体量无关 = 纯固定开销）。
-    // 注入前剥掉整行注释与空行（见 ReaderScriptCompactor）——传的是同一份语义的脚本，
-    // 只是不再把给人看的中文注释也编组、传输、解析一遍。
-    return ReaderScriptCompactor.compact('''
-(function() {
+    return '''
+window.__hoshiEngine = {
+install: function(C) {
   // BUG-1017: guarantee the `#hoshi-cloak` FOUC guard is always removed, even if
   // any synchronous statement in this setup IIFE throws before the tail reaches
   // its removal (below). Without this a single unhandled sync error anywhere in
@@ -666,19 +695,27 @@ extension _ReaderWebView on _ReaderHibikiPageState {
   Promise.resolve().then(function() {
     try { var c = document.getElementById('hoshi-cloak'); if (c) c.remove(); } catch (_ignored) {}
   });
-  window.scanNonJapaneseText = ${appModel.scanNonJapaneseText};
+  window.scanNonJapaneseText = C.scanNonJapaneseText;
   $selectionJs
   $paginationJs
+  window.__hoshiInstallShell(C);
   $caretJs
-  $caretInit;
+  // TODO-975：insetBottom 与 chromeBottomInset 同源 _readerBottomReserve
+  // （悬浮 0 / 挤压含底栏），由 Dart 侧算好放进 C。
+  window.hoshiCaret.init({
+    color: C.caretColor,
+    insetTop: C.caretInsetTop,
+    insetBottom: C.caretInsetBottom,
+    scopeSelector: null
+  });
   $furiganaJs
   // BUG-239: 连续模式不让 _gestureEnd 回传 onSwipe（交给原生滚动 + 边界 IIFE），
   // 消除横向滑动 90% 跳页与原生滚动的轴向冲突；分页模式照旧水平滑动翻页。
-  var hoshiContinuousMode = $continuousMode;
+  var hoshiContinuousMode = C.continuousMode;
   // TODO-909 M0: VN-mode blank-tap advance flag (see Dart above).
-  var hoshiVnMode = $vnMode;
-  var hoshiVnClickAdvance = $vnClickAdvance;
-  window.__hoverAutoLookup = $hoverAutoLookup;
+  var hoshiVnMode = C.vnMode;
+  var hoshiVnClickAdvance = C.vnClickAdvance;
+  window.__hoverAutoLookup = C.hoverAutoLookup;
   var startX = 0, startY = 0, startTime = 0, hasStart = false;
   var gestureExceededTapSlop = false;
   var imageLongPressTimer = null;
@@ -848,8 +885,8 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     var velocity = absDx / Math.max(1, elapsed) * 1000;
     var horizontalEnough = absDx > absDy;
     var distanceEnough =
-        absDx >= $swipeDistThreshold ||
-        (absDx >= $swipeFastDistThreshold && velocity >= 900);
+        absDx >= C.swipeDistThreshold ||
+        (absDx >= C.swipeFastDistThreshold && velocity >= 900);
     if (horizontalEnough && distanceEnough) {
       return dx < 0 ? 'left' : 'right';
     }
@@ -950,7 +987,7 @@ extension _ReaderWebView on _ReaderHibikiPageState {
   // 上限）。Dart 是唯一写者：本脚本注入时带当前真值，之后 chrome 翻转与设置热更新由
   // _syncTapGateJs 刷新。tap 手势据此在 JS 侧直接 selectText（见 _gestureEnd 的 tap
   // 分支），砍掉 onTap→Dart→evaluateJavascript 的整个来回。
-  window.__hoshiTapGate = { chrome: $_showChrome, lookup: ${ReaderHibikiSource.instance.highlightOnTap}, maxLen: 400 };
+  window.__hoshiTapGate = { chrome: C.showChrome, lookup: C.highlightOnTap, maxLen: 400 };
   function _gestureEnd(x, y, e) {
     if (!hasStart) return;
     // TODO-1317: a mobile long-press drag-select owns this gesture (finalized
@@ -982,7 +1019,7 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     var velocity = absDx / Math.max(1, elapsed) * 1000;
     // BUG-239: 连续模式（hoshiContinuousMode）不在此回传 onSwipe——原生滚动沿书写轴
     // 翻屏，到边界由 onBoundarySwipe 跨章；此处的水平 onSwipe 只属分页模式。
-    if (!hoshiContinuousMode && absDx > absDy && (absDx >= $swipeDistThreshold || (absDx >= $swipeFastDistThreshold && velocity >= 900))) {
+    if (!hoshiContinuousMode && absDx > absDy && (absDx >= C.swipeDistThreshold || (absDx >= C.swipeFastDistThreshold && velocity >= 900))) {
       if (e && e.preventDefault) e.preventDefault();
       if (dx < 0) {
         window.flutter_inappwebview.callHandler('onSwipe', 'left');
@@ -1012,12 +1049,12 @@ extension _ReaderWebView on _ReaderHibikiPageState {
         if (e && e.preventDefault) e.preventDefault();
         window.hoshiReader.paginate('forward');
       } else {
-        // TODO-806 [806-TAP] 框选点击坐标取证探针（默认 off，由 DebugLogService 门控
-        // 注入：${DebugLogService.instance.enabled} 为 false 时整段不进 JS）。打印 onTap
+        // TODO-806 [806-TAP] 框选点击坐标取证探针（默认 off，由 DebugLogService 门控：
+        // C.debugLogging 为 false 时整段跳过，不打日志）。打印 onTap
         // 实际回传的点击坐标，口径=WebView CSS 视口像素（e.clientX/clientY），**不是** OS
         // 屏幕坐标——差一个 devicePixelRatio + 页面在屏内的偏移，这条标明口径以正本清源。
         // 走 console.log → onConsoleMessage → debugPrint → DebugLogService 环形缓冲。
-        if (${DebugLogService.instance.enabled}) {
+        if (C.debugLogging) {
           try {
             console.log('[806-TAP] clientX=' + x + ' clientY=' + y
               + ' shift=' + !!(e && e.shiftKey)
@@ -1419,11 +1456,11 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
     // 旗在此 return 挡掉、永不回传落库（见下方）。无需再区分「是否用户驱动」。
     function _reportReaderScroll() {
       var r = window.hoshiReader;
-      // TODO-151/164 / BUG-225 诊断：默认 off（${DebugLogService.instance.enabled}
-      // 由 DebugLogService 门控注入），开了才打印。reanchorPending=true 会早返回不回传，
+      // TODO-151/164 / BUG-225 诊断：默认 off（C.debugLogging 由 DebugLogService
+      // 下发），开了才打印。reanchorPending=true 会早返回不回传，
       // hasBridge=false 说明 callHandler 不可用——便于真机定位「滚动了但进度没动」哪一链断。
       // console.log 经 onConsoleMessage → debugPrint → DebugLogService 环形缓冲。
-      if (${DebugLogService.instance.enabled}) {
+      if (C.debugLogging) {
         console.log('[ReaderDiag] scroll report'
           + ' reanchorPending=' + (r ? r._reanchorPending === true : 'noReader')
           + ' hasBridge=' + !!(window.flutter_inappwebview && window.flutter_inappwebview.callHandler));
@@ -1456,9 +1493,43 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
   $longPressDragJs
   var cloak = document.getElementById('hoshi-cloak');
   if (cloak) cloak.remove();
-})();
-''');
+}
+};
+''';
   }
+
+  /// 引擎源码只依赖 view-mode 与编译期常量，一个进程里逐字不变——每种模式建一次就够。
+  /// 拼装 + 压缩要扫近万行（实测 9ms），绝不能每次跨章重跑。
+  static final Map<String, String> _cachedEngineSource = <String, String>{};
+
+  /// 注入用的引擎源码（按 view-mode memoized）。
+  ///
+  /// 注入前剥掉整行注释与空行（见 [ReaderScriptCompactor]）——传的是同一份语义的
+  /// 脚本，只是不再把给人看的中文注释也编组、传输、解析一遍。
+  static String readerEngineSource({
+    required bool vnMode,
+    required bool continuousMode,
+  }) {
+    final String key =
+        vnMode ? 'vn' : (continuousMode ? 'continuous' : 'paged');
+    return _cachedEngineSource.putIfAbsent(
+      key,
+      () => ReaderScriptCompactor.compact(
+        _buildReaderEngineSource(
+          vnMode: vnMode,
+          continuousMode: continuousMode,
+        ),
+      ),
+    );
+  }
+
+  /// 每次导航下发的那一小份：config + 一次 install 调用。
+  ///
+  /// 与引擎源码拼在**同一次** `evaluateJavascript` 里发出去（往返次数不变）；
+  /// 分开写只是为了让引擎那半边可以 memoize。
+  static String readerEngineBoot(ReaderEngineConfig config) =>
+      'window.__hoshiReaderConfig = ${config.toJsLiteral()};'
+      'window.__hoshiEngine.install(window.__hoshiReaderConfig);';
 
   static String _stripScriptTags(String js) {
     return js
@@ -2276,8 +2347,17 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
       if (_currentChapter != chapterSnapshot || _navigateGeneration != gen) {
         return;
       }
+      // per-nav 参数走 config，引擎源码按 view-mode memoized。两半拼成**一次**
+      // evaluateJavascript 发出去——注入通道与执行时刻都与改动前逐字相同，省掉的是
+      // Dart 侧每章重新拼装 + 压缩近万行（实测 buildSetupScript 中位数 9ms）。
+      final ReaderEngineConfig engineConfig =
+          _buildReaderEngineConfig(sasayakiCuesJson: sasayakiCuesJson);
+      final String engineSource = readerEngineSource(
+        vnMode: engineConfig.vnMode,
+        continuousMode: engineConfig.continuousMode,
+      );
       final String setupScript =
-          _buildReaderSetupScript(sasayakiCuesJson: sasayakiCuesJson);
+          '$engineSource\n${readerEngineBoot(engineConfig)}';
       ReaderChapterPerfTrace.mark('buildSetupScript');
       ReaderChapterPerfTrace.noteSize('setupChars', setupScript.length);
       await controller.evaluateJavascript(source: setupScript);
@@ -2328,3 +2408,37 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
     }
   }
 }
+
+/// 静态引擎源码的公开入口（默认分页模式）。
+///
+/// 守卫测试用它断言「引擎里确实含有全部载荷」「引擎与导航状态无关」——这条链路
+/// 此前完全没有：所有脚本守卫都只断言各 builder 的返回值，没人断言那些返回值真的
+/// 进了注入物，漏装一个载荷 ~100 条测试照样全绿。
+String readerHibikiEngineSource({
+  bool vnMode = false,
+  bool continuousMode = false,
+}) =>
+    _ReaderWebView.readerEngineSource(
+      vnMode: vnMode,
+      continuousMode: continuousMode,
+    );
+
+/// 每次导航下发的那一小份（config + install 调用），供守卫测试断言它不含引擎本体。
+String readerHibikiEngineBoot(ReaderEngineConfig config) =>
+    _ReaderWebView.readerEngineBoot(config);
+
+/// 压缩**之前**的引擎源码 = 生产上真正交给 [ReaderScriptCompactor] 的那份。
+///
+/// 给压缩器守卫测试用：它要证明压缩器对**真实最终注入载荷**只删空行与整行注释、
+/// 幂等、扫完词法状态干净。此前那份「最终拼装脚本」是把 `webview.part.dart` 的三引号
+/// 模板抠出来、按一张手写替身表重建的——那张表是查找表，**新增**插值会 StateError
+/// （响亮），**删掉**一个载荷完全静默：整份注入物少一块，压缩覆盖跟着少一块，而没有
+/// 一条测试会红。现在直接向生产代码要同一份对象，那个不对称从根上没有了。
+String readerHibikiEngineSourceUncompacted({
+  bool vnMode = false,
+  bool continuousMode = false,
+}) =>
+    _ReaderWebView._buildReaderEngineSource(
+      vnMode: vnMode,
+      continuousMode: continuousMode,
+    );

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -52,6 +52,7 @@ import 'package:hibiki/src/profile/profile_repository.dart';
 import 'package:hibiki/src/profile/profile_view_model.dart';
 import 'package:hibiki/src/reader/reader_caret_scripts.dart';
 import 'package:hibiki/src/reader/reader_chapter_perf_trace.dart';
+import 'package:hibiki/src/reader/reader_engine_config.dart';
 import 'package:hibiki/src/reader/reader_script_compactor.dart';
 import 'package:hibiki/src/reader/reader_chrome_scaler.dart';
 import 'package:hibiki/src/reader/reader_lyrics_caret_scripts.dart';

--- a/hibiki/lib/src/reader/reader_engine_config.dart
+++ b/hibiki/lib/src/reader/reader_engine_config.dart
@@ -1,0 +1,151 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show immutable;
+
+/// BUG-1140 第二阶段①：阅读器引擎 JS 的**每次导航参数**。
+///
+/// 背景：此前整份引擎脚本（selection + 三种 shell + caret + furigana + 手势，压缩后
+/// 仍 ~145K 字符）在 Dart 侧把 `insets / pageWidth / progress / charOffset / fragment /
+/// sasayakiCues …` 逐个**插值进源码**，于是每次跨章都是一份**全新的字符串**：既要过一次
+/// platform channel，又要让 WebView 的 JS 引擎从零解析编译（`evaluateJavascript` 的字符串
+/// 没有 V8 code cache）。实测 `evalSetupScript` 中位数 24ms，与章节体量无关 = 纯固定开销。
+///
+/// 修法：引擎源码变成**零插值的静态资源**（`<script src>` 走 hoshi.local 拦截器 + 强缓存，
+/// 见 `ReaderEngineScript`），只暴露一个 `window.__hoshiEngine.install(C)`；本类就是那个
+/// `C`——每次导航只下发这一小份 JSON，引擎在**运行时读取**它。
+///
+/// 因此本类是「per-nav 参数」的唯一真相源：**任何随导航/设置变化的值都必须落在这里**，
+/// 不得回到脚本源码里插值（否则引擎不再静态，缓存与编译复用同时失效）。守卫见
+/// `test/reader/reader_engine_static_source_guard_test.dart`。
+@immutable
+class ReaderEngineConfig {
+  const ReaderEngineConfig({
+    required this.continuousMode,
+    required this.vnMode,
+    required this.vnClickAdvance,
+    required this.scanNonJapaneseText,
+    required this.hoverAutoLookup,
+    required this.highlightOnTap,
+    required this.showChrome,
+    required this.debugLogging,
+    required this.swipeDistThreshold,
+    required this.swipeFastDistThreshold,
+    required this.furiganaMode,
+    required this.caretColor,
+    required this.caretInsetTop,
+    required this.caretInsetBottom,
+    required this.initialProgress,
+    required this.initialCharOffset,
+    required this.initialCharOffsetEnd,
+    required this.initialFragment,
+    required this.chromeTopInset,
+    required this.chromeBottomInset,
+    required this.dartPageWidth,
+    required this.dartPageHeight,
+    required this.blurImages,
+    required this.revealedKeys,
+    required this.perfTraceEnabled,
+    required this.vnRevealSpeed,
+    required this.vnScreenMode,
+    required this.vnSentencesPerScreen,
+    required this.vnPreserveDialogue,
+    required this.vnMergeCrossScreenSasayakiCues,
+    this.sasayakiCuesJson,
+  });
+
+  // ── 视图模式 / 手势 ────────────────────────────────────────────────
+  final bool continuousMode;
+  final bool vnMode;
+  final bool vnClickAdvance;
+  final bool scanNonJapaneseText;
+  final bool hoverAutoLookup;
+  final bool highlightOnTap;
+  final bool showChrome;
+  final bool debugLogging;
+  final int swipeDistThreshold;
+  final int swipeFastDistThreshold;
+
+  /// `off` / `partial` / `toggle`（`ReaderSettings.furiganaMode` 的值域）。
+  final String furiganaMode;
+
+  // ── caret ─────────────────────────────────────────────────────────
+  final String caretColor;
+  final double caretInsetTop;
+  final double caretInsetBottom;
+
+  // ── 恢复锚（三选一，优先级 fragment > charOffset > progress）────────
+  final double initialProgress;
+  final int initialCharOffset;
+  final int initialCharOffsetEnd;
+  final String? initialFragment;
+
+  // ── 版面几何 ──────────────────────────────────────────────────────
+  final double chromeTopInset;
+  final double chromeBottomInset;
+  final double? dartPageWidth;
+  final double? dartPageHeight;
+
+  // ── 图片 ──────────────────────────────────────────────────────────
+  final bool blurImages;
+  final List<String> revealedKeys;
+
+  // ── 诊断 ──────────────────────────────────────────────────────────
+  final bool perfTraceEnabled;
+
+  // ── VN shell ──────────────────────────────────────────────────────
+  final int vnRevealSpeed;
+  final String vnScreenMode;
+  final int vnSentencesPerScreen;
+  final bool vnPreserveDialogue;
+  final bool vnMergeCrossScreenSasayakiCues;
+
+  /// 有声书 sasayaki cue 列表，**已经是 JSON 文本**（`_prepareSasayakiCuesJson` 的
+  /// 产物）。原样嵌进 config 字面量，避免「解码再编码」多走一遍。`null` = 本章无 cue。
+  final String? sasayakiCuesJson;
+
+  /// 除 [sasayakiCuesJson] 外的全部字段（它是已编码的 JSON 片段，见 [toJsLiteral]）。
+  Map<String, Object?> toJson() => <String, Object?>{
+        'continuousMode': continuousMode,
+        'vnMode': vnMode,
+        'vnClickAdvance': vnClickAdvance,
+        'scanNonJapaneseText': scanNonJapaneseText,
+        'hoverAutoLookup': hoverAutoLookup,
+        'highlightOnTap': highlightOnTap,
+        'showChrome': showChrome,
+        'debugLogging': debugLogging,
+        'swipeDistThreshold': swipeDistThreshold,
+        'swipeFastDistThreshold': swipeFastDistThreshold,
+        'furiganaMode': furiganaMode,
+        'caretColor': caretColor,
+        'caretInsetTop': caretInsetTop,
+        'caretInsetBottom': caretInsetBottom,
+        'initialProgress': initialProgress,
+        'initialCharOffset': initialCharOffset,
+        'initialCharOffsetEnd': initialCharOffsetEnd,
+        'initialFragment': initialFragment,
+        'chromeTopInset': chromeTopInset,
+        'chromeBottomInset': chromeBottomInset,
+        'dartPageWidth': dartPageWidth?.round(),
+        'dartPageHeight': dartPageHeight?.round(),
+        'blurImages': blurImages,
+        'revealedKeys': revealedKeys,
+        'perfTraceEnabled': perfTraceEnabled,
+        'vnRevealSpeed': vnRevealSpeed,
+        'vnScreenMode': vnScreenMode,
+        'vnSentencesPerScreen': vnSentencesPerScreen,
+        'vnPreserveDialogue': vnPreserveDialogue,
+        'vnMergeCrossScreenSasayakiCues': vnMergeCrossScreenSasayakiCues,
+      };
+
+  /// 可直接嵌进 JS 的对象字面量。
+  ///
+  /// [sasayakiCuesJson] 本身已是合法 JSON（数组）文本，直接拼进来；其余字段走
+  /// [jsonEncode]。这样避免 `jsonDecode` 一遍再 `jsonEncode` 一遍（cue 列表按章可达数千条）。
+  String toJsLiteral() {
+    final String head = jsonEncode(toJson());
+    assert(head.startsWith('{') && head.endsWith('}'));
+    final String body = head.substring(1, head.length - 1);
+    final String cues = sasayakiCuesJson ?? 'null';
+    return '{$body,"sasayakiCues":$cues}';
+  }
+}

--- a/hibiki/lib/src/reader/reader_pagination_scripts.dart
+++ b/hibiki/lib/src/reader/reader_pagination_scripts.dart
@@ -762,79 +762,39 @@ class ReaderPaginationScripts {
     return null;
   }
 
-  static String shellScript({
-    double initialProgress = 0.0,
-    int initialCharOffset = -1,
-    // BUG-461：收藏句跳转的句尾绝对字符偏移（句首 [initialCharOffset] + 句长）。仅连续
-    // 模式横排用它把整句对齐进可见区（句尾不被阅读底栏切）。<0 / 不传 = 单点句首锚（旧）。
-    int initialCharOffsetEnd = -1,
-    bool continuousMode = false,
-    // TODO-909: VN is the third view-mode. It is mutually exclusive with
-    // [continuousMode] (VN is a page-flip stage, not native scroll). When true
-    // it overrides [continuousMode] and selects the VN shell.
-    bool vnMode = false,
-    int fontSize = ReaderLayoutDefaults.fontSizePx,
-    String? sasayakiCuesJson,
-    String? initialFragment,
-    double chromeTopInset = 0.0,
-    double chromeBottomInset = 0.0,
-    double? dartPageWidth,
-    double? dartPageHeight,
-    bool blurImages = false,
-    String revealedKeysJson = '[]',
-    int vnRevealSpeed = 0,
-    String vnScreenMode = 'block',
-    int vnSentencesPerScreen = 1,
-    bool vnPreserveDialogue = false,
-    bool vnMergeCrossScreenSasayakiCues = false,
-    // 跨章分段计时总开关。默认 false = 生产；JS 侧 perfMark / perfSnapshot 零开销。
-    bool perfTraceEnabled = false,
+  /// 三种 view-mode 的 shell 源码，按模式选一份（零 per-nav 插值）。
+  ///
+  /// 改动前是 `shellScript({initialProgress, chromeTopInset, sasayakiCuesJson, …})`
+  /// —— 每次导航把当次参数插进源码，产出一份全新字符串，Dart 侧每章都要重新拼装 +
+  /// 压缩近万行。现在每种 shell 被包成一个只读取运行时 config 的安装函数，源码在一个
+  /// 进程里逐字不变，于是可以 memoize（见 `readerEngineSource`）。
+  ///
+  /// 每个 shell 函数体与改动前对应 shell 的 IIFE 内容逐字对应（`$x` → `C.x`），
+  /// 词法作用域自洽：shell 顶层只声明 `_hoshiBootInitialize`，其余全部写 `window.*`
+  /// 全局，与外层手势层之间没有任何跨作用域引用（守卫
+  /// `test/reader/reader_engine_static_source_guard_test.dart`）。
+  static String engineShell({
+    required bool vnMode,
+    required bool continuousMode,
   }) {
-    if (vnMode) {
-      return ReaderVisualNovelScripts.vnShellScript(
-        initialProgress: initialProgress,
-        initialCharOffset: initialCharOffset,
-        sasayakiCuesJson: sasayakiCuesJson,
-        initialFragment: initialFragment,
-        blurImages: blurImages,
-        revealSpeed: vnRevealSpeed,
-        screenMode: vnScreenMode,
-        sentencesPerScreen: vnSentencesPerScreen,
-        preserveDialogue: vnPreserveDialogue,
-        mergeCrossScreenSasayakiCues: vnMergeCrossScreenSasayakiCues,
-      );
-    }
-    if (continuousMode) {
-      return _continuousShellScript(
-        initialProgress: initialProgress,
-        initialCharOffset: initialCharOffset,
-        initialCharOffsetEnd: initialCharOffsetEnd,
-        sasayakiCuesJson: sasayakiCuesJson,
-        initialFragment: initialFragment,
-        chromeTopInset: chromeTopInset,
-        chromeBottomInset: chromeBottomInset,
-        dartPageWidth: dartPageWidth,
-        dartPageHeight: dartPageHeight,
-        blurImages: blurImages,
-        revealedKeysJson: revealedKeysJson,
-        perfTraceEnabled: perfTraceEnabled,
-      );
-    }
-    return _paginatedShellScript(
-      initialProgress: initialProgress,
-      initialCharOffset: initialCharOffset,
-      fontSize: fontSize,
-      sasayakiCuesJson: sasayakiCuesJson,
-      initialFragment: initialFragment,
-      chromeTopInset: chromeTopInset,
-      chromeBottomInset: chromeBottomInset,
-      dartPageWidth: dartPageWidth,
-      dartPageHeight: dartPageHeight,
-      blurImages: blurImages,
-      revealedKeysJson: revealedKeysJson,
-      perfTraceEnabled: perfTraceEnabled,
-    );
+    final String shell = vnMode
+        ? ReaderVisualNovelScripts.vnShellScript()
+        : (continuousMode ? continuousShellSource() : paginatedShellSource());
+    return '''<script>
+window.__hoshiShells = {};
+${_stripShellScriptTags(shell)}
+window.__hoshiInstallShell = function(C) {
+  if (C.vnMode) return window.__hoshiShells.vn(C);
+  if (C.continuousMode) return window.__hoshiShells.continuous(C);
+  return window.__hoshiShells.paginated(C);
+};
+</script>''';
   }
+
+  /// 三个 shell 各自仍以 `<script>…</script>` 形式返回（它们的单测按这个形状钉着），
+  /// 拼进引擎时剥掉外层标签。
+  static String _stripShellScriptTags(String js) =>
+      js.replaceAll('<script>', '').replaceAll('</script>', '').trim();
 
   // ── Shared JS (properties + methods used by both modes) ────────────
 
@@ -1668,6 +1628,41 @@ class ReaderPaginationScripts {
 
   // ── Shared init logic (viewport + SVG + images) ────────────────────
 
+  /// BUG-1140 第二阶段①：恢复锚的三选一从「Dart 注入期挑一条语句」搬到运行时。
+  ///
+  /// 优先级与旧的 Dart 三元式逐条相同：`initialFragment` 非空 → `jumpToFragment`；
+  /// 否则 `initialCharOffset >= 0` → `restoreToCharOffset`；否则 `restoreProgress`。
+  /// 分页 shell 只用单点句首锚（旧实现也只传一个参数）。
+  static const String _paginatedInitialRestoreJs = '''
+    if (C.initialFragment !== null && C.initialFragment !== undefined) {
+      window.hoshiReader.jumpToFragment(C.initialFragment);
+    } else if (C.initialCharOffset >= 0) {
+      window.hoshiReader.restoreToCharOffset(C.initialCharOffset);
+    } else {
+      window.hoshiReader.restoreProgress(C.initialProgress);
+    }''';
+
+  /// 连续 shell 版：多一条 BUG-461 的句尾区间对齐分支（`initialCharOffsetEnd >
+  /// initialCharOffset` 时透传句尾偏移），其余与 [_paginatedInitialRestoreJs] 相同。
+  static const String _continuousInitialRestoreJs = '''
+    if (C.initialFragment !== null && C.initialFragment !== undefined) {
+      window.hoshiReader.jumpToFragment(C.initialFragment);
+    } else if (C.initialCharOffset >= 0) {
+      if (C.initialCharOffsetEnd > C.initialCharOffset) {
+        window.hoshiReader.restoreToCharOffset(C.initialCharOffset, C.initialCharOffsetEnd);
+      } else {
+        window.hoshiReader.restoreToCharOffset(C.initialCharOffset);
+      }
+    } else {
+      window.hoshiReader.restoreProgress(C.initialProgress);
+    }''';
+
+  /// 有声书 cue 下发：旧实现「有 cue 才注入这一行」，现在「有 cue 才调用」。
+  static const String _sharedSasayakiInitJs = '''
+    if (C.sasayakiCues !== null && C.sasayakiCues !== undefined) {
+      window.hoshiReader.applySasayakiCues(C.sasayakiCues);
+    }''';
+
   static const String _sharedInitViewport = '''
   var viewport = document.querySelector('meta[name="viewport"]');
   if (viewport) { viewport.remove(); }
@@ -1685,19 +1680,9 @@ class ReaderPaginationScripts {
   /// 图片合并注入的前导插图（`.hoshi-merged-image`）保持 eager（不被挂 lazy），
   /// 从而 firstContentEdge 计入全部前导图、章首锚不跳过第一张。
   @visibleForTesting
-  static String initImagesScriptForTesting({
-    bool blurImages = false,
-    String revealedKeysJson = '[]',
-  }) =>
-      _sharedInitImages(
-        blurImages: blurImages,
-        revealedKeysJson: revealedKeysJson,
-      );
+  static String initImagesScriptForTesting() => _sharedInitImages();
 
-  static String _sharedInitImages({
-    bool blurImages = false,
-    String revealedKeysJson = '[]',
-  }) {
+  static String _sharedInitImages() {
     // TODO-1289：图片防剧透遮罩「点击揭开后又恢复」根因——揭开只删 DOM `blurred`
     // class，章节 (重)载 / 布局设置切换（writing mode / 分栏 / view mode / spread /
     // blur 开关，均经 _reloadWithCurrentSettings→_loadChapterDirectly）会重跑
@@ -1706,21 +1691,27 @@ class ReaderPaginationScripts {
     // baseURI 解析成绝对 URL）注入成 map，_hoshiBlurImage 命中则跳过重新遮罩。揭开
     // 状态的真相源是 Dart 侧 _revealedImageKeys（内存会话集），经 onImageRevealed
     // 回传持久，重载时再嵌入这里。domStorageEnabled=false 故不用 localStorage。
-    final String blurFn = blurImages
-        ? '''
+    // BUG-1140 第二阶段①：整块从「blurImages 为假时**整段不注入**」改成「函数照常
+    // 定义、副作用照常受 C.blurImages 门控」。行为等价：`window.__hoshiMarkImageRevealed`
+    // / `window.__hoshiImageRevealKey` 两个全局仍**只在开了防剧透遮罩时**才挂上
+    // （caret / 有声书桥接都用 `if (window.__hoshiImageRevealKey && …)` 探测），
+    // `_hoshiBlurImage` 也仍只在开关为真时被调用。
+    const String blurFn = '''
   var _hoshiRevealedKeys = Object.create(null);
-  (function() {
-    var keys = $revealedKeysJson;
-    if (keys && keys.length) {
-      for (var i = 0; i < keys.length; i++) { _hoshiRevealedKeys[keys[i]] = true; }
+  if (C.blurImages) {
+    var __hoshiKeys = C.revealedKeys;
+    if (__hoshiKeys && __hoshiKeys.length) {
+      for (var i = 0; i < __hoshiKeys.length; i++) { _hoshiRevealedKeys[__hoshiKeys[i]] = true; }
     }
-  })();
+  }
   // TODO-1367：暴露给有声书桥接（audiobook_bridge）——音频跟随读过某张图时把它的稳定
   // reveal key 登记进本活集，日后该图（含尚未 load 的懒图）真正 load 走 _hoshiBlurImage
   // 时命中 key 跳过遮罩，与点击 / 手柄揭开同一套「已揭开不再遮罩」真相源（会话内存活集）。
-  window.__hoshiMarkImageRevealed = function(key) {
-    if (key) _hoshiRevealedKeys[key] = true;
-  };
+  if (C.blurImages) {
+    window.__hoshiMarkImageRevealed = function(key) {
+      if (key) _hoshiRevealedKeys[key] = true;
+    };
+  }
   // BUG-898：稳定 reveal key 归一到「extractDir 相对、decode、正斜杠」路径（如
   // OEBPS/images/foo.jpg），与图片库磁盘 File 的相对路径、Dart ImageRevealKey.normalize
   // 完全一致 —— 三端（阅读器 WebView / 图片库 / Drift 持久表）共享同一 key，才能双向同步。
@@ -1746,15 +1737,16 @@ class ReaderPaginationScripts {
       return path.substring(i + pfx.length);
     } catch (e) { return raw; }
   }
-  window.__hoshiImageRevealKey = _hoshiImageRevealKey;
+  if (C.blurImages) {
+    window.__hoshiImageRevealKey = _hoshiImageRevealKey;
+  }
   function _hoshiBlurImage(element) {
     var key = _hoshiImageRevealKey(element);
     if (key && _hoshiRevealedKeys[key]) return;
     element.classList.add('blurred');
-  }'''
-        : '';
-    final String blurSvgCall = blurImages ? '_hoshiBlurImage(svg);' : '';
-    final String blurImgCall = blurImages ? '_hoshiBlurImage(img);' : '';
+  }''';
+    const String blurSvgCall = 'if (C.blurImages) _hoshiBlurImage(svg);';
+    const String blurImgCall = 'if (C.blurImages) _hoshiBlurImage(img);';
     return '''
 $blurFn
   Array.from(document.querySelectorAll('svg')).forEach(function(svg) {
@@ -1895,46 +1887,29 @@ if (document.readyState === 'complete') {
 
   // ── Paginated mode ─────────────────────────────────────────────────
 
-  static String _paginatedShellScript({
-    required double initialProgress,
-    int initialCharOffset = -1,
-    int fontSize = ReaderLayoutDefaults.fontSizePx,
-    String? sasayakiCuesJson,
-    String? initialFragment,
-    double chromeTopInset = 0.0,
-    double chromeBottomInset = 0.0,
-    double? dartPageWidth,
-    double? dartPageHeight,
-    bool blurImages = false,
-    String revealedKeysJson = '[]',
-    bool perfTraceEnabled = false,
-  }) {
+  /// 分页 shell 的静态源码（零 per-nav 插值，全部参数改由运行时 `C` 读取）。
+  static String paginatedShellSource() {
     // BUG-162: 优先精确字符偏移恢复（restoreToCharOffset），无精确锚（旧存档）才
     // 回退粗粒度 restoreProgress；书签/fragment 跳转仍走 jumpToFragment。
-    final String initialRestoreScript = initialFragment != null
-        ? 'window.hoshiReader.jumpToFragment(${_jsStringLiteral(initialFragment)});'
-        : (initialCharOffset >= 0
-            ? 'window.hoshiReader.restoreToCharOffset($initialCharOffset);'
-            : 'window.hoshiReader.restoreProgress($initialProgress);');
-
-    final String sasayakiInit = sasayakiCuesJson != null
-        ? 'window.hoshiReader.applySasayakiCues($sasayakiCuesJson);'
-        : '';
+    // BUG-1140 第二阶段①：三选一从「Dart 注入期挑一条语句」改成「运行时按同一优先级
+    // 读 C 分派」。判据逐条对齐旧实现（fragment 非空 > charOffset >= 0 > progress）。
+    const String initialRestoreScript = _paginatedInitialRestoreJs;
+    const String sasayakiInit = _sharedSasayakiInitJs;
 
     const int bottomOverlapPx = ReaderLayoutDefaults.bottomOverlapPx;
     const double imageWidthRatio = ReaderLayoutDefaults.imageWidthViewportRatio;
     const String spacerHeight = ReaderLayoutDefaults.trailingSpacerHeightCss;
     const String spacerWidth = ReaderLayoutDefaults.trailingSpacerWidthCss;
 
-    final String initImages = _sharedInitImages(
-        blurImages: blurImages, revealedKeysJson: revealedKeysJson);
+    final String initImages = _sharedInitImages();
 
     return '''<script>
+window.__hoshiShells.paginated = function(C) {
 window.__hoshiCssHighlightsSupported = !!(window.CSS && CSS.highlights && window.Highlight);
 window.hoshiReader = {
-  // 跨章分段计时总开关（Dart [ReaderChapterPerfTrace.enabled] 注入期写死）。
+  // 跨章分段计时总开关（Dart [ReaderChapterPerfTrace.enabled] → C.perfTraceEnabled）。
   // false = 生产路径，perfMark / perfSnapshot 零开销。
-  _perfOn: $perfTraceEnabled,
+  _perfOn: C.perfTraceEnabled === true,
   pageHeight: 0,
   pageWidth: 0,
   // TODO-734：纯视口高 V（不含 bottomOverlap=O）。竖排列高几何唯一用它（见
@@ -2641,13 +2616,13 @@ window.hoshiReader.initialize = function() {
   if (window.hoshiReader.didInitialize) return;
   window.hoshiReader.didInitialize = true;
   this.perfMark('initStart');
-  document.documentElement.style.setProperty('--chrome-top-inset', '${chromeTopInset}px');
-  document.documentElement.style.setProperty('--chrome-bottom-inset', '${chromeBottomInset}px');
+  document.documentElement.style.setProperty('--chrome-top-inset', C.chromeTopInset + 'px');
+  document.documentElement.style.setProperty('--chrome-bottom-inset', C.chromeBottomInset + 'px');
 $_sharedInitViewport
   // TODO-736 B-1：存图片宽比值供 _resetImageMaxVars 读（_sharedJs 不插值，见那里注释）。
   this._imageWidthRatio = $imageWidthRatio;
-  var dartW = ${dartPageWidth != null ? '${dartPageWidth.round()}' : 'null'};
-  var dartH = ${dartPageHeight != null ? '${dartPageHeight.round()}' : 'null'};
+  var dartW = C.dartPageWidth;
+  var dartH = C.dartPageHeight;
   var pageWidth = dartW || window.innerWidth;
   // TODO-734：viewportHeight = 纯视口高 V（不加 bottomOverlap）。pageHeight = V + O
   // 仍供图片虚高/scrollHeight 用。竖排列高几何（CSS column-width + JS contentBox）
@@ -2725,51 +2700,31 @@ window.hoshiReader.updatePageSize = function(cssWidth, cssHeight) {
   });
 };
 $_sharedInitBoot
+};
 </script>''';
   }
 
   // ── Continuous mode ────────────────────────────────────────────────
 
-  static String _continuousShellScript({
-    required double initialProgress,
-    int initialCharOffset = -1,
-    int initialCharOffsetEnd = -1,
-    String? sasayakiCuesJson,
-    String? initialFragment,
-    double chromeTopInset = 0.0,
-    double chromeBottomInset = 0.0,
-    double? dartPageWidth,
-    double? dartPageHeight,
-    bool blurImages = false,
-    String revealedKeysJson = '[]',
-    bool perfTraceEnabled = false,
-  }) {
+  /// 连续 shell 的静态源码（零 per-nav 插值，全部参数改由运行时 `C` 读取）。
+  static String continuousShellSource() {
     // BUG-162: 同分页——优先精确字符偏移恢复，旧存档回退分数。BUG-461：收藏句跳转带句尾
     // 偏移（initialCharOffsetEnd>句首）时透传给 restoreToCharOffset 做整句区间对齐。
-    final String restoreCharScript = initialCharOffsetEnd > initialCharOffset
-        ? 'window.hoshiReader.restoreToCharOffset($initialCharOffset, $initialCharOffsetEnd);'
-        : 'window.hoshiReader.restoreToCharOffset($initialCharOffset);';
-    final String initialRestoreScript = initialFragment != null
-        ? 'window.hoshiReader.jumpToFragment(${_jsStringLiteral(initialFragment)});'
-        : (initialCharOffset >= 0
-            ? restoreCharScript
-            : 'window.hoshiReader.restoreProgress($initialProgress);');
-
-    final String sasayakiInit = sasayakiCuesJson != null
-        ? 'window.hoshiReader.applySasayakiCues($sasayakiCuesJson);'
-        : '';
+    // BUG-1140 第二阶段①：判据整体搬到运行时，逐条对齐旧的 Dart 三元式。
+    const String initialRestoreScript = _continuousInitialRestoreJs;
+    const String sasayakiInit = _sharedSasayakiInitJs;
 
     const double imageWidthRatio = ReaderLayoutDefaults.imageWidthViewportRatio;
 
-    final String initImages = _sharedInitImages(
-        blurImages: blurImages, revealedKeysJson: revealedKeysJson);
+    final String initImages = _sharedInitImages();
 
     return '''<script>
+window.__hoshiShells.continuous = function(C) {
 window.__hoshiCssHighlightsSupported = !!(window.CSS && CSS.highlights && window.Highlight);
 window.hoshiReader = {
-  // 跨章分段计时总开关（Dart [ReaderChapterPerfTrace.enabled] 注入期写死）。
+  // 跨章分段计时总开关（Dart [ReaderChapterPerfTrace.enabled] → C.perfTraceEnabled）。
   // false = 生产路径，perfMark / perfSnapshot 零开销。
-  _perfOn: $perfTraceEnabled,
+  _perfOn: C.perfTraceEnabled === true,
   // TODO-734：连续模式不用竖排分页几何（无 column），故 initialize/updatePageSize
   // 不注入 --reader-viewport-height、getScrollContext 也不引用它。但属性仍声明 0
   // （补点2 防 stale）：两个 hoshiReader 实例属性表保持对齐，避免误读 undefined。
@@ -3281,12 +3236,12 @@ window.hoshiReader.initialize = function() {
   if (window.hoshiReader.didInitialize) return;
   window.hoshiReader.didInitialize = true;
   this.perfMark('initStart');
-  document.documentElement.style.setProperty('--chrome-top-inset', '${chromeTopInset}px');
-  document.documentElement.style.setProperty('--chrome-bottom-inset', '${chromeBottomInset}px');
+  document.documentElement.style.setProperty('--chrome-top-inset', C.chromeTopInset + 'px');
+  document.documentElement.style.setProperty('--chrome-bottom-inset', C.chromeBottomInset + 'px');
 $_sharedInitViewport
   // TODO-736 B-1：存图片宽比值供 _resetImageMaxVars 读（_sharedJs 不插值，见那里注释）。
   this._imageWidthRatio = $imageWidthRatio;
-  var dartH = ${dartPageHeight != null ? '${dartPageHeight.round()}' : 'null'};
+  var dartH = C.dartPageHeight;
   var contHeight = dartH || window.innerHeight;
   document.documentElement.style.setProperty('--hoshi-continuous-height', contHeight + 'px');
   var __imgBox = this._imageMaxBox();
@@ -3402,14 +3357,14 @@ window.hoshiReader.updatePageSize = function(cssWidth, cssHeight) {
   // 边界手势只保留触摸(touchstart/touchend)给手机。鼠标拖动选词到边界不再误跨章。
 })();
 $_sharedInitBoot
+};
 </script>''';
   }
 
-  // 注意：ReaderVisualNovelScripts._jsStringLiteral 是另一份独立实现（手写转义、
-  // 单引号输出）。两侧输出字节形式各被测试钉死（本文件双引号 →
-  // test/reader/reader_pagination_scripts_test.dart；VN 单引号 →
-  // test/reader/vn_shell_smoke_test.dart），刻意不共享；改任一侧转义逻辑时必须
-  // 同步核对另一侧仍是语法安全的 JS 字符串字面量转义。
+  // BUG-1140 第二阶段①：VN 侧那份手写转义的 `_jsStringLiteral` 已随「shell 不再插值」
+  // 一并删除（VN shell 不再从 Dart 造 JS 字符串字面量）。本实现仍供
+  // highlightSasayakiCue / scrollToSearchMatch 这类**调用式**注入使用，
+  // 输出字节形式由 test/reader/reader_pagination_scripts_test.dart 钉死。
   static String _jsStringLiteral(String value) {
     return jsonEncode(value);
   }

--- a/hibiki/lib/src/reader/reader_settings.dart
+++ b/hibiki/lib/src/reader/reader_settings.dart
@@ -394,7 +394,7 @@ class ReaderSettings {
 
   /// 翻页滑动灵敏度系数（TODO-113）。1.0 = 默认手感；<1 更灵敏（更短的滑动即可
   /// 翻页），>1 更迟钝（需滑得更远）。系数缩放 JS 端 `_gestureEnd` 的基础距离阈值
-  /// （44px / 快速短滑 22px），见 reader_hibiki_page.dart `_buildReaderSetupScript`。
+  /// （44px / 快速短滑 22px），见 webview.part.dart `_buildReaderEngineConfig`。
   static double normalizeSwipePageTurnSensitivity(num value) =>
       value.toDouble().clamp(0.3, 2.0).toDouble();
 

--- a/hibiki/lib/src/reader/reader_visual_novel_scripts.dart
+++ b/hibiki/lib/src/reader/reader_visual_novel_scripts.dart
@@ -38,73 +38,31 @@ import 'package:hibiki/src/reader/reader_content_styles.dart'
 class ReaderVisualNovelScripts {
   ReaderVisualNovelScripts._();
 
-  /// Returns the full `<script>...</script>` shell for VN mode.
-  static String vnShellScript({
-    double initialProgress = 0.0,
-    int initialCharOffset = -1,
-    String? sasayakiCuesJson,
-    String? initialFragment,
-    bool blurImages = false,
-    int revealSpeed = 0,
-    String screenMode = 'block',
-    int sentencesPerScreen = 1,
-    bool preserveDialogue = false,
-    bool mergeCrossScreenSasayakiCues = false,
-  }) {
-    final String screenModeLiteral = _jsStringLiteral(screenMode);
-    final String initialFragmentLiteral =
-        initialFragment != null ? _jsStringLiteral(initialFragment) : 'null';
-    final String sasayakiCuesJsonLiteral = sasayakiCuesJson ?? 'null';
-    final String initialRestoreScript = initialFragment != null
-        ? 'window.hoshiReader.jumpToFragment($initialFragmentLiteral);'
-        : (initialCharOffset >= 0
-            ? 'window.hoshiReader.restoreToCharOffset($initialCharOffset);'
-            : 'window.hoshiReader.restoreProgress($initialProgress);');
-    return _shell(
-      initialProgress: initialProgress,
-      initialFragmentLiteral: initialFragmentLiteral,
-      sasayakiCuesJson: sasayakiCuesJsonLiteral,
-      blurImages: blurImages,
-      revealSpeed: revealSpeed,
-      screenModeLiteral: screenModeLiteral,
-      sentencesPerScreen: sentencesPerScreen,
-      preserveDialogue: preserveDialogue,
-      mergeCrossScreenSasayakiCues: mergeCrossScreenSasayakiCues,
-      initialRestoreScript: initialRestoreScript,
-    );
-  }
+  /// VN shell 的静态源码（`<script>…</script>`，零 per-nav 插值）。
+  ///
+  /// BUG-1140 第二阶段①：原来 `vnShellScript({initialProgress, revealSpeed, …})`
+  /// 把每次导航的参数插进源码；现在整段被包成 `window.__hoshiShells.vn = function(C)`，
+  /// 参数由运行时读 `C`。恢复锚三选一的优先级与旧 Dart 三元式逐条相同。
+  static String vnShellScript() => _shell();
 
-  // 注意：ReaderPaginationScripts._jsStringLiteral 是另一份独立实现（jsonEncode、
-  // 双引号输出）。两侧输出字节形式各被测试钉死（本文件单引号 →
-  // test/reader/vn_shell_smoke_test.dart；分页双引号 →
-  // test/reader/reader_pagination_scripts_test.dart），刻意不共享；本实现已转义
-  // 单引号字面量全部语法破坏字符（\ ' \n \r），改动时必须保持 JS 语法安全。
-  static String _jsStringLiteral(String value) {
-    final String escaped = value
-        .replaceAll(r'\', r'\\')
-        .replaceAll("'", r"\'")
-        .replaceAll('\n', r'\n')
-        .replaceAll('\r', r'\r');
-    return "'$escaped'";
-  }
+  /// 恢复锚三选一的运行时分派（旧实现在 Dart 侧三元式挑一条语句）。
+  static const String _initialRestoreJs = '''
+    if (C.initialFragment !== null && C.initialFragment !== undefined) {
+      window.hoshiReader.jumpToFragment(C.initialFragment);
+    } else if (C.initialCharOffset >= 0) {
+      window.hoshiReader.restoreToCharOffset(C.initialCharOffset);
+    } else {
+      window.hoshiReader.restoreProgress(C.initialProgress);
+    }''';
 
-  static String _shell({
-    required double initialProgress,
-    required String initialFragmentLiteral,
-    required String sasayakiCuesJson,
-    required bool blurImages,
-    required int revealSpeed,
-    required String screenModeLiteral,
-    required int sentencesPerScreen,
-    required bool preserveDialogue,
-    required bool mergeCrossScreenSasayakiCues,
-    required String initialRestoreScript,
-  }) {
+  static String _shell() {
+    const String initialRestoreScript = _initialRestoreJs;
     // TODO-1085 (BUG-513): single source of truth for the image viewport ratio,
     // shared with the paginated shell (ReaderLayoutDefaults.imageWidthViewportRatio),
     // consumed by applyImageMaxVars below.
     const double imageWidthRatio = ReaderLayoutDefaults.imageWidthViewportRatio;
     return '''<script>
+window.__hoshiShells.vn = function(C) {
 (function(global) {
   'use strict';
 
@@ -802,14 +760,14 @@ class ReaderVisualNovelScripts {
 })(window);
 
 window.hoshiReader = {
-  revealSpeed: $revealSpeed,
-  screenMode: $screenModeLiteral,
-  sentencesPerScreen: $sentencesPerScreen,
-  preserveDialogue: $preserveDialogue,
-  mergeCrossScreenSasayakiCues: $mergeCrossScreenSasayakiCues,
-  initialSasayakiCues: $sasayakiCuesJson,
-  initialProgress: $initialProgress,
-  initialFragment: $initialFragmentLiteral,
+  revealSpeed: C.vnRevealSpeed,
+  screenMode: C.vnScreenMode,
+  sentencesPerScreen: C.vnSentencesPerScreen,
+  preserveDialogue: C.vnPreserveDialogue,
+  mergeCrossScreenSasayakiCues: C.vnMergeCrossScreenSasayakiCues,
+  initialSasayakiCues: C.sasayakiCues,
+  initialProgress: C.initialProgress,
+  initialFragment: C.initialFragment,
   initialHighlights: [],
   nativeSelectionActive: false,
   activeCueId: null,
@@ -2330,7 +2288,7 @@ window.hoshiReader = {
   },
   setupReaderImage: function(element, src, wrap, blurElement) {
     return window.hoshiReaderMediaSemantics.setupReaderImage(element, src, {
-      blurImages: $blurImages,
+      blurImages: C.blurImages,
       imageBridge: window.HoshiReaderImage,
       wrap: wrap,
       blurElement: blurElement
@@ -2349,7 +2307,7 @@ window.hoshiReader = {
     // applyImageMaxVars) drive their size. Gaiji glyph images are left inline.
     this.promoteBlockImages(scope);
     return window.hoshiReaderMediaSemantics.setupReaderImages(scope, {
-      blurImages: $blurImages,
+      blurImages: C.blurImages,
       imageBridge: window.HoshiReaderImage,
       waitForImages: false
     });
@@ -3041,6 +2999,7 @@ if (document.readyState === 'complete') {
     try { if (window.console && console.error) console.error('[HoshiVN] boot restore failed', e); } catch (_ignored) {}
   }
 }
+};
 </script>''';
   }
 }

--- a/hibiki/test/pages/reader_continuous_swipe_axis_guard_static_test.dart
+++ b/hibiki/test/pages/reader_continuous_swipe_axis_guard_static_test.dart
@@ -20,7 +20,7 @@ void main() {
       reason: '必须从 ReaderSettings.isContinuousMode 注入 continuousMode 标志',
     );
     expect(
-      source.contains(r'var hoshiContinuousMode = $continuousMode;'),
+      source.contains(r'var hoshiContinuousMode = C.continuousMode;'),
       isTrue,
       reason: 'setup 脚本必须把 continuousMode 注入成 JS 变量 hoshiContinuousMode',
     );

--- a/hibiki/test/pages/reader_fixed_layout_blank_cloak_guard_static_test.dart
+++ b/hibiki/test/pages/reader_fixed_layout_blank_cloak_guard_static_test.dart
@@ -58,11 +58,11 @@ void main() {
         read('lib/src/pages/implementations/reader_hibiki/webview.part.dart');
 
     // 顶部幂等 microtask 兜底摘 cloak：Promise.resolve().then 里 getElementById('hoshi-cloak').remove()。
-    // 只按 IIFE 起始的模板串定位（不绑定 return 表达式的写法）——setup 脚本注入前会
-    // 过一层 ReaderScriptCompactor.compact(...)，本守卫钉的是 IIFE 内容，与是否包了
-    // 压缩器无关。
-    final int iifeStart = src.indexOf("'''\n(function() {");
-    expect(iifeStart, greaterThan(-1), reason: '找不到 reader-setup IIFE');
+    // BUG-1140 第二阶段①：整段 setup 由 IIFE 变成 `window.__hoshiEngine.install(C)`
+    // 的函数体（外链静态引擎，执行时刻不变）。按 install 签名定位，不绑定外层写法
+    // ——本守卫钉的是函数体内容，与是否包了压缩器 / 是不是 IIFE 无关。
+    final int iifeStart = src.indexOf('install: function(C) {');
+    expect(iifeStart, greaterThan(-1), reason: '找不到 reader-setup install 函数体');
     final String iife = src.substring(iifeStart);
     expect(iife.contains('Promise.resolve().then(function() {'), isTrue,
         reason: 'IIFE 顶部必须排 microtask 兜底（任意抛点后仍摘 cloak）');

--- a/hibiki/test/pages/reader_init_page_width_guard_static_test.dart
+++ b/hibiki/test/pages/reader_init_page_width_guard_static_test.dart
@@ -11,7 +11,7 @@ import 'reader_hibiki_page_source_corpus.dart';
 /// postFrame 调 `_syncPageSize`，于是 `w != _lastSyncedWidth` 恒为 false、初始校验恒 no-op。
 ///
 /// 修复不变式（任一退回 → 红）：
-/// 1. `_buildReaderSetupScript` 必须把 JS 实际分页用的 `screenSize` 记进 `_paginatedWidth/Height`。
+/// 1. `_buildReaderEngineConfig` 必须把 JS 实际分页用的 `screenSize` 记进 `_paginatedWidth/Height`。
 /// 2. content-ready 收尾（`_onChapterLoadComplete` / `_onRestoreComplete`）的同步基线必须取
 ///    `_paginatedWidth/Height`（= JS 已分页的宽高），不得用 content-ready 那一刻的当前
 ///    MediaQuery（`screen.width` / `screenSync.width`）抹平差值。
@@ -25,20 +25,20 @@ void main() {
       () {
     final String setup = _functionSource(
       src,
-      '  String _buildReaderSetupScript(',
+      '  ReaderEngineConfig _buildReaderEngineConfig(',
       '  // ── ',
     );
     expect(
       setup,
       contains('_paginatedWidth = screenSize.width'),
       reason:
-          'setup 脚本必须把 dartPageWidth 用的 screenSize.width 记进 _paginatedWidth，'
+          'per-nav config 必须把 dartPageWidth 用的 screenSize.width 记进 _paginatedWidth，'
           '作为 content-ready 后的「已分页基线」。',
     );
     expect(
       setup,
       contains('_paginatedHeight = screenSize.height'),
-      reason: 'setup 脚本必须同步记录 _paginatedHeight。',
+      reason: 'per-nav config 必须同步记录 _paginatedHeight。',
     );
   });
 

--- a/hibiki/test/reader/audiobook_follow_scroll_settle_guard_test.dart
+++ b/hibiki/test/reader/audiobook_follow_scroll_settle_guard_test.dart
@@ -35,9 +35,9 @@ void main() {
   /// 取 `_continuousShellScript` 函数体（连续模式那份 hoshiReader），避免误把分页 shell
   /// 的滚动函数当成命中。从签名起到下一个顶层 `static String` 声明之间。
   String continuousShellBody() {
-    final int start = scripts.indexOf('static String _continuousShellScript(');
+    final int start = scripts.indexOf('static String continuousShellSource(');
     expect(start, greaterThanOrEqualTo(0),
-        reason: '找不到 _continuousShellScript 定义');
+        reason: '找不到 continuousShellSource 定义');
     final int next = scripts.indexOf('\n  static ', start + 1);
     final int end = next >= 0 ? next : scripts.length;
     return scripts.substring(start, end);

--- a/hibiki/test/reader/chapter_jump_late_load_reanchor_test.dart
+++ b/hibiki/test/reader/chapter_jump_late_load_reanchor_test.dart
@@ -33,15 +33,8 @@ void main() {
   late String continuous;
 
   setUpAll(() {
-    paginated = ReaderPaginationScripts.shellScript(
-      initialProgress: 0.99,
-      initialCharOffset: -1,
-    );
-    continuous = ReaderPaginationScripts.shellScript(
-      continuousMode: true,
-      initialProgress: 0.99,
-      initialCharOffset: -1,
-    );
+    paginated = ReaderPaginationScripts.paginatedShellSource();
+    continuous = ReaderPaginationScripts.continuousShellSource();
   });
 
   String norm(String s) => s.replaceAll(RegExp(r'\s+'), ' ');

--- a/hibiki/test/reader/favorite_jump_sentence_fit_guard_test.dart
+++ b/hibiki/test/reader/favorite_jump_sentence_fit_guard_test.dart
@@ -9,7 +9,7 @@ import '../pages/reader_hibiki_page_source_corpus.dart';
 ///
 /// 数据流：`FavoriteSentence.normCharLength` → `_CollectionItem.normCharLength` →
 /// `Bookmark.charAnchorLength` → 阅读器 `_initialCharOffsetEnd`(charAnchor+len) →
-/// `ReaderPaginationScripts.shellScript(initialCharOffsetEnd:)` → 连续 shell
+/// `ReaderPaginationScripts.paginatedShellSource()` → 连续 shell
 /// `restoreToCharOffset(start, end)` → 连续 `scrollToCharOffset(start, endCharOffset)`
 /// 句尾区间对齐。
 ///
@@ -35,18 +35,21 @@ void main() {
         reason: '阅读器 restore 必须读 bm.charAnchorLength');
     expect(pageSrc.contains('_initialCharOffsetEnd'), isTrue,
         reason: '阅读器必须算句尾绝对偏移 _initialCharOffsetEnd');
-    expect(pageSrc.contains('initialCharOffsetEnd:'), isTrue,
-        reason: 'shellScript 调用必须把 _initialCharOffsetEnd 传给 JS');
+    expect(pageSrc.contains('initialCharOffsetEnd: _initialCharOffsetEnd,'),
+        isTrue,
+        reason: 'BUG-1140 第二阶段①后改由 ReaderEngineConfig 下发，'
+            '仍必须把 _initialCharOffsetEnd 传给 JS');
   });
 
   test('shellScript / 连续 shell 接受并透传 initialCharOffsetEnd (BUG-461)', () {
-    expect(jsSrc.contains('int initialCharOffsetEnd = -1'), isTrue,
-        reason:
-            'shellScript 与 _continuousShellScript 必须接受 initialCharOffsetEnd 参数');
-    // 连续 shell 在句尾>句首时调带两参的 restoreToCharOffset。
+    // BUG-1140 第二阶段①：句尾锚从「Dart 注入期插值」改成「运行时读 C」，
+    // 判据本身（句尾>句首才走两参 restore）必须原样保留。
+    expect(
+        jsSrc.contains('C.initialCharOffsetEnd > C.initialCharOffset'), isTrue,
+        reason: '连续 shell 必须保留「句尾>句首」的两参 restore 判据');
     expect(
       jsSrc.contains(
-          r'restoreToCharOffset($initialCharOffset, $initialCharOffsetEnd)'),
+          'restoreToCharOffset(C.initialCharOffset, C.initialCharOffsetEnd)'),
       isTrue,
       reason: '连续 shell 必须在有句尾锚时调 restoreToCharOffset(start, end)',
     );

--- a/hibiki/test/reader/image_chapter_lazy_load_guard_test.dart
+++ b/hibiki/test/reader/image_chapter_lazy_load_guard_test.dart
@@ -27,15 +27,8 @@ void main() {
   late String continuous;
 
   setUpAll(() {
-    paginated = ReaderPaginationScripts.shellScript(
-      initialProgress: 0.0,
-      initialCharOffset: 100,
-    );
-    continuous = ReaderPaginationScripts.shellScript(
-      continuousMode: true,
-      initialProgress: 0.0,
-      initialCharOffset: 100,
-    );
+    paginated = ReaderPaginationScripts.paginatedShellSource();
+    continuous = ReaderPaginationScripts.continuousShellSource();
   });
 
   String norm(String s) => s.replaceAll(RegExp(r'\s+'), ' ');

--- a/hibiki/test/reader/prev_chapter_landing_guard_test.dart
+++ b/hibiki/test/reader/prev_chapter_landing_guard_test.dart
@@ -53,10 +53,7 @@ void main() {
     test(
         'continuous restoreProgress routes progress>=0.99 to scrollToChapterEnd',
         () {
-      final String continuous = ReaderPaginationScripts.shellScript(
-        continuousMode: true,
-        initialProgress: 0.99,
-      );
+      final String continuous = ReaderPaginationScripts.continuousShellSource();
       final String n = norm(continuous);
       // 连续 restoreProgress 里 progress>=0.99 分支必须走 scrollToChapterEnd。
       expect(
@@ -70,10 +67,7 @@ void main() {
 
     test('image-only chapter keeps <img> eager (paginated + continuous)', () {
       for (final bool continuous in <bool>[false, true]) {
-        final String shell = ReaderPaginationScripts.shellScript(
-          continuousMode: continuous,
-          initialProgress: 0.99,
-        );
+        final String shell = ReaderPaginationScripts.paginatedShellSource();
         final String n = norm(shell);
         // 纯图片章检测存在。
         expect(n.contains('__hoshiImageOnlyChapter'), isTrue,
@@ -93,7 +87,7 @@ void main() {
         () {
       // 纯图片章检测用 ttuRegex（有文本即短路→非纯图片→仍 lazy）。守卫接线在场即可，
       // 行为（文本章 lazy）由 integration/headless 端到端断言。
-      final String n = norm(ReaderPaginationScripts.shellScript());
+      final String n = norm(ReaderPaginationScripts.paginatedShellSource());
       expect(n.contains("setAttribute('loading', 'lazy')"), isTrue,
           reason: '普通图仍须 lazy 分支在场（不回退 TODO-1074）');
       expect(n.contains('ttuRegex.test(document.body.textContent'), isTrue,

--- a/hibiki/test/reader/reader_engine_static_source_guard_test.dart
+++ b/hibiki/test/reader/reader_engine_static_source_guard_test.dart
@@ -1,0 +1,332 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/pages.dart';
+import 'package:hibiki/src/reader/reader_caret_scripts.dart';
+import 'package:hibiki/src/reader/reader_engine_config.dart';
+import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
+import 'package:hibiki/src/reader/reader_selection_scripts.dart';
+import 'package:hibiki/src/reader/reader_visual_novel_scripts.dart';
+
+/// 守卫：阅读器引擎 JS 的 per-nav 参数走 [ReaderEngineConfig] 运行时读取，引擎源码本身
+/// 只依赖 view-mode 与编译期常量。
+///
+/// 为什么要这套守卫：
+///
+/// 1. **引擎源码"与导航状态无关"这条性质退化不会让任何现有测试变红**。一旦有人把某个
+///    per-nav 值插回源码，memoize 就悄悄失效（每章重新拼装 + 压缩近万行，实测 9ms），
+///    而功能完全正常。第 1 组把这条性质直接钉成断言。
+/// 2. **本仓出过"守卫逃逸出覆盖范围"**：把判定从 JS 侧搬到 Dart 侧，三条扫 JS 源码的
+///    守卫一个字都管不到，CI 照样全绿。判定从 Dart 插值搬到 JS 运行时正是同一类风险。
+/// 3. **改动前的覆盖是单向的**：约 100 条脚本守卫都只断言各 builder 的返回值，没有一条
+///    断言那些返回值真的进了注入物——漏装一个载荷（caret / longPressDrag / 某个 shell），
+///    那 100 条照样全绿。第 2 组补这条链。
+void main() {
+  late String webview;
+
+  setUpAll(() {
+    webview = File(
+      'lib/src/pages/implementations/reader_hibiki/webview.part.dart',
+    ).readAsStringSync().replaceAll('\r\n', '\n');
+  });
+
+  group('1. 引擎源码与导航状态无关', () {
+    test('引擎构造器是 static，参数表只有 view-mode 开关', () {
+      // 这是本改动的地基：static 让编译器保证引擎源码不可能掺进 _settings /
+      // _initialProgress / MediaQuery 这类每次导航才知道的值。
+      // static 保证读不到实例状态；参数表只许有 view-mode 两个开关——多一个
+      // per-nav 参数，引擎就会随导航变化，memoize 立刻失效。
+      final int declIdx =
+          webview.indexOf('static String _buildReaderEngineSource({');
+      expect(declIdx, isNonNegative,
+          reason: '_buildReaderEngineSource 必须是 static');
+      final String params =
+          webview.substring(declIdx, webview.indexOf('}) {', declIdx));
+      expect(params.contains('required bool vnMode,'), isTrue);
+      expect(params.contains('required bool continuousMode,'), isTrue);
+      expect('required '.allMatches(params).length, 2,
+          reason: '参数表只许有 vnMode / continuousMode 两个 view-mode 开关；'
+              '多一个 per-nav 参数，引擎就会随导航变化，memoize 立刻失效');
+      expect(
+        webview.contains('String _buildReaderSetupScript({'),
+        isFalse,
+        reason: '旧的 per-nav 拼装入口必须彻底消失，不能两条路并存',
+      );
+    });
+
+    test('三种 shell 的源码访问器同样无参', () {
+      final String pagination = File(
+        'lib/src/reader/reader_pagination_scripts.dart',
+      ).readAsStringSync().replaceAll('\r\n', '\n');
+      final String vn = File(
+        'lib/src/reader/reader_visual_novel_scripts.dart',
+      ).readAsStringSync().replaceAll('\r\n', '\n');
+      expect(pagination.contains('static String paginatedShellSource() {'),
+          isTrue);
+      expect(pagination.contains('static String continuousShellSource() {'),
+          isTrue);
+      expect(vn.contains('static String vnShellScript() => _shell();'), isTrue);
+      expect(
+        pagination.contains('static String shellScript('),
+        isFalse,
+        reason: '旧的按模式插值的 shellScript 必须消失',
+      );
+    });
+
+    test('同一进程里同一模式的引擎源码恒定（memoize 的前提）', () {
+      expect(readerHibikiEngineSource(), same(readerHibikiEngineSource()));
+      expect(readerHibikiEngineSource(continuousMode: true),
+          same(readerHibikiEngineSource(continuousMode: true)));
+      expect(readerHibikiEngineSource(vnMode: true),
+          same(readerHibikiEngineSource(vnMode: true)));
+      // 三种模式各自不同（没有被 memoize key 串味）。
+      expect(
+          readerHibikiEngineSource() ==
+              readerHibikiEngineSource(continuousMode: true),
+          isFalse);
+    });
+
+    test('引擎只定义不执行，install 之外没有顶层副作用', () {
+      final String src = readerHibikiEngineSource().trim();
+      expect(
+        src.startsWith('window.__hoshiEngine = {'),
+        isTrue,
+        reason: '引擎顶层只能是一个 window.__hoshiEngine 对象字面量赋值；'
+            '顶层副作用会脱离 install 的时序控制',
+      );
+      expect(src.endsWith('};'), isTrue);
+      expect('install: function(C) {'.allMatches(src).length, 1);
+    });
+  });
+
+  group('2. 引擎必须含有全部载荷（此前完全没有的一条链）', () {
+    test('每个真实载荷都**整段原样**出现在最终引擎里', () {
+      // 用整段比对而不是「挑一条特征行」：特征行会因为兄弟载荷里出现同名/同形的
+      // 行而假绿（本轮负向验证实测过——删掉整个 caret 载荷，特征行版本照样全绿）。
+      // 比对对象取压缩**之前**的引擎，因为载荷是字面拼接、压缩后才逐行剥注释。
+      final Map<String, String> payloads = <String, String>{
+        'selection': ReaderSelectionScripts.source(),
+        'longPressDrag': ReaderSelectionScripts.longPressDragGestureScript(),
+        'caret': ReaderCaretScripts.source(),
+      };
+      final Map<String, String> engines = <String, String>{
+        'paged': readerHibikiEngineSourceUncompacted(),
+        'continuous': readerHibikiEngineSourceUncompacted(continuousMode: true),
+        'vn': readerHibikiEngineSourceUncompacted(vnMode: true),
+      };
+      engines.forEach((String mode, String engine) {
+        payloads.forEach((String name, String payload) {
+          expect(
+            engine.contains(payload),
+            isTrue,
+            reason: '$mode 引擎里 $name 载荷不是整段在场 —— 拼装时漏装了一整块，'
+                '而各 builder 自己的守卫看不到这一层',
+          );
+        });
+      });
+      // 每种模式还必须整段带上**自己那一份** shell。
+      final Map<String, String> shells = <String, String>{
+        'paged':
+            _stripScriptTags(ReaderPaginationScripts.paginatedShellSource()),
+        'continuous':
+            _stripScriptTags(ReaderPaginationScripts.continuousShellSource()),
+        'vn': _stripScriptTags(ReaderVisualNovelScripts.vnShellScript()),
+      };
+      shells.forEach((String mode, String shell) {
+        expect(engines[mode]!.contains(shell), isTrue,
+            reason: '$mode 引擎没有整段带上自己那一份 shell');
+      });
+    });
+
+    test('每种模式只装自己那一份 shell，分流点仍在 JS 侧读运行时 C', () {
+      const Map<String, String> expected = <String, String>{
+        'paged': 'paginated',
+        'continuous': 'continuous',
+        'vn': 'vn',
+      };
+      final Map<String, String> engines = <String, String>{
+        'paged': readerHibikiEngineSource(),
+        'continuous': readerHibikiEngineSource(continuousMode: true),
+        'vn': readerHibikiEngineSource(vnMode: true),
+      };
+      engines.forEach((String mode, String engine) {
+        expect(
+          engine
+              .contains('window.__hoshiShells.${expected[mode]} = function(C)'),
+          isTrue,
+          reason: '\$mode 引擎必须装 \${expected[mode]} shell',
+        );
+        // 分流仍读运行时 C：Dart 只决定嵌哪一份，不决定运行时走哪条分支。
+        expect(engine.contains('if (C.vnMode)'), isTrue);
+        expect(engine.contains('if (C.continuousMode)'), isTrue);
+        expect(engine.contains('window.__hoshiInstallShell(C);'), isTrue);
+      });
+    });
+
+    test('caret / furigana 的初始化改成读运行时 config', () {
+      final String engine = readerHibikiEngineSource();
+      expect(engine.contains('window.hoshiCaret.init({'), isTrue);
+      expect(engine.contains('color: C.caretColor,'), isTrue);
+      expect(engine.contains("C.furiganaMode === 'partial'"), isTrue);
+      expect(engine.contains("C.furiganaMode === 'toggle'"), isTrue);
+    });
+  });
+
+  group('3. 每章注入载荷必须保持极小（收益本身）', () {
+    test('boot 载荷只有 config + 一次 install 调用，不含引擎本体', () {
+      final String boot = readerHibikiEngineBoot(_sampleConfig());
+      expect(
+        boot.length,
+        lessThan(4096),
+        reason: 'per-nav 那一半必须只是 config；一旦有人把引擎本体拼回这里，'
+            '引擎就不能再 memoize，每章又要重新拼装 + 压缩近万行',
+      );
+      expect(
+        boot.contains(
+            'window.__hoshiEngine.install(window.__hoshiReaderConfig);'),
+        isTrue,
+      );
+      // 引擎独有符号一个都不许出现在每章载荷里。
+      for (final String engineOnly in <String>[
+        'window.__hoshiShells.paginated = function(C)',
+        'buildNodeOffsets',
+        'window.hoshiSelection',
+        'window.hoshiCaret.init({',
+      ]) {
+        expect(
+          boot.contains(engineOnly),
+          isFalse,
+          reason: 'boot 载荷里出现了引擎本体符号，说明引擎又被塞回每章注入路径了',
+        );
+      }
+    });
+
+    test('per-nav 参数确实进了 config 字面量（含 cue 原样拼接）', () {
+      final ReaderEngineConfig cfg = _sampleConfig(
+        sasayakiCuesJson: '[{"id":"c1","start":0}]',
+      );
+      final String literal = cfg.toJsLiteral();
+      final Map<String, dynamic> decoded =
+          jsonDecode(literal) as Map<String, dynamic>;
+      expect(decoded['initialProgress'], 0.42);
+      expect(decoded['chromeBottomInset'], 64);
+      expect(decoded['furiganaMode'], 'toggle');
+      expect(decoded['dartPageWidth'], 800);
+      expect((decoded['sasayakiCues'] as List<dynamic>).length, 1);
+      expect(_sampleConfig().toJsLiteral().contains('"sasayakiCues":null'),
+          isTrue);
+    });
+  });
+
+  group('4. 时序保证（PR#461 / PR#469 建立的两条，不得被本改动动摇）', () {
+    test('install 仍由 Dart 在 onLoadStop 之后一次 evaluateJavascript 触发', () {
+      // 引擎源码 + boot 拼成同一份字符串、同一次注入，位置就是改动前
+      // evaluateJavascript(整份 setup 脚本) 的那一处：docLoad 打点之后、
+      // evalSetupScript 打点之前、同一个 _navigateGeneration 守卫下。
+      final int buildIdx = webview.indexOf('final String setupScript =');
+      final int evalIdx = webview
+          .indexOf('await controller.evaluateJavascript(source: setupScript);');
+      final int markIdx =
+          webview.indexOf("ReaderChapterPerfTrace.mark('evalSetupScript')");
+      expect(buildIdx, isNonNegative);
+      expect(evalIdx, greaterThan(buildIdx));
+      expect(markIdx, greaterThan(evalIdx));
+      expect(
+        readerHibikiEngineSource()
+            .contains("if (document.readyState === 'complete')"),
+        isTrue,
+        reason: 'shell 的 load / readyState 双分支 boot 语义保持不变',
+      );
+    });
+
+    test('注入仍是一次往返（不得拆成多次 evaluateJavascript）', () {
+      // 实测那条通道的固定往返约 7.5ms、与载荷大小几乎无关，拆成两次就是白送 7.5ms。
+      final int start =
+          webview.indexOf('final ReaderEngineConfig engineConfig =');
+      final int end = webview.indexOf(
+          "ReaderChapterPerfTrace.mark('caretReanchor')", start);
+      expect(start, isNonNegative);
+      expect(end, greaterThan(start));
+      expect(
+        'evaluateJavascript('.allMatches(webview.substring(start, end)).length,
+        1,
+        reason: 'setup 注入必须保持单次往返',
+      );
+    });
+  });
+
+  group('5. 生成的 JS 真能解析（node --check）', () {
+    test('引擎与 boot 都是合法 JS', () {
+      final ProcessResult probe = _runNode(<String>['--version']);
+      if (probe.exitCode != 0) {
+        markTestSkipped('node 不可用，跳过真解析');
+        return;
+      }
+      final Directory tmp = Directory.systemTemp.createTempSync('hoshi-engine');
+      try {
+        for (final MapEntry<String, String> entry in <String, String>{
+          'paged': readerHibikiEngineSource(),
+          'continuous': readerHibikiEngineSource(continuousMode: true),
+          'vn': readerHibikiEngineSource(vnMode: true),
+          'boot': readerHibikiEngineBoot(_sampleConfig()),
+        }.entries) {
+          final File f = File('${tmp.path}/${entry.key}.js')
+            ..writeAsStringSync(entry.value);
+          final ProcessResult r = _runNode(<String>['--check', f.path]);
+          expect(r.exitCode, 0, reason: '${entry.key} 解析失败: ${r.stderr}');
+        }
+      } finally {
+        tmp.deleteSync(recursive: true);
+      }
+    });
+  });
+}
+
+ProcessResult _runNode(List<String> args) {
+  try {
+    return Process.runSync('node', args);
+  } on ProcessException {
+    return ProcessResult(0, 127, '', 'node not found');
+  }
+}
+
+ReaderEngineConfig _sampleConfig({String? sasayakiCuesJson}) =>
+    ReaderEngineConfig(
+      continuousMode: false,
+      vnMode: false,
+      vnClickAdvance: false,
+      scanNonJapaneseText: false,
+      hoverAutoLookup: false,
+      highlightOnTap: true,
+      showChrome: true,
+      debugLogging: false,
+      swipeDistThreshold: 44,
+      swipeFastDistThreshold: 22,
+      furiganaMode: 'toggle',
+      caretColor: 'rgba(0,0,0,0.5)',
+      caretInsetTop: 0,
+      caretInsetBottom: 64,
+      initialProgress: 0.42,
+      initialCharOffset: -1,
+      initialCharOffsetEnd: -1,
+      initialFragment: null,
+      chromeTopInset: 0,
+      chromeBottomInset: 64,
+      dartPageWidth: 800,
+      dartPageHeight: 600,
+      blurImages: false,
+      revealedKeys: const <String>[],
+      perfTraceEnabled: false,
+      vnRevealSpeed: 0,
+      vnScreenMode: 'block',
+      vnSentencesPerScreen: 1,
+      vnPreserveDialogue: false,
+      vnMergeCrossScreenSasayakiCues: false,
+      sasayakiCuesJson: sasayakiCuesJson,
+    );
+
+String _stripScriptTags(String js) => js
+    .replaceFirst(RegExp('^<script[^>]*>'), '')
+    .replaceFirst(RegExp(r'</script>$'), '')
+    .trim();

--- a/hibiki/test/reader/reader_headless_shell_dump_test.dart
+++ b/hibiki/test/reader/reader_headless_shell_dump_test.dart
@@ -17,18 +17,8 @@ import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 /// 本测试永远 pass——它只是把真 shell 落盘，不断言渲染行为（那由 headless probe 断言）。
 void main() {
   test('dump paginated + continuous horizontal shell to systemTemp', () {
-    final String paginated = ReaderPaginationScripts.shellScript(
-      initialProgress: 0.0,
-      initialCharOffset: -1,
-      continuousMode: false,
-      vnMode: false,
-    );
-    final String continuous = ReaderPaginationScripts.shellScript(
-      initialProgress: 0.0,
-      initialCharOffset: -1,
-      continuousMode: true,
-      vnMode: false,
-    );
+    final String paginated = ReaderPaginationScripts.paginatedShellSource();
+    final String continuous = ReaderPaginationScripts.continuousShellSource();
     final String tmp = Directory.systemTemp.path;
     File('$tmp/hoshi_shell_paginated.html').writeAsStringSync(paginated);
     File('$tmp/hoshi_shell_continuous.html').writeAsStringSync(continuous);

--- a/hibiki/test/reader/reader_inchapter_progress_diag_log_test.dart
+++ b/hibiki/test/reader/reader_inchapter_progress_diag_log_test.dart
@@ -40,7 +40,7 @@ void main() {
       final String body = src.substring(idx, idx + 1300);
       // JS 门控用 Dart 插值的 DebugLogService.instance.enabled 渲染成字面 true/false。
       expect(
-        body.contains('if (\${DebugLogService.instance.enabled})'),
+        body.contains('if (C.debugLogging)'),
         isTrue,
         reason: 'JS 诊断 console.log 须由 DebugLogService.enabled 门控（默认 off）',
       );

--- a/hibiki/test/reader/reader_longpress_drag_select_guard_test.dart
+++ b/hibiki/test/reader/reader_longpress_drag_select_guard_test.dart
@@ -120,8 +120,7 @@ void main() {
 
   group('翻页/边界手势对拖选让路（消歧守卫）', () {
     test('连续模式边界跨章手势见到拖选标志即让路（不误跨章）', () {
-      final String js =
-          ReaderPaginationScripts.shellScript(continuousMode: true);
+      final String js = ReaderPaginationScripts.continuousShellSource();
       expect(js, contains('if (window.__hoshiTextSelectDragActive) return;'),
           reason: '_bEnd（跨章）必须在拖选进行时让路');
     });

--- a/hibiki/test/reader/reader_mouse_drag_scroll_guard_static_test.dart
+++ b/hibiki/test/reader/reader_mouse_drag_scroll_guard_static_test.dart
@@ -11,7 +11,7 @@ void main() {
     source = readReaderPageSource();
     setupScript = _between(
       source,
-      r'var hoshiContinuousMode = $continuousMode;',
+      r'var hoshiContinuousMode = C.continuousMode;',
       'window.hoshiProgressDetails = function()',
     );
   });

--- a/hibiki/test/reader/reader_mouse_paging_boundary_guard_static_test.dart
+++ b/hibiki/test/reader/reader_mouse_paging_boundary_guard_static_test.dart
@@ -16,7 +16,7 @@ void main() {
     source = readReaderPageSource();
     setupScript = _between(
       source,
-      r'var hoshiContinuousMode = $continuousMode;',
+      r'var hoshiContinuousMode = C.continuousMode;',
       'window.hoshiProgressDetails = function()',
     );
   });

--- a/hibiki/test/reader/reader_paged_touch_swipe_behavior_test.js
+++ b/hibiki/test/reader/reader_paged_touch_swipe_behavior_test.js
@@ -46,7 +46,7 @@ const source = fs.readFileSync(readerPath, 'utf8');
 // Extract the self-contained handler slice: from the continuous-mode flag down
 // to (but excluding) the non-left mouse seek listener. Every function the
 // handlers call is declared inside this slice, so it runs standalone.
-const sliceStart = source.indexOf('var hoshiContinuousMode = $continuousMode;');
+const sliceStart = source.indexOf('var hoshiContinuousMode = C.continuousMode;');
 assert.ok(sliceStart >= 0, 'missing handler slice start marker');
 const sliceEndMarker = '// 非左键';
 const sliceEnd = source.indexOf(sliceEndMarker, sliceStart);
@@ -141,29 +141,30 @@ function makeHarness(continuousMode) {
     getComputedStyle: windowObj.getComputedStyle,
   };
 
-  let prepared = rawSlice
-    // TODO-806: [806-TAP] 探针门控用 Dart 注入期插值 ${DebugLogService.instance.enabled}，
-    // 抽出的裸 JS 没替换会让 node 见到 `if (${...}) {` 语法报错。production 默认 off，
-    // 这里固定替成 false（探针整段不进 JS），与默认行为一致、不影响 swipe 断言。
-    .replace(/\$\{DebugLogService\.instance\.enabled\}/g, 'false')
-    .replace(/\$continuousMode/g, continuousMode ? 'true' : 'false')
+  // BUG-1140 第二阶段①：整段 setup 从「Dart 注入期插值」改成「运行时读 config」，
+  // 于是这里不再需要一张字符串替身表——切片本身就是一段读 `C` 的代码，直接把
+  // 同名 config 传进去即可（少一层「替身表漏一项就语法报错」的脆弱耦合）。
+  // tapSlop 仍是 Dart 编译期常量插值（不随导航变化，故留在源码里），单独替换。
+  const config = {
+    continuousMode: !!continuousMode,
     // TODO-909: VN flags default false here (this harness exercises the paged
     // path); keeps the slice self-contained when VN tap-advance was added.
-    .replace(/\$vnMode/g, 'false')
-    .replace(/\$vnClickAdvance/g, 'false')
-    .replace(/\$hoverAutoLookup/g, 'false')
-    .replace(/\$swipeDistThreshold/g, '44')
-    .replace(/\$swipeFastDistThreshold/g, '22')
-    .replace(/\$tapSlop/g, '10')
-    // BUG-712 ①: the tap-gate mirror line
-    // `window.__hoshiTapGate = { chrome: $_showChrome, lookup:
-    // ${ReaderHibikiSource.instance.highlightOnTap}, maxLen: 400 };` is emitted
-    // in the setup slice; stub both Dart interpolations to a valid bool so the
-    // raw JS parses. The gate governs tap-to-lookup, orthogonal to the paged
-    // swipe assertion, so a neutral `true` is fine.
-    .replace(/\$\{ReaderHibikiSource\.instance\.highlightOnTap\}/g, 'true')
-    .replace(/\$_showChrome/g, 'true');
-  prepared = '(function(){\n' + prepared + '\n})();';
+    vnMode: false,
+    vnClickAdvance: false,
+    hoverAutoLookup: false,
+    swipeDistThreshold: 44,
+    swipeFastDistThreshold: 22,
+    scanNonJapaneseText: false,
+    // TODO-806: [806-TAP] probe defaults off, matching production.
+    debugLogging: false,
+    // BUG-712 (1): the tap-gate mirror governs tap-to-lookup, orthogonal to the
+    // paged swipe assertion, so neutral values are fine.
+    highlightOnTap: true,
+    showChrome: true,
+  };
+  const prepared = '(function(C){\n'
+    + rawSlice.replace(/\$tapSlop/g, '10')
+    + '\n})(' + JSON.stringify(config) + ');';
 
   vm.createContext(sandbox);
   vm.runInContext(prepared, sandbox, { filename: 'reader-handlers.js' });

--- a/hibiki/test/reader/reader_pagination_scripts_test.dart
+++ b/hibiki/test/reader/reader_pagination_scripts_test.dart
@@ -153,80 +153,68 @@ void main() {
 
   group('ReaderPaginationScripts.shellScript contract', () {
     test('paginated mode contains hoshiReader object', () {
-      final String script = ReaderPaginationScripts.shellScript(
-        initialProgress: 0.0,
-        continuousMode: false,
-      );
+      final String script = ReaderPaginationScripts.paginatedShellSource();
       expect(script, contains('<script>'));
       expect(script, contains('</script>'));
       expect(script, contains('window.hoshiReader'));
     });
 
     test('continuous mode contains hoshiReader object', () {
-      final String script = ReaderPaginationScripts.shellScript(
-        initialProgress: 0.5,
-        continuousMode: true,
-      );
+      final String script = ReaderPaginationScripts.continuousShellSource();
       expect(script, contains('window.hoshiReader'));
     });
 
     test('paginated mode defines paginate method', () {
-      final String script = ReaderPaginationScripts.shellScript(
-        initialProgress: 0.0,
-        continuousMode: false,
-      );
+      final String script = ReaderPaginationScripts.paginatedShellSource();
       expect(script, contains('paginate'));
       expect(script, contains('calculateProgress'));
     });
 
-    test('initial progress is injected', () {
-      final String script = ReaderPaginationScripts.shellScript(
-        initialProgress: 0.75,
-        continuousMode: false,
-      );
-      expect(script, contains('0.75'));
+    // BUG-1140 第二阶段①：恢复锚与 cue 不再插进源码，改由运行时读 config。
+    // 判据（fragment > charOffset > progress 的优先级）必须原样保留。
+    test('initial progress / char offset / fragment are read from config', () {
+      final String script = ReaderPaginationScripts.paginatedShellSource();
+      expect(script,
+          contains('window.hoshiReader.restoreProgress(C.initialProgress)'));
+      expect(
+          script,
+          contains(
+              'window.hoshiReader.restoreToCharOffset(C.initialCharOffset)'));
+      expect(script,
+          contains('window.hoshiReader.jumpToFragment(C.initialFragment)'));
+      final int fragIdx = script.indexOf('C.initialFragment !== null');
+      final int charIdx = script.indexOf('C.initialCharOffset >= 0');
+      expect(fragIdx, isNonNegative);
+      expect(charIdx, isNonNegative);
+      expect(fragIdx < charIdx, isTrue, reason: 'fragment 跳转优先级必须高于精确字符锚');
     });
 
-    test('sasayaki cues JSON is injected when provided', () {
-      final String script = ReaderPaginationScripts.shellScript(
-        initialProgress: 0.0,
-        continuousMode: false,
-        sasayakiCuesJson: '[{"id":"cue1","start":0,"end":10}]',
-      );
-      expect(script, contains('cue1'));
+    test('sasayaki cues are read from config when present', () {
+      final String script = ReaderPaginationScripts.paginatedShellSource();
+      expect(script,
+          contains('window.hoshiReader.applySasayakiCues(C.sasayakiCues)'));
+      expect(script, contains('C.sasayakiCues !== null'));
     });
 
     test('defines onRestoreComplete callback', () {
-      final String script = ReaderPaginationScripts.shellScript(
-        initialProgress: 0.0,
-        continuousMode: false,
-      );
+      final String script = ReaderPaginationScripts.paginatedShellSource();
       expect(script, contains('onRestoreComplete'));
     });
 
     test('defines updatePageSize method', () {
-      final String script = ReaderPaginationScripts.shellScript(
-        initialProgress: 0.0,
-        continuousMode: false,
-      );
+      final String script = ReaderPaginationScripts.paginatedShellSource();
       expect(script, contains('updatePageSize'));
     });
 
     test('defines initialize function', () {
-      final String script = ReaderPaginationScripts.shellScript(
-        initialProgress: 0.0,
-        continuousMode: false,
-      );
+      final String script = ReaderPaginationScripts.paginatedShellSource();
       expect(script, contains('initialize'));
       expect(script, contains('addEventListener'));
     });
   });
 
   group('ReaderPaginationScripts continuous vertical position contract', () {
-    final String continuous = ReaderPaginationScripts.shellScript(
-      initialProgress: 0.5,
-      continuousMode: true,
-    );
+    final String continuous = ReaderPaginationScripts.continuousShellSource();
 
     test('continuous paginate actually scrolls before reporting scrolled', () {
       final String body = _between(
@@ -340,13 +328,8 @@ void main() {
   // char-precise + settle-aware）。本 group 只留与样式重锚无关的分页 metrics 预热守卫
   // （warmPaginationMetrics）；旧单函数 reanchorAfterStyleChange 已作死代码删除。
   group('ReaderPaginationScripts pagination metrics warm (BUG-023)', () {
-    final String paginated = ReaderPaginationScripts.shellScript(
-      initialProgress: 0.3,
-    );
-    final String continuous = ReaderPaginationScripts.shellScript(
-      continuousMode: true,
-      initialProgress: 0.3,
-    );
+    final String paginated = ReaderPaginationScripts.paginatedShellSource();
+    final String continuous = ReaderPaginationScripts.continuousShellSource();
 
     test('paginated restore completion warms pagination metrics during idle',
         () {

--- a/hibiki/test/reader/reader_script_compactor_test.dart
+++ b/hibiki/test/reader/reader_script_compactor_test.dart
@@ -1,9 +1,11 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/focus/webview_key_bridge.dart';
 import 'package:hibiki/src/reader/reader_caret_scripts.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
+import 'package:hibiki/src/reader/reader_visual_novel_scripts.dart';
 import 'package:hibiki/src/reader/reader_script_compactor.dart';
 import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 
@@ -15,15 +17,18 @@ import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 ///    与实现无关，直接钉住「反引号只在代码区才计数」这条根因修复。
 /// 2. **全部**真实注入 JS 载荷（selection / longPressDrag / caret / 分页 / 连续 / VN
 ///    三种 shell）——断言扫描器扫完干净、被删的每一行都确实是空行或整行注释、幂等。
-/// 3. 用 node `--check` 真解析：把 `webview.part.dart` 里那份**最终拼装脚本**按真实
-///    组件重建出来（821 行外壳 + 各真实载荷），压缩前后都必须是合法 JS。这才是生产上
-///    真正被 compact 的东西，此前一行测试都没有。
+/// 3. 用 node `--check` 真解析：**最终拼装脚本**（= 引擎源码，
+///    `readerHibikiEngineSourceUncompacted()`）压缩前后都必须是合法 JS。这才是生产上
+///    真正被 compact 的东西。
 /// 4. **装配完整性**（见 group「setup 装配完整性」）：reader 侧还有约 100 条守卫只断言
 ///    某个生成函数**返回的字符串**里含某符号——它们证明不了这个串真的被拼进最终注入的
-///    脚本。压缩器的插值替身表 [_setupSubstitutions] 对**新增**插值会抛 StateError（响
-///    亮），但对**删除**插值（例如从模板里抹掉 `$caretJs`）完全静默：整个 caret 载荷不
-///    再注入，那 100 条照样全绿。本层堵的正是这个单向漏洞：替换时收集命中的插值键，断言
-///    每个替身都被用上；再对最终产物断言各子载荷的运行时哨兵同时在场。
+///    脚本。本层堵的是这个单向漏洞：对最终产物断言各子载荷**整段原样在场** + 运行时
+///    哨兵在场。
+///
+///    BUG-1140 第二阶段①之前，最终脚本是把 `webview.part.dart` 的三引号模板抠出来、
+///    按一张手写替身表重建的；那张表对**新增**插值会抛 StateError（响亮），对**删除**
+///    插值完全静默，只能靠额外收集「命中键」来兜。现在引擎是零插值的静态源码，直接向
+///    生产代码要同一份对象，重建与漂移一起没有了。
 void main() {
   group('ReaderScriptCompactor.compact', () {
     test('剥掉整行注释与空行', () {
@@ -169,7 +174,7 @@ tail`;
           'pagination.paginated',
           'pagination.continuous',
           'pagination.vn',
-          'setupScript',
+          'engine',
         },
         reason: '新增参与拼装的 JS 载荷必须同时纳入本守卫，否则压缩器对它零覆盖',
       );
@@ -207,7 +212,7 @@ tail`;
         'selection',
         'pagination.paginated',
         'pagination.continuous',
-        'setupScript',
+        'engine',
       ]) {
         final String src = payloads[name]!;
         final String out = ReaderScriptCompactor.compact(src);
@@ -222,36 +227,44 @@ tail`;
   // 那约 100 条只断言「生成函数返回的串里含某符号」的守卫照样全绿。
   // 本组是「被注入」这件事的唯一集中证据，不要求那 100 条各自再证一遍。
   group('setup 装配完整性（子载荷真的被拼进最终脚本）', () {
-    final _AssembledSetup assembled = _assembleSetupScript(
-        _stripScriptTags(ReaderPaginationScripts.shellScript()));
+    // 三种 view-mode 各自的最终拼装脚本（生产上真正交给压缩器的那份）。
+    final Map<String, String> assembledByMode = <String, String>{
+      'paged': readerHibikiEngineSourceUncompacted(),
+      'continuous': readerHibikiEngineSourceUncompacted(continuousMode: true),
+      'vn': readerHibikiEngineSourceUncompacted(vnMode: true),
+    };
+    final String assembled = assembledByMode['paged']!;
 
-    test('替身表里的每个插值都在模板里被真正用上（删掉任一子载荷即红）', () {
-      expect(assembled.hitKeys, containsAll(assembled.subKeys),
-          reason: 'setup 模板不再引用这些插值：'
-              '${assembled.subKeys.difference(assembled.hitKeys).join(', ')}。'
-              '要么该子载荷被漏拼（= 线上整块功能失效，而单载荷守卫全绿看不出来），'
-              '要么它已被有意移除——后者请同步删掉替身表里的对应项。');
-    });
-
-    // 插值是**字面**插入，所以每个子载荷必须整段原样出现在产物里。这是「被拼进去」
+    // 载荷是**字面**拼接，所以每个子载荷必须整段原样出现在产物里。这是「被拼进去」
     // 最强的直接证据：哨兵符号会因为外壳/兄弟载荷里也出现同名符号而假绿（实测删掉
-    // `$caretJs` 后 `window.hoshiCaret` 仍在——它由 `$caretInit` 带进来），整段比对不会。
+    // caret 载荷后 `window.hoshiCaret` 仍在——它由 caret 初始化调用带进来），整段比对不会。
     test('最终脚本里各子载荷整段原样在场', () {
       final Map<String, String> payloads = <String, String>{
         'selection': ReaderSelectionScripts.source(),
         'caret': ReaderCaretScripts.source(),
         'longPressDrag': ReaderSelectionScripts.longPressDragGestureScript(),
-        'pagination': _stripScriptTags(ReaderPaginationScripts.shellScript()),
         'keyBridge': webViewKeyBridgeScript(
           handlerName: 'onSpaceKey',
           keys: const <String>[' '],
         ),
       };
       for (final MapEntry<String, String> entry in payloads.entries) {
-        expect(assembled.script, contains(entry.value),
+        expect(assembled, contains(entry.value),
             reason: '${entry.key} 载荷没有整段出现在最终注入脚本里——'
-                '它没被拼进 setup 脚本，注入后整块功能是死的');
+                '它没被拼进引擎，注入后整块功能是死的');
       }
+      // 每种 view-mode 的引擎必须整段带上**自己那一份** shell。
+      final Map<String, String> shells = <String, String>{
+        'paged':
+            _stripScriptTags(ReaderPaginationScripts.paginatedShellSource()),
+        'continuous':
+            _stripScriptTags(ReaderPaginationScripts.continuousShellSource()),
+        'vn': _stripScriptTags(ReaderVisualNovelScripts.vnShellScript()),
+      };
+      shells.forEach((String mode, String shell) {
+        expect(assembledByMode[mode]!, contains(shell),
+            reason: '$mode 引擎没有整段带上自己那一份 shell');
+      });
     });
 
     test('最终脚本里各子载荷的运行时哨兵同时在场', () {
@@ -263,14 +276,14 @@ tail`;
         'keyBridge': "'onSpaceKey'",
       };
       for (final MapEntry<String, String> entry in sentinels.entries) {
-        expect(assembled.script, contains(entry.value),
+        expect(assembled, contains(entry.value),
             reason: '最终注入脚本里找不到 ${entry.key} 的哨兵 ${entry.value}——'
-                '该载荷没被拼进 setup 脚本，注入后整块功能是死的');
+                '该载荷没被拼进引擎，注入后整块功能是死的');
       }
     });
 
     test('压缩之后哨兵依然在场（压缩不得吃掉任何子载荷）', () {
-      final String compacted = ReaderScriptCompactor.compact(assembled.script);
+      final String compacted = ReaderScriptCompactor.compact(assembled);
       for (final String sentinel in <String>[
         'window.hoshiSelection',
         'window.hoshiReader',
@@ -313,137 +326,31 @@ tail`;
 
 /// 全部真正被 [ReaderScriptCompactor.compact] 处理过的 JS 载荷。
 ///
-/// `setupScript` 是**最终拼装脚本**——生产上 `_buildReaderSetupScript` 交给压缩器的正是
-/// 它。它由 `webview.part.dart` 里那段 821 行的外壳模板 + 各真实子载荷拼成，这里按同一
-/// 份源码重建（见 [_assembledSetupScript]），不复制粘贴、不会漂。
+/// `engine` 是**最终拼装脚本**——生产上交给压缩器的正是它（`_buildReaderEngineSource`
+/// 的返回值，经 `readerHibikiEngineSourceUncompacted()` 直接取到）。
+///
+/// BUG-1140 第二阶段①之前，这里是把 `webview.part.dart` 的三引号模板抠出来、按一张
+/// 手写 `subs` 替身表重建一遍。那张表是**查找表**：新增插值会 fail，**删掉**一个载荷
+/// （比如 `$caretJs` 不再拼进去）却完全静默——整份注入物少了一块，压缩覆盖跟着少一块，
+/// 而没有一条测试会红。现在引擎是零插值的静态源码，直接向生产代码要同一份对象，
+/// 那个不对称从根上没有了。
 Map<String, String> _realPayloads() {
-  final String paginated =
-      _stripScriptTags(ReaderPaginationScripts.shellScript());
   return <String, String>{
     'selection': ReaderSelectionScripts.source(),
     'longPressDrag': ReaderSelectionScripts.longPressDragGestureScript(),
     'caret': ReaderCaretScripts.source(),
-    // PR#480 的裸 Space 键盘桥：它同样被拼进 setup 脚本后一起压缩，必须有独立的
-    // scansCleanly / 幂等 / node --check 覆盖，不能只靠 setupScript 顺带带过。
+    // PR#480 的裸 Space 键盘桥：它同样被拼进引擎后一起压缩，必须有独立的
+    // scansCleanly / 幂等 / node --check 覆盖，不能只靠 engine 顺带带过。
     'keyBridge.space': webViewKeyBridgeScript(
       handlerName: 'onSpaceKey',
       keys: const <String>[' '],
     ),
-    'pagination.paginated': paginated,
-    'pagination.continuous': _stripScriptTags(
-        ReaderPaginationScripts.shellScript(continuousMode: true)),
-    'pagination.vn':
-        _stripScriptTags(ReaderPaginationScripts.shellScript(vnMode: true)),
-    'setupScript': _assembleSetupScript(paginated).script,
-  };
-}
-
-/// [_assembleSetupScript] 的产物：最终拼装脚本 + 「哪些替身插值真的被用上了」。
-///
-/// [hitKeys] 是装配完整性的唯一证据：模板里少写一个 `$xxx`，它就少一个键。
-class _AssembledSetup {
-  const _AssembledSetup({
-    required this.script,
-    required this.hitKeys,
-    required this.subKeys,
-  });
-
-  /// 替换全部插值后的最终脚本（= 生产上真正交给压缩器的那份）。
-  final String script;
-
-  /// 在模板里真实出现并被替换掉的插值键。
-  final Set<String> hitKeys;
-
-  /// 替身表登记的全部插值键。
-  final Set<String> subKeys;
-}
-
-/// 从 `webview.part.dart` 抠出 `_buildReaderSetupScript` 的那段 Dart 三引号模板，把每个
-/// 插值换成真实子载荷（或语法上等价的标量替身），还原成生产上真正被压缩的整份脚本。
-///
-/// 插值一旦新增/改名，[_setupSubstitutions] 里没有对应替身就直接 fail——不会静默漏覆盖。
-/// 反方向（模板里**删掉**某个插值，例如整个 `$caretJs`）不会抛异常，由返回值的
-/// [_AssembledSetup.hitKeys] 交给「setup 装配完整性」那组测试断言。
-_AssembledSetup _assembleSetupScript(String paginationJs) {
-  final File part = File(
-    'lib/src/pages/implementations/reader_hibiki/webview.part.dart',
-  );
-  if (!part.existsSync()) {
-    throw StateError('${part.path} 必须存在');
-  }
-  final String source = part.readAsStringSync();
-  const String opener = "return ReaderScriptCompactor.compact('''";
-  final int start = source.indexOf(opener);
-  if (start < 0) {
-    throw StateError('_buildReaderSetupScript 的压缩入口变了，本守卫需同步更新');
-  }
-  String body = source.substring(start + opener.length);
-  final int end = body.indexOf("\n''');");
-  if (end <= 0) {
-    throw StateError('setup 模板的收尾三引号没找到');
-  }
-  body = body.substring(0, end);
-
-  // Dart 非 raw 三引号串里唯一出现的反斜杠转义是 `\.`（未知转义 = 字符本身）。
-  // 出现别的转义就说明重建逻辑需要扩展，直接失败而不是悄悄错。
-  final RegExp escapes = RegExp(r'\\(.)');
-  for (final RegExpMatch m in escapes.allMatches(body)) {
-    if (m.group(1) != '.') {
-      throw StateError('setup 模板出现新的转义 \${m.group(1)}，重建逻辑需同步');
-    }
-  }
-  body = body.replaceAll(r'\.', '.');
-
-  final Map<String, String> subs = _setupSubstitutions(paginationJs);
-  final Set<String> hit = <String>{};
-  final RegExp placeholder = RegExp(r'\$\{[^}]*\}|\$[A-Za-z_][A-Za-z0-9_]*');
-  final String script = body.replaceAllMapped(placeholder, (Match m) {
-    final String key = m.group(0)!;
-    final String? value = subs[key];
-    if (value == null) {
-      throw StateError('setup 模板新增插值 $key，请在本守卫里给出替身，'
-          '否则最终拼装脚本的压缩就没有覆盖');
-    }
-    hit.add(key);
-    return value;
-  });
-  return _AssembledSetup(
-    script: script,
-    hitKeys: hit,
-    subKeys: subs.keys.toSet(),
-  );
-}
-
-/// setup 模板里每个插值对应的真实子载荷（或语法上等价的标量替身）。
-Map<String, String> _setupSubstitutions(String paginationJs) {
-  return <String, String>{
-    r'$selectionJs': ReaderSelectionScripts.source(),
-    r'$paginationJs': paginationJs,
-    r'$caretJs': ReaderCaretScripts.source(),
-    r'$caretInit': ReaderCaretScripts.initInvocation(
-        color: 'rgba(0,0,0,0.5)', insetTop: 0, insetBottom: 0),
-    // _buildFuriganaJs 是 State 私有方法，测试拿不到；它是十几行无反引号的纯代码，
-    // 用占位注释顶上（拼装外壳与其余载荷才是本守卫的目标）。
-    r'$furiganaJs': '/* furigana placeholder */',
-    r'$longPressDragJs': ReaderSelectionScripts.longPressDragGestureScript(),
-    // TODO-1078 裸 Space 键盘桥：注入的是真实生成结果（含 JS 字符串字面量与
-    // 对象字面量 `{capture: true}`），压缩必须照样覆盖它。
-    r"${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}":
-        webViewKeyBridgeScript(
-      handlerName: 'onSpaceKey',
-      keys: const <String>[' '],
-    ),
-    r'$swipeFastDistThreshold': '22',
-    r'$swipeDistThreshold': '44',
-    r'$tapSlop': '10',
-    r'$continuousMode': 'false',
-    r'$hoverAutoLookup': 'false',
-    r'$vnClickAdvance': 'false',
-    r'$vnMode': 'false',
-    r'$_showChrome': 'false',
-    r'${DebugLogService.instance.enabled}': 'false',
-    r'${ReaderHibikiSource.instance.highlightOnTap}': 'false',
-    r'${appModel.scanNonJapaneseText}': 'false',
+    'pagination.paginated':
+        _stripScriptTags(ReaderPaginationScripts.paginatedShellSource()),
+    'pagination.continuous':
+        _stripScriptTags(ReaderPaginationScripts.continuousShellSource()),
+    'pagination.vn': _stripScriptTags(ReaderVisualNovelScripts.vnShellScript()),
+    'engine': readerHibikiEngineSourceUncompacted(),
   };
 }
 

--- a/hibiki/test/reader/reader_style_reanchor_both_shells_guard_test.dart
+++ b/hibiki/test/reader/reader_style_reanchor_both_shells_guard_test.dart
@@ -28,9 +28,7 @@ void main() {
     test(
         '${shell.label} shell defines beginStyleReanchor + commitStyleReanchor',
         () {
-      final String script = ReaderPaginationScripts.shellScript(
-        continuousMode: shell.continuousMode,
-      );
+      final String script = ReaderPaginationScripts.paginatedShellSource();
       expect(
         script.contains('beginStyleReanchor: function'),
         isTrue,
@@ -48,8 +46,7 @@ void main() {
   }
 
   test('beginStyleReanchorInvocation 目标方法在分页脚本里真实可解析', () {
-    final String paginated =
-        ReaderPaginationScripts.shellScript(continuousMode: false);
+    final String paginated = ReaderPaginationScripts.paginatedShellSource();
     // 调用点用 typeof === 'function' 门控；脚本里必须存在同名函数定义，否则门控恒假。
     expect(
       ReaderPaginationScripts.beginStyleReanchorInvocation('"body{}"')

--- a/hibiki/test/reader/reader_svg_cover_block_image_guard_test.dart
+++ b/hibiki/test/reader/reader_svg_cover_block_image_guard_test.dart
@@ -64,13 +64,12 @@ void main() {
 
   group('BUG-025 _sharedInitImages SVG promotion', () {
     test('paginated shell promotes large <svg><image> to block-img', () {
-      final String js = ReaderPaginationScripts.shellScript();
+      final String js = ReaderPaginationScripts.paginatedShellSource();
       _expectSvgPromotion(js);
     });
 
     test('continuous shell promotes large <svg><image> to block-img', () {
-      final String js =
-          ReaderPaginationScripts.shellScript(continuousMode: true);
+      final String js = ReaderPaginationScripts.continuousShellSource();
       _expectSvgPromotion(js);
     });
   });

--- a/hibiki/test/reader/reader_tap_coord_probe_guard_test.dart
+++ b/hibiki/test/reader/reader_tap_coord_probe_guard_test.dart
@@ -8,7 +8,7 @@ import '../pages/reader_hibiki_page_source_corpus.dart';
 ///
 /// 守护两件事：
 /// - A. JS 端 onTap 发射点有 `[806-TAP]` 调试探针，且**门控**在
-///   `${DebugLogService.instance.enabled}` 后（DebugLogService 注入期门控开关），
+///   `C.debugLogging` 后（DebugLogService 注入期门控开关），
 ///   口径注释写明 = WebView CSS 视口像素。撤回探针或去掉门控即红。
 /// - B. `onDismissBarrierHover` 用 WebView 的 RenderBox `globalToLocal` 把全局
 ///   指针位置映成 WebView 局部坐标（与 onShiftHover 口径一致），**不再**把
@@ -23,7 +23,7 @@ void main() {
           reason: 'onTap 框选坐标探针被移除——日志里又没有标明口径的真实点击坐标。');
 
       // 探针必须落在注入期门控块内：截取探针前后一小段，断言门控开关在 console.log
-      // 之前出现（gate 用 `${DebugLogService.instance.enabled}` 在拼 JS 字符串时
+      // 之前出现（gate 用 `C.debugLogging` 在拼 JS 字符串时
       // 决定是否注入这段）。
       final int probeIdx = src.indexOf("console.log('[806-TAP]");
       expect(probeIdx, greaterThan(0),
@@ -31,9 +31,9 @@ void main() {
       final String window =
           src.substring((probeIdx - 400).clamp(0, src.length), probeIdx);
       expect(
-        window.contains(r'if (${DebugLogService.instance.enabled})'),
+        window.contains(r'if (C.debugLogging)'),
         isTrue,
-        reason: '[806-TAP] 探针必须门控在 \${DebugLogService.instance.enabled} 后，'
+        reason: '[806-TAP] 探针必须门控在 C.debugLogging 后，'
             '默认 off，开调试日志才注入打印（沿用 DebugLogService 同开关，别新造）。',
       );
 

--- a/hibiki/test/reader/restore_charoffset_guard_test.dart
+++ b/hibiki/test/reader/restore_charoffset_guard_test.dart
@@ -44,18 +44,25 @@ void main() {
     final int defs = 'restoreToCharOffset: '.allMatches(jsSrc).length;
     expect(defs, greaterThanOrEqualTo(2),
         reason: '分页 + 连续都必须定义 restoreToCharOffset（复用精确 scrollToCharOffset）');
-    expect(jsSrc.contains('initialCharOffset'), isTrue,
+    expect(jsSrc.contains('C.initialCharOffset'), isTrue,
         reason:
-            'shell builder 必须接受 initialCharOffset 并在 >=0 时走 restoreToCharOffset');
+            'shell 必须读运行时 C.initialCharOffset 并在 >=0 时走 restoreToCharOffset');
   });
 
   test('恢复脚本在 initialCharOffset>=0 时优先精确路径 (BUG-162)', () {
-    // 两处 initialRestoreScript 三元都应：有 charOffset 走 restoreToCharOffset，
-    // 否则回退 restoreProgress（旧存档兼容）。
+    // BUG-1140 第二阶段①：三选一从 Dart 注入期三元式搬到 JS 运行时（读 C），
+    // 判据与优先级必须逐条保留：有 charOffset 走 restoreToCharOffset，
+    // 否则回退 restoreProgress（旧存档兼容）。分页 + 连续各一份。
     final int branches =
-        'restoreToCharOffset(\$initialCharOffset)'.allMatches(jsSrc).length;
+        'restoreToCharOffset(C.initialCharOffset)'.allMatches(jsSrc).length;
     expect(branches, greaterThanOrEqualTo(2),
         reason: '分页 + 连续的恢复脚本都必须在 initialCharOffset>=0 时调 restoreToCharOffset');
+    expect('C.initialCharOffset >= 0'.allMatches(jsSrc).length,
+        greaterThanOrEqualTo(2),
+        reason: '两个 shell 都必须保留 initialCharOffset>=0 的优先判据');
+    expect('restoreProgress(C.initialProgress)'.allMatches(jsSrc).length,
+        greaterThanOrEqualTo(2),
+        reason: '两个 shell 都必须保留旧存档的粗粒度回退');
   });
 
   test(
@@ -65,7 +72,7 @@ void main() {
         reason: 'repo.save 必须带 charOffset');
     expect(pageSrc.contains('saved.charOffset'), isTrue,
         reason: '恢复必须读 saved.charOffset 作精确锚');
-    expect(pageSrc.contains('initialCharOffset:'), isTrue,
-        reason: 'shellScript 必须把 _initialCharOffset 传给 JS');
+    expect(pageSrc.contains('initialCharOffset: _initialCharOffset,'), isTrue,
+        reason: 'ReaderEngineConfig 必须把 _initialCharOffset 传给 JS');
   });
 }

--- a/hibiki/test/reader/sparse_chapter_landing_guard_test.dart
+++ b/hibiki/test/reader/sparse_chapter_landing_guard_test.dart
@@ -25,10 +25,9 @@ import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 /// 懒加载 / BUG-661 纯图片章 eager）。
 void main() {
   String norm(String s) => s.replaceAll(RegExp(r'\s+'), ' ');
-  final String paged =
-      norm(ReaderPaginationScripts.shellScript(initialProgress: 0.99));
-  final String continuous = norm(ReaderPaginationScripts.shellScript(
-      continuousMode: true, initialProgress: 0.99));
+  final String paged = norm(ReaderPaginationScripts.paginatedShellSource());
+  final String continuous =
+      norm(ReaderPaginationScripts.continuousShellSource());
 
   group('BUG-671 sparse cover chapter backward-turn lands at chapter end', () {
     test('forceLoadPendingImages exists and flips lazy -> eager (both shells)',

--- a/hibiki/test/reader/swipe_page_turn_no_animation_test.dart
+++ b/hibiki/test/reader/swipe_page_turn_no_animation_test.dart
@@ -61,7 +61,7 @@ void main() {
       'reader page swipe threshold is parameterized, not a hard-coded literal 72',
       () {
     // Source-scan guard: the swipe-detection branch must read the
-    // sensitivity-scaled $swipeDistThreshold, not the old literal threshold.
+    // sensitivity-scaled C.swipeDistThreshold, not the old literal threshold.
     // If someone reverts to `absDx >= 72`, this fails.
     // TODO-589 batch8: swipe 阈值/连续模式 wheel(setup 脚本)已搬到
     // reader_hibiki/webview.part.dart，改读「主壳 + 全部 part」合并语料。
@@ -69,7 +69,7 @@ void main() {
 
     expect(
       src,
-      contains(r'absDx >= $swipeDistThreshold'),
+      contains('absDx >= C.swipeDistThreshold'),
       reason:
           'swipe distance threshold must use the injected sensitivity value',
     );

--- a/hibiki/test/reader/tap_gate_mirror_guard_test.dart
+++ b/hibiki/test/reader/tap_gate_mirror_guard_test.dart
@@ -34,10 +34,10 @@ void main() {
   test('setup script seeds the tap gate mirror with live Dart truth', () {
     expect(
       webviewPart,
-      contains(r'window.__hoshiTapGate = { chrome: $_showChrome, '
-          r'lookup: ${ReaderHibikiSource.instance.highlightOnTap}, '
-          'maxLen: 400 };'),
-      reason: '镜像初始值必须随 setup 脚本带当前门控真值注入',
+      contains('window.__hoshiTapGate = { chrome: C.showChrome, '
+          'lookup: C.highlightOnTap, maxLen: 400 };'),
+      reason: 'BUG-1140 第二阶段①后镜像初值随每章 config 下发（不再插进脚本源码），'
+          '但仍必须是当前门控真值',
     );
   });
 

--- a/hibiki/test/reader/todo1289_image_reveal_persist_guard_test.dart
+++ b/hibiki/test/reader/todo1289_image_reveal_persist_guard_test.dart
@@ -16,7 +16,7 @@ import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 /// 重跑 initialize→_sharedInitImages 无条件重加 `blurred`，把揭开状态冲掉。修复把
 /// 「本次会话已揭开」的稳定 key 注入分页脚本，`_hoshiBlurImage` 命中即跳过重新遮罩；
 /// 揭开状态由 Dart 会话集经 `onImageRevealed` 回传持久。这些守卫锁住三条不变量：
-///   1. 分页/连续脚本在 blurImages=true 时消费 revealedKeysJson 并跳过已揭开图片；
+///   1. 分页/连续脚本在 C.blurImages 为真时消费 C.revealedKeys 并跳过已揭开图片；
 ///   2. 揭开 key 计算器 `window.__hoshiImageRevealKey` 暴露给点击/焦点两条揭开路径；
 ///   3. 点击（webview.part.dart）与键盘/手柄（caret）揭开都回传 onImageRevealed。
 String _read(String relPath) => File(relPath).readAsStringSync();
@@ -24,13 +24,11 @@ String _read(String relPath) => File(relPath).readAsStringSync();
 void main() {
   group('TODO-1289 分页脚本消费已揭开集（不再无条件重新遮罩）', () {
     test('blurImages=true 时嵌入 revealedKeys 并让 _hoshiBlurImage 跳过命中项', () {
-      final String js = ReaderPaginationScripts.shellScript(
-        blurImages: true,
-        revealedKeysJson: '["hoshi.local/cover.jpg"]',
-      );
+      final String js = ReaderPaginationScripts.paginatedShellSource();
       // 已揭开集被嵌入并建成查找表。
       expect(js, contains('var _hoshiRevealedKeys = Object.create(null);'));
-      expect(js, contains('["hoshi.local/cover.jpg"]'));
+      // BUG-1140 第二阶段①：已揭开集不再插进源码，改由运行时 C.revealedKeys 读。
+      expect(js, contains('var __hoshiKeys = C.revealedKeys;'));
       // 遮罩前先看 key 是否已揭开——命中直接 return，不再重加 blurred。
       expect(js, contains('if (key && _hoshiRevealedKeys[key]) return;'));
       // 揭开 key 计算器暴露给点击/焦点揭开路径复用。
@@ -39,25 +37,34 @@ void main() {
     });
 
     test('连续模式同样透传 revealedKeys（重排/重载不复原遮罩）', () {
-      final String js = ReaderPaginationScripts.shellScript(
-        continuousMode: true,
-        blurImages: true,
-        revealedKeysJson: '["hoshi.local/pic.png"]',
-      );
+      final String js = ReaderPaginationScripts.continuousShellSource();
       expect(js, contains('var _hoshiRevealedKeys = Object.create(null);'));
-      expect(js, contains('["hoshi.local/pic.png"]'));
+      expect(js, contains('var __hoshiKeys = C.revealedKeys;'));
       expect(js, contains('if (key && _hoshiRevealedKeys[key]) return;'));
     });
 
-    test('blurImages=false 时不注入遮罩/揭开逻辑（边界，零行为变化）', () {
-      final String js = ReaderPaginationScripts.shellScript(blurImages: false);
-      expect(js, isNot(contains('_hoshiBlurImage')));
-      expect(js, isNot(contains('_hoshiRevealedKeys')));
-    });
-
-    test('默认 revealedKeysJson 为空数组（首开无已揭开项）', () {
-      final String js = ReaderPaginationScripts.shellScript(blurImages: true);
-      expect(js, contains('var keys = [];'));
+    test('blurImages=false 时不装遮罩/揭开副作用（边界，零行为变化）', () {
+      // 改动前是「blurImages 为假整段不注入」；引擎静态化后函数照常定义，
+      // **副作用**（重新遮罩、两个 window 全局的暴露）仍受同一个开关门控。
+      final String js = ReaderPaginationScripts.paginatedShellSource();
+      expect(js, contains('if (C.blurImages) _hoshiBlurImage(svg);'));
+      expect(js, contains('if (C.blurImages) _hoshiBlurImage(img);'));
+      expect(
+        js,
+        contains('window.__hoshiImageRevealKey = _hoshiImageRevealKey;'),
+        reason: '揭开 key 计算器仍要暴露给点击/焦点揭开路径复用',
+      );
+      // 两个 window 全局只在开了防剧透遮罩时才挂上（caret / 有声书桥接都靠这个
+      // 全局在不在来探测），否则行为与改动前不一致。
+      final int gate = js.indexOf('if (C.blurImages) {');
+      final int export =
+          js.indexOf('window.__hoshiImageRevealKey = _hoshiImageRevealKey;');
+      expect(gate, isNonNegative);
+      expect(export, greaterThan(gate),
+          reason: '揭开 key 计算器的 window 暴露必须落在 C.blurImages 门控之内');
+      final int markExport =
+          js.indexOf('window.__hoshiMarkImageRevealed = function(key)');
+      expect(markExport, greaterThan(gate), reason: '会话内揭开登记同样受同一个开关门控');
     });
   });
 
@@ -78,10 +85,10 @@ void main() {
       // 注册处理器把 key 收进会话内存集。
       expect(src, contains("handlerName: 'onImageRevealed'"));
       expect(src, contains('_revealedImageKeys.add(key)'));
-      // 构建章节 HTML 时把会话集嵌回分页脚本。
+      // BUG-1140 第二阶段①：会话集不再嵌进脚本源码，改随每章 config 下发。
       expect(
         src,
-        contains('revealedKeysJson: jsonEncode(_revealedImageKeys.toList())'),
+        contains('revealedKeys: _revealedImageKeys.toList(),'),
       );
     });
 

--- a/hibiki/test/reader/todo861_hoshi_ports_test.dart
+++ b/hibiki/test/reader/todo861_hoshi_ports_test.dart
@@ -111,10 +111,8 @@ void main() {
       );
       expect(src, isNot(contains('window.scanNonJapaneseText = true;')),
           reason: '注入端必须读 pref，不能回退硬编码 true');
-      expect(
-          src,
-          contains(
-              r'window.scanNonJapaneseText = ${appModel.scanNonJapaneseText};'));
+      expect(src,
+          contains(r'window.scanNonJapaneseText = C.scanNonJapaneseText;'));
     });
 
     test('② selection 消费端仍含 scanNonJapaneseText === false 分支', () {

--- a/hibiki/test/reader/vn_shell_smoke_test.dart
+++ b/hibiki/test/reader/vn_shell_smoke_test.dart
@@ -12,29 +12,20 @@ import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 
 void main() {
   test('VN shell builds and contains the object + restore + deps', () {
-    final String shell = ReaderVisualNovelScripts.vnShellScript(
-      initialCharOffset: 1234,
-      revealSpeed: 45,
-      screenMode: 'block',
-    );
+    final String shell = ReaderVisualNovelScripts.vnShellScript();
     expect(shell.contains('<script>'), isTrue);
     expect(shell.contains('window.hoshiReader = {'), isTrue);
     expect(shell.contains('global.hoshiReaderTextSemantics'), isTrue);
     expect(shell.contains('global.hoshiReaderVnContentStream'), isTrue);
     expect(shell.contains('global.hoshiReaderVnRangeMap'), isTrue);
     expect(shell.contains('global.hoshiReaderMediaSemantics'), isTrue);
-    expect(shell.contains('restoreToCharOffset(1234)'), isTrue);
-    expect(shell.contains('revealSpeed: 45'), isTrue);
-    expect(shell.contains("screenMode: 'block'"), isTrue);
+    // BUG-1140 第二阶段①：恢复锚 / reveal 参数不再插进源码，改由运行时读 C。
+    expect(shell.contains('restoreToCharOffset(C.initialCharOffset)'), isTrue);
+    expect(shell.contains('revealSpeed: C.vnRevealSpeed,'), isTrue);
+    expect(shell.contains('screenMode: C.vnScreenMode,'), isTrue);
     expect(shell.contains("callHandler('onRestoreComplete')"), isTrue);
-    // dispatch via shellScript(vnMode:true) reaches the VN shell.
-    final String viaShell = ReaderPaginationScripts.shellScript(
-      vnMode: true,
-      initialCharOffset: 7,
-      vnRevealSpeed: 45,
-    );
-    expect(viaShell.contains('window.hoshiReader = {'), isTrue);
-    expect(viaShell.contains('restoreToCharOffset(7)'), isTrue);
+    // 整份 shell 被包成运行时可复用的安装函数（引擎静态化的前提）。
+    expect(shell.contains('window.__hoshiShells.vn = function(C) {'), isTrue);
   });
 
   // TODO-909 M0 reveal contract. reveal（打字渐显）是 M1 功能；M0 在 webview 的
@@ -47,16 +38,14 @@ void main() {
   test(
       'M0 reveal speed 0 makes every screen complete on render (no '
       '"revealed" paginate path)', () {
-    final String shell0 = ReaderPaginationScripts.shellScript(
-      vnMode: true,
-      // M0 wire point forces this to 0 (see webview.part.dart
-      // vnRevealSpeedM0ForceZero); assert the shell carries it through.
-      vnRevealSpeed: 0,
-    );
+    final String shell0 = ReaderVisualNovelScripts.vnShellScript();
+    // M0 的 revealSpeed=0 强制点搬到 Dart 侧 config 组装处（webview.part.dart 的
+    // vnRevealSpeedM0ForceZero，由 vn_view_mode_three_state_guard 钉住）；shell 这边
+    // 只需保证它读的是运行时值、没有把任何 M1 默认值写死进源码。
     expect(
-      shell0.contains('revealSpeed: 0'),
+      shell0.contains('revealSpeed: C.vnRevealSpeed,'),
       isTrue,
-      reason: 'M0 shell must carry revealSpeed: 0',
+      reason: 'VN shell must read the reveal speed from the runtime config',
     );
     expect(
       shell0.contains('revealSpeed: 45'),
@@ -209,7 +198,7 @@ void main() {
   // 那些逻辑只存在于 VN shell，分页 shell 的图片处理仍走自己的 _sharedInitImages。
   test('BUG-513: paginated shell is unchanged (VN-only promoteBlockImages)',
       () {
-    final String paginated = ReaderPaginationScripts.shellScript();
+    final String paginated = ReaderPaginationScripts.paginatedShellSource();
     expect(
       paginated.contains('this.promoteBlockImages('),
       isFalse,
@@ -232,14 +221,13 @@ void main() {
   // 连累 cloak 移除。headless WebView 跑不到真实 cloak 时序，这里钉死源码顺序契约。
   test('BUG-718: charOffset-restore shim is defined BEFORE the boot calls it',
       () {
-    const int offset = 22059;
-    final String shell =
-        ReaderVisualNovelScripts.vnShellScript(initialCharOffset: offset);
-    // boot must restore by charOffset for a saved position.
-    final int bootCall =
-        shell.indexOf('window.hoshiReader.restoreToCharOffset($offset)');
+    final String shell = ReaderVisualNovelScripts.vnShellScript();
+    // boot must restore by charOffset for a saved position（现在读运行时 C）。
+    final int bootCall = shell
+        .indexOf('window.hoshiReader.restoreToCharOffset(C.initialCharOffset)');
     expect(bootCall, greaterThanOrEqualTo(0),
-        reason: 'charOffset restore must call restoreToCharOffset($offset)');
+        reason:
+            'charOffset restore must call restoreToCharOffset(C.initialCharOffset)');
     // the host-compat shim that defines restoreToCharOffset must appear earlier
     // in the script than the boot call site (so it is not undefined when called).
     final int shimDef = shell.indexOf('vn.restoreToCharOffset = ');
@@ -258,16 +246,15 @@ void main() {
         reason: 'boot (load listener) must come after the shim IIFE');
     expect(shell.substring(loadListener).contains('try {'), isTrue,
         reason: 'boot restore must be wrapped in try/catch');
-    // dispatch via shellScript(vnMode:true, initialCharOffset:) keeps the order.
-    final String viaShell = ReaderPaginationScripts.shellScript(
-      vnMode: true,
-      initialCharOffset: offset,
-    );
-    expect(
-      viaShell.indexOf('vn.restoreToCharOffset = ') <
-          viaShell.indexOf('window.hoshiReader.restoreToCharOffset($offset)'),
-      isTrue,
-      reason: 'dispatched VN shell must keep shim-before-boot ordering',
-    );
+    // 引擎里三种 shell 并存时，VN 那份仍保持 shim-before-boot 顺序。
+    final String engine = ReaderPaginationScripts.engineShell(
+        vnMode: true, continuousMode: false);
+    final int engShim = engine.indexOf('vn.restoreToCharOffset = ');
+    final int engBoot = engine.indexOf(
+        'window.hoshiReader.restoreToCharOffset(C.initialCharOffset)', engShim);
+    expect(engShim, greaterThanOrEqualTo(0));
+    expect(engBoot, greaterThan(engShim),
+        reason:
+            'engine-assembled VN shell must keep shim-before-boot ordering');
   });
 }

--- a/hibiki/test/reader/vn_view_mode_three_state_guard_test.dart
+++ b/hibiki/test/reader/vn_view_mode_three_state_guard_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 
 /// TODO-909 源码守卫（源码扫描，沿用仓库既有 `File(...).readAsStringSync()` +
 /// `contains` 模式）。
@@ -15,7 +16,6 @@ import 'package:flutter_test/flutter_test.dart';
 /// 本守卫只锁源码结构不回退。
 void main() {
   late String settings;
-  late String shell;
   late String styles;
   late String schema;
   late String webview;
@@ -23,9 +23,6 @@ void main() {
 
   setUpAll(() {
     settings = File('lib/src/reader/reader_settings.dart').readAsStringSync();
-    shell = File(
-      'lib/src/reader/reader_pagination_scripts.dart',
-    ).readAsStringSync();
     styles = File(
       'lib/src/reader/reader_content_styles.dart',
     ).readAsStringSync();
@@ -76,31 +73,33 @@ void main() {
     );
 
     test(
-      'shellScript routes VN to ReaderVisualNovelScripts before the '
-      'paginated/continuous branches',
+      'the engine routes VN before the paginated/continuous branches '
+      '(BUG-1140 第二阶段①：分流从 Dart 注入期搬到 JS 运行时)',
       () {
-        final String code = _stripLineComments(shell);
+        // 改动前：Dart 的 shellScript 按 vnMode/continuousMode 三选一**插值**出一份
+        // shell。现在 Dart 只决定嵌哪一份 shell，运行时分流点是引擎里的
+        // window.__hoshiInstallShell（读 C）—— 判据与顺序必须逐条保留。
+        final String engine = ReaderPaginationScripts.engineShell(
+            vnMode: true, continuousMode: false);
+        final int vnIdx = engine.indexOf('if (C.vnMode)');
+        final int contIdx = engine.indexOf('if (C.continuousMode)');
+        expect(vnIdx, isNonNegative, reason: 'engine must branch on C.vnMode');
+        expect(contIdx, isNonNegative,
+            reason: 'engine must branch on C.continuousMode');
+        expect(vnIdx < contIdx, isTrue,
+            reason: 'vnMode branch must precede continuousMode branch');
         expect(
-          code.contains('bool vnMode = false'),
+          engine.contains('window.__hoshiShells.vn = function(C)'),
           isTrue,
-          reason: 'shellScript must accept a vnMode flag',
+          reason: 'the VN engine must carry the VN shell installer',
         );
+        // Dart 侧只按 view-mode 选嵌哪一份 shell（memoize 的 key），运行时分流仍读
+        // C —— 不得回到「把 progress / charOffset 之类 per-nav 值插进 shell」的老路。
         expect(
-          code.contains('if (vnMode) {'),
+          _stripLineComments(webview)
+              .contains('ReaderPaginationScripts.engineShell('),
           isTrue,
-          reason: 'shellScript must branch on vnMode first',
-        );
-        expect(
-          code.contains('ReaderVisualNovelScripts.vnShellScript('),
-          isTrue,
-          reason: 'VN branch must delegate to the VN shell',
-        );
-        final int vnIdx = code.indexOf('if (vnMode) {');
-        final int contIdx = code.indexOf('if (continuousMode) {');
-        expect(
-          vnIdx >= 0 && contIdx >= 0 && vnIdx < contIdx,
-          isTrue,
-          reason: 'vnMode branch must precede continuousMode branch',
+          reason: 'webview must build the engine through engineShell(mode)',
         );
       },
     );
@@ -185,9 +184,14 @@ void main() {
       'blank-tap advance',
       () {
         expect(
-          webview.contains('vnMode: s.isVnMode'),
+          webview.contains('final bool vnMode = s.isVnMode;'),
           isTrue,
-          reason: 'webview must select the VN shell from view-mode',
+          reason: 'webview must derive VN mode from view-mode',
+        );
+        expect(
+          webview.contains('vnMode: vnMode,'),
+          isTrue,
+          reason: 'VN mode must reach the engine through ReaderEngineConfig',
         );
         // TODO-909 M0: reveal 渐显是 M1 功能。M0 强制 vnRevealSpeed=0，避免新屏停在
         // revealComplete=false 时 forward 翻屏命中 paginate 的 "revealed" 分支，与
@@ -197,17 +201,13 @@ void main() {
           isTrue,
           reason: 'M0 must define the reveal-speed force-zero constant',
         );
+
         expect(
           webview.contains(
-            'final int vnRevealSpeed = vnMode ? vnRevealSpeedM0ForceZero : 0;',
+            'vnRevealSpeed: vnMode ? vnRevealSpeedM0ForceZero : 0,',
           ),
           isTrue,
-          reason: 'M0 must force VN reveal speed to 0 at the wire point',
-        );
-        expect(
-          webview.contains('vnRevealSpeed: vnRevealSpeed,'),
-          isTrue,
-          reason: 'webview must forward the M0-forced reveal speed into shell',
+          reason: 'webview must forward the M0-forced reveal speed into config',
         );
         // M0 must NOT wire the live setting through (that is the M1 default 45).
         expect(


### PR DESCRIPTION
从 #497 拆出的**两块与 code cache / 外链无关**的独立改善。#497 的外链形态经实测收益上限只有 1.5~2.5ms（平台通道固定往返 ~7.5ms 才是大头，编译只占 ~1.0ms），已裁定当前形态不合并；本 PR **不含** `<script src>` 外链、拦截器路由、强缓存头、boot/install 兜底那套。

## ① `initialize` 的 per-nav 参数剥成 `ReaderEngineConfig`（结构改善）

改动前 `_buildReaderSetupScript` 把 insets / pageWidth·Height / progress / charOffset(+End) / fragment / sasayakiCues / revealedKeys / blurImages / furiganaMode / caret 色与 inset / 三种 view-mode 标志 / 手势阈值 / 诊断开关逐个**插值进脚本源码** —— 于是每次跨章都要重新拼装近万行、再整份过一遍 `ReaderScriptCompactor`（实测 `buildSetupScript` 中位数 **9ms**，纯 Dart 侧固定开销，与章节体量无关）。

现在这些值走新增的 `ReaderEngineConfig`，引擎源码整段变成 `window.__hoshiEngine.install(C)` 的函数体，一律运行时读 `C`；三种 shell 各包成 `window.__hoshiShells.{paginated,continuous,vn}`，分流点 `__hoshiInstallShell` 也读 `C`。源码只依赖 view-mode 与编译期常量 → **按模式 memoize**，拼装 + 压缩从每章一次降为每模式一次。

判据逐条对齐旧的 Dart 插值三元式：恢复锚 `fragment > charOffset >= 0 > progress`（连续 shell 多一条 BUG-461 句尾区间分支）、cue「有才调」、furigana 三模式、防剧透遮罩的两个 `window` 全局仍只在 `C.blurImages` 为真时才挂上。

**注入方式与执行时刻都没变**：仍是 `onLoadStop` 之后一次 `evaluateJavascript(引擎源码 + boot)` —— 同一时刻、同一同步执行序、**同一次平台通道往返**。本 PR 刻意不碰注入通道：实测那条通道固定往返 ~7.5ms 且与载荷大小几乎无关（发 2 字符 7.5ms vs 发 147459 字符 9.0ms），要压它得**减少往返次数**而不是减少字节数，属另一件事。守卫里专门钉了「注入必须保持单次往返」。

## ② 压缩器守卫改为直接向生产代码要最终拼装脚本

`reader_script_compactor_test` 原先把 `webview.part.dart` 的三引号模板抠出来、按一张手写替身表重建「最终拼装脚本」。那张表是**查找表**：新增插值会 `StateError`（响亮），**删掉**一个载荷完全静默 —— 整份注入物少一块、压缩覆盖跟着少一块，而没有一条测试会红。#493 为此额外加了「命中键」机制来兜。

现在引擎是零插值静态源码，直接 `readerHibikiEngineSourceUncompacted(mode)` 要同一份对象，重建与漂移一起没有了；#493 的三条断言（各子载荷整段原样在场 / 哨兵在场 / 压缩后哨兵仍在）原样保留并扩到三种 view-mode。

## 守卫与负向验证

新增 `test/reader/reader_engine_static_source_guard_test.dart`（12 项）：引擎构造器 `static` 且**参数表只有两个 view-mode 开关**、引擎只定义不执行、**每个载荷整段原样在场**、每种模式只装自己那一份 shell、caret/furigana 读运行时 config、boot 载荷 <4KB 且不含引擎本体、**注入保持单次往返**、`node --check` 真解析三种模式 + boot。

负向验证 2/2（改完转红、还原转绿）：
1. 给 `_buildReaderEngineSource` 加回一个 per-nav 参数 → 参数表守卫红（`Expected: <2> Actual: <3>`）。
2. 从拼装里删掉整个 caret 载荷 → 装配完整性守卫红。

⚠️ 第 2 条第一版用「特征行」比对时**没能转红**（兄弟载荷里有同形行造成假绿）——已改成整段比对后确认真的会红。这正是本仓「守卫逃逸出覆盖范围」的同款陷阱，记在测试注释里。

## 顺带

更正 `BUG-1140`「仍未做」第一条的机理描述：「24ms 是每次重编译整份引擎 JS」经探针实测**为假** —— 平台通道往返 ~7.5ms / JS 编译 ~1.0ms / 执行 ~6ms，大头是跨进程往返而非编译。并记下 `CustomSchemeResponse` 只有 `data`/`contentType`/`contentEncoding` 三个字段、**没有 headers**，iOS/macOS 上强缓存在类型层面就无法表达。真正值得下手的方向改为**减少每次跨章 `evaluateJavascript` 的往返次数**和 `docLoad`。

## 验证

`flutter analyze`（含 test）零 issue；`test/reader` + `test/pages` + `test/media` 定向 **7029 passed / 6 skipped / 0 failed**。未跑全量（按调度要求）。