### PR TITLE
feat(manga): 书 ↔ 漫画转化（阶段一：判定层 + 落库层）

### DIFF
--- a/hibiki/lib/src/media/manga/book_format_convert.dart
+++ b/hibiki/lib/src/media/manga/book_format_convert.dart
@@ -1,0 +1,136 @@
+/// 「书 ↔ 漫画」互相转化的**可行性判定**（纯函数层）。
+///
+/// 背景：`EpubBooks` 用 `format` 列区分三种书——`'epub'`（文字书/小说）、`'pdf'`、
+/// `'manga'`（漫画 OCR）。三者共用同一个书目录 `<hoshi_books>/<bookKey>/`，`format`
+/// 之外的身份（`bookKey` = 合集/标签/进度/统计/Profile 的 entryKey）完全不变。
+///
+/// **为什么需要转化**：查词能力只挂在 `format='manga'` 上，且不是「识别图像」——
+/// 漫画能查词是因为 OCR 产出的文本被渲成一层透明 DOM（`.ocr-box`）叠在页图上，查词
+/// 查的是那层真实文本节点。文字书阅读器对图片只有「揭开防剧透模糊 / 放大 / 画廊」，
+/// 零 OCR 通道。所以一本扫描版漫画若当成普通 EPUB 导入，**在阅读器里点图永远查不了
+/// 词**，除了转化没有别的出路。
+///
+/// **转化即重建**：不是翻一个字段就完事——`format='manga'` 的阅读器硬要求
+/// `extractDir/manga.json` + `images/` 存在（缺了直接 `_loadFailed`），所以转过去
+/// 必须真的产出页图与 `manga.json`。反向（漫画 → 书）则要求原始 `.epub`/`.pdf` 仍在
+/// 书目录里；从 `.mokuro`/裸图片目录导入的漫画压根没有那个原始文件，只能明确说不支持
+/// ——而不是造一本假书糊弄过去。
+///
+/// 本文件只做**判定**（纯函数，便于单测）；磁盘探测由调用方完成后把事实传进来，
+/// 与 `drop_classification.dart` 的 `isDirectory` / `isImageArchive` 注入同一范式。
+/// 真正的产物重建在 `book_format_rebuild.dart`。
+library;
+
+/// 转化目标。
+enum BookFormatTarget {
+  /// 转成漫画（`format='manga'`）：产出页图 + `manga.json`，之后可跑整卷 OCR 查词。
+  manga,
+
+  /// 转回书（`format='epub'`/`'pdf'`）：把 `epubPath` 指回书目录里仍在的原始文件。
+  book,
+}
+
+/// 不能转化的原因。每一条都要能直接翻译成一句**给用户看的**「为什么不支持」，
+/// 而不是笼统一句「不支持」——用户报过「拖进去一点反应都没有」，说明白比拒绝重要。
+enum BookConvertBlocker {
+  /// 已经是目标格式了，无需转化。
+  alreadyTarget,
+
+  /// 文字书（普通 EPUB）没有可用作页图的内容。转成漫画后阅读器只会打开一本空书。
+  textOnlyBook,
+
+  /// 这本漫画是从 `.mokuro` / 裸图片目录导入的，书目录里没有可还原的原始
+  /// `.epub`/`.pdf`。只能保持漫画身份。
+  noOriginalFile,
+
+  /// 记录在案的源文件在磁盘上找不到了（被手工删了 / 外部存储掉盘）。
+  sourceMissing,
+}
+
+/// 判定结果。[blocker] 为 null 即可转化，[sourcePath] 是重建要读的源文件
+/// （转漫画时 = 原 `.epub`/`.pdf`；转回书时 = 要指回去的那个原始文件）。
+class BookConvertVerdict {
+  const BookConvertVerdict.supported(this.sourcePath) : blocker = null;
+
+  const BookConvertVerdict.blocked(BookConvertBlocker this.blocker)
+      : sourcePath = null;
+
+  /// 可转化时非 null：重建所需的源文件**绝对路径**。
+  final String? sourcePath;
+
+  /// 不可转化时非 null：具体原因（调用方据此给出说明文案）。
+  final BookConvertBlocker? blocker;
+
+  bool get supported => blocker == null;
+}
+
+/// 书目录里那份原始文件的既有形态（调用方探测后传入）。
+///
+/// 三种 format 的 `epubPath` 语义各不相同，故这里只描述**事实**、不描述格式：
+/// - EPUB 行：`epubPath` = 原 `.epub` 文件名（导入时拷进书目录，仍在）；
+/// - PDF 行：`epubPath` = `hibiki.pdf`（PDF 拷进书目录，仍在）；
+/// - 漫画行：`epubPath` = `manga.json`（**不是**原始文件；原始文件可能存在也可能
+///   压根没有过——`.mokuro`/裸目录导入的漫画就没有）。
+class BookSourceProbe {
+  const BookSourceProbe({
+    required this.sourceExists,
+    required this.sourceIsImageArchive,
+    this.recoverableOriginalPath,
+  });
+
+  /// `extractDir/epubPath` 指向的文件当前是否存在。
+  final bool sourceExists;
+
+  /// 该文件是不是「一包页图」（`MangaArchiveImporter.looksLikeImageArchive`，
+  /// 对 `.epub` 有专门的图片型判定分支）。PDF 恒可渲染成页图，不看这一位。
+  final bool sourceIsImageArchive;
+
+  /// 漫画行专用：书目录里仍在的原始 `.epub`/`.pdf` 绝对路径（没有则 null）。
+  final String? recoverableOriginalPath;
+}
+
+/// 判定一本书能否转成漫画。纯函数。
+///
+/// [format] / [sourceAbsolutePath] 来自 `EpubBooks` 行（后者 =
+/// `p.join(extractDir, epubPath)`），[probe] 是调用方的磁盘探测结果。
+BookConvertVerdict verdictToManga({
+  required String format,
+  required String sourceAbsolutePath,
+  required BookSourceProbe probe,
+}) {
+  if (format == 'manga') {
+    return const BookConvertVerdict.blocked(BookConvertBlocker.alreadyTarget);
+  }
+  if (!probe.sourceExists) {
+    return const BookConvertVerdict.blocked(BookConvertBlocker.sourceMissing);
+  }
+  // PDF 每一页都能栅格化成页图，恒可转（扫描版 PDF 转过来正是刚需：PDF 阅读器
+  // 对无文本层的扫描件明确不做 OCR 兜底，转成漫画才有查词）。
+  if (format == 'pdf') {
+    return BookConvertVerdict.supported(sourceAbsolutePath);
+  }
+  // 普通 EPUB：只有「图片型」（扫描版漫画常见的分发形态）才有页图可用。
+  // 文字书转过去只会得到一本空漫画——明确说清楚，别让用户转完才发现。
+  if (!probe.sourceIsImageArchive) {
+    return const BookConvertVerdict.blocked(BookConvertBlocker.textOnlyBook);
+  }
+  return BookConvertVerdict.supported(sourceAbsolutePath);
+}
+
+/// 判定一本漫画能否转回书。纯函数。
+///
+/// 「转回」是把 `epubPath` 指回书目录里**仍在的**原始 `.epub`/`.pdf`——那才是真书。
+/// 从 `.mokuro`/裸图片目录导入的漫画没有这样的原始文件，不支持（不造假书）。
+BookConvertVerdict verdictToBook({
+  required String format,
+  required BookSourceProbe probe,
+}) {
+  if (format != 'manga') {
+    return const BookConvertVerdict.blocked(BookConvertBlocker.alreadyTarget);
+  }
+  final String? original = probe.recoverableOriginalPath;
+  if (original == null || original.isEmpty) {
+    return const BookConvertVerdict.blocked(BookConvertBlocker.noOriginalFile);
+  }
+  return BookConvertVerdict.supported(original);
+}

--- a/hibiki/test/database/epub_book_format_convert_test.dart
+++ b/hibiki/test/database/epub_book_format_convert_test.dart
@@ -145,6 +145,40 @@ void main() {
     expect((await db.getEpubBook(key))!.completedAt, isNotNull);
   });
 
+  test('不传 coverPath = 保持原封面不变（绝不静默清空）', () async {
+    final HibikiDatabase db = await seedImageEpub();
+    expect((await db.getEpubBook(key))!.coverPath, 'cover.jpg');
+
+    // 调用方只关心身份格式、没打算动封面：省略 coverPath。
+    // 相邻的 updateEpubBookContentPaths 就是「null = 保持不变」，本方法必须同约定，
+    // 否则漏传一个可选参数就把用户封面抹掉，且没有任何报错。
+    await db.updateEpubBookFormat(
+      key,
+      format: 'manga',
+      epubPath: 'manga.json',
+      chapterCount: 180,
+      chaptersJson: '[]',
+    );
+
+    final EpubBookRow row = (await db.getEpubBook(key))!;
+    expect(row.coverPath, 'cover.jpg',
+        reason: '省略 coverPath 必须保留原封面——写成 Value(coverPath) 会在此变成 null');
+    expect(row.format, 'manga', reason: '其余列照常写穿');
+  });
+
+  test('显式传 coverPath 仍然覆盖（「不变」只适用于省略的情况）', () async {
+    final HibikiDatabase db = await seedImageEpub();
+    await db.updateEpubBookFormat(
+      key,
+      format: 'manga',
+      epubPath: 'manga.json',
+      chapterCount: 180,
+      chaptersJson: '[]',
+      coverPath: 'images/page_0001.png',
+    );
+    expect((await db.getEpubBook(key))!.coverPath, 'images/page_0001.png');
+  });
+
   test('只影响目标行，同库其它书不受牵连', () async {
     final HibikiDatabase db = await seedImageEpub();
     await db.insertEpubBook(

--- a/hibiki/test/database/epub_book_format_convert_test.dart
+++ b/hibiki/test/database/epub_book_format_convert_test.dart
@@ -1,0 +1,175 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 「书 ↔ 漫画」转化的落库面。
+///
+/// 转化最容易被想象成「跨表迁移」，实际不是：漫画与书是**同一张 `EpubBooks` 表**的
+/// 行，靠 `format` 列区分，主键 `bookKey` 不变。因此统一媒体身份
+/// `(mediaType='epub', entryKey=bookKey)` 完全不动——本测试的重点不是「字段写对了」，
+/// 而是**连带引用一条都不断**：合集成员、标签、阅读进度、完成标记在转化后仍然指向
+/// 同一本书。这是「转化不会让用户丢东西」的地基。
+Future<HibikiDatabase> _openDb() async {
+  final HibikiDatabase db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  return db;
+}
+
+void main() {
+  const String key = 'Scanned Volume 01';
+
+  Future<HibikiDatabase> seedImageEpub() async {
+    final HibikiDatabase db = await _openDb();
+    await db.insertEpubBook(
+      EpubBooksCompanion.insert(
+        bookKey: key,
+        title: key,
+        epubPath: 'scan.epub',
+        extractDir: '/books/$key',
+        chapterCount: 12,
+        chaptersJson: '["c1","c2"]',
+        importedAt: 1700000000000,
+        coverPath: const Value<String>('cover.jpg'),
+        author: const Value<String>('作者'),
+      ),
+    );
+    return db;
+  }
+
+  test('转成漫画：format / 产物指针列一次写穿，extractDir 与身份不动', () async {
+    final HibikiDatabase db = await seedImageEpub();
+
+    await db.updateEpubBookFormat(
+      key,
+      format: 'manga',
+      epubPath: 'manga.json',
+      chapterCount: 180,
+      chaptersJson: '[]',
+      coverPath: 'images/page_0001.png',
+    );
+
+    final EpubBookRow? row = await db.getEpubBook(key);
+    expect(row, isNotNull);
+    expect(row!.format, 'manga');
+    expect(row.epubPath, 'manga.json',
+        reason: '漫画阅读器按 extractDir/epubPath 找 manga.json');
+    expect(row.chapterCount, 180, reason: '漫画的 chapterCount 是页数');
+    expect(row.chaptersJson, '[]');
+    expect(row.coverPath, 'images/page_0001.png');
+    expect(row.mangaReadingMode, isNull, reason: 'null = 跟随按页图比例自动判定');
+    // 不该被动到的列。
+    expect(row.bookKey, key, reason: '主键不变是整个转化设计的地基');
+    expect(row.extractDir, '/books/$key', reason: '三种格式共用同一个书目录');
+    expect(row.title, key);
+    expect(row.author, '作者');
+  });
+
+  test('转回书：指回原始文件并清掉 mangaReadingMode（表约定：非漫画恒 null）', () async {
+    final HibikiDatabase db = await seedImageEpub();
+    await db.updateEpubBookFormat(
+      key,
+      format: 'manga',
+      epubPath: 'manga.json',
+      chapterCount: 180,
+      chaptersJson: '[]',
+      coverPath: 'images/page_0001.png',
+      mangaReadingMode: 'webtoon',
+    );
+    expect((await db.getEpubBook(key))!.mangaReadingMode, 'webtoon');
+
+    await db.updateEpubBookFormat(
+      key,
+      format: 'epub',
+      epubPath: 'scan.epub',
+      chapterCount: 12,
+      chaptersJson: '["c1","c2"]',
+      coverPath: 'cover.jpg',
+    );
+
+    final EpubBookRow row = (await db.getEpubBook(key))!;
+    expect(row.format, 'epub');
+    expect(row.epubPath, 'scan.epub');
+    expect(row.mangaReadingMode, isNull,
+        reason: '仅 format=manga 的行有意义，转回书必须清掉');
+    expect(row.chaptersJson, '["c1","c2"]',
+        reason: '转漫画时被覆盖成 []，转回来必须由重新解析原文件得到——所以反向也是重建');
+  });
+
+  test('转化后合集成员仍指向这本书（身份不变 → 零悬挂引用）', () async {
+    final HibikiDatabase db = await seedImageEpub();
+    final int collectionId = await db.createMediaCollection('扫描本');
+    await db.addToCollection(collectionId, MediaKind.epub, key);
+
+    await db.updateEpubBookFormat(
+      key,
+      format: 'manga',
+      epubPath: 'manga.json',
+      chapterCount: 180,
+      chaptersJson: '[]',
+      coverPath: 'images/page_0001.png',
+    );
+
+    final List<MediaCollectionItemRow> items =
+        await db.getCollectionItems(collectionId);
+    expect(items, hasLength(1));
+    expect(items.single.entryKey, key);
+    expect(items.single.mediaType, MediaKind.epub.dbValue,
+        reason: '漫画在合集值域里就是 epub——MediaKind 里根本没有 manga');
+  });
+
+  test('转化后阅读进度与完成标记仍在（进度单位换轨是另一回事，行不能丢）', () async {
+    final HibikiDatabase db = await seedImageEpub();
+    await db.upsertReaderPosition(
+      ReaderPositionsCompanion.insert(
+        bookKey: key,
+        sectionIndex: 3,
+        normCharOffset: 4200,
+        updatedAt: 1700000000000,
+      ),
+    );
+    await db.setEpubBookCompleted(key, DateTime(2026, 7, 1));
+
+    await db.updateEpubBookFormat(
+      key,
+      format: 'manga',
+      epubPath: 'manga.json',
+      chapterCount: 180,
+      chaptersJson: '[]',
+      coverPath: 'images/page_0001.png',
+    );
+
+    final ReaderPositionRow? pos = await db.getReaderPosition(key);
+    expect(pos, isNotNull, reason: '进度行按 bookKey 关联，身份不变就不该丢');
+    expect(pos!.sectionIndex, 3);
+    expect((await db.getEpubBook(key))!.completedAt, isNotNull);
+  });
+
+  test('只影响目标行，同库其它书不受牵连', () async {
+    final HibikiDatabase db = await seedImageEpub();
+    await db.insertEpubBook(
+      EpubBooksCompanion.insert(
+        bookKey: 'Another',
+        title: 'Another',
+        epubPath: 'other.epub',
+        extractDir: '/books/Another',
+        chapterCount: 5,
+        chaptersJson: '[]',
+        importedAt: 1700000000000,
+      ),
+    );
+
+    await db.updateEpubBookFormat(
+      key,
+      format: 'manga',
+      epubPath: 'manga.json',
+      chapterCount: 180,
+      chaptersJson: '[]',
+      coverPath: 'images/page_0001.png',
+    );
+
+    final EpubBookRow other = (await db.getEpubBook('Another'))!;
+    expect(other.format, 'epub');
+    expect(other.epubPath, 'other.epub');
+  });
+}

--- a/hibiki/test/media/manga/book_format_convert_test.dart
+++ b/hibiki/test/media/manga/book_format_convert_test.dart
@@ -1,0 +1,156 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/manga/book_format_convert.dart';
+
+/// 「书 ↔ 漫画」转化的可行性判定。
+///
+/// 用户要求：手动导入哪个就是哪个，导错了用右键菜单转化，**转化就是重建**，
+/// 「那个不匹配的说明一下，说不支持」。这里守卫的就是「什么算不匹配」，以及每种
+/// 不匹配都得给出**具体**原因（能翻成一句人话），而不是笼统拒绝。
+void main() {
+  const BookSourceProbe present = BookSourceProbe(
+    sourceExists: true,
+    sourceIsImageArchive: false,
+  );
+  const BookSourceProbe imageArchive = BookSourceProbe(
+    sourceExists: true,
+    sourceIsImageArchive: true,
+  );
+  const BookSourceProbe missing = BookSourceProbe(
+    sourceExists: false,
+    sourceIsImageArchive: false,
+  );
+
+  group('转成漫画', () {
+    test('PDF 恒可转（扫描版 PDF 无文本层、阅读器不做 OCR 兜底，转漫画才有查词）', () {
+      final BookConvertVerdict v = verdictToManga(
+        format: 'pdf',
+        sourceAbsolutePath: '/books/k/hibiki.pdf',
+        probe: present,
+      );
+      expect(v.supported, isTrue);
+      expect(v.sourcePath, '/books/k/hibiki.pdf');
+    });
+
+    test('图片型 EPUB 可转（扫描版漫画的常见分发形态）', () {
+      final BookConvertVerdict v = verdictToManga(
+        format: 'epub',
+        sourceAbsolutePath: '/books/k/scan.epub',
+        probe: imageArchive,
+      );
+      expect(v.supported, isTrue);
+      expect(v.sourcePath, '/books/k/scan.epub');
+    });
+
+    test('文字书不可转，且原因必须是 textOnlyBook（要能说清「为什么」）', () {
+      final BookConvertVerdict v = verdictToManga(
+        format: 'epub',
+        sourceAbsolutePath: '/books/k/novel.epub',
+        probe: present,
+      );
+      expect(v.supported, isFalse);
+      expect(v.blocker, BookConvertBlocker.textOnlyBook,
+          reason: '文字书没有页图，转过去只会得到一本空漫画');
+      expect(v.sourcePath, isNull);
+    });
+
+    test('已经是漫画 -> alreadyTarget', () {
+      final BookConvertVerdict v = verdictToManga(
+        format: 'manga',
+        sourceAbsolutePath: '/books/k/manga.json',
+        probe: present,
+      );
+      expect(v.blocker, BookConvertBlocker.alreadyTarget);
+    });
+
+    test('源文件被删 -> sourceMissing（不是笼统的「不支持」）', () {
+      final BookConvertVerdict v = verdictToManga(
+        format: 'pdf',
+        sourceAbsolutePath: '/books/k/hibiki.pdf',
+        probe: missing,
+      );
+      expect(v.blocker, BookConvertBlocker.sourceMissing);
+    });
+
+    test('源文件不存在时即使标着图片型也不放行（先查存在性）', () {
+      final BookConvertVerdict v = verdictToManga(
+        format: 'epub',
+        sourceAbsolutePath: '/books/k/gone.epub',
+        probe: const BookSourceProbe(
+          sourceExists: false,
+          sourceIsImageArchive: true,
+        ),
+      );
+      expect(v.blocker, BookConvertBlocker.sourceMissing);
+    });
+  });
+
+  group('转回书', () {
+    test('原始文件仍在书目录 -> 可转，且指回那个文件', () {
+      final BookConvertVerdict v = verdictToBook(
+        format: 'manga',
+        probe: const BookSourceProbe(
+          sourceExists: true,
+          sourceIsImageArchive: true,
+          recoverableOriginalPath: '/books/k/scan.epub',
+        ),
+      );
+      expect(v.supported, isTrue);
+      expect(v.sourcePath, '/books/k/scan.epub');
+    });
+
+    test('mokuro / 裸图片目录导入的漫画没有原始文件 -> noOriginalFile（不造假书）', () {
+      final BookConvertVerdict v = verdictToBook(
+        format: 'manga',
+        probe: present,
+      );
+      expect(v.supported, isFalse);
+      expect(v.blocker, BookConvertBlocker.noOriginalFile);
+    });
+
+    test('原始路径是空串也算没有', () {
+      final BookConvertVerdict v = verdictToBook(
+        format: 'manga',
+        probe: const BookSourceProbe(
+          sourceExists: true,
+          sourceIsImageArchive: false,
+          recoverableOriginalPath: '',
+        ),
+      );
+      expect(v.blocker, BookConvertBlocker.noOriginalFile);
+    });
+
+    test('本来就不是漫画 -> alreadyTarget', () {
+      for (final String format in <String>['epub', 'pdf']) {
+        expect(
+          verdictToBook(format: format, probe: present).blocker,
+          BookConvertBlocker.alreadyTarget,
+          reason: '$format 本来就是书',
+        );
+      }
+    });
+  });
+
+  test('每个 blocker 都必须被判定函数真的产出过（没有说不出理由的拒绝）', () {
+    final Set<BookConvertBlocker> produced = <BookConvertBlocker>{
+      verdictToManga(
+        format: 'manga',
+        sourceAbsolutePath: '/a',
+        probe: present,
+      ).blocker!,
+      verdictToManga(
+        format: 'epub',
+        sourceAbsolutePath: '/a',
+        probe: present,
+      ).blocker!,
+      verdictToManga(
+        format: 'pdf',
+        sourceAbsolutePath: '/a',
+        probe: missing,
+      ).blocker!,
+      verdictToBook(format: 'manga', probe: present).blocker!,
+    };
+    expect(produced, BookConvertBlocker.values.toSet(),
+        reason: '新增 blocker 必须同时有产出它的判定路径与说明文案');
+  });
+}

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -4608,12 +4608,16 @@ class HibikiDatabase extends _$HibikiDatabase {
   /// 零悬挂引用。变的只是「这本书用哪个阅读器打开、产物在哪」：
   /// - [format]：`'epub'` | `'pdf'` | `'manga'`（阅读器路由的唯一真相源）；
   /// - [epubPath]：漫画指向 `manga.json`，书指向原始 `.epub`/`.pdf` 文件名；
-  /// - [coverPath]：漫画取首页页图相对路径，书取原封面；
+  /// - [coverPath]：漫画取首页页图相对路径，书取原封面。**null = 保持原封面不变**
+  ///   （与相邻的 [updateEpubBookContentPaths] 同一约定）——转化从不以「清空封面」
+  ///   为目的，若用 `Value(null)` 写穿，调用方一旦漏传就把用户封面静默抹掉；
   /// - [chapterCount] / [chaptersJson]：漫画是页数 + `'[]'`，EPUB 是章数 + 每章
   ///   字数数组（转回书时必须**重新解析**原文件得到，转漫画时被覆盖会丢，故反向
   ///   转化是重建而非撤销）；
   /// - [mangaReadingMode]：仅 `format='manga'` 的行有意义，转成非漫画时必须清 null
-  ///   （表约定：其它书身份恒 null）。
+  ///   （表约定：其它书身份恒 null）。**这一列 null 是有意义的取值**（漫画上 =
+  ///   「跟随页图比例自动判定」，非漫画上 = 唯一合法值），故与 [coverPath] 相反，
+  ///   必须无条件写穿，不能沿用「null = 不变」。
   ///
   /// 单条 UPDATE，不动 `extractDir`（三种格式共用同一个书目录）。
   Future<void> updateEpubBookFormat(
@@ -4631,7 +4635,7 @@ class HibikiDatabase extends _$HibikiDatabase {
       epubPath: Value(epubPath),
       chapterCount: Value(chapterCount),
       chaptersJson: Value(chaptersJson),
-      coverPath: Value(coverPath),
+      coverPath: coverPath == null ? const Value.absent() : Value(coverPath),
       mangaReadingMode: Value(mangaReadingMode),
     ));
   }

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -4601,6 +4601,41 @@ class HibikiDatabase extends _$HibikiDatabase {
         .write(EpubBooksCompanion(author: Value(value)));
   }
 
+  /// 「书 ↔ 漫画」转化：就地改写一本书的**身份格式**及其连带的产物指针列。
+  ///
+  /// 主键 `bookKey` 不变，因此 `(mediaType='epub', entryKey=bookKey)` 这个统一媒体
+  /// 身份完全不动——合集成员 / 标签 / 阅读进度 / 统计 / Profile / 墓碑全部原地存活，
+  /// 零悬挂引用。变的只是「这本书用哪个阅读器打开、产物在哪」：
+  /// - [format]：`'epub'` | `'pdf'` | `'manga'`（阅读器路由的唯一真相源）；
+  /// - [epubPath]：漫画指向 `manga.json`，书指向原始 `.epub`/`.pdf` 文件名；
+  /// - [coverPath]：漫画取首页页图相对路径，书取原封面；
+  /// - [chapterCount] / [chaptersJson]：漫画是页数 + `'[]'`，EPUB 是章数 + 每章
+  ///   字数数组（转回书时必须**重新解析**原文件得到，转漫画时被覆盖会丢，故反向
+  ///   转化是重建而非撤销）；
+  /// - [mangaReadingMode]：仅 `format='manga'` 的行有意义，转成非漫画时必须清 null
+  ///   （表约定：其它书身份恒 null）。
+  ///
+  /// 单条 UPDATE，不动 `extractDir`（三种格式共用同一个书目录）。
+  Future<void> updateEpubBookFormat(
+    String bookKey, {
+    required String format,
+    required String epubPath,
+    required int chapterCount,
+    required String chaptersJson,
+    String? coverPath,
+    String? mangaReadingMode,
+  }) {
+    return (update(epubBooks)..where((t) => t.bookKey.equals(bookKey)))
+        .write(EpubBooksCompanion(
+      format: Value(format),
+      epubPath: Value(epubPath),
+      chapterCount: Value(chapterCount),
+      chaptersJson: Value(chaptersJson),
+      coverPath: Value(coverPath),
+      mangaReadingMode: Value(mangaReadingMode),
+    ));
+  }
+
   /// TODO-1192: 重写一本书的 `chaptersJson`（每章元数据 + `characters` 计数 +
   /// `charCaliber` 口径版本）。开书时若发现落库计数是旧口径（含标点/括号/空白），
   /// 按新口径 [japaneseCharCount] 后台重算后回写，使书架总字数与后续统计对齐


### PR DESCRIPTION
用户诉求：「书架和漫画应该能互相转化，在右键菜单里面」，后续补充「手动导入哪个就是
哪个吧，然后转化就是重建。那个不匹配的说明一下，说不支持」。

**本 PR 是阶段一：两层地基（判定 + 落库），都有测试。还没有 UI 入口，功能尚不可用。**
剩余部分见文末。

## 为什么这个功能是刚需（实查结论，不是推测）

先查清了查词链路：**查词能力只挂在 `format='manga'` 上，而且不是「识别图像」**。
漫画能查词是因为 OCR 产出的文本被渲成一层透明 DOM（`.ocr-box` / `.ocr-char`，
`color:transparent`）叠在页图上、底图 `pointer-events:none`——查词查的是那层真实
文本节点（`manga_overlay_html.dart:27`）。

而 `reader_hibiki*` 全域 grep `ocr|OCR` **零命中**：文字书阅读器对图片只有揭开防
剧透模糊 / 放大 / 画廊三条路。PDF 走原生文本层，扫描版（无文本层）直接弹提示、
**明确不做 OCR 兜底**（`reader_pdf_page.dart:305`）。

结论：**一本扫描版漫画若当成普通 EPUB 导入，在阅读器里点图永远查不了词**，除了转化
没有别的出路。这也是为什么「导入哪个就是哪个」必须配上能用的转化。

## 阶段一做了什么

### 1. 判定层（`book_format_convert.dart`，纯函数 + 11 例测试）

定下「什么算不匹配」，并保证每种不匹配都给得出**具体**原因——用户报过「拖进去一点
反应都没有」，说明白比拒绝重要：

| 场景 | 结论 |
|---|---|
| PDF → 漫画 | 恒可（扫描版 PDF 无文本层时不做 OCR 兜底，转过来才有查词） |
| 图片型 EPUB → 漫画 | 可（扫描版漫画的常见分发形态） |
| **文字书 → 漫画** | **不可**：`textOnlyBook`——没有页图，转过去只会得到一本空漫画 |
| 源文件被删 | `sourceMissing` |
| 漫画 → 书（原始 .epub/.pdf 仍在书目录） | 可，指回那个文件 |
| **漫画 → 书（.mokuro / 裸图片目录导入的）** | **不可**：`noOriginalFile`——没有可还原的原始文件，**不造一本假书糊弄** |

纯函数，磁盘事实由调用方探测后注入（`BookSourceProbe`），与 `drop_classification`
的 `isDirectory` / `isImageArchive` 同一范式。测试里有一条**元断言**：每个
`BookConvertBlocker` 都必须真的被某条判定路径产出——新增拒绝理由时必须同时有产出
路径和说明文案，杜绝「说不出理由的拒绝」。

### 2. 落库层（`updateEpubBookFormat` DAO，5 例测试）

转化最容易被想象成跨表迁移，**实际不是**：漫画与书是同一张 `EpubBooks` 表的行，靠
`format` 列区分，主键 `bookKey` 不变。所以统一媒体身份 `(mediaType='epub',
entryKey=bookKey)` 完全不动，合集成员 / 标签 / 进度 / 统计 / Profile / 墓碑全部
原地存活、零悬挂引用。单条 UPDATE，不动 `extractDir`（三种格式共用同一个书目录）。

⚠️ `chaptersJson` 在转漫画时被覆盖成 `'[]'` 就丢了，所以**反向转化只能是重建**
（重新解析原文件拿回章节），不是撤销。这点写进 doc 并由测试钉住。

测试重点不在「字段写对了」而在**连带引用一条不断**：转化后合集成员仍指向本书且
`mediaType` 仍是 `epub`（`MediaKind` 里根本没有 manga）、进度行与完成标记仍在、
同库其它书不受牵连。

## 剩余（阶段二，尚未实现）

1. **重建执行层**：PDF 逐页栅格化成页图（`page.render` + BGRA→PNG，`PdfImporter`
   已有单页封面的同款路径）/ 图片型 EPUB 提图 / 写 `manga.json`（结构须与
   `importFromImageFolder` 逐字节同构：`MokuroImage(url, size, blocks: [])` →
   `MokuroPayload`）/ 失败回滚。反向要重新解析原文件拿回 `chaptersJson`。
   OCR **不在转化里做**——沿用 `importFromImageFolder` 的既有做法（blocks 留空），
   转完用现成的「整卷 OCR」补文字。
2. **右键菜单接线**：`_epubExtraActions`（`reader_hibiki_history_page.dart:1878`）
   加一条，一处同时覆盖普通书架与漫画书架（同一函数）+ 合集详情页成员卡。不可转时
   置灰并显示上表那句具体原因。
3. **导入入口意图化**：目前书架与漫画库的导入按钮**打开同一个对话框、只有文案不同**
   （`:618` / `:1807`），类型完全由内部嗅探内容决定——与「手动导入哪个就是哪个」正好
   相反。需要把入口意图传进 `BookImportDialog`，不匹配时明确说不支持。
   ⚠️ 这是行为收窄（现在书架能导图片包），落地前值得再确认一次。

未真机验证。

https://claude.ai/code/session_01W3Jxvqzh6bur9WVs7e56ib
