### PR TITLE
test(manga): 统计守卫跟上 v60 口径，钉量纲不交叉（BUG-1212）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1170 条。点号进各自文件。
+> 共 1171 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1212](bugs/BUG-1212-manga-stats-guard-stale.md) | ✅ | ✅ | 漫画统计守卫仍钉旧口径 charsRead: 0，PR#504 后 develop 变红 |
 | [BUG-1209](bugs/BUG-1209-folder-picker-requests-camera-permission.md) | ✅ | ✅ | 安卓选文件夹时顺带弹相机权限申请 |
 | [BUG-1208](bugs/BUG-1208-ps51-getrelativepath-build-dist.md) | ✅ | ✅ | helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩 |
 | [BUG-1207](bugs/BUG-1207-android-embedded-torrent-dead-setting.md) | ✅ | ✅ | 安卓下载设置能选「内置引擎」并改下载目录，实际静默回退外接 qBittorrent |

--- a/docs/bugs/BUG-1212-manga-stats-guard-stale.md
+++ b/docs/bugs/BUG-1212-manga-stats-guard-stale.md
@@ -1,0 +1,25 @@
+## BUG-1212 · 漫画统计守卫仍钉旧口径 charsRead: 0，PR#504 后 develop 变红
+- **报告**：2026-07-28（用户：内部，develop 全量套件 4256 条中的一条红）
+- **真实性**：✅ 真 bug（性质是**契约变更后守卫没跟上**，不是功能回归）。
+  根因 `hibiki/test/media/manga_routing_guard_test.dart:94`（旧断言 `src.contains('charsRead: 0')`）
+  对应实现侧 `hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart:1810`
+  （PR#504 / commit `62d0cc8ad` 把 `charsRead: 0` 字面量换成 `charsRead: charsRead`，
+  并新增 `pagesRead: pagesRead`，schema v60）。
+  归属证据：合入前 `d9d95cf0a` 单跑该文件 PASSED - 12 tests；合入点 `1ca0ef0ad` 单跑
+  同一文件 FAILED（唯一失败就是这条）。
+- **[x] ① 已修复** — 守卫断言从「钉字面量 `charsRead: 0`」改为「钉两个量纲的接线不交叉」。
+  旧断言的 reason 混了两件事：(A)「漫画无字数」是旧统计口径，产品决策已改为统计纳入
+  漫画/视频/游戏，漫画字数取 mokuro / 内置 OCR 实义字符（与 EPUB 同源的
+  `japaneseCharCount`），恒 0 反而是错的；(B)「页数不得塞进 charsRead」仍然成立，是这条
+  守卫真正在守的不变量，PR#504 正是用 v60 新增的独立 `pagesRead` 列来兑现它。
+  新守卫保留并**加强** (B)：断言字数来自 `mangaAccumulateReadingStats`、`charsRead:`
+  与 `pagesRead:` 各自落各自的列，且显式否证四种交叉接线写法
+  （`charsRead: pagesRead` / `charsRead: _sessionPagesRead` / `pagesRead: charsRead` /
+  `_sessionCharsRead += added.pages` / `_sessionPagesRead += added.chars`）。
+  实现侧一行未改。
+- **[x] ② 已加自动化测试** — 同文件 `hibiki/test/media/manga_routing_guard_test.dart`
+  的 `漫画阅读统计：字数走 OCR 记账、页数走独立列，两个量纲不交叉`。
+  已做变异验证：把实现改成 `charsRead: pagesRead` 后该守卫立刻变红（确认是加强而非放宽），
+  改回后 PASSED - 12 tests。
+- **备注**：PDF 侧 `reader_pdf_routing_guard_test.dart` 的同名 `charsRead: 0` 断言**不受影响**，
+  PDF 仍无字数口径（`reader_pdf_page.dart:251` 保持 `charsRead: 0`），本次不动。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+981
+version: 1.3.1+982
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/manga_routing_guard_test.dart
+++ b/hibiki/test/media/manga_routing_guard_test.dart
@@ -88,11 +88,34 @@ void main() {
     expect(src.contains('pageBased'), isTrue, reason: 'PDF/漫画共用页码型进度分支');
   });
 
-  test('漫画阅读统计不把页数当字数（charsRead 恒 0）', () {
+  test('漫画阅读统计：字数走 OCR 记账、页数走独立列，两个量纲不交叉', () {
     final String src =
         read('lib/src/media/manga/reader/manga_hibiki_page.dart');
-    expect(src.contains('charsRead: 0'), isTrue,
-        reason: '漫画无字数；把页数塞进 charsRead 会污染统计页的「字数」口径');
+    // 旧守卫钉的是字面量 `charsRead: 0`，理由写「漫画无字数」+「页数塞进 charsRead
+    // 会污染字数口径」。前半句在 schema v60 起**不再成立**：统计口径已按产品决策纳入
+    // 漫画，漫画的字来自 mokuro / 内置 OCR 的实义字符（口径与 EPUB 同源的
+    // japaneseCharCount），恒 0 反而是错的——统计页会永远显示漫画 0 字。
+    //
+    // 后半句仍然是真不变量，且是这条守卫真正要防的东西，所以原样保留并加强：页数有
+    // 自己的 `pagesRead` 列（v60 新增），绝不能冒充字数，否则「字数」和「阅读速度」
+    // 两个口径同时被污染。下面从「钉一个字面量」改成「钉两个量纲的接线不交叉」。
+    expect(src.contains('mangaAccumulateReadingStats'), isTrue,
+        reason: '字数必须来自 OCR 文本记账，不能凭页数现编');
+    expect(src.contains('charsRead: charsRead'), isTrue,
+        reason: 'charsRead 落 OCR 字符数');
+    expect(src.contains('pagesRead: pagesRead'), isTrue,
+        reason: '页数落 v60 新增的 pagesRead 独立列，不与字数混流');
+    // 交叉接线守卫：任何把页数喂给字数、或把字数喂给页数的写法都算口径污染。
+    expect(src.contains('charsRead: pagesRead'), isFalse,
+        reason: '页数绝不能塞进 charsRead（会污染字数口径与阅读速度）');
+    expect(src.contains('charsRead: _sessionPagesRead'), isFalse,
+        reason: '页数绝不能塞进 charsRead（会污染字数口径与阅读速度）');
+    expect(src.contains('pagesRead: charsRead'), isFalse,
+        reason: '字数绝不能塞进 pagesRead');
+    expect(src.contains('_sessionCharsRead += added.pages'), isFalse,
+        reason: '会话字数累加口必须取 chars，不能取 pages');
+    expect(src.contains('_sessionPagesRead += added.chars'), isFalse,
+        reason: '会话页数累加口必须取 pages，不能取 chars');
     expect(src.contains('ReadingTimeTracker'), isTrue, reason: '复用时长统计');
   });
 


### PR DESCRIPTION
## 背景

PR#504（统计口径纳入漫画/视频/游戏，schema v60）合入后 develop 上 `manga_routing_guard_test` 变红。

**归属证据**：
- 合入前 `d9d95cf0a` 单跑该文件 → `PASSED - 12 tests`
- 合入点 `1ca0ef0ad` 单跑同一文件 → `FAILED`，唯一失败就是这条

确认由 PR#504 的 commit `62d0cc8ad` 引入。

## 性质：契约变更，不是功能回归

旧断言 `expect(src.contains('charsRead: 0'), isTrue)`，reason 写「漫画无字数；把页数塞进 charsRead 会污染统计页的「字数」口径」。这句话混了两件事：

- **(A)「漫画无字数」** —— 旧统计口径。产品决策已改为统计纳入漫画/视频/游戏，漫画的字来自 mokuro / 内置 OCR 的实义字符（与 EPUB 同源的 `japaneseCharCount`）。恒 0 反而是错的：统计页会永远显示漫画 0 字。
- **(B)「页数不得塞进 charsRead」** —— 仍然成立，而且这才是这条守卫真正在守的不变量。PR#504 正是用 v60 新增的独立 `pagesRead` 列来兑现它。

## 改法：保留并加强 (B)，只去掉被推翻的 (A)

守卫从「钉一个字面量」改成「钉两个量纲的接线不交叉」：

- 字数必须来自 `mangaAccumulateReadingStats`（不能凭页数现编）
- `charsRead:` / `pagesRead:` 各落各的列
- 显式否证五种交叉接线写法：`charsRead: pagesRead`、`charsRead: _sessionPagesRead`、`pagesRead: charsRead`、`_sessionCharsRead += added.pages`、`_sessionPagesRead += added.chars`

**变异验证**：把实现改成 `charsRead: pagesRead` 后新守卫立刻变红 → 确认是加强而非放宽。改回后 `PASSED - 12 tests`。

**实现侧一行未改。** PDF 侧 `reader_pdf_routing_guard_test.dart` 的同名 `charsRead: 0` 断言不受影响（PDF 仍无字数口径，`reader_pdf_page.dart:251` 保持原样），本次不动。

## 验证

- `flutter analyze` → `No issues found!`
- `FLUTTER TEST VERDICT: PASSED - 225 tests ran, all tests passed`（exit 0），覆盖 `test/media/manga_routing_guard_test.dart`、PDF 同族守卫、`reader_stats_pure_duration_guard_static_test.dart`、`test/media/manga` 全量、bugs 守卫
- `dart run tool/bug.dart check` 通过 1171 条无撞号
- pubspec `1.3.1+981` → `1.3.1+982`（从 develop 实际值读取）

BUG-1212

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb