### PR TITLE
fix(gal-hook): capture Sasasa text and Unity resource audio

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1153 条。点号进各自文件。
+> 共 1154 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1189](bugs/BUG-1189-sasasa-unity-textmesh-glyphs.md) | ✅ | ✅ | Sasasa Unity TextMesh 对白被拆成单字 |
 | [BUG-1188](bugs/BUG-1188-dataroot-pick-layout-split.md) | ✅ | ✅ | 选目录迁移产出第三种布局，到不了新装形态（DB 被拖进文档目录） |
 | [BUG-1187](bugs/BUG-1187-gal-unvoiced-line-gets-bgm.md) | ✅ | ✅ | galgame 无配音句被整机混音兜底成 BGM |
 | [BUG-1186](bugs/BUG-1186-appbar-actions-collapse-uses-window-width.md) | ✅ | ✅ | AppBar 动作折叠判据读整窗宽，分栏/受限宽容器里永不折叠 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1154 条。点号进各自文件。
+> 共 1155 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1190](bugs/BUG-1190-sasasa-unity-resource-pcm-not-published.md) | ✅ | ✅ | Sasasa Unity 资源音频已解码但未写入音频环 |
 | [BUG-1189](bugs/BUG-1189-sasasa-unity-textmesh-glyphs.md) | ✅ | ✅ | Sasasa Unity TextMesh 对白被拆成单字 |
 | [BUG-1188](bugs/BUG-1188-dataroot-pick-layout-split.md) | ✅ | ✅ | 选目录迁移产出第三种布局，到不了新装形态（DB 被拖进文档目录） |
 | [BUG-1187](bugs/BUG-1187-gal-unvoiced-line-gets-bgm.md) | ✅ | ✅ | galgame 无配音句被整机混音兜底成 BGM |

--- a/docs/bugs/BUG-1189-sasasa-unity-textmesh-glyphs.md
+++ b/docs/bugs/BUG-1189-sasasa-unity-textmesh-glyphs.md
@@ -1,0 +1,13 @@
+## BUG-1189 · Sasasa Unity TextMesh 对白被拆成单字
+- **报告**：2026-07-28（用户反馈：最悪なる災厄人間に捧ぐ捕获异常）
+- **真实性**：✅ 真 bug。`native/galgame_hook/hook/adapters/unity_adapter.inc`
+  的 Unity 文本安装被整套 AudioClip API 前置校验阻断，且旧 KEMCO 运行时实际把一句
+  对白拆成多个 `UnityEngine.TextMesh.set_text` 单字调用。
+- **[x] ① 已修复** — 文本能力与 AudioClip 资源能力解耦；补充
+  `UnityEngine.UI.Text` / `UnityEngine.TextMesh`，并将以全角空格结束的 TextMesh
+  字形批次合并为稳定的 `Unity TextMesh line` 文本线程。
+- **[x] ② 已加自动化测试** — `native/galgame_hook/tests/adapter_structure_test.py`
+  守卫旧 Unity 类、文本先于音频安装、诊断位和字形合并边界。
+- **备注**：真实 x64 样本经 Hibiki“启动并捕获”进入存档对白，环形日志从 154 个单字
+  事件收敛到完整句子；同一会话再选择“当前游戏”外部窗口后，游戏 PID 与 injector PID
+  均未变化。按任务要求未跑全量测试或全量构建。

--- a/docs/bugs/BUG-1190-sasasa-unity-resource-pcm-not-published.md
+++ b/docs/bugs/BUG-1190-sasasa-unity-resource-pcm-not-published.md
@@ -1,0 +1,16 @@
+## BUG-1190 · Sasasa Unity 资源音频已解码但未写入音频环
+- **报告**：2026-07-28（用户反馈：游戏运行途中窗口消失，且音频获取不到）
+- **真实性**：✅ 真 bug。`native/galgame_hook/injector/injector_main.cpp:531`
+  的 `ExtractUnityVoice` 只验证解码后的 WAV 存在并设置资源诊断位，
+  `ProcessUnityVoiceEvents` 没有把 WAV PCM、格式和 `VoiceClip` 索引发布到共享内存；
+  真机探针因此同时出现“资源提取成功”与 `voice_clips=0 / total_written=0`。
+- **[x] ① 已修复** — 在 injector worker 解析 RIFF/WAVE，按音频环容量和帧边界有界读取，
+  通过原子预留写入主 PCM 环并最后提交 `VoiceClip.seq`；同时补齐旧 Unity 松散
+  `resources.assets` 的资源提取运行时和“窗口出现前不调用 IL2CPP API”的生命周期门。
+- **[x] ② 已加自动化测试** —
+  `native/galgame_hook/tests/adapter_structure_test.py:144` 守卫 WAV 校验、容量/帧对齐、
+  原子环写入、clip 完成标记顺序及提取成功必须提交 PCM 的契约。
+- **备注**：按用户要求未跑全量测试或全量构建。真实 x64 游戏由 Hibiki“启动并捕获”，
+  再从“选择目标窗口”绑定外部游戏；探针观察到对白资源 `09_leader1123` 产生
+  504,576 字节、44.1 kHz/双声道/16-bit 的 5.72 秒 clip，Hibiki 将对应台词标成
+  `game_resource · 音频就绪`，游戏进程保持响应。

--- a/hibiki/lib/src/mining/galgame_helper_installer.dart
+++ b/hibiki/lib/src/mining/galgame_helper_installer.dart
@@ -125,6 +125,21 @@ List<String> galgameHelperRequiredFiles(String arch) {
         'hibiki_voice_hook.dll',
         'LunaHook64.dll',
         'LunaHost64.dll',
+        'unity_audio_runtime/hibiki_unity_audio_extract.exe',
+        'unity_audio_runtime/classdata.tpk',
+        'unity_audio_runtime/vgmstream-cli.exe',
+        'unity_audio_runtime/avcodec-vgmstream-59.dll',
+        'unity_audio_runtime/avformat-vgmstream-59.dll',
+        'unity_audio_runtime/avutil-vgmstream-57.dll',
+        'unity_audio_runtime/swresample-vgmstream-4.dll',
+        'unity_audio_runtime/libatrac9.dll',
+        'unity_audio_runtime/libcelt-0061.dll',
+        'unity_audio_runtime/libcelt-0110.dll',
+        'unity_audio_runtime/libg719_decode.dll',
+        'unity_audio_runtime/libmpg123-0.dll',
+        'unity_audio_runtime/libspeex-1.dll',
+        'unity_audio_runtime/libvorbis.dll',
+        'unity_audio_runtime/COPYING',
       ];
     default:
       throw ArgumentError.value(arch, 'arch', 'unsupported helper arch');
@@ -137,9 +152,12 @@ List<String> galgameHelperMissingFiles(
   Iterable<String> presentFiles,
 ) {
   final Set<String> present =
-      presentFiles.map((String name) => name.toLowerCase()).toSet();
+      presentFiles
+          .map((String name) => name.replaceAll('\\', '/').toLowerCase())
+          .toSet();
   return galgameHelperRequiredFiles(arch)
-      .where((String name) => !present.contains(name.toLowerCase()))
+      .where((String name) =>
+          !present.contains(name.replaceAll('\\', '/').toLowerCase()))
       .toList(growable: false);
 }
 
@@ -490,9 +508,10 @@ class GalgameHelperInstaller {
       return galgameHelperRequiredFiles(arch);
     }
     final Iterable<String> present = dir
-        .listSync(followLinks: false)
+        .listSync(recursive: true, followLinks: false)
         .whereType<File>()
-        .map((File file) => p.basename(file.path));
+        .map((File file) =>
+            p.relative(file.path, from: dir.path).replaceAll('\\', '/'));
     return galgameHelperMissingFiles(arch, present);
   }
 
@@ -855,9 +874,9 @@ class GalgameHelperInstaller {
     final Directory staging =
         await Directory.systemTemp.createTemp('hibiki_voice_hook_staging_');
     try {
-      final Set<String> extractedRootFiles = await _extractZip(zip, staging);
+      final Set<String> extractedFiles = await _extractZip(zip, staging);
       final List<String> missingFromPackage =
-          galgameHelperMissingFiles(arch, extractedRootFiles);
+          galgameHelperMissingFiles(arch, extractedFiles);
       if (missingFromPackage.isNotEmpty) {
         // 摘要对得上但清单不全 = 发布包本身有问题（不是投毒）。仍然不换入。
         throw GalgameHelperInstallException(
@@ -1112,7 +1131,7 @@ class GalgameHelperInstaller {
     final Uint8List bytes = await zip.readAsBytes();
     final Archive archive = ZipDecoder().decodeBytes(bytes);
     final String targetRoot = p.normalize(targetDir.absolute.path);
-    final Set<String> extractedRootFiles = <String>{};
+    final Set<String> extractedFiles = <String>{};
     for (final ArchiveFile entry in archive) {
       if (!entry.isFile) continue;
       final String relativePath =
@@ -1134,11 +1153,9 @@ class GalgameHelperInstaller {
       final File out = File(outputPath);
       await out.parent.create(recursive: true);
       await out.writeAsBytes(content, flush: true);
-      if (p.dirname(relativePath) == '.') {
-        extractedRootFiles.add(p.basename(relativePath));
-      }
+      extractedFiles.add(relativePath.replaceAll('\\', '/'));
     }
-    return extractedRootFiles;
+    return extractedFiles;
   }
 }
 

--- a/hibiki/test/mining/galgame_helper_installer_test.dart
+++ b/hibiki/test/mining/galgame_helper_installer_test.dart
@@ -168,6 +168,9 @@ void main() {
             'hibiki_voice_hook.dll',
             'LunaHook64.dll',
             'LunaHost64.dll',
+            'unity_audio_runtime/hibiki_unity_audio_extract.exe',
+            'unity_audio_runtime/classdata.tpk',
+            'unity_audio_runtime/vgmstream-cli.exe',
           ]));
       expect(required, isNot(contains('LoaderDll.dll')));
       expect(required, isNot(contains('LocaleEmulator.dll')));
@@ -377,9 +380,11 @@ void main() {
         galgameHelperMissingFiles(
           'x64',
           installed
-              .listSync(followLinks: false)
+              .listSync(recursive: true, followLinks: false)
               .whereType<File>()
-              .map((File file) => p.basename(file.path)),
+              .map((File file) => p
+                  .relative(file.path, from: installed.path)
+                  .replaceAll('\\', '/')),
         ),
         isEmpty,
       );

--- a/hibiki/windows/runner/voice_hook_ipc.h
+++ b/hibiki/windows/runner/voice_hook_ipc.h
@@ -63,6 +63,12 @@ constexpr uint32_t kDiagUnityUiTextHookReady = 0x00002000u;
 constexpr uint32_t kDiagUnityTextMeshClassFound = 0x00004000u;
 constexpr uint32_t kDiagUnityTextMeshMethodFound = 0x00008000u;
 constexpr uint32_t kDiagUnityTextMeshHookReady = 0x00010000u;
+constexpr uint32_t kDiagUnityAudioClassFound = 0x00020000u;
+constexpr uint32_t kDiagUnityAudioResourceMethodsFound = 0x00040000u;
+constexpr uint32_t kDiagUnityAudioPcmMethodsFound = 0x00080000u;
+constexpr uint32_t kDiagUnityAudioPlaybackMethodFound = 0x00100000u;
+constexpr uint32_t kDiagUnityAudioPlaybackHookReady = 0x00200000u;
+constexpr uint32_t kDiagUnityHooksDeferredUntilWindow = 0x00400000u;
 
 inline constexpr bool HasReadyGameResourceAudio(uint32_t reserved_luna,
                                                 uint32_t hook_diagnostics) {

--- a/hibiki/windows/runner/voice_hook_ipc.h
+++ b/hibiki/windows/runner/voice_hook_ipc.h
@@ -55,6 +55,14 @@ constexpr uint32_t kDiagVisualArtsOvkCaptured = 0x00080000u;
 constexpr uint32_t kDiagKirikiriVoiceStreamHookReady = 0x00020000u;
 constexpr uint32_t kDiagKirikiriVoiceStreamDumped = 0x00080000u;
 constexpr uint32_t kDiagSiglusOvkHooksReady = 0x10000000u;
+// reserved_hook_diagnostics: Unity legacy-text installation trace.
+constexpr uint32_t kDiagUnityTextScanReady = 0x00000400u;
+constexpr uint32_t kDiagUnityUiTextClassFound = 0x00000800u;
+constexpr uint32_t kDiagUnityUiTextMethodFound = 0x00001000u;
+constexpr uint32_t kDiagUnityUiTextHookReady = 0x00002000u;
+constexpr uint32_t kDiagUnityTextMeshClassFound = 0x00004000u;
+constexpr uint32_t kDiagUnityTextMeshMethodFound = 0x00008000u;
+constexpr uint32_t kDiagUnityTextMeshHookReady = 0x00010000u;
 
 inline constexpr bool HasReadyGameResourceAudio(uint32_t reserved_luna,
                                                 uint32_t hook_diagnostics) {

--- a/native/galgame_hook/docs/engine-support.md
+++ b/native/galgame_hook/docs/engine-support.md
@@ -19,7 +19,7 @@
 | `catsystem2` | CatSystem2 / KIF INT | `partial` | luna_auto_or_pc_hooks (implemented_unverified) | catsystem2_unencrypted_kif_voice_resource (verified)；directsound_pcm (verified)；process_loopback (verified) | 1 |
 | `malie_libp` | Malie System / LIBP CFI | `partial` | luna_auto_or_pc_hooks (implemented_unverified) | malie_libp_cfi_voice_resource (verified)；directsound_pcm (verified)；process_loopback (verified) | 1 |
 | `qlie_filepack` | QLIE / FilePack | `partial` | luna_auto_or_pc_hooks (implemented_unverified) | qlie_wuvorbis_per_source_pcm (verified)；qlie_wuvorbis_float_per_source_pcm (implemented_unverified)；directsound_pcm (verified)；process_loopback (verified) | 1 |
-| `unity_il2cpp` | Unity IL2CPP | `verified` | luna_pc_hooks (verified)；unity_tmp_events (verified) | unity_audioclip_resource (verified)；xaudio2_source_voice_pcm (verified)；process_loopback (verified) | 1 |
+| `unity_il2cpp` | Unity IL2CPP | `verified` | luna_pc_hooks (verified)；unity_tmp_events (verified)；unity_legacy_text_events (implemented_unverified) | unity_audioclip_resource (verified)；xaudio2_source_voice_pcm (verified)；process_loopback (verified) | 1 |
 
 ## 识别与能力明细
 
@@ -498,15 +498,16 @@ Tests：`tests/qlie_pack_test.cpp`、`tests/adapter_structure_test.py`
 
 识别签名（所有非空项均带真实样本或运行时观察证据）：
 
-- `executable_names`：manosaba.exe；证据：real_sample — manosaba_game runtime recorded in hibiki-hook README
+- `executable_names`：manosaba.exe、Sasasa.exe；证据：real_sample — manosaba_game and 最悪なる災厄人間に捧ぐ runtime observations
 - `pe_architectures`：x64；证据：real_sample — manosaba_game Unity IL2CPP sample
-- `directory_files_all`：UnityPlayer.dll、GameAssembly.dll、*_Data/il2cpp_data/Metadata/global-metadata.dat；证据：real_sample — manosaba_game directory inspection recorded in hibiki-hook README
+- `directory_files_all`：UnityPlayer.dll、GameAssembly.dll、*/il2cpp_data/Metadata/global-metadata.dat；证据：real_sample — manosaba_game directory inspection recorded in hibiki-hook README
 - `runtime_modules`：UnityPlayer.dll、GameAssembly.dll；证据：runtime_observation — manosaba_game Unity IL2CPP sample
 
 文本能力：
 
 - `luna_pc_hooks`：`verified` — PC hooks are auto-enabled for the recorded Unity IL2CPP layout.
 - `unity_tmp_events`：`verified` — The baseline records TMP/text and AudioClip resource pairing on a real IL2CPP sample.
+- `unity_legacy_text_events`：`implemented_unverified` — Sasasa.exe was exercised through Hibiki launch/capture and produced complete Unity TextMesh lines; full offline gates were skipped by request.
 - codepage：utf-16 / managed strings
 - 线程提示：Prefer the stable TMP/Luna dialogue source; keep text active when audio falls back to loopback.
 
@@ -528,7 +529,7 @@ Tests：`tests/qlie_pack_test.cpp`、`tests/adapter_structure_test.py`
 
 Fixtures：尚无（P5 补齐）
 
-Tests：`tests/unity_event_cursor_test.cpp`、`tests/il2cpp_thread_scope_test.cpp`、`tests/resource_audio_ready_test.cpp`
+Tests：`tests/unity_event_cursor_test.cpp`、`tests/il2cpp_thread_scope_test.cpp`、`tests/resource_audio_ready_test.cpp`、`tests/adapter_structure_test.py`
 
 ## 状态定义
 

--- a/native/galgame_hook/engine-support.yaml
+++ b/native/galgame_hook/engine-support.yaml
@@ -1240,10 +1240,10 @@
       "family": {"id": "unity", "relation": "IL2CPP runtime"},
       "detection": {
         "executable_names": {
-          "values": ["manosaba.exe"],
+          "values": ["manosaba.exe", "Sasasa.exe"],
           "evidence": {
             "kind": "real_sample",
-            "reference": "manosaba_game runtime recorded in hibiki-hook README"
+            "reference": "manosaba_game and 最悪なる災厄人間に捧ぐ runtime observations"
           }
         },
         "pe_architectures": {
@@ -1257,7 +1257,7 @@
           "values": [
             "UnityPlayer.dll",
             "GameAssembly.dll",
-            "*_Data/il2cpp_data/Metadata/global-metadata.dat"
+            "*/il2cpp_data/Metadata/global-metadata.dat"
           ],
           "evidence": {
             "kind": "real_sample",
@@ -1294,6 +1294,11 @@
             "kind": "unity_tmp_events",
             "status": "verified",
             "verification": "The baseline records TMP/text and AudioClip resource pairing on a real IL2CPP sample."
+          },
+          {
+            "kind": "unity_legacy_text_events",
+            "status": "implemented_unverified",
+            "verification": "Sasasa.exe was exercised through Hibiki launch/capture and produced complete Unity TextMesh lines; full offline gates were skipped by request."
           }
         ],
         "codepage": "utf-16 / managed strings",
@@ -1342,7 +1347,8 @@
       "test_paths": [
         "tests/unity_event_cursor_test.cpp",
         "tests/il2cpp_thread_scope_test.cpp",
-        "tests/resource_audio_ready_test.cpp"
+        "tests/resource_audio_ready_test.cpp",
+        "tests/adapter_structure_test.py"
       ]
     }
   ]

--- a/native/galgame_hook/hook/adapter_registry.inc
+++ b/native/galgame_hook/hook/adapter_registry.inc
@@ -101,6 +101,7 @@ class UnityIl2CppAdapter final : public hibiki_voice_hook::EngineAdapter {
     return ready_;
   }
   bool ready() const { return ready_; }
+  void ProcessPendingEvents() { ProcessPendingUnityAudioEvents(); }
   hibiki_voice_hook::AdapterCapability capabilities() const override {
     return hibiki_voice_hook::AdapterCapability::kText |
            hibiki_voice_hook::AdapterCapability::kResourceAudio |
@@ -349,6 +350,7 @@ class AdapterRegistry {
 
   void Poll() {
     DispatchNewModules();
+    unity_.ProcessPendingEvents();
     siglus_.ProcessPendingEvents();
     tyrano_.ProcessPendingEvents();
     bgi_ethornell_.ProcessPendingEvents();

--- a/native/galgame_hook/hook/adapters/unity_adapter.inc
+++ b/native/galgame_hook/hook/adapters/unity_adapter.inc
@@ -51,10 +51,20 @@ const void* g_unity_clip_get_data = nullptr;
 const void* g_unity_source_get_clip = nullptr;
 const void* g_unity_object_get_name = nullptr;
 void* g_system_single_class = nullptr;
-volatile LONG g_unity_capture_busy = 0;
 void* g_last_unity_clip = nullptr;
 ULONGLONG g_last_unity_clip_tick = 0;
 wchar_t g_last_unity_voice_bundle[kUnityBundlePathChars] = {0};
+constexpr uint32_t kUnityPendingAudioEventCount = 32;
+struct PendingUnityAudioEvent {
+  uint64_t seq;
+  uint64_t timestamp_ms;
+  void* source;
+  void* clip;
+};
+PendingUnityAudioEvent
+    g_unity_pending_audio_events[kUnityPendingAudioEventCount] = {};
+volatile LONGLONG g_unity_pending_audio_write_count = 0;
+volatile LONGLONG g_unity_pending_audio_read_count = 0;
 
 using UnityAudioSourcePlay = void (*)(void*, const void*);
 using UnityAudioSourcePlayOneShot1 = void (*)(void*, void*, const void*);
@@ -288,39 +298,63 @@ void RecordUnityVoiceResourceEvent(void* clip, uint64_t timestamp_ms) {
   event->seq = index + 1;
 }
 
-void CaptureUnityAudioClip(void* source, void* clip) {
-  if (!g_capture_enabled || clip == nullptr || g_header == nullptr ||
-      g_system_single_class == nullptr || g_il2cpp_array_new == nullptr) {
-    return;
-  }
+void EnqueueUnityAudioClip(void* source, void* clip) {
   const ULONGLONG now = GetTickCount64();
-  // PlayOneShot(AudioClip) 的一参数包装会继续调用二参数重载；同一资源同一播放只写一次。
+  // Detour 可能运行在 Unity 的 GC/音频内部临界区。这里只写固定长本地环，绝不
+  // runtime_invoke/attach/分配托管对象；托管读取统一转移到 HookWorker。
   if (clip == g_last_unity_clip && now - g_last_unity_clip_tick < 100) return;
-  if (InterlockedCompareExchange(&g_unity_capture_busy, 1, 0) != 0) return;
+  g_last_unity_clip = clip;
+  g_last_unity_clip_tick = now;
+  const uint64_t index = static_cast<uint64_t>(InterlockedIncrement64(
+                             &g_unity_pending_audio_write_count)) -
+                         1;
+  PendingUnityAudioEvent* event =
+      &g_unity_pending_audio_events[index % kUnityPendingAudioEventCount];
+  event->seq = 0;
+  event->timestamp_ms = now;
+  event->source = source;
+  event->clip = clip;
+  MemoryBarrier();
+  InterlockedExchange64(reinterpret_cast<volatile LONGLONG*>(&event->seq),
+                        static_cast<LONGLONG>(index + 1));
+}
+
+void CaptureUnityAudioClip(void* source, void* clip) {
+  if (!g_capture_enabled || clip == nullptr || g_header == nullptr) return;
   g_header->hook_diagnostics |= kDiagUnityIl2CppPlaybackObserved;
-  // 本函数随后的每一个托管调用（RecordUnityVoiceResourceEvent 的 get_name、InvokeUnityInt
-  // 的装箱、array_new、AudioClip.GetData）都在托管堆分配。scheduled/delayed 播放会把内部
-  // Helper 派到 Unity 原生 audio 线程执行——那条线程未注册到 IL2CPP 域，直接分配会命中
-  // Boehm GC 的 "Collecting from unknown thread" 崩溃。进入托管区前确保当前线程已注册。
+  EnqueueUnityAudioClip(source, clip);
+}
+
+void ProcessUnityAudioEvent(const PendingUnityAudioEvent& event) {
+  if (!g_capture_enabled || event.clip == nullptr || g_header == nullptr) return;
+  // HookWorker 是普通 Win32 线程。先 attach 到 IL2CPP 域，再做 get_name/装箱/
+  // array_new/GetData，避免在 Unity 播放 detour 内重入 Boehm GC。
   const hibiki_voice_hook::Il2CppThreadFns il2cpp_thread_fns{
       g_il2cpp_thread_current, g_il2cpp_thread_attach, g_il2cpp_thread_detach,
       g_il2cpp_domain_get};
   hibiki_voice_hook::Il2CppManagedThreadScope managed_thread(il2cpp_thread_fns);
   if (!managed_thread.safe()) {
-    // 未注册且无法 attach：宁可放弃这次资源事件与 PCM，也不冒崩溃风险。
     g_header->hook_diagnostics |= kDiagUnityIl2CppGetDataRejected;
-    InterlockedExchange(&g_unity_capture_busy, 0);
     return;
   }
-  RecordUnityVoiceResourceEvent(clip, now);
-  // Streaming AudioClip 的 GetData 会拒绝读取，但资源事件仍然有效。去重状态必须在这里
-  // 更新，否则 Unity 6 的 public 包装与内部 Helper 会为同一次播放各触发一次解析/转码。
-  g_last_unity_clip = clip;
-  g_last_unity_clip_tick = now;
+  RecordUnityVoiceResourceEvent(event.clip, event.timestamp_ms);
 
-  const int samples = InvokeUnityInt(g_unity_clip_get_samples, clip);
-  const int channels = InvokeUnityInt(g_unity_clip_get_channels, clip);
-  const int frequency = InvokeUnityInt(g_unity_clip_get_frequency, clip);
+  const bool pcm_helpers_ready =
+      g_system_single_class != nullptr && g_il2cpp_array_new != nullptr &&
+      g_unity_clip_get_samples != nullptr &&
+      g_unity_clip_get_channels != nullptr &&
+      g_unity_clip_get_frequency != nullptr &&
+      g_unity_clip_get_data != nullptr;
+  if (!pcm_helpers_ready) {
+    // 旧 Unity 可能没有暴露 GetData 或数组辅助 API。资源事件已经写入，允许
+    // injector 走 bundle/resource 解码；这里只放弃托管 PCM 快路径。
+    g_header->hook_diagnostics |= kDiagUnityIl2CppGetDataRejected;
+    return;
+  }
+
+  const int samples = InvokeUnityInt(g_unity_clip_get_samples, event.clip);
+  const int channels = InvokeUnityInt(g_unity_clip_get_channels, event.clip);
+  const int frequency = InvokeUnityInt(g_unity_clip_get_frequency, event.clip);
   const uint64_t value_count =
       samples > 0 && channels > 0
           ? static_cast<uint64_t>(samples) * static_cast<uint64_t>(channels)
@@ -338,13 +372,14 @@ void CaptureUnityAudioClip(void* source, void* clip) {
     if (array != nullptr) {
       int offset_samples = 0;
       void* args[2] = {array, &offset_samples};
-      if (InvokeUnityBool(g_unity_clip_get_data, clip, args)) {
+      if (InvokeUnityBool(g_unity_clip_get_data, event.clip, args)) {
         // Il2CppArray = Il2CppObject(klass,monitor) + bounds + max_length；随后即 vector。
         const auto* pcm = reinterpret_cast<const uint8_t*>(array) +
                           sizeof(void*) * 4;
         const uint32_t len = static_cast<uint32_t>(byte_count);
         const uint32_t off = RingAppendVoice(pcm, len);
-        RecordVoiceClipFmt(off, len, reinterpret_cast<uint64_t>(source),
+        RecordVoiceClipFmt(off, len,
+                           reinterpret_cast<uint64_t>(event.source),
                            static_cast<uint32_t>(frequency),
                            static_cast<uint32_t>(channels), 32, 1);
         if (InterlockedCompareExchange(&g_format_set, 1, 0) == 0) {
@@ -362,7 +397,35 @@ void CaptureUnityAudioClip(void* source, void* clip) {
   } else {
     g_header->hook_diagnostics |= kDiagUnityIl2CppGetDataRejected;
   }
-  InterlockedExchange(&g_unity_capture_busy, 0);
+}
+
+void ProcessPendingUnityAudioEvents() {
+  for (uint32_t processed = 0;
+       processed < kUnityPendingAudioEventCount; ++processed) {
+    const uint64_t write_count = static_cast<uint64_t>(
+        InterlockedCompareExchange64(&g_unity_pending_audio_write_count, 0, 0));
+    uint64_t read_count = static_cast<uint64_t>(
+        InterlockedCompareExchange64(&g_unity_pending_audio_read_count, 0, 0));
+    if (read_count >= write_count) break;
+    const uint64_t oldest =
+        write_count > kUnityPendingAudioEventCount
+            ? write_count - kUnityPendingAudioEventCount
+            : 0;
+    if (read_count < oldest) {
+      read_count = oldest;
+      InterlockedExchange64(&g_unity_pending_audio_read_count,
+                            static_cast<LONGLONG>(read_count));
+    }
+    PendingUnityAudioEvent* slot =
+        &g_unity_pending_audio_events[read_count %
+                                      kUnityPendingAudioEventCount];
+    MemoryBarrier();
+    if (slot->seq != read_count + 1) break;
+    const PendingUnityAudioEvent event = *slot;
+    InterlockedExchange64(&g_unity_pending_audio_read_count,
+                          static_cast<LONGLONG>(read_count + 1));
+    ProcessUnityAudioEvent(event);
+  }
 }
 
 void Detour_UnityAudioSourcePlay(void* self, const void* method) {
@@ -536,6 +599,28 @@ const void* FindIl2CppMethod(void* klass, const char* method_name,
   return nullptr;
 }
 
+bool HasCurrentProcessTopLevelWindow() {
+  struct Search {
+    DWORD process_id;
+    bool found;
+  } search{GetCurrentProcessId(), false};
+  EnumWindows(
+      [](HWND window, LPARAM value) -> BOOL {
+        auto* search = reinterpret_cast<Search*>(value);
+        DWORD process_id = 0;
+        GetWindowThreadProcessId(window, &process_id);
+        if (process_id != search->process_id ||
+            GetWindow(window, GW_OWNER) != nullptr ||
+            !IsWindowVisible(window)) {
+          return TRUE;
+        }
+        search->found = true;
+        return FALSE;
+      },
+      reinterpret_cast<LPARAM>(&search));
+  return search.found;
+}
+
 bool TryHookUnityIl2CppAudio() {
   const bool audio_ready =
       g_orig_UnityAudioSourcePlay != nullptr ||
@@ -543,7 +628,10 @@ bool TryHookUnityIl2CppAudio() {
       g_orig_UnityAudioSourcePlayOneShot2 != nullptr ||
       g_orig_UnityAudioSourceSetClip != nullptr ||
       g_orig_UnityAudioSourcePlayScheduled != nullptr ||
-      g_orig_UnityAudioSourcePlayDelayed != nullptr;
+      g_orig_UnityAudioSourcePlayDelayed != nullptr ||
+      g_orig_UnityAudioSourcePlayHelper != nullptr ||
+      g_orig_UnityAudioSourcePlayOneShotHelper != nullptr ||
+      g_orig_UnityAudioSourcePlayDelayedHelper != nullptr;
   const bool text_ready =
       (g_orig_UnityTmpSetText != nullptr &&
        g_orig_UnityTmpSetText2 != nullptr) ||
@@ -555,6 +643,17 @@ bool TryHookUnityIl2CppAudio() {
   }
   HMODULE game = GetModuleHandleW(L"GameAssembly.dll");
   if (game == nullptr) return false;
+  // Hibiki 的“启动并捕获”会先以 CREATE_SUSPENDED 创建游戏。旧版 IL2CPP 在播放器
+  // 尚未创建窗口时连类型/方法枚举都可能进入未完成初始化的 Boehm GC；更不能在此时
+  // 用 MH_EnableHook 再次枚举并挂起线程。外部窗口附加天然越过此门；启动模式则由
+  // HookWorker 在窗口出现后按现有轮询节奏重试。
+  if (!HasCurrentProcessTopLevelWindow()) {
+    if (g_header != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityHooksDeferredUntilWindow;
+    }
+    return false;
+  }
   const auto domain_get = reinterpret_cast<Il2CppDomainGet>(
       GetProcAddress(game, "il2cpp_domain_get"));
   const auto domain_get_assemblies = reinterpret_cast<Il2CppDomainGetAssemblies>(
@@ -649,6 +748,11 @@ bool TryHookUnityIl2CppAudio() {
   if (g_header != nullptr) {
     g_header->reserved_hook_diagnostics |=
         hibiki_voice_hook::kDiagUnityTextScanReady;
+    if (source_class != nullptr && clip_class != nullptr &&
+        object_class != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityAudioClassFound;
+    }
     if (ui_text_class != nullptr) {
       g_header->reserved_hook_diagnostics |=
           hibiki_voice_hook::kDiagUnityUiTextClassFound;
@@ -656,6 +760,47 @@ bool TryHookUnityIl2CppAudio() {
     if (text_mesh_class != nullptr) {
       g_header->reserved_hook_diagnostics |=
           hibiki_voice_hook::kDiagUnityTextMeshClassFound;
+    }
+  }
+
+  bool resource_methods_ready = false;
+  bool pcm_helpers_ready = false;
+  if (class_get_method != nullptr && g_il2cpp_runtime_invoke != nullptr &&
+      source_class != nullptr && clip_class != nullptr &&
+      object_class != nullptr) {
+    g_unity_source_get_clip =
+        class_get_method(source_class, "get_clip", 0);
+    g_unity_object_get_name =
+        class_get_method(object_class, "get_name", 0);
+    resource_methods_ready =
+        g_unity_source_get_clip != nullptr &&
+        g_unity_object_get_name != nullptr;
+    if (resource_methods_ready && g_header != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityAudioResourceMethodsFound;
+    }
+
+    const void* corlib = get_corlib == nullptr ? nullptr : get_corlib();
+    g_system_single_class =
+        corlib == nullptr ? nullptr
+                          : class_from_name(corlib, "System", "Single");
+    g_unity_clip_get_samples =
+        class_get_method(clip_class, "get_samples", 0);
+    g_unity_clip_get_channels =
+        class_get_method(clip_class, "get_channels", 0);
+    g_unity_clip_get_frequency =
+        class_get_method(clip_class, "get_frequency", 0);
+    g_unity_clip_get_data = class_get_method(clip_class, "GetData", 2);
+    pcm_helpers_ready =
+        g_system_single_class != nullptr && g_il2cpp_array_new != nullptr &&
+        g_il2cpp_object_unbox != nullptr &&
+        g_unity_clip_get_samples != nullptr &&
+        g_unity_clip_get_channels != nullptr &&
+        g_unity_clip_get_frequency != nullptr &&
+        g_unity_clip_get_data != nullptr;
+    if (pcm_helpers_ready && g_header != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityAudioPcmMethodsFound;
     }
   }
 
@@ -733,39 +878,10 @@ bool TryHookUnityIl2CppAudio() {
     g_header->hook_diagnostics |= kDiagUnityNaninovelTextHookReady;
   }
 
-  // Text capture is independent from AudioClip resource extraction. Older
-  // Unity/IL2CPP games may expose UI.Text while omitting one of the managed
-  // audio helpers below; keep their dialogue hook and let audio use loopback.
-  const void* corlib = get_corlib == nullptr ? nullptr : get_corlib();
-  g_system_single_class =
-      corlib == nullptr ? nullptr
-                        : class_from_name(corlib, "System", "Single");
-  if (class_get_method == nullptr || get_corlib == nullptr ||
-      g_il2cpp_runtime_invoke == nullptr || g_il2cpp_array_new == nullptr ||
-      g_il2cpp_object_unbox == nullptr) {
-    return false;
-  }
-  if (source_class == nullptr || clip_class == nullptr || object_class == nullptr ||
-      g_system_single_class == nullptr) {
-    return false;
-  }
-
-  g_unity_clip_get_samples =
-      class_get_method(clip_class, "get_samples", 0);
-  g_unity_clip_get_channels =
-      class_get_method(clip_class, "get_channels", 0);
-  g_unity_clip_get_frequency =
-      class_get_method(clip_class, "get_frequency", 0);
-  g_unity_clip_get_data = class_get_method(clip_class, "GetData", 2);
-  g_unity_source_get_clip = class_get_method(source_class, "get_clip", 0);
-  g_unity_object_get_name = class_get_method(object_class, "get_name", 0);
-  if (g_unity_clip_get_samples == nullptr ||
-      g_unity_clip_get_channels == nullptr ||
-      g_unity_clip_get_frequency == nullptr ||
-      g_unity_clip_get_data == nullptr || g_unity_source_get_clip == nullptr ||
-      g_unity_object_get_name == nullptr) {
-    return false;
-  }
+  // Resource observation only needs the AudioSource/AudioClip/Object classes,
+  // runtime invoke, and the clip/name accessors. Keep it independent from the
+  // optional AudioClip.GetData PCM fast path used by newer Unity versions.
+  if (!resource_methods_ready) return false;
 
   bool any = audio_ready;
   const void* play = class_get_method(source_class, "Play", 0);
@@ -780,6 +896,15 @@ bool TryHookUnityIl2CppAudio() {
       class_get_method(source_class, "PlayOneShotHelper", 3);
   const void* play_delayed_helper =
       class_get_method(source_class, "PlayDelayedHelper", 2);
+  if (g_header != nullptr &&
+      (play != nullptr || one_shot_1 != nullptr ||
+       one_shot_2 != nullptr || set_clip != nullptr ||
+       play_scheduled != nullptr || play_delayed != nullptr ||
+       play_helper != nullptr || one_shot_helper != nullptr ||
+       play_delayed_helper != nullptr)) {
+    g_header->reserved_hook_diagnostics |=
+        hibiki_voice_hook::kDiagUnityAudioPlaybackMethodFound;
+  }
   any |= HookFn(Il2CppMethodPointer(play),
                 reinterpret_cast<void*>(&Detour_UnityAudioSourcePlay),
                 reinterpret_cast<void**>(&g_orig_UnityAudioSourcePlay));
@@ -813,6 +938,9 @@ bool TryHookUnityIl2CppAudio() {
       reinterpret_cast<void**>(&g_orig_UnityAudioSourcePlayDelayedHelper));
   if (any && g_header != nullptr) {
     g_header->hook_diagnostics |= kDiagUnityIl2CppHooksReady;
+    g_header->reserved_hook_diagnostics |=
+        hibiki_voice_hook::kDiagUnityAudioPlaybackHookReady;
   }
+
   return any && text_hooks_ready;
 }

--- a/native/galgame_hook/hook/adapters/unity_adapter.inc
+++ b/native/galgame_hook/hook/adapters/unity_adapter.inc
@@ -83,8 +83,15 @@ using UnityTmpSetText = void (*)(void*, void*, const void*);
 UnityTmpSetText g_orig_UnityTmpSetText = nullptr;
 using UnityTmpSetText2 = void (*)(void*, void*, bool, const void*);
 UnityTmpSetText2 g_orig_UnityTmpSetText2 = nullptr;
+using UnityUiTextSetText = void (*)(void*, void*, const void*);
+UnityUiTextSetText g_orig_UnityUiTextSetText = nullptr;
+using UnityTextMeshSetText = void (*)(void*, void*, const void*);
+UnityTextMeshSetText g_orig_UnityTextMeshSetText = nullptr;
 using NaninovelRevealableSetText = void (*)(void*, void*, const void*);
 NaninovelRevealableSetText g_orig_NaninovelRevealableSetText = nullptr;
+wchar_t g_unity_text_mesh_line[501] = {0};
+int g_unity_text_mesh_line_length = 0;
+ULONGLONG g_unity_text_mesh_last_tick = 0;
 
 int InvokeUnityInt(const void* method, void* instance) {
   if (method == nullptr || instance == nullptr ||
@@ -131,41 +138,13 @@ bool CopyUnityClipName(void* clip, wchar_t* out, size_t out_chars) {
   return true;
 }
 
-void RecordUnityTmpText(void* text_component, void* string_object,
-                        const char* hook_name, const wchar_t* hook_code) {
+void RecordUnityTextBuffer(void* text_component, const wchar_t* clean,
+                           int length, const char* hook_name,
+                           const wchar_t* hook_code) {
   if (!g_capture_enabled || g_header == nullptr || g_text_base == nullptr ||
-      text_component == nullptr || string_object == nullptr ||
-      g_il2cpp_string_chars == nullptr || g_il2cpp_string_length == nullptr) {
+      text_component == nullptr || clean == nullptr || length <= 0) {
     return;
   }
-  const wchar_t* chars = g_il2cpp_string_chars(string_object);
-  const int source_length = g_il2cpp_string_length(string_object);
-  if (chars == nullptr || source_length <= 0) return;
-
-  // TMP 富文本标签不显示为正文；移除 <...> 后保存用户实际看到的文本。保留换行与标点，
-  // 由 component 指针充当线程 id，让 UI 像 Luna 一样选择“正文 TextMeshPro 组件”。
-  wchar_t clean[501] = {0};
-  int length = 0;
-  bool in_tag = false;
-  bool has_cjk = false;
-  int meaningful = 0;
-  for (int i = 0; i < source_length && length < 500; ++i) {
-    const wchar_t c = chars[i];
-    if (c == L'<') {
-      in_tag = true;
-      continue;
-    }
-    if (in_tag) {
-      if (c == L'>') in_tag = false;
-      continue;
-    }
-    clean[length++] = c;
-    if (c != L' ' && c != L'\t' && c != L'\r' && c != L'\n' && c >= 0x20) {
-      ++meaningful;
-      if (c >= 0x3000) has_cjk = true;
-    }
-  }
-  if (length == 0 || meaningful == 0 || (!has_cjk && meaningful < 2)) return;
 
   const LONGLONG reserved = InterlockedIncrement64(
       reinterpret_cast<volatile LONGLONG*>(&g_header->text_write_count));
@@ -205,6 +184,82 @@ void RecordUnityTmpText(void* text_component, void* string_object,
   MemoryBarrier();
   text_slot->seq = static_cast<uint64_t>(reserved);
   g_header->text_hooked = 1;
+}
+
+void RecordUnityTmpText(void* text_component, void* string_object,
+                        const char* hook_name, const wchar_t* hook_code) {
+  if (string_object == nullptr || g_il2cpp_string_chars == nullptr ||
+      g_il2cpp_string_length == nullptr) {
+    return;
+  }
+  const wchar_t* chars = g_il2cpp_string_chars(string_object);
+  const int source_length = g_il2cpp_string_length(string_object);
+  if (chars == nullptr || source_length <= 0) return;
+
+  // TMP 富文本标签不显示为正文；移除 <...> 后保存用户实际看到的文本。保留换行与标点，
+  // 由 component 指针充当线程 id，让 UI 像 Luna 一样选择“正文 TextMeshPro 组件”。
+  wchar_t clean[501] = {0};
+  int length = 0;
+  bool in_tag = false;
+  bool has_cjk = false;
+  int meaningful = 0;
+  for (int i = 0; i < source_length && length < 500; ++i) {
+    const wchar_t c = chars[i];
+    if (c == L'<') {
+      in_tag = true;
+      continue;
+    }
+    if (in_tag) {
+      if (c == L'>') in_tag = false;
+      continue;
+    }
+    clean[length++] = c;
+    if (c != L' ' && c != L'\t' && c != L'\r' && c != L'\n' &&
+        c != L'\u3000' && c >= 0x20) {
+      ++meaningful;
+      if (c >= 0x3000) has_cjk = true;
+    }
+  }
+  if (length == 0 || meaningful == 0 || (!has_cjk && meaningful < 2)) return;
+  RecordUnityTextBuffer(text_component, clean, length, hook_name, hook_code);
+}
+
+void FlushUnityTextMeshLine() {
+  if (g_unity_text_mesh_line_length <= 0) return;
+  RecordUnityTextBuffer(
+      static_cast<void*>(g_unity_text_mesh_line), g_unity_text_mesh_line,
+      g_unity_text_mesh_line_length, "Unity TextMesh line",
+      L"UnityEngine.TextMesh.set_text(glyphs)");
+  memset(g_unity_text_mesh_line, 0, sizeof(g_unity_text_mesh_line));
+  g_unity_text_mesh_line_length = 0;
+}
+
+void RecordUnityTextMesh(void* string_object) {
+  if (g_il2cpp_string_chars == nullptr || g_il2cpp_string_length == nullptr) {
+    return;
+  }
+  const wchar_t* chars =
+      string_object == nullptr ? nullptr : g_il2cpp_string_chars(string_object);
+  const int source_length =
+      string_object == nullptr ? 0 : g_il2cpp_string_length(string_object);
+  const ULONGLONG now = GetTickCount64();
+  if (g_cs_ready) EnterCriticalSection(&g_cs);
+  if (g_unity_text_mesh_line_length > 0 &&
+      now - g_unity_text_mesh_last_tick > 250) {
+    FlushUnityTextMeshLine();
+  }
+  for (int i = 0; chars != nullptr && i < source_length; ++i) {
+    const wchar_t c = chars[i];
+    if (c == L'\u3000' || c == L'\r' || c == L'\n') {
+      FlushUnityTextMeshLine();
+      continue;
+    }
+    if (c < 0x20 || g_unity_text_mesh_line_length >= 500) continue;
+    g_unity_text_mesh_line[g_unity_text_mesh_line_length++] = c;
+  }
+  if (source_length == 0) FlushUnityTextMeshLine();
+  g_unity_text_mesh_last_tick = now;
+  if (g_cs_ready) LeaveCriticalSection(&g_cs);
 }
 
 void RecordUnityVoiceResourceEvent(void* clip, uint64_t timestamp_ms) {
@@ -418,6 +473,18 @@ void Detour_UnityTmpSetText2(void* self, void* text, bool sync_input_box,
                      L"TMPro.TMP_Text.SetText(string,bool)");
 }
 
+void Detour_UnityUiTextSetText(void* self, void* text, const void* method) {
+  g_orig_UnityUiTextSetText(self, text, method);
+  RecordUnityTmpText(self, text, "Unity UI.Text",
+                     L"UnityEngine.UI.Text.set_text");
+}
+
+void Detour_UnityTextMeshSetText(void* self, void* text,
+                                 const void* method) {
+  g_orig_UnityTextMeshSetText(self, text, method);
+  RecordUnityTextMesh(text);
+}
+
 void Detour_NaninovelRevealableSetText(void* self, void* text,
                                        const void* method) {
   g_orig_NaninovelRevealableSetText(self, text, method);
@@ -480,6 +547,8 @@ bool TryHookUnityIl2CppAudio() {
   const bool text_ready =
       (g_orig_UnityTmpSetText != nullptr &&
        g_orig_UnityTmpSetText2 != nullptr) ||
+      g_orig_UnityUiTextSetText != nullptr ||
+      g_orig_UnityTextMeshSetText != nullptr ||
       g_orig_NaninovelRevealableSetText != nullptr;
   if (audio_ready && text_ready) {
     return true;
@@ -532,9 +601,7 @@ bool TryHookUnityIl2CppAudio() {
       GetProcAddress(game, "il2cpp_thread_detach"));
   if (domain_get == nullptr || domain_get_assemblies == nullptr ||
       assembly_get_image == nullptr || class_from_name == nullptr ||
-      class_get_method == nullptr || get_corlib == nullptr ||
-      g_il2cpp_runtime_invoke == nullptr || g_il2cpp_array_new == nullptr ||
-      g_il2cpp_object_unbox == nullptr || g_il2cpp_string_chars == nullptr ||
+      g_il2cpp_string_chars == nullptr ||
       g_il2cpp_string_length == nullptr ||
       g_il2cpp_class_get_methods == nullptr ||
       g_il2cpp_method_get_name == nullptr ||
@@ -548,6 +615,8 @@ bool TryHookUnityIl2CppAudio() {
   void* clip_class = nullptr;
   void* object_class = nullptr;
   void* tmp_text_class = nullptr;
+  void* ui_text_class = nullptr;
+  void* text_mesh_class = nullptr;
   void* naninovel_revealable_text_class = nullptr;
   size_t assembly_count = 0;
   const void** assemblies = domain_get_assemblies(domain_get(), &assembly_count);
@@ -566,15 +635,116 @@ bool TryHookUnityIl2CppAudio() {
     if (tmp_text_class == nullptr) {
       tmp_text_class = class_from_name(image, "TMPro", "TMP_Text");
     }
+    if (ui_text_class == nullptr) {
+      ui_text_class = class_from_name(image, "UnityEngine.UI", "Text");
+    }
+    if (text_mesh_class == nullptr) {
+      text_mesh_class = class_from_name(image, "UnityEngine", "TextMesh");
+    }
     if (naninovel_revealable_text_class == nullptr) {
       naninovel_revealable_text_class =
           class_from_name(image, "Naninovel.UI", "RevealableText");
     }
   }
-  const void* corlib = get_corlib();
+  if (g_header != nullptr) {
+    g_header->reserved_hook_diagnostics |=
+        hibiki_voice_hook::kDiagUnityTextScanReady;
+    if (ui_text_class != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityUiTextClassFound;
+    }
+    if (text_mesh_class != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityTextMeshClassFound;
+    }
+  }
+
+  bool tmp_text_ready = false;
+  if (tmp_text_class != nullptr) {
+    const char* property_params[] = {"System.String"};
+    const char* method_params[] = {"System.String", "System.Boolean"};
+    const void* set_text = FindIl2CppMethod(
+        tmp_text_class, "set_text", property_params, 1);
+    const void* set_text_2 = FindIl2CppMethod(
+        tmp_text_class, "SetText", method_params, 2);
+    const bool property_ready = HookFn(
+        Il2CppMethodPointer(set_text),
+        reinterpret_cast<void*>(&Detour_UnityTmpSetText),
+        reinterpret_cast<void**>(&g_orig_UnityTmpSetText));
+    const bool method_ready = HookFn(
+        Il2CppMethodPointer(set_text_2),
+        reinterpret_cast<void*>(&Detour_UnityTmpSetText2),
+        reinterpret_cast<void**>(&g_orig_UnityTmpSetText2));
+    tmp_text_ready = property_ready && method_ready;
+  }
+  bool ui_text_ready = false;
+  if (ui_text_class != nullptr) {
+    const char* text_params[] = {"System.String"};
+    const void* set_text =
+        FindIl2CppMethod(ui_text_class, "set_text", text_params, 1);
+    if (set_text != nullptr && g_header != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityUiTextMethodFound;
+    }
+    ui_text_ready = HookFn(
+        Il2CppMethodPointer(set_text),
+        reinterpret_cast<void*>(&Detour_UnityUiTextSetText),
+        reinterpret_cast<void**>(&g_orig_UnityUiTextSetText));
+    if (ui_text_ready && g_header != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityUiTextHookReady;
+    }
+  }
+  bool text_mesh_ready = false;
+  if (text_mesh_class != nullptr) {
+    const char* text_params[] = {"System.String"};
+    const void* set_text =
+        FindIl2CppMethod(text_mesh_class, "set_text", text_params, 1);
+    if (set_text != nullptr && g_header != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityTextMeshMethodFound;
+    }
+    text_mesh_ready = HookFn(
+        Il2CppMethodPointer(set_text),
+        reinterpret_cast<void*>(&Detour_UnityTextMeshSetText),
+        reinterpret_cast<void**>(&g_orig_UnityTextMeshSetText));
+    if (text_mesh_ready && g_header != nullptr) {
+      g_header->reserved_hook_diagnostics |=
+          hibiki_voice_hook::kDiagUnityTextMeshHookReady;
+    }
+  }
+  bool naninovel_text_ready = false;
+  if (naninovel_revealable_text_class != nullptr) {
+    const char* text_params[] = {"System.String"};
+    const void* set_text = FindIl2CppMethod(
+        naninovel_revealable_text_class, "set_Text", text_params, 1);
+    naninovel_text_ready = HookFn(
+        Il2CppMethodPointer(set_text),
+        reinterpret_cast<void*>(&Detour_NaninovelRevealableSetText),
+        reinterpret_cast<void**>(&g_orig_NaninovelRevealableSetText));
+  }
+  const bool text_hooks_ready =
+      tmp_text_ready || ui_text_ready || text_mesh_ready ||
+      naninovel_text_ready;
+  if (tmp_text_ready && g_header != nullptr) {
+    g_header->hook_diagnostics |= kDiagUnityTmpTextHooksReady;
+  }
+  if (naninovel_text_ready && g_header != nullptr) {
+    g_header->hook_diagnostics |= kDiagUnityNaninovelTextHookReady;
+  }
+
+  // Text capture is independent from AudioClip resource extraction. Older
+  // Unity/IL2CPP games may expose UI.Text while omitting one of the managed
+  // audio helpers below; keep their dialogue hook and let audio use loopback.
+  const void* corlib = get_corlib == nullptr ? nullptr : get_corlib();
   g_system_single_class =
       corlib == nullptr ? nullptr
                         : class_from_name(corlib, "System", "Single");
+  if (class_get_method == nullptr || get_corlib == nullptr ||
+      g_il2cpp_runtime_invoke == nullptr || g_il2cpp_array_new == nullptr ||
+      g_il2cpp_object_unbox == nullptr) {
+    return false;
+  }
   if (source_class == nullptr || clip_class == nullptr || object_class == nullptr ||
       g_system_single_class == nullptr) {
     return false;
@@ -597,7 +767,7 @@ bool TryHookUnityIl2CppAudio() {
     return false;
   }
 
-  bool any = false;
+  bool any = audio_ready;
   const void* play = class_get_method(source_class, "Play", 0);
   const void* one_shot_1 = class_get_method(source_class, "PlayOneShot", 1);
   const void* one_shot_2 = class_get_method(source_class, "PlayOneShot", 2);
@@ -641,42 +811,8 @@ bool TryHookUnityIl2CppAudio() {
       Il2CppMethodPointer(play_delayed_helper),
       reinterpret_cast<void*>(&Detour_UnityAudioSourcePlayDelayedHelper),
       reinterpret_cast<void**>(&g_orig_UnityAudioSourcePlayDelayedHelper));
-  bool tmp_text_ready = false;
-  if (tmp_text_class != nullptr) {
-    const char* property_params[] = {"System.String"};
-    const char* method_params[] = {"System.String", "System.Boolean"};
-    const void* set_text = FindIl2CppMethod(
-        tmp_text_class, "set_text", property_params, 1);
-    const void* set_text_2 = FindIl2CppMethod(
-        tmp_text_class, "SetText", method_params, 2);
-    const bool property_ready = HookFn(
-        Il2CppMethodPointer(set_text),
-        reinterpret_cast<void*>(&Detour_UnityTmpSetText),
-        reinterpret_cast<void**>(&g_orig_UnityTmpSetText));
-    const bool method_ready = HookFn(
-        Il2CppMethodPointer(set_text_2),
-        reinterpret_cast<void*>(&Detour_UnityTmpSetText2),
-        reinterpret_cast<void**>(&g_orig_UnityTmpSetText2));
-    tmp_text_ready = property_ready && method_ready;
-  }
-  bool naninovel_text_ready = false;
-  if (naninovel_revealable_text_class != nullptr) {
-    const char* text_params[] = {"System.String"};
-    const void* set_text = FindIl2CppMethod(
-        naninovel_revealable_text_class, "set_Text", text_params, 1);
-    naninovel_text_ready = HookFn(
-        Il2CppMethodPointer(set_text),
-        reinterpret_cast<void*>(&Detour_NaninovelRevealableSetText),
-        reinterpret_cast<void**>(&g_orig_NaninovelRevealableSetText));
-  }
   if (any && g_header != nullptr) {
     g_header->hook_diagnostics |= kDiagUnityIl2CppHooksReady;
   }
-  if (tmp_text_ready && g_header != nullptr) {
-    g_header->hook_diagnostics |= kDiagUnityTmpTextHooksReady;
-  }
-  if (naninovel_text_ready && g_header != nullptr) {
-    g_header->hook_diagnostics |= kDiagUnityNaninovelTextHookReady;
-  }
-  return any && (tmp_text_ready || naninovel_text_ready);
+  return any && text_hooks_ready;
 }

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -106,6 +106,13 @@ constexpr uint32_t kDiagQlieVorbisOpenObserved = 0x00000040u;
 constexpr uint32_t kDiagQlieVorbisPcmCaptured = 0x00000080u;
 constexpr uint32_t kDiagQlieVorbisFloatHookReady = 0x00000100u;
 constexpr uint32_t kDiagQlieVorbisFloatPcmCaptured = 0x00000200u;
+constexpr uint32_t kDiagUnityTextScanReady = 0x00000400u;
+constexpr uint32_t kDiagUnityUiTextClassFound = 0x00000800u;
+constexpr uint32_t kDiagUnityUiTextMethodFound = 0x00001000u;
+constexpr uint32_t kDiagUnityUiTextHookReady = 0x00002000u;
+constexpr uint32_t kDiagUnityTextMeshClassFound = 0x00004000u;
+constexpr uint32_t kDiagUnityTextMeshMethodFound = 0x00008000u;
+constexpr uint32_t kDiagUnityTextMeshHookReady = 0x00010000u;
 
 // reserved_luna 的资源音频诊断位。KiriKiriZ 的 TVPCreateStream hook 直接导出当前播放的
 // 已解密 Ogg；Siglus 从 OVK 索引导出逐句 Ogg。它们只代表“资源捕获链已安装”，不要求 PCM

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -113,6 +113,12 @@ constexpr uint32_t kDiagUnityUiTextHookReady = 0x00002000u;
 constexpr uint32_t kDiagUnityTextMeshClassFound = 0x00004000u;
 constexpr uint32_t kDiagUnityTextMeshMethodFound = 0x00008000u;
 constexpr uint32_t kDiagUnityTextMeshHookReady = 0x00010000u;
+constexpr uint32_t kDiagUnityAudioClassFound = 0x00020000u;
+constexpr uint32_t kDiagUnityAudioResourceMethodsFound = 0x00040000u;
+constexpr uint32_t kDiagUnityAudioPcmMethodsFound = 0x00080000u;
+constexpr uint32_t kDiagUnityAudioPlaybackMethodFound = 0x00100000u;
+constexpr uint32_t kDiagUnityAudioPlaybackHookReady = 0x00200000u;
+constexpr uint32_t kDiagUnityHooksDeferredUntilWindow = 0x00400000u;
 
 // reserved_luna 的资源音频诊断位。KiriKiriZ 的 TVPCreateStream hook 直接导出当前播放的
 // 已解密 Ogg；Siglus 从 OVK 索引导出逐句 Ogg。它们只代表“资源捕获链已安装”，不要求 PCM

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -1,6 +1,7 @@
 #include <windows.h>
 
 #include <bcrypt.h>
+#include <mmreg.h>
 #include <shellapi.h>
 #include <tlhelp32.h>
 
@@ -10,6 +11,7 @@
 #include <cstring>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <sstream>
 #include <string>
@@ -287,6 +289,34 @@ UnityExtractorRuntime FindUnityExtractorRuntime() {
   return runtime;
 }
 
+std::wstring FindUnityDataDirectory(HANDLE process) {
+  std::vector<wchar_t> image(32768, L'\0');
+  DWORD length = static_cast<DWORD>(image.size());
+  if (!QueryFullProcessImageNameW(process, 0, image.data(), &length) ||
+      length == 0) {
+    return L"";
+  }
+  std::wstring executable(image.data(), length);
+  const size_t slash = executable.find_last_of(L"\\/");
+  const size_t dot = executable.find_last_of(L'.');
+  if (slash == std::wstring::npos) return L"";
+  const std::wstring directory = executable.substr(0, slash + 1);
+  const std::wstring stem = executable.substr(
+      slash + 1,
+      dot == std::wstring::npos || dot < slash ? std::wstring::npos
+                                               : dot - slash - 1);
+  const std::wstring candidates[] = {
+      directory + stem + L"_Data",
+      directory + L"Data",
+  };
+  for (const std::wstring& candidate : candidates) {
+    if (RegularFileExists(candidate + L"\\resources.assets")) {
+      return candidate;
+    }
+  }
+  return L"";
+}
+
 std::wstring QuoteWindowsArgument(const std::wstring& value) {
   std::wstring quoted = L"\"";
   size_t slashes = 0;
@@ -322,10 +352,189 @@ std::wstring SafeVoiceFileName(const wchar_t* clip_name) {
   return result;
 }
 
+struct WavePcm {
+  std::vector<uint8_t> bytes;
+  uint32_t sample_rate = 0;
+  uint32_t channels = 0;
+  uint32_t bits_per_sample = 0;
+  uint32_t block_align = 0;
+  uint32_t is_float = 0;
+};
+
+uint16_t ReadLe16(const uint8_t* data) {
+  return static_cast<uint16_t>(data[0]) |
+         (static_cast<uint16_t>(data[1]) << 8);
+}
+
+uint32_t ReadLe32(const uint8_t* data) {
+  return static_cast<uint32_t>(data[0]) |
+         (static_cast<uint32_t>(data[1]) << 8) |
+         (static_cast<uint32_t>(data[2]) << 16) |
+         (static_cast<uint32_t>(data[3]) << 24);
+}
+
+bool ReadUnityWavePcm(const std::wstring& path, uint32_t max_bytes,
+                      WavePcm* result) {
+  if (result == nullptr || max_bytes == 0) return false;
+  std::ifstream input(path, std::ios::binary);
+  uint8_t riff[12] = {0};
+  if (!input.read(reinterpret_cast<char*>(riff), sizeof(riff)) ||
+      memcmp(riff, "RIFF", 4) != 0 || memcmp(riff + 8, "WAVE", 4) != 0) {
+    return false;
+  }
+
+  bool found_format = false;
+  std::streamoff data_offset = 0;
+  uint32_t data_size = 0;
+  while (input) {
+    uint8_t chunk_header[8] = {0};
+    if (!input.read(reinterpret_cast<char*>(chunk_header),
+                    sizeof(chunk_header))) {
+      break;
+    }
+    const uint32_t chunk_size = ReadLe32(chunk_header + 4);
+    const std::streamoff payload = input.tellg();
+    if (memcmp(chunk_header, "fmt ", 4) == 0) {
+      if (chunk_size < 16 || chunk_size > 64) return false;
+      std::vector<uint8_t> format(chunk_size);
+      if (!input.read(reinterpret_cast<char*>(format.data()), chunk_size)) {
+        return false;
+      }
+      uint16_t format_tag = ReadLe16(format.data());
+      if (format_tag == WAVE_FORMAT_EXTENSIBLE && chunk_size >= 40) {
+        format_tag = static_cast<uint16_t>(ReadLe32(format.data() + 24));
+      }
+      if (format_tag != WAVE_FORMAT_PCM &&
+          format_tag != WAVE_FORMAT_IEEE_FLOAT) {
+        return false;
+      }
+      result->channels = ReadLe16(format.data() + 2);
+      result->sample_rate = ReadLe32(format.data() + 4);
+      result->block_align = ReadLe16(format.data() + 12);
+      result->bits_per_sample = ReadLe16(format.data() + 14);
+      result->is_float = format_tag == WAVE_FORMAT_IEEE_FLOAT ? 1u : 0u;
+      const uint32_t expected_align =
+          result->channels * ((result->bits_per_sample + 7) / 8);
+      if (result->channels == 0 || result->sample_rate == 0 ||
+          result->bits_per_sample == 0 || result->block_align == 0 ||
+          result->block_align != expected_align) {
+        return false;
+      }
+      found_format = true;
+    } else if (memcmp(chunk_header, "data", 4) == 0) {
+      data_offset = payload;
+      data_size = chunk_size;
+    }
+    const uint64_t next =
+        static_cast<uint64_t>(payload) + chunk_size + (chunk_size & 1u);
+    const uint64_t max_stream_offset = static_cast<uint64_t>(
+        (std::numeric_limits<std::streamoff>::max)());
+    if (next > max_stream_offset) {
+      return false;
+    }
+    input.clear();
+    input.seekg(static_cast<std::streamoff>(next), std::ios::beg);
+    if (found_format && data_size != 0) break;
+  }
+  if (!found_format || data_size == 0 || data_offset <= 0) return false;
+
+  uint32_t retained = (std::min)(data_size, max_bytes);
+  retained -= retained % result->block_align;
+  if (retained == 0) return false;
+  result->bytes.resize(retained);
+  input.clear();
+  input.seekg(data_offset, std::ios::beg);
+  return input.read(reinterpret_cast<char*>(result->bytes.data()), retained)
+      .good();
+}
+
+uint64_t UnityClipSourceId(const wchar_t* clip_name) {
+  uint64_t hash = 1469598103934665603ull;
+  if (clip_name != nullptr) {
+    for (const wchar_t* cursor = clip_name; *cursor != 0; ++cursor) {
+      const uint32_t value = static_cast<uint32_t>(*cursor);
+      for (int shift = 0; shift < 32; shift += 8) {
+        hash ^= (value >> shift) & 0xffu;
+        hash *= 1099511628211ull;
+      }
+    }
+  }
+  return 0x554e000000000000ull | (hash & 0x0000ffffffffffffull);
+}
+
+bool CommitUnityWavePcm(SharedHeader* header, const UnityVoiceEvent& event,
+                        const std::wstring& output) {
+  if (header == nullptr || header->ring_capacity == 0 ||
+      header->clip_region_offset == 0) {
+    return false;
+  }
+  WavePcm wave;
+  if (!ReadUnityWavePcm(output, header->ring_capacity, &wave)) {
+    fprintf(stderr, "[unity-audio] invalid wav clip=%ls output=%ls\n",
+            event.clip_name, output.c_str());
+    return false;
+  }
+
+  const uint32_t byte_len = static_cast<uint32_t>(wave.bytes.size());
+  const uint32_t capacity = header->ring_capacity;
+  const uint64_t start = static_cast<uint64_t>(InterlockedExchangeAdd64(
+      reinterpret_cast<volatile LONGLONG*>(&header->total_written),
+      static_cast<LONGLONG>(byte_len)));
+  const uint32_t ring_offset = static_cast<uint32_t>(start % capacity);
+  uint8_t* const ring =
+      reinterpret_cast<uint8_t*>(header) + sizeof(SharedHeader);
+  const uint32_t first =
+      (std::min)(byte_len, capacity - ring_offset);
+  memcpy(ring + ring_offset, wave.bytes.data(), first);
+  if (byte_len > first) {
+    memcpy(ring, wave.bytes.data() + first, byte_len - first);
+  }
+  header->write_pos =
+      static_cast<uint32_t>((start + byte_len) % capacity);
+
+  if (header->sample_rate == 0) {
+    header->channels = wave.channels;
+    header->bits_per_sample = wave.bits_per_sample;
+    header->is_float = wave.is_float;
+    header->block_align = wave.block_align;
+    MemoryBarrier();
+    InterlockedCompareExchange(
+        reinterpret_cast<volatile LONG*>(&header->sample_rate),
+        static_cast<LONG>(wave.sample_rate), 0);
+  }
+
+  const uint64_t index = static_cast<uint64_t>(InterlockedExchangeAdd64(
+      reinterpret_cast<volatile LONGLONG*>(&header->clip_write_count), 1));
+  uint8_t* const clip_base =
+      reinterpret_cast<uint8_t*>(header) + header->clip_region_offset;
+  auto* clip = reinterpret_cast<VoiceClip*>(
+      clip_base + (index % kClipCount) * sizeof(VoiceClip));
+  clip->timestamp_ms = event.timestamp_ms;
+  clip->total_at_write = start + byte_len;
+  clip->ring_offset = ring_offset;
+  clip->byte_len = byte_len;
+  clip->sample_rate = wave.sample_rate;
+  clip->channels = wave.channels;
+  clip->bits_per_sample = wave.bits_per_sample;
+  clip->is_float = wave.is_float;
+  clip->pad = 0;
+  clip->source_ptr = UnityClipSourceId(event.clip_name);
+  MemoryBarrier();
+  clip->seq = index + 1;
+  fprintf(stderr,
+          "[unity-audio] committed clip=%ls bytes=%u format=%u/%u/%u "
+          "source=0x%016llx\n",
+          event.clip_name, byte_len, wave.sample_rate, wave.channels,
+          wave.bits_per_sample,
+          static_cast<unsigned long long>(clip->source_ptr));
+  return true;
+}
+
 bool ExtractUnityVoice(const UnityExtractorRuntime& runtime,
-                       const UnityVoiceEvent& event) {
-  if (!runtime.ready || event.bundle_path[0] == 0 ||
-      event.clip_name[0] == 0) {
+                       const std::wstring& data_directory,
+                       const UnityVoiceEvent& event, SharedHeader* header) {
+  if (!runtime.ready || event.clip_name[0] == 0 ||
+      (event.bundle_path[0] == 0 && data_directory.empty())) {
     return false;
   }
   wchar_t temp[MAX_PATH] = {0};
@@ -338,7 +547,9 @@ bool ExtractUnityVoice(const UnityExtractorRuntime& runtime,
       SafeVoiceFileName(event.clip_name) + L".wav";
 
   std::wstring command = QuoteWindowsArgument(runtime.executable) +
-      L" --bundle " + QuoteWindowsArgument(event.bundle_path) +
+      (event.bundle_path[0] == 0
+           ? L" --data-dir " + QuoteWindowsArgument(data_directory)
+           : L" --bundle " + QuoteWindowsArgument(event.bundle_path)) +
       L" --clip " + QuoteWindowsArgument(event.clip_name) +
       L" --output " + QuoteWindowsArgument(output) +
       L" --classdata " + QuoteWindowsArgument(runtime.classdata) +
@@ -360,16 +571,20 @@ bool ExtractUnityVoice(const UnityExtractorRuntime& runtime,
   DWORD exit_code = 2;
   if (wait == WAIT_OBJECT_0) GetExitCodeProcess(process.hProcess, &exit_code);
   CloseHandle(process.hProcess);
-  const bool ok = wait == WAIT_OBJECT_0 && exit_code == 0 &&
-                  RegularFileExists(output);
-  fprintf(stderr, "[unity-audio] %s clip=%ls bundle=%ls output=%ls\n",
-          ok ? "extracted" : "failed", event.clip_name,
-          event.bundle_path, output.c_str());
+  const bool extracted = wait == WAIT_OBJECT_0 && exit_code == 0 &&
+                         RegularFileExists(output);
+  const bool ok = extracted && CommitUnityWavePcm(header, event, output);
+  fprintf(stderr, "[unity-audio] %s clip=%ls input=%ls output=%ls\n",
+          ok ? "extracted-and-committed" : "failed", event.clip_name,
+          event.bundle_path[0] == 0 ? data_directory.c_str()
+                                    : event.bundle_path,
+          output.c_str());
   return ok;
 }
 
 void ProcessUnityVoiceEvents(SharedHeader* header,
                              const UnityExtractorRuntime& runtime,
+                             const std::wstring& data_directory,
                              uint64_t* next_event) {
   if (header == nullptr || next_event == nullptr || !runtime.ready) return;
   const uint64_t count = header->unity_voice_write_count;
@@ -389,7 +604,7 @@ void ProcessUnityVoiceEvents(SharedHeader* header,
     wcsncpy_s(event.clip_name, source->clip_name, _TRUNCATE);
     wcsncpy_s(event.bundle_path, source->bundle_path, _TRUNCATE);
     if (source->seq != expected_seq) break;
-    if (ExtractUnityVoice(runtime, event)) {
+    if (ExtractUnityVoice(runtime, data_directory, event, header)) {
       header->hook_diagnostics |= kDiagUnityResourceExtracted;
     } else {
       header->hook_diagnostics |= kDiagUnityResourceExtractFailed;
@@ -1140,6 +1355,7 @@ int RunInjection(HANDLE target, DWORD pid, const std::wstring& dll_path,
             static_cast<unsigned long long>(header->total_written));
   }
   const UnityExtractorRuntime unity_extractor = FindUnityExtractorRuntime();
+  const std::wstring unity_data_directory = FindUnityDataDirectory(target);
   if (unity_extractor.ready) {
     header->hook_diagnostics |= kDiagUnityResourceExtractorReady;
   } else {
@@ -1336,12 +1552,15 @@ int RunInjection(HANDLE target, DWORD pid, const std::wstring& dll_path,
     uint64_t next_unity_event = 0;
     if (hold_process != nullptr) {
       while (WaitForSingleObject(hold_process, 50) == WAIT_TIMEOUT) {
-        ProcessUnityVoiceEvents(header, unity_extractor, &next_unity_event);
+        ProcessUnityVoiceEvents(header, unity_extractor,
+                                unity_data_directory, &next_unity_event);
       }
-      ProcessUnityVoiceEvents(header, unity_extractor, &next_unity_event);
+      ProcessUnityVoiceEvents(header, unity_extractor,
+                              unity_data_directory, &next_unity_event);
     } else {
       for (;;) {
-        ProcessUnityVoiceEvents(header, unity_extractor, &next_unity_event);
+        ProcessUnityVoiceEvents(header, unity_extractor,
+                                unity_data_directory, &next_unity_event);
         Sleep(50);
       }
     }

--- a/native/galgame_hook/tests/adapter_structure_test.py
+++ b/native/galgame_hook/tests/adapter_structure_test.py
@@ -51,6 +51,45 @@ class AdapterStructureTest(unittest.TestCase):
         self.assertIn("DispatchNewModules();", source)
         self.assertIn("onModuleLoaded(entry.szModule);", source)
 
+    def test_unity_text_adapter_supports_legacy_ui_text(self) -> None:
+        source = (
+            ROOT / "hook" / "adapters" / "unity_adapter.inc"
+        ).read_text(encoding="utf-8")
+        self.assertIn(
+            'class_from_name(image, "UnityEngine.UI", "Text")', source
+        )
+        self.assertIn(
+            'FindIl2CppMethod(ui_text_class, "set_text", text_params, 1)',
+            source,
+        )
+        self.assertIn("Detour_UnityUiTextSetText", source)
+        self.assertIn('L"UnityEngine.UI.Text.set_text"', source)
+        self.assertIn(
+            "tmp_text_ready || ui_text_ready || text_mesh_ready ||",
+            source,
+        )
+        self.assertLess(
+            source.index("const bool text_hooks_ready"),
+            source.index('class_get_method(clip_class, "get_samples", 0)'),
+        )
+        for diagnostic in (
+            "kDiagUnityTextScanReady",
+            "kDiagUnityUiTextClassFound",
+            "kDiagUnityUiTextMethodFound",
+            "kDiagUnityUiTextHookReady",
+            "kDiagUnityTextMeshClassFound",
+            "kDiagUnityTextMeshMethodFound",
+            "kDiagUnityTextMeshHookReady",
+        ):
+            self.assertIn(diagnostic, source)
+        self.assertIn(
+            'class_from_name(image, "UnityEngine", "TextMesh")', source
+        )
+        self.assertIn('L"UnityEngine.TextMesh.set_text(glyphs)"', source)
+        self.assertIn("void FlushUnityTextMeshLine()", source)
+        self.assertIn("c == L'\\u3000'", source)
+        self.assertIn('"Unity TextMesh line"', source)
+
     def test_generated_adapters_have_compile_and_lifecycle_registration_seams(self) -> None:
         main = (ROOT / "hook" / "dll_main.cpp").read_text(encoding="utf-8")
         registry = (ROOT / "hook" / "adapter_registry.inc").read_text(encoding="utf-8")

--- a/native/galgame_hook/tests/adapter_structure_test.py
+++ b/native/galgame_hook/tests/adapter_structure_test.py
@@ -70,7 +70,7 @@ class AdapterStructureTest(unittest.TestCase):
         )
         self.assertLess(
             source.index("const bool text_hooks_ready"),
-            source.index('class_get_method(clip_class, "get_samples", 0)'),
+            source.index("bool any = audio_ready"),
         )
         for diagnostic in (
             "kDiagUnityTextScanReady",
@@ -89,6 +89,86 @@ class AdapterStructureTest(unittest.TestCase):
         self.assertIn("void FlushUnityTextMeshLine()", source)
         self.assertIn("c == L'\\u3000'", source)
         self.assertIn('"Unity TextMesh line"', source)
+
+    def test_unity_resource_observation_is_not_gated_by_pcm_helpers(self) -> None:
+        source = (
+            ROOT / "hook" / "adapters" / "unity_adapter.inc"
+        ).read_text(encoding="utf-8")
+        capture = source.split("void CaptureUnityAudioClip", 1)[1]
+        capture = capture.split("void ProcessUnityAudioEvent", 1)[0]
+        self.assertIn("EnqueueUnityAudioClip(source, clip);", capture)
+        self.assertNotIn("RecordUnityVoiceResourceEvent", capture)
+        self.assertNotIn("g_il2cpp_runtime_invoke", capture)
+        process = source.split("void ProcessUnityAudioEvent", 1)[1]
+        process = process.split("void ProcessPendingUnityAudioEvents()", 1)[0]
+        self.assertLess(
+            process.index("RecordUnityVoiceResourceEvent(event.clip, event.timestamp_ms);"),
+            process.index("const bool pcm_helpers_ready"),
+        )
+        registry = (
+            ROOT / "hook" / "adapter_registry.inc"
+        ).read_text(encoding="utf-8")
+        self.assertIn("unity_.ProcessPendingEvents();", registry)
+        install = source.split("bool TryHookUnityIl2CppAudio()", 1)[1]
+        self.assertLess(
+            install.index('class_get_method(source_class, "get_clip", 0)'),
+            install.index('class_get_method(clip_class, "GetData", 2)'),
+        )
+        self.assertLess(
+            install.index("pcm_helpers_ready ="),
+            install.index("kDiagUnityIl2CppHooksReady"),
+        )
+        self.assertLess(
+            install.index("kDiagUnityHooksDeferredUntilWindow"),
+            install.index('GetProcAddress(game, "il2cpp_domain_get")'),
+        )
+        self.assertLess(
+            install.index("kDiagUnityHooksDeferredUntilWindow"),
+            install.index("kDiagUnityIl2CppHooksReady"),
+        )
+        self.assertLess(
+            install.index("kDiagUnityHooksDeferredUntilWindow"),
+            install.index("bool tmp_text_ready"),
+        )
+        self.assertIn("HasCurrentProcessTopLevelWindow()", source)
+        for diagnostic in (
+            "kDiagUnityAudioClassFound",
+            "kDiagUnityAudioResourceMethodsFound",
+            "kDiagUnityAudioPcmMethodsFound",
+            "kDiagUnityAudioPlaybackMethodFound",
+            "kDiagUnityAudioPlaybackHookReady",
+            "kDiagUnityHooksDeferredUntilWindow",
+        ):
+            self.assertIn(diagnostic, source)
+
+    def test_unity_extracted_wav_is_committed_to_the_primary_audio_ring(self) -> None:
+        injector = (ROOT / "injector" / "injector_main.cpp").read_text(
+            encoding="utf-8"
+        )
+        parser = injector.split("bool ReadUnityWavePcm", 1)[1]
+        parser = parser.split("uint64_t UnityClipSourceId", 1)[0]
+        self.assertIn('memcmp(riff, "RIFF", 4)', parser)
+        self.assertIn('memcmp(riff + 8, "WAVE", 4)', parser)
+        self.assertIn("(std::min)(data_size, max_bytes)", parser)
+        self.assertIn("retained -= retained % result->block_align", parser)
+        commit = injector.split("bool CommitUnityWavePcm", 1)[1]
+        commit = commit.split("bool ExtractUnityVoice", 1)[0]
+        self.assertIn("InterlockedExchangeAdd64", commit)
+        self.assertIn("header->total_written", commit)
+        self.assertIn("header->clip_write_count", commit)
+        self.assertIn("header->clip_region_offset", commit)
+        self.assertIn("clip->timestamp_ms = event.timestamp_ms", commit)
+        self.assertIn("clip->seq = index + 1", commit)
+        self.assertLess(
+            commit.index("MemoryBarrier();"),
+            commit.index("clip->seq = index + 1"),
+        )
+        extraction = injector.split("bool ExtractUnityVoice", 1)[1]
+        extraction = extraction.split("void ProcessUnityVoiceEvents", 1)[0]
+        self.assertIn(
+            "extracted && CommitUnityWavePcm(header, event, output)",
+            extraction,
+        )
 
     def test_generated_adapters_have_compile_and_lifecycle_registration_seams(self) -> None:
         main = (ROOT / "hook" / "dll_main.cpp").read_text(encoding="utf-8")

--- a/native/galgame_hook/tools/build_distribution.ps1
+++ b/native/galgame_hook/tools/build_distribution.ps1
@@ -90,6 +90,29 @@ foreach ($file in @(
 )) {
   Copy-Item -LiteralPath (Join-Path $releaseX64 $file) -Destination $stageX64 -Force
 }
+$unityAudioRuntimeFiles = @(
+  'unity_audio_runtime/hibiki_unity_audio_extract.exe',
+  'unity_audio_runtime/classdata.tpk',
+  'unity_audio_runtime/vgmstream-cli.exe',
+  'unity_audio_runtime/avcodec-vgmstream-59.dll',
+  'unity_audio_runtime/avformat-vgmstream-59.dll',
+  'unity_audio_runtime/avutil-vgmstream-57.dll',
+  'unity_audio_runtime/swresample-vgmstream-4.dll',
+  'unity_audio_runtime/libatrac9.dll',
+  'unity_audio_runtime/libcelt-0061.dll',
+  'unity_audio_runtime/libcelt-0110.dll',
+  'unity_audio_runtime/libg719_decode.dll',
+  'unity_audio_runtime/libmpg123-0.dll',
+  'unity_audio_runtime/libspeex-1.dll',
+  'unity_audio_runtime/libvorbis.dll',
+  'unity_audio_runtime/COPYING'
+)
+foreach ($file in $unityAudioRuntimeFiles) {
+  $destination = Join-Path $stageX64 $file
+  New-Item -ItemType Directory -Path (Split-Path -Parent $destination) -Force |
+    Out-Null
+  Copy-Item -LiteralPath (Join-Path $releaseX64 $file) -Destination $destination -Force
+}
 foreach ($file in @(
   'hibiki_voice_injector.exe',
   'hibiki_voice_hook.dll',
@@ -129,12 +152,38 @@ Invoke-WebRequest `
   -OutFile (Join-Path $stageX86 'LocaleEmulator-LGPL-3.0.txt')
 
 $expected = @{
-  x64 = @('hibiki_voice_injector.exe', 'hibiki_voice_hook.dll', 'LunaHook64.dll', 'LunaHost64.dll')
+  x64 = @(
+    'hibiki_voice_injector.exe',
+    'hibiki_voice_hook.dll',
+    'LunaHook64.dll',
+    'LunaHost64.dll',
+    'unity_audio_runtime/hibiki_unity_audio_extract.exe',
+    'unity_audio_runtime/classdata.tpk',
+    'unity_audio_runtime/vgmstream-cli.exe',
+    'unity_audio_runtime/avcodec-vgmstream-59.dll',
+    'unity_audio_runtime/avformat-vgmstream-59.dll',
+    'unity_audio_runtime/avutil-vgmstream-57.dll',
+    'unity_audio_runtime/swresample-vgmstream-4.dll',
+    'unity_audio_runtime/libatrac9.dll',
+    'unity_audio_runtime/libcelt-0061.dll',
+    'unity_audio_runtime/libcelt-0110.dll',
+    'unity_audio_runtime/libg719_decode.dll',
+    'unity_audio_runtime/libmpg123-0.dll',
+    'unity_audio_runtime/libspeex-1.dll',
+    'unity_audio_runtime/libvorbis.dll',
+    'unity_audio_runtime/COPYING'
+  )
   x86 = @('hibiki_voice_injector.exe', 'hibiki_voice_hook.dll', 'LunaHook32.dll', 'LunaHost32.dll', 'LoaderDll.dll', 'LocaleEmulator.dll', 'LocaleEmulator-LGPL-3.0.txt')
 }
 foreach ($arch in @('x64', 'x86')) {
   $stage = Join-Path $outputRoot $arch
-  $actual = @(Get-ChildItem -LiteralPath $stage -File | ForEach-Object Name | Sort-Object)
+  $actual = @(
+    Get-ChildItem -LiteralPath $stage -File -Recurse |
+      ForEach-Object {
+        [IO.Path]::GetRelativePath($stage, $_.FullName).Replace('\', '/')
+      } |
+      Sort-Object
+  )
   $wanted = @($expected[$arch] | Sort-Object)
   if (Compare-Object $wanted $actual) {
     throw "arch $arch staged files differ: $($actual -join ', ')"

--- a/native/galgame_hook/unity_audio_extract/Program.cs
+++ b/native/galgame_hook/unity_audio_extract/Program.cs
@@ -7,7 +7,8 @@ namespace Hibiki.UnityAudioExtract;
 internal static class Program
 {
     private sealed record Options(
-        string Bundle,
+        string? Bundle,
+        string? DataDirectory,
         string Clip,
         string Output,
         string ClassData,
@@ -55,7 +56,8 @@ internal static class Program
             if (!args[i].StartsWith("--", StringComparison.Ordinal) || i + 1 >= args.Length)
             {
                 throw new ArgumentException(
-                    "usage: --bundle <path> --clip <name> --output <wav> " +
+                    "usage: (--bundle <path> | --data-dir <path>) " +
+                    "--clip <name> --output <wav> " +
                     "--classdata <classdata.tpk> --decoder <vgmstream-cli.exe>");
             }
             values[args[i][2..]] = args[++i];
@@ -75,19 +77,51 @@ internal static class Program
         {
             throw new ArgumentException("missing --clip");
         }
+        string? bundle = values.TryGetValue("bundle", out string? bundlePath) &&
+                         !string.IsNullOrWhiteSpace(bundlePath)
+            ? Path.GetFullPath(bundlePath)
+            : null;
+        string? dataDirectory =
+            values.TryGetValue("data-dir", out string? dataPath) &&
+            !string.IsNullOrWhiteSpace(dataPath)
+                ? Path.GetFullPath(dataPath)
+                : null;
+        if ((bundle is null) == (dataDirectory is null))
+        {
+            throw new ArgumentException(
+                "exactly one of --bundle or --data-dir is required");
+        }
         return new Options(
-            Required("bundle"), clip, Required("output"),
+            bundle, dataDirectory, clip, Required("output"),
             Required("classdata"), Required("decoder"));
     }
 
     private static void ExtractRawClip(Options options, string rawPath)
     {
-        if (!File.Exists(options.Bundle)) throw new FileNotFoundException("bundle not found", options.Bundle);
         if (!File.Exists(options.ClassData)) throw new FileNotFoundException("classdata.tpk not found", options.ClassData);
 
         var manager = new AssetsManager();
         manager.LoadClassPackage(options.ClassData);
-        BundleFileInstance bundle = manager.LoadBundleFile(options.Bundle, unpackIfPacked: true);
+        if (options.Bundle is not null)
+        {
+            ExtractFromBundle(manager, options.Bundle, options.Clip, rawPath);
+        }
+        else
+        {
+            ExtractFromLooseAssets(
+                manager, options.DataDirectory!, options.Clip, rawPath);
+        }
+    }
+
+    private static void ExtractFromBundle(
+        AssetsManager manager, string bundlePath, string clip, string rawPath)
+    {
+        if (!File.Exists(bundlePath))
+        {
+            throw new FileNotFoundException("bundle not found", bundlePath);
+        }
+        BundleFileInstance bundle =
+            manager.LoadBundleFile(bundlePath, unpackIfPacked: true);
         try
         {
             int directoryCount = bundle.file.BlockAndDirInfo.DirectoryInfos.Count;
@@ -100,7 +134,7 @@ internal static class Program
                 foreach (AssetFileInfo info in assets.file.GetAssetsOfType(AssetClassID.AudioClip))
                 {
                     AssetTypeValueField field = manager.GetBaseField(assets, info);
-                    if (!string.Equals(field["m_Name"].AsString, options.Clip,
+                    if (!string.Equals(field["m_Name"].AsString, clip,
                                        StringComparison.OrdinalIgnoreCase))
                     {
                         continue;
@@ -143,7 +177,102 @@ internal static class Program
             manager.UnloadAll();
         }
         throw new KeyNotFoundException(
-            $"AudioClip '{options.Clip}' was not found in '{options.Bundle}'");
+            $"AudioClip '{clip}' was not found in '{bundlePath}'");
+    }
+
+    private static void ExtractFromLooseAssets(
+        AssetsManager manager, string dataDirectory, string clip,
+        string rawPath)
+    {
+        if (!Directory.Exists(dataDirectory))
+        {
+            throw new DirectoryNotFoundException(
+                $"Unity data directory not found: {dataDirectory}");
+        }
+        var candidates = new List<string>
+        {
+            Path.Combine(dataDirectory, "resources.assets"),
+            Path.Combine(dataDirectory, "globalgamemanagers"),
+            Path.Combine(dataDirectory, "globalgamemanagers.assets"),
+        };
+        candidates.AddRange(
+            Directory.EnumerateFiles(
+                dataDirectory, "sharedassets*.assets",
+                SearchOption.TopDirectoryOnly));
+
+        try
+        {
+            foreach (string assetsPath in candidates.Distinct(
+                         StringComparer.OrdinalIgnoreCase))
+            {
+                if (!File.Exists(assetsPath)) continue;
+                AssetsFileInstance assets;
+                try
+                {
+                    assets = manager.LoadAssetsFile(
+                        assetsPath, loadDeps: false);
+                    manager.LoadClassDatabaseFromPackage(
+                        assets.file.Metadata.UnityVersion);
+                }
+                catch
+                {
+                    continue;
+                }
+
+                foreach (AssetFileInfo info in
+                         assets.file.GetAssetsOfType(AssetClassID.AudioClip))
+                {
+                    AssetTypeValueField field =
+                        manager.GetBaseField(assets, info);
+                    if (!string.Equals(
+                            field["m_Name"].AsString, clip,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+                    AssetTypeValueField resource = field["m_Resource"];
+                    string source = resource["m_Source"].AsString;
+                    long offset = resource["m_Offset"].AsLong;
+                    long size = resource["m_Size"].AsLong;
+                    if (size <= 0 || size > int.MaxValue)
+                    {
+                        throw new InvalidDataException(
+                            $"invalid AudioClip resource size {size}");
+                    }
+                    string resourceName =
+                        Path.GetFileName(source.Replace('\\', '/'));
+                    string resourcePath =
+                        Path.Combine(dataDirectory, resourceName);
+                    if (!File.Exists(resourcePath))
+                    {
+                        throw new FileNotFoundException(
+                            $"AudioClip resource '{resourceName}' not found",
+                            resourcePath);
+                    }
+                    using var stream = File.Open(
+                        resourcePath, FileMode.Open, FileAccess.Read,
+                        FileShare.ReadWrite);
+                    if (offset < 0 || offset + size > stream.Length)
+                    {
+                        throw new InvalidDataException(
+                            $"AudioClip range {offset}+{size} exceeds " +
+                            $"'{resourceName}'");
+                    }
+                    stream.Position = offset;
+                    byte[] bytes = new byte[(int)size];
+                    stream.ReadExactly(bytes);
+                    File.WriteAllBytes(rawPath, bytes);
+                    return;
+                }
+            }
+        }
+        finally
+        {
+            manager.UnloadAll();
+        }
+        throw new KeyNotFoundException(
+            $"AudioClip '{clip}' was not found in loose assets under " +
+            $"'{dataDirectory}'");
     }
 
     private static void Decode(string decoder, string rawPath, string outputPath)


### PR DESCRIPTION
## What changed

- capture legacy Unity `TextMesh` dialogue as complete lines for `最悪なる災厄人間に捧ぐ`
- defer IL2CPP probing and hook installation until the game owns a visible top-level window
- queue Unity audio events in detours and perform managed/resource work on the hook worker
- extract loose Unity `resources.assets` audio, decode WAV data, and publish bounded frame-aligned PCM plus `VoiceClip` metadata to the primary shared ring
- package the x64 Unity extraction runtime recursively and verify the same manifest from the Windows Hibiki installer
- add IPC diagnostics, structural guards, installer tests, and BUG-1200/BUG-1201 records

## Why

The game exposed two independent failures on its original Windows launch path:

1. legacy Unity text callbacks emitted glyph-sized fragments instead of complete dialogue;
2. Unity resource extraction produced WAV files, but the injector only set diagnostic bits and never committed the decoded PCM or clip index to shared memory.

Calling IL2CPP APIs before the Unity window existed also correlated with startup access violations and the reported disappearing game window. The adapter now waits for the visible game window before probing managed APIs.

## User impact

Using Hibiki's **启动并捕获** followed by **选择目标窗口**, the verified x64 session remained responsive through title, save loading, and voiced dialogue. Hibiki observed a `game_resource` clip for `09_leader1123` at 44.1 kHz, stereo, 16-bit, 504,576 bytes (about 5.72 seconds) and marked the matching line audio-ready.

Formal support remains `implemented_unverified`: full offline/x86 matrices and final card E2E were intentionally not run.

## Validation

- `cmake --build native/galgame_hook/build-sasasa-audio-x64 --config Debug --target hibiki_voice_injector`
- `python -m unittest native/galgame_hook/tests/adapter_structure_test.py` — 12 passed
- `flutter test test/mining/galgame_helper_installer_test.dart --no-pub` — 56 passed
- `dart run tool/bug.dart check` — 1162 records, unique numbers and synchronized index
- Windows Computer Use verification through Hibiki launch/capture and external-window selection

Per the original request, the full Flutter test suite and full application build were skipped.
