### PR TITLE
fix(home): 统一游戏活动身份并恢复封面

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1187 条。点号进各自文件。
+> 共 1188 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1237](bugs/BUG-1237-activity-game-cover.md) | ✅ | ✅ | 游戏活动身份不统一导致封面缺失 |
 | [BUG-1233](bugs/BUG-1233-book-import-repeated-archive-probe.md) | ✅ | ✅ | 书籍导入重复整包判定 EPUB 载体 |
 | [BUG-1225](bugs/BUG-1225-shm-reader-write-access-must-stay.md) | ✅ | ✅ | 读端共享内存写权限不可收紧：SelectTextThread 的原子写落在只读页上会崩 |
 | [BUG-1221](bugs/BUG-1221-manga-path-case-folded.md) | ✅ | ✅ | 漫画页图解析把路径折成小写，制卡封面名被小写化且大小写敏感平台缺页 |

--- a/docs/bugs/BUG-1237-activity-game-cover.md
+++ b/docs/bugs/BUG-1237-activity-game-cover.md
@@ -13,6 +13,6 @@
   `test/mining/galgame_launch_args_test.dart` 覆盖三类历史/当前身份；
   `test/mining/galgame_helper_launch_guard_test.dart` 钉住三处调用接线；
   `test/pages/home_dashboard_page_test.dart` 用旧 exePath 复现并断言活动封面。
-- **备注**：改动提交哈希在提交后回填。定向测试启动前被 `pdfium_dart` 下载
+- **备注**：根因修复与自动化测试提交 `9d6243bd0`。定向测试启动前被 `pdfium_dart` 下载
   `pdfium-win-x64.tgz` 的 GitHub 网络超时阻断（0 条执行）；10 个改动项的
   `flutter analyze --no-pub` 通过。

--- a/docs/bugs/BUG-1237-activity-game-cover.md
+++ b/docs/bugs/BUG-1237-activity-game-cover.md
@@ -1,0 +1,18 @@
+## BUG-1237 · 游戏活动身份不统一导致封面缺失
+- **报告**：2026-07-29（用户：活动里的游戏缺少封面，怀疑命名不同）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/mining/gal_hook_session_controller.dart:1079`
+  的启动活动身份原先把 exe 绝对路径写进 `mediaKey`，而
+  `hibiki/lib/src/pages/implementations/home_dashboard_page.dart:1978` 的活动封面
+  按游戏库身份反查；attach 事件还可能没有 key，所以封面命不中。
+- **[x] ① 根因修复** — `launchGame` 明确接收 `gameId/gameTitle`，三个库内启动
+  入口统一传 `GalgameEntry.id/displayName`；读取侧新增
+  `findGalgameForActivity`，按新 id → 旧 exePath → 旧标题快照兼容历史活动。
+  首页与游戏首页时间线共用该解析，并复用 `resolveMediaCoverImage`。
+- **[x] ② 自动化测试** —
+  `test/mining/gal_hook_session_controller_test.dart` 钉住新活动实际落库身份；
+  `test/mining/galgame_launch_args_test.dart` 覆盖三类历史/当前身份；
+  `test/mining/galgame_helper_launch_guard_test.dart` 钉住三处调用接线；
+  `test/pages/home_dashboard_page_test.dart` 用旧 exePath 复现并断言活动封面。
+- **备注**：改动提交哈希在提交后回填。定向测试启动前被 `pdfium_dart` 下载
+  `pdfium-win-x64.tgz` 的 GitHub 网络超时阻断（0 条执行）；10 个改动项的
+  `flutter analyze --no-pub` 通过。

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -1038,12 +1038,16 @@ class GalHookSessionController extends ChangeNotifier {
   /// 拉起游戏并注入。
   ///
   /// [launchArguments] 是用户为该游戏配置的启动参数（已按 Windows 规则拆成 argv
-  /// token，见 `parseGameLaunchArguments`），[workdir] 是工作目录。两者都可省略：
-  /// 省略即维持旧行为（不发 `--arg` / 不发 `--workdir`，injector 缺省用 exe 所在目录）。
+  /// token，见 `parseGameLaunchArguments`），[workdir] 是工作目录。[gameId] 必须是
+  /// `galgames.id`，[gameTitle] 是当前库内显示名；游戏库入口应同时传入，使活动事件
+  /// 使用与封面/详情反查相同的稳定身份。裸 exe 启动可以省略二者，此时活动仍保留
+  /// exe 文件名快照，但 mediaKey 留空，不能再把路径伪装成 `galgames.id`。
   Future<GalHookLaunchResult> launchGame(
     String executablePath, {
     List<String> launchArguments = const <String>[],
     String workdir = '',
+    String? gameId,
+    String? gameTitle,
   }) async {
     final int generation = ++_operationGeneration;
     await _stopSources();
@@ -1074,10 +1078,14 @@ class GalHookSessionController extends ChangeNotifier {
         textSignalReceived: false,
       ),
     );
-    // launch 模式可执行文件路径是稳定 id：文件名去扩展名作游戏名，路径作 mediaKey。
+    final String normalizedTitle = gameTitle?.trim() ?? '';
+    // 活动 mediaKey 的跨层契约统一为 galgames.id。历史版本写过 exePath，读取侧保留
+    // 兼容；新写入不再延续一字段两种身份的歧义。
     _beginActivitySession(
-      title: _displayNameForExecutable(executablePath),
-      mediaKey: executablePath,
+      title: normalizedTitle.isEmpty
+          ? _displayNameForExecutable(executablePath)
+          : normalizedTitle,
+      mediaKey: gameId,
     );
     // 降级策略必须在这里恢复，不能搭 [_applyTrackMemory] 的便车：资源模式压根不枚举
     // 音轨（native 只枚举 PCM 环），等音轨快照就等不到，用户上次选的「禁止降级」会

--- a/hibiki/lib/src/mining/galgame_library.dart
+++ b/hibiki/lib/src/mining/galgame_library.dart
@@ -327,6 +327,49 @@ GalgameEntry? findGalgameByExePath(
   return null;
 }
 
+/// 把一条游戏活动反查回游戏库条目。
+///
+/// 新活动的 [mediaKey] 统一写 `galgames.id`；历史版本曾把 exe 绝对路径写进同一字段，
+/// attach 模式则可能完全没有 key。因此读取顺序固定为：
+///
+/// 1. `galgames.id`；
+/// 2. 旧 exe 路径（复用 [findGalgameByExePath] 的 Windows 路径归一）；
+/// 3. 活动落库时的标题快照（本地名 / 当前显示名 / 元数据名与别名 / exe 文件名）。
+///
+/// 这层兼容必须集中在领域模型旁边，首页 Activity 与游戏首页时间线共用；否则一个页面
+/// 能显示历史活动封面、另一个页面仍只剩占位图标。
+GalgameEntry? findGalgameForActivity(
+  List<GalgameEntry> games, {
+  String? mediaKey,
+  required String title,
+}) {
+  final String key = mediaKey?.trim() ?? '';
+  if (key.isNotEmpty) {
+    for (final GalgameEntry game in games) {
+      if (game.id == key) return game;
+    }
+    final GalgameEntry? byExePath = findGalgameByExePath(games, key);
+    if (byExePath != null) return byExePath;
+  }
+
+  final String snapshot = title.trim();
+  if (snapshot.isEmpty) return null;
+  for (final GalgameEntry game in games) {
+    final Iterable<String?> knownTitles = <String?>[
+      game.displayName,
+      game.name,
+      game.metadata.name,
+      game.metadata.nameCn,
+      ...game.metadata.aliases,
+      galgameNameFromExe(game.exePath),
+    ];
+    if (knownTitles.any((String? value) => value?.trim() == snapshot)) {
+      return game;
+    }
+  }
+  return null;
+}
+
 /// 把用户输入的一整行启动参数拆成 argv token，规则与 Windows `CommandLineToArgvW`
 /// 一致（injector 侧再按同一套规则逐个重新转义写进 `lpCommandLine`，往返无损）：
 ///

--- a/hibiki/lib/src/pages/implementations/galgame_home_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_home_page.dart
@@ -10,6 +10,7 @@ import 'package:hibiki/models.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/focus/hibiki_focus_target.dart';
 import 'package:hibiki/src/media/display_title.dart';
+import 'package:hibiki/src/media/media_cover_source.dart';
 import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
@@ -276,6 +277,8 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
         game.exePath,
         launchArguments: game.launchArgumentTokens,
         workdir: game.workdir,
+        gameId: game.id,
+        gameTitle: game.displayName,
       );
       if (!mounted) return;
       // 每种结果都播报（BUG-1089）。旧实现只在 `!launched` 时说话，可注入降级和
@@ -896,17 +899,12 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
     );
   }
 
-  /// 活动条 → 对应的库内游戏（先按 mediaKey==id，再按显示名匹配；查不到返回 null）。
-  GalgameEntry? _gameForActivity(ActivityEntry entry) {
-    final String? key = entry.mediaKey;
-    for (final GalgameEntry g in _games) {
-      if (key != null && g.id == key) return g;
-    }
-    for (final GalgameEntry g in _games) {
-      if (g.displayName == entry.title) return g;
-    }
-    return null;
-  }
+  /// 活动条 → 对应的库内游戏。新事件按 id，旧事件兼容 exePath / 标题快照。
+  GalgameEntry? _gameForActivity(ActivityEntry entry) => findGalgameForActivity(
+        _games,
+        mediaKey: entry.mediaKey,
+        title: entry.title,
+      );
 
   String _actionWord(String eventType) {
     switch (eventType) {
@@ -936,19 +934,20 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
   String _formatDay(int epochMs) =>
       HibikiTimeFormat.dayKey(DateTime.fromMillisecondsSinceEpoch(epochMs));
 
-  /// 封面 widget：有 coverPath 且文件存在则显示图片（cover 铺满），否则默认手柄图标
-  /// 占位（回落逻辑与库页卡片一致）。
+  /// 封面 widget：来源解析与首页 Activity / 游戏库共用；文件缺失或解码失败由渲染层
+  /// 回退默认手柄图标，不在 build 里做同步文件探测。
   Widget _coverImage(BuildContext context, GalgameEntry game) {
-    final String? cover = game.coverPath;
-    if (cover != null && cover.isNotEmpty && File(cover).existsSync()) {
-      return Image.file(
-        File(cover),
-        fit: BoxFit.cover,
-        errorBuilder: (BuildContext context, Object error, StackTrace? stack) =>
-            _coverFallback(context),
-      );
-    }
-    return _coverFallback(context);
+    final ImageProvider? provider = resolveMediaCoverImage(
+      kind: MediaKind.game,
+      localPath: game.coverPath,
+    );
+    if (provider == null) return _coverFallback(context);
+    return Image(
+      image: provider,
+      fit: BoxFit.cover,
+      errorBuilder: (BuildContext context, Object error, StackTrace? stack) =>
+          _coverFallback(context),
+    );
   }
 
   Widget _coverFallback(BuildContext context) {

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -504,6 +504,8 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         game.exePath,
         launchArguments: game.launchArgumentTokens,
         workdir: game.workdir,
+        gameId: game.id,
+        gameTitle: game.displayName,
       );
       if (!mounted) return;
       // 每种结果都播报（BUG-1089）。旧实现只在 `!launched` 时说话，可注入降级和

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -1,6 +1,5 @@
 import 'package:hibiki_dictionary/hibiki_dictionary.dart';
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
@@ -13,6 +12,7 @@ import 'package:hibiki/utils.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/display_title.dart';
+import 'package:hibiki/src/media/media_cover_source.dart';
 import 'package:hibiki/src/media/tracking/bangumi_api_client.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_labels.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_service.dart';
@@ -1286,34 +1286,43 @@ class _HomeDashboardPageState
     );
   }
 
-  /// 视频封面：coverPath 存在则 [Image.file]，否则占位图标。
+  /// 视频封面：来源解析与游戏/剧集列表共用 [resolveMediaCoverImage]。
   Widget _videoCover(HibikiDesignTokens tokens, VideoBookRow video) {
-    final String? path = video.coverPath;
-    if (path != null && path.isNotEmpty && File(path).existsSync()) {
-      return Image.file(
-        File(path),
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) =>
-            _coverPlaceholder(tokens, Icons.movie_outlined),
-      );
-    }
-    return _coverPlaceholder(tokens, Icons.movie_outlined);
+    return _localCover(
+      tokens,
+      kind: MediaKind.video,
+      path: video.coverPath,
+    );
   }
 
-  /// 游戏封面（BUG-1111 / BUG-1112）：`galgames.coverPath` 存在则 [Image.file]，
-  /// 否则占位图标。与 [_videoCover] 同一形态——封面是本机文件路径（目录扫描 /
-  /// exe 内嵌图标 / 刮削下载三种来源都落成本地文件），不走网络取图。
+  /// 游戏封面（BUG-1111 / BUG-1112）：目录扫描 / exe 图标 / 刮削最终都落到
+  /// `galgames.coverPath`，显示侧交给统一来源解析器，不在页面重复同步文件探测。
   Widget _gameCover(HibikiDesignTokens tokens, GalgameEntry game) {
-    final String? path = game.coverPath;
-    if (path != null && path.isNotEmpty && File(path).existsSync()) {
-      return Image.file(
-        File(path),
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) =>
-            _coverPlaceholder(tokens, Icons.videogame_asset_outlined),
-      );
+    return _localCover(
+      tokens,
+      kind: MediaKind.game,
+      path: game.coverPath,
+    );
+  }
+
+  Widget _localCover(
+    HibikiDesignTokens tokens, {
+    required MediaKind kind,
+    required String? path,
+  }) {
+    final ImageProvider? provider = resolveMediaCoverImage(
+      kind: kind,
+      localPath: path,
+    );
+    if (provider == null) {
+      return _coverPlaceholder(tokens, mediaCoverFallbackIcon(kind));
     }
-    return _coverPlaceholder(tokens, Icons.videogame_asset_outlined);
+    return Image(
+      image: provider,
+      fit: BoxFit.cover,
+      errorBuilder: (_, __, ___) =>
+          _coverPlaceholder(tokens, mediaCoverFallbackIcon(kind)),
+    );
   }
 
   /// 封面占位：中性底色 + 图标。
@@ -1636,29 +1645,12 @@ class _HomeDashboardPageState
   /// 游戏活动标题 → 显示名（P4）：先按 [mediaKey]（galgames.id）精确命中，
   /// 再按「落库时的标题快照 == 库内条目任一已知名」兜底（老事件无 mediaKey），
   /// 最后回落快照原文。查找委托 [displayTitleForGame]。
-  /// 按 `galgames.id` 反查本页已加载的游戏；找不到返回 null（已删除条目的历史
-  /// 活动行仍会渲染，只是没有封面/新名可用）。
-  GalgameEntry? _gameById(String? id) {
-    if (id == null || id.isEmpty) return null;
-    for (final GalgameEntry g in _games) {
-      if (g.id == id) return g;
-    }
-    return null;
-  }
-
   String _gameDisplayTitle(String rawTitle, {String? mediaKey}) {
-    GalgameEntry? entry = _gameById(mediaKey);
-    if (entry == null) {
-      for (final GalgameEntry g in _games) {
-        if (g.name == rawTitle ||
-            g.displayName == rawTitle ||
-            g.metadata.name == rawTitle ||
-            g.metadata.nameCn == rawTitle) {
-          entry = g;
-          break;
-        }
-      }
-    }
+    final GalgameEntry? entry = findGalgameForActivity(
+      _games,
+      mediaKey: mediaKey,
+      title: rawTitle,
+    );
     return displayTitleForGame(entry: entry, rawTitle: rawTitle);
   }
 
@@ -1984,7 +1976,25 @@ class _HomeDashboardPageState
     Map<String, VideoBookRow> videosByUid,
   ) {
     final String? key = entry.mediaKey;
-    if (key != null && key.isNotEmpty) {
+    if (entry.mediaType == kActivityMediaGame) {
+      // 新事件用 galgames.id；旧启动事件曾写 exePath，attach 事件还可能只有标题。
+      // 统一反查器兼容三者，封面和显示名因此命中同一个 GalgameEntry。
+      final GalgameEntry? game = findGalgameForActivity(
+        _games,
+        mediaKey: key,
+        title: entry.title,
+      );
+      if (game != null) {
+        return ClipRRect(
+          borderRadius: HibikiBorderRadius.card,
+          child: SizedBox(
+            width: 40,
+            height: 56,
+            child: _gameCover(tokens, game),
+          ),
+        );
+      }
+    } else if (key != null && key.isNotEmpty) {
       if (entry.mediaType == kActivityMediaVideo) {
         final VideoBookRow? video = videosByUid[key];
         if (video != null) {
@@ -1994,21 +2004,6 @@ class _HomeDashboardPageState
               width: 68,
               height: 40,
               child: _videoCover(tokens, video),
-            ),
-          );
-        }
-      } else if (entry.mediaType == kActivityMediaGame) {
-        // BUG-1112：游戏此前被硬编码进「回退图标」分支，时间轴上只有一个小图标，
-        // 而书与视频都有封面（用户报「活动里面没有封面」）。游戏封面就在
-        // `galgames.coverPath`（本机文件），按 mediaKey = galgames.id 反查即可。
-        final GalgameEntry? game = _gameById(key);
-        if (game != null) {
-          return ClipRRect(
-            borderRadius: HibikiBorderRadius.card,
-            child: SizedBox(
-              width: 40,
-              height: 56,
-              child: _gameCover(tokens, game),
             ),
           );
         }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -675,6 +675,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         executable,
         launchArguments: known?.launchArgumentTokens ?? const <String>[],
         workdir: known?.workdir ?? '',
+        gameId: known?.id,
+        gameTitle: known?.displayName,
       );
       if (!mounted) return;
       // 与游戏库页共用同一条结果播报（BUG-1089）。旧实现在这里自己判 `boundWindow`

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -1283,6 +1283,77 @@ void main() {
     endpoints.dispose();
   });
 
+  test('游戏库启动活动统一写 galgames.id 与当前显示名，不再把 exePath 当 mediaKey', () async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    final _FakeEngineSource engine = _FakeEngineSource(
+      pairedBytes: Uint8List(0),
+      audioFormat: null,
+      textReady: true,
+      polledLines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 1,
+          timestampMs: 1000,
+          text: '統一された活動',
+          threadId: 1,
+          hookName: 'Unity',
+        ),
+      ],
+    );
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      exe32BitProbe: (_) async => false,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+        List<String> launchArguments = const <String>[],
+        String launchWorkdir = '',
+      }) =>
+          engine,
+      loopbackSourceFactory: _FakeLoopbackSource.new,
+      windowListLoader: () async => const <ExternalWindowInfo>[],
+      windowPollAttempts: 1,
+      textPollInterval: const Duration(milliseconds: 5),
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+    controller.attachActivityDatabase(() => db);
+
+    final GalHookLaunchResult result = await controller.launchGame(
+      r'D:\Games\LegacyName.exe',
+      gameId: 'galgame-row-42',
+      gameTitle: '统一后的显示名',
+    );
+    expect(result.launched, isTrue);
+    for (int i = 0; i < 40 && service.entries.isEmpty; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+    expect(service.entries, hasLength(1));
+
+    await controller.stopCapture();
+    List<ActivityEventRow> rows = const <ActivityEventRow>[];
+    for (int i = 0; i < 40 && rows.isEmpty; i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      rows =
+          await db.getRecentActivityEvents(eventTypes: <String>[kActivityGame]);
+    }
+    expect(rows, hasLength(1));
+    expect(rows.single.title, '统一后的显示名');
+    expect(rows.single.mediaKey, 'galgame-row-42');
+    expect(rows.single.mediaKey, isNot(r'D:\Games\LegacyName.exe'));
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
   test('BUG-1085：重复台词/标点不计入字数，引擎计数后外部通道行不再双计', () async {
     final HibikiDatabase db =
         HibikiDatabase.forTesting(NativeDatabase.memory());

--- a/hibiki/test/mining/galgame_helper_launch_guard_test.dart
+++ b/hibiki/test/mining/galgame_helper_launch_guard_test.dart
@@ -102,4 +102,45 @@ void main() {
       );
     });
   });
+
+  group('BUG-1237：游戏库启动把稳定活动身份传进会话控制器', () {
+    void expectActivityIdentity({
+      required String path,
+      required String signature,
+      required String gameExpression,
+    }) {
+      final String body = methodBody(readStripped(path), signature);
+      expect(
+        body,
+        contains('gameId: $gameExpression.id'),
+        reason: '$signature 必须把 galgames.id 传给 launchGame，不能回退 exePath。',
+      );
+      expect(
+        body,
+        contains('gameTitle: $gameExpression.displayName'),
+        reason: '$signature 必须同步传当前显示名，不能另造一套文件名标题。',
+      );
+    }
+
+    test('游戏库与游戏首页传 game.id / displayName', () {
+      expectActivityIdentity(
+        path: 'lib/src/pages/implementations/games_library_page.dart',
+        signature: 'Future<void> _launchGame(GalgameEntry game)',
+        gameExpression: 'game',
+      );
+      expectActivityIdentity(
+        path: 'lib/src/pages/implementations/galgame_home_page.dart',
+        signature: 'Future<void> _launchGame(GalgameEntry game)',
+        gameExpression: 'game',
+      );
+    });
+
+    test('捕获工作台命中库条目时传同一活动身份', () {
+      expectActivityIdentity(
+        path: 'lib/src/pages/implementations/texthooker_page.dart',
+        signature: 'Future<void> _launchGalgameEngineHook()',
+        gameExpression: 'known?',
+      );
+    });
+  });
 }

--- a/hibiki/test/mining/galgame_launch_args_test.dart
+++ b/hibiki/test/mining/galgame_launch_args_test.dart
@@ -127,5 +127,28 @@ void main() {
       expect(findGalgameByExePath(games, ''), isNull);
       expect(findGalgameByExePath(<GalgameEntry>[], r'D:\a.exe'), isNull);
     });
+
+    test('活动身份统一兼容新 id、旧 exePath 与无 key 标题快照', () {
+      expect(
+        findGalgameForActivity(games, mediaKey: 'a', title: '旧标题')?.id,
+        'a',
+      );
+      expect(
+        findGalgameForActivity(
+          games,
+          mediaKey: r'd:/games/b/B.EXE',
+          title: '旧标题',
+        )?.id,
+        'b',
+      );
+      expect(
+        findGalgameForActivity(games, title: 'a')?.id,
+        'a',
+      );
+      expect(
+        findGalgameForActivity(games, mediaKey: 'missing', title: 'missing'),
+        isNull,
+      );
+    });
   });
 }

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -687,7 +687,8 @@ void main() {
     );
   });
 
-  testWidgets('BUG-1112：活动时间轴的游戏条目渲染封面，不再只有回退图标', (WidgetTester tester) async {
+  testWidgets('BUG-1112/BUG-1237：旧 exePath 活动身份也能反查并渲染游戏封面',
+      (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1280, 900);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -705,14 +706,15 @@ void main() {
       playedAt: now,
       coverPath: cover.path,
     );
-    // 时间轴的游戏行：mediaKey = galgames.id（据此反查封面）。
+    // 历史启动链路把 exePath 误写进 mediaKey，而且路径大小写/分隔符不一定一致；
+    // 活动展示必须兼容回查，不能只认 galgames.id。
     await db.addActivityEvent(
       eventType: kActivityGame,
       mediaType: kActivityMediaGame,
       title: '有封面的游戏',
       dateKey: HibikiTimeFormat.dayKey(now),
       timestampMs: now.millisecondsSinceEpoch,
-      mediaKey: 'g-3',
+      mediaKey: r'\ABS\G-3.EXE',
       durationMs: 60000,
     );
 
@@ -720,16 +722,21 @@ void main() {
     await pumpDashboard(tester);
 
     expect(tester.takeException(), isNull);
-    // 修复前游戏走「回退原类型图标」分支，时间轴上不会有任何 Image.file。
+    // 修复前 `_gameById(mediaKey)` 拿 exePath 去比 id，时间轴上不会有任何本地封面。
     // 必须收进「活动」区块：同一只游戏同时在「继续」与「最近添加」里各有一张
-    // `_gameCover`，裸 FileImage 谓词会被它们兜住——把 _activityLeading 的 game 分支
+    // `_gameCover`，裸本地 Image 谓词会被它们兜住——把 _activityLeading 的 game 分支
     // 删光也照样绿（实测过的假阳性）。
     final Finder fileImages = inSection(
       t.home_activity,
-      find.byWidgetPredicate((Widget w) => w is Image && w.image is FileImage),
+      find.byWidgetPredicate(
+        (Widget w) =>
+            w is Image &&
+            w.image is ResizeImage &&
+            (w.image as ResizeImage).imageProvider is FileImage,
+      ),
     );
     expect(fileImages, findsOneWidget,
-        reason: '游戏活动条应渲染 galgames.coverPath 封面（BUG-1112）');
+        reason: '游戏活动条应兼容旧 exePath 并渲染 galgames.coverPath 封面（BUG-1237）');
   });
 
   testWidgets('BUG-1112：点活动时间轴的游戏条切到「游戏」tab，不再落到视频 tab',


### PR DESCRIPTION
## 变更
- 游戏库启动活动统一写 `galgames.id` 和当前显示名，不再把 exePath 冒充 mediaKey
- 活动读取统一按 id → 旧 exePath → 旧标题快照反查，首页和游戏首页共用
- 游戏/视频本地封面显示接入 `resolveMediaCoverImage`，移除页面 build 中的同步文件探测
- 新增 BUG-1237 与控制器落库、历史兼容、三入口接线、活动封面回归测试

## 验证
- `flutter analyze --no-pub`（10 个改动项）：通过，0 issues
- `dart run tool/bug.dart check`：通过，1188 条、号唯一、索引同步
- `dart format --output=none --set-exit-if-changed`：通过
- `git diff --cached --check`：通过
- 定向 `flutter test`：未执行到测试体；`pdfium_dart` 下载 `pdfium-win-x64.tgz` 时 GitHub 网络超时，0 条测试执行。按用户要求不等待完整编译验收。