### PR TITLE
fix(manga): 抢救 PR#494 分支上的孤儿提交，并修掉它带的词典 zip 误判

### DIFF
--- a/hibiki/lib/src/media/drag_drop/drop_classification.dart
+++ b/hibiki/lib/src/media/drag_drop/drop_classification.dart
@@ -74,14 +74,29 @@ const Set<String> kDragDictionaryExtensions = <String>{
 /// - `mokuro`：mokuro v0.2+ 的 OCR 结果文件（+ 同级图片），走 `MangaImporter`；
 /// - `cbz`：图片压缩包，走 `MangaArchiveImporter`。
 ///
-/// 刻意**不含 `zip` / `epub`**：这两者要看包内容才知道是不是图片包
-/// （`MangaArchiveImporter.looksLikeImageArchive` 要真读包），而本文件是纯函数
-/// 分类层、不碰文件系统；且 `zip` 同时是词典包扩展名，无内容判据时把书架上拖入
-/// 的 Yomitan 词典 zip 当漫画导入是误判。图片型 zip/epub 仍可经导入对话框导入
-/// （对话框的分派会真读包），只是不由拖放分类层猜。
+/// 不含 `zip`：它同时是词典包扩展名，光看扩展名分不出「一包页图」还是 Yomitan
+/// 词典包，故走 [kDragImageArchiveProbeExtensions] + `isImageArchive` 注入判据。
+///
+/// 也不含 `epub`：图片型 EPUB（扫描版漫画）确实存在，但它在 books 分支就走
+/// `importNewBook` → `BookImportDialog`，而对话框的分派本来就会真读包
+/// （`{'.zip','.epub'} && MangaModule.isImageArchive` → `importArchive`），最终
+/// 照样导成漫画——行为已经正确。为它在**每次拖 EPUB** 时白开一次包换不来任何
+/// 可见改进，不值得。
 const Set<String> kDragMangaExtensions = <String>{
   'mokuro',
   'cbz',
+};
+
+/// 需要**真读包内容**才能定性的容器扩展名（不带点，小写）。
+///
+/// 只含 `zip`：它既可能是页图漫画包，也可能是 Yomitan/mdict 词典包。没有判据时
+/// 分类层只能按扩展名归 dictionaries，于是**图片型 zip 拖到书架/漫画库会回「本
+/// 页面不支持」**（books 分支走到 `files.hasAny` 兜底），而导入对话框导得了它——
+/// 又一处「按钮能导、拖进去不认」。判据由调用方注入（widget 层传
+/// `MangaModule.isImageArchive`，即 `MangaArchiveImporter.looksLikeImageArchive`），
+/// 分类层自身仍不碰文件系统；判据缺席时 zip 维持词典包分类，向后兼容。
+const Set<String> kDragImageArchiveProbeExtensions = <String>{
+  'zip',
 };
 
 /// 看得出是漫画包、但当前**导入器不支持**的扩展名（不带点，小写）。
@@ -194,6 +209,7 @@ bool isImportableDropUrl(String candidate) {
 DroppedFiles classifyDroppedFiles(
   List<String> paths, {
   bool Function(String path)? isDirectory,
+  bool Function(String path)? isImageArchive,
 }) {
   final List<String> books = <String>[];
   final List<String> videos = <String>[];
@@ -221,6 +237,16 @@ DroppedFiles classifyDroppedFiles(
     }
     final String ext = _ext(path);
     bool matched = false;
+    // 图片包（`.zip`）：光看扩展名与词典包同形，必须真读包——同 isDirectory，判据
+    // 由 widget 层注入。命中即**只**归 mangas（不再落 dictionaries），否则图片型
+    // zip 会走到 books 分支的 `files.hasAny` 兜底、回「本页面不支持」，而导入对话框
+    // 明明导得了它。与对话框同一判据，两条入口的回答因此必然一致。
+    if (isImageArchive != null &&
+        kDragImageArchiveProbeExtensions.contains(ext) &&
+        isImageArchive(path)) {
+      mangas.add(path);
+      continue;
+    }
     if (kDragMangaExtensions.contains(ext)) {
       mangas.add(path);
       matched = true;

--- a/hibiki/lib/src/media/manga/import/manga_archive_importer.dart
+++ b/hibiki/lib/src/media/manga/import/manga_archive_importer.dart
@@ -13,6 +13,24 @@ import 'package:hibiki/src/media/manga/manga_storage.dart';
 
 const int _maximumArchiveExpandedBytes = 2 * 1024 * 1024 * 1024;
 
+/// Yomitan/Yomichan 词典包的**结构**标记：包根下的数据库文件名前缀。
+///
+/// 与 C++ 导入器 `native/hoshidicts/hoshidicts_src/importer.cpp` 的
+/// `get_files()` 用同一组前缀（`term_bank_` / `kanji_bank_` /
+/// `term_meta_bank_` / `kanji_meta_bank_` / `tag_bank_`）——判据只有一处真相，
+/// 这里不自创第二套。
+const List<String> _kYomitanBankPrefixes = <String>[
+  'term_bank_',
+  'kanji_bank_',
+  'term_meta_bank_',
+  'kanji_meta_bank_',
+  'tag_bank_',
+];
+
+/// Yomitan 词典包的清单文件名（包根）。`prepareNameYomichanFormat` 就靠它读
+/// 词典标题。
+const String _kYomitanIndexEntry = 'index.json';
+
 abstract final class MangaArchiveImporter {
   static bool looksLikeImageArchive(String archivePath) {
     final String extension = p.extension(archivePath).toLowerCase();
@@ -22,10 +40,21 @@ abstract final class MangaArchiveImporter {
     try {
       final Archive archive = _decode(archivePath);
       bool hasImage = false;
+      bool hasDictionaryIndex = false;
+      bool hasDictionaryBank = false;
       for (final ArchiveFile entry in archive) {
         _validateEntry(entry);
         if (!entry.isFile) continue;
-        final String extension = p.extension(entry.name).toLowerCase();
+        final String name = entry.name;
+        if (name == _kYomitanIndexEntry) {
+          hasDictionaryIndex = true;
+          continue;
+        }
+        if (_kYomitanBankPrefixes.any(name.startsWith)) {
+          hasDictionaryBank = true;
+          continue;
+        }
+        final String extension = p.extension(name).toLowerCase();
         if (kMangaImageExtensions.contains(extension)) {
           hasImage = true;
         } else if (<String>{
@@ -36,6 +65,20 @@ abstract final class MangaArchiveImporter {
         }.contains(extension)) {
           return false;
         }
+      }
+      // 词典包一票否决，优先于「有图片就算漫画」。
+      //
+      // Yomitan 允许词典**自带图片**（structured-content 的 `image` 节点；C++
+      // 导入器 `get_files()` 把非 bank/非 index.json 的条目一律收成
+      // `media_files`）。只看「包里有没有图片」的话，一本带插图的词典包会被判成
+      // 图片包：拖进书架 → 静默导成一本只有插图的垃圾「漫画」，而词典**根本没
+      // 被导入**。那是用户数据被糟蹋，比多点两下严重得多。
+      //
+      // 判据要 index.json **和**至少一个 `*_bank_*.json` 同时在场：单有
+      // index.json 不算（打包工具随手生成的清单也叫这名），bank 前缀才是
+      // Yomitan 独有的结构指纹。
+      if (hasDictionaryIndex && hasDictionaryBank) {
+        return false;
       }
       return hasImage;
     } catch (_) {

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -20,6 +20,7 @@ import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
 import 'package:hibiki/src/media/display_title.dart';
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_download_queue.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/media/video/video_feature_flags.dart';

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -939,6 +939,9 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     final DroppedFiles files = classifyDroppedFiles(
       paths,
       isDirectory: (String pth) => Directory(pth).existsSync(),
+      // 图片型 .zip（一包页图的漫画）与 Yomitan 词典包同形，要真读包才分得出——
+      // 与导入对话框的分派同一判据，两条入口对「这算不算漫画」回答一致。
+      isImageArchive: MangaModule.isImageArchive,
     );
     debugPrint(
       '[hibiki-drop] [reader-shelf] classified '

--- a/hibiki/test/media/drag_drop/dictionary_zip_not_manga_test.dart
+++ b/hibiki/test/media/drag_drop/dictionary_zip_not_manga_test.dart
@@ -1,0 +1,164 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/drag_drop/drop_classification.dart';
+import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
+import 'package:path/path.dart' as p;
+
+/// 反向守卫：**词典 zip 不许被当漫画导**。
+///
+/// 拖放分类层给 `.zip` 加了内容判据（`isImageArchive`）之后，`.zip` 不再无条件
+/// 归词典包——判据说是图片包就归 mangas。判据本身必须扛得住真实的 Yomitan 词典
+/// 包：Yomitan 格式允许词典**自带图片**（structured-content 的 `image` 节点，本仓
+/// `YomichanFormat.processDefinition` 就处理 `case 'image'`），这类词典包解开后
+/// 同时含 `index.json` / `term_bank_*.json` 和 `.png`。
+///
+/// 这里用**真 zip 文件 + 真判据**（`MangaModule.isImageArchive`，即
+/// `MangaArchiveImporter.looksLikeImageArchive`）跑，不打桩：桩只能证明接线对，
+/// 证明不了判据对。
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('hibiki_dict_zip_guard_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  /// 在 [tempDir] 下写一个真 zip，[entries] 是 `包内路径 -> 内容字节`。
+  String writeZip(String name, Map<String, List<int>> entries) {
+    final Archive archive = Archive();
+    entries.forEach((String path, List<int> bytes) {
+      archive.addFile(ArchiveFile(path, bytes.length, bytes));
+    });
+    final List<int>? encoded = ZipEncoder().encode(archive);
+    expect(encoded, isNotNull, reason: 'zip 编码失败，测试前提不成立');
+    final String path = p.join(tempDir.path, name);
+    File(path).writeAsBytesSync(encoded!);
+    return path;
+  }
+
+  /// 最小 PNG（1x1，真字节）——词典自带插图就长这样。
+  List<int> onePixelPng() => <int>[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+        0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+        0x42, 0x60, 0x82,
+      ];
+
+  List<int> utf8Bytes(String text) => utf8.encode(text);
+
+  group('拖放分类 — 词典 zip 不许被当漫画', () {
+    test('自带插图的 Yomitan 词典 zip 仍归 dictionaries，不归 mangas', () {
+      final String dictZip = writeZip('yomitan_dict.zip', <String, List<int>>{
+        'index.json': utf8Bytes(
+          '{"title":"Test Dict","format":3,"revision":"1"}',
+        ),
+        'term_bank_1.json': utf8Bytes(
+          '[["猫","ねこ","n","",0,[{"type":"structured-content",'
+          '"content":{"tag":"img","path":"img/neko.png"}}],1,""]]',
+        ),
+        'tag_bank_1.json': utf8Bytes('[["n","partOfSpeech",0,"noun",0]]'),
+        'img/neko.png': onePixelPng(),
+      });
+
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>[dictZip],
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+      expect(
+        files.mangas,
+        isEmpty,
+        reason: '词典包被当漫画导 = 用户拖词典进书架，导出一本乱码「漫画」',
+      );
+      expect(files.dictionaries, <String>[dictZip]);
+      expect(
+        decideDropIntent(
+          surface: DropSurface.books,
+          files: files,
+          cardHit: false,
+        ),
+        isNot(DropIntent.importNewManga),
+      );
+    });
+
+    test('无插图的 Yomitan 词典 zip 归 dictionaries', () {
+      final String dictZip = writeZip('plain_dict.zip', <String, List<int>>{
+        'index.json': utf8Bytes('{"title":"Plain","format":3,"revision":"1"}'),
+        'term_bank_1.json': utf8Bytes('[["犬","いぬ","n","",0,["dog"],1,""]]'),
+      });
+
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>[dictZip],
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+      expect(files.mangas, isEmpty);
+      expect(files.dictionaries, <String>[dictZip]);
+    });
+
+    test('只有 kanji_bank 的汉字词典 zip（带笔顺图）仍归 dictionaries', () {
+      final String dictZip = writeZip('kanji_dict.zip', <String, List<int>>{
+        'index.json': utf8Bytes('{"title":"Kanji","format":3,"revision":"1"}'),
+        'kanji_bank_1.json': utf8Bytes('[["猫","ビョウ","ねこ","",["cat"],{}]]'),
+        'stroke/neko.png': onePixelPng(),
+      });
+
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>[dictZip],
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+      expect(files.mangas, isEmpty, reason: 'term_bank 不是唯一的 bank 形态');
+      expect(files.dictionaries, <String>[dictZip]);
+    });
+
+    test('页图 zip 只是恰好带了 index.json（无 bank）仍归 mangas', () {
+      // 反向误判防线：打包工具随手生成的清单也可能叫 index.json，光凭它否决会
+      // 把真漫画包挡在门外。bank 前缀才是 Yomitan 独有的结构指纹，缺 bank 即
+      // 不算词典包。
+      final String mangaZip = writeZip('vol2.zip', <String, List<int>>{
+        'index.json': utf8Bytes('{"pages":3,"packer":"some-comic-tool"}'),
+        '001.png': onePixelPng(),
+        '002.png': onePixelPng(),
+      });
+
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>[mangaZip],
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+      expect(files.mangas, <String>[mangaZip]);
+      expect(files.dictionaries, isEmpty);
+    });
+
+    test('纯页图 zip（真漫画包）归 mangas', () {
+      final String mangaZip = writeZip('vol1.zip', <String, List<int>>{
+        '001.png': onePixelPng(),
+        '002.png': onePixelPng(),
+        '003.png': onePixelPng(),
+      });
+
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>[mangaZip],
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+      expect(files.mangas, <String>[mangaZip]);
+      expect(files.dictionaries, isEmpty);
+    });
+  });
+}

--- a/hibiki/test/media/drag_drop/manga_drop_test.dart
+++ b/hibiki/test/media/drag_drop/manga_drop_test.dart
@@ -56,7 +56,62 @@ void main() {
       expect(files.unknown, <String>['/a/第01巻']);
     });
 
-    test('.zip 不归漫画（无内容判据，避免把词典包当漫画导）', () {
+    // ↓ 用户实指：「你怎么知道是普通 epub 啊」——同理，`.zip` 也分不出是一包页图的
+    //   漫画还是 Yomitan 词典包。没有判据时图片型 zip 归 dictionaries，books 分支
+    //   走到 `files.hasAny` 兜底回「本页面不支持」，而导入对话框导得了它（其分派
+    //   对 .zip 会真读包）——又一处「按钮能导、拖进去不认」。
+    test('图片型 .zip 经 isImageArchive 判据归 mangas（此前回「本页面不支持」）', () {
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>['/a/vol1.zip'],
+        isImageArchive: (String pth) => pth == '/a/vol1.zip',
+      );
+      expect(files.mangas, <String>['/a/vol1.zip']);
+      expect(files.dictionaries, isEmpty,
+          reason: '命中图片包判据后不得再落 dictionaries（否则归属歧义）');
+    });
+
+    test('图片型 .zip 在两个表面都 -> importNewManga', () {
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>['/a/vol1.zip'],
+        isImageArchive: (String _) => true,
+      );
+      for (final DropSurface surface in <DropSurface>[
+        DropSurface.books,
+        DropSurface.manga,
+      ]) {
+        expect(
+          decideDropIntent(surface: surface, files: files, cardHit: false),
+          DropIntent.importNewManga,
+          reason: '$surface 表面的图片型 zip 必须能导入而不是回「不支持」',
+        );
+      }
+    });
+
+    test('词典 .zip 有判据也仍归 dictionaries（不误把词典包当漫画导）', () {
+      final DroppedFiles files = classifyDroppedFiles(
+        <String>['/a/dict.zip'],
+        isImageArchive: (String _) => false,
+      );
+      expect(files.mangas, isEmpty);
+      expect(files.dictionaries, <String>['/a/dict.zip']);
+    });
+
+    test('判据只探 zip，不对 epub / 无关扩展名白开压缩包', () {
+      final List<String> probed = <String>[];
+      classifyDroppedFiles(
+        <String>['/a/v.mp4', '/a/b.epub', '/a/s.srt', '/a/x.zip'],
+        isImageArchive: (String pth) {
+          probed.add(pth);
+          return false;
+        },
+      );
+      // epub 刻意不探：它在 books 分支就走 BookImportDialog，对话框的分派本来就
+      // 会真读包并把图片型 EPUB 导成漫画，行为已正确——为每次拖 EPUB 白开一次包
+      // 换不来可见改进。
+      expect(probed, <String>['/a/x.zip']);
+    });
+
+    test('无判据时 .zip 维持词典包分类（向后兼容）', () {
       final DroppedFiles files = classifyDroppedFiles(<String>['/a/dict.zip']);
       expect(files.mangas, isEmpty);
       expect(files.dictionaries, <String>['/a/dict.zip']);


### PR DESCRIPTION
## 这是什么

从**已合并的 PR#494 分支**上抢救下来的孤儿提交 + 修掉它带的词典误判。

PR#494 合并**之后**，有人又往分支 `worktree-drag-to-collection` 推了一个提交
`166529350`。本仓的事实是：PR 合并后追加推送的 commit 永远进不了 develop——所以那个修复
一直是孤儿，不捞就永久丢失。这个 PR 把它捞回来，并补上它缺的那半个判据。

## 两个提交

### 1. `fix(manga): 图片型 .zip 拖进来不再回「本页面不支持」`（原样抢救，未改）

原提交解决的是真问题：图片型 zip（扫描版漫画的常见分发形态）拖进书架/漫画库，两个表面都回
「本页面不支持」，而导入对话框明明导得了它——又一处「按钮能导、拖进去不认」。

做法是给拖放分类层加可选谓词 `isImageArchive`（widget 层注入
`MangaModule.isImageArchive`），新增 `kDragImageArchiveProbeExtensions`（只含 `zip`），
分类层自身仍不碰 IO。两条入口（拖放 / 对话框）从此用同一判据。

### 2. `fix(manga): 带插图的 Yomitan 词典包不再被判成图片包`（本 PR 新增）

🔴 **原提交把归属交给了 `looksLikeImageArchive`，但那个判据本身有洞**，会重新引入 PR#494
当初刻意避开的误判。

判据原文：见到任一图片扩展名就 `hasImage = true`，**只在**遇到 `.opf/.xhtml/.html/.htm`
时才否决。Yomitan 词典包不含这些文件，**否决分支永不触发**。

而 Yomitan 允许词典**自带图片**——这不是臆想：

- `packages/hibiki_dictionary/lib/src/formats/yomichan_dictionary_format.dart:100`
  处理 structured-content 的 `case 'image'`；
- `native/hoshidicts/hoshidicts_src/importer.cpp` 的 `get_files()` 明确把非 bank、非
  `index.json` 的条目一律收成 `media_files`。

后果不是「导不进」，是**用户数据被糟蹋**：拖一本带插图的词典进书架 →
`DropIntent.importNewManga` → `importArchive` 只抽图片 → 静默导成一本只有插图的垃圾
「漫画」，而**词典根本没被导入**。

**修法沿用仓库既有的词典识别，不自创第二套**：包根有 `index.json` **且**至少一个
`term_bank_` / `kanji_bank_` / `term_meta_bank_` / `kanji_meta_bank_` / `tag_bank_`
前缀条目 → 判词典包，一票否决图片判据。前缀集与 C++ 导入器 `get_files()` 同源。

**为什么要求两者同时在场**（反向误判防线）：打包工具随手生成的清单也可能叫 `index.json`，
光凭它否决会把真漫画包挡在门外；bank 前缀才是 Yomitan 独有的结构指纹，一个页图包不会有
`term_bank_1.json`。取舍方向是保守的——判不准就不当漫画，让用户走导入对话框（多点两下），
绝不把词典静默导成漫画（数据被糟蹋）。

## 测试

`hibiki/test/media/drag_drop/dictionary_zip_not_manga_test.dart`：**真 zip 文件 + 真判据**
（`MangaModule.isImageArchive`），不打桩——桩只能证明接线对，证明不了判据对。

| 用例 | 期望 |
|---|---|
| 带插图的 term 词典包（`index.json` + `term_bank_1.json` + `img/neko.png`） | dictionaries |
| 只有 `kanji_bank_1.json` 的汉字词典（带笔顺图） | dictionaries |
| 纯页图 zip | mangas |
| 恰好带 `index.json` 但无 bank 的页图 zip | mangas |

**负向验证（两个方向都跑了）**：去掉那个否决分支 → 前两条转红（后两条仍绿，说明否决分支不是
在无差别地把 zip 判成词典）；还原 → 全绿。

## 验证

- `flutter analyze`（含 test）：`No issues found!`
- 定向：`test/media/drag_drop` + `test/media/manga` → `PASSED - 281 tests ran`（判绿取
  `tool/flutter_test_failures.dart` 末行判词 + 退出码）
- 未跑全量，交 PR CI 兜底。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
