### PR TITLE
fix(download): 字幕配对推迟到种子 add 之后，按包内真实文件名反查（BUG-1206）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1166 条。点号进各自文件。
+> 共 1167 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1206](bugs/BUG-1206-jimaku-season-pack-wrong-season-match.md) | ✅ | ✅ | 整季包字幕按标题猜集号导致错季配对且条数无上界 |
 | [BUG-1205](bugs/BUG-1205-video-mining-cover-audio-serial.md) | ✅ | ✅ | 视频制卡封面与句子音频串行且失败来源靠调用顺序区分 |
 | [BUG-1204](bugs/BUG-1204-lookup-audio-play-failure-reason-swallowed.md) | ✅ | ✅ | 浮窗单词发音首播失败且失败原因被吞无法定位 |
 | [BUG-1203](bugs/BUG-1203-epub-opf-mediatype-html-classification.md) | ✅ | ✅ | EPUB 内容文档按扩展名分类导致怪扩展名章节整本渲染空白 |

--- a/docs/bugs/BUG-1206-jimaku-season-pack-wrong-season-match.md
+++ b/docs/bugs/BUG-1206-jimaku-season-pack-wrong-season-match.md
@@ -1,0 +1,59 @@
+## BUG-1206 · 整季包字幕按标题猜集号导致错季配对且条数无上界
+- **报告**：2026-07-28（用户：审查 abcbab36 对 PR#515 的跟进）
+- **真实性**：✅ 真 bug。根因是**配对发生在还不知道包里有哪些文件的时候**。
+  `NyaaTorrent`（`hibiki/lib/src/media/torrent/nyaa_client.dart:31`）只有标题 +
+  体积，**没有文件列表**；种子要到用户点推送、`addTorrent` 之后引擎才给元数据，
+  而字幕在 `anime_download_dialog.dart:_push`（旧 L753-789）就已经下完了。于是
+  `chooseSubtitlesFor`（`anime_download_matching.dart:264`）只能靠标题猜：
+  - **错季**：整季包（`TorrentEpisodeScopeKind.season`）走 `_seasonEpisodes`
+    「取最前 cap 个」，Jimaku 条目用绝对集号编号（S2 编 13-24）时照样交出 13-24
+    的字幕，UI 画成「有字幕」——PR#515 只能把它降级成 `~` 不确定态，没根治。
+  - **条数无上界**：`seasonSubtitleCap`（同文件 L176）只有「标题自报 `全13話`」
+    与「AniList `media.episodes`」两个自述来源，两个都没有就 `return null`
+    = 不设上界；条目 24 集、包只 12 集时下满 24 条，多的永远配不上任何视频
+    （落位 `pairSubtitlesToVideos` 要求集号严格相等）。
+- **[x] ① 已修复** — 把配对推迟到种子 add 拿到元数据之后，按**包内真实视频文件名**
+  反查：
+  - 新纯函数 `matchJimakuFilesToVideoNames`
+    （`hibiki/lib/src/media/torrent/anime_download_matching.dart`）：视频集号走
+    `parseVideoFilename`、字幕集号走 `parseSubtitleEpisode`，**集号严格相等才配**；
+    只在「1 视频 + 字幕侧唯一确定」时做 1v1 兜底，且双方都有集号却不等时不兜底。
+    条数上界天然 = 真实视频文件数，不再需要任何自述上界启发式。
+  - 计划只记**意图**：`AnimeDownloadPlan` 新增 `jimakuEntryId` /
+    `jimakuEntryName` / `jimakuLanguage` / `subtitleStatus` / `subtitleNote`
+    （`none` / `pending` / `resolved` / `unavailable`）。
+  - 补取发生在完成钩子：`AnimeDownloadService._resolveSubtitles` →
+    `JimakuPlanSubtitleResolver`（`anime_download_subtitle_resolver.dart`），此刻
+    `_finishPlan` 手上已有引擎给的真实文件列表。
+  - **向后兼容**：老计划（无 `subtitleStatus`）decode 落 `resolved`/`none`，
+    完成时 resolver **不被调用**、已有 `subtitles` 不被重取或覆盖；
+    `_placeSidecars` 的「该集已有 sidecar 就跳过」原样保留（老档/手放档不动）。
+  - **降级不静默**：反查一条不配 / Jimaku 取不到 / 没接 resolver → 落
+    `subtitleUnavailable` + `subtitleNote`，任务行显示「字幕：未匹配到（可手动补）」，
+    视频照常入库不判失败。推送时 snack 说明「字幕将在下载完成后按包内实际文件配对」。
+  - 订阅路径（`anime_download_subscription.dart`）**未改行为**：它只追单集种子，
+    且有「要字幕却取不到就整条不下」的产品门，改成延迟会把该门变成「先下完再说
+    没字幕」；仅补齐 `subtitleStatus` 语义。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/torrent/anime_download_matching_test.dart`（group
+    `BUG-1206 matchJimakuFilesToVideoNames`，11 条）：**错季不再配上**（S2 包
+    01-12 × 绝对编号条目 13-24 → 结果为空）、**条数被真实文件数收敛**
+    （条目 24 集 × 包 12 集 → 恰好 12 条且集号是包里的）、部分覆盖、三种文件名
+    写法、语言偏好、1v1 兜底与「不猜」边界。
+  - `hibiki/test/torrent/anime_download_subtitle_resolver_test.dart`（5 条）：
+    集成层用 MockClient 断言**发出去的请求**——错季时一个 `/f/` 下载请求都不发；
+    条目 24 集时只发 12 个下载请求且不含第 13 集。
+  - `hibiki/test/torrent/anime_download_service_test.dart`（4 条）：完成时才调
+    resolver 且喂的是真实视频绝对路径、sidecar 只贴到对应那一集、失败落
+    `unavailable` + 原因且视频仍入库、**老计划 resolver 不被调用且旧字幕不被覆盖**。
+  - `hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart`：推送时
+    **不发任何字幕下载请求**、计划落 `pending` + `jimakuEntryId`、snack 说明时序。
+  - **变异实测**（退回修复确认断言真转红）：① 退回「按字幕侧顺序取最前 N 条」→
+    4 条红；② 退回「条数无上界」→ 6 条红；③ 退回「完成时不补取」→ 3 条红；
+    ④ 退回「计划不记 Jimaku 意图」→ 1 条红。
+- **备注**：PR#515 的 `~` 徽标 / 中性配色 / 确认页「集号未核对」提示行**全部保留**，
+  未回退。理由：选种阶段的不确定性是**真的**（那一刻确实还没有文件列表），根治
+  消除的是「错配真的落到磁盘上」，不是「选种时就能确定」。确认页额外恒显示一行
+  时序说明；确定态的落点改到任务行（完成后显示真配好的结果 / 未匹配）。
+  绝对集号偏移换算（审查建议 (a)）与条目季号校验（建议 (b)）**未做**——前者在
+  本方案下已无必要（对不上就不配，不猜），后者属条目选择层，另立。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46223 (2719 per locale)
+/// Strings: 46274 (2722 per locale)
 ///
-/// Built on 2026-07-28 at 09:05 UTC
+/// Built on 2026-07-28 at 10:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3653,6 +3653,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Subtitles: only ${done} of ${total} downloaded';
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -9873,6 +9879,15 @@ class _StringsAr extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -16161,6 +16176,15 @@ class _StringsDe extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -22465,6 +22489,15 @@ class _StringsEs extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -28780,6 +28813,15 @@ class _StringsFr extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -35024,6 +35066,15 @@ class _StringsId extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -41314,6 +41365,15 @@ class _StringsIt extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -47421,6 +47481,15 @@ class _StringsJa extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -53530,6 +53599,15 @@ class _StringsKo extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -59800,6 +59878,15 @@ class _StringsNl extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -66083,6 +66170,15 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -72350,6 +72446,15 @@ class _StringsRu extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -78565,6 +78670,15 @@ class _StringsTh extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -84812,6 +84926,15 @@ class _StringsTr extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -91044,6 +91167,15 @@ class _StringsVi extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 // Path: <root>
@@ -96838,6 +96970,12 @@ class _StringsZhCn extends _StringsEn {
       '字幕只成功下载 ${done}/${total} 条';
   @override
   String get anime_download_subs_episodes_unverified => '集号未与该整季包核对，字幕可能来自别的季。';
+  @override
+  String get anime_download_subs_deferred => '字幕将在下载完成后按包内实际文件配对';
+  @override
+  String get anime_download_subs_pending => '字幕：待下载完成后配对';
+  @override
+  String get anime_download_subs_unmatched => '字幕：未匹配到（可手动补）';
 }
 
 // Path: <root>
@@ -102866,6 +103004,15 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
+  @override
+  String get anime_download_subs_deferred =>
+      'Subtitles are matched after download, from the pack\'s actual files';
+  @override
+  String get anime_download_subs_pending =>
+      'Subtitles: pending until download completes';
+  @override
+  String get anime_download_subs_unmatched =>
+      'Subtitles: no match for this pack';
 }
 
 /// Flat map(s) containing all translations.
@@ -108437,6 +108584,12 @@ extension on _StringsEn {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -114006,6 +114159,12 @@ extension on _StringsAr {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -119596,6 +119755,12 @@ extension on _StringsDe {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -125185,6 +125350,12 @@ extension on _StringsEs {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -130780,6 +130951,12 @@ extension on _StringsFr {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -136357,6 +136534,12 @@ extension on _StringsId {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -141949,6 +142132,12 @@ extension on _StringsIt {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -147503,6 +147692,12 @@ extension on _StringsJa {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -153061,6 +153256,12 @@ extension on _StringsKo {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -158646,6 +158847,12 @@ extension on _StringsNl {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -164228,6 +164435,12 @@ extension on _StringsPtBr {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -169815,6 +170028,12 @@ extension on _StringsRu {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -175386,6 +175605,12 @@ extension on _StringsTh {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -180966,6 +181191,12 @@ extension on _StringsTr {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -186541,6 +186772,12 @@ extension on _StringsVi {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }
@@ -192070,6 +192307,12 @@ extension on _StringsZhCn {
             '字幕只成功下载 ${done}/${total} 条';
       case 'anime_download_subs_episodes_unverified':
         return '集号未与该整季包核对，字幕可能来自别的季。';
+      case 'anime_download_subs_deferred':
+        return '字幕将在下载完成后按包内实际文件配对';
+      case 'anime_download_subs_pending':
+        return '字幕：待下载完成后配对';
+      case 'anime_download_subs_unmatched':
+        return '字幕：未匹配到（可手动补）';
       default:
         return null;
     }
@@ -197619,6 +197862,12 @@ extension on _StringsZhHk {
             'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
+      case 'anime_download_subs_deferred':
+        return 'Subtitles are matched after download, from the pack\'s actual files';
+      case 'anime_download_subs_pending':
+        return 'Subtitles: pending until download completes';
+      case 'anime_download_subs_unmatched':
+        return 'Subtitles: no match for this pack';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "该系列没有记住的语言时优先使用",
   "video_jimaku_api_key_settings_hint": "也可在 设置 → 视频 → 字幕 中修改",
   "anime_download_subs_partial": "字幕只成功下载 $done/$total 条",
-  "anime_download_subs_episodes_unverified": "集号未与该整季包核对，字幕可能来自别的季。"
+  "anime_download_subs_episodes_unverified": "集号未与该整季包核对，字幕可能来自别的季。",
+  "anime_download_subs_deferred": "字幕将在下载完成后按包内实际文件配对",
+  "anime_download_subs_pending": "字幕：待下载完成后配对",
+  "anime_download_subs_unmatched": "字幕：未匹配到（可手动补）"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2717,5 +2717,8 @@
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
   "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
-  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season."
+  "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
+  "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
+  "anime_download_subs_pending": "Subtitles: pending until download completes",
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
 }

--- a/hibiki/lib/src/media/torrent/anime_download_matching.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_matching.dart
@@ -1,9 +1,21 @@
+import 'package:path/path.dart' as p;
+
 import 'package:hibiki/src/media/torrent/nyaa_client.dart';
 import 'package:hibiki/src/media/video/jimaku_client.dart';
+import 'package:hibiki/src/media/video/video_filename_parser.dart';
 
-/// 番剧下载选种对话框的纯决策逻辑：Jimaku 字幕按集索引 + 种子↔字幕匹配。
+/// 番剧下载的纯决策逻辑：Jimaku 字幕按集索引 + 种子↔字幕匹配。
 ///
 /// 全部纯函数/纯数据（不打网络、不碰磁盘），便于单测；对话框只做编排与渲染。
+///
+/// **两层匹配，输入强度不同，绝不可混用**：
+/// - 选种阶段（[jimakuCoverageFor] / [chooseSubtitlesFor]）手上只有 Nyaa RSS
+///   （[NyaaTorrent] 只有标题 + 体积，没有文件列表），集号只能从标题猜 →
+///   结论是**预估**，只配喂列表徽标与确认页预览；
+/// - 落位阶段（[matchJimakuFilesToVideoNames]）手上是种子 add 之后由引擎给出的
+///   **包内真实文件名** → 结论是**事实**，条数天然被真实视频文件数收敛。
+///
+/// 真正决定「下哪些字幕、贴给哪个视频」的只有后者（BUG-1206）。
 
 /// 从 Jimaku 文件列表构建的按集索引。
 ///
@@ -307,4 +319,103 @@ List<(int?, JimakuFile)> chooseSubtitlesFor(
       }
       return const <(int?, JimakuFile)>[];
   }
+}
+
+// ---------------------------------------------------------------------------
+// 落位阶段：按包内真实文件名反查（BUG-1206 根治层）
+// ---------------------------------------------------------------------------
+
+/// 一条「包内真实视频文件 ↔ Jimaku 字幕」的配对结论。
+class ResolvedSubtitleMatch {
+  const ResolvedSubtitleMatch({
+    required this.videoFileName,
+    required this.file,
+    this.episode,
+  });
+
+  /// 包内视频文件名（basename，含扩展名）。
+  final String videoFileName;
+
+  /// 配上的 Jimaku 字幕文件。
+  final JimakuFile file;
+
+  /// 从**视频文件名**解析出的集号；null = 走了 1v1 兜底（至少一方无集号）。
+  ///
+  /// 落位（`pairSubtitlesToVideos`）按集号严格相等对位，所以这里必须记视频侧
+  /// 的集号（而不是字幕侧的）——两者本来就相等，记视频侧才是「以真实文件为准」。
+  final int? episode;
+}
+
+/// 用**包内真实视频文件名**反查该配哪条 Jimaku 字幕。纯函数。
+///
+/// 这是 BUG-1206 的根治点。此前配对发生在种子 add 之前，输入只有 Nyaa 标题：
+/// 「包里有几集」靠 `全13話` / AniList `media.episodes` 猜（两者都没有就不设
+/// 上界），「哪一集」靠标题区间推。于是两个毛病：
+/// ① Jimaku 条目按**绝对集号**编号（S2 编 13-24）而包内文件是 01-12 时，
+///    旧的 season 分支「取最前 cap 个」照样交出 13-24 的字幕，条数看着对、
+///    集号根本对不上，UI 还画成「有字幕」；
+/// ② 条目 24 集、包只 12 集时下满 24 条，多下的永远配不上任何视频。
+///
+/// 改用真实文件名后两个毛病都消失，且**不需要任何上界启发式**：
+/// - 条数上界 = 真实视频文件数（每个视频至多配一条），不再有「猜上界」这回事；
+/// - 集号来自真实文件名，与字幕集号**严格相等**才配；S2 包 01-12 遇上绝对编号
+///   条目 13-24 时集号集合交集为空 → **一条都不配**，而不是配上错的。
+///
+/// 匹配规则（真实文件名格式五花八门，宁可不配也不猜）：
+/// 1. 视频集号走 [parseVideoFilename]（覆盖 `[Group] Title - 05 [1080p].mkv` /
+///    `S02E05` / `第5話` 等既有规则，与播放器侧同一套解析器，不另写一份）；
+///    字幕集号走 [JimakuFile.episode]（[parseSubtitleEpisode]，先剥字幕扩展名
+///    与语言子标签）。
+/// 2. 集号**严格相等**才配；同集多候选按语言权重取首选
+///    （[JimakuEpisodeIndex] 已按 [jimakuLanguageRank] 排好）。
+/// 3. 一条都没配上时，只在「恰好 1 个视频 + 字幕侧唯一确定」的场景做 1v1 兜底
+///    （剧场版 / 整季单文件字幕），且**双方都有集号却不相等时不兜底**——那正是
+///    错季的典型形状。
+/// 4. 其余一律不配（返回空），由调用方显式降级并告知用户，不静默。
+///
+/// [videoFileNames] 可以传绝对路径或裸文件名，内部一律取 basename。
+List<ResolvedSubtitleMatch> matchJimakuFilesToVideoNames(
+  List<String> videoFileNames,
+  List<JimakuFile> jimakuFiles, {
+  String? preferredLanguage,
+}) {
+  if (videoFileNames.isEmpty || jimakuFiles.isEmpty) {
+    return const <ResolvedSubtitleMatch>[];
+  }
+  final JimakuEpisodeIndex index = JimakuEpisodeIndex.fromFiles(
+    jimakuFiles,
+    preferredLanguage: preferredLanguage,
+  );
+  if (index.isEmpty) return const <ResolvedSubtitleMatch>[];
+
+  // ① 按集号严格相等逐个视频反查。
+  final List<ResolvedSubtitleMatch> out = <ResolvedSubtitleMatch>[];
+  for (final String path in videoFileNames) {
+    final String name = p.basename(path);
+    final int? episode = parseVideoFilename(name).episode;
+    if (episode == null) continue;
+    final List<JimakuFile>? candidates = index.byEpisode[episode];
+    if (candidates == null || candidates.isEmpty) continue;
+    out.add(ResolvedSubtitleMatch(
+      videoFileName: name,
+      file: candidates.first,
+      episode: episode,
+    ));
+  }
+  if (out.isNotEmpty) return out;
+
+  // ② 1v1 兜底：只覆盖「1 个视频 + 字幕侧唯一确定」，多文件时绝不猜。
+  if (videoFileNames.length != 1) return const <ResolvedSubtitleMatch>[];
+  final String only = p.basename(videoFileNames.first);
+  final JimakuFile? sole = index.unnumbered.isNotEmpty
+      ? index.unnumbered.first
+      : (index.totalFiles == 1 ? index.byEpisode.values.first.first : null);
+  if (sole == null) return const <ResolvedSubtitleMatch>[];
+  // 双方都有集号却没在 ① 配上 ⇒ 集号不等 ⇒ 错季/错编号，不配。
+  if (parseVideoFilename(only).episode != null && sole.episode != null) {
+    return const <ResolvedSubtitleMatch>[];
+  }
+  return <ResolvedSubtitleMatch>[
+    ResolvedSubtitleMatch(videoFileName: only, file: sole),
+  ];
 }

--- a/hibiki/lib/src/media/torrent/anime_download_plan.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_plan.dart
@@ -44,7 +44,25 @@ class AnimeDownloadPlan {
     this.failReason,
     this.collectionId,
     this.contentKind = kindVideo,
+    this.jimakuEntryId,
+    this.jimakuEntryName,
+    this.jimakuLanguage,
+    this.subtitleStatus = subtitleNone,
+    this.subtitleNote,
   });
+
+  /// 不涉及字幕（用户没勾「一并下字幕」/ 没选中 Jimaku 条目 / 通用磁链）。
+  static const String subtitleNone = 'none';
+
+  /// 已记下 Jimaku 条目，等下载完成后按包内真实文件名反查再取（BUG-1206）。
+  static const String subtitlePending = 'pending';
+
+  /// 已配好并落进 [subtitles]（老计划在选种时就下好的，也是这个状态）。
+  static const String subtitleResolved = 'resolved';
+
+  /// 反查完一条都没配上 / Jimaku 取不到；原因见 [subtitleNote]。
+  /// **不是静默失败**：任务行会显式显示，用户可用字幕对话框手动补。
+  static const String subtitleUnavailable = 'unavailable';
 
   /// 内容类型：视频（走视频库入库，番剧默认）。
   static const String kindVideo = 'video';
@@ -104,6 +122,25 @@ class AnimeDownloadPlan {
   /// 阅读库入库。默认 [kindVideo]（番剧 + 老计划向后兼容）。
   final String contentKind;
 
+  /// 用户在选种时选中的 Jimaku 条目 id；null = 不取字幕。
+  ///
+  /// 计划只记**意图**（取哪个条目的字幕），不记结论——结论要等种子 add 之后
+  /// 引擎给出包内真实文件名才算得准（BUG-1206）。
+  final int? jimakuEntryId;
+
+  /// Jimaku 条目名（仅用于任务行/失败原因里说清取的是哪个条目）。
+  final String? jimakuEntryName;
+
+  /// 用户选的优先字幕语言（`ja` / `zh` / ...）；null = 用默认权重（ja 优先）。
+  final String? jimakuLanguage;
+
+  /// [subtitleNone] / [subtitlePending] / [subtitleResolved] /
+  /// [subtitleUnavailable]。
+  final String subtitleStatus;
+
+  /// [subtitleUnavailable] 时的原因（英文短语，落日志/任务行用）。
+  final String? subtitleNote;
+
   /// 注意：可空字段（[failReason] / [collectionId] 等）无法通过 copyWith
   /// 置回 null（标准模式局限）；状态机只前进赋值，不需要清空。
   AnimeDownloadPlan copyWith({
@@ -120,6 +157,11 @@ class AnimeDownloadPlan {
     String? failReason,
     int? collectionId,
     String? contentKind,
+    int? jimakuEntryId,
+    String? jimakuEntryName,
+    String? jimakuLanguage,
+    String? subtitleStatus,
+    String? subtitleNote,
   }) {
     return AnimeDownloadPlan(
       id: id ?? this.id,
@@ -135,6 +177,11 @@ class AnimeDownloadPlan {
       failReason: failReason ?? this.failReason,
       collectionId: collectionId ?? this.collectionId,
       contentKind: contentKind ?? this.contentKind,
+      jimakuEntryId: jimakuEntryId ?? this.jimakuEntryId,
+      jimakuEntryName: jimakuEntryName ?? this.jimakuEntryName,
+      jimakuLanguage: jimakuLanguage ?? this.jimakuLanguage,
+      subtitleStatus: subtitleStatus ?? this.subtitleStatus,
+      subtitleNote: subtitleNote ?? this.subtitleNote,
     );
   }
 }
@@ -163,6 +210,11 @@ Map<String, dynamic> encodeAnimeDownloadPlan(AnimeDownloadPlan plan) {
     'failReason': plan.failReason,
     'collectionId': plan.collectionId,
     'contentKind': plan.contentKind,
+    'jimakuEntryId': plan.jimakuEntryId,
+    'jimakuEntryName': plan.jimakuEntryName,
+    'jimakuLanguage': plan.jimakuLanguage,
+    'subtitleStatus': plan.subtitleStatus,
+    'subtitleNote': plan.subtitleNote,
   };
 }
 
@@ -213,6 +265,25 @@ AnimeDownloadPlan? decodeAnimeDownloadPlan(Map<dynamic, dynamic> raw) {
               (raw['contentKind'] as String).isNotEmpty
           ? raw['contentKind'] as String
           : AnimeDownloadPlan.kindVideo,
+      jimakuEntryId:
+          raw['jimakuEntryId'] is int ? raw['jimakuEntryId'] as int : null,
+      jimakuEntryName: raw['jimakuEntryName'] is String
+          ? raw['jimakuEntryName'] as String
+          : null,
+      jimakuLanguage: raw['jimakuLanguage'] is String
+          ? raw['jimakuLanguage'] as String
+          : null,
+      // 缺字段（老计划）→ 字幕在选种时就下好了：有暂存条目即 resolved，否则 none。
+      // 绝不能落成 pending，否则老计划会在完成时被当成「还没取字幕」再取一遍，
+      // 把用户已有的暂存/sidecar 搅乱。
+      subtitleStatus: raw['subtitleStatus'] is String &&
+              (raw['subtitleStatus'] as String).isNotEmpty
+          ? raw['subtitleStatus'] as String
+          : (subtitles.isEmpty
+              ? AnimeDownloadPlan.subtitleNone
+              : AnimeDownloadPlan.subtitleResolved),
+      subtitleNote:
+          raw['subtitleNote'] is String ? raw['subtitleNote'] as String : null,
     );
   } catch (_) {
     return null;

--- a/hibiki/lib/src/media/torrent/anime_download_service.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_service.dart
@@ -6,6 +6,7 @@ import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
+import 'package:hibiki/src/media/torrent/anime_download_subtitle_resolver.dart';
 import 'package:hibiki/src/media/torrent/qb_torrent_backend.dart';
 import 'package:hibiki/src/media/torrent/qbittorrent_client.dart';
 import 'package:hibiki/src/media/torrent/torrent_backend.dart';
@@ -138,11 +139,16 @@ class AnimeDownloadService {
       AnimeDownloadPlan plan,
       List<String> bookAbsolutePaths,
     )? bookImporter,
+    Future<ResolvedPlanSubtitles> Function(
+      AnimeDownloadPlan plan,
+      List<String> videoAbsolutePaths,
+    )? subtitleResolver,
     void Function()? onTick,
     this.interval = const Duration(seconds: 20),
   })  : _configProvider = configProvider,
         _importer = importer,
         _bookImporter = bookImporter,
+        _subtitleResolver = subtitleResolver,
         _backendFactory = backendFactory ?? _defaultBackendFactory,
         _onTick = onTick;
 
@@ -172,6 +178,15 @@ class AnimeDownloadService {
     AnimeDownloadPlan plan,
     List<String> bookAbsolutePaths,
   )? _bookImporter;
+
+  /// 延迟字幕解析回调（[AnimeDownloadPlan.subtitlePending] 的计划完成时调用，
+  /// 用包内真实视频文件名反查 Jimaku，见 [JimakuPlanSubtitleResolver]）。
+  /// null = 不支持补取，pending 计划会显式落 [AnimeDownloadPlan.subtitleUnavailable]。
+  final Future<ResolvedPlanSubtitles> Function(
+    AnimeDownloadPlan plan,
+    List<String> videoAbsolutePaths,
+  )? _subtitleResolver;
+
   final TorrentBackend Function(QbConnectionConfig config) _backendFactory;
 
   /// 每 tick 起始（早于「无 pending 计划则跳过」判断）无条件跑一次的钩子；
@@ -368,11 +383,16 @@ class AnimeDownloadService {
     int booksImported = 0;
     String? importError;
 
-    // 视频：先落 sidecar 再入库（播放器按 sidecar 自动发现字幕）。
+    // 字幕：pending 的计划到这一刻才第一次知道包内真实文件名，现在才配得准
+    // （BUG-1206）。resolved/none 的老计划原样透传，行为不变。
+    AnimeDownloadPlan resolved = plan;
+
+    // 视频：先补字幕 → 落 sidecar → 入库（播放器按 sidecar 自动发现字幕）。
     if (videos.isNotEmpty) {
-      await _placeSidecars(videos, plan.subtitles);
+      resolved = await _resolveSubtitles(plan, videos);
+      await _placeSidecars(videos, resolved.subtitles);
       try {
-        outcome = await _importer(plan, videos);
+        outcome = await _importer(resolved, videos);
       } catch (e) {
         importError = 'video import failed: $e';
       }
@@ -395,15 +415,60 @@ class AnimeDownloadService {
 
     final bool imported = outcome != null || booksImported > 0;
     if (imported) {
-      await store.save(plan.copyWith(
+      await store.save(resolved.copyWith(
         status: AnimeDownloadPlan.statusImported,
         collectionId: outcome?.collectionId,
       ));
     } else {
-      await store.save(plan.copyWith(
+      await store.save(resolved.copyWith(
         status: AnimeDownloadPlan.statusFailed,
         failReason: importError ?? 'import failed',
       ));
+    }
+  }
+
+  /// 把 [AnimeDownloadPlan.subtitlePending] 的计划按 [videoAbsolutePaths]
+  /// （包内真实视频）补取字幕，返回已带结论的计划副本。
+  ///
+  /// 非 pending（老计划：选种时就下好了字幕，或压根不要字幕）原样返回——**绝不
+  /// 重取、绝不覆盖**已有的 [AnimeDownloadPlan.subtitles]。
+  ///
+  /// 任何失败路径都落 [AnimeDownloadPlan.subtitleUnavailable] + 原因，不静默：
+  /// 视频照常入库（字幕缺失不该让整个下载判失败），用户在任务行能看见「字幕未
+  /// 匹配」并用字幕对话框手动补。
+  Future<AnimeDownloadPlan> _resolveSubtitles(
+    AnimeDownloadPlan plan,
+    List<String> videoAbsolutePaths,
+  ) async {
+    if (plan.subtitleStatus != AnimeDownloadPlan.subtitlePending) return plan;
+    final Future<ResolvedPlanSubtitles> Function(
+      AnimeDownloadPlan,
+      List<String>,
+    )? resolver = _subtitleResolver;
+    if (resolver == null) {
+      return plan.copyWith(
+        subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+        subtitleNote: 'subtitle resolver unavailable',
+      );
+    }
+    try {
+      final ResolvedPlanSubtitles result =
+          await resolver(plan, videoAbsolutePaths);
+      if (result.subtitles.isEmpty) {
+        return plan.copyWith(
+          subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+          subtitleNote: result.failureReason ?? 'no matching subtitle',
+        );
+      }
+      return plan.copyWith(
+        subtitles: result.subtitles,
+        subtitleStatus: AnimeDownloadPlan.subtitleResolved,
+      );
+    } catch (e) {
+      return plan.copyWith(
+        subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
+        subtitleNote: 'subtitle resolve failed: $e',
+      );
     }
   }
 

--- a/hibiki/lib/src/media/torrent/anime_download_subscription.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_subscription.dart
@@ -583,6 +583,17 @@ class AnimeDownloadSubscriptionService {
               magnet: torrent.magnet,
               qbCategory: config.category,
               subtitles: subtitles,
+              jimakuEntryId: current.jimakuEntryId,
+              jimakuEntryName: current.jimakuEntryName,
+              jimakuLanguage: current.jimakuLanguage,
+              // 订阅只追**单集**种子（上面 `episode == null` 已 continue），标题
+              // 集号就是该集，且这里已经真的把字幕下下来了 → 直接 resolved。
+              // 不走 BUG-1206 的延迟反查：订阅有一条更强的产品约束——
+              // 「要字幕却取不到就整条不下」（见下方 pendingError 分支），
+              // 改成完成后再取会把这个门变成「先下完再说没字幕」。
+              subtitleStatus: subtitles.isEmpty
+                  ? AnimeDownloadPlan.subtitleNone
+                  : AnimeDownloadPlan.subtitleResolved,
             );
             await planStore.save(plan);
             queued = await backend.addTorrent(

--- a/hibiki/lib/src/media/torrent/anime_download_subtitle_resolver.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_subtitle_resolver.dart
@@ -1,0 +1,132 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/media/torrent/anime_download_matching.dart';
+import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
+import 'package:hibiki/src/media/video/jimaku_client.dart';
+
+/// 延迟字幕解析的结果：配好的字幕 + 失败原因（二选一有值）。
+class ResolvedPlanSubtitles {
+  const ResolvedPlanSubtitles.ok(this.subtitles) : failureReason = null;
+
+  const ResolvedPlanSubtitles.failed(this.failureReason)
+      : subtitles = const <PlanSubtitle>[];
+
+  /// 已下载落地的字幕（顺序 = 反查结果顺序）。
+  final List<PlanSubtitle> subtitles;
+
+  /// 失败原因（英文短语，落任务行/日志）；null = 未失败。
+  final String? failureReason;
+}
+
+/// 下载完成后按**包内真实视频文件名**补取 Jimaku 字幕（BUG-1206）。
+///
+/// 为什么是「完成后」而不是选种时：选种时手上只有 Nyaa 标题（没有文件列表），
+/// 集号与集数都只能猜；种子 add 之后引擎才给得出包内真实文件名。见
+/// [matchJimakuFilesToVideoNames] 的文档。
+///
+/// 职责边界：网络 + 磁盘全在这里，`AnimeDownloadService` 只按回调调用，保持可
+/// 纯 fake 测试。全部失败路径都返回带原因的 [ResolvedPlanSubtitles.failed]，
+/// **不静默吞掉**——调用方会把它落进计划的 `subtitleNote` 并显示给用户。
+class JimakuPlanSubtitleResolver {
+  JimakuPlanSubtitleResolver({
+    required String Function() apiKeyProvider,
+    required Future<http.Client> Function() httpClientFactory,
+    required Directory Function(String planId) stagingDirFor,
+  })  : _apiKeyProvider = apiKeyProvider,
+        _httpClientFactory = httpClientFactory,
+        _stagingDirFor = stagingDirFor;
+
+  final String Function() _apiKeyProvider;
+  final Future<http.Client> Function() _httpClientFactory;
+  final Directory Function(String planId) _stagingDirFor;
+
+  /// 为 [plan] 按 [videoAbsolutePaths]（包内真实视频）补取字幕。
+  Future<ResolvedPlanSubtitles> resolve(
+    AnimeDownloadPlan plan,
+    List<String> videoAbsolutePaths,
+  ) async {
+    final int? entryId = plan.jimakuEntryId;
+    if (entryId == null) {
+      return const ResolvedPlanSubtitles.failed('no jimaku entry recorded');
+    }
+    final String apiKey = _apiKeyProvider().trim();
+    if (apiKey.isEmpty) {
+      return const ResolvedPlanSubtitles.failed('jimaku api key missing');
+    }
+    if (videoAbsolutePaths.isEmpty) {
+      return const ResolvedPlanSubtitles.failed('no video files in pack');
+    }
+
+    JimakuClient? jimaku;
+    try {
+      jimaku = JimakuClient(
+        apiKey: apiKey,
+        client: await _httpClientFactory(),
+      );
+      // 列全部文件（不带 episode query）：反查要拿字幕侧完整集号集合，
+      // 服务端按文件名 best-effort 过滤反而会遮住「一条都对不上」这个事实。
+      final List<JimakuFile> files = await jimaku.listFiles(entryId);
+      if (files.isEmpty) {
+        return const ResolvedPlanSubtitles.failed('jimaku entry has no files');
+      }
+      final List<ResolvedSubtitleMatch> matches = matchJimakuFilesToVideoNames(
+        videoAbsolutePaths,
+        files,
+        preferredLanguage: plan.jimakuLanguage,
+      );
+      if (matches.isEmpty) {
+        // 反查一条都对不上——绝大多数是条目选错季或用了绝对集号编号。
+        // 明说，而不是悄悄不放字幕。
+        return const ResolvedPlanSubtitles.failed(
+            'no jimaku file matches the pack episodes');
+      }
+      return ResolvedPlanSubtitles.ok(
+        await _download(plan, matches, jimaku),
+      );
+    } catch (e) {
+      return ResolvedPlanSubtitles.failed('jimaku fetch failed: $e');
+    } finally {
+      jimaku?.close();
+    }
+  }
+
+  /// 逐条下载并落进计划暂存目录；同一 URL 只下一次（同集多版本视频会指向同一
+  /// 字幕）。单条失败跳过，不影响其余。
+  Future<List<PlanSubtitle>> _download(
+    AnimeDownloadPlan plan,
+    List<ResolvedSubtitleMatch> matches,
+    JimakuClient jimaku,
+  ) async {
+    final Directory subsDir = _stagingDirFor(plan.id);
+    final Map<String, String> stagedByUrl = <String, String>{};
+    final List<PlanSubtitle> out = <PlanSubtitle>[];
+    for (final ResolvedSubtitleMatch match in matches) {
+      String? staged = stagedByUrl[match.file.url];
+      if (staged == null) {
+        final Uint8List? bytes = await jimaku.downloadFile(match.file.url);
+        if (bytes == null) continue;
+        try {
+          final File dest =
+              File(p.join(subsDir.path, p.basename(match.file.name)))
+                ..createSync(recursive: true);
+          await dest.writeAsBytes(bytes);
+          staged = dest.path;
+          stagedByUrl[match.file.url] = staged;
+        } catch (_) {
+          continue; // 单条落盘失败跳过。
+        }
+      }
+      out.add(PlanSubtitle(
+        episode: match.episode,
+        fileName: match.file.name,
+        stagedPath: staged,
+        language: detectSubtitleLanguage(match.file.name),
+      ));
+    }
+    return out;
+  }
+}

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -56,6 +56,7 @@ import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 import 'package:hibiki/src/media/torrent/anime_download_importer.dart';
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
 import 'package:hibiki/src/media/torrent/anime_download_service.dart';
+import 'package:hibiki/src/media/torrent/anime_download_subtitle_resolver.dart';
 import 'package:hibiki/src/media/torrent/anime_download_subscription.dart';
 import 'package:hibiki/src/media/torrent/torrent_memory.dart';
 import 'package:hibiki/src/media/video/dandanplay_client.dart';
@@ -3309,6 +3310,12 @@ class AppModel with ChangeNotifier {
           effectiveTorrentConfig(prefsRepo.qbConnectionConfig),
       importer: buildAnimeDownloadImporter(database),
       bookImporter: _importDownloadedBooks,
+      // BUG-1206：字幕在下载完成时按包内真实文件名反查补取，不在选种时预下。
+      subtitleResolver: JimakuPlanSubtitleResolver(
+        apiKeyProvider: () => prefsRepo.jimakuApiKey,
+        httpClientFactory: createDownloadHttpClient,
+        stagingDirFor: store.subsDirFor,
+      ).resolve,
       backendFactory: _torrentBackendFor,
       onTick: () {
         _embeddedTorrentHost?.sweepAntiLeech();

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -1,11 +1,8 @@
 import 'dart:async' show unawaited;
-import 'dart:io';
 import 'dart:math' as math;
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/torrent/anime_download_matching.dart';
@@ -751,42 +748,13 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     if (!mounted) return;
     setState(() => _pushing = true);
 
-    // ① 逐条下载选中的字幕到计划暂存目录（单条失败跳过该条）。
-    // 整季包一次十几条，逐条失败以前是静默 continue，用户以为字幕都下好了；
-    // 记下应下条数，推送成功后按 N/M 汇报（见下方 snack）。
-    final int expectedSubs = _includeSubs ? _chosenSubs.length : 0;
-    final List<PlanSubtitle> staged = <PlanSubtitle>[];
-    if (_includeSubs && _chosenSubs.isNotEmpty) {
-      JimakuClient? jimaku;
-      try {
-        jimaku = JimakuClient(
-          apiKey: appModel.jimakuApiKey.trim(),
-          client: await appModel.createDownloadHttpClient(),
-        );
-        final Directory subsDir = store.subsDirFor(planId);
-        for (final (int? episode, JimakuFile file) in _chosenSubs) {
-          final Uint8List? bytes = await jimaku.downloadFile(file.url);
-          if (bytes == null) continue;
-          try {
-            final File dest = File(p.join(subsDir.path, p.basename(file.name)))
-              ..createSync(recursive: true);
-            await dest.writeAsBytes(bytes);
-            staged.add(PlanSubtitle(
-              episode: episode,
-              fileName: file.name,
-              stagedPath: dest.path,
-              language: detectSubtitleLanguage(file.name),
-            ));
-          } catch (_) {
-            // 单条落盘失败跳过，不影响其余字幕与推送。
-          }
-        }
-      } catch (_) {
-        // 字幕网络失败时仍允许下载视频；订阅轮询会在代理恢复后再次尝试。
-      } finally {
-        jimaku?.close();
-      }
-    }
+    // ① 字幕**不在这一刻下载**（BUG-1206）。此刻手上只有 Nyaa 标题，包里到底
+    // 有哪些文件要等种子 add 之后引擎给元数据才知道；照标题猜集号会把绝对编号
+    // 条目的字幕配到错季上，还看起来「配好了」。这里只把**意图**（取哪个
+    // Jimaku 条目、优先什么语言）记进计划，真正的反查交给完成钩子
+    // （`AnimeDownloadService._resolveSubtitles` → `JimakuPlanSubtitleResolver`），
+    // 那时按包内真实视频文件名对位，集号与条数都是事实而非猜测。
+    final JimakuEntry? subsEntry = _includeSubs ? _selectedJimakuEntry : null;
 
     // ② 落计划（先写盘再推 qb，推失败回滚删除）。
     final AnimeDownloadPlan plan = AnimeDownloadPlan(
@@ -798,7 +766,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       torrentTitle: torrent.title,
       magnet: torrent.magnet,
       qbCategory: config.category,
-      subtitles: staged,
+      jimakuEntryId: subsEntry?.id,
+      jimakuEntryName: subsEntry?.name,
+      jimakuLanguage: subsEntry == null ? null : _jimakuPreferredLanguage,
+      subtitleStatus: subsEntry == null
+          ? AnimeDownloadPlan.subtitleNone
+          : AnimeDownloadPlan.subtitlePending,
     );
     await store.save(plan);
 
@@ -858,13 +831,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     }
     unawaited(appModel.animeDownloadService?.tick());
     if (!mounted) return;
-    // 字幕缺条必须说出来：全成功不打扰，少一条就把 N/M 附在推送成功文案后面。
+    // 说清字幕的时序：选了条目就必然还没下，别让用户以为「推送时字幕已经拿好」。
     final String pushedMessage =
         subscribed ? t.download_subscription_created : t.anime_download_pushed;
-    _snack(staged.length < expectedSubs
-        ? '$pushedMessage · '
-            '${t.anime_download_subs_partial(done: staged.length, total: expectedSubs)}'
-        : pushedMessage);
+    _snack(subsEntry == null
+        ? pushedMessage
+        : '$pushedMessage · ${t.anime_download_subs_deferred}');
     // BUG-1006：embedded（下载页内联）没有对话框可关——无条件 pop 会把宿主
     // 路由（下载 tab 页/整个页面栈）弹掉。独立对话框才 pop；内联模式复位回
     // 搜番初始阶段并刷新任务区（对照 [_pushGeneric] 成功后的节奏）。
@@ -1828,35 +1800,44 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         ),
       );
     }
-    // 整季包：集号未经核对，可能配上错季字幕（见 [_subtitleEpisodesUnverified]）。
-    // 明说一句，别让用户以为「已确认配好」。
+    // 这份列表是**预览**（按种子标题猜的），不是最终会下的清单：真正配哪些
+    // 字幕要等种子 add 之后按包内真实文件名反查（BUG-1206）。所以恒显示一行
+    // 时序说明；整季包再叠一行「集号未核对」（PR#515 的不确定态表达仍然准确
+    // ——选种这一刻确实没核对，根治只保证错配不会真的落到磁盘上）。
     final NyaaTorrent? torrent = _selectedTorrent;
     final bool unverified =
         torrent != null && _subtitleEpisodesUnverified(torrent);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
+        _buildSubsHintRow(
+            theme, Icons.schedule, t.anime_download_subs_deferred),
         if (unverified)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Icon(Icons.help_outline,
-                    size: 16, color: theme.colorScheme.onSurfaceVariant),
-                const SizedBox(width: 6),
-                Expanded(
-                  child: Text(
-                    t.anime_download_subs_episodes_unverified,
-                    style: theme.textTheme.bodySmall
-                        ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-                  ),
-                ),
-              ],
-            ),
-          ),
+          _buildSubsHintRow(theme, Icons.help_outline,
+              t.anime_download_subs_episodes_unverified),
         Expanded(child: _buildChosenSubsListView(theme)),
       ],
+    );
+  }
+
+  /// 字幕列表上方的说明行（时序 / 未核对共用同一排版）。
+  Widget _buildSubsHintRow(ThemeData theme, IconData icon, String text) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Icon(icon, size: 16, color: theme.colorScheme.onSurfaceVariant),
+          const SizedBox(width: 6),
+          Expanded(
+            child: Text(
+              text,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+        ],
+      ),
     );
   }
 
@@ -2041,6 +2022,20 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         (failed && (plan.failReason?.isNotEmpty ?? false))
             ? plan.failReason
             : null;
+    // 字幕的时序对用户是可见的（BUG-1206）：推送时不再预下字幕，所以必须在这里
+    // 说清「还没配」「没配上」，否则用户会以为字幕功能没了。
+    // resolved / none 不占行——前者字幕已经贴成 sidecar，后者用户压根没要字幕。
+    final (String, Color)? subtitleNote = switch (plan.subtitleStatus) {
+      AnimeDownloadPlan.subtitlePending => (
+          t.anime_download_subs_pending,
+          scheme.onSurfaceVariant
+        ),
+      AnimeDownloadPlan.subtitleUnavailable => (
+          t.anime_download_subs_unmatched,
+          scheme.tertiary
+        ),
+      _ => null,
+    };
     return HibikiListItem(
       density: HibikiListDensity.compact,
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
@@ -2065,6 +2060,14 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
               progressText,
               maxLines: 1,
               style: theme.textTheme.bodySmall,
+            ),
+          if (subtitleNote != null)
+            Text(
+              subtitleNote.$1,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style:
+                  theme.textTheme.bodySmall?.copyWith(color: subtitleNote.$2),
             ),
           if (failReason != null)
             Text(

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+967
+version: 1.3.1+968
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
@@ -89,8 +89,11 @@ class _MemPlanStore extends AnimeDownloadPlanStore {
   Future<List<AnimeDownloadPlan>> loadAll() async =>
       const <AnimeDownloadPlan>[];
 
+  /// 推送真正落盘的计划（断言「计划里记了什么」用）。
+  final List<AnimeDownloadPlan> saved = <AnimeDownloadPlan>[];
+
   @override
-  Future<void> save(AnimeDownloadPlan plan) async {}
+  Future<void> save(AnimeDownloadPlan plan) async => saved.add(plan);
 
   @override
   Future<void> delete(String id) async {}
@@ -505,10 +508,15 @@ void main() {
         reason: '整季包集号未核对，必须明说，不能画成「字幕已配好」');
   });
 
-  // 整季包一次十几条字幕，单条下载失败以前被静默 continue，用户以为都下好了。
-  testWidgets('推送：字幕缺条时 snack 汇报 N/M', (WidgetTester tester) async {
+  // BUG-1206：推送这一刻手上只有 Nyaa 标题，包里到底有哪些文件还不知道，照标题
+  // 猜集号会静默配错季。所以字幕**不再在推送时下载**，计划只记「取哪个 Jimaku
+  // 条目」，真正的反查放到下载完成后按包内真实文件名做。
+  testWidgets('BUG-1206 推送：不预下字幕，计划落 pending 并说明时序',
+      (WidgetTester tester) async {
+    final List<String> requested = <String>[];
     final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
       final String url = req.url.toString();
+      requested.add(url);
       if (url.contains('/entries/search')) {
         return http.Response.bytes(
           utf8.encode(jsonEncode(<Map<String, Object>>[
@@ -529,8 +537,6 @@ void main() {
           200,
         );
       }
-      // 第 2 条字幕下载失败（其余成功）→ 3 条只成功 2 条。
-      if (url.endsWith('/f/2.srt')) return http.Response('', 500);
       if (url.contains('/f/')) return http.Response('sub body', 200);
       return http.Response('', 404);
     });
@@ -566,10 +572,23 @@ void main() {
       }
     });
     await tester.pump();
+
+    // ① 推送期间一条字幕都没下——这是「配对推迟到 add 之后」的直接证据。
     expect(
-      find.textContaining(t.anime_download_subs_partial(done: 2, total: 3)),
+      requested.where((String u) => u.contains('/f/')),
+      isEmpty,
+      reason: '推送时不得再预下字幕：那时还不知道包里有哪些文件',
+    );
+    // ② 计划记的是**意图**（条目 id + pending），不是结论。
+    final AnimeDownloadPlan plan = appModel.store.saved.single;
+    expect(plan.jimakuEntryId, 7);
+    expect(plan.subtitleStatus, AnimeDownloadPlan.subtitlePending);
+    expect(plan.subtitles, isEmpty, reason: '结论要等包内真实文件名，推送时不该有任何已配字幕');
+    // ③ 用户得知道字幕还在后头，不能以为字幕功能没了。
+    expect(
+      find.textContaining(t.anime_download_subs_deferred),
       findsOneWidget,
-      reason: '缺条必须说出来，不能只报「已推送」',
+      reason: '推送成功必须说清字幕的时序',
     );
   });
 }

--- a/hibiki/test/torrent/anime_download_matching_test.dart
+++ b/hibiki/test/torrent/anime_download_matching_test.dart
@@ -445,4 +445,175 @@ void main() {
       );
     });
   });
+
+  // ==========================================================================
+  // BUG-1206：落位阶段按包内真实视频文件名反查（根治层）
+  // ==========================================================================
+  group('BUG-1206 matchJimakuFilesToVideoNames', () {
+    List<JimakuFile> jimakuEpisodes(Iterable<int> episodes,
+        {String series = 'Test Anime', String lang = 'ja'}) {
+      return <JimakuFile>[
+        for (final int ep in episodes)
+          JimakuFile(
+            name: '$series - ${ep.toString().padLeft(2, '0')}.$lang.srt',
+            url: 'https://jimaku.cc/f/$ep.srt',
+          ),
+      ];
+    }
+
+    List<String> packVideos(Iterable<int> episodes,
+        {String group = 'Grp', String series = 'Test Anime'}) {
+      return <String>[
+        for (final int ep in episodes)
+          '[$group] $series - ${ep.toString().padLeft(2, '0')} [1080p].mkv',
+      ];
+    }
+
+    test('错季不再配上：S2 包 01-12 遇绝对编号条目 13-24 → 一条都不配', () {
+      // 这正是改前静默配错的形状：旧的 season 分支按「取最前 cap 个」交出
+      // 13-24 的字幕并画成「有字幕」。按真实文件名反查后集号集合交集为空。
+      final List<ResolvedSubtitleMatch> matches = matchJimakuFilesToVideoNames(
+        packVideos(<int>[for (int e = 1; e <= 12; e++) e]),
+        jimakuEpisodes(<int>[for (int e = 13; e <= 24; e++) e]),
+      );
+      expect(matches, isEmpty, reason: '集号对不上就必须不配，绝不能猜偏移或凑条数');
+    });
+
+    test('条数被真实文件数收敛：条目 24 集、包只 12 集 → 恰好 12 条且集号是包里的', () {
+      // 改前这里会下满 24 条（标题没写「全N話」且 AniList 没给 episodes 时
+      // 压根不设上界），多出来的 12 条永远配不上任何视频。
+      final List<ResolvedSubtitleMatch> matches = matchJimakuFilesToVideoNames(
+        packVideos(<int>[for (int e = 1; e <= 12; e++) e]),
+        jimakuEpisodes(<int>[for (int e = 1; e <= 24; e++) e]),
+      );
+      expect(matches, hasLength(12));
+      expect(
+        matches.map((ResolvedSubtitleMatch m) => m.episode).toList(),
+        <int>[for (int e = 1; e <= 12; e++) e],
+      );
+      expect(
+        matches.map((ResolvedSubtitleMatch m) => m.file.name).toList(),
+        <String>[
+          for (int e = 1; e <= 12; e++)
+            'Test Anime - ${e.toString().padLeft(2, '0')}.ja.srt',
+        ],
+        reason: '取的必须是包里那 12 集，不是条目的前 12 条',
+      );
+    });
+
+    test('部分覆盖：包 01-12、条目只有 03/05/07 → 只配这 3 集，其余跳过', () {
+      final List<ResolvedSubtitleMatch> matches = matchJimakuFilesToVideoNames(
+        packVideos(<int>[for (int e = 1; e <= 12; e++) e]),
+        jimakuEpisodes(<int>[3, 5, 7]),
+      );
+      expect(matches.map((ResolvedSubtitleMatch m) => m.episode).toList(),
+          <int>[3, 5, 7]);
+      expect(matches.first.videoFileName, '[Grp] Test Anime - 03 [1080p].mkv');
+    });
+
+    test('真实文件名三种写法（- 05 / S02E05 / 第5話）都能反查到同一集', () {
+      final List<JimakuFile> subs = jimakuEpisodes(<int>[5]);
+      for (final String video in <String>[
+        '[Grp] Test Anime - 05 [1080p].mkv',
+        'Test.Anime.S02E05.1080p.mkv',
+        'テストアニメ 第5話.mkv',
+      ]) {
+        final List<ResolvedSubtitleMatch> matches =
+            matchJimakuFilesToVideoNames(<String>[video], subs);
+        expect(matches, hasLength(1), reason: '解析不出集号的写法：$video');
+        expect(matches.single.episode, 5);
+      }
+    });
+
+    test('传绝对路径也按 basename 反查（服务侧喂的是绝对路径）', () {
+      // 用 POSIX 分隔符：`package:path` 的 windows context 也认 `/`，而反过来
+      // 硬编码 `D:\...` 在 Linux CI 上根本不会被拆分 → 本机绿、CI 红。
+      final List<ResolvedSubtitleMatch> matches = matchJimakuFilesToVideoNames(
+        <String>['/downloads/Test Anime/[Grp] Test Anime - 07 [1080p].mkv'],
+        jimakuEpisodes(<int>[7]),
+      );
+      expect(matches.single.episode, 7);
+      expect(matches.single.videoFileName, '[Grp] Test Anime - 07 [1080p].mkv');
+    });
+
+    test('同集多语言按偏好取首选（未指定时 ja 优先）', () {
+      final List<JimakuFile> mixed = <JimakuFile>[
+        const JimakuFile(
+            name: 'Test Anime - 05.zh.srt', url: 'https://jimaku.cc/f/5zh.srt'),
+        const JimakuFile(
+            name: 'Test Anime - 05.ja.srt', url: 'https://jimaku.cc/f/5ja.srt'),
+      ];
+      expect(
+        matchJimakuFilesToVideoNames(packVideos(<int>[5]), mixed)
+            .single
+            .file
+            .name,
+        'Test Anime - 05.ja.srt',
+      );
+      expect(
+        matchJimakuFilesToVideoNames(packVideos(<int>[5]), mixed,
+                preferredLanguage: 'zh')
+            .single
+            .file
+            .name,
+        'Test Anime - 05.zh.srt',
+      );
+    });
+
+    test('1v1 兜底：单视频无集号 + 条目唯一整片字幕 → 配上（episode 记 null）', () {
+      final List<ResolvedSubtitleMatch> matches = matchJimakuFilesToVideoNames(
+        <String>['Test Anime Movie [BDRip].mkv'],
+        const <JimakuFile>[
+          JimakuFile(name: 'Movie.ja.srt', url: 'https://jimaku.cc/f/m.srt'),
+        ],
+      );
+      expect(matches, hasLength(1));
+      expect(matches.single.episode, isNull);
+    });
+
+    test('1v1 不猜：单视频 ep05 + 条目唯一字幕 ep17 → 不配', () {
+      expect(
+        matchJimakuFilesToVideoNames(
+          packVideos(<int>[5]),
+          jimakuEpisodes(<int>[17]),
+        ),
+        isEmpty,
+        reason: '双方都有集号却不等 = 错季/错编号的典型形状，宁可不配',
+      );
+    });
+
+    test('多视频全部对不上时不做 1v1 兜底（多文件绝不猜）', () {
+      expect(
+        matchJimakuFilesToVideoNames(
+          packVideos(<int>[1, 2, 3]),
+          const <JimakuFile>[
+            JimakuFile(name: 'Whole Season.ja.srt', url: 'https://x/1.srt'),
+          ],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('非文本字幕（.zip/.mkv）被 JimakuEpisodeIndex 丢弃，不会被反查选中', () {
+      expect(
+        matchJimakuFilesToVideoNames(
+          packVideos(<int>[1]),
+          const <JimakuFile>[
+            JimakuFile(name: 'Test Anime - 01.zip', url: 'https://x/1.zip'),
+          ],
+        ),
+        isEmpty,
+      );
+    });
+
+    test('空输入不炸', () {
+      expect(
+          matchJimakuFilesToVideoNames(const <String>[], const <JimakuFile>[]),
+          isEmpty);
+      expect(
+          matchJimakuFilesToVideoNames(
+              packVideos(<int>[1]), const <JimakuFile>[]),
+          isEmpty);
+    });
+  });
 }

--- a/hibiki/test/torrent/anime_download_service_test.dart
+++ b/hibiki/test/torrent/anime_download_service_test.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' as p;
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
 import 'package:hibiki/src/media/torrent/anime_download_service.dart';
+import 'package:hibiki/src/media/torrent/anime_download_subtitle_resolver.dart';
 import 'package:hibiki/src/media/torrent/qb_torrent_backend.dart';
 import 'package:hibiki/src/media/torrent/qbittorrent_client.dart';
 import 'package:hibiki/src/media/torrent/torrent_backend.dart';
@@ -257,12 +258,27 @@ void main() {
         AnimeDownloadPlan, List<String>)? importerOverride;
     Future<int?> Function(AnimeDownloadPlan, List<String>)?
         bookImporterOverride;
+    late List<(AnimeDownloadPlan, List<String>)> subtitleResolverCalls;
+    Future<ResolvedPlanSubtitles> Function(AnimeDownloadPlan, List<String>)?
+        subtitleResolverOverride;
 
-    AnimeDownloadService buildService(
-        {QbConnectionConfig? Function()? config}) {
+    AnimeDownloadService buildService({
+      QbConnectionConfig? Function()? config,
+      bool withSubtitleResolver = true,
+    }) {
       return AnimeDownloadService(
         store: store,
         configProvider: config ?? () => _kConfig,
+        subtitleResolver: !withSubtitleResolver
+            ? null
+            : (AnimeDownloadPlan plan, List<String> videos) async {
+                subtitleResolverCalls.add((plan, videos));
+                final Future<ResolvedPlanSubtitles> Function(
+                        AnimeDownloadPlan, List<String>)? override =
+                    subtitleResolverOverride;
+                if (override != null) return override(plan, videos);
+                return const ResolvedPlanSubtitles.failed('not stubbed');
+              },
         importer: (AnimeDownloadPlan plan, List<String> videos) async {
           importCalls.add((plan, videos));
           if (importerOverride != null) return importerOverride!(plan, videos);
@@ -288,8 +304,10 @@ void main() {
       qb = _FakeQb();
       importCalls = <(AnimeDownloadPlan, List<String>)>[];
       bookImportCalls = <(AnimeDownloadPlan, List<String>)>[];
+      subtitleResolverCalls = <(AnimeDownloadPlan, List<String>)>[];
       importerOverride = null;
       bookImporterOverride = null;
+      subtitleResolverOverride = null;
     });
 
     tearDown(() {
@@ -336,6 +354,160 @@ void main() {
       expect(qb.filesRequests, 0);
       expect((await store.loadAll()).single.status,
           AnimeDownloadPlan.statusDownloading);
+    });
+
+    // ========================================================================
+    // BUG-1206：字幕改成「下载完成时按包内真实文件名补取」
+    // ========================================================================
+
+    /// 造一个「完成的整季包」场景：savePath 下 12 个真实视频文件（01-12）。
+    (String, List<Map<String, dynamic>>) completedSeasonPack() {
+      final String savePath = p.join(tempDir.path, 'downloads');
+      Directory(p.join(savePath, 'Show')).createSync(recursive: true);
+      return (
+        savePath,
+        <Map<String, dynamic>>[
+          for (int ep = 1; ep <= 12; ep++)
+            <String, dynamic>{
+              'name': 'Show/[Grp] Show - ${ep.toString().padLeft(2, '0')} '
+                  '[1080p].mkv',
+              'size': 10,
+              'progress': 1.0,
+            },
+        ],
+      );
+    }
+
+    test('BUG-1206 pending 计划：完成时才补取，resolver 拿到的是包内真实视频路径', () async {
+      final (String savePath, List<Map<String, dynamic>> files) =
+          completedSeasonPack();
+      await store.save(_plan().copyWith(
+        jimakuEntryId: 7,
+        subtitleStatus: AnimeDownloadPlan.subtitlePending,
+      ));
+      qb.torrents = <Map<String, dynamic>>[
+        _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
+      ];
+      qb.files = files;
+
+      final Directory subsDir = store.subsDirFor(_kHash)
+        ..createSync(recursive: true);
+      subtitleResolverOverride =
+          (AnimeDownloadPlan plan, List<String> videos) async {
+        final String staged = p.join(subsDir.path, 'Show - 03.ja.srt');
+        File(staged).writeAsStringSync('cue');
+        return ResolvedPlanSubtitles.ok(<PlanSubtitle>[
+          PlanSubtitle(
+              episode: 3,
+              fileName: 'Show - 03.ja.srt',
+              stagedPath: staged,
+              language: 'ja'),
+        ]);
+      };
+
+      await buildService().tick();
+
+      // ① 补取真的发生在完成之后，且喂进去的是**包内真实文件**的绝对路径。
+      expect(subtitleResolverCalls, hasLength(1));
+      final (AnimeDownloadPlan calledPlan, List<String> videos) =
+          subtitleResolverCalls.single;
+      expect(calledPlan.jimakuEntryId, 7);
+      expect(videos, hasLength(12));
+      expect(
+        videos.map(p.basename),
+        contains('[Grp] Show - 03 [1080p].mkv'),
+      );
+      // ② 反查结果真的贴成了第 3 集的 sidecar（不是第 1 集，也不是全都贴）。
+      expect(
+        File(p.join(savePath, 'Show', '[Grp] Show - 03 [1080p].ja.srt'))
+            .existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(savePath, 'Show', '[Grp] Show - 01 [1080p].ja.srt'))
+            .existsSync(),
+        isFalse,
+      );
+      // ③ 计划落成 resolved 并带上真配好的字幕。
+      final AnimeDownloadPlan saved = (await store.loadAll()).single;
+      expect(saved.subtitleStatus, AnimeDownloadPlan.subtitleResolved);
+      expect(saved.subtitles.single.episode, 3);
+      expect(saved.status, AnimeDownloadPlan.statusImported);
+    });
+
+    test('BUG-1206 反查一条都不配 → 落 unavailable + 原因，视频照常入库', () async {
+      final (String savePath, List<Map<String, dynamic>> files) =
+          completedSeasonPack();
+      await store.save(_plan().copyWith(
+        jimakuEntryId: 7,
+        jimakuEntryName: 'Wrong Season Entry',
+        subtitleStatus: AnimeDownloadPlan.subtitlePending,
+      ));
+      qb.torrents = <Map<String, dynamic>>[
+        _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
+      ];
+      qb.files = files;
+      subtitleResolverOverride = (_, __) async =>
+          const ResolvedPlanSubtitles.failed(
+              'no jimaku file matches the pack episodes');
+
+      await buildService().tick();
+
+      final AnimeDownloadPlan saved = (await store.loadAll()).single;
+      expect(saved.subtitleStatus, AnimeDownloadPlan.subtitleUnavailable);
+      expect(saved.subtitleNote, 'no jimaku file matches the pack episodes',
+          reason: '不能静默：原因要落进计划，任务行才显示得出来');
+      expect(saved.subtitles, isEmpty);
+      // 字幕没配上不该把整个下载判失败——视频还是要进库。
+      expect(saved.status, AnimeDownloadPlan.statusImported);
+      expect(importCalls, hasLength(1));
+    });
+
+    test('BUG-1206 老计划（选种时已下好字幕）不重取、不覆盖', () async {
+      final (String savePath, List<Map<String, dynamic>> files) =
+          completedSeasonPack();
+      final Directory subsDir = store.subsDirFor(_kHash)
+        ..createSync(recursive: true);
+      final String staged = p.join(subsDir.path, 'legacy 05.srt');
+      File(staged).writeAsStringSync('legacy cue');
+      // 老计划反序列化后 subtitleStatus = resolved（decode 的兼容分支）。
+      await store.save(_plan(subtitles: <PlanSubtitle>[
+        PlanSubtitle(episode: 5, fileName: 'legacy 05.srt', stagedPath: staged),
+      ]).copyWith(subtitleStatus: AnimeDownloadPlan.subtitleResolved));
+      qb.torrents = <Map<String, dynamic>>[
+        _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
+      ];
+      qb.files = files;
+
+      await buildService().tick();
+
+      expect(subtitleResolverCalls, isEmpty, reason: '老计划的字幕是既有数据，绝不能重取或覆盖');
+      expect(
+        File(p.join(savePath, 'Show', '[Grp] Show - 05 [1080p].srt'))
+            .readAsStringSync(),
+        'legacy cue',
+      );
+      expect((await store.loadAll()).single.subtitles.single.fileName,
+          'legacy 05.srt');
+    });
+
+    test('BUG-1206 没接 resolver 时 pending 计划落 unavailable，不静默', () async {
+      final (String savePath, List<Map<String, dynamic>> files) =
+          completedSeasonPack();
+      await store.save(_plan().copyWith(
+        jimakuEntryId: 7,
+        subtitleStatus: AnimeDownloadPlan.subtitlePending,
+      ));
+      qb.torrents = <Map<String, dynamic>>[
+        _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
+      ];
+      qb.files = files;
+
+      await buildService(withSubtitleResolver: false).tick();
+
+      final AnimeDownloadPlan saved = (await store.loadAll()).single;
+      expect(saved.subtitleStatus, AnimeDownloadPlan.subtitleUnavailable);
+      expect(saved.subtitleNote, isNotEmpty);
     });
 
     test('完成 → sidecar 落位 + importer 收到视频列表 + 计划标 imported', () async {
@@ -507,8 +679,8 @@ void main() {
         <String>['Show - 01.srt'],
         reason: '同一集有且只有一份 sidecar',
       );
-      expect(pickSidecar('Show - 01', dirFiles, langCode: 'ja'),
-          'Show - 01.srt');
+      expect(
+          pickSidecar('Show - 01', dirFiles, langCode: 'ja'), 'Show - 01.srt');
     });
 
     test('该集本来没有任何 sidecar 时照常落位（去重不得误伤首次下载）', () async {

--- a/hibiki/test/torrent/anime_download_subtitle_resolver_test.dart
+++ b/hibiki/test/torrent/anime_download_subtitle_resolver_test.dart
@@ -1,0 +1,149 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
+import 'package:hibiki/src/media/torrent/anime_download_subtitle_resolver.dart';
+
+/// BUG-1206 的集成层：resolver 真的走 HTTP 拉条目文件、真的按包内文件名反查、
+/// 真的只下配得上的那几条。断言的是**发出去的请求**与**落盘的文件**，不是符号。
+void main() {
+  late Directory tempDir;
+  late List<String> requested;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('jimaku_resolver_test');
+    requested = <String>[];
+  });
+
+  tearDown(() {
+    try {
+      tempDir.deleteSync(recursive: true);
+    } catch (_) {}
+  });
+
+  /// Jimaku 条目返回 [episodes] 这些集的字幕；文件本体一律返回 `cue`。
+  MockClient jimakuServing(List<int> episodes) {
+    return MockClient((http.Request req) async {
+      final String url = req.url.toString();
+      requested.add(url);
+      if (url.contains('/files')) {
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<Map<String, Object>>[
+            for (final int ep in episodes)
+              <String, Object>{
+                'name': 'Show - ${ep.toString().padLeft(2, '0')}.ja.srt',
+                'url': 'https://jimaku.cc/f/$ep.srt',
+              },
+          ])),
+          200,
+        );
+      }
+      if (url.contains('/f/')) return http.Response('cue', 200);
+      return http.Response('', 404);
+    });
+  }
+
+  JimakuPlanSubtitleResolver buildResolver(MockClient client,
+      {String apiKey = 'key'}) {
+    return JimakuPlanSubtitleResolver(
+      apiKeyProvider: () => apiKey,
+      httpClientFactory: () async => client,
+      stagingDirFor: (String planId) =>
+          Directory(p.join(tempDir.path, 'subs', planId)),
+    );
+  }
+
+  AnimeDownloadPlan pendingPlan({int? entryId = 7, String? language}) {
+    return AnimeDownloadPlan(
+      id: 'a' * 40,
+      createdAtMs: 0,
+      seriesTitle: 'Show',
+      torrentTitle: '[Grp] Show S2 Complete',
+      magnet: 'magnet:?xt=urn:btih:${'a' * 40}',
+      qbCategory: 'hibiki',
+      jimakuEntryId: entryId,
+      jimakuLanguage: language,
+      subtitleStatus: AnimeDownloadPlan.subtitlePending,
+    );
+  }
+
+  List<String> packVideos(int count) => <String>[
+        for (int ep = 1; ep <= count; ep++)
+          p.join(tempDir.path, 'dl',
+              '[Grp] Show - ${ep.toString().padLeft(2, '0')} [1080p].mkv'),
+      ];
+
+  test('错季：包 01-12 遇绝对编号条目 13-24 → 失败带原因，且一个字节都没下', () async {
+    final MockClient client =
+        jimakuServing(<int>[for (int e = 13; e <= 24; e++) e]);
+    final ResolvedPlanSubtitles result =
+        await buildResolver(client).resolve(pendingPlan(), packVideos(12));
+
+    expect(result.subtitles, isEmpty);
+    expect(result.failureReason, 'no jimaku file matches the pack episodes');
+    expect(requested.where((String u) => u.contains('/f/')), isEmpty,
+        reason: '配不上就不该下载任何字幕文件');
+    expect(Directory(p.join(tempDir.path, 'subs')).existsSync(), isFalse);
+  });
+
+  test('条数收敛：条目 24 集、包只 12 集 → 只下 12 条且都是包里的集', () async {
+    final MockClient client =
+        jimakuServing(<int>[for (int e = 1; e <= 24; e++) e]);
+    final ResolvedPlanSubtitles result =
+        await buildResolver(client).resolve(pendingPlan(), packVideos(12));
+
+    expect(result.failureReason, isNull);
+    expect(result.subtitles, hasLength(12));
+    expect(
+      result.subtitles.map((PlanSubtitle s) => s.episode).toList(),
+      <int>[for (int e = 1; e <= 12; e++) e],
+    );
+    // 只对这 12 集发过下载请求（第 13 集之后一条都没碰）。
+    final List<String> downloads =
+        requested.where((String u) => u.contains('/f/')).toList();
+    expect(downloads, hasLength(12));
+    expect(downloads, isNot(contains('https://jimaku.cc/f/13.srt')));
+    // 真落盘了。
+    for (final PlanSubtitle s in result.subtitles) {
+      expect(File(s.stagedPath).readAsStringSync(), 'cue');
+      expect(s.language, 'ja');
+    }
+  });
+
+  test('缺 API key / 缺条目 id → 明确原因，不发请求', () async {
+    final MockClient client = jimakuServing(<int>[1]);
+    expect(
+      (await buildResolver(client, apiKey: '  ')
+              .resolve(pendingPlan(), packVideos(1)))
+          .failureReason,
+      'jimaku api key missing',
+    );
+    expect(
+      (await buildResolver(client)
+              .resolve(pendingPlan(entryId: null), packVideos(1)))
+          .failureReason,
+      'no jimaku entry recorded',
+    );
+    expect(requested, isEmpty);
+  });
+
+  test('条目一个文件都没有 → 明确原因', () async {
+    final ResolvedPlanSubtitles result =
+        await buildResolver(jimakuServing(<int>[]))
+            .resolve(pendingPlan(), packVideos(3));
+    expect(result.failureReason, 'jimaku entry has no files');
+  });
+
+  test('包里没有视频文件 → 明确原因，不发请求', () async {
+    final ResolvedPlanSubtitles result =
+        await buildResolver(jimakuServing(<int>[1]))
+            .resolve(pendingPlan(), const <String>[]);
+    expect(result.failureReason, 'no video files in pack');
+    expect(requested, isEmpty);
+  });
+}


### PR DESCRIPTION
## 问题（PR#515 审查 abcbab36 的根治跟进）

配对发生在**还不知道种子包里到底有哪些文件**的时候。`NyaaTorrent` 只有标题 + 体积、**没有文件列表**；种子要到用户点推送、`addTorrent` 之后引擎才给元数据，而字幕在推送那一刻就已经下完了。于是只能靠标题猜集号、靠自述上界收敛条数：

1. **错季配对**：Jimaku 条目用绝对集号编号（S2 编 13-24），包内文件是 01-12 → 旧的 season 分支「取最前 cap 个」照样交出 13-24 的字幕，条数看着对、集号根本对不上，UI 还显示「有字幕」。
2. **条数无上界**：`seasonSubtitleCap` 只有「标题 `全13話`」和「AniList `media.episodes`」两个自述来源，两个都没有就 `return null` = 不设上界 → 条目 24 集、包只 12 集也下满 24 条。

## 改法

把配对推迟到种子 add 拿到元数据之后，按**包内真实视频文件名**反查；字幕改成下载完成时补取。

- 新纯函数 `matchJimakuFilesToVideoNames`：视频集号走 `parseVideoFilename`、字幕集号走 `parseSubtitleEpisode`，**集号严格相等才配**；只在「1 视频 + 字幕侧唯一确定」时做 1v1 兜底，且双方都有集号却不等时不兜底。**条数上界天然 = 真实视频文件数**，不再需要任何自述上界启发式。
- 计划只记**意图**：`jimakuEntryId` / `jimakuEntryName` / `jimakuLanguage` / `subtitleStatus`（`none`/`pending`/`resolved`/`unavailable`）/ `subtitleNote`。
- 补取在完成钩子：`AnimeDownloadService._resolveSubtitles` → `JimakuPlanSubtitleResolver`，此刻 `_finishPlan` 手上已有引擎给的真实文件列表。

### 五个设计问题

| 问题 | 结论 |
|---|---|
| **时序** | 选种徽标与确认页预览**照常显示**（它本就是「条目里有几集可用」的预估）；确认页恒加一行「下载完成后按包内实际文件配对」；推送 snack 同样说明；任务行 pending 期间显示「字幕：待下载完成后配对」。用户不会觉得字幕功能没了。 |
| **失败降级** | 元数据拿不到 → 沿用既有机制（`_finishPlan` 只在 `isComplete` 后跑，`importNow` 预检文件列表为空则不动状态，48h `torrentMissingTimeout`）。反查一条不配 / Jimaku 取不到 / 未接 resolver → `subtitleUnavailable` + `subtitleNote`，任务行显示「字幕：未匹配到（可手动补）」，**视频照常入库不判失败**。 |
| **既有数据** | 老计划无 `subtitleStatus` → decode 落 `resolved`/`none`，完成时 resolver **不被调用**，已有 `subtitles` 不重取不覆盖；`_placeSidecars` 的「该集已有 sidecar 就跳过」原样保留（用户手放/手改档不动）。有专门测试守住。 |
| **PR#515 不确定态** | `~` 徽标 / 中性配色 / 「集号未核对」提示行 **全部保留，未回退**。选种阶段的不确定性是**真的**——那一刻确实还没有文件列表；根治消除的是「错配真的落到磁盘上」，不是「选种时就能确定」。**确定态的落点改到任务行**：完成后显示真配好的结果或「未匹配到」。不是死装饰。 |
| **匹配规则** | 复用播放器侧同一套 `parseVideoFilename`（覆盖 `[Group] Title - 05 [1080p].mkv` / `S02E05` / `第5話`），不另写一份。集号严格相等；同集多候选按语言权重取首选；**匹配不上宁可不配**。 |

### 未做（明确划界）

- 审查建议 (a) 绝对集号偏移换算：本方案下已无必要——对不上就不配，不猜。
- 审查建议 (b) 条目季号校验：属**条目选择层**（选错了哪个 Jimaku 条目），与文件名反查正交，另立。
- 订阅路径**行为不变**：只追单集种子，且有「要字幕却取不到就整条不下」的产品门；改成延迟会把该门变成「先下完再说没字幕」。仅补齐 `subtitleStatus` 语义。

## 测试

- `anime_download_matching_test.dart`（11 条）：**错季不再配上**（S2 包 01-12 × 绝对编号条目 13-24 → 结果为空）、**条数被真实文件数收敛**（条目 24 集 × 包 12 集 → 恰好 12 条且集号是包里的）、三种文件名写法、语言偏好、1v1 兜底与「不猜」边界。
- `anime_download_subtitle_resolver_test.dart`（5 条，新）：MockClient 断言**发出去的请求**——错季时一个 `/f/` 下载请求都不发；条目 24 集时只发 12 个且不含第 13 集。
- `anime_download_service_test.dart`（4 条）：完成时才调 resolver 且喂真实绝对路径、sidecar 只贴到对应那一集、失败落 `unavailable` + 原因且视频仍入库、**老计划 resolver 不被调用且旧字幕不被覆盖**。
- `anime_download_dialog_discovery_ux_test.dart`：推送时**不发任何字幕下载请求**、计划落 `pending` + `jimakuEntryId`、snack 说明时序。（PR#515 的 N/M snack 测试按新契约改写——推送时已无「应下 N 条」这回事。）

**变异实测**：① 退回「按字幕侧顺序取最前 N 条」→ **4 条红**；② 退回「条数无上界」→ **6 条红**；③ 退回「完成时不补取」→ **3 条红**；④ 退回「计划不记 Jimaku 意图」→ **1 条红**。

## 验证

- `flutter analyze`（含 test）：`No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/torrent test/media/video test/pages/anime_download_dialog_* test/pages/jimaku_* test/i18n test/tools ...`
  → `FLUTTER TEST VERDICT: PASSED - 2468 tests ran, all tests passed`，退出码 0（含 test/epub 与 test/tools 守卫）。

⚠️ **未做真机验收**：下载 → 完成 → 字幕落 sidecar 的完整链路需要真实种子与 Jimaku API key，本轮只有自动化测试覆盖。

BUG-1206 · build `1.3.1+968`

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb


---

### 改号 / rebase 记录

- 原取号 **BUG-1203** 与已合入 develop 的 **PR#529**（EPUB 按 OPF media-type 分类）撞号 → 让号至 **BUG-1206**（1204/1205 期间被 PR#525 占走）。
  - ⚠️ `bug.dart renumber` 用不了：双方**都有代码引用**，全局改号会误伤 develop 侧 6 处（`epub_book.dart` / `epub_parser.dart` / `reader_hibiki_page.dart` / `webview.part.dart` / `mime_types.dart` / `epub_book_utils_test.dart`）。故做**限定本 PR 文件范围**的改号，四处（文件名 / 正文 H2 / 代码引用 / 测试名）齐改共 24 处；改后 `bug.dart check` 通过，develop 侧 6 处引用逐个核实完好，且 `git diff` 未碰任何 EPUB 文件。
- rebase 两轮：`e888da7c3` → `842a96f1d` → **`f65c713a3`**（期间 develop 合入 PR#526/527/528/529/525）。
  - 唯一的真实源码冲突是 `anime_download_dialog.dart` 的 **import 块**：develop 的 PR#526 把本文件的 `file_picker` 换成 `pickRealDirectoryPath` 并保留 `path`，而本 PR 删掉预下字幕逻辑后 `dart:io` / `dart:typed_data` / `path` 全部失去最后一个用法 → 合并后三者皆无用，由 `flutter analyze` 判定后移除。**无逻辑冲突。**
  - build 号让了两次：`+967` 被 develop 的 `e85bead8f` 占走 → 本 PR 取 **`+968`**。
