### PR TITLE
fix(lookup): 剪贴板面板查词不自动朗读，收口成两表面共用实现 (BUG-1210)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,12 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1172 条。点号进各自文件。
+> 共 1173 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1213](bugs/BUG-1213-android-legacy-storage-permission-query.md) | ✅ | ✅ | Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根 |
 | [BUG-1212](bugs/BUG-1212-manga-stats-guard-stale.md) | ✅ | ✅ | 漫画统计守卫仍钉旧口径 charsRead: 0，PR#504 后 develop 变红 |
+| [BUG-1210](bugs/BUG-1210-clipboard-panel-no-auto-read.md) | ✅ | ✅ | 剪贴板面板查词不自动朗读而浮窗会开关却是全局的 |
 | [BUG-1209](bugs/BUG-1209-folder-picker-requests-camera-permission.md) | ✅ | ✅ | 安卓选文件夹时顺带弹相机权限申请 |
 | [BUG-1208](bugs/BUG-1208-ps51-getrelativepath-build-dist.md) | ✅ | ✅ | helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩 |
 | [BUG-1207](bugs/BUG-1207-android-embedded-torrent-dead-setting.md) | ✅ | ✅ | 安卓下载设置能选「内置引擎」并改下载目录，实际静默回退外接 qBittorrent |

--- a/docs/bugs/BUG-1210-clipboard-panel-no-auto-read.md
+++ b/docs/bugs/BUG-1210-clipboard-panel-no-auto-read.md
@@ -1,0 +1,38 @@
+## BUG-1210 · 剪贴板面板查词不自动朗读而浮窗会开关却是全局的
+- **报告**：2026-07-28（用户：「我查词了，但是没读音，点音频按钮才有正常吗」）
+- **真实性**：✅ 真 bug — 根因 `hibiki/lib/src/lookup/clipboard_panel_controller.dart`
+  的 `update()`（改前 L219-253）：查词成功后 `_seedRootFrame` → `_renderPanel` → glog
+  「panel: updated」，**整条路径没有任何自动朗读调用**。
+  全仓 `autoReadWordUnified` / `LookupAutoReadCoordinator.runAutomatic` 的接入点只有三处
+  ——`global_lookup_controller.dart`（app 外瞬态查词覆盖窗）、`base_source_page.dart`
+  （app 内媒体页）、`dictionary_page_mixin.dart`（app 内词典页）。剪贴板面板是**唯一
+  漏接的查词表面**，而它正是 galgame / 复制文本流的主力表面。
+  用户偏好 `src:reader_ttu:auto_read_on_lookup` 实测为 `b:true`（`preferences` 与
+  `profile_settings` 两处一致），即开关是开着的——同一个全局开关在一个表面生效、在另一
+  个完全无效，用户表现为「面板查词不读，必须手动点 ♪」。
+  用户机器日志佐证：07-28 全天 52 次 `panel: updated`、**0 次 autoread**；而 07-27 用
+  瞬态浮窗那次（`lookup:` / `hotkey:` 路径）autoread 正常触发 token=1..6。
+- **[x] ① 已修复** — 自动朗读收口成共享 `hibiki/lib/src/lookup/overlay_auto_read.dart`
+  （`OverlayAutoRead`），app 外两个表面共用一份实现，各自注入自己的渲染通道与就绪门控、
+  token 表独立。这与 `overlay_bridge_handlers.dart` 的九根 deferred 桥同一条红线：两个
+  表面的行为不得漂开，**绝不复制**。
+  `global_lookup_controller` 改为委托该实现（原私有实现整段移出）；
+  `clipboard_panel_controller` 新增两处接线：① `update()` 渲染完成后
+  `_autoRead.autoReadFirstEntry(model, result)`（放在渲染之后——播放脚本走同一 render
+  通道，必须排在整栈渲染脚本之后，否则会被 last-wins 顶掉）；② `_onJsMessage` 接
+  `maybeHandleWordAudioPlayed`——**这一步不可省**，否则 Completer 永远等不到回报，每次
+  自动发音都要空耗满 5s 超时才回落 Dart 播放器。
+- **[x] ② 已加自动化测试** — `hibiki/test/lookup/overlay_auto_read_parity_test.dart`：
+  面板必须调 `autoReadFirstEntry`、必须接住播放回报、两个表面必须共用同一实现（断言各自
+  不再私有维护 `_pendingWordAudioPlays` / 自拼 `buildPlayWordAudioScript`）、共享实现须
+  保留既有播放契约（统一快路径 + 去重协调器 + 就绪门控 + 开关门控）。
+  受契约变更影响的既有守卫同步更新（守的意图一字未改，只是实现搬了家）：
+  `global_lookup_m1a_guard_test.dart` 改为分扫「接线 + 共享实现」；
+  `global_lookup_autoread_webview_guard_test.dart` 的 `[token, false]` 锚点改为前缀匹配
+  （BUG-1204 后回报多带了第三个 reason 参数）。
+  全量 `flutter analyze` 干净；test/lookup 584 + mining/build/utils 1750 用例全绿。
+- **备注**：这条与用户最初报的「单词音频响应巨慢」是同一症状的真正来源之一——不是某段
+  代码慢，而是**面板压根不自动读**，用户得自己点 ♪ 再等一下，主观上就是「响应巨慢」。
+  这也解释了为什么此前实测每一段（本地库 0.3ms / Dart 解析 3ms / 桥 9ms）都是毫秒级却
+  找不到慢的环节。BUG-1204 的首播失败（`token=1 ok=false`）是另一条独立线索，仍待用户
+  复现后从日志读到确切 DOMException 名字再定案。

--- a/docs/bugs/BUG-1210-clipboard-panel-no-auto-read.md
+++ b/docs/bugs/BUG-1210-clipboard-panel-no-auto-read.md
@@ -36,3 +36,17 @@
   这也解释了为什么此前实测每一段（本地库 0.3ms / Dart 解析 3ms / 桥 9ms）都是毫秒级却
   找不到慢的环节。BUG-1204 的首播失败（`token=1 ok=false`）是另一条独立线索，仍待用户
   复现后从日志读到确切 DOMException 名字再定案。
+- **[ ] 未做真机复测（如实留空）**：剪贴板面板主要在 Windows 上用（galgame / 复制文本流），
+  但本轮**没有**在真机上跑通「复制文本 → 面板查词 → 自动朗读」这条链。只有源码层守卫，
+  该链路的运行时依赖是真实 WebView2 + native overlay 通道，widget 测试跑不起来。
+- **审查补记**：初版把朗读调用接在 `_renderPanel` 之后却**漏了 seq 核对**——`update()` 的
+  契约是「每个 await 后核对 latest-wins 序号，过期即弃」（VN 流乱序守卫），`_showPanel` /
+  `raise` 两个分支后都有，唯独朗读这一处没有。后果是被后一句顶掉的旧查词仍会读出**旧词**
+  （屏幕新句、耳朵旧句），而面板正是被动流的主力表面。已补核对 + 守卫。这是收口共享实现时
+  典型的「把一方独有契约一起抹掉」：覆盖窗没有 latest-wins 机制，共享实现里自然也没有。
+- **顺带修复的 CI 红**：`test/lookup/global_lookup_autoread_webview_guard_test.dart` 在
+  develop 上已经红了（`Build Release APK` 的 `Run unit tests` 门）。根因是 BUG-1204 把
+  `global_lookup_host.js` 的回报从 `[token, false]` 改成三参数 `[token, false, reason]`，
+  打破了这条锚在两参数字面量上的既有守卫，而当时的定向测试没覆盖 `test/lookup/`。本 PR 把
+  锚点改成前缀匹配并补断 `FrameNotLoaded`，守的意图（未加载帧必须立刻回 false，不拖满 5s
+  超时）一字未改，实际比原来更严。

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -267,6 +267,17 @@ class ClipboardPanelController {
       // 放在渲染之后：播放脚本经同一 render 通道下发，必须排在整栈渲染脚本之后，
       // 否则会被 last-wins 的渲染脚本顶掉（与覆盖窗 _autoReadFirstEntry 同一位置
       // 语义）。协调器内部去重，被动剪贴板流重复同词不会连读。
+      //
+      // 但**必须先核对 seq**：本方法的契约是「每个 await 后核对，过期即弃」（VN 流
+      // 乱序守卫），而上面 _renderPanel / _showPanel / raise 都是 await。少这一句，
+      // 被后一句顶掉的旧查词仍会把**旧词**读出来——屏幕上是新句、耳朵里是上一句，
+      // 而面板正是被动剪贴板流（galgame 台词 / texthooker）的主力表面，这种快速
+      // 连续更新恰恰是它的常态。覆盖窗没有 latest-wins 机制故原实现无此步，这是
+      // 面板独有的契约，收口共享实现时不能把它一起抹掉。
+      if (seq != _updateSeq) {
+        glog('panel: autoread skipped (superseded seq=$seq)');
+        return;
+      }
       _autoRead.autoReadFirstEntry(model, result);
     } catch (e, st) {
       glog('panel: update EXCEPTION $e\n$st');

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -20,6 +20,7 @@ import 'package:hibiki/src/lookup/global_lookup_controller.dart'
         GlobalLookupController,
         GlobalLookupMediaRequest,
         resolveGlobalLookupMedia;
+import 'package:hibiki/src/lookup/overlay_auto_read.dart';
 import 'package:hibiki/src/lookup/clipboard_history_payload.dart';
 import 'package:hibiki/src/lookup/desktop_lookup_router.dart';
 import 'package:hibiki/src/lookup/global_lookup_log.dart';
@@ -74,6 +75,17 @@ class ClipboardPanelController {
 
   static const OverlayWindowChannel _channel =
       OverlayWindowChannel(HibikiChannels.clipboardPanel);
+
+  /// BUG-1210 — 查词后自动朗读。此前**只有瞬态覆盖窗接了线**，本面板整条路径没有
+  /// 任何朗读调用：同一个全局开关 `autoReadOnLookup` 在那个表面生效、在这里完全
+  /// 无效，用户表现为「面板查词不读，必须手动点 ♪」。实现与覆盖窗共用同一份
+  /// [OverlayAutoRead]（与 deferred 桥同一条「绝不复制」红线），只是各自注入自己
+  /// 的渲染通道与就绪门控，token 表互相独立。
+  final OverlayAutoRead _autoRead = OverlayAutoRead(
+    render: _channel.render,
+    isWebViewReady: _channel.isWebViewReady,
+    label: 'panel',
+  );
 
   AppModel? _appModel;
   bool _started = false;
@@ -251,6 +263,11 @@ class ClipboardPanelController {
       await _renderPanel(model, resetRootScroll: true);
       glog('panel: updated "${request.text.length} chars" '
           'entries=${result.entries.length}');
+      // BUG-1210：与瞬态覆盖窗一致——查到词就按 autoReadOnLookup 偏好自动发音。
+      // 放在渲染之后：播放脚本经同一 render 通道下发，必须排在整栈渲染脚本之后，
+      // 否则会被 last-wins 的渲染脚本顶掉（与覆盖窗 _autoReadFirstEntry 同一位置
+      // 语义）。协调器内部去重，被动剪贴板流重复同词不会连读。
+      _autoRead.autoReadFirstEntry(model, result);
     } catch (e, st) {
       glog('panel: update EXCEPTION $e\n$st');
     }
@@ -494,6 +511,13 @@ class ClipboardPanelController {
       // 与句子横幅同一 `_currentSentence`，落实 spec §2 的「兼作制卡 sentence」。
       sentenceContext: _currentSentence,
     )) {
+      return;
+    }
+    // BUG-1210 — 面板 iframe realm 回报自动发音 `audio.play()` 真实结果
+    // （args = [token, ok, reason?]）。**必须**接住：否则 playWordAudioUrl 的
+    // Completer 永远等不到回报，每次自动发音都要空耗满 5s 超时才回落 Dart 播放器。
+    // 与覆盖窗同一份 [OverlayAutoRead] 实现。
+    if (_autoRead.maybeHandleWordAudioPlayed(handler, message)) {
       return;
     }
     // BUG-1139 — Ctrl+滚轮内容缩放：改「词典字号」这一唯一真值后整栈重渲。

--- a/hibiki/lib/src/lookup/global_lookup_controller.dart
+++ b/hibiki/lib/src/lookup/global_lookup_controller.dart
@@ -17,6 +17,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' hide ModifierKey;
 import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/lookup/overlay_auto_read.dart';
 import 'package:hibiki/src/lookup/clipboard_history_payload.dart';
 import 'package:hibiki/src/lookup/desktop_lookup_router.dart';
 import 'package:hibiki/src/lookup/effective_lookup_size.dart';
@@ -34,8 +35,6 @@ import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/shortcuts/input_binding.dart';
 import 'package:hibiki/src/shortcuts/shortcut_action.dart';
 import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
-import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart';
-import 'package:hibiki/src/utils/misc/lookup_auto_read_coordinator.dart';
 import 'package:hibiki_core/hibiki_core.dart'
     show kStatSourceBook, mimeTypeForFilePath;
 import 'package:hibiki_dictionary/hibiki_dictionary.dart';
@@ -874,32 +873,10 @@ class GlobalLookupController {
     )) {
       return;
     }
-    // BUG-1127 — 浮窗 iframe realm 回报自动发音 `audio.play()` 真实结果
-    // （args = [token, ok]，host 包裹桥盖 __frameId 后原样转发）。完成对应
-    // pending Completer；过期 token（已超时回落）直接忽略。
-    if (handler == 'wordAudioPlayed') {
-      final Object? args = message['args'];
-      if (args is List && args.length >= 2) {
-        final Object? rawToken = args[0];
-        final int? token =
-            rawToken is num ? rawToken.toInt() : int.tryParse('$rawToken');
-        if (token != null) {
-          final bool ok = args[1] == true;
-          // BUG-1204：失败原因（args[2]，旧 host 不带 → 空）落日志。没有它，
-          // 「首播必失败」只是一个 false，分不清 autoplay 拦截 / 解码失败 / 被掐断，
-          // 而这三种的根因修法完全不同。成功不记，避免刷屏。
-          if (!ok) {
-            final String reason = (args.length >= 3 ? '${args[2]}' : '').trim();
-            glog('autoread: webview play token=$token FAILED '
-                'reason=${reason.isEmpty ? 'unreported' : reason}');
-          }
-          final Completer<bool>? completer =
-              _pendingWordAudioPlays.remove(token);
-          if (completer != null && !completer.isCompleted) {
-            completer.complete(ok);
-          }
-        }
-      }
+    // BUG-1127 / BUG-1210 — 浮窗 iframe realm 回报自动发音 `audio.play()` 真实
+    // 结果（args = [token, ok, reason?]）。处理收口进共享 [OverlayAutoRead]，与
+    // 剪贴板面板同一实现。
+    if (_autoRead.maybeHandleWordAudioPlayed(handler, message)) {
       return;
     }
     // 瞬态 root 卡🕘：从 DB 重载复制历史（主进程采集写入）并注入覆盖层。
@@ -1089,88 +1066,17 @@ class GlobalLookupController {
     }
   }
 
-  /// 全局查词查到词后，按用户「自动朗读」(autoReadOnLookup) 偏好自动发音。
-  /// 复用主 Dart 查词链路同一去重协调器 (LookupAutoReadCoordinator)，播放走与
-  /// in-app 相同的统一契约 autoReadWordUnified（BUG-1127）：优先驱动浮窗自己的
-  /// HTML5 `<audio>` 快路径（与手动 ♪ 同一 popup.js playWordAudio，桌面不再每播
-  /// 一次 libmpv stop→load→play），播放结果经 wordAudioPlayed 桥真实回报，失败/
-  /// 超时回落 Dart 播放器（受 BUG-1015 warmUp 保护），绝不静默丢发音。
-  void _autoReadFirstEntry(AppModel model, DictionarySearchResult result) {
-    if (!ReaderHibikiSource.instance.autoReadOnLookup) {
-      return;
-    }
-    if (result.entries.isEmpty) {
-      return;
-    }
-    final DictionaryEntry entry = result.entries.first;
-    final String expression = entry.word;
-    final String reading = entry.reading;
-    if (expression.isEmpty) {
-      return;
-    }
-    unawaited(LookupAutoReadCoordinator.instance.runAutomatic(
-      expression: expression,
-      reading: reading,
-      play: () => _playWordAudio(model, expression, reading),
-    ));
-  }
+  /// BUG-1210 — 自动朗读收口到 [OverlayAutoRead]（app 外两个表面共用一份实现，
+  /// 与 overlay_bridge_handlers 同一条「绝不复制」红线）。本控制器只提供自己的
+  /// 渲染通道与就绪门控。
+  late final OverlayAutoRead _autoRead = OverlayAutoRead(
+    render: GlobalLookupChannel.render,
+    isWebViewReady: GlobalLookupChannel.isWebViewReady,
+    label: 'overlay',
+  );
 
-  /// 与 in-app _playAutoReadWord 同构：解析一次 ref，WebView 快路径优先、Dart
-  /// 播放器兜底（autoReadWordUnified 单一真相）。返回是否真的出声，供协调器在
-  /// 静默失败时释放 800ms 去重窗（BUG-1127）。
-  Future<bool> _playWordAudio(
-          AppModel model, String expression, String reading) =>
-      autoReadWordUnified(
-        model,
-        expression,
-        reading,
-        playInWebView: _playWordAudioUrlInOverlay,
-      );
-
-  /// popup.js 侧 `audio.play()` 结果最长等待（与 in-app
-  /// DictionaryPopupWebView._kWordAudioPlayReportTimeout 同值同语义）。
-  static const Duration _kWordAudioPlayReportTimeout = Duration(seconds: 5);
-
-  int _wordAudioPlayToken = 0;
-  final Map<int, Completer<bool>> _pendingWordAudioPlays =
-      <int, Completer<bool>>{};
-
-  /// BUG-1127 — 在浮窗常驻 ROOT iframe 的 popup.js realm 里播放已解析的 URL，
-  /// 回报 `audio.play()` 的真实结果（token + Completer + 5s 超时，镜像 in-app
-  /// DictionaryPopupWebView.playWordAudioUrl 的 BUG-1093 契约）。目标固定为
-  /// 稳定 root 帧（TODO-1095 常驻复用、启动即预热）：音频与 realm 无关，任何
-  /// 已加载 realm 都能播，root 恒暖故无冷 iframe 等待。false = WebView 没播成
-  /// （未就绪/JS 缺失/autoplay 拒绝/超时），调用方回落 Dart 播放器。
-  ///
-  /// 发送前用 isWebViewReady 门控：native 的 render 通道在 surface 未就绪时按
-  /// last-wins 缓存脚本，直接盲发会把挂起中的整栈渲染脚本顶掉（卡片永不出现）。
-  Future<bool> _playWordAudioUrlInOverlay(String url) async {
-    if (url.isEmpty) {
-      return false;
-    }
-    if (!await GlobalLookupChannel.isWebViewReady()) {
-      return false;
-    }
-    final int token = ++_wordAudioPlayToken;
-    final Completer<bool> completer = Completer<bool>();
-    _pendingWordAudioPlays[token] = completer;
-    try {
-      await GlobalLookupChannel.render(
-          buildPlayWordAudioScript(kGlobalLookupRootFrameId, url, token));
-      final bool ok =
-          await completer.future.timeout(_kWordAudioPlayReportTimeout);
-      glog('autoread: webview play token=$token ok=$ok');
-      return ok;
-    } on TimeoutException {
-      glog('autoread: webview play token=$token TIMEOUT');
-      return false;
-    } catch (e) {
-      glog('autoread: webview play token=$token EXCEPTION $e');
-      return false;
-    } finally {
-      _pendingWordAudioPlays.remove(token);
-    }
-  }
+  void _autoReadFirstEntry(AppModel model, DictionarySearchResult result) =>
+      _autoRead.autoReadFirstEntry(model, result);
 
   Future<void> _lookupNested(String query, Rect? anchorRect) async {
     final AppModel? model = _appModel;

--- a/hibiki/lib/src/lookup/overlay_auto_read.dart
+++ b/hibiki/lib/src/lookup/overlay_auto_read.dart
@@ -1,0 +1,159 @@
+// BUG-1210 — app 外两个 WebView2 表面（瞬态查词覆盖窗 / 常驻剪贴板面板）共用的
+// 「查词后自动朗读」权威实现，从 GlobalLookupController 原样提出。
+//
+// 与 overlay_bridge_handlers.dart 同一条红线：两个表面的行为不得漂开，故收口成
+// 一份共享实现，绝不复制。此前自动朗读**只在瞬态覆盖窗上接了线**，剪贴板面板
+// （galgame / 复制文本流的主力表面）整条路径没有任何朗读调用——同一个全局开关
+// `autoReadOnLookup` 在一个表面生效、另一个表面完全无效，用户表现为「查词不读，
+// 必须手动点 ♪」。
+
+import 'dart:async';
+
+import 'package:hibiki/src/lookup/global_lookup_log.dart';
+import 'package:hibiki/src/lookup/global_lookup_render.dart';
+import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart';
+import 'package:hibiki/src/utils/misc/lookup_auto_read_coordinator.dart';
+import 'package:hibiki_dictionary/hibiki_dictionary.dart';
+
+/// 表面注入的「整栈渲染通道」：把脚本送进该表面的 WebView2。
+typedef OverlayScriptRunner = Future<void> Function(String script);
+
+/// 表面注入的「WebView 是否已就绪」门控。
+typedef OverlayReadinessProbe = Future<bool> Function();
+
+/// app 外表面的自动朗读控制器。每个表面持有**自己的**实例（token 与 pending 表
+/// 各自独立，两个窗口的播放回报不会串），但走同一份逻辑。
+class OverlayAutoRead {
+  OverlayAutoRead({
+    required OverlayScriptRunner render,
+    required OverlayReadinessProbe isWebViewReady,
+    required String label,
+  })  : _render = render,
+        _isWebViewReady = isWebViewReady,
+        _label = label;
+
+  final OverlayScriptRunner _render;
+  final OverlayReadinessProbe _isWebViewReady;
+
+  /// 日志前缀（`overlay` / `panel`），让两个表面的 autoread 记录能分辨来源。
+  final String _label;
+
+  /// popup.js 侧 `audio.play()` 结果最长等待（与 in-app
+  /// DictionaryPopupWebView._kWordAudioPlayReportTimeout 同值同语义）。
+  static const Duration _kWordAudioPlayReportTimeout = Duration(seconds: 5);
+
+  int _wordAudioPlayToken = 0;
+  final Map<int, Completer<bool>> _pendingWordAudioPlays =
+      <int, Completer<bool>>{};
+
+  /// 查到词后按用户「自动朗读」(autoReadOnLookup) 偏好自动发音。
+  /// 复用主 Dart 查词链路同一去重协调器 (LookupAutoReadCoordinator)，播放走与
+  /// in-app 相同的统一契约 autoReadWordUnified（BUG-1127）：优先驱动表面自己的
+  /// HTML5 `<audio>` 快路径（与手动 ♪ 同一 popup.js playWordAudio，桌面不再每播
+  /// 一次 libmpv stop→load→play），播放结果经 wordAudioPlayed 桥真实回报，失败/
+  /// 超时回落 Dart 播放器（受 BUG-1015 warmUp 保护），绝不静默丢发音。
+  void autoReadFirstEntry(AppModel model, DictionarySearchResult result) {
+    if (!ReaderHibikiSource.instance.autoReadOnLookup) {
+      return;
+    }
+    if (result.entries.isEmpty) {
+      return;
+    }
+    final DictionaryEntry entry = result.entries.first;
+    final String expression = entry.word;
+    final String reading = entry.reading;
+    if (expression.isEmpty) {
+      return;
+    }
+    unawaited(LookupAutoReadCoordinator.instance.runAutomatic(
+      expression: expression,
+      reading: reading,
+      play: () => _playWordAudio(model, expression, reading),
+    ));
+  }
+
+  /// 与 in-app _playAutoReadWord 同构：解析一次 ref，WebView 快路径优先、Dart
+  /// 播放器兜底（autoReadWordUnified 单一真相）。返回是否真的出声，供协调器在
+  /// 静默失败时释放 800ms 去重窗（BUG-1127）。
+  Future<bool> _playWordAudio(
+          AppModel model, String expression, String reading) =>
+      autoReadWordUnified(
+        model,
+        expression,
+        reading,
+        playInWebView: playWordAudioUrl,
+      );
+
+  /// BUG-1127 — 在表面常驻 ROOT iframe 的 popup.js realm 里播放已解析的 URL，
+  /// 回报 `audio.play()` 的真实结果（token + Completer + 5s 超时，镜像 in-app
+  /// DictionaryPopupWebView.playWordAudioUrl 的 BUG-1093 契约）。目标固定为
+  /// 稳定 root 帧（TODO-1095 常驻复用、启动即预热）：音频与 realm 无关，任何
+  /// 已加载 realm 都能播，root 恒暖故无冷 iframe 等待。false = WebView 没播成
+  /// （未就绪/JS 缺失/autoplay 拒绝/超时），调用方回落 Dart 播放器。
+  ///
+  /// 发送前用 isWebViewReady 门控：native 的 render 通道在 surface 未就绪时按
+  /// last-wins 缓存脚本，直接盲发会把挂起中的整栈渲染脚本顶掉（卡片永不出现）。
+  Future<bool> playWordAudioUrl(String url) async {
+    if (url.isEmpty) {
+      return false;
+    }
+    if (!await _isWebViewReady()) {
+      return false;
+    }
+    final int token = ++_wordAudioPlayToken;
+    final Completer<bool> completer = Completer<bool>();
+    _pendingWordAudioPlays[token] = completer;
+    try {
+      await _render(
+          buildPlayWordAudioScript(kGlobalLookupRootFrameId, url, token));
+      final bool ok =
+          await completer.future.timeout(_kWordAudioPlayReportTimeout);
+      glog('autoread($_label): webview play token=$token ok=$ok');
+      return ok;
+    } on TimeoutException {
+      glog('autoread($_label): webview play token=$token TIMEOUT');
+      return false;
+    } catch (e) {
+      glog('autoread($_label): webview play token=$token EXCEPTION $e');
+      return false;
+    } finally {
+      _pendingWordAudioPlays.remove(token);
+    }
+  }
+
+  /// 表面 iframe realm 回报自动发音 `audio.play()` 真实结果
+  /// （args = [token, ok, reason?]，host 包裹桥盖 __frameId 后原样转发）。
+  /// 完成对应 pending Completer；过期 token（已超时回落）直接忽略。
+  ///
+  /// 返回 true = 已处理（调用方 `_onJsMessage` 直接 return）。
+  bool maybeHandleWordAudioPlayed(
+      Object? handler, Map<String, Object?> message) {
+    if (handler != 'wordAudioPlayed') {
+      return false;
+    }
+    final Object? args = message['args'];
+    if (args is List && args.length >= 2) {
+      final Object? rawToken = args[0];
+      final int? token =
+          rawToken is num ? rawToken.toInt() : int.tryParse('$rawToken');
+      if (token != null) {
+        final bool ok = args[1] == true;
+        // BUG-1204：失败原因（args[2]，旧 host 不带 → 空）落日志。没有它，
+        // 「首播必失败」只是一个 false，分不清 autoplay 拦截 / 解码失败 / 被掐断，
+        // 而这三种的根因修法完全不同。成功不记，避免刷屏。
+        if (!ok) {
+          final String reason = (args.length >= 3 ? '${args[2]}' : '').trim();
+          glog('autoread($_label): webview play token=$token FAILED '
+              'reason=${reason.isEmpty ? 'unreported' : reason}');
+        }
+        final Completer<bool>? completer = _pendingWordAudioPlays.remove(token);
+        if (completer != null && !completer.isCompleted) {
+          completer.complete(ok);
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+983
+version: 1.3.1+984
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/lookup/global_lookup_autoread_webview_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_autoread_webview_guard_test.dart
@@ -58,10 +58,16 @@ void main() {
       // A missing/unloaded frame must resolve the Dart completer immediately
       // (postToHost false) instead of leaving it to the 5s timeout.
       expect(js.contains('record?.loaded'), isTrue);
+      // BUG-1201: the report now carries a THIRD arg — the failure reason — so
+      // an unloaded frame is distinguishable from an autoplay rejection in the
+      // log. Anchor on the prefix so the reason string stays free to evolve;
+      // the guarded intent (immediate false, no 5s timeout) is unchanged.
       expect(
-        js.contains("postToHost('wordAudioPlayed', [token, false])"),
+        js.contains("postToHost('wordAudioPlayed', [token, false,"),
         isTrue,
       );
+      expect(js.contains('FrameNotLoaded'), isTrue,
+          reason: 'an unloaded frame must report its own distinct reason');
     });
 
     test('iframe realm plays via __hibikiPlayWordAudioUrl and reports back',

--- a/hibiki/test/lookup/global_lookup_m1a_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_m1a_guard_test.dart
@@ -22,26 +22,36 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   String read(String p) => File(p).readAsStringSync();
 
+  // BUG-1210 — 自动朗读的实现搬进共享 `overlay_auto_read.dart`（app 外两个表面
+  // 共用，剪贴板面板此前整条路径没接线）。本组守的意图一字未改，只是实现细节现在
+  // 落在共享文件里：接线（controller）与实现（shared）分开扫。
   group('M1a-1 autoRead wiring (global lookup controller)', () {
     late String src;
+    late String shared;
     setUpAll(() {
       src = read('lib/src/lookup/global_lookup_controller.dart');
+      shared = read('lib/src/lookup/overlay_auto_read.dart');
     });
 
     test('uses the shared LookupAutoReadCoordinator', () {
       expect(
-        src.contains(
+        shared.contains(
             "import 'package:hibiki/src/utils/misc/lookup_auto_read_coordinator.dart';"),
         isTrue,
         reason: 'must import the shared dedupe coordinator',
       );
-      expect(src.contains('LookupAutoReadCoordinator.instance.runAutomatic('),
+      expect(
+          shared.contains('LookupAutoReadCoordinator.instance.runAutomatic('),
           isTrue);
+      // 控制器仍须真的接上这条线（否则共享实现形同虚设）。
+      expect(src.contains('OverlayAutoRead('), isTrue,
+          reason: 'the controller must wire up the shared implementation');
+      expect(src.contains('_autoRead.autoReadFirstEntry('), isTrue);
     });
 
     test('autoRead is gated on the autoReadOnLookup preference', () {
-      expect(
-          src.contains('ReaderHibikiSource.instance.autoReadOnLookup'), isTrue);
+      expect(shared.contains('ReaderHibikiSource.instance.autoReadOnLookup'),
+          isTrue);
     });
 
     test('play step goes through the unified fast path (BUG-1127)', () {
@@ -51,22 +61,24 @@ void main() {
       // back to the Dart player on a REPORTED failure. The controller must not
       // re-grow its own resolve + playAudioRef fork (the pre-BUG-1127 slow
       // path: libmpv stop→load→play per play, silent failures).
-      expect(src.contains('autoReadWordUnified('), isTrue);
-      expect(src.contains('playInWebView: _playWordAudioUrlInOverlay'), isTrue);
-      expect(
-        src.contains('TtsChannel.instance.playAudioRef('),
-        isFalse,
-        reason: 'the Dart fallback lives INSIDE autoReadWordUnified with the '
-            'already-resolved ref; a direct playAudioRef here would re-fork '
-            'the overlay off the unified path (BUG-1127 regression)',
-      );
-      // Must not bypass the unified helper via the all-in-one shortcut.
-      expect(
-        src.contains('playLookupAudio('),
-        isFalse,
-        reason: 'global lookup must reuse autoReadWordUnified, not the '
-            'playLookupAudio shortcut that skips the WebView fast path',
-      );
+      expect(shared.contains('autoReadWordUnified('), isTrue);
+      expect(shared.contains('playInWebView: playWordAudioUrl'), isTrue);
+      for (final String s in <String>[src, shared]) {
+        expect(
+          s.contains('TtsChannel.instance.playAudioRef('),
+          isFalse,
+          reason: 'the Dart fallback lives INSIDE autoReadWordUnified with the '
+              'already-resolved ref; a direct playAudioRef here would re-fork '
+              'the overlay off the unified path (BUG-1127 regression)',
+        );
+        // Must not bypass the unified helper via the all-in-one shortcut.
+        expect(
+          s.contains('playLookupAudio('),
+          isFalse,
+          reason: 'global lookup must reuse autoReadWordUnified, not the '
+              'playLookupAudio shortcut that skips the WebView fast path',
+        );
+      }
     });
 
     test('BUG-1127: WebView play reports the real audio.play() outcome', () {
@@ -74,23 +86,28 @@ void main() {
       // contract (BUG-1093): the Dart side must consume a REAL result — no
       // fire-and-forget (silent swallow) and no unconditional fallback (double
       // playback).
-      expect(src.contains("handler == 'wordAudioPlayed'"), isTrue);
-      expect(src.contains('_pendingWordAudioPlays'), isTrue);
-      expect(src.contains('completer.future.timeout'), isTrue);
+      expect(shared.contains("handler != 'wordAudioPlayed'"), isTrue,
+          reason: 'the shared handler must still dispatch on wordAudioPlayed');
+      expect(src.contains('_autoRead.maybeHandleWordAudioPlayed('), isTrue,
+          reason:
+              'the controller must route the report into the shared handler');
+      expect(shared.contains('_pendingWordAudioPlays'), isTrue);
+      expect(shared.contains('completer.future.timeout'), isTrue);
       // The play script must target the STABLE root frame (always warm after
       // prewarm; TODO-1095) and be gated on webview readiness — the native
       // render channel caches scripts last-wins while the surface is not
       // ready, so an ungated play script would clobber a pending stack render.
-      expect(src.contains('buildPlayWordAudioScript('), isTrue);
-      expect(src.contains('kGlobalLookupRootFrameId'), isTrue);
-      expect(src.contains('GlobalLookupChannel.isWebViewReady()'), isTrue);
+      expect(shared.contains('buildPlayWordAudioScript('), isTrue);
+      expect(shared.contains('kGlobalLookupRootFrameId'), isTrue);
+      expect(shared.contains('_isWebViewReady()'), isTrue);
     });
 
     test('autoRead fires on both first lookup and nested re-lookup', () {
       expect(
         '_autoReadFirstEntry('.allMatches(src).length,
         greaterThanOrEqualTo(3),
-        reason: 'one definition + two call sites (_onHotKey + _lookupNested)',
+        reason: 'one delegating wrapper + two call sites '
+            '(_onHotKey + _lookupNested)',
       );
     });
   });

--- a/hibiki/test/lookup/overlay_auto_read_parity_test.dart
+++ b/hibiki/test/lookup/overlay_auto_read_parity_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1210 守卫：app 外两个 WebView2 表面（瞬态查词覆盖窗 / 常驻剪贴板面板）
+/// 必须**都**接自动朗读，且走**同一份**实现。
+///
+/// 根因：自动朗读此前只在 `global_lookup_controller` 里接了线，
+/// `clipboard_panel_controller` 整条路径没有任何朗读调用——同一个全局开关
+/// `autoReadOnLookup` 在一个表面生效、在另一个完全无效，用户表现为「面板查词
+/// 不读，必须手动点 ♪」。而剪贴板面板正是 galgame / 复制文本流的主力表面。
+///
+/// 这条链路的运行时依赖是真实 WebView2 + native channel，widget 测试跑不起来，
+/// 故守在源码层（与 `overlay_bridge_handlers` 的「绝不复制」红线同一层保护）。
+///
+/// flutter test 的 cwd 是 hibiki 包根。
+void main() {
+  final String panel =
+      File('lib/src/lookup/clipboard_panel_controller.dart').readAsStringSync();
+  final String overlay =
+      File('lib/src/lookup/global_lookup_controller.dart').readAsStringSync();
+  final String shared =
+      File('lib/src/lookup/overlay_auto_read.dart').readAsStringSync();
+
+  test('剪贴板面板查到词后触发自动朗读（BUG-1210 的核心缺失）', () {
+    expect(panel.contains('autoReadFirstEntry('), true,
+        reason: '面板查词成功路径必须调用 autoReadFirstEntry，'
+            '否则 autoReadOnLookup 开关对面板完全无效（BUG-1210）');
+  });
+
+  test('面板接住播放回报，否则每次自动发音都空耗满 5s 超时', () {
+    expect(panel.contains('maybeHandleWordAudioPlayed('), true,
+        reason: '面板的 _onJsMessage 必须处理 wordAudioPlayed，'
+            '否则 Completer 永远等不到回报、每次都要等满超时才回落 Dart 播放器');
+  });
+
+  test('两个表面共用同一份实现，不得各写一份', () {
+    for (final ({String name, String src}) surface
+        in <({String name, String src})>[
+      (name: '剪贴板面板', src: panel),
+      (name: '瞬态覆盖窗', src: overlay),
+    ]) {
+      expect(surface.src.contains('OverlayAutoRead('), true,
+          reason: '${surface.name}必须使用共享的 OverlayAutoRead');
+      // 私有副本的标志物：自己维护 token / pending 表 / 播放脚本，
+      // 正是 BUG-1210 之前两个表面漂开的形态。
+      expect(surface.src.contains('_pendingWordAudioPlays'), false,
+          reason: '${surface.name}不得自己维护 pending 表——收口到共享实现');
+      expect(surface.src.contains('buildPlayWordAudioScript('), false,
+          reason: '${surface.name}不得自己拼播放脚本——收口到共享实现');
+    }
+  });
+
+  test('共享实现保留既有播放契约（WebView 快路径 + 就绪门控 + 超时回落）', () {
+    expect(shared.contains('autoReadWordUnified('), true,
+        reason: '播放必须走 autoReadWordUnified 单一真相（WebView 快路径 + Dart 兜底）');
+    expect(shared.contains('LookupAutoReadCoordinator.instance.runAutomatic('),
+        true,
+        reason: '必须复用同一去重协调器，避免被动剪贴板流重复同词连读');
+    expect(shared.contains('_isWebViewReady()'), true,
+        reason: '发播放脚本前必须过就绪门控，否则会顶掉挂起中的整栈渲染脚本');
+    expect(shared.contains('autoReadOnLookup'), true, reason: '必须尊重用户的自动朗读开关');
+  });
+}

--- a/hibiki/test/lookup/overlay_auto_read_parity_test.dart
+++ b/hibiki/test/lookup/overlay_auto_read_parity_test.dart
@@ -15,12 +15,23 @@ import 'package:flutter_test/flutter_test.dart';
 ///
 /// flutter test 的 cwd 是 hibiki 包根。
 void main() {
-  final String panel =
-      File('lib/src/lookup/clipboard_panel_controller.dart').readAsStringSync();
-  final String overlay =
-      File('lib/src/lookup/global_lookup_controller.dart').readAsStringSync();
-  final String shared =
-      File('lib/src/lookup/overlay_auto_read.dart').readAsStringSync();
+  /// 剥掉整行 `//` 注释后再扫。讲「BUG-1210 之前长什么样」「这一步为什么不能省」的
+  /// 注释里必然写着下面要断言的每一个符号名，连注释一起扫等于让文档给自己背书：
+  /// 把真实实现删光、只留注释也照样绿。**变异实测证实过**——删掉共享实现里
+  /// `if (!ReaderHibikiSource.instance.autoReadOnLookup) return;`（即用户明确关掉
+  /// 自动朗读也照读不误）后，本测试原版仍然全绿。
+  String stripComments(String src) => src
+      .split('\n')
+      .where((String l) => !l.trimLeft().startsWith('//'))
+      .join('\n');
+
+  final String panel = stripComments(
+      File('lib/src/lookup/clipboard_panel_controller.dart')
+          .readAsStringSync());
+  final String overlay = stripComments(
+      File('lib/src/lookup/global_lookup_controller.dart').readAsStringSync());
+  final String shared = stripComments(
+      File('lib/src/lookup/overlay_auto_read.dart').readAsStringSync());
 
   test('剪贴板面板查到词后触发自动朗读（BUG-1210 的核心缺失）', () {
     expect(panel.contains('autoReadFirstEntry('), true,
@@ -60,5 +71,40 @@ void main() {
     expect(shared.contains('_isWebViewReady()'), true,
         reason: '发播放脚本前必须过就绪门控，否则会顶掉挂起中的整栈渲染脚本');
     expect(shared.contains('autoReadOnLookup'), true, reason: '必须尊重用户的自动朗读开关');
+  });
+
+  test('两个表面各自注入自己的 native 通道（不得共用一个）', () {
+    // 共享的是**逻辑**，不是通道：覆盖窗走 GlobalLookupChannel、面板走
+    // OverlayWindowChannel(_channel)。注错通道 = 播放脚本发进另一个窗口，
+    // 表现为「面板查词，声音从看不见的覆盖窗出」或干脆不响。
+    expect(overlay.contains("label: 'overlay'"), true,
+        reason: '覆盖窗必须用自己的 label，日志才分得清来源');
+    expect(overlay.contains('GlobalLookupChannel.render'), true,
+        reason: '覆盖窗必须注入自己的渲染通道');
+    expect(panel.contains("label: 'panel'"), true, reason: '面板必须用自己的 label');
+    expect(panel.contains('_channel.render'), true,
+        reason: '面板必须注入自己的渲染通道（OverlayWindowChannel），不得借用覆盖窗的');
+  });
+
+  test('面板朗读前必须核对 latest-wins 序号（不能读出已被顶掉的旧词）', () {
+    // 面板 update() 的契约是「每个 await 后核对 seq，过期即弃」（VN 流乱序守卫），
+    // 而朗读调用排在 _renderPanel 这个 await 之后。少这一句核对，被后一句顶掉的
+    // 旧查词仍会把**旧词**读出来——屏幕上是新句、耳朵里是上一句。面板正是被动
+    // 剪贴板流（galgame 台词 / texthooker）的主力表面，快速连续更新是它的常态。
+    // 覆盖窗没有 latest-wins 机制，故这是面板独有的契约，收口共享实现时最容易被
+    // 一起抹掉——本 PR 初版就漏了这一步。
+    final int callIdx = panel.indexOf('_autoRead.autoReadFirstEntry(');
+    expect(callIdx, greaterThanOrEqualTo(0),
+        reason: '面板必须调用 autoReadFirstEntry；守卫锚点失效请同步更新本测试');
+    // 判据必须是「**最后一个 await 之后**有核对」，不能是「往前 N 字符内有核对」——
+    // update() 里本来就有好几处 seq 核对（_showPanel / raise 分支各一处），固定窗口
+    // 会够到那些，删掉朗读前这一句照样绿（变异实测漏过一次）。
+    final String before = panel.substring(0, callIdx);
+    final int lastAwait = before.lastIndexOf('await ');
+    expect(lastAwait, greaterThanOrEqualTo(0),
+        reason: '朗读调用前应有 await（渲染）；守卫锚点失效请同步更新本测试');
+    expect(before.substring(lastAwait).contains('seq != _updateSeq'), true,
+        reason: '朗读调用与它前面最后一个 await 之间必须核对 latest-wins 序号，'
+            '否则被顶掉的旧查词会读出与屏幕不符的旧词（BUG-1210）');
   });
 }

--- a/hibiki/test/utils/misc/word_audio_failure_reason_guard_test.dart
+++ b/hibiki/test/utils/misc/word_audio_failure_reason_guard_test.dart
@@ -137,8 +137,11 @@ void main() {
               '否则首播失败仍只是一个光秃秃的 false（BUG-1204）');
     }
 
-    expectReasonLoggedNearHandler(
-        'lib/src/lookup/global_lookup_controller.dart');
+    // BUG-1210：app 外的 wordAudioPlayed 处理已收口进共享 OverlayAutoRead（瞬态
+    // 覆盖窗与剪贴板面板共用同一实现），故「原因落日志」这一环现在扫共享文件，
+    // 而不再是 global_lookup_controller（那里只剩一行委托）。窗口锚定的严格口径
+    // 保持不变。
+    expectReasonLoggedNearHandler('lib/src/lookup/overlay_auto_read.dart');
     expectReasonLoggedNearHandler(
         'lib/src/pages/implementations/dictionary_popup_webview.dart');
   });


### PR DESCRIPTION
承接 #525。用户装上 #525 的构建后实测反馈：「我查词了，但是没读音，点音频按钮才有正常吗」——**不正常**，而这正是他最初报的「单词音频响应巨慢」的真正来源之一。

## 根因

`clipboard_panel_controller.dart` 的 `update()` 查词成功后 `_seedRootFrame` → `_renderPanel` → glog「panel: updated」就结束了，**整条路径没有任何自动朗读调用**。

全仓 `autoReadWordUnified` / `LookupAutoReadCoordinator.runAutomatic` 的接入点只有三处：
- `global_lookup_controller.dart`（app 外瞬态查词覆盖窗）
- `base_source_page.dart`（app 内媒体页）
- `dictionary_page_mixin.dart`（app 内词典页）

**剪贴板面板是唯一漏接的查词表面**，而它正是 galgame / 复制文本流的主力表面。

用户偏好 `src:reader_ttu:auto_read_on_lookup` 实测为 `b:true`（`preferences` 与 `profile_settings` 两处一致）——开关是开着的，却在一个表面生效、在另一个完全无效。

用户机器日志佐证：07-28 全天 **52 次 `panel: updated`、0 次 autoread**；而 07-27 走瞬态浮窗那次 autoread 正常触发 token=1..6。

## 修复

自动朗读收口成共享 `lib/src/lookup/overlay_auto_read.dart`（`OverlayAutoRead`），app 外两个表面共用一份实现，各自注入自己的渲染通道与就绪门控、token 表独立。这与 `overlay_bridge_handlers.dart` 的九根 deferred 桥同一条红线：**两个表面的行为不得漂开，绝不复制**。

- `global_lookup_controller` 改为委托（原私有实现整段移出）
- `clipboard_panel_controller` 新增两处接线：
  1. `update()` 渲染完成后 `autoReadFirstEntry` —— 必须排在整栈渲染脚本**之后**，否则播放脚本会被同一 render 通道的 last-wins 顶掉
  2. `_onJsMessage` 接 `maybeHandleWordAudioPlayed` —— **不可省**，否则 Completer 永远等不到回报，每次自动发音都空耗满 5s 超时才回落 Dart 播放器

## 测试

- `test/lookup/overlay_auto_read_parity_test.dart`：面板须调 `autoReadFirstEntry`、须接住播放回报、两表面须共用同一实现（断言各自不再私有维护 `_pendingWordAudioPlays` / 自拼 `buildPlayWordAudioScript`）、共享实现须保留既有播放契约（统一快路径 + 去重协调器 + 就绪门控 + 开关门控）。
- 既有守卫随契约变更同步更新，**守的意图一字未改**：`global_lookup_m1a_guard_test` 改为分扫「接线 + 共享实现」；`global_lookup_autoread_webview_guard_test` 的 `[token, false]` 锚点改前缀匹配（#525 后回报多带第三个 reason 参数）；`word_audio_failure_reason_guard_test` 的 app 外路径改扫共享文件，**保留 #525 review 加固的窗口锚定口径**。
- 全量 `flutter analyze` 干净；test/lookup + test/utils/misc + test/mining **2127** 用例全绿。

## 说明

本分支基于最新 `origin/develop`（#525 已合并，BUG 号被 review 改为 1204/1205，本 PR 内引用已同步更正）。原分支 `worktree-perf-mining-audio-diag` 在 #525 合并后已被 review 侧推进，故另开分支避免「合并后追加的 commit 永不落地」。

BUG-1204 的首播失败（`token=1 ok=false`）是另一条独立线索，仍待用户复现后从日志读到确切 DOMException 名字再定案。

https://claude.ai/code/session_01XrA5E25MKrSw3HtSSN9SVa