### PR TITLE
feat: 底栏游戏移到视频后 + 统计口径纳入漫画/视频/游戏（schema v60）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@
 - reader source：`hibiki/lib/src/media/sources/reader_hibiki_source.dart`（`ReaderHibikiSource`）。
 - 阅读器 JS/CSS：`hibiki/lib/src/reader/`（17 个 JS/CSS 注入封装，`reader_pagination_scripts.dart` 等）；JS 桥接全局是 `window.hoshiReader`（历史命名，是真实符号，勿改）。
 - 全局状态：`hibiki/lib/src/models/app_model.dart`（`AppModel`，~5150 行，初始化流程 + 子系统委托核心，改前先理解）。
-- Drift 数据库：`packages/hibiki_core/lib/src/database/database.dart` 和 `tables.dart`（schema v59，53 张表，WAL）。
+- Drift 数据库：`packages/hibiki_core/lib/src/database/database.dart` 和 `tables.dart`（schema v60，53 张表，WAL）。
 - 词典：Dart 封装 `packages/hibiki_dictionary/lib/src/engine/hoshidicts.dart` + FFI 绑定 `lib/src/ffi/hoshidicts_ffi_bindings.dart`；C++ 引擎源码全在 `native/hoshidicts/`（包内已无 C++），`hoshidicts_external/` 是 vendored 第三方，上游同步基线见 `native/hoshidicts/UPSTREAM.md`。
 - 有声书：`packages/hibiki_audio/` + `hibiki/lib/src/media/audiobook/`（导入入口 `book_import_dialog.dart` / `audiobook_import_dialog.dart`）。
 - 互联/同步：`hibiki/lib/src/sync/`（`interconnect_*.dart`、`aggregate_sync_service.dart`、`backup_*`）。
@@ -44,7 +44,7 @@
 - Flutter 版本分两处：本地钉 `.fvmrc` = `3.41.6`（pubspec `flutter: "^3.41.6"`），CI workflows 用 `3.44.0`；Dart SDK 约束 `>=3.5.0 <4.0.0`。最低 Android API 24，`compileSdk 36` / `targetSdk 35`。
 - 状态管理 Riverpod；音频 just_audio（桌面经 just_audio_media_kit）；录音 record 6.0.0；视频播放走 **media_kit**（third_party vendored 全套）+ youtube_explode_dart。
 - torrent 走内部包 `packages/hibiki_torrent`（libtorrent 2.x C ABI FFI，native 在 `native/hibiki_torrent/`；Windows 预编译 DLL 随包，缺失时回退外接 qBittorrent）。
-- 主存储是 Drift SQLite（`HibikiDatabase`，schema v59），偏好落 Drift `preferences` 表 + `profile_settings` 每 Profile 快照。**已无 Isar/Hive 依赖**；旧注释里的 Isar/Hive 不代表当前事实，先查代码再判断。
+- 主存储是 Drift SQLite（`HibikiDatabase`，schema v60），偏好落 Drift `preferences` 表 + `profile_settings` 每 Profile 快照。**已无 Isar/Hive 依赖**；旧注释里的 Isar/Hive 不代表当前事实，先查代码再判断。
 - EPUB 阅读器走 reader_hibiki 实现（见仓库地图）。`reader_ttu` key、`setTtu*` 方法、`ttu_*` i18n 只是旧数据兼容残留，不代表还有 TTU 阅读器；没有迁移方案别随手改这些持久化 key。（旧文档提过的 `ttuBookId` 列在当前 schema 已不存在，只活在迁移阶梯里。）
 - 旧 TTU 迁移代码已移除（develop `90c37b472`：`TtuMigrationServer` / `TtuIdbReader` / `assets/ttu-ebook-reader` 均已删除）；只剩上述命名残留作旧数据兼容。阅读器渲染/交互问题按 reader_hibiki 路径修，不要去上游 ttu fork 仓库改。
 - 词典导入/查询核心走 `hoshidicts` C++ FFI；格式 UI 或旧 Dart format 类不一定是真实导入路径。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46291 (2723 per locale)
+/// Strings: 46308 (2724 per locale)
 ///
-/// Built on 2026-07-28 at 11:26 UTC
+/// Built on 2026-07-28 at 11:47 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2434,8 +2434,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get stat_goal_reached => 'Goal reached';
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
   String get stat_goal_set => 'Set goal';
   String get stat_goal_unit_chars => 'chars';
   String get stat_goal_weekly => 'Weekly goal';
@@ -3661,6 +3659,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Subtitles: no match for this pack';
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  String get stat_source_breakdown => 'By source';
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -7719,9 +7719,6 @@ class _StringsAr extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -9893,6 +9890,10 @@ class _StringsAr extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -13994,9 +13995,6 @@ class _StringsDe extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -16193,6 +16191,10 @@ class _StringsDe extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -20302,9 +20304,6 @@ class _StringsEs extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -22509,6 +22508,10 @@ class _StringsEs extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -26629,9 +26632,6 @@ class _StringsFr extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -28836,6 +28836,10 @@ class _StringsFr extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -32907,9 +32911,6 @@ class _StringsId extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -35092,6 +35093,10 @@ class _StringsId extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -39194,9 +39199,6 @@ class _StringsIt extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -41394,6 +41396,10 @@ class _StringsIt extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -45389,9 +45395,6 @@ class _StringsJa extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -47513,6 +47516,10 @@ class _StringsJa extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -51505,9 +51512,6 @@ class _StringsKo extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -53634,6 +53638,10 @@ class _StringsKo extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -57721,9 +57729,6 @@ class _StringsNl extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -59916,6 +59921,10 @@ class _StringsNl extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -64014,9 +64023,6 @@ class _StringsPtBr extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -66211,6 +66217,10 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -70300,9 +70310,6 @@ class _StringsRu extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -72490,6 +72497,10 @@ class _StringsRu extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -76540,9 +76551,6 @@ class _StringsTh extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -78717,6 +78725,10 @@ class _StringsTh extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -82793,9 +82805,6 @@ class _StringsTr extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -84976,6 +84985,10 @@ class _StringsTr extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -89044,9 +89057,6 @@ class _StringsVi extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -91220,6 +91230,10 @@ class _StringsVi extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 // Path: <root>
@@ -95016,8 +95030,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String stat_goal_recent_average({required Object n}) => '近 7 日日均 ${n} 字';
   @override
-  String get stat_goal_scope_hint => '口径：阅读 + 视频字幕 + 游戏文本的全部字符数合计';
-  @override
   String get stat_goal_set => '设定目标';
   @override
   String get stat_goal_unit_chars => '字';
@@ -97023,6 +97035,10 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       '内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。';
+  @override
+  String get stat_source_breakdown => '各来源';
+  @override
+  String stat_format_pages({required Object n}) => '${n} 页';
 }
 
 // Path: <root>
@@ -100972,9 +100988,6 @@ class _StringsZhHk extends _StringsEn {
   String stat_goal_recent_average({required Object n}) =>
       'Last 7 days: ${n} chars/day on average';
   @override
-  String get stat_goal_scope_hint =>
-      'Counts all characters combined: reading + video subtitles + game text.';
-  @override
   String get stat_goal_set => 'Set Goal';
   @override
   String get stat_goal_unit_chars => 'chars';
@@ -103063,6 +103076,10 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get download_backend_desktop_only_note =>
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+  @override
+  String get stat_source_breakdown => 'By source';
+  @override
+  String stat_format_pages({required Object n}) => '${n} pages';
 }
 
 /// Flat map(s) containing all translations.
@@ -106710,8 +106727,6 @@ extension on _StringsEn {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set goal';
       case 'stat_goal_unit_chars':
@@ -108642,6 +108657,10 @@ extension on _StringsEn {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -112287,8 +112306,6 @@ extension on _StringsAr {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -114219,6 +114236,10 @@ extension on _StringsAr {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -117878,8 +117899,6 @@ extension on _StringsDe {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -119817,6 +119836,10 @@ extension on _StringsDe {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -123476,8 +123499,6 @@ extension on _StringsEs {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -125414,6 +125435,10 @@ extension on _StringsEs {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -129075,8 +129100,6 @@ extension on _StringsFr {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -131017,6 +131040,10 @@ extension on _StringsFr {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -134669,8 +134696,6 @@ extension on _StringsId {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -136602,6 +136627,10 @@ extension on _StringsId {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -140259,8 +140288,6 @@ extension on _StringsIt {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -142202,6 +142229,10 @@ extension on _StringsIt {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -145838,8 +145869,6 @@ extension on _StringsJa {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -147764,6 +147793,10 @@ extension on _StringsJa {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -151403,8 +151436,6 @@ extension on _StringsKo {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -153330,6 +153361,10 @@ extension on _StringsKo {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -156986,8 +157021,6 @@ extension on _StringsNl {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -158923,6 +158956,10 @@ extension on _StringsNl {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -162577,8 +162614,6 @@ extension on _StringsPtBr {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -164513,6 +164548,10 @@ extension on _StringsPtBr {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -168170,8 +168209,6 @@ extension on _StringsRu {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -170108,6 +170145,10 @@ extension on _StringsRu {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -173754,8 +173795,6 @@ extension on _StringsTh {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -175687,6 +175726,10 @@ extension on _StringsTh {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -179338,8 +179381,6 @@ extension on _StringsTr {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -181275,6 +181316,10 @@ extension on _StringsTr {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -184925,8 +184970,6 @@ extension on _StringsVi {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -186858,6 +186901,10 @@ extension on _StringsVi {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }
@@ -190481,8 +190528,6 @@ extension on _StringsZhCn {
         return '已达成';
       case 'stat_goal_recent_average':
         return ({required Object n}) => '近 7 日日均 ${n} 字';
-      case 'stat_goal_scope_hint':
-        return '口径：阅读 + 视频字幕 + 游戏文本的全部字符数合计';
       case 'stat_goal_set':
         return '设定目标';
       case 'stat_goal_unit_chars':
@@ -192395,6 +192440,10 @@ extension on _StringsZhCn {
         return '字幕：未匹配到（可手动补）';
       case 'download_backend_desktop_only_note':
         return '内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。';
+      case 'stat_source_breakdown':
+        return '各来源';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} 页';
       default:
         return null;
     }
@@ -196029,8 +196078,6 @@ extension on _StringsZhHk {
       case 'stat_goal_recent_average':
         return ({required Object n}) =>
             'Last 7 days: ${n} chars/day on average';
-      case 'stat_goal_scope_hint':
-        return 'Counts all characters combined: reading + video subtitles + game text.';
       case 'stat_goal_set':
         return 'Set Goal';
       case 'stat_goal_unit_chars':
@@ -197952,6 +197999,10 @@ extension on _StringsZhHk {
         return 'Subtitles: no match for this pack';
       case 'download_backend_desktop_only_note':
         return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
+      case 'stat_source_breakdown':
+        return 'By source';
+      case 'stat_format_pages':
+        return ({required Object n}) => '${n} pages';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal 字",
   "stat_goal_reached": "已达成",
   "stat_goal_recent_average": "近 7 日日均 $n 字",
-  "stat_goal_scope_hint": "口径：阅读 + 视频字幕 + 游戏文本的全部字符数合计",
   "stat_goal_set": "设定目标",
   "stat_goal_unit_chars": "字",
   "stat_goal_weekly": "每周目标",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "字幕将在下载完成后按包内实际文件配对",
   "anime_download_subs_pending": "字幕：待下载完成后配对",
   "anime_download_subs_unmatched": "字幕：未匹配到（可手动补）",
-  "download_backend_desktop_only_note": "内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。"
+  "download_backend_desktop_only_note": "内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。",
+  "stat_source_breakdown": "各来源",
+  "stat_format_pages": "$n 页"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1780,7 +1780,6 @@
   "stat_goal_progress": "$read / $goal chars",
   "stat_goal_reached": "Goal reached",
   "stat_goal_recent_average": "Last 7 days: $n chars/day on average",
-  "stat_goal_scope_hint": "Counts all characters combined: reading + video subtitles + game text.",
   "stat_goal_set": "Set Goal",
   "stat_goal_unit_chars": "chars",
   "stat_goal_weekly": "Weekly Goal",
@@ -2721,5 +2720,7 @@
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
-  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
+  "stat_source_breakdown": "By source",
+  "stat_format_pages": "$n pages"
 }

--- a/hibiki/lib/src/media/manga/manga_reading_stats.dart
+++ b/hibiki/lib/src/media/manga/manga_reading_stats.dart
@@ -1,0 +1,49 @@
+import 'package:hibiki/src/epub/epub_book.dart';
+import 'package:hibiki/src/media/manga/mokuro_payload.dart';
+
+/// 漫画阅读的**字数**记账（统计口径接入）。
+///
+/// 背景：漫画此前只往 `reading_statistics` 落时长，`charsRead` 恒 0——理由是
+/// 「页数绝不能塞进 charsRead」。那个理由仍然成立，但漫画并非没有文本：mokuro /
+/// 内置 OCR 每页都给出 [MokuroBlock.lines]，那才是用户真正读到的字。用它计数，
+/// 漫画就能和 EPUB / 视频字幕 / 游戏文本一样进同一个字数口径（首页每日目标、
+/// 热力图、阅读统计页），而不是永远显示 0 字。
+///
+/// 口径与 EPUB 完全一致：走 [japaneseCharCount]（只数假名/汉字/字母数字，剔除
+/// 标点、括号、空白），所以两种书的「字数」「阅读速度」可直接相加、直接比较。
+///
+/// 去重语义：以**页**为记账单位，一页在同一次阅读会话里只计一次（[counted]
+/// 集合），来回翻页刷不出字数或页数。跳读没停留过的页不计——宁可少算，不虚高。
+
+/// 单页 OCR 文本的实义字符数。无 OCR（纯图页 / 尚未识别）自然为 0。
+int mangaPageCharCount(MokuroImage page) {
+  final StringBuffer buffer = StringBuffer();
+  for (final MokuroBlock block in page.blocks) {
+    for (final String line in block.lines) {
+      buffer.write(line);
+    }
+  }
+  return japaneseCharCount(buffer.toString());
+}
+
+/// 把 [pageIndices] 中**尚未记账**的页计入 [counted]，返回本次新增的字符数与页数。
+///
+/// 字数与页数是两个独立量纲，一起返回、分别落库（`charsRead` / `pagesRead`）：漫画
+/// 「今天读了 3200 字 / 48 页」两个都要真，页数绝不塞进字数。越界页码直接忽略
+/// （布局重建 / payload 换书的竞态下可能短暂出现）。调用方在每次页码推进时调用，
+/// flush 时把累计值随时长一起落库。
+({int chars, int pages}) mangaAccumulateReadingStats({
+  required MokuroPayload payload,
+  required Iterable<int> pageIndices,
+  required Set<int> counted,
+}) {
+  int chars = 0;
+  int pages = 0;
+  for (final int index in pageIndices) {
+    if (index < 0 || index >= payload.images.length) continue;
+    if (!counted.add(index)) continue;
+    chars += mangaPageCharCount(payload.images[index]);
+    pages++;
+  }
+  return (chars: chars, pages: pages);
+}

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -21,6 +21,7 @@ import 'package:hibiki/src/media/manga/manga_ocr_background_job.dart';
 import 'package:hibiki/src/ocr/manga_ocr_service.dart';
 import 'package:hibiki/src/media/manga/manga_overlay_html.dart';
 import 'package:hibiki/src/media/manga/manga_reading_mode.dart';
+import 'package:hibiki/src/media/manga/manga_reading_stats.dart';
 import 'package:hibiki/src/media/manga/manga_spread_model.dart';
 import 'package:hibiki/src/media/manga/mokuro_payload.dart';
 import 'package:hibiki/src/media/manga/ocr/manga_ocr_cache_recovery.dart';
@@ -245,7 +246,8 @@ Future<int?> showMangaPageJumpDialog(
 /// 页图 + 透明 OCR 覆盖层在 WebView 里渲染（文档由 [mangaWindowDocument] 生成），
 /// 汇入同一批共享设施：[BaseSourcePageState.searchDictionaryResult]（查词弹窗）、
 /// [ReaderPositionRepository]（阅读位置，sectionIndex=0-based 页码）、
-/// [ReadingTimeTracker]（时长统计，charsRead 恒 0）、[AnkiMiningContext]（制卡，
+/// [ReadingTimeTracker]（时长统计；v60 起同时落 OCR 字数与页数，见
+/// [mangaAccumulateReadingStats]）、[AnkiMiningContext]（制卡，
 /// 卡图=当前页图文件路径）。
 ///
 /// 身份统一 `hoshi://book/<bookKey>`（无漫画专属 scheme 特例），关书自动同步天然工作。
@@ -562,6 +564,12 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   ReadingTimeTracker? _readingTimeTracker;
   DateTime _sessionStartTime = DateTime.now();
 
+  /// 本次会话尚未落库的 OCR 字符数与页数，以及已记账过的页（同一页只计一次，来回
+  /// 翻页刷不出数）。字数口径与 EPUB 同源，见 [mangaAccumulateReadingStats]。
+  int _sessionCharsRead = 0;
+  int _sessionPagesRead = 0;
+  final Set<int> _sessionCountedPages = <int>{};
+
   // 密集 OCR 命中层只保留当前 spread；图片页本身全部留在稳定的 lazy strip。
   static const int _kWindowRadius = 0;
 
@@ -786,6 +794,8 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       _lastSavedFraction = saved != null ? restoredFraction : -1;
     });
     _pageNotifier.value = _currentPage;
+    // 首屏页也要进字数/页数账：开书直接停在恢复位置时不会再有 _recordProgress。
+    _countVisiblePages();
     // A cancelled/background task intentionally does not replace manga.json,
     // but every atomic page cache is already safe to use. Restore those pages
     // after the first paint so opening a large book stays fast and both local
@@ -1695,11 +1705,33 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     );
     _currentPage = page;
     _pageNotifier.value = page;
+    _countVisiblePages();
     // 600ms debounce：连续翻页/滚动只落最后一次。
     _progressDebounce?.cancel();
     _progressDebounce = Timer(const Duration(milliseconds: 600), () {
       unawaited(_persistPosition(page, fraction));
     });
+  }
+
+  /// 把当前可见页记进本会话的字数/页数账（每页只记一次）。
+  ///
+  /// spread 模式当前 entry 的两页都算看过；webtoon 整本单文档竖滚，只有真正成为
+  /// 「当前页」的那页算读过（快速滚过没停留的页不计，宁可少算不虚高）。
+  void _countVisiblePages() {
+    final MokuroPayload? payload = _payload;
+    if (payload == null) return;
+    final bool isWebtoon = _mode == MangaReadingMode.webtoon;
+    final List<int> pages =
+        !isWebtoon && _currentSpread >= 0 && _currentSpread < _spreads.length
+            ? _spreads[_currentSpread].pageIndices
+            : <int>[_currentPage];
+    final ({int chars, int pages}) added = mangaAccumulateReadingStats(
+      payload: payload,
+      pageIndices: pages,
+      counted: _sessionCountedPages,
+    );
+    _sessionCharsRead += added.chars;
+    _sessionPagesRead += added.pages;
   }
 
   Future<void> _persistPosition(int page, double fraction) async {
@@ -1745,11 +1777,14 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     await _flushReadingStats();
   }
 
-  /// 落本次会话的阅读时长 + 首页「学习活动」事件。
+  /// 落本次会话的阅读时长 + OCR 字数 + 页数 + 首页「学习活动」事件。
   ///
   /// 与 PDF 同款纪律、刻意不复用 EPUB 的实现：EPUB 那条以 `charsRead <= 0` 早退，
-  /// 漫画无字数会整段被丢。这里以**时长**为触发条件，`charsRead` 恒 0——「页数」
-  /// 绝不塞进 charsRead，否则污染统计页「字数」口径与派生指标。
+  /// 漫画只有时长没字数的那些段会整段被丢。这里仍以**时长**为触发条件。
+  ///
+  /// v60 起漫画同时落两个独立量纲：`charsRead` = 已读页的 OCR 实义字符数（口径与
+  /// EPUB 同源），`pagesRead` = 已读页数。页数仍然绝不塞进 charsRead——那会污染
+  /// 字数口径与阅读速度；两者分列，统计页分别展示。
   Future<void> _flushReadingStats() async {
     final EpubBookRow? row = _bookRow;
     if (row == null) return;
@@ -1761,13 +1796,20 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         now.subtract(Duration(milliseconds: elapsedMs)), now)) {
       return;
     }
+    // 未落库的字数/页数先取走再清零：落库失败时不重复计（下一段仍会记新翻的页），
+    // 也不会因异常把同一批重复写进 DB。
+    final int charsRead = _sessionCharsRead;
+    final int pagesRead = _sessionPagesRead;
+    _sessionCharsRead = 0;
+    _sessionPagesRead = 0;
     final String dateKey = statDateKey(now);
     try {
       await appModel.database.addReadingStatistic(
         title: row.title,
         dateKey: dateKey,
-        charsRead: 0,
+        charsRead: charsRead,
         timeMs: elapsedMs,
+        pagesRead: pagesRead,
       );
       await appModel.database.addActivityEvent(
         eventType: kActivityRead,
@@ -1777,7 +1819,7 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         dateKey: dateKey,
         timestampMs: now.millisecondsSinceEpoch,
         durationMs: elapsedMs,
-        charsDelta: 0,
+        charsDelta: charsRead,
       );
     } catch (e, stack) {
       ErrorLogService.instance

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -199,10 +199,8 @@ class _DailyGoalDialogState extends State<_DailyGoalDialog> {
               keyboardType: TextInputType.number,
               decoration: InputDecoration(
                 labelText: t.stat_goal_daily,
-                // 单位 + 口径：目标是「每天多少字」，且计入阅读/视频字幕/游戏文本。
+                // 单位：目标是「每天多少字」。口径说明行按用户要求删除。
                 suffixText: t.stat_goal_unit_chars,
-                helperText: t.stat_goal_scope_hint,
-                helperMaxLines: 3,
               ),
             ),
             if (widget.recentDailyAverage > 0) ...<Widget>[
@@ -1411,7 +1409,8 @@ class _HomeDashboardPageState
     final int goal = ref.read(appProvider).readingGoalDailyChars;
     if (goal <= 0) {
       // BUG-1073 病灶 2：此前是热力图下方孤零零一个左对齐按钮。改成与已设目标态
-      // 同构的一整行（图标 + 标签 + 口径说明 + 右侧入口），视觉上属于这张卡。
+      // 同构的一整行（图标 + 标签 + 右侧入口），视觉上属于这张卡。口径说明按用户要求
+      // 删除，标签退回「每日目标」本名。
       return Padding(
         padding: EdgeInsets.symmetric(vertical: tokens.spacing.gap / 2),
         child: Row(
@@ -1424,7 +1423,7 @@ class _HomeDashboardPageState
             SizedBox(width: tokens.spacing.gap),
             Expanded(
               child: Text(
-                t.stat_goal_scope_hint,
+                t.stat_goal_daily,
                 maxLines: 2,
                 overflow: TextOverflow.ellipsis,
                 style: tokens.type.metadata,

--- a/hibiki/lib/src/pages/implementations/home_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_page.dart
@@ -43,8 +43,8 @@ import 'package:hibiki/src/shortcuts/shortcut_action.dart';
 /// 顶层 tab 的逻辑身份（取代写死的整数索引 0/1/2）。条件 tab（video/downloads 常驻、
 /// games 仅 Windows）用枚举身份而非位置来切换/路由——插入条件 tab 不会再打乱「设置/词典」
 /// 的索引（消除 `==2` / `case 1/2` / `%3` 这类特殊情况）。底栏/侧栏只在渲染层把身份映射
-/// 成位置。games（galgame 库）紧邻设置之前。顶层 texthooker tab 已删（galgame 捕获工作台
-/// 现内嵌于 games tab，会话见 [GalHookSessionController]）。
+/// 成位置。games（galgame 库）紧跟在 video 之后。顶层 texthooker tab 已删（galgame 捕获
+/// 工作台现内嵌于 games tab，会话见 [GalHookSessionController]）。
 enum HomeTab {
   home,
   books,
@@ -59,7 +59,8 @@ enum HomeTab {
 
 /// 纯函数：给定视频开关与游戏库开关，返回可见顶层 tab 的**视觉顺序**——视频固定插在书架
 /// 与词典之间（用户要求「在书架和词典管理中间」），games（galgame 库）仅在开启时出现，
-/// 位置固定在词典与设置之间。提取成顶层函数便于单测条件插入与顺序，不必实例化整个
+/// 位置固定紧跟 video 之后（用户要求「底栏里把游戏移动到视频后面」，与书/漫画/视频/游戏
+/// 四类媒体入口连成一段）。提取成顶层函数便于单测条件插入与顺序，不必实例化整个
 /// [HomePage]。底栏/侧栏的位置索引由此列表导出。
 List<HomeTab> homeActiveTabs({
   required bool videoEnabled,
@@ -71,11 +72,11 @@ List<HomeTab> homeActiveTabs({
       HomeTab.books,
       HomeTab.manga,
       if (videoEnabled) HomeTab.video,
+      if (gamesEnabled) HomeTab.games,
       // 下载 tab 恒在（统一下载中心）：除番剧 torrent 外还承载通用磁力（书）与
-      // 漫画「在线目录」卷下载队列，不再随视频开关隐藏；位置在视频（若开）之后。
+      // 漫画「在线目录」卷下载队列，不再随视频开关隐藏；位置在视频/游戏之后。
       HomeTab.downloads,
       HomeTab.dictionaries,
-      if (gamesEnabled) HomeTab.games,
       // 浏览器扩展管理（安装引导 + 连接检测 + 版本）独立成页，仅桌面出现（手机浏览器
       // 不支持加载未解压扩展，故按平台而非实验开关门控），位置紧邻设置之前。
       if (browserExtensionEnabled) HomeTab.browserExtension,
@@ -592,10 +593,10 @@ class _HomePageState extends BasePageState<HomePage>
     return KeyEventResult.ignored;
   }
 
-  /// 当前可见的顶层 tab：首页 → 书架 → 视频 → 下载 → 词典 → 游戏 → 设置。视频 tab
-  /// 已毕业为常驻（位于书架与词典之间）；games（galgame 库）仅 Windows 桌面出现（galgame
-  /// 引擎-hook 注入本就 Windows-only，故以平台而非实验开关门控，默认可见），位于词典与设置
-  /// 之间。底栏/侧栏的位置索引由此列表导出。
+  /// 当前可见的顶层 tab：首页 → 书架 → 漫画 → 视频 → 游戏 → 下载 → 词典 → 设置。视频
+  /// tab 已毕业为常驻（位于书架与词典之间）；games（galgame 库）仅 Windows 桌面出现
+  /// （galgame 引擎-hook 注入本就 Windows-only，故以平台而非实验开关门控，默认可见），
+  /// 紧跟视频之后。底栏/侧栏的位置索引由此列表导出。
   List<HomeTab> _activeTabs() => homeActiveTabs(
         videoEnabled: true,
         gamesEnabled: Platform.isWindows,

--- a/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
@@ -7,6 +7,7 @@ import 'package:hibiki/src/pages/implementations/stat_delete_confirm_dialog.dart
 import 'package:hibiki/src/pages/implementations/stat_kpi_strip.dart';
 import 'package:hibiki/src/pages/implementations/stat_ring.dart';
 import 'package:hibiki/src/pages/implementations/stat_shared.dart';
+import 'package:hibiki/src/pages/implementations/stat_source_totals.dart';
 import 'package:hibiki/src/pages/implementations/stat_summary.dart';
 import 'package:hibiki/src/pages/implementations/stat_trends.dart';
 import 'package:hibiki/utils.dart';
@@ -37,6 +38,22 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
   String? _error;
 
   List<ReadingStatisticRow> _allStats = [];
+
+  /// 视频与游戏的原始统计（与书内阅读一起构成同一个字数/时长口径）。「按书」列表
+  /// 仍只列书，这两源只进 KPI / 汇总 / 趋势 / 目标进度与「各来源」卡。
+  List<VideoWatchStatisticRow> _videoStats = <VideoWatchStatisticRow>[];
+  List<(String, int, int)> _gameDaily = <(String, int, int)>[];
+
+  /// 逐来源逐日合计（[aggregateStatSourceDaily] 的产物），四个来源同形状。
+  Map<StatBreakdownSource, Map<String, StatSourceTotals>> _sourceDaily =
+      <StatBreakdownSource, Map<String, StatSourceTotals>>{};
+
+  /// 「各来源」卡展示的窗口合计（今日 / 本周 / 本月 / 全部随 [_breakdownWindow]）。
+  Map<StatBreakdownSource, StatSourceTotals> _breakdownTotals =
+      <StatBreakdownSource, StatSourceTotals>{};
+
+  /// 「各来源」卡的窗口：0=今日 1=本周 2=本月 3=全部（默认全部）。
+  int _breakdownWindow = 3;
 
   /// 合集归属映射（书架同源）：按书 tile 显示所属合集名用。
   /// - [_collectionNamesById]：collectionId → 合集名。
@@ -116,6 +133,23 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     try {
       final db = appModelNoUpdate.database;
       _allStats = await db.getAllReadingStatistics();
+      // 口径统一：视频字幕字数/观看时长、游戏 hook 文本字数/游玩时长与书内阅读
+      // 同属一个学习总量（首页每日目标一直是这个口径，统计页此前漏了两源）。
+      _videoStats = await db.getAllVideoWatchStatistics();
+      _gameDaily = await db.getActivityDailyTotals(kActivityGame);
+      // 书身份（'epub' / 'pdf' / 'manga'）：统计行只存 title，靠 epub_books 反查，
+      // 用来把漫画从「阅读」里拆出来单列（页数是漫画独有的第三个量纲）。整表只查
+      // 一次，下面的 title→bookKey（合集归属用）复用同一批行。
+      final List<EpubBookRow> epubRows = await db.getAllEpubBooks();
+      final Map<String, String> formatByTitle = <String, String>{
+        for (final EpubBookRow r in epubRows) r.title: r.format,
+      };
+      _sourceDaily = aggregateStatSourceDaily(
+        reading: _allStats,
+        formatByTitle: formatByTitle,
+        video: _videoStats,
+        gameDaily: _gameDaily,
+      );
       _computeAggregates();
       final DateTime now = DateTime.now();
       final List<FavoriteWordRow> favs =
@@ -147,8 +181,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       };
       _primaryCollectionByEntry = await db.getPrimaryCollectionIdByEntry();
       _bookKeyByTitle = <String, String>{
-        for (final EpubBookRow r in await db.getAllEpubBooks())
-          r.title: r.bookKey,
+        for (final EpubBookRow r in epubRows) r.title: r.bookKey,
       };
       // 收藏语句按 source 分桶：非视频来源（书内 / 有声书 / 歌词）都归阅读统计。
       // BUG-893：写入端此前不带 dateKey，旧的 `dateKey != null` 过滤把所有书内收藏
@@ -204,32 +237,35 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     final dailyMap = <String, StatDayData>{};
     final bookMap = <String, _BookData>{};
 
+    // 窗口合计走四来源合并后的逐日表（书 + 漫画 + 视频 + 游戏），与首页每日目标
+    // 同一个分子；「按书」列表仍只用 reading_statistics 行（视频/游戏不是书）。
+    for (final Map<String, StatSourceTotals> byDay in _sourceDaily.values) {
+      byDay.forEach((String dateKey, StatSourceTotals totals) {
+        _allChars += totals.chars;
+        _allMs += totals.timeMs;
+        if (dateKey == todayKey) {
+          _todayChars += totals.chars;
+          _todayMs += totals.timeMs;
+        }
+        if (dateKey.compareTo(weekAgoKey) >= 0) {
+          _weekChars += totals.chars;
+          _weekMs += totals.timeMs;
+        } else if (dateKey.compareTo(prevWeekAgoKey) >= 0) {
+          // 上周窗口 [prevWeekAgo, weekAgo)：本周分支未命中且不早于 14 天前。
+          _prevWeekChars += totals.chars;
+        }
+        if (dateKey.compareTo(monthAgoKey) >= 0) {
+          _monthChars += totals.chars;
+          _monthMs += totals.timeMs;
+        }
+        final StatDayData day =
+            dailyMap.putIfAbsent(dateKey, () => StatDayData(dateKey: dateKey));
+        day.chars += totals.chars;
+        day.ms += totals.timeMs;
+      });
+    }
+
     for (final s in _allStats) {
-      _allChars += s.charactersRead;
-      _allMs += s.readingTimeMs;
-
-      if (s.dateKey == todayKey) {
-        _todayChars += s.charactersRead;
-        _todayMs += s.readingTimeMs;
-      }
-      if (s.dateKey.compareTo(weekAgoKey) >= 0) {
-        _weekChars += s.charactersRead;
-        _weekMs += s.readingTimeMs;
-      } else if (s.dateKey.compareTo(prevWeekAgoKey) >= 0) {
-        // 上周窗口 [prevWeekAgo, weekAgo)：本周分支未命中且不早于 14 天前。
-        _prevWeekChars += s.charactersRead;
-      }
-      if (s.dateKey.compareTo(monthAgoKey) >= 0) {
-        _monthChars += s.charactersRead;
-        _monthMs += s.readingTimeMs;
-      }
-
-      // 每日
-      final day = dailyMap.putIfAbsent(
-          s.dateKey, () => StatDayData(dateKey: s.dateKey));
-      day.chars += s.charactersRead;
-      day.ms += s.readingTimeMs;
-
       // 按书
       final book =
           bookMap.putIfAbsent(s.title, () => _BookData(title: s.title));
@@ -246,10 +282,10 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       _dailyData.add(dailyMap[key] ?? StatDayData(dateKey: key));
     }
 
-    // 总览：活跃天数 = distinct dateKey；日期范围 = min/max dateKey（dateKey 零填充可
-    // 字典序比较）。
-    final Set<String> activeDayKeys =
-        _allStats.map((ReadingStatisticRow s) => s.dateKey).toSet();
+    // 总览：活跃天数 = 任一来源有数据的 distinct dateKey（看了视频、玩了游戏的那天
+    // 也是学习日，不该因为没读书就断签）；日期范围 = min/max dateKey（dateKey 零填充
+    // 可字典序比较）。
+    final Set<String> activeDayKeys = allStatSourceDateKeys(_sourceDaily);
     _streak = computeReadingStreak(activeDayKeys, now);
     if (activeDayKeys.isEmpty) {
       _firstDateKey = null;
@@ -264,6 +300,38 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
 
     _bookData = bookMap.values.toList();
     _sortBookData();
+    _recomputeBreakdown();
+  }
+
+  /// 「各来源」卡当前窗口的日期谓词（0=今日 1=近 7 天 2=近 30 天 3=全部）。
+  /// dateKey 是零填充的 `YYYY-MM-DD`，字典序即时间序。
+  bool Function(String dateKey) _breakdownPredicate() {
+    final DateTime now = DateTime.now();
+    switch (_breakdownWindow) {
+      case 0:
+        final String today = statDateKey(now);
+        return (String dateKey) => dateKey == today;
+      case 1:
+        final String from = statDateKey(now.subtract(const Duration(days: 7)));
+        return (String dateKey) => dateKey.compareTo(from) >= 0;
+      case 2:
+        final String from = statDateKey(now.subtract(const Duration(days: 30)));
+        return (String dateKey) => dateKey.compareTo(from) >= 0;
+      default:
+        return (String dateKey) => true;
+    }
+  }
+
+  /// 按当前窗口重算四来源合计（纯内存，不重查 DB）。
+  void _recomputeBreakdown() {
+    final bool Function(String) inWindow = _breakdownPredicate();
+    _breakdownTotals = <StatBreakdownSource, StatSourceTotals>{
+      for (final StatBreakdownSource source in StatBreakdownSource.values)
+        source: sumStatSourceTotals(
+          _sourceDaily[source] ?? const <String, StatSourceTotals>{},
+          inWindow,
+        ),
+    };
   }
 
   /// 按当前排序键给 [_bookData] 重排（不重新查 DB）。
@@ -356,7 +424,9 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
           ? buildLoading(size: 25, color: theme.colorScheme.primary)
           : _error != null
               ? buildError(error: _error)
-              : _allStats.isEmpty
+              // 空态判据是**四来源皆空**：只看视频 / 只玩游戏的用户此前会被判成
+              // 「暂无数据」，明明有学习记录却什么也看不到。
+              : (_allStats.isEmpty && _videoStats.isEmpty && _gameDaily.isEmpty)
                   ? Center(
                       child: HibikiPlaceholderMessage(
                         icon: Icons.bar_chart_outlined,
@@ -400,6 +470,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
                   ),
                 ),
                 SliverToBoxAdapter(child: _buildSummaryCards()),
+                SliverToBoxAdapter(child: _buildSourceBreakdown()),
                 SliverToBoxAdapter(child: _buildGoalPanel()),
                 SliverToBoxAdapter(
                     child: buildStatHourlyChartSection(context, _hourlyMs)),
@@ -526,6 +597,104 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
           ),
           SizedBox(height: tokens.spacing.card),
           child,
+        ],
+      ),
+    );
+  }
+
+  /// 「各来源」卡：四个来源各自的两个量纲（字数 + 时长），漫画额外显示页数。
+  ///
+  /// 用户要的「游戏、漫画等加上支持」落在这里：统计页此前只有书内阅读，视频字幕
+  /// 与游戏文本的字数、漫画的页数都没有去处。空来源（从没看过视频 / 没玩过游戏）
+  /// 整行不渲染，装了也不用的人看不到噪音。
+  Widget _buildSourceBreakdown() {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final List<Widget> rows = <Widget>[];
+    for (final StatBreakdownSource source in StatBreakdownSource.values) {
+      final StatSourceTotals totals =
+          _breakdownTotals[source] ?? StatSourceTotals();
+      if (totals.isEmpty) continue;
+      rows.add(_breakdownRow(source, totals));
+    }
+    if (rows.isEmpty) return const SizedBox.shrink();
+    return Padding(
+      padding: EdgeInsets.only(
+        left: tokens.spacing.card,
+        right: tokens.spacing.card,
+        bottom: tokens.spacing.card,
+      ),
+      child: _card(
+        title: t.stat_source_breakdown,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Wrap(
+              spacing: tokens.spacing.gap,
+              runSpacing: tokens.spacing.gap,
+              children: <Widget>[
+                _breakdownWindowChip(t.stat_today, 0),
+                _breakdownWindowChip(t.stat_this_week, 1),
+                _breakdownWindowChip(t.stat_this_month, 2),
+                _breakdownWindowChip(t.stat_all_time, 3),
+              ],
+            ),
+            SizedBox(height: tokens.spacing.card),
+            ...rows,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _breakdownWindowChip(String label, int window) => HibikiSelectableChip(
+        label: label,
+        selected: _breakdownWindow == window,
+        onSelected: (_) => setState(() {
+          _breakdownWindow = window;
+          _recomputeBreakdown();
+        }),
+      );
+
+  /// 单个来源一行：图标 + 名称 + 「字数 · 时长（· 页数）」。
+  Widget _breakdownRow(StatBreakdownSource source, StatSourceTotals totals) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    final (IconData icon, String label) = switch (source) {
+      StatBreakdownSource.book => (Icons.menu_book, t.home_filter_read),
+      StatBreakdownSource.manga => (Icons.photo_library, t.manga_library),
+      StatBreakdownSource.video => (Icons.movie, t.home_filter_watch),
+      StatBreakdownSource.game => (Icons.videogame_asset, t.home_filter_game),
+    };
+    final List<String> metrics = <String>[
+      _formatChars(totals.chars),
+      formatStatTime(totals.timeMs),
+      // 页数只有漫画有；0 页不显示（未翻页的会话只贡献时长）。
+      if (totals.pages > 0) t.stat_format_pages(n: totals.pages),
+    ];
+    return Padding(
+      padding: EdgeInsets.only(bottom: tokens.spacing.gap),
+      child: Row(
+        children: <Widget>[
+          Icon(icon, size: 18, color: scheme.onSurfaceVariant),
+          SizedBox(width: tokens.spacing.gap),
+          Expanded(
+            child: Text(
+              label,
+              style: Theme.of(context).textTheme.bodyMedium,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          SizedBox(width: tokens.spacing.gap),
+          Flexible(
+            child: Text(
+              metrics.join(' · '),
+              textAlign: TextAlign.right,
+              overflow: TextOverflow.ellipsis,
+              style: tokens.type.metadata.copyWith(
+                color: scheme.onSurfaceVariant,
+              ),
+            ),
+          ),
         ],
       ),
     );
@@ -772,16 +941,15 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
-                // BUG-1075：单位 + 口径（与首页仪表盘目标对话框同一批 i18n key，
-                // 两处编辑的是同一个持久化目标）。
+                // BUG-1075：单位（与首页仪表盘目标对话框同一批 i18n key，两处编辑的是
+                // 同一个持久化目标）。口径说明行已按用户要求删除——统计口径由实际计入的
+                // 来源（阅读/漫画/视频字幕/游戏文本）自解释，不再在文案里逐项列举。
                 TextField(
                   controller: dailyController,
                   keyboardType: TextInputType.number,
                   decoration: InputDecoration(
                     labelText: t.stat_goal_daily,
                     suffixText: t.stat_goal_unit_chars,
-                    helperText: t.stat_goal_scope_hint,
-                    helperMaxLines: 3,
                   ),
                 ),
                 SizedBox(height: tokens.spacing.gap + tokens.spacing.gap / 2),

--- a/hibiki/lib/src/pages/implementations/stat_source_totals.dart
+++ b/hibiki/lib/src/pages/implementations/stat_source_totals.dart
@@ -1,0 +1,123 @@
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 学习统计的**来源**维度：阅读统计页与首页仪表盘的字数/时长口径由此统一。
+///
+/// 背景：统计页此前只读 `reading_statistics`（书内阅读），却在编辑与首页共用的
+/// 每日目标——首页把 阅读 + 视频字幕 + 游戏文本 三源合计当分子，统计页只算书，
+/// 同一个目标两个页面两套分子。这里把四个来源摊平成同一形状，两边共用。
+///
+/// 每个来源都带**两个独立量纲**（字数 + 时长），漫画额外带页数：
+/// - [book]：EPUB / PDF 等书内阅读（`reading_statistics` 中 `format != 'manga'`）。
+/// - [manga]：漫画（`format == 'manga'`），OCR 字数 + 页数 + 时长。
+/// - [video]：视频，字幕字数 + 观看时长。
+/// - [game]：galgame hook 文本字数 + 游玩时长。
+enum StatBreakdownSource { book, manga, video, game }
+
+/// 一个来源在某个窗口（某天 / 今日 / 本周 / 全部）内的量纲合计。
+///
+/// 可变是刻意的：聚合就是逐行累加，不为每行造一个新对象。
+class StatSourceTotals {
+  StatSourceTotals({this.chars = 0, this.timeMs = 0, this.pages = 0});
+
+  /// 字数（各来源各自的字数口径：书/漫画=实义字符，视频=字幕字符，游戏=hook 文本）。
+  int chars;
+
+  /// 时长（毫秒）。
+  int timeMs;
+
+  /// 页数。目前只有漫画产出（EPUB 无页概念，视频/游戏不适用），恒 >= 0。
+  int pages;
+
+  void add(StatSourceTotals other) {
+    chars += other.chars;
+    timeMs += other.timeMs;
+    pages += other.pages;
+  }
+
+  bool get isEmpty => chars == 0 && timeMs == 0 && pages == 0;
+}
+
+/// 逐来源、逐日的统计合计。
+///
+/// [formatByTitle] 是 `epub_books.title -> format`（`'epub'` / `'pdf'` / `'manga'`）；
+/// 统计行只存 title，靠它反查书身份。查不到的 title（书已删、统计还在）按 [book]
+/// 归类——宁可算进阅读，也不凭 `pagesRead > 0` 这类二元标志猜身份。
+Map<StatBreakdownSource, Map<String, StatSourceTotals>>
+    aggregateStatSourceDaily({
+  required List<ReadingStatisticRow> reading,
+  required Map<String, String> formatByTitle,
+  required List<VideoWatchStatisticRow> video,
+  required List<(String, int, int)> gameDaily,
+}) {
+  final Map<StatBreakdownSource, Map<String, StatSourceTotals>> out =
+      <StatBreakdownSource, Map<String, StatSourceTotals>>{
+    for (final StatBreakdownSource s in StatBreakdownSource.values)
+      s: <String, StatSourceTotals>{},
+  };
+
+  StatSourceTotals bucket(StatBreakdownSource source, String dateKey) =>
+      out[source]!.putIfAbsent(dateKey, StatSourceTotals.new);
+
+  for (final ReadingStatisticRow r in reading) {
+    final bool isManga = formatByTitle[r.title] == 'manga';
+    final StatSourceTotals b = bucket(
+      isManga ? StatBreakdownSource.manga : StatBreakdownSource.book,
+      r.dateKey,
+    );
+    b.chars += r.charactersRead;
+    b.timeMs += r.readingTimeMs;
+    b.pages += r.pagesRead;
+  }
+
+  for (final VideoWatchStatisticRow w in video) {
+    final StatSourceTotals b = bucket(StatBreakdownSource.video, w.dateKey);
+    b.chars += w.subtitleChars;
+    b.timeMs += w.watchTimeMs;
+  }
+
+  for (final (String dateKey, int charsDelta, int durationMs) in gameDaily) {
+    final StatSourceTotals b = bucket(StatBreakdownSource.game, dateKey);
+    b.chars += charsDelta;
+    b.timeMs += durationMs;
+  }
+
+  return out;
+}
+
+/// 把逐日合计压成一个窗口的合计：[inWindow] 决定哪些 dateKey 计入。
+StatSourceTotals sumStatSourceTotals(
+  Map<String, StatSourceTotals> byDay,
+  bool Function(String dateKey) inWindow,
+) {
+  final StatSourceTotals total = StatSourceTotals();
+  byDay.forEach((String dateKey, StatSourceTotals value) {
+    if (inWindow(dateKey)) total.add(value);
+  });
+  return total;
+}
+
+/// 全部来源在某窗口的合计（首页每日目标 / 统计页 KPI 的同一口径分子）。
+StatSourceTotals sumAllStatSources(
+  Map<StatBreakdownSource, Map<String, StatSourceTotals>> daily,
+  bool Function(String dateKey) inWindow,
+) {
+  final StatSourceTotals total = StatSourceTotals();
+  for (final Map<String, StatSourceTotals> byDay in daily.values) {
+    total.add(sumStatSourceTotals(byDay, inWindow));
+  }
+  return total;
+}
+
+/// 所有来源出现过的日期键并集（连续天数 / 活跃天数用：看了视频、玩了游戏的那天
+/// 也是学习日，不该因为没读书就断签）。
+Set<String> allStatSourceDateKeys(
+  Map<StatBreakdownSource, Map<String, StatSourceTotals>> daily,
+) {
+  final Set<String> keys = <String>{};
+  for (final Map<String, StatSourceTotals> byDay in daily.values) {
+    for (final MapEntry<String, StatSourceTotals> e in byDay.entries) {
+      if (!e.value.isEmpty) keys.add(e.key);
+    }
+  }
+  return keys;
+}

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+978
+version: 1.3.1+979
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/database/migration_test.dart
+++ b/hibiki/test/database/migration_test.dart
@@ -1079,7 +1079,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 hibiki_paired_peers). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 59,
+      expect(db.schemaVersion, 60,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1156,7 +1156,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 59,
+      expect(db.schemaVersion, 60,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1316,7 +1316,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 59,
+      expect(db.schemaVersion, 60,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1367,7 +1367,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 59);
+      expect(db.schemaVersion, 60);
     });
 
     test(
@@ -1376,7 +1376,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 59,
+      expect(db.schemaVersion, 60,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1410,7 +1410,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 59,
+      expect(db.schemaVersion, 60,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1450,7 +1450,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 59);
+      expect(db.schemaVersion, 60);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1481,7 +1481,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 59);
+      expect(db.schemaVersion, 60);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1515,7 +1515,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 59);
+      expect(db.schemaVersion, 60);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1527,7 +1527,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 59);
+      expect(db.schemaVersion, 60);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();

--- a/hibiki/test/database/migration_v40_collections_test.dart
+++ b/hibiki/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 59);
+    expect(db.schemaVersion, 60);
   });
 }

--- a/hibiki/test/database/migration_v51_pdf_format_test.dart
+++ b/hibiki/test/database/migration_v51_pdf_format_test.dart
@@ -110,6 +110,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 59);
+    expect(db.schemaVersion, 60);
   });
 }

--- a/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
@@ -117,6 +117,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 59);
+    expect(db.schemaVersion, 60);
   });
 }

--- a/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 59);
+    expect(db.schemaVersion, 60);
   });
 }

--- a/hibiki/test/database/migration_v55_galgame_library_test.dart
+++ b/hibiki/test/database/migration_v55_galgame_library_test.dart
@@ -122,7 +122,7 @@ CREATE TABLE preferences (
     final String? pref = await db.getPref('galgame_library');
     expect(pref, isNotNull);
 
-    expect(await userVersionOf(db), 59);
+    expect(await userVersionOf(db), 60);
   });
 
   test('脏数据被逐条跳过，不让整个迁移失败', () async {
@@ -158,7 +158,7 @@ CREATE TABLE preferences (
 
     final List<GalgameRow> rows = await db.getAllGalgames();
     expect(rows.map((GalgameRow r) => r.id), <String>['ok-1', 'ok-2']);
-    expect(await userVersionOf(db), 59);
+    expect(await userVersionOf(db), 60);
   });
 
   test('整串 JSON 损坏 / 非数组 / 空串时迁移仍然成功，只是回填为空', () async {
@@ -169,7 +169,7 @@ CREATE TABLE preferences (
     ]) {
       final HibikiDatabase db = await openV53Db(raw);
       expect(await db.getAllGalgames(), isEmpty, reason: 'raw=$raw');
-      expect(await userVersionOf(db), 59, reason: 'raw=$raw');
+      expect(await userVersionOf(db), 60, reason: 'raw=$raw');
       await db.close();
     }
   });
@@ -177,7 +177,7 @@ CREATE TABLE preferences (
   test('偏好里根本没有 galgame_library 时迁移正常，表为空', () async {
     final HibikiDatabase db = await openV53Db(null);
     expect(await db.getAllGalgames(), isEmpty);
-    expect(await userVersionOf(db), 59);
+    expect(await userVersionOf(db), 60);
   });
 
   test('回填幂等：表里已有行就不再重复回填', () async {
@@ -227,7 +227,7 @@ CREATE TABLE preferences (
       ),
     );
     expect(await db.getAllGalgames(), hasLength(1));
-    expect(await userVersionOf(db), 59);
+    expect(await userVersionOf(db), 60);
   });
 
   test('删游戏经 FK cascade 连带清掉 sources 与 sessions', () async {

--- a/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 59,
+    expect(db.schemaVersion, 60,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v57_naming_unification_test.dart
+++ b/hibiki/test/database/migration_v57_naming_unification_test.dart
@@ -154,7 +154,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 59,
+    expect(db.schemaVersion, 60,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签');
 
     final Set<String> mapping = await columnsOf(db, 'video_book_tag_mappings');

--- a/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 59,
+    expect(db.schemaVersion, 60,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v60_reading_pages_test.dart
+++ b/hibiki/test/database/migration_v60_reading_pages_test.dart
@@ -1,0 +1,123 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// v60 迁移：`reading_statistics` 增加 `pages_read`（漫画/PDF 的页数维度）。
+///
+/// 漫画此前只落时长、`characters_read` 恒 0，统计页永远「0 字 0 页」。现在字数
+/// （OCR 实义字符，口径与 EPUB 同源）与页数各占一列，两个量纲独立累加——页数
+/// 绝不塞进 characters_read，否则会污染字数口径与阅读速度。
+///
+/// 打开一个 user_version=59 的库（v59 shape：reading_statistics 无 pages_read），
+/// 触发真实的 `if (from < 60)` addColumn，验证：
+///  ① 旧统计行原样保留，新列回填 0（Never break userspace）；
+///  ② 新列可写可累加，且与字数互不影响；
+///  ③ fresh 库由 onCreate 直接建出该列。
+void main() {
+  Future<HibikiDatabase> openV59Db() async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (rawDb) {
+          rawDb.execute('PRAGMA foreign_keys = OFF');
+          // v59 shape：没有 pages_read 列。
+          rawDb.execute('''
+CREATE TABLE reading_statistics (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  date_key TEXT NOT NULL,
+  characters_read INTEGER NOT NULL,
+  reading_time_ms INTEGER NOT NULL,
+  last_statistic_modified INTEGER NOT NULL,
+  UNIQUE (title, date_key)
+)
+''');
+          // 统计删除墓碑表自 v-早期就在；新建统计行会清它，真实 v59 库必有此表。
+          rawDb.execute('''
+CREATE TABLE statistics_tombstones (
+  title TEXT NOT NULL,
+  source_type TEXT NOT NULL,
+  deleted_at INTEGER NOT NULL,
+  PRIMARY KEY (title, source_type)
+)
+''');
+          rawDb.execute(
+            'INSERT INTO reading_statistics '
+            '(title, date_key, characters_read, reading_time_ms, '
+            'last_statistic_modified) '
+            "VALUES ('旧書', '2026-07-01', 4321, 600000, 1700000000000)",
+          );
+          rawDb.execute('PRAGMA user_version = 59');
+        },
+      ),
+    );
+    addTearDown(db.close);
+    return db;
+  }
+
+  test('v60：旧统计行零破坏，pages_read 回填 0', () async {
+    final HibikiDatabase db = await openV59Db();
+
+    final version = await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.read<int>('user_version'), db.schemaVersion);
+    expect(db.schemaVersion, 60, reason: 'v60 = reading_statistics.pages_read');
+
+    final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
+    expect(rows, hasLength(1));
+    expect(rows.single.title, '旧書');
+    expect(rows.single.charactersRead, 4321, reason: '旧字数原样保留');
+    expect(rows.single.readingTimeMs, 600000);
+    expect(rows.single.pagesRead, 0, reason: '新列对旧行必须是 0，而不是猜出来的值');
+  });
+
+  test('v60：页数与字数各自独立累加', () async {
+    final HibikiDatabase db = await openV59Db();
+
+    // 漫画：同一天两段会话，字数与页数分别累加。
+    await db.addReadingStatistic(
+      title: '漫画',
+      dateKey: '2026-07-28',
+      charsRead: 200,
+      timeMs: 60000,
+      pagesRead: 8,
+    );
+    await db.addReadingStatistic(
+      title: '漫画',
+      dateKey: '2026-07-28',
+      charsRead: 90,
+      timeMs: 30000,
+      pagesRead: 4,
+    );
+    // EPUB：不传页数 → 页数保持 0，字数照常涨。
+    await db.addReadingStatistic(
+      title: '旧書',
+      dateKey: '2026-07-01',
+      charsRead: 1000,
+      timeMs: 60000,
+    );
+
+    final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
+    final ReadingStatisticRow manga =
+        rows.firstWhere((ReadingStatisticRow r) => r.title == '漫画');
+    final ReadingStatisticRow book =
+        rows.firstWhere((ReadingStatisticRow r) => r.title == '旧書');
+    expect(manga.charactersRead, 290);
+    expect(manga.pagesRead, 12);
+    expect(book.charactersRead, 5321);
+    expect(book.pagesRead, 0);
+  });
+
+  test('v60：fresh 库由 onCreate 直接建出该列（不依赖迁移梯子）', () async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+
+    await db.addReadingStatistic(
+      title: '漫画',
+      dateKey: '2026-07-28',
+      charsRead: 10,
+      timeMs: 1000,
+      pagesRead: 3,
+    );
+    expect((await db.getAllReadingStatistics()).single.pagesRead, 3);
+  });
+}

--- a/hibiki/test/database/reading_statistics_test.dart
+++ b/hibiki/test/database/reading_statistics_test.dart
@@ -49,6 +49,43 @@ void main() {
       expect(all.single.readingTimeMs, 15000);
     });
 
+    test('pagesRead 默认 0，且与字数各自独立累加（v60）', () async {
+      final db = await _openDb();
+      // EPUB：只有字数，不传页数 → 页数恒 0。
+      await db.addReadingStatistic(
+        title: 'Novel',
+        dateKey: '2026-07-28',
+        charsRead: 800,
+        timeMs: 60000,
+      );
+      // 漫画：字数与页数一起落，两个量纲互不顶替。
+      await db.addReadingStatistic(
+        title: 'Manga',
+        dateKey: '2026-07-28',
+        charsRead: 300,
+        timeMs: 30000,
+        pagesRead: 12,
+      );
+      await db.addReadingStatistic(
+        title: 'Manga',
+        dateKey: '2026-07-28',
+        charsRead: 120,
+        timeMs: 10000,
+        pagesRead: 5,
+      );
+
+      final List<ReadingStatisticRow> all = await db.getAllReadingStatistics();
+      final ReadingStatisticRow novel =
+          all.firstWhere((ReadingStatisticRow r) => r.title == 'Novel');
+      final ReadingStatisticRow manga =
+          all.firstWhere((ReadingStatisticRow r) => r.title == 'Manga');
+      expect(novel.pagesRead, 0);
+      expect(novel.charactersRead, 800);
+      expect(manga.charactersRead, 420);
+      expect(manga.pagesRead, 17);
+      expect(manga.readingTimeMs, 40000);
+    });
+
     test('different dates create separate rows', () async {
       final db = await _openDb();
       await db.addReadingStatistic(

--- a/hibiki/test/media/manga/manga_reading_stats_test.dart
+++ b/hibiki/test/media/manga/manga_reading_stats_test.dart
@@ -1,0 +1,100 @@
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/manga_reading_stats.dart';
+import 'package:hibiki/src/media/manga/mokuro_payload.dart';
+
+/// 守卫漫画的字数/页数记账（v60）：漫画此前 `charsRead` 恒 0，只记时长，统计页
+/// 永远显示 0 字。现在按已读页的 OCR 文本计字数、按已读页计页数，两个量纲各自
+/// 独立，且同一页在一次会话里只记一次。
+MokuroImage _page(List<String> lines) => MokuroImage(
+      url: 'p.jpg',
+      size: const Size(800, 1200),
+      blocks: <MokuroBlock>[
+        MokuroBlock(
+          rectangle: const Rect.fromLTRB(0, 0, 10, 10),
+          isVertical: true,
+          fontSize: 12,
+          zIndex: 0,
+          lines: lines,
+        ),
+      ],
+    );
+
+void main() {
+  group('mangaPageCharCount', () {
+    test('口径与 EPUB 同源：剔除标点/括号/空白，只数假名与汉字', () {
+      // 「こんにちは、世界。」→ こんにちは(5) + 世界(2) = 7。
+      expect(mangaPageCharCount(_page(<String>['「こんにちは、', '世界。」'])), 7);
+    });
+
+    test('无 OCR 的纯图页为 0', () {
+      expect(
+        mangaPageCharCount(const MokuroImage(
+          url: 'p.jpg',
+          size: Size(800, 1200),
+          blocks: <MokuroBlock>[],
+        )),
+        0,
+      );
+    });
+  });
+
+  group('mangaAccumulateReadingStats', () {
+    final MokuroPayload payload = MokuroPayload(
+      images: <MokuroImage>[
+        _page(<String>['あいう']), // 3
+        _page(<String>['かきくけ']), // 4
+        _page(<String>['さ']), // 1
+      ],
+    );
+
+    test('首次经过的页计字数与页数', () {
+      final Set<int> counted = <int>{};
+      final ({int chars, int pages}) r = mangaAccumulateReadingStats(
+        payload: payload,
+        pageIndices: <int>[0, 1],
+        counted: counted,
+      );
+      expect(r.chars, 7);
+      expect(r.pages, 2);
+      expect(counted, <int>{0, 1});
+    });
+
+    test('同一页翻回来不重复计（来回翻页刷不出数）', () {
+      final Set<int> counted = <int>{};
+      mangaAccumulateReadingStats(
+        payload: payload,
+        pageIndices: <int>[0, 1],
+        counted: counted,
+      );
+      final ({int chars, int pages}) again = mangaAccumulateReadingStats(
+        payload: payload,
+        pageIndices: <int>[1, 0],
+        counted: counted,
+      );
+      expect(again.chars, 0);
+      expect(again.pages, 0);
+
+      final ({int chars, int pages}) fresh = mangaAccumulateReadingStats(
+        payload: payload,
+        pageIndices: <int>[1, 2],
+        counted: counted,
+      );
+      expect(fresh.chars, 1, reason: '只有新页 2 计入');
+      expect(fresh.pages, 1);
+    });
+
+    test('越界页码忽略，不抛也不计', () {
+      final Set<int> counted = <int>{};
+      final ({int chars, int pages}) r = mangaAccumulateReadingStats(
+        payload: payload,
+        pageIndices: <int>[-1, 99],
+        counted: counted,
+      );
+      expect(r.chars, 0);
+      expect(r.pages, 0);
+      expect(counted, isEmpty);
+    });
+  });
+}

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -1006,15 +1006,16 @@ void main() {
     await tester.pump(const Duration(milliseconds: 300));
 
     final Finder dialog = find.byType(AlertDialog);
-    // 单位（suffixText）+ 口径说明（helperText）：用户「不知道该填什么」的解药。
+    // 单位（suffixText）+ 近 7 日日均：用户「不知道该填什么」的解药。口径说明行按用户
+    // 要求删除，这里守卫它不再出现（i18n key 也已下线）。
     expect(
       find.descendant(of: dialog, matching: find.text(t.stat_goal_unit_chars)),
       findsOneWidget,
     );
-    expect(
-      find.descendant(of: dialog, matching: find.text(t.stat_goal_scope_hint)),
-      findsOneWidget,
+    final TextField dailyField = tester.widget<TextField>(
+      find.descendant(of: dialog, matching: find.byType(TextField)).first,
     );
+    expect(dailyField.decoration?.helperText, isNull);
     // 参考值：与目标同口径（全来源合计）的近 7 日日均。
     expect(
       find.descendant(

--- a/hibiki/test/pages/home_tab_browser_extension_test.dart
+++ b/hibiki/test/pages/home_tab_browser_extension_test.dart
@@ -31,18 +31,22 @@ void main() {
     expect(settings, equals(ext + 1));
   });
 
-  test('games 与 browserExtension 同开时顺序为 词典 < 游戏 < 扩展 < 设置', () {
+  test('games 与 browserExtension 同开时顺序为 视频 < 游戏 < 下载 < 词典 < 扩展 < 设置', () {
     final List<HomeTab> tabs = homeActiveTabs(
       videoEnabled: true,
       gamesEnabled: true,
       browserExtensionEnabled: true,
     );
-    final int dict = tabs.indexOf(HomeTab.dictionaries);
+    final int video = tabs.indexOf(HomeTab.video);
     final int games = tabs.indexOf(HomeTab.games);
+    final int downloads = tabs.indexOf(HomeTab.downloads);
+    final int dict = tabs.indexOf(HomeTab.dictionaries);
     final int ext = tabs.indexOf(HomeTab.browserExtension);
     final int settings = tabs.indexOf(HomeTab.settings);
-    expect(games, equals(dict + 1));
-    expect(ext, equals(games + 1));
+    expect(games, equals(video + 1));
+    expect(downloads, equals(games + 1));
+    expect(dict, equals(downloads + 1));
+    expect(ext, equals(dict + 1));
     expect(settings, equals(ext + 1));
   });
 }

--- a/hibiki/test/pages/home_tab_games_test.dart
+++ b/hibiki/test/pages/home_tab_games_test.dart
@@ -20,27 +20,27 @@ void main() {
     );
   });
 
-  test('gamesEnabled 开启时夹在词典与设置之间', () {
+  test('gamesEnabled 开启时紧跟视频之后、下载之前', () {
     final List<HomeTab> tabs = homeActiveTabs(
       videoEnabled: true,
       gamesEnabled: true,
     );
-    final int dict = tabs.indexOf(HomeTab.dictionaries);
+    final int video = tabs.indexOf(HomeTab.video);
     final int games = tabs.indexOf(HomeTab.games);
-    final int settings = tabs.indexOf(HomeTab.settings);
-    expect(games, equals(dict + 1));
-    expect(settings, equals(games + 1));
+    final int downloads = tabs.indexOf(HomeTab.downloads);
+    expect(games, equals(video + 1));
+    expect(downloads, equals(games + 1));
   });
 
-  test('无视频时 games 仍夹在词典与设置之间', () {
+  test('无视频时 games 接在漫画之后、下载之前', () {
     final List<HomeTab> tabs = homeActiveTabs(
       videoEnabled: false,
       gamesEnabled: true,
     );
-    final int dict = tabs.indexOf(HomeTab.dictionaries);
+    final int manga = tabs.indexOf(HomeTab.manga);
     final int games = tabs.indexOf(HomeTab.games);
-    final int settings = tabs.indexOf(HomeTab.settings);
-    expect(games, equals(dict + 1));
-    expect(settings, equals(games + 1));
+    final int downloads = tabs.indexOf(HomeTab.downloads);
+    expect(games, equals(manga + 1));
+    expect(downloads, equals(games + 1));
   });
 }

--- a/hibiki/test/pages/home_tab_video_test.dart
+++ b/hibiki/test/pages/home_tab_video_test.dart
@@ -2,30 +2,30 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/pages/implementations/home_page.dart';
 
 /// 锁定首页顶层 tab 顺序与「实验视频」开关的条件插入（用户需求：视频 tab 放在
-/// 书架与词典管理之间，且仅在开启实验功能时显示）。用 games（galgame 库）作为词典与
-/// 设置之间的条件 tab 陪测（texthooker tab 已删）。
+/// 书架与词典管理之间，且仅在开启实验功能时显示）。用 games（galgame 库）作为紧跟视频
+/// 之后的条件 tab 陪测（texthooker tab 已删）。
 ///
 /// 用纯函数 [homeActiveTabs] 测，不必实例化整个 HomePage（它依赖 AppModel + DB +
 /// 一堆子系统）。设置覆盖率测试（settings_schema_coverage_test）另行验证开关写穿
 /// DB；此处验证它的「生效」= tab 的出现/位置。
 void main() {
   group('homeActiveTabs', () {
-    test('关闭实验视频：无视频 tab；下载 tab 恒在（统一下载中心），顺序为 首页→书架→下载→词典→游戏→设置', () {
+    test('关闭实验视频：无视频 tab；下载 tab 恒在（统一下载中心），顺序为 首页→书架→漫画→游戏→下载→词典→设置', () {
       final List<HomeTab> tabs =
           homeActiveTabs(videoEnabled: false, gamesEnabled: true);
       expect(tabs, <HomeTab>[
         HomeTab.home,
         HomeTab.books,
         HomeTab.manga,
+        HomeTab.games,
         HomeTab.downloads,
         HomeTab.dictionaries,
-        HomeTab.games,
         HomeTab.settings,
       ]);
       expect(tabs.contains(HomeTab.video), isFalse);
     });
 
-    test('开启实验视频：视频+下载 tab 出现，顺序为 首页→书架→视频→下载→词典→游戏→设置', () {
+    test('开启实验视频：视频+下载 tab 出现，顺序为 首页→书架→漫画→视频→游戏→下载→词典→设置', () {
       final List<HomeTab> tabs =
           homeActiveTabs(videoEnabled: true, gamesEnabled: true);
       expect(tabs, <HomeTab>[
@@ -33,25 +33,27 @@ void main() {
         HomeTab.books,
         HomeTab.manga,
         HomeTab.video,
+        HomeTab.games,
         HomeTab.downloads,
         HomeTab.dictionaries,
-        HomeTab.games,
         HomeTab.settings,
       ]);
       expect(tabs.indexOf(HomeTab.video), tabs.indexOf(HomeTab.manga) + 1);
     });
 
-    test('视频后紧随下载 tab，再到词典（用户要求：下载单独拿出来）', () {
+    test('视频后紧随游戏，再到下载与词典（用户要求：游戏移到视频后面）', () {
       final List<HomeTab> tabs =
           homeActiveTabs(videoEnabled: true, gamesEnabled: true);
       final int books = tabs.indexOf(HomeTab.books);
       final int manga = tabs.indexOf(HomeTab.manga);
       final int video = tabs.indexOf(HomeTab.video);
+      final int games = tabs.indexOf(HomeTab.games);
       final int downloads = tabs.indexOf(HomeTab.downloads);
       final int dict = tabs.indexOf(HomeTab.dictionaries);
       expect(manga, equals(books + 1));
       expect(video, equals(manga + 1));
-      expect(downloads, equals(video + 1));
+      expect(games, equals(video + 1));
+      expect(downloads, equals(games + 1));
       expect(dict, equals(downloads + 1));
     });
 

--- a/hibiki/test/pages/stat_source_totals_test.dart
+++ b/hibiki/test/pages/stat_source_totals_test.dart
@@ -63,8 +63,7 @@ void main() {
       expect(daily[StatBreakdownSource.book]!['2026-07-27']!.pages, 0);
       expect(daily[StatBreakdownSource.manga]!['2026-07-27']!.chars, 300);
       expect(daily[StatBreakdownSource.manga]!['2026-07-27']!.pages, 20);
-      expect(daily[StatBreakdownSource.book].toString(),
-          isNot(contains('漫画')));
+      expect(daily[StatBreakdownSource.book].toString(), isNot(contains('漫画')));
     });
 
     test('视频带字幕字数与观看时长；游戏带文本字数与游玩时长', () {
@@ -113,8 +112,7 @@ void main() {
     );
 
     test('全部来源合计 = 首页每日目标同一口径分子', () {
-      final StatSourceTotals all =
-          sumAllStatSources(daily, (String _) => true);
+      final StatSourceTotals all = sumAllStatSources(daily, (String _) => true);
       expect(all.chars, 1000 + 300 + 150 + 500 + 2000);
       expect(all.timeMs, 600000 + 300000 + 120000 + 1800000 + 3600000);
       expect(all.pages, 29);

--- a/hibiki/test/pages/stat_source_totals_test.dart
+++ b/hibiki/test/pages/stat_source_totals_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/stat_source_totals.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 守卫统计口径的来源拆分（用户要求「把游戏、漫画等加上支持」）：阅读统计页此前
+/// 只读 `reading_statistics`，视频字幕字数与游戏文本字数根本没进来，漫画又混在
+/// 「阅读」里且没有页数维度。这里锁定四来源的拆分、窗口求和与活跃日并集。
+ReadingStatisticRow _reading(
+  String title,
+  String dateKey, {
+  int chars = 0,
+  int ms = 0,
+  int pages = 0,
+}) =>
+    ReadingStatisticRow(
+      id: 0,
+      title: title,
+      dateKey: dateKey,
+      charactersRead: chars,
+      readingTimeMs: ms,
+      pagesRead: pages,
+      lastStatisticModified: 0,
+    );
+
+VideoWatchStatisticRow _video(String dateKey, {int chars = 0, int ms = 0}) =>
+    VideoWatchStatisticRow(
+      id: 0,
+      title: 'v',
+      dateKey: dateKey,
+      subtitleChars: chars,
+      watchTimeMs: ms,
+      lastModified: 0,
+    );
+
+void main() {
+  final List<ReadingStatisticRow> reading = <ReadingStatisticRow>[
+    _reading('小説', '2026-07-27', chars: 1000, ms: 600000),
+    _reading('漫画A', '2026-07-27', chars: 300, ms: 300000, pages: 20),
+    _reading('漫画A', '2026-07-28', chars: 150, ms: 120000, pages: 9),
+  ];
+  final Map<String, String> formats = <String, String>{
+    '小説': 'epub',
+    '漫画A': 'manga',
+  };
+  final List<VideoWatchStatisticRow> video = <VideoWatchStatisticRow>[
+    _video('2026-07-28', chars: 500, ms: 1800000),
+  ];
+  final List<(String, int, int)> games = <(String, int, int)>[
+    ('2026-07-26', 2000, 3600000),
+  ];
+
+  group('aggregateStatSourceDaily', () {
+    test('漫画按 epub_books.format 从阅读里拆出来，页数只落在漫画', () {
+      final Map<StatBreakdownSource, Map<String, StatSourceTotals>> daily =
+          aggregateStatSourceDaily(
+        reading: reading,
+        formatByTitle: formats,
+        video: video,
+        gameDaily: games,
+      );
+
+      expect(daily[StatBreakdownSource.book]!['2026-07-27']!.chars, 1000);
+      expect(daily[StatBreakdownSource.book]!['2026-07-27']!.pages, 0);
+      expect(daily[StatBreakdownSource.manga]!['2026-07-27']!.chars, 300);
+      expect(daily[StatBreakdownSource.manga]!['2026-07-27']!.pages, 20);
+      expect(daily[StatBreakdownSource.book].toString(),
+          isNot(contains('漫画')));
+    });
+
+    test('视频带字幕字数与观看时长；游戏带文本字数与游玩时长', () {
+      final Map<StatBreakdownSource, Map<String, StatSourceTotals>> daily =
+          aggregateStatSourceDaily(
+        reading: reading,
+        formatByTitle: formats,
+        video: video,
+        gameDaily: games,
+      );
+
+      final StatSourceTotals v =
+          daily[StatBreakdownSource.video]!['2026-07-28']!;
+      expect(v.chars, 500);
+      expect(v.timeMs, 1800000);
+
+      final StatSourceTotals g =
+          daily[StatBreakdownSource.game]!['2026-07-26']!;
+      expect(g.chars, 2000);
+      expect(g.timeMs, 3600000);
+    });
+
+    test('未知 title（书已删、统计还在）归阅读，不靠 pagesRead 猜身份', () {
+      final Map<StatBreakdownSource, Map<String, StatSourceTotals>> daily =
+          aggregateStatSourceDaily(
+        reading: <ReadingStatisticRow>[
+          _reading('已删的书', '2026-07-28', chars: 42, pages: 3),
+        ],
+        formatByTitle: const <String, String>{},
+        video: const <VideoWatchStatisticRow>[],
+        gameDaily: const <(String, int, int)>[],
+      );
+
+      expect(daily[StatBreakdownSource.book]!['2026-07-28']!.chars, 42);
+      expect(daily[StatBreakdownSource.manga], isEmpty);
+    });
+  });
+
+  group('窗口合计与活跃日', () {
+    final Map<StatBreakdownSource, Map<String, StatSourceTotals>> daily =
+        aggregateStatSourceDaily(
+      reading: reading,
+      formatByTitle: formats,
+      video: video,
+      gameDaily: games,
+    );
+
+    test('全部来源合计 = 首页每日目标同一口径分子', () {
+      final StatSourceTotals all =
+          sumAllStatSources(daily, (String _) => true);
+      expect(all.chars, 1000 + 300 + 150 + 500 + 2000);
+      expect(all.timeMs, 600000 + 300000 + 120000 + 1800000 + 3600000);
+      expect(all.pages, 29);
+    });
+
+    test('单日窗口只算当天', () {
+      final StatSourceTotals today =
+          sumAllStatSources(daily, (String d) => d == '2026-07-28');
+      expect(today.chars, 150 + 500);
+      expect(today.pages, 9);
+    });
+
+    test('活跃日是四来源并集：只看视频/只玩游戏的那天也算', () {
+      expect(
+        allStatSourceDateKeys(daily),
+        <String>{'2026-07-26', '2026-07-27', '2026-07-28'},
+      );
+    });
+
+    test('全零行不算活跃日', () {
+      final Map<StatBreakdownSource, Map<String, StatSourceTotals>> empty =
+          aggregateStatSourceDaily(
+        reading: <ReadingStatisticRow>[_reading('书', '2026-01-01')],
+        formatByTitle: const <String, String>{},
+        video: const <VideoWatchStatisticRow>[],
+        gameDaily: const <(String, int, int)>[],
+      );
+      expect(allStatSourceDateKeys(empty), isEmpty);
+    });
+  });
+}

--- a/packages/hibiki_core/CLAUDE.md
+++ b/packages/hibiki_core/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## 模块职责
 
-共享核心模块：定义 Drift SQLite 数据库 schema（53 张表，当前 schemaVersion=59）、表迁移逻辑、偏好键值编解码器（PrefCodec）、语言配置模型和文本选区模型。是所有其他 packages 的基础依赖。
+共享核心模块：定义 Drift SQLite 数据库 schema（53 张表，当前 schemaVersion=60）、表迁移逻辑、偏好键值编解码器（PrefCodec）、语言配置模型和文本选区模型。是所有其他 packages 的基础依赖。
 
 ## 入口与启动
 

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -414,7 +414,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   HibikiDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 59;
+  int get schemaVersion => 60;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1220,6 +1220,16 @@ class HibikiDatabase extends _$HibikiDatabase {
               await m.createTable(galgameTagMappings);
             }
             await _ensureIndexes();
+          }
+          if (from < 60) {
+            // v60：漫画/PDF 的「页数」维度。字数与页数是两个独立量纲，页数绝不塞进
+            // charactersRead（会污染字数口径与阅读速度）。旧行补默认 0。
+            // 表/列存在性双守卫：从 v1 起的完整迁移阶梯里 reading_statistics 可能
+            // 尚未建（早期版本没这张表），而某些路径下它是以最新定义建的（已含本列）。
+            if (await _tableExists('reading_statistics') &&
+                !await _columnExists('reading_statistics', 'pages_read')) {
+              await m.addColumn(readingStatistics, readingStatistics.pagesRead);
+            }
           }
         },
         onCreate: (m) async {
@@ -3404,6 +3414,9 @@ class HibikiDatabase extends _$HibikiDatabase {
   /// (e.g. sync merge). For incremental session deltas use
   /// [addReadingStatistic], which accumulates. Passing a delta here would
   /// silently reset the totals.
+  /// 绝对值覆盖（同步/备份合并用）。**刻意不写 `pagesRead`**：页数是 v60 新增的本机
+  /// 维度，跨设备 wire 契约不带它（[StatBucket] 要求两端字段集一致）。冲突更新只覆盖
+  /// 三个老列，本地已记的页数不会被对端的「没有页数」抹成 0。
   Future<void> setReadingStatistic(ReadingStatisticsCompanion stat) =>
       into(readingStatistics).insert(
         stat,
@@ -3420,11 +3433,14 @@ class HibikiDatabase extends _$HibikiDatabase {
   /// ACCUMULATE semantics: adds [charsRead]/[timeMs] to the existing totals
   /// for (title, dateKey). Use for reading-session deltas. For setting an
   /// absolute total (e.g. sync merge) use [setReadingStatistic].
+  /// 累加一条当日阅读统计。[pagesRead] 是 v60 的页数维度（漫画/PDF 传真实翻过的
+  /// 页数，EPUB 不传即 0），与 [charsRead] 各自独立累加，互不顶替。
   Future<void> addReadingStatistic({
     required String title,
     required String dateKey,
     required int charsRead,
     required int timeMs,
+    int pagesRead = 0,
   }) =>
       transaction(() async {
         final existing = await (select(readingStatistics)
@@ -3436,6 +3452,7 @@ class HibikiDatabase extends _$HibikiDatabase {
               .write(ReadingStatisticsCompanion(
             charactersRead: Value(existing.charactersRead + charsRead),
             readingTimeMs: Value(existing.readingTimeMs + timeMs),
+            pagesRead: Value(existing.pagesRead + pagesRead),
             lastStatisticModified: Value(DateTime.now().millisecondsSinceEpoch),
           ));
         } else {
@@ -3445,6 +3462,7 @@ class HibikiDatabase extends _$HibikiDatabase {
               dateKey: dateKey,
               charactersRead: charsRead,
               readingTimeMs: timeMs,
+              pagesRead: Value(pagesRead),
               lastStatisticModified: DateTime.now().millisecondsSinceEpoch,
             ),
           );

--- a/packages/hibiki_core/lib/src/database/database.g.dart
+++ b/packages/hibiki_core/lib/src/database/database.g.dart
@@ -5682,6 +5682,14 @@ class $ReadingStatisticsTable extends ReadingStatistics
   late final GeneratedColumn<int> readingTimeMs = GeneratedColumn<int>(
       'reading_time_ms', aliasedName, false,
       type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _pagesReadMeta =
+      const VerificationMeta('pagesRead');
+  @override
+  late final GeneratedColumn<int> pagesRead = GeneratedColumn<int>(
+      'pages_read', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
   static const VerificationMeta _lastStatisticModifiedMeta =
       const VerificationMeta('lastStatisticModified');
   @override
@@ -5695,6 +5703,7 @@ class $ReadingStatisticsTable extends ReadingStatistics
         dateKey,
         charactersRead,
         readingTimeMs,
+        pagesRead,
         lastStatisticModified
       ];
   @override
@@ -5739,6 +5748,10 @@ class $ReadingStatisticsTable extends ReadingStatistics
     } else if (isInserting) {
       context.missing(_readingTimeMsMeta);
     }
+    if (data.containsKey('pages_read')) {
+      context.handle(_pagesReadMeta,
+          pagesRead.isAcceptableOrUnknown(data['pages_read']!, _pagesReadMeta));
+    }
     if (data.containsKey('last_statistic_modified')) {
       context.handle(
           _lastStatisticModifiedMeta,
@@ -5770,6 +5783,8 @@ class $ReadingStatisticsTable extends ReadingStatistics
           .read(DriftSqlType.int, data['${effectivePrefix}characters_read'])!,
       readingTimeMs: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}reading_time_ms'])!,
+      pagesRead: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}pages_read'])!,
       lastStatisticModified: attachedDatabase.typeMapping.read(
           DriftSqlType.int, data['${effectivePrefix}last_statistic_modified'])!,
     );
@@ -5788,6 +5803,14 @@ class ReadingStatisticRow extends DataClass
   final String dateKey;
   final int charactersRead;
   final int readingTimeMs;
+
+  /// v60：当日读过的**页数**（漫画 / PDF 这类以页为单位的书；EPUB 恒 0）。
+  ///
+  /// 页数与字数是两个独立量纲，绝不互相顶替：漫画既落 OCR 字符数（与 EPUB 同口径）
+  /// 又落页数，统计页两个维度分别展示。旧库迁移补 0，跨设备聚合同步的 wire 契约
+  /// 不带此列（[StatBucket] 要求两端字段集一致，加字段会让新旧端互相抛错），页数
+  /// 随整库备份/恢复走。
+  final int pagesRead;
   final int lastStatisticModified;
   const ReadingStatisticRow(
       {required this.id,
@@ -5795,6 +5818,7 @@ class ReadingStatisticRow extends DataClass
       required this.dateKey,
       required this.charactersRead,
       required this.readingTimeMs,
+      required this.pagesRead,
       required this.lastStatisticModified});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -5804,6 +5828,7 @@ class ReadingStatisticRow extends DataClass
     map['date_key'] = Variable<String>(dateKey);
     map['characters_read'] = Variable<int>(charactersRead);
     map['reading_time_ms'] = Variable<int>(readingTimeMs);
+    map['pages_read'] = Variable<int>(pagesRead);
     map['last_statistic_modified'] = Variable<int>(lastStatisticModified);
     return map;
   }
@@ -5815,6 +5840,7 @@ class ReadingStatisticRow extends DataClass
       dateKey: Value(dateKey),
       charactersRead: Value(charactersRead),
       readingTimeMs: Value(readingTimeMs),
+      pagesRead: Value(pagesRead),
       lastStatisticModified: Value(lastStatisticModified),
     );
   }
@@ -5828,6 +5854,7 @@ class ReadingStatisticRow extends DataClass
       dateKey: serializer.fromJson<String>(json['dateKey']),
       charactersRead: serializer.fromJson<int>(json['charactersRead']),
       readingTimeMs: serializer.fromJson<int>(json['readingTimeMs']),
+      pagesRead: serializer.fromJson<int>(json['pagesRead']),
       lastStatisticModified:
           serializer.fromJson<int>(json['lastStatisticModified']),
     );
@@ -5841,6 +5868,7 @@ class ReadingStatisticRow extends DataClass
       'dateKey': serializer.toJson<String>(dateKey),
       'charactersRead': serializer.toJson<int>(charactersRead),
       'readingTimeMs': serializer.toJson<int>(readingTimeMs),
+      'pagesRead': serializer.toJson<int>(pagesRead),
       'lastStatisticModified': serializer.toJson<int>(lastStatisticModified),
     };
   }
@@ -5851,6 +5879,7 @@ class ReadingStatisticRow extends DataClass
           String? dateKey,
           int? charactersRead,
           int? readingTimeMs,
+          int? pagesRead,
           int? lastStatisticModified}) =>
       ReadingStatisticRow(
         id: id ?? this.id,
@@ -5858,6 +5887,7 @@ class ReadingStatisticRow extends DataClass
         dateKey: dateKey ?? this.dateKey,
         charactersRead: charactersRead ?? this.charactersRead,
         readingTimeMs: readingTimeMs ?? this.readingTimeMs,
+        pagesRead: pagesRead ?? this.pagesRead,
         lastStatisticModified:
             lastStatisticModified ?? this.lastStatisticModified,
       );
@@ -5872,6 +5902,7 @@ class ReadingStatisticRow extends DataClass
       readingTimeMs: data.readingTimeMs.present
           ? data.readingTimeMs.value
           : this.readingTimeMs,
+      pagesRead: data.pagesRead.present ? data.pagesRead.value : this.pagesRead,
       lastStatisticModified: data.lastStatisticModified.present
           ? data.lastStatisticModified.value
           : this.lastStatisticModified,
@@ -5886,14 +5917,15 @@ class ReadingStatisticRow extends DataClass
           ..write('dateKey: $dateKey, ')
           ..write('charactersRead: $charactersRead, ')
           ..write('readingTimeMs: $readingTimeMs, ')
+          ..write('pagesRead: $pagesRead, ')
           ..write('lastStatisticModified: $lastStatisticModified')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(
-      id, title, dateKey, charactersRead, readingTimeMs, lastStatisticModified);
+  int get hashCode => Object.hash(id, title, dateKey, charactersRead,
+      readingTimeMs, pagesRead, lastStatisticModified);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -5903,6 +5935,7 @@ class ReadingStatisticRow extends DataClass
           other.dateKey == this.dateKey &&
           other.charactersRead == this.charactersRead &&
           other.readingTimeMs == this.readingTimeMs &&
+          other.pagesRead == this.pagesRead &&
           other.lastStatisticModified == this.lastStatisticModified);
 }
 
@@ -5912,6 +5945,7 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
   final Value<String> dateKey;
   final Value<int> charactersRead;
   final Value<int> readingTimeMs;
+  final Value<int> pagesRead;
   final Value<int> lastStatisticModified;
   const ReadingStatisticsCompanion({
     this.id = const Value.absent(),
@@ -5919,6 +5953,7 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
     this.dateKey = const Value.absent(),
     this.charactersRead = const Value.absent(),
     this.readingTimeMs = const Value.absent(),
+    this.pagesRead = const Value.absent(),
     this.lastStatisticModified = const Value.absent(),
   });
   ReadingStatisticsCompanion.insert({
@@ -5927,6 +5962,7 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
     required String dateKey,
     required int charactersRead,
     required int readingTimeMs,
+    this.pagesRead = const Value.absent(),
     required int lastStatisticModified,
   })  : title = Value(title),
         dateKey = Value(dateKey),
@@ -5939,6 +5975,7 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
     Expression<String>? dateKey,
     Expression<int>? charactersRead,
     Expression<int>? readingTimeMs,
+    Expression<int>? pagesRead,
     Expression<int>? lastStatisticModified,
   }) {
     return RawValuesInsertable({
@@ -5947,6 +5984,7 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
       if (dateKey != null) 'date_key': dateKey,
       if (charactersRead != null) 'characters_read': charactersRead,
       if (readingTimeMs != null) 'reading_time_ms': readingTimeMs,
+      if (pagesRead != null) 'pages_read': pagesRead,
       if (lastStatisticModified != null)
         'last_statistic_modified': lastStatisticModified,
     });
@@ -5958,6 +5996,7 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
       Value<String>? dateKey,
       Value<int>? charactersRead,
       Value<int>? readingTimeMs,
+      Value<int>? pagesRead,
       Value<int>? lastStatisticModified}) {
     return ReadingStatisticsCompanion(
       id: id ?? this.id,
@@ -5965,6 +6004,7 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
       dateKey: dateKey ?? this.dateKey,
       charactersRead: charactersRead ?? this.charactersRead,
       readingTimeMs: readingTimeMs ?? this.readingTimeMs,
+      pagesRead: pagesRead ?? this.pagesRead,
       lastStatisticModified:
           lastStatisticModified ?? this.lastStatisticModified,
     );
@@ -5988,6 +6028,9 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
     if (readingTimeMs.present) {
       map['reading_time_ms'] = Variable<int>(readingTimeMs.value);
     }
+    if (pagesRead.present) {
+      map['pages_read'] = Variable<int>(pagesRead.value);
+    }
     if (lastStatisticModified.present) {
       map['last_statistic_modified'] =
           Variable<int>(lastStatisticModified.value);
@@ -6003,6 +6046,7 @@ class ReadingStatisticsCompanion extends UpdateCompanion<ReadingStatisticRow> {
           ..write('dateKey: $dateKey, ')
           ..write('charactersRead: $charactersRead, ')
           ..write('readingTimeMs: $readingTimeMs, ')
+          ..write('pagesRead: $pagesRead, ')
           ..write('lastStatisticModified: $lastStatisticModified')
           ..write(')'))
         .toString();
@@ -24445,6 +24489,7 @@ typedef $$ReadingStatisticsTableCreateCompanionBuilder
   required String dateKey,
   required int charactersRead,
   required int readingTimeMs,
+  Value<int> pagesRead,
   required int lastStatisticModified,
 });
 typedef $$ReadingStatisticsTableUpdateCompanionBuilder
@@ -24454,6 +24499,7 @@ typedef $$ReadingStatisticsTableUpdateCompanionBuilder
   Value<String> dateKey,
   Value<int> charactersRead,
   Value<int> readingTimeMs,
+  Value<int> pagesRead,
   Value<int> lastStatisticModified,
 });
 
@@ -24481,6 +24527,9 @@ class $$ReadingStatisticsTableFilterComposer
 
   ColumnFilters<int> get readingTimeMs => $composableBuilder(
       column: $table.readingTimeMs, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get pagesRead => $composableBuilder(
+      column: $table.pagesRead, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get lastStatisticModified => $composableBuilder(
       column: $table.lastStatisticModified,
@@ -24513,6 +24562,9 @@ class $$ReadingStatisticsTableOrderingComposer
       column: $table.readingTimeMs,
       builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get pagesRead => $composableBuilder(
+      column: $table.pagesRead, builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<int> get lastStatisticModified => $composableBuilder(
       column: $table.lastStatisticModified,
       builder: (column) => ColumnOrderings(column));
@@ -24541,6 +24593,9 @@ class $$ReadingStatisticsTableAnnotationComposer
 
   GeneratedColumn<int> get readingTimeMs => $composableBuilder(
       column: $table.readingTimeMs, builder: (column) => column);
+
+  GeneratedColumn<int> get pagesRead =>
+      $composableBuilder(column: $table.pagesRead, builder: (column) => column);
 
   GeneratedColumn<int> get lastStatisticModified => $composableBuilder(
       column: $table.lastStatisticModified, builder: (column) => column);
@@ -24580,6 +24635,7 @@ class $$ReadingStatisticsTableTableManager extends RootTableManager<
             Value<String> dateKey = const Value.absent(),
             Value<int> charactersRead = const Value.absent(),
             Value<int> readingTimeMs = const Value.absent(),
+            Value<int> pagesRead = const Value.absent(),
             Value<int> lastStatisticModified = const Value.absent(),
           }) =>
               ReadingStatisticsCompanion(
@@ -24588,6 +24644,7 @@ class $$ReadingStatisticsTableTableManager extends RootTableManager<
             dateKey: dateKey,
             charactersRead: charactersRead,
             readingTimeMs: readingTimeMs,
+            pagesRead: pagesRead,
             lastStatisticModified: lastStatisticModified,
           ),
           createCompanionCallback: ({
@@ -24596,6 +24653,7 @@ class $$ReadingStatisticsTableTableManager extends RootTableManager<
             required String dateKey,
             required int charactersRead,
             required int readingTimeMs,
+            Value<int> pagesRead = const Value.absent(),
             required int lastStatisticModified,
           }) =>
               ReadingStatisticsCompanion.insert(
@@ -24604,6 +24662,7 @@ class $$ReadingStatisticsTableTableManager extends RootTableManager<
             dateKey: dateKey,
             charactersRead: charactersRead,
             readingTimeMs: readingTimeMs,
+            pagesRead: pagesRead,
             lastStatisticModified: lastStatisticModified,
           ),
           withReferenceMapper: (p0) => p0

--- a/packages/hibiki_core/lib/src/database/tables.dart
+++ b/packages/hibiki_core/lib/src/database/tables.dart
@@ -136,6 +136,14 @@ class ReadingStatistics extends Table {
   TextColumn get dateKey => text()();
   IntColumn get charactersRead => integer()();
   IntColumn get readingTimeMs => integer()();
+
+  /// v60：当日读过的**页数**（漫画 / PDF 这类以页为单位的书；EPUB 恒 0）。
+  ///
+  /// 页数与字数是两个独立量纲，绝不互相顶替：漫画既落 OCR 字符数（与 EPUB 同口径）
+  /// 又落页数，统计页两个维度分别展示。旧库迁移补 0，跨设备聚合同步的 wire 契约
+  /// 不带此列（[StatBucket] 要求两端字段集一致，加字段会让新旧端互相抛错），页数
+  /// 随整库备份/恢复走。
+  IntColumn get pagesRead => integer().withDefault(const Constant(0))();
   IntColumn get lastStatisticModified => integer()();
 
   @override


### PR DESCRIPTION
## 用户需求

1. 底栏里把游戏移动到视频后面。
2. 删掉「口径：阅读 + 视频字幕 + 游戏文本的全部字符数合计」这句话，并且把游戏、漫画等加上支持。
3. 漫画同时统计页数、视频同时统计字数、游戏同时统计时长。

## 为什么那句口径文案该删

它根本对不上：首页每日目标的分子一直是 阅读 + 视频字幕 + 游戏文本 三源合计，而**阅读统计页只读 `reading_statistics`**（只有书内阅读），两个页面编辑同一个目标却是两套分子。漫画更糟——`charsRead` 恒 0，字数和页数都没有落点。所以不是改文案，是把口径做真。

## 改了什么

### 1. 底栏顺序
`homeActiveTabs` 里 games 从「词典 ↔ 设置之间」移到紧跟 video：
首页 → 书架 → 漫画 → **视频 → 游戏** → 下载 → 词典 →（扩展）→ 设置。位置仍由这一个纯函数导出，底栏 / 侧栏 / macOS 原生侧栏共用同一真值。

### 2. 删口径文案
`stat_goal_scope_hint` 三处使用（首页目标弹窗 helperText、首页未设目标行、统计页目标弹窗）全删，key 经 `i18n_sync --remove` 从 17 个语言下线并重生成 `strings.g.dart`。首页未设目标行退回「每日目标」本名。

### 3. schema v59 → v60：`reading_statistics.pages_read`
字数与页数是**两个独立量纲**，页数绝不塞进 `characters_read`（会污染字数口径与阅读速度）。

- 迁移带表 / 列存在性双守卫（从 v1 起的完整阶梯里该表可能尚未建），旧行回填 0。
- 跨设备聚合同步的 wire 契约**刻意不带页数**：`StatBucket.maxWith` 要求两端字段集一致，加字段会让新旧版设备互相抛 `ArgumentError`。`setReadingStatistic` 的冲突更新也不写该列，对端「没有页数」不会把本地已记的页数抹成 0。

### 4. 漫画真正进字数口径
按已读页的 mokuro OCR 文本计字数，口径复用 EPUB 的 `japaneseCharCount`（剔标点 / 括号 / 空白），所以漫画与 EPUB 的「字数」「速度」可直接相加比较；同时计页数。一页在一次会话里只记一次，来回翻页刷不出数；跳读没停留过的页不计——宁可少算，不虚高。

### 5. 阅读统计页四来源同口径
新增 `stat_source_totals.dart` 纯函数层，把 书 / 漫画 / 视频 / 游戏 摊平成同一形状（各带字数 + 时长，漫画多一维页数）：

- KPI、今日 / 本周 / 本月 / 全部、目标进度、趋势、连续天数全部改为四来源同一口径（与首页每日目标一致）。看了视频、玩了游戏的那天也算学习日，不再因为没读书就断签。
- 新增「各来源」卡：按窗口（今日 / 本周 / 本月 / 全部）展示每源「字数 · 时长（· 页数）」，空来源不渲染。
- 漫画按 `epub_books.format == 'manga'` 从阅读里拆出，**不靠 `pagesRead > 0` 猜身份**；查不到 title 的行（书已删统计还在）归阅读。
- 空态判据改为四来源皆空——只看视频 / 只玩游戏的用户此前会被判「暂无数据」。
- 「按书」列表仍只列书（视频 / 游戏不是书）。

## 验证

- `flutter analyze`（含 test）：零问题。
- `dart run tool/flutter_test_failures.dart --no-pub` 全量：**15015 例**，唯一失败 `home_video_remote_download_register`（host 外挂字幕下载）单独重跑即绿，属并发隔离型 flaky，与本改动无交集。
- 新增守卫：v60 迁移（旧行零破坏 + 页数字数独立累加 + fresh 库 onCreate）、漫画字数 / 页数记账（口径、去重、越界）、来源拆分（format 拆漫画、窗口求和、活跃日并集、未知 title 归阅读）。

## 未做（明确留出）

- PDF 页数：`pages_read` 列已就位，但 PDF 阅读器本轮未接入（用户只提了漫画）。
- 首页仪表盘未加「各来源」明细卡（用户指的是统计口径处）。
- 真机验收：统计页 UI 与漫画记账未在真机复测。

https://claude.ai/code/session_01BRfYR8cUvPNmsVPFR3fZYs
