### PR TITLE
fix(shortcuts): 摘掉 7 条无解析入口的死输入通道

### DIFF
--- a/hibiki/lib/src/pages/implementations/shortcut_settings/binding_edit_dialog.part.dart
+++ b/hibiki/lib/src/pages/implementations/shortcut_settings/binding_edit_dialog.part.dart
@@ -588,6 +588,18 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
     final bool showWheel =
         channels.contains(ShortcutChannel.wheel) || _wheel.isNotEmpty;
 
+    // 「显示」与「可新增」是两回事：上面的 show* 带上 `isNotEmpty`，让通道被摘掉的
+    // scope 上历史快照里的绑定仍然可见、可删（Never break userspace——否则那条永不
+    // 触发的死绑定反而永远删不掉）；但**新增入口只认通道是否开放**，否则用户还能
+    // 继续往没有解析入口的通道里塞永不触发的绑定，正是
+    // `shortcut_channel_wiring_guard_test` 要根除的那件事。
+    final bool canAddKeyboard = channels.contains(ShortcutChannel.keyboard);
+    final bool canAddGamepad = channels.contains(ShortcutChannel.gamepad);
+    // 鼠标额外要求平台真有非主键鼠标（移动端只读不加，TODO-1088 既有契约）。
+    final bool canAddMouse = channels.contains(ShortcutChannel.mouse) &&
+        _mouseBindingSupported(defaultTargetPlatform);
+    final bool canAddWheel = channels.contains(ShortcutChannel.wheel);
+
     return HibikiDialogFrame(
       maxWidth: 520,
       maxHeightFactor: 0.86,
@@ -671,7 +683,7 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
                     ),
                   ],
                 )
-              else
+              else if (canAddKeyboard)
                 TextButton.icon(
                   icon: const Icon(Icons.add, size: 18),
                   label: Text(t.shortcut_keyboard),
@@ -754,7 +766,7 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
                     ),
                   ],
                 )
-              else
+              else if (canAddGamepad)
                 Wrap(
                   spacing: tokens.spacing.gap,
                   crossAxisAlignment: WrapCrossAlignment.center,
@@ -813,9 +825,7 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
             // channels. On mobile there is no mouse, so the capture entry is
             // hidden and only inherited bindings (if any) show read-only — Never
             // break userspace: nothing captured, nothing lost.
-            if (_mouse.isNotEmpty ||
-                (channels.contains(ShortcutChannel.mouse) &&
-                    _mouseBindingSupported(defaultTargetPlatform))) ...<Widget>[
+            if (_mouse.isNotEmpty || canAddMouse) ...<Widget>[
               if (showKeyboard || showGamepad) const Divider(height: 24),
               Text(
                 t.shortcut_mouse_button,
@@ -833,7 +843,7 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
                     ),
                 ],
               ),
-              if (_mouseBindingSupported(defaultTargetPlatform)) ...<Widget>[
+              if (canAddMouse) ...<Widget>[
                 SizedBox(height: tokens.spacing.gap),
                 if (_mouseCapturing)
                   Column(
@@ -953,7 +963,7 @@ class _ShortcutBindingEditDialogState extends State<ShortcutBindingEditDialog> {
                     ),
                   ],
                 )
-              else
+              else if (canAddWheel)
                 TextButton.icon(
                   key: const Key('shortcut_add_wheel'),
                   icon: const Icon(Icons.mouse_outlined, size: 18),

--- a/hibiki/lib/src/shortcuts/shortcut_action.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_action.dart
@@ -76,22 +76,52 @@ enum ShortcutScope {
   /// 的通道即红。它与 `shortcut_action_wiring_guard` 互补——后者只看「action 符号
   /// 有没有出现过」，抓不到「同一个 action 的键盘接了、手柄没接」这种半接线。
   ///
-  /// 多数 scope 走页面派发，键盘/手柄/鼠标三通道全通；[manga] 只接了键盘、
-  /// [dictionaryPopup] 的动作只由弹窗 WebView 的滚轮事件触发（见各自 case 注释）。
+  /// 每个 scope 只列**真的存在解析入口**的通道，没有「多数 scope 三通道全通」这种
+  /// 省事写法——那正是 7 条死通道的来源（见各 case 注释）。
+  ///
+  /// 尤其注意 **mouse 通道在本 app 的唯一运行时输入源是 WebView 的 DOM `mousedown`**
+  /// （阅读器 `onPointerSeek` / 歌词 `onLyricsPointerSeek` → `resolveMouse`）。Flutter
+  /// 侧至今没有任何「PointerDownEvent → MouseBinding → 派发」的管线，故非 WebView
+  /// 宿主的 scope 一律不开 mouse。
   Set<ShortcutChannel> get channels {
     switch (this) {
+      // 阅读器与有声书是 WebView 宿主：键盘/手柄走页面派发，鼠标侧键经 WebView 的
+      // DOM mousedown → `resolveMouse`（webview.part.dart / pointer_seek.dart）。
       case reader:
       case audiobook:
-      case home:
-      case global:
-      case video:
-      case gamepad:
-      case globalExternal:
         return const <ShortcutChannel>{
           ShortcutChannel.keyboard,
           ShortcutChannel.gamepad,
           ShortcutChannel.mouse,
         };
+      // 首页 / 全局 / 视频页：键盘与手柄都有解析入口（home_page 的 resolveKeyboard、
+      // global_navigation、video_player_shortcuts 的 keyboardBindings、各页
+      // GamepadButtonIntent），但**鼠标没有**——这三个页面都是纯 Flutter 表面，没有
+      // WebView 接管 mousedown，也没有任何 Flutter 侧鼠标绑定派发管线。曾经开着
+      // mouse 通道纯属与 reader/audiobook 共用一个 case 分支的连带产物：设置页给出
+      // 「添加鼠标按键」入口，绑上去永不触发。要重开必须先真的建一条
+      // PointerDownEvent → MouseBinding → 派发的链路并验证。
+      case home:
+      case global:
+      case video:
+        return const <ShortcutChannel>{
+          ShortcutChannel.keyboard,
+          ShortcutChannel.gamepad,
+        };
+      // dpad 四向：唯一消费者是 GamepadService._dispatchButton，按 `GamepadButton`
+      // 做 `resolveGamepad(scope: gamepad)`，且结果只被映射成 TraversalDirection。
+      // 键盘/鼠标绑定在这里**按构造不可读**（没有也不可能有 resolveKeyboard/
+      // resolveMouse(scope: gamepad)）；默认表也刻意把键盘留空——方向焦点移动由箭头键
+      // 与摇杆负责，见 shortcut_defaults 的 dpad* 注释。
+      case gamepad:
+        return const <ShortcutChannel>{ShortcutChannel.gamepad};
+      // app 外全局查词热键：GlobalLookupController 只读 `.keyboardBindings` 注册到
+      // OS 级 hotkey_manager，而 `HotKey.key` 的类型就是 Flutter 的 `KeyboardKey`，
+      // 底层是 win32 `RegisterHotKey`（修饰键位掩码 + 虚拟键码）。手柄按钮无法表达，
+      // 鼠标键则要装 WH_MOUSE_LL 全局钩子并全系统吞掉该键——两者都不是这条机制能
+      // 提供的，故只开键盘。
+      case globalExternal:
+        return const <ShortcutChannel>{ShortcutChannel.keyboard};
       // 漫画页只有键盘解析入口：`_resolveMangaKeyAction` 走 `resolveKeyboard`，
       // 滚轮翻页是硬编码的 `wheelInputAction`（不查注册表），手柄则完全没接
       // （既无 `resolveGamepad`，也无 `GamepadButtonIntent` 的 Action）。开着手柄/

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+957
+version: 1.3.1+958
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/shortcuts/shortcut_channel_wiring_guard_test.dart
+++ b/hibiki/test/shortcuts/shortcut_channel_wiring_guard_test.dart
@@ -49,25 +49,23 @@ void main() {
 
   /// 既有欠账：**开放了通道但至今没有消费者**的 (scope, channel)。
   ///
-  /// 这些是本守卫落地之前就存在的，危害小于漫画那处——它们只是设置页多出一个空的
-  /// 通道分组，**默认表里没有任何绑定**，所以不会出现「开箱就配好了却按不动」。
+  /// **现在是空的**——本守卫落地时登记的 7 条已全部销账，全部走「摘掉通道」而非
+  /// 「接上解析入口」，因为它们无一例外是按构造不可接：
+  ///   · `video/home/global.mouse`：mouse 通道在本 app 的唯一运行时输入源是 WebView
+  ///     的 DOM `mousedown`，这三个页面都是纯 Flutter 表面，Flutter 侧根本不存在
+  ///     PointerDownEvent → MouseBinding → 派发的管线；
+  ///   · `gamepad.keyboard/mouse`：dpad 四向只由 `GamepadService._dispatchButton` 按
+  ///     `GamepadButton` 解析，键盘/鼠标绑定没有也不可能有读取方；
+  ///   · `globalExternal.gamepad/mouse`：OS 级热键走 win32 `RegisterHotKey`，
+  ///     `HotKey.key` 类型就是 `KeyboardKey`，手柄/鼠标压根无法表达。
+  /// 详见 `ShortcutScope.channels` 各 case 的注释。
+  ///
   /// 本清单是**棘轮**：下面断言的是「实际欠账集合 == 本清单」，因此
   ///   · 新增任何死通道 → 红（这正是漫画那处会被拦下的原因）；
   ///   · 接上某个通道后忘了从清单里划掉 → 也红，逼你把账销掉。
   /// 修的方向是二选一：要么接上解析入口，要么把该通道从 `scope.channels` 摘掉。
-  const Set<String> knownUnconsumedChannels = <String>{
-    // 视频页的鼠标绑定无人解析（`resolveMouse` 只有 reader / audiobook 两处）。
-    'video.mouse',
-    'home.mouse',
-    'global.mouse',
-    // gamepad scope 只装 dpad 四向，只经 GamepadService 的手柄通道消费。
-    'gamepad.keyboard',
-    'gamepad.mouse',
-    // globalExternal 只把键盘绑定注册进 OS 级 hotkey_manager，另两个通道没有 OS
-    // 级对应物。
-    'globalExternal.gamepad',
-    'globalExternal.mouse',
-  };
+  /// 往这里加条目 = 明知故犯地放一个死通道进设置页，必须在 commit 里说明理由。
+  const Set<String> knownUnconsumedChannels = <String>{};
 
   Map<ShortcutScope, List<ShortcutAction>> actionsByScope() {
     final Map<ShortcutScope, List<ShortcutAction>> byScope =

--- a/hibiki/test/shortcuts/shortcut_mouse_binding_capture_test.dart
+++ b/hibiki/test/shortcuts/shortcut_mouse_binding_capture_test.dart
@@ -121,28 +121,34 @@ void main() {
     await tester.pumpAndSettle();
   }
 
+  // 捕获用例统一挂在 readerDismissDict 上：mouse 通道现在只对 reader / audiobook
+  // 开放（它们是 WebView 宿主，`resolveMouse` 真有解析入口），而 readerDismissDict
+  // 正是 reader 侧那个真消费者（webview.part.dart 的 onPointerSeek）。曾用的
+  // homeFocusSearch 所在的 home scope 已不再开放 mouse 通道（无任何 Flutter 侧
+  // 鼠标派发管线），捕获入口不再渲染。
+  //
+  // 按键选右键(2)/后退键(3)：reader 与 audiobook 同属一个 co-active 组，而
+  // audiobookSeekToClickedSentence 默认占着中键(1)，中键会走冲突改绑流程而非直接
+  // 落 chip。
   testWidgets(
-      'desktop: capturing the middle button records a MouseBinding(1) chip',
+      'desktop: capturing the right button records a MouseBinding(2) chip',
       (WidgetTester tester) async {
     usePlatform(TargetPlatform.windows);
     final HibikiShortcutRegistry registry =
         buildRegistry(TargetPlatform.windows);
-    // homeFocusSearch is in the home scope, which is not coactive with the
-    // audiobook scope that ships the only default MouseBinding(1), so middle
-    // click is conflict-free here.
     await pumpDialog(
       tester,
       registry,
-      action: ShortcutAction.homeFocusSearch,
+      action: ShortcutAction.readerDismissDict,
     );
 
     await tester.tap(find.byKey(const Key('shortcut_add_mouse')));
     await tester.pumpAndSettle();
     expect(find.text(t.shortcut_press_mouse_button), findsOneWidget);
 
-    await pressMouseButton(tester, kMiddleMouseButton);
+    await pressMouseButton(tester, kSecondaryMouseButton);
 
-    expect(find.text(t.shortcut_mouse_middle), findsOneWidget);
+    expect(find.text(t.shortcut_mouse_right), findsOneWidget);
     expect(find.text(t.shortcut_press_mouse_button), findsNothing);
 
     resetPlatform();
@@ -156,7 +162,7 @@ void main() {
     await pumpDialog(
       tester,
       registry,
-      action: ShortcutAction.homeFocusSearch,
+      action: ShortcutAction.readerDismissDict,
     );
 
     await tester.tap(find.byKey(const Key('shortcut_add_mouse')));
@@ -178,7 +184,7 @@ void main() {
     await pumpDialogHost(
       tester,
       registry,
-      action: ShortcutAction.homeFocusSearch,
+      action: ShortcutAction.readerDismissDict,
     );
 
     await tester.tap(find.byKey(const Key('shortcut_add_mouse')));
@@ -189,14 +195,17 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(
-      registry.bindingsFor(ShortcutAction.homeFocusSearch).mouseBindings,
+      registry.bindingsFor(ShortcutAction.readerDismissDict).mouseBindings,
       contains(const MouseBinding(3)),
     );
 
     resetPlatform();
   });
 
-  testWidgets('desktop: deleting a mouse chip removes it from the draft',
+  // 通道被摘掉的 scope 上，历史快照里的鼠标绑定**不隐身、仍可删**（Never break
+  // userspace）。home 现在不开放 mouse 通道，故捕获入口消失，但老用户当年配下的
+  // 绑定仍要能看见并删掉——否则那条永不触发的死绑定就永远删不掉了。
+  testWidgets('desktop: 通道已摘的 scope 仍显示并可删除历史鼠标绑定（但没有捕获入口）',
       (WidgetTester tester) async {
     usePlatform(TargetPlatform.windows);
     final HibikiShortcutRegistry registry =
@@ -211,6 +220,7 @@ void main() {
     );
 
     expect(find.text(t.shortcut_mouse_right), findsOneWidget);
+    expect(find.byKey(const Key('shortcut_add_mouse')), findsNothing);
     await tester.tap(find.byIcon(Icons.close).first);
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
## 背景

PR#505 落地的守卫 `shortcut_channel_wiring_guard_test` 登记了 7 条既有欠账：设置页开着输入通道，但全仓没有对应的解析入口。本 PR 把它们全部销账，欠账清单清空。

## 逐条判定：7 条全部「摘通道」，无一条接线

不是为了省事——是逐条查到它们**按构造不可接**：

| 欠账 | 判定 | 依据 |
|---|---|---|
| `video.mouse` / `home.mouse` / `global.mouse` | 摘 | mouse 通道在本 app 的**唯一运行时输入源是 WebView 的 DOM `mousedown`**（reader `onPointerSeek` / 歌词 `onLyricsPointerSeek` → `resolveMouse`，全仓仅 `reader_hibiki/webview.part.dart:2148` 与 `media/audiobook/pointer_seek.dart:15` 两处）。这三个页面都是纯 Flutter 表面，Flutter 侧**根本不存在** `PointerDownEvent → MouseBinding → 派发` 的管线。它们开着 mouse 纯属与 reader/audiobook 共用同一个 `case` 分支的连带产物，不是设计意图 |
| `gamepad.keyboard` / `gamepad.mouse` | 摘 | dpad 四向的唯一消费者是 `GamepadService._dispatchButton`，按 `GamepadButton` 做 `resolveGamepad(scope: gamepad)`，且结果只被映射成 `TraversalDirection`。键盘/鼠标绑定**没有也不可能有读取方**；`shortcut_defaults` 也刻意把 dpad 的键盘默认留空（方向焦点移动由箭头键与摇杆负责） |
| `globalExternal.gamepad` / `globalExternal.mouse` | 摘 | `GlobalLookupController` 只读 `.keyboardBindings` 注册到 OS 级 `hotkey_manager`，而 `HotKey.key` 的类型就是 Flutter 的 `KeyboardKey`，底层是 win32 `RegisterHotKey`（修饰键掩码 + 虚拟键码）。手柄按钮无法表达；鼠标键则要装 `WH_MOUSE_LL` 全局钩子并全系统吞掉该键 —— 都不是这条机制能提供的 |

`video.mouse` 是其中唯一有产品想象空间的（桌面播放器绑鼠标侧键做快进/播放暂停）。但接它 = 新建一整条 Flutter 侧鼠标派发链路，属于新功能而非清账，且本轮无法自动化验证，故照 PR#505 处理漫画手柄的同一标准摘掉。

## 顺带修掉的同类根因缺陷

编辑对话框此前只用 `scope.channels` 控制**章节是否显示**，而新增/捕获入口只看平台能力。结果：通道被摘掉的 scope 上只要存在历史绑定，章节就会显示，用户**仍能继续往死通道里塞永不触发的新绑定**——正是本守卫要根除的那件事。

现在拆成两组判据：
- `show*`（显示，带 `isNotEmpty`）：历史快照不隐身、可删（Never break userspace，否则那条死绑定反而永远删不掉）
- `canAdd*`（新增，只认通道是否开放）：不再提供制造新死绑定的入口

四个通道（keyboard / gamepad / mouse / wheel）一并对齐。

## 用户可见变化

桌面端快捷键设置里，**视频 / 首页 / 全局 / dpad / app 外查词** 这几组动作的编辑对话框不再显示对应的「添加鼠标按键 / 添加手柄 / 添加键盘」入口。这些入口此前配上去 100% 不触发。已存在的历史绑定照常显示且可删除，无数据丢失。

## 验证

- `flutter analyze`（含 test）→ `No issues found!`
- `test/shortcuts/` 477 tests PASSED、`test/pages/` 2330 tests PASSED（`tool/flutter_test_failures.dart` 判词 + 退出码 0）
- **负向验证（棘轮两个方向都验了）**：
  - 重开 `video/home/global.mouse` + `globalExternal.gamepad` 而不接线 → 守卫转红，报 `新增了「设置页开放、却没有任何解析入口」的通道：{home.mouse, global.mouse, video.mouse, globalExternal.gamepad}`
  - 清单里留一条已修好的 `video.mouse` → 守卫转红，报 `{video.mouse} 已经有解析入口（或通道已摘掉），请从 knownUnconsumedChannels 里删掉`
  - 两次还原后均转绿

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
