### PR TITLE
feat(sync): unify catalog sources and share service config

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 46971 (2763 per locale)
+/// Strings: 46988 (2764 per locale)
 ///
-/// Built on 2026-07-29 at 07:19 UTC
+/// Built on 2026-07-29 at 11:02 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3715,6 +3715,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_import_detected_confirm => 'Import as manga';
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -10041,6 +10043,9 @@ class _StringsAr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -16435,6 +16440,9 @@ class _StringsDe extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -22845,6 +22853,9 @@ class _StringsEs extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -29266,6 +29277,9 @@ class _StringsFr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -35616,6 +35630,9 @@ class _StringsId extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -42012,6 +42029,9 @@ class _StringsIt extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -48225,6 +48245,9 @@ class _StringsJa extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -54440,6 +54463,9 @@ class _StringsKo extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -60816,6 +60842,9 @@ class _StringsNl extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -67205,6 +67234,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -73578,6 +73610,9 @@ class _StringsRu extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -79899,6 +79934,9 @@ class _StringsTh extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -86252,6 +86290,9 @@ class _StringsTr extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -92590,6 +92631,9 @@ class _StringsVi extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 // Path: <root>
@@ -98479,6 +98523,8 @@ class _StringsZhCn extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
+  @override
+  String get manga_online_source_disabled => '此互联网来源已关闭，请在「来源」中开启后浏览目录。';
 }
 
 // Path: <root>
@@ -104613,6 +104659,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String manga_import_detected_message({required Object name}) =>
       '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+  @override
+  String get manga_online_source_disabled =>
+      'This internet source is disabled. Enable it in Sources to browse the catalog.';
 }
 
 /// Flat map(s) containing all translations.
@@ -110274,6 +110323,8 @@ extension on _StringsEn {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -115933,6 +115984,8 @@ extension on _StringsAr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -121613,6 +121666,8 @@ extension on _StringsDe {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -127292,6 +127347,8 @@ extension on _StringsEs {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -132977,6 +133034,8 @@ extension on _StringsFr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -138644,6 +138703,8 @@ extension on _StringsId {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -144326,6 +144387,8 @@ extension on _StringsIt {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -149970,6 +150033,8 @@ extension on _StringsJa {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -155618,6 +155683,8 @@ extension on _StringsKo {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -161293,6 +161360,8 @@ extension on _StringsNl {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -166965,6 +167034,8 @@ extension on _StringsPtBr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -172642,6 +172713,8 @@ extension on _StringsRu {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -178303,6 +178376,8 @@ extension on _StringsTh {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -183973,6 +184048,8 @@ extension on _StringsTr {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -189638,6 +189715,8 @@ extension on _StringsVi {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }
@@ -195256,6 +195335,8 @@ extension on _StringsZhCn {
         return '按漫画导入';
       case 'manga_import_detected_message':
         return ({required Object name}) => '「${name}」是漫画文件，将走漫画导入流程，而不是书籍导入流程。';
+      case 'manga_online_source_disabled':
+        return '此互联网来源已关闭，请在「来源」中开启后浏览目录。';
       default:
         return null;
     }
@@ -200895,6 +200976,8 @@ extension on _StringsZhHk {
       case 'manga_import_detected_message':
         return ({required Object name}) =>
             '"${name}" is a manga file, so it will go through the manga importer instead of the book importer.';
+      case 'manga_online_source_disabled':
+        return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "请先选择漫画文件或文件夹。",
   "manga_import_detected_title": "这看起来是漫画",
   "manga_import_detected_confirm": "按漫画导入",
-  "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。"
+  "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。",
+  "manga_online_source_disabled": "此互联网来源已关闭，请在「来源」中开启后浏览目录。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2761,5 +2761,6 @@
   "manga_import_missing_input": "Pick a manga file or folder first.",
   "manga_import_detected_title": "This looks like manga",
   "manga_import_detected_confirm": "Import as manga",
-  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer."
+  "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
+  "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog."
 }

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_dialog.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_dialog.dart
@@ -21,6 +21,7 @@ class MokuroMoeCatalogDialog extends StatefulWidget {
     required this.db,
     this.clientOverride,
     this.queueOverride,
+    this.enabledOverride,
     super.key,
   });
 
@@ -32,6 +33,9 @@ class MokuroMoeCatalogDialog extends StatefulWidget {
 
   /// 测试用队列（null = 取 AppModel.mokuroMoeDownloadQueue 共享实例）。
   final MokuroMoeDownloadQueue? queueOverride;
+
+  /// Test/embedding source gate. Null reads the live AppModel preference.
+  final bool? enabledOverride;
 
   @override
   State<MokuroMoeCatalogDialog> createState() => _MokuroMoeCatalogDialogState();
@@ -67,6 +71,7 @@ class _MokuroMoeCatalogDialogState extends State<MokuroMoeCatalogDialog> {
         db: widget.db,
         clientOverride: widget.clientOverride,
         queueOverride: widget.queueOverride,
+        enabledOverride: widget.enabledOverride,
         embedded: false,
         onClose: _close,
         snapshotNotifier: _snapshot,

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_page.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_page.dart
@@ -47,6 +47,7 @@ class _MokuroMoeCatalogPageState extends ConsumerState<MokuroMoeCatalogPage> {
 
   @override
   Widget build(BuildContext context) {
+    final AppModel appModel = ref.watch(appProvider);
     // 与书架 / 视频 / 来源同构：DesktopContentLayout + HibikiPageHeader，
     // 外层 Scaffold 由 HomePage 提供。
     return DesktopContentLayout(
@@ -69,8 +70,9 @@ class _MokuroMoeCatalogPageState extends ConsumerState<MokuroMoeCatalogPage> {
             ),
           Expanded(
             child: MokuroMoeCatalogView(
-              db: widget.db ?? ref.read(appProvider).database,
+              db: widget.db ?? appModel.database,
               embedded: true,
+              enabledOverride: appModel.mangaOnlineCatalogEnabled,
               snapshotNotifier: _snapshot,
             ),
           ),

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
@@ -71,6 +71,7 @@ class MokuroMoeCatalogView extends ConsumerStatefulWidget {
     required this.db,
     this.clientOverride,
     this.queueOverride,
+    this.enabledOverride,
     this.embedded = false,
     this.onClose,
     this.snapshotNotifier,
@@ -85,6 +86,10 @@ class MokuroMoeCatalogView extends ConsumerStatefulWidget {
 
   /// 测试用队列（null = 取 [AppModel.mokuroMoeDownloadQueue] 共享实例）。
   final MokuroMoeDownloadQueue? queueOverride;
+
+  /// Source gate. Production hosts normally pass/read the AppModel preference;
+  /// tests can provide it explicitly without constructing an AppModel.
+  final bool? enabledOverride;
 
   /// false = 对话框语境（正文尺寸受外层约束、动作按钮由对话框 footer 提供）；
   /// true = 页面语境（正文撑满可用空间、动作按钮画在 View 内部底行）。
@@ -108,6 +113,7 @@ class MokuroMoeCatalogView extends ConsumerStatefulWidget {
 class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
   late final MokuroMoeClient _client;
   late final MokuroMoeDownloadQueue _queue;
+  late bool _enabled;
   final TextEditingController _searchCtrl = TextEditingController();
 
   _CatalogStage _stage = _CatalogStage.browse;
@@ -136,6 +142,10 @@ class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
   @override
   void initState() {
     super.initState();
+    _enabled = widget.enabledOverride ??
+        (widget.clientOverride != null && widget.queueOverride != null
+            ? true
+            : ref.read(appProvider).mangaOnlineCatalogEnabled);
     _client = widget.clientOverride ??
         MokuroMoeClient(
           baseUrl: ref.read(appProvider).mangaOnlineCatalogBaseUrl,
@@ -150,8 +160,30 @@ class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
       ),
     );
     _queue.addListener(_onQueueChanged);
-    unawaited(_loadLibrary());
-    unawaited(_loadExistingBooks());
+    if (_enabled) {
+      unawaited(_loadLibrary());
+      unawaited(_loadExistingBooks());
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant MokuroMoeCatalogView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final bool? nextOverride = widget.enabledOverride;
+    if (nextOverride == null || nextOverride == _enabled) return;
+    _enabled = nextOverride;
+    if (_enabled) {
+      unawaited(_loadLibrary());
+      unawaited(_loadExistingBooks());
+    } else {
+      _library = null;
+      _loadError = null;
+      _loading = false;
+      _series = null;
+      _selectedVolumes.clear();
+      _stage = _CatalogStage.browse;
+      _publishSnapshot();
+    }
   }
 
   @override
@@ -279,6 +311,28 @@ class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
   @override
   Widget build(BuildContext context) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    if (!_enabled) {
+      return Center(
+        child: Padding(
+          padding: EdgeInsets.all(tokens.spacing.gap * 2),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(
+                Icons.public_off_outlined,
+                color: tokens.surfaces.onVariant,
+              ),
+              SizedBox(height: tokens.spacing.gap),
+              Text(
+                t.manga_online_source_disabled,
+                style: tokens.type.listSubtitle,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      );
+    }
     final Widget body = _stage == _CatalogStage.browse
         ? _buildBrowse(tokens)
         : _buildSeries(tokens);

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -656,6 +656,10 @@ class AppModel with ChangeNotifier {
   Future<void> refreshAfterSyncRun(SyncRunReport report) async {
     if (!report.needsLocalLibraryRefresh) return;
 
+    if (report.serviceConfigsImported > 0) {
+      await refreshPrefCache();
+    }
+
     if (report.dictionariesImported > 0) {
       dictRepo.clearDictionariesCache();
       await _rebuildDictPathsCacheAsync();
@@ -714,6 +718,7 @@ class AppModel with ChangeNotifier {
   /// Preference management, extracted from AppModel for testability.
   PreferencesRepository? _prefsRepo;
   PreferencesRepository get prefsRepo => _prefsRepo!;
+  bool get isPreferencesReady => _prefsRepo != null;
 
   /// TODO-855: last prefs-version this process has reconciled its cache against.
   /// Used by [refreshPrefCacheIfChanged] so the warm-reuse :popup process only
@@ -5631,6 +5636,10 @@ class AppModel with ChangeNotifier {
   String get mangaOnlineCatalogBaseUrl => prefsRepo.mangaOnlineCatalogBaseUrl;
   Future<void> setMangaOnlineCatalogBaseUrl(String value) =>
       prefsRepo.setMangaOnlineCatalogBaseUrl(value);
+
+  bool get mangaOnlineCatalogEnabled => prefsRepo.mangaOnlineCatalogEnabled;
+  Future<void> setMangaOnlineCatalogEnabled(bool value) =>
+      prefsRepo.setMangaOnlineCatalogEnabled(value);
 
   // TODO-1024 / BUG-479：更新检查结果缓存（缓存优先 + 后台静默刷新）。
   UpdateCheckCacheEntry? get updateCheckCache => prefsRepo.updateCheckCache;

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1828,6 +1828,16 @@ class PreferencesRepository extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Whether the mokuro.moe internet catalog participates in manga browsing.
+  /// Defaults to true to preserve the pre-source-toggle behaviour.
+  bool get mangaOnlineCatalogEnabled =>
+      getPref('manga_online_catalog_enabled', defaultValue: true) as bool;
+
+  Future<void> setMangaOnlineCatalogEnabled(bool value) async {
+    await setPref('manga_online_catalog_enabled', value);
+    notifyListeners();
+  }
+
   // 旧版单框 Gemini 云端识别的三对 getter/setter（`manga_cloud_ocr_enabled` /
   // `manga_cloud_ocr_api_key` / `manga_cloud_ocr_model`）随 PR#474 删掉框选补扫
   // 实现后已零消费方，本轮一并清掉（BUG-1164）。

--- a/hibiki/lib/src/pages/implementations/media_sources_view.dart
+++ b/hibiki/lib/src/pages/implementations/media_sources_view.dart
@@ -28,6 +28,7 @@ import 'package:hibiki/src/media/source_library/source_library_row.dart';
 import 'package:hibiki/src/media/source_library/source_library_scanner.dart';
 import 'package:hibiki/src/sync/ftp_sync_backend.dart';
 import 'package:hibiki/src/sync/sftp_sync_backend.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/webdav_sync_backend.dart';
 import 'package:hibiki/src/pages/hibiki_page_placeholders.dart';
 import 'package:hibiki/utils.dart';
@@ -63,6 +64,12 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
   /// null = 仍在加载；非 null = 已加载（可能为空列表）。
   List<SourceLibraryRow>? _rows;
 
+  /// Virtual sources are not `media_sources` scan roots. They are composed into
+  /// this view so "Sources" describes every origin that can supply the media
+  /// experience instead of only local folders.
+  bool? _interconnectEnabled;
+  bool? _mangaOnlineCatalogEnabled;
+
   /// 每个来源 id → 当前**累计拥有**的媒体条目数（TODO-1036）。
   /// 与列表一起加载，避免逐行 FutureBuilder 抖动。来源不在 map 里时回退 0。
   final Map<int, int> _cumulativeCount = <int, int>{};
@@ -97,10 +104,18 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
   Future<void> _load() async {
     final List<SourceLibraryRow> rows =
         await _db.getMediaSourcesByKind(widget.mediaKind);
+    final bool interconnectEnabled =
+        await SyncRepository(_db).isInterconnectEnabled();
+    final bool mangaOnlineCatalogEnabled = await _db.getPrefTyped<bool>(
+      'manga_online_catalog_enabled',
+      true,
+    );
     final Map<int, int> counts = await _loadCumulativeCounts(rows);
     if (!mounted) return;
     setState(() {
       _rows = rows;
+      _interconnectEnabled = interconnectEnabled;
+      _mangaOnlineCatalogEnabled = mangaOnlineCatalogEnabled;
       _cumulativeCount
         ..clear()
         ..addAll(counts);
@@ -135,17 +150,48 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
 
   Widget _buildBody(HibikiDesignTokens tokens) {
     final List<SourceLibraryRow>? rows = _rows;
-    if (rows == null) {
+    final bool? interconnectEnabled = _interconnectEnabled;
+    final bool? mangaOnlineCatalogEnabled = _mangaOnlineCatalogEnabled;
+    if (rows == null ||
+        interconnectEnabled == null ||
+        mangaOnlineCatalogEnabled == null) {
       return buildLoading(padding: const EdgeInsets.all(24));
     }
-    if (rows.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Text(t.media_source_no_sources, textAlign: TextAlign.center),
+    final List<Widget> sourceRows = <Widget>[
+      _buildVirtualSourceRow(
+        tokens,
+        icon: Icons.devices_outlined,
+        title: t.audio_source_hibiki_interconnect,
+        subtitle: t.interconnect_enable_hint,
+        value: interconnectEnabled,
+        onChanged: _setInterconnectEnabled,
+      ),
+      if (widget.mediaKind == 'manga')
+        _buildVirtualSourceRow(
+          tokens,
+          icon: Icons.public_outlined,
+          title: 'Mokuro.moe',
+          subtitle: _appModel.isPreferencesReady
+              ? _appModel.mangaOnlineCatalogBaseUrl
+              : 'https://mokuro.moe',
+          value: mangaOnlineCatalogEnabled,
+          onChanged: _setMangaOnlineCatalogEnabled,
         ),
-      );
-    }
+      if (rows.isNotEmpty) ...<Widget>[
+        Padding(
+          padding: EdgeInsets.symmetric(vertical: tokens.spacing.gap / 2),
+          child: const Divider(height: 1),
+        ),
+        _buildFolderRows(tokens, rows),
+      ],
+    ];
+    return Column(children: sourceRows);
+  }
+
+  Widget _buildFolderRows(
+    HibikiDesignTokens tokens,
+    List<SourceLibraryRow> rows,
+  ) {
     // 自实现的 HibikiReorderableColumn（局部坐标长按拖拽，消祖先 HibikiAppUiScale
     // 缩放），与 LocalAudioSourcesDialog 同款，而非 SDK ReorderableListView。
     return HibikiReorderableColumn(
@@ -162,6 +208,74 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
       itemBuilder: (BuildContext context, int index) =>
           _buildRow(tokens, rows[index]),
     );
+  }
+
+  Widget _buildVirtualSourceRow(
+    HibikiDesignTokens tokens, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    return Padding(
+      padding: EdgeInsets.symmetric(vertical: tokens.spacing.gap / 2),
+      child: Row(
+        children: <Widget>[
+          Icon(icon, color: cs.onSurfaceVariant),
+          SizedBox(width: tokens.spacing.gap),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(title, style: theme.textTheme.titleSmall),
+                Text(
+                  subtitle,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: cs.onSurfaceVariant,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          SizedBox(width: tokens.spacing.gap),
+          adaptiveSwitch(
+            context: context,
+            value: value,
+            onChanged: onChanged,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _setInterconnectEnabled(bool value) async {
+    setState(() => _interconnectEnabled = value);
+    try {
+      await SyncRepository(_db).setInterconnectEnabled(value);
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _interconnectEnabled = !value);
+    }
+  }
+
+  Future<void> _setMangaOnlineCatalogEnabled(bool value) async {
+    setState(() => _mangaOnlineCatalogEnabled = value);
+    try {
+      if (_appModel.isPreferencesReady) {
+        await _appModel.setMangaOnlineCatalogEnabled(value);
+      } else {
+        await _db.setPrefTyped<bool>('manga_online_catalog_enabled', value);
+      }
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _mangaOnlineCatalogEnabled = !value);
+    }
   }
 
   Widget _buildRow(HibikiDesignTokens tokens, SourceLibraryRow row) {

--- a/hibiki/lib/src/sync/app_model_library_host_service.dart
+++ b/hibiki/lib/src/sync/app_model_library_host_service.dart
@@ -16,6 +16,7 @@ import 'package:hibiki/src/sync/aggregate_sync_service.dart';
 import 'package:hibiki/src/sync/collection_manifest.dart';
 import 'package:hibiki/src/sync/collection_sync_engine.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/interconnect_service_config.dart';
 import 'package:hibiki/src/sync/sync_asset_package_service.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/sync/sync_manager.dart'
@@ -46,7 +47,10 @@ import 'package:path/path.dart' as p;
 ///
 /// T2/T3 后续接线任务会在 AppModel 初始化时传入真实值。
 class AppModelLibraryHostService
-    implements HibikiLibraryHostService, DeletionTombstoneHost {
+    implements
+        HibikiLibraryHostService,
+        DeletionTombstoneHost,
+        InterconnectServiceConfigHost {
   AppModelLibraryHostService({
     required HibikiDatabase db,
     required Directory dictionaryResourceRoot,
@@ -86,6 +90,14 @@ class AppModelLibraryHostService
   final SyncAssetPackageService _packages;
   final Future<void> Function() _refreshDictionaryCache;
   final Future<void> Function(Future<void> Function() body) _runExclusive;
+
+  @override
+  Future<InterconnectServiceConfigSnapshot>
+      getInterconnectServiceConfig() async {
+    return InterconnectServiceConfigSnapshot.fromPreferences(
+      await _db.getAllPrefs(),
+    );
+  }
 
   /// 书籍导入回调（可选；null 时 importBook 抛 [UnsupportedError]）。
   /// 生产传 `(f) => EpubImporter.importFromPath(db: db, filePath: f.path, fileName: p.basename(f.path))`。

--- a/hibiki/lib/src/sync/hibiki_sync_server.dart
+++ b/hibiki/lib/src/sync/hibiki_sync_server.dart
@@ -15,6 +15,7 @@ import 'package:hibiki/src/media/video/video_subtitle_source.dart'
 import 'package:hibiki/src/sync/aggregate_snapshot.dart';
 import 'package:hibiki/src/sync/collection_manifest.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/interconnect_service_config.dart';
 import 'package:hibiki/src/sync/hibiki_manga_ocr_host.dart';
 import 'package:hibiki/src/sync/interconnect_device_name.dart';
 import 'package:hibiki/src/sync/hibiki_remote_api_handlers.dart';
@@ -435,12 +436,9 @@ class HibikiSyncServer {
       urlPath == 'api/lookup/audio/file';
 
   Future<bool> _validateAuth(String header) async {
-    if (!header.startsWith('Basic ')) return false;
+    final String? password = _basicPassword(header);
+    if (password == null) return false;
     try {
-      final decoded = utf8.decode(base64Decode(header.substring(6)));
-      final colonIdx = decoded.indexOf(':');
-      if (colonIdx < 0) return false;
-      final password = decoded.substring(colonIdx + 1);
       // 兼容路径：共享 [_token] 仍受理（未重新配对的老设备继续可用，Never break
       // userspace）。常量时间比较防计时侧信道泄漏 token 前缀。
       if (_constantTimeEquals(
@@ -462,6 +460,37 @@ class HibikiSyncServer {
       return false;
     } catch (_) {
       return false;
+    }
+  }
+
+  /// Sensitive service configuration is stricter than ordinary library APIs:
+  /// it accepts only a currently paired device token, never the legacy shared
+  /// server token.
+  Future<bool> _validatePeerAuth(String? header) async {
+    if (header == null) return false;
+    final String? password = _basicPassword(header);
+    if (password == null) return false;
+    final Uint8List supplied = Uint8List.fromList(utf8.encode(password));
+    for (final String peerToken in await _peerTokens()) {
+      if (_constantTimeEquals(
+        supplied,
+        Uint8List.fromList(utf8.encode(peerToken)),
+      )) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static String? _basicPassword(String header) {
+    if (!header.startsWith('Basic ')) return null;
+    try {
+      final String decoded =
+          utf8.decode(base64Decode(header.substring('Basic '.length)));
+      final int colonIdx = decoded.indexOf(':');
+      return colonIdx < 0 ? null : decoded.substring(colonIdx + 1);
+    } catch (_) {
+      return null;
     }
   }
 
@@ -574,6 +603,9 @@ class HibikiSyncServer {
     }
     if (reqPath == '/api/library/collections') {
       return _handleLibraryCollections(request, method, reqPath);
+    }
+    if (reqPath == '/api/interconnect/service-config') {
+      return _handleInterconnectServiceConfig(request, method);
     }
     if (reqPath == '/api/tombstones') {
       return _handleTombstones(request, method);
@@ -1153,6 +1185,8 @@ class HibikiSyncServer {
         'books': lib,
         'audio': lib,
         'videos': lib,
+        'serviceConfig': _securityContext != null &&
+            _libraryService is InterconnectServiceConfigHost,
       },
       // TODO-961 M1 能力协商（设计稿 §1.1 / §2.5）：老 client 读不到也不崩。
       'tls': <String, dynamic>{
@@ -2146,6 +2180,40 @@ class HibikiSyncServer {
       default:
         return shelf.Response(405);
     }
+  }
+
+  /// Host → paired child service configuration.
+  ///
+  /// This endpoint carries API keys and connection credentials, so its security
+  /// boundary is intentionally narrower than the ordinary library API:
+  /// HTTPS is mandatory, only a per-peer token is accepted, and no write method
+  /// exists. The legacy shared server token remains valid elsewhere for
+  /// compatibility but is explicitly rejected here.
+  Future<shelf.Response> _handleInterconnectServiceConfig(
+    shelf.Request request,
+    String method,
+  ) async {
+    if (method != 'GET') return shelf.Response(405);
+    if (_securityContext == null) {
+      return shelf.Response.forbidden('HTTPS required for service config');
+    }
+    if (!await _validatePeerAuth(request.headers['authorization'])) {
+      return shelf.Response.forbidden('Paired-device token required');
+    }
+    final HibikiLibraryHostService? library = _libraryService;
+    if (library is! InterconnectServiceConfigHost) {
+      return shelf.Response.notFound('Service config capability off');
+    }
+    final InterconnectServiceConfigSnapshot snapshot =
+        await (library as InterconnectServiceConfigHost)
+            .getInterconnectServiceConfig();
+    return shelf.Response.ok(
+      jsonEncode(snapshot.toJson()),
+      headers: const <String, String>{
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+      },
+    );
   }
 
   /// GET `/api/tombstones`：列 host 全部删除墓碑为 JSON 数组，供 client 拉取后与本地

--- a/hibiki/lib/src/sync/interconnect_service_config.dart
+++ b/hibiki/lib/src/sync/interconnect_service_config.dart
@@ -1,0 +1,98 @@
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// Host-owned service configuration that a paired child may import over the
+/// authenticated interconnect channel.
+///
+/// This is intentionally a small allowlist, not a general preferences backup.
+/// Device identity, pairing credentials, local paths, inbound API passwords and
+/// media-source secrets must never enter this payload.
+class InterconnectServiceConfigSnapshot {
+  InterconnectServiceConfigSnapshot._(this.preferences);
+
+  static const int schemaVersion = 1;
+
+  /// Preferences that describe external services shared by the user's devices.
+  ///
+  /// `yomitan_api_key` is deliberately absent: it protects this device's local
+  /// inbound API. Bangumi/Anki credentials and `media_source_secret_*` are also
+  /// device-scoped or have external write authority and remain local.
+  static const Set<String> sharedPreferenceKeys = <String>{
+    'jimaku_api_key',
+    'video_scraper_tmdb_api_key',
+    'qb_connection_config',
+    'manga_online_catalog_base_url',
+    'manga_online_catalog_enabled',
+  };
+
+  static final Map<String, String> _defaultRawValues = <String, String>{
+    'jimaku_api_key': PrefCodec.encode(''),
+    'video_scraper_tmdb_api_key': PrefCodec.encode(''),
+    'qb_connection_config': PrefCodec.encode(''),
+    'manga_online_catalog_base_url': PrefCodec.encode('https://mokuro.moe'),
+    'manga_online_catalog_enabled': PrefCodec.encode(true),
+  };
+
+  /// Raw [PrefCodec] values, kept raw so the client does not double-encode
+  /// strings or JSON. Missing host rows are materialized as semantic defaults,
+  /// allowing a cleared/rotated key to clear an older child value.
+  final Map<String, String> preferences;
+
+  factory InterconnectServiceConfigSnapshot.fromPreferences(
+    Map<String, String> allPreferences,
+  ) {
+    return InterconnectServiceConfigSnapshot._(
+      <String, String>{
+        for (final String key in sharedPreferenceKeys)
+          key: allPreferences[key] ?? _defaultRawValues[key]!,
+      },
+    );
+  }
+
+  factory InterconnectServiceConfigSnapshot.fromJson(
+    Map<String, Object?> json,
+  ) {
+    final Object? rawPreferences = json['preferences'];
+    if (json['schemaVersion'] != schemaVersion || rawPreferences is! Map) {
+      throw const FormatException('Unsupported service config snapshot');
+    }
+    final Map<String, String> accepted = <String, String>{};
+    for (final MapEntry<Object?, Object?> entry in rawPreferences.entries) {
+      final Object? key = entry.key;
+      final Object? value = entry.value;
+      if (key is! String ||
+          value is! String ||
+          !sharedPreferenceKeys.contains(key)) {
+        continue;
+      }
+      accepted[key] = value;
+    }
+    return InterconnectServiceConfigSnapshot._(accepted);
+  }
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'schemaVersion': schemaVersion,
+        'preferences': preferences,
+      };
+
+  /// Applies only changed allowlisted rows. Returns the number of rows changed.
+  ///
+  /// Unknown/missing fields are ignored; a real host snapshot contains every
+  /// allowlisted key (including encoded defaults for cleared values).
+  Future<int> applyTo(HibikiDatabase db) async {
+    int changed = 0;
+    for (final MapEntry<String, String> entry in preferences.entries) {
+      if (!sharedPreferenceKeys.contains(entry.key)) continue;
+      if (await db.getPref(entry.key) == entry.value) continue;
+      await db.setPref(entry.key, entry.value);
+      changed++;
+    }
+    return changed;
+  }
+}
+
+/// Optional host capability kept separate from [HibikiLibraryHostService]'s
+/// large media interface so older/test host implementations remain compatible.
+abstract interface class InterconnectServiceConfigHost {
+  Future<InterconnectServiceConfigSnapshot> getInterconnectServiceConfig();
+}

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:hibiki/src/sync/collection_manifest.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/interconnect_service_config.dart';
 import 'package:hibiki/src/sync/remote_book_client.dart';
 import 'package:hibiki/src/sync/remote_cover_fetcher.dart';
 import 'package:hibiki/src/sync/remote_library_source.dart';
@@ -676,6 +677,35 @@ class InterconnectSyncBackend extends SyncBackend
   /// host 根 origin（folder 路径是 `${_apiBase}/$kSyncRootFolderName/`，
   /// 故 /api 端点在 `${_apiBase}/api/...`）。
   String get _apiBase => _ops!.baseUrl;
+
+  /// Pulls the host-owned service configuration over the pinned HTTPS session.
+  /// Old hosts return 404 and are treated as not supporting the capability.
+  /// HTTP/shared-token sessions are rejected by the server rather than silently
+  /// downgrading API keys to plaintext transport.
+  Future<InterconnectServiceConfigSnapshot?> getRemoteServiceConfig() async {
+    await _ensureResolved();
+    final HttpClientRequest req = await _ops!.buildRequest(
+      'GET',
+      '$_apiBase/api/interconnect/service-config',
+    );
+    final HttpClientResponse res = await req.close();
+    if (res.statusCode == 404) {
+      await res.drain<void>();
+      return null;
+    }
+    _ops!.checkStatus(
+      res.statusCode,
+      'GET /api/interconnect/service-config',
+    );
+    final String body = await res.transform(utf8.decoder).join();
+    final Object? decoded = jsonDecode(body);
+    if (decoded is! Map) {
+      throw const FormatException('Invalid service config response');
+    }
+    return InterconnectServiceConfigSnapshot.fromJson(
+      decoded.cast<String, Object?>(),
+    );
+  }
 
   /// TODO-1235（TODO-961 回归）：把对端封面拉成字节，复用互联其余流量同一条钉扎
   /// 通路——[_ops.buildRequest] 对 https 用 pinned client（证书指纹相等才接受自签），

--- a/hibiki/lib/src/sync/sync_orchestrator.dart
+++ b/hibiki/lib/src/sync/sync_orchestrator.dart
@@ -11,6 +11,7 @@ import 'package:hibiki/src/sync/collection_manifest.dart';
 import 'package:hibiki/src/sync/collection_sync_engine.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
 import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
+import 'package:hibiki/src/sync/interconnect_service_config.dart';
 import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
 import 'package:hibiki/src/sync/aggregate_sync_service.dart';
 import 'package:hibiki/src/sync/sync_asset_package_service.dart';
@@ -181,6 +182,11 @@ class SyncRunReport {
   /// 故计入 [needsLocalLibraryRefresh]。
   int collectionsUpdated = 0;
 
+  /// Host-owned external-service preferences imported over the authenticated
+  /// interconnect channel. These require an AppModel preference-cache refresh
+  /// even though no media row was imported.
+  int serviceConfigsImported = 0;
+
   final List<String> errors = <String>[];
   final List<SyncConflict> conflicts = <SyncConflict>[];
 
@@ -205,7 +211,8 @@ class SyncRunReport {
       audiobooksImported > 0 ||
       localAudioImported > 0 ||
       localBookProgressPulled > 0 ||
-      collectionsUpdated > 0;
+      collectionsUpdated > 0 ||
+      serviceConfigsImported > 0;
 
   /// 合并另一条通道的报告到本报告（option B 双通道：云备份 + 互联并行各跑一轮后，
   /// 汇总成单一报告返回）。累加所有计数、拼接错误与冲突列表。
@@ -221,6 +228,7 @@ class SyncRunReport {
     localBookProgressPulled += other.localBookProgressPulled;
     rootSpillFilesRemoved += other.rootSpillFilesRemoved;
     collectionsUpdated += other.collectionsUpdated;
+    serviceConfigsImported += other.serviceConfigsImported;
     errors.addAll(other.errors);
     conflicts.addAll(other.conflicts);
     deletionCandidates.addAll(other.deletionCandidates);
@@ -355,6 +363,7 @@ class SyncOrchestrator {
     final bool isInterconnect = b is InterconnectSyncBackend;
 
     if (isInterconnect) {
+      await _syncServiceConfigLive(report, b);
       // 互联内容（epub）走 live 端点，仅当 syncContent 开时执行。
       // 元数据（进度/统计/有声书位置）由下方 SyncManager 以 syncContent=false 处理。
       if (syncContent) {
@@ -500,6 +509,22 @@ class SyncOrchestrator {
       );
     } catch (e) {
       report.errors.add('aggregate sync: $e');
+    }
+  }
+
+  /// Pulls the host's explicitly allowlisted service configuration. The host is
+  /// authoritative for keys it publishes; no client→host write exists.
+  Future<void> _syncServiceConfigLive(
+    SyncRunReport report,
+    InterconnectSyncBackend backend,
+  ) async {
+    try {
+      final InterconnectServiceConfigSnapshot? snapshot =
+          await backend.getRemoteServiceConfig();
+      if (snapshot == null) return;
+      report.serviceConfigsImported += await snapshot.applyTo(_db);
+    } catch (e) {
+      report.errors.add('service config live sync: $e');
     }
   }
 

--- a/hibiki/test/media/manga/online/mokuro_moe_catalog_dialog_test.dart
+++ b/hibiki/test/media/manga/online/mokuro_moe_catalog_dialog_test.dart
@@ -18,9 +18,11 @@ class _FakeClient extends MokuroMoeClient {
 
   final List<MokuroMoeSeries> library;
   Exception? libraryError;
+  int fetchCalls = 0;
 
   @override
   Future<List<MokuroMoeSeries>> fetchLibrary() async {
+    fetchCalls++;
     final Exception? error = libraryError;
     if (error != null) throw error;
     return library;
@@ -102,6 +104,23 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('よつばと!'), findsOneWidget);
     expect(find.text('ヨコハマ買い出し紀行'), findsNothing);
+    q.queue.dispose();
+  });
+
+  testWidgets('来源关闭时不请求目录，正文显示开启提示', (WidgetTester tester) async {
+    final q = makeQueue();
+    final _FakeClient client = _FakeClient(_library);
+    await tester.pumpWidget(wrap(MokuroMoeCatalogDialog(
+      db: db,
+      clientOverride: client,
+      queueOverride: q.queue,
+      enabledOverride: false,
+    )));
+    await tester.pumpAndSettle();
+
+    expect(client.fetchCalls, 0);
+    expect(find.text(t.manga_online_source_disabled), findsOneWidget);
+    expect(find.byType(TextField), findsNothing);
     q.queue.dispose();
   });
 

--- a/hibiki/test/pages/media_sources_dialog_test.dart
+++ b/hibiki/test/pages/media_sources_dialog_test.dart
@@ -1,5 +1,5 @@
 // TODO-817 M1c MediaSourcesDialog widget 行为 + 源码守卫测试：
-//  (1) 空库 -> 显示 media_source_no_sources。
+//  (1) 空扫描根仍显示 Hibiki 互联；漫画还显示独立可开关的 Mokuro.moe。
 //  (2) 预置 video 来源 -> 按 sortOrder 渲染 label/rootPath/统计文案。
 //  (3) lastScanError != null -> 显示 media_source_scan_error。
 //  (4) 移除来源 -> 确认对话框含 media_source_remove_keeps_media；确认后该来源消失，
@@ -111,11 +111,41 @@ Future<void> _seedBook(
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('empty library shows no-sources message', (tester) async {
+  testWidgets('empty scan-root list still shows Hibiki Interconnect',
+      (tester) async {
     final HibikiDatabase db = _memDb();
     addTearDown(db.close);
     await _pumpDialog(tester, db, 'video');
-    expect(find.text('No sources yet'), findsOneWidget);
+    expect(find.text('Hibiki Interconnect'), findsOneWidget);
+    expect(find.text('No sources yet'), findsNothing);
+  });
+
+  testWidgets('manga sources compose interconnect, internet and every folder',
+      (tester) async {
+    final HibikiDatabase db = _memDb();
+    addTearDown(db.close);
+    await _seedSource(
+      db,
+      label: 'Manga A',
+      mediaKind: 'manga',
+      rootPath: r'D:\manga\a',
+      sortOrder: 0,
+    );
+    await _seedSource(
+      db,
+      label: 'Manga B',
+      mediaKind: 'manga',
+      rootPath: r'D:\manga\b',
+      sortOrder: 1,
+    );
+    await _pumpDialog(tester, db, 'manga');
+
+    expect(find.text('Hibiki Interconnect'), findsOneWidget);
+    expect(find.text('Mokuro.moe'), findsOneWidget);
+    expect(find.text('Manga A'), findsOneWidget);
+    expect(find.text(r'D:\manga\a'), findsOneWidget);
+    expect(find.text('Manga B'), findsOneWidget);
+    expect(find.text(r'D:\manga\b'), findsOneWidget);
   });
 
   testWidgets('video sources render label / rootPath / count + last scan',

--- a/hibiki/test/sync/hibiki_sync_server_peer_token_test.dart
+++ b/hibiki/test/sync/hibiki_sync_server_peer_token_test.dart
@@ -50,6 +50,8 @@ void main() {
       Uri.parse('http://127.0.0.1:${server.port}/api/pair/v2/confirm');
   Uri capabilitiesUri() =>
       Uri.parse('http://127.0.0.1:${server.port}/api/capabilities');
+  Uri serviceConfigUri() => Uri.parse(
+      'http://127.0.0.1:${server.port}/api/interconnect/service-config');
 
   Future<String> startSession(String clientNonce,
       {String? clientDeviceId}) async {
@@ -112,6 +114,24 @@ void main() {
     expect(await authProbe('shared-token'), 200);
     // 随机错误 token 被拒。
     expect(await authProbe('bogus-token'), 401);
+  });
+
+  test('service config refuses plaintext HTTP even for a paired peer',
+      () async {
+    await startServer();
+    final String sid =
+        await startSession('cn-secure', clientDeviceId: 'device-secure');
+    final String peerToken = await confirm(sid);
+
+    final http.Response response = await http.get(
+      serviceConfigUri(),
+      headers: <String, String>{
+        'Authorization':
+            'Basic ${base64Encode(utf8.encode('hibiki:$peerToken'))}',
+      },
+    );
+    expect(response.statusCode, 403);
+    expect(response.body, contains('HTTPS required'));
   });
 
   test('revoking a peer token rejects it on the next request', () async {

--- a/hibiki/test/sync/interconnect_service_config_test.dart
+++ b/hibiki/test/sync/interconnect_service_config_test.dart
@@ -1,0 +1,107 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/interconnect_service_config.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+void main() {
+  late HibikiDatabase db;
+
+  setUp(() {
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() => db.close());
+
+  test('host snapshot includes only the explicit cross-device allowlist',
+      () async {
+    await db.setPref('jimaku_api_key', PrefCodec.encode('jimaku-secret'));
+    await db.setPref('video_scraper_tmdb_api_key', PrefCodec.encode('tmdb'));
+    await db.setPref(
+      'qb_connection_config',
+      PrefCodec.encode('{"password":"qb-secret"}'),
+    );
+    await db.setPref('yomitan_api_key', PrefCodec.encode('local-inbound'));
+    await db.setPref(
+        'sync_hibiki_client_token', PrefCodec.encode('peer-token'));
+    await db.setPref('sync_device_id', PrefCodec.encode('device-a'));
+    await db.setPref(
+      'media_source_secret_7',
+      PrefCodec.encode('folder-password'),
+    );
+    await db.setPref('download_save_root', PrefCodec.encode(r'D:\downloads'));
+
+    final InterconnectServiceConfigSnapshot snapshot =
+        InterconnectServiceConfigSnapshot.fromPreferences(
+      await db.getAllPrefs(),
+    );
+
+    expect(snapshot.preferences.keys,
+        InterconnectServiceConfigSnapshot.sharedPreferenceKeys);
+    expect(snapshot.preferences['jimaku_api_key'],
+        PrefCodec.encode('jimaku-secret'));
+    expect(snapshot.preferences, isNot(contains('yomitan_api_key')));
+    expect(snapshot.preferences, isNot(contains('sync_hibiki_client_token')));
+    expect(snapshot.preferences, isNot(contains('sync_device_id')));
+    expect(snapshot.preferences, isNot(contains('media_source_secret_7')));
+    expect(snapshot.preferences, isNot(contains('download_save_root')));
+  });
+
+  test('missing host rows materialize defaults so clearing propagates', () {
+    final InterconnectServiceConfigSnapshot snapshot =
+        InterconnectServiceConfigSnapshot.fromPreferences(
+      const <String, String>{},
+    );
+
+    expect(snapshot.preferences['jimaku_api_key'], PrefCodec.encode(''));
+    expect(
+      snapshot.preferences['manga_online_catalog_base_url'],
+      PrefCodec.encode('https://mokuro.moe'),
+    );
+    expect(
+      snapshot.preferences['manga_online_catalog_enabled'],
+      PrefCodec.encode(true),
+    );
+  });
+
+  test('client ignores unknown fields and applies only changed rows', () async {
+    await db.setPref('jimaku_api_key', PrefCodec.encode('old'));
+    await db.setPref('sync_device_id', PrefCodec.encode('keep-device'));
+
+    final InterconnectServiceConfigSnapshot snapshot =
+        InterconnectServiceConfigSnapshot.fromJson(<String, Object?>{
+      'schemaVersion': 1,
+      'preferences': <String, Object?>{
+        'jimaku_api_key': PrefCodec.encode('new'),
+        'manga_online_catalog_enabled': PrefCodec.encode(false),
+        'sync_device_id': PrefCodec.encode('attacker-device'),
+        'future_secret': PrefCodec.encode('attacker-secret'),
+      },
+    });
+
+    expect(await snapshot.applyTo(db), 2);
+    expect(
+      await db.getPref('jimaku_api_key'),
+      PrefCodec.encode('new'),
+    );
+    expect(
+      await db.getPref('manga_online_catalog_enabled'),
+      PrefCodec.encode(false),
+    );
+    expect(
+      await db.getPref('sync_device_id'),
+      PrefCodec.encode('keep-device'),
+    );
+    expect(await db.getPref('future_secret'), isNull);
+    expect(await snapshot.applyTo(db), 0, reason: 'replay must be idempotent');
+  });
+
+  test('rejects unsupported schema versions', () {
+    expect(
+      () => InterconnectServiceConfigSnapshot.fromJson(<String, Object?>{
+        'schemaVersion': 2,
+        'preferences': <String, Object?>{},
+      }),
+      throwsFormatException,
+    );
+  });
+}

--- a/hibiki/test/sync/sync_summary_test.dart
+++ b/hibiki/test/sync/sync_summary_test.dart
@@ -66,6 +66,11 @@ void main() {
         (SyncRunReport()..localAudioImported = 1).needsLocalLibraryRefresh,
         isTrue,
       );
+      expect(
+        (SyncRunReport()..serviceConfigsImported = 1).needsLocalLibraryRefresh,
+        isTrue,
+        reason: 'imported preferences require an AppModel cache refresh',
+      );
     });
 
     test('is false when sync only exported or changed remote data', () {
@@ -78,6 +83,13 @@ void main() {
             .needsLocalLibraryRefresh,
         isFalse,
       );
+    });
+
+    test('mergeFrom preserves service-config imports', () {
+      final SyncRunReport combined = SyncRunReport();
+      combined.mergeFrom(SyncRunReport()..serviceConfigsImported = 2);
+      expect(combined.serviceConfigsImported, 2);
+      expect(combined.needsLocalLibraryRefresh, isTrue);
     });
   });
 }


### PR DESCRIPTION
## What changed

- compose the Sources view from Hibiki Interconnect, the Mokuro.moe internet catalog, and every configured scan folder
- add a persistent Mokuro.moe source toggle; disabling it prevents catalog fetches and shows an explicit disabled state
- pull an explicit host-owned service-config allowlist during interconnect sync (Jimaku/TMDB API keys, qBittorrent connection config, and manga catalog URL/toggle)
- refresh AppModel preference caches after imported service config

## Security boundary

- keeps backup/Profile redaction unchanged
- service config is host -> child read-only
- requires HTTPS and a current per-peer token; plaintext HTTP and the legacy shared server token are rejected
- excludes device identity, pairing/sync credentials, local paths, media-source secrets, Yomitan inbound credentials, Bangumi/Anki credentials, and unknown future fields

## Root cause

Browse was wired directly to Mokuro.moe and fetched on init, while Sources only queried `media_sources` scan-root rows. The two surfaces had no shared enable state, so an empty Sources list could still show online catalog data.

## Validation

- targeted source/catalog/interconnect/service-config widget and unit suites: passed
- manga library split wiring suite: passed
- affected sync, manga-online, media-sources, and models static analysis: no issues
- `git diff --check`: passed
- full build intentionally not run/waited per request