### PR TITLE
test(gal): 守住读端共享内存的写权限，防再被「收紧成只读」（BUG-1225）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1184 条。点号进各自文件。
+> 共 1185 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1225](bugs/BUG-1225-shm-reader-write-access-must-stay.md) | ✅ | ✅ | 读端共享内存写权限不可收紧：SelectTextThread 的原子写落在只读页上会崩 |
 | [BUG-1221](bugs/BUG-1221-manga-path-case-folded.md) | ✅ | ✅ | 漫画页图解析把路径折成小写，制卡封面名被小写化且大小写敏感平台缺页 |
 | [BUG-1220](bugs/BUG-1220-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |
 | [BUG-1218](bugs/BUG-1218-epub-path-case-folded-android.md) | ✅ | ✅ | EPUB 解析把路径折成小写，大小写敏感平台上整本章节静默失踪 |

--- a/docs/bugs/BUG-1225-shm-reader-write-access-must-stay.md
+++ b/docs/bugs/BUG-1225-shm-reader-write-access-must-stay.md
@@ -1,0 +1,64 @@
+## BUG-1225 · 读端共享内存写权限不可收紧：SelectTextThread 的原子写落在只读页上会崩
+
+- **报告**：2026-07-28（用户：无——本条来自 BUG-1216 的跟进调查，是**预防性守卫**，不是线上故障）
+- **真实性**：✅ 真隐患（未发布）。差点作为"零代价收紧"改动发出去，复核时拦下。
+
+### 起因
+
+BUG-1216（共享内存打不开只说一句「请重启 Hibiki」）的根治调查里，曾提出一个看似零代价的旁路：
+读端 `voice_hook_reader.cpp` 用 `FILE_MAP_READ | FILE_MAP_WRITE` 打开映射，若读端其实从不写，
+就能收紧成只读——不动 native、不改 IPC、不重发 helper，而且若拒绝访问是"写权限"引起的，
+这一下就修好了。
+
+该结论**是错的**。首轮审计用 `grep '=' 赋值` 与 `grep memcpy` 判定"读端从不写"，
+而真正的写是**原子写**，两种都不是：
+
+- `hibiki/windows/runner/voice_hook_reader.cpp:446`
+  `InterlockedExchange64(reinterpret_cast<volatile LONGLONG*>(&h->selected_text_thread_id), ...)`
+- 目标字段在**映射内**：`hibiki/windows/runner/voice_hook_ipc.h:162`
+  `volatile uint64_t selected_text_thread_id;`
+- 同处 `voice_hook_reader.cpp:442` 的 `SharedHeader* h` 是全文件**唯一**非 const 的 header 指针，
+  首轮也一并漏看。
+
+### 后果（若当时改了）
+
+以 `FILE_MAP_READ` 映射的页是 PAGE_READONLY，往上面做原子写触发 **ACCESS_VIOLATION**，
+`SelectTextThread` 周围没有 SEH ——**Hibiki.exe 直接崩**。且该路径在**自动**流程上
+（`hibiki/lib/src/mining/gal_hook_session_controller.dart:2199` 自动挑选文本线程，无需用户手动），
+即常规 galgame 文本 hook 一跑就崩，而不是"某个功能不可用"。
+
+`selected_text_thread_id` 是一条真实的**读端 → 注入端控制通道**，注入端确实读它：
+`native/galgame_hook/hook/adapters/kirikiri_adapter.inc:114`、
+`native/galgame_hook/include/luna_text_selector.h`、
+`native/galgame_hook/injector/injector_main.cpp:764`。
+
+### 附带更正（BUG-1216 调查记录）
+
+- "存在零代价、不动 ACL 的旁路"——**划掉，不存在**。
+- 该调查给出的最小 DACL 形态 `(A;;GR;;;<用户SID>)` 只给读，**不够**，至少要到 `SECTION_MAP_WRITE`。
+- 读端既然必须写，若对象带高完整性标签，Windows 默认 **NO_WRITE_UP 会直接挡掉写**，
+  中完整性的 Hibiki 无解——除非提权或改对象 ACL/标签。即"可能绕不开信任边界"这一判断被加强。
+- 仍不能排除用户那例是 helper 版本漂开而非 ACL；以下一份带 token 的报错为准再定。
+
+- **[x] ① 已修复** — 无代码修复：正确行为就是**维持现状**（保留 `FILE_MAP_WRITE`）。本条交付的是
+  防止再犯的守卫，见 ②。
+- **[x] ② 已加自动化测试** — `hibiki/test/tools/voice_hook_reader_write_access_guard_test.dart`，2 例：
+  ①**前提**断言 `SelectTextThread` 仍对映射内 `selected_text_thread_id` 做 `InterlockedExchange64`；
+  ②**因此**断言 `Open` 里 `OpenFileMappingW` 与 `MapViewOfFile` **各自的实参**都含 `FILE_MAP_WRITE`
+  （判据落在两处实参上而非"函数体里出现过"，否则"一处保留、另一处改只读"能骗过守卫，而两处
+  任缺其一都同样让原子写落在只读页）。扫描前剥 `//` 与 `/* */` 注释，函数体扫不到即判红防空集。
+  守卫**把要求绑在成因上**：哪天 `SelectTextThread` 真改走别的通道，第一条断言先失败并指明
+  "前提没了，可以连同写权限一起撤"，守卫自行退休而非变成没人敢动的化石。
+
+  变异实测（`git diff --stat` 实证落盘，跑完还原）：去掉 `MapViewOfFile` 的 `FILE_MAP_WRITE` → 转红；
+  去掉 `OpenFileMappingW` 的 → 转红；把 `InterlockedExchange64` 换成普通赋值（前提伪装）→ 转红。
+
+### 备注
+
+🔴 **这条守卫只到源码扫描 + 编译门这一层，证明不了运行时行为。**
+`hibiki/windows/runner/voice_hook_reader.cpp` 由 `hibiki/windows/runner/CMakeLists.txt` 编译进
+Flutter Windows runner，与 `native/galgame_hook/` 那 22 条 ctest **不是同一构建单元**，
+那些 ctest 一行都跑不到它。本轮也**未做真机验证**（不涉及行为变更，无可验之新行为）。
+
+📌 通用教训（已请求存档）：审计"这段代码写不写某块内存"时，`=` 赋值与 `memcpy` **不构成全集**，
+必须一并扫**原子操作**（`Interlocked*`）、**非 const 指针**、以及任何经 `&` 取址传出的路径。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+993
+version: 1.3.1+994
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/tools/voice_hook_reader_write_access_guard_test.dart
+++ b/hibiki/test/tools/voice_hook_reader_write_access_guard_test.dart
@@ -1,0 +1,119 @@
+// 守卫：galgame 共享内存的**读端必须保留写权限**，不许被"顺手收紧成只读"。
+//
+// 为什么（BUG-1225）——这条理由必须具体到能阻止再犯，写"需要写权限"没有用：
+//
+//   `VoiceHookReader::SelectTextThread`（`hibiki/windows/runner/voice_hook_reader.cpp:446`）
+//   会对**映射内**的 `SharedHeader::selected_text_thread_id`
+//   （`hibiki/windows/runner/voice_hook_ipc.h:162`，`volatile uint64_t`）做一次
+//   `InterlockedExchange64` 原子写。那不是普通赋值、也不是 memcpy，所以按 `=` 或
+//   `memcpy` 搜"读端写不写共享内存"会**搜不到它**——本守卫的存在就是因为有人（作者本人）
+//   正是这样漏检的，差点把 `FILE_MAP_WRITE` 去掉。
+//
+//   去掉写权限的后果不是"功能失效"而是**崩溃**：以 `FILE_MAP_READ` 映射的页是
+//   PAGE_READONLY，往上面做原子写触发 ACCESS_VIOLATION，而 `SelectTextThread` 周围没有
+//   SEH。这条路径还在**自动**流程上（`gal_hook_session_controller.dart:2199` 自动挑选文本
+//   线程，不需要用户手动点），所以是常规 galgame 文本 hook 一跑就崩。
+//
+//   `selected_text_thread_id` 是一条真实的**读端 → 注入端控制通道**，注入端确实读它：
+//   `native/galgame_hook/hook/adapters/kirikiri_adapter.inc:114`、
+//   `native/galgame_hook/include/luna_text_selector.h`、
+//   `native/galgame_hook/injector/injector_main.cpp:764`。
+//
+// 本守卫**把要求绑在成因上**而不是把 `FILE_MAP_WRITE` 永久钉死：先断言那处原子写还在，
+// 再要求打开标志带写权限。哪天 `SelectTextThread` 真的改走别的通道、读端不再写共享内存，
+// 第一条断言会先失败并指明"前提没了，本守卫可以连同写权限一起撤"——守卫自己会退休，
+// 不会变成一条没人敢动的化石。
+//
+// 🔴 这条守卫只到**源码扫描**这一层。`hibiki/windows/runner/voice_hook_reader.cpp` 由
+// `hibiki/windows/runner/CMakeLists.txt` 编译进 Flutter Windows runner，与
+// `native/galgame_hook/` 那套 ctest **不是同一个构建单元**，那 22 条 ctest 一行都跑不到它。
+// 所以它证明不了运行时行为，只能保证"这两处源码事实同时成立或同时不成立"。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 从当前 cwd 向上找含 `hibiki/windows/runner` 的仓库根。
+Directory _repoRoot() {
+  var dir = Directory.current;
+  for (var i = 0; i < 6; i++) {
+    if (Directory('${dir.path}/hibiki/windows/runner').existsSync()) return dir;
+    final Directory parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  fail('找不到含 hibiki/windows/runner 的仓库根（从 ${Directory.current.path} 向上）');
+}
+
+/// 剥掉 `//` 行注释与 `/* */` 块注释再匹配。
+///
+/// 源码扫描守卫最经典的假绿：真代码改掉、注释里还留着同一串字面量，守卫照绿。本文件上面
+/// 的说明里就反复出现 `FILE_MAP_WRITE` 和 `InterlockedExchange64`，剥完不该再被任何断言看见。
+String _stripComments(String source) => source
+    .replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '')
+    .replaceAll(RegExp(r'//[^\n]*'), '');
+
+/// 取 [source] 中从 [signature] 起到该函数结尾（列 0 的 `}`）的函数体。
+String _functionBody(String source, String signature) {
+  final int at = source.indexOf(signature);
+  expect(at, greaterThan(0), reason: '扫不到 $signature —— 判红，别让空集假绿');
+  final int end = source.indexOf('\n}', at);
+  expect(end, greaterThan(at), reason: '扫不到 $signature 的函数体结尾 —— 判红');
+  return source.substring(at, end);
+}
+
+void main() {
+  final Directory root = _repoRoot();
+  final String readerPath =
+      '${root.path}/hibiki/windows/runner/voice_hook_reader.cpp';
+  final String ipcPath = '${root.path}/hibiki/windows/runner/voice_hook_ipc.h';
+
+  test('前提：读端仍然会对映射内的 selected_text_thread_id 做原子写', () {
+    final String ipc = _stripComments(File(ipcPath).readAsStringSync());
+    expect(
+      ipc,
+      contains('selected_text_thread_id'),
+      reason: 'selected_text_thread_id 必须仍是共享内存 SharedHeader 的字段；'
+          '它要是搬出映射了，写权限的前提就变了',
+    );
+
+    final String reader = _stripComments(File(readerPath).readAsStringSync());
+    final String body =
+        _functionBody(reader, 'bool VoiceHookReader::SelectTextThread');
+    expect(
+      body,
+      contains('InterlockedExchange64'),
+      reason: '前提消失：SelectTextThread 不再对共享内存做原子写。'
+          '若确实改走了别的通道，请连同本守卫与 FILE_MAP_WRITE 一起撤，而不是只删这条断言',
+    );
+    expect(
+      body,
+      contains('selected_text_thread_id'),
+      reason: '前提消失：写的目标已不是映射内的 selected_text_thread_id',
+    );
+  });
+
+  test('因此：Open 打开共享内存时必须带 FILE_MAP_WRITE（去掉会 ACCESS_VIOLATION 崩溃）', () {
+    final String reader = _stripComments(File(readerPath).readAsStringSync());
+    final String body =
+        _functionBody(reader, 'VoiceHookOpenResult VoiceHookReader::Open');
+
+    // 判据落在**这两个调用各自的实参上**，不是"整个函数体里出现过 FILE_MAP_WRITE"——
+    // 后者会被"一处保留、另一处改成只读"骗过，而两处任缺其一都同样让原子写落在只读页上。
+    for (final String call in <String>['OpenFileMappingW', 'MapViewOfFile']) {
+      final int at = body.indexOf(call);
+      expect(at, greaterThan(0), reason: 'Open 里扫不到 $call —— 判红');
+      final int close = body.indexOf(')', at);
+      expect(close, greaterThan(at), reason: '$call 的实参列表扫不到结尾 —— 判红');
+      final String args = body.substring(at, close);
+      expect(
+        args,
+        contains('FILE_MAP_WRITE'),
+        reason:
+            '$call 少了 FILE_MAP_WRITE：SelectTextThread 的 InterlockedExchange64 '
+            '会写到 PAGE_READONLY 页上，触发 ACCESS_VIOLATION 且无 SEH——'
+            'galgame 文本 hook 的自动选线程路径一跑就崩，不是"功能降级"',
+      );
+    }
+  });
+}


### PR DESCRIPTION
## 这是什么

**无生产代码改动。** 只加一条守卫 + BUG 记录。

BUG-1216 的跟进调查里，我提出过一个看似零代价的旁路：读端 `voice_hook_reader.cpp` 用 `FILE_MAP_READ | FILE_MAP_WRITE` 打开映射，若读端其实从不写，就收紧成只读——不动 native、不改 IPC、不重发 helper。

**那个结论是错的，复核时拦下了。** 首轮审计用 `grep '=' 赋值` 和 `grep memcpy` 判定"读端从不写"，而真正的写是**原子写**，两种都不是：

- `hibiki/windows/runner/voice_hook_reader.cpp:446` — `InterlockedExchange64(&h->selected_text_thread_id, ...)`
- 目标字段在**映射内**：`hibiki/windows/runner/voice_hook_ipc.h:162` `volatile uint64_t selected_text_thread_id`
- `voice_hook_reader.cpp:442` 的 `SharedHeader* h` 是全文件**唯一**非 const 的 header 指针，首轮也漏看

**若当时改了，后果不是功能失效而是崩溃**：`FILE_MAP_READ` 映射的页是 PAGE_READONLY，往上面做原子写触发 ACCESS_VIOLATION，该处无 SEH。且这条路径在**自动**流程上（`gal_hook_session_controller.dart:2199` 自动挑文本线程，无需用户手动），即常规 galgame 文本 hook 一跑就崩。

`selected_text_thread_id` 是真实的**读端 → 注入端控制通道**，注入端确实读它（`kirikiri_adapter.inc:114`、`luna_text_selector.h`、`injector_main.cpp:764`）。

## 守卫做了什么

`hibiki/test/tools/voice_hook_reader_write_access_guard_test.dart`，2 例：

1. **前提**：断言 `SelectTextThread` 仍对映射内 `selected_text_thread_id` 做 `InterlockedExchange64`；
2. **因此**：断言 `Open` 里 `OpenFileMappingW` 与 `MapViewOfFile` **各自的实参**都含 `FILE_MAP_WRITE`。

判据落在**两处实参各自**上，而不是"函数体里出现过 `FILE_MAP_WRITE`"——后者会被"一处保留、另一处改只读"骗过，而两处任缺其一都同样让原子写落在只读页上。扫描前剥 `//` 与 `/* */` 注释（说明文字里反复出现这些字面量，不剥就会自我满足）；函数体扫不到即判红，防空集假绿。

**要求绑在成因上而非把 `FILE_MAP_WRITE` 永久钉死**：哪天 `SelectTextThread` 真改走别的通道，第一条断言先失败并指明"前提没了，可以连同写权限一起撤"——守卫自行退休，不会变成没人敢动的化石。

理由字段写的是**为什么**需要写权限（具体到 ACCESS_VIOLATION、无 SEH、自动路径），不是"需要写权限"这种拦不住人的话。

## 变异实测

3 次，全部转红，每次先用 `git diff` 实证变异落盘、跑完还原：

| 变异 | 结果 |
|---|---|
| 去掉 `MapViewOfFile` 的 `FILE_MAP_WRITE` | 🔴 红 |
| 去掉 `OpenFileMappingW` 的 `FILE_MAP_WRITE` | 🔴 红 |
| 把 `InterlockedExchange64` 换成普通赋值（伪装前提消失） | 🔴 红 |

还原后 `voice_hook_reader.cpp` **不在本 PR 的改动文件列表里**，可核。

## 🔴 这一步证明不了什么

- **只到源码扫描 + 编译门这一层，证明不了运行时行为。** `voice_hook_reader.cpp` 由 `hibiki/windows/runner/CMakeLists.txt` 编译进 Flutter Windows runner，与 `native/galgame_hook/` 那 22 条 ctest **不是同一构建单元**，那些 ctest 一行都跑不到它。守卫只能保证"这两处源码事实同时成立或同时不成立"。
- **本 PR 不修任何用户可见问题**，尤其**没有**修管理员权限下捕获通道打不开那件事。它只是把一个差点发出去的崩溃挡在门外。
- **未做真机验证**——不涉及行为变更，无可验之新行为。

## 对 BUG-1216 调查记录的更正

- "存在零代价、不动 ACL 的旁路"——**划掉，不存在**。
- 该调查给的最小 DACL 形态 `(A;;GR;;;<用户SID>)` 只给读，**不够**，至少要到 `SECTION_MAP_WRITE`。
- 读端既然必须写，若对象带高完整性标签，Windows 默认 **NO_WRITE_UP 会直接挡掉写**，中完整性的 Hibiki 无解——除非提权或改对象 ACL/标签。即"可能绕不开信任边界"这一判断被**加强**。
- 仍不能排除用户那例是 helper 版本漂开而非 ACL；**以下一份带 token 的报错为准再定**。

## 验证

- `flutter analyze`（含 test）：`No issues found!`（退出码 0）
- `dart run tool/flutter_test_failures.dart --no-pub`：`PASSED - 5 tests ran, all tests passed`（退出码 0，含 per-file bug 守卫）
- `flutter build windows --release`：`√ Built build\windows\x64\runner\Release\hibiki.exe`（退出码 0）

BUG 记录：`docs/bugs/BUG-1225-shm-reader-write-access-must-stay.md`（原取 1224，开 PR 前重扫发现远端已占，走 `renumber` 改文件名/正文 H2/代码引用）