### PR TITLE
fix(galgame): 用 PowerShell 5.1 可用的写法替代 GetRelativePath (BUG-1208)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1168 条。点号进各自文件。
+> 共 1169 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1208](bugs/BUG-1208-ps51-getrelativepath-build-dist.md) | ✅ | ✅ | helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩 |
 | [BUG-1207](bugs/BUG-1207-android-embedded-torrent-dead-setting.md) | ✅ | ✅ | 安卓下载设置能选「内置引擎」并改下载目录，实际静默回退外接 qBittorrent |
 | [BUG-1206](bugs/BUG-1206-jimaku-season-pack-wrong-season-match.md) | ✅ | ✅ | 整季包字幕按标题猜集号导致错季配对且条数无上界 |
 | [BUG-1205](bugs/BUG-1205-video-mining-cover-audio-serial.md) | ✅ | ✅ | 视频制卡封面与句子音频串行且失败来源靠调用顺序区分 |

--- a/docs/bugs/BUG-1208-ps51-getrelativepath-build-dist.md
+++ b/docs/bugs/BUG-1208-ps51-getrelativepath-build-dist.md
@@ -1,0 +1,42 @@
+## BUG-1208 · helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩
+- **报告**：2026-07-28（用户：）
+- **真实性**：✅ 真 bug。根因 `native/galgame_hook/tools/build_distribution.ps1:206`（合入前）——
+  PR#528 加「递归打包 x64 Unity 提取运行时」时，用
+  `[IO.Path]::GetRelativePath($stage, $_.FullName)` 把 staged 文件转成相对路径去比对
+  `$expected` 清单。`GetRelativePath` 是 **.NET Core / netstandard2.1+ only** 的 API；
+  `.github/workflows/build-multiplatform.yml:788` 与 `release-desktop.yml:344` 用的是
+  `powershell -NoProfile -ExecutionPolicy Bypass -File ...`，即 **Windows PowerShell 5.1
+  （.NET Framework 4.x）**，该方法根本不存在，运行时抛
+  `Method invocation failed because [System.IO.Path] does not contain a method named 'GetRelativePath'`，
+  `build_distribution.ps1 -RunTests failed (1)`。
+  表现：develop `f81ed0d35` 的 `Build Desktop and Apple Release Artifacts`（run 30349973799）
+  job `windows` 红。**C++ 侧全绿**（x64/x86 各 22/22 CTest 通过），挂的纯粹是打包阶段的
+  PowerShell —— 单测和 CTest 都覆盖不到这一层。
+  下游连带：job `publish` 的 `Publish mirror update manifest (desktop assets)` 报
+  `No files matched hibiki-*-windows-setup.exe`，是 windows job 没产出安装包导致的次生失败，
+  非独立缺陷。
+- **[x] ① 已修复** — 用 5.1 也有的写法替代：新增 `Get-StageRelativePath` 辅助函数，
+  以 `GetFullPath` 归一化后做前缀截断（与同文件 `Reset-StageDirectory` 已有写法同形），
+  `OrdinalIgnoreCase` 对齐 `GetRelativePath` 在 Windows 上的比较语义，输出仍是 `/` 分隔，
+  与 `$expected` 清单一致。比较前给前缀补上目录分隔符是关键：否则 `<root>extra\f` 会被
+  误判成在 `<root>` 内。越界文件显式 throw，不再生成 `..\` 路径。
+- **[x] ② 已加自动化测试** — `hibiki/test/tools/powershell_51_compat_guard_test.dart`：
+  从 workflow 反推「被 `powershell -File`（真 5.1）执行」的脚本集合（`pwsh` 调用的是 PS7，
+  不受限，仓库里绝大多数 .ps1 走 pwsh，一刀切会误伤），对这些脚本扫 PS7/.NET Core 专属
+  API 黑名单；扫描前剥掉注释和引号内字面量，避免注释提到 API 名、或作为数据传给 bash 的
+  `&&`/`||` 误报。含「解析不到任何 powershell -File 调用就判红」的自校验，防守卫扫空变摆设
+  （BUG-1157 那类零执行伪装成通过）。变异实测：把 `::GetRelativePath(` 写回代码位，守卫
+  转红并指出 `build_distribution.ps1:206`；改回后 2 tests PASSED。
+- **备注**：本机 Windows PowerShell 5.1（5.1.26100.7462 / Desktop / CLR 4.0.30319）实测
+  `[System.IO.Path]` 无 `GetRelativePath` 方法，并复现了与 CI 字节一致的报错。
+  替代实现按 9 组边界用例验证（嵌套/顶层/base 带尾斜杠/正斜杠 base/大小写不一致/三层深/
+  base 含 `..`/同级越界/`x64extra` 前缀陷阱），并用真实 x64+x86 清单（19+7 文件）跑通
+  stage 列举与 `Compare-Object` 比对，含「删一个文件必须被发现」的反向对照。
+  另核实：PR#528 同段新增的 `Join-Path` 内嵌正斜杠 → `Split-Path -Parent` → `Copy-Item`
+  链路在 5.1 上实测正常（5.1 的 `Join-Path` 会自行归一化分隔符），非缺陷。
+  已知遗留（非本 bug、未改）：5.1 的 `Compress-Archive` 写 zip 条目名用反斜杠
+  （`unity_audio_runtime\x.dll`），不合 ZIP 规范（PS7 写正斜杠）。PR#528 之前 zip 里没有
+  子目录，所以这条以前不可能显现。当前消费端安全：Dart 侧
+  `hibiki/lib/src/mining/galgame_helper_installer.dart:1138` 解压时对 `/` 和 `\` 都做了
+  归一化。**未验证**：`.github/workflows/av-selfscan.yml` 用 pwsh 的 `Expand-Archive`
+  处理这种反斜杠条目的行为（本轮没跑该 workflow，本机也没有 pwsh 可复现）。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+978
+version: 1.3.1+979
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/tools/powershell_51_compat_guard_test.dart
+++ b/hibiki/test/tools/powershell_51_compat_guard_test.dart
@@ -1,0 +1,143 @@
+// 守卫：被真正的 Windows PowerShell 5.1 执行的 .ps1 不得使用 PowerShell 7 /
+// .NET Core 专属 API。
+//
+// 背景 BUG-1208：PR#528 给 native/galgame_hook/tools/build_distribution.ps1 加
+// 「递归打包 x64 Unity 提取运行时」时用了 [IO.Path]::GetRelativePath —— 那是
+// .NET Core / netstandard2.1+ 才有的 API。CI 的 windows runner 用
+// `powershell -File` 调它，那是 Windows PowerShell 5.1（.NET Framework 4.x），
+// 方法根本不存在，打包步骤当场 MethodNotFound 崩掉，develop 的
+// 「Build Desktop and Apple Release Artifacts」整条发布链全红。C++ 全绿，
+// 挂的是打包脚本 —— 单测和 CTest 都覆盖不到这一层，所以需要这条静态守卫。
+//
+// 受约束脚本集合是**从 workflow 反推**的，不是手工清单：凡被
+// `powershell ... -File <path>` 调用的就按 5.1 约束；`pwsh` 调用的是 PS7，
+// 不受此限（仓库里绝大多数 .ps1 走 pwsh，禁掉 PS7 语法会误伤）。新增一处
+// `powershell -File` 调用，对应脚本自动进入守卫范围。
+//
+// 纯 dart:io，不依赖 Flutter 运行时；cwd 是 hibiki/，所以跨出仓库根用 '../'。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 从当前 cwd 向上找含 .github/workflows 的仓库根。
+Directory _repoRoot() {
+  var dir = Directory.current;
+  for (var i = 0; i < 6; i++) {
+    if (Directory('${dir.path}/.github/workflows').existsSync()) return dir;
+    final Directory parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  fail('找不到含 .github/workflows 的仓库根（从 ${Directory.current.path} 向上）');
+}
+
+/// 匹配 `powershell ... -File <path>`（真 5.1），不匹配 `pwsh ... -File <path>`。
+/// 前置 (?<![\w-]) 防止匹配到某个以 powershell 结尾的别的词。
+final RegExp _ps51Invocation = RegExp(
+  r'(?<![\w.-])powershell(?:\.exe)?(?![\w.-])[^\r\n]*?-File\s+([^\s"]+)',
+);
+
+/// 5.1 上不存在 / 行为不同的写法。只收「不可能作为数据出现」的 API、参数和
+/// 自动变量；`&&` / `||` 这类同时可能是别的 shell 的字面量的，靠下面的
+/// 字符串剥离后再判。
+const Map<String, String> _forbidden = <String, String>{
+  r'::\s*GetRelativePath\s*\(':
+      '[IO.Path]::GetRelativePath 是 .NET Core / netstandard2.1+ only，5.1 没有（BUG-1208 就是它）',
+  r'::\s*GetFullPath\s*\([^)]*,':
+      '[IO.Path]::GetFullPath 的双参数重载是 .NET Core only，5.1 只有单参数版',
+  r'::\s*(TrimEndingDirectorySeparator|EndsInDirectorySeparator)\s*\(':
+      '[IO.Path] 的该方法是 .NET Core only',
+  r'::\s*HashData\s*\(': '::HashData 是 .NET 5+ only',
+  r'\[System\.Text\.Json': 'System.Text.Json 不在 .NET Framework 4.x 里',
+  r'-AsHashtable\b': 'ConvertFrom-Json -AsHashtable 是 PS 6+ only',
+  r'\$Is(Windows|Linux|MacOS)\b':
+      r'$IsWindows/$IsLinux/$IsMacOS 是 PS 6+ 自动变量，5.1 下恒为 $null',
+  r'\$PSStyle\b': r'$PSStyle 是 PS 7.2+ only',
+  r'-Parallel\b': 'ForEach-Object -Parallel 是 PS 7+ only',
+  r'\bJoin-String\b': 'Join-String 是 PS 6.2+ only',
+  r'\bTest-Json\b': 'Test-Json 是 PS 6+ only',
+  r'\bStart-ThreadJob\b': 'Start-ThreadJob 5.1 需额外装模块，CI 上没有',
+  r'-AsByteStream\b': '-AsByteStream 是 PS 6+ only（5.1 用 -Encoding Byte）',
+  r'utf8NoBOM': '-Encoding utf8NoBOM 是 PS 6+ only',
+  r'-SkipHttpErrorCheck\b': '-SkipHttpErrorCheck 是 PS 7+ only',
+  r'-RelativeBasePath\b': 'Resolve-Path -RelativeBasePath 是 PS 7+ only',
+  r'-LeafBase\b': 'Split-Path -LeafBase 是 PS 6+ only',
+  r'\?\?': 'PS 7 的 null 合并 / null 条件运算符，5.1 是 parser error',
+  r'(?<![\w&])&&(?!&)': 'pipeline chain 运算符 && 是 PS 7+ only，5.1 是 parser error',
+  r'(?<![\w|])\|\|(?!\|)':
+      'pipeline chain 运算符 || 是 PS 7+ only，5.1 是 parser error',
+};
+
+/// 剥掉引号内字面量和注释，只留可执行代码。
+///
+/// 顺序是关键：先剥字符串，这样 (a) 字符串里的 '#' 不会把后面的真代码误删；
+/// (b) 作为**数据**传给 bash / GitHub Actions 表达式的 '&&' '||'（仓库里
+/// tool/run_mac_itest.ps1、tool/check_release_policy.ps1 就有）不会误报。
+String _codeOnly(String line) {
+  String s = line
+      .replaceAll(RegExp(r"'[^']*'"), "''")
+      .replaceAll(RegExp(r'"[^"]*"'), '""');
+  final int hash = s.indexOf('#');
+  if (hash >= 0) s = s.substring(0, hash);
+  return s;
+}
+
+void main() {
+  final Directory root = _repoRoot();
+
+  /// 从所有 workflow 反推「被 5.1 执行」的脚本相对路径。
+  Set<String> ps51Scripts() {
+    final Set<String> found = <String>{};
+    final Directory dir = Directory('${root.path}/.github/workflows');
+    for (final FileSystemEntity e in dir.listSync()) {
+      if (e is! File || !e.path.endsWith('.yml')) continue;
+      for (final RegExpMatch m
+          in _ps51Invocation.allMatches(e.readAsStringSync())) {
+        found.add(m.group(1)!.replaceAll(r'\', '/'));
+      }
+    }
+    return found;
+  }
+
+  test('workflow 里确实存在 powershell -File 调用（守卫不能扫了个空）', () {
+    final Set<String> scripts = ps51Scripts();
+    // 自校验：如果调用形式变了导致一个脚本都没扫到，这条守卫就成了永远绿的
+    // 摆设（BUG-1157 那一类「零执行伪装成通过」）。宁可在这里红。
+    expect(
+      scripts,
+      isNotEmpty,
+      reason: '没有从 workflow 里解析出任何 `powershell -File` 调用，'
+          '守卫会扫空 —— 检查 _ps51Invocation 正则是否跟不上调用写法变化',
+    );
+    expect(
+      scripts,
+      contains('native/galgame_hook/tools/build_distribution.ps1'),
+      reason: 'galgame helper 打包脚本必须仍由 5.1 执行并受本守卫覆盖（BUG-1208）',
+    );
+  });
+
+  test('被 5.1 执行的 .ps1 不含 PowerShell 7 / .NET Core 专属写法', () {
+    final List<String> offenders = <String>[];
+    for (final String rel in ps51Scripts()) {
+      final File f = File('${root.path}/$rel');
+      expect(f.existsSync(), isTrue, reason: 'workflow 引用了不存在的脚本：$rel');
+      final List<String> lines = f.readAsLinesSync();
+      for (int i = 0; i < lines.length; i++) {
+        final String code = _codeOnly(lines[i]);
+        if (code.trim().isEmpty) continue;
+        _forbidden.forEach((String pattern, String why) {
+          if (RegExp(pattern).hasMatch(code)) {
+            offenders.add('$rel:${i + 1}: $why\n    ${lines[i].trim()}');
+          }
+        });
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason: '以下写法在 Windows PowerShell 5.1 上不可用，而 CI 正是用 '
+          '`powershell -File` 跑这些脚本：\n${offenders.join('\n')}',
+    );
+  });
+}

--- a/native/galgame_hook/tools/build_distribution.ps1
+++ b/native/galgame_hook/tools/build_distribution.ps1
@@ -49,6 +49,30 @@ function Reset-StageDirectory {
   New-Item -ItemType Directory -Force -Path $full | Out-Null
 }
 
+function Get-StageRelativePath {
+  # CI runs this on the windows runner under Windows PowerShell 5.1 (.NET Framework
+  # 4.x), which has NO [IO.Path]::GetRelativePath -- that API is .NET Core /
+  # netstandard2.1+ only. Calling it there throws "does not contain a method named
+  # GetRelativePath" and takes the whole packaging step down with it. Same
+  # prefix-trim shape as Reset-StageDirectory above; emits forward slashes so the
+  # result lines up with the $expected manifest.
+  param(
+    [Parameter(Mandatory = $true)][string]$Root,
+    [Parameter(Mandatory = $true)][string]$FullName
+  )
+  $rootPrefix = [IO.Path]::GetFullPath($Root).TrimEnd('\', '/') + [IO.Path]::DirectorySeparatorChar
+  $full = [IO.Path]::GetFullPath($FullName)
+  # OrdinalIgnoreCase mirrors GetRelativePath's own Windows comparison. Appending the
+  # separator before comparing is load-bearing: a bare StartsWith would treat
+  # "<root>extra\file" as living inside "<root>". A staged file outside its arch root
+  # is a packaging bug, so fail loudly instead of emitting a "..\" path that would
+  # only surface later as a baffling manifest diff.
+  if (-not $full.StartsWith($rootPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Staged file escapes its arch root ($Root): $full"
+  }
+  return $full.Substring($rootPrefix.Length).Replace('\', '/')
+}
+
 New-Item -ItemType Directory -Force -Path $outputRoot | Out-Null
 
 foreach ($config in @(
@@ -179,9 +203,7 @@ foreach ($arch in @('x64', 'x86')) {
   $stage = Join-Path $outputRoot $arch
   $actual = @(
     Get-ChildItem -LiteralPath $stage -File -Recurse |
-      ForEach-Object {
-        [IO.Path]::GetRelativePath($stage, $_.FullName).Replace('\', '/')
-      } |
+      ForEach-Object { Get-StageRelativePath -Root $stage -FullName $_.FullName } |
       Sort-Object
   )
   $wanted = @($expected[$arch] | Sort-Object)


### PR DESCRIPTION
## 问题

develop `f81ed0d35`（合入 PR#528 的 merge commit）的 **Build Desktop and Apple Release Artifacts** 全红（run 30349973799）。

- job `windows` / step `Build and bundle galgame helper archives`：
  `Method invocation failed because [System.IO.Path] does not contain a method named 'GetRelativePath'` → `build_distribution.ps1 -RunTests failed (1)`
- job `publish` / step `Publish mirror update manifest (desktop assets)`：
  `No files matched hibiki-*-windows-setup.exe` —— **次生失败**，windows job 没产出安装包所致，非独立缺陷。

**C++ 侧全绿**（x64/x86 各 22/22 CTest 通过）。挂的纯粹是打包阶段的 PowerShell，单测和 CTest 都覆盖不到这一层。

## 根因

PR#528 加「递归打包 x64 Unity 提取运行时」时用了 `[IO.Path]::GetRelativePath($stage, $_.FullName)`。该 API 是 **.NET Core / netstandard2.1+ only**；而 `build-multiplatform.yml:788` 与 `release-desktop.yml:344` 用的是 `powershell -NoProfile -ExecutionPolicy Bypass -File ...`，即 **Windows PowerShell 5.1（.NET Framework 4.x）**，方法根本不存在。

本机 5.1（5.1.26100.7462 / Desktop / CLR 4.0.30319）实测 `[System.IO.Path]` 无该方法，并复现了与 CI 字节一致的报错。

## 改法

新增 `Get-StageRelativePath`：`GetFullPath` 归一化后做前缀截断，与同文件已有的 `Reset-StageDirectory` 同形。

- **分隔符**：仍输出 `/`，与 `$expected` 清单一致
- **尾斜杠**：`TrimEnd` 后统一补 `DirectorySeparatorChar`
- **大小写**：`OrdinalIgnoreCase`，对齐 `GetRelativePath` 在 Windows 上的比较语义
- **前缀陷阱**：补分隔符后再比较是**载荷性的** —— 裸 `StartsWith` 会把 `<root>extra\f` 当成在 `<root>` 内
- **越界**：显式 throw，不再生成 `..\` 路径把问题推迟到清单比对时才以怪异 diff 出现

**不回退 PR#528 的功能**，只修兼容性。

## PR#528 其余 PowerShell 兼容性核查

逐行过了 PR#528 对 `build_distribution.ps1` 的全部 +51/-2（它是该 PR 唯一改动的 `.ps1`），**除 `GetRelativePath` 外没有别的 5.1 不兼容写法**。已实测确认这些**不是**问题：

- `Join-Path $stageX64 'unity_audio_runtime/x.exe'`（内嵌正斜杠）→ `Split-Path -Parent` → `Copy-Item`：5.1 的 `Join-Path` 会自行归一化分隔符，链路实测正常
- `New-Item -Force |` 行尾管道续行、`Get-ChildItem -File -Recurse`、`Compress-Archive`：5.1 全部可用
- 无 `??` / `?.` / `?:`、无 `&&` / `||`、无 `ConvertFrom-Json -AsHashtable`、无 `$IsWindows` / `$PSStyle`

全仓 19 个 `.ps1` 同口径扫描，修完后 0 命中。

## 守卫

新增 `hibiki/test/tools/powershell_51_compat_guard_test.dart`（与既有 `release_workflow_bash_portability_guard_test.dart` 同一类）。

受约束脚本集合**从 workflow 反推**而非硬编码清单：凡被 `powershell ... -File` 调用的按 5.1 约束；`pwsh` 调用的是 PS7 不受限（仓库里绝大多数 `.ps1` 走 pwsh，一刀切会误伤）。新增一处 `powershell -File` 调用，对应脚本自动进入守卫范围。

- 扫描前剥掉注释和引号内字面量：避免注释提到 API 名、或作为数据传给 bash 的 `&&`/`||`（`run_mac_itest.ps1`、`check_release_policy.ps1` 里就有）误报
- 含「解析不到任何 `powershell -File` 调用就判红」的自校验，防守卫扫空变永远绿的摆设（BUG-1157 那类零执行伪装成通过）

**变异实测**：把 `::GetRelativePath(` 写回代码位 → 守卫转红，退出码 1，指出 `build_distribution.ps1:206`；改回 → 2 tests PASSED。

## 验证（说明验到哪一层）

**没有完整跑 `build_distribution.ps1 -RunTests`**（需编译 C++ 双架构 + 联网下 Locale Emulator）。实际验到：

1. 本机 5.1 复现原始报错，与 CI 字节一致
2. 从**修改后的真实仓库文件**用 AST 抽出 `Get-StageRelativePath` 执行，9 组边界用例全过：嵌套 / 顶层 / base 带尾反斜杠 / 正斜杠 base / 大小写不一致 / 三层深 / base 含 `..` / 同级越界 / `x64extra` 前缀陷阱
3. 用**真实 x64+x86 清单**（19+7 文件）在真实目录树上跑通完整 stage 列举 + `Compare-Object`，两架构逐文件匹配；含「删一个文件必须被发现」的反向对照，证明比对没瞎
4. 5.1 解析器 `ParseFile` 全脚本 0 语法错误
5. `flutter analyze`（含 test）`No issues found!`；`test/mining/galgame_helper_installer_test.dart`（读同一脚本的相邻契约测试）56 tests PASSED

## 已知遗留（本 PR 未改）

5.1 的 `Compress-Archive` 写 zip 条目名用**反斜杠**（`unity_audio_runtime\x.dll`），不合 ZIP 规范（PS7 写正斜杠）。PR#528 之前 zip 里没有子目录，所以这条以前不可能显现。

当前消费端安全：Dart 侧 `galgame_helper_installer.dart:1138` 解压时对 `/` 和 `\` 都做了归一化。

**未验证**：`av-selfscan.yml`（用 pwsh 的 `Expand-Archive`）处理这种反斜杠条目的行为 —— 本轮没跑该 workflow，本机也没有 pwsh 可复现。

BUG 记录：`docs/bugs/BUG-1208-ps51-getrelativepath-build-dist.md`