### PR TITLE
fix(tracking): 按页翻的书不再把页码当章数报给 Bangumi + format 收敛成 BookFormat

### DIFF
--- a/hibiki/lib/src/media/manga/book_format_convert.dart
+++ b/hibiki/lib/src/media/manga/book_format_convert.dart
@@ -21,6 +21,8 @@
 /// 真正的产物重建在 `book_format_rebuild.dart`。
 library;
 
+import 'package:hibiki_core/hibiki_core.dart';
+
 /// 转化目标。
 enum BookFormatTarget {
   /// 转成漫画（`format='manga'`）：产出页图 + `manga.json`，之后可跑整卷 OCR 查词。
@@ -94,11 +96,11 @@ class BookSourceProbe {
 /// [format] / [sourceAbsolutePath] 来自 `EpubBooks` 行（后者 =
 /// `p.join(extractDir, epubPath)`），[probe] 是调用方的磁盘探测结果。
 BookConvertVerdict verdictToManga({
-  required String format,
+  required BookFormat format,
   required String sourceAbsolutePath,
   required BookSourceProbe probe,
 }) {
-  if (format == 'manga') {
+  if (format == BookFormat.manga) {
     return const BookConvertVerdict.blocked(BookConvertBlocker.alreadyTarget);
   }
   if (!probe.sourceExists) {
@@ -106,7 +108,7 @@ BookConvertVerdict verdictToManga({
   }
   // PDF 每一页都能栅格化成页图，恒可转（扫描版 PDF 转过来正是刚需：PDF 阅读器
   // 对无文本层的扫描件明确不做 OCR 兜底，转成漫画才有查词）。
-  if (format == 'pdf') {
+  if (format == BookFormat.pdf) {
     return BookConvertVerdict.supported(sourceAbsolutePath);
   }
   // 普通 EPUB：只有「图片型」（扫描版漫画常见的分发形态）才有页图可用。
@@ -122,10 +124,10 @@ BookConvertVerdict verdictToManga({
 /// 「转回」是把 `epubPath` 指回书目录里**仍在的**原始 `.epub`/`.pdf`——那才是真书。
 /// 从 `.mokuro`/裸图片目录导入的漫画没有这样的原始文件，不支持（不造假书）。
 BookConvertVerdict verdictToBook({
-  required String format,
+  required BookFormat format,
   required BookSourceProbe probe,
 }) {
-  if (format != 'manga') {
+  if (format != BookFormat.manga) {
     return const BookConvertVerdict.blocked(BookConvertBlocker.alreadyTarget);
   }
   final String? original = probe.recoverableOriginalPath;

--- a/hibiki/lib/src/media/manga/manga_importer.dart
+++ b/hibiki/lib/src/media/manga/manga_importer.dart
@@ -301,7 +301,7 @@ class MangaImporter {
           chapterCount: total,
           chaptersJson: '[]',
           importedAt: importedAtMs,
-          format: const Value('manga'),
+          format: Value(BookFormat.manga.dbValue),
           // mangaReadingMode 留 absent(null)：跟随阅读器自动判定（P1-L4 契约）。
           sourceId: sourceId != null ? Value(sourceId) : const Value.absent(),
         ),

--- a/hibiki/lib/src/media/sources/reader_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/reader_hibiki_source.dart
@@ -503,8 +503,9 @@ class ReaderHibikiSource extends ReaderMediaSource {
     // 缺这条分流，PDF/漫画行会用 EPUB 阅读器打开并在解压/解析路径崩溃。媒体标识前缀
     // 共用 `hoshi://book/<bookKey>`（bookKey 是主键、与 format 无关），路由只认
     // mediaSourceIdentifier。
-    final bool isPdf = book.format == 'pdf';
-    final bool isManga = book.format == 'manga';
+    final BookFormat format = BookFormat.parseOrEpub(book.format);
+    final bool isPdf = format == BookFormat.pdf;
+    final bool isManga = format == BookFormat.manga;
     // 页码型书（PDF/漫画）：进度单位是页而非章内字数。
     final bool pageBased = isPdf || isManga;
 

--- a/hibiki/lib/src/media/tracking/media_tracking_repository.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_repository.dart
@@ -427,14 +427,21 @@ class MediaTrackingRepository {
     return result;
   }
 
-  Future<int> loadBookChapterProgress({
+  /// 返回这本书「已读完多少章」，**null = 这本书没有章的概念，不要上报章进度**。
+  ///
+  /// 只有 `format='epub'` 的文字书有章。PDF / 漫画的 `chaptersJson` 是 `'[]'`、
+  /// `tocJson` 是 null，阅读位置的 `sectionIndex` 存的是**页码**——旧实现在这里只
+  /// 挡了 `'manga'`，PDF 一路走下去会在 [estimateCompletedBookChapters] 的
+  /// 「无 toc 即早退」分支拿到 `fallbackProgress`，也就是把**当前页码当成已读章数**
+  /// 报给 Bangumi。两个调用点（这里与下面 loadCompletedBookTrackingProgress）现在按
+  /// 同一判据 [BookFormat.isPagedImageBook] 收口，缺一处就会重新漂开。
+  Future<int?> loadBookChapterProgress({
     required String bookKey,
     required int fallbackProgress,
   }) async {
     final EpubBookRow? book = await _db.getEpubBook(bookKey);
-    if (book == null || book.format == 'manga') {
-      return math.max(0, fallbackProgress);
-    }
+    if (book == null) return math.max(0, fallbackProgress);
+    if (BookFormat.parseOrEpub(book.format).isPagedImageBook) return null;
     final ReaderPositionRow? position = await _db.getReaderPosition(bookKey);
     if (position == null) return math.max(0, fallbackProgress);
     return estimateCompletedBookChapters(
@@ -561,6 +568,9 @@ class MediaTrackingRepository {
       final int localProgress;
       if (isChapterCompanion ||
           mapping.progressMode == TrackingProgressMode.chapter.value) {
+        // 与 [loadBookChapterProgress] 同一判据：按页翻的书（PDF / 漫画）没有章，
+        // 这里的 fallbackProgress 是 sectionIndex＝页码，报出去就是错数。宁可不报。
+        if (BookFormat.parseOrEpub(book.format).isPagedImageBook) continue;
         localProgress = estimateCompletedBookChapters(
           chaptersJson: book.chaptersJson,
           tocJson: book.tocJson,

--- a/hibiki/lib/src/media/tracking/media_tracking_repository.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_repository.dart
@@ -433,7 +433,7 @@ class MediaTrackingRepository {
   /// `tocJson` 是 null，阅读位置的 `sectionIndex` 存的是**页码**——旧实现在这里只
   /// 挡了 `'manga'`，PDF 一路走下去会在 [estimateCompletedBookChapters] 的
   /// 「无 toc 即早退」分支拿到 `fallbackProgress`，也就是把**当前页码当成已读章数**
-  /// 报给 Bangumi。两个调用点（这里与下面 loadCompletedBookTrackingProgress）现在按
+  /// 报给 Bangumi。两个调用点（这里与下面 loadPersistedBookTrackingProgress）现在按
   /// 同一判据 [BookFormat.isPagedImageBook] 收口，缺一处就会重新漂开。
   Future<int?> loadBookChapterProgress({
     required String bookKey,

--- a/hibiki/lib/src/media/tracking/media_tracking_service.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_service.dart
@@ -458,7 +458,9 @@ class MediaTrackingService {
     final MediaTrackingMappingRow? mapping =
         await _ensureAutoBookMapping(bookKey);
     if (mapping == null) return;
-    final int logicalChapterProgress =
+    // null = 按页翻的书（PDF / 漫画），没有章的概念。此时**一律不产出 chapter
+    // 模式进度**：旧实现会把当前页码当已读章数写进用户的 Bangumi 公开记录。
+    final int? logicalChapterProgress =
         await _repository.loadBookChapterProgress(
       bookKey: bookKey,
       fallbackProgress: completedChapterCount,
@@ -469,14 +471,17 @@ class MediaTrackingService {
         isVolume && mapping.kind == TrackingKind.novel.value
             ? await _ensureBookChapterMapping(mapping)
             : null;
+    // 按页翻的书（PDF / 漫画）没有章：卷模式仍可如实上报「读完/未读完」，但 chapter
+    // 模式一律**整条不发**——报 0 也是往用户的 Bangumi 公开记录里写一个错数。
+    if (!isVolume && logicalChapterProgress == null) return;
     await _enqueueAndSync(
       mediaType: TrackingMediaType.book,
       mediaKey: bookKey,
       // 卷模式的 offset 就是当前卷号：在读时减一只报告此前已读卷，读完才计入本卷。
-      localProgress: isVolume ? (completed ? 0 : -1) : logicalChapterProgress,
+      localProgress: isVolume ? (completed ? 0 : -1) : logicalChapterProgress!,
       completed: completed,
     );
-    if (chapterMapping == null) return;
+    if (chapterMapping == null || logicalChapterProgress == null) return;
     await _enqueueAndSync(
       mediaType: TrackingMediaType.bookChapter,
       mediaKey: bookKey,
@@ -631,7 +636,9 @@ class MediaTrackingService {
             await _repository.loadAutoBookSource(bookKey);
         if (source == null) return null;
         final TrackingKind kind =
-            source.format == 'manga' ? TrackingKind.manga : TrackingKind.novel;
+            BookFormat.parseOrEpub(source.format) == BookFormat.manga
+                ? TrackingKind.manga
+                : TrackingKind.novel;
         final _PreparedTrackingTitle prepared =
             _prepareTrackingTitle(source.title);
         final List<BangumiSubject> subjects = await searchSubjects(

--- a/hibiki/lib/src/pdf/pdf_importer.dart
+++ b/hibiki/lib/src/pdf/pdf_importer.dart
@@ -103,7 +103,7 @@ class PdfImporter {
           chapterCount: pageCount,
           chaptersJson: '[]',
           importedAt: importedAtMs,
-          format: const Value('pdf'),
+          format: Value(BookFormat.pdf.dbValue),
           sourceId: sourceId != null ? Value(sourceId) : const Value.absent(),
         ),
       );

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+994
+version: 1.3.1+995
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/database/epub_book_format_convert_test.dart
+++ b/hibiki/test/database/epub_book_format_convert_test.dart
@@ -42,7 +42,7 @@ void main() {
 
     await db.updateEpubBookFormat(
       key,
-      format: 'manga',
+      format: BookFormat.manga,
       epubPath: 'manga.json',
       chapterCount: 180,
       chaptersJson: '[]',
@@ -69,7 +69,7 @@ void main() {
     final HibikiDatabase db = await seedImageEpub();
     await db.updateEpubBookFormat(
       key,
-      format: 'manga',
+      format: BookFormat.manga,
       epubPath: 'manga.json',
       chapterCount: 180,
       chaptersJson: '[]',
@@ -80,7 +80,7 @@ void main() {
 
     await db.updateEpubBookFormat(
       key,
-      format: 'epub',
+      format: BookFormat.epub,
       epubPath: 'scan.epub',
       chapterCount: 12,
       chaptersJson: '["c1","c2"]',
@@ -103,7 +103,7 @@ void main() {
 
     await db.updateEpubBookFormat(
       key,
-      format: 'manga',
+      format: BookFormat.manga,
       epubPath: 'manga.json',
       chapterCount: 180,
       chaptersJson: '[]',
@@ -132,7 +132,7 @@ void main() {
 
     await db.updateEpubBookFormat(
       key,
-      format: 'manga',
+      format: BookFormat.manga,
       epubPath: 'manga.json',
       chapterCount: 180,
       chaptersJson: '[]',
@@ -154,7 +154,7 @@ void main() {
     // 否则漏传一个可选参数就把用户封面抹掉，且没有任何报错。
     await db.updateEpubBookFormat(
       key,
-      format: 'manga',
+      format: BookFormat.manga,
       epubPath: 'manga.json',
       chapterCount: 180,
       chaptersJson: '[]',
@@ -170,7 +170,7 @@ void main() {
     final HibikiDatabase db = await seedImageEpub();
     await db.updateEpubBookFormat(
       key,
-      format: 'manga',
+      format: BookFormat.manga,
       epubPath: 'manga.json',
       chapterCount: 180,
       chaptersJson: '[]',
@@ -195,7 +195,7 @@ void main() {
 
     await db.updateEpubBookFormat(
       key,
-      format: 'manga',
+      format: BookFormat.manga,
       epubPath: 'manga.json',
       chapterCount: 180,
       chaptersJson: '[]',

--- a/hibiki/test/media/manga/book_format_convert_test.dart
+++ b/hibiki/test/media/manga/book_format_convert_test.dart
@@ -1,3 +1,4 @@
+import 'package:hibiki_core/hibiki_core.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:hibiki/src/media/manga/book_format_convert.dart';
@@ -24,7 +25,7 @@ void main() {
   group('转成漫画', () {
     test('PDF 恒可转（扫描版 PDF 无文本层、阅读器不做 OCR 兜底，转漫画才有查词）', () {
       final BookConvertVerdict v = verdictToManga(
-        format: 'pdf',
+        format: BookFormat.pdf,
         sourceAbsolutePath: '/books/k/hibiki.pdf',
         probe: present,
       );
@@ -34,7 +35,7 @@ void main() {
 
     test('图片型 EPUB 可转（扫描版漫画的常见分发形态）', () {
       final BookConvertVerdict v = verdictToManga(
-        format: 'epub',
+        format: BookFormat.epub,
         sourceAbsolutePath: '/books/k/scan.epub',
         probe: imageArchive,
       );
@@ -44,7 +45,7 @@ void main() {
 
     test('文字书不可转，且原因必须是 textOnlyBook（要能说清「为什么」）', () {
       final BookConvertVerdict v = verdictToManga(
-        format: 'epub',
+        format: BookFormat.epub,
         sourceAbsolutePath: '/books/k/novel.epub',
         probe: present,
       );
@@ -56,7 +57,7 @@ void main() {
 
     test('已经是漫画 -> alreadyTarget', () {
       final BookConvertVerdict v = verdictToManga(
-        format: 'manga',
+        format: BookFormat.manga,
         sourceAbsolutePath: '/books/k/manga.json',
         probe: present,
       );
@@ -65,7 +66,7 @@ void main() {
 
     test('源文件被删 -> sourceMissing（不是笼统的「不支持」）', () {
       final BookConvertVerdict v = verdictToManga(
-        format: 'pdf',
+        format: BookFormat.pdf,
         sourceAbsolutePath: '/books/k/hibiki.pdf',
         probe: missing,
       );
@@ -74,7 +75,7 @@ void main() {
 
     test('源文件不存在时即使标着图片型也不放行（先查存在性）', () {
       final BookConvertVerdict v = verdictToManga(
-        format: 'epub',
+        format: BookFormat.epub,
         sourceAbsolutePath: '/books/k/gone.epub',
         probe: const BookSourceProbe(
           sourceExists: false,
@@ -88,7 +89,7 @@ void main() {
   group('转回书', () {
     test('原始文件仍在书目录 -> 可转，且指回那个文件', () {
       final BookConvertVerdict v = verdictToBook(
-        format: 'manga',
+        format: BookFormat.manga,
         probe: const BookSourceProbe(
           sourceExists: true,
           sourceIsImageArchive: true,
@@ -101,7 +102,7 @@ void main() {
 
     test('mokuro / 裸图片目录导入的漫画没有原始文件 -> noOriginalFile（不造假书）', () {
       final BookConvertVerdict v = verdictToBook(
-        format: 'manga',
+        format: BookFormat.manga,
         probe: present,
       );
       expect(v.supported, isFalse);
@@ -110,7 +111,7 @@ void main() {
 
     test('原始路径是空串也算没有', () {
       final BookConvertVerdict v = verdictToBook(
-        format: 'manga',
+        format: BookFormat.manga,
         probe: const BookSourceProbe(
           sourceExists: true,
           sourceIsImageArchive: false,
@@ -121,7 +122,10 @@ void main() {
     });
 
     test('本来就不是漫画 -> alreadyTarget', () {
-      for (final String format in <String>['epub', 'pdf']) {
+      for (final BookFormat format in <BookFormat>[
+        BookFormat.epub,
+        BookFormat.pdf,
+      ]) {
         expect(
           verdictToBook(format: format, probe: present).blocker,
           BookConvertBlocker.alreadyTarget,
@@ -134,21 +138,21 @@ void main() {
   test('每个 blocker 都必须被判定函数真的产出过（没有说不出理由的拒绝）', () {
     final Set<BookConvertBlocker> produced = <BookConvertBlocker>{
       verdictToManga(
-        format: 'manga',
+        format: BookFormat.manga,
         sourceAbsolutePath: '/a',
         probe: present,
       ).blocker!,
       verdictToManga(
-        format: 'epub',
+        format: BookFormat.epub,
         sourceAbsolutePath: '/a',
         probe: present,
       ).blocker!,
       verdictToManga(
-        format: 'pdf',
+        format: BookFormat.pdf,
         sourceAbsolutePath: '/a',
         probe: missing,
       ).blocker!,
-      verdictToBook(format: 'manga', probe: present).blocker!,
+      verdictToBook(format: BookFormat.manga, probe: present).blocker!,
     };
     expect(produced, BookConvertBlocker.values.toSet(),
         reason: '新增 blocker 必须同时有产出它的判定路径与说明文案');

--- a/hibiki/test/media/manga_routing_guard_test.dart
+++ b/hibiki/test/media/manga_routing_guard_test.dart
@@ -28,12 +28,14 @@ void main() {
 
   test('书架列书按 format 路由：format==manga 的行带 MangaHibikiSource 源标识', () {
     final String src = read('lib/src/media/sources/reader_hibiki_source.dart');
-    expect(src.contains("book.format == 'manga'"), isTrue,
-        reason: '_bookToMediaItem 应按 format=="manga" 分流');
+    // 判据统一走 BookFormat 枚举后，锚点跟着走（裸字符串比较已被
+    // book_format_discipline_guard 禁掉——它正是「只挡 manga、漏掉 pdf」的温床）。
+    expect(src.contains('format == BookFormat.manga'), isTrue,
+        reason: '_bookToMediaItem 应按 BookFormat.manga 分流');
     expect(src.contains('MangaHibikiSource.kUniqueKey'), isTrue,
         reason: '漫画行 mediaSourceIdentifier 应取 MangaHibikiSource.kUniqueKey');
     // PDF 分流不能被漫画分流破坏（向后兼容守卫）。
-    expect(src.contains("book.format == 'pdf'"), isTrue);
+    expect(src.contains('format == BookFormat.pdf'), isTrue);
     expect(src.contains('ReaderPdfSource.kUniqueKey'), isTrue);
   });
 

--- a/hibiki/test/media/reader_pdf_routing_guard_test.dart
+++ b/hibiki/test/media/reader_pdf_routing_guard_test.dart
@@ -29,8 +29,9 @@ void main() {
     final String src = read('lib/src/media/sources/reader_hibiki_source.dart');
     // _bookToMediaItem 必须按 format 分流 mediaSourceIdentifier；缺这条 → PDF 行用
     // 'reader_ttu' 打开 → EPUB 阅读器解析 PDF → 崩。
-    expect(src.contains("book.format == 'pdf'"), isTrue,
-        reason: '_bookToMediaItem 应按 format=="pdf" 分流');
+    // 判据统一走 BookFormat 枚举后，锚点跟着走（见 book_format_discipline_guard）。
+    expect(src.contains('format == BookFormat.pdf'), isTrue,
+        reason: '_bookToMediaItem 应按 BookFormat.pdf 分流');
     expect(src.contains('ReaderPdfSource.kUniqueKey'), isTrue,
         reason: 'PDF 行 mediaSourceIdentifier 应取 ReaderPdfSource.kUniqueKey');
   });

--- a/hibiki/test/media/tracking/media_tracking_repository_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_repository_test.dart
@@ -15,6 +15,51 @@ void main() {
 
   tearDown(() => db.close());
 
+  /// 按页翻的书（PDF / 漫画）没有「章」：`chaptersJson` 是 `'[]'`、`tocJson` 是 null，
+  /// 阅读位置的 `sectionIndex` 存的是**页码**。旧实现在这里只挡了 `'manga'`，PDF 会
+  /// 一路走到 estimateCompletedBookChapters 的「无 toc 即早退」分支拿到
+  /// fallbackProgress —— 也就是把当前页码当成已读章数报进用户的 Bangumi 公开记录。
+  ///
+  /// 漫画当时只是**侥幸**没踩到：自动映射把它判成 volume 模式绕开了 chapter 分支，
+  /// 手动把映射改成 chapter 模式一样会中招。所以两种格式都要挡。
+  Future<void> seedBook(String key, BookFormat format) async {
+    await db.insertEpubBook(EpubBooksCompanion.insert(
+      bookKey: key,
+      title: key,
+      epubPath: 'x',
+      extractDir: 'd',
+      chapterCount: 300,
+      chaptersJson: '[]',
+      importedAt: 0,
+      format: Value(format.dbValue),
+    ));
+  }
+
+  for (final BookFormat format in <BookFormat>[
+    BookFormat.pdf,
+    BookFormat.manga,
+  ]) {
+    test('${format.dbValue} 不产出章进度（页码不得当章数上报）', () async {
+      await seedBook('b-${format.dbValue}', format);
+      final int? progress = await repository.loadBookChapterProgress(
+        bookKey: 'b-${format.dbValue}',
+        fallbackProgress: 137, // 当前第 137 页
+      );
+      expect(progress, isNull,
+          reason: '按页翻的书没有章，必须返回 null 让上层整条不发，'
+              '而不是把 137 页当成 137 章报出去');
+    });
+  }
+
+  test('epub 仍照常产出章进度（止血没有误伤文字书）', () async {
+    await seedBook('b-epub', BookFormat.epub);
+    final int? progress = await repository.loadBookChapterProgress(
+      bookKey: 'b-epub',
+      fallbackProgress: 5,
+    );
+    expect(progress, isNotNull);
+  });
+
   test('EPUB TOC progress counts logical chapters instead of spine files', () {
     final int progress = estimateCompletedBookChapters(
       chaptersJson: '''

--- a/hibiki/test/media/tracking/media_tracking_repository_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_repository_test.dart
@@ -51,6 +51,74 @@ void main() {
     });
   }
 
+  /// 调用点②：`loadPersistedBookTrackingProgress` 原本**完全没有 format 守卫**。
+  ///
+  /// 这条单独存在，是因为变异实测证明它必须存在：把 `:564` 那行 format 守卫删掉，
+  /// 只覆盖 `loadBookChapterProgress` 的测试**照样全绿**——两个调用点必须各有各的
+  /// 钉子，否则「只修一处、另一处漂开」会静默复发。
+  for (final BookFormat format in <BookFormat>[
+    BookFormat.pdf,
+    BookFormat.manga,
+  ]) {
+    test('${format.dbValue} 的 chapter 模式映射不进持久化进度（调用点②）', () async {
+      final String key = 'p-${format.dbValue}';
+      await seedBook(key, format);
+      await db.upsertReaderPosition(
+        ReaderPositionsCompanion.insert(
+          bookKey: key,
+          sectionIndex: 137, // 第 137 页
+          normCharOffset: 9990,
+          updatedAt: 5000,
+        ),
+      );
+      await repository.saveMappingIfAbsent(
+        mediaType: TrackingMediaType.book,
+        mediaKey: key,
+        mediaTitle: key,
+        kind: TrackingKind.novel,
+        subjectId: 4242,
+        subjectName: key,
+        progressMode: TrackingProgressMode.chapter,
+        progressOffset: 0,
+      );
+      final List<PersistedBookTrackingProgress> got =
+          await repository.loadPersistedBookTrackingProgress(afterMs: 0);
+      expect(
+        got.where((PersistedBookTrackingProgress e) => e.mediaKey == key),
+        isEmpty,
+        reason: '按页翻的书没有章：整条不产出，'
+            '否则第 137 页会被当成「已读 137 章」提交到用户的 Bangumi 记录',
+      );
+    });
+  }
+
+  test('epub 的 chapter 模式映射照常产出（调用点②没有误伤文字书）', () async {
+    await seedBook('p-epub', BookFormat.epub);
+    await db.upsertReaderPosition(
+      ReaderPositionsCompanion.insert(
+        bookKey: 'p-epub',
+        sectionIndex: 3,
+        normCharOffset: 9990,
+        updatedAt: 5000,
+      ),
+    );
+    await repository.saveMappingIfAbsent(
+      mediaType: TrackingMediaType.book,
+      mediaKey: 'p-epub',
+      mediaTitle: 'p-epub',
+      kind: TrackingKind.novel,
+      subjectId: 4243,
+      subjectName: 'p-epub',
+      progressMode: TrackingProgressMode.chapter,
+      progressOffset: 0,
+    );
+    final List<PersistedBookTrackingProgress> got =
+        await repository.loadPersistedBookTrackingProgress(afterMs: 0);
+    expect(
+        got.where((PersistedBookTrackingProgress e) => e.mediaKey == 'p-epub'),
+        isNotEmpty);
+  });
+
   test('epub 仍照常产出章进度（止血没有误伤文字书）', () async {
     await seedBook('b-epub', BookFormat.epub);
     final int? progress = await repository.loadBookChapterProgress(

--- a/hibiki/test/tools/book_format_discipline_guard_test.dart
+++ b/hibiki/test/tools/book_format_discipline_guard_test.dart
@@ -1,0 +1,161 @@
+/// 守卫：`EpubBooks.format` 的取值纪律。
+///
+/// ## 守什么
+///
+/// `format` 是阅读器路由的**唯一真相源**：`reader_hibiki_source.dart` 按它三态分流，
+/// 未知值会**全部 fallback 到 EPUB 阅读器**——不是静默隐身，是用错阅读器打开、在解析
+/// 路径出错。列上没有 CHECK 约束（为什么没加见 `BookFormat` 的文档：SQLite 加 CHECK
+/// 要重建核心书表，风险大于收益），所以纪律必须由**类型 + 本守卫**兜住：
+///
+/// 1. **落库入口不得收裸 String**。`updateEpubBookFormat` 是唯一不受常量约束的写入
+///    口，必须收 [BookFormat]，让「写进未知值」在编译期就不可表达。
+/// 2. **不得再出现裸字符串字面量的 format 落库**（`format: Value('manga')` 这类），
+///    一律走 `BookFormat.<x>.dbValue`。
+/// 3. **不得再用裸字符串比较 format**（`book.format == 'manga'`），一律走枚举——
+///    裸比较正是「PDF 被漏掉」那类 bug 的温床（见 tracking 两个调用点）。
+/// 4. **落库串逐字节冻结**。存量持久化名不追改，改了就是让老库里的行读不回来。
+///
+/// ## 变异实测打在哪
+///
+/// 这几条的**真值在手写源码里**（不是 drift 生成文件——本守卫不涉及 CHECK 约束，
+/// 生成的 `CREATE TABLE` 里没有本守卫断言的东西）。所以变异要改 `lib/`：把 DAO 参数
+/// 换回 `String`、把某处改回裸字面量、把某处改回裸字符串比较、改掉 dbValue。
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// DAO 所在文件（相对 `hibiki/`，故要跳出去一层）。
+const String kDaoFile =
+    '../packages/hibiki_core/lib/src/database/database.dart';
+
+/// 枚举定义文件。
+const String kEnumFile =
+    '../packages/hibiki_core/lib/src/database/book_format.dart';
+
+/// 本守卫自身：正文里写满了被禁的字面量当反例，不能扫自己。
+const String kSelfPath = 'test/tools/book_format_discipline_guard_test.dart';
+
+/// 迁移测试豁免：它们往库里塞的是**老版本磁盘上真实存在过的字面量**，是被测对象
+/// 本身，不是新写的落库点。这里若改成 `BookFormat.pdf.dbValue`，将来谁把 dbValue
+/// 改了，迁移测试会跟着一起变、于是永远绿——反而测不出「老库读不回来」。
+/// 值的冻结由本文件的 `dbValue 逐字节冻结` 一条单独钉住。
+///
+/// **只有这一类豁免**；不是每出现一个新违规就往里塞一条。
+const List<String> _kFrozenHistoryValueFiles = <String>[
+  'test/database/migration_v51_pdf_format_test.dart',
+  'test/database/migration_v53_manga_reading_mode_test.dart',
+];
+
+/// 读取并**剥掉整行注释**后的代码文本。
+///
+/// 结构断言一律走它：讲「此前是什么写法、为什么改」的注释是资产，但注释里出现
+/// `format == 'manga'` 不该算违规，反过来注释也不能冒充真声明。
+String _codeOf(String path) => File(path)
+    .readAsLinesSync()
+    .where((String l) => !l.trimLeft().startsWith('//'))
+    .join('\n');
+
+/// 扫 [roots] 下所有 .dart 的非注释行，返回命中 [pattern] 的 `文件:行号`。
+///
+/// 跳过 drift 生成文件：`database.g.dart` 里 `format: Value(format)` 这类是生成器
+/// 按表定义产出的搬运代码，不是人写的落库点，禁它只会逼人去改生成文件。
+List<String> _codeHits(List<String> roots, RegExp pattern) {
+  final List<String> hits = <String>[];
+  for (final String root in roots) {
+    final Directory dir = Directory(root);
+    if (!dir.existsSync()) continue;
+    for (final FileSystemEntity e in dir.listSync(recursive: true)) {
+      if (e is! File || !e.path.endsWith('.dart')) continue;
+      final String rel = e.path.replaceAll(r'\', '/');
+      if (rel.endsWith('.g.dart') || rel.endsWith(kSelfPath)) continue;
+      if (_kFrozenHistoryValueFiles.any(rel.endsWith)) continue;
+      final List<String> lines = e.readAsLinesSync();
+      for (int i = 0; i < lines.length; i++) {
+        if (lines[i].trimLeft().startsWith('//')) continue;
+        if (pattern.hasMatch(lines[i])) hits.add('$rel:${i + 1}');
+      }
+    }
+  }
+  return hits;
+}
+
+void main() {
+  const List<String> roots = <String>[
+    'lib',
+    'test',
+    '../packages/hibiki_core/lib',
+  ];
+
+  test('落库入口收 BookFormat 而非裸 String（未知值编译期不可表达）', () {
+    final String dao = _codeOf(kDaoFile);
+    final int at = dao.indexOf('Future<void> updateEpubBookFormat(');
+    expect(at, isNonNegative, reason: '找不到 updateEpubBookFormat');
+    // 只看签名那一段。注意不能用「第一个 `{`」切——那是具名参数块的开括号，会把
+    // 整个参数表切掉、断言恒假（本守卫自己先踩过一次）。切到函数体的 `}) {`。
+    final int bodyAt = dao.indexOf('}) {', at);
+    expect(bodyAt, isNonNegative, reason: '找不到 updateEpubBookFormat 的签名结尾');
+    final String signature = dao.substring(at, bodyAt);
+    expect(signature.contains('required BookFormat format'), isTrue,
+        reason: 'format 落库入口必须收 BookFormat：收裸 String 就等于把「写进未知值」'
+            '留到运行期，而未知值会让阅读器路由静默 fallback 到 EPUB。');
+    expect(signature.contains('String format'), isFalse,
+        reason: '不得退回裸 String 参数');
+  });
+
+  test('不得用裸字符串字面量落库 format', () {
+    // 形如 `format: Value('manga')` / `format: const Value("pdf")`。
+    final RegExp bare = RegExp(
+      r'''format:\s*(const\s+)?Value\s*\(\s*['"]''',
+    );
+    expect(
+      _codeHits(roots, bare),
+      isEmpty,
+      reason: '落库 format 请用 `BookFormat.<x>.dbValue`，别写裸字面量——'
+          '裸字面量绕开枚举，拼错一个字母就是一本永远用错阅读器打开的书。',
+    );
+  });
+
+  test('不得用裸字符串比较 format', () {
+    // 形如 `book.format == 'manga'` / `source.format != "pdf"`。
+    final RegExp bare = RegExp(
+      r'''\.format\s*[!=]=\s*['"]''',
+    );
+    expect(
+      _codeHits(roots, bare),
+      isEmpty,
+      reason: '请用 `BookFormat.parseOrEpub(x.format)` 再比枚举。裸比较正是'
+          '「只挡了 manga、漏掉 pdf」那类 bug 的温床（tracking 两个调用点即为此坏过）。',
+    );
+  });
+
+  test('dbValue 逐字节冻结（改了就是让老库的行读不回来）', () {
+    expect(BookFormat.epub.dbValue, 'epub');
+    expect(BookFormat.pdf.dbValue, 'pdf');
+    expect(BookFormat.manga.dbValue, 'manga');
+    expect(BookFormat.values.length, 3,
+        reason: '新增格式要同步 reader_hibiki_source 的路由与 isPagedImageBook 判据');
+  });
+
+  test('按页翻的书判据覆盖 pdf 与 manga（章计数下游全靠它排除）', () {
+    expect(BookFormat.pdf.isPagedImageBook, isTrue);
+    expect(BookFormat.manga.isPagedImageBook, isTrue);
+    expect(BookFormat.epub.isPagedImageBook, isFalse);
+  });
+
+  test('未知值按 epub 回退（与路由层实际行为一致）', () {
+    expect(BookFormat.tryParse('cbz'), isNull);
+    expect(BookFormat.tryParse(null), isNull);
+    expect(BookFormat.parseOrEpub('cbz'), BookFormat.epub);
+    expect(BookFormat.parseOrEpub(null), BookFormat.epub);
+  });
+
+  test('枚举文件写明了「为什么没加 CHECK 约束」（别让后人当遗漏又去重建书表）', () {
+    final String src = File(kEnumFile).readAsStringSync();
+    expect(src.contains('ALTER TABLE ADD CONSTRAINT'), isTrue);
+    expect(src.contains('user_version=60'), isTrue,
+        reason: '生产库实证是「值不值得补 CHECK」的判断依据，要留在代码里');
+  });
+}

--- a/packages/hibiki_core/lib/hibiki_core.dart
+++ b/packages/hibiki_core/lib/hibiki_core.dart
@@ -1,6 +1,7 @@
 library hibiki_core;
 
 export 'src/database/activity_event_types.dart';
+export 'src/database/book_format.dart';
 export 'src/database/collection_order.dart';
 export 'src/database/database.dart';
 export 'src/database/media_kind.dart';

--- a/packages/hibiki_core/lib/src/database/book_format.dart
+++ b/packages/hibiki_core/lib/src/database/book_format.dart
@@ -1,0 +1,63 @@
+/// 书身份格式的值域(`EpubBooks.format` 列)。
+///
+/// 三种书共用同一张 `EpubBooks` 表和同一个书目录 `<hoshi_books>/<bookKey>/`,
+/// `format` 是**阅读器路由的唯一真相源**:`'pdf'` 进 PDF 阅读器、`'manga'` 进漫画
+/// 阅读器、`'epub'`(默认)进 EPUB 阅读器。
+///
+/// ## 为什么要收敛成枚举
+///
+/// 列上没有 CHECK 约束,写入侧此前是裸 `String`。一旦写进枚举外的值,路由
+/// (`reader_hibiki_source.dart` 的 `isPdf ? ... : isManga ? ... : 本源`)会**全部
+/// fallback 到 EPUB 阅读器** —— 不是静默隐身,而是用错阅读器打开、在解析路径出错。
+/// 收敛成枚举后,「写进未知值」在**编译期**就不可表达。
+///
+/// ## 为什么没有加 CHECK 约束(刻意的取舍,别当遗漏)
+///
+/// SQLite 不支持 `ALTER TABLE ADD CONSTRAINT`,加 CHECK 只能重建 `epub_books`
+/// 这张核心书表;重建时任何越界行都会让**老库升级中断、app 直接打不开**。而实际
+/// 风险面已经为零:落库点只有三个,两个是常量(`pdf_importer` / `manga_importer`),
+/// 一个是列默认值 `'epub'`;唯一收裸串的入口 `updateEpubBookFormat` 已改成收本枚举。
+/// 实测生产库(`user_version=60`,19 行)`format` 全为 `'epub'`,零 NULL 零越界。
+/// 为覆盖「绕过 DAO 直接写裸 SQL」这一本仓不存在的用法去重建书表,不划算。
+///
+/// [dbValue] 即落库串,**逐字节冻结**(存量持久化名不追改;守卫:
+/// `test/tools/book_format_discipline_guard_test.dart`)。
+enum BookFormat {
+  /// 文字书:EPUB / TextToEpub / 有声书配对壳。列默认值,既有全部行都是它。
+  epub('epub'),
+
+  /// pdfrx 渲染的真 PDF。`chapterCount`=页数、`chaptersJson`=`'[]'`。
+  pdf('pdf'),
+
+  /// 漫画 OCR(第三种书)。`chapterCount`=页数、`chaptersJson`=`'[]'`。
+  manga('manga');
+
+  const BookFormat(this.dbValue);
+
+  /// `EpubBooks.format` 列的落库串。
+  final String dbValue;
+
+  /// 严格解析:未知串返回 null(调用方自行决定回退/报错)。
+  static BookFormat? tryParse(String? raw) {
+    for (final BookFormat format in values) {
+      if (format.dbValue == raw) return format;
+    }
+    return null;
+  }
+
+  /// 宽松解析:未知串按 [BookFormat.epub] 处理。
+  ///
+  /// 这**不是**在容忍脏数据,而是把路由层早就在做的事显式化:未知 format 今天就会
+  /// fallback 到 EPUB 阅读器。写成一个有名字的函数,读代码的人一眼看得见这条回退,
+  /// 而不用去 `isPdf ? ... : isManga ? ... : 本源` 的三元里倒推。
+  static BookFormat parseOrEpub(String? raw) =>
+      tryParse(raw) ?? BookFormat.epub;
+
+  /// 是否是「按页翻」的图像书(PDF / 漫画)。
+  ///
+  /// 这类书的 `chapterCount` 存的是**页数**、`chaptersJson` 是 `'[]'`,阅读位置的
+  /// `sectionIndex` 是**页码**而不是章序号 —— 任何「按章计数」的下游(尤其向
+  /// Bangumi 上报章进度)都必须先用它把这两种书排除掉,否则会把页码当章数报出去。
+  bool get isPagedImageBook =>
+      this == BookFormat.pdf || this == BookFormat.manga;
+}

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -11,6 +11,7 @@ import 'package:sqlite3/sqlite3.dart' as sqlite3;
 
 import '../utils/ttu_sanitize.dart';
 import '../utils/video_book_uid.dart';
+import 'book_format.dart';
 import 'collection_order.dart';
 import 'media_kind.dart';
 import 'pref_codec.dart';
@@ -4723,7 +4724,9 @@ class HibikiDatabase extends _$HibikiDatabase {
   /// 主键 `bookKey` 不变，因此 `(mediaType='epub', entryKey=bookKey)` 这个统一媒体
   /// 身份完全不动——合集成员 / 标签 / 阅读进度 / 统计 / Profile / 墓碑全部原地存活，
   /// 零悬挂引用。变的只是「这本书用哪个阅读器打开、产物在哪」：
-  /// - [format]：`'epub'` | `'pdf'` | `'manga'`（阅读器路由的唯一真相源）；
+  /// - [format]：[BookFormat]（阅读器路由的唯一真相源）。收枚举而非裸串——这是
+  ///   本列唯一不受常量约束的落库入口，收裸串就等于把「写进未知值」的可能性留在
+  ///   运行期，而未知值会让路由静默 fallback 到 EPUB 阅读器、在解析路径出错；
   /// - [epubPath]：漫画指向 `manga.json`，书指向原始 `.epub`/`.pdf` 文件名；
   /// - [coverPath]：漫画取首页页图相对路径，书取原封面。**null = 保持原封面不变**
   ///   （与相邻的 [updateEpubBookContentPaths] 同一约定）——转化从不以「清空封面」
@@ -4739,7 +4742,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   /// 单条 UPDATE，不动 `extractDir`（三种格式共用同一个书目录）。
   Future<void> updateEpubBookFormat(
     String bookKey, {
-    required String format,
+    required BookFormat format,
     required String epubPath,
     required int chapterCount,
     required String chaptersJson,
@@ -4748,7 +4751,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   }) {
     return (update(epubBooks)..where((t) => t.bookKey.equals(bookKey)))
         .write(EpubBooksCompanion(
-      format: Value(format),
+      format: Value(format.dbValue),
       epubPath: Value(epubPath),
       chapterCount: Value(chapterCount),
       chaptersJson: Value(chaptersJson),


### PR DESCRIPTION
## ④ 止血：向 Bangumi 上报错误章数（真 bug）

PDF 行 `chaptersJson='[]'`、`tocJson=null`，`estimateCompletedBookChapters` 在「无 toc 即早退」分支返回 `fallbackProgress`，而它是 `sectionIndex + …` —— 对 PDF / 漫画来说 **`sectionIndex` 是页码**。`_ensureAutoBookMapping` 又把 PDF 判成 `novel`，标题无卷号且条目 `volumeCount<=1` 时走 `chapter` 模式，于是「当前第 137 页」被当成「已读 137 章」**写进用户 Bangumi 的公开记录**。

⚠️ **漫画只是侥幸没踩到**：自动映射把它判成 volume 模式绕开了 chapter 分支，**手动把映射改成 chapter 模式一样会中招** —— 别当漫画天然安全。

两个调用点按**同一判据** `BookFormat.isPagedImageBook` 收口：
- `loadBookChapterProgress`：原本**只挡 `'manga'`、漏掉 pdf**，改为返回 `int?`（null = 没有章的概念）；
- `loadPersistedBookTrackingProgress`：原本**完全没有 format 守卫**，补 `continue`。

消费侧 `recordBookProgress`：非卷模式拿到 null 时**整条不发** —— 报 0 也是往外部服务写错数。卷模式不受影响。

## ① `format` 收敛成 `BookFormat`（B 方案：只做枚举，不加 CHECK）

唯一不受常量约束的落库入口 `updateEpubBookFormat` 改收枚举，「写进未知值」**编译期不可表达**；路由 / tracking / 转化判定一并改走枚举。

**刻意不加 CHECK 约束**（理由固化在 `book_format.dart` 里，别当遗漏）：
- SQLite 不支持 `ALTER TABLE ADD CONSTRAINT`，加 CHECK 只能**重建 `epub_books` 这张核心书表**，重建时任何越界行会让老库升级中断、**app 直接打不开**；
- 而真实风险面为零：落库点只有三个（`pdf_importer` / `manga_importer` 两个常量 + 列默认值 `'epub'`）；
- **生产库实证**：`user_version=60`、19 行，`format` **全为 `'epub'`，零 NULL 零越界**。

**本 PR 零 schema 改动**：`tables.dart` / `database.g.dart` / `schemaVersion` 均未动，**没占版本号**。

## 守卫与变异实测

`book_format_discipline_guard_test`：禁裸 String 落库入口 / 禁裸字面量落库 / 禁裸字符串比较 / `dbValue` 逐字节冻结。**唯一豁免**是迁移测试（它们塞的是老版本磁盘上真实存在过的字面量，是被测对象本身；跟着枚举改反而会永远绿）。

变异 6 种，每次先 `git diff` 实证落盘，**全部打在真值处（手写 `lib/`，本 PR 不涉及 drift 生成的 `CREATE TABLE`）**：DAO 退回裸 String / 落库退回裸字面量 / 路由退回裸字符串比较 / `dbValue` 改字节 / 删掉调用点② 守卫 / 调用点① 退回只挡 manga —— **6/6 转红**。

其中「删掉调用点② 守卫」**第一轮是绿的**，暴露出该调用点无覆盖，因此补了单独的测试再复验转红。

## 验证

- `flutter analyze` → `No issues found!`
- `FLUTTER TEST VERDICT: PASSED - 4416 tests ran, all tests passed`（退出码 0）

https://claude.ai/code/session_015QDaQq8BoqiqZ6KYyHLncb