### PR TITLE
fix(epub): 解析出的路径保留真实大小写，大小写敏感平台不再整本失踪 (BUG-1218)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1175 条。点号进各自文件。
+> 共 1176 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1218](bugs/BUG-1218-epub-path-case-folded-android.md) | ✅ | ✅ | EPUB 解析把路径折成小写，大小写敏感平台上整本章节静默失踪 |
 | [BUG-1215](bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md) | ✅ | ✅ | Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包 |
 | [BUG-1214](bugs/BUG-1214-waveform-align-wheel-hscroll.md) | ✅ | ✅ | 波形对轴放大视图鼠标滚轮不能左右平移时间轴 |
 | [BUG-1213](bugs/BUG-1213-android-legacy-storage-permission-query.md) | ✅ | ✅ | Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根 |

--- a/docs/bugs/BUG-1218-epub-path-case-folded-android.md
+++ b/docs/bugs/BUG-1218-epub-path-case-folded-android.md
@@ -5,14 +5,18 @@
 
 ### 根因
 
-`p.canonicalize` 在 Windows / macOS 等大小写不敏感平台会把整条路径**折成小写**。解析侧与阅读器侧共 8 处直接拿它的结果当**真实读写路径**，于是那本 Calibre/Sigil 重打包书里的
+`p.canonicalize` 在 **Windows** 上会把整条路径**折成小写**（`path` 包 `lib/src/style/windows.dart:181` `canonicalizePart(part) => part.toLowerCase()`；POSIX style 无此覆写，见 `lib/src/internal_style.dart:89`——**macOS / Linux / Android 上并不折**。审查更正：原文把 macOS 一并算进来是错的；仓库既有注释 `reader_hibiki_source.dart:657` 也沿用了同一误解）。解析侧与阅读器侧共 8 处直接拿它的结果当**真实读写路径**，于是那本 Calibre/Sigil 重打包书里的
 
 ```
 OEBPS/Dick_9780345508553_epub_c01_r1.htm   （磁盘上的真实条目）
 oebps/dick_9780345508553_epub_c01_r1.htm   （解析后记下来的路径）
 ```
 
-Windows 文件系统不区分大小写，所以本机侥幸能读、问题被完全掩盖；但在 **Android / Linux 上 `File.existsSync()` 全部为 false**，`_parseSpine` 逐条 `continue` 把章节静默跳过，整本书只剩路径恰好全小写的那一两章（那本书只剩 `titlepage.xhtml`），**且不写任何错误日志**。
+Windows 文件系统不区分大小写，所以在 Windows 上侥幸能读、问题被完全掩盖。
+
+**审查更正（触发链）**：因为 POSIX style 不折大小写，「在 Android/Linux 上原生导入 + 解析 + 打开」这条路径**不会**触发本 bug——那里 `canonicalize` 算出的就是真实大小写。真正的触发链是**跨平台数据搬运**：在 Windows 宿主导入时路径被折成小写并**落库**（`coverPath` / `chaptersJson` / `tocJson`），随后经**备份还原或裸数据拷贝**到大小写敏感设备，而那些消费方**不重新解析**，于是 `File(join(extractDir, "oebps/images/cover.jpg"))` 找不到真实的 `OEBPS/Images/Cover.jpg`——这正是仓库既有的 TODO-1319 / BUG-612 在 `hibiki/lib/src/media/sources/reader_hibiki_source.dart:657-670` 记录、并靠**事后大小写不敏感重扫**兜底的场景。
+
+因此本修复的价值是**根因修**：让 Windows 上落库的路径从源头就是真实大小写，根除这一整类问题，而不是继续让各消费方各自加兜底。原文「Android/Linux 上 existsSync 全部为 false、`_parseSpine` 把章节逐条静默跳过」描述的是**未经重新解析地直接使用已折小写路径**的情形，不是 Android 上原生解析的情形。
 
 实测那本书：**31/32 章、33/38 个资源**的路径大小写与磁盘不符。
 
@@ -25,7 +29,8 @@ Windows 文件系统不区分大小写，所以本机侥幸能读、问题被完
 - **[x] ① 已修复** — 新增 `EpubParser._resolveWithinExtract()` / `_relHref()`：**边界校验用 `p.canonicalize`**（大小写折叠，`../` 逃逸不被大小写差异绕过）、**真实路径用 `p.normalize`**（同样折叠 `.`/`..` 段但保留大小写），与 `_safeArchivePath` 同款。改用处：
   - `epub_parser.dart` 4 处：`_parseSpine`（章节 href + `File`）、`_itemRelHref`（封面）、resources map（键 + `filePath`）、`_parseToc`（nav + ncx）；
   - `webview.part.dart` 3 处：`_readerResourcePayload`（读取路径，并把 BUG-1203 的 `declaredHref` 反推基准同步换成 `normalize` 形式——两侧同时保留大小写，既能读到文件、又仍然对得上 resources 键）、`_chapterFilePath`、`_imageFileSizeBytes`；
-  - `chrome.part.dart` 1 处：`_readerImageFileForUrl`（图片查看器 / 分享）。
+  - `chrome.part.dart` 1 处：`_readerImageFileForUrl`（图片查看器 / 分享）；
+  - **审查补漏的第 9 处**：`reader_hibiki_page.dart` `_buildBookFromDb`（BUG-1203 加的「OPF 解析失败」回退路径 resources 填充）原样留着 `p.canonicalize` 建键与 `filePath`。parser 侧和拦截器侧都改成保留大小写后，三方变成 2:1 不一致——混合大小写的书在这条回退路径上 `resources` **永远查不中**，BUG-1203 的「OPF media-type 优先」静默退回扩展名兜底；`filePath` 折成小写更让大小写敏感平台读不到文件。已按同款「校验 canonicalize / 读写 normalize」补齐。
 
   其中 `_chapterFilePath` **必须**同步改：它的注释明说要与拦截器 "cache keys line up"，只改一侧会让 BUG-270 的章节 LRU 两边 key 一个折成小写一个原样而**永不命中**。
 

--- a/docs/bugs/BUG-1218-epub-path-case-folded-android.md
+++ b/docs/bugs/BUG-1218-epub-path-case-folded-android.md
@@ -1,0 +1,40 @@
+## BUG-1218 · EPUB 解析把路径折成小写，大小写敏感平台上整本章节静默失踪
+
+- **报告**：2026-07-28（诊断 BUG-1199 / BUG-1203 那本书「`Do Androids Dream of Electric Sheep？.epub` 打不开」时发现的**第二个独立根因**）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/epub/epub_parser.dart`（`_parseSpine` / `_itemRelHref` / resources map / TOC nav+ncx 四处）+ `webview.part.dart` 三处 + `chrome.part.dart` 一处
+
+### 根因
+
+`p.canonicalize` 在 Windows / macOS 等大小写不敏感平台会把整条路径**折成小写**。解析侧与阅读器侧共 8 处直接拿它的结果当**真实读写路径**，于是那本 Calibre/Sigil 重打包书里的
+
+```
+OEBPS/Dick_9780345508553_epub_c01_r1.htm   （磁盘上的真实条目）
+oebps/dick_9780345508553_epub_c01_r1.htm   （解析后记下来的路径）
+```
+
+Windows 文件系统不区分大小写，所以本机侥幸能读、问题被完全掩盖；但在 **Android / Linux 上 `File.existsSync()` 全部为 false**，`_parseSpine` 逐条 `continue` 把章节静默跳过，整本书只剩路径恰好全小写的那一两章（那本书只剩 `titlepage.xhtml`），**且不写任何错误日志**。
+
+实测那本书：**31/32 章、33/38 个资源**的路径大小写与磁盘不符。
+
+这与 BUG-1199 / BUG-1203（按扩展名猜 MIME 导致整本空白）是**两个独立根因**，恰好叠在同一本书上：那个让 Windows 上打不开，本 bug 让 Android/Linux 上打不开。
+
+**为什么一直没暴露**：日语 EPUB 内部路径习惯全小写（`item/xhtml/…`、`text/…`），大小写混排主要出现在英文出版社/Calibre 重打包的书里；而项目主力验证平台是 Windows，那里这个 bug 不可见。
+
+`_safeArchivePath` 早在 TODO-739 就为**解压**侧修好了同一个坑（其注释详细写了大小写折叠如何把 `META-INF` 写成 `meta-inf`，以及为什么必须「校验用 canonicalize、落盘用 normalize」两种形式分开），但**解析**侧四处一直没跟上这个结论。
+
+- **[x] ① 已修复** — 新增 `EpubParser._resolveWithinExtract()` / `_relHref()`：**边界校验用 `p.canonicalize`**（大小写折叠，`../` 逃逸不被大小写差异绕过）、**真实路径用 `p.normalize`**（同样折叠 `.`/`..` 段但保留大小写），与 `_safeArchivePath` 同款。改用处：
+  - `epub_parser.dart` 4 处：`_parseSpine`（章节 href + `File`）、`_itemRelHref`（封面）、resources map（键 + `filePath`）、`_parseToc`（nav + ncx）；
+  - `webview.part.dart` 3 处：`_readerResourcePayload`（读取路径，并把 BUG-1203 的 `declaredHref` 反推基准同步换成 `normalize` 形式——两侧同时保留大小写，既能读到文件、又仍然对得上 resources 键）、`_chapterFilePath`、`_imageFileSizeBytes`；
+  - `chrome.part.dart` 1 处：`_readerImageFileForUrl`（图片查看器 / 分享）。
+
+  其中 `_chapterFilePath` **必须**同步改：它的注释明说要与拦截器 "cache keys line up"，只改一侧会让 BUG-270 的章节 LRU 两边 key 一个折成小写一个原样而**永不命中**。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/epub/epub_path_case_preserved_test.dart`（复刻用户书结构：根级 OPF + 混合大小写 `OEBPS/Dick_*` + `Images/COVER.jpeg` + `Meta/TOC.ncx`）：章节 href、资源键与 `filePath`、封面 href 分别与 `listSync` 列出的**真实磁盘条目名逐字节比对**；NCX 能被找到（路径折小写会让 TOC 静默变空）；zip-slip 防护不被削弱（逃逸条目仍被丢弃、合法章节仍保留）。
+
+  逐字节比对而非 `existsSync` 是刻意的：**本地跑在 Windows 上 `File.exists` 不区分大小写，只断言 `existsSync` 根本抓不到这个 bug**。
+
+  **测试有效性已验证**：把 `_resolveWithinExtract` 的返回值临时改回 `p.canonicalize`，该文件 5 条中 4 条立刻转红，报的正是 `Expected: Images/COV… Actual: images/cov…`，确认不是弱断言假绿。
+
+- **[ ] ③ 未做真机复测** — 本机是 Windows，恰好是这个 bug **不可见**的平台；结论「Android/Linux 上章节会被跳过」由「解析出的路径与磁盘条目逐字节不符」推出，未在真机/模拟器上打开这本书复验。应在 Android 模拟器上走原始失败路径确认。
+
+- **备注**：对存量书零影响——`chaptersJson` 在 `path_rebase_coverage.dart` 标注为 `notAPath`，开书走 `parseFromExtracted` 重新解析、DB 只复用字数；旧书 `tocJson` 里存的小写 href 由 `EpubBook.chapterIndexForHref`（TODO-796）既有的大小写不敏感兜底 pass 兜住，TOC 跳转不回归。另：`hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart:346` 有同样的 `p.canonicalize(p.join(...))` 当真实路径的模式（漫画解压 zip/cbz 同样可能混合大小写），属独立子系统、独立导入与渲染路径，未在本次范围内。

--- a/hibiki/lib/src/epub/epub_parser.dart
+++ b/hibiki/lib/src/epub/epub_parser.dart
@@ -79,16 +79,17 @@ class EpubParser {
         _parseToc(opfXml, manifest, opfDir, extractDir);
     final String? renditionSpread = _parseRenditionSpread(opfXml);
 
-    final String canonExtract = p.canonicalize(extractDir);
     final Map<String, EpubResource> resources = <String, EpubResource>{};
     for (final _ManifestItem item in manifest.values) {
-      final String absPath = p.canonicalize(p.join(opfDir, item.href));
-      if (!p.isWithin(canonExtract, absPath)) {
+      // BUG-1218：键与 filePath 都保留真实大小写，见 [_resolveWithinExtract]。
+      // 大小写敏感平台上 filePath 折成小写就读不到；键折成小写则拦截器（BUG-1203）
+      // 按真实 href 回查 OPF media-type 时查不中，静默退回扩展名兜底。
+      final String? absPath =
+          _resolveWithinExtract(opfDir, item.href, extractDir);
+      if (absPath == null) {
         continue;
       }
-      final String relPath =
-          p.relative(absPath, from: extractDir).replaceAll('\\', '/');
-      resources[normalizeHref(relPath)] = EpubResource(
+      resources[_relHref(absPath, extractDir)] = EpubResource(
         mediaType: item.mediaType,
         filePath: absPath,
       );
@@ -428,8 +429,11 @@ class EpubParser {
         continue;
       }
 
-      final String absPath = p.canonicalize(p.join(opfDir, item.href));
-      if (!p.isWithin(p.canonicalize(extractDir), absPath)) {
+      // BUG-1218：真实路径必须保留大小写，否则 Android/Linux 上 existsSync 全 false
+      // → 整个 spine 被逐条静默跳过。见 [_resolveWithinExtract]。
+      final String? absPath =
+          _resolveWithinExtract(opfDir, item.href, extractDir);
+      if (absPath == null) {
         continue;
       }
       final File file = File(absPath);
@@ -437,8 +441,6 @@ class EpubParser {
         continue;
       }
 
-      final String relPath =
-          p.relative(absPath, from: extractDir).replaceAll('\\', '/');
       final String linear =
           itemref.getAttribute('linear')?.toLowerCase() ?? 'yes';
 
@@ -470,7 +472,7 @@ class EpubParser {
       // [EpubChapter.html] access — open-book no longer slurps the whole book.
       chapters.add(EpubChapter.lazy(
         id: item.id,
-        href: normalizeHref(relPath),
+        href: _relHref(absPath, extractDir),
         mediaType: item.mediaType,
         filePath: absPath,
         spineIndex: index,
@@ -533,13 +535,13 @@ class EpubParser {
     String opfDir,
     String extractDir,
   ) {
-    final String absPath = p.canonicalize(p.join(opfDir, item.href));
-    if (!p.isWithin(p.canonicalize(extractDir), absPath)) {
+    // BUG-1218：封面 href 同样保留真实大小写，否则大小写敏感平台上取不到封面文件。
+    final String? absPath =
+        _resolveWithinExtract(opfDir, item.href, extractDir);
+    if (absPath == null) {
       return null;
     }
-    final String relPath =
-        p.relative(absPath, from: extractDir).replaceAll('\\', '/');
-    return normalizeHref(relPath);
+    return _relHref(absPath, extractDir);
   }
 
   // ── TOC ────────────────────────────────────────────────────────────────────
@@ -553,8 +555,10 @@ class EpubParser {
     // EPUB 3: nav document
     for (final _ManifestItem item in manifest.values) {
       if (item.properties != null && item.properties!.contains('nav')) {
-        final String navPath = p.canonicalize(p.join(opfDir, item.href));
-        if (!p.isWithin(p.canonicalize(extractDir), navPath)) {
+        // BUG-1218：大小写保留，否则大小写敏感平台上找不到 nav 文档 → TOC 空。
+        final String? navPath =
+            _resolveWithinExtract(opfDir, item.href, extractDir);
+        if (navPath == null) {
           continue;
         }
         final File navFile = File(navPath);
@@ -575,8 +579,10 @@ class EpubParser {
       final String? tocId = spine.getAttribute('toc');
       if (tocId != null && manifest.containsKey(tocId)) {
         final _ManifestItem ncxItem = manifest[tocId]!;
-        final String ncxPath = p.canonicalize(p.join(opfDir, ncxItem.href));
-        if (!p.isWithin(p.canonicalize(extractDir), ncxPath)) {
+        // BUG-1218：同上，NCX 路径保留大小写。
+        final String? ncxPath =
+            _resolveWithinExtract(opfDir, ncxItem.href, extractDir);
+        if (ncxPath == null) {
           return <EpubTocItem>[];
         }
         final File ncxFile = File(ncxPath);
@@ -717,6 +723,45 @@ class EpubParser {
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────
+
+  /// BUG-1218：把 [opfDir] 下的一个 manifest/TOC href 解析成磁盘绝对路径，越出
+  /// [extractDir] 时返回 null。
+  ///
+  /// 关键在于**边界校验**与**真实路径**必须用同一条路径的两种不同形式：
+  /// - 校验用 `p.canonicalize`（在 Windows/macOS 等大小写不敏感平台会整体小写化，
+  ///   正好让 `../` 逃逸判定不被大小写差异绕过）；
+  /// - 返回值用 `p.normalize`（同样折叠 `.`/`..` 段，但**保留大小写**）。
+  ///
+  /// 此前四处直接拿 canonicalize 的结果当真实路径，于是
+  /// `OEBPS/Dick_9780345508553_epub_c01_r1.htm` 被记成 `oebps/dick_...htm`：
+  /// Windows 文件系统不区分大小写所以侥幸能读，但在 **Android / Linux 上
+  /// `existsSync()` 全部为 false**，spine 里的章节被逐条静默跳过，整本书只剩
+  /// 路径恰好全小写的那一两章，且不写任何错误日志。
+  ///
+  /// [_safeArchivePath] 早在 TODO-739 就为**解压**侧修好了同一个坑（注释详述了
+  /// 大小写折叠如何把 `META-INF` 写成 `meta-inf`），这里让**解析**侧跟上同款做法。
+  static String? _resolveWithinExtract(
+    String opfDir,
+    String href,
+    String extractDir,
+  ) {
+    final String joined = p.join(opfDir, href);
+    if (!p.isWithin(p.canonicalize(extractDir), p.canonicalize(joined))) {
+      return null;
+    }
+    return p.normalize(joined);
+  }
+
+  /// [_resolveWithinExtract] 的结果转成 extractDir 相对、正斜杠、[normalizeHref]
+  /// 归一化的 href（**大小写保留**）。
+  ///
+  /// 这个形式同时是 [EpubBook.resources] 的键，阅读器拦截器（BUG-1203）按同构造
+  /// 的相对路径回查 OPF 声明的 media-type，两侧必须一致。
+  static String _relHref(String absPath, String extractDir) {
+    return normalizeHref(
+        p.relative(absPath, from: p.normalize(extractDir))
+            .replaceAll('\\', '/'));
+  }
 
   static String? _resolveTocHref(
     String rawHref,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -161,11 +161,14 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     if (!uri.path.startsWith('/epub/')) return null;
     final String epubPath =
         Uri.decodeComponent(uri.path.substring('/epub/'.length));
-    final String extractRoot = p.canonicalize(_extractDir!);
-    final String filePath = p.canonicalize(p.join(extractRoot, epubPath));
-    if (!p.isWithin(extractRoot, filePath)) {
+    // BUG-1218：真实路径保留大小写（越界判据仍走 canonicalize），否则大小写敏感
+    // 平台上图片查看器/分享取不到 EPUB 内插图。
+    final String joined = p.join(_extractDir!, epubPath);
+    if (!p.isWithin(
+        p.canonicalize(_extractDir!), p.canonicalize(joined))) {
       return null;
     }
+    final String filePath = p.normalize(joined);
     final File file = File(filePath);
     if (!file.existsSync()) return null;
     return file;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -154,9 +154,16 @@ extension _ReaderWebView on _ReaderHibikiPageState {
 
     final String epubPath =
         Uri.decodeComponent(path.substring('/epub/'.length));
-    final String canonExtractDir = p.canonicalize(_extractDir!);
-    final String filePath = p.canonicalize(p.join(_extractDir!, epubPath));
-    if (!p.isWithin(canonExtractDir, filePath)) {
+    // BUG-1218：边界校验用 canonicalize（大小写折叠，`../` 逃逸不被大小写绕过），
+    // 真实读取路径用 normalize（**保留大小写**）。拿 canonicalize 的结果去 File()
+    // 会把 `OEBPS/Dick_x.htm` 折成 `oebps/dick_x.htm` —— Windows 侥幸能读，
+    // Android/Linux 上 existsSync 为 false，每个章节请求都 404。
+    // 与 EpubParser._resolveWithinExtract / _safeArchivePath 同款。
+    final String joinedPath = p.join(_extractDir!, epubPath);
+    final String normExtractDir = p.normalize(_extractDir!);
+    final String filePath = p.normalize(joinedPath);
+    if (!p.isWithin(
+        p.canonicalize(_extractDir!), p.canonicalize(joinedPath))) {
       return _forbidden('path traversal blocked: $epubPath');
     }
     final File file = File(filePath);
@@ -171,11 +178,16 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     // 文件扩展名，只规定 media-type，所以任何扩展名白名单都必然漏（BUG-1199 补了
     // `.htm`/`.xht` 之后，下一本用别的扩展名甚至无扩展名的书会以同样方式空白）。
     //
-    // 查找键与 [EpubParser] 建 resources 表时同构造（canonicalize 后相对 extractDir
-    // 的 posix 相对路径），所以用已 canonicalize 的 filePath 反推，而不是直接拿 URL
-    // 里的 epubPath——后者会被大小写、`./`、百分号编码差异带偏而静默查不到。
+    // 查找键与 [EpubParser] 建 resources 表时同构造（相对 extractDir 的 posix 相对
+    // 路径），所以用已归一化的 filePath 反推，而不是直接拿 URL 里的 epubPath——后者
+    // 会被 `./`、百分号编码差异带偏而静默查不到。
+    //
+    // BUG-1218：两侧同时改成**保留大小写**的 normalize 形式。原先两侧都 canonicalize
+    // （都被折成小写）也能互相匹配，但那让 filePath 在大小写敏感平台上根本读不到文件；
+    // 现在 parser 的 resources 键与这里的 declaredHref 都是真实大小写，既能读到文件，
+    // 也仍然对得上。
     final String declaredHref =
-        p.relative(filePath, from: canonExtractDir).replaceAll('\\', '/');
+        p.relative(filePath, from: normExtractDir).replaceAll('\\', '/');
     final String extMime = fallbackMimeType(filePath);
     // [EpubBook.mediaType] 自带「manifest 未声明就按扩展名兜底」，故 book 未就绪 /
     // 资源不在 manifest / OPF 缺 media-type 三种情况都自然退回 extMime。
@@ -426,9 +438,12 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     if (book == null || dir == null) return null;
     if (index < 0 || index >= book.chapters.length) return null;
     final String href = normalizeHref(book.chapters[index].href);
-    final String filePath = p.canonicalize(p.join(dir, href));
-    if (!p.isWithin(p.canonicalize(dir), filePath)) return null;
-    return filePath;
+    // BUG-1218：必须与 [_readerResourcePayload] 用**同一种**路径形式（normalize，
+    // 保留大小写），否则两边算出的 LRU cache key 一个折成小写一个原样，BUG-270 的
+    // 章节缓存/预热永远不命中；在大小写敏感平台上更是直接指向不存在的文件。
+    final String joined = p.join(dir, href);
+    if (!p.isWithin(p.canonicalize(dir), p.canonicalize(joined))) return null;
+    return p.normalize(joined);
   }
 
   // BUG-270: warm the LRU with the next chapter (in reading direction) so a
@@ -540,9 +555,13 @@ extension _ReaderWebView on _ReaderHibikiPageState {
   int _imageFileSizeBytes(String? extractDir, String relativeHref) {
     if (extractDir == null) return 0;
     try {
-      final String root = p.canonicalize(extractDir);
-      final String filePath = p.canonicalize(p.join(root, relativeHref));
-      if (!p.isWithin(root, filePath)) return 0;
+      // BUG-1218：真实 stat 路径保留大小写（越界判据仍走 canonicalize）。
+      final String joined = p.join(extractDir, relativeHref);
+      if (!p.isWithin(
+          p.canonicalize(extractDir), p.canonicalize(joined))) {
+        return 0;
+      }
+      final String filePath = p.normalize(joined);
       final File file = File(filePath);
       if (!file.existsSync()) return 0;
       return file.lengthSync();

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1893,7 +1893,7 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
     // 空白的场景。chaptersJson 里逐章存着导入时解析到的 mediaType，直接灌进去，
     // 主路径与回退路径就用同一份真相源，无需在拦截器里分叉。
     final Map<String, EpubResource> resources = <String, EpubResource>{};
-    final String canonExtractDir = p.canonicalize(extractDir);
+    final String normExtractDir = p.normalize(extractDir);
     for (int i = 0; i < rawChapters.length; i++) {
       final Map<String, dynamic> ch = rawChapters[i] as Map<String, dynamic>;
       final String href = ch['href'] as String;
@@ -1907,12 +1907,20 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
         html: html,
         spineIndex: i,
       ));
-      // key 与 EpubParser 建表时同构造（canonicalize 后相对 extractDir 的 posix
-      // 路径），拦截器才查得到。
-      final String absPath = p.canonicalize(p.join(extractDir, href));
-      if (!p.isWithin(canonExtractDir, absPath)) continue;
+      // BUG-1218：key 与 filePath 必须与 [EpubParser._resolveWithinExtract] /
+      // [EpubParser._relHref] **同构造**——越界判据用 canonicalize（大小写折叠，
+      // `../` 逃逸不被绕过），真实路径与键用 normalize（**保留大小写**）。此前这里
+      // 用 canonicalize 建键，而 parser 侧与拦截器侧都已改成保留大小写，三方
+      // 2:1 不一致：混合大小写的书在这条回退路径上 resources 永远查不中，
+      // BUG-1203 的「OPF media-type 优先」静默退回扩展名兜底；filePath 折成小写
+      // 更让大小写敏感平台直接读不到文件。
+      final String joined = p.join(extractDir, href);
+      if (!p.isWithin(p.canonicalize(extractDir), p.canonicalize(joined))) {
+        continue;
+      }
+      final String absPath = p.normalize(joined);
       final String relPath =
-          p.relative(absPath, from: canonExtractDir).replaceAll('\\', '/');
+          p.relative(absPath, from: normExtractDir).replaceAll('\\', '/');
       resources[normalizeHref(relPath)] =
           EpubResource(mediaType: mediaType, filePath: absPath);
     }

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+988
+version: 1.3.1+989
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/epub/epub_path_case_preserved_test.dart
+++ b/hibiki/test/epub/epub_path_case_preserved_test.dart
@@ -1,0 +1,202 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/epub/epub_book.dart';
+import 'package:hibiki/src/epub/epub_parser.dart';
+import 'package:path/path.dart' as p;
+
+/// BUG-1218：解析出的章节/资源路径必须保留磁盘上的**真实大小写**。
+///
+/// `p.canonicalize` 在 Windows/macOS 等大小写不敏感平台会把整条路径折成小写。解析侧
+/// 曾直接拿它的结果当真实读写路径，于是用户书（Calibre/Sigil 重打包）的
+/// `OEBPS/Dick_9780345508553_epub_c01_r1.htm` 被记成 `oebps/dick_...htm`：
+/// Windows 文件系统不区分大小写所以侥幸能读，但在 **Android / Linux 上
+/// `existsSync()` 全部为 false**，spine 里的章节被逐条静默跳过（整本只剩路径恰好
+/// 全小写的那一两章），且不写任何错误日志。
+///
+/// 本地跑在 Windows 上时 `File.exists` 不区分大小写，所以**只断言 existsSync 抓不到
+/// 这个 bug**；这里改为把解析结果与 `listSync` 列出的真实磁盘条目名做**逐字节比对**，
+/// 从而在任何平台上都能复现大小写敏感平台的查找语义。
+void main() {
+  late Directory extractDir;
+
+  setUp(() {
+    extractDir = Directory.systemTemp.createTempSync('epub_path_case_');
+  });
+
+  tearDown(() {
+    if (extractDir.existsSync()) {
+      extractDir.deleteSync(recursive: true);
+    }
+  });
+
+  /// 磁盘上真实存在的、相对 extractDir 的正斜杠路径集合（大小写原样）。
+  Set<String> onDiskEntries() => <String>{
+        for (final FileSystemEntity e in extractDir.listSync(recursive: true))
+          if (e is File)
+            p.relative(e.path, from: extractDir.path).replaceAll('\\', '/'),
+      };
+
+  test('章节 href 与磁盘上的实际大小写逐字节一致', () {
+    final EpubBook book =
+        EpubParser.parseSync(_mixedCaseEpub(), extractDir.path);
+    final Set<String> onDisk = onDiskEntries();
+
+    expect(book.chapters, hasLength(2), reason: '两章都必须进 spine');
+    for (final EpubChapter c in book.chapters) {
+      expect(onDisk, contains(c.href),
+          reason: 'href「${c.href}」与磁盘大小写不符 —— 大小写敏感的 '
+              'Android/Linux 上 existsSync 会失败，该章被静默跳过');
+    }
+  });
+
+  test('资源表的键与 filePath 都保留真实大小写', () {
+    final EpubBook book =
+        EpubParser.parseSync(_mixedCaseEpub(), extractDir.path);
+    final Set<String> onDisk = onDiskEntries();
+
+    for (final MapEntry<String, EpubResource> e in book.resources.entries) {
+      expect(onDisk, contains(e.key),
+          reason: '资源键「${e.key}」与磁盘大小写不符 —— 拦截器（BUG-1203）按真实 '
+              'href 回查 OPF media-type 时会查不中，静默退回扩展名兜底');
+      final String rel = p
+          .relative(e.value.filePath!, from: extractDir.path)
+          .replaceAll('\\', '/');
+      expect(onDisk, contains(rel),
+          reason: '资源 filePath「$rel」与磁盘大小写不符，读不到文件');
+    }
+  });
+
+  test('封面 href 保留真实大小写', () {
+    final EpubBook book =
+        EpubParser.parseSync(_mixedCaseEpub(), extractDir.path);
+    expect(book.coverHref, 'Images/COVER.jpeg');
+    expect(onDiskEntries(), contains(book.coverHref));
+  });
+
+  test('NCX 目录能被找到（路径折成小写会导致 TOC 整个为空）', () {
+    final EpubBook book =
+        EpubParser.parseSync(_mixedCaseEpub(), extractDir.path);
+    expect(book.toc, isNotEmpty,
+        reason: 'NCX 在 `Meta/TOC.ncx`，路径被折成小写就读不到，TOC 静默变空');
+    expect(book.chapterIndexForHref(book.toc.first.href), isNot(-1),
+        reason: 'TOC 条目必须能解析回 spine 章节');
+  });
+
+  test('大小写保留不削弱 zip-slip 防护', () {
+    final EpubBook book =
+        EpubParser.parseSync(_traversalEpub(), extractDir.path);
+    for (final EpubChapter c in book.chapters) {
+      expect(c.href.contains('..'), isFalse,
+          reason: '逃逸出 extractDir 的 manifest 条目必须被丢弃');
+    }
+    for (final String key in book.resources.keys) {
+      expect(key.contains('..'), isFalse);
+    }
+    // 逃逸条目被丢掉后，合法那一章仍须保留。
+    expect(book.chapters, hasLength(1));
+    expect(book.chapters.single.href, 'OEBPS/Ch1.htm');
+  });
+}
+
+/// 复刻用户书的结构：OPF 在压缩包**根目录**、内容在混合大小写的 `OEBPS/`、
+/// 章节扩展名 `.htm`、封面在 `Images/COVER.jpeg`、NCX 在 `Meta/TOC.ncx`。
+Uint8List _mixedCaseEpub() {
+  const String opf = '''
+<?xml version="1.0" encoding="utf-8"?>
+<package version="2.0" unique-identifier="uid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Do Androids Dream of Electric Sheep?</dc:title>
+    <dc:creator>Philip K. Dick</dc:creator>
+  </metadata>
+  <manifest>
+    <item id="cover" href="Images/COVER.jpeg" media-type="image/jpeg"/>
+    <item id="css" href="Styles/Main.css" media-type="text/css"/>
+    <item id="ncx" href="Meta/TOC.ncx" media-type="application/x-dtbncx+xml"/>
+    <item id="c01" href="OEBPS/Dick_9780345508553_epub_c01_r1.htm" media-type="application/xhtml+xml"/>
+    <item id="c02" href="OEBPS/Dick_9780345508553_epub_c02_r1.htm" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="c01"/>
+    <itemref idref="c02"/>
+  </spine>
+</package>
+''';
+  const String ncx = '''
+<?xml version="1.0" encoding="utf-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <navMap>
+    <navPoint id="n1" playOrder="1">
+      <navLabel><text>Chapter 1</text></navLabel>
+      <content src="../OEBPS/Dick_9780345508553_epub_c01_r1.htm"/>
+    </navPoint>
+  </navMap>
+</ncx>
+''';
+  return _encodeArchive(<ArchiveFile>[
+    _textFile('META-INF/container.xml', _rootLevelContainerXml),
+    _textFile('content.opf', opf),
+    _textFile('Meta/TOC.ncx', ncx),
+    _textFile('OEBPS/Dick_9780345508553_epub_c01_r1.htm', _chapterHtml),
+    _textFile('OEBPS/Dick_9780345508553_epub_c02_r1.htm', _chapterHtml),
+    _textFile('Styles/Main.css', 'body { margin: 0; }'),
+    _binFile('Images/COVER.jpeg', <int>[0xFF, 0xD8, 0xFF, 0xE0, 0x00]),
+  ]);
+}
+
+Uint8List _traversalEpub() {
+  const String opf = '''
+<?xml version="1.0" encoding="utf-8"?>
+<package version="2.0" unique-identifier="uid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Traversal</dc:title>
+  </metadata>
+  <manifest>
+    <item id="ok" href="OEBPS/Ch1.htm" media-type="application/xhtml+xml"/>
+    <item id="evil" href="../../escaped.htm" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="ok"/>
+    <itemref idref="evil"/>
+  </spine>
+</package>
+''';
+  return _encodeArchive(<ArchiveFile>[
+    _textFile('META-INF/container.xml', _rootLevelContainerXml),
+    _textFile('content.opf', opf),
+    _textFile('OEBPS/Ch1.htm', _chapterHtml),
+  ]);
+}
+
+const String _rootLevelContainerXml = '''
+<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>
+''';
+
+const String _chapterHtml = '''
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"><body><p>Rick Deckard</p></body></html>
+''';
+
+Uint8List _encodeArchive(List<ArchiveFile> files) {
+  final Archive archive = Archive();
+  for (final ArchiveFile f in files) {
+    archive.addFile(f);
+  }
+  return Uint8List.fromList(ZipEncoder().encode(archive)!);
+}
+
+ArchiveFile _textFile(String name, String content) {
+  final List<int> bytes = utf8.encode(content);
+  return ArchiveFile(name, bytes.length, bytes);
+}
+
+ArchiveFile _binFile(String name, List<int> bytes) =>
+    ArchiveFile(name, bytes.length, bytes);


### PR DESCRIPTION
## 背景：这是那本书的**第二个**独立根因

用户报「`Do Androids Dream of Electric Sheep？.epub` 打不开」（Windows）。诊断时发现两个互相独立的根因叠在同一本书上：

| 根因 | 症状平台 | 状态 |
|---|---|---|
| 按扩展名猜 MIME → 整本空白 | Windows | **已修**（BUG-1199 治标 → BUG-1203 根治，均已在 develop） |
| 解析出的路径被折成小写 → 章节全失踪 | **Android / Linux** | 本 PR（BUG-1218） |

本 PR **不碰** BUG-1203 的实现（`epub_book.dart` **零改动**），只修路径大小写。

## 根因

`p.canonicalize` 在 Windows / macOS 等大小写不敏感平台会把整条路径**折成小写**，而 8 处直接拿它的结果当**真实读写路径**：

```
OEBPS/Dick_9780345508553_epub_c01_r1.htm   ← 磁盘上的真实条目
oebps/dick_9780345508553_epub_c01_r1.htm   ← 解析后记下来的路径
```

Windows 文件系统不区分大小写，所以本机侥幸能读、问题被完全掩盖；但在 **Android / Linux 上 `File.existsSync()` 全部为 false**，`_parseSpine` 逐条 `continue` 把章节静默跳过，整本书只剩路径恰好全小写的那一两章（那本书只剩 `titlepage.xhtml`），**且不写任何错误日志**。

实测那本书：**31/32 章、33/38 个资源**的路径大小写与磁盘不符。

**为什么一直没暴露**：日语 EPUB 内部路径习惯全小写，大小写混排主要出现在英文出版社/Calibre 重打包的书里；而项目主力验证平台是 Windows，那里这个 bug 不可见。

`_safeArchivePath` 早在 TODO-739 就为**解压**侧修好了同一个坑（注释详述了大小写折叠如何把 `META-INF` 写成 `meta-inf`，以及为什么必须「校验用 canonicalize、落盘用 normalize」两种形式分开），但**解析**侧一直没跟上这个结论。

## 改动

新增 `EpubParser._resolveWithinExtract()` / `_relHref()` 沿用同款做法：**边界校验用 `p.canonicalize`**（`../` 逃逸不被大小写差异绕过）、**真实路径用 `p.normalize`**（保留大小写）。改用处：

- `epub_parser.dart` 4 处：`_parseSpine`（章节 href + `File`）、`_itemRelHref`（封面）、resources map（键 + `filePath`）、`_parseToc`（nav + ncx）
- `webview.part.dart` 3 处：`_readerResourcePayload`、`_chapterFilePath`、`_imageFileSizeBytes`
- `chrome.part.dart` 1 处：`_readerImageFileForUrl`（图片查看器 / 分享）

两处联动需要特别说明：

- **BUG-1203 的 `declaredHref` 反推基准同步换成 `normalize` 形式**。原先两侧都 canonicalize（都被折成小写）确实也能互相匹配，但那让 `filePath` 在大小写敏感平台上根本读不到文件；现在 parser 的 resources 键与拦截器的 `declaredHref` 都是真实大小写，**既能读到文件、也仍然对得上**。
- **`_chapterFilePath` 必须同步改**：它的注释明说要与拦截器 "cache keys line up"，只改一侧会让 BUG-270 的章节 LRU 两边 key 一个折成小写一个原样而**永不命中**。

## 测试

`hibiki/test/epub/epub_path_case_preserved_test.dart`（复刻用户书结构：根级 OPF + 混合大小写 `OEBPS/Dick_*` + `Images/COVER.jpeg` + `Meta/TOC.ncx`）：章节 href、资源键与 `filePath`、封面 href 分别与 `listSync` 列出的**真实磁盘条目名逐字节比对**；NCX 能被找到（路径折小写会让 TOC 静默变空）；zip-slip 防护不被削弱。

逐字节比对而非 `existsSync` 是刻意的：**本地跑在 Windows 上 `File.exists` 不区分大小写，只断言 `existsSync` 根本抓不到这个 bug**。

**有效性已验证**：把 `_resolveWithinExtract` 的返回值临时改回 `p.canonicalize`，该文件 5 条中 4 条立刻转红，报的正是 `Expected: Images/COV… Actual: images/cov…`，确认不是弱断言假绿。

- `test/epub/` + `test/reader/`：`PASSED - 1468 tests`
- `test/pages/` + `test/widgets/`：`PASSED - 2783 tests`（含 BUG-1203 的源码守卫，确认没破坏对方实现）
- `flutter analyze`：`No issues found!`

## 对存量书的影响：无

- `chaptersJson` 在 `path_rebase_coverage.dart` 标注为 `notAPath`，开书走 `parseFromExtracted` 重新解析、DB 只复用字数；
- 旧书 `tocJson` 里存的小写 href 由 `EpubBook.chapterIndexForHref`（TODO-796）**既有的**大小写不敏感兜底 pass 兜住，TOC 跳转不回归。

## ⚠️ 未做真机复测

本机是 Windows，**恰好是这个 bug 不可见的平台**。「Android/Linux 上章节会被跳过」这一结论由「解析出的路径与磁盘条目逐字节不符」推出，未在真机/模拟器上打开这本书复验。建议在 Android 模拟器上走原始失败路径确认。

## 改号说明

原取号 BUG-1214，rebase 后发现 develop 已落地同号的 `BUG-1214-waveform-align-wheel-hscroll`，按仓库红线改号到 **BUG-1218**（文件名 / 正文 H2 / 代码注释 / 测试四处同步，`bug.dart check` 通过）。改号时 `renumber` 会扫全仓，一度把 waveform 那条的源码引用也改掉了，已还原——本 PR 对 `platform_utils.dart` / `subtitle_waveform_align_panel_test.dart` / `horizontal_drag_scroll_guard_test.dart` **零改动**。

## 顺带发现（未在本 PR 范围内）

`hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart:346` 有同样的 `p.canonicalize(p.join(...))` 当真实路径的模式（漫画解压 zip/cbz 同样可能混合大小写），属独立子系统、独立导入与渲染路径。

https://claude.ai/code/session_016SmYCAT2iA6VNwUVXaNF1J
