### PR TITLE
rescue(sync): 抢救未推送的互联架构收敛提交（5 个，wire format 收敛）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,14 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1131 条。点号进各自文件。
+> 共 1135 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1178](bugs/BUG-1178-restore-auth-invalidates-session.md) | ✅ | ✅ | restoreAuth 无条件作废已解析地址，每次切页面重跑全候选探测 |
+| [BUG-1177](bugs/BUG-1177-show-remote-entries-gate-too-late.md) | ✅ | ✅ | 关闭「显示远端条目」仍全额拉取远端列表后丢弃 |
+| [BUG-1176](bugs/BUG-1176-manga-shelf-fetches-remote-books.md) | ✅ | ✅ | 漫画书架实例误拉远端书，切到书架触发双倍网络 |
+| [BUG-1175](bugs/BUG-1175-interconnect-remote-list-no-cache.md) | ✅ | ✅ | 互联远端库列表零缓存，每次切页面全额重拉 |
 | [BUG-1169](bugs/BUG-1169-gal-launch-failed-reason-release-assert.md) | ✅ | ✅ | release 剥离 assert 后 failed(none) 被判成启动成功 |
 | [BUG-1168](bugs/BUG-1168-post-frame-focus-reclaim-never-fires-on-idle-tree.md) | ✅ | ✅ | 静止树上 addPostFrameCallback 焦点回收永不触发（进出全屏/关字幕遮罩后快捷键失灵） |
 | [BUG-1167](bugs/BUG-1167-video-subtitle-align-dialog-focus-not-returned.md) | ✅ | ✅ | 视频字幕波形对轴弹窗关闭后不归还键盘焦点 |

--- a/docs/bugs/BUG-1175-interconnect-remote-list-no-cache.md
+++ b/docs/bugs/BUG-1175-interconnect-remote-list-no-cache.md
@@ -1,0 +1,54 @@
+## BUG-1175 · 互联远端库列表零缓存，每次切页面全额重拉
+
+- **报告**：2026-07-28（用户：每次切页面都要重新拉取）
+- **真实性**：✅ 真 bug。远端**条目列表**从来没有缓存层——只有封面图有磁盘缓存
+  （`hibiki/lib/src/sync/remote_cover_cache.dart:19`）。清单本身是裸 GET + jsonDecode：
+  - `hibiki/lib/src/sync/interconnect_sync_backend.dart:709` `listRemoteBooks`
+  - `hibiki/lib/src/sync/interconnect_sync_backend.dart:1163` `listRemoteVideos`
+  - `hibiki/lib/src/sync/interconnect_sync_backend.dart:1132` `listRemoteActivity`
+  - `hibiki/lib/src/sync/cloud_remote_video_client.dart:32` 云清单同样每次重读
+
+  而顶层 tab 保活（BUG-750）之后，为了让对端新增内容仍然可见（BUG-992/994），书架与
+  视频页各注册了一个「切回本 tab 就无条件重拉」的监听器：
+  - `hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart:358` `_onShellTabActivated`
+  - `hibiki/lib/src/pages/implementations/home_video_page.dart:264` `onTabActivated`
+
+  净效果：保活省下的重建被这两个监听器原样加了回来，**每切一次页面 = 一整轮完整
+  网络往返**。首页 dashboard 更差——它根本不在 `_keepAliveTabs`
+  （`home_page.dart:935`），每次进首页整页重建，并**串行**发三个远端请求
+  （`home_dashboard_page.dart:530-534`），`_scheduleReload` 的 400ms 防抖还会再走一遍。
+
+  放大器见 [BUG-1178](BUG-1178-restore-auth-invalidates-session.md)（每次拉取前
+  `restoreAuth` 把已探明的地址作废，逼出一轮全候选重探测）。
+
+- **[x] ① 已修复** — 新增 `hibiki/lib/src/sync/remote_library_cache.dart`：
+  `RemoteLibraryCache` = 通用 `key -> slot` 表，提供 TTL（默认 60s）、in-flight 去重、
+  显式失效、generation 守卫（拦截「旧请求后到覆盖新结果」）。app 级
+  `remoteLibraryCacheProvider` 让书架 / 漫画书架 / 视频页 / 首页共享同一份，
+  「首页刚拉过书清单、切到书架」直接命中。
+
+  接线：`reader_history/remote.part.dart` 的 `_loadRemoteBooks` /
+  `_loadStandaloneRemoteSrtAudiobooks`、`home_video_page.dart` 的 `_loadRemoteVideos`
+  （互联与云盘分属 `videos` / `cloud_videos` 两个 key——元素类型不同，共用会 cast 崩）、
+  `home_dashboard_page.dart` 的 `_loadRemoteDashboardData`（顺带把三个串行请求改成
+  `Future.wait` 并行）。
+
+  **强制穿透只有显式入口**：下拉刷新（两页的 `_pullToRefresh*` 传 `forceRefresh: true`）
+  与「管理来源」（`_openManageSources` 先 `invalidateAll()`，换了对端不能拿旧清单渲染）。
+
+  缓存只包住「问对端要清单」这一层，本地 DB 查询与去重仍每次照跑——本地新增/删除的
+  条目立即反映在混排网格里，BUG-992/994 的用户可见语义不受影响。
+
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/sync/remote_library_cache_test.dart`（12 例）：TTL 命中 / TTL 过期重取 /
+    forceRefresh 穿透 / in-flight 去重 / 失败不缓存且下次重试 / 失败保留上次成功值 /
+    单 key 失效不牵连别域 / invalidateAll / 在途请求被失效后不写回 /
+    forceRefresh 期间旧请求不覆盖新结果 / activity 按 limit 分槽 / 视频与云视频分槽。
+  - `hibiki/test/pages/reader_remote_interconnect_test.dart`：
+    「BUG-992/1175: 切回书架 tab 远端卡在场，且 TTL 内不重打网络」取代原 BUG-992 用例
+    （原用例断言的是实现细节「调用次数增加」，与本 bug 直接冲突；新用例断言用户可见的
+    不变式「远端卡在场」+ 新约束「不得重复联网」），以及
+    「BUG-1175: 下拉刷新强制穿透缓存」。
+
+- **备注**：TTL 定为 60s 的取舍——切页面是秒级操作必须命中缓存；「对端刚加了一本书」的
+  可见延迟上限一分钟，且下拉刷新随时可强制穿透。

--- a/docs/bugs/BUG-1176-manga-shelf-fetches-remote-books.md
+++ b/docs/bugs/BUG-1176-manga-shelf-fetches-remote-books.md
@@ -1,0 +1,34 @@
+## BUG-1176 · 漫画书架实例误拉远端书，切到书架触发双倍网络
+
+- **报告**：2026-07-28（用户：互联切页面重新拉取，排查时发现）
+- **真实性**：✅ 真 bug。漫画书架就是 `ReaderHibikiHistoryPage(mangaOnly: true)`
+  （`hibiki/lib/src/media/manga/manga_shelf_page.dart:14`）——与书架**同一个 State 类**，
+  且 manga 也在保活 tab 列表里（`home_page.dart:935-940`），常驻挂载。
+
+  两个实例都在 `initState` 注册了同一个监听器
+  （`hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart:331`），而回调
+  判的是 `homeShellTabNotifier.value == HomeTab.books`（同文件 `:358`），**不是判自己的
+  tab**。`_refreshRemoteBooks`（`reader_history/remote.part.dart:72`）又不对 `_mangaOnly`
+  早退。
+
+  于是用户每切到书架一次，远端书清单被完整拉**两遍**；漫画那一遍的结果在
+  `reader_hibiki_history_page.dart:1130` 被 `showRemote = !_mangaOnly && ...` 直接丢掉。
+  纯浪费一整轮网络往返。
+
+  （首帧不受影响——`:467` 的 `??=` 那里原本就有 `_mangaOnly ? null : ...` 短路，
+  漏的只是 tab 信号这条路径。）
+
+- **[x] ① 已修复** — 两道闸：
+  1. `reader_hibiki_history_page.dart` 的 `initState` 只在 `!_mangaOnly` 时才订阅
+     `homeShellTabNotifier`（漫画实例根本不消费远端书，不必订阅）。
+  2. `reader_history/remote.part.dart` 新增 `_shouldLoadRemoteBooks` 门控，
+     `_loadRemoteBooks` 开头即早退——任何**其它**触发路径（`_refreshSrtBooks` 等）
+     经过漫画实例时同样不联网，不依赖调用方自觉。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/reader_remote_interconnect_test.dart`
+  的「BUG-1176: 漫画书架实例从不拉远端书（它根本不消费）」：以 `mangaOnly: true` 挂载，
+  断言首帧 `listRemoteBooksCalls == 0`，再把 `homeShellTabNotifier` 切到 `HomeTab.books`
+  后仍为 0。
+
+- **备注**：与 [BUG-1175](BUG-1175-interconnect-remote-list-no-cache.md) 同一轮排查发现；
+  即便有了 TTL 缓存，这条也该修——漫画实例连缓存都不该去读。

--- a/docs/bugs/BUG-1177-show-remote-entries-gate-too-late.md
+++ b/docs/bugs/BUG-1177-show-remote-entries-gate-too-late.md
@@ -1,0 +1,37 @@
+## BUG-1177 · 关闭「显示远端条目」仍全额拉取远端列表后丢弃
+
+- **报告**：2026-07-28（用户：互联切页面重新拉取，排查时发现）
+- **真实性**：✅ 真 bug。`showRemoteEntries`
+  （`hibiki/lib/src/models/preferences_repository.dart:338`，默认 true）本意是「主网格
+  不渲染远端占位卡」，但两页的门控都落在**渲染期**，取数照发不误：
+  - 书架：`hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart:1134`
+    的 `showRemote` 里才读该开关，而 `_loadRemoteBooks`
+    （`reader_history/remote.part.dart:36`）无条件联网。
+  - 视频页：`hibiki/lib/src/pages/implementations/home_video_page.dart:576`
+    的 `_visibleRemoteVideos` 里才读，而 `_loadRemoteVideos`（同文件 `:491`）无条件联网。
+
+  即：明确关掉远端条目的用户，每次进页面/切 tab 仍然全额付网络代价，结果直接丢弃。
+
+  附带发现——该开关落在 `PreferencesRepository`（独立 `ChangeNotifier`，
+  `preferences_repository.dart:106`），**不经 AppModel 通知**，两页都没订阅它，
+  所以开关翻转后页面根本不重建，改了也要等别的原因触发重建才生效。
+
+- **[x] ① 已修复** — 门控前移 + 补订阅：
+  - 书架新增 `_shouldLoadRemoteBooks`（`reader_history/remote.part.dart`），
+    `_loadRemoteBooks` 开头早退；视频页新增 `_shouldLoadRemoteVideos`
+    （`home_video_page.dart`），`_loadRemoteVideos` 开头早退。关掉开关 = 一个字节都不发。
+  - 两页 `initState` 订阅 `appModelNoUpdate.prefsRepo`，回调里**只**比对门控值，
+    翻转才动远端 future（prefsRepo 通知频繁，不能每次都重取）。书架的翻转重取走
+    build 里那段门控比对（单一路径，避免回调与 build 各重取一遍）；视频页在回调里
+    直接重取。`dispose` 对称移除监听。
+  - 注意用 `appModelNoUpdate` 而非 `appModel`：后者是 `ref.watch`，在 `initState`
+    与非 build 回调里调用会触发「initState 完成前依赖 InheritedWidget」断言。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/reader_remote_interconnect_test.dart`
+  的「BUG-1177: 关闭「显示远端条目」后根本不联网（而不是拉完再丢）」：
+  先 `setShowRemoteEntries(false)` 挂载，断言 `listRemoteBooksCalls == 0` 且占位卡不在场；
+  再翻回 true，断言重新取数且占位卡出现（覆盖上面那条「翻转后不重建」的附带缺陷）。
+
+- **备注**：与 [BUG-1175](BUG-1175-interconnect-remote-list-no-cache.md) 同一轮排查发现。
+  首页 dashboard 的远端拉取**未**纳入本开关——该开关的语义是「库页主网格的占位卡」，
+  首页的「继续」与活动流是另一套口径，扩大范围属于行为变更，不在本轮。

--- a/docs/bugs/BUG-1178-restore-auth-invalidates-session.md
+++ b/docs/bugs/BUG-1178-restore-auth-invalidates-session.md
@@ -1,0 +1,42 @@
+## BUG-1178 · restoreAuth 无条件作废已解析地址，每次切页面重跑全候选探测
+
+- **报告**：2026-07-28（用户：互联切页面重新拉取，排查时发现）
+- **真实性**：✅ 真 bug。根因在
+  `hibiki/lib/src/sync/interconnect_sync_backend.dart:189` —— `_loadConfig` 末尾
+  **无条件** `_sessionResolved = false`，而 `_loadConfig` 是 `restoreAuth`
+  （同文件 `:270`）的第一步。
+
+  `restoreAuth` 又是每个消费方取 client 的必经之路：
+  - `hibiki/lib/src/pages/implementations/reader_history/remote.part.dart:20`
+  - `hibiki/lib/src/pages/implementations/home_video_page.dart:467`
+  - `hibiki/lib/src/pages/implementations/home_dashboard_page.dart:528`
+
+  且 `InterconnectSyncBackend.instance` 是**单例**，三个页面共享同一个
+  `_sessionResolved` / `_ops`。净效果：每切一次页面就把已经探明可达的地址作废一次，
+  下一次网络操作要在 `_ensureResolved`（`:218`）里重跑
+  `resolveReachableHibikiCandidate`（`:33`）的全候选**串行**探测；https 候选还各要一次
+  带指纹钉扎的 TLS 握手（`_pinnedReachabilityProbe`，`:57`）。三个页面之间还互相踩
+  ——视频页一 `restoreAuth`，书架页正在跑的会话就被作废。
+
+  这是 [BUG-1175](BUG-1175-interconnect-remote-list-no-cache.md)「切页面重拉」的
+  **延迟放大器**：不止多一次清单请求，是多一整轮地址探测再加一次清单请求。
+
+- **[x] ① 已修复** — 会话该不该重来，取决于**配置是否真变**，而不是「有人调了
+  restoreAuth」。`_loadConfig` 改为先算 `_sessionSignature(candidates, token)`
+  （地址集合 + 钉扎指纹 + 令牌；`deviceName` 是纯展示字段，不进签名），与
+  新增字段 `_configSignature` 比对，**只在不同时**才 `_sessionResolved = false`。
+  `signOut` 里把 `_configSignature` 归零，保证重新配上同样地址也会重探一次。
+
+  地址失联后的换路由径不受影响——那条路走 `clearCache()`（同文件 `:525`，
+  `SyncManager` 重试前调用），与本处正交。
+
+- **[x] ② 已加自动化测试** — 新增
+  `hibiki/test/sync/interconnect_session_reuse_test.dart`（6 例，经
+  `InterconnectSyncBackend.withProbe` 注入计数 probe）：
+  配置未变时连续 `restoreAuth` 不重探 / 令牌变化重探 / 候选地址集合变化重探 /
+  钉扎指纹变化重新解析（带指纹的候选绕过注入 probe 走真实 pinned 探测，故改断言
+  「确实重新解析而非沿用旧会话」）/ 仅 `deviceName` 变化不重探 / `signOut` 后必重探。
+
+- **备注**：与 [BUG-1175](BUG-1175-interconnect-remote-list-no-cache.md) /
+  [BUG-1176](BUG-1176-manga-shelf-fetches-remote-books.md) /
+  [BUG-1177](BUG-1177-show-remote-entries-gate-too-late.md) 同一轮排查。

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -25,6 +25,7 @@ import 'package:hibiki/src/pages/implementations/stat_shared.dart';
 import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_cover_image.dart';
+import 'package:hibiki/src/sync/remote_library_cache.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
 import 'package:hibiki/src/utils/misc/dashboard_remote_merge.dart';
@@ -527,11 +528,31 @@ class _HomeDashboardPageState
     final InterconnectSyncBackend backend = InterconnectSyncBackend.instance;
     if (!await backend.restoreAuth(syncRepo)) return;
     try {
-      final List<RemoteBookInfo> remoteBooks = await backend.listRemoteBooks();
+      // BUG-1175：首页不在 `_keepAliveTabs` 里，每次切回首页整页重建 → 这三个请求
+      // 原本每次都重发；`_scheduleReload` 的 400ms 防抖重载还会再走一遍。改为
+      // ① 过共享 TTL 缓存（书/视频清单与书架、视频页同槽，谁先拉到谁受益），
+      // ② 三个请求并行而不是串行（原本是三次完整往返首尾相接）。
+      final RemoteLibraryCache cache = ref.read(remoteLibraryCacheProvider);
+      final List<Object> results = await Future.wait<Object>(<Future<Object>>[
+        cache.read<List<RemoteBookInfo>>(
+          key: RemoteLibraryCacheKeys.books,
+          fetch: backend.listRemoteBooks,
+        ),
+        cache.read<List<RemoteVideoInfo>>(
+          key: RemoteLibraryCacheKeys.videos,
+          fetch: backend.listRemoteVideos,
+        ),
+        cache.read<List<RemoteActivityEvent>>(
+          key: RemoteLibraryCacheKeys.activity(200),
+          fetch: () => backend.listRemoteActivity(limit: 200),
+        ),
+      ]);
+      final List<RemoteBookInfo> remoteBooks =
+          results[0] as List<RemoteBookInfo>;
       final List<RemoteVideoInfo> remoteVideos =
-          await backend.listRemoteVideos();
+          results[1] as List<RemoteVideoInfo>;
       final List<RemoteActivityEvent> remoteActivity =
-          await backend.listRemoteActivity(limit: 200);
+          results[2] as List<RemoteActivityEvent>;
       if (!mounted) return;
       final List<MediaItem> books = ref
               .read(hibikiBooksProvider(JapaneseLanguage.instance))

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -69,6 +69,7 @@ import 'package:hibiki/src/sync/remote_download_progress_badge.dart';
 import 'package:hibiki/src/sync/interconnect_download_manager.dart';
 import 'package:hibiki/src/sync/cloud_remote_video_client.dart';
 import 'package:hibiki/src/sync/remote_cover_image.dart';
+import 'package:hibiki/src/sync/remote_library_cache.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_progress_banner.dart';
@@ -150,6 +151,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   Future<List<VideoBookRow>>? _future;
   Future<_RemoteVideoState?>? _remoteFuture;
   RemoteVideoClient? _remoteVideoClient;
+
+  /// 远端清单的共享 TTL 缓存（BUG-1175）。与书架 / 首页 dashboard 同一实例
+  /// （app 级 provider），切 tab 不再必然重打一轮网络。
+  RemoteLibraryCache get _remoteCache => ref.read(remoteLibraryCacheProvider);
 
   /// BUG-793：视频库 uid 集合监听。列表是一次性 FutureBuilder + 保活 tab，无此
   /// 订阅时非本页发起的导入（外部「用 Hibiki 打开」等直接落库不 _refresh 的路径）
@@ -247,6 +252,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     // BUG-793：订阅 videoBooks 表，任意导入路径落库后自动刷新库页。
     _videoUidsSub =
         widget.repo.watchVideoBookUids().listen(_onVideoUidsChanged);
+    // BUG-1177：「显示远端条目」开关落在 prefsRepo（独立 ChangeNotifier），不经
+    // AppModel 通知，本页不会因它重建 → 门控翻转后既不重取也不重渲染。显式订阅。
+    // 用 appModelNoUpdate：initState 里读 appModel 会走 ref.watch，触发
+    // 「initState 完成前依赖 InheritedWidget」断言。
+    // （门控基线已由上面的 _loadRemoteVideos() 首帧取数写入 _remoteGateAtLastLoad。）
+    appModelNoUpdate.prefsRepo.addListener(_onPrefsChangedForRemoteGate);
     assert(() {
       HomeVideoPage.debugRefreshVideos = _refresh;
       return true;
@@ -272,6 +283,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     _searchController.dispose();
     _videoUidsSub?.cancel();
     _autoScrape?.dispose();
+    appModelNoUpdate.prefsRepo.removeListener(_onPrefsChangedForRemoteGate);
     assert(() {
       HomeVideoPage.debugRefreshVideos = null;
       return true;
@@ -334,7 +346,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       announceBusy: false,
     );
     if (!mounted) return;
-    final Future<_RemoteVideoState?> remote = _loadRemoteVideos();
+    // 显式下拉 = 用户要最新的：强制穿透 [RemoteLibraryCache] 的 TTL（BUG-1175）。
+    final Future<_RemoteVideoState?> remote = _loadRemoteVideos(
+      forceRefresh: true,
+    );
     if (mounted) {
       setState(() {
         _future = widget.repo.listForShelf();
@@ -489,14 +504,52 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     return CloudRemoteVideoClient(backend: backend);
   }
 
-  Future<_RemoteVideoState?> _loadRemoteVideos() async {
+  /// 是否应该去问远端要视频清单。
+  ///
+  /// BUG-1177：`showRemoteEntries` 开关此前只在渲染期的 [_visibleRemoteVideos] 生效，
+  /// 拉取照发不误——关掉「显示远端条目」的用户仍全额付网络代价，只是结果被丢弃。
+  /// 门控前移到取数之前。
+  bool get _shouldLoadRemoteVideos =>
+      appModelNoUpdate.prefsRepo.showRemoteEntries;
+
+  /// 上一次取数时 [_shouldLoadRemoteVideos] 的值（BUG-1177），用于识别开关翻转。
+  bool _remoteGateAtLastLoad = true;
+
+  /// prefsRepo 变更回调：只关心「显示远端条目」门控是否翻转。其余偏好变动一概忽略
+  /// ——prefsRepo 的通知很频繁，不能每次都去动远端 future。
+  void _onPrefsChangedForRemoteGate() {
+    if (!mounted) return;
+    final bool gate = _shouldLoadRemoteVideos;
+    if (gate == _remoteGateAtLastLoad) return;
+    _remoteGateAtLastLoad = gate;
+    setState(() {
+      _remoteFuture = _loadRemoteVideos();
+    });
+  }
+
+  Future<_RemoteVideoState?> _loadRemoteVideos({
+    bool forceRefresh = false,
+  }) async {
+    _remoteGateAtLastLoad = _shouldLoadRemoteVideos;
+    if (!_shouldLoadRemoteVideos) {
+      _remoteVideoClient = null;
+      _cloudRemoteVideoClient = null;
+      return null;
+    }
     final RemoteVideoClient? client = await _resolveRemoteVideoClient();
     _remoteVideoClient = client;
     if (client != null) {
       // 互联后端：host live 库直接下发 RemoteVideoInfo。
       _cloudRemoteVideoClient = null;
       try {
-        final List<RemoteVideoInfo> videos = await client.listRemoteVideos();
+        // BUG-1175：经共享缓存取清单——切回视频 tab（[onTabActivated]）不再必然打一轮
+        // 网络，TTL 内直接复用。缓存只包住「问对端要清单」这一步，下面的本地库查询与
+        // 去重仍每次照跑，本地新增/删除的视频立即反映在混排网格里。
+        final List<RemoteVideoInfo> videos = await _remoteCache.read(
+          key: RemoteLibraryCacheKeys.videos,
+          forceRefresh: forceRefresh,
+          fetch: client.listRemoteVideos,
+        );
         // #6: 远端与本地是同一视频时（同 bookUid）不在混排网格重复展示。
         final List<VideoBookRow> localVideos = await widget.repo.listAll();
         final Set<String> localUids =
@@ -525,8 +578,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     try {
       // 清单不存在（从未有设备上传）→ listRemoteVideos 返回空表；结构非法
       // （FormatException）向上抛，此处 catch → 本轮云视频不可用（= 只剩本地语义）。
-      final List<RemoteVideoManifestEntry> entries =
-          await cloud.listRemoteVideos();
+      // BUG-1175：云清单同样过缓存。云盘 `videos.json` 的读取代价不比互联低（要
+      // ensureNamespace + findAsset + getJsonAsset 三次往返），切页面重读同样冤枉。
+      final List<RemoteVideoManifestEntry> entries = await _remoteCache.read(
+        key: RemoteLibraryCacheKeys.cloudVideos,
+        forceRefresh: forceRefresh,
+        fetch: cloud.listRemoteVideos,
+      );
       final List<RemoteVideoInfo> videos = <RemoteVideoInfo>[
         for (final RemoteVideoManifestEntry e in entries)
           _cloudManifestToRemoteVideoInfo(e),
@@ -810,7 +868,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       context: context,
       builder: (_) => const MediaSourcesDialog(mediaKind: 'video'),
     );
-    // 管理互联源可能新增/切换/移除远端 host，远端清单需重拉。
+    // 管理互联源可能新增/切换/移除远端 host，远端清单需重拉。换了对端后旧缓存全部
+    // 作废（BUG-1175）——否则 TTL 内还会拿上一台 host 的清单渲染。
+    _remoteCache.invalidateAll();
     if (mounted) _refresh(remote: true);
   }
 

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -74,7 +74,6 @@ import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_progress_banner.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
-import 'package:hibiki/src/sync/video_manifest.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki/src/utils/components/batch_tag_dialog_frame.dart';
 import 'package:hibiki/src/utils/cover_image.dart';
@@ -150,7 +149,28 @@ class HomeVideoPage extends BaseModuleTabPage {
 class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   Future<List<VideoBookRow>>? _future;
   Future<_RemoteVideoState?>? _remoteFuture;
-  RemoteVideoClient? _remoteVideoClient;
+
+  /// 当前远端视频来源：互联 host live 库 或 云盘目录，**至多一个**（TODO-2119）。
+  ///
+  /// 此前是 `_remoteVideoClient` + `_cloudRemoteVideoClient` 两个互斥 nullable 字段，
+  /// 每条下载/封面/字幕路径都要 `if (cloud != null) ... else ...` 分派，两个字段还可能
+  /// 被写得不同步。收成一个之后「谁是当前源」只有一个真相，能力差异改由类型系统表达：
+  /// 只有 [RemoteVideoClient]（live）才有流播/字幕/断点，见 [_liveVideoClient]。
+  RemoteVideoSource? _remoteVideoSource;
+
+  /// 当前源的 live 能力视图；云盘源在这里是 null。拿不到它的地方**编译期**就调不出
+  /// 流播/字幕/断点方法，而不是运行时抛异常。
+  RemoteVideoClient? get _remoteVideoClient {
+    final RemoteVideoSource? source = _remoteVideoSource;
+    return source is RemoteVideoClient ? source : null;
+  }
+
+  /// 当前源的云盘视图；互联源在这里是 null。仅用于云盘独有的收尾动作
+  /// （下载后按资产名取封面，见 [_registerDownloadedCloudVideo]）。
+  CloudRemoteVideoClient? get _cloudRemoteVideoClient {
+    final RemoteVideoSource? source = _remoteVideoSource;
+    return source is CloudRemoteVideoClient ? source : null;
+  }
 
   /// 远端清单的共享 TTL 缓存（BUG-1175）。与书架 / 首页 dashboard 同一实例
   /// （app 级 provider），切 tab 不再必然重打一轮网络。
@@ -165,11 +185,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 封面自愈 / 进度回写等纯列更新（集合不变）跳过，避免写回→重刷环。null=尚未收到
   /// 首个事件（首事件仅登记基线，不刷——initState 已首载）。
   Set<String>? _knownVideoUids;
-
-  /// 多端库联合视图 §2.2/§2.6：云后端（Google Drive 等）的云视频目录 client。互联
-  /// （hibikiServer）与云后端互斥——一台设备只配一种后端，故 [_remoteVideoClient]（互联）
-  /// 与本字段（云）至多一个非空，[_downloadRemote] 据此分派下载路径。
-  CloudRemoteVideoClient? _cloudRemoteVideoClient;
 
   /// 视频卡片拖放命中注册表：每张 [CardDropZone] 注册自身几何，拖放时按屏幕坐标
   /// 命中查找目标视频卡（字幕外挂到该视频）。范型=VideoBookRow。
@@ -532,63 +547,29 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }) async {
     _remoteGateAtLastLoad = _shouldLoadRemoteVideos;
     if (!_shouldLoadRemoteVideos) {
-      _remoteVideoClient = null;
-      _cloudRemoteVideoClient = null;
+      _remoteVideoSource = null;
       return null;
     }
-    final RemoteVideoClient? client = await _resolveRemoteVideoClient();
-    _remoteVideoClient = client;
-    if (client != null) {
-      // 互联后端：host live 库直接下发 RemoteVideoInfo。
-      _cloudRemoteVideoClient = null;
-      try {
-        // BUG-1175：经共享缓存取清单——切回视频 tab（[onTabActivated]）不再必然打一轮
-        // 网络，TTL 内直接复用。缓存只包住「问对端要清单」这一步，下面的本地库查询与
-        // 去重仍每次照跑，本地新增/删除的视频立即反映在混排网格里。
-        final List<RemoteVideoInfo> videos = await _remoteCache.read(
-          key: RemoteLibraryCacheKeys.videos,
-          forceRefresh: forceRefresh,
-          fetch: client.listRemoteVideos,
-        );
-        // #6: 远端与本地是同一视频时（同 bookUid）不在混排网格重复展示。
-        final List<VideoBookRow> localVideos = await widget.repo.listAll();
-        final Set<String> localUids =
-            localVideos.map((VideoBookRow r) => r.bookUid).toSet();
-        return _RemoteVideoState(
-          videos: dedupeRemoteVideos(remote: videos, localBookUids: localUids),
-        );
-      } catch (e) {
-        // spec §2.4 离线语义：拉取失败 → 占位卡不出现（failed 门控），只剩本地库。
-        // 原始异常只落 debugPrint 供排查；显式下拉刷新时的用户可见反馈用本地化友好
-        // 文案（见 _pullToRefresh），不把 TimeoutException 等开发者文本泄漏进 UI。
-        debugPrint('[home-video] remote video list failed: $e');
-        return _RemoteVideoState(
-          videos: const <RemoteVideoInfo>[],
-          failed: true,
-        );
-      }
-    }
-
-    // 云后端（§2.2/§2.6）：读 `__videos__/videos.json` 清单，把云视频条目适配成
-    // RemoteVideoInfo 混排进主网格（云角标/排序/散卡降级既有逻辑自动生效）。
-    final CloudRemoteVideoClient? cloud =
+    // TODO-2119：互联优先、否则回退云盘；两者都是 [RemoteVideoSource]，所以下面
+    // 「列清单 → 去重 → 出占位卡」这条主干只写一遍，不再按后端类型分叉。
+    final RemoteVideoSource? source = await _resolveRemoteVideoClient() ??
         await _resolveCloudRemoteVideoClient();
-    _cloudRemoteVideoClient = cloud;
-    if (cloud == null) return null;
+    _remoteVideoSource = source;
+    if (source == null) return null;
     try {
-      // 清单不存在（从未有设备上传）→ listRemoteVideos 返回空表；结构非法
-      // （FormatException）向上抛，此处 catch → 本轮云视频不可用（= 只剩本地语义）。
-      // BUG-1175：云清单同样过缓存。云盘 `videos.json` 的读取代价不比互联低（要
-      // ensureNamespace + findAsset + getJsonAsset 三次往返），切页面重读同样冤枉。
-      final List<RemoteVideoManifestEntry> entries = await _remoteCache.read(
-        key: RemoteLibraryCacheKeys.cloudVideos,
+      // BUG-1175：经共享缓存取清单——切回视频 tab（[onTabActivated]）不再必然打一轮
+      // 网络，TTL 内直接复用。缓存只包住「问对端要清单」这一步，下面的本地库查询与
+      // 去重仍每次照跑，本地新增/删除的视频立即反映在混排网格里。
+      //
+      // 两种源共用一个 key：清单已在各自 client 里统一成 List<RemoteVideoInfo>，
+      // 不再有「元素类型不同、共用会 cast 崩」的问题（TODO-2119 之前必须分槽）。
+      // 换后端时 `_openManageSources` 会 invalidateAll，不会串味。
+      final List<RemoteVideoInfo> videos = await _remoteCache.read(
+        key: RemoteLibraryCacheKeys.videos,
         forceRefresh: forceRefresh,
-        fetch: cloud.listRemoteVideos,
+        fetch: source.listRemoteVideos,
       );
-      final List<RemoteVideoInfo> videos = <RemoteVideoInfo>[
-        for (final RemoteVideoManifestEntry e in entries)
-          _cloudManifestToRemoteVideoInfo(e),
-      ];
+      // #6: 远端与本地是同一视频时（同 bookUid）不在混排网格重复展示。
       final List<VideoBookRow> localVideos = await widget.repo.listAll();
       final Set<String> localUids =
           localVideos.map((VideoBookRow r) => r.bookUid).toSet();
@@ -596,29 +577,16 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         videos: dedupeRemoteVideos(remote: videos, localBookUids: localUids),
       );
     } catch (e) {
-      debugPrint('[home-video] cloud video manifest failed: $e');
+      // spec §2.4 离线语义：拉取失败 → 占位卡不出现（failed 门控），只剩本地库。
+      // 云盘侧清单结构非法（FormatException）也落这里 → 本轮云视频不可用。
+      // 原始异常只落 debugPrint 供排查；显式下拉刷新时的用户可见反馈用本地化友好
+      // 文案（见 _pullToRefresh），不把 TimeoutException 等开发者文本泄漏进 UI。
+      debugPrint('[home-video] remote video list failed: $e');
       return _RemoteVideoState(
         videos: const <RemoteVideoInfo>[],
         failed: true,
       );
     }
-  }
-
-  /// 把云视频清单条目（[RemoteVideoManifestEntry]）适配成主网格占位卡消费的
-  /// [RemoteVideoInfo]。云清单只带 uid/title/大小/importedAt/封面资产名——无外挂字幕、
-  /// 无远端进度、无合集归属（云视频占位永远散卡，与 §2.3 host 合集归属互不影响），
-  /// 故这些字段取缺省。封面走下载时的 [CloudRemoteVideoClient.getRemoteVideoCover]，
-  /// 占位阶段用占位图（不预下封面），因此这里不设 coverPath/coverUrl。
-  RemoteVideoInfo _cloudManifestToRemoteVideoInfo(RemoteVideoManifestEntry e) {
-    return RemoteVideoInfo(
-      id: e.uid,
-      title: e.title,
-      sizeBytes: e.sizeBytes,
-      // tags 稳健档：把清单条目的标签 LWW 时钟带进 RemoteVideoInfo，供下载后
-      // mergeRemoteVideoTags 按名 max(add) vs max(removed) 解析（删除/改名传播）。
-      tagsAddedAt: e.tagsAddedAt,
-      tagTombstones: e.tagTombstones,
-    );
   }
 
   /// 多端库联合视图（spec §2.1/§2.4/§2.5）：解析可混排进主网格的远端占位视频。
@@ -1338,10 +1306,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }
 
   Future<void> _downloadRemote(RemoteVideoInfo video) async {
-    final RemoteVideoClient? client = _remoteVideoClient;
-    final CloudRemoteVideoClient? cloud = _cloudRemoteVideoClient;
+    final RemoteVideoSource? source = _remoteVideoSource;
     // #3: 服务不可达 / 未鉴权时给明确提示，不再静默 return（用户点了像没反应）。
-    if (client == null && cloud == null) {
+    if (source == null) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(t.remote_video_unavailable)),
@@ -1359,15 +1326,19 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (manager.isRunning(video.id)) return;
 
     final File dest = await _remoteDownloadDestination(video);
-    // 互联 vs 云后端分派：互联走 host live 下载 + 字幕；云后端（§2.2/§2.6）走
-    // CloudRemoteVideoClient.getRemoteVideo 拉整文件，收尾登记时无外挂字幕、封面可选。
+    // TODO-2119：下载本身是所有源的共同能力，不再分派——[RemoteVideoSource] 各自
+    // 实现续传口径（互联 host live 引擎 Range + `.part` 可续；云盘整文件重下）。
     // bookUid 用稳定的远端 video.id（与 dedupeRemoteVideos 去重键一致：upsert 同行不
     // 撞键），故下载好的视频立即出现在列表、并从混排占位区去重隐藏。
-    final InterconnectDownloadRunner run = client != null
-        ? (File target, {void Function(double progress)? onProgress}) =>
-            client.downloadRemoteVideo(video.id, target, onProgress: onProgress)
-        : (File target, {void Function(double progress)? onProgress}) =>
-            cloud!.getRemoteVideo(video.id, target, onProgress: onProgress);
+    Future<void> run(
+      File target, {
+      void Function(double progress)? onProgress,
+    }) =>
+        source.downloadRemoteVideo(video.id, target, onProgress: onProgress);
+    // 收尾登记仍按源分流：互联要回填外挂字幕 + host 断点，云盘要按资产名取封面、
+    // 且没有字幕/进度可回填。这是两种源**真实**的能力差异，不是样板分支。
+    final CloudRemoteVideoClient? cloud = _cloudRemoteVideoClient;
+    final RemoteVideoClient? client = _remoteVideoClient;
     final InterconnectDownloadComplete onComplete = client != null
         ? (File downloaded) =>
             _registerDownloadedVideo(client, video, downloaded)

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -62,6 +62,7 @@ import 'package:hibiki/src/sync/manual_sync_ui.dart';
 import 'package:hibiki/src/sync/remote_download_progress_badge.dart';
 import 'package:hibiki/src/sync/remote_cover_image.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
+import 'package:hibiki/src/sync/remote_library_cache.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_asset_package_service.dart';
 import 'package:hibiki/src/sync/sync_progress_banner.dart';
@@ -256,6 +257,14 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
 
   RemoteBookClient? _remoteBookClient;
 
+  /// 远端清单的共享 TTL 缓存（BUG-1175）。与视频页 / 首页 dashboard 同一实例
+  /// （app 级 provider），所以「首页刚拉过书列表、切到书架」不会再问对端要一次。
+  RemoteLibraryCache get _remoteCache => ref.read(remoteLibraryCacheProvider);
+
+  /// 上一次取数时 [_shouldLoadRemoteBooks] 的值（BUG-1177）。null = 还没取过。
+  /// 用于识别「显示远端条目」开关翻转，翻转时重新取数。
+  bool? _remoteGateAtLastLoad;
+
   /// 正在下载中的远端书（key = book.title）。值为进度分数 0..1；收到首个
   /// onProgress 前为 null（不确定进度）。下载期间用它在卡片上替换下载按钮为进度
   /// 指示（#3：远端下载全程有进行中反馈，不再 await 完才弹一次提示）。
@@ -348,7 +357,30 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     // BUG-992：顶层 tab IndexedStack 保活（BUG-750）后，切回书架不再隐式重拉远端书 →
     // 远端占位卡 + 书库概览总数要等用户手动下拉刷新才补齐。监听全局 tab 信号，切回
     // 书架 tab 时自动重拉一次远端（缓存 _lastRemoteState 顶住 waiting、不闪屏）。
-    homeShellTabNotifier.addListener(_onShellTabActivated);
+    //
+    // BUG-1176：漫画书架是本 State 类的另一个实例（`mangaOnly: true`），它也会走到
+    // 这里，而回调判的是 `== HomeTab.books` —— 于是切到书架时两个实例各拉一遍远端书，
+    // 漫画那份在 build 里被 `!_mangaOnly` 丢掉。漫画实例根本不消费远端书，直接不订阅。
+    if (!_mangaOnly) {
+      homeShellTabNotifier.addListener(_onShellTabActivated);
+      // BUG-1177：「显示远端条目」开关落在 prefsRepo（独立 ChangeNotifier），不经
+      // AppModel 通知，本页不会因它重建 → 门控翻转后既不重取也不重渲染。显式订阅。
+      // 用 appModelNoUpdate：initState 里读 appModel 会走 ref.watch，触发
+      // 「initState 完成前依赖 InheritedWidget」断言。
+      appModelNoUpdate.prefsRepo.addListener(_onPrefsChangedForRemoteGate);
+    }
+  }
+
+  /// prefsRepo 变更回调：只关心「显示远端条目」门控是否翻转（BUG-1177）。其余偏好
+  /// 变动一概忽略——prefsRepo 的通知很频繁，不能每次都去动远端 future。
+  ///
+  /// 翻转时只触发一次重建，真正的重新取数交给 build 里那段门控比对（单一路径，避免
+  /// 这里和 build 各自重取一遍）。
+  void _onPrefsChangedForRemoteGate() {
+    if (!mounted) return;
+    if (_remoteGateAtLastLoad == null) return;
+    if (_remoteGateAtLastLoad == _shouldLoadRemoteBooks) return;
+    _rebuild(() {});
   }
 
   /// 切回书架 tab 时自动重拉远端书（BUG-992）。非书架 tab 的切换忽略。
@@ -388,6 +420,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     mediaType.tabRefreshNotifier.removeListener(_reloadShelfMapsOnTabRefresh);
     _mokuroQueue?.removeListener(_onMokuroQueueChanged);
     homeShellTabNotifier.removeListener(_onShellTabActivated);
+    appModelNoUpdate.prefsRepo.removeListener(_onPrefsChangedForRemoteGate);
     assert(() {
       ReaderHibikiHistoryPage.debugOpenBook = null;
       return true;
@@ -464,9 +497,16 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                               const <String, _AudiobookInfo>{},
                             )
                           : _loadAllAudiobookInfo();
-                      _remoteBooksFuture ??= _mangaOnly
-                          ? Future<_RemoteBookState?>.value(null)
-                          : _loadRemoteBooks();
+                      // BUG-1177：「显示远端条目」门控已前移进 _loadRemoteBooks
+                      // （关掉就不联网，而不是拉完再丢）。开关从关翻到开时 `??=` 不会
+                      // 重跑，故这里显式比对上轮门控值，翻转时重新取数——否则用户在设置
+                      // 里打开开关后要下拉刷新才看得到远端卡。
+                      if (_remoteGateAtLastLoad != null &&
+                          _remoteGateAtLastLoad != _shouldLoadRemoteBooks) {
+                        _remoteBooksFuture = null;
+                      }
+                      _remoteGateAtLastLoad = _shouldLoadRemoteBooks;
+                      _remoteBooksFuture ??= _loadRemoteBooks();
                       _shelfMapsFuture ??= _loadShelfMaps();
                       final List<MediaItem> shelfBooks =
                           filterShelfEntriesByMangaSplit(

--- a/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
@@ -33,12 +33,39 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     );
   }
 
-  Future<_RemoteBookState?> _loadRemoteBooks() async {
+  /// 是否应该去问远端要书列表。
+  ///
+  /// BUG-1176：漫画书架（`mangaOnly`）和书架是**同一个 State 类**的两个实例，都注册了
+  /// [_onShellTabActivated]，且该回调判的是 `== HomeTab.books`。于是切到书架会触发两次
+  /// 完整拉取，漫画那次的结果在 build 里被 `!_mangaOnly` 直接丢掉——纯浪费一整轮网络。
+  ///
+  /// BUG-1177：`showRemoteEntries` 开关此前只在 build 的 `showRemote` 处生效（本文件
+  /// 上游 `reader_hibiki_history_page.dart` 的 remote 门控），拉取照发不误。关掉「显示
+  /// 远端条目」的用户仍然全额付网络代价，只是结果被丢弃。门控前移到取数之前。
+  /// 用 `appModelNoUpdate`（不 watch）：本门控只读 prefsRepo，与 AppModel 的通知无关；
+  /// 而本 getter 会在 prefsRepo 回调等非 build 时机被调用，那里 `ref.watch` 非法。
+  bool get _shouldLoadRemoteBooks =>
+      !_mangaOnly && appModelNoUpdate.prefsRepo.showRemoteEntries;
+
+  Future<_RemoteBookState?> _loadRemoteBooks(
+      {bool forceRefresh = false}) async {
+    if (!_shouldLoadRemoteBooks) {
+      _remoteBookClient = null;
+      return null;
+    }
     final RemoteBookClient? client = await _resolveRemoteBookClient();
     _remoteBookClient = client;
     if (client == null) return null;
     try {
-      final List<RemoteBookInfo> books = await client.listRemoteBooks();
+      // BUG-1175：经共享缓存取清单——切回书架 tab（[_onShellTabActivated]）不再必然
+      // 打一轮网络，TTL 内直接复用；首页 dashboard 刚拉过的同一份列表也在这里命中。
+      // 缓存只包住「问对端要清单」这一步，下面的本地库查询与去重仍每次照跑，所以本地
+      // 新增/删除的书立即反映在混排网格里。
+      final List<RemoteBookInfo> books = await _remoteCache.read(
+        key: RemoteLibraryCacheKeys.books,
+        forceRefresh: forceRefresh,
+        fetch: client.listRemoteBooks,
+      );
       // #6: 远端与本地是同一本书时（同 bookKey）不在混排网格重复展示（只显示本地卡）。
       final List<EpubBookRow> localBooks =
           await appModel.database.getAllEpubBooks();
@@ -50,7 +77,10 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
       // 有声书，只留 standalone（bookKey 空、身份=uid）且本地无同 uid SrtBook 的项，
       // 作为可下载占位卡。云盘后端无此 API → 空列表（占位卡不出现，与能力边界一致）。
       final List<RemoteAudiobookInfo> remoteSrt =
-          await _loadStandaloneRemoteSrtAudiobooks(client);
+          await _loadStandaloneRemoteSrtAudiobooks(
+        client,
+        forceRefresh: forceRefresh,
+      );
       return _RemoteBookState(
         books: dedupeRemoteBooks(
           remote: withContent,
@@ -69,6 +99,10 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     }
   }
 
+  /// 非强制的远端书重载：切回书架 tab（BUG-992）、本地有声书列表变动等「可能只是本地
+  /// 变了」的信号走这里。远端清单本身经 [RemoteLibraryCache] 的 TTL 判断是否真要联网，
+  /// 所以切页面不会再变成一轮网络往返（BUG-1175）。要**强制**穿透缓存只有一个入口：
+  /// 用户显式下拉刷新（[_pullToRefreshBooks]）。
   void _refreshRemoteBooks() {
     _rebuild(() {
       _remoteBooksFuture = _loadRemoteBooks();
@@ -100,7 +134,10 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     ref.invalidate(srtBooksProvider);
     _batchAudiobookInfoFuture = null;
     _batchAudiobookInfoResult = const <String, _AudiobookInfo>{};
-    final Future<_RemoteBookState?> future = _loadRemoteBooks();
+    // 显式下拉 = 用户要最新的：强制穿透 [RemoteLibraryCache] 的 TTL（BUG-1175）。
+    final Future<_RemoteBookState?> future = _loadRemoteBooks(
+      forceRefresh: true,
+    );
     _rebuild(() {
       _remoteBooksFuture = future;
       // 合集折叠映射也一并重载：下拉刷新前若后台同步落了新合集成员，只失效书列表
@@ -609,14 +646,20 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
   /// 只留 standalone（bookKey 空、身份=uid）且本地无同 uid SrtBook 的项作占位卡。
   /// 云盘后端无此能力 → 空列表（占位卡不出现，与真实能力边界一致，不静默 fail-open）。
   Future<List<RemoteAudiobookInfo>> _loadStandaloneRemoteSrtAudiobooks(
-    RemoteBookClient client,
-  ) async {
+    RemoteBookClient client, {
+    bool forceRefresh = false,
+  }) async {
     if (client is! InterconnectSyncBackend) {
       return const <RemoteAudiobookInfo>[];
     }
     List<RemoteAudiobookInfo> all;
     try {
-      all = await client.listRemoteAudiobooks();
+      // BUG-1175：与书清单同缓存策略——切回 tab 不再重打这一枪。
+      all = await _remoteCache.read(
+        key: RemoteLibraryCacheKeys.audiobooks,
+        forceRefresh: forceRefresh,
+        fetch: client.listRemoteAudiobooks,
+      );
     } catch (e) {
       debugPrint('[reader-shelf] remote audiobook list failed: $e');
       return const <RemoteAudiobookInfo>[];

--- a/hibiki/lib/src/sync/cloud_remote_video_client.dart
+++ b/hibiki/lib/src/sync/cloud_remote_video_client.dart
@@ -1,6 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart'
+    show RemoteVideoInfo;
+import 'package:hibiki/src/sync/remote_video_client.dart'
+    show RemoteVideoSource;
 import 'package:hibiki/src/sync/sync_asset_store.dart';
 import 'package:hibiki/src/sync/sync_backend.dart' show SyncBackendError;
 import 'package:hibiki/src/sync/sync_orchestrator.dart'
@@ -20,7 +24,7 @@ import 'package:hibiki/src/sync/video_manifest.dart';
 /// [backend] **必须**是 `resolveSyncBackend` 的产物（含 `ObfuscatingSyncBackend`
 /// 解混淆装饰层），否则下载下来的视频/封面是混淆字节。仅需资产存取能力，故按更窄的
 /// [SyncAssetStore] 契约声明依赖（`SyncBackend` 是其子类型，直接传入即可）。
-class CloudRemoteVideoClient {
+class CloudRemoteVideoClient implements RemoteVideoSource {
   CloudRemoteVideoClient({required this.backend});
 
   /// 远端资产存取层；务必是 `resolveSyncBackend` 的产物（带解混淆装饰层）。
@@ -29,7 +33,10 @@ class CloudRemoteVideoClient {
   /// 读 `__videos__/videos.json` 目录清单，返回全部云视频条目（uid/title/大小/
   /// importedAt/videoAsset/coverAsset）。命名空间或清单缺失（从未有设备上传）→ 空表。
   /// 清单结构非法（[FormatException]）向上抛，交调用方按「本轮云视频不可用」降级。
-  Future<List<RemoteVideoManifestEntry>> listRemoteVideos() async {
+  ///
+  /// 这是**清单层**视图（同步编排、上传去重等要看 `videoAsset`/`coverAsset` 资产名）；
+  /// 库页消费的是 [listRemoteVideos] 的 [RemoteVideoInfo] 视图。
+  Future<List<RemoteVideoManifestEntry>> listRemoteVideoManifest() async {
     final String ns = await backend.ensureNamespace(kSyncVideosNamespace);
     final AssetEntry? asset =
         await backend.findAsset(ns, kSyncVideosManifestName);
@@ -38,6 +45,45 @@ class CloudRemoteVideoClient {
     if (json == null) return const <RemoteVideoManifestEntry>[];
     return RemoteVideoManifest.fromJson(json).videos;
   }
+
+  /// [RemoteVideoSource] 视图：把云清单条目适配成库页主网格消费的 [RemoteVideoInfo]。
+  ///
+  /// 适配逻辑此前长在 `home_video_page.dart` 里（`_cloudManifestToRemoteVideoInfo`），
+  /// 于是给 [RemoteVideoInfo] 加字段时必须记得回去改页面，漏改则云侧该字段永远是空的
+  /// （TODO-2119）。DTO 知识归 client 所有，页面不该知道 manifest 长什么样。
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async {
+    return <RemoteVideoInfo>[
+      for (final RemoteVideoManifestEntry e in await listRemoteVideoManifest())
+        _manifestToInfo(e),
+    ];
+  }
+
+  /// 云清单只带 uid/title/大小/importedAt/封面资产名——无外挂字幕、无远端进度、
+  /// 无合集归属（云视频占位永远散卡，与 §2.3 host 合集归属互不影响），故这些字段取
+  /// 缺省。封面走下载时的 [getRemoteVideoCover]，占位阶段用占位图（不预下封面），
+  /// 因此这里不设 coverPath/coverUrl。
+  RemoteVideoInfo _manifestToInfo(RemoteVideoManifestEntry e) {
+    return RemoteVideoInfo(
+      id: e.uid,
+      title: e.title,
+      sizeBytes: e.sizeBytes,
+      // tags 稳健档：把清单条目的标签 LWW 时钟带进 RemoteVideoInfo，供下载后
+      // mergeRemoteVideoTags 按名 max(add) vs max(removed) 解析（删除/改名传播）。
+      tagsAddedAt: e.tagsAddedAt,
+      tagTombstones: e.tagTombstones,
+    );
+  }
+
+  /// [RemoteVideoSource] 视图的下载入口；云盘就是整文件重下（无 Range 续传），
+  /// 实现委托给既有的 [getRemoteVideo]。
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) =>
+      getRemoteVideo(id, dest, onProgress: onProgress);
 
   /// 把 [uid] 对应的视频文件资产下载到 [destination]。清单里无此 uid，或清单记录的
   /// 视频资产在命名空间下已不存在 → 抛 [SyncBackendError]（调用方提示下载失败）。
@@ -65,7 +111,7 @@ class CloudRemoteVideoClient {
   }
 
   Future<RemoteVideoManifestEntry> _requireEntry(String uid) async {
-    for (final RemoteVideoManifestEntry e in await listRemoteVideos()) {
+    for (final RemoteVideoManifestEntry e in await listRemoteVideoManifest()) {
       if (e.uid == uid) return e;
     }
     throw SyncBackendError('remote video not found in manifest: $uid');

--- a/hibiki/lib/src/sync/hibiki_remote_lookup_client.dart
+++ b/hibiki/lib/src/sync/hibiki_remote_lookup_client.dart
@@ -1,9 +1,7 @@
 import 'dart:convert';
 
-import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/interconnect_post_transport.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
-import 'package:hibiki/src/sync/tls/hibiki_pinning_http.dart';
-import 'package:hibiki/src/sync/webdav_ops.dart';
 import 'package:hibiki_dictionary/hibiki_dictionary.dart';
 import 'package:http/http.dart' as http;
 
@@ -23,46 +21,30 @@ class RemoteLookupUnreachableError implements Exception {
   String toString() => 'RemoteLookupUnreachableError: $message';
 }
 
-/// [HibikiRemoteLookupClient._postLookup] 的结局：`json` 为拿到并解析成功的响应
-/// 体；`allUnreachable` 仅当「至少发起过一次请求且所有候选都没拿到任何 HTTP
-/// 响应」时为 true——未配对/无 token/候选 URL 全畸形都不算不可达。
-typedef _PostLookupOutcome = ({
-  Map<String, dynamic>? json,
-  bool allUnreachable
-});
-
 class HibikiRemoteLookupClient {
   HibikiRemoteLookupClient({
     required SyncRepository repo,
     http.Client? httpClient,
     http.Client Function(String expectedFingerprint)? pinnedClientFactory,
     Duration timeout = const Duration(seconds: 3),
-  })  : _repo = repo,
-        _httpClient = httpClient ?? http.Client(),
-        _pinnedClientFactory = pinnedClientFactory ?? _defaultPinnedClient,
+  })  : _transport = InterconnectPostTransport(
+          repo: repo,
+          httpClient: httpClient,
+          pinnedClientFactory: pinnedClientFactory,
+        ),
         _timeout = timeout;
 
-  final SyncRepository _repo;
-
-  /// 明文 http 候选共用的 client（生产由 AppModel 注入 keep-alive client 复用连接，
-  /// TODO-744）。**绝不**用于带指纹的 https 候选——那必须走钉扎 client
-  /// （TODO-961 gap①：注入生产 client 不得旁路证书钉扎）。
-  final http.Client _httpClient;
-
-  /// https 候选的钉扎 client 工厂（每候选一个、用完即关）。默认真钉扎
-  /// [createPinnedHttpPackageClient]；测试注入 MockClient 工厂即可拦截。
-  final http.Client Function(String expectedFingerprint) _pinnedClientFactory;
+  /// 候选轮询 / 鉴权 / 指纹钉扎 / socket 回收统一由 [InterconnectPostTransport]
+  /// 承担——本类只管端点、超时与响应体的语义解析。
+  final InterconnectPostTransport _transport;
   final Duration _timeout;
-
-  static http.Client _defaultPinnedClient(String expectedFingerprint) =>
-      createPinnedHttpPackageClient(expectedFingerprint: expectedFingerprint);
 
   Future<DictionarySearchResult?> searchDictionary({
     required String term,
     required bool wildcards,
     required int maximumTerms,
   }) async {
-    final _PostLookupOutcome outcome = await _postLookup(
+    final InterconnectPostOutcome outcome = await _postLookup(
       path: '/api/lookup/dictionary',
       body: <String, dynamic>{
         'term': term,
@@ -110,7 +92,7 @@ class HibikiRemoteLookupClient {
     required String expression,
     required String reading,
   }) async {
-    final _PostLookupOutcome outcome = await _postLookup(
+    final InterconnectPostOutcome outcome = await _postLookup(
       path: '/api/lookup/audio',
       body: <String, dynamic>{
         'expression': expression,
@@ -129,88 +111,15 @@ class HibikiRemoteLookupClient {
     return (url == null || url.isEmpty) ? null : url;
   }
 
-  Future<_PostLookupOutcome> _postLookup({
+  Future<InterconnectPostOutcome> _postLookup({
     required String path,
     required Map<String, dynamic> body,
-  }) async {
-    final List<HibikiClientUrl> candidates = (await _repo.getHibikiClientUrls())
-        .where((HibikiClientUrl u) => u.enabled)
-        .toList(growable: false);
-    final String? token = await _repo.getHibikiClientToken();
-    if (candidates.isEmpty || token == null || token.isEmpty) {
-      // 未配对/未启用/无 token：不是「设备不可达」，按「无结果」处理。
-      return (json: null, allUnreachable: false);
-    }
-
-    bool attempted = false;
-    bool anyResponse = false;
-    for (final HibikiClientUrl candidate in candidates) {
-      final Uri? uri = _lookupUri(candidate.url, path);
-      if (uri == null) continue;
-      // TODO-961 M1/gap①: https 带指纹的候选**始终**走钉扎 client，与是否注入了
-      // 外部 client 无关（注入的 keep-alive client 只服务明文 http 候选，行为零变化）。
-      final String? fp = candidate.fingerprintSha256;
-      final bool usePinned =
-          uri.isScheme('https') && fp != null && fp.isNotEmpty;
-      final http.Client client =
-          usePinned ? _pinnedClientFactory(fp) : _httpClient;
-      attempted = true;
-      try {
-        final http.Response response = await client
-            .post(
-              uri,
-              headers: <String, String>{
-                'Authorization':
-                    'Basic ${base64Encode(utf8.encode('hibiki:$token'))}',
-                'Content-Type': 'application/json',
-              },
-              body: jsonEncode(body),
-            )
-            .timeout(_timeout);
-        // 拿到任何 HTTP 响应（含 401/404/405/非 2xx/坏 JSON 体）都算「可达」；
-        // 传输层失败（连接拒绝/超时/DNS）根本走不到这一行，落在 catch 里。
-        anyResponse = true;
-        if (response.statusCode == 401) {
-          throw SyncAuthError('Hibiki server rejected remote lookup token');
-        }
-        if (response.statusCode == 404 || response.statusCode == 405) {
-          continue;
-        }
-        if (response.statusCode < 200 || response.statusCode >= 300) {
-          continue;
-        }
-        final dynamic decoded = jsonDecode(response.body);
-        if (decoded is Map<String, dynamic>) {
-          return (json: decoded, allUnreachable: false);
-        }
-        if (decoded is Map) {
-          return (
-            json: Map<String, dynamic>.from(decoded),
-            allUnreachable: false,
-          );
-        }
-      } on SyncAuthError {
-        rethrow;
-      } catch (_) {
-        continue;
-      } finally {
-        // 每候选独立 pinned client 用完即关，所有出口（return/continue/throw）统一
-        // 经 finally 回收，不泄漏 socket；共享 _httpClient 绝不在此关闭。
-        if (usePinned) client.close();
-      }
-    }
-    // 走到这里没有任何候选给出可用结果；只有「试过且一个响应都没拿到」才算
-    // 全部不可达（传输层失败），可达但无结果仍是普通 null。
-    return (json: null, allUnreachable: attempted && !anyResponse);
-  }
-
-  Uri? _lookupUri(String baseUrl, String path) {
-    try {
-      final Uri base = Uri.parse(WebDavOps.normalizeUrl(baseUrl));
-      return base
-          .replace(path: path, queryParameters: const <String, String>{});
-    } catch (_) {
-      return null;
-    }
+  }) {
+    return _transport.post(
+      path: path,
+      body: body,
+      timeout: _timeout,
+      authErrorMessage: 'Hibiki server rejected remote lookup token',
+    );
   }
 }

--- a/hibiki/lib/src/sync/hibiki_remote_mining_client.dart
+++ b/hibiki/lib/src/sync/hibiki_remote_mining_client.dart
@@ -1,10 +1,7 @@
-import 'dart:convert';
-
 import 'package:hibiki/src/sync/forwarded_mine_payload.dart';
+import 'package:hibiki/src/sync/interconnect_post_transport.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
-import 'package:hibiki/src/sync/tls/hibiki_pinning_http.dart';
-import 'package:hibiki/src/sync/webdav_ops.dart';
 import 'package:http/http.dart' as http;
 
 /// 「制卡到服务端」发送器的窄接口（供 [RemoteMiningAnkiRepository] 依赖，便于单测注入假实现，
@@ -21,10 +18,10 @@ abstract class RemoteMineSender {
   });
 }
 
-/// 互联「制卡到服务端」的客户端发送器。传输契约与 [HibikiRemoteLookupClient] 完全同构
+/// 互联「制卡到服务端」的客户端发送器。传输走共享的 [InterconnectPostTransport]
 /// （enabled 候选按序 fallback / `Basic base64(hibiki:token)` / https 带指纹走钉扎 client /
-/// 每候选独立回收），只是端点换成 `/api/mine/forward` 与 `/api/duplicate`，且默认超时更长
-/// （制卡请求体带媒体字节，LAN 上可能几 MB）。
+/// 每候选独立回收），本类只管端点 `/api/mine/forward` 与 `/api/duplicate`，以及更长的
+/// 默认超时（制卡请求体带媒体字节，LAN 上可能几 MB）。
 class HibikiRemoteMiningClient implements RemoteMineSender {
   HibikiRemoteMiningClient({
     required SyncRepository repo,
@@ -33,19 +30,18 @@ class HibikiRemoteMiningClient implements RemoteMineSender {
     Duration mineTimeout = const Duration(seconds: 60),
     Duration duplicateTimeout = const Duration(seconds: 5),
   })  : _repo = repo,
-        _httpClient = httpClient ?? http.Client(),
-        _pinnedClientFactory = pinnedClientFactory ?? _defaultPinnedClient,
+        _transport = InterconnectPostTransport(
+          repo: repo,
+          httpClient: httpClient,
+          pinnedClientFactory: pinnedClientFactory,
+        ),
         _mineTimeout = mineTimeout,
         _duplicateTimeout = duplicateTimeout;
 
   final SyncRepository _repo;
-  final http.Client _httpClient;
-  final http.Client Function(String expectedFingerprint) _pinnedClientFactory;
+  final InterconnectPostTransport _transport;
   final Duration _mineTimeout;
   final Duration _duplicateTimeout;
-
-  static http.Client _defaultPinnedClient(String expectedFingerprint) =>
-      createPinnedHttpPackageClient(expectedFingerprint: expectedFingerprint);
 
   /// 是否已配置可达的已配对主机（enabled 候选 + token）。用于设置页/开关判断能否远端制卡。
   Future<bool> hasTarget() async {
@@ -85,68 +81,19 @@ class HibikiRemoteMiningClient implements RemoteMineSender {
     }
   }
 
+  /// 制卡侧不消费 `allUnreachable`（没有失败冷却机制），只取响应体——「全不可达」
+  /// 与「可达但无结果」在这里都是 null，与抽出共享传输层之前逐字一致。
   Future<Map<String, dynamic>?> _post({
     required String path,
     required Map<String, dynamic> body,
     required Duration timeout,
   }) async {
-    final List<HibikiClientUrl> candidates = (await _repo.getHibikiClientUrls())
-        .where((HibikiClientUrl u) => u.enabled)
-        .toList(growable: false);
-    final String? token = await _repo.getHibikiClientToken();
-    if (candidates.isEmpty || token == null || token.isEmpty) return null;
-
-    for (final HibikiClientUrl candidate in candidates) {
-      final Uri? uri = _uri(candidate.url, path);
-      if (uri == null) continue;
-      final String? fp = candidate.fingerprintSha256;
-      final bool usePinned =
-          uri.isScheme('https') && fp != null && fp.isNotEmpty;
-      final http.Client client =
-          usePinned ? _pinnedClientFactory(fp) : _httpClient;
-      try {
-        final http.Response response = await client
-            .post(
-              uri,
-              headers: <String, String>{
-                'Authorization':
-                    'Basic ${base64Encode(utf8.encode('hibiki:$token'))}',
-                'Content-Type': 'application/json',
-              },
-              body: jsonEncode(body),
-            )
-            .timeout(timeout);
-        if (response.statusCode == 401) {
-          throw SyncAuthError('Hibiki server rejected remote mining token');
-        }
-        // 404/405 = 该候选是旧版主机（无此端点）→ 换下一个候选。
-        if (response.statusCode == 404 || response.statusCode == 405) {
-          continue;
-        }
-        if (response.statusCode < 200 || response.statusCode >= 300) {
-          continue;
-        }
-        final dynamic decoded = jsonDecode(response.body);
-        if (decoded is Map<String, dynamic>) return decoded;
-        if (decoded is Map) return Map<String, dynamic>.from(decoded);
-      } on SyncAuthError {
-        rethrow;
-      } catch (_) {
-        continue;
-      } finally {
-        if (usePinned) client.close();
-      }
-    }
-    return null;
-  }
-
-  Uri? _uri(String baseUrl, String path) {
-    try {
-      final Uri base = Uri.parse(WebDavOps.normalizeUrl(baseUrl));
-      return base
-          .replace(path: path, queryParameters: const <String, String>{});
-    } catch (_) {
-      return null;
-    }
+    final InterconnectPostOutcome outcome = await _transport.post(
+      path: path,
+      body: body,
+      timeout: timeout,
+      authErrorMessage: 'Hibiki server rejected remote mining token',
+    );
+    return outcome.json;
   }
 }

--- a/hibiki/lib/src/sync/hibiki_sync_server.dart
+++ b/hibiki/lib/src/sync/hibiki_sync_server.dart
@@ -1163,6 +1163,91 @@ class HibikiSyncServer {
     });
   }
 
+  /// HBK-AUDIT-012 路径穿越闸门：资产名绝不能含路径分隔符或 `..`，否则能逃出 host
+  /// 的资产根目录（DELETE 最危险）。合法返回 null；非法直接返回要回给客户端的响应。
+  ///
+  /// 此前这段判断在四个域 + 三个 position/progress 子路由里逐字重复了 7 遍。安全闸门
+  /// 靠复制粘贴维持，抄漏一处就是真漏洞——收敛成一处后新端点只能显式调用它。
+  ///
+  /// 注意：视频域**不用**本闸门——视频 id 形如 `video/xxx`，合法地含 `/`，它有自己的
+  /// `_extractVideoId` 校验。不要把视频接进来。
+  shelf.Response? _rejectUnsafeAssetId(String id, String label) {
+    if (id.isEmpty) return shelf.Response.notFound('Missing $label');
+    if (id.contains('/') || id.contains('\\') || id.contains('..')) {
+      return shelf.Response.forbidden('Invalid $label');
+    }
+    return null;
+  }
+
+  /// 「按名字取 / 存 / 删一个资产包」端点的共同骨架：词典 / 书 / 本地音频 / 有声书
+  /// 四个域在这一层**逐字相同**，只差叫什么名字、临时文件用什么扩展名、调 service
+  /// 的哪三个方法。
+  ///
+  /// 此前是四份约 60 行的复制粘贴（TODO-2120），加一个新媒体域就要再抄一遍——而这
+  /// 段代码里含导出缓存 + ETag/Range 续传、上传临时目录的必清理、IOSink 的双重关闭
+  /// 保护，抄漏任何一处都是真事故（泄漏临时目录 / 续传验证器失效 / socket 不回收）。
+  ///
+  /// [id] 必须已经过 [_rejectUnsafeAssetId]。
+  Future<shelf.Response> _serveAssetPackage(
+    shelf.Request request,
+    String method, {
+    required String id,
+    required String cacheKind,
+    required String notFoundMessage,
+    required String tempPrefix,
+    required String tempExtension,
+    required Future<File> Function() export,
+    required Future<void> Function(File tmp) import,
+    required Future<void> Function() delete,
+  }) async {
+    switch (method) {
+      case 'GET':
+        // 经导出缓存 + Range/If-Range：TTL 内的续传钉在同一份字节上（ETag 作验证器）；
+        // 旧 client 不发 Range 收到 200 全量，行为不变。扩展名保留 → Content-Type
+        // 仍由 _guessContentType 按扩展名判定。
+        File file;
+        try {
+          file = await _exportCache.obtain(cacheKind, id, export);
+        } on StateError {
+          return shelf.Response.notFound(notFoundMessage);
+        }
+        return serveFileWithRange(file, request,
+            etag: ExportPackageCache.etagFor(file));
+
+      case 'PUT':
+        final Directory tmpDir =
+            Directory.systemTemp.createTempSync(tempPrefix);
+        final File tmp = File(p.join(tmpDir.path, '$id$tempExtension'));
+        final IOSink sink = tmp.openWrite();
+        try {
+          await request.read().forEach(sink.add);
+          await sink.close();
+          await import(tmp);
+          return shelf.Response(200);
+        } catch (e) {
+          try {
+            await sink.close();
+          } catch (_) {
+            // best-effort
+          }
+          return shelf.Response(500, body: 'Import failed: $e');
+        } finally {
+          try {
+            tmpDir.deleteSync(recursive: true);
+          } catch (_) {
+            // best-effort
+          }
+        }
+
+      case 'DELETE':
+        await delete();
+        return shelf.Response(204);
+
+      default:
+        return shelf.Response(405);
+    }
+  }
+
   Future<shelf.Response> _handleLibraryDictionaries(
     shelf.Request request,
     String method,
@@ -1187,63 +1272,23 @@ class HibikiSyncServer {
     // 导致 "Illegal percent encoding in URI"（Dart 不接受非 ASCII 作为
     // decodeComponent 输入）。直接 substring 即可得到正确的词典名。
     final String name = reqPath.substring('/api/library/dictionaries/'.length);
-    if (name.isEmpty) {
-      return shelf.Response.notFound('Missing dictionary name');
-    }
-    // HBK-AUDIT-012: reject path-traversal attempts.  Dictionary names must
-    // never contain path separators or dot-dot sequences; if they did they
-    // could escape the dictionary resource root on the host (DELETE being the
-    // most dangerous).  This single gate covers all three methods below.
-    if (name.contains('/') || name.contains('\\') || name.contains('..')) {
-      return shelf.Response.forbidden('Invalid dictionary name');
-    }
+    // HBK-AUDIT-012 路径穿越闸门（收敛到 _rejectUnsafeAssetId），覆盖下面三个方法。
+    final shelf.Response? unsafe =
+        _rejectUnsafeAssetId(name, 'dictionary name');
+    if (unsafe != null) return unsafe;
 
-    switch (method) {
-      case 'GET':
-        // 经导出缓存 + Range/If-Range（TTL 内续传钉在同一份字节上；旧 client
-        // 不发 Range 收到 200 全量，行为不变）。
-        File file;
-        try {
-          file = await _exportCache.obtain(
-              'dict', name, () => svc.exportDictionary(name));
-        } on StateError {
-          return shelf.Response.notFound('Dictionary not found');
-        }
-        return serveFileWithRange(file, request,
-            etag: ExportPackageCache.etagFor(file));
-
-      case 'PUT':
-        final Directory tmpDir =
-            Directory.systemTemp.createTempSync('hibiki_dict_in');
-        final File tmp = File(p.join(tmpDir.path, '$name.hibikidict'));
-        final IOSink sink = tmp.openWrite();
-        try {
-          await request.read().forEach(sink.add);
-          await sink.close();
-          await svc.importDictionary(tmp);
-          return shelf.Response(200);
-        } catch (e) {
-          try {
-            await sink.close();
-          } catch (_) {
-            // best-effort
-          }
-          return shelf.Response(500, body: 'Import failed: $e');
-        } finally {
-          try {
-            tmpDir.deleteSync(recursive: true);
-          } catch (_) {
-            // best-effort
-          }
-        }
-
-      case 'DELETE':
-        await svc.deleteDictionary(name);
-        return shelf.Response(204);
-
-      default:
-        return shelf.Response(405);
-    }
+    return _serveAssetPackage(
+      request,
+      method,
+      id: name,
+      cacheKind: 'dict',
+      notFoundMessage: 'Dictionary not found',
+      tempPrefix: 'hibiki_dict_in',
+      tempExtension: '.hibikidict',
+      export: () => svc.exportDictionary(name),
+      import: svc.importDictionary,
+      delete: () => svc.deleteDictionary(name),
+    );
   }
 
   Future<shelf.Response> _handleLibraryBooks(
@@ -1273,14 +1318,9 @@ class HibikiSyncServer {
       if (method != 'GET') return shelf.Response(405);
       final String coverBookId = reqPath.substring(
           bookPrefix.length, reqPath.length - coverSuffix.length);
-      if (coverBookId.isEmpty) {
-        return shelf.Response.notFound('Missing book title');
-      }
-      if (coverBookId.contains('/') ||
-          coverBookId.contains('\\') ||
-          coverBookId.contains('..')) {
-        return shelf.Response.forbidden('Invalid book title');
-      }
+      final shelf.Response? unsafeCoverBookId =
+          _rejectUnsafeAssetId(coverBookId, 'book title');
+      if (unsafeCoverBookId != null) return unsafeCoverBookId;
       final File? cover = await _resolveBookCover(svc, coverBookId);
       if (cover == null) return shelf.Response.notFound('Book cover not found');
       return serveFileWithRange(cover, request);
@@ -1293,14 +1333,9 @@ class HibikiSyncServer {
     if (reqPath.startsWith(bookPrefix) && reqPath.endsWith(progressSuffix)) {
       final String progressBookKey = reqPath.substring(
           bookPrefix.length, reqPath.length - progressSuffix.length);
-      if (progressBookKey.isEmpty) {
-        return shelf.Response.notFound('Missing book key');
-      }
-      if (progressBookKey.contains('/') ||
-          progressBookKey.contains('\\') ||
-          progressBookKey.contains('..')) {
-        return shelf.Response.forbidden('Invalid book key');
-      }
+      final shelf.Response? unsafeProgressBookKey =
+          _rejectUnsafeAssetId(progressBookKey, 'book key');
+      if (unsafeProgressBookKey != null) return unsafeProgressBookKey;
       switch (method) {
         case 'GET':
           final RemoteBookProgress progress =
@@ -1328,63 +1363,23 @@ class HibikiSyncServer {
     }
 
     final String bookId = reqPath.substring(bookPrefix.length);
-    if (bookId.isEmpty) {
-      return shelf.Response.notFound('Missing book title');
-    }
-    // HBK-AUDIT-012: reject path-traversal attempts.  Book titles must
-    // never contain path separators or dot-dot sequences.
-    if (bookId.contains('/') ||
-        bookId.contains('\\') ||
-        bookId.contains('..')) {
-      return shelf.Response.forbidden('Invalid book title');
-    }
+    final shelf.Response? unsafe = _rejectUnsafeAssetId(bookId, 'book title');
+    if (unsafe != null) return unsafe;
 
-    switch (method) {
-      case 'GET':
-        // 经导出缓存 + Range/If-Range（.epub 扩展名保留 → Content-Type 仍是
-        // application/epub+zip；见 _guessContentType）。
-        File file;
-        try {
-          file = await _exportCache.obtain(
-              'book', bookId, () => svc.exportBook(bookId));
-        } on StateError {
-          return shelf.Response.notFound('Book not found');
-        }
-        return serveFileWithRange(file, request,
-            etag: ExportPackageCache.etagFor(file));
-
-      case 'PUT':
-        final Directory tmpDir =
-            Directory.systemTemp.createTempSync('hibiki_book_in');
-        final File tmp = File(p.join(tmpDir.path, '$bookId.epub'));
-        final IOSink sink = tmp.openWrite();
-        try {
-          await request.read().forEach(sink.add);
-          await sink.close();
-          await svc.importBook(tmp);
-          return shelf.Response(200);
-        } catch (e) {
-          try {
-            await sink.close();
-          } catch (_) {
-            // best-effort
-          }
-          return shelf.Response(500, body: 'Import failed: $e');
-        } finally {
-          try {
-            tmpDir.deleteSync(recursive: true);
-          } catch (_) {
-            // best-effort
-          }
-        }
-
-      case 'DELETE':
-        await svc.deleteBook(bookId);
-        return shelf.Response(204);
-
-      default:
-        return shelf.Response(405);
-    }
+    // 注：`.epub` 扩展名保留 → Content-Type 仍是 application/epub+zip
+    // （见 _guessContentType）。
+    return _serveAssetPackage(
+      request,
+      method,
+      id: bookId,
+      cacheKind: 'book',
+      notFoundMessage: 'Book not found',
+      tempPrefix: 'hibiki_book_in',
+      tempExtension: '.epub',
+      export: () => svc.exportBook(bookId),
+      import: svc.importBook,
+      delete: () => svc.deleteBook(bookId),
+    );
   }
 
   Map<String, Object?> _remoteBookJsonForRequest(
@@ -1441,61 +1436,22 @@ class HibikiSyncServer {
     // reqPath 已在 _handleRequest 经 Uri.decodeFull 解码，此处无需再解码。
     final String displayName =
         reqPath.substring('/api/library/localaudio/'.length);
-    if (displayName.isEmpty) {
-      return shelf.Response.notFound('Missing displayName');
-    }
-    // HBK-AUDIT-012: reject path-traversal attempts.
-    if (displayName.contains('/') ||
-        displayName.contains('\\') ||
-        displayName.contains('..')) {
-      return shelf.Response.forbidden('Invalid displayName');
-    }
+    final shelf.Response? unsafe =
+        _rejectUnsafeAssetId(displayName, 'displayName');
+    if (unsafe != null) return unsafe;
 
-    switch (method) {
-      case 'GET':
-        // 经导出缓存 + Range/If-Range。
-        File file;
-        try {
-          file = await _exportCache.obtain('localaudio', displayName,
-              () => svc.exportLocalAudio(displayName));
-        } on StateError {
-          return shelf.Response.notFound('Local audio not found');
-        }
-        return serveFileWithRange(file, request,
-            etag: ExportPackageCache.etagFor(file));
-
-      case 'PUT':
-        final Directory tmpDir =
-            Directory.systemTemp.createTempSync('hibiki_localaudio_in');
-        final File tmp = File(p.join(tmpDir.path, '$displayName.localaudio'));
-        final IOSink sink = tmp.openWrite();
-        try {
-          await request.read().forEach(sink.add);
-          await sink.close();
-          await svc.importLocalAudio(tmp);
-          return shelf.Response(200);
-        } catch (e) {
-          try {
-            await sink.close();
-          } catch (_) {
-            // best-effort
-          }
-          return shelf.Response(500, body: 'Import failed: $e');
-        } finally {
-          try {
-            tmpDir.deleteSync(recursive: true);
-          } catch (_) {
-            // best-effort
-          }
-        }
-
-      case 'DELETE':
-        await svc.deleteLocalAudio(displayName);
-        return shelf.Response(204);
-
-      default:
-        return shelf.Response(405);
-    }
+    return _serveAssetPackage(
+      request,
+      method,
+      id: displayName,
+      cacheKind: 'localaudio',
+      notFoundMessage: 'Local audio not found',
+      tempPrefix: 'hibiki_localaudio_in',
+      tempExtension: '.localaudio',
+      export: () => svc.exportLocalAudio(displayName),
+      import: svc.importLocalAudio,
+      delete: () => svc.deleteLocalAudio(displayName),
+    );
   }
 
   Future<shelf.Response> _handleLibraryAudiobooks(
@@ -1528,14 +1484,9 @@ class HibikiSyncServer {
         reqPath.endsWith(positionSuffix)) {
       final String positionBookKey = reqPath.substring(
           audiobookPrefix.length, reqPath.length - positionSuffix.length);
-      if (positionBookKey.isEmpty) {
-        return shelf.Response.notFound('Missing bookKey');
-      }
-      if (positionBookKey.contains('/') ||
-          positionBookKey.contains('\\') ||
-          positionBookKey.contains('..')) {
-        return shelf.Response.forbidden('Invalid bookKey');
-      }
+      final shelf.Response? unsafePositionBookKey =
+          _rejectUnsafeAssetId(positionBookKey, 'bookKey');
+      if (unsafePositionBookKey != null) return unsafePositionBookKey;
       // 先确认该有声书在 host DB 真实存在，防任意 key 写脏 prefs；与视频 position
       // 先 resolveVideoFile 同语义。BUG-471a：改用廉价的 audiobookExists（单次 DB
       // 查询）替代旧的 exportAudiobook 打包探测——旧实现每次 GET/PUT position 都把整
@@ -1578,61 +1529,23 @@ class HibikiSyncServer {
     }
 
     final String bookKey = reqPath.substring('/api/library/audiobooks/'.length);
-    if (bookKey.isEmpty) {
-      return shelf.Response.notFound('Missing bookKey');
-    }
-    // HBK-AUDIT-012: reject path-traversal attempts.
-    if (bookKey.contains('/') ||
-        bookKey.contains('\\') ||
-        bookKey.contains('..')) {
-      return shelf.Response.forbidden('Invalid bookKey');
-    }
+    final shelf.Response? unsafe = _rejectUnsafeAssetId(bookKey, 'bookKey');
+    if (unsafe != null) return unsafe;
 
-    switch (method) {
-      case 'GET':
-        // 经导出缓存 + Range/If-Range（大有声书包中断续传的最大受益者）。
-        File file;
-        try {
-          file = await _exportCache.obtain(
-              'audiobook', bookKey, () => svc.exportAudiobook(bookKey));
-        } on StateError {
-          return shelf.Response.notFound('Audiobook not found');
-        }
-        return serveFileWithRange(file, request,
-            etag: ExportPackageCache.etagFor(file));
-
-      case 'PUT':
-        final Directory tmpDir =
-            Directory.systemTemp.createTempSync('hibiki_audiobook_in');
-        final File tmp = File(p.join(tmpDir.path, '$bookKey.audiobook'));
-        final IOSink sink = tmp.openWrite();
-        try {
-          await request.read().forEach(sink.add);
-          await sink.close();
-          await svc.importAudiobook(tmp, bookKeyOverride: bookKey);
-          return shelf.Response(200);
-        } catch (e) {
-          try {
-            await sink.close();
-          } catch (_) {
-            // best-effort
-          }
-          return shelf.Response(500, body: 'Import failed: $e');
-        } finally {
-          try {
-            tmpDir.deleteSync(recursive: true);
-          } catch (_) {
-            // best-effort
-          }
-        }
-
-      case 'DELETE':
-        await svc.deleteAudiobook(bookKey);
-        return shelf.Response(204);
-
-      default:
-        return shelf.Response(405);
-    }
+    // 有声书包是 Range 续传的最大受益者（包最大）。导入要带 bookKeyOverride：
+    // 落地时必须钉在 URL 上的这个 key，不能让包里的自述 key 改写身份（BUG-414）。
+    return _serveAssetPackage(
+      request,
+      method,
+      id: bookKey,
+      cacheKind: 'audiobook',
+      notFoundMessage: 'Audiobook not found',
+      tempPrefix: 'hibiki_audiobook_in',
+      tempExtension: '.audiobook',
+      export: () => svc.exportAudiobook(bookKey),
+      import: (File tmp) => svc.importAudiobook(tmp, bookKeyOverride: bookKey),
+      delete: () => svc.deleteAudiobook(bookKey),
+    );
   }
 
   // ── 视频端点（P4-2）──────────────────────────────────────────────────────────

--- a/hibiki/lib/src/sync/interconnect_post_transport.dart
+++ b/hibiki/lib/src/sync/interconnect_post_transport.dart
@@ -1,0 +1,152 @@
+import 'dart:convert';
+
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki/src/sync/tls/hibiki_pinning_http.dart';
+import 'package:hibiki/src/sync/webdav_ops.dart';
+import 'package:http/http.dart' as http;
+
+/// 互联客户端的 JSON POST 传输层：**唯一**一份「已启用候选按序 fallback +
+/// `Basic base64(hibiki:token)` 鉴权 + https 带指纹强制走钉扎 client + 每候选独立
+/// 回收」的实现。
+///
+/// **为什么抽出来**——这套逻辑此前被逐行复制过多份：
+/// `hibiki_remote_lookup_client.dart` 的 `_postLookup`、
+/// `hibiki_remote_mining_client.dart` 的 `_post`（它的类注释自己就写着「传输契约与
+/// [HibikiRemoteLookupClient] 完全同构」），
+/// 另有 `interconnect_manga_ocr_client.dart` 的 GET 版 `probe` 和
+/// `InterconnectSyncBackend` 走 `WebDavOps` 的第四份。每加一个互联端点就再抄一遍，
+/// 而钉扎、401 语义、socket 回收这些安全相关的细节一旦有一份抄漏就是真事故
+/// （TODO-961 gap①：注入的 keep-alive client 不得旁路证书钉扎）。
+///
+/// 现在新增一个互联端点 = 调一次 [post]，不再复制传输代码。
+class InterconnectPostTransport {
+  InterconnectPostTransport({
+    required SyncRepository repo,
+    http.Client? httpClient,
+    http.Client Function(String expectedFingerprint)? pinnedClientFactory,
+  })  : _repo = repo,
+        _httpClient = httpClient ?? http.Client(),
+        _pinnedClientFactory = pinnedClientFactory ?? _defaultPinnedClient;
+
+  final SyncRepository _repo;
+
+  /// 明文 http 候选共用的 client（生产由 AppModel 注入 keep-alive client 复用连接，
+  /// TODO-744）。**绝不**用于带指纹的 https 候选——那必须走钉扎 client
+  /// （TODO-961 gap①：注入生产 client 不得旁路证书钉扎）。
+  final http.Client _httpClient;
+
+  /// https 候选的钉扎 client 工厂（每候选一个、用完即关）。默认真钉扎
+  /// [createPinnedHttpPackageClient]；测试注入 MockClient 工厂即可拦截。
+  final http.Client Function(String expectedFingerprint) _pinnedClientFactory;
+
+  static http.Client _defaultPinnedClient(String expectedFingerprint) =>
+      createPinnedHttpPackageClient(expectedFingerprint: expectedFingerprint);
+
+  /// 向所有已启用候选按序 POST [body] 到 [path]，返回第一个拿到的可用 JSON 响应。
+  ///
+  /// 候选级语义（与抽出前逐字一致）：
+  /// - 401 → 抛 [SyncAuthError]（消息由 [authErrorMessage] 给，各调用方保留自己的文案）；
+  ///   所有候选共用一个 token，一次拒绝即全部失败，不再试下一个。
+  /// - 404 / 405 → 该候选是旧版 host（无此端点），换下一个候选。
+  /// - 其它非 2xx、响应体不是 JSON 对象 → 换下一个候选。
+  /// - 传输层失败（连接拒绝 / 超时 / DNS）→ 换下一个候选。
+  ///
+  /// 返回的 `allUnreachable` 仅当「至少发起过一次请求，且所有候选都没拿到**任何**
+  /// HTTP 响应」时为 true——未配对 / 无 token / 候选 URL 全畸形都**不**算不可达。
+  /// 这条区分是音频源失败冷却（BUG-575）的依据：设备可达但没这个词 ≠ 设备死了。
+  Future<InterconnectPostOutcome> post({
+    required String path,
+    required Map<String, dynamic> body,
+    required Duration timeout,
+    required String authErrorMessage,
+  }) async {
+    final List<HibikiClientUrl> candidates = (await _repo.getHibikiClientUrls())
+        .where((HibikiClientUrl u) => u.enabled)
+        .toList(growable: false);
+    final String? token = await _repo.getHibikiClientToken();
+    if (candidates.isEmpty || token == null || token.isEmpty) {
+      // 未配对/未启用/无 token：不是「设备不可达」，按「无结果」处理。
+      return (json: null, allUnreachable: false);
+    }
+
+    bool attempted = false;
+    bool anyResponse = false;
+    for (final HibikiClientUrl candidate in candidates) {
+      final Uri? uri = interconnectEndpointUri(candidate.url, path);
+      if (uri == null) continue;
+      // TODO-961 M1/gap①: https 带指纹的候选**始终**走钉扎 client，与是否注入了
+      // 外部 client 无关（注入的 keep-alive client 只服务明文 http 候选）。
+      final String? fp = candidate.fingerprintSha256;
+      final bool usePinned =
+          uri.isScheme('https') && fp != null && fp.isNotEmpty;
+      final http.Client client =
+          usePinned ? _pinnedClientFactory(fp) : _httpClient;
+      attempted = true;
+      try {
+        final http.Response response = await client
+            .post(
+              uri,
+              headers: <String, String>{
+                'Authorization':
+                    'Basic ${base64Encode(utf8.encode('hibiki:$token'))}',
+                'Content-Type': 'application/json',
+              },
+              body: jsonEncode(body),
+            )
+            .timeout(timeout);
+        // 拿到任何 HTTP 响应（含 401/404/405/非 2xx/坏 JSON 体）都算「可达」；
+        // 传输层失败（连接拒绝/超时/DNS）根本走不到这一行，落在 catch 里。
+        anyResponse = true;
+        if (response.statusCode == 401) {
+          throw SyncAuthError(authErrorMessage);
+        }
+        if (response.statusCode == 404 || response.statusCode == 405) {
+          continue;
+        }
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          continue;
+        }
+        final dynamic decoded = jsonDecode(response.body);
+        if (decoded is Map<String, dynamic>) {
+          return (json: decoded, allUnreachable: false);
+        }
+        if (decoded is Map) {
+          return (
+            json: Map<String, dynamic>.from(decoded),
+            allUnreachable: false,
+          );
+        }
+      } on SyncAuthError {
+        rethrow;
+      } catch (_) {
+        continue;
+      } finally {
+        // 每候选独立 pinned client 用完即关，所有出口（return/continue/throw）统一
+        // 经 finally 回收，不泄漏 socket；共享 _httpClient 绝不在此关闭。
+        if (usePinned) client.close();
+      }
+    }
+    // 走到这里没有任何候选给出可用结果；只有「试过且一个响应都没拿到」才算
+    // 全部不可达（传输层失败），可达但无结果仍是普通 null。
+    return (json: null, allUnreachable: attempted && !anyResponse);
+  }
+}
+
+/// [InterconnectPostTransport.post] 的结局：`json` 为拿到并解析成功的响应体；
+/// `allUnreachable` 的语义见 [InterconnectPostTransport.post] 的文档。
+typedef InterconnectPostOutcome = ({
+  Map<String, dynamic>? json,
+  bool allUnreachable
+});
+
+/// 把候选基址 [baseUrl] 与端点 [path] 拼成请求 URI；基址畸形返回 null（调用方跳过
+/// 该候选）。查询串一律清空——互联端点的入参全部走 JSON 请求体。
+Uri? interconnectEndpointUri(String baseUrl, String path) {
+  try {
+    final Uri base = Uri.parse(WebDavOps.normalizeUrl(baseUrl));
+    return base.replace(path: path, queryParameters: const <String, String>{});
+  } catch (_) {
+    return null;
+  }
+}

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -152,6 +152,10 @@ class InterconnectSyncBackend extends SyncBackend
   String? _token;
   bool _sessionResolved = false;
 
+  /// 上一次 [_loadConfig] 读到的配置身份（见 [_sessionSignature]）。BUG-1178：用它
+  /// 判断 `restoreAuth` 是否真需要作废已解析的地址。null = 还没读过配置。
+  String? _configSignature;
+
   WebDavOps? _ops;
   // TODO-961 M1: 当前选中地址的钉扎指纹（https 走 pinned client；http=null）。
   String? _activeFingerprint;
@@ -182,11 +186,44 @@ class InterconnectSyncBackend extends SyncBackend
   Future<String?> get currentEmail async => 'hibiki';
 
   Future<void> _loadConfig(SyncRepository repo) async {
-    _candidates = (await repo.getHibikiClientUrls())
+    final List<HibikiClientUrl> candidates = (await repo.getHibikiClientUrls())
         .where((HibikiClientUrl u) => u.enabled)
         .toList();
-    _token = await repo.getHibikiClientToken();
-    _sessionResolved = false;
+    final String? token = await repo.getHibikiClientToken();
+    // BUG-1178：这里原本无条件 `_sessionResolved = false`，而 [restoreAuth] 又是每个
+    // 消费方（书架 / 视频页 / 首页 dashboard）取 client 的必经之路，且本类是**单例**。
+    // 净效果：每切一次页面就把已经探明可达的地址作废一次，下一次网络操作要重跑
+    // [resolveReachableHibikiCandidate] 的全候选串行探测（https 候选还要各做一次带
+    // 指纹钉扎的 TLS 握手），三个页面之间还互相踩。
+    //
+    // 会话该不该重来，取决于**配置是否真的变了**——地址集合、启用状态、钉扎指纹、
+    // 令牌。没变就保留已解析地址；变了才作废。地址失联的换路由径由 [clearCache]
+    // 负责（SyncManager 重试前调用），与本处正交、不受影响。
+    final String signature = _sessionSignature(candidates, token);
+    if (signature != _configSignature) {
+      _configSignature = signature;
+      _sessionResolved = false;
+    }
+    _candidates = candidates;
+    _token = token;
+  }
+
+  /// 会话身份指纹：只包含影响「该连哪个地址、用什么凭据」的字段。`deviceName`
+  /// 是纯展示名，改它不该触发全候选重探测，故不进签名。
+  static String _sessionSignature(
+    List<HibikiClientUrl> candidates,
+    String? token,
+  ) {
+    // 换行做分隔符：URL 与指纹里都不可能出现裸换行，不会拼出歧义签名。
+    final StringBuffer buffer = StringBuffer(token ?? '');
+    for (final HibikiClientUrl candidate in candidates) {
+      buffer
+        ..write('\n')
+        ..write(candidate.url)
+        ..write('\n')
+        ..write(candidate.fingerprintSha256 ?? '');
+    }
+    return buffer.toString();
   }
 
   /// Builds a provisional [WebDavOps] on the first well-formed candidate so
@@ -258,6 +295,8 @@ class InterconnectSyncBackend extends SyncBackend
     _candidates = const <HibikiClientUrl>[];
     _token = null;
     _sessionResolved = false;
+    // 登出后配置身份归零，下次 restoreAuth 必然重探测（BUG-1178）。
+    _configSignature = null;
     await repo.setHibikiClientUrls(const <HibikiClientUrl>[]);
     // Also wipe the legacy single-url key, else getHibikiClientUrls would
     // migrate it back on the next read.

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -670,19 +670,44 @@ class InterconnectSyncBackend extends SyncBackend
   }
 
   /// 列出对端 host 当前实时词典清单（直打 `/api/library/dictionaries`）。
-  Future<List<RemoteDictionaryInfo>> listRemoteDictionaries() async {
+  /// 互联「列清单」端点的共同骨架：解析会话 → GET → 逐条 fromJson（TODO-2120）。
+  ///
+  /// 五个域此前各抄一份 12 行的同构代码。**降级与超时必须逐域按现状显式传入**，
+  /// 不能图省事统一给所有域打开：
+  /// - [degradeOn404]：只有 videos / activity 这类**后加的**端点才降级——老 host 没有
+  ///   它们，降级成空表是为了「不因老 server 缺端点让整页占位卡消失或转圈」。词典 /
+  ///   书 / 本地音频 / 有声书是最老的端点，假定必然存在；给它们也加降级，会把「host
+  ///   把库服务关了（404 Library service off）」从可见错误变成静默空列表——那是真实的
+  ///   行为回归，不是「更健壮」。
+  /// - [timeout]：只有 videos / activity 有封顶（host 侧这两个清单可能很慢）。
+  Future<List<T>> _listRemote<T>(
+    String path,
+    T Function(Map<String, Object?> json) parse, {
+    Duration? timeout,
+    bool degradeOn404 = false,
+  }) async {
     await _ensureResolved();
     final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/dictionaries');
-    final HttpClientResponse res = await req.close();
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/dictionaries');
-    final String body = await res.transform(utf8.decoder).join();
+        await _ops!.buildRequest('GET', '$_apiBase$path');
+    final Future<HttpClientResponse> closing = req.close();
+    final HttpClientResponse res =
+        timeout == null ? await closing : await closing.timeout(timeout);
+    if (degradeOn404 && res.statusCode == 404) {
+      await res.drain<void>();
+      return <T>[];
+    }
+    _ops!.checkStatus(res.statusCode, 'GET $path');
+    final Future<String> reading = res.transform(utf8.decoder).join();
+    final String body =
+        timeout == null ? await reading : await reading.timeout(timeout);
     final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteDictionaryInfo>[
-      for (final dynamic e in arr)
-        RemoteDictionaryInfo.fromJson((e as Map).cast<String, Object?>()),
+    return <T>[
+      for (final dynamic e in arr) parse((e as Map).cast<String, Object?>()),
     ];
   }
+
+  Future<List<RemoteDictionaryInfo>> listRemoteDictionaries() =>
+      _listRemote('/api/library/dictionaries', RemoteDictionaryInfo.fromJson);
 
   /// 从对端 host 下载名为 [name] 的词典包到 [destination] 文件。
   Future<void> getRemoteDictionary(
@@ -745,19 +770,8 @@ class InterconnectSyncBackend extends SyncBackend
 
   /// 列出对端 host 当前书库清单（直打 `/api/library/books`）。
   @override
-  Future<List<RemoteBookInfo>> listRemoteBooks() async {
-    await _ensureResolved();
-    final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/books');
-    final HttpClientResponse res = await req.close();
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/books');
-    final String body = await res.transform(utf8.decoder).join();
-    final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteBookInfo>[
-      for (final dynamic e in arr)
-        RemoteBookInfo.fromJson((e as Map).cast<String, Object?>()),
-    ];
-  }
+  Future<List<RemoteBookInfo>> listRemoteBooks() =>
+      _listRemote('/api/library/books', RemoteBookInfo.fromJson);
 
   /// 从对端 host 下载书名为 [title] 的 EPUB 到 [destination] 文件。
   @override
@@ -971,19 +985,8 @@ class InterconnectSyncBackend extends SyncBackend
   // 与 live books 对称：直打 /api/library/localaudio，不经 WebDAV 暂存。
 
   /// 列出对端 host 当前本地音频来源清单（直打 `/api/library/localaudio`）。
-  Future<List<RemoteLocalAudioInfo>> listRemoteLocalAudio() async {
-    await _ensureResolved();
-    final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/localaudio');
-    final HttpClientResponse res = await req.close();
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/localaudio');
-    final String body = await res.transform(utf8.decoder).join();
-    final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteLocalAudioInfo>[
-      for (final dynamic e in arr)
-        RemoteLocalAudioInfo.fromJson((e as Map).cast<String, Object?>()),
-    ];
-  }
+  Future<List<RemoteLocalAudioInfo>> listRemoteLocalAudio() =>
+      _listRemote('/api/library/localaudio', RemoteLocalAudioInfo.fromJson);
 
   /// 从对端 host 下载 displayName 为 [displayName] 的本地音频库到 [dest] 文件。
   Future<void> getRemoteLocalAudio(
@@ -1043,19 +1046,8 @@ class InterconnectSyncBackend extends SyncBackend
   // 与 live books 对称：直打 /api/library/audiobooks，不经 WebDAV 暂存。
 
   /// 列出对端 host 当前有声书清单（直打 `/api/library/audiobooks`）。
-  Future<List<RemoteAudiobookInfo>> listRemoteAudiobooks() async {
-    await _ensureResolved();
-    final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/audiobooks');
-    final HttpClientResponse res = await req.close();
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/audiobooks');
-    final String body = await res.transform(utf8.decoder).join();
-    final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteAudiobookInfo>[
-      for (final dynamic e in arr)
-        RemoteAudiobookInfo.fromJson((e as Map).cast<String, Object?>()),
-    ];
-  }
+  Future<List<RemoteAudiobookInfo>> listRemoteAudiobooks() =>
+      _listRemote('/api/library/audiobooks', RemoteAudiobookInfo.fromJson);
 
   /// 从对端 host 下载 bookKey 为 [bookKey] 的有声书到 [dest] 文件。
   Future<void> getRemoteAudiobook(
@@ -1199,24 +1191,14 @@ class InterconnectSyncBackend extends SyncBackend
   }
 
   @override
-  Future<List<RemoteVideoInfo>> listRemoteVideos() async {
-    await _ensureResolved();
-    final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/videos');
-    final HttpClientResponse res = await req.close().timeout(listTimeout);
-    if (res.statusCode == 404) {
-      await res.drain<void>();
-      return const <RemoteVideoInfo>[]; // 老 host 无视频端点：降级空表，不崩不转圈。
-    }
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/videos');
-    final String body =
-        await res.transform(utf8.decoder).join().timeout(listTimeout);
-    final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteVideoInfo>[
-      for (final dynamic e in arr)
-        RemoteVideoInfo.fromJson((e as Map).cast<String, Object?>()),
-    ];
-  }
+
+  /// 老 host 无视频端点 → 404 降级空表（不崩不转圈）；清单可能很慢，故超时封顶。
+  Future<List<RemoteVideoInfo>> listRemoteVideos() => _listRemote(
+        '/api/library/videos',
+        RemoteVideoInfo.fromJson,
+        timeout: listTimeout,
+        degradeOn404: true,
+      );
 
   /// 把本地视频 [file] 上传到对端 host，注册成 bookUid 为 [id] 的视频（client→host，
   /// syncVideoFiles 开关驱动的 live push）。[title] 与原始文件名经 URL-encode 走 header

--- a/hibiki/lib/src/sync/remote_library_cache.dart
+++ b/hibiki/lib/src/sync/remote_library_cache.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// 远端库列表（互联对端 / 云盘）的统一读取入口：TTL 缓存 + in-flight 去重 + 显式失效。
+///
+/// **为什么需要它（BUG-1175）**——远端条目列表此前在每个消费方裸调 `client.listX()`：
+/// 书架（`reader_history/remote.part.dart`）、漫画书架（同一 State 类的另一实例）、
+/// 视频页（`home_video_page.dart`）、首页 dashboard（`home_dashboard_page.dart`）各一份。
+/// 而书架/视频页为了让对端新增内容可见（BUG-992/994）各注册了「切回本 tab 就重拉」的
+/// 监听器。净效果是：顶层 tab 保活（BUG-750）省下的重建，被这两个监听器原样加成了
+/// 「每切一次页面 = 一整轮完整网络往返」。列表本身此前**没有任何**缓存层——只有封面图
+/// 有磁盘缓存（`remote_cover_cache.dart`），条目列表每次都是裸 GET + jsonDecode。
+///
+/// **为什么是通用 slot 而不是每域一份字段**——互联每加一个媒体域（书 / 视频 / 有声书 /
+/// 活动 / 词典，将来还有游戏、漫画）都要复制一遍「缓存 + 去重 + 失效」三件套，这正是
+/// 「每次加新东西都要重构互联」的一角。这里只有一张 `key -> slot` 表：新增一个域 =
+/// 传一个新 key 加一个取数闭包，缓存代码零增量，没有新分支。
+///
+/// **缓存的是网络层，不是组装结果**——[read] 只包住 `client.listRemoteX()` 这一层，
+/// 本地 DB 查询与去重（`dedupeRemoteBooks` 等）仍每次照跑。所以本地新增/删除条目立即
+/// 反映在混排网格里，只有「问对端要清单」这一步被 TTL 挡住，BUG-992/994 的用户可见
+/// 语义（切回 tab 远端卡在场）不受影响。
+///
+/// **失效由调用方显式驱动**：下拉刷新、管理互联源、配对变更、同步跑完 →
+/// [invalidate]/[invalidateAll]。缓存不试图从 client 身份推断对端是否换人，那种推断
+/// 在多地址候选 + 单例 backend 的现实下必然出错。
+class RemoteLibraryCache {
+  RemoteLibraryCache({
+    this.defaultTtl = const Duration(seconds: 60),
+    int Function()? nowMs,
+  }) : _nowMs = nowMs ?? _wallClockMs;
+
+  static int _wallClockMs() => DateTime.now().millisecondsSinceEpoch;
+
+  /// 未显式指定 `ttl` 时的新鲜期。60s 的取舍：切页面/切 tab 是秒级操作，必须命中缓存；
+  /// 而「对端刚加了一本书」的可见延迟上限一分钟，仍在用户可接受范围，且下拉刷新随时
+  /// 可以强制穿透。
+  final Duration defaultTtl;
+
+  final int Function() _nowMs;
+  final Map<String, _CacheSlot> _slots = <String, _CacheSlot>{};
+
+  /// 读 [key] 对应的远端列表：命中未过期缓存直接返回；有同 key 请求在途则复用它
+  /// （in-flight 去重，解决书架/漫画/首页同帧并发问一样东西）；否则调 [fetch] 取数。
+  ///
+  /// [forceRefresh] 为 true 时无条件重新取数（下拉刷新语义），并让任何在途的旧请求
+  /// 作废——靠 slot 的 generation 计数拦截，避免旧请求后到把新结果覆盖回去。
+  ///
+  /// [fetch] 抛出时**不缓存失败**，也不清掉已有的旧值：异常原样上抛给调用方按既有的
+  /// 「拉取失败 → 占位卡不出现」降级处理，而旧值保留让离线时仍能显示上一次已知列表。
+  /// 由于失败不刷新 `fetchedAt`，下一次读必然重试。
+  Future<T> read<T>({
+    required String key,
+    required Future<T> Function() fetch,
+    Duration? ttl,
+    bool forceRefresh = false,
+  }) {
+    final _CacheSlot slot = _slots.putIfAbsent(key, () => _CacheSlot());
+
+    if (!forceRefresh) {
+      final Future<Object?>? inFlight = slot.inFlight;
+      if (inFlight != null) {
+        return inFlight.then((Object? value) => value as T);
+      }
+      if (slot.hasValue &&
+          _nowMs() - slot.fetchedAtMs < (ttl ?? defaultTtl).inMilliseconds) {
+        return Future<T>.value(slot.value as T);
+      }
+    }
+
+    final int generation = ++slot.generation;
+    final Future<T> future = fetch();
+
+    // 供同 key 并发调用复用的句柄。它失败时，错误会分发给每个真实复用者（各自
+    // 按「拉取失败 → 占位卡不出现」降级）；但没有第二个调用者时这条链就没有监听者，
+    // Dart 会把它当成「无人处理的异步错误」抛进 Zone。额外挂一个吞错监听消掉该状态，
+    // 不影响其它监听者照常收到错误。
+    final Future<Object?> shared = future.then<Object?>((T value) => value);
+    unawaited(shared.catchError((Object _) => null));
+    slot.inFlight = shared;
+
+    return future.then<T>((T value) {
+      // 期间发生过 forceRefresh / invalidate → 本次结果已过时，丢弃写入但仍返回给
+      // 自己的调用方（它要的就是这次取数的结果）。
+      if (slot.generation == generation) {
+        slot.value = value;
+        slot.hasValue = true;
+        slot.fetchedAtMs = _nowMs();
+        slot.inFlight = null;
+      }
+      return value;
+    }, onError: (Object error, StackTrace stack) {
+      if (slot.generation == generation) slot.inFlight = null;
+      Error.throwWithStackTrace(error, stack);
+    });
+  }
+
+  /// 作废单个 key（含在途请求的写回）。下次 [read] 必然重新取数。
+  void invalidate(String key) {
+    final _CacheSlot? slot = _slots[key];
+    if (slot == null) return;
+    slot.generation++;
+    slot.inFlight = null;
+    slot.hasValue = false;
+    slot.value = null;
+    slot.fetchedAtMs = 0;
+  }
+
+  /// 作废全部 key。用于对端换人 / 配对变更 / 互联开关切换 / 同步跑完这类
+  /// 「远端库整体可能已变」的信号。
+  void invalidateAll() {
+    for (final String key in _slots.keys.toList()) {
+      invalidate(key);
+    }
+  }
+
+  /// 仅供测试与诊断：[key] 当前是否持有未过期的缓存值。
+  bool isFresh(String key, {Duration? ttl}) {
+    final _CacheSlot? slot = _slots[key];
+    if (slot == null || !slot.hasValue) return false;
+    return _nowMs() - slot.fetchedAtMs < (ttl ?? defaultTtl).inMilliseconds;
+  }
+}
+
+class _CacheSlot {
+  Object? value;
+  bool hasValue = false;
+  int fetchedAtMs = 0;
+
+  /// 每次取数自增；写回时比对，拦截「旧请求后到覆盖新结果」。
+  int generation = 0;
+  Future<Object?>? inFlight;
+}
+
+/// app 级单例 provider：书架 / 漫画书架 / 视频页 / 首页 dashboard 共享同一份缓存，
+/// 所以「首页已经拉过书列表、切到书架」不会再问对端要一次。
+///
+/// 用 provider 而不是全局单例，是为了测试隔离——每个 `ProviderScope` 一份新缓存，
+/// widget 测试之间不会互相看到对方的远端列表。
+final remoteLibraryCacheProvider = Provider<RemoteLibraryCache>(
+  (ref) => RemoteLibraryCache(),
+);
+
+/// 远端列表的缓存 key。集中在一处而不是散在各页面字符串字面量里——新增媒体域时
+/// 这里加一个常量/函数，编译器就能在所有消费点保证拼写一致。
+class RemoteLibraryCacheKeys {
+  const RemoteLibraryCacheKeys._();
+
+  static const String books = 'books';
+
+  /// 互联 host live 库的视频清单（`List<RemoteVideoInfo>`）。
+  static const String videos = 'videos';
+
+  /// 云盘 `__videos__/videos.json` 目录清单（`List<RemoteVideoManifestEntry>`）。
+  ///
+  /// 与 [videos] **必须**分槽：两者元素类型不同（`CloudRemoteVideoClient` 至今不实现
+  /// `RemoteVideoClient`，返回的是 manifest entry 而非 `RemoteVideoInfo`）。共用一个 key
+  /// 会在「互联切云盘」时把上一份缓存按错误类型取出，直接 cast 崩。
+  static const String cloudVideos = 'cloud_videos';
+  static const String audiobooks = 'audiobooks';
+  static const String dictionaries = 'dictionaries';
+
+  /// 活动流按 limit 分槽——不同 limit 是不同的结果集，共用一个 slot 会让首页的
+  /// limit:200 被别处的 limit:20 污染成截断列表。
+  static String activity(int limit) => 'activity:$limit';
+}

--- a/hibiki/lib/src/sync/remote_library_cache.dart
+++ b/hibiki/lib/src/sync/remote_library_cache.dart
@@ -149,15 +149,13 @@ class RemoteLibraryCacheKeys {
 
   static const String books = 'books';
 
-  /// 互联 host live 库的视频清单（`List<RemoteVideoInfo>`）。
-  static const String videos = 'videos';
-
-  /// 云盘 `__videos__/videos.json` 目录清单（`List<RemoteVideoManifestEntry>`）。
+  /// 远端视频清单（`List<RemoteVideoInfo>`）。
   ///
-  /// 与 [videos] **必须**分槽：两者元素类型不同（`CloudRemoteVideoClient` 至今不实现
-  /// `RemoteVideoClient`，返回的是 manifest entry 而非 `RemoteVideoInfo`）。共用一个 key
-  /// 会在「互联切云盘」时把上一份缓存按错误类型取出，直接 cast 崩。
-  static const String cloudVideos = 'cloud_videos';
+  /// 互联 host live 库与云盘目录**共用**这一个槽：两种源都实现 `RemoteVideoSource`，
+  /// 清单在各自 client 里已统一成 `RemoteVideoInfo`，不存在元素类型不一致的问题
+  /// （TODO-2119 之前云盘返回的是 manifest entry，被迫分成两个槽，否则换后端时会按
+  /// 错误类型取出缓存直接 cast 崩）。换对端/换后端由 `invalidateAll` 兜底。
+  static const String videos = 'videos';
   static const String audiobooks = 'audiobooks';
   static const String dictionaries = 'dictionaries';
 

--- a/hibiki/lib/src/sync/remote_video_client.dart
+++ b/hibiki/lib/src/sync/remote_video_client.dart
@@ -2,9 +2,42 @@ import 'dart:io';
 
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 
-abstract class RemoteVideoClient {
+/// **任何**远端视频来源都具备的能力：列清单 + 按 id 把整片下载到本地。
+///
+/// 互联 host 的 live 库与云盘的 `__videos__/` 目录都能做到这两件事，所以库页的
+/// 「列清单 → 混排占位卡 → 点击下载入库」这条主干可以只依赖本接口，不必知道背后
+/// 是哪一种源。
+///
+/// **为什么要分成两级**（TODO-2119）——此前只有 [RemoteVideoClient] 一个接口，而
+/// 云盘没有 live host、给不出流播 URL / 外挂字幕 / 跨端断点，于是
+/// `CloudRemoteVideoClient` 干脆**不实现**任何接口，逼得视频页同时持有两个互斥的
+/// nullable 字段，每条下载 / 封面 / 字幕路径都要 `if (cloud != null) ... else ...`，
+/// 还要在页面里手写一个 manifest→DTO 的适配函数（给 `RemoteVideoInfo` 加字段时
+/// 漏改那里，云侧该字段就永远是空的）。
+///
+/// 反过来让云端 `implements RemoteVideoClient` 再把 4 个方法写成抛异常也不对：那只是
+/// 把「能力靠 `is` 判断」换成「调了会抛」，编译器照样拦不住。按能力分级之后，
+/// `source is RemoteVideoClient` 是**类型系统认可**的能力判据——拿不到 live 能力的
+/// 地方根本调不出流播/字幕/断点方法。
+abstract class RemoteVideoSource {
+  /// 列出该源可见的远端视频。云盘源在这里就把目录清单适配成 [RemoteVideoInfo]，
+  /// 消费方（库页）不再需要知道 manifest 长什么样。
   Future<List<RemoteVideoInfo>> listRemoteVideos();
 
+  /// 把 [id] 对应的视频整片下载到 [dest]。
+  ///
+  /// 续传口径按源写实：互联走 host live 下载引擎（Range + `.part`，中断可续）；
+  /// 云盘是整文件重下，失败清残片、无断点续传。
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  });
+}
+
+/// 具备实时流播 / 外挂字幕 / 跨端断点的远端视频源——只有互联 host 的 live 库有这些
+/// 端点（云盘目录只是一堆静态资产，没有服务端能回答这些请求）。
+abstract class RemoteVideoClient extends RemoteVideoSource {
   /// 向 host 换取可直接播放的视频 stream URL。[episodeIndex]>0（TODO-885）请求远端
   /// 播放列表的某一集。
   Future<RemoteVideoStreamUrls> remoteVideoStreamUrls(
@@ -17,12 +50,6 @@ abstract class RemoteVideoClient {
     File dest, {
     int? embeddedStreamIndex,
     int episodeIndex = 0,
-    void Function(double progress)? onProgress,
-  });
-
-  Future<void> downloadRemoteVideo(
-    String id,
-    File dest, {
     void Function(double progress)? onProgress,
   });
 

--- a/hibiki/test/pages/home_video_cloud_download_test.dart
+++ b/hibiki/test/pages/home_video_cloud_download_test.dart
@@ -265,7 +265,30 @@ class _FakeCloudRemoteVideoClient implements CloudRemoteVideoClient {
   SyncAssetStore get backend => throw UnimplementedError();
 
   @override
-  Future<List<RemoteVideoManifestEntry>> listRemoteVideos() async => entries;
+  Future<List<RemoteVideoManifestEntry>> listRemoteVideoManifest() async =>
+      entries;
+
+  /// TODO-2119：[RemoteVideoSource] 视图——清单→DTO 的适配已收进真 client，
+  /// fake 这里照搬同样的映射（页面不再自己适配，所以这份映射必须由 client 侧提供）。
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async => <RemoteVideoInfo>[
+        for (final RemoteVideoManifestEntry e in entries)
+          RemoteVideoInfo(
+            id: e.uid,
+            title: e.title,
+            sizeBytes: e.sizeBytes,
+            tagsAddedAt: e.tagsAddedAt,
+            tagTombstones: e.tagTombstones,
+          ),
+      ];
+
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) =>
+      getRemoteVideo(id, dest, onProgress: onProgress);
 
   @override
   Future<void> getRemoteVideo(

--- a/hibiki/test/pages/reader_remote_interconnect_test.dart
+++ b/hibiki/test/pages/reader_remote_interconnect_test.dart
@@ -91,7 +91,7 @@ void main() {
     await db.close();
   });
 
-  Widget buildApp() => ProviderScope(
+  Widget buildApp({bool mangaOnly = false}) => ProviderScope(
         overrides: <Override>[
           appProvider.overrideWith((ref) => appModel),
           hibikiBooksProvider.overrideWith(
@@ -109,6 +109,7 @@ void main() {
                 child ?? const SizedBox.shrink(),
             home: Scaffold(
               body: ReaderHibikiHistoryPage(
+                mangaOnly: mangaOnly,
                 remoteBookClientLoader: () async => remoteClient,
                 remoteBookDownloadDestination: (RemoteBookInfo book) async =>
                     File(
@@ -519,24 +520,93 @@ void main() {
     );
   });
 
-  testWidgets('BUG-992: 切回书架 tab 自动重拉远端书（不必手动下拉刷新）',
+  testWidgets('BUG-992/1175: 切回书架 tab 远端卡在场，且 TTL 内不重打网络',
       (WidgetTester tester) async {
+    // BUG-992 当初断言的是「切回 tab 后 listRemoteBooks 调用次数增加」——那是实现
+    // 细节，不是用户诉求。用户要的是「切回书架能看到远端占位卡」，而**不是**「每切
+    // 一次页面就联网一次」（后者正是 BUG-1175 的症状）。清单现在过 RemoteLibraryCache
+    // 的 TTL：切回 tab 仍然重新组装（本地库变化立即反映），但 TTL 内不再打网络。
+    // 这里把断言换成用户可见的不变式 + 「不得重复联网」的新约束。
     homeShellTabNotifier.value = HomeTab.books;
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
     // 首帧懒加载已拉一次。
     expect(remoteClient.listRemoteBooksCalls, greaterThanOrEqualTo(1));
     final int before = remoteClient.listRemoteBooksCalls;
+    final Finder remoteCard =
+        find.byKey(const ValueKey<String>('remote_book_card_Remote_Book'));
+    expect(remoteCard, findsOneWidget);
 
-    // 切到别的 tab（不重拉）再切回书架（自动重拉）。
+    // 切到别的 tab 再切回书架。
     homeShellTabNotifier.value = HomeTab.video;
     await tester.pump();
     expect(remoteClient.listRemoteBooksCalls, before, reason: '切到非书架 tab 不应重拉');
 
     homeShellTabNotifier.value = HomeTab.books;
     await tester.pumpAndSettle();
+    expect(remoteCard, findsOneWidget,
+        reason: 'BUG-992：切回书架 tab 远端占位卡必须仍在场（不必手动下拉刷新）');
+    expect(remoteClient.listRemoteBooksCalls, before,
+        reason: 'BUG-1175：TTL 内切回 tab 不得再问对端要一次清单');
+  });
+
+  testWidgets('BUG-1175: 下拉刷新强制穿透缓存（用户要最新的就必须联网）', (WidgetTester tester) async {
+    homeShellTabNotifier.value = HomeTab.books;
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    final int before = remoteClient.listRemoteBooksCalls;
+
+    await tester.fling(
+      find.byType(RefreshIndicator).first,
+      const Offset(0, 300),
+      1000,
+    );
+    await tester.pumpAndSettle();
+
     expect(remoteClient.listRemoteBooksCalls, greaterThan(before),
-        reason: 'BUG-992：切回书架 tab 应自动重拉远端书');
+        reason: '显式下拉刷新是强制入口，必须穿透 TTL 重新联网');
+  });
+
+  testWidgets('BUG-1176: 漫画书架实例从不拉远端书（它根本不消费）', (WidgetTester tester) async {
+    // 漫画书架就是 ReaderHibikiHistoryPage(mangaOnly: true)——与书架**同一个 State
+    // 类**。它此前也注册了 homeShellTabNotifier 监听，且回调判的是 `== HomeTab.books`，
+    // 于是切到书架时两个实例各拉一遍远端书，漫画那份在 build 里被 `!_mangaOnly` 丢掉。
+    homeShellTabNotifier.value = HomeTab.manga;
+    await tester.pumpWidget(buildApp(mangaOnly: true));
+    await tester.pumpAndSettle();
+    expect(remoteClient.listRemoteBooksCalls, 0,
+        reason: '漫画书架不渲染远端书占位卡，首帧就不该联网');
+
+    // 切到书架 tab：漫画实例仍在树上（保活），但不得被 books 信号带着一起拉。
+    homeShellTabNotifier.value = HomeTab.books;
+    await tester.pumpAndSettle();
+    expect(remoteClient.listRemoteBooksCalls, 0,
+        reason: 'BUG-1176：漫画实例不得响应书架 tab 信号去拉远端书');
+  });
+
+  testWidgets('BUG-1177: 关闭「显示远端条目」后根本不联网（而不是拉完再丢）',
+      (WidgetTester tester) async {
+    await appModel.prefsRepo.setShowRemoteEntries(false);
+    homeShellTabNotifier.value = HomeTab.books;
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    expect(remoteClient.listRemoteBooksCalls, 0,
+        reason: '开关关闭时门控必须在取数之前，不能拉完再在渲染期丢弃');
+    expect(
+      find.byKey(const ValueKey<String>('remote_book_card_Remote_Book')),
+      findsNothing,
+    );
+
+    // 开关翻回来：`??=` 不会自己重跑，门控翻转必须触发重新取数，否则用户要下拉刷新。
+    await appModel.prefsRepo.setShowRemoteEntries(true);
+    await tester.pumpAndSettle();
+    expect(remoteClient.listRemoteBooksCalls, greaterThanOrEqualTo(1),
+        reason: 'BUG-1177：开关从关翻到开必须重新取数');
+    expect(
+      find.byKey(const ValueKey<String>('remote_book_card_Remote_Book')),
+      findsOneWidget,
+    );
   });
 
   testWidgets(

--- a/hibiki/test/pages/unified_collections_architecture_guard_test.dart
+++ b/hibiki/test/pages/unified_collections_architecture_guard_test.dart
@@ -317,18 +317,33 @@ void main() {
         reason: '云视频目录/下载必须经 CloudRemoteVideoClient');
     expect(homeSrc.contains('_resolveCloudRemoteVideoClient'), isTrue,
         reason: '云后端分支：resolveSyncBackend 产物包进 CloudRemoteVideoClient');
-    expect(homeSrc.contains('_cloudManifestToRemoteVideoInfo'), isTrue,
-        reason: '云清单条目须经适配函数转成 RemoteVideoInfo 混排');
+    // TODO-2119：清单→RemoteVideoInfo 的适配已从页面搬进 CloudRemoteVideoClient
+    // （原 `_cloudManifestToRemoteVideoInfo`）。页面现在只认 RemoteVideoSource 契约，
+    // 连 RemoteVideoManifestEntry 这个类型都不该出现——给 RemoteVideoInfo 加字段时
+    // 不必再回来改页面，漏改导致「云侧该字段永远为空」的坑就此消失。
+    expect(homeSrc.contains('_cloudManifestToRemoteVideoInfo'), isFalse,
+        reason: '清单→DTO 适配必须在 CloudRemoteVideoClient 里，不得回流页面');
+    expect(homeSrc.contains('RemoteVideoManifestEntry'), isFalse,
+        reason: '页面不得再感知清单条目类型（收敛到 CloudRemoteVideoClient）');
     // 页面不得自造清单解析（RemoteVideoManifest.fromJson 只应在 client 里）。
     expect(homeSrc.contains('RemoteVideoManifest.fromJson'), isFalse,
         reason: '页面不得自己解析 videos.json 清单（收敛到 CloudRemoteVideoClient）');
     expect(homeSrc.contains('kSyncVideosManifestName'), isFalse,
         reason: '页面不得直接触碰清单资产名（收敛到 CloudRemoteVideoClient）');
-    // 云视频下载走 CloudRemoteVideoClient.getRemoteVideo（整文件），登记时不双重导入。
-    expect(homeSrc.contains('getRemoteVideo('), isTrue,
-        reason: '云视频下载必须经 CloudRemoteVideoClient.getRemoteVideo 拉整文件');
+    // 下载统一走 RemoteVideoSource.downloadRemoteVideo：云盘实现内部委托给
+    // getRemoteVideo 拉整文件（无 Range 续传），互联走 host live 引擎。页面不再按
+    // 后端类型分派下载路径。
+    expect(homeSrc.contains('source.downloadRemoteVideo('), isTrue,
+        reason: '远端下载必须经 RemoteVideoSource.downloadRemoteVideo 统一入口');
     expect(homeSrc.contains('_registerDownloadedCloudVideo'), isTrue,
         reason: '云视频下载后必须建 VideoBooks 行（勿双重导入）');
+    // 两个互斥 nullable client 字段已收成一个 source（TODO-2119）：能力差异由类型
+    // 系统表达（source is RemoteVideoClient），不再靠「哪个字段非空」判后端。
+    expect(homeSrc.contains('CloudRemoteVideoClient? _cloudRemoteVideoClient;'),
+        isFalse,
+        reason: '不得恢复「互联 client + 云 client」两个互斥字段（TODO-2119 回归）');
+    expect(homeSrc.contains('RemoteVideoSource? _remoteVideoSource;'), isTrue,
+        reason: '当前远端视频来源必须是单一真相字段');
   });
 
   test('多端库联合视图 §2.3 任务10：合集行成员占位归属解析不到 → 散卡降级（不硬造行）', () {

--- a/hibiki/test/sync/hibiki_sync_server_asset_gate_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_asset_gate_test.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// HBK-AUDIT-012 路径穿越闸门 + 资产包端点骨架的收敛守卫（TODO-2120）。
+///
+/// 背景——「按名字取/存/删一个资产包」这层此前在词典 / 书 / 本地音频 / 有声书四个域
+/// 里逐字复制了四份（各约 60 行），路径穿越判断更是连同 position/progress 子路由一共
+/// 抄了 7 遍。这段代码里含导出缓存 + ETag/Range 续传、上传临时目录的必清理、IOSink
+/// 双重关闭保护，以及那道**安全闸门**——靠复制粘贴维持，加一个新媒体域就要再抄一遍，
+/// 抄漏任何一处都是真事故（泄漏临时目录 / 续传验证器失效 / 或者直接是路径穿越漏洞）。
+///
+/// 行为层面的 403 断言已由 `hibiki_sync_server_audio_test.dart`（localaudio /
+/// audiobooks 两域的 GET/DELETE `%2e%2e%2fevil`）端到端覆盖。本文件锁的是**结构**：
+/// 闸门只有一处实现、四个域都真的走它、视频域按设计不接入。
+void main() {
+  final String src =
+      File('lib/src/sync/hibiki_sync_server.dart').readAsStringSync();
+
+  test('路径穿越闸门只有一处实现', () {
+    expect(
+      RegExp(r'shelf\.Response\? _rejectUnsafeAssetId\(')
+          .allMatches(src)
+          .length,
+      1,
+      reason: '闸门必须唯一；再出现第二份实现就意味着有人又抄了一遍',
+    );
+    // 除闸门自身与视频域的两处专用校验外，不得再有裸的 `..` 判断。
+    final int dotDotChecks =
+        RegExp(r"contains\('\.\.'\)").allMatches(src).length;
+    expect(
+      dotDotChecks,
+      3,
+      reason: '预期恰好 3 处：_rejectUnsafeAssetId 自身 + 视频 id 的两处专用校验。'
+          '多出来就是有人在新端点里手抄了穿越判断，请改调 _rejectUnsafeAssetId',
+    );
+  });
+
+  test('四个资产域都经过共享闸门', () {
+    for (final String label in <String>[
+      "'dictionary name'",
+      "'book title'",
+      "'displayName'",
+      "'bookKey'",
+    ]) {
+      expect(
+        src.contains('_rejectUnsafeAssetId($label)') ||
+            RegExp('_rejectUnsafeAssetId\\([^,]+, $label\\)').hasMatch(src),
+        isTrue,
+        reason: '$label 域必须经共享闸门校验资产名',
+      );
+    }
+  });
+
+  test('资产包 GET/PUT/DELETE 骨架只有一处实现，四个域都走它', () {
+    expect(
+      RegExp(r'Future<shelf\.Response> _serveAssetPackage\(')
+          .allMatches(src)
+          .length,
+      1,
+      reason: '资产包端点骨架必须唯一',
+    );
+    expect(
+      RegExp(r'return _serveAssetPackage\(').allMatches(src).length,
+      4,
+      reason: '词典 / 书 / 本地音频 / 有声书四域都必须走共享骨架；'
+          '新增媒体域也应走它，而不是再抄一份 switch',
+    );
+  });
+
+  test('骨架保住三条易抄漏的约束：导出缓存 ETag、临时目录必清、IOSink 双重关闭', () {
+    final int start = src.indexOf('Future<shelf.Response> _serveAssetPackage(');
+    expect(start, isNonNegative);
+    final int end = src.indexOf(
+        'Future<shelf.Response> _handleLibraryDictionaries(', start);
+    expect(end, greaterThan(start));
+    final String body = src.substring(start, end);
+
+    expect(body.contains('ExportPackageCache.etagFor(file)'), isTrue,
+        reason: '包下载必须带 ETag 作 If-Range 验证器，否则续传会拼错字节');
+    expect(body.contains('_exportCache.obtain('), isTrue,
+        reason: '包导出必须经进程级缓存（否则每次请求重新打包）');
+    expect(body.contains('tmpDir.deleteSync(recursive: true)'), isTrue,
+        reason: '上传临时目录必须在 finally 里清理，否则每次导入泄漏一个目录');
+    expect(body.contains('} finally {'), isTrue,
+        reason: '临时目录清理必须在 finally，不能只在成功路径');
+  });
+
+  test('视频域按设计不接入共享闸门（视频 id 合法含 /）', () {
+    // 视频 bookUid 形如 `video/xxx`，走共享闸门会把全部视频端点判成 403。
+    expect(src.contains(r'_rejectUnsafeAssetId(videoId'), isFalse,
+        reason: '视频 id 合法含 /，不得接入禁止 / 的资产闸门');
+    expect(src.contains('_extractVideoId'), isTrue, reason: '视频 id 有自己的专用校验');
+  });
+}

--- a/hibiki/test/sync/interconnect_post_transport_test.dart
+++ b/hibiki/test/sync/interconnect_post_transport_test.dart
@@ -1,0 +1,368 @@
+import 'dart:convert';
+
+import 'package:drift/drift.dart' hide isNotNull, isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/interconnect_post_transport.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// [InterconnectPostTransport] 直接守卫。
+///
+/// 这套「已启用候选按序 fallback + Basic 鉴权 + https 带指纹强制钉扎 + 每候选独立回收」
+/// 的逻辑此前在 `hibiki_remote_lookup_client.dart` 与 `hibiki_remote_mining_client.dart`
+/// 各抄了一份（后者的类注释自己就写着「传输契约与前者完全同构」），另有 mangaOcr 的
+/// GET 版与 `InterconnectSyncBackend` 走 WebDavOps 的第四份。抄漏一处钉扎/回收就是真
+/// 事故（TODO-961 gap①），故收敛成一份并在此直接锁语义——制卡侧原本只有 1 个测试，
+/// 收敛后它的传输层由本文件与 lookup 的用例共同覆盖。
+HibikiDatabase _testDb() => HibikiDatabase.forTesting(
+      DatabaseConnection(NativeDatabase.memory()),
+    );
+
+Future<SyncRepository> _repo({
+  required HibikiDatabase db,
+  required List<HibikiClientUrl> urls,
+  String? token = 'tok',
+}) async {
+  final SyncRepository repo = SyncRepository(db);
+  await repo.setHibikiClientUrls(urls);
+  await repo.setHibikiClientToken(token);
+  return repo;
+}
+
+Future<InterconnectPostOutcome> _post(
+  InterconnectPostTransport transport,
+) =>
+    transport.post(
+      path: '/api/probe',
+      body: const <String, dynamic>{'k': 'v'},
+      timeout: const Duration(seconds: 3),
+      authErrorMessage: 'rejected',
+    );
+
+void main() {
+  test('按序 fallback：前一个候选非 2xx 时试下一个', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[
+        HibikiClientUrl(url: 'http://lan:8765'),
+        HibikiClientUrl(url: 'http://wan:8765'),
+      ],
+    );
+    final List<String> hosts = <String>[];
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((http.Request request) async {
+        hosts.add(request.url.host);
+        if (request.url.host == 'lan') return http.Response('down', 503);
+        return http.Response(jsonEncode(<String, dynamic>{'ok': true}), 200);
+      }),
+    );
+
+    final InterconnectPostOutcome outcome = await _post(transport);
+    expect(hosts, <String>['lan', 'wan']);
+    expect(outcome.json?['ok'], isTrue);
+    expect(outcome.allUnreachable, isFalse);
+  });
+
+  test('disabled 候选被跳过', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[
+        HibikiClientUrl(url: 'http://off:8765', enabled: false),
+        HibikiClientUrl(url: 'http://on:8765'),
+      ],
+    );
+    final List<String> hosts = <String>[];
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((http.Request request) async {
+        hosts.add(request.url.host);
+        return http.Response(jsonEncode(<String, dynamic>{'ok': true}), 200);
+      }),
+    );
+
+    await _post(transport);
+    expect(hosts, <String>['on'], reason: 'enabled=false 的候选一枪都不该发');
+  });
+
+  test('Basic 鉴权头用 base64(hibiki:token)', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[HibikiClientUrl(url: 'http://h:8765')],
+      token: 'secret',
+    );
+    String? auth;
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((http.Request request) async {
+        auth = request.headers['Authorization'];
+        return http.Response(jsonEncode(<String, dynamic>{'ok': true}), 200);
+      }),
+    );
+
+    await _post(transport);
+    expect(auth, 'Basic ${base64Encode(utf8.encode('hibiki:secret'))}');
+  });
+
+  test('401 抛 SyncAuthError 且不再试下一个候选（共用同一 token）', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[
+        HibikiClientUrl(url: 'http://a:8765'),
+        HibikiClientUrl(url: 'http://b:8765'),
+      ],
+    );
+    int calls = 0;
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((http.Request request) async {
+        calls++;
+        return http.Response('no', 401);
+      }),
+    );
+
+    await expectLater(_post(transport), throwsA(isA<SyncAuthError>()));
+    expect(calls, 1, reason: '一次拒绝即全部失败，不该拿同一个 token 再试别的候选');
+  });
+
+  test('404/405 视为老 host 无此端点，继续下一个候选', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[
+        HibikiClientUrl(url: 'http://old:8765'),
+        HibikiClientUrl(url: 'http://new:8765'),
+      ],
+    );
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((http.Request request) async {
+        if (request.url.host == 'old') return http.Response('nope', 404);
+        return http.Response(jsonEncode(<String, dynamic>{'ok': true}), 200);
+      }),
+    );
+
+    final InterconnectPostOutcome outcome = await _post(transport);
+    expect(outcome.json?['ok'], isTrue);
+  });
+
+  test('全部候选传输层失败 → allUnreachable（配对设备死了）', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[
+        HibikiClientUrl(url: 'http://a:8765'),
+        HibikiClientUrl(url: 'http://b:8765'),
+      ],
+    );
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      // 传输层失败（连接拒绝 / 超时 / DNS）在 http 包里就是 ClientException。
+      httpClient: MockClient((http.Request request) async {
+        throw http.ClientException('connection refused', request.url);
+      }),
+    );
+
+    final InterconnectPostOutcome outcome = await _post(transport);
+    expect(outcome.json, isNull);
+    expect(outcome.allUnreachable, isTrue);
+  });
+
+  test('可达但没结果 ≠ 不可达（失败冷却不得被误触发）', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[HibikiClientUrl(url: 'http://a:8765')],
+    );
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((http.Request request) async {
+        return http.Response('not json at all', 200);
+      }),
+    );
+
+    final InterconnectPostOutcome outcome = await _post(transport);
+    expect(outcome.json, isNull);
+    expect(outcome.allUnreachable, isFalse,
+        reason: '拿到了 HTTP 响应就算可达，哪怕响应体不是 JSON');
+  });
+
+  test('未配对 / 无 token 不算不可达', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository noUrls = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[],
+    );
+    final InterconnectPostOutcome a = await _post(
+      InterconnectPostTransport(
+        repo: noUrls,
+        httpClient: MockClient((_) async => throw StateError('不该发请求')),
+      ),
+    );
+    expect(a.allUnreachable, isFalse);
+
+    final SyncRepository noToken = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[HibikiClientUrl(url: 'http://a:8765')],
+      token: null,
+    );
+    final InterconnectPostOutcome b = await _post(
+      InterconnectPostTransport(
+        repo: noToken,
+        httpClient: MockClient((_) async => throw StateError('不该发请求')),
+      ),
+    );
+    expect(b.allUnreachable, isFalse);
+  });
+
+  test('https 带指纹的候选强制走钉扎 client，不碰注入的共享 client (TODO-961 gap①)', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[
+        HibikiClientUrl(
+          url: 'https://secure:8765',
+          fingerprintSha256: 'aa:bb:cc',
+        ),
+      ],
+    );
+    final List<String> pinnedFor = <String>[];
+    bool sharedUsed = false;
+    bool pinnedClosed = false;
+
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((_) async {
+        sharedUsed = true;
+        return http.Response('{}', 200);
+      }),
+      pinnedClientFactory: (String fingerprint) {
+        pinnedFor.add(fingerprint);
+        return _ClosableMockClient(
+          (http.Request request) async =>
+              http.Response(jsonEncode(<String, dynamic>{'ok': true}), 200),
+          onClose: () => pinnedClosed = true,
+        );
+      },
+    );
+
+    final InterconnectPostOutcome outcome = await _post(transport);
+    expect(outcome.json?['ok'], isTrue);
+    expect(pinnedFor, <String>['aa:bb:cc'],
+        reason: 'https 带指纹必须用该指纹建钉扎 client');
+    expect(sharedUsed, isFalse, reason: '注入的 keep-alive client 绝不能旁路证书钉扎');
+    expect(pinnedClosed, isTrue, reason: '每候选的钉扎 client 用完即关，不泄漏 socket');
+  });
+
+  test('明文 http 候选用共享 client，且绝不在此关闭它', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[HibikiClientUrl(url: 'http://plain:8765')],
+    );
+    bool sharedClosed = false;
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: _ClosableMockClient(
+        (http.Request request) async =>
+            http.Response(jsonEncode(<String, dynamic>{'ok': true}), 200),
+        onClose: () => sharedClosed = true,
+      ),
+      pinnedClientFactory: (_) => throw StateError('明文候选不该建钉扎 client'),
+    );
+
+    await _post(transport);
+    expect(sharedClosed, isFalse, reason: '共享 client 归调用方所有，传输层不得关它');
+  });
+
+  test('https 无指纹不走钉扎（老配置向后兼容）', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[HibikiClientUrl(url: 'https://nofp:8765')],
+    );
+    bool sharedUsed = false;
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((_) async {
+        sharedUsed = true;
+        return http.Response(jsonEncode(<String, dynamic>{'ok': true}), 200);
+      }),
+      pinnedClientFactory: (_) => throw StateError('无指纹不该建钉扎 client'),
+    );
+
+    await _post(transport);
+    expect(sharedUsed, isTrue);
+  });
+
+  test('畸形候选 URL 被跳过，不影响后续候选', () async {
+    final HibikiDatabase db = _testDb();
+    addTearDown(db.close);
+    final SyncRepository repo = await _repo(
+      db: db,
+      urls: const <HibikiClientUrl>[
+        HibikiClientUrl(url: '::::not a url::::'),
+        HibikiClientUrl(url: 'http://good:8765'),
+      ],
+    );
+    final List<String> hosts = <String>[];
+    final InterconnectPostTransport transport = InterconnectPostTransport(
+      repo: repo,
+      httpClient: MockClient((http.Request request) async {
+        hosts.add(request.url.host);
+        return http.Response(jsonEncode(<String, dynamic>{'ok': true}), 200);
+      }),
+    );
+
+    final InterconnectPostOutcome outcome = await _post(transport);
+    expect(outcome.json?['ok'], isTrue);
+    expect(hosts, <String>['good']);
+  });
+
+  group('interconnectEndpointUri', () {
+    test('拼端点并清空查询串', () {
+      final Uri? uri =
+          interconnectEndpointUri('http://h:8765/?x=1', '/api/probe');
+      expect(uri?.host, 'h');
+      expect(uri?.path, '/api/probe');
+      expect(uri?.query, isEmpty);
+    });
+
+    test('畸形基址返回 null', () {
+      expect(interconnectEndpointUri('::::bad::::', '/api/probe'), isNull);
+    });
+  });
+}
+
+/// [MockClient] 不暴露「是否被 close」，而 socket 回收正是本传输层的安全约束之一，
+/// 故包一层记录 close。
+class _ClosableMockClient extends MockClient {
+  _ClosableMockClient(super.handler, {required this.onClose});
+
+  final void Function() onClose;
+
+  @override
+  void close() {
+    onClose();
+    super.close();
+  }
+}

--- a/hibiki/test/sync/interconnect_session_reuse_test.dart
+++ b/hibiki/test/sync/interconnect_session_reuse_test.dart
@@ -1,0 +1,164 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
+import 'package:hibiki/src/sync/sync_backend.dart' show SyncBackendError;
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// BUG-1178 根因守卫：`restoreAuth` 不得无条件作废已解析的地址。
+///
+/// 症状——每切一次页面，互联请求都要先把全部候选地址重探测一遍才发真正的业务请求。
+/// 真根因：`_loadConfig` 末尾无条件 `_sessionResolved = false`，而 `restoreAuth` 是
+/// 每个消费方（书架 / 视频页 / 首页 dashboard）取 client 的必经之路，且
+/// [InterconnectSyncBackend] 是单例——三个页面互相把对方刚探明的会话踩掉。
+///
+/// 修复后的语义：会话该不该重来只取决于**配置是否真变**（地址集合 / 钉扎指纹 /
+/// 令牌）。地址失联后的换路由径走 `clearCache()`，与本处正交。
+void main() {
+  late HibikiDatabase db;
+  late SyncRepository repo;
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    repo = SyncRepository(db);
+    await repo.setHibikiClientUrls(<HibikiClientUrl>[
+      const HibikiClientUrl(url: 'http://192.168.1.10:8384'),
+    ]);
+    await repo.setHibikiClientToken('token-a');
+  });
+
+  tearDown(() async => db.close());
+
+  test('配置未变时 restoreAuth 不触发全候选重探测', () async {
+    int probes = 0;
+    final InterconnectSyncBackend backend =
+        InterconnectSyncBackend.withProbe((String url, String token) async {
+      probes++;
+      return true;
+    });
+
+    // 首次连接：必然要探一次。
+    await backend.authenticate(repo: repo);
+    expect(probes, 1);
+
+    // 模拟「切到另一个页面」——该页面的 _resolveRemoteXClient 会先 restoreAuth。
+    expect(await backend.restoreAuth(repo), isTrue);
+    await backend.authenticate(repo: repo);
+    expect(probes, 1, reason: 'BUG-1178：配置没变就不该把已探明可达的地址作废重探');
+
+    // 再切两次页面，仍不该重探。
+    await backend.restoreAuth(repo);
+    await backend.restoreAuth(repo);
+    await backend.authenticate(repo: repo);
+    expect(probes, 1);
+  });
+
+  test('令牌变化触发重探测（凭据换了，会话必须重来）', () async {
+    int probes = 0;
+    final InterconnectSyncBackend backend =
+        InterconnectSyncBackend.withProbe((String url, String token) async {
+      probes++;
+      return true;
+    });
+
+    await backend.authenticate(repo: repo);
+    expect(probes, 1);
+
+    await repo.setHibikiClientToken('token-b');
+    await backend.restoreAuth(repo);
+    await backend.authenticate(repo: repo);
+    expect(probes, 2, reason: '令牌变了必须重探，否则会拿旧凭据打新会话');
+  });
+
+  test('候选地址集合变化触发重探测（换了对端）', () async {
+    int probes = 0;
+    final InterconnectSyncBackend backend =
+        InterconnectSyncBackend.withProbe((String url, String token) async {
+      probes++;
+      return true;
+    });
+
+    await backend.authenticate(repo: repo);
+    expect(probes, 1);
+
+    await repo.setHibikiClientUrls(<HibikiClientUrl>[
+      const HibikiClientUrl(url: 'http://192.168.1.99:8384'),
+    ]);
+    await backend.restoreAuth(repo);
+    await backend.authenticate(repo: repo);
+    expect(probes, 2, reason: '地址集合变了必须重探');
+  });
+
+  test('钉扎指纹变化触发重解析（同地址换证书也是换身份）', () async {
+    int probes = 0;
+    final InterconnectSyncBackend backend =
+        InterconnectSyncBackend.withProbe((String url, String token) async {
+      probes++;
+      return true;
+    });
+
+    await backend.authenticate(repo: repo);
+    expect(probes, 1);
+
+    // 给同一个地址挂上钉扎指纹 = 换了身份。
+    await repo.setHibikiClientUrls(<HibikiClientUrl>[
+      const HibikiClientUrl(
+        url: 'http://192.168.1.10:8384',
+        fingerprintSha256: 'aa:bb:cc',
+      ),
+    ]);
+    await backend.restoreAuth(repo);
+
+    // 带指纹的候选**绕过**注入 probe，走 `_pinnedReachabilityProbe`（真实 TLS 握手），
+    // 所以这里数不到 probe 次数。改断言「确实重新走了解析」——地址不可达导致抛错，
+    // 正好证明它没有沿用上一次已解析的会话（沿用的话 authenticate 会直接返回）。
+    await expectLater(
+      backend.authenticate(repo: repo),
+      throwsA(isA<SyncBackendError>()),
+      reason: '指纹是地址身份的一部分，变了必须重新解析而不是沿用旧会话',
+    );
+  });
+
+  test('仅对端展示名变化不触发重探测（deviceName 不进会话身份）', () async {
+    int probes = 0;
+    final InterconnectSyncBackend backend =
+        InterconnectSyncBackend.withProbe((String url, String token) async {
+      probes++;
+      return true;
+    });
+
+    await backend.authenticate(repo: repo);
+    expect(probes, 1);
+
+    await repo.setHibikiClientUrls(<HibikiClientUrl>[
+      const HibikiClientUrl(
+        url: 'http://192.168.1.10:8384',
+        deviceName: '书房台式机',
+      ),
+    ]);
+    await backend.restoreAuth(repo);
+    await backend.authenticate(repo: repo);
+    expect(probes, 1, reason: '展示名是纯 UI 字段，改它不该引发一轮全候选探测');
+  });
+
+  test('signOut 后配置身份归零，下次连接必然重探', () async {
+    int probes = 0;
+    final InterconnectSyncBackend backend =
+        InterconnectSyncBackend.withProbe((String url, String token) async {
+      probes++;
+      return true;
+    });
+
+    await backend.authenticate(repo: repo);
+    expect(probes, 1);
+
+    await backend.signOut(repo: repo);
+    await repo.setHibikiClientUrls(<HibikiClientUrl>[
+      const HibikiClientUrl(url: 'http://192.168.1.10:8384'),
+    ]);
+    await repo.setHibikiClientToken('token-a');
+    await backend.restoreAuth(repo);
+    await backend.authenticate(repo: repo);
+    expect(probes, 2, reason: '登出抹掉会话身份，重新配上同样的地址也要重探一次');
+  });
+}

--- a/hibiki/test/sync/remote_dto_wire_format_golden_test.dart
+++ b/hibiki/test/sync/remote_dto_wire_format_golden_test.dart
@@ -1,0 +1,439 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki_core/hibiki_core.dart' show MediaKind;
+
+/// 互联 wire format 黄金守卫（TODO-2120 的前置安全网）。
+///
+/// **为什么需要这个文件**——互联 DTO 的 `toJson` 里有 **30+ 处条件省略 key**：
+/// `if (tags.isNotEmpty)`、`if (progressPercent > 0)`、`if (kind != MediaKind.epub)`、
+/// `if (episodes.length > 1)`、`if (hasDisplayCover)` …… 这些不是随手写的优化，而是
+/// **活的线上协议**：老 host / 老 client 靠「键不存在」来判断「没有这个东西」，
+/// 一旦某个键从「不写」变成「写 null / false / 空数组」，对端的解析分支就换了一条路。
+///
+/// 而此前只有 3 处（`kind` / `tags` / `collection`）被测试锁住，其余 30 来处**一旦被
+/// 改成无条件写出，全套测试照样全绿**。这意味着：
+/// - 任何人给 DTO 加字段、或把手写 `toJson` 换成 codegen（json_serializable 默认
+///   `includeIfNull: true`，且根本表达不了 `isNotEmpty` / `> 0` / `!= epub` 这类
+///   **基于值**的条件），都会静默改变 wire，且没有任何测试会红。
+///
+/// 本文件把「最小实例写出哪些键」和「最大实例写出哪些键」**逐 DTO 精确钉死**。
+/// 加字段时这里必然变红——那正是要的：强制作者显式声明新字段的省略语义，而不是
+/// 让它悄悄溜进协议。
+///
+/// 注意：断言的是 **key 集合**，不是值。值语义由各域自己的测试负责。
+void main() {
+  /// 断言 [json] 的键集合恰好是 [expected]（多一个少一个都红）。
+  void expectKeys(
+    Map<String, Object?> json,
+    Set<String> expected, {
+    required String what,
+  }) {
+    expect(
+      json.keys.toSet(),
+      expected,
+      reason: '$what 的 wire key 集合变了。若这是有意的协议变更，请连同老 host/老 '
+          'client 的兼容影响一起评估后再改本断言；若只是新加字段，请先想清楚它该在'
+          '什么条件下省略。',
+    );
+  }
+
+  group('RemoteBookInfo', () {
+    test('最小实例：只写 title / hasContent（其余全部省略）', () {
+      expectKeys(
+        const RemoteBookInfo(title: 'T', hasContent: false).toJson(),
+        <String>{'title', 'hasContent'},
+        what: 'RemoteBookInfo 最小实例',
+      );
+    });
+
+    test('最大实例：全部可选键都出现', () {
+      final Map<String, Object?> json = RemoteBookInfo(
+        title: 'T',
+        hasContent: true,
+        bookKey: 'k',
+        hasEmbeddedCover: true,
+        coverUrl: 'http://h/c.png',
+        coverPath: '/local/c.png',
+        hasAudiobook: true,
+        tags: const <String>['a'],
+        tagsAddedAt: const <String, int>{'a': 1},
+        tagTombstones: const <String, int>{'b': 2},
+        collection: const RemoteCollectionMembership(
+          collectionName: 'C',
+          collectionType: 'book',
+          sortIndex: 0,
+        ),
+        progressPercent: 50,
+        progressUpdatedAtMs: 123,
+        kind: MediaKind.srt,
+      ).toJson();
+      expectKeys(
+        json,
+        <String>{
+          'title',
+          'bookKey',
+          'hasContent',
+          'hasCover',
+          'coverUrl',
+          'hasAudiobook',
+          'tags',
+          'tagsAddedAt',
+          'tagTombstones',
+          'collection',
+          'progressPercent',
+          'progressUpdatedAtMs',
+          'kind',
+        },
+        what: 'RemoteBookInfo 最大实例',
+      );
+      // coverPath 是 host 本地绝对路径：fromJson 读、toJson **永不写**（不外泄）。
+      expect(json.containsKey('coverPath'), isFalse,
+          reason: 'host 本地路径绝不能出现在 wire 上');
+    });
+
+    test('epub 是默认 kind，不写 kind 键（旧 wire 字节不变）', () {
+      expect(
+        const RemoteBookInfo(title: 'T', hasContent: true).toJson(),
+        isNot(contains('kind')),
+      );
+      expect(
+        const RemoteBookInfo(title: 'T', hasContent: true, kind: MediaKind.epub)
+            .toJson(),
+        isNot(contains('kind')),
+      );
+    });
+
+    test('hasCover 写的是派生语义（coverPath/coverUrl 也算有封面）', () {
+      // wire key 叫 hasCover，值取的却是 hasDisplayCover（= 内嵌封面 或 有 coverUrl
+      // 或 有 coverPath）。Dart 侧字段名是 hasEmbeddedCover——同名不同义，改这里前
+      // 先读 DTO 里的注释。
+      expect(
+        const RemoteBookInfo(
+          title: 'T',
+          hasContent: true,
+          coverPath: '/local/c.png',
+        ).toJson()['hasCover'],
+        isTrue,
+        reason: '只有本地封面路径时，wire 上仍应告诉对端「这本书有封面」',
+      );
+    });
+
+    test('progress 为 0 时不写（0 与「没有进度」在 wire 上同义）', () {
+      final Map<String, Object?> json = const RemoteBookInfo(
+        title: 'T',
+        hasContent: true,
+        progressPercent: 0,
+        progressUpdatedAtMs: 0,
+      ).toJson();
+      expect(json.containsKey('progressPercent'), isFalse);
+      expect(json.containsKey('progressUpdatedAtMs'), isFalse);
+    });
+  });
+
+  group('RemoteVideoInfo', () {
+    test('最小实例：只写 id / title / hasSubtitle', () {
+      expectKeys(
+        const RemoteVideoInfo(id: 'video/x', title: 'T').toJson(),
+        <String>{'id', 'title', 'hasSubtitle'},
+        what: 'RemoteVideoInfo 最小实例',
+      );
+    });
+
+    test('最大实例：全部可选键都出现', () {
+      final Map<String, Object?> json = RemoteVideoInfo(
+        id: 'video/x',
+        title: 'T',
+        sizeBytes: 1,
+        hasSubtitle: true,
+        subtitleFileName: 's.srt',
+        embeddedSubtitleTracks: const <RemoteVideoEmbeddedSubtitleTrack>[
+          RemoteVideoEmbeddedSubtitleTrack(streamIndex: 0, codec: 'subrip'),
+        ],
+        durationMs: 2,
+        hasCover: true,
+        coverUrl: 'http://h/c.png',
+        coverPath: '/local/c.png',
+        positionMs: 3,
+        positionUpdatedAtMs: 4,
+        delayMs: 5,
+        episodes: const <RemoteVideoEpisode>[
+          RemoteVideoEpisode(index: 0, title: 'e0'),
+          RemoteVideoEpisode(index: 1, title: 'e1'),
+        ],
+        currentEpisode: 1,
+        tags: const <String>['a'],
+        tagsAddedAt: const <String, int>{'a': 1},
+        tagTombstones: const <String, int>{'b': 2},
+        collection: const RemoteCollectionMembership(
+          collectionName: 'C',
+          collectionType: 'video',
+          sortIndex: 0,
+        ),
+      ).toJson();
+      expectKeys(
+        json,
+        <String>{
+          'id',
+          'title',
+          'sizeBytes',
+          'hasSubtitle',
+          'subtitleFileName',
+          'embeddedSubtitleTracks',
+          'durationMs',
+          'hasCover',
+          'coverUrl',
+          'positionMs',
+          'positionUpdatedAtMs',
+          'delayMs',
+          'episodes',
+          'currentEpisode',
+          'tags',
+          'tagsAddedAt',
+          'tagTombstones',
+          'collection',
+        },
+        what: 'RemoteVideoInfo 最大实例',
+      );
+      expect(json.containsKey('coverPath'), isFalse,
+          reason: 'host 本地路径绝不能出现在 wire 上');
+    });
+
+    test('单视频（episodes<=1）不写 episodes / currentEpisode（旧 client 兼容）', () {
+      final Map<String, Object?> single = const RemoteVideoInfo(
+        id: 'video/x',
+        title: 'T',
+        episodes: <RemoteVideoEpisode>[
+          RemoteVideoEpisode(index: 0, title: 'e')
+        ],
+        currentEpisode: 0,
+      ).toJson();
+      expect(single.containsKey('episodes'), isFalse,
+          reason: '只有一集时 wire 上不应出现播放列表键');
+      expect(single.containsKey('currentEpisode'), isFalse);
+    });
+
+    test('无内封字幕轨时不写 embeddedSubtitleTracks', () {
+      expect(
+        const RemoteVideoInfo(id: 'video/x', title: 'T').toJson(),
+        isNot(contains('embeddedSubtitleTracks')),
+      );
+    });
+
+    test('delayMs 为 0 不写；非 0（含负值）要写', () {
+      expect(
+        const RemoteVideoInfo(id: 'v', title: 'T', delayMs: 0).toJson(),
+        isNot(contains('delayMs')),
+      );
+      expect(
+        const RemoteVideoInfo(id: 'v', title: 'T', delayMs: -250)
+            .toJson()['delayMs'],
+        -250,
+        reason: '负 delay 是合法的字幕提前量，不能被当成「无值」省掉',
+      );
+    });
+  });
+
+  group('RemoteVideoEmbeddedSubtitleTrack', () {
+    test('最小实例：streamIndex / codec / isText', () {
+      expectKeys(
+        const RemoteVideoEmbeddedSubtitleTrack(streamIndex: 0, codec: 'subrip')
+            .toJson(),
+        <String>{'streamIndex', 'codec', 'isText'},
+        what: '内封字幕轨最小实例',
+      );
+    });
+
+    test('最大实例', () {
+      expectKeys(
+        const RemoteVideoEmbeddedSubtitleTrack(
+          streamIndex: 1,
+          codec: 'ass',
+          language: 'jpn',
+          title: 'JP',
+          isText: false,
+          url: 'http://h/s',
+          fileName: 's.ass',
+        ).toJson(),
+        <String>{
+          'streamIndex',
+          'codec',
+          'language',
+          'title',
+          'isText',
+          'url',
+          'fileName'
+        },
+        what: '内封字幕轨最大实例',
+      );
+    });
+
+    test('isText 缺失解成 true（反向默认，不是 false）', () {
+      // 老 host 不下发 isText → 必须当文本轨处理，否则字幕全被当图形轨丢掉。
+      expect(
+        RemoteVideoEmbeddedSubtitleTrack.fromJson(
+          const <String, Object?>{'streamIndex': 0, 'codec': 'subrip'},
+        ).isText,
+        isTrue,
+      );
+      expect(
+        RemoteVideoEmbeddedSubtitleTrack.fromJson(
+          const <String, Object?>{
+            'streamIndex': 0,
+            'codec': 'hdmv_pgs',
+            'isText': false,
+          },
+        ).isText,
+        isFalse,
+      );
+    });
+  });
+
+  group('RemoteAudiobookInfo', () {
+    test('uid 为空时省略（旧 host 不下发此字段）', () {
+      expectKeys(
+        const RemoteAudiobookInfo(bookKey: 'k').toJson(),
+        <String>{'bookKey', 'title'},
+        what: 'RemoteAudiobookInfo 无 uid',
+      );
+      expectKeys(
+        const RemoteAudiobookInfo(bookKey: 'k', uid: 'u', title: 't').toJson(),
+        <String>{'bookKey', 'uid', 'title'},
+        what: 'RemoteAudiobookInfo 全字段',
+      );
+    });
+
+    test('身份键：srt-backed 用 bookKey，standalone 用 uid', () {
+      expect(const RemoteAudiobookInfo(bookKey: 'k', uid: 'u').identity, 'k');
+      expect(const RemoteAudiobookInfo(bookKey: '', uid: 'u').identity, 'u');
+      expect(const RemoteAudiobookInfo(bookKey: '').isStandaloneSrt, isTrue);
+    });
+  });
+
+  group('RemoteActivityEvent', () {
+    test('最小实例：5 个必填键', () {
+      expectKeys(
+        const RemoteActivityEvent(
+          eventType: 'read',
+          mediaType: 'book',
+          title: 'T',
+          dateKey: '2026-07-28',
+          timestampMs: 1,
+        ).toJson(),
+        <String>{'eventType', 'mediaType', 'title', 'dateKey', 'timestampMs'},
+        what: 'RemoteActivityEvent 最小实例',
+      );
+    });
+
+    test('最大实例：可选三键出现', () {
+      expectKeys(
+        const RemoteActivityEvent(
+          eventType: 'read',
+          mediaType: 'book',
+          title: 'T',
+          dateKey: '2026-07-28',
+          timestampMs: 1,
+          mediaKey: 'k',
+          durationMs: 2,
+          charsDelta: 3,
+        ).toJson(),
+        <String>{
+          'eventType',
+          'mediaType',
+          'title',
+          'dateKey',
+          'timestampMs',
+          'mediaKey',
+          'durationMs',
+          'charsDelta'
+        },
+        what: 'RemoteActivityEvent 最大实例',
+      );
+    });
+  });
+
+  group('固定键集的 DTO（无条件省略）', () {
+    test('RemoteCollectionMembership：wire key 是 name，不是 collectionName', () {
+      expectKeys(
+        const RemoteCollectionMembership(
+          collectionName: 'C',
+          collectionType: 'book',
+          sortIndex: 3,
+        ).toJson(),
+        <String>{'name', 'collectionType', 'sortIndex'},
+        what: 'RemoteCollectionMembership',
+      );
+    });
+
+    test('RemoteBookProgress', () {
+      expectKeys(
+        const RemoteBookProgress(
+          sectionIndex: 0,
+          normCharOffset: 0,
+          charOffset: -1,
+          updatedAtMs: 0,
+        ).toJson(),
+        <String>{'sectionIndex', 'normCharOffset', 'charOffset', 'updatedAtMs'},
+        what: 'RemoteBookProgress',
+      );
+    });
+
+    test('RemoteBookProgress.charOffset 缺失默认 -1（不是 0）', () {
+      // -1 = 「host 没有精确字符偏移」，0 是合法的「在开头」。混淆会让恢复跳到开头。
+      expect(
+        RemoteBookProgress.fromJson(const <String, Object?>{}).charOffset,
+        -1,
+      );
+    });
+
+    test('RemoteDictionaryInfo / RemoteLocalAudioInfo / RemoteVideoEpisode',
+        () {
+      expectKeys(
+        const RemoteDictionaryInfo(name: 'n', type: 't').toJson(),
+        <String>{'name', 'type'},
+        what: 'RemoteDictionaryInfo',
+      );
+      expectKeys(
+        const RemoteLocalAudioInfo(displayName: 'd').toJson(),
+        <String>{'displayName'},
+        what: 'RemoteLocalAudioInfo',
+      );
+      expectKeys(
+        const RemoteVideoEpisode(index: 0, title: 't').toJson(),
+        <String>{'index', 'title'},
+        what: 'RemoteVideoEpisode',
+      );
+    });
+  });
+
+  group('round-trip：省略的键在 fromJson 侧还原成等价缺省', () {
+    test('RemoteBookInfo 最小实例 round-trip 不产生新键', () {
+      const RemoteBookInfo original =
+          RemoteBookInfo(title: 'T', hasContent: true);
+      final RemoteBookInfo back = RemoteBookInfo.fromJson(original.toJson());
+      expect(back.toJson(), original.toJson(),
+          reason: 'toJson→fromJson→toJson 必须是幂等的，否则同一本书在两端会写出不同 wire');
+    });
+
+    test('RemoteVideoInfo 最小实例 round-trip 不产生新键', () {
+      const RemoteVideoInfo original = RemoteVideoInfo(id: 'v', title: 'T');
+      final RemoteVideoInfo back = RemoteVideoInfo.fromJson(original.toJson());
+      expect(back.toJson(), original.toJson());
+    });
+
+    test('RemoteVideoInfo 播放列表 round-trip 保住 episodes/currentEpisode', () {
+      const RemoteVideoInfo original = RemoteVideoInfo(
+        id: 'v',
+        title: 'T',
+        episodes: <RemoteVideoEpisode>[
+          RemoteVideoEpisode(index: 0, title: 'a'),
+          RemoteVideoEpisode(index: 1, title: 'b'),
+        ],
+        currentEpisode: 1,
+      );
+      final RemoteVideoInfo back = RemoteVideoInfo.fromJson(original.toJson());
+      expect(back.episodes.length, 2);
+      expect(back.currentEpisode, 1);
+      expect(back.toJson(), original.toJson());
+    });
+  });
+}

--- a/hibiki/test/sync/remote_library_cache_test.dart
+++ b/hibiki/test/sync/remote_library_cache_test.dart
@@ -1,0 +1,226 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/remote_library_cache.dart';
+
+/// BUG-1175 根因守卫：远端库列表的 TTL 缓存 + in-flight 去重 + 显式失效。
+///
+/// 症状——每切一次页面（书架 / 视频 / 首页），互联对端的条目清单就被完整重拉一遍。
+/// 真根因：远端列表**没有任何缓存层**（只有封面图有磁盘缓存），而书架与视频页为了让
+/// 对端新增内容可见（BUG-992/994）各注册了「切回本 tab 就重拉」的监听器，顶层 tab
+/// 保活（BUG-750）省下的重建被原样加了回来。
+///
+/// 本文件锁住缓存本身的语义；页面接线由 `reader_remote_interconnect_test.dart` /
+/// `home_video_remote_interconnect_test.dart` 覆盖。
+void main() {
+  /// 可控时钟：TTL 相关断言不能依赖真实墙钟（既慢又 flaky）。
+  late int now;
+  late RemoteLibraryCache cache;
+
+  setUp(() {
+    now = 1000000;
+    cache = RemoteLibraryCache(
+      defaultTtl: const Duration(seconds: 60),
+      nowMs: () => now,
+    );
+  });
+
+  test('TTL 内第二次读命中缓存，不再调 fetch（切页面不重拉的核心）', () async {
+    int calls = 0;
+    Future<List<String>> fetch() async {
+      calls++;
+      return <String>['a'];
+    }
+
+    expect(await cache.read(key: 'books', fetch: fetch), <String>['a']);
+    expect(calls, 1);
+
+    now += 59 * 1000; // 仍在 60s TTL 内
+    expect(await cache.read(key: 'books', fetch: fetch), <String>['a']);
+    expect(calls, 1, reason: 'TTL 内必须命中缓存，不得再联网');
+  });
+
+  test('TTL 过期后重新取数（对端新增内容最终可见）', () async {
+    int calls = 0;
+    Future<List<String>> fetch() async => <String>['v${++calls}'];
+
+    expect(await cache.read(key: 'books', fetch: fetch), <String>['v1']);
+    now += 61 * 1000;
+    expect(await cache.read(key: 'books', fetch: fetch), <String>['v2'],
+        reason: 'TTL 过期必须重新取数，否则对端新增的书永远看不到');
+    expect(calls, 2);
+  });
+
+  test('forceRefresh 无条件穿透 TTL（下拉刷新语义）', () async {
+    int calls = 0;
+    Future<List<String>> fetch() async => <String>['v${++calls}'];
+
+    await cache.read(key: 'books', fetch: fetch);
+    expect(
+      await cache.read(key: 'books', fetch: fetch, forceRefresh: true),
+      <String>['v2'],
+    );
+    expect(calls, 2);
+  });
+
+  test('in-flight 去重：同 key 并发只打一枪，双方拿到同一结果', () async {
+    int calls = 0;
+    final Completer<List<String>> gate = Completer<List<String>>();
+    Future<List<String>> fetch() {
+      calls++;
+      return gate.future;
+    }
+
+    // 书架与首页 dashboard 同帧各问一次远端书清单。
+    final Future<List<String>> first = cache.read(key: 'books', fetch: fetch);
+    final Future<List<String>> second = cache.read(key: 'books', fetch: fetch);
+    expect(calls, 1, reason: '同 key 有请求在途时不得再发一枪');
+
+    gate.complete(<String>['shared']);
+    expect(await first, <String>['shared']);
+    expect(await second, <String>['shared']);
+  });
+
+  test('取数失败不缓存失败，异常原样上抛，下次读必重试', () async {
+    int calls = 0;
+    Future<List<String>> failing() async {
+      calls++;
+      throw StateError('offline');
+    }
+
+    await expectLater(
+      cache.read(key: 'books', fetch: failing),
+      throwsA(isA<StateError>()),
+    );
+    expect(cache.isFresh('books'), isFalse);
+
+    await expectLater(
+      cache.read(key: 'books', fetch: failing),
+      throwsA(isA<StateError>()),
+    );
+    expect(calls, 2, reason: '失败不得被当成缓存值，下一次读必须重试');
+  });
+
+  test('取数失败保留上一次成功值（离线仍显示最后一次已知列表）', () async {
+    bool shouldFail = false;
+    Future<List<String>> fetch() async {
+      if (shouldFail) throw StateError('offline');
+      return <String>['ok'];
+    }
+
+    await cache.read(key: 'books', fetch: fetch);
+    now += 61 * 1000; // 过期
+    shouldFail = true;
+    await expectLater(
+      cache.read(key: 'books', fetch: fetch),
+      throwsA(isA<StateError>()),
+    );
+
+    // 失败没有刷新 fetchedAt，也没有抹掉旧值：调用方可继续用上一次快照渲染。
+    shouldFail = false;
+    expect(await cache.read(key: 'books', fetch: fetch), <String>['ok']);
+  });
+
+  test('invalidate 作废单 key，不牵连其它域', () async {
+    int bookCalls = 0;
+    int videoCalls = 0;
+
+    await cache.read(
+      key: RemoteLibraryCacheKeys.books,
+      fetch: () async => <String>['b${++bookCalls}'],
+    );
+    await cache.read(
+      key: RemoteLibraryCacheKeys.videos,
+      fetch: () async => <String>['v${++videoCalls}'],
+    );
+
+    cache.invalidate(RemoteLibraryCacheKeys.books);
+    expect(cache.isFresh(RemoteLibraryCacheKeys.books), isFalse);
+    expect(cache.isFresh(RemoteLibraryCacheKeys.videos), isTrue,
+        reason: '失效一个域不得连带清掉别的域');
+
+    await cache.read(
+      key: RemoteLibraryCacheKeys.books,
+      fetch: () async => <String>['b${++bookCalls}'],
+    );
+    expect(bookCalls, 2);
+    expect(videoCalls, 1);
+  });
+
+  test('invalidateAll 清空全部（换对端 / 管理互联源）', () async {
+    await cache.read(
+      key: RemoteLibraryCacheKeys.books,
+      fetch: () async => <String>['b'],
+    );
+    await cache.read(
+      key: RemoteLibraryCacheKeys.videos,
+      fetch: () async => <String>['v'],
+    );
+
+    cache.invalidateAll();
+    expect(cache.isFresh(RemoteLibraryCacheKeys.books), isFalse);
+    expect(cache.isFresh(RemoteLibraryCacheKeys.videos), isFalse);
+  });
+
+  test('在途请求被 invalidate 后，其结果不得写回缓存（generation 守卫）', () async {
+    final Completer<List<String>> slow = Completer<List<String>>();
+    final Future<List<String>> pending = cache.read(
+      key: 'books',
+      fetch: () => slow.future,
+    );
+
+    // 请求还在飞的时候换了对端 → 这一份结果已经不属于当前对端。
+    cache.invalidateAll();
+    slow.complete(<String>['stale-peer']);
+    expect(await pending, <String>['stale-peer'], reason: '发起方仍拿到自己那次取数的结果');
+    expect(cache.isFresh('books'), isFalse,
+        reason: '过时结果不得写回缓存，否则 TTL 内会拿上一台 host 的清单渲染');
+  });
+
+  test('forceRefresh 期间的旧 in-flight 结果不覆盖新结果', () async {
+    final Completer<List<String>> slowOld = Completer<List<String>>();
+    final Completer<List<String>> fastNew = Completer<List<String>>();
+
+    final Future<List<String>> old = cache.read(
+      key: 'books',
+      fetch: () => slowOld.future,
+    );
+    final Future<List<String>> fresh = cache.read(
+      key: 'books',
+      fetch: () => fastNew.future,
+      forceRefresh: true,
+    );
+
+    fastNew.complete(<String>['new']);
+    expect(await fresh, <String>['new']);
+
+    // 旧请求后到——不得把缓存打回旧值。
+    slowOld.complete(<String>['old']);
+    expect(await old, <String>['old']);
+
+    final List<String> cached = await cache.read(
+      key: 'books',
+      fetch: () async => throw StateError('不该重新取数'),
+    );
+    expect(cached, <String>['new'], reason: '后到的旧请求不得覆盖 forceRefresh 拿到的新结果');
+  });
+
+  test('不同 limit 的活动流分槽，互不污染', () async {
+    await cache.read(
+      key: RemoteLibraryCacheKeys.activity(200),
+      fetch: () async => List<int>.generate(200, (int i) => i),
+    );
+    final List<int> small = await cache.read(
+      key: RemoteLibraryCacheKeys.activity(20),
+      fetch: () async => List<int>.generate(20, (int i) => i),
+    );
+    expect(small.length, 20, reason: 'limit 不同即结果集不同，共用一槽会把首页的 200 条截断成 20 条');
+  });
+
+  test('互联视频与云视频分属不同 key（元素类型不同，共用会 cast 崩）', () {
+    expect(
+      RemoteLibraryCacheKeys.videos,
+      isNot(RemoteLibraryCacheKeys.cloudVideos),
+    );
+  });
+}

--- a/hibiki/test/sync/remote_library_cache_test.dart
+++ b/hibiki/test/sync/remote_library_cache_test.dart
@@ -217,10 +217,16 @@ void main() {
     expect(small.length, 20, reason: 'limit 不同即结果集不同，共用一槽会把首页的 200 条截断成 20 条');
   });
 
-  test('互联视频与云视频分属不同 key（元素类型不同，共用会 cast 崩）', () {
-    expect(
+  test('各媒体域分属不同 key，互不覆盖', () {
+    // 互联与云盘的视频清单**共用** videos 一个槽（TODO-2119 后两种源都实现
+    // RemoteVideoSource，元素统一是 RemoteVideoInfo）；域与域之间必须分开。
+    final Set<String> keys = <String>{
+      RemoteLibraryCacheKeys.books,
       RemoteLibraryCacheKeys.videos,
-      isNot(RemoteLibraryCacheKeys.cloudVideos),
-    );
+      RemoteLibraryCacheKeys.audiobooks,
+      RemoteLibraryCacheKeys.dictionaries,
+      RemoteLibraryCacheKeys.activity(200),
+    };
+    expect(keys.length, 5, reason: '域 key 不得重名，否则一个域的清单会盖掉另一个域');
   });
 }

--- a/hibiki/test/sync/sync_orchestrator_video_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_video_test.dart
@@ -144,7 +144,7 @@ void main() {
       final CloudRemoteVideoClient client =
           CloudRemoteVideoClient(backend: store);
       final List<RemoteVideoManifestEntry> entries =
-          await client.listRemoteVideos();
+          await client.listRemoteVideoManifest();
       expect(entries.length, 1);
       final RemoteVideoManifestEntry e = entries.single;
       expect(e.uid, uid);
@@ -206,7 +206,7 @@ void main() {
       final CloudRemoteVideoClient client =
           CloudRemoteVideoClient(backend: store);
       final RemoteVideoManifestEntry e =
-          (await client.listRemoteVideos()).single;
+          (await client.listRemoteVideoManifest()).single;
       expect(e.coverAsset, isNotNull);
 
       final File cover = File('${tmp.path}/pulled_cover.jpg');
@@ -278,10 +278,10 @@ void main() {
           .syncVideoAssets(report);
       expect(report.errors, isEmpty, reason: report.errors.join(' | '));
 
-      final Set<String> uids =
-          (await CloudRemoteVideoClient(backend: store).listRemoteVideos())
-              .map((RemoteVideoManifestEntry e) => e.uid)
-              .toSet();
+      final Set<String> uids = (await CloudRemoteVideoClient(backend: store)
+              .listRemoteVideoManifest())
+          .map((RemoteVideoManifestEntry e) => e.uid)
+          .toSet();
       expect(uids, containsAll(<String>['video/FromA', 'video/FromB']),
           reason: 'upload-only union must not drop the remote-only entry');
     });
@@ -357,7 +357,8 @@ void main() {
       await _orchestrator(db, backend, tmp, syncVideoFiles: true)
           .syncVideoAssets(SyncRunReport());
       final RemoteVideoManifestEntry e1 =
-          (await CloudRemoteVideoClient(backend: store).listRemoteVideos())
+          (await CloudRemoteVideoClient(backend: store)
+                  .listRemoteVideoManifest())
               .single;
       expect(e1.coverAsset, isNotNull);
 
@@ -368,7 +369,8 @@ void main() {
       await _orchestrator(db, backend, tmp, syncVideoFiles: true)
           .syncVideoAssets(SyncRunReport());
       final RemoteVideoManifestEntry e2 =
-          (await CloudRemoteVideoClient(backend: store).listRemoteVideos())
+          (await CloudRemoteVideoClient(backend: store)
+                  .listRemoteVideoManifest())
               .single;
       expect(e2.coverAsset, e1.coverAsset,
           reason:
@@ -429,7 +431,7 @@ void main() {
       final FakeAssetStore store = FakeAssetStore();
       final CloudRemoteVideoClient client =
           CloudRemoteVideoClient(backend: store);
-      expect(await client.listRemoteVideos(), isEmpty);
+      expect(await client.listRemoteVideoManifest(), isEmpty);
     });
 
     test('download of unknown uid throws SyncBackendError', () async {


### PR DESCRIPTION
## 抢救说明

这些提交此前**只存在于本地一个未推送的 worktree 分支** `worktree-fix-interconnect-cache-unify` 上：

- 不是 `origin/develop` 的祖先（`git merge-base --is-ancestor` 全部失败）
- 没有对应远端分支、没有 PR
- 看板上曾被记为「已在 PR#490 修复／部分落地」——**核实为错误**；PR#490 的分支 `fix/interconnect-cache-unify` 相对 develop 零领先提交

该 worktree 一旦被清理，这些提交会永久丢失。本 PR 以**原始 SHA 原样推送**（未 rebase、未 squash），先保命。

## 抢救出的提交（拓扑顺序，旧→新）

| SHA | 标题 |
|---|---|
| `963ebf99d` | fix(sync): 互联远端清单加共享 TTL 缓存，切页面不再全额重拉 (BUG-1175~1178) |
| `8dd8edebb` | refactor(sync): 互联 POST 传输层收敛成一份 InterconnectPostTransport |
| `7894e6c2c` | refactor(sync): 远端视频源按能力分级，视频页双 client 分支归一 (TODO-2119) |
| `0be4c99f8` | refactor(sync): 互联 server 资产端点收敛 + wire format 黄金守卫 (TODO-2120) |
| `1c4fa3bf9` | refactor(sync): 互联 client 列清单骨架收敛成一份 _listRemote (TODO-2120) |

**注意：实际是 5 个提交，不是 3 个。** 最初点名的三个（`7894e6c2c` / `0be4c99f8` / `1c4fa3bf9`）依赖前两个前置提交，无法单独摘出。

merge-base = `e83a9e77b`（PR#480 的合并点，是 develop 的祖先），develop 已前进 63 个提交。合并前需 rebase 到最新 develop 并重跑验证。

## 状态

Draft。审查进行中，重点：wire 格式是否被静默改变、路径穿越校验收敛后的严格度、降级/超时是否仍逐域显式。
