### PR TITLE
fix(reader): 修复跨章节书内搜索定位与高亮

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1190 条。点号进各自文件。
+> 共 1191 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1233](bugs/BUG-1233-book-import-repeated-archive-probe.md) | ✅ | ✅ | 书籍导入重复整包判定 EPUB 载体 |
+| [BUG-1231](bugs/BUG-1231-cross-chapter-search-locate-race.md) | ✅ | ✅ | 跨章节书内搜索只跳到章首且不高亮 |
 | [BUG-1228](bugs/BUG-1228-video-mining-queue.md) | ✅ | ✅ | 连续视频制卡未串行且换集可能污染在途任务 |
 | [BUG-1227](bugs/BUG-1227-anki-media-upload-orphan.md) | ✅ | ✅ | 大 GIF 上传超时被吞后仍创建无图卡并留下孤儿媒体 |
 | [BUG-1226](bugs/BUG-1226-anki-mining-ui-thread-stall.md) | ✅ | ✅ | 制卡前查重导致 Anki 未响应 |

--- a/docs/bugs/BUG-1231-cross-chapter-search-locate-race.md
+++ b/docs/bugs/BUG-1231-cross-chapter-search-locate-race.md
@@ -4,20 +4,27 @@
 - **真实性**：✅ 真 bug。根因位于
   `hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart:546-551` 的异步边界
   （修复后的绑定点见同文件 `390-402`）：
-  `_navigateToChapterAndWait` 先 `await _navigateToChapter()`，后者内部又
+  第一层根因是 `_navigateToChapterAndWait` 先 `await _navigateToChapter()`，后者内部又
   `await InAppWebViewController.loadUrl()`，返回后才写入 `_pendingPreciseLocate`。
   部分平台上 `loadUrl` 的 Future 返回前，新页面已经完成恢复并触发
   `_onRestoreComplete`；恢复链此时消费到空 pending，随后补写的
   `scrollToSearchMatch` 再无执行入口。因此章节导航本身成功，但章内定位与
-  `hoshi-search` CSS Highlight 都没有发生。同章分支不重载页面，直接执行
-  `scrollToSearchMatch`，所以不受该竞态影响。
+  `hoshi-search` CSS Highlight 都没有发生。审查又发现第二层竞态：
+  `_beginNavigation` 在目标 DOM ready 前已提前更新 `_currentChapter`；若 restore 中
+  再点同一目标章的另一个命中，旧分流只比较章号，便会对旧 DOM 直接执行第二次 JS，
+  而第一条 pending 随后在新 DOM settle 后反向覆盖它。
 - **[x] ① 已修复** — 把 `preciseLocateJs` 沿
   `_navigateToChapterAndWait → _navigateToChapter → _beginNavigation` 传入，在导航代际
   递增后立即绑定 pending，严格早于 `loadUrl`。新导航仍先清理上一代 pending，
-  失败/超时也会清理本代 pending，保留原有代际隔离语义。修复随本 PR 提交。
+  失败/超时也会清理本代 pending，保留原有代际隔离语义；并将章号与
+  `_restoreInFlight` / `_readerContentReady` 一起判定 DOM 所有权。同一逻辑目标章尚未
+  ready 时，新命中替换当前代际 pending，确保最后一次选择胜出；dispose 复用
+  `_failNavigation()` 立即清 pending 并完成 wait=false，不执行晚到的旧 DOM 定位。
 - **[x] ② 已加自动化测试** —
-  `hibiki/test/pages/chapter_jump_double_jump_atomic_chain_test.dart` 新增时序守卫：
+  `hibiki/test/pages/chapter_jump_double_jump_atomic_chain_test.dart` 保留时序守卫：
   定位意图必须完整转发到 `_beginNavigation`，绑定点必须位于
-  `await _loadChapterDirectly(index)` 之前；同时继续锁住一次消费和代际守卫。
+  `await _loadChapterDirectly(index)` 之前；同时
+  `hibiki/test/reader/reader_search_navigation_test.dart` 真执行共享状态机，覆盖跨章、
+  ready 同章、restore 中同章二次选择、重复文本不同 offset、代际顶替和 dispose。
 - **备注**：已做源码链路验真和自动化回归；按用户要求不等待完整编译验收。本条属于
   reader/WebView 交互，原始跨章节点击路径仍应由 PR CI 后补真实设备肉眼复测。

--- a/docs/bugs/BUG-1231-cross-chapter-search-locate-race.md
+++ b/docs/bugs/BUG-1231-cross-chapter-search-locate-race.md
@@ -12,7 +12,9 @@
   `hoshi-search` CSS Highlight 都没有发生。审查又发现第二层竞态：
   `_beginNavigation` 在目标 DOM ready 前已提前更新 `_currentChapter`；若 restore 中
   再点同一目标章的另一个命中，旧分流只比较章号，便会对旧 DOM 直接执行第二次 JS，
-  而第一条 pending 随后在新 DOM settle 后反向覆盖它。
+  而第一条 pending 随后在新 DOM settle 后反向覆盖它。独立复核再发现第三层竞态：
+  `onRestoreComplete` 没有携带创建该文档时的导航代次；旧文档的迟到回调可能完成新代
+  restore，并在 generation mismatch 时先清掉新代 pending。
 - **[x] ① 已修复** — 把 `preciseLocateJs` 沿
   `_navigateToChapterAndWait → _navigateToChapter → _beginNavigation` 传入，在导航代际
   递增后立即绑定 pending，严格早于 `loadUrl`。新导航仍先清理上一代 pending，
@@ -20,11 +22,15 @@
   `_restoreInFlight` / `_readerContentReady` 一起判定 DOM 所有权。同一逻辑目标章尚未
   ready 时，新命中替换当前代际 pending，确保最后一次选择胜出；dispose 复用
   `_failNavigation()` 立即清 pending 并完成 wait=false，不执行晚到的旧 DOM 定位。
+  每导航 config 另携带 immutable `navigationGeneration`，三种 reader shell 均随
+  restore 回调原样回传；Dart 在任何计时、ready、pending 副作用前校验回调代次。
+  stale generation 的 queue consume 只返回空、不清当前代 pending。
 - **[x] ② 已加自动化测试** —
   `hibiki/test/pages/chapter_jump_double_jump_atomic_chain_test.dart` 保留时序守卫：
   定位意图必须完整转发到 `_beginNavigation`，绑定点必须位于
   `await _loadChapterDirectly(index)` 之前；同时
   `hibiki/test/reader/reader_search_navigation_test.dart` 真执行共享状态机，覆盖跨章、
-  ready 同章、restore 中同章二次选择、重复文本不同 offset、代际顶替和 dispose。
+  ready 同章、restore 中同章二次选择、重复文本不同 offset、迟到旧回调不得消费或
+  清除新代最终选择、代际顶替和 dispose；引擎静态守卫另锁定三种 shell 的代次运输链。
 - **备注**：已做源码链路验真和自动化回归；按用户要求不等待完整编译验收。本条属于
   reader/WebView 交互，原始跨章节点击路径仍应由 PR CI 后补真实设备肉眼复测。

--- a/docs/bugs/BUG-1231-cross-chapter-search-locate-race.md
+++ b/docs/bugs/BUG-1231-cross-chapter-search-locate-race.md
@@ -1,0 +1,23 @@
+## BUG-1231 · 跨章节书内搜索只跳到章首且不高亮
+
+- **报告**：2026-07-29（用户：书内搜索命中其他章节时只跳到目标章开头，命中词既不定位也不高亮；同章命中正常）
+- **真实性**：✅ 真 bug。根因位于
+  `hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart:546-551` 的异步边界
+  （修复后的绑定点见同文件 `390-402`）：
+  `_navigateToChapterAndWait` 先 `await _navigateToChapter()`，后者内部又
+  `await InAppWebViewController.loadUrl()`，返回后才写入 `_pendingPreciseLocate`。
+  部分平台上 `loadUrl` 的 Future 返回前，新页面已经完成恢复并触发
+  `_onRestoreComplete`；恢复链此时消费到空 pending，随后补写的
+  `scrollToSearchMatch` 再无执行入口。因此章节导航本身成功，但章内定位与
+  `hoshi-search` CSS Highlight 都没有发生。同章分支不重载页面，直接执行
+  `scrollToSearchMatch`，所以不受该竞态影响。
+- **[x] ① 已修复** — 把 `preciseLocateJs` 沿
+  `_navigateToChapterAndWait → _navigateToChapter → _beginNavigation` 传入，在导航代际
+  递增后立即绑定 pending，严格早于 `loadUrl`。新导航仍先清理上一代 pending，
+  失败/超时也会清理本代 pending，保留原有代际隔离语义。修复随本 PR 提交。
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/pages/chapter_jump_double_jump_atomic_chain_test.dart` 新增时序守卫：
+  定位意图必须完整转发到 `_beginNavigation`，绑定点必须位于
+  `await _loadChapterDirectly(index)` 之前；同时继续锁住一次消费和代际守卫。
+- **备注**：已做源码链路验真和自动化回归；按用户要求不等待完整编译验收。本条属于
+  reader/WebView 交互，原始跨章节点击路径仍应由 PR CI 后补真实设备肉眼复测。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -164,8 +164,7 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     // BUG-1218：真实路径保留大小写（越界判据仍走 canonicalize），否则大小写敏感
     // 平台上图片查看器/分享取不到 EPUB 内插图。
     final String joined = p.join(_extractDir!, epubPath);
-    if (!p.isWithin(
-        p.canonicalize(_extractDir!), p.canonicalize(joined))) {
+    if (!p.isWithin(p.canonicalize(_extractDir!), p.canonicalize(joined))) {
       return null;
     }
     final String filePath = p.normalize(joined);
@@ -1517,32 +1516,46 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         epubBook: _book,
         chapterLabel: _currentChapterLabel(),
         onSearchJump: (BookSearchResult result, String query) async {
-          if (_book == null || _controller == null) return;
-          if (result.sectionIndex != _currentChapter) {
-            // TODO-1309：跨章搜索跳转把「章内定位」排进导航的原子恢复链（settle 之后应用），
-            // 不再在 restore 完成微任务里抢发被 settle-reflow / 连续重锚采样冲回章首（双跳，
-            // 首跳只到章节）。去掉旧的首跳失败早退分支——旧代码首跳超时/代际 stale 时会停在
-            // 章首、要点第二次才走「同章直接 restore」才生效；现在定位随恢复落定 settle
-            // 之后由 _applyPendingPreciseLocate 确定性应用。文本命中无法用分数烘进 shell，故走
-            // preciseLocateJs 队列（书签/收藏用 progress 烘进导航）。
-            await _navigateToChapterAndWait(
-              result.sectionIndex,
-              manual: true,
-              preciseLocateJs:
-                  ReaderPaginationScripts.scrollToSearchMatchInvocation(
-                query,
-                result.charOffset,
-              ),
-            );
-            return;
-          }
-          // 同章：章节已 settle，直接定位（既有正常路径，双跳的「第二次点」本就走这里）。
-          await _controller!.evaluateJavascript(
-            source: ReaderPaginationScripts.scrollToSearchMatchInvocation(
-              query,
-              result.charOffset,
-            ),
+          if (!mounted || _book == null || _controller == null) return;
+          final String preciseLocateJs =
+              ReaderPaginationScripts.scrollToSearchMatchInvocation(
+            query,
+            result.charOffset,
           );
+          final ReaderSearchJumpAction action = decideReaderSearchJump(
+            targetChapter: result.sectionIndex,
+            currentChapter: _currentChapter,
+            restoreInFlight: _restoreInFlight,
+            readerContentReady: _readerContentReady,
+          );
+          switch (action) {
+            case ReaderSearchJumpAction.navigate:
+              // TODO-1309：跨章搜索跳转把「章内定位」排进导航的原子恢复链（settle 之后应用），
+              // 不再在 restore 完成微任务里抢发被 settle-reflow / 连续重锚采样冲回章首（双跳，
+              // 首跳只到章节）。去掉旧的首跳失败早退分支——旧代码首跳超时/代际 stale 时会停在
+              // 章首、要点第二次才走「同章直接 restore」才生效；现在定位随恢复落定 settle
+              // 之后由 _applyPendingPreciseLocate 确定性应用。文本命中无法用分数烘进 shell，故走
+              // preciseLocateJs 队列（书签/收藏用 progress 烘进导航）。
+              await _navigateToChapterAndWait(
+                result.sectionIndex,
+                manual: true,
+                preciseLocateJs: preciseLocateJs,
+              );
+              return;
+            case ReaderSearchJumpAction.replacePending:
+              // _currentChapter 在 loadUrl 前就切到逻辑目标章。DOM 尚未 ready 时再次选择
+              // 同章结果，必须更新本导航代际的 pending；直接 evaluate 会命中旧 DOM，
+              // 且首条 pending 会在 restore settle 后反过来覆盖用户最后一次选择。
+              _preciseLocateQueue.replace(
+                generation: _navigateGeneration,
+                js: preciseLocateJs,
+              );
+              return;
+            case ReaderSearchJumpAction.evaluateNow:
+              // 同章且 DOM 已 settle：直接定位（既有正常路径）。
+              await _controller!.evaluateJavascript(source: preciseLocateJs);
+              return;
+          }
         },
         favoriteSentences: favorites,
         favoritePositionLabel: _favoritePositionLabel,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -393,10 +393,12 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     // 若调用方 await loadUrl 后才写 pending，onRestoreComplete 可能已经消费过空值，最终只
     // 落到目标章章首且没有搜索高亮。用户在恢复途中翻页/再跳时，新一次 _beginNavigation
     // 仍会从源头顶掉旧 pending；代际守卫继续兜底。
-    _pendingPreciseLocate = null;
+    _preciseLocateQueue.clear();
     if (preciseLocateJs != null) {
-      _pendingPreciseLocate =
-          (generation: _navigateGeneration, js: preciseLocateJs);
+      _preciseLocateQueue.replace(
+        generation: _navigateGeneration,
+        js: preciseLocateJs,
+      );
     }
     if (_restoreCompleter != null && !_restoreCompleter!.isCompleted) {
       _restoreCompleter!.complete(false);
@@ -440,7 +442,7 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     ReaderChapterPerfTrace.abort();
     _isNavigatingToChapter = false;
     _restoreInFlight = false;
-    _pendingPreciseLocate = null;
+    _preciseLocateQueue.clear();
     if (_restoreCompleter != null && !_restoreCompleter!.isCompleted) {
       _restoreCompleter!.complete(false);
     }
@@ -577,13 +579,13 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
   /// 代际守卫：`pending.generation != _navigateGeneration` = 被更晚的导航顶掉 → 丢弃，
   /// 绝不把搜索命中定位应用到错误章节。消费一次即清空（无论应用与否）。
   Future<void> _applyPendingPreciseLocate() async {
-    final ({int generation, String js})? pending = _pendingPreciseLocate;
-    if (pending == null) return;
-    _pendingPreciseLocate = null;
-    if (pending.generation != _navigateGeneration) return;
-    if (!mounted || _controller == null) return;
+    final String? js = _preciseLocateQueue.consume(
+      generation: _navigateGeneration,
+      canApply: mounted && _controller != null,
+    );
+    if (js == null) return;
     try {
-      await _controller!.evaluateJavascript(source: pending.js);
+      await _controller!.evaluateJavascript(source: js);
     } catch (e, stack) {
       ErrorLogService.instance
           .log('ReaderHibiki._applyPendingPreciseLocate', e, stack);

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -78,6 +78,27 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     _contentReadyDeadline = null;
   }
 
+  void _acceptRestoreComplete({
+    required int reportedGeneration,
+    Object? perfSnapshot,
+  }) {
+    if (!mounted ||
+        !isCurrentReaderRestoreCompletion(
+          reportedGeneration: reportedGeneration,
+          currentGeneration: _navigateGeneration,
+          expectedGeneration: _restoreExpectedGeneration,
+        )) {
+      debugPrint(
+        '[ReaderHibiki] stale onRestoreComplete: '
+        'reported=$reportedGeneration expected=$_restoreExpectedGeneration '
+        'current=$_navigateGeneration',
+      );
+      return;
+    }
+    ReaderChapterPerfTrace.noteJs(perfSnapshot);
+    _onRestoreComplete();
+  }
+
   void _onRestoreComplete() {
     ReaderChapterPerfTrace.mark('jsInitRestore');
     // BUG-438 / TODO-889：恢复完成=内容真正就绪，清掉兜底 deadline，下次导航拿新窗口。
@@ -86,13 +107,6 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     // 挡住随后的残余滚轮/惯性在新章边界二次跨章（滚轮离散事件在长加载期间不续窗的真因）。
     _noteChapterTurnSettledIfPending();
     if (!mounted) {
-      return;
-    }
-    if (_restoreExpectedGeneration != _navigateGeneration) {
-      debugPrint(
-        '[ReaderHibiki] stale onRestoreComplete: '
-        'expected=$_restoreExpectedGeneration current=$_navigateGeneration',
-      );
       return;
     }
     _restoreInFlight = false;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -384,13 +384,20 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     required int charOffset,
     int charOffsetEnd = -1,
     String? fragment,
+    String? preciseLocateJs,
   }) {
     _restoreExpectedGeneration = ++_navigateGeneration;
-    // TODO-1309：新一次导航开始 → 作废上一次排队但未消费的章内精确定位（文本搜索
-    // 跳转）。用户在搜索跳转恢复途中翻页/再跳，旧的 scrollToSearchMatch 不该落到新章
-    // （代际守卫同样兜底，这里从源头清掉，belt-and-suspenders）。_navigateToChapterAndWait
-    // 在本方法返回后才写入本次的 pending，故不会误清本次。
+    // BUG-1231 / TODO-1309：新导航先作废上一代的章内精确定位，再把本次定位绑定到
+    // 已递增的导航代际。绑定必须与导航状态初始化同处、且发生在 loadUrl 之前：
+    // InAppWebViewController.loadUrl 的 Future 在部分平台会等到页面生命周期已推进后才返回，
+    // 若调用方 await loadUrl 后才写 pending，onRestoreComplete 可能已经消费过空值，最终只
+    // 落到目标章章首且没有搜索高亮。用户在恢复途中翻页/再跳时，新一次 _beginNavigation
+    // 仍会从源头顶掉旧 pending；代际守卫继续兜底。
     _pendingPreciseLocate = null;
+    if (preciseLocateJs != null) {
+      _pendingPreciseLocate =
+          (generation: _navigateGeneration, js: preciseLocateJs);
+    }
     if (_restoreCompleter != null && !_restoreCompleter!.isCompleted) {
       _restoreCompleter!.complete(false);
     }
@@ -433,6 +440,7 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     ReaderChapterPerfTrace.abort();
     _isNavigatingToChapter = false;
     _restoreInFlight = false;
+    _pendingPreciseLocate = null;
     if (_restoreCompleter != null && !_restoreCompleter!.isCompleted) {
       _restoreCompleter!.complete(false);
     }
@@ -460,6 +468,7 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     int? charOffset,
     int charOffsetEnd = -1,
     bool manual = false,
+    String? preciseLocateJs,
   }) async {
     if (_book == null || index < 0 || index >= _book!.chapters.length) {
       return;
@@ -497,6 +506,7 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
       progress: progress,
       charOffset: charOffset ?? -1,
       charOffsetEnd: charOffsetEnd,
+      preciseLocateJs: preciseLocateJs,
     );
     _lastProgressCharOffset = _initialCharOffset;
 
@@ -537,15 +547,8 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
         progress: progress,
         charOffset: charOffset,
         charOffsetEnd: charOffsetEnd,
-        manual: manual);
-    if (preciseLocateJs != null) {
-      // 绑定本次导航代际（_beginNavigation 刚在 _navigateToChapter 里递增）：并发导航
-      // 顶掉后代际不匹配 → 消费时丢弃，绝不把搜索命中定位应用到错误章节。设在
-      // _navigateToChapter 之后（代际已定）、restore 完成之前（章节装载异步，
-      // _onRestoreComplete 稍后才触发），故稳被本次 _onRestoreComplete 消费。
-      _pendingPreciseLocate =
-          (generation: _navigateGeneration, js: preciseLocateJs);
-    }
+        manual: manual,
+        preciseLocateJs: preciseLocateJs);
     final bool success = await _restoreCompleter?.future.timeout(
           const Duration(seconds: 10),
           onTimeout: () {

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -162,8 +162,7 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     final String joinedPath = p.join(_extractDir!, epubPath);
     final String normExtractDir = p.normalize(_extractDir!);
     final String filePath = p.normalize(joinedPath);
-    if (!p.isWithin(
-        p.canonicalize(_extractDir!), p.canonicalize(joinedPath))) {
+    if (!p.isWithin(p.canonicalize(_extractDir!), p.canonicalize(joinedPath))) {
       return _forbidden('path traversal blocked: $epubPath');
     }
     final File file = File(filePath);
@@ -557,8 +556,7 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     try {
       // BUG-1218：真实 stat 路径保留大小写（越界判据仍走 canonicalize）。
       final String joined = p.join(extractDir, relativeHref);
-      if (!p.isWithin(
-          p.canonicalize(extractDir), p.canonicalize(joined))) {
+      if (!p.isWithin(p.canonicalize(extractDir), p.canonicalize(joined))) {
         return 0;
       }
       final String filePath = p.normalize(joined);

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -608,7 +608,10 @@ extension _ReaderWebView on _ReaderHibikiPageState {
   ///
   /// 这里聚齐的就是**改动前逐个插进脚本源码的那些值**——现在改成一份小 JSON 随
   /// boot 下发，引擎运行时读取。新增 per-nav 参数一律加在这里，不得回到脚本里插值。
-  ReaderEngineConfig _buildReaderEngineConfig({String? sasayakiCuesJson}) {
+  ReaderEngineConfig _buildReaderEngineConfig({
+    required int navigationGeneration,
+    String? sasayakiCuesJson,
+  }) {
     final ReaderSettings s = _settings!;
     // TODO-113: 滑动翻页距离阈值随灵敏度系数缩放。基础值 44px（纯距离触发）/ 22px
     // （配合速度的快速短滑触发），系数 1.0 = 默认「轻快」手感，越大越迟钝（需滑得更远）。
@@ -639,6 +642,7 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     _paginatedWidth = screenSize.width;
     _paginatedHeight = screenSize.height;
     return ReaderEngineConfig(
+      navigationGeneration: navigationGeneration,
       continuousMode: continuousMode,
       vnMode: vnMode,
       vnClickAdvance: vnMode && vnClickAdvanceM0ForceOn,
@@ -1813,12 +1817,24 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
 
         controller.addJavaScriptHandler(
           handlerName: 'onRestoreComplete',
-          // args[0] = JS 侧 perfSnapshot()（跨章分段计时诊断，见
-          // ReaderChapterPerfTrace）；恢复流程本身不依赖它，缺失/为空都无碍，故在
-          // handler 里就地消费，不进 _onRestoreComplete 的签名。
+          // args[0] = JS 侧 perfSnapshot()；args[1] = 文档安装引擎时捕获的
+          // navigationGeneration。代次缺失/失配一律不能完成当前 restore，更不能
+          // 消费当前代 pending。
           callback: (List<dynamic> args) {
-            ReaderChapterPerfTrace.noteJs(args.isEmpty ? null : args.first);
-            _onRestoreComplete();
+            if (args.length < 2 || args[1] is! num) {
+              debugPrint('[ReaderHibiki] onRestoreComplete missing generation');
+              return;
+            }
+            final num rawGeneration = args[1] as num;
+            if (!rawGeneration.isFinite ||
+                rawGeneration != rawGeneration.toInt()) {
+              debugPrint('[ReaderHibiki] onRestoreComplete invalid generation');
+              return;
+            }
+            _acceptRestoreComplete(
+              reportedGeneration: rawGeneration.toInt(),
+              perfSnapshot: args.first,
+            );
           },
         );
 
@@ -2408,8 +2424,10 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
       // per-nav 参数走 config，引擎源码按 view-mode memoized。两半拼成**一次**
       // evaluateJavascript 发出去——注入通道与执行时刻都与改动前逐字相同，省掉的是
       // Dart 侧每章重新拼装 + 压缩近万行（实测 buildSetupScript 中位数 9ms）。
-      final ReaderEngineConfig engineConfig =
-          _buildReaderEngineConfig(sasayakiCuesJson: sasayakiCuesJson);
+      final ReaderEngineConfig engineConfig = _buildReaderEngineConfig(
+        navigationGeneration: gen,
+        sasayakiCuesJson: sasayakiCuesJson,
+      );
       final String engineSource = readerEngineSource(
         vnMode: engineConfig.vnMode,
         continuousMode: engineConfig.continuousMode,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -60,6 +60,7 @@ import 'package:hibiki/src/reader/reader_content_styles.dart';
 import 'package:hibiki/src/reader/image_reveal_key.dart';
 import 'package:hibiki/src/reader/reader_resource_sanitizer.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
+import 'package:hibiki/src/reader/reader_search_navigation.dart';
 import 'package:hibiki/src/reader/reader_selection_data.dart';
 import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 import 'package:hibiki/src/reader/reader_chrome_floating.dart';
@@ -1162,7 +1163,8 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   // _applyPendingPreciseLocate 在恢复落定且 settle 之后消费。代际用于并发导航去重（顶掉后
   // 代际不匹配即丢弃，不误用到别的章）。null=无待处理。书签/收藏/字符跳转把分数烘进导航
   // （_navigateToChapterAndWait 的 progress），单次原子恢复直接落点，不入本队列。
-  ({int generation, String js})? _pendingPreciseLocate;
+  final ReaderPreciseLocateQueue _preciseLocateQueue =
+      ReaderPreciseLocateQueue();
 
   double _stableTopInset = 0;
   double _stableBottomInset = 0;
@@ -2018,6 +2020,10 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
 
   @override
   void dispose() {
+    // Search navigation can still be awaiting restore while the route closes.
+    // Complete it as failed now (and clear its precise-locate request) instead
+    // of leaving the callback alive until the 10-second timeout.
+    _failNavigation();
     assert(() {
       ReaderHibikiPage.debugEvaluateJavascript = null;
       ReaderHibikiPage.debugCaptureWebView = null;

--- a/hibiki/lib/src/reader/reader_engine_config.dart
+++ b/hibiki/lib/src/reader/reader_engine_config.dart
@@ -20,6 +20,7 @@ import 'package:flutter/foundation.dart' show immutable;
 @immutable
 class ReaderEngineConfig {
   const ReaderEngineConfig({
+    required this.navigationGeneration,
     required this.continuousMode,
     required this.vnMode,
     required this.vnClickAdvance,
@@ -52,6 +53,11 @@ class ReaderEngineConfig {
     required this.vnMergeCrossScreenSasayakiCues,
     this.sasayakiCuesJson,
   });
+
+  /// Immutable token identifying the document/navigation that owns this
+  /// config. Restore callbacks must echo it so a late callback from a replaced
+  /// document cannot complete or mutate the active navigation.
+  final int navigationGeneration;
 
   // ── 视图模式 / 手势 ────────────────────────────────────────────────
   final bool continuousMode;
@@ -105,6 +111,7 @@ class ReaderEngineConfig {
 
   /// 除 [sasayakiCuesJson] 外的全部字段（它是已编码的 JSON 片段，见 [toJsLiteral]）。
   Map<String, Object?> toJson() => <String, Object?>{
+        'navigationGeneration': navigationGeneration,
         'continuousMode': continuousMode,
         'vnMode': vnMode,
         'vnClickAdvance': vnClickAdvance,

--- a/hibiki/lib/src/reader/reader_pagination_scripts.dart
+++ b/hibiki/lib/src/reader/reader_pagination_scripts.dart
@@ -1060,7 +1060,11 @@ window.__hoshiInstallShell = function(C) {
   notifyRestoreComplete: function() {
     this.perfMark('restoreDone');
     if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
-      window.flutter_inappwebview.callHandler('onRestoreComplete', this.perfSnapshot());
+      window.flutter_inappwebview.callHandler(
+        'onRestoreComplete',
+        this.perfSnapshot(),
+        C.navigationGeneration
+      );
     }
     if (typeof this.warmPaginationMetrics === 'function') {
       this.warmPaginationMetrics();

--- a/hibiki/lib/src/reader/reader_search_navigation.dart
+++ b/hibiki/lib/src/reader/reader_search_navigation.dart
@@ -1,0 +1,62 @@
+enum ReaderSearchJumpAction {
+  navigate,
+  replacePending,
+  evaluateNow,
+}
+
+/// Decides which DOM owns a book-search result.
+///
+/// [currentChapter] is the logical navigation target and is updated before the
+/// target document has loaded. It is therefore not sufficient on its own to
+/// decide that JavaScript can run against the current DOM.
+ReaderSearchJumpAction decideReaderSearchJump({
+  required int targetChapter,
+  required int currentChapter,
+  required bool restoreInFlight,
+  required bool readerContentReady,
+}) {
+  if (targetChapter != currentChapter) {
+    return ReaderSearchJumpAction.navigate;
+  }
+  if (restoreInFlight || !readerContentReady) {
+    return ReaderSearchJumpAction.replacePending;
+  }
+  return ReaderSearchJumpAction.evaluateNow;
+}
+
+/// Last-write-wins queue for a precise locate bound to a navigation generation.
+///
+/// Search results can be selected again after the logical current chapter has
+/// changed but before the corresponding document is ready. Replacing the
+/// request within the active generation ensures the final selection is the one
+/// applied after restore settles.
+class ReaderPreciseLocateQueue {
+  ({int generation, String js})? _pending;
+
+  void replace({
+    required int generation,
+    required String js,
+  }) {
+    _pending = (generation: generation, js: js);
+  }
+
+  void clear() {
+    _pending = null;
+  }
+
+  /// Consumes the active generation once.
+  ///
+  /// A disposed/unavailable reader passes [canApply] as false; the request is
+  /// still discarded so it can never leak into a later document.
+  String? consume({
+    required int generation,
+    required bool canApply,
+  }) {
+    final ({int generation, String js})? pending = _pending;
+    _pending = null;
+    if (!canApply || pending == null || pending.generation != generation) {
+      return null;
+    }
+    return pending.js;
+  }
+}

--- a/hibiki/lib/src/reader/reader_search_navigation.dart
+++ b/hibiki/lib/src/reader/reader_search_navigation.dart
@@ -24,6 +24,19 @@ ReaderSearchJumpAction decideReaderSearchJump({
   return ReaderSearchJumpAction.evaluateNow;
 }
 
+/// Whether a restore-complete event belongs to the active navigation.
+///
+/// [reportedGeneration] is captured in the document's immutable per-navigation
+/// config. Comparing only the two Dart fields is insufficient: both fields
+/// have already advanced when an old document reports completion late.
+bool isCurrentReaderRestoreCompletion({
+  required int reportedGeneration,
+  required int currentGeneration,
+  required int expectedGeneration,
+}) =>
+    reportedGeneration == currentGeneration &&
+    reportedGeneration == expectedGeneration;
+
 /// Last-write-wins queue for a precise locate bound to a navigation generation.
 ///
 /// Search results can be selected again after the logical current chapter has
@@ -53,10 +66,14 @@ class ReaderPreciseLocateQueue {
     required bool canApply,
   }) {
     final ({int generation, String js})? pending = _pending;
-    _pending = null;
-    if (!canApply || pending == null || pending.generation != generation) {
+    if (!canApply) {
+      _pending = null;
       return null;
     }
+    // A stale restore callback must not discard the active generation's final
+    // selection. Only its owning generation may consume the request.
+    if (pending == null || pending.generation != generation) return null;
+    _pending = null;
     return pending.js;
   }
 }

--- a/hibiki/lib/src/reader/reader_visual_novel_scripts.dart
+++ b/hibiki/lib/src/reader/reader_visual_novel_scripts.dart
@@ -864,7 +864,11 @@ window.hoshiReader = {
     // (HoshiReaderRestore). Hibiki is InAppWebView, so forward to the same
     // 'onRestoreComplete' handler the paginated/continuous shells use.
     if (window.flutter_inappwebview && window.flutter_inappwebview.callHandler) {
-      window.flutter_inappwebview.callHandler('onRestoreComplete');
+      window.flutter_inappwebview.callHandler(
+        'onRestoreComplete',
+        null,
+        C.navigationGeneration
+      );
     }
   },
   buildNodeOffsets: function() {

--- a/hibiki/test/pages/chapter_jump_double_jump_atomic_chain_test.dart
+++ b/hibiki/test/pages/chapter_jump_double_jump_atomic_chain_test.dart
@@ -28,7 +28,7 @@ void main() {
     return source.substring(a, b);
   }
 
-  test('_navigateToChapterAndWait 收 progress + preciseLocateJs 并转发/绑定代际', () {
+  test('_navigateToChapterAndWait 收 progress + preciseLocateJs 并全部转发', () {
     final String body = slice(
       'Future<bool> _navigateToChapterAndWait(',
       'return success && _currentChapter == resolvedChapter;',
@@ -47,25 +47,34 @@ void main() {
         reason: 'charOffset 必须转发（收藏绝对字符锚运输通道）');
     expect(body, contains('progress: progress,'),
         reason: 'progress 仍必须转发（书签/字符跳转分数路径）');
-    // pending 必须绑定本次导航代际（并发导航去重，防应用到错误章节）。
-    expect(body,
-        contains('(generation: _navigateGeneration, js: preciseLocateJs)'),
-        reason: 'pending 必须绑定 _navigateGeneration');
-    // 绑定必须在 _navigateToChapter（递增代际）之后。
-    final int navIdx = body.indexOf('_navigateToChapter(index,');
-    final int bindIdx =
-        body.indexOf('generation: _navigateGeneration, js: preciseLocateJs');
-    expect(bindIdx, greaterThan(navIdx),
-        reason: '必须在 _navigateToChapter（代际已定）之后再绑定 pending');
+    expect(body, contains('preciseLocateJs: preciseLocateJs'),
+        reason: '搜索定位意图必须转发到 _navigateToChapter，不能留在 loadUrl await 之后');
   });
 
-  test('_beginNavigation 清空上一次未消费的 pending（并发导航从源头去重）', () {
+  test('_beginNavigation 在 loadUrl 前清旧 pending 并绑定本次代际', () {
     final String body = slice(
       'void _beginNavigation({',
       '_startContentReadyTimeout();',
     );
     expect(body, contains('_pendingPreciseLocate = null;'),
         reason: '新一次导航必须作废上一次排队但未消费的章内定位');
+    expect(body, contains('String? preciseLocateJs,'),
+        reason: '定位意图必须进入导航初始化原子步骤');
+    expect(body,
+        contains('(generation: _navigateGeneration, js: preciseLocateJs)'),
+        reason: '本次 pending 必须绑定已经递增的 _navigateGeneration');
+
+    final String navigate = slice(
+      'Future<void> _navigateToChapter(',
+      'Future<bool> _navigateToChapterAndWait(',
+    );
+    final int beginIdx = navigate.indexOf('_beginNavigation(');
+    final int loadIdx = navigate.indexOf('await _loadChapterDirectly(index);');
+    expect(beginIdx, isNonNegative);
+    expect(loadIdx, greaterThan(beginIdx),
+        reason: '必须先绑定定位意图再 loadUrl；反过来会让 onRestoreComplete 消费空 pending');
+    expect(navigate, contains('preciseLocateJs: preciseLocateJs,'),
+        reason: '_navigateToChapter 必须把定位意图交给 _beginNavigation');
   });
 
   test('_applyPendingPreciseLocate 有代际守卫且消费一次', () {

--- a/hibiki/test/pages/chapter_jump_double_jump_atomic_chain_test.dart
+++ b/hibiki/test/pages/chapter_jump_double_jump_atomic_chain_test.dart
@@ -56,12 +56,13 @@ void main() {
       'void _beginNavigation({',
       '_startContentReadyTimeout();',
     );
-    expect(body, contains('_pendingPreciseLocate = null;'),
+    expect(body, contains('_preciseLocateQueue.clear();'),
         reason: '新一次导航必须作废上一次排队但未消费的章内定位');
     expect(body, contains('String? preciseLocateJs,'),
         reason: '定位意图必须进入导航初始化原子步骤');
-    expect(body,
-        contains('(generation: _navigateGeneration, js: preciseLocateJs)'),
+    expect(body, contains('_preciseLocateQueue.replace('),
+        reason: '本次定位必须在 loadUrl 前进入 last-write-wins 队列');
+    expect(body, contains('generation: _navigateGeneration,'),
         reason: '本次 pending 必须绑定已经递增的 _navigateGeneration');
 
     final String navigate = slice(
@@ -82,11 +83,21 @@ void main() {
       'Future<void> _applyPendingPreciseLocate() async {',
       'debugPrint(\'[ReaderHibiki] _applyPendingPreciseLocate failed',
     );
-    // 先无条件清空（消费一次），再代际守卫（顶掉即丢弃）。
-    expect(body, contains('_pendingPreciseLocate = null;'), reason: '消费一次即清空');
-    expect(body,
-        contains('if (pending.generation != _navigateGeneration) return;'),
-        reason: '代际不匹配（被更晚导航顶掉）→ 丢弃，绝不应用到错误章节');
+    expect(body, contains('_preciseLocateQueue.consume('),
+        reason: '消费必须经过 last-write-wins 队列的一次性代际守卫');
+    expect(body, contains('generation: _navigateGeneration,'),
+        reason: '只消费当前导航代际');
+    expect(body, contains('canApply: mounted && _controller != null,'),
+        reason: 'dispose/控制器释放后必须丢弃 pending，不执行旧 DOM 脚本');
+  });
+
+  test('dispose 立即中止导航等待并清除 pending', () {
+    final String body = slice(
+      'void dispose() {',
+      'super.dispose();',
+    );
+    expect(body, contains('_failNavigation();'),
+        reason: 'dispose 必须立即 complete(false) 并清 pending，不能让搜索回调挂到超时');
   });
 
   test('_onRestoreComplete 在 settle 之后应用 pending（分派互斥：非连续直接 / 连续走 reanchor）',
@@ -116,7 +127,7 @@ void main() {
         reason: '连续模式在 reanchor commit（settle）之后应用 pending');
   });
 
-  test('onSearchJump 跨章走 preciseLocateJs 队列、删除 !ok 早退', () {
+  test('onSearchJump 按 logical chapter + DOM ready 分流，跨章排队且同章在飞最后写胜出', () {
     final String body = slice(
       'onSearchJump: (BookSearchResult result, String query) async {',
       'favoriteSentences: favorites,',
@@ -125,6 +136,17 @@ void main() {
     expect(body, contains('preciseLocateJs:'), reason: '跨章搜索定位必须排进导航的原子恢复链');
     expect(body, contains('scrollToSearchMatchInvocation'),
         reason: '搜索定位仍用 scrollToSearchMatch（文本命中）');
+    expect(body, contains('decideReaderSearchJump('),
+        reason: '不得只比较 sectionIndex/currentChapter；必须同时判断 DOM ready');
+    expect(
+        body,
+        contains(
+            'if (!mounted || _book == null || _controller == null) return;'),
+        reason: '搜索弹层回调晚到 dispose 后不得继续排队或求值旧 WebView');
+    expect(body, contains('ReaderSearchJumpAction.replacePending'),
+        reason: '同一逻辑目标章仍在 restore 时，新选择必须替换本代 pending');
+    expect(body, contains('_preciseLocateQueue.replace('),
+        reason: '最后一次同章选择必须成为 settle 后唯一执行的定位');
     // 旧的首跳 !ok 早退（停在章首、要点两次）必须已删除。
     expect(body.contains('if (!ok'), isFalse,
         reason: '删掉 !ok 早退——定位随恢复落定 settle 之后确定性应用，不再靠第二次点');

--- a/hibiki/test/reader/reader_engine_static_source_guard_test.dart
+++ b/hibiki/test/reader/reader_engine_static_source_guard_test.dart
@@ -210,12 +210,43 @@ void main() {
       final Map<String, dynamic> decoded =
           jsonDecode(literal) as Map<String, dynamic>;
       expect(decoded['initialProgress'], 0.42);
+      expect(decoded['navigationGeneration'], 17);
       expect(decoded['chromeBottomInset'], 64);
       expect(decoded['furiganaMode'], 'toggle');
       expect(decoded['dartPageWidth'], 800);
       expect((decoded['sasayakiCues'] as List<dynamic>).length, 1);
       expect(_sampleConfig().toJsLiteral().contains('"sasayakiCues":null'),
           isTrue);
+    });
+
+    test('三种 shell 回传 immutable navigation generation', () {
+      final String pagination = ReaderPaginationScripts.paginatedShellSource();
+      final String continuous = ReaderPaginationScripts.continuousShellSource();
+      final String vn = ReaderVisualNovelScripts.vnShellScript();
+      for (final String shell in <String>[pagination, continuous, vn]) {
+        expect(shell, contains("'onRestoreComplete'"));
+        expect(
+          shell,
+          contains('C.navigationGeneration'),
+          reason: 'restore 回调必须携带创建当前文档时捕获的代次',
+        );
+      }
+
+      final String navigation = File(
+        'lib/src/pages/implementations/reader_hibiki/navigation.part.dart',
+      ).readAsStringSync().replaceAll('\r\n', '\n');
+      final int gate = navigation.indexOf('void _acceptRestoreComplete({');
+      final int effects = navigation.indexOf(
+        "ReaderChapterPerfTrace.mark('jsInitRestore')",
+        gate,
+      );
+      expect(gate, isNonNegative);
+      expect(effects, greaterThan(gate));
+      final String guarded = navigation.substring(gate, effects);
+      expect(guarded, contains('isCurrentReaderRestoreCompletion('));
+      expect(guarded, contains('reportedGeneration: reportedGeneration,'));
+      expect(webview, contains('navigationGeneration: gen,'));
+      expect(webview, contains('reportedGeneration: rawGeneration.toInt(),'));
     });
   });
 
@@ -293,6 +324,7 @@ ProcessResult _runNode(List<String> args) {
 
 ReaderEngineConfig _sampleConfig({String? sasayakiCuesJson}) =>
     ReaderEngineConfig(
+      navigationGeneration: 17,
       continuousMode: false,
       vnMode: false,
       vnClickAdvance: false,

--- a/hibiki/test/reader/reader_search_navigation_test.dart
+++ b/hibiki/test/reader/reader_search_navigation_test.dart
@@ -76,12 +76,15 @@ void main() {
       expect(second, contains(', 91)'));
     });
 
-    test('new navigation generation cannot consume an old request', () {
+    test('stale completion cannot consume or clear the active request', () {
       final ReaderPreciseLocateQueue queue = ReaderPreciseLocateQueue();
-      queue.replace(generation: 9, js: 'old chapter');
+      queue.replace(generation: 10, js: 'new final selection');
 
-      expect(queue.consume(generation: 10, canApply: true), isNull);
       expect(queue.consume(generation: 9, canApply: true), isNull);
+      expect(
+        queue.consume(generation: 10, canApply: true),
+        'new final selection',
+      );
     });
 
     test('navigation dispose discards pending without evaluating it', () {
@@ -90,6 +93,28 @@ void main() {
 
       expect(queue.consume(generation: 11, canApply: false), isNull);
       expect(queue.consume(generation: 11, canApply: true), isNull);
+    });
+  });
+
+  group('restore completion generation', () {
+    test('only the document that owns the active navigation can settle it', () {
+      expect(
+        isCurrentReaderRestoreCompletion(
+          reportedGeneration: 14,
+          currentGeneration: 15,
+          expectedGeneration: 15,
+        ),
+        isFalse,
+        reason: 'late completion from the replaced document must be ignored',
+      );
+      expect(
+        isCurrentReaderRestoreCompletion(
+          reportedGeneration: 15,
+          currentGeneration: 15,
+          expectedGeneration: 15,
+        ),
+        isTrue,
+      );
     });
   });
 }

--- a/hibiki/test/reader/reader_search_navigation_test.dart
+++ b/hibiki/test/reader/reader_search_navigation_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
+import 'package:hibiki/src/reader/reader_search_navigation.dart';
+
+void main() {
+  group('decideReaderSearchJump', () {
+    test('cross-chapter result starts a new navigation', () {
+      expect(
+        decideReaderSearchJump(
+          targetChapter: 4,
+          currentChapter: 1,
+          restoreInFlight: false,
+          readerContentReady: true,
+        ),
+        ReaderSearchJumpAction.navigate,
+      );
+    });
+
+    test('same-chapter result evaluates only after the DOM is ready', () {
+      expect(
+        decideReaderSearchJump(
+          targetChapter: 4,
+          currentChapter: 4,
+          restoreInFlight: false,
+          readerContentReady: true,
+        ),
+        ReaderSearchJumpAction.evaluateNow,
+      );
+    });
+
+    test('same logical chapter replaces pending while restore is in flight',
+        () {
+      expect(
+        decideReaderSearchJump(
+          targetChapter: 4,
+          currentChapter: 4,
+          restoreInFlight: true,
+          readerContentReady: false,
+        ),
+        ReaderSearchJumpAction.replacePending,
+      );
+      expect(
+        decideReaderSearchJump(
+          targetChapter: 4,
+          currentChapter: 4,
+          restoreInFlight: false,
+          readerContentReady: false,
+        ),
+        ReaderSearchJumpAction.replacePending,
+        reason: 'logical current must not be treated as a ready DOM',
+      );
+    });
+  });
+
+  group('ReaderPreciseLocateQueue', () {
+    test('second same-generation selection wins before restore completes', () {
+      final ReaderPreciseLocateQueue queue = ReaderPreciseLocateQueue();
+      queue.replace(generation: 7, js: 'first');
+      queue.replace(generation: 7, js: 'second');
+
+      expect(queue.consume(generation: 7, canApply: true), 'second');
+      expect(queue.consume(generation: 7, canApply: true), isNull);
+    });
+
+    test('repeated text keeps the offset from the final selection', () {
+      final ReaderPreciseLocateQueue queue = ReaderPreciseLocateQueue();
+      final String first =
+          ReaderPaginationScripts.scrollToSearchMatchInvocation('猫', 12);
+      final String second =
+          ReaderPaginationScripts.scrollToSearchMatchInvocation('猫', 91);
+
+      queue.replace(generation: 8, js: first);
+      queue.replace(generation: 8, js: second);
+
+      expect(queue.consume(generation: 8, canApply: true), second);
+      expect(second, contains(', 91)'));
+    });
+
+    test('new navigation generation cannot consume an old request', () {
+      final ReaderPreciseLocateQueue queue = ReaderPreciseLocateQueue();
+      queue.replace(generation: 9, js: 'old chapter');
+
+      expect(queue.consume(generation: 10, canApply: true), isNull);
+      expect(queue.consume(generation: 9, canApply: true), isNull);
+    });
+
+    test('navigation dispose discards pending without evaluating it', () {
+      final ReaderPreciseLocateQueue queue = ReaderPreciseLocateQueue();
+      queue.replace(generation: 11, js: 'must not run');
+
+      expect(queue.consume(generation: 11, canApply: false), isNull);
+      expect(queue.consume(generation: 11, canApply: true), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## 改动

- 把跨章节书内搜索的 `preciseLocateJs` 沿导航调用链传入 `_beginNavigation`
- 在章节 `loadUrl` 之前绑定搜索定位意图与导航代际，恢复完成后可稳定执行定位和高亮
- 导航失败或超时时清理 pending，避免旧搜索意图泄漏到下一次导航
- 更新跨章原子跳转回归守卫，并登记 BUG-1231

## 根因

旧实现先等待 `_navigateToChapter()`；该调用内部还会等待 WebView `loadUrl()`，返回后才写入 `_pendingPreciseLocate`。部分平台上新章节已经在这个等待期间触发 `onRestoreComplete`，恢复链消费到的是空 pending。章节切换因此成功，但后写入的 `scrollToSearchMatch` 再无执行机会，最终停在章首且没有 `hoshi-search` 高亮。同章路径直接执行脚本，不经过这个时序窗口，所以一直正常。

## 用户影响

点击其他章节中的书内搜索结果后，会在目标章节恢复落定后继续滚到对应命中并显示搜索高亮；同章节搜索行为不变。

## 验证

- `flutter analyze --no-pub`：通过，No issues found
- `dart run tool/bug.dart check`：通过，1187 条、编号唯一、索引同步
- 加载顺序静态检查：通过，定位绑定早于 `_loadChapterDirectly`
- `flutter test test/pages/chapter_jump_double_jump_atomic_chain_test.dart --no-pub`：未进入测试；`pdfium_dart` 从 GitHub 下载 Windows 原生资产超时，属于依赖网络阻塞，不是断言失败
- 按用户要求未等待完整构建或设备验收；reader/WebView 原始跨章节点击路径仍需设备复测
