### PR TITLE
feat(gal): 制卡封面可选静态截图（BUG-1160，从 PR#471 拆出）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,7 +29,7 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1153 条。点号进各自文件。
+> 共 1154 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
@@ -61,6 +61,7 @@
 | [BUG-1163](bugs/BUG-1163-manga-ocr-silent-provider-fallback.md) | ✅ | ✅ | 漫画 OCR GPU 加速降级到 CPU 完全静默 |
 | [BUG-1162](bugs/BUG-1162-torrent-pipeline-disk-flush-race.md) | ✅ | ✅ | hibiki_torrent 端到端测试在字节落盘前就比对，CI Windows 约 24% 概率红 |
 | [BUG-1161](bugs/BUG-1161-subtitle-ruby-strip.md) | ✅ | ✅ | 字幕 <rt> 注音被拼进正文，污染查词/制卡 sentence/字数统计 |
+| [BUG-1160](bugs/BUG-1160-gal-card-cover-gif-only.md) | ✅ | ✅ | galgame 制卡封面只能 GIF，不能选静态截图 |
 | [BUG-1159](bugs/BUG-1159-gal-textthread-ctx-strict-match.md) | ✅ | ✅ | 文本线程记忆按 ctx 严格匹配掐断文本流，连带语音资源配对失败降级 |
 | [BUG-1157](bugs/BUG-1157-test-runner-zero-test-false-green.md) | ✅ | ✅ | 全量测试入口把「零测试执行」当成通过（native asset 构建失败被伪装成绿） |
 | [BUG-1156](bugs/BUG-1156-manga-spread-cropped-janky.md) | ✅ | ✅ | 漫画双页图片裁切且翻页卡顿 |

--- a/docs/bugs/BUG-1160-gal-card-cover-gif-only.md
+++ b/docs/bugs/BUG-1160-gal-card-cover-gif-only.md
@@ -1,0 +1,15 @@
+## BUG-1160 · galgame 制卡封面只能 GIF，不能选静态截图
+- **报告**：2026-07-27（用户：制卡要支持使用截图，而不是只能 gif）
+- **真实性**：✅ 真 bug（缺能力）。`hibiki/lib/src/mining/gal_hook_mining_coordinator.dart` 的封面链路把 GIF 写死成主路径：先 `_captureGif`，只有它返回空才退到 `_captureStill` 单帧并置 `degradedToStill`。用户没有任何入口选「我就要静态截图」。
+  - 视频侧早有 `VideoMiningImageMode { gif, currentFrame, subtitleStart }` + 偏好 `video_mining_image_mode` + 设置页选择器（`anki_settings_page.dart`），galgame 侧完全没有接。
+  - 这在 galgame 上尤其亏：一句台词内画面基本静止，GIF 多半只是把同一帧存二十遍，白白撑大卡片和 Anki 媒体库。
+- **[x] ① 已修复** — 复用视频侧的 `VideoMiningImageMode` 枚举（不新造概念），但**独立存偏好** `gal_mining_image_mode`：
+  - 视频的动图能拍出口型和动作，galgame 的不能——两者取舍不同，共用一个开关会逼用户为一边将就另一边，故分开存（`preferences_repository.dart` / `app_model.dart`）。
+  - `mineLine` 新增 `imageMode` 参数（缺省 `gif` = 旧行为逐字等价，Never break userspace），`texthooker_page.dart` 透传 `appModel.galMiningImageMode`。
+  - `imageMode.isStill` 时**直接抓单帧、完全不试 GIF**，且**不置 `degradedToStill`**（主动选静态图不是降级，不该弹「已降级为静态图」提示，与视频侧同语义）。
+  - BUG-1096 的 WGC/Magpie 诊断留痕抽成 `captureStillWithDiagnostics()`，GIF 降级与静态主路径共用，不因为多了一条路径就漏掉留痕。
+  - 设置页只渲染 gif / 静态截图两档——galgame 没有「字幕区间」，不给 `subtitleStart` 免得暗示能选；历史值若是 `subtitleStart` 按 `isStill` 归到静态截图，picker 不会落在未渲染的选项上。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_hook_mining_coordinator_test.dart`：
+  - `screenshot mode skips GIF entirely and is not a degradation`（断言 `gifCalls == 0`、封面 `.png`、`degradedToStill` 为假）；
+  - `gif mode remains the default and still degrades to png`（不传 `imageMode` 的旧调用形态必须逐字等价于原链路）。
+- **备注**：本条原与 [BUG-1187](BUG-1187-gal-unvoiced-line-gets-bgm.md) / [BUG-1165](BUG-1165-gal-track-panel-silent-predicate.md) 同在 PR#471，但它是**新增能力**而非缺陷修复，按用户要求拆成独立 PR 独立审查、独立验收；PR#471 只保留那两条 bug 修复。两个 PR 各自基于 develop，无代码依赖。真机验收待补：需在游戏里各制一张卡，确认静态模式落 `.png` 且不弹降级提示、GIF 模式行为与之前一致。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46019 (2707 per locale)
+/// Strings: 46070 (2710 per locale)
 ///
-/// Built on 2026-07-28 at 07:01 UTC
+/// Built on 2026-07-28 at 07:13 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3634,6 +3634,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'No local video in this collection';
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  String get gal_mining_image_mode => 'Galgame card image';
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -9823,6 +9827,13 @@ class _StringsAr extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -16080,6 +16091,13 @@ class _StringsDe extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -22353,6 +22371,13 @@ class _StringsEs extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -28637,6 +28662,13 @@ class _StringsFr extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -34850,6 +34882,13 @@ class _StringsId extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -41109,6 +41148,13 @@ class _StringsIt extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -47185,6 +47231,13 @@ class _StringsJa extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -53263,6 +53316,13 @@ class _StringsKo extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -59502,6 +59562,13 @@ class _StringsNl extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -65754,6 +65821,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -71990,6 +72064,13 @@ class _StringsRu extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -78174,6 +78255,13 @@ class _StringsTh extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -84390,6 +84478,13 @@ class _StringsTr extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -90591,6 +90686,13 @@ class _StringsVi extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 // Path: <root>
@@ -96358,6 +96460,13 @@ class _StringsZhCn extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       '为「${name}」匹配封面';
+  @override
+  String get gal_mining_image_mode => 'Galgame 制卡配图';
+  @override
+  String get gal_mining_image_mode_screenshot => '静态截图';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame 一句台词内画面基本不动，静态截图通常更小、信息量一样。';
 }
 
 // Path: <root>
@@ -102355,6 +102464,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String video_scrape_online_match_collection({required Object name}) =>
       'Match cover for ${name}';
+  @override
+  String get gal_mining_image_mode => 'Galgame card image';
+  @override
+  String get gal_mining_image_mode_screenshot => 'Screenshot';
+  @override
+  String get gal_mining_image_mode_hint =>
+      'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
 }
 
 /// Flat map(s) containing all translations.
@@ -107901,6 +108017,12 @@ extension on _StringsEn {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -113445,6 +113567,12 @@ extension on _StringsAr {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -119010,6 +119138,12 @@ extension on _StringsDe {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -124574,6 +124708,12 @@ extension on _StringsEs {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -130144,6 +130284,12 @@ extension on _StringsFr {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -135696,6 +135842,12 @@ extension on _StringsId {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -141263,6 +141415,12 @@ extension on _StringsIt {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -146792,6 +146950,12 @@ extension on _StringsJa {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -152325,6 +152489,12 @@ extension on _StringsKo {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -157885,6 +158055,12 @@ extension on _StringsNl {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -163442,6 +163618,12 @@ extension on _StringsPtBr {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -169004,6 +169186,12 @@ extension on _StringsRu {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -174550,6 +174738,12 @@ extension on _StringsTh {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -180105,6 +180299,12 @@ extension on _StringsTr {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -185655,6 +185855,12 @@ extension on _StringsVi {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }
@@ -191159,6 +191365,12 @@ extension on _StringsZhCn {
         return '本合集没有本地视频';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => '为「${name}」匹配封面';
+      case 'gal_mining_image_mode':
+        return 'Galgame 制卡配图';
+      case 'gal_mining_image_mode_screenshot':
+        return '静态截图';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame 一句台词内画面基本不动，静态截图通常更小、信息量一样。';
       default:
         return null;
     }
@@ -196683,6 +196895,12 @@ extension on _StringsZhHk {
         return 'No local video in this collection';
       case 'video_scrape_online_match_collection':
         return ({required Object name}) => 'Match cover for ${name}';
+      case 'gal_mining_image_mode':
+        return 'Galgame card image';
+      case 'gal_mining_image_mode_screenshot':
+        return 'Screenshot';
+      case 'gal_mining_image_mode_hint':
+        return 'Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "默认关闭：与局域网内 peer 的传输不受上面的限速约束。",
   "download_rate_limit_lan_included": "同时作用于局域网内的传输。",
   "video_collection_no_local_member": "本合集没有本地视频",
-  "video_scrape_online_match_collection": "为「$name」匹配封面"
+  "video_scrape_online_match_collection": "为「$name」匹配封面",
+  "gal_mining_image_mode": "Galgame 制卡配图",
+  "gal_mining_image_mode_screenshot": "静态截图",
+  "gal_mining_image_mode_hint": "Galgame 一句台词内画面基本不动，静态截图通常更小、信息量一样。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2705,5 +2705,8 @@
   "video_setting_torrent_limit_lan_hint": "Off by default: transfers with peers on your local network ignore the limits above.",
   "download_rate_limit_lan_included": "Also applies within your local network.",
   "video_collection_no_local_member": "No local video in this collection",
-  "video_scrape_online_match_collection": "Match cover for $name"
+  "video_scrape_online_match_collection": "Match cover for $name",
+  "gal_mining_image_mode": "Galgame card image",
+  "gal_mining_image_mode_screenshot": "Screenshot",
+  "gal_mining_image_mode_hint": "Galgame scenes barely move within one line, so a still screenshot is usually smaller and just as useful."
 }

--- a/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
+++ b/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
@@ -117,6 +117,9 @@ class GalHookMiningCoordinator {
     required BaseAnkiRepository repo,
     int? updateNoteId,
     bool addTitleTag = false,
+    // 缺省 gif = 旧行为逐字等价（Never break userspace）；调用方透传
+    // [AppModel.galMiningImageMode]。
+    VideoMiningImageMode imageMode = VideoMiningImageMode.gif,
   }) {
     // 串行化 + 永不毒化（BUG-956）：单次制卡异常（含错误日志自身抛）不得让后续制卡永久挂起。
     return _miningQueue.enqueue<GalHookMiningResult>(
@@ -127,6 +130,7 @@ class GalHookMiningCoordinator {
         repo: repo,
         updateNoteId: updateNoteId,
         addTitleTag: addTitleTag,
+        imageMode: imageMode,
       ),
       buildFailure: (Object error, StackTrace stack) =>
           GalHookMiningResult(failureReason: error.toString()),
@@ -145,6 +149,7 @@ class GalHookMiningCoordinator {
     required BaseAnkiRepository repo,
     required int? updateNoteId,
     required bool addTitleTag,
+    required VideoMiningImageMode imageMode,
   }) async {
     final TexthookerLineEntry? entry = _lineLookup(lineId);
     if (entry == null || !_lineValidator(entry)) {
@@ -180,13 +185,10 @@ class GalHookMiningCoordinator {
       );
     }
 
-    Uint8List? coverBytes = await _captureGif(hwnd: window.hwnd);
-    String coverName = 'external_window.gif';
-    bool degradedToStill = false;
-    if (coverBytes == null || coverBytes.isEmpty) {
+    // 单帧截图：GIF 模式下是降级路径，静态模式下是**主路径**。两条路径共用同一份
+    // 诊断留痕（BUG-1096：WGC 光标抑制是否生效 / 是否从 Magpie 缩放窗重定向回源窗）。
+    Future<WindowCaptureResult> captureStillWithDiagnostics() async {
       final WindowCaptureResult still = await _captureStill(window.hwnd);
-      // BUG-1096：native 成功路径诊断（WGC 光标抑制是否生效 / 是否从 Magpie 缩放窗
-      // 重定向到源窗口）。降级到单帧时也要留痕，否则这条路径仍是盲区。
       final String? diagnostics = still.diagnostics;
       if (diagnostics != null && diagnostics.isNotEmpty) {
         ErrorLogService.instance.log(
@@ -195,6 +197,17 @@ class GalHookMiningCoordinator {
           StackTrace.current,
         );
       }
+      return still;
+    }
+
+    Uint8List? coverBytes;
+    String coverName = 'external_window.gif';
+    bool degradedToStill = false;
+    if (imageMode.isStill) {
+      // 用户主动选静态截图：直接抓单帧，**不**先试 GIF。galgame 一句台词内画面基本
+      // 静止，动图多半只是把同一帧存二十遍，白白撑大卡片。这不是降级，故不置
+      // degradedToStill，也就不会弹「已降级为静态图」的提示（与视频侧同语义）。
+      final WindowCaptureResult still = await captureStillWithDiagnostics();
       if (!still.ok) {
         return GalHookMiningResult(
           failureReason: still.error ?? 'game window capture failed',
@@ -202,7 +215,19 @@ class GalHookMiningCoordinator {
       }
       coverBytes = still.pngBytes;
       coverName = 'external_window.png';
-      degradedToStill = true;
+    } else {
+      coverBytes = await _captureGif(hwnd: window.hwnd);
+      if (coverBytes == null || coverBytes.isEmpty) {
+        final WindowCaptureResult still = await captureStillWithDiagnostics();
+        if (!still.ok) {
+          return GalHookMiningResult(
+            failureReason: still.error ?? 'game window capture failed',
+          );
+        }
+        coverBytes = still.pngBytes;
+        coverName = 'external_window.png';
+        degradedToStill = true;
+      }
     }
 
     final String audioExtension = immersionMiningAudioExtension();

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4792,6 +4792,10 @@ class AppModel with ChangeNotifier {
   void setVideoMiningImageMode(VideoMiningImageMode mode) =>
       prefsRepo.setVideoMiningImageMode(mode);
 
+  VideoMiningImageMode get galMiningImageMode => prefsRepo.galMiningImageMode;
+  void setGalMiningImageMode(VideoMiningImageMode mode) =>
+      prefsRepo.setGalMiningImageMode(mode);
+
   bool get deduplicatePitchAccents => prefsRepo.deduplicatePitchAccents;
   void toggleDeduplicatePitchAccents() =>
       prefsRepo.toggleDeduplicatePitchAccents();

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1334,6 +1334,20 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  // galgame 场景卡封面模式，与视频**分开存**：视频的动图能拍出口型和动作，galgame
+  // 画面在一句台词内基本静止，动图多半只是把同一帧存二十遍。两者的取舍不同，共用一
+  // 个开关会逼用户为一边将就另一边。默认 gif=现状零破坏；galgame 没有「字幕区间」，
+  // 故只在 gif / currentFrame 两档间取值，其余值按 [VideoMiningImageMode.isStill]
+  // 归入静态截图。
+  VideoMiningImageMode get galMiningImageMode =>
+      VideoMiningImageMode.fromWireName(
+          getPref('gal_mining_image_mode', defaultValue: null) as String?);
+
+  void setGalMiningImageMode(VideoMiningImageMode mode) async {
+    await setPref('gal_mining_image_mode', mode.wireName);
+    notifyListeners();
+  }
+
   bool get deduplicatePitchAccents =>
       getPref('deduplicate_pitch_accents', defaultValue: true) as bool;
 

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -320,6 +320,7 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
             _buildMiningImageQualityRow(),
             _buildMiningAudioQualityRow(),
             _buildVideoMiningImageModePicker(),
+            _buildGalMiningImageModePicker(),
           ],
         ),
       ],
@@ -413,6 +414,40 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       ],
       onChanged: (VideoMiningImageMode mode) {
         appModel.setVideoMiningImageMode(mode);
+        setState(() {});
+      },
+    );
+  }
+
+  /// galgame 场景卡封面模式，与视频那项**分开存**（`gal_mining_image_mode`）：视频
+  /// 动图能拍出口型和动作，galgame 一句台词内画面基本静止，动图多半只是把同一帧存
+  /// 二十遍。共用一个开关会逼用户为一边将就另一边。
+  ///
+  /// galgame 没有「字幕区间」，所以只给 gif / 静态截图两档——不渲染 subtitleStart，
+  /// 免得暗示能选一个对这个场景无意义的模式。
+  Widget _buildGalMiningImageModePicker() {
+    return AdaptiveSettingsPickerRow<VideoMiningImageMode>(
+      title: t.gal_mining_image_mode,
+      subtitle: t.gal_mining_image_mode_hint,
+      icon: Icons.photo_camera_back_outlined,
+      controlBelow: true,
+      // 历史值可能是 subtitleStart（与视频项共用枚举）：按 isStill 归到静态截图，
+      // 不让 picker 落在一个没渲染的选项上。
+      selected: appModel.galMiningImageMode.isStill
+          ? VideoMiningImageMode.currentFrame
+          : VideoMiningImageMode.gif,
+      options: [
+        AdaptiveSettingsPickerOption<VideoMiningImageMode>(
+          value: VideoMiningImageMode.gif,
+          label: t.video_mining_image_mode_gif,
+        ),
+        AdaptiveSettingsPickerOption<VideoMiningImageMode>(
+          value: VideoMiningImageMode.currentFrame,
+          label: t.gal_mining_image_mode_screenshot,
+        ),
+      ],
+      onChanged: (VideoMiningImageMode mode) {
+        appModel.setGalMiningImageMode(mode);
         setState(() {});
       },
     );

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -519,6 +519,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       repo: repo,
       updateNoteId: updateNoteId,
       addTitleTag: mixinAppModel.autoAddBookNameToTags,
+      imageMode: mixinAppModel.galMiningImageMode,
     );
     if (result.aborted) {
       HibikiToast.showMine(

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+955
+version: 1.3.1+956
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
+++ b/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
@@ -5,6 +5,8 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/mining/gal_hook_mining_coordinator.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/immersion_mining_request.dart'
+    show VideoMiningImageMode;
 import 'package:hibiki/src/mining/window_capture_channel.dart';
 import 'package:hibiki/src/sync/texthooker_service.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
@@ -217,6 +219,54 @@ void main() {
     expect(failed.aborted, isTrue);
     expect(failed.failureReason, 'window disappeared');
     expect(failedRepo.contexts, isEmpty);
+  });
+
+  test('screenshot mode skips GIF entirely and is not a degradation', () async {
+    final TexthookerLineEntry entry = service.appendLine('静止画の台詞')!;
+    final _RecordingRepo repo = _RecordingRepo();
+    int gifCalls = 0;
+
+    final GalHookMiningResult result = await coordinator(
+      validator: (_) => true,
+      gif: ({required int hwnd}) async {
+        gifCalls++;
+        return Uint8List.fromList(<int>[1, 2, 3]);
+      },
+    ).mineLine(
+      lineId: entry.id,
+      fields: const <String, String>{'expression': '静止画'},
+      compression: MiningMediaCompression.compressed,
+      repo: repo,
+      imageMode: VideoMiningImageMode.currentFrame,
+    );
+
+    expect(result.success, isTrue);
+    expect(gifCalls, 0, reason: '用户选了截图就别再去抓 GIF——白花时间还白花体积');
+    expect(repo.contexts.single.coverPath, endsWith('.png'));
+    expect(
+      result.degradedToStill,
+      isFalse,
+      reason: '主动选静态图不是降级，不该弹「已降级为静态图」',
+    );
+  });
+
+  test('gif mode remains the default and still degrades to png', () async {
+    final TexthookerLineEntry entry = service.appendLine('動画の台詞')!;
+    final _RecordingRepo repo = _RecordingRepo();
+
+    // 不传 imageMode = 旧调用形态，必须逐字等价于原来的 GIF 优先链路。
+    final GalHookMiningResult result = await coordinator(
+      validator: (_) => true,
+    ).mineLine(
+      lineId: entry.id,
+      fields: const <String, String>{'expression': '動画'},
+      compression: MiningMediaCompression.compressed,
+      repo: repo,
+    );
+
+    expect(result.success, isTrue);
+    expect(repo.contexts.single.coverPath, endsWith('.gif'));
+    expect(result.degradedToStill, isFalse);
   });
 
   test('expired line is rejected before scene or audio capture', () async {


### PR DESCRIPTION
## 这个 PR 是从 PR#471 拆出来的

PR#471 原本只修两条 bug（BUG-1187 无配音句被混音兜底成 BGM、BUG-1165 音轨静音判据用错字段），后来把**「制卡封面可选静态截图」这个新增能力**也混了进去，规模从 11 个文件涨到 39 个。

用户拍板：**PR#471 只保留 bug 修复，新功能拆出来单独一个 PR 独立审查、独立验收**。这就是那个 PR。

两个 PR **各自基于 develop、无代码依赖**，可以任意顺序合入（唯一会撞的是 i18n 文件尾部追加和 `pubspec.yaml` 的 `+build`，属于本仓所有 PR 的常规合并冲突）。

## 做了什么（BUG-1160）

用户报「制卡要支持使用截图，而不是只能 gif」。galgame 封面链路把 GIF 写死成主路径：先 `_captureGif`，只有它返回空才退到单帧并置 `degradedToStill`——用户没有任何入口说「我就要静态截图」。这在 galgame 上尤其亏：一句台词内画面基本静止，GIF 多半只是把同一帧存二十遍，白白撑大卡片和 Anki 媒体库。

- 复用视频侧的 `VideoMiningImageMode` 枚举（不新造概念），但**独立存偏好** `gal_mining_image_mode`。视频的动图能拍出口型和动作，galgame 的不能——两者取舍不同，共用一个开关会逼用户为一边将就另一边。
- `mineLine` 新增 `imageMode` 参数，**缺省 `gif` = 旧行为逐字等价**（Never break userspace）；`texthooker_page.dart` 透传 `appModel.galMiningImageMode`。
- `imageMode.isStill` 时**直接抓单帧、完全不试 GIF**，且**不置 `degradedToStill`**——主动选静态图不是降级，不该弹「已降级为静态图」提示（与视频侧同语义）。
- BUG-1096 的 WGC/Magpie 诊断留痕抽成 `captureStillWithDiagnostics()`，GIF 降级路径与静态主路径共用，不因为多了一条路径就漏掉留痕。
- 设置页只渲染 gif / 静态截图两档——galgame 没有「字幕区间」，不给 `subtitleStart` 免得暗示能选一个对这个场景无意义的模式；历史值若是 `subtitleStart`，按 `isStill` 归到静态截图，picker 不会落在一个没渲染的选项上。

## 测试

`hibiki/test/mining/gal_hook_mining_coordinator_test.dart`：

- `screenshot mode skips GIF entirely and is not a degradation`（断言 `gifCalls == 0`、封面 `.png`、`degradedToStill` 为假）
- `gif mode remains the default and still degrades to png`（不传 `imageMode` 的旧调用形态必须逐字等价于原链路）

## 验证

- `flutter analyze`（含 test 目录）：**No issues found!**
- 定向套件（`dart run tool/flutter_test_failures.dart --no-pub`）：`FLUTTER TEST VERDICT: PASSED - 63 tests ran, all tests passed`
  - `test/mining/gal_hook_mining_coordinator_test.dart`、`test/pages/anki_settings_page_test.dart`、`test/pages/texthooker_page_test.dart`、`test/settings/settings_flatten_anki_profile_test.dart`、`test/settings/mining_media_quality_guard_test.dart`、`test/settings/settings_redesign_static_test.dart`
- 全量套件交由 PR CI 兜底。

## 待办

真机验收待补：在游戏里各制一张卡，确认静态模式落 `.png` 且不弹降级提示、GIF 模式行为与之前完全一致。

## 平台范围

Windows only（galgame hook 硬规则），未触碰任何其它平台实现。
