### PR TITLE
fix(reader,popup): 长按选区手柄拖不动(菜单是模态) + 弹窗触屏复制无效(ActionMode 已 finish)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1192 条。点号进各自文件。
+> 共 1194 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1239](bugs/BUG-1239-video-ime-fullwidth-space.md) | ✅ | ✅ | 全角空格在视频页仍无法播放暂停 |
+| [BUG-1237](bugs/BUG-1237-popup-touch-copy-actionmode-finished.md) | ✅ | ✅ | 查词弹窗触屏复制经已结束 ActionMode 失效 |
+| [BUG-1236](bugs/BUG-1236-reader-selection-menu-modal-blocks-handles.md) | ✅ | ✅ | 移动端阅读器选区菜单阻断手柄拖动 |
 | [BUG-1233](bugs/BUG-1233-book-import-repeated-archive-probe.md) | ✅ | ✅ | 书籍导入重复整包判定 EPUB 载体 |
 | [BUG-1231](bugs/BUG-1231-cross-chapter-search-locate-race.md) | ✅ | ✅ | 跨章节书内搜索只跳到章首且不高亮 |
 | [BUG-1228](bugs/BUG-1228-video-mining-queue.md) | ✅ | ✅ | 连续视频制卡未串行且换集可能污染在途任务 |

--- a/docs/bugs/BUG-1236-reader-selection-menu-modal-blocks-handles.md
+++ b/docs/bugs/BUG-1236-reader-selection-menu-modal-blocks-handles.md
@@ -1,0 +1,6 @@
+## BUG-1236 · 移动端阅读器选区菜单阻断手柄拖动
+- **报告**：2026-07-29（用户：Android 长按选区后无法继续拖动前后手柄）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart:434` 的旧实现用 `showMenu`；它创建带全屏 `ModalBarrier` 的 `PopupRoute`，菜单显示期间 WebView 手柄收不到触摸，手柄松开又重弹菜单。
+- **[x] ① 已修复** — commit `e6c5e5e98`：`chrome.part.dart:434-635` 改为非模态 `OverlayEntry`，手柄重入只刷新 payload/位置；清选区、收敛查词、隐藏手柄和页面 dispose 都移除并 dispose 操作条。Android 条内保留查词/复制并新增 `Share.share` 与系统网页搜索。
+- **[x] ② 已加自动化测试** — commit `e6c5e5e98`：`hibiki/test/reader/reader_selection_action_bar_nonmodal_guard_test.dart` 锁定无 `showMenu/showDialog`、Overlay 生命周期、四项 Android 动作及普通原生选区菜单反向守卫；相关定向套件 39/39。
+- **备注**：源码守卫不能代替 Android 触屏 WebView 真机拖柄复测；当前只能标 `implemented_unverified`，由非施工 reviewer 在受支持 Android 运行链验证。

--- a/docs/bugs/BUG-1237-popup-touch-copy-actionmode-finished.md
+++ b/docs/bugs/BUG-1237-popup-touch-copy-actionmode-finished.md
@@ -1,0 +1,6 @@
+## BUG-1237 · 查词弹窗触屏复制经已结束 ActionMode 失效
+- **报告**：2026-07-29（用户：Android 查词弹窗触屏复制无效）
+- **真实性**：✅ 真 bug。`third_party/flutter_inappwebview_android/.../InAppWebView.java:1564-1607` 在传入 ContextMenu 时走 `rebuildActionMode`，先 `actionMenu.clear()` / `actionMode.finish()`，再把菜单点击转发给已结束的 ActionMode；hybrid composition 又绕过了 `:1584-1587` 的旧补救。
+- **[x] ① 已修复** — commit `e6c5e5e98`：`dictionary_popup_webview.dart:1253-1336` 仅在 Android 隐藏失效的系统默认项，复制改由 Dart `Clipboard.setData`；分享与网页搜索复用 `SelectionExternalActions`，动作后穿透同源 iframe 清选区。iOS 不扩范围，Windows 右键路径不变。
+- **[x] ② 已加自动化测试** — commit `e6c5e5e98`：`popup_touch_copy_actionmode_guard_test.dart` 锁 ActionMode 绕行、iframe payload 与桌面反向守卫；`selection_external_actions_test.dart` 锁 CJK/空格/换行原样 payload；`android_selection_action_channel_guard_test.dart` 锁 `ACTION_WEB_SEARCH` + `SearchManager.QUERY`、无 URL/Google/Bing fallback。mutation 把 `SearchManager.QUERY` 改成普通 `"query"` 后守卫按预期转红，恢复后 3/3。
+- **备注**：无 Android 物理机，触屏选区、系统分享面板、系统默认搜索 handler 与“无 handler”可见 toast 尚待非施工 reviewer 真运行复测，当前标 `implemented_unverified`。

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/FloatingDictPluginRegistrant.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/FloatingDictPluginRegistrant.java
@@ -83,5 +83,11 @@ final class FloatingDictPluginRegistrant {
         } catch (Exception e) {
             Log.e(TAG, "Error registering plugin url_launcher_android", e);
         }
+        try {
+            flutterEngine.getPlugins().add(
+                new dev.fluttercommunity.plus.share.SharePlusPlugin());
+        } catch (Exception e) {
+            Log.e(TAG, "Error registering plugin share_plus", e);
+        }
     }
 }

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/MainActivity.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/MainActivity.java
@@ -501,6 +501,7 @@ public class MainActivity extends AudioServiceActivity {
     public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
         super.configureFlutterEngine(flutterEngine);
         FloatingDictService.initEngineGroup(getApplicationContext());
+        SelectionActionChannel.registerWith(flutterEngine, this);
 
         volumeKeyChannel = new MethodChannel(
                 flutterEngine.getDartExecutor().getBinaryMessenger(), VOLUME_KEY_CHANNEL);

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/PopupEngineHolder.kt
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/PopupEngineHolder.kt
@@ -90,6 +90,7 @@ object PopupEngineHolder {
         // BUG-865：传 applicationContext 让 registrant 也注册 anki channel，使 popupMain
         // 副 engine 上的 app 外查词面制卡不再抛 MissingPluginException。
         FloatingDictPluginRegistrant.registerWith(engine, context.applicationContext)
+        SelectionActionChannel.registerWith(engine, context.applicationContext)
 
         val ch = MethodChannel(engine.dartExecutor.binaryMessenger, ChannelNames.POPUP)
         ch.setMethodCallHandler { call, result ->

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/SelectionActionChannel.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/SelectionActionChannel.java
@@ -47,9 +47,6 @@ public final class SelectionActionChannel {
         if (!(context instanceof Activity)) {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         }
-        if (intent.resolveActivity(context.getPackageManager()) == null) {
-            return false;
-        }
         try {
             context.startActivity(intent);
             return true;

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/SelectionActionChannel.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/SelectionActionChannel.java
@@ -1,0 +1,60 @@
+package app.hibiki.reader;
+
+import android.app.Activity;
+import android.app.SearchManager;
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.Intent;
+
+import androidx.annotation.NonNull;
+
+import app.hibiki.reader.constants.ChannelNames;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.plugin.common.MethodChannel;
+
+/** Android-only selected-text actions shared by the reader and popup engines. */
+public final class SelectionActionChannel {
+    private static final String METHOD_WEB_SEARCH = "webSearch";
+    private static final String ARG_QUERY = "query";
+
+    private SelectionActionChannel() {}
+
+    public static void registerWith(
+            @NonNull FlutterEngine flutterEngine, @NonNull Context context) {
+        new MethodChannel(
+                flutterEngine.getDartExecutor().getBinaryMessenger(),
+                ChannelNames.SELECTION_ACTIONS)
+            .setMethodCallHandler((call, result) -> {
+                if (!METHOD_WEB_SEARCH.equals(call.method)) {
+                    result.notImplemented();
+                    return;
+                }
+
+                final String query = call.argument(ARG_QUERY);
+                if (query == null || query.isEmpty()) {
+                    result.error("INVALID_QUERY", "query must not be empty", null);
+                    return;
+                }
+                result.success(launchWebSearch(context, query));
+            });
+    }
+
+    private static boolean launchWebSearch(@NonNull Context context, @NonNull String query) {
+        final Intent intent = new Intent(Intent.ACTION_WEB_SEARCH);
+        // Do not trim or otherwise normalize: CJK, spaces, and newlines are the
+        // user's selected payload and must reach the system handler unchanged.
+        intent.putExtra(SearchManager.QUERY, query);
+        if (!(context instanceof Activity)) {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        }
+        if (intent.resolveActivity(context.getPackageManager()) == null) {
+            return false;
+        }
+        try {
+            context.startActivity(intent);
+            return true;
+        } catch (ActivityNotFoundException error) {
+            return false;
+        }
+    }
+}

--- a/hibiki/android/app/src/main/java/app/hibiki/reader/constants/ChannelNames.java
+++ b/hibiki/android/app/src/main/java/app/hibiki/reader/constants/ChannelNames.java
@@ -17,6 +17,7 @@ public final class ChannelNames {
     public static final String SAF = PREFIX + "/saf";
     public static final String ICON_SWITCH = PREFIX + "/icon_switch";
     public static final String SCREEN_BRIGHTNESS = PREFIX + "/screen_brightness";
+    public static final String SELECTION_ACTIONS = PREFIX + "/selection_actions";
     // TODO-1232 A3: render-backend toggle (persist the "disable Impeller / use
     // Skia" experiment flag; applied at next launch via MainActivity's
     // getFlutterShellArgs override).

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46971 (2763 per locale)
+/// Strings: 47022 (2766 per locale)
 ///
-/// Built on 2026-07-29 at 07:19 UTC
+/// Built on 2026-07-29 at 08:08 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3715,6 +3715,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_import_detected_confirm => 'Import as manga';
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  String get selection_web_search => 'Search the web';
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -10041,6 +10044,12 @@ class _StringsAr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -16435,6 +16444,12 @@ class _StringsDe extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -22845,6 +22860,12 @@ class _StringsEs extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -29266,6 +29287,12 @@ class _StringsFr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -35616,6 +35643,12 @@ class _StringsId extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -42012,6 +42045,12 @@ class _StringsIt extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -48225,6 +48264,12 @@ class _StringsJa extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -54440,6 +54485,12 @@ class _StringsKo extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -60816,6 +60867,12 @@ class _StringsNl extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -67205,6 +67262,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -73578,6 +73641,12 @@ class _StringsRu extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -79899,6 +79968,12 @@ class _StringsTh extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -86252,6 +86327,12 @@ class _StringsTr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -92590,6 +92671,12 @@ class _StringsVi extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 // Path: <root>
@@ -98479,6 +98566,12 @@ class _StringsZhCn extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
+  @override
+  String get selection_web_search => '网页搜索';
+  @override
+  String get selection_web_search_unavailable => '没有可用的网页搜索应用。';
+  @override
+  String get selection_share_failed => '无法打开分享面板。';
 }
 
 // Path: <root>
@@ -104613,6 +104706,12 @@ class _StringsZhHk extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get selection_web_search => 'Search the web';
+  @override
+  String get selection_web_search_unavailable => 'No app can search the web.';
+  @override
+  String get selection_share_failed => 'Could not open the share sheet.';
 }
 
 /// Flat map(s) containing all translations.
@@ -110274,6 +110373,12 @@ extension on _StringsEn {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -115933,6 +116038,12 @@ extension on _StringsAr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -121613,6 +121724,12 @@ extension on _StringsDe {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -127292,6 +127409,12 @@ extension on _StringsEs {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -132977,6 +133100,12 @@ extension on _StringsFr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -138644,6 +138773,12 @@ extension on _StringsId {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -144326,6 +144461,12 @@ extension on _StringsIt {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -149970,6 +150111,12 @@ extension on _StringsJa {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -155618,6 +155765,12 @@ extension on _StringsKo {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -161293,6 +161446,12 @@ extension on _StringsNl {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -166965,6 +167124,12 @@ extension on _StringsPtBr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -172642,6 +172807,12 @@ extension on _StringsRu {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -178303,6 +178474,12 @@ extension on _StringsTh {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -183973,6 +184150,12 @@ extension on _StringsTr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -189638,6 +189821,12 @@ extension on _StringsVi {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }
@@ -195256,6 +195445,12 @@ extension on _StringsZhCn {
         return '按漫画导入';
       case 'manga_import_detected_message':
         return ({required Object name}) => '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
+      case 'selection_web_search':
+        return '网页搜索';
+      case 'selection_web_search_unavailable':
+        return '没有可用的网页搜索应用。';
+      case 'selection_share_failed':
+        return '无法打开分享面板。';
       default:
         return null;
     }
@@ -200895,6 +201090,12 @@ extension on _StringsZhHk {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'selection_web_search':
+        return 'Search the web';
+      case 'selection_web_search_unavailable':
+        return 'No app can search the web.';
+      case 'selection_share_failed':
+        return 'Could not open the share sheet.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "请先选择漫画文件或文件夹。",
   "manga_import_detected_title": "这看起来是漫画",
   "manga_import_detected_confirm": "按漫画导入",
-  "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。"
+  "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。",
+  "selection_web_search": "网页搜索",
+  "selection_web_search_unavailable": "没有可用的网页搜索应用。",
+  "selection_share_failed": "无法打开分享面板。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2761,5 +2761,8 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "selection_web_search": "Search the web",
+  "selection_web_search_unavailable": "No app can search the web.",
+  "selection_share_failed": "Could not open the share sheet."
 }

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -12,6 +12,7 @@ import 'package:hibiki_dictionary/hibiki_dictionary.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_webview_media.dart';
 import 'package:hibiki/src/pages/implementations/popup_settings_injection.dart';
+import 'package:hibiki/src/platform/selection_external_actions.dart';
 import 'package:hibiki/src/reader/popup_swipe_close_script.dart';
 import 'package:hibiki/src/reader/reader_caret_scripts.dart';
 import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart';
@@ -539,6 +540,27 @@ JSON.stringify((function(){
       return raw.toString();
     }
     return '';
+  }
+
+  Future<void> _clearSelectedTextAcrossFrames() async {
+    try {
+      await _controller?.evaluateJavascript(source: r'''
+        (() => {
+          const clear = (win) => {
+            try {
+              win.getSelection()?.removeAllRanges();
+              for (let i = 0; i < win.frames.length; i += 1) {
+                clear(win.frames[i]);
+              }
+            } catch (_) {}
+          };
+          clear(window);
+        })()
+      ''');
+    } catch (e, stack) {
+      ErrorLogService.instance
+          .log('DictionaryPopup.clearSelectedTextAcrossFrames', e, stack);
+    }
   }
 
   Future<String> caretEnter() async {
@@ -1236,7 +1258,11 @@ JSON.stringify((function(){
           // 故离 WebView 左上角越远菜单偏得越狠（用户报「跑到很远」）。改走下面
           // [_showWindowsContextMenu] 的 Flutter showMenu（BUG-261 锚点范式，吃掉缩放
           // 残差）。非 Windows 平台保持原生菜单不变（false）。
-          hideDefaultSystemContextMenuItems: isWindowsPlatform,
+          // BUG-1237：Android 自定义 ContextMenu 会先 finish 系统 ActionMode，
+          // 所以系统默认「复制」不可用；Android 隐藏默认项并由 Dart 直做。
+          // iOS 保持原生菜单，Windows 仍由下方 Flutter 右键菜单接管。
+          hideDefaultSystemContextMenuItems:
+              Platform.isAndroid || isWindowsPlatform,
         ),
         // 非 Windows：保留原生菜单 + 自定义「查词」项（原行为）。Windows 下原生菜单已
         // 被上面禁用，这里的 menuItems 不渲染，右键改由 [_showWindowsContextMenu] 接管。
@@ -1253,6 +1279,48 @@ JSON.stringify((function(){
               }
             },
           ),
+          if (Platform.isAndroid)
+            ContextMenuItem(
+              id: 2,
+              title: t.copy,
+              action: () async {
+                final String text = await _selectedTextAcrossFrames();
+                if (text.isEmpty) return;
+                await Clipboard.setData(ClipboardData(text: text));
+                HibikiToast.show(msg: t.copied_to_clipboard);
+                await _clearSelectedTextAcrossFrames();
+              },
+            ),
+          if (Platform.isAndroid)
+            ContextMenuItem(
+              id: 3,
+              title: t.share,
+              action: () async {
+                final String text = await _selectedTextAcrossFrames();
+                if (text.isEmpty) return;
+                final bool shared =
+                    await SelectionExternalActions.instance.shareText(text);
+                if (!shared) {
+                  HibikiToast.show(msg: t.selection_share_failed);
+                }
+                await _clearSelectedTextAcrossFrames();
+              },
+            ),
+          if (Platform.isAndroid)
+            ContextMenuItem(
+              id: 4,
+              title: t.selection_web_search,
+              action: () async {
+                final String text = await _selectedTextAcrossFrames();
+                if (text.isEmpty) return;
+                final bool opened =
+                    await SelectionExternalActions.instance.searchWeb(text);
+                if (!opened) {
+                  HibikiToast.show(msg: t.selection_web_search_unavailable);
+                }
+                await _clearSelectedTextAcrossFrames();
+              },
+            ),
         ],
       ),
       // TODO-896 症状①：WebView 在手势竞技场必须争得正文区的「水平拖」，否则

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -438,102 +438,135 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       return;
     }
 
+    // BUG-1236：这里必须是非模态 OverlayEntry。showMenu 会 push 带全屏
+    // ModalBarrier 的 PopupRoute，菜单在场时 WebView 里的选区手柄收不到触摸。
+    _selectionActionData = data;
+    if (_selectionActionBarEntry != null) {
+      _selectionActionBarEntry!.markNeedsBuild();
+      return;
+    }
+    final OverlayState? overlay = Overlay.maybeOf(context);
+    if (overlay == null) return;
+    final OverlayEntry entry = OverlayEntry(
+      builder: (BuildContext overlayContext) =>
+          _buildSelectionActionBar(overlayContext),
+    );
+    _selectionActionBarEntry = entry;
+    overlay.insert(entry);
+  }
+
+  void _removeSelectionActionBar() {
+    _selectionActionBarEntry
+      ?..remove()
+      ..dispose();
+    _selectionActionBarEntry = null;
+    _selectionActionData = null;
+  }
+
+  Widget _buildSelectionActionBar(BuildContext overlayContext) {
+    final ReaderSelectionData? data = _selectionActionData;
+    if (data == null) return const SizedBox.shrink();
+
+    final RenderBox? overlayBox =
+        Overlay.of(overlayContext).context.findRenderObject() as RenderBox?;
+    if (overlayBox == null || !overlayBox.hasSize) {
+      return const SizedBox.shrink();
+    }
+    final Size overlaySize = overlayBox.size;
+    final double menuScale = _readerImageMenuScale;
+    final double barHeight = kMinInteractiveDimension * menuScale;
+    const double gap = 8;
+    const double handleReserve = 32 + gap;
+
     final RenderBox? webBox =
         _webViewKey.currentContext?.findRenderObject() as RenderBox?;
     final Map<String, double>? r = data.rect;
-    // Anchor just below the selection's start glyph (WebView-local coords).
-    final Offset localAnchor = r != null
-        ? Offset(r['x'] ?? 0, (r['y'] ?? 0) + (r['height'] ?? 0))
-        : Offset(
-            MediaQuery.of(context).size.width / 2,
-            MediaQuery.of(context).size.height / 2,
-          );
-    final Offset global = webBox?.localToGlobal(localAnchor) ?? localAnchor;
-    final RenderBox overlay =
-        Overlay.of(context).context.findRenderObject()! as RenderBox;
-    final Offset anchor = overlay.globalToLocal(global);
-    final double menuScale = _readerImageMenuScale;
+    double selectionTop;
+    double selectionBottom;
+    if (r != null && webBox != null) {
+      final Offset topGlobal = webBox.localToGlobal(
+        Offset(r['x'] ?? 0, r['y'] ?? 0),
+      );
+      selectionTop = overlayBox.globalToLocal(topGlobal).dy;
+      selectionBottom = selectionTop + (r['height'] ?? 0);
+    } else {
+      selectionTop = overlaySize.height / 2;
+      selectionBottom = selectionTop;
+    }
 
-    // TODO-1366: mobile drag-select "export clip" -- same gate (book has audio
-    // cues) and same backend as the desktop right-click / native ActionMode
-    // menus, driven from the app-drawn selection payload instead of a native
-    // selection (mobile touch never builds one, TODO-1279).
+    double top = selectionTop - gap - barHeight;
+    if (top < gap) {
+      top = selectionBottom + handleReserve;
+    }
+    top = top.clamp(
+      gap,
+      (overlaySize.height - barHeight - gap).clamp(gap, double.infinity),
+    );
+
     final bool hasAudio = _audiobookController != null &&
         _audiobookController!.chapterCueCount > 0;
-    final List<PopupMenuEntry<String>> items = <PopupMenuEntry<String>>[
-      PopupMenuItem<String>(
-        value: 'search',
-        height: kMinInteractiveDimension * menuScale,
-        padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Icon(Icons.search_outlined, size: 18.0 * menuScale),
-            SizedBox(width: 12.0 * menuScale),
-            Text(t.search, style: TextStyle(fontSize: 14.0 * menuScale)),
-          ],
-        ),
-      ),
-      PopupMenuItem<String>(
-        value: 'copy',
-        height: kMinInteractiveDimension * menuScale,
-        padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Icon(Icons.copy_outlined, size: 18.0 * menuScale),
-            SizedBox(width: 12.0 * menuScale),
-            Text(t.copy, style: TextStyle(fontSize: 14.0 * menuScale)),
-          ],
-        ),
-      ),
-      // BUG-854：选区菜单补「收藏」——与桌面底栏 / 查词弹窗顶栏的收藏句子
-      // （`_toggleFavoriteSentence`）同一后端，仅入口不同。触屏从不建原生选区
-      // （TODO-1279），旧菜单只有查词 / 复制 / 导出，无从收藏当前句；此项填平缺口。
-      PopupMenuItem<String>(
-        value: 'favorite',
-        height: kMinInteractiveDimension * menuScale,
-        padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Icon(Icons.star_border, size: 18.0 * menuScale),
-            SizedBox(width: 12.0 * menuScale),
-            Text(t.action_favorite,
-                style: TextStyle(fontSize: 14.0 * menuScale)),
-          ],
-        ),
-      ),
-      if (hasAudio)
-        PopupMenuItem<String>(
-          value: 'export',
-          height: kMinInteractiveDimension * menuScale,
-          padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
+    final ThemeData theme = Theme.of(overlayContext);
+
+    Widget button(IconData icon, String label, String action) {
+      return InkWell(
+        onTap: () => _runSelectionAction(action),
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: 12.0 * menuScale,
+            vertical: 10.0 * menuScale,
+          ),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Icon(Icons.movie_creation_outlined, size: 18.0 * menuScale),
-              SizedBox(width: 12.0 * menuScale),
-              Text(t.audiobook_export_clip,
-                  style: TextStyle(fontSize: 14.0 * menuScale)),
+              Icon(icon, size: 18.0 * menuScale),
+              SizedBox(width: 8.0 * menuScale),
+              Text(label, style: TextStyle(fontSize: 14.0 * menuScale)),
             ],
           ),
         ),
-    ];
+      );
+    }
 
-    final String? action = await showMenu<String>(
-      context: context,
-      position: RelativeRect.fromRect(
-        Rect.fromLTWH(anchor.dx, anchor.dy, 1, 1),
-        Offset.zero & overlay.size,
+    return Positioned(
+      left: gap,
+      right: gap,
+      top: top,
+      child: Align(
+        alignment: Alignment.center,
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          child: Material(
+            elevation: 6,
+            color: theme.popupMenuTheme.color ??
+                theme.colorScheme.surfaceContainerHigh,
+            borderRadius: BorderRadius.circular(8.0 * menuScale),
+            clipBehavior: Clip.antiAlias,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                button(Icons.search_outlined, t.search, 'search'),
+                button(Icons.copy_outlined, t.copy, 'copy'),
+                if (isAndroidPlatform)
+                  button(Icons.share_outlined, t.share, 'share'),
+                if (isAndroidPlatform)
+                  button(Icons.travel_explore, t.selection_web_search,
+                      'webSearch'),
+                button(Icons.star_border, t.action_favorite, 'favorite'),
+                if (hasAudio)
+                  button(Icons.movie_creation_outlined, t.audiobook_export_clip,
+                      'export'),
+              ],
+            ),
+          ),
+        ),
       ),
-      constraints: BoxConstraints(
-        minWidth: 112.0 * menuScale,
-        maxWidth: 280.0 * menuScale,
-      ),
-      menuPadding: EdgeInsets.symmetric(vertical: 8.0 * menuScale),
-      items: items,
     );
+  }
+
+  Future<void> _runSelectionAction(String action) async {
+    final ReaderSelectionData? data = _selectionActionData;
+    if (data == null) return;
+    _removeSelectionActionBar();
     if (!mounted) return;
     switch (action) {
       case 'search':
@@ -549,6 +582,22 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       case 'copy':
         await Clipboard.setData(ClipboardData(text: data.text));
         HibikiToast.show(msg: t.copied_to_clipboard);
+        await _clearReaderAppSelection();
+        return;
+      case 'share':
+        final bool shared =
+            await SelectionExternalActions.instance.shareText(data.text);
+        if (mounted && !shared) {
+          HibikiToast.show(msg: t.selection_share_failed);
+        }
+        await _clearReaderAppSelection();
+        return;
+      case 'webSearch':
+        final bool opened =
+            await SelectionExternalActions.instance.searchWeb(data.text);
+        if (mounted && !opened) {
+          HibikiToast.show(msg: t.selection_web_search_unavailable);
+        }
         await _clearReaderAppSelection();
         return;
       case 'favorite':
@@ -567,11 +616,6 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         await _clearReaderAppSelection();
         return;
       default:
-        // TODO-1366: dismissing the menu no longer cancels the selection -- keep
-        // the highlight + grips live so the user can drag a handle to adjust the
-        // range and re-open the menu (lookup only on an explicit confirm). Any
-        // later tap clears it: tap on text -> selectText clears + looks up; tap
-        // on empty -> onTapEmpty -> _clearReaderAppSelection.
         return;
     }
   }
@@ -580,6 +624,7 @@ extension _ReaderChrome on _ReaderHibikiPageState {
   // without touching any native selection. Best-effort: a half-torn-down WebView
   // throws MissingPluginException on eval; swallow it (nothing to clear).
   Future<void> _clearReaderAppSelection() async {
+    _removeSelectionActionBar();
     try {
       await _controller?.evaluateJavascript(
         source: ReaderSelectionScripts.clearInvocation(),
@@ -711,6 +756,7 @@ extension _ReaderChrome on _ReaderHibikiPageState {
   /// 整段拖选区间，隐藏它们但保留收敛后的查词高亮供弹窗用。半销毁 WebView 上 eval 抛异常，
   /// 吞掉（无手柄可隐藏）。
   Future<void> _hideReaderSelectionHandles() async {
+    _removeSelectionActionBar();
     try {
       await _controller?.evaluateJavascript(
         source: 'window.hoshiSelection.hideSelectionHandles()',

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/lookup.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/lookup.part.dart
@@ -137,6 +137,7 @@ extension _ReaderLookup on _ReaderHibikiPageState {
     if (data.text.isEmpty) {
       return;
     }
+    _removeSelectionActionBar();
     // TODO-393 / BUG-缓存串味：每次新查词（换词 / 换句）都从「只制当前句」起步，丢弃
     // 上一个词的「上 N 句 / 下 N 句」上下文选择。热槽 WebView 复用使弹窗 DOM 不重载，
     // 草稿若不在此清空，上一个词攒的上下文会带到下一个词的卡（用户报「弹窗会缓存」）。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -1689,6 +1689,39 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
                     await _clearReaderAppSelection();
                   },
                 ),
+                if (isAndroidPlatform)
+                  ContextMenuItem(
+                    id: 4,
+                    title: t.share,
+                    action: () async {
+                      final String? text = await _controller?.getSelectedText();
+                      if (text == null || text.isEmpty) return;
+                      final bool shared = await SelectionExternalActions
+                          .instance
+                          .shareText(text);
+                      if (mounted && !shared) {
+                        HibikiToast.show(msg: t.selection_share_failed);
+                      }
+                      await _clearReaderAppSelection();
+                    },
+                  ),
+                if (isAndroidPlatform)
+                  ContextMenuItem(
+                    id: 5,
+                    title: t.selection_web_search,
+                    action: () async {
+                      final String? text = await _controller?.getSelectedText();
+                      if (text == null || text.isEmpty) return;
+                      final bool opened = await SelectionExternalActions
+                          .instance
+                          .searchWeb(text);
+                      if (mounted && !opened) {
+                        HibikiToast.show(
+                            msg: t.selection_web_search_unavailable);
+                      }
+                      await _clearReaderAppSelection();
+                    },
+                  ),
               ],
             ),
       initialUserScripts: UnmodifiableListView<UserScript>(<UserScript>[

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -71,6 +71,7 @@ import 'package:hibiki/src/startup/exit_flush_registry.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
 import 'package:hibiki/src/media/audiobook/floating_lyric_channel.dart';
 import 'package:hibiki/src/media/audiobook/pointer_seek.dart';
+import 'package:hibiki/src/platform/selection_external_actions.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/utils/misc/coalesced_async_runner.dart';
@@ -1135,6 +1136,10 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   bool _readerContentReady = false;
   bool _hasEverLoaded = false;
   bool _readerTextContextMenuActive = false;
+  // BUG-1236：移动端长按拖选后的非模态选区操作条。旧 showMenu 的全屏
+  // ModalBarrier 会截断 WebView 手柄触摸；OverlayEntry 只让按钮区域命中。
+  OverlayEntry? _selectionActionBarEntry;
+  ReaderSelectionData? _selectionActionData;
   bool _restoreInFlight = false;
   bool _isNavigatingToChapter = false;
   // TODO-1037：跨章推进经过的「纯图片章逐个停留」序列在途时为真，防重入跨章导航。
@@ -2047,6 +2052,7 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       _exitFlushCallback = null;
     }
     WidgetsBinding.instance.removeObserver(this);
+    _removeSelectionActionBar();
     _progressPollTimer?.cancel();
     _saveDebounce?.cancel();
     _scrollProgressThrottleTimer?.cancel();

--- a/hibiki/lib/src/platform/selection_external_actions.dart
+++ b/hibiki/lib/src/platform/selection_external_actions.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/services.dart';
+import 'package:hibiki/src/utils/misc/channel_constants.dart';
+import 'package:share_plus/share_plus.dart';
+
+typedef ShareSelectedText = Future<void> Function(String text);
+
+/// Narrow platform seam for actions that hand a selected text payload to
+/// another Android app.
+///
+/// Sharing intentionally reuses [Share.share]. Web search is not a URL launch:
+/// Android receives the original text through `ACTION_WEB_SEARCH` /
+/// `SearchManager.QUERY` and lets the system-selected handler decide where it
+/// goes.
+class SelectionExternalActions {
+  SelectionExternalActions({
+    MethodChannel? channel,
+    ShareSelectedText? shareSelectedText,
+  })  : _channel = channel ?? HibikiChannels.selectionActions,
+        _shareSelectedText = shareSelectedText ??
+            ((String text) async {
+              await Share.share(text);
+            });
+
+  static final SelectionExternalActions instance = SelectionExternalActions();
+
+  final MethodChannel _channel;
+  final ShareSelectedText _shareSelectedText;
+
+  /// Opens the system share sheet with [text] unchanged.
+  Future<bool> shareText(String text) async {
+    if (text.isEmpty) return false;
+    try {
+      await _shareSelectedText(text);
+      return true;
+    } on Object {
+      return false;
+    }
+  }
+
+  /// Asks Android's default web-search handler to search [text] unchanged.
+  ///
+  /// `false` includes both "no handler installed" and a missing/broken native
+  /// channel. Callers must surface that outcome to the user.
+  Future<bool> searchWeb(String text) async {
+    if (text.isEmpty) return false;
+    try {
+      return await _channel.invokeMethod<bool>(
+            'webSearch',
+            <String, String>{'query': text},
+          ) ??
+          false;
+    } on Object {
+      return false;
+    }
+  }
+}

--- a/hibiki/lib/src/utils/misc/channel_constants.dart
+++ b/hibiki/lib/src/utils/misc/channel_constants.dart
@@ -24,6 +24,8 @@ abstract final class HibikiChannels {
       MethodChannel('$_prefix/clipboard_image');
   static const MethodChannel screenBrightness =
       MethodChannel('$_prefix/screen_brightness');
+  static const MethodChannel selectionActions =
+      MethodChannel('$_prefix/selection_actions');
   // TODO-617: drives the desktop global lookup overlay (bare WebView2 window).
   static const MethodChannel globalLookup =
       MethodChannel('$_prefix/global_lookup');

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1000
+version: 1.3.1+1001
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/dictionary/popup_touch_copy_actionmode_guard_test.dart
+++ b/hibiki/test/dictionary/popup_touch_copy_actionmode_guard_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _between(String source, String start, String end) {
+  final int startAt = source.indexOf(start);
+  final int endAt = source.indexOf(end, startAt + start.length);
+  if (startAt < 0 || endAt <= startAt) {
+    throw StateError('guard markers missing: $start .. $end');
+  }
+  return source.substring(startAt, endAt);
+}
+
+void main() {
+  final String source =
+      File('lib/src/pages/implementations/dictionary_popup_webview.dart')
+          .readAsStringSync();
+  final String menu =
+      _between(source, 'contextMenu: ContextMenu(', 'gestureRecognizers:');
+
+  group('BUG-1237 Android popup actions bypass finished ActionMode', () {
+    test('Android hides broken system items while iOS is not expanded', () {
+      expect(
+        menu,
+        contains('Platform.isAndroid || isWindowsPlatform'),
+      );
+      expect(menu, contains('if (Platform.isAndroid)'));
+    });
+
+    test('copy is custom Dart clipboard action and selection is cleared', () {
+      expect(menu, contains('title: t.copy'));
+      expect(menu, contains('Clipboard.setData(ClipboardData(text: text))'));
+      expect(menu, contains('_selectedTextAcrossFrames()'));
+      expect(menu, contains('_clearSelectedTextAcrossFrames()'));
+    });
+
+    test('share and web search reuse the common action seam', () {
+      expect(menu, contains('title: t.share'));
+      expect(menu, contains('title: t.selection_web_search'));
+      expect(
+          menu, contains('SelectionExternalActions.instance.shareText(text)'));
+      expect(
+          menu, contains('SelectionExternalActions.instance.searchWeb(text)'));
+      expect(menu, contains('t.selection_web_search_unavailable'));
+    });
+  });
+
+  test('Windows right-click path remains unchanged', () {
+    final String windows = _between(
+      source,
+      'Future<void> _showWindowsContextMenu(',
+      'static String? _cachedStylesJson',
+    );
+    expect(source, contains('disableContextMenu: isWindowsPlatform'));
+    expect(windows, contains('_selectedTextAcrossFrames()'));
+    expect(windows, contains('Clipboard.setData(ClipboardData(text: text))'));
+    expect(windows, isNot(contains('SelectionExternalActions')));
+  });
+}

--- a/hibiki/test/pages/dictionary_popup_webview_test.dart
+++ b/hibiki/test/pages/dictionary_popup_webview_test.dart
@@ -640,11 +640,12 @@ void main() {
 
     test('症状②：Windows 禁原生菜单 + 走 Flutter showMenu（BUG-261 锚点范式）', () {
       // 原生 WebView2 菜单只在 Windows 偏移（独立 Win32 popup 用未拉伸逻辑坐标），
-      // 故只在 Windows 禁原生改 Flutter 菜单；非 Windows 保持原生（false 不写死）。
+      // Windows 禁原生改 Flutter 菜单；Android 因 BUG-1237 的 ActionMode 转发缺陷
+      // 也隐藏系统项、改由 Dart 直做。iOS 不扩范围，保持原生。
       expect(
         source,
-        contains('hideDefaultSystemContextMenuItems: isWindowsPlatform'),
-        reason: 'Windows 才禁 WebView2 原生菜单，其它平台保持原生（症状②）。',
+        contains('Platform.isAndroid || isWindowsPlatform'),
+        reason: 'Windows 与 Android 各自按真实原生缺陷禁系统项；iOS 保持原生。',
       );
       // 右键入口 onSecondaryTapDown，仅 Windows 包 GestureDetector。
       expect(source, contains('onSecondaryTapDown:'),

--- a/hibiki/test/platform/android_selection_action_channel_guard_test.dart
+++ b/hibiki/test/platform/android_selection_action_channel_guard_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String native = File(
+    'android/app/src/main/java/app/hibiki/reader/SelectionActionChannel.java',
+  ).readAsStringSync();
+  final String lower = native.toLowerCase();
+
+  test('web search uses Android ACTION_WEB_SEARCH and SearchManager.QUERY', () {
+    expect(native, contains('Intent.ACTION_WEB_SEARCH'));
+    expect(native, contains('SearchManager.QUERY'));
+    expect(native, contains('intent.putExtra(SearchManager.QUERY, query)'));
+    expect(native,
+        contains('intent.resolveActivity(context.getPackageManager())'));
+    expect(native, contains('result.success(launchWebSearch(context, query))'));
+  });
+
+  test('web search has no URL or vendor fallback', () {
+    expect(native, isNot(contains('Intent.ACTION_VIEW')));
+    expect(native, isNot(contains('Uri.parse')));
+    expect(lower, isNot(contains('http://')));
+    expect(lower, isNot(contains('https://')));
+    expect(lower, isNot(contains('google.')));
+    expect(lower, isNot(contains('bing.')));
+  });
+
+  test('main and popup engines register the same channel seam', () {
+    final String main = File(
+      'android/app/src/main/java/app/hibiki/reader/MainActivity.java',
+    ).readAsStringSync();
+    final String popup = File(
+      'android/app/src/main/java/app/hibiki/reader/PopupEngineHolder.kt',
+    ).readAsStringSync();
+    final String registrant = File(
+      'android/app/src/main/java/app/hibiki/reader/'
+      'FloatingDictPluginRegistrant.java',
+    ).readAsStringSync();
+    expect(main,
+        contains('SelectionActionChannel.registerWith(flutterEngine, this)'));
+    expect(
+      popup,
+      contains(
+        'SelectionActionChannel.registerWith(engine, context.applicationContext)',
+      ),
+    );
+    expect(registrant,
+        contains('new dev.fluttercommunity.plus.share.SharePlusPlugin()'));
+  });
+}

--- a/hibiki/test/platform/android_selection_action_channel_guard_test.dart
+++ b/hibiki/test/platform/android_selection_action_channel_guard_test.dart
@@ -12,9 +12,21 @@ void main() {
     expect(native, contains('Intent.ACTION_WEB_SEARCH'));
     expect(native, contains('SearchManager.QUERY'));
     expect(native, contains('intent.putExtra(SearchManager.QUERY, query)'));
-    expect(native,
-        contains('intent.resolveActivity(context.getPackageManager())'));
     expect(native, contains('result.success(launchWebSearch(context, query))'));
+  });
+
+  test('web search launches directly despite package visibility filtering', () {
+    expect(native, isNot(contains('resolveActivity(')));
+    expect(native, contains('context.startActivity(intent)'));
+    expect(native, contains('catch (ActivityNotFoundException error)'));
+    expect(
+      native,
+      contains(
+        'catch (ActivityNotFoundException error) {\n'
+        '            return false;\n'
+        '        }',
+      ),
+    );
   });
 
   test('web search has no URL or vendor fallback', () {

--- a/hibiki/test/platform/selection_external_actions_test.dart
+++ b/hibiki/test/platform/selection_external_actions_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/platform/selection_external_actions.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('test/selection_actions');
+  final List<MethodCall> calls = <MethodCall>[];
+
+  setUp(() {
+    calls.clear();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall call) async {
+      calls.add(call);
+      return true;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  test('share forwards CJK, spaces, and newlines unchanged', () async {
+    const String payload = '日本語  中文\nsecond line  ';
+    String? shared;
+    final SelectionExternalActions actions = SelectionExternalActions(
+      channel: channel,
+      shareSelectedText: (String text) async {
+        shared = text;
+      },
+    );
+
+    expect(await actions.shareText(payload), isTrue);
+    expect(shared, payload);
+  });
+
+  test('web search uses exact method and QUERY payload unchanged', () async {
+    const String payload = '漢字  かな\nnext line  ';
+    final SelectionExternalActions actions = SelectionExternalActions(
+      channel: channel,
+      shareSelectedText: (String _) async {},
+    );
+
+    expect(await actions.searchWeb(payload), isTrue);
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'webSearch');
+    expect(calls.single.arguments, <String, String>{'query': payload});
+  });
+
+  test('missing search handler and failed share return visible-failure signal',
+      () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall _) async => false);
+    final SelectionExternalActions actions = SelectionExternalActions(
+      channel: channel,
+      shareSelectedText: (String _) async {
+        throw StateError('no share activity');
+      },
+    );
+
+    expect(await actions.searchWeb('query'), isFalse);
+    expect(await actions.shareText('query'), isFalse);
+  });
+}

--- a/hibiki/test/reader/reader_mobile_selection_export_menu_guard_test.dart
+++ b/hibiki/test/reader/reader_mobile_selection_export_menu_guard_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 /// TODO-1366：手机拖选选区菜单补「导出片段」守卫（自绘拖选 TODO-1317/BUG-624 的遗留缺口）。
 ///
-/// 手机长按拖选出的是 **app 自绘选区**（`onSelectionMenu` -> Flutter `showMenu`，即
+/// 手机长按拖选出的是 **app 自绘选区**（`onSelectionMenu` -> Flutter 非模态操作条，即
 /// `_handleSelectionMenu`），此前只有「查词 / 复制」，缺桌面右键 / 原生 ActionMode 早有的
 /// 「导出片段」。本守卫钉死：
 ///   ① 手机拖选菜单含「导出片段」（`t.audiobook_export_clip`），与桌面同 i18n key，且同门控
@@ -34,7 +34,7 @@ void main() {
     test('_handleSelectionMenu 菜单项含 export + 查词 + 复制', () {
       final String body = _between(chrome, 'Future<void> _handleSelectionMenu(',
           'Future<void> _clearReaderAppSelection(');
-      expect(body, contains("value: 'export'"), reason: '缺「导出片段」菜单项');
+      expect(body, contains("'export'"), reason: '缺「导出片段」操作项');
       expect(body, contains('t.audiobook_export_clip'),
           reason: '导出项必须复用桌面同一 i18n key');
       // 门控：本书有音频 cue 才出现（与桌面 _showReaderTextContextMenu 同判据）。

--- a/hibiki/test/reader/reader_selection_action_bar_nonmodal_guard_test.dart
+++ b/hibiki/test/reader/reader_selection_action_bar_nonmodal_guard_test.dart
@@ -1,0 +1,119 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+String _between(String source, String start, String end) {
+  final int startAt = source.indexOf(start);
+  final int endAt = source.indexOf(end, startAt + start.length);
+  if (startAt < 0 || endAt <= startAt) {
+    throw StateError('guard markers missing: $start .. $end');
+  }
+  return source.substring(startAt, endAt);
+}
+
+String _withoutLineComments(String source) =>
+    source.split('\n').map((String line) {
+      final int at = line.indexOf('//');
+      return at < 0 ? line : line.substring(0, at);
+    }).join('\n');
+
+void main() {
+  final String chrome =
+      File('lib/src/pages/implementations/reader_hibiki/chrome.part.dart')
+          .readAsStringSync();
+  final String bar = _between(
+    chrome,
+    'Future<void> _handleSelectionMenu(',
+    'Future<void> _clearReaderAppSelection(',
+  );
+
+  group('BUG-1236 selection action bar stays non-modal', () {
+    test('uses OverlayEntry and never showMenu/showDialog', () {
+      final String code = _withoutLineComments(bar);
+      expect(code, isNot(contains('showMenu')));
+      expect(code, isNot(contains('showDialog')));
+      expect(bar, contains('OverlayEntry('));
+      expect(bar, contains('overlay.insert(entry)'));
+      expect(bar, contains('markNeedsBuild()'));
+      expect(bar, contains('handleReserve'));
+    });
+
+    test('remove path disposes entry and clears payload', () {
+      final String remove = _between(
+        bar,
+        'void _removeSelectionActionBar()',
+        'Widget _buildSelectionActionBar(',
+      );
+      expect(remove, contains('remove()'));
+      expect(remove, contains('dispose()'));
+      expect(remove, contains('_selectionActionBarEntry = null'));
+      expect(remove, contains('_selectionActionData = null'));
+    });
+
+    test('Android actions include lookup copy share and web search', () {
+      expect(bar, contains("t.search, 'search'"));
+      expect(bar, contains("t.copy, 'copy'"));
+      expect(bar, contains("t.share, 'share'"));
+      expect(bar, contains('t.selection_web_search'));
+      expect(bar, contains("case 'share':"));
+      expect(bar, contains("case 'webSearch':"));
+      expect(bar,
+          contains('SelectionExternalActions.instance.shareText(data.text)'));
+      expect(bar,
+          contains('SelectionExternalActions.instance.searchWeb(data.text)'));
+      expect(bar, contains('t.selection_web_search_unavailable'));
+      expect(bar, contains('await _clearReaderAppSelection()'));
+    });
+  });
+
+  test('all selection convergence/lifecycle paths remove the bar', () {
+    final String lookup =
+        File('lib/src/pages/implementations/reader_hibiki/lookup.part.dart')
+            .readAsStringSync();
+    final String page =
+        File('lib/src/pages/implementations/reader_hibiki_page.dart')
+            .readAsStringSync();
+    expect(
+      _between(
+        chrome,
+        'Future<void> _clearReaderAppSelection(',
+        'Future<ReaderSelectionData?>',
+      ),
+      contains('_removeSelectionActionBar()'),
+    );
+    expect(
+      _between(
+        chrome,
+        'Future<void> _hideReaderSelectionHandles(',
+        '_extractSelectionClipImages',
+      ),
+      contains('_removeSelectionActionBar()'),
+    );
+    expect(
+      _between(
+        lookup,
+        'Future<void> _handleTextSelected(',
+        '_miningDraft.clear()',
+      ),
+      contains('_removeSelectionActionBar()'),
+    );
+    expect(page.substring(page.indexOf('void dispose()')),
+        contains('_removeSelectionActionBar()'));
+  });
+
+  test('ordinary Android native selection menu has all four requested actions',
+      () {
+    final String webview =
+        File('lib/src/pages/implementations/reader_hibiki/webview.part.dart')
+            .readAsStringSync();
+    final String menu = _between(
+        webview, 'contextMenu: isWindowsPlatform', 'initialUserScripts:');
+    expect(menu, contains('title: t.search'));
+    expect(menu, contains('title: t.copy'));
+    expect(menu, contains('title: t.share'));
+    expect(menu, contains('title: t.selection_web_search'));
+    expect(menu, contains('SelectionExternalActions'));
+    expect(menu, isNot(contains('multiSelect')));
+    expect(menu, isNot(contains('selectionMode')));
+  });
+}

--- a/hibiki/test/reader/reader_selection_favorite_menu_guard_test.dart
+++ b/hibiki/test/reader/reader_selection_favorite_menu_guard_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// （`_showReaderTextContextMenu`），两条选区入口此前都无收藏项。本守卫钉死两处都补上
 /// 「收藏」，且各自按选区类型正确填「查词状态」（`currentSentence` / 句级区间非空契约）
 /// 后复用同一后端 `_toggleFavoriteSentence`：
-///   ① 手机拖选菜单：`value: 'favorite'` + `t.action_favorite`，switch 分支经
+///   ① 手机拖选菜单：非模态条的 `'favorite'` + `t.action_favorite`，switch 分支经
 ///      `_fillLookupStateFromSelectionData(..., extractNativeImages: false)`（无原生选区）
 ///      填状态后 `_toggleFavoriteSentence()`；
 ///   ② 桌面右键菜单：同项，switch 分支经 `_fillLookupStateFromNativeSelection()`
@@ -44,7 +44,7 @@ void main() {
   group('① 手机拖选菜单补「收藏」（自绘选区，无原生选区）', () {
     test('菜单项含 favorite + 复用 action_favorite i18n key', () {
       final String body = selectionMenuBody();
-      expect(body, contains("value: 'favorite'"), reason: '缺「收藏」菜单项');
+      expect(body, contains("'favorite'"), reason: '缺「收藏」操作项');
       expect(body, contains('t.action_favorite'),
           reason: '收藏项必须复用既有 action_favorite i18n key（勿新增重复 key）');
       // 查词 / 复制两条老出口仍在（共存，不回退）。


### PR DESCRIPTION
用户报两条：①「手机在书里面长按没办法选择前后」②「查词弹窗/gal 弹窗等在各个版本都有问题，基本上都没办法复制」。两条各自都有独立的真根因，且都不是新回归。

## BUG-1197 · 长按后选不了前后 = 选区确认菜单是模态的

手柄自身的命中链在 BUG-765 续修里已经修好，问题在它**上面一层**：拖选松手后 Dart 弹的是 Flutter `showMenu`，其 `_PopupMenuRoute` 是 `PopupRoute`，**路由自带全屏 `ModalBarrier`**。于是

- 菜单在场期间所有指针被 barrier 吸走 → WebView 里画的选区手柄（`data-hoshi-sel-handle`）收不到 `touchstart`，按住怎么拖都不动；
- 想调整就得先点掉菜单，而那次触摸恰好被 barrier 当成 dismiss 吃掉；
- 手柄 `touchend` 又会再次 `fireSelectionMenu` 把菜单弹回来 → 「关菜单 → 拖一下 → 菜单又弹 → 再关」死循环。

即「确认菜单」与「调整手柄」被安排在同一时刻，却选了互斥的模态呈现方式。

**修复**：改成挂在 `Overlay` 上的**非模态操作条**——只有按钮那块矩形接收指针，其余区域穿透回 WebView，手柄与操作条同时可用；手柄拖完的重入只 `markNeedsBuild()` 刷新位置/payload。条优先贴选区**上方**，上方放不下才落到下方并额外让开手柄 32px 触控盒（永不压住手柄）；水平居中于屏幕（省掉按条宽夹紧那一整类边界特例），窄屏用 `FittedBox(scaleDown)` 等比缩小而非换行/裁切。查词 / 复制 / 收藏 / 导出片段四条出口与各自后端逐条不变。

条与选区**同生共死**：`_clearReaderAppSelection`（所有清选区路径汇合点，含点空白 `onTapEmpty`）、`_hideReaderSelectionHandles`（查词收敛后）、`_handleTextSelected`（tap 查词路径，JS 自己清了选区不经 Dart 清理）、`dispose`（条挂 Overlay，寿命长于本 State 子树）各自摘条，杜绝孤儿条。

桌面右键菜单 `_showReaderTextContextMenu` 仍用 `showMenu` **不动**——鼠标没有「一边拖手柄一边看菜单」的诉求，模态在那里没有代价。

## BUG-1198 · 查词弹窗触屏复制无效 = 复制被转发给已 finish 的 ActionMode

弹窗给 `InAppWebView` 传了**非空** `contextMenu.menuItems`（只为加一个「查词」项），撞上 vendored fork `InAppWebView.java:1564`：

```java
if (useHybridComposition && !disableContextMenu &&
    (contextMenu == null || contextMenu.keySet().size() == 0)) {
  return super.startActionMode(callback);   // 真·系统选择菜单
}
return rebuildActionMode(super.startActionMode(callback), callback);
```

非空 ⇒ 恒走 `rebuildActionMode`，它 `actionMenu.clear()` + **`actionMode.finish()`** 干掉系统 ActionMode，再自绘 floating menu，用户点系统「复制」时把点击转发给**那个已经 finish 掉的** ActionMode。上游已知缺陷（pichillilorenzo/flutter_inappwebview#678），fork 里的补救只写在 `!useHybridComposition` 分支、而 hybrid composition 恒开 ⇒ 补救永不命中 ⇒ 触屏点复制写不进剪贴板。

与 BUG-926 的分界：那条撤回 CSS 层全量禁选、恢复的是「**能不能选中**」；选中之后「**能不能复制**」断在本条的菜单层，两者叠加才是用户说的「基本上都没办法复制」。

**修复**照抄阅读器 BUG-544 已验证的范式：`hideDefaultSystemContextMenuItems` 恒 `true`，「复制」做成自定义项、动作由 Dart 直接 `_selectedTextAcrossFrames()`（BUG-802 穿透同源 iframe）→ `Clipboard.setData` → toast，不经任何 ActionMode 回调；与 Windows 右键菜单实现同源。Windows 原生菜单仍由 `disableContextMenu` 在 native 层关（BUG-477 不回归）。

**取舍（明说）**：隐藏系统默认项后 Android 选择菜单不再有「全选/分享/翻译/网页搜索」，只剩 [查词][复制]。与阅读器 BUG-544 一致——换回一个真的能用的复制，比留一排点了没反应的系统项有价值。将来若要恢复系统项，正确做法是修 fork 的 `rebuildActionMode`（别在 finish 掉的 ActionMode 上转发），而不是把这个标志改回去。

## 不在本 PR 范围（需要报告人补充信息）

- **gal 浮窗（app 外全局查词）**：核过后它**不是** `DictionaryPopupWebView`，而是 Windows native 的裸 WebView2 覆盖窗口（`windows/runner/global_lookup_window.cpp`），不共享上面修的那条路径。它既没设 `AreDefaultContextMenusEnabled`、也没注册 `ContextMenuRequested`，原生右键菜单默认是开的，理论上右键应有「复制」。到底是选不中 / 没菜单 / 菜单点了没反应，三种根因完全不同，不靠猜，等报告人确认后另开一条。
- **原地长按（不拖动）目前 = 直接查词**，不出选区手柄（TODO-971 慢速点词查词）。若期望「长按不动就该选中一个词并出手柄」，那是产品行为变更、会动到既有契约，未在本 PR 单方面改。

## 验证

- `flutter analyze`（含 test 目录）零 issue。
- 新增守卫 11 项全绿：`test/reader/reader_selection_action_bar_nonmodal_guard_test.dart`（不得回退模态呈现 / 必须 OverlayEntry / 重入只刷新 / 三出口与后端仍在 / 让开手柄触控盒 / 四条清选区路径 + dispose 都摘条）、`test/dictionary/popup_touch_copy_actionmode_guard_test.dart`（系统项必须隐藏且不得改回平台门控 / 自带复制项且 Dart 直接写剪贴板 / 选区读取穿透 iframe / Windows 契约不回归）。
- 既有相关守卫 38 项仍绿：`reader_longpress_selection_menu_guard_test` / `reader_longpress_drag_select_guard_test` / `reader_selection_handles_guard_test` / `popup_webview_disable_context_menu_guard_test` / `popup_touch_native_selection_guard_test` / `popup_selection_copy_search_iframe_guard_test`。
- 本地全量测试（`tool/flutter_test_failures.dart`）跑完后补结果。

**真机验收待报告人**（本机 `adb devices` 为空，代跑不了）：Android/iOS 书内长按拖选 → 两端圆钮能实时调整前后边界、操作条不吃触摸也不压手柄；查词弹窗长按释义 → 选中 → 菜单「复制」→ 粘贴校验。

https://claude.ai/code/session_01YNDznq5JdwE2cW3w3xu4zY