### PR TITLE
feat(extension): streamline subtitle lookup settings

### DIFF
--- a/hibiki/assets/browser_extension/README.md
+++ b/hibiki/assets/browser_extension/README.md
@@ -10,9 +10,9 @@ Anki 能力——一切经本机 Hibiki 桌面 App 内置的 yomitan API server�
 |---|---|---|
 | `manifest.json` | — | MV3 清单；content script 注入顺序有语义（先桥后消费者） |
 | `background.js` | service worker | 唯一网络出口：查词/制卡/字幕等所有 HTTP 请求 + 连接诊断 + 自更新执行 + 心跳 + Netflix 录制编排 |
-| `content.js` | 隔离 | Shift 悬停查词、弹窗渲染/定位、高亮、挖词队列、字幕轨 provider（textTracks 收割 / DOM 采样 / 整集拦截接收端）、Netflix/YouTube 批量制卡驱动 |
-| `subtitle-panel.js` | 隔离 | 字幕列表侧栏 + 视频覆盖层 + 外挂字幕加载 + 全轨时轴偏移 + 播放模式（自动暂停/精简/快进）+ 悬停暂停/防剧透模糊 + 快捷键执行端 |
-| `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；动作交 subtitle-panel 执行 |
+| `content.js` | 隔离 | Shift 悬停查词、查词暂停、弹窗渲染/定位、高亮、挖词队列、字幕轨 provider（textTracks 收割 / DOM 采样 / 整集拦截接收端）、Netflix/YouTube 批量制卡驱动 |
+| `subtitle-panel.js` | 隔离 | 字幕列表侧栏 + 视频覆盖层 + 外挂字幕加载 + 全轨时轴偏移 + 悬浮字幕自动查词/防剧透模糊 + 快捷键执行端 |
+| `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；每个动作独立开关，动作交 subtitle-panel 执行 |
 | `netflix-bridge.js` | MAIN | Netflix 专用：JSON.parse hook 抓整集字幕 + 官方 player.seek（避开 DRM M7375） |
 | `stream-bridge.js` | MAIN | 通用流媒体字幕桥（asb 移植）：TVer / Bilibili.tv / Hulu JP / Prime Video 整集字幕拦截 |
 | `THIRD_PARTY_LICENSES.md` | — | 随扩展分发的第三方版权与许可文本（当前含 asbplayer MIT） |
@@ -23,7 +23,7 @@ Anki 能力——一切经本机 Hibiki 桌面 App 内置的 yomitan API server�
 | `connection-diagnostics.js` | SW/options | 连接六态分类 + 中文文案（纯函数） |
 | `hibiki-defaults.js` | SW/options | 安装助手写入的自动配置（host/port/token/build 指纹） |
 | `offscreen.html/js` | offscreen | tabCapture MediaRecorder（Netflix 逐句回放录制） |
-| `options.html/css/js` | options | 设置页：连接、字幕/播放偏好、快捷键开关、版本与更新卡片 |
+| `options.html/css/js` | options | 设置页：连接、字幕偏好、逐动作视频快捷键、版本与更新卡片 |
 | `vendor/` | — | `popup.{js,css,html}`+`selection.js` = app 查词弹窗原样拷贝（上游 `hibiki/assets/popup/`）；`dict-media.js` 允许扩展分叉；`content.css` 由生成器产出；`action-popup.*` 扩展独有 |
 | `scripts/` | 开发 | `generate-content-css.mjs`（popup.css → 零特异性重根 content.css）、`sync-mirrors.mjs`（镜像同步） |
 
@@ -104,21 +104,20 @@ hook 安装；② `manifest.json` 的 stream-bridge matches 加域名；③ 新�
 `stream-bridge.test.js` 样例 JSON 测试；⑤ 跑 sync-mirrors。参考 asbplayer
 `extension/src/entrypoints/*-page.ts`（MIT）。
 
-## 快捷键（视频页，options 可整体关闭）
+## 快捷键（视频页，options 逐动作独立开关）
 
 | 键 | 动作 |
 |---|---|
 | ← / → | 上一句 / 下一句字幕（仅当前视频有字幕轨时接管） |
 | ↑ | 回当前句句首重播 |
-| Shift+P / O / F | 开关 自动暂停 / 精简播放 / 快进无字幕段（当前视频有 Hibiki 字幕轨时） |
 | Shift+S | 开关字幕列表面板（当前视频有 Hibiki 字幕轨时） |
 | Shift+H | 隐藏 / 显示字幕（站点原生字幕 + 扩展覆盖层；**不**需要 Hibiki 字幕轨） |
 | Ctrl+Shift+← / → / ↓ | 字幕偏移 −100ms / ＋100ms / 重置 |
 | Ctrl+Shift+Z | 复制当前字幕句（配合 Hibiki 剪贴板监看即查词） |
 | Ctrl+Shift+[ / ] | 播放速度 −0.25x / ＋0.25x（0.25–4x） |
 
-与 asbplayer 默认键位对齐（asb 用 hotkeys-js + 可改键；这里是固定键位 + 纯函数判定，站点
-输入框/可编辑区一律放行；无轨时方向键及 Shift+P/O/F/S 均放行给站点原生行为）。
+这里使用固定键位 + 纯函数判定；每个动作在扩展设置页各有自己的开关。站点输入框/可编辑区
+一律放行；无轨时方向键及 Shift+S 均放行给站点原生行为。
 
 `Shift+H` 的「隐藏」用 `visibility:hidden` 而非 `display:none`：扩展的取词、逐句制卡、caret
 兜底命中都要读字幕节点的 textContent / 几何，`display:none` 会把它们摘出布局，隐藏字幕就

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -28,6 +28,7 @@ let hibikiHost = null;
 // BUG-530 性能：划词监听器原来对每次 mousemove 都发查词请求 → 一直按 Shift 移动会把服务器
 // 刷爆、UI 卡顿。用「位移阈值 + 同词去重 + 在途请求闸」三重节流：只在移到**不同词**上才查。
 let hibikiLastTerm = '';
+let hibikiLastAutoLookupKey = '';
 let hibikiLastX = -1;
 let hibikiLastY = -1;
 let hibikiPending = false;
@@ -37,6 +38,37 @@ let hibikiPending = false;
 // 就当上一次已废弃、放行新查词（回调仍会正常复位，此值只是「回调永不来」的安全兜底）。
 let hibikiPendingSince = 0;
 const HIBIKI_PENDING_TIMEOUT_MS = 1500;
+
+// 「查词时暂停」取代旧的「悬停字幕时暂停」。新键显式值优先；旧
+// subtitleHoverPause 只作升级兼容读取，避免用户更新扩展后原选择突然丢失。
+let hibikiPauseOnLookup = false;
+let hibikiHasPauseOnLookupPref = false;
+function hibikiApplyPauseOnLookupPrefs(saved) {
+  saved = saved || {};
+  hibikiHasPauseOnLookupPref = typeof saved.subtitlePauseOnLookup === 'boolean';
+  hibikiPauseOnLookup = hibikiHasPauseOnLookupPref
+    ? saved.subtitlePauseOnLookup
+    : saved.subtitleHoverPause === true;
+}
+try {
+  const hibikiPausePrefsPromise = chrome.storage.local.get(
+    ['subtitlePauseOnLookup', 'subtitleHoverPause'],
+    hibikiApplyPauseOnLookupPrefs,
+  );
+  if (hibikiPausePrefsPromise &&
+      typeof hibikiPausePrefsPromise.then === 'function') {
+    hibikiPausePrefsPromise.then(hibikiApplyPauseOnLookupPrefs, () => {});
+  }
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local' || !changes) return;
+    if (changes.subtitlePauseOnLookup) {
+      hibikiHasPauseOnLookupPref = true;
+      hibikiPauseOnLookup = changes.subtitlePauseOnLookup.newValue === true;
+    } else if (changes.subtitleHoverPause && !hibikiHasPauseOnLookupPref) {
+      hibikiPauseOnLookup = changes.subtitleHoverPause.newValue === true;
+    }
+  });
+} catch (_) {}
 
 // 弹窗尺寸精细化 Phase D：拖拽调整扩展弹窗尺寸。
 // hibikiResizeGrip：右下角拖拽把手（顶层 position:fixed overlay，与高亮层同父挂在
@@ -1424,20 +1456,18 @@ function hibikiShowConnectionFailure(resp) {
   try { window.hibikiToast('⚠ ' + message, false, settingsFixable); } catch (_) {}
 }
 
-// 查词即自动暂停 + 发查词请求 + 渲染弹窗的共享收尾（mousemove 划词与面板行显式点击查词同源）。
-// 暂停：**仅对 Netflix 播放器**（按域名判定，不碰别的站点/后台视频）。定格画面+字幕（方便看词/看
-// 弹窗），冻结 video.currentTime → 句子窗口停在句末，offscreen 随之暂停录制保住这句 → 制卡得整句、
-// 干净。YouTube 走服务端裁剪路径不需暂停；普通网页背景视频更不该被查词误暂停。仅在播放时暂停、不
-// 自动恢复（用户查完自己按空格续播）。幂等（重复调用只在 !paused 时暂停）。
+// 发查词请求 + 渲染弹窗的共享收尾（Shift 悬停、面板行点击、悬浮字幕自动查词同源）。
+// 用户开启「查词时暂停」后，仅在确实发起了非空查词请求时暂停当前视频；不自动恢复，查完由用户
+// 继续播放。关闭时任何站点都不因查词被暂停。
 function hibikiSendLookup(term, anchorRect, cueWindow) {
   // TODO-1219 P3：每次查词刷新精确窗——面板行查词传 cueWindow（该行精确 [startMs,endMs]），
   // mousemove 划词不传则清空，使后续制卡回落 DOM 采样窗（live 视频 hover 取当前句）。
   hibikiPendingCueWindow = cueWindow || null;
   if (!term || !term.trim()) return;
-  if (hibikiSite() === 'netflix') {
+  if (!hibikiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
+  if (hibikiPauseOnLookup) {
     try { const _v = document.querySelector('video'); if (_v && !_v.paused) _v.pause(); } catch (_) {}
   }
-  if (!hibikiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
   hibikiPending = true;
   hibikiPendingSince = Date.now(); // BUG-1024：记发起时刻，供在途闸超时兜底
   try {
@@ -1472,7 +1502,7 @@ function hibikiSendLookup(term, anchorRect, cueWindow) {
 // TODO-1219 P2：面板行内文本「显式点击查词」的入口（供 subtitle-panel.js 调用）。点击命中的
 // (clientX,clientY) 复用与 mousemove 划词同一套 hoshiSelection 取词（含流媒体字幕覆盖层兜底），
 // 选中后走 hibikiSendLookup 发查词 + 渲染弹窗，取词/高亮/锚点与全局划词完全一致。
-window.hibikiLookupAtPoint = function (clientX, clientY, cueWindow) {
+window.hibikiLookupAtPoint = function (clientX, clientY, cueWindow, options) {
   if (!window.hoshiSelection || typeof window.hoshiSelection.getCharacterAtPoint !== 'function') return;
   let hit = window.hoshiSelection.getCharacterAtPoint(clientX, clientY);
   if (!hit) {
@@ -1490,8 +1520,22 @@ window.hibikiLookupAtPoint = function (clientX, clientY, cueWindow) {
       anchorRect = window.hoshiSelection.getSelectionRect(clientX, clientY);
     }
   } catch (_) { anchorRect = null; }
+  const autoLookup = !!(options && options.auto === true);
+  if (autoLookup && hibikiPending &&
+      Date.now() - hibikiPendingSince < HIBIKI_PENDING_TIMEOUT_MS) return;
+  if (autoLookup) {
+    const cueKey = cueWindow
+      ? String(cueWindow.startMs) + ':' + String(cueWindow.endMs) + ':' + String(cueWindow.text || '')
+      : '';
+    const lookupKey = String(term || '') + '\0' + cueKey;
+    if (lookupKey === hibikiLastAutoLookupKey) return;
+    hibikiLastAutoLookupKey = lookupKey;
+  }
   hibikiLastTerm = term || ''; // 与 mousemove 去重状态对齐，避免点后立刻 hover 同词重查
   hibikiSendLookup(term, anchorRect, cueWindow); // TODO-1219 P3：面板行传入精确窗
+};
+window.hibikiResetAutoLookupDedupe = function () {
+  hibikiLastAutoLookupKey = '';
 };
 
 // TODO-1185：嵌套查词——点释义里的词（词典交叉引用 a[href]）。popup.js 的 a.onclick →

--- a/hibiki/assets/browser_extension/options.html
+++ b/hibiki/assets/browser_extension/options.html
@@ -51,7 +51,7 @@
             <label class="setting-row" for="subtitleOverlayAllTracks">
               <span class="setting-copy">
                 <strong>所有字幕轨都用扩展覆盖层显示</strong>
-                <small>站点检测到的字幕轨也叠到视频上，配合防剧透模糊与悬停暂停使用。</small>
+                <small>站点检测到的字幕轨也叠到视频上，配合防剧透模糊与悬浮字幕查词使用。</small>
               </span>
               <span class="switch"><input id="subtitleOverlayAllTracks" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
@@ -69,58 +69,107 @@
               </span>
               <span class="switch"><input id="subtitleHidden" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="subtitleHoverPause">
+            <label class="setting-row" for="subtitlePauseOnLookup">
               <span class="setting-copy">
-                <strong>悬停字幕时暂停</strong>
-                <small>鼠标移到覆盖层字幕上自动暂停，移开继续播放，方便查词。</small>
+                <strong>查词时暂停</strong>
+                <small>从网页、字幕列表或悬浮字幕发起查词时暂停当前视频；查完后由你继续播放。</small>
               </span>
-              <span class="switch"><input id="subtitleHoverPause" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="subtitlePauseOnLookup" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleOverlayAutoLookup">
+              <span class="setting-copy">
+                <strong>悬浮字幕自动查词</strong>
+                <small>鼠标移到悬浮字幕里的词上就自动查词，无需按住 Shift 或点击。</small>
+              </span>
+              <span class="switch"><input id="subtitleOverlayAutoLookup" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
           </div>
         </section>
 
-        <section class="section" aria-labelledby="playback-heading">
+        <section class="section" aria-labelledby="shortcut-heading">
           <div class="section-heading compact">
             <div>
-              <p class="section-kicker">沉浸播放</p>
-              <h2 id="playback-heading">播放模式</h2>
+              <p class="section-kicker">按键控制</p>
+              <h2 id="shortcut-heading">视频快捷键</h2>
             </div>
           </div>
           <div class="setting-list">
-            <label class="setting-row" for="subtitleAutoPause">
+            <label class="setting-row" for="videoShortcutPrevCue">
               <span class="setting-copy">
-                <strong>每句结束时自动暂停</strong>
-                <small>只在字幕句结束时暂停，方便精读和查词。</small>
+                <strong>上一句字幕</strong>
+                <small>←</small>
               </span>
-              <span class="switch"><input id="subtitleAutoPause" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutPrevCue" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="subtitleCondensedPlayback">
+            <label class="setting-row" for="videoShortcutNextCue">
               <span class="setting-copy">
-                <strong>精简播放</strong>
-                <small>自动跳过当前字幕轨中较长的无字幕区间。</small>
+                <strong>下一句字幕</strong>
+                <small>→</small>
               </span>
-              <span class="switch"><input id="subtitleCondensedPlayback" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutNextCue" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="subtitleAutoPauseAtStart">
+            <label class="setting-row" for="videoShortcutReplayCue">
               <span class="setting-copy">
-                <strong>自动暂停改在句首</strong>
-                <small>开启「自动暂停」时改为每句开播即暂停（先猜再听），默认是句尾暂停。</small>
+                <strong>重播本句</strong>
+                <small>↑</small>
               </span>
-              <span class="switch"><input id="subtitleAutoPauseAtStart" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutReplayCue" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="subtitleFastForwardPlayback">
+            <label class="setting-row" for="videoShortcutTogglePanel">
               <span class="setting-copy">
-                <strong>快进无字幕段</strong>
-                <small>无字幕区间以 2.7 倍速播过（保留画面连续性），进句自动恢复原速。</small>
+                <strong>打开或关闭字幕列表</strong>
+                <small>Shift+S</small>
               </span>
-              <span class="switch"><input id="subtitleFastForwardPlayback" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutTogglePanel" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="videoShortcutsEnabled">
+            <label class="setting-row" for="videoShortcutToggleSubtitleHide">
               <span class="setting-copy">
-                <strong>视频页快捷键</strong>
-                <small>←/→ 上一句/下一句 · ↑ 重播本句 · Shift+P/O/F 暂停/精简/快进 · Shift+S 面板 · Shift+H 隐藏字幕 · Ctrl+Shift+←/→/↓ 偏移 · Ctrl+Shift+Z 复制字幕 · Ctrl+Shift+[ ] 变速。<br>制卡快捷键 Ctrl+Enter（查词弹窗打开时按下＝点弹窗里的「＋」）不受本开关影响。</small>
+                <strong>隐藏或显示字幕</strong>
+                <small>Shift+H</small>
               </span>
-              <span class="switch"><input id="videoShortcutsEnabled" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutToggleSubtitleHide" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutOffsetMinus">
+              <span class="setting-copy">
+                <strong>字幕提前 100 毫秒</strong>
+                <small>Ctrl+Shift+←</small>
+              </span>
+              <span class="switch"><input id="videoShortcutOffsetMinus" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutOffsetPlus">
+              <span class="setting-copy">
+                <strong>字幕延后 100 毫秒</strong>
+                <small>Ctrl+Shift+→</small>
+              </span>
+              <span class="switch"><input id="videoShortcutOffsetPlus" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutOffsetReset">
+              <span class="setting-copy">
+                <strong>重置字幕偏移</strong>
+                <small>Ctrl+Shift+↓</small>
+              </span>
+              <span class="switch"><input id="videoShortcutOffsetReset" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutCopyCue">
+              <span class="setting-copy">
+                <strong>复制当前字幕</strong>
+                <small>Ctrl+Shift+Z</small>
+              </span>
+              <span class="switch"><input id="videoShortcutCopyCue" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutRateDown">
+              <span class="setting-copy">
+                <strong>降低播放速度</strong>
+                <small>Ctrl+Shift+[</small>
+              </span>
+              <span class="switch"><input id="videoShortcutRateDown" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutRateUp">
+              <span class="setting-copy">
+                <strong>提高播放速度</strong>
+                <small>Ctrl+Shift+]</small>
+              </span>
+              <span class="switch"><input id="videoShortcutRateUp" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
           </div>
         </section>

--- a/hibiki/assets/browser_extension/options.js
+++ b/hibiki/assets/browser_extension/options.js
@@ -1,40 +1,54 @@
 // Hibiki 浏览器扩展设置：自动连接优先，用户覆盖与字幕偏好存 chrome.storage.local。
 const $ = (id) => document.getElementById(id);
 const D = self.HIBIKI_DEFAULTS || { host: '127.0.0.1', port: 19633, token: '' };
-const subtitleDefaults = Object.freeze({
+const settingDefaults = Object.freeze({
   netflixSubtitlePanel: false,
   subtitleOverlayEnabled: true,
   subtitleDragDropEnabled: true,
   subtitleAutoScroll: true,
-  subtitleAutoPause: false,
-  subtitleCondensedPlayback: false,
   netflixHideNextEpisode: true,
-  // asb 移植（默认关，快捷键默认开）。
-  subtitleAutoPauseAtStart: false,
-  subtitleFastForwardPlayback: false,
-  subtitleHoverPause: false,
+  subtitlePauseOnLookup: false,
+  subtitleOverlayAutoLookup: false,
   subtitleOverlayBlur: false,
   subtitleOverlayAllTracks: false,
-  // 隐藏字幕（Shift+H 也会翻它）：站点原生字幕 + 扩展覆盖层一起藏，实现在 content.js。
+  // 隐藏字幕是实际显示状态；Shift+H 是否接管由独立快捷键开关控制。
   subtitleHidden: false,
-  videoShortcutsEnabled: true,
+  videoShortcutPrevCue: true,
+  videoShortcutNextCue: true,
+  videoShortcutReplayCue: true,
+  videoShortcutTogglePanel: true,
+  videoShortcutToggleSubtitleHide: true,
+  videoShortcutOffsetMinus: true,
+  videoShortcutOffsetPlus: true,
+  videoShortcutOffsetReset: true,
+  videoShortcutCopyCue: true,
+  videoShortcutRateDown: true,
+  videoShortcutRateUp: true,
 });
 const toggleIds = Object.freeze({
   nfSubList: 'netflixSubtitlePanel',
   subtitleOverlayEnabled: 'subtitleOverlayEnabled',
   subtitleDragDropEnabled: 'subtitleDragDropEnabled',
   subtitleAutoScroll: 'subtitleAutoScroll',
-  subtitleAutoPause: 'subtitleAutoPause',
-  subtitleCondensedPlayback: 'subtitleCondensedPlayback',
   nfHideNext: 'netflixHideNextEpisode',
-  subtitleAutoPauseAtStart: 'subtitleAutoPauseAtStart',
-  subtitleFastForwardPlayback: 'subtitleFastForwardPlayback',
-  subtitleHoverPause: 'subtitleHoverPause',
+  subtitlePauseOnLookup: 'subtitlePauseOnLookup',
+  subtitleOverlayAutoLookup: 'subtitleOverlayAutoLookup',
   subtitleOverlayBlur: 'subtitleOverlayBlur',
   subtitleOverlayAllTracks: 'subtitleOverlayAllTracks',
   subtitleHidden: 'subtitleHidden',
-  videoShortcutsEnabled: 'videoShortcutsEnabled',
+  videoShortcutPrevCue: 'videoShortcutPrevCue',
+  videoShortcutNextCue: 'videoShortcutNextCue',
+  videoShortcutReplayCue: 'videoShortcutReplayCue',
+  videoShortcutTogglePanel: 'videoShortcutTogglePanel',
+  videoShortcutToggleSubtitleHide: 'videoShortcutToggleSubtitleHide',
+  videoShortcutOffsetMinus: 'videoShortcutOffsetMinus',
+  videoShortcutOffsetPlus: 'videoShortcutOffsetPlus',
+  videoShortcutOffsetReset: 'videoShortcutOffsetReset',
+  videoShortcutCopyCue: 'videoShortcutCopyCue',
+  videoShortcutRateDown: 'videoShortcutRateDown',
+  videoShortcutRateUp: 'videoShortcutRateUp',
 });
+const shortcutKeys = Object.freeze(Object.values(toggleIds).filter((key) => key.startsWith('videoShortcut')));
 
 let toastTimer = null;
 function toast(message) {
@@ -100,7 +114,10 @@ async function loadSettings() {
   $('port').placeholder = String(D.port || 19633);
   $('token').placeholder = D.token ? '已由 Hibiki 自动配置' : '';
 
-  const keys = ['host', 'port', 'token'].concat(Object.values(toggleIds));
+  // 旧 subtitleHoverPause / videoShortcutsEnabled 只作一次向后兼容读取：
+  // 新键已有显式值时永远优先；旧键不再由 UI 写入。
+  const keys = ['host', 'port', 'token', 'subtitleHoverPause', 'videoShortcutsEnabled']
+    .concat(Object.values(toggleIds));
   const saved = await chrome.storage.local.get(keys);
   if (saved.host != null && saved.host !== '') $('host').value = saved.host;
   if (saved.port != null && saved.port !== 0) $('port').value = saved.port;
@@ -109,7 +126,14 @@ async function loadSettings() {
   for (const [id, key] of Object.entries(toggleIds)) {
     const input = $(id);
     if (!input) continue;
-    input.checked = typeof saved[key] === 'boolean' ? saved[key] : subtitleDefaults[key];
+    let value = saved[key];
+    if (typeof value !== 'boolean' && key === 'subtitlePauseOnLookup') {
+      value = saved.subtitleHoverPause;
+    }
+    if (typeof value !== 'boolean' && shortcutKeys.includes(key)) {
+      value = saved.videoShortcutsEnabled;
+    }
+    input.checked = typeof value === 'boolean' ? value : settingDefaults[key];
     input.addEventListener('change', async () => {
       await chrome.storage.local.set({ [key]: input.checked });
       toast('已更新：' + input.closest('.setting-row').querySelector('strong').textContent);

--- a/hibiki/assets/browser_extension/subtitle-panel.js
+++ b/hibiki/assets/browser_extension/subtitle-panel.js
@@ -37,16 +37,16 @@
     pushSuspended: false, enabled: false,
     // B（外挂字幕）：用户主动打开面板（即使暂无轨也不自动拆）。
     forceOpen: false, offsetBar: null, offsetLabel: null,
-    overlayEnabled: true, dragDropEnabled: true, autoPause: false, condensedPlayback: false,
-    overlayEl: null, overlayCue: null, dropHint: null, lastCondensedTargetMs: -1,
+    overlayEnabled: true, dragDropEnabled: true,
+    overlayEl: null, overlayCue: null, dropHint: null,
     // asb 移植：任意轨（检测轨/外挂轨）的读取侧时轴偏移。store 永远存原始 cue，偏移只在
     // 面板/覆盖层/快捷键**读取时**套用——provider（textTracks 收割 / live 采样 / 整集拦截）
     // 增量刷新 store 不会与偏移打架。key = `${videoKey}|${lang}`，会话内记忆。
     trackOffsets: Object.create(null), builtOffset: 0,
-    // asb 移植：句首自动暂停 / 快进无字幕段 / 悬停暂停 / 覆盖层防剧透模糊 / 全轨覆盖层。
-    autoPauseAtStart: false, fastForward: false, hoverPause: false,
+    // 覆盖层防剧透模糊 / 全轨覆盖层 / 悬浮字幕自动查词。
+    overlayAutoLookup: false,
     overlayBlur: false, overlayAllTracks: false,
-    hoverPaused: false, overlayHovered: false, ffSavedRate: -1, lastAutoPauseIdx: -1,
+    overlayHovered: false, autoLookupLastX: -1, autoLookupLastY: -1,
   };
   var EXT_PREFIX = '外挂:';
 
@@ -358,12 +358,7 @@
     st.overlayEnabled = c.subtitleOverlayEnabled !== false;
     st.dragDropEnabled = c.subtitleDragDropEnabled !== false;
     st.autoScroll = c.subtitleAutoScroll !== false;
-    st.autoPause = c.subtitleAutoPause === true;
-    st.condensedPlayback = c.subtitleCondensedPlayback === true;
-    // asb 移植的扩展偏好（全部默认关，除快捷键在 video-shortcuts.js 自持默认开）。
-    st.autoPauseAtStart = c.subtitleAutoPauseAtStart === true;
-    st.fastForward = c.subtitleFastForwardPlayback === true;
-    st.hoverPause = c.subtitleHoverPause === true;
+    st.overlayAutoLookup = c.subtitleOverlayAutoLookup === true;
     st.overlayBlur = c.subtitleOverlayBlur === true;
     st.overlayAllTracks = c.subtitleOverlayAllTracks === true;
     if (!st.overlayEnabled) hideSubtitleOverlay();
@@ -375,11 +370,7 @@
       subtitleOverlayEnabled: st.overlayEnabled,
       subtitleDragDropEnabled: st.dragDropEnabled,
       subtitleAutoScroll: st.autoScroll,
-      subtitleAutoPause: st.autoPause,
-      subtitleCondensedPlayback: st.condensedPlayback,
-      subtitleAutoPauseAtStart: st.autoPauseAtStart,
-      subtitleFastForwardPlayback: st.fastForward,
-      subtitleHoverPause: st.hoverPause,
+      subtitleOverlayAutoLookup: st.overlayAutoLookup,
       subtitleOverlayBlur: st.overlayBlur,
       subtitleOverlayAllTracks: st.overlayAllTracks,
     };
@@ -388,8 +379,7 @@
   function readSubtitlePreferences() {
     var keys = [
       'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
-      'subtitleAutoPause', 'subtitleCondensedPlayback',
-      'subtitleAutoPauseAtStart', 'subtitleFastForwardPlayback', 'subtitleHoverPause',
+      'subtitleOverlayAutoLookup',
       'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
     ];
     try {
@@ -513,7 +503,6 @@
     var nowMs = videoTimeMs();
     var idx = cueIndexAt(st.cues, nowMs);
     updateSubtitleOverlay(idx >= 0 ? st.cues[idx] : null);
-    applyPlaybackMode(idx, nowMs);
     if (!st.panel || st.hidden) { st.currentIndex = idx; return; }
     if (idx === st.currentIndex) return;
     var prev = st.rowEls[st.currentIndex];
@@ -542,27 +531,34 @@
           });
         }
       });
-      // asb 移植：悬停暂停（pause-on-hover）——鼠标进覆盖层即暂停，方便查词；移出且确实是
-      // 因悬停而暂停时恢复播放（用户自己按的暂停不动）。防剧透模糊（blur）同一对监听里处理。
       el.addEventListener('mouseenter', function () {
         st.overlayHovered = true;
         applyOverlayBlur(el);
-        if (st.hoverPause) {
-          var v = videoEl();
-          if (v && !v.paused && typeof v.pause === 'function') {
-            try { v.pause(); st.hoverPaused = true; } catch (_) {}
-          }
-        }
+      });
+      // 悬浮字幕自动查词：只在覆盖层内启用，按与 content.js Shift 悬停同样的 4px 位移阈值
+      // 限流；取词、同词去重、在途闸和精确 cue 窗全部复用 hibikiLookupAtPoint。
+      el.addEventListener('mousemove', function (e) {
+        if (!st.overlayAutoLookup || !st.overlayCue ||
+            typeof window.hibikiLookupAtPoint !== 'function') return;
+        if (Math.abs(e.clientX - st.autoLookupLastX) < 4 &&
+            Math.abs(e.clientY - st.autoLookupLastY) < 4) return;
+        st.autoLookupLastX = e.clientX;
+        st.autoLookupLastY = e.clientY;
+        var cue = st.overlayCue;
+        window.hibikiLookupAtPoint(
+          e.clientX,
+          e.clientY,
+          { startMs: cue.startMs, endMs: cue.endMs, text: cue.text },
+          { auto: true },
+        );
       });
       el.addEventListener('mouseleave', function () {
         st.overlayHovered = false;
         applyOverlayBlur(el);
-        if (st.hoverPaused) {
-          st.hoverPaused = false;
-          var v = videoEl();
-          if (v && typeof v.play === 'function') {
-            Promise.resolve(v.play()).catch(function () {});
-          }
+        st.autoLookupLastX = -1;
+        st.autoLookupLastY = -1;
+        if (typeof window.hibikiResetAutoLookupDedupe === 'function') {
+          window.hibikiResetAutoLookupDedupe();
         }
       });
       st.overlayEl = el;
@@ -572,7 +568,7 @@
     return st.overlayEl;
   }
 
-  // asb 移植：防剧透模糊——覆盖层默认糊住，悬停即清晰（顺带触发悬停暂停，看+查一体）。
+  // 防剧透模糊——覆盖层默认糊住，悬停即清晰。
   function applyOverlayBlur(el) {
     if (!el || !el.style) return;
     var blurred = st.overlayBlur && !st.overlayHovered;
@@ -586,7 +582,7 @@
 
   function updateSubtitleOverlay(cue) {
     // 外挂轨恒显示；检测轨（站点自带字幕）默认不重复叠字，除非用户开了「全轨覆盖层」
-    // （overlayAllTracks，配合防剧透模糊/悬停暂停使用）。
+    // （overlayAllTracks，配合防剧透模糊/悬浮字幕自动查词使用）。
     if (!st.overlayEnabled || !cue ||
         (!isExternalLang(st.activeLang) && !st.overlayAllTracks)) {
       hideSubtitleOverlay();
@@ -613,60 +609,6 @@
       if (st.cues[mid].startMs > ms) { ans = mid; hi = mid - 1; } else { lo = mid + 1; }
     }
     return ans;
-  }
-
-  function applyPlaybackMode(idx, nowMs) {
-    var video = videoEl();
-    if (!video) return;
-    var previous = st.currentIndex;
-    // 自动暂停·句尾（既有默认）：上一句刚结束、尚未进入下一句时暂停。
-    if (st.autoPause && !st.autoPauseAtStart && previous >= 0 && idx < 0 &&
-        nowMs >= st.cues[previous].endMs && typeof video.pause === 'function') {
-      try { video.pause(); } catch (_) {}
-      return;
-    }
-    // asb 移植（AutoPausePreference.atStart）：自动暂停·句首——新句刚开播（<400ms，避免
-    // seek 进句中被误暂停）时暂停一次；同一句只暂停一次（用户继续播放后不再回按）。
-    if (st.autoPause && st.autoPauseAtStart && idx >= 0 && idx !== previous &&
-        idx !== st.lastAutoPauseIdx && nowMs - st.cues[idx].startMs < 400 &&
-        !video.paused && typeof video.pause === 'function') {
-      try { video.pause(); } catch (_) {}
-      st.lastAutoPauseIdx = idx;
-      return;
-    }
-    if (idx < 0) st.lastAutoPauseIdx = -1;
-    applyFastForward(video, idx, nowMs);
-    if (!st.condensedPlayback || st.autoPause || idx >= 0 || video.paused) {
-      if (idx >= 0) st.lastCondensedTargetMs = -1;
-      return;
-    }
-    var next = firstCueAfter(nowMs + 250);
-    if (next < 0) return;
-    var target = st.cues[next].startMs;
-    if (target - nowMs < 800 || target === st.lastCondensedTargetMs) return;
-    st.lastCondensedTargetMs = target;
-    seekTo(target);
-  }
-
-  // asb 移植（fastForward 播放模式）：无字幕区间倍速播过（asb 默认 2.7x），进句恢复原速。
-  // 与精简播放（直接跳过）互斥——精简开启时优先跳过；自动暂停开启时两者都不动。
-  function applyFastForward(video, idx, nowMs) {
-    var eligible = st.fastForward && !st.autoPause && !st.condensedPlayback &&
-        typeof video.playbackRate === 'number';
-    var inGap = false;
-    if (eligible && idx < 0 && !video.paused && st.cues.length) {
-      var next = firstCueAfter(nowMs + 250);
-      if (next >= 0 && st.cues[next].startMs - nowMs >= 800) inGap = true;
-    }
-    if (inGap) {
-      if (st.ffSavedRate < 0) {
-        st.ffSavedRate = video.playbackRate > 0 ? video.playbackRate : 1;
-        try { video.playbackRate = 2.7; } catch (_) {}
-      }
-    } else if (st.ffSavedRate >= 0) {
-      try { video.playbackRate = st.ffSavedRate; } catch (_) {}
-      st.ffSavedRate = -1;
-    }
   }
 
   function ensureMounted() {
@@ -951,15 +893,6 @@
     toast('已复制字幕：' + (text.length > 30 ? text.slice(0, 30) + '…' : text));
     return true;
   }
-  function togglePref(key, label) {
-    var snap = prefsSnapshot();
-    var next = snap[key] !== true;
-    snap[key] = next;
-    applySubtitlePreferences(snap); // 先行生效（无 chrome 环境的单测同样生效）
-    try { var patch = {}; patch[key] = next; chrome.storage.local.set(patch); } catch (_) {}
-    toast(label + (next ? '：开' : '：关'));
-    return true;
-  }
   function shortcutTogglePanel() {
     if (!st.enabled) {
       st.forceOpen = true;
@@ -984,9 +917,6 @@
       case 'offset-plus': return shortcutOffset(100);
       case 'offset-reset': return shortcutOffset(0);
       case 'copy-cue': return shortcutCopyCue();
-      case 'toggle-autopause': return togglePref('subtitleAutoPause', '自动暂停');
-      case 'toggle-condensed': return togglePref('subtitleCondensedPlayback', '精简播放');
-      case 'toggle-fastforward': return togglePref('subtitleFastForwardPlayback', '快进无字幕段');
       case 'toggle-panel': return shortcutTogglePanel();
       // 隐藏字幕：状态与 style 注入由 content.js 独占（见那里的「所有权」注释）——面板整体
       // 受 netflixSubtitlePanel 门控且默认关，状态放这里会导致「没开面板就不能隐藏字幕」。
@@ -1040,8 +970,7 @@
       var changed = false;
       var keys = [
         'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
-        'subtitleAutoPause', 'subtitleCondensedPlayback',
-        'subtitleAutoPauseAtStart', 'subtitleFastForwardPlayback', 'subtitleHoverPause',
+        'subtitleOverlayAutoLookup',
         'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
       ];
       for (var i = 0; i < keys.length; i++) {

--- a/hibiki/assets/browser_extension/video-shortcuts.js
+++ b/hibiki/assets/browser_extension/video-shortcuts.js
@@ -1,8 +1,7 @@
-// asb 移植：视频页快捷键（content script 隔离世界，manifest bundle 里排在 subtitle-panel.js
-// 之后加载）。键位与 asbplayer 默认键对齐（差异见 README「快捷键」表）：
+// 视频页快捷键（content script 隔离世界，manifest bundle 里排在 subtitle-panel.js
+// 之后加载）。每个动作在 options 里有独立开关：
 //   ←/→        上一句 / 下一句字幕（仅当前视频有字幕轨时接管，否则放行给站点）
 //   ↑           回当前句句首重播
-//   Shift+P/O/F 开关 自动暂停 / 精简播放 / 快进无字幕段
 //   Shift+S     开关字幕列表面板
 //   Shift+H     隐藏/显示字幕（站点原生字幕 + 扩展覆盖层，与 app 内视频页同键）
 //   Ctrl+Enter  制卡（等同点查词弹窗里的「＋」；判定不在本文件，见 vendor/popup.js）
@@ -11,7 +10,7 @@
 //   Ctrl+Shift+[ / ]  播放速度 −0.25x / ＋0.25x
 // 判定是纯函数 decide()（node 可测）；执行端是 subtitle-panel.js 暴露的
 // window.hibikiSubtitleShortcut(action)（面板持有轨/偏移/模式状态），播放速度直接操作 <video>。
-// 输入框/可编辑区一律放行；options 的 videoShortcutsEnabled（默认开）可整体关闭。
+// 输入框/可编辑区一律放行；旧 videoShortcutsEnabled 只作为升级时各动作的缺省值。
 (function (root, factory) {
   var api = factory();
   try { if (typeof module !== 'undefined' && module.exports) module.exports = api; } catch (_) { /* no-op */ }
@@ -26,14 +25,17 @@
     if (ev.alt) return null;
     var key = ev.key || '';
     var code = ev.code || '';
+    function result(action) {
+      return !ctx.bindings || ctx.bindings[action] !== false ? { action: action } : null;
+    }
     if (ev.ctrl && ev.shift) {
-      if (key === 'ArrowLeft') return ctx.hasTrack ? { action: 'offset-minus' } : null;
-      if (key === 'ArrowRight') return ctx.hasTrack ? { action: 'offset-plus' } : null;
-      if (key === 'ArrowDown') return ctx.hasTrack ? { action: 'offset-reset' } : null;
-      if (code === 'KeyZ') return ctx.hasTrack ? { action: 'copy-cue' } : null;
+      if (key === 'ArrowLeft') return ctx.hasTrack ? result('offset-minus') : null;
+      if (key === 'ArrowRight') return ctx.hasTrack ? result('offset-plus') : null;
+      if (key === 'ArrowDown') return ctx.hasTrack ? result('offset-reset') : null;
+      if (code === 'KeyZ') return ctx.hasTrack ? result('copy-cue') : null;
       // 括号键在 Shift 下 e.key 会变成 '{' / '}'，用布局无关的 e.code。
-      if (code === 'BracketLeft') return { action: 'rate-down' };
-      if (code === 'BracketRight') return { action: 'rate-up' };
+      if (code === 'BracketLeft') return result('rate-down');
+      if (code === 'BracketRight') return result('rate-up');
       return null;
     }
     if (ev.ctrl) return null;
@@ -42,17 +44,14 @@
       // YouTube 自带轨）+ 扩展自绘覆盖层，而 hasTrack 问的是「扩展这边有没有加载过字幕轨」。
       // 二者正交——绝大多数用户是在看站点原生字幕、根本没往扩展里挂轨，若卡在 hasTrack 后面，
       // 这个键在最主要的使用场景下会永远不触发。与 app 的 videoToggleSubtitleHide 默认键一致。
-      if (code === 'KeyH') return { action: 'toggle-subtitle-hide' };
+      if (code === 'KeyH') return result('toggle-subtitle-hide');
       if (!ctx.hasTrack) return null;
-      if (code === 'KeyP') return { action: 'toggle-autopause' };
-      if (code === 'KeyO') return { action: 'toggle-condensed' };
-      if (code === 'KeyF') return { action: 'toggle-fastforward' };
-      if (code === 'KeyS') return { action: 'toggle-panel' };
+      if (code === 'KeyS') return result('toggle-panel');
       return null;
     }
-    if (key === 'ArrowLeft') return ctx.hasTrack ? { action: 'prev-cue' } : null;
-    if (key === 'ArrowRight') return ctx.hasTrack ? { action: 'next-cue' } : null;
-    if (key === 'ArrowUp') return ctx.hasTrack ? { action: 'replay-cue' } : null;
+    if (key === 'ArrowLeft') return ctx.hasTrack ? result('prev-cue') : null;
+    if (key === 'ArrowRight') return ctx.hasTrack ? result('next-cue') : null;
+    if (key === 'ArrowUp') return ctx.hasTrack ? result('replay-cue') : null;
     return null;
   }
 
@@ -69,21 +68,53 @@
 (function () {
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
   var api = (typeof self !== 'undefined' ? self : window).HIBIKI_VIDEO_SHORTCUTS;
-  var enabled = true;
+  var bindingKeys = {
+    'prev-cue': 'videoShortcutPrevCue',
+    'next-cue': 'videoShortcutNextCue',
+    'replay-cue': 'videoShortcutReplayCue',
+    'toggle-panel': 'videoShortcutTogglePanel',
+    'toggle-subtitle-hide': 'videoShortcutToggleSubtitleHide',
+    'offset-minus': 'videoShortcutOffsetMinus',
+    'offset-plus': 'videoShortcutOffsetPlus',
+    'offset-reset': 'videoShortcutOffsetReset',
+    'copy-cue': 'videoShortcutCopyCue',
+    'rate-down': 'videoShortcutRateDown',
+    'rate-up': 'videoShortcutRateUp',
+  };
+  var rawSettings = Object.create(null);
+  var bindings = Object.create(null);
 
-  function applyEnabled(saved) {
-    // 缺省/非 false 一律视为开启（默认开）。
-    enabled = !(saved && saved.videoShortcutsEnabled === false);
+  function applySettings(saved) {
+    saved = saved || {};
+    for (var k in saved) rawSettings[k] = saved[k];
+    var legacyEnabled = rawSettings.videoShortcutsEnabled !== false;
+    for (var action in bindingKeys) {
+      var value = rawSettings[bindingKeys[action]];
+      bindings[action] = typeof value === 'boolean' ? value : legacyEnabled;
+    }
   }
   try {
-    var p = chrome.storage.local.get('videoShortcutsEnabled');
-    if (p && typeof p.then === 'function') p.then(applyEnabled, function () {});
-    else chrome.storage.local.get('videoShortcutsEnabled', applyEnabled);
+    var keys = ['videoShortcutsEnabled'];
+    for (var action in bindingKeys) keys.push(bindingKeys[action]);
+    var p = chrome.storage.local.get(keys, applySettings);
+    if (p && typeof p.then === 'function') p.then(applySettings, function () {});
   } catch (_) {}
   try {
     chrome.storage.onChanged.addListener(function (changes, area) {
-      if (area !== 'local' || !changes || !changes.videoShortcutsEnabled) return;
-      enabled = changes.videoShortcutsEnabled.newValue !== false;
+      if (area !== 'local' || !changes) return;
+      var patch = {};
+      var changed = false;
+      if (changes.videoShortcutsEnabled) {
+        patch.videoShortcutsEnabled = changes.videoShortcutsEnabled.newValue;
+        changed = true;
+      }
+      for (var action in bindingKeys) {
+        var key = bindingKeys[action];
+        if (!changes[key]) continue;
+        patch[key] = changes[key].newValue;
+        changed = true;
+      }
+      if (changed) applySettings(patch);
     });
   } catch (_) {}
 
@@ -136,9 +167,10 @@
         editable: isEditable(e.target),
       },
       {
-        enabled: enabled,
+        enabled: true,
         hasVideo: !!document.querySelector('video'),
         hasTrack: hasTrackForVideo(),
+        bindings: bindings,
       });
     if (!decision) return;
     var handled = false;

--- a/hibiki/test/build/browser_extension_dict_media_mirror_guard_test.dart
+++ b/hibiki/test/build/browser_extension_dict_media_mirror_guard_test.dart
@@ -233,15 +233,15 @@ void main() {
             reason: '$root options.css must not retain dead hero layout rules');
       });
 
-      test('[$name] options expose user-subtitle playback controls', () {
+      test('[$name] options expose subtitle lookup controls', () {
         final String html = File('$root/options.html').readAsStringSync();
         final String js = File('$root/options.js').readAsStringSync();
         for (final String id in <String>[
           'subtitleOverlayEnabled',
           'subtitleDragDropEnabled',
           'subtitleAutoScroll',
-          'subtitleAutoPause',
-          'subtitleCondensedPlayback',
+          'subtitlePauseOnLookup',
+          'subtitleOverlayAutoLookup',
         ]) {
           expect(html.contains('id="$id"'), isTrue,
               reason: '$root options.html missing $id');
@@ -260,10 +260,35 @@ void main() {
             reason: '$root subtitle-panel.js missing drag-and-drop loading');
         expect(src.contains("'hibiki-subtitle-overlay'"), isTrue,
             reason: '$root subtitle-panel.js missing video subtitle overlay');
-        expect(src.contains('st.autoPause'), isTrue,
-            reason: '$root subtitle-panel.js missing auto-pause mode');
-        expect(src.contains('st.condensedPlayback'), isTrue,
-            reason: '$root subtitle-panel.js missing condensed playback mode');
+        expect(src.contains('st.overlayAutoLookup'), isTrue,
+            reason:
+                '$root subtitle-panel.js missing floating-subtitle auto lookup');
+        expect(src.contains('applyPlaybackMode'), isFalse,
+            reason: '$root subtitle-panel.js must remove legacy playback modes');
+      });
+
+      test('[$name] video shortcuts are configured per action', () {
+        final String html = File('$root/options.html').readAsStringSync();
+        final String js = File('$root/options.js').readAsStringSync();
+        for (final String id in <String>[
+          'videoShortcutPrevCue',
+          'videoShortcutNextCue',
+          'videoShortcutReplayCue',
+          'videoShortcutTogglePanel',
+          'videoShortcutOffsetMinus',
+          'videoShortcutOffsetPlus',
+          'videoShortcutOffsetReset',
+          'videoShortcutCopyCue',
+          'videoShortcutRateDown',
+          'videoShortcutRateUp',
+        ]) {
+          expect(html.contains('id="$id"'), isTrue,
+              reason: '$root options.html missing independent shortcut $id');
+          expect(js.contains(id), isTrue,
+              reason: '$root options.js must persist independent shortcut $id');
+        }
+        expect(html.contains('id="videoShortcutsEnabled"'), isFalse,
+            reason: '$root options must not retain the all-in-one shortcut row');
       });
 
       test('[$name] background diagnoses Hibiki/Yomitan port ownership', () {
@@ -426,6 +451,8 @@ void main() {
       'manifest.json',
       // TODO-1219 P2：字幕列表面板新增/改动的共享文件，同样纳入字节守卫。
       'subtitle-panel.js',
+      // TODO-2301：视频快捷键逐动作开关和运行时接线必须与随 app 分发的镜像一致。
+      'video-shortcuts.js',
       'vendor/content.css',
       // TODO-1219：字幕列表面板默认关开关（options UI）——两镜像同步纳入字节守卫。
       'options.html',

--- a/hibiki/test/mining/netflix_mining_robustness_guard_test.dart
+++ b/hibiki/test/mining/netflix_mining_robustness_guard_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// 守住修复不被回退。两份扩展镜像（随 app 打包的 `assets/` 与真源 `tools/`）都守。
 ///
 /// 覆盖：
-/// - #1 查词即暂停**仅对 Netflix**（不再对页面任意 <video> 暂停 → UX 副作用）。
+/// - #1 查词暂停由用户设置门控；关闭时任何站点都不暂停，开启时暂停当前视频。
 /// - #2 Netflix 批量循环 beginClip→endClip 收口放 finally（异常也收口录制器，防状态叠加）。
 /// - #3 MediaRecorder 孤儿防御（offscreen beginClip 先停旧 recorder）+ hideStyle/cursor 还原放 finally。
 /// - #4 每句时间窗死代码已删（扩展 mineClip 不发段内窗/gifEnd；dart transcodeClipToCapture 去掉
@@ -34,22 +34,19 @@ void main() {
               reason: 'missing ${content.path}');
         });
 
-        test('#1 查词暂停仅门控 Netflix（不对任意 <video> 暂停）', () {
+        test('#1 查词暂停由 subtitlePauseOnLookup 门控', () {
           final String src = content.readAsStringSync();
-          // 暂停必须包在 hibikiSite()==='netflix' 门里。
           expect(
-            src.contains("if (hibikiSite() === 'netflix') {\n"
+            src.contains('if (hibikiPauseOnLookup) {\n'
                 "    try { const _v = document.querySelector('video'); if (_v && !_v.paused) _v.pause(); } catch (_) {}\n"
                 '  }'),
             isTrue,
-            reason: '${content.path} 查词暂停未门控到 Netflix',
+            reason: '${content.path} 查词暂停未受用户设置门控',
           );
-          // 不得再有顶层（2 空格缩进）未门控的查词暂停。
           expect(
-            src.contains(
-                "\n  try { const _v = document.querySelector('video'); if (_v && !_v.paused) _v.pause(); } catch (_) {}"),
+            src.contains("hibikiSite() === 'netflix'"),
             isFalse,
-            reason: '${content.path} 仍残留未门控的查词暂停（对任意 video 生效）',
+            reason: '${content.path} 不应再保留 Netflix 无设置强制暂停',
           );
         });
 

--- a/tools/browser-extension/README.md
+++ b/tools/browser-extension/README.md
@@ -10,9 +10,9 @@ Anki 能力——一切经本机 Hibiki 桌面 App 内置的 yomitan API server�
 |---|---|---|
 | `manifest.json` | — | MV3 清单；content script 注入顺序有语义（先桥后消费者） |
 | `background.js` | service worker | 唯一网络出口：查词/制卡/字幕等所有 HTTP 请求 + 连接诊断 + 自更新执行 + 心跳 + Netflix 录制编排 |
-| `content.js` | 隔离 | Shift 悬停查词、弹窗渲染/定位、高亮、挖词队列、字幕轨 provider（textTracks 收割 / DOM 采样 / 整集拦截接收端）、Netflix/YouTube 批量制卡驱动 |
-| `subtitle-panel.js` | 隔离 | 字幕列表侧栏 + 视频覆盖层 + 外挂字幕加载 + 全轨时轴偏移 + 播放模式（自动暂停/精简/快进）+ 悬停暂停/防剧透模糊 + 快捷键执行端 |
-| `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；动作交 subtitle-panel 执行 |
+| `content.js` | 隔离 | Shift 悬停查词、查词暂停、弹窗渲染/定位、高亮、挖词队列、字幕轨 provider（textTracks 收割 / DOM 采样 / 整集拦截接收端）、Netflix/YouTube 批量制卡驱动 |
+| `subtitle-panel.js` | 隔离 | 字幕列表侧栏 + 视频覆盖层 + 外挂字幕加载 + 全轨时轴偏移 + 悬浮字幕自动查词/防剧透模糊 + 快捷键执行端 |
+| `video-shortcuts.js` | 隔离 | 视频页快捷键判定（纯函数）+ 绑定；每个动作独立开关，动作交 subtitle-panel 执行 |
 | `netflix-bridge.js` | MAIN | Netflix 专用：JSON.parse hook 抓整集字幕 + 官方 player.seek（避开 DRM M7375） |
 | `stream-bridge.js` | MAIN | 通用流媒体字幕桥（asb 移植）：TVer / Bilibili.tv / Hulu JP / Prime Video 整集字幕拦截 |
 | `THIRD_PARTY_LICENSES.md` | — | 随扩展分发的第三方版权与许可文本（当前含 asbplayer MIT） |
@@ -23,7 +23,7 @@ Anki 能力——一切经本机 Hibiki 桌面 App 内置的 yomitan API server�
 | `connection-diagnostics.js` | SW/options | 连接六态分类 + 中文文案（纯函数） |
 | `hibiki-defaults.js` | SW/options | 安装助手写入的自动配置（host/port/token/build 指纹） |
 | `offscreen.html/js` | offscreen | tabCapture MediaRecorder（Netflix 逐句回放录制） |
-| `options.html/css/js` | options | 设置页：连接、字幕/播放偏好、快捷键开关、版本与更新卡片 |
+| `options.html/css/js` | options | 设置页：连接、字幕偏好、逐动作视频快捷键、版本与更新卡片 |
 | `vendor/` | — | `popup.{js,css,html}`+`selection.js` = app 查词弹窗原样拷贝（上游 `hibiki/assets/popup/`）；`dict-media.js` 允许扩展分叉；`content.css` 由生成器产出；`action-popup.*` 扩展独有 |
 | `scripts/` | 开发 | `generate-content-css.mjs`（popup.css → 零特异性重根 content.css）、`sync-mirrors.mjs`（镜像同步） |
 
@@ -104,21 +104,20 @@ hook 安装；② `manifest.json` 的 stream-bridge matches 加域名；③ 新�
 `stream-bridge.test.js` 样例 JSON 测试；⑤ 跑 sync-mirrors。参考 asbplayer
 `extension/src/entrypoints/*-page.ts`（MIT）。
 
-## 快捷键（视频页，options 可整体关闭）
+## 快捷键（视频页，options 逐动作独立开关）
 
 | 键 | 动作 |
 |---|---|
 | ← / → | 上一句 / 下一句字幕（仅当前视频有字幕轨时接管） |
 | ↑ | 回当前句句首重播 |
-| Shift+P / O / F | 开关 自动暂停 / 精简播放 / 快进无字幕段（当前视频有 Hibiki 字幕轨时） |
 | Shift+S | 开关字幕列表面板（当前视频有 Hibiki 字幕轨时） |
 | Shift+H | 隐藏 / 显示字幕（站点原生字幕 + 扩展覆盖层；**不**需要 Hibiki 字幕轨） |
 | Ctrl+Shift+← / → / ↓ | 字幕偏移 −100ms / ＋100ms / 重置 |
 | Ctrl+Shift+Z | 复制当前字幕句（配合 Hibiki 剪贴板监看即查词） |
 | Ctrl+Shift+[ / ] | 播放速度 −0.25x / ＋0.25x（0.25–4x） |
 
-与 asbplayer 默认键位对齐（asb 用 hotkeys-js + 可改键；这里是固定键位 + 纯函数判定，站点
-输入框/可编辑区一律放行；无轨时方向键及 Shift+P/O/F/S 均放行给站点原生行为）。
+这里使用固定键位 + 纯函数判定；每个动作在扩展设置页各有自己的开关。站点输入框/可编辑区
+一律放行；无轨时方向键及 Shift+S 均放行给站点原生行为。
 
 `Shift+H` 的「隐藏」用 `visibility:hidden` 而非 `display:none`：扩展的取词、逐句制卡、caret
 兜底命中都要读字幕节点的 textContent / 几何，`display:none` 会把它们摘出布局，隐藏字幕就

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -28,6 +28,7 @@ let hibikiHost = null;
 // BUG-530 性能：划词监听器原来对每次 mousemove 都发查词请求 → 一直按 Shift 移动会把服务器
 // 刷爆、UI 卡顿。用「位移阈值 + 同词去重 + 在途请求闸」三重节流：只在移到**不同词**上才查。
 let hibikiLastTerm = '';
+let hibikiLastAutoLookupKey = '';
 let hibikiLastX = -1;
 let hibikiLastY = -1;
 let hibikiPending = false;
@@ -37,6 +38,37 @@ let hibikiPending = false;
 // 就当上一次已废弃、放行新查词（回调仍会正常复位，此值只是「回调永不来」的安全兜底）。
 let hibikiPendingSince = 0;
 const HIBIKI_PENDING_TIMEOUT_MS = 1500;
+
+// 「查词时暂停」取代旧的「悬停字幕时暂停」。新键显式值优先；旧
+// subtitleHoverPause 只作升级兼容读取，避免用户更新扩展后原选择突然丢失。
+let hibikiPauseOnLookup = false;
+let hibikiHasPauseOnLookupPref = false;
+function hibikiApplyPauseOnLookupPrefs(saved) {
+  saved = saved || {};
+  hibikiHasPauseOnLookupPref = typeof saved.subtitlePauseOnLookup === 'boolean';
+  hibikiPauseOnLookup = hibikiHasPauseOnLookupPref
+    ? saved.subtitlePauseOnLookup
+    : saved.subtitleHoverPause === true;
+}
+try {
+  const hibikiPausePrefsPromise = chrome.storage.local.get(
+    ['subtitlePauseOnLookup', 'subtitleHoverPause'],
+    hibikiApplyPauseOnLookupPrefs,
+  );
+  if (hibikiPausePrefsPromise &&
+      typeof hibikiPausePrefsPromise.then === 'function') {
+    hibikiPausePrefsPromise.then(hibikiApplyPauseOnLookupPrefs, () => {});
+  }
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local' || !changes) return;
+    if (changes.subtitlePauseOnLookup) {
+      hibikiHasPauseOnLookupPref = true;
+      hibikiPauseOnLookup = changes.subtitlePauseOnLookup.newValue === true;
+    } else if (changes.subtitleHoverPause && !hibikiHasPauseOnLookupPref) {
+      hibikiPauseOnLookup = changes.subtitleHoverPause.newValue === true;
+    }
+  });
+} catch (_) {}
 
 // 弹窗尺寸精细化 Phase D：拖拽调整扩展弹窗尺寸。
 // hibikiResizeGrip：右下角拖拽把手（顶层 position:fixed overlay，与高亮层同父挂在
@@ -1424,20 +1456,18 @@ function hibikiShowConnectionFailure(resp) {
   try { window.hibikiToast('⚠ ' + message, false, settingsFixable); } catch (_) {}
 }
 
-// 查词即自动暂停 + 发查词请求 + 渲染弹窗的共享收尾（mousemove 划词与面板行显式点击查词同源）。
-// 暂停：**仅对 Netflix 播放器**（按域名判定，不碰别的站点/后台视频）。定格画面+字幕（方便看词/看
-// 弹窗），冻结 video.currentTime → 句子窗口停在句末，offscreen 随之暂停录制保住这句 → 制卡得整句、
-// 干净。YouTube 走服务端裁剪路径不需暂停；普通网页背景视频更不该被查词误暂停。仅在播放时暂停、不
-// 自动恢复（用户查完自己按空格续播）。幂等（重复调用只在 !paused 时暂停）。
+// 发查词请求 + 渲染弹窗的共享收尾（Shift 悬停、面板行点击、悬浮字幕自动查词同源）。
+// 用户开启「查词时暂停」后，仅在确实发起了非空查词请求时暂停当前视频；不自动恢复，查完由用户
+// 继续播放。关闭时任何站点都不因查词被暂停。
 function hibikiSendLookup(term, anchorRect, cueWindow) {
   // TODO-1219 P3：每次查词刷新精确窗——面板行查词传 cueWindow（该行精确 [startMs,endMs]），
   // mousemove 划词不传则清空，使后续制卡回落 DOM 采样窗（live 视频 hover 取当前句）。
   hibikiPendingCueWindow = cueWindow || null;
   if (!term || !term.trim()) return;
-  if (hibikiSite() === 'netflix') {
+  if (!hibikiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
+  if (hibikiPauseOnLookup) {
     try { const _v = document.querySelector('video'); if (_v && !_v.paused) _v.pause(); } catch (_) {}
   }
-  if (!hibikiExtAlive()) return; // 扩展已重载/失效：静默停手（重载页面恢复）
   hibikiPending = true;
   hibikiPendingSince = Date.now(); // BUG-1024：记发起时刻，供在途闸超时兜底
   try {
@@ -1472,7 +1502,7 @@ function hibikiSendLookup(term, anchorRect, cueWindow) {
 // TODO-1219 P2：面板行内文本「显式点击查词」的入口（供 subtitle-panel.js 调用）。点击命中的
 // (clientX,clientY) 复用与 mousemove 划词同一套 hoshiSelection 取词（含流媒体字幕覆盖层兜底），
 // 选中后走 hibikiSendLookup 发查词 + 渲染弹窗，取词/高亮/锚点与全局划词完全一致。
-window.hibikiLookupAtPoint = function (clientX, clientY, cueWindow) {
+window.hibikiLookupAtPoint = function (clientX, clientY, cueWindow, options) {
   if (!window.hoshiSelection || typeof window.hoshiSelection.getCharacterAtPoint !== 'function') return;
   let hit = window.hoshiSelection.getCharacterAtPoint(clientX, clientY);
   if (!hit) {
@@ -1490,8 +1520,22 @@ window.hibikiLookupAtPoint = function (clientX, clientY, cueWindow) {
       anchorRect = window.hoshiSelection.getSelectionRect(clientX, clientY);
     }
   } catch (_) { anchorRect = null; }
+  const autoLookup = !!(options && options.auto === true);
+  if (autoLookup && hibikiPending &&
+      Date.now() - hibikiPendingSince < HIBIKI_PENDING_TIMEOUT_MS) return;
+  if (autoLookup) {
+    const cueKey = cueWindow
+      ? String(cueWindow.startMs) + ':' + String(cueWindow.endMs) + ':' + String(cueWindow.text || '')
+      : '';
+    const lookupKey = String(term || '') + '\0' + cueKey;
+    if (lookupKey === hibikiLastAutoLookupKey) return;
+    hibikiLastAutoLookupKey = lookupKey;
+  }
   hibikiLastTerm = term || ''; // 与 mousemove 去重状态对齐，避免点后立刻 hover 同词重查
   hibikiSendLookup(term, anchorRect, cueWindow); // TODO-1219 P3：面板行传入精确窗
+};
+window.hibikiResetAutoLookupDedupe = function () {
+  hibikiLastAutoLookupKey = '';
 };
 
 // TODO-1185：嵌套查词——点释义里的词（词典交叉引用 a[href]）。popup.js 的 a.onclick →

--- a/tools/browser-extension/external-subtitle.test.js
+++ b/tools/browser-extension/external-subtitle.test.js
@@ -238,30 +238,3 @@ test('⑤ 外挂字幕按视频矩形叠到画面上，站点轨不重复叠字'
   assert.strictEqual(overlay.textContent, '画面上的外挂字幕');
   assert.strictEqual(overlay.style.left, '500px');
 });
-
-test('⑥ 自动暂停与精简播放按当前字幕轨工作', () => {
-  const pause = loadPanel({
-    hostname: 'example.com', pathname: '/video/1',
-    stored: { netflixSubtitlePanel: true, subtitleAutoPause: true },
-    response: OK([{ text: 'a', startMs: 1000, endMs: 2000 }]),
-  });
-  pause.loadFile('pause.srt', 'dummy');
-  pause.video.currentTime = 1.5;
-  pause.tick();
-  pause.video.currentTime = 2.1;
-  pause.tick();
-  assert.strictEqual(pause.video.pauseCount, 1, '字幕句结束时应暂停一次');
-
-  const condensed = loadPanel({
-    hostname: 'example.com', pathname: '/video/1',
-    stored: { netflixSubtitlePanel: true, subtitleCondensedPlayback: true },
-    response: OK([
-      { text: 'a', startMs: 1000, endMs: 2000 },
-      { text: 'b', startMs: 5000, endMs: 6000 },
-    ]),
-  });
-  condensed.loadFile('condensed.srt', 'dummy');
-  condensed.video.currentTime = 2.5;
-  condensed.tick();
-  assert.strictEqual(condensed.video.currentTime, 5, '长无字幕区间应跳到下一句');
-});

--- a/tools/browser-extension/options.html
+++ b/tools/browser-extension/options.html
@@ -51,7 +51,7 @@
             <label class="setting-row" for="subtitleOverlayAllTracks">
               <span class="setting-copy">
                 <strong>所有字幕轨都用扩展覆盖层显示</strong>
-                <small>站点检测到的字幕轨也叠到视频上，配合防剧透模糊与悬停暂停使用。</small>
+                <small>站点检测到的字幕轨也叠到视频上，配合防剧透模糊与悬浮字幕查词使用。</small>
               </span>
               <span class="switch"><input id="subtitleOverlayAllTracks" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
@@ -69,58 +69,107 @@
               </span>
               <span class="switch"><input id="subtitleHidden" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="subtitleHoverPause">
+            <label class="setting-row" for="subtitlePauseOnLookup">
               <span class="setting-copy">
-                <strong>悬停字幕时暂停</strong>
-                <small>鼠标移到覆盖层字幕上自动暂停，移开继续播放，方便查词。</small>
+                <strong>查词时暂停</strong>
+                <small>从网页、字幕列表或悬浮字幕发起查词时暂停当前视频；查完后由你继续播放。</small>
               </span>
-              <span class="switch"><input id="subtitleHoverPause" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="subtitlePauseOnLookup" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="subtitleOverlayAutoLookup">
+              <span class="setting-copy">
+                <strong>悬浮字幕自动查词</strong>
+                <small>鼠标移到悬浮字幕里的词上就自动查词，无需按住 Shift 或点击。</small>
+              </span>
+              <span class="switch"><input id="subtitleOverlayAutoLookup" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
           </div>
         </section>
 
-        <section class="section" aria-labelledby="playback-heading">
+        <section class="section" aria-labelledby="shortcut-heading">
           <div class="section-heading compact">
             <div>
-              <p class="section-kicker">沉浸播放</p>
-              <h2 id="playback-heading">播放模式</h2>
+              <p class="section-kicker">按键控制</p>
+              <h2 id="shortcut-heading">视频快捷键</h2>
             </div>
           </div>
           <div class="setting-list">
-            <label class="setting-row" for="subtitleAutoPause">
+            <label class="setting-row" for="videoShortcutPrevCue">
               <span class="setting-copy">
-                <strong>每句结束时自动暂停</strong>
-                <small>只在字幕句结束时暂停，方便精读和查词。</small>
+                <strong>上一句字幕</strong>
+                <small>←</small>
               </span>
-              <span class="switch"><input id="subtitleAutoPause" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutPrevCue" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="subtitleCondensedPlayback">
+            <label class="setting-row" for="videoShortcutNextCue">
               <span class="setting-copy">
-                <strong>精简播放</strong>
-                <small>自动跳过当前字幕轨中较长的无字幕区间。</small>
+                <strong>下一句字幕</strong>
+                <small>→</small>
               </span>
-              <span class="switch"><input id="subtitleCondensedPlayback" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutNextCue" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="subtitleAutoPauseAtStart">
+            <label class="setting-row" for="videoShortcutReplayCue">
               <span class="setting-copy">
-                <strong>自动暂停改在句首</strong>
-                <small>开启「自动暂停」时改为每句开播即暂停（先猜再听），默认是句尾暂停。</small>
+                <strong>重播本句</strong>
+                <small>↑</small>
               </span>
-              <span class="switch"><input id="subtitleAutoPauseAtStart" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutReplayCue" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="subtitleFastForwardPlayback">
+            <label class="setting-row" for="videoShortcutTogglePanel">
               <span class="setting-copy">
-                <strong>快进无字幕段</strong>
-                <small>无字幕区间以 2.7 倍速播过（保留画面连续性），进句自动恢复原速。</small>
+                <strong>打开或关闭字幕列表</strong>
+                <small>Shift+S</small>
               </span>
-              <span class="switch"><input id="subtitleFastForwardPlayback" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutTogglePanel" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
-            <label class="setting-row" for="videoShortcutsEnabled">
+            <label class="setting-row" for="videoShortcutToggleSubtitleHide">
               <span class="setting-copy">
-                <strong>视频页快捷键</strong>
-                <small>←/→ 上一句/下一句 · ↑ 重播本句 · Shift+P/O/F 暂停/精简/快进 · Shift+S 面板 · Shift+H 隐藏字幕 · Ctrl+Shift+←/→/↓ 偏移 · Ctrl+Shift+Z 复制字幕 · Ctrl+Shift+[ ] 变速。<br>制卡快捷键 Ctrl+Enter（查词弹窗打开时按下＝点弹窗里的「＋」）不受本开关影响。</small>
+                <strong>隐藏或显示字幕</strong>
+                <small>Shift+H</small>
               </span>
-              <span class="switch"><input id="videoShortcutsEnabled" type="checkbox"><span aria-hidden="true"></span></span>
+              <span class="switch"><input id="videoShortcutToggleSubtitleHide" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutOffsetMinus">
+              <span class="setting-copy">
+                <strong>字幕提前 100 毫秒</strong>
+                <small>Ctrl+Shift+←</small>
+              </span>
+              <span class="switch"><input id="videoShortcutOffsetMinus" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutOffsetPlus">
+              <span class="setting-copy">
+                <strong>字幕延后 100 毫秒</strong>
+                <small>Ctrl+Shift+→</small>
+              </span>
+              <span class="switch"><input id="videoShortcutOffsetPlus" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutOffsetReset">
+              <span class="setting-copy">
+                <strong>重置字幕偏移</strong>
+                <small>Ctrl+Shift+↓</small>
+              </span>
+              <span class="switch"><input id="videoShortcutOffsetReset" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutCopyCue">
+              <span class="setting-copy">
+                <strong>复制当前字幕</strong>
+                <small>Ctrl+Shift+Z</small>
+              </span>
+              <span class="switch"><input id="videoShortcutCopyCue" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutRateDown">
+              <span class="setting-copy">
+                <strong>降低播放速度</strong>
+                <small>Ctrl+Shift+[</small>
+              </span>
+              <span class="switch"><input id="videoShortcutRateDown" type="checkbox"><span aria-hidden="true"></span></span>
+            </label>
+            <label class="setting-row" for="videoShortcutRateUp">
+              <span class="setting-copy">
+                <strong>提高播放速度</strong>
+                <small>Ctrl+Shift+]</small>
+              </span>
+              <span class="switch"><input id="videoShortcutRateUp" type="checkbox"><span aria-hidden="true"></span></span>
             </label>
           </div>
         </section>

--- a/tools/browser-extension/options.js
+++ b/tools/browser-extension/options.js
@@ -1,40 +1,54 @@
 // Hibiki 浏览器扩展设置：自动连接优先，用户覆盖与字幕偏好存 chrome.storage.local。
 const $ = (id) => document.getElementById(id);
 const D = self.HIBIKI_DEFAULTS || { host: '127.0.0.1', port: 19633, token: '' };
-const subtitleDefaults = Object.freeze({
+const settingDefaults = Object.freeze({
   netflixSubtitlePanel: false,
   subtitleOverlayEnabled: true,
   subtitleDragDropEnabled: true,
   subtitleAutoScroll: true,
-  subtitleAutoPause: false,
-  subtitleCondensedPlayback: false,
   netflixHideNextEpisode: true,
-  // asb 移植（默认关，快捷键默认开）。
-  subtitleAutoPauseAtStart: false,
-  subtitleFastForwardPlayback: false,
-  subtitleHoverPause: false,
+  subtitlePauseOnLookup: false,
+  subtitleOverlayAutoLookup: false,
   subtitleOverlayBlur: false,
   subtitleOverlayAllTracks: false,
-  // 隐藏字幕（Shift+H 也会翻它）：站点原生字幕 + 扩展覆盖层一起藏，实现在 content.js。
+  // 隐藏字幕是实际显示状态；Shift+H 是否接管由独立快捷键开关控制。
   subtitleHidden: false,
-  videoShortcutsEnabled: true,
+  videoShortcutPrevCue: true,
+  videoShortcutNextCue: true,
+  videoShortcutReplayCue: true,
+  videoShortcutTogglePanel: true,
+  videoShortcutToggleSubtitleHide: true,
+  videoShortcutOffsetMinus: true,
+  videoShortcutOffsetPlus: true,
+  videoShortcutOffsetReset: true,
+  videoShortcutCopyCue: true,
+  videoShortcutRateDown: true,
+  videoShortcutRateUp: true,
 });
 const toggleIds = Object.freeze({
   nfSubList: 'netflixSubtitlePanel',
   subtitleOverlayEnabled: 'subtitleOverlayEnabled',
   subtitleDragDropEnabled: 'subtitleDragDropEnabled',
   subtitleAutoScroll: 'subtitleAutoScroll',
-  subtitleAutoPause: 'subtitleAutoPause',
-  subtitleCondensedPlayback: 'subtitleCondensedPlayback',
   nfHideNext: 'netflixHideNextEpisode',
-  subtitleAutoPauseAtStart: 'subtitleAutoPauseAtStart',
-  subtitleFastForwardPlayback: 'subtitleFastForwardPlayback',
-  subtitleHoverPause: 'subtitleHoverPause',
+  subtitlePauseOnLookup: 'subtitlePauseOnLookup',
+  subtitleOverlayAutoLookup: 'subtitleOverlayAutoLookup',
   subtitleOverlayBlur: 'subtitleOverlayBlur',
   subtitleOverlayAllTracks: 'subtitleOverlayAllTracks',
   subtitleHidden: 'subtitleHidden',
-  videoShortcutsEnabled: 'videoShortcutsEnabled',
+  videoShortcutPrevCue: 'videoShortcutPrevCue',
+  videoShortcutNextCue: 'videoShortcutNextCue',
+  videoShortcutReplayCue: 'videoShortcutReplayCue',
+  videoShortcutTogglePanel: 'videoShortcutTogglePanel',
+  videoShortcutToggleSubtitleHide: 'videoShortcutToggleSubtitleHide',
+  videoShortcutOffsetMinus: 'videoShortcutOffsetMinus',
+  videoShortcutOffsetPlus: 'videoShortcutOffsetPlus',
+  videoShortcutOffsetReset: 'videoShortcutOffsetReset',
+  videoShortcutCopyCue: 'videoShortcutCopyCue',
+  videoShortcutRateDown: 'videoShortcutRateDown',
+  videoShortcutRateUp: 'videoShortcutRateUp',
 });
+const shortcutKeys = Object.freeze(Object.values(toggleIds).filter((key) => key.startsWith('videoShortcut')));
 
 let toastTimer = null;
 function toast(message) {
@@ -100,7 +114,10 @@ async function loadSettings() {
   $('port').placeholder = String(D.port || 19633);
   $('token').placeholder = D.token ? '已由 Hibiki 自动配置' : '';
 
-  const keys = ['host', 'port', 'token'].concat(Object.values(toggleIds));
+  // 旧 subtitleHoverPause / videoShortcutsEnabled 只作一次向后兼容读取：
+  // 新键已有显式值时永远优先；旧键不再由 UI 写入。
+  const keys = ['host', 'port', 'token', 'subtitleHoverPause', 'videoShortcutsEnabled']
+    .concat(Object.values(toggleIds));
   const saved = await chrome.storage.local.get(keys);
   if (saved.host != null && saved.host !== '') $('host').value = saved.host;
   if (saved.port != null && saved.port !== 0) $('port').value = saved.port;
@@ -109,7 +126,14 @@ async function loadSettings() {
   for (const [id, key] of Object.entries(toggleIds)) {
     const input = $(id);
     if (!input) continue;
-    input.checked = typeof saved[key] === 'boolean' ? saved[key] : subtitleDefaults[key];
+    let value = saved[key];
+    if (typeof value !== 'boolean' && key === 'subtitlePauseOnLookup') {
+      value = saved.subtitleHoverPause;
+    }
+    if (typeof value !== 'boolean' && shortcutKeys.includes(key)) {
+      value = saved.videoShortcutsEnabled;
+    }
+    input.checked = typeof value === 'boolean' ? value : settingDefaults[key];
     input.addEventListener('change', async () => {
       await chrome.storage.local.set({ [key]: input.checked });
       toast('已更新：' + input.closest('.setting-row').querySelector('strong').textContent);

--- a/tools/browser-extension/shift-hover.test.js
+++ b/tools/browser-extension/shift-hover.test.js
@@ -22,6 +22,7 @@ function loadContentAndFireShift(options) {
   const src = fs.readFileSync(CONTENT, 'utf8');
   const docListeners = Object.create(null);
   const winListeners = Object.create(null);
+  const storageListeners = [];
   const sent = [];
   const dataset = {};
   const video = {
@@ -93,7 +94,7 @@ function loadContentAndFireShift(options) {
         },
         set: async () => {},
       },
-      onChanged: { addListener() {} },
+      onChanged: { addListener: (fn) => storageListeners.push(fn) },
     },
   };
   sandbox.window = {
@@ -116,7 +117,15 @@ function loadContentAndFireShift(options) {
   vm.createContext(sandbox);
   vm.runInContext(src, sandbox, { filename: 'content.js' });
 
-  return { docListeners, sent, dataset, nowRef, video, windowObj: sandbox.window };
+  return {
+    docListeners,
+    sent,
+    dataset,
+    nowRef,
+    video,
+    windowObj: sandbox.window,
+    storageListeners,
+  };
 }
 
 test('content.js 在加载时注册了顶层 document mousemove 监听器', () => {
@@ -177,6 +186,28 @@ test('查词暂停兼容旧 subtitleHoverPause，但新键显式 false 优先', 
     fn({ shiftKey: true, clientX: 300, clientY: 400 });
   }
   assert.strictEqual(overridden.video.pauseCount, 0, '新键显式 false 必须覆盖旧 true');
+});
+
+test('查词暂停经 storage.onChanged 热更新启停，无需刷新页面', () => {
+  const h = loadContentAndFireShift({
+    stored: { subtitlePauseOnLookup: false },
+  });
+  assert.ok(h.storageListeners.length > 0, 'content.js 应注册 storage.onChanged');
+
+  fireShiftLookup(h.docListeners, 300, 400);
+  assert.strictEqual(h.video.pauseCount, 0, '初始关闭时不得暂停');
+
+  for (const listener of h.storageListeners) {
+    listener({ subtitlePauseOnLookup: { newValue: true } }, 'local');
+  }
+  fireShiftLookup(h.docListeners, 500, 600);
+  assert.strictEqual(h.video.pauseCount, 1, '热更新开启后下一次查词必须暂停');
+
+  for (const listener of h.storageListeners) {
+    listener({ subtitlePauseOnLookup: { newValue: false } }, 'local');
+  }
+  fireShiftLookup(h.docListeners, 700, 650);
+  assert.strictEqual(h.video.pauseCount, 1, '热更新关闭后不得继续暂停');
 });
 
 test('悬浮字幕自动查词复用同词去重，移开复位后可重查', () => {

--- a/tools/browser-extension/shift-hover.test.js
+++ b/tools/browser-extension/shift-hover.test.js
@@ -17,12 +17,18 @@ const CONTENT = path.join(__dirname, 'content.js');
 // options.respond=false 模拟 MV3 background service worker 在消息在途时被系统终止：
 // sendMessage 的回调永不触发（BUG-1024 死锁场景）。options 缺省保持历史行为（同步回调）。
 function loadContentAndFireShift(options) {
+  options = options || {};
   const respond = !options || options.respond !== false;
   const src = fs.readFileSync(CONTENT, 'utf8');
   const docListeners = Object.create(null);
   const winListeners = Object.create(null);
   const sent = [];
   const dataset = {};
+  const video = {
+    paused: false,
+    pauseCount: 0,
+    pause() { this.paused = true; this.pauseCount++; },
+  };
   // 可控时钟：BUG-1024 的在途闸超时兜底按 Date.now() 判定，测试需要推进虚拟时间。
   const nowRef = { value: 1000000 };
   const RealDate = Date;
@@ -53,7 +59,7 @@ function loadContentAndFireShift(options) {
       (docListeners[t] = docListeners[t] || []).push(fn);
     },
     getElementById: () => null,
-    querySelector: () => null,
+    querySelector: (selector) => selector === 'video' ? video : null,
     querySelectorAll: () => [],
     createElement: () => ({
       style: {},
@@ -79,7 +85,14 @@ function loadContentAndFireShift(options) {
       },
     },
     storage: {
-      local: { get: async () => ({}), set: async () => {} },
+      local: {
+        get: (_keys, cb) => {
+          const saved = options.stored || {};
+          if (typeof cb === 'function') cb(saved);
+          return Promise.resolve(saved);
+        },
+        set: async () => {},
+      },
       onChanged: { addListener() {} },
     },
   };
@@ -103,7 +116,7 @@ function loadContentAndFireShift(options) {
   vm.createContext(sandbox);
   vm.runInContext(src, sandbox, { filename: 'content.js' });
 
-  return { docListeners, sent, dataset, nowRef };
+  return { docListeners, sent, dataset, nowRef, video, windowObj: sandbox.window };
 }
 
 test('content.js 在加载时注册了顶层 document mousemove 监听器', () => {
@@ -133,6 +146,55 @@ test('未按 Shift 的 mousemove 不发查词（不刷爆服务器）', () => {
     sent.filter((m) => m && m.type === 'lookup').length,
     0,
     '未按 Shift 也发了查词',
+  );
+});
+
+test('查词时暂停默认关闭；开启后任意视频站点只在发起查词时暂停', () => {
+  const off = loadContentAndFireShift();
+  for (const fn of off.docListeners.mousemove) {
+    fn({ shiftKey: true, clientX: 300, clientY: 400 });
+  }
+  assert.strictEqual(off.video.pauseCount, 0, '默认关闭时查词不得暂停视频');
+
+  const on = loadContentAndFireShift({ stored: { subtitlePauseOnLookup: true } });
+  for (const fn of on.docListeners.mousemove) {
+    fn({ shiftKey: true, clientX: 300, clientY: 400 });
+  }
+  assert.strictEqual(on.video.pauseCount, 1, '开启后发起查词应暂停当前视频');
+});
+
+test('查词暂停兼容旧 subtitleHoverPause，但新键显式 false 优先', () => {
+  const legacy = loadContentAndFireShift({ stored: { subtitleHoverPause: true } });
+  for (const fn of legacy.docListeners.mousemove) {
+    fn({ shiftKey: true, clientX: 300, clientY: 400 });
+  }
+  assert.strictEqual(legacy.video.pauseCount, 1, '旧开关为 true 的用户升级后应保留选择');
+
+  const overridden = loadContentAndFireShift({
+    stored: { subtitleHoverPause: true, subtitlePauseOnLookup: false },
+  });
+  for (const fn of overridden.docListeners.mousemove) {
+    fn({ shiftKey: true, clientX: 300, clientY: 400 });
+  }
+  assert.strictEqual(overridden.video.pauseCount, 0, '新键显式 false 必须覆盖旧 true');
+});
+
+test('悬浮字幕自动查词复用同词去重，移开复位后可重查', () => {
+  const h = loadContentAndFireShift();
+  const cue = { startMs: 1000, endMs: 2000, text: '世界です' };
+  h.windowObj.hibikiLookupAtPoint(300, 400, cue, { auto: true });
+  h.windowObj.hibikiLookupAtPoint(310, 400, cue, { auto: true });
+  assert.strictEqual(
+    h.sent.filter((m) => m && m.type === 'lookup').length,
+    1,
+    '同一句同一词的自动悬停不得重复发请求',
+  );
+  h.windowObj.hibikiResetAutoLookupDedupe();
+  h.windowObj.hibikiLookupAtPoint(310, 400, cue, { auto: true });
+  assert.strictEqual(
+    h.sent.filter((m) => m && m.type === 'lookup').length,
+    2,
+    '移开复位后再次悬停同词应可重新查词',
   );
 });
 

--- a/tools/browser-extension/subtitle-hide.test.js
+++ b/tools/browser-extension/subtitle-hide.test.js
@@ -14,6 +14,8 @@ const vm = require('node:vm');
 //   ② 站点原生字幕（Netflix/YouTube）和扩展自绘覆盖层都要被藏——只藏一半等于没藏。
 //   ③ 翻回「显示」时样式必须真的被移除（不是留着空规则），否则第二次开关就失效。
 const CONTENT = path.join(__dirname, 'content.js');
+const PANEL = path.join(__dirname, 'subtitle-panel.js');
+const SHORTCUTS = path.join(__dirname, 'video-shortcuts.js');
 
 function makeEl(tag) {
   const el = {
@@ -64,6 +66,7 @@ function loadContent(storedHidden) {
   html.appendChild(head);
   const stored = { subtitleHidden: storedHidden };
   const changeListeners = [];
+  const windowListeners = Object.create(null);
   const sandbox = {
     console: { log() {}, warn() {}, error() {} },
     setTimeout: () => 0,
@@ -110,7 +113,9 @@ function loadContent(storedHidden) {
     },
   };
   sandbox.window = {
-    addEventListener() {},
+    addEventListener(type, listener) {
+      (windowListeners[type] = windowListeners[type] || []).push(listener);
+    },
     innerWidth: 1200,
     innerHeight: 800,
     matchMedia: () => ({ matches: false }),
@@ -125,7 +130,7 @@ function loadContent(storedHidden) {
 
   vm.createContext(sandbox);
   vm.runInContext(src, sandbox, { filename: 'content.js' });
-  return { sandbox, head, stored, changeListeners };
+  return { sandbox, head, stored, changeListeners, windowListeners };
 }
 
 const STYLE_ID = 'hibiki-hide-subs';
@@ -181,4 +186,52 @@ test('隐藏字幕：options 页改开关经 storage.onChanged 实时生效', ()
     fn({ subtitleHidden: { newValue: false } }, 'local');
   }
   assert.strictEqual(findById(head, STYLE_ID), null);
+});
+
+test('Shift+H 真链：keydown 经 subtitle-panel 转发到 content 并持久化隐藏状态', () => {
+  const h = loadContent(false);
+  const video = { currentTime: 0, paused: false, playbackRate: 1 };
+  h.sandbox.document.querySelector = (selector) => selector === 'video' ? video : null;
+  h.sandbox.setInterval = () => 0;
+  h.sandbox.clearInterval = () => {};
+  h.sandbox.navigator = {
+    clipboard: { writeText: () => Promise.resolve() },
+  };
+  h.sandbox.self = h.sandbox.window;
+  h.sandbox.window.hibikiEpisodeCues = {};
+  h.sandbox.window.hibikiVideoKey = () => 'episode';
+
+  vm.runInContext(
+    fs.readFileSync(PANEL, 'utf8'),
+    h.sandbox,
+    { filename: 'subtitle-panel.js' },
+  );
+  vm.runInContext(
+    fs.readFileSync(SHORTCUTS, 'utf8'),
+    h.sandbox,
+    { filename: 'video-shortcuts.js' },
+  );
+
+  const keydown = (h.windowListeners.keydown || []).at(-1);
+  assert.strictEqual(typeof keydown, 'function', 'video-shortcuts 应注册 keydown');
+  let prevented = false;
+  let stopped = false;
+  keydown({
+    key: 'H',
+    code: 'KeyH',
+    shiftKey: true,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    target: null,
+    preventDefault() { prevented = true; },
+    stopPropagation() { stopped = true; },
+  });
+
+  assert.strictEqual(prevented, true, '真链执行成功后应接管 Shift+H');
+  assert.strictEqual(stopped, true, '真链执行成功后应阻止站点重复处理');
+  assert.strictEqual(h.stored.subtitleHidden, true,
+    'subtitle-panel 必须调用 content 的持有者并写回 subtitleHidden');
+  assert.ok(findById(h.head, STYLE_ID),
+    'keydown → panel → content 真链必须立即注入隐藏字幕样式');
 });

--- a/tools/browser-extension/subtitle-modes.test.js
+++ b/tools/browser-extension/subtitle-modes.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
 
-// asb 移植行为守卫：全轨读取侧偏移 / 句首自动暂停 / 快进无字幕段 / 悬停暂停 / 防剧透模糊 /
+// 字幕行为守卫：全轨读取侧偏移 / 防剧透模糊 / 悬浮字幕自动查词 /
 // 全轨覆盖层 / 快捷键执行端（window.hibikiSubtitleShortcut）。
 // 在受控 vm 里真加载 subtitle-panel.js，store 预置「检测轨」（非外挂），驱动 200ms tick。
 
@@ -79,11 +79,15 @@ function loadPanel(opts) {
   const toasts = [];
   const storageSets = [];
   const clipboard = [];
+  const lookups = [];
+  let autoLookupResets = 0;
   const windowObj = {
     hibikiEpisodeCues: opts.store || {},
     postMessage() {},
     addEventListener() {},
     hibikiToast: (m) => toasts.push(m),
+    hibikiLookupAtPoint: (...args) => lookups.push(args),
+    hibikiResetAutoLookupDedupe: () => { autoLookupResets++; },
   };
   const documentObj = {
     body,
@@ -115,7 +119,8 @@ function loadPanel(opts) {
   };
   vm.runInNewContext(src, sandbox, { filename: 'subtitle-panel.js' });
   return {
-    body, video, windowObj, toasts, storageSets, clipboard,
+    body, video, windowObj, toasts, storageSets, clipboard, lookups,
+    autoLookupResets: () => autoLookupResets,
     panel: () => findByIdDeep(body, 'hibiki-subtitle-panel'),
     overlay: () => findByIdDeep(body, 'hibiki-subtitle-overlay'),
     tick: () => { const t = intervals.find((it) => it.ms === 200); if (t) t.fn(); },
@@ -148,36 +153,7 @@ test('检测轨也有时轴偏移：读取侧平移，store 不动', () => {
   assert.strictEqual(h.video.currentTime, 1.5, '行 seek 用偏移后的 1500ms');
 });
 
-test('句首自动暂停：新句开播即暂停一次，恢复播放后同句不再回按', () => {
-  const h = loadPanel({
-    stored: { netflixSubtitlePanel: true, subtitleAutoPause: true, subtitleAutoPauseAtStart: true },
-    store: jaStore(),
-  });
-  h.video.currentTime = 1.1; // 句 1 开播 100ms（<400ms 句首窗）
-  h.tick();
-  assert.strictEqual(h.video.pauseCount, 1, '句首应暂停一次');
-  h.video.paused = false; // 用户继续播放
-  h.tick();
-  assert.strictEqual(h.video.pauseCount, 1, '同句不得再次暂停');
-  h.video.currentTime = 4.05; // 进句 2 句首
-  h.tick();
-  assert.strictEqual(h.video.pauseCount, 2, '下一句句首再暂停');
-});
-
-test('快进无字幕段：间隙 2.7x，进句恢复原速', () => {
-  const h = loadPanel({
-    stored: { netflixSubtitlePanel: true, subtitleFastForwardPlayback: true },
-    store: jaStore(),
-  });
-  h.video.currentTime = 2.5; // 句 1 之后的长间隙（距句 2 还有 1.5s）
-  h.tick();
-  assert.strictEqual(h.video.playbackRate, 2.7, '无字幕段应提速到 2.7x');
-  h.video.currentTime = 4.2; // 进句 2
-  h.tick();
-  assert.strictEqual(h.video.playbackRate, 1, '进句应恢复原速');
-});
-
-test('全轨覆盖层 + 防剧透模糊 + 悬停暂停', () => {
+test('全轨覆盖层 + 防剧透模糊 + 悬浮字幕自动查词', () => {
   const off = loadPanel({ stored: { netflixSubtitlePanel: true }, store: jaStore() });
   off.video.currentTime = 1.5;
   off.tick();
@@ -186,7 +162,7 @@ test('全轨覆盖层 + 防剧透模糊 + 悬停暂停', () => {
   const h = loadPanel({
     stored: {
       netflixSubtitlePanel: true, subtitleOverlayAllTracks: true,
-      subtitleOverlayBlur: true, subtitleHoverPause: true,
+      subtitleOverlayBlur: true, subtitleOverlayAutoLookup: true,
     },
     store: jaStore(),
   });
@@ -198,13 +174,22 @@ test('全轨覆盖层 + 防剧透模糊 + 悬停暂停', () => {
   assert.strictEqual(overlay.style.filter, 'blur(6px)', '防剧透默认模糊');
   overlay.fire('mouseenter');
   assert.strictEqual(overlay.style.filter, '', '悬停即清晰');
-  assert.strictEqual(h.video.paused, true, '悬停暂停');
+  assert.strictEqual(h.video.paused, false, '只悬停不得暂停，暂停已改为查词时触发');
+  overlay.fire('mousemove', { clientX: 300, clientY: 400 });
+  assert.strictEqual(h.lookups.length, 1, '悬浮字幕内移动应自动查词');
+  assert.strictEqual(h.lookups[0][2].startMs, 1000);
+  assert.strictEqual(h.lookups[0][2].endMs, 2000);
+  assert.strictEqual(h.lookups[0][2].text, '走り出した');
+  assert.strictEqual(h.lookups[0][3].auto, true,
+    '自动查词应携带当前 cue 精确窗与 auto 去重标记');
+  overlay.fire('mousemove', { clientX: 302, clientY: 402 });
+  assert.strictEqual(h.lookups.length, 1, '4px 内抖动不得重复查词');
   overlay.fire('mouseleave');
-  assert.strictEqual(h.video.paused, false, '移开恢复播放');
   assert.strictEqual(overlay.style.filter, 'blur(6px)', '移开重新模糊');
+  assert.strictEqual(h.autoLookupResets(), 1, '移开应复位自动查词同词去重');
 });
 
-test('快捷键执行端：上一句/下一句/重播/复制/切换模式', () => {
+test('快捷键执行端：上一句/下一句/重播/复制/偏移', () => {
   const h = loadPanel({ stored: { netflixSubtitlePanel: true }, store: jaStore() });
   // 下一句：0ms → 句 1 句首。
   assert.strictEqual(h.shortcut('next-cue'), true);
@@ -221,9 +206,6 @@ test('快捷键执行端：上一句/下一句/重播/复制/切换模式', () =
   h.video.currentTime = 1.5;
   assert.strictEqual(h.shortcut('copy-cue'), true);
   assert.deepStrictEqual(h.clipboard, ['走り出した']);
-  // 切换精简播放：写穿 chrome.storage（options 页开关保持同步）。
-  assert.strictEqual(h.shortcut('toggle-condensed'), true);
-  assert.ok(h.storageSets.some((s) => s.subtitleCondensedPlayback === true), '必须写穿 storage');
   // 偏移快捷键：+100ms 两次 → 行 seek 用 1200ms。
   assert.strictEqual(h.shortcut('offset-plus'), true);
   assert.strictEqual(h.shortcut('offset-plus'), true);

--- a/tools/browser-extension/subtitle-panel.js
+++ b/tools/browser-extension/subtitle-panel.js
@@ -37,16 +37,16 @@
     pushSuspended: false, enabled: false,
     // B（外挂字幕）：用户主动打开面板（即使暂无轨也不自动拆）。
     forceOpen: false, offsetBar: null, offsetLabel: null,
-    overlayEnabled: true, dragDropEnabled: true, autoPause: false, condensedPlayback: false,
-    overlayEl: null, overlayCue: null, dropHint: null, lastCondensedTargetMs: -1,
+    overlayEnabled: true, dragDropEnabled: true,
+    overlayEl: null, overlayCue: null, dropHint: null,
     // asb 移植：任意轨（检测轨/外挂轨）的读取侧时轴偏移。store 永远存原始 cue，偏移只在
     // 面板/覆盖层/快捷键**读取时**套用——provider（textTracks 收割 / live 采样 / 整集拦截）
     // 增量刷新 store 不会与偏移打架。key = `${videoKey}|${lang}`，会话内记忆。
     trackOffsets: Object.create(null), builtOffset: 0,
-    // asb 移植：句首自动暂停 / 快进无字幕段 / 悬停暂停 / 覆盖层防剧透模糊 / 全轨覆盖层。
-    autoPauseAtStart: false, fastForward: false, hoverPause: false,
+    // 覆盖层防剧透模糊 / 全轨覆盖层 / 悬浮字幕自动查词。
+    overlayAutoLookup: false,
     overlayBlur: false, overlayAllTracks: false,
-    hoverPaused: false, overlayHovered: false, ffSavedRate: -1, lastAutoPauseIdx: -1,
+    overlayHovered: false, autoLookupLastX: -1, autoLookupLastY: -1,
   };
   var EXT_PREFIX = '外挂:';
 
@@ -358,12 +358,7 @@
     st.overlayEnabled = c.subtitleOverlayEnabled !== false;
     st.dragDropEnabled = c.subtitleDragDropEnabled !== false;
     st.autoScroll = c.subtitleAutoScroll !== false;
-    st.autoPause = c.subtitleAutoPause === true;
-    st.condensedPlayback = c.subtitleCondensedPlayback === true;
-    // asb 移植的扩展偏好（全部默认关，除快捷键在 video-shortcuts.js 自持默认开）。
-    st.autoPauseAtStart = c.subtitleAutoPauseAtStart === true;
-    st.fastForward = c.subtitleFastForwardPlayback === true;
-    st.hoverPause = c.subtitleHoverPause === true;
+    st.overlayAutoLookup = c.subtitleOverlayAutoLookup === true;
     st.overlayBlur = c.subtitleOverlayBlur === true;
     st.overlayAllTracks = c.subtitleOverlayAllTracks === true;
     if (!st.overlayEnabled) hideSubtitleOverlay();
@@ -375,11 +370,7 @@
       subtitleOverlayEnabled: st.overlayEnabled,
       subtitleDragDropEnabled: st.dragDropEnabled,
       subtitleAutoScroll: st.autoScroll,
-      subtitleAutoPause: st.autoPause,
-      subtitleCondensedPlayback: st.condensedPlayback,
-      subtitleAutoPauseAtStart: st.autoPauseAtStart,
-      subtitleFastForwardPlayback: st.fastForward,
-      subtitleHoverPause: st.hoverPause,
+      subtitleOverlayAutoLookup: st.overlayAutoLookup,
       subtitleOverlayBlur: st.overlayBlur,
       subtitleOverlayAllTracks: st.overlayAllTracks,
     };
@@ -388,8 +379,7 @@
   function readSubtitlePreferences() {
     var keys = [
       'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
-      'subtitleAutoPause', 'subtitleCondensedPlayback',
-      'subtitleAutoPauseAtStart', 'subtitleFastForwardPlayback', 'subtitleHoverPause',
+      'subtitleOverlayAutoLookup',
       'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
     ];
     try {
@@ -513,7 +503,6 @@
     var nowMs = videoTimeMs();
     var idx = cueIndexAt(st.cues, nowMs);
     updateSubtitleOverlay(idx >= 0 ? st.cues[idx] : null);
-    applyPlaybackMode(idx, nowMs);
     if (!st.panel || st.hidden) { st.currentIndex = idx; return; }
     if (idx === st.currentIndex) return;
     var prev = st.rowEls[st.currentIndex];
@@ -542,27 +531,34 @@
           });
         }
       });
-      // asb 移植：悬停暂停（pause-on-hover）——鼠标进覆盖层即暂停，方便查词；移出且确实是
-      // 因悬停而暂停时恢复播放（用户自己按的暂停不动）。防剧透模糊（blur）同一对监听里处理。
       el.addEventListener('mouseenter', function () {
         st.overlayHovered = true;
         applyOverlayBlur(el);
-        if (st.hoverPause) {
-          var v = videoEl();
-          if (v && !v.paused && typeof v.pause === 'function') {
-            try { v.pause(); st.hoverPaused = true; } catch (_) {}
-          }
-        }
+      });
+      // 悬浮字幕自动查词：只在覆盖层内启用，按与 content.js Shift 悬停同样的 4px 位移阈值
+      // 限流；取词、同词去重、在途闸和精确 cue 窗全部复用 hibikiLookupAtPoint。
+      el.addEventListener('mousemove', function (e) {
+        if (!st.overlayAutoLookup || !st.overlayCue ||
+            typeof window.hibikiLookupAtPoint !== 'function') return;
+        if (Math.abs(e.clientX - st.autoLookupLastX) < 4 &&
+            Math.abs(e.clientY - st.autoLookupLastY) < 4) return;
+        st.autoLookupLastX = e.clientX;
+        st.autoLookupLastY = e.clientY;
+        var cue = st.overlayCue;
+        window.hibikiLookupAtPoint(
+          e.clientX,
+          e.clientY,
+          { startMs: cue.startMs, endMs: cue.endMs, text: cue.text },
+          { auto: true },
+        );
       });
       el.addEventListener('mouseleave', function () {
         st.overlayHovered = false;
         applyOverlayBlur(el);
-        if (st.hoverPaused) {
-          st.hoverPaused = false;
-          var v = videoEl();
-          if (v && typeof v.play === 'function') {
-            Promise.resolve(v.play()).catch(function () {});
-          }
+        st.autoLookupLastX = -1;
+        st.autoLookupLastY = -1;
+        if (typeof window.hibikiResetAutoLookupDedupe === 'function') {
+          window.hibikiResetAutoLookupDedupe();
         }
       });
       st.overlayEl = el;
@@ -572,7 +568,7 @@
     return st.overlayEl;
   }
 
-  // asb 移植：防剧透模糊——覆盖层默认糊住，悬停即清晰（顺带触发悬停暂停，看+查一体）。
+  // 防剧透模糊——覆盖层默认糊住，悬停即清晰。
   function applyOverlayBlur(el) {
     if (!el || !el.style) return;
     var blurred = st.overlayBlur && !st.overlayHovered;
@@ -586,7 +582,7 @@
 
   function updateSubtitleOverlay(cue) {
     // 外挂轨恒显示；检测轨（站点自带字幕）默认不重复叠字，除非用户开了「全轨覆盖层」
-    // （overlayAllTracks，配合防剧透模糊/悬停暂停使用）。
+    // （overlayAllTracks，配合防剧透模糊/悬浮字幕自动查词使用）。
     if (!st.overlayEnabled || !cue ||
         (!isExternalLang(st.activeLang) && !st.overlayAllTracks)) {
       hideSubtitleOverlay();
@@ -613,60 +609,6 @@
       if (st.cues[mid].startMs > ms) { ans = mid; hi = mid - 1; } else { lo = mid + 1; }
     }
     return ans;
-  }
-
-  function applyPlaybackMode(idx, nowMs) {
-    var video = videoEl();
-    if (!video) return;
-    var previous = st.currentIndex;
-    // 自动暂停·句尾（既有默认）：上一句刚结束、尚未进入下一句时暂停。
-    if (st.autoPause && !st.autoPauseAtStart && previous >= 0 && idx < 0 &&
-        nowMs >= st.cues[previous].endMs && typeof video.pause === 'function') {
-      try { video.pause(); } catch (_) {}
-      return;
-    }
-    // asb 移植（AutoPausePreference.atStart）：自动暂停·句首——新句刚开播（<400ms，避免
-    // seek 进句中被误暂停）时暂停一次；同一句只暂停一次（用户继续播放后不再回按）。
-    if (st.autoPause && st.autoPauseAtStart && idx >= 0 && idx !== previous &&
-        idx !== st.lastAutoPauseIdx && nowMs - st.cues[idx].startMs < 400 &&
-        !video.paused && typeof video.pause === 'function') {
-      try { video.pause(); } catch (_) {}
-      st.lastAutoPauseIdx = idx;
-      return;
-    }
-    if (idx < 0) st.lastAutoPauseIdx = -1;
-    applyFastForward(video, idx, nowMs);
-    if (!st.condensedPlayback || st.autoPause || idx >= 0 || video.paused) {
-      if (idx >= 0) st.lastCondensedTargetMs = -1;
-      return;
-    }
-    var next = firstCueAfter(nowMs + 250);
-    if (next < 0) return;
-    var target = st.cues[next].startMs;
-    if (target - nowMs < 800 || target === st.lastCondensedTargetMs) return;
-    st.lastCondensedTargetMs = target;
-    seekTo(target);
-  }
-
-  // asb 移植（fastForward 播放模式）：无字幕区间倍速播过（asb 默认 2.7x），进句恢复原速。
-  // 与精简播放（直接跳过）互斥——精简开启时优先跳过；自动暂停开启时两者都不动。
-  function applyFastForward(video, idx, nowMs) {
-    var eligible = st.fastForward && !st.autoPause && !st.condensedPlayback &&
-        typeof video.playbackRate === 'number';
-    var inGap = false;
-    if (eligible && idx < 0 && !video.paused && st.cues.length) {
-      var next = firstCueAfter(nowMs + 250);
-      if (next >= 0 && st.cues[next].startMs - nowMs >= 800) inGap = true;
-    }
-    if (inGap) {
-      if (st.ffSavedRate < 0) {
-        st.ffSavedRate = video.playbackRate > 0 ? video.playbackRate : 1;
-        try { video.playbackRate = 2.7; } catch (_) {}
-      }
-    } else if (st.ffSavedRate >= 0) {
-      try { video.playbackRate = st.ffSavedRate; } catch (_) {}
-      st.ffSavedRate = -1;
-    }
   }
 
   function ensureMounted() {
@@ -951,15 +893,6 @@
     toast('已复制字幕：' + (text.length > 30 ? text.slice(0, 30) + '…' : text));
     return true;
   }
-  function togglePref(key, label) {
-    var snap = prefsSnapshot();
-    var next = snap[key] !== true;
-    snap[key] = next;
-    applySubtitlePreferences(snap); // 先行生效（无 chrome 环境的单测同样生效）
-    try { var patch = {}; patch[key] = next; chrome.storage.local.set(patch); } catch (_) {}
-    toast(label + (next ? '：开' : '：关'));
-    return true;
-  }
   function shortcutTogglePanel() {
     if (!st.enabled) {
       st.forceOpen = true;
@@ -984,9 +917,6 @@
       case 'offset-plus': return shortcutOffset(100);
       case 'offset-reset': return shortcutOffset(0);
       case 'copy-cue': return shortcutCopyCue();
-      case 'toggle-autopause': return togglePref('subtitleAutoPause', '自动暂停');
-      case 'toggle-condensed': return togglePref('subtitleCondensedPlayback', '精简播放');
-      case 'toggle-fastforward': return togglePref('subtitleFastForwardPlayback', '快进无字幕段');
       case 'toggle-panel': return shortcutTogglePanel();
       // 隐藏字幕：状态与 style 注入由 content.js 独占（见那里的「所有权」注释）——面板整体
       // 受 netflixSubtitlePanel 门控且默认关，状态放这里会导致「没开面板就不能隐藏字幕」。
@@ -1040,8 +970,7 @@
       var changed = false;
       var keys = [
         'subtitleOverlayEnabled', 'subtitleDragDropEnabled', 'subtitleAutoScroll',
-        'subtitleAutoPause', 'subtitleCondensedPlayback',
-        'subtitleAutoPauseAtStart', 'subtitleFastForwardPlayback', 'subtitleHoverPause',
+        'subtitleOverlayAutoLookup',
         'subtitleOverlayBlur', 'subtitleOverlayAllTracks',
       ];
       for (var i = 0; i < keys.length; i++) {

--- a/tools/browser-extension/video-shortcuts.js
+++ b/tools/browser-extension/video-shortcuts.js
@@ -1,8 +1,7 @@
-// asb 移植：视频页快捷键（content script 隔离世界，manifest bundle 里排在 subtitle-panel.js
-// 之后加载）。键位与 asbplayer 默认键对齐（差异见 README「快捷键」表）：
+// 视频页快捷键（content script 隔离世界，manifest bundle 里排在 subtitle-panel.js
+// 之后加载）。每个动作在 options 里有独立开关：
 //   ←/→        上一句 / 下一句字幕（仅当前视频有字幕轨时接管，否则放行给站点）
 //   ↑           回当前句句首重播
-//   Shift+P/O/F 开关 自动暂停 / 精简播放 / 快进无字幕段
 //   Shift+S     开关字幕列表面板
 //   Shift+H     隐藏/显示字幕（站点原生字幕 + 扩展覆盖层，与 app 内视频页同键）
 //   Ctrl+Enter  制卡（等同点查词弹窗里的「＋」；判定不在本文件，见 vendor/popup.js）
@@ -11,7 +10,7 @@
 //   Ctrl+Shift+[ / ]  播放速度 −0.25x / ＋0.25x
 // 判定是纯函数 decide()（node 可测）；执行端是 subtitle-panel.js 暴露的
 // window.hibikiSubtitleShortcut(action)（面板持有轨/偏移/模式状态），播放速度直接操作 <video>。
-// 输入框/可编辑区一律放行；options 的 videoShortcutsEnabled（默认开）可整体关闭。
+// 输入框/可编辑区一律放行；旧 videoShortcutsEnabled 只作为升级时各动作的缺省值。
 (function (root, factory) {
   var api = factory();
   try { if (typeof module !== 'undefined' && module.exports) module.exports = api; } catch (_) { /* no-op */ }
@@ -26,14 +25,17 @@
     if (ev.alt) return null;
     var key = ev.key || '';
     var code = ev.code || '';
+    function result(action) {
+      return !ctx.bindings || ctx.bindings[action] !== false ? { action: action } : null;
+    }
     if (ev.ctrl && ev.shift) {
-      if (key === 'ArrowLeft') return ctx.hasTrack ? { action: 'offset-minus' } : null;
-      if (key === 'ArrowRight') return ctx.hasTrack ? { action: 'offset-plus' } : null;
-      if (key === 'ArrowDown') return ctx.hasTrack ? { action: 'offset-reset' } : null;
-      if (code === 'KeyZ') return ctx.hasTrack ? { action: 'copy-cue' } : null;
+      if (key === 'ArrowLeft') return ctx.hasTrack ? result('offset-minus') : null;
+      if (key === 'ArrowRight') return ctx.hasTrack ? result('offset-plus') : null;
+      if (key === 'ArrowDown') return ctx.hasTrack ? result('offset-reset') : null;
+      if (code === 'KeyZ') return ctx.hasTrack ? result('copy-cue') : null;
       // 括号键在 Shift 下 e.key 会变成 '{' / '}'，用布局无关的 e.code。
-      if (code === 'BracketLeft') return { action: 'rate-down' };
-      if (code === 'BracketRight') return { action: 'rate-up' };
+      if (code === 'BracketLeft') return result('rate-down');
+      if (code === 'BracketRight') return result('rate-up');
       return null;
     }
     if (ev.ctrl) return null;
@@ -42,17 +44,14 @@
       // YouTube 自带轨）+ 扩展自绘覆盖层，而 hasTrack 问的是「扩展这边有没有加载过字幕轨」。
       // 二者正交——绝大多数用户是在看站点原生字幕、根本没往扩展里挂轨，若卡在 hasTrack 后面，
       // 这个键在最主要的使用场景下会永远不触发。与 app 的 videoToggleSubtitleHide 默认键一致。
-      if (code === 'KeyH') return { action: 'toggle-subtitle-hide' };
+      if (code === 'KeyH') return result('toggle-subtitle-hide');
       if (!ctx.hasTrack) return null;
-      if (code === 'KeyP') return { action: 'toggle-autopause' };
-      if (code === 'KeyO') return { action: 'toggle-condensed' };
-      if (code === 'KeyF') return { action: 'toggle-fastforward' };
-      if (code === 'KeyS') return { action: 'toggle-panel' };
+      if (code === 'KeyS') return result('toggle-panel');
       return null;
     }
-    if (key === 'ArrowLeft') return ctx.hasTrack ? { action: 'prev-cue' } : null;
-    if (key === 'ArrowRight') return ctx.hasTrack ? { action: 'next-cue' } : null;
-    if (key === 'ArrowUp') return ctx.hasTrack ? { action: 'replay-cue' } : null;
+    if (key === 'ArrowLeft') return ctx.hasTrack ? result('prev-cue') : null;
+    if (key === 'ArrowRight') return ctx.hasTrack ? result('next-cue') : null;
+    if (key === 'ArrowUp') return ctx.hasTrack ? result('replay-cue') : null;
     return null;
   }
 
@@ -69,21 +68,53 @@
 (function () {
   if (typeof window === 'undefined' || typeof document === 'undefined') return;
   var api = (typeof self !== 'undefined' ? self : window).HIBIKI_VIDEO_SHORTCUTS;
-  var enabled = true;
+  var bindingKeys = {
+    'prev-cue': 'videoShortcutPrevCue',
+    'next-cue': 'videoShortcutNextCue',
+    'replay-cue': 'videoShortcutReplayCue',
+    'toggle-panel': 'videoShortcutTogglePanel',
+    'toggle-subtitle-hide': 'videoShortcutToggleSubtitleHide',
+    'offset-minus': 'videoShortcutOffsetMinus',
+    'offset-plus': 'videoShortcutOffsetPlus',
+    'offset-reset': 'videoShortcutOffsetReset',
+    'copy-cue': 'videoShortcutCopyCue',
+    'rate-down': 'videoShortcutRateDown',
+    'rate-up': 'videoShortcutRateUp',
+  };
+  var rawSettings = Object.create(null);
+  var bindings = Object.create(null);
 
-  function applyEnabled(saved) {
-    // 缺省/非 false 一律视为开启（默认开）。
-    enabled = !(saved && saved.videoShortcutsEnabled === false);
+  function applySettings(saved) {
+    saved = saved || {};
+    for (var k in saved) rawSettings[k] = saved[k];
+    var legacyEnabled = rawSettings.videoShortcutsEnabled !== false;
+    for (var action in bindingKeys) {
+      var value = rawSettings[bindingKeys[action]];
+      bindings[action] = typeof value === 'boolean' ? value : legacyEnabled;
+    }
   }
   try {
-    var p = chrome.storage.local.get('videoShortcutsEnabled');
-    if (p && typeof p.then === 'function') p.then(applyEnabled, function () {});
-    else chrome.storage.local.get('videoShortcutsEnabled', applyEnabled);
+    var keys = ['videoShortcutsEnabled'];
+    for (var action in bindingKeys) keys.push(bindingKeys[action]);
+    var p = chrome.storage.local.get(keys, applySettings);
+    if (p && typeof p.then === 'function') p.then(applySettings, function () {});
   } catch (_) {}
   try {
     chrome.storage.onChanged.addListener(function (changes, area) {
-      if (area !== 'local' || !changes || !changes.videoShortcutsEnabled) return;
-      enabled = changes.videoShortcutsEnabled.newValue !== false;
+      if (area !== 'local' || !changes) return;
+      var patch = {};
+      var changed = false;
+      if (changes.videoShortcutsEnabled) {
+        patch.videoShortcutsEnabled = changes.videoShortcutsEnabled.newValue;
+        changed = true;
+      }
+      for (var action in bindingKeys) {
+        var key = bindingKeys[action];
+        if (!changes[key]) continue;
+        patch[key] = changes[key].newValue;
+        changed = true;
+      }
+      if (changed) applySettings(patch);
     });
   } catch (_) {}
 
@@ -136,9 +167,10 @@
         editable: isEditable(e.target),
       },
       {
-        enabled: enabled,
+        enabled: true,
         hasVideo: !!document.querySelector('video'),
         hasTrack: hasTrackForVideo(),
+        bindings: bindings,
       });
     if (!decision) return;
     var handled = false;

--- a/tools/browser-extension/video-shortcuts.test.js
+++ b/tools/browser-extension/video-shortcuts.test.js
@@ -99,6 +99,136 @@ function createRuntime(initialSettings = {}, { hasTrack = true } = {}) {
   };
 }
 
+function makeOptionsElement(id) {
+  const listeners = Object.create(null);
+  const element = {
+    id,
+    value: '',
+    placeholder: '',
+    checked: false,
+    disabled: false,
+    open: false,
+    type: id === 'token' ? 'password' : '',
+    textContent: '',
+    dataset: {},
+    classList: { add() {}, remove() {} },
+    addEventListener(type, listener) {
+      (listeners[type] = listeners[type] || []).push(listener);
+    },
+    async fire(type) {
+      for (const listener of listeners[type] || []) {
+        await listener({ preventDefault() {} });
+      }
+    },
+    closest() {
+      return {
+        querySelector() {
+          return { textContent: id };
+        },
+      };
+    },
+  };
+  return element;
+}
+
+async function loadOptionsRuntime(initialSettings = {}) {
+  const storage = { ...initialSettings };
+  const writes = [];
+  const storageListeners = [];
+  const ids = [
+    'nfSubList',
+    'subtitleOverlayEnabled',
+    'subtitleDragDropEnabled',
+    'subtitleAutoScroll',
+    'nfHideNext',
+    'subtitlePauseOnLookup',
+    'subtitleOverlayAutoLookup',
+    'subtitleOverlayBlur',
+    'subtitleOverlayAllTracks',
+    'subtitleHidden',
+    ...shortcutSettingIds,
+    'host',
+    'port',
+    'token',
+    'connectionCard',
+    'connTitle',
+    'connDetail',
+    'connEndpoint',
+    'check',
+    'advancedConnection',
+    'connectionForm',
+    'reset',
+    'showToken',
+    'status',
+    'updTitle',
+    'updDetail',
+    'updBuild',
+  ];
+  const elements = Object.fromEntries(ids.map((id) => [id, makeOptionsElement(id)]));
+  const self = {
+    HIBIKI_DEFAULTS: { host: '127.0.0.1', port: 19633, token: '' },
+    HIBIKI_CONNECTION: {
+      states: { unauthorized: 'unauthorized', wrongService: 'wrong-service' },
+      copy() {
+        return { tone: 'good', title: '已连接', detail: '测试连接正常' };
+      },
+    },
+    HIBIKI_SELF_UPDATE: {
+      describeUpdateState() {
+        return { title: '已是最新', detail: '测试 build', build: 'test' };
+      },
+    },
+  };
+  const context = {
+    self,
+    document: {
+      getElementById(id) {
+        return elements[id] || null;
+      },
+    },
+    chrome: {
+      runtime: {
+        lastError: null,
+        sendMessage(_message, callback) {
+          callback({
+            connection: {
+              state: 'online',
+              port: 19633,
+              base: 'http://127.0.0.1:19633',
+            },
+          });
+        },
+      },
+      storage: {
+        local: {
+          async get(keys) {
+            const result = {};
+            for (const key of Array.isArray(keys) ? keys : [keys]) {
+              if (Object.hasOwn(storage, key)) result[key] = storage[key];
+            }
+            return result;
+          },
+          async set(patch) {
+            writes.push(patch);
+            Object.assign(storage, patch);
+          },
+        },
+        onChanged: {
+          addListener(listener) {
+            storageListeners.push(listener);
+          },
+        },
+      },
+    },
+    setTimeout() { return 1; },
+    clearTimeout() {},
+  };
+  vm.runInNewContext(optionsJs, context, { filename: 'options.js' });
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  return { elements, storage, writes, storageListeners };
+}
+
 test('options 把每个视频快捷键动作拆成独立开关', () => {
   for (const id of shortcutSettingIds) {
     assert.ok(optionsHtml.includes(`id="${id}"`), `options.html 缺独立快捷键开关 ${id}`);
@@ -108,6 +238,35 @@ test('options 把每个视频快捷键动作拆成独立开关', () => {
   assert.ok(!optionsHtml.includes('Shift+P/O/F'), '已删除的播放模式快捷键不得继续展示');
   assert.ok(optionsHtml.includes('id="subtitleHidden"'), '隐藏字幕实际状态仍须保留独立设置入口');
   assert.ok(optionsJs.includes("subtitleHidden: 'subtitleHidden'"), 'options.js 必须持久化隐藏字幕状态');
+});
+
+test('options runtime 真正回读默认/legacy/显式值，change 后 storage.set 并可重载读回', async () => {
+  const defaults = await loadOptionsRuntime();
+  assert.strictEqual(defaults.elements.videoShortcutPrevCue.checked, true,
+    '无存量时逐动作快捷键默认开启');
+  assert.strictEqual(defaults.elements.videoShortcutToggleSubtitleHide.checked, true,
+    'Shift+H 独立动作无存量时默认开启');
+
+  const legacy = await loadOptionsRuntime({
+    videoShortcutsEnabled: false,
+    videoShortcutPrevCue: true,
+  });
+  assert.strictEqual(legacy.elements.videoShortcutPrevCue.checked, true,
+    '新单项显式 true 必须优先于 legacy false');
+  assert.strictEqual(legacy.elements.videoShortcutNextCue.checked, false,
+    '未显式的新单项必须回退 legacy false');
+
+  legacy.elements.videoShortcutNextCue.checked = true;
+  await legacy.elements.videoShortcutNextCue.fire('change');
+  assert.strictEqual(legacy.writes.length, 1, 'change 必须真实调用 storage.set');
+  assert.strictEqual(legacy.writes[0].videoShortcutNextCue, true,
+    'storage.set 必须写入对应逐动作 key');
+  assert.strictEqual(legacy.storage.videoShortcutNextCue, true,
+    '持久化层必须保存 change 后的值');
+
+  const reloaded = await loadOptionsRuntime(legacy.storage);
+  assert.strictEqual(reloaded.elements.videoShortcutNextCue.checked, true,
+    '重新加载 options 后必须读回刚持久化的显式值');
 });
 
 test('←/→/↑：有轨时接管为上一句/下一句/重播本句', () => {

--- a/tools/browser-extension/video-shortcuts.test.js
+++ b/tools/browser-extension/video-shortcuts.test.js
@@ -3,15 +3,112 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const vm = require('node:vm');
 const { decide, nextRate } = require('./video-shortcuts.js');
+const optionsHtml = fs.readFileSync(require.resolve('./options.html'), 'utf8');
+const optionsJs = fs.readFileSync(require.resolve('./options.js'), 'utf8');
 
 // asb 移植：视频页快捷键判定矩阵。decide 是纯函数：ev={key,code,ctrl,shift,alt,editable}，
 // ctx={enabled,hasVideo,hasTrack}，返回 {action} 或 null（null = 放行给站点）。
 
 const CTX = { enabled: true, hasVideo: true, hasTrack: true };
+const shortcutSettingIds = [
+  'videoShortcutPrevCue',
+  'videoShortcutNextCue',
+  'videoShortcutReplayCue',
+  'videoShortcutTogglePanel',
+  'videoShortcutToggleSubtitleHide',
+  'videoShortcutOffsetMinus',
+  'videoShortcutOffsetPlus',
+  'videoShortcutOffsetReset',
+  'videoShortcutCopyCue',
+  'videoShortcutRateDown',
+  'videoShortcutRateUp',
+];
 
 function ev(over) {
   return Object.assign({ key: '', code: '', ctrl: false, shift: false, alt: false, editable: false }, over);
 }
+
+function createRuntime(initialSettings = {}, { hasTrack = true } = {}) {
+  const source = fs.readFileSync(require.resolve('./video-shortcuts.js'), 'utf8');
+  let keydown;
+  let storageChanged;
+  let requestedKeys;
+  const actions = [];
+  const video = { playbackRate: 1 };
+  const fakeWindow = {
+    hibikiEpisodeCues: hasTrack ? { 'episode|ja': [{ start: 0, end: 1, text: '字幕' }] } : {},
+    hibikiVideoKey: () => 'episode',
+    hibikiSubtitleShortcut(action) {
+      actions.push(action);
+      return true;
+    },
+    addEventListener(type, handler) {
+      if (type === 'keydown') keydown = handler;
+    },
+  };
+  const context = {
+    self: fakeWindow,
+    window: fakeWindow,
+    document: {
+      querySelector(selector) {
+        return selector === 'video' ? video : null;
+      },
+    },
+    chrome: {
+      storage: {
+        local: {
+          get(keys, callback) {
+            requestedKeys = Array.isArray(keys) ? [...keys] : [keys];
+            if (typeof callback === 'function') callback({ ...initialSettings });
+          },
+        },
+        onChanged: {
+          addListener(listener) {
+            storageChanged = listener;
+          },
+        },
+      },
+    },
+  };
+  vm.runInNewContext(source, context);
+  assert.strictEqual(typeof keydown, 'function');
+  assert.strictEqual(typeof storageChanged, 'function');
+
+  return {
+    actions,
+    requestedKeys,
+    key(overrides) {
+      let prevented = false;
+      let stopped = false;
+      keydown(Object.assign({
+        key: '',
+        code: '',
+        shiftKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        altKey: false,
+        target: null,
+        preventDefault() { prevented = true; },
+        stopPropagation() { stopped = true; },
+      }, overrides));
+      return { prevented, stopped };
+    },
+    change(key, newValue) {
+      storageChanged({ [key]: { newValue } }, 'local');
+    },
+  };
+}
+
+test('options 把每个视频快捷键动作拆成独立开关', () => {
+  for (const id of shortcutSettingIds) {
+    assert.ok(optionsHtml.includes(`id="${id}"`), `options.html 缺独立快捷键开关 ${id}`);
+    assert.ok(optionsJs.includes(`${id}: '${id}'`), `options.js 未持久化 ${id}`);
+  }
+  assert.ok(!optionsHtml.includes('id="videoShortcutsEnabled"'), '不得保留把快捷键塞成一坨的总开关');
+  assert.ok(!optionsHtml.includes('Shift+P/O/F'), '已删除的播放模式快捷键不得继续展示');
+  assert.ok(optionsHtml.includes('id="subtitleHidden"'), '隐藏字幕实际状态仍须保留独立设置入口');
+  assert.ok(optionsJs.includes("subtitleHidden: 'subtitleHidden'"), 'options.js 必须持久化隐藏字幕状态');
+});
 
 test('←/→/↑：有轨时接管为上一句/下一句/重播本句', () => {
   assert.deepStrictEqual(decide(ev({ key: 'ArrowLeft' }), CTX), { action: 'prev-cue' });
@@ -26,27 +123,31 @@ test('←/→/↑：无字幕轨一律放行（站点自己的 5s 快进/音量�
   assert.strictEqual(decide(ev({ key: 'ArrowUp' }), noTrack), null);
 });
 
-test('Shift+P/O/F/S：仅有 Hibiki 字幕轨时切换播放模式与面板', () => {
+test('Shift+S：仅有 Hibiki 字幕轨时切换面板；旧 Shift+P/O/F 不再接管', () => {
   const noTrack = { enabled: true, hasVideo: true, hasTrack: false };
   assert.strictEqual(decide(ev({ shift: true, code: 'KeyP' }), noTrack), null);
   assert.strictEqual(decide(ev({ shift: true, code: 'KeyO' }), noTrack), null);
   assert.strictEqual(decide(ev({ shift: true, code: 'KeyF' }), noTrack), null);
   assert.strictEqual(decide(ev({ shift: true, code: 'KeyS' }), noTrack), null);
-  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyP' }), CTX), { action: 'toggle-autopause' });
-  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyO' }), CTX), { action: 'toggle-condensed' });
-  assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyF' }), CTX), { action: 'toggle-fastforward' });
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyP' }), CTX), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyO' }), CTX), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyF' }), CTX), null);
   assert.deepStrictEqual(decide(ev({ shift: true, code: 'KeyS' }), CTX), { action: 'toggle-panel' });
 });
 
-test('Shift+H：隐藏字幕**不需要**字幕轨（藏的是站点原生字幕）', () => {
-  // 这是本键与 Shift+P/O/F/S 的关键差异，也是最容易写错的地方：hasTrack 问的是「扩展这边
-  // 加载过字幕轨没有」，而隐藏字幕作用的是站点自带字幕 + 扩展覆盖层。绝大多数用户看的是
-  // 站点原生字幕、从没往扩展里挂过轨——若卡在 hasTrack 门后面，这个键在主场景下永不触发。
+test('Shift+H：隐藏字幕不需要扩展字幕轨，并受独立动作开关控制', () => {
   const noTrack = { enabled: true, hasVideo: true, hasTrack: false };
   assert.deepStrictEqual(
-    decide(ev({ shift: true, code: 'KeyH' }), noTrack), { action: 'toggle-subtitle-hide' });
-  assert.deepStrictEqual(
-    decide(ev({ shift: true, code: 'KeyH' }), CTX), { action: 'toggle-subtitle-hide' });
+    decide(ev({ shift: true, code: 'KeyH' }), noTrack),
+    { action: 'toggle-subtitle-hide' },
+  );
+  assert.strictEqual(
+    decide(
+      ev({ shift: true, code: 'KeyH' }),
+      { ...noTrack, bindings: { 'toggle-subtitle-hide': false } },
+    ),
+    null,
+  );
 });
 
 test('Shift+H：无视频 / 输入框 / 加 Ctrl 或 Alt 时不接管', () => {
@@ -54,10 +155,30 @@ test('Shift+H：无视频 / 输入框 / 加 Ctrl 或 Alt 时不接管', () => {
   assert.strictEqual(decide(ev({ shift: true, code: 'KeyH' }), noVideo), null);
   assert.strictEqual(decide(ev({ shift: true, code: 'KeyH', editable: true }), CTX), null);
   assert.strictEqual(decide(ev({ shift: true, alt: true, code: 'KeyH' }), CTX), null);
-  // Ctrl+Shift+H 落进上面的 ctrl+shift 分支，未登记 → 放行（不误吞浏览器/站点组合键）。
   assert.strictEqual(decide(ev({ ctrl: true, shift: true, code: 'KeyH' }), CTX), null);
-  // 裸 H 交给站点（很多播放器自己用它），只有带 Shift 才是我们的。
   assert.strictEqual(decide(ev({ key: 'h', code: 'KeyH' }), CTX), null);
+});
+
+test('每个快捷键动作可独立关闭，不影响其它动作', () => {
+  const ctx = {
+    ...CTX,
+    bindings: {
+      'prev-cue': false,
+      'next-cue': true,
+      'rate-down': false,
+      'rate-up': true,
+    },
+  };
+  assert.strictEqual(decide(ev({ key: 'ArrowLeft' }), ctx), null);
+  assert.deepStrictEqual(decide(ev({ key: 'ArrowRight' }), ctx), { action: 'next-cue' });
+  assert.strictEqual(
+    decide(ev({ ctrl: true, shift: true, code: 'BracketLeft' }), ctx),
+    null,
+  );
+  assert.deepStrictEqual(
+    decide(ev({ ctrl: true, shift: true, code: 'BracketRight' }), ctx),
+    { action: 'rate-up' },
+  );
 });
 
 test('Ctrl+Shift+←/→/↓/Z：偏移与复制（需字幕轨）', () => {
@@ -85,9 +206,12 @@ test('输入框/可编辑区/Alt 组合/关闭开关/无视频：一律放行', 
   assert.strictEqual(decide(ev({ key: 'ArrowLeft' }), { enabled: true, hasVideo: false, hasTrack: true }), null);
 });
 
-test('普通打字（Shift+字母之外）不接管', () => {
+test('普通打字与已移除的 Shift+P/O/F 不接管', () => {
   assert.strictEqual(decide(ev({ key: 'a', code: 'KeyA' }), CTX), null);
   assert.strictEqual(decide(ev({ shift: true, code: 'KeyQ' }), CTX), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyP' }), CTX), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyO' }), CTX), null);
+  assert.strictEqual(decide(ev({ shift: true, code: 'KeyF' }), CTX), null);
   assert.strictEqual(decide(ev({ ctrl: true, code: 'KeyC' }), CTX), null); // Ctrl+C 复制绝不抢
 });
 
@@ -99,47 +223,82 @@ test('nextRate：0.25 步进、clamp 0.25–4', () => {
   assert.strictEqual(nextRate(undefined, 0.25), 1.25); // 坏输入按 1x 起步
 });
 
-test('runtime leaves site Shift shortcuts untouched without a Hibiki track', () => {
-  const source = fs.readFileSync(require.resolve('./video-shortcuts.js'), 'utf8');
-  let keydown;
-  const fakeWindow = {
-    addEventListener(type, handler) {
-      if (type === 'keydown') keydown = handler;
-    },
-  };
-  const context = {
-    self: fakeWindow,
-    window: fakeWindow,
-    document: {
-      querySelector(selector) {
-        return selector === 'video' ? { playbackRate: 1 } : null;
-      },
-    },
-    chrome: {
-      storage: {
-        local: { get: () => Promise.resolve({ videoShortcutsEnabled: true }) },
-        onChanged: { addListener() {} },
-      },
-    },
-  };
-  vm.runInNewContext(source, context);
-  assert.strictEqual(typeof keydown, 'function');
+test('runtime 初始 storage 映射默认开启，legacy false 回退且新单项显式值优先', () => {
+  const defaults = createRuntime();
+  assert.ok(defaults.requestedKeys.includes('videoShortcutsEnabled'));
+  for (const id of shortcutSettingIds) assert.ok(defaults.requestedKeys.includes(id), `runtime 未读取 ${id}`);
+  assert.deepStrictEqual(
+    defaults.key({ key: 'ArrowLeft', code: 'ArrowLeft' }),
+    { prevented: true, stopped: true },
+  );
+  assert.deepStrictEqual(defaults.actions, ['prev-cue']);
+
+  const legacyOff = createRuntime({ videoShortcutsEnabled: false });
+  assert.deepStrictEqual(
+    legacyOff.key({ key: 'ArrowLeft', code: 'ArrowLeft' }),
+    { prevented: false, stopped: false },
+  );
+
+  const explicitWins = createRuntime({
+    videoShortcutsEnabled: false,
+    videoShortcutNextCue: true,
+  });
+  assert.deepStrictEqual(
+    explicitWins.key({ key: 'ArrowLeft', code: 'ArrowLeft' }),
+    { prevented: false, stopped: false },
+  );
+  assert.deepStrictEqual(
+    explicitWins.key({ key: 'ArrowRight', code: 'ArrowRight' }),
+    { prevented: true, stopped: true },
+  );
+  assert.deepStrictEqual(explicitWins.actions, ['next-cue']);
+});
+
+test('runtime storage.onChanged 热更新单项开关，不影响其它动作', () => {
+  const runtime = createRuntime({
+    videoShortcutPrevCue: true,
+    videoShortcutNextCue: true,
+  });
+  runtime.change('videoShortcutPrevCue', false);
+  assert.deepStrictEqual(
+    runtime.key({ key: 'ArrowLeft', code: 'ArrowLeft' }),
+    { prevented: false, stopped: false },
+  );
+  assert.deepStrictEqual(
+    runtime.key({ key: 'ArrowRight', code: 'ArrowRight' }),
+    { prevented: true, stopped: true },
+  );
+  runtime.change('videoShortcutPrevCue', true);
+  assert.deepStrictEqual(
+    runtime.key({ key: 'ArrowLeft', code: 'ArrowLeft' }),
+    { prevented: true, stopped: true },
+  );
+  assert.deepStrictEqual(runtime.actions, ['next-cue', 'prev-cue']);
+});
+
+test('runtime 实际 keydown 只接管已开启动作；Shift+H 无扩展轨仍可独立关闭', () => {
+  const runtime = createRuntime({
+    videoShortcutPrevCue: false,
+    videoShortcutNextCue: true,
+    videoShortcutToggleSubtitleHide: true,
+  }, { hasTrack: false });
 
   for (const code of ['KeyP', 'KeyO', 'KeyF', 'KeyS']) {
-    let prevented = false;
-    let stopped = false;
-    keydown({
-      key: code.slice(-1),
-      code,
-      shiftKey: true,
-      ctrlKey: false,
-      metaKey: false,
-      altKey: false,
-      target: null,
-      preventDefault() { prevented = true; },
-      stopPropagation() { stopped = true; },
-    });
-    assert.strictEqual(prevented, false, `${code} must remain available to the site`);
-    assert.strictEqual(stopped, false, `${code} must continue propagating`);
+    assert.deepStrictEqual(
+      runtime.key({ key: code.slice(-1), code, shiftKey: true }),
+      { prevented: false, stopped: false },
+      `${code} must remain available to the site without a Hibiki track`,
+    );
   }
+  assert.deepStrictEqual(
+    runtime.key({ key: 'H', code: 'KeyH', shiftKey: true }),
+    { prevented: true, stopped: true },
+  );
+  assert.deepStrictEqual(runtime.actions, ['toggle-subtitle-hide']);
+
+  runtime.change('videoShortcutToggleSubtitleHide', false);
+  assert.deepStrictEqual(
+    runtime.key({ key: 'H', code: 'KeyH', shiftKey: true }),
+    { prevented: false, stopped: false },
+  );
 });


### PR DESCRIPTION
## 变更内容

- 删除“每句结束时自动暂停”“精简播放”“自动暂停改在句首”“快进无字幕段”四项旧播放设置
- 将“悬停字幕时暂停”改为用户可控的“查词时暂停”
- 新增“悬浮字幕自动查词”，悬停单词即可发起查词
- 将视频快捷键移到独立设置区，并为每个操作提供单独开关
- 保留旧设置键的只读迁移兼容，新设置使用独立键保存
- 同步浏览器扩展源码、Hibiki 内置镜像、说明文档与防回归测试

## 用户影响

设置页不再混杂已移除的播放模式。查词暂停只在实际发起查词时触发；悬浮字幕可按需自动查词。快捷键可以逐项开启或关闭。

## 验证

- `node --check`：扩展关键脚本通过
- `node --test`：156 项通过，0 失败
- 按 canonical mirror 规则核对 28 个内置扩展文件，内容完全一致
- `git diff --check` 通过

按需求未等待 Flutter 编译验收。`dart run tool/sync_browser_extension.dart` 启动时受 pdfium 构建钩子下载超时影响未完成，镜像已通过逐文件 SHA-256 比较确认一致。