### PR TITLE
fix(android): 查询侧按 SDK 分级选存储权限，修 Android 7~10 加不了扫描根 (BUG-1213)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1171 条。点号进各自文件。
+> 共 1172 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1213](bugs/BUG-1213-android-legacy-storage-permission-query.md) | ✅ | ✅ | Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根 |
 | [BUG-1212](bugs/BUG-1212-manga-stats-guard-stale.md) | ✅ | ✅ | 漫画统计守卫仍钉旧口径 charsRead: 0，PR#504 后 develop 变红 |
 | [BUG-1209](bugs/BUG-1209-folder-picker-requests-camera-permission.md) | ✅ | ✅ | 安卓选文件夹时顺带弹相机权限申请 |
 | [BUG-1208](bugs/BUG-1208-ps51-getrelativepath-build-dist.md) | ✅ | ✅ | helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩 |

--- a/docs/bugs/BUG-1213-android-legacy-storage-permission-query.md
+++ b/docs/bugs/BUG-1213-android-legacy-storage-permission-query.md
@@ -1,0 +1,53 @@
+## BUG-1213 · Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根
+
+- **报告**：2026-07-28（用户：）
+- **真实性**：✅ 真 bug（恒定复现，非偶发）。根因 `hibiki/lib/src/platform/android/android_permission_service.dart:6-7`（修复前）——
+  查询侧 `hasExternalStoragePermission()` 只看 `Permission.manageExternalStorage.isGranted`。
+  `MANAGE_EXTERNAL_STORAGE`（「所有文件访问权限」）是 Android 11 / API 30 才引入的；
+  本仓锁定的 `permission_handler_android` 10.2.1 在 `PermissionManager.java:381-382`
+  （`checkPermissionStatus`）与 `:255-256`（`requestPermissions`）都有
+  `Build.VERSION.SDK_INT < Build.VERSION_CODES.R → PERMISSION_STATUS_RESTRICTED`，
+  而 `isGranted` 只在 `granted` 时为真，所以在 API 24~29 上该谓词**恒假**。
+  于是 `hibiki/lib/src/media/import/real_path_directory_picker.dart:46-56`
+  的 `pickRealDirectoryPath()` 恒走「需要授权」分支 `return null` —— 用户在
+  Android 7~10 上**根本加不了本地扫描根**。
+  申请侧 `requestExternalStoragePermission()` 早就有 `Permission.storage` 回退，
+  查询侧却没有对应的 SDK 分级 —— **两侧不对称**就是本 bug 的根因形状。
+
+- **[x] ① 已修复** — `hibiki/lib/src/platform/android/android_permission_service.dart`：
+  抽出唯一的 `_externalStoragePermission()` 解析函数（API < 30 → `Permission.storage`；
+  API >= 30 或版本未知 → `Permission.manageExternalStorage`），**查询侧和申请侧共用同一个
+  解析结果**，两侧对同一件事只能给出同一个答案。SDK 版本走仓内既有的
+  `PlatformDeviceInfoService.sdkVersion`（`AndroidDeviceInfoService` → `device_info_plus`），
+  由 `hibiki/lib/src/platform/platform_services.dart:70` 构造注入，**未引入新依赖**
+  （与 `AndroidClipboardService(deviceInfo)` 同一套路）。
+  API >= 30 上「manage 被拒后再申请基础 storage」的既有行为保留不变。
+  提交：见本分支。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/platform/android_permission_service_test.dart`（36 条）：
+  被测对象是真实的 `AndroidPermissionService`；测试替换 `PermissionHandlerPlatform.instance`
+  为一个**忠实复刻 permission_handler_android 原生语义**的假平台
+  （`manageExternalStorage` 在 `sdkInt < 30` 时返回 `restricted`），不是抄一份谓词副本。
+  覆盖：① API 24/26/28/29 已授予 `storage` → 查询侧必须返回已授权（这正是修复前恒假的那条路径）；
+  ② API 30/33/35 已授予 `manageExternalStorage` → 行为不变，且 API 30 上只有基础 `storage` 不算全文件访问；
+  ③ SDK × 已授权集合的整张矩阵上，申请侧返回值与查询侧一致（锁死两侧同源）。
+  **变异实测**：把 `_externalStoragePermission()` 退回恒返回 `manageExternalStorage`，
+  6 条断言转红（API 24/26/28/29 各一条、API 29 分区存储一条、申请侧 API 24~29 一条）；
+  变异确实落到了文件上（`diff` 显示分流的 4 行被删除），恢复后再跑
+  `FLUTTER TEST VERDICT: PASSED - 36 tests ran`。
+
+- **[ ] ③ 真机验证（未做）** — 本机 `adb devices` 无 Android 7~10 设备/模拟器，
+  **未在真机上复测原始失败路径**。Android 11+ 设备测不出这条（那条路径本来就走
+  `manageExternalStorage`）。需要 API 24~29 真机/模拟器上验证：设置 → 添加扫描根 →
+  授予存储权限 → 目录选择器返回真实路径而不是 null。
+
+- **备注**：
+  - **API 29（Android 10）是分区存储中间态**：`MANAGE_EXTERNAL_STORAGE` 在 29 上
+    **根本不存在、不可能被授予**，所以 29 归入 `< 30` 分支、以 `Permission.storage`
+    （即 `READ_EXTERNAL_STORAGE`，已在 `AndroidManifest.xml:4` 声明）为准，是**唯一可能正确**的答案。
+  - **遗留不确定项（本次未动，属发布面改动）**：`hibiki/android/app/src/main/AndroidManifest.xml`
+    的 `<application>` 未声明 `android:requestLegacyExternalStorage="true"`，而
+    `targetSdk 35`。在 API 29 上这意味着 app 处于分区存储模式，授予
+    `READ_EXTERNAL_STORAGE` 后**通过 `dart:io` 直接读任意真实路径仍可能被系统限制**。
+    本次修复解决的是「权限查询恒假导致连目录都选不了」，29 上后续的真实路径读盘是否通畅
+    需真机确认；若确实被挡，再单独评估是否加该 manifest 标志（发布面改动，需先报批）。

--- a/hibiki/lib/src/platform/android/android_permission_service.dart
+++ b/hibiki/lib/src/platform/android/android_permission_service.dart
@@ -2,18 +2,53 @@ import 'package:hibiki_platform/hibiki_platform.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 class AndroidPermissionService implements PlatformPermissionService {
+  /// SDK 版本从 [_deviceInfo] 取，让版本依赖在构造处显式可见
+  /// （与 `AndroidClipboardService` 同一套路，不引入新依赖）。
+  AndroidPermissionService(this._deviceInfo);
+
+  final PlatformDeviceInfoService _deviceInfo;
+
+  /// `MANAGE_EXTERNAL_STORAGE`（「所有文件访问权限」）是 Android 11 / API 30
+  /// 才引入的。在 API < 30 上 permission_handler 对它**恒返回 `restricted`**
+  /// （`permission_handler_android` 的 `PermissionManager.java`：
+  /// `checkPermissionStatus` 与 `requestPermissions` 两处都有
+  /// `SDK_INT < VERSION_CODES.R -> PERMISSION_STATUS_RESTRICTED`），
+  /// 而 `isGranted` 只在 `granted` 时为真，于是旧系统上该谓词恒假。
+  ///
+  /// 旧系统（API 24~29）上真正管辖外部存储读写的是 `READ/WRITE_EXTERNAL_STORAGE`，
+  /// 也就是 `Permission.storage`。查询侧和申请侧必须按 SDK 版本选**同一个**权限，
+  /// 否则「问的」和「要的」不是同一件事——那正是 BUG-1213 的根因形状。
+  static const int _manageExternalStorageMinSdk = 30;
+
+  /// 当前系统版本下真正管辖「全盘真实路径访问」的那一个权限。
+  ///
+  /// 查询侧与申请侧共用这一个解析函数——两侧对同一件事只能有同一个答案。
+  /// `sdkVersion` 拿不到时（`null`）按新系统处理：在旧系统上多问一次
+  /// `MANAGE_EXTERNAL_STORAGE` 只会拿到 `restricted`（无害），而在新系统上
+  /// 漏掉它会真的读不到盘。
+  Future<Permission> _externalStoragePermission() async {
+    final int? sdk = await _deviceInfo.sdkVersion;
+    if (sdk != null && sdk < _manageExternalStorageMinSdk) {
+      return Permission.storage;
+    }
+    return Permission.manageExternalStorage;
+  }
+
   @override
-  Future<bool> hasExternalStoragePermission() =>
-      Permission.manageExternalStorage.isGranted;
+  Future<bool> hasExternalStoragePermission() async =>
+      (await _externalStoragePermission()).isGranted;
 
   @override
   Future<bool> requestExternalStoragePermission() async {
-    final status = await Permission.manageExternalStorage.request();
-    if (!status.isGranted) {
-      final basic = await Permission.storage.request();
-      return basic.isGranted;
+    final Permission permission = await _externalStoragePermission();
+    final PermissionStatus status = await permission.request();
+    if (status.isGranted) return true;
+    if (permission != Permission.storage) {
+      // API >= 30：用户拒绝「所有文件访问」后仍申请基础存储权限（保留既有行为）。
+      await Permission.storage.request();
     }
-    return true;
+    // 结论必须与查询侧同源，否则两侧会对同一件事给出不同答案。
+    return hasExternalStoragePermission();
   }
 
   @override

--- a/hibiki/lib/src/platform/platform_services.dart
+++ b/hibiki/lib/src/platform/platform_services.dart
@@ -67,7 +67,7 @@ class PlatformServices {
         directory: AndroidDirectoryService(),
         lifecycle: AndroidLifecycleService(),
         clipboard: clipboard,
-        permission: AndroidPermissionService(),
+        permission: AndroidPermissionService(deviceInfo),
         deviceInfo: deviceInfo,
         createAnkiRepository: AnkiRepository.new,
         androidClipboard: clipboard,

--- a/hibiki/pubspec.lock
+++ b/hibiki/pubspec.lock
@@ -1608,7 +1608,7 @@ packages:
     source: hosted
     version: "9.0.8"
   permission_handler_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: permission_handler_platform_interface
       sha256: "68abbc472002b5e6dfce47fe9898c6b7d8328d58b5d2524f75e277c07a97eb84"

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+982
+version: 1.3.1+983
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"
@@ -247,6 +247,10 @@ dev_dependencies:
   # flutter_charset_detector; declared here only for the test import.
   flutter_charset_detector_platform_interface: ^1.1.0
   plugin_platform_interface: ^2.1.0
+  # BUG-1213: android_permission_service_test 用它替换
+  # PermissionHandlerPlatform.instance，在 flutter test 里复刻
+  # permission_handler_android 的 SDK 分级语义（原生通道不可用）。
+  permission_handler_platform_interface: ^3.9.0
   drift_dev: ^2.23.0
   dependency_validator: ^3.0.0
   flutter_lints: ^2.0.1

--- a/hibiki/test/platform/android_permission_service_test.dart
+++ b/hibiki/test/platform/android_permission_service_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/platform/android/android_permission_service.dart';
+import 'package:permission_handler_platform_interface/permission_handler_platform_interface.dart';
+
+import '../helpers/fake_platform_services.dart';
+
+/// 忠实复刻 `permission_handler_android` 10.2.1 的原生语义（`PermissionManager.java`）：
+///
+/// - `MANAGE_EXTERNAL_STORAGE` 在 `SDK_INT < VERSION_CODES.R`(30) 时，
+///   `checkPermissionStatus` 与 `requestPermissions` 都返回 `RESTRICTED`
+///   （见 PermissionManager.java 的 `SDK_INT < R -> PERMISSION_STATUS_RESTRICTED`）。
+/// - 其余权限按 [granted] 集合返回 granted / denied。
+///
+/// 这里建模的是**平台插件的行为**，不是被测谓词的副本——被测对象仍是真实的
+/// [AndroidPermissionService]。
+class _FakePermissionHandlerPlatform extends PermissionHandlerPlatform {
+  _FakePermissionHandlerPlatform({required this.sdkInt});
+
+  int sdkInt;
+  final Set<Permission> granted = <Permission>{};
+  final List<Permission> checked = <Permission>[];
+  final List<Permission> requested = <Permission>[];
+
+  PermissionStatus _statusOf(Permission permission) {
+    if (permission == Permission.manageExternalStorage && sdkInt < 30) {
+      return PermissionStatus.restricted;
+    }
+    return granted.contains(permission)
+        ? PermissionStatus.granted
+        : PermissionStatus.denied;
+  }
+
+  @override
+  Future<PermissionStatus> checkPermissionStatus(Permission permission) async {
+    checked.add(permission);
+    return _statusOf(permission);
+  }
+
+  @override
+  Future<Map<Permission, PermissionStatus>> requestPermissions(
+    List<Permission> permissions,
+  ) async {
+    requested.addAll(permissions);
+    return <Permission, PermissionStatus>{
+      for (final Permission permission in permissions)
+        permission: _statusOf(permission),
+    };
+  }
+}
+
+void main() {
+  late PermissionHandlerPlatform originalPlatform;
+  late _FakePermissionHandlerPlatform platform;
+
+  AndroidPermissionService serviceFor(int? sdk) {
+    final FakeDeviceInfoService deviceInfo = FakeDeviceInfoService()..sdk = sdk;
+    return AndroidPermissionService(deviceInfo);
+  }
+
+  setUp(() {
+    originalPlatform = PermissionHandlerPlatform.instance;
+    platform = _FakePermissionHandlerPlatform(sdkInt: 30);
+    PermissionHandlerPlatform.instance = platform;
+  });
+
+  tearDown(() {
+    PermissionHandlerPlatform.instance = originalPlatform;
+  });
+
+  group('BUG-1213 旧安卓（API 24~29）查询侧', () {
+    // 这是修复前恒假的那条路径：MANAGE_EXTERNAL_STORAGE 在 API < 30 恒 restricted，
+    // 于是选文件夹恒走「需要授权」分支返回 null，用户根本加不了扫描根。
+    for (final int sdk in <int>[24, 26, 28, 29]) {
+      test('API $sdk 上已授予 storage → 查询侧返回已授权', () async {
+        platform.sdkInt = sdk;
+        platform.granted.add(Permission.storage);
+
+        expect(await serviceFor(sdk).hasExternalStoragePermission(), isTrue);
+        expect(
+          platform.checked,
+          contains(Permission.storage),
+          reason: 'API < 30 必须查 storage，而不是恒 restricted 的 '
+              'manageExternalStorage',
+        );
+        expect(platform.checked,
+            isNot(contains(Permission.manageExternalStorage)));
+      });
+
+      test('API $sdk 上未授予 storage → 查询侧返回未授权', () async {
+        platform.sdkInt = sdk;
+
+        expect(await serviceFor(sdk).hasExternalStoragePermission(), isFalse);
+      });
+    }
+
+    test(
+        'API 29（分区存储中间态）仍以 storage 为准：manageExternalStorage 在 29 上'
+        '无法被授予，storage 是该系统唯一可得的外部存储权限', () async {
+      platform.sdkInt = 29;
+      // 即便平台把 manageExternalStorage 标进 granted 集合，真实设备上 29 也
+      // 拿不到它（下面的 restricted 语义会覆盖），查询结论只能来自 storage。
+      platform.granted.add(Permission.manageExternalStorage);
+
+      expect(await serviceFor(29).hasExternalStoragePermission(), isFalse);
+
+      platform.granted.add(Permission.storage);
+      expect(await serviceFor(29).hasExternalStoragePermission(), isTrue);
+    });
+  });
+
+  group('BUG-1213 新安卓（API >= 30）行为不变', () {
+    for (final int sdk in <int>[30, 33, 35]) {
+      test('API $sdk 上已授予 manageExternalStorage → 查询侧返回已授权', () async {
+        platform.sdkInt = sdk;
+        platform.granted.add(Permission.manageExternalStorage);
+
+        expect(await serviceFor(sdk).hasExternalStoragePermission(), isTrue);
+        expect(platform.checked, contains(Permission.manageExternalStorage));
+        expect(platform.checked, isNot(contains(Permission.storage)));
+      });
+    }
+
+    test('API 30 上只有基础 storage 不算全文件访问', () async {
+      platform.sdkInt = 30;
+      platform.granted.add(Permission.storage);
+
+      expect(await serviceFor(30).hasExternalStoragePermission(), isFalse);
+    });
+
+    test('sdkVersion 拿不到时按新系统处理（查 manageExternalStorage）', () async {
+      platform.sdkInt = 30;
+      platform.granted.add(Permission.manageExternalStorage);
+
+      expect(await serviceFor(null).hasExternalStoragePermission(), isTrue);
+      expect(platform.checked, contains(Permission.manageExternalStorage));
+    });
+  });
+
+  group('BUG-1213 查询侧与申请侧对称', () {
+    test('API 24~29 申请侧直接申请 storage', () async {
+      platform.sdkInt = 26;
+      platform.granted.add(Permission.storage);
+
+      expect(await serviceFor(26).requestExternalStoragePermission(), isTrue);
+      expect(platform.requested, contains(Permission.storage));
+      expect(
+        platform.requested,
+        isNot(contains(Permission.manageExternalStorage)),
+        reason: 'API < 30 申请 manageExternalStorage 只会拿到 restricted，是空转',
+      );
+    });
+
+    test('API >= 30 申请侧仍先要 manageExternalStorage，被拒后回退 storage', () async {
+      platform.sdkInt = 33;
+
+      expect(await serviceFor(33).requestExternalStoragePermission(), isFalse);
+      expect(
+          platform.requested,
+          containsAllInOrder(<Permission>[
+            Permission.manageExternalStorage,
+            Permission.storage,
+          ]));
+    });
+
+    // 根因形状是「两侧对同一件事给出不同答案」。这条把整张 SDK × 授权矩阵
+    // 都跑一遍，锁死两侧同源。
+    for (final int sdk in <int>[24, 28, 29, 30, 33]) {
+      for (final Set<Permission> preGranted in <Set<Permission>>{
+        <Permission>{},
+        <Permission>{Permission.storage},
+        <Permission>{Permission.manageExternalStorage},
+        <Permission>{Permission.storage, Permission.manageExternalStorage},
+      }) {
+        test(
+            'API $sdk / 已授 ${preGranted.map((Permission p) => p.value).toList()}'
+            ' → 申请侧返回值与查询侧一致', () async {
+          platform.sdkInt = sdk;
+          platform.granted.addAll(preGranted);
+          final AndroidPermissionService service = serviceFor(sdk);
+
+          final bool requestAnswer =
+              await service.requestExternalStoragePermission();
+          final bool queryAnswer = await service.hasExternalStoragePermission();
+
+          expect(requestAnswer, queryAnswer);
+        });
+      }
+    }
+  });
+}


### PR DESCRIPTION
## 症状

Android 7~10（API 24~29）上用户**根本加不了本地扫描根**，恒定复现、不是偶发。

## 根因

`hibiki/lib/src/platform/android/android_permission_service.dart:6-7`（修复前）查询侧只看
`Permission.manageExternalStorage.isGranted`。

`MANAGE_EXTERNAL_STORAGE`（「所有文件访问权限」）是 Android 11 / API 30 才引入的。本仓锁定的
`permission_handler_android` **10.2.1** 在 `PermissionManager.java:381-382`（`checkPermissionStatus`）
和 `:255-256`（`requestPermissions`）都有
`Build.VERSION.SDK_INT < Build.VERSION_CODES.R → PERMISSION_STATUS_RESTRICTED`，
而 `isGranted` 只在 `granted` 时为真 → **API < 30 上该谓词恒假**。

于是 `real_path_directory_picker.dart:46-56` 的 `pickRealDirectoryPath()` 恒走「需要授权」分支
`return null`。

**申请侧早就有 `Permission.storage` 回退，查询侧却没有对应的 SDK 分级 —— 两侧不对称就是根因形状。**

## 修复

抽出**唯一**的 `_externalStoragePermission()`：

- API < 30 → `Permission.storage`（`READ_EXTERNAL_STORAGE`，已在 `AndroidManifest.xml:4` 声明）
- API >= 30 或版本未知 → `Permission.manageExternalStorage`

**查询侧与申请侧共用同一个解析结果**，且申请侧的返回值最终回到查询侧谓词 —— 两侧对同一件事只给出
同一个答案，不再制造新的不对称。API >= 30 上「manage 被拒后再申请基础 storage」的既有行为原样保留。

SDK 版本走仓内既有的 `PlatformDeviceInfoService.sdkVersion`（`AndroidDeviceInfoService` →
`device_info_plus`），由 `PlatformServices` 构造注入（与 `AndroidClipboardService(deviceInfo)` 同一
套路），**未引入新运行时依赖**。

**API 29（Android 10）分区存储中间态**：`MANAGE_EXTERNAL_STORAGE` 在 29 上根本不存在、不可能被授予，
`READ_EXTERNAL_STORAGE` 是该系统唯一可得的外部存储权限，所以 29 归入 `< 30` 分支是唯一可能正确的答案。

**未动 AndroidManifest.xml / Gradle。**

## 测试

`hibiki/test/platform/android_permission_service_test.dart`（36 条）：被测对象是真实的
`AndroidPermissionService`；测试把 `PermissionHandlerPlatform.instance` 换成**忠实复刻
permission_handler_android 原生 SDK 分级语义**的假平台（`manageExternalStorage` 在 `sdkInt < 30`
返回 `restricted`），不是手抄一份谓词副本。

- API 24/26/28/29 已授予 `storage` → 查询侧必须返回已授权（修复前恒假的那条路径）
- API 30/33/35 已授予 `manageExternalStorage` → 行为不变；API 30 上只有基础 `storage` 不算全文件访问
- SDK × 已授权集合的整张矩阵上，申请侧返回值与查询侧一致

**变异实测**：把 `_externalStoragePermission()` 退回恒返回 `manageExternalStorage`（`diff` 确认分流
4 行真被删除），**6 条断言转红**；恢复后 `FLUTTER TEST VERDICT: PASSED - 36 tests ran`。

## 验证

- `flutter analyze`（含 test）→ `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/platform/ test/media/video/real_path_directory_picker_test.dart test/tools/bugs_per_file_guard_test.dart`
  → `FLUTTER TEST VERDICT: PASSED - 113 tests ran, all tests passed`，退出码 0

## 🔴 未做：真机验证

本机 `adb devices` 无设备，`system-images` 只有 android-34 / android-36.1，**没有任何 API 24~29 的
真机或模拟器**，因此**未在 Android 7~10 上复测原始失败路径**。Android 11+ 设备测不出这条（那条路径
本来就走 `manageExternalStorage`），故不拿 11+ 冒充。BUG 文档里真机项留 `[ ]` 未勾。

## 遗留不确定项

`AndroidManifest.xml` 的 `<application>` 未声明 `android:requestLegacyExternalStorage="true"`，而
`targetSdk 35`。API 29 上这意味着 app 处于分区存储模式，即使拿到 `READ_EXTERNAL_STORAGE`，后续用
`dart:io` 直读任意真实路径**仍可能被系统限制**。本 PR 解决的是「权限查询恒假导致连目录都选不了」；
29 上后续读盘是否通畅需真机确认，若确实被挡再单独评估该 manifest 标志（发布面改动，需先报批）。

BUG-1213

---

**取号说明**：原取号 BUG-1212 与 develop 上先落地的 `BUG-1212-manga-stats-guard-stale` 撞车，已改为 **BUG-1213**（文件名 / 正文 H2 / 代码注释 / 测试名四处一起改，对方引用计数不变）。
