### PR TITLE
feat(stats): split game statistics into its own page (TODO-2176)

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46784 (2752 per locale)
+/// Strings: 46835 (2755 per locale)
 ///
-/// Built on 2026-07-29 at 04:02 UTC
+/// Built on 2026-07-29 at 05:10 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3698,6 +3698,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Matched and queued current progress';
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  String get game_statistics => 'Game statistics';
+  String get game_stat_by_game => 'By game';
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -9996,6 +10000,13 @@ class _StringsAr extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -16362,6 +16373,13 @@ class _StringsDe extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -22744,6 +22762,13 @@ class _StringsEs extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -29137,6 +29162,13 @@ class _StringsFr extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -35459,6 +35491,13 @@ class _StringsId extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -41827,6 +41866,13 @@ class _StringsIt extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -48012,6 +48058,13 @@ class _StringsJa extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -54199,6 +54252,13 @@ class _StringsKo extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -60547,6 +60607,13 @@ class _StringsNl extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -66908,6 +66975,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -73253,6 +73327,13 @@ class _StringsRu extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -79546,6 +79627,13 @@ class _StringsTh extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -85871,6 +85959,13 @@ class _StringsTr extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -92181,6 +92276,13 @@ class _StringsVi extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 // Path: <root>
@@ -98044,6 +98146,13 @@ class _StringsZhCn extends _StringsEn {
   String get media_tracking_retry_matched => '已重新关联并补发当前进度';
   @override
   String get media_tracking_retry_no_match => '仍未匹配到条目，请尝试手动关联';
+  @override
+  String get game_statistics => '游戏统计';
+  @override
+  String get game_stat_by_game => '按游戏';
+  @override
+  String get stat_clear_all_game_message =>
+      '确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。';
 }
 
 // Path: <root>
@@ -104150,6 +104259,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get media_tracking_retry_no_match =>
       'No match found. Try manual linking.';
+  @override
+  String get game_statistics => 'Game statistics';
+  @override
+  String get game_stat_by_game => 'By game';
+  @override
+  String get stat_clear_all_game_message =>
+      'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
 }
 
 /// Flat map(s) containing all translations.
@@ -109787,6 +109903,12 @@ extension on _StringsEn {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -115422,6 +115544,12 @@ extension on _StringsAr {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -121078,6 +121206,12 @@ extension on _StringsDe {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -126733,6 +126867,12 @@ extension on _StringsEs {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -132394,6 +132534,12 @@ extension on _StringsFr {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -138037,6 +138183,12 @@ extension on _StringsId {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -143695,6 +143847,12 @@ extension on _StringsIt {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -149315,6 +149473,12 @@ extension on _StringsJa {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -154939,6 +155103,12 @@ extension on _StringsKo {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -160590,6 +160760,12 @@ extension on _StringsNl {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -166238,6 +166414,12 @@ extension on _StringsPtBr {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -171891,6 +172073,12 @@ extension on _StringsRu {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -177528,6 +177716,12 @@ extension on _StringsTh {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -183174,6 +183368,12 @@ extension on _StringsTr {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -188815,6 +189015,12 @@ extension on _StringsVi {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }
@@ -194410,6 +194616,12 @@ extension on _StringsZhCn {
         return '已重新关联并补发当前进度';
       case 'media_tracking_retry_no_match':
         return '仍未匹配到条目，请尝试手动关联';
+      case 'game_statistics':
+        return '游戏统计';
+      case 'game_stat_by_game':
+        return '按游戏';
+      case 'stat_clear_all_game_message':
+        return '确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。';
       default:
         return null;
     }
@@ -200025,6 +200237,12 @@ extension on _StringsZhHk {
         return 'Matched and queued current progress';
       case 'media_tracking_retry_no_match':
         return 'No match found. Try manual linking.';
+      case 'game_statistics':
+        return 'Game statistics';
+      case 'game_stat_by_game':
+        return 'By game';
+      case 'stat_clear_all_game_message':
+        return 'Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "隐藏详情",
   "media_tracking_retry_mapping": "重试匹配",
   "media_tracking_retry_matched": "已重新关联并补发当前进度",
-  "media_tracking_retry_no_match": "仍未匹配到条目，请尝试手动关联"
+  "media_tracking_retry_no_match": "仍未匹配到条目，请尝试手动关联",
+  "game_statistics": "游戏统计",
+  "game_stat_by_game": "按游戏",
+  "stat_clear_all_game_message": "确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2750,5 +2750,8 @@
   "scrape_failure_detail_hide": "Hide details",
   "media_tracking_retry_mapping": "Retry matching",
   "media_tracking_retry_matched": "Matched and queued current progress",
-  "media_tracking_retry_no_match": "No match found. Try manual linking."
+  "media_tracking_retry_no_match": "No match found. Try manual linking.",
+  "game_statistics": "Game statistics",
+  "game_stat_by_game": "By game",
+  "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone."
 }

--- a/hibiki/lib/src/pages/implementations/galgame_home_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_home_page.dart
@@ -19,6 +19,7 @@ import 'package:hibiki/src/mining/galgame_repository.dart';
 import 'package:hibiki/src/pages/implementations/activity_feed.dart';
 import 'package:hibiki/src/pages/implementations/galgame_detail_page.dart';
 import 'package:hibiki/src/pages/implementations/game_shared.dart';
+import 'package:hibiki/src/pages/implementations/game_statistics_page.dart';
 import 'package:hibiki/src/pages/implementations/stat_shared.dart';
 import 'package:hibiki/utils.dart';
 
@@ -318,6 +319,15 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
     await _reload();
   }
 
+  Future<void> _openStatistics() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => const GameStatisticsPage(),
+      ),
+    );
+    await _reload();
+  }
+
   @override
   Widget build(BuildContext context) {
     return DesktopContentLayout(
@@ -327,6 +337,14 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
           HibikiPageHeader(
             title: t.nav_game,
             subtitle: t.game_home_subtitle,
+            actions: <Widget>[
+              HibikiIconButton(
+                icon: Icons.bar_chart_outlined,
+                tooltip: t.game_statistics,
+                label: t.game_statistics,
+                onTap: _openStatistics,
+              ),
+            ],
             bottom: GameSectionTabs(
               selected: GameSection.dashboard,
               focusIdPrefix: 'game-dashboard-tab',

--- a/hibiki/lib/src/pages/implementations/game_stat_aggregates.dart
+++ b/hibiki/lib/src/pages/implementations/game_stat_aggregates.dart
@@ -1,0 +1,75 @@
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/pages/implementations/stat_activity.dart';
+import 'package:hibiki/src/pages/implementations/stat_charts.dart';
+
+/// 游戏统计页的窗口聚合。
+///
+/// 时长与次数只来自 `galgame_sessions` 的按日 GROUP BY；[games] 只提供按游戏汇总
+/// 与显示信息，不读取 `activity_events`。
+class GameStatsAggregate {
+  GameStatsAggregate();
+
+  int todayMs = 0;
+  int weekMs = 0;
+  int monthMs = 0;
+  int allMs = 0;
+
+  int todaySessions = 0;
+  int weekSessions = 0;
+  int monthSessions = 0;
+  int allSessions = 0;
+
+  List<StatDayData> daily = <StatDayData>[];
+  List<GalgameEntry> byGame = <GalgameEntry>[];
+}
+
+GameStatsAggregate computeGameStats({
+  required List<GalgameEntry> games,
+  required Map<String, (int totalSeconds, int sessionCount)> dailyTotals,
+  required DateTime now,
+}) {
+  final GameStatsAggregate result = GameStatsAggregate();
+  final String todayKey = statDateKey(now);
+  final String weekAgoKey = statDateKey(now.subtract(const Duration(days: 7)));
+  final String monthAgoKey =
+      statDateKey(now.subtract(const Duration(days: 30)));
+
+  dailyTotals.forEach((
+    String dateKey,
+    (int totalSeconds, int sessionCount) totals,
+  ) {
+    final int ms = totals.$1 * 1000;
+    result.allMs += ms;
+    result.allSessions += totals.$2;
+    if (dateKey == todayKey) {
+      result.todayMs += ms;
+      result.todaySessions += totals.$2;
+    }
+    if (dateKey.compareTo(weekAgoKey) >= 0) {
+      result.weekMs += ms;
+      result.weekSessions += totals.$2;
+    }
+    if (dateKey.compareTo(monthAgoKey) >= 0) {
+      result.monthMs += ms;
+      result.monthSessions += totals.$2;
+    }
+  });
+
+  final DateTime firstDay = now.subtract(const Duration(days: 29));
+  result.daily = <StatDayData>[];
+  for (int i = 0; i < 30; i++) {
+    final String dateKey = statDateKey(firstDay.add(Duration(days: i)));
+    final StatDayData day = StatDayData(dateKey: dateKey);
+    day.ms = (dailyTotals[dateKey]?.$1 ?? 0) * 1000;
+    result.daily.add(day);
+  }
+
+  result.byGame =
+      games.where((GalgameEntry game) => game.sessionCount > 0).toList()
+        ..sort((GalgameEntry a, GalgameEntry b) {
+          final int byTime = b.totalPlaySeconds.compareTo(a.totalPlaySeconds);
+          if (byTime != 0) return byTime;
+          return b.lastPlayedMs.compareTo(a.lastPlayedMs);
+        });
+  return result;
+}

--- a/hibiki/lib/src/pages/implementations/game_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/game_statistics_page.dart
@@ -1,0 +1,257 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki/pages.dart';
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/mining/galgame_repository.dart';
+import 'package:hibiki/src/pages/implementations/galgame_detail_page.dart';
+import 'package:hibiki/src/pages/implementations/game_stat_aggregates.dart';
+import 'package:hibiki/src/pages/implementations/stat_activity.dart';
+import 'package:hibiki/src/pages/implementations/stat_delete_confirm_dialog.dart';
+import 'package:hibiki/src/pages/implementations/stat_shared.dart';
+import 'package:hibiki/utils.dart';
+
+/// 全游戏统计页。
+///
+/// 阅读、视频、游戏各自拥有独立统计页；本页的时长与次数只从
+/// `galgame_sessions` 事实表 GROUP BY 得出，活动时间线不参与统计。
+class GameStatisticsPage extends BasePage {
+  const GameStatisticsPage({super.key});
+
+  @override
+  BasePageState<GameStatisticsPage> createState() => _GameStatisticsPageState();
+}
+
+class _GameStatisticsPageState extends BasePageState<GameStatisticsPage> {
+  bool _loading = true;
+  String? _error;
+  GameStatsAggregate _aggregate = GameStatsAggregate();
+
+  GalgameRepository get _repo => appModelNoUpdate.galgameRepo;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final List<GalgameEntry> games = await _repo.load();
+      final Map<String, (int totalSeconds, int sessionCount)> dailyTotals =
+          await appModelNoUpdate.database.getAllGalgameDailyTotals();
+      _aggregate = computeGameStats(
+        games: games,
+        dailyTotals: dailyTotals,
+        now: DateTime.now(),
+      );
+    } catch (error, stack) {
+      ErrorLogService.instance.log('GameStatisticsPage.load', error, stack);
+      _error = error.toString();
+    }
+    if (mounted) setState(() => _loading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return HibikiPageScaffold(
+      title: t.game_statistics,
+      actions: <Widget>[
+        HibikiIconButton(
+          icon: Icons.refresh,
+          tooltip: t.stat_refresh,
+          enabled: !_loading,
+          onTap: _load,
+        ),
+        HibikiIconButton(
+          icon: Icons.delete_sweep_outlined,
+          tooltip: t.stat_clear_all,
+          enabled: !_loading,
+          onTap: _confirmAndClearAll,
+        ),
+      ],
+      body: buildStatPageBody(
+        loading: _loading,
+        error: _error,
+        isEmpty: _aggregate.allSessions == 0,
+        loadingBuilder: () =>
+            buildLoading(size: 25, color: theme.colorScheme.primary),
+        errorBuilder: (String error) => buildError(error: error),
+        emptyMessage: t.game_stat_no_sessions,
+        contentBuilder: _buildContent,
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    return CustomScrollView(
+      slivers: <Widget>[
+        SliverToBoxAdapter(child: _buildSummaryCards()),
+        SliverToBoxAdapter(
+          child: buildStatDailyDurationChartSection(
+            context,
+            _aggregate.daily,
+          ),
+        ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: EdgeInsets.fromLTRB(
+              tokens.spacing.card,
+              tokens.spacing.card + tokens.spacing.gap,
+              tokens.spacing.card,
+              tokens.spacing.gap,
+            ),
+            child: Text(
+              t.game_stat_by_game,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+        ),
+        SliverList(
+          delegate: SliverChildBuilderDelegate(
+            (BuildContext context, int index) =>
+                _buildGameRow(_aggregate.byGame[index]),
+            childCount: _aggregate.byGame.length,
+          ),
+        ),
+        SliverPadding(
+          padding: EdgeInsets.only(bottom: tokens.spacing.card * 2),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummaryCards() {
+    return buildStatPeriodSummaryGrid(
+      context,
+      <StatPeriodSummary>[
+        _periodSummary(
+          t.stat_today,
+          _aggregate.todayMs,
+          _aggregate.todaySessions,
+        ),
+        _periodSummary(
+          t.stat_this_week,
+          _aggregate.weekMs,
+          _aggregate.weekSessions,
+        ),
+        _periodSummary(
+          t.stat_this_month,
+          _aggregate.monthMs,
+          _aggregate.monthSessions,
+        ),
+        _periodSummary(
+          t.stat_all_time,
+          _aggregate.allMs,
+          _aggregate.allSessions,
+        ),
+      ],
+    );
+  }
+
+  StatPeriodSummary _periodSummary(String label, int ms, int sessions) {
+    return StatPeriodSummary(
+      label: label,
+      primaryValue: formatStatTime(ms),
+      lines: <StatSummaryLine>[
+        StatSummaryLine(
+          label: t.game_stat_sessions,
+          value: '$sessions',
+        ),
+      ],
+    );
+  }
+
+  Widget _buildGameRow(GalgameEntry game) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    final String lastPlayed = game.lastPlayedMs <= 0
+        ? '-'
+        : statDateKey(
+            DateTime.fromMillisecondsSinceEpoch(game.lastPlayedMs),
+          );
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: tokens.spacing.card,
+        vertical: tokens.spacing.gap / 2,
+      ),
+      child: HibikiCard(
+        onTap: () => _openGame(game),
+        child: Row(
+          children: <Widget>[
+            Icon(
+              Icons.sports_esports_outlined,
+              color: colors.primary,
+            ),
+            SizedBox(width: tokens.spacing.gap),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    game.displayName,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodyLarge,
+                  ),
+                  SizedBox(height: tokens.spacing.gap / 2),
+                  Text(
+                    '${t.game_stat_sessions}: ${game.sessionCount} · '
+                    '${t.game_stat_last_played}: $lastPlayed',
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: tokens.type.metadata.copyWith(
+                      color: colors.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(width: tokens.spacing.gap),
+            ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 120),
+              child: Text(
+                formatStatTime(game.totalPlaySeconds * 1000),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            SizedBox(width: tokens.spacing.gap / 2),
+            Icon(
+              Icons.chevron_right,
+              color: colors.onSurfaceVariant,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _openGame(GalgameEntry game) async {
+    await Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => GalgameDetailPage(
+          gameId: game.id,
+          initialTab: 0,
+        ),
+      ),
+    );
+    if (mounted) await _load();
+  }
+
+  /// 只清游戏统计事实 `galgame_sessions`。游戏库与 `activity_events` 时间线必须保留。
+  Future<void> _confirmAndClearAll() async {
+    final bool confirmed = await confirmClearAllStatistics(
+      context,
+      t.stat_clear_all_game_message,
+    );
+    if (!confirmed || !mounted) return;
+    await appModelNoUpdate.database.clearAllGalgameStatistics();
+    if (!mounted) return;
+    await _load();
+  }
+}

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -443,9 +443,12 @@ class _HomeDashboardPageState
         await db.getAllReadingStatistics();
     final List<VideoWatchStatisticRow> watch =
         await db.getAllVideoWatchStatistics();
-    // 游戏活动日聚合（activity_events 的 game 事件，热力图「游戏」档数据源）。
-    final List<(String, int, int)> gameDaily =
+    // 游戏文本字数仍取 hook 活动事件；游玩时长必须取 galgame_sessions 事实表。
+    // activity_events 只描述时间线，不能兼任游戏时长统计投影。
+    final List<(String, int, int)> gameActivityDaily =
         await db.getActivityDailyTotals(kActivityGame);
+    final Map<String, (int totalSeconds, int sessionCount)> gameSessionDaily =
+        await db.getAllGalgameDailyTotals();
     // P4：游戏库整表（日明细/时间轴的游戏显示名反查）。仓储缓存与表恒一致，
     // 未载入过才真查 DB（毫秒级）；load() 会 notify → 本页监听器防抖重载一次
     // 后 isLoaded=true，不再形成回环。
@@ -496,9 +499,12 @@ class _HomeDashboardPageState
     }
     final Map<String, int> gameChars = <String, int>{};
     final Map<String, int> gameTimeMs = <String, int>{};
-    for (final (String dateKey, int charsDelta, int durationMs) in gameDaily) {
+    for (final (String dateKey, int charsDelta, int _) in gameActivityDaily) {
       gameChars[dateKey] = (gameChars[dateKey] ?? 0) + charsDelta;
-      gameTimeMs[dateKey] = (gameTimeMs[dateKey] ?? 0) + durationMs;
+    }
+    for (final MapEntry<String, (int totalSeconds, int sessionCount)> entry
+        in gameSessionDaily.entries) {
+      gameTimeMs[entry.key] = entry.value.$1 * 1000;
     }
     final Map<String, int> charsByDay = <String, int>{};
     final Map<String, int> timeMsByDay = <String, int>{};

--- a/hibiki/lib/src/pages/implementations/home_game_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_game_page.dart
@@ -4,6 +4,7 @@ import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/pages/implementations/galgame_home_page.dart';
 import 'package:hibiki/src/pages/implementations/game_diagnostics_page.dart';
 import 'package:hibiki/src/pages/implementations/game_shared.dart';
+import 'package:hibiki/src/pages/implementations/game_statistics_page.dart';
 import 'package:hibiki/src/pages/implementations/games_library_page.dart';
 import 'package:hibiki/src/pages/implementations/texthooker_page.dart';
 import 'package:hibiki/utils.dart';
@@ -101,6 +102,12 @@ class _HomeGamePageState extends State<HomeGamePage> {
   void _showMonitor() => _showSection(GameSection.monitor);
   void _showDiagnostics() => _showSection(GameSection.diagnostics);
 
+  Future<void> _openStatistics() => Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => const GameStatisticsPage(),
+        ),
+      );
+
   @override
   Widget build(BuildContext context) {
     final GameMonitorBuilder monitorBuilder = widget.monitorBuilder ??
@@ -155,6 +162,14 @@ class _HomeGamePageState extends State<HomeGamePage> {
           HibikiPageHeader(
             title: t.nav_game,
             subtitle: t.game_home_subtitle,
+            actions: <Widget>[
+              HibikiIconButton(
+                icon: Icons.bar_chart_outlined,
+                tooltip: t.game_statistics,
+                label: t.game_statistics,
+                onTap: _openStatistics,
+              ),
+            ],
             // 顶部不再放「捕获工作台」图标钮——它与下方 GameSectionTabs 的
             // 「捕获工作台」页签去向完全相同，纯冗余；入口收敛到页签 + 状态带。
             bottom: GameSectionTabs(

--- a/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
@@ -39,12 +39,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
 
   List<ReadingStatisticRow> _allStats = [];
 
-  /// 视频与游戏的原始统计（与书内阅读一起构成同一个字数/时长口径）。「按书」列表
-  /// 仍只列书，这两源只进 KPI / 汇总 / 趋势 / 目标进度与「各来源」卡。
-  List<VideoWatchStatisticRow> _videoStats = <VideoWatchStatisticRow>[];
-  List<(String, int, int)> _gameDaily = <(String, int, int)>[];
-
-  /// 逐来源逐日合计（[aggregateStatSourceDaily] 的产物），四个来源同形状。
+  /// 阅读域逐日合计：普通书与漫画同属阅读统计，视频和游戏由各自统计页负责。
   Map<StatBreakdownSource, Map<String, StatSourceTotals>> _sourceDaily =
       <StatBreakdownSource, Map<String, StatSourceTotals>>{};
 
@@ -133,10 +128,6 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     try {
       final db = appModelNoUpdate.database;
       _allStats = await db.getAllReadingStatistics();
-      // 口径统一：视频字幕字数/观看时长、游戏 hook 文本字数/游玩时长与书内阅读
-      // 同属一个学习总量（首页每日目标一直是这个口径，统计页此前漏了两源）。
-      _videoStats = await db.getAllVideoWatchStatistics();
-      _gameDaily = await db.getActivityDailyTotals(kActivityGame);
       // 书身份（'epub' / 'pdf' / 'manga'）：统计行只存 title，靠 epub_books 反查，
       // 用来把漫画从「阅读」里拆出来单列（页数是漫画独有的第三个量纲）。整表只查
       // 一次，下面的 title→bookKey（合集归属用）复用同一批行。
@@ -147,8 +138,8 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       _sourceDaily = aggregateStatSourceDaily(
         reading: _allStats,
         formatByTitle: formatByTitle,
-        video: _videoStats,
-        gameDaily: _gameDaily,
+        video: const <VideoWatchStatisticRow>[],
+        gameDaily: const <(String, int, int)>[],
       );
       _computeAggregates();
       final DateTime now = DateTime.now();
@@ -237,9 +228,14 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     final dailyMap = <String, StatDayData>{};
     final bookMap = <String, _BookData>{};
 
-    // 窗口合计走四来源合并后的逐日表（书 + 漫画 + 视频 + 游戏），与首页每日目标
-    // 同一个分子；「按书」列表仍只用 reading_statistics 行（视频/游戏不是书）。
-    for (final Map<String, StatSourceTotals> byDay in _sourceDaily.values) {
+    // 阅读统计只合并阅读域的普通书与漫画。视频 / 游戏有各自统计页，不进入本页
+    // KPI、趋势、目标进度或活跃天数。
+    for (final StatBreakdownSource source in const <StatBreakdownSource>[
+      StatBreakdownSource.book,
+      StatBreakdownSource.manga,
+    ]) {
+      final Map<String, StatSourceTotals> byDay =
+          _sourceDaily[source] ?? const <String, StatSourceTotals>{};
       byDay.forEach((String dateKey, StatSourceTotals totals) {
         _allChars += totals.chars;
         _allMs += totals.timeMs;
@@ -282,10 +278,18 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
       _dailyData.add(dailyMap[key] ?? StatDayData(dateKey: key));
     }
 
-    // 总览：活跃天数 = 任一来源有数据的 distinct dateKey（看了视频、玩了游戏的那天
-    // 也是学习日，不该因为没读书就断签）；日期范围 = min/max dateKey（dateKey 零填充
-    // 可字典序比较）。
-    final Set<String> activeDayKeys = allStatSourceDateKeys(_sourceDaily);
+    // 总览活跃天数只取阅读域日期；dateKey 零填充，可直接字典序比较。
+    final Set<String> activeDayKeys = <String>{};
+    for (final StatBreakdownSource source in const <StatBreakdownSource>[
+      StatBreakdownSource.book,
+      StatBreakdownSource.manga,
+    ]) {
+      for (final MapEntry<String, StatSourceTotals> entry
+          in (_sourceDaily[source] ?? const <String, StatSourceTotals>{})
+              .entries) {
+        if (!entry.value.isEmpty) activeDayKeys.add(entry.key);
+      }
+    }
     _streak = computeReadingStreak(activeDayKeys, now);
     if (activeDayKeys.isEmpty) {
       _firstDateKey = null;
@@ -322,11 +326,14 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     }
   }
 
-  /// 按当前窗口重算四来源合计（纯内存，不重查 DB）。
+  /// 按当前窗口重算阅读域来源合计（普通书 + 漫画，纯内存，不重查 DB）。
   void _recomputeBreakdown() {
     final bool Function(String) inWindow = _breakdownPredicate();
     _breakdownTotals = <StatBreakdownSource, StatSourceTotals>{
-      for (final StatBreakdownSource source in StatBreakdownSource.values)
+      for (final StatBreakdownSource source in const <StatBreakdownSource>[
+        StatBreakdownSource.book,
+        StatBreakdownSource.manga,
+      ])
         source: sumStatSourceTotals(
           _sourceDaily[source] ?? const <String, StatSourceTotals>{},
           inWindow,
@@ -419,21 +426,16 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
           onTap: _confirmAndClearAll,
         ),
       ],
-      body: _loading
-          // BasePage 家族历史样式（25×25 主色圈），参数化保留、视觉不变。
-          ? buildLoading(size: 25, color: theme.colorScheme.primary)
-          : _error != null
-              ? buildError(error: _error)
-              // 空态判据是**四来源皆空**：只看视频 / 只玩游戏的用户此前会被判成
-              // 「暂无数据」，明明有学习记录却什么也看不到。
-              : (_allStats.isEmpty && _videoStats.isEmpty && _gameDaily.isEmpty)
-                  ? Center(
-                      child: HibikiPlaceholderMessage(
-                        icon: Icons.bar_chart_outlined,
-                        message: t.stat_no_data,
-                      ),
-                    )
-                  : _buildContent(),
+      body: buildStatPageBody(
+        loading: _loading,
+        error: _error,
+        isEmpty: _allStats.isEmpty,
+        loadingBuilder: () =>
+            buildLoading(size: 25, color: theme.colorScheme.primary),
+        errorBuilder: (String error) => buildError(error: error),
+        emptyMessage: t.stat_no_data,
+        contentBuilder: _buildContent,
+      ),
     );
   }
 
@@ -602,15 +604,14 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     );
   }
 
-  /// 「各来源」卡：四个来源各自的两个量纲（字数 + 时长），漫画额外显示页数。
-  ///
-  /// 用户要的「游戏、漫画等加上支持」落在这里：统计页此前只有书内阅读，视频字幕
-  /// 与游戏文本的字数、漫画的页数都没有去处。空来源（从没看过视频 / 没玩过游戏）
-  /// 整行不渲染，装了也不用的人看不到噪音。
+  /// 阅读域「各来源」卡：普通书与漫画各自的字数 + 时长，漫画额外显示页数。
   Widget _buildSourceBreakdown() {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     final List<Widget> rows = <Widget>[];
-    for (final StatBreakdownSource source in StatBreakdownSource.values) {
+    for (final StatBreakdownSource source in const <StatBreakdownSource>[
+      StatBreakdownSource.book,
+      StatBreakdownSource.manga,
+    ]) {
       final StatSourceTotals totals =
           _breakdownTotals[source] ?? StatSourceTotals();
       if (totals.isEmpty) continue;
@@ -701,103 +702,43 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
   }
 
   Widget _buildSummaryCards() {
-    final tokens = HibikiDesignTokens.of(context);
-    final double gap = tokens.spacing.gap + tokens.spacing.gap / 2;
-
-    // 四个汇总面板：今天 / 本周 / 本月 / 全部。
-    final List<Widget> panels = <Widget>[
-      _summaryStatPanel(t.stat_today, _todayChars, _todayMs, _lookup.today,
-          _mined.today, _favorited.today, _favoritedSentences.today),
-      _summaryStatPanel(t.stat_this_week, _weekChars, _weekMs, _lookup.week,
-          _mined.week, _favorited.week, _favoritedSentences.week),
-      _summaryStatPanel(t.stat_this_month, _monthChars, _monthMs, _lookup.month,
-          _mined.month, _favorited.month, _favoritedSentences.month),
-      _summaryStatPanel(t.stat_all_time, _allChars, _allMs, _lookup.all,
-          _mined.all, _favorited.all, _favoritedSentences.all),
-    ];
-
-    return Padding(
-      padding: EdgeInsets.all(tokens.spacing.card),
-      // BUG-1184：原先是两个写死的双列 Row，没有窄屏回退（同页的 _buildMidSection
-      // 早就有 wide 标志会堆叠，汇总卡一直漏了）。320dp 屏上每格只剩约 132px、
-      // 扣掉卡片内边距只有约 100px 的文字宽，而每个面板要放 7 行「标签: 数值」——
-      // 每一行都被迫折成两三行，读起来像一团乱码。窄屏改单列。
-      child: LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-          // 双列每格需要约 180px 才放得下一行「标签: 数值」，加上列间距即约 380。
-          final bool twoColumns =
-              !constraints.maxWidth.isFinite || constraints.maxWidth >= 380;
-          if (!twoColumns) {
-            return Column(
-              children: <Widget>[
-                for (int i = 0; i < panels.length; i++) ...<Widget>[
-                  if (i > 0) SizedBox(height: gap),
-                  panels[i],
-                ],
-              ],
-            );
-          }
-          return Column(
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Expanded(child: panels[0]),
-                  SizedBox(width: gap),
-                  Expanded(child: panels[1]),
-                ],
-              ),
-              SizedBox(height: gap),
-              Row(
-                children: <Widget>[
-                  Expanded(child: panels[2]),
-                  SizedBox(width: gap),
-                  Expanded(child: panels[3]),
-                ],
-              ),
-            ],
-          );
-        },
-      ),
+    return buildStatPeriodSummaryGrid(
+      context,
+      <StatPeriodSummary>[
+        _periodSummary(t.stat_today, _todayChars, _todayMs, _lookup.today,
+            _mined.today, _favorited.today, _favoritedSentences.today),
+        _periodSummary(t.stat_this_week, _weekChars, _weekMs, _lookup.week,
+            _mined.week, _favorited.week, _favoritedSentences.week),
+        _periodSummary(t.stat_this_month, _monthChars, _monthMs, _lookup.month,
+            _mined.month, _favorited.month, _favoritedSentences.month),
+        _periodSummary(t.stat_all_time, _allChars, _allMs, _lookup.all,
+            _mined.all, _favorited.all, _favoritedSentences.all),
+      ],
     );
   }
 
-  Widget _summaryStatPanel(String label, int chars, int ms, int lookup,
-      int mined, int favorited, int favoritedSentences) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final tokens = HibikiDesignTokens.of(context);
-    final TextStyle? subStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
-          color: colorScheme.onSurfaceVariant,
-        );
-    return HibikiCard(
-      child: Padding(
-        padding: EdgeInsets.zero,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(label,
-                style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                    )),
-            SizedBox(height: tokens.spacing.gap),
-            Text(_formatChars(chars),
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      color: colorScheme.onSurface,
-                      fontWeight: FontWeight.bold,
-                    )),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text(formatStatTime(ms), style: subStyle),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.stat_lookup}: $lookup', style: subStyle),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.stat_mined}: $mined', style: subStyle),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.stat_favorited}: $favorited', style: subStyle),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.stat_favorited_sentence}: $favoritedSentences',
-                style: subStyle),
-          ],
+  StatPeriodSummary _periodSummary(
+    String label,
+    int chars,
+    int ms,
+    int lookup,
+    int mined,
+    int favorited,
+    int favoritedSentences,
+  ) {
+    return StatPeriodSummary(
+      label: label,
+      primaryValue: _formatChars(chars),
+      lines: <StatSummaryLine>[
+        StatSummaryLine(value: formatStatTime(ms)),
+        StatSummaryLine(label: t.stat_lookup, value: '$lookup'),
+        StatSummaryLine(label: t.stat_mined, value: '$mined'),
+        StatSummaryLine(label: t.stat_favorited, value: '$favorited'),
+        StatSummaryLine(
+          label: t.stat_favorited_sentence,
+          value: '$favoritedSentences',
         ),
-      ),
+      ],
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/stat_shared.dart
+++ b/hibiki/lib/src/pages/implementations/stat_shared.dart
@@ -4,8 +4,184 @@ import 'package:hibiki/src/pages/implementations/stat_charts.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
-/// 阅读统计页与视频统计页**字节级相同**的聚合 / 格式化 / 图表辅助（机械去重抽出，
-/// 原先两页各持一份）。页面特有的加载与布局逻辑仍留在各自页面。
+/// 阅读、视频与游戏统计页共用的聚合 / 格式化 / 页面状态 / 卡片与图表辅助。
+
+/// 统一统计页的加载、错误、空态分派。
+///
+/// 三个页面只提供自己的数据判据和内容；状态优先级与空态视觉不再各复制一份三元表达式。
+Widget buildStatPageBody({
+  required bool loading,
+  required String? error,
+  required bool isEmpty,
+  required Widget Function() loadingBuilder,
+  required Widget Function(String error) errorBuilder,
+  required String emptyMessage,
+  required Widget Function() contentBuilder,
+}) {
+  if (loading) return loadingBuilder();
+  if (error != null) return errorBuilder(error);
+  if (isEmpty) {
+    return Center(
+      child: HibikiPlaceholderMessage(
+        icon: Icons.bar_chart_outlined,
+        message: emptyMessage,
+      ),
+    );
+  }
+  return contentBuilder();
+}
+
+/// 汇总周期卡的一条次级指标。[label] 为空时只显示值（如阅读卡主字数下的时长）。
+class StatSummaryLine {
+  const StatSummaryLine({this.label, required this.value});
+
+  final String? label;
+  final String value;
+}
+
+/// 今天 / 本周 / 本月 / 全部中的一个汇总卡数据。
+class StatPeriodSummary {
+  const StatPeriodSummary({
+    required this.label,
+    required this.primaryValue,
+    this.lines = const <StatSummaryLine>[],
+  });
+
+  final String label;
+  final String primaryValue;
+  final List<StatSummaryLine> lines;
+}
+
+/// 统计页共用的四周期汇总卡网格：宽屏 2×2，窄屏单列。
+Widget buildStatPeriodSummaryGrid(
+  BuildContext context,
+  List<StatPeriodSummary> summaries,
+) {
+  final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+  final double gap = tokens.spacing.gap + tokens.spacing.gap / 2;
+  final List<Widget> panels = summaries
+      .map((StatPeriodSummary summary) =>
+          _StatPeriodSummaryCard(summary: summary))
+      .toList();
+
+  return Padding(
+    padding: EdgeInsets.all(tokens.spacing.card),
+    child: LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final bool twoColumns =
+            constraints.maxWidth.isFinite && constraints.maxWidth >= 380;
+        if (!twoColumns) {
+          return Column(
+            children: <Widget>[
+              for (int i = 0; i < panels.length; i++) ...<Widget>[
+                if (i > 0) SizedBox(height: gap),
+                panels[i],
+              ],
+            ],
+          );
+        }
+        return Wrap(
+          spacing: gap,
+          runSpacing: gap,
+          children: <Widget>[
+            for (final Widget panel in panels)
+              SizedBox(
+                width: (constraints.maxWidth - gap) / 2,
+                child: panel,
+              ),
+          ],
+        );
+      },
+    ),
+  );
+}
+
+class _StatPeriodSummaryCard extends StatelessWidget {
+  const _StatPeriodSummaryCard({required this.summary});
+
+  final StatPeriodSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final TextStyle? subStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: colorScheme.onSurfaceVariant,
+        );
+    return HibikiCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            summary.label,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+          ),
+          SizedBox(height: tokens.spacing.gap),
+          FittedBox(
+            fit: BoxFit.scaleDown,
+            alignment: Alignment.centerLeft,
+            child: Text(
+              summary.primaryValue,
+              maxLines: 1,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.bold,
+                  ),
+            ),
+          ),
+          for (final StatSummaryLine line in summary.lines) ...<Widget>[
+            SizedBox(height: tokens.spacing.gap / 2),
+            Text(
+              line.label == null ? line.value : '${line.label}: ${line.value}',
+              style: subStyle,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// 最近 30 天时长柱状图（视频 / 游戏统计共用）。
+Widget buildStatDailyDurationChartSection(
+  BuildContext context,
+  List<StatDayData> daily,
+) {
+  final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+  final ColorScheme colorScheme = Theme.of(context).colorScheme;
+  return Padding(
+    padding: EdgeInsets.symmetric(horizontal: tokens.spacing.card),
+    child: Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          t.stat_last_30_days,
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        SizedBox(height: tokens.spacing.gap + tokens.spacing.gap / 2),
+        SizedBox(
+          height: 160,
+          child: CustomPaint(
+            size: Size.infinite,
+            painter: StatBarChartPainter(
+              data: daily,
+              barColor: colorScheme.primary,
+              barRadius: tokens.radii.chipCorner,
+              labelColor: colorScheme.onSurfaceVariant,
+              labelStyle: tokens.type.metadata.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+              valueOf: statMsValue,
+              labelFormatter: formatStatDurationAxis,
+            ),
+          ),
+        ),
+      ],
+    ),
+  );
+}
 
 /// TODO-1204：把查词/制卡计数行按 [LookupMiningCounterRow.title] 聚合成
 /// (查词数, 制卡数)，供 per-book / per-video tile 展示。无书查词（title 空）不入

--- a/hibiki/lib/src/pages/implementations/stat_source_totals.dart
+++ b/hibiki/lib/src/pages/implementations/stat_source_totals.dart
@@ -1,10 +1,9 @@
 import 'package:hibiki_core/hibiki_core.dart';
 
-/// 学习统计的**来源**维度：阅读统计页与首页仪表盘的字数/时长口径由此统一。
+/// 学习活动的**来源**维度：供跨来源首页汇总与来源拆分纯函数使用。
 ///
-/// 背景：统计页此前只读 `reading_statistics`（书内阅读），却在编辑与首页共用的
-/// 每日目标——首页把 阅读 + 视频字幕 + 游戏文本 三源合计当分子，统计页只算书，
-/// 同一个目标两个页面两套分子。这里把四个来源摊平成同一形状，两边共用。
+/// 四个来源摊平成同一形状，消费方再明确选择自己的域：阅读统计页只取
+/// [book]/[manga]，视频与游戏由各自统计页读取各自事实表；首页跨来源目标可取并集。
 ///
 /// 每个来源都带**两个独立量纲**（字数 + 时长），漫画额外带页数：
 /// - [book]：EPUB / PDF 等书内阅读（`reading_statistics` 中 `format != 'manga'`）。
@@ -96,7 +95,7 @@ StatSourceTotals sumStatSourceTotals(
   return total;
 }
 
-/// 全部来源在某窗口的合计（首页每日目标 / 统计页 KPI 的同一口径分子）。
+/// 全部来源在某窗口的合计（跨来源首页目标等场景使用）。
 StatSourceTotals sumAllStatSources(
   Map<StatBreakdownSource, Map<String, StatSourceTotals>> daily,
   bool Function(String dateKey) inWindow,
@@ -108,8 +107,7 @@ StatSourceTotals sumAllStatSources(
   return total;
 }
 
-/// 所有来源出现过的日期键并集（连续天数 / 活跃天数用：看了视频、玩了游戏的那天
-/// 也是学习日，不该因为没读书就断签）。
+/// 所有来源出现过的日期键并集（跨来源活跃天数使用）。
 Set<String> allStatSourceDateKeys(
   Map<StatBreakdownSource, Map<String, StatSourceTotals>> daily,
 ) {

--- a/hibiki/lib/src/pages/implementations/video_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_statistics_page.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/pages/implementations/stat_activity.dart';
-import 'package:hibiki/src/pages/implementations/stat_charts.dart';
 import 'package:hibiki/src/pages/implementations/stat_delete_confirm_dialog.dart';
 import 'package:hibiki/src/pages/implementations/stat_shared.dart';
 import 'package:hibiki/src/pages/implementations/video_stat_aggregates.dart';
@@ -170,19 +169,16 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
           onTap: _confirmAndClearAll,
         ),
       ],
-      body: _loading
-          // BasePage 家族历史样式（25×25 主色圈），参数化保留、视觉不变。
-          ? buildLoading(size: 25, color: theme.colorScheme.primary)
-          : _error != null
-              ? buildError(error: _error)
-              : !_hasData
-                  ? Center(
-                      child: HibikiPlaceholderMessage(
-                        icon: Icons.bar_chart_outlined,
-                        message: t.video_stat_no_data,
-                      ),
-                    )
-                  : _buildContent(),
+      body: buildStatPageBody(
+        loading: _loading,
+        error: _error,
+        isEmpty: !_hasData,
+        loadingBuilder: () =>
+            buildLoading(size: 25, color: theme.colorScheme.primary),
+        errorBuilder: (String error) => buildError(error: error),
+        emptyMessage: t.video_stat_no_data,
+        contentBuilder: _buildContent,
+      ),
     );
   }
 
@@ -194,7 +190,9 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
         SliverToBoxAdapter(child: _buildSummaryCards()),
         SliverToBoxAdapter(
             child: buildStatHourlyChartSection(context, _hourlyMs)),
-        SliverToBoxAdapter(child: _buildDailyChart()),
+        SliverToBoxAdapter(
+          child: buildStatDailyDurationChartSection(context, _agg.daily),
+        ),
         SliverToBoxAdapter(
           child: Padding(
             padding: EdgeInsets.fromLTRB(
@@ -220,146 +218,64 @@ class _VideoStatisticsPageState extends BasePageState<VideoStatisticsPage> {
   }
 
   Widget _buildSummaryCards() {
-    final tokens = HibikiDesignTokens.of(context);
-    final double gap = tokens.spacing.gap + tokens.spacing.gap / 2;
-
-    final List<Widget> panels = <Widget>[
-      _summaryStatPanel(
-          t.stat_today,
-          _agg.todayMs,
-          _agg.todayCompleted,
-          _lookup.today,
-          _mined.today,
-          _favorited.today,
-          _favoritedSentences.today),
-      _summaryStatPanel(t.stat_this_week, _agg.weekMs, _agg.weekCompleted,
-          _lookup.week, _mined.week, _favorited.week, _favoritedSentences.week),
-      _summaryStatPanel(
-          t.stat_this_month,
-          _agg.monthMs,
-          _agg.monthCompleted,
-          _lookup.month,
-          _mined.month,
-          _favorited.month,
-          _favoritedSentences.month),
-      _summaryStatPanel(t.stat_all_time, _agg.allMs, _agg.allCompleted,
-          _lookup.all, _mined.all, _favorited.all, _favoritedSentences.all),
-    ];
-
-    return Padding(
-      padding: EdgeInsets.all(tokens.spacing.card),
-      // BUG-1184：与阅读统计页同款——写死的双列在 320dp 上每格只剩约 100px 文字宽，
-      // 每行「标签: 数值」都被迫折行。窄屏改单列。
-      child: LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-          final bool twoColumns =
-              !constraints.maxWidth.isFinite || constraints.maxWidth >= 380;
-          if (!twoColumns) {
-            return Column(
-              children: <Widget>[
-                for (int i = 0; i < panels.length; i++) ...<Widget>[
-                  if (i > 0) SizedBox(height: gap),
-                  panels[i],
-                ],
-              ],
-            );
-          }
-          return Column(
-            children: <Widget>[
-              Row(
-                children: <Widget>[
-                  Expanded(child: panels[0]),
-                  SizedBox(width: gap),
-                  Expanded(child: panels[1]),
-                ],
-              ),
-              SizedBox(height: gap),
-              Row(
-                children: <Widget>[
-                  Expanded(child: panels[2]),
-                  SizedBox(width: gap),
-                  Expanded(child: panels[3]),
-                ],
-              ),
-            ],
-          );
-        },
-      ),
+    return buildStatPeriodSummaryGrid(
+      context,
+      <StatPeriodSummary>[
+        _periodSummary(
+            t.stat_today,
+            _agg.todayMs,
+            _agg.todayCompleted,
+            _lookup.today,
+            _mined.today,
+            _favorited.today,
+            _favoritedSentences.today),
+        _periodSummary(
+            t.stat_this_week,
+            _agg.weekMs,
+            _agg.weekCompleted,
+            _lookup.week,
+            _mined.week,
+            _favorited.week,
+            _favoritedSentences.week),
+        _periodSummary(
+            t.stat_this_month,
+            _agg.monthMs,
+            _agg.monthCompleted,
+            _lookup.month,
+            _mined.month,
+            _favorited.month,
+            _favoritedSentences.month),
+        _periodSummary(t.stat_all_time, _agg.allMs, _agg.allCompleted,
+            _lookup.all, _mined.all, _favorited.all, _favoritedSentences.all),
+      ],
     );
   }
 
-  Widget _summaryStatPanel(String label, int ms, int completed, int lookup,
-      int mined, int favorited, int favoritedSentences) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final tokens = HibikiDesignTokens.of(context);
-    final TextStyle? subStyle = Theme.of(context).textTheme.bodySmall?.copyWith(
-          color: colorScheme.onSurfaceVariant,
-        );
-    return HibikiCard(
-      child: Padding(
-        padding: EdgeInsets.zero,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(label,
-                style: Theme.of(context).textTheme.labelLarge?.copyWith(
-                      color: colorScheme.onSurfaceVariant,
-                    )),
-            SizedBox(height: tokens.spacing.gap),
-            // 删字数后以观看时长为主数字。
-            Text(formatStatTime(ms),
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      color: colorScheme.onSurface,
-                      fontWeight: FontWeight.bold,
-                    )),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.video_stat_completed}: $completed', style: subStyle),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.stat_lookup}: $lookup', style: subStyle),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.stat_mined}: $mined', style: subStyle),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.stat_favorited}: $favorited', style: subStyle),
-            SizedBox(height: tokens.spacing.gap / 2),
-            Text('${t.stat_favorited_sentence}: $favoritedSentences',
-                style: subStyle),
-          ],
+  StatPeriodSummary _periodSummary(
+    String label,
+    int ms,
+    int completed,
+    int lookup,
+    int mined,
+    int favorited,
+    int favoritedSentences,
+  ) {
+    return StatPeriodSummary(
+      label: label,
+      primaryValue: formatStatTime(ms),
+      lines: <StatSummaryLine>[
+        StatSummaryLine(
+          label: t.video_stat_completed,
+          value: '$completed',
         ),
-      ),
-    );
-  }
-
-  Widget _buildDailyChart() {
-    final tokens = HibikiDesignTokens.of(context);
-    final colorScheme = Theme.of(context).colorScheme;
-    return Padding(
-      padding: EdgeInsets.symmetric(horizontal: tokens.spacing.card),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(t.stat_last_30_days,
-              style: Theme.of(context).textTheme.titleMedium),
-          SizedBox(height: tokens.spacing.gap + tokens.spacing.gap / 2),
-          SizedBox(
-            height: 160,
-            child: CustomPaint(
-              size: Size.infinite,
-              painter: StatBarChartPainter(
-                data: _agg.daily,
-                barColor: colorScheme.primary,
-                barRadius: tokens.radii.chipCorner,
-                labelColor: colorScheme.onSurfaceVariant,
-                labelStyle: tokens.type.metadata.copyWith(
-                  color: colorScheme.onSurfaceVariant,
-                ),
-                // 删字数后日图画观看时长（ms），纵轴用时长格式（修 `0m` 退化）。
-                valueOf: statMsValue,
-                labelFormatter: formatStatDurationAxis,
-              ),
-            ),
-          ),
-        ],
-      ),
+        StatSummaryLine(label: t.stat_lookup, value: '$lookup'),
+        StatSummaryLine(label: t.stat_mined, value: '$mined'),
+        StatSummaryLine(label: t.stat_favorited, value: '$favorited'),
+        StatSummaryLine(
+          label: t.stat_favorited_sentence,
+          value: '$favoritedSentences',
+        ),
+      ],
     );
   }
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+996
+version: 1.3.1+997
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/database/galgame_sessions_dao_test.dart
+++ b/hibiki/test/database/galgame_sessions_dao_test.dart
@@ -149,6 +149,23 @@ void main() {
     expect(await db.getGalgameSecondsForDay('2026-07-25'), 0);
   });
 
+  test('getAllGalgameDailyTotals：跨游戏按天聚合时长与会话数', () async {
+    final HibikiDatabase db = await openDb();
+    await addGame(db, 'a');
+    await addGame(db, 'b');
+
+    await addSession(db, 'a',
+        startMs: 1, endMs: 2, durationSeconds: 100, dateKey: '2026-07-24');
+    await addSession(db, 'b',
+        startMs: 3, endMs: 4, durationSeconds: 250, dateKey: '2026-07-24');
+    await addSession(db, 'a',
+        startMs: 5, endMs: 6, durationSeconds: 999, dateKey: '2026-07-23');
+
+    final Map<String, (int, int)> totals = await db.getAllGalgameDailyTotals();
+    expect(totals['2026-07-24'], (350, 2));
+    expect(totals['2026-07-23'], (999, 1));
+  });
+
   test('getGalgameSessions：按起始时间倒序并支持分页', () async {
     final HibikiDatabase db = await openDb();
     await addGame(db, 'a');
@@ -198,6 +215,39 @@ void main() {
     expect(after['a']?.$1, 600); // 只剩最早那条 600 秒
     expect(after['a']?.$2, 1);
     expect(after['a']?.$3, 2000); // 最后游玩回退到剩下那条的 end_ms
+  });
+
+  test('clearAllGalgameStatistics：只清会话，保留游戏库与活动时间线', () async {
+    final HibikiDatabase db = await openDb();
+    await addGame(db, 'a');
+    await addSession(
+      db,
+      'a',
+      startMs: 1000,
+      endMs: 2000,
+      durationSeconds: 600,
+      dateKey: '2026-07-20',
+    );
+    await db.addActivityEvent(
+      eventType: kActivityGame,
+      mediaType: kActivityMediaGame,
+      title: 'a',
+      mediaKey: 'a',
+      dateKey: '2026-07-20',
+      timestampMs: 2000,
+      durationMs: 600000,
+      charsDelta: 100,
+    );
+
+    expect(await db.clearAllGalgameStatistics(), 1);
+
+    expect(await db.getGalgameSessions('a'), isEmpty);
+    expect(await db.getAllGalgameDailyTotals(), isEmpty);
+    expect(await db.getGalgame('a'), isNotNull);
+    final List<ActivityEventRow> activities =
+        await db.getRecentActivityEvents();
+    expect(activities, hasLength(1));
+    expect(activities.single.eventType, kActivityGame);
   });
 
   test('galgame_sources：同 (gameId, source) 覆盖而不是插重复行', () async {

--- a/hibiki/test/pages/game_stat_aggregates_test.dart
+++ b/hibiki/test/pages/game_stat_aggregates_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/galgame_library.dart';
+import 'package:hibiki/src/pages/implementations/game_stat_aggregates.dart';
+
+GalgameEntry _game(
+  String id, {
+  required int seconds,
+  required int sessions,
+  required int lastPlayedMs,
+}) {
+  return GalgameEntry(
+    id: id,
+    name: id,
+    exePath: '$id.exe',
+    workdir: '.',
+    addedAt: DateTime(2026),
+    totalPlaySeconds: seconds,
+    sessionCount: sessions,
+    lastPlayedMs: lastPlayedMs,
+  );
+}
+
+void main() {
+  final DateTime now = DateTime(2026, 7, 29, 12);
+
+  test('游戏窗口只聚合 galgame_sessions 的按日事实', () {
+    final GameStatsAggregate aggregate = computeGameStats(
+      games: <GalgameEntry>[
+        _game('a', seconds: 7200, sessions: 2, lastPlayedMs: 20),
+      ],
+      dailyTotals: <String, (int, int)>{
+        '2026-07-29': (1800, 1),
+        '2026-07-25': (3600, 2),
+        '2026-06-20': (7200, 3),
+      },
+      now: now,
+    );
+
+    expect(aggregate.todayMs, 1800 * 1000);
+    expect(aggregate.todaySessions, 1);
+    expect(aggregate.weekMs, (1800 + 3600) * 1000);
+    expect(aggregate.weekSessions, 3);
+    expect(aggregate.monthMs, (1800 + 3600) * 1000);
+    expect(aggregate.allMs, (1800 + 3600 + 7200) * 1000);
+    expect(aggregate.allSessions, 6);
+  });
+
+  test('近 30 天补零且按游戏时长降序，未游玩游戏不进入列表', () {
+    final GameStatsAggregate aggregate = computeGameStats(
+      games: <GalgameEntry>[
+        _game('short', seconds: 60, sessions: 1, lastPlayedMs: 30),
+        _game('never', seconds: 0, sessions: 0, lastPlayedMs: 0),
+        _game('long', seconds: 3600, sessions: 2, lastPlayedMs: 10),
+      ],
+      dailyTotals: <String, (int, int)>{
+        '2026-07-29': (90, 1),
+      },
+      now: now,
+    );
+
+    expect(aggregate.daily, hasLength(30));
+    expect(aggregate.daily.first.dateKey, '2026-06-30');
+    expect(aggregate.daily.last.dateKey, '2026-07-29');
+    expect(aggregate.daily.last.ms, 90000);
+    expect(
+      aggregate.byGame.map((GalgameEntry game) => game.id),
+      <String>['long', 'short'],
+    );
+  });
+}

--- a/hibiki/test/pages/game_statistics_page_guard_test.dart
+++ b/hibiki/test/pages/game_statistics_page_guard_test.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('两套游戏首页都接入独立游戏统计页', () {
+    for (final String path in <String>[
+      'lib/src/pages/implementations/galgame_home_page.dart',
+      'lib/src/pages/implementations/home_game_page.dart',
+    ]) {
+      final String source = File(path).readAsStringSync();
+      expect(source, contains('game_statistics_page.dart'), reason: path);
+      expect(source, contains('GameStatisticsPage()'), reason: path);
+    }
+  });
+
+  test('游戏统计页清空入口只调用游戏统计 DAO', () {
+    final String source = File(
+      'lib/src/pages/implementations/game_statistics_page.dart',
+    ).readAsStringSync();
+
+    expect(source, contains('tooltip: t.stat_clear_all'));
+    expect(source, contains('t.stat_clear_all_game_message'));
+    expect(source, contains('clearAllGalgameStatistics()'));
+    expect(source, isNot(contains('clearAllActivityEvents()')));
+    expect(source, isNot(contains('clearAllReadingStatistics()')));
+    expect(source, isNot(contains('clearAllVideoStatistics()')));
+  });
+}

--- a/hibiki/test/pages/home_game_capture_strip_guard_test.dart
+++ b/hibiki/test/pages/home_game_capture_strip_guard_test.dart
@@ -43,7 +43,13 @@ void main() {
     });
 
     test('库页顶部不再放与页签冗余的捕获图标钮', () {
-      expect(src.contains('HibikiIconButton'), isFalse,
+      final int headerStart = src.indexOf('HibikiPageHeader(');
+      final int headerEnd =
+          src.indexOf('bottom: GameSectionTabs(', headerStart);
+      expect(headerStart, greaterThanOrEqualTo(0));
+      expect(headerEnd, greaterThan(headerStart));
+      final String header = src.substring(headerStart, headerEnd);
+      expect(header.contains('onTap: _showMonitor'), isFalse,
           reason: '顶部「捕获工作台」图标钮与 GameSectionTabs 页签冗余，应删除');
     });
 

--- a/hibiki/test/pages/reading_statistics_goal_card_static_test.dart
+++ b/hibiki/test/pages/reading_statistics_goal_card_static_test.dart
@@ -89,7 +89,7 @@ void main() {
     final int actionsIdx = text.indexOf('actions: <Widget>[');
     expect(actionsIdx, greaterThanOrEqualTo(0),
         reason: '页面应有 scaffold actions');
-    final int bodyIdx = text.indexOf('body: _loading', actionsIdx);
+    final int bodyIdx = text.indexOf('body: buildStatPageBody(', actionsIdx);
     expect(bodyIdx, greaterThan(actionsIdx), reason: '应能定位 actions 与 body 边界');
 
     final String actionsRegion = text.substring(actionsIdx, bodyIdx);

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -3776,7 +3776,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   // ── galgames / galgame_sources / galgame_sessions (v55 游戏库) ──────
   //
   // 设计见 `docs/design/galgame-library-reina-parity.md`。这里刻意没有统计投影表：
-  // 时长/次数/最后游玩全部现算 GROUP BY（见下面三个聚合方法），一次消掉「投影与
+  // 时长/次数/最后游玩全部现算 GROUP BY（见下面聚合方法），一次消掉「投影与
   // 事实表不一致」的整类 bug。单机规模是几百游戏 × 几千会话，SQLite 毫秒级。
 
   /// 全部游戏，按添加时间升序（与旧 JSON 列表的天然顺序一致，Never break userspace）。
@@ -3877,6 +3877,12 @@ class HibikiDatabase extends _$HibikiDatabase {
   Future<int> deleteGalgameSession(int id) =>
       (delete(galgameSessions)..where((t) => t.id.equals(id))).go();
 
+  /// 清空游戏统计，只删除游玩会话事实。
+  ///
+  /// 游戏库（[galgames]）与首页活动时间线（[activityEvents]）是独立用户数据，
+  /// 不能因统计页的「清空」操作被连带删除。
+  Future<int> clearAllGalgameStatistics() => delete(galgameSessions).go();
+
   /// 全库每个游戏的时长合计（秒）+ 会话次数 + 最后游玩毫秒戳。
   ///
   /// 库页排序（按总时长 / 按最后游玩）与详情页 KPI 都吃这一个查询，取代上游的
@@ -3923,6 +3929,28 @@ class HibikiDatabase extends _$HibikiDatabase {
     return <String, int>{
       for (final QueryRow row in rows)
         row.read<String>('date_key'): row.read<int>('total_seconds'),
+    };
+  }
+
+  /// 全部游戏按天的游玩时长（秒）与会话数。
+  ///
+  /// 游戏统计页与首页汇总只认 [galgameSessions] 事实表；`activity_events` 是时间线，
+  /// 不能反过来充当时长统计投影。返回全部历史日期，读取端按今日/周/月窗口筛选。
+  Future<Map<String, (int totalSeconds, int sessionCount)>>
+      getAllGalgameDailyTotals() async {
+    final List<QueryRow> rows = await customSelect(
+      'SELECT date_key, '
+      'COALESCE(SUM(duration_seconds), 0) AS total_seconds, '
+      'COUNT(*) AS session_count '
+      'FROM galgame_sessions GROUP BY date_key',
+      readsFrom: {galgameSessions},
+    ).get();
+    return <String, (int, int)>{
+      for (final QueryRow row in rows)
+        row.read<String>('date_key'): (
+          row.read<int>('total_seconds'),
+          row.read<int>('session_count'),
+        ),
     };
   }
 


### PR DESCRIPTION
## What changed

- Added a dedicated game statistics page with today/week/month/all-time summaries, a 30-day duration chart, and per-game rankings.
- Kept reading statistics scoped to books and manga; video and game data no longer contributes to reading KPIs, trends, goals, streaks, or source breakdowns.
- Changed game duration/session aggregation to read from `galgame_sessions`; `activity_events` remains a timeline and game-text source instead of acting as a duration projection.
- Added game-statistics entry points to both the game dashboard and game library header.
- Unified the loading/error/empty states, period summary cards, and duration chart shared by reading, video, and game statistics pages.

## Why

Reading, video, and games already have separate product domains, but game duration had been folded into reading statistics and derived from activity records. That mixed unrelated statistics and made an activity timeline responsible for duration totals. This change restores domain ownership and uses the game-session fact table as the single source of truth for play time.

## Validation

- Targeted `dart analyze` for all changed Dart files: passed with no issues.
- `dart analyze packages/hibiki_core/lib/src/database/database.dart`: passed.
- `git diff --check`: passed.
- All 17 i18n JSON files parsed successfully; Slang output regenerated.
- Targeted Flutter tests were attempted but did not enter test execution because the sqlite3 native-asset download from GitHub timed out. Full compilation was intentionally not awaited for this task.
