### PR TITLE
feat(video): 按住临时倍速快捷键（默认 E，对齐手机长按倍速）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 47022 (2766 per locale)
+/// Strings: 47039 (2767 per locale)
 ///
-/// Built on 2026-07-29 at 08:08 UTC
+/// Built on 2026-07-31 at 04:49 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3718,6 +3718,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get selection_web_search => 'Search the web';
   String get selection_web_search_unavailable => 'No app can search the web.';
   String get selection_share_failed => 'Could not open the share sheet.';
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -10050,6 +10051,8 @@ class _StringsAr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -16450,6 +16453,8 @@ class _StringsDe extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -22866,6 +22871,8 @@ class _StringsEs extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -29293,6 +29300,8 @@ class _StringsFr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -35649,6 +35658,8 @@ class _StringsId extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -42051,6 +42062,8 @@ class _StringsIt extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -48270,6 +48283,8 @@ class _StringsJa extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -54491,6 +54506,8 @@ class _StringsKo extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -60873,6 +60890,8 @@ class _StringsNl extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -67268,6 +67287,8 @@ class _StringsPtBr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -73647,6 +73668,8 @@ class _StringsRu extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -79974,6 +79997,8 @@ class _StringsTh extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -86333,6 +86358,8 @@ class _StringsTr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -92677,6 +92704,8 @@ class _StringsVi extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 // Path: <root>
@@ -98572,6 +98601,8 @@ class _StringsZhCn extends _StringsEn {
   String get selection_web_search_unavailable => '没有可用的网页搜索应用。';
   @override
   String get selection_share_failed => '无法打开分享面板。';
+  @override
+  String get shortcut_action_video_hold_speed => '按住临时倍速';
 }
 
 // Path: <root>
@@ -104712,6 +104743,8 @@ class _StringsZhHk extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get shortcut_action_video_hold_speed => 'Hold for temporary speed';
 }
 
 /// Flat map(s) containing all translations.
@@ -110379,6 +110412,8 @@ extension on _StringsEn {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -116044,6 +116079,8 @@ extension on _StringsAr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -121730,6 +121767,8 @@ extension on _StringsDe {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -127415,6 +127454,8 @@ extension on _StringsEs {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -133106,6 +133147,8 @@ extension on _StringsFr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -138779,6 +138822,8 @@ extension on _StringsId {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -144467,6 +144512,8 @@ extension on _StringsIt {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -150117,6 +150164,8 @@ extension on _StringsJa {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -155771,6 +155820,8 @@ extension on _StringsKo {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -161452,6 +161503,8 @@ extension on _StringsNl {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -167130,6 +167183,8 @@ extension on _StringsPtBr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -172813,6 +172868,8 @@ extension on _StringsRu {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -178480,6 +178537,8 @@ extension on _StringsTh {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -184156,6 +184215,8 @@ extension on _StringsTr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -189827,6 +189888,8 @@ extension on _StringsVi {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }
@@ -195451,6 +195514,8 @@ extension on _StringsZhCn {
         return '没有可用的网页搜索应用。';
       case 'selection_share_failed':
         return '无法打开分享面板。';
+      case 'shortcut_action_video_hold_speed':
+        return '按住临时倍速';
       default:
         return null;
     }
@@ -201096,6 +201161,8 @@ extension on _StringsZhHk {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'shortcut_action_video_hold_speed':
+        return 'Hold for temporary speed';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。",
   "selection_web_search": "网页搜索",
   "selection_web_search_unavailable": "没有可用的网页搜索应用。",
-  "selection_share_failed": "无法打开分享面板。"
+  "selection_share_failed": "无法打开分享面板。",
+  "shortcut_action_video_hold_speed": "按住临时倍速"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "shortcut_action_video_hold_speed": "Hold for temporary speed"
 }

--- a/hibiki/lib/src/media/video/video_player_shortcuts.dart
+++ b/hibiki/lib/src/media/video/video_player_shortcuts.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/services.dart'
-    show LogicalKeyboardKey, PhysicalKeyboardKey;
+    show
+        HardwareKeyboard,
+        KeyDownEvent,
+        KeyEvent,
+        KeyRepeatEvent,
+        KeyUpEvent,
+        LogicalKeyboardKey,
+        PhysicalKeyboardKey;
 import 'package:flutter/widgets.dart';
 
+import 'package:hibiki/src/shortcuts/input_binding.dart' show ModifierKey;
 import 'package:hibiki/src/shortcuts/shortcut_action.dart';
 import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
 
@@ -21,6 +29,7 @@ class VideoPlayerShortcutActions {
     required this.speedUp,
     required this.speedDown,
     required this.resetSpeed,
+    required this.toggleHoldSpeed,
     required this.previousFrame,
     required this.nextFrame,
     required this.screenshot,
@@ -59,6 +68,13 @@ class VideoPlayerShortcutActions {
   final VoidCallback speedUp;
   final VoidCallback speedDown;
   final VoidCallback resetSpeed;
+
+  /// 按住临时倍速（对齐手机长按画面，默认裸 E）。**键盘通道不经本表**：按住语义
+  /// 需要 keyup 边沿，SingleActivator 表达不了，键盘按下/松开由视频页最外层
+  /// Focus.onKeyEvent 直接判定（见 _handleHoldSpeedKey）。本回调只服务手柄通道
+  /// （videoActionCallbacks → resolveGamepad 派发），退化成翻转语义：按一下切到
+  /// 长按倍速、再按恢复原速。
+  final VoidCallback toggleHoldSpeed;
   final VoidCallback previousFrame;
   final VoidCallback nextFrame;
   final VoidCallback screenshot;
@@ -138,6 +154,7 @@ Map<ShortcutAction, VoidCallback> videoActionCallbacks(
     ShortcutAction.videoSpeedUp: actions.speedUp,
     ShortcutAction.videoSpeedDown: actions.speedDown,
     ShortcutAction.videoResetSpeed: actions.resetSpeed,
+    ShortcutAction.videoHoldSpeed: actions.toggleHoldSpeed,
     ShortcutAction.videoPreviousFrame: actions.previousFrame,
     ShortcutAction.videoNextFrame: actions.nextFrame,
     ShortcutAction.videoScreenshot: actions.screenshot,
@@ -186,6 +203,11 @@ Map<ShortcutActivator, VoidCallback> buildVideoPlayerShortcutsFromRegistry(
     // 调用点可排除个别动作（如字幕对轴弹窗复用本 map 时排除 Escape / 全屏 / 打开字幕列表 /
     // 沉浸锁，避免它们拦掉弹窗自身的关闭或在弹窗后面改变布局）。
     if (exclude.contains(action)) continue;
+    // 按住临时倍速的**键盘绑定永不进本表**：按住语义需要 keyup 边沿，装成
+    // SingleActivator 会在 keydown 就把事件消费掉，页面级 Focus.onKeyEvent 的
+    // 按下/松开判定（_handleHoldSpeedKey）就永远收不到。手柄通道不受影响——
+    // resolveGamepad 派发仍走 videoActionCallbacks 里的 toggleHoldSpeed。
+    if (action == ShortcutAction.videoHoldSpeed) continue;
     // 模糊切换 / 遮蔽循环 / 隐藏切换都是 press-edge-only（按一下翻一次，长按不连发，
     // 与历史 videoToggleSubtitleBlur 同语义）。TODO-840 Part B。
     const Set<ShortcutAction> pressEdgeOnly = <ShortcutAction>{
@@ -263,4 +285,83 @@ bool isVideoImeSpacePlayPause({
   // 走既有 SingleActivator 路径，不进本回退。
   return physicalKey == PhysicalKeyboardKey.space &&
       logicalKey != LogicalKeyboardKey.space;
+}
+
+/// 按住临时倍速键盘状态机的单步结论（[resolveHoldSpeedKeyTransition]）。
+enum HoldSpeedKeyTransition {
+  /// 命中绑定的 keydown：进入临时倍速并记录触发键。
+  engage,
+
+  /// 按住期间的重复/重入事件：消费掉、状态不变（阻止 OS key-repeat 冒泡成别的行为）。
+  swallow,
+
+  /// 触发键的 keyup：恢复原速并清空触发键。
+  release,
+
+  /// 与按住倍速无关：不消费，交回既有解析路径。
+  none,
+}
+
+/// 按住临时倍速的键盘状态机（纯函数，供视频页最外层 Focus.onKeyEvent 调用与单测）。
+///
+/// 语义与手机长按画面一致：按下进入临时倍速、松开恢复。SingleActivator 只有按下
+/// 边沿，表达不了「松开」，故本动作不进 CallbackShortcuts activator 表（见
+/// [buildVideoPlayerShortcutsFromRegistry] 的跳过分支），按下/松开都在这里判定。
+///
+/// [activeTriggerKey] 非空 = 正在按住中。keyup/repeat 只按**触发键本身**识别、
+/// 不看修饰键——用户按住期间松开修饰键时 keyup 仍能命中，绝不把倍速卡在加速态。
+/// [matchesHoldSpeedBinding] 是 keydown 是否命中注册表绑定（[keyDownMatchesHoldSpeed]），
+/// 非 keydown 事件传什么都不影响结论。
+HoldSpeedKeyTransition resolveHoldSpeedKeyTransition({
+  required KeyEvent event,
+  required LogicalKeyboardKey? activeTriggerKey,
+  required bool matchesHoldSpeedBinding,
+}) {
+  if (event is KeyUpEvent) {
+    return activeTriggerKey == event.logicalKey
+        ? HoldSpeedKeyTransition.release
+        : HoldSpeedKeyTransition.none;
+  }
+  if (event is KeyRepeatEvent) {
+    return activeTriggerKey == event.logicalKey
+        ? HoldSpeedKeyTransition.swallow
+        : HoldSpeedKeyTransition.none;
+  }
+  if (event is! KeyDownEvent) return HoldSpeedKeyTransition.none;
+  if (activeTriggerKey != null) {
+    // 已在按住态：同键的再次 down（个别平台把 repeat 报成 down）照旧消费，
+    // 其它键不接管。
+    return activeTriggerKey == event.logicalKey
+        ? HoldSpeedKeyTransition.swallow
+        : HoldSpeedKeyTransition.none;
+  }
+  return matchesHoldSpeedBinding
+      ? HoldSpeedKeyTransition.engage
+      : HoldSpeedKeyTransition.none;
+}
+
+/// keydown 是否命中注册表里 [ShortcutAction.videoHoldSpeed] 的键盘绑定。
+///
+/// 修饰键取 [HardwareKeyboard] 实时状态（与 SingleActivator 同口径）；physicalKey
+/// 透传给 [HibikiShortcutRegistry.resolveKeyboard] 供 IME 改写回退（TODO-847）。
+/// [hasEditableFocus] 为 true（文本框持焦）时恒不命中，避免输入时误触加速。
+bool keyDownMatchesHoldSpeed(
+  HibikiShortcutRegistry registry,
+  KeyDownEvent event, {
+  required bool hasEditableFocus,
+}) {
+  if (hasEditableFocus) return false;
+  final Set<ModifierKey> modifiers = <ModifierKey>{
+    if (HardwareKeyboard.instance.isControlPressed) ModifierKey.ctrl,
+    if (HardwareKeyboard.instance.isShiftPressed) ModifierKey.shift,
+    if (HardwareKeyboard.instance.isAltPressed) ModifierKey.alt,
+    if (HardwareKeyboard.instance.isMetaPressed) ModifierKey.meta,
+  };
+  return registry.resolveKeyboard(
+        event.logicalKey,
+        modifiers: modifiers,
+        scope: ShortcutScope.video,
+        physicalKey: event.physicalKey,
+      ) ==
+      ShortcutAction.videoHoldSpeed;
 }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/speed.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/speed.part.dart
@@ -107,6 +107,13 @@ extension _VideoSpeed on _VideoHibikiPageState {
   }
 
   void _handleVideoLongPressEnd(LongPressEndDetails details) {
+    // 键盘/手柄的按住临时倍速正持有恢复位（手势 start 在 previous 非空时早退、
+    // 从未接管），这次长按松手只清徽章、不动倍速——恢复权归 [_releaseHoldSpeed]。
+    if (_holdSpeedActive) {
+      _longPressDragBaseSpeed = null;
+      _longPressSpeedBadge.value = null;
+      return;
+    }
     final double? previous = _longPressPreviousSpeed;
     _longPressPreviousSpeed = null;
     _longPressDragBaseSpeed = null;
@@ -114,6 +121,42 @@ extension _VideoSpeed on _VideoHibikiPageState {
     _longPressSpeedBadge.value = null;
     if (previous == null) return;
     unawaited(_setSpeed(previous, persist: false));
+  }
+
+  /// 键盘按住/手柄翻转的「临时倍速」进入（用户请求：与手机长按画面同语义）。
+  /// 与手势 [_handleVideoLongPressStart] 共用 [_longPressPreviousSpeed] 恢复位，
+  /// 两条输入通道互斥、绝不叠加接管；键盘无指针位置，反馈走左上角 OSD 而非
+  /// 跟随徽章。临时倍速一律 persist: false——松开恢复原速，绝不污染速度记忆。
+  void _engageHoldSpeed() {
+    if (_holdSpeedActive) return;
+    if (_longPressPreviousSpeed != null) return; // 手势长按已占用临时倍速
+    _holdSpeedActive = true;
+    _longPressPreviousSpeed = _playbackSpeed;
+    final double speed = _asbConfig.longPressSpeed;
+    unawaited(_setSpeed(speed, persist: false));
+    _showOsd('${speed}x', icon: Icons.speed);
+  }
+
+  /// 松开/再按恢复原速（[_engageHoldSpeed] 的逆操作）。未处于键盘/手柄按住态时
+  /// no-op——手势通道自己的恢复走 [_handleVideoLongPressEnd]。
+  void _releaseHoldSpeed() {
+    if (!_holdSpeedActive) return;
+    _holdSpeedActive = false;
+    final double? previous = _longPressPreviousSpeed;
+    _longPressPreviousSpeed = null;
+    if (previous == null) return;
+    unawaited(_setSpeed(previous, persist: false));
+    _showOsd('${previous}x', icon: Icons.speed);
+  }
+
+  /// 手柄通道的翻转语义（手柄没有可靠的松开事件管线）：按一下进入临时倍速、
+  /// 再按恢复。与键盘按住共用同一状态，二者混用也不会叠加。
+  void _toggleHoldSpeed() {
+    if (_holdSpeedActive) {
+      _releaseHoldSpeed();
+    } else {
+      _engageHoldSpeed();
+    }
   }
 
   Future<void> _adjustSpeed(double delta) async {

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -1573,6 +1573,15 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// 调速手势中；横向拖动以此为基准连续加减，松手清空。
   double? _longPressDragBaseSpeed;
 
+  /// 键盘按住/手柄翻转的临时倍速是否进行中（用户请求：与手机长按画面同语义）。
+  /// 与手势长按共用 [_longPressPreviousSpeed] 恢复位，此标志区分恢复权归属：
+  /// true 时恢复只走 [_releaseHoldSpeed]，手势松手不越权恢复。
+  bool _holdSpeedActive = false;
+
+  /// 键盘按住临时倍速的触发键（非空 = 正按住中）。keyup/repeat 只按此键识别、
+  /// 不看修饰键，按住期间先松修饰键也不会把倍速卡在加速态。
+  LogicalKeyboardKey? _holdSpeedTriggerKey;
+
   /// TODO-1154：长按倍速指示徽章的跟随锚点（局部坐标，即 GestureDetector/Stack 同一坐标系
   /// 的 `details.localPosition`）+ 当前速度。非空时在指针上方渲染「Nx」徽章跟手移动
   /// （B 站/YouTube 长按倍速气泡观感），松手清空。**不**复用钉死左上角的 [_showOsd]。
@@ -4063,6 +4072,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       resetSpeed: () => _runWhenImmersiveAllowsShortcuts(
         () => unawaited(_setSpeed(1.0)),
       ),
+      // 手柄通道的按住临时倍速（键盘通道不经此表，见 _handleHoldSpeedKey）：
+      // 手柄没有可靠的松开事件管线，退化成按一下开/再按恢复的翻转语义。
+      toggleHoldSpeed: () => _runWhenImmersiveAllowsShortcuts(_toggleHoldSpeed),
       previousFrame: () => _runWhenImmersiveAllowsShortcuts(
         () => unawaited(controller.frameStep(forward: false)),
       ),
@@ -4290,6 +4302,49 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     }
   }
 
+  /// 按住临时倍速的键盘入口（用户请求：与手机长按画面同语义——按下加速、松开
+  /// 恢复）。按住语义需要 keyup 边沿，SingleActivator/CallbackShortcuts 表达不了，
+  /// 故该动作的键盘绑定不进 activator 表（见 [buildVideoPlayerShortcutsFromRegistry]），
+  /// 由本页最外层 [Focus] 的 onKeyEvent 直接判定：状态机是纯函数
+  /// [resolveHoldSpeedKeyTransition]，绑定命中是 [keyDownMatchesHoldSpeed]（都在
+  /// video_player_shortcuts.dart，可单测）。
+  ///
+  /// 与其它视频键语义对齐：词典浮层可见时先关浮层不执行（BUG-924 同款）；进入
+  /// 动作过 [_runWhenImmersiveAllowsShortcuts] 沉浸锁门控；文本框持焦时不接管。
+  /// keyup/repeat 只按触发键识别（不看修饰键/门控），保证任何情况下松开都能恢复。
+  KeyEventResult _handleHoldSpeedKey(KeyEvent event) {
+    final bool matches = event is KeyDownEvent &&
+        _controller != null &&
+        keyDownMatchesHoldSpeed(
+          appModel.shortcutRegistry,
+          event,
+          hasEditableFocus: focusedEditableText() != null,
+        );
+    switch (resolveHoldSpeedKeyTransition(
+      event: event,
+      activeTriggerKey: _holdSpeedTriggerKey,
+      matchesHoldSpeedBinding: matches,
+    )) {
+      case HoldSpeedKeyTransition.none:
+        return KeyEventResult.ignored;
+      case HoldSpeedKeyTransition.swallow:
+        return KeyEventResult.handled;
+      case HoldSpeedKeyTransition.release:
+        _holdSpeedTriggerKey = null;
+        _releaseHoldSpeed();
+        return KeyEventResult.handled;
+      case HoldSpeedKeyTransition.engage:
+        // BUG-924 同语义：浮层可见时任何视频键先关顶层浮层、不执行原动作。
+        if (_hasVisiblePopup) {
+          _dismissTopVisiblePopup();
+          return KeyEventResult.handled;
+        }
+        _holdSpeedTriggerKey = event.logicalKey;
+        _runWhenImmersiveAllowsShortcuts(_engageHoldSpeed);
+        return KeyEventResult.handled;
+    }
+  }
+
   /// TODO-1342：把整页子树包进手柄输入层。外层 [Actions] 接桌面轮询派发的
   /// [GamepadButtonIntent]；内层 [Focus] 只旁观 Android 原生手柄按键的冒泡（不夺焦、
   /// 不参与焦点遍历，故不干扰 [_videoFocusNode] 的键盘持焦与既有 [autofocus] 时序）。
@@ -4312,6 +4367,11 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
               (event.logicalKey == LogicalKeyboardKey.shiftLeft ||
                   event.logicalKey == LogicalKeyboardKey.shiftRight)) {
             _triggerShiftLookupAtLastPointer();
+          }
+          // 按住临时倍速（按下加速/松开恢复）需要 keyup 边沿，绑定不进内层
+          // activator 表，在此按注册表绑定判定按下/松开（见 _handleHoldSpeedKey）。
+          if (_handleHoldSpeedKey(event) == KeyEventResult.handled) {
+            return KeyEventResult.handled;
           }
           // BUG-853：IME 改写成 process 的裸空格上浮到此，先按物理键还原播放/暂停；
           // 其余键交回手柄原生入口，行为不变。

--- a/hibiki/lib/src/shortcuts/shortcut_action.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_action.dart
@@ -246,6 +246,13 @@ enum ShortcutAction {
   videoSpeedUp(ShortcutScope.video, 'video_speed_up'),
   videoSpeedDown(ShortcutScope.video, 'video_speed_down'),
   videoResetSpeed(ShortcutScope.video, 'video_reset_speed'),
+  // 按住临时倍速（用户请求）：与手机长按画面同语义——按下时临时切到长按倍速
+  // （asbplayer 配置 longPressSpeed），松开恢复原速、不落盘。键盘按住需要 keyup
+  // 边沿，SingleActivator 表达不了，故它**不进** CallbackShortcuts activator 表，
+  // 由视频页最外层 Focus.onKeyEvent 读本 action 的绑定自行判定按下/松开（见
+  // video_hibiki_page 的 _handleHoldSpeedKey）；手柄通道退化成按一下开/再按恢复
+  // 的翻转语义（videoActionCallbacks → toggleHoldSpeed）。
+  videoHoldSpeed(ShortcutScope.video, 'video_hold_speed'),
 
   // 字幕/章节跳转
   videoPreviousSubtitle(ShortcutScope.video, 'video_previous_subtitle'),

--- a/hibiki/lib/src/shortcuts/shortcut_defaults.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_defaults.dart
@@ -282,6 +282,13 @@ class ShortcutDefaults {
     ShortcutAction.videoResetSpeed: _kb([
       _key(LogicalKeyboardKey.backspace),
     ]),
+    // 按住临时倍速（对齐手机长按画面）：默认裸 E——video co-active 组内空闲
+    // （A/J=快退、D/I=快进、C/S/F/M/L/B/H/R/Z/X/P 等均已占用），且在 WASD 手位旁
+    // 便于长按。键盘-only：手柄绑定退化成翻转语义（按一下开/再按恢复），默认不绑，
+    // 用户可在设置里自绑。
+    ShortcutAction.videoHoldSpeed: _kb([
+      _key(LogicalKeyboardKey.keyE),
+    ]),
     ShortcutAction.videoPreviousFrame: _kb([
       _key(LogicalKeyboardKey.comma),
     ]),

--- a/hibiki/lib/src/shortcuts/shortcut_labels.dart
+++ b/hibiki/lib/src/shortcuts/shortcut_labels.dart
@@ -103,6 +103,8 @@ extension ShortcutActionLabel on ShortcutAction {
         return t.shortcut_action_video_speed_down;
       case ShortcutAction.videoResetSpeed:
         return t.shortcut_action_video_reset_speed;
+      case ShortcutAction.videoHoldSpeed:
+        return t.shortcut_action_video_hold_speed;
       case ShortcutAction.videoPreviousFrame:
         return t.shortcut_action_video_previous_frame;
       case ShortcutAction.videoNextFrame:

--- a/hibiki/test/media/video/video_hold_speed_key_test.dart
+++ b/hibiki/test/media/video/video_hold_speed_key_test.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' hide ModifierKey;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/video/video_player_shortcuts.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+import 'package:hibiki/src/shortcuts/shortcut_defaults.dart';
+import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
+
+/// 按住临时倍速快捷键（用户请求：与手机长按画面同语义——按下加速、松开恢复）。
+///
+/// 三层契约：
+/// 1. 纯状态机 [resolveHoldSpeedKeyTransition]：keydown 进入、repeat 消费、keyup
+///    恢复，且 keyup/repeat 只按触发键识别（松修饰键不卡加速态）。
+/// 2. 绑定命中 [keyDownMatchesHoldSpeed]：默认裸 E 命中；文本框持焦不命中；别的
+///    视频键不误命中。
+/// 3. 接线约束：videoHoldSpeed 的键盘绑定**不进** CallbackShortcuts activator 表
+///    （装进去 keydown 就被消费，页面级 Focus.onKeyEvent 永远收不到、keyup 语义
+///    无从谈起）；手柄通道经 videoActionCallbacks 的 toggleHoldSpeed 仍然活着。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  KeyDownEvent down(LogicalKeyboardKey logical, PhysicalKeyboardKey physical) =>
+      KeyDownEvent(
+        physicalKey: physical,
+        logicalKey: logical,
+        timeStamp: Duration.zero,
+      );
+
+  group('resolveHoldSpeedKeyTransition 状态机', () {
+    test('命中绑定的 keydown → engage', () {
+      expect(
+        resolveHoldSpeedKeyTransition(
+          event: down(LogicalKeyboardKey.keyE, PhysicalKeyboardKey.keyE),
+          activeTriggerKey: null,
+          matchesHoldSpeedBinding: true,
+        ),
+        HoldSpeedKeyTransition.engage,
+      );
+    });
+
+    test('未命中绑定的 keydown → none（不消费，交回既有解析路径）', () {
+      expect(
+        resolveHoldSpeedKeyTransition(
+          event: down(LogicalKeyboardKey.keyS, PhysicalKeyboardKey.keyS),
+          activeTriggerKey: null,
+          matchesHoldSpeedBinding: false,
+        ),
+        HoldSpeedKeyTransition.none,
+      );
+    });
+
+    test('按住期间触发键的 OS key-repeat → swallow（不重入、不冒泡）', () {
+      expect(
+        resolveHoldSpeedKeyTransition(
+          event: const KeyRepeatEvent(
+            physicalKey: PhysicalKeyboardKey.keyE,
+            logicalKey: LogicalKeyboardKey.keyE,
+            timeStamp: Duration.zero,
+          ),
+          activeTriggerKey: LogicalKeyboardKey.keyE,
+          matchesHoldSpeedBinding: false,
+        ),
+        HoldSpeedKeyTransition.swallow,
+      );
+    });
+
+    test('触发键 keyup → release（即使修饰键已先松开也恢复，不卡加速态）', () {
+      expect(
+        resolveHoldSpeedKeyTransition(
+          event: const KeyUpEvent(
+            physicalKey: PhysicalKeyboardKey.keyE,
+            logicalKey: LogicalKeyboardKey.keyE,
+            timeStamp: Duration.zero,
+          ),
+          activeTriggerKey: LogicalKeyboardKey.keyE,
+          matchesHoldSpeedBinding: false,
+        ),
+        HoldSpeedKeyTransition.release,
+      );
+    });
+
+    test('非触发键的 keyup/repeat/keydown 在按住期间 → none（其它键照常工作）', () {
+      const KeyUpEvent otherUp = KeyUpEvent(
+        physicalKey: PhysicalKeyboardKey.keyS,
+        logicalKey: LogicalKeyboardKey.keyS,
+        timeStamp: Duration.zero,
+      );
+      expect(
+        resolveHoldSpeedKeyTransition(
+          event: otherUp,
+          activeTriggerKey: LogicalKeyboardKey.keyE,
+          matchesHoldSpeedBinding: false,
+        ),
+        HoldSpeedKeyTransition.none,
+      );
+      expect(
+        resolveHoldSpeedKeyTransition(
+          event: down(LogicalKeyboardKey.keyS, PhysicalKeyboardKey.keyS),
+          activeTriggerKey: LogicalKeyboardKey.keyE,
+          matchesHoldSpeedBinding: false,
+        ),
+        HoldSpeedKeyTransition.none,
+      );
+    });
+
+    test('未按住时的 keyup → none（松开别的键不误恢复）', () {
+      expect(
+        resolveHoldSpeedKeyTransition(
+          event: const KeyUpEvent(
+            physicalKey: PhysicalKeyboardKey.keyE,
+            logicalKey: LogicalKeyboardKey.keyE,
+            timeStamp: Duration.zero,
+          ),
+          activeTriggerKey: null,
+          matchesHoldSpeedBinding: false,
+        ),
+        HoldSpeedKeyTransition.none,
+      );
+    });
+  });
+
+  group('keyDownMatchesHoldSpeed 绑定命中（Windows 默认表）', () {
+    HibikiShortcutRegistry registry() =>
+        HibikiShortcutRegistry()..loadDefaults(TargetPlatform.windows);
+
+    test('默认裸 E 命中', () {
+      expect(
+        keyDownMatchesHoldSpeed(
+          registry(),
+          down(LogicalKeyboardKey.keyE, PhysicalKeyboardKey.keyE),
+          hasEditableFocus: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('文本框持焦时恒不命中（输入不误触加速）', () {
+      expect(
+        keyDownMatchesHoldSpeed(
+          registry(),
+          down(LogicalKeyboardKey.keyE, PhysicalKeyboardKey.keyE),
+          hasEditableFocus: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('绑给其它视频动作的键不误命中（] = 加速步进）', () {
+      expect(
+        keyDownMatchesHoldSpeed(
+          registry(),
+          down(
+            LogicalKeyboardKey.bracketRight,
+            PhysicalKeyboardKey.bracketRight,
+          ),
+          hasEditableFocus: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('接线约束', () {
+    VideoPlayerShortcutActions actions(List<String> log) {
+      void noop() {}
+      return VideoPlayerShortcutActions(
+        togglePlayPause: noop,
+        play: noop,
+        pause: noop,
+        previousSubtitle: noop,
+        nextSubtitle: noop,
+        seekBackward: noop,
+        seekForward: noop,
+        toggleShaderCompare: noop,
+        volumeUp: noop,
+        volumeDown: noop,
+        toggleMute: noop,
+        speedUp: noop,
+        speedDown: noop,
+        resetSpeed: noop,
+        toggleHoldSpeed: () => log.add('toggleHoldSpeed'),
+        previousFrame: noop,
+        nextFrame: noop,
+        screenshot: noop,
+        toggleFullscreen: noop,
+        toggleSubtitleList: noop,
+        toggleImmersiveLock: noop,
+        toggleSubtitleBlur: noop,
+        cycleSubtitleObscure: noop,
+        toggleSubtitleHide: noop,
+        cycleSecondarySubtitleObscure: noop,
+        toggleSecondarySubtitleHide: noop,
+        toggleFavoriteSentence: noop,
+        replayCurrentSubtitle: noop,
+        replayPreviousSubtitle: noop,
+        previousChapter: noop,
+        nextChapter: noop,
+        openSubtitleAlign: noop,
+        subtitleDelayIncrease: noop,
+        subtitleDelayDecrease: noop,
+        alignSubtitleToPrev: noop,
+        alignSubtitleToNext: noop,
+        escape: noop,
+      );
+    }
+
+    test('videoHoldSpeed 的键盘绑定不进 activator 表（keyup 语义前提）', () {
+      final HibikiShortcutRegistry registry = HibikiShortcutRegistry()
+        ..loadDefaults(TargetPlatform.windows);
+      final Map<ShortcutActivator, VoidCallback> activators =
+          buildVideoPlayerShortcutsFromRegistry(registry, actions(<String>[]));
+      for (final ShortcutActivator activator in activators.keys) {
+        if (activator is! SingleActivator) continue;
+        expect(
+          activator.trigger,
+          isNot(LogicalKeyboardKey.keyE),
+          reason: '裸 E（videoHoldSpeed 默认键）装进 activator 表会在 keydown '
+              '就消费事件，页面级按下/松开判定永远收不到',
+        );
+      }
+    });
+
+    test(
+        '手柄通道仍活着：videoActionCallbacks 把 videoHoldSpeed 派发到 '
+        'toggleHoldSpeed', () {
+      final List<String> log = <String>[];
+      final Map<ShortcutAction, VoidCallback> callbacks =
+          videoActionCallbacks(actions(log));
+      final VoidCallback? callback = callbacks[ShortcutAction.videoHoldSpeed];
+      expect(callback, isNotNull);
+      callback!();
+      expect(log, <String>['toggleHoldSpeed']);
+    });
+
+    test('三平台默认表都给 videoHoldSpeed 配了键盘绑定（裸 E）', () {
+      for (final TargetPlatform platform in <TargetPlatform>[
+        TargetPlatform.windows,
+        TargetPlatform.macOS,
+        TargetPlatform.android,
+      ]) {
+        final ShortcutBindingSet? bindings = ShortcutDefaults.forPlatform(
+            platform)[ShortcutAction.videoHoldSpeed];
+        expect(bindings, isNotNull, reason: '$platform 缺默认绑定');
+        expect(
+          bindings!.keyboardBindings.any((InputBinding b) =>
+              b.key == LogicalKeyboardKey.keyE && b.modifiers.isEmpty),
+          isTrue,
+          reason: '$platform 默认键应为裸 E',
+        );
+      }
+    });
+  });
+}

--- a/hibiki/test/media/video/video_player_shortcuts_dispatch_test.dart
+++ b/hibiki/test/media/video/video_player_shortcuts_dispatch_test.dart
@@ -22,6 +22,7 @@ VideoPlayerShortcutActions _recordingVideoActions(List<String> log) {
     speedUp: () => record('speedUp'),
     speedDown: () => record('speedDown'),
     resetSpeed: () => record('resetSpeed'),
+    toggleHoldSpeed: () => record('toggleHoldSpeed'),
     previousFrame: () => record('previousFrame'),
     nextFrame: () => record('nextFrame'),
     screenshot: () => record('screenshot'),

--- a/hibiki/test/pages/video_fullscreen_gamepad_dispatch_test.dart
+++ b/hibiki/test/pages/video_fullscreen_gamepad_dispatch_test.dart
@@ -203,6 +203,7 @@ class _Rig {
       speedUp: _noop,
       speedDown: _noop,
       resetSpeed: _noop,
+      toggleHoldSpeed: _noop,
       previousFrame: _noop,
       nextFrame: _noop,
       screenshot: _noop,

--- a/hibiki/test/shortcuts/video_shortcut_registry_test.dart
+++ b/hibiki/test/shortcuts/video_shortcut_registry_test.dart
@@ -25,6 +25,7 @@ VideoPlayerShortcutActions _recordingActions(List<String> log) {
     speedUp: () => log.add('speedUp'),
     speedDown: () => log.add('speedDown'),
     resetSpeed: () => log.add('resetSpeed'),
+    toggleHoldSpeed: () => log.add('toggleHoldSpeed'),
     previousFrame: () => log.add('previousFrame'),
     nextFrame: () => log.add('nextFrame'),
     screenshot: () => log.add('screenshot'),


### PR DESCRIPTION
## 需求

用户请求：给视频页加一个倍速快捷键，效果与手机长按画面相同——**按住加速、松开恢复原速**。

## 实现

- 新增 `ShortcutAction.videoHoldSpeed`（video scope，默认裸 `E`，可在快捷键设置改键）。
- 按下：临时切到 asbplayer 配置的长按倍速（`longPressSpeed`，与手势长按同一配置项）；松开：恢复原速。全程 `persist: false`，不污染 per-book 速度记忆。
- 与触屏长按手势共用 `_longPressPreviousSpeed` 恢复位，互斥不叠加；`_holdSpeedActive` 标志区分恢复权，手势松手不越权恢复键盘的按住态。
- **按住语义需要 keyup 边沿**，`SingleActivator`/CallbackShortcuts 表达不了，故该动作的键盘绑定不进 activator 表（`buildVideoPlayerShortcutsFromRegistry` 显式跳过），由视频页最外层 `Focus.onKeyEvent` 判定：
  - 纯函数状态机 `resolveHoldSpeedKeyTransition`（keydown 进入 / repeat 消费 / keyup 恢复；keyup 只按触发键识别，先松修饰键不会卡在加速态）。
  - 绑定命中 `keyDownMatchesHoldSpeed`（HardwareKeyboard 实时修饰键 + TODO-847 physicalKey IME 回退；文本框持焦不接管）。
  - 语义对齐既有视频键：浮层可见先关浮层（BUG-924 同款）、进入过沉浸锁门控。
- 手柄通道无可靠松开事件管线，经 `videoActionCallbacks` 退化为翻转语义（按一下开/再按恢复），默认不绑、避免死绑定。
- 键盘无指针位置，反馈走左上角 OSD（`2.0x`），不复用跟随指针的长按徽章。
- i18n：`shortcut_action_video_hold_speed` 经 i18n_sync 全 17 语言添加 + slang 重新生成。
- 旧快捷键快照兼容：新 action 不在旧快照里，`loadFromJsonString` 先落默认再覆盖显式条目，自动获得默认键 E，无需 bump schema。

## 验证

- `flutter analyze` 全量：No issues found。
- 定向 + 爆炸半径测试全绿（`test/shortcuts` 全目录 + `test/i18n` + 视频静态守卫 + 新测试，555 passed）。
- 新增 `test/media/video/video_hold_speed_key_test.dart`（状态机 / 绑定命中 / 「E 不进 activator 表、手柄回调仍在」接线契约），并对「跳过分支」做了变异实测：移除后测试即红。
- 未真机复测（键盘按住/松开的端到端手感），验证缺口记在此。

https://claude.ai/code/session_01JAzbrevw2215qYEq2j6C9k