### PR TITLE
fix(settings): center download settings content

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1204 条。点号进各自文件。
+> 共 1205 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1278](bugs/BUG-1278-download-settings-content-left.md) | ✅ | ✅ | 下载设置宽屏内容整体贴左且开关被推到远端 |
 | [BUG-1277](bugs/BUG-1277-reader-navigation-after-dispose.md) | ✅ | ✅ | 有声书跨章等待后触发已销毁 State 重绘 |
 | [BUG-1276](bugs/BUG-1276-dashboard-heatmap-dark-contrast.md) | ✅ | ✅ | 黑色主题下学习活动热力图空周融进背景 |
 | [BUG-1270](bugs/BUG-1270-youtube-live-subtitle-seek-duplicate.md) | ✅ | ✅ | YouTube 实时字幕回跳后重复且累积成长段 |

--- a/docs/bugs/BUG-1227-download-settings-content-left.md
+++ b/docs/bugs/BUG-1227-download-settings-content-left.md
@@ -1,0 +1,6 @@
+## BUG-1227 · 下载设置宽屏内容整体贴左且开关被推到远端
+- **报告**：2026-07-29（用户截图：4K 宽屏设置详情中，下载设置标题、说明和按钮全部贴在卡片最左侧，Switch 被推到最右侧）
+- **真实性**：✅ 真 bug。`TorrentSettingsSection` 的根 `Column` 在 `hibiki/lib/src/pages/implementations/torrent_settings_section.dart:309` 继续横向铺满详情卡片；BUG-1084 只把输入框限制为 480px 并左对齐，没有收拢标题、说明、分段按钮和 Switch。设置详情卡片在宽屏下按既定设计铺满 pane 后，这些控件便分散到卡片两端。
+- **[x] ① 已修复** — `TorrentSettingsSection` 在 `hibiki/lib/src/pages/implementations/torrent_settings_section.dart:643` 将整组表单约束到 560px 并水平居中；卡片表面仍铺满详情 pane，窄屏继续占满可用宽度。下载中心齿轮页改为复用同一宽度常量（本提交）。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/torrent_settings_field_width_test.dart` 覆盖 2400px pane 下表单 560px 居中、输入框 480px 限宽、分段控件和 Switch 不越出表单，以及 400px 窄 pane 下继续填满。
+- **备注**：按用户要求不等待编译验收；本轮只执行格式化与 `git diff --check`，widget 测试留给后续 CI/集成验收。

--- a/docs/bugs/BUG-1278-download-settings-content-left.md
+++ b/docs/bugs/BUG-1278-download-settings-content-left.md
@@ -1,4 +1,4 @@
-## BUG-1227 · 下载设置宽屏内容整体贴左且开关被推到远端
+## BUG-1278 · 下载设置宽屏内容整体贴左且开关被推到远端
 - **报告**：2026-07-29（用户截图：4K 宽屏设置详情中，下载设置标题、说明和按钮全部贴在卡片最左侧，Switch 被推到最右侧）
 - **真实性**：✅ 真 bug。`TorrentSettingsSection` 的根 `Column` 在 `hibiki/lib/src/pages/implementations/torrent_settings_section.dart:309` 继续横向铺满详情卡片；BUG-1084 只把输入框限制为 480px 并左对齐，没有收拢标题、说明、分段按钮和 Switch。设置详情卡片在宽屏下按既定设计铺满 pane 后，这些控件便分散到卡片两端。
 - **[x] ① 已修复** — `TorrentSettingsSection` 在 `hibiki/lib/src/pages/implementations/torrent_settings_section.dart:643` 将整组表单约束到 560px 并水平居中；卡片表面仍铺满详情 pane，窄屏继续占满可用宽度。下载中心齿轮页改为复用同一宽度常量（本提交）。

--- a/hibiki/lib/src/pages/implementations/downloads_page.dart
+++ b/hibiki/lib/src/pages/implementations/downloads_page.dart
@@ -92,7 +92,9 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                     // 桌面宽屏限宽 560 居中（对齐全 app 设置面板口径），不再全宽铺开。
                     Center(
                       child: ConstrainedBox(
-                        constraints: const BoxConstraints(maxWidth: 560),
+                        constraints: const BoxConstraints(
+                          maxWidth: kTorrentSettingsContentMaxWidth,
+                        ),
                         child: const TorrentSettingsSection(),
                       ),
                     ),

--- a/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
@@ -11,6 +11,12 @@ import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
 
+/// 下载设置表单在宽屏下的最大内容宽度。
+///
+/// 卡片表面仍由设置详情页铺满 pane；这里只把同属一组的标题、说明、按钮、输入框
+/// 和开关收在一起，避免左侧文案与最右侧操作控件隔着整块 4K 详情面板。
+const double kTorrentSettingsContentMaxWidth = 560;
+
 /// 下载后端配置（后端二选一 + qb 连接 / 内置引擎限速·上传·做种·内存·连接数）。
 /// 从「设置→视频」搬到「下载」页——下载既已独立成页，配置就该在页内，不再埋进
 /// 视频设置。所有字段写 `QbConnectionConfig`（即时生效到内置引擎）。
@@ -300,7 +306,7 @@ class _TorrentSettingsSectionState
     final bool isQb = backend == QbConnectionConfig.backendQbittorrent;
     final bool isEmbedded = backend == QbConnectionConfig.backendEmbedded;
 
-    return Column(
+    final Widget content = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         _sectionLabel(theme, t.download_network_proxy_section),
@@ -633,6 +639,18 @@ class _TorrentSettingsSectionState
           ],
         ],
       ],
+    );
+    return Align(
+      alignment: Alignment.topCenter,
+      child: ConstrainedBox(
+        constraints:
+            const BoxConstraints(maxWidth: kTorrentSettingsContentMaxWidth),
+        child: SizedBox(
+          key: const ValueKey<String>('torrent-settings-content'),
+          width: double.infinity,
+          child: content,
+        ),
+      ),
     );
   }
 }

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1012
+version: 1.3.1+1013
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/torrent_settings_field_width_test.dart
+++ b/hibiki/test/pages/torrent_settings_field_width_test.dart
@@ -14,10 +14,10 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import '../helpers/test_platform_services.dart';
 
-// BUG-1084 守卫：设置详情面板按用户拍板填满整宽（无 960 限宽），而
-// TextFormField 会吃满给定宽度——4K 全屏下「下载设置」每条输入框被拉到
-// 三千多像素。修复是把输入框自身限宽（Align 左对齐 + ConstrainedBox），
-// 开关行/分段按钮不受影响；窄面板（小于上限）输入框仍占满可用宽度。
+// BUG-1084 / BUG-1227 守卫：设置详情卡片按用户拍板填满整宽（无 960 面板限宽），
+// 但下载设置表单自身应在 4K pane 内按 560px 居中，避免说明与按钮贴住详情页左端、
+// Switch 被推到最右端。输入框在表单内继续限制为 480px；窄 pane 下两层限制均退化
+// 为填满可用宽度。
 class _TestAppModel extends AppModel {
   _TestAppModel() : super(testPlatformServices());
 
@@ -89,27 +89,59 @@ Widget _harness({required double paneWidth}) {
 
 void main() {
   testWidgets(
-      'wide pane: input fields cap at 480 and stay left-aligned '
-      '(BUG-1084)', (WidgetTester tester) async {
+      'wide pane: content centers at 560 and fields cap at 480 '
+      '(BUG-1084, BUG-1227)', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(2600, 2400);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
 
-    await tester.pumpWidget(_harness(paneWidth: 2400));
+    const double paneWidth = 2400;
+    await tester.pumpWidget(_harness(paneWidth: paneWidth));
     await tester.pumpAndSettle();
+
+    final Finder content = find.byKey(
+      const ValueKey<String>('torrent-settings-content'),
+    );
+    expect(content, findsOneWidget);
+    expect(
+      tester.getSize(content).width,
+      moreOrLessEquals(kTorrentSettingsContentMaxWidth, epsilon: 1.0),
+    );
+    expect(
+      tester.getCenter(content).dx,
+      moreOrLessEquals(paneWidth / 2, epsilon: 1.0),
+      reason: 'the whole settings form must be centered in the wide pane',
+    );
+
+    final double contentLeft = tester.getTopLeft(content).dx;
+    final Finder strips = find.byType(HibikiSegmentedStrip);
+    expect(strips, findsWidgets);
+    expect(
+      tester.getTopLeft(strips.first).dx,
+      moreOrLessEquals(contentLeft, epsilon: 1.0),
+      reason: 'segmented controls align with the centered form, not the pane',
+    );
+
+    final Finder switches = find.byType(AdaptiveSettingsSwitchRow);
+    expect(switches, findsWidgets);
+    for (final Element element in switches.evaluate()) {
+      expect(
+        tester.getSize(find.byWidget(element.widget)).width,
+        lessThanOrEqualTo(kTorrentSettingsContentMaxWidth + 1),
+        reason: 'switch labels and toggles stay together inside the form',
+      );
+    }
 
     final Finder fields = find.byType(TextFormField);
     expect(fields, findsWidgets,
         reason: 'embedded backend must render its input fields');
-    final double paneLeft =
-        tester.getTopLeft(find.byType(TorrentSettingsSection)).dx;
     for (final Element element in fields.evaluate()) {
       final Size size = tester.getSize(find.byWidget(element.widget));
       expect(size.width, lessThanOrEqualTo(481),
           reason: 'a field must never stretch across the full-width pane');
       expect(tester.getTopLeft(find.byWidget(element.widget)).dx,
-          moreOrLessEquals(paneLeft, epsilon: 1.0),
-          reason: 'capped fields stay left-aligned with the pane');
+          moreOrLessEquals(contentLeft, epsilon: 1.0),
+          reason: 'capped fields align with the centered form');
     }
   });
 
@@ -122,6 +154,13 @@ void main() {
     const double paneWidth = 400;
     await tester.pumpWidget(_harness(paneWidth: paneWidth));
     await tester.pumpAndSettle();
+
+    final Finder content = find.byKey(
+      const ValueKey<String>('torrent-settings-content'),
+    );
+    expect(tester.getSize(content).width,
+        moreOrLessEquals(paneWidth, epsilon: 1.0));
+    expect(tester.getTopLeft(content).dx, moreOrLessEquals(0, epsilon: 1.0));
 
     final Finder fields = find.byType(TextFormField);
     expect(fields, findsWidgets);

--- a/hibiki/test/pages/torrent_settings_field_width_test.dart
+++ b/hibiki/test/pages/torrent_settings_field_width_test.dart
@@ -114,7 +114,14 @@ void main() {
     );
 
     final double contentLeft = tester.getTopLeft(content).dx;
-    final Finder strips = find.byType(HibikiSegmentedStrip);
+    // HibikiSegmentedStrip 是泛型控件，实例的 runtimeType 是
+    // HibikiSegmentedStrip<DownloadNetworkProxyMode> / <String> / <int>；
+    // find.byType 走 runtimeType 精确相等，对泛型永远 0 命中。按 Dart 的协变
+    // 子类型关系用 `is HibikiSegmentedStrip<Object>` 判定才能覆盖全部实参。
+    final Finder strips = find.byWidgetPredicate(
+      (Widget widget) => widget is HibikiSegmentedStrip<Object>,
+      description: 'HibikiSegmentedStrip<*>',
+    );
     expect(strips, findsWidgets);
     expect(
       tester.getTopLeft(strips.first).dx,

--- a/hibiki/test/pages/torrent_settings_field_width_test.dart
+++ b/hibiki/test/pages/torrent_settings_field_width_test.dart
@@ -14,7 +14,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 
 import '../helpers/test_platform_services.dart';
 
-// BUG-1084 / BUG-1227 守卫：设置详情卡片按用户拍板填满整宽（无 960 面板限宽），
+// BUG-1084 / BUG-1278 守卫：设置详情卡片按用户拍板填满整宽（无 960 面板限宽），
 // 但下载设置表单自身应在 4K pane 内按 560px 居中，避免说明与按钮贴住详情页左端、
 // Switch 被推到最右端。输入框在表单内继续限制为 480px；窄 pane 下两层限制均退化
 // 为填满可用宽度。
@@ -90,7 +90,7 @@ Widget _harness({required double paneWidth}) {
 void main() {
   testWidgets(
       'wide pane: content centers at 560 and fields cap at 480 '
-      '(BUG-1084, BUG-1227)', (WidgetTester tester) async {
+      '(BUG-1084, BUG-1278)', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(2600, 2400);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);


### PR DESCRIPTION
## Summary

- keep the download settings card surface full-width while centering its form content at a 560 px maximum width
- keep the existing 480 px input-field cap and reuse the same form-width constant in the downloads-page settings entry
- add BUG-1227 plus wide- and narrow-pane widget regression coverage

## Root cause

BUG-1084 limited only `TextFormField` widgets to 480 px and explicitly left-aligned them, while the root `TorrentSettingsSection` column still stretched across the entire 4K detail pane. This left headings, descriptions, segmented buttons, and directory actions against the far-left edge, while switch controls were pushed to the far-right edge.

## Impact

On wide desktop settings panes, the related controls now stay together as one centered form. Narrow panes still use the full available width, and the surrounding detail card remains full-width as previously requested.

## Validation

- `dart format --output=none --set-exit-if-changed` on changed Dart files
- `dart run tool/bug.dart check`
- `git diff --check`
- Flutter compilation, widget-test execution, and device visual verification were intentionally not awaited per the user request
