### PR TITLE
fix(dict): OALD 分卷 MDD 挂载 + 词典内 sound:// 发音播放（BUG-1261）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1200 条。点号进各自文件。
+> 共 1201 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1261](bugs/BUG-1261-oald-mdd-parts-sound-play.md) | ✅ | ✅ | MDX 分卷 MDD 未挂载 + 词典内 sound:// 发音点击无反应（OALD） |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |
 | [BUG-1243](bugs/BUG-1243-audiobook-clip-multicue-export.md) | ✅ | ✅ | 有声书片段导出多句退化并附带多余音频文件 |

--- a/docs/bugs/BUG-1261-oald-mdd-parts-sound-play.md
+++ b/docs/bugs/BUG-1261-oald-mdd-parts-sound-play.md
@@ -1,0 +1,13 @@
+## BUG-1261 · MDX 分卷 MDD 未挂载 + 词典内 sound:// 发音点击无反应（OALD）
+- **报告**：2026-07-31（用户：导入「OALD 2024.09」（OALDPE：oaldpe.mdx + oaldpe.mdd + oaldpe.1/2/3.mdd）后，点词典释义里自带的发音按钮没反应）
+- **真实性**：✅ 真 bug，两层根因叠加（任一层都足以让发音完全无反应）：
+  1. **分卷 MDD 根本没导入**：`native/hoshidicts/hoshidicts_src/importer.cpp`（原 1027-1031 行）只做 `Foo.mdx → Foo.mdd` 单文件挂载；MDict 惯例的编号分卷 `Foo.1.mdd / Foo.2.mdd / ...` 完全被忽略。OALDPE 的全部发音 mp3（`oaldpe.1.mdd` 16 万个单词音 + `oaldpe.3.mdd` 11 万个例句音，实测均为 .mp3）和例句配图（`oaldpe.2.mdd`）都在分卷里 → `getMediaFile` 必 miss。zip 导入路径（原 1074 行）同样只放行 `fstem == stem` 的 `.mdd`。
+  2. **sound:// 播放从未实现**：`hibiki/assets/popup/popup.js` `handleGlossaryAnchorClick`（原 4317-4320 行）把 `sound://` 点击 preventDefault 后**故意丢弃**（注释「播放另属后续能力」，BUG-767 时留下的缺口）；四个弹窗表面注册的自定义 scheme 只有 `image`/`dictmedia`，无任何取音频播放的通路。
+- **[x] ① 已修复** — 提交 `8a2b0753c`：
+  - C++：`import_mdd_into` 改为多文件单索引合并写（逐分卷解析、峰值内存仍为单分卷；全部记录进**一个** `media.bin`/`media.idx`，查询侧二分不变）；新增 `collect_sibling_mdd_paths`（主 `.mdd` + 顺序编号 `.N.mdd`，断号即止）；zip 路径放行 `stem.N.mdd`。顺带把 `append_media_record` 的写偏移累计从 u32 加宽到 u64（磁盘格式本就是 u64 偏移；OALD 解压后 ~3.7GB 已贴近 4GB 回绕悬崖，多分卷合并必须消掉这个静默越界边界）。
+  - JS：`handleGlossaryAnchorClick` 的 `sound://` 分支剥前缀后复用 `rewriteDictionaryMediaPath`（与 `<img>`/gaiji 同一词典媒体字节通道：app 内 → `image://` scheme，四个宿主表面均已注册且 WebView2 过滤器为 `*`+CONTEXT_ALL；浏览器扩展 → 带 token 的 `/api/media/dictionary`），经 `playWordAudio` 播放（与单词 ♪ 同音量/interrupt 语义）。三份 popup.js 镜像经 sync-mirrors.mjs 同步。Dart/native 零改动（mp3 MIME 已在 `mimeTypeForFilePath`，autoplay 已放开）。
+  - Dart 导入层核查：目录导入把 .mdx **原始路径**直接交 native（`dictionary_import_manager.dart:343-347`），分卷躺在同目录，无需改动。
+- **[x] ② 已加自动化测试** — 同提交 `8a2b0753c`：
+  - `native/hoshidicts/tests/mdd_media_import_test.cpp`：M.mdd + M.1.mdd + M.2.mdd 三分卷导入，断言三个 key（含 mp3）全部可取（已变异实测：砍掉分卷发现逻辑 → 两个分卷 blob 取不到，测试红）。
+  - `test/js/dict_glossary_crossref_link.test.mjs`：`sound://` 点击（在 `data-dictionary` 容器内）断言阻止导航、不查词、且以精确 `image://?dictionary=...&path=...` URL 触发一次播放；无词典容器时不播不崩。
+- **备注**：修复要生效需**删除并重新导入** OALD（分卷资源是导入期写入 media.bin 的）。移动端单文件选择器（SAF）只拷 .mdx 本体、丢所有 sibling（主 .mdd 同样受影响）是既有限制，不在本轮范围；文件夹导入路径无此问题。`.spx`（老 OALD Speex）仍不可解码——OALDPE 2024.09 实测全 mp3，不涉及。

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -4315,7 +4315,19 @@ function handleGlossaryAnchorClick(event, anchor) {
         return;
     }
     if (/^sound:/i.test(href)) {
-        // 词典发音媒体节点（sound://xxx），不是查词目标；导航已被阻止，播放另属后续能力。
+        // BUG-1261：词典发音媒体节点（sound://xxx）。不是查词目标；导航已被阻止，
+        // 改走与 <img>/gaiji 完全相同的词典媒体字节通道播放：剥掉 sound: 前缀后交给
+        // rewriteDictionaryMediaPath（app 内 → image:// 自定义 scheme，四个宿主表面
+        // 均已注册；浏览器扩展 → 带 token 的 /api/media/dictionary HTTP 端点），
+        // 再用 playWordAudio 播（与单词 ♪ 同一 <audio> 路径：音量/interrupt 语义一致）。
+        // dictName 取最近的 [data-dictionary] 容器（MDX 释义 wrapper 3052 行必设）。
+        const dictNode = anchor.closest('[data-dictionary]');
+        const soundDict = dictNode ? dictNode.getAttribute('data-dictionary') : '';
+        const soundPath = href.replace(/^sound:\/*/i, '');
+        if (soundDict && soundPath) {
+            const soundUrl = rewriteDictionaryMediaPath(soundPath, soundDict);
+            if (soundUrl) playWordAudio(soundUrl);
+        }
         return;
     }
     const query = (anchor.textContent || '').trim();

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -4315,7 +4315,19 @@ function handleGlossaryAnchorClick(event, anchor) {
         return;
     }
     if (/^sound:/i.test(href)) {
-        // 词典发音媒体节点（sound://xxx），不是查词目标；导航已被阻止，播放另属后续能力。
+        // BUG-1261：词典发音媒体节点（sound://xxx）。不是查词目标；导航已被阻止，
+        // 改走与 <img>/gaiji 完全相同的词典媒体字节通道播放：剥掉 sound: 前缀后交给
+        // rewriteDictionaryMediaPath（app 内 → image:// 自定义 scheme，四个宿主表面
+        // 均已注册；浏览器扩展 → 带 token 的 /api/media/dictionary HTTP 端点），
+        // 再用 playWordAudio 播（与单词 ♪ 同一 <audio> 路径：音量/interrupt 语义一致）。
+        // dictName 取最近的 [data-dictionary] 容器（MDX 释义 wrapper 3052 行必设）。
+        const dictNode = anchor.closest('[data-dictionary]');
+        const soundDict = dictNode ? dictNode.getAttribute('data-dictionary') : '';
+        const soundPath = href.replace(/^sound:\/*/i, '');
+        if (soundDict && soundPath) {
+            const soundUrl = rewriteDictionaryMediaPath(soundPath, soundDict);
+            if (soundUrl) playWordAudio(soundUrl);
+        }
         return;
     }
     const query = (anchor.textContent || '').trim();

--- a/native/hoshidicts/hoshidicts_src/importer.cpp
+++ b/native/hoshidicts/hoshidicts_src/importer.cpp
@@ -779,29 +779,32 @@ std::vector<char> build_offset_index(std::vector<std::pair<uint64_t, uint64_t>>&
 // yomitan-zip writer and the .mdd writer so the on-disk media format stays
 // byte-identical (the query side binary-searches media.idx by path). Returns
 // false if the record was skipped (path too long).
-bool append_media_record(std::ofstream& media, uint32_t& write_pos,
-                         std::vector<std::pair<std::string, uint32_t>>& index_entries,
+// write_pos is u64 to match the on-disk u64 record offsets: multi-part MDD
+// dictionaries (OALD ships ~3.7GB of mp3) sit right under the u32 cliff, and a
+// u32 accumulator would wrap silently past 4GB -> garbage offsets in media.idx.
+bool append_media_record(std::ofstream& media, uint64_t& write_pos,
+                         std::vector<std::pair<std::string, uint64_t>>& index_entries,
                          std::string path, const void* blob, size_t blob_size) {
   path = hoshidicts::normalize_media_path(std::move(path));
   if (path.size() > std::numeric_limits<uint16_t>::max()) {
     HOSHI_LOGW("media path too long (%zu bytes), skipping", path.size());
     return false;
   }
-  uint32_t record_start = write_pos;
+  uint64_t record_start = write_pos;
   std::vector<char> buf;
   write_val<uint16_t>(buf, static_cast<uint16_t>(path.size()));
   write_str(buf, path);
   write_val<uint32_t>(buf, static_cast<uint32_t>(blob_size));
   write_bytes(buf, blob, blob_size);
   media.write(buf.data(), static_cast<std::streamsize>(buf.size()));
-  write_pos += static_cast<uint32_t>(buf.size());
+  write_pos += buf.size();
   index_entries.emplace_back(std::move(path), record_start);
   return true;
 }
 
 // Finalize media.idx: [u32 count][u64 record_offset x count], sorted by path.
 void write_media_idx(std::ofstream& media_idx,
-                     std::vector<std::pair<std::string, uint32_t>>& index_entries) {
+                     std::vector<std::pair<std::string, uint64_t>>& index_entries) {
   std::ranges::sort(index_entries);
   std::vector<char> index_buf;
   write_val<uint32_t>(index_buf, static_cast<uint32_t>(index_entries.size()));
@@ -823,8 +826,8 @@ size_t write_media(const std::string& path, const Zip& zip, const std::vector<in
   setup_stream_exceptions(media_idx);
 
   size_t media_count = 0;
-  uint32_t write_pos = 0;
-  std::vector<std::pair<std::string, uint32_t>> index_entries;
+  uint64_t write_pos = 0;
+  std::vector<std::pair<std::string, uint64_t>> index_entries;
   int media_seq = 0;
   for (int file_index : files) {
     // write_media runs on its own std::async thread (in parallel with the term/
@@ -847,43 +850,82 @@ size_t write_media(const std::string& path, const Zip& zip, const std::vector<in
   return media_count;
 }
 
-// Import an .mdd (MDX media companion) into an already-written dictionary
-// directory, producing media.bin/media.idx that the query side + popup image://
-// scheme consume unchanged. Media failure never aborts the host dictionary.
-size_t import_mdd_into(const std::string& mdd_path, const std::string& dict_dir) {
-  std::ifstream f(hoshi::fs_path(mdd_path), std::ios::binary | std::ios::ate);
-  if (!f) return 0;
-  auto n = f.tellg();
-  if (n <= 0) return 0;
-  std::vector<uint8_t> data(static_cast<size_t>(n));
-  f.seekg(0);
-  f.read(reinterpret_cast<char*>(data.data()), static_cast<std::streamsize>(n));
-
-  std::vector<MddEntry> media;
-  try {
-    media = mdx_reader::parse_mdd(data.data(), data.size());
-  } catch (const std::exception& e) {
-    HOSHI_LOGW("mdd parse failed (%s), continuing without media", e.what());
-    return 0;
-  }
-  if (media.empty()) return 0;
-
-  std::ofstream mbin(hoshi::fs_path(dict_dir + "/media.bin"), std::ios::binary);
-  std::ofstream midx(hoshi::fs_path(dict_dir + "/media.idx"), std::ios::binary);
-  setup_stream_exceptions(mbin);
-  setup_stream_exceptions(midx);
-
+// Import one or more .mdd files (MDX media companions) into an already-written
+// dictionary directory, producing media.bin/media.idx that the query side +
+// popup image:// scheme consume unchanged. All parts merge into ONE sorted
+// index -- the query side binary-searches a single media.idx, so writing per
+// file would truncate the previous part's store. Files are parsed one at a
+// time so peak memory stays one part (BUG-1261: OALD's parts total ~3.7GB).
+// Media failure never aborts the host dictionary; an unreadable/broken part is
+// skipped and the rest still mount.
+size_t import_mdd_into(const std::vector<std::string>& mdd_paths, const std::string& dict_dir) {
+  std::ofstream mbin;
+  std::ofstream midx;
+  bool opened = false;
   size_t count = 0;
-  uint32_t write_pos = 0;
-  std::vector<std::pair<std::string, uint32_t>> index_entries;
-  for (auto& m : media) {
-    if (append_media_record(mbin, write_pos, index_entries, std::move(m.path), m.blob.data(),
-                            m.blob.size())) {
-      count++;
+  uint64_t write_pos = 0;
+  std::vector<std::pair<std::string, uint64_t>> index_entries;
+
+  for (const auto& mdd_path : mdd_paths) {
+    std::ifstream f(hoshi::fs_path(mdd_path), std::ios::binary | std::ios::ate);
+    if (!f) continue;
+    auto n = f.tellg();
+    if (n <= 0) continue;
+    std::vector<uint8_t> data(static_cast<size_t>(n));
+    f.seekg(0);
+    f.read(reinterpret_cast<char*>(data.data()), static_cast<std::streamsize>(n));
+
+    std::vector<MddEntry> media;
+    try {
+      media = mdx_reader::parse_mdd(data.data(), data.size());
+    } catch (const std::exception& e) {
+      HOSHI_LOGW("mdd parse failed (%s), continuing without this part", e.what());
+      continue;
+    }
+    if (media.empty()) continue;
+
+    // Lazily create the store on the first non-empty part: zero usable parts
+    // must leave no (empty) media.bin/media.idx behind, same as before.
+    if (!opened) {
+      mbin.open(hoshi::fs_path(dict_dir + "/media.bin"), std::ios::binary);
+      midx.open(hoshi::fs_path(dict_dir + "/media.idx"), std::ios::binary);
+      setup_stream_exceptions(mbin);
+      setup_stream_exceptions(midx);
+      opened = true;
+    }
+    for (auto& m : media) {
+      if (append_media_record(mbin, write_pos, index_entries, std::move(m.path), m.blob.data(),
+                              m.blob.size())) {
+        count++;
+      }
     }
   }
+
+  if (!opened) return 0;
   write_media_idx(midx, index_entries);
   return count;
+}
+
+// MDict convention: media lives in Foo.mdd plus numbered overflow parts
+// Foo.1.mdd / Foo.2.mdd / ... (large dictionaries -- OALD splits ~3.7GB of
+// pronunciation mp3 across three numbered parts). Parts are strictly
+// sequential, so stop at the first gap. BUG-1261: only Foo.mdd was mounted,
+// leaving every blob in the numbered parts (all OALD audio + example images)
+// unreachable.
+std::vector<std::string> collect_sibling_mdd_paths(const std::string& mdx_path) {
+  std::vector<std::string> mdd_paths;
+  auto mdd_path = hoshi::fs_path(mdx_path);
+  mdd_path.replace_extension(".mdd");
+  if (std::filesystem::exists(mdd_path)) {
+    mdd_paths.push_back(hoshi::fs_to_utf8(mdd_path));
+  }
+  for (int part = 1;; ++part) {
+    auto part_path = hoshi::fs_path(mdx_path);
+    part_path.replace_extension("." + std::to_string(part) + ".mdd");
+    if (!std::filesystem::exists(part_path)) break;
+    mdd_paths.push_back(hoshi::fs_to_utf8(part_path));
+  }
+  return mdd_paths;
 }
 
 ProcessedFile process_simple_entries(const std::vector<SimpleEntry>& entries) {
@@ -1020,14 +1062,14 @@ ImportResult import_mdx(const std::string& mdx_path, const std::string& output_d
 
   ImportResult result = dictionary_importer::write_simple_dict(title, entries, output_dir, styles_css);
 
-  // Auto-mount the media companion (Foo.mdx -> Foo.mdd) into the same dict dir,
-  // so <img>/<link> in the glossaries resolve via the image:// media scheme.
+  // Auto-mount the media companions (Foo.mdx -> Foo.mdd + numbered overflow
+  // parts Foo.N.mdd) into the same dict dir, so <img>/<link>/sound:// in the
+  // glossaries resolve via the image:// media scheme.
   // Media is best-effort: a missing/broken .mdd never fails the dictionary.
   if (result.success) {
-    auto mdd_path = hoshi::fs_path(mdx_path);
-    mdd_path.replace_extension(".mdd");
-    if (std::filesystem::exists(mdd_path)) {
-      import_mdd_into(hoshi::fs_to_utf8(mdd_path), output_dir + "/" + result.title);
+    std::vector<std::string> mdd_paths = collect_sibling_mdd_paths(mdx_path);
+    if (!mdd_paths.empty()) {
+      import_mdd_into(mdd_paths, output_dir + "/" + result.title);
     }
   }
 
@@ -1061,8 +1103,18 @@ ImportResult import_mdx_from_zip(Zip& zip, const std::string& output_dir) {
     out.write(content.data(), static_cast<std::streamsize>(content.size()));
   };
 
-  // Extract the .mdx plus its sibling media (.mdd) / stylesheet (.css), renamed
-  // to share the .mdx stem, so import_mdx's sibling auto-mount finds them.
+  // Extract the .mdx plus its sibling media (.mdd, incl. numbered overflow
+  // parts Foo.N.mdd) / stylesheet (.css), flattened next to the .mdx so
+  // import_mdx's sibling auto-mount (collect_sibling_mdd_paths) finds them.
+  auto is_numbered_part_stem = [&stem](const std::string& fstem) {
+    // "Foo.3" for stem "Foo": stem + '.' + at least one digit, digits only.
+    if (fstem.size() < stem.size() + 2) return false;
+    if (fstem.compare(0, stem.size(), stem) != 0 || fstem[stem.size()] != '.') return false;
+    for (size_t k = stem.size() + 1; k < fstem.size(); ++k) {
+      if (fstem[k] < '0' || fstem[k] > '9') return false;
+    }
+    return true;
+  };
   extract(mdx_index, mdx_filename);
   for (size_t i = 0; i < zip.entries.size(); i++) {
     if (static_cast<int>(i) == mdx_index) continue;
@@ -1071,8 +1123,9 @@ ImportResult import_mdx_from_zip(Zip& zip, const std::string& output_dir) {
     std::string fn = hoshi::fs_to_utf8(hoshi::fs_path(name).filename());
     std::string ext = hoshi::fs_to_utf8(hoshi::fs_path(fn).extension());
     std::string fstem = hoshi::fs_to_utf8(hoshi::fs_path(fn).stem());
-    if ((ext == ".mdd" || ext == ".css") && fstem == stem) {
-      extract(static_cast<int>(i), stem + ext);
+    if ((ext == ".mdd" && (fstem == stem || is_numbered_part_stem(fstem))) ||
+        (ext == ".css" && fstem == stem)) {
+      extract(static_cast<int>(i), fstem + ext);
     }
   }
 

--- a/native/hoshidicts/tests/mdd_media_import_test.cpp
+++ b/native/hoshidicts/tests/mdd_media_import_test.cpp
@@ -2,9 +2,10 @@
 // path). This test covers two levels:
 //   1) mdx_reader::parse_mdd returns each record byte-exact (incl. embedded NUL)
 //      with its raw path key -- no transcoding, no NUL stripping, no @@@LINK.
-//   2) end-to-end: importing Foo.mdx auto-mounts a sibling Foo.mdd into the same
-//      dictionary dir, and DictionaryQuery::get_media_file returns the bytes via
-//      the normalized path -- exactly the image:// scheme the popup consumes.
+//   2) end-to-end: importing Foo.mdx auto-mounts sibling Foo.mdd PLUS numbered
+//      overflow parts Foo.1.mdd / Foo.2.mdd (BUG-1261) into one merged media
+//      store, and DictionaryQuery::get_media_file returns the bytes via the
+//      normalized path -- exactly the image:// scheme the popup consumes.
 //
 // Red/green: revert parse_mdd (binary records) or import_mdx's sibling mount and
 // the retrieved blob is empty / wrong -> FAIL.
@@ -61,16 +62,27 @@ int main() {
     }
   }
 
-  // --- Part 2: import Foo.mdx + sibling Foo.mdd -> queryable media ---------
+  // --- Part 2: import Foo.mdx + sibling Foo.mdd + numbered overflow parts ---
+  // BUG-1261: MDict splits large media across Foo.mdd / Foo.1.mdd / Foo.2.mdd
+  // (OALD ships all pronunciation mp3 in the numbered parts). All parts must
+  // merge into ONE media.bin/media.idx: every key from every part retrievable.
+  // Red/green: revert collect_sibling_mdd_paths -> uk/us mp3 missing; revert
+  // the merged single-index write (per-part truncation) -> img/a.png missing.
   const std::string base = hoshi_test::temp_dir() + "/hoshi_mdd";
   std::filesystem::create_directories(std::filesystem::u8path(base));
   const std::string mdx_path = base + "/M.mdx";
-  const std::string mdd_path = base + "/M.mdd";
   const std::string out_dir = base + "/out";
+
+  const std::string mp3_uk("\xFF\xFB\x90\x00UK-FRAME\x00\x01", 12);
+  const std::string mp3_us("\xFF\xFB\x90\x00US-FRAME\xFE", 11);
 
   write_file(mdx_path,
              mdx_fixture::build_mdx_plain("MediaDict", {{"apple", "<img src=\"img/a.png\">def"}}));
-  write_file(mdd_path, mdx_fixture::build_mdd_plain("MediaDict", {{mdd_key, png}}));
+  write_file(base + "/M.mdd", mdx_fixture::build_mdd_plain("MediaDict", {{mdd_key, png}}));
+  write_file(base + "/M.1.mdd",
+             mdx_fixture::build_mdd_plain("MediaDict", {{"\\uk\\apple.mp3", mp3_uk}}));
+  write_file(base + "/M.2.mdd",
+             mdx_fixture::build_mdd_plain("MediaDict", {{"\\us\\apple.mp3", mp3_us}}));
 
   ImportResult r = dictionary_importer::import(mdx_path, out_dir);
   if (!r.success) {
@@ -78,12 +90,20 @@ int main() {
   } else {
     DictionaryQuery q;
     q.add_term_dict(out_dir + "/" + r.title);
-    std::vector<char> blob = q.get_media_file(r.title, "img/a.png");
-    if (blob.empty()) {
-      fail("get_media_file returned empty (mdd not mounted / path not normalized)");
-    } else if (std::string(blob.begin(), blob.end()) != png) {
-      fail("get_media_file returned wrong bytes");
-    }
+    auto expect_media = [&](const char* path, const std::string& want, const char* what) {
+      std::vector<char> blob = q.get_media_file(r.title, path);
+      if (blob.empty()) {
+        std::fprintf(stderr, "FAIL %s: get_media_file empty (part not mounted / index clobbered)\n",
+                     what);
+        ++g_fail;
+      } else if (std::string(blob.begin(), blob.end()) != want) {
+        std::fprintf(stderr, "FAIL %s: wrong bytes\n", what);
+        ++g_fail;
+      }
+    };
+    expect_media("img/a.png", png, "main .mdd blob");
+    expect_media("uk/apple.mp3", mp3_uk, "numbered part .1.mdd blob");
+    expect_media("us/apple.mp3", mp3_us, "numbered part .2.mdd blob");
   }
 
   if (g_fail) {

--- a/test/js/dict_glossary_crossref_link.test.mjs
+++ b/test/js/dict_glossary_crossref_link.test.mjs
@@ -24,6 +24,13 @@ const POPUP_URL = new URL(
   import.meta.url,
 );
 const src = readFileSync(POPUP_URL, "utf8");
+// BUG-1261：sound:// 播放走真实 rewriteDictionaryMediaPath（dict-media.js，app 变体），
+// 整段注入以验到最终 image:// URL 的构造，而不是桩出一个假 URL。
+const DICT_MEDIA_URL = new URL(
+  "../../hibiki/assets/popup/dict-media.js",
+  import.meta.url,
+);
+const dictMediaSrc = readFileSync(DICT_MEDIA_URL, "utf8");
 
 // 提取 `function handleGlossaryAnchorClick(...) { ... }` 整段。函数体内的闭合大括号都带缩进
 // （`    }` / `    });`），唯一顶格的 `\n}` 是函数收尾，非贪婪匹配到它即止。
@@ -39,8 +46,9 @@ function extract(name) {
 const handlerSrc = extract("handleGlossaryAnchorClick");
 
 /**
- * 在 jsdom 页面里注入真实 handleGlossaryAnchorClick + 桩，点击首个 <a>，回收结果。
- * 返回 { prevented, linkCalls, externalCalls, extHitCalls }。
+ * 在 jsdom 页面里注入真实 handleGlossaryAnchorClick + 真实 dict-media.js + 桩，
+ * 点击首个 <a>，回收结果。
+ * 返回 { prevented, linkCalls, externalCalls, extHitCalls, playCalls }。
  */
 function clickAnchor(anchorHtml) {
   const dom = new JSDOM(
@@ -53,11 +61,16 @@ function clickAnchor(anchorHtml) {
     linkCalls: [],
     externalCalls: [],
     extHitCalls: 0,
+    playCalls: [],
   };
   // 桩：记录被调情况。
   win.openExternalLink = (url) => results.externalCalls.push(url);
   win.markGlobalLookupExtHit = () => {
     results.extHitCalls++;
+  };
+  win.playWordAudio = (url) => {
+    results.playCalls.push(url);
+    return Promise.resolve(true);
   };
   win.flutter_inappwebview = {
     callHandler: (name, ...args) => {
@@ -65,8 +78,8 @@ function clickAnchor(anchorHtml) {
     },
   };
   // 把真实函数装进这个 window 作用域（它引用 openExternalLink / markGlobalLookupExtHit /
-  // window.flutter_inappwebview 这些全局）。
-  win.eval(`${handlerSrc}\nwindow.__handleGlossaryAnchorClick = handleGlossaryAnchorClick;`);
+  // rewriteDictionaryMediaPath / playWordAudio / window.flutter_inappwebview 这些全局）。
+  win.eval(`${dictMediaSrc}\n${handlerSrc}\nwindow.__handleGlossaryAnchorClick = handleGlossaryAnchorClick;`);
 
   const anchor = win.document.querySelector("a[href]");
   assert.ok(anchor, "测试 fixture 缺少 <a href>");
@@ -101,10 +114,30 @@ test("BUG-767 外链：交给 openExternalLink，不误当查词", () => {
   assert.equal(r.linkCalls.length, 0, "外链不应触发 onLinkClick");
 });
 
-test("BUG-767 发音媒体节点 sound://：阻止导航但不查词", () => {
-  const r = clickAnchor(`<a href="sound://word.spx">🔊</a>`);
+test("BUG-1261 发音媒体节点 sound://：阻止导航、不查词，经词典媒体通道播放", () => {
+  // 真实形态（OALD）：发音锚点在 data-dictionary 词典容器内（popup.js 渲染 MDX
+  // 释义时必设，见 dictWrapper.setAttribute('data-dictionary', ...)）。
+  const r = clickAnchor(
+    `<div data-dictionary="OALD"><a href="sound://uk/apple.mp3">🔊</a></div>`,
+  );
   assert.equal(r.prevented, true, "sound:// 也必须阻止默认导航");
   assert.equal(r.linkCalls.length, 0, "发音节点不是查词目标");
+  assert.equal(r.externalCalls.length, 0);
+  // 播放守卫：剥掉 sound:// 前缀 → rewriteDictionaryMediaPath → app 内 image://
+  // 词典媒体 scheme（与 <img>/gaiji 同一字节通道，四个宿主表面均已注册）。
+  assert.equal(r.playCalls.length, 1, "sound:// 点击必须触发一次播放");
+  assert.equal(
+    r.playCalls[0],
+    "image://?dictionary=OALD&path=uk%2Fapple.mp3",
+    "播放 URL 应是 image:// 词典媒体 scheme + 编码后的资源路径",
+  );
+});
+
+test("BUG-1261 sound:// 缺 data-dictionary 容器：只阻止导航，不播放不崩", () => {
+  const r = clickAnchor(`<a href="sound://word.mp3">🔊</a>`);
+  assert.equal(r.prevented, true);
+  assert.equal(r.playCalls.length, 0, "无词典归属时不该盲播");
+  assert.equal(r.linkCalls.length, 0);
   assert.equal(r.externalCalls.length, 0);
 });
 

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -4315,7 +4315,19 @@ function handleGlossaryAnchorClick(event, anchor) {
         return;
     }
     if (/^sound:/i.test(href)) {
-        // 词典发音媒体节点（sound://xxx），不是查词目标；导航已被阻止，播放另属后续能力。
+        // BUG-1261：词典发音媒体节点（sound://xxx）。不是查词目标；导航已被阻止，
+        // 改走与 <img>/gaiji 完全相同的词典媒体字节通道播放：剥掉 sound: 前缀后交给
+        // rewriteDictionaryMediaPath（app 内 → image:// 自定义 scheme，四个宿主表面
+        // 均已注册；浏览器扩展 → 带 token 的 /api/media/dictionary HTTP 端点），
+        // 再用 playWordAudio 播（与单词 ♪ 同一 <audio> 路径：音量/interrupt 语义一致）。
+        // dictName 取最近的 [data-dictionary] 容器（MDX 释义 wrapper 3052 行必设）。
+        const dictNode = anchor.closest('[data-dictionary]');
+        const soundDict = dictNode ? dictNode.getAttribute('data-dictionary') : '';
+        const soundPath = href.replace(/^sound:\/*/i, '');
+        if (soundDict && soundPath) {
+            const soundUrl = rewriteDictionaryMediaPath(soundPath, soundDict);
+            if (soundUrl) playWordAudio(soundUrl);
+        }
         return;
     }
     const query = (anchor.textContent || '').trim();


### PR DESCRIPTION
## 症状
用户导入「OALD 2024.09」（OALDPE）后，点词典释义里自带的发音按钮完全没反应。

## 根因（两层叠加，任一层都足以让发音无反应）
1. **分卷 MDD 根本没导入**：`importer.cpp` 只挂 `Foo.mdx → Foo.mdd` 单文件；MDict 惯例的编号分卷 `Foo.1.mdd / Foo.2.mdd / ...` 被完全忽略。OALDPE 的全部发音 mp3（16 万单词音 + 11 万例句音，实测 .mp3）和例句配图都在分卷里。
2. **sound:// 播放从未实现**：`popup.js handleGlossaryAnchorClick` 把 `sound://` 点击 preventDefault 后故意丢弃（BUG-767 时留下的「后续能力」缺口）。

## 修复
- **C++**：`import_mdd_into` 改为多文件单索引合并写（逐分卷流式解析，峰值内存不变）；新增 `collect_sibling_mdd_paths`（主 .mdd + 顺序编号 .N.mdd）；zip 导入路径放行 `stem.N.mdd`；顺带把媒体写偏移累计 u32 → u64（磁盘格式本就是 u64，OALD ~3.7GB 已贴近 4GB 静默回绕悬崖）。
- **JS（3 镜像同步）**：`sound://` 点击剥前缀 → 复用 `rewriteDictionaryMediaPath`（与 <img>/gaiji 同一词典媒体字节通道：app 内 `image://` scheme 四表面已注册，扩展走带 token 的 HTTP 端点）→ `playWordAudio`（与单词 ♪ 同音量/interrupt 语义）。Dart/native 零改动（mp3 MIME 已覆盖、autoplay 已放开、WebView2 过滤器 `*`+CONTEXT_ALL）。

## 测试
- `mdd_media_import_test.cpp`：三分卷合并导入，全 key 可取；**已变异实测**（砍掉分卷发现 → 红）。native 套件 17/17 绿。
- `dict_glossary_crossref_link.test.mjs`：sound:// 点击 → 精确 image:// URL 播放一次；无 data-dictionary 容器不播不崩。JS 18/18 绿。
- `flutter analyze` 全量 No issues；popup 镜像/dict-media 守卫 102 绿；bugs per-file 守卫绿。

## 注意
- 生效需**删除并重导** OALD（分卷资源是导入期写入 media.bin 的）。
- 移动端单文件 SAF 选择器丢 sibling 是既有限制（主 .mdd 同样受影响），文件夹导入无此问题。

BUG 档案：docs/bugs/BUG-1261-oald-mdd-parts-sound-play.md

https://claude.ai/code/session_01Bg5SKVzc2pYjvdHCmddXCr