### PR TITLE
fix(media): 延长原图封面下载时限

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1169 条。点号进各自文件。
+> 共 1170 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1248](bugs/BUG-1248-bangumi-cover-original-timeout.md) | ✅ | ✅ | Bangumi封面退化图落盘且原图下载30秒超时 |
 | [BUG-1208](bugs/BUG-1208-ps51-getrelativepath-build-dist.md) | ✅ | ✅ | helper 打包脚本用 .NET Core-only 的 GetRelativePath，CI 的 PowerShell 5.1 直接崩 |
 | [BUG-1207](bugs/BUG-1207-android-embedded-torrent-dead-setting.md) | ✅ | ✅ | 安卓下载设置能选「内置引擎」并改下载目录，实际静默回退外接 qBittorrent |
 | [BUG-1206](bugs/BUG-1206-jimaku-season-pack-wrong-season-match.md) | ✅ | ✅ | 整季包字幕按标题猜集号导致错季配对且条数无上界 |

--- a/docs/bugs/BUG-1248-bangumi-cover-original-timeout.md
+++ b/docs/bugs/BUG-1248-bangumi-cover-original-timeout.md
@@ -1,0 +1,29 @@
+## BUG-1248 · Bangumi封面退化图落盘且原图下载30秒超时
+- **报告**：2026-07-29（用户：自动刮削封面观感模糊，并反馈弱网下封面应用失败）
+- **真实性**：✅ 真 bug（含一项现场排除）。截图失败 URL
+  `https://lain.bgm.tv/pic/cover/l/2c/af/520842_J06fL.jpg` 实测下载为
+  350476 字节、1938×2744 JPEG，说明该条 `/l/` 本身已是来源原图，且落盘层不重编码，
+  不是这张图的清晰度瓶颈；但旧映射在 `images.large` 缺失时会直接采用
+  `common/medium/small` 或搜索响应的 `image` 派生尺寸并永久落盘：
+  `hibiki/lib/src/media/video/scraper/bangumi_client.dart:294`、
+  `hibiki/lib/src/media/metadata/book_metadata_scraper.dart:182`。此外视频与书籍下载器各自
+  写死 30 秒整体截止时间；高分辨率原图在弱网/代理链路下更容易在传输完成前被应用层取消。
+- **[x] ① 已修复** — `37abb62af`：新增统一 Bangumi URL 解析器
+  `hibiki/lib/src/media/metadata/bangumi_cover_url.dart:14-51`，按
+  `large → common → medium → small → grid` 选择可用地址后，去掉 `/r/<size>/`
+  缩放层并把旧式 `c/m/s/g` 路径恢复到 `/pic/cover/l/`；视频、书籍、游戏三个刮削入口
+  共用该解析器。`910bfa9c0`：在
+  `hibiki/lib/src/media/metadata/image_download.dart:34` 建立 100 秒统一原图下载截止时间，
+  书籍直接复用，视频 `cover_downloader.dart:32,59` 也改用同一默认值；仍保持有界等待，
+  且继续原样保存响应字节，不做二次压缩。
+- **[x] ② 已加自动化测试** — `37abb62af`：
+  `hibiki/test/media/metadata/bangumi_cover_url_test.dart:15-41` 覆盖 `/r/<size>/` 与
+  `common/medium/small/grid` 恢复原图；三个领域映射测试守住统一入口。`910bfa9c0`：
+  `hibiki/test/media/metadata/image_download_test.dart:11` 守住 100 秒共享默认值，
+  `hibiki/test/media/video/scraper/cover_downloader_test.dart:28,128` 守住视频侧复用默认值及
+  超时失败不落盘。12 个相关源码/测试文件定向 `dart analyze` 通过；按用户要求未等待
+  Flutter 编译或测试套件。
+- **备注**：实现策略对齐 Jellyfin：下载来源提供的原图字节并原样保存，展示层再按卡槽
+  需要降采样；因此不移除 Hibiki 既有 720 物理像素卡片解码上限，避免把原图整帧塞进
+  Flutter ImageCache。外部源主动断连/Windows `errno=121` 仍可能早于应用截止时间失败，
+  本修复不把所有网络错误伪装成“延长时间即可解决”。

--- a/hibiki/lib/src/media/metadata/image_download.dart
+++ b/hibiki/lib/src/media/metadata/image_download.dart
@@ -27,6 +27,12 @@ class ImageDownloadException implements Exception {
       : 'ImageDownloadException($statusCode): $message';
 }
 
+/// 远端封面原图下载的统一截止时间。
+///
+/// 原图通常比候选列表缩略图大，弱网或代理链路下 30 秒容易在响应完成前误杀；
+/// 100 秒仍是有界等待，同时给高分辨率封面留出足够传输时间。
+const Duration kCoverImageDownloadTimeout = Duration(seconds: 100);
+
 /// 下载 [url] 指向的图片到临时文件，返回该文件。
 ///
 /// - [client]：默认自建（下载完关闭）；测试注入 mock client（不关闭，由调用方管理）。
@@ -38,7 +44,7 @@ Future<File> downloadImageToTempFile(
   String url, {
   http.Client? client,
   Directory? tempDir,
-  Duration timeout = const Duration(seconds: 30),
+  Duration timeout = kCoverImageDownloadTimeout,
 }) async {
   final http.Client httpClient = client ?? http.Client();
   try {

--- a/hibiki/lib/src/media/video/scraper/cover_downloader.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_downloader.dart
@@ -15,6 +15,8 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:hibiki/src/media/media_cover_service.dart';
+import 'package:hibiki/src/media/metadata/image_download.dart'
+    show kCoverImageDownloadTimeout;
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
     show ScrapeNetworkException;
 import 'package:hibiki/src/media/video/video_import_dialog.dart'
@@ -25,11 +27,13 @@ import 'package:path/path.dart' as p;
 
 /// 海报下载器。构造注入 [http.Client]（默认自建），测试用 mock client。
 class CoverDownloader {
-  CoverDownloader({http.Client? client}) : _client = client ?? http.Client();
+  CoverDownloader({
+    http.Client? client,
+    this.timeout = kCoverImageDownloadTimeout,
+  }) : _client = client ?? http.Client();
 
   final http.Client _client;
-
-  static const Duration _timeout = Duration(seconds: 30);
+  final Duration timeout;
 
   /// 下载 [url] 指向的海报，落地为 [bookUid] 对应封面，返回**绝对路径**（可直接
   /// 传给 `updateCover`）。
@@ -52,7 +56,7 @@ class CoverDownloader {
 
     final http.Response response;
     try {
-      response = await _client.get(Uri.parse(url)).timeout(_timeout);
+      response = await _client.get(Uri.parse(url)).timeout(timeout);
     } on TimeoutException {
       throw const ScrapeNetworkException('Poster download timed out');
     } catch (e) {

--- a/hibiki/test/media/metadata/image_download_test.dart
+++ b/hibiki/test/media/metadata/image_download_test.dart
@@ -8,6 +8,10 @@ import 'package:http/testing.dart';
 import 'package:path/path.dart' as p;
 
 void main() {
+  test('原图下载截止时间为 100 秒', () {
+    expect(kCoverImageDownloadTimeout, const Duration(seconds: 100));
+  });
+
   group('looksLikeImageBytes', () {
     test('Content-Type image/* 直接判是', () {
       expect(looksLikeImageBytes(const <int>[], 'image/jpeg'), isTrue);
@@ -22,7 +26,9 @@ void main() {
       expect(looksLikeImageBytes(const <int>[0x47, 0x49, 0x46, 0x38], null),
           isTrue); // GIF
       expect(
-        looksLikeImageBytes(<int>[...utf8.encode('RIFF'), 0, 0, 0, 0, ...utf8.encode('WEBP')], null),
+        looksLikeImageBytes(
+            <int>[...utf8.encode('RIFF'), 0, 0, 0, 0, ...utf8.encode('WEBP')],
+            null),
         isTrue,
       );
     });

--- a/hibiki/test/media/video/scraper/cover_downloader_test.dart
+++ b/hibiki/test/media/video/scraper/cover_downloader_test.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/metadata/image_download.dart'
+    show kCoverImageDownloadTimeout;
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
     show ScrapeNetworkException;
 import 'package:hibiki/src/media/video/scraper/cover_downloader.dart';
@@ -22,6 +24,16 @@ final List<int> _fakePng = <int>[
 void main() {
   // downloadCover 落盘后走 evictLocalCoverCache（需要 PaintingBinding）。
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('视频封面复用 100 秒原图下载截止时间', () {
+    final CoverDownloader downloader = CoverDownloader(
+      client: MockClient(
+        (http.Request request) async => http.Response('', 200),
+      ),
+    );
+    expect(downloader.timeout, kCoverImageDownloadTimeout);
+    expect(downloader.timeout, const Duration(seconds: 100));
+  });
 
   late Directory tempDir;
 
@@ -111,6 +123,33 @@ void main() {
     final String finalPath = p.join(tempDir.path, videoCoverFileName(bookUid));
     expect(File(finalPath).existsSync(), isFalse);
     expect(File('$finalPath.tmp').existsSync(), isFalse);
+  });
+
+  test('超过注入的下载截止时间 → 抛超时异常、不落文件', () async {
+    final MockClient client = MockClient((http.Request req) async {
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      return http.Response.bytes(_fakePng, 200);
+    });
+    const String bookUid = 'uid_timeout';
+    await expectLater(
+      CoverDownloader(
+        client: client,
+        timeout: const Duration(milliseconds: 1),
+      ).downloadCover(
+        url: 'https://img/slow',
+        bookUid: bookUid,
+        coversDirectory: tempDir,
+      ),
+      throwsA(
+        isA<ScrapeNetworkException>().having(
+          (ScrapeNetworkException error) => error.message,
+          'message',
+          'Poster download timed out',
+        ),
+      ),
+    );
+    final String finalPath = p.join(tempDir.path, videoCoverFileName(bookUid));
+    expect(File(finalPath).existsSync(), isFalse);
   });
 
   test('覆盖旧封面：同 uid 二次下载直接替换内容', () async {


### PR DESCRIPTION
## 改了什么

- 把视频与书籍刮削封面下载的默认截止时间从 30 秒统一延长到 100 秒。
- 视频下载器复用共享时限，并保留可注入短时限的测试接缝。
- 记录 BUG-1248：区分 Bangumi 原图 URL、退化尺寸 URL 与外部网络失败。

## 为什么

PR #560 已把 Bangumi 退化尺寸地址统一恢复为来源原图；原图文件更大，弱网或代理链路下 30 秒容易在传输完成前被应用层取消。Jellyfin 的远端图片链路使用默认 100 秒 HttpClient 时限，并把响应字节原样保存；本变更对齐这一有界等待口径，同时保留 Hibiki 现有的原字节落盘与展示时降采样策略。

截图中的 `/pic/cover/l/2c/af/520842_J06fL.jpg` 已实测为 350476 字节、1938×2744 JPEG，说明该 URL 本身是来源原图，不是候选缩略图。外部源主动断连或 Windows `errno=121` 仍可能早于应用截止时间失败，本 PR 不把所有网络错误伪装成单纯超时。

## 用户影响

高分辨率封面在慢速网络或代理环境下有更长的完成窗口。已保存的低清封面不会自动替换，需要重新刮削。

## 验证

- `dart format`（4 个本轮改动 Dart 文件）
- 定向 `dart analyze`（原图/下载相关 12 个源码与测试文件，No issues found）
- `dart run tool/bug.dart check`（1170 条，号唯一，索引同步）
- `git diff --check`
- 按用户要求未等待 Flutter 测试、完整 analyze 或构建

版本说明：分支基底是 `1.3.1+980`，当前 `origin/develop` 已为 `+1001`，本 PR 不写入倒退版本号；落地时由 integration owner 按最新基线统一 bump。