### PR TITLE
refactor(import): 漫画导入从书籍导入分家，载体身份提到入口

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1186 条。点号进各自文件。
+> 共 1187 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1233](bugs/BUG-1233-book-import-repeated-archive-probe.md) | ✅ | ✅ | 书籍导入重复整包判定 EPUB 载体 |
 | [BUG-1225](bugs/BUG-1225-shm-reader-write-access-must-stay.md) | ✅ | ✅ | 读端共享内存写权限不可收紧：SelectTextThread 的原子写落在只读页上会崩 |
 | [BUG-1221](bugs/BUG-1221-manga-path-case-folded.md) | ✅ | ✅ | 漫画页图解析把路径折成小写，制卡封面名被小写化且大小写敏感平台缺页 |
 | [BUG-1220](bugs/BUG-1220-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |

--- a/docs/bugs/BUG-1233-book-import-repeated-archive-probe.md
+++ b/docs/bugs/BUG-1233-book-import-repeated-archive-probe.md
@@ -1,0 +1,19 @@
+## BUG-1233 · 书籍导入重复整包判定 EPUB 载体
+- **报告**：2026-07-29（用户：TODO-2189）
+- **真实性**：✅ 真 bug。PR #523 分家后，普通 `.epub` 会先在
+  `hibiki/lib/src/media/audiobook/book_import_dialog.dart:224` 的漫画误投闸门执行
+  `MangaModule.isImageArchive`，仅 EPUB 路径又会在
+  `hibiki/lib/src/media/audiobook/book_import_dialog.dart:977` 最终分派时重复执行；
+  memo 前 exact head `22e7c1858` 的真实 EPUB widget 复现为期望 1、实际 2。
+- **[x] ① 已修复** — `c88df258a`：`ImportCarrierResolver.resolve` 按真实路径复用
+  载体判定，`BookImportDialog` 的误投闸门与最终分派共享同一 resolver；换路径自动
+  重算。
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/media/import/book_import_dialog_real_carrier_memo_test.dart` pump 真
+  `BookImportDialog`，用真实 EPUB+匹配 SRT、真实 Import 动作与真
+  `MangaModule.isImageArchive` 外层计数，断言对齐落库、同路径一次、换路径重算；
+  同时区分漫画专用入口无确认与书籍误投一次确认。
+- **备注**：旧 head 失败与缓存早退变异日志：
+  `.codex-test/todo-2189/pr523-pre-memo/old-head-failure.log`、
+  `.codex-test/todo-2189/mutation-cache-bypass/mutation-failure.log`。Android 物理机
+  未在本线程验证，不能据此宣称真机通过。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46852 (2756 per locale)
+/// Strings: 46971 (2763 per locale)
 ///
-/// Built on 2026-07-29 at 06:45 UTC
+/// Built on 2026-07-29 at 07:19 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3706,6 +3706,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Skipped ${m} of ${n} selected items that no longer exist';
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  String get manga_import_pick_file => 'Pick manga file';
+  String get manga_import_pick_folder => 'Pick manga folder';
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  String get manga_import_detected_title => 'This looks like manga';
+  String get manga_import_detected_confirm => 'Import as manga';
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -10016,6 +10025,22 @@ class _StringsAr extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -16394,6 +16419,22 @@ class _StringsDe extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -22788,6 +22829,22 @@ class _StringsEs extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -29193,6 +29250,22 @@ class _StringsFr extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -35527,6 +35600,22 @@ class _StringsId extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -41907,6 +41996,22 @@ class _StringsIt extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -48104,6 +48209,22 @@ class _StringsJa extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -54303,6 +54424,22 @@ class _StringsKo extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -60663,6 +60800,22 @@ class _StringsNl extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -67036,6 +67189,22 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -73393,6 +73562,22 @@ class _StringsRu extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -79698,6 +79883,22 @@ class _StringsTh extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -86035,6 +86236,22 @@ class _StringsTr extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -92357,6 +92574,22 @@ class _StringsVi extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -98231,6 +98464,21 @@ class _StringsZhCn extends _StringsEn {
       '选中的 ${n} 项中有 ${m} 项已不存在，已跳过';
   @override
   String get game_text_thread_unset => '尚未选择线程 · 选一条后开始捕获';
+  @override
+  String get manga_import_hint => '选择漫画文件夹、.cbz/.zip 页图压缩包，或 .mokuro 文件。';
+  @override
+  String get manga_import_pick_file => '选择漫画文件';
+  @override
+  String get manga_import_pick_folder => '选择漫画文件夹';
+  @override
+  String get manga_import_missing_input => '请先选择漫画文件或文件夹。';
+  @override
+  String get manga_import_detected_title => '这看起来是漫画';
+  @override
+  String get manga_import_detected_confirm => '按漫画导入';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
 }
 
 // Path: <root>
@@ -104349,6 +104597,22 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 /// Flat map(s) containing all translations.
@@ -109995,6 +110259,21 @@ extension on _StringsEn {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -115639,6 +115918,21 @@ extension on _StringsAr {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -121304,6 +121598,21 @@ extension on _StringsDe {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -126968,6 +127277,21 @@ extension on _StringsEs {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -132638,6 +132962,21 @@ extension on _StringsFr {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -138290,6 +138629,21 @@ extension on _StringsId {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -143957,6 +144311,21 @@ extension on _StringsIt {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -149586,6 +149955,21 @@ extension on _StringsJa {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -155219,6 +155603,21 @@ extension on _StringsKo {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -160879,6 +161278,21 @@ extension on _StringsNl {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -166536,6 +166950,21 @@ extension on _StringsPtBr {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -172198,6 +172627,21 @@ extension on _StringsRu {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -177844,6 +178288,21 @@ extension on _StringsTh {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -183499,6 +183958,21 @@ extension on _StringsTr {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -189149,6 +189623,21 @@ extension on _StringsVi {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -194753,6 +195242,20 @@ extension on _StringsZhCn {
             '选中的 ${n} 项中有 ${m} 项已不存在，已跳过';
       case 'game_text_thread_unset':
         return '尚未选择线程 · 选一条后开始捕获';
+      case 'manga_import_hint':
+        return '选择漫画文件夹、.cbz/.zip 页图压缩包，或 .mokuro 文件。';
+      case 'manga_import_pick_file':
+        return '选择漫画文件';
+      case 'manga_import_pick_folder':
+        return '选择漫画文件夹';
+      case 'manga_import_missing_input':
+        return '请先选择漫画文件或文件夹。';
+      case 'manga_import_detected_title':
+        return '这看起来是漫画';
+      case 'manga_import_detected_confirm':
+        return '按漫画导入';
+      case 'manga_import_detected_message':
+        return ({required Object name}) => '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
       default:
         return null;
     }
@@ -200377,6 +200880,21 @@ extension on _StringsZhHk {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "按游戏",
   "stat_clear_all_game_message": "确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。",
   "batch_selection_stale_skipped": "选中的 $n 项中有 $m 项已不存在，已跳过",
-  "game_text_thread_unset": "尚未选择线程 · 选一条后开始捕获"
+  "game_text_thread_unset": "尚未选择线程 · 选一条后开始捕获",
+  "manga_import_hint": "选择漫画文件夹、.cbz/.zip 页图压缩包，或 .mokuro 文件。",
+  "manga_import_pick_file": "选择漫画文件",
+  "manga_import_pick_folder": "选择漫画文件夹",
+  "manga_import_missing_input": "请先选择漫画文件或文件夹。",
+  "manga_import_detected_title": "这看起来是漫画",
+  "manga_import_detected_confirm": "按漫画导入",
+  "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2754,5 +2754,12 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -53,6 +53,7 @@ class BookImportDialog extends StatefulWidget {
     this.initialEpubPath,
     this.initialSubtitlePath,
     this.initialAudioPaths,
+    this.imageArchiveProbe,
     super.key,
   });
 
@@ -67,6 +68,11 @@ class BookImportDialog extends StatefulWidget {
   /// 故仅预填展示——`_doImport` 的「音频必须配字幕」校验照旧（拖 EPUB+音频无字幕
   /// 时仍要求补字幕）。
   final List<String>? initialAudioPaths;
+
+  /// 测试计数缝：生产始终走 [MangaModule.isImageArchive]；回归测试只在外层计数后
+  /// 委托同一个真判据，证明真实对话框没有重复执行昂贵的整包载体判定。
+  @visibleForTesting
+  final bool Function(String path)? imageArchiveProbe;
 
   @override
   State<BookImportDialog> createState() => _BookImportDialogState();
@@ -136,6 +142,10 @@ class _BookImportDialogState extends State<BookImportDialog>
   @override
   void initState() {
     super.initState();
+    _carrierResolver = ImportCarrierResolver(
+      isDirectory: (String pth) => Directory(pth).existsSync(),
+      isImageArchive: widget.imageArchiveProbe ?? MangaModule.isImageArchive,
+    );
     final String? epub = widget.initialEpubPath;
     if (epub != null) {
       _epubPath = epub;
@@ -250,10 +260,7 @@ class _BookImportDialogState extends State<BookImportDialog>
   /// 导入里会被问到三次（选中闸门 / `_doImport` 兜底闸门 / `_importEpubOnly` 分派），
   /// 而 `.zip` / `.epub` 的定性要真开包，问三次就整包解压三次。有声书对齐路径尤其亏
   /// ——它不进 `_importEpubOnly`，那几次开包纯属白开。记忆按路径失效，换文件会重算。
-  final ImportCarrierResolver _carrierResolver = ImportCarrierResolver(
-    isDirectory: (String pth) => Directory(pth).existsSync(),
-    isImageArchive: MangaModule.isImageArchive,
-  );
+  late final ImportCarrierResolver _carrierResolver;
 
   ImportCarrier _classifyCarrier(String path) => _carrierResolver.resolve(path);
 

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -245,11 +245,17 @@ class _BookImportDialogState extends State<BookImportDialog>
   }
 
   /// 判定一个待导入路径的载体身份。文件系统判据在此注入，分类函数本身不碰 IO。
-  ImportCarrier _classifyCarrier(String path) => classifyImportCarrier(
-        path,
-        isDirectory: (String pth) => Directory(pth).existsSync(),
-        isImageArchive: MangaModule.isImageArchive,
-      );
+  ///
+  /// 走 [ImportCarrierResolver] 而不是每次裸调 `classifyImportCarrier`：同一路径在一次
+  /// 导入里会被问到三次（选中闸门 / `_doImport` 兜底闸门 / `_importEpubOnly` 分派），
+  /// 而 `.zip` / `.epub` 的定性要真开包，问三次就整包解压三次。有声书对齐路径尤其亏
+  /// ——它不进 `_importEpubOnly`，那几次开包纯属白开。记忆按路径失效，换文件会重算。
+  final ImportCarrierResolver _carrierResolver = ImportCarrierResolver(
+    isDirectory: (String pth) => Directory(pth).existsSync(),
+    isImageArchive: MangaModule.isImageArchive,
+  );
+
+  ImportCarrier _classifyCarrier(String path) => _carrierResolver.resolve(path);
 
   /// 拖文件进本对话框 → 分类 → 按字段覆盖（仅填命中类，不清用户已选）。
   /// 纯解析交给 [resolveBookDialogDrop]；此处只 setState + sidecar/封面副作用。

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/src/media/audiobook/audiobook_alignment_service.dart';
 import 'package:hibiki/src/media/audiobook/sasayaki_rematch.dart';
 import 'package:hibiki/src/media/audiobook/text_to_epub.dart';
 import 'package:hibiki/src/media/import/audiobook_health_summary.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
 import 'package:hibiki/src/media/import/import_dialog_frame.dart';
 import 'package:hibiki/src/media/import/import_flow_mixin.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
@@ -24,10 +25,9 @@ import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/epub/book_title_conflict.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/pdf/pdf_importer.dart';
-import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
-import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/utils.dart';
 
 /// 统一"导入书"对话框。EPUB、字幕、音频可按需组合，一次导入。
@@ -41,6 +41,10 @@ import 'package:hibiki/utils.dart';
 ///   [EpubParser] 读回章节文本，跑 [EpubSrtMatcher] + [SasayakiMatchCodec]，
 ///   把 cue 对齐到真实 EPUB；cues + 可选音频落到 [AudiobookRepository]。
 /// - **音频但无字幕**：非法组合，音频必须配合字幕使用。
+///
+/// **漫画不在此列**：漫画有独立入口与独立对话框 [MangaImportDialog]（载体不同，
+/// 可填字段就不同——漫画没有字幕/音频/对齐，书籍没有 OCR）。本框仍然**认得**漫画
+/// 载体，但只做一件事：弹一次明确确认后把路径转交漫画流程（[_handoffIfManga]）。
 class BookImportDialog extends StatefulWidget {
   const BookImportDialog({
     required this.repo,
@@ -49,8 +53,6 @@ class BookImportDialog extends StatefulWidget {
     this.initialEpubPath,
     this.initialSubtitlePath,
     this.initialAudioPaths,
-    this.mangaOcrRemoteRunner,
-    this.ocrEntryDesktopOverride,
     super.key,
   });
 
@@ -59,14 +61,6 @@ class BookImportDialog extends StatefulWidget {
   final HibikiDatabase db;
   final String? initialEpubPath;
   final String? initialSubtitlePath;
-
-  /// 漫画 P3 测试缝：注入远程 OCR runner（探测已配对 host 能力 + 代跑）。
-  /// null = 生产路径，按 [db] 惰性构造 [InterconnectMangaOcrClient]。
-  final MangaOcrRemoteRunner? mangaOcrRemoteRunner;
-
-  /// 漫画 P3 测试缝：覆盖「是否桌面平台」判定（widget 测试模拟移动端入口
-  /// gating）。null = 用真实 [isDesktopPlatform]。
-  final bool? ocrEntryDesktopOverride;
 
   /// 拖拽导入预填：随新书一起拖入的音频文件路径。EPUB+音频拖到书架空白处时透传，
   /// 否则丢失（书架 `importNewBook` 此前未携带 `files.audios`）。音频必配字幕，
@@ -105,18 +99,6 @@ class _BookImportDialogState extends State<BookImportDialog>
   String? _subtitleName;
 
   bool _pickerActive = false;
-
-  /// 远程 OCR runner（生产 = [InterconnectMangaOcrClient]；测试注 fake）。
-  late final MangaOcrRemoteRunner _mangaOcrRemoteRunner =
-      widget.mangaOcrRemoteRunner ??
-          InterconnectMangaOcrClient(repo: SyncRepository(widget.db));
-
-  bool get _ocrEntryDesktop =>
-      widget.ocrEntryDesktopOverride ?? isDesktopPlatform;
-
-  /// Google Lens is available on every supported app platform, so the manga
-  /// OCR entry no longer depends on a paired desktop host on mobile.
-  bool get _showOcrEntry => true;
 
   /// TODO-935 ①A：「引用原文件（不复制）」开关。仅桌面可见/可选；移动端
   /// file_picker 返回缓存临时副本，引用即指向会被清掉的文件，故恒 false。
@@ -206,15 +188,8 @@ class _BookImportDialogState extends State<BookImportDialog>
         title: Text(t.srt_import),
         content: _buildForm(),
         actions: [
-          // 「OCR 导入漫画」：桌面恒显示（内置 OCR / 外部 mokuro CLI 均桌面工具）；
-          // 移动端在探测到可代跑 OCR 的已配对 host 时也显示（漫画 P3 远程引擎）。
-          if (_showOcrEntry)
-            adaptiveDialogAction(
-              context: context,
-              onPressed: importing ? null : _openOcrWizard,
-              child: Text(t.manga_ocr_wizard_title),
-            ),
-          // 漫画「在线目录」入口已从书籍导入框移除（属漫画域，入口收敛到下载页）。
+          // 漫画入口（「OCR 导入漫画」/「在线目录」）均已移出书籍导入框：
+          // OCR 归 [MangaImportDialog]，在线目录归下载页。书籍框只做书。
           adaptiveDialogAction(
             context: context,
             onPressed: () => Navigator.pop(context),
@@ -226,30 +201,67 @@ class _BookImportDialogState extends State<BookImportDialog>
     );
   }
 
-  /// 打开 OCR 导入漫画向导：从 provider 取内置 OCR 服务、按当前偏好构造外部
-  /// mokuro runner（均桌面工具），再挂上远程「已配对主机」runner（移动端唯一
-  /// 引擎，桌面亦可作后备）；向导内选裸图片文件夹跑整卷 OCR 后无缝落库；成功
-  /// （返回 bookKey）则连同关闭本导入框并回传 true，让书架刷新。
-  Future<void> _openOcrWizard() async {
-    final String? bookKey = await MangaModule.openOcrImportWizard(
+  /// 选/拖进来的路径若其实是漫画载体，弹一次明确确认并转交 [MangaImportDialog]。
+  ///
+  /// 返回 `true` 表示「本路径已被漫画流程接手，书籍侧不要再收下它」——用户在确认
+  /// 框里点取消也算接手（不继续按书导入，那只会产出一本乱码书）。
+  ///
+  /// 为什么书籍入口还要认漫画：图片型 `.zip` / 扫描版 `.epub` 与词典包/普通电子书
+  /// 同形，拖到书架时分类层按扩展名归 books（它刻意不为每次拖 EPUB 白开一次包）。
+  /// 此前这里是**静默**转漫画导入；现在改成用户可见的一次确认——识别照旧，分派不
+  /// 再背着用户发生。
+  Future<bool> _handoffIfManga(String path) async {
+    if (!_classifyCarrier(path).isManga) return false;
+    final bool? go = await showAppDialog<bool>(
       context: context,
-      db: widget.db,
-      remoteRunner: _mangaOcrRemoteRunner,
-      desktop: _ocrEntryDesktop,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: Text(t.manga_import_detected_title),
+        content: Text(
+          t.manga_import_detected_message(name: p.basename(path)),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(t.dialog_cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(t.manga_import_detected_confirm),
+          ),
+        ],
+      ),
     );
-    if (bookKey != null && mounted) {
-      Navigator.pop(context, true);
+    if (go != true || !mounted) return true;
+
+    final bool? imported = await showAppDialog<bool>(
+      context: context,
+      builder: (_) => MangaImportDialog(db: widget.db, initialPath: path),
+    );
+    if (mounted) {
+      // 关掉书籍框并把漫画侧的导入结果透传出去，书架照常刷新。
+      Navigator.pop(context, imported == true);
     }
+    return true;
   }
+
+  /// 判定一个待导入路径的载体身份。文件系统判据在此注入，分类函数本身不碰 IO。
+  ImportCarrier _classifyCarrier(String path) => classifyImportCarrier(
+        path,
+        isDirectory: (String pth) => Directory(pth).existsSync(),
+        isImageArchive: MangaModule.isImageArchive,
+      );
 
   /// 拖文件进本对话框 → 分类 → 按字段覆盖（仅填命中类，不清用户已选）。
   /// 纯解析交给 [resolveBookDialogDrop]；此处只 setState + sidecar/封面副作用。
-  void _handleDialogDrop(List<String> paths, Offset _) {
+  Future<void> _handleDialogDrop(List<String> paths, Offset _) async {
     if (importing) return;
     final DroppedFiles files = classifyDroppedFiles(paths);
     final BookDialogDropResult r = resolveBookDialogDrop(files);
     if (r.isEmpty) return;
     final String? droppedEpub = r.epubPath;
+    // 拖进来的「书」其实是漫画（图片型 zip / 扫描版 epub）→ 确认后转交漫画流程。
+    if (droppedEpub != null && await _handoffIfManga(droppedEpub)) return;
+    if (!mounted) return;
     final bool gotAudio = r.audioPaths.isNotEmpty;
     setState(() {
       if (droppedEpub != null) {
@@ -444,8 +456,10 @@ class _BookImportDialogState extends State<BookImportDialog>
     // PDF 阅读器 Phase 1：PDF 走独立 PdfImporter（真渲染，不经 TextToEpub 文本转换），
     // 在 [_importEpubOnly] 里按 .pdf 扩展名分支。
     'pdf',
-    // 漫画（第三种书）：`.mokuro`（v0.2+）+ 同级图片走独立 MangaImporter，落库 format='manga'，
-    // 在 [_importEpubOnly] 里按 .mokuro 扩展名分支（须在 TextToEpub 文本转换之前早退）。
+    // 漫画扩展名仍留在书籍选择器里，但**不再由本框导入**：选中后 [_handoffIfManga]
+    // 弹一次确认并转交 [MangaImportDialog]。留着是为了不打断老习惯——用户从书架
+    // 「导入书籍」里选到一本漫画时，得到的是一句「这是漫画」而不是「格式不支持」。
+    // `.zip` / `.epub` 无论如何都得留（图片型压缩包与词典包/普通电子书同形）。
     'mokuro',
     'cbz',
     'zip',
@@ -463,6 +477,9 @@ class _BookImportDialogState extends State<BookImportDialog>
       final PlatformFile? file = result?.files.single;
       final String? path = file?.path;
       if (path != null && file != null && mounted) {
+        // 选中的其实是漫画载体 → 明确确认后转交漫画流程，不再静默按书导入。
+        if (await _handoffIfManga(path)) return;
+        if (!mounted) return;
         setState(() {
           _epubPath = path;
           _epubName = file.name;
@@ -771,6 +788,12 @@ class _BookImportDialogState extends State<BookImportDialog>
       HibikiToast.show(msg: t.srt_import_missing_input);
       return;
     }
+    // 兜底闸门：选/拖两条入口在收下路径时就已过 [_handoffIfManga]，但 initialEpubPath
+    // 是构造参数直接塞进来的（书架拖入决策层刻意不为每个 EPUB 开包，图片型 .epub 会
+    // 以 books 身份到达这里）。同一个闸门在此再守一次，漫画绝不会走进书籍导入分支。
+    final String? epubPath = _epubPath;
+    if (epubPath != null && await _handoffIfManga(epubPath)) return;
+    if (!mounted) return;
     if (_epubPath != null && !_hasSubtitles && _audioPaths.isNotEmpty) {
       HibikiToast.show(msg: t.srt_import_audio_needs_subtitle);
       return;
@@ -941,35 +964,15 @@ class _BookImportDialogState extends State<BookImportDialog>
     final File file = File(_epubPath!);
 
     reportProgress(0.2, t.import_step_reading);
-    final String ext = p.extension(_epubPath!).toLowerCase();
 
-    // 漫画页图**目录**（拖入一个漫画文件夹）：整目录导入，OCR blocks 留空。
-    // 必须在所有按扩展名分派的分支之前——目录没有扩展名（目录名带点时 p.extension
-    // 还会误取出一个假扩展名），落到下面任何一条文件分支都会失败。
-    if (Directory(_epubPath!).existsSync()) {
-      reportProgress(0.5, t.import_step_importing_epub);
-      await MangaModule.importImageFolder(
-        db: widget.db,
-        path: _epubPath!,
-        title: title,
-        onDuplicateTitle: _onDuplicateTitle,
-        onProgress: (int done, int total) {
-          if (total > 0) {
-            reportProgress(
-              (done / total).clamp(0.0, 1.0),
-              t.import_step_copying_file(name: p.basename(_epubPath!)),
-            );
-          }
-        },
-      );
-      reportProgress(1, t.import_step_done);
-      return;
-    }
+    // 载体身份此前是在这里靠 4 个 if（含一次真读包）现场嗅出来的；现在它在**选中
+    // 文件那一刻**就已由 [classifyImportCarrier] 定死，且漫画载体根本进不来（三个
+    // 入口都过 [_handoffIfManga]）。这里只剩书籍侧的三种去向。
+    final ImportCarrier carrier = _classifyCarrier(_epubPath!);
 
-    // PDF 阅读器 Phase 1：.pdf 走独立 PdfImporter（pdfrx 真渲染 + 落库 format='pdf'），
-    // 必须在下面的 TextToEpub 文本转换分支之前早退——否则 PDF 二进制会被当文本转成乱码
-    // EPUB。PDF 封面在 PdfImporter 内栅格化首页得到，故不走 _applyBestCoverToEpub。
-    if (ext == '.pdf') {
+    // PDF 阅读器 Phase 1：.pdf 走独立 PdfImporter（pdfrx 真渲染 + 落库 format='pdf'）。
+    // PDF 封面在 PdfImporter 内栅格化首页得到，故不走 _applyBestCoverToEpub。
+    if (carrier == ImportCarrier.pdf) {
       reportProgress(0.5, t.import_step_importing_epub);
       await PdfImporter.importFromPath(
         db: widget.db,
@@ -982,54 +985,8 @@ class _BookImportDialogState extends State<BookImportDialog>
       return;
     }
 
-    // 漫画（第三种书）：.mokuro 走独立 MangaImporter（拷图 + 写 manga.json + 落库
-    // format='manga'），同样须在 TextToEpub 文本转换分支之前早退——否则 .mokuro 的 JSON 会被
-    // 当纯文本转成 EPUB。封面由 MangaImporter 取首页页图，故不走 _applyBestCoverToEpub。
-    if (ext == '.mokuro') {
-      reportProgress(0.5, t.import_step_importing_epub);
-      await MangaModule.importMokuro(
-        db: widget.db,
-        path: _epubPath!,
-        title: title,
-        onDuplicateTitle: _onDuplicateTitle,
-        onProgress: (int done, int total) {
-          if (total > 0) {
-            reportProgress(
-              (done / total).clamp(0.0, 1.0),
-              t.import_step_copying_file(name: p.basename(_epubPath!)),
-            );
-          }
-        },
-      );
-      reportProgress(1, t.import_step_done);
-      return;
-    }
-
-    if (ext == '.cbz' ||
-        (<String>{'.zip', '.epub'}.contains(ext) &&
-            MangaModule.isImageArchive(_epubPath!))) {
-      reportProgress(0.5, t.import_step_importing_epub);
-      await MangaModule.importArchive(
-        db: widget.db,
-        path: _epubPath!,
-        title: title,
-        onDuplicateTitle: _onDuplicateTitle,
-        onProgress: (int done, int total) {
-          if (total > 0) {
-            reportProgress(
-              (done / total).clamp(0.0, 1.0),
-              t.import_step_copying_file(name: p.basename(_epubPath!)),
-            );
-          }
-        },
-      );
-      reportProgress(1, t.import_step_done);
-      return;
-    }
-
     final String bookKey;
-    if (TextToEpub.isSupported(_epubPath!) ||
-        (ext != '.epub' && ext != '.zip')) {
+    if (carrier == ImportCarrier.text) {
       reportProgress(0.3, t.import_step_converting_epub);
       final Uint8List bytes =
           await TextToEpub.convert(file: file, title: title);

--- a/hibiki/lib/src/media/import/import_carrier.dart
+++ b/hibiki/lib/src/media/import/import_carrier.dart
@@ -1,0 +1,78 @@
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/media/audiobook/text_to_epub.dart';
+
+/// 一个待导入路径的**载体身份**：它到底是哪种东西，因而该交给哪个 importer。
+///
+/// 此前这个判断只活在 `BookImportDialog._importEpubOnly` 的函数体末尾——用户从
+/// 漫画库进来时「这是漫画」本来是已知的，却在入口被丢掉，一路走到导入执行阶段
+/// 再靠扩展名 + 真读包嗅回来。载体身份提到入口后，漫画和书籍各自有独立入口与
+/// 对话框，`isImageArchive` 那次真实 IO 只在**扩展名确实二义**时才发生。
+enum ImportCarrier {
+  /// 页图**目录**（一个漫画文件夹）。走 `MangaModule.importImageFolder`。
+  mangaFolder,
+
+  /// mokuro v0.2+ 的 `.mokuro` OCR 结果文件（+ 同级图片）。
+  /// 走 `MangaModule.importMokuro`。
+  mangaMokuro,
+
+  /// 图片压缩包：`.cbz`，或真读包确认装的是页图的 `.zip` / `.epub`。
+  /// 走 `MangaModule.importArchive`。
+  mangaArchive,
+
+  /// PDF。走 `PdfImporter`（真渲染，不经 TextToEpub 文本转换）。
+  pdf,
+
+  /// EPUB。走 `EpubImporter.importFromPath`。
+  epub,
+
+  /// 可转成 EPUB 的纯文本类（txt/md/html/…），以及不认识的扩展名。
+  /// 走 `TextToEpub.convert` + `EpubImporter.import`。
+  text;
+
+  /// 是否属漫画域（三种漫画载体的统称）。书籍侧入口只关心这一个问题。
+  bool get isManga =>
+      this == ImportCarrier.mangaFolder ||
+      this == ImportCarrier.mangaMokuro ||
+      this == ImportCarrier.mangaArchive;
+}
+
+/// 判定 [path] 的载体身份。
+///
+/// 文件系统判据由调用方注入（与 `classifyDroppedFiles` 同款设计），本函数自身
+/// 不碰 IO，故可在纯 Dart 测试里穷举各分支：
+///
+/// - [isDirectory]：目录判定。**必须最先问**——目录没有扩展名，而目录名带点时
+///   `p.extension` 还会误取出一个假扩展名，落到任何按扩展名分派的分支都会失败。
+/// - [isImageArchive]：真读包判定，只在扩展名二义（`.zip` / `.epub`）时才被调用。
+///   `.zip` 同时是 Yomitan 词典包扩展名，`.epub` 也可能是扫描版漫画——光看扩展名
+///   分不出，必须开包看里面装的是不是页图。
+ImportCarrier classifyImportCarrier(
+  String path, {
+  required bool Function(String path) isDirectory,
+  required bool Function(String path) isImageArchive,
+}) {
+  if (isDirectory(path)) return ImportCarrier.mangaFolder;
+
+  final String ext = p.extension(path).toLowerCase();
+
+  // PDF 必须在下面的文本分支之前早退——否则 PDF 二进制会被当文本转成乱码 EPUB。
+  if (ext == '.pdf') return ImportCarrier.pdf;
+
+  // .mokuro 同理：它的 JSON 内容会被文本分支当纯文本吞掉。
+  if (ext == '.mokuro') return ImportCarrier.mangaMokuro;
+
+  if (ext == '.cbz') return ImportCarrier.mangaArchive;
+  if (_ambiguousArchiveExtensions.contains(ext) && isImageArchive(path)) {
+    return ImportCarrier.mangaArchive;
+  }
+
+  // 非 epub/zip 的一切（含无扩展名文件）都尝试按文本转 EPUB——保持既有兜底语义。
+  if (TextToEpub.isSupported(path) || (ext != '.epub' && ext != '.zip')) {
+    return ImportCarrier.text;
+  }
+  return ImportCarrier.epub;
+}
+
+/// 需要真读包才能定性的容器扩展名（带点，小写）。
+const Set<String> _ambiguousArchiveExtensions = <String>{'.zip', '.epub'};

--- a/hibiki/lib/src/media/import/import_carrier.dart
+++ b/hibiki/lib/src/media/import/import_carrier.dart
@@ -76,3 +76,50 @@ ImportCarrier classifyImportCarrier(
 
 /// 需要真读包才能定性的容器扩展名（带点，小写）。
 const Set<String> _ambiguousArchiveExtensions = <String>{'.zip', '.epub'};
+
+/// 按路径记住一次载体身份的小盒子。
+///
+/// 为什么需要它：`.zip` / `.epub` 的定性要 [classifyImportCarrier] **真开包**
+/// （`isImageArchive` → 全量同步解压），那是导入对话框里唯一一处重量级同步 IO。
+/// 而一次导入里同一个路径会被问到不止一次：选中时的漫画闸门、`_doImport` 的兜底
+/// 闸门、以及真正分派时。每问一次就整包解压一次。有声书对齐路径（EPUB+字幕）尤其
+/// 亏——它根本不进按载体分派那一步，前面那几次开包纯属白开，而分家之前它一次都不开。
+///
+/// 载体身份本来就是路径的函数（这正是 [ImportCarrier] 的立意：身份在**选中那一刻**
+/// 定死，而不是一路嗅到导入执行阶段），所以按路径记住即可。换路径自动失效——key 变了
+/// 就重算，因此不会把上一个文件的判定张冠李戴到下一个文件上。
+///
+/// **不是**靠跳过判据来省 IO：判据一字未动，词典包一票否决照常生效（见
+/// `MangaArchiveImporter.looksLikeImageArchive`）。省掉的只是**重复**问同一个问题。
+class ImportCarrierResolver {
+  ImportCarrierResolver({
+    required this.isDirectory,
+    required this.isImageArchive,
+  });
+
+  final bool Function(String path) isDirectory;
+  final bool Function(String path) isImageArchive;
+
+  String? _cachedPath;
+  ImportCarrier? _cachedCarrier;
+
+  /// 判定 [path] 的载体身份；同一个 [path] 连续问只算一次真判定。
+  ImportCarrier resolve(String path) {
+    final ImportCarrier? cached = _cachedCarrier;
+    if (cached != null && _cachedPath == path) return cached;
+    final ImportCarrier carrier = classifyImportCarrier(
+      path,
+      isDirectory: isDirectory,
+      isImageArchive: isImageArchive,
+    );
+    _cachedPath = path;
+    _cachedCarrier = carrier;
+    return carrier;
+  }
+
+  /// 丢弃记忆。路径指向的文件可能在对话框开着时被换掉，需要重新定性时调用。
+  void invalidate() {
+    _cachedPath = null;
+    _cachedCarrier = null;
+  }
+}

--- a/hibiki/lib/src/media/manga/manga_import_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_import_dialog.dart
@@ -1,0 +1,397 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/epub/book_title_conflict.dart';
+import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
+import 'package:hibiki/src/media/import/import_dialog_frame.dart';
+import 'package:hibiki/src/media/import/import_flow_mixin.dart';
+import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki/utils.dart';
+
+/// 漫画导入对话框。
+///
+/// 与 [BookImportDialog] 分家的理由不是「代码重复」——两者共用 [ImportFlowMixin]
+/// 骨架、[ImportDialogFrame] 外框、同名书冲突解决和 `EpubBooks` 表，共用的部分一
+/// 点没少。分家是因为**载体不同、可填字段就不同**：漫画没有字幕、没有音频、没有
+/// 有声书对齐窗口，而书籍没有 OCR。此前两者挤在同一个对话框里，从漫画库点「导入
+/// 漫画」弹出的框有三行对漫画毫无意义的字幕/音频/对齐控件，且「这是漫画」这个在
+/// 入口就已知的事实被丢掉，一路走到导入执行阶段再靠扩展名 + 真读包嗅回来。
+///
+/// 本对话框只暴露漫画 importer 真正消费的两个参数：路径 + 标题。载体的三种细分
+/// （页图目录 / `.mokuro` / 图片压缩包）由 [classifyImportCarrier] 在**选中那一刻**
+/// 定死，[_doImport] 只是照着分派，不再二次嗅探。
+class MangaImportDialog extends StatefulWidget {
+  const MangaImportDialog({
+    required this.db,
+    this.initialPath,
+    this.mangaOcrRemoteRunner,
+    this.ocrEntryDesktopOverride,
+    super.key,
+  });
+
+  final HibikiDatabase db;
+
+  /// 拖放/书籍框转交时预填的漫画路径（目录 / `.cbz` / `.zip` 页图包 / `.mokuro`）。
+  final String? initialPath;
+
+  /// 测试缝：注入远程 OCR runner（探测已配对 host 能力 + 代跑）。
+  /// null = 生产路径，按 [db] 惰性构造 [InterconnectMangaOcrClient]。
+  final MangaOcrRemoteRunner? mangaOcrRemoteRunner;
+
+  /// 测试缝：覆盖「是否桌面平台」判定。null = 用真实 [isDesktopPlatform]。
+  final bool? ocrEntryDesktopOverride;
+
+  @override
+  State<MangaImportDialog> createState() => _MangaImportDialogState();
+}
+
+class _MangaImportDialogState extends State<MangaImportDialog>
+    with ImportFlowMixin<MangaImportDialog> {
+  final TextEditingController _titleCtrl = TextEditingController();
+
+  String? _path;
+  String? _pathName;
+  ImportCarrier? _carrier;
+
+  /// 用户是否手打过标题。打过就永不被自动派生覆盖。
+  ///
+  /// 书籍框那套五值 [ImportTitleSource] 是为「EPUB / 字幕 / 音频标签」三个来源
+  /// 抢同一个标题框而生的；漫画框只有一个来源（漫画路径），退化成一个 bool 即可，
+  /// 不搬那套跨来源优先级机器。
+  bool _titleFromUser = false;
+
+  bool _pickerActive = false;
+
+  late final MangaOcrRemoteRunner _mangaOcrRemoteRunner =
+      widget.mangaOcrRemoteRunner ??
+          InterconnectMangaOcrClient(repo: SyncRepository(widget.db));
+
+  bool get _ocrEntryDesktop =>
+      widget.ocrEntryDesktopOverride ?? isDesktopPlatform;
+
+  @override
+  void initState() {
+    super.initState();
+    final String? initial = widget.initialPath;
+    if (initial != null) {
+      // 预填路径来自已判定为漫画的上游（拖放决策层 / 书籍框转交），这里仍重跑一次
+      // 分类以拿到细分载体；万一上游给了非漫画路径，宁可留空也不静默导错东西。
+      final ImportCarrier carrier = _classify(initial);
+      if (carrier.isManga) {
+        _path = initial;
+        _pathName = p.basename(initial);
+        _carrier = carrier;
+        _titleCtrl.text = _deriveTitle(initial);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    super.dispose();
+  }
+
+  ImportCarrier _classify(String path) => classifyImportCarrier(
+        path,
+        isDirectory: (String pth) => Directory(pth).existsSync(),
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+  /// 目录取目录名，文件取去扩展名的文件名。
+  String _deriveTitle(String path) {
+    if (Directory(path).existsSync()) return p.basename(path);
+    return p.basenameWithoutExtension(path);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return HibikiFileDropTarget(
+      enabled: !importing,
+      debugLabel: 'manga-import-dialog',
+      onDrop: _handleDialogDrop,
+      child: ImportDialogFrame(
+        leadingIcon: Icons.auto_stories_outlined,
+        title: t.manga_import_action,
+        body: _buildForm(),
+        actions: <Widget>[
+          adaptiveDialogAction(
+            context: context,
+            onPressed: importing ? null : _openOcrWizard,
+            child: Text(t.manga_ocr_wizard_title),
+          ),
+          adaptiveDialogAction(
+            context: context,
+            onPressed: () => Navigator.pop(context),
+            child: Text(t.dialog_cancel),
+          ),
+          buildImportAction(context, onImport: _doImport),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Text(t.manga_import_hint, style: tokens.type.metadata),
+        SizedBox(height: tokens.spacing.gap),
+        AdaptiveSettingsSection(children: <Widget>[_mangaRow()]),
+        SizedBox(height: tokens.spacing.rowVertical),
+        HibikiTextField(
+          controller: _titleCtrl,
+          labelText: t.srt_import_title_hint,
+          onChanged: (String _) => _titleFromUser = true,
+        ),
+        if (importing) ...buildProgressSection(context, tokens),
+      ],
+    );
+  }
+
+  Widget _mangaRow() {
+    return HibikiFilePickerRow(
+      title: t.manga_import_pick_file,
+      subtitle: _pathName,
+      icon: Icons.auto_stories_outlined,
+      onTap: _pickFile,
+      actions: <Widget>[
+        // 漫画载体可以是**文件**（.cbz/.zip/.mokuro）也可以是**目录**（一卷页图），
+        // 两种选择器在系统层是两个不同的对话框，故并列两个入口而非合成一个。
+        HibikiIconButton(
+          icon: Icons.folder_open_outlined,
+          tooltip: t.manga_import_pick_folder,
+          isWideTapArea: true,
+          onTap: _pickFolder,
+        ),
+        HibikiIconButton(
+          icon: Icons.insert_drive_file_outlined,
+          tooltip: t.manga_import_pick_file,
+          isWideTapArea: true,
+          onTap: _pickFile,
+        ),
+      ],
+    );
+  }
+
+  // ── 选择 ────────────────────────────────────────────────────────────────
+
+  /// 漫画**文件**扩展名（不带点，小写）。`.zip` / `.epub` 在此列是因为图片型压缩包
+  /// 与词典包/普通电子书同形，选中后由 [classifyImportCarrier] 真读包定性；不是
+  /// 漫画的会被 [_adoptPath] 挡回。
+  static const Set<String> _mangaFileExtensions = <String>{
+    'mokuro',
+    'cbz',
+    'zip',
+    'epub',
+  };
+
+  Future<void> _pickFile() async {
+    if (_pickerActive) return;
+    _pickerActive = true;
+    try {
+      final AppModel appModel =
+          ProviderScope.containerOf(context, listen: false).read(appProvider);
+      final String? path = await pickRealFilePath(
+        context: context,
+        appModel: appModel,
+        allowedExtensions: _mangaFileExtensions,
+      );
+      if (path == null || !mounted) return;
+      _adoptPath(path);
+    } finally {
+      _pickerActive = false;
+    }
+  }
+
+  Future<void> _pickFolder() async {
+    if (_pickerActive) return;
+    _pickerActive = true;
+    try {
+      final AppModel appModel =
+          ProviderScope.containerOf(context, listen: false).read(appProvider);
+      final String? path = await pickRealDirectoryPath(
+        context: context,
+        appModel: appModel,
+      );
+      if (path == null || !mounted) return;
+      _adoptPath(path);
+    } finally {
+      _pickerActive = false;
+    }
+  }
+
+  /// 收下一个候选路径：先定性，非漫画直接挡回并说明，绝不静默吞掉。
+  void _adoptPath(String path) {
+    final ImportCarrier carrier = _classify(path);
+    if (!carrier.isManga) {
+      final String ext = p.extension(path).toLowerCase();
+      HibikiToast.show(
+        msg: t.import_unsupported_file_format(ext: ext.isEmpty ? path : ext),
+      );
+      return;
+    }
+    setState(() {
+      _path = path;
+      _pathName = p.basename(path);
+      _carrier = carrier;
+      if (!_titleFromUser) {
+        _titleCtrl.text = _deriveTitle(path);
+      }
+    });
+  }
+
+  void _handleDialogDrop(List<String> paths, Offset _) {
+    if (importing) return;
+    // 拖进本框的东西只有一种可能有意义：漫画。取第一个能定性成漫画的路径。
+    for (final String path in paths) {
+      if (_classify(path).isManga) {
+        _adoptPath(path);
+        return;
+      }
+    }
+    if (paths.isNotEmpty) {
+      final String ext = p.extension(paths.first).toLowerCase();
+      HibikiToast.show(
+        msg: t.import_unsupported_file_format(
+          ext: ext.isEmpty ? paths.first : ext,
+        ),
+      );
+    }
+  }
+
+  // ── OCR ─────────────────────────────────────────────────────────────────
+
+  /// 打开 OCR 导入漫画向导：向导内选裸图片文件夹跑整卷 OCR 后无缝落库；成功
+  /// （返回 bookKey）则连同关闭本导入框并回传 true，让书架刷新。
+  Future<void> _openOcrWizard() async {
+    final String? bookKey = await MangaModule.openOcrImportWizard(
+      context: context,
+      db: widget.db,
+      remoteRunner: _mangaOcrRemoteRunner,
+      desktop: _ocrEntryDesktop,
+    );
+    if (bookKey != null && mounted) {
+      Navigator.pop(context, true);
+    }
+  }
+
+  // ── 导入 ────────────────────────────────────────────────────────────────
+
+  /// 同名书弹窗回调。是→加后缀，否/关闭→取消这本书。与书籍框逐字同语义。
+  Future<DuplicateTitleResolution> _onDuplicateTitle(
+    String proposedTitle,
+  ) async {
+    if (!mounted) return DuplicateTitleResolution.cancel;
+    final bool? keep = await showAppDialog<bool>(
+      context: context,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: Text(t.book_import_duplicate_title),
+        content: Text(t.book_import_duplicate_message(name: proposedTitle)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(t.book_import_duplicate_cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(t.book_import_duplicate_keep),
+          ),
+        ],
+      ),
+    );
+    return keep == true
+        ? DuplicateTitleResolution.addSuffix
+        : DuplicateTitleResolution.cancel;
+  }
+
+  void _reportCopyProgress(int done, int total) {
+    if (total <= 0) return;
+    reportProgress(
+      (done / total).clamp(0.0, 1.0),
+      t.import_step_copying_file(name: _pathName ?? ''),
+    );
+  }
+
+  Future<void> _doImport() async {
+    final String? path = _path;
+    final ImportCarrier? carrier = _carrier;
+    if (path == null || carrier == null) {
+      HibikiToast.show(msg: t.manga_import_missing_input);
+      return;
+    }
+    final String title = _titleCtrl.text.trim();
+    if (title.isEmpty) {
+      HibikiToast.show(msg: t.srt_import_missing_title);
+      return;
+    }
+
+    await runImport(
+      logTag: 'MangaImportDialog.import',
+      debugMessage: (Object e) => 'MangaImportDialog error: $e',
+      isCancelled: (Object e) => e is DuplicateImportCancelledException,
+      onCancelled: () {
+        if (mounted) {
+          HibikiToast.show(msg: t.book_import_duplicate_cancelled);
+          Navigator.pop(context, false);
+        }
+      },
+      action: () async {
+        reportProgress(0, '');
+        debugPrint('[hibiki-import] manga route: carrier=$carrier path=$path');
+        reportProgress(0.5, t.import_step_importing_epub);
+
+        // 载体在选中那一刻已定死，这里只照着分派——不再二次嗅探扩展名或读包。
+        switch (carrier) {
+          case ImportCarrier.mangaFolder:
+            await MangaModule.importImageFolder(
+              db: widget.db,
+              path: path,
+              title: title,
+              onDuplicateTitle: _onDuplicateTitle,
+              onProgress: _reportCopyProgress,
+            );
+          case ImportCarrier.mangaMokuro:
+            await MangaModule.importMokuro(
+              db: widget.db,
+              path: path,
+              title: title,
+              onDuplicateTitle: _onDuplicateTitle,
+              onProgress: _reportCopyProgress,
+            );
+          case ImportCarrier.mangaArchive:
+            await MangaModule.importArchive(
+              db: widget.db,
+              path: path,
+              title: title,
+              onDuplicateTitle: _onDuplicateTitle,
+              onProgress: _reportCopyProgress,
+            );
+          case ImportCarrier.pdf:
+          case ImportCarrier.epub:
+          case ImportCarrier.text:
+            // 不可达：[_adoptPath] / [initState] 只收下 isManga 的载体。
+            throw StateError(
+                'non-manga carrier in MangaImportDialog: $carrier');
+        }
+
+        reportProgress(1, t.import_step_done);
+        if (mounted) {
+          HibikiToast.show(msg: t.srt_import_success);
+          Navigator.pop(context, true);
+        }
+      },
+    );
+  }
+}

--- a/hibiki/lib/src/media/sources/manga_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/manga_hibiki_source.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki/media.dart';
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/models.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/utils.dart';
@@ -83,15 +85,42 @@ class MangaHibikiSource extends ReaderMediaSource {
     required WidgetRef ref,
     required AppModel appModel,
   }) {
-    // 导入按钮统一由 EPUB 源提供（同一个对话框通吃 epub/pdf/manga）；本源作为打开-漫画
-    // 的短暂当前源，页头动作复用同一按钮以防被设为当前源时缺动作。
+    // 漫画有自己的导入按钮与对话框（载体不同、可填字段就不同）；本源作为打开-漫画
+    // 的短暂当前源，页头动作给出漫画导入以防被设为当前源时缺动作。
     return <Widget>[
-      ReaderHibikiSource.instance.buildBookImportButton(
+      buildMangaImportButton(
         context: context,
         ref: ref,
         appModel: appModel,
       ),
     ];
+  }
+
+  /// 「导入漫画」按钮。与 [ReaderHibikiSource.buildBookImportButton] 并列而非复用：
+  /// 两者打开的是不同对话框，仅外观规格（尺寸/宽窗展开成图标+文字）保持一致。
+  Widget buildMangaImportButton({
+    required BuildContext context,
+    required WidgetRef ref,
+    required AppModel appModel,
+    HibikiFocusId? focusId,
+    String? label,
+  }) {
+    return HibikiIconButton(
+      tooltip: t.manga_import_action,
+      label: label,
+      icon: Icons.library_add_outlined,
+      focusId: focusId,
+      onTap: () async {
+        final bool? imported = await showAppDialog<bool>(
+          context: context,
+          builder: (_) => MangaImportDialog(db: appModel.database),
+        );
+        if (imported == true) {
+          ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
+          ref.invalidate(srtBooksProvider);
+        }
+      },
+    );
   }
 
   @override

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -20,6 +20,7 @@ import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
 import 'package:hibiki/src/media/display_title.dart';
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_download_queue.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
@@ -641,17 +642,29 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       actions: <Widget>[
         // 宽窗（非 compact）时动作展开成「图标+文字」药丸（与视频 tab 页头一致，
         // 用户 mockup：导入书籍 / 来源 / 合集 / 阅读统计带文字外显）；窄窗回落纯图标。
-        mediaSource.buildBookImportButton(
-          context: context,
-          ref: ref,
-          appModel: appModel,
-          focusId: kShelfImportFocusId,
-          label: _mangaOnly ? t.manga_import_action : t.srt_import,
-        ),
+        // 漫画库和书架是同一页面的两种壳，但导入的是两种载体，故按钮指向两个不同
+        // 的对话框——不再是「同一个框换个 label」。
+        if (_mangaOnly)
+          MangaHibikiSource.instance.buildMangaImportButton(
+            context: context,
+            ref: ref,
+            appModel: appModel,
+            focusId: kShelfImportFocusId,
+            label: t.manga_import_action,
+          )
+        else
+          mediaSource.buildBookImportButton(
+            context: context,
+            ref: ref,
+            appModel: appModel,
+             focusId: kShelfImportFocusId,
+             label: t.srt_import,
+           ),
         // 「管理来源」在库页导航壳里已是一等视图（[MediaSourcesPage]），页头再放一个
-        // 按钮就是同一件事的两个入口。只有本页被独立使用（无导航条）时才保留按钮。
-        if (_pageWidget.navigation == null)
-          _headerAction(
+        // 按钮就是同一件事的两个入口。书架独立使用（无导航条）时才保留书籍来源按钮；
+        // 漫画入口由专属导入对话框负责，不复用书籍来源管理。
+        if (_pageWidget.navigation == null && !_mangaOnly)
+           _headerAction(
             tooltip: t.media_source_manage_title,
             icon: Icons.folder_copy_outlined,
             onTap: _openManageSources,
@@ -1858,13 +1871,16 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             icon: const Icon(Icons.library_add_outlined, size: 18),
             label: Text(_mangaOnly ? t.manga_import_action : t.srt_import),
             onPressed: () async {
+              // 空态按钮与页头按钮指向同一个对话框：漫画库开漫画框，书架开书籍框。
               final bool? imported = await showAppDialog<bool>(
                 context: context,
-                builder: (_) => BookImportDialog(
-                  repo: SrtBookRepository(appModel.database),
-                  audiobookRepo: AudiobookRepository(appModel.database),
-                  db: appModel.database,
-                ),
+                builder: (_) => _mangaOnly
+                    ? MangaImportDialog(db: appModel.database)
+                    : BookImportDialog(
+                        repo: SrtBookRepository(appModel.database),
+                        audiobookRepo: AudiobookRepository(appModel.database),
+                        db: appModel.database,
+                      ),
               );
               if (imported == true) {
                 ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -657,14 +657,14 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             context: context,
             ref: ref,
             appModel: appModel,
-             focusId: kShelfImportFocusId,
-             label: t.srt_import,
-           ),
+            focusId: kShelfImportFocusId,
+            label: t.srt_import,
+          ),
         // 「管理来源」在库页导航壳里已是一等视图（[MediaSourcesPage]），页头再放一个
         // 按钮就是同一件事的两个入口。书架独立使用（无导航条）时才保留书籍来源按钮；
         // 漫画入口由专属导入对话框负责，不复用书籍来源管理。
         if (_pageWidget.navigation == null && !_mangaOnly)
-           _headerAction(
+          _headerAction(
             tooltip: t.media_source_manage_title,
             icon: Icons.folder_copy_outlined,
             onTap: _openManageSources,

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -1012,14 +1012,10 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
           audioPaths: files.audios,
         );
       case DropIntent.importNewManga:
-        // 漫画（.mokuro / .cbz / 页图目录）走与书同一个导入对话框——它的导入分派
-        // 早已认得这几种载体（mokuro → MangaImporter、cbz/图片型 zip →
-        // MangaArchiveImporter、目录 → importFromImageFolder），拖入只负责把路径
-        // 预填进去，不重复一套导入逻辑。
-        _openBookImportPrefilled(
-          epubPath: files.mangas.first,
-          subtitlePath: null,
-        );
+        // 漫画（.mokuro / .cbz / 页图目录 / 图片型 zip）走漫画自己的导入对话框。
+        // 决策层本来就把漫画和书分成了两个 intent，此前两个 intent 却落到同一个
+        // 对话框；现在落点跟着 intent 走，载体身份不再在半路丢失。
+        _openMangaImportPrefilled(mangaPath: files.mangas.first);
       case DropIntent.unsupportedMangaArchive:
         debugPrint(
           '[hibiki-drop] [reader-shelf] intent=unsupportedMangaArchive',
@@ -1080,6 +1076,23 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
         initialEpubPath: epubPath,
         initialSubtitlePath: subtitlePath,
         initialAudioPaths: audioPaths.isEmpty ? null : audioPaths,
+      ),
+    );
+    if (imported == true && mounted) {
+      _refreshSrtBooks();
+      ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
+    }
+  }
+
+  /// 拖入漫画 → 打开 [MangaImportDialog]，预填漫画路径（目录 / .cbz / .mokuro /
+  /// 图片型 zip）。刷新范式与 [_openBookImportPrefilled] 一致：漫画与书共用
+  /// `EpubBooks` 表和同一块书架，故失效的 provider 也相同。
+  Future<void> _openMangaImportPrefilled({required String mangaPath}) async {
+    final bool? imported = await showAppDialog<bool>(
+      context: context,
+      builder: (_) => MangaImportDialog(
+        db: appModel.database,
+        initialPath: mangaPath,
       ),
     );
     if (imported == true && mounted) {

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+997
+version: 1.3.1+998
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/drag_drop/import_dialog_drop_target_guard_test.dart
+++ b/hibiki/test/media/drag_drop/import_dialog_drop_target_guard_test.dart
@@ -8,15 +8,18 @@ import 'package:hibiki/src/media/audiobook/book_import_dialog.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
-/// 守卫 TODO-790-B：三个导入对话框（book/audiobook/video）的 build 必须把根
+/// 守卫 TODO-790-B：每个导入对话框（book/manga/audiobook/video）的 build 必须把根
 /// frame 包进 [HibikiFileDropTarget]，否则拖文件进打开的模态对话框会被页级
 /// drop target 因 `isCurrent` 守卫静默忽略。
 ///
-/// 源码扫描守卫（仿 drag_drop_platform_guard_test.dart）：断言三文件各引用
-/// `HibikiFileDropTarget` 且各自定义 `_handleDialogDrop`。
+/// 源码扫描守卫（仿 drag_drop_platform_guard_test.dart）：断言各文件都引用
+/// `HibikiFileDropTarget` 且各自定义 `_handleDialogDrop`。漫画从书籍框分家后是
+/// 独立对话框，同样是模态落点，故一并纳入守卫——否则「漫画框拖不进东西」会成为
+/// 一个没人看守的回归。
 void main() {
   const Map<String, String> dialogs = <String, String>{
     'book': 'lib/src/media/audiobook/book_import_dialog.dart',
+    'manga': 'lib/src/media/manga/manga_import_dialog.dart',
     'audiobook': 'lib/src/media/audiobook/audiobook_import_dialog.dart',
     'video': 'lib/src/media/video/video_import_dialog.dart',
   };

--- a/hibiki/test/media/drag_drop/manga_drop_test.dart
+++ b/hibiki/test/media/drag_drop/manga_drop_test.dart
@@ -105,9 +105,9 @@ void main() {
           return false;
         },
       );
-      // epub 刻意不探：它在 books 分支就走 BookImportDialog，对话框的分派本来就
-      // 会真读包并把图片型 EPUB 导成漫画，行为已正确——为每次拖 EPUB 白开一次包
-      // 换不来可见改进。
+      // epub 刻意不探：它在 books 分支就走 BookImportDialog，而对话框收下路径时会
+      // 用 classifyImportCarrier 真读包，图片型 EPUB 在那里被认出并（经用户确认后）
+      // 转交漫画导入——识别没丢。为每次拖 EPUB 在分类层白开一次包换不来可见改进。
       expect(probed, <String>['/a/x.zip']);
     });
 

--- a/hibiki/test/media/import/book_import_carrier_memo_guard_test.dart
+++ b/hibiki/test/media/import/book_import_carrier_memo_guard_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫：书籍导入对话框问载体身份必须**走记忆**，不得裸调分类函数。
+///
+/// `.zip` / `.epub` 的定性要 `isImageArchive` 真开包（全量同步解压），是这个对话框里
+/// 唯一一处重量级同步 IO。而同一个路径在一次导入里会被问三次——选中时的漫画闸门、
+/// `_doImport` 的兜底闸门、`_importEpubOnly` 的分派。裸调 `classifyImportCarrier` 就是
+/// 解压三次；有声书对齐路径（EPUB+字幕）更亏：它根本不进 `_importEpubOnly`，前面那
+/// 几次开包纯属白开，而分家之前这条路一次都不开包。
+///
+/// 记忆层的行为正确性（同路径只算一次、换路径必须重算、不改判定结果）在
+/// `import_carrier_test.dart` 的 `ImportCarrierResolver` 组里用计数假回调验；这里只钉
+/// 接线——防止有人日后在对话框里再插一句裸调，把重复解压悄悄放回来。
+void main() {
+  late String src;
+
+  setUpAll(() {
+    final File f = File('lib/src/media/audiobook/book_import_dialog.dart');
+    expect(f.existsSync(), isTrue, reason: '守卫目标文件应存在');
+    src = f.readAsStringSync();
+  });
+
+  test('对话框不得裸调 classifyImportCarrier（必须经 ImportCarrierResolver）', () {
+    expect(src.contains('classifyImportCarrier('), isFalse,
+        reason: '裸调会绕过记忆 → 同一路径重复全量解压；改用 _classifyCarrier');
+  });
+
+  test('对话框持有且只持有一个 ImportCarrierResolver', () {
+    expect('ImportCarrierResolver('.allMatches(src).length, 1,
+        reason: '多个 resolver = 各自一份记忆 = 还是会重复开包');
+  });
+
+  test('_classifyCarrier 是唯一入口且委托给 resolver', () {
+    expect(src.contains('_carrierResolver.resolve('), isTrue,
+        reason: '_classifyCarrier 必须委托给 resolver，而不是自己再拼一次判据');
+    // 真实注入的判据不能被换成简化桩，否则词典包一票否决就失效了
+    // （那条判据活在 MangaArchiveImporter.looksLikeImageArchive 里）。
+    expect(src.contains('isImageArchive: MangaModule.isImageArchive'), isTrue,
+        reason: '必须注入真判据；换成按扩展名的桩会让 Yomitan 词典 zip 被当漫画导入');
+  });
+}

--- a/hibiki/test/media/import/book_import_carrier_memo_guard_test.dart
+++ b/hibiki/test/media/import/book_import_carrier_memo_guard_test.dart
@@ -37,7 +37,11 @@ void main() {
         reason: '_classifyCarrier 必须委托给 resolver，而不是自己再拼一次判据');
     // 真实注入的判据不能被换成简化桩，否则词典包一票否决就失效了
     // （那条判据活在 MangaArchiveImporter.looksLikeImageArchive 里）。
-    expect(src.contains('isImageArchive: MangaModule.isImageArchive'), isTrue,
-        reason: '必须注入真判据；换成按扩展名的桩会让 Yomitan 词典 zip 被当漫画导入');
+    expect(
+      src.contains('widget.imageArchiveProbe ?? MangaModule.isImageArchive'),
+      isTrue,
+      reason: '生产 fallback 必须是真判据；换成按扩展名的桩会让 '
+          'Yomitan 词典 zip 被当漫画导入',
+    );
   });
 }

--- a/hibiki/test/media/import/book_import_dialog_real_carrier_memo_test.dart
+++ b/hibiki/test/media/import/book_import_dialog_real_carrier_memo_test.dart
@@ -1,0 +1,307 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/epub/epub_storage.dart';
+import 'package:hibiki/src/media/audiobook/book_import_dialog.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+Uint8List _realEpubBytes(String title, {bool pureImage = false}) {
+  final Archive archive = Archive();
+
+  void addText(String name, String content) {
+    final List<int> bytes = utf8.encode(content);
+    archive.addFile(ArchiveFile(name, bytes.length, bytes));
+  }
+
+  addText('mimetype', 'application/epub+zip');
+  addText('META-INF/container.xml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0"
+    xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf"
+        media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+''');
+  addText('OEBPS/content.opf', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0"
+    unique-identifier="book-id">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:identifier id="book-id">todo-2189-$title</dc:identifier>
+    <dc:title>$title</dc:title>
+    <dc:language>ja</dc:language>
+  </metadata>
+  <manifest>
+    <item id="chapter" href="chapter.xhtml"
+        media-type="application/xhtml+xml"/>
+    <item id="page" href="page.png" media-type="image/png"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter"/>
+  </spine>
+</package>
+''');
+  addText('OEBPS/chapter.xhtml', '''
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter</title></head>
+  <body>
+    ${pureImage ? '' : '<p>これは真の EPUB と字幕を通る回帰テストです。</p>'}
+    <img src="page.png" alt="${pureImage ? '' : 'not a pure image manga'}"/>
+  </body>
+</html>
+''');
+  final List<int> png = base64Decode(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk'
+    '+A8AAQUBAScY42YAAAAASUVORK5CYII=',
+  );
+  archive.addFile(ArchiveFile('OEBPS/page.png', png.length, png));
+
+  return Uint8List.fromList(ZipEncoder().encode(archive)!);
+}
+
+Widget _host(BookImportDialog dialog) {
+  return TranslationProvider(
+    child: MaterialApp(
+      home: Scaffold(body: Center(child: dialog)),
+    ),
+  );
+}
+
+Future<void> _pumpUntil(
+  WidgetTester tester, {
+  required Future<bool> Function() condition,
+}) async {
+  for (int attempt = 0; attempt < 200; attempt += 1) {
+    final bool done = await tester.runAsync<bool>(() async {
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          return condition();
+        }) ??
+        false;
+    await tester.pump();
+    if (done) return;
+  }
+  fail('Timed out waiting for the real import path to finish');
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+  test('resolver reuses one real path and recomputes for another real path',
+      () {
+    final Directory root =
+        Directory.systemTemp.createTempSync('todo_2189_real_path_cache_');
+    addTearDown(() {
+      if (root.existsSync()) root.deleteSync(recursive: true);
+    });
+    final File first = File(p.join(root.path, 'first.epub'))
+      ..writeAsBytesSync(_realEpubBytes('TODO 2189 first'));
+    final File second = File(p.join(root.path, 'second.epub'))
+      ..writeAsBytesSync(_realEpubBytes('TODO 2189 second'));
+    final List<String> probedPaths = <String>[];
+    final ImportCarrierResolver resolver = ImportCarrierResolver(
+      isDirectory: (String path) => Directory(path).existsSync(),
+      isImageArchive: (String path) {
+        probedPaths.add(path);
+        return MangaModule.isImageArchive(path);
+      },
+    );
+
+    expect(resolver.resolve(first.path), ImportCarrier.epub);
+    expect(resolver.resolve(first.path), ImportCarrier.epub);
+    expect(resolver.resolve(second.path), ImportCarrier.epub);
+
+    expect(probedPaths, <String>[first.path, second.path],
+        reason: '同一路径只真开包一次，换真实路径必须重新调用真 MangaModule 判据');
+  });
+
+  testWidgets(
+      'real EPUB + matching SRT imports through the real dialog with one '
+      'image-archive probe', (WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1000, 1000);
+    addTearDown(tester.view.reset);
+
+    final Directory root =
+        Directory.systemTemp.createTempSync('todo_2189_real_epub_srt_');
+    final File epub = File(p.join(root.path, 'aligned.epub'))
+      ..writeAsBytesSync(_realEpubBytes('TODO 2189 aligned'));
+    final File srt = File(p.join(root.path, 'aligned.srt'))
+      ..writeAsStringSync('''
+1
+00:00:00,000 --> 00:00:03,000
+これは真の EPUB と字幕を通る回帰テストです。
+''');
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    EpubStorage.debugBaseDirectoryOverride = root.path;
+    AudiobookStorage.documentsRootResolver = () async => root;
+    addTearDown(() async {
+      EpubStorage.debugBaseDirectoryOverride = null;
+      AudiobookStorage.documentsRootResolver = null;
+      await db.close();
+      if (root.existsSync()) root.deleteSync(recursive: true);
+    });
+
+    final List<String> probedPaths = <String>[];
+    bool countThenRunRealProbe(String path) {
+      probedPaths.add(path);
+      return MangaModule.isImageArchive(path);
+    }
+
+    await tester.pumpWidget(
+      _host(
+        BookImportDialog(
+          repo: SrtBookRepository(db),
+          audiobookRepo: AudiobookRepository(db),
+          db: db,
+          initialEpubPath: epub.path,
+          initialSubtitlePath: srt.path,
+          imageArchiveProbe: countThenRunRealProbe,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text(t.dialog_import));
+    await tester.pump();
+    await _pumpUntil(
+      tester,
+      condition: () async {
+        final List<EpubBookRow> books = await db.getAllEpubBooks();
+        if (books.length != 1) return false;
+        return AudiobookRepository(db)
+            .findByBookKey(books.single.bookKey)
+            .then((Audiobook? value) => value != null);
+      },
+    );
+
+    expect(probedPaths, <String>[epub.path], reason: '同一路径的漫画误投闸门只能执行一次真整包判定');
+    final List<EpubBookRow> books = await db.getAllEpubBooks();
+    expect(books, hasLength(1), reason: '必须由真 EpubImporter 完成导入');
+    final Audiobook? audiobook =
+        await AudiobookRepository(db).findByBookKey(books.single.bookKey);
+    expect(audiobook, isNotNull,
+        reason: 'EPUB+SRT 必须走 _importEpubWithAlignment 并落有声书对齐记录');
+    final SrtBook? paired =
+        await SrtBookRepository(db).findByBookKey(books.single.bookKey);
+    expect(paired, isNotNull, reason: '匹配字幕必须落配对 SRT 书记录');
+  });
+
+  testWidgets('real EPUB-only import reuses the same probe at final dispatch',
+      (WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1000, 1000);
+    addTearDown(tester.view.reset);
+
+    final Directory root =
+        Directory.systemTemp.createTempSync('todo_2189_real_epub_only_');
+    final File epub = File(p.join(root.path, 'plain.epub'))
+      ..writeAsBytesSync(_realEpubBytes('TODO 2189 plain'));
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    EpubStorage.debugBaseDirectoryOverride = root.path;
+    addTearDown(() async {
+      EpubStorage.debugBaseDirectoryOverride = null;
+      await db.close();
+      if (root.existsSync()) root.deleteSync(recursive: true);
+    });
+
+    final List<String> probedPaths = <String>[];
+    bool countThenRunRealProbe(String path) {
+      probedPaths.add(path);
+      return MangaModule.isImageArchive(path);
+    }
+
+    await tester.pumpWidget(
+      _host(
+        BookImportDialog(
+          repo: SrtBookRepository(db),
+          audiobookRepo: AudiobookRepository(db),
+          db: db,
+          initialEpubPath: epub.path,
+          imageArchiveProbe: countThenRunRealProbe,
+        ),
+      ),
+    );
+    await tester.pump();
+
+    await tester.tap(find.text(t.dialog_import));
+    await tester.pump();
+    await _pumpUntil(
+      tester,
+      condition: () async => (await db.getAllEpubBooks()).length == 1,
+    );
+
+    expect(probedPaths, <String>[epub.path],
+        reason: '闸门与 _importEpubOnly 最终分派必须共用同一真实判定结果');
+    expect(await db.getAllEpubBooks(), hasLength(1));
+  });
+
+  testWidgets(
+      'dedicated manga dialog has no carrier confirmation while book '
+      'misroute shows exactly one', (WidgetTester tester) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(1000, 1000);
+    addTearDown(tester.view.reset);
+    final Directory root =
+        Directory.systemTemp.createTempSync('todo_2189_manga_route_');
+    final File manga = File(p.join(root.path, 'pages.epub'))
+      ..writeAsBytesSync(
+        _realEpubBytes('TODO 2189 manga', pureImage: true),
+      );
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(() async {
+      await db.close();
+      if (root.existsSync()) root.deleteSync(recursive: true);
+    });
+
+    await tester.pumpWidget(
+      TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: MangaImportDialog(db: db, initialPath: manga.path),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.text(t.manga_import_detected_title), findsNothing,
+        reason: '漫画专用入口已知道载体，不得再弹书籍误投确认');
+    expect(find.text(t.dialog_import), findsOneWidget);
+
+    await tester.pumpWidget(
+      _host(
+        BookImportDialog(
+          repo: SrtBookRepository(db),
+          audiobookRepo: AudiobookRepository(db),
+          db: db,
+          initialEpubPath: manga.path,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.tap(find.text(t.dialog_import));
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.manga_import_detected_title), findsOneWidget,
+        reason: '书籍入口误投漫画必须保留一次明确安全确认');
+    expect(find.text(t.manga_import_detected_confirm), findsOneWidget);
+  });
+}

--- a/hibiki/test/media/import/import_carrier_dictionary_zip_test.dart
+++ b/hibiki/test/media/import/import_carrier_dictionary_zip_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
+import 'package:path/path.dart' as p;
+
+/// 反向守卫：**词典 zip 不许在导入入口层被判成漫画**。
+///
+/// 载体分家把「这是什么」的判定从 `_importEpubOnly` 末尾提到了
+/// `classifyImportCarrier`，两个对话框（书籍 / 漫画）都改从这里问。`4f9644db4` 的
+/// 「词典包一票否决」判据本体（`index.json` + `*_bank_*.json` 同时在场 ⇒ 不是图片
+/// 包，优先于「有图片就算漫画」）留在 `MangaArchiveImporter.looksLikeImageArchive`，
+/// 分家没有改动它——但**没有任何测试钉住新入口层真的把这个判据接上了**。
+///
+/// 已有的 `test/media/drag_drop/dictionary_zip_not_manga_test.dart` 走的是拖放分类
+/// 层（`classifyDroppedFiles`），`test/media/import/import_carrier_test.dart` 全程
+/// 用假回调（`imageArchives.contains`）。两者都不覆盖「对话框入口 →
+/// classifyImportCarrier → 真判据」这条新链路：只要有人把
+/// `book_import_dialog.dart` / `manga_import_dialog.dart` 注入的实参从
+/// `MangaModule.isImageArchive` 换成按扩展名的简化桩，现有套件**一条都不会红**，
+/// 而一本自带插图的 Yomitan 词典包就会被静默导成只有插图的垃圾「漫画」。
+///
+/// 故这里用**真 zip + 真判据**（不打桩）跑新入口层，把那条链钉死。
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('hibiki_carrier_dict_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  /// 在 [tempDir] 下写一个真 zip，[entries] 是 `包内路径 -> 内容字节`。
+  String writeZip(String name, Map<String, List<int>> entries) {
+    final Archive archive = Archive();
+    entries.forEach((String path, List<int> bytes) {
+      archive.addFile(ArchiveFile(path, bytes.length, bytes));
+    });
+    final List<int>? encoded = ZipEncoder().encode(archive);
+    expect(encoded, isNotNull, reason: 'zip 编码失败，测试前提不成立');
+    final String path = p.join(tempDir.path, name);
+    File(path).writeAsBytesSync(encoded!);
+    return path;
+  }
+
+  /// 最小 PNG（1x1，真字节）——词典自带插图就长这样。
+  List<int> onePixelPng() => <int>[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+        0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+        0x42, 0x60, 0x82,
+      ];
+
+  List<int> utf8Bytes(String text) => utf8.encode(text);
+
+  /// 用**生产实参**跑分类：`isImageArchive` 就是两个对话框注入的那一个。
+  ImportCarrier classifyWithRealPredicate(String path) => classifyImportCarrier(
+        path,
+        isDirectory: (String p) => Directory(p).existsSync(),
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+  test('自带插图的 Yomitan 词典 zip 不得被判成漫画载体', () {
+    final String dictZip = writeZip('yomitan_dict.zip', <String, List<int>>{
+      'index.json': utf8Bytes(
+        '{"title":"Test Dict","format":3,"revision":"1"}',
+      ),
+      'term_bank_1.json': utf8Bytes(
+        '[["猫","ねこ","n","",0,[{"type":"structured-content",'
+        '"content":{"tag":"img","path":"img/neko.png"}}],1,""]]',
+      ),
+      'tag_bank_1.json': utf8Bytes('[["n","partOfSpeech",0,"noun",0]]'),
+      'img/neko.png': onePixelPng(),
+    });
+
+    final ImportCarrier carrier = classifyWithRealPredicate(dictZip);
+
+    expect(carrier.isManga, isFalse,
+        reason: '词典包一票否决必须优先于「有图片就算漫画」：判成漫画 = 词典没被导入，'
+            '还平白多出一本只有插图的垃圾漫画（4f9644db4 回归）');
+    expect(carrier, ImportCarrier.epub,
+        reason: '.zip 非图片包时落 epub 分支（与分家前 _importEpubOnly 的兜底一致）');
+  });
+
+  test('kanji_bank 形态的词典包同样被否决', () {
+    final String dictZip = writeZip('kanji_dict.zip', <String, List<int>>{
+      'index.json': utf8Bytes('{"title":"Kanji Dict","format":3}'),
+      'kanji_bank_1.json': utf8Bytes('[["猫","","","",[],[]]]'),
+      'img/stroke.png': onePixelPng(),
+    });
+
+    expect(classifyWithRealPredicate(dictZip).isManga, isFalse,
+        reason: 'kanji_bank_ 也在 Yomitan 前缀集里，不能只认 term_bank_');
+  });
+
+  test('反向用例：真页图 zip 仍判为漫画（否决判据不得误伤漫画）', () {
+    final String mangaZip = writeZip('scan.zip', <String, List<int>>{
+      '001.png': onePixelPng(),
+      '002.png': onePixelPng(),
+      '003.png': onePixelPng(),
+    });
+
+    expect(classifyWithRealPredicate(mangaZip), ImportCarrier.mangaArchive,
+        reason: '没有 index.json + bank 的纯页图包就是漫画——否决判据必须精确，'
+            '否则「拖图包 zip 到书架仍要能导成漫画」这条红线会被误伤');
+  });
+
+  test('只有 index.json 而没有 bank 的 zip 不算词典（单有清单不足以否决）', () {
+    final String zip = writeZip('has_index.zip', <String, List<int>>{
+      'index.json': utf8Bytes('{"name":"whatever"}'),
+      '001.png': onePixelPng(),
+      '002.png': onePixelPng(),
+    });
+
+    expect(classifyWithRealPredicate(zip), ImportCarrier.mangaArchive,
+        reason: '打包工具随手生成的清单也叫 index.json，bank 前缀才是 Yomitan 指纹；'
+            '只认 index.json 会把普通图包误判成词典而拒绝导入');
+  });
+}

--- a/hibiki/test/media/import/import_carrier_test.dart
+++ b/hibiki/test/media/import/import_carrier_test.dart
@@ -1,0 +1,169 @@
+/// 载体分类（漫画/书籍导入分家的判据核心）。
+///
+/// [classifyImportCarrier] 是从 `BookImportDialog._importEpubOnly` 函数体里提出来的
+/// ——那里原本有 4 个按顺序早退的 if（目录 / .pdf / .mokuro / .cbz|图片型压缩包），
+/// 埋在导入执行阶段、必须真跑一次导入才能验证。提成纯函数后可以在这里穷举，包括
+/// 那几条**顺序敏感**的分支：分支顺序一旦被人「整理」乱，PDF 会被当文本转成乱码
+/// EPUB、.mokuro 的 JSON 会被当纯文本吞掉、带点的目录名会取出假扩展名。
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
+
+/// 默认判据：什么都不是目录、什么都不是图片压缩包。
+ImportCarrier classify(
+  String path, {
+  Set<String> directories = const <String>{},
+  Set<String> imageArchives = const <String>{},
+}) =>
+    classifyImportCarrier(
+      path,
+      isDirectory: directories.contains,
+      isImageArchive: imageArchives.contains,
+    );
+
+void main() {
+  group('漫画载体', () {
+    test('目录 → mangaFolder', () {
+      expect(
+        classify('/m/vol1', directories: <String>{'/m/vol1'}),
+        ImportCarrier.mangaFolder,
+      );
+    });
+
+    test('目录判定必须先于扩展名判定：带点的目录名不会被当成文件', () {
+      // `p.extension('/m/Vol.1')` == '.1'，落到任何扩展名分支都会误判。
+      expect(
+        classify('/m/Vol.1', directories: <String>{'/m/Vol.1'}),
+        ImportCarrier.mangaFolder,
+      );
+      // 更狠的一例：目录名以真实文件扩展名结尾。
+      expect(
+        classify('/m/scan.zip', directories: <String>{'/m/scan.zip'}),
+        ImportCarrier.mangaFolder,
+      );
+    });
+
+    test('.mokuro → mangaMokuro（不得被文本分支吞掉）', () {
+      expect(classify('/m/vol1.mokuro'), ImportCarrier.mangaMokuro);
+    });
+
+    test('.cbz → mangaArchive，无需读包', () {
+      expect(classify('/m/vol1.cbz'), ImportCarrier.mangaArchive);
+    });
+
+    test('图片型 .zip → mangaArchive', () {
+      expect(
+        classify('/m/vol1.zip', imageArchives: <String>{'/m/vol1.zip'}),
+        ImportCarrier.mangaArchive,
+      );
+    });
+
+    test('图片型 .epub（扫描版漫画）→ mangaArchive', () {
+      expect(
+        classify('/m/scan.epub', imageArchives: <String>{'/m/scan.epub'}),
+        ImportCarrier.mangaArchive,
+      );
+    });
+
+    test('isManga 覆盖且仅覆盖三种漫画载体', () {
+      expect(ImportCarrier.mangaFolder.isManga, isTrue);
+      expect(ImportCarrier.mangaMokuro.isManga, isTrue);
+      expect(ImportCarrier.mangaArchive.isManga, isTrue);
+      expect(ImportCarrier.pdf.isManga, isFalse);
+      expect(ImportCarrier.epub.isManga, isFalse);
+      expect(ImportCarrier.text.isManga, isFalse);
+    });
+  });
+
+  group('书籍载体', () {
+    test('.pdf → pdf（必须先于文本分支，否则二进制被转成乱码 EPUB）', () {
+      expect(classify('/b/doc.pdf'), ImportCarrier.pdf);
+    });
+
+    test('普通 .epub → epub', () {
+      expect(classify('/b/novel.epub'), ImportCarrier.epub);
+    });
+
+    test('非图片型 .zip → epub 分支（维持既有兜底语义）', () {
+      expect(classify('/b/dict.zip'), ImportCarrier.epub);
+    });
+
+    test('.txt / .md / .html → text', () {
+      expect(classify('/b/a.txt'), ImportCarrier.text);
+      expect(classify('/b/a.md'), ImportCarrier.text);
+      expect(classify('/b/a.html'), ImportCarrier.text);
+    });
+
+    test('无扩展名文件 → text（非 epub/zip 一律尝试文本转换）', () {
+      expect(classify('/b/README'), ImportCarrier.text);
+    });
+
+    test('不认识的扩展名 → text', () {
+      expect(classify('/b/a.weirdext'), ImportCarrier.text);
+    });
+  });
+
+  group('读包判据只在真正二义时才被调用', () {
+    test('.cbz / .mokuro / .pdf / .txt 都不触发读包', () {
+      final List<String> probed = <String>[];
+      for (final String path in <String>[
+        '/x/a.cbz',
+        '/x/a.mokuro',
+        '/x/a.pdf',
+        '/x/a.txt',
+      ]) {
+        classifyImportCarrier(
+          path,
+          isDirectory: (_) => false,
+          isImageArchive: (String pth) {
+            probed.add(pth);
+            return false;
+          },
+        );
+      }
+      expect(probed, isEmpty, reason: '扩展名已能定性时不得白开一次包');
+    });
+
+    test('目录不触发读包', () {
+      final List<String> probed = <String>[];
+      classifyImportCarrier(
+        '/x/vol.zip',
+        isDirectory: (_) => true,
+        isImageArchive: (String pth) {
+          probed.add(pth);
+          return false;
+        },
+      );
+      expect(probed, isEmpty, reason: '目录在读包判据之前就已早退');
+    });
+
+    test('.zip / .epub 才触发读包', () {
+      final List<String> probed = <String>[];
+      for (final String path in <String>['/x/a.zip', '/x/a.epub']) {
+        classifyImportCarrier(
+          path,
+          isDirectory: (_) => false,
+          isImageArchive: (String pth) {
+            probed.add(pth);
+            return false;
+          },
+        );
+      }
+      expect(probed, <String>['/x/a.zip', '/x/a.epub']);
+    });
+  });
+
+  group('大小写与路径分隔符', () {
+    test('扩展名大小写不敏感', () {
+      expect(classify('/m/VOL1.CBZ'), ImportCarrier.mangaArchive);
+      expect(classify('/m/VOL1.MOKURO'), ImportCarrier.mangaMokuro);
+      expect(classify('/b/DOC.PDF'), ImportCarrier.pdf);
+    });
+
+    test('Windows 反斜杠路径同样定性', () {
+      expect(classify(r'C:\manga\vol1.cbz'), ImportCarrier.mangaArchive);
+      expect(classify(r'C:\books\novel.epub'), ImportCarrier.epub);
+    });
+  });
+}

--- a/hibiki/test/media/import/import_carrier_test.dart
+++ b/hibiki/test/media/import/import_carrier_test.dart
@@ -166,4 +166,72 @@ void main() {
       expect(classify(r'C:\books\novel.epub'), ImportCarrier.epub);
     });
   });
+
+  group('ImportCarrierResolver 按路径记忆（不重复开包）', () {
+    /// 造一个会数「开了几次包」的 resolver。`isImageArchive` 就是真实现里那次
+    /// 全量同步解压的位置，数它 = 数解压次数。
+    ({ImportCarrierResolver resolver, List<String> probes}) makeResolver({
+      Set<String> imageArchives = const <String>{},
+    }) {
+      final List<String> probes = <String>[];
+      return (
+        resolver: ImportCarrierResolver(
+          isDirectory: (String _) => false,
+          isImageArchive: (String path) {
+            probes.add(path);
+            return imageArchives.contains(path);
+          },
+        ),
+        probes: probes,
+      );
+    }
+
+    test('同一个 .epub 问三次只开一次包（书籍导入的真实提问序列）', () {
+      // 这三次提问对应 BookImportDialog 里真实存在的三处：选中时的漫画闸门、
+      // _doImport 的兜底闸门、_importEpubOnly 的分派。修复前每次都整包解压。
+      final r = makeResolver();
+      for (int i = 0; i < 3; i++) {
+        expect(r.resolver.resolve('/b/novel.epub'), ImportCarrier.epub);
+      }
+      expect(r.probes.length, 1, reason: '载体身份是路径的函数，问三次不该解压三次');
+    });
+
+    test('有声书对齐路径：两次闸门也只开一次包', () {
+      // EPUB+字幕 走 _importEpubWithAlignment，根本不进 _importEpubOnly，
+      // 所以它只被问两次——但分家前它一次都不开包，重复开包在这条路上纯属白开。
+      final r = makeResolver();
+      r.resolver.resolve('/b/novel.epub');
+      r.resolver.resolve('/b/novel.epub');
+      expect(r.probes.length, 1);
+    });
+
+    test('换路径必须重新定性（不得把上一个文件的判定张冠李戴）', () {
+      final r = makeResolver(imageArchives: <String>{'/m/scan.zip'});
+      expect(r.resolver.resolve('/b/novel.epub'), ImportCarrier.epub);
+      expect(r.resolver.resolve('/m/scan.zip'), ImportCarrier.mangaArchive);
+      expect(r.resolver.resolve('/b/novel.epub'), ImportCarrier.epub);
+      expect(
+          r.probes, <String>['/b/novel.epub', '/m/scan.zip', '/b/novel.epub'],
+          reason: '换路径就得重算，记忆只对「同一个路径连续问」生效');
+    });
+
+    test('invalidate() 后重新开包（文件可能在对话框开着时被换掉）', () {
+      final r = makeResolver();
+      r.resolver.resolve('/b/novel.epub');
+      r.resolver.invalidate();
+      r.resolver.resolve('/b/novel.epub');
+      expect(r.probes.length, 2);
+    });
+
+    test('记忆不改变判定结果本身（词典包一票否决照常）', () {
+      // /d/dict.zip 不在 imageArchives 里 = 判据说它不是图片包（真实现里正是
+      // 词典包一票否决给出的答案）。记忆层不得把它变成漫画。
+      final r = makeResolver(imageArchives: <String>{'/m/scan.zip'});
+      for (int i = 0; i < 3; i++) {
+        expect(r.resolver.resolve('/d/dict.zip'), ImportCarrier.epub,
+            reason: '缓存只省重复提问，绝不改答案');
+      }
+      expect(r.probes.length, 1);
+    });
+  });
 }

--- a/hibiki/test/media/manga/manga_import_dialog_ocr_entry_test.dart
+++ b/hibiki/test/media/manga/manga_import_dialog_ocr_entry_test.dart
@@ -1,4 +1,10 @@
-/// 漫画 P3：导入书对话框「OCR 导入漫画」入口 gating。
+/// 漫画 P3：漫画导入对话框「OCR 导入漫画」入口 gating。
+///
+/// ## 换宿主（漫画/书籍导入分家）
+///
+/// 入口原先挂在**书籍**导入框上——那是漫画和书挤在同一个对话框时代的产物。分家后
+/// OCR 入口随漫画域迁到 [MangaImportDialog]，本测试整体跟着换宿主；下面的 gating
+/// 判据（两端都亮、两端 probeCalls 都必须是 0）逐条保留，一条没放宽。
 ///
 /// ## 判据换靶（PR#474，BUG-1164）
 ///
@@ -26,9 +32,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
-import 'package:hibiki/src/media/audiobook/book_import_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
-import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 class _FakeRemoteRunner implements MangaOcrRemoteRunner {
@@ -78,9 +83,7 @@ void main() {
         child: TranslationProvider(
           child: MaterialApp(
             home: Scaffold(
-              body: BookImportDialog(
-                repo: SrtBookRepository(db),
-                audiobookRepo: AudiobookRepository(db),
+              body: MangaImportDialog(
                 db: db,
                 mangaOcrRemoteRunner: runner,
                 ocrEntryDesktopOverride: desktop,
@@ -106,8 +109,7 @@ void main() {
     final _FakeRemoteRunner runner = _FakeRemoteRunner(target: _capableTarget);
     await pumpDialog(tester, desktop: false, runner: runner);
     expect(find.text(t.manga_ocr_wizard_title), findsOneWidget);
-    expect(runner.probeCalls, 0,
-        reason: '入口不再依赖探测，渲染决策不得产生网络副作用');
+    expect(runner.probeCalls, 0, reason: '入口不再依赖探测，渲染决策不得产生网络副作用');
   });
 
   testWidgets('mobile: entry stays visible without any paired host',

--- a/hibiki/test/media/reader_pdf_routing_guard_test.dart
+++ b/hibiki/test/media/reader_pdf_routing_guard_test.dart
@@ -44,9 +44,18 @@ void main() {
   });
 
   test('导入对话框把 .pdf 路由到 PdfImporter（不经 TextToEpub 文本转换）', () {
+    // 载体分家（漫画导入从书籍导入拆出）后，「.pdf 是什么载体」的判定从
+    // _importEpubOnly 的扩展名早退挪到了 classifyImportCarrier 这个纯函数；
+    // 对话框只按分类结果分派。守卫跟着锚点走，两段各守一半，强度不放宽。
+    final String carrier = read('lib/src/media/import/import_carrier.dart');
+    expect(carrier.contains("ext == '.pdf'"), isTrue,
+        reason: 'classifyImportCarrier 必须早退分流 .pdf');
+    expect(carrier.contains('ImportCarrier.pdf'), isTrue,
+        reason: '.pdf 必须归到独立的 pdf 载体，而不是落进文本兜底分支');
+
     final String src = read('lib/src/media/audiobook/book_import_dialog.dart');
-    expect(src.contains("ext == '.pdf'"), isTrue,
-        reason: '_importEpubOnly 必须早退分流 .pdf');
+    expect(src.contains('ImportCarrier.pdf'), isTrue,
+        reason: '_importEpubOnly 必须按 pdf 载体分派，缺这条 → PDF 落文本兜底');
     expect(src.contains('PdfImporter.importFromPath'), isTrue,
         reason: '.pdf 走 PdfImporter，而非把 PDF 二进制喂 TextToEpub 转成乱码 EPUB');
     // .pdf 必须在文件选择白名单里，否则用户根本选不到。


### PR DESCRIPTION
## 为什么

漫画和书籍此前挤在同一个 `BookImportDialog`：

- 漫画库点「导入漫画」，弹出的框里是「选书 / 选字幕 / 选音频 / 有声书对齐」，字幕、音频、对齐三块对漫画毫无意义，连 tooltip 都还是 `t.srt_import`；
- 「这是漫画」这个**在入口就已知**的事实被丢掉，一路走到 `_importEpubOnly` 末尾，再靠 4 个 if（其中 `.zip/.epub` 要 `isImageArchive()` **真读开压缩包**）嗅回来；
- 拖放决策层本来就把漫画和书分成了 `DropIntent.importNewManga` / `importNewBook` 两个 intent，两个 intent 却落到同一个对话框。

这不是复用，是载体身份丢失后的考古——那次真实 IO 就是在为前面丢掉的信息买单。

## 改了什么

**拆的是入口和对话框，不是引擎。** `MangaImporter` / `MangaArchiveImporter` / `MangaModule` / OCR 向导 / `EpubBooks` 表 / `format=='manga'` / 同名书冲突解决，全部原样复用；共用的 `ImportFlowMixin` 骨架、`ImportDialogFrame` 外框一点没少。

| 文件 | 改动 |
|---|---|
| `media/import/import_carrier.dart`（新） | `ImportCarrier` 枚举 + `classifyImportCarrier` 纯函数。那 4 个顺序敏感的分支提成可穷举的分类器，文件系统判据注入（与 `classifyDroppedFiles` 同款设计）。读包判据**只在扩展名真二义**（`.zip`/`.epub`）时才被调用 |
| `media/manga/manga_import_dialog.dart`（新） | 只暴露漫画 importer 真正消费的两个参数（路径 + 标题）+ OCR 入口。载体细分在**选中那一刻**定死，`_doImport` 只照着 switch 分派，不再二次嗅探 |
| `book_import_dialog.dart` | 去掉 OCR 入口与全部漫画分支。仍**认得**漫画载体，但改为弹一次明确确认后转交漫画流程（`_handoffIfManga`）。选文件 / 拖入 / 预填三个入口共用同一个闸门 |
| `manga_hibiki_source.dart` | 自带 `buildMangaImportButton`，不再委托 `ReaderHibikiSource.buildBookImportButton` |
| `reader_hibiki_history_page.dart` | 漫画库页头按钮与空态按钮指向漫画对话框（不再是「同一个框换个 label」） |
| `reader_history/books.part.dart` | `DropIntent.importNewManga` 落点改为 `MangaImportDialog`，落点终于跟着 intent 走 |

## 向后兼容

**唯一红线是「拖图包 zip / 扫描版 epub 到书架仍要能导成漫画」，保住了。** 识别照旧（分类层刻意不为每次拖 EPUB 白开一次包，由对话框收下路径时真读包），但分派从**静默**改成用户可见的一次确认——不提供「仍按书导入」这个选项，因为那只能产出一本乱码书，不做假选择。

`EpubBooks` 表、`format=='manga'`、所有持久化键均未动。

## 验证

- `flutter analyze`（含 test 目录）全量 **零问题**
- 定向测试 **1392 例通过**（`test/media/import|manga|drag_drop|audiobook` + `test/i18n` + `test/tools` + MD3 静态守卫），走 `tool/flutter_test_failures.dart`，verdict: `PASSED - 1392 tests ran`
- 新增 `import_carrier_test.dart` 27 例，覆盖顺序敏感分支（带点目录名、PDF 早退、`.mokuro` 不被文本分支吞）与**读包时机**（扩展名已能定性时不得白开一次包）
- OCR 入口 gating 测试整体换宿主到 `MangaImportDialog`，判据（两端都亮、`probeCalls` 都必须是 0）**一条没放宽**
- drop target 守卫把漫画框纳入，防「漫画框拖不进东西」成为无人看守的回归

## 契约变更（预期的红，不是回归）

`book_import_dialog_ocr_entry_test.dart` → `test/media/manga/manga_import_dialog_ocr_entry_test.dart`；`BookImportDialog` 的 `mangaOcrRemoteRunner` / `ocrEntryDesktopOverride` 两个 OCR 测试缝随 OCR 入口迁到 `MangaImportDialog`。

## 未做

未 bump `pubspec.yaml` 版本号（本 PR 不是发布，且并发 PR 多，避免版本行冲突）。真机验证（漫画库导入、拖图包 zip 到书架的确认弹窗）未做，需要真设备。

https://claude.ai/code/session_01MbeBrZt6qqasJQhK9c9tZd
