### PR TITLE
fix(download): keep streaming progress and explain empty results

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,7 +29,7 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1207 条。点号进各自文件。
+> 共 1209 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
@@ -39,6 +39,8 @@
 | [BUG-1276](bugs/BUG-1276-dashboard-heatmap-dark-contrast.md) | ✅ | ✅ | 黑色主题下学习活动热力图空周融进背景 |
 | [BUG-1270](bugs/BUG-1270-youtube-live-subtitle-seek-duplicate.md) | ✅ | ✅ | YouTube 实时字幕回跳后重复且累积成长段 |
 | [BUG-1260](bugs/BUG-1260-sync-progress-blank-and-silent-noop.md) | ✅ | ✅ | 同步进度条只有线没有字 + 零通道空转静默收尾 |
+| [BUG-1250](bugs/BUG-1250-stream-import-hides-progress.md) | ✅ | ✅ | 边下边播提前入库把下载任务直接标成已完成并丢失进度 |
+| [BUG-1249](bugs/BUG-1249-download-empty-result-reason.md) | ✅ | ✅ | 下载发现把空响应或损坏 RSS 伪装成无结果且不说明筛选原因 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/bugs/BUG-1249-download-empty-result-reason.md
+++ b/docs/bugs/BUG-1249-download-empty-result-reason.md
@@ -1,0 +1,6 @@
+## BUG-1249 · 下载发现把空响应或损坏 RSS 伪装成无结果且不说明筛选原因
+- **报告**：2026-07-29（用户：下载时无结果且没有任何报错，要求说明原因）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/media/torrent/nyaa_client.dart:206` 的宽容解析会把空 body / 损坏 XML 都压成空列表；`hibiki/lib/src/pages/implementations/anime_download_dialog.dart:1575` 又把所有空列表统一渲染成一句「无结果」，真实响应异常与本次查询/筛选条件均不可见。
+- **[x] ① 已修复** — 本提交：Nyaa 搜索入口对空响应、非 RSS 与损坏 XML 抛出可见格式错误；有效 RSS 的 0 条结果显示实际查询词、分类和 Trusted 筛选。
+- **[x] ② 已加自动化测试** — `hibiki/test/torrent/nyaa_client_test.dart` 覆盖空响应/坏 RSS/有效空 feed 三分支；`hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart` 覆盖真实 0 条原因与损坏 feed 错误态。
+- **备注**：定向测试启动前被 `sqlite3` 原生资产从 GitHub 下载超时阻断（0 tests ran）；已保留该环境阻塞，不把它记为断言通过。

--- a/docs/bugs/BUG-1250-stream-import-hides-progress.md
+++ b/docs/bugs/BUG-1250-stream-import-hides-progress.md
@@ -1,0 +1,6 @@
+## BUG-1250 · 边下边播提前入库把下载任务直接标成已完成并丢失进度
+- **报告**：2026-07-29（用户：点边下边播会入库，但进度消失并直接变成已完成）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/media/torrent/anime_download_service.dart:247` 的 `importNow()` 复用下载完成处理，把未完成计划写成 `statusImported`；轮询器只跟踪 `statusDownloading`，因此任务立刻退出进度集合并显示完成。
+- **[x] ① 已修复** — 本提交：新增与下载状态正交的 `importedEarly` 持久标记；提前入库继续保持 downloading 并发布真实进度，真正下载完成后才转 imported，视频入库不会重复执行。
+- **[x] ② 已加自动化测试** — `hibiki/test/torrent/anime_download_plan_test.dart` 覆盖新字段兼容性；`hibiki/test/torrent/anime_download_service_test.dart` 覆盖 20% 提前入库、55% 继续跟踪、100% 完成且只导入一次的完整状态链。
+- **备注**：任务 UI 同步显示「已入库 · 下载继续」并隐藏重复的边下边播按钮。定向测试启动前被 `sqlite3` 原生资产下载超时阻断（0 tests ran）；仍需真实下载后端复测原始路径。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 47192 (2776 per locale)
+/// Strings: 47328 (2784 per locale)
 ///
-/// Built on 2026-07-31 at 10:14 UTC
+/// Built on 2026-07-31 at 10:25 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3731,6 +3731,18 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   String get sync_last_failed => 'Last sync: failed';
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  String get anime_download_task_settings => 'Task settings';
+  String get anime_download_task_library_name => 'Library name';
+  String get anime_download_task_content_kind => 'Import as';
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  String get anime_download_task_more_actions => 'More task actions';
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -10086,6 +10098,26 @@ class _StringsAr extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -16509,6 +16541,26 @@ class _StringsDe extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -22948,6 +23000,26 @@ class _StringsEs extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -29398,6 +29470,26 @@ class _StringsFr extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -35777,6 +35869,26 @@ class _StringsId extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -42202,6 +42314,26 @@ class _StringsIt extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -48444,6 +48576,26 @@ class _StringsJa extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -54688,6 +54840,26 @@ class _StringsKo extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -61093,6 +61265,26 @@ class _StringsNl extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -67511,6 +67703,26 @@ class _StringsPtBr extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -73913,6 +74125,26 @@ class _StringsRu extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -80263,6 +80495,26 @@ class _StringsTh extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -86645,6 +86897,26 @@ class _StringsTr extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -93012,6 +93284,26 @@ class _StringsVi extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 // Path: <root>
@@ -98928,6 +99220,25 @@ class _StringsZhCn extends _StringsEn {
   String get sync_last_cooled_down => '上次同步：已跳过——刚同步过';
   @override
   String get sync_last_failed => '上次同步：失败';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      '服务已正常响应，但按当前条件返回 0 条。查询：${query}；筛选：${filters}。请尝试别名或放宽筛选。';
+  @override
+  String get anime_download_streaming_ready => '已入库 · 下载继续';
+  @override
+  String get anime_download_task_settings => '任务设置';
+  @override
+  String get anime_download_task_library_name => '入库名称';
+  @override
+  String get anime_download_task_content_kind => '入库类型';
+  @override
+  String get anime_download_task_settings_hint =>
+      '这些设置影响入库；要修改下载文件名或目录，请使用“重命名 / 移动”。';
+  @override
+  String get anime_download_task_more_actions => '更多任务操作';
+  @override
+  String get anime_download_unfiltered => '未启用 Trusted 筛选';
 }
 
 // Path: <root>
@@ -105091,6 +105402,26 @@ class _StringsZhHk extends _StringsEn {
   String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
   @override
   String get sync_last_failed => 'Last sync: failed';
+  @override
+  String anime_download_no_results_detail(
+          {required Object query, required Object filters}) =>
+      'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+  @override
+  String get anime_download_streaming_ready =>
+      'In library · download continues';
+  @override
+  String get anime_download_task_settings => 'Task settings';
+  @override
+  String get anime_download_task_library_name => 'Library name';
+  @override
+  String get anime_download_task_content_kind => 'Import as';
+  @override
+  String get anime_download_task_settings_hint =>
+      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+  @override
+  String get anime_download_task_more_actions => 'More task actions';
+  @override
+  String get anime_download_unfiltered => 'No Trusted filter';
 }
 
 /// Flat map(s) containing all translations.
@@ -110779,6 +111110,23 @@ extension on _StringsEn {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -116465,6 +116813,23 @@ extension on _StringsAr {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -122172,6 +122537,23 @@ extension on _StringsDe {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -127878,6 +128260,23 @@ extension on _StringsEs {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -133590,6 +133989,23 @@ extension on _StringsFr {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -139284,6 +139700,23 @@ extension on _StringsId {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -144993,6 +145426,23 @@ extension on _StringsIt {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -150664,6 +151114,23 @@ extension on _StringsJa {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -156339,6 +156806,23 @@ extension on _StringsKo {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -162041,6 +162525,23 @@ extension on _StringsNl {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -167740,6 +168241,23 @@ extension on _StringsPtBr {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -173444,6 +173962,23 @@ extension on _StringsRu {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -179132,6 +179667,23 @@ extension on _StringsTh {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -184829,6 +185381,23 @@ extension on _StringsTr {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -190521,6 +191090,23 @@ extension on _StringsVi {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }
@@ -196165,6 +196751,23 @@ extension on _StringsZhCn {
         return '上次同步：已跳过——刚同步过';
       case 'sync_last_failed':
         return '上次同步：失败';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            '服务已正常响应，但按当前条件返回 0 条。查询：${query}；筛选：${filters}。请尝试别名或放宽筛选。';
+      case 'anime_download_streaming_ready':
+        return '已入库 · 下载继续';
+      case 'anime_download_task_settings':
+        return '任务设置';
+      case 'anime_download_task_library_name':
+        return '入库名称';
+      case 'anime_download_task_content_kind':
+        return '入库类型';
+      case 'anime_download_task_settings_hint':
+        return '这些设置影响入库；要修改下载文件名或目录，请使用“重命名 / 移动”。';
+      case 'anime_download_task_more_actions':
+        return '更多任务操作';
+      case 'anime_download_unfiltered':
+        return '未启用 Trusted 筛选';
       default:
         return null;
     }
@@ -201831,6 +202434,23 @@ extension on _StringsZhHk {
         return 'Last sync: skipped - synced recently';
       case 'sync_last_failed':
         return 'Last sync: failed';
+      case 'anime_download_no_results_detail':
+        return ({required Object query, required Object filters}) =>
+            'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
+      case 'anime_download_streaming_ready':
+        return 'In library · download continues';
+      case 'anime_download_task_settings':
+        return 'Task settings';
+      case 'anime_download_task_library_name':
+        return 'Library name';
+      case 'anime_download_task_content_kind':
+        return 'Import as';
+      case 'anime_download_task_settings_hint':
+        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
+      case 'anime_download_task_more_actions':
+        return 'More task actions';
+      case 'anime_download_unfiltered':
+        return 'No Trusted filter';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 47328 (2784 per locale)
+/// Strings: 47243 (2779 per locale)
 ///
-/// Built on 2026-07-31 at 10:25 UTC
+/// Built on 2026-07-31 at 10:28 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3736,12 +3736,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  String get anime_download_task_settings => 'Task settings';
-  String get anime_download_task_library_name => 'Library name';
-  String get anime_download_task_content_kind => 'Import as';
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  String get anime_download_task_more_actions => 'More task actions';
   String get anime_download_unfiltered => 'No Trusted filter';
 }
 
@@ -10105,17 +10099,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
@@ -16548,17 +16531,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
@@ -23007,17 +22979,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
@@ -29478,17 +29439,6 @@ class _StringsFr extends _StringsEn {
   String get anime_download_streaming_ready =>
       'In library · download continues';
   @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
-  @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
 
@@ -35876,17 +35826,6 @@ class _StringsId extends _StringsEn {
   @override
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
@@ -42322,17 +42261,6 @@ class _StringsIt extends _StringsEn {
   String get anime_download_streaming_ready =>
       'In library · download continues';
   @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
-  @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
 
@@ -48583,17 +48511,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
@@ -54847,17 +54764,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
@@ -61272,17 +61178,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
@@ -67711,17 +67606,6 @@ class _StringsPtBr extends _StringsEn {
   String get anime_download_streaming_ready =>
       'In library · download continues';
   @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
-  @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
 
@@ -74133,17 +74017,6 @@ class _StringsRu extends _StringsEn {
   String get anime_download_streaming_ready =>
       'In library · download continues';
   @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
-  @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
 
@@ -80502,17 +80375,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get anime_download_streaming_ready =>
       'In library · download continues';
-  @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
@@ -86905,17 +86767,6 @@ class _StringsTr extends _StringsEn {
   String get anime_download_streaming_ready =>
       'In library · download continues';
   @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
-  @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
 
@@ -93292,17 +93143,6 @@ class _StringsVi extends _StringsEn {
   String get anime_download_streaming_ready =>
       'In library · download continues';
   @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
-  @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
 
@@ -99226,17 +99066,6 @@ class _StringsZhCn extends _StringsEn {
       '服务已正常响应，但按当前条件返回 0 条。查询：${query}；筛选：${filters}。请尝试别名或放宽筛选。';
   @override
   String get anime_download_streaming_ready => '已入库 · 下载继续';
-  @override
-  String get anime_download_task_settings => '任务设置';
-  @override
-  String get anime_download_task_library_name => '入库名称';
-  @override
-  String get anime_download_task_content_kind => '入库类型';
-  @override
-  String get anime_download_task_settings_hint =>
-      '这些设置影响入库；要修改下载文件名或目录，请使用“重命名 / 移动”。';
-  @override
-  String get anime_download_task_more_actions => '更多任务操作';
   @override
   String get anime_download_unfiltered => '未启用 Trusted 筛选';
 }
@@ -105410,17 +105239,6 @@ class _StringsZhHk extends _StringsEn {
   String get anime_download_streaming_ready =>
       'In library · download continues';
   @override
-  String get anime_download_task_settings => 'Task settings';
-  @override
-  String get anime_download_task_library_name => 'Library name';
-  @override
-  String get anime_download_task_content_kind => 'Import as';
-  @override
-  String get anime_download_task_settings_hint =>
-      'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-  @override
-  String get anime_download_task_more_actions => 'More task actions';
-  @override
   String get anime_download_unfiltered => 'No Trusted filter';
 }
 
@@ -111115,16 +110933,6 @@ extension on _StringsEn {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -116818,16 +116626,6 @@ extension on _StringsAr {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -122542,16 +122340,6 @@ extension on _StringsDe {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -128265,16 +128053,6 @@ extension on _StringsEs {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -133994,16 +133772,6 @@ extension on _StringsFr {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -139705,16 +139473,6 @@ extension on _StringsId {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -145431,16 +145189,6 @@ extension on _StringsIt {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -151119,16 +150867,6 @@ extension on _StringsJa {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -156811,16 +156549,6 @@ extension on _StringsKo {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -162530,16 +162258,6 @@ extension on _StringsNl {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -168246,16 +167964,6 @@ extension on _StringsPtBr {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -173967,16 +173675,6 @@ extension on _StringsRu {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -179672,16 +179370,6 @@ extension on _StringsTh {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -185386,16 +185074,6 @@ extension on _StringsTr {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -191095,16 +190773,6 @@ extension on _StringsVi {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:
@@ -196756,16 +196424,6 @@ extension on _StringsZhCn {
             '服务已正常响应，但按当前条件返回 0 条。查询：${query}；筛选：${filters}。请尝试别名或放宽筛选。';
       case 'anime_download_streaming_ready':
         return '已入库 · 下载继续';
-      case 'anime_download_task_settings':
-        return '任务设置';
-      case 'anime_download_task_library_name':
-        return '入库名称';
-      case 'anime_download_task_content_kind':
-        return '入库类型';
-      case 'anime_download_task_settings_hint':
-        return '这些设置影响入库；要修改下载文件名或目录，请使用“重命名 / 移动”。';
-      case 'anime_download_task_more_actions':
-        return '更多任务操作';
       case 'anime_download_unfiltered':
         return '未启用 Trusted 筛选';
       default:
@@ -202439,16 +202097,6 @@ extension on _StringsZhHk {
             'The service responded successfully but returned 0 items. Query: ${query}; filters: ${filters}. Try another title or loosen the filters.';
       case 'anime_download_streaming_ready':
         return 'In library · download continues';
-      case 'anime_download_task_settings':
-        return 'Task settings';
-      case 'anime_download_task_library_name':
-        return 'Library name';
-      case 'anime_download_task_content_kind':
-        return 'Import as';
-      case 'anime_download_task_settings_hint':
-        return 'These settings affect library import. Use Rename / move to change downloaded files or their folder.';
-      case 'anime_download_task_more_actions':
-        return 'More task actions';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
       default:

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "上次同步：没有可同步的内容",
   "sync_last_auto_disabled": "上次同步：已跳过——自动同步已关闭",
   "sync_last_cooled_down": "上次同步：已跳过——刚同步过",
-  "sync_last_failed": "上次同步：失败"
+  "sync_last_failed": "上次同步：失败",
+  "anime_download_no_results_detail": "服务已正常响应，但按当前条件返回 0 条。查询：$query；筛选：$filters。请尝试别名或放宽筛选。",
+  "anime_download_streaming_ready": "已入库 · 下载继续",
+  "anime_download_task_settings": "任务设置",
+  "anime_download_task_library_name": "入库名称",
+  "anime_download_task_content_kind": "入库类型",
+  "anime_download_task_settings_hint": "这些设置影响入库；要修改下载文件名或目录，请使用“重命名 / 移动”。",
+  "anime_download_task_more_actions": "更多任务操作",
+  "anime_download_unfiltered": "未启用 Trusted 筛选"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "上次同步：失败",
   "anime_download_no_results_detail": "服务已正常响应，但按当前条件返回 0 条。查询：$query；筛选：$filters。请尝试别名或放宽筛选。",
   "anime_download_streaming_ready": "已入库 · 下载继续",
-  "anime_download_task_settings": "任务设置",
-  "anime_download_task_library_name": "入库名称",
-  "anime_download_task_content_kind": "入库类型",
-  "anime_download_task_settings_hint": "这些设置影响入库；要修改下载文件名或目录，请使用“重命名 / 移动”。",
-  "anime_download_task_more_actions": "更多任务操作",
   "anime_download_unfiltered": "未启用 Trusted 筛选"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2777,10 +2777,5 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_task_settings": "Task settings",
-  "anime_download_task_library_name": "Library name",
-  "anime_download_task_content_kind": "Import as",
-  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
-  "anime_download_task_more_actions": "More task actions",
   "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2774,5 +2774,13 @@
   "sync_last_nothing": "Last sync: nothing to sync",
   "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
   "sync_last_cooled_down": "Last sync: skipped - synced recently",
-  "sync_last_failed": "Last sync: failed"
+  "sync_last_failed": "Last sync: failed",
+  "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
+  "anime_download_streaming_ready": "In library · download continues",
+  "anime_download_task_settings": "Task settings",
+  "anime_download_task_library_name": "Library name",
+  "anime_download_task_content_kind": "Import as",
+  "anime_download_task_settings_hint": "These settings affect library import. Use Rename / move to change downloaded files or their folder.",
+  "anime_download_task_more_actions": "More task actions",
+  "anime_download_unfiltered": "No Trusted filter"
 }

--- a/hibiki/lib/src/media/torrent/anime_download_importer.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_importer.dart
@@ -34,8 +34,9 @@ List<String> sortVideoPathsByEpisode(List<String> paths) {
 /// 封面/绑定失败不影响入库结果（best-effort），入库本体失败返回 null（由
 /// [AnimeDownloadService] 把计划标 failed）。
 Future<AnimeDownloadImportOutcome?> Function(
-        AnimeDownloadPlan plan, List<String> videoAbsolutePaths)
-    buildAnimeDownloadImporter(HibikiDatabase db) {
+  AnimeDownloadPlan plan,
+  List<String> videoAbsolutePaths,
+) buildAnimeDownloadImporter(HibikiDatabase db) {
   final VideoBookRepository repo = VideoBookRepository(db);
   return (AnimeDownloadPlan plan, List<String> videoAbsolutePaths) async {
     if (videoAbsolutePaths.isEmpty) return null;
@@ -43,6 +44,10 @@ Future<AnimeDownloadImportOutcome?> Function(
     final ({int collectionId, List<String> episodeUids}) result =
         await repo.importSplitPlaylist(
       collectionName: plan.seriesTitle,
+      // plan JSON 与 Drift 无法做同一事务；若进程在 DB 提交后、计划 flag
+      // 回写前崩溃，重启会重放 importer。以归一化视频路径作稳定业务键并在
+      // importSplitPlaylist 的单事务内复用条目/合集，重放只补状态、不重复副作用。
+      reuseExistingPaths: true,
       entries: <PlaylistEntry>[
         for (final String path in sorted) PlaylistEntry(title: '', path: path),
       ],
@@ -52,7 +57,9 @@ Future<AnimeDownloadImportOutcome?> Function(
     if (plan.anilistId != null) {
       try {
         await db.setMediaCollectionAnilistId(
-            result.collectionId, plan.anilistId);
+          result.collectionId,
+          plan.anilistId,
+        );
       } catch (_) {}
     }
 
@@ -78,7 +85,9 @@ Future<AnimeDownloadImportOutcome?> Function(
           // ⚠️ 唯一落库点：MediaCollections.coverSource 持久化 'video|<uid>'，
           // compositeKey 生成串与历史手写插值逐字节一致。
           await db.updateMediaCollectionCover(
-              result.collectionId, MediaKind.video.compositeKey(firstUid));
+            result.collectionId,
+            MediaKind.video.compositeKey(firstUid),
+          );
         }
       } catch (_) {}
     }

--- a/hibiki/lib/src/media/torrent/anime_download_plan.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_plan.dart
@@ -43,6 +43,7 @@ class AnimeDownloadPlan {
     this.status = statusDownloading,
     this.failReason,
     this.collectionId,
+    this.importedEarly = false,
     this.contentKind = kindVideo,
     this.jimakuEntryId,
     this.jimakuEntryName,
@@ -115,8 +116,15 @@ class AnimeDownloadPlan {
   /// 失败原因；仅 [statusFailed] 时有意义。
   final String? failReason;
 
-  /// 入库后回填的合集 id；仅 [statusImported] 时有意义。
+  /// 入库后回填的合集 id；[statusImported] 或 [importedEarly] 时有意义。
   final int? collectionId;
+
+  /// 是否已通过「边下边播」提前入库。
+  ///
+  /// 这与 [status] 正交：提前入库后种子仍在下载，因此状态继续保持
+  /// [statusDownloading]，后台轮询与 UI 进度不能停止；真正下载完成后才转
+  /// [statusImported]。旧计划缺字段时默认 false。
+  final bool importedEarly;
 
   /// 内容类型（[kindVideo] / [kindBook] / [kindAuto]），决定完成后走视频库还是
   /// 阅读库入库。默认 [kindVideo]（番剧 + 老计划向后兼容）。
@@ -156,6 +164,7 @@ class AnimeDownloadPlan {
     String? status,
     String? failReason,
     int? collectionId,
+    bool? importedEarly,
     String? contentKind,
     int? jimakuEntryId,
     String? jimakuEntryName,
@@ -176,6 +185,7 @@ class AnimeDownloadPlan {
       status: status ?? this.status,
       failReason: failReason ?? this.failReason,
       collectionId: collectionId ?? this.collectionId,
+      importedEarly: importedEarly ?? this.importedEarly,
       contentKind: contentKind ?? this.contentKind,
       jimakuEntryId: jimakuEntryId ?? this.jimakuEntryId,
       jimakuEntryName: jimakuEntryName ?? this.jimakuEntryName,
@@ -209,6 +219,7 @@ Map<String, dynamic> encodeAnimeDownloadPlan(AnimeDownloadPlan plan) {
     'status': plan.status,
     'failReason': plan.failReason,
     'collectionId': plan.collectionId,
+    'importedEarly': plan.importedEarly,
     'contentKind': plan.contentKind,
     'jimakuEntryId': plan.jimakuEntryId,
     'jimakuEntryName': plan.jimakuEntryName,
@@ -260,6 +271,7 @@ AnimeDownloadPlan? decodeAnimeDownloadPlan(Map<dynamic, dynamic> raw) {
           raw['failReason'] is String ? raw['failReason'] as String : null,
       collectionId:
           raw['collectionId'] is int ? raw['collectionId'] as int : null,
+      importedEarly: raw['importedEarly'] == true,
       // 缺字段（老计划）→ 视频（既有番剧计划行为不变）。
       contentKind: raw['contentKind'] is String &&
               (raw['contentKind'] as String).isNotEmpty

--- a/hibiki/lib/src/media/torrent/anime_download_plan.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_plan.dart
@@ -44,6 +44,7 @@ class AnimeDownloadPlan {
     this.failReason,
     this.collectionId,
     this.importedEarly = false,
+    this.importInProgress = false,
     this.contentKind = kindVideo,
     this.jimakuEntryId,
     this.jimakuEntryName,
@@ -126,6 +127,13 @@ class AnimeDownloadPlan {
   /// [statusImported]。旧计划缺字段时默认 false。
   final bool importedEarly;
 
+  /// 是否已把本计划的稳定业务键持久化为「正在入库」。
+  ///
+  /// 这不是完成标志：进程可能在 importer 提交 DB 事务后、回写
+  /// [importedEarly]/[status] 前崩溃。重启看到 true 时仍会按相同 plan id +
+  /// 视频路径重放幂等 importer，从而补齐计划状态但不重复制造媒体/合集。
+  final bool importInProgress;
+
   /// 内容类型（[kindVideo] / [kindBook] / [kindAuto]），决定完成后走视频库还是
   /// 阅读库入库。默认 [kindVideo]（番剧 + 老计划向后兼容）。
   final String contentKind;
@@ -165,6 +173,7 @@ class AnimeDownloadPlan {
     String? failReason,
     int? collectionId,
     bool? importedEarly,
+    bool? importInProgress,
     String? contentKind,
     int? jimakuEntryId,
     String? jimakuEntryName,
@@ -186,6 +195,7 @@ class AnimeDownloadPlan {
       failReason: failReason ?? this.failReason,
       collectionId: collectionId ?? this.collectionId,
       importedEarly: importedEarly ?? this.importedEarly,
+      importInProgress: importInProgress ?? this.importInProgress,
       contentKind: contentKind ?? this.contentKind,
       jimakuEntryId: jimakuEntryId ?? this.jimakuEntryId,
       jimakuEntryName: jimakuEntryName ?? this.jimakuEntryName,
@@ -220,6 +230,7 @@ Map<String, dynamic> encodeAnimeDownloadPlan(AnimeDownloadPlan plan) {
     'failReason': plan.failReason,
     'collectionId': plan.collectionId,
     'importedEarly': plan.importedEarly,
+    'importInProgress': plan.importInProgress,
     'contentKind': plan.contentKind,
     'jimakuEntryId': plan.jimakuEntryId,
     'jimakuEntryName': plan.jimakuEntryName,
@@ -243,12 +254,14 @@ AnimeDownloadPlan? decodeAnimeDownloadPlan(Map<dynamic, dynamic> raw) {
         final dynamic fileName = s['fileName'];
         final dynamic stagedPath = s['stagedPath'];
         if (fileName is! String || stagedPath is! String) continue;
-        subtitles.add(PlanSubtitle(
-          episode: s['episode'] is int ? s['episode'] as int : null,
-          fileName: fileName,
-          stagedPath: stagedPath,
-          language: s['language'] is String ? s['language'] as String : null,
-        ));
+        subtitles.add(
+          PlanSubtitle(
+            episode: s['episode'] is int ? s['episode'] as int : null,
+            fileName: fileName,
+            stagedPath: stagedPath,
+            language: s['language'] is String ? s['language'] as String : null,
+          ),
+        );
       }
     }
     return AnimeDownloadPlan(
@@ -272,6 +285,7 @@ AnimeDownloadPlan? decodeAnimeDownloadPlan(Map<dynamic, dynamic> raw) {
       collectionId:
           raw['collectionId'] is int ? raw['collectionId'] as int : null,
       importedEarly: raw['importedEarly'] == true,
+      importInProgress: raw['importInProgress'] == true,
       // 缺字段（老计划）→ 视频（既有番剧计划行为不变）。
       contentKind: raw['contentKind'] is String &&
               (raw['contentKind'] as String).isNotEmpty
@@ -352,15 +366,21 @@ class AnimeDownloadPlanStore {
   }
 
   /// 原子写入计划（临时文件 + rename，避免中途断电留半个 JSON）。
-  Future<void> save(AnimeDownloadPlan plan) async {
+  ///
+  /// 返回值让跨 JSON/数据库的入库编排能做到 fail-closed：只有 durable marker
+  /// 确认真落盘后才允许执行 importer 副作用。普通调用方可以继续忽略返回值。
+  Future<bool> save(AnimeDownloadPlan plan) async {
     try {
       await _plansDir.create(recursive: true);
       final File target = _planFile(plan.id);
-      final File tmp = File('${target.path}.tmp');
+      final File tmp = File(
+        '${target.path}.${DateTime.now().microsecondsSinceEpoch}.tmp',
+      );
       await tmp.writeAsString(jsonEncode(encodeAnimeDownloadPlan(plan)));
       await tmp.rename(target.path);
+      return true;
     } catch (_) {
-      // 写失败静默：调用方（周期 tick）下轮会重写。
+      return false;
     }
   }
 

--- a/hibiki/lib/src/media/torrent/anime_download_service.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_service.dart
@@ -239,7 +239,8 @@ class AnimeDownloadService {
 
   /// 边下边播（提前入库）：不等种子完成，立刻按计划入库。顺序下载模式下视频
   /// 从下载初期即可顺序播放；还没下到的集在库里表现为缺失态，下载补齐后自然
-  /// 可播。成功后计划标 imported，完成轮询自然跳过，不会重复入库。
+  /// 可播。成功后只标 [AnimeDownloadPlan.importedEarly]，计划仍保持 downloading，
+  /// 继续轮询真实进度；真正完成后才转 imported，且不会重复导入视频。
   ///
   /// 预检种子元数据已解析出视频文件（磁力刚添加时文件列表为空——此时直接
   /// 返回 false 且**不动计划状态**，避免误标 failed）。返回 true = 已入库。
@@ -271,10 +272,21 @@ class AnimeDownloadService {
       if (info == null) return false;
       // 预检：元数据未解析（文件列表还空）时不入库、不动计划状态。
       final List<TorrentFileEntry> files = await client.listFiles(info.hash);
-      final (List<String> v, List<String> b) =
-          _classifyContent(plan, info, files);
-      if (v.isEmpty && b.isEmpty) return false;
-      await _finishPlan(client, plan, info);
+      final (List<String> videos, _) = _classifyContent(plan, info, files);
+      if (videos.isEmpty) return false;
+      if (!info.isComplete) {
+        _publishProgress(<String, double>{
+          ...downloadProgress.value,
+          plan.id: info.progress.clamp(0.0, 1.0).toDouble(),
+        });
+      }
+      await _finishPlan(
+        client,
+        plan,
+        info,
+        keepDownloading: !info.isComplete,
+        importBooks: info.isComplete,
+      );
     } catch (_) {
       return false;
     } finally {
@@ -283,7 +295,7 @@ class AnimeDownloadService {
     final List<AnimeDownloadPlan> after = await store.loadAll();
     for (final AnimeDownloadPlan p in after) {
       if (p.id == planId) {
-        return p.status == AnimeDownloadPlan.statusImported;
+        return p.status == AnimeDownloadPlan.statusImported || p.importedEarly;
       }
     }
     return false;
@@ -368,13 +380,19 @@ class AnimeDownloadService {
     }
   }
 
-  /// 单个计划的完成处理：按内容类型分流 → 视频落 sidecar + 视频库入库、书走
-  /// 阅读库入库 → 状态落盘（任一入库成功即 imported；全失败 failed，不重试）。
+  /// 单个计划的处理：按内容类型分流 → 视频落 sidecar + 视频库入库、书走
+  /// 阅读库入库 → 状态落盘。
+  ///
+  /// [keepDownloading] 只用于「边下边播」：视频入库成功后记录
+  /// [AnimeDownloadPlan.importedEarly]，但保留 downloading 状态与进度轮询。真实
+  /// 完成 tick 再进来时跳过重复视频导入，只补书籍分流并把状态转 imported。
   Future<void> _finishPlan(
     TorrentBackend client,
     AnimeDownloadPlan plan,
-    TorrentSnapshot info,
-  ) async {
+    TorrentSnapshot info, {
+    bool keepDownloading = false,
+    bool importBooks = true,
+  }) async {
     final List<TorrentFileEntry> files = await client.listFiles(info.hash);
     final (List<String> videos, List<String> books) =
         _classifyContent(plan, info, files);
@@ -391,15 +409,17 @@ class AnimeDownloadService {
     if (videos.isNotEmpty) {
       resolved = await _resolveSubtitles(plan, videos);
       await _placeSidecars(videos, resolved.subtitles);
-      try {
-        outcome = await _importer(resolved, videos);
-      } catch (e) {
-        importError = 'video import failed: $e';
+      if (!plan.importedEarly) {
+        try {
+          outcome = await _importer(resolved, videos);
+        } catch (e) {
+          importError = 'video import failed: $e';
+        }
       }
     }
 
     // 书：走阅读库入库回调（epub）。
-    if (books.isNotEmpty) {
+    if (importBooks && books.isNotEmpty) {
       final Future<int?> Function(AnimeDownloadPlan, List<String>)?
           bookImporter = _bookImporter;
       if (bookImporter == null) {
@@ -413,7 +433,18 @@ class AnimeDownloadService {
       }
     }
 
-    final bool imported = outcome != null || booksImported > 0;
+    if (keepDownloading) {
+      // 提前入库失败不应把仍在正常下载的任务标成 failed；保留下载状态，用户可
+      // 稍后再试。字幕解析结论仍落盘，避免下一次重复网络决策。
+      await store.save(resolved.copyWith(
+        importedEarly: outcome != null || plan.importedEarly,
+        collectionId: outcome?.collectionId,
+      ));
+      return;
+    }
+
+    final bool imported =
+        plan.importedEarly || outcome != null || booksImported > 0;
     if (imported) {
       await store.save(resolved.copyWith(
         status: AnimeDownloadPlan.statusImported,

--- a/hibiki/lib/src/media/torrent/anime_download_service.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_service.dart
@@ -97,8 +97,9 @@ Map<String, PlanSubtitle> pairSubtitlesToVideos(
 
   // 规则 ②：恰好 1v1 且任一方集号缺失（双方都有但不等 → 规则 ③ 不配）。
   if (out.isEmpty && videoAbsolutePaths.length == 1 && subtitles.length == 1) {
-    final int? videoEp =
-        parseVideoFilename(p.basename(videoAbsolutePaths.first)).episode;
+    final int? videoEp = parseVideoFilename(
+      p.basename(videoAbsolutePaths.first),
+    ).episode;
     final int? subEp = subtitles.first.episode;
     if (videoEp == null || subEp == null) {
       out[videoAbsolutePaths.first] = subtitles.first;
@@ -158,11 +159,13 @@ class AnimeDownloadService {
 
   /// 默认后端工厂：外接 qBittorrent WebUI（AppModel 不传工厂时走这里）。
   static TorrentBackend _defaultBackendFactory(QbConnectionConfig config) {
-    return QbTorrentBackend(QBittorrentClient(
-      baseUrl: config.baseUrl,
-      username: config.username,
-      password: config.password,
-    ));
+    return QbTorrentBackend(
+      QBittorrentClient(
+        baseUrl: config.baseUrl,
+        username: config.username,
+        password: config.password,
+      ),
+    );
   }
 
   final AnimeDownloadPlanStore store;
@@ -196,6 +199,9 @@ class AnimeDownloadService {
 
   Timer? _timer;
   bool _ticking = false;
+  final Map<String, Future<void>> _planOperationTails =
+      <String, Future<void>>{};
+  final Map<String, Future<bool>> _importNowInFlight = <String, Future<bool>>{};
 
   /// 下载中计划的实时进度（planId → 0.0~1.0），每轮 tick 从后端快照
   /// [TorrentSnapshot.progress] 透传（服务本就轮询 listTorrents，UI 不再另建
@@ -244,7 +250,21 @@ class AnimeDownloadService {
   ///
   /// 预检种子元数据已解析出视频文件（磁力刚添加时文件列表为空——此时直接
   /// 返回 false 且**不动计划状态**，避免误标 failed）。返回 true = 已入库。
-  Future<bool> importNow(String planId) async {
+  Future<bool> importNow(String planId) {
+    final Future<bool>? existing = _importNowInFlight[planId];
+    if (existing != null) return existing;
+    late final Future<bool> operation;
+    operation = _runPlanSerial<bool>(planId, () => _importNowUnlocked(planId))
+        .whenComplete(() {
+      if (identical(_importNowInFlight[planId], operation)) {
+        _importNowInFlight.remove(planId);
+      }
+    });
+    _importNowInFlight[planId] = operation;
+    return operation;
+  }
+
+  Future<bool> _importNowUnlocked(String planId) async {
     final QbConnectionConfig? config = _configProvider();
     if (config == null || !config.isConfigured) return false;
     final List<AnimeDownloadPlan> plans = await store.loadAll();
@@ -301,6 +321,47 @@ class AnimeDownloadService {
     return false;
   }
 
+  /// 删除计划并在后端支持时真实取消种子。与 importNow/tick 共用 per-plan
+  /// 串行边界，避免「删除后旧 tick 晚回又 save 把计划复活」。
+  Future<bool> deletePlan(String planId, {bool deleteFiles = false}) =>
+      _runPlanSerial<bool>(planId, () async {
+        final QbConnectionConfig? config = _configProvider();
+        if (config != null && config.isConfigured) {
+          final TorrentBackend backend = _backendFactory(config);
+          try {
+            if (backend is TorrentRemovalBackend) {
+              await backend.removeTorrent(planId, deleteFiles: deleteFiles);
+            }
+          } finally {
+            backend.close();
+          }
+        }
+        await store.delete(planId);
+        return !(await store.loadAll()).any(
+          (AnimeDownloadPlan plan) => plan.id == planId,
+        );
+      });
+
+  Future<T> _runPlanSerial<T>(
+    String planId,
+    Future<T> Function() operation,
+  ) async {
+    final Future<void> previous =
+        _planOperationTails[planId] ?? Future<void>.value();
+    final Completer<void> done = Completer<void>();
+    final Future<void> tail = done.future;
+    _planOperationTails[planId] = tail;
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      done.complete();
+      if (identical(_planOperationTails[planId], tail)) {
+        _planOperationTails.remove(planId);
+      }
+    }
+  }
+
   Future<void> _tickOnce() async {
     // 反吸血等后端维护钩子先跑：与是否有等待入库的计划无关（做种期也要封）。
     _onTick?.call();
@@ -334,29 +395,60 @@ class AnimeDownloadService {
       final Map<String, double> progressNext = <String, double>{
         for (final AnimeDownloadPlan plan in pending)
           if (byHash[plan.id.toLowerCase()] case final TorrentSnapshot info
-              when !info.isComplete)
+              when !info.isComplete && !info.isFailure)
             plan.id: info.progress.clamp(0.0, 1.0).toDouble(),
       };
       _publishProgress(progressNext);
 
       for (final AnimeDownloadPlan plan in pending) {
         final TorrentSnapshot? info = byHash[plan.id.toLowerCase()];
-        if (info == null) {
-          // 用户在 qb 里删了种子：超时标 failed，否则等下轮（可能刚添加还没上列表）。
-          if (nowMs - plan.createdAtMs > torrentMissingTimeout.inMilliseconds) {
-            await store.save(plan.copyWith(
-              status: AnimeDownloadPlan.statusFailed,
-              failReason: 'torrent missing',
-            ));
+        await _runPlanSerial<void>(plan.id, () async {
+          final AnimeDownloadPlan? current = await _loadDownloadingPlan(
+            plan.id,
+          );
+          if (current == null) return;
+          if (info == null) {
+            // 用户在后端删了种子：超时才失败，否则等下轮（可能刚添加还没上列表）。
+            // 这条写路径也必须处于 per-plan 串行边界；否则 deletePlan 删完 JSON 后，
+            // 旧 tick 仍可能拿着 stale plan 晚回 save，把已删任务复活。
+            if (nowMs - current.createdAtMs >
+                torrentMissingTimeout.inMilliseconds) {
+              await store.save(
+                current.copyWith(
+                  status: AnimeDownloadPlan.statusFailed,
+                  failReason: 'torrent missing',
+                ),
+              );
+            }
+            return;
           }
-          continue;
-        }
-        if (!info.isComplete) continue;
-        await _finishPlan(client, plan, info);
+          if (info.isFailure) {
+            await store.save(
+              current.copyWith(
+                status: AnimeDownloadPlan.statusFailed,
+                failReason: 'torrent backend state: ${info.state}',
+                importInProgress: false,
+              ),
+            );
+            return;
+          }
+          if (!info.isComplete) return;
+          await _finishPlan(client, current, info);
+        });
       }
     } finally {
       client.close();
     }
+  }
+
+  Future<AnimeDownloadPlan?> _loadDownloadingPlan(String planId) async {
+    for (final AnimeDownloadPlan plan in await store.loadAll()) {
+      if (plan.id == planId &&
+          plan.status == AnimeDownloadPlan.statusDownloading) {
+        return plan;
+      }
+    }
+    return null;
   }
 
   /// 按计划 [AnimeDownloadPlan.contentKind] 把已完成文件分流成（视频, 书）两组
@@ -394,8 +486,11 @@ class AnimeDownloadService {
     bool importBooks = true,
   }) async {
     final List<TorrentFileEntry> files = await client.listFiles(info.hash);
-    final (List<String> videos, List<String> books) =
-        _classifyContent(plan, info, files);
+    final (List<String> videos, List<String> books) = _classifyContent(
+      plan,
+      info,
+      files,
+    );
 
     AnimeDownloadImportOutcome? outcome;
     int booksImported = 0;
@@ -410,10 +505,15 @@ class AnimeDownloadService {
       resolved = await _resolveSubtitles(plan, videos);
       await _placeSidecars(videos, resolved.subtitles);
       if (!plan.importedEarly) {
-        try {
-          outcome = await _importer(resolved, videos);
-        } catch (e) {
-          importError = 'video import failed: $e';
+        resolved = resolved.copyWith(importInProgress: true);
+        if (await store.save(resolved)) {
+          try {
+            outcome = await _importer(resolved, videos);
+          } catch (e) {
+            importError = 'video import failed: $e';
+          }
+        } else {
+          importError = 'video import marker persist failed';
         }
       }
     }
@@ -436,25 +536,34 @@ class AnimeDownloadService {
     if (keepDownloading) {
       // 提前入库失败不应把仍在正常下载的任务标成 failed；保留下载状态，用户可
       // 稍后再试。字幕解析结论仍落盘，避免下一次重复网络决策。
-      await store.save(resolved.copyWith(
-        importedEarly: outcome != null || plan.importedEarly,
-        collectionId: outcome?.collectionId,
-      ));
+      await store.save(
+        resolved.copyWith(
+          importedEarly: outcome != null || plan.importedEarly,
+          collectionId: outcome?.collectionId,
+          importInProgress: false,
+        ),
+      );
       return;
     }
 
     final bool imported =
         plan.importedEarly || outcome != null || booksImported > 0;
     if (imported) {
-      await store.save(resolved.copyWith(
-        status: AnimeDownloadPlan.statusImported,
-        collectionId: outcome?.collectionId,
-      ));
+      await store.save(
+        resolved.copyWith(
+          status: AnimeDownloadPlan.statusImported,
+          collectionId: outcome?.collectionId,
+          importInProgress: false,
+        ),
+      );
     } else {
-      await store.save(resolved.copyWith(
-        status: AnimeDownloadPlan.statusFailed,
-        failReason: importError ?? 'import failed',
-      ));
+      await store.save(
+        resolved.copyWith(
+          status: AnimeDownloadPlan.statusFailed,
+          failReason: importError ?? 'import failed',
+          importInProgress: false,
+        ),
+      );
     }
   }
 
@@ -483,8 +592,10 @@ class AnimeDownloadService {
       );
     }
     try {
-      final ResolvedPlanSubtitles result =
-          await resolver(plan, videoAbsolutePaths);
+      final ResolvedPlanSubtitles result = await resolver(
+        plan,
+        videoAbsolutePaths,
+      );
       if (result.subtitles.isEmpty) {
         return plan.copyWith(
           subtitleStatus: AnimeDownloadPlan.subtitleUnavailable,
@@ -521,8 +632,10 @@ class AnimeDownloadService {
     List<String> videoAbsolutePaths,
     List<PlanSubtitle> subtitles,
   ) async {
-    final Map<String, PlanSubtitle> pairs =
-        pairSubtitlesToVideos(videoAbsolutePaths, subtitles);
+    final Map<String, PlanSubtitle> pairs = pairSubtitlesToVideos(
+      videoAbsolutePaths,
+      subtitles,
+    );
     for (final MapEntry<String, PlanSubtitle> entry in pairs.entries) {
       try {
         final File target = File(sidecarPathFor(entry.key, entry.value));

--- a/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
@@ -18,7 +18,7 @@ import 'package:hibiki_torrent/hibiki_torrent.dart';
 ///   记入 [_pendingFirstLast]，在每次 [listTorrents] 轮询时补应用 ——
 ///   上层服务本就以 20s tick 轮询，无需额外定时器。
 /// - close 只关本后端持有的 session；引擎（DLL）进程级共享不关。
-class EmbeddedTorrentBackend implements TorrentBackend {
+class EmbeddedTorrentBackend implements TorrentRemovalBackend {
   EmbeddedTorrentBackend({
     required EmbeddedTorrentSession session,
     required TorrentSaveRoots saveRoots,
@@ -70,12 +70,18 @@ class EmbeddedTorrentBackend implements TorrentBackend {
     if (!await prepareCategory(category)) return false;
     final HtAddResult result;
     if (magnetOrUrl.startsWith('magnet:')) {
-      result = _session.addMagnet(magnetOrUrl,
-          savePath: savePath, sequential: sequential);
+      result = _session.addMagnet(
+        magnetOrUrl,
+        savePath: savePath,
+        sequential: sequential,
+      );
     } else if (magnetOrUrl.toLowerCase().endsWith('.torrent') &&
         !magnetOrUrl.contains('://')) {
-      result = _session.addTorrentFile(magnetOrUrl,
-          savePath: savePath, sequential: sequential);
+      result = _session.addTorrentFile(
+        magnetOrUrl,
+        savePath: savePath,
+        sequential: sequential,
+      );
     } else {
       // http(s) .torrent URL：内置引擎不支持（见类注释）。
       return false;
@@ -95,9 +101,11 @@ class EmbeddedTorrentBackend implements TorrentBackend {
     _applyPendingFirstLast();
     return _session
         .listTorrents()
-        .where((HtTorrentStatus t) =>
-            category == null ||
-            _saveRoots.ownsCategoryPath(t.savePath, category))
+        .where(
+          (HtTorrentStatus t) =>
+              category == null ||
+              _saveRoots.ownsCategoryPath(t.savePath, category),
+        )
         .map(_toSnapshot)
         .toList(growable: false);
   }
@@ -107,14 +115,23 @@ class EmbeddedTorrentBackend implements TorrentBackend {
     final List<HtFileEntry>? files = _session.torrentFiles(torrentId);
     if (files == null) return const <TorrentFileEntry>[];
     return files
-        .map((HtFileEntry f) => TorrentFileEntry(
-              name: f.path,
-              size: f.size,
-              progress: f.size <= 0 ? 1.0 : (f.done / f.size).clamp(0.0, 1.0),
-              index: f.index,
-            ))
+        .map(
+          (HtFileEntry f) => TorrentFileEntry(
+            name: f.path,
+            size: f.size,
+            progress: f.size <= 0 ? 1.0 : (f.done / f.size).clamp(0.0, 1.0),
+            index: f.index,
+          ),
+        )
         .toList(growable: false);
   }
+
+  @override
+  Future<bool> removeTorrent(
+    String torrentId, {
+    bool deleteFiles = false,
+  }) async =>
+      _session.removeTorrent(torrentId, deleteFiles: deleteFiles);
 
   @override
   Future<TorrentStorageResult> renameFile(

--- a/hibiki/lib/src/media/torrent/nyaa_client.dart
+++ b/hibiki/lib/src/media/torrent/nyaa_client.dart
@@ -6,6 +6,29 @@ import 'package:xml/xml.dart';
 
 import 'package:hibiki/src/media/video/video_filename_parser.dart';
 
+const String _nyaaNamespace = 'https://nyaa.si/xmlns/nyaa';
+
+/// 严格搜索契约的稳定错误码。调用方可以按 [code] 区分「空响应、编码、XML、
+/// RSS 结构、字段」而不必解析第三方 parser 的易变错误文本。
+enum NyaaFeedErrorCode {
+  emptyBody,
+  unsupportedEncoding,
+  invalidUtf8,
+  malformedXml,
+  notRss,
+  missingStructure,
+  invalidNamespace,
+  missingField,
+  invalidField,
+}
+
+class NyaaFeedFormatException extends FormatException {
+  NyaaFeedFormatException(this.code, String detail)
+      : super('Nyaa RSS ${code.name}: $detail');
+
+  final NyaaFeedErrorCode code;
+}
+
 /// Nyaa 磁链标准 tracker 列表（nyaa.si 站点磁链默认附带的公开 tracker）。
 const List<String> kNyaaTrackers = <String>[
   'http://nyaa.tracker.wf:7777/announce',
@@ -87,7 +110,8 @@ class NyaaTorrent {
   /// 由 infoHash 构造的磁力链接（附 nyaa 标准 tracker 列表）。
   String get magnet {
     final StringBuffer sb = StringBuffer(
-        'magnet:?xt=urn:btih:$infoHash&dn=${Uri.encodeComponent(title)}');
+      'magnet:?xt=urn:btih:$infoHash&dn=${Uri.encodeComponent(title)}',
+    );
     for (final String tracker in kNyaaTrackers) {
       sb.write('&tr=${Uri.encodeComponent(tracker)}');
     }
@@ -218,23 +242,145 @@ List<NyaaTorrent> _parseNyaaDocument(XmlDocument doc) {
     final String title = _childText(item, 'title');
     if (title.isEmpty) continue;
     final String sizeText = _childText(item, 'size');
-    out.add(NyaaTorrent(
-      title: title,
-      torrentUrl: _childText(item, 'link'),
-      pageUrl: _childText(item, 'guid'),
-      infoHash: _childText(item, 'infoHash'),
-      seeders: int.tryParse(_childText(item, 'seeders')) ?? 0,
-      leechers: int.tryParse(_childText(item, 'leechers')) ?? 0,
-      downloads: int.tryParse(_childText(item, 'downloads')) ?? 0,
-      sizeText: sizeText,
-      sizeBytes: parseNyaaSize(sizeText),
-      categoryId: _childText(item, 'categoryId'),
-      trusted: _childText(item, 'trusted') == 'Yes',
-      remake: _childText(item, 'remake') == 'Yes',
-      pubDate: parseNyaaPubDate(_childText(item, 'pubDate')),
-    ));
+    out.add(
+      NyaaTorrent(
+        title: title,
+        torrentUrl: _childText(item, 'link'),
+        pageUrl: _childText(item, 'guid'),
+        infoHash: _childText(item, 'infoHash'),
+        seeders: int.tryParse(_childText(item, 'seeders')) ?? 0,
+        leechers: int.tryParse(_childText(item, 'leechers')) ?? 0,
+        downloads: int.tryParse(_childText(item, 'downloads')) ?? 0,
+        sizeText: sizeText,
+        sizeBytes: parseNyaaSize(sizeText),
+        categoryId: _childText(item, 'categoryId'),
+        trusted: _childText(item, 'trusted') == 'Yes',
+        remake: _childText(item, 'remake') == 'Yes',
+        pubDate: parseNyaaPubDate(_childText(item, 'pubDate')),
+      ),
+    );
   }
   return out;
+}
+
+List<NyaaTorrent> _parseNyaaDocumentStrict(XmlDocument doc) {
+  final XmlElement root = doc.rootElement;
+  if (root.name.local != 'rss') {
+    throw NyaaFeedFormatException(
+      NyaaFeedErrorCode.notRss,
+      'root element must be <rss>',
+    );
+  }
+  final List<XmlElement> channels = root.childElements
+      .where((XmlElement element) => element.name.local == 'channel')
+      .toList(growable: false);
+  if (channels.length != 1) {
+    throw NyaaFeedFormatException(
+      NyaaFeedErrorCode.missingStructure,
+      'feed must contain exactly one direct <channel>',
+    );
+  }
+
+  final List<NyaaTorrent> out = <NyaaTorrent>[];
+  for (final XmlElement item in channels.single.childElements.where(
+    (XmlElement element) => element.name.local == 'item',
+  )) {
+    String requiredRssField(String name) {
+      final String value = _childTextInNamespace(item, name, null);
+      if (value.isEmpty) {
+        throw NyaaFeedFormatException(
+          NyaaFeedErrorCode.missingField,
+          'item is missing <$name>',
+        );
+      }
+      return value;
+    }
+
+    String requiredNyaaField(String name) {
+      final XmlElement? element = _childElement(item, name);
+      if (element == null || element.innerText.trim().isEmpty) {
+        throw NyaaFeedFormatException(
+          NyaaFeedErrorCode.missingField,
+          'item is missing nyaa:$name',
+        );
+      }
+      if (element.name.namespaceUri != _nyaaNamespace) {
+        throw NyaaFeedFormatException(
+          NyaaFeedErrorCode.invalidNamespace,
+          '$name must use $_nyaaNamespace',
+        );
+      }
+      return element.innerText.trim();
+    }
+
+    final String title = requiredRssField('title');
+    final String torrentUrl = requiredRssField('link');
+    final String pageUrl = requiredRssField('guid');
+    final String infoHash = requiredNyaaField('infoHash');
+    if (!RegExp(r'^[0-9a-fA-F]{40}$').hasMatch(infoHash)) {
+      throw NyaaFeedFormatException(
+        NyaaFeedErrorCode.invalidField,
+        'nyaa:infoHash must be 40 hexadecimal characters',
+      );
+    }
+
+    final String sizeText = _childTextInNamespace(item, 'size', _nyaaNamespace);
+    out.add(
+      NyaaTorrent(
+        title: title,
+        torrentUrl: torrentUrl,
+        pageUrl: pageUrl,
+        infoHash: infoHash,
+        seeders: _optionalNyaaInt(item, 'seeders'),
+        leechers: _optionalNyaaInt(item, 'leechers'),
+        downloads: _optionalNyaaInt(item, 'downloads'),
+        sizeText: sizeText,
+        sizeBytes: parseNyaaSize(sizeText),
+        categoryId: _childTextInNamespace(item, 'categoryId', _nyaaNamespace),
+        trusted:
+            _childTextInNamespace(item, 'trusted', _nyaaNamespace) == 'Yes',
+        remake: _childTextInNamespace(item, 'remake', _nyaaNamespace) == 'Yes',
+        pubDate: parseNyaaPubDate(_childTextInNamespace(item, 'pubDate', null)),
+      ),
+    );
+  }
+  return out;
+}
+
+int _optionalNyaaInt(XmlElement item, String name) {
+  final XmlElement? element = _childElement(item, name);
+  if (element == null) return 0;
+  if (element.name.namespaceUri != _nyaaNamespace) {
+    throw NyaaFeedFormatException(
+      NyaaFeedErrorCode.invalidNamespace,
+      '$name must use $_nyaaNamespace',
+    );
+  }
+  final String value = element.innerText.trim();
+  final int? parsed = int.tryParse(value);
+  if (parsed == null || parsed < 0) {
+    throw NyaaFeedFormatException(
+      NyaaFeedErrorCode.invalidField,
+      'nyaa:$name must be a non-negative integer',
+    );
+  }
+  return parsed;
+}
+
+XmlElement? _childElement(XmlElement item, String local) {
+  for (final XmlElement child in item.childElements) {
+    if (child.name.local == local) return child;
+  }
+  return null;
+}
+
+String _childTextInNamespace(XmlElement item, String local, String? namespace) {
+  for (final XmlElement child in item.childElements) {
+    if (child.name.local == local && child.name.namespaceUri == namespace) {
+      return child.innerText.trim();
+    }
+  }
+  return '';
 }
 
 /// 取 [item] 下本地名为 [local] 的第一个子元素文本（去首尾空白）；没有返回空串。
@@ -280,23 +426,55 @@ class NyaaClient {
     if (res.statusCode != 200) {
       throw http.ClientException('HTTP ${res.statusCode}', uri);
     }
-    // Nyaa RSS 是 UTF-8 但常不声明 charset，http 的 res.body 会按 latin1 解码 →
-    // 日文标题变乱码（如「ソ・ラ・ノ・ヲ・ト」→「Soã»Ra...」）。显式按 UTF-8 解码。
-    final String body = utf8.decode(res.bodyBytes, allowMalformed: true);
+    final String? declaredCharset = RegExp(
+      r'''charset\s*=\s*['"]?([^;'"\s]+)''',
+      caseSensitive: false,
+    ).firstMatch(res.headers['content-type'] ?? '')?.group(1)?.toLowerCase();
+    if (declaredCharset != null &&
+        declaredCharset != 'utf-8' &&
+        declaredCharset != 'utf8') {
+      throw NyaaFeedFormatException(
+        NyaaFeedErrorCode.unsupportedEncoding,
+        'HTTP declared $declaredCharset; UTF-8 is required',
+      );
+    }
+
+    // Nyaa RSS 是 UTF-8但常不声明 charset；必须严格解码，损坏字节不能被 U+FFFD
+    // 替换后继续冒充有效结果。
+    final String body;
+    try {
+      body = utf8.decode(res.bodyBytes);
+    } on FormatException {
+      throw NyaaFeedFormatException(
+        NyaaFeedErrorCode.invalidUtf8,
+        'body contains invalid UTF-8 bytes',
+      );
+    }
     if (body.trim().isEmpty) {
-      throw const FormatException('Nyaa RSS response was empty');
+      throw NyaaFeedFormatException(
+        NyaaFeedErrorCode.emptyBody,
+        'response body was empty',
+      );
     }
     try {
       final XmlDocument doc = XmlDocument.parse(body);
-      final XmlElement root = doc.rootElement;
-      if (root.name.local != 'rss' || doc.findAllElements('channel').isEmpty) {
-        throw const FormatException('Nyaa response was not an RSS feed');
+      final String? xmlEncoding = doc.declaration?.encoding?.toLowerCase();
+      if (xmlEncoding != null &&
+          xmlEncoding != 'utf-8' &&
+          xmlEncoding != 'utf8') {
+        throw NyaaFeedFormatException(
+          NyaaFeedErrorCode.unsupportedEncoding,
+          'XML declared $xmlEncoding; UTF-8 is required',
+        );
       }
-      return _parseNyaaDocument(doc);
-    } on FormatException {
+      return _parseNyaaDocumentStrict(doc);
+    } on NyaaFeedFormatException {
       rethrow;
-    } catch (error) {
-      throw FormatException('Invalid Nyaa RSS response: $error');
+    } on XmlException catch (error) {
+      throw NyaaFeedFormatException(
+        NyaaFeedErrorCode.malformedXml,
+        error.message,
+      );
     }
   }
 

--- a/hibiki/lib/src/media/torrent/nyaa_client.dart
+++ b/hibiki/lib/src/media/torrent/nyaa_client.dart
@@ -206,32 +206,35 @@ DateTime? parseNyaaPubDate(String raw) {
 List<NyaaTorrent> parseNyaaRss(String body) {
   if (body.trim().isEmpty) return const <NyaaTorrent>[];
   try {
-    final XmlDocument doc = XmlDocument.parse(body);
-    final List<NyaaTorrent> out = <NyaaTorrent>[];
-    for (final XmlElement item in doc.findAllElements('item')) {
-      final String title = _childText(item, 'title');
-      if (title.isEmpty) continue;
-      final String sizeText = _childText(item, 'size');
-      out.add(NyaaTorrent(
-        title: title,
-        torrentUrl: _childText(item, 'link'),
-        pageUrl: _childText(item, 'guid'),
-        infoHash: _childText(item, 'infoHash'),
-        seeders: int.tryParse(_childText(item, 'seeders')) ?? 0,
-        leechers: int.tryParse(_childText(item, 'leechers')) ?? 0,
-        downloads: int.tryParse(_childText(item, 'downloads')) ?? 0,
-        sizeText: sizeText,
-        sizeBytes: parseNyaaSize(sizeText),
-        categoryId: _childText(item, 'categoryId'),
-        trusted: _childText(item, 'trusted') == 'Yes',
-        remake: _childText(item, 'remake') == 'Yes',
-        pubDate: parseNyaaPubDate(_childText(item, 'pubDate')),
-      ));
-    }
-    return out;
+    return _parseNyaaDocument(XmlDocument.parse(body));
   } catch (_) {
     return const <NyaaTorrent>[];
   }
+}
+
+List<NyaaTorrent> _parseNyaaDocument(XmlDocument doc) {
+  final List<NyaaTorrent> out = <NyaaTorrent>[];
+  for (final XmlElement item in doc.findAllElements('item')) {
+    final String title = _childText(item, 'title');
+    if (title.isEmpty) continue;
+    final String sizeText = _childText(item, 'size');
+    out.add(NyaaTorrent(
+      title: title,
+      torrentUrl: _childText(item, 'link'),
+      pageUrl: _childText(item, 'guid'),
+      infoHash: _childText(item, 'infoHash'),
+      seeders: int.tryParse(_childText(item, 'seeders')) ?? 0,
+      leechers: int.tryParse(_childText(item, 'leechers')) ?? 0,
+      downloads: int.tryParse(_childText(item, 'downloads')) ?? 0,
+      sizeText: sizeText,
+      sizeBytes: parseNyaaSize(sizeText),
+      categoryId: _childText(item, 'categoryId'),
+      trusted: _childText(item, 'trusted') == 'Yes',
+      remake: _childText(item, 'remake') == 'Yes',
+      pubDate: parseNyaaPubDate(_childText(item, 'pubDate')),
+    ));
+  }
+  return out;
 }
 
 /// 取 [item] 下本地名为 [local] 的第一个子元素文本（去首尾空白）；没有返回空串。
@@ -257,7 +260,8 @@ class NyaaClient {
   /// 按关键词搜索种子。网络错误 / 非 200 **抛出**（`ClientException` /
   /// `SocketException` / `HandshakeException` 等），由调用方决定展示或记录：
   /// 以前这里吞错返回空列表，真实网络故障（如站点被墙、代理未配）会被
-  /// 误报成「无结果」，用户无从判断。RSS 内容坏损仍宽容（[parseNyaaRss]）。
+  /// 误报成「无结果」，用户无从判断。空响应 / 损坏 RSS 同样抛
+  /// [FormatException]；只有结构有效、确实没有 `<item>` 才返回空列表。
   Future<List<NyaaTorrent>> search(
     String query, {
     String category = '1_0',
@@ -278,7 +282,22 @@ class NyaaClient {
     }
     // Nyaa RSS 是 UTF-8 但常不声明 charset，http 的 res.body 会按 latin1 解码 →
     // 日文标题变乱码（如「ソ・ラ・ノ・ヲ・ト」→「Soã»Ra...」）。显式按 UTF-8 解码。
-    return parseNyaaRss(utf8.decode(res.bodyBytes, allowMalformed: true));
+    final String body = utf8.decode(res.bodyBytes, allowMalformed: true);
+    if (body.trim().isEmpty) {
+      throw const FormatException('Nyaa RSS response was empty');
+    }
+    try {
+      final XmlDocument doc = XmlDocument.parse(body);
+      final XmlElement root = doc.rootElement;
+      if (root.name.local != 'rss' || doc.findAllElements('channel').isEmpty) {
+        throw const FormatException('Nyaa response was not an RSS feed');
+      }
+      return _parseNyaaDocument(doc);
+    } on FormatException {
+      rethrow;
+    } catch (error) {
+      throw FormatException('Invalid Nyaa RSS response: $error');
+    }
   }
 
   void close() => _client.close();

--- a/hibiki/lib/src/media/torrent/qb_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/qb_torrent_backend.dart
@@ -3,7 +3,7 @@ import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 
 /// [TorrentBackend] 的外接 qBittorrent 实现：纯转发适配器，把接口语义
 /// 一一映射到 [QBittorrentClient] 的 WebUI 调用，不加任何额外逻辑。
-class QbTorrentBackend implements TorrentBackend {
+class QbTorrentBackend implements TorrentRemovalBackend {
   QbTorrentBackend(this._client);
 
   final QBittorrentClient _client;
@@ -40,6 +40,10 @@ class QbTorrentBackend implements TorrentBackend {
   Future<List<TorrentFileEntry>> listFiles(String torrentId) =>
       _client.fetchTorrentFiles(torrentId);
 
+  @override
+  Future<bool> removeTorrent(String torrentId, {bool deleteFiles = false}) =>
+      _client.deleteTorrent(torrentId, deleteFiles: deleteFiles);
+
   /// TODO-1961-c：qb 的 renameFile 认的是**旧相对路径**而不是文件下标，
   /// 所以先用文件列表把下标翻成路径（内置引擎那边下标就是天然主键）。
   /// 翻不出来说明种子/下标不对，直接报错而不是猜一个路径去改。
@@ -49,8 +53,9 @@ class QbTorrentBackend implements TorrentBackend {
     int fileIndex,
     String newPath,
   ) async {
-    final List<TorrentFileEntry> files =
-        await _client.fetchTorrentFiles(torrentId);
+    final List<TorrentFileEntry> files = await _client.fetchTorrentFiles(
+      torrentId,
+    );
     String? oldPath;
     for (final TorrentFileEntry f in files) {
       if (f.index == fileIndex) {
@@ -67,7 +72,10 @@ class QbTorrentBackend implements TorrentBackend {
       newPath: newPath,
     );
     return TorrentStorageResult(
-        ok: ok, path: ok ? newPath : null, error: error);
+      ok: ok,
+      path: ok ? newPath : null,
+      error: error,
+    );
   }
 
   @override
@@ -75,10 +83,15 @@ class QbTorrentBackend implements TorrentBackend {
     String torrentId,
     String newSavePath,
   ) async {
-    final (bool ok, String? error) =
-        await _client.setLocation(hash: torrentId, location: newSavePath);
+    final (bool ok, String? error) = await _client.setLocation(
+      hash: torrentId,
+      location: newSavePath,
+    );
     return TorrentStorageResult(
-        ok: ok, path: ok ? newSavePath : null, error: error);
+      ok: ok,
+      path: ok ? newSavePath : null,
+      error: error,
+    );
   }
 
   @override

--- a/hibiki/lib/src/media/torrent/qbittorrent_client.dart
+++ b/hibiki/lib/src/media/torrent/qbittorrent_client.dart
@@ -19,8 +19,9 @@ String normalizeQbBaseUrl(String raw) {
 /// 边界正则找 `SID=`，兼容多 cookie 串与属性尾巴（`; path=/` 等）。
 String? extractSidCookie(String? setCookieHeader) {
   if (setCookieHeader == null || setCookieHeader.isEmpty) return null;
-  final RegExpMatch? match =
-      RegExp(r'(?:^|[\s,;])SID=([^;,\s]+)').firstMatch(setCookieHeader);
+  final RegExpMatch? match = RegExp(
+    r'(?:^|[\s,;])SID=([^;,\s]+)',
+  ).firstMatch(setCookieHeader);
   final String? sid = match?.group(1);
   if (sid == null || sid.isEmpty) return null;
   return sid;
@@ -38,16 +39,19 @@ List<TorrentSnapshot> parseQbTorrentInfos(String body) {
       if (e is! Map) continue;
       final dynamic hash = e['hash'];
       if (hash is! String || hash.isEmpty) continue;
-      out.add(TorrentSnapshot(
-        hash: hash,
-        name: e['name'] is String ? e['name'] as String : '',
-        progress: e['progress'] is num ? (e['progress'] as num).toDouble() : 0,
-        state: e['state'] is String ? e['state'] as String : '',
-        savePath: e['save_path'] is String ? e['save_path'] as String : '',
-        contentPath:
-            e['content_path'] is String ? e['content_path'] as String : '',
-        amountLeft: e['amount_left'] is int ? e['amount_left'] as int : -1,
-      ));
+      out.add(
+        TorrentSnapshot(
+          hash: hash,
+          name: e['name'] is String ? e['name'] as String : '',
+          progress:
+              e['progress'] is num ? (e['progress'] as num).toDouble() : 0,
+          state: e['state'] is String ? e['state'] as String : '',
+          savePath: e['save_path'] is String ? e['save_path'] as String : '',
+          contentPath:
+              e['content_path'] is String ? e['content_path'] as String : '',
+          amountLeft: e['amount_left'] is int ? e['amount_left'] as int : -1,
+        ),
+      );
     }
     return out;
   } catch (_) {
@@ -67,12 +71,15 @@ List<TorrentFileEntry> parseQbTorrentFiles(String body) {
       if (e is! Map) continue;
       final dynamic name = e['name'];
       if (name is! String || name.isEmpty) continue;
-      out.add(TorrentFileEntry(
-        name: name,
-        size: e['size'] is int ? e['size'] as int : 0,
-        progress: e['progress'] is num ? (e['progress'] as num).toDouble() : 0,
-        index: e['index'] is int ? e['index'] as int : -1,
-      ));
+      out.add(
+        TorrentFileEntry(
+          name: name,
+          size: e['size'] is int ? e['size'] as int : 0,
+          progress:
+              e['progress'] is num ? (e['progress'] as num).toDouble() : 0,
+          index: e['index'] is int ? e['index'] as int : -1,
+        ),
+      );
     }
     return out;
   } catch (_) {
@@ -200,6 +207,20 @@ class QBittorrentClient {
     );
     if (res == null || res.statusCode != 200) return const <TorrentFileEntry>[];
     return parseQbTorrentFiles(res.body);
+  }
+
+  /// 删除单个种子；默认只移除任务、保留已下载文件。
+  Future<bool> deleteTorrent(String hash, {bool deleteFiles = false}) async {
+    if (hash.isEmpty) return false;
+    final http.Response? res = await _request(
+      'POST',
+      '/api/v2/torrents/delete',
+      form: <String, String>{
+        'hashes': hash,
+        'deleteFiles': deleteFiles ? 'true' : 'false',
+      },
+    );
+    return res != null && res.statusCode == 200;
   }
 
   /// TODO-1961-c：改名种子内文件：`POST /api/v2/torrents/renameFile`

--- a/hibiki/lib/src/media/torrent/torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/torrent_backend.dart
@@ -47,10 +47,7 @@ class TorrentSnapshot {
   };
 
   /// 错误类状态：即使进度显示 100% 也不视为可用完成态。
-  static const Set<String> _errorStates = <String>{
-    'error',
-    'missingFiles',
-  };
+  static const Set<String> _errorStates = <String>{'error', 'missingFiles'};
 
   /// 是否已下载完成：state 属于做种类直接算完成；否则要求进度打满
   /// （`progress >= 1.0` 或 `amountLeft == 0`）且 state 不是 error 类。
@@ -59,6 +56,16 @@ class TorrentSnapshot {
     if (_errorStates.contains(state)) return false;
     return progress >= 1.0 || amountLeft == 0;
   }
+
+  /// 后端已明确进入不可继续的错误态。暂停态不是失败：暂停/恢复后计划仍继续
+  /// downloading，并保留实时进度。
+  bool get isFailure => _errorStates.contains(state);
+}
+
+/// 支持真实取消/删除种子的后端能力。单独拆接口，避免只读 fake 被迫伪造支持；
+/// qBittorrent 与内置引擎都实现，调用方仅在 capability 存在时触发。
+abstract interface class TorrentRemovalBackend implements TorrentBackend {
+  Future<bool> removeTorrent(String torrentId, {bool deleteFiles = false});
 }
 
 /// 种子内的单个文件（后端无关）。

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -41,34 +41,36 @@ class VideoBookRepository {
   /// 读回时由 [scrapeMetadata] 反序列化——JSON 编解码只在本仓库层出现一次，
   /// 展示层和刮削层都只见领域对象 [ScrapeMetadata]。
   Future<void> saveScrapeMetadata(String bookUid, ScrapeMetadata meta) {
-    return _db.upsertVideoScrapeMeta(VideoScrapeMetaCompanion.insert(
-      bookUid: bookUid,
-      source: meta.source.name,
-      subjectId: meta.subjectId,
-      title: meta.title,
-      originalTitle: Value<String?>(meta.originalTitle),
-      summary: Value<String?>(meta.summary),
-      airDate: Value<String?>(meta.airDate),
-      rating: Value<double?>(meta.rating),
-      ratingCount: Value<int?>(meta.ratingCount),
-      episodeCount: Value<int?>(meta.episodeCount),
-      tagsJson: Value<String?>(
-        meta.tags.isEmpty
-            ? null
-            : jsonEncode(<Map<String, Object?>>[
-                for (final ScrapeTag t in meta.tags) t.toJson(),
-              ]),
+    return _db.upsertVideoScrapeMeta(
+      VideoScrapeMetaCompanion.insert(
+        bookUid: bookUid,
+        source: meta.source.name,
+        subjectId: meta.subjectId,
+        title: meta.title,
+        originalTitle: Value<String?>(meta.originalTitle),
+        summary: Value<String?>(meta.summary),
+        airDate: Value<String?>(meta.airDate),
+        rating: Value<double?>(meta.rating),
+        ratingCount: Value<int?>(meta.ratingCount),
+        episodeCount: Value<int?>(meta.episodeCount),
+        tagsJson: Value<String?>(
+          meta.tags.isEmpty
+              ? null
+              : jsonEncode(<Map<String, Object?>>[
+                  for (final ScrapeTag t in meta.tags) t.toJson(),
+                ]),
+        ),
+        infoboxJson: Value<String?>(
+          meta.infobox.isEmpty
+              ? null
+              : jsonEncode(<Map<String, Object?>>[
+                  for (final ScrapeInfoboxEntry e in meta.infobox) e.toJson(),
+                ]),
+        ),
+        detailUrl: Value<String?>(meta.detailUrl),
+        scrapedAt: DateTime.now(),
       ),
-      infoboxJson: Value<String?>(
-        meta.infobox.isEmpty
-            ? null
-            : jsonEncode(<Map<String, Object?>>[
-                for (final ScrapeInfoboxEntry e in meta.infobox) e.toJson(),
-              ]),
-      ),
-      detailUrl: Value<String?>(meta.detailUrl),
-      scrapedAt: DateTime.now(),
-    ));
+    );
   }
 
   /// 读一本视频的条目资料；未刮过返回 null。JSON 列损坏时该列降级为空列表（其余
@@ -143,8 +145,9 @@ class VideoBookRepository {
         mediaType: kActivityMediaVideo,
         title: title,
         mediaKey: bookUid,
-        dateKey:
-            HibikiTimeFormat.dayKey(DateTime.fromMillisecondsSinceEpoch(nowMs)),
+        dateKey: HibikiTimeFormat.dayKey(
+          DateTime.fromMillisecondsSinceEpoch(nowMs),
+        ),
         timestampMs: nowMs,
       );
     } catch (e) {
@@ -177,8 +180,11 @@ class VideoBookRepository {
     required Map<String, int> remoteAddedAt,
     Map<String, int> remoteTombstones = const <String, int>{},
   }) =>
-      _db.mergeRemoteVideoTags(bookUid,
-          remoteAddedAt: remoteAddedAt, remoteTombstones: remoteTombstones);
+      _db.mergeRemoteVideoTags(
+        bookUid,
+        remoteAddedAt: remoteAddedAt,
+        remoteTombstones: remoteTombstones,
+      );
 
   /// 统一合集 Phase 2：把一个多集播放列表拆成 N 条独立 VideoBooks 行 + 一个 playlist
   /// [MediaCollections]（成员按序）。是「导入时拆集」的单一真相源，与 v38 迁移
@@ -192,23 +198,41 @@ class VideoBookRepository {
     required String collectionName,
     required List<PlaylistEntry> entries,
     int? sourceId,
+    bool reuseExistingPaths = false,
   }) async {
-    final Set<String> taken =
-        (await listAll()).map((VideoBookRow r) => r.bookUid).toSet();
     final List<String> epUids = <String>[];
     int collectionId = 0;
     await _db.transaction(() async {
+      final List<VideoBookRow> existingBooks = await listAll();
+      final Set<String> taken =
+          existingBooks.map((VideoBookRow r) => r.bookUid).toSet();
       for (final PlaylistEntry e in entries) {
-        final String uid =
-            coreUniqueVideoBookUid(coreSingleVideoBookUid(e.path), taken);
+        if (reuseExistingPaths) {
+          VideoBookRow? existing;
+          final String normalized = normalizeVideoPath(e.path);
+          for (final VideoBookRow row in existingBooks) {
+            if (normalizeVideoPath(row.videoPath) == normalized) {
+              existing = row;
+              break;
+            }
+          }
+          if (existing != null) {
+            epUids.add(existing.bookUid);
+            continue;
+          }
+        }
+        final String uid = coreUniqueVideoBookUid(
+          coreSingleVideoBookUid(e.path),
+          taken,
+        );
         taken.add(uid);
         epUids.add(uid);
         await saveVideoBook(
           VideoBooksCompanion(
             bookUid: Value(uid),
-            title: Value(e.title.isNotEmpty
-                ? e.title
-                : p.basenameWithoutExtension(e.path)),
+            title: Value(
+              e.title.isNotEmpty ? e.title : p.basenameWithoutExtension(e.path),
+            ),
             videoPath: Value(e.path),
             lastPositionMs: Value(e.positionMs),
             embeddedSubtitleTrack: const Value<int?>(0),
@@ -216,9 +240,14 @@ class VideoBookRepository {
           ),
           sourceId: sourceId,
         );
+        if (reuseExistingPaths) {
+          existingBooks.add((await _db.getVideoBookByBookUid(uid))!);
+        }
       }
-      collectionId = await _db.createMediaCollection(collectionName,
-          collectionType: 'playlist');
+      collectionId = await _db.createMediaCollection(
+        collectionName,
+        collectionType: 'playlist',
+      );
       for (final String uid in epUids) {
         await _db.addToCollection(collectionId, MediaKind.video, uid);
       }
@@ -250,8 +279,9 @@ class VideoBookRepository {
     int? sourceId,
   }) async {
     // 当前成员 bookUid → 其稳定基身份（用于与清单按基身份对齐）。
-    final List<MediaCollectionItemRow> items =
-        await _db.getCollectionItems(collectionId);
+    final List<MediaCollectionItemRow> items = await _db.getCollectionItems(
+      collectionId,
+    );
     final Map<String, String> memberBaseByUid = <String, String>{};
     for (final MediaCollectionItemRow item in items) {
       if (item.mediaType != MediaKind.video.dbValue) continue;
@@ -279,9 +309,9 @@ class VideoBookRepository {
         await saveVideoBook(
           VideoBooksCompanion(
             bookUid: Value(uid),
-            title: Value(e.title.isNotEmpty
-                ? e.title
-                : p.basenameWithoutExtension(e.path)),
+            title: Value(
+              e.title.isNotEmpty ? e.title : p.basenameWithoutExtension(e.path),
+            ),
             videoPath: Value(e.path),
             lastPositionMs: Value(e.positionMs),
             embeddedSubtitleTrack: const Value<int?>(0),
@@ -377,15 +407,18 @@ class VideoBookRepository {
     if (videoPath == null && subtitleSource == null) {
       return Future<void>.value();
     }
-    return (_db.update(_db.videoBooks)
-          ..where((tbl) => tbl.bookUid.equals(bookUid)))
-        .write(VideoBooksCompanion(
-      videoPath:
-          videoPath == null ? const Value.absent() : Value<String>(videoPath),
-      subtitleSource: subtitleSource == null
-          ? const Value.absent()
-          : Value<String?>(subtitleSource),
-    ));
+    return (_db.update(
+      _db.videoBooks,
+    )..where((tbl) => tbl.bookUid.equals(bookUid)))
+        .write(
+      VideoBooksCompanion(
+        videoPath:
+            videoPath == null ? const Value.absent() : Value<String>(videoPath),
+        subtitleSource: subtitleSource == null
+            ? const Value.absent()
+            : Value<String?>(subtitleSource),
+      ),
+    );
   }
 
   /// TODO-1961-d：把库里落在 [fromPath] 下的路径整体重映射到 [toPath]，
@@ -419,19 +452,22 @@ class VideoBookRepository {
     await _db.transaction(() async {
       for (final MapEntry<String, VideoPathRemap> entry in pending.entries) {
         final VideoPathRemap remap = entry.value;
-        await (_db.update(_db.videoBooks)
-              ..where((tbl) => tbl.bookUid.equals(entry.key)))
-            .write(VideoBooksCompanion(
-          videoPath: remap.videoPath == null
-              ? const Value.absent()
-              : Value<String>(remap.videoPath!),
-          subtitleSource: remap.subtitleSource == null
-              ? const Value.absent()
-              : Value<String?>(remap.subtitleSource),
-          secondarySubtitleSource: remap.secondarySubtitleSource == null
-              ? const Value.absent()
-              : Value<String?>(remap.secondarySubtitleSource),
-        ));
+        await (_db.update(
+          _db.videoBooks,
+        )..where((tbl) => tbl.bookUid.equals(entry.key)))
+            .write(
+          VideoBooksCompanion(
+            videoPath: remap.videoPath == null
+                ? const Value.absent()
+                : Value<String>(remap.videoPath!),
+            subtitleSource: remap.subtitleSource == null
+                ? const Value.absent()
+                : Value<String?>(remap.subtitleSource),
+            secondarySubtitleSource: remap.secondarySubtitleSource == null
+                ? const Value.absent()
+                : Value<String?>(remap.secondarySubtitleSource),
+          ),
+        );
       }
     });
     return pending.length;
@@ -459,9 +495,13 @@ class VideoBookRepository {
   /// 同款四态编码（外挂绝对路径 / `embedded:<n>` / `off:` / null）。副字幕由 libmpv
   /// `secondary-sid` 自渲染（不进 cue 流，不可查词），故无 cue，独立于 cue 事务写入。
   Future<void> updateSecondarySubtitleSource(
-          String bookUid, String? secondarySubtitleSource) =>
+    String bookUid,
+    String? secondarySubtitleSource,
+  ) =>
       _db.updateVideoBookSecondarySubtitleSource(
-          bookUid, secondarySubtitleSource);
+        bookUid,
+        secondarySubtitleSource,
+      );
 
   /// 更新用户选中的音轨 id（libmpv `AudioTrack.id`；清除存 null）。
   Future<void> updateAudioTrackId(String bookUid, String? audioTrackId) =>
@@ -470,13 +510,17 @@ class VideoBookRepository {
   /// 更新系列（合集）级音轨偏好（schema v52，同系列音轨记忆）。合集内任一集选音轨
   /// 写这里，全系列共享；null=清除（加载回退各集 per-book / libmpv 默认）。
   Future<void> updateCollectionAudioTrackId(
-          int collectionId, String? audioTrackId) =>
+    int collectionId,
+    String? audioTrackId,
+  ) =>
       _db.updateMediaCollectionAudioTrackId(collectionId, audioTrackId);
 
   /// 更新系列（合集）级字幕调轴（音画延迟毫秒，schema v52，同系列调轴记忆）。合集内
   /// 任一集调轴写这里，全系列共享；null=清除（加载回退各集 per-book / 0）。
   Future<void> updateCollectionSubtitleDelayMs(
-          int collectionId, int? delayMs) =>
+    int collectionId,
+    int? delayMs,
+  ) =>
       _db.updateMediaCollectionSubtitleDelayMs(collectionId, delayMs);
 
   /// 更新视频封面图绝对路径（书架/视频库长按菜单手动设置封面）。
@@ -505,8 +549,11 @@ class VideoBookRepository {
     // 标记、其他设备逐条确认后也删。keepLocalOnly 不记，避免删本地→回写墓碑循环。best-effort。
     if (scope == DeleteScope.syncEverywhere) {
       try {
-        await _db.writeSyncDeletionTombstone(SyncTombstoneKind.video.dbValue,
-            bookUid, DateTime.now().millisecondsSinceEpoch);
+        await _db.writeSyncDeletionTombstone(
+          SyncTombstoneKind.video.dbValue,
+          bookUid,
+          DateTime.now().millisecondsSinceEpoch,
+        );
       } catch (_) {
         // best-effort：记账失败不影响视频已删。
       }
@@ -674,7 +721,9 @@ class VideoBookRepository {
   }) =>
       _db.transaction(() async {
         await _db.replaceCuesForBook(
-            bookUid, cues.map(AudioCue.toCompanion).toList());
+          bookUid,
+          cues.map(AudioCue.toCompanion).toList(),
+        );
         await _db.updateVideoBookSubtitleSource(bookUid, subtitleSource);
       });
 }

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -115,6 +115,20 @@ List<String> animeTitleOptions(AniListMedia media) {
   return out;
 }
 
+class _TorrentSearchSnapshot {
+  const _TorrentSearchSnapshot({
+    required this.generation,
+    required this.query,
+    required this.category,
+    required this.trustedOnly,
+  });
+
+  final int generation;
+  final String query;
+  final String category;
+  final bool trustedOnly;
+}
+
 class AnimeDownloadDialog extends ConsumerStatefulWidget {
   const AnimeDownloadDialog({
     super.key,
@@ -197,6 +211,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   /// 错误态原样展示：站点被墙 / 代理未配时用户能看出是自己网络的问题。
   String? _torrentsErrorDetail;
   List<NyaaTorrent> _torrents = const <NyaaTorrent>[];
+  int _torrentRequestGeneration = 0;
+  NyaaClient? _activeNyaaClient;
+  _TorrentSearchSnapshot? _appliedTorrentSearch;
   String _category = '1_0';
   bool _trustedOnly = false;
   TorrentSortKey _torrentSort = TorrentSortKey.seeders;
@@ -213,8 +230,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   List<JimakuFile> _jimakuFiles = const <JimakuFile>[];
   String? _jimakuPreferredLanguage;
   int? _jimakuSearchEpisode;
-  JimakuEpisodeIndex _jimakuIndex =
-      JimakuEpisodeIndex.fromFiles(const <JimakuFile>[]);
+  JimakuEpisodeIndex _jimakuIndex = JimakuEpisodeIndex.fromFiles(
+    const <JimakuFile>[],
+  );
   bool _jimakuLoaded = false;
 
   /// Jimaku 字幕搜索状态（区分：搜索中 / 缺 API key / 出错 / 已搜到/无），
@@ -258,6 +276,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
 
   @override
   void dispose() {
+    _torrentRequestGeneration++;
+    _activeNyaaClient?.close();
+    _activeNyaaClient = null;
     _animeQueryCtrl.dispose();
     _nyaaQueryCtrl.dispose();
     _jimakuKeyCtrl.dispose();
@@ -276,8 +297,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
 
   void _snack(String message) {
     if (!mounted) return;
-    ScaffoldMessenger.of(context)
-        .showSnackBar(SnackBar(content: Text(message)));
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(SnackBar(content: Text(message)));
   }
 
   // ---------------------------------------------------------------- 阶段 1
@@ -359,10 +381,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       _jimakuIndex = JimakuEpisodeIndex.fromFiles(const <JimakuFile>[]);
       _jimakuLoaded = false;
     });
-    await Future.wait(<Future<void>>[
-      _fetchTorrents(),
-      _fetchJimaku(media),
-    ]);
+    await Future.wait(<Future<void>>[_fetchTorrents(), _fetchJimaku(media)]);
   }
 
   /// 返回搜番阶段（换番）。
@@ -381,6 +400,14 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   Future<void> _fetchTorrents() async {
     final String query = _nyaaQueryCtrl.text.trim();
     if (query.isEmpty) return;
+    final _TorrentSearchSnapshot request = _TorrentSearchSnapshot(
+      generation: ++_torrentRequestGeneration,
+      query: query,
+      category: _category,
+      trustedOnly: _trustedOnly,
+    );
+    _activeNyaaClient?.close();
+    _activeNyaaClient = null;
     setState(() {
       _loadingTorrents = true;
       _torrentsLoaded = false;
@@ -392,22 +419,27 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       nyaa = NyaaClient(
         client: await ref.read(appProvider).createDownloadHttpClient(),
       );
+      if (!mounted || request.generation != _torrentRequestGeneration) {
+        return;
+      }
+      _activeNyaaClient = nyaa;
       final List<NyaaTorrent> results = await nyaa
           .search(
-            query,
-            category: _category,
-            filter: _trustedOnly ? '2' : '0',
+            request.query,
+            category: request.category,
+            filter: request.trustedOnly ? '2' : '0',
           )
           .timeout(kDownloadDiscoveryTimeout);
       final List<NyaaTorrent> sorted = List<NyaaTorrent>.of(results)
         ..sort(_compareTorrents);
-      if (!mounted) return;
+      if (!mounted || request.generation != _torrentRequestGeneration) return;
       setState(() {
         _torrents = sorted;
         _torrentsLoaded = true;
+        _appliedTorrentSearch = request;
       });
     } catch (error) {
-      if (mounted) {
+      if (mounted && request.generation == _torrentRequestGeneration) {
         setState(() {
           _torrentsError = true;
           _torrentsErrorDetail = error.toString();
@@ -415,7 +447,10 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       }
     } finally {
       nyaa?.close();
-      if (mounted) setState(() => _loadingTorrents = false);
+      if (identical(_activeNyaaClient, nyaa)) _activeNyaaClient = null;
+      if (mounted && request.generation == _torrentRequestGeneration) {
+        setState(() => _loadingTorrents = false);
+      }
     }
   }
 
@@ -514,8 +549,10 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       // 匹配，不是按下标——重搜的结果集顺序/长度都会变），只有它彻底不在新结果里
       // 才回退首条。此前无条件重置成 `entries.first`，换个番剧名重搜就把用户的
       // 手选静默冲掉。必须在 listFiles 之前定下目标，否则拉的是首条的文件。
-      final JimakuEntry? target =
-          _resolveJimakuEntryFor(entries, torrent: _selectedTorrent);
+      final JimakuEntry? target = _resolveJimakuEntryFor(
+        entries,
+        torrent: _selectedTorrent,
+      );
       final List<JimakuFile> files = target == null
           ? const <JimakuFile>[]
           : await jimaku
@@ -744,8 +781,10 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     // （[_runJimakuSearch]）手上还没有种子，只能无条件取首条；那条首条可能
     // 是别的季，落位层的「集号严格相等」拦不住 S1 条目 × S2 包（集号照样相等）。
     final JimakuEntry? previous = _selectedJimakuEntry;
-    final JimakuEntry? target =
-        _resolveJimakuEntryFor(_jimakuEntries, torrent: torrent);
+    final JimakuEntry? target = _resolveJimakuEntryFor(
+      _jimakuEntries,
+      torrent: torrent,
+    );
     final bool switched = target?.id != previous?.id;
     setState(() {
       _selectedTorrent = torrent;
@@ -774,8 +813,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   Future<void> _push({bool subscribe = false}) async {
     final AppModel appModel = ref.read(appProvider);
     // null（全新用户没进过设置）→ 默认配置（auto：桌面内置引擎，开箱即用）。
-    final QbConnectionConfig config =
-        effectiveTorrentConfig(appModel.qbConnectionConfig);
+    final QbConnectionConfig config = effectiveTorrentConfig(
+      appModel.qbConnectionConfig,
+    );
     final NyaaTorrent? torrent = _selectedTorrent;
     final AniListMedia? media = _selectedMedia;
     if (!_backendReady) return;
@@ -883,9 +923,11 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     // 说清字幕的时序：选了条目就必然还没下，别让用户以为「推送时字幕已经拿好」。
     final String pushedMessage =
         subscribed ? t.download_subscription_created : t.anime_download_pushed;
-    _snack(subsEntry == null
-        ? pushedMessage
-        : '$pushedMessage · ${t.anime_download_subs_deferred}');
+    _snack(
+      subsEntry == null
+          ? pushedMessage
+          : '$pushedMessage · ${t.anime_download_subs_deferred}',
+    );
     // BUG-1006：embedded（下载页内联）没有对话框可关——无条件 pop 会把宿主
     // 路由（下载 tab 页/整个页面栈）弹掉。独立对话框才 pop；内联模式复位回
     // 搜番初始阶段并刷新任务区（对照 [_pushGeneric] 成功后的节奏）。
@@ -922,10 +964,15 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   }
 
   Future<void> _deletePlan(AnimeDownloadPlan plan) async {
-    final AnimeDownloadPlanStore? store =
-        ref.read(appProvider).animeDownloadPlanStore;
+    final AppModel appModel = ref.read(appProvider);
+    final AnimeDownloadPlanStore? store = appModel.animeDownloadPlanStore;
     if (store == null) return;
-    await store.delete(plan.id);
+    final AnimeDownloadService? service = appModel.animeDownloadService;
+    if (service == null) {
+      await store.delete(plan.id);
+    } else {
+      await service.deletePlan(plan.id);
+    }
     await _reloadPlans();
   }
 
@@ -936,8 +983,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   /// 救不回来。走这里则由引擎自己改（做种不断），库路径同步迁移。
   Future<void> _relocatePlan(AnimeDownloadPlan plan) async {
     final AppModel appModel = ref.read(appProvider);
-    final QbConnectionConfig config =
-        effectiveTorrentConfig(appModel.qbConnectionConfig);
+    final QbConnectionConfig config = effectiveTorrentConfig(
+      appModel.qbConnectionConfig,
+    );
     // 先拿这个种子的当前快照（save_path + 文件列表）：改名要文件下标与旧相对
     // 路径，移动要旧 save_path，都得从后端现问，不能猜。
     final TorrentBackend backend = appModel.createTorrentBackend(config);
@@ -945,7 +993,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     List<TorrentFileEntry> files = const <TorrentFileEntry>[];
     try {
       for (final TorrentSnapshot t in await backend.listTorrents(
-          category: config.category.isEmpty ? null : config.category)) {
+        category: config.category.isEmpty ? null : config.category,
+      )) {
         if (t.hash.toLowerCase() == plan.id.toLowerCase()) {
           snapshot = t;
           break;
@@ -991,11 +1040,13 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       case RelocateStatus.unchanged:
         break;
       case RelocateStatus.engineFailed:
-        _snack(t.anime_download_relocate_engine_failed(
-            reason: outcome.error ?? ''));
+        _snack(
+          t.anime_download_relocate_engine_failed(reason: outcome.error ?? ''),
+        );
       case RelocateStatus.libraryFailed:
-        _snack(t.anime_download_relocate_library_failed(
-            reason: outcome.error ?? ''));
+        _snack(
+          t.anime_download_relocate_library_failed(reason: outcome.error ?? ''),
+        );
     }
     await _reloadPlans();
   }
@@ -1010,27 +1061,6 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     if (ok) await _reloadPlans();
   }
 
-  /// 单任务配置：允许在入库前修正库内名称；通用磁链还可修正内容分流类型。
-  /// 下载文件/目录不在这里假改，仍统一走后端支持的 [_relocatePlan]。
-  Future<void> _configurePlan(AnimeDownloadPlan plan) async {
-    final AnimeDownloadPlanStore? store =
-        ref.read(appProvider).animeDownloadPlanStore;
-    if (store == null) {
-      _snack(t.anime_download_store_unavailable);
-      return;
-    }
-    final _TaskSettingsChoice? choice = await showDialog<_TaskSettingsChoice>(
-      context: context,
-      builder: (BuildContext context) => _TaskSettingsDialog(plan: plan),
-    );
-    if (choice == null) return;
-    await store.save(plan.copyWith(
-      seriesTitle: choice.libraryName,
-      contentKind: choice.contentKind,
-    ));
-    await _reloadPlans();
-  }
-
   // ---------------------------------------------------------------- 渲染
 
   /// 「去设置」：embedded 由下载页回调切页内设置面板；独立对话框（视频页入口）
@@ -1041,10 +1071,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       onOpenSettings();
       return;
     }
-    Navigator.of(context).push(MaterialPageRoute<void>(
-      builder: (BuildContext context) =>
-          const DownloadsPage(initialShowSettings: true),
-    ));
+    Navigator.of(context).push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) =>
+            const DownloadsPage(initialShowSettings: true),
+      ),
+    );
   }
 
   /// qb 未配置提示条（推送按钮禁用，浏览选种不禁）+「去设置」直达按钮。
@@ -1061,14 +1093,18 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       ),
       child: Row(
         children: <Widget>[
-          Icon(Icons.info_outline,
-              size: 18, color: theme.colorScheme.onSurfaceVariant),
+          Icon(
+            Icons.info_outline,
+            size: 18,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               t.download_backend_not_configured,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
           const SizedBox(width: 8),
@@ -1239,8 +1275,10 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         final double textScale = MediaQuery.textScalerOf(context).scale(1);
         final double stripWidth = estimateSegmentedStripWidth(
           segmentLabels: segments
-              .map<String?>((ButtonSegment<String> s) =>
-                  s.label is Text ? (s.label! as Text).data : null)
+              .map<String?>(
+                (ButtonSegment<String> s) =>
+                    s.label is Text ? (s.label! as Text).data : null,
+              )
               .toList(growable: false),
           fontSize: fontSize,
           textScaleFactor: textScale,
@@ -1307,8 +1345,11 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          Icon(Icons.cloud_off_outlined,
-              size: 40, color: theme.colorScheme.error),
+          Icon(
+            Icons.cloud_off_outlined,
+            size: 40,
+            color: theme.colorScheme.error,
+          ),
           const SizedBox(height: 8),
           Text(message, textAlign: TextAlign.center),
           if (detail != null && detail.isNotEmpty) ...<Widget>[
@@ -1320,8 +1361,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
                 textAlign: TextAlign.center,
                 maxLines: 4,
                 overflow: TextOverflow.ellipsis,
-                style: theme.textTheme.bodySmall
-                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
           ],
@@ -1332,8 +1374,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
               child: Text(
                 t.anime_download_search_error_proxy_hint,
                 textAlign: TextAlign.center,
-                style: theme.textTheme.bodySmall
-                    ?.copyWith(color: theme.colorScheme.outline),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
               ),
             ),
           ],
@@ -1388,8 +1431,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
                 filters: filters,
               ),
               textAlign: TextAlign.center,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ),
@@ -1431,8 +1475,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
             Text(
               t.anime_download_search_start_hint,
               textAlign: TextAlign.center,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ],
         ),
@@ -1495,7 +1540,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
             suffixIcon: IconButton(
               tooltip: t.anime_download_search,
               icon: const Icon(Icons.search, size: 20),
-              onPressed: _loadingTorrents ? null : _fetchTorrents,
+              onPressed: _fetchTorrents,
             ),
           ),
           onSubmitted: (_) => _fetchTorrents(),
@@ -1516,14 +1561,13 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
                 label: Text(label),
                 visualDensity: VisualDensity.compact,
                 selected: _category == id,
-                onSelected:
-                    _loadingTorrents ? null : (_) => _selectCategory(id),
+                onSelected: (_) => _selectCategory(id),
               ),
             FilterChip(
               label: Text(t.anime_download_trusted_only),
               visualDensity: VisualDensity.compact,
               selected: _trustedOnly,
-              onSelected: _loadingTorrents ? null : _toggleTrustedOnly,
+              onSelected: _toggleTrustedOnly,
             ),
             PopupMenuButton<TorrentSortKey>(
               tooltip: t.sort_by,
@@ -1566,7 +1610,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       );
     }
     if (_torrentsLoaded && _torrents.isEmpty) {
-      final String categoryLabel = switch (_category) {
+      final _TorrentSearchSnapshot applied = _appliedTorrentSearch!;
+      final String categoryLabel = switch (applied.category) {
         '1_4' => t.anime_download_category_raw,
         '1_2' => t.anime_download_category_english,
         '1_3' => t.anime_download_category_non_english,
@@ -1574,9 +1619,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       };
       return _buildNoResults(
         theme,
-        query: _nyaaQueryCtrl.text.trim(),
+        query: applied.query,
         filters:
-            '$categoryLabel · ${_trustedOnly ? t.anime_download_trusted_only : t.anime_download_unfiltered}',
+            '$categoryLabel · ${applied.trustedOnly ? t.anime_download_trusted_only : t.anime_download_unfiltered}',
       );
     }
     return ListView.builder(
@@ -1616,14 +1661,24 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     if (torrent.sizeText.isNotEmpty) {
       chips.add(_miniChip(theme, torrent.sizeText));
     }
-    chips.add(_miniChip(theme, '▲${torrent.seeders}',
+    chips.add(
+      _miniChip(
+        theme,
+        '▲${torrent.seeders}',
         background: scheme.secondaryContainer,
-        foreground: scheme.onSecondaryContainer));
+        foreground: scheme.onSecondaryContainer,
+      ),
+    );
     if (torrent.trusted) {
-      chips.add(_miniChip(theme, t.anime_download_trusted,
+      chips.add(
+        _miniChip(
+          theme,
+          t.anime_download_trusted,
           icon: Icons.verified_outlined,
           background: scheme.tertiaryContainer,
-          foreground: scheme.onTertiaryContainer));
+          foreground: scheme.onTertiaryContainer,
+        ),
+      );
     }
     if (torrent.isBatch) {
       final (int, int)? range = torrent.episodeRange;
@@ -1636,8 +1691,13 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     if (_jimakuLoaded) {
       final ({int covered, int? total}) coverage = _jimakuCoverageFor(torrent);
       if (coverage.covered == 0) {
-        chips.add(_miniChip(theme, t.anime_download_no_subs,
-            foreground: scheme.outline));
+        chips.add(
+          _miniChip(
+            theme,
+            t.anime_download_no_subs,
+            foreground: scheme.outline,
+          ),
+        );
       } else {
         // 应有集数未知（整季包 / 剧场版）→ 只报实际能给出的条数，不报 `?`：
         // 徽标数必须与确认页字幕列表条数一致，否则「列表说有、点进去说无」。
@@ -1647,16 +1707,19 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         // 整季包的集号未经核对（见 [_subtitleEpisodesUnverified]）→ 加 `~`
         // 并退成中性配色，不画成「字幕齐了」的确定态。
         final bool unverified = _subtitleEpisodesUnverified(torrent);
-        chips.add(_miniChip(
-          theme,
-          '${t.anime_download_subs_badge} ${unverified ? '~' : ''}$count',
-          icon: Icons.subtitles_outlined,
-          background: unverified
-              ? scheme.surfaceContainerHighest
-              : scheme.primaryContainer,
-          foreground:
-              unverified ? scheme.onSurfaceVariant : scheme.onPrimaryContainer,
-        ));
+        chips.add(
+          _miniChip(
+            theme,
+            '${t.anime_download_subs_badge} ${unverified ? '~' : ''}$count',
+            icon: Icons.subtitles_outlined,
+            background: unverified
+                ? scheme.surfaceContainerHighest
+                : scheme.primaryContainer,
+            foreground: unverified
+                ? scheme.onSurfaceVariant
+                : scheme.onPrimaryContainer,
+          ),
+        );
       }
     }
     return chips;
@@ -1865,9 +1928,10 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         // 输入框改了但没搜时按钮转强调色：手改番剧名/集号后「下面没变」不是坏了，
         // 是还没触发搜索——把这件事显式画出来（BUG-1190）。
         ListenableBuilder(
-          listenable: Listenable.merge(
-            <Listenable>[_jimakuQueryCtrl, _jimakuEpisodeCtrl],
-          ),
+          listenable: Listenable.merge(<Listenable>[
+            _jimakuQueryCtrl,
+            _jimakuEpisodeCtrl,
+          ]),
           builder: (BuildContext context, Widget? child) {
             final bool dirty = _jimakuQueryCtrl.text.trim().isNotEmpty &&
                 _currentJimakuSearchInput() != _appliedJimakuSearch;
@@ -1893,14 +1957,18 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         child: Text(
           t.anime_download_subs_need_key,
           textAlign: TextAlign.center,
-          style: theme.textTheme.bodySmall
-              ?.copyWith(color: theme.colorScheme.outline),
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.outline,
+          ),
         ),
       );
     }
     if (_jimakuError) {
       return _buildErrorRetry(
-          theme, t.anime_download_subs_failed, _retryJimaku);
+        theme,
+        t.anime_download_subs_failed,
+        _retryJimaku,
+      );
     }
     if (_chosenSubs.isEmpty) {
       // 季号校验拦下自动选中时**必然**落到这条空态分支（没条目 ⇒ 没文件 ⇒
@@ -1928,8 +1996,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
                 children: <Widget>[
                   Text(
                     t.anime_download_no_subs,
-                    style: theme.textTheme.bodySmall
-                        ?.copyWith(color: theme.colorScheme.outline),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
                   ),
                   const SizedBox(height: 8),
                   TextButton.icon(
@@ -1955,10 +2024,16 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         _buildSubsHintRow(
-            theme, Icons.schedule, t.anime_download_subs_deferred),
+          theme,
+          Icons.schedule,
+          t.anime_download_subs_deferred,
+        ),
         if (unverified)
-          _buildSubsHintRow(theme, Icons.help_outline,
-              t.anime_download_subs_episodes_unverified),
+          _buildSubsHintRow(
+            theme,
+            Icons.help_outline,
+            t.anime_download_subs_episodes_unverified,
+          ),
         Expanded(child: _buildChosenSubsListView(theme)),
       ],
     );
@@ -1976,8 +2051,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
           Expanded(
             child: Text(
               text,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
             ),
           ),
         ],
@@ -2039,8 +2115,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
                   padding: const EdgeInsets.all(12),
                   child: Text(
                     t.anime_download_no_tasks,
-                    style: theme.textTheme.bodySmall
-                        ?.copyWith(color: theme.colorScheme.outline),
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.outline,
+                    ),
                   ),
                 )
               : ListView.builder(
@@ -2077,8 +2154,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       _snack(t.anime_download_store_unavailable);
       return;
     }
-    final QbConnectionConfig config =
-        effectiveTorrentConfig(appModel.qbConnectionConfig);
+    final QbConnectionConfig config = effectiveTorrentConfig(
+      appModel.qbConnectionConfig,
+    );
     final TorrentBackend backend = appModel.createTorrentBackend(config);
     bool pushed = false;
     try {
@@ -2093,8 +2171,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         final List<TorrentSnapshot> torrents = await backend.listTorrents(
           category: config.category.isEmpty ? null : config.category,
         );
-        pushed = torrents.any((TorrentSnapshot t) =>
-            t.hash.toLowerCase() == plan.id.toLowerCase());
+        pushed = torrents.any(
+          (TorrentSnapshot t) => t.hash.toLowerCase() == plan.id.toLowerCase(),
+        );
       }
     } finally {
       backend.close();
@@ -2103,10 +2182,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       _snack(t.anime_download_push_failed);
       return;
     }
-    await store.save(plan.copyWith(
-      status: AnimeDownloadPlan.statusDownloading,
-      createdAtMs: DateTime.now().millisecondsSinceEpoch,
-    ));
+    await store.save(
+      plan.copyWith(
+        status: AnimeDownloadPlan.statusDownloading,
+        createdAtMs: DateTime.now().millisecondsSinceEpoch,
+      ),
+    );
     unawaited(appModel.animeDownloadService?.tick());
     _snack(t.anime_download_pushed);
     await _reloadPlans();
@@ -2135,16 +2216,25 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   }
 
   Widget _buildPlanRowInner(
-      ThemeData theme, AnimeDownloadPlan plan, double? progress) {
+    ThemeData theme,
+    AnimeDownloadPlan plan,
+    double? progress,
+  ) {
     final ColorScheme scheme = theme.colorScheme;
     final bool eink = isEinkTheme(context);
     final bool downloading = plan.status == AnimeDownloadPlan.statusDownloading;
     final bool failed = plan.status == AnimeDownloadPlan.statusFailed;
     final Widget statusIcon = switch (plan.status) {
-      AnimeDownloadPlan.statusImported =>
-        Icon(Icons.check_circle_outline, size: 20, color: scheme.primary),
-      AnimeDownloadPlan.statusFailed =>
-        Icon(Icons.error_outline, size: 20, color: scheme.error),
+      AnimeDownloadPlan.statusImported => Icon(
+          Icons.check_circle_outline,
+          size: 20,
+          color: scheme.primary,
+        ),
+      AnimeDownloadPlan.statusFailed => Icon(
+          Icons.error_outline,
+          size: 20,
+          color: scheme.error,
+        ),
       _ => eink
           ? const Icon(Icons.downloading_outlined, size: 20)
           : SizedBox(
@@ -2172,18 +2262,18 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     final (String, Color)? subtitleNote = switch (plan.subtitleStatus) {
       AnimeDownloadPlan.subtitlePending => (
           t.anime_download_subs_pending,
-          scheme.onSurfaceVariant
+          scheme.onSurfaceVariant,
         ),
       AnimeDownloadPlan.subtitleUnavailable => (
           t.anime_download_subs_unmatched,
-          scheme.tertiary
+          scheme.tertiary,
         ),
       _ => null,
     };
     return HibikiListItem(
       density: HibikiListDensity.compact,
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
-      subtitleMaxLines: 3,
+      subtitleMaxLines: plan.importedEarly ? 5 : 3,
       // BUG-1184：番剧名 + 种子名都很长，而这一行右侧还挂着最多 3 个操作按钮，窄屏
       // 上标题只剩百来像素。行高自由（在可滚动列表里，只有 minHeight 下限），放宽到
       // 两行；种子名同样从死板的单行放宽到两行。
@@ -2200,15 +2290,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
             style: theme.textTheme.bodySmall,
           ),
           if (progressText != null)
-            Text(
-              progressText,
-              maxLines: 1,
-              style: theme.textTheme.bodySmall,
-            ),
+            Text(progressText, maxLines: 1, style: theme.textTheme.bodySmall),
           if (plan.importedEarly)
             Text(
               t.anime_download_streaming_ready,
-              maxLines: 1,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
               style: theme.textTheme.bodySmall?.copyWith(color: scheme.primary),
             ),
           if (subtitleNote != null)
@@ -2216,8 +2303,9 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
               subtitleNote.$1,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style:
-                  theme.textTheme.bodySmall?.copyWith(color: subtitleNote.$2),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: subtitleNote.$2,
+              ),
             ),
           if (failReason != null)
             Text(
@@ -2245,44 +2333,17 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
               size: 20,
               onTap: () => _retryPlan(plan),
             ),
-          if (plan.status != AnimeDownloadPlan.statusImported &&
-              !plan.importedEarly)
-            HibikiIconButton(
-              tooltip: t.anime_download_task_settings,
-              icon: Icons.tune,
-              size: 20,
-              onTap: () => _configurePlan(plan),
-            ),
-          PopupMenuButton<_TaskMoreAction>(
-            tooltip: t.anime_download_task_more_actions,
-            icon: const Icon(Icons.more_vert, size: 20),
-            onSelected: (_TaskMoreAction action) {
-              switch (action) {
-                case _TaskMoreAction.relocate:
-                  unawaited(_relocatePlan(plan));
-                case _TaskMoreAction.delete:
-                  unawaited(_deletePlan(plan));
-              }
-            },
-            itemBuilder: (BuildContext context) =>
-                <PopupMenuEntry<_TaskMoreAction>>[
-              PopupMenuItem<_TaskMoreAction>(
-                value: _TaskMoreAction.relocate,
-                child: ListTile(
-                  dense: true,
-                  leading: const Icon(Icons.drive_file_move_outline),
-                  title: Text(t.anime_download_relocate),
-                ),
-              ),
-              PopupMenuItem<_TaskMoreAction>(
-                value: _TaskMoreAction.delete,
-                child: ListTile(
-                  dense: true,
-                  leading: const Icon(Icons.delete_outline),
-                  title: Text(t.anime_download_delete),
-                ),
-              ),
-            ],
+          HibikiIconButton(
+            tooltip: t.anime_download_relocate,
+            icon: Icons.drive_file_move_outline,
+            size: 20,
+            onTap: () => _relocatePlan(plan),
+          ),
+          HibikiIconButton(
+            tooltip: t.anime_download_delete,
+            icon: Icons.delete_outline,
+            size: 20,
+            onTap: () => _deletePlan(plan),
           ),
         ],
       ),
@@ -2390,128 +2451,6 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   }
 }
 
-enum _TaskMoreAction { relocate, delete }
-
-class _TaskSettingsChoice {
-  const _TaskSettingsChoice({
-    required this.libraryName,
-    required this.contentKind,
-  });
-
-  final String libraryName;
-  final String contentKind;
-}
-
-/// 单任务入库设置。番剧任务的内容类型固定为视频；通用磁链允许在自动 / 视频 /
-/// 书之间修正。名称与类型只在尚未入库时开放，避免给用户一个“保存成功但现有库
-/// 条目完全没变”的假配置入口。
-class _TaskSettingsDialog extends StatefulWidget {
-  const _TaskSettingsDialog({required this.plan});
-
-  final AnimeDownloadPlan plan;
-
-  @override
-  State<_TaskSettingsDialog> createState() => _TaskSettingsDialogState();
-}
-
-class _TaskSettingsDialogState extends State<_TaskSettingsDialog> {
-  late final TextEditingController _nameController =
-      TextEditingController(text: widget.plan.seriesTitle);
-  late String _contentKind = widget.plan.anilistId == null
-      ? widget.plan.contentKind
-      : AnimeDownloadPlan.kindVideo;
-
-  @override
-  void dispose() {
-    _nameController.dispose();
-    super.dispose();
-  }
-
-  void _save() {
-    final String name = _nameController.text.trim();
-    if (name.isEmpty) return;
-    Navigator.pop(
-      context,
-      _TaskSettingsChoice(
-        libraryName: name,
-        contentKind: _contentKind,
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final bool generic = widget.plan.anilistId == null;
-    return AlertDialog(
-      title: Text(t.anime_download_task_settings),
-      content: SizedBox(
-        width: 440,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: <Widget>[
-            TextField(
-              controller: _nameController,
-              autofocus: true,
-              decoration: InputDecoration(
-                labelText: t.anime_download_task_library_name,
-                border: const OutlineInputBorder(),
-              ),
-              onSubmitted: (_) => _save(),
-            ),
-            const SizedBox(height: 12),
-            DropdownButtonFormField<String>(
-              initialValue: _contentKind,
-              decoration: InputDecoration(
-                labelText: t.anime_download_task_content_kind,
-                border: const OutlineInputBorder(),
-              ),
-              items: <DropdownMenuItem<String>>[
-                if (generic)
-                  DropdownMenuItem<String>(
-                    value: AnimeDownloadPlan.kindAuto,
-                    child: Text(t.anime_download_kind_auto),
-                  ),
-                DropdownMenuItem<String>(
-                  value: AnimeDownloadPlan.kindVideo,
-                  child: Text(t.anime_download_kind_video),
-                ),
-                if (generic)
-                  DropdownMenuItem<String>(
-                    value: AnimeDownloadPlan.kindBook,
-                    child: Text(t.anime_download_kind_book),
-                  ),
-              ],
-              onChanged: generic
-                  ? (String? value) {
-                      if (value != null) setState(() => _contentKind = value);
-                    }
-                  : null,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              t.anime_download_task_settings_hint,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-            ),
-          ],
-        ),
-      ),
-      actions: <Widget>[
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: Text(t.dialog_cancel),
-        ),
-        FilledButton(
-          onPressed: _save,
-          child: Text(t.dialog_save),
-        ),
-      ],
-    );
-  }
-}
-
 /// TODO-1961-e：用户在改名/移动对话框里做出的选择。
 class _RelocateChoice {
   const _RelocateChoice.move(this.value)
@@ -2572,8 +2511,10 @@ class _RelocateDialogState extends State<_RelocateDialog> {
     // 迁移目标目录长期承载下载文件，必须是真实路径（见 pickRealDirectoryPath）。
     final String? picked = await pickRealDirectoryPath(
       context: context,
-      appModel:
-          ProviderScope.containerOf(context, listen: false).read(appProvider),
+      appModel: ProviderScope.containerOf(
+        context,
+        listen: false,
+      ).read(appProvider),
       dialogTitle: t.anime_download_relocate_pick_folder,
     );
     if (picked == null || picked.trim().isEmpty || !mounted) return;
@@ -2609,12 +2550,15 @@ class _RelocateDialogState extends State<_RelocateDialog> {
               // 改完再来问「怎么做种断了」。
               Text(
                 t.anime_download_relocate_hint,
-                style: theme.textTheme.bodySmall
-                    ?.copyWith(color: theme.colorScheme.outline),
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.outline,
+                ),
               ),
               const SizedBox(height: 16),
-              Text(t.anime_download_relocate_move_title,
-                  style: theme.textTheme.titleSmall),
+              Text(
+                t.anime_download_relocate_move_title,
+                style: theme.textTheme.titleSmall,
+              ),
               const SizedBox(height: 6),
               Text(widget.snapshot.savePath, style: theme.textTheme.bodySmall),
               const SizedBox(height: 6),
@@ -2628,8 +2572,10 @@ class _RelocateDialogState extends State<_RelocateDialog> {
               ),
               if (widget.files.isNotEmpty) ...<Widget>[
                 const Divider(height: 28),
-                Text(t.anime_download_relocate_rename_title,
-                    style: theme.textTheme.titleSmall),
+                Text(
+                  t.anime_download_relocate_rename_title,
+                  style: theme.textTheme.titleSmall,
+                ),
                 const SizedBox(height: 6),
                 for (final TorrentFileEntry file in widget.files)
                   Padding(

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -1010,6 +1010,27 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     if (ok) await _reloadPlans();
   }
 
+  /// 单任务配置：允许在入库前修正库内名称；通用磁链还可修正内容分流类型。
+  /// 下载文件/目录不在这里假改，仍统一走后端支持的 [_relocatePlan]。
+  Future<void> _configurePlan(AnimeDownloadPlan plan) async {
+    final AnimeDownloadPlanStore? store =
+        ref.read(appProvider).animeDownloadPlanStore;
+    if (store == null) {
+      _snack(t.anime_download_store_unavailable);
+      return;
+    }
+    final _TaskSettingsChoice? choice = await showDialog<_TaskSettingsChoice>(
+      context: context,
+      builder: (BuildContext context) => _TaskSettingsDialog(plan: plan),
+    );
+    if (choice == null) return;
+    await store.save(plan.copyWith(
+      seriesTitle: choice.libraryName,
+      contentKind: choice.contentKind,
+    ));
+    await _reloadPlans();
+  }
+
   // ---------------------------------------------------------------- 渲染
 
   /// 「去设置」：embedded 由下载页回调切页内设置面板；独立对话框（视频页入口）
@@ -1339,6 +1360,43 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     );
   }
 
+  /// 真正的 0 条结果：服务已正常响应，因此不是网络错误；把这次实际采用的
+  /// 查询词与筛选条件直接摆出来，用户能判断是标题别名、分类还是 Trusted
+  /// 过滤过严，而不是只看到一句没有行动信息的「无结果」。
+  Widget _buildNoResults(
+    ThemeData theme, {
+    required String query,
+    required String filters,
+  }) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 520),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              Icons.search_off_outlined,
+              size: 40,
+              color: theme.colorScheme.outline,
+            ),
+            const SizedBox(height: 8),
+            Text(t.anime_download_no_results, textAlign: TextAlign.center),
+            const SizedBox(height: 4),
+            Text(
+              t.anime_download_no_results_detail(
+                query: query,
+                filters: filters,
+              ),
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _buildAnimeResults(ThemeData theme) {
     if (_searchingAnime) {
       return buildLoading();
@@ -1353,7 +1411,11 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       );
     }
     if (_searchedAnime && _animeMatches.isEmpty) {
-      return Center(child: Text(t.anime_download_no_results));
+      return _buildNoResults(
+        theme,
+        query: _animeQueryCtrl.text.trim(),
+        filters: 'AniList · ANIME',
+      );
     }
     if (_animeMatches.isEmpty) {
       return Center(
@@ -1504,7 +1566,18 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       );
     }
     if (_torrentsLoaded && _torrents.isEmpty) {
-      return Center(child: Text(t.anime_download_no_results));
+      final String categoryLabel = switch (_category) {
+        '1_4' => t.anime_download_category_raw,
+        '1_2' => t.anime_download_category_english,
+        '1_3' => t.anime_download_category_non_english,
+        _ => t.anime_download_category_all,
+      };
+      return _buildNoResults(
+        theme,
+        query: _nyaaQueryCtrl.text.trim(),
+        filters:
+            '$categoryLabel · ${_trustedOnly ? t.anime_download_trusted_only : t.anime_download_unfiltered}',
+      );
     }
     return ListView.builder(
       itemCount: _torrents.length,
@@ -2132,6 +2205,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
               maxLines: 1,
               style: theme.textTheme.bodySmall,
             ),
+          if (plan.importedEarly)
+            Text(
+              t.anime_download_streaming_ready,
+              maxLines: 1,
+              style: theme.textTheme.bodySmall?.copyWith(color: scheme.primary),
+            ),
           if (subtitleNote != null)
             Text(
               subtitleNote.$1,
@@ -2152,7 +2231,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
-          if (downloading)
+          if (downloading && !plan.importedEarly)
             HibikiIconButton(
               tooltip: t.anime_download_play_now,
               icon: Icons.play_circle_outline,
@@ -2166,17 +2245,44 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
               size: 20,
               onTap: () => _retryPlan(plan),
             ),
-          HibikiIconButton(
-            tooltip: t.anime_download_relocate,
-            icon: Icons.drive_file_move_outline,
-            size: 20,
-            onTap: () => _relocatePlan(plan),
-          ),
-          HibikiIconButton(
-            tooltip: t.anime_download_delete,
-            icon: Icons.delete_outline,
-            size: 20,
-            onTap: () => _deletePlan(plan),
+          if (plan.status != AnimeDownloadPlan.statusImported &&
+              !plan.importedEarly)
+            HibikiIconButton(
+              tooltip: t.anime_download_task_settings,
+              icon: Icons.tune,
+              size: 20,
+              onTap: () => _configurePlan(plan),
+            ),
+          PopupMenuButton<_TaskMoreAction>(
+            tooltip: t.anime_download_task_more_actions,
+            icon: const Icon(Icons.more_vert, size: 20),
+            onSelected: (_TaskMoreAction action) {
+              switch (action) {
+                case _TaskMoreAction.relocate:
+                  unawaited(_relocatePlan(plan));
+                case _TaskMoreAction.delete:
+                  unawaited(_deletePlan(plan));
+              }
+            },
+            itemBuilder: (BuildContext context) =>
+                <PopupMenuEntry<_TaskMoreAction>>[
+              PopupMenuItem<_TaskMoreAction>(
+                value: _TaskMoreAction.relocate,
+                child: ListTile(
+                  dense: true,
+                  leading: const Icon(Icons.drive_file_move_outline),
+                  title: Text(t.anime_download_relocate),
+                ),
+              ),
+              PopupMenuItem<_TaskMoreAction>(
+                value: _TaskMoreAction.delete,
+                child: ListTile(
+                  dense: true,
+                  leading: const Icon(Icons.delete_outline),
+                  title: Text(t.anime_download_delete),
+                ),
+              ),
+            ],
           ),
         ],
       ),
@@ -2280,6 +2386,128 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
           ),
         ],
       ),
+    );
+  }
+}
+
+enum _TaskMoreAction { relocate, delete }
+
+class _TaskSettingsChoice {
+  const _TaskSettingsChoice({
+    required this.libraryName,
+    required this.contentKind,
+  });
+
+  final String libraryName;
+  final String contentKind;
+}
+
+/// 单任务入库设置。番剧任务的内容类型固定为视频；通用磁链允许在自动 / 视频 /
+/// 书之间修正。名称与类型只在尚未入库时开放，避免给用户一个“保存成功但现有库
+/// 条目完全没变”的假配置入口。
+class _TaskSettingsDialog extends StatefulWidget {
+  const _TaskSettingsDialog({required this.plan});
+
+  final AnimeDownloadPlan plan;
+
+  @override
+  State<_TaskSettingsDialog> createState() => _TaskSettingsDialogState();
+}
+
+class _TaskSettingsDialogState extends State<_TaskSettingsDialog> {
+  late final TextEditingController _nameController =
+      TextEditingController(text: widget.plan.seriesTitle);
+  late String _contentKind = widget.plan.anilistId == null
+      ? widget.plan.contentKind
+      : AnimeDownloadPlan.kindVideo;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    final String name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    Navigator.pop(
+      context,
+      _TaskSettingsChoice(
+        libraryName: name,
+        contentKind: _contentKind,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool generic = widget.plan.anilistId == null;
+    return AlertDialog(
+      title: Text(t.anime_download_task_settings),
+      content: SizedBox(
+        width: 440,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: <Widget>[
+            TextField(
+              controller: _nameController,
+              autofocus: true,
+              decoration: InputDecoration(
+                labelText: t.anime_download_task_library_name,
+                border: const OutlineInputBorder(),
+              ),
+              onSubmitted: (_) => _save(),
+            ),
+            const SizedBox(height: 12),
+            DropdownButtonFormField<String>(
+              initialValue: _contentKind,
+              decoration: InputDecoration(
+                labelText: t.anime_download_task_content_kind,
+                border: const OutlineInputBorder(),
+              ),
+              items: <DropdownMenuItem<String>>[
+                if (generic)
+                  DropdownMenuItem<String>(
+                    value: AnimeDownloadPlan.kindAuto,
+                    child: Text(t.anime_download_kind_auto),
+                  ),
+                DropdownMenuItem<String>(
+                  value: AnimeDownloadPlan.kindVideo,
+                  child: Text(t.anime_download_kind_video),
+                ),
+                if (generic)
+                  DropdownMenuItem<String>(
+                    value: AnimeDownloadPlan.kindBook,
+                    child: Text(t.anime_download_kind_book),
+                  ),
+              ],
+              onChanged: generic
+                  ? (String? value) {
+                      if (value != null) setState(() => _contentKind = value);
+                    }
+                  : null,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              t.anime_download_task_settings_hint,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(t.dialog_cancel),
+        ),
+        FilledButton(
+          onPressed: _save,
+          child: Text(t.dialog_save),
+        ),
+      ],
     );
   }
 }

--- a/hibiki/lib/src/pages/implementations/downloads_page.dart
+++ b/hibiki/lib/src/pages/implementations/downloads_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_tasks_section.dart';
+import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
 import 'package:hibiki/src/pages/implementations/download_subscriptions_panel.dart';
 import 'package:hibiki/src/pages/implementations/torrent_settings_section.dart';
@@ -9,7 +11,7 @@ import 'package:hibiki/utils.dart';
 
 /// 独立「下载」页（顶层底栏 tab）＝统一下载中心：番剧下载流程 **直接内联**
 /// 铺在页面上（搜番 → 选种 → 配字幕 → 推送 + 通用磁力 + 下载任务），任务 tab
-/// 同时列出漫画「在线目录」（mokuro.moe）的卷下载队列。
+/// 同时列出漫画「在线目录」（mokuro.moe）的卷下载队列；页头另有在线目录入口。
 /// 右上角齿轮切到「下载设置」（后端/限速/上传/做种/内存）。完成后按内容类型
 /// 自动入库（视频→视频库、epub→阅读库，见 AnimeDownloadService；漫画卷→
 /// 书架，见 MokuroMoeDownloadQueue）。
@@ -26,6 +28,18 @@ class DownloadsPage extends ConsumerStatefulWidget {
 
 class _DownloadsPageState extends ConsumerState<DownloadsPage> {
   late bool _showSettings = widget.initialShowSettings;
+
+  /// 漫画「在线目录」入口（统一下载中心：书/漫画获取入口与 torrent 并列）。
+  ///
+  /// 书架页与书籍导入框的旧入口已收敛到这里，故本页是
+  /// [MangaModule.openOnlineCatalog] 的唯一消费方——目录弹窗的构造统一收在
+  /// 漫画模块里，不在页面层直接 new 它。
+  Future<void> _openMangaCatalog() async {
+    await MangaModule.openOnlineCatalog(
+      context: context,
+      db: ref.read(appProvider).database,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -55,6 +69,12 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                     ],
                   ),
             actions: <Widget>[
+              if (!_showSettings)
+                IconButton(
+                  tooltip: t.manga_online_catalog_title,
+                  icon: const Icon(Icons.menu_book_outlined),
+                  onPressed: _openMangaCatalog,
+                ),
               IconButton(
                 // 齿轮已变 ✕ 时语义是「关闭设置」，tooltip 跟着换，不再答非所问。
                 tooltip: _showSettings ? t.dialog_close : t.download_settings,

--- a/hibiki/lib/src/pages/implementations/downloads_page.dart
+++ b/hibiki/lib/src/pages/implementations/downloads_page.dart
@@ -1,9 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_tasks_section.dart';
-import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
 import 'package:hibiki/src/pages/implementations/download_subscriptions_panel.dart';
 import 'package:hibiki/src/pages/implementations/torrent_settings_section.dart';
@@ -11,7 +9,7 @@ import 'package:hibiki/utils.dart';
 
 /// 独立「下载」页（顶层底栏 tab）＝统一下载中心：番剧下载流程 **直接内联**
 /// 铺在页面上（搜番 → 选种 → 配字幕 → 推送 + 通用磁力 + 下载任务），任务 tab
-/// 同时列出漫画「在线目录」（mokuro.moe）的卷下载队列；页头另有在线目录入口。
+/// 同时列出漫画「在线目录」（mokuro.moe）的卷下载队列。
 /// 右上角齿轮切到「下载设置」（后端/限速/上传/做种/内存）。完成后按内容类型
 /// 自动入库（视频→视频库、epub→阅读库，见 AnimeDownloadService；漫画卷→
 /// 书架，见 MokuroMoeDownloadQueue）。
@@ -28,18 +26,6 @@ class DownloadsPage extends ConsumerStatefulWidget {
 
 class _DownloadsPageState extends ConsumerState<DownloadsPage> {
   late bool _showSettings = widget.initialShowSettings;
-
-  /// 漫画「在线目录」入口（统一下载中心：书/漫画获取入口与 torrent 并列）。
-  ///
-  /// 书架页与书籍导入框的旧入口已收敛到这里，故本页是
-  /// [MangaModule.openOnlineCatalog] 的唯一消费方——目录弹窗的构造统一收在
-  /// 漫画模块里，不在页面层直接 new 它。
-  Future<void> _openMangaCatalog() async {
-    await MangaModule.openOnlineCatalog(
-      context: context,
-      db: ref.read(appProvider).database,
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -69,12 +55,6 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                     ],
                   ),
             actions: <Widget>[
-              if (!_showSettings)
-                IconButton(
-                  tooltip: t.manga_online_catalog_title,
-                  icon: const Icon(Icons.menu_book_outlined),
-                  onPressed: _openMangaCatalog,
-                ),
               IconButton(
                 // 齿轮已变 ✕ 时语义是「关闭设置」，tooltip 跟着换，不再答非所问。
                 tooltip: _showSettings ? t.dialog_close : t.download_settings,

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1017
+version: 1.3.1+1018
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/video/video_import_split_playlist_test.dart
+++ b/hibiki/test/media/video/video_import_split_playlist_test.dart
@@ -16,9 +16,15 @@ void main() {
 
     final List<PlaylistEntry> entries = <PlaylistEntry>[
       const PlaylistEntry(
-          title: 'E1', path: '/v/Show E01.mkv', positionMs: 1000),
+        title: 'E1',
+        path: '/v/Show E01.mkv',
+        positionMs: 1000,
+      ),
       const PlaylistEntry(
-          title: 'E2', path: '/v/Show E02.mkv', positionMs: 2000),
+        title: 'E2',
+        path: '/v/Show E02.mkv',
+        positionMs: 2000,
+      ),
       const PlaylistEntry(title: '', path: '/v/Show E03.mkv'),
     ];
 
@@ -26,8 +32,11 @@ void main() {
         .importSplitPlaylist(collectionName: 'Show', entries: entries);
 
     // 每集 uid = video/<集文件名>，有序返回。
-    expect(result.episodeUids,
-        <String>['video/Show E01', 'video/Show E02', 'video/Show E03']);
+    expect(result.episodeUids, <String>[
+      'video/Show E01',
+      'video/Show E02',
+      'video/Show E03',
+    ]);
 
     final List<VideoBookRow> rows = await repo.listAll();
     expect(rows, hasLength(3));
@@ -45,14 +54,51 @@ void main() {
     }
 
     // playlist 合集：type=playlist，名=Show，成员按序 = 各集 uid。
-    final MediaCollectionRow collection =
-        (await db.getMediaCollectionById(result.collectionId))!;
+    final MediaCollectionRow collection = (await db.getMediaCollectionById(
+      result.collectionId,
+    ))!;
     expect(collection.collectionType, 'playlist');
     expect(collection.name, 'Show');
-    final List<MediaCollectionItemRow> members =
-        await db.getCollectionItems(result.collectionId);
-    expect(members.map((MediaCollectionItemRow m) => m.entryKey).toList(),
-        result.episodeUids);
+    final List<MediaCollectionItemRow> members = await db.getCollectionItems(
+      result.collectionId,
+    );
+    expect(
+      members.map((MediaCollectionItemRow m) => m.entryKey).toList(),
+      result.episodeUids,
+    );
+  });
+
+  test('下载 importer 崩溃重放：归一化路径作业务键，单事务不重复媒体/合集/成员', () async {
+    final HibikiDatabase db = _memDb();
+    addTearDown(db.close);
+    final VideoBookRepository repo = VideoBookRepository(db);
+    const List<PlaylistEntry> first = <PlaylistEntry>[
+      PlaylistEntry(title: 'E1', path: r'D:\Downloads\Show E01.mkv'),
+      PlaylistEntry(title: 'E2', path: r'D:\Downloads\Show E02.mkv'),
+    ];
+    const List<PlaylistEntry> replay = <PlaylistEntry>[
+      PlaylistEntry(title: 'E1', path: 'D:/Downloads/Show E01.mkv'),
+      PlaylistEntry(title: 'E2', path: 'D:/Downloads/Show E02.mkv'),
+    ];
+
+    final ({int collectionId, List<String> episodeUids}) initial =
+        await repo.importSplitPlaylist(
+      collectionName: 'Show',
+      entries: first,
+      reuseExistingPaths: true,
+    );
+    final ({int collectionId, List<String> episodeUids}) restarted =
+        await repo.importSplitPlaylist(
+      collectionName: 'Show',
+      entries: replay,
+      reuseExistingPaths: true,
+    );
+
+    expect(restarted.collectionId, initial.collectionId);
+    expect(restarted.episodeUids, initial.episodeUids);
+    expect(await repo.listAll(), hasLength(2));
+    expect(await db.getAllMediaCollections(), hasLength(1));
+    expect(await db.getCollectionItems(initial.collectionId), hasLength(2));
   });
 
   test('删某集清合集引用；删空则合集自删', () async {
@@ -71,23 +117,33 @@ void main() {
 
     await repo.deleteVideoBook(result.episodeUids.first);
     expect(
-        (await db.getCollectionItems(result.collectionId))
-            .map((MediaCollectionItemRow m) => m.entryKey),
-        <String>[result.episodeUids[1]]);
+      (await db.getCollectionItems(
+        result.collectionId,
+      ))
+          .map((MediaCollectionItemRow m) => m.entryKey),
+      <String>[result.episodeUids[1]],
+    );
     expect(await db.getMediaCollectionById(result.collectionId), isNotNull);
 
     await repo.deleteVideoBook(result.episodeUids[1]);
-    expect(await db.getMediaCollectionById(result.collectionId), isNull,
-        reason: '移空后 playlist 合集自删');
+    expect(
+      await db.getMediaCollectionById(result.collectionId),
+      isNull,
+      reason: '移空后 playlist 合集自删',
+    );
   });
 
   group('reconcileSplitPlaylist：重扫按清单对齐成员（BUG-830）', () {
     /// 取合集当前成员对应的 videoPath 集（成员引用 bookUid → VideoBook.videoPath）。
     Future<Set<String>> memberPaths(
-        HibikiDatabase db, VideoBookRepository repo, int collectionId) async {
+      HibikiDatabase db,
+      VideoBookRepository repo,
+      int collectionId,
+    ) async {
       final Set<String> out = <String>{};
-      for (final MediaCollectionItemRow m
-          in await db.getCollectionItems(collectionId)) {
+      for (final MediaCollectionItemRow m in await db.getCollectionItems(
+        collectionId,
+      )) {
         final VideoBookRow? row = await repo.getByBookUid(m.entryKey);
         if (row != null) out.add(row.videoPath);
       }
@@ -120,12 +176,17 @@ void main() {
       expect(recon.added, 1);
       expect(recon.removed, 1);
 
-      expect(await memberPaths(db, repo, result.collectionId),
-          <String>{'/v/Show E02.mkv', '/v/Show E03.mkv'});
+      expect(await memberPaths(db, repo, result.collectionId), <String>{
+        '/v/Show E02.mkv',
+        '/v/Show E03.mkv',
+      });
 
       // 移出清单的 E01 只解绑，VideoBook 本体保留（保观看进度，非破坏性）。
-      expect(await repo.getByBookUid('video/Show E01'), isNotNull,
-          reason: '移出清单的集只 removeFromCollection，不删 VideoBook 本体');
+      expect(
+        await repo.getByBookUid('video/Show E01'),
+        isNotNull,
+        reason: '移出清单的集只 removeFromCollection，不删 VideoBook 本体',
+      );
       // 未变的 E02 不重建、E03 只新建一条 → 总 3 本（E01 保留 + E02 + E03）。
       expect((await repo.listAll()).length, 3);
     });
@@ -144,13 +205,17 @@ void main() {
 
       final ({int added, int removed}) recon =
           await repo.reconcileSplitPlaylist(
-              collectionId: result.collectionId, entries: entries);
+        collectionId: result.collectionId,
+        entries: entries,
+      );
       expect(recon.added, 0);
       expect(recon.removed, 0);
       // 未变集不重跑 importSplitPlaylist → 不撞 uid 加后缀造重复行（旧代码整体跳过之因）。
       expect((await repo.listAll()).length, 2);
-      expect(await memberPaths(db, repo, result.collectionId),
-          <String>{'/v/a.mkv', '/v/b.mkv'});
+      expect(await memberPaths(db, repo, result.collectionId), <String>{
+        '/v/a.mkv',
+        '/v/b.mkv',
+      });
     });
 
     test('整批替换清单 → 先加后删，合集不被移空自删', () async {
@@ -179,10 +244,15 @@ void main() {
       expect(recon.removed, 2);
 
       // 先加新集让合集非空、再删旧集 → 合集绝不瞬时空掉被「移空自删」误删。
-      expect(await db.getMediaCollectionById(result.collectionId), isNotNull,
-          reason: '先加后删，整批替换不误删合集');
-      expect(await memberPaths(db, repo, result.collectionId),
-          <String>{'/v/c.mkv', '/v/d.mkv'});
+      expect(
+        await db.getMediaCollectionById(result.collectionId),
+        isNotNull,
+        reason: '先加后删，整批替换不误删合集',
+      );
+      expect(await memberPaths(db, repo, result.collectionId), <String>{
+        '/v/c.mkv',
+        '/v/d.mkv',
+      });
     });
   });
 }

--- a/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
@@ -257,6 +257,35 @@ void main() {
     expect(find.text(t.download_open_settings), findsOneWidget);
   });
 
+  testWidgets('Nyaa 真 0 条：展示实际查询词与筛选；损坏 feed 不伪装成无结果',
+      (WidgetTester tester) async {
+    const String emptyRss =
+        '<rss><channel><title>valid empty</title></channel></rss>';
+    final _FakeAppModel emptyModel = _FakeAppModel(
+      (http.Request req) async => http.Response(emptyRss, 200),
+    );
+    await pumpDialog(tester, emptyModel);
+    await tester.tap(find.byTooltip(t.anime_download_search).first);
+    await tester.pumpAndSettle();
+
+    expect(find.text(t.anime_download_no_results), findsOneWidget);
+    expect(find.textContaining('Test Anime'), findsOneWidget);
+    expect(find.textContaining(t.anime_download_category_all), findsOneWidget);
+    expect(find.textContaining(t.anime_download_unfiltered), findsOneWidget);
+
+    // 损坏 RSS 必须落错误态并带真实解析原因，不能再显示「无结果」。
+    await tester.pumpWidget(const SizedBox.shrink());
+    final _FakeAppModel brokenModel = _FakeAppModel(
+      (http.Request req) async => http.Response('not xml <<<', 200),
+    );
+    await pumpDialog(tester, brokenModel);
+    await tester.tap(find.byTooltip(t.anime_download_search).first);
+    await tester.pumpAndSettle();
+    expect(find.text(t.anime_download_search_failed), findsOneWidget);
+    expect(find.textContaining('Invalid Nyaa RSS'), findsOneWidget);
+    expect(find.text(t.anime_download_no_results), findsNothing);
+  });
+
   testWidgets('选种结果排序：默认做种数降序，切「体积」就地重排', (WidgetTester tester) async {
     final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
       return http.Response.bytes(_kSortRss.codeUnits, 200);

--- a/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
@@ -82,8 +83,9 @@ ${_rssItem(title: 'middle', hash: 'c' * 40, seeders: 100, size: '5 GiB')}
 class _MemPlanStore extends AnimeDownloadPlanStore {
   _MemPlanStore() : super(baseDir: Directory('unused-mem-store'));
 
-  final Directory tempRoot =
-      Directory.systemTemp.createTempSync('hibiki-subs-test');
+  final Directory tempRoot = Directory.systemTemp.createTempSync(
+    'hibiki-subs-test',
+  );
 
   @override
   Future<List<AnimeDownloadPlan>> loadAll() async =>
@@ -93,7 +95,10 @@ class _MemPlanStore extends AnimeDownloadPlanStore {
   final List<AnimeDownloadPlan> saved = <AnimeDownloadPlan>[];
 
   @override
-  Future<void> save(AnimeDownloadPlan plan) async => saved.add(plan);
+  Future<bool> save(AnimeDownloadPlan plan) async {
+    saved.add(plan);
+    return true;
+  }
 
   @override
   Future<void> delete(String id) async {}
@@ -188,22 +193,22 @@ void main() {
     _FakeAppModel appModel, {
     NyaaTorrent? torrent,
   }) async {
-    await tester.pumpWidget(ProviderScope(
-      overrides: <Override>[
-        appProvider.overrideWith((ref) => appModel),
-      ],
-      child: TranslationProvider(
-        child: MaterialApp(
-          home: Scaffold(
-            body: AnimeDownloadDialog(
-              embedded: true,
-              debugInitialMedia: _kMedia,
-              debugInitialTorrent: torrent,
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[appProvider.overrideWith((ref) => appModel)],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: AnimeDownloadDialog(
+                embedded: true,
+                debugInitialMedia: _kMedia,
+                debugInitialTorrent: torrent,
+              ),
             ),
           ),
         ),
       ),
-    ));
+    );
     await tester.pumpAndSettle();
   }
 
@@ -213,25 +218,35 @@ void main() {
       final NyaaTorrent big = _torrentWith(seeders: 1, sizeBytes: 900);
       final NyaaTorrent noSize = _torrentWith(seeders: 9, sizeBytes: null);
       expect(
-          compareNyaaTorrents(TorrentSortKey.seeders, noSize, small) < 0, true);
+        compareNyaaTorrents(TorrentSortKey.seeders, noSize, small) < 0,
+        true,
+      );
       expect(compareNyaaTorrents(TorrentSortKey.size, big, small) < 0, true);
       expect(compareNyaaTorrents(TorrentSortKey.size, small, noSize) < 0, true);
 
-      final NyaaTorrent newer =
-          _torrentWith(seeders: 1, pubDate: DateTime.utc(2026, 7, 2));
-      final NyaaTorrent older =
-          _torrentWith(seeders: 1, pubDate: DateTime.utc(2026, 7, 1));
+      final NyaaTorrent newer = _torrentWith(
+        seeders: 1,
+        pubDate: DateTime.utc(2026, 7, 2),
+      );
+      final NyaaTorrent older = _torrentWith(
+        seeders: 1,
+        pubDate: DateTime.utc(2026, 7, 1),
+      );
       final NyaaTorrent noDate = _torrentWith(seeders: 1);
       expect(compareNyaaTorrents(TorrentSortKey.date, newer, older) < 0, true);
       expect(compareNyaaTorrents(TorrentSortKey.date, older, noDate) < 0, true);
     });
 
     test('animeTitleOptions：罗马字优先、去空去重保序', () {
-      expect(animeTitleOptions(_kMedia),
-          <String>['Test Anime', 'テスト・アニメ', 'The Test Anime']);
+      expect(animeTitleOptions(_kMedia), <String>[
+        'Test Anime',
+        'テスト・アニメ',
+        'The Test Anime',
+      ]);
       expect(
         animeTitleOptions(
-            const AniListMedia(id: 2, romaji: 'Same', native: 'Same')),
+          const AniListMedia(id: 2, romaji: 'Same', native: 'Same'),
+        ),
         <String>['Same'],
       );
       expect(
@@ -257,8 +272,9 @@ void main() {
     expect(find.text(t.download_open_settings), findsOneWidget);
   });
 
-  testWidgets('Nyaa 真 0 条：展示实际查询词与筛选；损坏 feed 不伪装成无结果',
-      (WidgetTester tester) async {
+  testWidgets('Nyaa 真 0 条：展示实际查询词与筛选；损坏 feed 不伪装成无结果', (
+    WidgetTester tester,
+  ) async {
     const String emptyRss =
         '<rss><channel><title>valid empty</title></channel></rss>';
     final _FakeAppModel emptyModel = _FakeAppModel(
@@ -269,9 +285,14 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text(t.anime_download_no_results), findsOneWidget);
-    expect(find.textContaining('Test Anime'), findsOneWidget);
-    expect(find.textContaining(t.anime_download_category_all), findsOneWidget);
-    expect(find.textContaining(t.anime_download_unfiltered), findsOneWidget);
+    expect(find.textContaining('Query: Test Anime;'), findsOneWidget);
+    expect(
+      find.textContaining(
+        'filters: ${t.anime_download_category_all} · '
+        '${t.anime_download_unfiltered}',
+      ),
+      findsOneWidget,
+    );
 
     // 损坏 RSS 必须落错误态并带真实解析原因，不能再显示「无结果」。
     await tester.pumpWidget(const SizedBox.shrink());
@@ -282,8 +303,57 @@ void main() {
     await tester.tap(find.byTooltip(t.anime_download_search).first);
     await tester.pumpAndSettle();
     expect(find.text(t.anime_download_search_failed), findsOneWidget);
-    expect(find.textContaining('Invalid Nyaa RSS'), findsOneWidget);
+    expect(find.textContaining('malformedXml'), findsOneWidget);
     expect(find.text(t.anime_download_no_results), findsNothing);
+  });
+
+  testWidgets('Nyaa 请求 generation + snapshot：旧请求晚回不覆盖，0条文案不读未提交控件', (
+    WidgetTester tester,
+  ) async {
+    final Completer<http.Response> oldResponse = Completer<http.Response>();
+    const String emptyRss =
+        '<rss><channel><title>valid empty</title></channel></rss>';
+    final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
+      if (req.url.queryParameters['q'] == 'old query') {
+        return oldResponse.future;
+      }
+      return http.Response(emptyRss, 200);
+    });
+    await pumpDialog(tester, appModel);
+
+    final Finder queryField = find.byWidgetPredicate(
+      (Widget widget) =>
+          widget is TextField &&
+          widget.decoration?.labelText == t.anime_download_nyaa_query,
+    );
+    final Finder searchButton = find.descendant(
+      of: queryField,
+      matching: find.byTooltip(t.anime_download_search),
+    );
+    await tester.enterText(queryField, 'old query');
+    await tester.tap(searchButton);
+    await tester.pump();
+
+    await tester.enterText(queryField, 'new query');
+    await tester.tap(searchButton);
+    await tester.pumpAndSettle();
+    expect(find.text(t.anime_download_no_results), findsOneWidget);
+    expect(find.textContaining('Query: new query;'), findsOneWidget);
+
+    // 控件改了但没发请求：0 条说明仍必须绑定上一响应的 snapshot。
+    await tester.enterText(queryField, 'unsent current text');
+    await tester.pump();
+    expect(find.textContaining('Query: new query;'), findsOneWidget);
+    expect(find.textContaining('Query: unsent current text;'), findsNothing);
+
+    oldResponse.complete(http.Response(_kSortRss, 200));
+    await tester.pumpAndSettle();
+    expect(find.text(t.anime_download_no_results), findsOneWidget);
+    expect(
+      find.text('seeders-top'),
+      findsNothing,
+      reason: '旧 generation 晚回不得覆盖新请求的有效 empty 结果',
+    );
   });
 
   testWidgets('选种结果排序：默认做种数降序，切「体积」就地重排', (WidgetTester tester) async {
@@ -308,25 +378,32 @@ void main() {
     expect(titles(), <String>['seeders-top', 'middle', 'size-top']);
 
     // 打开排序菜单，切换到「体积」。
-    await tester
-        .tap(find.text('${t.sort_by}: ${t.anime_download_sort_seeders}'));
+    await tester.tap(
+      find.text('${t.sort_by}: ${t.anime_download_sort_seeders}'),
+    );
     await tester.pumpAndSettle();
     await tester.tap(find.text(t.anime_download_sort_size).last);
     await tester.pumpAndSettle();
 
     expect(titles(), <String>['size-top', 'middle', 'seeders-top']);
-    expect(find.text('${t.sort_by}: ${t.anime_download_sort_size}'),
-        findsOneWidget);
+    expect(
+      find.text('${t.sort_by}: ${t.anime_download_sort_size}'),
+      findsOneWidget,
+    );
   });
 
-  testWidgets('确认阶段：字幕搜索词默认罗马字、下拉可切日文原名、集号框放得下 label',
-      (WidgetTester tester) async {
-    final _FakeAppModel appModel =
-        _FakeAppModel((http.Request req) async => http.Response('', 404));
+  testWidgets('确认阶段：字幕搜索词默认罗马字、下拉可切日文原名、集号框放得下 label', (
+    WidgetTester tester,
+  ) async {
+    final _FakeAppModel appModel = _FakeAppModel(
+      (http.Request req) async => http.Response('', 404),
+    );
     await pumpDialog(tester, appModel, torrent: _kTorrent);
 
-    final Finder queryField = find.byWidgetPredicate((Widget w) =>
-        w is TextField && w.decoration?.labelText == t.video_jimaku_query);
+    final Finder queryField = find.byWidgetPredicate(
+      (Widget w) =>
+          w is TextField && w.decoration?.labelText == t.video_jimaku_query,
+    );
     expect(queryField, findsOneWidget);
     expect(tester.widget<TextField>(queryField).controller!.text, 'Test Anime');
 
@@ -344,8 +421,10 @@ void main() {
     // 的数字，label 一变长（中文「集数（可选）」、英文 `Episode (optional)`）照样
     // 被裁，用户在 1920 宽的窗口上截到了「集数···」——跟屏幕宽窄根本无关。
     // 现在断言的是「装得下」这个性质，而不是某个具体数字。
-    final Finder episodeField = find.byWidgetPredicate((Widget w) =>
-        w is TextField && w.decoration?.labelText == t.video_jimaku_episode);
+    final Finder episodeField = find.byWidgetPredicate(
+      (Widget w) =>
+          w is TextField && w.decoration?.labelText == t.video_jimaku_episode,
+    );
     expect(episodeField, findsOneWidget);
 
     final TextPainter labelPainter = TextPainter(
@@ -387,20 +466,24 @@ void main() {
       if (url.contains('/entries/search')) {
         searchCalls++;
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{'id': 7, 'name': 'テスト・アニメ 字幕'},
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{'id': 7, 'name': 'テスト・アニメ 字幕'},
+            ]),
+          ),
           200,
         );
       }
       if (url.contains('/files')) {
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{
-              'name': 'Test Anime - 01.ja.srt',
-              'url': 'https://jimaku.cc/f/1.srt',
-            },
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{
+                'name': 'Test Anime - 01.ja.srt',
+                'url': 'https://jimaku.cc/f/1.srt',
+              },
+            ]),
+          ),
           200,
         );
       }
@@ -431,24 +514,29 @@ void main() {
       if (url.contains('/entries/search')) {
         // 两次搜索都返回同样的两个条目（重搜后手选那条依然存在）。
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{'id': 11, 'name': 'Auto First Entry'},
-            <String, Object>{'id': 22, 'name': 'User Picked Entry'},
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{'id': 11, 'name': 'Auto First Entry'},
+              <String, Object>{'id': 22, 'name': 'User Picked Entry'},
+            ]),
+          ),
           200,
         );
       }
-      final RegExpMatch? files =
-          RegExp(r'/entries/(\d+)/files').firstMatch(url);
+      final RegExpMatch? files = RegExp(
+        r'/entries/(\d+)/files',
+      ).firstMatch(url);
       if (files != null) {
         filesForEntry.add(int.parse(files.group(1)!));
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{
-              'name': 'Test Anime - 01.ja.srt',
-              'url': 'https://jimaku.cc/f/1.srt',
-            },
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{
+                'name': 'Test Anime - 01.ja.srt',
+                'url': 'https://jimaku.cc/f/1.srt',
+              },
+            ]),
+          ),
           200,
         );
       }
@@ -508,21 +596,25 @@ void main() {
       final String url = req.url.toString();
       if (url.contains('/entries/search')) {
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{'id': 7, 'name': 'Season Entry'},
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{'id': 7, 'name': 'Season Entry'},
+            ]),
+          ),
           200,
         );
       }
       if (url.contains('/files')) {
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            for (int ep = 1; ep <= 3; ep++)
-              <String, Object>{
-                'name': 'Test Anime - 0$ep.ja.srt',
-                'url': 'https://jimaku.cc/f/$ep.srt',
-              },
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              for (int ep = 1; ep <= 3; ep++)
+                <String, Object>{
+                  'name': 'Test Anime - 0$ep.ja.srt',
+                  'url': 'https://jimaku.cc/f/$ep.srt',
+                },
+            ]),
+          ),
           200,
         );
       }
@@ -533,36 +625,44 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Test Anime - 01.ja.srt'), findsOneWidget);
-    expect(find.text(t.anime_download_subs_episodes_unverified), findsOneWidget,
-        reason: '整季包集号未核对，必须明说，不能画成「字幕已配好」');
+    expect(
+      find.text(t.anime_download_subs_episodes_unverified),
+      findsOneWidget,
+      reason: '整季包集号未核对，必须明说，不能画成「字幕已配好」',
+    );
   });
 
   // BUG-1206：推送这一刻手上只有 Nyaa 标题，包里到底有哪些文件还不知道，照标题
   // 猜集号会静默配错季。所以字幕**不再在推送时下载**，计划只记「取哪个 Jimaku
   // 条目」，真正的反查放到下载完成后按包内真实文件名做。
-  testWidgets('BUG-1206 推送：不预下字幕，计划落 pending 并说明时序',
-      (WidgetTester tester) async {
+  testWidgets('BUG-1206 推送：不预下字幕，计划落 pending 并说明时序', (
+    WidgetTester tester,
+  ) async {
     final List<String> requested = <String>[];
     final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
       final String url = req.url.toString();
       requested.add(url);
       if (url.contains('/entries/search')) {
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{'id': 7, 'name': 'Range Entry'},
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{'id': 7, 'name': 'Range Entry'},
+            ]),
+          ),
           200,
         );
       }
       if (url.contains('/files')) {
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            for (int ep = 1; ep <= 3; ep++)
-              <String, Object>{
-                'name': 'Test Anime - 0$ep.ja.srt',
-                'url': 'https://jimaku.cc/f/$ep.srt',
-              },
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              for (int ep = 1; ep <= 3; ep++)
+                <String, Object>{
+                  'name': 'Test Anime - 0$ep.ja.srt',
+                  'url': 'https://jimaku.cc/f/$ep.srt',
+                },
+            ]),
+          ),
           200,
         );
       }
@@ -624,8 +724,9 @@ void main() {
   // PR#530 补的另一半：条目选择层的季号校验。落位层（按包内真实文件名反查）只能
   // 靠「集号严格相等」挡错配，可自动选中的条目本身就是 S1（编号 1-12）而包是 S2
   // 的 01-12 时集号照样相等 —— 必须在选条目这一层拦。
-  testWidgets('季号校验：S1 条目遇上 S2 包不自动选，说明原因；用户手选照旧放行',
-      (WidgetTester tester) async {
+  testWidgets('季号校验：S1 条目遇上 S2 包不自动选，说明原因；用户手选照旧放行', (
+    WidgetTester tester,
+  ) async {
     const NyaaTorrent s2Pack = NyaaTorrent(
       title: '[Grp] Test Anime S2 01-03 [1080p]',
       torrentUrl: '',
@@ -651,21 +752,25 @@ void main() {
         // 条目名不写季号 = 第一季（Jimaku 的 S1 条目就是这个形状），且没挂
         // anilist_id（文本回退搜出来的条目，正是错季的产地）。
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{'id': 7, 'name': 'Wrong Season Entry'},
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{'id': 7, 'name': 'Wrong Season Entry'},
+            ]),
+          ),
           200,
         );
       }
       if (url.contains('/files')) {
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            for (int ep = 1; ep <= 3; ep++)
-              <String, Object>{
-                'name': 'Test Anime - 0$ep.ja.srt',
-                'url': 'https://jimaku.cc/f/$ep.srt',
-              },
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              for (int ep = 1; ep <= 3; ep++)
+                <String, Object>{
+                  'name': 'Test Anime - 0$ep.ja.srt',
+                  'url': 'https://jimaku.cc/f/$ep.srt',
+                },
+            ]),
+          ),
           200,
         );
       }
@@ -676,10 +781,16 @@ void main() {
     await tester.pumpAndSettle();
 
     // ① 没自动选中 → 一条字幕都没配上，连该条目的文件列表都不去拉。
-    expect(find.text('Test Anime - 01.ja.srt'), findsNothing,
-        reason: '错季条目的字幕不该被自动配上');
-    expect(requested.where((String u) => u.contains('/files')), isEmpty,
-        reason: '没自动选中就不该拉它的文件');
+    expect(
+      find.text('Test Anime - 01.ja.srt'),
+      findsNothing,
+      reason: '错季条目的字幕不该被自动配上',
+    );
+    expect(
+      requested.where((String u) => u.contains('/files')),
+      isEmpty,
+      reason: '没自动选中就不该拉它的文件',
+    );
     // ② 不静默：说清「没有条目对得上第 2 季」。
     expect(
       find.text(t.anime_download_subs_season_mismatch(season: 2)),
@@ -692,10 +803,16 @@ void main() {
     // ④ 用户手选 → 季号校验不拦：文件照拉，字幕照配，提示行消失。
     await tester.tap(find.text('Wrong Season Entry'));
     await tester.pumpAndSettle();
-    expect(requested.where((String u) => u.contains('/files')), isNotEmpty,
-        reason: '手选的条目必须照常加载');
-    expect(find.text('Test Anime - 01.ja.srt'), findsOneWidget,
-        reason: '用户可能就是要另一季的字幕，不能拦');
+    expect(
+      requested.where((String u) => u.contains('/files')),
+      isNotEmpty,
+      reason: '手选的条目必须照常加载',
+    );
+    expect(
+      find.text('Test Anime - 01.ja.srt'),
+      findsOneWidget,
+      reason: '用户可能就是要另一季的字幕，不能拦',
+    );
     expect(
       find.text(t.anime_download_subs_season_mismatch(season: 2)),
       findsNothing,
@@ -709,20 +826,24 @@ void main() {
       final String url = req.url.toString();
       if (url.contains('/entries/search')) {
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{'id': 7, 'name': 'No Season Entry'},
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{'id': 7, 'name': 'No Season Entry'},
+            ]),
+          ),
           200,
         );
       }
       if (url.contains('/files')) {
         return http.Response.bytes(
-          utf8.encode(jsonEncode(<Map<String, Object>>[
-            <String, Object>{
-              'name': 'Test Anime - 01.ja.srt',
-              'url': 'https://jimaku.cc/f/1.srt',
-            },
-          ])),
+          utf8.encode(
+            jsonEncode(<Map<String, Object>>[
+              <String, Object>{
+                'name': 'Test Anime - 01.ja.srt',
+                'url': 'https://jimaku.cc/f/1.srt',
+              },
+            ]),
+          ),
           200,
         );
       }
@@ -732,8 +853,11 @@ void main() {
     await tester.tap(find.byTooltip(t.anime_download_search).last);
     await tester.pumpAndSettle();
 
-    expect(find.text('Test Anime - 01.ja.srt'), findsOneWidget,
-        reason: '拿不到季号就不校验，维持现状自动选，别因信息缺失把功能关掉');
+    expect(
+      find.text('Test Anime - 01.ja.srt'),
+      findsOneWidget,
+      reason: '拿不到季号就不校验，维持现状自动选，别因信息缺失把功能关掉',
+    );
     expect(
       find.text(t.anime_download_subs_season_mismatch(season: 1)),
       findsNothing,

--- a/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
@@ -268,4 +268,57 @@ void main() {
     expect(appModel.store.plans[_kHash]?.status,
         AnimeDownloadPlan.statusDownloading);
   });
+
+  testWidgets('下载中任务提供独立设置入口，可修改入库名称', (WidgetTester tester) async {
+    final (_FakeAppModel appModel, GlobalKey<NavigatorState> navKey) =
+        await pumpHost(tester);
+    appModel.store.plans[_kHash] = AnimeDownloadPlan(
+      id: _kHash,
+      createdAtMs: 1,
+      anilistId: 1,
+      seriesTitle: 'Old library name',
+      torrentTitle: '[Group] Test Anime - 01 [1080p]',
+      magnet: 'magnet:?xt=urn:btih:$_kHash',
+      qbCategory: 'hibiki',
+    );
+
+    navKey.currentState!.push(MaterialPageRoute<void>(
+      builder: (BuildContext context) => const Scaffold(
+        body: AnimeDownloadDialog(
+          embedded: true,
+          tasksOnly: true,
+          showTasks: false,
+        ),
+      ),
+    ));
+    // 下载进度是不定动画，不能 pumpAndSettle。
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(find.byTooltip(t.anime_download_task_settings), findsOneWidget);
+    await tester.tap(find.byTooltip(t.anime_download_task_settings));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text(t.anime_download_task_settings), findsOneWidget);
+    final Finder nameField = find.byWidgetPredicate(
+      (Widget widget) =>
+          widget is TextField &&
+          widget.decoration?.labelText == t.anime_download_task_library_name,
+    );
+    expect(nameField, findsOneWidget);
+    await tester.enterText(nameField, 'Configured library name');
+    await tester.tap(find.text(t.dialog_save));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(
+      appModel.store.plans[_kHash]?.seriesTitle,
+      'Configured library name',
+    );
+    expect(
+      appModel.store.plans[_kHash]?.contentKind,
+      AnimeDownloadPlan.kindVideo,
+    );
+  });
 }

--- a/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
@@ -6,11 +6,13 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
+import 'package:hibiki/src/media/torrent/anime_download_service.dart';
 import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 import 'package:hibiki/src/media/video/anilist_client.dart';
 import 'package:hibiki/src/media/torrent/nyaa_client.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
+import 'package:hibiki/src/utils/components/hibiki_icon_button.dart';
 
 import '../helpers/test_platform_services.dart';
 
@@ -64,8 +66,9 @@ class _MemPlanStore extends AnimeDownloadPlanStore {
   }
 
   @override
-  Future<void> save(AnimeDownloadPlan plan) async {
+  Future<bool> save(AnimeDownloadPlan plan) async {
     plans[plan.id] = plan;
+    return true;
   }
 
   @override
@@ -110,20 +113,34 @@ class _FakeBackend implements TorrentBackend {
   // 假装成功——真要测这条链路的用例应当显式覆盖它。
   @override
   Future<TorrentStorageResult> renameFile(
-          String torrentId, int fileIndex, String newPath) async =>
+    String torrentId,
+    int fileIndex,
+    String newPath,
+  ) async =>
       const TorrentStorageResult.failure('not supported by fake');
 
   @override
   Future<TorrentStorageResult> moveStorage(
-          String torrentId, String newSavePath) async =>
+    String torrentId,
+    String newSavePath,
+  ) async =>
       const TorrentStorageResult.failure('not supported by fake');
 }
 
 class _FakeAppModel extends AppModel {
-  _FakeAppModel() : super(testPlatformServices());
+  _FakeAppModel() : super(testPlatformServices()) {
+    service = AnimeDownloadService(
+      store: store,
+      configProvider: () => qbConnectionConfig,
+      backendFactory: (_) => backend,
+      importer: (_, __) async =>
+          const AnimeDownloadImportOutcome(collectionId: 42),
+    );
+  }
 
   final _MemPlanStore store = _MemPlanStore();
   final _FakeBackend backend = _FakeBackend();
+  late final AnimeDownloadService service;
 
   @override
   String get jimakuApiKey => 'key';
@@ -141,6 +158,9 @@ class _FakeAppModel extends AppModel {
   AnimeDownloadPlanStore? get animeDownloadPlanStore => store;
 
   @override
+  AnimeDownloadService? get animeDownloadService => service;
+
+  @override
   TorrentBackend createTorrentBackend(QbConnectionConfig config) => backend;
 }
 
@@ -154,34 +174,37 @@ void main() {
   ) async {
     final _FakeAppModel appModel = _FakeAppModel();
     final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
-    await tester.pumpWidget(ProviderScope(
-      overrides: <Override>[
-        appProvider.overrideWith((ref) => appModel),
-      ],
-      child: TranslationProvider(
-        child: MaterialApp(
-          navigatorKey: navKey,
-          home: const Scaffold(body: Center(child: Text('base-route'))),
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[appProvider.overrideWith((ref) => appModel)],
+        child: TranslationProvider(
+          child: MaterialApp(
+            navigatorKey: navKey,
+            home: const Scaffold(body: Center(child: Text('base-route'))),
+          ),
         ),
       ),
-    ));
+    );
     return (appModel, navKey);
   }
 
-  testWidgets('embedded 推送成功不 pop 宿主路由，复位搜番阶段并刷新任务区',
-      (WidgetTester tester) async {
+  testWidgets('embedded 推送成功不 pop 宿主路由，复位搜番阶段并刷新任务区', (
+    WidgetTester tester,
+  ) async {
     final (_FakeAppModel appModel, GlobalKey<NavigatorState> navKey) =
         await pumpHost(tester);
 
-    navKey.currentState!.push(MaterialPageRoute<void>(
-      builder: (BuildContext context) => const Scaffold(
-        body: AnimeDownloadDialog(
-          embedded: true,
-          debugInitialMedia: _kMedia,
-          debugInitialTorrent: _kTorrent,
+    navKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => const Scaffold(
+          body: AnimeDownloadDialog(
+            embedded: true,
+            debugInitialMedia: _kMedia,
+            debugInitialTorrent: _kTorrent,
+          ),
         ),
       ),
-    ));
+    );
     await tester.pumpAndSettle();
 
     // 直达确认推送阶段。
@@ -199,24 +222,91 @@ void main() {
     expect(find.text(t.anime_download_search_hint), findsOneWidget);
 
     // 计划已落盘且任务区计数刷新。
-    expect(appModel.store.plans[_kHash]?.status,
-        AnimeDownloadPlan.statusDownloading);
+    expect(
+      appModel.store.plans[_kHash]?.status,
+      AnimeDownloadPlan.statusDownloading,
+    );
     expect(appModel.backend.addCalls, 1);
     expect(find.text('${t.anime_download_tasks} (1)'), findsOneWidget);
+  });
+
+  testWidgets('early task 在 800x600/窄屏保留真实进度与生命周期语义，隐藏重复 import', (
+    WidgetTester tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    for (final Size size in <Size>[
+      const Size(800, 600),
+      const Size(360, 600),
+    ]) {
+      tester.view.physicalSize = size;
+      final (_FakeAppModel appModel, GlobalKey<NavigatorState> navKey) =
+          await pumpHost(tester);
+      appModel.store.plans[_kHash] = AnimeDownloadPlan(
+        id: _kHash,
+        createdAtMs: 1,
+        seriesTitle:
+            'A deliberately long translated series title that must remain usable',
+        torrentTitle:
+            '[Group] A deliberately long torrent title - 01 [2160p HDR]',
+        magnet: 'magnet:?xt=urn:btih:$_kHash',
+        qbCategory: 'hibiki',
+        importedEarly: true,
+        collectionId: 42,
+      );
+      appModel.service.downloadProgress.value = <String, double>{_kHash: 0.55};
+
+      navKey.currentState!.push(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => const Scaffold(
+            body: AnimeDownloadDialog(
+              embedded: true,
+              tasksOnly: true,
+              showTasks: false,
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 400));
+
+      expect(tester.takeException(), isNull);
+      expect(find.text('55%'), findsOneWidget);
+      expect(find.text(t.anime_download_streaming_ready), findsOneWidget);
+      expect(find.byTooltip(t.anime_download_play_now), findsNothing);
+      expect(find.byTooltip(t.anime_download_relocate), findsOneWidget);
+      expect(find.byTooltip(t.anime_download_delete), findsOneWidget);
+      final HibikiIconButton deleteButton = tester.widget<HibikiIconButton>(
+        find.byWidgetPredicate(
+          (Widget widget) =>
+              widget is HibikiIconButton &&
+              widget.tooltip == t.anime_download_delete,
+        ),
+      );
+      expect(deleteButton.icon, Icons.delete_outline);
+      expect(deleteButton.onTap, isNotNull);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+    }
   });
 
   testWidgets('独立对话框模式推送成功仍关闭自身（向后兼容）', (WidgetTester tester) async {
     final (_FakeAppModel appModel, GlobalKey<NavigatorState> navKey) =
         await pumpHost(tester);
 
-    navKey.currentState!.push(MaterialPageRoute<void>(
-      builder: (BuildContext context) => const Scaffold(
-        body: AnimeDownloadDialog(
-          debugInitialMedia: _kMedia,
-          debugInitialTorrent: _kTorrent,
+    navKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => const Scaffold(
+          body: AnimeDownloadDialog(
+            debugInitialMedia: _kMedia,
+            debugInitialTorrent: _kTorrent,
+          ),
         ),
       ),
-    ));
+    );
     await tester.pumpAndSettle();
     expect(find.text(t.anime_download_push), findsOneWidget);
 
@@ -226,8 +316,10 @@ void main() {
     // 对话框路由已关闭，回到宿主。
     expect(find.byType(AnimeDownloadDialog), findsNothing);
     expect(find.text('base-route'), findsOneWidget);
-    expect(appModel.store.plans[_kHash]?.status,
-        AnimeDownloadPlan.statusDownloading);
+    expect(
+      appModel.store.plans[_kHash]?.status,
+      AnimeDownloadPlan.statusDownloading,
+    );
   });
 
   testWidgets('失败任务行直显失败原因并可重试（复位 downloading）', (WidgetTester tester) async {
@@ -244,11 +336,12 @@ void main() {
       failReason: 'video import failed: boom',
     );
 
-    navKey.currentState!.push(MaterialPageRoute<void>(
-      builder: (BuildContext context) => const Scaffold(
-        body: AnimeDownloadDialog(embedded: true),
+    navKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) =>
+            const Scaffold(body: AnimeDownloadDialog(embedded: true)),
       ),
-    ));
+    );
     await tester.pumpAndSettle();
 
     // 展开任务折叠区。
@@ -265,60 +358,9 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     expect(appModel.backend.addCalls, 1);
-    expect(appModel.store.plans[_kHash]?.status,
-        AnimeDownloadPlan.statusDownloading);
-  });
-
-  testWidgets('下载中任务提供独立设置入口，可修改入库名称', (WidgetTester tester) async {
-    final (_FakeAppModel appModel, GlobalKey<NavigatorState> navKey) =
-        await pumpHost(tester);
-    appModel.store.plans[_kHash] = AnimeDownloadPlan(
-      id: _kHash,
-      createdAtMs: 1,
-      anilistId: 1,
-      seriesTitle: 'Old library name',
-      torrentTitle: '[Group] Test Anime - 01 [1080p]',
-      magnet: 'magnet:?xt=urn:btih:$_kHash',
-      qbCategory: 'hibiki',
-    );
-
-    navKey.currentState!.push(MaterialPageRoute<void>(
-      builder: (BuildContext context) => const Scaffold(
-        body: AnimeDownloadDialog(
-          embedded: true,
-          tasksOnly: true,
-          showTasks: false,
-        ),
-      ),
-    ));
-    // 下载进度是不定动画，不能 pumpAndSettle。
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 400));
-
-    expect(find.byTooltip(t.anime_download_task_settings), findsOneWidget);
-    await tester.tap(find.byTooltip(t.anime_download_task_settings));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-
-    expect(find.text(t.anime_download_task_settings), findsOneWidget);
-    final Finder nameField = find.byWidgetPredicate(
-      (Widget widget) =>
-          widget is TextField &&
-          widget.decoration?.labelText == t.anime_download_task_library_name,
-    );
-    expect(nameField, findsOneWidget);
-    await tester.enterText(nameField, 'Configured library name');
-    await tester.tap(find.text(t.dialog_save));
-    await tester.pump();
-    await tester.pump(const Duration(milliseconds: 300));
-
     expect(
-      appModel.store.plans[_kHash]?.seriesTitle,
-      'Configured library name',
-    );
-    expect(
-      appModel.store.plans[_kHash]?.contentKind,
-      AnimeDownloadPlan.kindVideo,
+      appModel.store.plans[_kHash]?.status,
+      AnimeDownloadPlan.statusDownloading,
     );
   });
 }

--- a/hibiki/test/pages/downloads_page_resize_inset_guard_test.dart
+++ b/hibiki/test/pages/downloads_page_resize_inset_guard_test.dart
@@ -33,14 +33,4 @@ void main() {
           '否则软键盘弹出会把贴底「下载任务」区顶到顶部输入框边上（BUG-1003）',
     );
   });
-
-  test('下载页右上角不再提供重复的在线目录入口', () {
-    final File f = File('lib/src/pages/implementations/downloads_page.dart');
-    expect(f.existsSync(), isTrue);
-    final String src = f.readAsStringSync();
-
-    expect(src.contains('Icons.menu_book_outlined'), isFalse);
-    expect(src.contains('_openMangaCatalog'), isFalse);
-    expect(src.contains('MangaModule.openOnlineCatalog'), isFalse);
-  });
 }

--- a/hibiki/test/pages/downloads_page_resize_inset_guard_test.dart
+++ b/hibiki/test/pages/downloads_page_resize_inset_guard_test.dart
@@ -33,4 +33,14 @@ void main() {
           '否则软键盘弹出会把贴底「下载任务」区顶到顶部输入框边上（BUG-1003）',
     );
   });
+
+  test('下载页右上角不再提供重复的在线目录入口', () {
+    final File f = File('lib/src/pages/implementations/downloads_page.dart');
+    expect(f.existsSync(), isTrue);
+    final String src = f.readAsStringSync();
+
+    expect(src.contains('Icons.menu_book_outlined'), isFalse);
+    expect(src.contains('_openMangaCatalog'), isFalse);
+    expect(src.contains('MangaModule.openOnlineCatalog'), isFalse);
+  });
 }

--- a/hibiki/test/torrent/anime_download_plan_test.dart
+++ b/hibiki/test/torrent/anime_download_plan_test.dart
@@ -103,6 +103,7 @@ void main() {
       expect(decoded.status, AnimeDownloadPlan.statusDownloading);
       expect(decoded.failReason, isNull);
       expect(decoded.collectionId, isNull);
+      expect(decoded.importedEarly, isFalse);
       expect(decoded.subtitles, hasLength(2));
       expect(decoded.subtitles.first.episode, 1);
       expect(decoded.subtitles.first.language, 'ja');
@@ -120,6 +121,22 @@ void main() {
           decodeAnimeDownloadPlan(encodeAnimeDownloadPlan(imported));
       expect(decoded!.status, AnimeDownloadPlan.statusImported);
       expect(decoded.collectionId, 42);
+    });
+
+    test('roundtrip 保持边下边播提前入库标记；老 JSON 默认 false', () {
+      final AnimeDownloadPlan streaming = _fullPlan().copyWith(
+        importedEarly: true,
+        collectionId: 42,
+      );
+      final AnimeDownloadPlan? decoded =
+          decodeAnimeDownloadPlan(encodeAnimeDownloadPlan(streaming));
+      expect(decoded!.status, AnimeDownloadPlan.statusDownloading);
+      expect(decoded.importedEarly, isTrue);
+      expect(decoded.collectionId, 42);
+
+      final AnimeDownloadPlan? legacy =
+          decodeAnimeDownloadPlan(<String, dynamic>{'id': 'legacy'});
+      expect(legacy!.importedEarly, isFalse);
     });
 
     test('缺 id 返回 null；空 Map 返回 null', () {

--- a/hibiki/test/torrent/anime_download_plan_test.dart
+++ b/hibiki/test/torrent/anime_download_plan_test.dart
@@ -24,10 +24,7 @@ AnimeDownloadPlan _fullPlan() {
         stagedPath: '/tmp/subs/One Piece 01.ja.srt',
         language: 'ja',
       ),
-      PlanSubtitle(
-        fileName: 'extra.ass',
-        stagedPath: '/tmp/subs/extra.ass',
-      ),
+      PlanSubtitle(fileName: 'extra.ass', stagedPath: '/tmp/subs/extra.ass'),
     ],
     status: AnimeDownloadPlan.statusDownloading,
   );
@@ -42,8 +39,9 @@ void main() {
         password: 'secret',
         category: 'anime',
       );
-      final QbConnectionConfig? decoded =
-          decodeQbConnectionConfig(encodeQbConnectionConfig(config));
+      final QbConnectionConfig? decoded = decodeQbConnectionConfig(
+        encodeQbConnectionConfig(config),
+      );
       expect(decoded, isNotNull);
       expect(decoded!.baseUrl, 'http://127.0.0.1:8080');
       expect(decoded.username, 'admin');
@@ -60,12 +58,14 @@ void main() {
     });
 
     test('category 缺失/为空回退默认 hibiki', () {
-      final QbConnectionConfig? decoded =
-          decodeQbConnectionConfig('{"baseUrl":"http://x"}');
+      final QbConnectionConfig? decoded = decodeQbConnectionConfig(
+        '{"baseUrl":"http://x"}',
+      );
       expect(decoded, isNotNull);
       expect(decoded!.category, 'hibiki');
-      final QbConnectionConfig? decoded2 =
-          decodeQbConnectionConfig('{"baseUrl":"http://x","category":""}');
+      final QbConnectionConfig? decoded2 = decodeQbConnectionConfig(
+        '{"baseUrl":"http://x","category":""}',
+      );
       expect(decoded2!.category, 'hibiki');
     });
 
@@ -76,8 +76,9 @@ void main() {
       expect(config.isConfigured, isTrue);
       expect(config.category, 'hibiki');
       // 显式外接 qb 但没填地址 → 未配置。
-      const QbConnectionConfig qbEmpty =
-          QbConnectionConfig(backend: QbConnectionConfig.backendQbittorrent);
+      const QbConnectionConfig qbEmpty = QbConnectionConfig(
+        backend: QbConnectionConfig.backendQbittorrent,
+      );
       expect(qbEmpty.isConfigured, isFalse);
       final QbConnectionConfig edited = qbEmpty.copyWith(baseUrl: 'http://x');
       expect(edited.isConfigured, isTrue);
@@ -89,8 +90,9 @@ void main() {
   group('AnimeDownloadPlan codec', () {
     test('roundtrip 保持全部字段（含 null 可空字段）', () {
       final AnimeDownloadPlan plan = _fullPlan();
-      final AnimeDownloadPlan? decoded =
-          decodeAnimeDownloadPlan(encodeAnimeDownloadPlan(plan));
+      final AnimeDownloadPlan? decoded = decodeAnimeDownloadPlan(
+        encodeAnimeDownloadPlan(plan),
+      );
       expect(decoded, isNotNull);
       expect(decoded!.id, plan.id);
       expect(decoded.createdAtMs, plan.createdAtMs);
@@ -104,6 +106,7 @@ void main() {
       expect(decoded.failReason, isNull);
       expect(decoded.collectionId, isNull);
       expect(decoded.importedEarly, isFalse);
+      expect(decoded.importInProgress, isFalse);
       expect(decoded.subtitles, hasLength(2));
       expect(decoded.subtitles.first.episode, 1);
       expect(decoded.subtitles.first.language, 'ja');
@@ -117,26 +120,32 @@ void main() {
         status: AnimeDownloadPlan.statusImported,
         collectionId: 42,
       );
-      final AnimeDownloadPlan? decoded =
-          decodeAnimeDownloadPlan(encodeAnimeDownloadPlan(imported));
+      final AnimeDownloadPlan? decoded = decodeAnimeDownloadPlan(
+        encodeAnimeDownloadPlan(imported),
+      );
       expect(decoded!.status, AnimeDownloadPlan.statusImported);
       expect(decoded.collectionId, 42);
     });
 
-    test('roundtrip 保持边下边播提前入库标记；老 JSON 默认 false', () {
+    test('roundtrip 保持边下边播/持久入库 marker；老 JSON 默认 false', () {
       final AnimeDownloadPlan streaming = _fullPlan().copyWith(
         importedEarly: true,
+        importInProgress: true,
         collectionId: 42,
       );
-      final AnimeDownloadPlan? decoded =
-          decodeAnimeDownloadPlan(encodeAnimeDownloadPlan(streaming));
+      final AnimeDownloadPlan? decoded = decodeAnimeDownloadPlan(
+        encodeAnimeDownloadPlan(streaming),
+      );
       expect(decoded!.status, AnimeDownloadPlan.statusDownloading);
       expect(decoded.importedEarly, isTrue);
+      expect(decoded.importInProgress, isTrue);
       expect(decoded.collectionId, 42);
 
-      final AnimeDownloadPlan? legacy =
-          decodeAnimeDownloadPlan(<String, dynamic>{'id': 'legacy'});
+      final AnimeDownloadPlan? legacy = decodeAnimeDownloadPlan(
+        <String, dynamic>{'id': 'legacy'},
+      );
       expect(legacy!.importedEarly, isFalse);
+      expect(legacy.importInProgress, isFalse);
     });
 
     test('缺 id 返回 null；空 Map 返回 null', () {
@@ -150,16 +159,17 @@ void main() {
     });
 
     test('缺字段用安全默认值；坏字幕条目逐条跳过', () {
-      final AnimeDownloadPlan? decoded =
-          decodeAnimeDownloadPlan(<String, dynamic>{
-        'id': 'hash1',
-        'createdAtMs': 'not int',
-        'subtitles': <dynamic>[
-          'not a map',
-          <String, dynamic>{'fileName': 'a.srt'}, // 缺 stagedPath → 跳过
-          <String, dynamic>{'fileName': 'b.srt', 'stagedPath': '/tmp/b.srt'},
-        ],
-      });
+      final AnimeDownloadPlan? decoded = decodeAnimeDownloadPlan(
+        <String, dynamic>{
+          'id': 'hash1',
+          'createdAtMs': 'not int',
+          'subtitles': <dynamic>[
+            'not a map',
+            <String, dynamic>{'fileName': 'a.srt'}, // 缺 stagedPath → 跳过
+            <String, dynamic>{'fileName': 'b.srt', 'stagedPath': '/tmp/b.srt'},
+          ],
+        },
+      );
       expect(decoded, isNotNull);
       expect(decoded!.createdAtMs, 0);
       expect(decoded.seriesTitle, '');
@@ -193,8 +203,9 @@ void main() {
     test('save 后 loadAll 读回；不留 .tmp 残骸', () async {
       final AnimeDownloadPlan plan = _fullPlan();
       await store.save(plan);
-      final File file =
-          File(p.join(store.baseDir.path, 'plans', '${plan.id}.json'));
+      final File file = File(
+        p.join(store.baseDir.path, 'plans', '${plan.id}.json'),
+      );
       expect(file.existsSync(), isTrue);
       expect(File('${file.path}.tmp').existsSync(), isFalse);
 
@@ -207,10 +218,12 @@ void main() {
     test('save 覆盖同 id 计划（状态推进落盘）', () async {
       final AnimeDownloadPlan plan = _fullPlan();
       await store.save(plan);
-      await store.save(plan.copyWith(
-        status: AnimeDownloadPlan.statusImported,
-        collectionId: 7,
-      ));
+      await store.save(
+        plan.copyWith(
+          status: AnimeDownloadPlan.statusImported,
+          collectionId: 7,
+        ),
+      );
       final List<AnimeDownloadPlan> loaded = await store.loadAll();
       expect(loaded, hasLength(1));
       expect(loaded.single.status, AnimeDownloadPlan.statusImported);
@@ -218,22 +231,30 @@ void main() {
     });
 
     test('loadAll 跳过坏文件，按 createdAtMs 升序', () async {
-      final AnimeDownloadPlan older =
-          _fullPlan().copyWith(id: 'older', createdAtMs: 100);
-      final AnimeDownloadPlan newer =
-          _fullPlan().copyWith(id: 'newer', createdAtMs: 200);
+      final AnimeDownloadPlan older = _fullPlan().copyWith(
+        id: 'older',
+        createdAtMs: 100,
+      );
+      final AnimeDownloadPlan newer = _fullPlan().copyWith(
+        id: 'newer',
+        createdAtMs: 200,
+      );
       await store.save(newer);
       await store.save(older);
       final Directory plansDir = Directory(p.join(store.baseDir.path, 'plans'));
       File(p.join(plansDir.path, 'garbage.json')).writeAsStringSync('not json');
-      File(p.join(plansDir.path, 'array.json'))
-          .writeAsStringSync(jsonEncode(<int>[1, 2]));
-      File(p.join(plansDir.path, 'noid.json'))
-          .writeAsStringSync(jsonEncode(<String, dynamic>{'seriesTitle': 'x'}));
+      File(
+        p.join(plansDir.path, 'array.json'),
+      ).writeAsStringSync(jsonEncode(<int>[1, 2]));
+      File(
+        p.join(plansDir.path, 'noid.json'),
+      ).writeAsStringSync(jsonEncode(<String, dynamic>{'seriesTitle': 'x'}));
 
       final List<AnimeDownloadPlan> loaded = await store.loadAll();
-      expect(loaded.map((AnimeDownloadPlan e) => e.id).toList(),
-          <String>['older', 'newer']);
+      expect(loaded.map((AnimeDownloadPlan e) => e.id).toList(), <String>[
+        'older',
+        'newer',
+      ]);
     });
 
     test('subsDirFor 布局 = baseDir/subs/<id>', () {
@@ -247,14 +268,17 @@ void main() {
       // 默认（番剧）= video。
       expect(_fullPlan().contentKind, AnimeDownloadPlan.kindVideo);
       // round-trip 保留 book。
-      final AnimeDownloadPlan book =
-          _fullPlan().copyWith(contentKind: AnimeDownloadPlan.kindBook);
-      final AnimeDownloadPlan decoded =
-          decodeAnimeDownloadPlan(encodeAnimeDownloadPlan(book))!;
+      final AnimeDownloadPlan book = _fullPlan().copyWith(
+        contentKind: AnimeDownloadPlan.kindBook,
+      );
+      final AnimeDownloadPlan decoded = decodeAnimeDownloadPlan(
+        encodeAnimeDownloadPlan(book),
+      )!;
       expect(decoded.contentKind, AnimeDownloadPlan.kindBook);
       // 老计划（JSON 无 contentKind 字段）→ video（向后兼容）。
-      final AnimeDownloadPlan legacy =
-          decodeAnimeDownloadPlan(<String, dynamic>{'id': 'x', 'magnet': 'm'})!;
+      final AnimeDownloadPlan legacy = decodeAnimeDownloadPlan(
+        <String, dynamic>{'id': 'x', 'magnet': 'm'},
+      )!;
       expect(legacy.contentKind, AnimeDownloadPlan.kindVideo);
     });
 

--- a/hibiki/test/torrent/anime_download_service_test.dart
+++ b/hibiki/test/torrent/anime_download_service_test.dart
@@ -838,7 +838,7 @@ void main() {
             AnimeDownloadPlan.statusDownloading);
       });
 
-      test('未完成但文件已解析 → 提前入库成功，后续 tick 不重复导入', () async {
+      test('未完成但文件已解析 → 提前入库后继续跟踪进度，完成时不重复导入', () async {
         final String savePath = p.join(tempDir.path, 'downloads');
         Directory(savePath).createSync(recursive: true);
         await store.save(_plan());
@@ -856,12 +856,39 @@ void main() {
         expect(await service.importNow(_kHash), isTrue);
         expect(importCalls, hasLength(1));
         expect(importCalls.single.$2.single, p.join(savePath, 'Show 01.mkv'));
-        expect((await store.loadAll()).single.status,
-            AnimeDownloadPlan.statusImported);
-        // 已 imported：tick 不再有 downloading 计划，不建连接、不重复导入。
-        final int factoryCallsBefore = qb.factoryCalls;
+        AnimeDownloadPlan saved = (await store.loadAll()).single;
+        expect(saved.status, AnimeDownloadPlan.statusDownloading);
+        expect(saved.importedEarly, isTrue);
+        expect(saved.collectionId, 42);
+        expect(service.downloadProgress.value[_kHash], 0.2);
+
+        // 提前入库不是下载完成：后续 tick 继续刷新真实进度，且不重复导入。
+        qb.torrents = <Map<String, dynamic>>[
+          _torrentJson(
+              state: 'downloading',
+              progress: 0.55,
+              amountLeft: 450,
+              savePath: savePath),
+        ];
         await service.tick();
-        expect(qb.factoryCalls, factoryCallsBefore);
+        expect(importCalls, hasLength(1));
+        expect(service.downloadProgress.value[_kHash], 0.55);
+        expect((await store.loadAll()).single.status,
+            AnimeDownloadPlan.statusDownloading);
+
+        // 真正完成后才转 imported；提前入库的视频仍不重复导入。
+        qb.torrents = <Map<String, dynamic>>[
+          _torrentJson(
+              state: 'stalledUP',
+              progress: 1,
+              amountLeft: 0,
+              savePath: savePath),
+        ];
+        await service.tick();
+        saved = (await store.loadAll()).single;
+        expect(saved.status, AnimeDownloadPlan.statusImported);
+        expect(saved.importedEarly, isTrue);
+        expect(saved.collectionId, 42);
         expect(importCalls, hasLength(1));
       });
 

--- a/hibiki/test/torrent/anime_download_service_test.dart
+++ b/hibiki/test/torrent/anime_download_service_test.dart
@@ -31,36 +31,52 @@ class _FakeQb {
   int infoRequests = 0;
   int filesRequests = 0;
   int factoryCalls = 0;
+  int deleteRequests = 0;
   String? lastInfoCategory;
+  Completer<void>? infoRequestStarted;
+  Future<void>? infoResponseGate;
   List<Map<String, dynamic>> torrents = <Map<String, dynamic>>[];
   List<Map<String, dynamic>> files = <Map<String, dynamic>>[];
 
   late final MockClient mock = MockClient((http.Request request) async {
     final String path = request.url.path;
     if (path == '/api/v2/auth/login') {
-      return http.Response('Ok.', 200,
-          headers: <String, String>{'set-cookie': 'SID=fake123; path=/'});
+      return http.Response(
+        'Ok.',
+        200,
+        headers: <String, String>{'set-cookie': 'SID=fake123; path=/'},
+      );
     }
     if (path == '/api/v2/torrents/info') {
       infoRequests++;
       lastInfoCategory = request.url.queryParameters['category'];
+      final Completer<void>? started = infoRequestStarted;
+      if (started != null && !started.isCompleted) started.complete();
+      final Future<void>? gate = infoResponseGate;
+      if (gate != null) await gate;
       return http.Response(jsonEncode(torrents), 200);
     }
     if (path == '/api/v2/torrents/files') {
       filesRequests++;
       return http.Response(jsonEncode(files), 200);
     }
+    if (path == '/api/v2/torrents/delete') {
+      deleteRequests++;
+      return http.Response('', 200);
+    }
     return http.Response('not found', 404);
   });
 
   TorrentBackend newBackend(QbConnectionConfig config) {
     factoryCalls++;
-    return QbTorrentBackend(QBittorrentClient(
-      baseUrl: config.baseUrl,
-      username: config.username,
-      password: config.password,
-      client: mock,
-    ));
+    return QbTorrentBackend(
+      QBittorrentClient(
+        baseUrl: config.baseUrl,
+        username: config.username,
+        password: config.password,
+        client: mock,
+      ),
+    );
   }
 }
 
@@ -114,11 +130,23 @@ void main() {
       final List<String> videos =
           resolveVideoAbsolutePaths(info, const <TorrentFileEntry>[
         TorrentFileEntry(
-            name: 'Show/Show - 01.mkv', size: 1, progress: 1, index: 0),
+          name: 'Show/Show - 01.mkv',
+          size: 1,
+          progress: 1,
+          index: 0,
+        ),
         TorrentFileEntry(
-            name: 'Show/Show - 02.MP4', size: 1, progress: 1, index: 1),
+          name: 'Show/Show - 02.MP4',
+          size: 1,
+          progress: 1,
+          index: 1,
+        ),
         TorrentFileEntry(
-            name: 'Show/readme.txt', size: 1, progress: 1, index: 2),
+          name: 'Show/readme.txt',
+          size: 1,
+          progress: 1,
+          index: 2,
+        ),
       ]);
       expect(videos, <String>[
         p.join('/dl', 'Show/Show - 01.mkv'),
@@ -136,8 +164,10 @@ void main() {
         contentPath: '/dl/movie.mkv',
         amountLeft: 0,
       );
-      expect(resolveVideoAbsolutePaths(single, const <TorrentFileEntry>[]),
-          <String>['/dl/movie.mkv']);
+      expect(
+        resolveVideoAbsolutePaths(single, const <TorrentFileEntry>[]),
+        <String>['/dl/movie.mkv'],
+      );
 
       const TorrentSnapshot nonVideo = TorrentSnapshot(
         hash: _kHash,
@@ -148,26 +178,35 @@ void main() {
         contentPath: '/dl/archive.zip',
         amountLeft: 0,
       );
-      expect(resolveVideoAbsolutePaths(nonVideo, const <TorrentFileEntry>[]),
-          isEmpty);
+      expect(
+        resolveVideoAbsolutePaths(nonVideo, const <TorrentFileEntry>[]),
+        isEmpty,
+      );
     });
   });
 
   group('pairSubtitlesToVideos', () {
     const PlanSubtitle ep1Ja = PlanSubtitle(
-        episode: 1,
-        fileName: 's01.ja.srt',
-        stagedPath: '/s/1.srt',
-        language: 'ja');
+      episode: 1,
+      fileName: 's01.ja.srt',
+      stagedPath: '/s/1.srt',
+      language: 'ja',
+    );
     const PlanSubtitle ep1Zh = PlanSubtitle(
-        episode: 1,
-        fileName: 's01.zh.srt',
-        stagedPath: '/s/1zh.srt',
-        language: 'zh');
-    const PlanSubtitle ep2 =
-        PlanSubtitle(episode: 2, fileName: 's02.srt', stagedPath: '/s/2.srt');
-    const PlanSubtitle noEp =
-        PlanSubtitle(fileName: 'movie.ass', stagedPath: '/s/m.ass');
+      episode: 1,
+      fileName: 's01.zh.srt',
+      stagedPath: '/s/1zh.srt',
+      language: 'zh',
+    );
+    const PlanSubtitle ep2 = PlanSubtitle(
+      episode: 2,
+      fileName: 's02.srt',
+      stagedPath: '/s/2.srt',
+    );
+    const PlanSubtitle noEp = PlanSubtitle(
+      fileName: 'movie.ass',
+      stagedPath: '/s/m.ass',
+    );
 
     test('规则①：集号相等配对；同集多字幕取第一个', () {
       final Map<String, PlanSubtitle> pairs = pairSubtitlesToVideos(
@@ -192,7 +231,9 @@ void main() {
       // 视频有集号、字幕无集号：也直接配对。
       expect(
         pairSubtitlesToVideos(
-            <String>['/v/Show - 01.mkv'], <PlanSubtitle>[noEp]),
+          <String>['/v/Show - 01.mkv'],
+          <PlanSubtitle>[noEp],
+        ),
         <String, PlanSubtitle>{'/v/Show - 01.mkv': noEp},
       );
     });
@@ -201,31 +242,40 @@ void main() {
       // 1v1 双方都有集号但不等 → 不配。
       expect(
         pairSubtitlesToVideos(
-            <String>['/v/Show - 01.mkv'], <PlanSubtitle>[ep2]),
+          <String>['/v/Show - 01.mkv'],
+          <PlanSubtitle>[ep2],
+        ),
         isEmpty,
       );
       // 多视频 + 无集号字幕 → 不配。
       expect(
-        pairSubtitlesToVideos(<String>['/v/Show - 01.mkv', '/v/Show - 02.mkv'],
-            <PlanSubtitle>[noEp]),
+        pairSubtitlesToVideos(
+          <String>['/v/Show - 01.mkv', '/v/Show - 02.mkv'],
+          <PlanSubtitle>[noEp],
+        ),
         isEmpty,
       );
-      expect(pairSubtitlesToVideos(const <String>[], <PlanSubtitle>[ep1Ja]),
-          isEmpty);
       expect(
-          pairSubtitlesToVideos(
-              <String>['/v/Show - 01.mkv'], const <PlanSubtitle>[]),
-          isEmpty);
+        pairSubtitlesToVideos(const <String>[], <PlanSubtitle>[ep1Ja]),
+        isEmpty,
+      );
+      expect(
+        pairSubtitlesToVideos(<String>[
+          '/v/Show - 01.mkv',
+        ], const <PlanSubtitle>[]),
+        isEmpty,
+      );
     });
   });
 
   group('sidecarPathFor', () {
     test('带语言：<视频目录>/<视频名去扩展>.<lang>.<字幕扩展>', () {
       const PlanSubtitle sub = PlanSubtitle(
-          episode: 1,
-          fileName: 'Show 01.ASS',
-          stagedPath: '/s/x.ass',
-          language: 'ja');
+        episode: 1,
+        fileName: 'Show 01.ASS',
+        stagedPath: '/s/x.ass',
+        language: 'ja',
+      );
       expect(
         sidecarPathFor(p.join('/dl', 'Show', 'Show - 01.mkv'), sub),
         p.join('/dl', 'Show', 'Show - 01.ja.ass'),
@@ -233,14 +283,18 @@ void main() {
     });
 
     test('language null 省略 lang 段；字幕无扩展退化 .srt', () {
-      const PlanSubtitle sub =
-          PlanSubtitle(fileName: 'Show 01.srt', stagedPath: '/s/x.srt');
+      const PlanSubtitle sub = PlanSubtitle(
+        fileName: 'Show 01.srt',
+        stagedPath: '/s/x.srt',
+      );
       expect(
         sidecarPathFor(p.join('/dl', 'Show - 01.mkv'), sub),
         p.join('/dl', 'Show - 01.srt'),
       );
-      const PlanSubtitle noExt =
-          PlanSubtitle(fileName: 'noext', stagedPath: '/s/noext');
+      const PlanSubtitle noExt = PlanSubtitle(
+        fileName: 'noext',
+        stagedPath: '/s/noext',
+      );
       expect(
         sidecarPathFor(p.join('/dl', 'Show - 01.mkv'), noExt),
         p.join('/dl', 'Show - 01.srt'),
@@ -255,7 +309,9 @@ void main() {
     late List<(AnimeDownloadPlan, List<String>)> importCalls;
     late List<(AnimeDownloadPlan, List<String>)> bookImportCalls;
     Future<AnimeDownloadImportOutcome?> Function(
-        AnimeDownloadPlan, List<String>)? importerOverride;
+      AnimeDownloadPlan,
+      List<String>,
+    )? importerOverride;
     Future<int?> Function(AnimeDownloadPlan, List<String>)?
         bookImporterOverride;
     late List<(AnimeDownloadPlan, List<String>)> subtitleResolverCalls;
@@ -274,8 +330,9 @@ void main() {
             : (AnimeDownloadPlan plan, List<String> videos) async {
                 subtitleResolverCalls.add((plan, videos));
                 final Future<ResolvedPlanSubtitles> Function(
-                        AnimeDownloadPlan, List<String>)? override =
-                    subtitleResolverOverride;
+                  AnimeDownloadPlan,
+                  List<String>,
+                )? override = subtitleResolverOverride;
                 if (override != null) return override(plan, videos);
                 return const ResolvedPlanSubtitles.failed('not stubbed');
               },
@@ -322,15 +379,18 @@ void main() {
       await store.save(_plan());
       await buildService(config: () => null).tick();
       await buildService(
-          config: () => const QbConnectionConfig(
-              backend: QbConnectionConfig.backendQbittorrent)).tick();
+        config: () => const QbConnectionConfig(
+          backend: QbConnectionConfig.backendQbittorrent,
+        ),
+      ).tick();
       expect(qb.factoryCalls, 0);
       expect(importCalls, isEmpty);
     });
 
     test('无 downloading 计划不建连接', () async {
-      await store
-          .save(_plan().copyWith(status: AnimeDownloadPlan.statusImported));
+      await store.save(
+        _plan().copyWith(status: AnimeDownloadPlan.statusImported),
+      );
       await buildService().tick();
       expect(qb.factoryCalls, 0);
     });
@@ -352,8 +412,10 @@ void main() {
       await buildService().tick();
       expect(importCalls, isEmpty);
       expect(qb.filesRequests, 0);
-      expect((await store.loadAll()).single.status,
-          AnimeDownloadPlan.statusDownloading);
+      expect(
+        (await store.loadAll()).single.status,
+        AnimeDownloadPlan.statusDownloading,
+      );
     });
 
     // ========================================================================
@@ -381,10 +443,12 @@ void main() {
     test('BUG-1206 pending 计划：完成时才补取，resolver 拿到的是包内真实视频路径', () async {
       final (String savePath, List<Map<String, dynamic>> files) =
           completedSeasonPack();
-      await store.save(_plan().copyWith(
-        jimakuEntryId: 7,
-        subtitleStatus: AnimeDownloadPlan.subtitlePending,
-      ));
+      await store.save(
+        _plan().copyWith(
+          jimakuEntryId: 7,
+          subtitleStatus: AnimeDownloadPlan.subtitlePending,
+        ),
+      );
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
       ];
@@ -398,10 +462,11 @@ void main() {
         File(staged).writeAsStringSync('cue');
         return ResolvedPlanSubtitles.ok(<PlanSubtitle>[
           PlanSubtitle(
-              episode: 3,
-              fileName: 'Show - 03.ja.srt',
-              stagedPath: staged,
-              language: 'ja'),
+            episode: 3,
+            fileName: 'Show - 03.ja.srt',
+            stagedPath: staged,
+            language: 'ja',
+          ),
         ]);
       };
 
@@ -413,19 +478,18 @@ void main() {
           subtitleResolverCalls.single;
       expect(calledPlan.jimakuEntryId, 7);
       expect(videos, hasLength(12));
-      expect(
-        videos.map(p.basename),
-        contains('[Grp] Show - 03 [1080p].mkv'),
-      );
+      expect(videos.map(p.basename), contains('[Grp] Show - 03 [1080p].mkv'));
       // ② 反查结果真的贴成了第 3 集的 sidecar（不是第 1 集，也不是全都贴）。
       expect(
-        File(p.join(savePath, 'Show', '[Grp] Show - 03 [1080p].ja.srt'))
-            .existsSync(),
+        File(
+          p.join(savePath, 'Show', '[Grp] Show - 03 [1080p].ja.srt'),
+        ).existsSync(),
         isTrue,
       );
       expect(
-        File(p.join(savePath, 'Show', '[Grp] Show - 01 [1080p].ja.srt'))
-            .existsSync(),
+        File(
+          p.join(savePath, 'Show', '[Grp] Show - 01 [1080p].ja.srt'),
+        ).existsSync(),
         isFalse,
       );
       // ③ 计划落成 resolved 并带上真配好的字幕。
@@ -438,25 +502,31 @@ void main() {
     test('BUG-1206 反查一条都不配 → 落 unavailable + 原因，视频照常入库', () async {
       final (String savePath, List<Map<String, dynamic>> files) =
           completedSeasonPack();
-      await store.save(_plan().copyWith(
-        jimakuEntryId: 7,
-        jimakuEntryName: 'Wrong Season Entry',
-        subtitleStatus: AnimeDownloadPlan.subtitlePending,
-      ));
+      await store.save(
+        _plan().copyWith(
+          jimakuEntryId: 7,
+          jimakuEntryName: 'Wrong Season Entry',
+          subtitleStatus: AnimeDownloadPlan.subtitlePending,
+        ),
+      );
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
       ];
       qb.files = files;
-      subtitleResolverOverride = (_, __) async =>
-          const ResolvedPlanSubtitles.failed(
-              'no jimaku file matches the pack episodes');
+      subtitleResolverOverride =
+          (_, __) async => const ResolvedPlanSubtitles.failed(
+                'no jimaku file matches the pack episodes',
+              );
 
       await buildService().tick();
 
       final AnimeDownloadPlan saved = (await store.loadAll()).single;
       expect(saved.subtitleStatus, AnimeDownloadPlan.subtitleUnavailable);
-      expect(saved.subtitleNote, 'no jimaku file matches the pack episodes',
-          reason: '不能静默：原因要落进计划，任务行才显示得出来');
+      expect(
+        saved.subtitleNote,
+        'no jimaku file matches the pack episodes',
+        reason: '不能静默：原因要落进计划，任务行才显示得出来',
+      );
       expect(saved.subtitles, isEmpty);
       // 字幕没配上不该把整个下载判失败——视频还是要进库。
       expect(saved.status, AnimeDownloadPlan.statusImported);
@@ -471,9 +541,17 @@ void main() {
       final String staged = p.join(subsDir.path, 'legacy 05.srt');
       File(staged).writeAsStringSync('legacy cue');
       // 老计划反序列化后 subtitleStatus = resolved（decode 的兼容分支）。
-      await store.save(_plan(subtitles: <PlanSubtitle>[
-        PlanSubtitle(episode: 5, fileName: 'legacy 05.srt', stagedPath: staged),
-      ]).copyWith(subtitleStatus: AnimeDownloadPlan.subtitleResolved));
+      await store.save(
+        _plan(
+          subtitles: <PlanSubtitle>[
+            PlanSubtitle(
+              episode: 5,
+              fileName: 'legacy 05.srt',
+              stagedPath: staged,
+            ),
+          ],
+        ).copyWith(subtitleStatus: AnimeDownloadPlan.subtitleResolved),
+      );
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
       ];
@@ -483,21 +561,26 @@ void main() {
 
       expect(subtitleResolverCalls, isEmpty, reason: '老计划的字幕是既有数据，绝不能重取或覆盖');
       expect(
-        File(p.join(savePath, 'Show', '[Grp] Show - 05 [1080p].srt'))
-            .readAsStringSync(),
+        File(
+          p.join(savePath, 'Show', '[Grp] Show - 05 [1080p].srt'),
+        ).readAsStringSync(),
         'legacy cue',
       );
-      expect((await store.loadAll()).single.subtitles.single.fileName,
-          'legacy 05.srt');
+      expect(
+        (await store.loadAll()).single.subtitles.single.fileName,
+        'legacy 05.srt',
+      );
     });
 
     test('BUG-1206 没接 resolver 时 pending 计划落 unavailable，不静默', () async {
       final (String savePath, List<Map<String, dynamic>> files) =
           completedSeasonPack();
-      await store.save(_plan().copyWith(
-        jimakuEntryId: 7,
-        subtitleStatus: AnimeDownloadPlan.subtitlePending,
-      ));
+      await store.save(
+        _plan().copyWith(
+          jimakuEntryId: 7,
+          subtitleStatus: AnimeDownloadPlan.subtitlePending,
+        ),
+      );
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(savePath: savePath, contentPath: p.join(savePath, 'Show')),
       ];
@@ -520,13 +603,18 @@ void main() {
       final String savePath = p.join(tempDir.path, 'downloads');
       Directory(savePath).createSync(recursive: true);
 
-      await store.save(_plan(subtitles: <PlanSubtitle>[
-        PlanSubtitle(
-            episode: 1,
-            fileName: 'Show 01.ja.srt',
-            stagedPath: staged,
-            language: 'ja'),
-      ]));
+      await store.save(
+        _plan(
+          subtitles: <PlanSubtitle>[
+            PlanSubtitle(
+              episode: 1,
+              fileName: 'Show 01.ja.srt',
+              stagedPath: staged,
+              language: 'ja',
+            ),
+          ],
+        ),
+      );
       // 种子 hash 用大写：验证与计划 id 的比对是大小写不敏感的。
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(
@@ -557,12 +645,14 @@ void main() {
       expect(importCalls.single.$2, <String>[expectedVideo]);
 
       final String sidecar = sidecarPathFor(
-          expectedVideo,
-          PlanSubtitle(
-              episode: 1,
-              fileName: 'Show 01.ja.srt',
-              stagedPath: staged,
-              language: 'ja'));
+        expectedVideo,
+        PlanSubtitle(
+          episode: 1,
+          fileName: 'Show 01.ja.srt',
+          stagedPath: staged,
+          language: 'ja',
+        ),
+      );
       expect(File(sidecar).existsSync(), isTrue);
       expect(File(sidecar).readAsStringSync(), 'subtitle content');
 
@@ -580,21 +670,27 @@ void main() {
       final String savePath = p.join(tempDir.path, 'downloads');
       final String video = p.join(savePath, 'Show - 01.mkv');
       const PlanSubtitle sub = PlanSubtitle(
-          episode: 1,
-          fileName: 'Show 01.ja.srt',
-          stagedPath: '',
-          language: 'ja');
+        episode: 1,
+        fileName: 'Show 01.ja.srt',
+        stagedPath: '',
+        language: 'ja',
+      );
       final String sidecar = sidecarPathFor(video, sub);
       File(sidecar).createSync(recursive: true);
       File(sidecar).writeAsStringSync('user edited');
 
-      await store.save(_plan(subtitles: <PlanSubtitle>[
-        PlanSubtitle(
-            episode: 1,
-            fileName: 'Show 01.ja.srt',
-            stagedPath: staged,
-            language: 'ja'),
-      ]));
+      await store.save(
+        _plan(
+          subtitles: <PlanSubtitle>[
+            PlanSubtitle(
+              episode: 1,
+              fileName: 'Show 01.ja.srt',
+              stagedPath: staged,
+              language: 'ja',
+            ),
+          ],
+        ),
+      );
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(savePath: savePath, contentPath: video),
       ];
@@ -609,8 +705,10 @@ void main() {
 
       await buildService().tick();
       expect(File(sidecar).readAsStringSync(), 'user edited');
-      expect((await store.loadAll()).single.status,
-          AnimeDownloadPlan.statusImported);
+      expect(
+        (await store.loadAll()).single.status,
+        AnimeDownloadPlan.statusImported,
+      );
     });
 
     // BUG-1189 跟进：去重键必须**语言无关**。本 PR 让 detectSubtitleLanguage 认出
@@ -633,21 +731,30 @@ void main() {
 
       // 本轮要落位的是带语言段的新名字 —— 与老档不同名，旧的「同名跳过」拦不住。
       const PlanSubtitle sub = PlanSubtitle(
-          episode: 1,
-          fileName: 'Show 01.ja.srt',
-          stagedPath: '',
-          language: 'ja');
+        episode: 1,
+        fileName: 'Show 01.ja.srt',
+        stagedPath: '',
+        language: 'ja',
+      );
       final String langSidecar = sidecarPathFor(video, sub);
-      expect(langSidecar, isNot(legacySidecar),
-          reason: '前提：两者不同名，否则这条用例证明不了语言无关去重');
+      expect(
+        langSidecar,
+        isNot(legacySidecar),
+        reason: '前提：两者不同名，否则这条用例证明不了语言无关去重',
+      );
 
-      await store.save(_plan(subtitles: <PlanSubtitle>[
-        PlanSubtitle(
-            episode: 1,
-            fileName: 'Show 01.ja.srt',
-            stagedPath: staged,
-            language: 'ja'),
-      ]));
+      await store.save(
+        _plan(
+          subtitles: <PlanSubtitle>[
+            PlanSubtitle(
+              episode: 1,
+              fileName: 'Show 01.ja.srt',
+              stagedPath: staged,
+              language: 'ja',
+            ),
+          ],
+        ),
+      );
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(savePath: savePath, contentPath: video),
       ];
@@ -662,10 +769,16 @@ void main() {
 
       await buildService().tick();
 
-      expect(File(langSidecar).existsSync(), isFalse,
-          reason: '该集已有 sidecar，不得再写第二份');
-      expect(File(legacySidecar).readAsStringSync(), 'legacy subtitle',
-          reason: '老档可能是用户手放/手改的，绝不覆盖或删除');
+      expect(
+        File(langSidecar).existsSync(),
+        isFalse,
+        reason: '该集已有 sidecar，不得再写第二份',
+      );
+      expect(
+        File(legacySidecar).readAsStringSync(),
+        'legacy subtitle',
+        reason: '老档可能是用户手放/手改的，绝不覆盖或删除',
+      );
 
       // 默认选中的确定答案：目录里始终只有一份 sidecar，所以「默认选中悄悄切档」
       // 这件事根本不会发生 —— pickSidecar 无论学习语言是什么都只能挑到老档。
@@ -675,12 +788,15 @@ void main() {
           .map((File f) => p.basename(f.path))
           .toList();
       expect(
-        listSidecarSubtitles('Show - 01', dirFiles),
-        <String>['Show - 01.srt'],
-        reason: '同一集有且只有一份 sidecar',
-      );
+          listSidecarSubtitles('Show - 01', dirFiles),
+          <String>[
+            'Show - 01.srt',
+          ],
+          reason: '同一集有且只有一份 sidecar');
       expect(
-          pickSidecar('Show - 01', dirFiles, langCode: 'ja'), 'Show - 01.srt');
+        pickSidecar('Show - 01', dirFiles, langCode: 'ja'),
+        'Show - 01.srt',
+      );
     });
 
     test('该集本来没有任何 sidecar 时照常落位（去重不得误伤首次下载）', () async {
@@ -696,13 +812,18 @@ void main() {
       Directory(savePath).createSync(recursive: true);
       File(p.join(savePath, 'Show - 02.srt')).writeAsStringSync('other ep');
 
-      await store.save(_plan(subtitles: <PlanSubtitle>[
-        PlanSubtitle(
-            episode: 1,
-            fileName: 'Show 01.ja.srt',
-            stagedPath: staged,
-            language: 'ja'),
-      ]));
+      await store.save(
+        _plan(
+          subtitles: <PlanSubtitle>[
+            PlanSubtitle(
+              episode: 1,
+              fileName: 'Show 01.ja.srt',
+              stagedPath: staged,
+              language: 'ja',
+            ),
+          ],
+        ),
+      );
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(savePath: savePath, contentPath: video),
       ];
@@ -717,9 +838,11 @@ void main() {
 
       await buildService().tick();
 
-      expect(File(p.join(savePath, 'Show - 01.ja.srt')).readAsStringSync(),
-          'fresh content',
-          reason: '本集无 sidecar → 必须正常落位；别集的字幕不该挡住它');
+      expect(
+        File(p.join(savePath, 'Show - 01.ja.srt')).readAsStringSync(),
+        'fresh content',
+        reason: '本集无 sidecar → 必须正常落位；别集的字幕不该挡住它',
+      );
     });
 
     test('importer 抛异常 → 计划标 failed 不重试', () async {
@@ -760,18 +883,22 @@ void main() {
     test('种子丢失：超 48h 标 failed(torrent missing)，未超跳过等下轮', () async {
       final int nowMs = DateTime.now().millisecondsSinceEpoch;
       await store.save(_plan(id: 'b' * 40, createdAtMs: nowMs - 1000));
-      await store.save(_plan(
-        id: 'c' * 40,
-        createdAtMs: nowMs - const Duration(hours: 49).inMilliseconds,
-      ));
+      await store.save(
+        _plan(
+          id: 'c' * 40,
+          createdAtMs: nowMs - const Duration(hours: 49).inMilliseconds,
+        ),
+      );
       qb.torrents = <Map<String, dynamic>>[]; // qb 列表为空 = 都被删了。
 
       await buildService().tick();
       final List<AnimeDownloadPlan> plans = await store.loadAll();
-      final AnimeDownloadPlan fresh =
-          plans.singleWhere((AnimeDownloadPlan e) => e.id == 'b' * 40);
-      final AnimeDownloadPlan stale =
-          plans.singleWhere((AnimeDownloadPlan e) => e.id == 'c' * 40);
+      final AnimeDownloadPlan fresh = plans.singleWhere(
+        (AnimeDownloadPlan e) => e.id == 'b' * 40,
+      );
+      final AnimeDownloadPlan stale = plans.singleWhere(
+        (AnimeDownloadPlan e) => e.id == 'c' * 40,
+      );
       expect(fresh.status, AnimeDownloadPlan.statusDownloading);
       expect(stale.status, AnimeDownloadPlan.statusFailed);
       expect(stale.failReason, 'torrent missing');
@@ -787,7 +914,8 @@ void main() {
       final int nowMs = DateTime.now().millisecondsSinceEpoch;
       await store.save(_plan()); // 会走到 importer 并卡在 gate 上。
       await store.save(
-          _plan(id: 'd' * 40, createdAtMs: nowMs)); // 种子缺席，保持 downloading。
+        _plan(id: 'd' * 40, createdAtMs: nowMs),
+      ); // 种子缺席，保持 downloading。
       qb.torrents = <Map<String, dynamic>>[
         _torrentJson(contentPath: '/dl/movie.mkv', savePath: '/dl'),
       ];
@@ -834,8 +962,10 @@ void main() {
         final bool ok = await buildService().importNow(_kHash);
         expect(ok, isFalse);
         expect(importCalls, isEmpty);
-        expect((await store.loadAll()).single.status,
-            AnimeDownloadPlan.statusDownloading);
+        expect(
+          (await store.loadAll()).single.status,
+          AnimeDownloadPlan.statusDownloading,
+        );
       });
 
       test('未完成但文件已解析 → 提前入库后继续跟踪进度，完成时不重复导入', () async {
@@ -844,10 +974,11 @@ void main() {
         await store.save(_plan());
         qb.torrents = <Map<String, dynamic>>[
           _torrentJson(
-              state: 'downloading',
-              progress: 0.2,
-              amountLeft: 800,
-              savePath: savePath),
+            state: 'downloading',
+            progress: 0.2,
+            amountLeft: 800,
+            savePath: savePath,
+          ),
         ];
         qb.files = <Map<String, dynamic>>[
           <String, dynamic>{'name': 'Show 01.mkv', 'size': 1, 'progress': 0.5},
@@ -865,24 +996,28 @@ void main() {
         // 提前入库不是下载完成：后续 tick 继续刷新真实进度，且不重复导入。
         qb.torrents = <Map<String, dynamic>>[
           _torrentJson(
-              state: 'downloading',
-              progress: 0.55,
-              amountLeft: 450,
-              savePath: savePath),
+            state: 'downloading',
+            progress: 0.55,
+            amountLeft: 450,
+            savePath: savePath,
+          ),
         ];
         await service.tick();
         expect(importCalls, hasLength(1));
         expect(service.downloadProgress.value[_kHash], 0.55);
-        expect((await store.loadAll()).single.status,
-            AnimeDownloadPlan.statusDownloading);
+        expect(
+          (await store.loadAll()).single.status,
+          AnimeDownloadPlan.statusDownloading,
+        );
 
         // 真正完成后才转 imported；提前入库的视频仍不重复导入。
         qb.torrents = <Map<String, dynamic>>[
           _torrentJson(
-              state: 'stalledUP',
-              progress: 1,
-              amountLeft: 0,
-              savePath: savePath),
+            state: 'stalledUP',
+            progress: 1,
+            amountLeft: 0,
+            savePath: savePath,
+          ),
         ];
         await service.tick();
         saved = (await store.loadAll()).single;
@@ -897,8 +1032,132 @@ void main() {
         await store.save(_plan());
         qb.torrents = <Map<String, dynamic>>[]; // 种子不在 qb。
         expect(await buildService().importNow(_kHash), isFalse);
-        expect((await store.loadAll()).single.status,
-            AnimeDownloadPlan.statusDownloading);
+        expect(
+          (await store.loadAll()).single.status,
+          AnimeDownloadPlan.statusDownloading,
+        );
+      });
+
+      test('并发 importNow single-flight：importer 只执行一次', () async {
+        final String savePath = p.join(tempDir.path, 'downloads');
+        Directory(savePath).createSync(recursive: true);
+        await store.save(_plan());
+        qb.torrents = <Map<String, dynamic>>[
+          _torrentJson(
+            state: 'downloading',
+            progress: 0.2,
+            amountLeft: 800,
+            savePath: savePath,
+          ),
+        ];
+        qb.files = <Map<String, dynamic>>[
+          <String, dynamic>{'name': 'Show 01.mkv', 'size': 1, 'progress': 0.2},
+        ];
+        final Completer<void> release = Completer<void>();
+        importerOverride = (AnimeDownloadPlan plan, List<String> videos) async {
+          await release.future;
+          return const AnimeDownloadImportOutcome(collectionId: 42);
+        };
+        final AnimeDownloadService service = buildService();
+        final Future<bool> first = service.importNow(_kHash);
+        final Future<bool> second = service.importNow(_kHash);
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        expect(importCalls, hasLength(1));
+        release.complete();
+        expect(await Future.wait(<Future<bool>>[first, second]), <bool>[
+          true,
+          true,
+        ]);
+        expect(importCalls, hasLength(1));
+      });
+
+      test('early 后暂停/恢复/失败保持入库正交，删除真实取消且不复活', () async {
+        final String savePath = p.join(tempDir.path, 'downloads');
+        Directory(savePath).createSync(recursive: true);
+        await store.save(_plan());
+        qb.files = <Map<String, dynamic>>[
+          <String, dynamic>{'name': 'Show 01.mkv', 'size': 1, 'progress': 0.2},
+        ];
+        qb.torrents = <Map<String, dynamic>>[
+          _torrentJson(
+            state: 'downloading',
+            progress: 0.2,
+            amountLeft: 800,
+            savePath: savePath,
+          ),
+        ];
+        final AnimeDownloadService service = buildService();
+        expect(await service.importNow(_kHash), isTrue);
+
+        qb.torrents = <Map<String, dynamic>>[
+          _torrentJson(
+            state: 'pausedDL',
+            progress: 0.55,
+            amountLeft: 450,
+            savePath: savePath,
+          ),
+        ];
+        await service.tick();
+        AnimeDownloadPlan saved = (await store.loadAll()).single;
+        expect(saved.status, AnimeDownloadPlan.statusDownloading);
+        expect(saved.importedEarly, isTrue);
+        expect(service.downloadProgress.value[_kHash], 0.55);
+
+        qb.torrents = <Map<String, dynamic>>[
+          _torrentJson(
+            state: 'downloading',
+            progress: 0.7,
+            amountLeft: 300,
+            savePath: savePath,
+          ),
+        ];
+        await service.tick();
+        expect(service.downloadProgress.value[_kHash], 0.7);
+        expect(importCalls, hasLength(1));
+
+        qb.torrents = <Map<String, dynamic>>[
+          _torrentJson(
+            state: 'error',
+            progress: 0.7,
+            amountLeft: 300,
+            savePath: savePath,
+          ),
+        ];
+        await service.tick();
+        saved = (await store.loadAll()).single;
+        expect(saved.status, AnimeDownloadPlan.statusFailed);
+        expect(saved.importedEarly, isTrue);
+        expect(saved.failReason, contains('error'));
+
+        expect(await service.deletePlan(_kHash), isTrue);
+        expect(await store.loadAll(), isEmpty);
+        expect(qb.deleteRequests, 1);
+        await service.tick();
+        expect(await store.loadAll(), isEmpty, reason: '晚到 tick 不得复活已删计划');
+      });
+
+      test('删除与 missing-torrent 旧 tick 并发：删除完成后 stale 写不得复活计划', () async {
+        await store.save(_plan(createdAtMs: 1));
+        qb.torrents = <Map<String, dynamic>>[];
+        final Completer<void> infoStarted = Completer<void>();
+        final Completer<void> releaseInfo = Completer<void>();
+        qb.infoRequestStarted = infoStarted;
+        qb.infoResponseGate = releaseInfo.future;
+        final AnimeDownloadService service = buildService();
+
+        final Future<void> staleTick = service.tick();
+        await infoStarted.future;
+        expect(await service.deletePlan(_kHash), isTrue);
+        expect(await store.loadAll(), isEmpty);
+
+        releaseInfo.complete();
+        await staleTick;
+        expect(
+          await store.loadAll(),
+          isEmpty,
+          reason: '超时 missing 分支也必须重读计划并服从 per-plan 串行边界',
+        );
+        expect(qb.deleteRequests, 1);
       });
     });
 
@@ -925,8 +1184,9 @@ void main() {
         await buildService().tick();
         expect(importCalls, isEmpty); // 视频入库未触发
         expect(bookImportCalls, hasLength(1));
-        expect(
-            bookImportCalls.single.$2, <String>[p.join('/dl', 'A Book.epub')]);
+        expect(bookImportCalls.single.$2, <String>[
+          p.join('/dl', 'A Book.epub'),
+        ]);
         final AnimeDownloadPlan saved = (await store.loadAll()).single;
         expect(saved.status, AnimeDownloadPlan.statusImported);
         expect(saved.collectionId, isNull); // 书无合集
@@ -943,20 +1203,24 @@ void main() {
           <String, dynamic>{
             'name': 'Show - 01.mkv',
             'size': 9,
-            'progress': 1.0
+            'progress': 1.0,
           },
           <String, dynamic>{'name': 'Bonus.epub', 'size': 9, 'progress': 1.0},
           <String, dynamic>{'name': 'readme.txt', 'size': 1, 'progress': 1.0},
         ];
         await buildService().tick();
         expect(importCalls, hasLength(1));
-        expect(
-            importCalls.single.$2, <String>[p.join(savePath, 'Show - 01.mkv')]);
+        expect(importCalls.single.$2, <String>[
+          p.join(savePath, 'Show - 01.mkv'),
+        ]);
         expect(bookImportCalls, hasLength(1));
-        expect(bookImportCalls.single.$2,
-            <String>[p.join(savePath, 'Bonus.epub')]);
-        expect((await store.loadAll()).single.status,
-            AnimeDownloadPlan.statusImported);
+        expect(bookImportCalls.single.$2, <String>[
+          p.join(savePath, 'Bonus.epub'),
+        ]);
+        expect(
+          (await store.loadAll()).single.status,
+          AnimeDownloadPlan.statusImported,
+        );
       });
 
       test('book 计划书库回调返回 0 → 标 failed', () async {
@@ -970,8 +1234,10 @@ void main() {
           <String, dynamic>{'name': 'A Book.epub', 'size': 9, 'progress': 1.0},
         ];
         await buildService().tick();
-        expect((await store.loadAll()).single.status,
-            AnimeDownloadPlan.statusFailed);
+        expect(
+          (await store.loadAll()).single.status,
+          AnimeDownloadPlan.statusFailed,
+        );
       });
     });
 
@@ -993,8 +1259,10 @@ void main() {
           ]),
           <String>[p.join('/dl', 'a.epub')],
         );
-        expect(resolveBookAbsolutePaths(info, const <TorrentFileEntry>[]),
-            <String>['/dl/x.epub']);
+        expect(
+          resolveBookAbsolutePaths(info, const <TorrentFileEntry>[]),
+          <String>['/dl/x.epub'],
+        );
       });
     });
   });

--- a/hibiki/test/torrent/nyaa_client_test.dart
+++ b/hibiki/test/torrent/nyaa_client_test.dart
@@ -285,6 +285,50 @@ void main() {
       client.close();
     });
 
+    test('空响应 / 损坏 RSS 抛格式错误；有效空 feed 才是 0 条结果', () async {
+      Future<Object?> searchBody(String body) async {
+        final NyaaClient client = NyaaClient(
+          client: MockClient(
+            (http.Request req) async => http.Response(body, 200),
+          ),
+        );
+        try {
+          return await client.search('frieren');
+        } catch (error) {
+          return error;
+        } finally {
+          client.close();
+        }
+      }
+
+      expect(
+        await searchBody(''),
+        isA<FormatException>().having(
+          (FormatException e) => e.message,
+          'message',
+          contains('empty'),
+        ),
+      );
+      expect(
+        await searchBody('not xml <<<'),
+        isA<FormatException>().having(
+          (FormatException e) => e.message,
+          'message',
+          contains('Invalid Nyaa RSS'),
+        ),
+      );
+      expect(
+        await searchBody(
+          '<rss><channel><title>valid empty</title></channel></rss>',
+        ),
+        isA<List<NyaaTorrent>>().having(
+          (List<NyaaTorrent> items) => items,
+          'items',
+          isEmpty,
+        ),
+      );
+    });
+
     test('UTF-8 无 charset 响应按 UTF-8 解码（日文标题不乱码）', () async {
       // Nyaa 实际返回 UTF-8 字节但常不声明 charset；用 Response.bytes 模拟。
       // 旧实现走 res.body(latin1) 会把「ソ・ラ・ノ・ヲ・ト」变成「Soã»...」。

--- a/hibiki/test/torrent/nyaa_client_test.dart
+++ b/hibiki/test/torrent/nyaa_client_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
@@ -86,8 +87,10 @@ void main() {
       expect(items, hasLength(3));
 
       final NyaaTorrent first = items[0];
-      expect(first.title,
-          '[SubsPlease] Sousou no Frieren - 05 (1080p) [ABCD1234].mkv');
+      expect(
+        first.title,
+        '[SubsPlease] Sousou no Frieren - 05 (1080p) [ABCD1234].mkv',
+      );
       expect(first.torrentUrl, 'https://nyaa.si/download/1234567.torrent');
       expect(first.pageUrl, 'https://nyaa.si/view/1234567');
       expect(first.infoHash, '0123456789abcdef0123456789abcdef01234567');
@@ -159,8 +162,9 @@ void main() {
       expect(
         t.magnet,
         startsWith(
-            'magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567'
-            '&dn=My%20Show%20%5Bx%5D'),
+          'magnet:?xt=urn:btih:0123456789abcdef0123456789abcdef01234567'
+          '&dn=My%20Show%20%5Bx%5D',
+        ),
       );
       expect('&tr='.allMatches(t.magnet), hasLength(5));
       expect(
@@ -228,15 +232,52 @@ void main() {
   });
 
   group('NyaaClient.search', () {
+    Future<Object?> searchResponse(
+      List<int> bytes, {
+      Map<String, String> headers = const <String, String>{},
+    }) async {
+      final NyaaClient client = NyaaClient(
+        client: MockClient(
+          (_) async => http.Response.bytes(bytes, 200, headers: headers),
+        ),
+      );
+      try {
+        return await client.search('show');
+      } catch (error) {
+        return error;
+      } finally {
+        client.close();
+      }
+    }
+
     test('拼出 page=rss&q&c&f 的查询 URL 并解析响应', () async {
       Uri? captured;
       final MockClient mock = MockClient((http.Request req) async {
         captured = req.url;
-        return http.Response(sampleRss, 200);
+        return http.Response(
+          sampleRss
+              .replaceFirst(
+                '<nyaa:seeders>bad</nyaa:seeders>',
+                '<nyaa:seeders>0</nyaa:seeders>',
+              )
+              .replaceFirst(
+                '<nyaa:leechers></nyaa:leechers>',
+                '<nyaa:leechers>0</nyaa:leechers>',
+              )
+              .replaceFirst(
+                '<nyaa:infoHash>aaaa</nyaa:infoHash>',
+                '<nyaa:infoHash>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                    '</nyaa:infoHash>',
+              ),
+          200,
+        );
       });
       final NyaaClient client = NyaaClient(client: mock);
-      final List<NyaaTorrent> items =
-          await client.search('frieren', category: '1_2', filter: '2');
+      final List<NyaaTorrent> items = await client.search(
+        'frieren',
+        category: '1_2',
+        filter: '2',
+      );
       expect(items, hasLength(3));
       expect(captured, isNotNull);
       expect(captured!.host, 'nyaa.si');
@@ -250,25 +291,32 @@ void main() {
       client.close();
     });
 
-    test('默认 category=1_0 / filter=0；非 200 → 抛 ClientException（含状态码）',
-        () async {
-      // 以前吞错返回空列表，真实网络故障（站点被墙/代理未配）会被误报成
-      // 「无结果」；现在必须抛出让调用方展示真实错误。
-      Uri? captured;
-      final MockClient mock = MockClient((http.Request req) async {
-        captured = req.url;
-        return http.Response('server error', 500);
-      });
-      final NyaaClient client = NyaaClient(client: mock);
-      await expectLater(
-        client.search('frieren'),
-        throwsA(isA<http.ClientException>().having(
-            (http.ClientException e) => e.message, 'message', 'HTTP 500')),
-      );
-      expect(captured!.queryParameters['c'], '1_0');
-      expect(captured!.queryParameters['f'], '0');
-      client.close();
-    });
+    test(
+      '默认 category=1_0 / filter=0；非 200 → 抛 ClientException（含状态码）',
+      () async {
+        // 以前吞错返回空列表，真实网络故障（站点被墙/代理未配）会被误报成
+        // 「无结果」；现在必须抛出让调用方展示真实错误。
+        Uri? captured;
+        final MockClient mock = MockClient((http.Request req) async {
+          captured = req.url;
+          return http.Response('server error', 500);
+        });
+        final NyaaClient client = NyaaClient(client: mock);
+        await expectLater(
+          client.search('frieren'),
+          throwsA(
+            isA<http.ClientException>().having(
+              (http.ClientException e) => e.message,
+              'message',
+              'HTTP 500',
+            ),
+          ),
+        );
+        expect(captured!.queryParameters['c'], '1_0');
+        expect(captured!.queryParameters['f'], '0');
+        client.close();
+      },
+    );
 
     test('底层网络异常（如握手失败）原样穿透，不吞成空列表', () async {
       final MockClient mock = MockClient((http.Request req) async {
@@ -277,10 +325,13 @@ void main() {
       final NyaaClient client = NyaaClient(client: mock);
       await expectLater(
         client.search('frieren'),
-        throwsA(isA<http.ClientException>().having(
+        throwsA(
+          isA<http.ClientException>().having(
             (http.ClientException e) => e.message,
             'message',
-            contains('HandshakeException'))),
+            contains('HandshakeException'),
+          ),
+        ),
       );
       client.close();
     });
@@ -311,10 +362,10 @@ void main() {
       );
       expect(
         await searchBody('not xml <<<'),
-        isA<FormatException>().having(
-          (FormatException e) => e.message,
-          'message',
-          contains('Invalid Nyaa RSS'),
+        isA<NyaaFeedFormatException>().having(
+          (NyaaFeedFormatException e) => e.code,
+          'code',
+          NyaaFeedErrorCode.malformedXml,
         ),
       );
       expect(
@@ -356,5 +407,117 @@ void main() {
       expect(items.single.title.contains('ソ・ラ・ノ・ヲ・ト'), isTrue);
       client.close();
     });
+
+    test('严格错误矩阵：编码/XML/RSS结构/命名空间/必需字段稳定可区分', () async {
+      Future<void> expectCode(
+        List<int> bytes,
+        NyaaFeedErrorCode code, {
+        Map<String, String> headers = const <String, String>{},
+      }) async {
+        expect(
+          await searchResponse(bytes, headers: headers),
+          isA<NyaaFeedFormatException>().having(
+            (NyaaFeedFormatException error) => error.code,
+            'code',
+            code,
+          ),
+        );
+      }
+
+      await expectCode(const <int>[], NyaaFeedErrorCode.emptyBody);
+      await expectCode(
+        utf8.encode('<rss><channel/></rss>'),
+        NyaaFeedErrorCode.unsupportedEncoding,
+        headers: const <String, String>{
+          'content-type': 'application/rss+xml; charset=shift_jis',
+        },
+      );
+      await expectCode(
+        utf8.encode(
+          '<?xml version="1.0" encoding="shift_jis"?><rss><channel/></rss>',
+        ),
+        NyaaFeedErrorCode.unsupportedEncoding,
+      );
+      await expectCode(<int>[
+        ...utf8.encode('<rss>'),
+        0xff,
+        ...utf8.encode('</rss>'),
+      ], NyaaFeedErrorCode.invalidUtf8);
+      await expectCode(
+        utf8.encode('<rss><channel>'),
+        NyaaFeedErrorCode.malformedXml,
+      );
+      await expectCode(
+        utf8.encode('<html><body/></html>'),
+        NyaaFeedErrorCode.notRss,
+      );
+      await expectCode(
+        utf8.encode('<rss/>'),
+        NyaaFeedErrorCode.missingStructure,
+      );
+      await expectCode(
+        utf8.encode(
+          '<rss><channel><item><link>x</link><guid>y</guid>'
+          '<n:infoHash xmlns:n="$_nyaaNamespaceForTest">'
+          '${'a' * 40}</n:infoHash></item></channel></rss>',
+        ),
+        NyaaFeedErrorCode.missingField,
+      );
+      await expectCode(
+        utf8.encode(
+          '<rss><channel><item><title>x</title><link>x</link><guid>y</guid>'
+          '<bad:infoHash xmlns:bad="https://invalid.example/ns">'
+          '${'a' * 40}</bad:infoHash></item></channel></rss>',
+        ),
+        NyaaFeedErrorCode.invalidNamespace,
+      );
+    });
+
+    test('真实本地 HTTP：特殊字符 query/category/trusted 与任意前缀 namespace', () async {
+      final HttpServer server = await HttpServer.bind(
+        InternetAddress.loopbackIPv4,
+        0,
+      );
+      addTearDown(() => server.close(force: true));
+      Uri? captured;
+      server.listen((HttpRequest request) async {
+        captured = request.uri;
+        request.response.headers.contentType = ContentType(
+          'application',
+          'rss+xml',
+          charset: 'utf-8',
+        );
+        request.response.write('''
+<?xml version="1.0" encoding="utf-8"?>
+<rss><channel><item>
+  <title>ソラ &amp; 星</title>
+  <link>https://nyaa.si/download/1.torrent</link>
+  <guid>https://nyaa.si/view/1</guid>
+  <alt:infoHash xmlns:alt="$_nyaaNamespaceForTest">${'a' * 40}</alt:infoHash>
+  <alt:trusted xmlns:alt="$_nyaaNamespaceForTest">Yes</alt:trusted>
+</item></channel></rss>''');
+        await request.response.close();
+      });
+
+      final NyaaClient client = NyaaClient(
+        baseUrl: 'http://${server.address.address}:${server.port}',
+      );
+      addTearDown(client.close);
+      final List<NyaaTorrent> items = await client.search(
+        'ソラ & 星/空',
+        category: '1_4 special',
+        filter: '2',
+      );
+      expect(items.single.title, 'ソラ & 星');
+      expect(items.single.trusted, isTrue);
+      expect(captured!.queryParameters, <String, String>{
+        'page': 'rss',
+        'q': 'ソラ & 星/空',
+        'c': '1_4 special',
+        'f': '2',
+      });
+    });
   });
 }
+
+const String _nyaaNamespaceForTest = 'https://nyaa.si/xmlns/nyaa';


### PR DESCRIPTION
## What changed

- Distinguish a valid empty Nyaa RSS result from an empty, malformed, or non-RSS response. Real zero-result states now show the actual query and filters so users can tell whether the title/category/Trusted filter caused it.
- Keep a task in `downloading` after “play while downloading” imports it early. Progress continues to update, the row shows “已入库 · 下载继续”, and the task only becomes completed when qBittorrent reports real completion.
- Add per-task settings before import: edit the library name and, for generic magnets, choose Auto / Video / Book routing. Move relocate/delete into the overflow menu.
- Remove the redundant online catalog button from the Download page header.
- Add BUG-1249 / BUG-1250 records, regenerate i18n for all locales, and bump the build number to `1.3.1+1002`.

## Root causes

- `NyaaClient.search` reused a tolerant parser that collapsed empty or broken responses into `[]`, making service failures indistinguishable from a legitimate zero-result search.
- `importNow()` reused the final completion path and immediately persisted `statusImported`; the polling loop only tracks `statusDownloading`, so the progress row disappeared even though the torrent was still downloading.

## Validation

- `flutter analyze --no-pub` — passed (`No issues found`).
- `dart tool/bug.dart check` — passed (1196 records, unique IDs, index synchronized).
- i18n sources synchronized and `strings.g.dart` regenerated.
- `git diff --check` / staged diff check — passed.
- Targeted Flutter tests were attempted but ran 0 tests because the sqlite3 Windows native asset download from GitHub timed out. This is an environment/network dependency failure, not a test assertion failure.
- Per request, no compile/package acceptance wait and no real qBittorrent/Nyaa device E2E claim.