### PR TITLE
feat(video): add cinematic episode rails

### DIFF
--- a/hibiki/lib/src/media/video/video_episode_panel.dart
+++ b/hibiki/lib/src/media/video/video_episode_panel.dart
@@ -1,37 +1,17 @@
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/media/video/video_chrome_colors.dart';
-import 'package:hibiki/src/media/video/video_panel_auto_scroll.dart';
+import 'package:hibiki/src/media/video/video_episode_rail.dart';
 
-/// 剧集面板的一条：标题 + 可选封面。
-///
-/// 此前面板的入参是 `List<String> episodeTitles`——**接口只收字符串，结构上就装
-/// 不下封面**，于是剧集列表恒无图（用户报「视频里面的剧集列表，少了封面」）。
-/// 封面源由调用方经 `resolveMediaCoverImage` 解析好再传进来：本组件只管画，不关心
-/// 这一集是本地文件还是互联远端（与 `PosterCoverImage` 同一分工原则）。
-class VideoEpisodeEntry {
-  const VideoEpisodeEntry({required this.title, this.cover});
+export 'package:hibiki/src/media/video/video_episode_rail.dart'
+    show VideoEpisodeEntry, VideoEpisodeRail;
 
-  final String title;
-
-  /// 已解析好的封面图源；null = 该集无封面可用，画占位图标。
-  final ImageProvider? cover;
-}
-
-/// 视频播放列表「剧集列表」push-aside 侧栏面板（TODO-638）。
+/// 视频播放列表的底部剧集轨道。
 ///
-/// 此前剧集列表是 `showModalBottomSheet`（底部弹层），与其它侧栏（字幕列表 push-aside、
-/// 设置 / 倍速等 overlay）显示风格不一致。改成与字幕列表同款的 push-aside 侧栏后，三者
-/// 视觉统一：顶部带标题 + 右上角 × 关闭按钮的 header，下面是可滚动的剧集列表。
+/// 不使用 modal sheet，也不再把画面挤成窄栏；面板在视频底部渐显，画面本身就是
+/// Jellyfin 式背景。字幕跳转列表仍保持 push-aside，二者由页面层互斥。
 ///
-/// 本 widget 只负责渲染——把每集列成「序号 / 当前集播放图标 + 封面缩略图 + 标题」
-/// 一行，点击 [onTapEpisode] 切到该集（页面层 `_switchEpisode`），高亮 [currentIndex]
-/// 当前集。可见性与互斥由页面层（`_episodeListVisible` / `_videoWithSubtitlePanel`）管。
-///
-/// 与 [VideoChapterPanel] 同构（简单的 [ListView] + 当前项高亮 + play_arrow 标记），但
-/// header 借鉴字幕列表面板（标题 + ×），让用户能从侧栏内部直接关闭，关闭交互（× / Esc /
-/// 控制条剧集按钮）与字幕列表三路等价。
+/// 横向卡片的封面、缺图、选中态由共享 [VideoEpisodeRail] 渲染，合集详情页复用同一
+/// 组件，保证播放器内外视觉和交互一致。
 class VideoEpisodePanel extends StatefulWidget {
   const VideoEpisodePanel({
     super.key,
@@ -43,7 +23,8 @@ class VideoEpisodePanel extends StatefulWidget {
     required this.title,
     required this.emptyHint,
     this.fontSize = 14,
-    this.width = 320,
+    this.width = double.infinity,
+    this.height = 220,
   });
 
   /// 播放列表各集（有序，标题 + 可选封面）。空列表（单视频）时显示 [emptyHint]
@@ -67,69 +48,47 @@ class VideoEpisodePanel extends StatefulWidget {
   final String emptyHint;
   final double fontSize;
   final double width;
+  final double height;
 
   @override
   State<VideoEpisodePanel> createState() => _VideoEpisodePanelState();
 }
 
 class _VideoEpisodePanelState extends State<VideoEpisodePanel> {
-  // 「当前集滚到视口中部偏上」的机器与章节面板共享（[VideoPanelAutoScroller]）。
-  final VideoPanelAutoScroller _autoScroller = VideoPanelAutoScroller();
-
-  @override
-  void initState() {
-    super.initState();
-    // 首帧滚到当前集（异步：列表挂载后才有 viewport）。
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _scrollToCurrentEpisode();
-    });
-  }
-
-  @override
-  void didUpdateWidget(covariant VideoEpisodePanel oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // 当前集变化（换集 / 自动连播）时滚动到它。
-    if (oldWidget.currentIndex != widget.currentIndex) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) _scrollToCurrentEpisode();
-      });
-    }
-  }
-
-  @override
-  void dispose() {
-    _autoScroller.dispose();
-    super.dispose();
-  }
-
-  void _scrollToCurrentEpisode() {
-    _autoScroller.scrollToIndex(
-      widget.currentIndex,
-      itemCount: widget.episodes.length,
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final ColorScheme cs = widget.colorScheme;
-    // 背景半透明色挂在 [Material] 上（而非中间套一层 [ColoredBox]）：行用 [ListTile]，
-    // 它要求 [Material] 是其直接祖先、且祖先与它之间不能夹不透明的 [ColoredBox]（否则
-    // 抛 inkwell-on-opaque 断言）。故 Material 直接着色，内层只用 [SizedBox] 定宽。
+    final double minimumHeight = 150 + widget.fontSize * 3;
+    final double panelHeight =
+        widget.height < minimumHeight ? minimumHeight : widget.height;
     return Material(
-      // 浮层 alpha 两档制的实底档（UI 巡检 PR-4，0.92 → 0.94 归档）：剧集行文本
-      // 密集，近实底保证可读。
-      color: cs.surface.withValues(alpha: kVideoOverlaySolidAlpha),
+      color: Colors.transparent,
       child: SizedBox(
         width: widget.width,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            _buildHeader(cs),
-            const Divider(height: 1),
-            Expanded(
-              child: widget.episodes.isEmpty ? _buildEmpty(cs) : _buildList(cs),
+        height: panelHeight,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: <Color>[
+                cs.surface.withValues(alpha: 0),
+                cs.surface.withValues(alpha: kVideoOverlaySolidAlpha),
+              ],
+              stops: const <double>[0, 0.38],
             ),
-          ],
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              _buildHeader(cs),
+              Expanded(
+                child:
+                    widget.episodes.isEmpty ? _buildEmpty(cs) : _buildRail(cs),
+              ),
+              const SizedBox(height: 12),
+            ],
+          ),
         ),
       ),
     );
@@ -138,19 +97,41 @@ class _VideoEpisodePanelState extends State<VideoEpisodePanel> {
   Widget _buildHeader(ColorScheme cs) {
     final double iconSize = widget.fontSize + 4;
     return Padding(
-      padding: const EdgeInsets.only(left: 16, right: 4, top: 4, bottom: 6),
+      padding: const EdgeInsetsDirectional.only(
+        start: 20,
+        end: 8,
+        top: 12,
+        bottom: 10,
+      ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
           Expanded(
-            child: Text(
-              widget.title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: cs.onSurface,
-                fontSize: widget.fontSize + 1,
-                fontWeight: FontWeight.w600,
-              ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  widget.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: cs.onSurface,
+                    fontSize: widget.fontSize + 2,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                if (widget.currentIndex >= 0 &&
+                    widget.currentIndex < widget.episodes.length)
+                  Text(
+                    widget.episodes[widget.currentIndex].title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      color: cs.onSurfaceVariant,
+                      fontSize: widget.fontSize - 1,
+                    ),
+                  ),
+              ],
             ),
           ),
           IconButton(
@@ -181,86 +162,20 @@ class _VideoEpisodePanelState extends State<VideoEpisodePanel> {
     );
   }
 
-  Widget _buildList(ColorScheme cs) {
-    return ListView.builder(
-      controller: _autoScroller.controller,
-      padding: const EdgeInsets.symmetric(vertical: 8),
-      itemCount: widget.episodes.length,
-      itemBuilder: (BuildContext _, int i) {
-        final VideoEpisodeEntry entry = widget.episodes[i];
-        final String episodeTitle = entry.title;
-        final bool selected = i == widget.currentIndex;
-        // 序号/播放标记 + 封面缩略图。封面缺失（旧单行 playlist 远端模型不下发
-        // 封面、或本集确实没图）时**不占位撑宽**，退回原来的纯序号形态——列表
-        // 宽度只有 240~420，给一列空占位会白吃走标题的横向空间。
-        final Widget indicator = selected
-            ? Icon(Icons.play_arrow, color: cs.primary)
-            : SizedBox(
-                // 序号列宽随字号缩放（对齐 TODO-567 字幕时间戳列范式）：固定 24px
-                // 在放大字号下放不下两位数序号（tabular figures，10 起约字号×1.2），
-                // Text 默认换行被 dense ListTile 行高纵向裁切。改为 `字号 + 12` 估宽
-                // 留余量，下界 24 保证窄字号像素不变（向后兼容）。配合 Text 单行不
-                // 换行（`maxLines:1` / `softWrap:false`），序号永不溢出 / 被裁。
-                width: math.max(24.0, widget.fontSize + 12),
-                child: Text(
-                  '${i + 1}',
-                  textAlign: TextAlign.center,
-                  maxLines: 1,
-                  softWrap: false,
-                  style: TextStyle(
-                    color: cs.onSurfaceVariant,
-                    fontSize: widget.fontSize,
-                    fontFeatures: const <FontFeature>[
-                      FontFeature.tabularFigures(),
-                    ],
-                  ),
-                ),
-              );
-        final ImageProvider? cover = entry.cover;
-        return ListTile(
-          dense: true,
-          leading: cover == null
-              ? indicator
-              : Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: <Widget>[
-                    indicator,
-                    const SizedBox(width: 8),
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(4),
-                      child: SizedBox(
-                        // 16:9 小图：视频封面现状是抽帧横图，按横版给位不裁脸。
-                        width: 56,
-                        height: 32,
-                        child: Image(
-                          image: cover,
-                          fit: BoxFit.cover,
-                          // 文件缺失 / 解码失败 / 远端拉不到 → 退占位图标，不炸列表。
-                          errorBuilder: (_, __, ___) => Icon(
-                            Icons.movie_outlined,
-                            size: 18,
-                            color: cs.onSurfaceVariant,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-          title: Text(
-            episodeTitle,
-            maxLines: 2,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: selected ? cs.primary : cs.onSurface,
-              fontSize: widget.fontSize,
-              fontWeight: selected ? FontWeight.w600 : null,
-            ),
-          ),
-          selected: selected,
-          selectedColor: cs.primary,
-          onTap: () => widget.onTapEpisode(i),
-        );
-      },
+  Widget _buildRail(ColorScheme cs) {
+    final double scale = (widget.fontSize / 14).clamp(0.9, 1.35);
+    final double cardWidth = (184 * scale).clamp(160, 232);
+    return Align(
+      alignment: AlignmentDirectional.centerStart,
+      child: VideoEpisodeRail(
+        episodes: widget.episodes,
+        currentIndex: widget.currentIndex,
+        onTapEpisode: widget.onTapEpisode,
+        colorScheme: cs,
+        fontSize: widget.fontSize,
+        cardWidth: cardWidth,
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+      ),
     );
   }
 }

--- a/hibiki/lib/src/media/video/video_episode_rail.dart
+++ b/hibiki/lib/src/media/video/video_episode_rail.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/material.dart';
+import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
+
+/// 横向剧集轨道的一条展示数据。
+///
+/// 页面层负责把本地 / 互联数据解析成统一的 [ImageProvider]；轨道只负责展示，
+/// 不知道文件路径、URL 或缓存细节。
+class VideoEpisodeEntry {
+  const VideoEpisodeEntry({
+    required this.title,
+    this.cover,
+    this.completed = false,
+    this.started = false,
+  });
+
+  final String title;
+  final ImageProvider? cover;
+  final bool completed;
+  final bool started;
+}
+
+/// Jellyfin 式横向剧集轨道：16:9 画面卡、集号、标题与当前集状态共用一条视觉轴。
+///
+/// 播放器和合集详情页共用本组件，避免两处再次分叉成不同的封面、选中态和缺图逻辑。
+class VideoEpisodeRail extends StatefulWidget {
+  const VideoEpisodeRail({
+    super.key,
+    required this.episodes,
+    required this.currentIndex,
+    required this.onTapEpisode,
+    required this.colorScheme,
+    this.fontSize = 14,
+    this.cardWidth = 184,
+    this.padding = const EdgeInsets.symmetric(horizontal: 20),
+  });
+
+  final List<VideoEpisodeEntry> episodes;
+  final int currentIndex;
+  final ValueChanged<int> onTapEpisode;
+  final ColorScheme colorScheme;
+  final double fontSize;
+  final double cardWidth;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  State<VideoEpisodeRail> createState() => _VideoEpisodeRailState();
+}
+
+class _VideoEpisodeRailState extends State<VideoEpisodeRail> {
+  static const double _gap = 12;
+  final ScrollController _controller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _revealCurrent());
+  }
+
+  @override
+  void didUpdateWidget(covariant VideoEpisodeRail oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.currentIndex != widget.currentIndex ||
+        oldWidget.episodes.length != widget.episodes.length) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _revealCurrent());
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _revealCurrent() {
+    if (!mounted ||
+        !_controller.hasClients ||
+        widget.currentIndex < 0 ||
+        widget.currentIndex >= widget.episodes.length) {
+      return;
+    }
+    final ScrollPosition position = _controller.position;
+    final double itemExtent = widget.cardWidth + _gap;
+    final double target =
+        (widget.currentIndex * itemExtent - position.viewportDimension * 0.18)
+            .clamp(0.0, position.maxScrollExtent);
+    if ((position.pixels - target).abs() < 1) return;
+    _controller.animateTo(
+      target,
+      duration: const Duration(milliseconds: 280),
+      curve: Curves.easeOutCubic,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final double cardHeight = widget.cardWidth * 9 / 16;
+    return SizedBox(
+      height: cardHeight,
+      child: ListView.separated(
+        controller: _controller,
+        scrollDirection: Axis.horizontal,
+        padding: widget.padding,
+        itemCount: widget.episodes.length,
+        separatorBuilder: (_, __) => const SizedBox(width: _gap),
+        itemBuilder: (BuildContext context, int index) => _EpisodeRailCard(
+          key: ValueKey<String>('video-episode-card-$index'),
+          entry: widget.episodes[index],
+          index: index,
+          selected: index == widget.currentIndex,
+          width: widget.cardWidth,
+          fontSize: widget.fontSize,
+          colorScheme: widget.colorScheme,
+          onTap: () => widget.onTapEpisode(index),
+        ),
+      ),
+    );
+  }
+}
+
+class _EpisodeRailCard extends StatelessWidget {
+  const _EpisodeRailCard({
+    super.key,
+    required this.entry,
+    required this.index,
+    required this.selected,
+    required this.width,
+    required this.fontSize,
+    required this.colorScheme,
+    required this.onTap,
+  });
+
+  final VideoEpisodeEntry entry;
+  final int index;
+  final bool selected;
+  final double width;
+  final double fontSize;
+  final ColorScheme colorScheme;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    const BorderRadius radius = HibikiBorderRadius.card;
+    final Color borderColor =
+        selected ? colorScheme.primary : Colors.white.withValues(alpha: 0.14);
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: '${index + 1}. ${entry.title}',
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOutCubic,
+        width: width,
+        decoration: BoxDecoration(
+          borderRadius: radius,
+          border: Border.all(
+            color: borderColor,
+            width: selected ? 2 : 1,
+          ),
+          boxShadow: selected
+              ? <BoxShadow>[
+                  BoxShadow(
+                    color: colorScheme.primary.withValues(alpha: 0.24),
+                    blurRadius: 14,
+                    spreadRadius: 1,
+                  ),
+                ]
+              : null,
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Material(
+          color: colorScheme.surfaceContainerHighest,
+          child: InkWell(
+            canRequestFocus: true,
+            onTap: onTap,
+            child: Stack(
+              fit: StackFit.expand,
+              children: <Widget>[
+                _EpisodeCover(entry: entry, colorScheme: colorScheme),
+                const DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                      stops: <double>[0.35, 1],
+                      colors: <Color>[Colors.transparent, Color(0xE6000000)],
+                    ),
+                  ),
+                ),
+                PositionedDirectional(
+                  start: 10,
+                  end: 10,
+                  bottom: 9,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: <Widget>[
+                      if (selected)
+                        Padding(
+                          padding: const EdgeInsetsDirectional.only(end: 6),
+                          child: Icon(
+                            Icons.play_arrow_rounded,
+                            size: fontSize + 5,
+                            color: Colors.white,
+                          ),
+                        )
+                      else
+                        Padding(
+                          padding: const EdgeInsetsDirectional.only(end: 7),
+                          child: Text(
+                            '${index + 1}'.padLeft(2, '0'),
+                            maxLines: 1,
+                            softWrap: false,
+                            style: TextStyle(
+                              color: Colors.white.withValues(alpha: 0.88),
+                              fontSize: fontSize,
+                              fontWeight: FontWeight.w700,
+                              fontFeatures: const <FontFeature>[
+                                FontFeature.tabularFigures(),
+                              ],
+                            ),
+                          ),
+                        ),
+                      Expanded(
+                        child: Text(
+                          entry.title,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: fontSize,
+                            height: 1.15,
+                            fontWeight:
+                                selected ? FontWeight.w700 : FontWeight.w600,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (entry.completed || entry.started)
+                  PositionedDirectional(
+                    top: 8,
+                    end: 8,
+                    child: Container(
+                      padding: const EdgeInsets.all(4),
+                      decoration: BoxDecoration(
+                        color: const Color(0xB8000000),
+                        borderRadius: BorderRadius.circular(99),
+                      ),
+                      child: Icon(
+                        entry.completed
+                            ? Icons.check_rounded
+                            : Icons.play_arrow_rounded,
+                        size: 15,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EpisodeCover extends StatelessWidget {
+  const _EpisodeCover({required this.entry, required this.colorScheme});
+
+  final VideoEpisodeEntry entry;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    final ImageProvider? cover = entry.cover;
+    if (cover == null) return _placeholder();
+    return Image(
+      image: cover,
+      fit: BoxFit.cover,
+      errorBuilder: (_, __, ___) => _placeholder(),
+    );
+  }
+
+  Widget _placeholder() => ColoredBox(
+        color: colorScheme.surfaceContainerHighest,
+        child: Center(
+          child: Icon(
+            Icons.movie_outlined,
+            size: 30,
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+      );
+}

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
@@ -7,6 +5,8 @@ import 'package:hibiki/src/focus/hibiki_focus_target.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_one_key_sort.dart'
     show CollectionSortMeta, compareCollectionMembers;
+import 'package:hibiki/src/media/media_cover_source.dart';
+import 'package:hibiki/src/media/video/video_episode_rail.dart';
 import 'package:hibiki/src/pages/implementations/collection_detail_shared.dart';
 import 'package:hibiki/src/pages/implementations/jimaku_batch_dialog.dart';
 import 'package:hibiki/utils.dart';
@@ -55,6 +55,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   late String _name;
   List<VideoBookRow> _members = const <VideoBookRow>[];
   bool _loading = true;
+  bool _showAllEpisodes = false;
 
   @override
   HibikiDatabase get detailDatabase => widget.database;
@@ -90,6 +91,51 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
             completed: r.completedAt != null,
           ),
       ]);
+
+  int get _watchedCount =>
+      _members.where((VideoBookRow row) => row.completedAt != null).length;
+
+  List<VideoEpisodeEntry> get _episodeEntries => <VideoEpisodeEntry>[
+        for (final VideoBookRow row in _members)
+          VideoEpisodeEntry(
+            title: row.title,
+            cover: resolveMediaCoverImage(
+              kind: MediaKind.video,
+              localPath: row.coverPath,
+            ),
+            completed: row.completedAt != null,
+            started: row.lastPositionMs > 0 && row.completedAt == null,
+          ),
+      ];
+
+  ImageProvider? get _heroCover {
+    final String? collectionCover = widget.collection.coverPath;
+    if (collectionCover != null && collectionCover.isNotEmpty) {
+      return resolveMediaCoverImage(
+        kind: MediaKind.video,
+        localPath: collectionCover,
+        decodeWidth: 1600,
+      );
+    }
+    if (_members.isEmpty) return null;
+    final String? continueCover = _members[_continueIndex].coverPath;
+    String? fallbackCover =
+        continueCover?.isNotEmpty == true ? continueCover : null;
+    if (fallbackCover == null) {
+      for (final VideoBookRow row in _members) {
+        final String? candidate = row.coverPath;
+        if (candidate != null && candidate.isNotEmpty) {
+          fallbackCover = candidate;
+          break;
+        }
+      }
+    }
+    return resolveMediaCoverImage(
+      kind: MediaKind.video,
+      localPath: fallbackCover,
+      decodeWidth: 1600,
+    );
+  }
 
   /// 把当前 [_members] 顺序一次落盘（sortIndex 全表回写）。库页合集行与播放器
   /// 换集读同一 `getCollectionItems`，落盘即三处同序（层次 C 单一真相源）。
@@ -228,12 +274,15 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   Widget _episodeThumb(VideoBookRow ep, ColorScheme cs) {
     const double w = 96;
     const double h = 54;
-    final String? cover = ep.coverPath;
-    if (cover != null && cover.isNotEmpty && File(cover).existsSync()) {
+    final ImageProvider? cover = resolveMediaCoverImage(
+      kind: MediaKind.video,
+      localPath: ep.coverPath,
+    );
+    if (cover != null) {
       return ClipRRect(
-        borderRadius: BorderRadius.circular(4),
-        child: Image.file(
-          File(cover),
+        borderRadius: HibikiBorderRadius.card,
+        child: Image(
+          image: cover,
           width: w,
           height: h,
           fit: BoxFit.cover,
@@ -251,49 +300,359 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         height: h,
         decoration: BoxDecoration(
           color: cs.surfaceContainerHighest,
-          borderRadius: BorderRadius.circular(4),
+          borderRadius: HibikiBorderRadius.card,
         ),
         child: Icon(Icons.movie_outlined, color: cs.onSurfaceVariant, size: 20),
       );
 
+  Widget _buildHero(
+    BuildContext context,
+    ColorScheme cs,
+    HibikiDesignTokens tokens,
+  ) {
+    final Size screen = MediaQuery.sizeOf(context);
+    final double height = (screen.height * 0.62).clamp(400.0, 600.0);
+    final ImageProvider? cover = _heroCover;
+    final VideoBookRow episode = _members[_continueIndex];
+    final bool rtl = Directionality.of(context) == TextDirection.rtl;
+    return SizedBox(
+      height: height,
+      child: Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          ColoredBox(color: cs.surfaceContainerHighest),
+          if (cover != null)
+            Image(
+              image: cover,
+              fit: BoxFit.cover,
+              alignment: Alignment.center,
+              errorBuilder: (_, __, ___) =>
+                  ColoredBox(color: cs.surfaceContainerHighest),
+            ),
+          const DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                stops: <double>[0, 0.48, 1],
+                colors: <Color>[
+                  Color(0x52000000),
+                  Color(0x22000000),
+                  Color(0xE8000000),
+                ],
+              ),
+            ),
+          ),
+          DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: rtl ? Alignment.centerRight : Alignment.centerLeft,
+                end: rtl ? Alignment.centerLeft : Alignment.centerRight,
+                stops: const <double>[0, 0.66, 1],
+                colors: const <Color>[
+                  Color(0xC9000000),
+                  Color(0x26000000),
+                  Color(0x7A000000),
+                ],
+              ),
+            ),
+          ),
+          SafeArea(
+            bottom: false,
+            child: Padding(
+              padding: EdgeInsets.fromLTRB(
+                tokens.spacing.page,
+                kToolbarHeight + tokens.spacing.gap,
+                tokens.spacing.page,
+                tokens.spacing.section,
+              ),
+              child: Align(
+                alignment: AlignmentDirectional.bottomStart,
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 680),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        _name,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style:
+                            Theme.of(context).textTheme.displaySmall?.copyWith(
+                                  color: Colors.white,
+                                  fontWeight: FontWeight.w700,
+                                  height: 1.08,
+                                ),
+                      ),
+                      SizedBox(height: tokens.spacing.gap),
+                      Text(
+                        t.collection_watched_progress(
+                          done: _watchedCount,
+                          total: _members.length,
+                        ),
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: Colors.white.withValues(alpha: 0.78),
+                              fontWeight: FontWeight.w500,
+                            ),
+                      ),
+                      SizedBox(height: tokens.spacing.card),
+                      Text(
+                        t.collection_continue_progress(n: _continueIndex + 1),
+                        style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                              color: Colors.white.withValues(alpha: 0.82),
+                              fontWeight: FontWeight.w700,
+                            ),
+                      ),
+                      SizedBox(height: tokens.spacing.gap / 2),
+                      Text(
+                        episode.title,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                      SizedBox(height: tokens.spacing.card),
+                      FilledButton.icon(
+                        icon: const Icon(Icons.play_arrow_rounded),
+                        label: Text(t.collection_play),
+                        onPressed: () => widget.onOpenEpisode(episode),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEpisodeSection(
+    BuildContext context,
+    ColorScheme cs,
+    HibikiDesignTokens tokens,
+  ) {
+    return Padding(
+      padding: EdgeInsets.only(
+        top: tokens.spacing.section,
+        bottom: tokens.spacing.section,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Padding(
+            padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
+            child: Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    t.video_episode_list,
+                    style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w700,
+                        ),
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: () =>
+                      setState(() => _showAllEpisodes = !_showAllEpisodes),
+                  icon: Icon(
+                    _showAllEpisodes
+                        ? Icons.keyboard_arrow_up
+                        : Icons.view_list_outlined,
+                  ),
+                  label: Text(
+                    _showAllEpisodes
+                        ? t.collection_collapse
+                        : t.collection_view_all,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          SizedBox(height: tokens.spacing.rowVertical),
+          VideoEpisodeRail(
+            key: const ValueKey<String>('collection-episode-rail'),
+            episodes: _episodeEntries,
+            currentIndex: _continueIndex,
+            onTapEpisode: (int index) => widget.onOpenEpisode(_members[index]),
+            colorScheme: cs,
+            fontSize: 14,
+            cardWidth:
+                (MediaQuery.sizeOf(context).width * 0.24).clamp(168.0, 232.0),
+            padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
+          ),
+          AnimatedSwitcher(
+            duration: const Duration(milliseconds: 220),
+            switchInCurve: Curves.easeOutCubic,
+            switchOutCurve: Curves.easeOut,
+            child: _showAllEpisodes
+                ? Padding(
+                    key: const ValueKey<String>('episode-management-list'),
+                    padding: EdgeInsets.fromLTRB(
+                      tokens.spacing.page,
+                      tokens.spacing.section,
+                      tokens.spacing.page,
+                      0,
+                    ),
+                    child: _buildEpisodeManagementList(cs, tokens),
+                  )
+                : const SizedBox.shrink(
+                    key: ValueKey<String>('episode-management-collapsed'),
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEpisodeManagementList(
+    ColorScheme cs,
+    HibikiDesignTokens tokens,
+  ) {
+    return HibikiReorderableColumn(
+      itemCount: _members.length,
+      keyForIndex: (int i) => ValueKey<String>(_members[i].bookUid),
+      onReorder: _onReorder,
+      spacing: tokens.spacing.gap,
+      itemBuilder: (BuildContext context, int i) {
+        final VideoBookRow episode = _members[i];
+        final bool completed = episode.completedAt != null;
+        final bool started = episode.lastPositionMs > 0;
+        final bool isContinue = i == _continueIndex;
+        final Widget row = Material(
+          key: ValueKey<String>('collection-episode-row-${episode.bookUid}'),
+          color: isContinue
+              ? cs.primaryContainer.withValues(alpha: 0.35)
+              : cs.surfaceContainerLow,
+          borderRadius: HibikiBorderRadius.card,
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            canRequestFocus: false,
+            onTap: () => widget.onOpenEpisode(episode),
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: tokens.spacing.rowHorizontal,
+                vertical: tokens.spacing.rowVertical,
+              ),
+              child: Row(
+                children: <Widget>[
+                  SizedBox(
+                    width: tokens.spacing.gap * 4,
+                    child: Text(
+                      '${i + 1}',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: cs.onSurfaceVariant),
+                    ),
+                  ),
+                  SizedBox(width: tokens.spacing.rowVertical),
+                  _episodeThumb(episode, cs),
+                  SizedBox(width: tokens.spacing.rowVertical),
+                  Expanded(
+                    child: Text(
+                      episode.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                  if (completed)
+                    Icon(Icons.check_circle, color: cs.primary, size: 20)
+                  else if (started)
+                    Icon(
+                      Icons.play_circle_outline,
+                      color: cs.onSurfaceVariant,
+                      size: 20,
+                    ),
+                  SizedBox(width: tokens.spacing.gap / 2),
+                  HibikiIconButton(
+                    tooltip: t.collection_remove_member,
+                    icon: Icons.remove_circle_outline,
+                    size: 18,
+                    onTap: () => _removeEpisode(episode),
+                  ),
+                  SizedBox(width: tokens.spacing.gap / 2),
+                  Icon(
+                    Icons.drag_handle,
+                    color: cs.onSurfaceVariant,
+                    size: 20,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        if (HibikiFocusRoot.maybeControllerOf(context) == null) return row;
+        return Actions(
+          actions: <Type, Action<Intent>>{
+            ActivateIntent: CallbackAction<ActivateIntent>(
+              onInvoke: (_) {
+                widget.onOpenEpisode(episode);
+                return null;
+              },
+            ),
+          },
+          child: HibikiFocusTarget(
+            id: HibikiFocusId('collection-episode-${episode.bookUid}'),
+            child: row,
+          ),
+        );
+      },
+    );
+  }
+
   /// [availableWidth] 是这条 AppBar 实际拿到的约束宽（由 [LayoutBuilder] 下发）。
-  AppBar _buildAppBar(double availableWidth) => AppBar(
-        title: Text(_name, maxLines: 1, overflow: TextOverflow.ellipsis),
-        // BUG-1184：5 个动作 + 返回键在 320dp 上吃掉约 296px，合集名只剩二十几像素、
-        // 等于完全看不见。窄屏把后 4 个收进溢出菜单，排序保持一眼可点。
-        actions: narrowAwareAppBarActions(
-          availableWidth: availableWidth,
-          alwaysVisible: <Widget>[_buildSortMenu()],
-          collapsible: <HibikiAppBarAction>[
-            HibikiAppBarAction(
-              icon: Icons.subtitles_outlined,
-              label: t.video_jimaku_batch_title,
-              onPressed: _members.isEmpty ? null : _fetchCollectionSubtitles,
-            ),
-            HibikiAppBarAction(
-              icon: Icons.drive_file_rename_outline,
-              label: t.rename_collection,
-              onPressed: renameDetailCollection,
-            ),
-            HibikiAppBarAction(
-              icon: Icons.sell_outlined,
-              label: t.tag_label,
-              onPressed: editDetailCollectionTags,
-            ),
-            HibikiAppBarAction(
-              icon: Icons.delete_outline,
-              label: t.delete_collection,
-              onPressed: _delete,
-            ),
-          ],
-        ),
-      );
+  AppBar _buildAppBar(double availableWidth) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    final bool cinematic = !_loading && _members.isNotEmpty;
+    return AppBar(
+      title: cinematic
+          ? null
+          : Text(_name, maxLines: 1, overflow: TextOverflow.ellipsis),
+      backgroundColor: cinematic ? const Color(0x42000000) : cs.surface,
+      foregroundColor: cinematic ? Colors.white : cs.onSurface,
+      surfaceTintColor: Colors.transparent,
+      elevation: 0,
+      // BUG-1184：5 个动作 + 返回键在 320dp 上吃掉约 296px，合集名只剩二十几像素、
+      // 等于完全看不见。窄屏把后 4 个收进溢出菜单，排序保持一眼可点。
+      actions: narrowAwareAppBarActions(
+        availableWidth: availableWidth,
+        alwaysVisible: <Widget>[_buildSortMenu()],
+        collapsible: <HibikiAppBarAction>[
+          HibikiAppBarAction(
+            icon: Icons.subtitles_outlined,
+            label: t.video_jimaku_batch_title,
+            onPressed: _members.isEmpty ? null : _fetchCollectionSubtitles,
+          ),
+          HibikiAppBarAction(
+            icon: Icons.drive_file_rename_outline,
+            label: t.rename_collection,
+            onPressed: renameDetailCollection,
+          ),
+          HibikiAppBarAction(
+            icon: Icons.sell_outlined,
+            label: t.tag_label,
+            onPressed: editDetailCollectionTags,
+          ),
+          HibikiAppBarAction(
+            icon: Icons.delete_outline,
+            label: t.delete_collection,
+            onPressed: _delete,
+          ),
+        ],
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
     final ColorScheme cs = Theme.of(context).colorScheme;
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final bool cinematic = !_loading && _members.isNotEmpty;
     return Scaffold(
+      extendBodyBehindAppBar: cinematic,
       // BUG-1186：动作要不要折叠，得看这条 AppBar 自己拿到多宽，而不是整窗多宽。
       // 包一层 [LayoutBuilder] 把局部约束喂给 [narrowAwareAppBarActions]；高度就是
       // [AppBar] 无 bottom 时的默认 preferredSize（kToolbarHeight），Scaffold 仍会
@@ -305,150 +664,34 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
               _buildAppBar(constraints.maxWidth),
         ),
       ),
-      body: SafeArea(
-        child: _loading
-            ? Center(child: adaptiveIndicator(context: context))
-            : _members.isEmpty
-                ? HibikiPlaceholderMessage(
+      body: _loading
+          ? SafeArea(
+              child: Center(child: adaptiveIndicator(context: context)),
+            )
+          : _members.isEmpty
+              ? SafeArea(
+                  child: HibikiPlaceholderMessage(
                     icon: Icons.collections_bookmark_outlined,
                     message: t.collection_empty,
-                  )
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.stretch,
-                    children: <Widget>[
-                      buildDetailTagChips(),
-                      Padding(
-                        padding: EdgeInsets.all(tokens.spacing.rowVertical),
-                        child: Align(
-                          alignment: AlignmentDirectional.centerStart,
-                          child: FilledButton.icon(
-                            icon: const Icon(Icons.play_arrow),
-                            label: Text(t.collection_play),
-                            onPressed: () =>
-                                widget.onOpenEpisode(_members[_continueIndex]),
-                          ),
-                        ),
-                      ),
-                      const Divider(height: 1),
-                      Expanded(
-                        // 排序交互重设计层次 B1：拖拽精修。BUG-778：SDK 的
-                        // ReorderableListView 拖拽代理用「全局坐标−overlay 原点」
-                        // 纯平移，不认祖先 Transform.scale（HibikiAppUiScale 的
-                        // 浏览器式整体缩放）——界面大小≠100% 时拖动位置按
-                        // (1−s)×距离 漂移。换自实现的 HibikiReorderableColumn
-                        // （浮层渲染在列表自身 Stack、指针经 globalToLocal 消
-                        // 祖先缩放，词典排序/媒体源排序同款）。整行拖拽：鼠标
-                        // 按下即拖、触摸长按；行尾拖柄图标保留为视觉提示。
-                        // onReorder 落盘 sortIndex 后库页行/播放器换集立即同序。
-                        child: SingleChildScrollView(
-                          child: HibikiReorderableColumn(
-                            itemCount: _members.length,
-                            keyForIndex: (int i) =>
-                                ValueKey<String>(_members[i].bookUid),
-                            onReorder: _onReorder,
-                            itemBuilder: (BuildContext _, int i) {
-                              final VideoBookRow ep = _members[i];
-                              final bool completed = ep.completedAt != null;
-                              final bool started = ep.lastPositionMs > 0;
-                              final bool isContinue = i == _continueIndex;
-                              // 用 InkWell+Row（非 ListTile）保持 MD3 设计系统一致；
-                              // VideoBooks 不存总时长无法算集内百分比 → 只标「已看完 /
-                              // 看过一半 / 未看」三态图标，不画误导性进度条。
-                              final Widget row = Material(
-                                color: isContinue
-                                    ? cs.primaryContainer
-                                        .withValues(alpha: 0.35)
-                                    : Colors.transparent,
-                                child: InkWell(
-                                  canRequestFocus: false,
-                                  onTap: () => widget.onOpenEpisode(ep),
-                                  child: Padding(
-                                    padding: EdgeInsets.symmetric(
-                                      horizontal: tokens.spacing.rowHorizontal,
-                                      vertical: tokens.spacing.rowVertical,
-                                    ),
-                                    child: Row(
-                                      children: <Widget>[
-                                        SizedBox(
-                                          width: tokens.spacing.gap * 4,
-                                          child: Text(
-                                            '${i + 1}',
-                                            textAlign: TextAlign.center,
-                                            style: TextStyle(
-                                                color: cs.onSurfaceVariant),
-                                          ),
-                                        ),
-                                        SizedBox(
-                                            width: tokens.spacing.rowVertical),
-                                        // Jellyfin 式：每集独立视频各自的封面缩略图（16:9
-                                        // 抽帧；无封面时占位）。
-                                        _episodeThumb(ep, cs),
-                                        SizedBox(
-                                            width: tokens.spacing.rowVertical),
-                                        Expanded(
-                                          child: Text(
-                                            ep.title,
-                                            maxLines: 2,
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                        ),
-                                        if (completed)
-                                          Icon(Icons.check_circle,
-                                              color: cs.primary, size: 20)
-                                        else if (started)
-                                          Icon(Icons.play_circle_outline,
-                                              color: cs.onSurfaceVariant,
-                                              size: 20),
-                                        SizedBox(width: tokens.spacing.gap / 2),
-                                        // 逐集移出（整理页删除后的唯一入口）。
-                                        HibikiIconButton(
-                                          tooltip: t.collection_remove_member,
-                                          icon: Icons.remove_circle_outline,
-                                          size: 18,
-                                          onTap: () => _removeEpisode(ep),
-                                        ),
-                                        SizedBox(width: tokens.spacing.gap / 2),
-                                        // 拖柄图标：纯视觉提示（整行可拖，见类注释）。
-                                        Icon(
-                                          Icons.drag_handle,
-                                          color: cs.onSurfaceVariant,
-                                          size: 20,
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                              );
-                              // 巡检 PR-3：剧集行接入手柄/键盘方向焦点（裸 InkWell
-                              // 不进 Hibiki 焦点系统，手柄用户到不了任何一集）。
-                              // Enter / 手柄 A 与鼠标点击同路径开该集。
-                              if (HibikiFocusRoot.maybeControllerOf(context) ==
-                                  null) {
-                                return row;
-                              }
-                              return Actions(
-                                actions: <Type, Action<Intent>>{
-                                  ActivateIntent:
-                                      CallbackAction<ActivateIntent>(
-                                    onInvoke: (_) {
-                                      widget.onOpenEpisode(ep);
-                                      return null;
-                                    },
-                                  ),
-                                },
-                                child: HibikiFocusTarget(
-                                  id: HibikiFocusId(
-                                      'collection-episode-${ep.bookUid}'),
-                                  child: row,
-                                ),
-                              );
-                            },
-                          ),
-                        ),
-                      ),
-                    ],
                   ),
-      ),
+                )
+              : CustomScrollView(
+                  slivers: <Widget>[
+                    SliverToBoxAdapter(
+                      child: _buildHero(context, cs, tokens),
+                    ),
+                    SliverToBoxAdapter(child: buildDetailTagChips()),
+                    SliverToBoxAdapter(
+                      child: _buildEpisodeSection(context, cs, tokens),
+                    ),
+                    SliverSafeArea(
+                      top: false,
+                      sliver: SliverToBoxAdapter(
+                        child: SizedBox(height: tokens.spacing.page),
+                      ),
+                    ),
+                  ],
+                ),
     );
   }
 }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/controls_visibility.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/controls_visibility.part.dart
@@ -122,7 +122,7 @@ extension _VideoControlsVisibility on _VideoHibikiPageState {
     // BUG-371：[_subtitleListVisible] 不再纳入门控——字幕跳转列表是 push-aside 侧栏
     // （把画面挤窄到左侧、不遮控制条），开列表时控制条应继续在被挤窄的画面上可见可用，
     // 不像真 overlay（[_videoSidePanel]）那样盖住控制条需强制隐藏。仅沉浸锁 / 真 overlay
-    // 面板 / 剧集列表（其 push-aside 但仍占右栏）/ 编辑态压制。
+    // 面板 / 剧集横向轨道 / 编辑态压制。
     final bool gated = _immersiveLocked.value ||
         _videoSidePanel.value != null ||
         _episodeListVisible.value ||
@@ -279,8 +279,8 @@ extension _VideoControlsVisibility on _VideoHibikiPageState {
     );
   }
 
-  /// 给 push-aside 侧栏兄弟列（字幕列表 [_subtitleJumpSidePanel] / 选集列表
-  /// [_episodeSidePanel]）包一层**声明式** `MouseRegion(opaque: true, cursor: basic)`
+  /// 给视频旁的浏览表面（字幕列表 [_subtitleJumpSidePanel] / 选集横向轨道
+  /// [_episodeOverlayPanel]）包一层**声明式** `MouseRegion(opaque: true, cursor: basic)`
   /// 外层——BUG-391 r5 的**根因修**（不是前几轮的救场 onEnter 直发）。
   ///
   /// 根因机理：侧栏是 [_videoWithSubtitlePanel] 的 Row 兄弟列，几何上不在视频列那条

--- a/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
@@ -1,7 +1,7 @@
 // GENERATED-NOTE: extracted from video_hibiki_page.dart (TODO-590 batch4).
 part of '../video_hibiki_page.dart';
 
-/// episode (剧集 push-aside 侧栏 + 自动连播倒计时) domain methods extracted via
+/// episode (剧集底部横向轨道 + 自动连播倒计时) domain methods extracted via
 /// part-of (TODO-590 batch4); shared private scope. Behaviour-preserving: bodies
 /// are verbatim copies — this domain references no `setState(` (so no `_rebuild(`
 /// forwarding). UI 巡检 PR-4 后 [_buildAutoAdvanceOverlay] 引用了一个 host
@@ -12,7 +12,7 @@ part of '../video_hibiki_page.dart';
 /// `_episodeListVisible` / `_autoAdvanceCountdownNotifier` notifiers, their
 /// timers/fields, and the `_episodes` / `_currentEpisode` playlist state stay in
 /// the main shell; the build-subtree parent `_videoWithSubtitlePanel` (subtitle
-/// domain) keeps calling the extracted `_episodeSidePanel` through shared private
+/// domain) keeps calling the extracted `_episodeOverlayPanel` through shared private
 /// scope.
 extension _VideoEpisode on _VideoHibikiPageState {
   void _handlePlaybackCompleted() {
@@ -158,26 +158,22 @@ extension _VideoEpisode on _VideoHibikiPageState {
     );
   }
 
-  /// 剧集列表入口（控制条剧集按钮）。TODO-638：从 `showModalBottomSheet`（底部弹层）
-  /// 改成与字幕列表同款的 push-aside 侧栏——翻转 [_toggleEpisodeList]，与其它侧栏视觉
-  /// 统一、不挡画面。保留方法名 `_showEpisodeList` 作为控制条入口（_handleVideoControlTap
-  /// 的 episodeList 分支调它），呈现改为侧栏 toggle。
+  /// 剧集列表入口（控制条剧集按钮）。保留 `_showEpisodeList` 作为控制条入口，
+  /// 呈现层由 [_episodeOverlayPanel] 在视频底部画非模态横向轨道。
   void _showEpisodeList() {
     _toggleEpisodeList();
   }
 
-  /// 翻转剧集列表 push-aside 侧栏可见性（TODO-638；控制条剧集按钮入口）。
+  /// 翻转剧集横向轨道可见性（控制条剧集按钮入口）。
   ///
-  /// 与字幕列表（[_toggleSubtitleJumpList]）同范式：push-aside 布局
-  /// （[_videoWithSubtitlePanel] / [_episodeListVisible]，`Row[Expanded(video), 面板列]`）
-  /// 真把画面挤窄到左侧、不浮层遮挡。与其它侧栏互斥：开剧集列表先关字幕列表
-  /// （[_subtitleListVisible]）与任何打开的浮层（[_videoSidePanel]）——同一时刻右栏只占
-  /// 其一，避免两个 push-aside 侧栏分占右栏。打开时唤醒控制条让用户看到入口。
+  /// 与字幕列表（[_toggleSubtitleJumpList]）保持互斥：开剧集轨道先关字幕列表
+  /// （[_subtitleListVisible]）与任何打开的浮层（[_videoSidePanel]），避免多个
+  /// 浏览/设置表面同时争抢视频空间。打开时唤醒控制条让用户看到入口。
   void _toggleEpisodeList() {
     final bool next = !_episodeListVisible.value;
     if (next) {
       _clearRailHover();
-      // 与浮层互斥：开 push-aside 剧集列表前关掉任何打开的浮层（设置/音轨/倍速等）。
+      // 与浮层互斥：开剧集轨道前关掉任何打开的浮层（设置/音轨/倍速等）。
       _hideVideoControlEditOverlay(revealControls: false);
       // 与字幕列表互斥：同一时刻右栏只占其一。
       if (_subtitleListVisible.value) {
@@ -194,7 +190,7 @@ extension _VideoEpisode on _VideoHibikiPageState {
     }
   }
 
-  /// 关闭 push-aside 剧集列表（TODO-638）。**三条关闭路径的单一真相源**：面板头部 ×
+  /// 关闭剧集轨道。**三条关闭路径的单一真相源**：面板头部 ×
   /// 按钮（[VideoEpisodePanel.onClose]）、Esc 键、控制条剧集按钮（后两者经
   /// [_toggleEpisodeList] 的关闭分支）都调它，避免「关闭副作用各写一份」分叉。关闭时
   /// 必须：隐藏列表（[_episodeListVisible]）、唤回控制条（[_pokeControlsVisible]）、把焦点
@@ -207,17 +203,13 @@ extension _VideoEpisode on _VideoHibikiPageState {
   }
 
   /// 点剧集列表里某集：切到该集（复用 [_switchEpisode]）。换集后保持列表常驻（用户可
-  /// 连续浏览/切集），与 asbplayer 风格的常驻侧栏一致；当前集高亮由面板按 currentIndex
+  /// 连续浏览/切集）；当前集高亮由面板按 currentIndex
   /// 自动跟随。
   void _handleEpisodeListTap(int index) {
     _pokeControlsVisible();
     _switchEpisode(index, intent: EpisodeStartIntent.listSelect);
   }
 
-  /// [_videoWithSubtitlePanel] 的剧集列表 push-aside 面板列（TODO-638）。与
-  /// [_subtitleJumpSidePanel] 同结构：[AnimatedSize] 让列宽在 0 ↔ panelWidth 平滑伸缩，
-  /// 可见时渲染 [VideoEpisodePanel]，隐藏时收成 0（[ClipRect] + [OverflowBox] 保证伸缩
-  /// 动画里内容布局稳定）。与字幕列表互斥，故两列同时只有一列非零宽。
   /// 把内部集表示 [_PlaylistEpisodeRef] 解析成面板要的 [VideoEpisodeEntry]。
   ///
   /// 封面来源判断**不在这里手写分支**——统一走 [resolveMediaCoverImage]：本地集给
@@ -242,48 +234,49 @@ extension _VideoEpisode on _VideoHibikiPageState {
     ];
   }
 
-  Widget _episodeSidePanel(bool visible) {
+  /// 剧集列表改为覆盖在**视频底部**的横向轨道：画面继续作为沉浸式背景，不把
+  /// 16:9 视频挤成窄栏。字幕跳转列表仍是 push-aside；两者沿用既有互斥状态。
+  ///
+  /// 隐藏态留在树里做 slide + fade，且 [IgnorePointer] 保证不可见层不吃画面点击。
+  /// × / Esc / 控制条按钮仍全部经 [_closeEpisodeList]，关闭副作用不分叉。
+  Widget _episodeOverlayPanel(bool visible) {
     final ColorScheme cs = _videoChromeColorScheme(context);
-    final double screenWidth = MediaQuery.sizeOf(context).width;
-    final double panelWidth = (screenWidth * 0.28).clamp(240.0, 420.0);
-    return AnimatedSize(
-      // eink 下归零（墨水屏残影，UI 巡检 PR-4）。
-      duration: einkSafeDuration(context, const Duration(milliseconds: 200)),
-      curve: Curves.easeOut,
-      alignment: Alignment.centerLeft,
-      child: SizedBox(
-        width: visible ? panelWidth : 0,
-        // BUG-391 r5 根因修：选集列表此前**完全无** cursor-reveal 覆盖（字幕列表有救场层但选集
-        // 列表裸奔），整列最外层补一层与字幕侧栏同款声明式 opaque MouseRegion（cursor:basic）——
-        // 让 MouseTracker 把侧栏列视为独立 annotation、鼠标进列即进干净 basic 会话，绕开「视频列
-        // none 会话残留 + lastSession 去重」竞态（见 _withSidePanelOpaqueCursor）。隐藏时透传
-        // SizedBox.shrink（零宽、无 region）。
-        child: visible
-            ? _withSidePanelOpaqueCursor(
-                ClipRect(
-                  child: OverflowBox(
-                    alignment: Alignment.centerLeft,
-                    minWidth: panelWidth,
-                    maxWidth: panelWidth,
-                    child: SafeArea(
-                      left: false,
-                      child: VideoEpisodePanel(
-                        key: const ValueKey<String>('video-episode-panel'),
-                        episodes: _episodePanelEntries(),
-                        currentIndex: _currentEpisode,
-                        onTapEpisode: _handleEpisodeListTap,
-                        onClose: _closeEpisodeList,
-                        colorScheme: cs,
-                        title: t.video_episode_list,
-                        emptyHint: t.video_episode_list_empty,
-                        fontSize: 14 * _videoUiScale,
-                        width: panelWidth,
-                      ),
-                    ),
-                  ),
+    final double panelHeight = (220 * _videoUiScale).clamp(200.0, 360.0);
+    final Duration duration =
+        einkSafeDuration(context, const Duration(milliseconds: 220));
+    return PositionedDirectional(
+      start: 0,
+      end: 0,
+      bottom: 0,
+      child: IgnorePointer(
+        ignoring: !visible,
+        child: AnimatedSlide(
+          offset: visible ? Offset.zero : const Offset(0, 0.18),
+          duration: duration,
+          curve: Curves.easeOutCubic,
+          child: AnimatedOpacity(
+            opacity: visible ? 1 : 0,
+            duration: duration,
+            curve: Curves.easeOut,
+            child: _withSidePanelOpaqueCursor(
+              SafeArea(
+                top: false,
+                child: VideoEpisodePanel(
+                  key: const ValueKey<String>('video-episode-panel'),
+                  episodes: _episodePanelEntries(),
+                  currentIndex: _currentEpisode,
+                  onTapEpisode: _handleEpisodeListTap,
+                  onClose: _closeEpisodeList,
+                  colorScheme: cs,
+                  title: t.video_episode_list,
+                  emptyHint: t.video_episode_list_empty,
+                  fontSize: 14 * _videoUiScale,
+                  height: panelHeight,
                 ),
-              )
-            : const SizedBox.shrink(),
+              ),
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
@@ -749,10 +749,9 @@ extension _VideoLayout on _VideoHibikiPageState {
     // 分支）。barrier 删除后列表锁定（TODO-611，原本
     // 唯一作用是把 barrier 门控成 no-op）失去意义，一并移除（TODO-634）。
     //
-    // TODO-638：剧集列表也是 push-aside 侧栏，与字幕列表共享同一右栏槽位（同时只一个
-    // 可见，互斥由 _toggleEpisodeList / _toggleSubtitleJumpList 保证）。Row 同时监听两个
-    // 可见性 notifier，渲染两列面板——隐藏的那列宽度收成 0（_subtitleJumpSidePanel /
-    // _episodeSidePanel 内部 AnimatedSize 处理伸缩），故画面只被当前打开的那个侧栏挤窄。
+    // TODO-638 后续视觉升级：字幕列表继续 push-aside；剧集列表改成视频底部的横向
+    // overlay rail（[_episodeOverlayPanel]），以画面本身作沉浸式背景。两者仍互斥，
+    // 所以剧集轨道出现时字幕侧栏宽度必为 0。
     return ListenableBuilder(
       listenable: Listenable.merge(
         <Listenable>[_subtitleListVisible, _episodeListVisible],
@@ -760,12 +759,17 @@ extension _VideoLayout on _VideoHibikiPageState {
       builder: (BuildContext _, __) {
         final bool visible = _subtitleListVisible.value;
         final bool episodeVisible = _episodeListVisible.value;
-        return Row(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
+        return Stack(
+          fit: StackFit.expand,
           children: <Widget>[
-            Expanded(child: video),
-            _subtitleJumpSidePanel(controller, visible),
-            _episodeSidePanel(episodeVisible),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Expanded(child: video),
+                _subtitleJumpSidePanel(controller, visible),
+              ],
+            ),
+            _episodeOverlayPanel(episodeVisible),
           ],
         );
       },

--- a/hibiki/test/media/video/video_episode_panel_test.dart
+++ b/hibiki/test/media/video/video_episode_panel_test.dart
@@ -32,16 +32,18 @@ void main() {
     ));
 
     expect(find.text('Episode 1'), findsOneWidget);
-    expect(find.text('Episode 2'), findsOneWidget);
+    // 当前集同时出现在面板摘要与自己的卡片中。
+    expect(find.text('Episode 2'), findsNWidgets(2));
     expect(find.text('Episode 3'), findsOneWidget);
 
-    await tester.tap(find.text('Episode 3'));
+    await tester
+        .tap(find.byKey(const ValueKey<String>('video-episode-card-2')));
     expect(tapped, <int>[2]);
   });
 
   testWidgets(
-      'highlights the current episode with a play_arrow leading icon '
-      '(TODO-638)', (WidgetTester tester) async {
+      'highlights the current episode card with a play icon and keeps '
+      'number labels on other cards', (WidgetTester tester) async {
     await tester.pumpWidget(wrap(
       VideoEpisodePanel(
         episodes: episodes(3),
@@ -54,26 +56,22 @@ void main() {
       ),
     ));
 
-    // 仅当前集（Episode 2, index 1）有 play_arrow leading 标记。
-    final Finder currentTile = find.ancestor(
-      of: find.text('Episode 2'),
-      matching: find.byType(ListTile),
-    );
+    final Finder currentCard =
+        find.byKey(const ValueKey<String>('video-episode-card-1'));
     expect(
-      find.descendant(of: currentTile, matching: find.byIcon(Icons.play_arrow)),
+      find.descendant(
+          of: currentCard, matching: find.byIcon(Icons.play_arrow_rounded)),
       findsOneWidget,
     );
-    final Finder otherTile = find.ancestor(
-      of: find.text('Episode 1'),
-      matching: find.byType(ListTile),
-    );
+    final Finder otherCard =
+        find.byKey(const ValueKey<String>('video-episode-card-0'));
     expect(
-      find.descendant(of: otherTile, matching: find.byIcon(Icons.play_arrow)),
+      find.descendant(
+          of: otherCard, matching: find.byIcon(Icons.play_arrow_rounded)),
       findsNothing,
     );
-    // 非当前集显示序号。
-    expect(find.text('1'), findsOneWidget);
-    expect(find.text('3'), findsOneWidget);
+    expect(find.text('01'), findsOneWidget);
+    expect(find.text('03'), findsOneWidget);
   });
 
   testWidgets('header × button reports onClose (TODO-638)',
@@ -114,13 +112,8 @@ void main() {
   });
 
   testWidgets(
-      'two-digit episode numbers stay single-line and visible at large font '
-      '(TODO-759)', (WidgetTester tester) async {
-    // 界面调大字号（appUiScale=3.0 → fontSize 14*3=42）下，两位数序号（tabular
-    // figures，宽于一位数）此前被固定 24px 的 leading SizedBox 逼着换行，dense
-    // ListTile 行高按 title 决定不随 leading 抬高，第二行被纵向裁切看不见。修复后
-    // 序号列宽随字号缩放且 Text 单行不换行：① 序号 Text 仍可见且单行 ② leading
-    // SizedBox 宽度 >= 阈值（不再固定 24）。
+      'two-digit episode numbers stay single-line in the horizontal rail at '
+      'large font', (WidgetTester tester) async {
     const double largeFontSize = 42; // 14 * appUiScale(3.0)
     await tester.pumpWidget(wrap(
       VideoEpisodePanel(
@@ -136,34 +129,22 @@ void main() {
     ));
     await tester.pumpAndSettle();
 
-    // ListView.builder 懒构建：大字号下后面的集可能在视口外未构建，先滚到序号「10」。
     final Finder tenText = find.text('10');
     await tester.scrollUntilVisible(tenText, 200,
         scrollable: find.byType(Scrollable));
     await tester.pumpAndSettle();
 
-    // 两位数序号「10」存在、可见、且单行（softWrap:false / maxLines:1）。
     expect(tenText, findsOneWidget);
     final Text tenWidget = tester.widget<Text>(tenText);
     expect(tenWidget.maxLines, 1);
     expect(tenWidget.softWrap, false);
 
-    // 序号未被纵向裁切：Text 的渲染高度约等于单行高度（< 1.6 行），不是两行。
     final Size tenSize = tester.getSize(tenText);
     expect(tenSize.height, lessThan(largeFontSize * 1.6),
         reason: 'episode number must render on a single line, not wrap');
-
-    // 序号 leading 列宽随字号放大到阈值以上（不再固定 24px）。
-    final Finder leadingBox = find.ancestor(
-      of: tenText,
-      matching: find.byType(SizedBox),
-    );
-    final SizedBox box = tester.widget<SizedBox>(leadingBox.first);
-    expect(box.width, isNotNull);
-    expect(box.width!, greaterThanOrEqualTo(largeFontSize + 12));
   });
 
-  testWidgets('renders an episode cover next to the indicator',
+  testWidgets('renders a cover as the full 16:9 episode card background',
       (WidgetTester tester) async {
     final MemoryImage cover = MemoryImage(kTransparentImage);
     await tester.pumpWidget(wrap(
@@ -178,14 +159,29 @@ void main() {
       ),
     ));
 
-    final Finder firstTile = find.ancestor(
-      of: find.text('Episode 1'),
-      matching: find.byType(ListTile),
-    );
+    final Finder firstCard =
+        find.byKey(const ValueKey<String>('video-episode-card-0'));
     final Finder image =
-        find.descendant(of: firstTile, matching: find.byType(Image));
+        find.descendant(of: firstCard, matching: find.byType(Image));
     expect(image, findsOneWidget);
     expect(tester.widget<Image>(image).image, same(cover));
-    expect(tester.getSize(image), const Size(56, 32));
+    expect(tester.getSize(firstCard).aspectRatio, closeTo(16 / 9, 0.01));
+  });
+
+  testWidgets('episode rail scrolls horizontally', (WidgetTester tester) async {
+    await tester.pumpWidget(wrap(
+      VideoEpisodePanel(
+        episodes: episodes(8),
+        currentIndex: 0,
+        onTapEpisode: (_) {},
+        onClose: () {},
+        colorScheme: const ColorScheme.light(),
+        title: 'Episodes',
+        emptyHint: 'No episodes',
+      ),
+    ));
+
+    final ListView list = tester.widget<ListView>(find.byType(ListView));
+    expect(list.scrollDirection, Axis.horizontal);
   });
 }

--- a/hibiki/test/pages/media_collection_detail_sort_test.dart
+++ b/hibiki/test/pages/media_collection_detail_sort_test.dart
@@ -71,7 +71,8 @@ void main() {
           it.entryKey,
       ];
 
-  Widget buildApp() => TranslationProvider(
+  Widget buildApp({ValueChanged<VideoBookRow>? onOpenEpisode}) =>
+      TranslationProvider(
         child: MaterialApp(
           home: MediaCollectionDetailPage(
             database: db,
@@ -85,11 +86,34 @@ void main() {
               orderUpdatedAt: 0,
             ),
             loadMembers: loadMembers,
-            onOpenEpisode: (VideoBookRow _) {},
+            onOpenEpisode: onOpenEpisode ?? (VideoBookRow _) {},
             onChanged: () {},
           ),
         ),
       );
+
+  testWidgets('默认展示沉浸式合集信息与横向剧集轨道，点卡打开对应集', (WidgetTester tester) async {
+    VideoBookRow? opened;
+    await tester.pumpWidget(
+        buildApp(onOpenEpisode: (VideoBookRow row) => opened = row));
+    await tester.pumpAndSettle();
+
+    expect(find.text('某番剧'), findsOneWidget);
+    expect(
+      find.byKey(const ValueKey<String>('collection-episode-rail')),
+      findsOneWidget,
+    );
+    final ListView rail = tester.widget<ListView>(find.descendant(
+      of: find.byKey(const ValueKey<String>('collection-episode-rail')),
+      matching: find.byType(ListView),
+    ));
+    expect(rail.scrollDirection, Axis.horizontal);
+
+    await tester
+        .tap(find.byKey(const ValueKey<String>('video-episode-card-1')));
+    await tester.pump();
+    expect(opened?.bookUid, 'video/a10');
+  });
 
   testWidgets('一键「按名称」：natural 序（第9话<第10话）真写穿 sortIndex',
       (WidgetTester tester) async {
@@ -128,10 +152,27 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
 
+    await tester.tap(find.text(t.collection_view_all));
+    await tester.pumpAndSettle();
+
     // BUG-778 后拖拽走 HibikiReorderableColumn：触摸 = 长按整行起拖（鼠标即
     // 拖）。三行从上到下 = Beta / 第10话 / 第9话；长按首行（Beta）往下拖两行。
+    final Finder betaRow = find.byKey(
+      const ValueKey<String>('collection-episode-row-video/beta'),
+    );
+    await tester.scrollUntilVisible(
+      betaRow,
+      240,
+      scrollable: find
+          .descendant(
+            of: find.byType(CustomScrollView),
+            matching: find.byType(Scrollable),
+          )
+          .first,
+    );
+    await tester.pumpAndSettle();
     final TestGesture gesture =
-        await tester.startGesture(tester.getCenter(find.text('Beta')));
+        await tester.startGesture(tester.getCenter(betaRow));
     await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
     for (int step = 0; step < 5; step++) {
       await gesture.moveBy(const Offset(0, 40));
@@ -211,10 +252,27 @@ void main() {
       await tester.pumpWidget(buildApp());
       await tester.pumpAndSettle();
 
+      await tester.tap(find.text(t.collection_view_all));
+      await tester.pumpAndSettle();
+
       // 可见三行仍是 Beta / 第10话 / 第9话（非 video 成员不渲染）。首行拖到末尾 →
       // 可见新序 a10 / a9 / beta，依次填回原来的三个 video 槽位（下标 0/2/4）。
+      final Finder betaRow = find.byKey(
+        const ValueKey<String>('collection-episode-row-video/beta'),
+      );
+      await tester.scrollUntilVisible(
+        betaRow,
+        240,
+        scrollable: find
+            .descendant(
+              of: find.byType(CustomScrollView),
+              matching: find.byType(Scrollable),
+            )
+            .first,
+      );
+      await tester.pumpAndSettle();
       final TestGesture gesture =
-          await tester.startGesture(tester.getCenter(find.text('Beta')));
+          await tester.startGesture(tester.getCenter(betaRow));
       await tester.pump(kLongPressTimeout + const Duration(milliseconds: 50));
       for (int step = 0; step < 5; step++) {
         await gesture.moveBy(const Offset(0, 40));

--- a/hibiki/test/pages/video_episode_list_push_aside_guard_test.dart
+++ b/hibiki/test/pages/video_episode_list_push_aside_guard_test.dart
@@ -1,12 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'video_hibiki_page_source_corpus.dart';
 
-/// 源码守卫：剧集列表走 push-aside 侧栏（把画面挤窄到左侧、与字幕列表风格统一），
-/// 而非 `showModalBottomSheet`（底部弹层）（TODO-638）。
+/// 源码守卫：剧集列表走视频底部的非模态横向轨道，而非
+/// `showModalBottomSheet` 或会挤窄画面的右侧栏。
 ///
-/// 用户报「视频的剧集列表弄成侧边栏或者什么的，和其他的显示效果差太多了」。此前剧集
-/// 列表是底部弹层，与字幕列表（push-aside）/ 设置·倍速（overlay）风格不一致。改成与
-/// 字幕列表同款 push-aside 侧栏（独立 [_episodeListVisible] 槽，与字幕列表互斥）。
+/// 字幕列表仍是 push-aside；剧集轨道覆盖在视频底部，以画面本身作沉浸式背景。
+/// 两者继续共用 [_episodeListVisible] / [_subtitleListVisible] 互斥状态。
 ///
 /// media_kit 在 headless test 跑不起真视频 widget，故断言源码层的可见性路由与结构
 /// （与 video_subtitle_list_push_aside_guard_test 同范式）。
@@ -16,7 +15,7 @@ void main() {
     src = readVideoHibikiSource();
   });
 
-  test('剧集列表不再用 showModalBottomSheet（已改 push-aside 侧栏）', () {
+  test('剧集列表不再用 showModalBottomSheet（已改底部横向轨道）', () {
     final int start = src.indexOf('void _showEpisodeList() {');
     expect(start, greaterThan(-1), reason: '应保留 _showEpisodeList 作为控制条入口');
     final int end = src.indexOf('\n  }', start);
@@ -24,12 +23,12 @@ void main() {
     expect(
       body.contains('showModalBottomSheet'),
       isFalse,
-      reason: '剧集列表入口不应再用 showModalBottomSheet（已改 push-aside）',
+      reason: '剧集列表入口不应再用 showModalBottomSheet（已改横向轨道）',
     );
     expect(
       body.contains('_toggleEpisodeList()'),
       isTrue,
-      reason: '_showEpisodeList 应翻转 push-aside 侧栏（_toggleEpisodeList）',
+      reason: '_showEpisodeList 应翻转非模态剧集轨道（_toggleEpisodeList）',
     );
   });
 
@@ -44,7 +43,7 @@ void main() {
     );
   });
 
-  test('_toggleEpisodeList 驱动 _episodeListVisible（push-aside），不走 overlay', () {
+  test('_toggleEpisodeList 驱动 _episodeListVisible，不走 modal route', () {
     final int start = src.indexOf('void _toggleEpisodeList() {');
     expect(start, greaterThan(-1), reason: '应有 _toggleEpisodeList 方法');
     final int end = src.indexOf('\n  }', start);
@@ -52,7 +51,7 @@ void main() {
     expect(
       body.contains('_episodeListVisible.value'),
       isTrue,
-      reason: '应翻转 push-aside 可见性 _episodeListVisible',
+      reason: '应翻转剧集轨道可见性 _episodeListVisible',
     );
   });
 
@@ -64,7 +63,7 @@ void main() {
     expect(
       epBody.contains('_closeSubtitleJumpList()'),
       isTrue,
-      reason: '开 push-aside 剧集列表前应关掉字幕列表（同一右栏槽，互斥）',
+      reason: '开剧集轨道前应关掉字幕列表（互斥）',
     );
     expect(
       epBody.contains('_hideVideoSidePanel()'),
@@ -82,7 +81,7 @@ void main() {
     );
   });
 
-  test('开任何浮层都关掉 push-aside 剧集列表（与字幕列表同处右栏）', () {
+  test('开任何浮层都关掉剧集轨道', () {
     // _showVideoSidePanel 开浮层时关剧集列表。
     final int showStart = src.indexOf('void _showVideoSidePanel(');
     expect(showStart, greaterThan(-1));
@@ -93,7 +92,7 @@ void main() {
     expect(
       showBody.contains('_episodeListVisible.value = false'),
       isTrue,
-      reason: '开任何浮层都应关掉 push-aside 剧集列表',
+      reason: '开任何浮层都应关掉剧集轨道',
     );
   });
 
@@ -110,10 +109,13 @@ void main() {
       final int end = src.indexOf('\n  }', start);
       final String body = src.substring(start, end);
       expect(body.contains('_episodeListVisible.value = false'), isTrue,
-          reason: '关闭应隐藏 push-aside 列表');
+          reason: '关闭应隐藏剧集轨道');
       expect(body.contains('_pokeControlsVisible()'), isTrue,
           reason: '关闭应唤回控制条');
-      expect(body.contains('_focusOwnership.reclaim(FocusReclaimCause.overlayClosed)'), isTrue,
+      expect(
+          body.contains(
+              '_focusOwnership.reclaim(FocusReclaimCause.overlayClosed)'),
+          isTrue,
           reason: '关闭应把焦点归还视频（否则键盘 / 手柄失焦）');
     });
 
@@ -153,23 +155,31 @@ void main() {
     });
   });
 
-  test('push-aside 布局渲染剧集面板列（_episodeSidePanel），用 VideoEpisodePanel', () {
+  test('视频布局用 Stack 渲染底部剧集轨道，不把它放进 push-aside Row', () {
     final int start = src.indexOf('Widget _videoWithSubtitlePanel(');
     expect(start, greaterThan(-1),
         reason: 'should have push-aside layout _videoWithSubtitlePanel');
-    // 找到该方法到下一个 `\n  Widget ` 之间的体（含 _episodeSidePanel 调用）。
-    final int rowIdx = src.indexOf('children: <Widget>[', start);
-    final int rowEnd = src.indexOf('],', rowIdx);
-    final String rowBody = src.substring(rowIdx, rowEnd);
+    final int end = src.indexOf('\n  Widget ', start + 1);
+    final String body = src.substring(start, end);
     expect(
-      rowBody.contains('_episodeSidePanel('),
+      body.contains('return Stack('),
       isTrue,
-      reason: 'push-aside Row 应渲染剧集面板列 _episodeSidePanel',
+      reason: '视频与剧集轨道应叠在 Stack 中',
+    );
+    expect(
+      body.contains('_episodeOverlayPanel(episodeVisible)'),
+      isTrue,
+      reason: 'Stack 应渲染底部 _episodeOverlayPanel',
+    );
+    expect(
+      body.contains('_episodeSidePanel('),
+      isFalse,
+      reason: '剧集列表不应再作为 Row 侧栏挤窄视频',
     );
     expect(
       src.contains('child: VideoEpisodePanel('),
       isTrue,
-      reason: '剧集面板列应渲染 VideoEpisodePanel widget',
+      reason: '剧集轨道应渲染 VideoEpisodePanel widget',
     );
   });
 
@@ -192,7 +202,7 @@ void main() {
         reason: 'VideoEpisodePanel 应接收解析后的标题与封面条目');
   });
 
-  test('剧集列表 push-aside 也门控控制条 / rail 可见性（与字幕列表一致）', () {
+  test('剧集轨道也门控控制条 / rail 可见性（与字幕列表一致）', () {
     // _applyControlsVisibilityFromMediaKit 的 gated 应含 _episodeListVisible。
     final int start =
         src.indexOf('void _applyControlsVisibilityFromMediaKit() {');

--- a/hibiki/test/pages/video_subtitle_list_cursor_reveal_guard_test.dart
+++ b/hibiki/test/pages/video_subtitle_list_cursor_reveal_guard_test.dart
@@ -150,14 +150,14 @@ void main() {
           reason:
               'opaque 外层应在最外、救场层 _withSubtitleListCursorReveal 在其内（opaque annotation 包整列）');
 
-      // 选集侧栏：此前**完全无** cursor-reveal 覆盖，r5 必须补 opaque 外层。
-      final int epStart = src.indexOf('Widget _episodeSidePanel(');
+      // 选集横向轨道：仍需 opaque cursor 外层，鼠标移入卡片后必须恢复 basic。
+      final int epStart = src.indexOf('Widget _episodeOverlayPanel(');
       expect(epStart, greaterThanOrEqualTo(0));
       final int epEnd = src.indexOf('\n  Widget ', epStart + 1);
       final String epBody =
           src.substring(epStart, epEnd > epStart ? epEnd : src.length);
       expect(epBody.contains('_withSidePanelOpaqueCursor('), isTrue,
-          reason: 'r5：选集侧栏外层必须补声明式 opaque cursor 包裹（此前裸奔 = 选集列表光标隐藏）');
+          reason: '选集轨道外层必须有声明式 opaque cursor 包裹');
       final int epOpaqueIdx = epBody.indexOf('_withSidePanelOpaqueCursor(');
       final int epPanelIdx = epBody.indexOf('VideoEpisodePanel(');
       expect(epPanelIdx, greaterThan(epOpaqueIdx),

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -871,10 +871,14 @@ void main() {
               'with appUiScale, not ordinary page chrome (same content rationale '
               'as the allowlisted sibling subtitle jump panel).',
       'lib/src/media/video/video_episode_panel.dart':
-          'Episode list panel (TODO-638) renders episode index + title rows '
-              'as video-subsystem content in a push-aside sidebar mirroring '
-              'the allowlisted sibling chapter panel; row font size scales '
+          'Episode list panel renders episode index + title cards as '
+              'video-subsystem content in a bottom overlay rail; row font size scales '
               'with appUiScale, not ordinary page chrome.',
+      'lib/src/media/video/video_episode_rail.dart':
+          'Shared episode rail renders 16:9 media cover frames, episode titles '
+              'and playback state as video-subsystem content in the player overlay '
+              'and collection hero; card typography scales with appUiScale in the '
+              'player, the same reviewed content exception as video_episode_panel.',
       'lib/src/media/video/video_side_panel.dart':
           'Video translucent side-panel scaffold (favorite sentences list etc.) '
               'renders video-subsystem overlay chrome; lock toggle (TODO-611) '


### PR DESCRIPTION
## What changed

- replace the in-player episode push-aside sidebar with a bottom cinematic horizontal episode rail
- redesign video collection detail with a cover backdrop, gradients, progress/continue action, and the same shared episode rail
- preserve subtitle push-aside behavior, close/focus parity, sorting, drag reorder, mixed-media ordering, and member removal
- centralize episode cover, placeholder, current, and watched presentation in VideoEpisodeRail

## Validation

- flutter test --no-pub across 8 focused test files - 118 tests passed
- flutter analyze --no-pub - no issues found
- git diff --check

## Not run

- full platform build or real-device visual acceptance, per request