### PR TITLE
fix(collections): 合集重排的不变量上移到 DAO (BUG-1194 根因)

### DIFF
--- a/docs/bugs/BUG-1194-collection-reorder-nonvideo-order.md
+++ b/docs/bugs/BUG-1194-collection-reorder-nonvideo-order.md
@@ -3,15 +3,37 @@
 - **真实性**：✅ 真 bug（但**不是**报告里说的「成员从合集里掉出去」——见下方「否定的部分」）。
   根因 `hibiki/lib/src/pages/implementations/media_collection_detail_page.dart:96`（`_persistOrder`
   只把可见的 video 成员键喂给 `reorderCollectionItems`）。
-- **[x] ① 已修复** — `media_collection_detail_page.dart:96` 改为「保序合并」回写**全表**：
-  先 `getCollectionItems` 取全部成员行定义槽位，可见槽按新可见序依次填入，不可见（非
-  video / 悬空 video）成员留在其原下标，与 `media_collection_grid_detail_page.dart` 的
-  `_onReorder` 同款纪律。提交 `40e8b2850`。
-- **[x] ② 已加自动化测试** — `hibiki/test/pages/media_collection_detail_sort_test.dart`
-  新增 group「混合种类合集」3 例：拖拽 / 一键按名称 / 一键按导入时间后，断言**成员数不变、
-  game 与 epub 成员仍在合集内、sortIndex 致密无碰撞、且非 video 成员相对 video 的手排位置
-  不被打乱**。提交 `40e8b2850`。
-- **备注**：
+- **[x] ① 已修复** — 两轮，第二轮才是根因修复：
+  - 第一轮（`40e8b2850`，页面级）：`media_collection_detail_page.dart:96` 改为「保序合并」
+    回写**全表**——先 `getCollectionItems` 取全部成员行定义槽位，可见槽按新可见序依次填入，
+    不可见成员留在其原下标。**治标**：它把不变量交给每个调用方自觉，而合集详情页天然只渲染
+    子集，下一个调用方（或下一个新页面）照样能再造出碰撞。
+  - 第二轮（根因，本次）：**不变量上移到 DAO**。`HibikiDatabase.reorderCollectionItems`
+    (`packages/hibiki_core/lib/src/database/database.dart:3142`) 的契约改为「[ordered] 只表达
+    它**点名**的那批成员之间的新相对顺序」，方法自己在同一事务内取全表槽位、保序合并、把
+    sortIndex 回写成致密 `0..n-1`。**传子集从此是合法用法**，页面漏做合并不再可能造出碰撞；
+    顺带自愈——任何一次重排都把历史遗留的碰撞 sortIndex 抹平。
+  - 合并规则抽成唯一真相源纯函数 `mergeCollectionOrder`
+    （新文件 `packages/hibiki_core/lib/src/database/collection_order.dart`），DAO 守落盘不变量、
+    `media_collection_grid_detail_page._onReorder` 维护内存展示序，两侧同一份实现不会漂开。
+    身份键统一为 record `CollectionMemberKey`，**废掉网格页原来的 `'<mediaType>|<entryKey>'`
+    拼串键**——entryKey 是用户数据，`('video','a|b')` 与 `('video|a','b')` 会拼成同一个串。
+  - `media_collection_detail_page._persistOrder` 的 30 行保序合并块随之整块删除，只传可见
+    video 键。
+- **[x] ② 已加自动化测试** — 三层：
+  - `hibiki/test/database/collection_order_test.dart`（新增，7 例）：纯规则——未点名成员留原
+    槽位 / 绝不挤到表尾 / 全量点名等价于直接排序 / 空 subset / 并发移出键丢弃 / 重复键 /
+    分隔符出现在 entryKey 里也不误判。
+  - `hibiki/test/database/media_collections_dao_test.dart`（新增 group「子集契约」3 例）：
+    **根因守卫**——只传可见 video 子集时非 video 成员留原槽位且全表致密无碰撞；用
+    `upsertCollectionItemAt` 种出旧版碰撞现场后一次重排自愈；点名已被并发移出的成员不越界。
+  - `hibiki/test/pages/media_collection_detail_sort_test.dart` 的 group「混合种类合集」3 例
+    （第一轮加的）保留：拖拽 / 一键按名称 / 一键按导入时间后，断言成员数不变、game 与 epub
+    成员仍在合集内、sortIndex 致密无碰撞、非 video 成员相对 video 的手排位置不被打乱。
+- **备注**：**不禁止混合种类合集**——网格详情页本就显示全部成员，混合是被支持的形态。
+  「加入合集」弹窗不按种类过滤、同步/备份按 `(name, collectionType)` 自然键对齐，这两条是
+  混合**如何产生**的解释，不是要改掉的缺陷；根因修复的方向是让排序在混合下正确，而不是
+  加特例阻止混合。
 
 ### 否定的部分：不存在数据丢失
 

--- a/docs/bugs/BUG-1194-collection-reorder-nonvideo-order.md
+++ b/docs/bugs/BUG-1194-collection-reorder-nonvideo-order.md
@@ -30,6 +30,22 @@
   - `hibiki/test/pages/media_collection_detail_sort_test.dart` 的 group「混合种类合集」3 例
     （第一轮加的）保留：拖拽 / 一键按名称 / 一键按导入时间后，断言成员数不变、game 与 epub
     成员仍在合集内、sortIndex 致密无碰撞、非 video 成员相对 video 的手排位置不被打乱。
+  - `hibiki/test/database/media_collections_dao_test.dart` 再加 1 例「sortIndex 碰撞时
+    按 entryKey 定序，并被一次重排冻结成致密序」：DAO 现在把 `getCollectionItems` 的
+    结果**冻结**成永久致密序，那个读的定序规则是整套修复的地基。用例刻意让 entryKey
+    序与 mediaType 序**相反**，去掉 ORDER BY 的 entryKey 段即转红（实测）。
+  - 同时给 `getCollectionItems` / `getAllCollectionItems` 的 ORDER BY 补末位
+    `mediaType` 段，让排序键 == 成员身份 `(collectionId, mediaType, entryKey)` 去掉被
+    where 钉死的 collectionId → 全序。**诚实标注**：当前 SQLite 计划走复合主键索引
+    扫描、本就是 mediaType 升序，删掉这一段行为不变，实测无法用行为测试守它；保留它
+    是为了不让"冻结"依赖查询计划的巧合，不是修一个今天可复现的症状。
+- **已知残留（不在本 PR 范围）**：备份合并路径不走 DAO，本次不变量管不到它。
+  `hibiki/lib/src/sync/backup_merge_engine.dart:437` 用裸 SQL
+  `INSERT OR IGNORE ... (collection_id, media_type, entry_key, sort_index)` **原样搬**
+  源库的 sort_index，既不致密化也不碰 `orderUpdatedAt`（该文件全文无此列）。所以一次
+  备份合并导入仍可能把碰撞 sortIndex 带回本地。影响面比原 bug 小（导入才发生，且下一次
+  任何重排会自愈），但要彻底闭合「顺序一致性」得单开一条：合并后按 `(sortIndex, entryKey,
+  mediaType)` 对受影响合集重编号，并决定是否传播序时间戳。
 - **备注**：**不禁止混合种类合集**——网格详情页本就显示全部成员，混合是被支持的形态。
   「加入合集」弹窗不按种类过滤、同步/备份按 `(name, collectionType)` 自然键对齐，这两条是
   混合**如何产生**的解释，不是要改掉的缺陷；根因修复的方向是让排序在混合下正确，而不是
@@ -59,7 +75,7 @@
   （`games_library_page.dart:378`）、书架（`reader_hibiki_history_page.dart:2044`）都能把
   game/epub/srt 成员加进一个已含 video 的合集。
 - `hibiki/lib/src/sync/collection_sync_engine.dart:624` 与
-  `hibiki/lib/src/sync/backup_merge_engine.dart:436` 按 `(name, collectionType)` 自然键对齐、
+  `hibiki/lib/src/sync/backup_merge_engine.dart:308` 按 `(name, collectionType)` 自然键对齐、
   裸串写入对端 mediaType：两台设备各建同名合集（一台放书、一台放视频），同步一轮即混合。
 
 混合后在本页拖拽 → video 成员拿到 0..n-1，非 video 成员留着旧 sortIndex 与之**碰撞**；

--- a/hibiki/lib/src/media/collections/collection_one_key_sort.dart
+++ b/hibiki/lib/src/media/collections/collection_one_key_sort.dart
@@ -115,7 +115,7 @@ Future<void> applyCollectionOneKeySort({
       await sortedCollectionRows(db: db, rows: rows, byTitle: byTitle);
   await db.reorderCollectionItems(
     collectionId,
-    <({String mediaType, String entryKey})>[
+    <CollectionMemberKey>[
       for (final MediaCollectionItemRow r in next)
         (mediaType: r.mediaType, entryKey: r.entryKey),
     ],

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -94,47 +94,18 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 把当前 [_members] 顺序一次落盘（sortIndex 全表回写）。库页合集行与播放器
   /// 换集读同一 `getCollectionItems`，落盘即三处同序（层次 C 单一真相源）。
   ///
-  /// BUG-1190：本页只渲染 video 成员（调用方 `loadMembers` 按 mediaType 过滤），但
-  /// 一个合集**可以**同时含非 video 成员——「加入合集」弹窗列全表不按种类过滤，
-  /// 合集同步/备份合并又按 `(name, collectionType)` 自然键对齐、原样并入对端的裸串
-  /// mediaType。只回写可见的 video 键，会让不可见成员留着旧 sortIndex 与新写的致密
-  /// 0..n-1 碰撞（`getCollectionItems` 平手退化按 entryKey 排），把用户在别处排好的
-  /// 跨种类顺序打乱，并随同事务 bump 的 orderUpdatedAt 以 LWW 赢家身份推给对端。
-  ///
-  /// 修法与 `MediaCollectionGridDetailPage._onReorder` 同款「保序合并」：回写**全表**，
-  /// 可见槽按新可见序依次填入，不可见成员留在其原下标。
+  /// 本页只渲染 video 成员（调用方 `loadMembers` 按 mediaType 过滤），而一个合集**可以**
+  /// 同时含非 video 成员，所以这里传的是**子集**——这是 `reorderCollectionItems` 的合法
+  /// 用法：不可见成员留在原槽位、全表写成致密序，由 DAO 保证（BUG-1194 的不变量归属在
+  /// DAO，不是各调用方自觉；页面不再自己做保序合并）。
   Future<void> _persistOrder() async {
-    final List<MediaCollectionItemRow> all =
-        await widget.database.getCollectionItems(widget.collection.id);
-    // 身份用 record 集合（值相等），不拼分隔符字符串——entryKey 是用户数据，任何
-    // 分隔符都可能歧义。
-    final Set<({String mediaType, String entryKey})> present =
-        <({String mediaType, String entryKey})>{
-      for (final MediaCollectionItemRow r in all)
-        (mediaType: r.mediaType, entryKey: r.entryKey),
-    };
-    // 可见序里只留 DB 仍在的成员：本页快照与 DB 之间可能有并发移出。过滤后可见槽数
-    // 恒等于 visible.length，下面合并时 vi 恰好消费完、不会越界。
-    final List<({String mediaType, String entryKey})> visible =
-        <({String mediaType, String entryKey})>[
-      for (final VideoBookRow r in _members)
-        if (present.contains(
-            (mediaType: MediaKind.video.dbValue, entryKey: r.bookUid)))
+    await widget.database.reorderCollectionItems(
+      widget.collection.id,
+      <CollectionMemberKey>[
+        for (final VideoBookRow r in _members)
           (mediaType: MediaKind.video.dbValue, entryKey: r.bookUid),
-    ];
-    final Set<({String mediaType, String entryKey})> visibleKeys =
-        visible.toSet();
-    int vi = 0;
-    final List<({String mediaType, String entryKey})> ordered =
-        <({String mediaType, String entryKey})>[
-      for (final MediaCollectionItemRow r in all)
-        if (visibleKeys
-            .contains((mediaType: r.mediaType, entryKey: r.entryKey)))
-          visible[vi++]
-        else
-          (mediaType: r.mediaType, entryKey: r.entryKey),
-    ];
-    await widget.database.reorderCollectionItems(widget.collection.id, ordered);
+      ],
+    );
     widget.onChanged();
   }
 

--- a/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
@@ -120,7 +120,7 @@ class _MediaCollectionGridDetailPageState
     setState(() => _rows = next);
     await widget.database.reorderCollectionItems(
       widget.collection.id,
-      <({String mediaType, String entryKey})>[
+      <CollectionMemberKey>[
         for (final MediaCollectionItemRow r in next)
           (mediaType: r.mediaType, entryKey: r.entryKey),
       ],
@@ -178,11 +178,12 @@ class _MediaCollectionGridDetailPageState
   }
 
   /// 网格拖拽落序：from/to 是**可见**成员下标（[_visibleRows]）。先在可见序上应用
-  /// removeAt/insert，再**保序合并**回 [_rows] 全表：遍历原 _rows，可见槽按新可见序
-  /// 依次填入、孤儿行（当前不可见——被书架标签筛选掉的成员）留在原下标。绝不把隐藏
-  /// 成员挤到表尾——否则筛选态下一次拖拽就把全部隐藏成员从原位挤到末尾落盘。最后
-  /// `reorderCollectionItems` 一次落盘。库页合集行 / 播放器换集读同一 `getCollectionItems`，
-  /// 落盘即同序。
+  /// removeAt/insert，再用共享的 [mergeCollectionOrder] **保序合并**回 [_rows] 全表：
+  /// 可见槽按新可见序依次填入、孤儿行（当前不可见——被书架标签筛选掉的成员）留在原
+  /// 下标。绝不把隐藏成员挤到表尾——否则筛选态下一次拖拽就把全部隐藏成员从原位挤到
+  /// 末尾。落盘只需传可见序（不可见成员留原槽位由 `reorderCollectionItems` 保证，与
+  /// 这里的内存合并同一份规则、不会漂开）；库页合集行 / 播放器换集读同一
+  /// `getCollectionItems`，落盘即同序。
   Future<void> _onReorder(int from, int to) async {
     if (from == to) return;
     final List<MediaCollectionItemRow> visible =
@@ -192,29 +193,20 @@ class _MediaCollectionGridDetailPageState
     }
     final MediaCollectionItemRow moved = visible.removeAt(from);
     visible.insert(to, moved);
-    // 保序合并：可见槽（key 命中 visibleKeys）按 visible 的新顺序依次消费，孤儿行按
-    // 其在原 _rows 中的下标原地保留。visible 的成员集合与拖前一致（只是被置换顺序），
-    // 故可见槽数 == visible.length，vi 恰好消费完，不会越界。
-    final Set<String> visibleKeys = <String>{
-      for (final MediaCollectionItemRow r in visible)
-        '${r.mediaType}|${r.entryKey}',
-    };
-    int vi = 0;
-    final List<MediaCollectionItemRow> next = <MediaCollectionItemRow>[
-      for (final MediaCollectionItemRow r in _rows)
-        if (visibleKeys.contains('${r.mediaType}|${r.entryKey}'))
-          visible[vi++]
-        else
-          r,
-    ];
+    final List<MediaCollectionItemRow> next = mergeCollectionOrder(
+      all: _rows,
+      subset: visible,
+      keyOf: (MediaCollectionItemRow r) =>
+          (mediaType: r.mediaType, entryKey: r.entryKey),
+    );
     setState(() {
       _rows = next;
       _visibleRows = visible;
     });
     await widget.database.reorderCollectionItems(
       widget.collection.id,
-      <({String mediaType, String entryKey})>[
-        for (final MediaCollectionItemRow r in next)
+      <CollectionMemberKey>[
+        for (final MediaCollectionItemRow r in visible)
           (mediaType: r.mediaType, entryKey: r.entryKey),
       ],
     );

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+980
+version: 1.3.1+981
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/database/collection_order_test.dart
+++ b/hibiki/test/database/collection_order_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// [mergeCollectionOrder] 纯规则测试（BUG-1194 根因修复的地基）。
+///
+/// 这条规则同时被 `HibikiDatabase.reorderCollectionItems`（守落盘不变量）和
+/// `MediaCollectionGridDetailPage._onReorder`（维护内存展示序）使用，一处写错两处
+/// 一起漂，所以单独直测。
+CollectionMemberKey _k(String mediaType, String entryKey) =>
+    (mediaType: mediaType, entryKey: entryKey);
+
+List<CollectionMemberKey> _merge(
+  List<CollectionMemberKey> all,
+  List<CollectionMemberKey> subset,
+) =>
+    mergeCollectionOrder<CollectionMemberKey>(
+      all: all,
+      subset: subset,
+      keyOf: (CollectionMemberKey k) => k,
+    );
+
+void main() {
+  test('未点名的成员留在原槽位，点名的按 subset 顺序依次填入', () {
+    // 交错基线：video / game / video / epub / video。
+    final List<CollectionMemberKey> all = <CollectionMemberKey>[
+      _k('video', 'v1'),
+      _k('game', 'g1'),
+      _k('video', 'v2'),
+      _k('epub', 'e1'),
+      _k('video', 'v3'),
+    ];
+    // 只点名三个 video，倒排。
+    expect(
+      _merge(all, <CollectionMemberKey>[
+        _k('video', 'v3'),
+        _k('video', 'v2'),
+        _k('video', 'v1'),
+      ]),
+      <CollectionMemberKey>[
+        _k('video', 'v3'),
+        _k('game', 'g1'),
+        _k('video', 'v2'),
+        _k('epub', 'e1'),
+        _k('video', 'v1'),
+      ],
+      reason: 'video 只在 video 槽位（0/2/4）内部换位，g1/e1 原地不动',
+    );
+  });
+
+  test('未点名成员绝不被挤到表尾', () {
+    final List<CollectionMemberKey> all = <CollectionMemberKey>[
+      _k('game', 'g1'),
+      _k('video', 'v1'),
+      _k('video', 'v2'),
+    ];
+    // 「挤到表尾」的错误实现会得到 [v2, v1, g1]。
+    expect(
+      _merge(all, <CollectionMemberKey>[_k('video', 'v2'), _k('video', 'v1')]),
+      <CollectionMemberKey>[
+        _k('game', 'g1'),
+        _k('video', 'v2'),
+        _k('video', 'v1'),
+      ],
+      reason: '筛选态下若把隐藏成员挤到末尾，一次拖拽就会把它们从原位全冲到表尾',
+    );
+  });
+
+  test('subset 点名全部成员 → 结果就是 subset 顺序（一键整理路径）', () {
+    final List<CollectionMemberKey> all = <CollectionMemberKey>[
+      _k('video', 'v1'),
+      _k('game', 'g1'),
+      _k('epub', 'e1'),
+    ];
+    final List<CollectionMemberKey> sorted = <CollectionMemberKey>[
+      _k('epub', 'e1'),
+      _k('video', 'v1'),
+      _k('game', 'g1'),
+    ];
+    expect(_merge(all, sorted), sorted);
+  });
+
+  test('subset 为空 → 全表顺序零变化', () {
+    final List<CollectionMemberKey> all = <CollectionMemberKey>[
+      _k('video', 'v1'),
+      _k('game', 'g1'),
+    ];
+    expect(_merge(all, const <CollectionMemberKey>[]), all);
+  });
+
+  test('subset 含已不在 all 中的键（并发移出）→ 丢弃，不越界', () {
+    final List<CollectionMemberKey> all = <CollectionMemberKey>[
+      _k('video', 'v1'),
+      _k('game', 'g1'),
+      _k('video', 'v3'),
+    ];
+    expect(
+      _merge(all, <CollectionMemberKey>[
+        _k('video', 'v3'),
+        _k('video', 'v2'), // 已被移出
+        _k('video', 'v1'),
+      ]),
+      <CollectionMemberKey>[
+        _k('video', 'v3'),
+        _k('game', 'g1'),
+        _k('video', 'v1'),
+      ],
+    );
+  });
+
+  test('subset 含重复键 → 只认第一次出现，不越界', () {
+    final List<CollectionMemberKey> all = <CollectionMemberKey>[
+      _k('video', 'v1'),
+      _k('game', 'g1'),
+      _k('video', 'v2'),
+    ];
+    expect(
+      _merge(all, <CollectionMemberKey>[
+        _k('video', 'v2'),
+        _k('video', 'v2'),
+        _k('video', 'v1'),
+      ]),
+      <CollectionMemberKey>[
+        _k('video', 'v2'),
+        _k('game', 'g1'),
+        _k('video', 'v1'),
+      ],
+    );
+  });
+
+  test('身份键是 record 不是拼串：entryKey 含分隔符也不误判同一成员', () {
+    // 拼 '<mediaType>|<entryKey>' 的旧写法下，('video', 'a|b') 与 ('video|a', 'b')
+    // 都拼成 'video|a|b' → 被当成同一成员，合并时槽位计数错乱。
+    final List<CollectionMemberKey> all = <CollectionMemberKey>[
+      _k('video', 'a|b'),
+      _k('video|a', 'b'),
+      _k('game', 'g1'),
+    ];
+    expect(
+      _merge(
+          all, <CollectionMemberKey>[_k('video|a', 'b'), _k('video', 'a|b')]),
+      <CollectionMemberKey>[
+        _k('video|a', 'b'),
+        _k('video', 'a|b'),
+        _k('game', 'g1'),
+      ],
+      reason: 'record 逐字段比较，分隔符出现在用户数据里也不歧义',
+    );
+  });
+}

--- a/hibiki/test/database/media_collections_dao_test.dart
+++ b/hibiki/test/database/media_collections_dao_test.dart
@@ -99,7 +99,7 @@ void main() {
     await db.addToCollection(c, MediaKind.video, 'v2');
     await db.addToCollection(c, MediaKind.video, 'v3');
 
-    await db.reorderCollectionItems(c, <({String mediaType, String entryKey})>[
+    await db.reorderCollectionItems(c, <CollectionMemberKey>[
       (mediaType: 'video', entryKey: 'v3'),
       (mediaType: 'video', entryKey: 'v1'),
       (mediaType: 'video', entryKey: 'v2'),
@@ -108,6 +108,95 @@ void main() {
       (await db.getCollectionItems(c)).map((m) => m.entryKey).toList(),
       <String>['v3', 'v1', 'v2'],
     );
+  });
+
+  // ── BUG-1194 根因守卫：reorderCollectionItems 的**子集**契约 ──────────────
+  // 合集详情页天然只渲染成员子集（视频详情页只显示 video；网格详情页按标签过滤），
+  // 所以「传子集」是合法用法。不变量必须由 DAO 自己守住，页面漏做保序合并不该再能
+  // 造出碰撞 sortIndex——旧实现按 ordered 下标直写，未点名成员留旧值与新写的致密
+  // 0..n-1 碰撞，getCollectionItems 平手退化按 entryKey 排，跨种类手排序被打乱。
+  group('reorderCollectionItems 子集契约（BUG-1194 根因）', () {
+    /// 交错基线：video/g1/video/e1/video —— 非 video 成员夹在 video 之间，只回写
+    /// 可见 video 键时它们的相对位置必然被打乱。
+    Future<int> seedMixed(HibikiDatabase db) async {
+      final int c = await db.createMediaCollection('Mixed');
+      await db.addToCollection(c, MediaKind.video, 'v1');
+      await db.addToCollection(c, MediaKind.game, 'g1');
+      await db.addToCollection(c, MediaKind.video, 'v2');
+      await db.addToCollection(c, MediaKind.epub, 'e1');
+      await db.addToCollection(c, MediaKind.video, 'v3');
+      return c;
+    }
+
+    Future<List<String>> members(HibikiDatabase db, int c) async => <String>[
+          for (final MediaCollectionItemRow r in await db.getCollectionItems(c))
+            '${r.mediaType}|${r.entryKey}',
+        ];
+
+    Future<List<int>> indices(HibikiDatabase db, int c) async => <int>[
+          for (final MediaCollectionItemRow r in await db.getCollectionItems(c))
+            r.sortIndex,
+        ];
+
+    test('只传可见 video 子集：非 video 成员留原槽位，全表致密无碰撞', () async {
+      final db = await _openDb();
+      final int c = await seedMixed(db);
+
+      // 视频详情页把可见的三个 video 倒排后落盘（**只传 video 子集**）。
+      await db.reorderCollectionItems(c, <CollectionMemberKey>[
+        (mediaType: 'video', entryKey: 'v3'),
+        (mediaType: 'video', entryKey: 'v2'),
+        (mediaType: 'video', entryKey: 'v1'),
+      ]);
+
+      expect(
+        await members(db, c),
+        <String>['video|v3', 'game|g1', 'video|v2', 'epub|e1', 'video|v1'],
+        reason: 'video 依次填回原来的三个 video 槽位（0/2/4），g1/e1 留在 1/3 不被挤走',
+      );
+      expect(await indices(db, c), <int>[0, 1, 2, 3, 4],
+          reason: 'sortIndex 必须致密 0..n-1；有重复即说明漏写了未点名成员');
+    });
+
+    test('历史遗留的碰撞 sortIndex：任何一次重排都自愈成致密序，相对顺序不变', () async {
+      final db = await _openDb();
+      final int c = await seedMixed(db);
+      // 种一份旧版（只回写可见 video 子集）留下的碰撞现场：v1/v2/v3 被写成 0/1/2，
+      // g1/e1 留着旧的 1/3 → sortIndex 1 上有 g1 与 v2 两行。upsertCollectionItemAt
+      // 是同步应用端的显式 sortIndex 写入口，这里借它复现旧数据。
+      await db.upsertCollectionItemAt(c, 'video', 'v1', 0);
+      await db.upsertCollectionItemAt(c, 'video', 'v2', 1);
+      await db.upsertCollectionItemAt(c, 'video', 'v3', 2);
+      await db.upsertCollectionItemAt(c, 'game', 'g1', 1);
+      await db.upsertCollectionItemAt(c, 'epub', 'e1', 3);
+      expect(await indices(db, c), <int>[0, 1, 1, 2, 3],
+          reason: '前置条件：现场确实有碰撞（sortIndex 1 两行）');
+
+      // 碰撞下 getCollectionItems 平手退化按 entryKey 排 —— 这就是用户此刻看到的序。
+      final List<String> before = await members(db, c);
+      await db.reorderCollectionItems(c, const <CollectionMemberKey>[]);
+
+      expect(await members(db, c), before, reason: '没点名任何成员 → 相对顺序零变化');
+      expect(await indices(db, c), <int>[0, 1, 2, 3, 4],
+          reason: '重排把全表写成致密序，历史碰撞就此消除（不再依赖 entryKey 兜底）');
+    });
+
+    test('点名了已被并发移出的成员：丢弃该键，其余成员照常重排不越界', () async {
+      final db = await _openDb();
+      final int c = await seedMixed(db);
+      // 页面持有的快照里还有 v2，但 DB 侧已被别处移出。
+      await db.removeFromCollection(c, MediaKind.video, 'v2');
+
+      await db.reorderCollectionItems(c, <CollectionMemberKey>[
+        (mediaType: 'video', entryKey: 'v3'),
+        (mediaType: 'video', entryKey: 'v2'), // 已不在 DB → 丢弃
+        (mediaType: 'video', entryKey: 'v1'),
+      ]);
+
+      expect(await members(db, c),
+          <String>['video|v3', 'game|g1', 'epub|e1', 'video|v1']);
+      expect(await indices(db, c), <int>[0, 1, 2, 3]);
+    });
   });
 
   test('removeEntryFromAllCollections 清全部引用 + 删空合集', () async {

--- a/hibiki/test/database/media_collections_dao_test.dart
+++ b/hibiki/test/database/media_collections_dao_test.dart
@@ -181,6 +181,38 @@ void main() {
           reason: '重排把全表写成致密序，历史碰撞就此消除（不再依赖 entryKey 兜底）');
     });
 
+    test('sortIndex 碰撞时按 entryKey 定序，并被一次重排冻结成致密序', () async {
+      // reorderCollectionItems 把 getCollectionItems 的结果**冻结**成永久致密序，
+      // 所以那个读的定序规则是本 PR 的地基。这里守的是**可观测**的那一段：
+      // sortIndex 全碰撞时按 entryKey 升序，且冻结后不再依赖任何并列兜底。
+      //
+      // 诚实标注：getCollectionItems 的 ORDER BY 末位还有一段 mediaType（补全序，
+      // 见该方法注释）。当前 SQLite 计划走复合主键索引扫描、本就是 mediaType 升序，
+      // 删掉那一段**行为不变**，故此处不为它写断言——写了也是永远绿的假守卫。
+      final db = await _openDb();
+      final int c = await db.createMediaCollection('Collided');
+      // 全部塞进 sortIndex 0，且**刻意让 entryKey 序与 mediaType 序相反**
+      // （entryKey aa<mm<zz 给出 video,game,epub；mediaType epub<game<video 给出
+      // 相反序），否则两段谁在起作用分不出来——换成同向数据这条断言就永远绿。
+      // 插入序也与期望序不同，顺带排除"恰好等于写入顺序"。
+      await db.upsertCollectionItemAt(c, 'game', 'mm', 0);
+      await db.upsertCollectionItemAt(c, 'epub', 'zz', 0);
+      await db.upsertCollectionItemAt(c, 'video', 'aa', 0);
+
+      expect(
+        await members(db, c),
+        <String>['video|aa', 'game|mm', 'epub|zz'],
+        reason: 'sortIndex 全碰撞 → 按 entryKey 升序（aa < mm < zz），'
+            '与插入序、与 mediaType 序都无关',
+      );
+
+      await db.reorderCollectionItems(c, const <CollectionMemberKey>[]);
+      expect(await members(db, c), <String>['video|aa', 'game|mm', 'epub|zz'],
+          reason: '冻结不改相对顺序');
+      expect(await indices(db, c), <int>[0, 1, 2],
+          reason: '冻结后 sortIndex 致密，展示序不再依赖并列兜底');
+    });
+
     test('点名了已被并发移出的成员：丢弃该键，其余成员照常重排不越界', () async {
       final db = await _openDb();
       final int c = await seedMixed(db);

--- a/packages/hibiki_core/lib/hibiki_core.dart
+++ b/packages/hibiki_core/lib/hibiki_core.dart
@@ -1,6 +1,7 @@
 library hibiki_core;
 
 export 'src/database/activity_event_types.dart';
+export 'src/database/collection_order.dart';
 export 'src/database/database.dart';
 export 'src/database/media_kind.dart';
 export 'src/database/media_kind_mappings.dart';

--- a/packages/hibiki_core/lib/src/database/collection_order.dart
+++ b/packages/hibiki_core/lib/src/database/collection_order.dart
@@ -1,0 +1,57 @@
+/// 合集成员顺序的**纯规则**：身份键类型 + 保序合并。
+///
+/// 存在理由（BUG-1194 根因）：合集详情页天然只渲染成员的一个**子集**——视频合集
+/// 详情页按 mediaType 过滤（只显示 video），书架网格详情页按标签过滤。用户在子集上
+/// 拖出的新顺序，必须先合并回**全表**顺序才能落盘；否则未被点名的成员留着旧
+/// sortIndex，与新写的致密 `0..n-1` 碰撞，`getCollectionItems` 平手退化按 entryKey
+/// 排，用户在别处排好的跨种类顺序就被静默打乱。
+///
+/// 这条规则原本被复制在两个页面里（且各写各的身份键），本文件是唯一真相源：
+/// [HibikiDatabase.reorderCollectionItems] 用它守住落盘不变量，页面用它维护内存
+/// 展示序，两侧同一份实现不会漂开。
+library;
+
+/// 合集成员的身份键：`(mediaType, entryKey)` 记录。
+///
+/// **值相等的 record，不是拼分隔符的字符串**：entryKey 是用户数据（epub=bookKey /
+/// srt=uid / video=bookUid / game=galgames.id，其中不乏路径与用户命名），任何分隔符
+/// 都可能出现在数据里造成歧义碰撞。record 的相等性按字段逐个比，无此风险。
+typedef CollectionMemberKey = ({String mediaType, String entryKey});
+
+/// 保序合并：把「一部分成员的新相对顺序」合并回全表顺序。
+///
+/// [all] 是合集当前的**全表**顺序，[subset] 是其中一部分成员被重排后的新相对顺序，
+/// [keyOf] 把元素映射到身份键。返回新的全表顺序：[all] 中被 [subset] 点名的**槽位**
+/// 按 [subset] 的顺序依次填入，未点名的成员**留在其原槽位**。
+///
+/// 「留在原槽位」而不是「挤到表尾」是关键：筛选态下若把隐藏成员挤到末尾，一次拖拽
+/// 就会把全部隐藏成员从原位冲到表尾落盘。
+///
+/// 健壮性（调用方无需自己过滤）：
+/// - [subset] 里不在 [all] 中的键（并发移出）被丢弃；
+/// - [subset] 里的重复键只认第一次出现。
+///
+/// 二者保证「被点名的槽位数」恒等于「有效 subset 长度」，合并时不会越界。
+/// [all] 内部键唯一是表约束（`media_collection_items` 复合主键含 mediaType +
+/// entryKey），故同一槽位不会被重复点名。
+List<T> mergeCollectionOrder<T>({
+  required List<T> all,
+  required List<T> subset,
+  required CollectionMemberKey Function(T item) keyOf,
+}) {
+  final Set<CollectionMemberKey> allKeys = <CollectionMemberKey>{
+    for (final T item in all) keyOf(item),
+  };
+  // named 与 namedKeys 一起建：能进 named 的元素其键恰好进 namedKeys（add 返回 true
+  // 才收），故 named.length == namedKeys.length。
+  final Set<CollectionMemberKey> namedKeys = <CollectionMemberKey>{};
+  final List<T> named = <T>[
+    for (final T item in subset)
+      if (allKeys.contains(keyOf(item)) && namedKeys.add(keyOf(item))) item,
+  ];
+  int next = 0;
+  return <T>[
+    for (final T item in all)
+      if (namedKeys.contains(keyOf(item))) named[next++] else item,
+  ];
+}

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -11,6 +11,7 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
 import '../utils/ttu_sanitize.dart';
 import '../utils/video_book_uid.dart';
+import 'collection_order.dart';
 import 'media_kind.dart';
 import 'pref_codec.dart';
 import 'sync_tombstone_kind.dart';
@@ -3145,19 +3146,46 @@ class HibikiDatabase extends _$HibikiDatabase {
         }
       });
 
-  /// 合集内重排：按 [ordered] 顺序逐条回写 sortIndex（退出重排页一次落盘）。同事务
-  /// bump 本合集 orderUpdatedAt = now（schema v40 跨端手动序整合集 LWW 的比较键，
-  /// 只有真实人为改序走这里；同步应用对端顺序走 [setCollectionOrderUpdatedAt]
-  /// 镜像对端时间戳，绝不 bump now——否则同步会伪装成更新的人为改序）。
-  Future<void> reorderCollectionItems(int collectionId,
-          List<({String mediaType, String entryKey})> ordered) =>
+  /// 合集内重排：[ordered] 表达**它点名的那批成员之间的新相对顺序**，本方法负责把它
+  /// 合并回全表并把 sortIndex 回写成致密 `0..n-1`（退出重排页一次落盘）。同事务 bump
+  /// 本合集 orderUpdatedAt = now（schema v40 跨端手动序整合集 LWW 的比较键，只有真实
+  /// 人为改序走这里；同步应用对端顺序走 [setCollectionOrderUpdatedAt] 镜像对端时间戳，
+  /// 绝不 bump now——否则同步会伪装成更新的人为改序）。
+  ///
+  /// BUG-1194 根因修复——**不变量归 DAO 所有，不是各调用方的自觉**：
+  /// 合集详情页天然只渲染成员子集（视频详情页按 mediaType 只显示 video；书架网格详情页
+  /// 按标签过滤），而 `media_collection_items.mediaType` 无 CHECK 约束、一个合集可混多种
+  /// 种类（「加入合集」弹窗列全表不按种类过滤；合集同步/备份合并按 `(name, collectionType)`
+  /// 自然键对齐并原样并入对端裸串 mediaType，两端各建同名合集同步一轮即混合）。旧实现
+  /// 直接按 [ordered] 的下标写 sortIndex：调用方只要传子集，未点名的成员就留着旧
+  /// sortIndex 与新写的致密 `0..n-1` **碰撞**，[getCollectionItems] 平手退化按 entryKey
+  /// 排，用户在网格详情页排好的跨种类顺序被打乱，还随同事务 bump 的 orderUpdatedAt 以
+  /// LWW 赢家身份推给全部对端。修在页面里治标——每个现有和将来的调用方都得自己记得
+  /// 合并；修在这里治本：**传子集是合法用法**，未点名的成员由本方法保证留在原槽位。
+  ///
+  /// 顺带自愈：任何一次重排都把全表写成致密序，历史遗留的碰撞 sortIndex 就此消除。
+  /// 合并规则（含并发移出/重复键的容错）见 [mergeCollectionOrder]。
+  Future<void> reorderCollectionItems(
+          int collectionId, List<CollectionMemberKey> ordered) =>
       transaction(() async {
-        for (int i = 0; i < ordered.length; i++) {
+        // 事务内取当前全表顺序作槽位基准（[getCollectionItems] 的 sortIndex→entryKey
+        // 口径 = 用户此刻看到的顺序）。
+        final List<MediaCollectionItemRow> all =
+            await getCollectionItems(collectionId);
+        final List<CollectionMemberKey> merged = mergeCollectionOrder(
+          all: <CollectionMemberKey>[
+            for (final MediaCollectionItemRow r in all)
+              (mediaType: r.mediaType, entryKey: r.entryKey),
+          ],
+          subset: ordered,
+          keyOf: (CollectionMemberKey k) => k,
+        );
+        for (int i = 0; i < merged.length; i++) {
           await (update(mediaCollectionItems)
                 ..where((t) =>
                     t.collectionId.equals(collectionId) &
-                    t.mediaType.equals(ordered[i].mediaType) &
-                    t.entryKey.equals(ordered[i].entryKey)))
+                    t.mediaType.equals(merged[i].mediaType) &
+                    t.entryKey.equals(merged[i].entryKey)))
               .write(MediaCollectionItemsCompanion(sortIndex: Value(i)));
         }
         await (update(mediaCollections)

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -3018,26 +3018,42 @@ class HibikiDatabase extends _$HibikiDatabase {
         return deleted;
       });
 
-  /// 某合集全部成员，按 sortIndex 升序、entryKey 升序（稳定播放/展示序）。
+  /// 某合集全部成员，按 sortIndex 升序、entryKey 升序、mediaType 升序（稳定播放/
+  /// 展示序）。
+  ///
+  /// 三段排序键**恰好等于表的成员身份**（复合主键 `(collectionId, mediaType,
+  /// entryKey)` 去掉已被 where 钉死的 collectionId）→ 全序，无并列。
+  ///
+  /// 末位 mediaType 段是**防御性**的，诚实说明其份量：只排到 entryKey 时，同一合集
+  /// 里同 entryKey 的两个不同 mediaType 行（entryKey 是各域裸串——epub=bookKey /
+  /// video=bookUid / game=galgames.id，命名空间不交叉是约定、不是 DB 约束）在
+  /// sortIndex 也碰撞的情况下，次序就交给了查询计划。当前计划走复合主键索引扫描、
+  /// 恰好已经是 mediaType 升序，所以补这一段**今天不改变任何可观测行为**——也因此
+  /// 没有能检测其删除的行为测试，别为它编一个假绿守卫。写出来的理由是
+  /// [reorderCollectionItems] 拿本查询的结果当槽位基准并**冻结**成永久的致密
+  /// sortIndex：喂给冻结操作的读不该依赖计划的巧合。
   Future<List<MediaCollectionItemRow>> getCollectionItems(int collectionId) =>
       (select(mediaCollectionItems)
             ..where((t) => t.collectionId.equals(collectionId))
             ..orderBy([
               (t) => OrderingTerm(expression: t.sortIndex),
               (t) => OrderingTerm(expression: t.entryKey),
+              (t) => OrderingTerm(expression: t.mediaType),
             ]))
           .get();
 
   /// 全部合集成员行（一次查询，供渲染层内存分组算组内 sortIndex，替代逐合集
-  /// [getCollectionItems] 的 N+1）。按 collectionId、sortIndex、entryKey 升序，
-  /// 与 [getCollectionItems] 同口径——同一 collectionId 的行连续且组内有序，
-  /// 调用方按 [MediaCollectionItemRow.collectionId] 分组即等价于逐合集查。
+  /// [getCollectionItems] 的 N+1）。按 collectionId、sortIndex、entryKey、mediaType
+  /// 升序，与 [getCollectionItems] 同口径（含末位 mediaType 的全序兜底）——同一
+  /// collectionId 的行连续且组内有序，调用方按
+  /// [MediaCollectionItemRow.collectionId] 分组即等价于逐合集查。
   Future<List<MediaCollectionItemRow>> getAllCollectionItems() =>
       (select(mediaCollectionItems)
             ..orderBy([
               (t) => OrderingTerm(expression: t.collectionId),
               (t) => OrderingTerm(expression: t.sortIndex),
               (t) => OrderingTerm(expression: t.entryKey),
+              (t) => OrderingTerm(expression: t.mediaType),
             ]))
           .get();
 
@@ -3168,8 +3184,9 @@ class HibikiDatabase extends _$HibikiDatabase {
   Future<void> reorderCollectionItems(
           int collectionId, List<CollectionMemberKey> ordered) =>
       transaction(() async {
-        // 事务内取当前全表顺序作槽位基准（[getCollectionItems] 的 sortIndex→entryKey
-        // 口径 = 用户此刻看到的顺序）。
+        // 事务内取当前全表顺序作槽位基准（[getCollectionItems] 的
+        // sortIndex→entryKey→mediaType 全序 = 用户此刻看到的顺序；那三段键就是成员
+        // 身份，无并列，故本次冻结出的致密序确定、不随查询计划变）。
         final List<MediaCollectionItemRow> all =
             await getCollectionItems(collectionId);
         final List<CollectionMemberKey> merged = mergeCollectionOrder(


### PR DESCRIPTION
## 问题

`reorderCollectionItems` 旧契约是「按 `ordered` 下标直写 sortIndex」。但合集详情页**天然只渲染成员子集**——视频详情页按 mediaType 只显示 video，网格详情页按标签过滤；而 `media_collection_items.mediaType` 无 CHECK 约束，一个合集可以混多种种类（「加入合集」弹窗列全表不按种类过滤；合集同步/备份合并按 `(name, collectionType)` 自然键对齐并原样并入对端裸串 mediaType，两端各建同名合集同步一轮即混合）。

于是调用方只要传子集：未点名的成员留着旧 sortIndex，与新写的致密 `0..n-1` **碰撞** → `getCollectionItems` 平手退化按 entryKey 排 → 用户在网格详情页排好的跨种类顺序被打乱，还随同事务 bump 的 `orderUpdatedAt` 以 LWW **赢家**身份推给全部对端。

**不是数据丢失**：重排是纯 UPDATE 循环无 delete，跨端同步走成员并集。是顺序一致性缺陷。

## 为什么上一轮不够

`40e8b2850` 把「保序合并」补在 `media_collection_detail_page` 里 —— 治标。它把不变量交给**每个调用方自觉**，而这条规则已经被复制在两个页面里（且各写各的身份键），下一个新页面照样能再犯。

## 本轮：不变量上移到 DAO

- `reorderCollectionItems` 契约改为「`ordered` 只表达它**点名**的那批成员之间的新相对顺序」，方法自己在同一事务内取全表槽位、保序合并、把 sortIndex 回写成致密 `0..n-1`。**传子集从此是合法用法**，页面漏做合并不再可能造出碰撞；顺带自愈历史遗留的碰撞 sortIndex。
- 合并规则抽成唯一真相源纯函数 `mergeCollectionOrder`（新 `packages/hibiki_core/lib/src/database/collection_order.dart`）：DAO 守落盘不变量、`MediaCollectionGridDetailPage._onReorder` 维护内存展示序，两侧同一份实现不会漂开。
- 身份键统一为 record `CollectionMemberKey`，**废掉网格页的 `'<mediaType>|<entryKey>'` 拼串键**——entryKey 是用户数据，`('video','a|b')` 与 `('video|a','b')` 会拼成同一个串。
- `media_collection_detail_page._persistOrder` 的 30 行保序合并块整块删除。

**不禁止混合种类合集**：网格详情页本就显示全部成员，混合是被支持的形态。「加入合集」弹窗不过滤、同步按自然键对齐是混合**如何产生**的解释，不是要改掉的缺陷；修复方向是让排序在混合下正确，不是加特例阻止混合。

## 测试

- `hibiki/test/database/collection_order_test.dart`（新增 7 例）：纯规则——未点名成员留原槽位 / 绝不挤到表尾 / 全量点名等价直接排序 / 空 subset / 并发移出键丢弃 / 重复键 / 分隔符出现在 entryKey 里也不误判。
- `hibiki/test/database/media_collections_dao_test.dart`（新增 group「子集契约」3 例）：**根因守卫**——只传可见 video 子集时非 video 成员留原槽位且全表致密无碰撞；用 `upsertCollectionItemAt` 种出旧版碰撞现场后一次重排自愈；点名已被并发移出的成员不越界。
- 既有混合种类页面测试 3 例保留（现在由 DAO 兜底而非页面自觉）。
- `flutter analyze --no-pub` 全量零 issue；合集相关定向测试 143 例全绿。

## 真机验证

排序 UI 行为改动请按 BUG-1194 的复现步骤真机复测：混合类型合集 → 网格详情页排好跨类型顺序 → 视频详情页拖拽 → 回网格详情页确认跨类型顺序不变；多设备再同步一轮确认对端顺序保持。

https://claude.ai/code/session_01NxoutfnhjP6xfD2zEcdXS2