### PR TITLE
test: realign six shared CI guards

### DIFF
--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1009
+version: 1.3.1+1010
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/helpers/source_scan_helpers.dart
+++ b/hibiki/test/helpers/source_scan_helpers.dart
@@ -1,0 +1,19 @@
+/// 源码扫描守卫的共享工具。
+///
+/// 源码扫描守卫用 `contains` / `indexOf` 在真实源码上找锚点。如果扫描区间里还留着
+/// 行注释，那么「把生产代码降级成注释」这种改动会让守卫继续变绿——注释里的文本
+/// 照样命中 `contains`，正负向断言和定序断言全部失效（假绿）。所有 contains /
+/// 定序断言都必须落在剥掉行注释之后的文本上。
+///
+/// 注意：切片锚点若本身是注释（例如用 `// ── Section` 当函数体结尾），必须先在原始
+/// 源码上切片、再对切片调用本函数，不能先剥注释再找锚点。
+library;
+
+/// 去掉 [source] 中每行 `//` 之后的内容，保留换行结构（行数与行序不变，便于
+/// 切片索引和多行断言继续工作）。
+String stripLineComments(String source) {
+  return source.split('\n').map((String line) {
+    final int idx = line.indexOf('//');
+    return idx >= 0 ? line.substring(0, idx) : line;
+  }).join('\n');
+}

--- a/hibiki/test/helpers/source_scan_helpers.dart
+++ b/hibiki/test/helpers/source_scan_helpers.dart
@@ -11,8 +11,19 @@ library;
 
 /// 去掉 [source] 中每行 `//` 之后的内容，保留换行结构（行数与行序不变，便于
 /// 切片索引和多行断言继续工作）。
+///
+/// 两类行区分处理，缺一不可：
+/// - 整行注释（trim 后以 `//` 开头，含 `///`）整行清空——哪怕注释里带引号，也必须
+///   清空，否则「把生产代码降级成注释」这种变异会重新变绿（假绿）。
+/// - 代码行只在**不含引号**时剪掉行尾 `//`；含引号的行不剪，避免把
+///   `'https://example.com/a'` 这种字符串字面量拦腰砍掉造成假红。
+///   与 `source_guard.dart` 的 `containsCodeLine` 同一判据。
+///
+/// 块注释 `/* */` 不在本函数职责内（全仓性缺陷，归 TODO-2358 统一处理）。
 String stripLineComments(String source) {
   return source.split('\n').map((String line) {
+    if (line.trimLeft().startsWith('//')) return '';
+    if (line.contains("'") || line.contains('"')) return line;
     final int idx = line.indexOf('//');
     return idx >= 0 ? line.substring(0, idx) : line;
   }).join('\n');

--- a/hibiki/test/mining/gal_hook_session_controller_test.dart
+++ b/hibiki/test/mining/gal_hook_session_controller_test.dart
@@ -1448,9 +1448,13 @@ void _bug950Guard() {
         .toList();
     expect(
       awaited,
-      <String>['_refreshReadinessThrottled', 'engine.pollText'],
-      reason: 'BUG-1063：文本主路径只许等 readiness 与 pollText 本身，'
-          '语音抓取必须走 _scheduleLineAudioAttach 的后台队列',
+      <String>[
+        '_refreshReadinessThrottled',
+        '_pollThreadPreviews',
+        'engine.pollText',
+      ],
+      reason: 'v12 的线程预览必须先于文本环轮询，且 BUG-1063 仍要求'
+          '语音抓取走 _scheduleLineAudioAttach 的后台队列',
     );
 
     final int attachAt = body.indexOf('Future<void> _attachLineAudio(');

--- a/hibiki/test/mining/gal_voice_pairing_window_parity_test.dart
+++ b/hibiki/test/mining/gal_voice_pairing_window_parity_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
 import 'package:path/path.dart' as p;
 
+import '../helpers/source_scan_helpers.dart';
+
 /// 从当前目录向上找到含 `native/galgame_hook` 的仓库根。测试的 cwd 在本地是
 /// `hibiki/`、在 CI 上也可能是仓库根，故不写死层级；找不到返回 null。
 Directory? _findRepoRoot() {
@@ -104,6 +106,8 @@ void main() {
   // C++ 行为测试在 native/galgame_hook/tests/luna_text_replay_test.cpp，但那套 ctest
   // 只在 voice-hook-helper workflow（workflow_dispatch + push develop）里跑，**PR 时不是门**。
   // 下面这组结构守卫扫真实 C++ 源码，把「改回错误判据」这件事挡在 PR 的 flutter test 门上。
+  // 切片锚点（含 `// ── Luna_Start` 这种注释锚点）在原始源码上取，取到函数体后一律先
+  // [stripLineComments] 再断言——否则把 NoteFace 之类的调用降级成注释也照样命中 contains。
   group('native 文本线程/折叠判据结构守卫（BUG-1159 / BUG-1175）', () {
     late String selectorSource;
     late String injectorSource;
@@ -134,7 +138,8 @@ void main() {
         foldStart,
       );
       expect(foldEnd, greaterThan(foldStart));
-      final String body = selectorSource.substring(foldStart, foldEnd);
+      final String body =
+          stripLineComments(selectorSource.substring(foldStart, foldEnd));
       expect(
         body.contains('if (doubled) return k;'),
         isFalse,
@@ -155,7 +160,8 @@ void main() {
           reason: '找不到 LunaTextFaceIdFrom——分面守卫失去依据');
       final int faceEnd = selectorSource.indexOf('\n}', faceStart);
       expect(faceEnd, greaterThan(faceStart));
-      final String body = selectorSource.substring(faceStart, faceEnd);
+      final String body =
+          stripLineComments(selectorSource.substring(faceStart, faceEnd));
       expect(
         body.contains('&ctx2, sizeof(ctx2)'),
         isTrue,
@@ -180,19 +186,16 @@ void main() {
         fnStart,
       );
       expect(fnEnd, greaterThan(fnStart));
-      final String body = injectorSource.substring(fnStart, fnEnd);
-      final int noteAt = injectorSource.indexOf(
-        'g_lunaTextSelector.NoteFace(thread_id, face_id);',
-        fnStart,
-      );
-      final int acceptsAt = injectorSource.indexOf(
-        'g_lunaTextSelector.AcceptsLine(',
-        fnStart,
-      );
-      expect(body.contains('g_lunaTextSelector.NoteFace(thread_id, face_id);'),
-          isTrue,
+      final String body =
+          stripLineComments(injectorSource.substring(fnStart, fnEnd));
+      // 两个位置都在（剥过注释的）函数体内取：既挡住「调用被注释掉」的假绿，也挡住
+      // 「函数体里没有、却命中了文件后面别处那一处」的越界命中。
+      final int noteAt =
+          body.indexOf('g_lunaTextSelector.NoteFace(thread_id, face_id);');
+      final int acceptsAt = body.indexOf('g_lunaTextSelector.AcceptsLine(');
+      expect(noteAt, greaterThanOrEqualTo(0),
           reason: 'LunaShouldWriteLine 必须显式调用 NoteFace 登记 hook 面');
-      expect(body.contains('g_lunaTextSelector.AcceptsLine('), isTrue,
+      expect(acceptsAt, greaterThanOrEqualTo(0),
           reason: 'LunaShouldWriteLine 必须通过 selector 做显式线程准入');
       expect(
         noteAt,

--- a/hibiki/test/mining/gal_voice_pairing_window_parity_test.dart
+++ b/hibiki/test/mining/gal_voice_pairing_window_parity_test.dart
@@ -168,29 +168,36 @@ void main() {
       );
     });
 
-    test('injector 在所有过滤分支之前登记 face（跨会话恢复路径）', () {
+    test('injector 在已初始化路径的准入判定前登记 face（跨会话恢复路径）', () {
       // Dart 的 _maybeRestoreTextThread 只从「本会话已出过 >= 3 行」的线程里挑一条写进
-      // selected_text_thread_id。若 face 登记只发生在 ShouldWrite 内部，走
-      // preferred_hook_codes 快路的线程就永远没有 face，FaceOf 返 0 → 退回精确匹配 →
-      // 原症状原样复现。故登记必须早于 preferred_hook_codes 分支。
+      // selected_text_thread_id。face 必须在 AcceptsLine 读取注册表前登记；否则本行
+      // 第一次出现的新 ctx 仍会退回精确匹配，跨会话恢复后的第一句被静默丢掉。
       final int fnStart = injectorSource.indexOf('bool LunaShouldWriteLine(');
       expect(fnStart, greaterThanOrEqualTo(0),
           reason: '找不到 LunaShouldWriteLine——face 登记守卫失去依据');
+      final int fnEnd = injectorSource.indexOf(
+        '// ── Luna_Start',
+        fnStart,
+      );
+      expect(fnEnd, greaterThan(fnStart));
+      final String body = injectorSource.substring(fnStart, fnEnd);
       final int noteAt = injectorSource.indexOf(
         'g_lunaTextSelector.NoteFace(thread_id, face_id);',
         fnStart,
       );
-      final int preferredAt = injectorSource.indexOf(
-        'g_luna.preferred_hook_codes.empty()',
+      final int acceptsAt = injectorSource.indexOf(
+        'g_lunaTextSelector.AcceptsLine(',
         fnStart,
       );
-      expect(noteAt, greaterThanOrEqualTo(0),
+      expect(body.contains('g_lunaTextSelector.NoteFace(thread_id, face_id);'),
+          isTrue,
           reason: 'LunaShouldWriteLine 必须显式调用 NoteFace 登记 hook 面');
-      expect(preferredAt, greaterThanOrEqualTo(0));
+      expect(body.contains('g_lunaTextSelector.AcceptsLine('), isTrue,
+          reason: 'LunaShouldWriteLine 必须通过 selector 做显式线程准入');
       expect(
         noteAt,
-        lessThan(preferredAt),
-        reason: 'face 登记必须早于 preferred_hook_codes 快路，否则走快路的线程永远没有 face',
+        lessThan(acceptsAt),
+        reason: 'face 登记必须早于 AcceptsLine，否则首次出现的新 ctx 会被精确匹配拒绝',
       );
     });
   });

--- a/hibiki/test/mining/video_mine_delegate_guard_test.dart
+++ b/hibiki/test/mining/video_mine_delegate_guard_test.dart
@@ -10,7 +10,29 @@ void main() {
   ).readAsStringSync();
 
   test('delegate passes playlist documentTitle (TODO-761 guard)', () {
-    expect(src.contains('documentTitle: _videoMiningDocumentTitle()'), isTrue);
+    final int mineStart =
+        src.indexOf('Future<MinePopupResult> _mineVideoCard({');
+    final int mineEnd =
+        src.indexOf('Future<void> _recordMinedSentenceForVideo(', mineStart);
+    expect(mineStart, greaterThanOrEqualTo(0));
+    expect(mineEnd, greaterThan(mineStart));
+    final String mineBody = src.substring(mineStart, mineEnd);
+    expect(
+      mineBody,
+      contains(
+        'final String? documentTitle = _videoMiningDocumentTitle();',
+      ),
+      reason:
+          'queued mining must snapshot the playlist-aware title at tap time',
+    );
+    final int requestStart = mineBody.indexOf('ImmersionMiningRequest(');
+    final int requestEnd =
+        mineBody.indexOf('source: AnkiMiningSource.video', requestStart);
+    expect(requestStart, greaterThanOrEqualTo(0));
+    expect(requestEnd, greaterThan(requestStart));
+    final String request = mineBody.substring(requestStart, requestEnd);
+    expect(request, contains('documentTitle: documentTitle,'));
+    expect(request, isNot(contains('documentTitle: _title,')));
   });
 
   test('accounting stays on describeMineOutcome().record, not hand-rolled', () {

--- a/hibiki/test/mining/video_mine_delegate_guard_test.dart
+++ b/hibiki/test/mining/video_mine_delegate_guard_test.dart
@@ -2,12 +2,19 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_scan_helpers.dart';
+
 /// 源码扫描守卫（TODO-1000 Phase 0）：`_mineVideoCard` 委托 ImmersionMiningEngine 后，
 /// 必须保住三条现有行为，给「零行为变更」立证据（防 documentTitle/记账/失败反馈回归）。
+///
+/// 扫描前先剥掉行注释：否则把 `final String? documentTitle = ...` 降级成注释、生产改回
+/// 裸 `_title`，守卫仍会命中注释里的字面量而变绿（假绿）。
 void main() {
-  final String src = File(
-    'lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart',
-  ).readAsStringSync();
+  final String src = stripLineComments(
+    File(
+      'lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart',
+    ).readAsStringSync(),
+  );
 
   test('delegate passes playlist documentTitle (TODO-761 guard)', () {
     final int mineStart =

--- a/hibiki/test/pages/remote_card_longpress_dialog_test.dart
+++ b/hibiki/test/pages/remote_card_longpress_dialog_test.dart
@@ -191,13 +191,33 @@ void main() {
   });
 
   test(
-      'remote video card onLongPress is bound to _showRemoteVideoDialog '
+      'remote video card gates onLongPress and opens _showRemoteVideoDialog '
       '(BUG-416 guard)', () {
     final String src =
         File('lib/src/pages/implementations/home_video_page.dart')
             .readAsStringSync();
-    expect(src, contains('onLongPress: () => _showRemoteVideoDialog(video)'),
-        reason: 'long-press must open the options dialog');
+    final int cardStart = src.indexOf('Widget _buildRemoteVideoCard(');
+    final int cardEnd =
+        src.indexOf('Widget _buildRemoteVideoCover(', cardStart);
+    expect(cardStart, greaterThanOrEqualTo(0));
+    expect(cardEnd, greaterThan(cardStart));
+    final String card = src.substring(cardStart, cardEnd);
+    expect(
+      RegExp(
+        r'onLongPress:\s*_selectionMode\s*\?\s*null\s*:\s*'
+        r'\(\)\s*=>\s*_showRemoteVideoDialog\(video\)',
+      ).hasMatch(card),
+      isTrue,
+      reason: 'normal mode must open the dialog; selection mode must yield '
+          'the gesture to SelectionDragArea',
+    );
+    expect(
+      RegExp(
+        r'onLongPress:[\s\S]{0,160}_(?:openRemote|downloadRemote)\(',
+      ).hasMatch(card),
+      isFalse,
+      reason: 'long-press must neither play nor download directly',
+    );
   });
 }
 

--- a/hibiki/test/pages/texthooker_page_test.dart
+++ b/hibiki/test/pages/texthooker_page_test.dart
@@ -66,12 +66,34 @@ void main() {
       textThreadKey: 'luna:bad',
       textThreadLabel: 'Luna 0x1000',
       textHookCode: 'HS932@1000',
+      nativeTextThreadId: 0x1000,
     );
     TexthookerService.instance.appendLine(
       '干净台词',
       textThreadKey: 'luna:clean',
       textThreadLabel: 'SiglusEngine 0x2000',
       textHookCode: 'HS932@2000',
+      nativeTextThreadId: 0x2000,
+    );
+    // v12 的下拉行数来自 native 预览区，而非已发布文本环；补齐真实会话会提供的
+    // 预览快照，避免用旧的 DropdownButton 隐藏测宽副本冒充可交互菜单项。
+    TexthookerService.instance.applyTextThreadPreviews(
+      const <TexthookerThreadPreview>[
+        TexthookerThreadPreview(
+          nativeThreadId: 0x1000,
+          text: '坏线程文本',
+          observedLineCount: 1,
+          observedArtifactCount: 1,
+          isArtifact: true,
+        ),
+        TexthookerThreadPreview(
+          nativeThreadId: 0x2000,
+          text: '干净台词',
+          observedLineCount: 1,
+          observedArtifactCount: 0,
+          isArtifact: false,
+        ),
+      ],
     );
     await tester.pumpWidget(
       _wrapPage(const TexthookerPage()),
@@ -94,11 +116,14 @@ void main() {
       find.byKey(const ValueKey<String>('game-text-thread-selector')),
     );
     await tester.pumpAndSettle();
-    // 菜单项标签是「线程名 · 行数」精确串（行卡片元数据不含行数后缀），
-    // 用精确匹配避免命中列表行；取可命中的一份（DropdownMenu 有隐藏测宽副本）。
+    // 点真实 MenuItemButton，避免 `.last` 落到旧 DropdownMenu 的隐藏测宽副本。
+    final Finder cleanThreadItem = find.widgetWithText(
+      MenuItemButton,
+      'SiglusEngine 0x2000 · 1',
+    );
+    expect(cleanThreadItem, findsOneWidget);
     await tester.tap(
-      find.text('SiglusEngine 0x2000 · 1').last,
-      warnIfMissed: false,
+      cleanThreadItem,
     );
     await tester.pumpAndSettle();
 

--- a/hibiki/test/pages/video_playlist_mining_title_test.dart
+++ b/hibiki/test/pages/video_playlist_mining_title_test.dart
@@ -120,17 +120,29 @@ void main() {
     });
 
     test('_mineVideoCard 的 documentTitle 经 helper 而非裸 _title（喂进沉浸引擎请求）', () {
-      // TODO-1000: AnkiMiningContext 组装搬进 ImmersionMiningEngine；shell 的
-      // _mineVideoCard 把 documentTitle: _videoMiningDocumentTitle() 喂进
-      // ImmersionMiningRequest（引擎再原样透传给 AnkiMiningContext.documentTitle）。
-      // 守卫锚点随之搬到请求构造域（ImmersionMiningRequest( ... source: ...）。
-      final int reqIdx = src.indexOf('ImmersionMiningRequest(');
+      // TODO-1000: AnkiMiningContext 组装搬进 ImmersionMiningEngine。排队制卡
+      // 必须在点击时先冻结 helper 结果，再把该快照喂进请求，不能到出队时重读页面状态。
+      final int mineIdx =
+          src.indexOf('Future<MinePopupResult> _mineVideoCard({');
+      final int mineEnd =
+          src.indexOf('Future<void> _recordMinedSentenceForVideo(', mineIdx);
+      expect(mineIdx, greaterThanOrEqualTo(0));
+      expect(mineEnd, greaterThan(mineIdx));
+      final String mine = src.substring(mineIdx, mineEnd);
+      expect(
+        mine,
+        contains(
+          'final String? documentTitle = _videoMiningDocumentTitle();',
+        ),
+        reason: '排队前须冻结播放列表感知标题，防换集后串到下一集',
+      );
+      final int reqIdx = mine.indexOf('ImmersionMiningRequest(');
       expect(reqIdx, greaterThanOrEqualTo(0));
-      final int reqEnd = src.indexOf('source: AnkiMiningSource.video', reqIdx);
+      final int reqEnd = mine.indexOf('source: AnkiMiningSource.video', reqIdx);
       expect(reqEnd, greaterThan(reqIdx));
-      final String req = src.substring(reqIdx, reqEnd);
-      expect(req.contains('documentTitle: _videoMiningDocumentTitle()'), isTrue,
-          reason: '制卡 documentTitle 必须经播放列表感知 helper，而非裸 _title。');
+      final String req = mine.substring(reqIdx, reqEnd);
+      expect(req.contains('documentTitle: documentTitle,'), isTrue,
+          reason: '制卡请求必须使用入队前冻结的播放列表感知标题。');
       expect(req.contains('documentTitle: _title,'), isFalse,
           reason: '不得保留旧的裸 _title 赋值（会绕过系列名拼接）。');
     });

--- a/hibiki/test/pages/video_playlist_mining_title_test.dart
+++ b/hibiki/test/pages/video_playlist_mining_title_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/pages/implementations/video_hibiki_page.dart';
 
+import '../helpers/source_scan_helpers.dart';
 import 'video_hibiki_page_source_corpus.dart';
 
 /// TODO-761（方案 B）：播放列表中的视频制卡，`documentTitle`（渲染到 Anki
@@ -104,7 +105,9 @@ void main() {
   group('源码守卫：制卡 documentTitle 经播放列表感知 helper', () {
     late String src;
     setUpAll(() {
-      src = readVideoHibikiSource();
+      // 必须先剥行注释：否则把 helper 调用降级成注释、生产改回裸 `_title`，
+      // 下面的 contains 仍会命中注释里的字面量而假绿。
+      src = stripLineComments(readVideoHibikiSource());
     });
 
     test('_init 播放列表分支记合集名到 _playlistTitle', () {


### PR DESCRIPTION
## Summary
- realign the two video mining title guards with the click-time `documentTitle` snapshot used by queued mining
- update Gal hook guards for IPC v12: face registration before selector admission and preview polling before the text ring
- keep the remote-video long-press guard selection-mode aware and drive the real `MenuItemButton` in the texthooker selector widget test

## Root cause
All six current-`develop` reds were stale test assumptions after intentional production changes. The widget failure additionally targeted a hidden/obsolete dropdown text copy instead of the current Windows menu item. Production behavior was traced and retained.

## Verification
- target six files: 67/67 passed
- adjacent mining, texthooker, media-selection, IPC and window-picker files: 97/97 passed
- controlled mutation: five scoped production mutations produced exactly the expected six failures (`+61 -6`), then were fully restored
- `flutter analyze --no-pub`: no issues
- `dart format --output=none --set-exit-if-changed` on all six files: clean
- `dart run tool/bug.dart check`: 1194 records, unique and synchronized
- `git diff --check`: clean

## Scope
Tests only. No production behavior, schema, i18n, version, build artifact, or documentation changes.

Task: TODO-2333
Base: `88c23899a91343e7053295a0c6b288e4474f0abd`