### PR TITLE
refactor(import): 重复条目处置收敛成单参 DuplicatePolicy 三态 + 统一判据命名

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,9 @@
 | 墓碑删除时刻 | `deletedAt` | removedAt |
 | 媒体种类值域 | 各域独立枚举（`MediaKind`/`ActivityMediaKind`/`StatSourceKind`/`ProfileMediaKind`/`SyncTombstoneKind`/`SourceLibraryKind`/`SentenceSourceKind`），跨域换算走 `media_kind_mappings.dart`，禁 UI 层裸字符串比较/bool 降维 | — |
 | 搜索匹配 | `matchesMediaSearch`/`filterByMediaSearch`（统一归一化） | 裸 `toLowerCase().contains` 做用户可见搜索 |
+| 重复条目**处置策略** | 单参 `DuplicatePolicy` 三态：交互式单条 `.ask(cb)` / 批量后台 `.skip()` / 程序化留副本 `.suffix()`。三种差异**有意**（交互预算不同），不要再往一起合，但必须显式声明 | `bool skipIfExists` + `DuplicateTitleCallback?` 两参编码三态；`onDuplicateTitle` 作参数名 |
+| 重复**判据**（这东西是否已在库） | `isDuplicate*` / `filterOutDuplicate*` | `isVideoPathReferenced`、`filterDroppedGameExes` |
+| 用户对重复的选择 | `DuplicateChoice{suffix, cancel}`（与策略词同形） | `DuplicateTitleResolution{addSuffix, cancel}` |
 | i18n key | `<域>_<子域名词>_<动作/状态>`（动词在尾）+ 英文 sentence case；改名必须 `i18n_sync --rename` | 手改 json；新增 `games_`/`ttu_` 前缀 key |
 
 ## Galgame Hook 硬规则

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46308 (2724 per locale)
+/// Strings: 46427 (2731 per locale)
 ///
-/// Built on 2026-07-28 at 11:47 UTC
+/// Built on 2026-07-28 at 12:00 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3661,6 +3661,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   String get stat_source_breakdown => 'By source';
   String stat_format_pages({required Object n}) => '${n} pages';
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  String get manga_import_pick_file => 'Pick manga file';
+  String get manga_import_pick_folder => 'Pick manga folder';
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  String get manga_import_detected_title => 'This looks like manga';
+  String get manga_import_detected_confirm => 'Import as manga';
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -9894,6 +9903,22 @@ class _StringsAr extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -16195,6 +16220,22 @@ class _StringsDe extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -22512,6 +22553,22 @@ class _StringsEs extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -28840,6 +28897,22 @@ class _StringsFr extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -35097,6 +35170,22 @@ class _StringsId extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -41400,6 +41489,22 @@ class _StringsIt extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -47520,6 +47625,22 @@ class _StringsJa extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -53642,6 +53763,22 @@ class _StringsKo extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -59925,6 +60062,22 @@ class _StringsNl extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -66221,6 +66374,22 @@ class _StringsPtBr extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -72501,6 +72670,22 @@ class _StringsRu extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -78729,6 +78914,22 @@ class _StringsTh extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -84989,6 +85190,22 @@ class _StringsTr extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -91234,6 +91451,22 @@ class _StringsVi extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 // Path: <root>
@@ -97039,6 +97272,21 @@ class _StringsZhCn extends _StringsEn {
   String get stat_source_breakdown => '各来源';
   @override
   String stat_format_pages({required Object n}) => '${n} 页';
+  @override
+  String get manga_import_hint => '选择漫画文件夹、.cbz/.zip 页图压缩包，或 .mokuro 文件。';
+  @override
+  String get manga_import_pick_file => '选择漫画文件';
+  @override
+  String get manga_import_pick_folder => '选择漫画文件夹';
+  @override
+  String get manga_import_missing_input => '请先选择漫画文件或文件夹。';
+  @override
+  String get manga_import_detected_title => '这看起来是漫画';
+  @override
+  String get manga_import_detected_confirm => '按漫画导入';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
 }
 
 // Path: <root>
@@ -103080,6 +103328,22 @@ class _StringsZhHk extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String get manga_import_hint =>
+      'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+  @override
+  String get manga_import_pick_file => 'Pick manga file';
+  @override
+  String get manga_import_pick_folder => 'Pick manga folder';
+  @override
+  String get manga_import_missing_input => 'Pick a manga file or folder first.';
+  @override
+  String get manga_import_detected_title => 'This looks like manga';
+  @override
+  String get manga_import_detected_confirm => 'Import as manga';
+  @override
+  String manga_import_detected_message({required Object name}) =>
+      '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
 }
 
 /// Flat map(s) containing all translations.
@@ -108661,6 +108925,21 @@ extension on _StringsEn {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -114240,6 +114519,21 @@ extension on _StringsAr {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -119840,6 +120134,21 @@ extension on _StringsDe {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -125439,6 +125748,21 @@ extension on _StringsEs {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -131044,6 +131368,21 @@ extension on _StringsFr {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -136631,6 +136970,21 @@ extension on _StringsId {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -142233,6 +142587,21 @@ extension on _StringsIt {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -147797,6 +148166,21 @@ extension on _StringsJa {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -153365,6 +153749,21 @@ extension on _StringsKo {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -158960,6 +159359,21 @@ extension on _StringsNl {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -164552,6 +164966,21 @@ extension on _StringsPtBr {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -170149,6 +170578,21 @@ extension on _StringsRu {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -175730,6 +176174,21 @@ extension on _StringsTh {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -181320,6 +181779,21 @@ extension on _StringsTr {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -186905,6 +187379,21 @@ extension on _StringsVi {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }
@@ -192444,6 +192933,20 @@ extension on _StringsZhCn {
         return '各来源';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} 页';
+      case 'manga_import_hint':
+        return '选择漫画文件夹、.cbz/.zip 页图压缩包，或 .mokuro 文件。';
+      case 'manga_import_pick_file':
+        return '选择漫画文件';
+      case 'manga_import_pick_folder':
+        return '选择漫画文件夹';
+      case 'manga_import_missing_input':
+        return '请先选择漫画文件或文件夹。';
+      case 'manga_import_detected_title':
+        return '这看起来是漫画';
+      case 'manga_import_detected_confirm':
+        return '按漫画导入';
+      case 'manga_import_detected_message':
+        return ({required Object name}) => '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
       default:
         return null;
     }
@@ -198003,6 +198506,21 @@ extension on _StringsZhHk {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'manga_import_hint':
+        return 'Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.';
+      case 'manga_import_pick_file':
+        return 'Pick manga file';
+      case 'manga_import_pick_folder':
+        return 'Pick manga folder';
+      case 'manga_import_missing_input':
+        return 'Pick a manga file or folder first.';
+      case 'manga_import_detected_title':
+        return 'This looks like manga';
+      case 'manga_import_detected_confirm':
+        return 'Import as manga';
+      case 'manga_import_detected_message':
+        return ({required Object name}) =>
+            '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "字幕：未匹配到（可手动补）",
   "download_backend_desktop_only_note": "内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。",
   "stat_source_breakdown": "各来源",
-  "stat_format_pages": "$n 页"
+  "stat_format_pages": "$n 页",
+  "manga_import_hint": "选择漫画文件夹、.cbz/.zip 页图压缩包，或 .mokuro 文件。",
+  "manga_import_pick_file": "选择漫画文件",
+  "manga_import_pick_folder": "选择漫画文件夹",
+  "manga_import_missing_input": "请先选择漫画文件或文件夹。",
+  "manga_import_detected_title": "这看起来是漫画",
+  "manga_import_detected_confirm": "按漫画导入",
+  "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2722,5 +2722,12 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "manga_import_hint": "Pick a manga folder, a .cbz/.zip page archive, or a .mokuro file.",
+  "manga_import_pick_file": "Pick manga file",
+  "manga_import_pick_folder": "Pick manga folder",
+  "manga_import_missing_input": "Pick a manga file or folder first.",
+  "manga_import_detected_title": "This looks like manga",
+  "manga_import_detected_confirm": "Import as manga",
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
 }

--- a/hibiki/lib/main.dart
+++ b/hibiki/lib/main.dart
@@ -970,7 +970,7 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
     try {
       // ② 去重：同一物理文件若已库内导入（`video/<basename>` 身份），复用其旧
       // bookUid，不再派生 `video/ext/<sha1>` 第二身份插第二行。按 videoPath 命中
-      // 走仓库单一真相源 findByVideoPath（与 isVideoPathReferenced 同比对语义）。
+      // 走仓库单一真相源 findByVideoPath（与 isDuplicateVideoPath 同比对语义）。
       final VideoBookRow? sameFile = await repo.findByVideoPath(videoPath);
       if (sameFile != null) {
         bookUid = sameFile.bookUid;

--- a/hibiki/lib/src/epub/book_title_conflict.dart
+++ b/hibiki/lib/src/epub/book_title_conflict.dart
@@ -1,10 +1,17 @@
 import 'package:hibiki/src/sync/ttu_filename.dart';
 
-/// 用户对"检测到同名书籍"弹窗的选择。
-enum DuplicateTitleResolution { addSuffix, cancel }
+/// 用户对「检测到同名书籍」弹窗的选择。
+///
+/// 值域与 [DuplicatePolicy] 的策略词对齐（`suffix` / `cancel`），不再叫
+/// `addSuffix`——同一个概念在策略侧叫 suffix、在选择侧叫 addSuffix，读代码时要
+/// 多绕一次。
+enum DuplicateChoice { suffix, cancel }
 
-/// 用户选择"否/取消添加这本书"时由 [resolveBookTitleConflict] 抛出，
+/// 用户选择「否/取消添加这本书」时由 [resolveDuplicateTitle] 抛出，
 /// 供导入流程干净地中止（不当作错误）。
+///
+/// [DuplicatePolicy.skip] 命中时也抛它——批量路径把「跳过」表达成同一个中止信号，
+/// 上层 `runImport(isCancelled:)` 已按取消（而非错误）处理，无需第二套通道。
 class DuplicateImportCancelledException implements Exception {
   const DuplicateImportCancelledException(this.title);
   final String title;
@@ -12,41 +19,88 @@ class DuplicateImportCancelledException implements Exception {
   String toString() => 'DuplicateImportCancelledException($title)';
 }
 
-/// 同名冲突回调：入参是拟用标题，返回用户选择。
-typedef DuplicateTitleCallback = Future<DuplicateTitleResolution> Function(
-  String proposedTitle,
-);
+/// 同名冲突询问回调：入参是拟用标题，返回用户选择。
+typedef AskOnDuplicate = Future<DuplicateChoice> Function(String proposedTitle);
+
+/// 重复条目的**处置策略**。三态互斥，且必须显式选一个。
+///
+/// ## 为什么是一个参数而不是两个
+///
+/// 此前这三态由 `(bool skipIfExists, AskOnDuplicate? onDuplicateTitle)` 两个参数
+/// 编码：`skipIfExists=true` → 跳过；回调非空 → 询问；两者都缺 → 加后缀。两个参数
+/// 有四种组合但只有三种合法，第四种（`skipIfExists=true` 且回调非空）的行为从没被
+/// 写下来过（实现里跳过赢），调用方只能靠读实现推理。而且哪个导入器支持哪个参数还不
+/// 齐：`importFromImageFolder` / `importArchive` 只有回调、没有 skip，于是批量扫描
+/// 压根用不了它们。
+///
+/// 收敛成一个 sealed 三态后：非法组合不可表达，[resolveDuplicateTitle] 里是穷尽
+/// switch（不写 default），将来加第四种策略会在所有分派点编译报错，而不是悄悄走进
+/// 某个 else。
+///
+/// ## 三种策略各自的适用场景（差异是**有意**的，不要再往一起合）
+///
+/// - [DuplicatePolicy.ask]：交互式**单条**导入（书籍/漫画导入对话框）。用户就在屏幕
+///   前，问得起，而且他确实想知道库里已经有一本同名的。
+/// - [DuplicatePolicy.skip]：**批量 / 后台**导入（来源库扫描、mokuro.moe 批量下载、
+///   torrent 下载完自动入库）。扫一个目录弹五十次框等于不可用（BUG-443）。
+/// - [DuplicatePolicy.suffix]：**程序化**路径（同步引擎拉书等）。没有人可问，又必须
+///   保住「本地不出现两本同 key 书」这个同步层依赖的不变量，只能留副本。
+sealed class DuplicatePolicy {
+  const DuplicatePolicy();
+
+  /// 交互式单条导入：把拟用标题交给用户裁决。
+  const factory DuplicatePolicy.ask(AskOnDuplicate ask) = AskDuplicate;
+
+  /// 批量 / 后台导入：命中已有条目直接跳过（抛
+  /// [DuplicateImportCancelledException]），既不加后缀也不询问。
+  const factory DuplicatePolicy.skip() = SkipDuplicate;
+
+  /// 静默留副本：自动加 ` (2)` 后缀。程序化路径的默认。
+  const factory DuplicatePolicy.suffix() = SuffixDuplicate;
+}
+
+/// [DuplicatePolicy.ask] 的实现类型。
+final class AskDuplicate extends DuplicatePolicy {
+  const AskDuplicate(this.ask);
+
+  /// 询问用户的回调。
+  final AskOnDuplicate ask;
+}
+
+/// [DuplicatePolicy.skip] 的实现类型。
+final class SkipDuplicate extends DuplicatePolicy {
+  const SkipDuplicate();
+}
+
+/// [DuplicatePolicy.suffix] 的实现类型。
+final class SuffixDuplicate extends DuplicatePolicy {
+  const SuffixDuplicate();
+}
 
 /// 返回最终入库标题。书籍跨设备身份 = `sanitizeTtuFilename(title)`（同步远端
-/// 文件夹 key）。若 [proposedTitle] 的身份 key 与 [existingTitles] 任一冲突：
-/// 有回调则询问——addSuffix 返回唯一后缀标题（`X (2)`），cancel 抛
-/// [DuplicateImportCancelledException]；无回调则自动加后缀（保持"本地不出现
-/// 两本同 key 书"这一同步层依赖的不变量，供后台同步/程序化调用安全使用）。
-///
-/// [skipIfExists] 为 true 时（文件夹扫描器的静默去重路径，BUG-443）：身份 key
-/// 命中已存在书时直接抛 [DuplicateImportCancelledException]（不加后缀、不询问），
-/// 让批量扫描像视频 `_importVideos` 那样静默跳过同名书，避免静默复制成 `X (2)`。
-/// 不影响单文件手动导入路径（默认 false，保留原弹窗/自动后缀语义）。
-Future<String> resolveBookTitleConflict({
+/// 文件夹 key）。[proposedTitle] 的身份 key 与 [existingTitles] 无冲突时原样返回；
+/// 冲突时按 [policy] 处置。
+Future<String> resolveDuplicateTitle({
   required List<String> existingTitles,
   required String proposedTitle,
-  DuplicateTitleCallback? onDuplicateTitle,
-  bool skipIfExists = false,
+  DuplicatePolicy policy = const DuplicatePolicy.suffix(),
 }) async {
   final Set<String> keys = existingTitles.map(sanitizeTtuFilename).toSet();
   if (!keys.contains(sanitizeTtuFilename(proposedTitle))) {
     return proposedTitle;
   }
-  if (skipIfExists) {
-    throw DuplicateImportCancelledException(proposedTitle);
-  }
-  if (onDuplicateTitle != null) {
-    final DuplicateTitleResolution res = await onDuplicateTitle(proposedTitle);
-    if (res == DuplicateTitleResolution.cancel) {
+  // 穷尽 switch，不写 default：加第四种策略时这里会编译报错，而不是悄悄落进某个分支。
+  switch (policy) {
+    case SkipDuplicate():
       throw DuplicateImportCancelledException(proposedTitle);
-    }
+    case AskDuplicate(:final AskOnDuplicate ask):
+      if (await ask(proposedTitle) == DuplicateChoice.cancel) {
+        throw DuplicateImportCancelledException(proposedTitle);
+      }
+      return _uniqueSuffixedTitle(proposedTitle, keys);
+    case SuffixDuplicate():
+      return _uniqueSuffixedTitle(proposedTitle, keys);
   }
-  return _uniqueSuffixedTitle(proposedTitle, keys);
 }
 
 String _uniqueSuffixedTitle(String base, Set<String> existingKeys) {

--- a/hibiki/lib/src/epub/epub_importer.dart
+++ b/hibiki/lib/src/epub/epub_importer.dart
@@ -26,7 +26,7 @@ class EpubImporter {
     required HibikiDatabase db,
     required Uint8List bytes,
     required String fileName,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
   }) async {
     final int tempId = DateTime.now().millisecondsSinceEpoch;
     final String tempDir = await EpubStorage.bookDirectory('.tmp-$tempId');
@@ -40,7 +40,7 @@ class EpubImporter {
       result: result,
       fileName: fileName,
       tempDir: tempDir,
-      onDuplicateTitle: onDuplicateTitle,
+      policy: policy,
     );
   }
 
@@ -51,13 +51,13 @@ class EpubImporter {
   static Future<String> importFromFile({
     required HibikiDatabase db,
     required String filePath,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
   }) async {
     return importFromPath(
       db: db,
       filePath: filePath,
       fileName: p.basename(filePath),
-      onDuplicateTitle: onDuplicateTitle,
+      policy: policy,
     );
   }
 
@@ -67,9 +67,8 @@ class EpubImporter {
     required HibikiDatabase db,
     required String filePath,
     required String fileName,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     int? sourceId,
-    bool skipIfExists = false,
   }) async {
     final int tempId = DateTime.now().millisecondsSinceEpoch;
     final String tempDir = await EpubStorage.bookDirectory('.tmp-$tempId');
@@ -83,9 +82,8 @@ class EpubImporter {
       result: result,
       fileName: fileName,
       tempDir: tempDir,
-      onDuplicateTitle: onDuplicateTitle,
+      policy: policy,
       sourceId: sourceId,
-      skipIfExists: skipIfExists,
     );
   }
 
@@ -103,9 +101,8 @@ class EpubImporter {
     required _ParseResult result,
     required String fileName,
     required String tempDir,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     int? sourceId,
-    bool skipIfExists = false,
   }) async {
     String? insertedKey;
     String extractDir = tempDir;
@@ -147,22 +144,21 @@ class EpubImporter {
               : book.title;
 
       final List<EpubBookRow> existingBooks = await db.getAllEpubBooks();
-      final String storedTitle = await resolveBookTitleConflict(
+      final String storedTitle = await resolveDuplicateTitle(
         existingTitles: existingBooks.map((EpubBookRow b) => b.title).toList(),
         proposedTitle: resolvedTitle,
-        onDuplicateTitle: onDuplicateTitle,
-        skipIfExists: skipIfExists,
+        policy: policy,
       );
 
       // bookKey is the EpubBooks primary key (= sanitized stored title). It is
-      // unique by construction (resolveBookTitleConflict guarantees no two
+      // unique by construction (resolveDuplicateTitle guarantees no two
       // local books share a sanitized key).
       final String bookKey = sanitizeTtuFilename(storedTitle);
 
       // Move the freshly-extracted temp dir to the key-named directory.
       //
       // BUG-564: the target dir may already exist on disk even though no live
-      // row owns the key (resolveBookTitleConflict guarantees key uniqueness
+      // row owns the key (resolveDuplicateTitle guarantees key uniqueness
       // against live rows): a crashed import or a failed post-delete disk
       // cleanup leaves an orphan dir, and Linux rename(2) onto a non-empty
       // target throws ENOTEMPTY (errno 39) -- e.g. re-downloading a remote

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -245,11 +245,17 @@ class _BookImportDialogState extends State<BookImportDialog>
   }
 
   /// 判定一个待导入路径的载体身份。文件系统判据在此注入，分类函数本身不碰 IO。
-  ImportCarrier _classifyCarrier(String path) => classifyImportCarrier(
-        path,
-        isDirectory: (String pth) => Directory(pth).existsSync(),
-        isImageArchive: MangaModule.isImageArchive,
-      );
+  ///
+  /// 走 [ImportCarrierResolver] 而不是每次裸调 `classifyImportCarrier`：同一路径在一次
+  /// 导入里会被问到三次（选中闸门 / `_doImport` 兜底闸门 / `_importEpubOnly` 分派），
+  /// 而 `.zip` / `.epub` 的定性要真开包，问三次就整包解压三次。有声书对齐路径尤其亏
+  /// ——它不进 `_importEpubOnly`，那几次开包纯属白开。记忆按路径失效，换文件会重算。
+  final ImportCarrierResolver _carrierResolver = ImportCarrierResolver(
+    isDirectory: (String pth) => Directory(pth).existsSync(),
+    isImageArchive: MangaModule.isImageArchive,
+  );
+
+  ImportCarrier _classifyCarrier(String path) => _carrierResolver.resolve(path);
 
   /// 拖文件进本对话框 → 分类 → 按字段覆盖（仅填命中类，不清用户已选）。
   /// 纯解析交给 [resolveBookDialogDrop]；此处只 setState + sidecar/封面副作用。

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/src/media/audiobook/audiobook_alignment_service.dart';
 import 'package:hibiki/src/media/audiobook/sasayaki_rematch.dart';
 import 'package:hibiki/src/media/audiobook/text_to_epub.dart';
 import 'package:hibiki/src/media/import/audiobook_health_summary.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
 import 'package:hibiki/src/media/import/import_dialog_frame.dart';
 import 'package:hibiki/src/media/import/import_flow_mixin.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
@@ -24,10 +25,9 @@ import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/epub/book_title_conflict.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/pdf/pdf_importer.dart';
-import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
-import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/utils.dart';
 
 /// 统一"导入书"对话框。EPUB、字幕、音频可按需组合，一次导入。
@@ -41,6 +41,10 @@ import 'package:hibiki/utils.dart';
 ///   [EpubParser] 读回章节文本，跑 [EpubSrtMatcher] + [SasayakiMatchCodec]，
 ///   把 cue 对齐到真实 EPUB；cues + 可选音频落到 [AudiobookRepository]。
 /// - **音频但无字幕**：非法组合，音频必须配合字幕使用。
+///
+/// **漫画不在此列**：漫画有独立入口与独立对话框 [MangaImportDialog]（载体不同，
+/// 可填字段就不同——漫画没有字幕/音频/对齐，书籍没有 OCR）。本框仍然**认得**漫画
+/// 载体，但只做一件事：弹一次明确确认后把路径转交漫画流程（[_handoffIfManga]）。
 class BookImportDialog extends StatefulWidget {
   const BookImportDialog({
     required this.repo,
@@ -49,8 +53,6 @@ class BookImportDialog extends StatefulWidget {
     this.initialEpubPath,
     this.initialSubtitlePath,
     this.initialAudioPaths,
-    this.mangaOcrRemoteRunner,
-    this.ocrEntryDesktopOverride,
     super.key,
   });
 
@@ -59,14 +61,6 @@ class BookImportDialog extends StatefulWidget {
   final HibikiDatabase db;
   final String? initialEpubPath;
   final String? initialSubtitlePath;
-
-  /// 漫画 P3 测试缝：注入远程 OCR runner（探测已配对 host 能力 + 代跑）。
-  /// null = 生产路径，按 [db] 惰性构造 [InterconnectMangaOcrClient]。
-  final MangaOcrRemoteRunner? mangaOcrRemoteRunner;
-
-  /// 漫画 P3 测试缝：覆盖「是否桌面平台」判定（widget 测试模拟移动端入口
-  /// gating）。null = 用真实 [isDesktopPlatform]。
-  final bool? ocrEntryDesktopOverride;
 
   /// 拖拽导入预填：随新书一起拖入的音频文件路径。EPUB+音频拖到书架空白处时透传，
   /// 否则丢失（书架 `importNewBook` 此前未携带 `files.audios`）。音频必配字幕，
@@ -105,18 +99,6 @@ class _BookImportDialogState extends State<BookImportDialog>
   String? _subtitleName;
 
   bool _pickerActive = false;
-
-  /// 远程 OCR runner（生产 = [InterconnectMangaOcrClient]；测试注 fake）。
-  late final MangaOcrRemoteRunner _mangaOcrRemoteRunner =
-      widget.mangaOcrRemoteRunner ??
-          InterconnectMangaOcrClient(repo: SyncRepository(widget.db));
-
-  bool get _ocrEntryDesktop =>
-      widget.ocrEntryDesktopOverride ?? isDesktopPlatform;
-
-  /// Google Lens is available on every supported app platform, so the manga
-  /// OCR entry no longer depends on a paired desktop host on mobile.
-  bool get _showOcrEntry => true;
 
   /// TODO-935 ①A：「引用原文件（不复制）」开关。仅桌面可见/可选；移动端
   /// file_picker 返回缓存临时副本，引用即指向会被清掉的文件，故恒 false。
@@ -206,15 +188,8 @@ class _BookImportDialogState extends State<BookImportDialog>
         title: Text(t.srt_import),
         content: _buildForm(),
         actions: [
-          // 「OCR 导入漫画」：桌面恒显示（内置 OCR / 外部 mokuro CLI 均桌面工具）；
-          // 移动端在探测到可代跑 OCR 的已配对 host 时也显示（漫画 P3 远程引擎）。
-          if (_showOcrEntry)
-            adaptiveDialogAction(
-              context: context,
-              onPressed: importing ? null : _openOcrWizard,
-              child: Text(t.manga_ocr_wizard_title),
-            ),
-          // 漫画「在线目录」入口已从书籍导入框移除（属漫画域，入口收敛到下载页）。
+          // 漫画入口（「OCR 导入漫画」/「在线目录」）均已移出书籍导入框：
+          // OCR 归 [MangaImportDialog]，在线目录归下载页。书籍框只做书。
           adaptiveDialogAction(
             context: context,
             onPressed: () => Navigator.pop(context),
@@ -226,30 +201,67 @@ class _BookImportDialogState extends State<BookImportDialog>
     );
   }
 
-  /// 打开 OCR 导入漫画向导：从 provider 取内置 OCR 服务、按当前偏好构造外部
-  /// mokuro runner（均桌面工具），再挂上远程「已配对主机」runner（移动端唯一
-  /// 引擎，桌面亦可作后备）；向导内选裸图片文件夹跑整卷 OCR 后无缝落库；成功
-  /// （返回 bookKey）则连同关闭本导入框并回传 true，让书架刷新。
-  Future<void> _openOcrWizard() async {
-    final String? bookKey = await MangaModule.openOcrImportWizard(
+  /// 选/拖进来的路径若其实是漫画载体，弹一次明确确认并转交 [MangaImportDialog]。
+  ///
+  /// 返回 `true` 表示「本路径已被漫画流程接手，书籍侧不要再收下它」——用户在确认
+  /// 框里点取消也算接手（不继续按书导入，那只会产出一本乱码书）。
+  ///
+  /// 为什么书籍入口还要认漫画：图片型 `.zip` / 扫描版 `.epub` 与词典包/普通电子书
+  /// 同形，拖到书架时分类层按扩展名归 books（它刻意不为每次拖 EPUB 白开一次包）。
+  /// 此前这里是**静默**转漫画导入；现在改成用户可见的一次确认——识别照旧，分派不
+  /// 再背着用户发生。
+  Future<bool> _handoffIfManga(String path) async {
+    if (!_classifyCarrier(path).isManga) return false;
+    final bool? go = await showAppDialog<bool>(
       context: context,
-      db: widget.db,
-      remoteRunner: _mangaOcrRemoteRunner,
-      desktop: _ocrEntryDesktop,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: Text(t.manga_import_detected_title),
+        content: Text(
+          t.manga_import_detected_message(name: p.basename(path)),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(t.dialog_cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(t.manga_import_detected_confirm),
+          ),
+        ],
+      ),
     );
-    if (bookKey != null && mounted) {
-      Navigator.pop(context, true);
+    if (go != true || !mounted) return true;
+
+    final bool? imported = await showAppDialog<bool>(
+      context: context,
+      builder: (_) => MangaImportDialog(db: widget.db, initialPath: path),
+    );
+    if (mounted) {
+      // 关掉书籍框并把漫画侧的导入结果透传出去，书架照常刷新。
+      Navigator.pop(context, imported == true);
     }
+    return true;
   }
+
+  /// 判定一个待导入路径的载体身份。文件系统判据在此注入，分类函数本身不碰 IO。
+  ImportCarrier _classifyCarrier(String path) => classifyImportCarrier(
+        path,
+        isDirectory: (String pth) => Directory(pth).existsSync(),
+        isImageArchive: MangaModule.isImageArchive,
+      );
 
   /// 拖文件进本对话框 → 分类 → 按字段覆盖（仅填命中类，不清用户已选）。
   /// 纯解析交给 [resolveBookDialogDrop]；此处只 setState + sidecar/封面副作用。
-  void _handleDialogDrop(List<String> paths, Offset _) {
+  Future<void> _handleDialogDrop(List<String> paths, Offset _) async {
     if (importing) return;
     final DroppedFiles files = classifyDroppedFiles(paths);
     final BookDialogDropResult r = resolveBookDialogDrop(files);
     if (r.isEmpty) return;
     final String? droppedEpub = r.epubPath;
+    // 拖进来的「书」其实是漫画（图片型 zip / 扫描版 epub）→ 确认后转交漫画流程。
+    if (droppedEpub != null && await _handoffIfManga(droppedEpub)) return;
+    if (!mounted) return;
     final bool gotAudio = r.audioPaths.isNotEmpty;
     setState(() {
       if (droppedEpub != null) {
@@ -444,8 +456,10 @@ class _BookImportDialogState extends State<BookImportDialog>
     // PDF 阅读器 Phase 1：PDF 走独立 PdfImporter（真渲染，不经 TextToEpub 文本转换），
     // 在 [_importEpubOnly] 里按 .pdf 扩展名分支。
     'pdf',
-    // 漫画（第三种书）：`.mokuro`（v0.2+）+ 同级图片走独立 MangaImporter，落库 format='manga'，
-    // 在 [_importEpubOnly] 里按 .mokuro 扩展名分支（须在 TextToEpub 文本转换之前早退）。
+    // 漫画扩展名仍留在书籍选择器里，但**不再由本框导入**：选中后 [_handoffIfManga]
+    // 弹一次确认并转交 [MangaImportDialog]。留着是为了不打断老习惯——用户从书架
+    // 「导入书籍」里选到一本漫画时，得到的是一句「这是漫画」而不是「格式不支持」。
+    // `.zip` / `.epub` 无论如何都得留（图片型压缩包与词典包/普通电子书同形）。
     'mokuro',
     'cbz',
     'zip',
@@ -463,6 +477,9 @@ class _BookImportDialogState extends State<BookImportDialog>
       final PlatformFile? file = result?.files.single;
       final String? path = file?.path;
       if (path != null && file != null && mounted) {
+        // 选中的其实是漫画载体 → 明确确认后转交漫画流程，不再静默按书导入。
+        if (await _handoffIfManga(path)) return;
+        if (!mounted) return;
         setState(() {
           _epubPath = path;
           _epubName = file.name;
@@ -771,6 +788,12 @@ class _BookImportDialogState extends State<BookImportDialog>
       HibikiToast.show(msg: t.srt_import_missing_input);
       return;
     }
+    // 兜底闸门：选/拖两条入口在收下路径时就已过 [_handoffIfManga]，但 initialEpubPath
+    // 是构造参数直接塞进来的（书架拖入决策层刻意不为每个 EPUB 开包，图片型 .epub 会
+    // 以 books 身份到达这里）。同一个闸门在此再守一次，漫画绝不会走进书籍导入分支。
+    final String? epubPath = _epubPath;
+    if (epubPath != null && await _handoffIfManga(epubPath)) return;
+    if (!mounted) return;
     if (_epubPath != null && !_hasSubtitles && _audioPaths.isNotEmpty) {
       HibikiToast.show(msg: t.srt_import_audio_needs_subtitle);
       return;
@@ -941,35 +964,15 @@ class _BookImportDialogState extends State<BookImportDialog>
     final File file = File(_epubPath!);
 
     reportProgress(0.2, t.import_step_reading);
-    final String ext = p.extension(_epubPath!).toLowerCase();
 
-    // 漫画页图**目录**（拖入一个漫画文件夹）：整目录导入，OCR blocks 留空。
-    // 必须在所有按扩展名分派的分支之前——目录没有扩展名（目录名带点时 p.extension
-    // 还会误取出一个假扩展名），落到下面任何一条文件分支都会失败。
-    if (Directory(_epubPath!).existsSync()) {
-      reportProgress(0.5, t.import_step_importing_epub);
-      await MangaModule.importImageFolder(
-        db: widget.db,
-        path: _epubPath!,
-        title: title,
-        onDuplicateTitle: _onDuplicateTitle,
-        onProgress: (int done, int total) {
-          if (total > 0) {
-            reportProgress(
-              (done / total).clamp(0.0, 1.0),
-              t.import_step_copying_file(name: p.basename(_epubPath!)),
-            );
-          }
-        },
-      );
-      reportProgress(1, t.import_step_done);
-      return;
-    }
+    // 载体身份此前是在这里靠 4 个 if（含一次真读包）现场嗅出来的；现在它在**选中
+    // 文件那一刻**就已由 [classifyImportCarrier] 定死，且漫画载体根本进不来（三个
+    // 入口都过 [_handoffIfManga]）。这里只剩书籍侧的三种去向。
+    final ImportCarrier carrier = _classifyCarrier(_epubPath!);
 
-    // PDF 阅读器 Phase 1：.pdf 走独立 PdfImporter（pdfrx 真渲染 + 落库 format='pdf'），
-    // 必须在下面的 TextToEpub 文本转换分支之前早退——否则 PDF 二进制会被当文本转成乱码
-    // EPUB。PDF 封面在 PdfImporter 内栅格化首页得到，故不走 _applyBestCoverToEpub。
-    if (ext == '.pdf') {
+    // PDF 阅读器 Phase 1：.pdf 走独立 PdfImporter（pdfrx 真渲染 + 落库 format='pdf'）。
+    // PDF 封面在 PdfImporter 内栅格化首页得到，故不走 _applyBestCoverToEpub。
+    if (carrier == ImportCarrier.pdf) {
       reportProgress(0.5, t.import_step_importing_epub);
       await PdfImporter.importFromPath(
         db: widget.db,
@@ -982,54 +985,8 @@ class _BookImportDialogState extends State<BookImportDialog>
       return;
     }
 
-    // 漫画（第三种书）：.mokuro 走独立 MangaImporter（拷图 + 写 manga.json + 落库
-    // format='manga'），同样须在 TextToEpub 文本转换分支之前早退——否则 .mokuro 的 JSON 会被
-    // 当纯文本转成 EPUB。封面由 MangaImporter 取首页页图，故不走 _applyBestCoverToEpub。
-    if (ext == '.mokuro') {
-      reportProgress(0.5, t.import_step_importing_epub);
-      await MangaModule.importMokuro(
-        db: widget.db,
-        path: _epubPath!,
-        title: title,
-        onDuplicateTitle: _onDuplicateTitle,
-        onProgress: (int done, int total) {
-          if (total > 0) {
-            reportProgress(
-              (done / total).clamp(0.0, 1.0),
-              t.import_step_copying_file(name: p.basename(_epubPath!)),
-            );
-          }
-        },
-      );
-      reportProgress(1, t.import_step_done);
-      return;
-    }
-
-    if (ext == '.cbz' ||
-        (<String>{'.zip', '.epub'}.contains(ext) &&
-            MangaModule.isImageArchive(_epubPath!))) {
-      reportProgress(0.5, t.import_step_importing_epub);
-      await MangaModule.importArchive(
-        db: widget.db,
-        path: _epubPath!,
-        title: title,
-        onDuplicateTitle: _onDuplicateTitle,
-        onProgress: (int done, int total) {
-          if (total > 0) {
-            reportProgress(
-              (done / total).clamp(0.0, 1.0),
-              t.import_step_copying_file(name: p.basename(_epubPath!)),
-            );
-          }
-        },
-      );
-      reportProgress(1, t.import_step_done);
-      return;
-    }
-
     final String bookKey;
-    if (TextToEpub.isSupported(_epubPath!) ||
-        (ext != '.epub' && ext != '.zip')) {
+    if (carrier == ImportCarrier.text) {
       reportProgress(0.3, t.import_step_converting_epub);
       final Uint8List bytes =
           await TextToEpub.convert(file: file, title: title);

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -763,10 +763,10 @@ class _BookImportDialogState extends State<BookImportDialog>
   // ── 导入 ────────────────────────────────────────────────────────────────
 
   /// 同名书弹窗回调，喂给 [EpubImporter]。是→加后缀，否/关闭→取消这本书。
-  Future<DuplicateTitleResolution> _onDuplicateTitle(
+  Future<DuplicateChoice> _askOnDuplicate(
     String proposedTitle,
   ) async {
-    if (!mounted) return DuplicateTitleResolution.cancel;
+    if (!mounted) return DuplicateChoice.cancel;
     final bool? keep = await showAppDialog<bool>(
       context: context,
       builder: (BuildContext ctx) => AlertDialog(
@@ -784,9 +784,7 @@ class _BookImportDialogState extends State<BookImportDialog>
         ],
       ),
     );
-    return keep == true
-        ? DuplicateTitleResolution.addSuffix
-        : DuplicateTitleResolution.cancel;
+    return keep == true ? DuplicateChoice.suffix : DuplicateChoice.cancel;
   }
 
   Future<void> _doImport() async {
@@ -883,7 +881,7 @@ class _BookImportDialogState extends State<BookImportDialog>
           db: widget.db,
           filePath: epubPath,
           fileName: '${title.replaceAll(RegExp(r'[^\w\s\-]'), '')}.epub',
-          onDuplicateTitle: _onDuplicateTitle,
+          policy: DuplicatePolicy.ask(_askOnDuplicate),
         );
         debugPrint(
             '[hibiki-import] subtitleBook: EPUB import done, key=$bookKey');
@@ -985,7 +983,7 @@ class _BookImportDialogState extends State<BookImportDialog>
         filePath: _epubPath!,
         fileName: _epubName ?? p.basename(_epubPath!),
         title: title,
-        onDuplicateTitle: _onDuplicateTitle,
+        policy: DuplicatePolicy.ask(_askOnDuplicate),
       );
       reportProgress(1, t.import_step_done);
       return;
@@ -1003,7 +1001,7 @@ class _BookImportDialogState extends State<BookImportDialog>
         db: widget.db,
         bytes: bytes,
         fileName: filename,
-        onDuplicateTitle: _onDuplicateTitle,
+        policy: DuplicatePolicy.ask(_askOnDuplicate),
       );
     } else {
       reportProgress(0.5, t.import_step_importing_epub);
@@ -1011,7 +1009,7 @@ class _BookImportDialogState extends State<BookImportDialog>
         db: widget.db,
         filePath: _epubPath!,
         fileName: _epubName ?? p.basename(_epubPath!),
-        onDuplicateTitle: _onDuplicateTitle,
+        policy: DuplicatePolicy.ask(_askOnDuplicate),
       );
     }
 
@@ -1046,7 +1044,7 @@ class _BookImportDialogState extends State<BookImportDialog>
         db: widget.db,
         bytes: importBytes,
         fileName: importFilename,
-        onDuplicateTitle: _onDuplicateTitle,
+        policy: DuplicatePolicy.ask(_askOnDuplicate),
       );
     } else {
       reportProgress(0.2, t.import_step_importing_epub);
@@ -1054,7 +1052,7 @@ class _BookImportDialogState extends State<BookImportDialog>
         db: widget.db,
         filePath: _epubPath!,
         fileName: _epubName ?? p.basename(_epubPath!),
-        onDuplicateTitle: _onDuplicateTitle,
+        policy: DuplicatePolicy.ask(_askOnDuplicate),
       );
     }
 

--- a/hibiki/lib/src/media/import/import_carrier.dart
+++ b/hibiki/lib/src/media/import/import_carrier.dart
@@ -1,0 +1,78 @@
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki/src/media/audiobook/text_to_epub.dart';
+
+/// 一个待导入路径的**载体身份**：它到底是哪种东西，因而该交给哪个 importer。
+///
+/// 此前这个判断只活在 `BookImportDialog._importEpubOnly` 的函数体末尾——用户从
+/// 漫画库进来时「这是漫画」本来是已知的，却在入口被丢掉，一路走到导入执行阶段
+/// 再靠扩展名 + 真读包嗅回来。载体身份提到入口后，漫画和书籍各自有独立入口与
+/// 对话框，`isImageArchive` 那次真实 IO 只在**扩展名确实二义**时才发生。
+enum ImportCarrier {
+  /// 页图**目录**（一个漫画文件夹）。走 `MangaModule.importImageFolder`。
+  mangaFolder,
+
+  /// mokuro v0.2+ 的 `.mokuro` OCR 结果文件（+ 同级图片）。
+  /// 走 `MangaModule.importMokuro`。
+  mangaMokuro,
+
+  /// 图片压缩包：`.cbz`，或真读包确认装的是页图的 `.zip` / `.epub`。
+  /// 走 `MangaModule.importArchive`。
+  mangaArchive,
+
+  /// PDF。走 `PdfImporter`（真渲染，不经 TextToEpub 文本转换）。
+  pdf,
+
+  /// EPUB。走 `EpubImporter.importFromPath`。
+  epub,
+
+  /// 可转成 EPUB 的纯文本类（txt/md/html/…），以及不认识的扩展名。
+  /// 走 `TextToEpub.convert` + `EpubImporter.import`。
+  text;
+
+  /// 是否属漫画域（三种漫画载体的统称）。书籍侧入口只关心这一个问题。
+  bool get isManga =>
+      this == ImportCarrier.mangaFolder ||
+      this == ImportCarrier.mangaMokuro ||
+      this == ImportCarrier.mangaArchive;
+}
+
+/// 判定 [path] 的载体身份。
+///
+/// 文件系统判据由调用方注入（与 `classifyDroppedFiles` 同款设计），本函数自身
+/// 不碰 IO，故可在纯 Dart 测试里穷举各分支：
+///
+/// - [isDirectory]：目录判定。**必须最先问**——目录没有扩展名，而目录名带点时
+///   `p.extension` 还会误取出一个假扩展名，落到任何按扩展名分派的分支都会失败。
+/// - [isImageArchive]：真读包判定，只在扩展名二义（`.zip` / `.epub`）时才被调用。
+///   `.zip` 同时是 Yomitan 词典包扩展名，`.epub` 也可能是扫描版漫画——光看扩展名
+///   分不出，必须开包看里面装的是不是页图。
+ImportCarrier classifyImportCarrier(
+  String path, {
+  required bool Function(String path) isDirectory,
+  required bool Function(String path) isImageArchive,
+}) {
+  if (isDirectory(path)) return ImportCarrier.mangaFolder;
+
+  final String ext = p.extension(path).toLowerCase();
+
+  // PDF 必须在下面的文本分支之前早退——否则 PDF 二进制会被当文本转成乱码 EPUB。
+  if (ext == '.pdf') return ImportCarrier.pdf;
+
+  // .mokuro 同理：它的 JSON 内容会被文本分支当纯文本吞掉。
+  if (ext == '.mokuro') return ImportCarrier.mangaMokuro;
+
+  if (ext == '.cbz') return ImportCarrier.mangaArchive;
+  if (_ambiguousArchiveExtensions.contains(ext) && isImageArchive(path)) {
+    return ImportCarrier.mangaArchive;
+  }
+
+  // 非 epub/zip 的一切（含无扩展名文件）都尝试按文本转 EPUB——保持既有兜底语义。
+  if (TextToEpub.isSupported(path) || (ext != '.epub' && ext != '.zip')) {
+    return ImportCarrier.text;
+  }
+  return ImportCarrier.epub;
+}
+
+/// 需要真读包才能定性的容器扩展名（带点，小写）。
+const Set<String> _ambiguousArchiveExtensions = <String>{'.zip', '.epub'};

--- a/hibiki/lib/src/media/import/import_carrier.dart
+++ b/hibiki/lib/src/media/import/import_carrier.dart
@@ -76,3 +76,50 @@ ImportCarrier classifyImportCarrier(
 
 /// 需要真读包才能定性的容器扩展名（带点，小写）。
 const Set<String> _ambiguousArchiveExtensions = <String>{'.zip', '.epub'};
+
+/// 按路径记住一次载体身份的小盒子。
+///
+/// 为什么需要它：`.zip` / `.epub` 的定性要 [classifyImportCarrier] **真开包**
+/// （`isImageArchive` → 全量同步解压），那是导入对话框里唯一一处重量级同步 IO。
+/// 而一次导入里同一个路径会被问到不止一次：选中时的漫画闸门、`_doImport` 的兜底
+/// 闸门、以及真正分派时。每问一次就整包解压一次。有声书对齐路径（EPUB+字幕）尤其
+/// 亏——它根本不进按载体分派那一步，前面那几次开包纯属白开，而分家之前它一次都不开。
+///
+/// 载体身份本来就是路径的函数（这正是 [ImportCarrier] 的立意：身份在**选中那一刻**
+/// 定死，而不是一路嗅到导入执行阶段），所以按路径记住即可。换路径自动失效——key 变了
+/// 就重算，因此不会把上一个文件的判定张冠李戴到下一个文件上。
+///
+/// **不是**靠跳过判据来省 IO：判据一字未动，词典包一票否决照常生效（见
+/// `MangaArchiveImporter.looksLikeImageArchive`）。省掉的只是**重复**问同一个问题。
+class ImportCarrierResolver {
+  ImportCarrierResolver({
+    required this.isDirectory,
+    required this.isImageArchive,
+  });
+
+  final bool Function(String path) isDirectory;
+  final bool Function(String path) isImageArchive;
+
+  String? _cachedPath;
+  ImportCarrier? _cachedCarrier;
+
+  /// 判定 [path] 的载体身份；同一个 [path] 连续问只算一次真判定。
+  ImportCarrier resolve(String path) {
+    final ImportCarrier? cached = _cachedCarrier;
+    if (cached != null && _cachedPath == path) return cached;
+    final ImportCarrier carrier = classifyImportCarrier(
+      path,
+      isDirectory: isDirectory,
+      isImageArchive: isImageArchive,
+    );
+    _cachedPath = path;
+    _cachedCarrier = carrier;
+    return carrier;
+  }
+
+  /// 丢弃记忆。路径指向的文件可能在对话框开着时被换掉，需要重新定性时调用。
+  void invalidate() {
+    _cachedPath = null;
+    _cachedCarrier = null;
+  }
+}

--- a/hibiki/lib/src/media/manga/import/manga_archive_importer.dart
+++ b/hibiki/lib/src/media/manga/import/manga_archive_importer.dart
@@ -90,7 +90,7 @@ abstract final class MangaArchiveImporter {
     required HibikiDatabase db,
     required String archivePath,
     String? title,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     void Function(int done, int total)? onProgress,
   }) async {
     final Archive archive = _decode(archivePath);
@@ -130,7 +130,7 @@ abstract final class MangaArchiveImporter {
         title: title?.trim().isNotEmpty == true
             ? title
             : p.basenameWithoutExtension(archivePath),
-        onDuplicateTitle: onDuplicateTitle,
+        policy: policy,
         onProgress: onProgress,
       );
     } finally {

--- a/hibiki/lib/src/media/manga/manga_import_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_import_dialog.dart
@@ -1,0 +1,397 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as p;
+
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/epub/book_title_conflict.dart';
+import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
+import 'package:hibiki/src/media/import/import_dialog_frame.dart';
+import 'package:hibiki/src/media/import/import_flow_mixin.dart';
+import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki/utils.dart';
+
+/// 漫画导入对话框。
+///
+/// 与 [BookImportDialog] 分家的理由不是「代码重复」——两者共用 [ImportFlowMixin]
+/// 骨架、[ImportDialogFrame] 外框、同名书冲突解决和 `EpubBooks` 表，共用的部分一
+/// 点没少。分家是因为**载体不同、可填字段就不同**：漫画没有字幕、没有音频、没有
+/// 有声书对齐窗口，而书籍没有 OCR。此前两者挤在同一个对话框里，从漫画库点「导入
+/// 漫画」弹出的框有三行对漫画毫无意义的字幕/音频/对齐控件，且「这是漫画」这个在
+/// 入口就已知的事实被丢掉，一路走到导入执行阶段再靠扩展名 + 真读包嗅回来。
+///
+/// 本对话框只暴露漫画 importer 真正消费的两个参数：路径 + 标题。载体的三种细分
+/// （页图目录 / `.mokuro` / 图片压缩包）由 [classifyImportCarrier] 在**选中那一刻**
+/// 定死，[_doImport] 只是照着分派，不再二次嗅探。
+class MangaImportDialog extends StatefulWidget {
+  const MangaImportDialog({
+    required this.db,
+    this.initialPath,
+    this.mangaOcrRemoteRunner,
+    this.ocrEntryDesktopOverride,
+    super.key,
+  });
+
+  final HibikiDatabase db;
+
+  /// 拖放/书籍框转交时预填的漫画路径（目录 / `.cbz` / `.zip` 页图包 / `.mokuro`）。
+  final String? initialPath;
+
+  /// 测试缝：注入远程 OCR runner（探测已配对 host 能力 + 代跑）。
+  /// null = 生产路径，按 [db] 惰性构造 [InterconnectMangaOcrClient]。
+  final MangaOcrRemoteRunner? mangaOcrRemoteRunner;
+
+  /// 测试缝：覆盖「是否桌面平台」判定。null = 用真实 [isDesktopPlatform]。
+  final bool? ocrEntryDesktopOverride;
+
+  @override
+  State<MangaImportDialog> createState() => _MangaImportDialogState();
+}
+
+class _MangaImportDialogState extends State<MangaImportDialog>
+    with ImportFlowMixin<MangaImportDialog> {
+  final TextEditingController _titleCtrl = TextEditingController();
+
+  String? _path;
+  String? _pathName;
+  ImportCarrier? _carrier;
+
+  /// 用户是否手打过标题。打过就永不被自动派生覆盖。
+  ///
+  /// 书籍框那套五值 [ImportTitleSource] 是为「EPUB / 字幕 / 音频标签」三个来源
+  /// 抢同一个标题框而生的；漫画框只有一个来源（漫画路径），退化成一个 bool 即可，
+  /// 不搬那套跨来源优先级机器。
+  bool _titleFromUser = false;
+
+  bool _pickerActive = false;
+
+  late final MangaOcrRemoteRunner _mangaOcrRemoteRunner =
+      widget.mangaOcrRemoteRunner ??
+          InterconnectMangaOcrClient(repo: SyncRepository(widget.db));
+
+  bool get _ocrEntryDesktop =>
+      widget.ocrEntryDesktopOverride ?? isDesktopPlatform;
+
+  @override
+  void initState() {
+    super.initState();
+    final String? initial = widget.initialPath;
+    if (initial != null) {
+      // 预填路径来自已判定为漫画的上游（拖放决策层 / 书籍框转交），这里仍重跑一次
+      // 分类以拿到细分载体；万一上游给了非漫画路径，宁可留空也不静默导错东西。
+      final ImportCarrier carrier = _classify(initial);
+      if (carrier.isManga) {
+        _path = initial;
+        _pathName = p.basename(initial);
+        _carrier = carrier;
+        _titleCtrl.text = _deriveTitle(initial);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleCtrl.dispose();
+    super.dispose();
+  }
+
+  ImportCarrier _classify(String path) => classifyImportCarrier(
+        path,
+        isDirectory: (String pth) => Directory(pth).existsSync(),
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+  /// 目录取目录名，文件取去扩展名的文件名。
+  String _deriveTitle(String path) {
+    if (Directory(path).existsSync()) return p.basename(path);
+    return p.basenameWithoutExtension(path);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return HibikiFileDropTarget(
+      enabled: !importing,
+      debugLabel: 'manga-import-dialog',
+      onDrop: _handleDialogDrop,
+      child: ImportDialogFrame(
+        leadingIcon: Icons.auto_stories_outlined,
+        title: t.manga_import_action,
+        body: _buildForm(),
+        actions: <Widget>[
+          adaptiveDialogAction(
+            context: context,
+            onPressed: importing ? null : _openOcrWizard,
+            child: Text(t.manga_ocr_wizard_title),
+          ),
+          adaptiveDialogAction(
+            context: context,
+            onPressed: () => Navigator.pop(context),
+            child: Text(t.dialog_cancel),
+          ),
+          buildImportAction(context, onImport: _doImport),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildForm() {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: <Widget>[
+        Text(t.manga_import_hint, style: tokens.type.metadata),
+        SizedBox(height: tokens.spacing.gap),
+        AdaptiveSettingsSection(children: <Widget>[_mangaRow()]),
+        SizedBox(height: tokens.spacing.rowVertical),
+        HibikiTextField(
+          controller: _titleCtrl,
+          labelText: t.srt_import_title_hint,
+          onChanged: (String _) => _titleFromUser = true,
+        ),
+        if (importing) ...buildProgressSection(context, tokens),
+      ],
+    );
+  }
+
+  Widget _mangaRow() {
+    return HibikiFilePickerRow(
+      title: t.manga_import_pick_file,
+      subtitle: _pathName,
+      icon: Icons.auto_stories_outlined,
+      onTap: _pickFile,
+      actions: <Widget>[
+        // 漫画载体可以是**文件**（.cbz/.zip/.mokuro）也可以是**目录**（一卷页图），
+        // 两种选择器在系统层是两个不同的对话框，故并列两个入口而非合成一个。
+        HibikiIconButton(
+          icon: Icons.folder_open_outlined,
+          tooltip: t.manga_import_pick_folder,
+          isWideTapArea: true,
+          onTap: _pickFolder,
+        ),
+        HibikiIconButton(
+          icon: Icons.insert_drive_file_outlined,
+          tooltip: t.manga_import_pick_file,
+          isWideTapArea: true,
+          onTap: _pickFile,
+        ),
+      ],
+    );
+  }
+
+  // ── 选择 ────────────────────────────────────────────────────────────────
+
+  /// 漫画**文件**扩展名（不带点，小写）。`.zip` / `.epub` 在此列是因为图片型压缩包
+  /// 与词典包/普通电子书同形，选中后由 [classifyImportCarrier] 真读包定性；不是
+  /// 漫画的会被 [_adoptPath] 挡回。
+  static const Set<String> _mangaFileExtensions = <String>{
+    'mokuro',
+    'cbz',
+    'zip',
+    'epub',
+  };
+
+  Future<void> _pickFile() async {
+    if (_pickerActive) return;
+    _pickerActive = true;
+    try {
+      final AppModel appModel =
+          ProviderScope.containerOf(context, listen: false).read(appProvider);
+      final String? path = await pickRealFilePath(
+        context: context,
+        appModel: appModel,
+        allowedExtensions: _mangaFileExtensions,
+      );
+      if (path == null || !mounted) return;
+      _adoptPath(path);
+    } finally {
+      _pickerActive = false;
+    }
+  }
+
+  Future<void> _pickFolder() async {
+    if (_pickerActive) return;
+    _pickerActive = true;
+    try {
+      final AppModel appModel =
+          ProviderScope.containerOf(context, listen: false).read(appProvider);
+      final String? path = await pickRealDirectoryPath(
+        context: context,
+        appModel: appModel,
+      );
+      if (path == null || !mounted) return;
+      _adoptPath(path);
+    } finally {
+      _pickerActive = false;
+    }
+  }
+
+  /// 收下一个候选路径：先定性，非漫画直接挡回并说明，绝不静默吞掉。
+  void _adoptPath(String path) {
+    final ImportCarrier carrier = _classify(path);
+    if (!carrier.isManga) {
+      final String ext = p.extension(path).toLowerCase();
+      HibikiToast.show(
+        msg: t.import_unsupported_file_format(ext: ext.isEmpty ? path : ext),
+      );
+      return;
+    }
+    setState(() {
+      _path = path;
+      _pathName = p.basename(path);
+      _carrier = carrier;
+      if (!_titleFromUser) {
+        _titleCtrl.text = _deriveTitle(path);
+      }
+    });
+  }
+
+  void _handleDialogDrop(List<String> paths, Offset _) {
+    if (importing) return;
+    // 拖进本框的东西只有一种可能有意义：漫画。取第一个能定性成漫画的路径。
+    for (final String path in paths) {
+      if (_classify(path).isManga) {
+        _adoptPath(path);
+        return;
+      }
+    }
+    if (paths.isNotEmpty) {
+      final String ext = p.extension(paths.first).toLowerCase();
+      HibikiToast.show(
+        msg: t.import_unsupported_file_format(
+          ext: ext.isEmpty ? paths.first : ext,
+        ),
+      );
+    }
+  }
+
+  // ── OCR ─────────────────────────────────────────────────────────────────
+
+  /// 打开 OCR 导入漫画向导：向导内选裸图片文件夹跑整卷 OCR 后无缝落库；成功
+  /// （返回 bookKey）则连同关闭本导入框并回传 true，让书架刷新。
+  Future<void> _openOcrWizard() async {
+    final String? bookKey = await MangaModule.openOcrImportWizard(
+      context: context,
+      db: widget.db,
+      remoteRunner: _mangaOcrRemoteRunner,
+      desktop: _ocrEntryDesktop,
+    );
+    if (bookKey != null && mounted) {
+      Navigator.pop(context, true);
+    }
+  }
+
+  // ── 导入 ────────────────────────────────────────────────────────────────
+
+  /// 同名书弹窗回调。是→加后缀，否/关闭→取消这本书。与书籍框逐字同语义。
+  Future<DuplicateTitleResolution> _onDuplicateTitle(
+    String proposedTitle,
+  ) async {
+    if (!mounted) return DuplicateTitleResolution.cancel;
+    final bool? keep = await showAppDialog<bool>(
+      context: context,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: Text(t.book_import_duplicate_title),
+        content: Text(t.book_import_duplicate_message(name: proposedTitle)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: Text(t.book_import_duplicate_cancel),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: Text(t.book_import_duplicate_keep),
+          ),
+        ],
+      ),
+    );
+    return keep == true
+        ? DuplicateTitleResolution.addSuffix
+        : DuplicateTitleResolution.cancel;
+  }
+
+  void _reportCopyProgress(int done, int total) {
+    if (total <= 0) return;
+    reportProgress(
+      (done / total).clamp(0.0, 1.0),
+      t.import_step_copying_file(name: _pathName ?? ''),
+    );
+  }
+
+  Future<void> _doImport() async {
+    final String? path = _path;
+    final ImportCarrier? carrier = _carrier;
+    if (path == null || carrier == null) {
+      HibikiToast.show(msg: t.manga_import_missing_input);
+      return;
+    }
+    final String title = _titleCtrl.text.trim();
+    if (title.isEmpty) {
+      HibikiToast.show(msg: t.srt_import_missing_title);
+      return;
+    }
+
+    await runImport(
+      logTag: 'MangaImportDialog.import',
+      debugMessage: (Object e) => 'MangaImportDialog error: $e',
+      isCancelled: (Object e) => e is DuplicateImportCancelledException,
+      onCancelled: () {
+        if (mounted) {
+          HibikiToast.show(msg: t.book_import_duplicate_cancelled);
+          Navigator.pop(context, false);
+        }
+      },
+      action: () async {
+        reportProgress(0, '');
+        debugPrint('[hibiki-import] manga route: carrier=$carrier path=$path');
+        reportProgress(0.5, t.import_step_importing_epub);
+
+        // 载体在选中那一刻已定死，这里只照着分派——不再二次嗅探扩展名或读包。
+        switch (carrier) {
+          case ImportCarrier.mangaFolder:
+            await MangaModule.importImageFolder(
+              db: widget.db,
+              path: path,
+              title: title,
+              onDuplicateTitle: _onDuplicateTitle,
+              onProgress: _reportCopyProgress,
+            );
+          case ImportCarrier.mangaMokuro:
+            await MangaModule.importMokuro(
+              db: widget.db,
+              path: path,
+              title: title,
+              onDuplicateTitle: _onDuplicateTitle,
+              onProgress: _reportCopyProgress,
+            );
+          case ImportCarrier.mangaArchive:
+            await MangaModule.importArchive(
+              db: widget.db,
+              path: path,
+              title: title,
+              onDuplicateTitle: _onDuplicateTitle,
+              onProgress: _reportCopyProgress,
+            );
+          case ImportCarrier.pdf:
+          case ImportCarrier.epub:
+          case ImportCarrier.text:
+            // 不可达：[_adoptPath] / [initState] 只收下 isManga 的载体。
+            throw StateError(
+                'non-manga carrier in MangaImportDialog: $carrier');
+        }
+
+        reportProgress(1, t.import_step_done);
+        if (mounted) {
+          HibikiToast.show(msg: t.srt_import_success);
+          Navigator.pop(context, true);
+        }
+      },
+    );
+  }
+}

--- a/hibiki/lib/src/media/manga/manga_import_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_import_dialog.dart
@@ -290,10 +290,10 @@ class _MangaImportDialogState extends State<MangaImportDialog>
   // ── 导入 ────────────────────────────────────────────────────────────────
 
   /// 同名书弹窗回调。是→加后缀，否/关闭→取消这本书。与书籍框逐字同语义。
-  Future<DuplicateTitleResolution> _onDuplicateTitle(
+  Future<DuplicateChoice> _askOnDuplicate(
     String proposedTitle,
   ) async {
-    if (!mounted) return DuplicateTitleResolution.cancel;
+    if (!mounted) return DuplicateChoice.cancel;
     final bool? keep = await showAppDialog<bool>(
       context: context,
       builder: (BuildContext ctx) => AlertDialog(
@@ -311,9 +311,7 @@ class _MangaImportDialogState extends State<MangaImportDialog>
         ],
       ),
     );
-    return keep == true
-        ? DuplicateTitleResolution.addSuffix
-        : DuplicateTitleResolution.cancel;
+    return keep == true ? DuplicateChoice.suffix : DuplicateChoice.cancel;
   }
 
   void _reportCopyProgress(int done, int total) {
@@ -359,7 +357,7 @@ class _MangaImportDialogState extends State<MangaImportDialog>
               db: widget.db,
               path: path,
               title: title,
-              onDuplicateTitle: _onDuplicateTitle,
+              policy: DuplicatePolicy.ask(_askOnDuplicate),
               onProgress: _reportCopyProgress,
             );
           case ImportCarrier.mangaMokuro:
@@ -367,7 +365,7 @@ class _MangaImportDialogState extends State<MangaImportDialog>
               db: widget.db,
               path: path,
               title: title,
-              onDuplicateTitle: _onDuplicateTitle,
+              policy: DuplicatePolicy.ask(_askOnDuplicate),
               onProgress: _reportCopyProgress,
             );
           case ImportCarrier.mangaArchive:
@@ -375,7 +373,7 @@ class _MangaImportDialogState extends State<MangaImportDialog>
               db: widget.db,
               path: path,
               title: title,
-              onDuplicateTitle: _onDuplicateTitle,
+              policy: DuplicatePolicy.ask(_askOnDuplicate),
               onProgress: _reportCopyProgress,
             );
           case ImportCarrier.pdf:

--- a/hibiki/lib/src/media/manga/manga_importer.dart
+++ b/hibiki/lib/src/media/manga/manga_importer.dart
@@ -75,7 +75,7 @@ class MangaImporter {
     required HibikiDatabase db,
     required String imageDirPath,
     String? title,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     void Function(int done, int total)? onProgress,
   }) async {
     final Directory root = Directory(imageDirPath);
@@ -111,7 +111,7 @@ class MangaImporter {
       srcDir: root,
       payload: MokuroPayload(images: pages),
       proposedTitle: proposedTitle,
-      onDuplicateTitle: onDuplicateTitle,
+      policy: policy,
       onProgress: onProgress,
     );
   }
@@ -119,18 +119,17 @@ class MangaImporter {
   /// 从 [mokuroPath] 指向的 `.mokuro` 文件导入一本漫画，返回新建的 `bookKey`。
   ///
   /// [title]：由导入对话框传入的用户可编辑标题（优先）；缺省则从 mokuro 顶层 `title`/
-  /// `volume` 组合派生，再退化文件名。同名卷冲突走 [resolveBookTitleConflict]（与 EPUB/PDF
-  /// 一致）：有 [onDuplicateTitle] 回调则询问用户加后缀/取消，无回调自动加后缀。
+  /// `volume` 组合派生，再退化文件名。同名卷冲突走 [resolveDuplicateTitle]（与 EPUB/PDF
+  /// 一致）：有 [DuplicatePolicy.ask] 回调则询问用户加后缀/取消，无回调自动加后缀。
   /// [onProgress] 在每复制完一页图片后回报 `(done, total)`。校验失败（非法文件夹 / 路径穿越
   /// / 缺图）抛 [MangaImportException]；用户取消同名弹窗抛 [DuplicateImportCancelledException]。
   static Future<String> importFromMokuroPath({
     required HibikiDatabase db,
     required String mokuroPath,
     String? title,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     void Function(int done, int total)? onProgress,
     int? sourceId,
-    bool skipIfExists = false,
   }) async {
     if (!mangaImportCanImport(<String>[mokuroPath])) {
       throw const MangaImportException('Not a valid Mokuro manga folder');
@@ -161,10 +160,9 @@ class MangaImporter {
       srcDir: srcDir,
       payload: payload,
       proposedTitle: proposedTitle,
-      onDuplicateTitle: onDuplicateTitle,
+      policy: policy,
       onProgress: onProgress,
       sourceId: sourceId,
-      skipIfExists: skipIfExists,
     );
   }
 
@@ -187,10 +185,9 @@ class MangaImporter {
     required String mangaJsonPath,
     String? imageRootPath,
     String? title,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     void Function(int done, int total)? onProgress,
     int? sourceId,
-    bool skipIfExists = false,
   }) async {
     final File jsonFile = File(mangaJsonPath);
     if (!jsonFile.existsSync()) {
@@ -215,10 +212,9 @@ class MangaImporter {
       srcDir: srcDir,
       payload: payload,
       proposedTitle: proposedTitle,
-      onDuplicateTitle: onDuplicateTitle,
+      policy: policy,
       onProgress: onProgress,
       sourceId: sourceId,
-      skipIfExists: skipIfExists,
     );
   }
 
@@ -233,10 +229,9 @@ class MangaImporter {
     required Directory srcDir,
     required MokuroPayload payload,
     required String proposedTitle,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     void Function(int done, int total)? onProgress,
     int? sourceId,
-    bool skipIfExists = false,
   }) async {
     // 第一遍：规划每页 destRel（sanitize + 保留子目录 + 去重）并校验源图存在 + 防路径穿越。
     // 全部在任何落盘/落库之前完成——校验失败零副作用，无需回滚。
@@ -253,11 +248,10 @@ class MangaImporter {
     }
 
     final List<EpubBookRow> existingBooks = await db.getAllEpubBooks();
-    final String storedTitle = await resolveBookTitleConflict(
+    final String storedTitle = await resolveDuplicateTitle(
       existingTitles: existingBooks.map((EpubBookRow b) => b.title).toList(),
       proposedTitle: proposedTitle,
-      onDuplicateTitle: onDuplicateTitle,
-      skipIfExists: skipIfExists,
+      policy: policy,
     );
     final String bookKey = sanitizeTtuFilename(storedTitle);
     final String bookDir = await MangaStorage.bookDirectory(bookKey);

--- a/hibiki/lib/src/media/manga/manga_module.dart
+++ b/hibiki/lib/src/media/manga/manga_module.dart
@@ -28,14 +28,14 @@ abstract final class MangaModule {
     required HibikiDatabase db,
     required String path,
     String? title,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     void Function(int done, int total)? onProgress,
   }) =>
       MangaImporter.importFromMokuroPath(
         db: db,
         mokuroPath: path,
         title: title,
-        onDuplicateTitle: onDuplicateTitle,
+        policy: policy,
         onProgress: onProgress,
       );
 
@@ -48,14 +48,14 @@ abstract final class MangaModule {
     required HibikiDatabase db,
     required String path,
     String? title,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     void Function(int done, int total)? onProgress,
   }) =>
       MangaImporter.importFromImageFolder(
         db: db,
         imageDirPath: path,
         title: title,
-        onDuplicateTitle: onDuplicateTitle,
+        policy: policy,
         onProgress: onProgress,
       );
 
@@ -63,14 +63,14 @@ abstract final class MangaModule {
     required HibikiDatabase db,
     required String path,
     String? title,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     void Function(int done, int total)? onProgress,
   }) =>
       MangaArchiveImporter.importArchive(
         db: db,
         archivePath: path,
         title: title,
-        onDuplicateTitle: onDuplicateTitle,
+        policy: policy,
         onProgress: onProgress,
       );
 

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_volume_downloader.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_volume_downloader.dart
@@ -43,7 +43,7 @@ enum MokuroMoeDownloadStage {
 }
 
 /// 下载事件：阶段 + 字节进度（total 未知时为 null）+ 导入页进度。
-/// [stage] == done 时 [bookKey] 非空（skipIfExists 命中则 [skippedExisting]
+/// [stage] == done 时 [bookKey] 非空（DuplicatePolicy.skip() 命中则 [skippedExisting]
 /// 为 true、bookKey 为空——该卷已在库，视作成功但无新行）。
 class MokuroMoeVolumeDownloadEvent {
   const MokuroMoeVolumeDownloadEvent({
@@ -198,7 +198,7 @@ class MokuroMoeVolumeDownloader {
           File(p.join(extractDir.path, '$volumeName.mokuro'));
       mokuroFile.copySync(placedMokuro.path);
 
-      // 5. 现有导入链落库（skipIfExists：同名卷静默跳过，不复制成 `X (2)`）。
+      // 5. 现有导入链落库（DuplicatePolicy.skip()：同名卷静默跳过，不复制成 `X (2)`）。
       controller.add(const MokuroMoeVolumeDownloadEvent(
         stage: MokuroMoeDownloadStage.importing,
       ));
@@ -209,7 +209,7 @@ class MokuroMoeVolumeDownloader {
           db: db,
           mokuroPath: placedMokuro.path,
           title: volumeTitle(seriesName, volumeName),
-          skipIfExists: true,
+          policy: const DuplicatePolicy.skip(),
           onProgress: (int done, int total) =>
               controller.add(MokuroMoeVolumeDownloadEvent(
             stage: MokuroMoeDownloadStage.importing,

--- a/hibiki/lib/src/media/source_library/source_library_scanner.dart
+++ b/hibiki/lib/src/media/source_library/source_library_scanner.dart
@@ -371,7 +371,7 @@ class SourceLibraryScanner {
   /// BUG-443: silent same-title dedup, mirroring [_importVideos]. Manual single-
   /// file import asks the user (or auto-suffixes to `X (2)`), but a batch folder
   /// scan must NOT re-import already-imported books as `X (2)`. We pass
-  /// `skipIfExists: true` so [EpubImporter.importFromPath] reuses the existing
+  /// `DuplicatePolicy.skip()` so [EpubImporter.importFromPath] reuses the existing
   /// `sanitizeTtuFilename` identity key: on a collision it throws
   /// [DuplicateImportCancelledException], which we catch per book and skip
   /// (not counted, not an error). The within-isolate parse + DB read picks up
@@ -392,7 +392,7 @@ class SourceLibraryScanner {
           epubTmp ??= Directory.systemTemp.createTempSync('m1c_scan_books_');
           localEpub = await fs.copyToLocal(item.epubPath, epubTmp.path);
         }
-        // skipIfExists:true reuses the sanitizeTtuFilename identity key so a
+        // DuplicatePolicy.skip() reuses the sanitizeTtuFilename identity key so a
         // re-scan / same-batch duplicate throws DuplicateImportCancelledException
         // (caught below) instead of a silent "X (2)" (BUG-443). The returned
         // bookKey is the audiobook anchor when a sidecar audio attaches.
@@ -401,7 +401,7 @@ class SourceLibraryScanner {
           filePath: localEpub,
           fileName: p.basename(item.epubPath),
           sourceId: sourceId,
-          skipIfExists: true,
+          policy: const DuplicatePolicy.skip(),
         );
         count++;
         // TODO-946：同目录有同名字幕 + 音频 -> 复用对话框抽出的非 UI 落库 service
@@ -488,7 +488,7 @@ class SourceLibraryScanner {
         existingRows.map((VideoBookRow r) => r.bookUid).toSet();
     // TODO-1237 ②: existing physical paths (normalized) for re-scan dedup — a
     // folder re-scan must SKIP files already imported instead of suffixing
-    // `X (2)` duplicates (mirrors _importBooks' skipIfExists, BUG-443). Grown as
+    // `X (2)` duplicates (mirrors _importBooks' skip policy, BUG-443). Grown as
     // we insert so a same-batch duplicate path is skipped too.
     final Set<String> existingPaths = existingRows
         .map((VideoBookRow r) => normalizeVideoPath(r.videoPath))
@@ -592,7 +592,7 @@ class SourceLibraryScanner {
   ///
   /// Re-scan dedup: there is no single playlist row to key on any more, so the
   /// manifest is deduped on whether its FIRST episode's path is already imported
-  /// ([VideoBookRepository.isVideoPathReferenced], same key the dialog folder
+  /// ([VideoBookRepository.isDuplicateVideoPath], same key the dialog folder
   /// import uses) — a re-scan of an already-imported folder skips it. Unlike the
   /// old first-episode key this now runs after parse (parsing a small manifest
   /// on re-scan is cheap); correctness of idempotency wins over the micro-cost.

--- a/hibiki/lib/src/media/sources/manga_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/manga_hibiki_source.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki/media.dart';
+import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/models.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/utils.dart';
@@ -83,15 +85,42 @@ class MangaHibikiSource extends ReaderMediaSource {
     required WidgetRef ref,
     required AppModel appModel,
   }) {
-    // 导入按钮统一由 EPUB 源提供（同一个对话框通吃 epub/pdf/manga）；本源作为打开-漫画
-    // 的短暂当前源，页头动作复用同一按钮以防被设为当前源时缺动作。
+    // 漫画有自己的导入按钮与对话框（载体不同、可填字段就不同）；本源作为打开-漫画
+    // 的短暂当前源，页头动作给出漫画导入以防被设为当前源时缺动作。
     return <Widget>[
-      ReaderHibikiSource.instance.buildBookImportButton(
+      buildMangaImportButton(
         context: context,
         ref: ref,
         appModel: appModel,
       ),
     ];
+  }
+
+  /// 「导入漫画」按钮。与 [ReaderHibikiSource.buildBookImportButton] 并列而非复用：
+  /// 两者打开的是不同对话框，仅外观规格（尺寸/宽窗展开成图标+文字）保持一致。
+  Widget buildMangaImportButton({
+    required BuildContext context,
+    required WidgetRef ref,
+    required AppModel appModel,
+    HibikiFocusId? focusId,
+    String? label,
+  }) {
+    return HibikiIconButton(
+      tooltip: t.manga_import_action,
+      label: label,
+      icon: Icons.library_add_outlined,
+      focusId: focusId,
+      onTap: () async {
+        final bool? imported = await showAppDialog<bool>(
+          context: context,
+          builder: (_) => MangaImportDialog(db: appModel.database),
+        );
+        if (imported == true) {
+          ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
+          ref.invalidate(srtBooksProvider);
+        }
+      },
+    );
   }
 
   @override

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -565,7 +565,7 @@ class VideoBookRepository {
         stillReferencedSubtitlePaths: refs.subtitles,
       );
       await VideoStorage.gcOrphanCovers(referencedCoverPaths: refs.covers);
-      if (!await isVideoPathReferenced(
+      if (!await isDuplicateVideoPath(
         deletedVideoPath,
         excludeBookUid: deletedBookUid,
       )) {
@@ -626,7 +626,7 @@ class VideoBookRepository {
   /// [externalVideoBookUid] 同款语义），因此 Windows 上 `D:\Foo\bar.mkv` 与
   /// `D:/Foo/bar.mkv`（file_picker 原始路径 vs argv 路径分隔符不一致）视为同一
   /// 文件命中同一行——既覆盖新写入行也覆盖存的是未归一路径的旧库内导入行。
-  /// 与 [isVideoPathReferenced] 同一比对语义（后者即据此实现），是「同一物理
+  /// 与 [isDuplicateVideoPath] 同一比对语义（后者即据此实现），是「同一物理
   /// 文件是否已入库」的单一真相源。外部「打开方式」入库前用它复用库内已导入的
   /// 同文件 bookUid，避免派生 `video/ext/<sha1>` 第二身份重复插行（TODO-903）。
   ///
@@ -646,7 +646,7 @@ class VideoBookRepository {
     return null;
   }
 
-  Future<bool> isVideoPathReferenced(
+  Future<bool> isDuplicateVideoPath(
     String videoPath, {
     String? excludeBookUid,
   }) async =>

--- a/hibiki/lib/src/media/video/video_import_dialog.dart
+++ b/hibiki/lib/src/media/video/video_import_dialog.dart
@@ -69,7 +69,7 @@ String singleVideoBookUid(String videoPath) {
 /// （`base (2)` / `base (3)`...）；否则原样返回。
 ///
 /// 纯函数。照搬 EpubImporter 的**无回调静默加后缀**策略（见
-/// `resolveBookTitleConflict` 的 `_uniqueSuffixedTitle`），保持"本地不出现两个
+/// `resolveDuplicateTitle` 的 `_uniqueSuffixedTitle`），保持"本地不出现两个
 /// 同 book_uid 视频"的不变量，供同步/导入安全使用。video 导入对话框无重名提示
 /// 回调基础设施，故采用与 EpubImporter 无回调路径一致的静默后缀 UX。
 String uniqueVideoBookUid(String base, Set<String> existingKeys) {
@@ -432,10 +432,10 @@ class _VideoImportDialogState extends State<VideoImportDialog>
   /// 单集 → 单片 VideoBook（内嵌默认字幕轨）。返回写入的 bookUid。
   Future<String?> _importGroup(VideoGroup group) async {
     // TODO-1237 ②：文件夹扫描去重——同一物理文件已在库则跳过，不再 uniqueVideoBookUid
-    // 加后缀建 `X (2)` 重复条目（对齐 EPUB 扫描的 skipIfExists，BUG-443）。以首集/单片
+    // 加后缀建 `X (2)` 重复条目（对齐 EPUB 扫描的 DuplicatePolicy.skip()，BUG-443）。以首集/单片
     // 绝对路径判重（findByVideoPath 的单一真相，按 normalizeVideoPath 归一），返回 null
     // 表示本组已导入、被跳过。
-    if (await widget.repo.isVideoPathReferenced(group.episodes.first.path)) {
+    if (await widget.repo.isDuplicateVideoPath(group.episodes.first.path)) {
       return null;
     }
     if (group.isPlaylist) {

--- a/hibiki/lib/src/mining/galgame_library.dart
+++ b/hibiki/lib/src/mining/galgame_library.dart
@@ -386,7 +386,7 @@ List<String> parseGameLaunchArguments(String raw) {
 
 /// 从一批拖入的文件路径里筛出**可新增**的游戏 exe：只认 `.exe` 扩展名
 /// （大小写无关），去掉批内重复与已在 [existing] 库里的路径。保序。纯函数。
-List<String> filterDroppedGameExes(
+List<String> filterOutDuplicateGameExes(
   List<GalgameEntry> existing,
   List<String> dropped,
 ) {

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -34,6 +34,7 @@ import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:hibiki/src/media/floating_dict_channel.dart';
 import 'package:hibiki/src/models/app_font_loader.dart';
 import 'package:hibiki/src/models/builtin_tags.dart';
+import 'package:hibiki/src/epub/book_title_conflict.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
 import 'package:hibiki/src/reader/reader_settings.dart';
 import 'package:hibiki/src/lookup/browser_extension_installer.dart';
@@ -3422,7 +3423,7 @@ class AppModel with ChangeNotifier {
   }
 
   /// 下载完成的书籍（epub）入库回调：逐个走 [EpubImporter] 进阅读库
-  /// （skipIfExists，重复导入不报错），返回成功入库的书本数。单本失败跳过。
+  /// （DuplicatePolicy.skip()，重复导入不报错），返回成功入库的书本数。单本失败跳过。
   Future<int?> _importDownloadedBooks(
       AnimeDownloadPlan plan, List<String> bookAbsolutePaths) async {
     int imported = 0;
@@ -3432,7 +3433,7 @@ class AppModel with ChangeNotifier {
           db: database,
           filePath: filePath,
           fileName: path.basename(filePath),
-          skipIfExists: true,
+          policy: const DuplicatePolicy.skip(),
         );
         imported++;
       } catch (_) {

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -166,7 +166,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     if (exe == null || exe.isEmpty) {
       return; // 用户取消
     }
-    if (filterDroppedGameExes(_games, <String>[exe]).isEmpty) {
+    if (filterOutDuplicateGameExes(_games, <String>[exe]).isEmpty) {
       HibikiToast.show(msg: t.game_already_added);
       return; // 已在库里：不重复添加
     }
@@ -179,7 +179,7 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   /// 拖入文件导入：筛出新的 `.exe` 批量添加，toast 汇报数量；每条落库后走
   /// 与「添加游戏」同一套 [_autoCover] 后台补齐封面（#370 目录级联 + exe 图标）。
   Future<void> _handleDrop(List<String> paths, Offset _) async {
-    final List<String> exes = filterDroppedGameExes(_games, paths);
+    final List<String> exes = filterOutDuplicateGameExes(_games, paths);
     if (exes.isEmpty) {
       HibikiToast.show(msg: t.game_drop_no_exe);
       return;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -20,6 +20,7 @@ import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
 import 'package:hibiki/src/media/display_title.dart';
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_download_queue.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
@@ -610,13 +611,24 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       actions: <Widget>[
         // 宽窗（非 compact）时动作展开成「图标+文字」药丸（与视频 tab 页头一致，
         // 用户 mockup：导入书籍 / 来源 / 合集 / 阅读统计带文字外显）；窄窗回落纯图标。
-        mediaSource.buildBookImportButton(
-          context: context,
-          ref: ref,
-          appModel: appModel,
-          focusId: kShelfImportFocusId,
-          label: _mangaOnly ? t.manga_import_action : t.srt_import,
-        ),
+        // 漫画库和书架是同一页面的两种壳，但导入的是两种载体，故按钮指向两个不同
+        // 的对话框——不再是「同一个框换个 label」。
+        if (_mangaOnly)
+          MangaHibikiSource.instance.buildMangaImportButton(
+            context: context,
+            ref: ref,
+            appModel: appModel,
+            focusId: kShelfImportFocusId,
+            label: t.manga_import_action,
+          )
+        else
+          mediaSource.buildBookImportButton(
+            context: context,
+            ref: ref,
+            appModel: appModel,
+            focusId: kShelfImportFocusId,
+            label: t.srt_import,
+          ),
         if (!_mangaOnly)
           _headerAction(
             tooltip: t.media_source_manage_title,
@@ -1806,13 +1818,16 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
             icon: const Icon(Icons.library_add_outlined, size: 18),
             label: Text(_mangaOnly ? t.manga_import_action : t.srt_import),
             onPressed: () async {
+              // 空态按钮与页头按钮指向同一个对话框：漫画库开漫画框，书架开书籍框。
               final bool? imported = await showAppDialog<bool>(
                 context: context,
-                builder: (_) => BookImportDialog(
-                  repo: SrtBookRepository(appModel.database),
-                  audiobookRepo: AudiobookRepository(appModel.database),
-                  db: appModel.database,
-                ),
+                builder: (_) => _mangaOnly
+                    ? MangaImportDialog(db: appModel.database)
+                    : BookImportDialog(
+                        repo: SrtBookRepository(appModel.database),
+                        audiobookRepo: AudiobookRepository(appModel.database),
+                        db: appModel.database,
+                      ),
               );
               if (imported == true) {
                 ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -978,14 +978,10 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
           audioPaths: files.audios,
         );
       case DropIntent.importNewManga:
-        // 漫画（.mokuro / .cbz / 页图目录）走与书同一个导入对话框——它的导入分派
-        // 早已认得这几种载体（mokuro → MangaImporter、cbz/图片型 zip →
-        // MangaArchiveImporter、目录 → importFromImageFolder），拖入只负责把路径
-        // 预填进去，不重复一套导入逻辑。
-        _openBookImportPrefilled(
-          epubPath: files.mangas.first,
-          subtitlePath: null,
-        );
+        // 漫画（.mokuro / .cbz / 页图目录 / 图片型 zip）走漫画自己的导入对话框。
+        // 决策层本来就把漫画和书分成了两个 intent，此前两个 intent 却落到同一个
+        // 对话框；现在落点跟着 intent 走，载体身份不再在半路丢失。
+        _openMangaImportPrefilled(mangaPath: files.mangas.first);
       case DropIntent.unsupportedMangaArchive:
         debugPrint(
           '[hibiki-drop] [reader-shelf] intent=unsupportedMangaArchive',
@@ -1046,6 +1042,23 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
         initialEpubPath: epubPath,
         initialSubtitlePath: subtitlePath,
         initialAudioPaths: audioPaths.isEmpty ? null : audioPaths,
+      ),
+    );
+    if (imported == true && mounted) {
+      _refreshSrtBooks();
+      ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
+    }
+  }
+
+  /// 拖入漫画 → 打开 [MangaImportDialog]，预填漫画路径（目录 / .cbz / .mokuro /
+  /// 图片型 zip）。刷新范式与 [_openBookImportPrefilled] 一致：漫画与书共用
+  /// `EpubBooks` 表和同一块书架，故失效的 provider 也相同。
+  Future<void> _openMangaImportPrefilled({required String mangaPath}) async {
+    final bool? imported = await showAppDialog<bool>(
+      context: context,
+      builder: (_) => MangaImportDialog(
+        db: appModel.database,
+        initialPath: mangaPath,
       ),
     );
     if (imported == true && mounted) {

--- a/hibiki/lib/src/pdf/pdf_importer.dart
+++ b/hibiki/lib/src/pdf/pdf_importer.dart
@@ -48,9 +48,8 @@ class PdfImporter {
     required String filePath,
     required String fileName,
     required String title,
-    DuplicateTitleCallback? onDuplicateTitle,
+    DuplicatePolicy policy = const DuplicatePolicy.suffix(),
     int? sourceId,
-    bool skipIfExists = false,
   }) async {
     await PdfEngine.ensureInitialized();
 
@@ -71,11 +70,10 @@ class PdfImporter {
 
     // 解析标题冲突 → bookKey（与 EpubImporter 同口径：净化标题即主键，保证本地唯一）。
     final List<EpubBookRow> existingBooks = await db.getAllEpubBooks();
-    final String storedTitle = await resolveBookTitleConflict(
+    final String storedTitle = await resolveDuplicateTitle(
       existingTitles: existingBooks.map((EpubBookRow b) => b.title).toList(),
       proposedTitle: title,
-      onDuplicateTitle: onDuplicateTitle,
-      skipIfExists: skipIfExists,
+      policy: policy,
     );
     final String bookKey = sanitizeTtuFilename(storedTitle);
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+987
+version: 1.3.1+988
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+983
+version: 1.3.1+987
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/epub/book_title_conflict_test.dart
+++ b/hibiki/test/epub/book_title_conflict_test.dart
@@ -4,36 +4,36 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/epub/book_title_conflict.dart';
 
 void main() {
-  group('resolveBookTitleConflict', () {
+  group('resolveDuplicateTitle', () {
     test('no conflict returns proposed title and never calls callback',
         () async {
       var called = false;
-      final String out = await resolveBookTitleConflict(
+      final String out = await resolveDuplicateTitle(
         existingTitles: const <String>['Rust'],
         proposedTitle: 'Go',
-        onDuplicateTitle: (_) async {
+        policy: DuplicatePolicy.ask((_) async {
           called = true;
-          return DuplicateTitleResolution.cancel;
-        },
+          return DuplicateChoice.cancel;
+        }),
       );
       expect(out, 'Go');
       expect(called, isFalse);
     });
 
     test('conflict + addSuffix returns " (2)" suffixed title', () async {
-      final String out = await resolveBookTitleConflict(
+      final String out = await resolveDuplicateTitle(
         existingTitles: const <String>['Rust'],
         proposedTitle: 'Rust',
-        onDuplicateTitle: (_) async => DuplicateTitleResolution.addSuffix,
+        policy: DuplicatePolicy.ask((_) async => DuplicateChoice.suffix),
       );
       expect(out, 'Rust (2)');
     });
 
     test('addSuffix skips already-taken suffixes', () async {
-      final String out = await resolveBookTitleConflict(
+      final String out = await resolveDuplicateTitle(
         existingTitles: const <String>['Rust', 'Rust (2)'],
         proposedTitle: 'Rust',
-        onDuplicateTitle: (_) async => DuplicateTitleResolution.addSuffix,
+        policy: DuplicatePolicy.ask((_) async => DuplicateChoice.suffix),
       );
       expect(out, 'Rust (3)');
     });
@@ -41,10 +41,10 @@ void main() {
     test('conflict + cancel throws DuplicateImportCancelledException',
         () async {
       expect(
-        () => resolveBookTitleConflict(
+        () => resolveDuplicateTitle(
           existingTitles: const <String>['Rust'],
           proposedTitle: 'Rust',
-          onDuplicateTitle: (_) async => DuplicateTitleResolution.cancel,
+          policy: DuplicatePolicy.ask((_) async => DuplicateChoice.cancel),
         ),
         throwsA(isA<DuplicateImportCancelledException>()),
       );
@@ -52,7 +52,7 @@ void main() {
 
     test('no callback auto-suffixes (keeps invariant for programmatic callers)',
         () async {
-      final String out = await resolveBookTitleConflict(
+      final String out = await resolveDuplicateTitle(
         existingTitles: const <String>['Rust'],
         proposedTitle: 'Rust',
       );
@@ -62,10 +62,10 @@ void main() {
     test('conflict is judged on the sync key sanitizeTtuFilename(title)',
         () async {
       // "a*" sanitizes to "a~ttu-star~"; a second "a*" must be detected as dup.
-      final String out = await resolveBookTitleConflict(
+      final String out = await resolveDuplicateTitle(
         existingTitles: const <String>['a*'],
         proposedTitle: 'a*',
-        onDuplicateTitle: (_) async => DuplicateTitleResolution.addSuffix,
+        policy: DuplicatePolicy.ask((_) async => DuplicateChoice.suffix),
       );
       expect(out, 'a* (2)');
     });
@@ -74,12 +74,14 @@ void main() {
   test('EpubImporter wires the conflict resolver into both import paths', () {
     final String src =
         File('lib/src/epub/epub_importer.dart').readAsStringSync();
-    // 两条插库路径都必须在 insert 前过 resolveBookTitleConflict，且暴露回调。
+    // 两条插库路径都必须在 insert 前过 resolveDuplicateTitle，且暴露回调。
     expect(
-      'resolveBookTitleConflict'.allMatches(src).length,
+      'resolveDuplicateTitle'.allMatches(src).length,
       greaterThanOrEqualTo(2),
       reason: 'both import() and importFromPath() must resolve title conflicts',
     );
-    expect(src.contains('onDuplicateTitle'), isTrue);
+    // 策略参数必须透传到底（此前锁的是 `onDuplicateTitle` 这个旧参数名；三态收敛
+    // 成单参 DuplicatePolicy 后，锁的对象换成它——守的仍是「调用方能左右冲突处置」）。
+    expect(src.contains('DuplicatePolicy'), isTrue);
   });
 }

--- a/hibiki/test/media/drag_drop/import_dialog_drop_target_guard_test.dart
+++ b/hibiki/test/media/drag_drop/import_dialog_drop_target_guard_test.dart
@@ -8,15 +8,18 @@ import 'package:hibiki/src/media/audiobook/book_import_dialog.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
-/// 守卫 TODO-790-B：三个导入对话框（book/audiobook/video）的 build 必须把根
+/// 守卫 TODO-790-B：每个导入对话框（book/manga/audiobook/video）的 build 必须把根
 /// frame 包进 [HibikiFileDropTarget]，否则拖文件进打开的模态对话框会被页级
 /// drop target 因 `isCurrent` 守卫静默忽略。
 ///
-/// 源码扫描守卫（仿 drag_drop_platform_guard_test.dart）：断言三文件各引用
-/// `HibikiFileDropTarget` 且各自定义 `_handleDialogDrop`。
+/// 源码扫描守卫（仿 drag_drop_platform_guard_test.dart）：断言各文件都引用
+/// `HibikiFileDropTarget` 且各自定义 `_handleDialogDrop`。漫画从书籍框分家后是
+/// 独立对话框，同样是模态落点，故一并纳入守卫——否则「漫画框拖不进东西」会成为
+/// 一个没人看守的回归。
 void main() {
   const Map<String, String> dialogs = <String, String>{
     'book': 'lib/src/media/audiobook/book_import_dialog.dart',
+    'manga': 'lib/src/media/manga/manga_import_dialog.dart',
     'audiobook': 'lib/src/media/audiobook/audiobook_import_dialog.dart',
     'video': 'lib/src/media/video/video_import_dialog.dart',
   };

--- a/hibiki/test/media/drag_drop/manga_drop_test.dart
+++ b/hibiki/test/media/drag_drop/manga_drop_test.dart
@@ -105,9 +105,9 @@ void main() {
           return false;
         },
       );
-      // epub 刻意不探：它在 books 分支就走 BookImportDialog，对话框的分派本来就
-      // 会真读包并把图片型 EPUB 导成漫画，行为已正确——为每次拖 EPUB 白开一次包
-      // 换不来可见改进。
+      // epub 刻意不探：它在 books 分支就走 BookImportDialog，而对话框收下路径时会
+      // 用 classifyImportCarrier 真读包，图片型 EPUB 在那里被认出并（经用户确认后）
+      // 转交漫画导入——识别没丢。为每次拖 EPUB 在分类层白开一次包换不来可见改进。
       expect(probed, <String>['/a/x.zip']);
     });
 

--- a/hibiki/test/media/import/book_import_carrier_memo_guard_test.dart
+++ b/hibiki/test/media/import/book_import_carrier_memo_guard_test.dart
@@ -1,0 +1,43 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫：书籍导入对话框问载体身份必须**走记忆**，不得裸调分类函数。
+///
+/// `.zip` / `.epub` 的定性要 `isImageArchive` 真开包（全量同步解压），是这个对话框里
+/// 唯一一处重量级同步 IO。而同一个路径在一次导入里会被问三次——选中时的漫画闸门、
+/// `_doImport` 的兜底闸门、`_importEpubOnly` 的分派。裸调 `classifyImportCarrier` 就是
+/// 解压三次；有声书对齐路径（EPUB+字幕）更亏：它根本不进 `_importEpubOnly`，前面那
+/// 几次开包纯属白开，而分家之前这条路一次都不开包。
+///
+/// 记忆层的行为正确性（同路径只算一次、换路径必须重算、不改判定结果）在
+/// `import_carrier_test.dart` 的 `ImportCarrierResolver` 组里用计数假回调验；这里只钉
+/// 接线——防止有人日后在对话框里再插一句裸调，把重复解压悄悄放回来。
+void main() {
+  late String src;
+
+  setUpAll(() {
+    final File f = File('lib/src/media/audiobook/book_import_dialog.dart');
+    expect(f.existsSync(), isTrue, reason: '守卫目标文件应存在');
+    src = f.readAsStringSync();
+  });
+
+  test('对话框不得裸调 classifyImportCarrier（必须经 ImportCarrierResolver）', () {
+    expect(src.contains('classifyImportCarrier('), isFalse,
+        reason: '裸调会绕过记忆 → 同一路径重复全量解压；改用 _classifyCarrier');
+  });
+
+  test('对话框持有且只持有一个 ImportCarrierResolver', () {
+    expect('ImportCarrierResolver('.allMatches(src).length, 1,
+        reason: '多个 resolver = 各自一份记忆 = 还是会重复开包');
+  });
+
+  test('_classifyCarrier 是唯一入口且委托给 resolver', () {
+    expect(src.contains('_carrierResolver.resolve('), isTrue,
+        reason: '_classifyCarrier 必须委托给 resolver，而不是自己再拼一次判据');
+    // 真实注入的判据不能被换成简化桩，否则词典包一票否决就失效了
+    // （那条判据活在 MangaArchiveImporter.looksLikeImageArchive 里）。
+    expect(src.contains('isImageArchive: MangaModule.isImageArchive'), isTrue,
+        reason: '必须注入真判据；换成按扩展名的桩会让 Yomitan 词典 zip 被当漫画导入');
+  });
+}

--- a/hibiki/test/media/import/import_carrier_dictionary_zip_test.dart
+++ b/hibiki/test/media/import/import_carrier_dictionary_zip_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
+import 'package:path/path.dart' as p;
+
+/// 反向守卫：**词典 zip 不许在导入入口层被判成漫画**。
+///
+/// 载体分家把「这是什么」的判定从 `_importEpubOnly` 末尾提到了
+/// `classifyImportCarrier`，两个对话框（书籍 / 漫画）都改从这里问。`4f9644db4` 的
+/// 「词典包一票否决」判据本体（`index.json` + `*_bank_*.json` 同时在场 ⇒ 不是图片
+/// 包，优先于「有图片就算漫画」）留在 `MangaArchiveImporter.looksLikeImageArchive`，
+/// 分家没有改动它——但**没有任何测试钉住新入口层真的把这个判据接上了**。
+///
+/// 已有的 `test/media/drag_drop/dictionary_zip_not_manga_test.dart` 走的是拖放分类
+/// 层（`classifyDroppedFiles`），`test/media/import/import_carrier_test.dart` 全程
+/// 用假回调（`imageArchives.contains`）。两者都不覆盖「对话框入口 →
+/// classifyImportCarrier → 真判据」这条新链路：只要有人把
+/// `book_import_dialog.dart` / `manga_import_dialog.dart` 注入的实参从
+/// `MangaModule.isImageArchive` 换成按扩展名的简化桩，现有套件**一条都不会红**，
+/// 而一本自带插图的 Yomitan 词典包就会被静默导成只有插图的垃圾「漫画」。
+///
+/// 故这里用**真 zip + 真判据**（不打桩）跑新入口层，把那条链钉死。
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('hibiki_carrier_dict_');
+  });
+
+  tearDown(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  /// 在 [tempDir] 下写一个真 zip，[entries] 是 `包内路径 -> 内容字节`。
+  String writeZip(String name, Map<String, List<int>> entries) {
+    final Archive archive = Archive();
+    entries.forEach((String path, List<int> bytes) {
+      archive.addFile(ArchiveFile(path, bytes.length, bytes));
+    });
+    final List<int>? encoded = ZipEncoder().encode(archive);
+    expect(encoded, isNotNull, reason: 'zip 编码失败，测试前提不成立');
+    final String path = p.join(tempDir.path, name);
+    File(path).writeAsBytesSync(encoded!);
+    return path;
+  }
+
+  /// 最小 PNG（1x1，真字节）——词典自带插图就长这样。
+  List<int> onePixelPng() => <int>[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+        0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+        0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41,
+        0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+        0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+        0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+        0x42, 0x60, 0x82,
+      ];
+
+  List<int> utf8Bytes(String text) => utf8.encode(text);
+
+  /// 用**生产实参**跑分类：`isImageArchive` 就是两个对话框注入的那一个。
+  ImportCarrier classifyWithRealPredicate(String path) => classifyImportCarrier(
+        path,
+        isDirectory: (String p) => Directory(p).existsSync(),
+        isImageArchive: MangaModule.isImageArchive,
+      );
+
+  test('自带插图的 Yomitan 词典 zip 不得被判成漫画载体', () {
+    final String dictZip = writeZip('yomitan_dict.zip', <String, List<int>>{
+      'index.json': utf8Bytes(
+        '{"title":"Test Dict","format":3,"revision":"1"}',
+      ),
+      'term_bank_1.json': utf8Bytes(
+        '[["猫","ねこ","n","",0,[{"type":"structured-content",'
+        '"content":{"tag":"img","path":"img/neko.png"}}],1,""]]',
+      ),
+      'tag_bank_1.json': utf8Bytes('[["n","partOfSpeech",0,"noun",0]]'),
+      'img/neko.png': onePixelPng(),
+    });
+
+    final ImportCarrier carrier = classifyWithRealPredicate(dictZip);
+
+    expect(carrier.isManga, isFalse,
+        reason: '词典包一票否决必须优先于「有图片就算漫画」：判成漫画 = 词典没被导入，'
+            '还平白多出一本只有插图的垃圾漫画（4f9644db4 回归）');
+    expect(carrier, ImportCarrier.epub,
+        reason: '.zip 非图片包时落 epub 分支（与分家前 _importEpubOnly 的兜底一致）');
+  });
+
+  test('kanji_bank 形态的词典包同样被否决', () {
+    final String dictZip = writeZip('kanji_dict.zip', <String, List<int>>{
+      'index.json': utf8Bytes('{"title":"Kanji Dict","format":3}'),
+      'kanji_bank_1.json': utf8Bytes('[["猫","","","",[],[]]]'),
+      'img/stroke.png': onePixelPng(),
+    });
+
+    expect(classifyWithRealPredicate(dictZip).isManga, isFalse,
+        reason: 'kanji_bank_ 也在 Yomitan 前缀集里，不能只认 term_bank_');
+  });
+
+  test('反向用例：真页图 zip 仍判为漫画（否决判据不得误伤漫画）', () {
+    final String mangaZip = writeZip('scan.zip', <String, List<int>>{
+      '001.png': onePixelPng(),
+      '002.png': onePixelPng(),
+      '003.png': onePixelPng(),
+    });
+
+    expect(classifyWithRealPredicate(mangaZip), ImportCarrier.mangaArchive,
+        reason: '没有 index.json + bank 的纯页图包就是漫画——否决判据必须精确，'
+            '否则「拖图包 zip 到书架仍要能导成漫画」这条红线会被误伤');
+  });
+
+  test('只有 index.json 而没有 bank 的 zip 不算词典（单有清单不足以否决）', () {
+    final String zip = writeZip('has_index.zip', <String, List<int>>{
+      'index.json': utf8Bytes('{"name":"whatever"}'),
+      '001.png': onePixelPng(),
+      '002.png': onePixelPng(),
+    });
+
+    expect(classifyWithRealPredicate(zip), ImportCarrier.mangaArchive,
+        reason: '打包工具随手生成的清单也叫 index.json，bank 前缀才是 Yomitan 指纹；'
+            '只认 index.json 会把普通图包误判成词典而拒绝导入');
+  });
+}

--- a/hibiki/test/media/import/import_carrier_test.dart
+++ b/hibiki/test/media/import/import_carrier_test.dart
@@ -1,0 +1,169 @@
+/// 载体分类（漫画/书籍导入分家的判据核心）。
+///
+/// [classifyImportCarrier] 是从 `BookImportDialog._importEpubOnly` 函数体里提出来的
+/// ——那里原本有 4 个按顺序早退的 if（目录 / .pdf / .mokuro / .cbz|图片型压缩包），
+/// 埋在导入执行阶段、必须真跑一次导入才能验证。提成纯函数后可以在这里穷举，包括
+/// 那几条**顺序敏感**的分支：分支顺序一旦被人「整理」乱，PDF 会被当文本转成乱码
+/// EPUB、.mokuro 的 JSON 会被当纯文本吞掉、带点的目录名会取出假扩展名。
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/import/import_carrier.dart';
+
+/// 默认判据：什么都不是目录、什么都不是图片压缩包。
+ImportCarrier classify(
+  String path, {
+  Set<String> directories = const <String>{},
+  Set<String> imageArchives = const <String>{},
+}) =>
+    classifyImportCarrier(
+      path,
+      isDirectory: directories.contains,
+      isImageArchive: imageArchives.contains,
+    );
+
+void main() {
+  group('漫画载体', () {
+    test('目录 → mangaFolder', () {
+      expect(
+        classify('/m/vol1', directories: <String>{'/m/vol1'}),
+        ImportCarrier.mangaFolder,
+      );
+    });
+
+    test('目录判定必须先于扩展名判定：带点的目录名不会被当成文件', () {
+      // `p.extension('/m/Vol.1')` == '.1'，落到任何扩展名分支都会误判。
+      expect(
+        classify('/m/Vol.1', directories: <String>{'/m/Vol.1'}),
+        ImportCarrier.mangaFolder,
+      );
+      // 更狠的一例：目录名以真实文件扩展名结尾。
+      expect(
+        classify('/m/scan.zip', directories: <String>{'/m/scan.zip'}),
+        ImportCarrier.mangaFolder,
+      );
+    });
+
+    test('.mokuro → mangaMokuro（不得被文本分支吞掉）', () {
+      expect(classify('/m/vol1.mokuro'), ImportCarrier.mangaMokuro);
+    });
+
+    test('.cbz → mangaArchive，无需读包', () {
+      expect(classify('/m/vol1.cbz'), ImportCarrier.mangaArchive);
+    });
+
+    test('图片型 .zip → mangaArchive', () {
+      expect(
+        classify('/m/vol1.zip', imageArchives: <String>{'/m/vol1.zip'}),
+        ImportCarrier.mangaArchive,
+      );
+    });
+
+    test('图片型 .epub（扫描版漫画）→ mangaArchive', () {
+      expect(
+        classify('/m/scan.epub', imageArchives: <String>{'/m/scan.epub'}),
+        ImportCarrier.mangaArchive,
+      );
+    });
+
+    test('isManga 覆盖且仅覆盖三种漫画载体', () {
+      expect(ImportCarrier.mangaFolder.isManga, isTrue);
+      expect(ImportCarrier.mangaMokuro.isManga, isTrue);
+      expect(ImportCarrier.mangaArchive.isManga, isTrue);
+      expect(ImportCarrier.pdf.isManga, isFalse);
+      expect(ImportCarrier.epub.isManga, isFalse);
+      expect(ImportCarrier.text.isManga, isFalse);
+    });
+  });
+
+  group('书籍载体', () {
+    test('.pdf → pdf（必须先于文本分支，否则二进制被转成乱码 EPUB）', () {
+      expect(classify('/b/doc.pdf'), ImportCarrier.pdf);
+    });
+
+    test('普通 .epub → epub', () {
+      expect(classify('/b/novel.epub'), ImportCarrier.epub);
+    });
+
+    test('非图片型 .zip → epub 分支（维持既有兜底语义）', () {
+      expect(classify('/b/dict.zip'), ImportCarrier.epub);
+    });
+
+    test('.txt / .md / .html → text', () {
+      expect(classify('/b/a.txt'), ImportCarrier.text);
+      expect(classify('/b/a.md'), ImportCarrier.text);
+      expect(classify('/b/a.html'), ImportCarrier.text);
+    });
+
+    test('无扩展名文件 → text（非 epub/zip 一律尝试文本转换）', () {
+      expect(classify('/b/README'), ImportCarrier.text);
+    });
+
+    test('不认识的扩展名 → text', () {
+      expect(classify('/b/a.weirdext'), ImportCarrier.text);
+    });
+  });
+
+  group('读包判据只在真正二义时才被调用', () {
+    test('.cbz / .mokuro / .pdf / .txt 都不触发读包', () {
+      final List<String> probed = <String>[];
+      for (final String path in <String>[
+        '/x/a.cbz',
+        '/x/a.mokuro',
+        '/x/a.pdf',
+        '/x/a.txt',
+      ]) {
+        classifyImportCarrier(
+          path,
+          isDirectory: (_) => false,
+          isImageArchive: (String pth) {
+            probed.add(pth);
+            return false;
+          },
+        );
+      }
+      expect(probed, isEmpty, reason: '扩展名已能定性时不得白开一次包');
+    });
+
+    test('目录不触发读包', () {
+      final List<String> probed = <String>[];
+      classifyImportCarrier(
+        '/x/vol.zip',
+        isDirectory: (_) => true,
+        isImageArchive: (String pth) {
+          probed.add(pth);
+          return false;
+        },
+      );
+      expect(probed, isEmpty, reason: '目录在读包判据之前就已早退');
+    });
+
+    test('.zip / .epub 才触发读包', () {
+      final List<String> probed = <String>[];
+      for (final String path in <String>['/x/a.zip', '/x/a.epub']) {
+        classifyImportCarrier(
+          path,
+          isDirectory: (_) => false,
+          isImageArchive: (String pth) {
+            probed.add(pth);
+            return false;
+          },
+        );
+      }
+      expect(probed, <String>['/x/a.zip', '/x/a.epub']);
+    });
+  });
+
+  group('大小写与路径分隔符', () {
+    test('扩展名大小写不敏感', () {
+      expect(classify('/m/VOL1.CBZ'), ImportCarrier.mangaArchive);
+      expect(classify('/m/VOL1.MOKURO'), ImportCarrier.mangaMokuro);
+      expect(classify('/b/DOC.PDF'), ImportCarrier.pdf);
+    });
+
+    test('Windows 反斜杠路径同样定性', () {
+      expect(classify(r'C:\manga\vol1.cbz'), ImportCarrier.mangaArchive);
+      expect(classify(r'C:\books\novel.epub'), ImportCarrier.epub);
+    });
+  });
+}

--- a/hibiki/test/media/import/import_carrier_test.dart
+++ b/hibiki/test/media/import/import_carrier_test.dart
@@ -166,4 +166,72 @@ void main() {
       expect(classify(r'C:\books\novel.epub'), ImportCarrier.epub);
     });
   });
+
+  group('ImportCarrierResolver 按路径记忆（不重复开包）', () {
+    /// 造一个会数「开了几次包」的 resolver。`isImageArchive` 就是真实现里那次
+    /// 全量同步解压的位置，数它 = 数解压次数。
+    ({ImportCarrierResolver resolver, List<String> probes}) makeResolver({
+      Set<String> imageArchives = const <String>{},
+    }) {
+      final List<String> probes = <String>[];
+      return (
+        resolver: ImportCarrierResolver(
+          isDirectory: (String _) => false,
+          isImageArchive: (String path) {
+            probes.add(path);
+            return imageArchives.contains(path);
+          },
+        ),
+        probes: probes,
+      );
+    }
+
+    test('同一个 .epub 问三次只开一次包（书籍导入的真实提问序列）', () {
+      // 这三次提问对应 BookImportDialog 里真实存在的三处：选中时的漫画闸门、
+      // _doImport 的兜底闸门、_importEpubOnly 的分派。修复前每次都整包解压。
+      final r = makeResolver();
+      for (int i = 0; i < 3; i++) {
+        expect(r.resolver.resolve('/b/novel.epub'), ImportCarrier.epub);
+      }
+      expect(r.probes.length, 1, reason: '载体身份是路径的函数，问三次不该解压三次');
+    });
+
+    test('有声书对齐路径：两次闸门也只开一次包', () {
+      // EPUB+字幕 走 _importEpubWithAlignment，根本不进 _importEpubOnly，
+      // 所以它只被问两次——但分家前它一次都不开包，重复开包在这条路上纯属白开。
+      final r = makeResolver();
+      r.resolver.resolve('/b/novel.epub');
+      r.resolver.resolve('/b/novel.epub');
+      expect(r.probes.length, 1);
+    });
+
+    test('换路径必须重新定性（不得把上一个文件的判定张冠李戴）', () {
+      final r = makeResolver(imageArchives: <String>{'/m/scan.zip'});
+      expect(r.resolver.resolve('/b/novel.epub'), ImportCarrier.epub);
+      expect(r.resolver.resolve('/m/scan.zip'), ImportCarrier.mangaArchive);
+      expect(r.resolver.resolve('/b/novel.epub'), ImportCarrier.epub);
+      expect(
+          r.probes, <String>['/b/novel.epub', '/m/scan.zip', '/b/novel.epub'],
+          reason: '换路径就得重算，记忆只对「同一个路径连续问」生效');
+    });
+
+    test('invalidate() 后重新开包（文件可能在对话框开着时被换掉）', () {
+      final r = makeResolver();
+      r.resolver.resolve('/b/novel.epub');
+      r.resolver.invalidate();
+      r.resolver.resolve('/b/novel.epub');
+      expect(r.probes.length, 2);
+    });
+
+    test('记忆不改变判定结果本身（词典包一票否决照常）', () {
+      // /d/dict.zip 不在 imageArchives 里 = 判据说它不是图片包（真实现里正是
+      // 词典包一票否决给出的答案）。记忆层不得把它变成漫画。
+      final r = makeResolver(imageArchives: <String>{'/m/scan.zip'});
+      for (int i = 0; i < 3; i++) {
+        expect(r.resolver.resolve('/d/dict.zip'), ImportCarrier.epub,
+            reason: '缓存只省重复提问，绝不改答案');
+      }
+      expect(r.probes.length, 1);
+    });
+  });
 }

--- a/hibiki/test/media/manga/manga_import_dialog_ocr_entry_test.dart
+++ b/hibiki/test/media/manga/manga_import_dialog_ocr_entry_test.dart
@@ -1,4 +1,10 @@
-/// 漫画 P3：导入书对话框「OCR 导入漫画」入口 gating。
+/// 漫画 P3：漫画导入对话框「OCR 导入漫画」入口 gating。
+///
+/// ## 换宿主（漫画/书籍导入分家）
+///
+/// 入口原先挂在**书籍**导入框上——那是漫画和书挤在同一个对话框时代的产物。分家后
+/// OCR 入口随漫画域迁到 [MangaImportDialog]，本测试整体跟着换宿主；下面的 gating
+/// 判据（两端都亮、两端 probeCalls 都必须是 0）逐条保留，一条没放宽。
 ///
 /// ## 判据换靶（PR#474，BUG-1164）
 ///
@@ -26,9 +32,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
-import 'package:hibiki/src/media/audiobook/book_import_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
-import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 class _FakeRemoteRunner implements MangaOcrRemoteRunner {
@@ -78,9 +83,7 @@ void main() {
         child: TranslationProvider(
           child: MaterialApp(
             home: Scaffold(
-              body: BookImportDialog(
-                repo: SrtBookRepository(db),
-                audiobookRepo: AudiobookRepository(db),
+              body: MangaImportDialog(
                 db: db,
                 mangaOcrRemoteRunner: runner,
                 ocrEntryDesktopOverride: desktop,
@@ -106,8 +109,7 @@ void main() {
     final _FakeRemoteRunner runner = _FakeRemoteRunner(target: _capableTarget);
     await pumpDialog(tester, desktop: false, runner: runner);
     expect(find.text(t.manga_ocr_wizard_title), findsOneWidget);
-    expect(runner.probeCalls, 0,
-        reason: '入口不再依赖探测，渲染决策不得产生网络副作用');
+    expect(runner.probeCalls, 0, reason: '入口不再依赖探测，渲染决策不得产生网络副作用');
   });
 
   testWidgets('mobile: entry stays visible without any paired host',

--- a/hibiki/test/media/manga/manga_importer_test.dart
+++ b/hibiki/test/media/manga/manga_importer_test.dart
@@ -437,7 +437,7 @@ void main() {
       MangaImporter.importFromMokuroPath(
         db: db,
         mokuroPath: second,
-        onDuplicateTitle: (String _) async => DuplicateTitleResolution.cancel,
+        policy: DuplicatePolicy.ask((String _) async => DuplicateChoice.cancel),
       ),
       throwsA(isA<DuplicateImportCancelledException>()),
     );

--- a/hibiki/test/media/manga/online/mokuro_moe_downloader_test.dart
+++ b/hibiki/test/media/manga/online/mokuro_moe_downloader_test.dart
@@ -208,7 +208,8 @@ void main() {
     expect(stagingDir().existsSync(), isFalse);
   });
 
-  test('同卷重跑：skipIfExists 命中 → done(skippedExisting=true)，不建重复行', () async {
+  test('同卷重跑：DuplicatePolicy.skip() 命中 → done(skippedExisting=true)，不建重复行',
+      () async {
     serveVolume();
     await downloader()
         .run(db: db, seriesName: series, volumeName: volume)

--- a/hibiki/test/media/reader_pdf_routing_guard_test.dart
+++ b/hibiki/test/media/reader_pdf_routing_guard_test.dart
@@ -43,9 +43,18 @@ void main() {
   });
 
   test('导入对话框把 .pdf 路由到 PdfImporter（不经 TextToEpub 文本转换）', () {
+    // 载体分家（漫画导入从书籍导入拆出）后，「.pdf 是什么载体」的判定从
+    // _importEpubOnly 的扩展名早退挪到了 classifyImportCarrier 这个纯函数；
+    // 对话框只按分类结果分派。守卫跟着锚点走，两段各守一半，强度不放宽。
+    final String carrier = read('lib/src/media/import/import_carrier.dart');
+    expect(carrier.contains("ext == '.pdf'"), isTrue,
+        reason: 'classifyImportCarrier 必须早退分流 .pdf');
+    expect(carrier.contains('ImportCarrier.pdf'), isTrue,
+        reason: '.pdf 必须归到独立的 pdf 载体，而不是落进文本兜底分支');
+
     final String src = read('lib/src/media/audiobook/book_import_dialog.dart');
-    expect(src.contains("ext == '.pdf'"), isTrue,
-        reason: '_importEpubOnly 必须早退分流 .pdf');
+    expect(src.contains('ImportCarrier.pdf'), isTrue,
+        reason: '_importEpubOnly 必须按 pdf 载体分派，缺这条 → PDF 落文本兜底');
     expect(src.contains('PdfImporter.importFromPath'), isTrue,
         reason: '.pdf 走 PdfImporter，而非把 PDF 二进制喂 TextToEpub 转成乱码 EPUB');
     // .pdf 必须在文件选择白名单里，否则用户根本选不到。

--- a/hibiki/test/media/source_library/source_library_scanner_test.dart
+++ b/hibiki/test/media/source_library/source_library_scanner_test.dart
@@ -365,7 +365,7 @@ void main() {
   // ── BUG-443: folder-scan book dedup (no silent X (2) re-import) ──────
   // Manual single-file import asks / auto-suffixes; a batch folder scan must NOT
   // re-import an already-imported same-title book as "X (2)". _importBooks passes
-  // skipIfExists:true -> EpubImporter throws DuplicateImportCancelledException on
+  // DuplicatePolicy.skip() -> EpubImporter throws DuplicateImportCancelledException on
   // a sanitizeTtuFilename key collision, which the scanner catches and skips.
   group('SourceLibraryScanner.scan book dedup (BUG-443)', () {
     late Directory tmp;
@@ -612,7 +612,7 @@ ep2.mp4
 
     // TODO-1237 ②: re-scanning the same video folder must NOT create `X (2)`
     // duplicates — already-imported single videos are skipped (path dedup),
-    // mirroring _importBooks' skipIfExists (BUG-443).
+    // mirroring _importBooks' skip policy (BUG-443).
     test('re-scan skips already-imported single videos (no X (2) dup)',
         () async {
       final HibikiDatabase db = _memDb();
@@ -755,12 +755,15 @@ sub_b/ep2.mp4
 
   // Source guard: _importBooks must keep the BUG-443 dedup wiring so a future
   // edit can't silently drop it and re-introduce X (2) folder-scan duplicates.
-  test('source guard: _importBooks passes skipIfExists for dedup (BUG-443)',
+  test('source guard: _importBooks requests DuplicatePolicy.skip (BUG-443)',
       () {
     final String src = File(
       'lib/src/media/source_library/source_library_scanner.dart',
     ).readAsStringSync();
-    expect(src.contains('skipIfExists: true'), isTrue,
+    // 旧锚点是 `skipIfExists: true`；三态收敛成单参 DuplicatePolicy 后换成
+    // `DuplicatePolicy.skip()`。守的仍是同一件事：批量扫描必须向导入器要「静默跳过」，
+    // 而不是加后缀（否则复扫一次就多一批 `X (2)`）。
+    expect(src.contains('DuplicatePolicy.skip()'), isTrue,
         reason: '_importBooks must request silent dedup from the importer');
     expect(src.contains('DuplicateImportCancelledException'), isTrue,
         reason: '_importBooks must catch+skip the duplicate-cancel signal');

--- a/hibiki/test/media/video/external_video_open_guard_test.dart
+++ b/hibiki/test/media/video/external_video_open_guard_test.dart
@@ -10,7 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 ///
 /// `_openExternalVideo` runs on the global navigator from the widget tree, so a
 /// full behaviour test would need the whole app + a navigator + a real DB. The
-/// repository dedup half (findByVideoPath / isVideoPathReferenced same-source
+/// repository dedup half (findByVideoPath / isDuplicateVideoPath same-source
 /// semantics) is covered by a real behaviour test in
 /// test/media/video/video_book_repository_test.dart; here we pin the call-site
 /// wiring at the source level so a future refactor can't silently drop one of
@@ -41,7 +41,7 @@ void main() {
       final String body = openExternalVideoBody();
       expect(body, contains('findByVideoPath('),
           reason: 'must reuse the repository videoPath comparison (same source '
-              'as isVideoPathReferenced) to reuse an already-imported bookUid '
+              'as isDuplicateVideoPath) to reuse an already-imported bookUid '
               'instead of inserting a second video/ext/<sha1> row');
     });
 

--- a/hibiki/test/media/video/playlist_cover_test.dart
+++ b/hibiki/test/media/video/playlist_cover_test.dart
@@ -69,13 +69,13 @@ void main() {
       expect(f.calls, hasLength(3), reason: '尝试次数受 maxAttempts 硬上限约束');
     });
 
-    // TODO-1237 ②：守卫对话框「导入文件夹」路径保留按物理路径去重（isVideoPathReferenced
+    // TODO-1237 ②：守卫对话框「导入文件夹」路径保留按物理路径去重（isDuplicateVideoPath
     // 命中即跳过），防止未来改动悄悄回退成 uniqueVideoBookUid 加后缀重复导入。
-    test('source guard: 文件夹导入 _importGroup 用 isVideoPathReferenced 去重', () {
+    test('source guard: 文件夹导入 _importGroup 用 isDuplicateVideoPath 去重', () {
       final String src = File(
         'lib/src/media/video/video_import_dialog.dart',
       ).readAsStringSync();
-      expect(src.contains('isVideoPathReferenced(group.episodes.first.path)'),
+      expect(src.contains('isDuplicateVideoPath(group.episodes.first.path)'),
           isTrue,
           reason: '_importGroup 必须先按物理路径判重再决定导入');
       expect(src.contains('extractPlaylistCover('), isTrue,

--- a/hibiki/test/media/video/video_book_repository_test.dart
+++ b/hibiki/test/media/video/video_book_repository_test.dart
@@ -459,8 +459,7 @@ void main() {
   });
   test(
       'findByVideoPath returns the row referencing a physical file; '
-      'isVideoPathReferenced delegates to it (TODO-903 dedup source)',
-      () async {
+      'isDuplicateVideoPath delegates to it (TODO-903 dedup source)', () async {
     final db = HibikiDatabase.forTesting(NativeDatabase.memory());
     addTearDown(db.close);
     final repo = VideoBookRepository(db);
@@ -476,15 +475,15 @@ void main() {
     final hit = await repo.findByVideoPath('/library/movie.mkv');
     expect(hit, isNotNull);
     expect(hit!.bookUid, 'video/movie.mkv');
-    expect(await repo.isVideoPathReferenced('/library/movie.mkv'), isTrue);
+    expect(await repo.isDuplicateVideoPath('/library/movie.mkv'), isTrue);
 
     // 未入库路径无匹配。
     expect(await repo.findByVideoPath('/elsewhere/other.mkv'), isNull);
-    expect(await repo.isVideoPathReferenced('/elsewhere/other.mkv'), isFalse);
+    expect(await repo.isDuplicateVideoPath('/elsewhere/other.mkv'), isFalse);
 
     // 空路径不匹配（守卫提前返回）。
     expect(await repo.findByVideoPath(''), isNull);
-    expect(await repo.isVideoPathReferenced(''), isFalse);
+    expect(await repo.isDuplicateVideoPath(''), isFalse);
 
     // excludeBookUid 跳过自身：删除/自比对时该行不护住自己。
     expect(
@@ -511,7 +510,7 @@ void main() {
     final forward = await repo.findByVideoPath('D:/Foo/bar.mp4');
     expect(forward, isNotNull);
     expect(forward!.bookUid, 'video/bar.mp4');
-    expect(await repo.isVideoPathReferenced('D:/Foo/bar.mp4'), isTrue);
+    expect(await repo.isDuplicateVideoPath('D:/Foo/bar.mp4'), isTrue);
 
     // 含冗余路径段（`.` / `..`）也归一命中同一行。
     final redundant = await repo.findByVideoPath('D:/Foo/./sub/../bar.mp4');

--- a/hibiki/test/mining/galgame_library_test.dart
+++ b/hibiki/test/mining/galgame_library_test.dart
@@ -78,11 +78,11 @@ void main() {
     });
   });
 
-  group('filterDroppedGameExes', () {
+  group('filterOutDuplicateGameExes', () {
     GalgameEntry entryFor(String exe) => newGalgameEntryFromExe(exe);
 
     test('只保留 .exe（大小写无关），非 exe 与空路径被过滤', () {
-      final List<String> out = filterDroppedGameExes(
+      final List<String> out = filterOutDuplicateGameExes(
         const <GalgameEntry>[],
         <String>[
           r'D:\g\a.exe',
@@ -96,7 +96,7 @@ void main() {
     });
 
     test('批内重复去重且保序（大小写 / 斜杠归一）', () {
-      final List<String> out = filterDroppedGameExes(
+      final List<String> out = filterOutDuplicateGameExes(
         const <GalgameEntry>[],
         <String>[
           r'D:\g\a.exe',
@@ -112,7 +112,7 @@ void main() {
       final List<GalgameEntry> existing = <GalgameEntry>[
         entryFor(r'D:\g\a.exe'),
       ];
-      final List<String> out = filterDroppedGameExes(
+      final List<String> out = filterOutDuplicateGameExes(
         existing,
         <String>[r'd:/G/A.EXE', r'D:\g\c.exe'],
       );
@@ -121,11 +121,12 @@ void main() {
 
     test('全部重复 / 无 exe 时返回空', () {
       expect(
-        filterDroppedGameExes(const <GalgameEntry>[], <String>[r'x\y.txt']),
+        filterOutDuplicateGameExes(
+            const <GalgameEntry>[], <String>[r'x\y.txt']),
         isEmpty,
       );
       expect(
-        filterDroppedGameExes(
+        filterOutDuplicateGameExes(
           <GalgameEntry>[entryFor(r'D:\g\a.exe')],
           <String>[r'D:\g\a.exe'],
         ),

--- a/hibiki/test/tools/duplicate_policy_naming_guard_test.dart
+++ b/hibiki/test/tools/duplicate_policy_naming_guard_test.dart
@@ -37,6 +37,16 @@ const Map<String, String> kRetiredNames = <String, String>{
 /// 会永远红（自指）。
 const String kSelfPath = 'test/tools/duplicate_policy_naming_guard_test.dart';
 
+/// 读取 [path] 并**剥掉整行注释**后的代码文本。
+///
+/// 结构断言一律走它，绝不用含注释的原文：本守卫早先版本直接 `src.contains(...)`，
+/// 把 `sealed class DuplicatePolicy` 的真声明删掉、只在注释里留下同一串字面量，
+/// 守卫照样全绿（实测）。注释是资产，但**不能替代声明**。
+String _codeOf(String path) => File(path)
+    .readAsLinesSync()
+    .where((String l) => !l.trimLeft().startsWith('//'))
+    .join('\n');
+
 /// 扫 [roots] 下所有 .dart 的**非注释**行，返回 `文件:行号` 命中列表。
 ///
 /// 跳过 `//` / `///` 开头的行：讲「此前叫什么、为什么改」的注释是资产，不是债。
@@ -79,7 +89,7 @@ void main() {
   });
 
   group('三态不得退回两参编码', () {
-    late final String src = File(kPolicyFile).readAsStringSync();
+    late final String src = _codeOf(kPolicyFile);
 
     test('DuplicatePolicy 是 sealed 的（非法组合不可表达）', () {
       expect(src.contains('sealed class DuplicatePolicy'), isTrue,
@@ -98,14 +108,8 @@ void main() {
 
     test('resolveDuplicateTitle 只收一个策略参数', () {
       expect(src.contains('DuplicatePolicy policy'), isTrue);
-      // 只看代码行：文件顶部的设计说明里引用了旧的两参签名（讲清为什么收敛），
-      // 那是资产不是债。
-      final String code = src
-          .split('\n')
-          .where((String l) => !l.trimLeft().startsWith('//'))
-          .join('\n');
       expect(
-        code.contains('bool skipIfExists'),
+        src.contains('bool skipIfExists'),
         isFalse,
         reason: '不得退回 (bool, callback?) 两参编码三态',
       );
@@ -113,15 +117,21 @@ void main() {
   });
 
   test('策略分派必须穷尽（switch 不许有 default）', () {
-    final String src = File(kPolicyFile).readAsStringSync();
+    // 剥注释后再找 switch：注释里的 `default:` 不该算数。
+    final String src = _codeOf(kPolicyFile);
     final int switchAt = src.indexOf('switch (policy)');
     expect(switchAt, isNonNegative, reason: '分派应是对 policy 的 switch');
     final String body = src.substring(switchAt);
     expect(
-      RegExp(r'^\s*default:', multiLine: true).hasMatch(body),
-      isFalse,
-      reason: '写了 default 就等于放弃穷尽检查——加第四种策略时这里必须编译报错，'
-          '而不是悄悄走兜底分支',
+      // Dart 3 里 `case _:` / `case _ when ...` 与 `default:` 等效，一样让穷尽性
+      // 失效。只堵 `default:` 是假绿——实测 `case _:` 能整个穿过去。
+      RegExp(r'^\s*(default\s*:|case\s+_\s*(:|when))', multiLine: true)
+          .allMatches(body)
+          .map((RegExpMatch m) => m.group(0)!.trim())
+          .toList(),
+      isEmpty,
+      reason: '写兜底分支就等于放弃穷尽检查——加第四种策略时这里必须编译报错，'
+          '而不是悄悄走进 default / case _',
     );
   });
 }

--- a/hibiki/test/tools/duplicate_policy_naming_guard_test.dart
+++ b/hibiki/test/tools/duplicate_policy_naming_guard_test.dart
@@ -1,0 +1,127 @@
+/// 守卫：重复条目处置的命名统一（CLAUDE.md 命名术语表新增三行）。
+///
+/// ## 守什么
+///
+/// 1. **淘汰词不得复活**。`skipIfExists` / `onDuplicateTitle` / `DuplicateTitleCallback`
+///    / `DuplicateTitleResolution` / `resolveBookTitleConflict` / `isVideoPathReferenced`
+///    / `filterDroppedGameExes` 已全部换名，`lib/` 与 `test/` 里不得再出现（注释除外
+///    ——讲历史的注释是有价值的，扫描跳过注释行）。
+///
+/// 2. **三态不得退回两参编码**。这是本次改名的实质：此前
+///    `(bool skipIfExists, AskOnDuplicate? onDuplicateTitle)` 两个参数有四种组合、
+///    只有三种合法，第四种的行为从没被写下来过。收敛成 sealed `DuplicatePolicy`
+///    后非法组合不可表达。守卫钉住 sealed 声明与三个 factory 都在。
+///
+/// 3. **分派必须穷尽**。`resolveDuplicateTitle` 里的 switch 不许写 `default`——
+///    将来加第四种策略要在这里编译报错，而不是悄悄落进某个兜底分支。
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+const String kPolicyFile = 'lib/src/epub/book_title_conflict.dart';
+
+/// 已淘汰的名字 → 换成什么。
+const Map<String, String> kRetiredNames = <String, String>{
+  'skipIfExists': 'DuplicatePolicy.skip()',
+  'onDuplicateTitle': 'policy: DuplicatePolicy.ask(...)',
+  'DuplicateTitleCallback': 'AskOnDuplicate',
+  'DuplicateTitleResolution': 'DuplicateChoice',
+  'resolveBookTitleConflict': 'resolveDuplicateTitle',
+  'isVideoPathReferenced': 'isDuplicateVideoPath',
+  'filterDroppedGameExes': 'filterOutDuplicateGameExes',
+};
+
+/// 本守卫自身的路径。它的 [kRetiredNames] 清单里当然写满了淘汰词——不排除自己就
+/// 会永远红（自指）。
+const String kSelfPath = 'test/tools/duplicate_policy_naming_guard_test.dart';
+
+/// 扫 [roots] 下所有 .dart 的**非注释**行，返回 `文件:行号` 命中列表。
+///
+/// 跳过 `//` / `///` 开头的行：讲「此前叫什么、为什么改」的注释是资产，不是债。
+List<String> _codeHits(List<String> roots, String needle) {
+  final List<String> hits = <String>[];
+  for (final String root in roots) {
+    final Directory dir = Directory(root);
+    if (!dir.existsSync()) continue;
+    for (final FileSystemEntity e in dir.listSync(recursive: true)) {
+      if (e is! File || !e.path.endsWith('.dart')) continue;
+      final String rel = e.path.replaceAll(r'\', '/');
+      if (rel.endsWith(kSelfPath)) continue;
+      final List<String> lines = e.readAsLinesSync();
+      for (int i = 0; i < lines.length; i++) {
+        final String trimmed = lines[i].trimLeft();
+        if (trimmed.startsWith('//')) continue;
+        if (lines[i].contains(needle)) {
+          hits.add('$rel:${i + 1}');
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+void main() {
+  const List<String> roots = <String>['lib', 'test'];
+
+  group('淘汰词不得复活', () {
+    kRetiredNames.forEach((String retired, String replacement) {
+      test('$retired 已退休（应使用 $replacement）', () {
+        expect(
+          _codeHits(roots, retired),
+          isEmpty,
+          reason: '`$retired` 是淘汰词，新代码请用 `$replacement`'
+              '（见 CLAUDE.md 命名术语表）。讲历史的注释不受限——把它写进注释即可。',
+        );
+      });
+    });
+  });
+
+  group('三态不得退回两参编码', () {
+    late final String src = File(kPolicyFile).readAsStringSync();
+
+    test('DuplicatePolicy 是 sealed 的（非法组合不可表达）', () {
+      expect(src.contains('sealed class DuplicatePolicy'), isTrue,
+          reason: '必须 sealed：否则外部可以再造第四种状态，穷尽 switch 失效');
+    });
+
+    test('三个策略 factory 都在', () {
+      for (final String f in <String>[
+        'factory DuplicatePolicy.ask(',
+        'factory DuplicatePolicy.skip(',
+        'factory DuplicatePolicy.suffix(',
+      ]) {
+        expect(src.contains(f), isTrue, reason: '缺少 $f');
+      }
+    });
+
+    test('resolveDuplicateTitle 只收一个策略参数', () {
+      expect(src.contains('DuplicatePolicy policy'), isTrue);
+      // 只看代码行：文件顶部的设计说明里引用了旧的两参签名（讲清为什么收敛），
+      // 那是资产不是债。
+      final String code = src
+          .split('\n')
+          .where((String l) => !l.trimLeft().startsWith('//'))
+          .join('\n');
+      expect(
+        code.contains('bool skipIfExists'),
+        isFalse,
+        reason: '不得退回 (bool, callback?) 两参编码三态',
+      );
+    });
+  });
+
+  test('策略分派必须穷尽（switch 不许有 default）', () {
+    final String src = File(kPolicyFile).readAsStringSync();
+    final int switchAt = src.indexOf('switch (policy)');
+    expect(switchAt, isNonNegative, reason: '分派应是对 policy 的 switch');
+    final String body = src.substring(switchAt);
+    expect(
+      RegExp(r'^\s*default:', multiLine: true).hasMatch(body),
+      isFalse,
+      reason: '写了 default 就等于放弃穷尽检查——加第四种策略时这里必须编译报错，'
+          '而不是悄悄走兜底分支',
+    );
+  });
+}


### PR DESCRIPTION
> **Stacked on #523**（base 是 `worktree-split-manga-book-import`，不是 develop）。#523 新建的 `MangaImportDialog` 也调这些回调，基于 develop 做必然撞车。#523 合入后本 PR 的 base 改指 develop 即可。
> 已 rebase 到 #523 最新（`858a06c20`），本 PR 只含一个 commit。

## 为什么不是「单纯改名」

原计划是把 `skipIfExists` 改成 `skipDuplicate`、`onDuplicateTitle` 改成 `askOnDuplicate`。做进去发现那是涂口红——**三个词仍然不是三个东西**。真正的问题是这三态由**两个参数**编码：

```dart
bool skipIfExists = false,                 // true  → 跳过
DuplicateTitleCallback? onDuplicateTitle,  // 非空  → 问用户
                                           // 都没有 → 自动加后缀
```

两个参数有四种组合，只有三种合法。第四种（`skipIfExists=true` **且**回调非空）的行为**从没被写下来过**——实现里是跳过赢，但调用方只能读实现才知道。

而且哪个导入器支持哪个参数还不齐：`importFromImageFolder` / `importArchive` 只有回调、没有 skip，于是**批量扫描压根用不了它们**。这个洞收敛成单参后自动消失。

## 改了什么

**1. sealed `DuplicatePolicy` 三态**

```dart
sealed class DuplicatePolicy {
  const factory DuplicatePolicy.ask(AskOnDuplicate ask) = AskDuplicate;  // 交互式单条
  const factory DuplicatePolicy.skip() = SkipDuplicate;                  // 批量 / 后台
  const factory DuplicatePolicy.suffix() = SuffixDuplicate;              // 程序化留副本
}
```

非法组合不可表达。`resolveDuplicateTitle` 里是**穷尽 switch，不写 `default`**——将来加第四种策略会在所有分派点编译报错，而不是悄悄落进兜底分支。

四个导入器（epub / pdf / manga / manga_archive）统一收单参，默认 `.suffix()`，与旧默认（无回调、无 skip = 自动加后缀）**逐字等价，零行为变化**。

**2. 判据统一用 `duplicate` 一词**

`isVideoPathReferenced` → `isDuplicateVideoPath`；`filterDroppedGameExes` → `filterOutDuplicateGameExes`。

（**更正我先前的说法**：我之前把这两个也说成「同一件事的三种策略」，那是错的——它们是**判据**不是策略，名字本身没毛病，只是没跟术语表对齐。）

**3. 选择枚举与策略词同形**

`DuplicateTitleResolution{addSuffix, cancel}` → `DuplicateChoice{suffix, cancel}`；`DuplicateTitleCallback` → `AskOnDuplicate`；`resolveBookTitleConflict` → `resolveDuplicateTitle`。

**4. CLAUDE.md 命名术语表补三行**，并写明一句关键约束：

> 三种策略的差异是**有意**的（交互预算不同——交互式单条 / 批量后台 / 程序化），不要再往一起合，但必须显式声明。

这是为了防下一个人「顺手统一一下行为」：书籍单本弹窗问得起，扫一个目录弹五十次框等于不可用（BUG-443）。

**5. 新增 `test/tools/duplicate_policy_naming_guard_test.dart`**
- 淘汰词不得复活（**注释除外**——讲「此前叫什么、为什么改」的注释是资产不是债）
- 三态不得退回两参编码（钉 sealed 声明 + 三个 factory）
- 分派 switch 不许有 `default`

## 契约变更（预期的红）

两条源码扫描守卫的锚点跟着换，**守的意图逐条保留**：
- `book_title_conflict_test` 锁 `DuplicatePolicy` 而非旧参数名 `onDuplicateTitle`
- `source_library_scanner_test` 锁 `DuplicatePolicy.skip()` 而非 `skipIfExists: true`

## 验证（rebase 后重跑）

- `flutter analyze`（含 test）**零问题**
- **5313 例**跑完（`test/epub` + `test/media` + `test/mining` + `test/tools` + `test/models`），我的改动范围内全绿

其中 2 条失败**均与本改动无交集**，已逐条核实：
1. `test/media/manga_routing_guard_test.dart`「漫画阅读统计不把页数当字数」——**develop 上的既有红**。它扫的 `manga_hibiki_page.dart` 在 develop / #523 基底 / 本分支上**逐字相同**且不在本 PR diff 内；守卫仍断言旧的 `charsRead: 0`，而 v60 起漫画改为同时落 `charsRead`（OCR 实义字数）+ `pagesRead`（页数），锚点过时。已另开小 PR 单独修。
2. `test/tools/update_manifest_publish_race_test.dart`——跑外部发布脚本，`exit=-1`，环境问题。

https://claude.ai/code/session_01MbeBrZt6qqasJQhK9c9tZd
