### PR TITLE
fix(sync): 远端清单缓存按来源分槽，互联与云盘不再串味 (BUG-1202)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1162 条。点号进各自文件。
+> 共 1163 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1202](bugs/BUG-1202-remote-library-cache-source-crosstalk.md) | ✅ | ✅ | 互联与云盘共用远端清单缓存槽，换来源后看到上一个来源的条目 |
 | [BUG-1201](bugs/BUG-1201-sasasa-unity-resource-pcm-not-published.md) | ✅ | ✅ | Sasasa Unity 资源音频已解码但未写入音频环 |
 | [BUG-1200](bugs/BUG-1200-sasasa-unity-textmesh-glyphs.md) | ✅ | ✅ | Sasasa Unity TextMesh 对白被拆成单字 |
 | [BUG-1199](bugs/BUG-1199-epub-htm-mime-blank.md) | ✅ | ✅ | EPUB 章节用 .htm 扩展名时整本渲染空白（MIME 表缺 htm/xht） |

--- a/docs/bugs/BUG-1202-remote-library-cache-source-crosstalk.md
+++ b/docs/bugs/BUG-1202-remote-library-cache-source-crosstalk.md
@@ -1,0 +1,53 @@
+## BUG-1202 · 互联与云盘共用远端清单缓存槽，换来源后看到上一个来源的条目
+- **报告**：2026-07-28（用户：项目负责人巡检）
+- **真实性**：✅ 真 bug（结构上可触发，非防御性加固）。根因 `hibiki/lib/src/sync/remote_library_cache.dart:63`（`read` 只按域 `key` 定位槽，槽里不带来源身份）+ `hibiki/lib/src/sync/remote_library_cache.dart:179`（唯一的失效订阅挂在 `InterconnectSyncBackend.sessionIdentityRevision` 上）。消费点：`hibiki/lib/src/pages/implementations/home_video_page.dart:557`、`hibiki/lib/src/pages/implementations/reader_history/remote.part.dart:65`、`hibiki/lib/src/pages/implementations/home_dashboard_page.dart:553`。
+
+### 判定过程
+
+两种来源确实写进同一个 key。`PR#510`（TODO-2119，commit `b7a495bbd`）把 `CloudRemoteVideoClient` 收敛成 `RemoteVideoSource` 之后删掉了 `cloudVideos` 槽，于是视频页的取数主干
+
+```dart
+final RemoteVideoSource? source = await _resolveRemoteVideoClient() ??
+    await _resolveCloudRemoteVideoClient();
+...
+await _remoteCache.read(key: RemoteLibraryCacheKeys.videos, fetch: source.listRemoteVideos);
+```
+
+对互联与云盘两种源用同一个 `videos` 槽。书侧（`RemoteLibraryCacheKeys.books`）从一开始就是这样——`InterconnectSyncBackend` 与 `CloudRemoteBookClient` 共用一个槽，比 PR#510 更早。
+
+**失效信号覆盖不到换来源**。唯一的自动失效是 `remoteLibraryCacheProvider` 订阅 `InterconnectSyncBackend.sessionIdentityRevision`，而它只在 `_loadConfig` 发现「地址集合 / 钉扎指纹 / 令牌」变了时自增（`interconnect_sync_backend.dart:221`）。`_loadConfig` 只在 `restoreAuth` 内被调用，而：
+
+- **关互联开关**：`_resolveRemoteVideoClient` 在 `isInterconnectEnabled()` 为 false 时**先 return null，根本不调 `restoreAuth`** → revision 不自增。
+- **再开互联开关**：`restoreAuth` 跑了，但地址/令牌都没改，signature 与上次相同 → 同样不自增。
+- **换云盘后端类型**（Drive → WebDAV 等）：整条路径不碰 `InterconnectSyncBackend` → 永远不自增。
+
+三条路都没有失效兜底，TTL 60s 内命中上一个来源的清单，`fetch` 根本不执行，且不报错。
+
+### 触发序列（用户可复现）
+
+前提：互联已配对并启用，云备份后端（如 Google Drive）也已配好，「显示远端条目」开着。
+
+1. 打开视频库 → 渲染出互联对端的视频占位卡，`videos` 槽装着对端清单（60s 新鲜）。
+2. 去设置页**关掉互联开关**（不改地址、不改令牌）。
+3. 60s 内切走再切回视频 tab（`onTabActivated` → 非 forceRefresh 的读）。
+4. 页面走云盘分支，但 `read(key: videos)` 命中步骤 1 的缓存 → **在「云视频」视图里看到互联对端的片子**，云角标俱全，不报错。点下载会向云盘要一个它根本没有的 uid。
+
+反向同理（先云盘热缓存 → 开互联 → 看到云盘的条目）。书架（`books` 槽）与首页 dashboard 共用同一份缓存，同样受影响。换云盘后端类型（Drive→WebDAV）是第三条，且 60s 后仍可能反复发生。
+
+### 修复方案：乙（缓存 key 带来源身份）
+
+选乙而不是甲/丙：
+
+- **甲（恢复两个槽）治不了本 bug 的一半**。双槽只区分「互联 vs 云盘」，`cloud_videos` 一个槽仍被所有云盘后端共用 → 换后端类型照样串。而且 PR#510 的收敛本身是对的（元素类型已统一成 `RemoteVideoInfo`，域名不该再按来源拆），退回去是走回头路。
+- **丙（给云盘也接失效信号）是「记得在每个入口失效」的老路**。`BUG-1180` 自己的注释就批判过这个做法并已经漏过一次；何况「翻互联开关」不属于任何一侧的「身份变了」，还得再补第三个信号。
+- **乙从数据结构上消灭问题**：槽 = (来源身份, 域)。来源身份由来源自己申报，声明成接口上的**抽象**成员，新增任何远端源时编译器当场要求给出身份 —— 「忘了分槽」这个失败模式不存在。
+
+实现：新增 `hibiki/lib/src/sync/remote_library_source.dart` 的 `RemoteLibrarySource.remoteLibrarySourceId`；`RemoteVideoSource` / `RemoteBookClient` 实现它；`InterconnectSyncBackend` 报 `interconnect`，两个云 client 报 `cloud:<backendType>`（`backendType` 成为构造必填，由已经查过 `getBackendType()` 的调用方传入）；`RemoteLibraryCache.read/invalidate/isFresh` 增加 `sourceId` 维度。
+
+同来源同域仍共享一个槽，BUG-1180 省下的那轮网络不受影响。
+
+**已知残留（不在本轮范围）**：同一云盘后端类型下换账号（Drive A → Drive B）身份不变，60s TTL 内仍可能串。需要后端侧给出账号级身份信号，属独立议题；量级远小于本 bug 修掉的跨来源无限期串味。
+
+- **[x] ① 已修复** — `remote_library_source.dart`（新增）/ `remote_library_cache.dart` / `interconnect_sync_backend.dart` / `cloud_remote_video_client.dart` / `cloud_remote_book_client.dart` / `url_stream_video.dart` / `home_video_page.dart` / `reader_history/remote.part.dart` / `home_dashboard_page.dart`
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/home_video_remote_source_switch_test.dart`（新增，行为层：切换来源后断言**渲染出的是哪一个来源的卡**）+ `hibiki/test/sync/remote_library_cache_test.dart`（新增 5 条跨来源用例）
+- **备注**：断言刻意锁**内容归属**而非「缓存被清空」。负向验证：把 `_slotKey` 退回 `=> key`（等价 PR#510 后的现状）→ 5 条转红，页面用例的失败是「云盘卡片一个都找不到（渲染的是互联那张）」；还原 → 21 条全绿。若只断言「远端区为空」或「`isFresh` 为 false」，退回修复后仍然通过，抓不住这个缺陷。

--- a/hibiki/lib/src/media/video/url_stream_video.dart
+++ b/hibiki/lib/src/media/video/url_stream_video.dart
@@ -236,6 +236,12 @@ class UrlStreamVideoClient implements RemoteVideoClient {
     http.Client? httpClient,
   }) : _httpClient = httpClient ?? http.Client();
 
+  /// 远端清单缓存里的来源身份（BUG-1202）。本 client 从不进库页的清单缓存
+  /// （[listRemoteVideos] 恒空，它只是把一条粘贴来的 URL 包成播放页能吃的契约），
+  /// 但契约要求每个源都能报出身份，给一个独立值即可，绝不与互联/云盘同槽。
+  @override
+  String get remoteLibrarySourceId => 'url_stream';
+
   /// 用户粘贴的视频流 URL（http/https 直链 / HLS / m3u8）。
   final String streamUrl;
 

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -549,15 +549,21 @@ class _HomeDashboardPageState
       // ② 三个请求并行而不是串行（原本是三次完整往返首尾相接）。
       final RemoteLibraryCache cache = ref.read(remoteLibraryCacheProvider);
       final List<Object> results = await Future.wait<Object>(<Future<Object>>[
+        // 首页只走互联（上面已 return 掉未启用的情况），来源身份仍从 backend 自己
+        // 取而不是写字面量——书/视频两个域与书架、视频页同槽命中，靠的就是双方报出
+        // 同一个 id（BUG-1202）。
         cache.read<List<RemoteBookInfo>>(
+          sourceId: backend.remoteLibrarySourceId,
           key: RemoteLibraryCacheKeys.books,
           fetch: backend.listRemoteBooks,
         ),
         cache.read<List<RemoteVideoInfo>>(
+          sourceId: backend.remoteLibrarySourceId,
           key: RemoteLibraryCacheKeys.videos,
           fetch: backend.listRemoteVideos,
         ),
         cache.read<List<RemoteActivityEvent>>(
+          sourceId: backend.remoteLibrarySourceId,
           key: RemoteLibraryCacheKeys.activity(200),
           fetch: () => backend.listRemoteActivity(limit: 200),
         ),

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -518,7 +518,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (type == SyncBackendType.hibikiServer) return null;
     final SyncBackend backend = resolveSyncBackend(type);
     if (!await backend.restoreAuth(syncRepo)) return null;
-    return CloudRemoteVideoClient(backend: backend);
+    return CloudRemoteVideoClient(backend: backend, backendType: type);
   }
 
   /// 是否应该去问远端要视频清单。
@@ -563,10 +563,11 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       // 网络，TTL 内直接复用。缓存只包住「问对端要清单」这一步，下面的本地库查询与
       // 去重仍每次照跑，本地新增/删除的视频立即反映在混排网格里。
       //
-      // 两种源共用一个 key：清单已在各自 client 里统一成 List<RemoteVideoInfo>，
-      // 不再有「元素类型不同、共用会 cast 崩」的问题（TODO-2119 之前必须分槽）。
-      // 换对端/换后端时由会话身份 revision 驱动 invalidateAll（BUG-1180），不会串味。
+      // 槽 = 来源身份 + 域（BUG-1202）。上面那行 `?? ` 让本方法**故意**不知道拿到的
+      // 是互联还是云盘，所以来源身份只能由 source 自己申报；靠调用点分辨来源、或靠
+      // 「换后端时记得失效」都治不了串味（换云盘后端根本不经过互联的失效信号）。
       final List<RemoteVideoInfo> videos = await _remoteCache.read(
+        sourceId: source.remoteLibrarySourceId,
         key: RemoteLibraryCacheKeys.videos,
         forceRefresh: forceRefresh,
         fetch: source.listRemoteVideos,

--- a/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
@@ -29,6 +29,7 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     final String rootFolderId = await backend.findOrCreateRootFolder();
     return CloudRemoteBookClient(
       backend: backend,
+      backendType: type,
       rootFolderId: rootFolderId,
     );
   }
@@ -61,7 +62,10 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
       // 打一轮网络，TTL 内直接复用；首页 dashboard 刚拉过的同一份列表也在这里命中。
       // 缓存只包住「问对端要清单」这一步，下面的本地库查询与去重仍每次照跑，所以本地
       // 新增/删除的书立即反映在混排网格里。
+      // 槽 = 来源身份 + 域（BUG-1202）：互联对端与云盘书库都往 books 域写，共用一个
+      // 槽会让「关掉互联开关 / 换云盘后端」之后 TTL 内看到上一个来源的书。
       final List<RemoteBookInfo> books = await _remoteCache.read(
+        sourceId: client.remoteLibrarySourceId,
         key: RemoteLibraryCacheKeys.books,
         forceRefresh: forceRefresh,
         fetch: client.listRemoteBooks,
@@ -656,6 +660,7 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     try {
       // BUG-1180：与书清单同缓存策略——切回 tab 不再重打这一枪。
       all = await _remoteCache.read(
+        sourceId: client.remoteLibrarySourceId,
         key: RemoteLibraryCacheKeys.audiobooks,
         forceRefresh: forceRefresh,
         fetch: client.listRemoteAudiobooks,

--- a/hibiki/lib/src/sync/cloud_remote_book_client.dart
+++ b/hibiki/lib/src/sync/cloud_remote_book_client.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/sync_asset_store.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_orchestrator.dart'
@@ -24,6 +25,7 @@ import 'package:hibiki/src/sync/sync_file_ref.dart' show SyncFileRef;
 class CloudRemoteBookClient implements RemoteBookClient {
   CloudRemoteBookClient({
     required this.backend,
+    required this.backendType,
     required this.rootFolderId,
     this.contentProbeConcurrency = 4,
     this.contentProbeRetries = 1,
@@ -34,8 +36,17 @@ class CloudRemoteBookClient implements RemoteBookClient {
   /// 远端存储后端；务必是 `resolveSyncBackend` 的产物（带解混淆装饰层）。
   final SyncBackend backend;
 
+  /// [backend] 背后的云盘类型。只用于把清单缓存分槽——换后端类型（Drive→WebDAV）
+  /// 之后两边的书库毫无关系，必须落在不同槽里（BUG-1202）。由构造方
+  /// （已经查过 `getBackendType()`）传入。
+  final SyncBackendType backendType;
+
   /// 根命名空间定位符（`findOrCreateRootFolder()` 的返回值）。
   final String rootFolderId;
+
+  @override
+  String get remoteLibrarySourceId =>
+      cloudRemoteLibrarySourceId(backendType.name);
 
   /// 内容探测（每本书一次 `listChildren`）的并发上限，默认 4：避免串行慢、又不打爆
   /// 云端 API 速率。

--- a/hibiki/lib/src/sync/cloud_remote_video_client.dart
+++ b/hibiki/lib/src/sync/cloud_remote_video_client.dart
@@ -6,7 +6,9 @@ import 'package:hibiki/src/sync/hibiki_library_host_service.dart'
 import 'package:hibiki/src/sync/remote_video_client.dart'
     show RemoteVideoSource;
 import 'package:hibiki/src/sync/sync_asset_store.dart';
-import 'package:hibiki/src/sync/sync_backend.dart' show SyncBackendError;
+import 'package:hibiki/src/sync/remote_library_source.dart';
+import 'package:hibiki/src/sync/sync_backend.dart'
+    show SyncBackendError, SyncBackendType;
 import 'package:hibiki/src/sync/sync_orchestrator.dart'
     show kSyncVideosNamespace, kSyncVideosManifestName;
 import 'package:hibiki/src/sync/video_manifest.dart';
@@ -25,10 +27,19 @@ import 'package:hibiki/src/sync/video_manifest.dart';
 /// 解混淆装饰层），否则下载下来的视频/封面是混淆字节。仅需资产存取能力，故按更窄的
 /// [SyncAssetStore] 契约声明依赖（`SyncBackend` 是其子类型，直接传入即可）。
 class CloudRemoteVideoClient implements RemoteVideoSource {
-  CloudRemoteVideoClient({required this.backend});
+  CloudRemoteVideoClient({required this.backend, required this.backendType});
 
   /// 远端资产存取层；务必是 `resolveSyncBackend` 的产物（带解混淆装饰层）。
   final SyncAssetStore backend;
+
+  /// [backend] 背后的云盘类型。只用于把清单缓存分槽——换后端类型（Drive→WebDAV）
+  /// 之后两边的 `__videos__/` 内容毫无关系，必须落在不同槽里（BUG-1202）。
+  /// [SyncAssetStore] 本身不带身份，所以由构造方（已经查过 `getBackendType()`）传入。
+  final SyncBackendType backendType;
+
+  @override
+  String get remoteLibrarySourceId =>
+      cloudRemoteLibrarySourceId(backendType.name);
 
   /// 读 `__videos__/videos.json` 目录清单，返回全部云视频条目（uid/title/大小/
   /// importedAt/videoAsset/coverAsset）。命名空间或清单缺失（从未有设备上传）→ 空表。

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -7,6 +7,7 @@ import 'package:hibiki/src/sync/deletion_propagation.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
 import 'package:hibiki/src/sync/remote_cover_fetcher.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki/src/utils/misc/resumable_downloader.dart';
 import 'package:hibiki/src/sync/sync_asset_store.dart';
@@ -155,6 +156,14 @@ class InterconnectSyncBackend extends SyncBackend
   /// 上一次 [_loadConfig] 读到的配置身份（见 [_sessionSignature]）。BUG-1183：用它
   /// 判断 `restoreAuth` 是否真需要作废已解析的地址。null = 还没读过配置。
   String? _configSignature;
+
+  /// 远端清单缓存里的来源身份（BUG-1202）：互联对端 live 库。
+  ///
+  /// 不随「当前是哪一台对端」变化——本类是单例，换对端由
+  /// [sessionIdentityRevision] 驱动 `invalidateAll()`，那是唯一权威判据。这个 id
+  /// 只回答「这份清单是问互联要的，不是问云盘要的」。
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   /// 对端身份（地址集合 / 钉扎指纹 / 令牌）真的变了时自增。
   ///

--- a/hibiki/lib/src/sync/remote_book_client.dart
+++ b/hibiki/lib/src/sync/remote_book_client.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 
 /// 远端书来源类型：决定书架「远端书」分区的标题/副标题文案（BUG-699 / TODO-1384）。
 ///
@@ -11,7 +12,7 @@ import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 ///   「云端书」。WebDAV-only 用户从没配过互联，绝不能给他们看「互联/对端设备」。
 enum RemoteBookSourceKind { interconnect, cloud }
 
-abstract class RemoteBookClient {
+abstract class RemoteBookClient implements RemoteLibrarySource {
   /// 本客户端代表的远端书来源类型（驱动书架分区的标题/副标题文案；这是「展示」
   /// 归类，不是能力门控——删除/有声书等能力仍按具体后端类型判断）。
   RemoteBookSourceKind get remoteSourceKind;

--- a/hibiki/lib/src/sync/remote_library_cache.dart
+++ b/hibiki/lib/src/sync/remote_library_cache.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 
 /// 远端库列表（互联对端 / 云盘）的统一读取入口：TTL 缓存 + in-flight 去重 + 显式失效。
 ///
@@ -24,11 +25,21 @@ import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
 /// 反映在混排网格里，只有「问对端要清单」这一步被 TTL 挡住，BUG-992/994 的用户可见
 /// 语义（切回 tab 远端卡在场）不受影响。
 ///
+/// **槽由 (来源身份, 域) 联合定位（BUG-1202）**——只按域分槽会让互联对端与云盘备份
+/// 后端共用同一个 `videos` / `books` 槽，于是「互联拉过的清单」被云盘那次读原样命中，
+/// 用户在云盘视图里看到互联对端的条目且不报错。来源身份由来源自己申报
+/// （[RemoteLibrarySource.remoteLibrarySourceId]），是 [read] 的必填参数——新增任何
+/// 一种远端源，编译器当场要求它给出身份，「忘了分槽」这个失败模式不存在。
+///
 /// **失效有两条路**：① 用户显式下拉刷新 → [read] 传 `forceRefresh: true`；
 /// ② 对端身份变了 → [remoteLibraryCacheProvider] 订阅
 /// `InterconnectSyncBackend.sessionIdentityRevision` 自动 [invalidateAll]。
 /// 缓存类自身不试图从 client 身份推断对端是否换人（那种推断在多地址候选 + 单例
 /// backend 的现实下必然出错），判据由 backend 给，本类只负责照做。
+///
+/// 注意这两条路都**只覆盖互联**（下拉刷新是用户手动的，revision 只在互联内部自增），
+/// 所以「换云盘后端 / 翻互联开关」不能指望它们——那正是要靠上面的按源分槽在结构上
+/// 消灭掉，而不是再补第三个失效信号。
 class RemoteLibraryCache {
   RemoteLibraryCache({
     this.defaultTtl = const Duration(seconds: 60),
@@ -45,8 +56,13 @@ class RemoteLibraryCache {
   final int Function() _nowMs;
   final Map<String, _CacheSlot> _slots = <String, _CacheSlot>{};
 
-  /// 读 [key] 对应的远端列表：命中未过期缓存直接返回；有同 key 请求在途则复用它
-  /// （in-flight 去重，解决书架/漫画/首页同帧并发问一样东西）；否则调 [fetch] 取数。
+  /// 读 [sourceId] 这个来源的 [key] 域列表：命中未过期缓存直接返回；有同槽请求在途
+  /// 则复用它（in-flight 去重，解决书架/漫画/首页同帧并发问一样东西）；否则调 [fetch]
+  /// 取数。
+  ///
+  /// [sourceId] 取自 [RemoteLibrarySource.remoteLibrarySourceId]——**必填**，因为
+  /// 「同一个域、不同来源」的清单毫无关系，共用一个槽就是 BUG-1202 的串味。调用方
+  /// 不该自己编字面量，从手里那个 client/source 上读。
   ///
   /// [forceRefresh] 为 true 时无条件重新取数（下拉刷新语义），并让任何在途的旧请求
   /// 作废——靠 slot 的 generation 计数拦截，避免旧请求后到把新结果覆盖回去。
@@ -55,12 +71,14 @@ class RemoteLibraryCache {
   /// 「拉取失败 → 占位卡不出现」降级处理，而旧值保留让离线时仍能显示上一次已知列表。
   /// 由于失败不刷新 `fetchedAt`，下一次读必然重试。
   Future<T> read<T>({
+    required String sourceId,
     required String key,
     required Future<T> Function() fetch,
     Duration? ttl,
     bool forceRefresh = false,
   }) {
-    final _CacheSlot slot = _slots.putIfAbsent(key, () => _CacheSlot());
+    final _CacheSlot slot =
+        _slots.putIfAbsent(_slotKey(sourceId, key), () => _CacheSlot());
 
     if (!forceRefresh) {
       final Future<Object?>? inFlight = slot.inFlight;
@@ -100,9 +118,18 @@ class RemoteLibraryCache {
     });
   }
 
-  /// 作废单个 key（含在途请求的写回）。下次 [read] 必然重新取数。
-  void invalidate(String key) {
-    final _CacheSlot? slot = _slots[key];
+  /// 槽的联合定位符。竖线做分隔符：来源身份（[kInterconnectRemoteLibrarySourceId] /
+  /// [cloudRemoteLibrarySourceId]）与域名（[RemoteLibraryCacheKeys]）都是本仓写死的标识符，
+  /// 两侧都不含竖线，所以拼不出歧义槽名。
+  static String _slotKey(String sourceId, String key) => '$sourceId|$key';
+
+  /// 作废 [sourceId] 的 [key] 槽（含在途请求的写回）。下次 [read] 必然重新取数。
+  void invalidate(String sourceId, String key) {
+    _invalidateSlot(_slotKey(sourceId, key));
+  }
+
+  void _invalidateSlot(String slotKey) {
+    final _CacheSlot? slot = _slots[slotKey];
     if (slot == null) return;
     slot.generation++;
     slot.inFlight = null;
@@ -111,17 +138,17 @@ class RemoteLibraryCache {
     slot.fetchedAtMs = 0;
   }
 
-  /// 作废全部 key。用于对端换人 / 配对变更 / 互联开关切换 / 同步跑完这类
+  /// 作废全部槽（所有来源、所有域）。用于对端换人 / 配对变更 / 同步跑完这类
   /// 「远端库整体可能已变」的信号。
   void invalidateAll() {
-    for (final String key in _slots.keys.toList()) {
-      invalidate(key);
+    for (final String slotKey in _slots.keys.toList()) {
+      _invalidateSlot(slotKey);
     }
   }
 
-  /// 仅供测试与诊断：[key] 当前是否持有未过期的缓存值。
-  bool isFresh(String key, {Duration? ttl}) {
-    final _CacheSlot? slot = _slots[key];
+  /// 仅供测试与诊断：[sourceId] 的 [key] 槽当前是否持有未过期的缓存值。
+  bool isFresh(String sourceId, String key, {Duration? ttl}) {
+    final _CacheSlot? slot = _slots[_slotKey(sourceId, key)];
     if (slot == null || !slot.hasValue) return false;
     return _nowMs() - slot.fetchedAtMs < (ttl ?? defaultTtl).inMilliseconds;
   }
@@ -159,8 +186,12 @@ final remoteLibraryCacheProvider = Provider<RemoteLibraryCache>((ref) {
   return cache;
 });
 
-/// 远端列表的缓存 key。集中在一处而不是散在各页面字符串字面量里——新增媒体域时
+/// 远端列表的缓存**域** key。集中在一处而不是散在各页面字符串字面量里——新增媒体域时
 /// 这里加一个常量/函数，编译器就能在所有消费点保证拼写一致。
+///
+/// 这里只有「哪一类东西」，没有「问谁要的」——后者是 [RemoteLibraryCache.read] 的
+/// `sourceId` 参数（BUG-1202）。两个维度分开，才不会出现「videos 是共用的、
+/// cloud_videos 是云盘专用的」这种一半按域、一半按源的混合命名。
 class RemoteLibraryCacheKeys {
   const RemoteLibraryCacheKeys._();
 
@@ -168,10 +199,10 @@ class RemoteLibraryCacheKeys {
 
   /// 远端视频清单（`List<RemoteVideoInfo>`）。
   ///
-  /// 互联 host live 库与云盘目录**共用**这一个槽：两种源都实现 `RemoteVideoSource`，
-  /// 清单在各自 client 里已统一成 `RemoteVideoInfo`，不存在元素类型不一致的问题
-  /// （TODO-2119 之前云盘返回的是 manifest entry，被迫分成两个槽，否则换后端时会按
-  /// 错误类型取出缓存直接 cast 崩）。换对端/换后端由 `invalidateAll` 兜底。
+  /// 互联 host live 库与云盘目录用**同一个域** key，但落在**各自的槽**里（槽 =
+  /// 来源身份 + 域）。TODO-2119 之前云盘返回的是 manifest entry，被迫拆出第二个
+  /// `cloud_videos` 域常量；现在两种源都实现 `RemoteVideoSource`、清单都已在各自
+  /// client 里统一成 `RemoteVideoInfo`，域名可以只留一个，来源隔离交给 `sourceId`。
   static const String videos = 'videos';
   static const String audiobooks = 'audiobooks';
   static const String dictionaries = 'dictionaries';

--- a/hibiki/lib/src/sync/remote_library_source.dart
+++ b/hibiki/lib/src/sync/remote_library_source.dart
@@ -1,0 +1,49 @@
+/// 远端库来源的**缓存身份**：任何能给库页供清单的来源都必须能说出自己是谁。
+///
+/// **为什么必须是接口上的抽象成员（BUG-1202）**——远端清单共享 TTL 缓存
+/// （`RemoteLibraryCache`）此前按「域」分槽（`books` / `videos`），而互联对端与云盘
+/// 备份后端**都**往同一个域槽里写：视频页的取数主干是
+/// `_resolveRemoteVideoClient() ?? _resolveCloudRemoteVideoClient()`——它自己都不知道
+/// 拿到的是哪一种源（这正是 TODO-2119 按能力分级想要的解耦）。于是「互联拉过的清单」
+/// 会在 TTL 内被云盘那次读原样命中，用户在云盘视图里看到互联对端的条目，且不报错。
+///
+/// 靠「换后端时记得失效」治不了：失效信号只有 `InterconnectSyncBackend
+/// .sessionIdentityRevision` 一个，它只在**互联对端身份**变化时自增；关互联开关、
+/// 换云盘后端这两条路根本不经过它。而把失效钩子逐个补到每个切换入口，正是
+/// BUG-1180 自己批判过、并已经漏过一次的做法。
+///
+/// 正确做法是让「不同来源」在数据结构上**天然不撞**：缓存槽由 (来源身份, 域) 联合
+/// 定位，来源身份由来源自己申报。声明成抽象成员 = 将来新增任何一种远端源，编译器
+/// 当场要求它给出身份，不存在「忘了登记」这个失败模式。
+abstract class RemoteLibrarySource {
+  /// 本来源在远端清单缓存里的身份。
+  ///
+  /// 口径：**同一个 id 必须意味着「问它要清单会得到同一份东西」**。所以按「哪一种源 +
+  /// 哪一个后端」取值，而不是按对象实例（页面每次取数都新建 client 实例，按实例分槽
+  /// 等于关掉缓存）。
+  ///
+  /// 互联对端**内部**换人（改地址 / 改令牌 / 重新配对）不体现在这里——那由
+  /// `InterconnectSyncBackend.sessionIdentityRevision` 驱动 `invalidateAll()`，是唯一
+  /// 权威的对端身份判据（BUG-1180），本 id 不重复造第二套推断。
+  String get remoteLibrarySourceId;
+}
+
+/// 互联对端（局域网 hibiki host live 库）的来源身份。
+///
+/// 全局只有一台「当前对端」（`InterconnectSyncBackend` 是单例），换对端由
+/// `sessionIdentityRevision` → `invalidateAll()` 兜底，故不按对端地址细分。
+const String kInterconnectRemoteLibrarySourceId = 'interconnect';
+
+/// 云盘备份后端的来源身份：按**后端类型**细分（Google Drive / WebDAV / OneDrive /
+/// Dropbox / FTP / SFTP 各一个槽），因为换后端类型是设置页里一个开关就能做到的事，
+/// 换完两边的清单毫无关系。
+///
+/// [backendTypeName] 传 `SyncBackendType.<x>.name`（本文件刻意不 import
+/// `sync_backend.dart`：那条链会把整套后端实现拖进来，而这里只需要一个名字）。
+///
+/// 已知残留：同一后端类型下换账号（如退出 Google Drive A 登录 B）身份不变，TTL 内
+/// 仍可能看到上一个账号的清单。上界是 60s 且需要在同一分钟内完成「换账号 + 回库页」，
+/// 与本 bug 修掉的「跨源无限期串味」不是一个量级；真要治需要后端侧给出账号级身份
+/// 信号，属独立议题，不在此就地推断（推断会错，见 BUG-1180 的教训）。
+String cloudRemoteLibrarySourceId(String backendTypeName) =>
+    'cloud:$backendTypeName';

--- a/hibiki/lib/src/sync/remote_video_client.dart
+++ b/hibiki/lib/src/sync/remote_video_client.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 
 /// **任何**远端视频来源都具备的能力：列清单 + 按 id 把整片下载到本地。
 ///
@@ -19,7 +20,7 @@ import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 /// 把「能力靠 `is` 判断」换成「调了会抛」，编译器照样拦不住。按能力分级之后，
 /// `source is RemoteVideoClient` 是**类型系统认可**的能力判据——拿不到 live 能力的
 /// 地方根本调不出流播/字幕/断点方法。
-abstract class RemoteVideoSource {
+abstract class RemoteVideoSource implements RemoteLibrarySource {
   /// 列出该源可见的远端视频。云盘源在这里就把目录清单适配成 [RemoteVideoInfo]，
   /// 消费方（库页）不再需要知道 manifest 长什么样。
   Future<List<RemoteVideoInfo>> listRemoteVideos();

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+962
+version: 1.3.1+963
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/home_video_cloud_download_test.dart
+++ b/hibiki/test/pages/home_video_cloud_download_test.dart
@@ -17,7 +17,9 @@ import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/sync/cloud_remote_video_client.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/interconnect_download_manager.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/sync_asset_store.dart';
+import 'package:hibiki/src/sync/sync_backend.dart' show SyncBackendType;
 import 'package:hibiki/src/sync/video_manifest.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -263,6 +265,13 @@ class _FakeCloudRemoteVideoClient implements CloudRemoteVideoClient {
 
   @override
   SyncAssetStore get backend => throw UnimplementedError();
+
+  @override
+  SyncBackendType get backendType => SyncBackendType.webDav;
+
+  @override
+  String get remoteLibrarySourceId =>
+      cloudRemoteLibrarySourceId(backendType.name);
 
   @override
   Future<List<RemoteVideoManifestEntry>> listRemoteVideoManifest() async =>

--- a/hibiki/test/pages/home_video_cover_badge_test.dart
+++ b/hibiki/test/pages/home_video_cover_badge_test.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/src/pages/implementations/home_video_page.dart';
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki/src/utils/components/cover_badge.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -153,6 +154,9 @@ void main() {
 
 class _FakeRemoteVideoClient implements RemoteVideoClient {
   _FakeRemoteVideoClient();
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => <RemoteVideoInfo>[

--- a/hibiki/test/pages/home_video_interconnect_manager_test.dart
+++ b/hibiki/test/pages/home_video_interconnect_manager_test.dart
@@ -12,6 +12,7 @@ import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_video_page.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/interconnect_download_manager.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:drift/native.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -136,6 +137,9 @@ void main() {
 
 class _GatedClient implements RemoteVideoClient {
   final Completer<void> completer = Completer<void>();
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => <RemoteVideoInfo>[

--- a/hibiki/test/pages/home_video_remote_collection_membership_test.dart
+++ b/hibiki/test/pages/home_video_remote_collection_membership_test.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/src/pages/implementations/home_video_page.dart';
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -200,6 +201,9 @@ void main() {
 class _ListFakeRemoteVideoClient implements RemoteVideoClient {
   _ListFakeRemoteVideoClient(this._videos);
   final List<RemoteVideoInfo> _videos;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => _videos;

--- a/hibiki/test/pages/home_video_remote_download_dedup_test.dart
+++ b/hibiki/test/pages/home_video_remote_download_dedup_test.dart
@@ -14,6 +14,7 @@ import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_video_page.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -153,6 +154,9 @@ class _ListFakeRemoteVideoClient implements RemoteVideoClient {
   final List<RemoteVideoInfo> _videos;
 
   @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
+  @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => _videos;
 
   @override
@@ -196,6 +200,9 @@ class _ListFakeRemoteVideoClient implements RemoteVideoClient {
 
 class _GatedFakeRemoteVideoClient implements RemoteVideoClient {
   final Completer<void> completer = Completer<void>();
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => <RemoteVideoInfo>[

--- a/hibiki/test/pages/home_video_remote_download_register_test.dart
+++ b/hibiki/test/pages/home_video_remote_download_register_test.dart
@@ -13,6 +13,7 @@ import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_video_page.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/interconnect_download_manager.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -202,6 +203,9 @@ class _FakeRemoteVideoClient implements RemoteVideoClient {
 
   final List<RemoteVideoInfo> videos;
   final String? subtitleContent;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => videos;

--- a/hibiki/test/pages/home_video_remote_interconnect_test.dart
+++ b/hibiki/test/pages/home_video_remote_interconnect_test.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -213,6 +214,9 @@ class _FakeRemoteVideoClient implements RemoteVideoClient {
   final List<String> downloadedIds = <String>[];
   final List<String> streamUrlRequests = <String>[];
   final List<String> subtitleDestinations = <String>[];
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => <RemoteVideoInfo>[

--- a/hibiki/test/pages/home_video_remote_mixed_grid_test.dart
+++ b/hibiki/test/pages/home_video_remote_mixed_grid_test.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/src/pages/implementations/home_video_page.dart';
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -235,6 +236,9 @@ class _ListFakeRemoteVideoClient implements RemoteVideoClient {
   final List<RemoteVideoInfo> _videos;
 
   @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
+  @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => _videos;
 
   @override
@@ -276,6 +280,9 @@ class _ListFakeRemoteVideoClient implements RemoteVideoClient {
 
 /// listRemoteVideos 抛异常 → 页面走 failed 门控（占位卡不出现）。
 class _ThrowingRemoteVideoClient implements RemoteVideoClient {
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async =>
       throw const SocketException('offline');

--- a/hibiki/test/pages/home_video_remote_source_switch_test.dart
+++ b/hibiki/test/pages/home_video_remote_source_switch_test.dart
@@ -1,0 +1,410 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/anki/anki_view_model.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/home_page.dart';
+import 'package:hibiki/src/pages/implementations/home_video_page.dart';
+import 'package:hibiki/src/platform/platform_providers.dart';
+import 'package:hibiki/src/platform/platform_services.dart';
+import 'package:hibiki/src/sync/cloud_remote_video_client.dart';
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
+import 'package:hibiki/src/sync/remote_video_client.dart';
+import 'package:hibiki/src/sync/sync_asset_store.dart';
+import 'package:hibiki/src/sync/sync_backend.dart' show SyncBackendType;
+import 'package:hibiki/src/sync/video_manifest.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1202 行为守卫：换远端来源之后，视频库里出现的必须是**当前来源**的条目。
+///
+/// 真实缺陷路径（develop `fdd71adcb`）——`_loadRemoteVideos` 的取数主干是
+/// `_resolveRemoteVideoClient() ?? _resolveCloudRemoteVideoClient()`（TODO-2119 把
+/// 双分支塌缩成一条），而共享 TTL 缓存只按「域」分槽（`videos` 一个槽），互联与云盘
+/// 两种源都往里写。于是：
+///
+///   ① 互联启用 → 视频页拉对端清单 → 写进 videos 槽（60s 新鲜）
+///   ② 用户关掉互联开关 → `_resolveRemoteVideoClient` 在
+///      `isInterconnectEnabled()` 为 false 时**先 return null，压根不调 restoreAuth**，
+///      所以 `InterconnectSyncBackend.sessionIdentityRevision` 不会自增
+///   ③ 切走再切回视频 tab（[BaseModuleTabPageState.onTabActivated]）→ 走云盘分支 →
+///      `read(key: videos)` 命中①那份缓存，`fetch` 根本不执行
+///   ④ 用户在「云视频」视图里看到互联对端的片子，且不报错
+///
+/// 唯一的失效信号挂在互联内部，翻开关 / 换云盘后端都不经过它——所以这条不能靠
+/// 「记得在切换入口失效」来治，得让两种源在数据结构上就不共用槽（`sourceId`）。
+///
+/// **这条断言锁的是内容归属，不是「缓存清空了」**：把修复退回去（`read` 不按
+/// sourceId 分槽）时，槽仍然是 fresh 的、页面照样渲染出卡片——错在渲染出的是**上一个
+/// 来源**的卡片。只断言「远端区为空」或「缓存被清了」都抓不住这个缺陷。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_remote_switch_pp');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      try {
+        pathProviderDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  late HibikiDatabase db;
+  late PreferencesRepository prefs;
+  late PlatformServices platformServices;
+  late FakeAnkiRepository ankiRepository;
+  late AppModel appModel;
+  late Directory storeDir;
+  late VideoBookRepository repo;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir =
+        Directory.systemTemp.createTempSync('hibiki_remote_switch_store');
+    platformServices = testPlatformServices();
+    ankiRepository = FakeAnkiRepository();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+    repo = VideoBookRepository(db);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (storeDir.existsSync()) storeDir.deleteSync(recursive: true);
+  });
+
+  /// 「切走再切回视频 tab」——推的是生产里那个真信号 [homeShellTabNotifier]，由
+  /// `BaseModuleTabPageState` 监听后回调 `onTabActivated()`（BUG-994 的保活刷新范式），
+  /// 不是测试直接去戳页面的私有/受保护方法。
+  ///
+  /// 走的是**非** forceRefresh 的读，正是会命中 TTL 缓存的那条路；下拉刷新
+  /// （forceRefresh: true）无条件穿透缓存、会掩盖缺陷，所以这里不能用它。
+  Future<void> reactivateTab(WidgetTester tester) async {
+    homeShellTabNotifier.value = HomeTab.books;
+    homeShellTabNotifier.value = HomeTab.video;
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() => homeShellTabNotifier.value = HomeTab.video);
+
+  testWidgets('BUG-1202: 关掉互联后视频库显示云盘的片子，不是上一个来源的', (tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    // 互联开关：由测试直接翻，模拟用户去设置页关掉「互联」。翻它**不会**触碰
+    // InterconnectSyncBackend，所以没有任何缓存失效发生——这正是缺陷成立的前提。
+    bool interconnectEnabled = true;
+
+    final _FakeInterconnectVideoClient interconnect =
+        _FakeInterconnectVideoClient(<RemoteVideoInfo>[
+      const RemoteVideoInfo(id: 'peer-only-vid', title: '对端才有的片子'),
+    ]);
+    final _FakeCloudVideoSource cloud = _FakeCloudVideoSource(<RemoteVideoInfo>[
+      const RemoteVideoInfo(id: 'cloud-only-vid', title: '云盘才有的片子'),
+    ]);
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[
+        platformServicesProvider.overrideWithValue(platformServices),
+        ankiRepositoryProvider.overrideWithValue(ankiRepository),
+        appProvider.overrideWith((ref) => appModel),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: HomeVideoPage(
+              repo: repo,
+              // 互联启用时给互联 client；关掉后返 null → 页面回退云盘分支，
+              // 与生产的 `_resolveRemoteVideoClient` 语义一致。
+              remoteVideoClientLoader: () async =>
+                  interconnectEnabled ? interconnect : null,
+              cloudRemoteVideoClientLoader: () async => cloud,
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    // ① 互联来源：对端的片子在场。
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_peer-only-vid')),
+      findsOneWidget,
+      reason: '前提：互联启用时先渲染出对端条目，缓存里因此装着互联的清单',
+    );
+    expect(interconnect.listCalls, 1);
+
+    // ② 用户关掉互联开关。时钟没动，互联那份缓存仍在 60s TTL 内。
+    interconnectEnabled = false;
+
+    // ③ 切走再切回视频 tab。
+    await reactivateTab(tester);
+
+    // ④ 断言内容归属：看到的必须是云盘的片子，且对端那张卡必须消失。
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_cloud-only-vid')),
+      findsOneWidget,
+      reason: 'BUG-1202：云盘视图必须渲染云盘自己的条目',
+    );
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_peer-only-vid')),
+      findsNothing,
+      reason: 'BUG-1202：关掉互联后不得再看到互联对端的条目（缓存串味）',
+    );
+    expect(find.text('云盘才有的片子'), findsOneWidget);
+    expect(find.text('对端才有的片子'), findsNothing);
+    expect(
+      cloud.listCalls,
+      1,
+      reason: '云盘是另一个槽，必须真去问云盘要清单，而不是复用互联那份缓存',
+    );
+  });
+
+  testWidgets('BUG-1202: 反向——云盘视图开启互联后显示对端的片子', (tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    bool interconnectEnabled = false;
+
+    final _FakeInterconnectVideoClient interconnect =
+        _FakeInterconnectVideoClient(<RemoteVideoInfo>[
+      const RemoteVideoInfo(id: 'peer-only-vid', title: '对端才有的片子'),
+    ]);
+    final _FakeCloudVideoSource cloud = _FakeCloudVideoSource(<RemoteVideoInfo>[
+      const RemoteVideoInfo(id: 'cloud-only-vid', title: '云盘才有的片子'),
+    ]);
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[
+        platformServicesProvider.overrideWithValue(platformServices),
+        ankiRepositoryProvider.overrideWithValue(ankiRepository),
+        appProvider.overrideWith((ref) => appModel),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: HomeVideoPage(
+              repo: repo,
+              remoteVideoClientLoader: () async =>
+                  interconnectEnabled ? interconnect : null,
+              cloudRemoteVideoClientLoader: () async => cloud,
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_cloud-only-vid')),
+      findsOneWidget,
+      reason: '前提：先用云盘来源把清单缓存热起来',
+    );
+
+    // 用户打开互联开关。重新 restoreAuth 时 _sessionSignature 与上次相同（地址/令牌
+    // 都没改）→ revision 不自增 → 同样没有失效兜底。
+    interconnectEnabled = true;
+    await reactivateTab(tester);
+
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_peer-only-vid')),
+      findsOneWidget,
+      reason: 'BUG-1202：互联视图必须渲染对端自己的条目',
+    );
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_cloud-only-vid')),
+      findsNothing,
+      reason: 'BUG-1202：开启互联后不得再看到云盘的条目（缓存串味）',
+    );
+  });
+
+  testWidgets('BUG-1202: 同来源反复切 tab 仍复用缓存（没把 BUG-1180 弄丢）', (tester) async {
+    tester.view.physicalSize = const Size(1280, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final _FakeInterconnectVideoClient interconnect =
+        _FakeInterconnectVideoClient(<RemoteVideoInfo>[
+      const RemoteVideoInfo(id: 'peer-only-vid', title: '对端才有的片子'),
+    ]);
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[
+        platformServicesProvider.overrideWithValue(platformServices),
+        ankiRepositoryProvider.overrideWithValue(ankiRepository),
+        appProvider.overrideWith((ref) => appModel),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: HomeVideoPage(
+              repo: repo,
+              remoteVideoClientLoader: () async => interconnect,
+            ),
+          ),
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(interconnect.listCalls, 1);
+
+    await reactivateTab(tester);
+    await reactivateTab(tester);
+
+    expect(
+      interconnect.listCalls,
+      1,
+      reason: 'BUG-1180：同来源 TTL 内切回 tab 不得重打网络——分槽修复不能把它弄丢',
+    );
+    expect(
+      find.byKey(const ValueKey<String>('remote_video_card_peer-only-vid')),
+      findsOneWidget,
+    );
+  });
+}
+
+/// 互联对端 live 库的 fake。只实现清单能力，其余 live 端点本用例不触碰。
+class _FakeInterconnectVideoClient implements RemoteVideoClient {
+  _FakeInterconnectVideoClient(this.videos);
+
+  final List<RemoteVideoInfo> videos;
+  int listCalls = 0;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async {
+    listCalls++;
+    return videos;
+  }
+
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<RemoteVideoStreamUrls> remoteVideoStreamUrls(
+    String id, {
+    int episodeIndex = 0,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> getRemoteVideoSubtitle(
+    String id,
+    File dest, {
+    int? embeddedStreamIndex,
+    int episodeIndex = 0,
+    void Function(double progress)? onProgress,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<({int positionMs, int updatedAtMs})> remoteVideoPosition(
+    String id, {
+    int episodeIndex = 0,
+  }) async =>
+      (positionMs: 0, updatedAtMs: 0);
+
+  @override
+  Future<void> putRemoteVideoPosition(
+    String id,
+    int positionMs,
+    int updatedAtMs, {
+    int episodeIndex = 0,
+  }) async {}
+}
+
+/// 云盘目录源的 fake。页面的 `cloudRemoteVideoClientLoader` 收的是具体类
+/// [CloudRemoteVideoClient]，故用 `implements` 覆盖其公共面；本用例只走清单一条路，
+/// 下载/封面路径由 `home_video_cloud_download_test.dart` 覆盖。
+class _FakeCloudVideoSource implements CloudRemoteVideoClient {
+  _FakeCloudVideoSource(this.videos);
+
+  final List<RemoteVideoInfo> videos;
+  int listCalls = 0;
+
+  @override
+  SyncAssetStore get backend => throw UnimplementedError();
+
+  /// 与 [remoteLibrarySourceId] 保持同源：这个 fake 冒充的是 Google Drive 后端。
+  @override
+  SyncBackendType get backendType => SyncBackendType.googleDrive;
+
+  @override
+  String get remoteLibrarySourceId =>
+      cloudRemoteLibrarySourceId(backendType.name);
+
+  @override
+  Future<List<RemoteVideoManifestEntry>> listRemoteVideoManifest() async =>
+      throw UnimplementedError();
+
+  @override
+  Future<List<RemoteVideoInfo>> listRemoteVideos() async {
+    listCalls++;
+    return videos;
+  }
+
+  @override
+  Future<void> downloadRemoteVideo(
+    String id,
+    File dest, {
+    void Function(double progress)? onProgress,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<void> getRemoteVideo(
+    String uid,
+    File destination, {
+    void Function(double progress)? onProgress,
+  }) async =>
+      throw UnimplementedError();
+
+  @override
+  Future<bool> getRemoteVideoCover(
+    String uid,
+    File destination, {
+    void Function(double progress)? onProgress,
+  }) async =>
+      false;
+}

--- a/hibiki/test/pages/reader_remote_collection_membership_test.dart
+++ b/hibiki/test/pages/reader_remote_collection_membership_test.dart
@@ -12,6 +12,7 @@ import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/ttu_filename.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -202,6 +203,9 @@ class _ListFakeRemoteBookClient implements RemoteBookClient {
   @override
   RemoteBookSourceKind get remoteSourceKind =>
       RemoteBookSourceKind.interconnect;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteBookInfo>> listRemoteBooks() async => _books;

--- a/hibiki/test/pages/reader_remote_download_dedup_test.dart
+++ b/hibiki/test/pages/reader_remote_download_dedup_test.dart
@@ -13,6 +13,7 @@ import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/ttu_filename.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -162,6 +163,9 @@ class _ListFakeRemoteBookClient implements RemoteBookClient {
       RemoteBookSourceKind.interconnect;
 
   @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
+  @override
   Future<List<RemoteBookInfo>> listRemoteBooks() async => _books;
 
   @override
@@ -190,6 +194,9 @@ class _GatedFakeRemoteBookClient implements RemoteBookClient {
   @override
   RemoteBookSourceKind get remoteSourceKind =>
       RemoteBookSourceKind.interconnect;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteBookInfo>> listRemoteBooks() async => <RemoteBookInfo>[

--- a/hibiki/test/pages/reader_remote_interconnect_test.dart
+++ b/hibiki/test/pages/reader_remote_interconnect_test.dart
@@ -16,6 +16,7 @@ import 'package:hibiki/src/pages/implementations/home_page.dart'
 import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/ttu_filename.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -651,6 +652,9 @@ class _FakeRemoteBookClient implements RemoteBookClient {
 
   @override
   RemoteBookSourceKind get remoteSourceKind => sourceKind;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   // BUG-992：listRemoteBooks 调用次数（观测「切回书架 tab 自动重拉远端」）。
   int listRemoteBooksCalls = 0;

--- a/hibiki/test/pages/reader_remote_mixed_grid_test.dart
+++ b/hibiki/test/pages/reader_remote_mixed_grid_test.dart
@@ -12,6 +12,7 @@ import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/ttu_filename.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -194,6 +195,9 @@ class _ListFakeRemoteBookClient implements RemoteBookClient {
       RemoteBookSourceKind.interconnect;
 
   @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
+  @override
   Future<List<RemoteBookInfo>> listRemoteBooks() async => _books;
 
   @override
@@ -221,6 +225,9 @@ class _ThrowingRemoteBookClient implements RemoteBookClient {
   @override
   RemoteBookSourceKind get remoteSourceKind =>
       RemoteBookSourceKind.interconnect;
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteBookInfo>> listRemoteBooks() async =>

--- a/hibiki/test/pages/remote_card_longpress_dialog_test.dart
+++ b/hibiki/test/pages/remote_card_longpress_dialog_test.dart
@@ -16,6 +16,7 @@ import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart
 import 'package:hibiki/src/pages/implementations/video_hibiki_page.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -211,6 +212,9 @@ class _FakeRemoteBookClient implements RemoteBookClient {
       RemoteBookSourceKind.interconnect;
 
   @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
+
+  @override
   Future<List<RemoteBookInfo>> listRemoteBooks() async => <RemoteBookInfo>[
         RemoteBookInfo.fromJson(<String, Object?>{
           'title': 'Remote Book',
@@ -249,6 +253,9 @@ class _FakeRemoteVideoClient implements RemoteVideoClient {
 
   final String coverPath;
   final List<String> streamUrlRequests = <String>[];
+
+  @override
+  String get remoteLibrarySourceId => kInterconnectRemoteLibrarySourceId;
 
   @override
   Future<List<RemoteVideoInfo>> listRemoteVideos() async => <RemoteVideoInfo>[

--- a/hibiki/test/sync/cloud_remote_book_client_test.dart
+++ b/hibiki/test/sync/cloud_remote_book_client_test.dart
@@ -236,8 +236,11 @@ void main() {
           'fid_b': <AssetEntry>[_epub('cover_b', 'cover.jpg')],
         },
       );
-      final client =
-          CloudRemoteBookClient(backend: backend, rootFolderId: 'root');
+      final client = CloudRemoteBookClient(
+        backend: backend,
+        rootFolderId: 'root',
+        backendType: SyncBackendType.webDav,
+      );
 
       final List<RemoteBookInfo> books = await client.listRemoteBooks();
 
@@ -266,8 +269,11 @@ void main() {
           'fid_real': <AssetEntry>[_epub('asset_real', 'Real Book.epub')],
         },
       );
-      final client =
-          CloudRemoteBookClient(backend: backend, rootFolderId: 'root');
+      final client = CloudRemoteBookClient(
+        backend: backend,
+        rootFolderId: 'root',
+        backendType: SyncBackendType.webDav,
+      );
 
       final List<RemoteBookInfo> books = await client.listRemoteBooks();
 
@@ -292,6 +298,7 @@ void main() {
       final client = CloudRemoteBookClient(
         backend: backend,
         rootFolderId: 'root',
+        backendType: SyncBackendType.webDav,
         contentProbeRetryBackoff: Duration.zero,
       );
 
@@ -325,6 +332,7 @@ void main() {
       final client = CloudRemoteBookClient(
         backend: backend,
         rootFolderId: 'root',
+        backendType: SyncBackendType.webDav,
         contentProbeRetryBackoff: Duration.zero,
       );
 
@@ -349,6 +357,7 @@ void main() {
       final client = CloudRemoteBookClient(
         backend: backend,
         rootFolderId: 'root',
+        backendType: SyncBackendType.webDav,
         contentProbeConcurrency: 3,
       );
 
@@ -373,8 +382,11 @@ void main() {
           ],
         },
       );
-      final client =
-          CloudRemoteBookClient(backend: backend, rootFolderId: 'root');
+      final client = CloudRemoteBookClient(
+        backend: backend,
+        rootFolderId: 'root',
+        backendType: SyncBackendType.webDav,
+      );
       final Directory tmp =
           Directory.systemTemp.createTempSync('cloud_remote_book_dl');
       addTearDown(() {
@@ -399,8 +411,11 @@ void main() {
           'fid_empty': <AssetEntry>[_epub('cover', 'cover.jpg')],
         },
       );
-      final client =
-          CloudRemoteBookClient(backend: backend, rootFolderId: 'root');
+      final client = CloudRemoteBookClient(
+        backend: backend,
+        rootFolderId: 'root',
+        backendType: SyncBackendType.webDav,
+      );
       final Directory tmp =
           Directory.systemTemp.createTempSync('cloud_remote_book_empty');
       addTearDown(() {

--- a/hibiki/test/sync/remote_library_cache_test.dart
+++ b/hibiki/test/sync/remote_library_cache_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
 import 'package:hibiki/src/sync/remote_library_cache.dart';
+import 'package:hibiki/src/sync/remote_library_source.dart';
 
 /// BUG-1180 根因守卫：远端库列表的 TTL 缓存 + in-flight 去重 + 显式失效。
 ///
@@ -12,12 +13,18 @@ import 'package:hibiki/src/sync/remote_library_cache.dart';
 /// 对端新增内容可见（BUG-992/994）各注册了「切回本 tab 就重拉」的监听器，顶层 tab
 /// 保活（BUG-750）省下的重建被原样加了回来。
 ///
+/// BUG-1202 追加：槽由 (来源身份, 域) 联合定位，互联与云盘不再共用一个域槽。
+///
 /// 本文件锁住缓存本身的语义；页面接线由 `reader_remote_interconnect_test.dart` /
-/// `home_video_remote_interconnect_test.dart` 覆盖。
+/// `home_video_remote_interconnect_test.dart` /
+/// `home_video_remote_source_switch_test.dart` 覆盖。
 void main() {
   /// 可控时钟：TTL 相关断言不能依赖真实墙钟（既慢又 flaky）。
   late int now;
   late RemoteLibraryCache cache;
+
+  /// 本文件里绝大多数用例只关心「一个来源内部」的语义，统一用互联身份。
+  const String ic = kInterconnectRemoteLibrarySourceId;
 
   setUp(() {
     now = 1000000;
@@ -34,11 +41,17 @@ void main() {
       return <String>['a'];
     }
 
-    expect(await cache.read(key: 'books', fetch: fetch), <String>['a']);
+    expect(
+      await cache.read(sourceId: ic, key: 'books', fetch: fetch),
+      <String>['a'],
+    );
     expect(calls, 1);
 
     now += 59 * 1000; // 仍在 60s TTL 内
-    expect(await cache.read(key: 'books', fetch: fetch), <String>['a']);
+    expect(
+      await cache.read(sourceId: ic, key: 'books', fetch: fetch),
+      <String>['a'],
+    );
     expect(calls, 1, reason: 'TTL 内必须命中缓存，不得再联网');
   });
 
@@ -46,10 +59,16 @@ void main() {
     int calls = 0;
     Future<List<String>> fetch() async => <String>['v${++calls}'];
 
-    expect(await cache.read(key: 'books', fetch: fetch), <String>['v1']);
+    expect(
+      await cache.read(sourceId: ic, key: 'books', fetch: fetch),
+      <String>['v1'],
+    );
     now += 61 * 1000;
-    expect(await cache.read(key: 'books', fetch: fetch), <String>['v2'],
-        reason: 'TTL 过期必须重新取数，否则对端新增的书永远看不到');
+    expect(
+      await cache.read(sourceId: ic, key: 'books', fetch: fetch),
+      <String>['v2'],
+      reason: 'TTL 过期必须重新取数，否则对端新增的书永远看不到',
+    );
     expect(calls, 2);
   });
 
@@ -57,15 +76,20 @@ void main() {
     int calls = 0;
     Future<List<String>> fetch() async => <String>['v${++calls}'];
 
-    await cache.read(key: 'books', fetch: fetch);
+    await cache.read(sourceId: ic, key: 'books', fetch: fetch);
     expect(
-      await cache.read(key: 'books', fetch: fetch, forceRefresh: true),
+      await cache.read(
+        sourceId: ic,
+        key: 'books',
+        fetch: fetch,
+        forceRefresh: true,
+      ),
       <String>['v2'],
     );
     expect(calls, 2);
   });
 
-  test('in-flight 去重：同 key 并发只打一枪，双方拿到同一结果', () async {
+  test('in-flight 去重：同槽并发只打一枪，双方拿到同一结果', () async {
     int calls = 0;
     final Completer<List<String>> gate = Completer<List<String>>();
     Future<List<String>> fetch() {
@@ -74,9 +98,11 @@ void main() {
     }
 
     // 书架与首页 dashboard 同帧各问一次远端书清单。
-    final Future<List<String>> first = cache.read(key: 'books', fetch: fetch);
-    final Future<List<String>> second = cache.read(key: 'books', fetch: fetch);
-    expect(calls, 1, reason: '同 key 有请求在途时不得再发一枪');
+    final Future<List<String>> first =
+        cache.read(sourceId: ic, key: 'books', fetch: fetch);
+    final Future<List<String>> second =
+        cache.read(sourceId: ic, key: 'books', fetch: fetch);
+    expect(calls, 1, reason: '同槽有请求在途时不得再发一枪');
 
     gate.complete(<String>['shared']);
     expect(await first, <String>['shared']);
@@ -91,13 +117,13 @@ void main() {
     }
 
     await expectLater(
-      cache.read(key: 'books', fetch: failing),
+      cache.read(sourceId: ic, key: 'books', fetch: failing),
       throwsA(isA<StateError>()),
     );
-    expect(cache.isFresh('books'), isFalse);
+    expect(cache.isFresh(ic, 'books'), isFalse);
 
     await expectLater(
-      cache.read(key: 'books', fetch: failing),
+      cache.read(sourceId: ic, key: 'books', fetch: failing),
       throwsA(isA<StateError>()),
     );
     expect(calls, 2, reason: '失败不得被当成缓存值，下一次读必须重试');
@@ -110,38 +136,44 @@ void main() {
       return <String>['ok'];
     }
 
-    await cache.read(key: 'books', fetch: fetch);
+    await cache.read(sourceId: ic, key: 'books', fetch: fetch);
     now += 61 * 1000; // 过期
     shouldFail = true;
     await expectLater(
-      cache.read(key: 'books', fetch: fetch),
+      cache.read(sourceId: ic, key: 'books', fetch: fetch),
       throwsA(isA<StateError>()),
     );
 
     // 失败没有刷新 fetchedAt，也没有抹掉旧值：调用方可继续用上一次快照渲染。
     shouldFail = false;
-    expect(await cache.read(key: 'books', fetch: fetch), <String>['ok']);
+    expect(
+      await cache.read(sourceId: ic, key: 'books', fetch: fetch),
+      <String>['ok'],
+    );
   });
 
-  test('invalidate 作废单 key，不牵连其它域', () async {
+  test('invalidate 作废单槽，不牵连其它域', () async {
     int bookCalls = 0;
     int videoCalls = 0;
 
     await cache.read(
+      sourceId: ic,
       key: RemoteLibraryCacheKeys.books,
       fetch: () async => <String>['b${++bookCalls}'],
     );
     await cache.read(
+      sourceId: ic,
       key: RemoteLibraryCacheKeys.videos,
       fetch: () async => <String>['v${++videoCalls}'],
     );
 
-    cache.invalidate(RemoteLibraryCacheKeys.books);
-    expect(cache.isFresh(RemoteLibraryCacheKeys.books), isFalse);
-    expect(cache.isFresh(RemoteLibraryCacheKeys.videos), isTrue,
+    cache.invalidate(ic, RemoteLibraryCacheKeys.books);
+    expect(cache.isFresh(ic, RemoteLibraryCacheKeys.books), isFalse);
+    expect(cache.isFresh(ic, RemoteLibraryCacheKeys.videos), isTrue,
         reason: '失效一个域不得连带清掉别的域');
 
     await cache.read(
+      sourceId: ic,
       key: RemoteLibraryCacheKeys.books,
       fetch: () async => <String>['b${++bookCalls}'],
     );
@@ -149,24 +181,34 @@ void main() {
     expect(videoCalls, 1);
   });
 
-  test('invalidateAll 清空全部（换对端 / 管理互联源）', () async {
+  test('invalidateAll 清空全部来源与全部域（换对端 / 管理互联源）', () async {
     await cache.read(
+      sourceId: ic,
       key: RemoteLibraryCacheKeys.books,
       fetch: () async => <String>['b'],
     );
     await cache.read(
+      sourceId: cloudRemoteLibrarySourceId('googleDrive'),
       key: RemoteLibraryCacheKeys.videos,
       fetch: () async => <String>['v'],
     );
 
     cache.invalidateAll();
-    expect(cache.isFresh(RemoteLibraryCacheKeys.books), isFalse);
-    expect(cache.isFresh(RemoteLibraryCacheKeys.videos), isFalse);
+    expect(cache.isFresh(ic, RemoteLibraryCacheKeys.books), isFalse);
+    expect(
+      cache.isFresh(
+        cloudRemoteLibrarySourceId('googleDrive'),
+        RemoteLibraryCacheKeys.videos,
+      ),
+      isFalse,
+      reason: 'invalidateAll 必须跨来源清干净，否则换对端只清掉一半',
+    );
   });
 
   test('在途请求被 invalidate 后，其结果不得写回缓存（generation 守卫）', () async {
     final Completer<List<String>> slow = Completer<List<String>>();
     final Future<List<String>> pending = cache.read(
+      sourceId: ic,
       key: 'books',
       fetch: () => slow.future,
     );
@@ -175,7 +217,7 @@ void main() {
     cache.invalidateAll();
     slow.complete(<String>['stale-peer']);
     expect(await pending, <String>['stale-peer'], reason: '发起方仍拿到自己那次取数的结果');
-    expect(cache.isFresh('books'), isFalse,
+    expect(cache.isFresh(ic, 'books'), isFalse,
         reason: '过时结果不得写回缓存，否则 TTL 内会拿上一台 host 的清单渲染');
   });
 
@@ -184,10 +226,12 @@ void main() {
     final Completer<List<String>> fastNew = Completer<List<String>>();
 
     final Future<List<String>> old = cache.read(
+      sourceId: ic,
       key: 'books',
       fetch: () => slowOld.future,
     );
     final Future<List<String>> fresh = cache.read(
+      sourceId: ic,
       key: 'books',
       fetch: () => fastNew.future,
       forceRefresh: true,
@@ -201,6 +245,7 @@ void main() {
     expect(await old, <String>['old']);
 
     final List<String> cached = await cache.read(
+      sourceId: ic,
       key: 'books',
       fetch: () async => throw StateError('不该重新取数'),
     );
@@ -209,10 +254,12 @@ void main() {
 
   test('不同 limit 的活动流分槽，互不污染', () async {
     await cache.read(
+      sourceId: ic,
       key: RemoteLibraryCacheKeys.activity(200),
       fetch: () async => List<int>.generate(200, (int i) => i),
     );
     final List<int> small = await cache.read(
+      sourceId: ic,
       key: RemoteLibraryCacheKeys.activity(20),
       fetch: () async => List<int>.generate(20, (int i) => i),
     );
@@ -220,8 +267,6 @@ void main() {
   });
 
   test('各媒体域分属不同 key，互不覆盖', () {
-    // 互联与云盘的视频清单**共用** videos 一个槽（TODO-2119 后两种源都实现
-    // RemoteVideoSource，元素统一是 RemoteVideoInfo）；域与域之间必须分开。
     final Set<String> keys = <String>{
       RemoteLibraryCacheKeys.books,
       RemoteLibraryCacheKeys.videos,
@@ -230,6 +275,107 @@ void main() {
       RemoteLibraryCacheKeys.activity(200),
     };
     expect(keys.length, 5, reason: '域 key 不得重名，否则一个域的清单会盖掉另一个域');
+  });
+
+  // ── BUG-1202：跨来源串味 ───────────────────────────────────────────
+  //
+  // 这几条锁的是**内容归属**，不是「缓存被清空了」。区别很要命：把修复退回去
+  // （`read` 不再按 sourceId 分槽）时，槽照样是「fresh」的——错就错在里面装的是
+  // 别人家的东西。只断言 isFresh / 断言清空，一条都抓不住。
+
+  test('BUG-1202: 互联拉过清单后，云盘那次读拿到的是云盘自己的内容', () async {
+    const String cloud = 'cloud:googleDrive';
+
+    // ① 互联启用时视频页拉过一次：缓存里现在是对端的片子。
+    final List<String> fromInterconnect = await cache.read(
+      sourceId: ic,
+      key: RemoteLibraryCacheKeys.videos,
+      fetch: () async => <String>['对端才有的片子'],
+    );
+    expect(fromInterconnect, <String>['对端才有的片子']);
+
+    // ② 用户关掉互联开关 → 视频页回退云盘分支。注意这里**没有任何失效发生**：
+    //    互联的 sessionIdentityRevision 只在互联内部自增，翻开关根本不经过它。
+    //    时钟也没往前走 —— 仍在 60s TTL 内，正是用户能撞上的窗口。
+    bool cloudFetched = false;
+    final List<String> fromCloud = await cache.read(
+      sourceId: cloud,
+      key: RemoteLibraryCacheKeys.videos,
+      fetch: () async {
+        cloudFetched = true;
+        return <String>['云盘才有的片子'];
+      },
+    );
+
+    expect(fromCloud, <String>['云盘才有的片子'],
+        reason: 'BUG-1202：云盘视图必须拿到云盘的清单，不得命中互联那份缓存');
+    expect(cloudFetched, isTrue, reason: '云盘是另一个槽，必须真去问云盘要，而不是复用互联的结果');
+    expect(fromCloud, isNot(contains('对端才有的片子')));
+  });
+
+  test('BUG-1202: 反向——云盘拉过清单后，互联那次读不得拿到云盘的条目', () async {
+    const String cloud = 'cloud:googleDrive';
+
+    await cache.read(
+      sourceId: cloud,
+      key: RemoteLibraryCacheKeys.books,
+      fetch: () async => <String>['云盘备份里的书'],
+    );
+
+    // 用户重新打开互联开关。首次 restoreAuth 之后 signature 与上次相同 → 不 bump
+    // revision，所以这里同样没有任何失效兜底。
+    final List<String> fromInterconnect = await cache.read(
+      sourceId: ic,
+      key: RemoteLibraryCacheKeys.books,
+      fetch: () async => <String>['对端在读的书'],
+    );
+
+    expect(fromInterconnect, <String>['对端在读的书'],
+        reason: 'BUG-1202：互联视图必须拿到对端的书，不得命中云盘那份缓存');
+  });
+
+  test('BUG-1202: 换云盘后端类型（Drive→WebDAV）落不同槽，各拿各的', () async {
+    final List<String> drive = await cache.read(
+      sourceId: cloudRemoteLibrarySourceId('googleDrive'),
+      key: RemoteLibraryCacheKeys.videos,
+      fetch: () async => <String>['Drive 上的片子'],
+    );
+    final List<String> webdav = await cache.read(
+      sourceId: cloudRemoteLibrarySourceId('webDav'),
+      key: RemoteLibraryCacheKeys.videos,
+      fetch: () async => <String>['WebDAV 上的片子'],
+    );
+
+    expect(drive, <String>['Drive 上的片子']);
+    expect(webdav, <String>['WebDAV 上的片子'],
+        reason: '换后端类型后两边的 __videos__ 内容毫无关系，共用一槽 60s 内会串味');
+  });
+
+  test('BUG-1202: 同来源同域仍然共享（缓存没被分槽分废）', () async {
+    int calls = 0;
+    Future<List<String>> fetch() async => <String>['v${++calls}'];
+
+    // 书架与首页 dashboard 都问互联要书清单 —— 必须命中同一个槽，这是 BUG-1180
+    // 省下的那一轮网络，不能被 BUG-1202 的分槽修复顺手弄丢。
+    await cache.read(
+      sourceId: ic,
+      key: RemoteLibraryCacheKeys.books,
+      fetch: fetch,
+    );
+    await cache.read(
+      sourceId: ic,
+      key: RemoteLibraryCacheKeys.books,
+      fetch: fetch,
+    );
+    expect(calls, 1, reason: '同来源同域必须还是一个槽，否则每页各拉一次，BUG-1180 白修');
+  });
+
+  test('BUG-1202: 来源身份与域名拼不出歧义槽', () async {
+    // 分隔符选错（比如直接字符串相加）时，('a', 'bc') 与 ('ab', 'c') 会撞成同一槽。
+    await cache.read(sourceId: 'a', key: 'bc', fetch: () async => 'first');
+    final String second =
+        await cache.read(sourceId: 'ab', key: 'c', fetch: () async => 'second');
+    expect(second, 'second', reason: '(来源, 域) 的拼接必须无歧义');
   });
 
   /// BUG-1180 接线守卫：provider 必须订阅「对端身份变了」的信号并整体失效。
@@ -245,15 +391,16 @@ void main() {
     final RemoteLibraryCache scoped =
         container.read(remoteLibraryCacheProvider);
     await scoped.read(
+      sourceId: ic,
       key: RemoteLibraryCacheKeys.books,
       fetch: () async => <String>['host-a 的书'],
     );
-    expect(scoped.isFresh(RemoteLibraryCacheKeys.books), isTrue);
+    expect(scoped.isFresh(ic, RemoteLibraryCacheKeys.books), isTrue);
 
     // 模拟「对端身份变了」——真实路径是 restoreAuth 里 _sessionSignature 比对失败。
     InterconnectSyncBackend.instance.sessionIdentityRevision.value++;
 
-    expect(scoped.isFresh(RemoteLibraryCacheKeys.books), isFalse,
+    expect(scoped.isFresh(ic, RemoteLibraryCacheKeys.books), isFalse,
         reason: 'BUG-1180：换对端后不得再拿上一台 host 的清单渲染');
   });
 }

--- a/hibiki/test/sync/sync_orchestrator_video_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_video_test.dart
@@ -141,8 +141,8 @@ void main() {
       expect(report.videosExported, 1);
 
       // Manifest present with one correct entry.
-      final CloudRemoteVideoClient client =
-          CloudRemoteVideoClient(backend: store);
+      final CloudRemoteVideoClient client = CloudRemoteVideoClient(
+          backend: store, backendType: SyncBackendType.webDav);
       final List<RemoteVideoManifestEntry> entries =
           await client.listRemoteVideoManifest();
       expect(entries.length, 1);
@@ -203,8 +203,8 @@ void main() {
           .syncVideoAssets(report);
       expect(report.errors, isEmpty, reason: report.errors.join(' | '));
 
-      final CloudRemoteVideoClient client =
-          CloudRemoteVideoClient(backend: store);
+      final CloudRemoteVideoClient client = CloudRemoteVideoClient(
+          backend: store, backendType: SyncBackendType.webDav);
       final RemoteVideoManifestEntry e =
           (await client.listRemoteVideoManifest()).single;
       expect(e.coverAsset, isNotNull);
@@ -278,7 +278,8 @@ void main() {
           .syncVideoAssets(report);
       expect(report.errors, isEmpty, reason: report.errors.join(' | '));
 
-      final Set<String> uids = (await CloudRemoteVideoClient(backend: store)
+      final Set<String> uids = (await CloudRemoteVideoClient(
+                  backend: store, backendType: SyncBackendType.webDav)
               .listRemoteVideoManifest())
           .map((RemoteVideoManifestEntry e) => e.uid)
           .toSet();
@@ -356,10 +357,10 @@ void main() {
       // Round 1: cover uploaded, manifest entry carries coverAsset.
       await _orchestrator(db, backend, tmp, syncVideoFiles: true)
           .syncVideoAssets(SyncRunReport());
-      final RemoteVideoManifestEntry e1 =
-          (await CloudRemoteVideoClient(backend: store)
-                  .listRemoteVideoManifest())
-              .single;
+      final RemoteVideoManifestEntry e1 = (await CloudRemoteVideoClient(
+                  backend: store, backendType: SyncBackendType.webDav)
+              .listRemoteVideoManifest())
+          .single;
       expect(e1.coverAsset, isNotNull);
 
       // Local cover file vanishes (moved/deleted on this device) before round 2.
@@ -368,10 +369,10 @@ void main() {
       // Round 2: manifest entry must still carry the coverAsset (not nulled).
       await _orchestrator(db, backend, tmp, syncVideoFiles: true)
           .syncVideoAssets(SyncRunReport());
-      final RemoteVideoManifestEntry e2 =
-          (await CloudRemoteVideoClient(backend: store)
-                  .listRemoteVideoManifest())
-              .single;
+      final RemoteVideoManifestEntry e2 = (await CloudRemoteVideoClient(
+                  backend: store, backendType: SyncBackendType.webDav)
+              .listRemoteVideoManifest())
+          .single;
       expect(e2.coverAsset, e1.coverAsset,
           reason:
               'missing local cover file must not wipe published coverAsset');
@@ -429,15 +430,15 @@ void main() {
   group('CloudRemoteVideoClient', () {
     test('empty backend lists nothing (never uploaded)', () async {
       final FakeAssetStore store = FakeAssetStore();
-      final CloudRemoteVideoClient client =
-          CloudRemoteVideoClient(backend: store);
+      final CloudRemoteVideoClient client = CloudRemoteVideoClient(
+          backend: store, backendType: SyncBackendType.webDav);
       expect(await client.listRemoteVideoManifest(), isEmpty);
     });
 
     test('download of unknown uid throws SyncBackendError', () async {
       final FakeAssetStore store = FakeAssetStore();
-      final CloudRemoteVideoClient client =
-          CloudRemoteVideoClient(backend: store);
+      final CloudRemoteVideoClient client = CloudRemoteVideoClient(
+          backend: store, backendType: SyncBackendType.webDav);
       await expectLater(
         client.getRemoteVideo('video/none', File('${work.path}/x.mp4')),
         throwsA(isA<SyncBackendError>()),


### PR DESCRIPTION
## 判定：真会串（不是防御性加固）

两种来源确实写进同一个 key。`PR#510`（TODO-2119，`b7a495bbd`）删掉 `cloudVideos` 槽后，视频页的取数主干

```dart
final RemoteVideoSource? source = await _resolveRemoteVideoClient() ??
    await _resolveCloudRemoteVideoClient();
await _remoteCache.read(key: RemoteLibraryCacheKeys.videos, fetch: source.listRemoteVideos);
```

对互联与云盘用同一个 `videos` 槽。**书侧更早**：`books` 槽从一开始就被 `InterconnectSyncBackend` 与 `CloudRemoteBookClient` 共用，不是 PR#510 引入的（原始描述这一点偏窄）。

唯一的自动失效挂在 `InterconnectSyncBackend.sessionIdentityRevision`，只在互联内部「地址/指纹/令牌变了」时自增。三条换来源的路都绕过它：

| 用户动作 | 为什么不失效 |
|---|---|
| 关互联开关 | `_resolveRemoteVideoClient` 在 `isInterconnectEnabled()` 为 false 时**先 return null，压根不调 `restoreAuth`** |
| 再开互联开关 | `restoreAuth` 跑了，但地址/令牌没改，signature 相同 → 不自增 |
| 换云盘后端类型 | 整条路径不碰 `InterconnectSyncBackend` |

### 触发序列（用户可复现）

前提：互联已配对并启用 + 云备份后端已配好 +「显示远端条目」开着。

1. 打开视频库 → 渲染互联对端的占位卡，`videos` 槽装着对端清单（60s 新鲜）
2. 设置页**关掉互联开关**（不改地址、不改令牌）
3. 60s 内切走再切回视频 tab（`onTabActivated`，非 forceRefresh 的读）
4. 页面走云盘分支，但 `read(key: videos)` 命中步骤 1 的缓存 → **「云视频」视图里出现互联对端的片子**，云角标俱全，不报错；点下载会向云盘要一个它根本没有的 uid

反向同理。书架与首页 dashboard 共用同一份缓存，同样受影响。

## 选了乙（缓存 key 带来源身份）

- **甲（恢复两个槽）只治一半**：双槽只区分「互联 vs 云盘」，`cloud_videos` 仍被所有云盘后端共用 → 换后端类型照样串。且 PR#510 的收敛本身是对的（元素类型已统一成 `RemoteVideoInfo`）。
- **丙（给云盘接失效信号）是老路**：`BUG-1180` 自己的注释就批判过「每个入口记得失效」并已经漏过一次；何况「翻互联开关」不属于任何一侧的「身份变了」，还得再补第三个信号。
- **乙从数据结构上消灭问题**：槽 = (来源身份, 域)，身份由来源自己申报，且声明成接口上的**抽象**成员 —— 新增任何远端源时编译器当场要求给出身份，「忘了分槽」这个失败模式不存在。

实现：新增 `RemoteLibrarySource.remoteLibrarySourceId`；`InterconnectSyncBackend` 报 `interconnect`（对端换人仍由 revision 兜底 —— 那是唯一权威判据，不重复造第二套推断），云 client 报 `cloud:<backendType>`（`backendType` 成为构造必填，由已经查过 `getBackendType()` 的调用方传入）；`RemoteLibraryCache.read/invalidate/isFresh` 增加 `sourceId` 维度。

同来源同域仍共享一个槽 —— BUG-1180 省下的那轮网络不受影响（有专门用例钉住）。

## 测试锁的是内容归属，不是「缓存清空了」

- `test/pages/home_video_remote_source_switch_test.dart`（新增）：切换来源后断言**渲染出的是哪一个来源的卡**，并推真信号 `homeShellTabNotifier` 而非直接戳受保护方法
- `test/sync/remote_library_cache_test.dart`：新增 5 条跨来源用例

**负向验证（两个方向）**：
- 把 `_slotKey` 退回 `=> key`（等价当前 develop 行为）→ **5 条转红**（3 缓存 + 2 页面），退出码 1。缓存用例的失败是 `Expected: ['云盘才有的片子'] Actual: ['对端才有的片子']`；页面用例的失败是「`remote_video_card_cloud-only-vid` 找到 0 个」—— 因为渲染的是互联那张卡。
- 还原 → **全绿**，退出码 0。

若只断言「远端区为空」或 `isFresh == false`，退回修复后**仍会通过**，抓不住这个缺陷。

## 已知残留（不在本轮范围）

同一云盘类型换账号（Drive A → Drive B）身份不变，60s TTL 内仍可能串。需要后端侧给出账号级身份信号，属独立议题；量级远小于本 PR 修掉的跨来源无限期串味。

## 验证（rebase 到 `e888da7c3` 之后重跑）

- `flutter analyze`（含 test）：**No issues found!**
- 定向 `test/sync/` + `test/pages/`：`FLUTTER TEST VERDICT: PASSED - 4133 tests ran, all tests passed`（退出码 0）
- `dart run tool/bug.dart check`：1161 条，号唯一，索引同步
- BUG 号 **1202**（原取 1200 与 PR#525 撞号，已 `renumber` —— 文件名 / 正文 H2 / 代码注释 / 测试名四处同改，零残留；1200 让回 PR#525）
- `+build` = `1.3.1+963`（develop 当前 +962）

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
