### PR TITLE
fix(tracking): Bangumi 同步链路可观测化 + 删掉未接入的读书 meter 说明

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,8 +33,8 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1220](bugs/BUG-1220-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |
 | [BUG-1218](bugs/BUG-1218-epub-path-case-folded-android.md) | ✅ | ✅ | EPUB 解析把路径折成小写，大小写敏感平台上整本章节静默失踪 |
-| [BUG-1216](bugs/BUG-1216-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |
 | [BUG-1215](bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md) | ✅ | ✅ | Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包 |
 | [BUG-1214](bugs/BUG-1214-waveform-align-wheel-hscroll.md) | ✅ | ✅ | 波形对轴放大视图鼠标滚轮不能左右平移时间轴 |
 | [BUG-1213](bugs/BUG-1213-android-legacy-storage-permission-query.md) | ✅ | ✅ | Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1176 条。点号进各自文件。
+> 共 1178 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1218](bugs/BUG-1218-epub-path-case-folded-android.md) | ✅ | ✅ | EPUB 解析把路径折成小写，大小写敏感平台上整本章节静默失踪 |
+| [BUG-1216](bugs/BUG-1216-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |
 | [BUG-1215](bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md) | ✅ | ✅ | Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包 |
 | [BUG-1214](bugs/BUG-1214-waveform-align-wheel-hscroll.md) | ✅ | ✅ | 波形对轴放大视图鼠标滚轮不能左右平移时间轴 |
 | [BUG-1213](bugs/BUG-1213-android-legacy-storage-permission-query.md) | ✅ | ✅ | Android 7~10 上查询侧恒判未授权，用户根本加不了本地扫描根 |

--- a/docs/bugs/BUG-1216-bangumi-sync-invisible.md
+++ b/docs/bugs/BUG-1216-bangumi-sync-invisible.md
@@ -1,0 +1,38 @@
+## BUG-1216 · Bangumi 同步链路全静默：看完了没反应且无处查看
+
+- **报告**：2026-07-28（用户：看完了没反应，也不知道怎么查看这个 bangumi 数据）
+- **真实性**：✅ 真 bug（可观测性缺陷，非链路断裂）
+
+调用点其实都在，事件确实会进 outbox：
+- `hibiki/lib/src/pages/implementations/video_hibiki_page.dart:2876`（看完一集 → `recordVideoCompleted`）
+- `hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart:1118`（阅读位置落盘 → `recordBookProgress`）
+- `hibiki/lib/src/models/app_model.dart:4928`（游戏状态 → `recordGameStatus`）
+
+根因是这条链路的**每一个失败点都不出声**，用户端零反馈，因此「同步没同步、断在哪一段」完全不可观测：
+
+| 位置 | 静默行为 |
+|---|---|
+| `media_tracking_service.dart` `_ensureAutoBookMapping` / `_ensureAutoVideoMapping` / `_ensureAutoGameMapping` | 没令牌 → `return null`；标题匹配不唯一或相似度 < 0.92 → `return null`，且 `_autoMappingMissAt` 让同一条目 10 分钟内不再尝试 |
+| `media_tracking_service.dart` `_sync` | 上报失败只 `ErrorLogService.log`，`markFailed` 退避 30s→最长 6h |
+| `media_tracking_repository.dart` `markSucceeded` | 成功即 **删除** outbox 行——同步成功不留任何痕迹 |
+| `media_tracking_repository.dart` `dueUpdates` | 按 `nextAttemptAt` 过滤，退避窗口内失败行连「待办」都不算 |
+
+于是「已连接 + 零待办」与「从来没跑过同步」在 UI 上完全同形，而设置页只有一个 `Pending: 0`。
+
+附带问题：设置页有一条「読書メーター 未公开个人写入 API」说明（`media_tracking_bookmeter_note`），全仓仅此一处 UI 引用、零实现代码——从未接入的东西不该出现在设置里。
+
+- **[x] ① 已修复** — commit 见本分支
+  1. 服务层新增可观测出口：`MediaTrackingStatus` / `MediaTrackingFailure` 快照 + `loadStatus()`；每轮同步结束落 `media_tracking_last_sync_*_v1` 偏好（区分「跑过零待办」与「从未跑过」），`statusRevision` 通知 UI；`connect()` 把「校验 + 落令牌 + 记账号名」收成一次原子操作，换令牌清旧账号名。
+  2. `MediaTrackingRepository.allPending()`：**不**按 `nextAttemptAt` 过滤的展示侧查询，退避窗口里也能说出失败原因。
+  3. 首页 dashboard 新增「Bangumi 同步」卡（宽屏侧列顶部 / 窄屏继续区之后）：未连接→说明 + 连接入口；已连接→账号、上次同步、已关联数、待发送数、令牌被拒提示、已关联条目（点击开 bgm.tv 条目页）、立即同步 + 管理关联。零映射时明说「没有任何条目关联，所以看完不会有变化」。
+     - 失败原因**挂在对应条目行上**（`MediaTrackingFailure.mappingId` + `mappingsProblemFirst` 把出问题的条目排到最前），不另开一段——首版写成独立「失败」段时 widget 测试立刻抓到同一条目标题出现两次，读起来像两个不同的东西。设置页同口径（错误进该行副标题）。
+  4. 设置页删掉 bookmeter 死文案（含 17 语言 i18n key，走 `i18n_sync --remove`），并复用同一状态快照显示上次同步/失败原因；`_kindLabel`/`_modeLabel` 抽成共享 `media_tracking_labels.dart`。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/tracking/media_tracking_service_test.dart`（group「可见状态快照（BUG-1216）」7 项）
+  - 从未同步 vs 同步过零待办可区分
+  - 未配置令牌时不谎报「已同步过」
+  - 失败待办在退避窗口内仍带原因外显（`dueUpdates` 为空而 `loadStatus().failures` 有值）
+  - 令牌被拒 → `unauthorized`
+  - `connect` 记住账号名 / 换令牌清旧账号
+  - bookChapter 伴随映射不作为独立条目外显
+  - 同步结束自增 `statusRevision`
+- **备注**：本条只解决可观测性与死文案。自动映射的高置信度门槛（exact 唯一 / score ≥ 0.92）**未放宽**——宁可不建映射也不把进度写到别人的条目上；现在这种情况会在首页明说「没关联」并指向手工关联入口。UI 部分需真机目视验收。

--- a/docs/bugs/BUG-1216-bangumi-sync-invisible.md
+++ b/docs/bugs/BUG-1216-bangumi-sync-invisible.md
@@ -23,7 +23,7 @@
 
 - **[x] ① 已修复** — commit 见本分支
   1. 服务层新增可观测出口：`MediaTrackingStatus` / `MediaTrackingFailure` 快照 + `loadStatus()`；每轮同步结束落 `media_tracking_last_sync_*_v1` 偏好（区分「跑过零待办」与「从未跑过」），`statusRevision` 通知 UI；`connect()` 把「校验 + 落令牌 + 记账号名」收成一次原子操作，换令牌清旧账号名。
-  2. `MediaTrackingRepository.allPending()`：**不**按 `nextAttemptAt` 过滤的展示侧查询，退避窗口里也能说出失败原因。
+  2. `MediaTrackingRepository.allPending()`：**不**按 `nextAttemptAt` 过滤的展示侧查询，退避窗口里也能说出失败原因。它带展示上限（默认 50 行），因此「待发送 N 项」的计数仍走 `pendingCount()` 的 `COUNT(*)`，不能用列表长度（否则待办多于上限时少报，有回归测试守卫）。
   3. 首页 dashboard 新增「Bangumi 同步」卡（宽屏侧列顶部 / 窄屏继续区之后）：未连接→说明 + 连接入口；已连接→账号、上次同步、已关联数、待发送数、令牌被拒提示、已关联条目（点击开 bgm.tv 条目页）、立即同步 + 管理关联。零映射时明说「没有任何条目关联，所以看完不会有变化」。
      - 失败原因**挂在对应条目行上**（`MediaTrackingFailure.mappingId` + `mappingsProblemFirst` 把出问题的条目排到最前），不另开一段——首版写成独立「失败」段时 widget 测试立刻抓到同一条目标题出现两次，读起来像两个不同的东西。设置页同口径（错误进该行副标题）。
   4. 设置页删掉 bookmeter 死文案（含 17 语言 i18n key，走 `i18n_sync --remove`），并复用同一状态快照显示上次同步/失败原因；`_kindLabel`/`_modeLabel` 抽成共享 `media_tracking_labels.dart`。

--- a/docs/bugs/BUG-1220-bangumi-sync-invisible.md
+++ b/docs/bugs/BUG-1220-bangumi-sync-invisible.md
@@ -1,4 +1,4 @@
-## BUG-1216 · Bangumi 同步链路全静默：看完了没反应且无处查看
+## BUG-1220 · Bangumi 同步链路全静默：看完了没反应且无处查看
 
 - **报告**：2026-07-28（用户：看完了没反应，也不知道怎么查看这个 bangumi 数据）
 - **真实性**：✅ 真 bug（可观测性缺陷，非链路断裂）
@@ -27,7 +27,7 @@
   3. 首页 dashboard 新增「Bangumi 同步」卡（宽屏侧列顶部 / 窄屏继续区之后）：未连接→说明 + 连接入口；已连接→账号、上次同步、已关联数、待发送数、令牌被拒提示、已关联条目（点击开 bgm.tv 条目页）、立即同步 + 管理关联。零映射时明说「没有任何条目关联，所以看完不会有变化」。
      - 失败原因**挂在对应条目行上**（`MediaTrackingFailure.mappingId` + `mappingsProblemFirst` 把出问题的条目排到最前），不另开一段——首版写成独立「失败」段时 widget 测试立刻抓到同一条目标题出现两次，读起来像两个不同的东西。设置页同口径（错误进该行副标题）。
   4. 设置页删掉 bookmeter 死文案（含 17 语言 i18n key，走 `i18n_sync --remove`），并复用同一状态快照显示上次同步/失败原因；`_kindLabel`/`_modeLabel` 抽成共享 `media_tracking_labels.dart`。
-- **[x] ② 已加自动化测试** — `hibiki/test/media/tracking/media_tracking_service_test.dart`（group「可见状态快照（BUG-1216）」7 项）
+- **[x] ② 已加自动化测试** — `hibiki/test/media/tracking/media_tracking_service_test.dart`（group「可见状态快照（BUG-1220）」7 项）
   - 从未同步 vs 同步过零待办可区分
   - 未配置令牌时不谎报「已同步过」
   - 失败待办在退避窗口内仍带原因外显（`dueUpdates` 为空而 `loadStatus().failures` 有值）

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46308 (2724 per locale)
+/// Strings: 46495 (2735 per locale)
 ///
-/// Built on 2026-07-28 at 12:37 UTC
+/// Built on 2026-07-28 at 14:53 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -1865,8 +1865,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get media_tracking_account => 'Bangumi account';
   String get media_tracking_add_mapping => 'Add mapping';
   String get media_tracking_anime => 'Anime';
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   String get media_tracking_chapter => 'Chapter';
   String get media_tracking_connect => 'Connect and verify';
   String get media_tracking_connected_as => 'Connected account';
@@ -3660,6 +3658,22 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String stat_format_pages({required Object n}) => '${n} pages';
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  String get media_tracking_card_title => 'Bangumi sync';
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  String get media_tracking_last_sync => 'Last sync';
+  String get media_tracking_never_synced => 'Never synced';
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  String get media_tracking_all_synced => 'Everything sent';
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  String get media_tracking_manage_links => 'Manage links';
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -6665,9 +6679,6 @@ class _StringsAr extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -9892,6 +9903,34 @@ class _StringsAr extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -12926,9 +12965,6 @@ class _StringsDe extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -16192,6 +16228,34 @@ class _StringsDe extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -19230,9 +19294,6 @@ class _StringsEs extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -22508,6 +22569,34 @@ class _StringsEs extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -25553,9 +25642,6 @@ class _StringsFr extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -28835,6 +28921,34 @@ class _StringsFr extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -31843,9 +31957,6 @@ class _StringsId extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -35091,6 +35202,34 @@ class _StringsId extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -38122,9 +38261,6 @@ class _StringsIt extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -41393,6 +41529,34 @@ class _StringsIt extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -44355,9 +44519,6 @@ class _StringsJa extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -47512,6 +47673,34 @@ class _StringsJa extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -50475,9 +50664,6 @@ class _StringsKo extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -53633,6 +53819,34 @@ class _StringsKo extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -56655,9 +56869,6 @@ class _StringsNl extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -59915,6 +60126,34 @@ class _StringsNl extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -62948,9 +63187,6 @@ class _StringsPtBr extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -66210,6 +66446,34 @@ class _StringsPtBr extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -69234,9 +69498,6 @@ class _StringsRu extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -72489,6 +72750,34 @@ class _StringsRu extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -75487,9 +75776,6 @@ class _StringsTh extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -78716,6 +79002,34 @@ class _StringsTh extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -81733,9 +82047,6 @@ class _StringsTr extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -84975,6 +85286,34 @@ class _StringsTr extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -87985,9 +88324,6 @@ class _StringsVi extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -91219,6 +91555,34 @@ class _StringsVi extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 // Path: <root>
@@ -94019,9 +94383,6 @@ class _StringsZhCn extends _StringsEn {
   String get media_tracking_add_mapping => '添加映射';
   @override
   String get media_tracking_anime => '番剧';
-  @override
-  String get media_tracking_bookmeter_note =>
-      '读书 Meter 未公开个人写入 API，因此仅参考其进度交互，不进行网页抓取。';
   @override
   String get media_tracking_chapter => '话';
   @override
@@ -97023,6 +97384,31 @@ class _StringsZhCn extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       '没有字幕条目对得上该种子的第 ${season} 季，已不自动选中。要用的话请手动选一条。';
+  @override
+  String get media_tracking_card_title => 'Bangumi 同步';
+  @override
+  String get media_tracking_not_connected => '未连接。进度只记在本地，不会同步到 Bangumi。';
+  @override
+  String get media_tracking_last_sync => '上次同步';
+  @override
+  String get media_tracking_never_synced => '从未同步';
+  @override
+  String media_tracking_linked_count({required Object n}) => '已关联 ${n} 项';
+  @override
+  String media_tracking_pending_count({required Object n}) => '${n} 项待发送';
+  @override
+  String get media_tracking_all_synced => '全部已发送';
+  @override
+  String get media_tracking_unauthorized => 'Bangumi 拒绝了访问令牌，请在设置里重新连接。';
+  @override
+  String get media_tracking_unlinked_hint =>
+      '还没有任何条目关联到 Bangumi 条目，所以看完/读完在那边不会有任何变化。自动匹配只在标题唯一命中时才建立关联，其余需要手动关联。';
+  @override
+  String get media_tracking_open_subject => '在 Bangumi 打开';
+  @override
+  String get media_tracking_manage_links => '管理关联';
+  @override
+  String get media_tracking_last_error => '上次错误';
 }
 
 // Path: <root>
@@ -99952,9 +100338,6 @@ class _StringsZhHk extends _StringsEn {
   String get media_tracking_add_mapping => 'Add mapping';
   @override
   String get media_tracking_anime => 'Anime';
-  @override
-  String get media_tracking_bookmeter_note =>
-      'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
   @override
   String get media_tracking_chapter => 'Chapter';
   @override
@@ -103063,6 +103446,34 @@ class _StringsZhHk extends _StringsEn {
   @override
   String anime_download_subs_season_mismatch({required Object season}) =>
       'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+  @override
+  String get media_tracking_card_title => 'Bangumi sync';
+  @override
+  String get media_tracking_not_connected =>
+      'Not connected. Progress stays local and nothing reaches Bangumi.';
+  @override
+  String get media_tracking_last_sync => 'Last sync';
+  @override
+  String get media_tracking_never_synced => 'Never synced';
+  @override
+  String media_tracking_linked_count({required Object n}) => '${n} linked';
+  @override
+  String media_tracking_pending_count({required Object n}) =>
+      '${n} waiting to send';
+  @override
+  String get media_tracking_all_synced => 'Everything sent';
+  @override
+  String get media_tracking_unauthorized =>
+      'Bangumi rejected the access token. Reconnect it in settings.';
+  @override
+  String get media_tracking_unlinked_hint =>
+      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+  @override
+  String get media_tracking_open_subject => 'Open on Bangumi';
+  @override
+  String get media_tracking_manage_links => 'Manage links';
+  @override
+  String get media_tracking_last_error => 'Last error';
 }
 
 /// Flat map(s) containing all translations.
@@ -105730,8 +106141,6 @@ extension on _StringsEn {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -108644,6 +109053,30 @@ extension on _StringsEn {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -111311,8 +111744,6 @@ extension on _StringsAr {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -114223,6 +114654,30 @@ extension on _StringsAr {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -116897,8 +117352,6 @@ extension on _StringsDe {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -119823,6 +120276,30 @@ extension on _StringsDe {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -122497,8 +122974,6 @@ extension on _StringsEs {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -125422,6 +125897,30 @@ extension on _StringsEs {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -128100,8 +128599,6 @@ extension on _StringsFr {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -131027,6 +131524,30 @@ extension on _StringsFr {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -133698,8 +134219,6 @@ extension on _StringsId {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -136614,6 +137133,30 @@ extension on _StringsId {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -139288,8 +139831,6 @@ extension on _StringsIt {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -142216,6 +142757,30 @@ extension on _StringsIt {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -144875,8 +145440,6 @@ extension on _StringsJa {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -147780,6 +148343,30 @@ extension on _StringsJa {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -150441,8 +151028,6 @@ extension on _StringsKo {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -153348,6 +153933,30 @@ extension on _StringsKo {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -156021,8 +156630,6 @@ extension on _StringsNl {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -158943,6 +159550,30 @@ extension on _StringsNl {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -161615,8 +162246,6 @@ extension on _StringsPtBr {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -164535,6 +165164,30 @@ extension on _StringsPtBr {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -167210,8 +167863,6 @@ extension on _StringsRu {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -170132,6 +170783,30 @@ extension on _StringsRu {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -172798,8 +173473,6 @@ extension on _StringsTh {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -175713,6 +176386,30 @@ extension on _StringsTh {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -178384,8 +179081,6 @@ extension on _StringsTr {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -181303,6 +181998,30 @@ extension on _StringsTr {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -183971,8 +184690,6 @@ extension on _StringsVi {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -186888,6 +187605,30 @@ extension on _StringsVi {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }
@@ -189536,8 +190277,6 @@ extension on _StringsZhCn {
         return '添加映射';
       case 'media_tracking_anime':
         return '番剧';
-      case 'media_tracking_bookmeter_note':
-        return '读书 Meter 未公开个人写入 API，因此仅参考其进度交互，不进行网页抓取。';
       case 'media_tracking_chapter':
         return '话';
       case 'media_tracking_connect':
@@ -192427,6 +193166,30 @@ extension on _StringsZhCn {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             '没有字幕条目对得上该种子的第 ${season} 季，已不自动选中。要用的话请手动选一条。';
+      case 'media_tracking_card_title':
+        return 'Bangumi 同步';
+      case 'media_tracking_not_connected':
+        return '未连接。进度只记在本地，不会同步到 Bangumi。';
+      case 'media_tracking_last_sync':
+        return '上次同步';
+      case 'media_tracking_never_synced':
+        return '从未同步';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '已关联 ${n} 项';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} 项待发送';
+      case 'media_tracking_all_synced':
+        return '全部已发送';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi 拒绝了访问令牌，请在设置里重新连接。';
+      case 'media_tracking_unlinked_hint':
+        return '还没有任何条目关联到 Bangumi 条目，所以看完/读完在那边不会有任何变化。自动匹配只在标题唯一命中时才建立关联，其余需要手动关联。';
+      case 'media_tracking_open_subject':
+        return '在 Bangumi 打开';
+      case 'media_tracking_manage_links':
+        return '管理关联';
+      case 'media_tracking_last_error':
+        return '上次错误';
       default:
         return null;
     }
@@ -195085,8 +195848,6 @@ extension on _StringsZhHk {
         return 'Add mapping';
       case 'media_tracking_anime':
         return 'Anime';
-      case 'media_tracking_bookmeter_note':
-        return 'Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.';
       case 'media_tracking_chapter':
         return 'Chapter';
       case 'media_tracking_connect':
@@ -197986,6 +198747,30 @@ extension on _StringsZhHk {
       case 'anime_download_subs_season_mismatch':
         return ({required Object season}) =>
             'No subtitle entry matches season ${season} of this pack - not auto-selected. Pick one manually if you want it anyway.';
+      case 'media_tracking_card_title':
+        return 'Bangumi sync';
+      case 'media_tracking_not_connected':
+        return 'Not connected. Progress stays local and nothing reaches Bangumi.';
+      case 'media_tracking_last_sync':
+        return 'Last sync';
+      case 'media_tracking_never_synced':
+        return 'Never synced';
+      case 'media_tracking_linked_count':
+        return ({required Object n}) => '${n} linked';
+      case 'media_tracking_pending_count':
+        return ({required Object n}) => '${n} waiting to send';
+      case 'media_tracking_all_synced':
+        return 'Everything sent';
+      case 'media_tracking_unauthorized':
+        return 'Bangumi rejected the access token. Reconnect it in settings.';
+      case 'media_tracking_unlinked_hint':
+        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
+      case 'media_tracking_open_subject':
+        return 'Open on Bangumi';
+      case 'media_tracking_manage_links':
+        return 'Manage links';
+      case 'media_tracking_last_error':
+        return 'Last error';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi 账号",
   "media_tracking_add_mapping": "添加映射",
   "media_tracking_anime": "番剧",
-  "media_tracking_bookmeter_note": "读书 Meter 未公开个人写入 API，因此仅参考其进度交互，不进行网页抓取。",
   "media_tracking_chapter": "话",
   "media_tracking_connect": "连接并验证",
   "media_tracking_connected_as": "已连接账号",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "内置引擎仅桌面平台可用，本设备使用外接 qBittorrent。",
   "stat_source_breakdown": "各来源",
   "stat_format_pages": "$n 页",
-  "anime_download_subs_season_mismatch": "没有字幕条目对得上该种子的第 $season 季，已不自动选中。要用的话请手动选一条。"
+  "anime_download_subs_season_mismatch": "没有字幕条目对得上该种子的第 $season 季，已不自动选中。要用的话请手动选一条。",
+  "media_tracking_card_title": "Bangumi 同步",
+  "media_tracking_not_connected": "未连接。进度只记在本地，不会同步到 Bangumi。",
+  "media_tracking_last_sync": "上次同步",
+  "media_tracking_never_synced": "从未同步",
+  "media_tracking_linked_count": "已关联 $n 项",
+  "media_tracking_pending_count": "$n 项待发送",
+  "media_tracking_all_synced": "全部已发送",
+  "media_tracking_unauthorized": "Bangumi 拒绝了访问令牌，请在设置里重新连接。",
+  "media_tracking_unlinked_hint": "还没有任何条目关联到 Bangumi 条目，所以看完/读完在那边不会有任何变化。自动匹配只在标题唯一命中时才建立关联，其余需要手动关联。",
+  "media_tracking_open_subject": "在 Bangumi 打开",
+  "media_tracking_manage_links": "管理关联",
+  "media_tracking_last_error": "上次错误"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1295,7 +1295,6 @@
   "media_tracking_account": "Bangumi account",
   "media_tracking_add_mapping": "Add mapping",
   "media_tracking_anime": "Anime",
-  "media_tracking_bookmeter_note": "Bookmeter is used as a progress UI reference only because it does not expose a public personal write API.",
   "media_tracking_chapter": "Chapter",
   "media_tracking_connect": "Connect and verify",
   "media_tracking_connected_as": "Connected account",
@@ -2722,5 +2721,17 @@
   "download_backend_desktop_only_note": "Built-in engine requires a desktop platform. This device uses external qBittorrent.",
   "stat_source_breakdown": "By source",
   "stat_format_pages": "$n pages",
-  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway."
+  "anime_download_subs_season_mismatch": "No subtitle entry matches season $season of this pack - not auto-selected. Pick one manually if you want it anyway.",
+  "media_tracking_card_title": "Bangumi sync",
+  "media_tracking_not_connected": "Not connected. Progress stays local and nothing reaches Bangumi.",
+  "media_tracking_last_sync": "Last sync",
+  "media_tracking_never_synced": "Never synced",
+  "media_tracking_linked_count": "$n linked",
+  "media_tracking_pending_count": "$n waiting to send",
+  "media_tracking_all_synced": "Everything sent",
+  "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
+  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
+  "media_tracking_open_subject": "Open on Bangumi",
+  "media_tracking_manage_links": "Manage links",
+  "media_tracking_last_error": "Last error"
 }

--- a/hibiki/lib/src/media/tracking/bangumi_api_client.dart
+++ b/hibiki/lib/src/media/tracking/bangumi_api_client.dart
@@ -232,6 +232,11 @@ class BangumiApiClient implements BangumiTrackingApi {
   /// 挡在登录页，因此另给一个注册入口，两者并存而不是互相替代。
   static const String signupUrl = 'https://bgm.tv/signup';
 
+  /// 条目网页地址（首页/设置页「在 Bangumi 打开」用；api.bgm.tv 是纯 JSON 接口，
+  /// 给用户看的必须是 bgm.tv 的人类页面）。
+  static String subjectUrl(int subjectId) =>
+      'https://bgm.tv/subject/$subjectId';
+
   final String _accessToken;
   final String _userAgent;
   final http.Client _client;

--- a/hibiki/lib/src/media/tracking/media_tracking_labels.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_labels.dart
@@ -1,0 +1,53 @@
+import 'package:hibiki/src/media/tracking/media_tracking_service.dart';
+import 'package:hibiki/src/pages/implementations/stat_shared.dart';
+import 'package:hibiki/utils.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 追踪状态的 i18n 外显（设置页与首页 Bangumi 同步卡共用）。
+///
+/// 这些标签原先是设置页的文件私有函数，首页卡片一并需要；抽到这里而不是复制一份，
+/// 避免两处对同一枚举值给出不同说法。
+
+/// 条目类别外显（`TrackingKind` 的持久化值）。
+String trackingKindLabel(String value) {
+  switch (value) {
+    case 'anime':
+      return t.media_tracking_anime;
+    case 'manga':
+      return t.media_tracking_manga;
+    case 'game':
+      return t.media_tracking_game;
+    default:
+      return t.media_tracking_novel;
+  }
+}
+
+/// 进度单位外显（`TrackingProgressMode` 的持久化值）。
+String trackingProgressModeLabel(String value) {
+  switch (value) {
+    case 'episode':
+      return t.media_tracking_episode;
+    case 'volume':
+      return t.media_tracking_volume;
+    case 'status':
+      return t.media_tracking_status;
+    default:
+      return t.media_tracking_chapter;
+  }
+}
+
+/// 「上次同步」外显：从未跑过同步时明确说「从未同步」，否则给相对时间。
+///
+/// 这一行是「看完了没反应」的第一诊断位：只要它显示「从未同步」，问题就在同步根本
+/// 没被触发（多数是没连令牌），而不在映射或远端。
+String trackingLastSyncLabel(MediaTrackingStatus status, DateTime now) {
+  if (status.hasNeverSynced) return t.media_tracking_never_synced;
+  return formatActivityRelativeTime(status.lastSyncAt, now);
+}
+
+/// 一条映射的副标题：类别 · Bangumi 条目名 · 进度单位。
+String trackingMappingSubtitle(MediaTrackingMappingRow mapping) => <String>[
+      trackingKindLabel(mapping.kind),
+      mapping.subjectName,
+      trackingProgressModeLabel(mapping.progressMode),
+    ].join(' · ');

--- a/hibiki/lib/src/media/tracking/media_tracking_repository.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_repository.dart
@@ -697,6 +697,37 @@ class MediaTrackingRepository {
         .toList(growable: false);
   }
 
+  /// 全部待同步行（**不**按 `nextAttemptAt` 过滤），带各自的映射。
+  ///
+  /// 与 [dueUpdates] 的区别是它服务于「展示」而不是「发送」：失败行退避最长 6 小时，
+  /// 若 UI 也只看 due 的行，用户在退避窗口里看到的会是「零待办、零错误」，正好把
+  /// 失败原因藏起来。按 updatedAt 倒序，最近的事件排在前面。
+  Future<List<PendingTrackingUpdate>> allPending({int limit = 50}) async {
+    final query = _db.select(_db.mediaTrackingOutbox).join(<Join>[
+      innerJoin(
+        _db.mediaTrackingMappings,
+        _db.mediaTrackingMappings.id
+            .equalsExp(_db.mediaTrackingOutbox.mappingId),
+      ),
+    ])
+      ..orderBy(<OrderingTerm>[
+        OrderingTerm(
+          expression: _db.mediaTrackingOutbox.updatedAt,
+          mode: OrderingMode.desc,
+        ),
+      ])
+      ..limit(limit);
+    final List<TypedResult> rows = await query.get();
+    return rows
+        .map(
+          (TypedResult row) => PendingTrackingUpdate(
+            outbox: row.readTable(_db.mediaTrackingOutbox),
+            mapping: row.readTable(_db.mediaTrackingMappings),
+          ),
+        )
+        .toList(growable: false);
+  }
+
   Future<int> pendingCount() async {
     final Expression<int> count = _db.mediaTrackingOutbox.id.count();
     final TypedResult row = await (_db.selectOnly(_db.mediaTrackingOutbox)

--- a/hibiki/lib/src/media/tracking/media_tracking_service.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_service.dart
@@ -331,6 +331,9 @@ class MediaTrackingService {
   Future<MediaTrackingStatus> loadStatus() async {
     final List<MediaTrackingMappingRow> mappings =
         await _repository.listMappings();
+    // 计数走 COUNT(*) 而不是 allPending().length：后者带展示上限（默认 50 行），
+    // 待办超过上限时会把「待发送」少报成上限值。
+    final int pendingCount = await _repository.pendingCount();
     final List<PendingTrackingUpdate> pending = await _repository.allPending();
     return MediaTrackingStatus(
       configured: isConfigured,
@@ -343,7 +346,7 @@ class MediaTrackingService {
             defaultValue: false,
           ) ==
           true,
-      pending: pending.length,
+      pending: pendingCount,
       // bookChapter 是卷映射的伴随行（只负责 ep_status），不是用户建立的独立关联，
       // 与设置页列表同口径地隐藏，避免同一本书显示成两条。
       mappings: mappings

--- a/hibiki/lib/src/media/tracking/media_tracking_service.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:hibiki/src/media/tracking/bangumi_api_client.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_repository.dart';
 import 'package:hibiki/src/media/video/scraper/filename_parser.dart';
@@ -10,6 +11,23 @@ import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 const String kBangumiAccessTokenPref = 'media_tracking_bangumi_access_token';
+
+/// 连接成功时记下的 Bangumi 昵称/用户名。令牌本身不可读回账号，重开 app 后若不存
+/// 这一条，UI 就只能显示「已配置」而说不出是谁的账号。
+const String kBangumiAccountNamePref = 'media_tracking_bangumi_account_name';
+
+/// 最近一次同步尝试的结果（首页/设置页「上次同步」行的唯一数据源）。
+///
+/// outbox 行同步成功即删除，成功不留任何痕迹；不落这几条偏好，用户就无法区分
+/// 「同步过且没有待办」与「从来没跑过同步」——这正是「看完了没反应」的可观测缺口。
+const String kMediaTrackingLastSyncAtPref = 'media_tracking_last_sync_at_v1';
+const String kMediaTrackingLastSyncSucceededPref =
+    'media_tracking_last_sync_succeeded_v1';
+const String kMediaTrackingLastSyncFailedPref =
+    'media_tracking_last_sync_failed_v1';
+const String kMediaTrackingLastSyncUnauthorizedPref =
+    'media_tracking_last_sync_unauthorized_v1';
+
 const String kVideoTrackingReconcileWatermarkPref =
     'media_tracking_video_reconcile_watermark_v1';
 const String kBookTrackingReconcileWatermarkPref =
@@ -33,6 +51,102 @@ class MediaTrackingSyncResult {
   final bool unauthorized;
 
   bool get isSuccess => failed == 0 && !unauthorized;
+}
+
+/// 一条同步失败的待办（首页/设置页展示「为什么没同步上去」）。
+///
+/// 带 [mappingId] 是为了让 UI 把错误挂回对应的条目行，而不是另开一段再把标题重复
+/// 一遍——同一条目在「失败」和「已关联」里各出现一次，读起来像两个不同的东西。
+class MediaTrackingFailure {
+  const MediaTrackingFailure({
+    required this.mappingId,
+    required this.mediaTitle,
+    required this.subjectId,
+    required this.subjectName,
+    required this.attemptCount,
+    required this.nextAttemptAt,
+    required this.error,
+  });
+
+  final int mappingId;
+  final String mediaTitle;
+  final int subjectId;
+  final String subjectName;
+  final int attemptCount;
+  final int nextAttemptAt;
+  final String error;
+}
+
+/// 追踪链路的整体可见状态。
+///
+/// 这条链路的每个失败点原本都是静默的（没令牌→不建映射、标题匹配不唯一→不建映射、
+/// 上报失败→只进错误日志），用户端零反馈。本快照把「连没连上、关联了哪些条目、
+/// 还有多少没发出去、上次同步什么时候、失败原因是什么」一次性摊开给 UI。
+class MediaTrackingStatus {
+  const MediaTrackingStatus({
+    required this.configured,
+    required this.accountName,
+    required this.lastSyncAt,
+    required this.lastSucceeded,
+    required this.lastFailed,
+    required this.unauthorized,
+    required this.pending,
+    required this.mappings,
+    required this.failures,
+  });
+
+  /// 未配置令牌时的空快照（服务未就绪/读库失败的降级值）。
+  static const MediaTrackingStatus empty = MediaTrackingStatus(
+    configured: false,
+    accountName: '',
+    lastSyncAt: 0,
+    lastSucceeded: 0,
+    lastFailed: 0,
+    unauthorized: false,
+    pending: 0,
+    mappings: <MediaTrackingMappingRow>[],
+    failures: <MediaTrackingFailure>[],
+  );
+
+  final bool configured;
+  final String accountName;
+
+  /// 最近一次同步尝试的时刻（epoch 毫秒；0 = 从未跑过）。
+  final int lastSyncAt;
+  final int lastSucceeded;
+  final int lastFailed;
+
+  /// 最近一次同步因令牌被拒而中止（令牌过期/被撤销，必须重新连接）。
+  final bool unauthorized;
+
+  /// 待同步条数（outbox 行数，含尚未到退避重试时刻的）。
+  final int pending;
+
+  /// 用户可见的映射（已滤掉 bookChapter 伴随映射，它不是独立条目）。
+  final List<MediaTrackingMappingRow> mappings;
+  final List<MediaTrackingFailure> failures;
+
+  bool get hasNeverSynced => lastSyncAt <= 0;
+
+  bool get hasProblem => unauthorized || failures.isNotEmpty;
+
+  /// 按 mapping id 索引失败原因，供 UI 把错误挂回对应条目行。
+  Map<int, MediaTrackingFailure> get failureByMappingId =>
+      <int, MediaTrackingFailure>{
+        for (final MediaTrackingFailure failure in failures)
+          failure.mappingId: failure,
+      };
+
+  /// 展示序：有失败的条目排在最前（首页只列前几条，出问题的那条不能被挤下去），
+  /// 其余保持 [mappings] 原序（kind → 标题，与设置页一致）。
+  List<MediaTrackingMappingRow> get mappingsProblemFirst {
+    final Map<int, MediaTrackingFailure> byId = failureByMappingId;
+    if (byId.isEmpty) return mappings;
+    return <MediaTrackingMappingRow>[
+      ...mappings.where((MediaTrackingMappingRow m) => byId.containsKey(m.id)),
+      ...mappings.where((MediaTrackingMappingRow m) => !byId.containsKey(m.id)),
+    ];
+  }
 }
 
 typedef _PreparedTrackingTitle = ({
@@ -154,12 +268,24 @@ class MediaTrackingService {
 
   static const Duration _autoMappingMissRetry = Duration(minutes: 10);
 
+  /// 每次同步结束/连接状态变化后自增，供 UI（首页卡片、设置页）订阅刷新。
+  /// 用计数器而不是 ChangeNotifier：外部无法合法调用 `notifyListeners`（@protected）。
+  final ValueNotifier<int> _statusRevision = ValueNotifier<int>(0);
+
+  ValueListenable<int> get statusRevision => _statusRevision;
+
   String get accessToken =>
       (_preferences.getPref(kBangumiAccessTokenPref, defaultValue: '')
               as String)
           .trim();
 
   bool get isConfigured => accessToken.isNotEmpty;
+
+  /// 已连接账号的显示名（未连接或旧版本连接过但没记过名字时为空串）。
+  String get accountName =>
+      (_preferences.getPref(kBangumiAccountNamePref, defaultValue: '')
+              as String)
+          .trim();
 
   Future<void> setAccessToken(String value) async {
     final String normalized = value.trim();
@@ -170,7 +296,10 @@ class MediaTrackingService {
       await _preferences.setPref(kVideoTrackingReconcileWatermarkPref, 0);
       await _preferences.setPref(kBookTrackingReconcileWatermarkPref, 0);
       await _preferences.setPref(kGameTrackingReconcileWatermarkPref, 0);
+      // 账号名属于旧令牌，换令牌后必须失效，否则 UI 会挂着上一个账号的名字。
+      await _preferences.setPref(kBangumiAccountNamePref, '');
     }
+    _statusRevision.value++;
   }
 
   Future<BangumiUser> validateAccessToken(String token) async {
@@ -180,6 +309,66 @@ class MediaTrackingService {
     } finally {
       api.close();
     }
+  }
+
+  /// 校验令牌 → 落盘 → 记住账号名，一步完成「连接」。
+  ///
+  /// 校验失败时抛出且不写入任何偏好：半连接状态（令牌存了但账号名空着）会让
+  /// UI 显示「已连接」而实际每次同步都 401。
+  Future<BangumiUser> connect(String token) async {
+    final BangumiUser user = await validateAccessToken(token);
+    await setAccessToken(token);
+    final String name = user.nickname.trim().isEmpty
+        ? user.username.trim()
+        : user.nickname.trim();
+    await _preferences.setPref(kBangumiAccountNamePref, name);
+    await _preferences.setPref(kMediaTrackingLastSyncUnauthorizedPref, false);
+    _statusRevision.value++;
+    return user;
+  }
+
+  /// 汇总当前追踪状态（映射 + 待办 + 上次同步结果），给 UI 一次读齐。
+  Future<MediaTrackingStatus> loadStatus() async {
+    final List<MediaTrackingMappingRow> mappings =
+        await _repository.listMappings();
+    final List<PendingTrackingUpdate> pending = await _repository.allPending();
+    return MediaTrackingStatus(
+      configured: isConfigured,
+      accountName: accountName,
+      lastSyncAt: _intPref(kMediaTrackingLastSyncAtPref),
+      lastSucceeded: _intPref(kMediaTrackingLastSyncSucceededPref),
+      lastFailed: _intPref(kMediaTrackingLastSyncFailedPref),
+      unauthorized: _preferences.getPref(
+            kMediaTrackingLastSyncUnauthorizedPref,
+            defaultValue: false,
+          ) ==
+          true,
+      pending: pending.length,
+      // bookChapter 是卷映射的伴随行（只负责 ep_status），不是用户建立的独立关联，
+      // 与设置页列表同口径地隐藏，避免同一本书显示成两条。
+      mappings: mappings
+          .where((MediaTrackingMappingRow row) =>
+              row.mediaType != TrackingMediaType.bookChapter.value)
+          .toList(growable: false),
+      failures: <MediaTrackingFailure>[
+        for (final PendingTrackingUpdate update in pending)
+          if ((update.outbox.lastError ?? '').trim().isNotEmpty)
+            MediaTrackingFailure(
+              mappingId: update.mapping.id,
+              mediaTitle: update.mapping.mediaTitle,
+              subjectId: update.mapping.subjectId,
+              subjectName: update.mapping.subjectName,
+              attemptCount: update.outbox.attemptCount,
+              nextAttemptAt: update.outbox.nextAttemptAt,
+              error: update.outbox.lastError!.trim(),
+            ),
+      ],
+    );
+  }
+
+  int _intPref(String key) {
+    final Object? stored = _preferences.getPref(key, defaultValue: 0);
+    return stored is int ? stored : int.tryParse('$stored') ?? 0;
   }
 
   Future<List<BangumiSubject>> searchSubjects({
@@ -625,7 +814,41 @@ class MediaTrackingService {
       _syncAgainRequested = false;
       result = await _reconcileAndSync(force: false);
     }
+    await _persistSyncOutcome(result);
     return result;
+  }
+
+  /// 把本轮同步结果落成可见状态。未配置令牌时不写「上次同步」（那一轮什么都没发，
+  /// 记上去会让 UI 谎报同步过），但仍要通知 UI 刷新待办计数。
+  Future<void> _persistSyncOutcome(MediaTrackingSyncResult result) async {
+    if (isConfigured) {
+      try {
+        await _preferences.setPref(
+          kMediaTrackingLastSyncAtPref,
+          DateTime.now().millisecondsSinceEpoch,
+        );
+        await _preferences.setPref(
+          kMediaTrackingLastSyncSucceededPref,
+          result.succeeded,
+        );
+        await _preferences.setPref(
+          kMediaTrackingLastSyncFailedPref,
+          result.failed,
+        );
+        await _preferences.setPref(
+          kMediaTrackingLastSyncUnauthorizedPref,
+          result.unauthorized,
+        );
+      } catch (error, stackTrace) {
+        // fail-open：状态记录失败不能影响已经发出去的同步结果本身。
+        ErrorLogService.instance.log(
+          'MediaTrackingService.persistOutcome',
+          error,
+          stackTrace,
+        );
+      }
+    }
+    _statusRevision.value++;
   }
 
   Future<MediaTrackingSyncResult> _reconcileAndSync({

--- a/hibiki/lib/src/media/tracking/media_tracking_settings_body.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_settings_body.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/media/tracking/bangumi_api_client.dart';
+import 'package:hibiki/src/media/tracking/media_tracking_labels.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_repository.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_service.dart';
 import 'package:hibiki/src/models/app_model.dart';
@@ -29,12 +30,20 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
 
   List<MediaTrackingMappingRow> _mappings = const <MediaTrackingMappingRow>[];
   int _pending = 0;
+
+  /// 最近一次载入的状态快照（上次同步时刻/结果、失败原因）。
+  MediaTrackingStatus? _status;
+
+  /// 已连接账号名。取自持久化偏好而非仅本次会话的连接结果——否则重开设置页
+  /// 就只剩一个填了令牌的输入框，用户无法确认连的是哪个账号。
   String? _connectedAccount;
   bool _busy = false;
 
   @override
   void initState() {
     super.initState();
+    final String stored = widget.appModel.mediaTrackingService.accountName;
+    if (stored.isNotEmpty) _connectedAccount = stored;
     _reload();
   }
 
@@ -45,18 +54,15 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
   }
 
   Future<void> _reload() async {
-    final List<MediaTrackingMappingRow> mappings =
-        await _repository.listMappings();
-    final int pending = await _repository.pendingCount();
+    // 映射列表 / 待办数 / 上次同步结果 / 失败原因统一走服务层快照，与首页卡片同源
+    // （含「隐藏 bookChapter 伴随映射」这条口径），不再各查一遍各滤一遍。
+    final MediaTrackingStatus status =
+        await widget.appModel.mediaTrackingService.loadStatus();
     if (!mounted) return;
     setState(() {
-      _mappings = mappings
-          .where(
-            (mapping) =>
-                mapping.mediaType != TrackingMediaType.bookChapter.value,
-          )
-          .toList(growable: false);
-      _pending = pending;
+      _status = status;
+      _mappings = status.mappings;
+      _pending = status.pending;
     });
   }
 
@@ -68,9 +74,10 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
     }
     setState(() => _busy = true);
     try {
+      // 校验 + 落令牌 + 记账号名是一次原子的「连接」，交给服务层，避免设置页与
+      // 首页各写一份半状态。
       final BangumiUser user =
-          await widget.appModel.mediaTrackingService.validateAccessToken(token);
-      await widget.appModel.mediaTrackingService.setAccessToken(token);
+          await widget.appModel.mediaTrackingService.connect(token);
       if (!mounted) return;
       setState(() => _connectedAccount =
           user.nickname.isEmpty ? user.username : user.nickname);
@@ -127,6 +134,9 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
 
   @override
   Widget build(BuildContext context) {
+    final MediaTrackingStatus? status = _status;
+    final Map<int, MediaTrackingFailure> failureByMappingId =
+        status?.failureByMappingId ?? const <int, MediaTrackingFailure>{};
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
@@ -193,6 +203,23 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
               title: t.media_tracking_pending,
               trailing: Text('$_pending'),
             ),
+            // 「上次同步」+ 失败原因：同步成功即删 outbox 行，没有这两行的话
+            // 「跑过但没有待办」与「从没跑过」在 UI 上完全同形。
+            AdaptiveSettingsRow(
+              title: t.media_tracking_last_sync,
+              trailing: Text(
+                status == null
+                    ? '—'
+                    : trackingLastSyncLabel(status, DateTime.now()),
+              ),
+            ),
+            if (status != null && status.unauthorized)
+              AdaptiveSettingsRow(
+                title: t.media_tracking_unauthorized,
+                titleMaxLines: 4,
+                icon: Icons.error_outline,
+                showIcon: true,
+              ),
             AdaptiveSettingsRow(
               title: t.media_tracking_sync_now,
               trailing: FilledButton.tonalIcon(
@@ -214,14 +241,22 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
                 title: t.media_tracking_no_mappings,
                 titleMaxLines: 4,
               ),
+            // 失败原因挂在对应条目行的副标题上（与首页卡同口径），不另开一段把
+            // 标题重复一遍。
             for (final MediaTrackingMappingRow mapping in _mappings)
               AdaptiveSettingsRow(
                 title: mapping.mediaTitle,
-                subtitle: '${_kindLabel(mapping.kind)} · '
-                    '${mapping.subjectName} · '
-                    '${_modeLabel(mapping.progressMode)} '
-                    '+${mapping.progressOffset}',
+                subtitle: <String>[
+                  '${trackingMappingSubtitle(mapping)} '
+                      '+${mapping.progressOffset}',
+                  if (failureByMappingId[mapping.id]
+                      case final MediaTrackingFailure failure)
+                    '${t.media_tracking_last_error}: ${failure.error}',
+                ].join('\n'),
+                subtitleMaxLines: 4,
                 titleMaxLines: 3,
+                icon: Icons.sync_problem_outlined,
+                showIcon: failureByMappingId.containsKey(mapping.id),
                 trailing: IconButton(
                   tooltip: t.media_tracking_delete_mapping,
                   onPressed: () async {
@@ -233,44 +268,8 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
               ),
           ],
         ),
-        AdaptiveSettingsSection(
-          children: <Widget>[
-            AdaptiveSettingsRow(
-              title: t.media_tracking_bookmeter_note,
-              titleMaxLines: 5,
-              icon: Icons.info_outline,
-              showIcon: true,
-            ),
-          ],
-        ),
       ],
     );
-  }
-}
-
-String _kindLabel(String value) {
-  switch (value) {
-    case 'anime':
-      return t.media_tracking_anime;
-    case 'manga':
-      return t.media_tracking_manga;
-    case 'game':
-      return t.media_tracking_game;
-    default:
-      return t.media_tracking_novel;
-  }
-}
-
-String _modeLabel(String value) {
-  switch (value) {
-    case 'episode':
-      return t.media_tracking_episode;
-    case 'volume':
-      return t.media_tracking_volume;
-    case 'status':
-      return t.media_tracking_status;
-    default:
-      return t.media_tracking_chapter;
   }
 }
 

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -2,15 +2,20 @@ import 'package:hibiki_dictionary/hibiki_dictionary.dart';
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:transparent_image/transparent_image.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:hibiki/media.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/display_title.dart';
+import 'package:hibiki/src/media/tracking/bangumi_api_client.dart';
+import 'package:hibiki/src/media/tracking/media_tracking_labels.dart';
+import 'package:hibiki/src/media/tracking/media_tracking_service.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
@@ -21,6 +26,8 @@ import 'package:hibiki/src/pages/implementations/home_page.dart';
 import 'package:hibiki/src/pages/implementations/home_video_page.dart'
     show openLocalVideoBook;
 import 'package:hibiki/src/pages/implementations/stat_shared.dart';
+import 'package:hibiki/src/settings/settings_detail_page.dart';
+import 'package:hibiki/src/settings/settings_schema_tracking.dart';
 import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/remote_cover_image.dart';
@@ -245,6 +252,11 @@ class _DailyGoalDialogState extends State<_DailyGoalDialog> {
 /// 仪表盘内容最大宽度（逻辑像素）：超宽屏限宽居中，避免每个区块被拉成大片空白。
 const double _kDashboardMaxWidth = 1600;
 
+/// Bangumi 同步卡最多列出的已关联条目数（超出的去设置页看全量；首页卡片是状态
+/// 概览，不是映射管理器）。有失败的条目由
+/// [MediaTrackingStatus.mappingsProblemFirst] 排到最前，不会被这个上限挤掉。
+const int _kTrackingMappingLimit = 5;
+
 class _HomeDashboardPageState
     extends BaseModuleTabPageState<HomeDashboardPage> {
   /// 「继续」横滑行：卡片封面等高，书竖版 5:7 / 视频横版 16:9 由宽度区分（同一行
@@ -347,6 +359,12 @@ class _HomeDashboardPageState
   /// 每个视频 bookUid 的最近观看时刻（epoch 毫秒），继续观看排序用。
   Map<String, int> _videoWatchAtByUid = const <String, int>{};
 
+  /// Bangumi 追踪链路的可见状态（[MediaTrackingService.loadStatus]）。
+  MediaTrackingStatus _tracking = MediaTrackingStatus.empty;
+
+  /// 「立即同步」按钮的进行中态。
+  bool _trackingSyncBusy = false;
+
   /// 订阅「数据变了」信号（阅读/观看/导入落库）以自动刷新，及其防抖定时器。
   /// 首页不保活、且阅读器是 pushed 路由（读完回来首页不重建 initState），故必须靠
   /// DB 表级变更主动重查，否则「打开一本书读完回来」活动/热力图仍是旧数据。
@@ -370,7 +388,17 @@ class _HomeDashboardPageState
     // 与视频（videoBooks 表级信号）对齐失效语义。
     _galgameRepo = ref.read(appProvider).galgameRepo
       ..addListener(_scheduleReload);
+    // Bangumi 同步状态：outbox 与偏好都不在 watchDashboardDataChanges 的表集里，
+    // 由服务层每轮同步结束后自增的 revision 通知（后台自动同步完成也会刷新本卡）。
+    _trackingRevision = ref
+        .read(appProvider)
+        .mediaTrackingService
+        .statusRevision
+      ..addListener(_scheduleReload);
   }
+
+  /// 追踪状态版本号（[initState] 挂监听，[dispose] 解除）。
+  ValueListenable<int>? _trackingRevision;
 
   /// 游戏库仓储（[initState] 挂监听，[dispose] 解除）。
   GalgameRepository? _galgameRepo;
@@ -388,6 +416,7 @@ class _HomeDashboardPageState
     _reloadDebounce?.cancel();
     unawaited(_dataChangeSub?.cancel());
     _galgameRepo?.removeListener(_scheduleReload);
+    _trackingRevision?.removeListener(_scheduleReload);
     super.dispose();
   }
 
@@ -502,10 +531,16 @@ class _HomeDashboardPageState
       }
     }
 
+    // Bangumi 追踪状态（映射 + 待办 + 上次同步结果）。读的是本地库与偏好，不发
+    // 网络请求，可以和其它聚合一起进首屏。
+    final MediaTrackingStatus tracking =
+        await appModel.mediaTrackingService.loadStatus();
+
     if (!mounted) return;
     setState(() {
       _videos = videos;
       _games = games;
+      _tracking = tracking;
       _localActivityEvents = events;
       _activityEvents = events;
       _readingCharsByDay = charsByDay;
@@ -652,6 +687,9 @@ class _HomeDashboardPageState
         _buildActivitySection(tokens, now, appModel, booksByKey, videosByUid);
     final Widget? recentCard =
         _buildRecentlyAddedSection(tokens, appModel, books, now);
+    // Bangumi 同步卡恒显示（未连接时也要显示——「没连上」本身就是用户最需要看到的
+    // 那条状态，隐藏它就回到了「看完了没反应」的黑盒）。
+    final Widget trackingCard = _buildTrackingCard(tokens, appModel, now);
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
@@ -688,7 +726,18 @@ class _HomeDashboardPageState
                 ),
               ),
               SizedBox(width: tokens.spacing.card),
-              Expanded(flex: 2, child: activityCard),
+              Expanded(
+                flex: 2,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    trackingCard,
+                    SizedBox(height: tokens.spacing.card),
+                    activityCard,
+                  ],
+                ),
+              ),
             ],
           );
         } else {
@@ -699,6 +748,8 @@ class _HomeDashboardPageState
               heatmapCard,
               SizedBox(height: tokens.spacing.card),
               continueCard,
+              SizedBox(height: tokens.spacing.card),
+              trackingCard,
               SizedBox(height: tokens.spacing.card),
               activityCard,
               if (recentCard != null) ...<Widget>[
@@ -2062,18 +2113,247 @@ class _HomeDashboardPageState
     }
   }
 
-  /// 相对时间结构化结果 → i18n 文案。
-  String _relativeTimeLabel(int timestampMs, DateTime now) {
-    final ActivityRelativeTime rel = activityRelativeTime(timestampMs, now);
-    switch (rel.unit) {
-      case ActivityRelativeUnit.justNow:
-        return t.activity_just_now;
-      case ActivityRelativeUnit.minutesAgo:
-        return t.activity_minutes_ago(n: rel.value);
-      case ActivityRelativeUnit.hoursAgo:
-        return t.activity_hours_ago(n: rel.value);
-      case ActivityRelativeUnit.daysAgo:
-        return t.activity_days_ago(n: rel.value);
+  /// 相对时间结构化结果 → i18n 文案（口径与 Bangumi 同步卡共用，见
+  /// [formatActivityRelativeTime]）。
+  String _relativeTimeLabel(int timestampMs, DateTime now) =>
+      formatActivityRelativeTime(timestampMs, now);
+
+  // ── 区块 5：Bangumi 同步 ─────────────────────────────────────────────────
+
+  /// Bangumi 同步卡：把原本全静默的追踪链路摊成用户可见状态。
+  ///
+  /// 这条链路每一步失败都不出声——没令牌不建映射、标题匹配不唯一不建映射且 10 分钟
+  /// 内不再重试、上报失败只进错误日志并退避最长 6 小时、成功则删 outbox 行不留痕迹。
+  /// 于是「看完一部作品」之后没有任何反馈可看。这张卡按链路的三段（连接 → 关联 →
+  /// 发送）依次给出当前事实与下一步动作：哪一段断了，卡上就只可能显示那一段的文案。
+  Widget _buildTrackingCard(
+    HibikiDesignTokens tokens,
+    AppModel appModel,
+    DateTime now,
+  ) {
+    final MediaTrackingStatus status = _tracking;
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+
+    // 第一段：没连令牌 → 后面两段都无从谈起，只给连接入口。
+    if (!status.configured) {
+      return _sectionCard(
+        tokens,
+        title: t.media_tracking_card_title,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(t.media_tracking_not_connected, style: tokens.type.metadata),
+            SizedBox(height: tokens.spacing.gap),
+            Align(
+              alignment: AlignmentDirectional.centerStart,
+              child: FilledButton.tonalIcon(
+                onPressed: _openTrackingSettings,
+                icon: const Icon(Icons.link),
+                label: Text(t.media_tracking_connect),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    final List<String> summary = <String>[
+      '${t.media_tracking_last_sync}: '
+          '${trackingLastSyncLabel(status, now)}',
+      t.media_tracking_linked_count(n: status.mappings.length),
+      status.pending > 0
+          ? t.media_tracking_pending_count(n: status.pending)
+          : t.media_tracking_all_synced,
+    ];
+
+    return _sectionCard(
+      tokens,
+      title: t.media_tracking_card_title,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Icon(Icons.person_outline, size: 18, color: scheme.primary),
+              SizedBox(width: tokens.spacing.gap / 2),
+              Expanded(
+                child: Text(
+                  status.accountName.isEmpty
+                      ? t.media_tracking_account
+                      : status.accountName,
+                  style: tokens.type.listTitle,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: tokens.spacing.gap / 2),
+          Text(summary.join(' · '), style: tokens.type.metadata),
+
+          // 令牌被拒是「已连接」下最容易误判成「没反应」的情形：令牌还在偏好里，
+          // isConfigured 仍为 true，但每次同步都在 getMe 就 401 中止。
+          if (status.unauthorized) ...<Widget>[
+            SizedBox(height: tokens.spacing.gap),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Icon(Icons.error_outline, size: 18, color: scheme.error),
+                SizedBox(width: tokens.spacing.gap / 2),
+                Expanded(
+                  child: Text(
+                    t.media_tracking_unauthorized,
+                    style: tokens.type.metadata.copyWith(color: scheme.error),
+                  ),
+                ),
+              ],
+            ),
+          ],
+
+          SizedBox(height: tokens.spacing.gap),
+
+          // 第二段：一条映射都没有 → 完成事件根本进不了 outbox，必须说清原因，
+          // 否则「已连接 + 零待办 + 全部已发送」看起来像一切正常。
+          if (status.mappings.isEmpty)
+            Text(t.media_tracking_unlinked_hint, style: tokens.type.metadata)
+          else
+            // 第三段：逐条条目。失败原因挂在对应行上（有失败的排在最前），不另开
+            // 一段——否则同一个条目在「失败」和「已关联」里各出现一次。
+            for (final MediaTrackingMappingRow mapping
+                in status.mappingsProblemFirst.take(_kTrackingMappingLimit))
+              _buildTrackingMappingRow(
+                tokens,
+                mapping,
+                status.failureByMappingId[mapping.id],
+              ),
+
+          SizedBox(height: tokens.spacing.gap),
+          Wrap(
+            spacing: tokens.spacing.gap,
+            runSpacing: tokens.spacing.gap / 2,
+            children: <Widget>[
+              FilledButton.tonalIcon(
+                onPressed: _trackingSyncBusy ? null : _syncTrackingNow,
+                icon: _trackingSyncBusy
+                    ? const SizedBox.square(
+                        dimension: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.sync),
+                label: Text(t.media_tracking_sync_now),
+              ),
+              TextButton.icon(
+                onPressed: _openTrackingSettings,
+                icon: const Icon(Icons.tune),
+                label: Text(t.media_tracking_manage_links),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 一条已关联条目：本地标题 + 「类别 · Bangumi 条目名 · 进度单位」+（有则）失败
+  /// 原因，整行点击在浏览器打开该 Bangumi 条目页。
+  ///
+  /// 打开 bgm.tv 是「怎么查看这个 bangumi 数据」的落点：远端收藏与进度的真相在
+  /// Bangumi，app 内不镜像一份（镜像就得再养一套失效逻辑，且永远可能与远端不符）。
+  Widget _buildTrackingMappingRow(
+    HibikiDesignTokens tokens,
+    MediaTrackingMappingRow mapping,
+    MediaTrackingFailure? failure,
+  ) {
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    return InkWell(
+      onTap: () => unawaited(_openBangumiSubject(mapping.subjectId)),
+      borderRadius: HibikiBorderRadius.card,
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: tokens.spacing.gap / 2),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            if (failure != null) ...<Widget>[
+              Icon(Icons.sync_problem_outlined, size: 18, color: scheme.error),
+              SizedBox(width: tokens.spacing.gap / 2),
+            ],
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    mapping.mediaTitle,
+                    style: tokens.type.listTitle,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    trackingMappingSubtitle(mapping),
+                    style: tokens.type.metadata,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  // 退避窗口内也照显：markFailed 最长把重试推到 6 小时后，那段时间
+                  // 里发送侧看不到这一行，展示侧不说就等于「零错误」。
+                  if (failure != null)
+                    Text(
+                      '${t.media_tracking_last_error}: ${failure.error}',
+                      style: tokens.type.metadata.copyWith(color: scheme.error),
+                      maxLines: 3,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                ],
+              ),
+            ),
+            SizedBox(width: tokens.spacing.gap / 2),
+            Tooltip(
+              message: t.media_tracking_open_subject,
+              child: const Icon(Icons.open_in_new, size: 16),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openBangumiSubject(int subjectId) async {
+    await launchUrl(
+      Uri.parse(BangumiApiClient.subjectUrl(subjectId)),
+      mode: LaunchMode.externalApplication,
+    );
+  }
+
+  void _openTrackingSettings() {
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (_) =>
+            SettingsDetailPage(destination: buildMediaTrackingDestination()),
+      ),
+    );
+  }
+
+  /// 手动同步：结果用 SnackBar 明确回执（成功/失败），再刷新卡片状态。
+  /// 服务层的 `statusRevision` 也会触发重载，这里的 await 只为按钮 busy 态收敛。
+  Future<void> _syncTrackingNow() async {
+    setState(() => _trackingSyncBusy = true);
+    try {
+      final MediaTrackingSyncResult result =
+          await ref.read(appProvider).mediaTrackingService.syncNow(force: true);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(result.isSuccess
+                ? t.media_tracking_sync_success
+                : t.media_tracking_sync_failed),
+          ),
+        );
+    } catch (e, stack) {
+      ErrorLogService.instance.log('HomeDashboardPage.syncTracking', e, stack);
+    } finally {
+      if (mounted) setState(() => _trackingSyncBusy = false);
     }
   }
 

--- a/hibiki/lib/src/pages/implementations/stat_shared.dart
+++ b/hibiki/lib/src/pages/implementations/stat_shared.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hibiki/src/pages/implementations/activity_feed.dart';
 import 'package:hibiki/src/pages/implementations/stat_charts.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -130,6 +131,26 @@ String formatStatChars(int chars) {
     return t.stat_format_chars_wan(n: (chars / 10000).toStringAsFixed(1));
   }
   return t.stat_format_chars(n: chars);
+}
+
+/// 相对时间外显：把 [activityRelativeTime] 的结构化结果套上 i18n 文案
+/// （刚刚 / N 分钟前 / N 小时前 / N 天前）。
+///
+/// [activityRelativeTime] 刻意留在纯数据层不碰 i18n，这里是它唯一的 widget 层
+/// 映射：首页活动时间轴与 Bangumi 同步卡的「上次同步」共用同一口径，不各写一份
+/// switch（否则单位阈值一改就只改到一处）。
+String formatActivityRelativeTime(int timestampMs, DateTime now) {
+  final ActivityRelativeTime rel = activityRelativeTime(timestampMs, now);
+  switch (rel.unit) {
+    case ActivityRelativeUnit.justNow:
+      return t.activity_just_now;
+    case ActivityRelativeUnit.minutesAgo:
+      return t.activity_minutes_ago(n: rel.value);
+    case ActivityRelativeUnit.hoursAgo:
+      return t.activity_hours_ago(n: rel.value);
+    case ActivityRelativeUnit.daysAgo:
+      return t.activity_days_ago(n: rel.value);
+  }
 }
 
 /// 热力图气泡日期标签：`M-dd`；跨年补年份成 `Y-M-dd`。[dateKey] 形如 `2026-07-18`

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+989
+version: 1.3.1+990
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/tracking/media_tracking_service_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_service_test.dart
@@ -1162,4 +1162,135 @@ void main() {
     expect(bangumiSubjectTypeOf(TrackingKind.novel), 1);
     expect(bangumiSubjectTypeOf(TrackingKind.manga), 1);
   });
+
+  // BUG-1216：整条追踪链路原本零可观测——成功即删 outbox 行、失败只进错误日志并
+  // 退避最长 6 小时、没建映射就静默返回。用户「看完了没反应」时无从判断断在哪一段。
+  group('可见状态快照（BUG-1216）', () {
+    Future<void> saveAnimeMapping() => repository.saveMapping(
+          mediaType: TrackingMediaType.videoCollection,
+          mediaKey: '8',
+          mediaTitle: 'Anime',
+          kind: TrackingKind.anime,
+          subjectId: 88,
+          subjectName: 'Remote anime',
+          progressMode: TrackingProgressMode.episode,
+          progressOffset: 1,
+        );
+
+    test('从未同步过与同步过零待办可区分', () async {
+      final MediaTrackingStatus before = await service.loadStatus();
+      expect(before.hasNeverSynced, isTrue);
+      expect(before.configured, isTrue);
+
+      // 队列本来就空：这一轮什么都没发出去，但确实跑过一次同步。成功即删行的
+      // 设计下，若不落「上次同步」，这个状态与「从没跑过」在 UI 上完全同形。
+      await service.syncNow(force: true);
+
+      final MediaTrackingStatus after = await service.loadStatus();
+      expect(after.hasNeverSynced, isFalse);
+      expect(after.lastSyncAt, greaterThan(0));
+      expect(after.pending, 0);
+    });
+
+    test('未配置令牌时同步不谎报「已同步过」', () async {
+      await preferences.setPref(kBangumiAccessTokenPref, '');
+
+      await service.syncNow(force: true);
+
+      final MediaTrackingStatus status = await service.loadStatus();
+      expect(status.configured, isFalse);
+      expect(status.hasNeverSynced, isTrue, reason: '没有令牌那一轮一条都发不出去，不能记成同步过');
+    });
+
+    test('失败待办在退避窗口内仍带原因外显', () async {
+      await saveAnimeMapping();
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.videoCollection,
+        mediaKey: '8',
+        localProgress: 1,
+        completed: false,
+      );
+      api.error = const BangumiApiException(statusCode: 500, message: 'boom');
+
+      final MediaTrackingSyncResult result = await service.syncNow(force: true);
+      expect(result.failed, 1);
+
+      // markFailed 把 nextAttemptAt 推到 30 秒后：发送侧（dueUpdates）此刻应看不到
+      // 这一行，展示侧（loadStatus）必须照样能说出失败原因，否则退避窗口就是一个
+      // 「零待办、零错误」的假象。
+      expect(await repository.dueUpdates(), isEmpty);
+      final MediaTrackingStatus status = await service.loadStatus();
+      expect(status.pending, 1);
+      expect(status.failures, hasLength(1));
+      expect(status.failures.single.mediaTitle, 'Anime');
+      expect(status.failures.single.error, contains('500'));
+      expect(status.hasProblem, isTrue);
+    });
+
+    test('令牌被拒记成 unauthorized 状态', () async {
+      await saveAnimeMapping();
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.videoCollection,
+        mediaKey: '8',
+        localProgress: 1,
+        completed: false,
+      );
+      api.error = const BangumiApiException(statusCode: 401, message: 'nope');
+
+      await service.syncNow(force: true);
+
+      final MediaTrackingStatus status = await service.loadStatus();
+      expect(status.unauthorized, isTrue);
+      expect(status.hasProblem, isTrue);
+    });
+
+    test('connect 记住账号名，换令牌清掉旧账号', () async {
+      final BangumiUser user = await service.connect('fresh-token');
+
+      expect(user.nickname, 'Alice');
+      expect(service.accountName, 'Alice');
+      expect(service.accessToken, 'fresh-token');
+      expect((await service.loadStatus()).accountName, 'Alice');
+
+      await service.setAccessToken('another-token');
+      expect(service.accountName, isEmpty,
+          reason: '账号名属于旧令牌，换令牌后必须失效，不能挂着上一个账号');
+    });
+
+    test('伴随的 bookChapter 映射不作为独立条目外显', () async {
+      await repository.saveMapping(
+        mediaType: TrackingMediaType.book,
+        mediaKey: 'book-1',
+        mediaTitle: 'Novel',
+        kind: TrackingKind.novel,
+        subjectId: 77,
+        subjectName: 'Remote novel',
+        progressMode: TrackingProgressMode.volume,
+        progressOffset: 2,
+      );
+      await repository.saveMapping(
+        mediaType: TrackingMediaType.bookChapter,
+        mediaKey: 'book-1',
+        mediaTitle: 'Novel',
+        kind: TrackingKind.novel,
+        subjectId: 77,
+        subjectName: 'Remote novel',
+        progressMode: TrackingProgressMode.chapter,
+        progressOffset: 12,
+      );
+
+      final MediaTrackingStatus status = await service.loadStatus();
+
+      expect(status.mappings, hasLength(1));
+      expect(status.mappings.single.mediaType, TrackingMediaType.book.value);
+    });
+
+    test('同步结束自增 statusRevision 供 UI 刷新', () async {
+      final int before = service.statusRevision.value;
+
+      await service.syncNow(force: true);
+
+      expect(service.statusRevision.value, greaterThan(before));
+    });
+  });
 }

--- a/hibiki/test/media/tracking/media_tracking_service_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_service_test.dart
@@ -1257,6 +1257,33 @@ void main() {
           reason: '账号名属于旧令牌，换令牌后必须失效，不能挂着上一个账号');
     });
 
+    test('待发送计数走 COUNT(*)，不被展示上限截断', () async {
+      // allPending 带展示上限（默认 50 行），计数若跟着它走，待办多于上限时就会
+      // 把「待发送 N 项」少报成上限值。
+      for (int i = 0; i < 55; i++) {
+        await repository.saveMapping(
+          mediaType: TrackingMediaType.video,
+          mediaKey: 'v$i',
+          mediaTitle: 'Video $i',
+          kind: TrackingKind.anime,
+          subjectId: 1000 + i,
+          subjectName: 'Remote $i',
+          progressMode: TrackingProgressMode.episode,
+          progressOffset: 1,
+        );
+        await repository.enqueueProgress(
+          mediaType: TrackingMediaType.video,
+          mediaKey: 'v$i',
+          localProgress: 1,
+          completed: false,
+        );
+      }
+
+      final MediaTrackingStatus status = await service.loadStatus();
+
+      expect(status.pending, 55);
+    });
+
     test('伴随的 bookChapter 映射不作为独立条目外显', () async {
       await repository.saveMapping(
         mediaType: TrackingMediaType.book,

--- a/hibiki/test/media/tracking/media_tracking_service_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_service_test.dart
@@ -1163,9 +1163,9 @@ void main() {
     expect(bangumiSubjectTypeOf(TrackingKind.manga), 1);
   });
 
-  // BUG-1216：整条追踪链路原本零可观测——成功即删 outbox 行、失败只进错误日志并
+  // BUG-1220：整条追踪链路原本零可观测——成功即删 outbox 行、失败只进错误日志并
   // 退避最长 6 小时、没建映射就静默返回。用户「看完了没反应」时无从判断断在哪一段。
-  group('可见状态快照（BUG-1216）', () {
+  group('可见状态快照（BUG-1220）', () {
     Future<void> saveAnimeMapping() => repository.saveMapping(
           mediaType: TrackingMediaType.videoCollection,
           mediaKey: '8',

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -1068,10 +1068,10 @@ void main() {
     expect(find.byType(StatContributionHeatmap), findsOneWidget);
   });
 
-  // BUG-1216：追踪链路原本零可观测（成功即删 outbox 行、失败只进错误日志并退避、
+  // BUG-1220：追踪链路原本零可观测（成功即删 outbox 行、失败只进错误日志并退避、
   // 没建映射就静默返回），用户「看完了没反应」时无处可看。这张卡是唯一出口，
   // 三种断裂状态各自必须说得出话。
-  group('Bangumi 同步卡（BUG-1216）', () {
+  group('Bangumi 同步卡（BUG-1220）', () {
     void useWideSurface(WidgetTester tester) {
       tester.view.physicalSize = const Size(1400, 1800);
       tester.view.devicePixelRatio = 1.0;

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -10,6 +10,9 @@ import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/media.dart';
 import 'package:hibiki/models.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
+import 'package:hibiki/src/media/tracking/bangumi_api_client.dart';
+import 'package:hibiki/src/media/tracking/media_tracking_repository.dart';
+import 'package:hibiki/src/media/tracking/media_tracking_service.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_dashboard_page.dart';
@@ -58,11 +61,14 @@ void main() {
   late AppModel appModel;
   late Directory storeDir;
 
+  /// 提到外层：Bangumi 同步卡的状态全部来自偏好（令牌/账号名/上次同步），测试要能写。
+  late PreferencesRepository prefs;
+
   setUp(() async {
     SharedPreferences.setMockInitialValues(<String, Object>{});
     LocaleSettings.setLocale(AppLocale.zhCn);
     db = HibikiDatabase.forTesting(NativeDatabase.memory());
-    final PreferencesRepository prefs = PreferencesRepository(db);
+    prefs = PreferencesRepository(db);
     await prefs.loadFromDb();
     storeDir = Directory.systemTemp.createTempSync('hibiki_dashboard');
     platformServices = testPlatformServices();
@@ -1060,6 +1066,143 @@ void main() {
 
     expect(tester.takeException(), isNull);
     expect(find.byType(StatContributionHeatmap), findsOneWidget);
+  });
+
+  // BUG-1216：追踪链路原本零可观测（成功即删 outbox 行、失败只进错误日志并退避、
+  // 没建映射就静默返回），用户「看完了没反应」时无处可看。这张卡是唯一出口，
+  // 三种断裂状态各自必须说得出话。
+  group('Bangumi 同步卡（BUG-1216）', () {
+    void useWideSurface(WidgetTester tester) {
+      tester.view.physicalSize = const Size(1400, 1800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+    }
+
+    Future<void> connect({String account = 'Alice'}) async {
+      await prefs.setPref(kBangumiAccessTokenPref, 'token');
+      await prefs.setPref(kBangumiAccountNamePref, account);
+    }
+
+    testWidgets('未连接：明说未连接并给出连接入口', (WidgetTester tester) async {
+      useWideSurface(tester);
+      await tester.pumpWidget(buildApp());
+      await pumpDashboard(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(t.media_tracking_card_title), findsOneWidget);
+      expect(find.text(t.media_tracking_not_connected), findsOneWidget);
+      expect(
+        find.widgetWithText(FilledButton, t.media_tracking_connect),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('已连接但零关联：说清「所以什么都不会同步」，不是一切正常', (WidgetTester tester) async {
+      useWideSurface(tester);
+      await connect();
+      await tester.pumpWidget(buildApp());
+      await pumpDashboard(tester);
+
+      expect(tester.takeException(), isNull);
+      // 账号名从偏好读回（不只是本次会话的连接结果）。
+      expect(find.text('Alice'), findsOneWidget);
+      // 从未同步必须与「同步过零待办」区分：成功即删 outbox 行，两者否则同形。
+      expect(
+          find.textContaining(t.media_tracking_never_synced), findsOneWidget);
+      expect(find.text(t.media_tracking_unlinked_hint), findsOneWidget);
+    });
+
+    testWidgets('已关联条目列出本地标题 + Bangumi 条目名，并给出打开入口',
+        (WidgetTester tester) async {
+      useWideSurface(tester);
+      await connect();
+      await MediaTrackingRepository(db).saveMapping(
+        mediaType: TrackingMediaType.videoCollection,
+        mediaKey: '8',
+        mediaTitle: '本地动画合集',
+        kind: TrackingKind.anime,
+        subjectId: 88,
+        subjectName: 'Remote anime',
+        progressMode: TrackingProgressMode.episode,
+        progressOffset: 1,
+      );
+
+      await tester.pumpWidget(buildApp());
+      await pumpDashboard(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('本地动画合集'), findsOneWidget);
+      expect(find.textContaining('Remote anime'), findsOneWidget);
+      expect(find.byIcon(Icons.open_in_new), findsOneWidget);
+      expect(
+        find.textContaining(t.media_tracking_linked_count(n: 1)),
+        findsOneWidget,
+      );
+      expect(find.text(t.media_tracking_unlinked_hint), findsNothing);
+    });
+
+    testWidgets('上报失败：退避窗口内也照说失败原因', (WidgetTester tester) async {
+      useWideSurface(tester);
+      await connect();
+      final MediaTrackingRepository repository = MediaTrackingRepository(db);
+      await repository.saveMapping(
+        mediaType: TrackingMediaType.videoCollection,
+        mediaKey: '8',
+        mediaTitle: '失败的动画',
+        kind: TrackingKind.anime,
+        subjectId: 88,
+        subjectName: 'Remote anime',
+        progressMode: TrackingProgressMode.episode,
+        progressOffset: 1,
+      );
+      await repository.enqueueProgress(
+        mediaType: TrackingMediaType.videoCollection,
+        mediaKey: '8',
+        localProgress: 1,
+        completed: false,
+      );
+      final List<PendingTrackingUpdate> due = await repository.dueUpdates();
+      await repository.markFailed(
+        due.single.outbox,
+        const BangumiApiException(statusCode: 500, message: 'boom'),
+      );
+      // 退避后发送侧已看不到这一行——展示侧仍必须说得出原因。
+      expect(await repository.dueUpdates(), isEmpty);
+
+      await tester.pumpWidget(buildApp());
+      await pumpDashboard(tester);
+
+      expect(tester.takeException(), isNull);
+      // 失败原因挂在条目行上，标题只出现一次（不另开「失败」段重复一遍）。
+      expect(find.text('失败的动画'), findsOneWidget);
+      expect(
+        find.textContaining('${t.media_tracking_last_error}: '),
+        findsOneWidget,
+      );
+      expect(find.textContaining('500'), findsOneWidget);
+      expect(find.byIcon(Icons.sync_problem_outlined), findsOneWidget);
+      expect(
+        find.textContaining(t.media_tracking_pending_count(n: 1)),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('令牌被拒：给出「重新连接」提示', (WidgetTester tester) async {
+      useWideSurface(tester);
+      await connect();
+      await prefs.setPref(kMediaTrackingLastSyncUnauthorizedPref, true);
+      await prefs.setPref(
+        kMediaTrackingLastSyncAtPref,
+        DateTime.now().millisecondsSinceEpoch,
+      );
+
+      await tester.pumpWidget(buildApp());
+      await pumpDashboard(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.text(t.media_tracking_unauthorized), findsOneWidget);
+    });
   });
 }
 


### PR DESCRIPTION
## 用户报告

> 删掉读书meter 未公开个人写入api这个东西。没接入就不要写了。还有 bangumi 根本没同步。我看完了没反应，也不知道怎么查看这个 bangumi 数据。在首页里面加一个？

> 旧的已经完成的也应该上传吧

两个独立的真 bug + 一处死文案。

---

## BUG-1220 · 链路全静默：看完了没反应且无处查看

调用点其实都在（`video_hibiki_page.dart:2876` / `reader_hibiki/navigation.part.dart:1118` / `app_model.dart:4928`），事件确实会进 outbox。根因是**每个失败点都不出声**：

| 位置 | 静默行为 |
|---|---|
| `_ensureAuto*Mapping` | 没令牌 → `return null`；标题匹配不唯一或相似度 < 0.92 → `return null`，且同条目 10 分钟内不再尝试 |
| `_sync` | 上报失败只 `ErrorLogService.log`，退避 30s→最长 6h |
| `markSucceeded` | 成功即**删除** outbox 行，同步成功不留任何痕迹 |
| `dueUpdates` | 按 `nextAttemptAt` 过滤，退避窗口内失败行连「待办」都不算 |

于是「已连接 + 零待办」与「从来没跑过同步」在 UI 上完全同形，设置页只有一个 `Pending: 0`。

**改动**（不动 schema，零迁移风险）：
1. 服务层 `MediaTrackingStatus` / `MediaTrackingFailure` + `loadStatus()`；每轮同步结束落 `media_tracking_last_sync_*_v1` 偏好（区分「跑过零待办」与「从未跑过」）；`statusRevision` 通知 UI；`connect()` 把「校验 + 落令牌 + 记账号名」收成原子操作，换令牌清旧账号名。
2. `MediaTrackingRepository.allPending()`：展示侧查询不按 `nextAttemptAt` 过滤（`dueUpdates` 仍只服务发送侧）。计数仍走 `pendingCount()` 的 `COUNT(*)`——用带上限的列表长度会在待办超 50 时少报。
3. **首页 dashboard 新增「Bangumi 同步」卡**（宽屏侧列顶部 / 窄屏继续区之后）：未连接 → 说明 + 连接入口；已连接 → 账号、上次同步、已关联数、待发送数、令牌被拒提示、已关联条目（点击开 bgm.tv 条目页）、立即同步 + 管理关联；零映射 → 明说「没有任何条目关联，所以看完不会有变化」并指向手工关联。失败原因**挂在对应条目行上**（`mappingId` + `mappingsProblemFirst` 把出问题的排最前），不另开一段重复标题。
4. **删掉 bookmeter 死文案**：UI 一处 + i18n key 走 `i18n_sync --remove` 从 17 语言下线（全仓仅一处 UI 引用、零实现代码）。
5. 设置页复用同一快照显示上次同步/失败原因；`_kindLabel`/`_modeLabel` 抽成共享 `media_tracking_labels.dart`；相对时间 i18n 映射抽成 `formatActivityRelativeTime`。

## BUG-1223 · 连令牌前已完成的条目永不上传

进度上报的前提是先有 mapping 行，而 mapping 只在**实时**完成事件里建。三个 reconcile 中：

| 补发路径 | 出发点 | 能否补建映射 |
|---|---|---|
| `loadPersistedGameTrackingStatus` | `getAllGalgames()` | ✅ 走 `recordGameStatus` 完整路径 |
| `loadCompletedVideoTrackingProgress` | `listMappings()` | ❌ 且只调裸 `enqueueProgress` |
| `loadPersistedBookTrackingProgress` | `listMappings()` | ❌ 同上 |

于是连上 Bangumi 之前看完/读完的视频和书落进死角：没映射 → `enqueueProgress` 返回 false → reconcile 又只从映射出发看不见它们 → **永远不上传**，除非把那一集重新看完一次。游戏侧没这个洞，纯粹是视频/书籍侧实现不对称。

**改动**：
1. `loadCompletedUnmappedVideos()` / `loadCompletedUnmappedBooks()`：查「本地 `completed_at` 非空但从未关联」的条目（视频同时排除所属合集已映射的情况），按 `completed_at` 升序。
2. `_backfillCompletedMappings()` 跑在三个 reconcile **之前**，每条走 `recordVideoCompleted` / `recordBookProgress` 完整路径（刮削优先、单集 vs 合集语义、高置信度门槛都在那两个方法里，不复制一份）；映射建好后 reconcile 自然算准确进度，outbox 单调合并取较大值。
3. 限流：每批 20、单次 `syncNow` 预算 100（可注入，测试用 1/2），剩余留给下次同步——首次连接时全库可能上千条，一次打上千个搜索既慢又易被限流。
4. 视频/书**各自独立水位**（共用会让另一类 evidenceAt 小于水位的条目被永久跳过）；每条只尝试建一次映射，换令牌时归零重新全量补。

**未放宽**自动映射的高置信度门槛（exact 唯一 / score ≥ 0.92）——宁可不建映射也不把进度写到别人的条目上；这种情况现在首页明说而不是静默。

## 验证

- `flutter analyze`（含 test）：No issues found
- 定向 110 项全绿：`test/media/tracking/`（service 8 + backfill 6 项新增）、`test/pages/home_dashboard_page_test.dart`（卡片 5 项新增，既有 BUG-1073 宽窄屏排版守卫未破）、`test/i18n/`
- **变异实测**：注释掉 `_backfillCompletedMappings()` 调用后 backfill 5 项立刻变红（第 6 项是负向断言，本该保持绿），确认不是假绿
- 全量 15565 项跑过（在让号前的基底上），唯一失败是 `test/lookup/global_lookup_autoread_webview_guard_test.dart`（develop 既有红，来自 `a758789f3`，本 PR 未碰任何 lookup 文件）
- ⚠️ 卡片视觉、「立即同步」交互、以及「库里已有大量已完成条目时逐批补齐且不被远端限流」待真机验收

## 协作说明

本分支中途被另一会话 rebase 到最新 develop 并把 BUG-1216 让号成 **BUG-1220**（与 PR #546 撞号）。BUG-1223 的落地跟随该基底的让号结果（放弃本地一度选用的 1222），未改动其 pubspec bump 与 1220 文档内容。

https://claude.ai/code/session_01AMxogtr2xo5YpW182w7z9q
