### PR TITLE
fix(scrape): route failures through shared MD3 detail

### DIFF
--- a/hibiki/lib/src/media/metadata/scrape_failure_view.dart
+++ b/hibiki/lib/src/media/metadata/scrape_failure_view.dart
@@ -47,6 +47,7 @@ class _ScrapeFailureViewState extends State<ScrapeFailureView> {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     return Center(
       // 结果区高度由弹窗决定，可能比本列矮（窄窗/小屏）：外层滚动兜底，避免
       // RenderFlex overflow 把失败态本身变成一条黄黑警告。
@@ -88,18 +89,19 @@ class _ScrapeFailureViewState extends State<ScrapeFailureView> {
               // 「复制」按钮推出可视区，用户永远够得着上报入口。
               ConstrainedBox(
                 constraints: const BoxConstraints(maxHeight: 132),
-                child: Container(
+                child: SizedBox(
                   width: double.infinity,
-                  padding: const EdgeInsets.all(8),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.surfaceContainerHighest,
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                  child: SingleChildScrollView(
-                    child: SelectableText(
-                      widget.detail,
-                      style: theme.textTheme.bodySmall
-                          ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  child: HibikiCard(
+                    padding: EdgeInsets.all(tokens.spacing.gap),
+                    color: tokens.surfaces.overlay,
+                    borderRadius: tokens.radii.cardRadius,
+                    child: SingleChildScrollView(
+                      child: SelectableText(
+                        widget.detail,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
                     ),
                   ),
                 ),

--- a/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
+++ b/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:hibiki/src/media/metadata/bangumi_api_client.dart'
     show parseBangumiSubjectUrl;
+import 'package:hibiki/src/media/metadata/credential_redaction.dart'
+    show redactCredentialsInText;
 import 'package:hibiki/src/media/metadata/scrape_failure_view.dart';
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
     show ScrapeNetworkException;
@@ -131,6 +133,10 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   /// 正在应用的候选（用于在其「使用」按钮上显示转圈；null = 无进行中应用）。
   ScrapeCandidate? _applyingCandidate;
 
+  /// 上一次应用失败的安全详情。应用链可能抛出带请求 URL 的异常，先脱敏再同时送入
+  /// 错误日志与 [ScrapeFailureView]，避免「界面安全、日志仍泄露」的半修复。
+  ({Object error, String detail})? _applyFailure;
+
   @override
   void initState() {
     super.initState();
@@ -176,6 +182,7 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
         _searching = true;
         _searched = true;
         _searchFailure = null;
+        _applyFailure = null;
       });
       List<ScrapeCandidate> results = const <ScrapeCandidate>[];
       Object? failure;
@@ -202,7 +209,10 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     }
     // TMDB 分段但无 key：展开输入行，不搜。
     if (_source == ScrapeSource.tmdb && _storedTmdbKey().isEmpty) {
-      setState(() => _showTmdbKeyField = true);
+      setState(() {
+        _showTmdbKeyField = true;
+        _applyFailure = null;
+      });
       HibikiToast.show(msg: t.video_scrape_tmdb_key_required);
       return;
     }
@@ -210,6 +220,7 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
       _searching = true;
       _searched = true;
       _searchFailure = null;
+      _applyFailure = null;
     });
     List<ScrapeCandidate> results = const <ScrapeCandidate>[];
     Object? failure;
@@ -312,9 +323,10 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     setState(() {
       _applying = true;
       _applyingCandidate = candidate;
+      _applyFailure = null;
     });
     final CoverMatchCollectionTarget? collection = widget.collection;
-    Object? failure;
+    ({Object error, String detail})? failure;
     try {
       if (collection != null) {
         // 合集入口：下载 → 只写合集自有封面列。**刻意不调
@@ -337,10 +349,12 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
         );
       }
     } catch (e, stack) {
-      // 走下方失败分支——绝不吞成静默无反馈。原始原因进错误日志，界面只给
-      // 「失败了 + 大概因为什么」，不把堆栈抛到用户面前。
-      ErrorLogService.instance.log('CoverMatchDialog.applyCandidate', e, stack);
-      failure = e;
+      // 走下方失败分支——绝不吞成静默无反馈。与搜索失败共用完整详情视图；
+      // 日志和界面都只接收同一份脱敏文本，避免异常 URL 的 query 凭据泄露。
+      final String detail = redactCredentialsInText(e.toString());
+      ErrorLogService.instance
+          .log('CoverMatchDialog.applyCandidate', detail, stack);
+      failure = (error: e, detail: detail);
     }
     if (!mounted) return;
     if (failure != null) {
@@ -348,10 +362,8 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
       setState(() {
         _applying = false;
         _applyingCandidate = null;
+        _applyFailure = failure;
       });
-      HibikiToast.show(
-        msg: '${t.video_scrape_apply_failed}\n${_failureReason(failure)}',
-      );
       return;
     }
     // 成功：刷新库页 + 关弹窗 + 成功提示。onApplied 单独 guard，任何异常都不得阻断关闭
@@ -527,11 +539,29 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     if (_searched && _results.isEmpty) {
       return Center(child: Text(t.video_scrape_no_results));
     }
+    final ({Object error, String detail})? applyFailure = _applyFailure;
+    final int firstCandidateIndex = applyFailure == null ? 0 : 1;
     return ListView.separated(
-      itemCount: _results.length,
+      key: ValueKey<String>(
+        applyFailure == null
+            ? 'cover_match_results'
+            : 'cover_match_apply_failure',
+      ),
+      itemCount: _results.length + firstCandidateIndex,
       separatorBuilder: (_, __) => const Divider(height: 1),
-      itemBuilder: (BuildContext context, int index) =>
-          _buildCandidateTile(theme, _results[index]),
+      itemBuilder: (BuildContext context, int index) {
+        if (applyFailure != null && index == 0) {
+          return ScrapeFailureView(
+            title: t.video_scrape_apply_failed,
+            reason: _failureReason(applyFailure.error),
+            detail: applyFailure.detail,
+          );
+        }
+        return _buildCandidateTile(
+          theme,
+          _results[index - firstCandidateIndex],
+        );
+      },
     );
   }
 

--- a/hibiki/lib/src/media/video/scraper/cover_downloader.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_downloader.dart
@@ -15,6 +15,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:hibiki/src/media/media_cover_service.dart';
+import 'package:hibiki/src/media/metadata/credential_redaction.dart';
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
     show ScrapeNetworkException;
 import 'package:hibiki/src/media/video/video_import_dialog.dart'
@@ -56,7 +57,11 @@ class CoverDownloader {
     } on TimeoutException {
       throw const ScrapeNetworkException('Poster download timed out');
     } catch (e) {
-      throw ScrapeNetworkException('Poster request failed: $e');
+      // package:http 的 ClientException 会把完整请求 URL 拼进 toString()；候选
+      // 海报 URL 可能带签名/token，必须在异常构造侧先脱敏，保证日志/界面/复制同源安全。
+      throw ScrapeNetworkException(
+        redactCredentialsInText('Poster request failed: $e'),
+      );
     }
 
     if (response.statusCode < 200 || response.statusCode >= 300) {
@@ -80,7 +85,9 @@ class CoverDownloader {
       await MediaCoverService.applyCoverBytes(
           bytes: bytes, destPath: finalPath);
     } catch (e) {
-      throw ScrapeNetworkException('Cover write failed: $e');
+      throw ScrapeNetworkException(
+        redactCredentialsInText('Cover write failed: $e'),
+      );
     }
 
     return finalPath;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+996
+version: 1.3.1+997
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/metadata/book_cover_scrape_dialog_test.dart
+++ b/hibiki/test/media/metadata/book_cover_scrape_dialog_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/media/metadata/book_cover_scrape_dialog.dart';
@@ -131,6 +132,23 @@ void main() {
   // BUG-1219：两句折叠文案只回答「我该做什么」，不回答「到底怎么了」。完整异常串必须
   // 留在出错的地方，并且可一键复制上报（与视频封面匹配弹窗共用 ScrapeFailureView）。
   testWidgets('BUG-1219 搜索失败在弹窗内直出完整技术详情 + 可复制', (WidgetTester tester) async {
+    String? copied;
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      SystemChannels.platform,
+      (MethodCall call) async {
+        if (call.method == 'Clipboard.setData') {
+          copied = (call.arguments as Map<Object?, Object?>)['text'] as String?;
+        }
+        return null;
+      },
+    );
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        null,
+      );
+    });
+
     final BookMetadataScraper scraper = BookMetadataScraper(
       client: MockClient((http.Request req) async =>
           throw http.ClientException("Failed host lookup: 'api.bgm.tv'")),
@@ -151,12 +169,17 @@ void main() {
     await tester.tap(
         find.byKey(const ValueKey<String>('scrape_failure_detail_toggle')));
     await tester.pumpAndSettle();
-    expect(
-      find.byWidgetPredicate((Widget w) =>
-          w is SelectableText && (w.data ?? '').contains('api.bgm.tv')),
-      findsOneWidget,
-    );
+    final Finder detailFinder = find.byWidgetPredicate((Widget w) =>
+        w is SelectableText && (w.data ?? '').contains('api.bgm.tv'));
+    expect(detailFinder, findsOneWidget);
     expect(find.text(t.copy_error), findsOneWidget);
+
+    // 「复制错误」写出的必须是界面里这段完整详情，而不是折叠原因或截断文本。
+    final String detail =
+        tester.widget<SelectableText>(detailFinder).data ?? '';
+    await tester.tap(find.text(t.copy_error));
+    await tester.pump();
+    expect(copied, detail);
   });
 
   testWidgets('BUG-1219 源站 HTTP 500 的详情里带得到状态码', (WidgetTester tester) async {

--- a/hibiki/test/media/video/scraper/cover_downloader_test.dart
+++ b/hibiki/test/media/video/scraper/cover_downloader_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/metadata/credential_redaction.dart';
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
     show ScrapeNetworkException;
 import 'package:hibiki/src/media/video/scraper/cover_downloader.dart';
@@ -111,6 +112,27 @@ void main() {
     final String finalPath = p.join(tempDir.path, videoCoverFileName(bookUid));
     expect(File(finalPath).existsSync(), isFalse);
     expect(File('$finalPath.tmp').existsSync(), isFalse);
+  });
+
+  test('传输异常在构造侧脱敏候选海报 URL 凭据', () async {
+    const String secret = 'SECRET_POSTER_TOKEN_456';
+    final MockClient client = MockClient((http.Request req) async {
+      throw http.ClientException('connection reset', req.url);
+    });
+
+    try {
+      await CoverDownloader(client: client).downloadCover(
+        url: 'https://img.example/poster?size=original&api_key=$secret',
+        bookUid: 'uid-secret',
+        coversDirectory: tempDir,
+      );
+      fail('should throw');
+    } on ScrapeNetworkException catch (error) {
+      final String detail = error.toString();
+      expect(detail, contains('size=original'));
+      expect(detail, contains('api_key=$kRedactedPlaceholder'));
+      expect(detail, isNot(contains(secret)));
+    }
   });
 
   test('覆盖旧封面：同 uid 二次下载直接替换内容', () async {

--- a/hibiki/test/media/video/scraper/cover_match_dialog_test.dart
+++ b/hibiki/test/media/video/scraper/cover_match_dialog_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/models.dart';
+import 'package:hibiki/src/media/metadata/credential_redaction.dart';
 import 'package:hibiki/src/media/video/cover_ui/cover_match_dialog.dart';
 import 'package:hibiki/src/media/video/scraper/alias_cache.dart';
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
@@ -59,6 +60,7 @@ class _StubScraperService extends CoverScraperService {
 
   /// 逐次出队的搜索异常（非 null 即抛）。让「第一次失败 → 重试成功」可测。
   final List<Object?> searchErrors = <Object?>[];
+  final List<Object?> applyErrors = <Object?>[];
   int searchCalls = 0;
 
   @override
@@ -80,6 +82,8 @@ class _StubScraperService extends CoverScraperService {
     required ScrapeCandidate candidate,
     String? aliasKey,
   }) async {
+    final Object? error = applyErrors.isEmpty ? null : applyErrors.removeAt(0);
+    if (error != null) Error.throwWithStackTrace(error, StackTrace.current);
     appliedUids.addAll(bookUids);
     // 真写穿：成员封面被刷这件事必须在 DB 上留下痕迹，断言才有牙。
     for (final String uid in bookUids) {
@@ -248,6 +252,65 @@ void main() {
     expect(service.appliedUids, <String>['video/my_anime']);
     // 弹窗应用后关闭。
     expect(find.text(t.video_scrape_use), findsNothing);
+  });
+
+  testWidgets('TODO-2284 应用失败直出完整脱敏详情，候选保留可重试', (WidgetTester tester) async {
+    const String secret = 'SECRET_APPLY_KEY_123';
+    final VideoBookRow book = await seed();
+    final _StubScraperService service = buildService()
+      ..applyErrors.add(
+        const ScrapeNetworkException(
+          'Poster request failed: ClientException: connection reset, '
+          'uri=https://img.example/poster?size=original&api_key=$secret',
+        ),
+      );
+    final int logsBefore = ErrorLogService.instance.entries.length;
+
+    await tester.pumpWidget(wrap(CoverMatchDialog(
+      service: service,
+      book: book,
+      collectionMemberUids: const <String>['video/my_anime'],
+      onApplied: () {},
+    )));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text(t.video_scrape_use).first);
+    await tester.pumpAndSettle();
+
+    // 弹窗与候选都保留，用户可换候选或重试；失败不再只是一闪而过的两句 toast。
+    expect(find.text(t.video_scrape_apply_failed), findsOneWidget);
+    expect(find.text(t.video_scrape_use), findsOneWidget);
+    expect(
+      tester
+          .widget<FilledButton>(
+            find.widgetWithText(FilledButton, t.video_scrape_use),
+          )
+          .onPressed,
+      isNotNull,
+    );
+    expect(find.text(t.scrape_reason_network), findsOneWidget);
+    expect(find.byType(SelectableText), findsNothing);
+
+    await tester.tap(
+      find.byKey(const ValueKey<String>('scrape_failure_detail_toggle')),
+    );
+    await tester.pumpAndSettle();
+    final SelectableText detail =
+        tester.widget<SelectableText>(find.byType(SelectableText));
+    expect(detail.data, contains('Poster request failed'));
+    expect(detail.data, contains('size=original'));
+    expect(detail.data, contains('api_key=$kRedactedPlaceholder'));
+    expect(detail.data, isNot(contains(secret)));
+
+    // 错误日志与界面吃同一份脱敏详情，不能只堵 UI、让日志/上传继续漏。
+    final List<ErrorLogEntry> added =
+        ErrorLogService.instance.entries.sublist(logsBefore);
+    final ErrorLogEntry applyLog = added.singleWhere(
+      (ErrorLogEntry entry) =>
+          entry.source == 'CoverMatchDialog.applyCandidate',
+    );
+    expect(applyLog.error, contains('api_key=$kRedactedPlaceholder'));
+    expect(applyLog.error, isNot(contains(secret)));
   });
 
   // BUG-1176：搜索失败曾被 `catch (_)` 吞成空表，界面显示「无匹配」——用户无从分辨

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -1163,6 +1163,20 @@ void main() {
     );
   });
 
+  test('scrape failure detail uses the shared MD3 card and design tokens', () {
+    final String source = File(
+      'lib/src/media/metadata/scrape_failure_view.dart',
+    ).readAsStringSync();
+
+    expect(source, contains('HibikiCard('));
+    expect(source, contains('HibikiDesignTokens.of(context)'));
+    expect(source, contains('tokens.surfaces.overlay'));
+    expect(source, contains('tokens.radii.cardRadius'));
+    expect(source, contains('tokens.spacing.gap'));
+    expect(source, isNot(contains('surfaceContainerHighest')));
+    expect(source, isNot(contains('BorderRadius.circular(')));
+  });
+
   test('reader history hover overlays use design tokens', () {
     // BookDragTarget 已从 reader_hibiki_history_page.dart 提取为独立文件
     // book_drag_target.dart（history 页只剩调用点），守卫跟随到新文件。


### PR DESCRIPTION
## What changed

- route `ScrapeFailureView`'s detail block through `HibikiCard` and shared MD3
  surface/radius/spacing tokens, without adding an allowlist
- keep full error details collapsed by default and verify copy writes the exact
  complete detail
- show cover-application failures persistently through the same shared failure
  view while keeping candidates and the retry button available
- redact credential-like query values at poster-download exception construction
  and again before application errors enter logs/UI
- bump the app build from `1.3.1+996` to `1.3.1+997`

## Why

PR #548 introduced a hand-built `surfaceContainerHighest` +
`BorderRadius.circular(8)` detail block, which made the develop Build Release
APK run fail the MD3 static gate. The application stage also still discarded
the full failure message and only showed the old two-line toast. Candidate
poster URLs can carry signed query parameters, so surfacing their exceptions
also needs to preserve the existing credential boundary.

## User impact

Search and application failures now use one consistent failure presentation: a
human-readable reason, an expandable complete detail, and copy support.
Application failures no longer disappear with a toast; users can inspect the
reason and retry without losing the candidate list. Credential values are
excluded from both the visible detail and error log.

## Validation

- `flutter test test/settings/md3_design_system_static_test.dart --no-pub` -
  60 passed
- `flutter test test/media/metadata/book_cover_scrape_dialog_test.dart --no-pub`
  - 7 passed
- `flutter test test/media/metadata/credential_redaction_test.dart --no-pub` -
  4 passed
- `flutter test test/media/video/scraper/cover_match_dialog_test.dart --no-pub`
  - 9 passed
- `flutter test test/media/video/scraper/cover_downloader_test.dart --no-pub` -
  7 passed
- `flutter analyze` - no issues

Tracks TODO-2288, TODO-2302, and TODO-2284. Does not touch TODO-2303 / Magpie.
