### PR TITLE
fix(ui): AppBar 动作折叠改按本行约束宽判定 (BUG-1186) + history_reader LayoutBuilder 判定

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1149 条。点号进各自文件。
+> 共 1150 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1186](bugs/BUG-1186-appbar-actions-collapse-uses-window-width.md) | ✅ | ✅ | AppBar 动作折叠判据读整窗宽，分栏/受限宽容器里永不折叠 |
 | [BUG-1185](bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md) | ✅ | ✅ | 远端制卡查重吞掉认证失败，静默答「不重复」 |
 | [BUG-1184](bugs/BUG-1184-narrow-screen-segmented-clipped.md) | ✅ | ✅ | 窄屏/小窗口下多处内容显示不全（说明文字、分段控件、书名、对话框标题） |
 | [BUG-1183](bugs/BUG-1183-restore-auth-invalidates-session.md) | ✅ | ✅ | restoreAuth 无条件作废已解析地址，每次切页面重跑全候选探测 |

--- a/docs/bugs/BUG-1186-appbar-actions-collapse-uses-window-width.md
+++ b/docs/bugs/BUG-1186-appbar-actions-collapse-uses-window-width.md
@@ -1,0 +1,26 @@
+## BUG-1186 · AppBar 动作折叠判据读整窗宽，分栏/受限宽容器里永不折叠
+- **报告**：2026-07-28（用户：PR#495 审查遗留建议）
+- **真实性**：✅ 真 bug（判据错源，非视觉主观问题）。根因
+  `hibiki/lib/src/utils/components/hibiki_material_components.dart:1126`（修复前）——
+  `narrowAwareAppBarActions` 用 `MediaQuery.sizeOf(context).width` 拿**整个窗口**的宽度
+  判「是不是窄屏」，而它要回答的问题是「这条 AppBar 塞不塞得下这些动作按钮」。二者只在
+  「页面独占整窗」时碰巧相等；页面嵌进分栏 / 受限宽容器 / 对话框时整窗很宽而本行很窄，
+  判据永远判为「宽」，BUG-1184 折叠机制整个不触发，合集名 / 书名照样被一排图标挤没。
+  这与 PR#495 在 `HibikiToolScaffold`（同文件，原 `MediaQuery.sizeOf(context).width * 0.48`）
+  亲手修掉的是同一类错误——那边已改用 `LayoutBuilder` 的局部约束，这里漏了。
+- **[x] ① 已修复** — 判据改取该 AppBar 自己拿到的约束宽：
+  `narrowAwareAppBarActions` 去掉 `BuildContext` 参数（改后已无用途），改为必填
+  `availableWidth`；**故意不给默认值**，没有「取不到就退回整窗宽」的后路，这个 bug 就走不回来。
+  两个调用点（`media_collection_detail_page.dart`、`media_collection_grid_detail_page.dart`）
+  把 `AppBar` 包进 `PreferredSize(kToolbarHeight) + LayoutBuilder`，下发 `constraints.maxWidth`
+  ——`kToolbarHeight` 正是 `AppBar` 无 `bottom` 时的默认 `preferredSize`，Scaffold 仍自行叠加
+  状态栏 padding，与直接挂 `AppBar` 行为一致。
+  判据比的是**逻辑像素**：动作按钮固有宽（`IconButton` 48）同样是逻辑像素，「几个按钮塞得下」
+  是逻辑坐标系里的几何问题，不需要像 `windowSizeClassReal` 那样按 UI 缩放还原物理宽。
+- **[x] ② 已加自动化测试** — `hibiki/test/widgets/narrow_screen_overflow_test.dart`
+  「AppBar 动作折叠」组按真实调用形态搭台（`Scaffold` + `PreferredSize` + `LayoutBuilder`），
+  三条用例：窄窗窄行折叠、**宽窗（1200）窄行（360）仍折叠**（钉住本 bug，改回
+  `MediaQuery.sizeOf` 即红）、宽窗宽行（700）逐个平铺（宽屏零行为变化的反向用例）。
+  用例同时断言 `LayoutBuilder` 观测到的宽度，证明喂进判据的确实是局部宽。
+- **备注**：负向验证已做——把判据回退成 `MediaQuery.sizeOf(context).width` 后，
+  「宽窗窄行」用例转红且仅该条红（另两条仍绿，说明它精确锚定本 bug）；还原后全绿。

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -240,17 +240,13 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         child: Icon(Icons.movie_outlined, color: cs.onSurfaceVariant, size: 20),
       );
 
-  @override
-  Widget build(BuildContext context) {
-    final ColorScheme cs = Theme.of(context).colorScheme;
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    return Scaffold(
-      appBar: AppBar(
+  /// [availableWidth] 是这条 AppBar 实际拿到的约束宽（由 [LayoutBuilder] 下发）。
+  AppBar _buildAppBar(double availableWidth) => AppBar(
         title: Text(_name, maxLines: 1, overflow: TextOverflow.ellipsis),
         // BUG-1184：5 个动作 + 返回键在 320dp 上吃掉约 296px，合集名只剩二十几像素、
         // 等于完全看不见。窄屏把后 4 个收进溢出菜单，排序保持一眼可点。
         actions: narrowAwareAppBarActions(
-          context,
+          availableWidth: availableWidth,
           alwaysVisible: <Widget>[_buildSortMenu()],
           collapsible: <HibikiAppBarAction>[
             HibikiAppBarAction(
@@ -274,6 +270,23 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
               onPressed: _delete,
             ),
           ],
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Scaffold(
+      // BUG-1186：动作要不要折叠，得看这条 AppBar 自己拿到多宽，而不是整窗多宽。
+      // 包一层 [LayoutBuilder] 把局部约束喂给 [narrowAwareAppBarActions]；高度就是
+      // [AppBar] 无 bottom 时的默认 preferredSize（kToolbarHeight），Scaffold 仍会
+      // 自己叠上状态栏 padding，行为与直接挂 AppBar 完全一致。
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(kToolbarHeight),
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) =>
+              _buildAppBar(constraints.maxWidth),
         ),
       ),
       body: SafeArea(

--- a/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
@@ -312,29 +312,12 @@ class _MediaCollectionGridDetailPageState
     }
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final List<({MediaCollectionItemRow row, Widget card})> members =
-        <({MediaCollectionItemRow row, Widget card})>[
-      for (final MediaCollectionItemRow r in _rows)
-        if (widget.memberCardBuilder(
-          r.mediaType,
-          r.entryKey,
-          onRemoveFromCollection: () => _removeMember(r),
-        )
-            case final Widget card)
-          (row: r, card: card),
-    ];
-    _visibleRows = <MediaCollectionItemRow>[
-      for (final ({MediaCollectionItemRow row, Widget card}) m in members)
-        m.row,
-    ];
-    return Scaffold(
-      appBar: AppBar(
+  /// [availableWidth] 是这条 AppBar 实际拿到的约束宽（由 [LayoutBuilder] 下发）。
+  AppBar _buildAppBar(double availableWidth) => AppBar(
         title: Text(_name, maxLines: 1, overflow: TextOverflow.ellipsis),
         // BUG-1184：同合集详情页——窄屏把次要动作收进溢出菜单，给合集名让出宽度。
         actions: narrowAwareAppBarActions(
-          context,
+          availableWidth: availableWidth,
           alwaysVisible: <Widget>[_buildSortMenu()],
           collapsible: <HibikiAppBarAction>[
             HibikiAppBarAction(
@@ -353,6 +336,33 @@ class _MediaCollectionGridDetailPageState
               onPressed: _delete,
             ),
           ],
+        ),
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final List<({MediaCollectionItemRow row, Widget card})> members =
+        <({MediaCollectionItemRow row, Widget card})>[
+      for (final MediaCollectionItemRow r in _rows)
+        if (widget.memberCardBuilder(
+          r.mediaType,
+          r.entryKey,
+          onRemoveFromCollection: () => _removeMember(r),
+        )
+            case final Widget card)
+          (row: r, card: card),
+    ];
+    _visibleRows = <MediaCollectionItemRow>[
+      for (final ({MediaCollectionItemRow row, Widget card}) m in members)
+        m.row,
+    ];
+    return Scaffold(
+      // BUG-1186：折叠判据取这条 AppBar 的局部约束宽，不是整窗宽（同合集详情页）。
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(kToolbarHeight),
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) =>
+              _buildAppBar(constraints.maxWidth),
         ),
       ),
       body: SafeArea(

--- a/hibiki/lib/src/utils/components/hibiki_material_components.dart
+++ b/hibiki/lib/src/utils/components/hibiki_material_components.dart
@@ -1117,14 +1117,27 @@ class HibikiAppBarAction {
 /// [alwaysVisible] 放最高频、必须一眼可点的动作（如排序）；[collapsible] 里的
 /// 在宽屏逐个平铺，窄屏收进一个 [PopupMenuButton]。折叠后动作一个都没少，只是
 /// 多一次点击——比标题消失划算得多。
-List<Widget> narrowAwareAppBarActions(
-  BuildContext context, {
+///
+/// BUG-1186：判「窄」必须用**这条 AppBar 实际拿到的约束宽**，不是 `MediaQuery`
+/// 的整窗宽。页面嵌进分栏 / 受限宽容器 / 对话框时，整窗很宽而本行很窄，按整窗判
+/// 定就永远不折叠，标题照样被挤没——与 [HibikiToolScaffold] 里 BUG-1184 修掉的
+/// 是同一类错误（那边已改用 [LayoutBuilder] 的局部约束）。
+///
+/// [availableWidth] 故意做成必填、且不提供「取不到就退回整窗宽」的默认值：有默认
+/// 值就等于给这个 bug 留了一条随时能走回去的路。调用点把该 AppBar 包进
+/// [LayoutBuilder]（或包住整个 [Scaffold]——appBar 与 Scaffold 同宽）后把
+/// `constraints.maxWidth` 传进来即可。
+///
+/// 注意这里比的是**逻辑像素**：动作按钮的固有宽（[IconButton] 48）也是逻辑像素，
+/// 「几个按钮塞得下」纯粹是逻辑坐标系里的几何问题，不需要像
+/// [windowSizeClassReal] 那样按 UI 缩放还原真实物理宽。
+List<Widget> narrowAwareAppBarActions({
+  required double availableWidth,
   required List<HibikiAppBarAction> collapsible,
   List<Widget> alwaysVisible = const <Widget>[],
   double narrowWidth = 480,
 }) {
-  final double width = MediaQuery.sizeOf(context).width;
-  final bool narrow = width.isFinite && width < narrowWidth;
+  final bool narrow = availableWidth.isFinite && availableWidth < narrowWidth;
   if (!narrow || collapsible.length < 2) {
     return <Widget>[
       ...alwaysVisible,

--- a/hibiki/test/widgets/narrow_screen_overflow_test.dart
+++ b/hibiki/test/widgets/narrow_screen_overflow_test.dart
@@ -268,28 +268,61 @@ void main() {
           ),
         ];
 
-    testWidgets('窄屏折成单个溢出菜单，给标题让出宽度', (WidgetTester tester) async {
-      late List<Widget> built;
+    /// 照两个合集详情页的真实写法搭台：整窗宽 [windowWidth]，但这条 AppBar 只拿到
+    /// [rowWidth] 的约束（分栏 / 受限宽容器）。返回 [LayoutBuilder] 实际观测到的
+    /// 约束宽，供用例断言「喂进折叠判据的确实是局部宽而不是整窗宽」。
+    Future<double> pumpAppBar(
+      WidgetTester tester, {
+      required double windowWidth,
+      required double rowWidth,
+    }) async {
+      double observedWidth = double.nan;
       await tester.pumpWidget(
         buildTestApp(
           MediaQuery(
-            data: const MediaQueryData(size: Size(320, 640)),
-            child: Builder(
-              builder: (BuildContext context) {
-                built = narrowAwareAppBarActions(
-                  context,
-                  collapsible: actions(),
-                );
-                return Row(children: built);
-              },
+            data: MediaQueryData(size: Size(windowWidth, 900)),
+            child: Center(
+              child: SizedBox(
+                width: rowWidth,
+                height: 400,
+                child: Scaffold(
+                  appBar: PreferredSize(
+                    preferredSize: const Size.fromHeight(kToolbarHeight),
+                    child: LayoutBuilder(
+                      builder: (BuildContext context, BoxConstraints c) {
+                        observedWidth = c.maxWidth;
+                        return AppBar(
+                          title: const Text('合集名'),
+                          actions: narrowAwareAppBarActions(
+                            availableWidth: c.maxWidth,
+                            collapsible: actions(),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                  body: const SizedBox.shrink(),
+                ),
+              ),
             ),
           ),
         ),
       );
       await tester.pump();
+      return observedWidth;
+    }
 
-      expect(built.length, 1, reason: '三个动作必须折成一个溢出菜单（BUG-1184）');
-      expect(find.byType(PopupMenuButton<int>), findsOneWidget);
+    testWidgets('窄屏折成单个溢出菜单，给标题让出宽度', (WidgetTester tester) async {
+      final double observed = await pumpAppBar(
+        tester,
+        windowWidth: 320,
+        rowWidth: 320,
+      );
+
+      expect(observed, 320);
+      expect(find.byType(PopupMenuButton<int>), findsOneWidget,
+          reason: '三个动作必须折成一个溢出菜单（BUG-1184）');
+      expect(find.byIcon(Icons.drive_file_rename_outline), findsNothing);
       // 折叠后动作一个都不能少：菜单里必须仍能找到全部三条。
       await tester.tap(find.byType(PopupMenuButton<int>));
       await tester.pumpAndSettle();
@@ -298,28 +331,37 @@ void main() {
       expect(find.text('删除'), findsOneWidget);
     });
 
-    testWidgets('宽屏保持逐个平铺（零行为变化）', (WidgetTester tester) async {
-      late List<Widget> built;
-      await tester.pumpWidget(
-        buildTestApp(
-          MediaQuery(
-            data: const MediaQueryData(size: Size(1200, 900)),
-            child: Builder(
-              builder: (BuildContext context) {
-                built = narrowAwareAppBarActions(
-                  context,
-                  collapsible: actions(),
-                );
-                return Row(children: built);
-              },
-            ),
-          ),
-        ),
+    testWidgets('窗口很宽但这条 AppBar 只有 360 时，仍按窄屏折叠', (WidgetTester tester) async {
+      final double observed = await pumpAppBar(
+        tester,
+        windowWidth: 1200,
+        rowWidth: 360,
       );
-      await tester.pump();
 
-      expect(built.length, 3);
+      expect(observed, 360, reason: '判据必须取 AppBar 的局部约束宽');
+      expect(
+        find.byType(PopupMenuButton<int>),
+        findsOneWidget,
+        reason: 'BUG-1186：折叠判据曾读 MediaQuery 的整窗宽（1200，不算窄），'
+            '于是分栏 / 受限宽容器里三个动作照样平铺，把合集名挤没。'
+            '真正决定塞不塞得下的是这条 AppBar 自己拿到的 360',
+      );
+      expect(find.byIcon(Icons.drive_file_rename_outline), findsNothing);
+    });
+
+    testWidgets('宽屏保持逐个平铺（零行为变化）', (WidgetTester tester) async {
+      final double observed = await pumpAppBar(
+        tester,
+        windowWidth: 1200,
+        rowWidth: 700,
+      );
+
+      expect(observed, 700);
       expect(find.byType(PopupMenuButton<int>), findsNothing);
+      expect(find.byIcon(Icons.drive_file_rename_outline), findsOneWidget,
+          reason: '宽屏必须零行为变化：三个动作逐个平铺');
+      expect(find.byIcon(Icons.sell_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.delete_outline), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
PR#495（窄屏适配）审查遗留的两条收尾。

## ① `narrowAwareAppBarActions` 用整窗宽判窄屏 —— 已修 (BUG-1186)

`hibiki_material_components.dart` 里 `narrowAwareAppBarActions` 用
`MediaQuery.sizeOf(context).width` 拿**整个窗口**的宽度判「是不是窄屏」，而它要回答的
问题是「这条 AppBar 塞不塞得下这些动作按钮」。二者只在「页面独占整窗」时碰巧相等；
页面嵌进分栏 / 受限宽容器 / 对话框时整窗很宽而本行很窄，判据永远判「宽」，
BUG-1184 的折叠机制整个不触发，合集名照样被一排图标挤没。

**这正是 PR#495 在同一文件的 `HibikiToolScaffold` 里亲手修掉的同类写法**
（原 `MediaQuery.sizeOf(context).width * 0.48`，已改用 `LayoutBuilder` 的局部约束），
这里漏了。

改法照 `HibikiToolScaffold` 同一思路：

- `narrowAwareAppBarActions` 去掉 `BuildContext` 参数（改后确实已无用途，
  `t.common_more_actions` 是全局 slang），改为**必填** `availableWidth`。
  故意不给默认值 —— 没有「取不到就退回整窗宽」的后路，这个 bug 就走不回来，
  漏传是编译错误而不是静默退化。
- 两个调用点（`media_collection_detail_page` / `media_collection_grid_detail_page`）
  把 `AppBar` 包进 `PreferredSize(kToolbarHeight) + LayoutBuilder`，下发
  `constraints.maxWidth`。`kToolbarHeight` 正是 `AppBar` 无 `bottom` 时的默认
  `preferredSize`，Scaffold 仍自行叠加状态栏 padding，与直接挂 `AppBar` 行为一致。

判据比的是**逻辑像素**：动作按钮固有宽（`IconButton` 48）同样是逻辑像素，
「几个按钮塞得下」是逻辑坐标系里的几何问题，不需要像 `windowSizeClassReal` 那样按
UI 缩放还原物理宽 —— 这一点与 `_HibikiPageHeaderRow` 里「是否展开成药丸」用
`windowSizeClassReal` 的那处判定不同，注释里已说明区别。

### 测试

`test/widgets/narrow_screen_overflow_test.dart` 的「AppBar 动作折叠」组重写成按**真实
调用形态**搭台（`Scaffold` + `PreferredSize` + `LayoutBuilder`），并断言 `LayoutBuilder`
观测到的宽度，证明喂进判据的确实是局部宽：

| 用例 | 整窗宽 | 本行宽 | 期望 |
|---|---|---|---|
| 窄窗窄行 | 320 | 320 | 折叠成溢出菜单，菜单里三条动作一条不少 |
| **宽窗窄行（钉住本 bug）** | 1200 | 360 | 仍折叠 |
| 宽窗宽行（反向用例） | 1200 | 700 | 三个动作逐个平铺，零行为变化 |

### 负向验证（两个方向都跑了）

- **回退成 `MediaQuery.sizeOf`** → `FAILED`，且**只有**「宽窗 1200 / 窄行 360」一条转红
  （另两条仍绿），说明新用例精确锚定本 bug、没有误伤。
- **还原修复** → `PASSED - 14 tests ran`。

## ② `history_reader_page` 的 `LayoutBuilder` —— 判定：确实是 no-op，本 PR 不改

按要求只做判定、不动代码。结论：**确实 no-op，但机理与 PR#495 作者的推断略有出入，
而且更关键的是这段代码本身是死路径。**

**父链证据**：`history_reader_page.dart:97-101` 的
`Stack(alignment: bottomLeft, fit: StackFit.expand)`，该 `LayoutBuilder` 是它的**直接
非 positioned child**（无 `Positioned` / `Align` / `Padding` 包裹）→ 拿到
`BoxConstraints.tight(cellSize)`。再往上 `base_history_page.dart:78-91`
`HibikiCard(padding: EdgeInsets.zero, ...)` → `hibiki_material_components.dart:82-114`
全是约束透传 → `history_reader_page.dart:71` `GridView` 的 SliverGrid 给每个 cell 的
就是 tight 约束。无条件分支。

**机理更正**：`constraints.maxHeight` 是有限值（= cell 高），`isFinite` 分支会走、
`math.max(maxHeight * 0.25, needed)` 也算得出来。真正失效的是**返回值**：tight 约束下
`Container(height: bandHeight)` 的 `RenderConstrainedBox` 走
`additionalConstraints.enforce(incoming)`，height 被夹回 cell 高，scrim 标题带被强撑成
整格。旧的 `* 0.25` 写法同样被丢弃 —— 所以这处改动既不是回归也不生效，**改前改后
渲染完全一致**。旁证：同一 `Stack` 里 `:103` 的 `AspectRatio` 在 tight 下也是 no-op。

**更关键：整个 `HistoryReaderPage` 是死代码。** 三个 `ReaderMediaSource` 子类
（`reader_hibiki_source.dart:439`、`reader_pdf_source.dart:94`、
`manga_hibiki_source.dart:98`）全部 override `buildHistoryPage()` 返回
`ReaderHibikiHistoryPage`；而 `_ReaderHibikiHistoryPageState`
（`reader_hibiki_history_page.dart:147`）又 override 了 `build`(:433)、
`buildMediaItem`(:1869)、`buildMediaItemContent`(:1828)。`reader_media_source.dart:31`
那句 `return const HistoryReaderPage()` 无法触达；`HistoryReaderPage` 在全仓的唯一其余
引用是编译烟雾测试 `test/pages/history_reader_page_static_test.dart:8`。
仓库自己的审计早有记录：`docs/reviews/2026-05-29-deep-quality-audit.md:2309`
(HBK-AUDIT-114)、`:2827`。

反向佐证：若这页真的上屏，60% alpha 的 scrim 会盖满整张卡（而不是底部一条），
不可能没人报。

**建议（未执行，等你定）**：
1. 若要留这段代码并让它生效：把 `LayoutBuilder + Container(height:)` 换成
   `Positioned(left: 0, right: 0, bottom: 0, child: ...)`，或直接去掉外层测量、用
   `Align(alignment: bottomCenter, child: ConstrainedBox(minHeight: needed, ...))`
   让子级按内容自然定高（此时 `LayoutBuilder` 本就多余）。
2. 更彻底：整段 `HistoryReaderPage` 按 HBK-AUDIT-114 的处置建议删除。
3. BUG-1184 在这条路径上的**真正**修复应落在活代码
   `reader_hibiki_history_page.dart:1828` 的书卡布局上。

因为是死代码上的 no-op，无用户可见影响，故**未建 BUG 档**，也未改任何代码。

## 验证

- `flutter analyze`（含 test 目录）：`No issues found!`
- 定向测试（`dart run tool/flutter_test_failures.dart --no-pub`，含改动覆盖 + 相邻功能
  11 个套件）：`PASSED - 159 tests ran, all tests passed`
- `bug.dart check` 通过；BUG-1186 已跨 1033 个本地+远端分支重扫确认唯一。
- 未跑全量套件（按分级验证，交 PR CI 兜底）。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
