### PR TITLE
fix(video): 桌面字幕避让进度条整段命中区，点进度条不再被吸成查词（BUG-1224）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1180 条。点号进各自文件。
+> 共 1181 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1224](bugs/BUG-1224-video-desktop-seekbar-click-stolen-by-subtitle.md) | ✅ | ✅ | 桌面视频点进度条被字幕吸走成查词 |
 | [BUG-1221](bugs/BUG-1221-manga-path-case-folded.md) | ✅ | ✅ | 漫画页图解析把路径折成小写，制卡封面名被小写化且大小写敏感平台缺页 |
 | [BUG-1220](bugs/BUG-1220-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |
 | [BUG-1218](bugs/BUG-1218-epub-path-case-folded-android.md) | ✅ | ✅ | EPUB 解析把路径折成小写，大小写敏感平台上整本章节静默失踪 |

--- a/docs/bugs/BUG-1224-video-desktop-seekbar-click-stolen-by-subtitle.md
+++ b/docs/bugs/BUG-1224-video-desktop-seekbar-click-stolen-by-subtitle.md
@@ -1,0 +1,39 @@
+## BUG-1224 · 桌面视频点进度条被字幕吸走成查词
+- **报告**：2026-07-28（用户：点进度条时进度条会下去、点成了字幕查词，附全屏截图——字幕行紧贴进度条上方，且 seek hover 缩略图预览正显示在同一位置）
+- **真实性**：✅ 真 bug（桌面几何恒定重叠，非偶发）。根因 `hibiki/lib/src/media/video/video_subtitle_style.dart:87-89`（旧桌面分支 `return buttonBarHeight`），几何来源 `third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart:873-878`（写死 `Transform.translate(Offset(0, 16))`）+ `:1228-1231`（`seekBarContainerHeight` 高的透明命中容器 + 裸 `Listener`），吸收层 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:2445-2460`（`_RenderGlyphPriorityHitTest.hitTest`）。
+
+### 根因
+桌面 seek bar 的**可点区域不是那条可见轨道**：`MaterialDesktopSeekBar` 把一个 `seekBarContainerHeight`（fork 默认 36）高的**全透明** `Container` 包在裸 `Listener` 里（`onPointerUp` 直接 `player.seek`），可见轨道只有 3.2px 且在容器里竖直居中；容器又被 `Transform.translate(Offset(0,16))` 整体下压去骑按钮行上沿。于是热区实际占据
+
+```
+[buttonBarHeight − 16 , buttonBarHeight − 16 + 36]   （离视频底边）
+```
+
+即**上缘比按钮行高再高 20px**，那 20px 正好探出按钮行、露在按钮行上方。
+
+而字幕避让 `videoSubtitleControlsReserve` 的桌面分支只 `return buttonBarHeight`——它让出的是**可见轨道**所在高度，不是热区上缘。字幕底缘（`max(用户 bottomPadding, reserve)`）因此恒落在这段热区里。字幕层在 controls Stack 之上（`video_hibiki/layout.part.dart:257` vs `:323`），且 BUG-838 起对命中 glyph 的指针**主动吸收**（`_GlyphPriorityHitTest.hitTest` 返回 true，截断父 Stack 向下命中）——指针根本到不了 seek 的裸 `Listener`。
+
+症状因此表现为「看得见能点、点下去却是查词」：hover 走 `opaque:false` 的 `MouseRegion`、不被吸收，所以缩略图预览照常出现（用户截图里预览正显示），但按下就被字幕赢走 → 弹查词 + 视频暂停（控制条随即淡出＝用户说的「进度条会下去」），seek 从未发生。
+
+同一根因的第二症状：在重叠带按下并拖动想 scrub，指针被吸收层截断（seek 收不到 pointerDown），而 tap 识别器又因超 slop 被 reject → 既不 seek 也不查词的死区。
+
+**为什么移动端没事**：BUG-901 已把移动 reserve 改成「触摸热区上缘 + 呼吸间距」，桌面分支当时没跟上（BUG-838 备注里写的「方案 B（收窄 reserve 避让）后续单独评估，本次不动」就是这里）。这是平台特例分支各自腐化的典型：不变量（字幕命中区必须清出整段 seek 命中区）本该无分支。
+
+### 修复
+- fork 把写死的下压量提成主题字段 `seekBarBottomButtonBarOverlap`（默认仍 16.0，渲染逐像素不变），`Transform.translate` 改读它；见 `third_party/media_kit_video/PATCHES.md` 的 BUG-1224 段。
+- 桌面 theme 显式传 `seekBarContainerHeight` / `seekBarBottomButtonBarOverlap`（36 / 16，仍不随缩放，外观不变），于是**控制条布局**与**字幕避让**读同一份常量，不再一个吃 fork 构造器默认、一个靠猜。
+- `videoSubtitleControlsReserve` 改成：先按平台算**热区下缘**，再统一 `+ 热区全高 + 呼吸间距`。安全不变量（reserve ≥ 热区上缘）两平台同一条、无分支，桌面不会再单独腐化。
+- 页面新增 `_activeSeekBarContainerHeight` / `_activeSeekBarButtonBarOverlap`，保证避让永远用**当前平台 theme 真实生效**的值（桌面 36 不随缩放 / 移动 40×缩放）。
+
+数值：桌面 reserve 由 `56×scale` 变为 `56×scale − 16 + 36 + 8×scale`（scale=1.0 时 84）。仍小于 BUG-228 被用户否掉的 98，默认基线 75 下字幕只多抬 9px；控制条隐藏后字幕照旧落回用户基线。
+
+- **[x] ① 已修复** — 见本次提交（fork 主题字段 + 桌面 theme 显式几何 + reserve 改用热区上缘）。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/media/video/video_subtitle_style_test.dart`「桌面 reserve = 进度条触摸热区上缘 + 呼吸间距…」：钉死 84 / 不变量 `reserve ≥ 热区上缘` / 防退回 `> buttonBarHeight` / BUG-228 不回归 `< 98`，并在缩放 2.0 下复验不变量。
+  - `hibiki/test/pages/video_subtitle_push_up_guard_test.dart`「BUG-1224：桌面 theme 与字幕避让读同一份进度条几何…」：扫 fork 确认下压偏移读主题字段（写死 `const Offset(0.0, 16.0)` → 红）、命中容器高读主题字段，并扫页面确认桌面 theme 显式传两项、reserve 用 `_active*` 而非移动端值。
+  - 变异实测（三条各自单独还原成旧写法后复跑，全部真红）：fork 退回写死偏移 → guard 159 行红；页面退回 `_videoSeekBarContainerHeight` → guard 128 行红；纯函数退回 `if (isDesktop) return buttonBarHeight` → 单测 332 行红。
+
+### 备注 / 遗留
+- 控制条淡入 150ms 与字幕 `AnimatedPadding` 200ms 不同相位：淡入途中字幕尚未抬到位，那一小段时间内重叠仍在（seek bar 一 mount 就可命中）。属瞬态、未在本次处理；若真机上仍能稳定复现「刚唤出控制条就点不中进度条」，再按「避让必须先行于命中」单独立项。
+- `videoSeekBarTrackBand` 桌面分支把轨道中线近似成 `buttonBarHeight`（真实是 `buttonBarHeight + 2`），章节刻度因此有 2px 偏差——既存、与本 bug 无关，未一并改。
+- 真机验收未做（本轮为离线定位 + 单测/守卫层验证）：需在 Windows 真机沿原始失败路径复测「点进度条上缘 20px 带 → 真 seek、不弹查词」，以及界面缩放放大后同样成立。

--- a/hibiki/lib/src/media/video/video_subtitle_style.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_style.dart
@@ -49,8 +49,10 @@ const double kVideoControlsTopReserve = _kButtonBarHeight;
 ///
 /// 故 reserve 必须 = 进度条上缘真实高度（按平台几何加总）×缩放，且 > 默认基线 75 才能
 /// 让取下限真正抬升字幕盖过进度条。本函数把这套几何收敛成纯函数（页面与测试同源调用）：
-/// - 桌面：进度条骑按钮行上沿 → reserve = 一个按钮行高（[buttonBarHeight]），保持
-///   BUG-228「只让出进度条那一条、不抬过整条按钮行」的桌面观感，但现在随缩放变化；
+/// - 桌面：进度条骑按钮行上沿（再被下压 [seekBarBottomButtonBarOverlap]）→ reserve =
+///   `[buttonBarHeight] − overlap + [seekBarContainerHeight] + [subtitleBreathingGap]`
+///   （= 触摸热区上缘 + 呼吸，BUG-1224；旧版只让一个按钮行高 = 压住热区上半截误触）。
+///   仍守 BUG-228「不抬过整条按钮行 + 离底 margin（旧 98）」：scale=1.0 时为 84 < 98；
 /// - 移动：进度条整体被抬到按钮行上方 → reserve = [bottomChromeBaseline] + 系统底部
 ///   inset + [buttonBarHeight] + [seekBarButtonGap] + **进度条触摸热区全高**
 ///   [seekBarContainerHeight] + 字幕呼吸间距 [subtitleBreathingGap]（= 进度条**触摸热区
@@ -71,32 +73,44 @@ const double kVideoControlsTopReserve = _kButtonBarHeight;
 /// 收窄 `_videoSeekBarContainerHeight`（进度条可点热区）或 [subtitleBreathingGap] 即可，
 /// 但不能退回只让可见轨道高——那会重新让两命中区重叠（本 bug 根因）。
 ///
+/// BUG-1224（桌面同源缺口）：BUG-901 只修了移动分支，桌面分支仍 `return buttonBarHeight`
+/// ——那是**可见轨道**所在高度，不是进度条**可点热区**的上缘。桌面 seek bar 的透明命中容器
+/// 高 `seekBarContainerHeight`（fork 默认 36），且被 `Transform.translate` 向下压
+/// [seekBarBottomButtonBarOverlap]（默认 16）骑到按钮行上沿，于是热区实际占
+/// `[buttonBarHeight - overlap, buttonBarHeight - overlap + containerHeight]`——**上缘比
+/// 按钮行高再高 20px**。字幕底缘停在 `buttonBarHeight` 就恰好压住这段热区的上半截，而字幕层
+/// 在 Stack 上层且对 glyph 命中主动吸收指针（`_GlyphPriorityHitTest`，BUG-838），指针根本
+/// 到不了 seek 的裸 `Listener` → 用户点进度条上缘那条带 = 弹查词、seek 被吞（悬停缩略图
+/// 预览却照常出现，因为 hover 走 non-opaque MouseRegion 不被吸收，「看得见能点、点下去
+/// 却是查词」）。故桌面分支与移动分支同一口径：让出**热区上缘** + 呼吸间距。
+///
 /// 几何项均来自 `video_hibiki_page.dart` 的同名控制条 getter（已 ×uiScale）；本函数不再
 /// 二次乘 uiScale，由调用方传入已缩放值，避免双重缩放。[bottomChromeBaseline] 是不随
 /// 缩放的离底基线常量（与页面 `_videoBottomChromeBaseline` 一致），故在此显式加上而非
-/// 乘缩放。
+/// 乘缩放。[seekBarContainerHeight] / [seekBarBottomButtonBarOverlap] 必须传**当前平台
+/// 控制主题真实生效**的值（两套 theme 取值不同，见页面 `_activeSeekBarContainerHeight`）。
 double videoSubtitleControlsReserve({
   required bool isDesktop,
   required double buttonBarHeight,
   required double seekBarButtonGap,
   required double seekBarContainerHeight,
+  required double seekBarBottomButtonBarOverlap,
   required double subtitleBreathingGap,
   required double bottomChromeBaseline,
   required double bottomSystemInset,
 }) {
-  if (isDesktop) {
-    // 桌面进度条骑按钮行上沿：让出一个（已缩放的）按钮行高即可（BUG-228）。
-    return buttonBarHeight;
-  }
-  // 移动进度条**触摸热区上缘** = 离底基线 + 系统 inset + 按钮行 + 进度条/按钮间距 +
-  // 触摸热区全高；再加字幕呼吸间距让字幕命中区整体骑在进度条整段可点区上方，不与 seek
-  // 命中区重叠（BUG-901：只让可见轨道高会落进热区上方那段透明可点区、误触）。
-  return bottomChromeBaseline +
-      bottomSystemInset +
-      buttonBarHeight +
-      seekBarButtonGap +
-      seekBarContainerHeight +
-      subtitleBreathingGap;
+  // 进度条**触摸热区下缘**离视频底边的高度：桌面 seek bar 直接骑按钮行上沿（再下压
+  // overlap），移动端被 `seekBarMargin.bottom` 整体抬到按钮行上方。这是两平台唯一真正的
+  // 布局差异；差异之上的安全不变量（字幕必须清出整段热区）无分支、两平台同一条。
+  final double hotzoneBottom = isDesktop
+      ? buttonBarHeight - seekBarBottomButtonBarOverlap
+      : bottomChromeBaseline +
+          bottomSystemInset +
+          buttonBarHeight +
+          seekBarButtonGap;
+  // 热区上缘 + 呼吸间距：字幕命中区整体骑在进度条整段可点区上方，不与 seek 命中区重叠
+  // （BUG-901 移动 / BUG-1224 桌面）。
+  return hotzoneBottom + seekBarContainerHeight + subtitleBreathingGap;
 }
 
 /// 控制条可见时**顶部锚字幕**要让出的「顶栏下缘距视频顶边的高度」（逻辑像素），与

--- a/hibiki/lib/src/pages/implementations/video_hibiki/controls_theme.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/controls_theme.part.dart
@@ -86,6 +86,14 @@ extension _VideoControlsTheme on _VideoHibikiPageState {
       buttonBarButtonColor: _videoChromeAccent(cs),
       buttonBarHeight: _videoButtonBarHeight,
       buttonBarButtonSize: _videoControlIconSize,
+      // BUG-1224：进度条触摸热区高与「骑按钮行上沿的下压量」显式传入（取值 = fork 原本
+      // 的默认 36 / 16，桌面渲染逐像素不变）。目的是让**控制条实际布局**与**字幕避让计算**
+      // 读同一份常量：此前避让只让出一个按钮行高，而热区上缘其实还高出 36−16=20px，字幕
+      // 恰好压住那条带 → 点进度条上缘被字幕 glyph 命中层吸走成查词（seek 收不到指针）。
+      seekBarContainerHeight:
+          _VideoHibikiPageState._videoDesktopSeekBarContainerHeight,
+      seekBarBottomButtonBarOverlap:
+          _VideoHibikiPageState._videoDesktopSeekBarButtonBarOverlap,
       keyboardShortcuts: _videoKeyboardShortcuts(controller),
       primaryButtonBar: const <Widget>[],
       // 视频内顶栏（替代被删的 Scaffold AppBar，BUG-102）：左右按钮和标题均从用户布局

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -724,15 +724,44 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// reserve 抬到「轨道上缘 + 本间距」让字幕底缘恰骑进度条上方一点点（不被遮、也不像
   /// 旧版用整段热区高那样顶飞 ~47×缩放 的空白）。随界面缩放。
   static const double _videoSubtitleSeekBarBreathingBase = 8;
+
+  /// **桌面**控制条进度条触摸热区高度（BUG-1224）。桌面 theme 此前不覆盖
+  /// `seekBarContainerHeight`、吃 media_kit fork 的构造器默认 36；现在显式传同一个值，
+  /// 让「控制条实际用的热区高」与「字幕避让算的热区高」是同一个真相源，不再靠猜 fork
+  /// 默认值（fork 改默认值 → 避让会跟着漂，本 bug 的隐蔽处之一）。取值仍是 36 且**不随
+  /// 缩放**，与改动前的桌面渲染逐像素一致（本次只修避让，不动控制条外观）。
+  static const double _videoDesktopSeekBarContainerHeight = 36;
+
+  /// **桌面**进度条被向下压、骑到按钮行上沿的重叠量（BUG-1224）。media_kit fork 桌面
+  /// 控制条用 `Transform.translate` 把进度条整体下压这么多，于是它 36px 高的透明触摸热区
+  /// 只有下半截落在按钮行里、上半截（36 − 16 = 20px）探出到按钮行**上方**——正是字幕
+  /// 底缘所在处。fork 侧已把这个量提成主题字段 `seekBarBottomButtonBarOverlap`（默认同为
+  /// 16），本值同时喂给 theme 和字幕避让，两边不会各自漂。不随缩放（与 fork 原常量一致）。
+  static const double _videoDesktopSeekBarButtonBarOverlap = 16;
+
   static const double _videoControlPopoverGapBase = 8;
 
   /// 进度条与按钮条竖直间距，随界面大小缩放（TODO-156）。
   double get _videoSeekBarButtonGap =>
       _videoSeekBarButtonGapBase * _videoUiScale;
 
-  /// 进度条触摸热区高度，随界面大小缩放（TODO-157）。
+  /// 进度条触摸热区高度，随界面大小缩放（TODO-157）。**移动** theme 用。
   double get _videoSeekBarContainerHeight =>
       _videoSeekBarContainerHeightBase * _videoUiScale;
+
+  /// 当前平台控制条**实际生效**的进度条触摸热区高度（BUG-1224）：桌面 theme 传
+  /// [_videoDesktopSeekBarContainerHeight]（36，不随缩放），移动 theme 传
+  /// [_videoSeekBarContainerHeight]（40×缩放）。字幕避让必须按**这个**值算，用错平台的
+  /// 值就会算出错的热区上缘、字幕重新压进 seek 命中区。
+  double get _activeSeekBarContainerHeight => _isDesktopVideoControls
+      ? _videoDesktopSeekBarContainerHeight
+      : _videoSeekBarContainerHeight;
+
+  /// 当前平台进度条骑按钮行上沿的重叠量（BUG-1224）：桌面 =
+  /// [_videoDesktopSeekBarButtonBarOverlap]；移动端进度条被 `seekBarMargin.bottom` 整体
+  /// 抬到按钮行**上方**、不下压，故为 0。
+  double get _activeSeekBarButtonBarOverlap =>
+      _isDesktopVideoControls ? _videoDesktopSeekBarButtonBarOverlap : 0;
 
   /// 进度条拖动滑块尺寸，随界面大小缩放（TODO-157）。
   double get _videoSeekBarThumbSize =>
@@ -5269,7 +5298,10 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       // BUG-901：用**触摸热区全高**（进度条真正可点目标，含可见轨道上方那段透明 seek
       // 命中区）+ 呼吸间距，让字幕命中区整体骑在进度条整段可点区上方，与 seek 不重叠。
       // 只让可见轨道高（旧 TODO-568）会让字幕落进那段透明热区、两命中区在同一竞技场误触。
-      seekBarContainerHeight: _videoSeekBarContainerHeight,
+      // BUG-1224：必须取**当前平台 theme 真实生效**的热区高（桌面 36 不随缩放 / 移动
+      // 40×缩放），并减去桌面把进度条下压骑按钮行上沿的重叠量，才是真的热区上缘。
+      seekBarContainerHeight: _activeSeekBarContainerHeight,
+      seekBarBottomButtonBarOverlap: _activeSeekBarButtonBarOverlap,
       subtitleBreathingGap: _videoSubtitleSeekBarBreathingGap,
       bottomChromeBaseline: _videoBottomChromeBaseline,
       bottomSystemInset: _videoBottomSystemInset(),

--- a/hibiki/test/media/video/video_subtitle_style_test.dart
+++ b/hibiki/test/media/video/video_subtitle_style_test.dart
@@ -225,12 +225,20 @@ void main() {
     const double breathingBase =
         8; // 字幕呼吸间距（_videoSubtitleSeekBarBreathingBase）。
     const double chromeBaseline = 24; // 不随缩放的离底基线常量。
+    // BUG-1224：桌面控制条的进度条几何与移动端不同——热区高恒 36（fork 默认，不随缩放，
+    // 页面 _videoDesktopSeekBarContainerHeight），且被 Transform.translate 下压 16 骑到
+    // 按钮行上沿（_videoDesktopSeekBarButtonBarOverlap / fork 主题字段
+    // seekBarBottomButtonBarOverlap）。
+    const double desktopSeekContainer = 36;
+    const double desktopSeekOverlap = 16;
 
     double mobileReserve(double scale) => videoSubtitleControlsReserve(
           isDesktop: false,
           buttonBarHeight: buttonBarBase * scale,
           seekBarButtonGap: seekGapBase * scale,
           seekBarContainerHeight: seekContainerBase * scale,
+          // 移动端进度条被整体抬到按钮行上方、不下压，故无重叠量。
+          seekBarBottomButtonBarOverlap: 0,
           subtitleBreathingGap: breathingBase * scale,
           bottomChromeBaseline: chromeBaseline,
           bottomSystemInset: 0,
@@ -239,7 +247,8 @@ void main() {
           isDesktop: true,
           buttonBarHeight: buttonBarBase * scale,
           seekBarButtonGap: seekGapBase * scale,
-          seekBarContainerHeight: seekContainerBase * scale,
+          seekBarContainerHeight: desktopSeekContainer,
+          seekBarBottomButtonBarOverlap: desktopSeekOverlap,
           subtitleBreathingGap: breathingBase * scale,
           bottomChromeBaseline: chromeBaseline,
           bottomSystemInset: 0,
@@ -250,6 +259,11 @@ void main() {
     double seekHotzoneTop(double scale) =>
         chromeBaseline +
         (buttonBarBase + seekGapBase + seekContainerBase) * scale;
+
+    // 桌面进度条触摸热区**上缘**离底高（BUG-1224）：热区下缘 = 按钮行高 − 下压量，
+    // 上缘再加热区全高。scale=1.0：56 − 16 + 36 = 76（比按钮行高 56 还高出 20）。
+    double desktopSeekHotzoneTop(double scale) =>
+        buttonBarBase * scale - desktopSeekOverlap + desktopSeekContainer;
 
     test('移动端 reserve = 进度条触摸热区上缘 + 呼吸间距，字幕命中区整体清出 seek 命中区（BUG-901）', () {
       // 根因守卫：只让**可见轨道高** 5 的旧取舍（TODO-568）让 reserve 只抬到可见轨道上缘，
@@ -280,6 +294,7 @@ void main() {
         buttonBarHeight: buttonBarBase,
         seekBarButtonGap: seekGapBase,
         seekBarContainerHeight: seekContainerBase,
+        seekBarBottomButtonBarOverlap: 0,
         subtitleBreathingGap: breathingBase,
         bottomChromeBaseline: chromeBaseline,
         bottomSystemInset: 48,
@@ -297,17 +312,39 @@ void main() {
       // 缩放后仍清出热区上缘（差值 = 呼吸 ×scale）。
       expect(mobileReserve(2.0), greaterThanOrEqualTo(seekHotzoneTop(2.0)),
           reason: '任意缩放下字幕命中区都要清出进度条触摸热区（BUG-901）');
-      // 桌面也随缩放：一个按钮行高 ×scale。
+      // 桌面也随缩放：按钮行高 ×scale（热区高 / 下压量是 fork 常量，不随缩放）。
       expect(desktopReserve(2.0), greaterThan(desktopReserve(1.0)));
-      expect(desktopReserve(2.0), closeTo(112, 0.001)); // 56 * 2.0
+      // scale=2.0：112 − 16 + 36 + 8*2 = 148。
+      expect(desktopReserve(2.0), closeTo(148, 0.001));
+      expect(
+          desktopReserve(2.0), greaterThanOrEqualTo(desktopSeekHotzoneTop(2.0)),
+          reason: '任意缩放下桌面字幕也要清出进度条触摸热区（BUG-1224）');
     });
 
-    test('桌面 reserve = 一个按钮行高（进度条骑按钮行上沿，保 BUG-228 观感）', () {
-      // 桌面进度条用 Transform.translate 骑在按钮行上沿，只需让出一个按钮行高；
-      // 默认基线 75 已在其上（scale 1.0 时 max(75,56)=75），不被多抬（BUG-228）。
-      expect(desktopReserve(1.0), closeTo(56, 0.001));
+    test('桌面 reserve = 进度条触摸热区上缘 + 呼吸间距，点进度条不再被字幕吸走（BUG-1224）', () {
+      // 根因守卫：旧实现桌面分支直接 `return buttonBarHeight`（56），那只是**可见轨道**
+      // 所在高度。桌面 seek bar 的透明触摸热区高 36、被下压 16 骑按钮行上沿，热区上缘其实
+      // 在 56 − 16 + 36 = 76 —— 比 56 高出 20px。字幕底缘停在 56（或默认基线 75）就压住这
+      // 条带，而字幕层在 Stack 上层且对 glyph 命中主动吸收指针（_GlyphPriorityHitTest，
+      // BUG-838）→ 用户点进度条上缘 = 弹查词、seek 收不到指针（悬停缩略图却照常出现，
+      // 因为 hover 走 non-opaque MouseRegion 不被吸收）。
+      // scale=1.0：56 − 16 + 36 + 8 = 84。
+      expect(desktopReserve(1.0), closeTo(84, 0.001));
+      // 核心不变量（与移动端同一条，无平台特例）：reserve ≥ 进度条触摸热区上缘。
+      expect(
+          desktopReserve(1.0), greaterThanOrEqualTo(desktopSeekHotzoneTop(1.0)),
+          reason: '桌面字幕底缘必须骑在进度条触摸热区上缘之上，否则点进度条被字幕吸走成查词（BUG-1224）');
+      expect(desktopReserve(1.0) - desktopSeekHotzoneTop(1.0),
+          closeTo(breathingBase, 0.001),
+          reason: 'reserve 应恰为热区上缘 + 一个呼吸间距');
+      // BUG-1224 防回退：退回「只让一个按钮行高」(56) → 本条红。
+      expect(desktopReserve(1.0), greaterThan(buttonBarBase),
+          reason: '不应退回只让一个按钮行高——那让字幕压住进度条热区上缘 20px 带（BUG-1224）');
+      // BUG-228 不回归：仍必须小于旧的「整条按钮行 + 离底 margin」98，字幕不被顶飞。
+      expect(desktopReserve(1.0), lessThan(98),
+          reason: '桌面避让仍不得抬过旧的 98（BUG-228 用户报「字幕被顶太高很怪」）');
       expect(desktopReserve(1.0), lessThan(mobileReserve(1.0)),
-          reason: '桌面 reserve 应小于移动（桌面进度条没被抬高）');
+          reason: '桌面 reserve 应小于移动（桌面进度条没被整体抬到按钮行上方）');
     });
   });
 

--- a/hibiki/test/pages/video_subtitle_push_up_guard_test.dart
+++ b/hibiki/test/pages/video_subtitle_push_up_guard_test.dart
@@ -115,7 +115,12 @@ void main() {
       '_videoSeekBarButtonGap',
       // BUG-901：移动 reserve 抬到「进度条**触摸热区**上缘 + 呼吸间距」——热区含可见轨道
       // 上方那段透明可点 seek 区，字幕命中区要整体清出它才不与 seek 重叠误触。
-      '_videoSeekBarContainerHeight',
+      // BUG-1224：必须取**当前平台 theme 真实生效**的热区高（桌面 36 不随缩放 / 移动
+      // 40×缩放），退回裸 `_videoSeekBarContainerHeight` 会在桌面用移动端的值算热区上缘。
+      '_activeSeekBarContainerHeight',
+      // BUG-1224：桌面进度条被下压骑按钮行上沿，热区上缘 = 按钮行高 − 下压量 + 热区高；
+      // 漏掉这项就退回「只让一个按钮行高」、字幕重新压住热区上缘 20px 带。
+      '_activeSeekBarButtonBarOverlap',
       '_videoSubtitleSeekBarBreathingGap',
       '_videoBottomChromeBaseline',
       '_videoBottomSystemInset()',
@@ -131,6 +136,56 @@ void main() {
     expect(body, isNot(contains('_videoSeekBarTrackHeight')),
         reason: 'reserve 不应再只用可见轨道高 _videoSeekBarTrackHeight'
             '（字幕落进进度条透明热区、点击挨太近误触，BUG-901 改用触摸热区全高）');
+  });
+
+  test('BUG-1224：桌面 theme 与字幕避让读同一份进度条几何，fork 下压量不再是写死常量', () {
+    // 根因：桌面 seek bar 的透明触摸热区高 seekBarContainerHeight（36），又被
+    // Transform.translate 向下压 16 骑到按钮行上沿 → 热区上缘比按钮行高再高 20px。旧实现
+    // 里这两个数一个是 fork 构造器默认（页面没传）、一个是 fork build() 里写死的
+    // `const Offset(0.0, 16.0)`，页面**无从得知**，于是避让只让出一个按钮行高、字幕恰好
+    // 压住热区上缘那条带，点进度条被字幕 glyph 命中层吸走成查词。
+    final File forkSrc = File(
+      '../third_party/media_kit_video/lib/media_kit_video_controls/'
+      'src/controls/material_desktop.dart',
+    );
+    expect(forkSrc.existsSync(), isTrue,
+        reason: 'vendored media_kit_video fork 应存在');
+    final String fork = forkSrc.readAsStringSync();
+    // fork 必须把下压量提成主题字段并真的用它——退回写死 `Offset(0.0, 16.0)` → 本条红。
+    expect(fork, contains('final double seekBarBottomButtonBarOverlap'),
+        reason: 'fork 桌面主题必须暴露 seekBarBottomButtonBarOverlap，'
+            '否则宿主算不出进度条真实热区上缘（BUG-1224）');
+    // 下压偏移本身必须由主题字段构成（不是文件里别处随便提一下这个名字就算数）。
+    expect(
+        RegExp(r'Offset\(\s*0\.0,\s*_theme\(context\)\s*\.\s*'
+                r'seekBarBottomButtonBarOverlap')
+            .hasMatch(fork),
+        isTrue,
+        reason:
+            '进度条下压偏移必须读主题字段 seekBarBottomButtonBarOverlap，不得写死常量（BUG-1224）');
+    // 热区高同理：Listener 包裹的透明命中容器必须用主题值（宿主传什么就是什么）。
+    expect(
+        RegExp(r'height:\s*_theme\(context\)\s*\.\s*seekBarContainerHeight')
+            .hasMatch(fork),
+        isTrue,
+        reason: '进度条透明命中容器高必须读主题 seekBarContainerHeight（BUG-1224）');
+    expect(fork.contains('const Offset(0.0, 16.0)'), isFalse,
+        reason: '不应残留写死的 16px 下压常量（宿主看不见 → 避让算错，BUG-1224）');
+    // 页面必须显式把同一份常量喂给桌面 theme（而非依赖 fork 构造器默认值漂移）。
+    // theme 在 `extension on _VideoHibikiPageState` 里，静态常量须限定类名，故容忍该前缀。
+    expect(
+        RegExp(r'seekBarContainerHeight:\s*(?:_VideoHibikiPageState\.)?\s*'
+                r'_videoDesktopSeekBarContainerHeight')
+            .hasMatch(src),
+        isTrue,
+        reason: '桌面 theme 必须显式传热区高，与字幕避让同源（BUG-1224）');
+    expect(
+        RegExp(r'seekBarBottomButtonBarOverlap:\s*'
+                r'(?:_VideoHibikiPageState\.)?\s*'
+                r'_videoDesktopSeekBarButtonBarOverlap')
+            .hasMatch(src),
+        isTrue,
+        reason: '桌面 theme 必须显式传下压量，与字幕避让同源（BUG-1224）');
   });
 
   test('桌面 hover 包裹层 non-opaque 下探 media_kit 自己的 MouseRegion（TODO-364）', () {

--- a/third_party/media_kit_video/PATCHES.md
+++ b/third_party/media_kit_video/PATCHES.md
@@ -372,3 +372,34 @@ throttle above is unchanged and complementary (it bounds build/relayout
 frequency, the boundary bounds raster area).
 
 Source-guard test: `hibiki/test/third_party/media_kit_video_seekbar_repaint_boundary_test.dart`.
+
+## BUG-1224: expose the desktop seek-bar push-down as a theme field (`seekBarBottomButtonBarOverlap`)
+
+`MaterialDesktopVideoControls` stacks the bottom chrome as a `Column`
+(seek bar, then button bar) anchored to the bottom edge, and pushes the seek bar
+**down** with a hard-coded `Transform.translate(offset: Offset(0.0, 16.0))` so
+its thin visible track rides on the top edge of the button bar. The seek bar's
+clickable area is not the track, though: it is a fully transparent
+`seekBarContainerHeight`-tall (default 36) `Container` wrapped in a bare
+`Listener`, with the track centred inside it. Net effect: the clickable area
+spans `[buttonBarHeight - 16, buttonBarHeight - 16 + 36]` above the video's
+bottom edge, i.e. it sticks out **20 logical pixels above the button bar** — and
+nothing outside this file could know that, because one number was a constructor
+default the host never passed and the other was a literal inside `build()`.
+
+Hibiki draws its own subtitles (`VideoSubtitleOverlay`) above the controls and,
+since BUG-838, absorbs pointers that land on a subtitle glyph so a lookup tap is
+not stolen by the seek bar's bare `Listener`. With the subtitle's controls-visible
+avoidance stopping at `buttonBarHeight`, the subtitle sat exactly on that 20px
+band: hovering it still showed the seek preview thumbnail (hover goes through a
+non-opaque `MouseRegion`), but pressing there was absorbed by the subtitle and
+turned into a dictionary lookup while the seek never fired.
+
+The patch adds `seekBarBottomButtonBarOverlap` (default `16.0`, so the rendered
+layout is unchanged) to `MaterialDesktopVideoControlsThemeData` + `copyWith`, and
+`Transform.translate` now reads it. Hibiki passes the same constant to the theme
+and to `videoSubtitleControlsReserve`, so the controls layout and the subtitle
+avoidance are computed from one source instead of two guesses.
+
+Source-guard test: `hibiki/test/pages/video_subtitle_push_up_guard_test.dart`
+(`BUG-1224：桌面 theme 与字幕避让读同一份进度条几何…`).

--- a/third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
+++ b/third_party/media_kit_video/lib/media_kit_video_controls/src/controls/material_desktop.dart
@@ -139,6 +139,20 @@ class MaterialDesktopVideoControlsThemeData {
   /// Height of the seek bar [Container].
   final double seekBarContainerHeight;
 
+  /// Hibiki patch (BUG-1224): how far the seek bar is pushed **down** so that it
+  /// rides on the top edge of the bottom button bar (only applied when
+  /// [bottomButtonBar] is non-empty). Upstream hard-coded this as
+  /// `Transform.translate(offset: Offset(0, 16))`, which made the seek bar's
+  /// [seekBarContainerHeight]-tall transparent hit area stick out
+  /// `seekBarContainerHeight - 16` above the button bar with no way for the host
+  /// to know about it. Hibiki's subtitle overlay must lift the subtitle clear of
+  /// that hit area (otherwise a click meant for the seek bar is absorbed by the
+  /// subtitle's glyph-priority hit test and turns into a dictionary lookup), so
+  /// the value has to be readable from the theme instead of buried in the widget
+  /// tree. Default keeps the upstream 16.0 (no visual change).
+  /// See third_party/media_kit_video/PATCHES.md.
+  final double seekBarBottomButtonBarOverlap;
+
   /// [Color] of the seek bar.
   final Color seekBarColor;
 
@@ -268,6 +282,8 @@ class MaterialDesktopVideoControlsThemeData {
     this.seekBarHeight = 3.2,
     this.seekBarHoverHeight = 5.6,
     this.seekBarContainerHeight = 36.0,
+    // Hibiki patch (BUG-1224): was a hard-coded `Offset(0, 16)` in build().
+    this.seekBarBottomButtonBarOverlap = 16.0,
     this.seekBarColor = const Color(0x3DFFFFFF),
     this.seekBarHoverColor = const Color(0x3DFFFFFF),
     this.seekBarPositionColor = const Color(0xFFFF0000),
@@ -313,6 +329,7 @@ class MaterialDesktopVideoControlsThemeData {
     double? seekBarHeight,
     double? seekBarHoverHeight,
     double? seekBarContainerHeight,
+    double? seekBarBottomButtonBarOverlap,
     Color? seekBarColor,
     Color? seekBarHoverColor,
     Color? seekBarPositionColor,
@@ -368,6 +385,8 @@ class MaterialDesktopVideoControlsThemeData {
       seekBarHoverHeight: seekBarHoverHeight ?? this.seekBarHoverHeight,
       seekBarContainerHeight:
           seekBarContainerHeight ?? this.seekBarContainerHeight,
+      seekBarBottomButtonBarOverlap:
+          seekBarBottomButtonBarOverlap ?? this.seekBarBottomButtonBarOverlap,
       seekBarColor: seekBarColor ?? this.seekBarColor,
       seekBarHoverColor: seekBarHoverColor ?? this.seekBarHoverColor,
       seekBarPositionColor: seekBarPositionColor ?? this.seekBarPositionColor,
@@ -871,10 +890,20 @@ class _MaterialDesktopVideoControlsState
                                       ),
                                       if (_theme(context).displaySeekBar)
                                         Transform.translate(
+                                          // Hibiki patch (BUG-1224): the push-down
+                                          // amount now comes from the theme
+                                          // ([seekBarBottomButtonBarOverlap],
+                                          // default = upstream 16.0) so the host
+                                          // can compute the seek bar's real hit
+                                          // area and lift subtitles clear of it.
                                           offset: _theme(context)
                                                   .bottomButtonBar
                                                   .isNotEmpty
-                                              ? const Offset(0.0, 16.0)
+                                              ? Offset(
+                                                  0.0,
+                                                  _theme(context)
+                                                      .seekBarBottomButtonBarOverlap,
+                                                )
                                               : Offset.zero,
                                           child: MaterialDesktopSeekBar(
                                             // Hibiki patch (TODO-669): forward


### PR DESCRIPTION
## 用户报的症状

点进度条时「进度条会下去、点成了字幕查词」。截图里字幕行紧贴进度条上方，且 seek 的 hover 缩略图预览正显示在同一位置。

## 根因（桌面几何恒定重叠，非偶发）

桌面 seek bar 的**可点区域不是那条可见轨道**：`MaterialDesktopSeekBar` 把一个 `seekBarContainerHeight`（fork 默认 36）高的**全透明** Container 包在裸 `Listener` 里（`onPointerUp` 直接 `player.seek`），可见轨道只有 3.2px 且在容器里竖直居中；容器又被 `Transform.translate(Offset(0,16))` 整体下压去骑按钮行上沿。热区因此实际占 `[buttonBarHeight − 16, buttonBarHeight − 16 + 36]`，**上缘比按钮行高再高 20px**。

而 `videoSubtitleControlsReserve` 的桌面分支只 `return buttonBarHeight`——让出的是**可见轨道**所在高度，不是热区上缘。字幕底缘恒落在这 20px 带里；字幕层在 controls Stack 之上且自 BUG-838 起对命中 glyph 的指针**主动吸收**（`_GlyphPriorityHitTest.hitTest` 返回 true 截断父 Stack），指针根本到不了 seek 的裸 Listener。

于是：hover 走 `opaque:false` MouseRegion、不被吸收 → 缩略图预览照常出现；按下却被字幕赢走 → 弹查词 + 暂停，控制条随即淡出（＝用户说的「进度条会下去」），seek 从未发生。**「看得见能点、点下去却是查词」**。同一根因的第二症状是在该带按下拖动想 scrub 时的死区（seek 收不到 pointerDown，tap 又因超 slop 被 reject）。

BUG-901 已按同一口径修好移动分支，桌面分支当时没跟上——正是 BUG-838 备注里挂起的「方案 B 后续单独评估」。平台特例分支各自腐化的典型：不变量本该无分支。

## 改法

- **fork**：把写死的下压量提成主题字段 `seekBarBottomButtonBarOverlap`（默认仍 `16.0`，渲染逐像素不变），`Transform.translate` 改读它。见 `third_party/media_kit_video/PATCHES.md` 的 BUG-1224 段。
- **桌面 theme** 显式传 `seekBarContainerHeight` / `seekBarBottomButtonBarOverlap`（36 / 16，仍不随缩放，外观不变）→ 控制条布局与字幕避让读同一份常量，不再一个吃 fork 构造器默认、一个靠猜。
- **`videoSubtitleControlsReserve`** 改成「按平台算**热区下缘** → 统一 `+ 热区全高 + 呼吸间距`」。安全不变量（reserve ≥ 热区上缘）两平台同一条、无分支。
- 页面新增 `_activeSeekBarContainerHeight` / `_activeSeekBarButtonBarOverlap`，保证避让永远用**当前平台 theme 真实生效**的值（桌面 36 不随缩放 / 移动 40×缩放）。

数值：桌面 reserve `56×scale` → `56×scale − 16 + 36 + 8×scale`（scale=1 时 **84**）。仍小于 BUG-228 被用户否掉的 98；默认基线 75 下字幕只多抬 9px，控制条隐藏后照旧落回用户基线。

## 验证

- `flutter analyze`（全量含 test）：No issues found。
- 定向 + 相邻：`test/third_party`、字幕 overlay / 逐字符命中容差 / 章节刻度 / 字幕样式 / 视频页避让守卫 —— **154 tests ran, all tests passed**（走 `tool/flutter_test_failures.dart`，认 VERDICT 行）。
- **变异实测**（新增守卫防假绿，四条各自单独还原成旧写法后复跑，全部真红）：
  1. fork 退回写死 `const Offset(0.0, 16.0)` → guard 红
  2. 页面 reserve 退回 `_videoSeekBarContainerHeight`（移动端值）→ guard 红
  3. 纯函数退回 `if (isDesktop) return buttonBarHeight` → 单测红
  4. 桌面 theme 漏接 `seekBarBottomButtonBarOverlap` → guard 红

## 未做 / 遗留

- **真机验收未做**：需在 Windows 真机沿原始失败路径复测「点进度条上缘 20px 带 → 真 seek、不弹查词」，以及界面缩放放大后同样成立。
- 控制条淡入 150ms 与字幕 `AnimatedPadding` 200ms 不同相位，淡入途中仍有瞬态重叠（seek bar 一 mount 就可命中）；属瞬态，未在本轮处理，已记在 BUG 文档遗留里。
- `videoSeekBarTrackBand` 桌面轨道中线近似 `buttonBarHeight`（真实 `+2`），章节刻度 2px 偏差，既存、与本 bug 无关，未一并改。

BUG 文档：`docs/bugs/BUG-1224-video-desktop-seekbar-click-stolen-by-subtitle.md`

https://claude.ai/code/session_015rAN1H8hsAijG2YXJTgQMv