### PR TITLE
fix(gal): isolate Unity text threads and preserve full lines

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1194 条。点号进各自文件。
+> 共 1195 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1247](bugs/BUG-1247-gal-unity-text-source-isolation.md) | ✅ | ✅ | Unity TextMesh 停顿拆句且绕过文本线程选择 |
 | [BUG-1239](bugs/BUG-1239-video-ime-fullwidth-space.md) | ✅ | ✅ | 全角空格在视频页仍无法播放暂停 |
 | [BUG-1237](bugs/BUG-1237-popup-touch-copy-actionmode-finished.md) | ✅ | ✅ | 查词弹窗触屏复制经已结束 ActionMode 失效 |
 | [BUG-1236](bugs/BUG-1236-reader-selection-menu-modal-blocks-handles.md) | ✅ | ✅ | 移动端阅读器选区菜单阻断手柄拖动 |

--- a/docs/bugs/BUG-1247-gal-unity-text-source-isolation.md
+++ b/docs/bugs/BUG-1247-gal-unity-text-source-isolation.md
@@ -1,0 +1,23 @@
+## BUG-1247 · Unity TextMesh 停顿拆句且绕过文本线程选择
+- **报告**：2026-07-29（用户：同一句括号内文本被拆成上下两条；质疑 Luna 与
+  Unity TextMesh 为何不能分别作为候选线程）
+- **真实性**：✅ 真 bug。`native/galgame_hook/hook/adapters/unity_adapter.inc`
+  的 legacy TextMesh 聚合器把 250ms 停顿、CR、LF 和 U+3000 都当作句界，并直接写
+  `text_write_count`，完全没有检查 v12 的 `selected_text_thread_id`。因此一次打字停顿
+  会把一句拆半；即便用户未选或选了 Luna，native TextMesh 仍会污染正式文本环。
+- **[x] ① 已修复** — Luna 与 native adapter 使用互斥预览槽分区和互斥 thread-id
+  namespace；native 文本先进入候选预览，只有精确命中显式选择才发布正式行。TextMesh
+  去掉时钟断句，保留 CR/LF/TAB；U+3000 仅在真实样本证明其为批次结束符的
+  `Sasasa.exe` profile 中终止，其他 Unity 标题按正文保留。空字符串和正常 helper
+  收尾仍提交尚未结束的末句。
+- **[x] ② 已加自动化测试** —
+  `native/galgame_hook/tests/unity_text_mesh_reassembler_test.cpp` 覆盖换行、全角空格、
+  profile 负向和 thread-id namespace；
+  `native/galgame_hook/tests/thread_preview_ipc_test.cpp` 守卫跨进程槽分区与原子变更计数；
+  `native/galgame_hook/tests/adapter_structure_test.py` 守卫无时间断句、选择门和正常收尾；
+  `hibiki/test/tools/voice_hook_ipc_contract_test.dart` 守卫 host/native 契约；
+  `hibiki/test/mining/gal_capture_audio_integrity_test.dart` 守卫未选择时工作台、浮窗、
+  配对和制卡均不得消费历史正式环。
+- **备注**：本修复不把 Luna 与 TextMesh 合并或互相屏蔽；两者始终作为独立候选供用户
+  选择。按用户要求不等待 x86/x64 全编译验收，合入前仍执行生成器、结构和可用的定向测试，
+  未运行项在 PR 中明确记录。

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -658,22 +658,20 @@ class GalHookSessionController extends ChangeNotifier {
   List<TexthookerTextThread> get textThreads =>
       _textService.textThreadsSince(_state.sessionStartedAt);
 
-  /// 捕获工作台当前应展示的行。捕获中只看本次会话，避免上一个进程的 Luna 线程/台词
-  /// 混进当前选择；「全部线程」再折叠同一渲染瞬间的跨线程双写。底层 buffer 不删。
+  /// 捕获工作台当前应展示的正式行。没有选择时只允许下拉里的候选预览可见，
+  /// 正式台词、浮窗、配对和制卡都必须为空；底层诊断 buffer 不删。
   List<TexthookerLineEntry> get workbenchLines {
+    final String? selectedKey = selectedTextThreadKey;
+    if (selectedKey == null) return const <TexthookerLineEntry>[];
     final DateTime? startedAt = _state.sessionStartedAt;
     Iterable<TexthookerLineEntry> scoped =
-        _textService.entriesForTextThread(selectedTextThreadKey);
+        _textService.entriesForTextThread(selectedKey);
     if (startedAt != null) {
       scoped = scoped.where(
         (TexthookerLineEntry entry) => !entry.receivedAt.isBefore(startedAt),
       );
     }
-    final List<TexthookerLineEntry> materialized =
-        scoped.toList(growable: false);
-    return selectedTextThreadKey == null
-        ? collapseParallelTextThreadDuplicates(materialized)
-        : List<TexthookerLineEntry>.unmodifiable(materialized);
+    return List<TexthookerLineEntry>.unmodifiable(scoped);
   }
 
   String? get selectedTextThreadKey {
@@ -699,10 +697,13 @@ class GalHookSessionController extends ChangeNotifier {
   /// 制卡只允许消费这里的行，防止跨会话或跨线程借用上下文。
   List<TexthookerLineEntry> get selectedSessionLines {
     final DateTime? startedAt = _state.sessionStartedAt;
-    if (startedAt == null) return const <TexthookerLineEntry>[];
+    final String? selectedKey = selectedTextThreadKey;
+    if (startedAt == null || selectedKey == null) {
+      return const <TexthookerLineEntry>[];
+    }
     return List<TexthookerLineEntry>.unmodifiable(
       _textService
-          .entriesForTextThread(selectedTextThreadKey)
+          .entriesForTextThread(selectedKey)
           .where((entry) => !entry.receivedAt.isBefore(startedAt)),
     );
   }
@@ -1857,7 +1858,7 @@ class GalHookSessionController extends ChangeNotifier {
       'text',
       selected ? 'text.thread_selected' : 'text.thread_select_failed',
       threadId == null || threadId == 0
-          ? 'Automatic text-thread selection enabled'
+          ? 'Text thread selection cleared'
           : 'Text thread selected',
       details: <String, Object?>{
         'threadId': threadId ?? 0,
@@ -2217,7 +2218,7 @@ class GalHookSessionController extends ChangeNotifier {
     );
   }
 
-  /// 用户显式选定/取消文本线程后同步持久化（null = 自动，清掉记忆）。
+  /// 用户显式选定/取消文本线程后同步持久化（null = 未选择，清掉记忆）。
   void _persistTextThread(TexthookerTextThread? thread) {
     if (!_ensureCaptureMemoryLoaded()) return;
     final String? fingerprint =

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1001
+version: 1.3.1+1002
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/mining/gal_capture_audio_integrity_test.dart
+++ b/hibiki/test/mining/gal_capture_audio_integrity_test.dart
@@ -372,9 +372,19 @@ void main() {
       expect(controller.selectedNativeTextThreadId, 7);
       await waitUntil(() => service.entries.length == 3);
 
-      // 用户改选「全部」：记忆被清掉，不再自动恢复。
+      // 用户取消选择：记忆被清掉，不再自动恢复，正式消费者也必须立刻归零。
       await controller.selectTextThread(null, remember: true);
       expect(store[r'd:\games\fake.exe']!.textThreadFingerprint, isNull);
+      expect(
+        controller.workbenchLines,
+        isEmpty,
+        reason: '未选线程时历史正式环只能留作诊断，不得继续进入工作台',
+      );
+      expect(
+        controller.selectedSessionLines,
+        isEmpty,
+        reason: '未选线程时浮窗、配对和制卡不得消费任何来源',
+      );
 
       await controller.close();
       endpoints.dispose();

--- a/hibiki/test/tools/voice_hook_ipc_contract_test.dart
+++ b/hibiki/test/tools/voice_hook_ipc_contract_test.dart
@@ -67,6 +67,16 @@ void main() {
     );
     expect(
       sharedHeader,
+      contains('constexpr uint32_t kLunaThreadPreviewCount = 48;'),
+    );
+    expect(
+      sharedHeader,
+      contains(
+        'constexpr uint32_t kNativeThreadPreviewStart = kLunaThreadPreviewCount;',
+      ),
+    );
+    expect(
+      sharedHeader,
       contains(
         'constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;',
       ),
@@ -90,6 +100,10 @@ void main() {
     // reader 只发布 odd/even 原子双读后的稳定快照，write_count 同样不能在 x86 裸读。
     expect(reader, contains('TryReadThreadPreviewSnapshot(slot, &snapshot)'));
     expect(reader, contains('AtomicLoadPreview64('));
+    expect(
+      sharedHeader,
+      contains('inline void PublishThreadPreviewChange('),
+    );
   });
 
   test('native profile prefer cannot bypass v12 explicit thread selection', () {
@@ -111,12 +125,37 @@ void main() {
       isNot(contains('preferred_hook_codes')),
     );
     expect(functionBody, isNot(contains('const wchar_t* hookcode')));
-    expect(functionBody, contains('selected_text_thread_id'));
+    expect(functionBody, contains('SelectedTextThreadId(g_luna.header)'));
     expect(
       functionBody,
       contains(
         'AcceptsLine(\n      thread_id, is_artifact, manually_selected, face_id)',
       ),
+    );
+  });
+
+  test('Unity native text uses preview first and the same explicit gate', () {
+    final String source = File(
+      '../native/galgame_hook/hook/adapters/unity_adapter.inc',
+    ).readAsStringSync();
+    final int functionStart = source.indexOf('void PublishUnityText(');
+    final int functionEnd = source.indexOf(
+      '\n}\n\nvoid RecordUnityTmpText',
+      functionStart,
+    );
+    expect(functionStart, greaterThanOrEqualTo(0));
+    expect(functionEnd, greaterThan(functionStart));
+    final String body = source.substring(functionStart, functionEnd);
+
+    expect(body, contains('WriteUnityThreadPreview('));
+    expect(body, contains('IsExactTextThreadSelected(g_header, thread_id)'));
+    expect(
+      body.indexOf('WriteUnityThreadPreview('),
+      lessThan(body.indexOf('IsExactTextThreadSelected(')),
+    );
+    expect(
+      body.indexOf('IsExactTextThreadSelected('),
+      lessThan(body.indexOf('WriteUnityTextEvent(')),
     );
   });
 }

--- a/hibiki/windows/runner/voice_hook_ipc.h
+++ b/hibiki/windows/runner/voice_hook_ipc.h
@@ -15,7 +15,8 @@
 // v10：文本槽追加事件类型，透传 Luna ThreadCreate，使尚无台词的候选线程也可被选择。
 // v12：追加「线程预览区」并取消 injector 自动选线程。文本环仍只装**当前生效线程**（配对路径
 //     不受影响），每条线程的最近一行改由预览区按线程分槽保存，供选择器展示——两个诉求相反的
-//     消费者不再抢同一块 256 槽 FIFO。完整推导见真相源头文件的 v12 注释。
+//     消费者不再抢同一块 256 槽 FIFO。LunaHost 与游戏内 native adapter 还会使用
+//     `thread_preview_ipc.h` 声明的互斥槽分区，避免跨进程 writer 争抢同一槽。
 // 读共享内存不是注入、不被杀软标记，可安全进 hibiki.exe。契约用 magic/version 版本化。
 namespace hibiki_voice_hook {
 
@@ -189,7 +190,8 @@ struct SharedHeader {
   // ── v12 线程预览区（布局最尾，前面各区偏移一个都不动）──
   uint32_t thread_preview_offset;
   uint32_t thread_preview_slot_count;
-  // 单调累计已写预览行数。只用于判断「有没有新预览」以跳过整区扫描；预览槽本身按
+  // 单调累计预览变更次数（含 partial TextMesh 快照）。只用于判断「有没有新预览」；
+  // 预览槽本身按
   // thread_id 寻址，**不**靠这个序号定位（与 text_write_count 语义不同，勿照搬取模那套）。
   volatile uint64_t thread_preview_write_count;
 };

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -198,6 +198,15 @@ target_compile_definitions(hibiki_thread_preview_ipc_test
 add_test(NAME hibiki_thread_preview_ipc_test
   COMMAND hibiki_thread_preview_ipc_test)
 
+add_executable(hibiki_unity_text_mesh_reassembler_test
+  tests/unity_text_mesh_reassembler_test.cpp)
+target_include_directories(hibiki_unity_text_mesh_reassembler_test
+  PRIVATE include)
+target_compile_definitions(hibiki_unity_text_mesh_reassembler_test
+  PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
+add_test(NAME hibiki_unity_text_mesh_reassembler_test
+  COMMAND hibiki_unity_text_mesh_reassembler_test)
+
 add_executable(hibiki_adapter_contract_test tests/adapter_contract_test.cpp)
 target_include_directories(hibiki_adapter_contract_test PRIVATE hook)
 add_test(NAME hibiki_adapter_contract_test COMMAND hibiki_adapter_contract_test)

--- a/native/galgame_hook/hook/adapters/unity_adapter.inc
+++ b/native/galgame_hook/hook/adapters/unity_adapter.inc
@@ -99,9 +99,11 @@ using UnityTextMeshSetText = void (*)(void*, void*, const void*);
 UnityTextMeshSetText g_orig_UnityTextMeshSetText = nullptr;
 using NaninovelRevealableSetText = void (*)(void*, void*, const void*);
 NaninovelRevealableSetText g_orig_NaninovelRevealableSetText = nullptr;
-wchar_t g_unity_text_mesh_line[501] = {0};
-int g_unity_text_mesh_line_length = 0;
-ULONGLONG g_unity_text_mesh_last_tick = 0;
+hibiki_voice_hook::UnityTextMeshReassembler<501>
+    g_unity_text_mesh_reassembler;
+bool g_unity_sasasa_text_mesh_profile = false;
+bool g_unity_text_profile_initialized = false;
+alignas(8) volatile uint64_t g_unity_preview_generation = 0;
 
 int InvokeUnityInt(const void* method, void* instance) {
   if (method == nullptr || instance == nullptr ||
@@ -148,11 +150,14 @@ bool CopyUnityClipName(void* clip, wchar_t* out, size_t out_chars) {
   return true;
 }
 
-void RecordUnityTextBuffer(void* text_component, const wchar_t* clean,
-                           int length, const char* hook_name,
-                           const wchar_t* hook_code) {
+void WriteUnityTextEvent(uint64_t thread_id, void* text_component,
+                         const wchar_t* clean, int length,
+                         const char* hook_name, const wchar_t* hook_code,
+                         uint32_t event_kind) {
   if (!g_capture_enabled || g_header == nullptr || g_text_base == nullptr ||
-      text_component == nullptr || clean == nullptr || length <= 0) {
+      thread_id == 0 ||
+      (event_kind == hibiki_voice_hook::kTextEventLine &&
+       (clean == nullptr || length <= 0))) {
     return;
   }
 
@@ -163,18 +168,25 @@ void RecordUnityTextBuffer(void* text_component, const wchar_t* clean,
       static_cast<size_t>(index % kTextSlotCount) * kTextSlotBytes;
   auto* text_slot = reinterpret_cast<TextSlot*>(slot);
   memset(text_slot, 0, sizeof(TextSlot));
-  uint32_t byte_length = static_cast<uint32_t>(length) * sizeof(wchar_t);
+  uint32_t byte_length =
+      clean == nullptr || length <= 0
+          ? 0
+          : static_cast<uint32_t>(length) * sizeof(wchar_t);
   uint32_t max_bytes = kTextSlotBytes - static_cast<uint32_t>(sizeof(TextSlot));
   max_bytes -= max_bytes % sizeof(wchar_t);
   if (byte_length > max_bytes) byte_length = max_bytes;
-  memcpy(slot + sizeof(TextSlot), clean, byte_length);
+  if (byte_length != 0) {
+    memcpy(slot + sizeof(TextSlot), clean, byte_length);
+  }
   text_slot->timestamp_ms = GetTickCount64();
   text_slot->byte_len = byte_length;
   text_slot->is_utf8 = 0;
-  text_slot->thread_id = reinterpret_cast<uint64_t>(text_component);
+  text_slot->thread_id = thread_id;
+  text_slot->thread_address = reinterpret_cast<uint64_t>(text_component);
   text_slot->thread_context = reinterpret_cast<uint64_t>(text_component);
   text_slot->process_id = GetCurrentProcessId();
   text_slot->source_kind = hibiki_voice_hook::kTextSourceUnityTmp;
+  text_slot->event_kind = event_kind;
   const size_t hook_name_capacity = sizeof(text_slot->hook_name) - 1;
   const size_t hook_name_length =
       hook_name == nullptr ? 0 : strnlen_s(hook_name, hook_name_capacity);
@@ -194,6 +206,101 @@ void RecordUnityTextBuffer(void* text_component, const wchar_t* clean,
   MemoryBarrier();
   text_slot->seq = static_cast<uint64_t>(reserved);
   g_header->text_hooked = 1;
+}
+
+bool WriteUnityThreadPreview(uint64_t thread_id, const wchar_t* clean,
+                             int length, bool completed_line,
+                             const char* hook_name,
+                             const wchar_t* hook_code,
+                             void* text_component) {
+  if (!g_capture_enabled || g_header == nullptr || thread_id == 0 ||
+      clean == nullptr || length <= 0 ||
+      g_header->thread_preview_offset == 0) {
+    return false;
+  }
+
+  if (g_cs_ready) EnterCriticalSection(&g_cs);
+  auto* all_slots = reinterpret_cast<hibiki_voice_hook::ThreadPreviewSlot*>(
+      reinterpret_cast<uint8_t*>(g_header) +
+      g_header->thread_preview_offset);
+  const uint32_t total_count =
+      (std::min)(g_header->thread_preview_slot_count,
+                 hibiki_voice_hook::kThreadPreviewCount);
+  if (total_count <= hibiki_voice_hook::kNativeThreadPreviewStart) {
+    if (g_cs_ready) LeaveCriticalSection(&g_cs);
+    return false;
+  }
+  auto* native_slots =
+      all_slots + hibiki_voice_hook::kNativeThreadPreviewStart;
+  const uint32_t native_count =
+      (std::min)(total_count - hibiki_voice_hook::kNativeThreadPreviewStart,
+                 hibiki_voice_hook::kNativeThreadPreviewCount);
+  auto* preview = hibiki_voice_hook::FindThreadPreviewSlot(
+      native_slots, native_count, thread_id);
+  if (preview == nullptr) {
+    // Native Unity components do not have a reliable ThreadRemove callback.
+    // Recycle the oldest non-selected candidate instead of permanently
+    // blinding the selector after 16 historical menu/text components.
+    const uint64_t selected =
+        hibiki_voice_hook::SelectedTextThreadId(g_header);
+    for (uint32_t i = 0; i < native_count; ++i) {
+      auto* candidate = &native_slots[i];
+      if (candidate->thread_id == selected) continue;
+      if (preview == nullptr ||
+          candidate->timestamp_ms < preview->timestamp_ms) {
+        preview = candidate;
+      }
+    }
+    if (preview == nullptr) {
+      if (g_cs_ready) LeaveCriticalSection(&g_cs);
+      return false;
+    }
+  }
+
+  const bool discovered = preview->thread_id != thread_id;
+  const uint64_t generation =
+      hibiki_voice_hook::NextThreadPreviewGeneration(
+          &g_unity_preview_generation);
+  hibiki_voice_hook::BeginThreadPreviewWrite(preview, generation);
+  if (discovered) {
+    preview->line_count = 0;
+    preview->artifact_count = 0;
+  }
+  preview->thread_id = thread_id;
+  if (completed_line) preview->line_count++;
+  const uint32_t max_bytes =
+      hibiki_voice_hook::kThreadPreviewTextChars * sizeof(wchar_t);
+  uint32_t byte_length = static_cast<uint32_t>(length) * sizeof(wchar_t);
+  if (byte_length > max_bytes) byte_length = max_bytes;
+  ZeroMemory(preview->text, sizeof(preview->text));
+  memcpy(preview->text, clean, byte_length);
+  preview->byte_len = byte_length;
+  preview->event_flags = 0;
+  preview->timestamp_ms = GetTickCount64();
+  hibiki_voice_hook::PublishThreadPreviewWrite(preview, generation);
+  hibiki_voice_hook::PublishThreadPreviewChange(
+      &g_header->thread_preview_write_count);
+  if (g_cs_ready) LeaveCriticalSection(&g_cs);
+
+  if (discovered) {
+    WriteUnityTextEvent(
+        thread_id, text_component, nullptr, 0, hook_name, hook_code,
+        hibiki_voice_hook::kTextEventThreadDiscovered);
+  }
+  return true;
+}
+
+void PublishUnityText(uint64_t thread_id, void* text_component,
+                      const wchar_t* clean, int length, bool completed_line,
+                      const char* hook_name, const wchar_t* hook_code) {
+  WriteUnityThreadPreview(thread_id, clean, length, completed_line, hook_name,
+                          hook_code, text_component);
+  if (!completed_line ||
+      !hibiki_voice_hook::IsExactTextThreadSelected(g_header, thread_id)) {
+    return;
+  }
+  WriteUnityTextEvent(thread_id, text_component, clean, length, hook_name,
+                      hook_code, hibiki_voice_hook::kTextEventLine);
 }
 
 void RecordUnityTmpText(void* text_component, void* string_object,
@@ -231,44 +338,62 @@ void RecordUnityTmpText(void* text_component, void* string_object,
     }
   }
   if (length == 0 || meaningful == 0 || (!has_cjk && meaningful < 2)) return;
-  RecordUnityTextBuffer(text_component, clean, length, hook_name, hook_code);
+  const uint64_t thread_id = hibiki_voice_hook::NativeTextThreadIdFrom(
+      reinterpret_cast<uint64_t>(text_component), hook_code, hook_name);
+  PublishUnityText(thread_id, text_component, clean, length, true, hook_name,
+                   hook_code);
 }
 
 void FlushUnityTextMeshLine() {
-  if (g_unity_text_mesh_line_length <= 0) return;
-  RecordUnityTextBuffer(
-      static_cast<void*>(g_unity_text_mesh_line), g_unity_text_mesh_line,
-      g_unity_text_mesh_line_length, "Unity TextMesh line",
-      L"UnityEngine.TextMesh.set_text(glyphs)");
-  memset(g_unity_text_mesh_line, 0, sizeof(g_unity_text_mesh_line));
-  g_unity_text_mesh_line_length = 0;
+  if (g_unity_text_mesh_reassembler.empty()) return;
+  constexpr char kHookName[] = "Unity TextMesh line";
+  constexpr wchar_t kHookCode[] =
+      L"UnityEngine.TextMesh.set_text(glyphs)";
+  const uint64_t thread_id =
+      hibiki_voice_hook::NativeTextThreadIdFrom(0, kHookCode, kHookName);
+  PublishUnityText(thread_id, nullptr, g_unity_text_mesh_reassembler.text(),
+                   g_unity_text_mesh_reassembler.length(), true, kHookName,
+                   kHookCode);
+  g_unity_text_mesh_reassembler.Reset();
 }
 
-void RecordUnityTextMesh(void* string_object) {
-  if (g_il2cpp_string_chars == nullptr || g_il2cpp_string_length == nullptr) {
+void RecordUnityTextMesh(void* text_component, void* string_object) {
+  if (!g_capture_enabled || g_il2cpp_string_chars == nullptr ||
+      g_il2cpp_string_length == nullptr) {
+    return;
+  }
+  if (!g_unity_sasasa_text_mesh_profile) {
+    RecordUnityTmpText(text_component, string_object, "Unity TextMesh",
+                       L"UnityEngine.TextMesh.set_text");
     return;
   }
   const wchar_t* chars =
       string_object == nullptr ? nullptr : g_il2cpp_string_chars(string_object);
   const int source_length =
       string_object == nullptr ? 0 : g_il2cpp_string_length(string_object);
-  const ULONGLONG now = GetTickCount64();
   if (g_cs_ready) EnterCriticalSection(&g_cs);
-  if (g_unity_text_mesh_line_length > 0 &&
-      now - g_unity_text_mesh_last_tick > 250) {
-    FlushUnityTextMeshLine();
+  if (!g_capture_enabled) {
+    if (g_cs_ready) LeaveCriticalSection(&g_cs);
+    return;
   }
   for (int i = 0; chars != nullptr && i < source_length; ++i) {
     const wchar_t c = chars[i];
-    if (c == L'\u3000' || c == L'\r' || c == L'\n') {
+    if (g_unity_text_mesh_reassembler.ShouldTerminate(c, true)) {
       FlushUnityTextMeshLine();
       continue;
     }
-    if (c < 0x20 || g_unity_text_mesh_line_length >= 500) continue;
-    g_unity_text_mesh_line[g_unity_text_mesh_line_length++] = c;
+    if (!g_unity_text_mesh_reassembler.Append(c)) continue;
+    constexpr char kHookName[] = "Unity TextMesh line";
+    constexpr wchar_t kHookCode[] =
+        L"UnityEngine.TextMesh.set_text(glyphs)";
+    const uint64_t thread_id =
+        hibiki_voice_hook::NativeTextThreadIdFrom(0, kHookCode, kHookName);
+    PublishUnityText(thread_id, nullptr,
+                     g_unity_text_mesh_reassembler.text(),
+                     g_unity_text_mesh_reassembler.length(), false, kHookName,
+                     kHookCode);
   }
   if (source_length == 0) FlushUnityTextMeshLine();
-  g_unity_text_mesh_last_tick = now;
   if (g_cs_ready) LeaveCriticalSection(&g_cs);
 }
 
@@ -545,7 +670,7 @@ void Detour_UnityUiTextSetText(void* self, void* text, const void* method) {
 void Detour_UnityTextMeshSetText(void* self, void* text,
                                  const void* method) {
   g_orig_UnityTextMeshSetText(self, text, method);
-  RecordUnityTextMesh(text);
+  RecordUnityTextMesh(self, text);
 }
 
 void Detour_NaninovelRevealableSetText(void* self, void* text,
@@ -622,6 +747,16 @@ bool HasCurrentProcessTopLevelWindow() {
 }
 
 bool TryHookUnityIl2CppAudio() {
+  if (!g_unity_text_profile_initialized) {
+    wchar_t executable_path[MAX_PATH] = {0};
+    const DWORD path_length =
+        GetModuleFileNameW(nullptr, executable_path, MAX_PATH);
+    g_unity_sasasa_text_mesh_profile =
+        path_length != 0 && path_length < MAX_PATH &&
+        hibiki_voice_hook::UsesSasasaLegacyTextMeshTerminator(
+            executable_path);
+    g_unity_text_profile_initialized = true;
+  }
   const bool audio_ready =
       g_orig_UnityAudioSourcePlay != nullptr ||
       g_orig_UnityAudioSourcePlayOneShot1 != nullptr ||

--- a/native/galgame_hook/hook/dll_main.cpp
+++ b/native/galgame_hook/hook/dll_main.cpp
@@ -44,6 +44,9 @@
 #include "ffmpeg_runtime.h"
 #include "siglus_ovk.h"
 #include "siglus_text.h"
+#include "text_thread_identity.h"
+#include "unity_text_mesh_reassembler.h"
+#include "unity_text_profile.h"
 #include "visual_arts_ovk.h"
 #include "voice_hook_ipc.h"
 #include "voice_resource_filename.h"
@@ -510,8 +513,12 @@ DWORD WINAPI HookWorker(LPVOID) {
     Sleep(registry.PollDelayMs());
   }
 
-  // 收尾在工作线程里做（不在 loader lock 中）：先关捕获总开关，join loopback 线程，再拆 MinHook。
+  // 收尾在工作线程里做（不在 loader lock 中）：先提交仍在组装的 legacy TextMesh
+  // 末句，再在同一把 adapter 锁内关总开关，确保正常结束不会静默丢尾句。
+  if (g_cs_ready) EnterCriticalSection(&g_cs);
+  FlushUnityTextMeshLine();
   g_capture_enabled = false;
+  if (g_cs_ready) LeaveCriticalSection(&g_cs);
   registry.Shutdown();
   if (g_mh_init) {
     MH_DisableHook(MH_ALL_HOOKS);

--- a/native/galgame_hook/include/text_thread_identity.h
+++ b/native/galgame_hook/include/text_thread_identity.h
@@ -1,0 +1,52 @@
+#ifndef HIBIKI_TEXT_THREAD_IDENTITY_H_
+#define HIBIKI_TEXT_THREAD_IDENTITY_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <cwchar>
+
+namespace hibiki_voice_hook {
+
+// Native engine adapters and Luna share one selected_text_thread_id field.
+// Reserve bit 62 for native sources while keeping bit 63 clear so ids survive
+// Flutter's signed int64 platform channel as positive values.
+constexpr uint64_t kNativeTextThreadNamespaceBit = 1ull << 62;
+constexpr uint64_t kTextThreadIdentityPayloadMask =
+    kNativeTextThreadNamespaceBit - 1;
+
+inline uint64_t NormalizeLunaTextThreadId(uint64_t raw) {
+  const uint64_t normalized = raw & kTextThreadIdentityPayloadMask;
+  return normalized == 0 ? 1 : normalized;
+}
+
+inline uint64_t TextThreadFnv1a64(uint64_t hash, const void* data,
+                                  size_t size) {
+  const auto* bytes = static_cast<const unsigned char*>(data);
+  for (size_t i = 0; i < size; ++i) {
+    hash ^= bytes[i];
+    hash *= 1099511628211ull;
+  }
+  return hash;
+}
+
+inline uint64_t NativeTextThreadIdFrom(uint64_t component_identity,
+                                       const wchar_t* hook_code,
+                                       const char* hook_name) {
+  uint64_t hash = 1469598103934665603ull;
+  hash = TextThreadFnv1a64(hash, &component_identity,
+                          sizeof(component_identity));
+  if (hook_code != nullptr) {
+    hash = TextThreadFnv1a64(
+        hash, hook_code, std::wcslen(hook_code) * sizeof(wchar_t));
+  }
+  if (hook_name != nullptr) {
+    hash = TextThreadFnv1a64(hash, hook_name, std::strlen(hook_name));
+  }
+  return (hash & kTextThreadIdentityPayloadMask) |
+         kNativeTextThreadNamespaceBit;
+}
+
+}  // namespace hibiki_voice_hook
+
+#endif  // HIBIKI_TEXT_THREAD_IDENTITY_H_

--- a/native/galgame_hook/include/thread_preview_ipc.h
+++ b/native/galgame_hook/include/thread_preview_ipc.h
@@ -13,6 +13,15 @@ constexpr uint32_t kThreadPreviewCount = 64;
 constexpr uint32_t kThreadPreviewTextChars = 192;
 constexpr uint32_t kThreadPreviewFlagArtifact = 0x00000001u;
 constexpr uint32_t kThreadPreviewSnapshotRetries = 4;
+// LunaHost lives in the injector process while native adapters run inside the
+// game process. They must never claim/write the same preview slot because a
+// process-local CRITICAL_SECTION cannot serialize the other process.
+constexpr uint32_t kLunaThreadPreviewCount = 48;
+constexpr uint32_t kNativeThreadPreviewStart = kLunaThreadPreviewCount;
+constexpr uint32_t kNativeThreadPreviewCount =
+    kThreadPreviewCount - kNativeThreadPreviewStart;
+static_assert(kNativeThreadPreviewCount > 0,
+              "native text producers need reserved preview slots");
 
 #pragma pack(push, 8)
 // v12 线程预览槽。writer 必须先由进程内锁串行化，再执行：
@@ -62,8 +71,9 @@ inline void AtomicStorePreview64(volatile uint64_t* value, uint64_t next) {
 }
 
 inline uint64_t NextThreadPreviewGeneration(
-    const volatile uint64_t* write_count) {
-  return AtomicLoadPreview64(write_count) + 1;
+    volatile uint64_t* process_local_generation) {
+  return static_cast<uint64_t>(InterlockedIncrement64(
+      reinterpret_cast<volatile LONGLONG*>(process_local_generation)));
 }
 
 inline uint64_t ThreadPreviewWritingSequence(uint64_t generation) {
@@ -86,9 +96,9 @@ inline void PublishThreadPreviewWrite(ThreadPreviewSlot* slot,
                        ThreadPreviewCommittedSequence(generation));
 }
 
-inline void PublishThreadPreviewGeneration(volatile uint64_t* write_count,
-                                           uint64_t generation) {
-  AtomicStorePreview64(write_count, generation);
+inline void PublishThreadPreviewChange(volatile uint64_t* write_count) {
+  InterlockedIncrement64(
+      reinterpret_cast<volatile LONGLONG*>(write_count));
 }
 
 // 调用方持有 writer 锁。回收会产生空洞，因此必须继续扫描以优先找回已有 id。

--- a/native/galgame_hook/include/unity_text_mesh_reassembler.h
+++ b/native/galgame_hook/include/unity_text_mesh_reassembler.h
@@ -1,0 +1,54 @@
+#ifndef HIBIKI_UNITY_TEXT_MESH_REASSEMBLER_H_
+#define HIBIKI_UNITY_TEXT_MESH_REASSEMBLER_H_
+
+#include <cstddef>
+#include <cwchar>
+
+namespace hibiki_voice_hook {
+
+// Legacy Unity titles may call TextMesh.set_text once per rendered glyph. This
+// accumulator deliberately has no clock: a typewriter pause is not a semantic
+// sentence boundary. CR/LF/TAB are visible content and remain in the line.
+template <size_t Capacity>
+class UnityTextMeshReassembler {
+ public:
+  static_assert(Capacity >= 2, "TextMesh buffer needs room for a terminator");
+
+  bool ShouldTerminate(wchar_t c,
+                       bool fullwidth_space_is_profile_terminator) const {
+    return fullwidth_space_is_profile_terminator && c == L'\u3000';
+  }
+
+  bool Append(wchar_t c) {
+    if (c < 0x20 && c != L'\r' && c != L'\n' && c != L'\t') {
+      return false;
+    }
+    if (length_ + 1 >= Capacity) {
+      truncated_ = true;
+      return false;
+    }
+    text_[length_++] = c;
+    text_[length_] = L'\0';
+    return true;
+  }
+
+  const wchar_t* text() const { return text_; }
+  int length() const { return static_cast<int>(length_); }
+  bool empty() const { return length_ == 0; }
+  bool truncated() const { return truncated_; }
+
+  void Reset() {
+    text_[0] = L'\0';
+    length_ = 0;
+    truncated_ = false;
+  }
+
+ private:
+  wchar_t text_[Capacity] = {};
+  size_t length_ = 0;
+  bool truncated_ = false;
+};
+
+}  // namespace hibiki_voice_hook
+
+#endif  // HIBIKI_UNITY_TEXT_MESH_REASSEMBLER_H_

--- a/native/galgame_hook/include/unity_text_profile.h
+++ b/native/galgame_hook/include/unity_text_profile.h
@@ -1,0 +1,26 @@
+#ifndef HIBIKI_UNITY_TEXT_PROFILE_H_
+#define HIBIKI_UNITY_TEXT_PROFILE_H_
+
+#include <cwchar>
+
+namespace hibiki_voice_hook {
+
+inline const wchar_t* WindowsBaseName(const wchar_t* path) {
+  if (path == nullptr) return L"";
+  const wchar_t* base = path;
+  for (const wchar_t* p = path; *p != L'\0'; ++p) {
+    if (*p == L'\\' || *p == L'/') base = p + 1;
+  }
+  return base;
+}
+
+// Real Sasasa.exe evidence shows the old KEMCO renderer emits a standalone
+// U+3000 after each glyph batch. That marker is not a generic Unity rule:
+// every other title preserves U+3000 as ordinary text.
+inline bool UsesSasasaLegacyTextMeshTerminator(const wchar_t* executable_path) {
+  return _wcsicmp(WindowsBaseName(executable_path), L"Sasasa.exe") == 0;
+}
+
+}  // namespace hibiki_voice_hook
+
+#endif  // HIBIKI_UNITY_TEXT_PROFILE_H_

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -39,7 +39,8 @@ constexpr uint32_t kSharedMagic = 0x31485648;  // 'H''V''H''1'
 //     都发布"必然把配对候选挤出环（kExpired → 降级 loopback，即 BUG-1159 的失败链），这才是
 //     BUG-1193 真正的根因——不是门控本身。v12 把两个消费者拆到两块内存：
 //       * 文本环（Ring A）：语义不变，仍只发布**当前生效线程**的行，配对路径逐字节不受影响；
-//       * 线程预览区（本区）：每条线程各占**固定槽位**，只留最近一行。
+//       * 线程预览区（本区）：每条线程各占**固定槽位**，只留最近一行。Luna 与游戏内
+//         native adapter 使用互斥槽分区，跨进程 writer 不会争抢同一槽。
 //     预览区按线程分槽而不是全局 FIFO，所以逐字重绘型 hook 只能覆盖它自己的槽，**物理上挤不掉
 //     别的线程**——"挤压"从"要小心防"变成结构上不可能，这正是自动赢家门控得以退役的前提。
 constexpr uint32_t kSharedVersion = 12;
@@ -288,11 +289,22 @@ struct SharedHeader {
   // 内存布局尾部再追加：[...标记表][线程预览区 thread_preview_slot_count*ThreadPreviewSlot]
   uint32_t thread_preview_offset;      // 线程预览区起始（header 起算字节偏移）
   uint32_t thread_preview_slot_count;  // 槽数（= kThreadPreviewCount，冗余便于 reader 自洽）
-  // 单调累计已写预览行数。host 只用它判断「有没有新预览」以跳过整区扫描；预览槽本身按
+  // 单调累计预览变更次数（含 partial TextMesh 快照）。host 只用它判断「有没有新预览」；
+  // 预览槽本身按
   // thread_id 寻址，不靠这个序号定位（与文本环的 text_write_count 语义不同，勿照搬）。
   volatile uint64_t thread_preview_write_count;
 };
 #pragma pack(pop)
+
+inline uint64_t SelectedTextThreadId(const SharedHeader* header) {
+  if (header == nullptr) return 0;
+  return AtomicLoadPreview64(&header->selected_text_thread_id);
+}
+
+inline bool IsExactTextThreadSelected(const SharedHeader* header,
+                                      uint64_t thread_id) {
+  return thread_id != 0 && SelectedTextThreadId(header) == thread_id;
+}
 
 static_assert(sizeof(SharedHeader) % 8 == 0, "SharedHeader must stay 8-aligned");
 static_assert(sizeof(TextSlot) % 8 == 0, "TextSlot must stay 8-aligned");

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -30,6 +30,7 @@
 #include "luna_bridge.h"
 #include "luna_hook_config.h"
 #include "luna_text_selector.h"
+#include "text_thread_identity.h"
 
 // galgame 一键制卡 C 阶段注入器（C.1）。把 hook DLL 注入目标游戏进程，建立共享内存 + 就绪
 // 事件，确认注入成功后读回语音格式。Hibiki 主进程把它当子进程拉起（部署红线：注入代码只在
@@ -649,8 +650,9 @@ bool LunaPassesFilter(const wchar_t* text, int len) {
 // 其内部工作线程并发触发，原子占号同样保证 injector 侧多次调用互不撞槽。
 uint64_t LunaTextThreadId(const wchar_t* hookcode, const char* hookname,
                           const LunaThreadParam& tp) {
-  return hibiki_voice_hook::LunaTextThreadIdFrom(tp.processId, tp.addr, tp.ctx,
-                                                 tp.ctx2, hookcode, hookname);
+  return hibiki_voice_hook::NormalizeLunaTextThreadId(
+      hibiki_voice_hook::LunaTextThreadIdFrom(
+          tp.processId, tp.addr, tp.ctx, tp.ctx2, hookcode, hookname));
 }
 
 // hook「面」id：与 LunaTextThreadId 同源，但**刻意不含 ctx**（BUG-1159）。
@@ -751,6 +753,7 @@ void WriteLunaTextLine(SharedHeader* header, const wchar_t* hookcode,
 hibiki_voice_hook::LunaTextSelector g_lunaTextSelector;
 CRITICAL_SECTION g_lunaSelectCs;
 bool g_lunaSelectCsInit = false;
+alignas(8) volatile uint64_t g_lunaPreviewGeneration = 0;
 
 // v12：把本行记进该线程的预览槽。**必须在任何过滤/门控之前调用**——预览区存在的意义
 // 就是让用户看见那些没被发布的线程；只记已发布行等于什么都没做。
@@ -771,7 +774,7 @@ void WriteThreadPreview(SharedHeader* header, uint64_t thread_id,
   auto* slots = reinterpret_cast<hibiki_voice_hook::ThreadPreviewSlot*>(
       reinterpret_cast<uint8_t*>(header) + header->thread_preview_offset);
   const uint32_t count = (std::min)(header->thread_preview_slot_count,
-                                    hibiki_voice_hook::kThreadPreviewCount);
+                                    hibiki_voice_hook::kLunaThreadPreviewCount);
   hibiki_voice_hook::ThreadPreviewSlot* slot =
       hibiki_voice_hook::FindThreadPreviewSlot(slots, count, thread_id);
   if (slot == nullptr) {
@@ -779,7 +782,7 @@ void WriteThreadPreview(SharedHeader* header, uint64_t thread_id,
     return;  // 只有 64 条同时存活线程时才会满；ThreadRemove 后的槽会立即可复用。
   }
   const uint64_t generation = hibiki_voice_hook::NextThreadPreviewGeneration(
-      &header->thread_preview_write_count);
+      &g_lunaPreviewGeneration);
   hibiki_voice_hook::BeginThreadPreviewWrite(slot, generation);
   if (slot->thread_id == 0) {
     slot->line_count = 0;
@@ -802,8 +805,8 @@ void WriteThreadPreview(SharedHeader* header, uint64_t thread_id,
   slot->timestamp_ms = GetTickCount64();
   hibiki_voice_hook::PublishThreadPreviewWrite(slot, generation);
   // 全局计数最后发布：把它当变化信号的 reader 看到新 generation 时，槽必已是稳定偶数态。
-  hibiki_voice_hook::PublishThreadPreviewGeneration(
-      &header->thread_preview_write_count, generation);
+  hibiki_voice_hook::PublishThreadPreviewChange(
+      &header->thread_preview_write_count);
   LeaveCriticalSection(&g_lunaSelectCs);
 }
 
@@ -811,15 +814,8 @@ void WriteThreadPreview(SharedHeader* header, uint64_t thread_id,
 // selected_text_thread_id 仍为 0、UI 显示未选择时，profile 快路却会在后台悄悄发布文本。
 bool LunaShouldWriteLine(uint64_t thread_id, bool is_artifact,
                          uint64_t face_id) {
-  const uint64_t manually_selected = g_luna.header == nullptr
-                                         ? 0
-                                         : static_cast<uint64_t>(
-                                               InterlockedCompareExchange64(
-                                                   reinterpret_cast<
-                                                       volatile LONGLONG*>(
-                                                       &g_luna.header
-                                                            ->selected_text_thread_id),
-                                                   0, 0));
+  const uint64_t manually_selected =
+      hibiki_voice_hook::SelectedTextThreadId(g_luna.header);
   if (!g_lunaSelectCsInit) {
     // 锁未初始化（理论上不该发生）时也遵守 v12 的"没显式选择就不发布"，否则这条退路会
     // 变成一个悄悄恢复旧行为的后门。face 匹配需要锁保护的注册表，这里只能精确匹配。
@@ -977,18 +973,18 @@ void LunaThreadRemove(const wchar_t* hookcode, const char* hookname,
       g_luna.header->thread_preview_offset);
   const uint32_t count =
       (std::min)(g_luna.header->thread_preview_slot_count,
-                 hibiki_voice_hook::kThreadPreviewCount);
+                 hibiki_voice_hook::kLunaThreadPreviewCount);
   for (uint32_t i = 0; i < count; ++i) {
     auto* slot = &slots[i];
     if (slot->thread_id != thread_id) continue;
     const uint64_t generation =
         hibiki_voice_hook::NextThreadPreviewGeneration(
-            &g_luna.header->thread_preview_write_count);
+            &g_lunaPreviewGeneration);
     hibiki_voice_hook::BeginThreadPreviewWrite(slot, generation);
     hibiki_voice_hook::ClearThreadPreviewPayload(slot);
     hibiki_voice_hook::PublishThreadPreviewWrite(slot, generation);
-    hibiki_voice_hook::PublishThreadPreviewGeneration(
-        &g_luna.header->thread_preview_write_count, generation);
+    hibiki_voice_hook::PublishThreadPreviewChange(
+        &g_luna.header->thread_preview_write_count);
     break;
   }
   LeaveCriticalSection(&g_lunaSelectCs);

--- a/native/galgame_hook/tests/adapter_structure_test.py
+++ b/native/galgame_hook/tests/adapter_structure_test.py
@@ -87,8 +87,25 @@ class AdapterStructureTest(unittest.TestCase):
         )
         self.assertIn('L"UnityEngine.TextMesh.set_text(glyphs)"', source)
         self.assertIn("void FlushUnityTextMeshLine()", source)
-        self.assertIn("c == L'\\u3000'", source)
+        self.assertIn("UsesSasasaLegacyTextMeshTerminator", source)
+        self.assertIn("g_unity_text_mesh_reassembler.ShouldTerminate(c, true)", source)
+        self.assertIn("IsExactTextThreadSelected", source)
+        self.assertIn("kNativeThreadPreviewStart", source)
+        self.assertIn("candidate->thread_id == selected", source)
+        text_mesh = source.split("void RecordUnityTextMesh", 1)[1]
+        text_mesh = text_mesh.split("void RecordUnityVoiceResourceEvent", 1)[0]
+        self.assertNotIn("GetTickCount64", text_mesh)
+        self.assertNotIn("c == L'\\r'", text_mesh)
+        self.assertNotIn("c == L'\\n'", text_mesh)
         self.assertIn('"Unity TextMesh line"', source)
+        dll = (ROOT / "hook" / "dll_main.cpp").read_text(encoding="utf-8")
+        shutdown = dll.split(
+            "// 收尾在工作线程里做（不在 loader lock 中）", 1
+        )[1]
+        self.assertLess(
+            shutdown.index("FlushUnityTextMeshLine();"),
+            shutdown.index("g_capture_enabled = false;"),
+        )
 
     def test_unity_resource_observation_is_not_gated_by_pcm_helpers(self) -> None:
         source = (

--- a/native/galgame_hook/tests/thread_preview_ipc_test.cpp
+++ b/native/galgame_hook/tests/thread_preview_ipc_test.cpp
@@ -15,6 +15,7 @@ using hibiki_voice_hook::ThreadPreviewSnapshot;
 
 struct PreviewTable {
   volatile uint64_t write_count = 0;
+  volatile uint64_t generation = 0;
   std::array<ThreadPreviewSlot, hibiki_voice_hook::kThreadPreviewCount> slots{};
   std::mutex writer_mutex;
 };
@@ -26,7 +27,7 @@ void WritePattern(PreviewTable* table, uint64_t thread_id) {
       thread_id);
   if (slot == nullptr) return;
   const uint64_t generation =
-      hibiki_voice_hook::NextThreadPreviewGeneration(&table->write_count);
+      hibiki_voice_hook::NextThreadPreviewGeneration(&table->generation);
   hibiki_voice_hook::BeginThreadPreviewWrite(slot, generation);
   slot->thread_id = thread_id;
   slot->timestamp_ms = generation * 3;
@@ -37,8 +38,7 @@ void WritePattern(PreviewTable* table, uint64_t thread_id) {
   const wchar_t pattern = static_cast<wchar_t>(L'A' + (generation % 23));
   for (uint32_t i = 0; i < 128; ++i) slot->text[i] = pattern;
   hibiki_voice_hook::PublishThreadPreviewWrite(slot, generation);
-  hibiki_voice_hook::PublishThreadPreviewGeneration(&table->write_count,
-                                                    generation);
+  hibiki_voice_hook::PublishThreadPreviewChange(&table->write_count);
 }
 
 void RemovePreview(PreviewTable* table, uint64_t thread_id) {
@@ -46,12 +46,11 @@ void RemovePreview(PreviewTable* table, uint64_t thread_id) {
   for (ThreadPreviewSlot& slot : table->slots) {
     if (slot.thread_id != thread_id) continue;
     const uint64_t generation =
-        hibiki_voice_hook::NextThreadPreviewGeneration(&table->write_count);
+        hibiki_voice_hook::NextThreadPreviewGeneration(&table->generation);
     hibiki_voice_hook::BeginThreadPreviewWrite(&slot, generation);
     hibiki_voice_hook::ClearThreadPreviewPayload(&slot);
     hibiki_voice_hook::PublishThreadPreviewWrite(&slot, generation);
-    hibiki_voice_hook::PublishThreadPreviewGeneration(&table->write_count,
-                                                      generation);
+    hibiki_voice_hook::PublishThreadPreviewChange(&table->write_count);
     return;
   }
 }
@@ -77,6 +76,23 @@ bool SnapshotMatchesOneGeneration(const ThreadPreviewSnapshot& snapshot) {
 }  // namespace
 
 int main() {
+  if (hibiki_voice_hook::kLunaThreadPreviewCount +
+          hibiki_voice_hook::kNativeThreadPreviewCount !=
+      hibiki_voice_hook::kThreadPreviewCount) {
+    return 10;
+  }
+  PreviewTable partitioned;
+  ThreadPreviewSlot* luna_slot = hibiki_voice_hook::FindThreadPreviewSlot(
+      partitioned.slots.data(), hibiki_voice_hook::kLunaThreadPreviewCount, 1);
+  ThreadPreviewSlot* native_slot = hibiki_voice_hook::FindThreadPreviewSlot(
+      partitioned.slots.data() + hibiki_voice_hook::kNativeThreadPreviewStart,
+      hibiki_voice_hook::kNativeThreadPreviewCount, 2);
+  if (luna_slot != &partitioned.slots.front() ||
+      native_slot !=
+          &partitioned.slots[hibiki_voice_hook::kNativeThreadPreviewStart]) {
+    return 11;
+  }
+
   PreviewTable table;
 
   // 回收后允许空洞：已有 id 必须优先命中，新的第 65 条线程必须复用被释放的槽。

--- a/native/galgame_hook/tests/unity_text_mesh_reassembler_test.cpp
+++ b/native/galgame_hook/tests/unity_text_mesh_reassembler_test.cpp
@@ -1,0 +1,46 @@
+#include <cassert>
+#include <cstdint>
+#include <cwchar>
+
+#include "text_thread_identity.h"
+#include "unity_text_mesh_reassembler.h"
+#include "unity_text_profile.h"
+
+int main() {
+  using hibiki_voice_hook::UnityTextMeshReassembler;
+
+  UnityTextMeshReassembler<32> line;
+  assert(line.Append(L'前'));
+  assert(line.Append(L'\r'));
+  assert(line.Append(L'\n'));
+  assert(line.Append(L'後'));
+  assert(std::wcscmp(line.text(), L"前\r\n後") == 0);
+
+  // A pause has no API and therefore cannot flush or split the accumulator.
+  assert(!line.ShouldTerminate(L'\n', true));
+  assert(!line.ShouldTerminate(L'\r', true));
+  assert(!line.ShouldTerminate(L'\u3000', false));
+  assert(line.ShouldTerminate(L'\u3000', true));
+
+  line.Reset();
+  assert(line.Append(L'文'));
+  assert(line.Append(L'\u3000'));
+  assert(line.Append(L'中'));
+  assert(std::wcscmp(line.text(), L"文\u3000中") == 0);
+
+  assert(hibiki_voice_hook::UsesSasasaLegacyTextMeshTerminator(
+      L"E:\\games\\Sasasa.exe"));
+  assert(hibiki_voice_hook::UsesSasasaLegacyTextMeshTerminator(
+      L"c:/games/SASASA.EXE"));
+  assert(!hibiki_voice_hook::UsesSasasaLegacyTextMeshTerminator(
+      L"E:\\games\\manosaba.exe"));
+
+  const uint64_t native_id = hibiki_voice_hook::NativeTextThreadIdFrom(
+      0, L"UnityEngine.TextMesh.set_text(glyphs)",
+      "Unity TextMesh line");
+  assert((native_id & hibiki_voice_hook::kNativeTextThreadNamespaceBit) != 0);
+  assert((hibiki_voice_hook::NormalizeLunaTextThreadId(native_id) &
+          hibiki_voice_hook::kNativeTextThreadNamespaceBit) == 0);
+  assert(native_id != hibiki_voice_hook::NormalizeLunaTextThreadId(native_id));
+  return 0;
+}


### PR DESCRIPTION
## 修复内容

- 将 Luna 与游戏内 native 文本写者分配到互斥预览槽和独立 thread-id namespace；Unity TMP/TextMesh 始终先作为候选预览，只有显式选中的来源才能写正式文本环。
- 重做 Sasasa legacy TextMesh 组句：删除 250ms 停顿断句，保留 CR/LF/TAB；U+3000 结束符只限真实样本证明的 `Sasasa.exe` profile，其他 Unity 标题按正文保留；空字符串和正常 helper 收尾提交末句。
- Flutter 正式消费者增加第二道门：未选择线程时工作台、浮窗、语音配对和制卡均为空，即使连接旧 helper 也不会显示其越权写入。

## 根因

旧 Unity TextMesh adapter 直接递增 `text_write_count`，绕过 v12 `selected_text_thread_id`；同时把 250ms、CR、LF、U+3000 都当句界，打字停顿会把一句拆成两条。Luna 线程没有消失，冲突来自 native 写者绕过选择契约。

## 验证

通过：

- `python native/galgame_hook/tests/adapter_structure_test.py`（12 tests）
- `python native/galgame_hook/tools/generate_engine_support.py --check`
- `python native/galgame_hook/tools/generate_luna_profiles.py --check`
- `dart run tool/bug.dart reindex`
- `git diff --check`
- `flutter pub get --offline`

未完成：

- 定向 Flutter tests 在测试代码执行前被 `pdfium_dart` 下载 `pdfium-win-x64.tgz` 超时（Windows errno 121）阻断，不是断言失败。
- 按请求不等待 x86/x64 helper 全编译验收；未做 Sasasa 真实运行回放，因此修正后的 legacy TextMesh 路径仍按 `implemented_unverified` 口径交付。

记录：BUG-1247。版本：`1.3.1+1002`。