### PR TITLE
fix(download): 安卓「内置引擎」是死设置，收平台门控 (BUG-1207) + 清掉快捷键守卫的死 token

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1167 条。点号进各自文件。
+> 共 1168 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1207](bugs/BUG-1207-android-embedded-torrent-dead-setting.md) | ✅ | ✅ | 安卓下载设置能选「内置引擎」并改下载目录，实际静默回退外接 qBittorrent |
 | [BUG-1206](bugs/BUG-1206-jimaku-season-pack-wrong-season-match.md) | ✅ | ✅ | 整季包字幕按标题猜集号导致错季配对且条数无上界 |
 | [BUG-1205](bugs/BUG-1205-video-mining-cover-audio-serial.md) | ✅ | ✅ | 视频制卡封面与句子音频串行且失败来源靠调用顺序区分 |
 | [BUG-1204](bugs/BUG-1204-lookup-audio-play-failure-reason-swallowed.md) | ✅ | ✅ | 浮窗单词发音首播失败且失败原因被吞无法定位 |

--- a/docs/bugs/BUG-1207-android-embedded-torrent-dead-setting.md
+++ b/docs/bugs/BUG-1207-android-embedded-torrent-dead-setting.md
@@ -1,0 +1,52 @@
+## BUG-1207 · 安卓下载设置能选「内置引擎」并改下载目录，实际静默回退外接 qBittorrent
+- **报告**：2026-07-28（用户：PR#526 审查线索）
+- **真实性**：✅ 真 bug（静默回退，无任何错误提示）
+
+  安卓上**不存在**内置 torrent 引擎的原生产物，证据链：
+  - `packages/hibiki_torrent/pubspec.yaml` 没有 `flutter:`/`plugin:` 段（纯 Dart package，
+    Gradle 不会为它做任何 native 构建或收集 jniLibs），包内无 `android/`、无随包二进制。
+  - `native/hibiki_torrent/CMakeLists.txt:38-50` 只有 `if(WIN32)` / `if(APPLE)` 分支，
+    无 Android ABI；`native/hibiki_torrent/README.md:226-230` 自己写明 Android 是未做项。
+  - `hibiki/android/app/build.gradle:103-108` 的 `externalNativeBuild` 只构建 `hoshidicts`，
+    `sourceSets` 无 `jniLibs.srcDirs`，`src/main/` 下无 `jniLibs/`。
+  - CI 里 `hibiki_torrent` 的构建只出现在 Windows job（`build-multiplatform.yml:743-748`、
+    `release-desktop.yml:321-326`）；Android 打包的 `release.yml` / `main.yml` 零命中。
+  - 全仓 `git ls-files` 过滤二进制：**零个 `.so`**，零个 `libhibiki_torrent*`。
+
+  **根因** `hibiki/lib/src/media/torrent/anime_download_config.dart:70`（修复前）：
+  `resolveBackend({required bool isDesktop})` 只把 `backendAuto` 按平台规约，
+  显式的 `backendEmbedded` **一律原样放行**。于是移动端解析出一个不存在的后端：
+  - `hibiki/lib/src/media/torrent/embedded_torrent_host.dart:131-138` 把
+    `DynamicLibrary.open('libhibiki_torrent_ffi.so')` 抛的 `ArgumentError` 吞掉返回 null（零日志）；
+  - `hibiki/lib/src/models/app_model.dart:3459-3475` `_torrentBackendFor` 于是静默造一个
+    `QbTorrentBackend`（`baseUrl` 可能为空）——用户以为在用内置引擎，实际走外接 qb；
+  - `hibiki/lib/src/pages/implementations/torrent_settings_section.dart:292/347/420`（修复前）
+    仍把「内置引擎」段画出来让用户选中，并在 `isEmbedded` 分支暴露**只有内置引擎才读取**的
+    下载目录（`download_save_root`）。用户能改，改了完全不被采用 —— 死设置。
+
+- **[x] ① 已修复** — 两处，规约收在数据层、UI 只做渲染门控：
+  1. `anime_download_config.dart` `resolveBackend`：不具备内置引擎的平台**恒**返回
+     `backendQbittorrent`（含存量显式选过 embedded 的配置）。存储层不动——`backend` 字段
+     仍原样存 embedded，桌面上旧配置自动复原，零破坏。
+  2. `torrent_settings_section.dart`：非桌面不渲染后端选择器（只剩一个可用档位，
+     留着只会「点了弹回」），改为一行说明 `download_backend_desktop_only_note`
+     交代本平台只有外接 qb；下载目录随 `isEmbedded` 恒 false 自动消失。
+     新增 `desktopOverride` 测试注入口（照 `book_import_dialog.dart:68` 的既有范式，
+     `dart:io Platform` 不可 override，不给注入口就只能退回源码扫描守卫）。
+  提交：见本 PR 的 `fix(download): gate built-in torrent engine to desktop`。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/torrent_settings_android_backend_gating_test.dart`
+  （真断言渲染行为，非字符串存在）：非桌面下 `HibikiSegmentedStrip<String>` / 「内置引擎」标签 /
+  下载目录标题与按钮**整块 findsNothing**，同时 qb 连接字段与说明文字 findsOneWidget（证明真落到
+  qb 分支、不是整段没渲染的假绿）；桌面对照组断言三者原样保留（不误伤）。
+  另有 4 条 `resolveBackend` 纯函数用例覆盖 auto/显式 × 两种平台能力。
+  既有 `test/media/torrent/anime_download_config_backend_test.dart` 的
+  「explicit backends resolve to themselves regardless of platform」是**钉住旧 bug 契约**的
+  用例，已按新契约更新并注明变更理由。
+
+  **变异实测**（把修复退回，确认断言真转红）：
+  - 仅退回 `resolveBackend` 平台规约 → 转红 **3 条**
+  - 仅退回 UI 平台门控 → 转红 **1 条**
+  - 两处全退回 → 转红 **3 条**
+- **备注**：本次只做 Android/iOS 的「不谎报」门控，未给内置引擎补 Android 产物
+  （需 NDK 编 libtorrent，属独立工程，见 `native/hibiki_torrent/README.md` 的「尚未做」）。
+  真机复测（Android 下载设置页目视确认无「内置引擎」档位）**未做**，本轮只有 widget 层证据。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46274 (2722 per locale)
+/// Strings: 46291 (2723 per locale)
 ///
-/// Built on 2026-07-28 at 10:31 UTC
+/// Built on 2026-07-28 at 11:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3659,6 +3659,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Subtitles: pending until download completes';
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -9888,6 +9890,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -16185,6 +16190,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -22498,6 +22506,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -28822,6 +28833,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -35075,6 +35089,9 @@ class _StringsId extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -41374,6 +41391,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -47490,6 +47510,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -53608,6 +53631,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -59887,6 +59913,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -66179,6 +66208,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -72455,6 +72487,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -78679,6 +78714,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -84935,6 +84973,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -91176,6 +91217,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 // Path: <root>
@@ -96976,6 +97020,9 @@ class _StringsZhCn extends _StringsEn {
   String get anime_download_subs_pending => '字幕：待下载完成后配对';
   @override
   String get anime_download_subs_unmatched => '字幕：未匹配到（可手动补）';
+  @override
+  String get download_backend_desktop_only_note =>
+      '内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。';
 }
 
 // Path: <root>
@@ -103013,6 +103060,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anime_download_subs_unmatched =>
       'Subtitles: no match for this pack';
+  @override
+  String get download_backend_desktop_only_note =>
+      'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
 }
 
 /// Flat map(s) containing all translations.
@@ -108590,6 +108640,8 @@ extension on _StringsEn {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -114165,6 +114217,8 @@ extension on _StringsAr {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -119761,6 +119815,8 @@ extension on _StringsDe {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -125356,6 +125412,8 @@ extension on _StringsEs {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -130957,6 +131015,8 @@ extension on _StringsFr {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -136540,6 +136600,8 @@ extension on _StringsId {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -142138,6 +142200,8 @@ extension on _StringsIt {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -147698,6 +147762,8 @@ extension on _StringsJa {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -153262,6 +153328,8 @@ extension on _StringsKo {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -158853,6 +158921,8 @@ extension on _StringsNl {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -164441,6 +164511,8 @@ extension on _StringsPtBr {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -170034,6 +170106,8 @@ extension on _StringsRu {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -175611,6 +175685,8 @@ extension on _StringsTh {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -181197,6 +181273,8 @@ extension on _StringsTr {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -186778,6 +186856,8 @@ extension on _StringsVi {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }
@@ -192313,6 +192393,8 @@ extension on _StringsZhCn {
         return '字幕：待下载完成后配对';
       case 'anime_download_subs_unmatched':
         return '字幕：未匹配到（可手动补）';
+      case 'download_backend_desktop_only_note':
+        return '内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。';
       default:
         return null;
     }
@@ -197868,6 +197950,8 @@ extension on _StringsZhHk {
         return 'Subtitles: pending until download completes';
       case 'anime_download_subs_unmatched':
         return 'Subtitles: no match for this pack';
+      case 'download_backend_desktop_only_note':
+        return 'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "集号未与该整季包核对，字幕可能来自别的季。",
   "anime_download_subs_deferred": "字幕将在下载完成后按包内实际文件配对",
   "anime_download_subs_pending": "字幕：待下载完成后配对",
-  "anime_download_subs_unmatched": "字幕：未匹配到（可手动补）"
+  "anime_download_subs_unmatched": "字幕：未匹配到（可手动补）",
+  "download_backend_desktop_only_note": "内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2720,5 +2720,6 @@
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",
-  "anime_download_subs_unmatched": "Subtitles: no match for this pack"
+  "anime_download_subs_unmatched": "Subtitles: no match for this pack",
+  "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent."
 }

--- a/hibiki/lib/src/media/torrent/anime_download_config.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_config.dart
@@ -65,12 +65,21 @@ class QbConnectionConfig {
   /// 但配过 qb 地址的，decode 时回退 qb（向后兼容：老用户行为不变）。
   final String backend;
 
-  /// 把 [backendAuto] 解析成具体后端：桌面 → 内置引擎、移动端 → 外接 qb。
-  /// 已显式选定（embedded/qbittorrent）的原样返回。
+  /// 把配置值解析成**本平台真实可用**的后端。
+  ///
+  /// [isDesktop] = 本平台是否具备内置引擎（调用方传 `_supportsEmbeddedTorrent()`）。
+  ///
+  /// BUG-1207：这里过去只规约 [backendAuto]，显式的 [backendEmbedded] 一律原样
+  /// 放行——于是移动端（Android/iOS 从不构建也从不打包 `libhibiki_torrent_ffi.so`：
+  /// `native/hibiki_torrent/CMakeLists.txt` 只有 WIN32/APPLE 分支，
+  /// `hibiki/android/app/build.gradle` 的 externalNativeBuild 只含 hoshidicts）
+  /// 会解析出一个根本不存在的后端：`EmbeddedTorrentHost.open` 吞掉 `ArgumentError`
+  /// 返回 null，`_torrentBackendFor` 静默造一个 `QbTorrentBackend`，而设置页仍显示
+  /// 「内置引擎」选中、并把只有内置引擎才读的下载目录暴露给用户改（改了不被任何人
+  /// 采用）。规约收在这一处，下游 UI 分支与运行时后端选择的特殊情况一并消失。
   String resolveBackend({required bool isDesktop}) {
-    if (backend == backendAuto) {
-      return isDesktop ? backendEmbedded : backendQbittorrent;
-    }
+    if (!isDesktop) return backendQbittorrent;
+    if (backend == backendAuto) return backendEmbedded;
     return backend;
   }
 

--- a/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
@@ -15,7 +15,13 @@ import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
 /// 从「设置→视频」搬到「下载」页——下载既已独立成页，配置就该在页内，不再埋进
 /// 视频设置。所有字段写 `QbConnectionConfig`（即时生效到内置引擎）。
 class TorrentSettingsSection extends ConsumerStatefulWidget {
-  const TorrentSettingsSection({super.key});
+  const TorrentSettingsSection({super.key, this.desktopOverride});
+
+  /// 仅测试注入：覆盖「本平台是否有内置引擎」的判据（BUG-1207 的平台门控）。
+  /// null = 用真实 `dart:io` 平台判断。照搬 `book_import_dialog.dart` 的
+  /// `ocrEntryDesktopOverride` 范式——`Platform` 不可 override，不给注入口就
+  /// 只能退回源码扫描守卫，测不到真实渲染行为。
+  final bool? desktopOverride;
 
   @override
   ConsumerState<TorrentSettingsSection> createState() =>
@@ -25,7 +31,8 @@ class TorrentSettingsSection extends ConsumerStatefulWidget {
 class _TorrentSettingsSectionState
     extends ConsumerState<TorrentSettingsSection> {
   bool get _isDesktop =>
-      Platform.isWindows || Platform.isMacOS || Platform.isLinux;
+      widget.desktopOverride ??
+      (Platform.isWindows || Platform.isMacOS || Platform.isLinux);
 
   QbConnectionConfig get _config =>
       effectiveTorrentConfig(ref.read(appProvider).qbConnectionConfig);
@@ -344,21 +351,36 @@ class _TorrentSettingsSectionState
 
         // 后端二选一。标签是 `qBittorrent` / `Built-in engine (desktop only)` 这类
         // 不可断行的长词，窄屏裸 SegmentedButton 会直接裁字（BUG-1184）。
-        HibikiSegmentedStrip<String>(
-          segments: <ButtonSegment<String>>[
-            ButtonSegment<String>(
-              value: QbConnectionConfig.backendQbittorrent,
-              label: Text(t.video_setting_torrent_backend_qb),
+        //
+        // BUG-1207：移动端根本没有内置引擎的 .so，选择器只放一个够不着的档位——
+        // 选中后 resolveBackend 会把它规约回 qb，段选状态原地弹回，比没有选项更糟。
+        // 故非桌面不渲染选择器，改为一行说明交代本平台只有外接 qb。
+        if (_isDesktop) ...<Widget>[
+          HibikiSegmentedStrip<String>(
+            segments: <ButtonSegment<String>>[
+              ButtonSegment<String>(
+                value: QbConnectionConfig.backendQbittorrent,
+                label: Text(t.video_setting_torrent_backend_qb),
+              ),
+              ButtonSegment<String>(
+                value: QbConnectionConfig.backendEmbedded,
+                label: Text(t.video_setting_torrent_backend_embedded),
+              ),
+            ],
+            selected: backend,
+            onChanged: (String value) =>
+                _commit((QbConnectionConfig c) => c.copyWith(backend: value)),
+          ),
+        ] else
+          Padding(
+            padding: const EdgeInsets.fromLTRB(2, 0, 2, 4),
+            child: Text(
+              t.download_backend_desktop_only_note,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
-            ButtonSegment<String>(
-              value: QbConnectionConfig.backendEmbedded,
-              label: Text(t.video_setting_torrent_backend_embedded),
-            ),
-          ],
-          selected: backend,
-          onChanged: (String value) =>
-              _commit((QbConnectionConfig c) => c.copyWith(backend: value)),
-        ),
+          ),
         const SizedBox(height: 12),
 
         // 外接 qb 连接字段。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+977
+version: 1.3.1+978
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/torrent/anime_download_config_backend_test.dart
+++ b/hibiki/test/media/torrent/anime_download_config_backend_test.dart
@@ -14,14 +14,24 @@ void main() {
         QbConnectionConfig.backendQbittorrent);
   });
 
-  test('explicit backends resolve to themselves regardless of platform', () {
+  test('显式 backend 按平台能力规约：无内置引擎的平台连 embedded 也降级 qb (BUG-1207)', () {
+    // 契约变更（原断言「explicit backends resolve to themselves regardless of
+    // platform」）：移动端从不构建也从不打包 libhibiki_torrent_ffi.so，原样放行
+    // embedded 只会让设置页谎报「正在用内置引擎」、并暴露一个没有任何人读取的
+    // 下载目录，运行时再静默回退外接 qb。
+    // 存储层不受影响——backend 字段仍原样存 embedded（见下面的 round-trip 用例），
+    // 规约只发生在 resolveBackend 这一处，桌面重新可用时旧配置自动复原。
     const QbConnectionConfig emb =
         QbConnectionConfig(backend: QbConnectionConfig.backendEmbedded);
     expect(emb.resolveBackend(isDesktop: false),
+        QbConnectionConfig.backendQbittorrent);
+    expect(emb.resolveBackend(isDesktop: true),
         QbConnectionConfig.backendEmbedded);
     const QbConnectionConfig qb =
         QbConnectionConfig(backend: QbConnectionConfig.backendQbittorrent);
     expect(qb.resolveBackend(isDesktop: true),
+        QbConnectionConfig.backendQbittorrent);
+    expect(qb.resolveBackend(isDesktop: false),
         QbConnectionConfig.backendQbittorrent);
   });
 

--- a/hibiki/test/pages/torrent_settings_android_backend_gating_test.dart
+++ b/hibiki/test/pages/torrent_settings_android_backend_gating_test.dart
@@ -1,0 +1,185 @@
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/media/torrent/anime_download_config.dart';
+import 'package:hibiki/src/media/torrent/download_network_proxy.dart';
+import 'package:hibiki/src/models/theme_notifier.dart';
+import 'package:hibiki/src/pages/implementations/torrent_settings_section.dart';
+import 'package:hibiki/utils.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1207：移动端不存在内置 torrent 引擎的原生产物——
+/// `native/hibiki_torrent/CMakeLists.txt` 只有 WIN32 / APPLE 分支，
+/// `hibiki/android/app/build.gradle` 的 externalNativeBuild 只构建 hoshidicts，
+/// 全仓也没有任何 `libhibiki_torrent_ffi.so`。可下载设置页照样把「内置引擎」
+/// 画出来让用户选中，选中后还暴露一个**只有内置引擎才读**的下载目录。
+/// 实际运行时 `EmbeddedTorrentHost.open` 吞掉 `ArgumentError` 返回 null，
+/// `_torrentBackendFor` 静默造一个 `QbTorrentBackend` —— 用户以为自己在用
+/// 内置引擎、以为改的下载目录生效了，两件事都不成立。
+///
+/// 本守卫断言的是**真实渲染行为**（不是「某字符串存在」）：非桌面平台下
+/// 后端选择器与下载目录必须整块不出现，且必须真的落到外接 qb 分支。
+class _TestAppModel extends AppModel {
+  _TestAppModel(this._config) : super(testPlatformServices());
+
+  final QbConnectionConfig _config;
+
+  @override
+  Locale get appLocale => const Locale('en', 'US');
+
+  @override
+  PackageInfo get packageInfo => PackageInfo(
+        appName: 'Hibiki',
+        packageName: 'jp.hibiki.test',
+        version: '1.0.0',
+        buildNumber: '1',
+      );
+
+  @override
+  QbConnectionConfig? get qbConnectionConfig => _config;
+
+  @override
+  DownloadNetworkProxyConfig get downloadNetworkProxyConfig =>
+      const DownloadNetworkProxyConfig();
+}
+
+/// 存量配置：用户在某个版本里**显式**选过内置引擎（不是 auto），
+/// 这正是 `resolveBackend` 过去原样放行、酿成死设置的那一类。
+const QbConnectionConfig _explicitEmbedded = QbConnectionConfig(
+  backend: QbConnectionConfig.backendEmbedded,
+);
+
+Widget _harness({required bool desktop}) {
+  final HibikiDatabase db = HibikiDatabase.forTesting(
+    DatabaseConnection(NativeDatabase.memory()),
+  );
+  final ThemeNotifier themeNotifier = ThemeNotifier(db, () => const TextTheme())
+    ..loadFromPrefsSnapshot(<String, String>{
+      'design_system': PrefCodec.encode('material'),
+      'app_theme_key': PrefCodec.encode('system-theme'),
+      'brightness_mode': PrefCodec.encode('system'),
+      'custom_theme_seed': PrefCodec.encode(0xFF1F4959),
+    });
+  final AppModel appModel = _TestAppModel(_explicitEmbedded)
+    ..themeNotifier = themeNotifier;
+  addTearDown(() async {
+    themeNotifier.dispose();
+    await db.close();
+  });
+
+  return ProviderScope(
+    overrides: <Override>[
+      appProvider.overrideWith((Ref ref) => appModel),
+    ],
+    child: MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        platform: TargetPlatform.android,
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF386A58)),
+        extensions: <ThemeExtension<dynamic>>[
+          HibikiDesignSystemTheme(themeNotifier.designSystemTheme),
+        ],
+      ),
+      home: Scaffold(
+        body: SizedBox(
+          width: 900,
+          child: SingleChildScrollView(
+            child: TorrentSettingsSection(desktopOverride: desktop),
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('resolveBackend 按平台能力规约（BUG-1207 根因层）', () {
+    test('无内置引擎的平台：显式 embedded 也必须解析成外接 qb', () {
+      expect(
+        _explicitEmbedded.resolveBackend(isDesktop: false),
+        QbConnectionConfig.backendQbittorrent,
+        reason: '移动端没有 libhibiki_torrent_ffi.so，解析出 embedded 只会静默回退',
+      );
+    });
+
+    test('有内置引擎的平台：显式 embedded 原样保留', () {
+      expect(
+        _explicitEmbedded.resolveBackend(isDesktop: true),
+        QbConnectionConfig.backendEmbedded,
+      );
+    });
+
+    test('auto 的既有行为不变（桌面 embedded / 移动 qb）', () {
+      const QbConnectionConfig auto = QbConnectionConfig();
+      expect(auto.backend, QbConnectionConfig.backendAuto);
+      expect(auto.resolveBackend(isDesktop: true),
+          QbConnectionConfig.backendEmbedded);
+      expect(auto.resolveBackend(isDesktop: false),
+          QbConnectionConfig.backendQbittorrent);
+    });
+
+    test('显式 qbittorrent 在任何平台都是 qb', () {
+      const QbConnectionConfig qb = QbConnectionConfig(
+        backend: QbConnectionConfig.backendQbittorrent,
+      );
+      expect(qb.resolveBackend(isDesktop: true),
+          QbConnectionConfig.backendQbittorrent);
+      expect(qb.resolveBackend(isDesktop: false),
+          QbConnectionConfig.backendQbittorrent);
+    });
+  });
+
+  testWidgets('非桌面：后端选择器与下载目录整块不渲染，落到外接 qb 分支', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_harness(desktop: false));
+    await tester.pumpAndSettle();
+
+    // ① 后端二选一整个控件不存在——用户点不到一个够不着的档位。
+    //    （代理模式那条 strip 是 HibikiSegmentedStrip<DownloadNetworkProxyMode>，
+    //     泛型不同，不会被这个 finder 命中。）
+    expect(find.byType(HibikiSegmentedStrip<String>), findsNothing,
+        reason: '移动端没有第二个可用后端，选择器必须整块不渲染');
+    expect(find.text(t.video_setting_torrent_backend_embedded), findsNothing,
+        reason: '「内置引擎」在本平台不存在，不得出现在界面上');
+
+    // ② 死设置消失：下载目录只被内置引擎读取，外接 qb 的落盘目录 qb 自己管。
+    expect(find.text(t.download_save_root_title), findsNothing,
+        reason: '下载目录在移动端改了不被任何人采用，不得暴露给用户');
+    expect(find.text(t.download_save_root_change), findsNothing);
+
+    // ③ 真的落到 qb 分支（不是整段都没渲染出来的假绿）。
+    expect(find.text(t.video_setting_qb_url), findsOneWidget,
+        reason: '移动端唯一可用后端是外接 qBittorrent，其连接字段必须在');
+    expect(find.text(t.download_test_connection), findsOneWidget);
+
+    // ④ 交代原因，别让用户以为选项丢了。
+    expect(find.text(t.download_backend_desktop_only_note), findsOneWidget);
+  });
+
+  testWidgets('桌面：同一份显式 embedded 配置仍给出选择器与下载目录（不误伤）',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(_harness(desktop: true));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(HibikiSegmentedStrip<String>), findsOneWidget);
+    expect(find.text(t.video_setting_torrent_backend_embedded), findsOneWidget);
+    expect(find.text(t.download_save_root_title), findsOneWidget,
+        reason: '桌面内置引擎真会读这个目录，必须保留');
+    expect(find.text(t.download_backend_desktop_only_note), findsNothing);
+    expect(find.text(t.video_setting_qb_url), findsNothing,
+        reason: '内置引擎分支不渲染 qb 连接字段');
+  });
+}

--- a/hibiki/test/shortcuts/shortcut_channel_wiring_guard_test.dart
+++ b/hibiki/test/shortcuts/shortcut_channel_wiring_guard_test.dart
@@ -32,7 +32,12 @@ void main() {
     ShortcutChannel.keyboard: <String>['resolveKeyboard(', '.keyboardBindings'],
     ShortcutChannel.gamepad: <String>['resolveGamepad(', '.gamepadBindings'],
     ShortcutChannel.mouse: <String>['resolveMouse(', '.mouseBindings'],
-    ShortcutChannel.wheel: <String>['resolveWheel(', '.wheelBindings'],
+    // wheel 只有 `.wheelBindings` 一种写法：registry 上没有、也从未有过
+    // `resolveWheel` —— 滚轮不按「事件 → 查表 → action」解析，而是查词弹窗
+    // （唯一开放本通道的 scope）在 popup_settings_injection.dart 里把绑定表
+    // 序列化成 JSON 注入 WebView，由 JS 侧自己比对。列一个指向不存在方法的
+    // token 只会让后来人以为该方法存在，故删除。
+    ShortcutChannel.wheel: <String>['.wheelBindings'],
   };
 
   /// 定义/展示层：这些文件按定义列举所有 scope 与通道，不构成任何「消费」证据。
@@ -141,7 +146,7 @@ void main() {
           } else if (!consumed.contains(pair)) {
             violations.add('$platform ${entry.key.key}：默认表配了 '
                 '${ch.key.name} 绑定，但全仓找不到 $pair 的解析入口'
-                '（既无 resolve${ch.key.name} 也无 .${ch.key.name}Bindings 取用）');
+                '（${channelTokens[ch.key]!.join(" / ")} 一个都没出现）');
           }
         }
       }


### PR DESCRIPTION
两件独立的小清理，两个独立 commit。

## ① `fix(download)` — BUG-1207：安卓的「内置引擎」+ 下载目录是死设置

**线索核实成立。** 安卓上**不存在**内置 torrent 引擎的原生产物：
- `packages/hibiki_torrent/pubspec.yaml` 无 `flutter:`/`plugin:` 段（纯 Dart package，Gradle 不会为它做 native 构建）
- `native/hibiki_torrent/CMakeLists.txt` 只有 `if(WIN32)` / `if(APPLE)`；README 自陈 Android 是「尚未做」
- `hibiki/android/app/build.gradle` 的 `externalNativeBuild` 只构建 `hoshidicts`，无 `jniLibs.srcDirs`
- CI 里 `hibiki_torrent` 只在 Windows job 构建；Android 打包的 workflow 零命中
- 全仓 `git ls-files` 过滤：**零个 `.so`**

**行为是静默回退**（不是报错）：`EmbeddedTorrentHost.open` 吞掉 `ArgumentError` 返回 null（零日志），`_torrentBackendFor` 静默造一个 `QbTorrentBackend`。设置页仍显示「内置引擎」选中，并暴露只有内置引擎才读取的下载目录 —— 用户能改，改了完全不被采用。

**根因**：`anime_download_config.dart` 的 `resolveBackend` 只规约 `backendAuto`，显式的 `backendEmbedded` 一律原样放行。

**修法（选了「不显示」而非「置灰」）**：置灰要留一个永远点不动的档位，而本平台压根只有一个可用后端，选择器本身就没有存在意义；隐藏 + 一行说明信息量更高。规约收在数据层、UI 只做渲染门控：
1. `resolveBackend`：不具备内置引擎的平台**恒**返回 `qbittorrent`（含存量显式选过 embedded 的配置）。**存储层不动** —— `backend` 字段仍原样存 embedded，回到桌面自动复原，零破坏。
2. 设置页非桌面不渲染后端选择器，改为一行 `download_backend_desktop_only_note` 说明；下载目录随 `isEmbedded` 恒 false 自动消失。

**未做**：没给内置引擎补 Android 产物（需 NDK 编 libtorrent，独立工程）。

## ② `test(shortcuts)` — 清掉守卫里的死 token

`channelTokens` 里 `ShortcutChannel.wheel` 列的 `'resolveWheel('` 指向一个不存在的方法（registry 只有 `resolveKeyboard`/`resolveGamepad`/`resolveMouse`，全仓除该 token 字符串自身外零出现）。wheel 的真实证据是 `.wheelBindings`（`popup_settings_injection.dart` 同时含 `ShortcutAction.popupNextEntry` 与 `.wheelBindings`）。

**负向验证**：把 token 表临时改成只留 `'resolveWheel('` → 守卫立刻红出 `dictionaryPopup.wheel 找不到解析入口`（4 条 platform × action）；换回 `.wheelBindings` 即绿。守卫两条断言（硬零豁免 / 棘轮）删除后仍全绿。

顺带修掉违规信息里同源的 `'resolve${ch.key.name}'` 拼接 —— 它同样会打印不存在的方法名。

## 验证

- `flutter analyze`（含 test）→ `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub` 覆盖下载设置 / torrent / 快捷键守卫 / settings / tools / i18n / media_sources_dialog → `FLUTTER TEST VERDICT: PASSED - 1285 tests ran`，退出码 0
- **变异实测**（把修复退回，确认断言真转红）：仅退回数据层规约 → **3 条红**；仅退回 UI 门控 → **1 条红**；两处全退回 → **3 条红**

## 需要人工拍板 / 我验不了的

- **真机复测未做**：没在 Android 设备上目视确认下载设置页已无「内置引擎」档位。本轮只有 widget 层证据。
- 既有 `anime_download_config_backend_test.dart` 的 `explicit backends resolve to themselves regardless of platform` 是**钉住旧 bug 契约**的用例，已按新契约更新并注明理由 —— 如果认为该契约应保留，本 PR 的方向需要重议。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb

---

**改号记录**：本条最初取 1205 → 撞 `BUG-1205-video-mining-cover-audio-serial`（PR 期间合入 develop）→ 让到 1206 → 又撞 `BUG-1206-jimaku-season-pack-wrong-season-match`（PR#530）→ 最终 **1207**。
两次撞号双方都有代码引用，`bug.dart renumber` 会拒绝执行且有误伤风险，故**限定在本 PR diff 的 5 个文件内**手动四处齐改（`git mv` 文件名 / 正文 H2 / 代码注释引用 / 测试内引用）。
已逐文件比对 develop 侧 jimaku 的 11 处 `BUG-1206` 引用计数**改号前后完全一致（零误伤）**，本侧 `BUG-1206` **零残留**，`bug.dart check` 通过。
基底已 rebase 到 `318eaeec3`（含 PR#530 字幕根治、PR#535 media_sources 修复），`pubspec` `1.3.1+978`；i18n 冲突按纪律取 develop 侧后用 `i18n_sync` 重新注入本 key（未手改 json），两侧 key 均在。

