### PR TITLE
fix(lookup): 面板另两条查词路径补自动朗读 + 两层覆盖守卫 (BUG-1210)

### DIFF
--- a/docs/bugs/BUG-1210-clipboard-panel-no-auto-read.md
+++ b/docs/bugs/BUG-1210-clipboard-panel-no-auto-read.md
@@ -50,3 +50,38 @@
   打破了这条锚在两参数字面量上的既有守卫，而当时的定向测试没覆盖 `test/lookup/`。本 PR 把
   锚点改成前缀匹配并补断 `FrameNotLoaded`，守的意图（未加载帧必须立刻回 false，不拖满 5s
   超时）一字未改，实际比原来更严。
+
+### 补记（2026-07-28）：第一版只修了三条路径里的一条
+
+第一版把朗读接在了 `update()`（剪贴板流）上，并据此判定「剪贴板面板是**唯一**漏接的表面」。
+那个判定是**循环论证**：当时是从 `autoRead` 符号侧去找接入点，只能看见「已经调了朗读的地方」，
+天生看不见「没调的路径」。
+
+改从**结果产生侧**穷举（`AppModel.searchDictionary(` 的全部 23 个调用点，并验证过没有旁路：
+无表面绕开它直连引擎，`DictionarySearchResult` 直接构造的 3 处都不是独立表面）后发现，
+同一个面板里还有两条**用户主动查词**的路径没接：
+
+- `_lookupFromBanner`（点句中字换根）—— 用户表现为「复制进来会读、点字不读」。
+- `_lookupNested`（点释义里的词再查）—— 更要命：**瞬态覆盖窗的同名路径是会读的**
+  （`global_lookup_controller._lookupNested` 末尾就有 `_autoReadFirstEntry`），两个表面在
+  同一个动作上行为漂开，而「两表面不得漂开」正是本条要收口的东西。
+
+两条都已补上。`_lookupFromBanner` 与 `update()` 同款，在 `_renderPanel` 这个 await **之后**
+再核对一次 latest-wins 序号才朗读（少这一句，被后一句剪贴板顶掉的旧点击会读出旧词）；
+`_lookupNested` 不加序号核对，因为它自始就不参与 root 的 latest-wins（是压栈不是换根），
+只给朗读单独引入一套序号语义会和既有的「压栈 + 渲染」边界不一致，与瞬态窗 nested 保持同构。
+
+守卫补两层：`test/lookup/auto_read_surface_coverage_guard_test.dart` 按**文件**粒度要求每个
+查词调用点显式声明接不接朗读（豁免必须写具体理由，占位符会红）；
+`overlay_auto_read_parity_test.dart` 再按**方法**粒度要求「凡查了词的方法都得有朗读调用」——
+前者抓不到同文件内删掉某一条路径的朗读，后者能（变异实测证实）。
+
+### 仍未处理：Android 悬浮词典（待产品拍板）
+
+`floating_dict_page._doSearch` 与 `app_model._setupFloatingDictHandlers.onSearch` 两条路径同样
+不朗读。同为「搜索框手动输入」的 `home_dictionary_page` 是朗读的，故**行为并不一致**；但悬浮
+词典是浮在别的 app 上层的小窗，突然出声更打扰，该不该自动朗读是产品取舍。已进守卫的豁免名单
+并注明「待产品拍板」，定了再挪进 wiredSurfaces。
+
+- **[ ] 未做真机复测（如实留空）**：本轮全部是静态代码分析 + 单测，**没有**在真机上实际
+  复现「点字查词 / 嵌套查词听不到声音 → 修后能听到」。「用户实际能不能听到」未经验证。

--- a/hibiki/lib/src/lookup/clipboard_panel_controller.dart
+++ b/hibiki/lib/src/lookup/clipboard_panel_controller.dart
@@ -716,6 +716,18 @@ class ClipboardPanelController {
       _rootHitStart = hitStart < 0 ? 0 : hitStart;
       _seedRootFrame(suffix, result);
       await _renderPanel(model);
+      // BUG-1210 的另一半：点句中字**也是用户主动查词**，与 update() 那条剪贴板流同样
+      // 该按 autoReadOnLookup 自动发音。此前只有 update() 接了线，点字换根这条整条没有
+      // 朗读调用——同一个面板里「复制进来会读、点字不读」。
+      //
+      // 与 update() 同款：必须在 _renderPanel 这个 await **之后**再核对一次 seq。本方法
+      // 的契约是「每个 await 后核对，过期即弃」（VN 流乱序守卫），少这一句，被后一句
+      // 剪贴板顶掉的旧点击仍会把旧词读出来——屏幕上是新句、耳朵里是上一次点的字。
+      if (seq != _updateSeq) {
+        glog('panel: banner autoread skipped (superseded seq=$seq)');
+        return;
+      }
+      _autoRead.autoReadFirstEntry(model, result);
     } catch (e, st) {
       glog('panel: banner lookup EXCEPTION $e\n$st');
     }
@@ -815,6 +827,15 @@ class ClipboardPanelController {
       _frameResults[child.id] = result;
       _frameAnchors[child.id] = anchorRect;
       await _renderPanel(model);
+      // BUG-1210 的另一半：嵌套查词（点释义里的词再查）在**瞬态覆盖窗上是会朗读的**
+      // （global_lookup_controller 的 _lookupNested 末尾就有 _autoReadFirstEntry），
+      // 面板这条却没有——两个表面在同一个动作上行为漂开，正是 BUG-1210 要收口掉的东西。
+      //
+      // 这里**不**加 seq 核对：本方法自始就不参与 root 的 latest-wins（不领 _updateSeq、
+      // 不核对），它是压栈行为而非换根；只给朗读单独引入一套序号语义，会和上面既有的
+      // 「压栈 + 渲染」边界不一致（渲染出来了却不读）。与瞬态窗 nested 保持同构。
+      // 无结果的嵌套查词在上面 identical(next, _stack) 处已 return，走不到这里。
+      _autoRead.autoReadFirstEntry(model, result);
     } catch (e, st) {
       glog('panel: nested EXCEPTION $e\n$st');
     }

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+992
+version: 1.3.1+993
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/lookup/auto_read_surface_coverage_guard_test.dart
+++ b/hibiki/test/lookup/auto_read_surface_coverage_guard_test.dart
@@ -1,0 +1,155 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1210 守卫：**每一个查词表面都必须明确声明它接不接自动朗读**。
+///
+/// 为什么要这条：BUG-1210 的第一版只补了剪贴板面板的 `update()`（剪贴板流）一条路径，
+/// 而同一个面板里 `_lookupFromBanner`（点句中字换根）和 `_lookupNested`（点释义里的词
+/// 再查）两条**用户主动查词**的路径仍然不读——「复制进来会读、点字不读」，而且嵌套那条
+/// 在瞬态覆盖窗上是会读的，两个表面在同一个动作上行为漂开。
+///
+/// 当初判成「唯一漏接」是因为**扫的方向反了**：从 `autoRead` 符号侧去找调用点，只能看见
+/// 「已经调了朗读的地方」，天生看不见「没调的路径」——那是循环论证。正确的方向是从
+/// **查词结果的产生侧**穷举：所有查词表面最终都经 `AppModel.searchDictionary(`，把它的
+/// 全部调用点列出来，逐个要求声明。本守卫把这个方向固化下来。
+///
+/// 守的是：**新增一个查词表面时，必须在下面两张表之一里显式声明**，否则测试红。
+/// 不守的是：同一个文件里**新增调用点**（表按文件粒度；行号粒度会随重构漂移、变成噪音）。
+/// 这个局限是有意的取舍，不是疏漏。
+///
+/// flutter test 的 cwd 是 hibiki 包根。
+void main() {
+  /// 已接自动朗读的查词表面：路径 → 接线位置。
+  /// 这里的每一项都会被**正向验证**（文件里真的要有朗读调用），防止名单过期成橡皮图章。
+  const Map<String, String> wiredSurfaces = <String, String>{
+    'lib/src/lookup/global_lookup_controller.dart':
+        'app 外瞬态查词覆盖窗：lookupText 与 _lookupNested 两条路径末尾各调 '
+            '_autoReadFirstEntry（委托共享 OverlayAutoRead）。',
+    'lib/src/lookup/clipboard_panel_controller.dart':
+        'app 外常驻剪贴板面板：update()（剪贴板流）/ _lookupFromBanner（点字换根）/ '
+            '_lookupNested（嵌套查词）三条路径均调 _autoRead.autoReadFirstEntry。'
+            '前两条在 _renderPanel 之后还要核对 latest-wins 序号才朗读。',
+    'lib/src/pages/base_source_page.dart':
+        'app 内媒体页：查词后读 autoReadOnLookup 偏好并调 _autoReadWord。',
+    'lib/src/pages/implementations/home_dictionary_page.dart':
+        'app 内词典主页：除 mixin 的 searchPopup 外自己也直接查词（_performSearch），'
+            '命中后按 autoRead ?? autoReadOnLookup 调 autoReadWord。剪贴板注入那条路径'
+            '显式传 autoRead: false，是有意覆盖（避免被动注入时突然出声），不是漏接。',
+    'lib/src/pages/implementations/dictionary_page_mixin.dart':
+        'app 内词典页 mixin：searchPopup(autoRead:) 决定是否调 autoReadWord。'
+            '五个消费方（home_dictionary / popup_dictionary / texthooker / '
+            'floating_lyric_lookup_host / video_hibiki_page）均传 autoRead: true。',
+  };
+
+  /// 豁免的查词调用点：路径 → **具体**理由。
+  /// 理由必须说清「为什么这里不该自动出声」，不能只写个文件名或「不需要」——
+  /// 只有文件名的白名单过两个月就会退化成「往里塞一行」的橡皮图章。
+  const Map<String, String> exemptCallSites = <String, String>{
+    'lib/src/models/app_model.dart':
+        '三类都不是查词表面：① 启动与切 profile 时的预热（Future.wait 里的 '
+            'searchDictionary，没有任何 UI 呈现）；② _searchRemoteDictionary 是 '
+            'searchDictionary 自己的远端分支，不是独立入口；③ '
+            '_setupFloatingDictHandlers.onSearch 是 Android 悬浮词典的 native 通道 '
+            'handler——**待产品拍板**，见下面 floating_dict_page 那条同一取舍。',
+    'lib/src/pages/implementations/floating_dict_page.dart':
+        'Android 悬浮词典页的搜索框查词。同为「手动输入」的 home_dictionary_page 是朗读的，'
+            '故行为并不一致；但悬浮词典是浮在别的 app 上层的小窗，突然出声更打扰，'
+            '该不该自动朗读是产品取舍——**待产品拍板**，定了再从本表挪进 wiredSurfaces。',
+    'lib/src/pages/implementations/home_page.dart':
+        'resumed 生命周期里用固定的 helloWorld 串 + useCache:false 预热词典引擎，'
+            '不是用户查词，也没有结果呈现。',
+    'lib/src/sync/hibiki_remote_api_handlers.dart':
+        '互联对端 / 浏览器扩展经 HTTP 拉词的服务端 handler：结果序列化给**远端**渲染，'
+            '本机屏幕上什么都没发生，出声等于对着空气念。',
+    'lib/src/sync/yomitan_api_server.dart':
+        'Yomitan 兼容 API 的服务端：同上，结果给外部客户端消费，本机不该出声。',
+    'lib/src/sync/hibiki_remote_lookup_client.dart':
+        '本机作为 client 向 host 查词的传输层封装，返回给上层表面渲染；'
+            '朗读由那个表面负责，这里重复朗读会双读。',
+    'lib/src/sync/hibiki_remote_lookup_service.dart':
+        '上一条的抽象接口声明（HibikiRemoteLookupService），只有方法签名没有实现体，'
+            '不产生任何结果也不呈现 UI，谈不上朗读。',
+  };
+
+  /// 收集 lib/ 下所有 `searchDictionary(` 的**调用**点（排除声明/重写本身）。
+  Set<String> collectCallSiteFiles() {
+    final Set<String> hits = <String>{};
+    for (final FileSystemEntity e
+        in Directory('lib').listSync(recursive: true)) {
+      if (e is! File || !e.path.endsWith('.dart')) continue;
+      final String rel = e.path.replaceAll('\\', '/');
+      for (final String line in e.readAsStringSync().split('\n')) {
+        final String t = line.trim();
+        if (t.startsWith('//') || t.startsWith('///')) continue;
+        if (!t.contains('searchDictionary(')) continue;
+        // 方法声明/接口签名本身不算调用点。
+        if (RegExp(r'Future<DictionarySearchResult\??>\s+searchDictionary\(')
+            .hasMatch(t)) {
+          continue;
+        }
+        hits.add(rel);
+      }
+    }
+    return hits;
+  }
+
+  test('每个查词调用点都必须显式声明接不接自动朗读', () {
+    final Set<String> found = collectCallSiteFiles();
+    expect(found, isNotEmpty,
+        reason: '一个 searchDictionary 调用点都没扫到——扫描逻辑失效了，'
+            '这条守卫会变成永远绿的摆设，请修扫描而不是删断言');
+    final Set<String> declared = <String>{
+      ...wiredSurfaces.keys,
+      ...exemptCallSites.keys,
+    };
+    final Set<String> undeclared = found.difference(declared);
+    expect(undeclared, isEmpty,
+        reason: '这些文件里有查词调用点，但没在 wiredSurfaces / exemptCallSites 任一表中'
+            '声明：$undeclared\n'
+            '新增查词表面时必须显式选一边——接朗读就接上并进 wiredSurfaces，'
+            '不该接就进 exemptCallSites 并写清**为什么不该出声**（BUG-1210）。');
+  });
+
+  test('wiredSurfaces 里的文件必须真的接了朗读（名单不许过期）', () {
+    for (final MapEntry<String, String> e in wiredSurfaces.entries) {
+      final File f = File(e.key);
+      expect(f.existsSync(), true,
+          reason: 'wiredSurfaces 里的 ${e.key} 已不存在，请更新名单');
+      // 剥注释：讲「这里为什么要朗读」的注释里必然写着这些符号名，
+      // 连注释一起扫会让「实现删光、注释还在」照样绿。
+      final String code = f
+          .readAsStringSync()
+          .split('\n')
+          .where((String l) => !l.trimLeft().startsWith('//'))
+          .join('\n');
+      final bool wired = code.contains('autoReadFirstEntry(') ||
+          code.contains('autoReadWord(') ||
+          code.contains('_autoReadWord(') ||
+          code.contains('autoRead:');
+      expect(wired, true,
+          reason: '${e.key} 在 wiredSurfaces 里声明为「已接朗读」，但剥掉注释后找不到任何'
+              '朗读调用——要么朗读被删了（回归），要么该挪进 exemptCallSites 并说明理由。');
+    }
+  });
+
+  test('豁免必须带具体理由，不能是只有文件名的橡皮图章', () {
+    for (final MapEntry<String, String> e in exemptCallSites.entries) {
+      expect(File(e.key).existsSync(), true,
+          reason: 'exemptCallSites 里的 ${e.key} 已不存在，请清理名单');
+      final String why = e.value.trim();
+      expect(why.length, greaterThanOrEqualTo(20),
+          reason: '${e.key} 的豁免理由太短（"$why"）——要说清为什么这里不该自动出声');
+      for (final String placeholder in <String>[
+        'TODO',
+        'FIXME',
+        'n/a',
+        'N/A',
+        '待补'
+      ]) {
+        expect(why.contains(placeholder), false,
+            reason: '${e.key} 的豁免理由是占位符（含 "$placeholder"），等于没写');
+      }
+    }
+  });
+}

--- a/hibiki/test/lookup/overlay_auto_read_parity_test.dart
+++ b/hibiki/test/lookup/overlay_auto_read_parity_test.dart
@@ -107,4 +107,52 @@ void main() {
         reason: '朗读调用与它前面最后一个 await 之间必须核对 latest-wins 序号，'
             '否则被顶掉的旧查词会读出与屏幕不符的旧词（BUG-1210）');
   });
+
+  test('每条查词路径都朗读：两个表面里凡是查词的方法，都不能少了朗读调用', () {
+    // 为什么要按**方法**粒度再守一层：auto_read_surface_coverage_guard 是按**文件**
+    // 粒度的（新增查词表面必须声明），但同一个文件里删掉其中一条路径的朗读它抓不到——
+    // 那正是 BUG-1210 第一版的形态：面板 update() 接了朗读，同文件的 _lookupFromBanner
+    // 和 _lookupNested 没接，于是「复制进来会读、点字不读」，而嵌套那条在瞬态覆盖窗上
+    // 又是会读的，两个表面同一动作行为漂开。变异实测证实过：删掉 _lookupNested 的朗读
+    // 调用，文件粒度那条守卫仍然全绿。
+    //
+    // 判据：把源码切成类成员方法，凡方法体内查了词（await model.searchDictionary），
+    // 就必须也有朗读调用。不是「数量相等」那种快照断言——新增一条查词路径同样会被要求
+    // 接朗读，而不是等着谁去更新一个计数。
+    List<({String name, String body})> splitMethods(String src) {
+      final RegExp head = RegExp(
+          r'^  (?:Future<[^>]*>|void|bool|int|String)\s+(\w+)\(',
+          multiLine: true);
+      final List<RegExpMatch> ms = head.allMatches(src).toList();
+      return <({String name, String body})>[
+        for (int i = 0; i < ms.length; i++)
+          (
+            name: ms[i].group(1)!,
+            body: src.substring(
+                ms[i].start, i + 1 < ms.length ? ms[i + 1].start : src.length),
+          ),
+      ];
+    }
+
+    for (final ({String src, String label, String readCall}) surface
+        in <({String src, String label, String readCall})>[
+      (src: panel, label: '剪贴板面板', readCall: 'autoReadFirstEntry('),
+      (src: overlay, label: '瞬态覆盖窗', readCall: 'autoReadFirstEntry('),
+    ]) {
+      final List<({String name, String body})> lookupMethods =
+          splitMethods(surface.src)
+              .where((({String name, String body}) m) =>
+                  m.body.contains('await model.searchDictionary('))
+              .toList();
+      expect(lookupMethods, isNotEmpty,
+          reason: '${surface.label}里一个查词方法都没切出来——守卫锚点失效了，'
+              '请修切分逻辑而不是删断言');
+      for (final ({String name, String body}) m in lookupMethods) {
+        expect(m.body.contains(surface.readCall), true,
+            reason: '${surface.label}的 ${m.name}() 查了词却没有朗读调用。'
+                '同一个表面内不同查词路径行为必须一致，否则就是 BUG-1210 那种'
+                '「这条读、那条不读」；确实不该读的路径请在这里显式说明理由后豁免。');
+      }
+    }
+  });
 }


### PR DESCRIPTION
承接 BUG-1210：第一版只修了三条路径里的一条。

## 为什么漏了
当时判「剪贴板面板是**唯一**漏接的表面」是**循环论证** —— 从 `autoRead` 符号侧找接入点，只能看见「已经调了朗读的地方」，天生看不见「没调的路径」。

改从**结果产生侧**穷举：`AppModel.searchDictionary(` 的全部 23 个调用点，并验证过没有旁路（无表面绕开它直连引擎；`DictionarySearchResult` 直接构造的 3 处都不是独立表面）。

## 补上的两条
| 路径 | 症状 |
|---|---|
| `_lookupFromBanner`（点句中字换根） | 「复制进来会读、点字不读」 |
| `_lookupNested`（点释义里的词再查） | **瞬态覆盖窗的同名路径是会读的**，两个表面同一动作行为漂开 —— 而「两表面不得漂开」正是 BUG-1210 要收口的东西 |

接线各按自己的既有语义：`_lookupFromBanner` 与 `update()` 同款，在 `_renderPanel` 这个 await **之后**再核对 latest-wins 序号才朗读；`_lookupNested` 不加核对（它自始不参与 root 的 latest-wins，是压栈不是换根），与瞬态窗 nested 同构。

## 守卫两层（单层不够）
- **文件粒度**（新增 `auto_read_surface_coverage_guard_test`）：每个查词调用点必须显式声明接不接朗读；豁免必须写**具体理由**（长度门 + 占位符检测）；`wiredSurfaces` 会被正向验证（剥注释后真有朗读调用），防止名单过期成橡皮图章。
- **方法粒度**（`overlay_auto_read_parity_test` 补一条）：凡方法体内查了词就必须有朗读调用。

实测删 `_lookupNested` 的朗读，**文件粒度守卫仍全绿**、方法粒度这条才红 —— 所以两层都要。

## 变异实测（每条都先用 `git diff` 实证落盘）
| 变异 | 结果 |
|---|---|
| 删 `_lookupNested` 朗读 | 文件粒度绿 / **方法粒度红** |
| 删 `_lookupFromBanner` 朗读 | **红** |
| 豁免理由换成 `'TODO'` | **红** |

## 未处理（待产品拍板）
Android 悬浮词典两条路径（`floating_dict_page._doSearch`、`app_model._setupFloatingDictHandlers.onSearch`）同样不朗读，与 `home_dictionary_page` 行为不一致；但浮在别的 app 上层的小窗该不该突然出声是产品取舍。**已进豁免名单并注明「待产品拍板」，未擅自改。**

## 🔴 真机未验
全部是静态分析 + 单测，**没有**实际复现「点字查词听不到声音 → 修后能听到」。用户实际能否听到未经验证。