### PR TITLE
fix(video): 让字幕和封面在线匹配结果可辨识

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1190 条。点号进各自文件。
+> 共 1192 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1235](bugs/BUG-1235-jimaku-batch-availability.md) | ✅ | ✅ | 合集字幕匹配无法区分来源与逐集可用性 |
+| [BUG-1234](bugs/BUG-1234-cover-match-source-state.md) | ✅ | ✅ | 封面匹配切换来源会自动重搜并保留旧来源结果 |
 | [BUG-1233](bugs/BUG-1233-book-import-repeated-archive-probe.md) | ✅ | ✅ | 书籍导入重复整包判定 EPUB 载体 |
 | [BUG-1228](bugs/BUG-1228-video-mining-queue.md) | ✅ | ✅ | 连续视频制卡未串行且换集可能污染在途任务 |
 | [BUG-1227](bugs/BUG-1227-anki-media-upload-orphan.md) | ✅ | ✅ | 大 GIF 上传超时被吞后仍创建无图卡并留下孤儿媒体 |

--- a/docs/bugs/BUG-1234-cover-match-source-state.md
+++ b/docs/bugs/BUG-1234-cover-match-source-state.md
@@ -11,7 +11,7 @@
   `hibiki/test/media/video/scraper/cover_match_dialog_test.dart` 覆盖切换不自动请求、旧
   Bangumi 候选不混入 TMDB、手动搜索恢复结果、来源标识与默认关闭；另钉住保存 TMDB
   key 尚未完成时切换来源的竞态，迟到 continuation 不得搜索新来源。
-- **修复提交**：`37b101471`
+- **修复提交**：`1a4107e69`
 - **备注**：定向测试使用已缓存的 `pdfium.dll` 与仅测试期间启用的系统
   `winsqlite3` 完成 55/55；临时 pubspec 配置已在提交前移除。`flutter analyze
   --no-pub` 通过。

--- a/docs/bugs/BUG-1234-cover-match-source-state.md
+++ b/docs/bugs/BUG-1234-cover-match-source-state.md
@@ -1,0 +1,17 @@
+## BUG-1234 · 封面匹配切换来源会自动重搜并保留旧来源结果
+- **报告**：2026-07-29（用户：在线匹配封面切换来源会重新加载并报错；TMDB 无 key
+  但下方仍有数据）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart:511`
+  的来源切换回调原先直接调用 `_search()`，且切换时不清空 `_results`；因此切到 TMDB
+  会立即请求，缺 key/请求失败时还可能展示上一来源候选。
+- **[x] ① 已修复** — 来源切换只更新目标来源，作废在途请求并清空候选/失败状态；显式
+  点「搜索」或保存 key 才请求。TMDB 无 key 展示专属空态，候选行同时标出来源与条目
+  ID；单集批量应用保持默认关闭并解释其覆盖语义。
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/media/video/scraper/cover_match_dialog_test.dart` 覆盖切换不自动请求、旧
+  Bangumi 候选不混入 TMDB、手动搜索恢复结果、来源标识与默认关闭；另钉住保存 TMDB
+  key 尚未完成时切换来源的竞态，迟到 continuation 不得搜索新来源。
+- **修复提交**：`37b101471`
+- **备注**：定向测试使用已缓存的 `pdfium.dll` 与仅测试期间启用的系统
+  `winsqlite3` 完成 55/55；临时 pubspec 配置已在提交前移除。`flutter analyze
+  --no-pub` 通过。

--- a/docs/bugs/BUG-1235-jimaku-batch-availability.md
+++ b/docs/bugs/BUG-1235-jimaku-batch-availability.md
@@ -1,0 +1,19 @@
+## BUG-1235 · 合集字幕匹配无法区分来源与逐集可用性
+- **报告**：2026-07-29（用户：字幕来源看不出哪个是哪个，也看不出每集有没有字幕）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/pages/implementations/jimaku_entry_picker.dart:11`
+  原先只渲染 `entry.name` 的 chip；`jimaku_batch_dialog.dart` 的成员副标题也只在下载
+  完成后显示语言，下载前没有文件清单、来源身份或逐集可用性；同时
+  `jimaku_client.dart` 把空白 `name` 当有效值，未回退 `english_name`，会直接画出空条目。
+- **[x] ① 已修复** — 搜到来源后，每个 Jimaku 条目只列一次全部文件，汇总可解析字幕
+  数、覆盖集数、语言、Jimaku/AniList ID；当前来源再按真实集号把合集成员标成有字幕、
+  无字幕或存在未标集号候选。严格预检查会把 HTTP 失败、畸形 200 与合法零字幕分开；
+  客户端创建失败也会结束 loading，下载只在当前来源预检查成功且非空时开放，快速切
+  系列的迟到响应与数据库写入不会覆盖新选择，实际批量下载不再把请求失败伪装成无匹配。
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/media/video/jimaku_client_test.dart` 覆盖清单聚合、严格 HTTP/畸形响应与
+  合法空数组；`jimaku_batch_test.dart` 覆盖批量失败语义和下载门禁；
+  `jimaku_batch_dialog_state_test.dart` 覆盖客户端工厂失败、loading/成功门禁与快速
+  切系列竞态；`jimaku_entry_picker_test.dart` 覆盖来源身份、摘要、失败态和选择。
+- **修复提交**：`37b101471`
+- **备注**：同组定向测试 55/55，`flutter analyze --no-pub` 通过；真实 Jimaku 网络
+  与设备 UI E2E 未在本轮执行。

--- a/docs/bugs/BUG-1235-jimaku-batch-availability.md
+++ b/docs/bugs/BUG-1235-jimaku-batch-availability.md
@@ -14,6 +14,6 @@
   合法空数组；`jimaku_batch_test.dart` 覆盖批量失败语义和下载门禁；
   `jimaku_batch_dialog_state_test.dart` 覆盖客户端工厂失败、loading/成功门禁与快速
   切系列竞态；`jimaku_entry_picker_test.dart` 覆盖来源身份、摘要、失败态和选择。
-- **修复提交**：`37b101471`
+- **修复提交**：`1a4107e69`
 - **备注**：同组定向测试 55/55，`flutter analyze --no-pub` 通过；真实 Jimaku 网络
   与设备 UI E2E 未在本轮执行。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46971 (2763 per locale)
+/// Strings: 47158 (2774 per locale)
 ///
-/// Built on 2026-07-29 at 07:19 UTC
+/// Built on 2026-07-29 at 08:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3715,6 +3715,31 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_import_detected_confirm => 'Import as manga';
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -10041,6 +10066,42 @@ class _StringsAr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -16435,6 +16496,42 @@ class _StringsDe extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -22845,6 +22942,42 @@ class _StringsEs extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -29266,6 +29399,42 @@ class _StringsFr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -35616,6 +35785,42 @@ class _StringsId extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -42012,6 +42217,42 @@ class _StringsIt extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -48225,6 +48466,42 @@ class _StringsJa extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -54440,6 +54717,42 @@ class _StringsKo extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -60816,6 +61129,42 @@ class _StringsNl extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -67205,6 +67554,42 @@ class _StringsPtBr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -73578,6 +73963,42 @@ class _StringsRu extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -79899,6 +80320,42 @@ class _StringsTh extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -86252,6 +86709,42 @@ class _StringsTr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -92590,6 +93083,42 @@ class _StringsVi extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 // Path: <root>
@@ -98479,6 +99008,41 @@ class _StringsZhCn extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
+  @override
+  String get video_jimaku_source_loading => '正在检查字幕可用性…';
+  @override
+  String get video_jimaku_source_failed => '字幕可用性检查失败，请重新查找。';
+  @override
+  String get video_jimaku_language_unknown => '语言未标注';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} 个字幕文件 · 覆盖 ${episodes} 集 · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      '未发现标为第 ${episode} 集的字幕；另有 ${count} 个未标集号文件可尝试';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      '没有找到第 ${episode} 集字幕';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '有 ${count} 个字幕 · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      '手动匹配会替换本集封面，并保存来源映射和条目资料。切换来源后，点“搜索”才会请求该来源。';
+  @override
+  String get video_scrape_collection_match_hint =>
+      '这里只替换合集封面，不会修改各集封面或条目资料。切换来源后，点“搜索”才会请求该来源。';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      '这会把同一张封面写到每一集；只有确实需要统一单集封面时才开启。';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      '先保存 TMDB API Key，再点“搜索”。这里不会混入其他来源的结果。';
 }
 
 // Path: <root>
@@ -104613,6 +105177,42 @@ class _StringsZhHk extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get video_jimaku_source_loading => 'Checking subtitle availability...';
+  @override
+  String get video_jimaku_source_failed =>
+      'Could not check subtitle availability. Try searching again.';
+  @override
+  String get video_jimaku_language_unknown => 'Language not labeled';
+  @override
+  String video_jimaku_source_summary(
+          {required Object files,
+          required Object episodes,
+          required Object languages}) =>
+      '${files} subtitle files · ${episodes} episodes · ${languages}';
+  @override
+  String video_jimaku_episode_unlabeled(
+          {required Object episode, required Object count}) =>
+      'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+  @override
+  String video_jimaku_episode_unavailable({required Object episode}) =>
+      'No subtitle found for episode ${episode}';
+  @override
+  String video_jimaku_episode_available(
+          {required Object count, required Object languages}) =>
+      '${count} subtitles available · ${languages}';
+  @override
+  String get video_scrape_manual_match_hint =>
+      'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_collection_match_hint =>
+      'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+  @override
+  String get video_scrape_apply_to_collection_hint =>
+      'This writes the same cover to every episode. Leave it off unless that is intentional.';
+  @override
+  String get video_scrape_tmdb_key_empty =>
+      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
 }
 
 /// Flat map(s) containing all translations.
@@ -110274,6 +110874,35 @@ extension on _StringsEn {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -115933,6 +116562,35 @@ extension on _StringsAr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -121613,6 +122271,35 @@ extension on _StringsDe {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -127292,6 +127979,35 @@ extension on _StringsEs {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -132977,6 +133693,35 @@ extension on _StringsFr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -138644,6 +139389,35 @@ extension on _StringsId {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -144326,6 +145100,35 @@ extension on _StringsIt {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -149970,6 +150773,35 @@ extension on _StringsJa {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -155618,6 +156450,35 @@ extension on _StringsKo {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -161293,6 +162154,35 @@ extension on _StringsNl {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -166965,6 +167855,35 @@ extension on _StringsPtBr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -172642,6 +173561,35 @@ extension on _StringsRu {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -178303,6 +179251,35 @@ extension on _StringsTh {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -183973,6 +184950,35 @@ extension on _StringsTr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -189638,6 +190644,35 @@ extension on _StringsVi {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }
@@ -195256,6 +196291,34 @@ extension on _StringsZhCn {
         return '按漫画导入';
       case 'manga_import_detected_message':
         return ({required Object name}) => '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
+      case 'video_jimaku_source_loading':
+        return '正在检查字幕可用性…';
+      case 'video_jimaku_source_failed':
+        return '字幕可用性检查失败，请重新查找。';
+      case 'video_jimaku_language_unknown':
+        return '语言未标注';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} 个字幕文件 · 覆盖 ${episodes} 集 · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            '未发现标为第 ${episode} 集的字幕；另有 ${count} 个未标集号文件可尝试';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) => '没有找到第 ${episode} 集字幕';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '有 ${count} 个字幕 · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return '手动匹配会替换本集封面，并保存来源映射和条目资料。切换来源后，点“搜索”才会请求该来源。';
+      case 'video_scrape_collection_match_hint':
+        return '这里只替换合集封面，不会修改各集封面或条目资料。切换来源后，点“搜索”才会请求该来源。';
+      case 'video_scrape_apply_to_collection_hint':
+        return '这会把同一张封面写到每一集；只有确实需要统一单集封面时才开启。';
+      case 'video_scrape_tmdb_key_empty':
+        return '先保存 TMDB API Key，再点“搜索”。这里不会混入其他来源的结果。';
       default:
         return null;
     }
@@ -200895,6 +201958,35 @@ extension on _StringsZhHk {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'video_jimaku_source_loading':
+        return 'Checking subtitle availability...';
+      case 'video_jimaku_source_failed':
+        return 'Could not check subtitle availability. Try searching again.';
+      case 'video_jimaku_language_unknown':
+        return 'Language not labeled';
+      case 'video_jimaku_source_summary':
+        return (
+                {required Object files,
+                required Object episodes,
+                required Object languages}) =>
+            '${files} subtitle files · ${episodes} episodes · ${languages}';
+      case 'video_jimaku_episode_unlabeled':
+        return ({required Object episode, required Object count}) =>
+            'No subtitle labeled episode ${episode}; ${count} unlabeled files may still match';
+      case 'video_jimaku_episode_unavailable':
+        return ({required Object episode}) =>
+            'No subtitle found for episode ${episode}';
+      case 'video_jimaku_episode_available':
+        return ({required Object count, required Object languages}) =>
+            '${count} subtitles available · ${languages}';
+      case 'video_scrape_manual_match_hint':
+        return 'Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.';
+      case 'video_scrape_collection_match_hint':
+        return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
+      case 'video_scrape_apply_to_collection_hint':
+        return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
+      case 'video_scrape_tmdb_key_empty':
+        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "请先选择漫画文件或文件夹。",
   "manga_import_detected_title": "这看起来是漫画",
   "manga_import_detected_confirm": "按漫画导入",
-  "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。"
+  "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。",
+  "video_jimaku_source_loading": "正在检查字幕可用性…",
+  "video_jimaku_source_failed": "字幕可用性检查失败，请重新查找。",
+  "video_jimaku_language_unknown": "语言未标注",
+  "video_jimaku_source_summary": "$files 个字幕文件 · 覆盖 $episodes 集 · $languages",
+  "video_jimaku_episode_unlabeled": "未发现标为第 $episode 集的字幕；另有 $count 个未标集号文件可尝试",
+  "video_jimaku_episode_unavailable": "没有找到第 $episode 集字幕",
+  "video_jimaku_episode_available": "有 $count 个字幕 · $languages",
+  "video_scrape_manual_match_hint": "手动匹配会替换本集封面，并保存来源映射和条目资料。切换来源后，点“搜索”才会请求该来源。",
+  "video_scrape_collection_match_hint": "这里只替换合集封面，不会修改各集封面或条目资料。切换来源后，点“搜索”才会请求该来源。",
+  "video_scrape_apply_to_collection_hint": "这会把同一张封面写到每一集；只有确实需要统一单集封面时才开启。",
+  "video_scrape_tmdb_key_empty": "先保存 TMDB API Key，再点“搜索”。这里不会混入其他来源的结果。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2761,5 +2761,16 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "video_jimaku_source_loading": "Checking subtitle availability...",
+  "video_jimaku_source_failed": "Could not check subtitle availability. Try searching again.",
+  "video_jimaku_language_unknown": "Language not labeled",
+  "video_jimaku_source_summary": "$files subtitle files · $episodes episodes · $languages",
+  "video_jimaku_episode_unlabeled": "No subtitle labeled episode $episode; $count unlabeled files may still match",
+  "video_jimaku_episode_unavailable": "No subtitle found for episode $episode",
+  "video_jimaku_episode_available": "$count subtitles available · $languages",
+  "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
+  "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
+  "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
+  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here."
 }

--- a/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
+++ b/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
@@ -118,6 +118,7 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   List<ScrapeCandidate> _results = const <ScrapeCandidate>[];
   bool _searching = false;
   bool _searched = false;
+  int _searchGeneration = 0;
 
   /// 上一次搜索失败的异常（null = 没失败）。BUG-1176：「搜不到」和「搜不了」是两回
   /// 事，失败必须有出口——失败态在结果区显示错误行 + 可行动原因，绝不塌缩成
@@ -174,6 +175,8 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   Future<void> _search() async {
     final String keyword = _queryCtrl.text.trim();
     if (keyword.isEmpty) return;
+    final int generation = ++_searchGeneration;
+    final ScrapeSource source = _source;
     // 添加/修改 Bangumi 映射：贴条目 URL = 直接按 id 取该条目改绑（跳过关键词
     // 搜索与 TMDB key 门，无论当前在哪个数据源分段）。
     final String? mappedSubjectId = parseBangumiSubjectUrl(keyword);
@@ -199,7 +202,7 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
             .log('CoverMatchDialog.fetchBangumiCandidateById', e, stack);
         failure = e;
       }
-      if (!mounted) return;
+      if (!mounted || generation != _searchGeneration) return;
       setState(() {
         _results = results;
         _searching = false;
@@ -208,9 +211,12 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
       return;
     }
     // TMDB 分段但无 key：展开输入行，不搜。
-    if (_source == ScrapeSource.tmdb && _storedTmdbKey().isEmpty) {
+    if (source == ScrapeSource.tmdb && _storedTmdbKey().isEmpty) {
       setState(() {
         _showTmdbKeyField = true;
+        _results = const <ScrapeCandidate>[];
+        _searched = false;
+        _searchFailure = null;
         _applyFailure = null;
       });
       HibikiToast.show(msg: t.video_scrape_tmdb_key_required);
@@ -225,13 +231,13 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     List<ScrapeCandidate> results = const <ScrapeCandidate>[];
     Object? failure;
     try {
-      results = await _searchSource(keyword);
+      results = await _searchSource(keyword, source);
     } catch (e, stack) {
       // 同上：搜索失败与「零结果」必须分开，否则用户以为片名搜不到而放弃重试。
       ErrorLogService.instance.log('CoverMatchDialog.search', e, stack);
       failure = e;
     }
-    if (!mounted) return;
+    if (!mounted || generation != _searchGeneration) return;
     setState(() {
       _results = results;
       _searching = false;
@@ -250,8 +256,11 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
 
   /// TMDB 分段用当前 key 现建 client 搜索（服务注入的 client 可能因启动时无 key 而为
   /// null；此处支持用户中途填入 key 后立即可搜）；其余源走注入的 service。
-  Future<List<ScrapeCandidate>> _searchSource(String keyword) async {
-    if (_source == ScrapeSource.tmdb) {
+  Future<List<ScrapeCandidate>> _searchSource(
+    String keyword,
+    ScrapeSource source,
+  ) async {
+    if (source == ScrapeSource.tmdb) {
       final String key = _storedTmdbKey();
       if (key.isEmpty) return const <ScrapeCandidate>[];
       final TmdbClient client = TmdbClient(apiKey: key);
@@ -264,13 +273,13 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     // 纯数字输入既可能是 Bangumi subject id（用户改绑映射）也可能就是标题
     // （如动画《86》）：两路依次都试，id 直取命中置顶、与同 id 搜索结果去重——
     // 不牺牲任何一种意图。
-    if (_source == ScrapeSource.bangumi && RegExp(r'^\d+$').hasMatch(keyword)) {
+    if (source == ScrapeSource.bangumi && RegExp(r'^\d+$').hasMatch(keyword)) {
       List<ScrapeCandidate> searched = const <ScrapeCandidate>[];
       Object? searchError;
       StackTrace? searchStack;
       try {
         searched = await widget.service
-            .searchCandidates(source: _source, keyword: keyword);
+            .searchCandidates(source: source, keyword: keyword);
       } catch (e, stack) {
         // 单路失败只是降级（另一路还可能有结果），不打扰用户；但要留取证痕迹，
         // 否则「数字关键词结果时多时少」无从查起。
@@ -305,7 +314,7 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
         ...searched.where((ScrapeCandidate c) => c.entryId != directId),
       ];
     }
-    return widget.service.searchCandidates(source: _source, keyword: keyword);
+    return widget.service.searchCandidates(source: source, keyword: keyword);
   }
 
   MatchConfidence? _confidenceFor(ScrapeCandidate candidate) {
@@ -403,6 +412,15 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
             _buildSearchRow(),
             const SizedBox(height: 8),
             _buildSourceSelector(),
+            const SizedBox(height: 6),
+            Text(
+              collection == null
+                  ? t.video_scrape_manual_match_hint
+                  : t.video_scrape_collection_match_hint,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
             if (_showTmdbKeyField) ...<Widget>[
               const SizedBox(height: 8),
               _buildTmdbKeyRow(),
@@ -430,6 +448,7 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
                     n: widget.collectionMemberUids.length,
                   ),
                 ),
+                subtitle: Text(t.video_scrape_apply_to_collection_hint),
               ),
           ],
         ),
@@ -491,12 +510,20 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
         showSelectedIcon: false,
         onSelectionChanged: (Set<ScrapeSource> selected) {
           final ScrapeSource next = selected.first;
+          if (next == _source) return;
           setState(() {
+            // 切来源只改变搜索目标，不替用户立刻发网络请求。旧来源结果必须同时清空，
+            // 否则 TMDB 无 key 时仍挂着 Bangumi 候选，看起来像「TMDB 也有数据」。
+            _searchGeneration++;
             _source = next;
+            _results = const <ScrapeCandidate>[];
+            _searching = false;
+            _searched = false;
+            _searchFailure = null;
+            _applyFailure = null;
             _showTmdbKeyField =
                 next == ScrapeSource.tmdb && _storedTmdbKey().isEmpty;
           });
-          _search();
         },
       ),
     );
@@ -518,10 +545,16 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
         const SizedBox(width: 8),
         FilledButton(
           onPressed: () async {
-            await _saveTmdbKey(_tmdbKeyCtrl.text);
-            if (!mounted) return;
-            setState(
-                () => _showTmdbKeyField = _tmdbKeyCtrl.text.trim().isEmpty);
+            final String key = _tmdbKeyCtrl.text;
+            final ScrapeSource source = _source;
+            final int generation = _searchGeneration;
+            await _saveTmdbKey(key);
+            if (!mounted ||
+                source != _source ||
+                generation != _searchGeneration) {
+              return;
+            }
+            setState(() => _showTmdbKeyField = key.trim().isEmpty);
             await _search();
           },
           child: Text(t.video_scrape_tmdb_key_save),
@@ -533,6 +566,18 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   Widget _buildResults(ThemeData theme) {
     if (_searching) {
       return const Center(child: CircularProgressIndicator());
+    }
+    if (_source == ScrapeSource.tmdb &&
+        _storedTmdbKey().isEmpty &&
+        !_searched) {
+      return Center(
+        child: Text(
+          t.video_scrape_tmdb_key_empty,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium
+              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+        ),
+      );
     }
     final Object? failure = _searchFailure;
     if (failure != null) return _buildSearchFailure(failure);
@@ -578,6 +623,7 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   Widget _buildCandidateTile(ThemeData theme, ScrapeCandidate candidate) {
     final MatchConfidence? confidence = _confidenceFor(candidate);
     final List<String> metaParts = <String>[
+      '${_sourceLabel(candidate.source)} #${candidate.entryId}',
       if (candidate.year != null) '${candidate.year}',
       if (candidate.type != ScrapeEntryType.unknown) candidate.type.name,
       if (candidate.ratingText != null) candidate.ratingText!,
@@ -585,6 +631,9 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     // 自绘 Row（不用 ListTile.subtitle 叠两行——会撞 ListTile 固定 subtitle 高度而
     // 竖向溢出）：缩略图 + 标题/元信息/置信度纵列 + 「使用」按钮。
     return Padding(
+      key: ValueKey<String>(
+        'cover_match_candidate_${candidate.source.name}_${candidate.entryId}',
+      ),
       padding: const EdgeInsets.symmetric(vertical: 6),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
@@ -625,6 +674,15 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
         ],
       ),
     );
+  }
+
+  String _sourceLabel(ScrapeSource source) {
+    return switch (source) {
+      ScrapeSource.bangumi => 'Bangumi',
+      ScrapeSource.tmdb => 'TMDB',
+      ScrapeSource.offlineDb => t.video_scrape_source_offline,
+      ScrapeSource.manualUrl => 'URL',
+    };
   }
 
   Widget _buildThumb(ThemeData theme, String url) {

--- a/hibiki/lib/src/media/video/jimaku_batch.dart
+++ b/hibiki/lib/src/media/video/jimaku_batch.dart
@@ -131,6 +131,26 @@ String batchSubtitleFileName(String bookUid, String fileName) {
 /// 每集处理完（下载落盘后，含 noMatch/failed）的回调；调用方据此持久化 + 刷新 UI。
 typedef JimakuBatchItemCallback = Future<void> Function(JimakuBatchItem item);
 
+/// 批量下载只能在所选来源的预检查已经成功完成且确有可解析字幕时开放。
+///
+/// loading / failed / 合法空库存都必须保持禁用，避免用户在还没看完预览或已经明确
+/// 失败时启动一条语义不同的下载请求链。
+bool canDownloadJimakuInventory({
+  required int? selectedEntryId,
+  required Map<int, JimakuFileInventory> inventories,
+  required Set<int> loadingEntryIds,
+  required Set<int> failedEntryIds,
+}) {
+  final int? entryId = selectedEntryId;
+  if (entryId == null ||
+      loadingEntryIds.contains(entryId) ||
+      failedEntryIds.contains(entryId)) {
+    return false;
+  }
+  final JimakuFileInventory? inventory = inventories[entryId];
+  return inventory != null && inventory.files.isNotEmpty;
+}
+
 /// 编排合集批量字幕下载：对 [targets] 逐集在 [entryIds]（合集绑定的 Jimaku 条目）里按
 /// 集号列文件 → 挑最佳 → 下载 → 落 [saveDirectory]。每集处理前后各回调一次
 /// （[onItemStart] / [onItemDone]），持久化由 [onItemDone] 里调用方按 target.isStream 分派。
@@ -160,7 +180,13 @@ Future<List<JimakuBatchItem>> runJimakuBatch({
     try {
       final List<JimakuFile> files = <JimakuFile>[];
       for (final int id in ids) {
-        files.addAll(await client.listFiles(id, episode: item.episode));
+        files.addAll(
+          await client.listFiles(
+            id,
+            episode: item.episode,
+            throwOnError: true,
+          ),
+        );
       }
       final JimakuFile? best = pickBestSubtitleFile(
         files,

--- a/hibiki/lib/src/media/video/jimaku_client.dart
+++ b/hibiki/lib/src/media/video/jimaku_client.dart
@@ -47,6 +47,43 @@ class JimakuFile {
   int? get episode => parseSubtitleEpisode(name);
 }
 
+/// 一个 Jimaku 条目下可供 UI 预览的文本字幕清单。
+///
+/// 合集批量下载弹窗在用户真正点「下载全部」前先列一次条目文件，用这份清单回答两个
+/// 关键问题：这个来源到底有什么字幕、合集里的哪几集能精确匹配。只统计 Hibiki 能解析
+/// 的文本字幕；压缩包/图片字幕不会被误报成「可用」。
+class JimakuFileInventory {
+  JimakuFileInventory._(this.files)
+      : episodes = <int>{
+          for (final JimakuFile file in files)
+            if (file.episode != null) file.episode!,
+        },
+        languages = <String>{
+          for (final JimakuFile file in files)
+            if (detectSubtitleLanguage(file.name) != null)
+              detectSubtitleLanguage(file.name)!,
+        },
+        unlabeledCount =
+            files.where((JimakuFile file) => file.episode == null).length;
+
+  factory JimakuFileInventory.fromFiles(Iterable<JimakuFile> files) {
+    return JimakuFileInventory._(
+      files
+          .where((JimakuFile file) => file.isTextSubtitle)
+          .toList(growable: false),
+    );
+  }
+
+  final List<JimakuFile> files;
+  final Set<int> episodes;
+  final Set<String> languages;
+  final int unlabeledCount;
+
+  List<JimakuFile> filesForEpisode(int episode) => files
+      .where((JimakuFile file) => file.episode == episode)
+      .toList(growable: false);
+}
+
 /// 从字幕文件名启发式解析集号。复用 [parseVideoFilename] 的集号识别规则（`SxxEyy` /
 /// CJK `第N話` / `EP/E` / `- N` / 结尾裸数字），但先剥掉字幕扩展名（srt/ass/ssa/vtt）
 /// 与可选的语言子标签（`.ja` / `.zh-cn` 等），使 `Show - 12.ja.srt` 这类文件名也能
@@ -82,10 +119,15 @@ List<JimakuEntry> parseJimakuEntries(String body) {
       if (e is! Map) continue;
       final dynamic id = e['id'];
       if (id is! int) continue;
+      final String primaryName = (e['name'] as String?)?.trim() ?? '';
+      final String englishName = (e['english_name'] as String?)?.trim() ?? '';
       out.add(JimakuEntry(
         id: id,
-        name:
-            (e['name'] as String?) ?? (e['english_name'] as String?) ?? '#$id',
+        name: primaryName.isNotEmpty
+            ? primaryName
+            : englishName.isNotEmpty
+                ? englishName
+                : '#$id',
         anilistId: e['anilist_id'] as int?,
       ));
     }
@@ -214,17 +256,36 @@ String? _languageFromToken(String rawToken) {
   return table[token.split('-').first];
 }
 
-/// 解析 Jimaku files 响应（JSON 数组）为 [JimakuFile] 列表。纯函数，容错。
-List<JimakuFile> parseJimakuFiles(String body) {
+/// 解析 Jimaku files 响应（JSON 数组）为 [JimakuFile] 列表。
+///
+/// 默认沿用历史 fail-open 语义；库存预检查传 [strict] 时，非法 JSON、非数组顶层或
+/// 缺少必需 name/url 的元素都属于响应结构失败，必须抛出
+/// [JimakuRequestException]，不能与合法空数组混成同一个「零字幕」状态。
+List<JimakuFile> parseJimakuFiles(String body, {bool strict = false}) {
   try {
     final dynamic json = jsonDecode(body);
-    if (json is! List) return const <JimakuFile>[];
+    if (json is! List) {
+      throw const FormatException('Jimaku files response is not a JSON array');
+    }
     final List<JimakuFile> out = <JimakuFile>[];
-    for (final dynamic f in json) {
-      if (f is! Map) continue;
+    for (int index = 0; index < json.length; index++) {
+      final dynamic f = json[index];
+      if (f is! Map) {
+        if (strict) {
+          throw FormatException('Jimaku file at index $index is not an object');
+        }
+        continue;
+      }
       final dynamic name = f['name'];
       final dynamic url = f['url'];
-      if (name is! String || url is! String) continue;
+      if (name is! String || url is! String) {
+        if (strict) {
+          throw FormatException(
+            'Jimaku file at index $index is missing name or url',
+          );
+        }
+        continue;
+      }
       out.add(JimakuFile(
         name: name,
         url: url,
@@ -232,10 +293,36 @@ List<JimakuFile> parseJimakuFiles(String body) {
       ));
     }
     return out;
-  } catch (e) {
+  } catch (e, stack) {
     // fail-open：解析失败返回空列表（同旧行为），补 diagnostic 便于排障。
     ErrorLogService.instance.logDiagnostic('JimakuClient.parseJimakuFiles', e);
+    if (strict) {
+      Error.throwWithStackTrace(
+        const JimakuRequestException('invalid list files response'),
+        stack,
+      );
+    }
     return const <JimakuFile>[];
+  }
+}
+
+/// Jimaku 请求失败。默认客户端路径仍可 fail-open；需要向用户区分「零结果」与「请求
+/// 失败」的界面可通过 `throwOnError: true` 保留这个异常。
+class JimakuRequestException implements Exception {
+  const JimakuRequestException(
+    this.message, {
+    this.statusCode,
+  });
+
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() {
+    final int? status = statusCode;
+    return status == null
+        ? 'JimakuRequestException: $message'
+        : 'JimakuRequestException($status): $message';
   }
 }
 
@@ -318,15 +405,31 @@ class JimakuClient {
   /// [episode] 非空时附 `episode=<n>` query，由 Jimaku 服务端**按文件名启发式**只返回
   /// 匹配该集的文件（文档原文：best-effort guess based off filename matching）；为空时
   /// 不带该 query，行为 = 旧路径（列全部文件，向后兼容）。
-  Future<List<JimakuFile>> listFiles(int entryId, {int? episode}) async {
+  Future<List<JimakuFile>> listFiles(
+    int entryId, {
+    int? episode,
+    bool throwOnError = false,
+  }) async {
     try {
       final Uri uri = buildListFilesUri(_base, entryId, episode: episode);
       final http.Response res = await _client.get(uri, headers: _headers);
-      if (res.statusCode != 200) return const <JimakuFile>[];
-      return parseJimakuFiles(utf8.decode(res.bodyBytes, allowMalformed: true));
-    } catch (e) {
+      if (res.statusCode != 200) {
+        if (throwOnError) {
+          throw JimakuRequestException(
+            'list files for entry $entryId failed',
+            statusCode: res.statusCode,
+          );
+        }
+        return const <JimakuFile>[];
+      }
+      return parseJimakuFiles(
+        utf8.decode(res.bodyBytes, allowMalformed: true),
+        strict: throwOnError,
+      );
+    } catch (e, stack) {
       // fail-open：预期可失败的网络路径，返回空列表（同旧行为），补 diagnostic。
       ErrorLogService.instance.logDiagnostic('JimakuClient.listFiles', e);
+      if (throwOnError) Error.throwWithStackTrace(e, stack);
       return const <JimakuFile>[];
     }
   }

--- a/hibiki/lib/src/pages/implementations/jimaku_batch_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/jimaku_batch_dialog.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
 import 'package:hibiki/models.dart';
@@ -17,6 +20,8 @@ import 'package:hibiki/src/storage/app_paths.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
+typedef JimakuBatchHttpClientFactory = Future<http.Client> Function();
+
 /// 「为整个合集获取字幕」批量对话框：把合集绑定到一个 AniList 系列（快照 anilist_id），
 /// 再对合集里每一集经 Jimaku 按集号拉最佳字幕、下载、持久化——本地集落 DB（subtitleSource
 /// 列 + cue），远端/流媒体集落 prefs（`<bookUid>#ep`）。逐集显示状态，尽力而为（单集失败
@@ -28,6 +33,7 @@ class JimakuBatchDialog extends ConsumerStatefulWidget {
     required this.database,
     required this.collection,
     required this.members,
+    this.httpClientFactory,
     super.key,
   });
 
@@ -37,12 +43,18 @@ class JimakuBatchDialog extends ConsumerStatefulWidget {
   /// 合集里**有序**的视频成员（调用方已按 sortIndex 加载）。
   final List<VideoBookRow> members;
 
+  /// 测试注入点；生产路径为空时仍统一走 AppModel 的代理感知客户端工厂。
+  final JimakuBatchHttpClientFactory? httpClientFactory;
+
   @override
   ConsumerState<JimakuBatchDialog> createState() => _JimakuBatchDialogState();
 }
 
 class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
   AppModel get appModel => ref.read(appProvider);
+
+  Future<http.Client> _createHttpClient() =>
+      widget.httpClientFactory?.call() ?? appModel.createDownloadHttpClient();
 
   late final VideoBookRepository _repo = VideoBookRepository(widget.database);
   late final TextEditingController _apiKeyCtrl =
@@ -60,6 +72,15 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
   List<JimakuEntry> _entries = const <JimakuEntry>[];
   int? _selectedEntryId;
   String? _preferredLanguage;
+
+  /// 每个 Jimaku 来源的文本字幕清单。来源搜索完成后立即预取一次，选来源和点下载前
+  /// 就能看到文件数、覆盖集数、语言与逐集可用性。
+  final Map<int, JimakuFileInventory> _inventories =
+      <int, JimakuFileInventory>{};
+  final Set<int> _loadingInventoryIds = <int>{};
+  final Set<int> _failedInventoryIds = <int>{};
+  int _inventoryGeneration = 0;
+  int _seriesResolutionGeneration = 0;
 
   /// 逐集状态：bookUid → item（下载推进时更新）。
   final Map<String, JimakuBatchItem> _statusByUid = <String, JimakuBatchItem>{};
@@ -106,74 +127,121 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
     }
     if (query.isEmpty) return;
     await appModel.setJimakuApiKey(apiKey);
+    final int generation = ++_seriesResolutionGeneration;
     setState(() {
       _resolving = true;
       _seriesMatches = const <AniListMedia>[];
       _entries = const <JimakuEntry>[];
       _selectedEntryId = null;
+      _inventories.clear();
+      _loadingInventoryIds.clear();
+      _failedInventoryIds.clear();
+      _inventoryGeneration++;
     });
     AniListClient? anilist;
     try {
       anilist = AniListClient(
-        client: await appModel.createDownloadHttpClient(),
+        client: await _createHttpClient(),
       );
       final List<AniListMedia> media = await anilist.searchAnime(query);
-      if (!mounted) return;
+      if (!mounted || generation != _seriesResolutionGeneration) return;
       setState(() => _seriesMatches = media);
       if (media.isNotEmpty) {
-        await _selectSeries(media.first, persist: true);
+        await _selectSeries(
+          media.first,
+          persist: true,
+          generation: generation,
+        );
       } else {
         // AniList 无命中 → 用文本直接搜 Jimaku 条目（无 anilist 绑定）。
-        await _resolveEntriesByQuery(query);
+        await _resolveEntriesByQuery(query, generation: generation);
       }
     } finally {
       anilist?.close();
-      if (mounted) setState(() => _resolving = false);
+      if (mounted && generation == _seriesResolutionGeneration) {
+        setState(() => _resolving = false);
+      }
     }
   }
 
   /// 用户点某系列 chip：绑定该系列、快照 anilist_id 到合集、解析其 Jimaku 条目。
-  Future<void> _selectSeries(AniListMedia media, {bool persist = false}) async {
-    setState(() => _selectedSeriesId = media.id);
+  Future<void> _selectSeries(
+    AniListMedia media, {
+    bool persist = false,
+    int? generation,
+  }) async {
+    final int requestGeneration = generation ?? ++_seriesResolutionGeneration;
+    setState(() {
+      _selectedSeriesId = media.id;
+      _entries = const <JimakuEntry>[];
+      _selectedEntryId = null;
+      _inventories.clear();
+      _loadingInventoryIds.clear();
+      _failedInventoryIds.clear();
+      _inventoryGeneration++;
+    });
     if (persist || widget.collection.anilistId != media.id) {
       await widget.database
           .setMediaCollectionAnilistId(widget.collection.id, media.id);
+      if (!mounted || requestGeneration != _seriesResolutionGeneration) {
+        // 旧选择的慢 DB 写可能晚于新选择落库；以当前 UI 选择重申一次，避免数据库
+        // 最终回退到旧 AniList id。
+        final int? latestSeriesId = _selectedSeriesId;
+        if (latestSeriesId != null) {
+          await widget.database.setMediaCollectionAnilistId(
+            widget.collection.id,
+            latestSeriesId,
+          );
+        }
+        return;
+      }
     }
-    await _resolveEntriesForSeries(media.id);
+    await _resolveEntriesForSeries(
+      media.id,
+      generation: requestGeneration,
+    );
   }
 
-  Future<void> _resolveEntriesForSeries(int anilistId) async {
+  Future<void> _resolveEntriesForSeries(
+    int anilistId, {
+    int? generation,
+  }) async {
     final String apiKey = _apiKeyCtrl.text.trim();
     if (apiKey.isEmpty) return;
+    final int requestGeneration = generation ?? ++_seriesResolutionGeneration;
     JimakuClient? jimaku;
     try {
       jimaku = JimakuClient(
         apiKey: apiKey,
-        client: await appModel.createDownloadHttpClient(),
+        client: await _createHttpClient(),
       );
       final List<JimakuEntry> entries =
           await jimaku.searchByAnilistId(anilistId);
-      if (!mounted) return;
+      if (!mounted ||
+          requestGeneration != _seriesResolutionGeneration ||
+          _selectedSeriesId != anilistId) {
+        return;
+      }
       _setEntries(entries);
     } finally {
       jimaku?.close();
     }
   }
 
-  Future<void> _resolveEntriesByQuery(String query) async {
+  Future<void> _resolveEntriesByQuery(
+    String query, {
+    required int generation,
+  }) async {
     JimakuClient? jimaku;
     try {
       jimaku = JimakuClient(
         apiKey: _apiKeyCtrl.text.trim(),
-        client: await appModel.createDownloadHttpClient(),
+        client: await _createHttpClient(),
       );
       final List<JimakuEntry> entries = await jimaku.searchByQuery(query);
-      if (!mounted) return;
-      setState(() {
-        _selectedSeriesId = null;
-        _entries = entries;
-        _selectedEntryId = entries.isEmpty ? null : entries.first.id;
-      });
+      if (!mounted || generation != _seriesResolutionGeneration) return;
+      setState(() => _selectedSeriesId = null);
+      _setEntries(entries);
     } finally {
       jimaku?.close();
     }
@@ -187,21 +255,84 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
   }
 
   void _setEntries(List<JimakuEntry> entries) {
+    final int generation = ++_inventoryGeneration;
     setState(() {
       _entries = entries;
       _selectedEntryId = entries.isEmpty ? null : entries.first.id;
+      _inventories.clear();
+      _failedInventoryIds.clear();
+      _loadingInventoryIds
+        ..clear()
+        ..addAll(entries.map((JimakuEntry entry) => entry.id));
     });
+    if (entries.isNotEmpty) {
+      unawaited(_loadEntryInventories(entries, generation));
+    }
+  }
+
+  /// 一条来源只列一次全部文件；不按「来源 × 集数」制造几十次请求。文件名里的集号与
+  /// 语言标记足够构造来源摘要和逐集预览。严格模式保留请求异常，避免断网被画成「0 字幕」。
+  Future<void> _loadEntryInventories(
+    List<JimakuEntry> entries,
+    int generation,
+  ) async {
+    JimakuClient? jimaku;
+    try {
+      jimaku = JimakuClient(
+        apiKey: _apiKeyCtrl.text.trim(),
+        client: await _createHttpClient(),
+      );
+      for (final JimakuEntry entry in entries) {
+        try {
+          final List<JimakuFile> files = await jimaku.listFiles(
+            entry.id,
+            throwOnError: true,
+          );
+          if (!mounted || generation != _inventoryGeneration) return;
+          setState(() {
+            _loadingInventoryIds.remove(entry.id);
+            _inventories[entry.id] = JimakuFileInventory.fromFiles(files);
+          });
+        } catch (_) {
+          if (!mounted || generation != _inventoryGeneration) return;
+          setState(() {
+            _loadingInventoryIds.remove(entry.id);
+            _failedInventoryIds.add(entry.id);
+          });
+        }
+      }
+    } catch (e, stack) {
+      ErrorLogService.instance.log(
+        'JimakuBatchDialog.loadEntryInventories',
+        e,
+        stack,
+      );
+      if (!mounted || generation != _inventoryGeneration) return;
+      setState(() {
+        for (final JimakuEntry entry in entries) {
+          if (_loadingInventoryIds.remove(entry.id)) {
+            _failedInventoryIds.add(entry.id);
+          }
+        }
+      });
+    } finally {
+      jimaku?.close();
+    }
+  }
+
+  JimakuBatchTarget _targetAt(int index) {
+    final VideoBookRow member = widget.members[index];
+    return JimakuBatchTarget(
+      bookUid: member.bookUid,
+      title: member.title,
+      videoPath: member.videoPath,
+      sortIndex: index,
+      isStream: isStreamVideoBook(member),
+    );
   }
 
   List<JimakuBatchTarget> _targets() => <JimakuBatchTarget>[
-        for (int i = 0; i < widget.members.length; i++)
-          JimakuBatchTarget(
-            bookUid: widget.members[i].bookUid,
-            title: widget.members[i].title,
-            videoPath: widget.members[i].videoPath,
-            sortIndex: i,
-            isStream: isStreamVideoBook(widget.members[i]),
-          ),
+        for (int i = 0; i < widget.members.length; i++) _targetAt(i),
       ];
 
   /// 运行批量下载：对每集列文件→挑最佳→下载→持久化（本地落 DB / 远端落 prefs）。
@@ -226,7 +357,7 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
     try {
       jimaku = JimakuClient(
         apiKey: apiKey,
-        client: await appModel.createDownloadHttpClient(),
+        client: await _createHttpClient(),
       );
       await runJimakuBatch(
         client: jimaku,
@@ -282,27 +413,103 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
     }
   }
 
-  Widget _statusIcon(String bookUid) {
+  Widget _statusIcon(String bookUid, int memberIndex) {
     final JimakuBatchItem? item = _statusByUid[bookUid];
-    if (item == null) {
-      return const Icon(Icons.remove, size: 18);
+    if (item != null) {
+      switch (item.status) {
+        case JimakuBatchStatus.downloading:
+          return const SizedBox(
+            width: 18,
+            height: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          );
+        case JimakuBatchStatus.done:
+          return const Icon(Icons.check_circle, size: 18, color: Colors.green);
+        case JimakuBatchStatus.noMatch:
+          return const Icon(Icons.search_off, size: 18);
+        case JimakuBatchStatus.failed:
+          return const Icon(Icons.error_outline, size: 18, color: Colors.red);
+        case JimakuBatchStatus.pending:
+          return const Icon(Icons.schedule, size: 18);
+      }
     }
-    switch (item.status) {
-      case JimakuBatchStatus.downloading:
-        return const SizedBox(
-          width: 18,
-          height: 18,
-          child: CircularProgressIndicator(strokeWidth: 2),
+    final int? entryId = _selectedEntryId;
+    if (entryId == null) return const Icon(Icons.remove, size: 18);
+    if (_loadingInventoryIds.contains(entryId)) {
+      return const SizedBox(
+        width: 18,
+        height: 18,
+        child: CircularProgressIndicator(strokeWidth: 2),
+      );
+    }
+    if (_failedInventoryIds.contains(entryId)) {
+      return const Icon(Icons.error_outline, size: 18, color: Colors.red);
+    }
+    final JimakuFileInventory? inventory = _inventories[entryId];
+    if (inventory == null) return const Icon(Icons.remove, size: 18);
+    final int episode = resolveBatchEpisode(_targetAt(memberIndex));
+    return inventory.filesForEpisode(episode).isEmpty
+        ? const Icon(Icons.search_off, size: 18)
+        : const Icon(Icons.check_circle_outline, size: 18, color: Colors.green);
+  }
+
+  Widget? _episodeSubtitle(VideoBookRow member, int memberIndex) {
+    final JimakuBatchItem? item = _statusByUid[member.bookUid];
+    if (item != null) {
+      switch (item.status) {
+        case JimakuBatchStatus.done:
+          return Text(
+            item.language == null
+                ? t.video_jimaku_downloaded
+                : '${t.video_jimaku_downloaded} · '
+                    '${jimakuLanguageLabel(item.language!)}',
+          );
+        case JimakuBatchStatus.noMatch:
+          return Text(t.video_jimaku_no_results);
+        case JimakuBatchStatus.failed:
+          return Text(t.video_jimaku_download_failed);
+        case JimakuBatchStatus.downloading:
+        case JimakuBatchStatus.pending:
+          return Text(t.video_jimaku_source_loading);
+      }
+    }
+    final int? entryId = _selectedEntryId;
+    if (entryId == null) return null;
+    if (_loadingInventoryIds.contains(entryId)) {
+      return Text(t.video_jimaku_source_loading);
+    }
+    if (_failedInventoryIds.contains(entryId)) {
+      return Text(t.video_jimaku_source_failed);
+    }
+    final JimakuFileInventory? inventory = _inventories[entryId];
+    if (inventory == null) return Text(t.video_jimaku_source_hint);
+    final int episode = resolveBatchEpisode(_targetAt(memberIndex));
+    final List<JimakuFile> matches = inventory.filesForEpisode(episode);
+    if (matches.isEmpty) {
+      if (inventory.unlabeledCount > 0) {
+        return Text(
+          t.video_jimaku_episode_unlabeled(
+            episode: episode,
+            count: inventory.unlabeledCount,
+          ),
         );
-      case JimakuBatchStatus.done:
-        return const Icon(Icons.check_circle, size: 18, color: Colors.green);
-      case JimakuBatchStatus.noMatch:
-        return const Icon(Icons.search_off, size: 18);
-      case JimakuBatchStatus.failed:
-        return const Icon(Icons.error_outline, size: 18, color: Colors.red);
-      case JimakuBatchStatus.pending:
-        return const Icon(Icons.schedule, size: 18);
+      }
+      return Text(t.video_jimaku_episode_unavailable(episode: episode));
     }
+    final Set<String> languages = <String>{
+      for (final JimakuFile file in matches)
+        if (detectSubtitleLanguage(file.name) != null)
+          detectSubtitleLanguage(file.name)!,
+    };
+    final String languageText = languages.isEmpty
+        ? t.video_jimaku_language_unknown
+        : languages.map(jimakuLanguageLabel).join(' / ');
+    return Text(
+      t.video_jimaku_episode_available(
+        count: matches.length,
+        languages: languageText,
+      ),
+    );
   }
 
   /// 「标签在上、chip 在下」分区（与单集对话框 _chipSection 同款清爽排版）：标签弱化，
@@ -331,7 +538,12 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final bool hasSource = _selectedEntryId != null;
+    final bool canDownload = canDownloadJimakuInventory(
+      selectedEntryId: _selectedEntryId,
+      inventories: _inventories,
+      loadingEntryIds: _loadingInventoryIds,
+      failedEntryIds: _failedInventoryIds,
+    );
     return HibikiDialogFrame(
       maxWidth: 720,
       maxHeightFactor: 0.86,
@@ -397,6 +609,9 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
                     JimakuEntryPicker(
                       entries: _entries,
                       selectedEntryId: _selectedEntryId,
+                      inventories: _inventories,
+                      loadingEntryIds: _loadingInventoryIds,
+                      failedEntryIds: _failedInventoryIds,
                       enabled: !_running,
                       onSelected: (JimakuEntry entry) =>
                           setState(() => _selectedEntryId = entry.id),
@@ -420,19 +635,16 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
               itemCount: widget.members.length,
               itemBuilder: (BuildContext context, int i) {
                 final VideoBookRow m = widget.members[i];
-                final JimakuBatchItem? item = _statusByUid[m.bookUid];
                 return ListTile(
                   dense: true,
                   contentPadding: EdgeInsets.zero,
-                  leading: _statusIcon(m.bookUid),
+                  leading: _statusIcon(m.bookUid, i),
                   title: Text(
                     m.title,
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                   ),
-                  subtitle: item != null && item.language != null
-                      ? Text(jimakuLanguageLabel(item.language!))
-                      : null,
+                  subtitle: _episodeSubtitle(m, i),
                 );
               },
             ),
@@ -448,7 +660,7 @@ class _JimakuBatchDialogState extends ConsumerState<JimakuBatchDialog> {
                 child: Text(t.dialog_close),
               ),
               FilledButton.icon(
-                onPressed: _running || !hasSource ? null : _downloadAll,
+                onPressed: _running || !canDownload ? null : _downloadAll,
                 icon: _running
                     ? const SizedBox(
                         width: 18,

--- a/hibiki/lib/src/pages/implementations/jimaku_entry_picker.dart
+++ b/hibiki/lib/src/pages/implementations/jimaku_entry_picker.dart
@@ -13,6 +13,9 @@ class JimakuEntryPicker extends StatelessWidget {
     required this.entries,
     required this.selectedEntryId,
     required this.onSelected,
+    this.inventories = const <int, JimakuFileInventory>{},
+    this.loadingEntryIds = const <int>{},
+    this.failedEntryIds = const <int>{},
     this.enabled = true,
     super.key,
   });
@@ -20,6 +23,9 @@ class JimakuEntryPicker extends StatelessWidget {
   final List<JimakuEntry> entries;
   final int? selectedEntryId;
   final ValueChanged<JimakuEntry> onSelected;
+  final Map<int, JimakuFileInventory> inventories;
+  final Set<int> loadingEntryIds;
+  final Set<int> failedEntryIds;
   final bool enabled;
 
   @override
@@ -35,26 +41,11 @@ class JimakuEntryPicker extends StatelessWidget {
               ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
         ),
         const SizedBox(height: 6),
-        Wrap(
-          spacing: 8,
-          runSpacing: 8,
-          children: <Widget>[
-            for (final JimakuEntry entry in entries)
-              ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 320),
-                child: ChoiceChip(
-                  label: Text(
-                    entry.name,
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  tooltip: entry.name,
-                  selected: selectedEntryId == entry.id,
-                  onSelected: enabled ? (_) => onSelected(entry) : null,
-                ),
-              ),
-          ],
-        ),
+        for (final JimakuEntry entry in entries)
+          Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: _buildEntryChoice(context, entry),
+          ),
         const SizedBox(height: 6),
         Text(
           t.video_jimaku_source_hint,
@@ -62,6 +53,126 @@ class JimakuEntryPicker extends StatelessWidget {
               ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
         ),
       ],
+    );
+  }
+
+  Widget _buildEntryChoice(BuildContext context, JimakuEntry entry) {
+    final ThemeData theme = Theme.of(context);
+    final bool selected = selectedEntryId == entry.id;
+    return Material(
+      key: ValueKey<String>('jimaku_entry_${entry.id}'),
+      color: selected
+          ? theme.colorScheme.secondaryContainer
+          : theme.colorScheme.surfaceContainerLow,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12),
+        side: BorderSide(
+          color: selected
+              ? theme.colorScheme.primary
+              : theme.colorScheme.outlineVariant,
+        ),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: enabled ? () => onSelected(entry) : null,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.only(top: 2),
+                child: Icon(
+                  selected
+                      ? Icons.radio_button_checked
+                      : Icons.radio_button_unchecked,
+                  size: 20,
+                  color: selected
+                      ? theme.colorScheme.primary
+                      : theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Text(
+                      entry.name,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.bodyLarge,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      <String>[
+                        'Jimaku #${entry.id}',
+                        if (entry.anilistId != null)
+                          'AniList #${entry.anilistId}',
+                      ].join(' · '),
+                      style: theme.textTheme.labelSmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    _buildInventorySummary(theme, entry.id),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInventorySummary(ThemeData theme, int entryId) {
+    if (loadingEntryIds.contains(entryId)) {
+      return Row(
+        children: <Widget>[
+          const SizedBox(
+            width: 14,
+            height: 14,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: 6),
+          Text(t.video_jimaku_source_loading, style: theme.textTheme.bodySmall),
+        ],
+      );
+    }
+    if (failedEntryIds.contains(entryId)) {
+      return Text(
+        t.video_jimaku_source_failed,
+        style:
+            theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.error),
+      );
+    }
+    final JimakuFileInventory? inventory = inventories[entryId];
+    if (inventory == null) {
+      return Text(
+        t.video_jimaku_source_hint,
+        style: theme.textTheme.bodySmall
+            ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+      );
+    }
+    if (inventory.files.isEmpty) {
+      return Text(
+        t.video_jimaku_no_results,
+        style:
+            theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.error),
+      );
+    }
+    final String languages = inventory.languages.isEmpty
+        ? t.video_jimaku_language_unknown
+        : inventory.languages.map(jimakuLanguageLabel).join(' / ');
+    return Text(
+      t.video_jimaku_source_summary(
+        files: inventory.files.length,
+        episodes: inventory.episodes.length,
+        languages: languages,
+      ),
+      style: theme.textTheme.bodySmall
+          ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
     );
   }
 }

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+998
+version: 1.3.1+999
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/video/jimaku_batch_test.dart
+++ b/hibiki/test/media/video/jimaku_batch_test.dart
@@ -85,6 +85,64 @@ void main() {
     expect(a == b, isFalse, reason: '不同 book 的同名字幕落盘不得互相覆盖');
   });
 
+  group('canDownloadJimakuInventory', () {
+    final JimakuFileInventory nonEmpty = JimakuFileInventory.fromFiles(
+      <JimakuFile>[_f('Show - 01.ja.srt')],
+    );
+    final JimakuFileInventory empty =
+        JimakuFileInventory.fromFiles(const <JimakuFile>[]);
+
+    test('仅预检查成功且非空的当前来源可下载', () {
+      expect(
+        canDownloadJimakuInventory(
+          selectedEntryId: 7,
+          inventories: <int, JimakuFileInventory>{7: nonEmpty},
+          loadingEntryIds: const <int>{},
+          failedEntryIds: const <int>{},
+        ),
+        isTrue,
+      );
+    });
+
+    test('未选、loading、failed、合法空库存都禁用', () {
+      bool canDownload({
+        int? selectedEntryId = 7,
+        Map<int, JimakuFileInventory> inventories =
+            const <int, JimakuFileInventory>{},
+        Set<int> loading = const <int>{},
+        Set<int> failed = const <int>{},
+      }) =>
+          canDownloadJimakuInventory(
+            selectedEntryId: selectedEntryId,
+            inventories: inventories,
+            loadingEntryIds: loading,
+            failedEntryIds: failed,
+          );
+
+      expect(canDownload(selectedEntryId: null), isFalse);
+      expect(
+        canDownload(
+          inventories: <int, JimakuFileInventory>{7: nonEmpty},
+          loading: const <int>{7},
+        ),
+        isFalse,
+      );
+      expect(
+        canDownload(
+          inventories: <int, JimakuFileInventory>{7: nonEmpty},
+          failed: const <int>{7},
+        ),
+        isFalse,
+      );
+      expect(
+        canDownload(
+          inventories: <int, JimakuFileInventory>{7: empty},
+        ),
+        isFalse,
+      );
+    });
+  });
+
   group('runJimakuBatch（编排，MockClient 注入）', () {
     late Directory tempDir;
 
@@ -176,6 +234,64 @@ void main() {
       );
       expect(results[0].status, JimakuBatchStatus.done);
       expect(results[1].status, JimakuBatchStatus.noMatch);
+    });
+
+    test('HTTP 请求失败记 failed，不得 fail-open 冒充 noMatch', () async {
+      final JimakuClient client = JimakuClient(
+        apiKey: 'k',
+        client: MockClient(
+          (http.Request req) async => http.Response('unavailable', 503),
+        ),
+      );
+      addTearDown(client.close);
+
+      final List<JimakuBatchItem> results = await runJimakuBatch(
+        client: client,
+        entryIds: <int>[7],
+        targets: <JimakuBatchTarget>[
+          _t('video/a', '/v/Show - 01.mkv'),
+        ],
+        saveDirectory: tempDir.path,
+      );
+
+      expect(results.single.status, JimakuBatchStatus.failed);
+      expect(results.single.message, contains('JimakuRequestException(503)'));
+    });
+
+    test('malformed HTTP 200 记 failed；合法 [] 的 noMatch 语义不变', () async {
+      final JimakuClient malformed = JimakuClient(
+        apiKey: 'k',
+        client: MockClient(
+          (http.Request req) async => http.Response('{not-json', 200),
+        ),
+      );
+      addTearDown(malformed.close);
+      final List<JimakuBatchItem> malformedResults = await runJimakuBatch(
+        client: malformed,
+        entryIds: <int>[7],
+        targets: <JimakuBatchTarget>[
+          _t('video/a', '/v/Show - 01.mkv'),
+        ],
+        saveDirectory: tempDir.path,
+      );
+      expect(malformedResults.single.status, JimakuBatchStatus.failed);
+
+      final JimakuClient validEmpty = JimakuClient(
+        apiKey: 'k',
+        client: MockClient(
+          (http.Request req) async => http.Response('[]', 200),
+        ),
+      );
+      addTearDown(validEmpty.close);
+      final List<JimakuBatchItem> emptyResults = await runJimakuBatch(
+        client: validEmpty,
+        entryIds: <int>[7],
+        targets: <JimakuBatchTarget>[
+          _t('video/a', '/v/Show - 01.mkv'),
+        ],
+        saveDirectory: tempDir.path,
+      );
+      expect(emptyResults.single.status, JimakuBatchStatus.noMatch);
     });
   });
 }

--- a/hibiki/test/media/video/jimaku_client_test.dart
+++ b/hibiki/test/media/video/jimaku_client_test.dart
@@ -40,7 +40,7 @@ void main() {
     test('解析条目（name 回退 english_name / #id）', () {
       const String body = '''
 [{"id":10,"name":"鬼滅の刃","anilist_id":101922},
- {"id":11,"english_name":"Demon Slayer"},
+ {"id":11,"name":"  ","english_name":"Demon Slayer"},
  {"id":12}]''';
       final List<JimakuEntry> entries = parseJimakuEntries(body);
       expect(entries, hasLength(3));
@@ -75,6 +75,25 @@ void main() {
       expect(const JimakuFile(name: 'a.vtt', url: 'u').isTextSubtitle, isTrue);
       expect(const JimakuFile(name: 'a.zip', url: 'u').isTextSubtitle, isFalse);
       expect(const JimakuFile(name: 'noext', url: 'u').extension, '');
+    });
+
+    test('BUG-1235 inventory 只统计可解析字幕，并汇总集数、语言与未标集号文件', () {
+      final JimakuFileInventory inventory = JimakuFileInventory.fromFiles(
+        const <JimakuFile>[
+          JimakuFile(name: 'Show S01E01.ja.srt', url: 'u1'),
+          JimakuFile(name: 'Show S01E01.zh-cn.ass', url: 'u2'),
+          JimakuFile(name: 'Show S01E02.vtt', url: 'u3'),
+          JimakuFile(name: 'Show extra.ja.srt', url: 'u4'),
+          JimakuFile(name: 'Show S01E03.zip', url: 'u5'),
+        ],
+      );
+
+      expect(inventory.files, hasLength(4));
+      expect(inventory.episodes, <int>{1, 2});
+      expect(inventory.languages, <String>{'ja', 'zh'});
+      expect(inventory.unlabeledCount, 1);
+      expect(inventory.filesForEpisode(1), hasLength(2));
+      expect(inventory.filesForEpisode(3), isEmpty);
     });
   });
 
@@ -234,6 +253,79 @@ void main() {
       final List<JimakuEntry> entries =
           await jc.searchEntries(queryFallbacks: <String>['x']);
       expect(entries.single.name, 'q');
+    });
+  });
+
+  group('JimakuClient.listFiles strict availability check', () {
+    test('默认保持 fail-open，预检查严格模式保留 HTTP 状态码', () async {
+      final JimakuClient jc = JimakuClient(
+        apiKey: 'k',
+        client: MockClient(
+          (http.Request request) async => http.Response('unavailable', 503),
+        ),
+      );
+
+      expect(await jc.listFiles(42), isEmpty);
+      await expectLater(
+        jc.listFiles(42, throwOnError: true),
+        throwsA(
+          isA<JimakuRequestException>().having(
+              (JimakuRequestException e) => e.statusCode, 'status', 503),
+        ),
+      );
+    });
+
+    test('BUG-1235 malformed HTTP 200 严格模式报失败，合法 [] 仍是零字幕', () async {
+      final JimakuClient malformed = JimakuClient(
+        apiKey: 'k',
+        client: MockClient(
+          (http.Request request) async => http.Response('{not-json', 200),
+        ),
+      );
+      addTearDown(malformed.close);
+
+      // 历史调用保持 fail-open。
+      expect(await malformed.listFiles(42), isEmpty);
+      // 但库存预检查不能把 malformed 200 冒充成合法空数组。
+      await expectLater(
+        malformed.listFiles(42, throwOnError: true),
+        throwsA(
+          isA<JimakuRequestException>().having(
+            (JimakuRequestException e) => e.statusCode,
+            'status',
+            isNull,
+          ),
+        ),
+      );
+
+      final JimakuClient validEmpty = JimakuClient(
+        apiKey: 'k',
+        client: MockClient(
+          (http.Request request) async => http.Response('[]', 200),
+        ),
+      );
+      addTearDown(validEmpty.close);
+      expect(
+        await validEmpty.listFiles(42, throwOnError: true),
+        isEmpty,
+      );
+    });
+
+    test('strict 模式拒绝缺 name/url 的数组元素，默认模式仍跳过', () async {
+      final JimakuClient client = JimakuClient(
+        apiKey: 'k',
+        client: MockClient(
+          (http.Request request) async =>
+              http.Response('[{"name":"missing-url"}]', 200),
+        ),
+      );
+      addTearDown(client.close);
+
+      expect(await client.listFiles(42), isEmpty);
+      await expectLater(
+        client.listFiles(42, throwOnError: true),
+        throwsA(isA<JimakuRequestException>()),
+      );
     });
   });
 }

--- a/hibiki/test/media/video/scraper/cover_match_dialog_test.dart
+++ b/hibiki/test/media/video/scraper/cover_match_dialog_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -92,6 +93,21 @@ class _StubScraperService extends CoverScraperService {
   }
 }
 
+class _DelayedPreferencesRepository extends PreferencesRepository {
+  _DelayedPreferencesRepository(super.database);
+
+  Completer<void>? tmdbKeyWriteGate;
+
+  @override
+  Future<void> setPref(String key, dynamic value) async {
+    final Completer<void>? gate = tmdbKeyWriteGate;
+    if (key == kVideoScraperTmdbApiKeyPref && gate != null) {
+      await gate.future;
+    }
+    await super.setPref(key, value);
+  }
+}
+
 void main() {
   final TestWidgetsFlutterBinding binding =
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -119,6 +135,7 @@ void main() {
   late VideoBookRepository repo;
   late Directory tmp;
   late AppModel appModel;
+  late _DelayedPreferencesRepository prefs;
   late PlatformServices platformServices;
 
   setUp(() async {
@@ -127,7 +144,7 @@ void main() {
     db = HibikiDatabase.forTesting(NativeDatabase.memory());
     repo = VideoBookRepository(db);
     tmp = await Directory.systemTemp.createTemp('hibiki_poster_match_');
-    final PreferencesRepository prefs = PreferencesRepository(db);
+    prefs = _DelayedPreferencesRepository(db);
     await prefs.loadFromDb();
     platformServices = testPlatformServices();
     appModel = AppModel(platformServices)
@@ -243,6 +260,7 @@ void main() {
     expect(find.text('My Anime'), findsWidgets);
     // 置信度徽标（高匹配）。
     expect(find.text(t.video_scrape_confidence_high), findsOneWidget);
+    expect(find.textContaining('Bangumi #42'), findsOneWidget);
 
     // 点「使用」→ 回调应用（桩为纯内存记账，pumpAndSettle 即可驱动）。
     await tester.tap(find.text(t.video_scrape_use).first);
@@ -252,6 +270,110 @@ void main() {
     expect(service.appliedUids, <String>['video/my_anime']);
     // 弹窗应用后关闭。
     expect(find.text(t.video_scrape_use), findsNothing);
+  });
+
+  testWidgets('BUG-1234 切换来源清空旧结果且不自动搜索；TMDB 无 key 不显示 Bangumi 数据',
+      (WidgetTester tester) async {
+    final VideoBookRow book = await seed();
+    final _StubScraperService service = buildService();
+
+    await tester.pumpWidget(wrap(CoverMatchDialog(
+      service: service,
+      book: book,
+      collectionMemberUids: const <String>['video/my_anime'],
+      onApplied: () {},
+    )));
+    await tester.pumpAndSettle();
+
+    expect(service.searchCalls, 1);
+    expect(
+      find.byKey(
+        const ValueKey<String>('cover_match_candidate_bangumi_42'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text(t.video_scrape_manual_match_hint), findsOneWidget);
+
+    await tester.tap(find.text('TMDB'));
+    await tester.pump();
+
+    // 切换本身不发请求，旧 Bangumi 候选也不能冒充 TMDB 结果。
+    expect(service.searchCalls, 1);
+    expect(
+      find.byKey(
+        const ValueKey<String>('cover_match_candidate_bangumi_42'),
+      ),
+      findsNothing,
+    );
+    expect(find.text(t.video_scrape_tmdb_key_empty), findsOneWidget);
+    expect(
+      find.byWidgetPredicate(
+        (Widget widget) =>
+            widget is TextField &&
+            widget.decoration?.hintText == t.video_scrape_tmdb_key_hint,
+      ),
+      findsOneWidget,
+    );
+
+    // 切回 Bangumi 仍等用户明确点搜索，不暗中再次请求。
+    await tester.tap(find.text('Bangumi'));
+    await tester.pump();
+    expect(service.searchCalls, 1);
+    expect(find.text(t.video_scrape_tmdb_key_empty), findsNothing);
+    await tester.tap(find.text(t.video_scrape_search));
+    await tester.pumpAndSettle();
+    expect(service.searchCalls, 2);
+    expect(
+      find.byKey(
+        const ValueKey<String>('cover_match_candidate_bangumi_42'),
+      ),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('BUG-1234 保存 TMDB key 未完成时切来源，旧 continuation 不得搜索新来源',
+      (WidgetTester tester) async {
+    final VideoBookRow book = await seed();
+    final _StubScraperService service = buildService();
+
+    await tester.pumpWidget(wrap(CoverMatchDialog(
+      service: service,
+      book: book,
+      collectionMemberUids: const <String>['video/my_anime'],
+      onApplied: () {},
+    )));
+    await tester.pumpAndSettle();
+    expect(service.searchCalls, 1);
+
+    await tester.tap(find.text('TMDB'));
+    await tester.pump();
+    final Finder keyField = find.byWidgetPredicate(
+      (Widget widget) =>
+          widget is TextField &&
+          widget.decoration?.hintText == t.video_scrape_tmdb_key_hint,
+    );
+    await tester.enterText(keyField, 'delayed-tmdb-key');
+
+    final Completer<void> writeGate = Completer<void>();
+    prefs.tmdbKeyWriteGate = writeGate;
+    await tester.tap(find.text(t.video_scrape_tmdb_key_save));
+    await tester.pump();
+
+    // 持久化尚未完成时切回 Bangumi：来源切换必须立即生效且不自动搜索。
+    await tester.tap(find.text('Bangumi'));
+    await tester.pump();
+    expect(service.searchCalls, 1);
+
+    // 放行旧 Save continuation。旧实现会在这里对当前 Bangumi 再调一次 _search()。
+    writeGate.complete();
+    await tester.pumpAndSettle();
+    expect(service.searchCalls, 1);
+    expect(
+      find.byKey(
+        const ValueKey<String>('cover_match_candidate_bangumi_42'),
+      ),
+      findsNothing,
+    );
   });
 
   testWidgets('TODO-2284 应用失败直出完整脱敏详情，候选保留可重试', (WidgetTester tester) async {
@@ -570,6 +692,7 @@ void main() {
       find.byKey(const ValueKey<String>('cover_match_apply_collection')),
     );
     expect(toggle.value, isFalse, reason: '他点的就是这一集，别替他改整个合集');
+    expect(find.text(t.video_scrape_apply_to_collection_hint), findsOneWidget);
 
     await tester.tap(find.text(t.video_scrape_use).first);
     await tester.pumpAndSettle();

--- a/hibiki/test/pages/jimaku_batch_dialog_state_test.dart
+++ b/hibiki/test/pages/jimaku_batch_dialog_state_test.dart
@@ -1,0 +1,259 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/pages/implementations/jimaku_batch_dialog.dart';
+import 'package:hibiki/src/platform/platform_providers.dart';
+import 'package:hibiki/src/platform/platform_services.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import '../helpers/test_platform_services.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late HibikiDatabase db;
+  late VideoBookRepository repo;
+  late Directory tempDir;
+  late AppModel appModel;
+  late PlatformServices platformServices;
+
+  setUp(() async {
+    LocaleSettings.setLocale(AppLocale.zhCn);
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    repo = VideoBookRepository(db);
+    tempDir =
+        await Directory.systemTemp.createTemp('jimaku_batch_dialog_state_');
+    final PreferencesRepository prefs = PreferencesRepository(db);
+    await prefs.loadFromDb();
+    platformServices = testPlatformServices();
+    appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(
+        prefsRepo: prefs,
+        databaseDirectory: tempDir,
+      );
+    await appModel.setJimakuApiKey('test-key');
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await tempDir.exists()) await tempDir.delete(recursive: true);
+  });
+
+  Future<VideoBookRow> seedMember() async {
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value<String>('video/show-01'),
+      title: Value<String>('Show - 01'),
+      videoPath: Value<String>('C:/video/Show - 01.mkv'),
+    ));
+    return (await repo.getByBookUid('video/show-01'))!;
+  }
+
+  Future<MediaCollectionRow> seedCollection({int? anilistId}) async {
+    final int id = await db.createMediaCollection(
+      'Show',
+      collectionType: 'collection',
+    );
+    if (anilistId != null) {
+      await db.setMediaCollectionAnilistId(id, anilistId);
+    }
+    return (await db.getMediaCollectionById(id))!;
+  }
+
+  Widget wrap({
+    required MediaCollectionRow collection,
+    required VideoBookRow member,
+    required JimakuBatchHttpClientFactory factory,
+  }) {
+    return ProviderScope(
+      overrides: <Override>[
+        platformServicesProvider.overrideWithValue(platformServices),
+        appProvider.overrideWith((ref) => appModel),
+      ],
+      child: TranslationProvider(
+        child: MaterialApp(
+          home: Scaffold(
+            body: JimakuBatchDialog(
+              database: db,
+              collection: collection,
+              members: <VideoBookRow>[member],
+              httpClientFactory: factory,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Finder downloadButton() =>
+      find.widgetWithText(FilledButton, t.video_jimaku_batch_download);
+
+  testWidgets('inventory client 创建失败转 failed，下载保持禁用',
+      (WidgetTester tester) async {
+    final VideoBookRow member = await seedMember();
+    final MediaCollectionRow collection = await seedCollection(anilistId: 21);
+    int factoryCalls = 0;
+
+    Future<http.Client> factory() async {
+      factoryCalls++;
+      if (factoryCalls == 1) {
+        return MockClient(
+          (http.Request request) async =>
+              http.Response('[{"id":7,"name":"Source"}]', 200),
+        );
+      }
+      throw StateError('client factory unavailable');
+    }
+
+    await tester.pumpWidget(
+      wrap(collection: collection, member: member, factory: factory),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.video_jimaku_source_failed), findsWidgets);
+    expect(tester.widget<FilledButton>(downloadButton()).onPressed, isNull);
+  });
+
+  testWidgets('inventory loading 时禁用；成功且非空后才开放下载', (WidgetTester tester) async {
+    final VideoBookRow member = await seedMember();
+    final MediaCollectionRow collection = await seedCollection(anilistId: 21);
+    final Completer<http.Response> inventoryResponse =
+        Completer<http.Response>();
+
+    Future<http.Client> factory() async {
+      return MockClient((http.Request request) async {
+        if (request.url.path.endsWith('/entries/search')) {
+          return http.Response('[{"id":7,"name":"Source"}]', 200);
+        }
+        if (request.url.path.endsWith('/entries/7/files')) {
+          return inventoryResponse.future;
+        }
+        return http.Response('not found', 404);
+      });
+    }
+
+    await tester.pumpWidget(
+      wrap(collection: collection, member: member, factory: factory),
+    );
+    for (int i = 0;
+        i < 20 && find.text(t.video_jimaku_source_loading).evaluate().isEmpty;
+        i++) {
+      await tester.pump();
+    }
+
+    expect(find.text(t.video_jimaku_source_loading), findsWidgets);
+    expect(tester.widget<FilledButton>(downloadButton()).onPressed, isNull);
+
+    inventoryResponse.complete(http.Response(
+      jsonEncode(<Map<String, String>>[
+        <String, String>{
+          'name': 'Show - 01.ja.srt',
+          'url': 'https://x/show-01.ja.srt',
+        },
+      ]),
+      200,
+    ));
+    await tester.pumpAndSettle();
+
+    expect(tester.widget<FilledButton>(downloadButton()).onPressed, isNotNull);
+  });
+
+  testWidgets('快速切系列时迟到旧响应不覆盖新条目，DB 也保留最新系列', (WidgetTester tester) async {
+    final VideoBookRow member = await seedMember();
+    final MediaCollectionRow collection = await seedCollection();
+    final Completer<http.Response> staleBResponse = Completer<http.Response>();
+    final Completer<void> staleBStarted = Completer<void>();
+    int seriesACalls = 0;
+
+    Future<http.Client> factory() async {
+      return MockClient((http.Request request) async {
+        if (request.url.host == 'graphql.anilist.co') {
+          return http.Response(
+            jsonEncode(<String, Object?>{
+              'data': <String, Object?>{
+                'Page': <String, Object?>{
+                  'media': <Object?>[
+                    <String, Object?>{
+                      'id': 1,
+                      'title': <String, Object?>{'romaji': 'Series A'},
+                    },
+                    <String, Object?>{
+                      'id': 2,
+                      'title': <String, Object?>{'romaji': 'Series B'},
+                    },
+                  ],
+                },
+              },
+            }),
+            200,
+          );
+        }
+        if (request.url.path.endsWith('/entries/search')) {
+          final String? id = request.url.queryParameters['anilist_id'];
+          if (id == '2') {
+            if (!staleBStarted.isCompleted) staleBStarted.complete();
+            return staleBResponse.future;
+          }
+          if (id == '1') {
+            seriesACalls++;
+            return http.Response(
+              seriesACalls == 1
+                  ? '[{"id":101,"name":"A initial"}]'
+                  : '[{"id":111,"name":"A latest"}]',
+              200,
+            );
+          }
+        }
+        if (request.url.path.endsWith('/files')) {
+          return http.Response('[]', 200);
+        }
+        return http.Response('not found', 404);
+      });
+    }
+
+    await tester.pumpWidget(
+      wrap(collection: collection, member: member, factory: factory),
+    );
+    await tester.tap(find.text(t.video_jimaku_find_sources));
+    await tester.pumpAndSettle();
+    expect(find.text('A initial'), findsOneWidget);
+
+    final Finder seriesBChip = find.widgetWithText(ChoiceChip, 'Series B');
+    await tester.ensureVisible(seriesBChip);
+    await tester.tap(seriesBChip);
+    for (int i = 0; i < 20 && !staleBStarted.isCompleted; i++) {
+      await tester.pump();
+    }
+    expect(staleBStarted.isCompleted, isTrue);
+
+    final Finder seriesAChip = find.widgetWithText(ChoiceChip, 'Series A');
+    await tester.ensureVisible(seriesAChip);
+    await tester.tap(seriesAChip);
+    await tester.pumpAndSettle();
+    expect(find.text('A latest'), findsOneWidget);
+
+    staleBResponse.complete(
+      http.Response('[{"id":202,"name":"B stale"}]', 200),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('A latest'), findsOneWidget);
+    expect(find.text('B stale'), findsNothing);
+    expect(
+      (await db.getMediaCollectionById(collection.id))!.anilistId,
+      1,
+    );
+  });
+}

--- a/hibiki/test/pages/jimaku_entry_picker_test.dart
+++ b/hibiki/test/pages/jimaku_entry_picker_test.dart
@@ -12,6 +12,13 @@ void main() {
       (WidgetTester tester) async {
     int selectedEntry = 1;
     String? selectedLanguage;
+    final JimakuFileInventory inventory = JimakuFileInventory.fromFiles(
+      const <JimakuFile>[
+        JimakuFile(name: 'Show S01E01.ja.srt', url: 'https://x/1'),
+        JimakuFile(name: 'Show S01E02.zh-cn.ass', url: 'https://x/2'),
+        JimakuFile(name: 'Show.zip', url: 'https://x/archive'),
+      ],
+    );
     await tester.pumpWidget(
       TranslationProvider(
         child: MaterialApp(
@@ -27,6 +34,8 @@ void main() {
                           JimakuEntry(id: 2, name: 'Complete season pack'),
                         ],
                         selectedEntryId: selectedEntry,
+                        inventories: <int, JimakuFileInventory>{1: inventory},
+                        failedEntryIds: const <int>{2},
                         onSelected: (JimakuEntry entry) {
                           setState(() => selectedEntry = entry.id);
                         },
@@ -47,16 +56,33 @@ void main() {
       ),
     );
 
-    ChoiceChip entryChip = tester.widget<ChoiceChip>(
-      find.widgetWithText(ChoiceChip, 'Complete season pack'),
+    expect(find.text('Jimaku #1'), findsOneWidget);
+    expect(find.text('Jimaku #2'), findsOneWidget);
+    expect(
+      find.text(t.video_jimaku_source_summary(
+        files: 2,
+        episodes: 2,
+        languages: '日本語 / 中文',
+      )),
+      findsOneWidget,
     );
-    expect(entryChip.selected, isFalse);
+    expect(find.text(t.video_jimaku_source_failed), findsOneWidget);
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('jimaku_entry_2')),
+        matching: find.byIcon(Icons.radio_button_checked),
+      ),
+      findsNothing,
+    );
     await tester.tap(find.text('Complete season pack'));
     await tester.pump();
-    entryChip = tester.widget<ChoiceChip>(
-      find.widgetWithText(ChoiceChip, 'Complete season pack'),
+    expect(
+      find.descendant(
+        of: find.byKey(const ValueKey<String>('jimaku_entry_2')),
+        matching: find.byIcon(Icons.radio_button_checked),
+      ),
+      findsOneWidget,
     );
-    expect(entryChip.selected, isTrue);
 
     await tester.tap(find.text('日本語'));
     await tester.pump();


### PR DESCRIPTION
## 改动

- 合集 Jimaku 字幕来源改成可辨识卡片：空白 `name` 回退英文名，显示 Jimaku/AniList ID、可解析字幕文件数、覆盖集数和语言。
- 选择来源后直接预览每集是否有字幕；未标集号候选、零字幕和请求失败分别显示，不再全是空状态。
- 封面来源切换只切换目标并清空旧结果/作废在途请求，不再自动重搜；TMDB 无 key 时显示专属空态，不混入 Bangumi 数据。
- 候选显示来源与条目 ID；补充“在线匹配 / 后台刮削”语义，以及“同一封面应用到全部集”的风险说明。批量应用继续默认关闭。
- 新增 BUG-1234 / BUG-1235 回归记录，build number 升至 `1.3.1+998`。

## 验证

- `dart analyze`（4 个改动源文件 + 3 个定向测试文件）：No issues found
- `dart format --output=none --set-exit-if-changed`：通过
- 17 locale / 2767 key 一致性检查：通过
- `dart run tool/bug.dart check`：1188 条、号唯一、索引同步
- `git diff --cached --check`：通过
- `flutter test test/media/video/jimaku_client_test.dart test/pages/jimaku_entry_picker_test.dart test/media/video/scraper/cover_match_dialog_test.dart --no-pub`：未进入测试用例；`pdfium_dart` 下载 `pdfium-win-x64.tgz` 时 GitHub 连接超时。按本次要求未等待编译验收。