### PR TITLE
fix(permissions): 选文件夹不再顺带申请相机权限 (BUG-1207)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1169 条。点号进各自文件。
+> 共 1170 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1209](bugs/BUG-1209-folder-picker-requests-camera-permission.md) | ✅ | ✅ | 安卓选文件夹时顺带弹相机权限申请 |
 | [BUG-1208](bugs/BUG-1208-ps51-getrelativepath-build-dist.md) | ✅ | ✅ | helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩 |
 | [BUG-1207](bugs/BUG-1207-android-embedded-torrent-dead-setting.md) | ✅ | ✅ | 安卓下载设置能选「内置引擎」并改下载目录，实际静默回退外接 qBittorrent |
 | [BUG-1206](bugs/BUG-1206-jimaku-season-pack-wrong-season-match.md) | ✅ | ✅ | 整季包字幕按标题猜集号导致错季配对且条数无上界 |

--- a/docs/bugs/BUG-1205-folder-picker-requests-camera-permission.md
+++ b/docs/bugs/BUG-1205-folder-picker-requests-camera-permission.md
@@ -27,7 +27,7 @@
   拆权限——该函数只申请存储权限，早退门只看存储；相机归真正需要相机的入口自己负责
   （`camera_enhancement.dart` 走系统拍照 intent，manifest 未声明 CAMERA，本就不需要运行时
   权限）。`PlatformPermissionService` 的 `hasCameraPermission` / `requestCameraPermission`
-  能力方法保留未删（属权限层抽象，删除是更大范围的改动，另议）。commit: <fix-sha>
+  能力方法保留未删（属权限层抽象，删除是更大范围的改动，另议）。commit: 5958414f7
 - **[x] ② 已加自动化测试** — `hibiki/test/models/app_model_storage_permission_test.dart`
   （3 条行为测试，非源码扫描）：用记录型 `PlatformPermissionService` 记下**真实生产代码**
   对权限层的每一次调用，断言 ①存储未授权时调用序列恰为 `has:storage → request:storage`、

--- a/docs/bugs/BUG-1205-folder-picker-requests-camera-permission.md
+++ b/docs/bugs/BUG-1205-folder-picker-requests-camera-permission.md
@@ -1,0 +1,50 @@
+## BUG-1205 · 安卓选文件夹时顺带弹相机权限申请
+- **报告**：2026-07-28（用户：PR#526 审查线索）
+- **真实性**：⚠️ 部分属实（代码属实，安卓可见症状未复现）
+  - **代码属实**：`hibiki/lib/src/models/app_model.dart:3951-3966`（修复前）的
+    `requestExternalStoragePermissions()` 早退门是
+    `hasExternalStoragePermission() && hasCameraPermission()`，函数体里还先调
+    `requestCameraPermission()` 再调 `requestExternalStoragePermission()`。它的全部
+    3 个调用点都在 `hibiki/lib/src/media/import/real_path_directory_picker.dart:37,86,153`
+    （选扫描根 / 选文件 / 改下载目录），没有一个需要相机。
+  - **相机零消费方**：全仓 `hasCameraPermission` / `requestCameraPermission` 的调用点
+    只有这一处（其余全是接口定义与各平台实现）。唯一真正用相机的
+    `hibiki/lib/src/creator/enhancements/camera_enhancement.dart:46` 走
+    `ImagePicker(ImageSource.camera)` 的系统拍照 intent，从不调这两个方法。
+  - **未复现的部分**：`hibiki/android/app/src/main/AndroidManifest.xml` 未声明
+    `android.permission.CAMERA`，合并后的 release manifest 里也没有（核过
+    `build/app/intermediates/merged_manifest/release/.../AndroidManifest.xml`，且无任何插件
+    贡献该权限）。permission_handler_android 10.2.1 对未在 manifest 声明的权限直接判
+    denied、**不调 `ActivityCompat.requestPermissions`**
+    （`PermissionUtils.java:106-108` + `PermissionManager.java:239-256`），所以当前安卓
+    包上**弹不出相机权限框**，`Permission.camera.isGranted` 恒 false。
+  - **恒 false 带来的真实副作用**：早退门里的 `&& hasCameraPermission()` 在安卓上恒不
+    成立 → 存储已授权时也永远走不进早退分支，每次选文件夹都要重跑一遍申请流程
+    （首次安装期还会重复弹 `storage_permissions` toast）。
+  - iOS 侧 `hasExternalStoragePermission()` 恒 true、`hasCameraPermission()` 是真状态，
+    一旦哪天有非安卓调用点接进来就会弹真·相机框；这条隐患随本次修复一并消除。
+- **[x] ① 已修复** — `hibiki/lib/src/models/app_model.dart:3968-3997`：按调用点实际需要
+  拆权限——该函数只申请存储权限，早退门只看存储；相机归真正需要相机的入口自己负责
+  （`camera_enhancement.dart` 走系统拍照 intent，manifest 未声明 CAMERA，本就不需要运行时
+  权限）。`PlatformPermissionService` 的 `hasCameraPermission` / `requestCameraPermission`
+  能力方法保留未删（属权限层抽象，删除是更大范围的改动，另议）。commit: <fix-sha>
+- **[x] ② 已加自动化测试** — `hibiki/test/models/app_model_storage_permission_test.dart`
+  （3 条行为测试，非源码扫描）：用记录型 `PlatformPermissionService` 记下**真实生产代码**
+  对权限层的每一次调用，断言 ①存储未授权时调用序列恰为 `has:storage → request:storage`、
+  ②存储已授权时恰为 `has:storage`（早退，相机未授权也不影响）、③走真实用户入口
+  `pickRealDirectoryPath()`（安卓分支 + mock SAF channel）全程零相机调用。
+  变异实测：把修复退回旧实现后 3 条全部转红。
+- **[ ] ③ 真机复测（未做，必须补）** — 单测只能证明「代码不再向权限层请求相机」，
+  证明不了用户在真机上看到什么。需在安卓真机/模拟器走「设置 → 添加本地扫描根」与
+  「修改下载目录」，确认只出现存储/全文件访问授权、不出现相机弹框，且授权后扫描能出内容。
+- **备注**：
+  - 修复期间发现**另一个独立缺陷（未在本 PR 修）**：`AndroidPermissionService`
+    `hibiki/lib/src/platform/android/android_permission_service.dart:6-7` 的
+    `hasExternalStoragePermission()` 只看 `Permission.manageExternalStorage.isGranted`，
+    而 `MANAGE_EXTERNAL_STORAGE` 是 Android 11(API 30) 才引入的，permission_handler 在
+    API < 30 上恒返回 RESTRICTED（`PermissionUtils.java:245-250`、
+    `PermissionManager.java:347-352`）→ **Android 7~10（API 24-29）上该方法恒 false**，
+    `pickRealDirectoryPath()` 因此恒走 `folder_picker_permission_required` 分支并返回
+    null，用户加不了扫描根。申请侧 `requestExternalStoragePermission()` 已有
+    `Permission.storage` 回退、是好的，缺的是查询侧的 SDK 分级。修它需要真机验证
+    Android 7~10 路径，故单独立项。

--- a/docs/bugs/BUG-1209-folder-picker-requests-camera-permission.md
+++ b/docs/bugs/BUG-1209-folder-picker-requests-camera-permission.md
@@ -1,4 +1,4 @@
-## BUG-1205 · 安卓选文件夹时顺带弹相机权限申请
+## BUG-1209 · 安卓选文件夹时顺带弹相机权限申请
 - **报告**：2026-07-28（用户：PR#526 审查线索）
 - **真实性**：⚠️ 部分属实（代码属实，安卓可见症状未复现）
   - **代码属实**：`hibiki/lib/src/models/app_model.dart:3951-3966`（修复前）的
@@ -27,7 +27,7 @@
   拆权限——该函数只申请存储权限，早退门只看存储；相机归真正需要相机的入口自己负责
   （`camera_enhancement.dart` 走系统拍照 intent，manifest 未声明 CAMERA，本就不需要运行时
   权限）。`PlatformPermissionService` 的 `hasCameraPermission` / `requestCameraPermission`
-  能力方法保留未删（属权限层抽象，删除是更大范围的改动，另议）。commit: 5958414f7
+  能力方法保留未删（属权限层抽象，删除是更大范围的改动，另议）。commit: 1e19e32f4
 - **[x] ② 已加自动化测试** — `hibiki/test/models/app_model_storage_permission_test.dart`
   （3 条行为测试，非源码扫描）：用记录型 `PlatformPermissionService` 记下**真实生产代码**
   对权限层的每一次调用，断言 ①存储未授权时调用序列恰为 `has:storage → request:storage`、

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -3974,7 +3974,7 @@ class AppModel with ChangeNotifier {
   /// Requests for full external storage permissions. Required to handle video
   /// files and their subtitle files in the same directory.
   ///
-  /// **只申请存储权限，不碰相机**（BUG-1205）。本函数的全部调用点都是「选扫描根 /
+  /// **只申请存储权限，不碰相机**（BUG-1209）。本函数的全部调用点都是「选扫描根 /
   /// 选文件 / 改下载目录」（`media/import/real_path_directory_picker.dart`），它们只需要
   /// 读盘。此前这里顺带 `requestCameraPermission()`：用户理解不了选个文件夹为什么要给
   /// 相机，合理反应是拒绝，而在同一串权限流程里拒绝很可能把本该给的存储权限一起否掉

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -3973,9 +3973,23 @@ class AppModel with ChangeNotifier {
 
   /// Requests for full external storage permissions. Required to handle video
   /// files and their subtitle files in the same directory.
+  ///
+  /// **只申请存储权限，不碰相机**（BUG-1205）。本函数的全部调用点都是「选扫描根 /
+  /// 选文件 / 改下载目录」（`media/import/real_path_directory_picker.dart`），它们只需要
+  /// 读盘。此前这里顺带 `requestCameraPermission()`：用户理解不了选个文件夹为什么要给
+  /// 相机，合理反应是拒绝，而在同一串权限流程里拒绝很可能把本该给的存储权限一起否掉
+  /// ——于是「加了扫描根却扫不出东西」。
+  ///
+  /// 相机是另一件事，归真正需要相机的入口自己申请：当前唯一的相机消费方
+  /// `creator/enhancements/camera_enhancement.dart` 走 image_picker 的 `ImageSource.camera`
+  /// 系统拍照 intent，而 `AndroidManifest.xml` 并未声明 `android.permission.CAMERA`，
+  /// 该 intent 本就不需要运行时权限，故它从来没有、也不需要调这里。
+  ///
+  /// 早退门同样只看存储：旧版的 `&& hasCameraPermission()` 在安卓上恒为 false
+  /// （CAMERA 未在 manifest 声明 → permission_handler 直接判 denied），使得存储已授权时
+  /// 也永远走不进早退分支。
   Future<void> requestExternalStoragePermissions() async {
-    if (await platformServices.permission.hasExternalStoragePermission() &&
-        await platformServices.permission.hasCameraPermission()) {
+    if (await platformServices.permission.hasExternalStoragePermission()) {
       return;
     }
     if (isFirstTimeSetup) {
@@ -3986,7 +4000,6 @@ class AppModel with ChangeNotifier {
       );
     }
 
-    await platformServices.permission.requestCameraPermission();
     await platformServices.permission.requestExternalStoragePermission();
   }
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+980
+version: 1.3.1+981
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/models/app_model_storage_permission_test.dart
+++ b/hibiki/test/models/app_model_storage_permission_test.dart
@@ -1,0 +1,194 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/utils/misc/channel_constants.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/fake_platform_services.dart';
+
+/// BUG-1205：选文件夹 / 选文件 / 改下载目录时不得申请相机权限。
+///
+/// `AppModel.requestExternalStoragePermissions()` 曾顺带 `requestCameraPermission()`，
+/// 而它的调用点全在 `media/import/real_path_directory_picker.dart`（选扫描根 / 选文件 /
+/// 改目录），只需要读盘。用户在选文件夹时被问相机会拒绝，同一串权限流程里的拒绝很可能
+/// 连本该给的存储权限一起否掉。
+///
+/// 这里是行为测试：用记录型 `PlatformPermissionService` 记下**真实生产代码**对权限层的
+/// 每一次调用，断言相机相关调用为零。
+/// 注意：单测只能证明「代码不再向权限层请求相机」，**证明不了真机上系统弹框长什么样**
+/// ——授权弹框行为必须真机复测。
+class _RecordingPermissionService extends FakePermissionService {
+  /// 生产代码对权限层的调用序列，形如 `has:storage` / `request:camera`。
+  final List<String> calls = <String>[];
+
+  List<String> get cameraCalls =>
+      calls.where((String call) => call.endsWith(':camera')).toList();
+
+  @override
+  Future<bool> hasExternalStoragePermission() {
+    calls.add('has:storage');
+    return super.hasExternalStoragePermission();
+  }
+
+  @override
+  Future<bool> requestExternalStoragePermission() {
+    calls.add('request:storage');
+    return super.requestExternalStoragePermission();
+  }
+
+  @override
+  Future<bool> hasCameraPermission() {
+    calls.add('has:camera');
+    return super.hasCameraPermission();
+  }
+
+  @override
+  Future<bool> requestCameraPermission() {
+    calls.add('request:camera');
+    return super.requestCameraPermission();
+  }
+}
+
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory pathProviderDir;
+  setUpAll(() {
+    pathProviderDir =
+        Directory.systemTemp.createTempSync('hibiki_path_provider_perm');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => pathProviderDir.path,
+    );
+  });
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (pathProviderDir.existsSync()) {
+      pathProviderDir.deleteSync(recursive: true);
+    }
+  });
+
+  late HibikiDatabase db;
+  late PreferencesRepository prefs;
+  late Directory storeDir;
+  late _RecordingPermissionService permission;
+  late AppModel appModel;
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    storeDir = Directory.systemTemp.createTempSync('hibiki_app_model_perm');
+    permission = _RecordingPermissionService();
+    appModel = AppModel(fakePlatformServices(permission: permission))
+      ..wireLocalAudioForTesting(prefsRepo: prefs, databaseDirectory: storeDir);
+  });
+
+  tearDown(() async {
+    prefs.dispose();
+    await db.close();
+    if (storeDir.existsSync()) {
+      storeDir.deleteSync(recursive: true);
+    }
+  });
+
+  group('BUG-1205 storage permission never drags the camera along', () {
+    test('storage not granted: requests storage only, never the camera',
+        () async {
+      permission.hasExternalStorage = false;
+      permission.hasCamera = false;
+
+      await appModel.requestExternalStoragePermissions();
+
+      expect(
+        permission.calls,
+        <String>['has:storage', 'request:storage'],
+        reason: '选文件夹只需要读盘权限；相机是另一件事，不得混进同一串权限流程',
+      );
+      expect(permission.cameraCalls, isEmpty);
+    });
+
+    test('storage already granted: short-circuits without asking anything',
+        () async {
+      // 相机未授权也必须早退：旧版早退门是 storage && camera，安卓上 camera 恒为
+      // false（CAMERA 未在 manifest 声明），导致存储已授权也永远走不进早退分支。
+      permission.hasExternalStorage = true;
+      permission.hasCamera = false;
+
+      await appModel.requestExternalStoragePermissions();
+
+      expect(
+        permission.calls,
+        <String>['has:storage'],
+        reason: '存储已授权时不该再向权限层要任何东西',
+      );
+    });
+
+    testWidgets(
+        'android folder picker entry point asks for storage, not the camera',
+        (WidgetTester tester) async {
+      // 真实用户入口：选扫描根 / 改下载目录都走 pickRealDirectoryPath。
+      permission.hasExternalStorage = true;
+      permission.hasCamera = false;
+
+      final List<String> safCalls = <String>[];
+      binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        HibikiChannels.saf,
+        (MethodCall call) async {
+          safCalls.add(call.method);
+          return '/storage/emulated/0/Books';
+        },
+      );
+      addTearDown(() {
+        binding.defaultBinaryMessenger
+            .setMockMethodCallHandler(HibikiChannels.saf, null);
+      });
+
+      late BuildContext capturedContext;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) {
+              capturedContext = context;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      // 覆写必须在 test body 内还原：flutter_test 在 body 结束时就校验 foundation
+      // debug 变量已复位，addTearDown 太晚。
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+      final String? picked;
+      try {
+        picked = await pickRealDirectoryPath(
+          context: capturedContext,
+          appModel: appModel,
+        );
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
+
+      expect(picked, '/storage/emulated/0/Books');
+      expect(safCalls, <String>['pickRealDirectory'],
+          reason: '安卓目录选择必须落到原生 SAF 选择器');
+      expect(
+        permission.cameraCalls,
+        isEmpty,
+        reason: '选文件夹的整条路径上不得出现任何相机权限查询或申请',
+      );
+    });
+  });
+}

--- a/hibiki/test/models/app_model_storage_permission_test.dart
+++ b/hibiki/test/models/app_model_storage_permission_test.dart
@@ -14,7 +14,7 @@ import 'package:hibiki_core/hibiki_core.dart';
 
 import '../helpers/fake_platform_services.dart';
 
-/// BUG-1205：选文件夹 / 选文件 / 改下载目录时不得申请相机权限。
+/// BUG-1209：选文件夹 / 选文件 / 改下载目录时不得申请相机权限。
 ///
 /// `AppModel.requestExternalStoragePermissions()` 曾顺带 `requestCameraPermission()`，
 /// 而它的调用点全在 `media/import/real_path_directory_picker.dart`（选扫描根 / 选文件 /
@@ -104,7 +104,7 @@ void main() {
     }
   });
 
-  group('BUG-1205 storage permission never drags the camera along', () {
+  group('BUG-1209 storage permission never drags the camera along', () {
     test('storage not granted: requests storage only, never the camera',
         () async {
       permission.hasExternalStorage = false;


### PR DESCRIPTION
## 问题

`AppModel.requestExternalStoragePermissions()` 在申请存储权限的同时**顺带申请相机权限**，早退门也把相机算进条件。而它的 3 个调用点全部在 `hibiki/lib/src/media/import/real_path_directory_picker.dart:37,86,153`（选扫描根 / 选文件 / 改下载目录），只需要读盘。用户理解不了选个文件夹为什么要给相机，合理反应是拒绝；同一串权限流程里的拒绝很可能把本该给的存储权限一起否掉 → 「加了扫描根却扫不出东西」。

PR#526 把目录选择统一到 `pickRealDirectoryPath` 之后，走这条路径的入口变多，爆炸半径随之扩大。

## 调用点分类（按实际需要拆，不是一刀切删）

- **需要相机的调用点：0 个。** 全仓 `hasCameraPermission` / `requestCameraPermission` 的调用点只有这一处，其余全是接口定义与各平台实现。唯一真正用相机的 `creator/enhancements/camera_enhancement.dart:46` 走 image_picker 的 `ImageSource.camera` 系统拍照 intent，**从不调这两个方法**；`AndroidManifest.xml` 也未声明 `android.permission.CAMERA`，该 intent 本就不需要运行时权限。
- **只需要存储的调用点：3 个**（上述 picker）。

因此本 PR 把这个函数收敛为「只申请存储」，相机能力方法 `PlatformPermissionService.{has,request}CameraPermission` **保留不删**（属权限层抽象，删除是更大范围改动）。

## 顺带修掉的死门

旧早退门 `hasExternalStoragePermission() && hasCameraPermission()` 在安卓上恒不成立——CAMERA 未在 manifest 声明 → permission_handler 10.2.1 直接判 denied（`PermissionUtils.java:106-108` + `PermissionManager.java:239-256`）→ 存储已授权也永远走不进早退分支，每次选文件夹都重跑一遍申请流程。

## 复现程度（如实说）

代码属实，但**「安卓上弹出相机权限框」这一可见症状当前复现不了**：合并后的 release manifest 里没有 CAMERA（已核 `build/app/intermediates/merged_manifest/release/.../AndroidManifest.xml`，无插件贡献），permission_handler 对未声明权限**不调 `ActivityCompat.requestPermissions`**，所以弹不出框。真正的现存副作用是上面那个恒 false 的早退门。iOS 侧 `hasCameraPermission()` 是真状态，一旦有非安卓调用点接进来就会弹真·相机框，这个隐患一并消除。

## 测试

`hibiki/test/models/app_model_storage_permission_test.dart`（3 条**行为**测试，不是源码扫描、不是谓词副本）：用记录型 `PlatformPermissionService` 记下**真实生产代码**对权限层的每一次调用——

1. 存储未授权：调用序列恰为 `has:storage → request:storage`；
2. 存储已授权（相机未授权）：恰为 `has:storage`，早退；
3. 走真实用户入口 `pickRealDirectoryPath()`（安卓分支 + mock SAF channel）：全程零相机调用，且落到原生 `pickRealDirectory`。

**变异实测**：把修复退回旧实现，3 条全部转红。

## 未覆盖 / 待办

- 🔴 **真机授权弹框行为未验证**——单测只能证明代码不再向权限层请求相机，证明不了用户在真机上看到什么。BUG 文档里真机项保持未勾选。
- **AndroidManifest.xml 未改动**（本就没有 CAMERA 声明，无需删）。
- **另发现一个独立缺陷，本 PR 未修**：`android_permission_service.dart:6-7` 的 `hasExternalStoragePermission()` 只看 `manageExternalStorage.isGranted`，而该权限 Android 11 才引入，permission_handler 在 API < 30 恒返回 RESTRICTED → **Android 7~10 上恒 false**，`pickRealDirectoryPath()` 因此恒走「需要授权」分支返回 null，用户加不了扫描根。申请侧已有 `Permission.storage` 回退，缺的是查询侧的 SDK 分级。需真机验证 Android 7~10，单独立项。

## 验证

- `flutter analyze`（含 test）→ `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/media test/tools test/models test/platform` → `FLUTTER TEST VERDICT: PASSED - 4244 tests ran, all tests passed`（退出码 0）
- `hibiki/pubspec.yaml` → `1.3.1+969`

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
