### PR TITLE
fix(tracking): retry matching and backfill manual links

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46733 (2749 per locale)
+/// Strings: 46784 (2752 per locale)
 ///
-/// Built on 2026-07-28 at 17:15 UTC
+/// Built on 2026-07-29 at 04:02 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3693,6 +3693,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get library_view_media => 'Library';
   String get scrape_failure_detail_show => 'Show details';
   String get scrape_failure_detail_hide => 'Hide details';
+  String get media_tracking_retry_mapping => 'Retry matching';
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -9983,6 +9988,14 @@ class _StringsAr extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -16341,6 +16354,14 @@ class _StringsDe extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -22715,6 +22736,14 @@ class _StringsEs extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -29100,6 +29129,14 @@ class _StringsFr extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -35414,6 +35451,14 @@ class _StringsId extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -41774,6 +41819,14 @@ class _StringsIt extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -47951,6 +48004,14 @@ class _StringsJa extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -54130,6 +54191,14 @@ class _StringsKo extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -60470,6 +60539,14 @@ class _StringsNl extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -66823,6 +66900,14 @@ class _StringsPtBr extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -73160,6 +73245,14 @@ class _StringsRu extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -79445,6 +79538,14 @@ class _StringsTh extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -85762,6 +85863,14 @@ class _StringsTr extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -92064,6 +92173,14 @@ class _StringsVi extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 // Path: <root>
@@ -97921,6 +98038,12 @@ class _StringsZhCn extends _StringsEn {
   String get scrape_failure_detail_show => '显示详情';
   @override
   String get scrape_failure_detail_hide => '隐藏详情';
+  @override
+  String get media_tracking_retry_mapping => '重试匹配';
+  @override
+  String get media_tracking_retry_matched => '已重新关联并补发当前进度';
+  @override
+  String get media_tracking_retry_no_match => '仍未匹配到条目，请尝试手动关联';
 }
 
 // Path: <root>
@@ -104019,6 +104142,14 @@ class _StringsZhHk extends _StringsEn {
   String get scrape_failure_detail_show => 'Show details';
   @override
   String get scrape_failure_detail_hide => 'Hide details';
+  @override
+  String get media_tracking_retry_mapping => 'Retry matching';
+  @override
+  String get media_tracking_retry_matched =>
+      'Matched and queued current progress';
+  @override
+  String get media_tracking_retry_no_match =>
+      'No match found. Try manual linking.';
 }
 
 /// Flat map(s) containing all translations.
@@ -109650,6 +109781,12 @@ extension on _StringsEn {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -115279,6 +115416,12 @@ extension on _StringsAr {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -120929,6 +121072,12 @@ extension on _StringsDe {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -126578,6 +126727,12 @@ extension on _StringsEs {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -132233,6 +132388,12 @@ extension on _StringsFr {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -137870,6 +138031,12 @@ extension on _StringsId {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -143522,6 +143689,12 @@ extension on _StringsIt {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -149136,6 +149309,12 @@ extension on _StringsJa {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -154754,6 +154933,12 @@ extension on _StringsKo {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -160399,6 +160584,12 @@ extension on _StringsNl {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -166041,6 +166232,12 @@ extension on _StringsPtBr {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -171688,6 +171885,12 @@ extension on _StringsRu {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -177319,6 +177522,12 @@ extension on _StringsTh {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -182959,6 +183168,12 @@ extension on _StringsTr {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -188594,6 +188809,12 @@ extension on _StringsVi {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }
@@ -194183,6 +194404,12 @@ extension on _StringsZhCn {
         return '显示详情';
       case 'scrape_failure_detail_hide':
         return '隐藏详情';
+      case 'media_tracking_retry_mapping':
+        return '重试匹配';
+      case 'media_tracking_retry_matched':
+        return '已重新关联并补发当前进度';
+      case 'media_tracking_retry_no_match':
+        return '仍未匹配到条目，请尝试手动关联';
       default:
         return null;
     }
@@ -199792,6 +200019,12 @@ extension on _StringsZhHk {
         return 'Show details';
       case 'scrape_failure_detail_hide':
         return 'Hide details';
+      case 'media_tracking_retry_mapping':
+        return 'Retry matching';
+      case 'media_tracking_retry_matched':
+        return 'Matched and queued current progress';
+      case 'media_tracking_retry_no_match':
+        return 'No match found. Try manual linking.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "来源",
   "library_view_media": "媒体库",
   "scrape_failure_detail_show": "显示详情",
-  "scrape_failure_detail_hide": "隐藏详情"
+  "scrape_failure_detail_hide": "隐藏详情",
+  "media_tracking_retry_mapping": "重试匹配",
+  "media_tracking_retry_matched": "已重新关联并补发当前进度",
+  "media_tracking_retry_no_match": "仍未匹配到条目，请尝试手动关联"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2747,5 +2747,8 @@
   "library_view_sources": "Sources",
   "library_view_media": "Library",
   "scrape_failure_detail_show": "Show details",
-  "scrape_failure_detail_hide": "Hide details"
+  "scrape_failure_detail_hide": "Hide details",
+  "media_tracking_retry_mapping": "Retry matching",
+  "media_tracking_retry_matched": "Matched and queued current progress",
+  "media_tracking_retry_no_match": "No match found. Try manual linking."
 }

--- a/hibiki/lib/src/media/tracking/media_tracking_service.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_service.dart
@@ -53,6 +53,20 @@ class MediaTrackingSyncResult {
   bool get isSuccess => failed == 0 && !unauthorized;
 }
 
+class MediaTrackingMappingRetryResult {
+  const MediaTrackingMappingRetryResult({
+    required this.attempted,
+    required this.matched,
+    this.syncResult,
+  });
+
+  final int attempted;
+  final int matched;
+  final MediaTrackingSyncResult? syncResult;
+
+  bool get matchedAny => matched > 0;
+}
+
 /// 一条同步失败的待办（首页/设置页展示「为什么没同步上去」）。
 ///
 /// 带 [mappingId] 是为了让 UI 把错误挂回对应的条目行，而不是另开一段再把标题重复
@@ -93,6 +107,8 @@ class MediaTrackingStatus {
     required this.pending,
     required this.mappings,
     required this.failures,
+    required this.automaticMappingMissCount,
+    required this.automaticMappingErrors,
   });
 
   /// 未配置令牌时的空快照（服务未就绪/读库失败的降级值）。
@@ -106,6 +122,8 @@ class MediaTrackingStatus {
     pending: 0,
     mappings: <MediaTrackingMappingRow>[],
     failures: <MediaTrackingFailure>[],
+    automaticMappingMissCount: 0,
+    automaticMappingErrors: <String>[],
   );
 
   final bool configured;
@@ -126,9 +144,16 @@ class MediaTrackingStatus {
   final List<MediaTrackingMappingRow> mappings;
   final List<MediaTrackingFailure> failures;
 
+  /// 本会话内仍处于 10 分钟自动匹配退避的本地条目数。
+  final int automaticMappingMissCount;
+
+  /// 自动匹配请求失败的诊断文本。无候选/低置信度不是异常，因此只计 miss、不伪造错误。
+  final List<String> automaticMappingErrors;
+
   bool get hasNeverSynced => lastSyncAt <= 0;
 
-  bool get hasProblem => unauthorized || failures.isNotEmpty;
+  bool get hasProblem =>
+      unauthorized || failures.isNotEmpty || automaticMappingErrors.isNotEmpty;
 
   /// 按 mapping id 索引失败原因，供 UI 把错误挂回对应条目行。
   Map<int, MediaTrackingFailure> get failureByMappingId =>
@@ -265,6 +290,10 @@ class MediaTrackingService {
   final Map<String, Future<MediaTrackingMappingRow?>> _autoMappingInFlight =
       <String, Future<MediaTrackingMappingRow?>>{};
   final Map<String, int> _autoMappingMissAt = <String, int>{};
+  final Map<String, Future<MediaTrackingMappingRow?> Function()>
+      _autoMappingRetry =
+      <String, Future<MediaTrackingMappingRow?> Function()>{};
+  final Map<String, String> _autoMappingErrors = <String, String>{};
 
   static const Duration _autoMappingMissRetry = Duration(minutes: 10);
 
@@ -366,6 +395,8 @@ class MediaTrackingService {
               error: update.outbox.lastError!.trim(),
             ),
       ],
+      automaticMappingMissCount: _autoMappingMissAt.length,
+      automaticMappingErrors: _autoMappingErrors.values.toList(growable: false),
     );
   }
 
@@ -386,6 +417,139 @@ class MediaTrackingService {
       );
     } finally {
       api.close();
+    }
+  }
+
+  /// 绕过本会话内自动匹配的 10 分钟 miss 退避，立即重跑所有失败条目。
+  ///
+  /// 成功建映射后立刻 reconciliation：mapping.updatedAt 会让当前本地权威进度越过
+  /// 水位并幂等进入 outbox；失败仍留在 miss/error 状态供首页诊断。
+  Future<MediaTrackingMappingRetryResult> retryAutomaticMappings() async {
+    final Map<String, Future<MediaTrackingMappingRow?> Function()> retries =
+        Map<String, Future<MediaTrackingMappingRow?> Function()>.of(
+      _autoMappingRetry,
+    );
+    int matched = 0;
+    for (final MapEntry<String,
+        Future<MediaTrackingMappingRow?> Function()> entry in retries.entries) {
+      _autoMappingMissAt.remove(entry.key);
+      final MediaTrackingMappingRow? mapping =
+          await _singleFlightAutoMapping(entry.key, entry.value);
+      if (mapping != null) {
+        matched++;
+        await _enqueueCurrentProgress(mapping);
+      }
+    }
+    if (matched == 0) {
+      _statusRevision.value++;
+      return MediaTrackingMappingRetryResult(
+        attempted: retries.length,
+        matched: 0,
+      );
+    }
+    final MediaTrackingSyncResult syncResult = await syncNow(force: true);
+    return MediaTrackingMappingRetryResult(
+      attempted: retries.length,
+      matched: matched,
+      syncResult: syncResult,
+    );
+  }
+
+  /// 保存用户确认的映射后，立即把当前本地权威进度补入 outbox 并尝试同步。
+  ///
+  /// reconciliation 水位 + outbox 单行合并共同保证同一当前进度不会重复发送。
+  Future<MediaTrackingSyncResult> saveManualMappingAndSync({
+    required TrackingMediaType mediaType,
+    required String mediaKey,
+    required String mediaTitle,
+    required TrackingKind kind,
+    required int subjectId,
+    required String subjectName,
+    required TrackingProgressMode progressMode,
+    required int progressOffset,
+  }) async {
+    await _repository.saveMapping(
+      mediaType: mediaType,
+      mediaKey: mediaKey,
+      mediaTitle: mediaTitle,
+      kind: kind,
+      subjectId: subjectId,
+      subjectName: subjectName,
+      progressMode: progressMode,
+      progressOffset: progressOffset,
+    );
+    final String key = '${mediaType.value}:$mediaKey';
+    _autoMappingMissAt.remove(key);
+    _autoMappingRetry.remove(key);
+    _autoMappingErrors.remove(key);
+    final MediaTrackingMappingRow? mapping = await _repository.findMapping(
+      mediaType: mediaType,
+      mediaKey: mediaKey,
+    );
+    if (mapping == null) {
+      throw StateError('Manual media tracking mapping was not persisted');
+    }
+    await _enqueueCurrentProgress(mapping);
+    return syncNow(force: true);
+  }
+
+  /// 读取指定 mapping 的当前权威本地事实并幂等入队，不依赖毫秒水位先后关系。
+  Future<void> _enqueueCurrentProgress(MediaTrackingMappingRow mapping) async {
+    TrackingMediaType? mediaType;
+    for (final TrackingMediaType value in TrackingMediaType.values) {
+      if (value.value == mapping.mediaType) {
+        mediaType = value;
+        break;
+      }
+    }
+    if (mediaType == null) return;
+    if (mediaType == TrackingMediaType.video ||
+        mediaType == TrackingMediaType.videoCollection) {
+      final List<CompletedVideoTrackingProgress> progress =
+          await _repository.loadCompletedVideoTrackingProgress(afterMs: -1);
+      for (final CompletedVideoTrackingProgress item in progress) {
+        if (item.mediaType != mediaType || item.mediaKey != mapping.mediaKey) {
+          continue;
+        }
+        await _repository.enqueueProgress(
+          mediaType: item.mediaType,
+          mediaKey: item.mediaKey,
+          localProgress: item.localProgress,
+          completed: item.completed,
+        );
+      }
+      return;
+    }
+    if (mediaType == TrackingMediaType.book ||
+        mediaType == TrackingMediaType.bookChapter) {
+      final List<PersistedBookTrackingProgress> progress =
+          await _repository.loadPersistedBookTrackingProgress(afterMs: -1);
+      for (final PersistedBookTrackingProgress item in progress) {
+        if (item.mediaType != mediaType || item.mediaKey != mapping.mediaKey) {
+          continue;
+        }
+        await _repository.enqueueProgress(
+          mediaType: item.mediaType,
+          mediaKey: item.mediaKey,
+          localProgress: item.localProgress,
+          completed: item.completed,
+        );
+      }
+      return;
+    }
+    if (mediaType == TrackingMediaType.game) {
+      final List<PersistedGameTrackingStatus> progress =
+          await _repository.loadPersistedGameTrackingStatus(afterMs: -1);
+      for (final PersistedGameTrackingStatus item in progress) {
+        if (item.gameId != mapping.mediaKey) continue;
+        await _repository.enqueueProgress(
+          mediaType: TrackingMediaType.game,
+          mediaKey: item.gameId,
+          localProgress: item.status,
+          completed: item.status == 2,
+          monotonic: false,
+        );
+      }
     }
   }
 
@@ -719,6 +883,7 @@ class MediaTrackingService {
     String key,
     Future<MediaTrackingMappingRow?> Function() resolve,
   ) {
+    _autoMappingRetry[key] = resolve;
     final Future<MediaTrackingMappingRow?>? running = _autoMappingInFlight[key];
     if (running != null) return running;
     final int now = DateTime.now().millisecondsSinceEpoch;
@@ -733,12 +898,18 @@ class MediaTrackingService {
         final MediaTrackingMappingRow? result = await resolve();
         if (result == null) {
           _autoMappingMissAt[key] = DateTime.now().millisecondsSinceEpoch;
+          _autoMappingErrors.remove(key);
         } else {
           _autoMappingMissAt.remove(key);
+          _autoMappingRetry.remove(key);
+          _autoMappingErrors.remove(key);
         }
+        _statusRevision.value++;
         return result;
       } catch (error, stackTrace) {
         _autoMappingMissAt[key] = DateTime.now().millisecondsSinceEpoch;
+        _autoMappingErrors[key] = error.toString();
+        _statusRevision.value++;
         ErrorLogService.instance.log(
           'MediaTrackingService.autoMap',
           error,

--- a/hibiki/lib/src/media/tracking/media_tracking_settings_body.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_settings_body.dart
@@ -115,12 +115,11 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
       context: context,
       builder: (BuildContext context) => _AddMappingDialog(
         database: widget.appModel.database,
-        repository: _repository,
         service: widget.appModel.mediaTrackingService,
       ),
     );
-    if (saved ?? false) {
-      _message(t.media_tracking_saved);
+    if (saved != null) {
+      _message(saved ? t.media_tracking_saved : t.media_tracking_sync_failed);
       await _reload();
     }
   }
@@ -292,12 +291,10 @@ class _LocalTrackingTarget {
 class _AddMappingDialog extends StatefulWidget {
   const _AddMappingDialog({
     required this.database,
-    required this.repository,
     required this.service,
   });
 
   final HibikiDatabase database;
-  final MediaTrackingRepository repository;
   final MediaTrackingService service;
 
   @override
@@ -427,7 +424,8 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
         ? 0
         : (int.tryParse(_offsetController.text) ??
             (_mode == TrackingProgressMode.chapter ? 0 : 1));
-    await widget.repository.saveMapping(
+    final MediaTrackingSyncResult result =
+        await widget.service.saveManualMappingAndSync(
       mediaType: target.type,
       mediaKey: target.key,
       mediaTitle: target.title,
@@ -437,7 +435,7 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
       progressMode: _mode,
       progressOffset: offset.clamp(0, 100000),
     );
-    if (mounted) Navigator.of(context).pop(true);
+    if (mounted) Navigator.of(context).pop(result.isSuccess);
   }
 
   @override

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -2216,7 +2216,10 @@ class _HomeDashboardPageState
           // 第二段：一条映射都没有 → 完成事件根本进不了 outbox，必须说清原因，
           // 否则「已连接 + 零待办 + 全部已发送」看起来像一切正常。
           if (status.mappings.isEmpty)
-            Text(t.media_tracking_unlinked_hint, style: tokens.type.metadata)
+            Text(
+              t.media_tracking_unlinked_hint,
+              style: tokens.type.metadata,
+            )
           else
             // 第三段：逐条条目。失败原因挂在对应行上（有失败的排在最前），不另开
             // 一段——否则同一个条目在「失败」和「已关联」里各出现一次。
@@ -2227,6 +2230,13 @@ class _HomeDashboardPageState
                 mapping,
                 status.failureByMappingId[mapping.id],
               ),
+          for (final String error in status.automaticMappingErrors)
+            Text(
+              '${t.media_tracking_last_error}: $error',
+              style: tokens.type.metadata.copyWith(color: scheme.error),
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+            ),
 
           SizedBox(height: tokens.spacing.gap),
           Wrap(
@@ -2243,6 +2253,12 @@ class _HomeDashboardPageState
                     : const Icon(Icons.sync),
                 label: Text(t.media_tracking_sync_now),
               ),
+              if (status.automaticMappingMissCount > 0)
+                FilledButton.tonalIcon(
+                  onPressed: _trackingSyncBusy ? null : _retryTrackingMappings,
+                  icon: const Icon(Icons.refresh),
+                  label: Text(t.media_tracking_retry_mapping),
+                ),
               TextButton.icon(
                 onPressed: _openTrackingSettings,
                 icon: const Icon(Icons.tune),
@@ -2352,6 +2368,47 @@ class _HomeDashboardPageState
         );
     } catch (e, stack) {
       ErrorLogService.instance.log('HomeDashboardPage.syncTracking', e, stack);
+    } finally {
+      if (mounted) setState(() => _trackingSyncBusy = false);
+    }
+  }
+
+  /// 自动匹配重试：由服务层清掉对应 miss 退避并重新调用原匹配解析器；结果必须明确
+  /// 回显，不能把「按钮被 10 分钟退避挡住」伪装成成功。
+  Future<void> _retryTrackingMappings() async {
+    setState(() => _trackingSyncBusy = true);
+    try {
+      final MediaTrackingMappingRetryResult result = await ref
+          .read(appProvider)
+          .mediaTrackingService
+          .retryAutomaticMappings();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+        ..hideCurrentSnackBar()
+        ..showSnackBar(
+          SnackBar(
+            content: Text(
+              !result.matchedAny
+                  ? t.media_tracking_retry_no_match
+                  : (result.syncResult?.isSuccess ?? false)
+                      ? t.media_tracking_retry_matched
+                      : t.media_tracking_sync_failed,
+            ),
+          ),
+        );
+    } catch (e, stack) {
+      ErrorLogService.instance.log(
+        'HomeDashboardPage.retryTrackingMappings',
+        e,
+        stack,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+          ..hideCurrentSnackBar()
+          ..showSnackBar(
+            SnackBar(content: Text(t.media_tracking_sync_failed)),
+          );
+      }
     } finally {
       if (mounted) setState(() => _trackingSyncBusy = false);
     }

--- a/hibiki/test/media/tracking/media_tracking_service_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_service_test.dart
@@ -44,6 +44,7 @@ class _FakeBangumiApi implements BangumiTrackingApi {
     required int subjectType,
   }) async {
     searches.add((keyword: keyword, subjectType: subjectType));
+    _throwIfNeeded();
     return searchResults;
   }
 
@@ -1318,6 +1319,147 @@ void main() {
       await service.syncNow(force: true);
 
       expect(service.statusRevision.value, greaterThan(before));
+    });
+
+    test('自动匹配重试绕过十分钟 miss 退避并立即重新关联', () async {
+      await db.insertEpubBook(
+        EpubBooksCompanion.insert(
+          bookKey: 'retry-book',
+          title: 'Retry Book',
+          epubPath: '/tmp/retry.epub',
+          extractDir: '/tmp/retry',
+          chapterCount: 4,
+          chaptersJson: '[]',
+          importedAt: 1,
+        ),
+      );
+      await db.upsertReaderPosition(
+        ReaderPositionsCompanion.insert(
+          bookKey: 'retry-book',
+          sectionIndex: 2,
+          normCharOffset: 0,
+          updatedAt: 2,
+        ),
+      );
+
+      await service.recordBookProgress(
+        bookKey: 'retry-book',
+        completedChapterCount: 2,
+        completed: false,
+      );
+      expect(api.searches, hasLength(1));
+      expect((await service.loadStatus()).automaticMappingMissCount, 1);
+
+      // 普通事件仍被十分钟退避挡住；显式重试必须绕过它。
+      await service.recordBookProgress(
+        bookKey: 'retry-book',
+        completedChapterCount: 2,
+        completed: false,
+      );
+      expect(api.searches, hasLength(1));
+
+      api.searchResults = const <BangumiSubject>[
+        BangumiSubject(
+          id: 99,
+          type: 1,
+          name: 'Retry Book',
+          nameCn: '',
+          platform: '小说',
+          episodeCount: 4,
+          volumeCount: 1,
+        ),
+      ];
+      final MediaTrackingMappingRetryResult result =
+          await service.retryAutomaticMappings();
+
+      expect(result.attempted, 1);
+      expect(result.matched, 1);
+      expect(api.searches, hasLength(2), reason: '重试必须真的再次请求匹配');
+      expect((await service.loadStatus()).automaticMappingMissCount, 0);
+      expect(
+        await repository.findMapping(
+          mediaType: TrackingMediaType.book,
+          mediaKey: 'retry-book',
+        ),
+        isNotNull,
+      );
+      expect(api.creates, <Map<String, dynamic>>[
+        <String, dynamic>{'ep_status': 2, 'type': 3},
+      ]);
+    });
+
+    test('手动关联后当前权威进度补发一次且后续同步幂等', () async {
+      await db.insertEpubBook(
+        EpubBooksCompanion.insert(
+          bookKey: 'manual-book',
+          title: 'Manual Book',
+          epubPath: '/tmp/manual.epub',
+          extractDir: '/tmp/manual',
+          chapterCount: 4,
+          chaptersJson: '[]',
+          importedAt: 1,
+        ),
+      );
+      await db.upsertReaderPosition(
+        ReaderPositionsCompanion.insert(
+          bookKey: 'manual-book',
+          sectionIndex: 2,
+          normCharOffset: 0,
+          updatedAt: 2,
+        ),
+      );
+
+      final MediaTrackingSyncResult result =
+          await service.saveManualMappingAndSync(
+        mediaType: TrackingMediaType.book,
+        mediaKey: 'manual-book',
+        mediaTitle: 'Manual Book',
+        kind: TrackingKind.novel,
+        subjectId: 77,
+        subjectName: 'Remote manual book',
+        progressMode: TrackingProgressMode.chapter,
+        progressOffset: 0,
+      );
+
+      expect(result.succeeded, 1);
+      expect(api.creates, <Map<String, dynamic>>[
+        <String, dynamic>{'ep_status': 2, 'type': 3},
+      ]);
+      expect(await repository.pendingCount(), 0);
+
+      await service.syncNow(force: true);
+      expect(api.creates, hasLength(1),
+          reason: '同一 mapping 水位后的重复同步不得再次补发当前进度');
+    });
+
+    test('自动匹配网络失败保留可诊断 miss 状态', () async {
+      await db.insertEpubBook(
+        EpubBooksCompanion.insert(
+          bookKey: 'offline-book',
+          title: 'Offline Book',
+          epubPath: '/tmp/offline.epub',
+          extractDir: '/tmp/offline',
+          chapterCount: 2,
+          chaptersJson: '[]',
+          importedAt: 1,
+        ),
+      );
+      api.error = const BangumiApiException(
+        statusCode: 503,
+        message: 'offline',
+      );
+
+      await service.recordBookProgress(
+        bookKey: 'offline-book',
+        completedChapterCount: 1,
+        completed: false,
+      );
+
+      final MediaTrackingStatus status = await service.loadStatus();
+      expect(status.automaticMappingMissCount, 1);
+      expect(status.automaticMappingErrors, hasLength(1));
+      expect(status.automaticMappingErrors.single, contains('503'));
+      expect(status.hasProblem, isTrue);
     });
   });
 }

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -1203,6 +1203,36 @@ void main() {
       expect(tester.takeException(), isNull);
       expect(find.text(t.media_tracking_unauthorized), findsOneWidget);
     });
+
+    testWidgets('自动关联 miss 后显示真实重试入口并回显结果', (WidgetTester tester) async {
+      useWideSurface(tester);
+      await connect();
+      // 不存在的本地游戏会形成一次可重试 miss，且不访问真实网络。
+      await appModel.mediaTrackingService.recordGameStatus(
+        gameId: 'missing-game',
+        status: 3,
+      );
+
+      await tester.pumpWidget(buildApp());
+      await pumpDashboard(tester);
+
+      final Finder retryButton = find.widgetWithText(
+        FilledButton,
+        t.media_tracking_retry_mapping,
+      );
+      expect(retryButton, findsOneWidget);
+
+      await tester.tap(retryButton);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+
+      expect(
+        find.text(t.media_tracking_retry_no_match),
+        findsOneWidget,
+        reason: '重试不能被 10 分钟退避无声吞掉，匹配结果必须回显',
+      );
+      expect(tester.takeException(), isNull);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary

- expose a real dashboard retry action for automatic Bangumi mapping misses; it clears the 10-minute in-memory miss backoff and reruns the original resolver
- preserve automatic-match request errors in the visible tracking status
- route manual mapping saves through immediate authoritative-progress backfill and sync, while retaining durable outbox diagnostics on failure
- keep the existing `0.92` confidence and `0.08` runner-up thresholds unchanged

## Verification

- `flutter analyze`
- `flutter test test/media/tracking/media_tracking_service_test.dart --no-pub` (38 tests)
- `flutter test test/pages/home_dashboard_page_test.dart --no-pub` (30 tests)
- verified through the fake Bangumi API boundary that retry performs a second search, current progress is sent once, and a later forced sync is idempotent

## Limits

- no real Bangumi token/account E2E was run
- branch started from `origin/develop@f6dd710`; develop advanced while implementation was running, so integration owner should resolve landing order without relying on this agent to rebase

Todo: TODO-2266
