### PR TITLE
fix(sources): AppModel 在 initState 捕获，恢复 BUG-513 不变量

### DIFF
--- a/hibiki/lib/src/pages/implementations/media_sources_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/media_sources_dialog.dart
@@ -62,13 +62,20 @@ class _MediaSourcesDialogState extends ConsumerState<MediaSourcesDialog>
   /// `containerOf` 抛 `Bad state: No ProviderScope found`（BUG-513）。
   late final HibikiDatabase _db;
 
+  /// 同 [_db]：`AppModel` 也在 initState 捕获。`_addLocalFolder` 要把它交给
+  /// `pickRealDirectoryPath`（安卓那条腿用它申请全文件访问），而系统目录选择器是一段
+  /// **很长的 async gap**——用户完全可能在选择器开着时把对话框关掉。捕获成字段后此处
+  /// 不再出现任何 `ref.*`，BUG-513 的不变量（ref 只在 initState）继续成立。
+  late final AppModel _appModel;
+
   /// 网络来源仅对 'book' 开放（见文件头说明）。
   bool get _networkSupported => widget.mediaKind == 'book';
 
   @override
   void initState() {
     super.initState();
-    _db = ref.read(appProvider).database;
+    _appModel = ref.read(appProvider);
+    _db = _appModel.database;
     _load();
   }
 
@@ -409,7 +416,7 @@ class _MediaSourcesDialogState extends ConsumerState<MediaSourcesDialog>
     // （安卓先取全文件访问再经原生 SAF 解析真实路径；桌面/iOS 行为逐字不变）。
     final String? picked = await pickRealDirectoryPath(
       context: context,
-      appModel: ref.read(appProvider),
+      appModel: _appModel,
       dialogTitle: t.media_source_add_local_folder,
     );
     if (!mounted || picked == null || picked.isEmpty) return;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+968
+version: 1.3.1+977
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"


### PR DESCRIPTION
## 因果

PR#526 的审查修复里，我把 `_addLocalFolder` 的
`ProviderScope.containerOf(context, listen: false).read(appProvider)`
「简化」成了 `ref.read(appProvider)` —— 这恰好撞进 BUG-513 修掉的反模式。

`media_sources_dialog.dart` 的不变量是 **`ref.*` 只允许出现在 `initState`**：对话框可以在 async gap 里被关掉，此后再走 ProviderScope 查找会抛 `Bad state: No ProviderScope found`。而系统目录选择器正是一段**很长的 async gap** —— 用户完全可能在选择器开着时把对话框关掉。

`test/pages/media_sources_dialog_test.dart` 的 BUG-513 源码守卫如实报了红。**是守卫对、我的改动错。**

## 修法

不放宽守卫。跟着这个文件自己的范式走：像已有的 `_db` 一样，在 `initState` 把 `AppModel` 捕获成 `late final _appModel`，调用点用字段。改完全文件 `ref.*` 只剩 `initState` 里那一处。

## 为什么上一轮没发现

定向测试只跑了守卫本体和导入相关目标 —— 改了 `media_sources_dialog.dart` 却没跑它自己的测试。本轮改跑 `test/pages` + `test/tools` + `test/media` 全量。

## 验证

- `flutter analyze` → `No issues found!`
- `FLUTTER TEST VERDICT: PASSED - 6024 tests ran, all tests passed`（退出码 0）
- 复现证据：在干净 develop `842a96f1d` 上，该测试报
  `ref.* outside initState ... (BUG-513): "      appModel: ref.read(appProvider),"`

`pubspec` 取 `+977`。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb