### PR TITLE
feat(manga): 漫画页补齐焦点所有权 + 共享键盘桥 + 快捷键注册表

### DIFF
--- a/docs/agent/focus-ownership.md
+++ b/docs/agent/focus-ownership.md
@@ -40,9 +40,9 @@
 
 焦点抢回来只解决「OS 焦点归 Flutter」的情况。焦点归 WebView2 期间按下的键**只存在于 DOM 里**，必须在内容层截获后交回 Dart——桌面 Windows 上 fork 的 `flutter_inappwebview_windows` 只转鼠标不转键盘。
 
-用 `lib/src/focus/webview_key_bridge.dart` 的 `webViewKeyBridgeScript({handlerName, keys})`，别自己写一份 `keydown` 监听：它固化了「只拦裸键、放行修饰键组合 / IME composing / `input|textarea|contenteditable`、命中才 `preventDefault`」这套判据，漏一条就是吃掉用户改键语义或打不出空格。
+用 `lib/src/focus/webview_key_bridge.dart` 的 `webViewKeyBridgeScript({handlerName, keys, forwardRepeats, stopPropagation})`，别自己写一份 `keydown` 监听：它固化了「只拦裸键、放行修饰键组合 / IME composing / `input|textarea|contenteditable`、命中才 `preventDefault`」这套判据，漏一条就是吃掉用户改键语义或打不出空格。
 
-生成结果整体裹在 `;(function () { … })();` 里，键表关在闭包中：同一 document 注入多份桥（阅读器一份、漫画页规划中再一份）时，若键表是脚本级全局 `var`，后注入的一份会把先注入的整个覆盖掉而两个 listener 都还在，表现为「某一页的键突然全不响应」。前导 `;` 是拼接安全惯例（本脚本插在 setup 大脚本中间）。
+生成结果整体裹在 `;(function () { … })();` 里，键表关在闭包中：同一 document 注入多份桥（阅读器的 Space 桥、漫画的导航键桥）时，若键表是脚本级全局 `var`，后注入的一份会把先注入的整个覆盖掉而两个 listener 都还在，表现为「某一页的键突然全不响应」。前导 `;` 是拼接安全惯例（本脚本插在 setup 大脚本中间）。
 
 改动注入脚本后注意 `hibiki/test/reader/reader_script_compactor_test.dart`：给 setup 模板新增插值必须在它的替身表里登记，否则该守卫直接 `StateError`（它保证最终拼装脚本的压缩有覆盖，并用 node `--check` 真解析）。
 

--- a/docs/agent/focus-ownership.md
+++ b/docs/agent/focus-ownership.md
@@ -56,6 +56,8 @@
 
 翻页方向：注册表存**页序语义**（forward = 下一页），左右键的物理朝向由 `shortcuts/manga_arrow_override.dart` 的 `resolveMangaArrowPageTurn` 按跨页方向（日漫默认 rtl）校正，与 reader 的 `resolveReaderArrowPageTurn` 同构。方向不能进注册表——注册表全局、每本书排版不同，直接把 `ArrowLeft` 绑成 backward 会让 rtl 的书翻反。
 
-键盘桥用 `forwardRepeats: false`（本页有意设计：按住方向键不堆翻页风暴）+ `stopPropagation: true`。桥每次换加载窗口都会重新注入，靠生成器自带的幂等守卫防 listener 叠加（否则一次按键翻两页）。
+键盘桥用 `forwardRepeats: false`（本页有意设计：按住方向键不堆翻页风暴）+ `stopPropagation: true`。注意桥从旧手写版的 **capture 阶段**（`addEventListener(..., true)`）改成了共享生成器的**冒泡阶段**（仍带 `stopImmediatePropagation`）——漫画文档目前没有别的 `keydown` 监听，所以行为等价；若将来给漫画页图注入了自己的键盘处理，要重新核这条。桥每次换加载窗口都会重新注入，靠生成器自带的幂等守卫防 listener 叠加（否则一次按键翻两页）。
 
-新增 action 后若 `shortcut_action_wiring_guard` 报「死项」，是执行体清单没登记本页——那正是它该拦的。
+**③ 漫画只接了键盘通道，没接手柄/鼠标。** `ShortcutScope.manga.channels` 因此只开 `keyboard`，默认表里也**不许**有手柄绑定。曾经配过 RB/LB/dpad/B，但本页既没有 `resolveGamepad`、也没有 `GamepadButtonIntent` 的 Action（Android 的 `gameButton*` 键事件同样匹配不到纯键盘绑定），结果是用户在设置里能配、按下去毫无反应——**比压根没这个选项更糟**，用户会以为自己手柄坏了。要加回来必须先照 reader 的 `_handleGamepadButton`（`caret.part.dart`）接上解析入口 + 在 build 里挂 `Actions(GamepadButtonIntent: …)`，并真机验证过再开通道。滚轮同理：本页翻页走硬编码的 `wheelInputAction`，不查注册表。
+
+两条守卫分工别搞混：`shortcut_action_wiring_guard` 只看「`ShortcutAction.<名>` 这个符号在执行体文件里出现过没有」，抓不到「键盘接了、手柄没接」这种半接线；`shortcut_channel_wiring_guard` 才是按 **(scope, channel)** 核解析入口的那条——新增 action 后报「死项」找前者，开了通道却没接线报红找后者。

--- a/docs/agent/focus-ownership.md
+++ b/docs/agent/focus-ownership.md
@@ -46,8 +46,16 @@
 
 改动注入脚本后注意 `hibiki/test/reader/reader_script_compactor_test.dart`：给 setup 模板新增插值必须在它的替身表里登记，否则该守卫直接 `StateError`（它保证最终拼装脚本的压缩有覆盖，并用 node `--check` 真解析）。
 
-## 已知未接入：漫画页
+## 漫画页（已接入，注意两处与阅读器相反的规则）
 
-`manga_hibiki_page.dart` 至今是硬编码 `if (key == LogicalKeyboardKey.arrowRight)`：不查 registry（不能改键、无手柄）、丢 `KeyRepeatEvent`（按住方向键不连翻）、零焦点回收、JS 侧无 keydown 桥。桌面上在漫画 WebView 里点/拖一次之后方向键翻页即失效且**无自愈路径**。
+实现在 `lib/src/media/manga/reader/manga_hibiki_page.dart`（`lib/src/pages/implementations/manga_hibiki_page.dart` 只是 3 行兼容 export，别改那个）。三层都已接：`PageFocusOwnership` + `ShortcutScope.manga` + 共享键盘桥。
 
-接入时要做的：`ShortcutScope.manga` + manga action 集 + 默认绑定 + i18n（走 `hibiki/tool/i18n_sync.dart --add`，禁手改 json）+ `PageFocusOwnership` 实例 + 键盘桥。**动手前先确认漫画在线源那批 PR（#411 / #417 系）已落地**，否则必然撞车重做。
+**① 词典弹窗可见时，漫画不让位。** 阅读器的 `gesture` 判据在弹窗可见时早退（弹窗自持焦点，BUG-136）；漫画的 `_canOwnMangaFocus` 必须相反——本页规定弹窗可见时左右键仍要「关弹窗并翻页」、Escape 要关弹窗，而弹窗是纯原生 WebView、没有 Flutter 焦点节点，不主动收回这些键就全部落空。这与本页覆写 `capturesDictionaryPopupNavigationKeys` 是同一诉求的两半，改任一边都要同时想另一边。
+
+**② 左右方向键不受 webtoon / 弹窗门控。** 它们是**跨页步进**语义（`inputActionForShortcut` 的 `horizontalArrow` 参数）：webtoon 的纵向滚动不影响它们，弹窗可见时也要生效。其余前进/后退键则要让位——弹窗可见时空格归词典，webtoon 下纵向键归 WebView 原生竖滚。
+
+翻页方向：注册表存**页序语义**（forward = 下一页），左右键的物理朝向由 `shortcuts/manga_arrow_override.dart` 的 `resolveMangaArrowPageTurn` 按跨页方向（日漫默认 rtl）校正，与 reader 的 `resolveReaderArrowPageTurn` 同构。方向不能进注册表——注册表全局、每本书排版不同，直接把 `ArrowLeft` 绑成 backward 会让 rtl 的书翻反。
+
+键盘桥用 `forwardRepeats: false`（本页有意设计：按住方向键不堆翻页风暴）+ `stopPropagation: true`。桥每次换加载窗口都会重新注入，靠生成器自带的幂等守卫防 listener 叠加（否则一次按键翻两页）。
+
+新增 action 后若 `shortcut_action_wiring_guard` 报「死项」，是执行体清单没登记本页——那正是它该拦的。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46070 (2710 per locale)
+/// Strings: 46138 (2714 per locale)
 ///
-/// Built on 2026-07-28 at 07:13 UTC
+/// Built on 2026-07-28 at 07:50 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3638,6 +3638,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get gal_mining_image_mode_screenshot => 'Screenshot';
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  String get shortcut_scope_manga => 'Manga';
+  String get shortcut_action_manga_page_forward => 'Next page';
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -9834,6 +9838,14 @@ class _StringsAr extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -16098,6 +16110,14 @@ class _StringsDe extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -22378,6 +22398,14 @@ class _StringsEs extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -28669,6 +28697,14 @@ class _StringsFr extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -34889,6 +34925,14 @@ class _StringsId extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -41155,6 +41199,14 @@ class _StringsIt extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -47238,6 +47290,14 @@ class _StringsJa extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -53323,6 +53383,14 @@ class _StringsKo extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -59569,6 +59637,14 @@ class _StringsNl extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -65828,6 +65904,14 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -72071,6 +72155,14 @@ class _StringsRu extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -78262,6 +78354,14 @@ class _StringsTh extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -84485,6 +84585,14 @@ class _StringsTr extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -90693,6 +90801,14 @@ class _StringsVi extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 // Path: <root>
@@ -96467,6 +96583,14 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame 一句台词内画面基本不动，静态截图通常更小、信息量一样。';
+  @override
+  String get shortcut_scope_manga => '漫画';
+  @override
+  String get shortcut_action_manga_page_forward => '下一页';
+  @override
+  String get shortcut_action_manga_page_backward => '上一页';
+  @override
+  String get shortcut_action_manga_dismiss_dict => '关闭词典';
 }
 
 // Path: <root>
@@ -102471,6 +102595,14 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get gal_mining_image_mode_hint =>
       'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+  @override
+  String get shortcut_scope_manga => 'Manga';
+  @override
+  String get shortcut_action_manga_page_forward => 'Next page';
+  @override
+  String get shortcut_action_manga_page_backward => 'Previous page';
+  @override
+  String get shortcut_action_manga_dismiss_dict => 'Close dictionary';
 }
 
 /// Flat map(s) containing all translations.
@@ -108023,6 +108155,14 @@ extension on _StringsEn {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -113573,6 +113713,14 @@ extension on _StringsAr {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -119144,6 +119292,14 @@ extension on _StringsDe {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -124714,6 +124870,14 @@ extension on _StringsEs {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -130290,6 +130454,14 @@ extension on _StringsFr {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -135848,6 +136020,14 @@ extension on _StringsId {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -141421,6 +141601,14 @@ extension on _StringsIt {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -146956,6 +147144,14 @@ extension on _StringsJa {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -152495,6 +152691,14 @@ extension on _StringsKo {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -158061,6 +158265,14 @@ extension on _StringsNl {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -163624,6 +163836,14 @@ extension on _StringsPtBr {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -169192,6 +169412,14 @@ extension on _StringsRu {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -174744,6 +174972,14 @@ extension on _StringsTh {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -180305,6 +180541,14 @@ extension on _StringsTr {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -185861,6 +186105,14 @@ extension on _StringsVi {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }
@@ -191371,6 +191623,14 @@ extension on _StringsZhCn {
         return '静态截图';
       case 'gal_mining_image_mode_hint':
         return 'Galgame 一句台词内画面基本不动，静态截图通常更小、信息量一样。';
+      case 'shortcut_scope_manga':
+        return '漫画';
+      case 'shortcut_action_manga_page_forward':
+        return '下一页';
+      case 'shortcut_action_manga_page_backward':
+        return '上一页';
+      case 'shortcut_action_manga_dismiss_dict':
+        return '关闭词典';
       default:
         return null;
     }
@@ -196901,6 +197161,14 @@ extension on _StringsZhHk {
         return 'Screenshot';
       case 'gal_mining_image_mode_hint':
         return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
+      case 'shortcut_scope_manga':
+        return 'Manga';
+      case 'shortcut_action_manga_page_forward':
+        return 'Next page';
+      case 'shortcut_action_manga_page_backward':
+        return 'Previous page';
+      case 'shortcut_action_manga_dismiss_dict':
+        return 'Close dictionary';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "为「$name」匹配封面",
   "gal_mining_image_mode": "Galgame 制卡配图",
   "gal_mining_image_mode_screenshot": "静态截图",
-  "gal_mining_image_mode_hint": "Galgame 一句台词内画面基本不动，静态截图通常更小、信息量一样。"
+  "gal_mining_image_mode_hint": "Galgame 一句台词内画面基本不动，静态截图通常更小、信息量一样。",
+  "shortcut_scope_manga": "漫画",
+  "shortcut_action_manga_page_forward": "下一页",
+  "shortcut_action_manga_page_backward": "上一页",
+  "shortcut_action_manga_dismiss_dict": "关闭词典"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2708,5 +2708,9 @@
   "video_scrape_online_match_collection": "Match cover for $name",
   "gal_mining_image_mode": "Galgame card image",
   "gal_mining_image_mode_screenshot": "Screenshot",
-  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.",
+  "shortcut_scope_manga": "Manga",
+  "shortcut_action_manga_page_forward": "Next page",
+  "shortcut_action_manga_page_backward": "Previous page",
+  "shortcut_action_manga_dismiss_dict": "Close dictionary"
 }

--- a/hibiki/lib/src/focus/webview_key_bridge.dart
+++ b/hibiki/lib/src/focus/webview_key_bridge.dart
@@ -32,25 +32,45 @@ library;
 /// 且极难定位。裹进 IIFE 后每份桥各自闭包持有自己的键表，多份共存互不相干。
 /// 前导 `;` 是拼接安全惯例：本脚本被插进一大段 setup 脚本中间，前一条语句若少了
 /// 分号，裸 `(function…` 会被解析成对它的调用。
+/// [forwardRepeats] 为 false 时丢弃长按产生的 `KeyRepeatEvent`（`e.repeat`）。
+/// 漫画页要的是「按住方向键不堆翻页风暴」，阅读器则保留连发，故做成参数而不是
+/// 二选一写死。
+///
+/// [stopPropagation] 为 true 时额外 `stopImmediatePropagation()`，用于宿主文档里
+/// 还有别的 keydown 监听、且这些键必须**独占**给 Dart 的场合。
+///
+/// 生成的脚本自带按 [handlerName] 派生的幂等安装守卫：宿主可能对同一 document
+/// 反复注入（漫画每次换加载窗口都重新 evaluate 一次），没有守卫就会叠加多个
+/// listener → 一次按键回传多次 → 翻页翻两页。
 String webViewKeyBridgeScript({
   required String handlerName,
   required List<String> keys,
+  bool forwardRepeats = true,
+  bool stopPropagation = false,
 }) {
   assert(keys.isNotEmpty, 'a key bridge with no keys would be dead code');
   final String keyList = keys.map(_jsStringLiteral).join(', ');
+  final String installFlag =
+      _jsStringLiteral('__hoshiKeyBridgeInstalled_$handlerName');
+  final String repeatGuard =
+      forwardRepeats ? '' : '\n    if (e.repeat) return;';
+  final String propagationGuard =
+      stopPropagation ? '\n    e.stopImmediatePropagation();' : '';
   return '''
   ;(function () {
+  if (window[$installFlag]) return;
+  window[$installFlag] = true;
   var _hoshiBridgeKeys = [$keyList];
   document.addEventListener('keydown', function(e) {
     if (!e || _hoshiBridgeKeys.indexOf(e.key) === -1) return;
     if (e.ctrlKey || e.shiftKey || e.altKey || e.metaKey) return;
-    if (e.isComposing) return;
+    if (e.isComposing) return;$repeatGuard
     var t = e.target;
     if (t) {
       var tag = t.tagName ? t.tagName.toUpperCase() : '';
       if (tag === 'INPUT' || tag === 'TEXTAREA' || t.isContentEditable) return;
     }
-    e.preventDefault();
+    e.preventDefault();$propagationGuard
     if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
       window.flutter_inappwebview.callHandler('$handlerName', e.key);
     }

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -8,7 +8,7 @@ import 'package:drift/drift.dart' show Value;
 import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
+import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:path/path.dart' as p;
 
@@ -25,6 +25,11 @@ import 'package:hibiki/src/media/manga/manga_spread_model.dart';
 import 'package:hibiki/src/media/manga/mokuro_payload.dart';
 import 'package:hibiki/src/media/manga/ocr/manga_ocr_cache_recovery.dart';
 import 'package:hibiki/src/focus/page_focus_ownership.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart'
+    show ModifierKey, activeModifierKeys;
+import 'package:hibiki/src/shortcuts/manga_arrow_override.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
 import 'package:hibiki/src/focus/webview_key_bridge.dart';
 import 'package:hibiki/src/media/manga/reader/manga_window_load_gate.dart';
 import 'package:hibiki/src/pages/base_source_page.dart';
@@ -276,37 +281,35 @@ class MangaHibikiPage extends BaseSourcePage {
     return rightKey == rtl ? 'prev' : 'next';
   }
 
-  static MangaReaderInputAction? keyInputAction({
-    required LogicalKeyboardKey key,
+  /// 把注册表解析出的 [ShortcutAction] 落成本页的输入动作。
+  ///
+  /// 键位本身由 `ShortcutRegistry`（`ShortcutScope.manga`）解析，左右方向键的朝向
+  /// 再由 [resolveMangaArrowPageTurn] 按跨页方向校正——两步都在调用侧完成，本函数
+  /// 只负责「拿到动作之后，当前上下文该不该执行它」这层门控。
+  ///
+  /// [horizontalArrow] = 触发键是否为左/右方向键。它们是**跨页步进**语义，两道
+  /// 门控都不适用：webtoon 的纵向滚动不影响左右翻页；词典弹窗可见时也要「关弹窗
+  /// 并翻页」（本页与阅读器的关键差异）。其余前进/后退键则要让位——弹窗可见时空格
+  /// 归词典自己，webtoon 模式下纵向键归 WebView 原生滚动。
+  static MangaReaderInputAction? inputActionForShortcut({
+    required ShortcutAction? action,
+    required bool horizontalArrow,
     required bool dictionaryShown,
     required MangaReadingMode mode,
-    required String direction,
   }) {
-    if (dictionaryShown && key == LogicalKeyboardKey.escape) {
-      return MangaReaderInputAction.dismissDictionary;
+    if (action == null) return null;
+    if (action == ShortcutAction.mangaDismissDict) {
+      return dictionaryShown ? MangaReaderInputAction.dismissDictionary : null;
     }
-    if (key == LogicalKeyboardKey.arrowRight ||
-        key == LogicalKeyboardKey.arrowLeft) {
-      final String turn = horizontalKeyTurn(
-        direction: direction,
-        rightKey: key == LogicalKeyboardKey.arrowRight,
-      );
-      return turn == 'next'
-          ? MangaReaderInputAction.next
-          : MangaReaderInputAction.previous;
+    if (!horizontalArrow) {
+      if (dictionaryShown) return null;
+      if (mode == MangaReadingMode.webtoon) return null;
     }
-    if (dictionaryShown || mode == MangaReadingMode.webtoon) {
-      return null;
-    }
-    if (key == LogicalKeyboardKey.arrowDown ||
-        key == LogicalKeyboardKey.space ||
-        key == LogicalKeyboardKey.pageDown) {
-      return MangaReaderInputAction.next;
-    }
-    if (key == LogicalKeyboardKey.arrowUp || key == LogicalKeyboardKey.pageUp) {
-      return MangaReaderInputAction.previous;
-    }
-    return null;
+    return switch (action) {
+      ShortcutAction.mangaPageForward => MangaReaderInputAction.next,
+      ShortcutAction.mangaPageBackward => MangaReaderInputAction.previous,
+      _ => null,
+    };
   }
 
   static MangaReaderInputAction? wheelInputAction(Offset delta) {
@@ -1151,11 +1154,9 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     if (event is! KeyDownEvent) {
       return KeyEventResult.ignored;
     }
-    final MangaReaderInputAction? action = MangaHibikiPage.keyInputAction(
-      key: event.logicalKey,
-      dictionaryShown: isDictionaryShown,
-      mode: _mode,
-      direction: _spreadDirection,
+    final MangaReaderInputAction? action = _resolveMangaKeyAction(
+      event.logicalKey,
+      activeModifierKeys(),
     );
     if (action == null) return KeyEventResult.ignored;
     _executeReaderInputAction(
@@ -1236,6 +1237,34 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     _focusOwnership.reclaim(FocusReclaimCause.popupDismissed);
   }
 
+  /// 注册表解析 → 跨页方向校正 → 上下文门控。键盘路径与 WebView 桥回传路径共用，
+  /// 保证「改键」对两条路径同时生效（否则改了键，WebView 持焦时又变回默认键位）。
+  MangaReaderInputAction? _resolveMangaKeyAction(
+    LogicalKeyboardKey key,
+    Set<ModifierKey> modifiers,
+  ) {
+    final HibikiShortcutRegistry registry = appModel.shortcutRegistry;
+    final ShortcutAction? bound = registry.resolveKeyboard(
+      key,
+      modifiers: modifiers,
+      scope: ShortcutScope.manga,
+    );
+    final ShortcutAction? corrected = resolveMangaArrowPageTurn(
+          key: key,
+          modifiers: modifiers,
+          rtl: _spreadDirection == 'rtl',
+          boundAction: bound,
+        ) ??
+        bound;
+    return MangaHibikiPage.inputActionForShortcut(
+      action: corrected,
+      horizontalArrow: key == LogicalKeyboardKey.arrowLeft ||
+          key == LogicalKeyboardKey.arrowRight,
+      dictionaryShown: isDictionaryShown,
+      mode: _mode,
+    );
+  }
+
   void _handleNativeNavigationKey(String key) {
     final LogicalKeyboardKey? logicalKey = switch (key) {
       'ArrowLeft' => LogicalKeyboardKey.arrowLeft,
@@ -1244,11 +1273,10 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       _ => null,
     };
     if (logicalKey == null) return;
-    final MangaReaderInputAction? action = MangaHibikiPage.keyInputAction(
-      key: logicalKey,
-      dictionaryShown: isDictionaryShown,
-      mode: _mode,
-      direction: _spreadDirection,
+    // 桥只转发裸键（[webViewKeyBridgeScript] 放行一切修饰键组合），故这里传空集。
+    final MangaReaderInputAction? action = _resolveMangaKeyAction(
+      logicalKey,
+      const <ModifierKey>{},
     );
     if (action != null) {
       _executeReaderInputAction(

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -24,6 +24,8 @@ import 'package:hibiki/src/media/manga/manga_reading_mode.dart';
 import 'package:hibiki/src/media/manga/manga_spread_model.dart';
 import 'package:hibiki/src/media/manga/mokuro_payload.dart';
 import 'package:hibiki/src/media/manga/ocr/manga_ocr_cache_recovery.dart';
+import 'package:hibiki/src/focus/page_focus_ownership.dart';
+import 'package:hibiki/src/focus/webview_key_bridge.dart';
 import 'package:hibiki/src/media/manga/reader/manga_window_load_gate.dart';
 import 'package:hibiki/src/pages/base_source_page.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart';
@@ -319,23 +321,19 @@ class MangaHibikiPage extends BaseSourcePage {
   /// Native WebView2 owns keyboard focus while the user is reading. Forward
   /// navigation keys from the manga document to Dart so page turns do not
   /// depend on the platform view bubbling key events through Flutter.
+  /// 走共享生成器而非自写一份：手写版少了「放行修饰键组合 / IME 组字 / 输入框」
+  /// 三条放行判据，会吞掉 Ctrl+方向键，以及词典搜索框里的方向键。
+  ///
+  /// `forwardRepeats: false` 保留本页既有语义（按住方向键不堆翻页风暴）；
+  /// `stopPropagation: true` 保留独占（这些键必须只给 Dart）。`'Esc'` 与
+  /// `'Escape'` 都列进键表，旧浏览器归一由 [_handleNativeNavigationKey] 完成。
   @visibleForTesting
-  static const String navigationKeyBridgeScript = '''
-(function(){
-  if (window.__hibikiMangaNavigationKeysInstalled) return;
-  window.__hibikiMangaNavigationKeysInstalled = true;
-  document.addEventListener('keydown', function(e) {
-    if (e.repeat) return;
-    var key = e.key === 'Esc' ? 'Escape' : e.key;
-    if (key !== 'ArrowLeft' && key !== 'ArrowRight' && key !== 'Escape') return;
-    e.preventDefault();
-    e.stopImmediatePropagation();
-    try {
-      window.flutter_inappwebview.callHandler('onMangaNavigationKey', key);
-    } catch (err) {}
-  }, true);
-})();
-''';
+  static final String navigationKeyBridgeScript = webViewKeyBridgeScript(
+    handlerName: 'onMangaNavigationKey',
+    keys: const <String>['ArrowLeft', 'ArrowRight', 'Escape', 'Esc'],
+    forwardRepeats: false,
+    stopPropagation: true,
+  );
 
   /// 纯路径解析 + 穿越守卫。[relative] 在 [imagesRoot] 内解析到存在的文件时返回
   /// 规范绝对路径，否则 null（越界/缺文件都不 serve）。从 WebView 路径抽出，安全
@@ -564,6 +562,48 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   // 密集 OCR 命中层只保留当前 spread；图片页本身全部留在稳定的 lazy strip。
   static const int _kWindowRadius = 0;
 
+  /// 漫画正文的键盘焦点节点（本页唯一持有者）。
+  final FocusNode _focusNode = FocusNode(debugLabel: 'mangaKeyboard');
+
+  /// 本页键盘焦点的单一所有者：所有回收走它，判据集中在 [_canOwnMangaFocus]。
+  ///
+  /// 统一前漫画页**一处焦点回收都没有**（视频页 29 处、阅读器页 28 处），而它同样
+  /// 把正文交给原生 WebView 渲染——桌面上用户在漫画 WebView 里点/拖一次，OS 焦点
+  /// 就归了 WebView2，整页 `autofocus: true` 只在首帧生效、之后再没有任何路径把
+  /// 焦点要回来，方向键翻页从此失效且**无自愈**。
+  late final PageFocusOwnership _focusOwnership = PageFocusOwnership(
+    node: _focusNode,
+    canOwn: _canOwnMangaFocus,
+  );
+
+  /// 「漫画正文此刻应当持有键盘」的统一判据。
+  bool _canOwnMangaFocus(FocusReclaimCause cause) {
+    if (!mounted) return false;
+    switch (cause) {
+      // 与阅读器**相反**：阅读器在词典弹窗可见时让位（弹窗自持焦点，BUG-136），
+      // 漫画不能让——[MangaHibikiPage.keyInputAction] 规定弹窗可见时左右键仍要
+      // 「关弹窗并翻页」、Escape 要关弹窗，这些键必须抵达 [_handleReaderKey]。
+      // 词典弹窗是纯原生 WebView、没有 Flutter 焦点节点，不主动收回就全部落空。
+      // 这也正是本页覆写 [capturesDictionaryPopupNavigationKeys] 的同一诉求。
+      case FocusReclaimCause.popupRendered:
+        return isDictionaryShown;
+      case FocusReclaimCause.gesture:
+      case FocusReclaimCause.popupDismissed:
+      case FocusReclaimCause.contentReady:
+      case FocusReclaimCause.overlayClosed:
+      case FocusReclaimCause.surfaceRemounted:
+      // 本页顶部 chrome（页码 + 阅读模式切换）是常驻的，不参与焦点遍历，
+      // 显隐后重新确认焦点仍在正文即可。
+      case FocusReclaimCause.chromeToggled:
+        return true;
+      // 回前台是全局生命周期回调，本页上方可能压着全屏看图路由 / 对话框；
+      // 此时抢焦点会夺走它们的键盘（Never break userspace）。
+      case FocusReclaimCause.appResumed:
+        final ModalRoute<Object?>? owner = ModalRoute.of(context);
+        return owner == null || owner.isCurrent;
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -589,6 +629,7 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     unawaited(_flushPosition());
     _readingTimeTracker?.dispose();
     _pageNotifier.dispose();
+    _focusNode.dispose();
     super.dispose();
   }
 
@@ -603,6 +644,8 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       // BUG-892 同款纪律：回前台重锚会话起点，否则整段后台时长被计入。
       _sessionStartTime = DateTime.now();
       _readingTimeTracker?.start();
+      // OS 层焦点丢失后 Flutter 不保证归还到原节点：切窗回来若不收回，翻页键全死。
+      _focusOwnership.reclaim(FocusReclaimCause.appResumed);
     }
   }
 
@@ -1172,6 +1215,25 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   @override
   void onDictionaryPopupNavigationKey(String key) {
     _handleNativeNavigationKey(key);
+  }
+
+  /// 词典弹窗渲染完成（指针唤出路径）：把 Flutter 焦点收回正文。
+  ///
+  /// 弹窗是纯原生 WebView，指针唤出它时 OS 焦点落在弹窗上。漫画在弹窗可见时
+  /// **仍要**处理左右键（关弹窗并翻页）与 Escape（关弹窗），不收回这些键就全部
+  /// 落空——[onDictionaryPopupNavigationKey] 的转发只覆盖弹窗自己收到的键，
+  /// 覆盖不了「焦点悬空」的情况。
+  @override
+  void onDictionaryPopupRendered(int index) {
+    super.onDictionaryPopupRendered(index);
+    _focusOwnership.reclaim(FocusReclaimCause.popupRendered);
+  }
+
+  /// 整条查词弹窗栈关闭：键盘所有权无条件回到正文，否则用户被困死（收不到任何键）。
+  @override
+  void onAllPopupsDismissed() {
+    super.onAllPopupsDismissed();
+    _focusOwnership.reclaim(FocusReclaimCause.popupDismissed);
   }
 
   void _handleNativeNavigationKey(String key) {
@@ -1858,6 +1920,7 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         // 键盘兜底必须包住正文、chrome 和词典弹层。旧结构只包正文 WebView，
         // 词典 WebView 获得焦点后变成 sibling，左右键/Escape 不再经过本处理器。
         body: Focus(
+          focusNode: _focusNode,
           autofocus: true,
           onKeyEvent: _handleReaderKey,
           child: Stack(
@@ -2092,7 +2155,11 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         // 空白 tap 是 no-op（记录 sink 让手势机契约可观察）。
         controller.addJavaScriptHandler(
           handlerName: 'onTapEmpty',
-          callback: (List<dynamic> args) {},
+          callback: (List<dynamic> args) {
+            // 空白 tap 本身是 no-op，但指针已让原生 WebView 夺走 OS 焦点，
+            // 必须把 Flutter 焦点收回，否则此后方向键翻页全部失效。
+            _focusOwnership.reclaim(FocusReclaimCause.gesture);
+          },
         );
         controller.addJavaScriptHandler(
           handlerName: 'onMangaOcrHitDebug',
@@ -2116,6 +2183,9 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
           handlerName: 'onMangaTurn',
           callback: (List<dynamic> args) {
             if (args.isEmpty) return;
+            // 手势/滚轮翻页经原生 WebView 触发，指针已夺焦：翻完把键盘收回，
+            // 否则「滑一下之后方向键就不灵了」（与阅读器 BUG-136 同源）。
+            _focusOwnership.reclaim(FocusReclaimCause.gesture);
             unawaited(_onMangaTurn(args[0] as String));
           },
         );
@@ -2230,5 +2300,9 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     }
     _windowGate.complete(ticket, MangaWindowLoadOutcome.ready);
     _recordProgress();
+    // 正文就绪的确定性落焦：整页 autofocus 会抢在 WebView 内容就绪之前，焦点落在
+    // 表面层；换窗（翻到下一个加载窗口）同样会重挂平台视图。这里在每个就绪落点
+    // 补一次，让首开/换窗后第一次按方向键就作用在漫画上。
+    _focusOwnership.reclaim(FocusReclaimCause.contentReady);
   }
 }

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/caret.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/caret.part.dart
@@ -26,22 +26,9 @@ part of '../reader_hibiki_page.dart';
 extension _ReaderCaret on _ReaderHibikiPageState {
   /// 当前按下的修饰键集合（Ctrl/Shift/Alt/Meta）。键盘快捷解析与底栏焦点的
   /// Space 覆写共用，避免两处各自重建一份。
-  Set<ModifierKey> _activeModifiers() {
-    final Set<ModifierKey> modifiers = <ModifierKey>{};
-    if (HardwareKeyboard.instance.isControlPressed) {
-      modifiers.add(ModifierKey.ctrl);
-    }
-    if (HardwareKeyboard.instance.isShiftPressed) {
-      modifiers.add(ModifierKey.shift);
-    }
-    if (HardwareKeyboard.instance.isAltPressed) {
-      modifiers.add(ModifierKey.alt);
-    }
-    if (HardwareKeyboard.instance.isMetaPressed) {
-      modifiers.add(ModifierKey.meta);
-    }
-    return modifiers;
-  }
+  /// 实现已抽到 [activeModifierKeys]（漫画页也要同一份，各自重建必漂）；
+  /// 这里保留同名转发，避免改动本 part 里十余处调用点。
+  Set<ModifierKey> _activeModifiers() => activeModifierKeys();
 
   KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
     // The popup header toolbar (sibling of the popup content). Down returns to

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -92,7 +92,7 @@ import 'package:hibiki/src/utils/components/hibiki_icon_button.dart';
 import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
 import 'package:hibiki/src/utils/misc/show_app_dialog.dart';
 import 'package:hibiki/src/shortcuts/input_binding.dart'
-    show GamepadButton, ModifierKey;
+    show GamepadButton, ModifierKey, activeModifierKeys;
 import 'package:hibiki/src/shortcuts/gamepad_service.dart'
     show GamepadButtonIntent, GamepadLongPressIntent, focusedEditableText;
 import 'package:hibiki/src/shortcuts/shortcut_action.dart';

--- a/hibiki/lib/src/shortcuts/input_binding.dart
+++ b/hibiki/lib/src/shortcuts/input_binding.dart
@@ -675,3 +675,24 @@ class ShortcutBindingSet {
         wheelBindings: wheelBindings ?? this.wheelBindings,
       );
 }
+
+/// 当前按下的修饰键集合（Ctrl / Shift / Alt / Meta）。
+///
+/// 所有页面解析键盘绑定前都要拼这个集合，各自重建一份只会漂——阅读器与漫画页
+/// 共用本函数，新页面也应直接调它，不要再抄一遍 [HardwareKeyboard] 四连判。
+Set<ModifierKey> activeModifierKeys() {
+  final Set<ModifierKey> modifiers = <ModifierKey>{};
+  if (HardwareKeyboard.instance.isControlPressed) {
+    modifiers.add(ModifierKey.ctrl);
+  }
+  if (HardwareKeyboard.instance.isShiftPressed) {
+    modifiers.add(ModifierKey.shift);
+  }
+  if (HardwareKeyboard.instance.isAltPressed) {
+    modifiers.add(ModifierKey.alt);
+  }
+  if (HardwareKeyboard.instance.isMetaPressed) {
+    modifiers.add(ModifierKey.meta);
+  }
+  return modifiers;
+}

--- a/hibiki/lib/src/shortcuts/manga_arrow_override.dart
+++ b/hibiki/lib/src/shortcuts/manga_arrow_override.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
+
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+
+/// 漫画左右方向键的跨页方向校正。
+///
+/// 与阅读器的 `resolveReaderArrowPageTurn` 同构，理由也相同：注册表里存的是**页序
+/// 语义**（forward = 下一页），而左右方向键的物理朝向该对应哪一侧，取决于书自己的
+/// 跨页方向（日漫默认 rtl：下一页在**左**边，故左键 = 前进）。方向不能进注册表——
+/// 注册表是全局的、每本书的排版却各不相同；若把 `ArrowLeft` 直接绑成 backward，
+/// rtl 的书就会「翻反」。
+///
+/// 只在该键**当前仍绑定到翻页动作**时才覆写（[boundAction] 判据）：用户若把左/右
+/// 键改绑成别的动作或解绑，就完全不介入，交回注册表的真实绑定。这样「改键」与
+/// 「跟随书写方向」两个特性互不打架。
+///
+/// 上下键 / PageUp / PageDown / 空格**不参与**校正：它们是屏幕轴语义（下 = 往后
+/// 读），与跨页方向无关，任何排版下都一致。
+ShortcutAction? resolveMangaArrowPageTurn({
+  required LogicalKeyboardKey key,
+  required Set<ModifierKey> modifiers,
+  required bool rtl,
+  required ShortcutAction? boundAction,
+}) {
+  if (modifiers.isNotEmpty) return null;
+  if (boundAction != ShortcutAction.mangaPageForward &&
+      boundAction != ShortcutAction.mangaPageBackward) {
+    return null;
+  }
+  final bool isLeft = key == LogicalKeyboardKey.arrowLeft;
+  final bool isRight = key == LogicalKeyboardKey.arrowRight;
+  if (!isLeft && !isRight) return null;
+  // rtl（日漫默认）：下一页在左 → 左键前进。ltr：下一页在右 → 右键前进。
+  final bool leftIsForward = rtl;
+  if (isLeft) {
+    return leftIsForward
+        ? ShortcutAction.mangaPageForward
+        : ShortcutAction.mangaPageBackward;
+  }
+  return leftIsForward
+      ? ShortcutAction.mangaPageBackward
+      : ShortcutAction.mangaPageForward;
+}

--- a/hibiki/lib/src/shortcuts/shortcut_action.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_action.dart
@@ -67,11 +67,17 @@ enum ShortcutScope {
   }
 
   /// 本 scope 真正会被消费的输入通道。设置页的编辑对话框据此渲染章节——绑了不会
-  /// 生效的通道根本不给入口，杜绝「设置里能配、按了没反应」的死项（同
-  /// shortcut_action_wiring_guard 的不变式，只是发生在 UI 层）。
+  /// 生效的通道根本不给入口，杜绝「设置里能配、按了没反应」的死项。
   ///
-  /// 绝大多数 scope 走页面派发，键盘/手柄/鼠标三通道全通；[dictionaryPopup] 的
-  /// 动作只由弹窗 WebView 的滚轮事件触发（见枚举注释），故只开滚轮。
+  /// ⚠️ 这里开一个通道，就等于对用户承诺该通道真的能用，因此**必须同时存在该通道
+  /// 的解析入口**（`resolveKeyboard/resolveGamepad/resolveMouse(scope: 本 scope)`，
+  /// 或按 action 取 `bindingsFor(...).<通道>Bindings`）。守卫
+  /// `shortcut_channel_wiring_guard_test` 会对着源码核这件事：新开一个没有解析入口
+  /// 的通道即红。它与 `shortcut_action_wiring_guard` 互补——后者只看「action 符号
+  /// 有没有出现过」，抓不到「同一个 action 的键盘接了、手柄没接」这种半接线。
+  ///
+  /// 多数 scope 走页面派发，键盘/手柄/鼠标三通道全通；[manga] 只接了键盘、
+  /// [dictionaryPopup] 的动作只由弹窗 WebView 的滚轮事件触发（见各自 case 注释）。
   Set<ShortcutChannel> get channels {
     switch (this) {
       case reader:
@@ -79,7 +85,6 @@ enum ShortcutScope {
       case home:
       case global:
       case video:
-      case manga:
       case gamepad:
       case globalExternal:
         return const <ShortcutChannel>{
@@ -87,6 +92,13 @@ enum ShortcutScope {
           ShortcutChannel.gamepad,
           ShortcutChannel.mouse,
         };
+      // 漫画页只有键盘解析入口：`_resolveMangaKeyAction` 走 `resolveKeyboard`，
+      // 滚轮翻页是硬编码的 `wheelInputAction`（不查注册表），手柄则完全没接
+      // （既无 `resolveGamepad`，也无 `GamepadButtonIntent` 的 Action）。开着手柄/
+      // 鼠标通道 = 设置页给出能配却按了没反应的入口，比没有这个选项更糟。
+      // 接上对应解析入口（照 reader `_handleGamepadButton`）并真机验证后再开。
+      case manga:
+        return const <ShortcutChannel>{ShortcutChannel.keyboard};
       case dictionaryPopup:
         return const <ShortcutChannel>{ShortcutChannel.wheel};
     }

--- a/hibiki/lib/src/shortcuts/shortcut_action.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_action.dart
@@ -4,6 +4,10 @@ enum ShortcutScope {
   global,
   audiobook,
   video,
+  // 漫画阅读器（mokuro 页图 + OCR 文本层）。与 reader 分开是因为动作集不同：漫画
+  // 没有章节/振假名/有声书，翻页是整页跨页步进而非文字流分页，且左右键要按跨页
+  // 方向（日漫默认 rtl）校正。
+  manga,
   // TODO-700 T6：摇杆与 dpad 解耦后，dpad 四向成为「可绑触发键」，落在独立的
   // gamepad 作用域（自成 co-active 组，不与 reader/home 等任何组冲突）。摇杆固定
   // 做方向焦点移动、永不经注册表，故没有对应 action——只有 dpad 进这个 scope。
@@ -42,6 +46,10 @@ enum ShortcutScope {
       // detection therefore scans just video.
       case video:
         return const <ShortcutScope>[video];
+      // 漫画阅读器同样是独立界面：只解析自己的绑定，故自成 co-active 组，
+      // 冲突检测只扫 manga（与 video 同理）。
+      case manga:
+        return const <ShortcutScope>[manga];
       // gamepad（dpad 四向）是独立 co-active 组：dpad 绑定永不与 reader/home 的
       // 按钮跨组冲突，冲突检测只扫 gamepad 自身。
       case gamepad:
@@ -71,6 +79,7 @@ enum ShortcutScope {
       case home:
       case global:
       case video:
+      case manga:
       case gamepad:
       case globalExternal:
         return const <ShortcutChannel>{
@@ -252,6 +261,16 @@ enum ShortcutAction {
   videoToggleShaderCompare(ShortcutScope.video, 'video_toggle_shader_compare'),
   videoToggleFavoriteSentence(
       ShortcutScope.video, 'video_toggle_favorite_sentence'),
+
+  // 漫画：翻页存的是**页序语义**（forward=下一页），左右方向键再按跨页方向
+  // （日漫默认 rtl）校正——与 reader 的 resolveReaderArrowPageTurn 同构，见
+  // resolveMangaArrowPageTurn。这样用户改键改的是「哪个键翻页」，方向仍由书自己
+  // 的排版决定，不会出现「改了键之后 rtl 书翻反」。
+  mangaPageForward(ShortcutScope.manga, 'manga_page_forward'),
+  mangaPageBackward(ShortcutScope.manga, 'manga_page_backward'),
+  // 关词典弹窗。漫画与阅读器的差异：本页弹窗可见时左右键仍要「关弹窗并翻页」，
+  // 故没有独立的「退书」动作绑在 Esc 上（退书走系统返回 / PopScope）。
+  mangaDismissDict(ShortcutScope.manga, 'manga_dismiss_dict'),
 
   // Gamepad（TODO-700 T6）：dpad 四向作为可绑触发键。默认各绑对应 dpad 键，执行体
   // = 通用方向焦点移动（与摇杆同效果，但摇杆固定走 onStickMove 通道、不经注册表，

--- a/hibiki/lib/src/shortcuts/shortcut_defaults.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_defaults.dart
@@ -313,28 +313,27 @@ class ShortcutDefaults {
     ]),
     // 漫画：默认键位与 reader 同构（PageDown/右/下/空格 前进），左右方向键的最终
     // 朝向再由 resolveMangaArrowPageTurn 按跨页方向（日漫默认 rtl）校正，所以这里
-    // 存的是**页序语义**而非物理方向。手柄同 reader：RB/dpad 右前进、LB/dpad 左后退。
+    // 存的是**页序语义**而非物理方向。
+    //
+    // **只有键盘绑定**：漫画页至今没有手柄解析入口（既无 `resolveGamepad`，也无
+    // `GamepadButtonIntent` 的 Action，Android 的 gameButton* 键事件同样匹配不到
+    // 纯键盘绑定）。曾在这里配过 RB/LB/dpad/B，效果是用户在设置里能配、按下去毫无
+    // 反应——比压根没有这个选项更糟，用户会以为自己手柄坏了。要加回来必须先照
+    // reader `_handleGamepadButton` 接上解析入口并真机验证；`manga` scope 的
+    // `channels` 也相应只开键盘，`shortcut_channel_wiring_guard_test` 会盯住两者一致。
     ShortcutAction.mangaPageForward: _kb([
       _key(LogicalKeyboardKey.pageDown),
       _key(LogicalKeyboardKey.arrowRight),
       _key(LogicalKeyboardKey.arrowDown),
       _key(LogicalKeyboardKey.space),
-    ], [
-      _gRB,
-      _gDpadRight
     ]),
     ShortcutAction.mangaPageBackward: _kb([
       _key(LogicalKeyboardKey.pageUp),
       _key(LogicalKeyboardKey.arrowLeft),
       _key(LogicalKeyboardKey.arrowUp),
-    ], [
-      _gLB,
-      _gDpadLeft
     ]),
     ShortcutAction.mangaDismissDict: _kb([
       _key(LogicalKeyboardKey.escape),
-    ], [
-      _gB
     ]),
     ShortcutAction.videoReplayCurrentSubtitle: _kb([
       _key(LogicalKeyboardKey.keyR),

--- a/hibiki/lib/src/shortcuts/shortcut_defaults.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_defaults.dart
@@ -311,6 +311,31 @@ class ShortcutDefaults {
     ShortcutAction.videoToggleFavoriteSentence: _kb([
       _key(LogicalKeyboardKey.keyD, {ModifierKey.ctrl}),
     ]),
+    // 漫画：默认键位与 reader 同构（PageDown/右/下/空格 前进），左右方向键的最终
+    // 朝向再由 resolveMangaArrowPageTurn 按跨页方向（日漫默认 rtl）校正，所以这里
+    // 存的是**页序语义**而非物理方向。手柄同 reader：RB/dpad 右前进、LB/dpad 左后退。
+    ShortcutAction.mangaPageForward: _kb([
+      _key(LogicalKeyboardKey.pageDown),
+      _key(LogicalKeyboardKey.arrowRight),
+      _key(LogicalKeyboardKey.arrowDown),
+      _key(LogicalKeyboardKey.space),
+    ], [
+      _gRB,
+      _gDpadRight
+    ]),
+    ShortcutAction.mangaPageBackward: _kb([
+      _key(LogicalKeyboardKey.pageUp),
+      _key(LogicalKeyboardKey.arrowLeft),
+      _key(LogicalKeyboardKey.arrowUp),
+    ], [
+      _gLB,
+      _gDpadLeft
+    ]),
+    ShortcutAction.mangaDismissDict: _kb([
+      _key(LogicalKeyboardKey.escape),
+    ], [
+      _gB
+    ]),
     ShortcutAction.videoReplayCurrentSubtitle: _kb([
       _key(LogicalKeyboardKey.keyR),
     ], [
@@ -433,6 +458,7 @@ class ShortcutDefaults {
         switch (action.scope) {
           case ShortcutScope.reader:
           case ShortcutScope.video:
+          case ShortcutScope.manga:
             return ShortcutBindingSet(
               keyboardBindings: desktop.keyboardBindings,
               gamepadBindings: desktop.gamepadBindings,

--- a/hibiki/lib/src/shortcuts/shortcut_labels.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_labels.dart
@@ -17,6 +17,12 @@ import 'package:hibiki/src/shortcuts/shortcut_action.dart';
 extension ShortcutActionLabel on ShortcutAction {
   String get label {
     switch (this) {
+      case ShortcutAction.mangaPageForward:
+        return t.shortcut_action_manga_page_forward;
+      case ShortcutAction.mangaPageBackward:
+        return t.shortcut_action_manga_page_backward;
+      case ShortcutAction.mangaDismissDict:
+        return t.shortcut_action_manga_dismiss_dict;
       case ShortcutAction.readerPageForward:
         return t.shortcut_action_reader_page_forward;
       case ShortcutAction.readerPageBackward:
@@ -173,6 +179,8 @@ extension ShortcutScopeLabel on ShortcutScope {
         return t.shortcut_scope_audiobook;
       case ShortcutScope.video:
         return t.shortcut_scope_video;
+      case ShortcutScope.manga:
+        return t.shortcut_scope_manga;
       case ShortcutScope.gamepad:
         return t.shortcut_scope_gamepad;
       case ShortcutScope.globalExternal:

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+956
+version: 1.3.1+957
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/focus/media_page_focus_ownership_guard_test.dart
+++ b/hibiki/test/focus/media_page_focus_ownership_guard_test.dart
@@ -29,6 +29,9 @@ void main() {
     'lib/src/pages/implementations/video_hibiki',
     'lib/src/pages/implementations/reader_hibiki_page.dart',
     'lib/src/pages/implementations/reader_hibiki',
+    // 漫画阅读器（pages/implementations/manga_hibiki_page.dart 只是 3 行兼容
+    // export，真实现在这里）。它曾是三个媒体页里唯一零焦点回收的那个。
+    'lib/src/media/manga/reader',
   ];
 
   Iterable<File> dartFilesUnder(String path) {
@@ -77,10 +80,11 @@ void main() {
     );
   });
 
-  test('两个媒体页都接入了 PageFocusOwnership', () {
+  test('三个媒体页都接入了 PageFocusOwnership', () {
     for (final String page in <String>[
       'lib/src/pages/implementations/video_hibiki_page.dart',
       'lib/src/pages/implementations/reader_hibiki_page.dart',
+      'lib/src/media/manga/reader/manga_hibiki_page.dart',
     ]) {
       final String source = File(page).readAsStringSync();
       expect(source, contains('PageFocusOwnership'),

--- a/hibiki/test/focus/webview_key_bridge_test.dart
+++ b/hibiki/test/focus/webview_key_bridge_test.dart
@@ -56,6 +56,42 @@ void main() {
       expect(multi, contains("callHandler('onMangaKey', e.key)"));
     });
 
+    test('默认转发长按（阅读器语义），forwardRepeats:false 时丢弃', () {
+      expect(spaceBridge, isNot(contains('e.repeat')),
+          reason: '默认不加 repeat 门，保持阅读器既有连发行为');
+      final String noRepeat = webViewKeyBridgeScript(
+        handlerName: 'onMangaNavigationKey',
+        keys: const <String>['ArrowLeft'],
+        forwardRepeats: false,
+      );
+      expect(noRepeat, contains('if (e.repeat) return;'),
+          reason: '漫画要「按住方向键不堆翻页风暴」');
+    });
+
+    test('stopPropagation 可选，默认不独占', () {
+      expect(spaceBridge, isNot(contains('stopImmediatePropagation')));
+      final String exclusive = webViewKeyBridgeScript(
+        handlerName: 'onX',
+        keys: const <String>['Escape'],
+        stopPropagation: true,
+      );
+      expect(exclusive, contains('e.stopImmediatePropagation();'));
+    });
+
+    test('幂等安装守卫按 handlerName 派生（宿主可反复注入）', () {
+      // 漫画每次换加载窗口都重新 evaluate 一次；没有守卫就会叠加 listener，
+      // 一次按键回传多次 → 翻页翻两页。
+      expect(spaceBridge,
+          contains("window['__hoshiKeyBridgeInstalled_onSpaceKey']"));
+      final String other = webViewKeyBridgeScript(
+        handlerName: 'onMangaNavigationKey',
+        keys: const <String>['ArrowLeft'],
+      );
+      expect(other,
+          contains("window['__hoshiKeyBridgeInstalled_onMangaNavigationKey']"),
+          reason: 'flag 必须按 handler 区分，否则同文档里两份桥互相把对方挡掉');
+    });
+
     test('键名里的引号 / 反斜杠被转义（不产生语法坏掉的 JS）', () {
       final String weird = webViewKeyBridgeScript(
         handlerName: 'onWeird',

--- a/hibiki/test/pages/manga_hibiki_page_test.dart
+++ b/hibiki/test/pages/manga_hibiki_page_test.dart
@@ -6,8 +6,8 @@ import 'package:drift/drift.dart' show Value;
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/models.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_provider.dart';
@@ -433,44 +433,102 @@ void main() {
         reason: 'webtoon 页内滚动位置必须经 charOffset 千分比写穿并无损恢复');
   });
 
-  test('查词弹窗显示后仍解析左右翻页、Escape 只关闭弹窗', () {
-    expect(
-      MangaHibikiPage.keyInputAction(
-        key: LogicalKeyboardKey.arrowRight,
-        dictionaryShown: true,
-        mode: MangaReadingMode.spread,
-        direction: 'ltr',
-      ),
-      MangaReaderInputAction.next,
-    );
-    expect(
-      MangaHibikiPage.keyInputAction(
-        key: LogicalKeyboardKey.arrowLeft,
-        dictionaryShown: true,
-        mode: MangaReadingMode.spread,
-        direction: 'rtl',
-      ),
-      MangaReaderInputAction.next,
-    );
-    expect(
-      MangaHibikiPage.keyInputAction(
-        key: LogicalKeyboardKey.escape,
-        dictionaryShown: true,
-        mode: MangaReadingMode.spread,
-        direction: 'ltr',
-      ),
-      MangaReaderInputAction.dismissDictionary,
-    );
-    expect(
-      MangaHibikiPage.keyInputAction(
-        key: LogicalKeyboardKey.space,
-        dictionaryShown: true,
-        mode: MangaReadingMode.spread,
-        direction: 'ltr',
-      ),
-      isNull,
-      reason: '词典内容仍保留自己的空格键语义',
-    );
+  group('键位经注册表解析后的上下文门控（inputActionForShortcut）', () {
+    // 键位本身由 ShortcutRegistry(ShortcutScope.manga) 解析、左右键朝向由
+    // resolveMangaArrowPageTurn 校正（各自有测试）；这里守的是「拿到动作之后，
+    // 当前上下文该不该执行」这层——它承载了本页与阅读器最关键的行为差异。
+    test('查词弹窗显示时左右方向键仍翻页（关弹窗并翻页）', () {
+      expect(
+        MangaHibikiPage.inputActionForShortcut(
+          action: ShortcutAction.mangaPageForward,
+          horizontalArrow: true,
+          dictionaryShown: true,
+          mode: MangaReadingMode.spread,
+        ),
+        MangaReaderInputAction.next,
+        reason: '与阅读器相反：漫画在弹窗可见时不让位给弹窗，左右键必须仍然翻页',
+      );
+    });
+
+    test('Escape（mangaDismissDict）仅在弹窗可见时消费', () {
+      expect(
+        MangaHibikiPage.inputActionForShortcut(
+          action: ShortcutAction.mangaDismissDict,
+          horizontalArrow: false,
+          dictionaryShown: true,
+          mode: MangaReadingMode.spread,
+        ),
+        MangaReaderInputAction.dismissDictionary,
+      );
+      expect(
+        MangaHibikiPage.inputActionForShortcut(
+          action: ShortcutAction.mangaDismissDict,
+          horizontalArrow: false,
+          dictionaryShown: false,
+          mode: MangaReadingMode.spread,
+        ),
+        isNull,
+        reason: '无弹窗时不消费 Escape，交给外层（退书 / PopScope）',
+      );
+    });
+
+    test('弹窗可见时非方向键（空格等）让位给词典', () {
+      expect(
+        MangaHibikiPage.inputActionForShortcut(
+          action: ShortcutAction.mangaPageForward,
+          horizontalArrow: false,
+          dictionaryShown: true,
+          mode: MangaReadingMode.spread,
+        ),
+        isNull,
+        reason: '词典内容仍保留自己的空格键语义',
+      );
+    });
+
+    test('webtoon 模式：纵向键交原生竖滚，左右方向键仍翻页', () {
+      expect(
+        MangaHibikiPage.inputActionForShortcut(
+          action: ShortcutAction.mangaPageForward,
+          horizontalArrow: false,
+          dictionaryShown: false,
+          mode: MangaReadingMode.webtoon,
+        ),
+        isNull,
+        reason: 'webtoon 每页 width:100vw，纵向键属 WebView 原生滚动',
+      );
+      expect(
+        MangaHibikiPage.inputActionForShortcut(
+          action: ShortcutAction.mangaPageForward,
+          horizontalArrow: true,
+          dictionaryShown: false,
+          mode: MangaReadingMode.webtoon,
+        ),
+        MangaReaderInputAction.next,
+        reason: '左右键是跨页步进语义，不受纵向滚动模式影响',
+      );
+    });
+
+    test('未绑定动作 / 非本 scope 动作不产生输入', () {
+      expect(
+        MangaHibikiPage.inputActionForShortcut(
+          action: null,
+          horizontalArrow: true,
+          dictionaryShown: false,
+          mode: MangaReadingMode.spread,
+        ),
+        isNull,
+      );
+      expect(
+        MangaHibikiPage.inputActionForShortcut(
+          action: ShortcutAction.readerPageForward,
+          horizontalArrow: false,
+          dictionaryShown: false,
+          mode: MangaReadingMode.spread,
+        ),
+        isNull,
+        reason: '别的 scope 的动作落到这里只能是接线错误，不得被当成翻页',
+      );
+    });
   });
 
   test('查词弹窗外的滚轮按主轴解析前后翻页', () {

--- a/hibiki/test/pages/manga_hibiki_page_test.dart
+++ b/hibiki/test/pages/manga_hibiki_page_test.dart
@@ -490,14 +490,22 @@ void main() {
   });
 
   test('漫画正文按键桥接只捕获导航键并保持幂等', () {
-    const String script = MangaHibikiPage.navigationKeyBridgeScript;
-    expect(script, contains('__hibikiMangaNavigationKeysInstalled'));
+    // 桥已改走共享生成器 webViewKeyBridgeScript（手写版少了「放行修饰键组合 /
+    // IME 组字 / 输入框」三条判据，会吞 Ctrl+方向键和词典搜索框里的方向键）。
+    // JS 本身的通用不变式由 test/focus/webview_key_bridge_test.dart 守，这里只钉
+    // 本页特有的接线：键表、幂等、独占、不转发长按。
+    final String script = MangaHibikiPage.navigationKeyBridgeScript;
+    expect(script, contains('__hoshiKeyBridgeInstalled_onMangaNavigationKey'),
+        reason: '每次换加载窗口都会重新注入，必须幂等，否则 listener 叠加导致一次按键翻两页');
     expect(script, contains("'ArrowLeft'"));
     expect(script, contains("'ArrowRight'"));
     expect(script, contains("'Escape'"));
     expect(script, contains('preventDefault()'));
-    expect(script, contains('stopImmediatePropagation()'));
-    expect(script, contains("callHandler('onMangaNavigationKey', key)"));
+    expect(script, contains('stopImmediatePropagation()'),
+        reason: '导航键必须独占给 Dart');
+    expect(script, contains('if (e.repeat) return;'),
+        reason: '按住方向键不得堆翻页风暴（本页既有语义）');
+    expect(script, contains("callHandler('onMangaNavigationKey', e.key)"));
   });
 
   test('高频翻页在异步窗口加载期间累积并按净位移排空', () async {

--- a/hibiki/test/shortcuts/manga_arrow_override_test.dart
+++ b/hibiki/test/shortcuts/manga_arrow_override_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/manga_arrow_override.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+
+void main() {
+  group('resolveMangaArrowPageTurn', () {
+    ShortcutAction? call(
+      LogicalKeyboardKey key, {
+      required bool rtl,
+      ShortcutAction? bound = ShortcutAction.mangaPageForward,
+      Set<ModifierKey> modifiers = const <ModifierKey>{},
+    }) =>
+        resolveMangaArrowPageTurn(
+          key: key,
+          modifiers: modifiers,
+          rtl: rtl,
+          boundAction: bound,
+        );
+
+    test('rtl（日漫默认）：下一页在左 → 左键前进、右键后退', () {
+      expect(call(LogicalKeyboardKey.arrowLeft, rtl: true),
+          ShortcutAction.mangaPageForward);
+      expect(call(LogicalKeyboardKey.arrowRight, rtl: true),
+          ShortcutAction.mangaPageBackward);
+    });
+
+    test('ltr：下一页在右 → 右键前进、左键后退', () {
+      expect(call(LogicalKeyboardKey.arrowRight, rtl: false),
+          ShortcutAction.mangaPageForward);
+      expect(call(LogicalKeyboardKey.arrowLeft, rtl: false),
+          ShortcutAction.mangaPageBackward);
+    });
+
+    test('校正与「原本绑的是前进还是后退」无关，只看物理方向 + 排版方向', () {
+      // 左右键互为镜像：无论注册表把某一侧绑成 forward 还是 backward，校正后的
+      // 结果只由 rtl 决定。否则用户把左右键对调绑定后会出现「两个键都翻同一向」。
+      expect(
+        call(LogicalKeyboardKey.arrowLeft,
+            rtl: true, bound: ShortcutAction.mangaPageBackward),
+        ShortcutAction.mangaPageForward,
+      );
+      expect(
+        call(LogicalKeyboardKey.arrowRight,
+            rtl: true, bound: ShortcutAction.mangaPageForward),
+        ShortcutAction.mangaPageBackward,
+      );
+    });
+
+    test('该键已被改绑成非翻页动作 → 不覆写，交回注册表', () {
+      expect(
+        call(LogicalKeyboardKey.arrowLeft,
+            rtl: true, bound: ShortcutAction.mangaDismissDict),
+        isNull,
+        reason: '尊重改键：只有仍绑定到翻页时方向校正才适用',
+      );
+      expect(
+          call(LogicalKeyboardKey.arrowLeft, rtl: true, bound: null), isNull);
+    });
+
+    test('带修饰键的组合不覆写', () {
+      expect(
+        call(LogicalKeyboardKey.arrowLeft,
+            rtl: true, modifiers: const <ModifierKey>{ModifierKey.ctrl}),
+        isNull,
+      );
+    });
+
+    test('非左右键不参与校正（上下 / PageUp / 空格是屏幕轴语义）', () {
+      for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+        LogicalKeyboardKey.arrowUp,
+        LogicalKeyboardKey.arrowDown,
+        LogicalKeyboardKey.pageUp,
+        LogicalKeyboardKey.pageDown,
+        LogicalKeyboardKey.space,
+      ]) {
+        expect(call(key, rtl: true), isNull, reason: '$key 不该被方向校正');
+      }
+    });
+  });
+}

--- a/hibiki/test/shortcuts/shortcut_action_wiring_guard_test.dart
+++ b/hibiki/test/shortcuts/shortcut_action_wiring_guard_test.dart
@@ -47,6 +47,11 @@ void main() {
       'lib/src/media/audiobook/pointer_seek.dart',
       'lib/src/shortcuts/gamepad_service.dart',
       'lib/src/shortcuts/reader_space_override.dart',
+      // 漫画阅读器：inputActionForShortcut 把注册表解析出的动作落成翻页/关词典，
+      // 键盘与 WebView 键桥两条路径共用（见 _resolveMangaKeyAction）。
+      'lib/src/media/manga/reader/manga_hibiki_page.dart',
+      // 漫画左右方向键的跨页方向校正（与 reader_space_override 同类）。
+      'lib/src/shortcuts/manga_arrow_override.dart',
       // TODO-1066: the app-external global lookup hotkey's executor. It reads
       // ShortcutAction.globalExternalLookup from the registry and registers it
       // to the OS-level hotkey_manager (the one action that runs via a system

--- a/hibiki/test/shortcuts/shortcut_channel_wiring_guard_test.dart
+++ b/hibiki/test/shortcuts/shortcut_channel_wiring_guard_test.dart
@@ -1,0 +1,212 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+import 'package:hibiki/src/shortcuts/shortcut_defaults.dart';
+
+/// 「某个 scope 开放了某个输入通道，就必须真的存在该通道的解析入口」。
+///
+/// 与 `shortcut_action_wiring_guard_test` 的区别，也正是它抓不到的那类：那条守卫
+/// 只扫「`ShortcutAction.<名>` 这个符号在某个执行体文件里出现过没有」。漫画页把
+/// `ShortcutAction.mangaPageForward` 用在**键盘**路径上，符号出现了，于是那条守卫
+/// 全绿——而同一个 action 的**手柄**默认绑定（RB / LB / dpad / B）压根没有消费者：
+/// 漫画页既没有 `resolveGamepad`，也没有 `GamepadButtonIntent` 的 Action，Android
+/// 的 `gameButton*` 键事件同样匹配不到纯键盘绑定。结果是用户在设置里能配手柄、按下
+/// 去毫无反应——**比压根没有这个选项更糟**，用户会以为是自己手柄坏了。
+///
+/// 判据因此不是「符号出现过」，而是「**这个通道有没有解析入口**」：
+/// 消费一个通道只有两种真实写法，缺一不可地都算证据——
+///   ① 按 scope 解析：`registry.resolveKeyboard/resolveGamepad/resolveMouse(
+///      …, scope: ShortcutScope.X)`；
+///   ② 按 action 取绑定表：`registry.bindingsFor(<该 scope 的某个 action>)
+///      .keyboardBindings / .gamepadBindings / .mouseBindings / .wheelBindings`
+///      （video 的键盘、globalExternal 的 OS 级热键、查词弹窗的滚轮都走这条）。
+/// 一个文件只有同时出现「该 scope 的身份」（`ShortcutScope.X` 或它名下某个
+/// `ShortcutAction.<名>`）和「该通道的取用」，才算这个 (scope, channel) 的消费者。
+void main() {
+  /// 通道 → 该通道在源码里的取用写法（命中任一即算取用）。
+  const Map<ShortcutChannel, List<String>> channelTokens =
+      <ShortcutChannel, List<String>>{
+    ShortcutChannel.keyboard: <String>['resolveKeyboard(', '.keyboardBindings'],
+    ShortcutChannel.gamepad: <String>['resolveGamepad(', '.gamepadBindings'],
+    ShortcutChannel.mouse: <String>['resolveMouse(', '.mouseBindings'],
+    ShortcutChannel.wheel: <String>['resolveWheel(', '.wheelBindings'],
+  };
+
+  /// 定义/展示层：这些文件按定义列举所有 scope 与通道，不构成任何「消费」证据。
+  /// 不排掉它们，每个 scope 的每个通道都会因为设置页而假绿。
+  const List<String> definitionOnly = <String>[
+    'lib/src/shortcuts/shortcut_action.dart',
+    'lib/src/shortcuts/shortcut_defaults.dart',
+    'lib/src/shortcuts/shortcut_registry.dart',
+    'lib/src/shortcuts/input_binding.dart',
+    'lib/src/shortcuts/shortcut_labels.dart',
+    'lib/src/pages/implementations/shortcut_settings_page.dart',
+    'lib/src/pages/implementations/shortcut_settings',
+  ];
+
+  /// 既有欠账：**开放了通道但至今没有消费者**的 (scope, channel)。
+  ///
+  /// 这些是本守卫落地之前就存在的，危害小于漫画那处——它们只是设置页多出一个空的
+  /// 通道分组，**默认表里没有任何绑定**，所以不会出现「开箱就配好了却按不动」。
+  /// 本清单是**棘轮**：下面断言的是「实际欠账集合 == 本清单」，因此
+  ///   · 新增任何死通道 → 红（这正是漫画那处会被拦下的原因）；
+  ///   · 接上某个通道后忘了从清单里划掉 → 也红，逼你把账销掉。
+  /// 修的方向是二选一：要么接上解析入口，要么把该通道从 `scope.channels` 摘掉。
+  const Set<String> knownUnconsumedChannels = <String>{
+    // 视频页的鼠标绑定无人解析（`resolveMouse` 只有 reader / audiobook 两处）。
+    'video.mouse',
+    'home.mouse',
+    'global.mouse',
+    // gamepad scope 只装 dpad 四向，只经 GamepadService 的手柄通道消费。
+    'gamepad.keyboard',
+    'gamepad.mouse',
+    // globalExternal 只把键盘绑定注册进 OS 级 hotkey_manager，另两个通道没有 OS
+    // 级对应物。
+    'globalExternal.gamepad',
+    'globalExternal.mouse',
+  };
+
+  Map<ShortcutScope, List<ShortcutAction>> actionsByScope() {
+    final Map<ShortcutScope, List<ShortcutAction>> byScope =
+        <ShortcutScope, List<ShortcutAction>>{};
+    for (final ShortcutAction action in ShortcutAction.values) {
+      byScope.putIfAbsent(action.scope, () => <ShortcutAction>[]).add(action);
+    }
+    return byScope;
+  }
+
+  List<File> consumerFiles() {
+    return Directory('lib')
+        .listSync(recursive: true)
+        .whereType<File>()
+        .where((File f) => f.path.endsWith('.dart'))
+        .where((File f) {
+      final String p = f.path.replaceAll('\\', '/');
+      return !definitionOnly.any((String d) => p.startsWith(d));
+    }).toList();
+  }
+
+  /// 实际存在消费者的 (scope, channel)。
+  Set<String> consumedPairs() {
+    final Map<ShortcutScope, List<ShortcutAction>> byScope = actionsByScope();
+    final Set<String> consumed = <String>{};
+    for (final File file in consumerFiles()) {
+      final String source = file.readAsStringSync();
+      for (final MapEntry<ShortcutScope, List<ShortcutAction>> entry
+          in byScope.entries) {
+        final bool identifiesScope =
+            source.contains('ShortcutScope.${entry.key.name}') ||
+                entry.value.any((ShortcutAction a) =>
+                    source.contains('ShortcutAction.${a.name}'));
+        if (!identifiesScope) continue;
+        for (final MapEntry<ShortcutChannel, List<String>> ch
+            in channelTokens.entries) {
+          if (ch.value.any((String token) => source.contains(token))) {
+            consumed.add('${entry.key.name}.${ch.key.name}');
+          }
+        }
+      }
+    }
+    return consumed;
+  }
+
+  test('默认表里配了某通道的绑定 → 该通道必须开放且有解析入口（零豁免）', () {
+    // 这是硬断言，没有豁免清单：**开箱就带着默认绑定**的通道，用户不做任何配置就
+    // 会去按，按不动就是纯粹的谎报。漫画页的手柄绑定正是死在这一条上。
+    final Set<String> consumed = consumedPairs();
+    final List<String> violations = <String>[];
+    for (final TargetPlatform platform in <TargetPlatform>[
+      TargetPlatform.windows,
+      TargetPlatform.macOS,
+      TargetPlatform.android,
+    ]) {
+      final Map<ShortcutAction, ShortcutBindingSet> table =
+          ShortcutDefaults.forPlatform(platform);
+      for (final MapEntry<ShortcutAction, ShortcutBindingSet> entry
+          in table.entries) {
+        final ShortcutScope scope = entry.key.scope;
+        final Map<ShortcutChannel, bool> declared = <ShortcutChannel, bool>{
+          ShortcutChannel.keyboard: entry.value.keyboardBindings.isNotEmpty,
+          ShortcutChannel.gamepad: entry.value.gamepadBindings.isNotEmpty,
+          ShortcutChannel.mouse: entry.value.mouseBindings.isNotEmpty,
+          ShortcutChannel.wheel: entry.value.wheelBindings.isNotEmpty,
+        };
+        for (final MapEntry<ShortcutChannel, bool> ch in declared.entries) {
+          if (!ch.value) continue;
+          final String pair = '${scope.name}.${ch.key.name}';
+          if (!scope.channels.contains(ch.key)) {
+            violations.add('$platform ${entry.key.key}：默认表配了 '
+                '${ch.key.name} 绑定，但 ${scope.name}.channels 没开放该通道');
+          } else if (!consumed.contains(pair)) {
+            violations.add('$platform ${entry.key.key}：默认表配了 '
+                '${ch.key.name} 绑定，但全仓找不到 $pair 的解析入口'
+                '（既无 resolve${ch.key.name} 也无 .${ch.key.name}Bindings 取用）');
+          }
+        }
+      }
+    }
+    expect(
+      violations,
+      isEmpty,
+      reason: '开箱即带默认绑定却无人解析 = 用户配了/直接按都没反应，'
+          '比没有这个选项更糟。要么接上解析入口，要么把默认绑定和通道一起撤掉。'
+          '命中：\n${violations.join('\n')}',
+    );
+  });
+
+  test('开放但无人消费的通道集合 == 已登记的既有欠账（棘轮，只许缩不许涨）', () {
+    final Set<String> consumed = consumedPairs();
+    final Set<String> unconsumed = <String>{};
+    for (final ShortcutScope scope in ShortcutScope.values) {
+      for (final ShortcutChannel channel in scope.channels) {
+        final String pair = '${scope.name}.${channel.name}';
+        if (!consumed.contains(pair)) unconsumed.add(pair);
+      }
+    }
+
+    final Set<String> newlyDead =
+        unconsumed.difference(knownUnconsumedChannels);
+    expect(
+      newlyDead,
+      isEmpty,
+      reason: '新增了「设置页开放、却没有任何解析入口」的通道：$newlyDead。'
+          '用户能在设置里配，按下去不会有任何反应。要么接上解析入口，'
+          '要么别在 channels 里开放它。',
+    );
+
+    final Set<String> alreadyFixed =
+        knownUnconsumedChannels.difference(unconsumed);
+    expect(
+      alreadyFixed,
+      isEmpty,
+      reason: '$alreadyFixed 已经有解析入口（或通道已摘掉），'
+          '请从 knownUnconsumedChannels 里删掉，别让欠账清单虚高。',
+    );
+  });
+
+  test('漫画 scope 只开放键盘，且默认表不含手柄绑定', () {
+    // 回归钉：这三个 action 曾带着 RB/LB/dpad/B 默认绑定发出去，而漫画页没有任何
+    // 手柄解析入口。要恢复必须先照 reader `_handleGamepadButton` 接上入口并真机验证。
+    expect(ShortcutScope.manga.channels, <ShortcutChannel>{
+      ShortcutChannel.keyboard,
+    });
+    for (final TargetPlatform platform in <TargetPlatform>[
+      TargetPlatform.windows,
+      TargetPlatform.macOS,
+      TargetPlatform.android,
+    ]) {
+      final Map<ShortcutAction, ShortcutBindingSet> table =
+          ShortcutDefaults.forPlatform(platform);
+      for (final ShortcutAction action in ShortcutAction.values
+          .where((ShortcutAction a) => a.scope == ShortcutScope.manga)) {
+        expect(table[action]!.gamepadBindings, isEmpty,
+            reason: '$platform ${action.key} 不得有手柄默认绑定（漫画页没接手柄）');
+        expect(table[action]!.keyboardBindings, isNotEmpty,
+            reason: '$platform ${action.key} 必须有键盘默认绑定');
+      }
+    }
+  });
+}


### PR DESCRIPTION
## 背景

接 #480（焦点所有权统一，已合并）。当时漫画页因为在线源那批 PR 在飞而暂缓，现在补上。

漫画页是三个媒体页里唯一**三层全缺**的：

| | 视频页 | 阅读器页 | 漫画页（改前） |
|---|---|---|---|
| 焦点回收 | ✅ | ✅ | ❌ **一处都没有** |
| 快捷键注册表 | ✅ | ✅ | ❌ 硬编码 `if (key == arrowRight)` |
| WebView 键盘桥 | — | ✅ 共享生成器 | ⚠️ 自写一份，判据更弱 |

它同样把正文交给原生 WebView 渲染：桌面上在漫画 WebView 里点/拖一次，OS 焦点归 WebView2，整页 `autofocus` 只在首帧生效，之后**没有任何路径**把焦点要回来——方向键翻页从此失效且无自愈。这正是用户报的「漫画特别容易丢快捷键」。

## 三个 commit

**① 焦点所有权**（`0698aab1c`）接入 `PageFocusOwnership`。回收点：内容就绪（每个加载窗口）、指针手势（`onTapEmpty` / `onMangaTurn`）、词典弹窗渲染与全栈关闭、app 回前台。

**② 键盘桥**（同上）改走共享 `webViewKeyBridgeScript`。⚠️ **未声明的行为变化**：桥因此从旧手写版的 **capture 阶段**（`addEventListener(..., true)`）改成生成器的**冒泡阶段**（仍带 `stopImmediatePropagation`）。已核实漫画文档目前没有其它 `keydown` 监听，故行为等价；若将来给漫画页图注入自己的键盘处理，需重新核这条。手写版少了「放行修饰键组合 / IME 组字 / 输入框」三条判据，会吞掉 Ctrl+方向键和词典搜索框里的方向键。给生成器加了两个可选参数（默认保持阅读器行为不变）：`forwardRepeats: false`（本页有意设计：按住不堆翻页风暴）、`stopPropagation: true`（导航键独占）。另加按 `handlerName` 派生的**幂等安装守卫**——漫画每次换加载窗口都重新注入，没守卫会叠加 listener → 一次按键翻两页。

**③ 快捷键注册表**（`d78d0274d`）新增 `ShortcutScope.manga` + 三个 action。白捡可改键 + 出现在设置页。

**④ 只接键盘通道**（`4182d4980`，审查中补）。③ 最初还给这三个 action 配了手柄默认绑定（RB / LB / dpad / B），**那是错的**：本页没有任何手柄解析入口——既无 `resolveGamepad`，也无 `GamepadButtonIntent` 的 Action，Android 的 `gameButton*` 键事件同样匹配不到纯键盘绑定。结果会是用户在设置里能配手柄、按下去毫无反应，**比压根没有这个选项更糟**（用户会以为自己手柄坏了）。已撤掉手柄绑定，并把 `ShortcutScope.manga.channels` 收成 `{keyboard}`（滚轮同理走硬编码 `wheelInputAction`，不查注册表）。

选「撤掉」而非「接上」：接手柄要同时补桌面轮询路径的 `Actions(GamepadButtonIntent)`、Android 的 `gameButton*` 键分支和 reader `_handleGamepadButton` 的对应体，且**无手柄可做真机验证**。宁可少宣称一个功能。撤掉是零行为变更——这些按键此前就落到 `GamepadService` 的全局兜底（方向焦点 / 激活 / 返回）。

## 两处与阅读器**相反**的规则（本 PR 的关键，已建模+测试）

**词典弹窗可见时，漫画不让位。** 阅读器的 `gesture` 判据在弹窗可见时早退（弹窗自持焦点，BUG-136）；漫画必须相反——本页规定弹窗可见时左右键仍要「关弹窗并翻页」、Escape 要关弹窗，而弹窗是纯原生 WebView、没有 Flutter 焦点节点，不主动收回这些键就全部落空。这与本页既有的 `capturesDictionaryPopupNavigationKeys` 是同一诉求的两半。

**左右方向键不受 webtoon / 弹窗门控。** 它们是跨页步进语义（`inputActionForShortcut` 的 `horizontalArrow`）；其余键要让位——弹窗可见时空格归词典，webtoon 下纵向键归原生竖滚。

## 翻页方向为什么不进注册表

注册表存**页序语义**（forward = 下一页），左右键的物理朝向由 `resolveMangaArrowPageTurn` 按跨页方向（日漫默认 rtl）校正，与 reader 的 `resolveReaderArrowPageTurn` 同构。方向不能进注册表——注册表是全局的、每本书排版却各不相同，直接把 `ArrowLeft` 绑成 backward 会让 rtl 的书**翻反**。且只在该键仍绑定到翻页时才覆写，用户改绑成别的动作就完全不介入：「改键」与「跟随书写方向」互不打架。

## 顺带消除的重复

`_activeModifiers` 抽成 `input_binding.activeModifierKeys()`，阅读器改为同名转发（零行为变化），漫画直接用。否则两页各建一份修饰键集合必然漂。

## 守卫

- `shortcut_action_wiring_guard` 的执行体清单登记了漫画两个新文件
- **`shortcut_channel_wiring_guard`（新）**：上面 ④ 那个死绑定，既有守卫**抓不到**——它只扫「`ShortcutAction.<名>` 这个符号在执行体文件里出现过没有」，漫画页把该符号用在键盘路径上就全绿。新守卫改按 **(scope, channel)** 核解析入口，两种真实消费写法都算证据（按 scope 的 `resolveX(scope: ...)`、按 action 的 `bindingsFor(...).<通道>Bindings`）：
  1. **硬断言（零豁免）**：默认表里配了某通道的绑定 → 该通道必须开放且有解析入口。开箱即带默认绑定却无人解析 = 纯粹的谎报。
  2. **棘轮**：开放但无人消费的 `(scope, channel)` 集合必须**等于**已登记的既有欠账清单——新增即红，修好后不划掉也红。

  负向验证做了三次（做完还原）：恢复手柄默认绑定 + 重开通道 → 红；只重开通道不配绑定 → 红；往欠账清单塞一个已修好的 pair → 红。

  顺带如实登记了 **7 条既有欠账**（`video/home/global` 的 mouse、`gamepad` 的 keyboard+mouse、`globalExternal` 的 gamepad+mouse）：这些通道在设置页开着却无人解析。危害小于漫画那处——它们默认表里没有绑定，不会「开箱按不动」，只是多出一个空分组。**本 PR 不顺手改**，避免扩大爆炸半径。
- `manga_arrow_override_test`（新）：rtl/ltr 双向、改绑后不覆写、修饰键不覆写、非左右键不参与
- `manga_hibiki_page_test` 的旧 `keyInputAction` 用例搬到 `inputActionForShortcut`，三条原语义（弹窗时左右键仍翻页 / Escape 关弹窗 / 空格让位词典）全部保留并补了 webtoon 与「别的 scope 动作不得被当成翻页」两条

## 验证

按 CLAUDE.md 规则用 `dart run tool/flutter_test_failures.dart --no-pub` 判绿（认 `FLUTTER TEST VERDICT` + 退出码）：

- `flutter analyze` 全量：**No issues found**
- shortcuts + 漫画 + i18n：**VERDICT: PASSED — 514 tests**
- 更广面（i18n/settings/focus/reader/pages/media·manga）：4134 tests，1 个 flaky（`home_video_remote_download_register`，与本改动零交集，单独重跑 **PASSED**）
- i18n 走 `tool/i18n_sync.dart --add` 补齐 17 语言 + `dart run slang` 重生成，未手改 json

**未做真机验证**：焦点行为依赖真实平台焦点遍历 / WebView2，headless 照不到。

## 建议真机复测（桌面）

1. 打开漫画 → 在页面上点一下 → 直接按方向键应能翻页（改前必须先按 Tab 之类才可能恢复，通常直接失效）
2. 划词查词弹出词典 → 按左右键应「关弹窗并翻页」，Esc 应关弹窗
3. 日漫（rtl）左键 = 下一页；ltr 漫画右键 = 下一页
4. 设置 → 快捷键 → 应出现「漫画」分组，改键后键盘与 WebView 持焦两种情况都应生效
5. webtoon 模式：上下键/滚轮走原生竖滚，左右键仍翻页
6. 按住方向键不应连续翻页

https://claude.ai/code/session_01LR4uRM9ZXa6x18zwfLc6qf


