### PR TITLE
fix(sync): 给每轮同步补上身份与结局，消除「进度条只有线没有字」（BUG-1260）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,7 +29,7 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1206 条。点号进各自文件。
+> 共 1207 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
@@ -38,6 +38,7 @@
 | [BUG-1277](bugs/BUG-1277-reader-navigation-after-dispose.md) | ✅ | ✅ | 有声书跨章等待后触发已销毁 State 重绘 |
 | [BUG-1276](bugs/BUG-1276-dashboard-heatmap-dark-contrast.md) | ✅ | ✅ | 黑色主题下学习活动热力图空周融进背景 |
 | [BUG-1270](bugs/BUG-1270-youtube-live-subtitle-seek-duplicate.md) | ✅ | ✅ | YouTube 实时字幕回跳后重复且累积成长段 |
+| [BUG-1260](bugs/BUG-1260-sync-progress-blank-and-silent-noop.md) | ✅ | ✅ | 同步进度条只有线没有字 + 零通道空转静默收尾 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/bugs/BUG-1260-sync-progress-blank-and-silent-noop.md
+++ b/docs/bugs/BUG-1260-sync-progress-blank-and-silent-noop.md
@@ -1,0 +1,29 @@
+## BUG-1260 · 同步进度条只有线没有字 + 零通道空转静默收尾
+- **报告**：2026-07-31（用户：书架页顶部那条同步进度条什么文字都没有，「是同步还是没同步」）
+- **真实性**：✅ 真 bug。截图那条线是 `SyncProgressBanner`（`hibiki/lib/src/sync/sync_progress_banner.dart:22` 的 `if (!syncing) return const SizedBox.shrink()` 保证只在 `syncInProgress == true` 时渲染），所以**确实有同步在飞**；但文字行挂在 `if (p != null)` 上（同文件 `:31`），`syncProgress` 为 null 时整行消失，只剩一条不确定进度条。
+
+  根因是状态模型缺一层，不是 UI 忘了画。`syncInProgress` 是裸 bool，`syncProgress` 只在编排器真进入某个阶段后才有值，于是三种完全不同的现实在界面上**同形**：
+
+  | 现实 | 以前的界面 |
+  |---|---|
+  | 合集 / 单本两条**天生没有阶段结构**的轻量路径在跑 | 一条线，零文字 |
+  | 全量 sweep 还停在第一个阶段 tick 之前的准备段（等互斥锁 → 读自动同步开关 → 冷却判断 → `restoreAuth`/`isAuthenticated` 走网络） | 一条线，零文字 |
+  | 所有通道 `isAuthenticated` 为 false 被 `continue` 跳过 —— **什么也没同步的纯空转** | 一条线，零文字，然后静默消失 |
+
+  具体位置（修复前的 `hibiki/lib/src/sync/sync_auto_trigger.dart`）：四条路径都置 `syncInProgress.value = true`（`:289` 开机自动 sweep / `:385` 手动全量 / `:503` 合集轻量 / `:561` 单本），但只有前两条传 `onProgress` 上报阶段（`:318`、`:410`）；后两条从头到尾没有任何阶段回调。通道跳过点在 `:512`（合集）与 `:588`（单本），`_runSyncChannel` 的鉴权返回 null 在 `:190`。三处跳过都是静默 `continue`，跑完不留任何痕迹。
+
+  顺带暴露的第二个缺陷：`_runCollectionsSync` 与 `_runAutoSync` 的 finally **漏清 `syncProgress`**（只有另两条路径清）。全量 sweep 结束时若还有别的同步在飞就不清，而那两条自己也不清，于是上一轮的阶段文字会残留到下一轮开头闪一下。四份手写的 notifier 维护正是这个不一致的来源。
+
+- **[x] ① 已修复** — 补上缺失的那一层数据，而不是给进度条加特例分支：
+  - 新增 `hibiki/lib/src/sync/sync_activity.dart`：`SyncActivityKind`（fullSweep / collections / singleBook）+ `SyncActivity`（带单本书名）+ `SyncOutcomeReason`（completed / noChannels / nothingToSync / autoDisabled / cooledDown / failed）+ `SyncRunOutcome`。每轮同步**先声明自己是谁，结束时必须留下结局**。
+  - 四处手写的 `_activeSyncs++` / notifier 赋值 / finally 复位收敛成 `_beginSyncActivity` / `_endSyncActivity` 一对（`sync_auto_trigger.dart`），清理逻辑只剩一处——顺带修掉上面那个漏清 `syncProgress` 的不一致。
+  - 每条路径统计实跑通道数 `channelsRun`，零通道 → `noChannels`；自动同步关闭 / 冷却跳过 / 书已不在库 各有独立 reason，不再静默收尾。
+  - `SyncProgressBanner` 文字行两级取值：有阶段 tick 用 `syncProgressLine`，否则退化到 `syncActivityLine`；同步中不再可能出现零文字。设置页「立即同步」行再加第三级：空闲时显示上一轮的 `syncOutcomeLine`（尤其「没有可用的同步通道」＝上轮其实什么都没同步）。
+  - 新增 10 个 i18n key（走 `hibiki/tool/i18n_sync.dart --add`，17 语言）。
+  - 提交 `5ce8cfdc4`。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/sync_activity_visibility_test.dart`（14 例）：
+  - 文案层：三种身份 / 六种结局两两不同且非空（断言语言无关信号，不绑措辞）；单本带书名/空书名/无书名三分支；**「跑完了」与「一条通道都没跑起来」文案必须不同**（本 bug 的核心）。
+  - widget 层：同步中无阶段 tick（轻量路径 / 准备段）时 banner **仍有文字**；有 tick 时阶段行优先且进度确定；无同步时零高度。
+  - 源码扫描守卫：`_beginSyncActivity(` / `_endSyncActivity(` 各恰好 5 处（1 定义 + 4 路径），`syncInProgress.value = true` / `_activeSyncs++` / `_activeSyncs--` / `if (_activeSyncs == 0)` 各恰好 1 处 —— 新增第五条同步路径若忘记登记身份会直接红。
+  - **变异实测**：把合集路径改回手写 notifier → 守卫红 2 条；把 banner 文字行改回 `p != null ? ... : null` → widget 测试红 2 条；均已还原并复验全绿。
+- **备注**：`SyncOutcomeReason.nothingToSync` 与 `noChannels` 刻意分开——一个是「连不上」，一个是「没东西可传」，混成一个词就是让状态撒谎。本次未改任何同步链路行为，只补状态与显示；用户原始现象（书架页那条线）属于上表第 1 或第 2 种，第 3 种（真空转）现在也能在设置页「立即同步」行读到。

--- a/docs/bugs/BUG-1260-sync-progress-blank-and-silent-noop.md
+++ b/docs/bugs/BUG-1260-sync-progress-blank-and-silent-noop.md
@@ -20,10 +20,12 @@
   - 每条路径统计实跑通道数 `channelsRun`，零通道 → `noChannels`；自动同步关闭 / 冷却跳过 / 书已不在库 各有独立 reason，不再静默收尾。
   - `SyncProgressBanner` 文字行两级取值：有阶段 tick 用 `syncProgressLine`，否则退化到 `syncActivityLine`；同步中不再可能出现零文字。设置页「立即同步」行再加第三级：空闲时显示上一轮的 `syncOutcomeLine`（尤其「没有可用的同步通道」＝上轮其实什么都没同步）。
   - 新增 10 个 i18n key（走 `hibiki/tool/i18n_sync.dart --add`，17 语言）。
-  - 提交 `5ce8cfdc4`。
-- **[x] ② 已加自动化测试** — `hibiki/test/sync/sync_activity_visibility_test.dart`（14 例）：
+  - 设置页「立即同步」的空闲副标题只认 `SyncActivityKind.fullSweep` 的结局：那一行讲的是「立即同步」这件事，拿后台单本 / 合集轻量同步的结局来填会答非所问。进行中的两段不做此过滤——它们回答的是「现在有没有东西在跑」，任何同步都算数（BUG-101 的教训）。
+  - 提交 `5ce8cfdc4`、`b95dd88c9`。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/sync_activity_visibility_test.dart`（15 例）：
   - 文案层：三种身份 / 六种结局两两不同且非空（断言语言无关信号，不绑措辞）；单本带书名/空书名/无书名三分支；**「跑完了」与「一条通道都没跑起来」文案必须不同**（本 bug 的核心）。
   - widget 层：同步中无阶段 tick（轻量路径 / 准备段）时 banner **仍有文字**；有 tick 时阶段行优先且进度确定；无同步时零高度。
   - 源码扫描守卫：`_beginSyncActivity(` / `_endSyncActivity(` 各恰好 5 处（1 定义 + 4 路径），`syncInProgress.value = true` / `_activeSyncs++` / `_activeSyncs--` / `if (_activeSyncs == 0)` 各恰好 1 处 —— 新增第五条同步路径若忘记登记身份会直接红。
   - **变异实测**：把合集路径改回手写 notifier → 守卫红 2 条；把 banner 文字行改回 `p != null ? ... : null` → widget 测试红 2 条；均已还原并复验全绿。
+  - 全量 `test/sync`（1815 例）经 `flutter_test_failures.dart` 复跑：唯一失败是 `hibiki_library_host_service_books_test.dart` 的 `PathAccessException`（Windows 并发临时目录删除撞文件锁，errno 32），单独重跑该文件 26 例全过 → 既有环境 flaky，与本次改动无关（本次未碰 host service / book export）。
 - **备注**：`SyncOutcomeReason.nothingToSync` 与 `noChannels` 刻意分开——一个是「连不上」，一个是「没东西可传」，混成一个词就是让状态撒谎。本次未改任何同步链路行为，只补状态与显示；用户原始现象（书架页那条线）属于上表第 1 或第 2 种，第 3 种（真空转）现在也能在设置页「立即同步」行读到。

--- a/docs/bugs/BUG-1260-sync-progress-blank-and-silent-noop.md
+++ b/docs/bugs/BUG-1260-sync-progress-blank-and-silent-noop.md
@@ -21,7 +21,7 @@
   - `SyncProgressBanner` 文字行两级取值：有阶段 tick 用 `syncProgressLine`，否则退化到 `syncActivityLine`；同步中不再可能出现零文字。设置页「立即同步」行再加第三级：空闲时显示上一轮的 `syncOutcomeLine`（尤其「没有可用的同步通道」＝上轮其实什么都没同步）。
   - 新增 10 个 i18n key（走 `hibiki/tool/i18n_sync.dart --add`，17 语言）。
   - 设置页「立即同步」的空闲副标题只认 `SyncActivityKind.fullSweep` 的结局：那一行讲的是「立即同步」这件事，拿后台单本 / 合集轻量同步的结局来填会答非所问。进行中的两段不做此过滤——它们回答的是「现在有没有东西在跑」，任何同步都算数（BUG-101 的教训）。
-  - 提交 `5ce8cfdc4`、`b95dd88c9`。
+  - 提交 `5ce8cfdc4`、`74f0ff4cc`。
 - **[x] ② 已加自动化测试** — `hibiki/test/sync/sync_activity_visibility_test.dart`（15 例）：
   - 文案层：三种身份 / 六种结局两两不同且非空（断言语言无关信号，不绑措辞）；单本带书名/空书名/无书名三分支；**「跑完了」与「一条通道都没跑起来」文案必须不同**（本 bug 的核心）。
   - widget 层：同步中无阶段 tick（轻量路径 / 准备段）时 banner **仍有文字**；有 tick 时阶段行优先且进度确定；无同步时零高度。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 47192 (2776 per locale)
 ///
-/// Built on 2026-07-31 at 04:34 UTC
+/// Built on 2026-07-31 at 10:14 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 47022 (2766 per locale)
+/// Strings: 47192 (2776 per locale)
 ///
-/// Built on 2026-07-29 at 08:08 UTC
+/// Built on 2026-07-31 at 04:34 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3718,6 +3718,19 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get selection_web_search => 'Search the web';
   String get selection_web_search_unavailable => 'No app can search the web.';
   String get selection_share_failed => 'Could not open the share sheet.';
+  String get sync_progress_preparing => 'Preparing sync';
+  String get sync_progress_collections => 'Syncing collections';
+  String get sync_progress_book => 'Syncing book';
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -10050,6 +10063,29 @@ class _StringsAr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -16450,6 +16486,29 @@ class _StringsDe extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -22866,6 +22925,29 @@ class _StringsEs extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -29293,6 +29375,29 @@ class _StringsFr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -35649,6 +35754,29 @@ class _StringsId extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -42051,6 +42179,29 @@ class _StringsIt extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -48270,6 +48421,29 @@ class _StringsJa extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -54491,6 +54665,29 @@ class _StringsKo extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -60873,6 +61070,29 @@ class _StringsNl extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -67268,6 +67488,29 @@ class _StringsPtBr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -73647,6 +73890,29 @@ class _StringsRu extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -79974,6 +80240,29 @@ class _StringsTh extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -86333,6 +86622,29 @@ class _StringsTr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -92677,6 +92989,29 @@ class _StringsVi extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 // Path: <root>
@@ -98572,6 +98907,27 @@ class _StringsZhCn extends _StringsEn {
   String get selection_web_search_unavailable => '没有可用的网页搜索应用。';
   @override
   String get selection_share_failed => '无法打开分享面板。';
+  @override
+  String get sync_progress_preparing => '正在准备同步';
+  @override
+  String get sync_progress_collections => '同步合集';
+  @override
+  String get sync_progress_book => '同步书籍';
+  @override
+  String sync_progress_book_titled({required Object title}) => '同步 ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      '上次同步：已完成（${count} 条通道）';
+  @override
+  String get sync_last_no_channels => '上次同步：未同步——没有已连接的同步通道';
+  @override
+  String get sync_last_nothing => '上次同步：没有可同步的内容';
+  @override
+  String get sync_last_auto_disabled => '上次同步：已跳过——自动同步已关闭';
+  @override
+  String get sync_last_cooled_down => '上次同步：已跳过——刚同步过';
+  @override
+  String get sync_last_failed => '上次同步：失败';
 }
 
 // Path: <root>
@@ -104712,6 +105068,29 @@ class _StringsZhHk extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get sync_progress_preparing => 'Preparing sync';
+  @override
+  String get sync_progress_collections => 'Syncing collections';
+  @override
+  String get sync_progress_book => 'Syncing book';
+  @override
+  String sync_progress_book_titled({required Object title}) =>
+      'Syncing ${title}';
+  @override
+  String sync_last_completed({required Object count}) =>
+      'Last sync: done (${count} channels)';
+  @override
+  String get sync_last_no_channels =>
+      'Last sync: nothing synced - no connected sync channel';
+  @override
+  String get sync_last_nothing => 'Last sync: nothing to sync';
+  @override
+  String get sync_last_auto_disabled => 'Last sync: skipped - auto sync is off';
+  @override
+  String get sync_last_cooled_down => 'Last sync: skipped - synced recently';
+  @override
+  String get sync_last_failed => 'Last sync: failed';
 }
 
 /// Flat map(s) containing all translations.
@@ -110379,6 +110758,27 @@ extension on _StringsEn {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -116044,6 +116444,27 @@ extension on _StringsAr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -121730,6 +122151,27 @@ extension on _StringsDe {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -127415,6 +127857,27 @@ extension on _StringsEs {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -133106,6 +133569,27 @@ extension on _StringsFr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -138779,6 +139263,27 @@ extension on _StringsId {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -144467,6 +144972,27 @@ extension on _StringsIt {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -150117,6 +150643,27 @@ extension on _StringsJa {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -155771,6 +156318,27 @@ extension on _StringsKo {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -161452,6 +162020,27 @@ extension on _StringsNl {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -167130,6 +167719,27 @@ extension on _StringsPtBr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -172813,6 +173423,27 @@ extension on _StringsRu {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -178480,6 +179111,27 @@ extension on _StringsTh {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -184156,6 +184808,27 @@ extension on _StringsTr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -189827,6 +190500,27 @@ extension on _StringsVi {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }
@@ -195451,6 +196145,26 @@ extension on _StringsZhCn {
         return '没有可用的网页搜索应用。';
       case 'selection_share_failed':
         return '无法打开分享面板。';
+      case 'sync_progress_preparing':
+        return '正在准备同步';
+      case 'sync_progress_collections':
+        return '同步合集';
+      case 'sync_progress_book':
+        return '同步书籍';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => '同步 ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) => '上次同步：已完成（${count} 条通道）';
+      case 'sync_last_no_channels':
+        return '上次同步：未同步——没有已连接的同步通道';
+      case 'sync_last_nothing':
+        return '上次同步：没有可同步的内容';
+      case 'sync_last_auto_disabled':
+        return '上次同步：已跳过——自动同步已关闭';
+      case 'sync_last_cooled_down':
+        return '上次同步：已跳过——刚同步过';
+      case 'sync_last_failed':
+        return '上次同步：失败';
       default:
         return null;
     }
@@ -201096,6 +201810,27 @@ extension on _StringsZhHk {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'sync_progress_preparing':
+        return 'Preparing sync';
+      case 'sync_progress_collections':
+        return 'Syncing collections';
+      case 'sync_progress_book':
+        return 'Syncing book';
+      case 'sync_progress_book_titled':
+        return ({required Object title}) => 'Syncing ${title}';
+      case 'sync_last_completed':
+        return ({required Object count}) =>
+            'Last sync: done (${count} channels)';
+      case 'sync_last_no_channels':
+        return 'Last sync: nothing synced - no connected sync channel';
+      case 'sync_last_nothing':
+        return 'Last sync: nothing to sync';
+      case 'sync_last_auto_disabled':
+        return 'Last sync: skipped - auto sync is off';
+      case 'sync_last_cooled_down':
+        return 'Last sync: skipped - synced recently';
+      case 'sync_last_failed':
+        return 'Last sync: failed';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。",
   "selection_web_search": "网页搜索",
   "selection_web_search_unavailable": "没有可用的网页搜索应用。",
-  "selection_share_failed": "无法打开分享面板。"
+  "selection_share_failed": "无法打开分享面板。",
+  "sync_progress_preparing": "正在准备同步",
+  "sync_progress_collections": "同步合集",
+  "sync_progress_book": "同步书籍",
+  "sync_progress_book_titled": "同步 $title",
+  "sync_last_completed": "上次同步：已完成（$count 条通道）",
+  "sync_last_no_channels": "上次同步：未同步——没有已连接的同步通道",
+  "sync_last_nothing": "上次同步：没有可同步的内容",
+  "sync_last_auto_disabled": "上次同步：已跳过——自动同步已关闭",
+  "sync_last_cooled_down": "上次同步：已跳过——刚同步过",
+  "sync_last_failed": "上次同步：失败"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2764,5 +2764,15 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "sync_progress_preparing": "Preparing sync",
+  "sync_progress_collections": "Syncing collections",
+  "sync_progress_book": "Syncing book",
+  "sync_progress_book_titled": "Syncing $title",
+  "sync_last_completed": "Last sync: done ($count channels)",
+  "sync_last_no_channels": "Last sync: nothing synced - no connected sync channel",
+  "sync_last_nothing": "Last sync: nothing to sync",
+  "sync_last_auto_disabled": "Last sync: skipped - auto sync is off",
+  "sync_last_cooled_down": "Last sync: skipped - synced recently",
+  "sync_last_failed": "Last sync: failed"
 }

--- a/hibiki/lib/src/sync/manual_sync_ui.dart
+++ b/hibiki/lib/src/sync/manual_sync_ui.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/widgets.dart';
 import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/sync/sync_activity.dart';
 import 'package:hibiki/src/sync/sync_auto_trigger.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_conflict_prompter.dart';
@@ -63,6 +64,46 @@ String syncProgressLine(SyncProgress p) {
   final String head = '$phase (${p.itemIndex + 1}/${p.itemTotal})';
   final String? title = p.title;
   return (title == null || title.isEmpty) ? head : '$head $title';
+}
+
+/// 没有阶段 tick 可显示时的兜底行 —— 说清这轮同步**是谁**。
+///
+/// 全量 sweep 在第一个阶段 tick 之前有一整段准备期（等锁 / 读开关 / 走网络鉴权），
+/// 合集与单本两条路径则全程没有阶段结构。以前这三种情况一律显示空白，进度条成了
+/// 一条无法解读的线。
+String syncActivityLine(SyncActivity a) {
+  switch (a.kind) {
+    case SyncActivityKind.fullSweep:
+      return t.sync_progress_preparing;
+    case SyncActivityKind.collections:
+      return t.sync_progress_collections;
+    case SyncActivityKind.singleBook:
+      final String? title = a.title;
+      return (title == null || title.isEmpty)
+          ? t.sync_progress_book
+          : t.sync_progress_book_titled(title: title);
+  }
+}
+
+/// 上一轮同步的结局行（设置页「立即同步」在空闲时显示）。
+///
+/// 关键的是 [SyncOutcomeReason.noChannels]：一条通道都没通过认证意味着**什么也
+/// 没同步**，而在补上这行之前它与正常跑完在界面上完全同形。
+String syncOutcomeLine(SyncRunOutcome o) {
+  switch (o.reason) {
+    case SyncOutcomeReason.completed:
+      return t.sync_last_completed(count: o.channelsRun);
+    case SyncOutcomeReason.noChannels:
+      return t.sync_last_no_channels;
+    case SyncOutcomeReason.nothingToSync:
+      return t.sync_last_nothing;
+    case SyncOutcomeReason.autoDisabled:
+      return t.sync_last_auto_disabled;
+    case SyncOutcomeReason.cooledDown:
+      return t.sync_last_cooled_down;
+    case SyncOutcomeReason.failed:
+      return t.sync_last_failed;
+  }
 }
 
 /// 手动同步在 UI 层的**单一入口**：跑 [runManualFullSync]，再统一处理三种 outcome

--- a/hibiki/lib/src/sync/sync_activity.dart
+++ b/hibiki/lib/src/sync/sync_activity.dart
@@ -1,0 +1,100 @@
+/// 一轮同步的**身份**与**结局** —— 补上 [SyncProgress] 覆盖不到的那些段落。
+///
+/// 根因：`syncInProgress` 是个裸 bool，`syncProgress` 只在编排器真正进入某个阶段
+/// 后才有值。于是「同步在飞」这一个状态下混着三种完全不同的现实，UI 上却同形
+/// （一条不确定进度条 + 零文字）：
+///
+/// 1. 跑的是合集 / 单本这两条**天生没有阶段结构**的轻量路径；
+/// 2. 跑的是全量 sweep，但还停在第一个阶段 tick 之前的准备段（等互斥锁 → 读自动
+///    同步开关 → 冷却判断 → `restoreAuth` / `isAuthenticated` 走网络）；
+/// 3. 全量 sweep 进去了，但每条通道都没通过认证被 `continue` 跳过 —— 一个阶段都
+///    没跑，什么也没同步，条子转一会儿就消失。
+///
+/// 第 3 种是纯粹的静默空转，跟 1、2 在界面上无法区分。修法不是给进度条加特例，
+/// 而是补上缺失的那一层数据：每轮同步都必须先声明自己**是谁**（[SyncActivity]），
+/// 结束时都必须留下**结局**（[SyncRunOutcome]）。
+library;
+
+/// 当前在飞的这轮同步是哪一种。
+///
+/// 保持成枚举（而不是预本地化的字符串）把 i18n 留在 widget 层，也让触发器可测。
+enum SyncActivityKind {
+  /// 全量双向 sweep：开机自动同步、手动「立即同步」、媒体页下拉。
+  /// 只有这一种会上报 [SyncProgress] 阶段 tick，且仅在准备段之后。
+  fullSweep,
+
+  /// 合集变更防抖后触发的轻量同步（`SyncOrchestrator.runCollectionsOnly`）。
+  /// 只含合集维度，没有阶段结构 —— 阶段进度对它永远是 null，这是设计如此。
+  collections,
+
+  /// 退出书 / 切后台触发的单本同步（`SyncManager.syncBook`）。
+  /// 同样没有阶段结构。
+  singleBook,
+}
+
+/// 在飞的那轮同步的身份。UI 在没有阶段 tick 可显示时退化到这一层。
+class SyncActivity {
+  const SyncActivity(this.kind, {this.title});
+
+  final SyncActivityKind kind;
+
+  /// 单本同步的书名（拿到书之前为 null）。其余种类不用。
+  final String? title;
+
+  /// 带上书名的副本 —— 单本同步在入口只有 mediaIdentifier，取到书之后才能补名。
+  SyncActivity withTitle(String? title) =>
+      SyncActivity(kind, title: title ?? this.title);
+
+  @override
+  bool operator ==(Object other) =>
+      other is SyncActivity && other.kind == kind && other.title == title;
+
+  @override
+  int get hashCode => Object.hash(kind, title);
+}
+
+/// 一轮同步**为什么**结束。
+///
+/// 除 [completed] 外每一种都意味着「这轮什么也没同步」，而在补上这层之前它们全都
+/// 静默收尾，用户只看到进度条消失。
+enum SyncOutcomeReason {
+  /// 至少一条通道通过认证并真的跑完了编排。
+  completed,
+
+  /// 通道全都没通过认证（没配后端 / 令牌失效 / 互联对端不可达）—— 空转。
+  noChannels,
+
+  /// 通道是通的，但本轮没有可同步的对象（单本路径上那本书已不在库里）。
+  /// 与 [noChannels] 分开：一个是「连不上」，一个是「没东西可传」，混成一个词就是
+  /// 让状态撒谎。
+  nothingToSync,
+
+  /// 自动同步开关关着（只可能出现在自动路径；手动同步显式绕过该开关）。
+  autoDisabled,
+
+  /// 距上次同步不足冷却窗口，本轮跳过（只可能出现在开机自动 sweep）。
+  cooledDown,
+
+  /// 抛异常收场。异常本身仍照旧进日志，这里只留「失败了」这个可见事实。
+  failed,
+}
+
+/// 一轮同步的结局。设置页据此显示「上次同步」那行，非打断式。
+class SyncRunOutcome {
+  const SyncRunOutcome({
+    required this.kind,
+    required this.reason,
+    required this.channelsRun,
+    required this.finishedAt,
+  });
+
+  final SyncActivityKind kind;
+  final SyncOutcomeReason reason;
+
+  /// 本轮实际跑完编排的通道数（云备份 / 互联）。[SyncOutcomeReason.completed]
+  /// 时必 > 0；其余种类为 0。
+  final int channelsRun;
+
+  /// 结束时刻，毫秒（命名遵循仓库约定：时刻列用 `<名>At`，无 `Ms` 后缀）。
+  final int finishedAt;
+}

--- a/hibiki/lib/src/sync/sync_auto_trigger.dart
+++ b/hibiki/lib/src/sync/sync_auto_trigger.dart
@@ -8,6 +8,7 @@ import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/models/local_audio_manager.dart';
 import 'package:hibiki/src/sync/book_exit_sync_scope.dart';
 import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
+import 'package:hibiki/src/sync/sync_activity.dart';
 import 'package:hibiki/src/sync/sync_asset_package_service.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_manager.dart';
@@ -31,7 +32,48 @@ final ValueNotifier<bool> syncInProgress = ValueNotifier<bool>(false);
 /// the single-book auto-sync path, which has no phase structure → indeterminate).
 final ValueNotifier<SyncProgress?> syncProgress =
     ValueNotifier<SyncProgress?>(null);
+
+/// 在飞的这轮同步的**身份**。null = 没有同步在跑。
+///
+/// [syncProgress] 只在编排器真进入某个阶段后才有值，而每轮同步在那之前还有一整段
+/// 准备期（等互斥锁 → 读开关 → 冷却判断 → 走网络鉴权），合集/单本两条轻量路径更是
+/// 从头到尾都没有阶段结构。缺了这一层，界面上「在准备」「在跑轻量同步」「所有通道
+/// 都没认证过、正在空转」三种现实完全同形。UI 拿不到阶段 tick 时退化到这一层。
+final ValueNotifier<SyncActivity?> syncActivity =
+    ValueNotifier<SyncActivity?>(null);
+
+/// 最近结束的那轮同步的**结局**，供设置页非打断式地显示「上次同步」。
+///
+/// 在此之前，通道全没通过认证（什么也没同步）与正常跑完在 UI 上无从区分：两者都是
+/// 进度条转一会儿然后消失。自动路径尤其不能靠 SnackBar 补救（退出书同步必须静默，
+/// TODO-132 诉求B），所以结局落成状态而不是提示。
+final ValueNotifier<SyncRunOutcome?> lastSyncOutcome =
+    ValueNotifier<SyncRunOutcome?>(null);
 final Set<String> _syncingIds = {};
+
+/// 登记一轮同步开始：递增在飞计数并公布它的身份。
+///
+/// 四条同步路径（开机自动 sweep / 手动全量 / 合集轻量 / 单本）**必须**经这一对
+/// [_beginSyncActivity]、[_endSyncActivity] 维护全局状态，不得再各自手写 notifier
+/// 赋值。之前那份四处重复正是「合集与单本路径的 finally 漏清 [syncProgress]」的
+/// 来源：全量 sweep 结束时若还有别的同步在飞就不清，而那两条路径自己也不清，于是
+/// 上一轮的阶段文字会残留到下一轮开头闪一下。
+void _beginSyncActivity(SyncActivity activity) {
+  _activeSyncs++;
+  syncActivity.value = activity;
+  syncInProgress.value = true;
+}
+
+/// 登记一轮同步结束：公布结局，并在最后一个在飞同步退出时清空瞬时状态。
+void _endSyncActivity(SyncRunOutcome outcome) {
+  _activeSyncs--;
+  lastSyncOutcome.value = outcome;
+  syncInProgress.value = _activeSyncs > 0;
+  if (_activeSyncs == 0) {
+    syncProgress.value = null;
+    syncActivity.value = null;
+  }
+}
 
 // HBK-AUDIT-049: cloud backends (GoogleDrive/Dropbox/OneDrive/WebDAV/SMB) are
 // process-wide singletons holding mutable shared state (_accessToken,
@@ -285,19 +327,27 @@ Future<void> _runAutoSyncAll({
 }) async {
   if (!_syncingIds.add('__all__')) return;
 
-  _activeSyncs++;
-  syncInProgress.value = true;
+  _beginSyncActivity(const SyncActivity(SyncActivityKind.fullSweep));
+  // 默认 failed：只有走到判定点才会被改写，异常路径原样留下「失败了」这个事实。
+  SyncOutcomeReason reason = SyncOutcomeReason.failed;
+  int channelsRun = 0;
 
   try {
     // HBK-AUDIT-049: serialize the actual sync work so it never overlaps a
     // per-book sync mutating the same singleton backend state.
     await _autoSyncMutex.withLock(() async {
       final repo = SyncRepository(db);
-      if (!await repo.isAutoSyncEnabled()) return;
+      if (!await repo.isAutoSyncEnabled()) {
+        reason = SyncOutcomeReason.autoDisabled;
+        return;
+      }
 
       final lastSync = await repo.getLastSyncMs();
       final now = DateTime.now().millisecondsSinceEpoch;
-      if (lastSync != null && (now - lastSync) < _syncCooldownMs) return;
+      if (lastSync != null && (now - lastSync) < _syncCooldownMs) {
+        reason = SyncOutcomeReason.cooledDown;
+        return;
+      }
 
       // option B 双通道：依次跑云备份通道 + 互联通道（若启用），互不排斥。每条通道
       // 各自认证成功才实际跑；未配置的通道 no-op（_runSyncChannel 返回 null）。
@@ -318,10 +368,16 @@ Future<void> _runAutoSyncAll({
           onProgress: (SyncProgress p) => syncProgress.value = p,
         );
         if (report == null) continue;
+        channelsRun++;
         logSyncReportErrors(report);
         await onPostRun?.call(report);
         onReport?.call(report, channel.backend);
       }
+      // 一条通道都没跑起来 = 本轮什么也没同步。以前这里静默收尾，界面上与「正常
+      // 跑完」完全同形（进度条转一会儿消失），用户无从判断到底同没同步。
+      reason = channelsRun > 0
+          ? SyncOutcomeReason.completed
+          : SyncOutcomeReason.noChannels;
     });
   } catch (e) {
     developer.log(
@@ -331,9 +387,12 @@ Future<void> _runAutoSyncAll({
     );
   } finally {
     _syncingIds.remove('__all__');
-    _activeSyncs--;
-    syncInProgress.value = _activeSyncs > 0;
-    if (_activeSyncs == 0) syncProgress.value = null;
+    _endSyncActivity(SyncRunOutcome(
+      kind: SyncActivityKind.fullSweep,
+      reason: reason,
+      channelsRun: channelsRun,
+      finishedAt: DateTime.now().millisecondsSinceEpoch,
+    ));
   }
 }
 
@@ -381,8 +440,9 @@ Future<ManualSyncResult> runManualFullSync({
   if (!_syncingIds.add('__all__')) {
     return const ManualSyncResult(ManualSyncOutcome.busy);
   }
-  _activeSyncs++;
-  syncInProgress.value = true;
+  _beginSyncActivity(const SyncActivity(SyncActivityKind.fullSweep));
+  SyncOutcomeReason reason = SyncOutcomeReason.failed;
+  int channelsRun = 0;
   try {
     return await _autoSyncMutex.withLock(() async {
       final repo = SyncRepository(db);
@@ -412,14 +472,17 @@ Future<ManualSyncResult> runManualFullSync({
           },
         );
         if (report == null) continue;
+        channelsRun++;
         logSyncReportErrors(report);
         await onPostRun?.call(report);
         merged.mergeFrom(report);
         channelReports.add(ManualSyncChannelReport(channel.backend, report));
       }
       if (channelReports.isEmpty) {
+        reason = SyncOutcomeReason.noChannels;
         return const ManualSyncResult(ManualSyncOutcome.notConfigured);
       }
+      reason = SyncOutcomeReason.completed;
       return ManualSyncResult(
         ManualSyncOutcome.completed,
         merged,
@@ -428,9 +491,12 @@ Future<ManualSyncResult> runManualFullSync({
     });
   } finally {
     _syncingIds.remove('__all__');
-    _activeSyncs--;
-    syncInProgress.value = _activeSyncs > 0;
-    if (_activeSyncs == 0) syncProgress.value = null;
+    _endSyncActivity(SyncRunOutcome(
+      kind: SyncActivityKind.fullSweep,
+      reason: reason,
+      channelsRun: channelsRun,
+      finishedAt: DateTime.now().millisecondsSinceEpoch,
+    ));
   }
 }
 
@@ -499,12 +565,16 @@ Future<void> _runCollectionsSync({required HibikiDatabase db}) async {
     return;
   }
   if (!_syncingIds.add('__collections__')) return;
-  _activeSyncs++;
-  syncInProgress.value = true;
+  _beginSyncActivity(const SyncActivity(SyncActivityKind.collections));
+  SyncOutcomeReason reason = SyncOutcomeReason.failed;
+  int channelsRun = 0;
   try {
     await _autoSyncMutex.withLock(() async {
       final repo = SyncRepository(db);
-      if (!await repo.isAutoSyncEnabled()) return;
+      if (!await repo.isAutoSyncEnabled()) {
+        reason = SyncOutcomeReason.autoDisabled;
+        return;
+      }
       for (final SyncChannel channel
           in await enabledSyncChannelBackends(repo)) {
         final SyncBackend backend = channel.backend;
@@ -530,8 +600,12 @@ Future<void> _runCollectionsSync({required HibikiDatabase db}) async {
           onLocalAudioImported: (LocalAudioPackageContents _) async {},
         );
         final SyncRunReport report = await orchestrator.runCollectionsOnly();
+        channelsRun++;
         logSyncReportErrors(report);
       }
+      reason = channelsRun > 0
+          ? SyncOutcomeReason.completed
+          : SyncOutcomeReason.noChannels;
     });
   } catch (e) {
     developer.log(
@@ -541,8 +615,12 @@ Future<void> _runCollectionsSync({required HibikiDatabase db}) async {
     );
   } finally {
     _syncingIds.remove('__collections__');
-    _activeSyncs--;
-    syncInProgress.value = _activeSyncs > 0;
+    _endSyncActivity(SyncRunOutcome(
+      kind: SyncActivityKind.collections,
+      reason: reason,
+      channelsRun: channelsRun,
+      finishedAt: DateTime.now().millisecondsSinceEpoch,
+    ));
   }
 }
 
@@ -557,8 +635,9 @@ Future<void> _runAutoSync({
   if (_syncingIds.contains('__all__')) return;
   if (!_syncingIds.add(mediaIdentifier)) return;
 
-  _activeSyncs++;
-  syncInProgress.value = true;
+  _beginSyncActivity(const SyncActivity(SyncActivityKind.singleBook));
+  SyncOutcomeReason reason = SyncOutcomeReason.failed;
+  int channelsRun = 0;
 
   try {
     // HBK-AUDIT-049: serialize against any other in-flight auto-sync (other
@@ -566,10 +645,20 @@ Future<void> _runAutoSync({
     // token/api/folder cache is never mutated concurrently.
     await _autoSyncMutex.withLock(() async {
       final repo = SyncRepository(db);
-      if (!await repo.isAutoSyncEnabled()) return;
+      if (!await repo.isAutoSyncEnabled()) {
+        reason = SyncOutcomeReason.autoDisabled;
+        return;
+      }
 
       final book = await db.getEpubBook(bookKey);
-      if (book == null) return;
+      if (book == null) {
+        // 书没了（导入记录被删/清库）——本轮无对象可同步，与「跑完了」不是一回事。
+        reason = SyncOutcomeReason.nothingToSync;
+        return;
+      }
+      // 拿到书才有书名可显示；入口时只有 mediaIdentifier。
+      syncActivity.value =
+          const SyncActivity(SyncActivityKind.singleBook).withTitle(book.title);
 
       final syncStats = await repo.isSyncStatsEnabled();
       final syncAudioBook = await repo.isSyncAudioBookEnabled();
@@ -587,6 +676,7 @@ Future<void> _runAutoSync({
         await backend.restoreAuth(repo);
         if (!await backend.isAuthenticated) continue;
 
+        channelsRun++;
         final manager = SyncManager(db: db, backend: backend);
         final result = await manager.syncBook(
           book: book,
@@ -621,6 +711,9 @@ Future<void> _runAutoSync({
           onReport(report, backend);
         }
       }
+      reason = channelsRun > 0
+          ? SyncOutcomeReason.completed
+          : SyncOutcomeReason.noChannels;
     });
   } catch (e) {
     developer.log(
@@ -630,7 +723,11 @@ Future<void> _runAutoSync({
     );
   } finally {
     _syncingIds.remove(mediaIdentifier);
-    _activeSyncs--;
-    syncInProgress.value = _activeSyncs > 0;
+    _endSyncActivity(SyncRunOutcome(
+      kind: SyncActivityKind.singleBook,
+      reason: reason,
+      channelsRun: channelsRun,
+      finishedAt: DateTime.now().millisecondsSinceEpoch,
+    ));
   }
 }

--- a/hibiki/lib/src/sync/sync_progress_banner.dart
+++ b/hibiki/lib/src/sync/sync_progress_banner.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/sync/manual_sync_ui.dart';
+import 'package:hibiki/src/sync/sync_activity.dart';
 import 'package:hibiki/src/sync/sync_auto_trigger.dart';
 import 'package:hibiki/src/sync/sync_progress.dart';
 
@@ -9,6 +10,11 @@ import 'package:hibiki/src/sync/sync_progress.dart';
 /// 卡在哪一步。这条 banner 直接消费全局 [syncInProgress] / [syncProgress]，因此它
 /// 对**任何**在飞的同步都亮（含后台/开机自动同步），不只是本页下拉触发的那次 ——
 /// 页面本地 flag 做不到这点（BUG-101 同款教训）。
+///
+/// 文字行来自两级数据：有阶段 tick 用 [syncProgress]（"同步阅读数据 (3/12) 书名"），
+/// 没有则退化到 [syncActivity]（"正在准备同步" / "同步合集" / "同步「书名」"）。二者
+/// 同时为空是不可能的 —— 每条同步路径都先登记身份再干活 —— 所以这条 banner 不再会
+/// 出现「一条线 + 零文字」那种无法解读的状态（用户据此分不清在同步还是在空转）。
 ///
 /// 没有同步在跑时收成零高度（[SizedBox.shrink]），不占布局、不改现有几何。
 class SyncProgressBanner extends StatelessWidget {
@@ -23,26 +29,34 @@ class SyncProgressBanner extends StatelessWidget {
         return ValueListenableBuilder<SyncProgress?>(
           valueListenable: syncProgress,
           builder: (BuildContext context, SyncProgress? p, __) {
-            final ThemeData theme = Theme.of(context);
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
-                if (p != null)
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
-                    child: Text(
-                      syncProgressLine(p),
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
+            return ValueListenableBuilder<SyncActivity?>(
+              valueListenable: syncActivity,
+              builder: (BuildContext context, SyncActivity? activity, ___) {
+                final ThemeData theme = Theme.of(context);
+                final String? line = p != null
+                    ? syncProgressLine(p)
+                    : (activity != null ? syncActivityLine(activity) : null);
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: <Widget>[
+                    if (line != null)
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+                        child: Text(
+                          line,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
                       ),
-                    ),
-                  ),
-                // 阶段没有可测总数时退化成不确定进度条（value 为 null）。
-                LinearProgressIndicator(value: p?.fraction, minHeight: 2),
-              ],
+                    // 阶段没有可测总数时退化成不确定进度条（value 为 null）。
+                    LinearProgressIndicator(value: p?.fraction, minHeight: 2),
+                  ],
+                );
+              },
             );
           },
         );

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -34,6 +34,7 @@ import 'package:hibiki/src/sync/pairing/hibiki_ping_client.dart';
 import 'package:hibiki/src/sync/pairing/discovered_pairing_probe.dart';
 import 'package:hibiki/src/sync/sftp_sync_backend.dart';
 import 'package:hibiki/src/sync/tls/hibiki_tofu_probe.dart';
+import 'package:hibiki/src/sync/sync_activity.dart';
 import 'package:hibiki/src/sync/sync_backend.dart';
 import 'package:hibiki/src/sync/sync_auto_trigger.dart';
 import 'package:hibiki/src/sync/sync_compare_dialog.dart';

--- a/hibiki/lib/src/sync/sync_settings_schema/actions.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/actions.part.dart
@@ -44,10 +44,38 @@ class _SyncNowWidgetState extends State<_SyncNowWidget> {
         return ValueListenableBuilder<SyncProgress?>(
           valueListenable: syncProgress,
           builder: (BuildContext context, SyncProgress? p, __) {
+            return _buildRow(syncing, p);
+          },
+        );
+      },
+    );
+  }
+
+  /// 副标题分三段取值，都是「说清现在到底怎么了」：
+  /// 1. 同步中且有阶段 tick → 阶段行；
+  /// 2. 同步中但还没有 tick（准备段 / 轻量路径）→ 这轮同步的身份；
+  /// 3. 空闲 → 上一轮的**结局**（尤其「没有可用的同步通道」＝上轮其实什么都没同步；
+  ///    以前它与正常跑完同形，用户只看得到进度条闪一下）。没跑过才回落到静态提示。
+  Widget _buildRow(bool syncing, SyncProgress? p) {
+    return ValueListenableBuilder<SyncActivity?>(
+      valueListenable: syncActivity,
+      builder: (BuildContext context, SyncActivity? activity, _) {
+        return ValueListenableBuilder<SyncRunOutcome?>(
+          valueListenable: lastSyncOutcome,
+          builder: (BuildContext context, SyncRunOutcome? outcome, __) {
+            final String subtitle;
+            if (syncing && p != null) {
+              subtitle = syncProgressLine(p);
+            } else if (syncing && activity != null) {
+              subtitle = syncActivityLine(activity);
+            } else if (!syncing && outcome != null) {
+              subtitle = syncOutcomeLine(outcome);
+            } else {
+              subtitle = t.sync_now_hint;
+            }
             final AdaptiveSettingsRow row = AdaptiveSettingsRow(
               title: t.sync_now,
-              subtitle:
-                  syncing && p != null ? syncProgressLine(p) : t.sync_now_hint,
+              subtitle: subtitle,
               icon: Icons.sync,
               controlBelow: true,
               // The action lives on the trailing button; giving the ROW an onTap

--- a/hibiki/lib/src/sync/sync_settings_schema/actions.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/actions.part.dart
@@ -54,8 +54,14 @@ class _SyncNowWidgetState extends State<_SyncNowWidget> {
   /// 副标题分三段取值，都是「说清现在到底怎么了」：
   /// 1. 同步中且有阶段 tick → 阶段行；
   /// 2. 同步中但还没有 tick（准备段 / 轻量路径）→ 这轮同步的身份；
-  /// 3. 空闲 → 上一轮的**结局**（尤其「没有可用的同步通道」＝上轮其实什么都没同步；
-  ///    以前它与正常跑完同形，用户只看得到进度条闪一下）。没跑过才回落到静态提示。
+  /// 3. 空闲 → 上一轮**全量**同步的结局（尤其「没有可用的同步通道」＝上轮其实什么
+  ///    都没同步；以前它与正常跑完同形，用户只看得到进度条闪一下）。没跑过才回落到
+  ///    静态提示。
+  ///
+  /// 第 3 段只认 [SyncActivityKind.fullSweep]：本行讲的是「立即同步」这件事，拿后台
+  /// 单本 / 合集轻量同步的结局来填会答非所问（用户点的是全量，看到的却是某本书的
+  /// 结果）。进行中的第 1、2 段不做这个过滤 —— 那两段回答的是「现在有没有东西在跑」，
+  /// 任何同步都算数（BUG-101 的教训）。
   Widget _buildRow(bool syncing, SyncProgress? p) {
     return ValueListenableBuilder<SyncActivity?>(
       valueListenable: syncActivity,
@@ -68,7 +74,9 @@ class _SyncNowWidgetState extends State<_SyncNowWidget> {
               subtitle = syncProgressLine(p);
             } else if (syncing && activity != null) {
               subtitle = syncActivityLine(activity);
-            } else if (!syncing && outcome != null) {
+            } else if (!syncing &&
+                outcome != null &&
+                outcome.kind == SyncActivityKind.fullSweep) {
               subtitle = syncOutcomeLine(outcome);
             } else {
               subtitle = t.sync_now_hint;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1016
+version: 1.3.1+1017
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/sync/sync_activity_visibility_test.dart
+++ b/hibiki/test/sync/sync_activity_visibility_test.dart
@@ -1,0 +1,246 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/manual_sync_ui.dart';
+import 'package:hibiki/src/sync/sync_activity.dart';
+import 'package:hibiki/src/sync/sync_auto_trigger.dart';
+import 'package:hibiki/src/sync/sync_progress.dart';
+import 'package:hibiki/src/sync/sync_progress_banner.dart';
+
+/// 「同步进度条只有一条线、没有任何文字」的回归守卫。
+///
+/// 用户报告：书架页顶部那条细线在转，但一个字都没有，无从判断到底是在同步还是在
+/// 空转。根因是状态模型缺了一层——`syncInProgress` 是裸 bool，`syncProgress` 只在
+/// 编排器真进入某个阶段后才有值，于是三种完全不同的现实在界面上同形：
+///   1. 跑的是合集 / 单本这两条天生没有阶段结构的轻量路径；
+///   2. 全量 sweep 还停在第一个阶段 tick 之前的准备段（等锁 / 读开关 / 网络鉴权）；
+///   3. 所有通道都没通过认证被跳过 —— 什么也没同步的纯空转。
+///
+/// 断言用语言无关信号（非空、两两不同、含书名），不绑定具体措辞，避免 17 语言脆弱。
+void main() {
+  group('syncActivityLine：没有阶段 tick 时也必须说清这轮同步是谁', () {
+    test('三种同步身份各有各的文案，且都不为空', () {
+      final Map<SyncActivityKind, String> lines = <SyncActivityKind, String>{
+        for (final SyncActivityKind kind in SyncActivityKind.values)
+          kind: syncActivityLine(SyncActivity(kind)),
+      };
+      for (final MapEntry<SyncActivityKind, String> e in lines.entries) {
+        expect(e.value, isNotEmpty, reason: '${e.key} 没有可显示的文案');
+      }
+      // 两两不同：否则用户仍分不清在跑哪一种同步。
+      expect(
+        lines.values.toSet().length,
+        SyncActivityKind.values.length,
+        reason: '不同种类的同步必须显示不同文案',
+      );
+    });
+
+    test('单本同步拿到书名后把书名显示出来', () {
+      const String title = 'Do Androids Dream of Electric Sheep?';
+      final String withTitle = syncActivityLine(
+        const SyncActivity(SyncActivityKind.singleBook, title: title),
+      );
+      expect(withTitle, contains(title));
+      // 没书名时退化成不带名字的文案，不能漏出空引号 / null。
+      final String withoutTitle =
+          syncActivityLine(const SyncActivity(SyncActivityKind.singleBook));
+      expect(withoutTitle, isNotEmpty);
+      expect(withoutTitle, isNot(contains('null')));
+      expect(withoutTitle, isNot(equals(withTitle)));
+    });
+
+    test('空字符串书名按「没有书名」处理（不显示空标题）', () {
+      final String line = syncActivityLine(
+        const SyncActivity(SyncActivityKind.singleBook, title: ''),
+      );
+      expect(
+        line,
+        equals(
+            syncActivityLine(const SyncActivity(SyncActivityKind.singleBook))),
+      );
+    });
+  });
+
+  group('syncOutcomeLine：一轮同步结束后必须留下可读的结局', () {
+    test('每种结局各有各的文案，且都不为空', () {
+      final Map<SyncOutcomeReason, String> lines = <SyncOutcomeReason, String>{
+        for (final SyncOutcomeReason reason in SyncOutcomeReason.values)
+          reason: syncOutcomeLine(SyncRunOutcome(
+            kind: SyncActivityKind.fullSweep,
+            reason: reason,
+            channelsRun: reason == SyncOutcomeReason.completed ? 1 : 0,
+            finishedAt: 0,
+          )),
+      };
+      for (final MapEntry<SyncOutcomeReason, String> e in lines.entries) {
+        expect(e.value, isNotEmpty, reason: '${e.key} 没有可显示的文案');
+      }
+      expect(
+        lines.values.toSet().length,
+        SyncOutcomeReason.values.length,
+        reason: '不同结局必须显示不同文案',
+      );
+    });
+
+    test('「跑完了」与「一条通道都没跑起来」文案必须不同（本 bug 的核心）', () {
+      String lineFor(SyncOutcomeReason reason, int channels) => syncOutcomeLine(
+            SyncRunOutcome(
+              kind: SyncActivityKind.fullSweep,
+              reason: reason,
+              channelsRun: channels,
+              finishedAt: 0,
+            ),
+          );
+      expect(
+        lineFor(SyncOutcomeReason.completed, 2),
+        isNot(equals(lineFor(SyncOutcomeReason.noChannels, 0))),
+        reason: '零通道空转以前与正常跑完在界面上完全同形，用户无从判断同没同步',
+      );
+    });
+
+    test('completed 把实跑通道数带进文案', () {
+      final String one = syncOutcomeLine(const SyncRunOutcome(
+        kind: SyncActivityKind.fullSweep,
+        reason: SyncOutcomeReason.completed,
+        channelsRun: 1,
+        finishedAt: 0,
+      ));
+      final String two = syncOutcomeLine(const SyncRunOutcome(
+        kind: SyncActivityKind.fullSweep,
+        reason: SyncOutcomeReason.completed,
+        channelsRun: 2,
+        finishedAt: 0,
+      ));
+      expect(one, contains('1'));
+      expect(two, contains('2'));
+      expect(one, isNot(equals(two)));
+    });
+  });
+
+  group('SyncProgressBanner', () {
+    tearDown(() {
+      syncInProgress.value = false;
+      syncProgress.value = null;
+      syncActivity.value = null;
+    });
+
+    Future<void> pumpBanner(WidgetTester tester) => tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(body: SyncProgressBanner()),
+          ),
+        );
+
+    testWidgets('没有同步在跑时收成零高度，不占布局', (WidgetTester tester) async {
+      syncInProgress.value = false;
+      await pumpBanner(tester);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(find.byType(Text), findsNothing);
+    });
+
+    testWidgets('同步中但没有阶段 tick（轻量路径）→ 仍然有文字，不是光秃秃一条线',
+        (WidgetTester tester) async {
+      syncInProgress.value = true;
+      syncProgress.value = null;
+      syncActivity.value = const SyncActivity(SyncActivityKind.collections);
+      await pumpBanner(tester);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+      final Finder text = find.byType(Text);
+      expect(text, findsOneWidget, reason: '这正是用户报的现象：条子在转但一个字都没有');
+      expect(
+        (tester.widget<Text>(text).data ?? ''),
+        equals(
+            syncActivityLine(const SyncActivity(SyncActivityKind.collections))),
+      );
+    });
+
+    testWidgets('全量 sweep 的准备段（尚无 tick）也有文字', (WidgetTester tester) async {
+      syncInProgress.value = true;
+      syncProgress.value = null;
+      syncActivity.value = const SyncActivity(SyncActivityKind.fullSweep);
+      await pumpBanner(tester);
+      expect(find.byType(Text), findsOneWidget);
+      // 准备段没有可测总数 → 不确定进度条。
+      expect(
+        tester
+            .widget<LinearProgressIndicator>(
+              find.byType(LinearProgressIndicator),
+            )
+            .value,
+        isNull,
+      );
+    });
+
+    testWidgets('有阶段 tick 时阶段行优先于身份行，并给出确定性进度', (WidgetTester tester) async {
+      syncInProgress.value = true;
+      syncActivity.value = const SyncActivity(SyncActivityKind.fullSweep);
+      const SyncProgress p = SyncProgress(
+        phase: SyncPhase.readingData,
+        itemIndex: 2,
+        itemTotal: 8,
+      );
+      syncProgress.value = p;
+      await pumpBanner(tester);
+      expect(
+        tester.widget<Text>(find.byType(Text)).data,
+        equals(syncProgressLine(p)),
+      );
+      expect(
+        tester
+            .widget<LinearProgressIndicator>(
+              find.byType(LinearProgressIndicator),
+            )
+            .value,
+        closeTo(2 / 8, 1e-9),
+      );
+    });
+  });
+
+  group('同步状态维护的单点守卫（源码扫描）', () {
+    // 运行时表面在 headless 测试里挂不稳（真跑一轮同步要 DB + 网络后端），故用源码
+    // 扫描锁住不变式本身：全局同步状态只能由 _beginSyncActivity / _endSyncActivity
+    // 这一对维护。
+    final String src =
+        File('lib/src/sync/sync_auto_trigger.dart').readAsStringSync();
+
+    int occurrences(String needle) => needle.allMatches(src).length;
+
+    test('四条同步路径都经由 _beginSyncActivity 登记身份', () {
+      // 1 处定义 + 4 处调用（开机自动 sweep / 手动全量 / 合集轻量 / 单本）。
+      expect(
+        occurrences('_beginSyncActivity('),
+        5,
+        reason: '新增同步路径必须一并登记身份，否则进度条又会退回「只有线没有字」',
+      );
+    });
+
+    test('每条路径都在 finally 里经由 _endSyncActivity 公布结局', () {
+      expect(
+        occurrences('_endSyncActivity('),
+        5,
+        reason: '漏掉结局 = 那轮同步静默收尾，用户无从判断到底同没同步',
+      );
+    });
+
+    test('在飞标志与计数只在这一对 helper 里被写', () {
+      expect(
+        occurrences('syncInProgress.value = true'),
+        1,
+        reason: '各路径手写这行正是「合集/单本 finally 漏清 syncProgress」的来源',
+      );
+      expect(occurrences('_activeSyncs++'), 1);
+      expect(occurrences('_activeSyncs--'), 1);
+    });
+
+    test('最后一个在飞同步退出时同时清掉阶段与身份', () {
+      // 两者必须一起清：只清其一会把上一轮的残留文字带进下一轮开头。
+      expect(src, contains('syncProgress.value = null'));
+      expect(src, contains('syncActivity.value = null'));
+      expect(
+        occurrences('if (_activeSyncs == 0)'),
+        1,
+        reason: '清理只能有一处（在 _endSyncActivity 内），不得散回各路径',
+      );
+    });
+  });
+}

--- a/hibiki/test/sync/sync_activity_visibility_test.dart
+++ b/hibiki/test/sync/sync_activity_visibility_test.dart
@@ -232,6 +232,22 @@ void main() {
       expect(occurrences('_activeSyncs--'), 1);
     });
 
+    test('设置页「立即同步」只拿全量同步的结局填副标题', () {
+      // 那一行讲的是「立即同步」这件事；拿后台单本 / 合集轻量同步的结局来填会
+      // 答非所问（用户点的是全量，看到的却是某本书的结果）。设置页运行时表面要
+      // AppModel + SettingsContext，headless 挂不稳，故在此锁不变式。
+      final String rowSrc =
+          File('lib/src/sync/sync_settings_schema/actions.part.dart')
+              .readAsStringSync();
+      expect(
+        rowSrc,
+        contains('outcome.kind == SyncActivityKind.fullSweep'),
+        reason: '空闲副标题必须过滤同步种类，否则会显示别的同步的结局',
+      );
+      // 进行中的两段不做这个过滤：它们回答「现在有没有东西在跑」，任何同步都算数。
+      expect(rowSrc, contains('syncActivityLine(activity)'));
+    });
+
     test('最后一个在飞同步退出时同时清掉阶段与身份', () {
       // 两者必须一起清：只清其一会把上一轮的残留文字带进下一轮开头。
       expect(src, contains('syncProgress.value = null'));


### PR DESCRIPTION
## 用户报告

书架页顶部那条同步进度条什么文字都没有 —— 「是同步还是没同步」。

## 是在同步。但这条 UI 回答不了「同成没同」

那条线是 `SyncProgressBanner`，第一道门就是 `if (!syncing) return const SizedBox.shrink()`，所以能看见它就说明确实有同步在飞。问题在于文字行挂在 `if (p != null)` 上，`syncProgress` 为 null 时整行消失。

根因是状态模型缺一层，不是 UI 忘了画。`syncInProgress` 是裸 bool，`syncProgress` 只在编排器真进入某个阶段后才有值，于是三种完全不同的现实在界面上**同形**：

| 现实 | 以前的界面 |
|---|---|
| 合集 / 单本这两条**天生没有阶段结构**的轻量路径在跑 | 一条线，零文字 |
| 全量 sweep 还停在第一个阶段 tick 之前的准备段（等锁 → 读开关 → 冷却判断 → 走网络鉴权） | 一条线，零文字 |
| 所有通道都没通过认证被 `continue` 跳过 —— **什么也没同步的纯空转** | 一条线，零文字，然后静默消失 |

四条路径都置 `syncInProgress = true`，但只有两条传 `onProgress`；三处通道跳过点全是静默 `continue`，跑完不留任何痕迹。

顺带暴露的第二个缺陷：`_runCollectionsSync` 与 `_runAutoSync` 的 finally **漏清 `syncProgress`**，上一轮的阶段文字会残留到下一轮开头闪一下。四份手写的 notifier 维护正是这个不一致的来源。

## 修法：补上缺失的那层数据，不是给进度条加特例分支

- 新增 `sync_activity.dart`：`SyncActivity`（fullSweep / collections / singleBook，单本带书名）+ `SyncRunOutcome`（completed / noChannels / nothingToSync / autoDisabled / cooledDown / failed）。**每轮同步先声明自己是谁，结束时必须留下结局。**
- 四处手写的 `_activeSyncs++` / notifier 赋值 / finally 复位收敛成 `_beginSyncActivity` 与 `_endSyncActivity` 一对，清理逻辑只剩一处 —— 顺带修掉上面那个漏清缺陷。
- 每条路径统计实跑通道数；零通道不再静默收尾，各跳过原因都有独立 reason。`nothingToSync` 与 `noChannels` 刻意分开：一个是「连不上」，一个是「没东西可传」，混成一个词就是让状态撒谎。
- banner 文字行两级取值（阶段行 → 身份行）；设置页「立即同步」再加第三级：空闲时显示上一轮结局，尤其「没有可用的同步通道」＝上轮其实什么都没同步。
- 10 个新 i18n key 经 `tool/i18n_sync.dart` 落 17 语言。

**未改任何同步链路行为**，只补状态与显示。

## 验证

- `flutter analyze`（全量含 test）：No issues found。
- 定向测试 33 例全绿：新增 14 例 + `pull_to_sync_wiring_guard_test` + `sync_summary_test`。
- **变异实测**：把合集路径改回手写 notifier → 源码扫描守卫红 2 条；把 banner 文字行改回 `p != null ? ... : null` → widget 测试红 2 条；均已还原并复验全绿。
- `test/sync` 全目录经 `flutter_test_failures.dart` 复跑中，结果补在评论。

BUG-1260（`docs/bugs/BUG-1260-sync-progress-blank-and-silent-noop.md`）