### PR TITLE
fix(manga): 页图解析保留真实大小写，制卡封面名不再被小写化 (BUG-1221)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1178 条。点号进各自文件。
+> 共 1179 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1221](bugs/BUG-1221-manga-path-case-folded.md) | ✅ | ✅ | 漫画页图解析把路径折成小写，制卡封面名被小写化且大小写敏感平台缺页 |
 | [BUG-1220](bugs/BUG-1220-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |
 | [BUG-1218](bugs/BUG-1218-epub-path-case-folded-android.md) | ✅ | ✅ | EPUB 解析把路径折成小写，大小写敏感平台上整本章节静默失踪 |
 | [BUG-1215](bugs/BUG-1215-jimaku-entry-wrong-season-auto-select.md) | ✅ | ✅ | Jimaku 条目自动选中不校验季号，S1 条目被配给 S2 包 |

--- a/docs/bugs/BUG-1221-manga-path-case-folded.md
+++ b/docs/bugs/BUG-1221-manga-path-case-folded.md
@@ -1,0 +1,72 @@
+## BUG-1221 · 漫画页图解析把路径折成小写，制卡封面名被小写化且大小写敏感平台缺页
+
+- **报告**：2026-07-28（BUG-1218 审查时点名、划在范围外的「第 10 处」，现单独修）
+- **真实性**：✅ 真 bug（同款模式，根因 `hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart:346` `resolveMangaResource`）
+
+### 根因
+
+`p.canonicalize` 在 **Windows** 上会把整条路径折成小写（`path` 包
+`lib/src/style/windows.dart:181` `canonicalizePart(part) => part.toLowerCase()`；
+POSIX style 无此覆写，见 `lib/src/internal_style.dart:89`——**macOS / Linux /
+Android 上并不折**）。`resolveMangaResource` 此前直接把 canonicalize 的结果当**返回的
+真实路径**：
+
+```
+Vol1/P001.JPG   （漫画包里的真实条目，落盘时大小写原样保留）
+vol1/p001.jpg   （解析后返回的路径）
+```
+
+漫画的落盘名确实保留原大小写——`MangaStorage.uniqueDestRel`
+（`manga_storage.dart:88`）只把**去重键**转小写（"Windows 文件系统大小写不敏感，故用
+小写键去重"，刻意为之），返回的 `candidate` 与写进 `manga.json` 的 `url` 都是原大小写。
+所以磁盘条目与 manifest 一致，唯一折平的就是这个解析函数。
+
+**影响面（如实界定，不夸大）**：
+
+- **Windows**：文件系统不区分大小写，页图能读出来，**不缺页**。但返回值会**流出本次
+  读取**——`_updateCurrentPageImagePath`（`:1350`）把它存进 `_currentPageImagePath`，
+  制卡时经 `ensureMangaCoverPng`（对已有合法扩展名的路径**原样返回**）直接当 Anki 封面
+  源路径，**媒体名因此被小写化**，与源文件名不一致。这是 Windows 上真实可观察的副作用，
+  但不影响卡片显示。
+- **大小写敏感平台（Android / Linux）**：`canonicalize` 不折大小写，所以**原生导入 +
+  阅读不触发**。触发链与 BUG-1218 同类，是**跨平台数据搬运**：Windows 侧算出的小写路径
+  一旦被持久化并搬到大小写敏感设备（备份还原 / 裸数据拷贝），`existsSync` 为 false →
+  页图 404、制卡无封面。
+- 因此本条属**正确性 / 防御性根因修**（消除"读写路径 ≠ 真实路径"这一整类隐患），
+  **不是**修一个当前 Windows 上用户可见的缺页故障。原始 BUG-1218 曾把同类问题的故障链
+  说成"Android 上原生解析整本失踪"，那个说法已在 BUG-1218 里更正，此处不重复该错误。
+
+**逐处判定**（漫画链全仓扫 `canonicalize`，共 6 处）：
+
+| 位置 | 判定 | 处置 |
+|---|---|---|
+| `manga_hibiki_page.dart:347/349` `resolveMangaResource` | **(甲) 当真实读写路径用** | ✅ 已改 |
+| `manga_hibiki_page.dart:916/918` `_interceptRequest` 的 403/404 判别 | (乙) `candidate` 只进 `isWithin` 比较、不进 `File()` | ❌ 不改（本就是纯边界比较） |
+| `hibiki_manga_ocr_host.dart:356/361` | (乙) 集合成员比较（`live.contains`），刻意的大小写不敏感 key | ❌ 不改 |
+| `manga_storage.dart:88/91/106` `uniqueDestRel`（非 canonicalize，是 `toLowerCase`） | (乙) 刻意的大小写不敏感**去重键**，返回值已保留原大小写 | ❌ 不改 |
+
+**无第 11 处**：漫画链其余路径构造（`:730` `mangaJsonPath`、`:739` `imagesDir`、
+`:1488`）都是裸 `p.join`，从不经 canonicalize，本就保留大小写。
+
+- **[x] ① 已修复** — `resolveMangaResource` 改为「**越界校验用 `p.canonicalize`**
+  （折大小写，`../` 逃逸不被大小写差异绕过）、**返回值用 `p.absolute` + `p.normalize`**
+  （同样绝对化并折叠 `.`/`..` 段，但保留大小写）」。与
+  `EpubParser._resolveWithinExtract`（BUG-1218）、`_safeArchivePath`（TODO-739）同款。
+  比 EPUB 侧多一个 `p.absolute`：本函数契约是返回**绝对**路径，而 `p.normalize` 与
+  `canonicalize` 不同、**不会**绝对化——漏掉它会静默改变返回值语义。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/manga_path_case_preserved_test.dart`：
+  三种混合大小写条目（`Vol1/P001.JPG` / `CH02/Page_01.Jpeg` /
+  `MixedCase/SubDir/IMG_0001.PNG`）的解析结果与 `listSync` 列出的**真实磁盘条目名逐字节
+  比对**；URL 入口 `resolveImageUrlToFile` 与百分号编码条目同样覆盖；返回值绝对性被单独
+  钉住（防 `p.absolute` 补偿被删）；穿越守卫三条负向用例（`../` 逃逸、解析到 root 外的
+  真实文件、缺文件）确认大小写保留没削弱防护。
+
+  **逐字节比对而非 `existsSync` 是刻意的**：本地跑在 Windows 上 `File.exists` 不区分
+  大小写，只断言 `existsSync` 根本抓不到这个 bug。
+
+- **[ ] ③ 未做真机复测** — 本机是 Windows（`adb devices` 为空，无任何 Android/Linux
+  设备），恰好是这个 bug 页图不缺的平台。「大小写敏感平台上页图 404」这一结论由「解析出
+  的路径与磁盘条目逐字节不符」推出，未在真机上复验。Windows 上的全绿**不能**当作已验证。
+
+- **备注**：与 BUG-1218（EPUB 侧同款）、TODO-739（解压侧同款）构成同一结论的三处落地。

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -341,13 +341,32 @@ class MangaHibikiPage extends BaseSourcePage {
   );
 
   /// 纯路径解析 + 穿越守卫。[relative] 在 [imagesRoot] 内解析到存在的文件时返回
-  /// 规范绝对路径，否则 null（越界/缺文件都不 serve）。从 WebView 路径抽出，安全
-  /// 边界无需 WebView 后端即可单测。
+  /// 规范绝对路径（**保留磁盘上的真实大小写**），否则 null（越界/缺文件都不 serve）。
+  /// 从 WebView 路径抽出，安全边界无需 WebView 后端即可单测。
+  ///
+  /// BUG-1221：**越界校验**与**真实读写路径**必须用同一条路径的两种不同形式——
+  /// - 校验用 `p.canonicalize`（在 Windows 上整体小写化，见 `path` 包
+  ///   `style/windows.dart:181`，正好让 `../` 逃逸判定不被大小写差异绕过）；
+  /// - 返回值用 `p.absolute` + `p.normalize`（同样绝对化并折叠 `.`/`..` 段，但
+  ///   **保留大小写**）。
+  ///
+  /// 此前返回的是 canonicalize 的结果：漫画包里 `Vol1/P001.JPG` 这类混合大小写的
+  /// 条目被记成 `vol1/p001.jpg`。Windows 文件系统不区分大小写所以侥幸能读，但这个
+  /// 返回值会流出本次读取——`_updateCurrentPageImagePath` 把它存进
+  /// `_currentPageImagePath`，制卡时经 `ensureMangaCoverPng` 直接当作 Anki 封面
+  /// 源路径，媒体名因此被小写化；在大小写敏感平台上更是 `existsSync` 直接为 false
+  /// （页图 404、制卡无封面）。与 `EpubParser._resolveWithinExtract`（BUG-1218）
+  /// 及 `_safeArchivePath`（TODO-739）同款做法。
+  ///
+  /// 注意比 EPUB 侧多一个 `p.absolute`：本函数的契约是返回**绝对**路径，而
+  /// `p.normalize` 与 `canonicalize` 不同、**不会**绝对化。
   static String? resolveMangaResource(String imagesRoot, String relative) {
-    final String canonicalRoot = p.canonicalize(imagesRoot);
     final String decoded = Uri.decodeComponent(relative);
-    final String filePath = p.canonicalize(p.join(canonicalRoot, decoded));
-    if (!p.isWithin(canonicalRoot, filePath)) return null;
+    final String joined = p.join(imagesRoot, decoded);
+    if (!p.isWithin(p.canonicalize(imagesRoot), p.canonicalize(joined))) {
+      return null;
+    }
+    final String filePath = p.normalize(p.absolute(joined));
     final File file = File(filePath);
     if (!file.existsSync()) return null;
     return filePath;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+990
+version: 1.3.1+991
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/manga_path_case_preserved_test.dart
+++ b/hibiki/test/pages/manga_path_case_preserved_test.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/reader/manga_hibiki_page.dart';
+import 'package:path/path.dart' as p;
+
+/// BUG-1221：漫画页图解析出的路径必须保留磁盘上的**真实大小写**。
+///
+/// `p.canonicalize` 在 Windows 上会把整条路径折成小写（`path` 包
+/// `style/windows.dart:181` `canonicalizePart(part) => part.toLowerCase()`；POSIX
+/// 无此覆写）。[MangaHibikiPage.resolveMangaResource] 此前直接返回它的结果，于是
+/// 漫画包里 `Vol1/P001.JPG` 被记成 `vol1/p001.jpg`。
+///
+/// 本地跑在 Windows 上时 `File.exists` 不区分大小写，所以**只断言 existsSync 抓不到
+/// 这个 bug**；这里改为把解析结果与 `listSync` 列出的真实磁盘条目名做**逐字节比对**，
+/// 从而在任何平台上都能复现大小写敏感平台的查找语义。
+void main() {
+  late Directory root;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('manga_path_case_');
+  });
+
+  tearDown(() {
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  });
+
+  /// 磁盘上真实存在的、相对 [root] 的正斜杠路径集合（大小写原样）。
+  Set<String> onDiskEntries() => <String>{
+        for (final FileSystemEntity e in root.listSync(recursive: true))
+          if (e is File)
+            p.relative(e.path, from: root.path).replaceAll('\\', '/'),
+      };
+
+  void writeImage(String relative) {
+    final File f = File(p.join(root.path, p.joinAll(relative.split('/'))));
+    f.parent.createSync(recursive: true);
+    // 最小 JPEG 头，内容无关紧要——本组只关心路径大小写。
+    f.writeAsBytesSync(<int>[0xFF, 0xD8, 0xFF, 0xE0, 0x00]);
+  }
+
+  /// 解析结果转成相对 root 的正斜杠路径，便于与磁盘条目集合逐字节比对。
+  String relOf(String absolute) =>
+      p.relative(absolute, from: root.path).replaceAll('\\', '/');
+
+  for (final String entry in <String>[
+    'Vol1/P001.JPG',
+    'CH02/Page_01.Jpeg',
+    'MixedCase/SubDir/IMG_0001.PNG',
+  ]) {
+    test('解析「$entry」保留真实大小写，与磁盘条目逐字节一致', () {
+      writeImage(entry);
+      final String? resolved =
+          MangaHibikiPage.resolveMangaResource(root.path, entry);
+
+      expect(resolved, isNotNull, reason: '文件真实存在，解析不该返回 null');
+      expect(onDiskEntries(), contains(relOf(resolved!)),
+          reason: '解析出的「${relOf(resolved)}」与磁盘大小写不符 —— 大小写敏感的 '
+              'Android/Linux 上 existsSync 会失败（页图 404、制卡无封面），'
+              '在 Windows 上则让 Anki 封面媒体名被小写化');
+      // 返回值契约：绝对路径（canonicalize 会绝对化，normalize 不会，故实现里
+      // 显式补了 p.absolute；这条断言锁住那个补偿别被删掉）。
+      expect(p.isAbsolute(resolved), isTrue);
+    });
+  }
+
+  test('URL 入口 resolveImageUrlToFile 同样保留大小写', () {
+    writeImage('Vol1/P001.JPG');
+    final String? resolved = MangaHibikiPage.resolveImageUrlToFile(
+      root.path,
+      'https://${MangaHibikiPage.kMangaHost}/img/Vol1/P001.JPG',
+    );
+    expect(resolved, isNotNull);
+    expect(onDiskEntries(), contains(relOf(resolved!)));
+  });
+
+  test('百分号编码的混合大小写条目解码后仍保留大小写', () {
+    writeImage('Vol 1/P001.JPG');
+    final String? resolved = MangaHibikiPage.resolveMangaResource(
+      root.path,
+      'Vol%201/P001.JPG',
+    );
+    expect(resolved, isNotNull);
+    expect(onDiskEntries(), contains(relOf(resolved!)));
+  });
+
+  group('大小写保留不削弱穿越守卫', () {
+    test('../ 逃逸仍被拒绝', () {
+      writeImage('Vol1/P001.JPG');
+      expect(
+        MangaHibikiPage.resolveMangaResource(root.path, '../escaped.jpg'),
+        isNull,
+      );
+      expect(
+        MangaHibikiPage.resolveMangaResource(
+            root.path, 'Vol1/../../escaped.jpg'),
+        isNull,
+      );
+    });
+
+    test('大小写不同的 ../ 逃逸也被拒绝（校验侧仍走 canonicalize）', () {
+      // 逃逸判定不能因为大小写差异被绕过：即便根目录名大小写写反，
+      // 越界校验用的 canonicalize 仍把两侧折平，`../` 照样拦下。
+      final Directory outside =
+          Directory.systemTemp.createTempSync('manga_outside_');
+      addTearDown(() {
+        if (outside.existsSync()) outside.deleteSync(recursive: true);
+      });
+      File(p.join(outside.path, 'Secret.JPG'))
+          .writeAsBytesSync(<int>[0xFF, 0xD8]);
+      final String escape =
+          p.relative(p.join(outside.path, 'Secret.JPG'), from: root.path);
+      expect(
+        MangaHibikiPage.resolveMangaResource(root.path, escape),
+        isNull,
+        reason: '解析到 root 之外的真实文件必须被拒绝',
+      );
+    });
+
+    test('缺文件返回 null（不因大小写保留而误判存在）', () {
+      writeImage('Vol1/P001.JPG');
+      expect(
+        MangaHibikiPage.resolveMangaResource(root.path, 'Vol1/missing.JPG'),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
BUG-1218（EPUB 侧）审查时点名、当时**有意划在范围外**的「第 10 处」，现单独修。

## 逐处判定（漫画链全仓扫 `canonicalize`，共 6 处，只改 1 处）

| 位置 | 判定 | 处置 |
|---|---|---|
| `manga_hibiki_page.dart:347/349` `resolveMangaResource` | **(甲) 当真实读写路径用** | ✅ 已改 |
| `manga_hibiki_page.dart:916/918` `_interceptRequest` 的 403/404 判别 | (乙) `candidate` 只进 `isWithin` 比较、**不进 `File()`** | ❌ 不改（本就是纯边界比较） |
| `hibiki_manga_ocr_host.dart:356/361` | (乙) 集合成员比较（`live.contains`），刻意的大小写不敏感 key | ❌ 不改 |
| `manga_storage.dart:88/91/106` `uniqueDestRel`（是 `toLowerCase` 不是 canonicalize） | (乙) 刻意的大小写不敏感**去重键**，返回的 `candidate` 本就保留原大小写 | ❌ 不改 |

**无第 11 处**：漫画链其余路径构造（`:730` `mangaJsonPath`、`:739` `imagesDir`、`:1488`）都是裸 `p.join`，从不经 canonicalize。

## 修法

与 `EpubParser._resolveWithinExtract`（BUG-1218）/ `_safeArchivePath`（TODO-739）同款：**越界校验用 `p.canonicalize`**（折大小写，`../` 逃逸不被大小写差异绕过）、**返回值用 `p.absolute` + `p.normalize`**（同样绝对化并折叠 `.`/`..` 段，但保留大小写）。

🔴 **比 EPUB 侧多一个 `p.absolute`**：本函数契约是返回**绝对**路径，而 `p.normalize` 与 `canonicalize` 不同、**不会**绝对化——照抄 EPUB 侧的纯 `normalize` 会静默改变返回值语义。测试单独钉住了这一点。

## 影响面（如实界定，不夸大）

- **Windows**：文件系统不区分大小写，页图**不缺页**。但返回值会**流出本次读取**——`_updateCurrentPageImagePath`（`:1350`）存进 `_currentPageImagePath`，制卡时经 `ensureMangaCoverPng`（对已有合法扩展名的路径**原样返回**）直接当 Anki 封面源路径，**媒体名因此被小写化**。这是 Windows 上真实可观察的副作用，但不影响卡片显示。
- **大小写敏感平台**：`canonicalize` 不折大小写（POSIX 无 `canonicalizePart` 覆写），所以**原生导入 + 阅读不触发**。触发链与 BUG-1218 同类，是**跨平台数据搬运**（Windows 侧算出的小写路径被持久化后搬到大小写敏感设备）。
- 因此本条属**正确性 / 防御性根因修**，**不是**修一个当前 Windows 上可见的缺页故障。BUG-1218 原文曾把同类问题的故障链说成「Android 上原生解析整本失踪」，那个说法已在 BUG-1218 里更正，**此处不重复该错误**。

## 数据兼容

漫画的落盘名本就保留原大小写——`MangaStorage.uniqueDestRel` 只把**去重键**转小写（注释明写「Windows 文件系统大小写不敏感，故用小写键去重」），返回的 `candidate` 与写进 `manga.json` 的 `url` 都是原大小写。磁盘条目与 manifest 一致，唯一折平的就是这个解析函数，且它**每次请求实时解析、不落库**。故**老漫画不会「以前能看、现在缺页」**——本次改动只让实时解析出的路径更准，没有任何持久化数据需要迁移。

## 测试

`hibiki/test/pages/manga_path_case_preserved_test.dart`：

- 三种混合大小写条目（`Vol1/P001.JPG` / `CH02/Page_01.Jpeg` / `MixedCase/SubDir/IMG_0001.PNG`）的解析结果与 `listSync` 列出的**真实磁盘条目名逐字节比对**；
- URL 入口 `resolveImageUrlToFile` 与百分号编码条目（`Vol%201/...`）同样覆盖；
- 返回值**绝对性**单独钉住（防 `p.absolute` 补偿被删）；
- 穿越守卫三条负向用例（`../` 逃逸、解析到 root 外的真实文件、缺文件）确认大小写保留没削弱防护。

🔴 **逐字节比对而非 `existsSync` 是刻意的**：本地跑在 Windows 上 `File.exists` 不区分大小写，只断言 `existsSync` 根本抓不到这个 bug。

**变异实测**（返回值改回 `p.canonicalize`，先用 `git diff` 实证变异确已落盘）：**转红 5/8 条**，报的正是 `Expected: contains 'vol1/p001.jpg' / Actual: Set:['Vol1/P001.JPG']`；3 条穿越守卫用例正确**保持绿**（说明变异只打中了大小写这一维，没有把整组测试连坐）。

验证：

- `flutter analyze` → `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/pages/manga_path_case_preserved_test.dart test/pages/manga_interceptor_test.dart test/pages/manga_mining_cover_test.dart test/epub/`
  → `FLUTTER TEST VERDICT: PASSED - 234 tests ran, all tests passed`，退出码 0。
- pubspec `+989 → +990`（从 develop 实际值读取），push 前已用 `git diff bc9770e53..HEAD -- hibiki/pubspec.yaml` 显式确认打出 `-989/+990`。

## 🔴 未验证

- **未做真机复测**。本机是 Windows，`adb devices` **为空、无任何 Android/Linux 设备**，而这正是本 bug 页图不缺的平台。「大小写敏感平台上页图 404」由「解析出的路径与磁盘条目逐字节不符」推出，未在真机复验。**Windows 上的全绿不能当作已验证**，BUG-1221 文档真机项保持 `[ ]`。

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb
