### PR TITLE
fix(download): Jimaku 条目自动选中加季号校验 (BUG-1215)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,9 +33,9 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1215](bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md) | ✅ | ✅ | Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包 |
 | [BUG-1213](bugs/BUG-1213-android-legacy-storage-permission-query.md) | ✅ | ✅ | Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根 |
 | [BUG-1212](bugs/BUG-1212-manga-stats-guard-stale.md) | ✅ | ✅ | 漫画统计守卫仍钉旧口径 charsRead: 0，PR#504 后 develop 变红 |
-| [BUG-1211](bugs/BUG-1211-jimaku-entry-wrong-season-auto-select.md) | ✅ | ✅ | Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包 |
 | [BUG-1210](bugs/BUG-1210-clipboard-panel-no-auto-read.md) | ✅ | ✅ | 剪贴板面板查词不自动朗读而浮窗会开关却是全局的 |
 | [BUG-1209](bugs/BUG-1209-folder-picker-requests-camera-permission.md) | ✅ | ✅ | 安卓选文件夹时顺带弹相机权限申请 |
 | [BUG-1208](bugs/BUG-1208-ps51-getrelativepath-build-dist.md) | ✅ | ✅ | helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,12 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1173 条。点号进各自文件。
+> 共 1174 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1213](bugs/BUG-1213-android-legacy-storage-permission-query.md) | ✅ | ✅ | Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根 |
 | [BUG-1212](bugs/BUG-1212-manga-stats-guard-stale.md) | ✅ | ✅ | 漫画统计守卫仍钉旧口径 charsRead: 0，PR#504 后 develop 变红 |
+| [BUG-1211](bugs/BUG-1211-jimaku-entry-wrong-season-auto-select.md) | ✅ | ✅ | Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包 |
 | [BUG-1210](bugs/BUG-1210-clipboard-panel-no-auto-read.md) | ✅ | ✅ | 剪贴板面板查词不自动朗读而浮窗会开关却是全局的 |
 | [BUG-1209](bugs/BUG-1209-folder-picker-requests-camera-permission.md) | ✅ | ✅ | 安卓选文件夹时顺带弹相机权限申请 |
 | [BUG-1208](bugs/BUG-1208-ps51-getrelativepath-build-dist.md) | ✅ | ✅ | helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩 |

--- a/docs/bugs/BUG-1211-jimaku-entry-wrong-season-auto-select.md
+++ b/docs/bugs/BUG-1211-jimaku-entry-wrong-season-auto-select.md
@@ -1,0 +1,40 @@
+## BUG-1211 · Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包
+- **报告**：2026-07-28（用户：PR#515 审查建议 b / PR#530 施工方自报未解决的另一半）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/anime_download_dialog.dart:590`
+  （改前 `_resolveJimakuEntryFor` 的 `return entries.first;`）——自动选中的判据只有
+  「Jimaku 服务端返回的第一条」，既不打相似度分也不核季号。
+  BUG-1206（PR#530）把配对推迟到种子 add 之后、按包内真实视频文件名反查，
+  落位层 `matchJimakuFilesToVideoNames`（`anime_download_matching.dart:377`）
+  要求集号**严格相等**。但当自动选中的条目本身就是 S1（文件编号 1-12）、
+  而包是 S2 的 01-12 时，集号照样相等 —— 落位层无从分辨，字幕错季且看起来完全正确。
+  这一支在 `_subtitleEpisodesUnverified` 的注释里早已写明（「或自动选中的首条根本是
+  别的季」），只是当时没有检测手段，只能整类降级成 `~`。
+- **[x] ① 已修复** — 条目选择层加季号校验，收敛成纯函数
+  `resolveJimakuEntry` / `jimakuEntrySeasonConflicts` / `jimakuEntrySeason`
+  （`hibiki/lib/src/media/torrent/anime_download_matching.dart` 尾部）：
+  1. 用户手选过的条目**一律放行**（用户可能就是要另一季的字幕，如合集版编号不同）；
+  2. 条目挂的 `anilist_id` 命中所选番 → 放行（AniList 按季拆条目，id 命中即权威），
+     于是校验实际只作用在文本回退搜出来的条目上 —— 错季真正的产地；
+  3. 种子标题解析不出季号（`NyaaTorrent.season == null`）→ 不校验，维持现状自动选，
+     不因信息缺失关掉一个本来能用的功能；
+  4. 其余情况按 `jimakuEntrySeason(entry.name)` 比对，条目名不写季号按**第一季**算
+     （Jimaku 的 S1 条目名就是光秃秃的作品名，这正是本 bug 的形状）。
+  自动选中改成「取第一条季号不冲突的」，全都冲突则不选，并在字幕列表上方用与
+  「集号未核对」同一排版的提示行（`_buildSubsHintRow` +
+  `anime_download_subs_season_mismatch`）说明原因，不静默。选中种子这一刻
+  （`_selectTorrent`）才知道包的季号，故在那里复核选番阶段的自动选中结果；
+  `~` 徽标（`_subtitleEpisodesUnverified`）同步补上季号冲突这一支。
+  提交：见 PR 分支 `fix/jimaku-season-guard`。
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/torrent/anime_download_matching_test.dart`（group「条目自动选中的季号校验」，
+  10 例：S1×S2 不自动选 / 候选里有对得上的季就选它 / 两边都无季号照常自动选 /
+  种子无季号不凭空拦 / 手选不被拦（带对照组）/ 手选已失效则回退且仍受校验 /
+  anilist_id 命中放行 + 挂错 id 不放行 / 真实条目名季号解析）；
+  `hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart`（2 例 widget 行为：
+  S2 包 + S1 条目 → 不拉文件、不配字幕、显示原因提示行、候选仍可手选且手选后照常加载；
+  两边都无季号 → 仍自动选首条）。
+  变异实测：把 `jimakuEntrySeasonConflicts` 退回恒 false，上述断言转红 6 条。
+- **备注**：本轮只动条目选择层，PR#530 的「按包内真实文件名反查」链路未改。
+  已知遗留：选番阶段（还没选种）无从知道包的季号，此时仍自动选首条；
+  一旦选中种子即复核。合集/跨季包（`S01+S02`）不在本轮判据内，
+  种子标题解析出单一季号时才校验。

--- a/docs/bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md
+++ b/docs/bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md
@@ -1,4 +1,4 @@
-## BUG-1211 · Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包
+## BUG-1215 · Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包
 - **报告**：2026-07-28（用户：PR#515 审查建议 b / PR#530 施工方自报未解决的另一半）
 - **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/anime_download_dialog.dart:590`
   （改前 `_resolveJimakuEntryFor` 的 `return entries.first;`）——自动选中的判据只有

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46325 (2725 per locale)
+/// Strings: 46308 (2724 per locale)
 ///
-/// Built on 2026-07-28 at 12:36 UTC
+/// Built on 2026-07-28 at 12:37 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3646,9 +3646,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Preferred language when the series has no remembered choice';
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
   String get anime_download_subs_deferred =>
@@ -9873,10 +9870,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
@@ -16177,10 +16170,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
@@ -22497,10 +22486,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
@@ -28829,10 +28814,6 @@ class _StringsFr extends _StringsEn {
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
-  @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
   @override
@@ -35088,10 +35069,6 @@ class _StringsId extends _StringsEn {
   @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
@@ -41395,10 +41372,6 @@ class _StringsIt extends _StringsEn {
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
-  @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
   @override
@@ -47517,10 +47490,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
@@ -53642,10 +53611,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
@@ -59928,10 +59893,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
@@ -66228,10 +66189,6 @@ class _StringsPtBr extends _StringsEn {
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
-  @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
   @override
@@ -72511,10 +72468,6 @@ class _StringsRu extends _StringsEn {
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
-  @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
   @override
@@ -78741,10 +78694,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
   @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
@@ -85005,10 +84954,6 @@ class _StringsTr extends _StringsEn {
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
-  @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
   @override
@@ -91253,10 +91198,6 @@ class _StringsVi extends _StringsEn {
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
-  @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
   @override
@@ -97064,10 +97005,6 @@ class _StringsZhCn extends _StringsEn {
   String get video_setting_jimaku_default_language_hint => '该系列没有记住的语言时优先使用';
   @override
   String get video_jimaku_api_key_settings_hint => '也可在 设置 → 视频 → 字幕 中修改';
-  @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      '字幕只成功下载 ${done}/${total} 条';
   @override
   String get anime_download_subs_episodes_unverified => '集号未与该整季包核对，字幕可能来自别的季。';
   @override
@@ -103105,10 +103042,6 @@ class _StringsZhHk extends _StringsEn {
   String get video_jimaku_api_key_settings_hint =>
       'Also editable in Settings → Video → Subtitles';
   @override
-  String anime_download_subs_partial(
-          {required Object done, required Object total}) =>
-      'Subtitles: only ${done} of ${total} downloaded';
-  @override
   String get anime_download_subs_episodes_unverified =>
       'Episode numbers are not verified against this pack - subtitles may come from another season.';
   @override
@@ -108694,9 +108627,6 @@ extension on _StringsEn {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -114276,9 +114206,6 @@ extension on _StringsAr {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -119879,9 +119806,6 @@ extension on _StringsDe {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -125481,9 +125405,6 @@ extension on _StringsEs {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -131089,9 +131010,6 @@ extension on _StringsFr {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -136679,9 +136597,6 @@ extension on _StringsId {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -142284,9 +142199,6 @@ extension on _StringsIt {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -147851,9 +147763,6 @@ extension on _StringsJa {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -153422,9 +153331,6 @@ extension on _StringsKo {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -159020,9 +158926,6 @@ extension on _StringsNl {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -164615,9 +164518,6 @@ extension on _StringsPtBr {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -170215,9 +170115,6 @@ extension on _StringsRu {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -175799,9 +175696,6 @@ extension on _StringsTh {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -181392,9 +181286,6 @@ extension on _StringsTr {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -186980,9 +186871,6 @@ extension on _StringsVi {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':
@@ -192522,9 +192410,6 @@ extension on _StringsZhCn {
         return '该系列没有记住的语言时优先使用';
       case 'video_jimaku_api_key_settings_hint':
         return '也可在 设置 → 视频 → 字幕 中修改';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            '字幕只成功下载 ${done}/${total} 条';
       case 'anime_download_subs_episodes_unverified':
         return '集号未与该整季包核对，字幕可能来自别的季。';
       case 'anime_download_subs_deferred':
@@ -198084,9 +197969,6 @@ extension on _StringsZhHk {
         return 'Preferred language when the series has no remembered choice';
       case 'video_jimaku_api_key_settings_hint':
         return 'Also editable in Settings → Video → Subtitles';
-      case 'anime_download_subs_partial':
-        return ({required Object done, required Object total}) =>
-            'Subtitles: only ${done} of ${total} downloaded';
       case 'anime_download_subs_episodes_unverified':
         return 'Episode numbers are not verified against this pack - subtitles may come from another season.';
       case 'anime_download_subs_deferred':

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46308 (2724 per locale)
+/// Strings: 46325 (2725 per locale)
 ///
-/// Built on 2026-07-28 at 11:47 UTC
+/// Built on 2026-07-28 at 12:36 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3661,6 +3661,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Built-in engine requires a desktop platform. This device uses external qBittorrent.';
   String get stat_source_breakdown => 'By source';
   String stat_format_pages({required Object n}) => '${n} pages';
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -9894,6 +9896,9 @@ class _StringsAr extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -16195,6 +16200,9 @@ class _StringsDe extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -22512,6 +22520,9 @@ class _StringsEs extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -28840,6 +28851,9 @@ class _StringsFr extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -35097,6 +35111,9 @@ class _StringsId extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -41400,6 +41417,9 @@ class _StringsIt extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -47520,6 +47540,9 @@ class _StringsJa extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -53642,6 +53665,9 @@ class _StringsKo extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -59925,6 +59951,9 @@ class _StringsNl extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -66221,6 +66250,9 @@ class _StringsPtBr extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -72501,6 +72533,9 @@ class _StringsRu extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -78729,6 +78764,9 @@ class _StringsTh extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -84989,6 +85027,9 @@ class _StringsTr extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -91234,6 +91275,9 @@ class _StringsVi extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 // Path: <root>
@@ -97039,6 +97083,9 @@ class _StringsZhCn extends _StringsEn {
   String get stat_source_breakdown => '各来源';
   @override
   String stat_format_pages({required Object n}) => '${n} 页';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      '没有字幕条目对得上该种子的第 ${season} 季，已不自动选中。要用的话请手动选一条。';
 }
 
 // Path: <root>
@@ -103080,6 +103127,9 @@ class _StringsZhHk extends _StringsEn {
   String get stat_source_breakdown => 'By source';
   @override
   String stat_format_pages({required Object n}) => '${n} pages';
+  @override
+  String anime_download_subs_season_mismatch({required Object season}) =>
+      'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
 }
 
 /// Flat map(s) containing all translations.
@@ -108661,6 +108711,9 @@ extension on _StringsEn {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -114240,6 +114293,9 @@ extension on _StringsAr {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -119840,6 +119896,9 @@ extension on _StringsDe {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -125439,6 +125498,9 @@ extension on _StringsEs {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -131044,6 +131106,9 @@ extension on _StringsFr {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -136631,6 +136696,9 @@ extension on _StringsId {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -142233,6 +142301,9 @@ extension on _StringsIt {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -147797,6 +147868,9 @@ extension on _StringsJa {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -153365,6 +153439,9 @@ extension on _StringsKo {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -158960,6 +159037,9 @@ extension on _StringsNl {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -164552,6 +164632,9 @@ extension on _StringsPtBr {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -170149,6 +170232,9 @@ extension on _StringsRu {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -175730,6 +175816,9 @@ extension on _StringsTh {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -181320,6 +181409,9 @@ extension on _StringsTr {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -186905,6 +186997,9 @@ extension on _StringsVi {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }
@@ -192444,6 +192539,9 @@ extension on _StringsZhCn {
         return '各来源';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} 页';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            '没有字幕条目对得上该种子的第 ${season} 季，已不自动选中。要用的话请手动选一条。';
       default:
         return null;
     }
@@ -198003,6 +198101,9 @@ extension on _StringsZhHk {
         return 'By source';
       case 'stat_format_pages':
         return ({required Object n}) => '${n} pages';
+      case 'anime_download_subs_season_mismatch':
+        return ({required Object season}) =>
+            'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "字幕：未匹配到（可手动补）",
   "download_backend_desktop_only_note": "内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。",
   "stat_source_breakdown": "各来源",
-  "stat_format_pages": "$n 页"
+  "stat_format_pages": "$n 页",
+  "anime_download_subs_season_mismatch": "没有字幕条目对得上该种子的第 $season 季，已不自动选中。要用的话请手动选一条。"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "默认字幕语言",
   "video_setting_jimaku_default_language_hint": "该系列没有记住的语言时优先使用",
   "video_jimaku_api_key_settings_hint": "也可在 设置 → 视频 → 字幕 中修改",
-  "anime_download_subs_partial": "字幕只成功下载 $done/$total 条",
   "anime_download_subs_episodes_unverified": "集号未与该整季包核对，字幕可能来自别的季。",
   "anime_download_subs_deferred": "字幕将在下载完成后按包内实际文件配对",
   "anime_download_subs_pending": "字幕：待下载完成后配对",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2715,7 +2715,6 @@
   "video_setting_jimaku_default_language": "Default subtitle language",
   "video_setting_jimaku_default_language_hint": "Preferred language when the series has no remembered choice",
   "video_jimaku_api_key_settings_hint": "Also editable in Settings → Video → Subtitles",
-  "anime_download_subs_partial": "Subtitles: only $done of $total downloaded",
   "anime_download_subs_episodes_unverified": "Episode numbers are not verified against this pack - subtitles may come from another season.",
   "anime_download_subs_deferred": "Subtitles are matched after download, from the pack's actual files",
   "anime_download_subs_pending": "Subtitles: pending until download completes",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2722,5 +2722,6 @@
   "anime_download_subs_unmatched": "Subtitles: no match for this pack",
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
-  "stat_format_pages": "$n pages"
+  "stat_format_pages": "$n pages",
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
 }

--- a/hibiki/lib/src/media/torrent/anime_download_matching.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_matching.dart
@@ -419,3 +419,69 @@ List<ResolvedSubtitleMatch> matchJimakuFilesToVideoNames(
     ResolvedSubtitleMatch(videoFileName: only, file: sole),
   ];
 }
+
+/// Jimaku 条目名解析出的季号；名字不写季号一律按**第一季**算。
+///
+/// 「不写季号 = 第一季」是发布/编目惯例，也是被报的失败形状本身：Jimaku 的 S1
+/// 条目名就是光秃秃的作品名（`Sousou no Frieren`），S2 条目才带
+/// `2nd Season` / `第2期` / `S2` / `Part 2` 之类 token。若把「解析不出」当成
+/// 「未知、不校验」，S1 条目撞上 S2 包这条主线就永远拦不住。
+///
+/// 复用 [parseVideoFilename] 的季号规则（与播放器/刮削同一套解析器，不另写一份）。
+int jimakuEntrySeason(String entryName) =>
+    parseVideoFilename(entryName).season ?? 1;
+
+/// 「自动选中的 Jimaku 条目」与种子包的季号是否冲突。纯函数。
+///
+/// 补的是 BUG-1206 之外的另一半：落位层 [matchJimakuFilesToVideoNames] 只能靠
+/// 「集号严格相等」挡错配，可当条目本身就是 S1（编号 1-12）而包是 S2 的 01-12
+/// 时，集号照样相等 —— 落位层无从分辨，必须在**条目选择层**拦。
+///
+/// 判据只用手上已有的两个信息源，不新增任何网络请求：
+/// - [anilistId] 命中（条目挂的 `anilist_id` == 用户选的那个番）→ 一律不冲突。
+///   AniList 是**按季拆条目**的，id 命中即权威，条目名写不写季号都不重要；
+///   于是本校验实际只作用在「文本回退搜出来的条目」上，也就是错季真正的产地。
+/// - 种子标题解析不出季号（[torrentSeason] 为 null）→ 不冲突。我们对这个包的季
+///   一无所知，不能因为信息缺失就把一个本来能用的自动选择关掉。
+/// - 其余情况拿 [jimakuEntrySeason] 比对。
+bool jimakuEntrySeasonConflicts({
+  required JimakuEntry entry,
+  required int? torrentSeason,
+  required int? anilistId,
+}) {
+  if (anilistId != null && entry.anilistId == anilistId) return false;
+  if (torrentSeason == null) return false;
+  return jimakuEntrySeason(entry.name) != torrentSeason;
+}
+
+/// 重搜 / 选种后该**自动**选中哪条 Jimaku 条目。纯函数，UI 只做编排。
+///
+/// 顺序：
+/// 1. 用户手选过某条目（[userPickedEntryId]）且它仍在 [entries] 里 → 沿用手选，
+///    **不做任何季号校验**。用户可能就是要另一季的字幕（合集版编号不同等），
+///    拦他是越权；此前无条件重置成首条会把手选静默冲掉。
+/// 2. 否则按顺序取**第一条季号不冲突**的（[jimakuEntrySeasonConflicts]）。
+/// 3. 全都冲突（或 [entries] 为空）→ null：不自动选，由 UI 显式告知原因。
+JimakuEntry? resolveJimakuEntry(
+  List<JimakuEntry> entries, {
+  int? userPickedEntryId,
+  int? torrentSeason,
+  int? anilistId,
+}) {
+  if (entries.isEmpty) return null;
+  if (userPickedEntryId != null) {
+    for (final JimakuEntry entry in entries) {
+      if (entry.id == userPickedEntryId) return entry;
+    }
+  }
+  for (final JimakuEntry entry in entries) {
+    if (!jimakuEntrySeasonConflicts(
+      entry: entry,
+      torrentSeason: torrentSeason,
+      anilistId: anilistId,
+    )) {
+      return entry;
+    }
+  }
+  return null;
+}

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -514,7 +514,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       // 匹配，不是按下标——重搜的结果集顺序/长度都会变），只有它彻底不在新结果里
       // 才回退首条。此前无条件重置成 `entries.first`，换个番剧名重搜就把用户的
       // 手选静默冲掉。必须在 listFiles 之前定下目标，否则拉的是首条的文件。
-      final JimakuEntry? target = _resolveJimakuEntryFor(entries);
+      final JimakuEntry? target =
+          _resolveJimakuEntryFor(entries, torrent: _selectedTorrent);
       final List<JimakuFile> files = target == null
           ? const <JimakuFile>[]
           : await jimaku
@@ -571,11 +572,26 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   /// UI 还显示「有字幕」。改前 season 类一条不给，所以这是从「没有」变成
   /// 「错的且看起来对」，必须显式降级成不确定态。
   ///
-  /// 真正的根治（识别绝对集号编号、按季换算偏移、核对条目季号）不在本轮范围。
-  /// range / single 类的集号来自种子标题自身，不属此列。
-  bool _subtitleEpisodesUnverified(NyaaTorrent torrent) =>
-      torrentEpisodeScope(torrent).kind == TorrentEpisodeScopeKind.season &&
-      _chooseSubsFor(torrent).any(((int?, JimakuFile) e) => e.$1 != null);
+  /// 「或自动选中的首条根本是别的季」这一支现在**能测出来了**（第二个判据）：
+  /// 当前加载的条目季号与本行种子的季号冲突时，同样退成不确定态。选番阶段还没
+  /// 选种，无从在选中前替换条目，但至少不把它画成「字幕齐了」。
+  /// range / single 类的集号来自种子标题自身，不属第一个判据。
+  bool _subtitleEpisodesUnverified(NyaaTorrent torrent) {
+    final List<(int?, JimakuFile)> subs = _chooseSubsFor(torrent);
+    if (subs.isEmpty) return false;
+    final JimakuEntry? entry = _selectedJimakuEntry;
+    if (entry != null &&
+        jimakuEntrySeasonConflicts(
+          entry: entry,
+          torrentSeason: torrent.season,
+          anilistId: _selectedMedia?.id,
+        )) {
+      return true;
+    }
+    return torrentEpisodeScope(torrent).kind ==
+            TorrentEpisodeScopeKind.season &&
+        subs.any(((int?, JimakuFile) e) => e.$1 != null);
+  }
 
   /// 字幕覆盖度徽标，与 [_chooseSubsFor] 同源（同一 `seriesEpisodeCount`）。
   ({int covered, int? total}) _jimakuCoverageFor(NyaaTorrent torrent) =>
@@ -585,29 +601,46 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         seriesEpisodeCount: _selectedMedia?.episodes,
       );
 
-  /// 重搜后该选中哪条字幕来源：用户手选过且它仍在 [entries] 里 → 沿用手选；
-  /// 否则回退首条；空结果 → null。纯查找，不改 state。
-  JimakuEntry? _resolveJimakuEntryFor(List<JimakuEntry> entries) {
-    if (entries.isEmpty) return null;
-    final int? pickedId = _userPickedJimakuEntryId;
-    if (pickedId != null) {
-      for (final JimakuEntry entry in entries) {
-        if (entry.id == pickedId) return entry;
-      }
-    }
-    return entries.first;
-  }
+  /// 重搜/选种后该选中哪条字幕来源。纯查找，不改 state；决策收敛在纯函数
+  /// [resolveJimakuEntry]（用户手选优先 → 首条季号不冲突的 → 都冲突则 null）。
+  ///
+  /// [torrent] 已选中时才有包的季号可比；选番阶段还没选种（null）→ 季号校验
+  /// 天然是 no-op，行为与改前完全一致（回退首条）。
+  JimakuEntry? _resolveJimakuEntryFor(
+    List<JimakuEntry> entries, {
+    NyaaTorrent? torrent,
+  }) =>
+      resolveJimakuEntry(
+        entries,
+        userPickedEntryId: _userPickedJimakuEntryId,
+        torrentSeason: torrent?.season,
+        anilistId: _selectedMedia?.id,
+      );
+
+  /// 自动选中被季号校验拦下：没手选过、有候选条目，但没有一条季号对得上 [torrent]。
+  /// 纯派生（不另存 state，避免与 [_selectedJimakuEntry] 漂开）。
+  bool _jimakuSeasonBlockedFor(NyaaTorrent torrent) =>
+      _jimakuLoaded &&
+      _jimakuEntries.isNotEmpty &&
+      _resolveJimakuEntryFor(_jimakuEntries, torrent: torrent) == null;
 
   Future<void> _selectJimakuEntry(JimakuEntry entry) async {
     if (_selectedJimakuEntry?.id == entry.id || _jimakuLoading) return;
+    // 记下「用户手选过这一条」，供重搜时优先沿用、并让季号校验对它放行
+    // （见 [resolveJimakuEntry]）。**只有这条路径**能置位。
+    _userPickedJimakuEntryId = entry.id;
+    await _loadJimakuFilesFor(entry);
+  }
+
+  /// 切到条目 [entry] 并拉它的文件列表 → 重建索引 → 刷新已选种子的字幕命中。
+  /// 手选（[_selectJimakuEntry]）与选种后的季号复核（[_selectTorrent]）共用。
+  Future<void> _loadJimakuFilesFor(JimakuEntry entry) async {
     final AniListMedia? media = _selectedMedia;
     if (media == null) return;
     final String apiKey = ref.read(appProvider).jimakuApiKey.trim();
     if (apiKey.isEmpty) return;
     setState(() {
       _selectedJimakuEntry = entry;
-      // 记下「用户手选过这一条」，供重搜时优先沿用（见 [_resolveJimakuEntryFor]）。
-      _userPickedJimakuEntryId = entry.id;
       _jimakuLoading = true;
       _jimakuError = false;
       _jimakuFiles = const <JimakuFile>[];
@@ -707,11 +740,27 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   // ---------------------------------------------------------------- 阶段 3
 
   void _selectTorrent(NyaaTorrent torrent) {
+    // 选中种子这一刻才知道包的季号 → 复核自动选中的字幕条目。选番阶段
+    // （[_runJimakuSearch]）手上还没有种子，只能无条件取首条；那条首条可能
+    // 是别的季，落位层的「集号严格相等」拦不住 S1 条目 × S2 包（集号照样相等）。
+    final JimakuEntry? previous = _selectedJimakuEntry;
+    final JimakuEntry? target =
+        _resolveJimakuEntryFor(_jimakuEntries, torrent: torrent);
+    final bool switched = target?.id != previous?.id;
     setState(() {
       _selectedTorrent = torrent;
+      if (switched) {
+        // 旧条目的文件/索引属于错季条目，先清干净再按新目标重建。
+        _selectedJimakuEntry = target;
+        _jimakuFiles = const <JimakuFile>[];
+        _jimakuIndex = JimakuEpisodeIndex.fromFiles(const <JimakuFile>[]);
+      }
       _chosenSubs = _chooseSubsFor(torrent);
       _includeSubs = true;
     });
+    if (switched && target != null && !_jimakuLoading) {
+      unawaited(_loadJimakuFilesFor(target));
+    }
   }
 
   void _clearSelectedTorrent() {
@@ -1781,23 +1830,45 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
           theme, t.anime_download_subs_failed, _retryJimaku);
     }
     if (_chosenSubs.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            Text(
-              t.anime_download_no_subs,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.outline),
+      // 季号校验拦下自动选中时**必然**落到这条空态分支（没条目 ⇒ 没文件 ⇒
+      // 没字幕）。不能只说「无字幕」——那是静默：候选条目就在上面的 picker 里，
+      // 只是没有一条季号对得上这个包。用与「集号未核对」同一排版的提示行说清
+      // 原因，用户手选任意一条即可放行（手选不受本校验拦截）。
+      final NyaaTorrent? blockedTorrent = _selectedTorrent;
+      final bool seasonBlocked =
+          blockedTorrent != null && _jimakuSeasonBlockedFor(blockedTorrent);
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          if (seasonBlocked)
+            _buildSubsHintRow(
+              theme,
+              Icons.help_outline,
+              t.anime_download_subs_season_mismatch(
+                season: blockedTorrent.season ?? 1,
+              ),
             ),
-            const SizedBox(height: 8),
-            TextButton.icon(
-              onPressed: _retryJimaku,
-              icon: const Icon(Icons.refresh, size: 18),
-              label: Text(t.anime_download_retry),
+          Expanded(
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  Text(
+                    t.anime_download_no_subs,
+                    style: theme.textTheme.bodySmall
+                        ?.copyWith(color: theme.colorScheme.outline),
+                  ),
+                  const SizedBox(height: 8),
+                  TextButton.icon(
+                    onPressed: _retryJimaku,
+                    icon: const Icon(Icons.refresh, size: 18),
+                    label: Text(t.anime_download_retry),
+                  ),
+                ],
+              ),
             ),
-          ],
-        ),
+          ),
+        ],
       );
     }
     // 这份列表是**预览**（按种子标题猜的），不是最终会下的清单：真正配哪些

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+984
+version: 1.3.1+985
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
@@ -591,6 +591,125 @@ void main() {
       reason: '推送成功必须说清字幕的时序',
     );
   });
+
+  // PR#530 补的另一半：条目选择层的季号校验。落位层（按包内真实文件名反查）只能
+  // 靠「集号严格相等」挡错配，可自动选中的条目本身就是 S1（编号 1-12）而包是 S2
+  // 的 01-12 时集号照样相等 —— 必须在选条目这一层拦。
+  testWidgets('季号校验：S1 条目遇上 S2 包不自动选，说明原因；用户手选照旧放行',
+      (WidgetTester tester) async {
+    const NyaaTorrent s2Pack = NyaaTorrent(
+      title: '[Grp] Test Anime S2 01-03 [1080p]',
+      torrentUrl: '',
+      pageUrl: '',
+      infoHash: 'dddddddddddddddddddddddddddddddddddddddd',
+      seeders: 10,
+      leechers: 0,
+      downloads: 0,
+      sizeText: '3 GiB',
+      sizeBytes: null,
+      categoryId: '1_2',
+      trusted: false,
+      remake: false,
+      pubDate: null,
+    );
+    expect(s2Pack.season, 2, reason: '前提：种子标题能解析出季号');
+
+    final List<String> requested = <String>[];
+    final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
+      final String url = req.url.toString();
+      requested.add(url);
+      if (url.contains('/entries/search')) {
+        // 条目名不写季号 = 第一季（Jimaku 的 S1 条目就是这个形状），且没挂
+        // anilist_id（文本回退搜出来的条目，正是错季的产地）。
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<Map<String, Object>>[
+            <String, Object>{'id': 7, 'name': 'Wrong Season Entry'},
+          ])),
+          200,
+        );
+      }
+      if (url.contains('/files')) {
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<Map<String, Object>>[
+            for (int ep = 1; ep <= 3; ep++)
+              <String, Object>{
+                'name': 'Test Anime - 0$ep.ja.srt',
+                'url': 'https://jimaku.cc/f/$ep.srt',
+              },
+          ])),
+          200,
+        );
+      }
+      return http.Response('', 404);
+    });
+    await pumpDialog(tester, appModel, torrent: s2Pack);
+    await tester.tap(find.byTooltip(t.anime_download_search).last);
+    await tester.pumpAndSettle();
+
+    // ① 没自动选中 → 一条字幕都没配上，连该条目的文件列表都不去拉。
+    expect(find.text('Test Anime - 01.ja.srt'), findsNothing,
+        reason: '错季条目的字幕不该被自动配上');
+    expect(requested.where((String u) => u.contains('/files')), isEmpty,
+        reason: '没自动选中就不该拉它的文件');
+    // ② 不静默：说清「没有条目对得上第 2 季」。
+    expect(
+      find.text(t.anime_download_subs_season_mismatch(season: 2)),
+      findsOneWidget,
+      reason: '不自动选必须给理由，否则用户只看到「无字幕」',
+    );
+    // ③ 候选条目仍列在 picker 里，用户随时能手选。
+    expect(find.text('Wrong Season Entry'), findsOneWidget);
+
+    // ④ 用户手选 → 季号校验不拦：文件照拉，字幕照配，提示行消失。
+    await tester.tap(find.text('Wrong Season Entry'));
+    await tester.pumpAndSettle();
+    expect(requested.where((String u) => u.contains('/files')), isNotEmpty,
+        reason: '手选的条目必须照常加载');
+    expect(find.text('Test Anime - 01.ja.srt'), findsOneWidget,
+        reason: '用户可能就是要另一季的字幕，不能拦');
+    expect(
+      find.text(t.anime_download_subs_season_mismatch(season: 2)),
+      findsNothing,
+    );
+  });
+
+  // 反向：信息缺失不能把功能关掉。两边都拿不到季号时必须维持原有的「自动选首条」。
+  testWidgets('季号校验：两边都拿不到 season 时仍照常自动选首条', (WidgetTester tester) async {
+    expect(_kTorrent.season, isNull, reason: '前提：种子标题没有季号 token');
+    final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
+      final String url = req.url.toString();
+      if (url.contains('/entries/search')) {
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<Map<String, Object>>[
+            <String, Object>{'id': 7, 'name': 'No Season Entry'},
+          ])),
+          200,
+        );
+      }
+      if (url.contains('/files')) {
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<Map<String, Object>>[
+            <String, Object>{
+              'name': 'Test Anime - 01.ja.srt',
+              'url': 'https://jimaku.cc/f/1.srt',
+            },
+          ])),
+          200,
+        );
+      }
+      return http.Response('', 404);
+    });
+    await pumpDialog(tester, appModel, torrent: _kTorrent);
+    await tester.tap(find.byTooltip(t.anime_download_search).last);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Test Anime - 01.ja.srt'), findsOneWidget,
+        reason: '拿不到季号就不校验，维持现状自动选，别因信息缺失把功能关掉');
+    expect(
+      find.text(t.anime_download_subs_season_mismatch(season: 1)),
+      findsNothing,
+    );
+  });
 }
 
 NyaaTorrent _torrentWith({

--- a/hibiki/test/torrent/anime_download_matching_test.dart
+++ b/hibiki/test/torrent/anime_download_matching_test.dart
@@ -616,4 +616,155 @@ void main() {
           isEmpty);
     });
   });
+
+  group('条目自动选中的季号校验（resolveJimakuEntry）', () {
+    const JimakuEntry s1 =
+        JimakuEntry(id: 11, name: 'Sousou no Frieren'); // 不写季号 = 第一季
+    const JimakuEntry s2 =
+        JimakuEntry(id: 22, name: 'Sousou no Frieren 2nd Season');
+
+    test('S1 条目遇上 S2 包：不自动选（本轮根因）', () {
+      // 这正是落位层（matchJimakuFilesToVideoNames）拦不住的形状：条目按 1-12
+      // 编号、包也是 01-12，集号严格相等照样能配上，配的却是错季字幕。
+      final NyaaTorrent pack =
+          _torrent('[Group] Sousou no Frieren S2 [01-12][1080p]');
+      expect(pack.season, 2, reason: '前提：种子标题解析得出季号');
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[s1],
+          torrentSeason: pack.season,
+          anilistId: 999,
+        ),
+        isNull,
+      );
+    });
+
+    test('候选里有对得上的季 → 自动选那一条，而不是首条', () {
+      final NyaaTorrent pack =
+          _torrent('[Group] Sousou no Frieren S2 [01-12][1080p]');
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[s1, s2],
+          torrentSeason: pack.season,
+          anilistId: 999,
+        )?.id,
+        22,
+      );
+    });
+
+    test('两边都拿不到 season：照常自动选首条（信息缺失不关功能）', () {
+      final NyaaTorrent pack = _torrent('[Group] Test Anime - 01 [1080p]');
+      expect(pack.season, isNull, reason: '前提：种子标题没有季号 token');
+      expect(jimakuEntrySeason(s1.name), 1);
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[s1],
+          torrentSeason: pack.season,
+          anilistId: 999,
+        )?.id,
+        11,
+      );
+    });
+
+    test('种子没写季号、条目写了季号：仍照常自动选（不凭空拦）', () {
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[s2],
+          torrentSeason: null,
+          anilistId: 999,
+        )?.id,
+        22,
+      );
+    });
+
+    test('用户手选的条目不被拦：季号明显不符也原样沿用', () {
+      final NyaaTorrent pack =
+          _torrent('[Group] Sousou no Frieren S2 [01-12][1080p]');
+      // 同一份输入，不带 userPickedEntryId 时被拦成 null（对照组，证明拦截确实生效）。
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[s1],
+          torrentSeason: pack.season,
+          anilistId: 999,
+        ),
+        isNull,
+      );
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[s1],
+          userPickedEntryId: 11,
+          torrentSeason: pack.season,
+          anilistId: 999,
+        )?.id,
+        11,
+        reason: '用户可能就是要另一季的字幕（合集版编号不同等），拦他是越权',
+      );
+    });
+
+    test('手选的条目已不在新结果里 → 回退自动选，且自动选仍受季号校验', () {
+      final NyaaTorrent pack =
+          _torrent('[Group] Sousou no Frieren S2 [01-12][1080p]');
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[s1],
+          userPickedEntryId: 4242,
+          torrentSeason: pack.season,
+          anilistId: 999,
+        ),
+        isNull,
+      );
+    });
+
+    test('条目挂的 anilist_id 命中所选番 → 一律放行（AniList 按季拆条目，id 即权威）', () {
+      final NyaaTorrent pack =
+          _torrent('[Group] Sousou no Frieren S2 [01-12][1080p]');
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[
+            JimakuEntry(id: 33, name: 'Sousou no Frieren', anilistId: 999),
+          ],
+          torrentSeason: pack.season,
+          anilistId: 999,
+        )?.id,
+        33,
+      );
+      // 挂的是别的番的 id → 不算命中，照常按名字比季号。
+      expect(
+        resolveJimakuEntry(
+          const <JimakuEntry>[
+            JimakuEntry(id: 33, name: 'Sousou no Frieren', anilistId: 12345),
+          ],
+          torrentSeason: pack.season,
+          anilistId: 999,
+        ),
+        isNull,
+      );
+    });
+
+    test('空候选列表 → null（与改前一致）', () {
+      expect(resolveJimakuEntry(const <JimakuEntry>[]), isNull);
+    });
+
+    test('jimakuEntrySeason：真实条目名解析，不写季号按第一季', () {
+      expect(jimakuEntrySeason('Sousou no Frieren'), 1);
+      expect(jimakuEntrySeason('Oshi no Ko 2nd Season'), 2);
+      expect(jimakuEntrySeason('Mushoku Tensei S2'), 2);
+      expect(jimakuEntrySeason('葬送のフリーレン 第2期'), 2);
+      expect(jimakuEntrySeason('Yuru Camp Season 3'), 3);
+      expect(jimakuEntrySeason('Spice and Wolf Part 2'), 2);
+    });
+
+    test('同季不算冲突：条目与包都写 S2', () {
+      final NyaaTorrent pack =
+          _torrent('[Group] Sousou no Frieren S2 [01-12][1080p]');
+      expect(
+        jimakuEntrySeasonConflicts(
+          entry: s2,
+          torrentSeason: pack.season,
+          anilistId: 999,
+        ),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
补 PR#530（BUG-1206）自报未解决的另一半：**条目选择层**的季号校验。

## 问题
PR#530 把字幕配对推迟到种子 add 之后、按包内真实视频文件名反查，落位层
`matchJimakuFilesToVideoNames` 要求集号**严格相等**。但当自动选中的 Jimaku 条目
本身就是 S1（编号 1-12）、而包是 S2 的 01-12 时，集号照样相等 —— 落位层无从分辨，
字幕错季且看起来完全正确。

根因在条目选择层：`_resolveJimakuEntryFor` 的判据只有「Jimaku 服务端返回的第一条」
（`anime_download_dialog.dart:590` 的 `return entries.first;`），既不打相似度分也不核季号。
这一支在 `_subtitleEpisodesUnverified` 的注释里早已写明（「或自动选中的首条根本是别的季」），
只是当时没有检测手段。

## 改动
决策收敛成纯函数 `resolveJimakuEntry` / `jimakuEntrySeasonConflicts` / `jimakuEntrySeason`
（`anime_download_matching.dart` 尾部）：

- **用户手选的条目一律放行** —— 他可能就是要另一季的字幕（合集版编号不同等），拦他是越权。
- **条目挂的 `anilist_id` 命中所选番 → 放行**：AniList 按季拆条目，id 命中即权威。
  校验因此只作用在**文本回退搜出来的条目**上，也就是错季真正的产地。
- **种子标题解析不出季号 → 不校验**，维持现状自动选，不因信息缺失把功能关掉。
- 其余按条目名比季号，**条目名不写季号按第一季算**（Jimaku 的 S1 条目就是光秃秃的
  作品名，这正是本 bug 的形状；若按「未知不校验」处理，主线永远拦不住）。

自动选中改成「取第一条季号不冲突的」；全都冲突则不自动选，并在字幕列表上方用与
「集号未核对」**同一排版**的提示行（`_buildSubsHintRow` + 新 key
`anime_download_subs_season_mismatch`）说清原因，不静默。选中种子这一刻才知道包的季号，
故在 `_selectTorrent` 复核选番阶段的自动选中结果；`~` 徽标同步补上季号冲突这一支。

**未动 PR#530 的按包内真实文件名反查链路。**

## 顺带清理（独立 commit）
`anime_download_subs_partial`：PR#530 之后推送时不再预下字幕，「应下 N 条只成功 M 条」
已不存在，全仓 grep 确认 `strings.g.dart` 之外零引用。走 `i18n_sync.dart --remove` +
`dart run slang` 删除。

## 验证
- `flutter analyze`（含 test）→ `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/torrent/ test/pages/ test/media/video/ test/tools/`
- **变异实测**：把 `jimakuEntrySeasonConflicts` 退回恒 `false`，断言转红 **6 条**。

## 已知遗留
- 选番阶段（还没选种）无从知道包的季号，此时仍自动选首条；一旦选中种子即复核。
- 跨季合集包（`S01+S02`）不在判据内 —— 只有种子标题解析出**单一**季号时才校验。
- 真机未复测（无 Jimaku API key 的真实错季场景），仅 widget 行为级验证。

BUG-1215 · `docs/bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md`

（原取 BUG-1211，与 PR#538「合集封面」撞号。PR#538 有 22 处 BUG-1211 引用横跨 12 个源文件，
本 PR 只有 doc 文件一处 H2 + 文件名 —— 让号成本最低、零误伤风险，故本 PR 让号 → BUG-1215。
走 `tool/bug.dart renumber`，已比对 PR#538 引用计数改号前后均不变。
⚠️ 第一个 commit 的 message 里仍写着 BUG-1211（非交互环境无法改写历史 message），
以 `docs/bugs/BUG-1215-*.md` 与让号 commit 为准。）

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb

