### PR TITLE
fix(lookup): 加快 App 外查词弹窗的鼠标滚轮速度

### DIFF
--- a/docs/bugs/BUG-1026-popup-wheel-speed-config.md
+++ b/docs/bugs/BUG-1026-popup-wheel-speed-config.md
@@ -5,3 +5,4 @@
 - **[x] ② 已加自动化测试** — `hibiki/test/reader/popup_wheel_speed_asset_test.dart`：三份 popup.js 均含读取 `__hoshiPopupWheelSpeed` 且乘入 factor 的源码守卫；`popup_settings_injection` 测试断言注入该全局；`browser_extension_theme_colors` 测试断言 theme map 含 `--hibiki-wheel-speed`。提交：e413d2d58
 - **集成补丁**：merge 时发现 `buildPopupStaticSettingsJs` 新读 `appModel.popupWheelSpeed`，但既有 fake `PushDedupAppModel`（`dictionary_popup_push_dedup_test.dart`）未覆盖该 getter，真 getter 走 `prefsRepo!` 抛 Null check 使 `_pushResults` 中断（pushCount 归零，BUG-712 守卫红）。已按其它注入 getter 同法在该 fake 覆盖 `popupWheelSpeed => 1.0`。
 - **备注**：默认 1.0 倍率与改前行为逐帧一致（粗鼠标 0.24、触控板 1.0）；倍率同乘两类设备，作为统一「滚轮速度」旋钮。
+- **2026-07-29 跟进**：用户实测 app 外查词窗口的鼠标滚轮默认仍偏慢。链路核对确认 native 覆盖窗原样转发 `WHEEL_DELTA`，`buildFrameSettingsJs` 也已注入同一 `popupWheelSpeed`；慢感来自粗鼠标固定 `0.24` 系数，一格约只移动 24 visual px。将粗鼠标基准校准为 `0.48`（约 48 visual px，仍明显低于 WebView2 原生整格），保留单帧 120px 上限与用户 0.5–5.0 倍率。触控板/高分辨率滚轮仍走独立 `1.0` fine-device 路径，速度不变；三份 `popup.js` 镜像同步。

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -3971,15 +3971,15 @@ window.updatePopupIncremental = function() {
 // element with its own y-overflow) keep native scroll until they hit a boundary,
 // so nested scroll regions are not stolen — only the main document scroll, which
 // is the coarse one, is refined.
-const POPUP_WHEEL_PIXEL_FACTOR = 0.24;      // fraction of the raw px delta (coarse mouse notch)
+const POPUP_WHEEL_PIXEL_FACTOR = 0.48;      // fraction of the raw px delta (coarse mouse notch)
 const POPUP_WHEEL_MAX_VISUAL_STEP = 120;    // px cap after scaling, before zoom
 const POPUP_WHEEL_LINE_HEIGHT = 16;         // px per line for deltaMode === LINE
 // BUG-870: a precision touchpad / high-resolution wheel reports deltaMode=PIXEL
-// with small per-frame deltas; the 0.24 downscale (tuned for a coarse mouse notch,
-// deltaY≈100-120) makes those devices ~4x too slow — the "very hard to scroll"
+// with small per-frame deltas; the coarse-mouse downscale (tuned for a notch,
+// deltaY≈100-120) makes those devices too slow — the "very hard to scroll"
 // symptom. A pixel-mode frame whose |deltaY| is below this many px is treated as a
 // fine device and scrolls ~1:1 (factor 1.0, still zoom-corrected); at/above it is a
-// coarse mouse notch and keeps the 0.24 taming. A mouse notch on WebView2/Chromium
+// coarse mouse notch and keeps the 0.48 taming. A mouse notch on WebView2/Chromium
 // is ≈100px, well above this; slow touchpad frames are well below.
 const POPUP_WHEEL_MOUSE_NOTCH_PX = 60;
 const POPUP_WHEEL_TRACKPAD_FACTOR = 1.0;    // fine devices: natural 1:1, no downscale
@@ -4139,7 +4139,7 @@ const __hibikiPopupWheelListener = (e) => {
     // 已在本监听最顶部解析并早退）；返回 null 时唯一合法「滚 window」的表面是 in-app
     // 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。普通网页上扩展 content script 有
     // chrome.runtime.id，滚轮不在弹窗内已在顶部放行原生滚动：否则整页会被
-    // POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
+    // POPUP_WHEEL_PIXEL_FACTOR(0.48) 降速 + preventDefault 抢走原生滚动。
     e.preventDefault();
     // TODO-1387: carry the sub-pixel remainder across events; BUG-870: also reset
     // the device-class latch here so each new gesture is classified fresh. A
@@ -4159,10 +4159,10 @@ const __hibikiPopupWheelListener = (e) => {
         _popupWheelFineDevice = false;
     }
     _popupWheelResidualAt = nowMs;
-    // BUG-870: the 0.24 downscale is tuned for a COARSE mouse notch (deltaMode
-    // PIXEL, deltaY≈100-120 → visualStep≈24) so a notch does not jump a huge
+    // BUG-870: the 0.48 downscale is tuned for a COARSE mouse notch (deltaMode
+    // PIXEL, deltaY≈100-120 → visualStep≈48) so a notch does not jump a huge
     // chunk. A precision touchpad / hi-res wheel reports small pixel deltas;
-    // applying 0.24 to them makes scrolling ~4x too slow ("very hard to scroll").
+    // applying the coarse-mouse factor to them makes scrolling unnaturally slow.
     // Classify per gesture: a small pixel-mode frame latches the stream as a fine
     // device (kept until the idle reset above, so an occasional large mid-fling
     // frame is not mis-tamed); fine devices scroll ~1:1 (factor 1.0, still divided

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -3971,15 +3971,15 @@ window.updatePopupIncremental = function() {
 // element with its own y-overflow) keep native scroll until they hit a boundary,
 // so nested scroll regions are not stolen — only the main document scroll, which
 // is the coarse one, is refined.
-const POPUP_WHEEL_PIXEL_FACTOR = 0.24;      // fraction of the raw px delta (coarse mouse notch)
+const POPUP_WHEEL_PIXEL_FACTOR = 0.48;      // fraction of the raw px delta (coarse mouse notch)
 const POPUP_WHEEL_MAX_VISUAL_STEP = 120;    // px cap after scaling, before zoom
 const POPUP_WHEEL_LINE_HEIGHT = 16;         // px per line for deltaMode === LINE
 // BUG-870: a precision touchpad / high-resolution wheel reports deltaMode=PIXEL
-// with small per-frame deltas; the 0.24 downscale (tuned for a coarse mouse notch,
-// deltaY≈100-120) makes those devices ~4x too slow — the "very hard to scroll"
+// with small per-frame deltas; the coarse-mouse downscale (tuned for a notch,
+// deltaY≈100-120) makes those devices too slow — the "very hard to scroll"
 // symptom. A pixel-mode frame whose |deltaY| is below this many px is treated as a
 // fine device and scrolls ~1:1 (factor 1.0, still zoom-corrected); at/above it is a
-// coarse mouse notch and keeps the 0.24 taming. A mouse notch on WebView2/Chromium
+// coarse mouse notch and keeps the 0.48 taming. A mouse notch on WebView2/Chromium
 // is ≈100px, well above this; slow touchpad frames are well below.
 const POPUP_WHEEL_MOUSE_NOTCH_PX = 60;
 const POPUP_WHEEL_TRACKPAD_FACTOR = 1.0;    // fine devices: natural 1:1, no downscale
@@ -4139,7 +4139,7 @@ const __hibikiPopupWheelListener = (e) => {
     // 已在本监听最顶部解析并早退）；返回 null 时唯一合法「滚 window」的表面是 in-app
     // 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。普通网页上扩展 content script 有
     // chrome.runtime.id，滚轮不在弹窗内已在顶部放行原生滚动：否则整页会被
-    // POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
+    // POPUP_WHEEL_PIXEL_FACTOR(0.48) 降速 + preventDefault 抢走原生滚动。
     e.preventDefault();
     // TODO-1387: carry the sub-pixel remainder across events; BUG-870: also reset
     // the device-class latch here so each new gesture is classified fresh. A
@@ -4159,10 +4159,10 @@ const __hibikiPopupWheelListener = (e) => {
         _popupWheelFineDevice = false;
     }
     _popupWheelResidualAt = nowMs;
-    // BUG-870: the 0.24 downscale is tuned for a COARSE mouse notch (deltaMode
-    // PIXEL, deltaY≈100-120 → visualStep≈24) so a notch does not jump a huge
+    // BUG-870: the 0.48 downscale is tuned for a COARSE mouse notch (deltaMode
+    // PIXEL, deltaY≈100-120 → visualStep≈48) so a notch does not jump a huge
     // chunk. A precision touchpad / hi-res wheel reports small pixel deltas;
-    // applying 0.24 to them makes scrolling ~4x too slow ("very hard to scroll").
+    // applying the coarse-mouse factor to them makes scrolling unnaturally slow.
     // Classify per gesture: a small pixel-mode frame latches the stream as a fine
     // device (kept until the idle reset above, so an occasional large mid-fling
     // frame is not mis-tamed); fine devices scroll ~1:1 (factor 1.0, still divided

--- a/hibiki/test/reader/popup_wheel_scroll_asset_test.dart
+++ b/hibiki/test/reader/popup_wheel_scroll_asset_test.dart
@@ -38,21 +38,21 @@ void main() {
     expect(js, contains('deltaPx * factor'));
   });
 
-  test('uses a browser-like wheel pixel factor below the old coarse step', () {
+  test('uses a balanced coarse-mouse factor below the native step', () {
     final factor = parseNumberConstant('POPUP_WHEEL_PIXEL_FACTOR');
 
-    expect(factor, greaterThanOrEqualTo(0.12),
-        reason: 'The factor must stay positive enough for touchpad inertia and '
-            'long dictionary entries to remain usable.');
-    expect(factor, lessThan(0.35),
-        reason: 'TODO-460 asks for a smaller per-notch distance than the old '
-            'BUG-260 factor.');
+    expect(factor, greaterThanOrEqualTo(0.4),
+        reason: 'The old 0.24 factor moved only about 24px per mouse notch and '
+            'felt too slow in the app-external lookup window.');
+    expect(factor, lessThan(0.65),
+        reason: 'The refined path must remain clearly below the native full '
+            'step so one notch does not become chunky again.');
   });
 
-  // BUG-870: the 0.24 factor is only for a COARSE mouse notch. A precision
+  // BUG-870: POPUP_WHEEL_PIXEL_FACTOR is only for a COARSE mouse notch. A precision
   // touchpad / hi-res wheel reports small pixel deltas; the handler must classify
   // a small pixel-mode frame as a fine device and scroll it ~1:1 (factor 1.0),
-  // otherwise the 0.24 taming makes touchpad scrolling ~4x too slow. A gesture
+  // otherwise coarse-mouse taming makes touchpad scrolling too slow. A gesture
   // latches its device class so a large mid-fling frame is not mis-tamed.
   test('classifies fine devices and scrolls them ~1:1 (BUG-870)', () {
     final trackpadFactor = parseNumberConstant('POPUP_WHEEL_TRACKPAD_FACTOR');
@@ -66,7 +66,7 @@ void main() {
     expect(notchPx, lessThan(100),
         reason: 'and below a WebView2/Chromium mouse notch (≈100px)');
 
-    // The per-frame factor is chosen by device class, not hard-coded to 0.24.
+    // The per-frame factor is chosen by device class, not applied universally.
     expect(js, contains('const fineFrame ='));
     expect(js, contains('_popupWheelFineDevice'),
         reason: 'the gesture must latch its device class to avoid mis-taming a '

--- a/hibiki/test/reader/popup_wheel_scroll_behavior_test.js
+++ b/hibiki/test/reader/popup_wheel_scroll_behavior_test.js
@@ -10,10 +10,10 @@
 // the sub-pixel fraction every frame and the popup froze. The fix carries the
 // remainder across events and stops horizontal jitter from dropping vertical frames.
 //
-// BUG-870 extends this: the 0.24 POPUP_WHEEL_PIXEL_FACTOR is a coarse-mouse-notch
+// BUG-870 extends this: POPUP_WHEEL_PIXEL_FACTOR is a coarse-mouse-notch
 // taming; applying it to a fine device (small pixel deltas) made scrolling ~4x too
 // slow ("very hard to scroll"). Fine-device frames now scroll ~1:1 (factor 1.0,
-// still zoom-corrected); a mouse notch (deltaY≈100) keeps the 0.24 step. A gesture
+// still zoom-corrected); a mouse notch (deltaY≈100) uses the 0.48 step. A gesture
 // latches to its device class so a large mid-fling touchpad frame is not mis-tamed.
 
 const assert = require('assert');
@@ -102,9 +102,9 @@ const tests = [];
 const test = (name, fn) => tests.push([name, fn]);
 
 // A. BUG-870: a precision touchpad's small pixel-mode frames scroll ~1:1 (natural),
-// NOT downscaled by the 0.24 mouse-notch factor. deltaY=2 (< MOUSE_NOTCH_PX 60) is a
+// NOT downscaled by the 0.48 mouse-notch factor. deltaY=2 (< MOUSE_NOTCH_PX 60) is a
 // fine-device frame => factor 1.0 => 2 layout px/frame at zoom 1.
-test('slow touchpad frames scroll ~1:1 natural, not the 0.24 mouse taming (zoom 1)', () => {
+test('slow touchpad frames scroll ~1:1 natural, not the coarse-mouse taming (zoom 1)', () => {
   const ctx = loadPopup();
   clockMs = 1000;
   let prevCount = 0;
@@ -135,37 +135,37 @@ test('fine-device sub-pixel carry is lossless under zoom (deltaY 1, zoom 3)', ()
 
 // BUG-870 latch: a gesture that starts fine (small frame) stays fine even when an
 // occasional larger mid-fling frame (>= MOUSE_NOTCH_PX) arrives — it must NOT be
-// suddenly downscaled by 0.24 as if it were a mouse notch.
+// suddenly downscaled by the coarse-mouse factor as if it were a mouse notch.
 test('touchpad gesture latches fine: a large mid-fling frame is not mouse-tamed', () => {
   const ctx = loadPopup();
   clockMs = 1000; clockMs += 16;
   fireWheel(ctx, { deltaY: 4, deltaMode: 0 });   // small first frame => latch fine (4px)
   clockMs += 16;
-  fireWheel(ctx, { deltaY: 80, deltaMode: 0 });  // big fling frame, still fine => 80px (not 19)
+  fireWheel(ctx, { deltaY: 80, deltaMode: 0 });  // big fling frame, still fine => 80px (not 38)
   assert.equal(ctx.__win.scrollY, 84,
     'latched fine device must scroll the fling frame ~1:1 (4+80=84), got ' + ctx.__win.scrollY);
 });
 
-// B. Mouse-wheel large-delta path is UNCHANGED (no regression).
-test('mouse notch (large delta) moves the full step every notch, zoom 1', () => {
+// B. Mouse-wheel large-delta path uses the calibrated 48px visual step.
+test('mouse notch (large delta) moves the calibrated full step every notch, zoom 1', () => {
   const ctx = loadPopup();
   clockMs = 1000;
-  // A Windows WebView2 mouse notch: deltaMode=PIXEL, deltaY=100 => x0.24=24 (< cap).
+  // A Windows WebView2 mouse notch: deltaMode=PIXEL, deltaY=100 => x0.48=48 (< cap).
   for (let n = 1; n <= 3; n++) {
     clockMs += 200; // notch-to-notch; even crossing idle the whole step is intact
     fireWheel(ctx, { deltaY: 100, deltaMode: 0 });
-    assert.equal(ctx.__win.scrollY, 24 * n,
-      'mouse notch ' + n + ' must move a full 24px, got ' + ctx.__win.scrollY);
+    assert.equal(ctx.__win.scrollY, 48 * n,
+      'mouse notch ' + n + ' must move a full 48px, got ' + ctx.__win.scrollY);
   }
 });
 
-test('mouse notch under zoom keeps the pre-fix zoom-divided step (12px at zoom 2)', () => {
+test('mouse notch under zoom keeps a zoom-independent 48px visual step', () => {
   const ctx = loadPopup();
   ctx.__setZoom(2);
   clockMs = 1000; clockMs += 16;
-  fireWheel(ctx, { deltaY: 100, deltaMode: 0 }); // 24 visual / 2 zoom = 12 layout px
-  assert.equal(ctx.__win.scrollY, 12,
-    'mouse notch at zoom 2 must still move 12px, got ' + ctx.__win.scrollY);
+  fireWheel(ctx, { deltaY: 100, deltaMode: 0 }); // 48 visual / 2 zoom = 24 layout px
+  assert.equal(ctx.__win.scrollY, 24,
+    'mouse notch at zoom 2 must move 24 layout px, got ' + ctx.__win.scrollY);
   assert.ok(ctx.__win.scrollY > 1, 'a mouse notch must never freeze');
 });
 

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -3971,15 +3971,15 @@ window.updatePopupIncremental = function() {
 // element with its own y-overflow) keep native scroll until they hit a boundary,
 // so nested scroll regions are not stolen — only the main document scroll, which
 // is the coarse one, is refined.
-const POPUP_WHEEL_PIXEL_FACTOR = 0.24;      // fraction of the raw px delta (coarse mouse notch)
+const POPUP_WHEEL_PIXEL_FACTOR = 0.48;      // fraction of the raw px delta (coarse mouse notch)
 const POPUP_WHEEL_MAX_VISUAL_STEP = 120;    // px cap after scaling, before zoom
 const POPUP_WHEEL_LINE_HEIGHT = 16;         // px per line for deltaMode === LINE
 // BUG-870: a precision touchpad / high-resolution wheel reports deltaMode=PIXEL
-// with small per-frame deltas; the 0.24 downscale (tuned for a coarse mouse notch,
-// deltaY≈100-120) makes those devices ~4x too slow — the "very hard to scroll"
+// with small per-frame deltas; the coarse-mouse downscale (tuned for a notch,
+// deltaY≈100-120) makes those devices too slow — the "very hard to scroll"
 // symptom. A pixel-mode frame whose |deltaY| is below this many px is treated as a
 // fine device and scrolls ~1:1 (factor 1.0, still zoom-corrected); at/above it is a
-// coarse mouse notch and keeps the 0.24 taming. A mouse notch on WebView2/Chromium
+// coarse mouse notch and keeps the 0.48 taming. A mouse notch on WebView2/Chromium
 // is ≈100px, well above this; slow touchpad frames are well below.
 const POPUP_WHEEL_MOUSE_NOTCH_PX = 60;
 const POPUP_WHEEL_TRACKPAD_FACTOR = 1.0;    // fine devices: natural 1:1, no downscale
@@ -4139,7 +4139,7 @@ const __hibikiPopupWheelListener = (e) => {
     // 已在本监听最顶部解析并早退）；返回 null 时唯一合法「滚 window」的表面是 in-app
     // 弹窗文档（整份文档即弹窗，且无 chrome.runtime）。普通网页上扩展 content script 有
     // chrome.runtime.id，滚轮不在弹窗内已在顶部放行原生滚动：否则整页会被
-    // POPUP_WHEEL_PIXEL_FACTOR(0.24) 降速 + preventDefault 抢走原生滚动。
+    // POPUP_WHEEL_PIXEL_FACTOR(0.48) 降速 + preventDefault 抢走原生滚动。
     e.preventDefault();
     // TODO-1387: carry the sub-pixel remainder across events; BUG-870: also reset
     // the device-class latch here so each new gesture is classified fresh. A
@@ -4159,10 +4159,10 @@ const __hibikiPopupWheelListener = (e) => {
         _popupWheelFineDevice = false;
     }
     _popupWheelResidualAt = nowMs;
-    // BUG-870: the 0.24 downscale is tuned for a COARSE mouse notch (deltaMode
-    // PIXEL, deltaY≈100-120 → visualStep≈24) so a notch does not jump a huge
+    // BUG-870: the 0.48 downscale is tuned for a COARSE mouse notch (deltaMode
+    // PIXEL, deltaY≈100-120 → visualStep≈48) so a notch does not jump a huge
     // chunk. A precision touchpad / hi-res wheel reports small pixel deltas;
-    // applying 0.24 to them makes scrolling ~4x too slow ("very hard to scroll").
+    // applying the coarse-mouse factor to them makes scrolling unnaturally slow.
     // Classify per gesture: a small pixel-mode frame latches the stream as a fine
     // device (kept until the idle reset above, so an occasional large mid-fling
     // frame is not mis-tamed); fine devices scroll ~1:1 (factor 1.0, still divided


### PR DESCRIPTION
## 改动

- 将查词弹窗粗鼠标滚轮基准系数从 `0.24` 校准为 `0.48`，每格视觉位移约从 24px 提升到 48px。
- 同步更新 App 内资源、内置浏览器扩展资源和 `tools/browser-extension` 三份 `popup.js` 镜像。
- 更新源码守卫与真实 JS wheel 行为测试，并在 BUG-1026 记录本次实测跟进。

## 根因与影响

App 外覆盖窗的 native `WHEEL_DELTA` 转发与 `popupWheelSpeed` 注入都正常；慢感来自共享 `popup.js` 对粗鼠标整格位移固定乘 `0.24`。本次仍保留 WebView2 原生整格以下的细化滚动，同时不改触控板/高分辨率滚轮的 fine-device `1.0` 路径、120px 单帧上限及用户可调倍率。

由于三类弹窗共用同一资源真值，App 内、App 外和浏览器扩展的粗鼠标手感继续保持一致。

## 验证

- `node --check`：三份 `popup.js` 通过
- `node hibiki/test/reader/popup_wheel_scroll_behavior_test.js`：11 项行为断言通过
- `dart analyze test/reader/popup_wheel_scroll_asset_test.dart`：No issues found
- 三份 `popup.js` SHA-256 完全一致
- `dart run tool/bug.dart reindex`：通过，1169 条
- `git diff --check`：通过

`flutter test test/reader/popup_wheel_speed_asset_test.dart test/models/preferences_repository_test.dart --no-pub` 在进入测试体前被 `pdfium_dart` native-asset hook 的 GitHub 下载超时阻断；未把外部下载失败记作测试失败，也未等待 Windows 完整编译/真机验收。
