### PR TITLE
fix(storage): 选目录迁移归一化到新装形态，消除布局分裂 (BUG-1188)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1152 条。点号进各自文件。
+> 共 1153 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1188](bugs/BUG-1188-dataroot-pick-layout-split.md) | ✅ | ✅ | 选目录迁移产出第三种布局，到不了新装形态（DB 被拖进文档目录） |
 | [BUG-1187](bugs/BUG-1187-gal-unvoiced-line-gets-bgm.md) | ✅ | ✅ | galgame 无配音句被整机混音兜底成 BGM |
 | [BUG-1186](bugs/BUG-1186-appbar-actions-collapse-uses-window-width.md) | ✅ | ✅ | AppBar 动作折叠判据读整窗宽，分栏/受限宽容器里永不折叠 |
 | [BUG-1185](bugs/BUG-1185-remote-mining-duplicate-auth-swallowed.md) | ✅ | ✅ | 远端制卡查重吞掉认证失败，静默答「不重复」 |

--- a/docs/bugs/BUG-1115-default-documents-root-flat.md
+++ b/docs/bugs/BUG-1115-default-documents-root-flat.md
@@ -74,6 +74,13 @@
   - 仅改「默认根」的落点，**不做任何自动迁移**：启动期搬整个书库既慢又可能被文件锁半途
     打断。老用户要整理，走设置 →「数据存储位置」选 `Documents\Hibiki`（迁移引擎会连 DB 里
     的绝对路径一起 rebase），或任意其它目录。
+    ⚠️ **BUG-1188 更正**：这条指引在当时会产出**第三种布局**——`Documents\Hibiki\documents`
+    + `Documents\Hibiki\support`，且把 `hibiki.db` 一起搬进文档目录，与新装的
+    `Documents\Hibiki\data` + `%APPDATA%` 不同形。BUG-1188 已把「挑中默认位置」归一化：现在选
+    `Documents\Hibiki`（或 `Documents\Hibiki\data`）得到的就是**与全新安装逐字节同形**的结果
+    ——内容落 `Documents\Hibiki\data`、DB 留在 `%APPDATA%` 不动、`data_root` 被清掉并把
+    `documents_layout` 锚成 `nested`。选**其它**目录仍是自定义数据根语义（`<root>/documents`
+    + `<root>/support`，DB 随之搬走），未变。
   - `ErrorLogService` 的 `error_log.txt` / `*_breadcrumb.txt` 仍直连平台 `Documents`
     （刻意不随数据根走，搬走会让服务失去续写目标），本次未动——文档根下仍会看到这两类
     **文件**（不是目录）。要一并收编需单独评估旧日志的续写衔接。
@@ -85,3 +92,4 @@
   - **本机现有安装（含报告者本人）会被判为老安装、继续用扁平布局**——这是刻意的零破坏
     设计。要立刻看到文档根变干净，走设置 →「数据存储位置」选 `Documents\Hibiki`（本次
     放开的正是这条路径），迁移引擎会把 16 个目录搬过去并 rebase DB 里的绝对路径。
+    BUG-1188 之后这条路径的产物就是新装形态本身（`Documents\Hibiki\data`，DB 不动）。

--- a/docs/bugs/BUG-1188-dataroot-pick-layout-split.md
+++ b/docs/bugs/BUG-1188-dataroot-pick-layout-split.md
@@ -1,0 +1,102 @@
+## BUG-1188 · 选目录迁移产出第三种布局，到不了新装形态（DB 被拖进文档目录）
+- **报告**：2026-07-28（用户：内部审计，走「设置 → 数据存储位置 → 选目录」即可触发）
+- **真实性**：✅ 真 bug（在 develop `862ce0d17` 上跑真 `DataRootMigrator.migrate()` 实测复现）
+
+  根因 `hibiki/lib/src/storage/data_root_migrator.dart:143-148`（改动前）：`migrate()` 无条件
+  `AppPaths.rootsForDataRoot(req.newDataRoot)`，即**目标只有一种表达**——一个 dataRoot 字符串，
+  硬派生 `<root>/documents`（`app_paths.dart:114`）+ `<root>/support`（`app_paths.dart:117`）。
+
+  于是 BUG-1115 给老安装写的指引（`docs/bugs/BUG-1115-default-documents-root-flat.md:75-76,86-87`
+  「走设置 →「数据存储位置」选 `Documents\Hibiki`」）产出的是**第三种布局**，与全新安装
+  （`app_paths.dart:_resolveDefaultDocumentsRoot` → `<Documents>/Hibiki/data` + 平台固定
+  `getApplicationSupportDirectory()`）不同：
+
+  ```
+  新装形态 documents 根: <Documents>\Hibiki\data
+  新装形态 support 根:   <AppData>\app.hibiki.reader
+  迁移实际 documents 根: <Documents>\Hibiki\documents      ← 名字不同
+  迁移实际 support 根:   <Documents>\Hibiki\support        ← DB 被拖进文档目录
+  data_root pref 写入:   <Documents>\Hibiki
+  ```
+
+  两个后果：
+  1. **布局分裂**：同一个物理位置有两种持久化表达（`data_root=<Documents>/Hibiki` vs 无
+     `data_root` + `documents_layout=nested`），磁盘形态还不一样。用户照文档整理完就**永远回不到
+     新装形态**，也无法与新装机器对齐。
+  2. **DB 被搬进用户文档目录**：Windows 的 `Documents` 常被 OneDrive 重定向同步，WAL 模式的
+     SQLite 主库落在那里既有损坏风险，也会被反复上传；而持久化 `data_root` 的
+     `shared_preferences.json` 按设计**不能**跟着搬（`data_root_migrator.dart` 的鸡生蛋铁律），
+     结果两份配置存储被劈开在两处。改动前的迁移把「换个盘放数据」和「把散落目录收进子目录」
+     这两件语义完全不同的事塞进了同一条硬派生路径。
+
+- **[x] ① 已修复** — `fix(storage): normalize data-root migration to the default layout`
+  - **把「迁移目标」提升成数据结构**：新增 `DataRootMigrationTarget`
+    （`data_root_migrator.dart`），携带解析后的 `documentsRoot` / `supportRoot` /
+    `dataRootPrefValue`；`DataRootMigrationRequest.newDataRoot` → `target`，
+    `writeDataRootPref` → `commitLocation(target)`。两种情形因此是**同一条代码路径的两个取值**，
+    不是两条分支：
+    - `DataRootMigrationTarget.customRoot(R)` —— `<R>/documents` + `<R>/support`，提交写
+      `data_root`。**行为逐字节不变**（换盘放数据的语义原样保留，DB 仍随之搬走）。
+    - `DataRootMigrationTarget.defaultLocation(...)` —— documents 根 = `<Documents>/Hibiki/data`、
+      support 根 = 平台固定落点（**DB 不动**），提交清掉 `data_root` 并把
+      `documents_layout` 锚成 `nested`。
+  - **归一化入口** `resolveDataRootMigrationTarget()`：用户挑的目录若是默认位置
+    （`<Documents>/Hibiki` 伞目录，或 `<Documents>/Hibiki/data` 本身）就走 defaultLocation。
+    这消除的正是「同一个物理位置两种表达」这个歧义，而不是给它加一个 if 分支。
+    伞目录靠 `defaultDocumentsChildSegments` 恒 ≥2 段保证绝不等于共享 `Documents`（有守卫）。
+  - **判定「默认位置」必须用不看锚点的根**：新增 `AppPaths.defaultLocationDocumentsRoot()`。
+    `_resolveDefaultDocumentsRoot()` 在老安装上会因锚点 `flat` 返回平台 `Documents`，用它判定
+    则老安装永远解析不出 defaultLocation 这个目标。
+  - **support 根未变时的三条禁令**（`migrate()`）：不建搬移计划、不跑
+    `_deleteOldSupportPreservingPrefs`（它会把活着的固定落点里除 prefs 外的一切删光，包括刚
+    rebase 完的 `hibiki.db`）、不进 `_cleanupCreatedSubtrees`（整目录删掉 = 抹掉用户全部设置）。
+  - **合并搬入**（自定义根 → 默认位置，目标固定落点里已有 prefs）：`_MovePlan.mergeIntoDestination`
+    强制逐顶层项搬移（整目录 rename 到非空 dst 在 Windows 上必失败），回滚改用
+    `_MovePlan.movedTopLevelNames`（只搬回**本次真正搬进去**的项）并保留 dst 本体——旧的
+    `_rollbackSelective` 按 dst 列目录回滚，会把先于迁移就存在的 `shared_preferences.json`
+    一起搬进即将被删的旧根。
+  - **空目标校验收窄**：`_hasAnyFileAsync` 支持 `ignoreTopLevelNames`，检查目标 support 根时忽略
+    顶层 prefs 文件族（它刻意不参与搬移），但**任何别的残留**（比如陈旧的 `hibiki.db`）仍照拒。
+  - **提交原子性**：`_commitDefaultLocation` 先锚 `nested` 再清 `data_root` 再清 macOS 书签，
+    任一步失败全部复原并抛错（引擎据此回滚整次迁移）。两个键必须同时生效——只锚 nested 会指向
+    已搬空的旧根，只清 `data_root` 会把 documents 根解析回共享 `Documents` = 书库集体消失。
+  - **确认弹窗**列出解析后的两个根，用户按下确认前就能看到数据到底会去哪（归一化不是暗箱）。
+  - **未触碰**：`anime_downloads` 的搬移 / fast-resume / 活跃文件句柄逻辑（与 BUG-1174 同样刻意
+    不碰）；未加「一键整理」按钮；`<dataRoot>/documents` 这个存量子目录名未改名（改名要给存量
+    自定义根用户再加一个永久锚点，纯外观收益、爆炸半径不成比例）。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/storage/data_root_default_location_migration_test.dart`
+  （12 例，行为 + 源码守卫）：
+  - ① 目标解析归一化：伞目录 / 默认 documents 根 → defaultLocation（且 `dataRootPrefValue==null`）；
+    别的目录 → customRoot 且与 `AppPaths.rootsForDataRoot` 逐字节一致；共享 `Documents` 根本身
+    **不是**默认位置 + `defaultDocumentsChildSegments.length >= 2` 不变量守卫。
+  - ② 扁平老安装照文档指引整理的**端到端**（真 `migrate()`）：产物 == 新装形态、`Hibiki` 伞下
+    只有 `data`（无 `documents`/`support`）、`hibiki.db` 仍在平台固定落点、用户文件与 prefs 一字
+    未动、DB 内 documents 路径已 rebase 而外部视频路径/support 路径不动、提交是 defaultLocation
+    语义。
+  - ② **幂等**：默认位置的路径改写连跑两次逐字节 no-op，并显式断言不出现
+    `Hibiki/data/Hibiki/data`。
+  - ③ 旧方式搬过的用户：`<root>/documents` + `<root>/support` 解析规则原样不变（继续正常工作）；
+    再选一次 `Hibiki` 能归一化回默认位置（DB 合并搬回固定落点、既存 prefs 一字未动）；
+    提交失败回滚时**平台固定落点不被整目录删掉**、prefs 与旧根数据都还在。
+  - ④ 源码守卫：UI 必须经 `resolveDataRootMigrationTarget` 解析且不得自己再
+    `AppPaths.rootsForDataRoot`；默认位置提交必须同时锚 nested 并清 `data_root`；
+    `supportUnchanged` 的两条禁令必须在源码里。
+  - 负向验证（改回旧逻辑 → 转红 → 还原 → 转绿）三条各自确认：
+    ① 关掉归一化（恒 customRoot）→ 4 例红；② 去掉 `if (!supportUnchanged)` 删旧 support 守卫
+    → 2 例红（`hibiki.db` 被从固定落点删掉）；③ 让 `newSupport` 无条件进 `_cleanupCreatedSubtrees`
+    → 2 例红（回滚删掉平台固定落点）。还原后 12/12 绿。
+
+- **备注**：
+  - **数据库位置的选择**：默认位置目标下 DB **留在** `getApplicationSupportDirectory()`
+    （Windows `%APPDATA%\app.hibiki.reader`）——① 那就是全新安装的落点，不这样就谈不上「同形」；
+    ② 用户 `Documents` 常被 OneDrive 重定向，WAL SQLite 放进去有损坏与反复上传风险；
+    ③ `shared_preferences.json` 按鸡生蛋铁律钉死在固定落点，DB 留在它旁边避免两份配置存储劈开。
+    显式选一个普通目录（换盘）时 DB **仍然跟着搬**，语义与改动前逐字节一致。
+  - `schema` 未改动；持久化 key 未改名；`data_root` / `documents_layout` 的取值域未扩。
+  - 已按旧方式搬过的用户零破坏：`AppPaths._resolveDocumentsRoot` 的 dataRoot 分支优先于布局锚点，
+    解析规则一字未改，他们的 `<root>/documents` + `<root>/support` 继续工作；愿意收敛的话再选一次
+    `Documents\Hibiki` 即可归一化（不强制、不自动）。
+  - 未做真机验证（纯路径解析 + 文件搬移逻辑，单测可在真实文件系统上端到端覆盖）。真机需验的是：
+    老安装选 `Documents\Hibiki` 后重启，书库/有声书/词典资源全部可见且 `Documents\Hibiki` 下只有
+    `data`、`%APPDATA%` 下仍有 `hibiki.db`。

--- a/hibiki/lib/src/storage/app_paths.dart
+++ b/hibiki/lib/src/storage/app_paths.dart
@@ -117,7 +117,8 @@ class AppPaths {
   static const String _dataRootSupportChild = 'support';
 
   /// BUG-1115：**默认** documents 根的布局键（SharedPreferences，与 [dataRootPrefKey]
-  /// 同一通道，DB 打开前可读）。值只有两个：[_layoutFlat] / [_layoutNested]。
+  /// 同一通道，DB 打开前可读）。值只有两个：[documentsLayoutFlat] /
+  /// [documentsLayoutNested]。
   ///
   /// 一经写入就是本机的**永久锚点**，不再重新探测：布局若随「Documents 里此刻有没有某个
   /// 目录」漂移，同一台机器两次启动就可能解析出两个不同的内容根 = 用户书库凭空消失。
@@ -125,12 +126,15 @@ class AppPaths {
 
   /// 历史扁平布局：documents 根 = 平台 `Documents` **本身**，16 个 Hibiki 子目录直接摊在
   /// 用户文档根下。老安装锚定于此（零迁移，见 [_resolveDefaultDocumentsRoot]）。
-  static const String _layoutFlat = 'flat';
+  static const String documentsLayoutFlat = 'flat';
 
   /// 当前默认布局：documents 根 = `<Documents>/Hibiki/data`（Hibiki 专属容器）。
-  static const String _layoutNested = 'nested';
+  ///
+  /// BUG-1188：迁移把数据归一化到默认位置时，提交阶段必须把这个锚点写成本值——否则下次
+  /// 启动仍按 `flat` 把 documents 根解析回共享 `Documents`，而数据已经在 `Hibiki/data` 里。
+  static const String documentsLayoutNested = 'nested';
 
-  /// [_layoutNested] 下平台 Documents 到 documents 根的相对路径段。
+  /// [documentsLayoutNested] 下平台 Documents 到 documents 根的相对路径段。
   ///
   /// 为什么是 `Hibiki/data` 而不是 `Hibiki`：`<Documents>/Hibiki` 已经是**用户可见导出
   /// 目录**（`DesktopDirectoryService.getHibikiExportDirectory` /
@@ -254,6 +258,23 @@ class AppPaths {
     final Directory platformDocuments =
         await getApplicationDocumentsDirectory();
     if (await _useLegacyFlatDocumentsRoot()) return platformDocuments;
+    return defaultLocationDocumentsRoot();
+  }
+
+  /// BUG-1188：**「默认位置」这个概念本身**的 documents 根 = `<Documents>/Hibiki/data`，
+  /// 与本机布局锚点无关。
+  ///
+  /// [_resolveDefaultDocumentsRoot] 会因老安装锚定 [documentsLayoutFlat] 而返回平台
+  /// `Documents`；而「用户在目录选择器里挑的就是默认位置吗」这个判断问的是**全新安装会落
+  /// 在哪**，两者在老安装上并不相等。迁移目标解析（`resolveDataRootMigrationTarget`）必须
+  /// 用本函数，否则老安装永远解析不出「默认位置」这个目标。
+  ///
+  /// [hibikiTestDirectory] 测试分支仍优先（与三个 `_resolve*` 的顺序铁律一致）。
+  static Future<Directory> defaultLocationDocumentsRoot() async {
+    final Directory? test = hibikiTestDirectory('app-documents');
+    if (test != null) return test;
+    final Directory platformDocuments =
+        await getApplicationDocumentsDirectory();
     return Directory(p.joinAll(<String>[
       platformDocuments.path,
       ...defaultDocumentsChildSegments,
@@ -273,7 +294,7 @@ class AppPaths {
     final bool? decided = _legacyFlatDocumentsRoot;
     if (decided != null) return decided;
     final SharedPreferences? prefs = await _prefsOrNull();
-    return prefs?.getString(documentsLayoutPrefKey) != _layoutNested;
+    return prefs?.getString(documentsLayoutPrefKey) != documentsLayoutNested;
   }
 
   /// 判定 + 固化默认布局。**唯一做探测 IO 的地方**，只由 [resolve] 在启动期调用一次；
@@ -289,8 +310,8 @@ class AppPaths {
     if (_legacyFlatDocumentsRoot != null) return;
     final SharedPreferences? prefs = await _prefsOrNull();
     final String? stored = prefs?.getString(documentsLayoutPrefKey);
-    if (stored == _layoutFlat || stored == _layoutNested) {
-      _legacyFlatDocumentsRoot = stored == _layoutFlat;
+    if (stored == documentsLayoutFlat || stored == documentsLayoutNested) {
+      _legacyFlatDocumentsRoot = stored == documentsLayoutFlat;
       return;
     }
     final bool flat = await _existingInstallHasDatabase();
@@ -298,8 +319,8 @@ class AppPaths {
     // 固化锚点（best-effort）。写失败只意味着下次启动再探一次，不改变本次结果——而下次
     // 探测的判据（hibiki.db 是否存在）此时只会更成立，不会翻转成新布局。
     try {
-      await prefs?.setString(
-          documentsLayoutPrefKey, flat ? _layoutFlat : _layoutNested);
+      await prefs?.setString(documentsLayoutPrefKey,
+          flat ? documentsLayoutFlat : documentsLayoutNested);
     } catch (e) {
       debugPrint('AppPaths: 固化 documents 布局失败（下次启动重新判定）: $e');
     }
@@ -355,7 +376,7 @@ class AppPaths {
 
   /// TODO-1226：documents 根顶层**属于 Hibiki 的目录名全集**（数据根迁移白名单）。
   ///
-  /// **老安装（[_layoutFlat]）** 的 documents 根 = 整个用户 `Documents`（共享目录，含
+  /// **老安装（[documentsLayoutFlat]）** 的 documents 根 = 整个用户 `Documents`（共享目录，含
   /// 用户自己的文件和 shell junction）。迁移引擎对共享根**只搬这份白名单里的顶层项**，
   /// 绝不整树搬移 / 整树删除用户 `Documents`。BUG-1115 之后新装走
   /// `<Documents>/Hibiki/data`（Hibiki 专属根，迁移走整树语义），白名单对它不生效——但

--- a/hibiki/lib/src/storage/data_root_migrator.dart
+++ b/hibiki/lib/src/storage/data_root_migrator.dart
@@ -38,13 +38,118 @@ import 'package:hibiki/src/sync/backup_service.dart'
 ///    根。任一步失败 → 保留旧根、清理新根半成品、抛错、**不写 data_root**（断电/跨盘安全）。
 ///  - **同盘 rename / 跨盘 copy+verify+delete**：同卷用原子 `rename`；跨卷退回逐文件
 ///    复制并按字节数校验后再删源。
+/// BUG-1188：一次迁移的**目标形态**——解析后的两个根 + 提交时如何记录位置。
+///
+/// 历史上目标只有一种表达：一个 `newDataRoot` 字符串，引擎按 `<root>/documents` +
+/// `<root>/support` 硬派生。于是「把数据收回默认位置」这件事**无法表达**——用户按
+/// BUG-1115 的文档指引选 `<Documents>\Hibiki`，得到的是 `<Documents>\Hibiki\documents`
+/// + `<Documents>\Hibiki\support`（DB 被一起搬进文档目录），与**全新安装**的
+/// `<Documents>\Hibiki\data` + 平台固定 support 根形成两种并存布局。
+///
+/// 把目标提升成数据结构之后，两种情形是**同一条代码路径的两个取值**，不是两条分支：
+///  - [DataRootMigrationTarget.customRoot]：用户挑了一个普通目录 →
+///    `<root>/documents` + `<root>/support`，提交写 `data_root`，行为逐字节不变。
+///  - [DataRootMigrationTarget.defaultLocation]：用户挑的就是默认位置 → documents 根 =
+///    `<Documents>/Hibiki/data`、support 根 = 平台固定落点（**DB 不进文档目录**），提交
+///    清掉 `data_root` 并把 `documents_layout` 锚成 [AppPaths.documentsLayoutNested]。
+class DataRootMigrationTarget {
+  const DataRootMigrationTarget._({
+    required this.pickedPath,
+    required this.documentsRoot,
+    required this.supportRoot,
+    required this.dataRootPrefValue,
+  });
+
+  /// 普通自定义数据根：两个根都落在 [dataRootPath] 下（TODO-935 的原语义）。
+  factory DataRootMigrationTarget.customRoot(String dataRootPath) {
+    final (Directory documents, Directory support) =
+        AppPaths.rootsForDataRoot(dataRootPath);
+    return DataRootMigrationTarget._(
+      pickedPath: dataRootPath,
+      documentsRoot: documents,
+      supportRoot: support,
+      dataRootPrefValue: dataRootPath,
+    );
+  }
+
+  /// 默认位置：与**全新安装**逐字节同形。[platformSupportRoot] 必须是
+  /// `getApplicationSupportDirectory()` 的真实返回值（不是当前可能被自定义根覆盖过的
+  /// support 根）——它就是新装时 DB 的落点。
+  factory DataRootMigrationTarget.defaultLocation({
+    required String pickedPath,
+    required String defaultDocumentsRoot,
+    required String platformSupportRoot,
+  }) =>
+      DataRootMigrationTarget._(
+        pickedPath: pickedPath,
+        documentsRoot: Directory(defaultDocumentsRoot),
+        supportRoot: Directory(platformSupportRoot),
+        dataRootPrefValue: null,
+      );
+
+  /// 用户在目录选择器里真正挑中的路径。校验（自我迁移 / 安装目录）按它判定，与用户看到的
+  /// 那个目录一致。
+  final String pickedPath;
+
+  /// 目标「内容/书库」根。
+  final Directory documentsRoot;
+
+  /// 目标「数据库/支持」根。等于旧 support 根时表示**本次不搬 DB**（归一化到默认位置且
+  /// DB 本来就在平台固定落点）。
+  final Directory supportRoot;
+
+  /// 提交时要写进 [AppPaths.dataRootPrefKey] 的值；null = 默认位置（清掉该 pref）。
+  final String? dataRootPrefValue;
+
+  /// 本次目标是否是「默认位置」（= 与全新安装同形）。
+  bool get isDefaultLocation => dataRootPrefValue == null;
+
+  @override
+  String toString() => 'DataRootMigrationTarget(picked: $pickedPath, '
+      'documents: ${documentsRoot.path}, support: ${supportRoot.path}, '
+      'dataRootPref: $dataRootPrefValue)';
+}
+
+/// BUG-1188：把用户挑的目录 [pickedRoot] 解析成 [DataRootMigrationTarget]。
+///
+/// 挑中**默认位置**时归一化成 [DataRootMigrationTarget.defaultLocation]。接受两种等价
+/// 写法：默认 documents 根本身（`<Documents>/Hibiki/data`），或它的 `Hibiki` 伞目录
+/// （`<Documents>/Hibiki` —— BUG-1115 的文档指引一直让老用户选的就是这个）。
+///
+/// 归一化消除的是「同一个物理位置有两种持久化表达」这个歧义：`data_root=<Documents>/
+/// Hibiki`（派生 documents/support 两个子目录、把 DB 拖进文档目录）和全新安装的默认形态
+/// 指的是同一个地方，却解析成不同布局。留着两种表达，用户按文档整理完就永远回不到新装形态。
+///
+/// [defaultDocumentsRoot] 传 [AppPaths.defaultLocationDocumentsRoot] 的结果，
+/// [platformSupportRoot] 传 `getApplicationSupportDirectory()` 的结果。
+DataRootMigrationTarget resolveDataRootMigrationTarget({
+  required String pickedRoot,
+  required String defaultDocumentsRoot,
+  required String platformSupportRoot,
+}) {
+  final String canonPicked = p.canonicalize(pickedRoot);
+  final String canonDefaultDocs = p.canonicalize(defaultDocumentsRoot);
+  // 伞目录 = 默认 documents 根的父目录。`defaultDocumentsChildSegments` 恒有 ≥2 段
+  // （`Hibiki/data`），故伞目录绝不会等于共享的平台 `Documents` 本身——否则「挑 Documents
+  // 根」会被误判成默认位置。该不变量由 `data_root_default_location_test.dart` 守卫。
+  final String canonUmbrella = p.canonicalize(p.dirname(defaultDocumentsRoot));
+  if (canonPicked == canonDefaultDocs || canonPicked == canonUmbrella) {
+    return DataRootMigrationTarget.defaultLocation(
+      pickedPath: pickedRoot,
+      defaultDocumentsRoot: defaultDocumentsRoot,
+      platformSupportRoot: platformSupportRoot,
+    );
+  }
+  return DataRootMigrationTarget.customRoot(pickedRoot);
+}
+
 class DataRootMigrationRequest {
   const DataRootMigrationRequest({
     required this.oldDocumentsRoot,
     required this.oldSupportRoot,
-    required this.newDataRoot,
+    required this.target,
     required this.closeResources,
-    required this.writeDataRootPref,
+    required this.commitLocation,
     required this.documentsTopLevelIncludeNames,
     this.onProgress,
     this.resolvedExecutablePath,
@@ -56,17 +161,18 @@ class DataRootMigrationRequest {
   /// 旧「数据库/支持」根（`hibiki.db` + 各 `local_audio_*.db`）。
   final Directory oldSupportRoot;
 
-  /// 目标 dataRoot 绝对路径；其下派生 `<dataRoot>/documents` 与 `<dataRoot>/support`
-  /// （与 [AppPaths.rootsForDataRoot] 逐字节一致）。
-  final String newDataRoot;
+  /// BUG-1188：本次迁移的目标形态（两个根 + 位置如何记录）。见 [DataRootMigrationTarget]。
+  final DataRootMigrationTarget target;
 
   /// 迁移前**必须**完成的运行时关闭：checkpoint+关 Drift DB、关词典 FFI 句柄、停音频。
   /// 引擎在搬任何文件前 `await` 它；调用方负责真正关闭全局单例（保持引擎可纯测）。
   final Future<void> Function() closeResources;
 
-  /// 迁移全部成功后，把新 dataRoot 写进 SharedPreferences（[AppPaths.dataRootPrefKey]）。
-  /// 作为回调注入而非引擎内直连 SharedPreferences，使引擎在纯 Dart 单测里可断言写入。
-  final Future<void> Function(String newDataRoot) writeDataRootPref;
+  /// 迁移全部成功后**提交新位置**：自定义根写 [AppPaths.dataRootPrefKey]；默认位置清掉
+  /// 它并把 [AppPaths.documentsLayoutPrefKey] 锚成
+  /// [AppPaths.documentsLayoutNested]。作为回调注入而非引擎内直连 SharedPreferences，使
+  /// 引擎在纯 Dart 单测里可断言提交内容。抛错 ⇒ 引擎整次回滚（文件搬回旧根 + DB 路径改回）。
+  final Future<void> Function(DataRootMigrationTarget target) commitLocation;
 
   /// 跨盘 copy 阶段的进度回调（可选）。仅在退回逐文件复制（不同卷）时触发：每复制完一个
   /// 文件回报一次 (已复制文件数, 总文件数)。同盘 `rename` 是瞬时原子操作，不产生进度。
@@ -143,11 +249,21 @@ class DataRootMigrator {
   Future<(Directory documents, Directory support)> migrate(
     DataRootMigrationRequest req,
   ) async {
-    final Directory newRoot = Directory(req.newDataRoot);
-    final (Directory newDocs, Directory newSupport) =
-        AppPaths.rootsForDataRoot(req.newDataRoot);
+    final Directory newRoot = Directory(req.target.pickedPath);
+    final Directory newDocs = req.target.documentsRoot;
+    final Directory newSupport = req.target.supportRoot;
+    // BUG-1188：归一化到默认位置时 DB 本来就躺在平台固定落点（新装的落点也是它）→ support
+    // 根根本不需要搬。这一条必须在建搬移计划**之前**判定：源=目标时既不能建搬移计划
+    // （rename 到自己），也绝不能跑迁移末尾的 `_deleteOldSupportPreservingPrefs`
+    // （那会把活着的 support 根里除 prefs 外的一切删光，包括刚"搬"过去的 hibiki.db）。
+    final bool supportUnchanged =
+        p.equals(req.oldSupportRoot.path, newSupport.path);
+    // 目标 support 根已有内容（回到默认位置时 = 平台固定落点里的 `shared_preferences.json`）
+    // → 逐顶层项**合并**搬入，不能整目录 rename（Windows 上 dst 非空必失败）。
+    final bool mergeSupport =
+        !supportUnchanged && await _hasAnyEntryAsync(newSupport);
 
-    await _validateTarget(req, newDocs, newSupport);
+    await _validateTarget(req, newDocs, newSupport, supportUnchanged);
 
     // ① 先关运行时句柄（DB/FFI/音频），否则 Windows 上 rename/删源会被占用锁住。
     await req.closeResources();
@@ -160,15 +276,28 @@ class DataRootMigrator {
     // 迁移后固定落点读不到 data_root，重启回退默认根（TODO-935/959 根因）。故对 support
     // 搬移排除源根顶层的 prefs 文件族；从自定义根迁移时源根顶层无 prefs → 排除集为空 →
     // 走原子 rename 快路径，行为不变。
-    final Set<String> supportExclude =
-        _prefsFileNamesToPreserveAt(req.oldSupportRoot);
+    final Set<String> supportExclude = supportUnchanged
+        ? const <String>{}
+        : _prefsFileNamesToPreserveAt(req.oldSupportRoot);
     final List<_MovePlan> moves = <_MovePlan>[
       // documents：共享默认根（白名单非 null）只搬 Hibiki 自有顶层项；自定义根整树搬。
       _MovePlan(req.oldDocumentsRoot, newDocs,
           includeTopLevelNames: req.documentsTopLevelIncludeNames,
           excludeTopLevelNames: const <String>{}),
-      _MovePlan(req.oldSupportRoot, newSupport,
-          includeTopLevelNames: null, excludeTopLevelNames: supportExclude),
+      // BUG-1188：support 根未变（默认位置归一化）⇒ 一个搬移计划都不建。
+      if (!supportUnchanged)
+        _MovePlan(req.oldSupportRoot, newSupport,
+            includeTopLevelNames: null,
+            excludeTopLevelNames: supportExclude,
+            mergeIntoDestination: mergeSupport),
+    ];
+    // BUG-1188：回滚时可以**整目录清掉**的「本次迁移自建子树」。support 根在两种情况下
+    // 绝不能进这个列表：① 未变（它就是活着的平台固定落点，里面还躺着刚 rebase 完的
+    // hibiki.db）；② 合并搬入（里面有先于本次迁移就存在的 `shared_preferences.json`）。
+    // 整目录删掉等于抹掉用户的全部设置与 data_root 配置本身。
+    final List<Directory> createdSubtrees = <Directory>[
+      newDocs,
+      if (!supportUnchanged && !mergeSupport) newSupport,
     ];
     final List<_MovePlan> done = <_MovePlan>[];
     // TODO-1324（数据完整性铁律）：跨盘复制阶段**刻意保留的源**，只有在 DB rebase + pref
@@ -189,7 +318,7 @@ class DataRootMigrator {
       await _rollbackMoves(done);
       // TODO-1182：回滚只清理迁移自己创建的 documents/support 子树，**绝不**删用户选定的
       // 整个 newRoot（它可能是安装目录或含用户其它文件）；newRoot 本体一律保留。
-      await _cleanupCreatedSubtrees(newDocs, newSupport);
+      await _cleanupCreatedSubtrees(createdSubtrees);
       if (_isFileInUseError(e)) {
         throw DataRootMigrationException(
             '有文件被占用，无法迁移数据（请关闭正在使用书库/音频的功能后重试），已回滚到旧根',
@@ -210,16 +339,17 @@ class DataRootMigrator {
     } catch (e) {
       // DB 改写失败：把已搬目录搬回旧根、只清迁移自建子树（不删用户选定的 newRoot 本体）。
       await _rollbackMoves(done);
-      await _cleanupCreatedSubtrees(newDocs, newSupport);
+      await _cleanupCreatedSubtrees(createdSubtrees);
       throw DataRootMigrationException('改写数据库内绝对路径失败，已回滚到旧根', cause: e);
     }
 
-    // ④ 全成功：先写 data_root pref；只有 pref 写成功后才删除旧根。若 pref 写失败，
-    // 先把新 DB 路径 rebase 回旧根，再把目录搬回旧位置，避免下次启动仍读旧 pref 但
-    // 旧 DB 里已指向新根。pref 写成功后删旧根时，oldSupportRoot 若保留了 prefs
-    // 文件（默认根迁移），只删非 prefs 残留、保住 prefs 本体（那正是持久化 data_root 的地方）。
+    // ④ 全成功：先提交新位置（自定义根写 data_root / 默认位置清它并锚 nested 布局）；只有
+    // 提交成功后才删除旧根。若提交失败，先把新 DB 路径 rebase 回旧根，再把目录搬回旧位置，
+    // 避免下次启动仍按旧配置解析、而旧 DB 里已指向新根。提交成功后删旧根时，oldSupportRoot
+    // 若保留了 prefs 文件（默认根迁移），只删非 prefs 残留、保住 prefs 本体（那正是持久化
+    // data_root / documents_layout 的地方）。
     try {
-      await req.writeDataRootPref(req.newDataRoot);
+      await req.commitLocation(req.target);
     } catch (e) {
       try {
         await _rebaseDatabasePaths(
@@ -236,7 +366,7 @@ class DataRootMigrator {
         );
       }
       await _rollbackMoves(done);
-      await _cleanupCreatedSubtrees(newDocs, newSupport);
+      await _cleanupCreatedSubtrees(createdSubtrees);
       throw DataRootMigrationException('写入新数据根设置失败，已回滚到旧根', cause: e);
     }
 
@@ -256,7 +386,12 @@ class DataRootMigrator {
     if (req.documentsTopLevelIncludeNames == null) {
       await _deleteOldRootAfterSwitch(req.oldDocumentsRoot);
     }
-    await _deleteOldSupportPreservingPrefs(req.oldSupportRoot, supportExclude);
+    // BUG-1188：support 根未变时**绝不**跑这一步——它会把源根里除 prefs 外的一切删光，
+    // 而此时源根就是目标根（刚 rebase 好的 hibiki.db 正躺在里面）。
+    if (!supportUnchanged) {
+      await _deleteOldSupportPreservingPrefs(
+          req.oldSupportRoot, supportExclude);
+    }
 
     return (newDocs, newSupport);
   }
@@ -265,8 +400,9 @@ class DataRootMigrator {
     DataRootMigrationRequest req,
     Directory newDocs,
     Directory newSupport,
+    bool supportUnchanged,
   ) async {
-    final String canonNew = p.canonicalize(req.newDataRoot);
+    final String canonNew = p.canonicalize(req.target.pickedPath);
     // BUG-1115：共享 documents 根（白名单选择性搬移）下的**非白名单**子目录是安全目标
     // ——搬移只动白名单顶层项，新根在整个过程里是旁观者。这让老安装能把散落在用户
     // `Documents` 根下的 16 个 Hibiki 目录一键收进 `Documents\Hibiki`。白名单为 null
@@ -275,7 +411,7 @@ class DataRootMigrator {
     final bool nestedInSharedDocuments = whitelist != null &&
         AppPaths.isSafeNestedTargetInSharedDocuments(
           sharedDocumentsRoot: req.oldDocumentsRoot.path,
-          newDataRoot: req.newDataRoot,
+          newDataRoot: req.target.pickedPath,
           ownedEntries: whitelist,
         );
     if (canonNew == p.canonicalize(req.oldDocumentsRoot.path) ||
@@ -295,11 +431,24 @@ class DataRootMigrator {
             '新数据根不能是应用安装目录（含正在运行的程序），请另选一个空目录');
       }
     }
-    // 目标 dataRoot 若已存在且其 documents/support 子树非空 → 拒绝（不覆盖已有数据）。
+    // 目标的 documents/support 根若已存在且非空 → 拒绝（不覆盖已有数据）。
     // TODO-1324：用**异步** list 探测，绝不在主 isolate 上同步递归列目录——用户挑的目标可能
     // 含庞大预存子树，同步 listSync(recursive) 会卡死 UI 线程（黑屏/转圈）。
-    if ((newDocs.existsSync() && await _hasAnyFileAsync(newDocs)) ||
-        (newSupport.existsSync() && await _hasAnyFileAsync(newSupport))) {
+    //
+    // BUG-1188 两处收窄：
+    //  - support 根未变时**不检查**（它当然非空——里面正是本次要保留在原地的 DB）。
+    //  - 检查目标 support 根时**忽略顶层 prefs 文件**：归一化回默认位置时目标就是平台固定
+    //    落点，`shared_preferences.json` 一直住在那儿、且刻意不参与搬移，它的存在不代表
+    //    「那里已有一份别的数据」。除 prefs 外的任何残留（比如一个陈旧的 hibiki.db）仍照拒。
+    if (newDocs.existsSync() && await _hasAnyFileAsync(newDocs)) {
+      throw const DataRootMigrationException('目标数据根已存在数据，拒绝覆盖');
+    }
+    if (!supportUnchanged &&
+        newSupport.existsSync() &&
+        await _hasAnyFileAsync(
+          newSupport,
+          ignoreTopLevelNames: _prefsFileNamesToPreserveAt(newSupport),
+        )) {
       throw const DataRootMigrationException('目标数据根已存在数据，拒绝覆盖');
     }
   }
@@ -370,6 +519,7 @@ class DataRootMigrator {
         try {
           // 同盘 rename：源随之移走（原子、near-instant），无需延迟删源。
           await _withLockRetry(() => entity.rename(target));
+          plan.movedTopLevelNames.add(name);
           continue;
         } on FileSystemException catch (e) {
           if (!_shouldCopyAfterRenameFailure(e)) rethrow;
@@ -513,16 +663,24 @@ class DataRootMigrator {
     }
   }
 
-  /// 选择性搬移的回滚：把 [m.dst]（新根 support，含已搬的非 prefs 数据）顶层项逐个搬回
-  /// [m.src]（旧固定落点，prefs 仍在原地），同卷 rename / 跨卷 copy+delete；搬完删空的
-  /// dst 目录。尽力而为——回滚是异常清理，任何一步失败只记日志不再抛。
+  /// 选择性搬移的回滚：把**本次真正搬进去**的顶层项（[_MovePlan.movedTopLevelNames]）
+  /// 逐个从 [m.dst] 搬回 [m.src]，同卷 rename / 跨卷 copy+delete；搬完删掉本次自建的 dst
+  /// 目录。尽力而为——回滚是异常清理，任何一步失败只记日志不再抛。
+  ///
+  /// BUG-1188：判据从「列 dst 的全部顶层项」改成「本次搬进去的那些项」，并在
+  /// [_MovePlan.mergeIntoDestination] 时保留 dst 本体。旧实现假设 dst 是迁移自建的空目录，
+  /// 合并搬入（归一化回默认位置，dst = 平台固定落点）下会把用户的 `shared_preferences.json`
+  /// 一起搬进即将被删的旧根、再把 dst 整个删掉 = 抹掉全部设置。
   Future<void> _rollbackSelective(_MovePlan m) async {
     try {
       if (!await m.dst.exists()) return;
       await m.src.create(recursive: true);
-      for (final FileSystemEntity entity
-          in m.dst.listSync(recursive: false, followLinks: false)) {
-        final String name = p.basename(entity.path);
+      for (final String name in m.movedTopLevelNames) {
+        final String from = p.join(m.dst.path, name);
+        final FileSystemEntity entity = await FileSystemEntity.isDirectory(from)
+            ? Directory(from)
+            : File(from);
+        if (!await entity.exists()) continue;
         final String back = p.join(m.src.path, name);
         try {
           await entity.rename(back);
@@ -537,7 +695,7 @@ class DataRootMigrator {
           }
         }
       }
-      await _deleteIfPresent(m.dst);
+      if (!m.mergeIntoDestination) await _deleteIfPresent(m.dst);
     } catch (e) {
       debugPrint('DataRootMigrator: 选择性回滚失败 ${m.dst.path}: $e');
     }
@@ -551,16 +709,17 @@ class DataRootMigrator {
     }
   }
 
-  /// TODO-1182：回滚时只删迁移**自己创建**的 `<newRoot>/documents` 与 `<newRoot>/support`
-  /// 子树，**绝不**触碰用户选定的 [newRoot] 本体（它可能是安装目录或含用户其它文件）。
-  /// [_validateTarget] 已保证迁移前这两个子树为空或不存在，故此处清掉的必然是本次迁移搬进
-  /// 去的数据（正常路径下 `_rollbackMoves` 已把它们搬回旧根、这里是幂等兜底）。尽力而为：
-  /// 任一子树删不掉只记日志不抛（数据已回滚在旧根，用户根保留完整）。
+  /// TODO-1182：回滚时只删迁移**自己创建**的目标子树，**绝不**触碰用户选定的根本体（它可能
+  /// 是安装目录或含用户其它文件）。[_validateTarget] 已保证迁移前这些子树为空或不存在，故此处
+  /// 清掉的必然是本次迁移搬进去的数据（正常路径下 `_rollbackMoves` 已把它们搬回旧根、这里是
+  /// 幂等兜底）。尽力而为：任一子树删不掉只记日志不抛（数据已回滚在旧根，用户根保留完整）。
+  ///
+  /// BUG-1188：[subtrees] 由 `migrate` 计算——support 根未变 / 合并搬入时它**不在列表里**
+  /// （那是活着的平台固定落点，删掉等于抹掉用户全部设置）。
   static Future<void> _cleanupCreatedSubtrees(
-    Directory newDocs,
-    Directory newSupport,
+    List<Directory> subtrees,
   ) async {
-    for (final Directory sub in <Directory>[newDocs, newSupport]) {
+    for (final Directory sub in subtrees) {
       try {
         await _deleteIfPresent(sub);
       } catch (e) {
@@ -715,11 +874,31 @@ class DataRootMigrator {
   }
 
   /// TODO-1324：**异步** list（非 listSync）——绝不在主 isolate 上同步递归列大目录（冻结 UI）。
-  static Future<bool> _hasAnyFileAsync(Directory dir) async {
+  ///
+  /// BUG-1188：[ignoreTopLevelNames] 里的**顶层**项整棵跳过（用于忽略目标 support 根里
+  /// 刻意不参与搬移的 `shared_preferences.json` 族）。只忽略顶层同名项，子目录里的同名文件
+  /// 照常算数据。
+  static Future<bool> _hasAnyFileAsync(
+    Directory dir, {
+    Set<String> ignoreTopLevelNames = const <String>{},
+  }) async {
     // followLinks: false —— 同 [_countFilesAsync]：不追 junction/symlink（TODO-1226）。
     await for (final FileSystemEntity e
-        in dir.list(recursive: true, followLinks: false)) {
+        in dir.list(recursive: false, followLinks: false)) {
+      if (ignoreTopLevelNames.contains(p.basename(e.path))) continue;
       if (e is File) return true;
+      if (e is Directory && await _hasAnyFileAsync(e)) return true;
+    }
+    return false;
+  }
+
+  /// 目录是否**存在且含任何顶层项**（文件/目录/链接都算）。BUG-1188 用它判定目标 support
+  /// 根需不需要走「合并搬入」——目标已有内容时整目录 rename 在 Windows 上必失败。
+  static Future<bool> _hasAnyEntryAsync(Directory dir) async {
+    if (!await dir.exists()) return false;
+    await for (final FileSystemEntity _
+        in dir.list(recursive: false, followLinks: false)) {
+      return true;
     }
     return false;
   }
@@ -1025,9 +1204,21 @@ class _MovePlan {
     this.dst, {
     required this.includeTopLevelNames,
     required this.excludeTopLevelNames,
+    this.mergeIntoDestination = false,
   });
   final Directory src;
   final Directory dst;
+
+  /// BUG-1188：目标目录**已有内容**（归一化回默认位置时 = 平台固定落点里的 prefs 文件）。
+  /// 为真 ⇒ 强制走逐顶层项搬移（整目录 rename 到非空 dst 在 Windows 上必失败），且回滚
+  /// **绝不删除 dst 本体**——它先于本次迁移就存在，里面躺着用户的 prefs。
+  final bool mergeIntoDestination;
+
+  /// 本 plan 实际以 rename 搬进 dst 的顶层项基名。回滚只搬回这些项——merge 模式下 dst 里
+  /// 还有先于迁移就存在的项（prefs），照 dst 列目录回滚会把它们一并搬进 src（= 把用户设置
+  /// 挪进一个即将被删的目录）。跨盘 copy 分支不记：那条路径源未删、回滚整体跳过（见
+  /// [deferredCopy]）。
+  final List<String> movedTopLevelNames = <String>[];
 
   /// TODO-1226：只允许搬移的顶层项基名白名单；null = 全部可搬（Hibiki 专属根整树
   /// 语义）。非 null（共享用户 `Documents`）⇒ 白名单外的顶层项（用户文件、shell
@@ -1044,7 +1235,9 @@ class _MovePlan {
   bool deferredCopy = false;
 
   bool get isSelective =>
-      includeTopLevelNames != null || excludeTopLevelNames.isNotEmpty;
+      includeTopLevelNames != null ||
+      excludeTopLevelNames.isNotEmpty ||
+      mergeIntoDestination;
 
   /// 顶层项 [name] 是否应被搬移：命中白名单（或无白名单）且不在排除集。
   bool shouldMoveTopLevel(String name) =>

--- a/hibiki/lib/src/sync/sync_settings_schema/data_root.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/data_root.part.dart
@@ -18,7 +18,7 @@ enum DataRootTargetRejection {
   containsExecutable,
 }
 
-/// 纯函数：在不触碰文件系统搬移的前提下判断 [newDataRoot] 是否可作为迁移目标。
+/// 纯函数：在不触碰文件系统搬移的前提下判断 [target] 是否可作为迁移目标。
 /// [existsAndHasFiles] 注入目录是否存在且含文件的判定（生产传真实 FS 探测，测试传
 /// 桩），保持本函数无 IO 依赖、可纯测。
 ///
@@ -27,20 +27,20 @@ enum DataRootTargetRejection {
 /// 非白名单子目录（典型：`Documents\Hibiki`，即用户把散落的 16 个目录收进自己的子目录）
 /// 是安全的，不再按 [DataRootTargetRejection.insideCurrentRoot] 一刀切拒绝。
 DataRootTargetRejection? validateDataRootTarget({
-  required String newDataRoot,
+  required DataRootMigrationTarget target,
   required String oldDocumentsRoot,
   required String oldSupportRoot,
   required bool Function(String absolutePath) existsAndHasFiles,
   String? executablePath,
   bool sharedDocumentsRoot = false,
 }) {
-  final String canonNew = p.canonicalize(newDataRoot);
+  final String canonNew = p.canonicalize(target.pickedPath);
   final String canonDocs = p.canonicalize(oldDocumentsRoot);
   final String canonSupport = p.canonicalize(oldSupportRoot);
   final bool nestedInSharedDocuments = sharedDocumentsRoot &&
       AppPaths.isSafeNestedTargetInSharedDocuments(
         sharedDocumentsRoot: oldDocumentsRoot,
-        newDataRoot: newDataRoot,
+        newDataRoot: target.pickedPath,
       );
   if (canonNew == canonDocs ||
       canonNew == canonSupport ||
@@ -55,9 +55,14 @@ DataRootTargetRejection? validateDataRootTarget({
       return DataRootTargetRejection.containsExecutable;
     }
   }
-  final (Directory docs, Directory support) =
-      AppPaths.rootsForDataRoot(newDataRoot);
-  if (existsAndHasFiles(docs.path) || existsAndHasFiles(support.path)) {
+  if (existsAndHasFiles(target.documentsRoot.path)) {
+    return DataRootTargetRejection.targetNotEmpty;
+  }
+  // BUG-1188：默认位置的 support 根就是平台固定落点——里面必然躺着
+  // `shared_preferences.json`（它刻意不参与搬移），甚至就是当前 support 根本身。这里这个
+  // 粗粒度预检不认识 prefs 文件族，一检必误报，故交给引擎的 prefs-aware 校验
+  // （`DataRootMigrator._validateTarget`，会忽略顶层 prefs、但仍拒绝任何别的残留）。
+  if (!target.isDefaultLocation && existsAndHasFiles(target.supportRoot.path)) {
     return DataRootTargetRejection.targetNotEmpty;
   }
   return null;
@@ -161,11 +166,36 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
     } catch (_) {
       sharedDocumentsRoot = true;
     }
+    // BUG-1188：把用户挑的目录解析成迁移目标。挑中默认位置（`<Documents>\Hibiki` 或
+    // `<Documents>\Hibiki\data`）时归一化成「与全新安装同形」：documents 根落
+    // `<Documents>\Hibiki\data`、DB 留在平台固定落点。旧实现无条件按 `<picked>/documents`
+    // + `<picked>/support` 派生，用户照文档指引整理完就得到第三种布局（DB 还被拖进文档目录）。
+    final DataRootMigrationTarget target;
+    try {
+      final Directory defaultDocs =
+          await AppPaths.defaultLocationDocumentsRoot();
+      final Directory platformSupport = await getApplicationSupportDirectory();
+      target = resolveDataRootMigrationTarget(
+        pickedRoot: picked,
+        defaultDocumentsRoot: defaultDocs.path,
+        platformSupportRoot: platformSupport.path,
+      );
+    } catch (e, stack) {
+      ErrorLogService.instance
+          .logFatal('DataRootMigration.resolveTarget', e, stack);
+      if (mounted) {
+        _showSnackBar(
+          context,
+          t.data_storage_migrate_failed(message: e.toString()),
+        );
+      }
+      return;
+    }
     if (!mounted) return;
 
     // 触发前纯校验：自我迁移 / 目标非空，直接报错，不进确认弹窗。
     final DataRootTargetRejection? rejection = validateDataRootTarget(
-      newDataRoot: picked,
+      target: target,
       oldDocumentsRoot: oldDocs,
       oldSupportRoot: oldSupport,
       existsAndHasFiles: _dirExistsAndHasFiles,
@@ -179,12 +209,16 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
       return;
     }
 
-    final bool confirmed = await _confirmMigrate();
+    final bool confirmed = await _confirmMigrate(target);
     if (!confirmed || !mounted) return;
 
+    // 默认位置不需要 macOS 安全域书签（平台固定落点 + 应用自己的 Documents 容器，沙箱本就
+    // 可访问）；提交时反而要把可能存在的旧书签清掉。
     final String? macOSBookmark;
     try {
-      macOSBookmark = await MacOSDataRootAccess.createBookmarkForPath(picked);
+      macOSBookmark = target.isDefaultLocation
+          ? null
+          : await MacOSDataRootAccess.createBookmarkForPath(picked);
     } catch (e, stack) {
       ErrorLogService.instance
           .logFatal('DataRootMigration.createBookmark', e, stack);
@@ -207,34 +241,15 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
       final DataRootMigrationRequest req = DataRootMigrationRequest(
         oldDocumentsRoot: Directory(oldDocs),
         oldSupportRoot: Directory(oldSupport),
-        newDataRoot: picked,
+        target: target,
         closeResources: () => _closeRuntimeResources(appModel),
-        writeDataRootPref: (String newRoot) async {
+        commitLocation: (DataRootMigrationTarget t) async {
           final SharedPreferences sp = await SharedPreferences.getInstance();
-          final String? previousBookmark =
-              sp.getString(MacOSDataRootAccess.dataRootBookmarkPrefKey);
-          final bool bookmarkStored =
-              await MacOSDataRootAccess.storeBookmark(sp, macOSBookmark);
-          if (!bookmarkStored) {
-            throw const DataRootMigrationException('写入 macOS 数据根授权失败');
+          if (t.isDefaultLocation) {
+            await _commitDefaultLocation(sp);
+            return;
           }
-          try {
-            final bool rootStored =
-                await sp.setString(AppPaths.dataRootPrefKey, newRoot);
-            if (!rootStored) {
-              throw const DataRootMigrationException('写入新数据根设置失败');
-            }
-          } catch (e) {
-            final bool bookmarkRestored =
-                await MacOSDataRootAccess.restoreBookmark(sp, previousBookmark);
-            if (!bookmarkRestored) {
-              throw DataRootMigrationException(
-                '写入新数据根设置失败，且恢复旧授权失败',
-                cause: e,
-              );
-            }
-            throw DataRootMigrationException('写入新数据根设置失败', cause: e);
-          }
+          await _commitCustomRoot(sp, t.dataRootPrefValue!, macOSBookmark);
         },
         // 跨盘复制进度回灌到遮罩进度条（同盘 rename 不触发，遮罩显示不确定进度）。
         onProgress: (int copied, int total) =>
@@ -272,6 +287,92 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
       );
     } finally {
       if (mounted) setState(() => _migrating = false);
+    }
+  }
+
+  /// 自定义数据根的提交：存 macOS 安全域书签 + 写 `data_root`。任一步失败复原旧书签并抛错
+  /// （引擎据此整次回滚）。行为与 BUG-1188 之前逐字节一致。
+  static Future<void> _commitCustomRoot(
+    SharedPreferences sp,
+    String newRoot,
+    String? macOSBookmark,
+  ) async {
+    final String? previousBookmark =
+        sp.getString(MacOSDataRootAccess.dataRootBookmarkPrefKey);
+    final bool bookmarkStored =
+        await MacOSDataRootAccess.storeBookmark(sp, macOSBookmark);
+    if (!bookmarkStored) {
+      throw const DataRootMigrationException('写入 macOS 数据根授权失败');
+    }
+    try {
+      final bool rootStored =
+          await sp.setString(AppPaths.dataRootPrefKey, newRoot);
+      if (!rootStored) {
+        throw const DataRootMigrationException('写入新数据根设置失败');
+      }
+    } catch (e) {
+      final bool bookmarkRestored =
+          await MacOSDataRootAccess.restoreBookmark(sp, previousBookmark);
+      if (!bookmarkRestored) {
+        throw DataRootMigrationException(
+          '写入新数据根设置失败，且恢复旧授权失败',
+          cause: e,
+        );
+      }
+      throw DataRootMigrationException('写入新数据根设置失败', cause: e);
+    }
+  }
+
+  /// BUG-1188：归一化到**默认位置**的提交：把 `documents_layout` 锚成 nested、清掉
+  /// `data_root` 与 macOS 书签。
+  ///
+  /// 两个键必须**同时**生效，否则下次启动必然解析到错误的根：
+  ///  - 只锚 nested、`data_root` 还在 ⇒ 仍走自定义根分支，指向已经搬空的旧根。
+  ///  - 只清 `data_root`、锚点还是 `flat` ⇒ documents 根解析回共享 `Documents`，而数据
+  ///    已经在 `Hibiki/data` 里 = 书库/有声书/词典资源在 UI 上集体消失。
+  /// 故任一步失败就把已改的键全部复原并抛错，由引擎回滚整次迁移。
+  static Future<void> _commitDefaultLocation(SharedPreferences sp) async {
+    final String? previousLayout =
+        sp.getString(AppPaths.documentsLayoutPrefKey);
+    final String? previousRoot = sp.getString(AppPaths.dataRootPrefKey);
+    final String? previousBookmark =
+        sp.getString(MacOSDataRootAccess.dataRootBookmarkPrefKey);
+    if (!await sp.setString(
+        AppPaths.documentsLayoutPrefKey, AppPaths.documentsLayoutNested)) {
+      throw const DataRootMigrationException('写入数据位置布局设置失败');
+    }
+    try {
+      if (!await sp.remove(AppPaths.dataRootPrefKey)) {
+        throw const DataRootMigrationException('清除自定义数据根设置失败');
+      }
+      if (!await MacOSDataRootAccess.restoreBookmark(sp, null)) {
+        throw const DataRootMigrationException('清除 macOS 数据根授权失败');
+      }
+    } catch (e) {
+      await _restorePrefString(
+          sp, AppPaths.documentsLayoutPrefKey, previousLayout);
+      await _restorePrefString(sp, AppPaths.dataRootPrefKey, previousRoot);
+      await MacOSDataRootAccess.restoreBookmark(sp, previousBookmark);
+      if (e is DataRootMigrationException) rethrow;
+      throw DataRootMigrationException('写入默认数据位置设置失败', cause: e);
+    }
+  }
+
+  /// 把一个字符串 pref 复原到 [previous]（null 表示原本就没有这个键 → 删掉）。
+  /// 提交失败回退用，尽力而为：复原本身失败只记日志（外层已在抛错回滚整次迁移）。
+  static Future<void> _restorePrefString(
+    SharedPreferences sp,
+    String key,
+    String? previous,
+  ) async {
+    try {
+      if (previous == null) {
+        await sp.remove(key);
+      } else {
+        await sp.setString(key, previous);
+      }
+    } catch (e) {
+      debugPrint('DataRoot migrate: 复原 pref $key 失败: $e');
     }
   }
 
@@ -399,7 +500,12 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
         appModel.failDataRootMigration(message);
       });
 
-  Future<bool> _confirmMigrate() async {
+  /// BUG-1188：确认弹窗里把**解析后的**两个根原样列出来。挑中默认位置时目标会被归一化
+  /// （`<Documents>\Hibiki` → 内容落 `<Documents>\Hibiki\data`、DB 留在平台固定落点），
+  /// 用户必须在按下确认前就看到数据到底会去哪，而不是重启后自己找。
+  Future<bool> _confirmMigrate(DataRootMigrationTarget target) async {
+    final String body = '${t.data_storage_change_confirm_body}\n\n'
+        '${target.documentsRoot.path}\n${target.supportRoot.path}';
     final bool? confirmed = await showAppDialog<bool>(
       context: context,
       builder: (BuildContext ctx) {
@@ -426,7 +532,7 @@ class _DataRootWidgetState extends State<_DataRootWidget> {
               tokens.spacing.card,
               tokens.spacing.card,
             ),
-            body: Text(t.data_storage_change_confirm_body),
+            body: Text(body),
             footer: Wrap(
               alignment: WrapAlignment.end,
               spacing: tokens.spacing.gap,

--- a/hibiki/test/settings/data_root_settings_test.dart
+++ b/hibiki/test/settings/data_root_settings_test.dart
@@ -8,6 +8,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/storage/data_root_migrator.dart';
 import 'package:hibiki/src/sync/sync_settings_schema.dart';
 import 'package:path/path.dart' as p;
 
@@ -20,7 +21,7 @@ void main() {
 
     test('a fresh sibling directory is accepted', () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: '/data/new-root',
+        target: DataRootMigrationTarget.customRoot('/data/new-root'),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -30,7 +31,7 @@ void main() {
 
     test('target equal to the documents root is rejected (self-migrate)', () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: oldDocs,
+        target: DataRootMigrationTarget.customRoot(oldDocs),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -40,7 +41,8 @@ void main() {
 
     test('target inside the support root is rejected', () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: p.join(oldSupport, 'nested'),
+        target:
+            DataRootMigrationTarget.customRoot(p.join(oldSupport, 'nested')),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -53,7 +55,7 @@ void main() {
       // The probe reports the derived <newRoot>/documents (or /support) as
       // containing files -> must refuse to overwrite existing data.
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: '/data/occupied',
+        target: DataRootMigrationTarget.customRoot('/data/occupied'),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: (String path) => path.contains('occupied'),
@@ -65,7 +67,7 @@ void main() {
         () {
       // TODO-1182：exe 落在 newRoot 里 → newRoot 是安装目录 → 拒绝（否则失败回滚会删安装目录）。
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: '/apps/Hibiki',
+        target: DataRootMigrationTarget.customRoot('/apps/Hibiki'),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -76,7 +78,7 @@ void main() {
 
     test('target is an ancestor of the exe dir is rejected', () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: '/apps',
+        target: DataRootMigrationTarget.customRoot('/apps'),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -88,7 +90,7 @@ void main() {
     test('exe outside the target dir does not trigger install-dir rejection',
         () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: '/data/new-root',
+        target: DataRootMigrationTarget.customRoot('/data/new-root'),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -100,7 +102,7 @@ void main() {
     test('null executablePath keeps pre-1182 behavior (no install-dir check)',
         () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: '/data/new-root',
+        target: DataRootMigrationTarget.customRoot('/data/new-root'),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -116,7 +118,7 @@ void main() {
         'BUG-1115: nested non-whitelisted dir under the SHARED documents root '
         'is accepted', () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: p.join(oldDocs, 'Hibiki'),
+        target: DataRootMigrationTarget.customRoot(p.join(oldDocs, 'Hibiki')),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -129,7 +131,7 @@ void main() {
         'BUG-1115: the same nested target is still rejected for a DEDICATED '
         'root (whole-tree move would swallow it)', () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: p.join(oldDocs, 'Hibiki'),
+        target: DataRootMigrationTarget.customRoot(p.join(oldDocs, 'Hibiki')),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -141,7 +143,8 @@ void main() {
     test('BUG-1115: a whitelisted top-level dir is never an accepted target',
         () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: p.join(oldDocs, 'audiobooks'),
+        target:
+            DataRootMigrationTarget.customRoot(p.join(oldDocs, 'audiobooks')),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,
@@ -153,7 +156,7 @@ void main() {
     test('BUG-1115: the shared root itself is still a self-migrate rejection',
         () {
       final DataRootTargetRejection? r = validateDataRootTarget(
-        newDataRoot: oldDocs,
+        target: DataRootMigrationTarget.customRoot(oldDocs),
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
         existsAndHasFiles: alwaysEmpty,

--- a/hibiki/test/storage/data_root_default_location_migration_test.dart
+++ b/hibiki/test/storage/data_root_default_location_migration_test.dart
@@ -1,0 +1,438 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/storage/app_paths.dart';
+import 'package:hibiki/src/storage/data_root_migrator.dart';
+
+/// BUG-1188：「选目录」迁移到不了新装形态 —— 目标解析归一化 + 端到端布局守卫。
+///
+/// 修前实测（真 `DataRootMigrator.migrate()`）：老安装照 BUG-1115 文档指引选
+/// `<Documents>\Hibiki`，产出的是 `Hibiki\documents` + `Hibiki\support`，并且 `hibiki.db`
+/// 被一起搬进文档目录；而**全新安装**是 `<Documents>\Hibiki\data` + 平台固定 support 根。
+/// 同一个物理位置有两种持久化表达、两种磁盘布局，用户整理完永远回不到新装形态。
+///
+/// 修后：挑中默认位置（`<Documents>\Hibiki` 或 `<Documents>\Hibiki\data`）时目标被归一化
+/// 成「与全新安装同形」——内容落 `<Documents>\Hibiki\data`、DB 留在平台固定落点、提交清掉
+/// `data_root` 并把 `documents_layout` 锚成 nested。挑别的目录时行为逐字节不变。
+void main() {
+  late Directory tmp;
+  late Directory platformDocuments;
+  late Directory platformSupport;
+  late String defaultDocsRoot;
+
+  setUp(() {
+    tmp = Directory.systemTemp.createTempSync('hibiki_default_loc_');
+    platformDocuments = Directory(p.join(tmp.path, 'Documents'))
+      ..createSync(recursive: true);
+    platformSupport =
+        Directory(p.join(tmp.path, 'AppData', 'Roaming', 'app.hibiki.reader'))
+          ..createSync(recursive: true);
+    defaultDocsRoot = p.joinAll(<String>[
+      platformDocuments.path,
+      ...AppPaths.defaultDocumentsChildSegments,
+    ]);
+  });
+
+  tearDown(() {
+    if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+  });
+
+  DataRootMigrationTarget resolve(String picked) =>
+      resolveDataRootMigrationTarget(
+        pickedRoot: picked,
+        defaultDocumentsRoot: defaultDocsRoot,
+        platformSupportRoot: platformSupport.path,
+      );
+
+  /// 在 [documentsRoot] 下铺白名单内容 + 用户自己的文件，在 [supportRoot] 下铺
+  /// `hibiki.db`（含指向 documents 根的绝对路径行）与 `shared_preferences.json`。
+  Future<void> seed({
+    required Directory documentsRoot,
+    required Directory supportRoot,
+    bool withPrefsFile = true,
+  }) async {
+    File(p.join(documentsRoot.path, 'hoshi_books', 'Bk', 'a.html'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync('hello');
+    File(p.join(documentsRoot.path, 'audiobooks', 'Bk', 'a.mp3'))
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(<int>[1, 2, 3]);
+    File(p.join(documentsRoot.path, 'video_covers', 'v.jpg'))
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(<int>[4, 5]);
+    if (withPrefsFile) {
+      File(p.join(supportRoot.path, 'shared_preferences.json'))
+        ..createSync(recursive: true)
+        ..writeAsStringSync('{"flutter.documents_layout":"flat"}');
+    }
+    File(p.join(supportRoot.path, 'local_audio_1.db'))
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(<int>[9]);
+
+    final HibikiDatabase db = HibikiDatabase(supportRoot.path);
+    try {
+      await db.insertEpubBook(EpubBooksCompanion.insert(
+        bookKey: 'Bk',
+        title: 'Bk',
+        epubPath: p.join(documentsRoot.path, 'hoshi_books', 'Bk', 'o.epub'),
+        extractDir: p.join(documentsRoot.path, 'hoshi_books', 'Bk'),
+        chapterCount: 1,
+        chaptersJson: '["c"]',
+        importedAt: 0,
+        coverPath:
+            Value(p.join(documentsRoot.path, 'hoshi_books', 'Bk', 'c.jpg')),
+      ));
+      await db.upsertVideoBook(VideoBooksCompanion.insert(
+        bookUid: 'video/Bk',
+        title: 'Video Bk',
+        videoPath: p.join('E:', 'anime', 'Bk.mkv'),
+        coverPath: Value(p.join(documentsRoot.path, 'video_covers', 'v.jpg')),
+      ));
+      await db.setPref(
+        'local_audio_dbs',
+        jsonEncode(<Map<String, dynamic>>[
+          <String, dynamic>{
+            'path': p.join(supportRoot.path, 'local_audio_1.db'),
+            'displayName': 'L1',
+            'enabled': true,
+          }
+        ]),
+      );
+    } finally {
+      await db.close();
+    }
+  }
+
+  Future<Map<String, String?>> dbSnapshot(String supportDir) async {
+    final HibikiDatabase db = HibikiDatabase(supportDir);
+    try {
+      final EpubBookRow b = (await db.getAllEpubBooks()).single;
+      final VideoBookRow v = (await db.allVideoBooks()).single;
+      final Map<String, String> prefs = await db.getAllPrefs();
+      return <String, String?>{
+        'epubPath': b.epubPath,
+        'extractDir': b.extractDir,
+        'coverPath': b.coverPath,
+        'videoPath': v.videoPath,
+        'videoCover': v.coverPath,
+        'localAudioDbs': prefs['local_audio_dbs'],
+      };
+    } finally {
+      await db.close();
+    }
+  }
+
+  group('BUG-1188 ①：目标解析归一化', () {
+    test('挑 Hibiki 伞目录 → 默认位置（内容落 Hibiki/data、DB 留平台固定落点）', () {
+      final DataRootMigrationTarget t =
+          resolve(p.join(platformDocuments.path, 'Hibiki'));
+      expect(t.isDefaultLocation, isTrue);
+      expect(t.documentsRoot.path, equals(defaultDocsRoot));
+      expect(t.supportRoot.path, equals(platformSupport.path));
+      expect(t.dataRootPrefValue, isNull,
+          reason: '默认位置不写 data_root——写了就又变成"自定义根"这种第二种表达');
+    });
+
+    test('挑默认 documents 根本身 → 同一个默认位置目标', () {
+      final DataRootMigrationTarget t = resolve(defaultDocsRoot);
+      expect(t.isDefaultLocation, isTrue);
+      expect(t.documentsRoot.path, equals(defaultDocsRoot));
+      expect(t.supportRoot.path, equals(platformSupport.path));
+    });
+
+    test('挑别的目录 → 自定义根，派生 documents/support（行为逐字节不变）', () {
+      final String picked = p.join(tmp.path, 'Elsewhere');
+      final DataRootMigrationTarget t = resolve(picked);
+      expect(t.isDefaultLocation, isFalse);
+      expect(t.dataRootPrefValue, equals(picked));
+      final (Directory docs, Directory support) =
+          AppPaths.rootsForDataRoot(picked);
+      expect(t.documentsRoot.path, equals(docs.path));
+      expect(t.supportRoot.path, equals(support.path));
+    });
+
+    test('挑共享 Documents 根本身**不是**默认位置（伞目录恒比它深一层）', () {
+      expect(AppPaths.defaultDocumentsChildSegments.length,
+          greaterThanOrEqualTo(2),
+          reason: '伞目录 = 默认 documents 根的父目录。默认段只有 1 段时伞目录就等于共享的平台 '
+              'Documents，挑 Documents 根会被误判成"默认位置"而绕过自我迁移拒绝');
+      expect(resolve(platformDocuments.path).isDefaultLocation, isFalse);
+    });
+  });
+
+  group('BUG-1188 ②：扁平老安装照文档指引整理 → 与新装同形', () {
+    test('产出 Hibiki/data + DB 留在平台固定落点，且不再出现 documents/support 两个目录', () async {
+      await seed(
+          documentsRoot: platformDocuments, supportRoot: platformSupport);
+      final File userDoc = File(p.join(platformDocuments.path, 'essay.docx'))
+        ..writeAsStringSync('user data');
+      final File prefsFile =
+          File(p.join(platformSupport.path, 'shared_preferences.json'));
+
+      final DataRootMigrationTarget target =
+          resolve(p.join(platformDocuments.path, 'Hibiki'));
+      DataRootMigrationTarget? committed;
+      final (Directory newDocs, Directory newSupport) =
+          await const DataRootMigrator().migrate(DataRootMigrationRequest(
+        oldDocumentsRoot: platformDocuments,
+        oldSupportRoot: platformSupport,
+        target: target,
+        closeResources: () async {},
+        commitLocation: (DataRootMigrationTarget t) async => committed = t,
+        documentsTopLevelIncludeNames: AppPaths.hibikiOwnedDocumentsEntries,
+      ));
+
+      // 与全新安装逐字节同形。
+      expect(newDocs.path, equals(defaultDocsRoot));
+      expect(newSupport.path, equals(platformSupport.path));
+      // 布局分裂的两个症状都消失：Hibiki 伞下只有 data，DB 没被拖进文档目录。
+      expect(
+        Directory(p.join(platformDocuments.path, 'Hibiki'))
+            .listSync()
+            .map((FileSystemEntity e) => p.basename(e.path))
+            .toList(),
+        equals(<String>['data']),
+      );
+      expect(
+          Directory(p.join(platformDocuments.path, 'Hibiki', 'documents'))
+              .existsSync(),
+          isFalse);
+      expect(
+          Directory(p.join(platformDocuments.path, 'Hibiki', 'support'))
+              .existsSync(),
+          isFalse);
+      expect(
+          File(p.join(platformSupport.path, 'hibiki.db')).existsSync(), isTrue,
+          reason: 'DB 必须留在平台固定落点（新装的落点），绝不搬进用户文档目录');
+      expect(File(p.join(newDocs.path, 'hibiki.db')).existsSync(), isFalse);
+      // 内容真的搬过去了，用户自己的文件与 prefs 一字未动。
+      expect(
+          File(p.join(newDocs.path, 'hoshi_books', 'Bk', 'a.html'))
+              .existsSync(),
+          isTrue);
+      expect(
+          File(p.join(newDocs.path, 'audiobooks', 'Bk', 'a.mp3')).existsSync(),
+          isTrue);
+      expect(
+          Directory(p.join(platformDocuments.path, 'audiobooks')).existsSync(),
+          isFalse);
+      expect(userDoc.readAsStringSync(), equals('user data'));
+      expect(prefsFile.existsSync(), isTrue,
+          reason: 'support 根未变 ⇒ 绝不能跑"删旧 support 只留 prefs"那一步');
+      expect(
+          File(p.join(platformSupport.path, 'local_audio_1.db')).existsSync(),
+          isTrue);
+
+      // 提交是"默认位置"语义（清 data_root + 锚 nested），不是写一个自定义根。
+      expect(committed?.isDefaultLocation, isTrue);
+      expect(committed?.dataRootPrefValue, isNull);
+
+      // DB 内 documents 路径已 rebase；support 路径与外部视频路径原样不动。
+      final Map<String, String?> snap = await dbSnapshot(newSupport.path);
+      expect(snap['epubPath'], startsWith(newDocs.path));
+      expect(snap['extractDir'], startsWith(newDocs.path));
+      expect(snap['coverPath'], startsWith(newDocs.path));
+      expect(snap['videoCover'], startsWith(newDocs.path));
+      expect(snap['videoPath'], equals(p.join('E:', 'anime', 'Bk.mkv')));
+      expect(
+          (jsonDecode(snap['localAudioDbs']!) as List<dynamic>).single
+              as Map<dynamic, dynamic>,
+          containsPair(
+              'path', p.join(platformSupport.path, 'local_audio_1.db')));
+    });
+
+    test('路径改写幂等：同一次默认位置改写连跑两次逐字节 no-op、不产出 Hibiki/data/Hibiki/data', () async {
+      await seed(
+          documentsRoot: platformDocuments, supportRoot: platformSupport);
+      Future<void> runOnce() =>
+          const DataRootMigrator().rebaseDatabasePathsForTesting(
+            dbDirectory: platformSupport.path,
+            oldDocumentsRoot: platformDocuments.path,
+            newDocumentsRoot: defaultDocsRoot,
+            // 默认位置：support 根不变。
+            newSupportRoot: platformSupport.path,
+            documentsScopeEntries: AppPaths.hibikiOwnedDocumentsEntries,
+          );
+
+      await runOnce();
+      final Map<String, String?> first = await dbSnapshot(platformSupport.path);
+      expect(first['epubPath'], startsWith(defaultDocsRoot));
+
+      await runOnce();
+      final Map<String, String?> second =
+          await dbSnapshot(platformSupport.path);
+      expect(second, equals(first), reason: '第二遍必须是逐字节 no-op');
+
+      final String doubled = p.joinAll(<String>[
+        defaultDocsRoot,
+        ...AppPaths.defaultDocumentsChildSegments,
+      ]);
+      for (final MapEntry<String, String?> e in second.entries) {
+        expect(e.value ?? '', isNot(contains(doubled)), reason: e.key);
+      }
+    });
+  });
+
+  group('BUG-1188 ③：已按旧方式搬过的用户', () {
+    /// 旧方式的产物：`<Documents>/Hibiki/documents` + `<Documents>/Hibiki/support`，
+    /// `data_root = <Documents>/Hibiki`。这批用户必须**继续正常工作**（解析规则一字未改），
+    /// 并且现在多了一条收敛回默认形态的路径。
+    test('旧布局仍按 <root>/documents + <root>/support 解析（自定义根语义未变）', () {
+      final String oldStyleRoot = p.join(platformDocuments.path, 'Hibiki2');
+      final (Directory docs, Directory support) =
+          AppPaths.rootsForDataRoot(oldStyleRoot);
+      expect(docs.path, equals(p.join(oldStyleRoot, 'documents')));
+      expect(support.path, equals(p.join(oldStyleRoot, 'support')));
+    });
+
+    test('再选一次 Hibiki → 归一化回默认位置：内容进 Hibiki/data、DB 搬回平台落点、prefs 保住', () async {
+      final Directory oldRoot =
+          Directory(p.join(platformDocuments.path, 'Hibiki'))
+            ..createSync(recursive: true);
+      final Directory oldDocs = Directory(p.join(oldRoot.path, 'documents'))
+        ..createSync(recursive: true);
+      final Directory oldSupport = Directory(p.join(oldRoot.path, 'support'))
+        ..createSync(recursive: true);
+      // 旧方式搬过之后，平台固定落点里只剩 prefs（迁移器刻意保住的那一份）。
+      final File prefsFile =
+          File(p.join(platformSupport.path, 'shared_preferences.json'))
+            ..writeAsStringSync('{"flutter.data_root":"keep-me"}');
+      await seed(
+          documentsRoot: oldDocs,
+          supportRoot: oldSupport,
+          withPrefsFile: false);
+
+      final DataRootMigrationTarget target = resolve(oldRoot.path);
+      DataRootMigrationTarget? committed;
+      final (Directory newDocs, Directory newSupport) =
+          await const DataRootMigrator().migrate(DataRootMigrationRequest(
+        oldDocumentsRoot: oldDocs,
+        oldSupportRoot: oldSupport,
+        target: target,
+        closeResources: () async {},
+        commitLocation: (DataRootMigrationTarget t) async => committed = t,
+        // 旧布局的 documents 根是 Hibiki 专属目录 → 整树搬移语义。
+        documentsTopLevelIncludeNames: null,
+      ));
+
+      expect(newDocs.path, equals(defaultDocsRoot));
+      expect(newSupport.path, equals(platformSupport.path));
+      expect(committed?.isDefaultLocation, isTrue);
+      // 内容与 DB 都到位，旧的 documents/support 两个目录消失。
+      expect(
+          File(p.join(newDocs.path, 'hoshi_books', 'Bk', 'a.html'))
+              .existsSync(),
+          isTrue);
+      expect(
+          File(p.join(platformSupport.path, 'hibiki.db')).existsSync(), isTrue);
+      expect(
+          File(p.join(platformSupport.path, 'local_audio_1.db')).existsSync(),
+          isTrue);
+      expect(oldDocs.existsSync(), isFalse);
+      expect(oldSupport.existsSync(), isFalse);
+      // 合并搬入平台落点时，先于迁移就存在的 prefs 必须一字未动。
+      expect(prefsFile.existsSync(), isTrue);
+      expect(prefsFile.readAsStringSync(),
+          equals('{"flutter.data_root":"keep-me"}'));
+
+      final Map<String, String?> snap = await dbSnapshot(newSupport.path);
+      expect(snap['epubPath'], startsWith(newDocs.path));
+      expect(
+          (jsonDecode(snap['localAudioDbs']!) as List<dynamic>).single
+              as Map<dynamic, dynamic>,
+          containsPair(
+              'path', p.join(platformSupport.path, 'local_audio_1.db')));
+    });
+
+    test('提交失败回滚：平台固定落点不被整目录删掉，prefs 与旧根数据都还在', () async {
+      final Directory oldRoot =
+          Directory(p.join(platformDocuments.path, 'Hibiki'))
+            ..createSync(recursive: true);
+      final Directory oldDocs = Directory(p.join(oldRoot.path, 'documents'))
+        ..createSync(recursive: true);
+      final Directory oldSupport = Directory(p.join(oldRoot.path, 'support'))
+        ..createSync(recursive: true);
+      final File prefsFile =
+          File(p.join(platformSupport.path, 'shared_preferences.json'))
+            ..writeAsStringSync('{"flutter.data_root":"keep-me"}');
+      await seed(
+          documentsRoot: oldDocs,
+          supportRoot: oldSupport,
+          withPrefsFile: false);
+
+      await expectLater(
+        const DataRootMigrator().migrate(DataRootMigrationRequest(
+          oldDocumentsRoot: oldDocs,
+          oldSupportRoot: oldSupport,
+          target: resolve(oldRoot.path),
+          closeResources: () async {},
+          commitLocation: (DataRootMigrationTarget t) async =>
+              throw StateError('prefs unavailable'),
+          documentsTopLevelIncludeNames: null,
+        )),
+        throwsA(isA<DataRootMigrationException>()),
+      );
+
+      expect(platformSupport.existsSync(), isTrue,
+          reason: '目标 support 根是活着的平台固定落点，回滚绝不能整目录删掉它');
+      expect(prefsFile.existsSync(), isTrue);
+      expect(prefsFile.readAsStringSync(),
+          equals('{"flutter.data_root":"keep-me"}'));
+      // 数据搬回旧根，平台落点里不留本次搬进去的东西。
+      expect(File(p.join(oldSupport.path, 'hibiki.db')).existsSync(), isTrue);
+      expect(
+          File(p.join(oldDocs.path, 'hoshi_books', 'Bk', 'a.html'))
+              .existsSync(),
+          isTrue);
+      expect(File(p.join(platformSupport.path, 'hibiki.db')).existsSync(),
+          isFalse);
+      expect(Directory(defaultDocsRoot).existsSync(), isFalse);
+    });
+  });
+
+  group('BUG-1188 ④：源码守卫', () {
+    String readSource(String rel) {
+      final File f = File(rel);
+      expect(f.existsSync(), isTrue, reason: 'missing source file: $rel');
+      return f.readAsStringSync();
+    }
+
+    test('设置页必须经 resolveDataRootMigrationTarget 解析，不得把 picked 直接当 dataRoot',
+        () {
+      final String src =
+          readSource('lib/src/sync/sync_settings_schema/data_root.part.dart');
+      expect(src.contains('resolveDataRootMigrationTarget('), isTrue);
+      expect(src.contains('AppPaths.defaultLocationDocumentsRoot()'), isTrue);
+      expect(src.contains('getApplicationSupportDirectory()'), isTrue);
+      expect(src.contains('AppPaths.rootsForDataRoot('), isFalse,
+          reason: 'BUG-1188：目标派生只有一个入口（resolveDataRootMigrationTarget），'
+              'UI 再自己派生一次就会与引擎的认知漂开');
+    });
+
+    test('默认位置提交必须同时锚 nested 布局并清掉 data_root', () {
+      final String src =
+          readSource('lib/src/sync/sync_settings_schema/data_root.part.dart');
+      expect(src.contains('AppPaths.documentsLayoutNested'), isTrue,
+          reason: '只清 data_root 不锚 nested，下次启动 documents 根解析回共享 Documents '
+              '= 书库集体消失');
+      expect(src.contains('sp.remove(AppPaths.dataRootPrefKey)'), isTrue,
+          reason: '只锚 nested 不清 data_root，下次启动仍指向已搬空的旧自定义根');
+    });
+
+    test('support 根未变时绝不跑"删旧 support"，也不把它当自建子树清掉', () {
+      final String src = readSource('lib/src/storage/data_root_migrator.dart');
+      expect(src.contains('if (!supportUnchanged) {'), isTrue);
+      expect(
+        src.contains('if (!supportUnchanged && !mergeSupport) newSupport,'),
+        isTrue,
+        reason: 'BUG-1188：平台固定落点进了 _cleanupCreatedSubtrees 就会被整目录删掉，'
+            '用户全部设置与 data_root 配置一起没',
+      );
+    });
+  });
+}

--- a/hibiki/test/storage/data_root_migrator_path_gaps_test.dart
+++ b/hibiki/test/storage/data_root_migrator_path_gaps_test.dart
@@ -293,9 +293,10 @@ void main() {
         await const DataRootMigrator().migrate(DataRootMigrationRequest(
       oldDocumentsRoot: oldDocs,
       oldSupportRoot: oldSupport,
-      newDataRoot: newDataRoot,
+      target: DataRootMigrationTarget.customRoot(newDataRoot),
       closeResources: () async {},
-      writeDataRootPref: (String root) async => prefWrites.add(root),
+      commitLocation: (DataRootMigrationTarget t) async =>
+          prefWrites.add(t.dataRootPrefValue!),
       documentsTopLevelIncludeNames: AppPaths.hibikiOwnedDocumentsEntries,
     ));
     expect(prefWrites, equals(<String>[newDataRoot]));
@@ -342,9 +343,9 @@ void main() {
         await const DataRootMigrator().migrate(DataRootMigrationRequest(
       oldDocumentsRoot: oldDocs,
       oldSupportRoot: oldSupport,
-      newDataRoot: newDataRoot,
+      target: DataRootMigrationTarget.customRoot(newDataRoot),
       closeResources: () async {},
-      writeDataRootPref: (String root) async {},
+      commitLocation: (DataRootMigrationTarget t) async {},
       documentsTopLevelIncludeNames: AppPaths.hibikiOwnedDocumentsEntries,
     ));
 

--- a/hibiki/test/storage/data_root_migrator_test.dart
+++ b/hibiki/test/storage/data_root_migrator_test.dart
@@ -148,11 +148,12 @@ void main() {
           await const DataRootMigrator().migrate(DataRootMigrationRequest(
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
-        newDataRoot: newDataRoot,
+        target: DataRootMigrationTarget.customRoot(newDataRoot),
         // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
         documentsTopLevelIncludeNames: null,
         closeResources: () async => closed = true,
-        writeDataRootPref: (String r) async => wroteDataRoot = r,
+        commitLocation: (DataRootMigrationTarget t) async =>
+            wroteDataRoot = t.dataRootPrefValue,
       ));
 
       // 关闭回调被调用。
@@ -238,11 +239,11 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
           documentsTopLevelIncludeNames: null,
           closeResources: () async {},
-          writeDataRootPref: (String r) async => wrote = true,
+          commitLocation: (DataRootMigrationTarget t) async => wrote = true,
         )),
         throwsA(isA<DataRootMigrationException>()),
       );
@@ -266,11 +267,11 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
           documentsTopLevelIncludeNames: null,
           closeResources: () async {},
-          writeDataRootPref: (String r) async {
+          commitLocation: (DataRootMigrationTarget t) async {
             writeAttempts++;
             throw StateError('prefs unavailable');
           },
@@ -391,11 +392,12 @@ void main() {
           await const DataRootMigrator().migrate(DataRootMigrationRequest(
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
-        newDataRoot: newDataRoot,
+        target: DataRootMigrationTarget.customRoot(newDataRoot),
         // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
         documentsTopLevelIncludeNames: null,
         closeResources: () async {},
-        writeDataRootPref: (String r) async => wroteDataRoot = r,
+        commitLocation: (DataRootMigrationTarget t) async =>
+            wroteDataRoot = t.dataRootPrefValue,
       ));
 
       // (a) prefs 仍在原 oldSupportRoot，内容不变；sidecar 也留下。
@@ -461,11 +463,12 @@ void main() {
           await const DataRootMigrator().migrate(DataRootMigrationRequest(
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
-        newDataRoot: newDataRoot,
+        target: DataRootMigrationTarget.customRoot(newDataRoot),
         // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
         documentsTopLevelIncludeNames: null,
         closeResources: () async {},
-        writeDataRootPref: (String r) async => wroteDataRoot = r,
+        commitLocation: (DataRootMigrationTarget t) async =>
+            wroteDataRoot = t.dataRootPrefValue,
       ));
 
       // 整树搬齐：DB + local_audio + documents。
@@ -511,11 +514,11 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
           documentsTopLevelIncludeNames: null,
           closeResources: () async {},
-          writeDataRootPref: (String r) async {},
+          commitLocation: (DataRootMigrationTarget t) async {},
         )),
         throwsA(isA<DataRootMigrationException>()),
       );
@@ -550,9 +553,10 @@ void main() {
           await const DataRootMigrator().migrate(DataRootMigrationRequest(
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
-        newDataRoot: newDataRoot,
+        target: DataRootMigrationTarget.customRoot(newDataRoot),
         closeResources: () async {},
-        writeDataRootPref: (String r) async => wrote = r,
+        commitLocation: (DataRootMigrationTarget t) async =>
+            wrote = t.dataRootPrefValue,
         documentsTopLevelIncludeNames: const <String>{
           'hoshi_books',
           'audiobooks',
@@ -612,9 +616,10 @@ void main() {
           await const DataRootMigrator().migrate(DataRootMigrationRequest(
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
-        newDataRoot: newDataRoot,
+        target: DataRootMigrationTarget.customRoot(newDataRoot),
         closeResources: () async {},
-        writeDataRootPref: (String r) async => wrote = r,
+        commitLocation: (DataRootMigrationTarget t) async =>
+            wrote = t.dataRootPrefValue,
         documentsTopLevelIncludeNames: const <String>{
           'hoshi_books',
           'audiobooks',
@@ -658,9 +663,10 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: p.join(oldDocsPath, 'audiobooks'),
+          target: DataRootMigrationTarget.customRoot(
+              p.join(oldDocsPath, 'audiobooks')),
           closeResources: () async {},
-          writeDataRootPref: (String r) async {},
+          commitLocation: (DataRootMigrationTarget t) async {},
           documentsTopLevelIncludeNames: const <String>{
             'hoshi_books',
             'audiobooks',
@@ -680,9 +686,10 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: p.join(oldDocsPath, 'Hibiki'),
+          target:
+              DataRootMigrationTarget.customRoot(p.join(oldDocsPath, 'Hibiki')),
           closeResources: () async {},
-          writeDataRootPref: (String r) async {},
+          commitLocation: (DataRootMigrationTarget t) async {},
           // null = Hibiki 专属根、整树搬移语义。
           documentsTopLevelIncludeNames: null,
         )),
@@ -703,9 +710,9 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           closeResources: () async {},
-          writeDataRootPref: (String r) async =>
+          commitLocation: (DataRootMigrationTarget t) async =>
               throw StateError('prefs unavailable'),
           documentsTopLevelIncludeNames: const <String>{
             'hoshi_books',
@@ -771,11 +778,11 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
           documentsTopLevelIncludeNames: null,
           closeResources: () async {},
-          writeDataRootPref: (String r) async => wrote = true,
+          commitLocation: (DataRootMigrationTarget t) async => wrote = true,
           resolvedExecutablePath: exe,
         )),
         throwsA(isA<DataRootMigrationException>().having(
@@ -804,11 +811,11 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
           documentsTopLevelIncludeNames: null,
           closeResources: () async {},
-          writeDataRootPref: (String r) async {},
+          commitLocation: (DataRootMigrationTarget t) async {},
           resolvedExecutablePath: exe,
         )),
         throwsA(isA<DataRootMigrationException>()),
@@ -830,11 +837,12 @@ void main() {
           await const DataRootMigrator().migrate(DataRootMigrationRequest(
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
-        newDataRoot: newDataRoot,
+        target: DataRootMigrationTarget.customRoot(newDataRoot),
         // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
         documentsTopLevelIncludeNames: null,
         closeResources: () async {},
-        writeDataRootPref: (String r) async => wrote = r,
+        commitLocation: (DataRootMigrationTarget t) async =>
+            wrote = t.dataRootPrefValue,
         resolvedExecutablePath: exe,
       ));
       expect(File(p.join(newSupport.path, 'hibiki.db')).existsSync(), isTrue);
@@ -858,11 +866,11 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           // 自定义专属根语义：整树搬移（TODO-1226 前的原行为）。
           documentsTopLevelIncludeNames: null,
           closeResources: () async {},
-          writeDataRootPref: (String r) async =>
+          commitLocation: (DataRootMigrationTarget t) async =>
               throw StateError('prefs unavailable'),
         )),
         throwsA(isA<DataRootMigrationException>()),
@@ -960,11 +968,11 @@ void main() {
           const DataRootMigrator().migrate(DataRootMigrationRequest(
             oldDocumentsRoot: oldDocs,
             oldSupportRoot: oldSupport,
-            newDataRoot: newDataRoot,
+            target: DataRootMigrationTarget.customRoot(newDataRoot),
             documentsTopLevelIncludeNames: null,
             closeResources: () async {},
             // pref 提交失败 = 任意提交时点中断的代理。
-            writeDataRootPref: (String r) async =>
+            commitLocation: (DataRootMigrationTarget t) async =>
                 throw StateError('interrupted before commit'),
           )),
           throwsA(isA<DataRootMigrationException>()),
@@ -1007,10 +1015,11 @@ void main() {
             await const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: oldDocs,
           oldSupportRoot: oldSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           documentsTopLevelIncludeNames: null,
           closeResources: () async {},
-          writeDataRootPref: (String r) async => wrote = r,
+          commitLocation: (DataRootMigrationTarget t) async =>
+              wrote = t.dataRootPrefValue,
         ));
         // 新根齐全。
         expect(
@@ -1061,10 +1070,10 @@ void main() {
       await const DataRootMigrator().migrate(DataRootMigrationRequest(
         oldDocumentsRoot: oldDocs,
         oldSupportRoot: oldSupport,
-        newDataRoot: newDataRoot,
+        target: DataRootMigrationTarget.customRoot(newDataRoot),
         documentsTopLevelIncludeNames: null,
         closeResources: () async {},
-        writeDataRootPref: (String r) async {},
+        commitLocation: (DataRootMigrationTarget t) async {},
       ));
       final String newSupportPath = p.join(newDataRoot, 'support');
       expect(File(p.join(newSupportPath, 'hibiki.db')).existsSync(), isTrue);
@@ -1083,10 +1092,10 @@ void main() {
         const DataRootMigrator().migrate(DataRootMigrationRequest(
           oldDocumentsRoot: otherDocs,
           oldSupportRoot: otherSupport,
-          newDataRoot: newDataRoot,
+          target: DataRootMigrationTarget.customRoot(newDataRoot),
           documentsTopLevelIncludeNames: null,
           closeResources: () async {},
-          writeDataRootPref: (String r) async => wrote = true,
+          commitLocation: (DataRootMigrationTarget t) async => wrote = true,
         )),
         throwsA(isA<DataRootMigrationException>()),
       );


### PR DESCRIPTION
## 问题（已实测复现，develop `862ce0d17`）

跑真 `DataRootMigrator.migrate()`，老安装照 BUG-1115 文档指引选 `Documents\Hibiki`：

```
新装形态 documents 根: <Documents>\Hibiki\data
新装形态 support 根:   <AppData>\app.hibiki.reader
迁移实际 documents 根: <Documents>\Hibiki\documents      ← 名字不同
迁移实际 support 根:   <Documents>\Hibiki\support        ← DB 被拖进文档目录
data_root pref 写入:   <Documents>\Hibiki
```

根因 `data_root_migrator.dart:143-148`（改前）：迁移目标只有**一种表达**——一个 dataRoot 字符串，
无条件 `AppPaths.rootsForDataRoot()` 硬派生两个子目录。于是「换个盘放数据」和「把散落的目录收进
子目录」这两件语义不同的事被塞进同一条路径，产出第三种布局；且 Windows `Documents` 常被 OneDrive
重定向，WAL SQLite 落进去有损坏/反复上传风险，而持久化 `data_root` 的 `shared_preferences.json`
按鸡生蛋铁律不能跟着搬 → 两份配置存储被劈开在两处。

## 修法

把目标提升成数据结构 `DataRootMigrationTarget`（`documentsRoot` / `supportRoot` /
`dataRootPrefValue`），两种情形成为**同一条代码路径的两个取值**：

| 目标 | documents 根 | support 根 | 提交 |
|---|---|---|---|
| `customRoot(R)`（挑普通目录） | `<R>/documents` | `<R>/support` | 写 `data_root` |
| `defaultLocation`（挑 `Documents\Hibiki` 或 `…\Hibiki\data`） | `<Documents>/Hibiki/data` | 平台固定落点（**DB 不动**） | 清 `data_root` + 锚 `documents_layout=nested` |

`resolveDataRootMigrationTarget()` 归一化「挑中默认位置」这件事，消除「同一物理位置两种持久化
表达」的歧义（不是加一个 if 分支）。配套：`supportUnchanged` 时不建搬移计划 / 不跑
`_deleteOldSupportPreservingPrefs` / 不进 `_cleanupCreatedSubtrees`；合并搬入平台落点时按
`movedTopLevelNames` 回滚并保留 dst 本体；目标空校验忽略顶层 prefs 文件族；两个 pref 键原子提交。
确认弹窗列出解析后的两个根。

**未做**：一键整理按钮；`anime_downloads` 搬移/fast-resume/句柄逻辑；`<dataRoot>/documents`
子目录名未改名（改名要给存量自定义根用户再加一个永久锚点，纯外观收益、爆炸半径不成比例）。

## 向后兼容

已按旧方式搬过的用户（`data_root=<Documents>\Hibiki`）**零破坏**：`AppPaths._resolveDocumentsRoot`
的 dataRoot 分支优先于布局锚点，解析规则一字未改，`<root>/documents` + `<root>/support` 继续工作。
愿意收敛时再选一次 `Documents\Hibiki` 即可归一化回默认形态（不强制、不自动）。
挑任意其它目录的行为逐字节不变（DB 仍随之搬走 —— 那正是换盘的语义）。

## 验证

- `flutter analyze`（全仓含 test）→ `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/storage test/settings test/profile test/startup test/tools`
  → `PASSED - 654 tests ran`（首轮 `update_manifest_publish_race_test.dart` 抖了一次，单跑 `test/tools` 114/114 绿，重跑 654 全绿）
- 新增 `test/storage/data_root_default_location_migration_test.dart`（12 例，端到端真 `migrate()` + 源码守卫）
- **幂等**：默认位置的路径改写连跑两次逐字节 no-op，显式断言无 `Hibiki/data/Hibiki/data`
- **负向验证**（三条，各自转红 → 还原转绿）：① 关掉归一化 → 4 例红；② 去掉 `if (!supportUnchanged)`
  删旧 support 守卫 → 2 例红（`hibiki.db` 被从固定落点删掉）；③ `newSupport` 无条件进
  `_cleanupCreatedSubtrees` → 2 例红（回滚删掉平台固定落点）

## 文档

- 新增 `docs/bugs/BUG-1188-dataroot-pick-layout-split.md`（① 修复 ② 测试均已勾 `[x]`）
- `docs/bugs/BUG-1115-*.md` 的两处「选 `Documents\Hibiki`」指引加了 BUG-1188 更正，说明现在的产物形态

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
