### PR TITLE
feat(dict): 推荐词典弹窗新增学习语言维度（其他语言词典）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 47022 (2766 per locale)
+/// Strings: 47073 (2769 per locale)
 ///
-/// Built on 2026-07-29 at 08:08 UTC
+/// Built on 2026-07-31 at 04:51 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3718,6 +3718,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get selection_web_search => 'Search the web';
   String get selection_web_search_unavailable => 'No app can search the web.';
   String get selection_share_failed => 'Could not open the share sheet.';
+  String get dict_download_learning_language => 'Learning language';
+  String get dict_category_bilingual => 'Bilingual';
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -10050,6 +10053,12 @@ class _StringsAr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -16450,6 +16459,12 @@ class _StringsDe extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -22866,6 +22881,12 @@ class _StringsEs extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -29293,6 +29314,12 @@ class _StringsFr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -35649,6 +35676,12 @@ class _StringsId extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -42051,6 +42084,12 @@ class _StringsIt extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -48270,6 +48309,12 @@ class _StringsJa extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -54491,6 +54536,12 @@ class _StringsKo extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -60873,6 +60924,12 @@ class _StringsNl extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -67268,6 +67325,12 @@ class _StringsPtBr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -73647,6 +73710,12 @@ class _StringsRu extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -79974,6 +80043,12 @@ class _StringsTh extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -86333,6 +86408,12 @@ class _StringsTr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -92677,6 +92758,12 @@ class _StringsVi extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 // Path: <root>
@@ -98572,6 +98659,12 @@ class _StringsZhCn extends _StringsEn {
   String get selection_web_search_unavailable => '没有可用的网页搜索应用。';
   @override
   String get selection_share_failed => '无法打开分享面板。';
+  @override
+  String get dict_download_learning_language => '学习语言';
+  @override
+  String get dict_category_bilingual => '双语';
+  @override
+  String get dict_category_monolingual => '单语';
 }
 
 // Path: <root>
@@ -104712,6 +104805,12 @@ class _StringsZhHk extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get dict_download_learning_language => 'Learning language';
+  @override
+  String get dict_category_bilingual => 'Bilingual';
+  @override
+  String get dict_category_monolingual => 'Monolingual';
 }
 
 /// Flat map(s) containing all translations.
@@ -110379,6 +110478,12 @@ extension on _StringsEn {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -116044,6 +116149,12 @@ extension on _StringsAr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -121730,6 +121841,12 @@ extension on _StringsDe {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -127415,6 +127532,12 @@ extension on _StringsEs {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -133106,6 +133229,12 @@ extension on _StringsFr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -138779,6 +138908,12 @@ extension on _StringsId {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -144467,6 +144602,12 @@ extension on _StringsIt {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -150117,6 +150258,12 @@ extension on _StringsJa {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -155771,6 +155918,12 @@ extension on _StringsKo {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -161452,6 +161605,12 @@ extension on _StringsNl {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -167130,6 +167289,12 @@ extension on _StringsPtBr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -172813,6 +172978,12 @@ extension on _StringsRu {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -178480,6 +178651,12 @@ extension on _StringsTh {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -184156,6 +184333,12 @@ extension on _StringsTr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -189827,6 +190010,12 @@ extension on _StringsVi {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }
@@ -195451,6 +195640,12 @@ extension on _StringsZhCn {
         return '没有可用的网页搜索应用。';
       case 'selection_share_failed':
         return '无法打开分享面板。';
+      case 'dict_download_learning_language':
+        return '学习语言';
+      case 'dict_category_bilingual':
+        return '双语';
+      case 'dict_category_monolingual':
+        return '单语';
       default:
         return null;
     }
@@ -201096,6 +201291,12 @@ extension on _StringsZhHk {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'dict_download_learning_language':
+        return 'Learning language';
+      case 'dict_category_bilingual':
+        return 'Bilingual';
+      case 'dict_category_monolingual':
+        return 'Monolingual';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。",
   "selection_web_search": "网页搜索",
   "selection_web_search_unavailable": "没有可用的网页搜索应用。",
-  "selection_share_failed": "无法打开分享面板。"
+  "selection_share_failed": "无法打开分享面板。",
+  "dict_download_learning_language": "学习语言",
+  "dict_category_bilingual": "双语",
+  "dict_category_monolingual": "单语"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2764,5 +2764,8 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "dict_download_learning_language": "Learning language",
+  "dict_category_bilingual": "Bilingual",
+  "dict_category_monolingual": "Monolingual"
 }

--- a/hibiki/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -548,6 +548,10 @@ class _DictionaryDialogPageState extends BasePageState {
         return t.dict_category_names;
       case DictionaryCategory.supplementary:
         return t.dict_category_supplementary;
+      case DictionaryCategory.bilingual:
+        return t.dict_category_bilingual;
+      case DictionaryCategory.monolingual:
+        return t.dict_category_monolingual;
     }
   }
 
@@ -591,10 +595,14 @@ class _DictionaryDialogPageState extends BasePageState {
     if (!DictionaryDownloader.availableLanguages.containsKey(selectedLang)) {
       selectedLang = 'en';
     }
-    var workingCatalog = DictionaryDownloader.catalogForLang(selectedLang);
+    var selectedLearningLang = 'ja';
+    var workingCatalog = DictionaryDownloader.catalogForLearningLang(
+        learningLang: selectedLearningLang, glossLang: selectedLang);
     var installedIndices = _computeInstalledIndices(workingCatalog);
-    var defaults = DictionaryDownloader.defaultSelectionForLang(
-        selectedLang, workingCatalog);
+    var defaults = DictionaryDownloader.defaultSelectionForLearningLang(
+        learningLang: selectedLearningLang,
+        glossLang: selectedLang,
+        workingCatalog: workingCatalog);
     var checked = Set<int>.from(defaults.difference(installedIndices));
     // HBK-AUDIT-110: byCategory and the rec->index map depend only on
     // workingCatalog, not on checkbox toggles. Compute them here (and again
@@ -602,9 +610,25 @@ class _DictionaryDialogPageState extends BasePageState {
     // don't re-derive the grouping or run O(n) catalog.indexOf per checkbox.
     var byCategory = DictionaryDownloader.byCategoryFrom(workingCatalog);
     var recIndex = _computeRecIndices(workingCatalog);
+    // 学习语言/释义语言任一变化都重建整个目录派生状态。
+    void recomputeCatalogState() {
+      workingCatalog = DictionaryDownloader.catalogForLearningLang(
+          learningLang: selectedLearningLang, glossLang: selectedLang);
+      byCategory = DictionaryDownloader.byCategoryFrom(workingCatalog);
+      recIndex = _computeRecIndices(workingCatalog);
+      installedIndices = _computeInstalledIndices(workingCatalog);
+      defaults = DictionaryDownloader.defaultSelectionForLearningLang(
+          learningLang: selectedLearningLang,
+          glossLang: selectedLang,
+          workingCatalog: workingCatalog);
+      checked = Set<int>.from(defaults.difference(installedIndices));
+    }
+
     final Set<DictionaryCategory> expandedCategories = <DictionaryCategory>{
       DictionaryCategory.jaEn,
       DictionaryCategory.jaJa,
+      DictionaryCategory.bilingual,
+      DictionaryCategory.monolingual,
     };
 
     final selected = await showAppDialog<Set<int>>(
@@ -621,25 +645,26 @@ class _DictionaryDialogPageState extends BasePageState {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     _buildLanguageSelector(
+                      label: t.dict_download_learning_language,
+                      selectedLang: selectedLearningLang,
+                      onChanged: (String lang) {
+                        setDialogState(() {
+                          selectedLearningLang = lang;
+                          recomputeCatalogState();
+                        });
+                      },
+                    ),
+                    SizedBox(height: tokens.spacing.gap),
+                    _buildLanguageSelector(
+                      label: t.dict_download_language,
                       selectedLang: selectedLang,
                       onChanged: (String lang) {
                         setDialogState(() {
                           selectedLang = lang;
-                          workingCatalog =
-                              DictionaryDownloader.catalogForLang(lang);
                           // HBK-AUDIT-110: recompute the catalog-derived
                           // structures only when the language (hence catalog)
                           // actually changes.
-                          byCategory = DictionaryDownloader.byCategoryFrom(
-                              workingCatalog);
-                          recIndex = _computeRecIndices(workingCatalog);
-                          installedIndices =
-                              _computeInstalledIndices(workingCatalog);
-                          defaults =
-                              DictionaryDownloader.defaultSelectionForLang(
-                                  lang, workingCatalog);
-                          checked = Set<int>.from(
-                              defaults.difference(installedIndices));
+                          recomputeCatalogState();
                         });
                       },
                     ),
@@ -705,6 +730,7 @@ class _DictionaryDialogPageState extends BasePageState {
   }
 
   Widget _buildLanguageSelector({
+    required String label,
     required String selectedLang,
     required ValueChanged<String> onChanged,
   }) {
@@ -712,7 +738,7 @@ class _DictionaryDialogPageState extends BasePageState {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     return Row(
       children: [
-        Text(t.dict_download_language, style: tokens.type.controlLabel),
+        Text(label, style: tokens.type.controlLabel),
         SizedBox(width: tokens.spacing.gap),
         Expanded(
           child: GamepadMenuDropdown<String>(

--- a/hibiki/test/dictionary/dictionary_downloader_learning_catalog_test.dart
+++ b/hibiki/test/dictionary/dictionary_downloader_learning_catalog_test.dart
@@ -1,0 +1,158 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_dictionary/hibiki_dictionary.dart';
+
+/// 推荐词典「学习语言」维度：非日语学习语言动态生成 wty 双语/单语条目，
+/// 日语路径必须与旧 [DictionaryDownloader.catalogForLang] 完全一致（零破坏）。
+void main() {
+  group('catalogForLearningLang', () {
+    test('日语学习语言 == 旧目录（行为零变化）', () {
+      for (final String gloss in ['en', 'zh', 'ko', 'de', 'ja']) {
+        final List<RecommendedDictionary> legacy =
+            DictionaryDownloader.catalogForLang(gloss);
+        final List<RecommendedDictionary> viaLearning =
+            DictionaryDownloader.catalogForLearningLang(
+                learningLang: 'ja', glossLang: gloss);
+        expect(
+          viaLearning.map((d) => d.matchPrefix).toList(),
+          legacy.map((d) => d.matchPrefix).toList(),
+          reason: 'gloss=$gloss 时日语目录必须与旧实现逐条一致',
+        );
+      }
+    });
+
+    test('学英语 + 中文释义 → 双语 en-zh + 英语兜底不重复 + 单语 en-en', () {
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLearningLang(
+              learningLang: 'en', glossLang: 'zh');
+      expect(cat.map((d) => d.matchPrefix), ['wty-en-zh', 'wty-en-en']);
+      expect(cat[0].category, DictionaryCategory.bilingual);
+      expect(cat[0].url,
+          'https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/dict/en/zh/wty-en-zh.zip');
+      expect(cat[1].category, DictionaryCategory.monolingual);
+    });
+
+    test('学中文 + 日语释义 → zh-ja、zh-en 兜底、zh-zh 单语', () {
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLearningLang(
+              learningLang: 'zh', glossLang: 'ja');
+      expect(cat.map((d) => d.matchPrefix),
+          ['wty-zh-ja', 'wty-zh-en', 'wty-zh-zh']);
+    });
+
+    test('释义语言 == 学习语言 → 只有英语兜底双语 + 单语', () {
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLearningLang(
+              learningLang: 'ko', glossLang: 'ko');
+      expect(cat.map((d) => d.matchPrefix), ['wty-ko-en', 'wty-ko-ko']);
+    });
+
+    test('受限源语言（hu）缺 sv 目标与单语 → 只剩英语兜底', () {
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLearningLang(
+              learningLang: 'hu', glossLang: 'sv');
+      expect(cat.map((d) => d.matchPrefix), ['wty-hu-en']);
+    });
+
+    test('id 源缺 mn 目标但保留单语', () {
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLearningLang(
+              learningLang: 'id', glossLang: 'mn');
+      expect(cat.map((d) => d.matchPrefix), ['wty-id-en', 'wty-id-id']);
+    });
+
+    test('非日语目录不含日语专属条目（JPDB/KANJIDIC 等）', () {
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLearningLang(
+              learningLang: 'en', glossLang: 'zh');
+      expect(
+        cat.where((d) => !d.matchPrefix.startsWith('wty-')),
+        isEmpty,
+        reason: '非日语学习语言只应有 wty 动态条目',
+      );
+    });
+  });
+
+  group('defaultSelectionForLearningLang', () {
+    test('日语委托旧默认勾选', () {
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLang('zh');
+      expect(
+        DictionaryDownloader.defaultSelectionForLearningLang(
+            learningLang: 'ja', glossLang: 'zh', workingCatalog: cat),
+        DictionaryDownloader.defaultSelectionForLang('zh', cat),
+      );
+    });
+
+    test('非日语默认勾第一个双语条目', () {
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLearningLang(
+              learningLang: 'en', glossLang: 'zh');
+      final Set<int> sel = DictionaryDownloader.defaultSelectionForLearningLang(
+          learningLang: 'en', glossLang: 'zh', workingCatalog: cat);
+      expect(sel, {0});
+      expect(cat[0].matchPrefix, 'wty-en-zh');
+    });
+
+    test('无双语（受限对全灭时）回落单语；目录空则空选', () {
+      // en 学 en 释义：无双语（同语言），应勾英英单语。
+      final List<RecommendedDictionary> cat =
+          DictionaryDownloader.catalogForLearningLang(
+              learningLang: 'en', glossLang: 'en');
+      expect(cat.map((d) => d.matchPrefix), ['wty-en-en']);
+      expect(
+        DictionaryDownloader.defaultSelectionForLearningLang(
+            learningLang: 'en', glossLang: 'en', workingCatalog: cat),
+        {0},
+      );
+      expect(
+        DictionaryDownloader.defaultSelectionForLearningLang(
+            learningLang: 'en',
+            glossLang: 'en',
+            workingCatalog: const <RecommendedDictionary>[]),
+        isEmpty,
+      );
+    });
+  });
+
+  group('indexUrl 对任意 wty 语言对派生（在线更新能力保持）', () {
+    test('wty-en-zh → 独立 index 端点', () {
+      final RecommendedDictionary d =
+          DictionaryDownloader.wtyPairDict(srcLang: 'en', tgtLang: 'zh')!;
+      expect(
+        d.indexUrl,
+        'https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/index/wty-en-zh-index.json?download=true',
+      );
+      expect(d.isCatalogUpdatable, isTrue);
+    });
+
+    test('旧 ja 条目派生不变（wty-ja-en）', () {
+      final RecommendedDictionary d = DictionaryDownloader.catalog
+          .singleWhere((x) => x.matchPrefix == 'wty-ja-en');
+      expect(
+        d.indexUrl,
+        'https://huggingface.co/datasets/daxida/wty-release/resolve/main/latest/index/wty-ja-en-index.json?download=true',
+      );
+    });
+  });
+
+  group('wtyPairAvailable 矩阵规则', () {
+    test('主流语言对全可用', () {
+      expect(DictionaryDownloader.wtyPairAvailable('en', 'zh'), isTrue);
+      expect(DictionaryDownloader.wtyPairAvailable('zh', 'hu'), isTrue);
+      expect(DictionaryDownloader.wtyPairAvailable('ja', 'mn'), isTrue);
+    });
+
+    test('受限源 × 缺失目标 不可用', () {
+      expect(DictionaryDownloader.wtyPairAvailable('hu', 'hu'), isFalse);
+      expect(DictionaryDownloader.wtyPairAvailable('sv', 'mn'), isFalse);
+      expect(DictionaryDownloader.wtyPairAvailable('mn', 'sl'), isFalse);
+      expect(DictionaryDownloader.wtyPairAvailable('id', 'id'), isTrue,
+          reason: 'id 有单语，只缺 hu/sl/sv/mn 目标');
+    });
+
+    test('未知语言码不可用', () {
+      expect(DictionaryDownloader.wtyPairAvailable('xx', 'en'), isFalse);
+      expect(DictionaryDownloader.wtyPairAvailable('en', 'xx'), isFalse);
+    });
+  });
+}

--- a/packages/hibiki_dictionary/lib/src/formats/dictionary_downloader.dart
+++ b/packages/hibiki_dictionary/lib/src/formats/dictionary_downloader.dart
@@ -14,6 +14,12 @@ enum DictionaryCategory {
   frequency,
   names,
   supplementary,
+
+  /// 非日语学习语言的「学习语言→释义语言」双语词典分组。
+  bilingual,
+
+  /// 非日语学习语言的单语词典分组。
+  monolingual,
 }
 
 class RecommendedDictionary {
@@ -59,15 +65,17 @@ class RecommendedDictionary {
     if (url.startsWith(yomidevsPrefix) && url.endsWith('.zip')) {
       return '${url.substring(0, url.length - '.zip'.length)}.json';
     }
-    // wty: .../latest/dict/ja/<lang>/wty-ja-<lang>.zip
-    //   →  .../latest/index/wty-ja-<lang>-index.json?download=true
+    // wty: .../latest/dict/<src>/<tgt>/wty-<src>-<tgt>.zip
+    //   →  .../latest/index/wty-<src>-<tgt>-index.json?download=true
+    // （对任意语言对同构；ja 与非 ja 学习语言共用一条派生规则，实测非 ja 对
+    // 的 index 端点同样 200，如 wty-en-zh-index.json。）
     final RegExp wtyRe = RegExp(
-      r'^(https://huggingface\.co/datasets/daxida/wty-release/resolve/main/latest)/dict/ja/([a-z-]+)/(wty-ja-[a-z-]+)\.zip$',
+      r'^(https://huggingface\.co/datasets/daxida/wty-release/resolve/main/latest)/dict/[a-z-]+/[a-z-]+/(wty-[a-z-]+)\.zip$',
     );
     final RegExpMatch? m = wtyRe.firstMatch(url);
     if (m != null) {
       final String base = m.group(1)!;
-      final String stem = m.group(3)!;
+      final String stem = m.group(2)!;
       return '$base/index/$stem-index.json?download=true';
     }
     return null;
@@ -163,6 +171,107 @@ class DictionaryDownloader {
     final RecommendedDictionary? wty = wtyDictForLang(langCode);
     if (wty != null) result.add(wty);
     return result;
+  }
+
+  // ── 学习语言维度（非日语） ──────────────────────────────────────────
+  //
+  // wty-release 语言对矩阵实测快照（2026-07-31，逐语言枚举 HuggingFace tree API）：
+  // [availableLanguages] 的 23 种语言全部存在源语言目录；仅下述受限源缺少
+  // {hu, sl, sv, mn} 目标语言（含各自的单语包）。快照可能随上游再生成漂移，
+  // 下载失败路径由 UI 层既有错误提示兜底。
+
+  /// wty 上目标语言覆盖不全的源语言（缺 [_wtyLimitedTargets]）。
+  static const Set<String> _wtyLimitedSources = {'hu', 'sl', 'sv', 'id', 'mn'};
+
+  /// 受限源语言缺失的目标语言集合。
+  static const Set<String> _wtyLimitedTargets = {'hu', 'sl', 'sv', 'mn'};
+
+  /// Whether wty publishes a `wty-<src>-<tgt>.zip` for this pair.
+  static bool wtyPairAvailable(String srcLang, String tgtLang) {
+    if (!availableLanguages.containsKey(srcLang) ||
+        !availableLanguages.containsKey(tgtLang)) {
+      return false;
+    }
+    return !(_wtyLimitedSources.contains(srcLang) &&
+        _wtyLimitedTargets.contains(tgtLang));
+  }
+
+  /// Builds the wty entry for learning [srcLang] glossed in [tgtLang].
+  /// Returns null when the pair is not published.
+  static RecommendedDictionary? wtyPairDict({
+    required String srcLang,
+    required String tgtLang,
+  }) {
+    if (!wtyPairAvailable(srcLang, tgtLang)) return null;
+    final String srcName = availableLanguages[srcLang]!;
+    final String tgtName = availableLanguages[tgtLang]!;
+    final bool mono = srcLang == tgtLang;
+    return RecommendedDictionary(
+      name: mono
+          ? 'Wiktionary ${srcLang.toUpperCase()}-${srcLang.toUpperCase()} '
+              '($srcName)'
+          : 'Wiktionary ${srcLang.toUpperCase()}-${tgtLang.toUpperCase()} '
+              '($tgtName)',
+      url: '$_wtyBase/$srcLang/$tgtLang/wty-$srcLang-$tgtLang.zip',
+      description:
+          mono ? 'Wiktionary $srcName' : 'Wiktionary $srcName–$tgtName',
+      matchPrefix: 'wty-$srcLang-$tgtLang',
+      category:
+          mono ? DictionaryCategory.monolingual : DictionaryCategory.bilingual,
+      sizeEstimate: '~10 MB',
+      langCode: tgtLang,
+    );
+  }
+
+  /// Catalog for learning [learningLang] with glosses in [glossLang].
+  ///
+  /// 日语沿用完整人工目录（行为与 [catalogForLang] 完全一致）；其余学习语言
+  /// 动态生成 wty 双语（学习语言→释义语言，另附→英语兜底）+ 单语条目。
+  static List<RecommendedDictionary> catalogForLearningLang({
+    required String learningLang,
+    required String glossLang,
+  }) {
+    if (learningLang == 'ja') return catalogForLang(glossLang);
+    final List<RecommendedDictionary> result = [];
+    void add(RecommendedDictionary? d) {
+      if (d == null) return;
+      if (result.any((e) => e.matchPrefix == d.matchPrefix)) return;
+      result.add(d);
+    }
+
+    if (glossLang != learningLang) {
+      add(wtyPairDict(srcLang: learningLang, tgtLang: glossLang));
+    }
+    if (glossLang != 'en' && learningLang != 'en') {
+      add(wtyPairDict(srcLang: learningLang, tgtLang: 'en'));
+    }
+    add(wtyPairDict(srcLang: learningLang, tgtLang: learningLang));
+    return result;
+  }
+
+  /// Pre-checked indices for the learning-language catalog.
+  ///
+  /// 日语委托 [defaultSelectionForLang]；其余学习语言默认勾选第一个双语条目
+  /// （学习语言→释义语言，缺对时是→英语兜底），没有双语时勾单语。
+  static Set<int> defaultSelectionForLearningLang({
+    required String learningLang,
+    required String glossLang,
+    required List<RecommendedDictionary> workingCatalog,
+  }) {
+    if (learningLang == 'ja') {
+      return defaultSelectionForLang(glossLang, workingCatalog);
+    }
+    for (int i = 0; i < workingCatalog.length; i++) {
+      if (workingCatalog[i].category == DictionaryCategory.bilingual) {
+        return {i};
+      }
+    }
+    for (int i = 0; i < workingCatalog.length; i++) {
+      if (workingCatalog[i].category == DictionaryCategory.monolingual) {
+        return {i};
+      }
+    }
+    return {};
   }
 
   /// Groups [items] by category.


### PR DESCRIPTION
## 需求

推荐词典下载弹窗此前只有「你的语言」（释义语言）一个下拉，目录全部是学日语的词典。本 PR 新增「学习语言」维度：为其他学习语言提供推荐词典。

## 实现

- **学习语言下拉**（默认日语）：日语路径与旧实现逐条一致（有零破坏守卫测试）；其他 22 种学习语言动态生成 Wiktionary（HuggingFace daxida/wty-release，与现有 wty 条目同一数据源）双语 + 单语条目：
  - 双语：学习语言→释义语言；释义语言非英语时另附→英语兜底条目
  - 单语：学习语言→学习语言
- **语言对可用性**按实测矩阵快照编码（2026-07-31 逐语言枚举 HuggingFace tree API）：23 种语言全部存在源目录，仅 hu/sl/sv/id/mn 作源时缺 hu/sl/sv/mn 目标（含相应单语）。不会生成 404 条目。
- **在线更新能力保持**：wty indexUrl 派生正则从 ja 专用泛化到任意语言对（wty-en-zh-index.json 实测 200），初装即回填 isUpdatable 三件套（TODO-1075 契约不变）。
- **分组**：`DictionaryCategory` 新增 `bilingual`/`monolingual`；i18n 经 i18n_sync 新增 3 key（dict_download_learning_language / dict_category_bilingual / dict_category_monolingual），`dart run slang` 重新生成。
- 引擎侧无改动：19 种语言变换表本就全量预加载进 hoshidicts，多语言查词能力已存在。

## 验证

- `flutter analyze` 全量：No issues found
- `flutter test test/dictionary test/i18n --no-pub`：272 passed
- 相邻 widget/守卫测试（download dialog / dialog layout / update UI guard / 下载报错穿透）：34 passed
- 新增 `test/dictionary/dictionary_downloader_learning_catalog_test.dart`：日语零变化、双语/兜底/单语生成、受限矩阵、indexUrl 派生、默认勾选

## 未验证

- 真机下载安装非日语词典的端到端路径未验证（弹窗 UI 手动路径）

https://claude.ai/code/session_016fE6wcKVmgibuDNqHw8wXc