### PR TITLE
fix(reader): EPUB 内容文档按 OPF media-type 分类，扩展名表降为兜底 (BUG-1203)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1163 条。点号进各自文件。
+> 共 1164 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1203](bugs/BUG-1203-epub-opf-mediatype-html-classification.md) | ✅ | ✅ | EPUB 内容文档按扩展名分类导致怪扩展名章节整本渲染空白 |
 | [BUG-1202](bugs/BUG-1202-remote-library-cache-source-crosstalk.md) | ✅ | ✅ | 互联与云盘共用远端清单缓存槽，换来源后看到上一个来源的条目 |
 | [BUG-1201](bugs/BUG-1201-sasasa-unity-resource-pcm-not-published.md) | ✅ | ✅ | Sasasa Unity 资源音频已解码但未写入音频环 |
 | [BUG-1200](bugs/BUG-1200-sasasa-unity-textmesh-glyphs.md) | ✅ | ✅ | Sasasa Unity TextMesh 对白被拆成单字 |

--- a/docs/bugs/BUG-1203-epub-opf-mediatype-html-classification.md
+++ b/docs/bugs/BUG-1203-epub-opf-mediatype-html-classification.md
@@ -1,0 +1,37 @@
+## BUG-1203 · EPUB 内容文档按扩展名分类导致怪扩展名章节整本渲染空白
+- **报告**：2026-07-28（承接 BUG-1199 的审查结论：扩展名白名单是治标，下一本用别的扩展名的书会以完全相同的方式再空白一次）
+- **真实性**：✅ 真 bug（沿真实代码路径定位；与 BUG-1199 同一根因，BUG-1199 只补了白名单的两格）
+- **[x] ① 已修复** — 判据换成 EPUB 自己声明的 media-type，扩展名表降为兜底
+- **[x] ② 已加自动化测试** — `hibiki/test/epub/epub_book_utils_test.dart`（`BUG-1203: content documents are classified by declared media-type` 组：真谓词行为 + 真查找链 + 源码守卫）
+- **[ ] ③ 未做真机复测** — `_readerResourcePayload` 是 `_ReaderHibikiPageState` 的私有方法，挂不上单测；「怪扩展名的书真能渲染出非空正文」这一环只能真机/离屏真实 WebView 验证，本轮**未做**
+- **备注**：见下
+
+### 根因
+
+`hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:167`（修复前）无条件
+
+```dart
+final String mime = fallbackMimeType(filePath);   // 只按文件扩展名查表
+...
+if ((mime == 'text/html' || mime.contains('xhtml')) && _settings != null) {
+```
+
+EPUB 规范只规定内容文档的 **media-type**（EPUB 3 = `application/xhtml+xml`，EPUB 2 另允许 `text/html`），**不规定文件扩展名**。所以任何扩展名白名单都必然漏：漏掉的章节被当二进制下发，`sanitizeXhtml`（BUG-079 / BUG-737）、样式注入、防闪烁全部跳过 → 书在书架上、目录也解析得出来，但正文一片空白，且**错误日志无任何记录**（不是异常路径，是判据取假）。
+
+BUG-1199（PR#520）往 `mimeTypeForFilePath` 补了 `.htm` / `.xht` 两格，属有意的治标，根因未动。
+
+真相源一直在手边：`EpubResource.mediaType` / `EpubChapter.mediaType`（`hibiki/lib/src/epub/epub_parser.dart:91` / `:473`）已从 OPF manifest 落库，`EpubBook.mediaType()`（`hibiki/lib/src/epub/epub_book.dart:56`）此前**全仓零调用**，而 `_readerResourcePayload` 所在的 State 本来就持有 `_book`。
+
+### 修复
+
+1. `hibiki/lib/src/epub/epub_book.dart` — 新增共享顶层谓词 `bool isHtmlMediaType(String)`，由 `EpubParser._isHtmlMediaType` 提升而来（原私有副本删除，解析器改调共享版），全仓**只此一份**，杜绝平行副本漂移。
+2. `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart` — 分类改为 media-type 优先：用已 canonicalize 的 `filePath` 反推出与解析器建表同构造的相对 href，查 `_book?.mediaType(...)`；`EpubBook.mediaType` 自带「manifest 未声明则按扩展名兜底」，故 book 未就绪 / 资源不在 manifest / OPF 缺项三种情况都自然退回扩展名表。判据取 `isHtmlMediaType(declared) || isHtmlMediaType(ext)`——**只放宽不收紧**，OPF 把 xhtml 错标成 `text/plain` 时扩展名仍兜住。
+3. **下发的 Content-Type 仍一律 `text/html`**，绝不回 `application/xhtml+xml`：后者让渲染器切严格 XML 解析，出版社 EPUB 普遍存在的 well-formedness 瑕疵会变成整页 parse error，而 BUG-079 / BUG-737 的 `sanitizeXhtml` 是为 HTML5 解析语义写的补偿，切走后不再防护那两类故障。分类与下发被明确拆成两件事。
+4. `hibiki/lib/src/pages/implementations/reader_hibiki_page.dart` `_buildBookFromDb` — 该 DB 元数据回退路径（OPF 解析失败时走）此前不建 `resources`，media-type 真相源在那条路上是空的，判据会退化回纯扩展名。改为用 `chaptersJson` 里逐章存着的 `mediaType` 灌满 `resources`（key 与解析器同构造），主路径与回退路径共用同一份真相源，拦截器里无需分叉。
+
+### 验证
+
+- `flutter analyze` → No issues found!
+- `dart run tool/flutter_test_failures.dart --no-pub test/epub/ test/reader/ test/pages/reader_hibiki_page_*`，VERDICT 见提交说明。
+- **变异实测**：把拦截器判据退回 `fallbackMimeType` + 旧谓词后，BUG-1203 组转红（详见 PR 说明）。
+- ⚠️ 未做真机复测（见上面 ③）。

--- a/hibiki/lib/src/epub/epub_book.dart
+++ b/hibiki/lib/src/epub/epub_book.dart
@@ -600,3 +600,26 @@ String normalizeHref(String href) => href
 /// 命名统一轮 G8：收敛到 hibiki_core 单一映射表 [mimeTypeForFilePath]（旧本地副本
 /// 缺 `.webp` 等，EPUB 内 webp 插图曾被按 octet-stream 提供）。保留旧名薄 shim。
 String fallbackMimeType(String path) => mimeTypeForFilePath(path);
+
+/// BUG-1203：一个 media-type 是不是「EPUB 内容文档」（该走 HTML 处理链的网页）。
+///
+/// EPUB 只规定内容文档的 **media-type**（EPUB 3 为 `application/xhtml+xml`，
+/// EPUB 2 另允许 `text/html`），**没有**规定文件扩展名——`.htm` / `.xht` / 甚至无
+/// 扩展名都合法，所以「按扩展名猜」天然是漏的：漏一个就整本正文空白且无错误日志。
+///
+/// 唯一实现，两处消费：[EpubParser] 筛 spine 用它；阅读器资源拦截器
+/// (`reader_hibiki/webview.part.dart` 的 `_readerResourcePayload`) 判「要不要净化 +
+/// 注样式 + 当文档渲染」也用它。**不要抄第二份平行谓词**——抄本会漂移，一边改了另一
+/// 边没跟就是静默空白页。
+///
+/// ⚠️ 本谓词只用于**分类**。分类命中后下发给 WebView 的 Content-Type 仍必须是
+/// `text/html`，绝不能回 `application/xhtml+xml`：后者让渲染器切到严格 XML 解析，
+/// 出版社 EPUB 普遍存在的 well-formedness 瑕疵会直接变成整页 parse error，而
+/// BUG-079 / BUG-737 的 `sanitizeXhtml`（为 HTML5 解析器补偿自闭合标签）是针对
+/// HTML5 解析语义设计的，切走后既失去意义也不再防护那两类空白/查不了词。
+bool isHtmlMediaType(String mediaType) {
+  final String lower = mediaType.trim().toLowerCase();
+  return lower == 'application/xhtml+xml' ||
+      lower == 'text/html' ||
+      lower.endsWith('+html');
+}

--- a/hibiki/lib/src/epub/epub_parser.dart
+++ b/hibiki/lib/src/epub/epub_parser.dart
@@ -423,7 +423,8 @@ class EpubParser {
       if (item == null) {
         continue;
       }
-      if (!_isHtmlMediaType(item.mediaType)) {
+      // BUG-1203：与阅读器资源拦截器共用同一个谓词（epub_book.dart），不再各留副本。
+      if (!isHtmlMediaType(item.mediaType)) {
         continue;
       }
 
@@ -774,13 +775,6 @@ class EpubParser {
     } on ArgumentError {
       return href;
     }
-  }
-
-  static bool _isHtmlMediaType(String mediaType) {
-    final String lower = mediaType.toLowerCase();
-    return lower == 'application/xhtml+xml' ||
-        lower == 'text/html' ||
-        lower.endsWith('+html');
   }
 }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -154,8 +154,9 @@ extension _ReaderWebView on _ReaderHibikiPageState {
 
     final String epubPath =
         Uri.decodeComponent(path.substring('/epub/'.length));
+    final String canonExtractDir = p.canonicalize(_extractDir!);
     final String filePath = p.canonicalize(p.join(_extractDir!, epubPath));
-    if (!p.isWithin(p.canonicalize(_extractDir!), filePath)) {
+    if (!p.isWithin(canonExtractDir, filePath)) {
       return _forbidden('path traversal blocked: $epubPath');
     }
     final File file = File(filePath);
@@ -164,7 +165,30 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     }
 
     Uint8List data = await file.readAsBytes();
-    final String mime = fallbackMimeType(filePath);
+
+    // BUG-1203：「这是不是一个该走 HTML 处理链的内容文档」以 **EPUB 自己声明的
+    // media-type** 为准，扩展名表只在声明缺失/畸形时兜底。EPUB 不规定内容文档的
+    // 文件扩展名，只规定 media-type，所以任何扩展名白名单都必然漏（BUG-1199 补了
+    // `.htm`/`.xht` 之后，下一本用别的扩展名甚至无扩展名的书会以同样方式空白）。
+    //
+    // 查找键与 [EpubParser] 建 resources 表时同构造（canonicalize 后相对 extractDir
+    // 的 posix 相对路径），所以用已 canonicalize 的 filePath 反推，而不是直接拿 URL
+    // 里的 epubPath——后者会被大小写、`./`、百分号编码差异带偏而静默查不到。
+    final String declaredHref =
+        p.relative(filePath, from: canonExtractDir).replaceAll('\\', '/');
+    final String extMime = fallbackMimeType(filePath);
+    // [EpubBook.mediaType] 自带「manifest 未声明就按扩展名兜底」，故 book 未就绪 /
+    // 资源不在 manifest / OPF 缺 media-type 三种情况都自然退回 extMime。
+    final String declaredMime = _book?.mediaType(declaredHref) ?? extMime;
+    // 两个真相源任一认它是 HTML 就当 HTML：只放宽不收紧，OPF 声明畸形（例如把 xhtml
+    // 标成 text/plain）时仍由扩展名兜住，不会比改动前更差。
+    final bool isHtmlDocument =
+        isHtmlMediaType(declaredMime) || isHtmlMediaType(extMime);
+    // ⚠️ 分类归分类，下发的 Content-Type 一律 `text/html`，绝不回
+    // `application/xhtml+xml`：那会让渲染器切到严格 XML 解析，出版社 EPUB 常见的
+    // well-formedness 瑕疵会变成整页 parse error，且 BUG-079 / BUG-737 的
+    // `sanitizeXhtml` 是为 HTML5 解析语义写的补偿，切走后不再防护那两类故障。
+    final String mime = isHtmlDocument ? 'text/html' : extMime;
 
     if (mime == 'text/css') {
       data = _sanitizedCssCache.putIfAbsent(filePath, () {
@@ -175,7 +199,7 @@ extension _ReaderWebView on _ReaderHibikiPageState {
       });
     }
 
-    if ((mime == 'text/html' || mime.contains('xhtml')) && _settings != null) {
+    if (isHtmlDocument && _settings != null) {
       // BUG-270 (TODO-296 B): repeat chapter visits (forward/back paging,
       // prefetched chapters) reuse the sanitized + style-injected bytes from
       // the LRU cache instead of re-reading/decoding/sanitizing/injecting. The

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1887,18 +1887,34 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
     if (rawChapters.isEmpty) return null;
 
     final List<EpubChapter> chapters = <EpubChapter>[];
+    // BUG-1203：资源拦截器按 [EpubBook.mediaType]（即 resources 表）判「这是不是该
+    // 走 HTML 处理链的内容文档」。这条 DB 元数据回退路径此前不建 resources，判据在
+    // 这里只能退回扩展名猜测——正是「OPF 解析失败 + 章节用怪扩展名」这本书会整本
+    // 空白的场景。chaptersJson 里逐章存着导入时解析到的 mediaType，直接灌进去，
+    // 主路径与回退路径就用同一份真相源，无需在拦截器里分叉。
+    final Map<String, EpubResource> resources = <String, EpubResource>{};
+    final String canonExtractDir = p.canonicalize(extractDir);
     for (int i = 0; i < rawChapters.length; i++) {
       final Map<String, dynamic> ch = rawChapters[i] as Map<String, dynamic>;
       final String href = ch['href'] as String;
       final File file = File(p.join(extractDir, href));
       final String html = file.existsSync() ? file.readAsStringSync() : '';
+      final String mediaType = ch['mediaType'] as String? ?? 'text/html';
       chapters.add(EpubChapter(
         id: ch['id'] as String? ?? 'section-$i',
         href: href,
-        mediaType: ch['mediaType'] as String? ?? 'text/html',
+        mediaType: mediaType,
         html: html,
         spineIndex: i,
       ));
+      // key 与 EpubParser 建表时同构造（canonicalize 后相对 extractDir 的 posix
+      // 路径），拦截器才查得到。
+      final String absPath = p.canonicalize(p.join(extractDir, href));
+      if (!p.isWithin(canonExtractDir, absPath)) continue;
+      final String relPath =
+          p.relative(absPath, from: canonExtractDir).replaceAll('\\', '/');
+      resources[normalizeHref(relPath)] =
+          EpubResource(mediaType: mediaType, filePath: absPath);
     }
 
     List<EpubTocItem> toc = const <EpubTocItem>[];
@@ -1926,6 +1942,7 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       // 分支永不进，制卡恒无封面。row.coverPath 正是导入时落库的相对封面路径
       // （epub_importer.dart: coverPath = book.coverHref），与 _extractDir 拼接即封面文件。
       coverHref: row.coverPath,
+      resources: resources,
       rootDirectory: extractDir,
     );
   }

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+965
+version: 1.3.1+966
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/epub/epub_book_utils_test.dart
+++ b/hibiki/test/epub/epub_book_utils_test.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -66,52 +67,139 @@ void main() {
       expect(fallbackMimeType('chapter.xhtml'), 'text/html');
     });
 
-    // BUG-1199：`.htm` / `.xht` 是 EPUB 3 允许的内容文档扩展名，表里漏了这两条时
-    // 章节按 octet-stream 下发，阅读器既不净化也不注样式，整本翻页空白。
+    // BUG-1203（承接 BUG-1199）：阅读器拦截器判「这是不是一个该走 HTML 处理链的
+    // 内容文档」的**真相源是 EPUB 自己声明的 media-type**，扩展名表只在声明缺失时
+    // 兜底。BUG-1199 只往扩展名表补了 `.htm` / `.xht`，那是治标——EPUB 不规定内容
+    // 文档的扩展名，只规定 media-type，下一本用别的怪扩展名（甚至无扩展名）的书会
+    // 以完全相同的方式整本空白且不写任何错误日志。
     //
-    // 下面的 [readerTreatsAsHtml] 是阅读器拦截器
-    // (`webview.part.dart` `_readerResourcePayload`) 那条判定的**复刻**——复刻会
-    // 漂移，所以另配一条源码守卫（`interceptor predicate is still the one
-    // replicated here`）锁住被复刻的原文；实现侧改了谓词而这里没跟，守卫先红。
-    group('BUG-1199: all EPUB content-document extensions serve as HTML', () {
-      // 与 webview.part.dart 逐字对应；改这里必须同步改下面守卫里的字面量。
-      const String interceptorHtmlPredicate =
-          "mime == 'text/html' || mime.contains('xhtml')";
+    // 本组不复刻拦截器的谓词（复刻会漂移，是假绿的常见来源），而是：
+    // ① 直接测拦截器真正调用的那个公开谓词 [isHtmlMediaType]；
+    // ② 直接测拦截器真正走的那条查找链 [EpubBook.mediaType]（声明优先 / 扩展名兜底）；
+    // ③ 用源码守卫钉住拦截器方法体里的**新契约**（media-type 优先 + 一律以
+    //    text/html 下发），实现侧退回旧的「只按扩展名」写法立刻转红。
+    group('BUG-1203: content documents are classified by declared media-type',
+        () {
+      test('isHtmlMediaType accepts every EPUB content-document media-type',
+          () {
+        expect(isHtmlMediaType('application/xhtml+xml'), isTrue);
+        expect(isHtmlMediaType('text/html'), isTrue);
+        // `+html` 结构化后缀（EPUB 2 遗留 / 厂商变体）。
+        expect(isHtmlMediaType('application/vnd.pub+html'), isTrue);
+        // 大小写与首尾空白由 OPF 手写而来，必须容忍。
+        expect(isHtmlMediaType('  APPLICATION/XHTML+XML '), isTrue);
+      });
 
-      bool readerTreatsAsHtml(String path) {
-        final String mime = fallbackMimeType(path);
-        return mime == 'text/html' || mime.contains('xhtml');
+      test('isHtmlMediaType rejects non-document media-types', () {
+        expect(isHtmlMediaType('image/jpeg'), isFalse);
+        expect(isHtmlMediaType('text/css'), isFalse);
+        expect(isHtmlMediaType('application/octet-stream'), isFalse);
+        // 「像 html」但不是内容文档：不能靠 contains('html') 之类的松判据放行。
+        expect(isHtmlMediaType('text/htmlish'), isFalse);
+        expect(isHtmlMediaType('application/xhtml+xml-fragment'), isFalse);
+      });
+
+      // 根治判据：扩展名再怪、甚至根本没有扩展名，只要 OPF 声明了内容文档
+      // media-type，拦截器就必须把它当网页处理。这条是 BUG-1199 的扩展名白名单
+      // **永远做不到**的。
+      for (final String href in <String>[
+        'OEBPS/text/chapter1', // 无扩展名
+        'OEBPS/text/chapter1.xml',
+        'OEBPS/text/chapter1.chapter',
+      ]) {
+        test('declared media-type wins for unusual href "$href"', () {
+          final EpubBook book = EpubBook(
+            title: 'T',
+            chapters: const <EpubChapter>[],
+            resources: <String, EpubResource>{
+              href: EpubResource(mediaType: 'application/xhtml+xml'),
+            },
+          );
+          expect(fallbackMimeType(href), isNot('text/html'),
+              reason: '前提：这个 href 靠扩展名表是判不出 HTML 的，'
+                  '否则本用例证明不了 media-type 优先');
+          expect(isHtmlMediaType(book.mediaType(href)), isTrue,
+              reason: 'OPF 声明是内容文档，拦截器必须当网页处理'
+                  '（否则整本正文空白且无错误日志）');
+        });
       }
 
-      test('interceptor predicate is still the one replicated here', () {
+      // 兜底契约：OPF 缺项 / 资源不在 manifest 时退回扩展名表——BUG-1199 补的
+      // `.htm` / `.xht` 仍然是这条兜底路径上必须成立的行为。
+      for (final String ext in <String>['xhtml', 'html', 'htm', 'xht']) {
+        test('.$ext falls back to HTML when the OPF declares nothing', () {
+          final EpubBook book = EpubBook(
+            title: 'T',
+            chapters: const <EpubChapter>[],
+            resources: const <String, EpubResource>{}, // manifest 查不到
+          );
+          expect(isHtmlMediaType(book.mediaType('OEBPS/c01.$ext')), isTrue,
+              reason: '.$ext must not fall back to octet-stream — the reader '
+                  'would skip sanitize/style injection and render blank');
+        });
+      }
+
+      test('a malformed OPF declaration cannot un-classify a known extension',
+          () {
+        // 只放宽不收紧：OPF 把 xhtml 错标成 text/plain 时，扩展名仍须兜住，
+        // 否则「换成 media-type 优先」本身会变成新的空白页来源。
+        final EpubBook book = EpubBook(
+          title: 'T',
+          chapters: const <EpubChapter>[],
+          resources: <String, EpubResource>{
+            'OEBPS/c01.xhtml': EpubResource(mediaType: 'text/plain'),
+          },
+        );
+        final String declared = book.mediaType('OEBPS/c01.xhtml');
+        final String ext = fallbackMimeType('OEBPS/c01.xhtml');
+        expect(isHtmlMediaType(declared) || isHtmlMediaType(ext), isTrue);
+      });
+
+      test('the shared predicate has no parallel copy in the parser', () {
+        final String parser =
+            File('lib/src/epub/epub_parser.dart').readAsStringSync();
+        expect(parser.contains('_isHtmlMediaType'), isFalse,
+            reason: '解析器又抄回了一份私有谓词——两份判据必然漂开，'
+                '一边认怪 media-type 另一边不认就是静默空白页');
+        expect(parser.contains('isHtmlMediaType('), isTrue,
+            reason: '解析器筛 spine 必须走共享谓词');
+      });
+
+      test('interceptor classifies by media-type and still serves text/html',
+          () {
         final String reader = readReaderPageSource();
         final int payloadIdx = reader
             .indexOf('Future<_ReaderResourceResponse> _readerResourcePayload(');
         expect(payloadIdx, greaterThan(0),
-            reason: '_readerResourcePayload 被改名/搬走——本组复刻的谓词已失去锚点');
+            reason: '_readerResourcePayload 被改名/搬走——本组守卫已失去锚点');
         final int endIdx =
             reader.indexOf('Future<WebResourceResponse?> _interceptRequest(');
         expect(endIdx, greaterThan(payloadIdx));
         final String payloadBody = reader.substring(payloadIdx, endIdx);
 
+        expect(payloadBody.contains('_book?.mediaType('), isTrue,
+            reason: '拦截器不再读 EPUB 声明的 media-type，退回「按扩展名猜」——'
+                'BUG-1203 的根因原样复活');
+        expect(payloadBody.contains('isHtmlMediaType('), isTrue,
+            reason: '拦截器必须复用共享谓词 isHtmlMediaType，'
+                '不得在本地另写一份平行判据');
         expect(payloadBody.contains('fallbackMimeType(filePath)'), isTrue,
-            reason: '拦截器一旦不再按扩展名表定 MIME（例如改读 OPF media-type），'
-                '本组「补全扩展名表」的断言就不再代表真实渲染判据，必须重写');
-        expect(payloadBody.contains(interceptorHtmlPredicate), isTrue,
-            reason: '拦截器判「是不是 HTML 文档」的谓词变了，'
-                '本组复刻的 readerTreatsAsHtml 已与实现脱节');
+            reason: 'OPF 允许缺 media-type，扩展名兜底不能被删掉');
+        expect(payloadBody.contains("isHtmlDocument ? 'text/html'"), isTrue,
+            reason: '内容文档必须一律以 text/html 下发；一旦改成回声 OPF 声明的'
+                ' application/xhtml+xml，渲染器切严格 XML 解析，'
+                'BUG-079 / BUG-737 的 sanitizeXhtml 补偿失效');
+        // 只禁 **Dart 字符串字面量**形式（注释里为解释约束会写到这个词，
+        // 用反引号包裹，不带单引号，故不会误伤自己）。
+        expect(payloadBody.contains("'application/xhtml+xml'"), isFalse,
+            reason: '拦截器方法体里出现这个字符串字面量，几乎必然是把它当成了下发的'
+                ' Content-Type 或又抄了一份本地谓词——两者都不允许');
+        expect(
+            payloadBody
+                .contains("mime == 'text/html' || mime.contains('xhtml')"),
+            isFalse,
+            reason: '旧的纯扩展名谓词回来了——BUG-1203 的根因原样复活');
       });
-
-      for (final String ext in <String>['xhtml', 'html', 'htm', 'xht']) {
-        test('.$ext chapter is served as an HTML document', () {
-          expect(
-            readerTreatsAsHtml('OEBPS/Dick_9780345508553_epub_c01_r1.$ext'),
-            isTrue,
-            reason: '.$ext must not fall back to octet-stream — the reader '
-                'would skip style/pagination injection and render blank',
-          );
-        });
-      }
     });
 
     test('case insensitive extension matching', () {

--- a/packages/hibiki_core/lib/src/utils/mime_types.dart
+++ b/packages/hibiki_core/lib/src/utils/mime_types.dart
@@ -28,11 +28,13 @@ const Map<String, String> kMimeTypeByExtension = <String, String>{
   'epub': 'application/epub+zip',
   'css': 'text/css',
   'js': 'application/javascript',
-  // BUG-1199：`.htm` / `.xht` 与 `.html` / `.xhtml` 是同一类文档的合法扩展名，缺
-  // 这两条时 EPUB 章节按 [kFallbackMimeType]（octet-stream）下发，阅读器拦截器的
-  // 「是 HTML 吗」判定（`mime == 'text/html' || mime.contains('xhtml')`）取假 →
-  // 既不注入阅读器样式/分页脚本、也不做 XHTML 净化，WebView 更不把它当文档渲染，
-  // 整本书翻页全空白。EPUB 3 规范允许这四种扩展名，表必须四条齐全。
+  // BUG-1199 / BUG-1203：`.htm` / `.xht` 与 `.html` / `.xhtml` 是同一类文档的合法
+  // 扩展名。阅读器拦截器判「这是不是内容文档」现在以 OPF 声明的 media-type 为准
+  // （`isHtmlMediaType`，见 `hibiki/lib/src/epub/epub_book.dart`），本表只是 OPF
+  // 缺项 / 畸形时的**兜底**——但兜底路径同样不能漏：漏掉时章节按
+  // [kFallbackMimeType]（octet-stream）下发，既不注入阅读器样式/分页脚本、也不做
+  // XHTML 净化，WebView 更不把它当文档渲染，整本书翻页全空白且无错误日志。
+  // EPUB 3 规范允许这四种扩展名，表必须四条齐全。
   'xhtml': 'text/html',
   'html': 'text/html',
   'htm': 'text/html',


### PR DESCRIPTION
承接 PR#520 / BUG-1199 的审查结论：扩展名白名单是**治标**——EPUB 只规定内容文档的
media-type，不规定文件扩展名，所以下一本用怪扩展名（甚至无扩展名）的书会以完全
相同的方式整本渲染空白，且错误日志无任何记录。本 PR 把判据换成 EPUB 自己声明的
media-type。

## 改了什么

- **`hibiki/lib/src/epub/epub_book.dart`** — 新增共享顶层谓词 `isHtmlMediaType`，
  由 `EpubParser._isHtmlMediaType` 提升（私有副本删除，解析器改调共享版）。全仓
  只此一份，杜绝「手抄平行谓词然后漂开」。
- **`reader_hibiki/webview.part.dart` `_readerResourcePayload`** — 分类改为
  media-type 优先：用已 canonicalize 的 `filePath` 反推出与解析器建 `resources`
  表**同构造**的相对 href（避开 URL 大小写 / `./` / 百分号编码差异），查
  `_book?.mediaType(...)`。该方法自带「manifest 未声明则按扩展名兜底」，故
  book 未就绪 / 资源不在 manifest / OPF 缺 media-type 三种情况都自然退回扩展名表。
  判据取 `isHtmlMediaType(declared) || isHtmlMediaType(ext)`，**只放宽不收紧**。
- 🔴 **分类 ≠ 下发**：命中后下发的 Content-Type 仍一律 `text/html`，绝不回
  `application/xhtml+xml`。理由有两条，且都**不是**「XML 解析会破坏
  `sanitizeXhtml` 的输出」（`<tag></tag>` 在 XML 下同样合法）：
  ① `sanitizeXhtml` 本身就是**为 HTML5 解析语义写的补偿**，切到 XML 后它变成
  无用，BUG-079 / BUG-737 那两类故障失去全部防护；
  ② 严格 XML 下**任何** well-formedness 瑕疵（出版社 EPUB 里很常见）会直接变成
  整页 parse error，**比原病更严重**。
- **`mime_types.dart`** — 更新被本次改动作废的注释（引用的是旧判据原文）。

### ⚠️ 一处超出原定最小范围的改动（已获裁定保留，此处留痕）

- **`reader_hibiki_page.dart` `_buildBookFromDb`** — 这条 DB 元数据回退路径
  （`parseBookOnly` 抛 `FormatException`，即 OPF 解析失败时走）此前不建
  `resources`，media-type 真相源在那条路上是空的，新判据会退化回纯扩展名——而那
  恰恰是「怪扩展名的书」最可能落到的路径。改为用 `chaptersJson` 里逐章存着的
  `mediaType` 灌满 `resources`（key 与解析器同构造）。
- **这段超出了原定的最小改动范围**，如实标明：`resources` 还被
  `EpubBook.readResource` 消费（填入后会先命中 map 读 `filePath`，而非走
  `rootDirectory` 拼接——两者指向同一个文件，行为等价）；但这一结论**只做了代码
  推理，没有跑到「OPF 解析失败」那条真实路径上验证**。如需收敛范围可以拆掉这一段，
  代价是根因在该回退路径上等于没修。

## 测试

PR#520 那条源码守卫钉的是**旧形状**（方法体里仍有 `fallbackMimeType(filePath)`
与旧谓词原文），本次改判据必然让它红——这是**契约变更不是回归**，故重写为钉住
**新契约**，并把「复刻拦截器谓词」这种易漂移写法换成：

1. 直接测拦截器真正调用的公开谓词 `isHtmlMediaType`（正向 + 负向，含
   `text/htmlish` / `application/xhtml+xml-fragment` 这类不能被松判据放行的）；
2. 直接测真查找链 `EpubBook.mediaType`——无扩展名 / `.xml` / `.chapter` 三种
   **扩展名表判不出**的 href，只要 OPF 声明了内容文档就必须当网页处理（这条是
   BUG-1199 的白名单永远做不到的）；反向再钉兜底契约与「OPF 畸形不能反而
   un-classify 已知扩展名」；
3. 源码守卫钉新契约：`_book?.mediaType(` / `isHtmlMediaType(` /
   `fallbackMimeType(filePath)` / `isHtmlDocument ? 'text/html'` 必须在，
   旧谓词原文与 `'application/xhtml+xml'` 字符串字面量必须不在；解析器里不得
   再出现 `_isHtmlMediaType`。

**变异实测**（把修复退回去，确认断言真转红）：

| 变异 | 转红 |
|---|---|
| A：拦截器判据整块退回 `fallbackMimeType` + 旧谓词 | 1 条（`interceptor classifies by media-type…`，首条断言即命中） |
| B+C：解析器抄回私有 `_isHtmlMediaType` ＋ 下发改成 `application/xhtml+xml` | 2 条（`the shared predicate has no parallel copy in the parser` ＋ `interceptor classifies…`） |

验证（已 rebase 到 `21c98af83` 后重跑）：

- `flutter analyze` → `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/epub/ test/reader/ test/pages/reader_chapter_html_cache_test.dart test/pages/reader_hibiki_page_source_corpus_test.dart test/sync/mime_types_test.dart`
  → `FLUTTER TEST VERDICT: PASSED`，退出码 0。
- rebase 冲突仅 `docs/BUGS.md`（跑 `bug.dart reindex` 重生成，未手改）与
  `hibiki/pubspec.yaml`（保留 `+966`）；**源码零冲突**，含 PR#520 刚改过的
  `webview.part.dart`。BUG-1203 已跨全部远端分支复扫，号唯一。

## 🔴 未验证 / 需注意

- **未做真机复测**。`_readerResourcePayload` 是 `_ReaderHibikiPageState` 的私有
  方法，挂不上单测；「怪扩展名的书真能渲染出非空正文」这一环只能真机 / 离屏真实
  WebView 验证，本轮**没做**，BUG-1203 文档里如实留 `[ ] ③`。
- 上面那段 `_buildBookFromDb` 的超范围改动，及其未走真实路径验证的推理。
- 审查提到 `.xht` 在另外 5 处白名单（阅读器降级路径、拖拽分类、txt→epub、漫画包
  判定、Anki 去重）也缺——本 PR **有意不碰**，它们不影响开书。
- 版本：`+build 965 → 966`。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
