### PR TITLE
fix(download): 集号输入框宽度改由 label 实测决定，不再写死像素 (BUG-1184)

### DIFF
--- a/docs/bugs/BUG-1184-narrow-screen-segmented-clipped.md
+++ b/docs/bugs/BUG-1184-narrow-screen-segmented-clipped.md
@@ -21,13 +21,19 @@
 | 12 | 会真抛 RenderFlex overflow 的按钮行/固定高 | `interconnect.part.dart:1056`、`backup.part.dart:445/560`、`media_sources_dialog.dart:149/362`、`mokuro_moe_tasks_section.dart:62`、`mokuro_moe_catalog_dialog.dart:218` | 令牌操作按钮、备份选择计数行、来源对话框页脚、任务列表死高 220、目录对话框死高 440 |
 | 13 | 统计汇总卡写死双列，无窄屏回退 | `reading_statistics_page.dart:541/565`、`video_statistics_page.dart:229/255` | 320dp 上每格只剩约 100px 文字宽，而每格要放 7 行「标签: 数值」，每行都被迫折行。同页 `_buildMidSection` 早有窄屏堆叠，汇总卡一直漏了 |
 | 14 | 下载页 TabBar 均分宽度 | `downloads_page.dart:59` | 窄屏 + 大字号下较长 tab 名（英文 `Subscriptions`）被裁 |
+| 15 | 集号输入框写死 `width: 96` 装 label | `anime_download_dialog.dart:1603` | **用户截图实证**：1920 宽的窗口下「集数（可选）」被裁成「集数···」。与屏幕宽窄无关，任何窗口宽度下都裁。此处先后写死过 72 和 96，`96` 那版注释就写着「72 在界面缩放 >1 时装不下 label」——上一次修法是在同一个错误里换个更大的数字 |
 
 ### 修复取向
 
-不是逐点打补丁，而是先修共享组件的根因（1/2/4/5/6 一改多治），再收口重复几何（9 的两处 `0.62`、3 的四处裸分段条），最后处理确会抛异常的点（12）。新增两个共享件消除「同一问题两套写法」的特殊情况：
+不是逐点打补丁，而是先修共享组件的根因（1/2/4/5/6 一改多治），再收口重复几何（9 的两处 `0.62`、3 的四处裸分段条），最后处理确会抛异常的点（12）。
+
+贯穿全部 15 条的同一个反模式是**用固定像素/固定行数去装一段会变的内容**——文案会随语言变长、字号会随系统设置放大、界面缩放会再乘一次。根因 15 是最典型的样本：同一处先后写死 72、96 两次，每次都是「上次那个数字不够，换个大的」，而正确做法是让尺寸由内容的实测结果决定（`TextPainter` 量 label、`TextStyle.height` 算行高），连兜底上限也不写死像素、改取可用宽度的比例。
+
+新增三个共享件消除「同一问题两套写法」的特殊情况：
 
 - `HibikiSegmentedStrip`——把设置行里早已存在（BUG-008）但私有的「装不下就横向滚动」契约开放给任意调用点。
 - `narrowAwareAppBarActions` + `HibikiAppBarAction`——窄屏把次要 AppBar 动作折进溢出菜单，动作一个不少，只是多一次点击。
+- `textLineHeight(context, style)`——需要「预留 N 行文字高度」的地方（网格 `mainAxisExtent`、横滑行 `SizedBox`、卡片文字块）此前各自猜行高系数，统一读 `TextStyle.height` 真实值。
 
 ### 两处需要留档的权衡
 
@@ -38,7 +44,9 @@
 
 - Cupertino renderer 的单行标题（`cupertino_settings_renderer.dart:55`，`CupertinoListTile` 由 Flutter SDK 强制 `maxLines: 1`）与 `settings_shared.dart` Cupertino trailing 按屏宽 0.42 限宽：Cupertino 仅为隐藏内部能力（`auto` 下五平台统一走 MD3），非用户可见路径。
 - `profile_management_page.dart` / `dictionary_settings_dialog_page.dart` 的 trailing 挂 4~5 个控件：已被根因 2 的窄屏堆叠覆盖（不再与标题抢宽），但更彻底的做法是把它们收进溢出菜单。
-- `anime_download_dialog.dart` 集号输入框固定 96px、`galgame_home_page.dart` 卡片固定 126px 高：影响面较小，未在本轮处理。
+- `galgame_home_page.dart` 卡片固定 126px 高：影响面较小，未在本轮处理。
+
+> **补记（用户复核后回填）**：集号输入框那条原本也列在这里，理由是「影响面较小」——判断错了。用户随后贴出 1920 宽窗口的截图，label 就在那儿被裁成「集数···」，说明它跟屏幕宽窄无关、**任何宽度下都复现**，已作为根因 15 修掉（见下方提交）。教训：把一条已经定位到的显示不全推迟为「影响面较小」，前提是真的确认过它只在极端条件下出现；这条我没确认就推迟了。
 
 - **[x] ① 已修复** — `e0ca57a80`（共享组件根因 + 会抛异常的按钮行）、`88df6f8e2`（媒体名称单行截断 + 死高/死比例）、`1a8b51ce7`（游戏名/统计卡/AppBar 标题）、本轮末次提交（历史卡标题条、TabBar、测试）
 - **[x] ② 已加自动化测试** — `hibiki/test/widgets/narrow_screen_overflow_test.dart`（13 例，逐条锚定根因 1/2/3/4/7/10：说明文字不再钳行数且逃生口仍生效、窄行 flexible trailing 堆叠且宽行不误堆叠、分段条装不下即滚动且装得下不引入多余滚动、对话框边距窄屏收窄/宽屏不变/显式值优先、AppBar 折叠后三个动作仍在菜单里、footer 高度随文字缩放变高）。另更新两处既有守卫：`test/settings/settings_redesign_static_test.dart` 改守「subtitle 由 opt-in 覆盖决定行数，旧的无条件 3 行钳制必须保持消失」；`test/pages/video_card_cover_aspect_guard_test.dart` 改守「文字块高度必须按真实行高算出、不得退回硬编码常量」并留档 BUG-943 权衡。

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -1,5 +1,6 @@
 import 'dart:async' show unawaited;
 import 'dart:io';
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
@@ -34,6 +35,48 @@ import 'package:hibiki/utils.dart';
 /// 分节渐进式（同 [JimakuSubtitleDialog] 的节奏）：三个阶段互斥展示（搜番结果 /
 /// 种子列表 / 确认推送），底部常驻「下载任务」折叠区列出既有计划。所有网络操作
 /// 容错降级为空结果 + 节内提示，不崩对话框。
+/// 集号输入框该有多宽：**按 label 的真实测量宽度算出**，而不是写死像素。
+///
+/// BUG-1184：这里先后写死过 72 和 96——`96` 那一版的注释就写着「72 在界面缩放 >1
+/// 时装不下 label」，也就是上一次的修法是在同一个错误里换一个更大的数字。可 label
+/// 本身是会变的：中文「集数（可选）」是 6 个全角字，英文 `Episode (optional)` 更长，
+/// 再乘上界面缩放与系统字号，96 照样装不下——用户截图里它就被裁成了「集数···」。
+/// 而且这跟屏幕宽窄无关，**任何窗口宽度下都裁**。
+///
+/// 所以宽度必须由 label 决定，而不是反过来指望 label 挤进某个常数：用 [TextPainter]
+/// 量出它在当前语言/字号/文字缩放下的实际宽度，再加上 [InputDecoration] 的水平内
+/// 边距和集号本身要占的输入宽度。
+///
+/// [rowWidth] 是整行的可用宽度。上限取它的四成——这个框右边还有搜索按钮、左边是
+/// 会被挤压的搜索词输入框，某些语言的超长译文不该把搜索词框挤没。上限同样不写死
+/// 像素：宽屏上四成足够放下任何译文，窄屏上才真正起到保护作用。[rowWidth] 为空或
+/// 无界时退回一个保守常数。
+double jimakuEpisodeFieldWidth(
+  BuildContext context,
+  String label, {
+  double? rowWidth,
+}) {
+  // label 未浮起时按 bodyLarge 渲染（浮起后缩到 75%），按较大的那个量才安全。
+  final TextStyle labelStyle =
+      Theme.of(context).textTheme.bodyLarge ?? const TextStyle(fontSize: 16);
+  final TextPainter painter = TextPainter(
+    text: TextSpan(text: label, style: labelStyle),
+    textDirection: Directionality.of(context),
+    textScaler: MediaQuery.textScalerOf(context),
+    maxLines: 1,
+  )..layout();
+  final double labelWidth = painter.width;
+  painter.dispose();
+  final double cap = (rowWidth != null && rowWidth.isFinite && rowWidth > 0)
+      ? math.max(96.0, rowWidth * 0.4)
+      : 260.0;
+  return (labelWidth + kJimakuEpisodeFieldChrome).clamp(96.0, cap);
+}
+
+/// [jimakuEpisodeFieldWidth] 里 label 之外要占掉的宽度：`isDense` 的
+/// [InputDecoration] 左右内边距各 12，再给集号本身留出约三位数字。
+const double kJimakuEpisodeFieldChrome = 24 + 28;
+
 /// 选种结果排序键（一律降序：多的/大的/新的在前）。
 enum TorrentSortKey { seeders, size, date }
 
@@ -1559,6 +1602,15 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   /// 集号 + 搜索按钮。自动搜不到或命中错版时，用户改词/填集号重搜 Jimaku
   /// （i18n 复用视频字幕对话框同款 key）。
   Widget _buildJimakuManualSearch(ThemeData theme) {
+    // BUG-1184：集号框宽度由 label 实测宽度决定，上限取整行宽的四成——所以需要
+    // 先拿到整行可用宽。
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) =>
+          _buildJimakuManualSearchRow(theme, constraints.maxWidth),
+    );
+  }
+
+  Widget _buildJimakuManualSearchRow(ThemeData theme, double rowWidth) {
     final AniListMedia? media = _selectedMedia;
     final List<String> titleOptions =
         media == null ? const <String>[] : _titleOptions(media);
@@ -1599,8 +1651,11 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         ),
         const SizedBox(width: 8),
         SizedBox(
-          // 96：72 在界面缩放 >1 时装不下「集号」label，会截成「集…」。
-          width: 96,
+          width: jimakuEpisodeFieldWidth(
+            context,
+            t.video_jimaku_episode,
+            rowWidth: rowWidth,
+          ),
           child: TextField(
             controller: _jimakuEpisodeCtrl,
             keyboardType: TextInputType.number,

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -49,12 +49,20 @@ import 'package:hibiki/utils.dart';
 ///
 /// [rowWidth] 是整行的可用宽度。上限取它的四成——这个框右边还有搜索按钮、左边是
 /// 会被挤压的搜索词输入框，某些语言的超长译文不该把搜索词框挤没。上限同样不写死
-/// 像素：宽屏上四成足够放下任何译文，窄屏上才真正起到保护作用。[rowWidth] 为空或
-/// 无界时退回一个保守常数。
+/// 像素：宽屏上四成足够放下任何译文，窄屏上才真正起到保护作用。
+///
+/// [rowWidth] 故意做成必填、且不提供「取不到就退回某个保守常数」的默认值——与
+/// [narrowAwareAppBarActions] 的 `availableWidth` 同一口径：有默认值就等于给这个
+/// bug 留了一条随时能走回去的路，而这个 bug 的历史恰恰是「换一个更大的常数」。
+/// 调用点把这一行包进 [LayoutBuilder] 后传 `constraints.maxWidth` 即可。
+///
+/// [rowWidth] 非有限（`double.infinity`，Row 在无界约束下就是这个值）时**不设上
+/// 限**，而不是退回一个像素常数：上限的唯一职责是「别把同一行的邻居挤没」，而无界
+/// 行里根本不存在会被挤没的邻居——此时 label 多长就多宽，反倒是唯一不会裁字的解。
 double jimakuEpisodeFieldWidth(
   BuildContext context,
   String label, {
-  double? rowWidth,
+  required double rowWidth,
 }) {
   // label 未浮起时按 bodyLarge 渲染（浮起后缩到 75%），按较大的那个量才安全。
   final TextStyle labelStyle =
@@ -67,9 +75,9 @@ double jimakuEpisodeFieldWidth(
   )..layout();
   final double labelWidth = painter.width;
   painter.dispose();
-  final double cap = (rowWidth != null && rowWidth.isFinite && rowWidth > 0)
+  final double cap = (rowWidth.isFinite && rowWidth > 0)
       ? math.max(96.0, rowWidth * 0.4)
-      : 260.0;
+      : double.infinity;
   return (labelWidth + kJimakuEpisodeFieldChrome).clamp(96.0, cap);
 }
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+958
+version: 1.3.1+959
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
@@ -20,7 +20,8 @@ import '../helpers/test_platform_services.dart';
 ///   代理提示 + 「去设置」（用户报告：站点被墙时切分类超时无从定位）。
 /// - 选种结果排序（做种数/体积/发布时间，一律降序）。
 /// - 手动字幕搜索词默认罗马字（与 Nyaa 查询词同口径），下拉可切日文原名。
-/// - 集号输入框宽度 96（72 在界面缩放 >1 时 label 截成「集…」）。
+/// - 集号输入框宽度必须放得下 label（BUG-1184：先后写死 72、96，都是在同一个错误
+///   里换更大的数字；label 随语言/字号/界面缩放变长，写死多少都会被裁）。
 
 const AniListMedia _kMedia = AniListMedia(
   id: 1,
@@ -227,7 +228,8 @@ void main() {
         findsOneWidget);
   });
 
-  testWidgets('确认阶段：字幕搜索词默认罗马字、下拉可切日文原名、集号框宽 96', (WidgetTester tester) async {
+  testWidgets('确认阶段：字幕搜索词默认罗马字、下拉可切日文原名、集号框放得下 label',
+      (WidgetTester tester) async {
     final _FakeAppModel appModel =
         _FakeAppModel((http.Request req) async => http.Response('', 404));
     await pumpDialog(tester, appModel, torrent: _kTorrent);
@@ -244,11 +246,45 @@ void main() {
     await tester.pumpAndSettle();
     expect(tester.widget<TextField>(queryField).controller!.text, 'テスト・アニメ');
 
-    // 集号输入框宽度 96（回归：72 在界面缩放 >1 时 label 截成「集…」）。
+    // BUG-1184：集号框宽度必须放得下 label，且**由 label 的实测宽度决定**。
+    //
+    // 这里原先断言的是「宽度恰好 96」——而 96 本身就是上一次补丁的产物（更早写死
+    // 72，注释写着「72 在界面缩放 >1 时 label 截成『集…』」）。同一个错误换个更大
+    // 的数字，label 一变长（中文「集数（可选）」、英文 `Episode (optional)`）照样
+    // 被裁，用户在 1920 宽的窗口上截到了「集数···」——跟屏幕宽窄根本无关。
+    // 现在断言的是「装得下」这个性质，而不是某个具体数字。
     final Finder episodeField = find.byWidgetPredicate((Widget w) =>
         w is TextField && w.decoration?.labelText == t.video_jimaku_episode);
     expect(episodeField, findsOneWidget);
-    expect(tester.getSize(episodeField).width, 96);
+
+    final TextPainter labelPainter = TextPainter(
+      text: TextSpan(
+        text: t.video_jimaku_episode,
+        style: Theme.of(tester.element(episodeField)).textTheme.bodyLarge,
+      ),
+      textDirection: TextDirection.ltr,
+      textScaler: MediaQuery.textScalerOf(tester.element(episodeField)),
+      maxLines: 1,
+    )..layout();
+    final double labelWidth = labelPainter.width;
+    labelPainter.dispose();
+
+    final double fieldWidth = tester.getSize(episodeField).width;
+    expect(
+      fieldWidth,
+      greaterThan(96.0),
+      reason: '不得退回写死的 96（更早是 72）——label 随语言/字号/界面缩放变长，'
+          '写死多少都会被裁（BUG-1184）',
+    );
+    expect(
+      fieldWidth,
+      greaterThanOrEqualTo(labelWidth),
+      reason: '框宽必须由 label 的实测宽度决定，至少放得下 label 本体',
+    );
+    // 注：本用例跑在对话框真实布局里，拿不到那一行的可用宽度，而宽度上限是行宽的
+    // 四成；加之测试字体（Ahem）每字符整字宽、把 label 量成真实字体的两倍多，所以
+    // 这里只能断言到「不是常数、装得下 label 本体」。「含内边距完整装下」这条性质
+    // 由 test/widgets/narrow_screen_overflow_test.dart 覆盖——那里可以自己给定行宽。
   });
 }
 

--- a/hibiki/test/widgets/narrow_screen_overflow_test.dart
+++ b/hibiki/test/widgets/narrow_screen_overflow_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
 import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
 import 'package:hibiki/src/utils/components/settings_shared.dart';
 import 'package:hibiki/src/utils/components/shelf_card_widgets.dart';
@@ -362,6 +363,114 @@ void main() {
           reason: '宽屏必须零行为变化：三个动作逐个平铺');
       expect(find.byIcon(Icons.sell_outlined), findsOneWidget);
       expect(find.byIcon(Icons.delete_outline), findsOneWidget);
+    });
+  });
+
+  group('集号输入框宽度', () {
+    /// 在给定文字缩放下，量出 [label] 用 bodyLarge 渲染的真实宽度，并取回
+    /// [jimakuEpisodeFieldWidth] 的结果，供逐条断言。
+    Future<({double fieldWidth, double labelWidth})> measure(
+      WidgetTester tester,
+      String label, {
+      double textScale = 1.0,
+      double rowWidth = 1200,
+    }) async {
+      late double fieldWidth;
+      late double labelWidth;
+      await tester.pumpWidget(
+        buildTestApp(
+          MediaQuery(
+            data: MediaQueryData(
+              size: const Size(1280, 800),
+              textScaler: TextScaler.linear(textScale),
+            ),
+            child: Builder(
+              builder: (BuildContext context) {
+                fieldWidth = jimakuEpisodeFieldWidth(
+                  context,
+                  label,
+                  rowWidth: rowWidth,
+                );
+                final TextPainter painter = TextPainter(
+                  text: TextSpan(
+                    text: label,
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                  textDirection: TextDirection.ltr,
+                  textScaler: MediaQuery.textScalerOf(context),
+                  maxLines: 1,
+                )..layout();
+                labelWidth = painter.width;
+                painter.dispose();
+                return const SizedBox.shrink();
+              },
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      return (fieldWidth: fieldWidth, labelWidth: labelWidth);
+    }
+
+    // 用户实报（截图）：宽屏 1920 窗口下 label 仍被裁成「集数···」——这跟屏幕宽窄
+    // 无关，是「用固定像素装一段会变长的文案」。此前写死 96，而中文「集数（可选）」
+    // 与英文 `Episode (optional)` 都超过它。
+    for (final ({String label, String desc}) sample
+        in <({String label, String desc})>[
+      (label: '集数（可选）', desc: '中文'),
+      (label: 'Episode (optional)', desc: '英文'),
+      (label: 'Folge (optional)', desc: '德文'),
+    ]) {
+      testWidgets('${sample.desc} label 完整放得下，不再被裁',
+          (WidgetTester tester) async {
+        final ({double fieldWidth, double labelWidth}) m =
+            await measure(tester, sample.label);
+        expect(
+          m.fieldWidth,
+          greaterThanOrEqualTo(m.labelWidth + kJimakuEpisodeFieldChrome),
+          reason: '框宽必须由 label 的实测宽度决定；写死 96 时 ${sample.desc} label '
+              '（实测 ${m.labelWidth.toStringAsFixed(1)}px）放不下（BUG-1184）',
+        );
+      });
+    }
+
+    testWidgets('界面放大时跟着变宽（旧的写死 96 正是栽在这里）', (WidgetTester tester) async {
+      final ({double fieldWidth, double labelWidth}) base =
+          await measure(tester, '集数（可选）');
+      final ({double fieldWidth, double labelWidth}) scaled =
+          await measure(tester, '集数（可选）', textScale: 1.5);
+      expect(scaled.fieldWidth, greaterThan(base.fieldWidth));
+      expect(
+        scaled.fieldWidth,
+        greaterThanOrEqualTo(scaled.labelWidth + kJimakuEpisodeFieldChrome),
+      );
+    });
+
+    testWidgets('窄行里有上限，不会把左边的搜索词输入框挤没', (WidgetTester tester) async {
+      const double rowWidth = 320;
+      final ({double fieldWidth, double labelWidth}) m = await measure(
+        tester,
+        'Episodennummer (optional, mehrere durch Komma getrennt)',
+        rowWidth: rowWidth,
+      );
+      expect(
+        m.fieldWidth,
+        lessThanOrEqualTo(rowWidth * 0.4),
+        reason: '上限本身也不写死像素——取整行宽的四成，窄屏才真正起保护作用',
+      );
+    });
+
+    testWidgets('行够宽时上限不再是限制，长译文照样完整显示', (WidgetTester tester) async {
+      const String longLabel =
+          'Episodennummer (optional, mehrere durch Komma getrennt)';
+      // 测试字体（Ahem）每个字符都是整字宽，这段 label 被量成真实字体的两倍多；
+      // 行宽给足即可表达「上限只在窄行起作用」，与真实字体下的结论一致。
+      final ({double fieldWidth, double labelWidth}) m =
+          await measure(tester, longLabel, rowWidth: 4000);
+      expect(
+        m.fieldWidth,
+        greaterThanOrEqualTo(m.labelWidth + kJimakuEpisodeFieldChrome),
+      );
     });
   });
 

--- a/hibiki/test/widgets/narrow_screen_overflow_test.dart
+++ b/hibiki/test/widgets/narrow_screen_overflow_test.dart
@@ -472,6 +472,29 @@ void main() {
         greaterThanOrEqualTo(m.labelWidth + kJimakuEpisodeFieldChrome),
       );
     });
+
+    // rowWidth 现在是必填的（不再有「取不到就退回 260」的默认值，那等于给
+    // BUG-1184 留一条走回去的路）。无界约束下 Row 给出的就是 double.infinity，
+    // 此时同一行里不存在会被挤没的邻居，上限没有任何职责——必须彻底不设上限，
+    // 而不是换回一个像素常数（260 会把下面这段 label 重新裁掉）。
+    testWidgets('无界行宽时不设上限，长 label 照样完整显示', (WidgetTester tester) async {
+      const String longLabel =
+          'Episodennummer (optional, mehrere durch Komma getrennt)';
+      final ({double fieldWidth, double labelWidth}) m = await measure(
+        tester,
+        longLabel,
+        rowWidth: double.infinity,
+      );
+      expect(m.fieldWidth.isFinite, isTrue, reason: '框宽本身必须是有限值');
+      expect(
+        m.fieldWidth,
+        greaterThanOrEqualTo(m.labelWidth + kJimakuEpisodeFieldChrome),
+        reason: '无界行里 label 多长就多宽；退回任何像素常数都会重新裁字（BUG-1184）',
+      );
+      // 守住「不是悄悄换了个更大的常数」：这段 label 的实测宽度远超任何历史兜底值
+      // （72 / 96 / 260），所以结果必须真的跟着 label 走。
+      expect(m.fieldWidth, greaterThan(260.0));
+    });
   });
 
   group('书架卡标题 footer', () {


### PR DESCRIPTION
接 #495（已合并）的补漏。用户贴图指出：**1920 宽的窗口**下，下载页「发现」里的集号输入框 label 仍被裁成「集数···」。

我在 #495 收尾时把这条列进了「未纳入（影响面较小）」——判断错了。它跟屏幕宽窄根本无关，**任何窗口宽度下都裁**。

## 根因不是「96 太小」

是**用固定像素装一段会变长的文案**。这处代码先后写死过两个数字：

- 最早 `width: 72`；
- 后来改成 `width: 96`，注释写着「72 在界面缩放 >1 时装不下『集号』label，会截成『集…』」。

也就是说上一次的修法，是在同一个错误里换一个更大的数字。可 label 本身是会变的——中文「集数（可选）」是 6 个全角字，英文 `Episode (optional)` 更长，再乘上界面缩放与系统字号，96 一样不够。写死多少都会在某个语言 / 某个缩放下被裁。

## 改法

宽度必须由 label 决定，而不是反过来指望 label 挤进某个常数：

- 用 `TextPainter` 量出 label 在当前语言/字号/文字缩放下的**实际**宽度，加上 `InputDecoration` 的水平内边距与集号本身的输入宽度。
- **上限同样不写死像素**：取整行可用宽的四成（调用点用 `LayoutBuilder` 拿行宽）。宽屏上四成足够放下任何译文；窄屏上它才真正起到「不把左边的搜索词输入框挤没」的保护作用。

## 守卫测试换了锚点

原来的用例名就叫「集号框宽 96」，断言的是 `width == 96` —— 那等于把上一次的补丁数字焊死，下次 label 一变长照样红不了。现在断言的是**性质**：

- `anime_download_dialog_discovery_ux_test`：不是常数（`> 96`）、放得下 label 本体。这个用例跑在对话框真实布局里拿不到行宽，所以只能断言到这个强度，注释里写明了原因。
- `narrow_screen_overflow_test`：新增 6 个用例，能自己给定行宽，覆盖中文/英文/德文 label 完整放下、界面放大时跟着变宽、窄行有上限保护、行够宽时上限不再是限制。

## 验证

- `flutter analyze`（含 test）：No issues found。
- 相关测试全绿；基底已 rebase 到当前 `develop`（先前基于旧基底的 diff 会误删 156 个文件，已重建分支避免）。

BUG-1184 已补记根因 15 与这次误判的教训：把一条已经定位到的显示不全推迟为「影响面较小」，前提是真的确认过它只在极端条件下出现——这条我没确认就推迟了。

https://claude.ai/code/session_01Q9amMdjZ5SzmXBJMapgBpD