### PR TITLE
fix(galgame): remove legacy global upscaling data

### DIFF
--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1843,9 +1843,9 @@ class PreferencesRepository extends ChangeNotifier {
   // 游戏**的原生分辨率：同一个人手上既有 800×600 的老 gal，也有本身就 1080p 的新作。
   // 档位已改为每游戏一档，存在 galgame 库那一行（`galgames.upscaling_mode`）。
   //
-  // ⚠️ 存量设备里可能写过的 `galgame_magpie_upscaling_mode` 行**不删也不迁移**：
-  // 全局值没法映射成「每个游戏各自开不开」，硬迁移只会让一批游戏被莫名其妙打开超分。
-  // 新结构一律从「关闭」起步，用户按游戏自己开。
+  // v63 精确删除存量 `galgame_magpie_upscaling_mode` live 行及其 pref Profile
+  // 副本，不迁移到任何游戏；旧 Profile apply/JSON import 也会拒绝它复活。全局值
+  // 无法映射成「每个游戏各自开不开」，新结构仍一律从关闭起步，用户按游戏自己开。
 
   /// AniList/Nyaa/Jimaku requests: auto (env > enabled system proxy > direct),
   /// explicit direct, or a user-provided host:port proxy.

--- a/hibiki/lib/src/profile/profile_keys.dart
+++ b/hibiki/lib/src/profile/profile_keys.dart
@@ -11,6 +11,13 @@ class ProfileKeys {
   static const String categoryAnki = 'anki';
   static const String categoryPref = 'pref';
 
+  /// v63 已从 live preferences 与 Profile 副本中删除的旧全局超分键。
+  ///
+  /// 每游戏真值是 `galgames.upscaling_mode`；此键只保留为输入拒绝标识，防止
+  /// 旧快照或旧分享 JSON 在升级后把废弃数据重新写回。
+  static const String obsoleteGalgameUpscalingModePrefKey =
+      'galgame_magpie_upscaling_mode';
+
   /// TODO-1077: per-profile snapshot of the `dictionary_metadata` Drift table
   /// (enable list / order / formatKey / type / hidden+collapsed languages /
   /// metadata). This is a NEW category, distinct from the legacy pref-style
@@ -58,6 +65,7 @@ class ProfileKeys {
     // path that may not even exist on this machine.
     'download_save_root',
     'download_save_root_history',
+    obsoleteGalgameUpscalingModePrefKey,
     // TODO-855: the monotonic prefs-version counter is the cross-process signal
     // the :popup process reads to decide whether to refresh its warm-reuse
     // pref cache. It must stay app-global and monotonic — snapshotting it

--- a/hibiki/lib/src/profile/profile_repository.dart
+++ b/hibiki/lib/src/profile/profile_repository.dart
@@ -565,6 +565,12 @@ class ProfileRepository {
     int profileId,
   ) =>
       entries
+          // v63 只拒绝旧全局超分键的 pref 分类。不要改成过滤全部
+          // isExcludedPref：其它排除键有各自的跨版本/设备本地语义，扩大过滤会
+          // 无授权地改变旧 Profile JSON 的导入行为；同名非 pref 分类也必须保留。
+          .where((ProfileSettingEntry e) =>
+              e.category != ProfileKeys.categoryPref ||
+              e.key != ProfileKeys.obsoleteGalgameUpscalingModePrefKey)
           .map((ProfileSettingEntry e) => ProfileSettingsCompanion.insert(
                 profileId: profileId,
                 category: e.category,

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+998
+version: 1.3.1+999
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/database/migration_test.dart
+++ b/hibiki/test/database/migration_test.dart
@@ -1079,7 +1079,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 hibiki_paired_peers). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 62,
+      expect(db.schemaVersion, 63,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1156,7 +1156,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 62,
+      expect(db.schemaVersion, 63,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1316,7 +1316,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 62,
+      expect(db.schemaVersion, 63,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1367,7 +1367,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 62);
+      expect(db.schemaVersion, 63);
     });
 
     test(
@@ -1376,7 +1376,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 62,
+      expect(db.schemaVersion, 63,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1410,7 +1410,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 62,
+      expect(db.schemaVersion, 63,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1450,7 +1450,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 62);
+      expect(db.schemaVersion, 63);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1481,7 +1481,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 62);
+      expect(db.schemaVersion, 63);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1515,7 +1515,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 62);
+      expect(db.schemaVersion, 63);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1527,7 +1527,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 62);
+      expect(db.schemaVersion, 63);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();

--- a/hibiki/test/database/migration_v40_collections_test.dart
+++ b/hibiki/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62);
+    expect(db.schemaVersion, 63);
   });
 }

--- a/hibiki/test/database/migration_v51_pdf_format_test.dart
+++ b/hibiki/test/database/migration_v51_pdf_format_test.dart
@@ -110,6 +110,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62);
+    expect(db.schemaVersion, 63);
   });
 }

--- a/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
@@ -117,6 +117,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62);
+    expect(db.schemaVersion, 63);
   });
 }

--- a/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62);
+    expect(db.schemaVersion, 63);
   });
 }

--- a/hibiki/test/database/migration_v55_galgame_library_test.dart
+++ b/hibiki/test/database/migration_v55_galgame_library_test.dart
@@ -122,7 +122,7 @@ CREATE TABLE preferences (
     final String? pref = await db.getPref('galgame_library');
     expect(pref, isNotNull);
 
-    expect(await userVersionOf(db), 62);
+    expect(await userVersionOf(db), 63);
   });
 
   test('脏数据被逐条跳过，不让整个迁移失败', () async {
@@ -158,7 +158,7 @@ CREATE TABLE preferences (
 
     final List<GalgameRow> rows = await db.getAllGalgames();
     expect(rows.map((GalgameRow r) => r.id), <String>['ok-1', 'ok-2']);
-    expect(await userVersionOf(db), 62);
+    expect(await userVersionOf(db), 63);
   });
 
   test('整串 JSON 损坏 / 非数组 / 空串时迁移仍然成功，只是回填为空', () async {
@@ -169,7 +169,7 @@ CREATE TABLE preferences (
     ]) {
       final HibikiDatabase db = await openV53Db(raw);
       expect(await db.getAllGalgames(), isEmpty, reason: 'raw=$raw');
-      expect(await userVersionOf(db), 62, reason: 'raw=$raw');
+      expect(await userVersionOf(db), 63, reason: 'raw=$raw');
       await db.close();
     }
   });
@@ -177,7 +177,7 @@ CREATE TABLE preferences (
   test('偏好里根本没有 galgame_library 时迁移正常，表为空', () async {
     final HibikiDatabase db = await openV53Db(null);
     expect(await db.getAllGalgames(), isEmpty);
-    expect(await userVersionOf(db), 62);
+    expect(await userVersionOf(db), 63);
   });
 
   test('回填幂等：表里已有行就不再重复回填', () async {
@@ -227,7 +227,7 @@ CREATE TABLE preferences (
       ),
     );
     expect(await db.getAllGalgames(), hasLength(1));
-    expect(await userVersionOf(db), 62);
+    expect(await userVersionOf(db), 63);
   });
 
   test('删游戏经 FK cascade 连带清掉 sources 与 sessions', () async {

--- a/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62,
+    expect(db.schemaVersion, 63,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v57_naming_unification_test.dart
+++ b/hibiki/test/database/migration_v57_naming_unification_test.dart
@@ -154,9 +154,10 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62,
+    expect(db.schemaVersion, 63,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
-            'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位');
+            'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
+            'v63 = 清理旧全局超分 pref');
 
     final Set<String> mapping = await columnsOf(db, 'video_book_tag_mappings');
     expect(mapping, contains('book_uid'));

--- a/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62,
+    expect(db.schemaVersion, 63,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v60_reading_pages_test.dart
+++ b/hibiki/test/database/migration_v60_reading_pages_test.dart
@@ -59,7 +59,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 63, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/hibiki/test/database/migration_v61_collection_cover_path_test.dart
+++ b/hibiki/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62,
+    expect(db.schemaVersion, 63,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/hibiki/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/hibiki/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 62,
+    expect(db.schemaVersion, 63,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/hibiki/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/hibiki/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -1,0 +1,313 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show QueryRow;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:sqlite3/sqlite3.dart' as sqlite3;
+
+const String _obsoleteKey = 'galgame_magpie_upscaling_mode';
+
+void _seedV62(
+  sqlite3.Database db, {
+  bool includeObsoleteRows = true,
+  bool malformedProfileSettings = false,
+}) {
+  db.execute('''
+CREATE TABLE preferences (
+  key TEXT NOT NULL PRIMARY KEY,
+  value TEXT NOT NULL
+)
+''');
+  db.execute(malformedProfileSettings
+      ? '''
+CREATE TABLE profile_settings (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  profile_id INTEGER NOT NULL,
+  key TEXT NOT NULL,
+  value TEXT NOT NULL
+)
+'''
+      : '''
+CREATE TABLE profile_settings (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  profile_id INTEGER NOT NULL,
+  category TEXT NOT NULL,
+  key TEXT NOT NULL,
+  value TEXT NOT NULL,
+  UNIQUE (profile_id, category, key)
+)
+''');
+  db.execute('''
+CREATE TABLE galgames (
+  id TEXT NOT NULL PRIMARY KEY,
+  upscaling_mode TEXT NOT NULL DEFAULT ''
+)
+''');
+  db.execute('''
+CREATE TABLE unrelated_table (
+  id INTEGER NOT NULL PRIMARY KEY,
+  payload TEXT NOT NULL
+)
+''');
+
+  db.execute(
+    '''INSERT INTO preferences (key, value) VALUES '''
+    '''('theme', 's:dark'), ('download_custom_proxy', 's:127.0.0.1:7890')''',
+  );
+  if (includeObsoleteRows) {
+    db.execute(
+      "INSERT INTO preferences (key, value) VALUES ('$_obsoleteKey', 's:auto')",
+    );
+  }
+
+  if (malformedProfileSettings) {
+    db.execute(
+      '''INSERT INTO profile_settings (profile_id, key, value) '''
+      '''VALUES (1, '$_obsoleteKey', 's:auto')''',
+    );
+  } else {
+    db.execute(
+      '''INSERT INTO profile_settings (profile_id, category, key, value) VALUES '''
+      '''(1, 'pref', '$_obsoleteKey', 's:auto'), '''
+      '''(2, 'pref', '$_obsoleteKey', 's:installed_only'), '''
+      '''(1, 'pref', 'font_size', 'i:20'), '''
+      '''(1, 'legacy_non_pref', '$_obsoleteKey', 'must-survive'), '''
+      '''(2, 'dictionary', '$_obsoleteKey', 'also-survives')''',
+    );
+  }
+  db.execute(
+    '''INSERT INTO galgames (id, upscaling_mode) VALUES '''
+    '''('old-default-off', ''), '''
+    '''('auto-game', 'auto'), '''
+    '''('installed-game', 'installed_only')''',
+  );
+  db.execute(
+    "INSERT INTO unrelated_table (id, payload) VALUES (1, 'untouched')",
+  );
+  db.execute('PRAGMA user_version = 62');
+}
+
+Map<String, String> _tableSql(sqlite3.Database db) => <String, String>{
+      for (final row in db.select(
+        "SELECT name, sql FROM sqlite_master WHERE type = 'table' "
+        "AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      ))
+        row['name'] as String: row['sql'] as String,
+    };
+
+Future<Map<String, String>> _tableSqlFromDrift(HibikiDatabase db) async {
+  final List<QueryRow> rows = await db
+      .customSelect(
+        "SELECT name, sql FROM sqlite_master WHERE type = 'table' "
+        "AND name NOT LIKE 'sqlite_%' ORDER BY name",
+      )
+      .get();
+  return <String, String>{
+    for (final QueryRow row in rows)
+      row.read<String>('name'): row.read<String>('sql'),
+  };
+}
+
+void main() {
+  test(
+      'v63 deletes only the legacy live/pref Profile rows and leaves schema, '
+      'per-game modes, and unrelated data untouched', () async {
+    late Map<String, String> schemaBefore;
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (sqlite3.Database rawDb) {
+          _seedV62(rawDb);
+          schemaBefore = _tableSql(rawDb);
+        },
+      ),
+    );
+    addTearDown(db.close);
+
+    final QueryRow version =
+        await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.read<int>('user_version'), 63);
+    expect(db.schemaVersion, 63);
+
+    final List<QueryRow> preferences = await db
+        .customSelect(
+          'SELECT key, value FROM preferences ORDER BY key',
+        )
+        .get();
+    expect(
+      preferences.map((QueryRow row) =>
+          (row.read<String>('key'), row.read<String>('value'))),
+      <(String, String)>[
+        ('download_custom_proxy', 's:127.0.0.1:7890'),
+        ('theme', 's:dark'),
+      ],
+    );
+
+    final List<QueryRow> profileRows = await db
+        .customSelect(
+          'SELECT category, key, value FROM profile_settings '
+          'ORDER BY profile_id, category, key',
+        )
+        .get();
+    expect(
+      profileRows.map((QueryRow row) => (
+            row.read<String>('category'),
+            row.read<String>('key'),
+            row.read<String>('value'),
+          )),
+      <(String, String, String)>[
+        ('legacy_non_pref', _obsoleteKey, 'must-survive'),
+        ('pref', 'font_size', 'i:20'),
+        ('dictionary', _obsoleteKey, 'also-survives'),
+      ],
+      reason: '只删 category=pref 的旧键，同名非 pref 与普通 pref 必须保留',
+    );
+
+    final List<QueryRow> gameRows = await db
+        .customSelect(
+          'SELECT id, upscaling_mode FROM galgames ORDER BY id',
+        )
+        .get();
+    expect(
+      gameRows.map((QueryRow row) => (
+            row.read<String>('id'),
+            row.read<String>('upscaling_mode'),
+          )),
+      <(String, String)>[
+        ('auto-game', 'auto'),
+        ('installed-game', 'installed_only'),
+        ('old-default-off', ''),
+      ],
+      reason: '每游戏真值与老游戏默认关闭不受旧全局数据清理影响',
+    );
+    expect(
+      (await db.customSelect('SELECT payload FROM unrelated_table').getSingle())
+          .read<String>('payload'),
+      'untouched',
+    );
+    expect(await _tableSqlFromDrift(db), schemaBefore,
+        reason: 'v63 只能删行，不得 ALTER/DROP/create/rebuild 或留影子表');
+  });
+
+  test('v63 is idempotent when the obsolete rows are already absent', () async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (sqlite3.Database rawDb) {
+          _seedV62(rawDb, includeObsoleteRows: false);
+        },
+      ),
+    );
+    addTearDown(db.close);
+
+    expect(await db.getPref(_obsoleteKey), isNull);
+    expect(await db.getPref('theme'), 's:dark');
+    final QueryRow version =
+        await db.customSelect('PRAGMA user_version').getSingle();
+    expect(version.read<int>('user_version'), 63);
+  });
+
+  test(
+      'backup source opened through atFile upgrades once and cannot resurrect '
+      'the obsolete rows on reopen', () async {
+    final Directory tempDir =
+        Directory.systemTemp.createTempSync('hibiki_v63_backup_upgrade');
+    final String dbPath =
+        '${tempDir.path}${Platform.pathSeparator}backup-source.db';
+    addTearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    final sqlite3.Database raw = sqlite3.sqlite3.open(dbPath);
+    try {
+      _seedV62(raw);
+    } finally {
+      raw.dispose();
+    }
+
+    HibikiDatabase migrated =
+        HibikiDatabase.atFile(dbPath, isMainProcess: false);
+    expect(await migrated.getPref(_obsoleteKey), isNull);
+    expect(await migrated.getPref('theme'), 's:dark');
+    await migrated.close();
+
+    final sqlite3.Database probe =
+        sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
+    try {
+      expect(probe.select('PRAGMA user_version').first.values.first, 63);
+      expect(
+        probe.select(
+          'SELECT 1 FROM profile_settings '
+          "WHERE category = 'pref' AND key = ?",
+          <Object?>[_obsoleteKey],
+        ),
+        isEmpty,
+      );
+      expect(
+        probe.select(
+          'SELECT value FROM profile_settings '
+          "WHERE category = 'legacy_non_pref' AND key = ?",
+          <Object?>[_obsoleteKey],
+        ).single['value'],
+        'must-survive',
+      );
+    } finally {
+      probe.dispose();
+    }
+
+    migrated = HibikiDatabase.atFile(dbPath, isMainProcess: false);
+    expect(await migrated.getPref(_obsoleteKey), isNull,
+        reason: '第二次打开 user_version=63，不得产生复活或重复迁移副作用');
+    await migrated.close();
+  });
+
+  test('a failure in the second delete rolls the first delete back as a batch',
+      () async {
+    final Directory tempDir =
+        Directory.systemTemp.createTempSync('hibiki_v63_rollback');
+    final String dbPath = '${tempDir.path}${Platform.pathSeparator}rollback.db';
+    addTearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    final sqlite3.Database raw = sqlite3.sqlite3.open(dbPath);
+    try {
+      _seedV62(raw, malformedProfileSettings: true);
+    } finally {
+      raw.dispose();
+    }
+
+    final HibikiDatabase broken =
+        HibikiDatabase.atFile(dbPath, isMainProcess: false);
+    await expectLater(
+      broken.getPref('theme'),
+      throwsA(anything),
+      reason: '缺 category 列必须让第二条 DELETE 失败，不能吞异常假装升级成功',
+    );
+    try {
+      await broken.close();
+    } catch (_) {
+      // The lazy connection failed during migration; close may repeat it.
+    }
+
+    final sqlite3.Database probe =
+        sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
+    try {
+      expect(probe.select('PRAGMA user_version').first.values.first, 62,
+          reason: '失败升级不得推进 user_version');
+      expect(
+        probe.select(
+          'SELECT value FROM preferences WHERE key = ?',
+          <Object?>[_obsoleteKey],
+        ).single['value'],
+        's:auto',
+        reason: '第二条失败后第一条 DELETE 必须回滚，整批同成同败',
+      );
+    } finally {
+      probe.dispose();
+    }
+  });
+}

--- a/hibiki/test/mining/magpie_per_game_upscaling_test.dart
+++ b/hibiki/test/mining/magpie_per_game_upscaling_test.dart
@@ -245,15 +245,38 @@ void main() {
       );
     });
 
-    test('不得再有全局超分偏好（两份真值一定会漂开）', () async {
+    test('不得再有全局超分偏好读写或 UI/AppModel 入口', () async {
+      const String obsoleteKey = 'galgame_magpie_upscaling_mode';
       final String prefs = await File(
         'lib/src/models/preferences_repository.dart',
       ).readAsString();
       expect(
-        prefs.contains("getPref('galgame_magpie_upscaling_mode'"),
+        prefs.contains("getPref('$obsoleteKey'"),
         isFalse,
         reason: '档位已落 galgames.upscaling_mode，全局偏好必须没有读取点',
       );
+      expect(
+        prefs.contains("setPref('$obsoleteKey'"),
+        isFalse,
+        reason: '旧全局偏好也不得留下写入点',
+      );
+
+      final String appModel =
+          await File('lib/src/models/app_model.dart').readAsString();
+      expect(appModel.contains(obsoleteKey), isFalse,
+          reason: 'AppModel 不得重新暴露旧全局超分状态');
+
+      final Iterable<File> settingsFiles = Directory('lib/src/settings')
+          .listSync(recursive: true)
+          .whereType<File>()
+          .where((File file) => file.path.endsWith('.dart'));
+      for (final File file in settingsFiles) {
+        expect(
+          (await file.readAsString()).contains(obsoleteKey),
+          isFalse,
+          reason: 'settings schema 不得重新出现旧全局超分 key：${file.path}',
+        );
+      }
     });
 
     test('helper 随包归档必须由 CMake install 拷进 bundle（开发构建也要有）', () async {

--- a/hibiki/test/profile/profile_export_import_test.dart
+++ b/hibiki/test/profile/profile_export_import_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/profile/profile_repository.dart';
+import 'package:hibiki/src/profile/profile_keys.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -201,6 +202,32 @@ void main() {
   });
 
   group('ProfileRepository import', () {
+    String legacyUpscalingJson(String profileName) => jsonEncode(
+          <String, dynamic>{
+            'type': ProfileExport.fileType,
+            'formatVersion': ProfileExport.currentFormatVersion,
+            'schemaVersion': 62,
+            'profileName': profileName,
+            'settings': <Map<String, String>>[
+              <String, String>{
+                'category': ProfileKeys.categoryPref,
+                'key': ProfileKeys.obsoleteGalgameUpscalingModePrefKey,
+                'value': 's:auto',
+              },
+              <String, String>{
+                'category': 'legacy_non_pref',
+                'key': ProfileKeys.obsoleteGalgameUpscalingModePrefKey,
+                'value': 'must-survive',
+              },
+              <String, String>{
+                'category': ProfileKeys.categoryPref,
+                'key': 'font_size',
+                'value': '24',
+              },
+            ],
+          },
+        );
+
     Future<String> exportFixture(
       HibikiDatabase db,
       ProfileRepository repo,
@@ -240,6 +267,36 @@ void main() {
       final kv = <String, String>{for (final s in settings) s.key: s.value};
       expect(kv['font_size'], '24');
       expect(kv['theme'], 'sepia');
+    });
+
+    test(
+        'v63 create import drops only the obsolete pref row and keeps the '
+        'same key in a non-pref category', () async {
+      final db = await _openDb();
+      final repo = _repo(db);
+
+      final int id =
+          await repo.importProfileFromJson(legacyUpscalingJson('Legacy'));
+      final rows = await db.getProfileSettings(id);
+
+      expect(
+        rows.where((r) =>
+            r.category == ProfileKeys.categoryPref &&
+            r.key == ProfileKeys.obsoleteGalgameUpscalingModePrefKey),
+        isEmpty,
+      );
+      expect(
+        rows.where((r) =>
+            r.category == 'legacy_non_pref' &&
+            r.key == ProfileKeys.obsoleteGalgameUpscalingModePrefKey),
+        hasLength(1),
+        reason: '用户只授权删除 pref 分类，同名非 pref 行必须保留',
+      );
+      expect(
+        rows.where((r) =>
+            r.category == ProfileKeys.categoryPref && r.key == 'font_size'),
+        hasLength(1),
+      );
     });
 
     test('duplicate name gets a numeric suffix', () async {
@@ -285,6 +342,48 @@ void main() {
       final kv = <String, String>{for (final s in settings) s.key: s.value};
       expect(kv['font_size'], '32');
       expect(kv['new_key'], 'v');
+    });
+
+    test('v63 overwrite import also cannot recreate the obsolete pref row',
+        () async {
+      final db = await _openDb();
+      final repo = _repo(db);
+      final int target = await repo.createProfile('Target');
+      await db.replaceProfileSettings(target, <ProfileSettingsCompanion>[
+        ProfileSettingsCompanion.insert(
+          profileId: target,
+          category: ProfileKeys.categoryPref,
+          key: ProfileKeys.obsoleteGalgameUpscalingModePrefKey,
+          value: 's:off',
+        ),
+      ]);
+
+      await repo.importProfileFromJson(
+        legacyUpscalingJson('Ignored'),
+        mode: ProfileImportMode.overwrite,
+        targetProfileId: target,
+      );
+      final rows = await db.getProfileSettings(target);
+
+      expect(
+        rows.where((r) =>
+            r.category == ProfileKeys.categoryPref &&
+            r.key == ProfileKeys.obsoleteGalgameUpscalingModePrefKey),
+        isEmpty,
+      );
+      expect(
+        rows.where((r) =>
+            r.category == 'legacy_non_pref' &&
+            r.key == ProfileKeys.obsoleteGalgameUpscalingModePrefKey),
+        hasLength(1),
+      );
+      expect(
+        rows
+            .singleWhere((r) =>
+                r.category == ProfileKeys.categoryPref && r.key == 'font_size')
+            .value,
+        '24',
+      );
     });
 
     test('corrupt JSON throws ProfileImportException before touching the DB',

--- a/hibiki/test/profile/profile_keys_test.dart
+++ b/hibiki/test/profile/profile_keys_test.dart
@@ -29,6 +29,13 @@ void main() {
       // TODO-1961: download folder + legacy-folder history are device-local.
       expect(ProfileKeys.isExcludedPref('download_save_root'), isTrue);
       expect(ProfileKeys.isExcludedPref('download_save_root_history'), isTrue);
+      expect(
+        ProfileKeys.isExcludedPref(
+          ProfileKeys.obsoleteGalgameUpscalingModePrefKey,
+        ),
+        isTrue,
+        reason: 'v63 删除的旧全局超分键不得再进入 Profile 快照',
+      );
     });
 
     test('excludes keys with current_source/ prefix', () {

--- a/hibiki/test/profile/profile_repository_test.dart
+++ b/hibiki/test/profile/profile_repository_test.dart
@@ -123,6 +123,42 @@ void main() {
       expect(keys, isNot(contains('current_source/reader')));
     });
 
+    test(
+        'v63 obsolete galgame upscaling pref is not snapshotted and an old '
+        'snapshot cannot restore it', () async {
+      final db = await _openDb();
+      final repo = _repo(db);
+      final pid = await repo.createProfile('Legacy');
+      const String obsoleteKey = 'galgame_magpie_upscaling_mode';
+
+      await db.setPref(obsoleteKey, 's:auto');
+      await db.setPref('font_size', '16');
+      await repo.snapshotCurrentSettings(pid);
+      expect(await _prefKeys(db, pid), isNot(contains(obsoleteKey)));
+
+      // Simulate a pre-v63 snapshot captured before the key became excluded.
+      await db.replaceProfileSettings(pid, <ProfileSettingsCompanion>[
+        ProfileSettingsCompanion.insert(
+          profileId: pid,
+          category: 'pref',
+          key: obsoleteKey,
+          value: 's:installed_only',
+        ),
+        ProfileSettingsCompanion.insert(
+          profileId: pid,
+          category: 'pref',
+          key: 'font_size',
+          value: '20',
+        ),
+      ]);
+      await db.deletePref(obsoleteKey);
+      await repo.applyProfile(pid);
+
+      expect(await db.getPref(obsoleteKey), isNull,
+          reason: '旧 Profile apply 不得把 v63 已删除的全局值写回 live prefs');
+      expect(await db.getPref('font_size'), '20', reason: '同一旧快照中的正常偏好仍照常恢复');
+    });
+
     test('snapshot and apply keep app UI scale prefs device-local', () async {
       final db = await _openDb();
       final repo = _repo(db);

--- a/packages/hibiki_core/CLAUDE.md
+++ b/packages/hibiki_core/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## 模块职责
 
-共享核心模块：定义 Drift SQLite 数据库 schema（53 张表，当前 schemaVersion=62）、表迁移逻辑、偏好键值编解码器（PrefCodec）、语言配置模型和文本选区模型。是所有其他 packages 的基础依赖。
+共享核心模块：定义 Drift SQLite 数据库 schema（53 张表，当前 schemaVersion=63）、表迁移逻辑、偏好键值编解码器（PrefCodec）、语言配置模型和文本选区模型。是所有其他 packages 的基础依赖。
 
 ## 入口与启动
 

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -416,7 +416,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   HibikiDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 62;
+  int get schemaVersion => 63;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1260,6 +1260,32 @@ class HibikiDatabase extends _$HibikiDatabase {
                 !await _columnExists('galgames', 'upscaling_mode')) {
               await m.addColumn(galgames, galgames.upscalingMode);
             }
+          }
+          if (from < 63) {
+            // v63：删除已废弃的 galgame 全局窗口超分偏好。v62 起超分档位的
+            // 唯一真值是 galgames.upscaling_mode；旧 KV 既不能映射成任一游戏，
+            // 也不能留在 Profile 快照里等切换 Profile 时复活。
+            //
+            // 两张表的清理必须同成同败：onUpgrade 本身不保证把多个裸 SQL 包成
+            // 一个事务，因此这里显式 transaction。第二条 DELETE 若因损坏的历史
+            // schema 失败，第一条也回滚，user_version 仍停在旧版本供修复后重试。
+            // 成功后不留影子副本——这是用户明确要求的不可逆数据删除。
+            const String obsoleteKey = 'galgame_magpie_upscaling_mode';
+            await transaction(() async {
+              if (await _tableExists('preferences')) {
+                await customStatement(
+                  'DELETE FROM preferences WHERE key = ?',
+                  <Object?>[obsoleteKey],
+                );
+              }
+              if (await _tableExists('profile_settings')) {
+                await customStatement(
+                  'DELETE FROM profile_settings '
+                  "WHERE category = 'pref' AND key = ?",
+                  <Object?>[obsoleteKey],
+                );
+              }
+            });
           }
         },
         onCreate: (m) async {


### PR DESCRIPTION
## Summary

- bump the database to v63 and irreversibly delete only `preferences.key=galgame_magpie_upscaling_mode` plus `profile_settings(category='pref')` copies in one rollback-safe transaction
- prevent old Profile snapshots and create/overwrite JSON imports from restoring that pref while preserving same-name non-pref rows
- keep `galgames.upscaling_mode`, Magpie configuration, helper sources, CMake and workflows unchanged; bump app build to `1.3.1+999`

## Verification

- migration v63: 4/4 (exact retained-data/DDL boundary, idempotency, on-disk `atFile` upgrade/reopen, failed-batch rollback)
- migration main suite: 34/34; specialized v40/v51/v53/v54/v55/v56/v57/v59/v60/v61: 36/36
- Profile repository 20/20; Profile JSON import/export 14/14; Profile keys + v62 migration 20/20
- Magpie per-game/source guards 18/18; helper/behavior static guard batch 111/111
- `dart analyze` in `packages/hibiki_core`: no issues
- targeted Flutter analyze for changed core/Profile/migration files: no issues
- formatter unchanged; `git diff --check` passed
- rebased onto `origin/develop@2d54819756c98891eb7208e7d5c18f39ef535b83`; develop is schema v62 / build `+998`, this PR remains the sole v63 and advances to `+999`
- range-diff changes only the build baseline; seven key Profile/JSON/Magpie/test blobs are byte-identical to the independently reviewed head; merge-tree is clean
- post-rebase rerun: v63 4/4; the reviewed eight-file set 117/117; core and five targeted analyze groups clean; BUG index and diff checks clean

## Remaining validation / environment block

- full `flutter analyze --no-pub` exceeded the local 60-second execution window and was terminated before emitting diagnostics, so it is not claimed as passed
- `native/galgame_hook/tools/build_distribution.ps1 -RunTests` was blocked while downloading the existing Unity runtime dependency (`Invoke-WebRequest: Unable to connect to the remote server`, CMake/MSBuild exit 1); no fresh helper distribution/four-file artifact assertion was produced
- no real Windows galgame injection/card-creation E2E was run
- exact implementation head: `70a03887ba381075ef81ea46d2c2ac381e936b70`
- evidence: `.codex-test/todo-2169/summary.md` in the implementation worktree (ignored, not committed); native build logs are alongside it

## Review gate

This is intentionally a Draft. TODO-2169 requires a separate non-construction review before any merge; this PR does not merge `develop`.
