### PR TITLE
fix(media): 刮削封面默认使用 Bangumi 原图

### DIFF
--- a/hibiki/lib/src/media/metadata/bangumi_cover_url.dart
+++ b/hibiki/lib/src/media/metadata/bangumi_cover_url.dart
@@ -1,0 +1,55 @@
+/// Bangumi 封面 URL 的统一解析。
+///
+/// 当前 API 的 `images.large` 通常直接指向无缩放参数的原图，例如
+/// `https://lain.bgm.tv/pic/cover/l/...jpg`；其它尺寸可能是
+/// `/r/800/pic/cover/l/...jpg` 或旧式 `/pic/cover/c|m|s|g/...jpg`。
+/// 刮削结果会长期落盘，不能把候选预览用的缩略图永久保存成媒体封面，因此所有
+/// Bangumi 刮削入口都通过本文件选择候选并还原原图 URL。
+library;
+
+/// 从 Bangumi subject 的 `images` / 兼容 `image` 字段取原图 URL。
+///
+/// 字段优先级仍与 API 语义一致：`large → common → medium → small → grid`；
+/// 无论命中哪个尺寸，都由 [bangumiOriginalImageUrl] 去掉 CDN 缩放层。
+String? bangumiOriginalCoverUrl(Map<Object?, Object?> subject) {
+  final Object? images = subject['images'];
+  if (images is Map) {
+    for (final String key in const <String>[
+      'large',
+      'common',
+      'medium',
+      'small',
+      'grid',
+    ]) {
+      final String? url = bangumiOriginalImageUrl(images[key]);
+      if (url != null) return url;
+    }
+  }
+  return bangumiOriginalImageUrl(subject['image']);
+}
+
+/// 把一条 Bangumi CDN 封面地址正规化为上传原图地址。
+///
+/// 非 Bangumi CDN 地址不改写，只负责 trim；这样测试源、代理源或未来 API 返回的
+/// 独立图床仍可照常下载。
+String? bangumiOriginalImageUrl(Object? value) {
+  if (value is! String) return null;
+  final String trimmed = value.trim();
+  if (trimmed.isEmpty) return null;
+
+  final Uri? uri = Uri.tryParse(trimmed);
+  if (uri == null || uri.host.toLowerCase() != 'lain.bgm.tv') {
+    return trimmed;
+  }
+
+  final RegExp derivativePath = RegExp(
+    r'^/(?:r/[^/]+/)?pic/cover/[lcmsg]/',
+  );
+  if (!derivativePath.hasMatch(uri.path)) return trimmed;
+
+  final String originalPath = uri.path.replaceFirst(
+    derivativePath,
+    '/pic/cover/l/',
+  );
+  return uri.replace(path: originalPath).toString();
+}

--- a/hibiki/lib/src/media/metadata/book_metadata_scraper.dart
+++ b/hibiki/lib/src/media/metadata/book_metadata_scraper.dart
@@ -13,6 +13,7 @@ library;
 import 'dart:convert';
 
 import 'package:hibiki/src/media/metadata/bangumi_api_client.dart';
+import 'package:hibiki/src/media/metadata/bangumi_cover_url.dart';
 import 'package:http/http.dart' as http;
 
 /// 书籍刮削领域异常（网络失败 / 非 2xx / JSON 异常）。绝不吞异常，交上层给用户可见提示。
@@ -46,7 +47,7 @@ class BookScrapeCandidate {
   /// 展示用主标题（优先中文名）。
   final String title;
 
-  /// 封面图 URL（满分辨率优先 large；下载层负责落地）。
+  /// 封面原图 URL（下载层负责落地）。
   final String coverUrl;
 
   /// 原名（与主标题不同才留）。
@@ -176,9 +177,9 @@ List<BookScrapeCandidate> parseBookSearchResponse(String body) {
   return out;
 }
 
-/// 把单个 Bangumi 书籍 subject 映射为候选；缺封面（large/common/medium 皆无）返回 null。
+/// 把单个 Bangumi 书籍 subject 映射为候选；缺封面返回 null。
 BookScrapeCandidate? mapBookSubject(Map<String, Object?> subject) {
-  final String? coverUrl = _coverUrl(subject);
+  final String? coverUrl = bangumiOriginalCoverUrl(subject);
   if (coverUrl == null) return null; // 无封面的条目对「刮封面」无用，跳过。
 
   final String? nameCn = _nonEmptyString(subject['name_cn']);
@@ -198,19 +199,6 @@ BookScrapeCandidate? mapBookSubject(Map<String, Object?> subject) {
     year: _yearFromDate(_nonEmptyString(subject['date'])),
     summary: _nonEmptyString(subject['summary']),
   );
-}
-
-/// 封面 URL：`images.large → common → medium → small`；搜索结果偶尔退化成 `image`。
-String? _coverUrl(Map<String, Object?> subject) {
-  final Object? images = subject['images'];
-  if (images is Map<String, Object?>) {
-    final String? url = _nonEmptyString(images['large']) ??
-        _nonEmptyString(images['common']) ??
-        _nonEmptyString(images['medium']) ??
-        _nonEmptyString(images['small']);
-    if (url != null) return url;
-  }
-  return _nonEmptyString(subject['image']);
 }
 
 /// 从 `YYYY-MM-DD` 取年份，非法返回 null。

--- a/hibiki/lib/src/media/video/scraper/bangumi_client.dart
+++ b/hibiki/lib/src/media/video/scraper/bangumi_client.dart
@@ -14,6 +14,7 @@ library;
 import 'dart:convert';
 
 import 'package:hibiki/src/media/metadata/bangumi_api_client.dart';
+import 'package:hibiki/src/media/metadata/bangumi_cover_url.dart';
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
 import 'package:http/http.dart' as http;
 
@@ -288,14 +289,9 @@ List<ScrapeCandidate> parseBangumiSearchResponse(String body) {
   return candidates;
 }
 
-/// 把单个 Bangumi subject 映射为 [ScrapeCandidate]；缺海报（large/common 皆无）返回 null。
+/// 把单个 Bangumi subject 映射为 [ScrapeCandidate]；缺封面返回 null。
 ScrapeCandidate? _mapBangumiSubject(Map<String, Object?> subject) {
-  final Object? images = subject['images'];
-  String? posterUrl;
-  if (images is Map<String, Object?>) {
-    posterUrl =
-        _nonEmptyString(images['large']) ?? _nonEmptyString(images['common']);
-  }
+  final String? posterUrl = bangumiOriginalCoverUrl(subject);
   if (posterUrl == null) return null; // 无海报的条目对封面刮削无用，跳过。
 
   final String? nameCn = _nonEmptyString(subject['name_cn']);

--- a/hibiki/lib/src/mining/metadata/adapters/bangumi_adapter.dart
+++ b/hibiki/lib/src/mining/metadata/adapters/bangumi_adapter.dart
@@ -10,6 +10,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:hibiki/src/media/metadata/bangumi_api_client.dart';
+import 'package:hibiki/src/media/metadata/bangumi_cover_url.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_adapter.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_draft.dart';
 import 'package:hibiki/src/mining/metadata/galgame_metadata_rate_limit.dart';
@@ -261,20 +262,9 @@ List<SourceCandidate> parseBangumiSearchResults(
   return out;
 }
 
-/// 取封面 URL：`images.large` → `common` → `medium`；搜索结果里可能退化成 `image` 字符串。
-String? bangumiCoverUrl(Map<Object?, Object?> subject) {
-  final Object? images = subject['images'];
-  if (images is Map) {
-    final String? url = draftString(images['large']) ??
-        draftString(images['common']) ??
-        draftString(images['medium']) ??
-        draftString(images['small']);
-    if (url != null) {
-      return url;
-    }
-  }
-  return draftString(subject['image']);
-}
+/// 取 Bangumi 上传原图；保留公开 wrapper，供 adapter 解析测试与调用方复用。
+String? bangumiCoverUrl(Map<Object?, Object?> subject) =>
+    bangumiOriginalCoverUrl(subject);
 
 /// `tags: [{name, count}]` → 按 count 降序取前 [kBangumiMaxTags] 个名字。
 List<String> _parseTags(Object? value) {

--- a/hibiki/test/media/metadata/bangumi_cover_url_test.dart
+++ b/hibiki/test/media/metadata/bangumi_cover_url_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/metadata/bangumi_cover_url.dart';
+
+void main() {
+  group('bangumiOriginalImageUrl', () {
+    test('原图地址保持不变（含查询参数）', () {
+      expect(
+        bangumiOriginalImageUrl(
+          'https://lain.bgm.tv/pic/cover/l/aa/bb/42_cover.jpg?r=123',
+        ),
+        'https://lain.bgm.tv/pic/cover/l/aa/bb/42_cover.jpg?r=123',
+      );
+    });
+
+    test('去掉当前 /r/尺寸/ 缩放层', () {
+      expect(
+        bangumiOriginalImageUrl(
+          'https://lain.bgm.tv/r/800/pic/cover/l/aa/bb/42_cover.jpg',
+        ),
+        'https://lain.bgm.tv/pic/cover/l/aa/bb/42_cover.jpg',
+      );
+      expect(
+        bangumiOriginalImageUrl(
+          'https://lain.bgm.tv/r/200x200/pic/cover/l/aa/bb/42_cover.jpg',
+        ),
+        'https://lain.bgm.tv/pic/cover/l/aa/bb/42_cover.jpg',
+      );
+    });
+
+    test('旧式 common/medium/small/grid 路径回到 large 原图路径', () {
+      for (final String size in <String>['c', 'm', 's', 'g']) {
+        expect(
+          bangumiOriginalImageUrl(
+            'https://lain.bgm.tv/pic/cover/$size/aa/bb/42_cover.jpg',
+          ),
+          'https://lain.bgm.tv/pic/cover/l/aa/bb/42_cover.jpg',
+        );
+      }
+    });
+
+    test('非 Bangumi 图床不猜路径，只去首尾空白', () {
+      expect(
+        bangumiOriginalImageUrl('  https://img.example/r/400/cover.jpg  '),
+        'https://img.example/r/400/cover.jpg',
+      );
+      expect(bangumiOriginalImageUrl('  '), isNull);
+      expect(bangumiOriginalImageUrl(null), isNull);
+    });
+  });
+
+  group('bangumiOriginalCoverUrl', () {
+    test('按字段优先级选择，并把退化尺寸还原为原图', () {
+      expect(
+        bangumiOriginalCoverUrl(<Object?, Object?>{
+          'images': <String, Object?>{
+            'large': '',
+            'common':
+                'https://lain.bgm.tv/r/400/pic/cover/l/aa/bb/42_cover.jpg',
+            'medium': 'https://lain.bgm.tv/r/800/pic/cover/l/aa/bb/other.jpg',
+          },
+        }),
+        'https://lain.bgm.tv/pic/cover/l/aa/bb/42_cover.jpg',
+      );
+    });
+
+    test('兼容搜索响应的 image 字段', () {
+      expect(
+        bangumiOriginalCoverUrl(<Object?, Object?>{
+          'image': 'https://lain.bgm.tv/pic/cover/s/aa/bb/42_cover.jpg',
+        }),
+        'https://lain.bgm.tv/pic/cover/l/aa/bb/42_cover.jpg',
+      );
+    });
+
+    test('没有可用字段返回 null', () {
+      expect(
+        bangumiOriginalCoverUrl(<Object?, Object?>{
+          'images': <String, Object?>{'large': '  '},
+        }),
+        isNull,
+      );
+    });
+  });
+}

--- a/hibiki/test/media/metadata/book_metadata_scraper_test.dart
+++ b/hibiki/test/media/metadata/book_metadata_scraper_test.dart
@@ -37,16 +37,19 @@ void main() {
       expect(c.originalTitle, isNull);
     });
 
-    test('缺 large 用 common；无任何封面 → 跳过该条', () {
+    test('缺 large 用 common 原图；无任何封面 → 跳过该条', () {
       const String body = '''
 {"data":[
-  {"id":2,"name":"A","images":{"common":"https://img/c.jpg"}},
+  {"id":2,"name":"A","images":{"common":"https://lain.bgm.tv/pic/cover/c/a/b/c.jpg"}},
   {"id":3,"name":"B","images":{}},
   {"id":4,"name":"C"}
 ]}''';
       final List<BookScrapeCandidate> list = parseBookSearchResponse(body);
       expect(list, hasLength(1)); // 只有 id=2 有封面
-      expect(list.first.coverUrl, 'https://img/c.jpg');
+      expect(
+        list.first.coverUrl,
+        'https://lain.bgm.tv/pic/cover/l/a/b/c.jpg',
+      );
     });
 
     test('data 缺失/非数组 → 空列表（不抛）；非法 JSON → 抛', () {

--- a/hibiki/test/media/video/scraper/bangumi_client_test.dart
+++ b/hibiki/test/media/video/scraper/bangumi_client_test.dart
@@ -41,16 +41,19 @@ void main() {
       expect(list.first.aliases, isEmpty);
     });
 
-    test('缺 large 用 common；large/common 皆缺 → 跳过该条', () {
+    test('缺 large 用 common 原图；所有尺寸皆缺 → 跳过该条', () {
       const String body = '''
 {"data":[
-  {"id":2,"name":"A","images":{"common":"https://img/c.jpg"}},
+  {"id":2,"name":"A","images":{"common":"https://lain.bgm.tv/r/400/pic/cover/l/a/b/c.jpg"}},
   {"id":3,"name":"B","images":{}},
   {"id":4,"name":"C"}
 ]}''';
       final List<ScrapeCandidate> list = parseBangumiSearchResponse(body);
       expect(list, hasLength(1)); // 只有 id=2 有海报
-      expect(list.first.posterUrl, 'https://img/c.jpg');
+      expect(
+        list.first.posterUrl,
+        'https://lain.bgm.tv/pic/cover/l/a/b/c.jpg',
+      );
     });
 
     test('eps=0 → episodeCount 为 null；score=0 → ratingText 为 null', () {

--- a/hibiki/test/mining/metadata/bangumi_adapter_test.dart
+++ b/hibiki/test/mining/metadata/bangumi_adapter_test.dart
@@ -81,7 +81,7 @@ const Map<String, Object?> _searchFixture = <String, Object?>{
       'name': 'Fate/hollow ataraxia',
       'name_cn': '',
       'date': '2005',
-      'image': 'https://lain.bgm.tv/pic/cover/l/fha.jpg',
+      'image': 'https://lain.bgm.tv/r/400/pic/cover/l/fha.jpg',
     },
   ],
 };
@@ -424,12 +424,14 @@ void main() {
       expect(draft.tags.first, 'tag0');
     });
 
-    test('封面按 large → common → medium 回退', () {
+    test('封面按 large → common → medium 回退并还原原图', () {
       expect(
         bangumiCoverUrl(<Object?, Object?>{
-          'images': <String, Object?>{'medium': 'm.jpg'},
+          'images': <String, Object?>{
+            'medium': 'https://lain.bgm.tv/r/800/pic/cover/l/a/b/m.jpg',
+          },
         }),
-        'm.jpg',
+        'https://lain.bgm.tv/pic/cover/l/a/b/m.jpg',
       );
       expect(bangumiCoverUrl(<Object?, Object?>{'images': 'x'}), isNull);
       expect(bangumiCoverUrl(const <Object?, Object?>{}), isNull);


### PR DESCRIPTION
## 改了什么

- 新增统一的 Bangumi 封面原图 URL 解析器。
- 去掉 `/r/<尺寸>/` CDN 缩放层，并把旧式 `c/m/s/g` 封面路径还原为 `l` 原图路径。
- 视频、书籍和游戏三条 Bangumi 刮削链路共用同一解析逻辑。
- TMDB 已使用 `/original/`、VNDB 已返回原始图片 URL，因此保持不变。

## 为什么

Bangumi 搜索响应在 `large` 缺失或兼容旧响应时会回退到 `common/medium/small/image`。这些地址可能是缩略图，而刮削结果会长期下载落盘，导致封面在较大卡片或高 DPI 屏幕上显得模糊。

## 用户影响

新刮削和“重新刮削”会下载来源原图。已有低清封面不会自动重下，需要重新刮削一次。

## 验证

- `tool/setup_worktree.ps1` / bootstrap 完成
- `dart format`（8 个改动文件）
- 定向 `dart analyze`（8 个改动文件，No issues found）
- `git diff --cached --check`
- 按用户要求未等待 Flutter 测试或完整构建
