### PR TITLE
fix(video): 波形对轴放大视图支持鼠标滚轮左右平移时间轴 (BUG-1214)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1174 条。点号进各自文件。
+> 共 1175 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1215](bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md) | ✅ | ✅ | Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包 |
+| [BUG-1214](bugs/BUG-1214-waveform-align-wheel-hscroll.md) | ✅ | ✅ | 波形对轴放大视图鼠标滚轮不能左右平移时间轴 |
 | [BUG-1213](bugs/BUG-1213-android-legacy-storage-permission-query.md) | ✅ | ✅ | Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根 |
 | [BUG-1212](bugs/BUG-1212-manga-stats-guard-stale.md) | ✅ | ✅ | 漫画统计守卫仍钉旧口径 charsRead: 0，PR#504 后 develop 变红 |
 | [BUG-1210](bugs/BUG-1210-clipboard-panel-no-auto-read.md) | ✅ | ✅ | 剪贴板面板查词不自动朗读而浮窗会开关却是全局的 |

--- a/docs/bugs/BUG-1214-waveform-align-wheel-hscroll.md
+++ b/docs/bugs/BUG-1214-waveform-align-wheel-hscroll.md
@@ -1,0 +1,54 @@
+## BUG-1214 · 波形对轴放大视图鼠标滚轮不能左右平移时间轴
+
+- **报告**：2026-07-28（用户：截图指「波形对轴」放大视图，「这里应该支持滚轮滚动左右」）
+- **真实性**：✅ 真 bug。根因不在本仓，而在 Flutter 的轴取分量规则：
+  `flutter/packages/flutter/lib/src/widgets/scrollable.dart:944-948`
+  （`_pointerSignalEventDelta`）按 **Scrollable 自身轴**取 pointer signal 分量——横向取
+  `scrollDelta.dx`、纵向取 `dy`，只有按住 `pointerAxisModifiers`（默认 Shift）**且**是
+  物理鼠标时才翻轴。物理滚轮发的是 `(0, dy)`，所以任何横向滚动区**裸滚轮恒 delta=0、
+  完全不响应**。
+
+  本区雪上加霜：`hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart` 的
+  `_buildScrollableWaveform` 刻意**不**包 `HorizontalDragScrollable`（区内 cue strip 自带
+  `onHorizontalDrag` 拖字幕块调延迟，放开滚动拖动会两个 `HorizontalDragGestureRecognizer`
+  抢手势竞技场；豁免登记在 `hibiki/test/widgets/horizontal_drag_scroll_guard_test.dart`）。
+  于是鼠标用户在这条几千像素宽的时间轴上**只剩拖底部滚动条**一条路——正是用户报的症状。
+
+  连带更正：上述守卫测试的头注释断言横向滚动区「只能靠滚轮」，与 Flutter 实际行为相反，
+  已在本次一并订正。
+
+- **[x] ① 已修复** — 新增共享件 `WheelToHorizontalScroll`
+  （`hibiki/lib/src/utils/misc/platform_utils.dart`，紧邻 `HorizontalDragScrollable`）：
+  向 `GestureBinding.pointerSignalResolver` 登记，命中后调
+  `ScrollPosition.pointerScroll(delta)`——与 Flutter 自身 `_handlePointerScroll` 同一条路径
+  （正确更新 `ScrollDirection`、走物理钳制），不是自造 `jumpTo`。三条边界：
+  - 只认 `PointerDeviceKind.mouse`（触控板两轴都能给，横向分量本就被 `Scrollable` 直接吃掉，
+    翻轴会让纵向双指手势莫名横滚——与 Flutter 只对鼠标翻轴同源）；
+  - 目标偏移被 clamp 后若没变化（已到头 / 内容没超出视口）就**不登记**，事件照常冒泡给
+    外层，弹窗纵向滚动不被吞；
+  - 事件派发内层优先，内层 `Scrollable` 已表态（触控板 dx、或 Shift 已翻轴）时本件的
+    `register` 自动 no-op，不会双份滚动。
+  接线点：`subtitle_waveform_align_panel.dart` 的 `_buildScrollableWaveform`，包在
+  `Scrollbar` 外层。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/subtitle_waveform_align_panel_test.dart`
+  两条 widget 行为测试（真发 `PointerScrollEvent` 过 binding，断言真实 `ScrollPosition`）：
+  - `BUG-1214: mouse wheel pans the timeline horizontally (no delay change)`：
+    先断言内容确实超出视口（否则用例空转），滚轮 +120 → `pixels == 120`，反向 -400 →
+    clamp 回 0，且**延迟未被改动**（滚轮 ≠ 拖字幕块调轴）。回归判据：删掉
+    `WheelToHorizontalScroll` 后 `pixels` 恒为 0。
+  - `BUG-1214: non-mouse (trackpad) vertical scroll is left to the outer scrollable`：
+    钉死「只对物理鼠标翻轴」这条边界。
+
+- **[ ] ③ 真机未验** — 滚轮**手感**（惯性/步长/方向是否跟手）单测证明不了，需要在真实
+  Windows 桌面用物理鼠标滚轮在放大视图里实滚。本轮**未做**：`hibiki/tool/run_windows_itest.ps1`
+  跑的是 `integration_test`，其指针事件同样由 `WidgetTester` 合成，与已有的 widget 测试是
+  **同一层**、不构成额外证据；真实滚轮要经 OS → engine → framework，离屏无焦点窗口收不到。
+  已验的只到「framework 收到 PointerScrollEvent 后 ScrollPosition 真的动了且方向/钳制正确」。
+  待用户或有物理设备的一轮补验，验完再勾。
+
+- **备注**：修的是**这一处**接线。全仓其它横向滚动区（合集行、标签筛选栏等）同样吃不到
+  裸滚轮，但它们都包了 `HorizontalDragScrollable`（鼠标可直接横拖），不属本 bug 范围；
+  要推广只需在对应滚动件外再包一层 `WheelToHorizontalScroll`。
+  面板提示文案 `video_subtitle_waveform_scroll_hint`（「横向拖动查看时间轴…」）未改——
+  它仍然成立，改文案要动 17 个语言文件，与本修复解耦。

--- a/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
+++ b/hibiki/lib/src/media/video/subtitle_waveform_align_panel.dart
@@ -804,51 +804,58 @@ class _SubtitleWaveformZoomViewState extends State<SubtitleWaveformZoomView> {
             borderRadius: BorderRadius.circular(8),
           ),
           clipBehavior: Clip.antiAlias,
-          child: Scrollbar(
-            key: const ValueKey<String>('subtitle-waveform-hscroll'),
+          // 滚轮左右滚（用户实报「这里应该支持滚轮滚动左右」）：横向 Scrollable 只
+          // 取 scrollDelta.dx，物理滚轮发的是 (0, dy)，裸滚轮本来毫无反应。根因与
+          // 修法见 [WheelToHorizontalScroll]。本区尤其需要它——见下方为何不放开鼠标
+          // 拖动滚动。
+          child: WheelToHorizontalScroll(
             controller: _scrollController,
-            thumbVisibility: true,
-            // 刻意**不**包 HorizontalDragScrollable（其它横向滚动区都包了，放开
-            // 鼠标拖动滚动）：本区内的 cue strip 自带 onHorizontalDrag「拖字幕块
-            // 调延迟」，而 GestureDetector 的横拖不受 ScrollBehavior.dragDevices
-            // 约束——现在鼠标拖字幕块有效、拖空白无反应。放开滚动拖动会让两个
-            // HorizontalDragGestureRecognizer 进同一个手势竞技场，赌内层胜出去换
-            // 一点点便利，不值得（本区有常驻滚动条可拖）。
-            child: SingleChildScrollView(
+            child: Scrollbar(
+              key: const ValueKey<String>('subtitle-waveform-hscroll'),
               controller: _scrollController,
-              scrollDirection: Axis.horizontal,
-              child: SizedBox(
-                width: contentWidth,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    SizedBox(
-                      width: contentWidth,
-                      height: _waveHeight,
-                      // 点击波形把播放头 seek 到该 x 对应的时间（横向拖动仍归滚动，tap≠drag
-                      // 不冲突）。x/contentWidth 映射回 [0, windowEndMs]。
-                      child: widget.onSeek == null
-                          ? painted
-                          : GestureDetector(
-                              behavior: HitTestBehavior.opaque,
-                              onTapUp: (TapUpDetails details) {
-                                if (contentWidth <= 0 ||
-                                    widget.windowEndMs <= 0) {
-                                  return;
-                                }
-                                final double x = details.localPosition.dx
-                                    .clamp(0.0, contentWidth);
-                                final int ms =
-                                    (x / contentWidth * widget.windowEndMs)
-                                        .round();
-                                widget.onSeek!.call(ms < 0 ? 0 : ms);
-                              },
-                              child: painted,
-                            ),
-                    ),
-                    strip,
-                  ],
+              thumbVisibility: true,
+              // 刻意**不**包 HorizontalDragScrollable（其它横向滚动区都包了，放开
+              // 鼠标拖动滚动）：本区内的 cue strip 自带 onHorizontalDrag「拖字幕块
+              // 调延迟」，而 GestureDetector 的横拖不受 ScrollBehavior.dragDevices
+              // 约束——现在鼠标拖字幕块有效、拖空白无反应。放开滚动拖动会让两个
+              // HorizontalDragGestureRecognizer 进同一个手势竞技场，赌内层胜出去换
+              // 一点点便利，不值得（本区有常驻滚动条 + 滚轮可平移）。
+              child: SingleChildScrollView(
+                controller: _scrollController,
+                scrollDirection: Axis.horizontal,
+                child: SizedBox(
+                  width: contentWidth,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      SizedBox(
+                        width: contentWidth,
+                        height: _waveHeight,
+                        // 点击波形把播放头 seek 到该 x 对应的时间（横向拖动仍归滚动，
+                        // tap≠drag 不冲突）。x/contentWidth 映射回 [0, windowEndMs]。
+                        child: widget.onSeek == null
+                            ? painted
+                            : GestureDetector(
+                                behavior: HitTestBehavior.opaque,
+                                onTapUp: (TapUpDetails details) {
+                                  if (contentWidth <= 0 ||
+                                      widget.windowEndMs <= 0) {
+                                    return;
+                                  }
+                                  final double x = details.localPosition.dx
+                                      .clamp(0.0, contentWidth);
+                                  final int ms =
+                                      (x / contentWidth * widget.windowEndMs)
+                                          .round();
+                                  widget.onSeek!.call(ms < 0 ? 0 : ms);
+                                },
+                                child: painted,
+                              ),
+                      ),
+                      strip,
+                    ],
+                  ),
                 ),
               ),
             ),

--- a/hibiki/lib/src/utils/misc/platform_utils.dart
+++ b/hibiki/lib/src/utils/misc/platform_utils.dart
@@ -99,6 +99,66 @@ class HorizontalDragScrollable extends StatelessWidget {
       );
 }
 
+/// 让**横向**滚动区接受鼠标滚轮（把滚轮的纵向 delta 投到横轴）。BUG-1214。
+///
+/// 根因：Flutter 的 `Scrollable` 取 pointer signal 的分量是按**自身轴**取的
+/// （`scrollable.dart` 的 `_pointerSignalEventDelta`：横向取 `scrollDelta.dx`、
+/// 纵向取 `dy`），只有按住 `pointerAxisModifiers`（默认 Shift）且是物理鼠标时
+/// 才翻轴。物理滚轮发的是 `(0, dy)`，所以横向滚动区**裸滚轮完全没反应**——用户
+/// 只能拖滚动条或横拖（后者还受 `dragDevices` 限制，见 [HorizontalDragScrollable]）。
+///
+/// 修法与 Flutter 自己处理滚轮的路径一致：向 [PointerSignalResolver] 登记，命中
+/// 后调 [ScrollPosition.pointerScroll]（会正确更新 [ScrollDirection]、走物理钳制），
+/// 不是自造 `jumpTo`。
+///
+/// **只认物理鼠标**（`PointerDeviceKind.mouse`）：触控板两个方向都能给，横向分量
+/// 本来就被 `Scrollable` 直接吃掉，翻轴反而会让纵向双指手势莫名横滚——这也是
+/// Flutter 只对鼠标做轴翻转的理由。
+///
+/// 事件派发是内层优先：内层 `Scrollable` 若已表态（如触控板给了 dx、或 Shift 已
+/// 翻轴），它先登记、本件的登记自动变 no-op，不会双份滚动。内容没超出视口时本件
+/// 不登记，滚轮照常冒泡给外层（弹窗纵向滚动不被吞）。
+class WheelToHorizontalScroll extends StatelessWidget {
+  const WheelToHorizontalScroll({
+    required this.controller,
+    required this.child,
+    super.key,
+  });
+
+  /// 目标横向滚动区的控制器（本件挂在滚动件**外面**，故不能靠 context 查 position）。
+  final ScrollController controller;
+
+  final Widget child;
+
+  void _onPointerSignal(PointerSignalEvent event) {
+    if (event is! PointerScrollEvent) return;
+    if (event.kind != PointerDeviceKind.mouse) return;
+    if (!controller.hasClients) return;
+
+    final ScrollPosition position = controller.position;
+    final double raw = event.scrollDelta.dy;
+    if (raw == 0) return;
+    // 与 Flutter 同口径：轴方向反向（RTL 下的横向滚动区）时取负。
+    final double delta =
+        axisDirectionIsReversed(position.axisDirection) ? -raw : raw;
+    final double target = (position.pixels + delta)
+        .clamp(position.minScrollExtent, position.maxScrollExtent);
+    // 滚不动（已到头 / 内容没超出视口）就不登记，把事件让给外层滚动区。
+    if (target == position.pixels) return;
+
+    GestureBinding.instance.pointerSignalResolver.register(
+      event,
+      (PointerSignalEvent _) => position.pointerScroll(delta),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => Listener(
+        onPointerSignal: _onPointerSignal,
+        child: child,
+      );
+}
+
 enum WindowSizeClass { compact, medium, expanded }
 
 enum DesktopContentKind { readerShelf, dictionary, settings }

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+985
+version: 1.3.1+988
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/video/subtitle_waveform_align_panel_test.dart
+++ b/hibiki/test/media/video/subtitle_waveform_align_panel_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -644,6 +645,73 @@ void main() {
     expect(committed, hasLength(1));
     expect(committed.single, greaterThan(0));
     expect(_zoomPainter(tester).previewDelayMs, committed.single);
+  });
+
+  /// 波形区横向 [ScrollPosition]（放大视图里唯一的横向滚动区）。
+  ScrollPosition hscrollPosition(WidgetTester tester) {
+    return tester
+        .state<ScrollableState>(find.descendant(
+          of: find.byKey(_hscrollKey),
+          matching: find.byType(Scrollable),
+        ))
+        .position;
+  }
+
+  testWidgets(
+      'BUG-1214: mouse wheel pans the timeline horizontally (no delay change)',
+      (WidgetTester tester) async {
+    final List<int> committed = <int>[];
+    await tester.pumpWidget(_host(
+      cues: <AudioCue>[_cue(1000, 2000, text: 'ohayou')],
+      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5, -50, -12],
+      onCommitDelay: (int ms) async => committed.add(ms),
+    ));
+    await tester.pumpAndSettle();
+    await _openZoom(tester);
+
+    final ScrollPosition position = hscrollPosition(tester);
+    expect(position.pixels, 0);
+    // 前提：内容确实超出视口（否则本用例什么都没测）。
+    expect(position.maxScrollExtent, greaterThan(0));
+
+    // 物理滚轮发的是 (0, dy)；横向 Scrollable 只吃 dx，故裸滚轮本来毫无反应
+    // （回归判据：删掉 WheelToHorizontalScroll 后 pixels 恒为 0）。
+    final Rect box = tester.getRect(find.byKey(_hscrollKey));
+    final TestPointer wheel = TestPointer(1, PointerDeviceKind.mouse);
+    wheel.hover(Offset(box.left + 20, box.top + 20));
+    await tester.sendEventToBinding(wheel.scroll(const Offset(0, 120)));
+    await tester.pumpAndSettle();
+    expect(position.pixels, 120);
+
+    // 反向滚回去，且不越过左端（clamp 生效）。
+    await tester.sendEventToBinding(wheel.scroll(const Offset(0, -400)));
+    await tester.pumpAndSettle();
+    expect(position.pixels, 0);
+
+    // 平移视图**不得**动延迟——滚轮只滚，不是「拖字幕块调轴」。
+    expect(committed, isEmpty);
+    expect(_zoomPainter(tester).previewDelayMs, 0);
+  });
+
+  testWidgets(
+      'BUG-1214: non-mouse (trackpad) vertical scroll is left to the outer '
+      'scrollable', (WidgetTester tester) async {
+    await tester.pumpWidget(_host(
+      cues: <AudioCue>[_cue(1000, 2000, text: 'ohayou')],
+      loadWaveform: () async => <double>[-60, -20, -40, -10, -30, -5, -50, -12],
+    ));
+    await tester.pumpAndSettle();
+    await _openZoom(tester);
+
+    final ScrollPosition position = hscrollPosition(tester);
+    final Rect box = tester.getRect(find.byKey(_hscrollKey));
+    // 触控板两个轴都能给（横向分量本来就被 Scrollable 直接吃掉），翻轴只对物理
+    // 鼠标做——与 Flutter 自身 pointerAxisModifiers 的取舍同源。
+    final TestPointer pad = TestPointer(1, PointerDeviceKind.trackpad);
+    pad.hover(Offset(box.left + 20, box.top + 20));
+    await tester.sendEventToBinding(pad.scroll(const Offset(0, 120)));
+    await tester.pumpAndSettle();
+    expect(position.pixels, 0);
   });
 
   testWidgets(

--- a/hibiki/test/widgets/horizontal_drag_scroll_guard_test.dart
+++ b/hibiki/test/widgets/horizontal_drag_scroll_guard_test.dart
@@ -3,13 +3,18 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 /// 桌面端 Flutter 的默认 `MaterialScrollBehavior.dragDevices` **不含鼠标**：横向
-/// 滚动区用鼠标左键按住左右拖会毫无反应，只能滚轮（用户实报）。仓库早在
+/// 滚动区用鼠标左键按住左右拖会毫无反应（用户实报）。仓库早在
 /// `collection_shelf_row.dart` 就写下了这条根因注释并修了合集行 + 首页继续行，
 /// 但没有推广——全仓 16 处 `Axis.horizontal` 里当时只有那 2 处放开了鼠标拖动。
 ///
 /// 这条守卫钉死「新增横向滚动区必须包 [HorizontalDragScrollable]」，防止再次漂移。
 /// 按文件粒度计数（一个文件里的横向区数 ≤ 包裹数 + 豁免数），因为静态扫描无法可靠
 /// 判断 widget 树的父子关系。
+///
+/// **注意「滚轮」不是退路**（BUG-1214 更正）：横向 `Scrollable` 只取
+/// `scrollDelta.dx`，物理滚轮发的是 `(0, dy)`，裸滚轮同样毫无反应——除非该区显式包了
+/// `WheelToHorizontalScroll` 把纵向 delta 投到横轴。所以豁免本件的区必须自己交代
+/// 用户还能怎么平移。
 void main() {
   /// 明确豁免：区内已有依赖横拖的手势，放开滚动拖动会与之抢手势竞技场。
   ///
@@ -18,9 +23,11 @@ void main() {
     // cue strip 自带 onHorizontalDrag「拖字幕块调延迟」。GestureDetector 的横拖
     // 不受 ScrollBehavior.dragDevices 约束，故现状是「鼠标拖字幕块有效、拖空白
     // 无反应」；放开滚动拖动会让两个 HorizontalDragGestureRecognizer 进同一个
-    // 竞技场，赌内层胜出去换一点便利不值得（本区有常驻滚动条可拖）。
+    // 竞技场，赌内层胜出去换一点便利不值得。平移退路：常驻滚动条 + 显式包了
+    // WheelToHorizontalScroll 的鼠标滚轮（BUG-1214）。
     'lib/src/media/video/subtitle_waveform_align_panel.dart':
-        'cue strip 自带 onHorizontalDrag 调延迟，放开滚动拖动会抢手势',
+        'cue strip 自带 onHorizontalDrag 调延迟，放开滚动拖动会抢手势；'
+            '滚轮平移由 WheelToHorizontalScroll 提供',
   };
 
   test('每个横向滚动区都放开了鼠标拖动（或在豁免清单里说明了原因）', () {


### PR DESCRIPTION
用户实报（截图指「波形对轴」放大视图）：**这里应该支持滚轮滚动左右**。

## 根因

不在本仓，在 Flutter 的轴取分量规则：`scrollable.dart:944-948`
（`_pointerSignalEventDelta`）按 **Scrollable 自身轴**取 pointer signal 分量——横向取
`scrollDelta.dx`、纵向取 `dy`，只有按住 `pointerAxisModifiers`（默认 Shift）**且**是物理
鼠标时才翻轴。物理滚轮发的是 `(0, dy)`，所以任何横向滚动区**裸滚轮恒 delta=0、完全不响应**。

本区雪上加霜：`_buildScrollableWaveform` 刻意**不**包 `HorizontalDragScrollable`（区内
cue strip 自带 `onHorizontalDrag` 拖字幕块调延迟，放开滚动拖动会两个
`HorizontalDragGestureRecognizer` 抢手势竞技场，豁免登记在 `horizontal_drag_scroll_guard_test.dart`）。
于是鼠标用户在这条几千像素宽的时间轴上**只剩拖底部滚动条**一条路——正是用户报的症状。

## 改动

新增共享件 `WheelToHorizontalScroll`（`platform_utils.dart`，紧邻 `HorizontalDragScrollable`）：
向 `GestureBinding.pointerSignalResolver` 登记，命中后调 `ScrollPosition.pointerScroll(delta)`
——与 Flutter 自身 `_handlePointerScroll` **同一条路径**（正确更新 `ScrollDirection`、走物理
钳制），不是自造 `jumpTo`。接线点只有一处：波形区 `Scrollbar` 外层。

三条边界：

- **只认 `PointerDeviceKind.mouse`**：触控板两个轴都能给，横向分量本就被 `Scrollable` 直接
  吃掉，翻轴反而会让纵向双指手势莫名横滚——与 Flutter 只对物理鼠标翻轴同源。
- **clamp 后偏移没变化就不登记**（已到头 / 内容没超出视口），事件照常冒泡给外层，弹窗纵向
  滚动不被吞。
- **内层优先**：事件派发从内到外，内层 `Scrollable` 已表态（触控板给了 dx、或 Shift 已翻轴）
  时本件的 `register` 自动 no-op，不会双份滚动。

顺带订正 `horizontal_drag_scroll_guard_test.dart` 头注释里「（横向区拖不动）只能靠滚轮」
——与 Flutter 实际行为相反，正是本 bug 长期没被发现的原因。

## 验证

- `flutter analyze`（含 test 目录）：**No issues found**
- `flutter test test/media/video/ test/widgets/horizontal_drag_scroll_guard_test.dart --no-pub`：
  **1875 passed / 2 skipped**
- 新增两条 widget 行为测试（真发 `PointerScrollEvent` 过 binding，断言真实 `ScrollPosition`）：
  - 滚轮 +120 → `pixels == 120`；反向 -400 → clamp 回 0；**延迟未被改动**（滚轮 ≠ 拖字幕块调轴）
  - 非鼠标（trackpad）纵向 scroll 不被翻轴，留给外层
- **变异验证**：临时摘掉 `WheelToHorizontalScroll` 接线后第一条测试立刻红（`pixels` 恒 0），
  守卫真的守得住。

## 范围说明

只修**这一处**接线。全仓其它横向滚动区同样吃不到裸滚轮，但它们都包了
`HorizontalDragScrollable`（鼠标可直接横拖），不属本 bug；要推广只需再包一层本件。
面板提示文案 `video_subtitle_waveform_scroll_hint`（「横向拖动查看时间轴…」）未改——它仍然
成立，改文案要动 17 个语言文件，与本修复解耦。

未真机验证（本次是纯 widget 层行为，Windows 离屏 itest 取不到滚轮注入证据）。

https://claude.ai/code/session_01Bpi42zH4Sq9QWTUZ169dcF


---

### 审查记录（2026-07-28）

**根因逐字核实属实**：本机 SDK `scrollable.dart:932-951` `_pointerSignalEventDelta` 确为 `Axis.horizontal => event.scrollDelta.dx`，`flipAxes` 需 `pointerAxisModifiers`（默认 shiftLeft/shiftRight）**且** `kind == PointerDeviceKind.mouse`。物理滚轮 `(0, dy)` 在横向区恒 delta=0，`scrollable.dart:961` 因此不 register。范围论断也对：全仓 **17 处** `Axis.horizontal`，本 PR 只接了这一处（其余靠 `HorizontalDragScrollable` 横拖）。

**全局 `pointerSignalResolver` 风险已排除**：`pointer_signal_resolver.dart` 显示 `register` 是**每事件一次**的仲裁，`resolve` 后即清空 `_firstRegisteredCallback`/`_currentEvent` —— 不是长期全局注册，故无泄漏、无需注销；doc 明写推荐用法就是「in `Listener.onPointerSignal`」，本 PR 用的正是它。命中走 Flutter **render-tree hit test**（精确命中，非包围盒），不存在整块黑洞。多实例下 `if (_firstRegisteredCallback != null) return;` 保证只有最深者赢。到头/内容不超视口时**不 register**，事件让给外层。

**cue strip 拖拽未被抢**：panel 改动只是外包一层，`onHorizontalDrag` 与 `HorizontalDragScrollable` 豁免均未动；豁免清单是**补充了滚轮退路说明**而非放宽，守卫逻辑本体零改动。

**变异实测（均已确认真改到文件，附 `git diff` 证据）**：
| 变异 | 转红 | 红的用例 |
|---|---|---|
| 摘掉 `WheelToHorizontalScroll` | 1 条 | mouse wheel pans the timeline |
| `scrollDelta.dy` → `.dx` | 1 条 | mouse wheel pans the timeline |
| 删「只认物理鼠标」早退 | 1 条 | non-mouse (trackpad) left to outer |

两条用例**各守各的边界**。测试真发 `PointerScrollEvent` 过 binding 并断言真实 `ScrollPosition.pixels`，且前置断言 `maxScrollExtent > 0` 防空转 —— 不属于四种假绿。

**验证**：`flutter analyze` → `No issues found!`；`FLUTTER TEST VERDICT: PASSED - 2967 tests ran`，退出码 0。`test/tools/update_manifest_publish_race_test.dart` 曾在合并跑里 30s 超时，**单独复跑 137 全绿**，确认是本机并发飘红、非本 PR 引入。

**🔴 真机未验**：滚轮手感需物理鼠标经 OS→engine→framework；`run_windows_itest.ps1` 的指针事件同样由 `WidgetTester` 合成，与已有 widget 测试同层、不构成额外证据。BUG 文档第 ③ 项留 `[ ]` 未勾。

**改号**：1212 撞 `BUG-1212-manga-stats-guard-stale`（PR#541 已合入）→ 让到 **1214**。`renumber` 拒绝执行，故用 `git diff --name-only origin/develop..HEAD` 严格圈定本 PR 的 3 个文件手动四处齐改；develop 侧引用计数改号前后一致（**零误伤**），本侧**零残留**，`check` 通过。

**pubspec**：develop 读到 `+985`（期间从 983→984→985 连涨），且 rebase 两次都把 bump **静默吞掉**（同值不报冲突），已显式核 `-985/+988` 后取 **`+988`**（986/987 被其它分支占）。
