### PR TITLE
fix(tracking): report completed PDFs as one volume

### DIFF
--- a/hibiki/lib/src/media/tracking/media_tracking_repository.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_repository.dart
@@ -43,6 +43,13 @@ enum TrackingProgressMode {
 
   const TrackingProgressMode(this.value);
   final String value;
+
+  static TrackingProgressMode? tryParse(String value) {
+    for (final TrackingProgressMode mode in TrackingProgressMode.values) {
+      if (mode.value == value) return mode;
+    }
+    return null;
+  }
 }
 
 typedef AutoVideoTrackingSource = ({
@@ -86,6 +93,33 @@ typedef PersistedBookTrackingProgress = ({
   bool completed,
   int evidenceAt,
 });
+
+typedef BookTrackingSnapshot = ({
+  BookFormat format,
+  int? chapterProgress,
+});
+
+/// 把书籍格式、映射模式和明确完成状态收敛成唯一的本地上报值。
+///
+/// PDF / 漫画没有可靠章节，chapter 模式返回 null（整条不发）；volume 模式只在
+/// [completed] 为 true 时把当前卷计入，未完成时用 -1 配合卷号 offset 仅保留此前卷数。
+/// 即时阅读事件和持久化补发必须都走这里，避免两条入口再次漂开。
+int? resolveBookTrackingLocalProgress({
+  required BookFormat format,
+  required TrackingProgressMode progressMode,
+  required int? chapterProgress,
+  required bool completed,
+}) {
+  switch (progressMode) {
+    case TrackingProgressMode.chapter:
+      return format.isPagedImageBook ? null : chapterProgress;
+    case TrackingProgressMode.volume:
+      return completed ? 0 : -1;
+    case TrackingProgressMode.episode:
+    case TrackingProgressMode.status:
+      return null;
+  }
+}
 
 final RegExp _ignoredBookTocLabel = RegExp(
   r'^(?:目次|目录|目錄|contents?|table\s+of\s+contents|扉|title\s+page|表紙|cover|奥付|版权|版權|colophon|口絵|イラスト|插图|插圖|あとがき|后记|後記|著者紹介)$',
@@ -438,19 +472,49 @@ class MediaTrackingRepository {
   Future<int?> loadBookChapterProgress({
     required String bookKey,
     required int fallbackProgress,
+  }) async =>
+      (await loadBookTrackingSnapshot(
+        bookKey: bookKey,
+        fallbackProgress: fallbackProgress,
+      ))
+          .chapterProgress;
+
+  /// 读取即时上报所需的格式与逻辑章节快照。
+  ///
+  /// chapter/volume 的最终选择统一交给 [resolveBookTrackingLocalProgress]；这里仅把
+  /// PDF/漫画的“无章节”事实表达成 null，并为 EPUB 计算逻辑 TOC 章节数。
+  Future<BookTrackingSnapshot> loadBookTrackingSnapshot({
+    required String bookKey,
+    required int fallbackProgress,
   }) async {
     final EpubBookRow? book = await _db.getEpubBook(bookKey);
-    if (book == null) return math.max(0, fallbackProgress);
-    if (BookFormat.parseOrEpub(book.format).isPagedImageBook) return null;
+    if (book == null) {
+      return (
+        format: BookFormat.epub,
+        chapterProgress: math.max(0, fallbackProgress),
+      );
+    }
+    final BookFormat format = BookFormat.parseOrEpub(book.format);
+    if (format.isPagedImageBook) {
+      return (format: format, chapterProgress: null);
+    }
     final ReaderPositionRow? position = await _db.getReaderPosition(bookKey);
-    if (position == null) return math.max(0, fallbackProgress);
-    return estimateCompletedBookChapters(
-      chaptersJson: book.chaptersJson,
-      tocJson: book.tocJson,
-      sectionIndex: position.sectionIndex,
-      sectionCompleted: position.normCharOffset >= 9990,
-      bookCompleted: book.completedAt != null,
-      fallbackProgress: fallbackProgress,
+    if (position == null) {
+      return (
+        format: format,
+        chapterProgress: math.max(0, fallbackProgress),
+      );
+    }
+    return (
+      format: format,
+      chapterProgress: estimateCompletedBookChapters(
+        chaptersJson: book.chaptersJson,
+        tocJson: book.tocJson,
+        sectionIndex: position.sectionIndex,
+        sectionCompleted: position.normCharOffset >= 9990,
+        bookCompleted: book.completedAt != null,
+        fallbackProgress: fallbackProgress,
+      ),
     );
   }
 
@@ -562,29 +626,31 @@ class MediaTrackingRepository {
 
       final bool isChapterCompanion =
           mediaType == TrackingMediaType.bookChapter;
-      final bool isVolume =
-          mapping.progressMode == TrackingProgressMode.volume.value;
       final bool completed = completedAt != null;
-      final int localProgress;
-      if (isChapterCompanion ||
-          mapping.progressMode == TrackingProgressMode.chapter.value) {
-        // 与 [loadBookChapterProgress] 同一判据：按页翻的书（PDF / 漫画）没有章，
-        // 这里的 fallbackProgress 是 sectionIndex＝页码，报出去就是错数。宁可不报。
-        if (BookFormat.parseOrEpub(book.format).isPagedImageBook) continue;
-        localProgress = estimateCompletedBookChapters(
-          chaptersJson: book.chaptersJson,
-          tocJson: book.tocJson,
-          sectionIndex: position?.sectionIndex ?? 0,
-          sectionCompleted: (position?.normCharOffset ?? 0) >= 9990,
-          bookCompleted: completed,
-          fallbackProgress: (position?.sectionIndex ?? 0) +
-              ((position?.normCharOffset ?? 0) >= 9990 ? 1 : 0),
-        );
-      } else if (isVolume) {
-        localProgress = completed ? 0 : -1;
-      } else {
-        continue;
-      }
+      final BookFormat format = BookFormat.parseOrEpub(book.format);
+      final TrackingProgressMode? storedMode =
+          TrackingProgressMode.tryParse(mapping.progressMode);
+      final TrackingProgressMode? effectiveMode =
+          isChapterCompanion ? TrackingProgressMode.chapter : storedMode;
+      if (effectiveMode == null) continue;
+      final int? chapterProgress = format.isPagedImageBook
+          ? null
+          : estimateCompletedBookChapters(
+              chaptersJson: book.chaptersJson,
+              tocJson: book.tocJson,
+              sectionIndex: position?.sectionIndex ?? 0,
+              sectionCompleted: (position?.normCharOffset ?? 0) >= 9990,
+              bookCompleted: completed,
+              fallbackProgress: (position?.sectionIndex ?? 0) +
+                  ((position?.normCharOffset ?? 0) >= 9990 ? 1 : 0),
+            );
+      final int? localProgress = resolveBookTrackingLocalProgress(
+        format: format,
+        progressMode: effectiveMode,
+        chapterProgress: chapterProgress,
+        completed: completed,
+      );
+      if (localProgress == null) continue;
       result.add((
         mediaKey: mapping.mediaKey,
         mediaType: mediaType,

--- a/hibiki/lib/src/media/tracking/media_tracking_service.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_service.dart
@@ -622,34 +622,38 @@ class MediaTrackingService {
     final MediaTrackingMappingRow? mapping =
         await _ensureAutoBookMapping(bookKey);
     if (mapping == null) return;
-    // null = 按页翻的书（PDF / 漫画），没有章的概念。此时**一律不产出 chapter
-    // 模式进度**：旧实现会把当前页码当已读章数写进用户的 Bangumi 公开记录。
-    final int? logicalChapterProgress =
-        await _repository.loadBookChapterProgress(
+    final TrackingProgressMode? progressMode =
+        TrackingProgressMode.tryParse(mapping.progressMode);
+    if (progressMode == null) return;
+    final BookTrackingSnapshot snapshot =
+        await _repository.loadBookTrackingSnapshot(
       bookKey: bookKey,
       fallbackProgress: completedChapterCount,
     );
-    final bool isVolume =
-        mapping.progressMode == TrackingProgressMode.volume.value;
-    final MediaTrackingMappingRow? chapterMapping =
-        isVolume && mapping.kind == TrackingKind.novel.value
-            ? await _ensureBookChapterMapping(mapping)
-            : null;
-    // 按页翻的书（PDF / 漫画）没有章：卷模式仍可如实上报「读完/未读完」，但 chapter
-    // 模式一律**整条不发**——报 0 也是往用户的 Bangumi 公开记录里写一个错数。
-    if (!isVolume && logicalChapterProgress == null) return;
+    final int? localProgress = resolveBookTrackingLocalProgress(
+      format: snapshot.format,
+      progressMode: progressMode,
+      chapterProgress: snapshot.chapterProgress,
+      completed: completed,
+    );
+    if (localProgress == null) return;
+    final bool isVolume = progressMode == TrackingProgressMode.volume;
+    final MediaTrackingMappingRow? chapterMapping = isVolume &&
+            mapping.kind == TrackingKind.novel.value &&
+            snapshot.chapterProgress != null
+        ? await _ensureBookChapterMapping(mapping)
+        : null;
     await _enqueueAndSync(
       mediaType: TrackingMediaType.book,
       mediaKey: bookKey,
-      // 卷模式的 offset 就是当前卷号：在读时减一只报告此前已读卷，读完才计入本卷。
-      localProgress: isVolume ? (completed ? 0 : -1) : logicalChapterProgress!,
+      localProgress: localProgress,
       completed: completed,
     );
-    if (chapterMapping == null || logicalChapterProgress == null) return;
+    if (chapterMapping == null) return;
     await _enqueueAndSync(
       mediaType: TrackingMediaType.bookChapter,
       mediaKey: bookKey,
-      localProgress: logicalChapterProgress,
+      localProgress: snapshot.chapterProgress!,
       // 章节伴随映射只负责 ep_status；整部作品是否读完由主卷映射判断。
       completed: false,
     );
@@ -799,10 +803,10 @@ class MediaTrackingService {
         final AutoBookTrackingSource? source =
             await _repository.loadAutoBookSource(bookKey);
         if (source == null) return null;
-        final TrackingKind kind =
-            BookFormat.parseOrEpub(source.format) == BookFormat.manga
-                ? TrackingKind.manga
-                : TrackingKind.novel;
+        final BookFormat format = BookFormat.parseOrEpub(source.format);
+        final TrackingKind kind = format == BookFormat.manga
+            ? TrackingKind.manga
+            : TrackingKind.novel;
         final _PreparedTrackingTitle prepared =
             _prepareTrackingTitle(source.title);
         final List<BangumiSubject> subjects = await searchSubjects(
@@ -812,7 +816,7 @@ class MediaTrackingService {
         final BangumiSubject? subject =
             _uniqueHighConfidenceSubject(prepared.query, subjects, kind);
         if (subject == null) return null;
-        final bool trackAsVolume = kind == TrackingKind.manga ||
+        final bool trackAsVolume = format.isPagedImageBook ||
             prepared.volumeNumber != null ||
             subject.volumeCount > 1;
         return _repository.saveMappingIfAbsent(
@@ -825,7 +829,11 @@ class MediaTrackingService {
           progressMode: trackAsVolume
               ? TrackingProgressMode.volume
               : TrackingProgressMode.chapter,
-          progressOffset: trackAsVolume ? (prepared.volumeNumber ?? 1) : 0,
+          // 用户选择的 PDF 口径是“一本算一卷”：文件名即使带“第 3 卷”也不能据此
+          // 推断前两卷已读。漫画仍保留卷号识别；手动映射的 offset 也不会被自动路径覆盖。
+          progressOffset: format == BookFormat.pdf
+              ? 1
+              : (trackAsVolume ? (prepared.volumeNumber ?? 1) : 0),
         );
       },
     );

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1013
+version: 1.3.1+1014
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/tracking/media_tracking_repository_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_repository_test.dart
@@ -92,6 +92,46 @@ void main() {
     });
   }
 
+  test('PDF 的 volume 模式只在明确完成时把当前卷计入（持久化入口）', () async {
+    const String key = 'persisted-pdf-volume';
+    await seedBook(key, BookFormat.pdf);
+    await db.upsertReaderPosition(
+      ReaderPositionsCompanion.insert(
+        bookKey: key,
+        sectionIndex: 137,
+        normCharOffset: 5000,
+        updatedAt: 5000,
+      ),
+    );
+    await repository.saveMappingIfAbsent(
+      mediaType: TrackingMediaType.book,
+      mediaKey: key,
+      mediaTitle: key,
+      kind: TrackingKind.novel,
+      subjectId: 2289,
+      subjectName: key,
+      progressMode: TrackingProgressMode.volume,
+      progressOffset: 1,
+    );
+
+    List<PersistedBookTrackingProgress> got =
+        await repository.loadPersistedBookTrackingProgress(afterMs: 0);
+    PersistedBookTrackingProgress progress =
+        got.singleWhere((PersistedBookTrackingProgress e) => e.mediaKey == key);
+    expect(progress.localProgress, -1);
+    expect(progress.completed, isFalse);
+
+    await db.markEpubBookCompletedIfUnset(
+      key,
+      DateTime.fromMillisecondsSinceEpoch(6000),
+    );
+    got = await repository.loadPersistedBookTrackingProgress(afterMs: 0);
+    progress =
+        got.singleWhere((PersistedBookTrackingProgress e) => e.mediaKey == key);
+    expect(progress.localProgress, 0);
+    expect(progress.completed, isTrue);
+  });
+
   test('epub 的 chapter 模式映射照常产出（调用点②没有误伤文字书）', () async {
     await seedBook('p-epub', BookFormat.epub);
     await db.upsertReaderPosition(

--- a/hibiki/test/media/tracking/media_tracking_service_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_service_test.dart
@@ -22,6 +22,8 @@ class _FakeBangumiApi implements BangumiTrackingApi {
   Exception? error;
   final List<Map<String, dynamic>> creates = <Map<String, dynamic>>[];
   final List<Map<String, dynamic>> patches = <Map<String, dynamic>>[];
+  final List<int> createSubjectIds = <int>[];
+  final List<int> patchSubjectIds = <int>[];
   final List<List<int>> episodePatches = <List<int>>[];
   List<BangumiSubject> searchResults = const <BangumiSubject>[];
   final List<({String keyword, int subjectType})> searches =
@@ -70,6 +72,7 @@ class _FakeBangumiApi implements BangumiTrackingApi {
     required Map<String, dynamic> payload,
   }) async {
     _throwIfNeeded();
+    createSubjectIds.add(subjectId);
     creates.add(payload);
   }
 
@@ -79,6 +82,7 @@ class _FakeBangumiApi implements BangumiTrackingApi {
     required Map<String, dynamic> payload,
   }) async {
     _throwIfNeeded();
+    patchSubjectIds.add(subjectId);
     patches.add(payload);
   }
 
@@ -890,6 +894,150 @@ void main() {
       api.patches,
       anyElement(equals(<String, dynamic>{'ep_status': 2})),
     );
+  });
+
+  test(
+      'PDF auto mapping reports one volume only after completion and is idempotent',
+      () async {
+    await db.insertEpubBook(
+      EpubBooksCompanion.insert(
+        bookKey: 'pdf-key',
+        title: '单册 PDF 第3卷',
+        epubPath: '/tmp/single.pdf',
+        extractDir: '/tmp/pdf',
+        chapterCount: 200,
+        chaptersJson: '[]',
+        importedAt: 1,
+        format: const Value<String>('pdf'),
+      ),
+    );
+    await db.upsertReaderPosition(
+      ReaderPositionsCompanion.insert(
+        bookKey: 'pdf-key',
+        sectionIndex: 137,
+        normCharOffset: 5000,
+        updatedAt: 2,
+      ),
+    );
+    api.searchResults = const <BangumiSubject>[
+      BangumiSubject(
+        id: 2289,
+        type: 1,
+        name: '单册 PDF',
+        nameCn: '',
+        platform: '小说',
+        episodeCount: 12,
+        volumeCount: 1,
+      ),
+    ];
+    api.subject = api.searchResults.single;
+
+    await service.recordBookProgress(
+      bookKey: 'pdf-key',
+      completedChapterCount: 137,
+      completed: false,
+    );
+    await service.syncNow();
+
+    final MediaTrackingMappingRow? mapping = await repository.findMapping(
+      mediaType: TrackingMediaType.book,
+      mediaKey: 'pdf-key',
+    );
+    expect(mapping, isNotNull);
+    expect(mapping!.progressMode, TrackingProgressMode.volume.value);
+    expect(mapping.progressOffset, 1,
+        reason: '一本 PDF 只算一卷，不能因标题带“第3卷”猜测此前两卷也已读');
+    expect(
+      await repository.findMapping(
+        mediaType: TrackingMediaType.bookChapter,
+        mediaKey: 'pdf-key',
+      ),
+      isNull,
+      reason: 'PDF 没有章节进度，不应创建章节伴随映射',
+    );
+    expect(api.createSubjectIds, <int>[2289]);
+    expect(
+      api.creates.single,
+      <String, dynamic>{'type': 3},
+      reason: '未完成 PDF 可以标记在读，但不能把第 137 页或本卷计入进度',
+    );
+
+    api.collection = const BangumiUserCollection(
+      type: 3,
+      episodeProgress: 0,
+      volumeProgress: 0,
+    );
+    await db.markEpubBookCompletedIfUnset(
+      'pdf-key',
+      DateTime.fromMillisecondsSinceEpoch(3),
+    );
+    await service.recordBookProgress(
+      bookKey: 'pdf-key',
+      completedChapterCount: 200,
+      completed: true,
+    );
+    await service.syncNow();
+
+    expect(api.patchSubjectIds, <int>[2289]);
+    expect(
+      api.patches.single,
+      <String, dynamic>{'vol_status': 1, 'type': 2},
+      reason: '明确完成一本 PDF 后只上报 1 卷，并将单卷条目标为读过',
+    );
+
+    await service.recordBookProgress(
+      bookKey: 'pdf-key',
+      completedChapterCount: 200,
+      completed: true,
+    );
+    await service.syncNow();
+    expect(api.patches, hasLength(1), reason: '重复完成回调必须幂等，不二次写 Bangumi');
+  });
+
+  test(
+      'manual PDF chapter mapping is preserved and never reports page progress',
+      () async {
+    await db.insertEpubBook(
+      EpubBooksCompanion.insert(
+        bookKey: 'manual-pdf',
+        title: '手动映射 PDF',
+        epubPath: '/tmp/manual.pdf',
+        extractDir: '/tmp/manual-pdf',
+        chapterCount: 88,
+        chaptersJson: '[]',
+        importedAt: 1,
+        format: const Value<String>('pdf'),
+      ),
+    );
+    await repository.saveMapping(
+      mediaType: TrackingMediaType.book,
+      mediaKey: 'manual-pdf',
+      mediaTitle: '手动映射 PDF',
+      kind: TrackingKind.novel,
+      subjectId: 2290,
+      subjectName: '用户选择的条目',
+      progressMode: TrackingProgressMode.chapter,
+      progressOffset: 7,
+    );
+
+    await service.recordBookProgress(
+      bookKey: 'manual-pdf',
+      completedChapterCount: 88,
+      completed: true,
+    );
+    await service.syncNow();
+
+    final MediaTrackingMappingRow mapping = (await repository.findMapping(
+      mediaType: TrackingMediaType.book,
+      mediaKey: 'manual-pdf',
+    ))!;
+    expect(mapping.subjectId, 2290);
+    expect(mapping.progressMode, TrackingProgressMode.chapter.value);
+    expect(mapping.progressOffset, 7);
+    expect(api.searches, isEmpty);
+    expect(api.creates, isEmpty);
+    expect(api.patches, isEmpty);
+    expect(await repository.pendingCount(), 0);
   });
 
   test('manga volume suffix reports previous volumes while current is reading',


### PR DESCRIPTION
## 需求

TODO-2289：「按卷报吧」。PDF 一本只算一卷，未明确完成不报 1，明确完成后报 1；不得回退 EPUB、漫画或手动映射。

## 根因与修复

- 止血提交已阻止 PDF 页码走 chapter 上报，但 PDF 自动映射仍创建 chapter 模式，所以完成后也没有卷进度。
- 即时与持久化入口现在共用 `resolveBookTrackingLocalProgress`：paged-image chapter 不发；volume 未完成不计当前卷，完成才计入。
- 新 PDF 自动映射固定 `volume + offset 1`；即使标题带「第3卷」也不猜此前卷已读。漫画卷号与手动映射不变。
- PDF 不再创建无意义的章节伴随映射。

## 验证

- `flutter test test/media/tracking/media_tracking_repository_test.dart test/media/tracking/media_tracking_service_test.dart test/tools/book_format_discipline_guard_test.dart --no-pub`：64 项通过。
- `flutter analyze`：No issues found。
- fake API 断言 `subjectId=2289`、未完成请求不含卷进度、完成 payload 为 `{vol_status: 1, type: 2}`、重复完成无二次写。

> fake API 仅证明外部调用参数与本地幂等契约，不代表真实 Bangumi 线上写入成功；本 PR 未使用用户账号污染公开进度。

证据：`D:\APP\vs_claude_code\hibiki\.worktrees\todo-2289-pdf-volume\.codex-test\todo-2289\verification.md`