### PR TITLE
refactor(sync): 互联统一层续作——能力分级 / 样板收敛 / wire format 黄金守卫 (TODO-2119/2120)

### DIFF
--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -75,7 +75,6 @@ import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_progress_banner.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
-import 'package:hibiki/src/sync/video_manifest.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki/src/utils/components/batch_tag_dialog_frame.dart';
 import 'package:hibiki/src/utils/cover_image.dart';
@@ -151,7 +150,28 @@ class HomeVideoPage extends BaseModuleTabPage {
 class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   Future<List<VideoBookRow>>? _future;
   Future<_RemoteVideoState?>? _remoteFuture;
-  RemoteVideoClient? _remoteVideoClient;
+
+  /// 当前远端视频来源：互联 host live 库 或 云盘目录，**至多一个**（TODO-2119）。
+  ///
+  /// 此前是 `_remoteVideoClient` + `_cloudRemoteVideoClient` 两个互斥 nullable 字段，
+  /// 每条下载/封面/字幕路径都要 `if (cloud != null) ... else ...` 分派，两个字段还可能
+  /// 被写得不同步。收成一个之后「谁是当前源」只有一个真相，能力差异改由类型系统表达：
+  /// 只有 [RemoteVideoClient]（live）才有流播/字幕/断点，见 [_liveVideoClient]。
+  RemoteVideoSource? _remoteVideoSource;
+
+  /// 当前源的 live 能力视图；云盘源在这里是 null。拿不到它的地方**编译期**就调不出
+  /// 流播/字幕/断点方法，而不是运行时抛异常。
+  RemoteVideoClient? get _remoteVideoClient {
+    final RemoteVideoSource? source = _remoteVideoSource;
+    return source is RemoteVideoClient ? source : null;
+  }
+
+  /// 当前源的云盘视图；互联源在这里是 null。仅用于云盘独有的收尾动作
+  /// （下载后按资产名取封面，见 [_registerDownloadedCloudVideo]）。
+  CloudRemoteVideoClient? get _cloudRemoteVideoClient {
+    final RemoteVideoSource? source = _remoteVideoSource;
+    return source is CloudRemoteVideoClient ? source : null;
+  }
 
   /// 远端清单的共享 TTL 缓存（BUG-1180）。与书架 / 首页 dashboard 同一实例
   /// （app 级 provider），切 tab 不再必然重打一轮网络。
@@ -166,11 +186,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 封面自愈 / 进度回写等纯列更新（集合不变）跳过，避免写回→重刷环。null=尚未收到
   /// 首个事件（首事件仅登记基线，不刷——initState 已首载）。
   Set<String>? _knownVideoUids;
-
-  /// 多端库联合视图 §2.2/§2.6：云后端（Google Drive 等）的云视频目录 client。互联
-  /// （hibikiServer）与云后端互斥——一台设备只配一种后端，故 [_remoteVideoClient]（互联）
-  /// 与本字段（云）至多一个非空，[_downloadRemote] 据此分派下载路径。
-  CloudRemoteVideoClient? _cloudRemoteVideoClient;
 
   /// 视频卡片拖放命中注册表：每张 [CardDropZone] 注册自身几何，拖放时按屏幕坐标
   /// 命中查找目标视频卡（字幕外挂到该视频）。范型=VideoBookRow。
@@ -533,63 +548,29 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }) async {
     _remoteGateAtLastLoad = _shouldLoadRemoteVideos;
     if (!_shouldLoadRemoteVideos) {
-      _remoteVideoClient = null;
-      _cloudRemoteVideoClient = null;
+      _remoteVideoSource = null;
       return null;
     }
-    final RemoteVideoClient? client = await _resolveRemoteVideoClient();
-    _remoteVideoClient = client;
-    if (client != null) {
-      // 互联后端：host live 库直接下发 RemoteVideoInfo。
-      _cloudRemoteVideoClient = null;
-      try {
-        // BUG-1180：经共享缓存取清单——切回视频 tab（[onTabActivated]）不再必然打一轮
-        // 网络，TTL 内直接复用。缓存只包住「问对端要清单」这一步，下面的本地库查询与
-        // 去重仍每次照跑，本地新增/删除的视频立即反映在混排网格里。
-        final List<RemoteVideoInfo> videos = await _remoteCache.read(
-          key: RemoteLibraryCacheKeys.videos,
-          forceRefresh: forceRefresh,
-          fetch: client.listRemoteVideos,
-        );
-        // #6: 远端与本地是同一视频时（同 bookUid）不在混排网格重复展示。
-        final List<VideoBookRow> localVideos = await widget.repo.listAll();
-        final Set<String> localUids =
-            localVideos.map((VideoBookRow r) => r.bookUid).toSet();
-        return _RemoteVideoState(
-          videos: dedupeRemoteVideos(remote: videos, localBookUids: localUids),
-        );
-      } catch (e) {
-        // spec §2.4 离线语义：拉取失败 → 占位卡不出现（failed 门控），只剩本地库。
-        // 原始异常只落 debugPrint 供排查；显式下拉刷新时的用户可见反馈用本地化友好
-        // 文案（见 _pullToRefresh），不把 TimeoutException 等开发者文本泄漏进 UI。
-        debugPrint('[home-video] remote video list failed: $e');
-        return _RemoteVideoState(
-          videos: const <RemoteVideoInfo>[],
-          failed: true,
-        );
-      }
-    }
-
-    // 云后端（§2.2/§2.6）：读 `__videos__/videos.json` 清单，把云视频条目适配成
-    // RemoteVideoInfo 混排进主网格（云角标/排序/散卡降级既有逻辑自动生效）。
-    final CloudRemoteVideoClient? cloud =
+    // TODO-2119：互联优先、否则回退云盘；两者都是 [RemoteVideoSource]，所以下面
+    // 「列清单 → 去重 → 出占位卡」这条主干只写一遍，不再按后端类型分叉。
+    final RemoteVideoSource? source = await _resolveRemoteVideoClient() ??
         await _resolveCloudRemoteVideoClient();
-    _cloudRemoteVideoClient = cloud;
-    if (cloud == null) return null;
+    _remoteVideoSource = source;
+    if (source == null) return null;
     try {
-      // 清单不存在（从未有设备上传）→ listRemoteVideos 返回空表；结构非法
-      // （FormatException）向上抛，此处 catch → 本轮云视频不可用（= 只剩本地语义）。
-      // BUG-1180：云清单同样过缓存。云盘 `videos.json` 的读取代价不比互联低（要
-      // ensureNamespace + findAsset + getJsonAsset 三次往返），切页面重读同样冤枉。
-      final List<RemoteVideoManifestEntry> entries = await _remoteCache.read(
-        key: RemoteLibraryCacheKeys.cloudVideos,
+      // BUG-1180：经共享缓存取清单——切回视频 tab（[onTabActivated]）不再必然打一轮
+      // 网络，TTL 内直接复用。缓存只包住「问对端要清单」这一步，下面的本地库查询与
+      // 去重仍每次照跑，本地新增/删除的视频立即反映在混排网格里。
+      //
+      // 两种源共用一个 key：清单已在各自 client 里统一成 List<RemoteVideoInfo>，
+      // 不再有「元素类型不同、共用会 cast 崩」的问题（TODO-2119 之前必须分槽）。
+      // 换对端/换后端时由会话身份 revision 驱动 invalidateAll（BUG-1180），不会串味。
+      final List<RemoteVideoInfo> videos = await _remoteCache.read(
+        key: RemoteLibraryCacheKeys.videos,
         forceRefresh: forceRefresh,
-        fetch: cloud.listRemoteVideos,
+        fetch: source.listRemoteVideos,
       );
-      final List<RemoteVideoInfo> videos = <RemoteVideoInfo>[
-        for (final RemoteVideoManifestEntry e in entries)
-          _cloudManifestToRemoteVideoInfo(e),
-      ];
+      // #6: 远端与本地是同一视频时（同 bookUid）不在混排网格重复展示。
       final List<VideoBookRow> localVideos = await widget.repo.listAll();
       final Set<String> localUids =
           localVideos.map((VideoBookRow r) => r.bookUid).toSet();
@@ -597,29 +578,16 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         videos: dedupeRemoteVideos(remote: videos, localBookUids: localUids),
       );
     } catch (e) {
-      debugPrint('[home-video] cloud video manifest failed: $e');
+      // spec §2.4 离线语义：拉取失败 → 占位卡不出现（failed 门控），只剩本地库。
+      // 云盘侧清单结构非法（FormatException）也落这里 → 本轮云视频不可用。
+      // 原始异常只落 debugPrint 供排查；显式下拉刷新时的用户可见反馈用本地化友好
+      // 文案（见 _pullToRefresh），不把 TimeoutException 等开发者文本泄漏进 UI。
+      debugPrint('[home-video] remote video list failed: $e');
       return _RemoteVideoState(
         videos: const <RemoteVideoInfo>[],
         failed: true,
       );
     }
-  }
-
-  /// 把云视频清单条目（[RemoteVideoManifestEntry]）适配成主网格占位卡消费的
-  /// [RemoteVideoInfo]。云清单只带 uid/title/大小/importedAt/封面资产名——无外挂字幕、
-  /// 无远端进度、无合集归属（云视频占位永远散卡，与 §2.3 host 合集归属互不影响），
-  /// 故这些字段取缺省。封面走下载时的 [CloudRemoteVideoClient.getRemoteVideoCover]，
-  /// 占位阶段用占位图（不预下封面），因此这里不设 coverPath/coverUrl。
-  RemoteVideoInfo _cloudManifestToRemoteVideoInfo(RemoteVideoManifestEntry e) {
-    return RemoteVideoInfo(
-      id: e.uid,
-      title: e.title,
-      sizeBytes: e.sizeBytes,
-      // tags 稳健档：把清单条目的标签 LWW 时钟带进 RemoteVideoInfo，供下载后
-      // mergeRemoteVideoTags 按名 max(add) vs max(removed) 解析（删除/改名传播）。
-      tagsAddedAt: e.tagsAddedAt,
-      tagTombstones: e.tagTombstones,
-    );
   }
 
   /// 多端库联合视图（spec §2.1/§2.4/§2.5）：解析可混排进主网格的远端占位视频。
@@ -1344,10 +1312,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   }
 
   Future<void> _downloadRemote(RemoteVideoInfo video) async {
-    final RemoteVideoClient? client = _remoteVideoClient;
-    final CloudRemoteVideoClient? cloud = _cloudRemoteVideoClient;
+    final RemoteVideoSource? source = _remoteVideoSource;
     // #3: 服务不可达 / 未鉴权时给明确提示，不再静默 return（用户点了像没反应）。
-    if (client == null && cloud == null) {
+    if (source == null) {
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(t.remote_video_unavailable)),
@@ -1365,15 +1332,19 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (manager.isRunning(video.id)) return;
 
     final File dest = await _remoteDownloadDestination(video);
-    // 互联 vs 云后端分派：互联走 host live 下载 + 字幕；云后端（§2.2/§2.6）走
-    // CloudRemoteVideoClient.getRemoteVideo 拉整文件，收尾登记时无外挂字幕、封面可选。
+    // TODO-2119：下载本身是所有源的共同能力，不再分派——[RemoteVideoSource] 各自
+    // 实现续传口径（互联 host live 引擎 Range + `.part` 可续；云盘整文件重下）。
     // bookUid 用稳定的远端 video.id（与 dedupeRemoteVideos 去重键一致：upsert 同行不
     // 撞键），故下载好的视频立即出现在列表、并从混排占位区去重隐藏。
-    final InterconnectDownloadRunner run = client != null
-        ? (File target, {void Function(double progress)? onProgress}) =>
-            client.downloadRemoteVideo(video.id, target, onProgress: onProgress)
-        : (File target, {void Function(double progress)? onProgress}) =>
-            cloud!.getRemoteVideo(video.id, target, onProgress: onProgress);
+    Future<void> run(
+      File target, {
+      void Function(double progress)? onProgress,
+    }) =>
+        source.downloadRemoteVideo(video.id, target, onProgress: onProgress);
+    // 收尾登记仍按源分流：互联要回填外挂字幕 + host 断点，云盘要按资产名取封面、
+    // 且没有字幕/进度可回填。这是两种源**真实**的能力差异，不是样板分支。
+    final CloudRemoteVideoClient? cloud = _cloudRemoteVideoClient;
+    final RemoteVideoClient? client = _remoteVideoClient;
     final InterconnectDownloadComplete onComplete = client != null
         ? (File downloaded) =>
             _registerDownloadedVideo(client, video, downloaded)

--- a/hibiki/lib/src/sync/cloud_remote_video_client.dart
+++ b/hibiki/lib/src/sync/cloud_remote_video_client.dart
@@ -1,6 +1,10 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart'
+    show RemoteVideoInfo;
+import 'package:hibiki/src/sync/remote_video_client.dart'
+    show RemoteVideoSource;
 import 'package:hibiki/src/sync/sync_asset_store.dart';
 import 'package:hibiki/src/sync/sync_backend.dart' show SyncBackendError;
 import 'package:hibiki/src/sync/sync_orchestrator.dart'
@@ -20,7 +24,7 @@ import 'package:hibiki/src/sync/video_manifest.dart';
 /// [backend] **必须**是 `resolveSyncBackend` 的产物（含 `ObfuscatingSyncBackend`
 /// 解混淆装饰层），否则下载下来的视频/封面是混淆字节。仅需资产存取能力，故按更窄的
 /// [SyncAssetStore] 契约声明依赖（`SyncBackend` 是其子类型，直接传入即可）。
-class CloudRemoteVideoClient {
+class CloudRemoteVideoClient implements RemoteVideoSource {
   CloudRemoteVideoClient({required this.backend});
 
   /// 远端资产存取层；务必是 `resolveSyncBackend` 的产物（带解混淆装饰层）。
@@ -29,7 +33,10 @@ class CloudRemoteVideoClient {
   /// 读 `__videos__/videos.json` 目录清单，返回全部云视频条目（uid/title/大小/
   /// importedAt/videoAsset/coverAsset）。命名空间或清单缺失（从未有设备上传）→ 空表。
   /// 清单结构非法（[FormatException]）向上抛，交调用方按「本轮云视频不可用」降级。
-  Future<List<RemoteVideoManifestEntry>> listRemoteVideos() async {
+  ///
+  /// 这是**清单层**视图（同步编排、上传去重等要看 `videoAsset`/`coverAsset` 资产名）；
+  /// 库页消费的是 [listRemoteVideos] 的 [RemoteVideoInfo] 视图。
+  Future<List<RemoteVideoManifestEntry>> listRemoteVideoManifest() async {
     final String ns = await backend.ensureNamespace(kSyncVideosNamespace);
     final AssetEntry? asset =
         await backend.findAsset(ns, kSyncVideosManifestName);
@@ -38,6 +45,45 @@ class CloudRemoteVideoClient {
     if (json == null) return const <RemoteVideoManifestEntry>[];
     return RemoteVideoManifest.fromJson(json).videos;
   }
+
+  /// [RemoteVideoSource] 视图：把云清单条目适配成库页主网格消费的 [RemoteVideoInfo]。
+  ///
+  /// 适配逻辑此前长在 `home_video_page.dart` 里（`_cloudManifestToRemoteVideoInfo`），
+  /// 于是给 [RemoteVideoInfo] 加字段时必须记得回去改页面，漏改则云侧该字段永远是空的
+  /// （TODO-2119）。DTO 知识归 client 所有，页面不该知道 manifest 长什么样。
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async {
+    return <RemoteVideoInfo>[
+      for (final RemoteVideoManifestEntry e in await listRemoteVideoManifest())
+        _manifestToInfo(e),
+    ];
+  }
+
+  /// 云清单只带 uid/title/大小/importedAt/封面资产名——无外挂字幕、无远端进度、
+  /// 无合集归属（云视频占位永远散卡，与 §2.3 host 合集归属互不影响），故这些字段取
+  /// 缺省。封面走下载时的 [getRemoteVideoCover]，占位阶段用占位图（不预下封面），
+  /// 因此这里不设 coverPath/coverUrl。
+  RemoteVideoInfo _manifestToInfo(RemoteVideoManifestEntry e) {
+    return RemoteVideoInfo(
+      id: e.uid,
+      title: e.title,
+      sizeBytes: e.sizeBytes,
+      // tags 稳健档：把清单条目的标签 LWW 时钟带进 RemoteVideoInfo，供下载后
+      // mergeRemoteVideoTags 按名 max(add) vs max(removed) 解析（删除/改名传播）。
+      tagsAddedAt: e.tagsAddedAt,
+      tagTombstones: e.tagTombstones,
+    );
+  }
+
+  /// [RemoteVideoSource] 视图的下载入口；云盘就是整文件重下（无 Range 续传），
+  /// 实现委托给既有的 [getRemoteVideo]。
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) =>
+      getRemoteVideo(id, dest, onProgress: onProgress);
 
   /// 把 [uid] 对应的视频文件资产下载到 [destination]。清单里无此 uid，或清单记录的
   /// 视频资产在命名空间下已不存在 → 抛 [SyncBackendError]（调用方提示下载失败）。
@@ -65,7 +111,7 @@ class CloudRemoteVideoClient {
   }
 
   Future<RemoteVideoManifestEntry> _requireEntry(String uid) async {
-    for (final RemoteVideoManifestEntry e in await listRemoteVideos()) {
+    for (final RemoteVideoManifestEntry e in await listRemoteVideoManifest()) {
       if (e.uid == uid) return e;
     }
     throw SyncBackendError('remote video not found in manifest: $uid');

--- a/hibiki/lib/src/sync/hibiki_sync_server.dart
+++ b/hibiki/lib/src/sync/hibiki_sync_server.dart
@@ -1163,6 +1163,91 @@ class HibikiSyncServer {
     });
   }
 
+  /// HBK-AUDIT-012 路径穿越闸门：资产名绝不能含路径分隔符或 `..`，否则能逃出 host
+  /// 的资产根目录（DELETE 最危险）。合法返回 null；非法直接返回要回给客户端的响应。
+  ///
+  /// 此前这段判断在四个域 + 三个 position/progress 子路由里逐字重复了 7 遍。安全闸门
+  /// 靠复制粘贴维持，抄漏一处就是真漏洞——收敛成一处后新端点只能显式调用它。
+  ///
+  /// 注意：视频域**不用**本闸门——视频 id 形如 `video/xxx`，合法地含 `/`，它有自己的
+  /// `_extractVideoId` 校验。不要把视频接进来。
+  shelf.Response? _rejectUnsafeAssetId(String id, String label) {
+    if (id.isEmpty) return shelf.Response.notFound('Missing $label');
+    if (id.contains('/') || id.contains('\\') || id.contains('..')) {
+      return shelf.Response.forbidden('Invalid $label');
+    }
+    return null;
+  }
+
+  /// 「按名字取 / 存 / 删一个资产包」端点的共同骨架：词典 / 书 / 本地音频 / 有声书
+  /// 四个域在这一层**逐字相同**，只差叫什么名字、临时文件用什么扩展名、调 service
+  /// 的哪三个方法。
+  ///
+  /// 此前是四份约 60 行的复制粘贴（TODO-2120），加一个新媒体域就要再抄一遍——而这
+  /// 段代码里含导出缓存 + ETag/Range 续传、上传临时目录的必清理、IOSink 的双重关闭
+  /// 保护，抄漏任何一处都是真事故（泄漏临时目录 / 续传验证器失效 / socket 不回收）。
+  ///
+  /// [id] 必须已经过 [_rejectUnsafeAssetId]。
+  Future<shelf.Response> _serveAssetPackage(
+    shelf.Request request,
+    String method, {
+    required String id,
+    required String cacheKind,
+    required String notFoundMessage,
+    required String tempPrefix,
+    required String tempExtension,
+    required Future<File> Function() export,
+    required Future<void> Function(File tmp) import,
+    required Future<void> Function() delete,
+  }) async {
+    switch (method) {
+      case 'GET':
+        // 经导出缓存 + Range/If-Range：TTL 内的续传钉在同一份字节上（ETag 作验证器）；
+        // 旧 client 不发 Range 收到 200 全量，行为不变。扩展名保留 → Content-Type
+        // 仍由 _guessContentType 按扩展名判定。
+        File file;
+        try {
+          file = await _exportCache.obtain(cacheKind, id, export);
+        } on StateError {
+          return shelf.Response.notFound(notFoundMessage);
+        }
+        return serveFileWithRange(file, request,
+            etag: ExportPackageCache.etagFor(file));
+
+      case 'PUT':
+        final Directory tmpDir =
+            Directory.systemTemp.createTempSync(tempPrefix);
+        final File tmp = File(p.join(tmpDir.path, '$id$tempExtension'));
+        final IOSink sink = tmp.openWrite();
+        try {
+          await request.read().forEach(sink.add);
+          await sink.close();
+          await import(tmp);
+          return shelf.Response(200);
+        } catch (e) {
+          try {
+            await sink.close();
+          } catch (_) {
+            // best-effort
+          }
+          return shelf.Response(500, body: 'Import failed: $e');
+        } finally {
+          try {
+            tmpDir.deleteSync(recursive: true);
+          } catch (_) {
+            // best-effort
+          }
+        }
+
+      case 'DELETE':
+        await delete();
+        return shelf.Response(204);
+
+      default:
+        return shelf.Response(405);
+    }
+  }
+
   Future<shelf.Response> _handleLibraryDictionaries(
     shelf.Request request,
     String method,
@@ -1187,63 +1272,23 @@ class HibikiSyncServer {
     // 导致 "Illegal percent encoding in URI"（Dart 不接受非 ASCII 作为
     // decodeComponent 输入）。直接 substring 即可得到正确的词典名。
     final String name = reqPath.substring('/api/library/dictionaries/'.length);
-    if (name.isEmpty) {
-      return shelf.Response.notFound('Missing dictionary name');
-    }
-    // HBK-AUDIT-012: reject path-traversal attempts.  Dictionary names must
-    // never contain path separators or dot-dot sequences; if they did they
-    // could escape the dictionary resource root on the host (DELETE being the
-    // most dangerous).  This single gate covers all three methods below.
-    if (name.contains('/') || name.contains('\\') || name.contains('..')) {
-      return shelf.Response.forbidden('Invalid dictionary name');
-    }
+    // HBK-AUDIT-012 路径穿越闸门（收敛到 _rejectUnsafeAssetId），覆盖下面三个方法。
+    final shelf.Response? unsafe =
+        _rejectUnsafeAssetId(name, 'dictionary name');
+    if (unsafe != null) return unsafe;
 
-    switch (method) {
-      case 'GET':
-        // 经导出缓存 + Range/If-Range（TTL 内续传钉在同一份字节上；旧 client
-        // 不发 Range 收到 200 全量，行为不变）。
-        File file;
-        try {
-          file = await _exportCache.obtain(
-              'dict', name, () => svc.exportDictionary(name));
-        } on StateError {
-          return shelf.Response.notFound('Dictionary not found');
-        }
-        return serveFileWithRange(file, request,
-            etag: ExportPackageCache.etagFor(file));
-
-      case 'PUT':
-        final Directory tmpDir =
-            Directory.systemTemp.createTempSync('hibiki_dict_in');
-        final File tmp = File(p.join(tmpDir.path, '$name.hibikidict'));
-        final IOSink sink = tmp.openWrite();
-        try {
-          await request.read().forEach(sink.add);
-          await sink.close();
-          await svc.importDictionary(tmp);
-          return shelf.Response(200);
-        } catch (e) {
-          try {
-            await sink.close();
-          } catch (_) {
-            // best-effort
-          }
-          return shelf.Response(500, body: 'Import failed: $e');
-        } finally {
-          try {
-            tmpDir.deleteSync(recursive: true);
-          } catch (_) {
-            // best-effort
-          }
-        }
-
-      case 'DELETE':
-        await svc.deleteDictionary(name);
-        return shelf.Response(204);
-
-      default:
-        return shelf.Response(405);
-    }
+    return _serveAssetPackage(
+      request,
+      method,
+      id: name,
+      cacheKind: 'dict',
+      notFoundMessage: 'Dictionary not found',
+      tempPrefix: 'hibiki_dict_in',
+      tempExtension: '.hibikidict',
+      export: () => svc.exportDictionary(name),
+      import: svc.importDictionary,
+      delete: () => svc.deleteDictionary(name),
+    );
   }
 
   Future<shelf.Response> _handleLibraryBooks(
@@ -1273,14 +1318,9 @@ class HibikiSyncServer {
       if (method != 'GET') return shelf.Response(405);
       final String coverBookId = reqPath.substring(
           bookPrefix.length, reqPath.length - coverSuffix.length);
-      if (coverBookId.isEmpty) {
-        return shelf.Response.notFound('Missing book title');
-      }
-      if (coverBookId.contains('/') ||
-          coverBookId.contains('\\') ||
-          coverBookId.contains('..')) {
-        return shelf.Response.forbidden('Invalid book title');
-      }
+      final shelf.Response? unsafeCoverBookId =
+          _rejectUnsafeAssetId(coverBookId, 'book title');
+      if (unsafeCoverBookId != null) return unsafeCoverBookId;
       final File? cover = await _resolveBookCover(svc, coverBookId);
       if (cover == null) return shelf.Response.notFound('Book cover not found');
       return serveFileWithRange(cover, request);
@@ -1293,14 +1333,9 @@ class HibikiSyncServer {
     if (reqPath.startsWith(bookPrefix) && reqPath.endsWith(progressSuffix)) {
       final String progressBookKey = reqPath.substring(
           bookPrefix.length, reqPath.length - progressSuffix.length);
-      if (progressBookKey.isEmpty) {
-        return shelf.Response.notFound('Missing book key');
-      }
-      if (progressBookKey.contains('/') ||
-          progressBookKey.contains('\\') ||
-          progressBookKey.contains('..')) {
-        return shelf.Response.forbidden('Invalid book key');
-      }
+      final shelf.Response? unsafeProgressBookKey =
+          _rejectUnsafeAssetId(progressBookKey, 'book key');
+      if (unsafeProgressBookKey != null) return unsafeProgressBookKey;
       switch (method) {
         case 'GET':
           final RemoteBookProgress progress =
@@ -1328,63 +1363,23 @@ class HibikiSyncServer {
     }
 
     final String bookId = reqPath.substring(bookPrefix.length);
-    if (bookId.isEmpty) {
-      return shelf.Response.notFound('Missing book title');
-    }
-    // HBK-AUDIT-012: reject path-traversal attempts.  Book titles must
-    // never contain path separators or dot-dot sequences.
-    if (bookId.contains('/') ||
-        bookId.contains('\\') ||
-        bookId.contains('..')) {
-      return shelf.Response.forbidden('Invalid book title');
-    }
+    final shelf.Response? unsafe = _rejectUnsafeAssetId(bookId, 'book title');
+    if (unsafe != null) return unsafe;
 
-    switch (method) {
-      case 'GET':
-        // 经导出缓存 + Range/If-Range（.epub 扩展名保留 → Content-Type 仍是
-        // application/epub+zip；见 _guessContentType）。
-        File file;
-        try {
-          file = await _exportCache.obtain(
-              'book', bookId, () => svc.exportBook(bookId));
-        } on StateError {
-          return shelf.Response.notFound('Book not found');
-        }
-        return serveFileWithRange(file, request,
-            etag: ExportPackageCache.etagFor(file));
-
-      case 'PUT':
-        final Directory tmpDir =
-            Directory.systemTemp.createTempSync('hibiki_book_in');
-        final File tmp = File(p.join(tmpDir.path, '$bookId.epub'));
-        final IOSink sink = tmp.openWrite();
-        try {
-          await request.read().forEach(sink.add);
-          await sink.close();
-          await svc.importBook(tmp);
-          return shelf.Response(200);
-        } catch (e) {
-          try {
-            await sink.close();
-          } catch (_) {
-            // best-effort
-          }
-          return shelf.Response(500, body: 'Import failed: $e');
-        } finally {
-          try {
-            tmpDir.deleteSync(recursive: true);
-          } catch (_) {
-            // best-effort
-          }
-        }
-
-      case 'DELETE':
-        await svc.deleteBook(bookId);
-        return shelf.Response(204);
-
-      default:
-        return shelf.Response(405);
-    }
+    // 注：`.epub` 扩展名保留 → Content-Type 仍是 application/epub+zip
+    // （见 _guessContentType）。
+    return _serveAssetPackage(
+      request,
+      method,
+      id: bookId,
+      cacheKind: 'book',
+      notFoundMessage: 'Book not found',
+      tempPrefix: 'hibiki_book_in',
+      tempExtension: '.epub',
+      export: () => svc.exportBook(bookId),
+      import: svc.importBook,
+      delete: () => svc.deleteBook(bookId),
+    );
   }
 
   Map<String, Object?> _remoteBookJsonForRequest(
@@ -1441,61 +1436,22 @@ class HibikiSyncServer {
     // reqPath 已在 _handleRequest 经 Uri.decodeFull 解码，此处无需再解码。
     final String displayName =
         reqPath.substring('/api/library/localaudio/'.length);
-    if (displayName.isEmpty) {
-      return shelf.Response.notFound('Missing displayName');
-    }
-    // HBK-AUDIT-012: reject path-traversal attempts.
-    if (displayName.contains('/') ||
-        displayName.contains('\\') ||
-        displayName.contains('..')) {
-      return shelf.Response.forbidden('Invalid displayName');
-    }
+    final shelf.Response? unsafe =
+        _rejectUnsafeAssetId(displayName, 'displayName');
+    if (unsafe != null) return unsafe;
 
-    switch (method) {
-      case 'GET':
-        // 经导出缓存 + Range/If-Range。
-        File file;
-        try {
-          file = await _exportCache.obtain('localaudio', displayName,
-              () => svc.exportLocalAudio(displayName));
-        } on StateError {
-          return shelf.Response.notFound('Local audio not found');
-        }
-        return serveFileWithRange(file, request,
-            etag: ExportPackageCache.etagFor(file));
-
-      case 'PUT':
-        final Directory tmpDir =
-            Directory.systemTemp.createTempSync('hibiki_localaudio_in');
-        final File tmp = File(p.join(tmpDir.path, '$displayName.localaudio'));
-        final IOSink sink = tmp.openWrite();
-        try {
-          await request.read().forEach(sink.add);
-          await sink.close();
-          await svc.importLocalAudio(tmp);
-          return shelf.Response(200);
-        } catch (e) {
-          try {
-            await sink.close();
-          } catch (_) {
-            // best-effort
-          }
-          return shelf.Response(500, body: 'Import failed: $e');
-        } finally {
-          try {
-            tmpDir.deleteSync(recursive: true);
-          } catch (_) {
-            // best-effort
-          }
-        }
-
-      case 'DELETE':
-        await svc.deleteLocalAudio(displayName);
-        return shelf.Response(204);
-
-      default:
-        return shelf.Response(405);
-    }
+    return _serveAssetPackage(
+      request,
+      method,
+      id: displayName,
+      cacheKind: 'localaudio',
+      notFoundMessage: 'Local audio not found',
+      tempPrefix: 'hibiki_localaudio_in',
+      tempExtension: '.localaudio',
+      export: () => svc.exportLocalAudio(displayName),
+      import: svc.importLocalAudio,
+      delete: () => svc.deleteLocalAudio(displayName),
+    );
   }
 
   Future<shelf.Response> _handleLibraryAudiobooks(
@@ -1528,14 +1484,9 @@ class HibikiSyncServer {
         reqPath.endsWith(positionSuffix)) {
       final String positionBookKey = reqPath.substring(
           audiobookPrefix.length, reqPath.length - positionSuffix.length);
-      if (positionBookKey.isEmpty) {
-        return shelf.Response.notFound('Missing bookKey');
-      }
-      if (positionBookKey.contains('/') ||
-          positionBookKey.contains('\\') ||
-          positionBookKey.contains('..')) {
-        return shelf.Response.forbidden('Invalid bookKey');
-      }
+      final shelf.Response? unsafePositionBookKey =
+          _rejectUnsafeAssetId(positionBookKey, 'bookKey');
+      if (unsafePositionBookKey != null) return unsafePositionBookKey;
       // 先确认该有声书在 host DB 真实存在，防任意 key 写脏 prefs；与视频 position
       // 先 resolveVideoFile 同语义。BUG-471a：改用廉价的 audiobookExists（单次 DB
       // 查询）替代旧的 exportAudiobook 打包探测——旧实现每次 GET/PUT position 都把整
@@ -1578,61 +1529,23 @@ class HibikiSyncServer {
     }
 
     final String bookKey = reqPath.substring('/api/library/audiobooks/'.length);
-    if (bookKey.isEmpty) {
-      return shelf.Response.notFound('Missing bookKey');
-    }
-    // HBK-AUDIT-012: reject path-traversal attempts.
-    if (bookKey.contains('/') ||
-        bookKey.contains('\\') ||
-        bookKey.contains('..')) {
-      return shelf.Response.forbidden('Invalid bookKey');
-    }
+    final shelf.Response? unsafe = _rejectUnsafeAssetId(bookKey, 'bookKey');
+    if (unsafe != null) return unsafe;
 
-    switch (method) {
-      case 'GET':
-        // 经导出缓存 + Range/If-Range（大有声书包中断续传的最大受益者）。
-        File file;
-        try {
-          file = await _exportCache.obtain(
-              'audiobook', bookKey, () => svc.exportAudiobook(bookKey));
-        } on StateError {
-          return shelf.Response.notFound('Audiobook not found');
-        }
-        return serveFileWithRange(file, request,
-            etag: ExportPackageCache.etagFor(file));
-
-      case 'PUT':
-        final Directory tmpDir =
-            Directory.systemTemp.createTempSync('hibiki_audiobook_in');
-        final File tmp = File(p.join(tmpDir.path, '$bookKey.audiobook'));
-        final IOSink sink = tmp.openWrite();
-        try {
-          await request.read().forEach(sink.add);
-          await sink.close();
-          await svc.importAudiobook(tmp, bookKeyOverride: bookKey);
-          return shelf.Response(200);
-        } catch (e) {
-          try {
-            await sink.close();
-          } catch (_) {
-            // best-effort
-          }
-          return shelf.Response(500, body: 'Import failed: $e');
-        } finally {
-          try {
-            tmpDir.deleteSync(recursive: true);
-          } catch (_) {
-            // best-effort
-          }
-        }
-
-      case 'DELETE':
-        await svc.deleteAudiobook(bookKey);
-        return shelf.Response(204);
-
-      default:
-        return shelf.Response(405);
-    }
+    // 有声书包是 Range 续传的最大受益者（包最大）。导入要带 bookKeyOverride：
+    // 落地时必须钉在 URL 上的这个 key，不能让包里的自述 key 改写身份（BUG-414）。
+    return _serveAssetPackage(
+      request,
+      method,
+      id: bookKey,
+      cacheKind: 'audiobook',
+      notFoundMessage: 'Audiobook not found',
+      tempPrefix: 'hibiki_audiobook_in',
+      tempExtension: '.audiobook',
+      export: () => svc.exportAudiobook(bookKey),
+      import: (File tmp) => svc.importAudiobook(tmp, bookKeyOverride: bookKey),
+      delete: () => svc.deleteAudiobook(bookKey),
+    );
   }
 
   // ── 视频端点（P4-2）──────────────────────────────────────────────────────────

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -686,19 +686,44 @@ class InterconnectSyncBackend extends SyncBackend
   }
 
   /// 列出对端 host 当前实时词典清单（直打 `/api/library/dictionaries`）。
-  Future<List<RemoteDictionaryInfo>> listRemoteDictionaries() async {
+  /// 互联「列清单」端点的共同骨架：解析会话 → GET → 逐条 fromJson（TODO-2120）。
+  ///
+  /// 五个域此前各抄一份 12 行的同构代码。**降级与超时必须逐域按现状显式传入**，
+  /// 不能图省事统一给所有域打开：
+  /// - [degradeOn404]：只有 videos / activity 这类**后加的**端点才降级——老 host 没有
+  ///   它们，降级成空表是为了「不因老 server 缺端点让整页占位卡消失或转圈」。词典 /
+  ///   书 / 本地音频 / 有声书是最老的端点，假定必然存在；给它们也加降级，会把「host
+  ///   把库服务关了（404 Library service off）」从可见错误变成静默空列表——那是真实的
+  ///   行为回归，不是「更健壮」。
+  /// - [timeout]：只有 videos / activity 有封顶（host 侧这两个清单可能很慢）。
+  Future<List<T>> _listRemote<T>(
+    String path,
+    T Function(Map<String, Object?> json) parse, {
+    Duration? timeout,
+    bool degradeOn404 = false,
+  }) async {
     await _ensureResolved();
     final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/dictionaries');
-    final HttpClientResponse res = await req.close();
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/dictionaries');
-    final String body = await res.transform(utf8.decoder).join();
+        await _ops!.buildRequest('GET', '$_apiBase$path');
+    final Future<HttpClientResponse> closing = req.close();
+    final HttpClientResponse res =
+        timeout == null ? await closing : await closing.timeout(timeout);
+    if (degradeOn404 && res.statusCode == 404) {
+      await res.drain<void>();
+      return <T>[];
+    }
+    _ops!.checkStatus(res.statusCode, 'GET $path');
+    final Future<String> reading = res.transform(utf8.decoder).join();
+    final String body =
+        timeout == null ? await reading : await reading.timeout(timeout);
     final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteDictionaryInfo>[
-      for (final dynamic e in arr)
-        RemoteDictionaryInfo.fromJson((e as Map).cast<String, Object?>()),
+    return <T>[
+      for (final dynamic e in arr) parse((e as Map).cast<String, Object?>()),
     ];
   }
+
+  Future<List<RemoteDictionaryInfo>> listRemoteDictionaries() =>
+      _listRemote('/api/library/dictionaries', RemoteDictionaryInfo.fromJson);
 
   /// 从对端 host 下载名为 [name] 的词典包到 [destination] 文件。
   Future<void> getRemoteDictionary(
@@ -761,19 +786,8 @@ class InterconnectSyncBackend extends SyncBackend
 
   /// 列出对端 host 当前书库清单（直打 `/api/library/books`）。
   @override
-  Future<List<RemoteBookInfo>> listRemoteBooks() async {
-    await _ensureResolved();
-    final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/books');
-    final HttpClientResponse res = await req.close();
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/books');
-    final String body = await res.transform(utf8.decoder).join();
-    final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteBookInfo>[
-      for (final dynamic e in arr)
-        RemoteBookInfo.fromJson((e as Map).cast<String, Object?>()),
-    ];
-  }
+  Future<List<RemoteBookInfo>> listRemoteBooks() =>
+      _listRemote('/api/library/books', RemoteBookInfo.fromJson);
 
   /// 从对端 host 下载书名为 [title] 的 EPUB 到 [destination] 文件。
   @override
@@ -987,19 +1001,8 @@ class InterconnectSyncBackend extends SyncBackend
   // 与 live books 对称：直打 /api/library/localaudio，不经 WebDAV 暂存。
 
   /// 列出对端 host 当前本地音频来源清单（直打 `/api/library/localaudio`）。
-  Future<List<RemoteLocalAudioInfo>> listRemoteLocalAudio() async {
-    await _ensureResolved();
-    final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/localaudio');
-    final HttpClientResponse res = await req.close();
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/localaudio');
-    final String body = await res.transform(utf8.decoder).join();
-    final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteLocalAudioInfo>[
-      for (final dynamic e in arr)
-        RemoteLocalAudioInfo.fromJson((e as Map).cast<String, Object?>()),
-    ];
-  }
+  Future<List<RemoteLocalAudioInfo>> listRemoteLocalAudio() =>
+      _listRemote('/api/library/localaudio', RemoteLocalAudioInfo.fromJson);
 
   /// 从对端 host 下载 displayName 为 [displayName] 的本地音频库到 [dest] 文件。
   Future<void> getRemoteLocalAudio(
@@ -1059,19 +1062,8 @@ class InterconnectSyncBackend extends SyncBackend
   // 与 live books 对称：直打 /api/library/audiobooks，不经 WebDAV 暂存。
 
   /// 列出对端 host 当前有声书清单（直打 `/api/library/audiobooks`）。
-  Future<List<RemoteAudiobookInfo>> listRemoteAudiobooks() async {
-    await _ensureResolved();
-    final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/audiobooks');
-    final HttpClientResponse res = await req.close();
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/audiobooks');
-    final String body = await res.transform(utf8.decoder).join();
-    final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteAudiobookInfo>[
-      for (final dynamic e in arr)
-        RemoteAudiobookInfo.fromJson((e as Map).cast<String, Object?>()),
-    ];
-  }
+  Future<List<RemoteAudiobookInfo>> listRemoteAudiobooks() =>
+      _listRemote('/api/library/audiobooks', RemoteAudiobookInfo.fromJson);
 
   /// 从对端 host 下载 bookKey 为 [bookKey] 的有声书到 [dest] 文件。
   Future<void> getRemoteAudiobook(
@@ -1215,24 +1207,14 @@ class InterconnectSyncBackend extends SyncBackend
   }
 
   @override
-  Future<List<RemoteVideoInfo>> listRemoteVideos() async {
-    await _ensureResolved();
-    final HttpClientRequest req =
-        await _ops!.buildRequest('GET', '$_apiBase/api/library/videos');
-    final HttpClientResponse res = await req.close().timeout(listTimeout);
-    if (res.statusCode == 404) {
-      await res.drain<void>();
-      return const <RemoteVideoInfo>[]; // 老 host 无视频端点：降级空表，不崩不转圈。
-    }
-    _ops!.checkStatus(res.statusCode, 'GET /api/library/videos');
-    final String body =
-        await res.transform(utf8.decoder).join().timeout(listTimeout);
-    final List<dynamic> arr = jsonDecode(body) as List<dynamic>;
-    return <RemoteVideoInfo>[
-      for (final dynamic e in arr)
-        RemoteVideoInfo.fromJson((e as Map).cast<String, Object?>()),
-    ];
-  }
+
+  /// 老 host 无视频端点 → 404 降级空表（不崩不转圈）；清单可能很慢，故超时封顶。
+  Future<List<RemoteVideoInfo>> listRemoteVideos() => _listRemote(
+        '/api/library/videos',
+        RemoteVideoInfo.fromJson,
+        timeout: listTimeout,
+        degradeOn404: true,
+      );
 
   /// 把本地视频 [file] 上传到对端 host，注册成 bookUid 为 [id] 的视频（client→host，
   /// syncVideoFiles 开关驱动的 live push）。[title] 与原始文件名经 URL-encode 走 header

--- a/hibiki/lib/src/sync/remote_library_cache.dart
+++ b/hibiki/lib/src/sync/remote_library_cache.dart
@@ -166,15 +166,13 @@ class RemoteLibraryCacheKeys {
 
   static const String books = 'books';
 
-  /// 互联 host live 库的视频清单（`List<RemoteVideoInfo>`）。
-  static const String videos = 'videos';
-
-  /// 云盘 `__videos__/videos.json` 目录清单（`List<RemoteVideoManifestEntry>`）。
+  /// 远端视频清单（`List<RemoteVideoInfo>`）。
   ///
-  /// 与 [videos] **必须**分槽：两者元素类型不同（`CloudRemoteVideoClient` 至今不实现
-  /// `RemoteVideoClient`，返回的是 manifest entry 而非 `RemoteVideoInfo`）。共用一个 key
-  /// 会在「互联切云盘」时把上一份缓存按错误类型取出，直接 cast 崩。
-  static const String cloudVideos = 'cloud_videos';
+  /// 互联 host live 库与云盘目录**共用**这一个槽：两种源都实现 `RemoteVideoSource`，
+  /// 清单在各自 client 里已统一成 `RemoteVideoInfo`，不存在元素类型不一致的问题
+  /// （TODO-2119 之前云盘返回的是 manifest entry，被迫分成两个槽，否则换后端时会按
+  /// 错误类型取出缓存直接 cast 崩）。换对端/换后端由 `invalidateAll` 兜底。
+  static const String videos = 'videos';
   static const String audiobooks = 'audiobooks';
   static const String dictionaries = 'dictionaries';
 

--- a/hibiki/lib/src/sync/remote_video_client.dart
+++ b/hibiki/lib/src/sync/remote_video_client.dart
@@ -2,9 +2,42 @@ import 'dart:io';
 
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 
-abstract class RemoteVideoClient {
+/// **任何**远端视频来源都具备的能力：列清单 + 按 id 把整片下载到本地。
+///
+/// 互联 host 的 live 库与云盘的 `__videos__/` 目录都能做到这两件事，所以库页的
+/// 「列清单 → 混排占位卡 → 点击下载入库」这条主干可以只依赖本接口，不必知道背后
+/// 是哪一种源。
+///
+/// **为什么要分成两级**（TODO-2119）——此前只有 [RemoteVideoClient] 一个接口，而
+/// 云盘没有 live host、给不出流播 URL / 外挂字幕 / 跨端断点，于是
+/// `CloudRemoteVideoClient` 干脆**不实现**任何接口，逼得视频页同时持有两个互斥的
+/// nullable 字段，每条下载 / 封面 / 字幕路径都要 `if (cloud != null) ... else ...`，
+/// 还要在页面里手写一个 manifest→DTO 的适配函数（给 `RemoteVideoInfo` 加字段时
+/// 漏改那里，云侧该字段就永远是空的）。
+///
+/// 反过来让云端 `implements RemoteVideoClient` 再把 4 个方法写成抛异常也不对：那只是
+/// 把「能力靠 `is` 判断」换成「调了会抛」，编译器照样拦不住。按能力分级之后，
+/// `source is RemoteVideoClient` 是**类型系统认可**的能力判据——拿不到 live 能力的
+/// 地方根本调不出流播/字幕/断点方法。
+abstract class RemoteVideoSource {
+  /// 列出该源可见的远端视频。云盘源在这里就把目录清单适配成 [RemoteVideoInfo]，
+  /// 消费方（库页）不再需要知道 manifest 长什么样。
   Future<List<RemoteVideoInfo>> listRemoteVideos();
 
+  /// 把 [id] 对应的视频整片下载到 [dest]。
+  ///
+  /// 续传口径按源写实：互联走 host live 下载引擎（Range + `.part`，中断可续）；
+  /// 云盘是整文件重下，失败清残片、无断点续传。
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  });
+}
+
+/// 具备实时流播 / 外挂字幕 / 跨端断点的远端视频源——只有互联 host 的 live 库有这些
+/// 端点（云盘目录只是一堆静态资产，没有服务端能回答这些请求）。
+abstract class RemoteVideoClient extends RemoteVideoSource {
   /// 向 host 换取可直接播放的视频 stream URL。[episodeIndex]>0（TODO-885）请求远端
   /// 播放列表的某一集。
   Future<RemoteVideoStreamUrls> remoteVideoStreamUrls(
@@ -17,12 +50,6 @@ abstract class RemoteVideoClient {
     File dest, {
     int? embeddedStreamIndex,
     int episodeIndex = 0,
-    void Function(double progress)? onProgress,
-  });
-
-  Future<void> downloadRemoteVideo(
-    String id,
-    File dest, {
     void Function(double progress)? onProgress,
   });
 

--- a/hibiki/test/pages/home_video_cloud_download_test.dart
+++ b/hibiki/test/pages/home_video_cloud_download_test.dart
@@ -265,7 +265,30 @@ class _FakeCloudRemoteVideoClient implements CloudRemoteVideoClient {
   SyncAssetStore get backend => throw UnimplementedError();
 
   @override
-  Future<List<RemoteVideoManifestEntry>> listRemoteVideos() async => entries;
+  Future<List<RemoteVideoManifestEntry>> listRemoteVideoManifest() async =>
+      entries;
+
+  /// TODO-2119：[RemoteVideoSource] 视图——清单→DTO 的适配已收进真 client，
+  /// fake 这里照搬同样的映射（页面不再自己适配，所以这份映射必须由 client 侧提供）。
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async => <RemoteVideoInfo>[
+        for (final RemoteVideoManifestEntry e in entries)
+          RemoteVideoInfo(
+            id: e.uid,
+            title: e.title,
+            sizeBytes: e.sizeBytes,
+            tagsAddedAt: e.tagsAddedAt,
+            tagTombstones: e.tagTombstones,
+          ),
+      ];
+
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) =>
+      getRemoteVideo(id, dest, onProgress: onProgress);
 
   @override
   Future<void> getRemoteVideo(

--- a/hibiki/test/pages/unified_collections_architecture_guard_test.dart
+++ b/hibiki/test/pages/unified_collections_architecture_guard_test.dart
@@ -317,18 +317,33 @@ void main() {
         reason: '云视频目录/下载必须经 CloudRemoteVideoClient');
     expect(homeSrc.contains('_resolveCloudRemoteVideoClient'), isTrue,
         reason: '云后端分支：resolveSyncBackend 产物包进 CloudRemoteVideoClient');
-    expect(homeSrc.contains('_cloudManifestToRemoteVideoInfo'), isTrue,
-        reason: '云清单条目须经适配函数转成 RemoteVideoInfo 混排');
+    // TODO-2119：清单→RemoteVideoInfo 的适配已从页面搬进 CloudRemoteVideoClient
+    // （原 `_cloudManifestToRemoteVideoInfo`）。页面现在只认 RemoteVideoSource 契约，
+    // 连 RemoteVideoManifestEntry 这个类型都不该出现——给 RemoteVideoInfo 加字段时
+    // 不必再回来改页面，漏改导致「云侧该字段永远为空」的坑就此消失。
+    expect(homeSrc.contains('_cloudManifestToRemoteVideoInfo'), isFalse,
+        reason: '清单→DTO 适配必须在 CloudRemoteVideoClient 里，不得回流页面');
+    expect(homeSrc.contains('RemoteVideoManifestEntry'), isFalse,
+        reason: '页面不得再感知清单条目类型（收敛到 CloudRemoteVideoClient）');
     // 页面不得自造清单解析（RemoteVideoManifest.fromJson 只应在 client 里）。
     expect(homeSrc.contains('RemoteVideoManifest.fromJson'), isFalse,
         reason: '页面不得自己解析 videos.json 清单（收敛到 CloudRemoteVideoClient）');
     expect(homeSrc.contains('kSyncVideosManifestName'), isFalse,
         reason: '页面不得直接触碰清单资产名（收敛到 CloudRemoteVideoClient）');
-    // 云视频下载走 CloudRemoteVideoClient.getRemoteVideo（整文件），登记时不双重导入。
-    expect(homeSrc.contains('getRemoteVideo('), isTrue,
-        reason: '云视频下载必须经 CloudRemoteVideoClient.getRemoteVideo 拉整文件');
+    // 下载统一走 RemoteVideoSource.downloadRemoteVideo：云盘实现内部委托给
+    // getRemoteVideo 拉整文件（无 Range 续传），互联走 host live 引擎。页面不再按
+    // 后端类型分派下载路径。
+    expect(homeSrc.contains('source.downloadRemoteVideo('), isTrue,
+        reason: '远端下载必须经 RemoteVideoSource.downloadRemoteVideo 统一入口');
     expect(homeSrc.contains('_registerDownloadedCloudVideo'), isTrue,
         reason: '云视频下载后必须建 VideoBooks 行（勿双重导入）');
+    // 两个互斥 nullable client 字段已收成一个 source（TODO-2119）：能力差异由类型
+    // 系统表达（source is RemoteVideoClient），不再靠「哪个字段非空」判后端。
+    expect(homeSrc.contains('CloudRemoteVideoClient? _cloudRemoteVideoClient;'),
+        isFalse,
+        reason: '不得恢复「互联 client + 云 client」两个互斥字段（TODO-2119 回归）');
+    expect(homeSrc.contains('RemoteVideoSource? _remoteVideoSource;'), isTrue,
+        reason: '当前远端视频来源必须是单一真相字段');
   });
 
   test('多端库联合视图 §2.3 任务10：合集行成员占位归属解析不到 → 散卡降级（不硬造行）', () {

--- a/hibiki/test/sync/hibiki_sync_server_asset_gate_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_asset_gate_test.dart
@@ -1,0 +1,95 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// HBK-AUDIT-012 路径穿越闸门 + 资产包端点骨架的收敛守卫（TODO-2120）。
+///
+/// 背景——「按名字取/存/删一个资产包」这层此前在词典 / 书 / 本地音频 / 有声书四个域
+/// 里逐字复制了四份（各约 60 行），路径穿越判断更是连同 position/progress 子路由一共
+/// 抄了 7 遍。这段代码里含导出缓存 + ETag/Range 续传、上传临时目录的必清理、IOSink
+/// 双重关闭保护，以及那道**安全闸门**——靠复制粘贴维持，加一个新媒体域就要再抄一遍，
+/// 抄漏任何一处都是真事故（泄漏临时目录 / 续传验证器失效 / 或者直接是路径穿越漏洞）。
+///
+/// 行为层面的 403 断言已由 `hibiki_sync_server_audio_test.dart`（localaudio /
+/// audiobooks 两域的 GET/DELETE `%2e%2e%2fevil`）端到端覆盖。本文件锁的是**结构**：
+/// 闸门只有一处实现、四个域都真的走它、视频域按设计不接入。
+void main() {
+  final String src =
+      File('lib/src/sync/hibiki_sync_server.dart').readAsStringSync();
+
+  test('路径穿越闸门只有一处实现', () {
+    expect(
+      RegExp(r'shelf\.Response\? _rejectUnsafeAssetId\(')
+          .allMatches(src)
+          .length,
+      1,
+      reason: '闸门必须唯一；再出现第二份实现就意味着有人又抄了一遍',
+    );
+    // 除闸门自身与视频域的两处专用校验外，不得再有裸的 `..` 判断。
+    final int dotDotChecks =
+        RegExp(r"contains\('\.\.'\)").allMatches(src).length;
+    expect(
+      dotDotChecks,
+      3,
+      reason: '预期恰好 3 处：_rejectUnsafeAssetId 自身 + 视频 id 的两处专用校验。'
+          '多出来就是有人在新端点里手抄了穿越判断，请改调 _rejectUnsafeAssetId',
+    );
+  });
+
+  test('四个资产域都经过共享闸门', () {
+    for (final String label in <String>[
+      "'dictionary name'",
+      "'book title'",
+      "'displayName'",
+      "'bookKey'",
+    ]) {
+      expect(
+        src.contains('_rejectUnsafeAssetId($label)') ||
+            RegExp('_rejectUnsafeAssetId\\([^,]+, $label\\)').hasMatch(src),
+        isTrue,
+        reason: '$label 域必须经共享闸门校验资产名',
+      );
+    }
+  });
+
+  test('资产包 GET/PUT/DELETE 骨架只有一处实现，四个域都走它', () {
+    expect(
+      RegExp(r'Future<shelf\.Response> _serveAssetPackage\(')
+          .allMatches(src)
+          .length,
+      1,
+      reason: '资产包端点骨架必须唯一',
+    );
+    expect(
+      RegExp(r'return _serveAssetPackage\(').allMatches(src).length,
+      4,
+      reason: '词典 / 书 / 本地音频 / 有声书四域都必须走共享骨架；'
+          '新增媒体域也应走它，而不是再抄一份 switch',
+    );
+  });
+
+  test('骨架保住三条易抄漏的约束：导出缓存 ETag、临时目录必清、IOSink 双重关闭', () {
+    final int start = src.indexOf('Future<shelf.Response> _serveAssetPackage(');
+    expect(start, isNonNegative);
+    final int end = src.indexOf(
+        'Future<shelf.Response> _handleLibraryDictionaries(', start);
+    expect(end, greaterThan(start));
+    final String body = src.substring(start, end);
+
+    expect(body.contains('ExportPackageCache.etagFor(file)'), isTrue,
+        reason: '包下载必须带 ETag 作 If-Range 验证器，否则续传会拼错字节');
+    expect(body.contains('_exportCache.obtain('), isTrue,
+        reason: '包导出必须经进程级缓存（否则每次请求重新打包）');
+    expect(body.contains('tmpDir.deleteSync(recursive: true)'), isTrue,
+        reason: '上传临时目录必须在 finally 里清理，否则每次导入泄漏一个目录');
+    expect(body.contains('} finally {'), isTrue,
+        reason: '临时目录清理必须在 finally，不能只在成功路径');
+  });
+
+  test('视频域按设计不接入共享闸门（视频 id 合法含 /）', () {
+    // 视频 bookUid 形如 `video/xxx`，走共享闸门会把全部视频端点判成 403。
+    expect(src.contains(r'_rejectUnsafeAssetId(videoId'), isFalse,
+        reason: '视频 id 合法含 /，不得接入禁止 / 的资产闸门');
+    expect(src.contains('_extractVideoId'), isTrue, reason: '视频 id 有自己的专用校验');
+  });
+}

--- a/hibiki/test/sync/remote_dto_wire_format_golden_test.dart
+++ b/hibiki/test/sync/remote_dto_wire_format_golden_test.dart
@@ -1,0 +1,439 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki_core/hibiki_core.dart' show MediaKind;
+
+/// 互联 wire format 黄金守卫（TODO-2120 的前置安全网）。
+///
+/// **为什么需要这个文件**——互联 DTO 的 `toJson` 里有 **30+ 处条件省略 key**：
+/// `if (tags.isNotEmpty)`、`if (progressPercent > 0)`、`if (kind != MediaKind.epub)`、
+/// `if (episodes.length > 1)`、`if (hasDisplayCover)` …… 这些不是随手写的优化，而是
+/// **活的线上协议**：老 host / 老 client 靠「键不存在」来判断「没有这个东西」，
+/// 一旦某个键从「不写」变成「写 null / false / 空数组」，对端的解析分支就换了一条路。
+///
+/// 而此前只有 3 处（`kind` / `tags` / `collection`）被测试锁住，其余 30 来处**一旦被
+/// 改成无条件写出，全套测试照样全绿**。这意味着：
+/// - 任何人给 DTO 加字段、或把手写 `toJson` 换成 codegen（json_serializable 默认
+///   `includeIfNull: true`，且根本表达不了 `isNotEmpty` / `> 0` / `!= epub` 这类
+///   **基于值**的条件），都会静默改变 wire，且没有任何测试会红。
+///
+/// 本文件把「最小实例写出哪些键」和「最大实例写出哪些键」**逐 DTO 精确钉死**。
+/// 加字段时这里必然变红——那正是要的：强制作者显式声明新字段的省略语义，而不是
+/// 让它悄悄溜进协议。
+///
+/// 注意：断言的是 **key 集合**，不是值。值语义由各域自己的测试负责。
+void main() {
+  /// 断言 [json] 的键集合恰好是 [expected]（多一个少一个都红）。
+  void expectKeys(
+    Map<String, Object?> json,
+    Set<String> expected, {
+    required String what,
+  }) {
+    expect(
+      json.keys.toSet(),
+      expected,
+      reason: '$what 的 wire key 集合变了。若这是有意的协议变更，请连同老 host/老 '
+          'client 的兼容影响一起评估后再改本断言；若只是新加字段，请先想清楚它该在'
+          '什么条件下省略。',
+    );
+  }
+
+  group('RemoteBookInfo', () {
+    test('最小实例：只写 title / hasContent（其余全部省略）', () {
+      expectKeys(
+        const RemoteBookInfo(title: 'T', hasContent: false).toJson(),
+        <String>{'title', 'hasContent'},
+        what: 'RemoteBookInfo 最小实例',
+      );
+    });
+
+    test('最大实例：全部可选键都出现', () {
+      final Map<String, Object?> json = RemoteBookInfo(
+        title: 'T',
+        hasContent: true,
+        bookKey: 'k',
+        hasEmbeddedCover: true,
+        coverUrl: 'http://h/c.png',
+        coverPath: '/local/c.png',
+        hasAudiobook: true,
+        tags: const <String>['a'],
+        tagsAddedAt: const <String, int>{'a': 1},
+        tagTombstones: const <String, int>{'b': 2},
+        collection: const RemoteCollectionMembership(
+          collectionName: 'C',
+          collectionType: 'book',
+          sortIndex: 0,
+        ),
+        progressPercent: 50,
+        progressUpdatedAtMs: 123,
+        kind: MediaKind.srt,
+      ).toJson();
+      expectKeys(
+        json,
+        <String>{
+          'title',
+          'bookKey',
+          'hasContent',
+          'hasCover',
+          'coverUrl',
+          'hasAudiobook',
+          'tags',
+          'tagsAddedAt',
+          'tagTombstones',
+          'collection',
+          'progressPercent',
+          'progressUpdatedAtMs',
+          'kind',
+        },
+        what: 'RemoteBookInfo 最大实例',
+      );
+      // coverPath 是 host 本地绝对路径：fromJson 读、toJson **永不写**（不外泄）。
+      expect(json.containsKey('coverPath'), isFalse,
+          reason: 'host 本地路径绝不能出现在 wire 上');
+    });
+
+    test('epub 是默认 kind，不写 kind 键（旧 wire 字节不变）', () {
+      expect(
+        const RemoteBookInfo(title: 'T', hasContent: true).toJson(),
+        isNot(contains('kind')),
+      );
+      expect(
+        const RemoteBookInfo(title: 'T', hasContent: true, kind: MediaKind.epub)
+            .toJson(),
+        isNot(contains('kind')),
+      );
+    });
+
+    test('hasCover 写的是派生语义（coverPath/coverUrl 也算有封面）', () {
+      // wire key 叫 hasCover，值取的却是 hasDisplayCover（= 内嵌封面 或 有 coverUrl
+      // 或 有 coverPath）。Dart 侧字段名是 hasEmbeddedCover——同名不同义，改这里前
+      // 先读 DTO 里的注释。
+      expect(
+        const RemoteBookInfo(
+          title: 'T',
+          hasContent: true,
+          coverPath: '/local/c.png',
+        ).toJson()['hasCover'],
+        isTrue,
+        reason: '只有本地封面路径时，wire 上仍应告诉对端「这本书有封面」',
+      );
+    });
+
+    test('progress 为 0 时不写（0 与「没有进度」在 wire 上同义）', () {
+      final Map<String, Object?> json = const RemoteBookInfo(
+        title: 'T',
+        hasContent: true,
+        progressPercent: 0,
+        progressUpdatedAtMs: 0,
+      ).toJson();
+      expect(json.containsKey('progressPercent'), isFalse);
+      expect(json.containsKey('progressUpdatedAtMs'), isFalse);
+    });
+  });
+
+  group('RemoteVideoInfo', () {
+    test('最小实例：只写 id / title / hasSubtitle', () {
+      expectKeys(
+        const RemoteVideoInfo(id: 'video/x', title: 'T').toJson(),
+        <String>{'id', 'title', 'hasSubtitle'},
+        what: 'RemoteVideoInfo 最小实例',
+      );
+    });
+
+    test('最大实例：全部可选键都出现', () {
+      final Map<String, Object?> json = RemoteVideoInfo(
+        id: 'video/x',
+        title: 'T',
+        sizeBytes: 1,
+        hasSubtitle: true,
+        subtitleFileName: 's.srt',
+        embeddedSubtitleTracks: const <RemoteVideoEmbeddedSubtitleTrack>[
+          RemoteVideoEmbeddedSubtitleTrack(streamIndex: 0, codec: 'subrip'),
+        ],
+        durationMs: 2,
+        hasCover: true,
+        coverUrl: 'http://h/c.png',
+        coverPath: '/local/c.png',
+        positionMs: 3,
+        positionUpdatedAtMs: 4,
+        delayMs: 5,
+        episodes: const <RemoteVideoEpisode>[
+          RemoteVideoEpisode(index: 0, title: 'e0'),
+          RemoteVideoEpisode(index: 1, title: 'e1'),
+        ],
+        currentEpisode: 1,
+        tags: const <String>['a'],
+        tagsAddedAt: const <String, int>{'a': 1},
+        tagTombstones: const <String, int>{'b': 2},
+        collection: const RemoteCollectionMembership(
+          collectionName: 'C',
+          collectionType: 'video',
+          sortIndex: 0,
+        ),
+      ).toJson();
+      expectKeys(
+        json,
+        <String>{
+          'id',
+          'title',
+          'sizeBytes',
+          'hasSubtitle',
+          'subtitleFileName',
+          'embeddedSubtitleTracks',
+          'durationMs',
+          'hasCover',
+          'coverUrl',
+          'positionMs',
+          'positionUpdatedAtMs',
+          'delayMs',
+          'episodes',
+          'currentEpisode',
+          'tags',
+          'tagsAddedAt',
+          'tagTombstones',
+          'collection',
+        },
+        what: 'RemoteVideoInfo 最大实例',
+      );
+      expect(json.containsKey('coverPath'), isFalse,
+          reason: 'host 本地路径绝不能出现在 wire 上');
+    });
+
+    test('单视频（episodes<=1）不写 episodes / currentEpisode（旧 client 兼容）', () {
+      final Map<String, Object?> single = const RemoteVideoInfo(
+        id: 'video/x',
+        title: 'T',
+        episodes: <RemoteVideoEpisode>[
+          RemoteVideoEpisode(index: 0, title: 'e')
+        ],
+        currentEpisode: 0,
+      ).toJson();
+      expect(single.containsKey('episodes'), isFalse,
+          reason: '只有一集时 wire 上不应出现播放列表键');
+      expect(single.containsKey('currentEpisode'), isFalse);
+    });
+
+    test('无内封字幕轨时不写 embeddedSubtitleTracks', () {
+      expect(
+        const RemoteVideoInfo(id: 'video/x', title: 'T').toJson(),
+        isNot(contains('embeddedSubtitleTracks')),
+      );
+    });
+
+    test('delayMs 为 0 不写；非 0（含负值）要写', () {
+      expect(
+        const RemoteVideoInfo(id: 'v', title: 'T', delayMs: 0).toJson(),
+        isNot(contains('delayMs')),
+      );
+      expect(
+        const RemoteVideoInfo(id: 'v', title: 'T', delayMs: -250)
+            .toJson()['delayMs'],
+        -250,
+        reason: '负 delay 是合法的字幕提前量，不能被当成「无值」省掉',
+      );
+    });
+  });
+
+  group('RemoteVideoEmbeddedSubtitleTrack', () {
+    test('最小实例：streamIndex / codec / isText', () {
+      expectKeys(
+        const RemoteVideoEmbeddedSubtitleTrack(streamIndex: 0, codec: 'subrip')
+            .toJson(),
+        <String>{'streamIndex', 'codec', 'isText'},
+        what: '内封字幕轨最小实例',
+      );
+    });
+
+    test('最大实例', () {
+      expectKeys(
+        const RemoteVideoEmbeddedSubtitleTrack(
+          streamIndex: 1,
+          codec: 'ass',
+          language: 'jpn',
+          title: 'JP',
+          isText: false,
+          url: 'http://h/s',
+          fileName: 's.ass',
+        ).toJson(),
+        <String>{
+          'streamIndex',
+          'codec',
+          'language',
+          'title',
+          'isText',
+          'url',
+          'fileName'
+        },
+        what: '内封字幕轨最大实例',
+      );
+    });
+
+    test('isText 缺失解成 true（反向默认，不是 false）', () {
+      // 老 host 不下发 isText → 必须当文本轨处理，否则字幕全被当图形轨丢掉。
+      expect(
+        RemoteVideoEmbeddedSubtitleTrack.fromJson(
+          const <String, Object?>{'streamIndex': 0, 'codec': 'subrip'},
+        ).isText,
+        isTrue,
+      );
+      expect(
+        RemoteVideoEmbeddedSubtitleTrack.fromJson(
+          const <String, Object?>{
+            'streamIndex': 0,
+            'codec': 'hdmv_pgs',
+            'isText': false,
+          },
+        ).isText,
+        isFalse,
+      );
+    });
+  });
+
+  group('RemoteAudiobookInfo', () {
+    test('uid 为空时省略（旧 host 不下发此字段）', () {
+      expectKeys(
+        const RemoteAudiobookInfo(bookKey: 'k').toJson(),
+        <String>{'bookKey', 'title'},
+        what: 'RemoteAudiobookInfo 无 uid',
+      );
+      expectKeys(
+        const RemoteAudiobookInfo(bookKey: 'k', uid: 'u', title: 't').toJson(),
+        <String>{'bookKey', 'uid', 'title'},
+        what: 'RemoteAudiobookInfo 全字段',
+      );
+    });
+
+    test('身份键：srt-backed 用 bookKey，standalone 用 uid', () {
+      expect(const RemoteAudiobookInfo(bookKey: 'k', uid: 'u').identity, 'k');
+      expect(const RemoteAudiobookInfo(bookKey: '', uid: 'u').identity, 'u');
+      expect(const RemoteAudiobookInfo(bookKey: '').isStandaloneSrt, isTrue);
+    });
+  });
+
+  group('RemoteActivityEvent', () {
+    test('最小实例：5 个必填键', () {
+      expectKeys(
+        const RemoteActivityEvent(
+          eventType: 'read',
+          mediaType: 'book',
+          title: 'T',
+          dateKey: '2026-07-28',
+          timestampMs: 1,
+        ).toJson(),
+        <String>{'eventType', 'mediaType', 'title', 'dateKey', 'timestampMs'},
+        what: 'RemoteActivityEvent 最小实例',
+      );
+    });
+
+    test('最大实例：可选三键出现', () {
+      expectKeys(
+        const RemoteActivityEvent(
+          eventType: 'read',
+          mediaType: 'book',
+          title: 'T',
+          dateKey: '2026-07-28',
+          timestampMs: 1,
+          mediaKey: 'k',
+          durationMs: 2,
+          charsDelta: 3,
+        ).toJson(),
+        <String>{
+          'eventType',
+          'mediaType',
+          'title',
+          'dateKey',
+          'timestampMs',
+          'mediaKey',
+          'durationMs',
+          'charsDelta'
+        },
+        what: 'RemoteActivityEvent 最大实例',
+      );
+    });
+  });
+
+  group('固定键集的 DTO（无条件省略）', () {
+    test('RemoteCollectionMembership：wire key 是 name，不是 collectionName', () {
+      expectKeys(
+        const RemoteCollectionMembership(
+          collectionName: 'C',
+          collectionType: 'book',
+          sortIndex: 3,
+        ).toJson(),
+        <String>{'name', 'collectionType', 'sortIndex'},
+        what: 'RemoteCollectionMembership',
+      );
+    });
+
+    test('RemoteBookProgress', () {
+      expectKeys(
+        const RemoteBookProgress(
+          sectionIndex: 0,
+          normCharOffset: 0,
+          charOffset: -1,
+          updatedAtMs: 0,
+        ).toJson(),
+        <String>{'sectionIndex', 'normCharOffset', 'charOffset', 'updatedAtMs'},
+        what: 'RemoteBookProgress',
+      );
+    });
+
+    test('RemoteBookProgress.charOffset 缺失默认 -1（不是 0）', () {
+      // -1 = 「host 没有精确字符偏移」，0 是合法的「在开头」。混淆会让恢复跳到开头。
+      expect(
+        RemoteBookProgress.fromJson(const <String, Object?>{}).charOffset,
+        -1,
+      );
+    });
+
+    test('RemoteDictionaryInfo / RemoteLocalAudioInfo / RemoteVideoEpisode',
+        () {
+      expectKeys(
+        const RemoteDictionaryInfo(name: 'n', type: 't').toJson(),
+        <String>{'name', 'type'},
+        what: 'RemoteDictionaryInfo',
+      );
+      expectKeys(
+        const RemoteLocalAudioInfo(displayName: 'd').toJson(),
+        <String>{'displayName'},
+        what: 'RemoteLocalAudioInfo',
+      );
+      expectKeys(
+        const RemoteVideoEpisode(index: 0, title: 't').toJson(),
+        <String>{'index', 'title'},
+        what: 'RemoteVideoEpisode',
+      );
+    });
+  });
+
+  group('round-trip：省略的键在 fromJson 侧还原成等价缺省', () {
+    test('RemoteBookInfo 最小实例 round-trip 不产生新键', () {
+      const RemoteBookInfo original =
+          RemoteBookInfo(title: 'T', hasContent: true);
+      final RemoteBookInfo back = RemoteBookInfo.fromJson(original.toJson());
+      expect(back.toJson(), original.toJson(),
+          reason: 'toJson→fromJson→toJson 必须是幂等的，否则同一本书在两端会写出不同 wire');
+    });
+
+    test('RemoteVideoInfo 最小实例 round-trip 不产生新键', () {
+      const RemoteVideoInfo original = RemoteVideoInfo(id: 'v', title: 'T');
+      final RemoteVideoInfo back = RemoteVideoInfo.fromJson(original.toJson());
+      expect(back.toJson(), original.toJson());
+    });
+
+    test('RemoteVideoInfo 播放列表 round-trip 保住 episodes/currentEpisode', () {
+      const RemoteVideoInfo original = RemoteVideoInfo(
+        id: 'v',
+        title: 'T',
+        episodes: <RemoteVideoEpisode>[
+          RemoteVideoEpisode(index: 0, title: 'a'),
+          RemoteVideoEpisode(index: 1, title: 'b'),
+        ],
+        currentEpisode: 1,
+      );
+      final RemoteVideoInfo back = RemoteVideoInfo.fromJson(original.toJson());
+      expect(back.episodes.length, 2);
+      expect(back.currentEpisode, 1);
+      expect(back.toJson(), original.toJson());
+    });
+  });
+}

--- a/hibiki/test/sync/remote_library_cache_test.dart
+++ b/hibiki/test/sync/remote_library_cache_test.dart
@@ -219,11 +219,17 @@ void main() {
     expect(small.length, 20, reason: 'limit 不同即结果集不同，共用一槽会把首页的 200 条截断成 20 条');
   });
 
-  test('互联视频与云视频分属不同 key（元素类型不同，共用会 cast 崩）', () {
-    expect(
+  test('各媒体域分属不同 key，互不覆盖', () {
+    // 互联与云盘的视频清单**共用** videos 一个槽（TODO-2119 后两种源都实现
+    // RemoteVideoSource，元素统一是 RemoteVideoInfo）；域与域之间必须分开。
+    final Set<String> keys = <String>{
+      RemoteLibraryCacheKeys.books,
       RemoteLibraryCacheKeys.videos,
-      isNot(RemoteLibraryCacheKeys.cloudVideos),
-    );
+      RemoteLibraryCacheKeys.audiobooks,
+      RemoteLibraryCacheKeys.dictionaries,
+      RemoteLibraryCacheKeys.activity(200),
+    };
+    expect(keys.length, 5, reason: '域 key 不得重名，否则一个域的清单会盖掉另一个域');
   });
 
   /// BUG-1180 接线守卫：provider 必须订阅「对端身份变了」的信号并整体失效。

--- a/hibiki/test/sync/sync_orchestrator_video_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_video_test.dart
@@ -144,7 +144,7 @@ void main() {
       final CloudRemoteVideoClient client =
           CloudRemoteVideoClient(backend: store);
       final List<RemoteVideoManifestEntry> entries =
-          await client.listRemoteVideos();
+          await client.listRemoteVideoManifest();
       expect(entries.length, 1);
       final RemoteVideoManifestEntry e = entries.single;
       expect(e.uid, uid);
@@ -206,7 +206,7 @@ void main() {
       final CloudRemoteVideoClient client =
           CloudRemoteVideoClient(backend: store);
       final RemoteVideoManifestEntry e =
-          (await client.listRemoteVideos()).single;
+          (await client.listRemoteVideoManifest()).single;
       expect(e.coverAsset, isNotNull);
 
       final File cover = File('${tmp.path}/pulled_cover.jpg');
@@ -278,10 +278,10 @@ void main() {
           .syncVideoAssets(report);
       expect(report.errors, isEmpty, reason: report.errors.join(' | '));
 
-      final Set<String> uids =
-          (await CloudRemoteVideoClient(backend: store).listRemoteVideos())
-              .map((RemoteVideoManifestEntry e) => e.uid)
-              .toSet();
+      final Set<String> uids = (await CloudRemoteVideoClient(backend: store)
+              .listRemoteVideoManifest())
+          .map((RemoteVideoManifestEntry e) => e.uid)
+          .toSet();
       expect(uids, containsAll(<String>['video/FromA', 'video/FromB']),
           reason: 'upload-only union must not drop the remote-only entry');
     });
@@ -357,7 +357,8 @@ void main() {
       await _orchestrator(db, backend, tmp, syncVideoFiles: true)
           .syncVideoAssets(SyncRunReport());
       final RemoteVideoManifestEntry e1 =
-          (await CloudRemoteVideoClient(backend: store).listRemoteVideos())
+          (await CloudRemoteVideoClient(backend: store)
+                  .listRemoteVideoManifest())
               .single;
       expect(e1.coverAsset, isNotNull);
 
@@ -368,7 +369,8 @@ void main() {
       await _orchestrator(db, backend, tmp, syncVideoFiles: true)
           .syncVideoAssets(SyncRunReport());
       final RemoteVideoManifestEntry e2 =
-          (await CloudRemoteVideoClient(backend: store).listRemoteVideos())
+          (await CloudRemoteVideoClient(backend: store)
+                  .listRemoteVideoManifest())
               .single;
       expect(e2.coverAsset, e1.coverAsset,
           reason:
@@ -429,7 +431,7 @@ void main() {
       final FakeAssetStore store = FakeAssetStore();
       final CloudRemoteVideoClient client =
           CloudRemoteVideoClient(backend: store);
-      expect(await client.listRemoteVideos(), isEmpty);
+      expect(await client.listRemoteVideoManifest(), isEmpty);
     });
 
     test('download of unknown uid throws SyncBackendError', () async {


### PR DESCRIPTION
PR #490 的**续作**。#490 已合入 develop（`f22699b63`），本 PR 是那之后写的三个 commit——它们当时被推到了已合并的分支上，成了孤儿（PR 合并后追加 push 的 commit 不会进 develop），现已 rebase 到当前 develop 重新提交。

用户诉求：「统一代码，让其不要每次加新东西都要重构 hibiki 互联」。先摸清互联 8 层各自的真实形状，只动**可安全塌缩**的部分。

## `5d3847764` 远端视频源按能力分级（TODO-2119）

问题不在「云端要不要 `implements RemoteVideoClient`」，而在契约把「所有源都能做的」和「只有 live host 能做的」混成一个接口。让云端实现接口再把 4 个方法写成抛异常不算修复——那只是把「能力靠 `is` 判断」换成「调了会抛」，编译器照样拦不住。

拆两级：`RemoteVideoSource`（列清单 + 下载）/ `RemoteVideoClient extends RemoteVideoSource`（+ 流播 / 字幕 / 断点）。`source is RemoteVideoClient` 成为**类型系统认可**的能力判据。

- 视频页两个互斥 nullable 字段 → 一个 `_remoteVideoSource`，`_loadRemoteVideos` 两分支塌缩成一条
- 清单→DTO 适配从页面搬进 client：**给 `RemoteVideoInfo` 加字段不必再回页面改**（漏改导致云侧字段永远为空的坑消失）
- 缓存的 `cloudVideos` key 删除，两种源共用一个槽
- 保留：收尾登记仍按源分流（互联回填字幕+断点、云盘取封面）——那是真实能力差异，不是样板分支

## `273b2828e` server 资产端点收敛 + wire format 黄金守卫（TODO-2120）

「取/存/删资产包」在词典 / 书 / 本地音频 / 有声书四域逐字复制四份（各约 60 行），路径穿越判断连子路由抄了 7 遍。这段代码里含导出缓存 + ETag/Range 续传、临时目录必清理，以及一道**安全闸门**——靠复制粘贴维持，抄漏一处就是真事故。

收成 `_serveAssetPackage` + `_rejectUnsafeAssetId`，`hibiki_sync_server.dart` **净减 87 行**。行为逐字保持（错误文案 / 状态码 / ETag / 清理时机 / 有声书 `bookKeyOverride`）。视频域**按设计不接入**：视频 id 形如 `video/xxx` 合法含 `/`，接进禁止 `/` 的闸门会把全部视频端点判成 403。

**`remote_dto_wire_format_golden_test.dart`（24 例）**——互联 DTO 的 `toJson` 有 30+ 处条件省略 key，是活的线上协议（对端靠「键不存在」判断「没这个东西」），此前只有 3 处被测试保护，其余改成无条件写出全套测试照样绿。现在逐 DTO 钉死最小/最大实例的键集合，外加几条最易写反的语义：`coverPath` 只读不写（host 本地路径不外泄）、`hasCover` 写的是派生语义、`isText` 缺失=true、`charOffset` 缺失=-1、单视频不写 `episodes`、负 `delayMs` 不得被当成无值省掉。

## `82bc601e2` client 列清单骨架收敛（TODO-2120）

5 份 → `_listRemote`。**404 降级与超时逐域显式传入，绝不统一打开**：只有 videos 降级（后加的端点，老 host 没有）。给最老的四个端点也加降级，会把「host 把库服务关了」从可见错误变成静默空列表——那是行为回归，不是更健壮。`listRemoteActivity` 不接入（有逐条跳过坏条目的容错和 limit 参数，真差异）。

## 评估后**不做**的两项

- **DTO 上 json_serializable**：默认 `includeIfNull:true` 把 30+ 处省略全变成显式 null；即便关掉也只覆盖 null 一类，`isNotEmpty` / `>0` / `!=epub` / `length>1` 这些**基于值**的条件生成器根本表达不了。再加 `hasCover` 的 key/字段语义错位、`coverPath` 单向、`RemoteCollectionMembership.fromJson(Object?)` 返 nullable。生成器化 = 静默破坏与老 host 的协议。上面的黄金守卫是它的前置条件，现在有了。
- **host service `listX` 表驱动**：`listBooks`(69行) / `listVideos`(42+95行) / `listAudiobooks`(27行) 各自携带批量预取的性能修复（注释明写是「互联视频极慢」的主根因）与 BUG-812/1119 语义，是真业务不是样板。

## 验证

- `flutter analyze` 全仓（含 test）零问题 ✅
- 本 PR 测试面 88 例全绿（缓存 / 黄金守卫 / 资产闸门 / 传输层 / 合集架构守卫 / 云下载 / 视频同步编排）✅
- rebase 到当前 develop 无冲突

合并前请以 **Build Release APK 工作流的 Run unit tests** 为准（真单测门，非 Build and Test）。

https://claude.ai/code/session_01LPJDyZXKCXBm8tGWq47Kx1