### PR TITLE
fix: 展示完整 Bangumi 看过记录与待手动关联条目

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1186 条。点号进各自文件。
+> 共 1187 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1236](bugs/BUG-1236-bangumi-dashboard-history.md) | ✅ | ✅ | Bangumi 首页卡把映射误当观看历史且不列待手动关联条目 |
 | [BUG-1225](bugs/BUG-1225-shm-reader-write-access-must-stay.md) | ✅ | ✅ | 读端共享内存写权限不可收紧：SelectTextThread 的原子写落在只读页上会崩 |
 | [BUG-1221](bugs/BUG-1221-manga-path-case-folded.md) | ✅ | ✅ | 漫画页图解析把路径折成小写，制卡封面名被小写化且大小写敏感平台缺页 |
 | [BUG-1220](bugs/BUG-1220-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |

--- a/docs/bugs/BUG-1236-bangumi-dashboard-history.md
+++ b/docs/bugs/BUG-1236-bangumi-dashboard-history.md
@@ -1,0 +1,6 @@
+## BUG-1236 · Bangumi 首页卡把映射误当观看历史且不列待手动关联条目
+- **报告**：2026-07-29（用户：右上角 Bangumi 点击应展示全部看过；删掉“还没有任何条目关联……”泛化说明；明确写出哪些需要手动关联；以前看过的内容没有显示。）
+- **真实性**：✅ 真 bug。首页卡的数据源只有 `MediaTrackingStatus.mappings`（`hibiki/lib/src/pages/implementations/home_dashboard_page.dart:2247`），而映射表只含 Hibiki 建立过的本地→Bangumi 关联，既不是账号收藏历史，也不会包含尚未关联的旧本地观看/阅读记录。因此“以前看过”必然缺失；零映射文案只能给出泛化说明，无法回答“哪些需要手动关联”。Bangumi 官方收藏列表接口与本地历史表两套真相源都没有接进卡片。
+- **[x] ① 已修复** — 本提交。账号行改为可点击入口，直接分页读取当前 Bangumi 账号所有 `subject_type=2&type=2` 的“看过”动画（`media_tracking_service.dart:433`），不再从映射反推。仓储新增本地旧历史反查（`media_tracking_repository.dart:232`）：已完成视频/有阅读位置的书/已设置游玩状态的游戏减去现有映射，视频 playlist 折叠成合集后输出“需要手动关联”清单；首页显示前 5 项，设置页显示全量并可直接带目标进入添加映射。用户指定的旧泛化文案及 17 语言 key 已移除。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/tracking/bangumi_api_client_test.dart`（官方收藏分页与筛选参数）、`media_tracking_repository_test.dart`（旧完成视频进入待关联、映射后消失）、`media_tracking_service_test.dart`（远端历史不依赖本地映射）、`home_dashboard_page_test.dart`（旧历史条目与明确手动关联提示）。
+- **备注**：`flutter analyze --no-pub` 通过。定向 Flutter 测试在执行 0 个用例前被 `pdfium_dart` 原生资产从 GitHub 下载超时阻断，按用户要求不等待完整编译验收；不是断言失败。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46852 (2756 per locale)
+/// Strings: 47005 (2765 per locale)
 ///
-/// Built on 2026-07-29 at 06:45 UTC
+/// Built on 2026-07-29 at 08:00 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3664,8 +3664,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get media_tracking_all_synced => 'Everything sent';
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
   String get media_tracking_open_subject => 'Open on Bangumi';
   String get media_tracking_manage_links => 'Manage links';
   String get media_tracking_last_error => 'Last error';
@@ -3706,6 +3704,23 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Skipped ${m} of ${n} selected items that no longer exist';
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  String get media_tracking_watched_show => 'View all watched anime';
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  String get media_tracking_manual_required => 'Needs manual link';
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -9947,9 +9962,6 @@ class _StringsAr extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -10016,6 +10028,33 @@ class _StringsAr extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -16325,9 +16364,6 @@ class _StringsDe extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -16394,6 +16430,33 @@ class _StringsDe extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -22719,9 +22782,6 @@ class _StringsEs extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -22788,6 +22848,33 @@ class _StringsEs extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -29124,9 +29211,6 @@ class _StringsFr extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -29193,6 +29277,33 @@ class _StringsFr extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -35458,9 +35569,6 @@ class _StringsId extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -35527,6 +35635,33 @@ class _StringsId extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -41838,9 +41973,6 @@ class _StringsIt extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -41907,6 +42039,33 @@ class _StringsIt extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -48035,9 +48194,6 @@ class _StringsJa extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -48104,6 +48260,33 @@ class _StringsJa extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -54234,9 +54417,6 @@ class _StringsKo extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -54303,6 +54483,33 @@ class _StringsKo extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -60594,9 +60801,6 @@ class _StringsNl extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -60663,6 +60867,33 @@ class _StringsNl extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -66967,9 +67198,6 @@ class _StringsPtBr extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -67036,6 +67264,33 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -73324,9 +73579,6 @@ class _StringsRu extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -73393,6 +73645,33 @@ class _StringsRu extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -79629,9 +79908,6 @@ class _StringsTh extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -79698,6 +79974,33 @@ class _StringsTh extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -85966,9 +86269,6 @@ class _StringsTr extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -86035,6 +86335,33 @@ class _StringsTr extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -92288,9 +92615,6 @@ class _StringsVi extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -92357,6 +92681,33 @@ class _StringsVi extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 // Path: <root>
@@ -98167,9 +98518,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get media_tracking_unauthorized => 'Bangumi 拒绝了访问令牌，请在设置里重新连接。';
   @override
-  String get media_tracking_unlinked_hint =>
-      '还没有任何条目关联到 Bangumi 条目，所以看完/读完在那边不会有任何变化。自动匹配只在标题唯一命中时才建立关联，其余需要手动关联。';
-  @override
   String get media_tracking_open_subject => '在 Bangumi 打开';
   @override
   String get media_tracking_manage_links => '管理关联';
@@ -98231,6 +98579,30 @@ class _StringsZhCn extends _StringsEn {
       '选中的 ${n} 项中有 ${m} 项已不存在，已跳过';
   @override
   String get game_text_thread_unset => '尚未选择线程 · 选一条后开始捕获';
+  @override
+  String get media_tracking_watched_show => '查看全部看过';
+  @override
+  String get media_tracking_watched_title => 'Bangumi 看过';
+  @override
+  String get media_tracking_watched_empty => '这个 Bangumi 账号还没有标记为“看过”的番剧。';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      '读取看过记录失败：${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) => '已看 ${n} 集';
+  @override
+  String get media_tracking_manual_required => '需要手动关联';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} 项需要手动关联';
+  @override
+  String get media_tracking_manual_required_hint =>
+      '这些本地条目已有观看、阅读或游玩记录，但还没有关联到 Bangumi。';
+  @override
+  String get media_tracking_no_local_history => '暂无需要关联的本地观看、阅读或游玩记录。';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '另有 ${n} 项需要手动关联';
 }
 
 // Path: <root>
@@ -104280,9 +104652,6 @@ class _StringsZhHk extends _StringsEn {
   String get media_tracking_unauthorized =>
       'Bangumi rejected the access token. Reconnect it in settings.';
   @override
-  String get media_tracking_unlinked_hint =>
-      'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
-  @override
   String get media_tracking_open_subject => 'Open on Bangumi';
   @override
   String get media_tracking_manage_links => 'Manage links';
@@ -104349,6 +104718,33 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get game_text_thread_unset =>
       'No thread selected — pick one to start capturing';
+  @override
+  String get media_tracking_watched_show => 'View all watched anime';
+  @override
+  String get media_tracking_watched_title => 'Watched on Bangumi';
+  @override
+  String get media_tracking_watched_empty =>
+      'No anime is marked as watched on this Bangumi account.';
+  @override
+  String media_tracking_watched_load_failed({required Object error}) =>
+      'Could not load watched anime: ${error}';
+  @override
+  String media_tracking_watched_progress({required Object n}) =>
+      'Watched ${n} episodes';
+  @override
+  String get media_tracking_manual_required => 'Needs manual link';
+  @override
+  String media_tracking_manual_required_count({required Object n}) =>
+      '${n} items need manual links';
+  @override
+  String get media_tracking_manual_required_hint =>
+      'These local items already have progress but are not linked to Bangumi.';
+  @override
+  String get media_tracking_no_local_history =>
+      'No local watch, reading, or game progress needs linking.';
+  @override
+  String media_tracking_more_manual_required({required Object n}) =>
+      '${n} more items need manual links';
 }
 
 /// Flat map(s) containing all translations.
@@ -109938,8 +110334,6 @@ extension on _StringsEn {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -109995,6 +110389,27 @@ extension on _StringsEn {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -115582,8 +115997,6 @@ extension on _StringsAr {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -115639,6 +116052,27 @@ extension on _StringsAr {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -121247,8 +121681,6 @@ extension on _StringsDe {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -121304,6 +121736,27 @@ extension on _StringsDe {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -126911,8 +127364,6 @@ extension on _StringsEs {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -126968,6 +127419,27 @@ extension on _StringsEs {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -132581,8 +133053,6 @@ extension on _StringsFr {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -132638,6 +133108,27 @@ extension on _StringsFr {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -138233,8 +138724,6 @@ extension on _StringsId {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -138290,6 +138779,27 @@ extension on _StringsId {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -143900,8 +144410,6 @@ extension on _StringsIt {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -143957,6 +144465,27 @@ extension on _StringsIt {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -149529,8 +150058,6 @@ extension on _StringsJa {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -149586,6 +150113,27 @@ extension on _StringsJa {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -155162,8 +155710,6 @@ extension on _StringsKo {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -155219,6 +155765,27 @@ extension on _StringsKo {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -160822,8 +161389,6 @@ extension on _StringsNl {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -160879,6 +161444,27 @@ extension on _StringsNl {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -166479,8 +167065,6 @@ extension on _StringsPtBr {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -166536,6 +167120,27 @@ extension on _StringsPtBr {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -172141,8 +172746,6 @@ extension on _StringsRu {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -172198,6 +172801,27 @@ extension on _StringsRu {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -177787,8 +178411,6 @@ extension on _StringsTh {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -177844,6 +178466,27 @@ extension on _StringsTh {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -183442,8 +184085,6 @@ extension on _StringsTr {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -183499,6 +184140,27 @@ extension on _StringsTr {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -189092,8 +189754,6 @@ extension on _StringsVi {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -189149,6 +189809,27 @@ extension on _StringsVi {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }
@@ -194696,8 +195377,6 @@ extension on _StringsZhCn {
         return '全部已发送';
       case 'media_tracking_unauthorized':
         return 'Bangumi 拒绝了访问令牌，请在设置里重新连接。';
-      case 'media_tracking_unlinked_hint':
-        return '还没有任何条目关联到 Bangumi 条目，所以看完/读完在那边不会有任何变化。自动匹配只在标题唯一命中时才建立关联，其余需要手动关联。';
       case 'media_tracking_open_subject':
         return '在 Bangumi 打开';
       case 'media_tracking_manage_links':
@@ -194753,6 +195432,26 @@ extension on _StringsZhCn {
             '选中的 ${n} 项中有 ${m} 项已不存在，已跳过';
       case 'game_text_thread_unset':
         return '尚未选择线程 · 选一条后开始捕获';
+      case 'media_tracking_watched_show':
+        return '查看全部看过';
+      case 'media_tracking_watched_title':
+        return 'Bangumi 看过';
+      case 'media_tracking_watched_empty':
+        return '这个 Bangumi 账号还没有标记为“看过”的番剧。';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) => '读取看过记录失败：${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => '已看 ${n} 集';
+      case 'media_tracking_manual_required':
+        return '需要手动关联';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} 项需要手动关联';
+      case 'media_tracking_manual_required_hint':
+        return '这些本地条目已有观看、阅读或游玩记录，但还没有关联到 Bangumi。';
+      case 'media_tracking_no_local_history':
+        return '暂无需要关联的本地观看、阅读或游玩记录。';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '另有 ${n} 项需要手动关联';
       default:
         return null;
     }
@@ -200320,8 +201019,6 @@ extension on _StringsZhHk {
         return 'Everything sent';
       case 'media_tracking_unauthorized':
         return 'Bangumi rejected the access token. Reconnect it in settings.';
-      case 'media_tracking_unlinked_hint':
-        return 'No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.';
       case 'media_tracking_open_subject':
         return 'Open on Bangumi';
       case 'media_tracking_manage_links':
@@ -200377,6 +201074,27 @@ extension on _StringsZhHk {
             'Skipped ${m} of ${n} selected items that no longer exist';
       case 'game_text_thread_unset':
         return 'No thread selected — pick one to start capturing';
+      case 'media_tracking_watched_show':
+        return 'View all watched anime';
+      case 'media_tracking_watched_title':
+        return 'Watched on Bangumi';
+      case 'media_tracking_watched_empty':
+        return 'No anime is marked as watched on this Bangumi account.';
+      case 'media_tracking_watched_load_failed':
+        return ({required Object error}) =>
+            'Could not load watched anime: ${error}';
+      case 'media_tracking_watched_progress':
+        return ({required Object n}) => 'Watched ${n} episodes';
+      case 'media_tracking_manual_required':
+        return 'Needs manual link';
+      case 'media_tracking_manual_required_count':
+        return ({required Object n}) => '${n} items need manual links';
+      case 'media_tracking_manual_required_hint':
+        return 'These local items already have progress but are not linked to Bangumi.';
+      case 'media_tracking_no_local_history':
+        return 'No local watch, reading, or game progress needs linking.';
+      case 'media_tracking_more_manual_required':
+        return ({required Object n}) => '${n} more items need manual links';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n 项待发送",
   "media_tracking_all_synced": "全部已发送",
   "media_tracking_unauthorized": "Bangumi 拒绝了访问令牌，请在设置里重新连接。",
-  "media_tracking_unlinked_hint": "还没有任何条目关联到 Bangumi 条目，所以看完/读完在那边不会有任何变化。自动匹配只在标题唯一命中时才建立关联，其余需要手动关联。",
   "media_tracking_open_subject": "在 Bangumi 打开",
   "media_tracking_manage_links": "管理关联",
   "media_tracking_last_error": "上次错误",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "按游戏",
   "stat_clear_all_game_message": "确定清空全部游戏统计吗？将删除所有游戏时长和游玩次数。你的游戏库与首页活动流不受影响。此操作不可撤销。",
   "batch_selection_stale_skipped": "选中的 $n 项中有 $m 项已不存在，已跳过",
-  "game_text_thread_unset": "尚未选择线程 · 选一条后开始捕获"
+  "game_text_thread_unset": "尚未选择线程 · 选一条后开始捕获",
+  "media_tracking_watched_show": "查看全部看过",
+  "media_tracking_watched_title": "Bangumi 看过",
+  "media_tracking_watched_empty": "这个 Bangumi 账号还没有标记为“看过”的番剧。",
+  "media_tracking_watched_load_failed": "读取看过记录失败：$error",
+  "media_tracking_watched_progress": "已看 $n 集",
+  "media_tracking_manual_required": "需要手动关联",
+  "media_tracking_manual_required_count": "$n 项需要手动关联",
+  "media_tracking_manual_required_hint": "这些本地条目已有观看、阅读或游玩记录，但还没有关联到 Bangumi。",
+  "media_tracking_no_local_history": "暂无需要关联的本地观看、阅读或游玩记录。",
+  "media_tracking_more_manual_required": "另有 $n 项需要手动关联"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2727,7 +2727,6 @@
   "media_tracking_pending_count": "$n waiting to send",
   "media_tracking_all_synced": "Everything sent",
   "media_tracking_unauthorized": "Bangumi rejected the access token. Reconnect it in settings.",
-  "media_tracking_unlinked_hint": "No item is linked to a Bangumi subject yet, so finishing something changes nothing there. Automatic matching only links a subject when the title matches unambiguously; link the rest by hand.",
   "media_tracking_open_subject": "Open on Bangumi",
   "media_tracking_manage_links": "Manage links",
   "media_tracking_last_error": "Last error",
@@ -2754,5 +2753,15 @@
   "game_stat_by_game": "By game",
   "stat_clear_all_game_message": "Clear all game play time and session counts? Your game library and activity timeline are kept. This cannot be undone.",
   "batch_selection_stale_skipped": "Skipped $m of $n selected items that no longer exist",
-  "game_text_thread_unset": "No thread selected — pick one to start capturing"
+  "game_text_thread_unset": "No thread selected — pick one to start capturing",
+  "media_tracking_watched_show": "View all watched anime",
+  "media_tracking_watched_title": "Watched on Bangumi",
+  "media_tracking_watched_empty": "No anime is marked as watched on this Bangumi account.",
+  "media_tracking_watched_load_failed": "Could not load watched anime: $error",
+  "media_tracking_watched_progress": "Watched $n episodes",
+  "media_tracking_manual_required": "Needs manual link",
+  "media_tracking_manual_required_count": "$n items need manual links",
+  "media_tracking_manual_required_hint": "These local items already have progress but are not linked to Bangumi.",
+  "media_tracking_no_local_history": "No local watch, reading, or game progress needs linking.",
+  "media_tracking_more_manual_required": "$n more items need manual links"
 }

--- a/hibiki/lib/src/media/tracking/bangumi_api_client.dart
+++ b/hibiki/lib/src/media/tracking/bangumi_api_client.dart
@@ -74,6 +74,29 @@ class BangumiUserCollection {
   final int volumeProgress;
 }
 
+/// Bangumi 账号收藏列表中的一条「看过」动画。
+///
+/// 这不是本地映射：用户在接入 Hibiki 之前已经在 Bangumi 标记过的条目也会出现，
+/// 正是首页账号入口需要展示的完整远端历史。
+class BangumiWatchedItem {
+  const BangumiWatchedItem({
+    required this.subject,
+    required this.episodeProgress,
+    required this.updatedAt,
+  });
+
+  final BangumiSubject subject;
+  final int episodeProgress;
+  final DateTime? updatedAt;
+}
+
+typedef BangumiWatchedPage = ({
+  List<BangumiWatchedItem> items,
+  int total,
+  int limit,
+  int offset,
+});
+
 Map<String, dynamic>? _map(dynamic value) {
   if (value is! Map) return null;
   return value.map(
@@ -159,6 +182,38 @@ BangumiUserCollection parseBangumiCollection(String body) {
   );
 }
 
+BangumiWatchedPage parseBangumiWatchedPage(String body) {
+  final Map<String, dynamic>? root = _map(jsonDecode(body));
+  if (root == null) {
+    throw const FormatException('Invalid Bangumi collection page');
+  }
+  final List<BangumiWatchedItem> items = <BangumiWatchedItem>[];
+  final dynamic data = root['data'];
+  if (data is List) {
+    for (final dynamic item in data) {
+      final Map<String, dynamic>? collection = _map(item);
+      if (collection == null || _int(collection['type']) != 2) continue;
+      final Map<String, dynamic>? subjectValue = _map(collection['subject']);
+      if (subjectValue == null) continue;
+      final BangumiSubject? subject = _parseBangumiSubjectValue(subjectValue);
+      if (subject == null || subject.type != 2) continue;
+      items.add(
+        BangumiWatchedItem(
+          subject: subject,
+          episodeProgress: _int(collection['ep_status']),
+          updatedAt: DateTime.tryParse(_string(collection['updated_at'])),
+        ),
+      );
+    }
+  }
+  return (
+    items: items,
+    total: _int(root['total'], items.length),
+    limit: _int(root['limit'], items.length),
+    offset: _int(root['offset']),
+  );
+}
+
 ({List<BangumiEpisode> episodes, int total}) parseBangumiEpisodes(String body) {
   final Map<String, dynamic>? root = _map(jsonDecode(body));
   if (root == null) throw const FormatException('Invalid Bangumi episodes');
@@ -185,6 +240,8 @@ BangumiUserCollection parseBangumiCollection(String body) {
 
 abstract interface class BangumiTrackingApi {
   Future<BangumiUser> getMe();
+
+  Future<List<BangumiWatchedItem>> getWatchedAnime(String username);
 
   Future<List<BangumiSubject>> searchSubjects({
     required String keyword,
@@ -256,6 +313,35 @@ class BangumiApiClient implements BangumiTrackingApi {
     );
     _require(response, const <int>{200});
     return parseBangumiUser(_body(response));
+  }
+
+  @override
+  Future<List<BangumiWatchedItem>> getWatchedAnime(String username) async {
+    const int pageSize = 50;
+    int offset = 0;
+    int total = pageSize;
+    final List<BangumiWatchedItem> all = <BangumiWatchedItem>[];
+    final String encodedUsername = Uri.encodeComponent(username);
+    while (offset < total) {
+      final Uri uri = Uri.parse(
+        '$apiBase/v0/users/$encodedUsername/collections',
+      ).replace(
+        queryParameters: <String, String>{
+          'subject_type': '2',
+          'type': '2',
+          'limit': '$pageSize',
+          'offset': '$offset',
+        },
+      );
+      final http.Response response = await _client.get(uri, headers: _headers);
+      _require(response, const <int>{200});
+      final BangumiWatchedPage page = parseBangumiWatchedPage(_body(response));
+      all.addAll(page.items);
+      total = page.total;
+      if (page.items.isEmpty) break;
+      offset += page.limit > 0 ? page.limit : page.items.length;
+    }
+    return all;
   }
 
   @override

--- a/hibiki/lib/src/media/tracking/media_tracking_repository.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_repository.dart
@@ -87,6 +87,26 @@ typedef PersistedBookTrackingProgress = ({
   int evidenceAt,
 });
 
+/// 本地已经产生过可同步进度、但尚未建立 Bangumi 映射的条目。
+///
+/// 这份列表专供 UI 明确指出「哪些需要手动关联」。它与映射表是互补关系，不把
+/// “没有映射”误写成“没有看过/读过”。
+class MediaTrackingUnlinkedItem {
+  const MediaTrackingUnlinkedItem({
+    required this.mediaType,
+    required this.mediaKey,
+    required this.mediaTitle,
+    required this.kind,
+    required this.lastActivityAt,
+  });
+
+  final TrackingMediaType mediaType;
+  final String mediaKey;
+  final String mediaTitle;
+  final TrackingKind kind;
+  final int lastActivityAt;
+}
+
 final RegExp _ignoredBookTocLabel = RegExp(
   r'^(?:目次|目录|目錄|contents?|table\s+of\s+contents|扉|title\s+page|表紙|cover|奥付|版权|版權|colophon|口絵|イラスト|插图|插圖|あとがき|后记|後記|著者紹介)$',
   caseSensitive: false,
@@ -204,6 +224,155 @@ class MediaTrackingRepository {
               (t) => OrderingTerm(expression: t.mediaTitle),
             ]))
           .get();
+
+  /// 列出全部「已有本地观看/阅读/游玩事实，但没有 Bangumi 映射」的条目。
+  ///
+  /// 视频合集优先于成员：同一季已经放进 playlist 时只提示一次合集，避免把十二集
+  /// 全部写成十二条“需手动关联”。未归合集的已完成视频仍按单条列出。
+  Future<List<MediaTrackingUnlinkedItem>> listUnlinkedHistory() async {
+    final Set<String> mapped = <String>{
+      for (final MediaTrackingMappingRow row in await listMappings())
+        '${row.mediaType}|${row.mediaKey}',
+    };
+    bool isMapped(TrackingMediaType type, String key) =>
+        mapped.contains('${type.value}|$key');
+
+    final List<VideoBookRow> videos = await _db.allVideoBooks();
+    final Map<String, VideoBookRow> videosByUid = <String, VideoBookRow>{
+      for (final VideoBookRow video in videos) video.bookUid: video,
+    };
+    final List<MediaCollectionRow> collections =
+        await _db.getAllMediaCollections();
+    final List<MediaCollectionItemRow> members =
+        await _db.getAllCollectionItems();
+    final Map<int, List<MediaCollectionItemRow>> videoMembersByCollection =
+        <int, List<MediaCollectionItemRow>>{};
+    for (final MediaCollectionItemRow member in members) {
+      if (member.mediaType != MediaKind.video.dbValue) continue;
+      videoMembersByCollection
+          .putIfAbsent(member.collectionId, () => <MediaCollectionItemRow>[])
+          .add(member);
+    }
+
+    final List<MediaTrackingUnlinkedItem> result =
+        <MediaTrackingUnlinkedItem>[];
+    final Set<String> videosCoveredByPlaylist = <String>{};
+    for (final MediaCollectionRow collection in collections) {
+      final String key = collection.id.toString();
+      if (collection.collectionType != 'playlist' ||
+          !isMapped(TrackingMediaType.videoCollection, key)) {
+        continue;
+      }
+      for (final MediaCollectionItemRow member
+          in videoMembersByCollection[collection.id] ??
+              const <MediaCollectionItemRow>[]) {
+        if (videosByUid[member.entryKey]?.completedAt != null) {
+          videosCoveredByPlaylist.add(member.entryKey);
+        }
+      }
+    }
+    for (final MediaCollectionRow collection in collections) {
+      if (collection.collectionType != 'playlist') continue;
+      final String key = collection.id.toString();
+      if (isMapped(TrackingMediaType.videoCollection, key)) continue;
+      final List<MediaCollectionItemRow> collectionMembers =
+          videoMembersByCollection[collection.id] ??
+              const <MediaCollectionItemRow>[];
+      int lastCompletedAt = 0;
+      final Set<String> completedMembers = <String>{};
+      for (final MediaCollectionItemRow member in collectionMembers) {
+        final VideoBookRow? video = videosByUid[member.entryKey];
+        final DateTime? completedAt = video?.completedAt;
+        if (completedAt == null ||
+            videosCoveredByPlaylist.contains(member.entryKey) ||
+            isMapped(TrackingMediaType.video, member.entryKey)) {
+          continue;
+        }
+        completedMembers.add(member.entryKey);
+        lastCompletedAt =
+            math.max(lastCompletedAt, completedAt.millisecondsSinceEpoch);
+      }
+      if (completedMembers.isEmpty) continue;
+      videosCoveredByPlaylist.addAll(completedMembers);
+      result.add(
+        MediaTrackingUnlinkedItem(
+          mediaType: TrackingMediaType.videoCollection,
+          mediaKey: key,
+          mediaTitle: collection.name,
+          kind: TrackingKind.anime,
+          lastActivityAt: lastCompletedAt,
+        ),
+      );
+    }
+
+    for (final VideoBookRow video in videos) {
+      final DateTime? completedAt = video.completedAt;
+      if (completedAt == null ||
+          videosCoveredByPlaylist.contains(video.bookUid) ||
+          isMapped(TrackingMediaType.video, video.bookUid)) {
+        continue;
+      }
+      result.add(
+        MediaTrackingUnlinkedItem(
+          mediaType: TrackingMediaType.video,
+          mediaKey: video.bookUid,
+          mediaTitle: video.title,
+          kind: TrackingKind.anime,
+          lastActivityAt: completedAt.millisecondsSinceEpoch,
+        ),
+      );
+    }
+
+    final Map<String, ReaderPositionRow> positions =
+        <String, ReaderPositionRow>{
+      for (final ReaderPositionRow position
+          in await _db.getAllReaderPositions())
+        position.bookKey: position,
+    };
+    for (final EpubBookRow book in await _db.getAllEpubBooks()) {
+      final ReaderPositionRow? position = positions[book.bookKey];
+      final DateTime? completedAt = book.completedAt;
+      if ((position == null && completedAt == null) ||
+          isMapped(TrackingMediaType.book, book.bookKey)) {
+        continue;
+      }
+      result.add(
+        MediaTrackingUnlinkedItem(
+          mediaType: TrackingMediaType.book,
+          mediaKey: book.bookKey,
+          mediaTitle: book.title,
+          kind: BookFormat.parseOrEpub(book.format) == BookFormat.manga
+              ? TrackingKind.manga
+              : TrackingKind.novel,
+          lastActivityAt: math.max(
+            position?.updatedAt ?? 0,
+            completedAt?.millisecondsSinceEpoch ?? 0,
+          ),
+        ),
+      );
+    }
+
+    for (final GalgameRow game in await _db.getAllGalgames()) {
+      if (game.playStatus <= 0 || isMapped(TrackingMediaType.game, game.id)) {
+        continue;
+      }
+      result.add(
+        MediaTrackingUnlinkedItem(
+          mediaType: TrackingMediaType.game,
+          mediaKey: game.id,
+          mediaTitle: game.name,
+          kind: TrackingKind.game,
+          lastActivityAt: game.addedAt,
+        ),
+      );
+    }
+
+    result.sort((MediaTrackingUnlinkedItem a, MediaTrackingUnlinkedItem b) {
+      final int byTime = b.lastActivityAt.compareTo(a.lastActivityAt);
+      return byTime != 0 ? byTime : a.mediaTitle.compareTo(b.mediaTitle);
+    });
+    return result;
+  }
 
   Future<MediaTrackingMappingRow?> findMapping({
     required TrackingMediaType mediaType,

--- a/hibiki/lib/src/media/tracking/media_tracking_service.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_service.dart
@@ -106,6 +106,7 @@ class MediaTrackingStatus {
     required this.unauthorized,
     required this.pending,
     required this.mappings,
+    required this.unlinked,
     required this.failures,
     required this.automaticMappingMissCount,
     required this.automaticMappingErrors,
@@ -121,6 +122,7 @@ class MediaTrackingStatus {
     unauthorized: false,
     pending: 0,
     mappings: <MediaTrackingMappingRow>[],
+    unlinked: <MediaTrackingUnlinkedItem>[],
     failures: <MediaTrackingFailure>[],
     automaticMappingMissCount: 0,
     automaticMappingErrors: <String>[],
@@ -142,6 +144,9 @@ class MediaTrackingStatus {
 
   /// 用户可见的映射（已滤掉 bookChapter 伴随映射，它不是独立条目）。
   final List<MediaTrackingMappingRow> mappings;
+
+  /// 本地已经看过/读过/设置过游玩状态，但仍没有映射的条目。
+  final List<MediaTrackingUnlinkedItem> unlinked;
   final List<MediaTrackingFailure> failures;
 
   /// 本会话内仍处于 10 分钟自动匹配退避的本地条目数。
@@ -382,6 +387,7 @@ class MediaTrackingService {
           .where((MediaTrackingMappingRow row) =>
               row.mediaType != TrackingMediaType.bookChapter.value)
           .toList(growable: false),
+      unlinked: await _repository.listUnlinkedHistory(),
       failures: <MediaTrackingFailure>[
         for (final PendingTrackingUpdate update in pending)
           if ((update.outbox.lastError ?? '').trim().isNotEmpty)
@@ -415,6 +421,21 @@ class MediaTrackingService {
         keyword: keyword,
         subjectType: bangumiSubjectTypeOf(kind),
       );
+    } finally {
+      api.close();
+    }
+  }
+
+  /// 拉取当前账号在 Bangumi 标记为「看过」的全部动画收藏。
+  ///
+  /// 不从本地映射反推：映射只记录 Hibiki 建过的关联，会永久漏掉用户接入 Hibiki
+  /// 之前的历史。账号入口必须直接以 Bangumi 收藏列表为真相源。
+  Future<List<BangumiWatchedItem>> loadWatchedAnime() async {
+    if (!isConfigured) return const <BangumiWatchedItem>[];
+    final BangumiTrackingApi api = _apiFactory(accessToken);
+    try {
+      final BangumiUser user = await api.getMe();
+      return api.getWatchedAnime(user.username);
     } finally {
       api.close();
     }

--- a/hibiki/lib/src/media/tracking/media_tracking_settings_body.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_settings_body.dart
@@ -106,7 +106,7 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
     if (mounted) setState(() => _busy = false);
   }
 
-  Future<void> _addMapping() async {
+  Future<void> _addMapping({MediaTrackingUnlinkedItem? initial}) async {
     if (!widget.appModel.mediaTrackingService.isConfigured) {
       _message(t.media_tracking_token_required);
       return;
@@ -116,6 +116,8 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
       builder: (BuildContext context) => _AddMappingDialog(
         database: widget.appModel.database,
         service: widget.appModel.mediaTrackingService,
+        initialMediaType: initial?.mediaType,
+        initialMediaKey: initial?.mediaKey,
       ),
     );
     if (saved != null) {
@@ -230,11 +232,36 @@ class _MediaTrackingSettingsBodyState extends State<MediaTrackingSettingsBody> {
             AdaptiveSettingsRow(
               title: t.media_tracking_add_mapping,
               trailing: FilledButton.icon(
-                onPressed: _busy ? null : _addMapping,
+                onPressed: _busy ? null : () => _addMapping(),
                 icon: const Icon(Icons.add_link),
                 label: Text(t.media_tracking_add_mapping),
               ),
             ),
+            if (status != null && status.unlinked.isNotEmpty) ...<Widget>[
+              AdaptiveSettingsRow(
+                title: t.media_tracking_manual_required_count(
+                  n: status.unlinked.length,
+                ),
+                subtitle: t.media_tracking_manual_required_hint,
+                titleMaxLines: 3,
+                subtitleMaxLines: 4,
+                icon: Icons.link_off,
+                showIcon: true,
+              ),
+              for (final MediaTrackingUnlinkedItem item in status.unlinked)
+                AdaptiveSettingsRow(
+                  title: item.mediaTitle,
+                  subtitle: '${trackingKindLabel(item.kind.value)} · '
+                      '${t.media_tracking_manual_required}',
+                  titleMaxLines: 3,
+                  subtitleMaxLines: 2,
+                  trailing: TextButton.icon(
+                    onPressed: _busy ? null : () => _addMapping(initial: item),
+                    icon: const Icon(Icons.add_link),
+                    label: Text(t.media_tracking_add_mapping),
+                  ),
+                ),
+            ],
             if (_mappings.isEmpty)
               AdaptiveSettingsRow(
                 title: t.media_tracking_no_mappings,
@@ -292,10 +319,14 @@ class _AddMappingDialog extends StatefulWidget {
   const _AddMappingDialog({
     required this.database,
     required this.service,
+    this.initialMediaType,
+    this.initialMediaKey,
   });
 
   final HibikiDatabase database;
   final MediaTrackingService service;
+  final TrackingMediaType? initialMediaType;
+  final String? initialMediaKey;
 
   @override
   State<_AddMappingDialog> createState() => _AddMappingDialogState();
@@ -372,7 +403,15 @@ class _AddMappingDialogState extends State<_AddMappingDialog> {
       _targets = targets;
       _busy = false;
     });
-    if (targets.isNotEmpty) _selectTarget(targets.first);
+    if (targets.isNotEmpty) {
+      final _LocalTrackingTarget initial = targets.firstWhere(
+        (_LocalTrackingTarget target) =>
+            target.type == widget.initialMediaType &&
+            target.key == widget.initialMediaKey,
+        orElse: () => targets.first,
+      );
+      _selectTarget(initial);
+    }
   }
 
   void _selectTarget(_LocalTrackingTarget target) {

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/display_title.dart';
 import 'package:hibiki/src/media/tracking/bangumi_api_client.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_labels.dart';
+import 'package:hibiki/src/media/tracking/media_tracking_repository.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_service.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
@@ -249,6 +250,114 @@ class _DailyGoalDialogState extends State<_DailyGoalDialog> {
   }
 }
 
+class _BangumiWatchedDialog extends StatefulWidget {
+  const _BangumiWatchedDialog({
+    required this.service,
+    required this.onOpenSubject,
+  });
+
+  final MediaTrackingService service;
+  final Future<void> Function(int subjectId) onOpenSubject;
+
+  @override
+  State<_BangumiWatchedDialog> createState() => _BangumiWatchedDialogState();
+}
+
+class _BangumiWatchedDialogState extends State<_BangumiWatchedDialog> {
+  late final Future<List<BangumiWatchedItem>> _watched =
+      widget.service.loadWatchedAnime();
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Row(
+        children: <Widget>[
+          const Icon(Icons.visibility_outlined),
+          const SizedBox(width: 12),
+          Expanded(child: Text(t.media_tracking_watched_title)),
+        ],
+      ),
+      content: SizedBox(
+        width: 640,
+        height: MediaQuery.sizeOf(context).height * 0.6,
+        child: FutureBuilder<List<BangumiWatchedItem>>(
+          future: _watched,
+          builder: (
+            BuildContext context,
+            AsyncSnapshot<List<BangumiWatchedItem>> snapshot,
+          ) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (snapshot.hasError) {
+              return Center(
+                child: Text(
+                  t.media_tracking_watched_load_failed(
+                    error: snapshot.error!,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              );
+            }
+            final List<BangumiWatchedItem> watched =
+                snapshot.data ?? const <BangumiWatchedItem>[];
+            if (watched.isEmpty) {
+              return Center(child: Text(t.media_tracking_watched_empty));
+            }
+            return ListView.separated(
+              itemCount: watched.length,
+              separatorBuilder: (_, __) => const Divider(height: 1),
+              itemBuilder: (BuildContext context, int index) {
+                final BangumiWatchedItem item = watched[index];
+                final String? coverUrl = item.subject.coverUrl;
+                return ListTile(
+                  contentPadding: EdgeInsets.zero,
+                  leading: SizedBox(
+                    width: 42,
+                    height: 56,
+                    child: coverUrl == null
+                        ? const Icon(Icons.movie_outlined)
+                        : ClipRRect(
+                            borderRadius: BorderRadius.circular(4),
+                            child: Image.network(
+                              coverUrl,
+                              fit: BoxFit.cover,
+                              errorBuilder: (_, __, ___) =>
+                                  const Icon(Icons.broken_image_outlined),
+                            ),
+                          ),
+                  ),
+                  title: Text(
+                    item.subject.displayName,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    t.media_tracking_watched_progress(
+                      n: item.episodeProgress,
+                    ),
+                  ),
+                  trailing: Tooltip(
+                    message: t.media_tracking_open_subject,
+                    child: const Icon(Icons.open_in_new, size: 18),
+                  ),
+                  onTap: () => unawaited(widget.onOpenSubject(item.subject.id)),
+                );
+              },
+            );
+          },
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(t.dialog_close),
+        ),
+      ],
+    );
+  }
+}
+
 /// 仪表盘内容最大宽度（逻辑像素）：超宽屏限宽居中，避免每个区块被拉成大片空白。
 const double _kDashboardMaxWidth = 1600;
 
@@ -256,6 +365,9 @@ const double _kDashboardMaxWidth = 1600;
 /// 概览，不是映射管理器）。有失败的条目由
 /// [MediaTrackingStatus.mappingsProblemFirst] 排到最前，不会被这个上限挤掉。
 const int _kTrackingMappingLimit = 5;
+
+/// 首页卡最多直接摊开的待手动关联条目数；完整清单在「管理关联」页。
+const int _kTrackingUnlinkedLimit = 5;
 
 class _HomeDashboardPageState
     extends BaseModuleTabPageState<HomeDashboardPage> {
@@ -2180,20 +2292,48 @@ class _HomeDashboardPageState
         crossAxisAlignment: CrossAxisAlignment.stretch,
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Row(
-            children: <Widget>[
-              Icon(Icons.person_outline, size: 18, color: scheme.primary),
-              SizedBox(width: tokens.spacing.gap / 2),
-              Expanded(
-                child: Text(
-                  status.accountName.isEmpty
-                      ? t.media_tracking_account
-                      : status.accountName,
-                  style: tokens.type.listTitle,
-                  overflow: TextOverflow.ellipsis,
+          Tooltip(
+            message: t.media_tracking_watched_show,
+            child: InkWell(
+              onTap: () => unawaited(_showBangumiWatched()),
+              borderRadius: HibikiBorderRadius.card,
+              child: Padding(
+                padding: EdgeInsets.symmetric(
+                  vertical: tokens.spacing.gap / 2,
+                ),
+                child: Row(
+                  children: <Widget>[
+                    Icon(
+                      Icons.person_outline,
+                      size: 18,
+                      color: scheme.primary,
+                    ),
+                    SizedBox(width: tokens.spacing.gap / 2),
+                    Expanded(
+                      child: Text(
+                        status.accountName.isEmpty
+                            ? t.media_tracking_account
+                            : status.accountName,
+                        style: tokens.type.listTitle,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    Text(
+                      t.media_tracking_watched_show,
+                      style: tokens.type.metadata.copyWith(
+                        color: scheme.primary,
+                      ),
+                    ),
+                    SizedBox(width: tokens.spacing.gap / 4),
+                    Icon(
+                      Icons.chevron_right,
+                      size: 18,
+                      color: scheme.primary,
+                    ),
+                  ],
                 ),
               ),
-            ],
+            ),
           ),
           SizedBox(height: tokens.spacing.gap / 2),
           Text(summary.join(' · '), style: tokens.type.metadata),
@@ -2219,23 +2359,45 @@ class _HomeDashboardPageState
 
           SizedBox(height: tokens.spacing.gap),
 
-          // 第二段：一条映射都没有 → 完成事件根本进不了 outbox，必须说清原因，
-          // 否则「已连接 + 零待办 + 全部已发送」看起来像一切正常。
-          if (status.mappings.isEmpty)
+          // 本地历史与映射是两个独立口径：先明确列出已有进度但仍没关联的条目。
+          // 旧文案只在映射表为空时泛泛说“其余需手动关联”，既没写出“哪些”，
+          // 又把“零映射”误当成“零历史”。
+          if (status.unlinked.isNotEmpty) ...<Widget>[
             Text(
-              t.media_tracking_unlinked_hint,
+              t.media_tracking_manual_required_count(n: status.unlinked.length),
+              style: tokens.type.listTitle.copyWith(color: scheme.error),
+            ),
+            SizedBox(height: tokens.spacing.gap / 4),
+            Text(
+              t.media_tracking_manual_required_hint,
               style: tokens.type.metadata,
-            )
-          else
-            // 第三段：逐条条目。失败原因挂在对应行上（有失败的排在最前），不另开
-            // 一段——否则同一个条目在「失败」和「已关联」里各出现一次。
-            for (final MediaTrackingMappingRow mapping
-                in status.mappingsProblemFirst.take(_kTrackingMappingLimit))
-              _buildTrackingMappingRow(
-                tokens,
-                mapping,
-                status.failureByMappingId[mapping.id],
+            ),
+            for (final MediaTrackingUnlinkedItem item
+                in status.unlinked.take(_kTrackingUnlinkedLimit))
+              _buildTrackingUnlinkedRow(tokens, item),
+            if (status.unlinked.length > _kTrackingUnlinkedLimit)
+              TextButton(
+                onPressed: _openTrackingSettings,
+                child: Text(
+                  t.media_tracking_more_manual_required(
+                    n: status.unlinked.length - _kTrackingUnlinkedLimit,
+                  ),
+                ),
               ),
+          ] else if (status.mappings.isEmpty)
+            Text(
+              t.media_tracking_no_local_history,
+              style: tokens.type.metadata,
+            ),
+
+          // 已关联条目仍保留作同步诊断；失败原因挂在对应行上并排到最前。
+          for (final MediaTrackingMappingRow mapping
+              in status.mappingsProblemFirst.take(_kTrackingMappingLimit))
+            _buildTrackingMappingRow(
+              tokens,
+              mapping,
+              status.failureByMappingId[mapping.id],
+            ),
           for (final String error in status.automaticMappingErrors)
             Text(
               '${t.media_tracking_last_error}: $error',
@@ -2273,6 +2435,47 @@ class _HomeDashboardPageState
             ],
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildTrackingUnlinkedRow(
+    HibikiDesignTokens tokens,
+    MediaTrackingUnlinkedItem item,
+  ) {
+    final ColorScheme scheme = Theme.of(context).colorScheme;
+    return InkWell(
+      onTap: _openTrackingSettings,
+      borderRadius: HibikiBorderRadius.card,
+      child: Padding(
+        padding: EdgeInsets.symmetric(vertical: tokens.spacing.gap / 2),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Icon(Icons.link_off, size: 18, color: scheme.error),
+            SizedBox(width: tokens.spacing.gap / 2),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    item.mediaTitle,
+                    style: tokens.type.listTitle,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    '${trackingKindLabel(item.kind.value)} · '
+                    '${t.media_tracking_manual_required}',
+                    style: tokens.type.metadata.copyWith(color: scheme.error),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(width: tokens.spacing.gap / 2),
+            const Icon(Icons.chevron_right, size: 18),
+          ],
+        ),
       ),
     );
   }
@@ -2343,6 +2546,16 @@ class _HomeDashboardPageState
     await launchUrl(
       Uri.parse(BangumiApiClient.subjectUrl(subjectId)),
       mode: LaunchMode.externalApplication,
+    );
+  }
+
+  Future<void> _showBangumiWatched() async {
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext dialogContext) => _BangumiWatchedDialog(
+        service: ref.read(appProvider).mediaTrackingService,
+        onOpenSubject: _openBangumiSubject,
+      ),
     );
   }
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+997
+version: 1.3.1+998
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/tracking/bangumi_api_client_test.dart
+++ b/hibiki/test/media/tracking/bangumi_api_client_test.dart
@@ -165,6 +165,65 @@ void main() {
     expect(subject.volumeCount, 3);
   });
 
+  test('watched anime list follows every official collection page', () async {
+    final List<http.Request> captured = <http.Request>[];
+    final BangumiApiClient client = BangumiApiClient(
+      accessToken: 'token',
+      userAgent: 'test-agent',
+      client: MockClient((http.Request request) async {
+        captured.add(request);
+        final int offset =
+            int.parse(request.url.queryParameters['offset'] ?? '0');
+        final int id = offset == 0 ? 41 : 42;
+        return http.Response.bytes(
+          utf8.encode(jsonEncode(<String, dynamic>{
+            'total': 51,
+            'limit': 50,
+            'offset': offset,
+            'data': <Map<String, dynamic>>[
+              <String, dynamic>{
+                'subject_id': id,
+                'subject_type': 2,
+                'type': 2,
+                'ep_status': offset == 0 ? 12 : 24,
+                'updated_at': '2026-07-29T12:00:00+08:00',
+                'subject': <String, dynamic>{
+                  'id': id,
+                  'type': 2,
+                  'name': 'Anime $id',
+                  'name_cn': '番剧 $id',
+                  'platform': 'TV',
+                  'eps': offset == 0 ? 12 : 24,
+                  'volumes': 0,
+                  'images': <String, String>{
+                    'medium': 'https://example/$id.jpg',
+                  },
+                },
+              },
+            ],
+          })),
+          200,
+        );
+      }),
+    );
+    addTearDown(client.close);
+
+    final List<BangumiWatchedItem> watched =
+        await client.getWatchedAnime('alice name');
+
+    expect(captured, hasLength(2));
+    expect(captured.first.url.path, '/v0/users/alice%20name/collections');
+    expect(
+        captured.first.url.queryParameters, containsPair('subject_type', '2'));
+    expect(captured.first.url.queryParameters, containsPair('type', '2'));
+    expect(captured.last.url.queryParameters, containsPair('offset', '50'));
+    expect(
+      watched.map((BangumiWatchedItem item) => item.subject.id),
+      <int>[41, 42],
+    );
+    expect(watched.last.episodeProgress, 24);
+  });
+
   test('markEpisodesDone sends one idempotent batch patch', () async {
     late http.Request captured;
     final BangumiApiClient client = BangumiApiClient(

--- a/hibiki/test/media/tracking/media_tracking_repository_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_repository_test.dart
@@ -15,6 +15,38 @@ void main() {
 
   tearDown(() => db.close());
 
+  test('旧的已完成视频会列为待手动关联，建立映射后立即消失', () async {
+    final DateTime completedAt = DateTime.fromMillisecondsSinceEpoch(5000);
+    await db.upsertVideoBook(
+      VideoBooksCompanion.insert(
+        bookUid: 'old-video',
+        title: '以前看过的番剧',
+        videoPath: 'C:/video/old.mkv',
+        completedAt: Value<DateTime?>(completedAt),
+      ),
+    );
+
+    List<MediaTrackingUnlinkedItem> unlinked =
+        await repository.listUnlinkedHistory();
+    expect(unlinked, hasLength(1));
+    expect(unlinked.single.mediaKey, 'old-video');
+    expect(unlinked.single.lastActivityAt, 5000);
+
+    await repository.saveMapping(
+      mediaType: TrackingMediaType.video,
+      mediaKey: 'old-video',
+      mediaTitle: '以前看过的番剧',
+      kind: TrackingKind.anime,
+      subjectId: 42,
+      subjectName: 'Remote anime',
+      progressMode: TrackingProgressMode.episode,
+      progressOffset: 1,
+    );
+
+    unlinked = await repository.listUnlinkedHistory();
+    expect(unlinked, isEmpty);
+  });
+
   /// 按页翻的书（PDF / 漫画）没有「章」：`chaptersJson` 是 `'[]'`、`tocJson` 是 null，
   /// 阅读位置的 `sectionIndex` 存的是**页码**。旧实现在这里只挡了 `'manga'`，PDF 会
   /// 一路走到 estimateCompletedBookChapters 的「无 toc 即早退」分支拿到

--- a/hibiki/test/media/tracking/media_tracking_service_test.dart
+++ b/hibiki/test/media/tracking/media_tracking_service_test.dart
@@ -24,6 +24,7 @@ class _FakeBangumiApi implements BangumiTrackingApi {
   final List<Map<String, dynamic>> patches = <Map<String, dynamic>>[];
   final List<List<int>> episodePatches = <List<int>>[];
   List<BangumiSubject> searchResults = const <BangumiSubject>[];
+  List<BangumiWatchedItem> watched = const <BangumiWatchedItem>[];
   final List<({String keyword, int subjectType})> searches =
       <({String keyword, int subjectType})>[];
 
@@ -36,6 +37,13 @@ class _FakeBangumiApi implements BangumiTrackingApi {
   Future<BangumiUser> getMe() async {
     _throwIfNeeded();
     return const BangumiUser(username: 'alice', nickname: 'Alice');
+  }
+
+  @override
+  Future<List<BangumiWatchedItem>> getWatchedAnime(String username) async {
+    _throwIfNeeded();
+    expect(username, 'alice');
+    return watched;
   }
 
   @override
@@ -126,6 +134,29 @@ void main() {
   tearDown(() async {
     preferences.dispose();
     await db.close();
+  });
+
+  test('账号入口直接读取 Bangumi 全量看过，不从本地映射反推', () async {
+    api.watched = const <BangumiWatchedItem>[
+      BangumiWatchedItem(
+        subject: BangumiSubject(
+          id: 42,
+          type: 2,
+          name: 'Old anime',
+          nameCn: '以前看过的番剧',
+          platform: 'TV',
+          episodeCount: 12,
+          volumeCount: 0,
+        ),
+        episodeProgress: 12,
+        updatedAt: null,
+      ),
+    ];
+
+    final List<BangumiWatchedItem> watched = await service.loadWatchedAnime();
+
+    expect(await repository.listMappings(), isEmpty);
+    expect(watched.single.subject.displayName, '以前看过的番剧');
   });
 
   test('anime sync creates doing collection and marks all episodes to progress',

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -1098,7 +1098,7 @@ void main() {
       );
     });
 
-    testWidgets('已连接但零关联：说清「所以什么都不会同步」，不是一切正常', (WidgetTester tester) async {
+    testWidgets('已连接但没有本地历史：不再显示泛化的零关联警告', (WidgetTester tester) async {
       useWideSurface(tester);
       await connect();
       await tester.pumpWidget(buildApp());
@@ -1110,7 +1110,38 @@ void main() {
       // 从未同步必须与「同步过零待办」区分：成功即删 outbox 行，两者否则同形。
       expect(
           find.textContaining(t.media_tracking_never_synced), findsOneWidget);
-      expect(find.text(t.media_tracking_unlinked_hint), findsOneWidget);
+      expect(find.text(t.media_tracking_no_local_history), findsOneWidget);
+      expect(find.text(t.media_tracking_watched_show), findsOneWidget);
+    });
+
+    testWidgets('以前看完但未映射的视频会明确列为需要手动关联', (WidgetTester tester) async {
+      useWideSurface(tester);
+      await connect();
+      await db.upsertVideoBook(
+        VideoBooksCompanion.insert(
+          bookUid: 'old-video',
+          title: '以前看过的番剧',
+          videoPath: 'C:/video/old.mkv',
+          completedAt: Value<DateTime?>(DateTime.now()),
+        ),
+      );
+
+      await tester.pumpWidget(buildApp());
+      await pumpDashboard(tester);
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('以前看过的番剧'), findsOneWidget);
+      expect(
+        find.text(
+          '${t.media_tracking_anime} · '
+          '${t.media_tracking_manual_required}',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.text(t.media_tracking_manual_required_count(n: 1)),
+        findsOneWidget,
+      );
     });
 
     testWidgets('已关联条目列出本地标题 + Bangumi 条目名，并给出打开入口',
@@ -1139,7 +1170,7 @@ void main() {
         find.textContaining(t.media_tracking_linked_count(n: 1)),
         findsOneWidget,
       );
-      expect(find.text(t.media_tracking_unlinked_hint), findsNothing);
+      expect(find.text(t.media_tracking_no_local_history), findsNothing);
     });
 
     testWidgets('上报失败：退避窗口内也照说失败原因', (WidgetTester tester) async {


### PR DESCRIPTION
## 改动

- 右上角 Bangumi 账号区域可点击，直接读取并分页展示该账号全部“看过”的动画收藏，不再把本地映射数量当成观看历史
- 删除“还没有任何条目关联到 Bangumi 条目……”的笼统提示
- 首页明确列出需要手动关联的本地观看、阅读、游玩记录，并可跳转到管理关联
- 管理关联页展示完整待关联列表，点击时预选对应本地条目
- 补充 Bangumi 分页、历史读取、待关联识别与首页展示测试
- 构建号更新至 1.3.1+998，记录 BUG-1236

## 验证

- `flutter analyze --no-pub`：通过（No issues found）
- `dart run tool/bug.dart check`：通过（1187 条，编号唯一，索引同步）
- `dart run tool/i18n_sync.dart --dry-run`：通过（全部翻译源同步）
- `git diff --check`：通过
- 定向 Flutter 测试：未执行到测试用例；`pdfium_dart` 在构建钩子下载 GitHub 原生资源时网络超时（Windows errno 121，0 条测试开始），按需求未继续等待编译验收