### PR TITLE
feat(anki): 英语制卡默认带 IPA 音标（Yomitan ipa meta 接通制卡侧）

### DIFF
--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -946,19 +946,49 @@ function constructFrequencyHtml(frequencies) {
     return result;
 }
 
+function escapePitchText(text) {
+    return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// TODO-688 mining side: Yomitan `ipa`-mode dicts (e.g. English) ship phonetic
+// transcriptions in the pitch group instead of pitch positions. They are the
+// same nature as pitch (phonetic notation), so {pitch-accent-positions} carries
+// them too — that is what makes English cards get their transcription with the
+// default field mappings, no remap needed. Plain pitch-accent dicts (Japanese)
+// have an empty transcriptions array and render byte-identically to before.
 function constructPitchPositionHtml(pitches) {
     if (!pitches?.length) {
         return '';
     }
-    
-    let result = '<ol>';
+
+    let items = '';
     pitches.forEach(pitchGroup => {
         pitchGroup.pitchPositions.forEach(pos => {
-            result += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
+            items += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
+        });
+        (pitchGroup.transcriptions || []).forEach(ipa => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
         });
     });
-    result += '</ol>';
-    return result;
+    // No positions AND no transcriptions: return '' instead of an empty <ol>
+    // shell, so the field is treated as empty and skipped.
+    return items ? `<ol>${items}</ol>` : '';
+}
+
+// Yomitan-named {phonetic-transcriptions}: ONLY the IPA transcriptions, for
+// users who map them to a dedicated note field. '' when no dict provides any.
+function constructPhoneticTranscriptionsHtml(pitches) {
+    if (!pitches?.length) {
+        return '';
+    }
+
+    let items = '';
+    pitches.forEach(pitchGroup => {
+        (pitchGroup.transcriptions || []).forEach(ipa => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
+        });
+    });
+    return items ? `<ol>${items}</ol>` : '';
 }
 
 function constructPitchCategories(pitches, reading, rules) {
@@ -1287,6 +1317,7 @@ async function buildMinePayload(expression, reading, frequencies, pitches, rules
     const glossaryFirst = Object.values(singleGlossaries)[0] || '';
     const pitchPositions = constructPitchPositionHtml(pitches);
     const pitchCategories = constructPitchCategories(pitches, reading, rules);
+    const phoneticTranscriptions = constructPhoneticTranscriptionsHtml(pitches);
 
     const audioReading = reading || expression;
     let audio = '';
@@ -1328,6 +1359,7 @@ async function buildMinePayload(expression, reading, frequencies, pitches, rules
         singleGlossaries: JSON.stringify(singleGlossaries),
         pitchPositions,
         pitchCategories,
+        phoneticTranscriptions,
         popupSelectionText,
         audio,
         selectedDictionary: selectedDictionaries[idx]?.name || '',

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -946,19 +946,49 @@ function constructFrequencyHtml(frequencies) {
     return result;
 }
 
+function escapePitchText(text) {
+    return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// TODO-688 mining side: Yomitan `ipa`-mode dicts (e.g. English) ship phonetic
+// transcriptions in the pitch group instead of pitch positions. They are the
+// same nature as pitch (phonetic notation), so {pitch-accent-positions} carries
+// them too — that is what makes English cards get their transcription with the
+// default field mappings, no remap needed. Plain pitch-accent dicts (Japanese)
+// have an empty transcriptions array and render byte-identically to before.
 function constructPitchPositionHtml(pitches) {
     if (!pitches?.length) {
         return '';
     }
-    
-    let result = '<ol>';
+
+    let items = '';
     pitches.forEach(pitchGroup => {
         pitchGroup.pitchPositions.forEach(pos => {
-            result += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
+            items += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
+        });
+        (pitchGroup.transcriptions || []).forEach(ipa => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
         });
     });
-    result += '</ol>';
-    return result;
+    // No positions AND no transcriptions: return '' instead of an empty <ol>
+    // shell, so the field is treated as empty and skipped.
+    return items ? `<ol>${items}</ol>` : '';
+}
+
+// Yomitan-named {phonetic-transcriptions}: ONLY the IPA transcriptions, for
+// users who map them to a dedicated note field. '' when no dict provides any.
+function constructPhoneticTranscriptionsHtml(pitches) {
+    if (!pitches?.length) {
+        return '';
+    }
+
+    let items = '';
+    pitches.forEach(pitchGroup => {
+        (pitchGroup.transcriptions || []).forEach(ipa => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
+        });
+    });
+    return items ? `<ol>${items}</ol>` : '';
 }
 
 function constructPitchCategories(pitches, reading, rules) {
@@ -1287,6 +1317,7 @@ async function buildMinePayload(expression, reading, frequencies, pitches, rules
     const glossaryFirst = Object.values(singleGlossaries)[0] || '';
     const pitchPositions = constructPitchPositionHtml(pitches);
     const pitchCategories = constructPitchCategories(pitches, reading, rules);
+    const phoneticTranscriptions = constructPhoneticTranscriptionsHtml(pitches);
 
     const audioReading = reading || expression;
     let audio = '';
@@ -1328,6 +1359,7 @@ async function buildMinePayload(expression, reading, frequencies, pitches, rules
         singleGlossaries: JSON.stringify(singleGlossaries),
         pitchPositions,
         pitchCategories,
+        phoneticTranscriptions,
         popupSelectionText,
         audio,
         selectedDictionary: selectedDictionaries[idx]?.name || '',

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 47022 (2766 per locale)
+/// Strings: 47039 (2767 per locale)
 ///
-/// Built on 2026-07-29 at 08:08 UTC
+/// Built on 2026-07-31 at 04:45 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3718,6 +3718,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get selection_web_search => 'Search the web';
   String get selection_web_search_unavailable => 'No app can search the web.';
   String get selection_share_failed => 'Could not open the share sheet.';
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -10050,6 +10051,8 @@ class _StringsAr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -16450,6 +16453,8 @@ class _StringsDe extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -22866,6 +22871,8 @@ class _StringsEs extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -29293,6 +29300,8 @@ class _StringsFr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -35649,6 +35658,8 @@ class _StringsId extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -42051,6 +42062,8 @@ class _StringsIt extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -48270,6 +48283,8 @@ class _StringsJa extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -54491,6 +54506,8 @@ class _StringsKo extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -60873,6 +60890,8 @@ class _StringsNl extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -67268,6 +67287,8 @@ class _StringsPtBr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -73647,6 +73668,8 @@ class _StringsRu extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -79974,6 +79997,8 @@ class _StringsTh extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -86333,6 +86358,8 @@ class _StringsTr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -92677,6 +92704,8 @@ class _StringsVi extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 // Path: <root>
@@ -98572,6 +98601,8 @@ class _StringsZhCn extends _StringsEn {
   String get selection_web_search_unavailable => '没有可用的网页搜索应用。';
   @override
   String get selection_share_failed => '无法打开分享面板。';
+  @override
+  String get handlebar_phonetic_transcriptions => '音标';
 }
 
 // Path: <root>
@@ -104712,6 +104743,8 @@ class _StringsZhHk extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get handlebar_phonetic_transcriptions => 'Phonetic transcriptions';
 }
 
 /// Flat map(s) containing all translations.
@@ -110379,6 +110412,8 @@ extension on _StringsEn {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -116044,6 +116079,8 @@ extension on _StringsAr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -121730,6 +121767,8 @@ extension on _StringsDe {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -127415,6 +127454,8 @@ extension on _StringsEs {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -133106,6 +133147,8 @@ extension on _StringsFr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -138779,6 +138822,8 @@ extension on _StringsId {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -144467,6 +144512,8 @@ extension on _StringsIt {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -150117,6 +150164,8 @@ extension on _StringsJa {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -155771,6 +155820,8 @@ extension on _StringsKo {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -161452,6 +161503,8 @@ extension on _StringsNl {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -167130,6 +167183,8 @@ extension on _StringsPtBr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -172813,6 +172868,8 @@ extension on _StringsRu {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -178480,6 +178537,8 @@ extension on _StringsTh {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -184156,6 +184215,8 @@ extension on _StringsTr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -189827,6 +189888,8 @@ extension on _StringsVi {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }
@@ -195451,6 +195514,8 @@ extension on _StringsZhCn {
         return '没有可用的网页搜索应用。';
       case 'selection_share_failed':
         return '无法打开分享面板。';
+      case 'handlebar_phonetic_transcriptions':
+        return '音标';
       default:
         return null;
     }
@@ -201096,6 +201161,8 @@ extension on _StringsZhHk {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'handlebar_phonetic_transcriptions':
+        return 'Phonetic transcriptions';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。",
   "selection_web_search": "网页搜索",
   "selection_web_search_unavailable": "没有可用的网页搜索应用。",
-  "selection_share_failed": "无法打开分享面板。"
+  "selection_share_failed": "无法打开分享面板。",
+  "handlebar_phonetic_transcriptions": "音标"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "handlebar_phonetic_transcriptions": "Phonetic transcriptions"
 }

--- a/hibiki/lib/src/anki/ankimobile_repository.dart
+++ b/hibiki/lib/src/anki/ankimobile_repository.dart
@@ -386,6 +386,7 @@ class AnkiMobileRepository extends BaseAnkiRepository {
       singleGlossaries: payload.singleGlossaries,
       pitchPositions: payload.pitchPositions,
       pitchCategories: payload.pitchCategories,
+      phoneticTranscriptions: payload.phoneticTranscriptions,
       popupSelectionText: payload.popupSelectionText,
       audio: audio.fieldValue,
       selectedDictionary: payload.selectedDictionary,

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -1069,6 +1069,8 @@ String _ankiHandlebarBaseLabel(String option) {
       return t.handlebar_pitch_accent_positions;
     case '{pitch-accent-categories}':
       return t.handlebar_pitch_accent_categories;
+    case '{phonetic-transcriptions}':
+      return t.handlebar_phonetic_transcriptions;
     case '{document-title}':
       return t.handlebar_document_title;
     case '{card-image}':

--- a/hibiki/test/anki/phonetic_transcriptions_mining_test.dart
+++ b/hibiki/test/anki/phonetic_transcriptions_mining_test.dart
@@ -1,0 +1,168 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+/// 英语制卡音标（IPA）契约：Yomitan `ipa`-mode 词典（典型：英语）在 pitch 组里
+/// 带 `transcriptions` 而没有 `pitchPositions`，修复前制卡侧只消费 positions，
+/// 英语卡的声调字段恒空（弹窗展示侧 TODO-688 早已渲染，唯独制卡断链）。
+///
+/// 契约（与 Yomitan 命名对齐）：
+///  1. `{pitch-accent-positions}`（默认 Lapis PitchPosition 映射）在制卡侧同时
+///     渲染 positions 与 transcriptions——英语卡零配置拿到音标；日语纯声调词典
+///     的 transcriptions 恒为空数组，输出逐字节不变。
+///  2. 新增 `{phonetic-transcriptions}`（Yomitan 同名 marker）只含 IPA，供用户
+///     单独映射。
+///
+/// popup.js 三镜像的字节一致由 browser_extension_popup_parity_guard_test 锁定，
+/// 本文件只扫 app 侧真身。
+class _TestRepo extends BaseAnkiRepository {
+  @override
+  Future<AnkiFetchResult> fetchConfiguration() => throw UnimplementedError();
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Future<bool> isDuplicate(String expression, String reading) =>
+      throw UnimplementedError();
+
+  @override
+  Future<bool> createNoteType(AnkiNoteTypeTemplate template) =>
+      throw UnimplementedError();
+
+  @override
+  Future<bool> createDeck(String name) => throw UnimplementedError();
+
+  RenderedMinedFields renderFor({
+    required AnkiSettings settings,
+    required AnkiMiningPayload payload,
+    required AnkiMiningContext context,
+  }) =>
+      renderMediaPayload(
+        settings: settings,
+        payload: payload,
+        context: context,
+        coverRef: null,
+        sasayakiRef: null,
+        processedAudio: '',
+        dictionaryMediaTags: const <String, String>{},
+      );
+}
+
+const String _ipaHtml = '<ol><li><span style="display:inline;">'
+    '<span>[</span><span>ˈwɜːd</span><span>]</span></span></li></ol>';
+
+void main() {
+  group('{phonetic-transcriptions} marker (Yomitan 命名)', () {
+    test('renderer maps the marker to payload.phoneticTranscriptions', () {
+      const AnkiMiningPayload payload = AnkiMiningPayload(
+        expression: 'word',
+        phoneticTranscriptions: _ipaHtml,
+      );
+      final String out = AnkiHandlebarRenderer.render(
+        '{phonetic-transcriptions}',
+        payload,
+        const AnkiMiningContext(sentence: ''),
+      );
+      expect(out, _ipaHtml);
+    });
+
+    test('fromJson reads the popup.js payload key phoneticTranscriptions', () {
+      final AnkiMiningPayload payload = AnkiMiningPayload.fromJson(
+        <String, dynamic>{
+          'expression': 'word',
+          'phoneticTranscriptions': _ipaHtml,
+        },
+      );
+      expect(payload.phoneticTranscriptions, _ipaHtml);
+      // 缺 key（旧草稿/旧桥）安全回退为空，不炸。
+      expect(
+        AnkiMiningPayload.fromJson(<String, dynamic>{'expression': 'a'})
+            .phoneticTranscriptions,
+        '',
+      );
+    });
+
+    test('coreOptions offers {phonetic-transcriptions} in the mapping UI', () {
+      expect(
+        AnkiHandlebarOptions.coreOptions,
+        contains('{phonetic-transcriptions}'),
+      );
+    });
+
+    test(
+        'renderMediaPayload passes phoneticTranscriptions through '
+        '(媒体二次渲染透传，防 16 字段漂移)', () {
+      final _TestRepo repo = _TestRepo();
+      final RenderedMinedFields rendered = repo.renderFor(
+        settings: const AnkiSettings(
+          fieldMappings: <String, String>{'IPA': '{phonetic-transcriptions}'},
+        ),
+        payload: const AnkiMiningPayload(
+          expression: 'word',
+          phoneticTranscriptions: _ipaHtml,
+        ),
+        context: const AnkiMiningContext(sentence: ''),
+      );
+      expect(rendered.fields['IPA'], _ipaHtml);
+    });
+  });
+
+  group('popup.js mining builders (source scan)', () {
+    // flutter test cwd 是 hibiki 包根。
+    final String src = File('assets/popup/popup.js').readAsStringSync();
+
+    /// 取顶层函数体：从 `function <name>(` 到下一个列首 `}`。锚定函数体而不是
+    /// 全文件，防止别处注释里出现同名字面量假绿；再剥掉行注释，防「把代码注释
+    /// 掉但字面量还在」的假绿（变异实测过：注释掉 forEach 本守卫必红）。
+    String functionBody(String name) {
+      final int start = src.indexOf('function $name(');
+      expect(start, greaterThanOrEqualTo(0),
+          reason: 'popup.js 缺少 function $name');
+      final int end = src.indexOf('\n}', start);
+      expect(end, greaterThan(start), reason: '$name 函数体未闭合？');
+      return src
+          .substring(start, end + 2)
+          .split('\n')
+          .where((String l) => !l.trimLeft().startsWith('//'))
+          .join('\n');
+    }
+
+    test(
+        'constructPitchPositionHtml folds transcriptions into '
+        '{pitch-accent-positions}（英语默认路径）', () {
+      final String body = functionBody('constructPitchPositionHtml');
+      expect(body, contains('pitchGroup.transcriptions'),
+          reason: '制卡侧不再消费 transcriptions —— 英语卡声调字段会回到恒空');
+      expect(body, contains('escapePitchText(ipa)'),
+          reason: 'IPA 来自词典数据，进 HTML 前必须转义');
+      // 全空组返回 ''（而不是 <ol></ol> 空壳），字段才会被按空跳过。
+      expect(body, contains(r"items ? `<ol>${items}</ol>` : ''"));
+    });
+
+    test(
+        'constructPhoneticTranscriptionsHtml exists and only reads '
+        'transcriptions', () {
+      final String body = functionBody('constructPhoneticTranscriptionsHtml');
+      expect(body, contains('pitchGroup.transcriptions'));
+      expect(body, isNot(contains('pitchGroup.pitchPositions')),
+          reason: '{phonetic-transcriptions} 只含 IPA，不混声调 positions');
+    });
+
+    test('buildMinePayload computes and ships phoneticTranscriptions', () {
+      final String body = functionBody('buildMinePayload');
+      expect(
+        body,
+        contains(
+            'const phoneticTranscriptions = constructPhoneticTranscriptionsHtml(pitches);'),
+      );
+      // return 对象里必须带该 key（shorthand 属性）。
+      expect(body, contains('\n        phoneticTranscriptions,'));
+    });
+  });
+}

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -410,6 +410,7 @@ class AnkiMiningPayload {
     this.singleGlossaries = const {},
     this.pitchPositions = '',
     this.pitchCategories = '',
+    this.phoneticTranscriptions = '',
     this.popupSelectionText = '',
     this.audio = '',
     this.selectedDictionary = '',
@@ -457,6 +458,7 @@ class AnkiMiningPayload {
       singleGlossaries: singleGlossaries,
       pitchPositions: json['pitchPositions'] as String? ?? '',
       pitchCategories: json['pitchCategories'] as String? ?? '',
+      phoneticTranscriptions: json['phoneticTranscriptions'] as String? ?? '',
       popupSelectionText: json['popupSelectionText'] as String? ?? '',
       audio: json['audio'] as String? ?? '',
       selectedDictionary: json['selectedDictionary'] as String? ?? '',
@@ -474,6 +476,11 @@ class AnkiMiningPayload {
   final Map<String, String> singleGlossaries;
   final String pitchPositions;
   final String pitchCategories;
+
+  /// Yomitan `ipa`-mode 词典的音标（IPA）HTML；纯声调（positions）词典恒为空。
+  /// `{pitch-accent-positions}` 已默认并入音标（popup.js 制卡侧），本字段只服务
+  /// 想把音标单独映射到独立字段的用户（Yomitan 命名 `{phonetic-transcriptions}`）。
+  final String phoneticTranscriptions;
   final String popupSelectionText;
   final String audio;
   final String selectedDictionary;
@@ -630,6 +637,8 @@ class AnkiHandlebarRenderer {
         return payload.pitchPositions;
       case '{pitch-accent-categories}':
         return payload.pitchCategories;
+      case '{phonetic-transcriptions}':
+        return payload.phoneticTranscriptions;
       case '{document-title}':
         return context.documentTitle ?? '';
       // {card-image} 是通用图片键（书籍封面 / 视频 GIF 共用，语义中性、名副其实）：
@@ -721,6 +730,7 @@ class AnkiHandlebarOptions {
     '{frequency-harmonic-rank}',
     '{pitch-accent-positions}',
     '{pitch-accent-categories}',
+    '{phonetic-transcriptions}',
     '{document-title}',
     '{card-image}',
     '{book-cover}',

--- a/packages/hibiki_anki/lib/src/base_anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/base_anki_repository.dart
@@ -465,6 +465,7 @@ abstract class BaseAnkiRepository {
       singleGlossaries: payload.singleGlossaries,
       pitchPositions: payload.pitchPositions,
       pitchCategories: payload.pitchCategories,
+      phoneticTranscriptions: payload.phoneticTranscriptions,
       popupSelectionText: payload.popupSelectionText,
       audio: processedAudio,
       selectedDictionary: payload.selectedDictionary,

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -946,19 +946,49 @@ function constructFrequencyHtml(frequencies) {
     return result;
 }
 
+function escapePitchText(text) {
+    return String(text).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+// TODO-688 mining side: Yomitan `ipa`-mode dicts (e.g. English) ship phonetic
+// transcriptions in the pitch group instead of pitch positions. They are the
+// same nature as pitch (phonetic notation), so {pitch-accent-positions} carries
+// them too — that is what makes English cards get their transcription with the
+// default field mappings, no remap needed. Plain pitch-accent dicts (Japanese)
+// have an empty transcriptions array and render byte-identically to before.
 function constructPitchPositionHtml(pitches) {
     if (!pitches?.length) {
         return '';
     }
-    
-    let result = '<ol>';
+
+    let items = '';
     pitches.forEach(pitchGroup => {
         pitchGroup.pitchPositions.forEach(pos => {
-            result += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
+            items += `<li><span style="display:inline;"><span>[</span><span>${pos}</span><span>]</span></span></li>`;
+        });
+        (pitchGroup.transcriptions || []).forEach(ipa => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
         });
     });
-    result += '</ol>';
-    return result;
+    // No positions AND no transcriptions: return '' instead of an empty <ol>
+    // shell, so the field is treated as empty and skipped.
+    return items ? `<ol>${items}</ol>` : '';
+}
+
+// Yomitan-named {phonetic-transcriptions}: ONLY the IPA transcriptions, for
+// users who map them to a dedicated note field. '' when no dict provides any.
+function constructPhoneticTranscriptionsHtml(pitches) {
+    if (!pitches?.length) {
+        return '';
+    }
+
+    let items = '';
+    pitches.forEach(pitchGroup => {
+        (pitchGroup.transcriptions || []).forEach(ipa => {
+            items += `<li><span style="display:inline;"><span>[</span><span>${escapePitchText(ipa)}</span><span>]</span></span></li>`;
+        });
+    });
+    return items ? `<ol>${items}</ol>` : '';
 }
 
 function constructPitchCategories(pitches, reading, rules) {
@@ -1287,6 +1317,7 @@ async function buildMinePayload(expression, reading, frequencies, pitches, rules
     const glossaryFirst = Object.values(singleGlossaries)[0] || '';
     const pitchPositions = constructPitchPositionHtml(pitches);
     const pitchCategories = constructPitchCategories(pitches, reading, rules);
+    const phoneticTranscriptions = constructPhoneticTranscriptionsHtml(pitches);
 
     const audioReading = reading || expression;
     let audio = '';
@@ -1328,6 +1359,7 @@ async function buildMinePayload(expression, reading, frequencies, pitches, rules
         singleGlossaries: JSON.stringify(singleGlossaries),
         pitchPositions,
         pitchCategories,
+        phoneticTranscriptions,
         popupSelectionText,
         audio,
         selectedDictionary: selectedDictionaries[idx]?.name || '',


### PR DESCRIPTION
## 根因

Yomitan `ipa`-mode 词典（英语典型）把音标放在 pitch 组的 `transcriptions` 里、没有 `pitchPositions`。引擎（TODO-687）与弹窗展示（TODO-688）早已打通，唯独制卡 payload 生成器 `popup.js constructPitchPositionHtml` 只消费 positions —— 英语卡的 `{pitch-accent-positions}` 恒空（实际是 `<ol></ol>` 空壳）。

## 修法（参考 Yomitan 命名）

1. **默认路径**：`constructPitchPositionHtml` 同时渲染 positions 与 transcriptions（镜像弹窗展示侧的统一），默认 Lapis `PitchPosition → {pitch-accent-positions}` 映射零配置拿到音标；顺带修掉全空组输出 `<ol></ol>` 空壳（改返回 `''`，字段按空跳过）；IPA 文本进 HTML 前转义。
2. **新 marker**：`{phonetic-transcriptions}`（Yomitan 同名）只含 IPA，payload 键 `phoneticTranscriptions`；渲染器 / coreOptions / 媒体二次渲染透传（AnkiConnect+AnkiDroid 与 AnkiMobile 两处）/ 设置页标签 / i18n（`i18n_sync` 全 17 语言 + `dart run slang` + format）同步。
3. popup.js 三镜像字节同步（parity guard 锁定）。

## 日语零影响

日语纯声调词典的 `transcriptions` 恒为空数组 —— node 直接执行新函数实测：日语输入输出与旧实现**逐字节一致**。桥接层（in-app WebView / gal 覆盖窗 / 扩展）全是泛型 Map 透传，新键自然流过。

## 验证

- `flutter analyze` 全量绿（No issues found）。
- 定向测试：`test/anki` 全目录 + handlebar 标签守卫 + 三镜像 parity 守卫 = **+217 全绿**。
- 新守卫 `test/anki/phonetic_transcriptions_mining_test.dart`（Dart 契约 4 条 + popup.js 函数体级源码扫描 3 条，扫描剥注释）；按纪律做了三处变异实测（注释掉 forEach / 去转义 / return 掉键），全部抓红。
- node 行为验证 6/6：日语逐字节不变、英语双字段拿到 IPA、转义、空壳修复、旧数据缺 `transcriptions` 键不炸。

https://claude.ai/code/session_01McGusqoJX9U49mgAdeM8Zs