### PR TITLE
feat(gal): IPC v12 线程预览区 + 取消自动选文本线程（BUG-1193）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -60,7 +60,7 @@
 | [BUG-1196](bugs/BUG-1196-galgame-helper-drop-network-download.md) | ✅ | ✅ | 删除 helper 网络下载与后台自更新，只保留随主包归档 |
 | [BUG-1195](bugs/BUG-1195-vn-blank-tap-blocks-chrome.md) | ✅ | ✅ | 视觉小说模式点空白只翻页，控制栏（菜单）永远唤不出 |
 | [BUG-1194](bugs/BUG-1194-collection-reorder-nonvideo-order.md) | ✅ | ✅ | 视频合集详情页拖拽排序打乱非 video 成员的跨种类顺序 |
-| [BUG-1193](bugs/BUG-1193-galgame-luna-nonwinner-threads-dropped.md) | 🚧 | 🚧 | primed 后非赢家 hook 线程被 native 丢弃，无法像 LunaTranslator 那样切换 |
+| [BUG-1193](bugs/BUG-1193-galgame-luna-nonwinner-threads-dropped.md) | ✅ | ✅ | primed 后非赢家 hook 线程被 native 丢弃，无法像 LunaTranslator 那样切换 |
 | [BUG-1192](bugs/BUG-1192-galgame-steam-drm-load-error.md) | 🚧 | 🚧 | Steam 游戏直接启动撞 DRM 报 Application load error 3 |
 | [BUG-1191](bugs/BUG-1191-galgame-upscaling-per-game.md) | ✅ | ✅ | 窗口超分改为每游戏一档，入口挪进游戏卡右键菜单 |
 | [BUG-1190](bugs/BUG-1190-jimaku-title-dropdown-no-research.md) | ✅ | ✅ | 换番剧名后字幕来源不刷新 |

--- a/docs/bugs/BUG-1193-galgame-luna-nonwinner-threads-dropped.md
+++ b/docs/bugs/BUG-1193-galgame-luna-nonwinner-threads-dropped.md
@@ -26,8 +26,55 @@
 - **测试影响面指错**：原稿说要改 `luna_text_replay_test.cpp:170-215`，那段是 BUG-1159 的 face 用例、走不到 winner 门控；真正依赖 winner 行为的是 `tests/fixtures/luna_thread_selection.tsv`。
 - **🔴 一引擎一任务**：`LunaTextSelector` 是**引擎无关**的公共层，删 winner 门控是**全引擎行为变更**，不是「修一个 KiriKiriZ 症状」。按根 `CLAUDE.md` 与 `docs/agent/galgame-hooking.md`，动它必须有跨引擎负向测试，且每个受影响引擎的支持状态都要重新按证据门评估。
 
-- **[ ] ① 未修复** —— 方案需按上述四条重做；在真机量出「放开门控后单句产行数」与 `HIBIKI_LUNA_DIAG` 语言/hook_code 对应关系之前，不要动 `ShouldWrite`。
-- **[ ] ② 未加自动化测试** —— 至少需要：`tests/fixtures/luna_thread_selection.tsv` 的 winner 行为用例改写、「文本环被逐字重绘 hook 挤满时候选不得丢失」的负向用例、跨引擎负向测试。
+### 🔵 读 LunaTranslator 源码后的定案（2026-07-29）
+
+上面「其余待补证据」里那条『日文/中文来自不同 hook 是推断，未验证』**已经有确定答案**，来自上游源码
+（`HIllya51/LunaTranslator@v10.16.1.2`，与本仓 vendored DLL 同版本，`KiriKiri.cpp` 字节数一致）：
+
+1. **`EmbedKrkrZ` 带 `NO_CONTEXT`**（`engine32/KiriKiri.cpp:1544`），而 `texthook.cc:364` 有
+   `if (hp.type & (NO_CONTEXT | FIXING_SPLIT)) lpRetn = 0;` —— ctx 被强制清零后才组装
+   `ThreadParam tp{pid, address, lpRetn, lpSplit}`。**该 hook 的全部输出永远落在同一个 tp 上**，
+   中文与日文的 ThreadParam 逐字节相同。→ 猜测 (b)「同 hook 不同 ctx2」**排除**；
+   → 也意味着**在这条线程内部分不开中日**，任何"分线程"的做法都治不了它。
+2. **译文会经同一 hook 回流并被上报**：`texthook.cc:393` 的顺序是 `TextOutput(...)` 在前、内嵌替换
+   （`EMBED_AFTER_NEW` 改 `*plpdatain` 指针）在后；被替换的串会被游戏再走一遍流程再次撞上该 hook，
+   `checktranslatedok`（`embed_util.cc:267`）靠 `translatecache` 认出"这是我自己产的译文"后**只清
+   `EMBED_ABLE` 位、不 `__leave`**，因此译文照样被上报。原文/译文同线程交替是 Luna 架构下的已知现象。
+3. **Luna 采集层零淘汰**：`LunaHost/host.cpp:222-243` 每个 `ThreadParam` 一个 `TextThread`，全路径无
+   winner 分支；去重复（`textthread.cpp:5-12` `RemoveRepetition`）是**线程内部**的。Luna 能"正确分开"
+   靠的是**不丢弃**——用户切到 `TextRender` 那条纯日文线程即可，不是靠什么分离算法。
+
+**结论**：原始诉求（不丢非赢家线程）方向正确，但必须解掉 256 槽挤压与死结，且不能指望它能分开
+EmbedKrkrZ 内部的中日文。
+
+- **[x] ① 已修复** —— IPC v12（`native/galgame_hook/include/voice_hook_ipc.h`）新增**线程预览区**，并
+  取消 injector 自动选线程：
+  - **数据结构层解掉 256 槽挤压**：旧结构里文本环是唯一文本出口，同时伺候两个诉求相反的消费者——
+    语音配对要高信噪的单条线程，选择器要每条线程都有样本。v12 把二者拆开：文本环语义不变（仍只装
+    当前生效线程，配对/loopback 路径逐字节不受影响），新增的 `ThreadPreviewSlot` **按 thread_id 认领
+    固定槽**、每线程一条。按线程分槽而非全局取模，逐字重绘型 hook 只能覆盖自己的槽，**挤压跨线程
+    发生在结构上不可能**——不是加护栏，是让那种情况不存在。
+  - **死结随自动选线程一起消失**：原方案的死结来自「Dart 自动选线程 → 回写 `selected_text_thread_id`
+    → 重新激活过滤」。v12 不再有任何自动选择（`luna_text_selector.h` 的 winner 统计整体删除，
+    `ShouldWrite` → `AcceptsLine`），选择只来自用户显式操作或 profile `prefer=`，回环不存在。
+  - **`preferred_hook_codes` 快路已覆盖**：预览写入点在所有门控之前（`injector_main.cpp` 的
+    `WriteThreadPreview`，与 `NoteFace` 同一位置），profile 命中的游戏同样有预览。
+  - **跨会话记忆不被锁死**：`_maybeRestoreTextThread` 的消歧判据从已发布行数改为
+    `TexthookerTextThread.observedLineCount`（预览槽的 `line_count`，含被过滤/门控丢弃的行）。取消
+    自动选线程后已发布行数在用户选定前恒为 0，不换判据会让记忆永远无法恢复、每局都要重选。
+  - 消费端：`windows/runner` 新增 `PollThreadPreviews` + `pollThreadPreviews` MethodChannel；Dart 侧
+    `TexthookerService.applyTextThreadPreviews`，线程下拉的行数/预览改读观测值，空选项文案改为
+    `game_text_thread_unset`（不选 = 不发布，旧文案「全部线程」会误导）。
+- **[x] ② 已加自动化测试** ——
+  - `native/galgame_hook/tests/luna_text_replay_test.cpp`：新增「反复喂 16 行干净行也不得自动放行」
+    的守卫（防自动选线程以任何形式回归）+ face 登记必须在未选择阶段就发生；原 face/跨引擎/split H 码
+    负向用例改用 `AcceptsLine`。
+  - `native/galgame_hook/tests/fixtures/luna_thread_selection.tsv`：按 v12 契约重写（`hook_code` 列
+    随判定一并移除），`manual_thread==0` 全部期望不发布。
+  - `hibiki/test/sync/texthooker_service_test.dart`：新增 `v12 线程预览区` 6 例（未发布线程也有内容/
+    发现事件不抹预览/脏线程排序/替换非合并/无变化不通知/clear 清预览）。
+  - `hibiki/test/tools/voice_hook_ipc_contract_test.dart`：版本锁 11→12，新增预览区常量与结构体的
+    两侧同步守卫。
 - **备注**：
   - 修复须改 native 并**重新构建双架构 helper + 重发 release**，用户机上的 `voice_hook/x86` 才会拿到；开工前须按根 `CLAUDE.md` 读 `docs/agent/galgame-hooking.md` 并走证据门。
   - 本条从 PR#516 撤出单列（原 PR 只做超分改动 + Steam 定位），理由即上述四条。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 46852 (2756 per locale)
 ///
-/// Built on 2026-07-29 at 05:49 UTC
+/// Built on 2026-07-29 at 06:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -1484,7 +1484,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_text_source_unknown => 'Unknown source';
   String get game_text_source_websocket => 'WebSocket';
   String get game_text_thread => 'Text thread';
-  String get game_text_thread_all => 'All text threads';
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
   String get game_text_thread_hint =>
@@ -3705,6 +3704,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -6033,8 +6034,6 @@ class _StringsAr extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -10014,6 +10013,9 @@ class _StringsAr extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -12370,8 +12372,6 @@ class _StringsDe extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -16391,6 +16391,9 @@ class _StringsDe extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -18748,8 +18751,6 @@ class _StringsEs extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -22784,6 +22785,9 @@ class _StringsEs extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -25149,8 +25153,6 @@ class _StringsFr extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -29188,6 +29190,9 @@ class _StringsFr extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -31519,8 +31524,6 @@ class _StringsId extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -35521,6 +35524,9 @@ class _StringsId extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -37872,8 +37878,6 @@ class _StringsIt extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -41900,6 +41904,9 @@ class _StringsIt extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -44196,8 +44203,6 @@ class _StringsJa extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -48096,6 +48101,9 @@ class _StringsJa extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -50392,8 +50400,6 @@ class _StringsKo extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -54294,6 +54300,9 @@ class _StringsKo extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -56639,8 +56648,6 @@ class _StringsNl extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -60653,6 +60660,9 @@ class _StringsNl extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -63006,8 +63016,6 @@ class _StringsPtBr extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -67025,6 +67033,9 @@ class _StringsPtBr extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -69370,8 +69381,6 @@ class _StringsRu extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -73381,6 +73390,9 @@ class _StringsRu extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -75704,8 +75716,6 @@ class _StringsTh extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -79685,6 +79695,9 @@ class _StringsTh extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -82026,8 +82039,6 @@ class _StringsTr extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -86021,6 +86032,9 @@ class _StringsTr extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -88355,8 +88369,6 @@ class _StringsVi extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -92342,6 +92354,9 @@ class _StringsVi extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 // Path: <root>
@@ -94515,8 +94530,6 @@ class _StringsZhCn extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => '文本线程';
-  @override
-  String get game_text_thread_all => '全部文本线程';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} 行有音频';
@@ -98216,6 +98229,8 @@ class _StringsZhCn extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object n, required Object m}) =>
       '选中的 ${n} 项中有 ${m} 项已不存在，已跳过';
+  @override
+  String get game_text_thread_unset => '尚未选择线程 · 选一条后开始捕获';
 }
 
 // Path: <root>
@@ -100482,8 +100497,6 @@ class _StringsZhHk extends _StringsEn {
   String get game_text_source_websocket => 'WebSocket';
   @override
   String get game_text_thread => 'Text thread';
-  @override
-  String get game_text_thread_all => 'All text threads';
   @override
   String game_text_thread_audio_count({required Object count}) =>
       '${count} with audio';
@@ -104333,6 +104346,9 @@ class _StringsZhHk extends _StringsEn {
   String batch_selection_stale_skipped(
           {required Object m, required Object n}) =>
       'Skipped ${m} of ${n} selected items that no longer exist';
+  @override
+  String get game_text_thread_unset =>
+      'No thread selected — pick one to start capturing';
 }
 
 /// Flat map(s) containing all translations.
@@ -106398,8 +106414,6 @@ extension on _StringsEn {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -109979,6 +109993,8 @@ extension on _StringsEn {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -112045,8 +112061,6 @@ extension on _StringsAr {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -115623,6 +115637,8 @@ extension on _StringsAr {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -117692,8 +117708,6 @@ extension on _StringsDe {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -121288,6 +121302,8 @@ extension on _StringsDe {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -123358,8 +123374,6 @@ extension on _StringsEs {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -126952,6 +126966,8 @@ extension on _StringsEs {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -129025,8 +129041,6 @@ extension on _StringsFr {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -132622,6 +132636,8 @@ extension on _StringsFr {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -134690,8 +134706,6 @@ extension on _StringsId {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -138274,6 +138288,8 @@ extension on _StringsId {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -140344,8 +140360,6 @@ extension on _StringsIt {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -143941,6 +143955,8 @@ extension on _StringsIt {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -146000,8 +146016,6 @@ extension on _StringsJa {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -149570,6 +149584,8 @@ extension on _StringsJa {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -151630,8 +151646,6 @@ extension on _StringsKo {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -155203,6 +155217,8 @@ extension on _StringsKo {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -157272,8 +157288,6 @@ extension on _StringsNl {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -160863,6 +160877,8 @@ extension on _StringsNl {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -162931,8 +162947,6 @@ extension on _StringsPtBr {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -166520,6 +166534,8 @@ extension on _StringsPtBr {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -168591,8 +168607,6 @@ extension on _StringsRu {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -172182,6 +172196,8 @@ extension on _StringsRu {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -174246,8 +174262,6 @@ extension on _StringsTh {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -177828,6 +177842,8 @@ extension on _StringsTh {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -179897,8 +179913,6 @@ extension on _StringsTr {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -183483,6 +183497,8 @@ extension on _StringsTr {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -185549,8 +185565,6 @@ extension on _StringsVi {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -189133,6 +189147,8 @@ extension on _StringsVi {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }
@@ -191183,8 +191199,6 @@ extension on _StringsZhCn {
         return 'WebSocket';
       case 'game_text_thread':
         return '文本线程';
-      case 'game_text_thread_all':
-        return '全部文本线程';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} 行有音频';
       case 'game_text_thread_hint':
@@ -194737,6 +194751,8 @@ extension on _StringsZhCn {
       case 'batch_selection_stale_skipped':
         return ({required Object n, required Object m}) =>
             '选中的 ${n} 项中有 ${m} 项已不存在，已跳过';
+      case 'game_text_thread_unset':
+        return '尚未选择线程 · 选一条后开始捕获';
       default:
         return null;
     }
@@ -196795,8 +196811,6 @@ extension on _StringsZhHk {
         return 'WebSocket';
       case 'game_text_thread':
         return 'Text thread';
-      case 'game_text_thread_all':
-        return 'All text threads';
       case 'game_text_thread_audio_count':
         return ({required Object count}) => '${count} with audio';
       case 'game_text_thread_hint':
@@ -200361,6 +200375,8 @@ extension on _StringsZhHk {
       case 'batch_selection_stale_skipped':
         return ({required Object m, required Object n}) =>
             'Skipped ${m} of ${n} selected items that no longer exist';
+      case 'game_text_thread_unset':
+        return 'No thread selected — pick one to start capturing';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "未知来源",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "文本线程",
-  "game_text_thread_all": "全部文本线程",
   "game_text_thread_audio_count": "$count 行有音频",
   "game_text_thread_hint": "像 Luna Translator 一样选择干净的台词线程",
   "game_track_auto": "自动选择",
@@ -2754,5 +2753,6 @@
   "game_statistics": "游戏统计",
   "game_stat_by_game": "按游戏",
   "stat_clear_all_game_message": "确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。",
-  "batch_selection_stale_skipped": "选中的 $n 项中有 $m 项已不存在，已跳过"
+  "batch_selection_stale_skipped": "选中的 $n 项中有 $m 项已不存在，已跳过",
+  "game_text_thread_unset": "尚未选择线程 · 选一条后开始捕获"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1001,7 +1001,6 @@
   "game_text_source_unknown": "Unknown source",
   "game_text_source_websocket": "WebSocket",
   "game_text_thread": "Text thread",
-  "game_text_thread_all": "All text threads",
   "game_text_thread_audio_count": "$count with audio",
   "game_text_thread_hint": "Choose the clean dialogue thread, like Luna Translator",
   "game_track_auto": "Automatic selection",
@@ -2754,5 +2753,6 @@
   "game_statistics": "Game statistics",
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
-  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist"
+  "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
+  "game_text_thread_unset": "No thread selected — pick one to start capturing"
 }

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -2190,8 +2190,14 @@ class GalHookSessionController extends ChangeNotifier {
     TexthookerTextThread? best;
     for (final TexthookerTextThread thread in _textService.textThreads) {
       if (textThreadFingerprint(thread) != wanted) continue;
-      if (thread.lineCount < _textThreadRestoreMinLines) continue;
-      if (best == null || thread.lineCount > best.lineCount) best = thread;
+      // 🔴 判据必须用 observedLineCount（native 观测总行数），**不能**用 lineCount
+      // （已发布行数）。v12 取消自动选线程后，用户选定之前文本环恒空、lineCount 对所有
+      // 线程都是 0，用它做判据会让这里永远选不出候选 → 记忆永远恢复不了 → 每次开游戏
+      // 都要重新手选。这正是「第一次由用户选」与「之后自动恢复」能同时成立的关键。
+      if (thread.observedLineCount < _textThreadRestoreMinLines) continue;
+      if (best == null || thread.observedLineCount > best.observedLineCount) {
+        best = thread;
+      }
     }
     if (best == null) return;
     _textThreadMemoryApplied = true;
@@ -3167,6 +3173,29 @@ class GalHookSessionController extends ChangeNotifier {
     await source?.stop();
   }
 
+  /// 拉一次 native 线程预览快照并合进线程目录。
+  ///
+  /// 预览是**全量快照**，没有游标，漏一次不会丢数据；因此这里失败静默返回即可，不需要
+  /// 补偿逻辑。native 不支持（旧 helper）返回 null，此时选择器退回旧行为（只有已发布
+  /// 线程有内容）——不崩，只是选不动，与升级 helper 前的现状一致。
+  Future<void> _pollThreadPreviews(EngineHookGalAudioSource engine) async {
+    final List<GalTextThreadPreview>? previews =
+        await engine.pollThreadPreviews();
+    if (previews == null || engine != _engineSource) return;
+    _textService.applyTextThreadPreviews(<TexthookerThreadPreview>[
+      for (final GalTextThreadPreview preview in previews)
+        TexthookerThreadPreview(
+          nativeThreadId: preview.threadId,
+          text: preview.text,
+          observedLineCount: preview.lineCount,
+          observedArtifactCount: preview.artifactCount,
+          isArtifact: preview.isArtifact,
+        ),
+    ]);
+    // 预览带来了新的观测行数，跨会话记忆的消歧条件可能刚刚成立。
+    _maybeRestoreTextThread();
+  }
+
   Future<void> _pollHookedText() async {
     if (_pollInFlight) return;
     final EngineHookGalAudioSource? engine = _engineSource;
@@ -3174,6 +3203,10 @@ class GalHookSessionController extends ChangeNotifier {
     _pollInFlight = true;
     try {
       await _refreshReadinessThrottled(engine);
+      if (engine != _engineSource) return;
+      // v12：预览区与文本环是两份独立数据，必须各poll各的。文本环在用户选定线程之前
+      // 恒空，只轮询它会让选择器永远是一列空壳——那正是本次要修的症状。
+      await _pollThreadPreviews(engine);
       if (engine != _engineSource) return;
       final GalTextPoll? poll = await engine.pollText(_lastTextSeq);
       if (poll == null || engine != _engineSource) return;

--- a/hibiki/lib/src/mining/galgame_audio_source.dart
+++ b/hibiki/lib/src/mining/galgame_audio_source.dart
@@ -1434,7 +1434,44 @@ class EngineHookGalAudioSource implements GalAudioSource {
     }
   }
 
-  /// 选择 Luna 文本线程。null/0 恢复 helper 自动选择；非 0 时 helper 只发布该线程。
+  /// v12 线程预览区：取**每条线程**的最近一行与观测行数，含尚未被选中的线程。
+  ///
+  /// 与 [pollText] 的区别是数据来源不同，不是同一份数据的两种视图：[pollText] 读文本环
+  /// （只有当前生效线程的行），本方法读按线程分槽的预览区（所有线程都有）。全量快照、
+  /// 无游标——预览槽按 thread id 寻址，不存在「漏读就被覆盖」的问题。
+  Future<List<GalTextThreadPreview>?> pollThreadPreviews() async {
+    try {
+      final Map<Object?, Object?>? r =
+          await _channel.invokeMethod<Map<Object?, Object?>>(
+        'pollThreadPreviews',
+      );
+      if (r == null) return null;
+      final List<Object?> raw =
+          (r['previews'] as List<Object?>?) ?? const <Object?>[];
+      final List<GalTextThreadPreview> previews = <GalTextThreadPreview>[];
+      for (final Object? e in raw) {
+        if (e is! Map) continue;
+        final Object? threadId = e['threadId'];
+        if (threadId is! int || threadId == 0) continue;
+        previews.add(GalTextThreadPreview(
+          threadId: threadId,
+          text: (e['text'] as String?) ?? '',
+          timestampMs: (e['ts'] as int?) ?? 0,
+          lineCount: (e['lineCount'] as int?) ?? 0,
+          artifactCount: (e['artifactCount'] as int?) ?? 0,
+          eventFlags: (e['eventFlags'] as int?) ?? 0,
+        ));
+      }
+      return previews;
+    } on PlatformException {
+      return null;
+    } on MissingPluginException {
+      return null;
+    }
+  }
+
+  /// 选择 Luna 文本线程。0/null 清除选择（v12 起清除后不再发布任何行，**不会**回到
+  /// 自动选择）；非 0 时 helper 只发布该线程。
   Future<bool> selectTextThread(int? threadId) async {
     try {
       final Map<Object?, Object?>? result =
@@ -1856,6 +1893,34 @@ class GalTextPoll {
   const GalTextPoll({required this.count, required this.lines});
   final int count;
   final List<GalHookedLine> lines;
+}
+
+/// v12 线程预览区里的一条快照：某条 Luna 文本线程的最近一行 + 观测统计。
+///
+/// [lineCount] 是 native 观测到的**全部**行数（含被伪影过滤和线程门控丢弃的），与
+/// 「已发布行数」不是一回事。v12 取消自动选线程后，用户选定之前已发布行数对所有线程
+/// 恒为 0，凡是判断线程活跃度/可选性/记忆恢复都必须用本字段。
+class GalTextThreadPreview {
+  const GalTextThreadPreview({
+    required this.threadId,
+    required this.text,
+    this.timestampMs = 0,
+    this.lineCount = 0,
+    this.artifactCount = 0,
+    this.eventFlags = 0,
+  });
+
+  /// native 侧 `ThreadPreviewSlot::event_flags` 的伪影位。
+  static const int flagArtifact = 0x1;
+
+  final int threadId;
+  final String text;
+  final int timestampMs;
+  final int lineCount;
+  final int artifactCount;
+  final int eventFlags;
+
+  bool get isArtifact => (eventFlags & flagArtifact) != 0;
 }
 
 enum GalTextEventKind {

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -1400,16 +1400,21 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                       ? selectedTextThreadKey
                       : '',
                   entries: <GamepadDropdownEntry<String>>[
-                    (value: '', label: t.game_text_thread_all),
+                    // v12：空值不再是「全部线程」——不选就一行都不发布。标签必须如实
+                    // 说明，否则用户会以为不选也在抓，然后奇怪为什么没有台词。
+                    (value: '', label: t.game_text_thread_unset),
                     for (final TexthookerTextThread thread in textThreads)
                       (
                         value: thread.key,
                         // 同一 hook 面在不同调用上下文会报成多条同 label 线程；
                         // assignThreadDisplayLabels 给重名线程补 `#N` 序号，避免下拉
                         // 里出现一整列一模一样的 `TextRender · 0x… · 0`。
+                        // 行数用 observedLineCount（native 观测总行数）而不是已发布
+                        // 行数：v12 起未被选中的线程一行都不发布，用已发布行数会让
+                        // 每条候选都显示 `· 0`，用户还是没法判断该选哪条。
                         label:
                             '${threadDisplayLabels[thread.key] ?? thread.label}'
-                            ' · ${thread.lineCount}',
+                            ' · ${thread.observedLineCount}',
                       ),
                   ],
                   // 每条线程第二行：有音频行数 + 最近台词预览——没有预览用户
@@ -1420,7 +1425,9 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                       if (thread.key == key) {
                         return texthookerThreadSubtitle(
                           audioLineCount: thread.audioLineCount,
-                          latestText: thread.latestText,
+                          // 预览优先取已发布台词，回落 native 预览行——未被选中的
+                          // 线程只有后者，而那正是用户挑线程时唯一能看的东西。
+                          latestText: thread.displayPreviewText,
                           audioLabel: t.game_text_thread_audio_count(
                             count: thread.audioLineCount,
                           ),

--- a/hibiki/lib/src/sync/texthooker_service.dart
+++ b/hibiki/lib/src/sync/texthooker_service.dart
@@ -167,21 +167,70 @@ class TexthookerTextThread {
     this.nativeThreadId,
     this.latestText,
     this.audioLineCount = 0,
+    this.previewText,
+    this.observedLineCount = 0,
+    this.observedArtifactCount = 0,
+    this.previewIsArtifact = false,
   });
 
   final String key;
   final String label;
   final String? hookCode;
   final int? nativeThreadId;
+
+  /// 已**发布**到文本环的行数（即当前生效线程的行）。v12 起未被选中的线程恒为 0，
+  /// 判断「这条线程有没有内容」必须用 [observedLineCount]，不是本字段。
   final int lineCount;
   final DateTime latestAt;
 
-  /// 该线程最近一条台词原文（线程选择下拉的预览；尚无台词为 null）。
+  /// 该线程最近一条**已发布**台词原文（尚无已发布台词为 null）。
   final String? latestText;
 
   /// 该线程已配到句音的行数（[TexthookerLineEntry.hasAudio] 计数；语音线程
   /// 通常≈lineCount，UI 线程为 0——选择下拉靠它区分「选哪个」）。
   final int audioLineCount;
+
+  /// native 线程预览区里该线程的最近一行（v12）。**不受线程选择门控影响**：未被选中
+  /// 的线程也有值，这正是选择器能像 LunaTranslator 那样展示全部候选的来源。
+  final String? previewText;
+
+  /// native 观测到的该线程总行数，**含被伪影过滤和线程门控丢弃的**。
+  ///
+  /// 它和 [lineCount] 的区别是本次改动的关键：v12 取消自动选线程后，用户选定之前
+  /// 文本环恒空，[lineCount] 对所有线程都是 0。凡是「这条线程活不活跃 / 该不该排前面 /
+  /// 跨会话记忆能不能认回它」这类判断，都必须读本字段。
+  final int observedLineCount;
+
+  /// [observedLineCount] 中被判为重复伪影的行数。UI 据此把脏线程标出来而不是藏掉
+  /// （对齐 LunaTranslator：逐字重绘那条一直显示，只是你不选它）。
+  final int observedArtifactCount;
+
+  /// 预览里这最近一行是否被判为伪影。
+  final bool previewIsArtifact;
+
+  /// 下拉展示用的预览文本：优先已发布台词，回落 native 预览行。
+  String? get displayPreviewText => latestText ?? previewText;
+
+  /// 该线程是否出过内容（发布与否无关）。
+  bool get hasObservedLines => observedLineCount > 0 || lineCount > 0;
+}
+
+/// native 线程预览区的一条快照（v12）。按 native thread id 对齐到线程目录。
+@immutable
+class TexthookerThreadPreview {
+  const TexthookerThreadPreview({
+    required this.nativeThreadId,
+    required this.text,
+    required this.observedLineCount,
+    required this.observedArtifactCount,
+    required this.isArtifact,
+  });
+
+  final int nativeThreadId;
+  final String text;
+  final int observedLineCount;
+  final int observedArtifactCount;
+  final bool isArtifact;
 }
 
 @immutable
@@ -357,7 +406,37 @@ class TexthookerService extends ChangeNotifier {
         latestText: entry.text,
         audioLineCount:
             (previous?.audioLineCount ?? 0) + (entry.hasAudio ? 1 : 0),
+        previewText: previous?.previewText,
+        observedLineCount: previous?.observedLineCount ?? 0,
+        observedArtifactCount: previous?.observedArtifactCount ?? 0,
+        previewIsArtifact: previous?.previewIsArtifact ?? false,
       );
+    }
+    // native 预览按 thread id 对齐：线程目录的 key 是 Dart 侧字符串，预览区只知道
+    // native thread id，故在这里合流而不是在写入侧——写入侧拿不到 key 映射。
+    if (_threadPreviews.isNotEmpty) {
+      for (final MapEntry<String, TexthookerTextThread> entry
+          in byKey.entries) {
+        final int? nativeId = entry.value.nativeThreadId;
+        if (nativeId == null) continue;
+        final TexthookerThreadPreview? preview = _threadPreviews[nativeId];
+        if (preview == null) continue;
+        final TexthookerTextThread thread = entry.value;
+        byKey[entry.key] = TexthookerTextThread(
+          key: thread.key,
+          label: thread.label,
+          hookCode: thread.hookCode,
+          nativeThreadId: thread.nativeThreadId,
+          lineCount: thread.lineCount,
+          latestAt: thread.latestAt,
+          latestText: thread.latestText,
+          audioLineCount: thread.audioLineCount,
+          previewText: preview.text.isEmpty ? thread.previewText : preview.text,
+          observedLineCount: preview.observedLineCount,
+          observedArtifactCount: preview.observedArtifactCount,
+          previewIsArtifact: preview.isArtifact,
+        );
+      }
     }
     final List<TexthookerTextThread> result = byKey.values.toList()
       ..sort(_compareTextThreads);
@@ -396,6 +475,10 @@ class TexthookerService extends ChangeNotifier {
             latestAt: thread.latestAt,
             latestText: thread.latestText,
             audioLineCount: thread.audioLineCount,
+            previewText: thread.previewText,
+            observedLineCount: thread.observedLineCount,
+            observedArtifactCount: thread.observedArtifactCount,
+            previewIsArtifact: thread.previewIsArtifact,
           ),
     ];
   }
@@ -412,17 +495,73 @@ class TexthookerService extends ChangeNotifier {
   /// 线程的 `latestAt` 顶到当下，导致刚发现、尚无文本的线程压过真正在出台词的线程
   /// （用户看到列表最前面一堆 `· 0`）。有台词优先让「该选哪条」一眼可见（对齐 Luna
   /// 「选择文本」把有内容的线程排在前面的行为）。纯函数、静态，供 [textThreads] 复用。
+  ///
+  /// v12：判据从「已发布行数」改成 [TexthookerTextThread.hasObservedLines]。取消自动选
+  /// 线程后，用户选定之前所有线程的 `lineCount` 都是 0，旧判据会退化成「只按时间排」，
+  /// 又把刚发现的空线程顶回最前——正是本函数当初要修的那个症状换个方式复发。
   static int _compareTextThreads(
     TexthookerTextThread a,
     TexthookerTextThread b,
   ) {
-    final bool aHasLines = a.lineCount > 0;
-    final bool bHasLines = b.lineCount > 0;
-    if (aHasLines != bHasLines) return aHasLines ? -1 : 1;
+    if (a.hasObservedLines != b.hasObservedLines) {
+      return a.hasObservedLines ? -1 : 1;
+    }
     if (a.audioLineCount != b.audioLineCount) {
       return b.audioLineCount.compareTo(a.audioLineCount);
     }
+    // 干净线程排在脏线程之前：伪影占比低者优先。脏线程仍然可见可选（对齐 Luna），
+    // 只是不该挡在真台词前面。
+    final bool aDirty = a.observedArtifactCount * 2 > a.observedLineCount &&
+        a.observedLineCount > 0;
+    final bool bDirty = b.observedArtifactCount * 2 > b.observedLineCount &&
+        b.observedLineCount > 0;
+    if (aDirty != bDirty) return aDirty ? 1 : -1;
+    if (a.observedLineCount != b.observedLineCount) {
+      return b.observedLineCount.compareTo(a.observedLineCount);
+    }
     return b.latestAt.compareTo(a.latestAt);
+  }
+
+  /// native thread id → 该线程的预览快照（v12 线程预览区的全量快照，每次轮询整体替换）。
+  final Map<int, TexthookerThreadPreview> _threadPreviews =
+      <int, TexthookerThreadPreview>{};
+
+  /// 用 native 的线程预览快照整体替换本地副本。
+  ///
+  /// 是**替换**不是合并：预览区本身就是全量快照（每线程恒一条），合并只会让已经消失的
+  /// 线程永远留在列表里。会话结束由 [clearTextThreadPreviews] 清。
+  void applyTextThreadPreviews(List<TexthookerThreadPreview> previews) {
+    bool changed = previews.length != _threadPreviews.length;
+    if (!changed) {
+      for (final TexthookerThreadPreview preview in previews) {
+        final TexthookerThreadPreview? existing =
+            _threadPreviews[preview.nativeThreadId];
+        if (existing == null ||
+            existing.text != preview.text ||
+            existing.observedLineCount != preview.observedLineCount ||
+            existing.observedArtifactCount != preview.observedArtifactCount ||
+            existing.isArtifact != preview.isArtifact) {
+          changed = true;
+          break;
+        }
+      }
+    }
+    if (!changed) return; // 无变化不通知，避免每次轮询都重建线程下拉
+    _threadPreviews
+      ..clear()
+      ..addEntries(
+        previews.map(
+          (TexthookerThreadPreview p) =>
+              MapEntry<int, TexthookerThreadPreview>(p.nativeThreadId, p),
+        ),
+      );
+    notifyListeners();
+  }
+
+  void clearTextThreadPreviews() {
+    if (_threadPreviews.isEmpty) return;
+    _threadPreviews.clear();
+    notifyListeners();
   }
 
   void registerTextThread({
@@ -448,6 +587,12 @@ class TexthookerService extends ChangeNotifier {
       latestAt: previous != null && previous.latestAt.isAfter(observedAt)
           ? previous.latestAt
           : observedAt,
+      // 线程发现事件不携带内容，但**不得清掉已有预览**：ThreadCreate 会在同一条线程上
+      // 重复触发，清掉等于每次重新发现都把用户刚看到的预览抹成空白。
+      previewText: previous?.previewText,
+      observedLineCount: previous?.observedLineCount ?? 0,
+      observedArtifactCount: previous?.observedArtifactCount ?? 0,
+      previewIsArtifact: previous?.previewIsArtifact ?? false,
     );
     notifyListeners();
   }
@@ -559,9 +704,16 @@ class TexthookerService extends ChangeNotifier {
   }
 
   void clear() {
-    if (_entries.isEmpty && _discoveredTextThreads.isEmpty) return;
+    if (_entries.isEmpty &&
+        _discoveredTextThreads.isEmpty &&
+        _threadPreviews.isEmpty) {
+      return;
+    }
     _entries.clear();
     _discoveredTextThreads.clear();
+    // 预览必须一并清：它是**会话级**快照，thread id 含 processId，跨会话残留会让上一局
+    // 的预览挂在这一局的空线程上，用户照着选到一条死线程。
+    _threadPreviews.clear();
     notifyListeners();
   }
 }

--- a/hibiki/test/mining/gal_capture_audio_integrity_test.dart
+++ b/hibiki/test/mining/gal_capture_audio_integrity_test.dart
@@ -301,7 +301,10 @@ void main() {
     test('文本线程记忆：指纹匹配且够行数才恢复，用户手选覆盖记忆', () async {
       final TexthookerService service = TexthookerService.test();
       final ChangeNotifier endpoints = ChangeNotifier();
-      final _FakeEngine engine = _FakeEngine(readyFormat: kPcm);
+      final _FakeEngine engine = _FakeEngine(
+        readyFormat: kPcm,
+        enforceTextSelection: true,
+      );
       final GalHookSessionController controller = build(
         service: service,
         endpoints: endpoints,
@@ -318,36 +321,56 @@ void main() {
             store[gameKey] = memory,
       );
       await controller.launchGame(r'D:\Games\fake.exe');
+      engine.enqueue(
+        const GalHookedLine(
+          seq: 1,
+          timestampMs: 500,
+          text: '',
+          threadId: 7,
+          sourceKind: 2,
+          eventKind: GalTextEventKind.threadDiscovered,
+          hookName: 'CodeX',
+          hookCode: 'HB4@459F50',
+        ),
+      );
 
       // 前两行不足门限（3 行）：不得恢复，避免开局蹦一行的 UI 线程把选择钉死。
       for (int i = 1; i <= 2; i++) {
         engine.enqueue(
           GalHookedLine(
-            seq: i,
+            seq: i + 1,
             timestampMs: 1000 * i,
             text: 'せりふ$i',
             threadId: 7,
+            sourceKind: 2,
             hookName: 'CodeX',
             hookCode: 'HB4@459F50',
           ),
         );
       }
-      await waitUntil(() => service.entries.length >= 2);
+      await waitUntil(
+        () =>
+            service.textThreads.length == 1 &&
+            service.textThreads.single.observedLineCount == 2,
+      );
+      expect(service.entries, isEmpty, reason: 'v12 未选线程前文本环必须为空，观测行只存在预览区');
       expect(controller.selectedTextThreadKey, isNull);
 
-      // 第三行到达 -> 达到门限，按指纹恢复。
+      // 第三条预览到达 -> 达到门限，按指纹恢复；恢复后文本环才发布该线程的行。
       engine.enqueue(
         const GalHookedLine(
-          seq: 3,
+          seq: 4,
           timestampMs: 3000,
           text: 'せりふ3',
           threadId: 7,
+          sourceKind: 2,
           hookName: 'CodeX',
           hookCode: 'HB4@459F50',
         ),
       );
       await waitUntil(() => controller.selectedTextThreadKey != null);
-      expect(controller.selectedTextThreadKey, isNotNull);
+      expect(controller.selectedNativeTextThreadId, 7);
+      await waitUntil(() => service.entries.length == 3);
 
       // 用户改选「全部」：记忆被清掉，不再自动恢复。
       await controller.selectTextThread(null, remember: true);
@@ -415,11 +438,14 @@ void main() {
 class _FakeEngine extends EngineHookGalAudioSource {
   _FakeEngine({
     this.readyFormat,
+    this.enforceTextSelection = false,
   }) : super(targetPid: 0, launchExe: 'fake.exe', injectorPath: 'fake.exe');
 
   final PcmFormat? readyFormat;
+  final bool enforceTextSelection;
   List<GalAudioTrack> tracks = <GalAudioTrack>[];
   final List<GalHookedLine> _pending = <GalHookedLine>[];
+  int? _selectedTextThreadId;
 
   void enqueue(GalHookedLine line) => _pending.add(line);
 
@@ -447,13 +473,42 @@ class _FakeEngine extends EngineHookGalAudioSource {
   @override
   Future<GalTextPoll?> pollText(int fromSeq) async {
     final List<GalHookedLine> fresh = _pending
-        .where((GalHookedLine line) => line.seq > fromSeq)
+        .where(
+          (GalHookedLine line) =>
+              line.seq > fromSeq &&
+              (line.eventKind == GalTextEventKind.threadDiscovered ||
+                  !enforceTextSelection ||
+                  line.threadId == _selectedTextThreadId),
+        )
         .toList(growable: false);
     return GalTextPoll(count: _pending.length, lines: fresh);
   }
 
   @override
-  Future<bool> selectTextThread(int? threadId) async => true;
+  Future<List<GalTextThreadPreview>?> pollThreadPreviews() async {
+    final Map<int, List<GalHookedLine>> byThread = <int, List<GalHookedLine>>{};
+    for (final GalHookedLine line in _pending) {
+      if (line.eventKind != GalTextEventKind.line || line.threadId == 0) {
+        continue;
+      }
+      byThread.putIfAbsent(line.threadId, () => <GalHookedLine>[]).add(line);
+    }
+    return <GalTextThreadPreview>[
+      for (final MapEntry<int, List<GalHookedLine>> entry in byThread.entries)
+        GalTextThreadPreview(
+          threadId: entry.key,
+          text: entry.value.last.text,
+          timestampMs: entry.value.last.timestampMs,
+          lineCount: entry.value.length,
+        ),
+    ];
+  }
+
+  @override
+  Future<bool> selectTextThread(int? threadId) async {
+    _selectedTextThreadId = threadId;
+    return true;
+  }
 
   @override
   Future<GalAudioSlice?> grabUtterance(

--- a/hibiki/test/sync/texthooker_service_test.dart
+++ b/hibiki/test/sync/texthooker_service_test.dart
@@ -401,4 +401,163 @@ void main() {
         threads.map((t) => t.key).toList());
     expect(disambiguated[0].lineCount, 160);
   });
+
+  group('v12 线程预览区', () {
+    // 未被选中的线程在文本环里一行都没有（v12 取消了自动选线程），它们能不能在选择器里
+    // 显示内容、能不能被排序、能不能被跨会话记忆认回，全靠预览区这一份独立数据。
+    test('预览让未发布的线程也有内容和行数', () {
+      final TexthookerService svc = TexthookerService.instance;
+      svc.registerTextThread(
+        key: 'luna:aa',
+        label: 'TextRender · 0x1',
+        nativeThreadId: 111,
+      );
+
+      // 只发现、无预览：既没有已发布行，也没有观测行。
+      TexthookerTextThread thread = svc.textThreads.single;
+      expect(thread.lineCount, 0);
+      expect(thread.observedLineCount, 0);
+      expect(thread.displayPreviewText, isNull);
+      expect(thread.hasObservedLines, isFalse);
+
+      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
+        TexthookerThreadPreview(
+          nativeThreadId: 111,
+          text: '可愛らしい声がオレを呼び止める。',
+          observedLineCount: 7,
+          observedArtifactCount: 0,
+          isArtifact: false,
+        ),
+      ]);
+
+      thread = svc.textThreads.single;
+      // 已发布行数仍是 0 —— 这条线程没被选中，本就不该有已发布行。
+      expect(thread.lineCount, 0);
+      // 但观测行数和预览文本到位了，用户因此能判断该不该选它。
+      expect(thread.observedLineCount, 7);
+      expect(thread.previewText, '可愛らしい声がオレを呼び止める。');
+      expect(thread.displayPreviewText, '可愛らしい声がオレを呼び止める。');
+      expect(thread.hasObservedLines, isTrue);
+    });
+
+    test('线程发现事件不得抹掉已有预览', () {
+      final TexthookerService svc = TexthookerService.instance;
+      svc.registerTextThread(key: 'luna:aa', label: 'A', nativeThreadId: 111);
+      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
+        TexthookerThreadPreview(
+          nativeThreadId: 111,
+          text: 'keep me',
+          observedLineCount: 3,
+          observedArtifactCount: 0,
+          isArtifact: false,
+        ),
+      ]);
+      // ThreadCreate 会在同一条线程上重复触发。
+      svc.registerTextThread(key: 'luna:aa', label: 'A', nativeThreadId: 111);
+      expect(svc.textThreads.single.previewText, 'keep me');
+      expect(svc.textThreads.single.observedLineCount, 3);
+    });
+
+    test('排序：有观测行的排前面，脏线程排后面', () {
+      final TexthookerService svc = TexthookerService.instance;
+      svc.registerTextThread(
+          key: 'luna:empty', label: 'Empty', nativeThreadId: 1);
+      svc.registerTextThread(
+          key: 'luna:dirty', label: 'Dirty', nativeThreadId: 2);
+      svc.registerTextThread(
+          key: 'luna:clean', label: 'Clean', nativeThreadId: 3);
+      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
+        // 逐字重绘型 hook：行多但绝大多数是伪影。
+        TexthookerThreadPreview(
+          nativeThreadId: 2,
+          text: '男男男男男子子',
+          observedLineCount: 90,
+          observedArtifactCount: 80,
+          isArtifact: true,
+        ),
+        TexthookerThreadPreview(
+          nativeThreadId: 3,
+          text: '「あの……保科君」',
+          observedLineCount: 9,
+          observedArtifactCount: 0,
+          isArtifact: false,
+        ),
+      ]);
+
+      final List<String> order =
+          svc.textThreads.map((TexthookerTextThread t) => t.key).toList();
+      // 干净线程第一，脏线程仍然可见（对齐 Luna：不藏，只是排后面），空线程垫底。
+      expect(order, <String>['luna:clean', 'luna:dirty', 'luna:empty']);
+    });
+
+    test('applyTextThreadPreviews 是替换不是合并', () {
+      final TexthookerService svc = TexthookerService.instance;
+      svc.registerTextThread(key: 'luna:a', label: 'A', nativeThreadId: 1);
+      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
+        TexthookerThreadPreview(
+          nativeThreadId: 1,
+          text: 'first',
+          observedLineCount: 2,
+          observedArtifactCount: 0,
+          isArtifact: false,
+        ),
+      ]);
+      expect(svc.textThreads.single.previewText, 'first');
+
+      // 空快照（helper 重启/会话切换）必须让预览消失，而不是留着上一局的残影。
+      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[]);
+      expect(svc.textThreads.single.previewText, isNull);
+      expect(svc.textThreads.single.observedLineCount, 0);
+    });
+
+    test('无变化的快照不触发通知', () {
+      final TexthookerService svc = TexthookerService.instance;
+      svc.registerTextThread(key: 'luna:a', label: 'A', nativeThreadId: 1);
+      const List<TexthookerThreadPreview> snapshot = <TexthookerThreadPreview>[
+        TexthookerThreadPreview(
+          nativeThreadId: 1,
+          text: 'same',
+          observedLineCount: 5,
+          observedArtifactCount: 1,
+          isArtifact: false,
+        ),
+      ];
+      svc.applyTextThreadPreviews(snapshot);
+
+      int notifications = 0;
+      void listener() => notifications++;
+      svc.addListener(listener);
+      // 轮询每 400ms 一次，内容没变就重建下拉会让选择器一直闪。
+      svc.applyTextThreadPreviews(snapshot);
+      expect(notifications, 0);
+      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
+        TexthookerThreadPreview(
+          nativeThreadId: 1,
+          text: 'changed',
+          observedLineCount: 6,
+          observedArtifactCount: 1,
+          isArtifact: false,
+        ),
+      ]);
+      expect(notifications, 1);
+      svc.removeListener(listener);
+    });
+
+    test('clear 一并清掉预览（thread id 含 processId，跨会话不可复用）', () {
+      final TexthookerService svc = TexthookerService.instance;
+      svc.registerTextThread(key: 'luna:a', label: 'A', nativeThreadId: 1);
+      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
+        TexthookerThreadPreview(
+          nativeThreadId: 1,
+          text: 'stale',
+          observedLineCount: 4,
+          observedArtifactCount: 0,
+          isArtifact: false,
+        ),
+      ]);
+      svc.clear();
+      svc.registerTextThread(key: 'luna:a', label: 'A', nativeThreadId: 1);
+      expect(svc.textThreads.single.previewText, isNull);
+    });
+  });
 }

--- a/hibiki/test/sync/texthooker_service_test.dart
+++ b/hibiki/test/sync/texthooker_service_test.dart
@@ -1,6 +1,21 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/sync/texthooker_service.dart';
 
+TexthookerThreadPreview preview({
+  required int threadId,
+  required String text,
+  required int lineCount,
+  int artifactCount = 0,
+  bool isArtifact = false,
+}) =>
+    TexthookerThreadPreview(
+      nativeThreadId: threadId,
+      text: text,
+      observedLineCount: lineCount,
+      observedArtifactCount: artifactCount,
+      isArtifact: isArtifact,
+    );
+
 void main() {
   setUp(() => TexthookerService.instance.clear());
 
@@ -420,13 +435,11 @@ void main() {
       expect(thread.displayPreviewText, isNull);
       expect(thread.hasObservedLines, isFalse);
 
-      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
-        TexthookerThreadPreview(
-          nativeThreadId: 111,
+      svc.applyTextThreadPreviews(<TexthookerThreadPreview>[
+        preview(
+          threadId: 111,
           text: '可愛らしい声がオレを呼び止める。',
-          observedLineCount: 7,
-          observedArtifactCount: 0,
-          isArtifact: false,
+          lineCount: 7,
         ),
       ]);
 
@@ -443,13 +456,11 @@ void main() {
     test('线程发现事件不得抹掉已有预览', () {
       final TexthookerService svc = TexthookerService.instance;
       svc.registerTextThread(key: 'luna:aa', label: 'A', nativeThreadId: 111);
-      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
-        TexthookerThreadPreview(
-          nativeThreadId: 111,
+      svc.applyTextThreadPreviews(<TexthookerThreadPreview>[
+        preview(
+          threadId: 111,
           text: 'keep me',
-          observedLineCount: 3,
-          observedArtifactCount: 0,
-          isArtifact: false,
+          lineCount: 3,
         ),
       ]);
       // ThreadCreate 会在同一条线程上重复触发。
@@ -466,21 +477,19 @@ void main() {
           key: 'luna:dirty', label: 'Dirty', nativeThreadId: 2);
       svc.registerTextThread(
           key: 'luna:clean', label: 'Clean', nativeThreadId: 3);
-      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
+      svc.applyTextThreadPreviews(<TexthookerThreadPreview>[
         // 逐字重绘型 hook：行多但绝大多数是伪影。
-        TexthookerThreadPreview(
-          nativeThreadId: 2,
+        preview(
+          threadId: 2,
           text: '男男男男男子子',
-          observedLineCount: 90,
-          observedArtifactCount: 80,
+          lineCount: 90,
+          artifactCount: 80,
           isArtifact: true,
         ),
-        TexthookerThreadPreview(
-          nativeThreadId: 3,
+        preview(
+          threadId: 3,
           text: '「あの……保科君」',
-          observedLineCount: 9,
-          observedArtifactCount: 0,
-          isArtifact: false,
+          lineCount: 9,
         ),
       ]);
 
@@ -493,13 +502,11 @@ void main() {
     test('applyTextThreadPreviews 是替换不是合并', () {
       final TexthookerService svc = TexthookerService.instance;
       svc.registerTextThread(key: 'luna:a', label: 'A', nativeThreadId: 1);
-      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
-        TexthookerThreadPreview(
-          nativeThreadId: 1,
+      svc.applyTextThreadPreviews(<TexthookerThreadPreview>[
+        preview(
+          threadId: 1,
           text: 'first',
-          observedLineCount: 2,
-          observedArtifactCount: 0,
-          isArtifact: false,
+          lineCount: 2,
         ),
       ]);
       expect(svc.textThreads.single.previewText, 'first');
@@ -513,13 +520,12 @@ void main() {
     test('无变化的快照不触发通知', () {
       final TexthookerService svc = TexthookerService.instance;
       svc.registerTextThread(key: 'luna:a', label: 'A', nativeThreadId: 1);
-      const List<TexthookerThreadPreview> snapshot = <TexthookerThreadPreview>[
-        TexthookerThreadPreview(
-          nativeThreadId: 1,
+      final List<TexthookerThreadPreview> snapshot = <TexthookerThreadPreview>[
+        preview(
+          threadId: 1,
           text: 'same',
-          observedLineCount: 5,
-          observedArtifactCount: 1,
-          isArtifact: false,
+          lineCount: 5,
+          artifactCount: 1,
         ),
       ];
       svc.applyTextThreadPreviews(snapshot);
@@ -530,13 +536,12 @@ void main() {
       // 轮询每 400ms 一次，内容没变就重建下拉会让选择器一直闪。
       svc.applyTextThreadPreviews(snapshot);
       expect(notifications, 0);
-      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
-        TexthookerThreadPreview(
-          nativeThreadId: 1,
+      svc.applyTextThreadPreviews(<TexthookerThreadPreview>[
+        preview(
+          threadId: 1,
           text: 'changed',
-          observedLineCount: 6,
-          observedArtifactCount: 1,
-          isArtifact: false,
+          lineCount: 6,
+          artifactCount: 1,
         ),
       ]);
       expect(notifications, 1);
@@ -546,13 +551,11 @@ void main() {
     test('clear 一并清掉预览（thread id 含 processId，跨会话不可复用）', () {
       final TexthookerService svc = TexthookerService.instance;
       svc.registerTextThread(key: 'luna:a', label: 'A', nativeThreadId: 1);
-      svc.applyTextThreadPreviews(const <TexthookerThreadPreview>[
-        TexthookerThreadPreview(
-          nativeThreadId: 1,
+      svc.applyTextThreadPreviews(<TexthookerThreadPreview>[
+        preview(
+          threadId: 1,
           text: 'stale',
-          observedLineCount: 4,
-          observedArtifactCount: 0,
-          isArtifact: false,
+          lineCount: 4,
         ),
       ]);
       svc.clear();

--- a/hibiki/test/tools/voice_hook_ipc_contract_test.dart
+++ b/hibiki/test/tools/voice_hook_ipc_contract_test.dart
@@ -91,4 +91,32 @@ void main() {
     expect(reader, contains('TryReadThreadPreviewSnapshot(slot, &snapshot)'));
     expect(reader, contains('AtomicLoadPreview64('));
   });
+
+  test('native profile prefer cannot bypass v12 explicit thread selection', () {
+    final String injector = File(
+      '../native/galgame_hook/injector/injector_main.cpp',
+    ).readAsStringSync();
+    final int functionStart = injector.indexOf('bool LunaShouldWriteLine(');
+    final int functionEnd = injector.indexOf(
+      '\n}\n\n// ── Luna_Start',
+      functionStart,
+    );
+    expect(functionStart, greaterThanOrEqualTo(0));
+    expect(functionEnd, greaterThan(functionStart));
+    final String functionBody = injector.substring(functionStart, functionEnd);
+
+    // hookcode/prefer 不能再进入准入函数；唯一真值必须是共享内存里的显式 thread id。
+    expect(
+      functionBody,
+      isNot(contains('preferred_hook_codes')),
+    );
+    expect(functionBody, isNot(contains('const wchar_t* hookcode')));
+    expect(functionBody, contains('selected_text_thread_id'));
+    expect(
+      functionBody,
+      contains(
+        'AcceptsLine(\n      thread_id, is_artifact, manually_selected, face_id)',
+      ),
+    );
+  });
 }

--- a/hibiki/test/tools/voice_hook_ipc_contract_test.dart
+++ b/hibiki/test/tools/voice_hook_ipc_contract_test.dart
@@ -32,6 +32,41 @@ void main() {
         '(hook_diagnostics & kDiagVisualArtsOvkHooksReady) != 0',
       ),
     );
-    expect(source, contains('constexpr uint32_t kSharedVersion = 11;'));
+    expect(source, contains('constexpr uint32_t kSharedVersion = 12;'));
+  });
+
+  test('host mirrors the v12 thread preview region contract', () {
+    final String source = File(
+      'windows/runner/voice_hook_ipc.h',
+    ).readAsStringSync();
+
+    // 预览区的三个常量与 header 字段必须与 native 真相源同步；漏一个就会读到错位内存。
+    expect(source, contains('constexpr uint32_t kThreadPreviewCount = 64;'));
+    expect(
+      source,
+      contains('constexpr uint32_t kThreadPreviewTextChars = 192;'),
+    );
+    expect(
+      source,
+      contains(
+        'constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;',
+      ),
+    );
+    expect(source, contains('struct ThreadPreviewSlot {'));
+    expect(source, contains('uint32_t thread_preview_offset;'));
+    expect(source, contains('uint32_t thread_preview_slot_count;'));
+    expect(
+      source,
+      contains('volatile uint64_t thread_preview_write_count;'),
+    );
+    // 预览槽必须带不受门控影响的行计数，否则跨会话记忆恢复没有消歧依据。
+    expect(source, contains('uint64_t line_count;'));
+    expect(source, contains('uint64_t artifact_count;'));
+    expect(
+      source,
+      contains(
+        'static_assert(sizeof(ThreadPreviewSlot) % 8 == 0,',
+      ),
+    );
   });
 }

--- a/hibiki/test/tools/voice_hook_ipc_contract_test.dart
+++ b/hibiki/test/tools/voice_hook_ipc_contract_test.dart
@@ -35,38 +35,60 @@ void main() {
     expect(source, contains('constexpr uint32_t kSharedVersion = 12;'));
   });
 
-  test('host mirrors the v12 thread preview region contract', () {
-    final String source = File(
+  test('host and native share the v12 thread preview seqlock contract', () {
+    final String hostHeader = File(
       'windows/runner/voice_hook_ipc.h',
     ).readAsStringSync();
+    final String nativeHeader = File(
+      '../native/galgame_hook/include/voice_hook_ipc.h',
+    ).readAsStringSync();
+    final String sharedHeader = File(
+      '../native/galgame_hook/include/thread_preview_ipc.h',
+    ).readAsStringSync();
+    final String reader = File(
+      'windows/runner/voice_hook_reader.cpp',
+    ).readAsStringSync();
 
-    // 预览区的三个常量与 header 字段必须与 native 真相源同步；漏一个就会读到错位内存。
-    expect(source, contains('constexpr uint32_t kThreadPreviewCount = 64;'));
+    // 布局只定义一次，host 直接包含 native 共用头，避免镜像漂移和重复代码。
     expect(
-      source,
+      hostHeader,
+      contains(
+        '#include "../../../native/galgame_hook/include/thread_preview_ipc.h"',
+      ),
+    );
+    expect(nativeHeader, contains('#include "thread_preview_ipc.h"'));
+    expect(
+      sharedHeader,
+      contains('constexpr uint32_t kThreadPreviewCount = 64;'),
+    );
+    expect(
+      sharedHeader,
       contains('constexpr uint32_t kThreadPreviewTextChars = 192;'),
     );
     expect(
-      source,
+      sharedHeader,
       contains(
         'constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;',
       ),
     );
-    expect(source, contains('struct ThreadPreviewSlot {'));
-    expect(source, contains('uint32_t thread_preview_offset;'));
-    expect(source, contains('uint32_t thread_preview_slot_count;'));
+    expect(sharedHeader, contains('struct ThreadPreviewSlot {'));
+    expect(hostHeader, contains('uint32_t thread_preview_offset;'));
+    expect(hostHeader, contains('uint32_t thread_preview_slot_count;'));
     expect(
-      source,
+      hostHeader,
       contains('volatile uint64_t thread_preview_write_count;'),
     );
     // 预览槽必须带不受门控影响的行计数，否则跨会话记忆恢复没有消歧依据。
-    expect(source, contains('uint64_t line_count;'));
-    expect(source, contains('uint64_t artifact_count;'));
+    expect(sharedHeader, contains('uint64_t line_count;'));
+    expect(sharedHeader, contains('uint64_t artifact_count;'));
     expect(
-      source,
+      sharedHeader,
       contains(
-        'static_assert(sizeof(ThreadPreviewSlot) % 8 == 0,',
+        'static_assert(offsetof(ThreadPreviewSlot, seq) == 0,',
       ),
     );
+    // reader 只发布 odd/even 原子双读后的稳定快照，write_count 同样不能在 x86 裸读。
+    expect(reader, contains('TryReadThreadPreviewSnapshot(slot, &snapshot)'));
+    expect(reader, contains('AtomicLoadPreview64('));
   });
 }

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -1895,6 +1895,39 @@ void FlutterWindow::RegisterVoiceHookChannel() {
           }));
           return;
         }
+        if (method == "pollThreadPreviews") {
+          // v12：每条线程的最近一行（含未被选中的线程），供选择器展示。全量快照，无游标。
+          std::vector<hibiki::VoiceHookThreadPreview> previews;
+          const uint64_t write_count =
+              hibiki::VoiceHookReader::Instance().PollThreadPreviews(previews);
+          flutter::EncodableList list;
+          for (const auto& pv : previews) {
+            list.push_back(flutter::EncodableValue(flutter::EncodableMap{
+                {flutter::EncodableValue("threadId"),
+                 flutter::EncodableValue(static_cast<int64_t>(pv.thread_id))},
+                {flutter::EncodableValue("seq"),
+                 flutter::EncodableValue(static_cast<int64_t>(pv.seq))},
+                {flutter::EncodableValue("ts"),
+                 flutter::EncodableValue(static_cast<int64_t>(pv.timestamp_ms))},
+                {flutter::EncodableValue("lineCount"),
+                 flutter::EncodableValue(static_cast<int64_t>(pv.line_count))},
+                {flutter::EncodableValue("artifactCount"),
+                 flutter::EncodableValue(
+                     static_cast<int64_t>(pv.artifact_count))},
+                {flutter::EncodableValue("eventFlags"),
+                 flutter::EncodableValue(static_cast<int64_t>(pv.event_flags))},
+                {flutter::EncodableValue("text"),
+                 flutter::EncodableValue(pv.utf8)},
+            }));
+          }
+          result->Success(flutter::EncodableValue(flutter::EncodableMap{
+              {flutter::EncodableValue("writeCount"),
+               flutter::EncodableValue(static_cast<int64_t>(write_count))},
+              {flutter::EncodableValue("previews"),
+               flutter::EncodableValue(std::move(list))},
+          }));
+          return;
+        }
         if (method == "selectTextThread") {
           const uint64_t thread_id =
               static_cast<uint64_t>(read_long("threadId"));

--- a/hibiki/windows/runner/voice_hook_ipc.h
+++ b/hibiki/windows/runner/voice_hook_ipc.h
@@ -11,17 +11,26 @@
 // v2：音频环形 + 文本环（hook 抓的台词行）+ 语音 clip 索引（按句切的语音片段，含时间戳供配对）。
 // v6：clip 索引之后追加 loopback 混音环 + 时间戳↔环位置标记表（无引擎专属纯人声 hook 时的兜底）。
 // v10：文本槽追加事件类型，透传 Luna ThreadCreate，使尚无台词的候选线程也可被选择。
+// v12：追加「线程预览区」并取消 injector 自动选线程。文本环仍只装**当前生效线程**（配对路径
+//     不受影响），每条线程的最近一行改由预览区按线程分槽保存，供选择器展示——两个诉求相反的
+//     消费者不再抢同一块 256 槽 FIFO。完整推导见真相源头文件的 v12 注释。
 // 读共享内存不是注入、不被杀软标记，可安全进 hibiki.exe。契约用 magic/version 版本化。
 namespace hibiki_voice_hook {
 
 constexpr uint32_t kSharedMagic = 0x31485648;  // 'H''V''H''1'
-constexpr uint32_t kSharedVersion = 11;
+constexpr uint32_t kSharedVersion = 12;
 constexpr uint32_t kStableIpcVersion = 1;
 constexpr uint32_t kLunaBridgeAbiVersion = 1;
 constexpr uint32_t kLunaVendoredVersion = 0x0A100102;  // 10.16.1.2
 
 constexpr uint32_t kTextSlotCount = 256;
 constexpr uint32_t kTextSlotBytes = 2048;
+// v12 线程预览区：每条线程一个固定槽（按 thread_id 认领），只留最近一行。按线程分槽而非
+// 全局取模，所以逐字重绘型 hook 只覆盖自己的槽，挤不掉别的线程——这是取消自动选线程后
+// 仍能保证「每条线程都看得见」的结构保证。
+constexpr uint32_t kThreadPreviewCount = 64;
+constexpr uint32_t kThreadPreviewTextChars = 192;
+constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;
 constexpr uint32_t kTextHookNameChars = 64;
 constexpr uint32_t kTextHookCodeChars = 128;
 constexpr uint32_t kTextSourceUnknown = 0;
@@ -109,6 +118,21 @@ struct TextSlot {
   // 紧跟文本字节。
 };
 
+// v12 线程预览槽。字段语义与真相源头文件一致，改动必须两侧同步。
+// [line_count] 统计该线程出过的**全部**行（含被伪影过滤和线程门控丢弃的），是跨会话记忆
+// 恢复的消歧依据——v12 取消自动选线程后文本环在用户选定前恒空，用已发布行数做判据会让
+// 记忆永远无法恢复。
+struct ThreadPreviewSlot {
+  volatile uint64_t seq;    // 单调写序号（0=空槽/尚无预览行），最后写，作完成标记
+  uint64_t thread_id;       // 认领键，对应 TextSlot::thread_id；0=未认领
+  uint64_t timestamp_ms;
+  uint64_t line_count;      // 累计行数（含被过滤/门控丢弃的）
+  uint64_t artifact_count;  // 其中判为重复伪影的行数
+  uint32_t byte_len;        // 预览文本字节数（UTF-16LE）
+  uint32_t event_flags;     // bit0 = 本行被判为伪影
+  wchar_t text[kThreadPreviewTextChars];
+};
+
 struct VoiceClip {
   volatile uint64_t seq;
   uint64_t timestamp_ms;    // 该 clip 播放时刻
@@ -159,7 +183,9 @@ struct SharedHeader {
   uint32_t clip_region_offset;
   volatile uint64_t text_write_count;
   volatile uint64_t clip_write_count;
-  volatile uint64_t selected_text_thread_id;  // 0=自动；非0=用户选择的 TextSlot::thread_id
+  // 0=尚未选定（v12 起**不再有"自动选线程"**，此时文本环恒空，由 UI 引导用户从预览区挑）；
+  // 非 0 = 用户选定的 TextSlot::thread_id。
+  volatile uint64_t selected_text_thread_id;
   volatile uint32_t luna_active;  // LunaHook 出干净行后 =1，游戏内 GDI 文本 hook 让位（见 native 头注释）
   uint32_t reserved_luna;         // 32 位引擎诊断位（已满，loopback 另立字段）
   volatile uint32_t hook_diagnostics;
@@ -179,11 +205,19 @@ struct SharedHeader {
   uint32_t loopback_diag;
   volatile uint64_t loopback_total_written;
   volatile uint64_t loopback_marker_count;
+  // ── v12 线程预览区（布局最尾，前面各区偏移一个都不动）──
+  uint32_t thread_preview_offset;
+  uint32_t thread_preview_slot_count;
+  // 单调累计已写预览行数。只用于判断「有没有新预览」以跳过整区扫描；预览槽本身按
+  // thread_id 寻址，**不**靠这个序号定位（与 text_write_count 语义不同，勿照搬取模那套）。
+  volatile uint64_t thread_preview_write_count;
 };
 #pragma pack(pop)
 
 static_assert(sizeof(SharedHeader) % 8 == 0, "SharedHeader must stay 8-aligned");
 static_assert(sizeof(TextSlot) % 8 == 0, "TextSlot must stay 8-aligned");
+static_assert(sizeof(ThreadPreviewSlot) % 8 == 0,
+              "ThreadPreviewSlot must stay 8-aligned");
 static_assert(sizeof(VoiceClip) % 8 == 0, "VoiceClip must stay 8-aligned");
 static_assert(sizeof(UnityVoiceEvent) % 8 == 0,
               "UnityVoiceEvent must stay 8-aligned");

--- a/hibiki/windows/runner/voice_hook_ipc.h
+++ b/hibiki/windows/runner/voice_hook_ipc.h
@@ -6,6 +6,8 @@
 #include <cstdint>
 #include <string>
 
+#include "../../../native/galgame_hook/include/thread_preview_ipc.h"
+
 // galgame 一键制卡 C 阶段（docs/specs/galgame-mining）—— 引擎级 voice/text hook 共享内存契约的
 // **host 端副本**（真相源在独立仓库 hibiki-hook 的 `include/voice_hook_ipc.h`，须同步）。
 // v2：音频环形 + 文本环（hook 抓的台词行）+ 语音 clip 索引（按句切的语音片段，含时间戳供配对）。
@@ -25,12 +27,6 @@ constexpr uint32_t kLunaVendoredVersion = 0x0A100102;  // 10.16.1.2
 
 constexpr uint32_t kTextSlotCount = 256;
 constexpr uint32_t kTextSlotBytes = 2048;
-// v12 线程预览区：每条线程一个固定槽（按 thread_id 认领），只留最近一行。按线程分槽而非
-// 全局取模，所以逐字重绘型 hook 只覆盖自己的槽，挤不掉别的线程——这是取消自动选线程后
-// 仍能保证「每条线程都看得见」的结构保证。
-constexpr uint32_t kThreadPreviewCount = 64;
-constexpr uint32_t kThreadPreviewTextChars = 192;
-constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;
 constexpr uint32_t kTextHookNameChars = 64;
 constexpr uint32_t kTextHookCodeChars = 128;
 constexpr uint32_t kTextSourceUnknown = 0;
@@ -118,21 +114,6 @@ struct TextSlot {
   // 紧跟文本字节。
 };
 
-// v12 线程预览槽。字段语义与真相源头文件一致，改动必须两侧同步。
-// [line_count] 统计该线程出过的**全部**行（含被伪影过滤和线程门控丢弃的），是跨会话记忆
-// 恢复的消歧依据——v12 取消自动选线程后文本环在用户选定前恒空，用已发布行数做判据会让
-// 记忆永远无法恢复。
-struct ThreadPreviewSlot {
-  volatile uint64_t seq;    // 单调写序号（0=空槽/尚无预览行），最后写，作完成标记
-  uint64_t thread_id;       // 认领键，对应 TextSlot::thread_id；0=未认领
-  uint64_t timestamp_ms;
-  uint64_t line_count;      // 累计行数（含被过滤/门控丢弃的）
-  uint64_t artifact_count;  // 其中判为重复伪影的行数
-  uint32_t byte_len;        // 预览文本字节数（UTF-16LE）
-  uint32_t event_flags;     // bit0 = 本行被判为伪影
-  wchar_t text[kThreadPreviewTextChars];
-};
-
 struct VoiceClip {
   volatile uint64_t seq;
   uint64_t timestamp_ms;    // 该 clip 播放时刻
@@ -216,8 +197,6 @@ struct SharedHeader {
 
 static_assert(sizeof(SharedHeader) % 8 == 0, "SharedHeader must stay 8-aligned");
 static_assert(sizeof(TextSlot) % 8 == 0, "TextSlot must stay 8-aligned");
-static_assert(sizeof(ThreadPreviewSlot) % 8 == 0,
-              "ThreadPreviewSlot must stay 8-aligned");
 static_assert(sizeof(VoiceClip) % 8 == 0, "VoiceClip must stay 8-aligned");
 static_assert(sizeof(UnityVoiceEvent) % 8 == 0,
               "UnityVoiceEvent must stay 8-aligned");

--- a/hibiki/windows/runner/voice_hook_reader.cpp
+++ b/hibiki/windows/runner/voice_hook_reader.cpp
@@ -451,32 +451,32 @@ uint64_t VoiceHookReader::PollThreadPreviews(
       reinterpret_cast<const uint8_t*>(h) + h->thread_preview_offset);
   for (uint32_t i = 0; i < slots; i++) {
     const auto& slot = base[i];
-    // 槽是顺序认领的：撞到未认领的槽即说明后面全空。
-    if (slot.thread_id == 0) {
-      break;
-    }
-    // seq==0 表示已认领但还没写过预览行（不应发生，认领与写入同在一次调用里）；
-    // 保守跳过而不是发一条空预览，避免 UI 出现无内容的幽灵行。
-    if (slot.seq == 0) {
+    hibiki_voice_hook::ThreadPreviewSnapshot snapshot;
+    // writer 用 odd/even seqlock 发布；这里最多重试四次，只接受前后 seq 相同的偶数快照。
+    // 所有 64 位 seq 读都走 Interlocked，x86 不会因裸 uint64_t 访问而撕裂。
+    if (!hibiki_voice_hook::TryReadThreadPreviewSnapshot(slot, &snapshot) ||
+        snapshot.thread_id == 0) {
       continue;
     }
     VoiceHookThreadPreview preview;
-    preview.thread_id = slot.thread_id;
-    preview.seq = slot.seq;
-    preview.timestamp_ms = slot.timestamp_ms;
-    preview.line_count = slot.line_count;
-    preview.artifact_count = slot.artifact_count;
-    preview.event_flags = slot.event_flags;
-    uint32_t blen = slot.byte_len;
+    preview.thread_id = snapshot.thread_id;
+    preview.seq = snapshot.seq;
+    preview.timestamp_ms = snapshot.timestamp_ms;
+    preview.line_count = snapshot.line_count;
+    preview.artifact_count = snapshot.artifact_count;
+    preview.event_flags = snapshot.event_flags;
+    uint32_t blen = snapshot.byte_len;
     const uint32_t maxb =
         hibiki_voice_hook::kThreadPreviewTextChars * sizeof(wchar_t);
     if (blen > maxb) {
       blen = maxb;
     }
-    preview.utf8 = WideToUtf8(slot.text, static_cast<int>(blen / 2));
+    preview.utf8 =
+        WideToUtf8(snapshot.text, static_cast<int>(blen / 2));
     out.push_back(std::move(preview));
   }
-  return h->thread_preview_write_count;
+  return hibiki_voice_hook::AtomicLoadPreview64(
+      &h->thread_preview_write_count);
 }
 
 bool VoiceHookReader::SelectTextThread(uint64_t thread_id) {

--- a/hibiki/windows/runner/voice_hook_reader.cpp
+++ b/hibiki/windows/runner/voice_hook_reader.cpp
@@ -436,6 +436,49 @@ void VoiceHookReader::PollText(uint64_t from_seq,
   }
 }
 
+uint64_t VoiceHookReader::PollThreadPreviews(
+    std::vector<VoiceHookThreadPreview>& out) {
+  out.clear();
+  ReaderState& st = State();
+  std::lock_guard<std::mutex> lock(st.mutex);
+  const SharedHeader* h = st.header;
+  if (!ProtocolMatches(h) || h->thread_preview_offset == 0) {
+    return 0;
+  }
+  const uint32_t slots = (std::min)(h->thread_preview_slot_count,
+                                    hibiki_voice_hook::kThreadPreviewCount);
+  const auto* base = reinterpret_cast<const hibiki_voice_hook::ThreadPreviewSlot*>(
+      reinterpret_cast<const uint8_t*>(h) + h->thread_preview_offset);
+  for (uint32_t i = 0; i < slots; i++) {
+    const auto& slot = base[i];
+    // 槽是顺序认领的：撞到未认领的槽即说明后面全空。
+    if (slot.thread_id == 0) {
+      break;
+    }
+    // seq==0 表示已认领但还没写过预览行（不应发生，认领与写入同在一次调用里）；
+    // 保守跳过而不是发一条空预览，避免 UI 出现无内容的幽灵行。
+    if (slot.seq == 0) {
+      continue;
+    }
+    VoiceHookThreadPreview preview;
+    preview.thread_id = slot.thread_id;
+    preview.seq = slot.seq;
+    preview.timestamp_ms = slot.timestamp_ms;
+    preview.line_count = slot.line_count;
+    preview.artifact_count = slot.artifact_count;
+    preview.event_flags = slot.event_flags;
+    uint32_t blen = slot.byte_len;
+    const uint32_t maxb =
+        hibiki_voice_hook::kThreadPreviewTextChars * sizeof(wchar_t);
+    if (blen > maxb) {
+      blen = maxb;
+    }
+    preview.utf8 = WideToUtf8(slot.text, static_cast<int>(blen / 2));
+    out.push_back(std::move(preview));
+  }
+  return h->thread_preview_write_count;
+}
+
 bool VoiceHookReader::SelectTextThread(uint64_t thread_id) {
   ReaderState& st = State();
   std::lock_guard<std::mutex> lock(st.mutex);

--- a/hibiki/windows/runner/voice_hook_reader.h
+++ b/hibiki/windows/runner/voice_hook_reader.h
@@ -88,6 +88,19 @@ struct VoiceHookText {
   std::string hook_code;
 };
 
+// 一条线程的预览快照（v12 线程预览区）。与 [VoiceHookText] 的关键差别：预览按 thread_id
+// 寻址、每线程恒一条，**不受线程选择门控影响**——未被选中的线程也有预览，这正是选择器
+// 能像 LunaTranslator 那样展示全部候选的来源。
+struct VoiceHookThreadPreview {
+  uint64_t thread_id = 0;
+  uint64_t seq = 0;             // 该槽最近一次写入的全局序号
+  uint64_t timestamp_ms = 0;
+  uint64_t line_count = 0;      // 累计行数（含被过滤/门控丢弃的），跨会话记忆恢复的消歧依据
+  uint64_t artifact_count = 0;  // 其中判为重复伪影的行数
+  uint32_t event_flags = 0;     // bit0 = 最近这行是伪影
+  std::string utf8;             // 预览文本
+};
+
 // 一条**活跃语音源**（source voice / DS buffer）的元数据快照（[ListAudioTracks] 产出）。游戏常有
 // 多条并行流式源（BGM/语音/SE 各一条），本结构供 app UI 列「音轨列表」让用户手动选/排除语音源
 // （自动能量选源可能误选 BGM，见 GrabUtterance）。所有量取自 ts_ms 附近环形窗口内该源的 clip。
@@ -132,8 +145,13 @@ class VoiceHookReader {
   // 回最近 kTextSlotCount 个（更旧的已被覆盖）。未打开 / 无新事件时 [out] 空。
   void PollText(uint64_t from_seq, std::vector<VoiceHookText>& out);
 
-  // 选择 Luna 文本线程：0 恢复自动选择，非 0 写入共享 header 让 injector 只发布该线程。
-  // 映射未打开或契约不匹配返回 false。
+  // 取全部已认领线程的预览快照（v12）。这是**全量快照**而非增量：预览槽按 thread_id 寻址、
+  // 每线程恒一条，没有"漏读就丢"的问题，故不需要游标。返回 thread_preview_write_count 供
+  // 调用方判断"有没有变"以跳过整区扫描；未打开 / 契约不匹配时 [out] 空并返回 0。
+  uint64_t PollThreadPreviews(std::vector<VoiceHookThreadPreview>& out);
+
+  // 选择 Luna 文本线程：0 = 清除选择（v12 起清除后文本环恒空，不再回到自动选择），
+  // 非 0 写入共享 header 让 injector 只发布该线程。映射未打开或契约不匹配返回 false。
   bool SelectTextThread(uint64_t thread_id);
 
   // **按句取语音**：找时间戳与 [ts_ms] 最近（且差 <= [tolerance_ms]）的语音 clip，把它那段 PCM

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -190,6 +190,14 @@ target_include_directories(hibiki_luna_text_replay_test PRIVATE include)
 add_test(NAME hibiki_luna_text_replay_test COMMAND hibiki_luna_text_replay_test
   "${CMAKE_CURRENT_SOURCE_DIR}/tests/fixtures/luna_thread_selection.tsv")
 
+add_executable(hibiki_thread_preview_ipc_test
+  tests/thread_preview_ipc_test.cpp)
+target_include_directories(hibiki_thread_preview_ipc_test PRIVATE include)
+target_compile_definitions(hibiki_thread_preview_ipc_test
+  PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
+add_test(NAME hibiki_thread_preview_ipc_test
+  COMMAND hibiki_thread_preview_ipc_test)
+
 add_executable(hibiki_adapter_contract_test tests/adapter_contract_test.cpp)
 target_include_directories(hibiki_adapter_contract_test PRIVATE hook)
 add_test(NAME hibiki_adapter_contract_test COMMAND hibiki_adapter_contract_test)

--- a/native/galgame_hook/include/luna_text_selector.h
+++ b/native/galgame_hook/include/luna_text_selector.h
@@ -197,8 +197,8 @@ inline bool LunaSelectedThreadAccepts(uint64_t manually_selected,
 // voice_hook_ipc.h ThreadPreviewSlot）挑一条。预览区按线程分槽，不受本判定影响，所以
 // "让用户看见所有线程"和"文本环只装选定线程"不再互相排斥——这是删掉赢家逻辑的前提。
 //
-// 显式选择有两个来源，都在调用方（injector）处理：用户选定的 selected_text_thread_id，
-// 以及 profile 的 `prefer=` hook code。本类只负责前者的匹配。
+// 唯一准入来源是用户选定的 selected_text_thread_id。profile 的 `prefer=` 只保留为旧配置
+// 元数据，v12 不得据此绕过显式选择。
 class LunaTextSelector {
  public:
   // 判定本行是否写入文本环。[face_id] 是不含 ctx 的 hook 面 id（见
@@ -218,11 +218,10 @@ class LunaTextSelector {
 
   // 登记一条 thread_id → face 映射。
   //
-  // BUG-1159：这一步必须对**每一行**做，且必须早于所有过滤分支。injector 侧
-  // 的 preferred_hook_codes 快路根本不进选择器；如果只在 ShouldWrite 里登记，
-  // 那些行的 thread 就永远没有 face。而跨会话记忆恢复（Dart `_maybeRestoreTextThread`）
-  // 正是从「本会话已出过 >= 3 行」的线程里挑一条写进 `selected_text_thread_id`，
-  // 若那几行走的是快路，FaceOf 会返回 0 → 退回精确匹配 → 原症状原样复现。
+  // BUG-1159：这一步必须对**每一行**做，且必须早于准入判定。未选择阶段的行只进入
+  // 预览区、不进入文本环；跨会话记忆恢复（Dart `_maybeRestoreTextThread`）会从
+  // 「本会话已出过 >= 3 行」的线程里挑一条写进 `selected_text_thread_id`，所以这些
+  // 预览行也必须提前登记 face。
   // 登记在全路径完成后，「选定线程已出过 >= 3 行」就硬性蕴含「face 已知」。
   void NoteFace(uint64_t thread_id, uint64_t face_id) {
     if (face_id != 0 && thread_id != 0) thread_face_[thread_id] = face_id;

--- a/native/galgame_hook/include/luna_text_selector.h
+++ b/native/galgame_hook/include/luna_text_selector.h
@@ -182,49 +182,38 @@ inline bool LunaSelectedThreadAccepts(uint64_t manually_selected,
   return selected_face != 0 && selected_face == face_id;
 }
 
+// 文本环（Ring A）的准入判定。
+//
+// BUG-1193 / v12：这里**不再有"自动选干净线程"**。旧实现按 hookcode 统计 clean/dirty，
+// 累计够 3 行干净就锁定赢家，此后只发布赢家的行。它撑住了很长一段时间，但有两个无法
+// 在本层解决的问题：
+//   ① 猜错就没有出路。赢家一旦锁定，其余线程在采集端就被丢弃，用户在 UI 里看到的是
+//     一堆没有内容的空壳线程，"选不动"——这正是用户报的症状；
+//   ② 它把"哪条是台词"这个只有用户能回答的问题，交给了一个字符级启发式。带汉化补丁的
+//     KiriKiri 上这个启发式必然失败：原文和译文经由**同一个 hook**（EmbedKrkrZ 带
+//     NO_CONTEXT，ctx 被强制清零）流出，两种语言的 ThreadParam 逐字节相同，任何统计
+//     都不可能把它们分开。
+// v12 的答案是不猜：没有显式选择就不发布，由 UI 引导用户从**线程预览区**（见
+// voice_hook_ipc.h ThreadPreviewSlot）挑一条。预览区按线程分槽，不受本判定影响，所以
+// "让用户看见所有线程"和"文本环只装选定线程"不再互相排斥——这是删掉赢家逻辑的前提。
+//
+// 显式选择有两个来源，都在调用方（injector）处理：用户选定的 selected_text_thread_id，
+// 以及 profile 的 `prefer=` hook code。本类只负责前者的匹配。
 class LunaTextSelector {
  public:
-  // [face_id] 是不含 ctx/ctx2 的 hook 面 id（见 LunaSelectedThreadAccepts）。传 0 表示
-  // 调用方无法提供，此时手动选择退化为精确 thread_id 匹配。
-  bool ShouldWrite(const std::wstring& hook_code, uint64_t thread_id,
-                   bool artifact, uint64_t manually_selected,
+  // 判定本行是否写入文本环。[face_id] 是不含 ctx 的 hook 面 id（见
+  // LunaSelectedThreadAccepts）；传 0 表示调用方无法提供，此时退化为精确 thread_id 匹配。
+  //
+  // [manually_selected] 为 0 表示用户尚未为本游戏选定线程：**返回 false**，一行都不发布。
+  // 这是有意的——见类注释。伪影行任何情况下都不进文本环（预览区另有 artifact 标记位，
+  // 脏线程在 UI 里仍然看得见，不会被藏掉）。
+  bool AcceptsLine(uint64_t thread_id, bool artifact, uint64_t manually_selected,
                    uint64_t face_id = 0) {
     NoteFace(thread_id, face_id);
-    Stats& stats = stats_[hook_code];
-    if (artifact) ++stats.dirty;
-    else ++stats.clean;
-
-    const std::wstring* best = nullptr;
-    const std::wstring* pristine = nullptr;
-    uint64_t best_clean = 0;
-    uint64_t pristine_clean = 0;
-    uint64_t total_clean = 0;
-    for (const auto& entry : stats_) {
-      const uint64_t clean = entry.second.clean;
-      const uint64_t dirty = entry.second.dirty;
-      total_clean += clean;
-      if (clean == 0) continue;
-      if (dirty == 0 && clean > pristine_clean) {
-        pristine = &entry.first;
-        pristine_clean = clean;
-      }
-      if (clean >= dirty && clean > best_clean) {
-        best = &entry.first;
-        best_clean = clean;
-      }
-    }
-    const std::wstring* winner = pristine != nullptr ? pristine : best;
-    if (total_clean >= 3 && winner != nullptr) {
-      primed_ = true;
-      selected_hook_ = *winner;
-    }
-
     if (artifact) return false;
-    if (manually_selected != 0) {
-      return LunaSelectedThreadAccepts(manually_selected, thread_id,
-                                       FaceOf(manually_selected), face_id);
-    }
-    return !primed_ || hook_code == selected_hook_;
+    if (manually_selected == 0) return false;
+    return LunaSelectedThreadAccepts(manually_selected, thread_id,
+                                     FaceOf(manually_selected), face_id);
   }
 
   // 登记一条 thread_id → face 映射。
@@ -245,24 +234,12 @@ class LunaTextSelector {
     return it == thread_face_.end() ? 0 : it->second;
   }
 
-  void Reset() {
-    stats_.clear();
-    thread_face_.clear();
-    selected_hook_.clear();
-    primed_ = false;
-  }
+  void Reset() { thread_face_.clear(); }
 
  private:
-  struct Stats {
-    uint64_t clean = 0;
-    uint64_t dirty = 0;
-  };
-  std::map<std::wstring, Stats> stats_;
   // thread_id → hook 面 id。只增不删：一次会话内 hook 面数量有界（每个 hook 的每个
   // 调用上下文一条），且必须跨「用户选定线程」之前/之后都能查到。
   std::map<uint64_t, uint64_t> thread_face_;
-  std::wstring selected_hook_;
-  bool primed_ = false;
 };
 
 }  // namespace hibiki_voice_hook

--- a/native/galgame_hook/include/thread_preview_ipc.h
+++ b/native/galgame_hook/include/thread_preview_ipc.h
@@ -1,0 +1,161 @@
+#ifndef HIBIKI_THREAD_PREVIEW_IPC_H_
+#define HIBIKI_THREAD_PREVIEW_IPC_H_
+
+#include <windows.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace hibiki_voice_hook {
+
+constexpr uint32_t kThreadPreviewCount = 64;
+constexpr uint32_t kThreadPreviewTextChars = 192;
+constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;
+constexpr uint32_t kThreadPreviewSnapshotRetries = 4;
+
+#pragma pack(push, 8)
+// v12 线程预览槽。writer 必须先由进程内锁串行化，再执行：
+//   seq=odd（写中）→ 写全部 payload → seq=even（已提交）→ 发布全局 generation。
+// reader 对 seq 原子双读，仅接受相同的非零偶数值。Windows Interlocked 操作是全栅栏；
+// 槽和 seq 均保持 8 字节对齐，因此 x86 上的 64 位 seq 也不会撕裂。
+struct ThreadPreviewSlot {
+  volatile uint64_t seq;
+  uint64_t thread_id;       // 0=空槽；回收后允许预览表出现空洞
+  uint64_t timestamp_ms;
+  uint64_t line_count;
+  uint64_t artifact_count;
+  uint32_t byte_len;
+  uint32_t event_flags;
+  wchar_t text[kThreadPreviewTextChars];
+};
+#pragma pack(pop)
+
+struct ThreadPreviewSnapshot {
+  uint64_t seq = 0;
+  uint64_t thread_id = 0;
+  uint64_t timestamp_ms = 0;
+  uint64_t line_count = 0;
+  uint64_t artifact_count = 0;
+  uint32_t byte_len = 0;
+  uint32_t event_flags = 0;
+  wchar_t text[kThreadPreviewTextChars] = {};
+};
+
+static_assert(offsetof(ThreadPreviewSlot, seq) == 0,
+              "ThreadPreviewSlot seq must be the first field");
+static_assert(alignof(ThreadPreviewSlot) >= alignof(uint64_t),
+              "ThreadPreviewSlot must keep 64-bit atomic alignment");
+static_assert(sizeof(ThreadPreviewSlot) % 8 == 0,
+              "ThreadPreviewSlot must stay 8-aligned");
+
+inline uint64_t AtomicLoadPreview64(const volatile uint64_t* value) {
+  return static_cast<uint64_t>(InterlockedCompareExchange64(
+      reinterpret_cast<volatile LONGLONG*>(
+          const_cast<volatile uint64_t*>(value)),
+      0, 0));
+}
+
+inline void AtomicStorePreview64(volatile uint64_t* value, uint64_t next) {
+  InterlockedExchange64(reinterpret_cast<volatile LONGLONG*>(value),
+                        static_cast<LONGLONG>(next));
+}
+
+inline uint64_t NextThreadPreviewGeneration(
+    const volatile uint64_t* write_count) {
+  return AtomicLoadPreview64(write_count) + 1;
+}
+
+inline uint64_t ThreadPreviewWritingSequence(uint64_t generation) {
+  return (generation << 1) | 1u;
+}
+
+inline uint64_t ThreadPreviewCommittedSequence(uint64_t generation) {
+  return generation << 1;
+}
+
+inline void BeginThreadPreviewWrite(ThreadPreviewSlot* slot,
+                                    uint64_t generation) {
+  AtomicStorePreview64(&slot->seq,
+                       ThreadPreviewWritingSequence(generation));
+}
+
+inline void PublishThreadPreviewWrite(ThreadPreviewSlot* slot,
+                                      uint64_t generation) {
+  AtomicStorePreview64(&slot->seq,
+                       ThreadPreviewCommittedSequence(generation));
+}
+
+inline void PublishThreadPreviewGeneration(volatile uint64_t* write_count,
+                                           uint64_t generation) {
+  AtomicStorePreview64(write_count, generation);
+}
+
+// 调用方持有 writer 锁。回收会产生空洞，因此必须继续扫描以优先找回已有 id。
+inline ThreadPreviewSlot* FindThreadPreviewSlot(ThreadPreviewSlot* slots,
+                                                uint32_t count,
+                                                uint64_t thread_id) {
+  ThreadPreviewSlot* first_empty = nullptr;
+  for (uint32_t i = 0; i < count; ++i) {
+    if (slots[i].thread_id == thread_id) return &slots[i];
+    if (slots[i].thread_id == 0 && first_empty == nullptr) {
+      first_empty = &slots[i];
+    }
+  }
+  return first_empty;
+}
+
+inline void ClearThreadPreviewPayload(ThreadPreviewSlot* slot) {
+  slot->thread_id = 0;
+  slot->timestamp_ms = 0;
+  slot->line_count = 0;
+  slot->artifact_count = 0;
+  slot->byte_len = 0;
+  slot->event_flags = 0;
+  std::memset(slot->text, 0, sizeof(slot->text));
+}
+
+inline void CopyThreadPreviewSnapshot(const ThreadPreviewSlot& slot,
+                                      uint64_t sequence,
+                                      ThreadPreviewSnapshot* snapshot) {
+  snapshot->seq = sequence;
+  snapshot->thread_id = slot.thread_id;
+  snapshot->timestamp_ms = slot.timestamp_ms;
+  snapshot->line_count = slot.line_count;
+  snapshot->artifact_count = slot.artifact_count;
+  snapshot->byte_len = slot.byte_len;
+  snapshot->event_flags = slot.event_flags;
+  std::memcpy(snapshot->text, slot.text, sizeof(snapshot->text));
+}
+
+inline bool ThreadPreviewSequenceIsStable(const ThreadPreviewSlot& slot,
+                                          uint64_t begin_sequence) {
+  const uint64_t end_sequence = AtomicLoadPreview64(&slot.seq);
+  return begin_sequence != 0 && (begin_sequence & 1u) == 0 &&
+         begin_sequence == end_sequence;
+}
+
+inline bool TryReadThreadPreviewSnapshot(const ThreadPreviewSlot& slot,
+                                         ThreadPreviewSnapshot* snapshot) {
+  if (snapshot == nullptr) return false;
+  for (uint32_t attempt = 0; attempt < kThreadPreviewSnapshotRetries;
+       ++attempt) {
+    const uint64_t begin_sequence = AtomicLoadPreview64(&slot.seq);
+    if (begin_sequence == 0 || (begin_sequence & 1u) != 0) {
+      YieldProcessor();
+      continue;
+    }
+    ThreadPreviewSnapshot candidate;
+    CopyThreadPreviewSnapshot(slot, begin_sequence, &candidate);
+    if (ThreadPreviewSequenceIsStable(slot, begin_sequence)) {
+      *snapshot = candidate;
+      return true;
+    }
+    YieldProcessor();
+  }
+  return false;
+}
+
+}  // namespace hibiki_voice_hook
+
+#endif  // HIBIKI_THREAD_PREVIEW_IPC_H_

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -256,8 +256,8 @@ struct SharedHeader {
   uint32_t clip_region_offset;      // clip 索引起始
   volatile uint64_t text_write_count;  // 单调：已写文本事件数（host 取 last..count 的新事件）
   volatile uint64_t clip_write_count;  // 单调：已写语音 clip 数
-  // 0=injector 自动选干净线程；非 0=用户在 Hibiki 选择的 TextSlot::thread_id。
-  // injector 仍无条件过滤重复伪影，再仅写该线程。
+  // 0=尚未选定（v12 起文本环恒空）；非 0=用户在 Hibiki 选择的 TextSlot::thread_id。
+  // injector 无条件过滤重复伪影，再仅写该线程/同一 hook face。
   volatile uint64_t selected_text_thread_id;
   // LunaHook（引擎精确）出干净行后 injector 置 1；置 1 后游戏内 GDI 文本 hook 让位不再写文本，
   // 消除「LunaHook 干净行 + GDI 每字重画伪影」双写者污染。音频写入不受此标志影响。GDI 仅在

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "luna_version.h"
+#include "thread_preview_ipc.h"
 
 // galgame 一键制卡 C 阶段（docs/specs/galgame-mining）—— 引擎级 voice hook 的**进程间契约**。
 //
@@ -64,23 +65,6 @@ constexpr uint32_t kTextSourceSiglus = 4;
 constexpr uint32_t kTextEventLine = 0;
 constexpr uint32_t kTextEventThreadDiscovered = 1;
 
-// 线程预览区（v12）：每条 Luna 文本线程占一个**固定槽**，保存它最近一行。
-// 与文本环的关键差别是**寻址方式**，不是容量：文本环按全局写序号取模（谁写得快谁占满），
-// 预览区按线程认领槽位（谁写得快只覆盖自己）。因此逐字重绘型 hook 无论多吵，都不可能挤掉
-// 别的线程的预览行——这是取消自动赢家门控之后仍能保证"每条线程都看得见"的结构保证。
-//
-// 槽数是线程数上界而不是行数上界。实测同一游戏并行 Luna 线程在个位数到几十条量级，64 留足余量；
-// 满槽后新线程只是**没有预览**（仍会经 kTextEventThreadDiscovered 出现在选择器里），不影响
-// 文本环、配对与任何既有路径。
-constexpr uint32_t kThreadPreviewCount = 64;
-// 单条预览行的文本容量（wchar 数，不含结尾 0）。预览只用于"认出这条是不是我要的线程"，
-// 不参与制卡内容，故远小于 kTextSlotBytes；超长按 wchar 边界截断。
-constexpr uint32_t kThreadPreviewTextChars = 192;
-// 每线程只保留**最近一行**：UI（含 LunaTranslator 的「选择文本」表）每条线程就展示一行，
-// 多留的行没有消费者。要改成多行请把 ThreadPreviewSlot::text 换成显式环形数组并同步 host
-// 读取端，不要靠加一个没人读的常量假装可配置。
-// ThreadPreviewSlot::event_flags 位。
-constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;
 // 语音 clip 索引：最近 kClipCount 条语音片段的位置记录（按 source voice / DirectSound buffer
 // 的一次提交切一条；galgame 一句台词≈一条语音）。指向音频环形里的 [ring_offset, byte_len)。
 constexpr uint32_t kClipCount = 1024;  // clip 索引环：128≈仅2秒历史不够重建整句语音，扩到 ~16秒
@@ -210,27 +194,6 @@ struct TextSlot {
   // 紧跟文本字节。
 };
 
-// 线程预览槽（v12）：一条线程一个，按 thread_id 认领，覆盖只发生在自己槽内。
-//
-// [thread_id] 是认领键：0 表示空槽。认领后**不释放**——一次会话内线程数有界，释放会让
-// 「用户刚选中的线程恰好静默几秒就被顶掉」变成可能，那正是选择器最不能有的抖动。
-//
-// [line_count] 统计该线程**出过的全部行**，含被伪影过滤和线程门控丢弃的。它是给
-// 「跨会话记忆恢复」消歧用的：hook code 指纹只能锚到 hook、锚不到具体并行线程（ctx 未
-// 透出到 Dart），恢复时要靠「谁真的在出台词」区分。v12 取消自动选线程后文本环在用户选定
-// 前恒空，若仍用已发布行数做判据，记忆将永远无法恢复——必须用本字段这种**不受门控影响**
-// 的计数。artifact_count 单独计，让 UI 能像 LunaTranslator 那样把脏线程标出来而不是藏掉。
-struct ThreadPreviewSlot {
-  volatile uint64_t seq;     // 单调递增写序号（0=空槽/尚无预览行）；最后写，作完成标记
-  uint64_t thread_id;        // 认领键，对应 TextSlot::thread_id；0=未认领
-  uint64_t timestamp_ms;     // 最近一行的写入时刻
-  uint64_t line_count;       // 该线程累计行数（含被过滤/门控丢弃的）
-  uint64_t artifact_count;   // 其中被判为重复伪影的行数
-  uint32_t byte_len;         // 预览文本有效字节数（UTF-16LE，<= kThreadPreviewTextChars*2）
-  uint32_t event_flags;      // bit0 = 本行被判为伪影
-  wchar_t text[kThreadPreviewTextChars];
-};
-
 // 语音 clip 记录：一段独立语音片段在音频环形里的位置 + 时刻 + 格式。host 按文本时间戳找最近
 // clip，再从音频环形 [ring_offset, ring_offset+byte_len) 取 PCM（若已被环形覆盖则 total_at_write
 // 与当前 total_written 差值 > ring_capacity，host 判为过期）。
@@ -333,8 +296,6 @@ struct SharedHeader {
 
 static_assert(sizeof(SharedHeader) % 8 == 0, "SharedHeader must stay 8-aligned");
 static_assert(sizeof(TextSlot) % 8 == 0, "TextSlot must stay 8-aligned");
-static_assert(sizeof(ThreadPreviewSlot) % 8 == 0,
-              "ThreadPreviewSlot must stay 8-aligned");
 static_assert(sizeof(VoiceClip) % 8 == 0, "VoiceClip must stay 8-aligned");
 static_assert(sizeof(UnityVoiceEvent) % 8 == 0,
               "UnityVoiceEvent must stay 8-aligned");

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -32,7 +32,16 @@ constexpr uint32_t kSharedMagic = 0x31485648;  // 'H''V''H''1'
 // v9：合并 v8 的引擎诊断/Unity 资源事件与 v6 的 loopback 环。
 // v10：文本槽追加事件类型，透传 Luna ThreadCreate，使尚无台词的候选线程也可被选择。
 // v11：显式声明稳定 IPC、Luna bridge ABI 与 vendored Luna 版本，host 可在读数据前拒绝错配。
-constexpr uint32_t kSharedVersion = 11;
+// v12：追加「线程预览区」，并取消 injector 自动替用户选线程。
+//     旧结构里文本环是**唯一**的文本出口，同时伺候两个诉求相反的消费者：语音配对要高信噪的
+//     单条线程，线程选择器要每条线程都有样本。二者共用一块 256 槽全局 FIFO，于是"让所有 hook
+//     都发布"必然把配对候选挤出环（kExpired → 降级 loopback，即 BUG-1159 的失败链），这才是
+//     BUG-1193 真正的根因——不是门控本身。v12 把两个消费者拆到两块内存：
+//       * 文本环（Ring A）：语义不变，仍只发布**当前生效线程**的行，配对路径逐字节不受影响；
+//       * 线程预览区（本区）：每条线程各占**固定槽位**，只留最近一行。
+//     预览区按线程分槽而不是全局 FIFO，所以逐字重绘型 hook 只能覆盖它自己的槽，**物理上挤不掉
+//     别的线程**——"挤压"从"要小心防"变成结构上不可能，这正是自动赢家门控得以退役的前提。
+constexpr uint32_t kSharedVersion = 12;
 constexpr uint32_t kStableIpcVersion = 1;
 
 // 环形缓冲保留时长（秒）。C 阶段语音轨常见 48k 立体声 float32；60s 上界 ≈ 23MB。
@@ -54,6 +63,24 @@ constexpr uint32_t kTextSourceUnityTmp = 3;
 constexpr uint32_t kTextSourceSiglus = 4;
 constexpr uint32_t kTextEventLine = 0;
 constexpr uint32_t kTextEventThreadDiscovered = 1;
+
+// 线程预览区（v12）：每条 Luna 文本线程占一个**固定槽**，保存它最近一行。
+// 与文本环的关键差别是**寻址方式**，不是容量：文本环按全局写序号取模（谁写得快谁占满），
+// 预览区按线程认领槽位（谁写得快只覆盖自己）。因此逐字重绘型 hook 无论多吵，都不可能挤掉
+// 别的线程的预览行——这是取消自动赢家门控之后仍能保证"每条线程都看得见"的结构保证。
+//
+// 槽数是线程数上界而不是行数上界。实测同一游戏并行 Luna 线程在个位数到几十条量级，64 留足余量；
+// 满槽后新线程只是**没有预览**（仍会经 kTextEventThreadDiscovered 出现在选择器里），不影响
+// 文本环、配对与任何既有路径。
+constexpr uint32_t kThreadPreviewCount = 64;
+// 单条预览行的文本容量（wchar 数，不含结尾 0）。预览只用于"认出这条是不是我要的线程"，
+// 不参与制卡内容，故远小于 kTextSlotBytes；超长按 wchar 边界截断。
+constexpr uint32_t kThreadPreviewTextChars = 192;
+// 每线程只保留**最近一行**：UI（含 LunaTranslator 的「选择文本」表）每条线程就展示一行，
+// 多留的行没有消费者。要改成多行请把 ThreadPreviewSlot::text 换成显式环形数组并同步 host
+// 读取端，不要靠加一个没人读的常量假装可配置。
+// ThreadPreviewSlot::event_flags 位。
+constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;
 // 语音 clip 索引：最近 kClipCount 条语音片段的位置记录（按 source voice / DirectSound buffer
 // 的一次提交切一条；galgame 一句台词≈一条语音）。指向音频环形里的 [ring_offset, byte_len)。
 constexpr uint32_t kClipCount = 1024;  // clip 索引环：128≈仅2秒历史不够重建整句语音，扩到 ~16秒
@@ -183,6 +210,27 @@ struct TextSlot {
   // 紧跟文本字节。
 };
 
+// 线程预览槽（v12）：一条线程一个，按 thread_id 认领，覆盖只发生在自己槽内。
+//
+// [thread_id] 是认领键：0 表示空槽。认领后**不释放**——一次会话内线程数有界，释放会让
+// 「用户刚选中的线程恰好静默几秒就被顶掉」变成可能，那正是选择器最不能有的抖动。
+//
+// [line_count] 统计该线程**出过的全部行**，含被伪影过滤和线程门控丢弃的。它是给
+// 「跨会话记忆恢复」消歧用的：hook code 指纹只能锚到 hook、锚不到具体并行线程（ctx 未
+// 透出到 Dart），恢复时要靠「谁真的在出台词」区分。v12 取消自动选线程后文本环在用户选定
+// 前恒空，若仍用已发布行数做判据，记忆将永远无法恢复——必须用本字段这种**不受门控影响**
+// 的计数。artifact_count 单独计，让 UI 能像 LunaTranslator 那样把脏线程标出来而不是藏掉。
+struct ThreadPreviewSlot {
+  volatile uint64_t seq;     // 单调递增写序号（0=空槽/尚无预览行）；最后写，作完成标记
+  uint64_t thread_id;        // 认领键，对应 TextSlot::thread_id；0=未认领
+  uint64_t timestamp_ms;     // 最近一行的写入时刻
+  uint64_t line_count;       // 该线程累计行数（含被过滤/门控丢弃的）
+  uint64_t artifact_count;   // 其中被判为重复伪影的行数
+  uint32_t byte_len;         // 预览文本有效字节数（UTF-16LE，<= kThreadPreviewTextChars*2）
+  uint32_t event_flags;      // bit0 = 本行被判为伪影
+  wchar_t text[kThreadPreviewTextChars];
+};
+
 // 语音 clip 记录：一段独立语音片段在音频环形里的位置 + 时刻 + 格式。host 按文本时间戳找最近
 // clip，再从音频环形 [ring_offset, ring_offset+byte_len) 取 PCM（若已被环形覆盖则 total_at_write
 // 与当前 total_written 差值 > ring_capacity，host 判为过期）。
@@ -273,11 +321,20 @@ struct SharedHeader {
   uint32_t loopback_diag;                // loopback 诊断位（线程启动/设备就绪/捕获非静音等）
   volatile uint64_t loopback_total_written;  // 单调累计写入 loopback 字节（reader 判可读量/覆盖）
   volatile uint64_t loopback_marker_count;   // 单调累计已写标记数
+  // ── v12 线程预览区（injector 填偏移/槽数，写入者是 Luna 回调路径）──
+  // 内存布局尾部再追加：[...标记表][线程预览区 thread_preview_slot_count*ThreadPreviewSlot]
+  uint32_t thread_preview_offset;      // 线程预览区起始（header 起算字节偏移）
+  uint32_t thread_preview_slot_count;  // 槽数（= kThreadPreviewCount，冗余便于 reader 自洽）
+  // 单调累计已写预览行数。host 只用它判断「有没有新预览」以跳过整区扫描；预览槽本身按
+  // thread_id 寻址，不靠这个序号定位（与文本环的 text_write_count 语义不同，勿照搬）。
+  volatile uint64_t thread_preview_write_count;
 };
 #pragma pack(pop)
 
 static_assert(sizeof(SharedHeader) % 8 == 0, "SharedHeader must stay 8-aligned");
 static_assert(sizeof(TextSlot) % 8 == 0, "TextSlot must stay 8-aligned");
+static_assert(sizeof(ThreadPreviewSlot) % 8 == 0,
+              "ThreadPreviewSlot must stay 8-aligned");
 static_assert(sizeof(VoiceClip) % 8 == 0, "VoiceClip must stay 8-aligned");
 static_assert(sizeof(UnityVoiceEvent) % 8 == 0,
               "UnityVoiceEvent must stay 8-aligned");

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -756,34 +756,37 @@ bool g_lunaSelectCsInit = false;
 // 就是让用户看见那些没被发布的线程；只记已发布行等于什么都没做。
 //
 // 寻址按 thread_id 线性查找/认领，不取模全局序号：这正是预览区不会被逐字重绘型 hook
-// 挤爆的原因（它只覆盖自己的槽）。槽数有界、认领后不释放，故线性扫描的代价恒定且很小。
+// 挤爆的原因（它只覆盖自己的槽）。ThreadRemove 会回收槽并留下空洞，所以查找必须扫完整张
+// 表：先找已有 id，再回退到遇到的第一个空槽。
 //
-// 与 ShouldWrite 复用同一把锁，理由是二者本就在同一回调路径上顺序执行，多一把锁只会
-// 多一次加锁开销和一个新的死锁面。
+// 与 ShouldWrite 复用同一把锁。锁串行化多个 Luna 回调 writer；槽内 odd/even seq 则保护
+// 跨进程 reader，二者缺一不可。
 void WriteThreadPreview(SharedHeader* header, uint64_t thread_id,
                         bool is_artifact, const wchar_t* text, int wlen) {
-  if (header == nullptr || thread_id == 0 || header->thread_preview_offset == 0) {
+  if (header == nullptr || thread_id == 0 ||
+      header->thread_preview_offset == 0 || !g_lunaSelectCsInit) {
     return;
   }
+  EnterCriticalSection(&g_lunaSelectCs);
   auto* slots = reinterpret_cast<hibiki_voice_hook::ThreadPreviewSlot*>(
       reinterpret_cast<uint8_t*>(header) + header->thread_preview_offset);
-  const uint32_t count = header->thread_preview_slot_count;
-  hibiki_voice_hook::ThreadPreviewSlot* slot = nullptr;
-  for (uint32_t i = 0; i < count; ++i) {
-    if (slots[i].thread_id == thread_id) {
-      slot = &slots[i];
-      break;
-    }
-    if (slots[i].thread_id == 0) {
-      // 认领空槽。槽是顺序分配的，命中空槽即说明后面全空，无需继续找同 id。
-      slots[i].thread_id = thread_id;
-      slot = &slots[i];
-      break;
-    }
-  }
+  const uint32_t count = (std::min)(header->thread_preview_slot_count,
+                                    hibiki_voice_hook::kThreadPreviewCount);
+  hibiki_voice_hook::ThreadPreviewSlot* slot =
+      hibiki_voice_hook::FindThreadPreviewSlot(slots, count, thread_id);
   if (slot == nullptr) {
-    return;  // 槽满：该线程没有预览，但仍会经 ThreadCreate 出现在选择器里。
+    LeaveCriticalSection(&g_lunaSelectCs);
+    return;  // 只有 64 条同时存活线程时才会满；ThreadRemove 后的槽会立即可复用。
   }
+  const uint64_t generation = hibiki_voice_hook::NextThreadPreviewGeneration(
+      &header->thread_preview_write_count);
+  hibiki_voice_hook::BeginThreadPreviewWrite(slot, generation);
+  if (slot->thread_id == 0) {
+    slot->line_count = 0;
+    slot->artifact_count = 0;
+    ZeroMemory(slot->text, sizeof(slot->text));
+  }
+  slot->thread_id = thread_id;
   slot->line_count++;
   if (is_artifact) slot->artifact_count++;
   uint32_t byte_len = (text == nullptr || wlen <= 0)
@@ -797,9 +800,11 @@ void WriteThreadPreview(SharedHeader* header, uint64_t thread_id,
   slot->event_flags =
       is_artifact ? hibiki_voice_hook::kThreadPreviewFlagArtifact : 0u;
   slot->timestamp_ms = GetTickCount64();
-  slot->seq = static_cast<uint64_t>(InterlockedIncrement64(
-      reinterpret_cast<volatile LONGLONG*>(
-          &header->thread_preview_write_count)));  // 完成标记，最后写
+  hibiki_voice_hook::PublishThreadPreviewWrite(slot, generation);
+  // 全局计数最后发布：把它当变化信号的 reader 看到新 generation 时，槽必已是稳定偶数态。
+  hibiki_voice_hook::PublishThreadPreviewGeneration(
+      &header->thread_preview_write_count, generation);
+  LeaveCriticalSection(&g_lunaSelectCs);
 }
 
 // 多 hook 自动选干净线程：更新某 hookcode 的计数并重算当前赢家，返回本行是否应写入文本环。
@@ -969,13 +974,36 @@ void LunaThreadCreate(const wchar_t* hookcode, const char* hookname,
       hibiki_voice_hook::kTextEventThreadDiscovered, embedable ? 1u : 0u,
       nullptr, 0);
 }
-// 线程目录按捕获会话整体清理；移除事件暂不透传，避免用户刚选中的短生命周期线程在 Luna
-// 重建同一 ThreadParam 的间隙被 UI 擅自切回自动。
+// 移除事件不透传到线程目录，且不清 selected_text_thread_id / face map：同 ThreadParam 短暂
+// 重建仍沿用用户选择。这里只回收预览槽，避免累计超过 64 个历史线程后新线程永久没有预览。
 void LunaThreadRemove(const wchar_t* hookcode, const char* hookname,
                       LunaThreadParam tp) {
-  (void)hookcode;
-  (void)hookname;
-  (void)tp;
+  if (g_luna.header == nullptr || !g_lunaSelectCsInit ||
+      g_luna.header->thread_preview_offset == 0) {
+    return;
+  }
+  const uint64_t thread_id = LunaTextThreadId(hookcode, hookname, tp);
+  EnterCriticalSection(&g_lunaSelectCs);
+  auto* slots = reinterpret_cast<hibiki_voice_hook::ThreadPreviewSlot*>(
+      reinterpret_cast<uint8_t*>(g_luna.header) +
+      g_luna.header->thread_preview_offset);
+  const uint32_t count =
+      (std::min)(g_luna.header->thread_preview_slot_count,
+                 hibiki_voice_hook::kThreadPreviewCount);
+  for (uint32_t i = 0; i < count; ++i) {
+    auto* slot = &slots[i];
+    if (slot->thread_id != thread_id) continue;
+    const uint64_t generation =
+        hibiki_voice_hook::NextThreadPreviewGeneration(
+            &g_luna.header->thread_preview_write_count);
+    hibiki_voice_hook::BeginThreadPreviewWrite(slot, generation);
+    hibiki_voice_hook::ClearThreadPreviewPayload(slot);
+    hibiki_voice_hook::PublishThreadPreviewWrite(slot, generation);
+    hibiki_voice_hook::PublishThreadPreviewGeneration(
+        &g_luna.header->thread_preview_write_count, generation);
+    break;
+  }
+  LeaveCriticalSection(&g_lunaSelectCs);
 }
 void LunaHostInfo(int type, const wchar_t* log) {
   if (LunaDiagEnabled() && log != nullptr) {

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -737,7 +737,7 @@ void WriteLunaTextLine(SharedHeader* header, const wchar_t* hookcode,
 // 干净，其余是坏 hook 产生的伪影（整串重复 / 每字重复 N 次）。
 //
 // v12 起**不再自动挑赢家**：只有用户为本游戏显式选定的线程（selected_text_thread_id）
-// 或 profile 的 `prefer=` hook code 才能写进文本环，其余一行不发布。理由见
+// 才能写进文本环，profile 的 `prefer=` 不再绕过选择，其余一行不发布。理由见
 // luna_text_selector.h 的 LunaTextSelector 类注释。所有线程（含未选中的）仍会经
 // WriteThreadPreview 进预览区，用户据此挑选——"看得见"与"只装选定线程"由两块内存分别
 // 承担，不再互相排斥。

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -732,21 +732,75 @@ void WriteLunaTextLine(SharedHeader* header, const wchar_t* hookcode,
                      hibiki_voice_hook::kTextEventLine, 0, text, wlen);
 }
 
-// ── 多 hook 自动选干净线程（LunaHook 伪影过滤）────
+// ── 文本线程准入（LunaHook 伪影过滤 + 显式线程选择）────
 // LunaHook 对同一个游戏常同时装多条 hook，同一句对白会被多条各回传一次：只有一条
-// 干净，其余是坏 hook 产生的伪影（整串重复 / 每字重复 N 次）。这里按 hookcode 分组统计
-// clean/dirty，自动锁定表现最干净的那条 hook；用户在 Hibiki 选择线程后则以共享 header 的
-// selected_text_thread_id 覆盖自动赢家。重复伪影始终不写，手动选择也不能绕过过滤。
-
+// 干净，其余是坏 hook 产生的伪影（整串重复 / 每字重复 N 次）。
+//
+// v12 起**不再自动挑赢家**：只有用户为本游戏显式选定的线程（selected_text_thread_id）
+// 或 profile 的 `prefer=` hook code 才能写进文本环，其余一行不发布。理由见
+// luna_text_selector.h 的 LunaTextSelector 类注释。所有线程（含未选中的）仍会经
+// WriteThreadPreview 进预览区，用户据此挑选——"看得见"与"只装选定线程"由两块内存分别
+// 承担，不再互相排斥。
+//
 // EmbedKrkrZ 的精确完整行双写先折叠成第一份；其他引擎保持原过滤语义。
 // 伪影判别（纯函数）：给定规范化后的 [text,len]，判断是否为坏 hook 的重复伪影。
 //   ① 等长游程：对字符串做游程编码（连续相同字符归为一段），若段数 >=3 且所有段
 //     长度相等且 >=2 → 伪影（捕获每字×2/×3/×10 等）。
 // 其余为“干净”。
-// 线程选择的纯逻辑位于 luna_text_selector.h；运行时只负责跨回调加锁和读取手动选择值。
+// 线程准入的纯逻辑位于 luna_text_selector.h；运行时只负责跨回调加锁和读取手动选择值。
 hibiki_voice_hook::LunaTextSelector g_lunaTextSelector;
 CRITICAL_SECTION g_lunaSelectCs;
 bool g_lunaSelectCsInit = false;
+
+// v12：把本行记进该线程的预览槽。**必须在任何过滤/门控之前调用**——预览区存在的意义
+// 就是让用户看见那些没被发布的线程；只记已发布行等于什么都没做。
+//
+// 寻址按 thread_id 线性查找/认领，不取模全局序号：这正是预览区不会被逐字重绘型 hook
+// 挤爆的原因（它只覆盖自己的槽）。槽数有界、认领后不释放，故线性扫描的代价恒定且很小。
+//
+// 与 ShouldWrite 复用同一把锁，理由是二者本就在同一回调路径上顺序执行，多一把锁只会
+// 多一次加锁开销和一个新的死锁面。
+void WriteThreadPreview(SharedHeader* header, uint64_t thread_id,
+                        bool is_artifact, const wchar_t* text, int wlen) {
+  if (header == nullptr || thread_id == 0 || header->thread_preview_offset == 0) {
+    return;
+  }
+  auto* slots = reinterpret_cast<hibiki_voice_hook::ThreadPreviewSlot*>(
+      reinterpret_cast<uint8_t*>(header) + header->thread_preview_offset);
+  const uint32_t count = header->thread_preview_slot_count;
+  hibiki_voice_hook::ThreadPreviewSlot* slot = nullptr;
+  for (uint32_t i = 0; i < count; ++i) {
+    if (slots[i].thread_id == thread_id) {
+      slot = &slots[i];
+      break;
+    }
+    if (slots[i].thread_id == 0) {
+      // 认领空槽。槽是顺序分配的，命中空槽即说明后面全空，无需继续找同 id。
+      slots[i].thread_id = thread_id;
+      slot = &slots[i];
+      break;
+    }
+  }
+  if (slot == nullptr) {
+    return;  // 槽满：该线程没有预览，但仍会经 ThreadCreate 出现在选择器里。
+  }
+  slot->line_count++;
+  if (is_artifact) slot->artifact_count++;
+  uint32_t byte_len = (text == nullptr || wlen <= 0)
+                          ? 0
+                          : static_cast<uint32_t>(wlen) * sizeof(wchar_t);
+  const uint32_t max_bytes =
+      hibiki_voice_hook::kThreadPreviewTextChars * sizeof(wchar_t);
+  if (byte_len > max_bytes) byte_len = max_bytes;  // 截断到槽容量（wchar 边界）
+  if (byte_len != 0) memcpy(slot->text, text, byte_len);
+  slot->byte_len = byte_len;
+  slot->event_flags =
+      is_artifact ? hibiki_voice_hook::kThreadPreviewFlagArtifact : 0u;
+  slot->timestamp_ms = GetTickCount64();
+  slot->seq = static_cast<uint64_t>(InterlockedIncrement64(
+      reinterpret_cast<volatile LONGLONG*>(
+          &header->thread_preview_write_count)));  // 完成标记，最后写
+}
 
 // 多 hook 自动选干净线程：更新某 hookcode 的计数并重算当前赢家，返回本行是否应写入文本环。
 // hookcode 可能为 nullptr（归到空串 key）。冷启动（总 clean < 阈值）时干净行照写；一旦某
@@ -764,8 +818,10 @@ bool LunaShouldWriteLine(const wchar_t* hookcode, uint64_t thread_id,
                                                             ->selected_text_thread_id),
                                                    0, 0));
   if (!g_lunaSelectCsInit) {
-    return !is_artifact &&
-           (manually_selected == 0 || manually_selected == thread_id);
+    // 锁未初始化（理论上不该发生）时也遵守 v12 的"没显式选择就不发布"，否则这条退路会
+    // 变成一个悄悄恢复旧行为的后门。face 匹配需要锁保护的注册表，这里只能精确匹配。
+    return !is_artifact && manually_selected != 0 &&
+           manually_selected == thread_id;
   }
   // BUG-1159：face 登记必须**先于所有过滤分支**。下面的 preferred_hook_codes
   // 快路整段不进选择器，若只靠 ShouldWrite 内部登记，走快路的线程就永远没有
@@ -783,11 +839,9 @@ bool LunaShouldWriteLine(const wchar_t* hookcode, uint64_t thread_id,
     }
     return false;
   }
-  const std::wstring key =
-      (hookcode != nullptr) ? std::wstring(hookcode) : std::wstring();
   EnterCriticalSection(&g_lunaSelectCs);
-  const bool should_write = g_lunaTextSelector.ShouldWrite(
-      key, thread_id, is_artifact, manually_selected, face_id);
+  const bool should_write = g_lunaTextSelector.AcceptsLine(
+      thread_id, is_artifact, manually_selected, face_id);
   LeaveCriticalSection(&g_lunaSelectCs);
   return should_write;
 }
@@ -848,19 +902,29 @@ void LunaOutput(const wchar_t* hookcode, const char* hookname,
       fflush(stderr);
     }
     if (LunaPassesFilter(text, normalized_len)) {
-      // 多 hook 自动选干净线程：先判伪影并累计，再决定本行是否写入文本环。
+      // 先判伪影，再决定本行是否写入文本环。
       const bool artifact =
           hibiki_voice_hook::LunaTextIsArtifact(text, normalized_len);
       const uint64_t thread_id = LunaTextThreadId(hookcode, hookname, tp);
       const uint64_t face_id = LunaTextFaceId(hookcode, hookname, tp);
+      // v12：预览必须写在门控**之前**且无条件（含伪影行）。预览区的全部意义就是让用户
+      // 看见未被发布的线程；放到门控之后就只剩已选中的那条，等于没做。
+      WriteThreadPreview(g_luna.header, thread_id, artifact, text,
+                         normalized_len);
+      // LunaHook 权威标记：游戏内 GDI 文本 hook 据此让位，避免双写者污染（见
+      // voice_hook_ipc.h SharedHeader::luna_active 注释）。幂等，写 1 即可。
+      //
+      // v12：判据从「已**发布**干净行」改成「已**观测到**干净行」。取消自动选线程后
+      // 用户选定之前一行都不发布，若仍绑在发布上，luna_active 永远是 0，GDI 会在整个
+      // 选线程期间把逐字重绘垃圾灌进文本环——旧行为下自动赢家几行内就置位，这个窗口
+      // 根本不存在。绑在观测上既保住原意（LunaHook 确实覆盖了这个引擎 → GDI 让位），
+      // 又不依赖发布门控；LunaHook 对该引擎无输出时 luna_active 仍为 0，GDI 兜底照旧。
+      if (!artifact) {
+        g_luna.header->luna_active = 1;
+      }
       if (LunaShouldWriteLine(hookcode, thread_id, artifact, face_id)) {
         WriteLunaTextLine(g_luna.header, hookcode, hookname, tp, thread_id, text,
                           normalized_len);
-        // 一旦 LunaHook 写出干净行，标记 LunaHook 权威：游戏内 GDI 文本 hook 让位不再写文本，
-        // 避免双写者污染（见 voice_hook_ipc.h SharedHeader::luna_active 注释）。幂等，写 1 即可。
-        if (!artifact) {
-          g_luna.header->luna_active = 1;
-        }
       }
     }
   }
@@ -1281,18 +1345,23 @@ int RunInjection(HANDLE target, DWORD pid, const std::wstring& dll_path,
   // hold 模式下常驻维持它存活，供 host 消费。
   const uint32_t ring_capacity = ComputeRingCapacity();
   const uint32_t loopback_capacity = ComputeLoopbackCapacity();
-  // v6 布局：[SharedHeader][音频环形 ring_capacity][文本环 kTextSlotCount*kTextSlotBytes]
+  // v12 布局：[SharedHeader][音频环形 ring_capacity][文本环 kTextSlotCount*kTextSlotBytes]
   //          [clip 索引 kClipCount*sizeof(VoiceClip)][loopback 环 loopback_capacity]
-  //          [loopback 标记表 kLoopbackMarkerCount*sizeof(LoopbackMarker)]。各区偏移下面填进 header。
+  //          [loopback 标记表 kLoopbackMarkerCount*sizeof(LoopbackMarker)]
+  //          [线程预览区 kThreadPreviewCount*sizeof(ThreadPreviewSlot)]。各区偏移下面填进 header。
   const uint64_t text_region_bytes =
       static_cast<uint64_t>(kTextSlotCount) * kTextSlotBytes;
   const uint64_t clip_region_bytes =
       static_cast<uint64_t>(kClipCount) * sizeof(VoiceClip);
   const uint64_t loopback_marker_bytes =
       static_cast<uint64_t>(kLoopbackMarkerCount) * sizeof(LoopbackMarker);
+  const uint64_t thread_preview_bytes =
+      static_cast<uint64_t>(hibiki_voice_hook::kThreadPreviewCount) *
+      sizeof(hibiki_voice_hook::ThreadPreviewSlot);
   const uint64_t total_size = sizeof(SharedHeader) + ring_capacity +
                               text_region_bytes + clip_region_bytes +
-                              loopback_capacity + loopback_marker_bytes;
+                              loopback_capacity + loopback_marker_bytes +
+                              thread_preview_bytes;
   const std::wstring shm = SharedMemoryName(pid);
   SetLastError(ERROR_SUCCESS);
   HANDLE mapping = CreateFileMappingW(
@@ -1348,6 +1417,11 @@ int RunInjection(HANDLE target, DWORD pid, const std::wstring& dll_path,
     header->loopback_marker_offset = static_cast<uint32_t>(
         header->loopback_ring_offset + loopback_capacity);
     header->loopback_marker_slot_count = kLoopbackMarkerCount;
+    // v12：线程预览区紧随标记表。放在**布局最尾**是有意的——前面各区的偏移一个都不动，
+    // 旧 host 即使只认到 v11 的字段也不会读错位（版本号仍会先把它挡掉，这只是纵深防御）。
+    header->thread_preview_offset = static_cast<uint32_t>(
+        header->loopback_marker_offset + loopback_marker_bytes);
+    header->thread_preview_slot_count = hibiki_voice_hook::kThreadPreviewCount;
   } else {
     fprintf(stderr,
             "[session] reusing live hook mapping pid=%lu text=%u audioBytes=%llu\n",

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -807,12 +807,10 @@ void WriteThreadPreview(SharedHeader* header, uint64_t thread_id,
   LeaveCriticalSection(&g_lunaSelectCs);
 }
 
-// 多 hook 自动选干净线程：更新某 hookcode 的计数并重算当前赢家，返回本行是否应写入文本环。
-// hookcode 可能为 nullptr（归到空串 key）。冷启动（总 clean < 阈值）时干净行照写；一旦某
-// hook 累计干净行达阈值即锁定为赢家，之后只写赢家的行；赢家按 clean_count 最高 + 占比
-// clean/(clean+dirty) >= 0.5 重选，可随游戏切换重新评估。
-bool LunaShouldWriteLine(const wchar_t* hookcode, uint64_t thread_id,
-                         bool is_artifact, uint64_t face_id) {
+// v12 文本环只接受用户显式选择的线程。hookcode/profile prefer 不参与准入判定：否则
+// selected_text_thread_id 仍为 0、UI 显示未选择时，profile 快路却会在后台悄悄发布文本。
+bool LunaShouldWriteLine(uint64_t thread_id, bool is_artifact,
+                         uint64_t face_id) {
   const uint64_t manually_selected = g_luna.header == nullptr
                                          ? 0
                                          : static_cast<uint64_t>(
@@ -828,22 +826,12 @@ bool LunaShouldWriteLine(const wchar_t* hookcode, uint64_t thread_id,
     return !is_artifact && manually_selected != 0 &&
            manually_selected == thread_id;
   }
-  // BUG-1159：face 登记必须**先于所有过滤分支**。下面的 preferred_hook_codes
-  // 快路整段不进选择器，若只靠 ShouldWrite 内部登记，走快路的线程就永远没有
-  // face；Dart 跨会话记忆恢复恰恰只从这些“已出过行”的线程里挑，于是
-  // FaceOf 返 0 → 退回精确匹配 → 原症状原样复现。
+  // BUG-1159：face 登记必须**先于准入判定**。Dart 跨会话记忆恢复会在未选择阶段
+  // 根据预览行数挑线程；这些行不进文本环，但仍必须提前登记 face，才能在恢复选定后
+  // 接受同一 hook 面的兄弟线程。
   EnterCriticalSection(&g_lunaSelectCs);
   g_lunaTextSelector.NoteFace(thread_id, face_id);
   LeaveCriticalSection(&g_lunaSelectCs);
-  if (manually_selected == 0 && !g_luna.preferred_hook_codes.empty()) {
-    if (is_artifact) return false;
-    for (const std::wstring& preferred : g_luna.preferred_hook_codes) {
-      if (hibiki_voice_hook::LunaHookCodeMatchesBlock(preferred, hookcode)) {
-        return true;
-      }
-    }
-    return false;
-  }
   EnterCriticalSection(&g_lunaSelectCs);
   const bool should_write = g_lunaTextSelector.AcceptsLine(
       thread_id, is_artifact, manually_selected, face_id);
@@ -927,7 +915,7 @@ void LunaOutput(const wchar_t* hookcode, const char* hookname,
       if (!artifact) {
         g_luna.header->luna_active = 1;
       }
-      if (LunaShouldWriteLine(hookcode, thread_id, artifact, face_id)) {
+      if (LunaShouldWriteLine(thread_id, artifact, face_id)) {
         WriteLunaTextLine(g_luna.header, hookcode, hookname, tp, thread_id, text,
                           normalized_len);
       }
@@ -1113,8 +1101,8 @@ bool InitLunaHook(SharedHeader* header, HANDLE target, DWORD pid, int codepage,
     bridge.settings(200, true, codepage, 8192, 1000, false);
   }
 
-  // 多 hook 自动选干净线程的计数锁：Output 回调可在 LunaHook 工作线程并发，
-  // 于 start() 注册回调前初始化（进程生命期内一次，多次 Init 由 flag 守卫）。
+  // 文本线程 face 表、显式选择判定与预览 writer 的共享锁：Output/ThreadRemove 回调可在
+  // LunaHook 工作线程并发，于 start() 注册回调前初始化（进程生命期内一次）。
   if (!g_lunaSelectCsInit) {
     InitializeCriticalSection(&g_lunaSelectCs);
     g_lunaSelectCsInit = true;

--- a/native/galgame_hook/tests/fixtures/luna_thread_selection.tsv
+++ b/native/galgame_hook/tests/fixtures/luna_thread_selection.tsv
@@ -1,9 +1,14 @@
-# hook_code	thread_id	manual_thread	text	expected_write
-bad	1	0	menu	1
-bad	1	0	load	1
-good	2	0	dialogue	0
-bad	1	0	AABBCC	0
-good	2	0	clean-line	1
-bad	1	1	manual-line	1
-bad	1	1	AABBCC	0
-good	2	0	clean-again	1
+# thread_id	manual_thread	text	expected_write
+#
+# 文本环准入的黄金表（v12）。契约：manual_thread==0（用户尚未为本游戏选定线程）时
+# **一行都不发布**，无论文本多干净、也无论该线程已经出过多少行。旧实现在这里会按
+# hookcode 统计 clean/dirty 自动锁定「赢家」并放行——那正是 BUG-1193 里用户被锁死在
+# 猜错线程上的成因，故 hook_code 列已随判定一起移除。伪影行任何情况下都不进文本环。
+1	0	menu	0
+1	0	load	0
+2	0	dialogue	0
+2	0	clean-line	0
+1	1	manual-line	1
+1	1	AABBCC	0
+2	1	other-thread	0
+1	1	clean-again	1

--- a/native/galgame_hook/tests/luna_text_replay_test.cpp
+++ b/native/galgame_hook/tests/luna_text_replay_test.cpp
@@ -202,9 +202,8 @@ int main(int argc, char** argv) {
     }
   }
   {
-    // BUG-1159 跨会话恢复路径：injector 的 preferred_hook_codes 快路不进选择器，
-    // 靠的是 NoteFace 单独登记。只要选定线程本会话出过行，即使它一行都没进过准入判定，
-    // 兄弟线程也必须能被认回。
+    // BUG-1159 跨会话恢复路径：未选择阶段的行不进文本环，只靠 NoteFace 单独登记。
+    // 只要选定线程本会话出过预览行，即使它一行都没通过准入判定，兄弟线程也必须能被认回。
     hibiki_voice_hook::LunaTextSelector restore_selector;
     const uint64_t remembered = 5001, sibling = 5002, face = 909;
     restore_selector.NoteFace(remembered, face);

--- a/native/galgame_hook/tests/luna_text_replay_test.cpp
+++ b/native/galgame_hook/tests/luna_text_replay_test.cpp
@@ -166,59 +166,71 @@ int main(int argc, char** argv) {
         pid, krkr_addr, 0x18fe40ull, 0x2ull, split_code, krkr_name);
 
     hibiki_voice_hook::LunaTextSelector face_selector;
-    const std::wstring krkr_key(krkr_code);
-    if (!face_selector.ShouldWrite(krkr_key, selected_thread, false,
-                                   selected_thread, krkr_face)) {
+    if (!face_selector.AcceptsLine(selected_thread, false, selected_thread,
+                                   krkr_face)) {
       return 35;  // 选定线程自己当然要放行
     }
-    if (!face_selector.ShouldWrite(krkr_key, sibling_thread, false,
-                                   selected_thread, krkr_face)) {
+    if (!face_selector.AcceptsLine(sibling_thread, false, selected_thread,
+                                   krkr_face)) {
       return 36;  // 同 hook 面、不同 ctx → 必须放行（本 bug 的核心回归点）
     }
     // 跨引擎负向：另一个引擎的行绝不能被并进选定线程。
-    if (face_selector.ShouldWrite(std::wstring(siglus_code), siglus_thread,
-                                  false, selected_thread, siglus_face)) {
+    if (face_selector.AcceptsLine(siglus_thread, false, selected_thread,
+                                  siglus_face)) {
       return 37;
     }
     // split H 码负向：同 addr、同 hookcode，仅 ctx2 不同（角色名）→ 必须挡掉。
     hibiki_voice_hook::LunaTextSelector split_selector;
-    if (!split_selector.ShouldWrite(std::wstring(split_code), split_body_thread,
-                                    false, split_body_thread,
+    if (!split_selector.AcceptsLine(split_body_thread, false, split_body_thread,
                                     split_body_face)) {
       return 38;
     }
-    if (split_selector.ShouldWrite(std::wstring(split_code), split_name_thread,
-                                   false, split_body_thread,
+    if (split_selector.AcceptsLine(split_name_thread, false, split_body_thread,
                                    split_name_face)) {
       return 39;
     }
-    if (face_selector.ShouldWrite(krkr_key, sibling_thread, true,
-                                  selected_thread, krkr_face)) {
+    if (face_selector.AcceptsLine(sibling_thread, true, selected_thread,
+                                  krkr_face)) {
       return 40;  // 伪影门在选择之前，放宽粒度不得让伪影漏进来
     }
   }
   {
     // face 未知（调用方给 0）时退回精确 thread_id 匹配，与旧实现语义一致。
     hibiki_voice_hook::LunaTextSelector legacy_selector;
-    if (legacy_selector.ShouldWrite(L"HB0@0:test.exe", 1002, false, 1001, 0)) {
+    if (legacy_selector.AcceptsLine(1002, false, 1001, 0)) {
       return 41;
     }
   }
   {
     // BUG-1159 跨会话恢复路径：injector 的 preferred_hook_codes 快路不进选择器，
-    // 靠的是 NoteFace 单独登记。只要选定线程本会话出过行（Dart 恢复前提是 >= 3 行），
-    // 即使它一行都没进过 ShouldWrite，兄弟线程也必须能被认回。
+    // 靠的是 NoteFace 单独登记。只要选定线程本会话出过行，即使它一行都没进过准入判定，
+    // 兄弟线程也必须能被认回。
     hibiki_voice_hook::LunaTextSelector restore_selector;
     const uint64_t remembered = 5001, sibling = 5002, face = 909;
     restore_selector.NoteFace(remembered, face);
     if (restore_selector.FaceOf(remembered) != face) return 42;
-    if (!restore_selector.ShouldWrite(L"HB0@0:test.exe", sibling, false,
-                                      remembered, face)) {
+    if (!restore_selector.AcceptsLine(sibling, false, remembered, face)) {
       return 43;
     }
     // Reset 必须一并清掉 face 表，否则换游戏后旧 face 会幽灵放行。
     restore_selector.Reset();
     if (restore_selector.FaceOf(remembered) != 0) return 44;
+  }
+  {
+    // BUG-1193 / v12 核心：**没有显式选择就一行都不发布**，无论这行多干净、也无论
+    // 之前那条 hook 表现多好。旧实现在这里会自动锁定赢家并放行，正是它把用户锁死在
+    // 猜错的线程上。这条是防"自动选线程"以任何形式悄悄回归的守卫。
+    hibiki_voice_hook::LunaTextSelector no_auto;
+    for (int i = 0; i < 16; ++i) {
+      // 反复喂同一条线程的干净行——旧实现累计到阈值就会 primed 并放行。
+      if (no_auto.AcceptsLine(7001, false, 0, 4242)) return 45;
+    }
+    // 另一条线程同样不得被自动选中。
+    if (no_auto.AcceptsLine(7002, false, 0, 4243)) return 46;
+    // 用户显式选定之后才开始发布。
+    if (!no_auto.AcceptsLine(7001, false, 7001, 4242)) return 47;
+    // face 登记必须在"未选择"阶段就已发生，否则用户选定后第一批兄弟线程会被漏掉。
+    if (no_auto.FaceOf(7002) != 4243) return 48;
   }
 
   std::ifstream input(argv[1]);
@@ -230,15 +242,16 @@ int main(int argc, char** argv) {
     if (line.empty() || line[0] == '#') continue;
     ++row;
     const auto fields = Split(line);
-    if (fields.size() != 5) return 10 + row;
-    const std::wstring hook(fields[0].begin(), fields[0].end());
-    const std::wstring text(fields[3].begin(), fields[3].end());
-    const bool actual = selector.ShouldWrite(
-        hook, std::stoull(fields[1]),
+    // v12 起 hook_code 不参与准入判定（自动赢家已退役），fixture 随之去掉该列——
+    // 留一个没人读的列只会让下一个读者以为它还有意义。
+    if (fields.size() != 4) return 10 + row;
+    const std::wstring text(fields[2].begin(), fields[2].end());
+    const bool actual = selector.AcceptsLine(
+        std::stoull(fields[0]),
         hibiki_voice_hook::LunaTextIsArtifact(text.c_str(),
                                                static_cast<int>(text.size())),
-        std::stoull(fields[2]));
-    if (actual != (fields[4] == "1")) return 100 + row;
+        std::stoull(fields[1]));
+    if (actual != (fields[3] == "1")) return 100 + row;
   }
   return row == 8 ? 0 : 3;
 }

--- a/native/galgame_hook/tests/thread_preview_ipc_test.cpp
+++ b/native/galgame_hook/tests/thread_preview_ipc_test.cpp
@@ -1,0 +1,152 @@
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "thread_preview_ipc.h"
+
+namespace {
+
+using hibiki_voice_hook::ThreadPreviewSlot;
+using hibiki_voice_hook::ThreadPreviewSnapshot;
+
+struct PreviewTable {
+  volatile uint64_t write_count = 0;
+  std::array<ThreadPreviewSlot, hibiki_voice_hook::kThreadPreviewCount> slots{};
+  std::mutex writer_mutex;
+};
+
+void WritePattern(PreviewTable* table, uint64_t thread_id) {
+  std::lock_guard<std::mutex> lock(table->writer_mutex);
+  ThreadPreviewSlot* slot = hibiki_voice_hook::FindThreadPreviewSlot(
+      table->slots.data(), static_cast<uint32_t>(table->slots.size()),
+      thread_id);
+  if (slot == nullptr) return;
+  const uint64_t generation =
+      hibiki_voice_hook::NextThreadPreviewGeneration(&table->write_count);
+  hibiki_voice_hook::BeginThreadPreviewWrite(slot, generation);
+  slot->thread_id = thread_id;
+  slot->timestamp_ms = generation * 3;
+  slot->line_count = generation;
+  slot->artifact_count = generation ^ 0x55aa55aaull;
+  slot->byte_len = 128 * sizeof(wchar_t);
+  slot->event_flags = static_cast<uint32_t>(generation & 1u);
+  const wchar_t pattern = static_cast<wchar_t>(L'A' + (generation % 23));
+  for (uint32_t i = 0; i < 128; ++i) slot->text[i] = pattern;
+  hibiki_voice_hook::PublishThreadPreviewWrite(slot, generation);
+  hibiki_voice_hook::PublishThreadPreviewGeneration(&table->write_count,
+                                                    generation);
+}
+
+void RemovePreview(PreviewTable* table, uint64_t thread_id) {
+  std::lock_guard<std::mutex> lock(table->writer_mutex);
+  for (ThreadPreviewSlot& slot : table->slots) {
+    if (slot.thread_id != thread_id) continue;
+    const uint64_t generation =
+        hibiki_voice_hook::NextThreadPreviewGeneration(&table->write_count);
+    hibiki_voice_hook::BeginThreadPreviewWrite(&slot, generation);
+    hibiki_voice_hook::ClearThreadPreviewPayload(&slot);
+    hibiki_voice_hook::PublishThreadPreviewWrite(&slot, generation);
+    hibiki_voice_hook::PublishThreadPreviewGeneration(&table->write_count,
+                                                      generation);
+    return;
+  }
+}
+
+bool SnapshotMatchesOneGeneration(const ThreadPreviewSnapshot& snapshot) {
+  if (snapshot.thread_id == 0) return true;
+  if ((snapshot.seq & 1u) != 0) return false;
+  const uint64_t generation = snapshot.seq >> 1;
+  if (snapshot.timestamp_ms != generation * 3 ||
+      snapshot.line_count != generation ||
+      snapshot.artifact_count != (generation ^ 0x55aa55aaull) ||
+      snapshot.byte_len != 128 * sizeof(wchar_t) ||
+      snapshot.event_flags != static_cast<uint32_t>(generation & 1u)) {
+    return false;
+  }
+  const wchar_t pattern = static_cast<wchar_t>(L'A' + (generation % 23));
+  for (uint32_t i = 0; i < 128; ++i) {
+    if (snapshot.text[i] != pattern) return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+int main() {
+  PreviewTable table;
+
+  // 回收后允许空洞：已有 id 必须优先命中，新的第 65 条线程必须复用被释放的槽。
+  for (uint64_t id = 1; id <= hibiki_voice_hook::kThreadPreviewCount; ++id) {
+    WritePattern(&table, id);
+  }
+  if (hibiki_voice_hook::FindThreadPreviewSlot(
+          table.slots.data(), static_cast<uint32_t>(table.slots.size()),
+          1000) != nullptr) {
+    return 1;
+  }
+  ThreadPreviewSlot* released = &table.slots[16];
+  RemovePreview(&table, 17);
+  if (hibiki_voice_hook::FindThreadPreviewSlot(
+          table.slots.data(), static_cast<uint32_t>(table.slots.size()),
+          1000) != released) {
+    return 2;
+  }
+  WritePattern(&table, 1000);
+  ThreadPreviewSnapshot reused;
+  if (!hibiki_voice_hook::TryReadThreadPreviewSnapshot(*released, &reused) ||
+      reused.thread_id != 1000 || !SnapshotMatchesOneGeneration(reused)) {
+    return 3;
+  }
+
+  // reader 若拿着旧 begin，期间发生覆盖，末读必须拒绝旧 seq，不能把新 payload 当旧快照。
+  const uint64_t old_sequence =
+      hibiki_voice_hook::AtomicLoadPreview64(&released->seq);
+  WritePattern(&table, 1000);
+  ThreadPreviewSnapshot mixed_candidate;
+  hibiki_voice_hook::CopyThreadPreviewSnapshot(
+      *released, old_sequence, &mixed_candidate);
+  if (hibiki_voice_hook::ThreadPreviewSequenceIsStable(*released,
+                                                       old_sequence)) {
+    return 4;
+  }
+
+  // 多 writer + remove/reuse + lock-free reader 压测。生产 writer 同样由一把锁串行，
+  // reader 只靠跨进程可用的 odd/even seq 验证快照。
+  PreviewTable stress;
+  std::atomic<int> writers_done{0};
+  std::atomic<bool> failed{false};
+  std::vector<std::thread> writers;
+  for (uint64_t thread_id = 1; thread_id <= 4; ++thread_id) {
+    writers.emplace_back([&stress, &writers_done, thread_id]() {
+      for (int i = 0; i < 200000; ++i) WritePattern(&stress, thread_id);
+      writers_done.fetch_add(1, std::memory_order_release);
+    });
+  }
+  std::thread recycler([&stress, &writers_done]() {
+    while (writers_done.load(std::memory_order_acquire) != 4) {
+      RemovePreview(&stress, 3);
+      WritePattern(&stress, 3);
+    }
+  });
+  std::thread reader([&stress, &writers_done, &failed]() {
+    do {
+      for (const ThreadPreviewSlot& slot : stress.slots) {
+        ThreadPreviewSnapshot snapshot;
+        if (hibiki_voice_hook::TryReadThreadPreviewSnapshot(slot, &snapshot) &&
+            !SnapshotMatchesOneGeneration(snapshot)) {
+          failed.store(true, std::memory_order_release);
+          return;
+        }
+      }
+    } while (writers_done.load(std::memory_order_acquire) != 4);
+  });
+
+  for (std::thread& writer : writers) writer.join();
+  recycler.join();
+  reader.join();
+  return failed.load(std::memory_order_acquire) ? 5 : 0;
+}


### PR DESCRIPTION
## 起因

用户报：「Luna 有正确分开（中文/日文），我们没有，两个语言混一块了，并且没办法选择。」

## 读上游源码得到的定案

源码：`HIllya51/LunaTranslator@v10.16.1.2`（与本仓 vendored DLL 同版本，`KiriKiri.cpp` 字节数一致）。

1. **中日文在 EmbedKrkrZ 内部结构上不可分**。该 hook 带 `NO_CONTEXT`（`engine32/KiriKiri.cpp:1544`），`texthook.cc:364` 的 `if (hp.type & (NO_CONTEXT|FIXING_SPLIT)) lpRetn = 0;` 把 ctx 强制清零后才组装 `ThreadParam`，于是它的全部输出落在**逐字节相同**的同一个 tp 上。→ BUG-1193 里「同 hook 不同 ctx2」的猜测排除；也说明任何「在这条线程里分中日」的做法都是死路。
2. **译文会经同一 hook 回流并被上报**：`texthook.cc:393` 是 `TextOutput` 在前、内嵌替换在后；被替换的串再走一遍流程会再次撞上该 hook，`checktranslatedok`（`embed_util.cc:267`）认出自产译文后**只清 `EMBED_ABLE` 位、不 `__leave`**，译文照样上报。
3. **Luna「能分开」靠的是不丢弃**：`LunaHost/host.cpp:222-243` 每个 `ThreadParam` 一个 `TextThread`，全路径无 winner 分支；去重复是线程内部的（`textthread.cpp:5-12`）。用户切到 `TextRender` 那条纯日文线程即可。我们的症状是 winner 门把其余线程掐成空壳 —— 列表里有、选了没内容。

## 根因与做法

真正的 bug 不是门控，是**一块 256 槽全局 FIFO 同时伺候两个诉求相反的消费者**：语音配对要高信噪的单条线程，选择器要每条线程都有样本。直接放开门控必然把配对候选挤出环（`kExpired` → 降级 loopback，即 BUG-1159 的失败链）——这正是上一版方案被撤下的原因。

本 PR 把两者拆到两块内存：

| | 文本环（Ring A） | 线程预览区（新增） |
|---|---|---|
| 装什么 | 当前生效线程的行 | 每条线程最近一行 + 观测统计 |
| 寻址 | 全局写序号取模 | **按 thread_id 认领固定槽** |
| 谁能挤掉谁 | 谁写得快谁占满 | **只能覆盖自己的槽** |

按线程分槽是关键：逐字重绘型 hook 无论多吵都挤不掉别的线程 —— 挤压从「要小心防」变成**结构上不可能**。这是取消自动选线程的前提。

**Ring A 语义一个字节没动**，配对/loopback 路径无回归面；也因此不需要每个引擎重新过证据门。

## 行为变更（按用户要求）

- **不再自动挑赢家**。`LunaTextSelector` 的 winner 统计整体删除（`ShouldWrite` → `AcceptsLine`），只有用户显式选定或 profile `prefer=` 才发布。
- **每个游戏第一次由用户自己选**，之后按 exe 指纹自动恢复。
- 原方案的死结（Dart 自动选线程 → 回写 `selected_text_thread_id` → 重新激活过滤）随自动选择一起消失，不需要额外机制。

## 连带修复（都是取消自动选线程后才暴露的）

- `luna_active` 判据从「已**发布**干净行」改为「已**观测到**干净行」。绑在发布上会让它在整个选线程期间恒为 0，游戏内 GDI 逐字垃圾灌满文本环 —— 旧行为下自动赢家几行内就置位，这个窗口根本不存在。
- `_maybeRestoreTextThread` 的消歧判据改用 `observedLineCount`（预览槽 `line_count`，含被过滤/门控丢弃的行）。用已发布行数会让跨会话记忆**永远无法恢复**、每局都要重选 —— 这是「第一次手选」与「之后自动恢复」能同时成立的关键。
- 线程下拉的行数/预览改读观测值；空选项 `game_text_thread_all` → `game_text_thread_unset`（不选 = 不发布，旧文案「全部线程」会误导）。

## 验证

| 项 | 结果 |
|---|---|
| native x86 cmake Release 构建 | ✅ exit 0 |
| native x86 ctest | ✅ 22/22 |
| `generate_engine_support.py --check` / `generate_luna_profiles.py --check` | ✅ OK |
| `adapter_structure_test` / `galhook_workflow_test` / `engine_support_manifest_test` | ✅ OK |
| `flutter analyze`（含 test） | ✅ No issues found |
| 定向 `flutter test`（texthooker_service + voice_hook_ipc_contract） | ✅ 29/29 |
| native x64 构建 | ⚠️ 卡在 `hibiki_unity_audio_runtime` 的联网下载步骤，与本改动无关（无任何 C++ 编译错误） |
| 全量 `flutter_test_failures.dart` | ❌ **未跑完**（按作者要求跳过）。两次尝试都在整套跑完前被 10 分钟工具超时掐断，**不是测试失败**——该工具把输出全缓冲到结束才吐，中断后无 verdict 可读。残留 `flutter_tester`/`dartaotruntime` 已按 worktree 路径清理并确认归零（否则会锁住 `sqlite3.dll` 让下一轮「零测试执行」伪装成通过，见 BUG-1157）。**合入 develop 前必须补跑并确认 `FLUTTER TEST VERDICT: PASSED`。** |
| **真机 E2E** | ❌ **未做** |

## 未验证 / 后续

- **真机 E2E 未做**：需要在用户原始启动路径跑「显示台词 → 选线程 → 对应语音 → 配对 → 真卡写入」。按 SOP 本 PR 只能算 `implemented_unverified`。
- helper 需**重新双架构构建并发 release**，用户机上的 `voice_hook/<arch>` 才会拿到 v12；在那之前旧 helper 与新 host 版本号不匹配会被拒绝（这是预期的纵深防御，不是 bug）。
- 旧 helper + 新 host：`pollThreadPreviews` 返回 null，选择器退回旧行为（只有已发布线程有内容），不崩。


