### PR TITLE
fix(reader): stop audiobook navigation after dispose

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1203 条。点号进各自文件。
+> 共 1204 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1277](bugs/BUG-1277-reader-navigation-after-dispose.md) | ✅ | ✅ | 有声书跨章等待后触发已销毁 State 重绘 |
 | [BUG-1276](bugs/BUG-1276-dashboard-heatmap-dark-contrast.md) | ✅ | ✅ | 黑色主题下学习活动热力图空周融进背景 |
 | [BUG-1270](bugs/BUG-1270-youtube-live-subtitle-seek-duplicate.md) | ✅ | ✅ | YouTube 实时字幕回跳后重复且累积成长段 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |

--- a/docs/bugs/BUG-1246-reader-navigation-after-dispose.md
+++ b/docs/bugs/BUG-1246-reader-navigation-after-dispose.md
@@ -1,0 +1,29 @@
+## BUG-1246 · 有声书跨章等待后触发已销毁 State 重绘
+
+- **报告**：2026-07-29（用户：Android 错误日志显示有声书 cue 跨章节时，
+  `_handleCueCrossChapter → _navigateToChapter → _beginNavigation → _rebuild`
+  最终触发 `State.setState` 的空值断言）
+- **真实性**：✅ 真 bug。根因位于
+  `hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart:648-701`：
+  `_handleCueCrossChapter` 会先 `await _pauseThroughImageOnlyChapters` 展示中间纯图片章，
+  但 await 返回后没有复检 reader 生命周期，直接继续 `_navigateToChapter`。用户在等待期
+  退出 reader 时，`dispose` 已 detach 有声书回调并销毁 State，但这个已经在飞的 Future
+  仍会返回；`InAppWebViewController` 字段此时仍非 null，因此旧导航入口的
+  book/controller 守卫放行，随后 `_beginNavigation` 通过
+  `reader_hibiki_page.dart:1110-1113` 的 `_rebuild` 调用已销毁 State 的 `setState`。
+  同时，图片章序列的 `finally` 会持住 controller 的 chapter transition，若直接丢弃
+  导航而不取消，还会把守卫泄漏给进程级有声书 session。
+- **[x] ① 已修复** — 在跨图片章 await 返回后复检 `mounted` 与 controller；页面已退出
+  时先取消 chapter transition 再终止旧导航。`_navigateToChapter` 入口同步增加
+  `mounted` 生命周期门，统一 `_rebuild` 转发器也在 `setState` 前做最终 mounted 复检，
+  三层分别保证异步资源收尾、导航状态机和 State 更新边界不会越过 dispose。
+  修复提交：`cda704db6`。
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/pages/reader_navigation_dispose_guard_test.dart` 锁定三项顺序契约：
+  `_rebuild` 必须先 mounted 后 setState、导航必须在 `_beginNavigation` 前拒绝已销毁
+  reader、有声书跨图片章必须在 await 后复检并释放 transition 后才允许最终导航。
+  测试随修复提交 `cda704db6` 入库；改动文件定向 `dart analyze` 通过。
+- **备注**：同一日志中的互联同步 Socket/HTTP 超时是独立网络错误，不是本崩溃的调用链
+  根因，未在本条中混修。定向 `flutter test` 在执行任何断言前被 `pdfium_dart` native
+  asset 下载超时阻断；按用户要求不等待完整编译/真机验收，仍应由 PR CI 执行单测，
+  并在 Android 真机覆盖“播放跟随跨过纯图片章时立刻退出 reader”路径。

--- a/docs/bugs/BUG-1277-reader-navigation-after-dispose.md
+++ b/docs/bugs/BUG-1277-reader-navigation-after-dispose.md
@@ -1,4 +1,4 @@
-## BUG-1246 · 有声书跨章等待后触发已销毁 State 重绘
+## BUG-1277 · 有声书跨章等待后触发已销毁 State 重绘
 
 - **报告**：2026-07-29（用户：Android 错误日志显示有声书 cue 跨章节时，
   `_handleCueCrossChapter → _navigateToChapter → _beginNavigation → _rebuild`

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
@@ -690,6 +690,14 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
     // 被推进看见），图片等待对它彻底失效。跨章落定前先把中间纯图片章逐个导航过去
     // 并停留 imagePauseSec 秒，让用户看见每张整章插图，再继续到目标文本章。
     await _pauseThroughImageOnlyChapters(newSection);
+    // BUG-1246：图片章停留会跨越多个 await；期间 route 可能已 dispose。
+    // dispose 会 detach reader，但已经在飞的回调仍会从上面的 Future 返回。此时既不能
+    // 再进入 _navigateToChapter/setState，也不能把图片序列 finally 持住的跨章守卫
+    // 留给进程级有声书 session；取消本次 transition 后终止旧 reader 的导航。
+    if (!mounted || _controller == null) {
+      _audiobookController?.cancelChapterTransition();
+      return;
+    }
     await _navigateToChapter(newSection, progress: progress ?? 0.0);
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
@@ -690,7 +690,7 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
     // 被推进看见），图片等待对它彻底失效。跨章落定前先把中间纯图片章逐个导航过去
     // 并停留 imagePauseSec 秒，让用户看见每张整章插图，再继续到目标文本章。
     await _pauseThroughImageOnlyChapters(newSection);
-    // BUG-1246：图片章停留会跨越多个 await；期间 route 可能已 dispose。
+    // BUG-1277：图片章停留会跨越多个 await；期间 route 可能已 dispose。
     // dispose 会 detach reader，但已经在飞的回调仍会从上面的 Future 返回。此时既不能
     // 再进入 _navigateToChapter/setState，也不能把图片序列 finally 持住的跨章守卫
     // 留给进程级有声书 session；取消本次 transition 后终止旧 reader 的导航。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -486,7 +486,10 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     bool manual = false,
     String? preciseLocateJs,
   }) async {
-    if (_book == null || index < 0 || index >= _book!.chapters.length) {
+    if (!mounted ||
+        _book == null ||
+        index < 0 ||
+        index >= _book!.chapters.length) {
       return;
     }
     if (_controller == null) {

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1106,8 +1106,12 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
 
   /// 库内 part 文件（extension）改状态的入口：扩展不被视作 State 子类实例成员，
   /// 直接调 @protected 的 setState 会报 invalid_use_of_protected_member。由本 State
-  /// 子类持有的这个转发器统一承接，零行为变化（仅转发）。
-  void _rebuild(VoidCallback fn) => setState(fn);
+  /// 子类持有的这个转发器统一承接。part 中的异步回调可能在 route dispose 后才返回；
+  /// 此时状态已不可再更新，统一在转发边界丢弃，避免晚到回调触发 setState-after-dispose。
+  void _rebuild(VoidCallback fn) {
+    if (!mounted) return;
+    setState(fn);
+  }
 
   /// 同 [_rebuild] 的理由：part 扩展不被视作 State 子类实例成员，直接读写
   /// `BaseSourcePageState` 的 @protected 弹窗栈成员会报 invalid_use_of_protected_member。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1011
+version: 1.3.1+1012
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/reader_navigation_dispose_guard_test.dart
+++ b/hibiki/test/pages/reader_navigation_dispose_guard_test.dart
@@ -1,0 +1,90 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final String readerPage = File(
+    'lib/src/pages/implementations/reader_hibiki_page.dart',
+  ).readAsStringSync();
+  final String navigationPart = File(
+    'lib/src/pages/implementations/reader_hibiki/navigation.part.dart',
+  ).readAsStringSync();
+  final String audiobookPart = File(
+    'lib/src/pages/implementations/reader_hibiki/audiobook.part.dart',
+  ).readAsStringSync();
+
+  String bodyBetween(String source, String start, String end) {
+    final int startIndex = source.indexOf(start);
+    expect(startIndex, isNonNegative, reason: '找不到方法起点：$start');
+    final int endIndex = source.indexOf(end, startIndex + start.length);
+    expect(endIndex, greaterThan(startIndex), reason: '找不到方法终点：$end');
+    return source.substring(startIndex, endIndex);
+  }
+
+  test('_rebuild 在统一 setState 转发边界拒绝已销毁 State', () {
+    final String body = bodyBetween(
+      readerPage,
+      'void _rebuild(VoidCallback fn) {',
+      'DictionaryPopupWebViewState? get _caretTopPopupState',
+    );
+    final int mountedGuard = body.indexOf('if (!mounted) return;');
+    final int setStateCall = body.indexOf('setState(fn);');
+
+    expect(mountedGuard, isNonNegative);
+    expect(
+      setStateCall,
+      greaterThan(mountedGuard),
+      reason: 'mounted 必须在 setState 之前复检，晚到的 part 回调不得触发已销毁 State',
+    );
+  });
+
+  test('_navigateToChapter 在任何状态变更前拒绝已销毁 reader', () {
+    final String body = bodyBetween(
+      navigationPart,
+      'Future<void> _navigateToChapter(',
+      'Future<bool> _navigateToChapterAndWait(',
+    );
+    final int mountedGuard = body.indexOf('if (!mounted ||');
+    final int beginNavigation = body.indexOf('_beginNavigation(');
+
+    expect(mountedGuard, isNonNegative);
+    expect(
+      beginNavigation,
+      greaterThan(mountedGuard),
+      reason: '所有导航入口都必须先验证 State 仍 mounted，再初始化导航代际并重绘',
+    );
+  });
+
+  test('有声书跨图片章 await 返回后复检生命周期并释放 transition', () {
+    final String body = bodyBetween(
+      audiobookPart,
+      'Future<void> _handleCueCrossChapter(',
+      'Future<void> _pauseThroughImageOnlyChapters(',
+    );
+    final int pauseAwait =
+        body.indexOf('await _pauseThroughImageOnlyChapters(newSection);');
+    final int mountedGuard =
+        body.indexOf('if (!mounted || _controller == null)', pauseAwait);
+    final int cancelTransition = body.indexOf(
+      '_audiobookController?.cancelChapterTransition();',
+      mountedGuard,
+    );
+    final int finalNavigation = body.indexOf(
+      'await _navigateToChapter(newSection',
+      pauseAwait,
+    );
+
+    expect(pauseAwait, isNonNegative);
+    expect(mountedGuard, greaterThan(pauseAwait));
+    expect(
+      cancelTransition,
+      greaterThan(mountedGuard),
+      reason: 'dispose 竞态终止导航时必须释放图片序列持住的跨章 transition',
+    );
+    expect(
+      finalNavigation,
+      greaterThan(cancelTransition),
+      reason: '最终跨章导航只能发生在 await 后的生命周期复检与清理分支之后',
+    );
+  });
+}


### PR DESCRIPTION
## 改动

- 有声书跨纯图片章等待结束后，重新检查 reader 是否仍 mounted；已退出时释放 chapter transition 并终止旧导航。
- `_navigateToChapter` 在初始化导航代际和重绘前统一拒绝已销毁 State。
- `_rebuild` 在 `setState` 前增加最终 mounted 边界，防止其他 part 的晚到异步回调复现同类崩溃。
- 新增 BUG-1246、三项源码顺序守卫，并将版本从 `1.3.1+1001` 升到 `1.3.1+1002`。

## 根因

`_handleCueCrossChapter` 会 await 中间纯图片章的展示序列。用户在等待期间退出 reader 后，已经在飞的 Future 仍会返回；旧代码随后进入 `_navigateToChapter → _beginNavigation → _rebuild → setState`。WebView controller 字段仍非 null，因此原有 book/controller 检查不能代表 State 仍存活。同时，图片序列 finally 持住的 chapter transition 若不取消，会泄漏到进程级有声书 session。

同一日志里的互联同步 Socket/HTTP 超时是独立网络故障，不在本 PR 混修。

## 验证

- `dart analyze`（3 个生产文件 + 新测试）：通过，No issues found。
- `dart tool/bug.dart check`：通过，1195 条、编号唯一、索引同步。
- `git diff --check`：通过。
- 定向 `flutter test --no-pub test/pages/reader_navigation_dispose_guard_test.dart test/media/audiobook/cross_chapter_no_zero_test.dart test/media/audiobook/cross_chapter_toc_guard_test.dart`：未进入测试体；`pdfium_dart` native asset 从 GitHub Release 下载超时，0 个断言运行。
- 按用户要求未等待完整编译、全量 analyze 或 Android 真机验收。后续真机应覆盖“播放跟随跨过纯图片章时立刻退出 reader”。