### PR TITLE
test(gal): 修 PR#507 的测试命名不符 + 补 GIF 降级路径断言

### DIFF
--- a/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
+++ b/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
@@ -250,7 +250,7 @@ void main() {
     );
   });
 
-  test('gif mode remains the default and still degrades to png', () async {
+  test('gif is still the default when imageMode is omitted', () async {
     final TexthookerLineEntry entry = service.appendLine('動画の台詞')!;
     final _RecordingRepo repo = _RecordingRepo();
 
@@ -267,6 +267,31 @@ void main() {
     expect(result.success, isTrue);
     expect(repo.contexts.single.coverPath, endsWith('.gif'));
     expect(result.degradedToStill, isFalse);
+  });
+
+  test('gif mode degrades to png and flags degradedToStill', () async {
+    // 上一条只证明「默认仍是 GIF」，并没有走降级路径——名字曾写着 "still degrades
+    // to png" 却没有任何断言覆盖它。这条把降级真验上：GIF 抓取返回空 → 退到单帧
+    // PNG，并且**必须**置 degradedToStill（用户要看到「已降级为静态图」提示，这正是
+    // 它与「主动选静态截图」的分水岭）。
+    final TexthookerLineEntry entry = service.appendLine('降格の台詞')!;
+    final _RecordingRepo repo = _RecordingRepo();
+
+    final GalHookMiningResult result = await coordinator(
+      validator: (_) => true,
+      gif: ({required int hwnd}) async => Uint8List(0),
+    ).mineLine(
+      lineId: entry.id,
+      fields: const <String, String>{'expression': '降格'},
+      compression: MiningMediaCompression.compressed,
+      repo: repo,
+      imageMode: VideoMiningImageMode.gif,
+    );
+
+    expect(result.success, isTrue);
+    expect(repo.contexts.single.coverPath, endsWith('.png'));
+    expect(result.degradedToStill, isTrue,
+        reason: 'GIF 失败退到单帧是降级，必须置标志，否则用户拿不到降级提示');
   });
 
   test('expired line is rejected before scene or audio capture', () async {


### PR DESCRIPTION
审查 #507 时发现、#507 已合入 develop（`5f696f504`），故拆成本跟进 PR。

## 问题

`gif mode remains the default and still degrades to png` 只断言了 `.gif` + `degradedToStill == false`——**"still degrades to png" 这半句没有任何断言覆盖**。用例名宣称了断言没做的事，读测试列表的人会以为降级路径有守，实际没有。

与本轮在纠的「宣称了实现里没有的事」同族，只是小号版本。

## 改动（纯测试，无产品代码）

- 原用例改名 `gif is still the default when imageMode is omitted`，与它真正断言的「缺省参数仍走 GIF 优先链路」一致。
- 新增 `gif mode degrades to png and flags degradedToStill`：GIF 抓取返回空 → 退到单帧 PNG，且**必须**置 `degradedToStill`。

这条标志正是「GIF 失败降级」与「用户主动选静态截图」的分水岭——后者刻意不置它、因而不弹「已降级为静态图」提示。此前只有静态模式那一侧被断言（`degradedToStill` 为假），降级这一侧没有对照，标志被误删也不会红。

## 验证

`flutter analyze test/mining/` → No issues found!；`test/mining/gal_hook_mining_coordinator_test.dart` 12 tests 全绿。

无 `pubspec` bump：纯测试改动，不产出发布物。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb