### PR TITLE
feat(library): 显式选择模式 + Shift 区间选 + 长按扫选

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46835 (2755 per locale)
+/// Strings: 46852 (2756 per locale)
 ///
-/// Built on 2026-07-29 at 05:10 UTC
+/// Built on 2026-07-29 at 05:49 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3702,6 +3702,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_stat_by_game => 'By game';
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -10007,6 +10010,10 @@ class _StringsAr extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -16380,6 +16387,10 @@ class _StringsDe extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -22769,6 +22780,10 @@ class _StringsEs extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -29169,6 +29184,10 @@ class _StringsFr extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -35498,6 +35517,10 @@ class _StringsId extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -41873,6 +41896,10 @@ class _StringsIt extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -48065,6 +48092,10 @@ class _StringsJa extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -54259,6 +54290,10 @@ class _StringsKo extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -60614,6 +60649,10 @@ class _StringsNl extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -66982,6 +67021,10 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -73334,6 +73377,10 @@ class _StringsRu extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -79634,6 +79681,10 @@ class _StringsTh extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -85966,6 +86017,10 @@ class _StringsTr extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -92283,6 +92338,10 @@ class _StringsVi extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 // Path: <root>
@@ -98153,6 +98212,10 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       '确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object n, required Object m}) =>
+      '选中的 ${n} 项中有 ${m} 项已不存在，已跳过';
 }
 
 // Path: <root>
@@ -104266,6 +104329,10 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get stat_clear_all_game_message =>
       'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+  @override
+  String batch_selection_stale_skipped(
+          {required Object m, required Object n}) =>
+      'Skipped ${m} of ${n} selected items that no longer exist';
 }
 
 /// Flat map(s) containing all translations.
@@ -109909,6 +109976,9 @@ extension on _StringsEn {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -115550,6 +115620,9 @@ extension on _StringsAr {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -121212,6 +121285,9 @@ extension on _StringsDe {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -126873,6 +126949,9 @@ extension on _StringsEs {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -132540,6 +132619,9 @@ extension on _StringsFr {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -138189,6 +138271,9 @@ extension on _StringsId {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -143853,6 +143938,9 @@ extension on _StringsIt {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -149479,6 +149567,9 @@ extension on _StringsJa {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -155109,6 +155200,9 @@ extension on _StringsKo {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -160766,6 +160860,9 @@ extension on _StringsNl {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -166420,6 +166517,9 @@ extension on _StringsPtBr {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -172079,6 +172179,9 @@ extension on _StringsRu {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -177722,6 +177825,9 @@ extension on _StringsTh {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -183374,6 +183480,9 @@ extension on _StringsTr {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -189021,6 +189130,9 @@ extension on _StringsVi {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }
@@ -194622,6 +194734,9 @@ extension on _StringsZhCn {
         return '按游戏';
       case 'stat_clear_all_game_message':
         return '确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。';
+      case 'batch_selection_stale_skipped':
+        return ({required Object n, required Object m}) =>
+            '选中的 ${n} 项中有 ${m} 项已不存在，已跳过';
       default:
         return null;
     }
@@ -200243,6 +200358,9 @@ extension on _StringsZhHk {
         return 'By game';
       case 'stat_clear_all_game_message':
         return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
+      case 'batch_selection_stale_skipped':
+        return ({required Object m, required Object n}) =>
+            'Skipped ${m} of ${n} selected items that no longer exist';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "仍未匹配到条目，请尝试手动关联",
   "game_statistics": "游戏统计",
   "game_stat_by_game": "按游戏",
-  "stat_clear_all_game_message": "确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。"
+  "stat_clear_all_game_message": "确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。",
+  "batch_selection_stale_skipped": "选中的 $n 项中有 $m 项已不存在，已跳过"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2753,5 +2753,6 @@
   "media_tracking_retry_no_match": "No match found. Try manual linking.",
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
-  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
 }

--- a/hibiki/lib/src/media/selection/media_selection_controller.dart
+++ b/hibiki/lib/src/media/selection/media_selection_controller.dart
@@ -1,0 +1,306 @@
+/// 库页多选的共享状态机（书架 / 视频库共用一份）。
+///
+/// 抽出来的理由：书架（`reader_hibiki_history_page.dart`）与视频库
+/// （`home_video_page.dart`）此前各自维护形状完全相同的三件套——散卡选中集
+/// `Set<String>`、合集整选集 `Set<int>`、模式位 `bool`——外加各自一份
+/// toggle / 全选 / 反选。补 Shift 区间选与长按扫选时若继续各写一遍，两页行为
+/// 必然漂开（历史上「本地视频卡漏 onSecondaryTap」BUG-758 就是这么来的）。
+///
+/// 本类**只管选择语义**，不碰 UI、不碰 setState：调用方在 `setState` 里调它，
+/// 读它的 [looseKeys] / [collectionIds] 渲染。故可纯 Dart 单测。
+///
+/// ## 锚点（anchor）
+///
+/// Shift 区间选与长按扫选都需要一个「上次点击处」。锚点由 [toggle] /
+/// [enterWith] / [beginRangeDrag] 设定，并在**可见顺序变化时清空**
+/// （[setVisibleOrder]）——排序、搜索、筛选一变，旧锚点指向的位置对用户已无
+/// 意义，此时 Shift 点击退化成普通切换，而不是选中一片他根本没看见的条目。
+///
+/// ## 分区
+///
+/// 库页把合集行与散卡分两区渲染，两区各有自己的可见顺序。区间选**不跨区**：
+/// 锚点与目标不同区时退化为普通切换（并重设锚点）。这比「跨区时按某种拼接顺序
+/// 选一片」可预测得多。
+library;
+
+import 'dart:collection';
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+/// 多选的一格身份：要么是一张散卡（[looseKey]），要么是一个整合集
+/// （[collectionId]）。
+///
+/// 刻意不复用 `MediaRef`：合集不是媒体条目（没有 `MediaKind` / `entryKey`），
+/// 而两区必须能放进同一个「锚点」变量里才能表达「跨区退化」这条规则。
+@immutable
+class SelectionSlot {
+  /// 散卡：书架是 `mediaIdentifier` / `srt_` 前缀键，视频库是 `bookUid`。
+  const SelectionSlot.loose(String key)
+      : looseKey = key,
+        collectionId = null;
+
+  /// 整合集：`MediaCollections.id`。
+  const SelectionSlot.collection(int id)
+      : collectionId = id,
+        looseKey = null;
+
+  final String? looseKey;
+  final int? collectionId;
+
+  bool get isCollection => collectionId != null;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SelectionSlot &&
+          other.looseKey == looseKey &&
+          other.collectionId == collectionId;
+
+  @override
+  int get hashCode => Object.hash(looseKey, collectionId);
+
+  @override
+  String toString() => isCollection
+      ? 'SelectionSlot.collection($collectionId)'
+      : 'SelectionSlot.loose($looseKey)';
+}
+
+/// 一次卡片点击要按哪种语义处理。由按键修饰符决定（见 `selection_gestures.dart`）。
+enum SelectionTapKind {
+  /// 普通点击：切换该格，并把它设为新锚点。
+  toggle,
+
+  /// Shift + 点击：把锚点到该格的可见区间并入选中集，锚点不动。
+  extend,
+}
+
+/// 库页多选状态机。见库文档。
+class MediaSelectionController {
+  bool _active = false;
+  final Set<String> _looseKeys = <String>{};
+  final Set<int> _collectionIds = <int>{};
+
+  SelectionSlot? _anchor;
+
+  List<String> _visibleLoose = const <String>[];
+  List<int> _visibleCollections = const <int>[];
+
+  /// 长按扫选期间的基线选中集（拖动只在基线上叠加区间，故手指往回滑能取消刚
+  /// 刷上的那一段，而不是只增不减）。null = 当前没在扫选。
+  Set<String>? _dragBaseLoose;
+  Set<int>? _dragBaseCollections;
+
+  /// 多选态是否开启。
+  bool get active => _active;
+
+  /// 已选散卡键（只读视图）。
+  Set<String> get looseKeys => UnmodifiableSetView<String>(_looseKeys);
+
+  /// 已选合集 id（只读视图）。
+  Set<int> get collectionIds => UnmodifiableSetView<int>(_collectionIds);
+
+  /// 当前锚点（无则 null）。仅供测试与调试断言。
+  @visibleForTesting
+  SelectionSlot? get anchor => _anchor;
+
+  /// 是否正在长按扫选。
+  bool get isRangeDragging => _dragBaseLoose != null;
+
+  /// 选中总数（散卡 + 合集）。
+  int get length => _looseKeys.length + _collectionIds.length;
+
+  bool get isEmpty => length == 0;
+
+  bool get isNotEmpty => length != 0;
+
+  bool isSelected(SelectionSlot slot) => slot.isCollection
+      ? _collectionIds.contains(slot.collectionId)
+      : _looseKeys.contains(slot.looseKey);
+
+  /// 每帧写入当前**可见顺序**（排序 / 搜索 / 筛选之后的实际渲染顺序）。
+  ///
+  /// 顺序一变就清锚点——见库文档「锚点」。内容相同（每帧新建但等值的列表）
+  /// 视为未变，不会误清。
+  void setVisibleOrder({
+    required List<String> loose,
+    required List<int> collections,
+  }) {
+    if (listEquals(_visibleLoose, loose) &&
+        listEquals(_visibleCollections, collections)) {
+      return;
+    }
+    _visibleLoose = List<String>.unmodifiable(loose);
+    _visibleCollections = List<int>.unmodifiable(collections);
+    _anchor = null;
+  }
+
+  /// 切换多选态（工具栏的选择按钮）。开与关都清空选中集，与两页原行为一致。
+  void toggleMode() {
+    _active = !_active;
+    _resetSelection();
+  }
+
+  /// 退出多选态并清空。
+  void exit() {
+    _active = false;
+    _resetSelection();
+  }
+
+  /// 从非多选态直接进入多选并选中 [slot]（触屏长按 / 桌面 Ctrl+点击）。
+  ///
+  /// 已在多选态时等价于 [toggle]——避免「长按已选中的卡」把整个选中集清掉。
+  void enterWith(SelectionSlot slot) {
+    if (_active) {
+      toggle(slot);
+      return;
+    }
+    _active = true;
+    _resetSelection();
+    _addSlot(slot);
+    _anchor = slot;
+  }
+
+  /// 普通点击：切换该格，并把它设为新锚点。
+  void toggle(SelectionSlot slot) {
+    if (!_removeSlot(slot)) _addSlot(slot);
+    _anchor = slot;
+  }
+
+  /// Shift + 点击：把锚点到 [slot] 的可见区间并入选中集（只增不减），锚点不动。
+  ///
+  /// 无锚点 / 跨分区 / 锚点或目标已不在可见顺序里 → 退化为 [toggle]。
+  void extendTo(SelectionSlot slot) {
+    final List<SelectionSlot>? range = _rangeFromAnchor(slot);
+    if (range == null) {
+      toggle(slot);
+      return;
+    }
+    for (final SelectionSlot each in range) {
+      _addSlot(each);
+    }
+  }
+
+  /// 按 [kind] 分派 [toggle] / [extendTo]。
+  void applyTap(SelectionSlot slot, SelectionTapKind kind) {
+    switch (kind) {
+      case SelectionTapKind.toggle:
+        toggle(slot);
+      case SelectionTapKind.extend:
+        extendTo(slot);
+    }
+  }
+
+  /// 长按扫选开始：记基线、设锚点、选中起点。
+  ///
+  /// 起点采用「并入」而非「切换」语义：扫选是刷一片进来，起点若已选中不该被
+  /// 这一下抹掉。
+  void beginRangeDrag(SelectionSlot slot) {
+    _dragBaseLoose = Set<String>.of(_looseKeys);
+    _dragBaseCollections = Set<int>.of(_collectionIds);
+    _anchor = slot;
+    _addSlot(slot);
+  }
+
+  /// 长按扫选移动：选中集 = 基线 ∪ [锚点, slot] 区间。
+  ///
+  /// 未在扫选中、或 [slot] 与锚点跨区 / 不可见时忽略（保持上一帧结果，手指滑到
+  /// 空白处不会把已刷的一段抖没）。
+  void updateRangeDrag(SelectionSlot slot) {
+    final Set<String>? baseLoose = _dragBaseLoose;
+    final Set<int>? baseCollections = _dragBaseCollections;
+    if (baseLoose == null || baseCollections == null) return;
+    final List<SelectionSlot>? range = _rangeFromAnchor(slot);
+    if (range == null) return;
+    _looseKeys
+      ..clear()
+      ..addAll(baseLoose);
+    _collectionIds
+      ..clear()
+      ..addAll(baseCollections);
+    for (final SelectionSlot each in range) {
+      _addSlot(each);
+    }
+  }
+
+  /// 长按扫选结束：丢弃基线，锚点保留（用户接着 Shift 点击可继续延展）。
+  void endRangeDrag() {
+    _dragBaseLoose = null;
+    _dragBaseCollections = null;
+  }
+
+  /// 全选：把调用方给出的候选（各页自有资格规则，如视频库跳过已折进合集的成员）
+  /// 全部并入。
+  void selectAll({
+    required Iterable<String> loose,
+    required Iterable<int> collections,
+  }) {
+    _looseKeys.addAll(loose);
+    _collectionIds.addAll(collections);
+  }
+
+  /// 反选：在候选集内取补集。锚点失效（选中集与最后一次点击已无关系）。
+  void invert({
+    required Iterable<String> loose,
+    required Iterable<int> collections,
+  }) {
+    final Set<String> invertedLoose = loose.toSet().difference(_looseKeys);
+    final Set<int> invertedCollections =
+        collections.toSet().difference(_collectionIds);
+    _looseKeys
+      ..clear()
+      ..addAll(invertedLoose);
+    _collectionIds
+      ..clear()
+      ..addAll(invertedCollections);
+    _anchor = null;
+  }
+
+  /// 清空选中集但**留在**多选态（批量操作落库后调用）。
+  void clearSelection() => _resetSelection();
+
+  /// 锚点 → [slot] 的可见区间。不可用时返回 null（调用方退化处理）。
+  List<SelectionSlot>? _rangeFromAnchor(SelectionSlot slot) {
+    final SelectionSlot? anchor = _anchor;
+    if (anchor == null) return null;
+    // 跨分区不连续：合集区与散卡区各有自己的顺序，拼起来选一片没有可预测语义。
+    if (anchor.isCollection != slot.isCollection) return null;
+    if (slot.isCollection) {
+      final int from = _visibleCollections.indexOf(anchor.collectionId!);
+      final int to = _visibleCollections.indexOf(slot.collectionId!);
+      if (from < 0 || to < 0) return null;
+      return <SelectionSlot>[
+        for (int i = math.min(from, to); i <= math.max(from, to); i++)
+          SelectionSlot.collection(_visibleCollections[i]),
+      ];
+    }
+    final int from = _visibleLoose.indexOf(anchor.looseKey!);
+    final int to = _visibleLoose.indexOf(slot.looseKey!);
+    if (from < 0 || to < 0) return null;
+    return <SelectionSlot>[
+      for (int i = math.min(from, to); i <= math.max(from, to); i++)
+        SelectionSlot.loose(_visibleLoose[i]),
+    ];
+  }
+
+  void _addSlot(SelectionSlot slot) {
+    if (slot.isCollection) {
+      _collectionIds.add(slot.collectionId!);
+    } else {
+      _looseKeys.add(slot.looseKey!);
+    }
+  }
+
+  /// 移除并返回「原本在不在集合里」。
+  bool _removeSlot(SelectionSlot slot) => slot.isCollection
+      ? _collectionIds.remove(slot.collectionId)
+      : _looseKeys.remove(slot.looseKey);
+
+  void _resetSelection() {
+    _looseKeys.clear();
+    _collectionIds.clear();
+    _anchor = null;
+    _dragBaseLoose = null;
+    _dragBaseCollections = null;
+  }
+}

--- a/hibiki/lib/src/media/selection/media_selection_controller.dart
+++ b/hibiki/lib/src/media/selection/media_selection_controller.dart
@@ -259,6 +259,37 @@ class MediaSelectionController {
   /// 清空选中集但**留在**多选态（批量操作落库后调用）。
   void clearSelection() => _resetSelection();
 
+  /// 把选中集收敛到**当前真实存在**的条目上，返回被剔掉的个数。
+  ///
+  /// 为什么必须有这一步：选中集只按用户点击增删，从不随库变化剪枝。多选态可以
+  /// 存活很久（切 tab、进详情页再回来都保留），期间下拉同步 / 互联对端下架 /
+  /// 另一处删除都可能让某个 key 对应的行消失。此时选中集里留着的就是**幽灵键**，
+  /// 后果不是「少做一件事」而是三种糟得多的结局：
+  ///
+  /// - 批量打标签：`bookTags` 对 `bookKey` 有外键，插幽灵键抛
+  ///   `SqliteException`，而弹窗的确定按钮把落库 await 在自己的 loading 态里，
+  ///   异常一抛 loading 永不落地 → **弹窗卡死**，用户只能杀进程。
+  /// - 批量组合：`addToCollection` 同样撞外键，且它挂在 `void` 回调后面无人
+  ///   catch，用户看到的是「点了没反应」，会以为合集建好了。
+  /// - 计数虚高：底部「已选 N 项」和确认框里的 N 都把幽灵键算进去，用户是**照着
+  ///   一个虚数在做删除决定**。
+  ///
+  /// [loose] / [collections] 传当前真实存在的全集（不是「可见」全集——被搜索或
+  /// 标签筛掉的条目仍然存在，用户先勾后筛是合法用法，不该被悄悄剔掉）。
+  ///
+  /// 剔除后锚点失效：它可能正指着被剔掉的那一格。
+  int retainExisting({
+    required Set<String> loose,
+    required Set<int> collections,
+  }) {
+    final int before = length;
+    _looseKeys.retainWhere(loose.contains);
+    _collectionIds.retainWhere(collections.contains);
+    final int dropped = before - length;
+    if (dropped > 0) _anchor = null;
+    return dropped;
+  }
+
   /// 锚点 → [slot] 的可见区间。不可用时返回 null（调用方退化处理）。
   List<SelectionSlot>? _rangeFromAnchor(SelectionSlot slot) {
     final SelectionSlot? anchor = _anchor;

--- a/hibiki/lib/src/media/selection/selection_gestures.dart
+++ b/hibiki/lib/src/media/selection/selection_gestures.dart
@@ -35,8 +35,19 @@ SelectionTapKind selectionTapKind() => HardwareKeyboard.instance.isShiftPressed
 /// 非多选态下，这一次点击是不是「用修饰键直接进多选」。
 ///
 /// macOS 用 ⌘、其余桌面用 Ctrl（各自平台的多选惯例）；Shift 也算，此时相当于
-/// 进多选并选中该项（无锚点，区间退化为单项）。触屏无键盘，恒 false。
+/// 进多选并选中该项（无锚点，区间退化为单项）。Android / iOS / Fuchsia 即使
+/// 外接物理键盘也恒 false：触屏库页必须先点明确的「选择」入口。
 bool selectionEntryModifierPressed(BuildContext context) {
+  switch (Theme.of(context).platform) {
+    case TargetPlatform.android:
+    case TargetPlatform.iOS:
+    case TargetPlatform.fuchsia:
+      return false;
+    case TargetPlatform.linux:
+    case TargetPlatform.windows:
+    case TargetPlatform.macOS:
+      break;
+  }
   final HardwareKeyboard keyboard = HardwareKeyboard.instance;
   if (keyboard.isShiftPressed) return true;
   return Theme.of(context).platform == TargetPlatform.macOS

--- a/hibiki/lib/src/media/selection/selection_gestures.dart
+++ b/hibiki/lib/src/media/selection/selection_gestures.dart
@@ -1,0 +1,190 @@
+/// 库页多选的手势层：按键修饰符判定、卡片身份标记、长按扫选。
+///
+/// 与 [MediaSelectionController]（纯语义）分开：这一层只负责「用户这一下是什么
+/// 意思」，判完调 controller。
+///
+/// ## 手势归属（2026-07 重划）
+///
+/// 长按此前在两个库页上都是「上下文菜单」（`card_widgets.part.dart` 的
+/// `_bookCardShell`、`home_video_page.dart` 的视频卡），触屏因此没有任何进多选
+/// 的快捷路径——这也是 `collection_drag.dart` 里「移动端不建拖拽源」那段注释记的
+/// 死结的由来。现在按输入方式重新分派：
+///
+/// | | 触屏（Android / iOS / Fuchsia） | 桌面（鼠标） |
+/// |---|---|---|
+/// | 上下文菜单 | 卡片上的 `⋮` 按钮 | 右键 `onSecondaryTap`（**未变**） |
+/// | 进入多选 | 长按卡片 | Ctrl/⌘ + 点击 |
+/// | 多选态内扩选 | 长按后滑动扫选 | Shift + 点击 |
+///
+/// 桌面的长按（鼠标按住不动）保持弹菜单不变——桌面用户按住不动就是等菜单。
+library;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart' show RenderMetaData;
+import 'package:flutter/services.dart';
+
+import 'package:hibiki/src/media/selection/media_selection_controller.dart';
+
+/// 触屏平台（长按 = 进多选；桌面则长按 = 菜单）。
+bool isTouchSelectionPlatform(BuildContext context) {
+  switch (Theme.of(context).platform) {
+    case TargetPlatform.android:
+    case TargetPlatform.iOS:
+    case TargetPlatform.fuchsia:
+      return true;
+    case TargetPlatform.linux:
+    case TargetPlatform.windows:
+    case TargetPlatform.macOS:
+      return false;
+  }
+}
+
+/// 多选态内的一次点击该按哪种语义：按住 Shift = 区间扩选，否则普通切换。
+///
+/// 读 [HardwareKeyboard] 而不是从手势事件里取：`InkWell.onTap` 不带修饰符，
+/// 而全局键盘状态在点击那一刻就是准的。
+SelectionTapKind selectionTapKind() => HardwareKeyboard.instance.isShiftPressed
+    ? SelectionTapKind.extend
+    : SelectionTapKind.toggle;
+
+/// 非多选态下，这一次点击是不是「用修饰键直接进多选」。
+///
+/// macOS 用 ⌘、其余桌面用 Ctrl（各自平台的多选惯例）；Shift 也算，此时相当于
+/// 进多选并选中该项（无锚点，区间退化为单项）。触屏无键盘，恒 false。
+bool selectionEntryModifierPressed(BuildContext context) {
+  final HardwareKeyboard keyboard = HardwareKeyboard.instance;
+  if (keyboard.isShiftPressed) return true;
+  return Theme.of(context).platform == TargetPlatform.macOS
+      ? keyboard.isMetaPressed
+      : keyboard.isControlPressed;
+}
+
+/// 给卡片贴上「我是哪一格」的标记，供 [SelectionDragArea] 按屏幕坐标反查。
+///
+/// 用 [MetaData] 而不是自建几何注册表（视频页 `CardDropRegistry` 那种）：
+/// [MetaData] 走真实命中测试，滚动、裁剪、遮挡、`Sliver` 复用全部天然正确，
+/// 且不改变布局（不会动到既有的等尺寸 golden 断言）。
+class SelectionSlotTarget extends StatelessWidget {
+  const SelectionSlotTarget({
+    required this.slot,
+    required this.child,
+    super.key,
+  });
+
+  final SelectionSlot slot;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => MetaData(metaData: slot, child: child);
+}
+
+/// 长按扫选的接管区：包在库页滚动体外面，多选态才生效。
+///
+/// 只在 [enabled] 为真（= 多选态）时挂长按识别器。多选态下卡片自身的
+/// `onLongPress` / `onSecondaryTap` 本就已置 null（两页原有纪律），故这里的
+/// 长按无竞争对手；快速点击仍归卡片 `InkWell.onTap`（长按识别器要过
+/// `kLongPressTimeout` 才宣布胜出），列表滚动仍归 `Scrollable`（手指先动就
+/// 由拖动识别器赢下竞技场，长按根本不会触发）。
+///
+/// ⚠️ 未做边缘自动滚动：手指扫到屏幕边缘不会自动翻页，需要抬手滚动后再扫。
+/// 这是刻意的 v1 范围——自动滚动要引入定时器 + 速度曲线，且与
+/// `Scrollable` 的竞技场归属交互复杂，值得单独一轮验证。
+class SelectionDragArea extends StatefulWidget {
+  const SelectionDragArea({
+    required this.enabled,
+    required this.onDragBegin,
+    required this.onDragUpdate,
+    required this.onDragEnd,
+    required this.child,
+    super.key,
+  });
+
+  /// 多选态才为真。
+  final bool enabled;
+
+  /// 长按落在某张卡上：记基线并选中它。
+  final void Function(SelectionSlot slot) onDragBegin;
+
+  /// 扫过某张卡：刷成 [锚点, slot] 区间。
+  final void Function(SelectionSlot slot) onDragUpdate;
+
+  /// 抬手。
+  final VoidCallback onDragEnd;
+
+  final Widget child;
+
+  @override
+  State<SelectionDragArea> createState() => _SelectionDragAreaState();
+}
+
+class _SelectionDragAreaState extends State<SelectionDragArea> {
+  /// 本次扫选是否真的起始于一张卡。落在空白处长按不算开始，后续移动一概忽略。
+  bool _dragging = false;
+
+  /// 上一次已上报的格，用于对 `onLongPressMoveUpdate` 的高频回调去重
+  /// （一次滑动每帧都回调，同一张卡上重复刷区间是纯浪费）。
+  SelectionSlot? _lastSlot;
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.enabled) return widget.child;
+    return GestureDetector(
+      // 卡片之间的间隙也要能起手（不然扫选起点必须精确落在卡上）。
+      behavior: HitTestBehavior.translucent,
+      onLongPressStart: _handleStart,
+      onLongPressMoveUpdate: _handleMove,
+      onLongPressEnd: _handleEnd,
+      onLongPressCancel: _handleCancel,
+      child: widget.child,
+    );
+  }
+
+  void _handleStart(LongPressStartDetails details) {
+    final SelectionSlot? slot = _slotAt(details.globalPosition);
+    if (slot == null) return;
+    _dragging = true;
+    _lastSlot = slot;
+    widget.onDragBegin(slot);
+  }
+
+  void _handleMove(LongPressMoveUpdateDetails details) {
+    if (!_dragging) return;
+    final SelectionSlot? slot = _slotAt(details.globalPosition);
+    // 滑到空白 / 跨到另一分区时保持上一帧结果，不抖动。
+    if (slot == null || slot == _lastSlot) return;
+    _lastSlot = slot;
+    widget.onDragUpdate(slot);
+  }
+
+  void _handleEnd(LongPressEndDetails details) => _finish();
+
+  void _handleCancel() => _finish();
+
+  void _finish() {
+    if (!_dragging) return;
+    _dragging = false;
+    _lastSlot = null;
+    widget.onDragEnd();
+  }
+
+  /// 屏幕坐标 → 该处卡片的 [SelectionSlot]（无卡则 null）。
+  SelectionSlot? _slotAt(Offset globalPosition) {
+    final HitTestResult result = HitTestResult();
+    WidgetsBinding.instance.hitTestInView(
+      result,
+      globalPosition,
+      View.of(context).viewId,
+    );
+    for (final HitTestEntry<HitTestTarget> entry in result.path) {
+      final HitTestTarget target = entry.target;
+      // 命中路径上可能有别的 MetaData（视频页给卡挂过 meta: VideoBookRow），
+      // 按类型筛掉，不做位置约定。
+      if (target is RenderMetaData) {
+        final Object? meta = target.metaData;
+        if (meta is SelectionSlot) return meta;
+      }
+    }
+    return null;
+  }
+}

--- a/hibiki/lib/src/media/selection/selection_gestures.dart
+++ b/hibiki/lib/src/media/selection/selection_gestures.dart
@@ -81,11 +81,23 @@ class SelectionSlotTarget extends StatelessWidget {
 
 /// 长按扫选的接管区：包在库页滚动体外面，多选态才生效。
 ///
-/// 只在 [enabled] 为真（= 多选态）时挂长按识别器。多选态下卡片自身的
-/// `onLongPress` / `onSecondaryTap` 本就已置 null（两页原有纪律），故这里的
-/// 长按无竞争对手；快速点击仍归卡片 `InkWell.onTap`（长按识别器要过
+/// 只在 [enabled] 为真（= 多选态）时**接上**长按回调。多选态下参与多选的卡片
+/// 自身的 `onLongPress` / `onSecondaryTap` 已置 null（两页原有纪律），故这里的
+/// 长按在这些卡上无竞争对手；快速点击仍归卡片 `InkWell.onTap`（长按识别器要过
 /// `kLongPressTimeout` 才宣布胜出），列表滚动仍归 `Scrollable`（手指先动就
 /// 由拖动识别器赢下竞技场，长按根本不会触发）。
+///
+/// ⚠️ 「卡片长按已置 null」只对**参与多选的卡**成立。不可单独勾选的卡（合集成员
+/// 卡、远端占位卡）在多选态仍保留自己的长按菜单，长按它们归卡片、不起手扫选——
+/// 它们本来也没有 [SelectionSlot]，扫不出东西。别把这条注释读成「多选态下全页
+/// 没有第二个长按识别器」。
+///
+/// 🔴 [GestureDetector] **恒建**，只按 [enabled] 决定回调传不传 null：早期实现
+/// 在 `!enabled` 时 early-return `child`，导致进/退多选态时这一层的子树形状
+/// 变化（`GestureDetector` ↔ 业务子树 `runtimeType` 不同 → `Element` 无法复用
+/// → 整棵 body 重建），用户正翻到列表中段一进多选就被弹回顶部（两个库页都没有
+/// `PageStorageKey` / 外挂 `ScrollController` 兜底）。守卫见
+/// `test/media/selection_gestures_test.dart` 的「进/退多选态不重建子树」组。
 ///
 /// ⚠️ 未做边缘自动滚动：手指扫到屏幕边缘不会自动翻页，需要抬手滚动后再扫。
 /// 这是刻意的 v1 范围——自动滚动要引入定时器 + 速度曲线，且与
@@ -126,16 +138,32 @@ class _SelectionDragAreaState extends State<SelectionDragArea> {
   /// （一次滑动每帧都回调，同一张卡上重复刷区间是纯浪费）。
   SelectionSlot? _lastSlot;
 
+  /// 多选态在扫选途中被关掉（批量操作落库后自动退出多选）时，识别器的回调已被
+  /// 摘成 null，`onLongPressEnd` 永远不会再来。不在这里收尾的话 [_dragging] 会
+  /// 一直留 true，下次进多选后第一次滑动就会绕过 [_handleStart] 直接刷区间。
+  @override
+  void didUpdateWidget(SelectionDragArea oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.enabled && !widget.enabled) {
+      _dragging = false;
+      _lastSlot = null;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    if (!widget.enabled) return widget.child;
+    // 恒建 GestureDetector（见类 doc 🔴）：树形状不随 enabled 变，滚动位置才不会
+    // 在进/退多选态时被重建冲掉。回调置 null 时 GestureDetector 不注册任何识别器，
+    // 命中行为与不存在这一层等价。
+    final bool on = widget.enabled;
     return GestureDetector(
-      // 卡片之间的间隙也要能起手（不然扫选起点必须精确落在卡上）。
+      // 卡片之间的间隙也要能起手（不然扫选起点必须精确落在卡上）。非多选态回调
+      // 全 null，此时 translucent 也不会吃掉任何命中（无识别器 = 不参与竞技场）。
       behavior: HitTestBehavior.translucent,
-      onLongPressStart: _handleStart,
-      onLongPressMoveUpdate: _handleMove,
-      onLongPressEnd: _handleEnd,
-      onLongPressCancel: _handleCancel,
+      onLongPressStart: on ? _handleStart : null,
+      onLongPressMoveUpdate: on ? _handleMove : null,
+      onLongPressEnd: on ? _handleEnd : null,
+      onLongPressCancel: on ? _handleCancel : null,
       child: widget.child,
     );
   }

--- a/hibiki/lib/src/media/selection/selection_gestures.dart
+++ b/hibiki/lib/src/media/selection/selection_gestures.dart
@@ -3,20 +3,18 @@
 /// 与 [MediaSelectionController]（纯语义）分开：这一层只负责「用户这一下是什么
 /// 意思」，判完调 controller。
 ///
-/// ## 手势归属（2026-07 重划）
+/// ## 手势归属
 ///
-/// 长按此前在两个库页上都是「上下文菜单」（`card_widgets.part.dart` 的
-/// `_bookCardShell`、`home_video_page.dart` 的视频卡），触屏因此没有任何进多选
-/// 的快捷路径——这也是 `collection_drag.dart` 里「移动端不建拖拽源」那段注释记的
-/// 死结的由来。现在按输入方式重新分派：
+/// 两个库页都必须先通过标签栏末尾明确的「选择」入口进入多选态。未进入选择态时，
+/// 触屏长按和桌面长按 / 右键都继续打开卡片上下文菜单；进入选择态后，卡片点击切换
+/// 勾选，长按后滑动才由 [SelectionDragArea] 接管为扫选。桌面额外保留
+/// Ctrl/⌘/Shift + 点击直接进入多选的既有快捷路径。
 ///
 /// | | 触屏（Android / iOS / Fuchsia） | 桌面（鼠标） |
 /// |---|---|---|
-/// | 上下文菜单 | 卡片上的 `⋮` 按钮 | 右键 `onSecondaryTap`（**未变**） |
-/// | 进入多选 | 长按卡片 | Ctrl/⌘ + 点击 |
-/// | 多选态内扩选 | 长按后滑动扫选 | Shift + 点击 |
-///
-/// 桌面的长按（鼠标按住不动）保持弹菜单不变——桌面用户按住不动就是等菜单。
+/// | 上下文菜单 | 长按卡片 | 长按 / 右键 |
+/// | 进入多选 | 点「选择」 | 点「选择」或 Ctrl/⌘/Shift + 点击 |
+/// | 多选态内扩选 | 长按后滑动扫选 | Shift + 点击 / 长按后滑动扫选 |
 library;
 
 import 'package:flutter/gestures.dart';
@@ -25,20 +23,6 @@ import 'package:flutter/rendering.dart' show RenderMetaData;
 import 'package:flutter/services.dart';
 
 import 'package:hibiki/src/media/selection/media_selection_controller.dart';
-
-/// 触屏平台（长按 = 进多选；桌面则长按 = 菜单）。
-bool isTouchSelectionPlatform(BuildContext context) {
-  switch (Theme.of(context).platform) {
-    case TargetPlatform.android:
-    case TargetPlatform.iOS:
-    case TargetPlatform.fuchsia:
-      return true;
-    case TargetPlatform.linux:
-    case TargetPlatform.windows:
-    case TargetPlatform.macOS:
-      return false;
-  }
-}
 
 /// 多选态内的一次点击该按哪种语义：按住 Shift = 区间扩选，否则普通切换。
 ///

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -662,7 +662,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ));
   }
 
-  /// 触屏长按卡片 / 桌面 Ctrl+点击：直接进入多选并选中该项。
+  /// 桌面 Ctrl/⌘/Shift + 点击：直接进入多选并选中该项。
+  /// 触屏（含外接键盘）只允许从明确的「选择」入口进入。
   void _enterSelectionWith(SelectionSlot slot) {
     setState(() => _selection.enterWith(slot));
   }
@@ -1998,7 +1999,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                 const SyncProgressBanner(),
                 Expanded(
                   // 多选态才接管长按：长按落在卡上 = 起手扫选，不抬手滑动即刷出
-                  // 一段区间。非多选态原样透传（长按仍归卡片自身的菜单 / 进多选）。
+                  // 一段区间。非多选态原样透传（长按仍归卡片自身的菜单）。
                   child: SelectionDragArea(
                     enabled: _selectionMode,
                     onDragBegin: (SelectionSlot slot) =>

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -52,6 +52,8 @@ import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
 import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/collections/collection_drag.dart';
+import 'package:hibiki/src/media/selection/media_selection_controller.dart';
+import 'package:hibiki/src/media/selection/selection_gestures.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/pages/implementations/jimaku_batch_dialog.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_detail_page.dart';
@@ -201,12 +203,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 批量选择模式（与书架 tab 对齐）。开启后卡片点击切换勾选、长按/拖放禁用，
   /// 底部弹批量操作栏（打标签 / 删除）。视频书是扁平 bookUid（不像书架有
   /// epub `mediaIdentifier` + `srt_` 双类前缀），故选择集直接用 bookUid 字符串。
-  bool _selectionMode = false;
-  final Set<String> _selectedUids = <String>{};
+  /// 与书架 tab 共用的多选状态机（[MediaSelectionController]）：模式位、散卡选中集、
+  /// 合集整选集、Shift / 长按扫选的锚点全在里面。下面三个 getter 保留旧字段名，
+  /// 让本页几十处读取点原样成立。
+  final MediaSelectionController _selection = MediaSelectionController();
+
+  bool get _selectionMode => _selection.active;
+
+  Set<String> get _selectedUids => _selection.looseKeys;
 
   /// 多选态合集整选（块2）：选中合集 id 集，与散卡选中集 [_selectedUids] 并存。
   /// 组合三档判定（块3）与批量解散/删除（块4）都读这两个集。
-  final Set<int> _selectedCollectionIds = <int>{};
+  Set<int> get _selectedCollectionIds => _selection.collectionIds;
 
   /// 当前可见（过滤后）的本地视频列表，供全选 / 反选用。
   List<VideoBookRow> _visibleVideos = const <VideoBookRow>[];
@@ -631,70 +639,57 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   // 选择集与 picker 比书架简单一层（无 epub/srt 双类分支）。
 
   void _toggleSelectionMode() {
-    setState(() {
-      _selectionMode = !_selectionMode;
-      _selectedUids.clear();
-      _selectedCollectionIds.clear();
-    });
+    setState(_selection.toggleMode);
   }
 
   void _exitSelectionMode() {
-    setState(() {
-      _selectionMode = false;
-      _selectedUids.clear();
-      _selectedCollectionIds.clear();
-    });
+    setState(_selection.exit);
   }
 
+  /// 散卡点击：普通点击切换 + 设锚点，Shift + 点击选中锚点到该卡的可见区间。
   void _toggleSelection(String bookUid) {
-    setState(() {
-      if (!_selectedUids.remove(bookUid)) {
-        _selectedUids.add(bookUid);
-      }
-    });
+    setState(() => _selection.applyTap(
+          SelectionSlot.loose(bookUid),
+          selectionTapKind(),
+        ));
   }
 
-  /// 块2：切换整合集选中（合集行头勾选框）。
+  /// 块2：切换整合集选中（合集行头勾选框）。Shift 同样在合集区内成段。
   void _toggleCollectionSelection(int collectionId) {
-    setState(() {
-      if (!_selectedCollectionIds.remove(collectionId)) {
-        _selectedCollectionIds.add(collectionId);
-      }
-    });
+    setState(() => _selection.applyTap(
+          SelectionSlot.collection(collectionId),
+          selectionTapKind(),
+        ));
+  }
+
+  /// 触屏长按卡片 / 桌面 Ctrl+点击：直接进入多选并选中该项。
+  void _enterSelectionWith(SelectionSlot slot) {
+    setState(() => _selection.enterWith(slot));
   }
 
   /// 一个可见视频是否已折进某合集（= 合集成员，不作散卡单选/全选）。
   bool _isCollectionMember(String bookUid) => _primaryCollectionByEntry
       .containsKey(MediaKind.video.compositeKey(bookUid));
 
-  void _selectAllVisible() {
-    setState(() {
-      // 散卡：只选未折进合集的可见视频（折进的成员由整合集选中，不单独勾）。
-      for (final VideoBookRow book in _visibleVideos) {
-        if (_isCollectionMember(book.bookUid)) continue;
-        _selectedUids.add(book.bookUid);
-      }
-      _selectedCollectionIds.addAll(_visibleCollectionIds);
-    });
-  }
-
-  void _invertSelection() {
-    setState(() {
-      final Set<String> allLoose = <String>{
+  /// 全选 / 反选的候选散卡键：只含未折进合集的可见视频（折进的成员由整合集选中，
+  /// 不单独勾）。两处共用同一份资格判据，避免全选与反选口径漂开。
+  Set<String> _selectableLooseUids() => <String>{
         for (final VideoBookRow book in _visibleVideos)
           if (!_isCollectionMember(book.bookUid)) book.bookUid,
       };
-      final Set<String> invertedLoose = allLoose.difference(_selectedUids);
-      _selectedUids
-        ..clear()
-        ..addAll(invertedLoose);
-      final Set<int> allCollections = _visibleCollectionIds.toSet();
-      final Set<int> invertedCollections =
-          allCollections.difference(_selectedCollectionIds);
-      _selectedCollectionIds
-        ..clear()
-        ..addAll(invertedCollections);
-    });
+
+  void _selectAllVisible() {
+    setState(() => _selection.selectAll(
+          loose: _selectableLooseUids(),
+          collections: _visibleCollectionIds,
+        ));
+  }
+
+  void _invertSelection() {
+    setState(() => _selection.invert(
+          loose: _selectableLooseUids(),
+          collections: _visibleCollectionIds,
+        ));
   }
 
   /// 块4：批量删除区分解散/删媒体。
@@ -1966,7 +1961,17 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                 // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
                 const SyncProgressBanner(),
                 Expanded(
-                  child: _buildVideoLibraryBody(),
+                  // 多选态才接管长按：长按落在卡上 = 起手扫选，不抬手滑动即刷出
+                  // 一段区间。非多选态原样透传（长按仍归卡片自身的菜单 / 进多选）。
+                  child: SelectionDragArea(
+                    enabled: _selectionMode,
+                    onDragBegin: (SelectionSlot slot) =>
+                        setState(() => _selection.beginRangeDrag(slot)),
+                    onDragUpdate: (SelectionSlot slot) =>
+                        setState(() => _selection.updateRangeDrag(slot)),
+                    onDragEnd: () => setState(_selection.endRangeDrag),
+                    child: _buildVideoLibraryBody(),
+                  ),
                 ),
                 if (_selectionMode) _buildBatchActionBar(),
               ],
@@ -2402,6 +2407,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         loose.add(_VideoLooseCard(
           sortKey: _groupSortKey(group),
           build: () => _buildVideoSlotCard(slot),
+          selectionKey: slot.local?.bookUid,
         ));
       } else if (collectionVisible(group.collection!.id)) {
         collectionGroups.add(group);
@@ -2410,6 +2416,16 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     }
     loose.sort((_VideoLooseCard a, _VideoLooseCard b) =>
         compareShelfSortKeys(a.sortKey, b.sortKey, _sortMode));
+    // Shift 区间选 / 长按扫选的顺序真值：取排序**之后**的散卡序，与用户屏幕上的
+    // 排列逐项一致（排序 / 搜索 / 标签筛选都已作用其上）。顺序一变，控制器自动
+    // 清锚点，Shift 不会选中一片没看见的条目。
+    _selection.setVisibleOrder(
+      loose: <String>[
+        for (final _VideoLooseCard card in loose)
+          if (card.selectionKey != null) card.selectionKey!,
+      ],
+      collections: _visibleCollectionIds,
+    );
     final List<Widget Function()> cells = <Widget Function()>[
       for (final CollectionGroup<_VideoSlot> group in collectionGroups)
         () => _buildCollectionCoverCard(group),
@@ -2555,19 +2571,34 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         (CollectionOrderingItem<_VideoSlot> it) => it.payload.remote != null);
     final bool selected =
         _selectionMode && _selectedCollectionIds.contains(collection.id);
+    final bool touchLongPressSelects = isTouchSelectionPlatform(context);
     final HibikiCard card = HibikiCard(
       key: ValueKey<String>('home_video_collection_card_${collection.id}'),
       focusId: HibikiFocusId('home-video-collection-${collection.id}'),
       padding: EdgeInsets.zero,
       selected: selected,
       // 多选态整卡点击 = 整选合集；平时点击 = 进详情（原「查看全部」）。
-      onTap: _selectionMode
-          ? () => _toggleCollectionSelection(collection.id)
-          : () => _openCollectionDetail(collection),
+      onTap: () {
+        if (_selectionMode) {
+          _toggleCollectionSelection(collection.id);
+          return;
+        }
+        // 桌面 Ctrl/⌘（macOS）/ Shift + 点击 = 直接进多选并整选该合集。
+        if (selectionEntryModifierPressed(context)) {
+          _enterSelectionWith(SelectionSlot.collection(collection.id));
+          return;
+        }
+        _openCollectionDetail(collection);
+      },
       // 合集卡长按/右键 = 合集上下文菜单（统一三库页：打开/重命名/标签/删除）；
-      // 多选态压制，与散卡长按菜单同一纪律。
-      onLongPress:
-          _selectionMode ? null : () => _showCollectionContextMenu(collection),
+      // 多选态压制，与散卡长按菜单同一纪律。触屏长按改判给进多选（菜单走封面
+      // 右下角 ⋮），桌面长按 / 右键不变。
+      onLongPress: _selectionMode
+          ? null
+          : (touchLongPressSelects
+              ? () =>
+                  _enterSelectionWith(SelectionSlot.collection(collection.id))
+              : () => _showCollectionContextMenu(collection)),
       onSecondaryTap:
           _selectionMode ? null : () => _showCollectionContextMenu(collection),
       child: Column(
@@ -2614,6 +2645,16 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                   ),
                 if (selected)
                   const Positioned.fill(child: ShelfSelectedOverlay()),
+                // 触屏菜单入口（长按已改判给进多选）。右上角可能有云角标、左下角
+                // 是成员数徽标，故落右下角。
+                if (touchLongPressSelects && !_selectionMode)
+                  Positioned(
+                    right: 6,
+                    bottom: 6,
+                    child: ShelfCardMenuButton(
+                      onPressed: () => _showCollectionContextMenu(collection),
+                    ),
+                  ),
               ],
             ),
           ),
@@ -2649,19 +2690,24 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ],
       ),
     );
+    // 长按扫选身份标记：合集区自成一段区间，扫选可在合集之间连选。
+    final SelectionSlot slot = SelectionSlot.collection(collection.id);
     // 选择态下禁用标签拖放命中（与散卡一致：避免选卡时误触拖标签）。
-    if (_selectionMode) return card;
+    if (_selectionMode) return SelectionSlotTarget(slot: slot, child: card);
     // 视频合集是封面卡（不是 CollectionShelfRow 行头——`unified_collections_
     // architecture_guard_test` 明令禁止视频页回退用行式布局），故接收端直接包在
     // 卡上：拖视频卡落到合集封面 = 加入该合集。
-    return CollectionDropTarget(
-      onMediaDropped: (MediaRef mediaRef) =>
-          _addMediaToCollection(collection.id, mediaRef),
-      child: BookDragTarget(
-        bookId: 'collection:${collection.id}',
-        onTagDropped: (BookTagRow tag) =>
-            _addTagToVideoCollection(collection.id, tag),
-        child: card,
+    return SelectionSlotTarget(
+      slot: slot,
+      child: CollectionDropTarget(
+        onMediaDropped: (MediaRef mediaRef) =>
+            _addMediaToCollection(collection.id, mediaRef),
+        child: BookDragTarget(
+          bookId: 'collection:${collection.id}',
+          onTagDropped: (BookTagRow tag) =>
+              _addTagToVideoCollection(collection.id, tag),
+          child: card,
+        ),
       ),
     );
   }
@@ -3457,20 +3503,43 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     // 块2：只有可单独勾选的卡才在多选态显示勾选框/高亮/切换选中。
     final bool showSelection = _selectionMode && selectable;
     final bool selected = showSelection && _selectedUids.contains(book.bookUid);
+    final SelectionSlot slot = SelectionSlot.loose(book.bookUid);
+    // 触屏：长按 = 进多选（菜单改由封面右上角 [ShelfCardMenuButton] 触发）。
+    // 桌面：长按 / 右键仍弹管理菜单。成员卡（selectable=false）不可单独勾选，
+    // 故不参与任何多选手势。
+    final bool touchLongPressSelects =
+        isTouchSelectionPlatform(context) && selectable;
+    void handleTap() {
+      if (showSelection) {
+        _toggleSelection(book.bookUid);
+        return;
+      }
+      // 桌面 Ctrl/⌘（macOS）/ Shift + 点击 = 不经工具栏直接进多选并选中该卡。
+      if (selectable &&
+          !_selectionMode &&
+          selectionEntryModifierPressed(context)) {
+        _enterSelectionWith(slot);
+        return;
+      }
+      _open(book, playlistCollectionId: playlistCollectionId);
+    }
+
     final HibikiCard hibikiCard = HibikiCard(
       key: ValueKey<String>('home_video_${book.bookUid}'),
       focusId: HibikiFocusId('home-video-${book.bookUid}'),
       padding: EdgeInsets.zero,
       selected: selected,
-      // 选择态：点击切换勾选、长按禁用（与书架 _buildBookCard 一致）。成员卡
-      // （selectable=false）多选态照常开播、不切换选中。
-      onTap: showSelection
-          ? () => _toggleSelection(book.bookUid)
-          : () => _open(book, playlistCollectionId: playlistCollectionId),
+      // 选择态：点击切换勾选、长按交给祖先的扫选接管区（与书架 _bookCardShell 一致）。
+      // 成员卡（selectable=false）多选态照常开播、不切换选中。
+      onTap: handleTap,
       // 长按 / 桌面右键都弹管理菜单，与书架书卡（_bookCardShell）、远端视频卡
       // （_buildRemoteVideoCard）一致——本地视频卡此前只挂了 onLongPress、漏了
       // onSecondaryTap，故桌面右键本地视频卡无反应（BUG-758）。
-      onLongPress: _selectionMode ? null : () => _showVideoMenu(book),
+      onLongPress: _selectionMode
+          ? null
+          : (touchLongPressSelects
+              ? () => _enterSelectionWith(slot)
+              : () => _showVideoMenu(book)),
       onSecondaryTap: _selectionMode ? null : () => _showVideoMenu(book),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -3525,6 +3594,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                         backgroundColor: Colors.black.withValues(alpha: 0.35),
                         color: Theme.of(context).colorScheme.primary,
                       ),
+                    ),
+                  ),
+                // 触屏菜单入口：长按已改判给「进入多选」，菜单必须另有入口。
+                // 书卡放右上角，视频卡右上角被播放列表角标占着，故落右下角；
+                // 进度条只有 3px 高，按钮抬 8px 让开。放在 Stack 末尾＝盖在最上层，
+                // 保证可点。
+                if (touchLongPressSelects && !_selectionMode)
+                  Positioned(
+                    right: 6,
+                    bottom: 8,
+                    child: ShelfCardMenuButton(
+                      onPressed: () => _showVideoMenu(book),
                     ),
                   ),
               ],
@@ -3588,7 +3669,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         mediaRef: MediaRef(kind: MediaKind.video, entryKey: book.bookUid),
         label: book.title,
         enabled: !_selectionMode,
-        child: card,
+        // 长按扫选靠命中测试反查「手指下面是哪一格」。仅可单独勾选的散卡贴标记：
+        // 合集成员卡（selectable=false）不可单独勾，扫过去应当无事发生。
+        child: selectable
+            ? SelectionSlotTarget(
+                slot: SelectionSlot.loose(book.bookUid),
+                child: card,
+              )
+            : card,
       ),
     );
   }
@@ -3952,10 +4040,18 @@ class _VideoBatchTagIntentRow extends StatelessWidget {
 /// 本地散卡（[_buildCard]）与远端占位卡（[_buildRemoteVideoCard]）用同一列表按当前
 /// 排序模式混排（[compareShelfSortKeys]）。构造用惰性闭包，排序后再取需要的那些。
 class _VideoLooseCard {
-  const _VideoLooseCard({required this.sortKey, required this.build});
+  const _VideoLooseCard({
+    required this.sortKey,
+    required this.build,
+    required this.selectionKey,
+  });
 
   final ShelfSortKey sortKey;
   final Widget Function() build;
+
+  /// 该散卡的多选键（= `bookUid`）。远端占位卡不可多选，为 null——排序后按此
+  /// 抽出「可见散卡顺序」喂给 [MediaSelectionController]，故顺序与屏幕一致。
+  final String? selectionKey;
 }
 
 /// 视频库分组 union 载荷（多端库联合视图 §2.3 任务10）：本地视频行 [local] 或

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -692,11 +692,41 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         ));
   }
 
+  /// 批量操作前把选中集收敛到真实存在的条目上，真剔掉了就明说。
+  ///
+  /// 选中集不随库变化剪枝（见 [MediaSelectionController.retainExisting]），多选态
+  /// 期间同步下架 / 别处删除都会留下幽灵键。必须在**任何**批量操作落库前剔干净：
+  /// 否则打标签撞外键会把弹窗卡死、组合撞外键会静默失败、确认框里的数字是虚数。
+  ///
+  /// 返回剔完后是否还有东西可做（全空则调用方直接返回）。
+  Future<bool> _pruneStaleSelection() async {
+    if (_selection.isEmpty) return false;
+    final List<VideoBookRow> books = await widget.repo.listAll();
+    final List<MediaCollectionRow> collections =
+        await ref.read(appProvider).database.getAllMediaCollections();
+    if (!mounted) return false;
+    final int dropped = _selection.retainExisting(
+      loose: <String>{for (final VideoBookRow b in books) b.bookUid},
+      collections: <int>{for (final MediaCollectionRow c in collections) c.id},
+    );
+    if (dropped == 0) return _selection.isNotEmpty;
+    setState(() {});
+    HibikiToast.show(
+      msg: t.batch_selection_stale_skipped(
+        n: dropped + _selection.length,
+        m: dropped,
+      ),
+    );
+    return _selection.isNotEmpty;
+  }
+
   /// 块4：批量删除区分解散/删媒体。
   /// - 选中合集 → 解散（[HibikiDatabase.deleteMediaCollection]：只解除分组，不删媒体本体）；
   /// - 选中散卡 → 删媒体本体（[VideoBookRepository.deleteVideoBook]，现状语义）；
   /// - 混选 → 确认框文案写明「删 N 个媒体、解散 M 个合集」。
   Future<void> _batchDeleteConfirm() async {
+    // 先剔幽灵键再取数：确认框里的 N / M 必须是真会被删的条数。
+    if (!await _pruneStaleSelection() || !mounted) return;
     final int mediaCount = _selectedUids.length;
     final int collectionCount = _selectedCollectionIds.length;
     if (mediaCount == 0 && collectionCount == 0) return;
@@ -807,6 +837,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 应用到所有选中视频书（经 [HibikiDatabase.addTagToVideoBook] /
   /// [HibikiDatabase.removeTagFromVideoBook]），关闭后刷新映射。
   Future<void> _batchShowTagPicker() async {
+    // 幽灵键会让 bookTags 的外键插入抛异常，而弹窗把落库 await 在 loading 态里，
+    // 一抛就永远转圈（卡死）。必须在开弹窗前剔干净。
+    if (!await _pruneStaleSelection() || !mounted) return;
     if (_selectedUids.isEmpty) return;
     final List<BookTagRow>? allTags = ref.read(allTagsProvider).valueOrNull;
     if (allTags == null || allTags.isEmpty) {
@@ -1030,6 +1063,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// - ≥2 合集（可带散卡）→ 合并成一个（[_combineMergeCollections]，默认名=成员最多合集名）。
   /// 全部走既有 DAO（createMediaCollection / addToCollection / deleteMediaCollection）。
   Future<void> _batchCombineIntoSeries() async {
+    // 幽灵键会让 addToCollection 撞外键，且它挂在无人 catch 的路径上——用户只会
+    // 看到「点了没反应」，以为合集建好了。先剔干净再分档。
+    if (!await _pruneStaleSelection() || !mounted) return;
     final HibikiDatabase db = ref.read(appProvider).database;
     final List<int> collectionIds = _selectedCollectionIds.toList()..sort();
     final List<ShelfEntryRef> looseRefs = <ShelfEntryRef>[
@@ -2814,8 +2850,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       // 短按仍流式播放（_openRemote）；长按 / 桌面右键弹选项面板，与本地视频
       // 卡长按一致（TODO-768 / BUG-416）。原先远端视频卡无 onLongPress（长按
       // 没反应），现在补齐。
-      onLongPress: () => _showRemoteVideoDialog(video),
-      onSecondaryTap: () => _showRemoteVideoDialog(video),
+      //
+      // 多选态压制，与本地散卡 / 合集卡同一纪律：远端占位卡不可单独勾选，但它
+      // 此前**漏了这道门控**，多选态长按它会弹选项面板，而不是被祖先
+      // [SelectionDragArea] 接走起手扫选——正好证伪了那一层「多选态下卡片长按
+      // 本就置 null」的前提。
+      onLongPress: _selectionMode ? null : () => _showRemoteVideoDialog(video),
+      onSecondaryTap:
+          _selectionMode ? null : () => _showRemoteVideoDialog(video),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -3504,7 +3504,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final bool showSelection = _selectionMode && selectable;
     final bool selected = showSelection && _selectedUids.contains(book.bookUid);
     final SelectionSlot slot = SelectionSlot.loose(book.bookUid);
-    // 触屏：长按 = 进多选（菜单改由封面右上角 [ShelfCardMenuButton] 触发）。
+    // 触屏：长按 = 进多选（菜单改由封面右下角 [ShelfCardMenuButton] 触发）。
     // 桌面：长按 / 右键仍弹管理菜单。成员卡（selectable=false）不可单独勾选，
     // 故不参与任何多选手势。
     final bool touchLongPressSelects =

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2607,7 +2607,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         (CollectionOrderingItem<_VideoSlot> it) => it.payload.remote != null);
     final bool selected =
         _selectionMode && _selectedCollectionIds.contains(collection.id);
-    final bool touchLongPressSelects = isTouchSelectionPlatform(context);
     final HibikiCard card = HibikiCard(
       key: ValueKey<String>('home_video_collection_card_${collection.id}'),
       focusId: HibikiFocusId('home-video-collection-${collection.id}'),
@@ -2626,15 +2625,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         }
         _openCollectionDetail(collection);
       },
-      // 合集卡长按/右键 = 合集上下文菜单（统一三库页：打开/重命名/标签/删除）；
-      // 多选态压制，与散卡长按菜单同一纪律。触屏长按改判给进多选（菜单走封面
-      // 右下角 ⋮），桌面长按 / 右键不变。
-      onLongPress: _selectionMode
-          ? null
-          : (touchLongPressSelects
-              ? () =>
-                  _enterSelectionWith(SelectionSlot.collection(collection.id))
-              : () => _showCollectionContextMenu(collection)),
+      // 未进入选择态时，触屏与桌面长按都保留合集上下文菜单；只有显式进入选择态
+      // 后才禁用菜单，让整卡点击/扫选负责勾选。
+      onLongPress:
+          _selectionMode ? null : () => _showCollectionContextMenu(collection),
       onSecondaryTap:
           _selectionMode ? null : () => _showCollectionContextMenu(collection),
       child: Column(
@@ -2681,16 +2675,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                   ),
                 if (selected)
                   const Positioned.fill(child: ShelfSelectedOverlay()),
-                // 触屏菜单入口（长按已改判给进多选）。右上角可能有云角标、左下角
-                // 是成员数徽标，故落右下角。
-                if (touchLongPressSelects && !_selectionMode)
-                  Positioned(
-                    right: 6,
-                    bottom: 6,
-                    child: ShelfCardMenuButton(
-                      onPressed: () => _showCollectionContextMenu(collection),
-                    ),
-                  ),
               ],
             ),
           ),
@@ -3546,11 +3530,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final bool showSelection = _selectionMode && selectable;
     final bool selected = showSelection && _selectedUids.contains(book.bookUid);
     final SelectionSlot slot = SelectionSlot.loose(book.bookUid);
-    // 触屏：长按 = 进多选（菜单改由封面右下角 [ShelfCardMenuButton] 触发）。
-    // 桌面：长按 / 右键仍弹管理菜单。成员卡（selectable=false）不可单独勾选，
-    // 故不参与任何多选手势。
-    final bool touchLongPressSelects =
-        isTouchSelectionPlatform(context) && selectable;
     void handleTap() {
       if (showSelection) {
         _toggleSelection(book.bookUid);
@@ -3577,11 +3556,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       // 长按 / 桌面右键都弹管理菜单，与书架书卡（_bookCardShell）、远端视频卡
       // （_buildRemoteVideoCard）一致——本地视频卡此前只挂了 onLongPress、漏了
       // onSecondaryTap，故桌面右键本地视频卡无反应（BUG-758）。
-      onLongPress: _selectionMode
-          ? null
-          : (touchLongPressSelects
-              ? () => _enterSelectionWith(slot)
-              : () => _showVideoMenu(book)),
+      // 未进入选择态时，触屏与桌面长按都保留管理菜单；显式进入选择态后才摘掉
+      // 卡片长按识别器，让祖先 SelectionDragArea 接管扫选。
+      onLongPress: _selectionMode ? null : () => _showVideoMenu(book),
       onSecondaryTap: _selectionMode ? null : () => _showVideoMenu(book),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -3636,18 +3613,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                         backgroundColor: Colors.black.withValues(alpha: 0.35),
                         color: Theme.of(context).colorScheme.primary,
                       ),
-                    ),
-                  ),
-                // 触屏菜单入口：长按已改判给「进入多选」，菜单必须另有入口。
-                // 书卡放右上角，视频卡右上角被播放列表角标占着，故落右下角；
-                // 进度条只有 3px 高，按钮抬 8px 让开。放在 Stack 末尾＝盖在最上层，
-                // 保证可点。
-                if (touchLongPressSelects && !_selectionMode)
-                  Positioned(
-                    right: 6,
-                    bottom: 8,
-                    child: ShelfCardMenuButton(
-                      onPressed: () => _showVideoMenu(book),
                     ),
                   ),
               ],

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -46,6 +46,8 @@ import 'package:hibiki/src/media/collections/collection_grouping.dart';
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
 import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/collections/collection_drag.dart';
+import 'package:hibiki/src/media/selection/media_selection_controller.dart';
+import 'package:hibiki/src/media/selection/selection_gestures.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/pages/implementations/media_collection_grid_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/series_shelf_card.dart';
@@ -200,12 +202,18 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             hasAudiobook: false, healthKind: HealthKind.notApplicable);
   }
 
-  bool _selectionMode = false;
-  final Set<String> _selectedKeys = {};
+  /// 批量选择状态机（与视频库 tab 共用同一个 [MediaSelectionController]）：模式位、
+  /// 散卡选中集、合集整选集、Shift / 长按扫选的锚点全在里面。下面三个 getter 保留
+  /// 旧字段名，让本页几十处读取点原样成立。
+  final MediaSelectionController _selection = MediaSelectionController();
+
+  bool get _selectionMode => _selection.active;
+
+  Set<String> get _selectedKeys => _selection.looseKeys;
 
   /// 多选态合集整选（块2）：选中合集 id 集，与散卡选中集 [_selectedKeys] 并存。
   /// 组合三档（块3）与批量解散/删除（块4）都读这两个集。
-  final Set<int> _selectedCollectionIds = <int>{};
+  Set<int> get _selectedCollectionIds => _selection.collectionIds;
 
   /// 当前渲染成横排行的合集 id 列表（[_buildBodyWithSrtBooks] 每帧写入），供
   /// 全选 / 反选把可见合集纳入整选集。
@@ -314,36 +322,42 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
   }
 
   void _toggleSelectionMode() {
-    setState(() {
-      _selectionMode = !_selectionMode;
-      _selectedKeys.clear();
-      _selectedCollectionIds.clear();
-    });
+    setState(_selection.toggleMode);
   }
 
   void _exitSelectionMode() {
-    setState(() {
-      _selectionMode = false;
-      _selectedKeys.clear();
-      _selectedCollectionIds.clear();
-    });
+    setState(_selection.exit);
   }
 
+  /// 散卡点击：普通点击切换 + 设锚点，Shift + 点击选中锚点到该卡的可见区间。
   void _toggleSelection(String key) {
-    setState(() {
-      if (!_selectedKeys.remove(key)) {
-        _selectedKeys.add(key);
-      }
-    });
+    setState(() => _selection.applyTap(
+          SelectionSlot.loose(key),
+          selectionTapKind(),
+        ));
   }
 
-  /// 块2：切换整合集选中（合集行头勾选框）。
+  /// 块2：切换整合集选中（合集行头勾选框）。Shift 同样在合集区内成段。
   void _toggleCollectionSelection(int collectionId) {
-    setState(() {
-      if (!_selectedCollectionIds.remove(collectionId)) {
-        _selectedCollectionIds.add(collectionId);
-      }
-    });
+    setState(() => _selection.applyTap(
+          SelectionSlot.collection(collectionId),
+          selectionTapKind(),
+        ));
+  }
+
+  /// 触屏长按卡片 / 桌面 Ctrl+点击：直接进入多选并选中该项。
+  void _enterSelectionWith(SelectionSlot slot) {
+    setState(() => _selection.enterWith(slot));
+  }
+
+  /// 散卡组的多选键（与 [_selectAll] 同一套：EPUB 用 `mediaIdentifier`、SRT 用
+  /// `srt_` 前缀 uid）。远端占位卡不可多选，返回 null。
+  String? _looseSelectionKey(_ShelfBookSlot slot) {
+    final MediaItem? epub = slot.epub;
+    if (epub != null) return epub.mediaIdentifier;
+    final SrtBook? srt = slot.srt;
+    if (srt != null) return 'srt_${srt.uid}';
+    return null;
   }
 
   @override
@@ -497,91 +511,101 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                 // 下拉同步可能跑几十秒，光一个转圈看不出进展；没同步在飞时零高度。
                 const SyncProgressBanner(),
                 Expanded(
-                  child: books.when(
-                    data: (bookList) {
-                      _batchAudiobookInfoFuture ??= _mangaOnly
-                          ? Future<Map<String, _AudiobookInfo>>.value(
-                              const <String, _AudiobookInfo>{},
-                            )
-                          : _loadAllAudiobookInfo();
-                      // BUG-1182：「显示远端条目」门控已前移进 _loadRemoteBooks
-                      // （关掉就不联网，而不是拉完再丢）。开关从关翻到开时 `??=` 不会
-                      // 重跑，故这里显式比对上轮门控值，翻转时重新取数——否则用户在设置
-                      // 里打开开关后要下拉刷新才看得到远端卡。
-                      if (_remoteGateAtLastLoad != null &&
-                          _remoteGateAtLastLoad != _shouldLoadRemoteBooks) {
-                        _remoteBooksFuture = null;
-                      }
-                      _remoteGateAtLastLoad = _shouldLoadRemoteBooks;
-                      _remoteBooksFuture ??= _loadRemoteBooks();
-                      _shelfMapsFuture ??= _loadShelfMaps();
-                      final List<MediaItem> shelfBooks =
-                          filterShelfEntriesByMangaSplit(
-                        bookList,
-                        mangaOnly: _mangaOnly,
-                      );
-                      final Set<String>? filterSet = filteredIds.valueOrNull;
-                      List<MediaItem> filtered;
-                      if (filterSet == null) {
-                        filtered = shelfBooks;
-                      } else {
-                        filtered = shelfBooks.where((item) {
-                          final String? key =
-                              _parseBookKey(item.mediaIdentifier);
-                          if (key == null) return false;
-                          // BUG-940：成员命中标签、或所属合集命中标签都保留（后者让
-                          // 打了标签的合集其成员整组存活，折叠出合集组）。
-                          return keepMemberUnderTagFilter(
-                            memberMatched: filterSet.contains(key),
-                            primaryCollectionId: _primaryCollectionByEntry[
-                                MediaKind.epub.compositeKey(key)],
-                            collectionFilter: tagCollectionFilter,
-                          );
-                        }).toList();
-                      }
-                      // P5-A：搜索按**显示名 + DB 原名**双口径匹配——改过名的书
-                      // 用户既可能记得新名也可能记得旧名，只匹配其一都会「搜不到
-                      // 明明在书架上的书」。归一化走与游戏库页同一份
-                      // [matchesMediaSearch]（全角/片假名/标点折叠）。
-                      if (_searchQuery.trim().isNotEmpty) {
-                        filtered = filtered.where((MediaItem item) {
-                          return matchesMediaSearch(
-                            query: _searchQuery,
-                            titles: <String>[
-                              ReaderHibikiSource.instance
-                                  .getDisplayTitleFromMediaItem(item),
-                              item.title,
-                            ],
-                          );
-                        }).toList();
-                      }
-                      return FutureBuilder<Map<String, _AudiobookInfo>>(
-                        future: _batchAudiobookInfoFuture,
-                        builder: (context, abSnapshot) =>
-                            FutureBuilder<_RemoteBookState?>(
-                          future: _remoteBooksFuture,
-                          builder: (context, remoteSnapshot) =>
-                              FutureBuilder<void>(
-                            future: _shelfMapsFuture,
-                            builder: (context, _) =>
-                                buildBody(filtered, remoteSnapshot),
+                  // 多选态才接管长按：长按落在卡上 = 起手扫选，不抬手滑动即刷出
+                  // 一段区间。非多选态原样透传（长按仍归卡片自身的菜单 / 进多选）。
+                  child: SelectionDragArea(
+                    enabled: _selectionMode,
+                    onDragBegin: (SelectionSlot slot) =>
+                        setState(() => _selection.beginRangeDrag(slot)),
+                    onDragUpdate: (SelectionSlot slot) =>
+                        setState(() => _selection.updateRangeDrag(slot)),
+                    onDragEnd: () => setState(_selection.endRangeDrag),
+                    child: books.when(
+                      data: (bookList) {
+                        _batchAudiobookInfoFuture ??= _mangaOnly
+                            ? Future<Map<String, _AudiobookInfo>>.value(
+                                const <String, _AudiobookInfo>{},
+                              )
+                            : _loadAllAudiobookInfo();
+                        // BUG-1182：「显示远端条目」门控已前移进 _loadRemoteBooks
+                        // （关掉就不联网，而不是拉完再丢）。开关从关翻到开时 `??=` 不会
+                        // 重跑，故这里显式比对上轮门控值，翻转时重新取数——否则用户在设置
+                        // 里打开开关后要下拉刷新才看得到远端卡。
+                        if (_remoteGateAtLastLoad != null &&
+                            _remoteGateAtLastLoad != _shouldLoadRemoteBooks) {
+                          _remoteBooksFuture = null;
+                        }
+                        _remoteGateAtLastLoad = _shouldLoadRemoteBooks;
+                        _remoteBooksFuture ??= _loadRemoteBooks();
+                        _shelfMapsFuture ??= _loadShelfMaps();
+                        final List<MediaItem> shelfBooks =
+                            filterShelfEntriesByMangaSplit(
+                          bookList,
+                          mangaOnly: _mangaOnly,
+                        );
+                        final Set<String>? filterSet = filteredIds.valueOrNull;
+                        List<MediaItem> filtered;
+                        if (filterSet == null) {
+                          filtered = shelfBooks;
+                        } else {
+                          filtered = shelfBooks.where((item) {
+                            final String? key =
+                                _parseBookKey(item.mediaIdentifier);
+                            if (key == null) return false;
+                            // BUG-940：成员命中标签、或所属合集命中标签都保留（后者让
+                            // 打了标签的合集其成员整组存活，折叠出合集组）。
+                            return keepMemberUnderTagFilter(
+                              memberMatched: filterSet.contains(key),
+                              primaryCollectionId: _primaryCollectionByEntry[
+                                  MediaKind.epub.compositeKey(key)],
+                              collectionFilter: tagCollectionFilter,
+                            );
+                          }).toList();
+                        }
+                        // P5-A：搜索按**显示名 + DB 原名**双口径匹配——改过名的书
+                        // 用户既可能记得新名也可能记得旧名，只匹配其一都会「搜不到
+                        // 明明在书架上的书」。归一化走与游戏库页同一份
+                        // [matchesMediaSearch]（全角/片假名/标点折叠）。
+                        if (_searchQuery.trim().isNotEmpty) {
+                          filtered = filtered.where((MediaItem item) {
+                            return matchesMediaSearch(
+                              query: _searchQuery,
+                              titles: <String>[
+                                ReaderHibikiSource.instance
+                                    .getDisplayTitleFromMediaItem(item),
+                                item.title,
+                              ],
+                            );
+                          }).toList();
+                        }
+                        return FutureBuilder<Map<String, _AudiobookInfo>>(
+                          future: _batchAudiobookInfoFuture,
+                          builder: (context, abSnapshot) =>
+                              FutureBuilder<_RemoteBookState?>(
+                            future: _remoteBooksFuture,
+                            builder: (context, remoteSnapshot) =>
+                                FutureBuilder<void>(
+                              future: _shelfMapsFuture,
+                              builder: (context, _) =>
+                                  buildBody(filtered, remoteSnapshot),
+                            ),
                           ),
-                        ),
-                      );
-                    },
-                    error: (error, stack) => buildError(
-                      error: error,
-                      stack: stack,
-                      refresh: () {
-                        _refreshSrtBooks();
-                        ref.invalidate(
-                          hibikiBooksProvider(JapaneseLanguage.instance),
                         );
                       },
+                      error: (error, stack) => buildError(
+                        error: error,
+                        stack: stack,
+                        refresh: () {
+                          _refreshSrtBooks();
+                          ref.invalidate(
+                            hibikiBooksProvider(JapaneseLanguage.instance),
+                          );
+                        },
+                      ),
+                      // BasePage 家族历史样式（25×25 主色圈），参数化保留、视觉不变。
+                      loading: () => buildLoading(
+                          size: 25, color: theme.colorScheme.primary),
                     ),
-                    // BasePage 家族历史样式（25×25 主色圈），参数化保留、视觉不变。
-                    loading: () => buildLoading(
-                        size: 25, color: theme.colorScheme.primary),
                   ),
                 ),
                 if (_selectionMode) _buildBatchActionBar(),
@@ -1324,6 +1348,20 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       for (final CollectionGroup<_ShelfBookSlot> g in shelfGroups)
         if (g.collection != null) g.collection!.id,
     ];
+    // Shift 区间选 / 长按扫选的顺序真值：与上面的合集顺序取自同一份 shelfGroups，
+    // 故与用户屏幕上的排列逐项一致（排序 / 搜索 / 标签筛选都已作用其上）。散卡组
+    // `collection == null` 且 items 长度恒 1；远端占位卡不参与多选（与 [_selectAll]
+    // 同判据），跳过。顺序一变，控制器自动清锚点。
+    final List<String> visibleLooseKeys = <String>[];
+    for (final CollectionGroup<_ShelfBookSlot> g in shelfGroups) {
+      if (g.collection != null) continue;
+      final String? key = _looseSelectionKey(g.items.first.payload);
+      if (key != null) visibleLooseKeys.add(key);
+    }
+    _selection.setVisibleOrder(
+      loose: visibleLooseKeys,
+      collections: _visibleCollectionIds,
+    );
     _epubCoverUrisByBookKey = epubCoverUrisByBookKey;
     _epubBackedBookKeys = epubBackedBookKeys;
     _epubProgressByBookKey = epubProgressByBookKey;
@@ -1463,48 +1501,52 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     // 导致「远端书已折进本地合集」时行头数字比眼前卡片少（甚至全为未下载远端书时显示
     // 「0 本」），与所见割裂（用户实报）。行头数字必须诚实反映该行看得见的卡片数。
     final int memberCount = group.items.length;
-    return Padding(
-      // 水平不加 padding：书卡自带 12px 内边距，与网格散卡左缘逐像素对齐。
-      padding: EdgeInsets.symmetric(
-        vertical: tokens.spacing.gap / 2,
-      ),
-      child: CollectionShelfRow(
-        key: ValueKey<String>('reader_shelf_collection_row_${collection.id}'),
-        title: collection.name,
-        countLabel: t.series_item_count(n: memberCount),
-        itemCount: group.items.length,
-        itemWidth: itemWidth,
-        rowHeight: rowHeight,
-        // 书卡自带 12px 内边距 → 行内间距归零，与散书网格视觉间距一致。
-        itemGap: 0,
-        headerFocusId:
-            HibikiFocusId('reader-shelf-collection-${collection.id}'),
-        onOpenDetail: () => _openCollectionDetail(collection),
-        collapsed:
-            appModel.prefsRepo.collapsedCollectionIds.contains(collection.id),
-        onToggleCollapsed: () => _toggleCollectionCollapsed(collection.id),
-        // 块2：多选态行头挂整选勾选框（选=选中整个合集）；成员卡多选态不可单独勾。
-        selectionCheckbox: _selectionMode
-            ? _buildSelectionCheck(
-                _selectedCollectionIds.contains(collection.id))
-            : null,
-        onToggleSelected: _selectionMode
-            ? () => _toggleCollectionSelection(collection.id)
-            : null,
-        // 拖标签到行头 = 给整个合集打标签（与散书书级拖放一致）。
-        onTagDropped: (BookTagRow tag) =>
-            _addTagToCollection(collection.id, tag),
-        // 拖书卡到行头 = 把该书加入本合集（payload 泛型与标签互不误接）。
-        onMediaDropped: (MediaRef mediaRef) =>
-            _addMediaToCollection(collection.id, mediaRef),
-        // 行头长按/右键 = 合集上下文菜单（统一三库页：打开/重命名/标签/删除）。
-        onContextMenu: () => _showCollectionContextMenu(collection),
-        // 行头下方展示该合集已打的标签 chip（与散书标签列同形）。
-        tags: ref.watch(collectionTagMapProvider).valueOrNull?[collection.id],
-        itemBuilder: (BuildContext _, int i) => _buildShelfMemberCard(
-          group.items[i].payload,
-          epubCoverUrisByBookKey,
-          selectable: false,
+    return SelectionSlotTarget(
+      // 长按扫选也能扫到合集行（合集区自成一段区间，不与散卡串区）。
+      slot: SelectionSlot.collection(collection.id),
+      child: Padding(
+        // 水平不加 padding：书卡自带 12px 内边距，与网格散卡左缘逐像素对齐。
+        padding: EdgeInsets.symmetric(
+          vertical: tokens.spacing.gap / 2,
+        ),
+        child: CollectionShelfRow(
+          key: ValueKey<String>('reader_shelf_collection_row_${collection.id}'),
+          title: collection.name,
+          countLabel: t.series_item_count(n: memberCount),
+          itemCount: group.items.length,
+          itemWidth: itemWidth,
+          rowHeight: rowHeight,
+          // 书卡自带 12px 内边距 → 行内间距归零，与散书网格视觉间距一致。
+          itemGap: 0,
+          headerFocusId:
+              HibikiFocusId('reader-shelf-collection-${collection.id}'),
+          onOpenDetail: () => _openCollectionDetail(collection),
+          collapsed:
+              appModel.prefsRepo.collapsedCollectionIds.contains(collection.id),
+          onToggleCollapsed: () => _toggleCollectionCollapsed(collection.id),
+          // 块2：多选态行头挂整选勾选框（选=选中整个合集）；成员卡多选态不可单独勾。
+          selectionCheckbox: _selectionMode
+              ? _buildSelectionCheck(
+                  _selectedCollectionIds.contains(collection.id))
+              : null,
+          onToggleSelected: _selectionMode
+              ? () => _toggleCollectionSelection(collection.id)
+              : null,
+          // 拖标签到行头 = 给整个合集打标签（与散书书级拖放一致）。
+          onTagDropped: (BookTagRow tag) =>
+              _addTagToCollection(collection.id, tag),
+          // 拖书卡到行头 = 把该书加入本合集（payload 泛型与标签互不误接）。
+          onMediaDropped: (MediaRef mediaRef) =>
+              _addMediaToCollection(collection.id, mediaRef),
+          // 行头长按/右键 = 合集上下文菜单（统一三库页：打开/重命名/标签/删除）。
+          onContextMenu: () => _showCollectionContextMenu(collection),
+          // 行头下方展示该合集已打的标签 chip（与散书标签列同形）。
+          tags: ref.watch(collectionTagMapProvider).valueOrNull?[collection.id],
+          itemBuilder: (BuildContext _, int i) => _buildShelfMemberCard(
+            group.items[i].payload,
+            epubCoverUrisByBookKey,
+            selectable: false,
+          ),
         ),
       ),
     );

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -345,7 +345,8 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
         ));
   }
 
-  /// 触屏长按卡片 / 桌面 Ctrl+点击：直接进入多选并选中该项。
+  /// 桌面 Ctrl/⌘/Shift + 点击：直接进入多选并选中该项。
+  /// 触屏（含外接键盘）只允许从明确的「选择」入口进入。
   void _enterSelectionWith(SelectionSlot slot) {
     setState(() => _selection.enterWith(slot));
   }
@@ -512,7 +513,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                 const SyncProgressBanner(),
                 Expanded(
                   // 多选态才接管长按：长按落在卡上 = 起手扫选，不抬手滑动即刷出
-                  // 一段区间。非多选态原样透传（长按仍归卡片自身的菜单 / 进多选）。
+                  // 一段区间。非多选态原样透传（长按仍归卡片自身的菜单）。
                   child: SelectionDragArea(
                     enabled: _selectionMode,
                     onDragBegin: (SelectionSlot slot) =>

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -385,43 +385,28 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
   bool _isSrtCollectionMember(String uid) =>
       _primaryCollectionByEntry.containsKey(MediaKind.srt.compositeKey(uid));
 
-  void _selectAll() {
-    _rebuild(() {
-      // 散卡：只选未折进合集的可见书（折进的成员由整合集选中，不单独勾）。
-      for (final item in _visibleEpubBooks) {
-        if (_isEpubCollectionMember(_parseBookKey(item.mediaIdentifier))) {
-          continue;
-        }
-        _selectedKeys.add(item.mediaIdentifier);
-      }
-      for (final book in _visibleSrtBooks) {
-        if (_isSrtCollectionMember(book.uid)) continue;
-        _selectedKeys.add('srt_${book.uid}');
-      }
-      _selectedCollectionIds.addAll(_visibleCollectionIds);
-    });
-  }
-
-  void _invertSelection() {
-    _rebuild(() {
-      final Set<String> allKeys = {
+  /// 全选 / 反选的候选散卡键：只含未折进合集的可见书（折进的成员由整合集选中，
+  /// 不单独勾）。两处共用同一份资格判据，避免全选与反选口径漂开。
+  Set<String> _selectableLooseKeys() => <String>{
         for (final item in _visibleEpubBooks)
           if (!_isEpubCollectionMember(_parseBookKey(item.mediaIdentifier)))
             item.mediaIdentifier,
         for (final book in _visibleSrtBooks)
           if (!_isSrtCollectionMember(book.uid)) 'srt_${book.uid}',
       };
-      final Set<String> inverted = allKeys.difference(_selectedKeys);
-      _selectedKeys
-        ..clear()
-        ..addAll(inverted);
-      final Set<int> allCollections = _visibleCollectionIds.toSet();
-      final Set<int> invertedCollections =
-          allCollections.difference(_selectedCollectionIds);
-      _selectedCollectionIds
-        ..clear()
-        ..addAll(invertedCollections);
-    });
+
+  void _selectAll() {
+    _rebuild(() => _selection.selectAll(
+          loose: _selectableLooseKeys(),
+          collections: _visibleCollectionIds,
+        ));
+  }
+
+  void _invertSelection() {
+    _rebuild(() => _selection.invert(
+          loose: _selectableLooseKeys(),
+          collections: _visibleCollectionIds,
+        ));
   }
 
   Widget _buildBatchActionBar() {

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -502,6 +502,8 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
   /// - 选中散卡 → 删媒体本体（EPUB/SRT，现状语义）；
   /// - 混选 → 确认框文案写明「删 N 个媒体、解散 M 个合集」。
   Future<void> _batchDeleteConfirm() async {
+    // 先剔幽灵键再取数：确认框里的 N / M 必须是真会被删的条数。
+    if (!await _pruneStaleSelection() || !mounted) return;
     final int mediaCount = _selectedKeys.length;
     final int collectionCount = _selectedCollectionIds.length;
     if (mediaCount == 0 && collectionCount == 0) return;
@@ -582,7 +584,52 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     HibikiToast.show(msg: successMsg);
   }
 
+  /// 批量操作前把选中集收敛到真实存在的条目上，真剔掉了就明说。
+  ///
+  /// 与视频库同一纪律（见 `home_video_page._pruneStaleSelection`）：选中集不随库
+  /// 变化剪枝，多选态期间同步下架 / 别处删除都会留下幽灵键，落库时撞外键——打标签
+  /// 会把弹窗卡死在 loading、组合会静默失败、确认框数字是虚数。
+  ///
+  /// 存在性全集取**全库**而非可见集：被搜索或标签筛掉的书仍然存在，用户先勾后筛
+  /// 是合法用法，不该被悄悄剔掉。
+  ///
+  /// 返回剔完后是否还有东西可做。
+  Future<bool> _pruneStaleSelection() async {
+    if (_selection.isEmpty) return false;
+    final HibikiDatabase db = appModel.database;
+    // 存在性真值必须取自**书架选择键的来源表**，不是名字相近的 `media_items`：
+    // 书架 EPUB 卡的选择键是 `ReaderHibikiSource.mediaIdentifierFor(bookKey)`，
+    // bookKey 的真值在 `epub_books`（`hibikiBooksProvider` 也是从这里取的）；
+    // `getAllMediaItems()` 是另一张表、另一套 mediaIdentifier 语义，拿它做判据
+    // 会把全部选中项误判成幽灵键而整批剔光。
+    final List<EpubBookRow> epubBooks = await db.getAllEpubBooks();
+    final List<SrtBook> srtBooks = await SrtBookRepository(db).listAll();
+    final List<MediaCollectionRow> collections =
+        await db.getAllMediaCollections();
+    if (!mounted) return false;
+    final int dropped = _selection.retainExisting(
+      loose: <String>{
+        for (final EpubBookRow row in epubBooks)
+          ReaderHibikiSource.mediaIdentifierFor(row.bookKey),
+        for (final SrtBook book in srtBooks) 'srt_${book.uid}',
+      },
+      collections: <int>{for (final MediaCollectionRow c in collections) c.id},
+    );
+    if (dropped == 0) return _selection.isNotEmpty;
+    _rebuild(() {});
+    HibikiToast.show(
+      msg: t.batch_selection_stale_skipped(
+        n: dropped + _selection.length,
+        m: dropped,
+      ),
+    );
+    return _selection.isNotEmpty;
+  }
+
   Future<void> _batchShowTagPicker() async {
+    // 幽灵键会让 bookTags 外键插入抛异常，弹窗把落库 await 在 loading 态里，
+    // 一抛就永远转圈（卡死）。必须在开弹窗前剔干净。
+    if (!await _pruneStaleSelection() || !mounted) return;
     final allTags = ref.read(allTagsProvider).valueOrNull;
     if (allTags == null || allTags.isEmpty) {
       HibikiToast.show(msg: t.tag_no_tags_hint);
@@ -610,6 +657,8 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
   /// - 恰 1 合集 + 若干散卡 → 散卡并入该合集（[_combineAddToExisting]，不弹命名）；
   /// - ≥2 合集（可带散卡）→ 合并成一个（[_combineMergeCollections]，默认名=成员最多合集名）。
   Future<void> _batchCombineIntoSeries() async {
+    // 幽灵键会让 addToCollection 撞外键且无人 catch（用户只看到「点了没反应」）。
+    if (!await _pruneStaleSelection() || !mounted) return;
     final List<int> collectionIds = _selectedCollectionIds.toList()..sort();
     final List<ShelfEntryRef> looseRefs = <ShelfEntryRef>[
       for (final String key in _selectedKeys)

--- a/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
@@ -216,10 +216,6 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
     final double selectionInset = tokens.spacing.gap / 2;
     final SelectionSlot? slot =
         selectionKey == null ? null : SelectionSlot.loose(selectionKey);
-    // 触屏：长按 = 进多选（菜单改由封面右下角 [ShelfCardMenuButton] 触发）。
-    // 桌面：长按 / 右键仍是菜单（鼠标按住不动就是在等菜单，不该跳进多选）。
-    final bool touch = isTouchSelectionPlatform(context);
-    final bool touchLongPressSelects = touch && slot != null;
     void handleTap() {
       if (slot == null) {
         onTap();
@@ -237,11 +233,6 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
       onTap();
     }
 
-    final VoidCallback? longPressAction = _selectionMode
-        ? null
-        : (touchLongPressSelects
-            ? () => _enterSelectionWith(slot)
-            : onLongPress);
     Widget interactiveCard = Padding(
       key: cardKey,
       padding: EdgeInsets.all(tokens.spacing.rowVertical),
@@ -251,7 +242,9 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
           canRequestFocus: false,
           borderRadius: tokens.radii.cardRadius,
           onTap: handleTap,
-          onLongPress: longPressAction,
+          // 未进入选择态时，触屏与桌面长按都保留上下文菜单；只有显式进入选择态后
+          // 才摘掉卡片识别器，让祖先 SelectionDragArea 接管长按扫选。
+          onLongPress: _selectionMode ? null : onLongPress,
           // 桌面端鼠标右键打开与长按相同的书籍上下文菜单（PC 用户惯例）。多选态
           // 压制不变。
           onSecondaryTap: _selectionMode ? null : onLongPress,
@@ -266,19 +259,6 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
                     top: selectionInset,
                     left: selectionInset,
                     child: ShelfSelectionCheck(selected: selected),
-                  ),
-                // 触屏菜单入口：长按被多选占用后，这是菜单唯一的触达方式。多选态
-                // 不渲染（此时全卡都是勾选目标）。
-                //
-                // 落在**封面右下角**：右上角是恒有的类型徽章（[_bookCardLayout] 的
-                // `coverBadge`，与本按钮同为 22px 圆形，挨在一起会被读成两颗按钮），
-                // 左上角是标签列。封面底部只有细进度条（`metadata`），故按 footer
-                // 高度 + 内边距把按钮抬到封面区内，与视频卡的 ⋮ 位置同侧。
-                if (touchLongPressSelects && !_selectionMode)
-                  Positioned(
-                    bottom: ShelfCardFooter.heightFor(context) + selectionInset,
-                    right: selectionInset,
-                    child: ShelfCardMenuButton(onPressed: onLongPress),
                   ),
                 if (selected)
                   const Positioned.fill(child: ShelfSelectedOverlay()),

--- a/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
@@ -216,7 +216,7 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
     final double selectionInset = tokens.spacing.gap / 2;
     final SelectionSlot? slot =
         selectionKey == null ? null : SelectionSlot.loose(selectionKey);
-    // 触屏：长按 = 进多选（菜单改由封面右上角 [ShelfCardMenuButton] 触发）。
+    // 触屏：长按 = 进多选（菜单改由封面右下角 [ShelfCardMenuButton] 触发）。
     // 桌面：长按 / 右键仍是菜单（鼠标按住不动就是在等菜单，不该跳进多选）。
     final bool touch = isTouchSelectionPlatform(context);
     final bool touchLongPressSelects = touch && slot != null;

--- a/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/card_widgets.part.dart
@@ -214,9 +214,34 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
         selectionKey != null && _selectedKeys.contains(selectionKey);
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final double selectionInset = tokens.spacing.gap / 2;
-    final VoidCallback effectiveTap = _selectionMode && selectionKey != null
-        ? () => _toggleSelection(selectionKey)
-        : onTap;
+    final SelectionSlot? slot =
+        selectionKey == null ? null : SelectionSlot.loose(selectionKey);
+    // 触屏：长按 = 进多选（菜单改由封面右上角 [ShelfCardMenuButton] 触发）。
+    // 桌面：长按 / 右键仍是菜单（鼠标按住不动就是在等菜单，不该跳进多选）。
+    final bool touch = isTouchSelectionPlatform(context);
+    final bool touchLongPressSelects = touch && slot != null;
+    void handleTap() {
+      if (slot == null) {
+        onTap();
+        return;
+      }
+      if (_selectionMode) {
+        _toggleSelection(slot.looseKey!);
+        return;
+      }
+      // 桌面 Ctrl/⌘（macOS）/ Shift + 点击 = 不经工具栏直接进多选并选中该卡。
+      if (selectionEntryModifierPressed(context)) {
+        _enterSelectionWith(slot);
+        return;
+      }
+      onTap();
+    }
+
+    final VoidCallback? longPressAction = _selectionMode
+        ? null
+        : (touchLongPressSelects
+            ? () => _enterSelectionWith(slot)
+            : onLongPress);
     Widget interactiveCard = Padding(
       key: cardKey,
       padding: EdgeInsets.all(tokens.spacing.rowVertical),
@@ -225,9 +250,10 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
         child: InkWell(
           canRequestFocus: false,
           borderRadius: tokens.radii.cardRadius,
-          onTap: effectiveTap,
-          onLongPress: _selectionMode ? null : onLongPress,
-          // 桌面端鼠标右键打开与长按相同的书籍上下文菜单（PC 用户惯例）。
+          onTap: handleTap,
+          onLongPress: longPressAction,
+          // 桌面端鼠标右键打开与长按相同的书籍上下文菜单（PC 用户惯例）。多选态
+          // 压制不变。
           onSecondaryTap: _selectionMode ? null : onLongPress,
           child: AspectRatio(
             aspectRatio: slotAspectRatio,
@@ -240,6 +266,19 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
                     top: selectionInset,
                     left: selectionInset,
                     child: ShelfSelectionCheck(selected: selected),
+                  ),
+                // 触屏菜单入口：长按被多选占用后，这是菜单唯一的触达方式。多选态
+                // 不渲染（此时全卡都是勾选目标）。
+                //
+                // 落在**封面右下角**：右上角是恒有的类型徽章（[_bookCardLayout] 的
+                // `coverBadge`，与本按钮同为 22px 圆形，挨在一起会被读成两颗按钮），
+                // 左上角是标签列。封面底部只有细进度条（`metadata`），故按 footer
+                // 高度 + 内边距把按钮抬到封面区内，与视频卡的 ⋮ 位置同侧。
+                if (touchLongPressSelects && !_selectionMode)
+                  Positioned(
+                    bottom: ShelfCardFooter.heightFor(context) + selectionInset,
+                    right: selectionInset,
+                    child: ShelfCardMenuButton(onPressed: onLongPress),
                   ),
                 if (selected)
                   const Positioned.fill(child: ShelfSelectedOverlay()),
@@ -254,7 +293,7 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
         actions: <Type, Action<Intent>>{
           ActivateIntent: CallbackAction<ActivateIntent>(
             onInvoke: (_) {
-              effectiveTap();
+              handleTap();
               return null;
             },
           ),
@@ -286,6 +325,11 @@ extension _ReaderHistoryCardWidgets on _ReaderHibikiHistoryPageState {
         label: dragLabel ?? '',
         child: result,
       );
+    }
+    // 长按扫选靠命中测试反查「手指下面是哪一格」，故身份标记包在最外层（
+    // [MetaData] 默认 deferToChild，只有真命中卡片时才进命中路径）。不改布局。
+    if (slot != null) {
+      result = SelectionSlotTarget(slot: slot, child: result);
     }
     return result;
   }

--- a/hibiki/lib/src/utils/components/shelf_card_widgets.dart
+++ b/hibiki/lib/src/utils/components/shelf_card_widgets.dart
@@ -71,7 +71,9 @@ class ShelfCardFooter extends StatelessWidget {
   }
 }
 
-/// 触屏上卡片上下文菜单的入口按钮（封面右上角）。
+/// 触屏上卡片上下文菜单的入口按钮（由调用方 [Positioned] 落在封面**右下角**——
+/// 右上角在书卡是类型徽章、在视频卡是播放列表 / 云角标，同形同尺寸挨在一起会被
+/// 读成两颗按钮）。
 ///
 /// 存在的理由：长按在触屏上已改判给「进入多选」（见
 /// `media/selection/selection_gestures.dart` 的手势归属表），菜单必须另有入口。

--- a/hibiki/lib/src/utils/components/shelf_card_widgets.dart
+++ b/hibiki/lib/src/utils/components/shelf_card_widgets.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 import 'package:hibiki/src/utils/cover_image.dart';
@@ -63,6 +64,54 @@ class ShelfCardFooter extends StatelessWidget {
           style: tokens.type.metadata.copyWith(
             color: tokens.surfaces.onSurface,
             fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 触屏上卡片上下文菜单的入口按钮（封面右上角）。
+///
+/// 存在的理由：长按在触屏上已改判给「进入多选」（见
+/// `media/selection/selection_gestures.dart` 的手势归属表），菜单必须另有入口。
+/// 桌面不建此按钮——右键仍是菜单，鼠标按住不动也仍是菜单，加个常驻按钮只会污染
+/// 封面。
+///
+/// 尺寸取 [kMinInteractiveDimension] 的一半再加内边距，落在触屏可点区下限附近；
+/// 底色与 [ShelfSelectionCheck] 同源（eink 去半透明），确保浅色封面上仍可辨。
+class ShelfCardMenuButton extends StatelessWidget {
+  const ShelfCardMenuButton({required this.onPressed, super.key});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final bool eink = isEinkTheme(context);
+    final Color fill = eink
+        ? tokens.surfaces.page
+        : tokens.surfaces.page.withValues(alpha: 0.7);
+    return Tooltip(
+      message: t.common_more_actions,
+      child: Material(
+        color: fill,
+        shape: CircleBorder(
+          side: BorderSide(color: tokens.surfaces.outline),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          // 卡片本体的 onTap 是「打开条目」；这颗按钮必须自己吃掉点击，
+          // 否则点菜单等于开书。
+          onTap: onPressed,
+          customBorder: const CircleBorder(),
+          child: Padding(
+            padding: EdgeInsets.all(tokens.spacing.gap / 2),
+            child: Icon(
+              Icons.more_vert,
+              size: tokens.spacing.gap * 1.75,
+              color: tokens.surfaces.onSurface,
+            ),
           ),
         ),
       ),

--- a/hibiki/lib/src/utils/components/shelf_card_widgets.dart
+++ b/hibiki/lib/src/utils/components/shelf_card_widgets.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/utils/adaptive/adaptive_platform.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 import 'package:hibiki/src/utils/cover_image.dart';
@@ -64,56 +63,6 @@ class ShelfCardFooter extends StatelessWidget {
           style: tokens.type.metadata.copyWith(
             color: tokens.surfaces.onSurface,
             fontWeight: FontWeight.w600,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// 触屏上卡片上下文菜单的入口按钮（由调用方 [Positioned] 落在封面**右下角**——
-/// 右上角在书卡是类型徽章、在视频卡是播放列表 / 云角标，同形同尺寸挨在一起会被
-/// 读成两颗按钮）。
-///
-/// 存在的理由：长按在触屏上已改判给「进入多选」（见
-/// `media/selection/selection_gestures.dart` 的手势归属表），菜单必须另有入口。
-/// 桌面不建此按钮——右键仍是菜单，鼠标按住不动也仍是菜单，加个常驻按钮只会污染
-/// 封面。
-///
-/// 尺寸取 [kMinInteractiveDimension] 的一半再加内边距，落在触屏可点区下限附近；
-/// 底色与 [ShelfSelectionCheck] 同源（eink 去半透明），确保浅色封面上仍可辨。
-class ShelfCardMenuButton extends StatelessWidget {
-  const ShelfCardMenuButton({required this.onPressed, super.key});
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
-    final bool eink = isEinkTheme(context);
-    final Color fill = eink
-        ? tokens.surfaces.page
-        : tokens.surfaces.page.withValues(alpha: 0.7);
-    return Tooltip(
-      message: t.common_more_actions,
-      child: Material(
-        color: fill,
-        shape: CircleBorder(
-          side: BorderSide(color: tokens.surfaces.outline),
-        ),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          // 卡片本体的 onTap 是「打开条目」；这颗按钮必须自己吃掉点击，
-          // 否则点菜单等于开书。
-          onTap: onPressed,
-          customBorder: const CircleBorder(),
-          child: Padding(
-            padding: EdgeInsets.all(tokens.spacing.gap / 2),
-            child: Icon(
-              Icons.more_vert,
-              size: tokens.spacing.gap * 1.75,
-              color: tokens.surfaces.onSurface,
-            ),
           ),
         ),
       ),

--- a/hibiki/test/media/media_selection_controller_test.dart
+++ b/hibiki/test/media/media_selection_controller_test.dart
@@ -218,4 +218,92 @@ void main() {
       expect(set, hasLength(2));
     });
   });
+
+  group('retainExisting（批量操作前剔除幽灵键）', () {
+    /// 建一个「选了 3 张散卡 + 2 个合集」的多选态。
+    MediaSelectionController seeded() {
+      final MediaSelectionController c = MediaSelectionController();
+      c.setVisibleOrder(
+        loose: <String>['a', 'b', 'c'],
+        collections: <int>[10, 20],
+      );
+      c.enterWith(const SelectionSlot.loose('a'));
+      c.toggle(const SelectionSlot.loose('b'));
+      c.toggle(const SelectionSlot.loose('c'));
+      c.toggle(const SelectionSlot.collection(10));
+      c.toggle(const SelectionSlot.collection(20));
+      return c;
+    }
+
+    test('全都还在时不剔任何东西，返回 0，锚点保留', () {
+      final MediaSelectionController c = seeded();
+      final SelectionSlot? anchorBefore = c.anchor;
+      final int dropped = c.retainExisting(
+        loose: <String>{'a', 'b', 'c'},
+        collections: <int>{10, 20},
+      );
+      expect(dropped, 0);
+      expect(c.looseKeys, <String>{'a', 'b', 'c'});
+      expect(c.collectionIds, <int>{10, 20});
+      expect(c.anchor, anchorBefore);
+    });
+
+    test('散卡与合集各剔掉一个，返回总剔除数', () {
+      final MediaSelectionController c = seeded();
+      // 同步把 b 和合集 20 下架了。
+      final int dropped = c.retainExisting(
+        loose: <String>{'a', 'c'},
+        collections: <int>{10},
+      );
+      expect(dropped, 2);
+      expect(c.looseKeys, <String>{'a', 'c'});
+      expect(c.collectionIds, <int>{10});
+      expect(c.length, 3);
+    });
+
+    test('剔除后锚点失效——它可能正指着被剔掉的那一格', () {
+      final MediaSelectionController c = seeded();
+      expect(c.anchor, isNotNull);
+      c.retainExisting(
+        loose: <String>{'a', 'b'},
+        collections: <int>{10, 20},
+      );
+      expect(c.anchor, isNull);
+    });
+
+    test('存在性全集比选中集大也不会凭空多选（只做交集，不做并集）', () {
+      final MediaSelectionController c = seeded();
+      final int dropped = c.retainExisting(
+        loose: <String>{'a', 'b', 'c', 'd', 'e'},
+        collections: <int>{10, 20, 30},
+      );
+      expect(dropped, 0);
+      expect(c.looseKeys, <String>{'a', 'b', 'c'});
+      expect(c.collectionIds, <int>{10, 20});
+    });
+
+    test('全部消失时清空并返回原长度，调用方据此中止批量操作', () {
+      final MediaSelectionController c = seeded();
+      final int dropped = c.retainExisting(
+        loose: const <String>{},
+        collections: const <int>{},
+      );
+      expect(dropped, 5);
+      expect(c.isEmpty, isTrue);
+      // 多选态本身不被 retainExisting 关掉——关不关由调用方决定。
+      expect(c.active, isTrue);
+    });
+
+    test('「已跳过 M 项 / 共 N 项」的 N 由剔除数 + 剩余数还原得出', () {
+      final MediaSelectionController c = seeded();
+      final int dropped = c.retainExisting(
+        loose: <String>{'a'},
+        collections: <int>{10},
+      );
+      // 两个页面都用 `dropped + length` 还原用户当初勾的总数，别让提示里的 N
+      // 变成剔除后的数字（那样 M/N 会自相矛盾）。
+      expect(dropped + c.length, 5);
+      expect(dropped, 3);
+    });
+  });
 }

--- a/hibiki/test/media/media_selection_controller_test.dart
+++ b/hibiki/test/media/media_selection_controller_test.dart
@@ -1,0 +1,221 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/selection/media_selection_controller.dart';
+
+/// 库页多选状态机：区间选、扫选、锚点失效、分区隔离。
+///
+/// 这些规则以前分散在书架 / 视频库两页的 setState 里，谁都测不到；抽成纯 Dart
+/// 类后在这里一次性钉死，两页共用同一份行为。
+void main() {
+  late MediaSelectionController controller;
+
+  /// 一个典型库页：3 个合集行 + 5 张散卡。
+  void seedVisible() {
+    controller.setVisibleOrder(
+      loose: const <String>['a', 'b', 'c', 'd', 'e'],
+      collections: const <int>[10, 20, 30],
+    );
+  }
+
+  setUp(() {
+    controller = MediaSelectionController();
+    seedVisible();
+  });
+
+  group('模式与入口', () {
+    test('初始不在多选态，toggleMode 开关并清空', () {
+      expect(controller.active, isFalse);
+      controller.toggleMode();
+      expect(controller.active, isTrue);
+      controller.toggle(const SelectionSlot.loose('a'));
+      expect(controller.looseKeys, <String>{'a'});
+      controller.toggleMode();
+      expect(controller.active, isFalse);
+      expect(controller.isEmpty, isTrue);
+    });
+
+    test('enterWith 从非多选态进入并选中该项', () {
+      controller.enterWith(const SelectionSlot.loose('c'));
+      expect(controller.active, isTrue);
+      expect(controller.looseKeys, <String>{'c'});
+    });
+
+    test('已在多选态时 enterWith 退化为切换，不清空既有选中集', () {
+      controller.enterWith(const SelectionSlot.loose('a'));
+      controller.toggle(const SelectionSlot.loose('b'));
+      // 长按已选中的 b：只取消 b，a 必须留着（曾经的踩坑：重进多选把全清了）。
+      controller.enterWith(const SelectionSlot.loose('b'));
+      expect(controller.looseKeys, <String>{'a'});
+      expect(controller.active, isTrue);
+    });
+
+    test('exit 关闭并清空；clearSelection 只清空、留在多选态', () {
+      controller.enterWith(const SelectionSlot.loose('a'));
+      controller.clearSelection();
+      expect(controller.active, isTrue);
+      expect(controller.isEmpty, isTrue);
+      controller.toggle(const SelectionSlot.loose('a'));
+      controller.exit();
+      expect(controller.active, isFalse);
+      expect(controller.isEmpty, isTrue);
+    });
+  });
+
+  group('Shift 区间选', () {
+    test('锚点到目标的可见区间整段并入（正向）', () {
+      controller.toggle(const SelectionSlot.loose('b'));
+      controller.extendTo(const SelectionSlot.loose('d'));
+      expect(controller.looseKeys, <String>{'b', 'c', 'd'});
+    });
+
+    test('反向 Shift 点击同样成立', () {
+      controller.toggle(const SelectionSlot.loose('d'));
+      controller.extendTo(const SelectionSlot.loose('b'));
+      expect(controller.looseKeys, <String>{'b', 'c', 'd'});
+    });
+
+    test('区间只增不减，锚点不动，可反复调整末端', () {
+      controller.toggle(const SelectionSlot.loose('b'));
+      controller.extendTo(const SelectionSlot.loose('d'));
+      controller.extendTo(const SelectionSlot.loose('e'));
+      expect(controller.looseKeys, <String>{'b', 'c', 'd', 'e'});
+      expect(controller.anchor, const SelectionSlot.loose('b'));
+    });
+
+    test('无锚点时退化为普通切换', () {
+      controller.extendTo(const SelectionSlot.loose('c'));
+      expect(controller.looseKeys, <String>{'c'});
+    });
+
+    test('合集区自己的区间选', () {
+      controller.toggle(const SelectionSlot.collection(10));
+      controller.extendTo(const SelectionSlot.collection(30));
+      expect(controller.collectionIds, <int>{10, 20, 30});
+      expect(controller.looseKeys, isEmpty);
+    });
+
+    test('跨分区退化为普通切换并重设锚点，不牵连另一区', () {
+      controller.toggle(const SelectionSlot.collection(10));
+      controller.extendTo(const SelectionSlot.loose('d'));
+      expect(controller.collectionIds, <int>{10});
+      expect(controller.looseKeys, <String>{'d'});
+      // 锚点已挪到散卡区，接着 Shift 点击在散卡区内正常成段。
+      controller.extendTo(const SelectionSlot.loose('b'));
+      expect(controller.looseKeys, <String>{'b', 'c', 'd'});
+    });
+
+    test('目标已不在可见顺序里时退化为普通切换', () {
+      controller.toggle(const SelectionSlot.loose('b'));
+      controller.extendTo(const SelectionSlot.loose('zzz'));
+      expect(controller.looseKeys, <String>{'b', 'zzz'});
+    });
+  });
+
+  group('锚点随可见顺序失效', () {
+    test('排序/筛选变化后 Shift 点击退化为切换，不会选中一片没看见的条目', () {
+      controller.toggle(const SelectionSlot.loose('b'));
+      // 用户改了排序：可见顺序整个换了。
+      controller.setVisibleOrder(
+        loose: const <String>['e', 'd', 'c', 'b', 'a'],
+        collections: const <int>[10, 20, 30],
+      );
+      controller.extendTo(const SelectionSlot.loose('a'));
+      expect(controller.looseKeys, <String>{'b', 'a'});
+    });
+
+    test('同内容的新列表（每帧重建）不算变化，锚点保留', () {
+      controller.toggle(const SelectionSlot.loose('b'));
+      controller.setVisibleOrder(
+        loose: <String>['a', 'b', 'c', 'd', 'e'],
+        collections: <int>[10, 20, 30],
+      );
+      controller.extendTo(const SelectionSlot.loose('d'));
+      expect(controller.looseKeys, <String>{'b', 'c', 'd'});
+    });
+  });
+
+  group('长按扫选', () {
+    test('从起点刷到目标，等价于区间选', () {
+      controller.beginRangeDrag(const SelectionSlot.loose('b'));
+      controller.updateRangeDrag(const SelectionSlot.loose('d'));
+      controller.endRangeDrag();
+      expect(controller.looseKeys, <String>{'b', 'c', 'd'});
+      expect(controller.isRangeDragging, isFalse);
+    });
+
+    test('手指往回滑取消刚刷上的一段（基线语义，不是只增不减）', () {
+      controller.beginRangeDrag(const SelectionSlot.loose('b'));
+      controller.updateRangeDrag(const SelectionSlot.loose('e'));
+      expect(controller.looseKeys, <String>{'b', 'c', 'd', 'e'});
+      controller.updateRangeDrag(const SelectionSlot.loose('c'));
+      expect(controller.looseKeys, <String>{'b', 'c'});
+    });
+
+    test('扫选叠加在已有选中集之上，不抹掉先前的选择', () {
+      controller.toggle(const SelectionSlot.loose('a'));
+      controller.beginRangeDrag(const SelectionSlot.loose('c'));
+      controller.updateRangeDrag(const SelectionSlot.loose('d'));
+      expect(controller.looseKeys, <String>{'a', 'c', 'd'});
+      // 回滑到起点：a 是基线的一部分，必须留着。
+      controller.updateRangeDrag(const SelectionSlot.loose('c'));
+      expect(controller.looseKeys, <String>{'a', 'c'});
+    });
+
+    test('起点已选中时扫选不把它取消（并入语义）', () {
+      controller.toggle(const SelectionSlot.loose('c'));
+      controller.beginRangeDrag(const SelectionSlot.loose('c'));
+      expect(controller.looseKeys, <String>{'c'});
+    });
+
+    test('滑到另一分区时保持上一帧结果，不抖动', () {
+      controller.beginRangeDrag(const SelectionSlot.loose('b'));
+      controller.updateRangeDrag(const SelectionSlot.loose('d'));
+      controller.updateRangeDrag(const SelectionSlot.collection(20));
+      expect(controller.looseKeys, <String>{'b', 'c', 'd'});
+      expect(controller.collectionIds, isEmpty);
+    });
+
+    test('未开始扫选时的 update 是 no-op', () {
+      controller.updateRangeDrag(const SelectionSlot.loose('d'));
+      expect(controller.isEmpty, isTrue);
+    });
+  });
+
+  group('全选 / 反选', () {
+    test('全选只并入调用方给的候选（各页资格规则留在页里）', () {
+      controller.selectAll(
+        loose: const <String>['a', 'c'],
+        collections: const <int>[10],
+      );
+      expect(controller.looseKeys, <String>{'a', 'c'});
+      expect(controller.collectionIds, <int>{10});
+    });
+
+    test('反选在候选集内取补集并清锚点', () {
+      controller.toggle(const SelectionSlot.loose('b'));
+      controller.invert(
+        loose: const <String>['a', 'b', 'c'],
+        collections: const <int>[10, 20],
+      );
+      expect(controller.looseKeys, <String>{'a', 'c'});
+      expect(controller.collectionIds, <int>{10, 20});
+      expect(controller.anchor, isNull);
+    });
+  });
+
+  group('SelectionSlot 值语义', () {
+    test('同值相等、可作 Set 键；两分区互不相等', () {
+      expect(const SelectionSlot.loose('a'), const SelectionSlot.loose('a'));
+      expect(const SelectionSlot.collection(1),
+          isNot(const SelectionSlot.loose('1')));
+      // 逐个 add 而非 set 字面量：字面量里的重复元素会被
+      // `equal_elements_in_set` 判为 warning（CI 视 warning 为致命），而 `.toSet()`
+      // 又撞 `prefer_collection_literals`。这里的重复正是被测行为。
+      final Set<SelectionSlot> set = <SelectionSlot>{};
+      set.add(const SelectionSlot.loose('a'));
+      set.add(const SelectionSlot.loose('a'));
+      set.add(const SelectionSlot.collection(1));
+      expect(set, hasLength(2));
+    });
+  });
+}

--- a/hibiki/test/media/selection_gestures_test.dart
+++ b/hibiki/test/media/selection_gestures_test.dart
@@ -226,6 +226,39 @@ void main() {
       expect(selectionEntryModifierPressed(ctx), isFalse);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
     });
+
+    testWidgets('Android/iOS/Fuchsia 外接键盘修饰键也不能绕过明确选择入口',
+        (WidgetTester tester) async {
+      for (final TargetPlatform platform in <TargetPlatform>[
+        TargetPlatform.android,
+        TargetPlatform.iOS,
+        TargetPlatform.fuchsia,
+      ]) {
+        late BuildContext ctx;
+        await tester.pumpWidget(MaterialApp(
+          theme: ThemeData(platform: platform),
+          home: Builder(builder: (BuildContext context) {
+            ctx = context;
+            return const SizedBox();
+          }),
+        ));
+        await tester.pumpAndSettle();
+
+        for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+          LogicalKeyboardKey.shiftLeft,
+          LogicalKeyboardKey.controlLeft,
+          LogicalKeyboardKey.metaLeft,
+        ]) {
+          await tester.sendKeyDownEvent(key);
+          expect(
+            selectionEntryModifierPressed(ctx),
+            isFalse,
+            reason: '$platform + $key 必须先点明确的「选择」入口',
+          );
+          await tester.sendKeyUpEvent(key);
+        }
+      }
+    });
   });
 
   group('进/退多选态不重建子树（滚动位置守卫）', () {

--- a/hibiki/test/media/selection_gestures_test.dart
+++ b/hibiki/test/media/selection_gestures_test.dart
@@ -139,13 +139,14 @@ void main() {
       onChanged: () {},
     ));
 
-    expect(find.byType(GestureDetector), findsNothing);
+    // 刻意**不**断言「树里没有 GestureDetector」：那是在钉实现形状，而恰恰是
+    // 那个形状（enabled=false 时 early-return child）导致进/退多选态整棵子树重建、
+    // 把列表滚动位置冲回顶部。唯一该钉的是行为——长按不产生任何选中。
     await longPressDrag(tester, from: 'card-0', to: 'card-2');
     expect(controller.looseKeys, isEmpty);
   });
 
-  testWidgets('扫选期间每跨一张卡才回调一次（同卡内的高频移动被去重）',
-      (WidgetTester tester) async {
+  testWidgets('扫选期间每跨一张卡才回调一次（同卡内的高频移动被去重）', (WidgetTester tester) async {
     final MediaSelectionController controller = MediaSelectionController();
     controller.setVisibleOrder(
       loose: <String>['card-0', 'card-1', 'card-2', 'card-3', 'card-4'],
@@ -181,8 +182,7 @@ void main() {
   });
 
   group('修饰键判定', () {
-    testWidgets('按住 Shift 时点击 = 区间扩选，否则普通切换',
-        (WidgetTester tester) async {
+    testWidgets('按住 Shift 时点击 = 区间扩选，否则普通切换', (WidgetTester tester) async {
       expect(selectionTapKind(), SelectionTapKind.toggle);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
       expect(selectionTapKind(), SelectionTapKind.extend);
@@ -190,8 +190,7 @@ void main() {
       expect(selectionTapKind(), SelectionTapKind.toggle);
     });
 
-    testWidgets('Windows/Linux 用 Ctrl 进多选，⌘ 不算',
-        (WidgetTester tester) async {
+    testWidgets('Windows/Linux 用 Ctrl 进多选，⌘ 不算', (WidgetTester tester) async {
       late BuildContext ctx;
       await tester.pumpWidget(MaterialApp(
         theme: ThemeData(platform: TargetPlatform.windows),
@@ -253,6 +252,121 @@ void main() {
       expect(await touchOn(TargetPlatform.windows), isFalse);
       expect(await touchOn(TargetPlatform.macOS), isFalse);
       expect(await touchOn(TargetPlatform.linux), isFalse);
+    });
+  });
+
+  group('进/退多选态不重建子树（滚动位置守卫）', () {
+    /// 一条长列表包在 [SelectionDragArea] 里；[enabled] 由外部 setState 翻转，
+    /// 模拟用户点工具栏进/退多选。
+    Widget buildScrollHarness({
+      required ValueNotifier<bool> enabled,
+      required ScrollController scrollController,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: ValueListenableBuilder<bool>(
+            valueListenable: enabled,
+            builder: (BuildContext context, bool on, Widget? _) {
+              return SelectionDragArea(
+                enabled: on,
+                onDragBegin: (SelectionSlot _) {},
+                onDragUpdate: (SelectionSlot _) {},
+                onDragEnd: () {},
+                child: ListView.builder(
+                  controller: scrollController,
+                  itemCount: 200,
+                  itemBuilder: (BuildContext _, int i) => SizedBox(
+                    height: 50,
+                    child: Text('item $i'),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      );
+    }
+
+    // 用户正翻到列表中段，点「选择」进多选——不该被弹回顶部。旧实现在
+    // `!enabled` 时 early-return `child`，翻转 enabled 会让这一层的子 widget
+    // runtimeType 从 GestureDetector 变成业务子树（或反过来），Element 无法复用，
+    // 整棵 body 连同 Scrollable 一起重建，滚动位置归零（两个库页都没有
+    // PageStorageKey / 外挂 ScrollController 兜底）。
+    testWidgets('进多选（false→true）保持滚动位置', (WidgetTester tester) async {
+      final ValueNotifier<bool> enabled = ValueNotifier<bool>(false);
+      addTearDown(enabled.dispose);
+      final ScrollController scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(buildScrollHarness(
+        enabled: enabled,
+        scrollController: scrollController,
+      ));
+
+      final ScrollableState before = tester.state(find.byType(Scrollable));
+      before.position.jumpTo(2000);
+      await tester.pump();
+      expect(before.position.pixels, 2000);
+
+      enabled.value = true;
+      await tester.pump();
+
+      final ScrollableState after = tester.state(find.byType(Scrollable));
+      // 同一个 State 实例 = Element 被复用 = 子树没被重建。
+      expect(identical(after, before), isTrue,
+          reason: 'SelectionDragArea 翻转 enabled 时重建了子树');
+      expect(after.position.pixels, 2000, reason: '进多选把列表滚回了顶部');
+    });
+
+    // 反方向同样要守：批量操作落库后自动退出多选，也不该把用户弹回顶部。
+    testWidgets('退出多选（true→false）保持滚动位置', (WidgetTester tester) async {
+      final ValueNotifier<bool> enabled = ValueNotifier<bool>(true);
+      addTearDown(enabled.dispose);
+      final ScrollController scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(buildScrollHarness(
+        enabled: enabled,
+        scrollController: scrollController,
+      ));
+
+      final ScrollableState before = tester.state(find.byType(Scrollable));
+      before.position.jumpTo(1500);
+      await tester.pump();
+      expect(before.position.pixels, 1500);
+
+      enabled.value = false;
+      await tester.pump();
+
+      final ScrollableState after = tester.state(find.byType(Scrollable));
+      expect(identical(after, before), isTrue,
+          reason: 'SelectionDragArea 翻转 enabled 时重建了子树');
+      expect(after.position.pixels, 1500, reason: '退出多选把列表滚回了顶部');
+    });
+
+    // 恒建 GestureDetector 之后，非多选态必须仍然完全不接管长按——否则「不重建
+    // 子树」是靠让 disabled 态也吃手势换来的，那是另一个 bug。
+    testWidgets('非多选态即便 GestureDetector 常驻也不吃长按', (WidgetTester tester) async {
+      final ValueNotifier<bool> enabled = ValueNotifier<bool>(false);
+      addTearDown(enabled.dispose);
+      final ScrollController scrollController = ScrollController();
+      addTearDown(scrollController.dispose);
+      await tester.pumpWidget(buildScrollHarness(
+        enabled: enabled,
+        scrollController: scrollController,
+      ));
+
+      // 长按后拖动：非多选态下这一串必须仍然被 Scrollable 当成普通拖动消费，
+      // 而不是被 SelectionDragArea 截走。
+      final TestGesture gesture =
+          await tester.startGesture(const Offset(200, 300));
+      await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+      await gesture.moveBy(const Offset(0, -200));
+      await tester.pump();
+      await gesture.up();
+      await tester.pump();
+
+      final ScrollableState state = tester.state(find.byType(Scrollable));
+      expect(state.position.pixels, greaterThan(0),
+          reason: '非多选态的长按后拖动应当仍然滚动列表');
     });
   });
 }

--- a/hibiki/test/media/selection_gestures_test.dart
+++ b/hibiki/test/media/selection_gestures_test.dart
@@ -228,33 +228,6 @@ void main() {
     });
   });
 
-  group('平台分流', () {
-    testWidgets('触屏平台长按归多选，桌面归菜单', (WidgetTester tester) async {
-      Future<bool> touchOn(TargetPlatform platform) async {
-        late BuildContext ctx;
-        await tester.pumpWidget(MaterialApp(
-          theme: ThemeData(platform: platform),
-          home: Builder(builder: (BuildContext context) {
-            ctx = context;
-            return const SizedBox();
-          }),
-        ));
-        // MaterialApp 的 AnimatedTheme 在主题间插值，而 `ThemeData.lerp` 的
-        // platform 是 `t < 0.5 ? a : b` 的硬切——同一个 tester 里连续换主题时，
-        // 首帧读到的仍是上一个平台。必须让动画跑完再读。
-        await tester.pumpAndSettle();
-        return isTouchSelectionPlatform(ctx);
-      }
-
-      expect(await touchOn(TargetPlatform.android), isTrue);
-      expect(await touchOn(TargetPlatform.iOS), isTrue);
-      expect(await touchOn(TargetPlatform.fuchsia), isTrue);
-      expect(await touchOn(TargetPlatform.windows), isFalse);
-      expect(await touchOn(TargetPlatform.macOS), isFalse);
-      expect(await touchOn(TargetPlatform.linux), isFalse);
-    });
-  });
-
   group('进/退多选态不重建子树（滚动位置守卫）', () {
     /// 一条长列表包在 [SelectionDragArea] 里；[enabled] 由外部 setState 翻转，
     /// 模拟用户点工具栏进/退多选。
@@ -342,9 +315,9 @@ void main() {
       expect(after.position.pixels, 1500, reason: '退出多选把列表滚回了顶部');
     });
 
-    // 恒建 GestureDetector 之后，非多选态必须仍然完全不接管长按——否则「不重建
-    // 子树」是靠让 disabled 态也吃手势换来的，那是另一个 bug。
-    testWidgets('非多选态即便 GestureDetector 常驻也不吃长按', (WidgetTester tester) async {
+    // 恒建 GestureDetector 之后，未点「选择」时必须仍然完全不接管长按——否则
+    // 触屏卡片的上下文菜单会被祖先扫选识别器抢走。
+    testWidgets('未进入选择态时常驻 GestureDetector 不接管长按', (WidgetTester tester) async {
       final ValueNotifier<bool> enabled = ValueNotifier<bool>(false);
       addTearDown(enabled.dispose);
       final ScrollController scrollController = ScrollController();

--- a/hibiki/test/media/selection_gestures_test.dart
+++ b/hibiki/test/media/selection_gestures_test.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/selection/media_selection_controller.dart';
+import 'package:hibiki/src/media/selection/selection_gestures.dart';
+
+/// 多选手势层：长按扫选的命中反查、启用门控，以及修饰键判定。
+///
+/// 这些是「长按 = 进多选 / 扫选」这套手势归属重划里最容易悄悄坏掉的部分——
+/// 命中测试走真实渲染树，改布局、加遮挡层都可能让它反查不到卡片。
+void main() {
+  /// 竖排 5 张卡的最小库页：每张贴 [SelectionSlotTarget] 身份标记，整体包在
+  /// [SelectionDragArea] 里。
+  Widget buildHarness({
+    required MediaSelectionController controller,
+    required bool enabled,
+    required VoidCallback onChanged,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SelectionDragArea(
+          enabled: enabled,
+          onDragBegin: (SelectionSlot slot) {
+            controller.beginRangeDrag(slot);
+            onChanged();
+          },
+          onDragUpdate: (SelectionSlot slot) {
+            controller.updateRangeDrag(slot);
+            onChanged();
+          },
+          onDragEnd: () {
+            controller.endRangeDrag();
+            onChanged();
+          },
+          child: Column(
+            children: <Widget>[
+              for (int i = 0; i < 5; i++)
+                SelectionSlotTarget(
+                  slot: SelectionSlot.loose('card-$i'),
+                  child: SizedBox(
+                    key: ValueKey<String>('card-$i'),
+                    height: 60,
+                    width: 200,
+                    child: ColoredBox(color: Colors.blue.shade100),
+                  ),
+                ),
+              // 尾部留白：长按落在这里不该起手扫选。
+              const SizedBox(key: ValueKey<String>('blank'), height: 120),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<void> longPressDrag(
+    WidgetTester tester, {
+    required String from,
+    String? to,
+  }) async {
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(ValueKey<String>(from))),
+    );
+    // 过长按判定时限，长按识别器才宣布胜出。
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    if (to != null) {
+      await gesture.moveTo(
+        tester.getCenter(find.byKey(ValueKey<String>(to))),
+      );
+      await tester.pump();
+    }
+    await gesture.up();
+    await tester.pump();
+  }
+
+  testWidgets('长按起手后滑动，刷出起点到落点的整段', (WidgetTester tester) async {
+    final MediaSelectionController controller = MediaSelectionController();
+    controller.setVisibleOrder(
+      loose: <String>['card-0', 'card-1', 'card-2', 'card-3', 'card-4'],
+      collections: const <int>[],
+    );
+    await tester.pumpWidget(buildHarness(
+      controller: controller,
+      enabled: true,
+      onChanged: () {},
+    ));
+
+    await longPressDrag(tester, from: 'card-0', to: 'card-2');
+
+    expect(controller.looseKeys, <String>{'card-0', 'card-1', 'card-2'});
+    expect(controller.isRangeDragging, isFalse);
+  });
+
+  testWidgets('反向扫选同样成段', (WidgetTester tester) async {
+    final MediaSelectionController controller = MediaSelectionController();
+    controller.setVisibleOrder(
+      loose: <String>['card-0', 'card-1', 'card-2', 'card-3', 'card-4'],
+      collections: const <int>[],
+    );
+    await tester.pumpWidget(buildHarness(
+      controller: controller,
+      enabled: true,
+      onChanged: () {},
+    ));
+
+    await longPressDrag(tester, from: 'card-3', to: 'card-1');
+
+    expect(controller.looseKeys, <String>{'card-1', 'card-2', 'card-3'});
+  });
+
+  testWidgets('长按落在空白处不起手，滑过卡片也不选中', (WidgetTester tester) async {
+    final MediaSelectionController controller = MediaSelectionController();
+    controller.setVisibleOrder(
+      loose: <String>['card-0', 'card-1', 'card-2', 'card-3', 'card-4'],
+      collections: const <int>[],
+    );
+    await tester.pumpWidget(buildHarness(
+      controller: controller,
+      enabled: true,
+      onChanged: () {},
+    ));
+
+    await longPressDrag(tester, from: 'blank', to: 'card-2');
+
+    expect(controller.looseKeys, isEmpty);
+  });
+
+  testWidgets('非多选态（enabled=false）不接管长按', (WidgetTester tester) async {
+    final MediaSelectionController controller = MediaSelectionController();
+    controller.setVisibleOrder(
+      loose: <String>['card-0', 'card-1', 'card-2', 'card-3', 'card-4'],
+      collections: const <int>[],
+    );
+    await tester.pumpWidget(buildHarness(
+      controller: controller,
+      enabled: false,
+      onChanged: () {},
+    ));
+
+    expect(find.byType(GestureDetector), findsNothing);
+    await longPressDrag(tester, from: 'card-0', to: 'card-2');
+    expect(controller.looseKeys, isEmpty);
+  });
+
+  testWidgets('扫选期间每跨一张卡才回调一次（同卡内的高频移动被去重）',
+      (WidgetTester tester) async {
+    final MediaSelectionController controller = MediaSelectionController();
+    controller.setVisibleOrder(
+      loose: <String>['card-0', 'card-1', 'card-2', 'card-3', 'card-4'],
+      collections: const <int>[],
+    );
+    int changes = 0;
+    await tester.pumpWidget(buildHarness(
+      controller: controller,
+      enabled: true,
+      onChanged: () => changes++,
+    ));
+
+    final TestGesture gesture = await tester.startGesture(
+      tester.getCenter(find.byKey(const ValueKey<String>('card-0'))),
+    );
+    await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
+    // 在同一张卡内挪动三次：begin 之后不应再产生 update 回调。
+    final Offset within = tester.getCenter(
+      find.byKey(const ValueKey<String>('card-0')),
+    );
+    await gesture.moveTo(within + const Offset(0, 4));
+    await tester.pump();
+    await gesture.moveTo(within + const Offset(0, 8));
+    await tester.pump();
+    await gesture.moveTo(within + const Offset(0, 12));
+    await tester.pump();
+    await gesture.up();
+    await tester.pump();
+
+    // begin + end 各一次，中间零次 update。
+    expect(changes, 2);
+    expect(controller.looseKeys, <String>{'card-0'});
+  });
+
+  group('修饰键判定', () {
+    testWidgets('按住 Shift 时点击 = 区间扩选，否则普通切换',
+        (WidgetTester tester) async {
+      expect(selectionTapKind(), SelectionTapKind.toggle);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      expect(selectionTapKind(), SelectionTapKind.extend);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      expect(selectionTapKind(), SelectionTapKind.toggle);
+    });
+
+    testWidgets('Windows/Linux 用 Ctrl 进多选，⌘ 不算',
+        (WidgetTester tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.windows),
+        home: Builder(builder: (BuildContext context) {
+          ctx = context;
+          return const SizedBox();
+        }),
+      ));
+
+      expect(selectionEntryModifierPressed(ctx), isFalse);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      expect(selectionEntryModifierPressed(ctx), isTrue);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+      expect(selectionEntryModifierPressed(ctx), isFalse);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+    });
+
+    testWidgets('macOS 用 ⌘ 进多选，Ctrl 不算', (WidgetTester tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(platform: TargetPlatform.macOS),
+        home: Builder(builder: (BuildContext context) {
+          ctx = context;
+          return const SizedBox();
+        }),
+      ));
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+      expect(selectionEntryModifierPressed(ctx), isTrue);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      expect(selectionEntryModifierPressed(ctx), isFalse);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    });
+  });
+
+  group('平台分流', () {
+    testWidgets('触屏平台长按归多选，桌面归菜单', (WidgetTester tester) async {
+      Future<bool> touchOn(TargetPlatform platform) async {
+        late BuildContext ctx;
+        await tester.pumpWidget(MaterialApp(
+          theme: ThemeData(platform: platform),
+          home: Builder(builder: (BuildContext context) {
+            ctx = context;
+            return const SizedBox();
+          }),
+        ));
+        // MaterialApp 的 AnimatedTheme 在主题间插值，而 `ThemeData.lerp` 的
+        // platform 是 `t < 0.5 ? a : b` 的硬切——同一个 tester 里连续换主题时，
+        // 首帧读到的仍是上一个平台。必须让动画跑完再读。
+        await tester.pumpAndSettle();
+        return isTouchSelectionPlatform(ctx);
+      }
+
+      expect(await touchOn(TargetPlatform.android), isTrue);
+      expect(await touchOn(TargetPlatform.iOS), isTrue);
+      expect(await touchOn(TargetPlatform.fuchsia), isTrue);
+      expect(await touchOn(TargetPlatform.windows), isFalse);
+      expect(await touchOn(TargetPlatform.macOS), isFalse);
+      expect(await touchOn(TargetPlatform.linux), isFalse);
+    });
+  });
+}

--- a/hibiki/test/pages/home_video_collection_cover_card_test.dart
+++ b/hibiki/test/pages/home_video_collection_cover_card_test.dart
@@ -143,6 +143,20 @@ void main() {
   Finder cardFinder(int cid) =>
       find.byKey(ValueKey<String>('home_video_collection_card_$cid'));
 
+  testWidgets('触屏未进选择态长按视频合集卡仍弹合集菜单', (WidgetTester tester) async {
+    await seedEpisode('video/ep1', '第1集');
+    final int cid = await seedCollection(<String>['video/ep1']);
+
+    await pumpPage(tester);
+    await tester.longPress(cardFinder(cid));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.rename_collection), findsOneWidget,
+        reason: '触屏长按合集卡必须保留上下文菜单');
+    expect(find.text(t.batch_selected_count(n: 1)), findsNothing,
+        reason: '未点明确「选择」入口时不得暗中整选合集');
+  });
+
   testWidgets('有封面成员 → 卡显该成员封面（借用组内首个有封面的本地成员）', (WidgetTester tester) async {
     // ep1 无封面、ep2 有封面：组内序首成员缺封面时向后借。
     final File cover = File('${storeDir.path}/ep2_cover.png')

--- a/hibiki/test/pages/home_video_page_menu_test.dart
+++ b/hibiki/test/pages/home_video_page_menu_test.dart
@@ -23,6 +23,7 @@ import 'package:hibiki/src/pages/implementations/tag_filter_bar.dart';
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
+import 'package:hibiki/src/utils/components/shelf_card_widgets.dart';
 import 'package:hibiki/src/utils/misc/hibiki_toast.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:path/path.dart' as p;
@@ -314,7 +315,21 @@ void main() {
     );
   });
 
-  testWidgets('长按视频卡弹出封面背景动作面板（管理动作、无播放）', (WidgetTester tester) async {
+  /// 触屏上打开某张卡的动作面板 = 点封面上的 ⋮ 按钮。
+  ///
+  /// 2026-07 手势归属重划后长按改判给「进入多选」（见
+  /// `media/selection/selection_gestures.dart`），菜单在触屏上只有这一个入口；
+  /// widget 测试默认平台是 android，故走触屏分支。桌面右键仍是菜单（下面另有用例）。
+  Future<void> openCardMenu(WidgetTester tester, Finder card) async {
+    await tester.tap(find.descendant(
+      of: card,
+      matching: find.byType(ShelfCardMenuButton),
+    ));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('触屏长按视频卡进入多选并选中该卡（不再弹菜单）',
+      (WidgetTester tester) async {
     await seedTaggedVideo();
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
@@ -322,7 +337,21 @@ void main() {
     await tester.longPress(find.byType(HibikiCard).first);
     await tester.pumpAndSettle();
 
-    // 长按只做管理动作；播放仍由卡片点击负责。
+    // 长按不再弹动作面板，而是开多选并把该卡勾上（底部批量栏出现即多选态）。
+    expect(find.byType(HibikiDialogFrame), findsNothing);
+    expect(find.text(t.batch_selected_count(n: 1)), findsOneWidget);
+    expect(find.byType(ShelfSelectionCheck), findsWidgets);
+  });
+
+  testWidgets('封面 ⋮ 按钮弹出封面背景动作面板（管理动作、无播放）',
+      (WidgetTester tester) async {
+    await seedTaggedVideo();
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+
+    await openCardMenu(tester, find.byType(HibikiCard).first);
+
+    // 菜单只做管理动作；播放仍由卡片点击负责。
     expect(find.byType(HibikiDialogFrame), findsOneWidget);
     expect(find.text(t.tag_label), findsOneWidget);
     expect(find.text(t.video_rename), findsOneWidget);
@@ -532,7 +561,7 @@ void main() {
         reason: 'video/1 被批量删除，video/2 保留');
   });
 
-  testWidgets('长按菜单单删会回收本视频 app-owned 封面字幕与内嵌字幕缓存',
+  testWidgets('卡片菜单单删会回收本视频 app-owned 封面字幕与内嵌字幕缓存',
       (WidgetTester tester) async {
     resetAppOwnedVideoAssetDirs();
     final deleted = await seedVideoWithAssets(
@@ -567,9 +596,8 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
-    await tester
-        .longPress(find.byKey(const ValueKey<String>('home_video_video/1')));
-    await tester.pumpAndSettle();
+    await openCardMenu(
+        tester, find.byKey(const ValueKey<String>('home_video_video/1')));
     await tester.tap(find.text(t.dialog_delete).last);
     await tester.pumpAndSettle();
     await tester.tap(find.text(t.dialog_delete).last);

--- a/hibiki/test/pages/home_video_page_menu_test.dart
+++ b/hibiki/test/pages/home_video_page_menu_test.dart
@@ -23,7 +23,6 @@ import 'package:hibiki/src/pages/implementations/tag_filter_bar.dart';
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
-import 'package:hibiki/src/utils/components/shelf_card_widgets.dart';
 import 'package:hibiki/src/utils/misc/hibiki_toast.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:path/path.dart' as p;
@@ -315,43 +314,21 @@ void main() {
     );
   });
 
-  /// 触屏上打开某张卡的动作面板 = 点封面上的 ⋮ 按钮。
-  ///
-  /// 2026-07 手势归属重划后长按改判给「进入多选」（见
-  /// `media/selection/selection_gestures.dart`），菜单在触屏上只有这一个入口；
-  /// widget 测试默认平台是 android，故走触屏分支。桌面右键仍是菜单（下面另有用例）。
+  /// 打开某张卡的动作面板。触屏和桌面长按都走同一条管理菜单链路。
   Future<void> openCardMenu(WidgetTester tester, Finder card) async {
-    await tester.tap(find.descendant(
-      of: card,
-      matching: find.byType(ShelfCardMenuButton),
-    ));
+    await tester.longPress(card);
     await tester.pumpAndSettle();
   }
 
-  testWidgets('触屏长按视频卡进入多选并选中该卡（不再弹菜单）',
-      (WidgetTester tester) async {
-    await seedTaggedVideo();
-    await tester.pumpWidget(buildApp());
-    await tester.pumpAndSettle();
-
-    await tester.longPress(find.byType(HibikiCard).first);
-    await tester.pumpAndSettle();
-
-    // 长按不再弹动作面板，而是开多选并把该卡勾上（底部批量栏出现即多选态）。
-    expect(find.byType(HibikiDialogFrame), findsNothing);
-    expect(find.text(t.batch_selected_count(n: 1)), findsOneWidget);
-    expect(find.byType(ShelfSelectionCheck), findsWidgets);
-  });
-
-  testWidgets('封面 ⋮ 按钮弹出封面背景动作面板（管理动作、无播放）',
-      (WidgetTester tester) async {
+  testWidgets('触屏未进选择态长按视频卡弹管理菜单，不进入多选', (WidgetTester tester) async {
     await seedTaggedVideo();
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
     await openCardMenu(tester, find.byType(HibikiCard).first);
 
-    // 菜单只做管理动作；播放仍由卡片点击负责。
+    expect(find.text(t.batch_selected_count(n: 1)), findsNothing,
+        reason: '触屏必须先点明确的「选择」入口，长按不能暗中进入多选');
     expect(find.byType(HibikiDialogFrame), findsOneWidget);
     expect(find.text(t.tag_label), findsOneWidget);
     expect(find.text(t.video_rename), findsOneWidget);
@@ -364,6 +341,24 @@ void main() {
     expect(find.text(t.add_to_collection), findsOneWidget);
     expect(find.text(t.dialog_delete), findsOneWidget);
     expect(find.text(t.dialog_read), findsNothing);
+  });
+
+  testWidgets('桌面长按本地视频卡仍弹同一动作面板，不进入多选', (WidgetTester tester) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    try {
+      await seedTaggedVideo();
+      await tester.pumpWidget(buildApp());
+      await tester.pumpAndSettle();
+
+      await openCardMenu(tester, find.byType(HibikiCard).first);
+
+      expect(find.text(t.batch_selected_count(n: 1)), findsNothing);
+      expect(find.byType(HibikiDialogFrame), findsOneWidget);
+      expect(find.text(t.video_rename), findsOneWidget);
+      expect(find.text(t.add_to_collection), findsOneWidget);
+    } finally {
+      debugDefaultTargetPlatformOverride = null;
+    }
   });
 
   testWidgets('桌面右键（次按钮）本地视频卡弹出同一动作面板（BUG-758）', (WidgetTester tester) async {

--- a/hibiki/test/pages/reader_shelf_batch_collection_ops_test.dart
+++ b/hibiki/test/pages/reader_shelf_batch_collection_ops_test.dart
@@ -71,6 +71,8 @@ void main() {
       ..wireDatabaseForTesting(db)
       ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
     appModel.populateLanguages();
+    appModel.populateMediaTypes();
+    appModel.populateMediaSources();
     epubItems = <MediaItem>[];
     srtItems = <SrtBook>[];
   });
@@ -163,6 +165,28 @@ void main() {
   Finder epubCard(String bookKey) => find.byKey(ValueKey<String>(
       'book_entry_${ReaderHibikiSource.mediaIdentifierFor(bookKey)}'));
   Finder srtCard(String uid) => find.byKey(ValueKey<String>('srt_entry_$uid'));
+
+  testWidgets('触屏书卡长按保留菜单；点明确选择后才能勾选', (WidgetTester tester) async {
+    await seedEpub('epubKey1', 'Epub One');
+    await pumpPage(tester);
+
+    await tester.longPress(epubCard('epubKey1'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.dialog_delete), findsOneWidget,
+        reason: '未进入选择态时，触屏长按书卡必须继续打开上下文菜单');
+    expect(find.text(t.batch_selected_count(n: 1)), findsNothing,
+        reason: '长按不能暗中进入多选');
+
+    await tester.tapAt(const Offset(5, 5));
+    await tester.pumpAndSettle();
+    await enterSelectionMode(tester);
+    await tester.tap(epubCard('epubKey1'));
+    await tester.pump();
+
+    expect(find.text(t.batch_selected_count(n: 1)), findsOneWidget,
+        reason: '点明确「选择」入口后，书卡才能参与多选');
+  });
 
   testWidgets('档1：epub + srt 混合散卡 → 命名弹窗新建合集（真写穿 DB）',
       (WidgetTester tester) async {

--- a/hibiki/test/pages/video_tags_menu_source_guard_test.dart
+++ b/hibiki/test/pages/video_tags_menu_source_guard_test.dart
@@ -50,9 +50,8 @@ void main() {
     final String src = homeVideoSrc;
 
     test('视频卡 onLongPress 走菜单，不再等于打开播放页', () {
-      // TODO-063 起 onLongPress 是三元（选择态禁用长按、非选择态弹菜单），故不再锁
-      // 死 `onLongPress: () => _showVideoMenu(book)` 字面量前缀，只断言长按指向
-      // _showVideoMenu（弹菜单）这条不变式。
+      // TODO-063 起选择态禁用卡片长按，让祖先扫选接管；未进入选择态时所有平台
+      // 都必须继续走 _showVideoMenu。
       expect(src.contains('_showVideoMenu(book)'), isTrue, reason: '长按必须弹菜单');
       // 旧 bug：onLongPress 与 onTap 一样调 _open。
       expect(src.contains('onLongPress: () => _open(book)'), isFalse,
@@ -60,36 +59,24 @@ void main() {
     });
 
     test('选择态长按禁用、点击改切换勾选（批量选择，TODO-063）', () {
-      // 2026-07 手势归属重划：非选择态的长按按平台分流（触屏 = 进多选，桌面 =
-      // 弹菜单，见 media/selection/selection_gestures.dart），故不再锁死单一字面量；
-      // 但「选择态下长按必须禁用」这条不变式没变——长按与勾选冲突。
       // 折掉换行/缩进后比对，免得 dart format 的换行位置成为守卫的隐形前提。
       final String flat = src.replaceAll(RegExp(r'\s+'), ' ');
-      expect(flat.contains('onLongPress: _selectionMode ? null :'), isTrue,
-          reason: '选择态长按必须禁用');
-      expect(flat.contains('touchLongPressSelects ? () => _enterSelectionWith'),
+      expect(
+          flat.contains(
+              'onLongPress: _selectionMode ? null : () => _showVideoMenu(book)'),
           isTrue,
-          reason: '触屏非选择态长按 = 进入多选');
-      expect(flat.contains('() => _showVideoMenu(book))'), isTrue,
-          reason: '桌面非选择态长按仍弹菜单');
+          reason: '未进选择态时触屏/桌面长按都弹菜单，选择态才禁用');
+      expect(flat.contains('touchLongPressSelects'), isFalse,
+          reason: '不得再按触屏平台把未进入选择态的长按改判成多选');
       expect(src.contains('_toggleSelection(book.bookUid)'), isTrue,
           reason: '选择态点卡片切换勾选');
     });
 
-    test('触屏长按改判给多选后，菜单必须另有入口（封面 ⋮ 按钮）', () {
-      // 长按在触屏上已归多选，若不同时给出 ⋮ 入口，移动端就再也打不开卡片菜单。
-      // 这是本次重划最容易漏掉的一环，钉死在这里。
+    test('未进选择态的长按不按平台改判，也不再叠加临时 ⋮ 按钮', () {
       final String flat = src.replaceAll(RegExp(r'\s+'), ' ');
-      expect(
-          flat.contains(
-              'ShelfCardMenuButton( onPressed: () => _showVideoMenu(book)'),
-          isTrue,
-          reason: '视频卡必须有 ⋮ 菜单入口');
-      expect(
-          flat.contains(
-              'ShelfCardMenuButton( onPressed: () => _showCollectionContextMenu(collection)'),
-          isTrue,
-          reason: '合集卡必须有 ⋮ 菜单入口');
+      expect(flat.contains('isTouchSelectionPlatform'), isFalse);
+      expect(flat.contains('ShelfCardMenuButton'), isFalse,
+          reason: '恢复长按菜单后不需要在封面上永久叠加替代入口');
     });
 
     test('长按面板复用封面背景 frame，不再用 bottom sheet', () {

--- a/hibiki/test/pages/video_tags_menu_source_guard_test.dart
+++ b/hibiki/test/pages/video_tags_menu_source_guard_test.dart
@@ -60,14 +60,36 @@ void main() {
     });
 
     test('选择态长按禁用、点击改切换勾选（批量选择，TODO-063）', () {
-      // 选择态下长按必须禁用（避免与勾选冲突），点击切换勾选而非打开播放页。
-      expect(
-          src.contains(
-              'onLongPress: _selectionMode ? null : () => _showVideoMenu(book)'),
+      // 2026-07 手势归属重划：非选择态的长按按平台分流（触屏 = 进多选，桌面 =
+      // 弹菜单，见 media/selection/selection_gestures.dart），故不再锁死单一字面量；
+      // 但「选择态下长按必须禁用」这条不变式没变——长按与勾选冲突。
+      // 折掉换行/缩进后比对，免得 dart format 的换行位置成为守卫的隐形前提。
+      final String flat = src.replaceAll(RegExp(r'\s+'), ' ');
+      expect(flat.contains('onLongPress: _selectionMode ? null :'), isTrue,
+          reason: '选择态长按必须禁用');
+      expect(flat.contains('touchLongPressSelects ? () => _enterSelectionWith'),
           isTrue,
-          reason: '选择态长按禁用，非选择态才弹菜单');
+          reason: '触屏非选择态长按 = 进入多选');
+      expect(flat.contains('() => _showVideoMenu(book))'), isTrue,
+          reason: '桌面非选择态长按仍弹菜单');
       expect(src.contains('_toggleSelection(book.bookUid)'), isTrue,
           reason: '选择态点卡片切换勾选');
+    });
+
+    test('触屏长按改判给多选后，菜单必须另有入口（封面 ⋮ 按钮）', () {
+      // 长按在触屏上已归多选，若不同时给出 ⋮ 入口，移动端就再也打不开卡片菜单。
+      // 这是本次重划最容易漏掉的一环，钉死在这里。
+      final String flat = src.replaceAll(RegExp(r'\s+'), ' ');
+      expect(
+          flat.contains(
+              'ShelfCardMenuButton( onPressed: () => _showVideoMenu(book)'),
+          isTrue,
+          reason: '视频卡必须有 ⋮ 菜单入口');
+      expect(
+          flat.contains(
+              'ShelfCardMenuButton( onPressed: () => _showCollectionContextMenu(collection)'),
+          isTrue,
+          reason: '合集卡必须有 ⋮ 菜单入口');
     });
 
     test('长按面板复用封面背景 frame，不再用 bottom sheet', () {


### PR DESCRIPTION
## 背景

用户最终选择了显式入口语义：**「进入选择才能多选，和电脑一样。」**

书架与视频库此前各自维护多选状态，直接分别补 Shift / 扫选会继续漂移。本 PR 抽出共享 `MediaSelectionController`，统一选中集、锚点、可见顺序、区间选择、扫选与幽灵项剪枝；两页保留各自展示与批量操作入口。

## 最终交互

| | 触屏（Android / iOS） | 桌面（鼠标） |
|---|---|---|
| 上下文菜单 | 未进入选择态时长按卡片 | 长按 / 右键 |
| 进入多选 | 点标签栏末尾明确的「选择」；外接键盘修饰键也不能绕过 | 点「选择」或 Ctrl/⌘/Shift + 点击 |
| 多选态内选择 | 点卡片；长按后滑动扫选 | 点卡片；Shift + 点击区间选；长按后滑动扫选 |

- 书、视频、合集都必须先进入选择态才能做触屏多选；未进入时长按不再暗中改判。
- 区间按当前排序 / 搜索 / 筛选后的**可见顺序**计算；顺序变化即清锚点，避免选到不可见条目。
- 合集区与散卡区各自成段，跨区退化为普通切换。
- 扫选用「基线 ∪ 当前区间」，往回滑可撤销本次刚刷上的一段。
- `SelectionDragArea` 恒建、只切换回调，进退选择态不替换滚动子树，滚动位置保持。

## 审查轮已修

1. 进 / 退多选态会把列表从中段弹回顶部：改为恒建 `GestureDetector`，并在选择态中途关闭时清理扫选状态。
2. 远端视频卡漏选择态门控：补齐长按 / 右键门控。
3. 选中项被同步删掉后形成幽灵键：新增 `retainExisting`，书架 / 视频在删除、打标签、组合前统一剔除并提示跳过数量。
4. 触屏未进入选择态长按被改成进多选：恢复书卡、视频卡、视频合集卡的长按菜单，并移除只为旧改判存在的封面 `⋮` 临时按钮。
5. Android / iOS 外接键盘可用 Shift / Ctrl / ⌘ 绕过显式入口：`selectionEntryModifierPressed` 改为仅 Linux / Windows / macOS 生效，并补触屏平台负向与桌面平台正向测试。

## 当前 exact head 验证

- exact head：`3b4b29103c4a73cc3e8e5979e0976ef87259f123`
- rebase base：`origin/develop@f6036b7508ac0dc8544a584af6bdf1cbb22983dc`
- `flutter analyze --no-pub`：`No issues found!`
- 直接覆盖 5 套件：`49 tests`，全部通过。
- 邻接选择 / 合集 / 拖拽 / 返回 / 幽灵剪枝 4 套件：`38 tests`，全部通过。
- `pubspec.yaml` 保留最新 `1.3.1+996`；i18n 保留最新 `develop` 源并用仓库工具补回任务键，随后重新生成 `strings.g.dart`。

## 范围与门禁

- TODO-2180 的批量删除文案 / 删除范围语义不在本 PR 修改范围，本轮未改任何删除实现。
- 当前 head 已推送并触发 CI；触屏真机手势与可见滚动仍需由非施工线程复测后才能离开 review。
- 扫选未做边缘自动滚动；手指到屏幕边缘需抬手滚动后继续，这是本 PR 的既定范围。
