### PR TITLE
fix(media): 竖版海报封面在继续/继续观看/合集详情槽向自适应渲染（BUG-1272）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1201 条。点号进各自文件。
+> 共 1202 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1262](bugs/BUG-1262-continue-cover-portrait-crop.md) | ✅ | ✅ | 竖版海报封面在继续/继续观看/合集详情被裁切或留灰带 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,7 +33,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-1262](bugs/BUG-1262-continue-cover-portrait-crop.md) | ✅ | ✅ | 竖版海报封面在继续/继续观看/合集详情被裁切或留灰带 |
+| [BUG-1272](bugs/BUG-1272-continue-cover-portrait-crop.md) | ✅ | ✅ | 竖版海报封面在继续/继续观看/合集详情被裁切或留灰带 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/bugs/BUG-1262-continue-cover-portrait-crop.md
+++ b/docs/bugs/BUG-1262-continue-cover-portrait-crop.md
@@ -1,0 +1,9 @@
+## BUG-1262 · 竖版海报封面在继续/继续观看/合集详情被裁切或留灰带
+- **报告**：2026-07-31（用户：截图报「如果是海报，在继续里面和继续观看里面渲染有问题」）
+- **真实性**：✅ 真 bug。刮削（Bangumi/TMDB）会把竖版 2:3 海报写进 `video_books.cover_path`（与抽帧封面同路径同列，无横竖标记），但三处消费端都是硬编码横版槽 + 固定 fit，全部绕过了视频库主网格已在用的自适应组件 `PortraitCoverImage`：
+  - 首页「继续」卡：视频条目走 234×132 的 16:9 槽 + `BoxFit.cover`（`hibiki/lib/src/pages/implementations/home_dashboard_page.dart:1290`，`_videoCover`），竖版海报上下被裁掉约 62% 只剩中间一条；
+  - 视频首页「继续观看」hero：148×84 硬槽 + `BoxFit.contain`（`hibiki/lib/src/pages/implementations/home_video_page.dart:2250`），竖版海报两侧各露约 50px surfaceContainer 灰带；
+  - 合集详情单集缩略图：96×54 硬槽 + `BoxFit.cover`（`hibiki/lib/src/pages/implementations/media_collection_detail_page.dart:228`，`_episodeThumb`），同样裁成中间一条。
+- **[x] ① 已修复** — 根因修复：`PortraitCoverImage` 推广为槽向自适应（新增 `landscapeSlot`，横槽内竖图改模糊垫底 + contain）；「继续」卡消灭视频专属宽度特例，三类条目统一 94×132 竖版槽走 `PortraitCoverImage`；「继续观看」hero 换 80×120 竖版槽走既有 `poster: true` 路径；合集详情缩略图保留 96×54 槽但改 `landscapeSlot: true` 自适应。提交：见本分支。
+- **[x] ② 已加自动化测试** — `hibiki/test/widgets/portrait_cover_image_test.dart`（组件四象限行为：竖槽竖图铺满/竖槽横图垫底/横槽横图铺满/横槽竖图垫底）+ `hibiki/test/pages/continue_cover_portrait_guard_test.dart`（源码扫描守卫：三处消费端必须走 PortraitCoverImage、禁止回退硬编码 fit）。
+- **备注**：封面数据模型无横竖/来源标记（`cover_meta.json` 仅刮削侧防覆盖用），故修复统一走运行时解码宽高比判定（`ImageStream` 零额外解码），与主网格同源。

--- a/docs/bugs/BUG-1272-continue-cover-portrait-crop.md
+++ b/docs/bugs/BUG-1272-continue-cover-portrait-crop.md
@@ -1,4 +1,4 @@
-## BUG-1262 · 竖版海报封面在继续/继续观看/合集详情被裁切或留灰带
+## BUG-1272 · 竖版海报封面在继续/继续观看/合集详情被裁切或留灰带
 - **报告**：2026-07-31（用户：截图报「如果是海报，在继续里面和继续观看里面渲染有问题」）
 - **真实性**：✅ 真 bug。刮削（Bangumi/TMDB）会把竖版 2:3 海报写进 `video_books.cover_path`（与抽帧封面同路径同列，无横竖标记），但三处消费端都是硬编码横版槽 + 固定 fit，全部绕过了视频库主网格已在用的自适应组件 `PortraitCoverImage`：
   - 首页「继续」卡：视频条目走 234×132 的 16:9 槽 + `BoxFit.cover`（`hibiki/lib/src/pages/implementations/home_dashboard_page.dart:1290`，`_videoCover`），竖版海报上下被裁掉约 62% 只剩中间一条；

--- a/hibiki/lib/src/media/media_cover_source.dart
+++ b/hibiki/lib/src/media/media_cover_source.dart
@@ -14,8 +14,8 @@
 ///
 /// - **写入**：`MediaCoverService`（选图 / 覆盖 / 落盘 / 缓存驱逐）。
 /// - **来源解析**：本文件。
-/// - **渲染**：`PosterCoverImage`（竖图 cover / 横图模糊垫底 + contain），它明确
-///   「不关心来源」，接收本文件解析出的 provider。
+/// - **渲染**：`PortraitCoverImage`（朝向合槽 cover / 不合槽模糊垫底 + contain），
+///   它明确「不关心来源」，接收本文件解析出的 provider。
 ///
 /// # 互联（远端）封面
 ///

--- a/hibiki/lib/src/media/video/cover_ui/portrait_cover_image.dart
+++ b/hibiki/lib/src/media/video/cover_ui/portrait_cover_image.dart
@@ -2,7 +2,7 @@ import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 
-/// 槽向自适应封面（Kazumi 式，用户拍板 2026-07-24 统一竖版；BUG-1262 推广为
+/// 槽向自适应封面（Kazumi 式，用户拍板 2026-07-24 统一竖版；BUG-1272 推广为
 /// 横竖槽通用）。
 ///
 /// 外层由调用方给定槽位区域（主网格是 `AspectRatio(aspectRatio: 2 / 3)`），本组件
@@ -38,7 +38,7 @@ class PortraitCoverImage extends StatefulWidget {
   final WidgetBuilder? errorBuilder;
 
   /// 槽位朝向：false = 竖版槽（默认，主网格 2:3），横图垫底；true = 横版槽
-  /// （合集详情 16:9 单集缩略图等），竖图垫底（BUG-1262）。
+  /// （合集详情 16:9 单集缩略图等），竖图垫底（BUG-1272）。
   final bool landscapeSlot;
 
   /// 竖图判定阈值：宽高比 ≤ 此值直接 cover（海报 2:3≈0.67，留裕量收到 0.85）。

--- a/hibiki/lib/src/media/video/cover_ui/portrait_cover_image.dart
+++ b/hibiki/lib/src/media/video/cover_ui/portrait_cover_image.dart
@@ -2,16 +2,16 @@ import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
 
-/// 视频库主网格 2:3 海报封面（Kazumi 式，用户拍板 2026-07-24 统一竖版）。
+/// 槽向自适应封面（Kazumi 式，用户拍板 2026-07-24 统一竖版；BUG-1262 推广为
+/// 横竖槽通用）。
 ///
-/// 外层由调用方给定 2:3 区域（`AspectRatio(aspectRatio: 2 / 3)`），本组件按图片
-/// 固有宽高比选择填充手法，**不出黑边、不变形，也不搞「有海报竖版、无海报横版」
-/// 的混排特例**：
+/// 外层由调用方给定槽位区域（主网格是 `AspectRatio(aspectRatio: 2 / 3)`），本组件
+/// 按图片固有宽高比与槽位朝向选择填充手法，**不出黑边、不变形，也不搞「有海报
+/// 竖版、无海报横版」的混排特例**：
 ///
-/// * 竖图（宽高比 ≤ [portraitAspectThreshold]，真海报 2:3≈0.67）→ 直接
-///   `BoxFit.cover` 铺满；
-/// * 横图（现状导入抽帧的 16:9 截帧）→ 同图两层：底层 `cover` 放大 + 高斯模糊 +
-///   半透明压暗垫底，前景 `contain` 居中完整显示；
+/// * 图片朝向与槽位一致（竖槽竖图 / 横槽横图）→ 直接 `BoxFit.cover` 铺满；
+/// * 朝向不一致（竖槽里的 16:9 截帧 / 横槽里的 2:3 海报）→ 同图两层：底层
+///   `cover` 放大 + 高斯模糊 + 半透明压暗垫底，前景 `contain` 居中完整显示；
 /// * 尺寸未知（首帧解码前）先按 `cover` 渲染，[ImageStream] 拿到尺寸后再切换，
 ///   避免先占位后闪换；
 /// * 加载/解码失败 → [errorBuilder]（通常是调用方的占位封面）。
@@ -24,6 +24,7 @@ class PortraitCoverImage extends StatefulWidget {
     required this.image,
     this.imageKey,
     this.errorBuilder,
+    this.landscapeSlot = false,
   });
 
   /// 已解析好的图片源。本地文件请自带解码上限（如 `resizedFileImage`），远端用
@@ -36,8 +37,16 @@ class PortraitCoverImage extends StatefulWidget {
   /// 加载/解码失败时的替代内容（通常是调用方的无封面占位）。
   final WidgetBuilder? errorBuilder;
 
+  /// 槽位朝向：false = 竖版槽（默认，主网格 2:3），横图垫底；true = 横版槽
+  /// （合集详情 16:9 单集缩略图等），竖图垫底（BUG-1262）。
+  final bool landscapeSlot;
+
   /// 竖图判定阈值：宽高比 ≤ 此值直接 cover（海报 2:3≈0.67，留裕量收到 0.85）。
   static const double portraitAspectThreshold = 0.85;
+
+  /// 横版槽的横图判定阈值：宽高比 ≥ 此值直接 cover（截帧 16:9≈1.78；方图/竖图
+  /// cover 进 16:9 槽会裁掉四成以上，走垫底）。
+  static const double landscapeAspectThreshold = 1.2;
 
   /// 横图垫底的模糊强度（sigma，任务定 12~16 取中）。
   static const double backdropBlurSigma = 14;
@@ -116,19 +125,22 @@ class _PortraitCoverImageState extends State<PortraitCoverImage> {
       return widget.errorBuilder?.call(context) ?? const SizedBox.shrink();
     }
     final double? aspect = _aspect;
-    final bool landscape =
-        aspect != null && aspect > PortraitCoverImage.portraitAspectThreshold;
+    // 朝向不合槽 = 垫底 + contain；首帧前（aspect 未知）按合槽 cover 渲染。
+    final bool mismatch = aspect != null &&
+        (widget.landscapeSlot
+            ? aspect < PortraitCoverImage.landscapeAspectThreshold
+            : aspect > PortraitCoverImage.portraitAspectThreshold);
     final Widget foreground = Image(
       key: widget.imageKey,
       image: widget.image,
-      // 竖图 / 首帧前：cover 铺满；已知横图：contain 完整居中浮于模糊垫底上。
-      fit: landscape ? BoxFit.contain : BoxFit.cover,
+      // 合槽 / 首帧前：cover 铺满；已知不合槽：contain 完整居中浮于模糊垫底上。
+      fit: mismatch ? BoxFit.contain : BoxFit.cover,
       errorBuilder: widget.errorBuilder == null
           ? null
           : (BuildContext context, Object error, StackTrace? stackTrace) =>
               widget.errorBuilder!(context),
     );
-    if (!landscape) return foreground;
+    if (!mismatch) return foreground;
     return ClipRect(
       child: Stack(
         fit: StackFit.expand,

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -261,7 +261,7 @@ const int _kTrackingMappingLimit = 5;
 
 class _HomeDashboardPageState
     extends BaseModuleTabPageState<HomeDashboardPage> {
-  /// 「继续」横滑行：三类条目统一竖版海报槽（BUG-1262）。视频封面可能是刮削
+  /// 「继续」横滑行：三类条目统一竖版海报槽（BUG-1272）。视频封面可能是刮削
   /// 落地的 2:3 竖版海报，旧「书竖 5:7 / 视频横 16:9」混排会把海报裁成中间一条；
   /// 现在与视频库主网格同源走 [PortraitCoverImage]——竖图铺满、横版截帧模糊
   /// 垫底，宽度特例随之消灭。行总高 = 封面 + 标题/副标题两行文字块。
@@ -1167,7 +1167,7 @@ class _HomeDashboardPageState
     AppModel appModel,
     _ContinueEntry entry,
   ) {
-    // BUG-1262：三类条目统一竖版槽（见 [_kContinueCoverWidth] 注释）。
+    // BUG-1272：三类条目统一竖版槽（见 [_kContinueCoverWidth] 注释）。
     const double coverWidth = _kContinueCoverWidth;
     // BUG-1111：游戏没有阅读百分比（无完成度概念），状态段只标类型，不能套用
     // 书的「阅读 · x%」——否则一律显示「阅读 · 0%」。
@@ -1281,14 +1281,14 @@ class _HomeDashboardPageState
     if (coverUrl == null || coverUrl.isEmpty || fetcher == null) {
       return _coverPlaceholder(tokens, icon);
     }
-    // BUG-1262：远端封面横竖不可知（host 侧可能是截帧也可能是海报），槽向自适应。
+    // BUG-1272：远端封面横竖不可知（host 侧可能是截帧也可能是海报），槽向自适应。
     return PortraitCoverImage(
       image: RemoteCoverImage(coverUrl, fetcher, cacheKey: remote.id),
       errorBuilder: (BuildContext _) => _coverPlaceholder(tokens, icon),
     );
   }
 
-  /// 视频封面：coverPath 存在则渲染，否则占位图标。BUG-1262：封面可能是抽帧
+  /// 视频封面：coverPath 存在则渲染，否则占位图标。BUG-1272：封面可能是抽帧
   /// （16:9 横）也可能是刮削海报（2:3 竖），走 [PortraitCoverImage] 槽向自适应，
   /// 不再 `BoxFit.cover` 硬裁。[landscapeSlot] 跟随调用方槽位朝向（继续卡竖版 /
   /// 活动条视频缩略 68×40 横版）。
@@ -2002,7 +2002,7 @@ class _HomeDashboardPageState
             child: SizedBox(
               width: 68,
               height: 40,
-              // BUG-1262：横版槽，判定方向随槽走（海报垫底、截帧铺满）。
+              // BUG-1272：横版槽，判定方向随槽走（海报垫底、截帧铺满）。
               child: _videoCover(tokens, video, landscapeSlot: true),
             ),
           );

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -18,6 +18,7 @@ import 'package:hibiki/src/media/tracking/media_tracking_labels.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_service.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
+import 'package:hibiki/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/pages/base_module_tab_page.dart';
@@ -34,6 +35,7 @@ import 'package:hibiki/src/sync/remote_cover_image.dart';
 import 'package:hibiki/src/sync/remote_library_cache.dart';
 import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/src/utils/components/stat_contribution_heatmap.dart';
+import 'package:hibiki/src/utils/cover_image.dart';
 import 'package:hibiki/src/utils/misc/dashboard_remote_merge.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -259,11 +261,12 @@ const int _kTrackingMappingLimit = 5;
 
 class _HomeDashboardPageState
     extends BaseModuleTabPageState<HomeDashboardPage> {
-  /// 「继续」横滑行：卡片封面等高，书竖版 5:7 / 视频横版 16:9 由宽度区分（同一行
-  /// 混排不同宽度，Jellyfin 式）。行总高 = 封面 + 标题/副标题两行文字块。
+  /// 「继续」横滑行：三类条目统一竖版海报槽（BUG-1262）。视频封面可能是刮削
+  /// 落地的 2:3 竖版海报，旧「书竖 5:7 / 视频横 16:9」混排会把海报裁成中间一条；
+  /// 现在与视频库主网格同源走 [PortraitCoverImage]——竖图铺满、横版截帧模糊
+  /// 垫底，宽度特例随之消灭。行总高 = 封面 + 标题/副标题两行文字块。
   static const double _kContinueCoverHeight = 132;
-  static const double _kContinueBookCoverWidth = 94; // ≈132×5/7 竖版
-  static const double _kContinueVideoCoverWidth = 234; // ≈132×16/9 横版
+  static const double _kContinueCoverWidth = 94; // ≈132×5/7 竖版
 
   /// 「继续」横滑行的总高：封面 + 两行标题 + 一行副标题 + 行间距。
   ///
@@ -1164,9 +1167,8 @@ class _HomeDashboardPageState
     AppModel appModel,
     _ContinueEntry entry,
   ) {
-    // 视频是横版 16:9，书与游戏都是竖版封面（galgame 封面同为竖版海报）。
-    final double coverWidth =
-        entry.isVideo ? _kContinueVideoCoverWidth : _kContinueBookCoverWidth;
+    // BUG-1262：三类条目统一竖版槽（见 [_kContinueCoverWidth] 注释）。
+    const double coverWidth = _kContinueCoverWidth;
     // BUG-1111：游戏没有阅读百分比（无完成度概念），状态段只标类型，不能套用
     // 书的「阅读 · x%」——否则一律显示「阅读 · 0%」。
     String status = switch (entry.kind) {
@@ -1279,37 +1281,44 @@ class _HomeDashboardPageState
     if (coverUrl == null || coverUrl.isEmpty || fetcher == null) {
       return _coverPlaceholder(tokens, icon);
     }
-    return Image(
+    // BUG-1262：远端封面横竖不可知（host 侧可能是截帧也可能是海报），槽向自适应。
+    return PortraitCoverImage(
       image: RemoteCoverImage(coverUrl, fetcher, cacheKey: remote.id),
-      fit: BoxFit.cover,
-      errorBuilder: (_, __, ___) => _coverPlaceholder(tokens, icon),
+      errorBuilder: (BuildContext _) => _coverPlaceholder(tokens, icon),
     );
   }
 
-  /// 视频封面：coverPath 存在则 [Image.file]，否则占位图标。
-  Widget _videoCover(HibikiDesignTokens tokens, VideoBookRow video) {
+  /// 视频封面：coverPath 存在则渲染，否则占位图标。BUG-1262：封面可能是抽帧
+  /// （16:9 横）也可能是刮削海报（2:3 竖），走 [PortraitCoverImage] 槽向自适应，
+  /// 不再 `BoxFit.cover` 硬裁。[landscapeSlot] 跟随调用方槽位朝向（继续卡竖版 /
+  /// 活动条视频缩略 68×40 横版）。
+  Widget _videoCover(
+    HibikiDesignTokens tokens,
+    VideoBookRow video, {
+    bool landscapeSlot = false,
+  }) {
     final String? path = video.coverPath;
     if (path != null && path.isNotEmpty && File(path).existsSync()) {
-      return Image.file(
-        File(path),
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) =>
+      return PortraitCoverImage(
+        image: resizedFileImage(File(path)),
+        landscapeSlot: landscapeSlot,
+        errorBuilder: (BuildContext _) =>
             _coverPlaceholder(tokens, Icons.movie_outlined),
       );
     }
     return _coverPlaceholder(tokens, Icons.movie_outlined);
   }
 
-  /// 游戏封面（BUG-1111 / BUG-1112）：`galgames.coverPath` 存在则 [Image.file]，
-  /// 否则占位图标。与 [_videoCover] 同一形态——封面是本机文件路径（目录扫描 /
-  /// exe 内嵌图标 / 刮削下载三种来源都落成本地文件），不走网络取图。
+  /// 游戏封面（BUG-1111 / BUG-1112）：`galgames.coverPath` 存在则渲染，否则占位
+  /// 图标。与 [_videoCover] 同一形态——封面是本机文件路径（目录扫描 / exe 内嵌
+  /// 图标 / 刮削下载三种来源都落成本地文件），不走网络取图；渲染同走
+  /// [PortraitCoverImage]（exe 图标是方图，cover 硬裁会糊，垫底完整显示）。
   Widget _gameCover(HibikiDesignTokens tokens, GalgameEntry game) {
     final String? path = game.coverPath;
     if (path != null && path.isNotEmpty && File(path).existsSync()) {
-      return Image.file(
-        File(path),
-        fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) =>
+      return PortraitCoverImage(
+        image: resizedFileImage(File(path)),
+        errorBuilder: (BuildContext _) =>
             _coverPlaceholder(tokens, Icons.videogame_asset_outlined),
       );
     }
@@ -1993,7 +2002,8 @@ class _HomeDashboardPageState
             child: SizedBox(
               width: 68,
               height: 40,
-              child: _videoCover(tokens, video),
+              // BUG-1262：横版槽，判定方向随槽走（海报垫底、截帧铺满）。
+              child: _videoCover(tokens, video, landscapeSlot: true),
             ),
           );
         }

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2247,10 +2247,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         children: <Widget>[
           ClipRRect(
             borderRadius: HibikiBorderRadius.card,
+            // BUG-1262：hero 封面改竖版 2:3 海报槽（刮削海报在旧 148×84 横槽里
+            // 两侧露灰带）；横版截帧由 poster 路径的 [PortraitCoverImage] 垫底。
             child: SizedBox(
-              width: 148,
-              height: 84,
-              child: _buildCover(hero),
+              width: 80,
+              height: 120,
+              child: _buildCover(hero, poster: true),
             ),
           ),
           SizedBox(width: tokens.spacing.gap + 4),
@@ -2319,10 +2321,11 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         children: <Widget>[
           ClipRRect(
             borderRadius: HibikiBorderRadius.card,
+            // BUG-1262：与本地 hero 同款竖版 2:3 海报槽。
             child: SizedBox(
-              width: 148,
-              height: 84,
-              child: _buildRemoteVideoCover(video),
+              width: 80,
+              height: 120,
+              child: _buildRemoteVideoCover(video, poster: true),
             ),
           ),
           SizedBox(width: tokens.spacing.gap + 4),
@@ -3811,8 +3814,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
   }
 
-  /// [poster] = true：主网格 2:3 竖版槽位，走 [PortraitCoverImage]（横版截帧模糊
-  /// 垫底 + contain 前景）；false：hero / 长按菜单等 16:9 语境保持原渲染。
+  /// [poster] = true：主网格 / 继续观看 hero 的 2:3 竖版槽位（BUG-1262 起 hero
+  /// 也走此路径），走 [PortraitCoverImage]（横版截帧模糊垫底 + contain 前景）；
+  /// false：长按菜单等 16:9 语境保持原渲染。
   Widget _buildCover(VideoBookRow book, {bool poster = false}) {
     final String? cover = book.coverPath;
     // 保留同步 existsSync 短路：对已知不存在的封面直接占位，避免对缺失文件发起

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2247,7 +2247,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         children: <Widget>[
           ClipRRect(
             borderRadius: HibikiBorderRadius.card,
-            // BUG-1262：hero 封面改竖版 2:3 海报槽（刮削海报在旧 148×84 横槽里
+            // BUG-1272：hero 封面改竖版 2:3 海报槽（刮削海报在旧 148×84 横槽里
             // 两侧露灰带）；横版截帧由 poster 路径的 [PortraitCoverImage] 垫底。
             child: SizedBox(
               width: 80,
@@ -2321,7 +2321,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         children: <Widget>[
           ClipRRect(
             borderRadius: HibikiBorderRadius.card,
-            // BUG-1262：与本地 hero 同款竖版 2:3 海报槽。
+            // BUG-1272：与本地 hero 同款竖版 2:3 海报槽。
             child: SizedBox(
               width: 80,
               height: 120,
@@ -3814,7 +3814,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
   }
 
-  /// [poster] = true：主网格 / 继续观看 hero 的 2:3 竖版槽位（BUG-1262 起 hero
+  /// [poster] = true：主网格 / 继续观看 hero 的 2:3 竖版槽位（BUG-1272 起 hero
   /// 也走此路径），走 [PortraitCoverImage]（横版截帧模糊垫底 + contain 前景）；
   /// false：长按菜单等 16:9 语境保持原渲染。
   Widget _buildCover(VideoBookRow book, {bool poster = false}) {

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -5,10 +5,12 @@ import 'package:flutter/material.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/focus/hibiki_focus_target.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
+import 'package:hibiki/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:hibiki/src/media/collections/collection_one_key_sort.dart'
     show CollectionSortMeta, compareCollectionMembers;
 import 'package:hibiki/src/pages/implementations/collection_detail_shared.dart';
 import 'package:hibiki/src/pages/implementations/jimaku_batch_dialog.dart';
+import 'package:hibiki/src/utils/cover_image.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -222,9 +224,11 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     Navigator.of(context).maybePop();
   }
 
-  /// 单集封面缩略图（16:9）：有封面文件则 [Image.file]，否则 letterbox 占位图标。
+  /// 单集封面缩略图（16:9 槽）：有封面文件则渲染，否则 letterbox 占位图标。
   /// 每集是独立视频行，[VideoBookRow.coverPath] 由导入 / 后台补齐（home_video_page
-  /// `_maybeBackfillCovers`）逐集抽帧填充。
+  /// `_maybeBackfillCovers`）逐集抽帧填充；刮削可把它覆盖成 2:3 竖版海报——
+  /// BUG-1262：走 [PortraitCoverImage] 的横槽自适应（横版截帧铺满、竖版海报
+  /// 模糊垫底 + contain），不再 `BoxFit.cover` 把海报裁成中间一条。
   Widget _episodeThumb(VideoBookRow ep, ColorScheme cs) {
     const double w = 96;
     const double h = 54;
@@ -232,14 +236,15 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     if (cover != null && cover.isNotEmpty && File(cover).existsSync()) {
       return ClipRRect(
         borderRadius: BorderRadius.circular(4),
-        child: Image.file(
-          File(cover),
+        child: SizedBox(
           width: w,
           height: h,
-          fit: BoxFit.cover,
-          // 抽帧文件损坏 / 读取失败时退回占位，绝不抛。
-          errorBuilder: (BuildContext _, Object __, StackTrace? ___) =>
-              _thumbPlaceholder(w, h, cs),
+          child: PortraitCoverImage(
+            image: resizedFileImage(File(cover)),
+            landscapeSlot: true,
+            // 抽帧文件损坏 / 读取失败时退回占位，绝不抛。
+            errorBuilder: (BuildContext _) => _thumbPlaceholder(w, h, cs),
+          ),
         ),
       );
     }

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -227,7 +227,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 单集封面缩略图（16:9 槽）：有封面文件则渲染，否则 letterbox 占位图标。
   /// 每集是独立视频行，[VideoBookRow.coverPath] 由导入 / 后台补齐（home_video_page
   /// `_maybeBackfillCovers`）逐集抽帧填充；刮削可把它覆盖成 2:3 竖版海报——
-  /// BUG-1262：走 [PortraitCoverImage] 的横槽自适应（横版截帧铺满、竖版海报
+  /// BUG-1272：走 [PortraitCoverImage] 的横槽自适应（横版截帧铺满、竖版海报
   /// 模糊垫底 + contain），不再 `BoxFit.cover` 把海报裁成中间一条。
   Widget _episodeThumb(VideoBookRow ep, ColorScheme cs) {
     const double w = 96;

--- a/hibiki/test/pages/continue_cover_portrait_guard_test.dart
+++ b/hibiki/test/pages/continue_cover_portrait_guard_test.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// BUG-1262 守卫：竖版海报封面在「继续 / 继续观看 / 合集详情」三处消费端必须
+/// BUG-1272 守卫：竖版海报封面在「继续 / 继续观看 / 合集详情」三处消费端必须
 /// 走 [PortraitCoverImage] 槽向自适应，禁止回退成硬编码 fit 的裸 `Image.file`。
 ///
 /// 根因：刮削会把 2:3 竖版海报写进 `video_books.cover_path`（与 16:9 抽帧同列
@@ -26,7 +26,7 @@ void main() {
       source,
       isNot(contains('_kContinueVideoCoverWidth')),
       reason: '「继续」卡的视频专属 16:9 宽度特例已消灭（三类条目统一竖版槽），'
-          '不得回退（BUG-1262）',
+          '不得回退（BUG-1272）',
     );
     for (final String fn in <String>[
       'Widget _videoCover(',
@@ -37,7 +37,7 @@ void main() {
       expect(
         body,
         contains('PortraitCoverImage('),
-        reason: '$fn 必须走 PortraitCoverImage 槽向自适应（BUG-1262）',
+        reason: '$fn 必须走 PortraitCoverImage 槽向自适应（BUG-1272）',
       );
       expect(
         body,
@@ -58,7 +58,7 @@ void main() {
         body,
         contains('poster: true'),
         reason: '$fn 封面必须走 poster 竖版槽路径（PortraitCoverImage 自适应），'
-            '旧 148×84 横槽会让竖版海报两侧露灰带（BUG-1262）',
+            '旧 148×84 横槽会让竖版海报两侧露灰带（BUG-1272）',
       );
     }
   });
@@ -70,7 +70,7 @@ void main() {
     expect(
       body,
       contains('PortraitCoverImage('),
-      reason: '_episodeThumb 必须走 PortraitCoverImage（BUG-1262）',
+      reason: '_episodeThumb 必须走 PortraitCoverImage（BUG-1272）',
     );
     expect(
       body,

--- a/hibiki/test/pages/continue_cover_portrait_guard_test.dart
+++ b/hibiki/test/pages/continue_cover_portrait_guard_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1262 守卫：竖版海报封面在「继续 / 继续观看 / 合集详情」三处消费端必须
+/// 走 [PortraitCoverImage] 槽向自适应，禁止回退成硬编码 fit 的裸 `Image.file`。
+///
+/// 根因：刮削会把 2:3 竖版海报写进 `video_books.cover_path`（与 16:9 抽帧同列
+/// 无标记），旧实现三处各写各的横版硬槽——`BoxFit.cover` 把海报裁成中间一条、
+/// `BoxFit.contain` 留两侧灰带。组件行为本体见
+/// `test/widgets/portrait_cover_image_test.dart`；本守卫只锁「三处消费端确实
+/// 接上了组件」这条布线，防各写各的回归。
+///
+/// 断言前剥掉整行注释：防止把断言字面量写进注释造成假绿（守卫变异纪律）。
+void main() {
+  const String dashboardPath =
+      'lib/src/pages/implementations/home_dashboard_page.dart';
+  const String videoHomePath =
+      'lib/src/pages/implementations/home_video_page.dart';
+  const String collectionDetailPath =
+      'lib/src/pages/implementations/media_collection_detail_page.dart';
+
+  test('首页「继续」卡：视频/游戏/远端封面走 PortraitCoverImage，无 16:9 宽度特例', () {
+    final String source = File(dashboardPath).readAsStringSync();
+    expect(
+      source,
+      isNot(contains('_kContinueVideoCoverWidth')),
+      reason: '「继续」卡的视频专属 16:9 宽度特例已消灭（三类条目统一竖版槽），'
+          '不得回退（BUG-1262）',
+    );
+    for (final String fn in <String>[
+      'Widget _videoCover(',
+      'Widget _gameCover(',
+      'Widget _remoteCover(',
+    ]) {
+      final String body = _stripLineComments(_functionSource(source, fn));
+      expect(
+        body,
+        contains('PortraitCoverImage('),
+        reason: '$fn 必须走 PortraitCoverImage 槽向自适应（BUG-1262）',
+      );
+      expect(
+        body,
+        isNot(contains('BoxFit.cover')),
+        reason: '$fn 不得再用 BoxFit.cover 硬裁——竖版海报会被裁成中间一条',
+      );
+    }
+  });
+
+  test('视频首页「继续观看」hero：本地/远端封面都走 poster 竖版槽', () {
+    final String source = File(videoHomePath).readAsStringSync();
+    for (final String fn in <String>[
+      'Widget _buildContinueHero(',
+      'Widget _buildContinueHeroRemote(',
+    ]) {
+      final String body = _stripLineComments(_functionSource(source, fn));
+      expect(
+        body,
+        contains('poster: true'),
+        reason: '$fn 封面必须走 poster 竖版槽路径（PortraitCoverImage 自适应），'
+            '旧 148×84 横槽会让竖版海报两侧露灰带（BUG-1262）',
+      );
+    }
+  });
+
+  test('合集详情单集缩略图：走 PortraitCoverImage 横槽自适应', () {
+    final String source = File(collectionDetailPath).readAsStringSync();
+    final String body =
+        _stripLineComments(_functionSource(source, 'Widget _episodeThumb('));
+    expect(
+      body,
+      contains('PortraitCoverImage('),
+      reason: '_episodeThumb 必须走 PortraitCoverImage（BUG-1262）',
+    );
+    expect(
+      body,
+      contains('landscapeSlot: true'),
+      reason: '_episodeThumb 是 16:9 横槽，必须声明 landscapeSlot——否则竖版'
+          '海报仍按竖槽语义 cover 硬裁',
+    );
+    expect(
+      body,
+      isNot(contains('BoxFit.cover')),
+      reason: '_episodeThumb 不得再用 BoxFit.cover 硬裁竖版海报',
+    );
+  });
+}
+
+/// 截取从 [startToken] 起到下一个顶层 `  Widget xxx(` 方法定义之前的源码片段。
+String _functionSource(String source, String startToken) {
+  final int start = source.indexOf(startToken);
+  expect(start, isNonNegative, reason: 'missing $startToken');
+  final RegExp nextWidget = RegExp(r'\n  Widget [_A-Za-z0-9]+\(');
+  final RegExpMatch? next = nextWidget.firstMatch(
+    source.substring(start + startToken.length),
+  );
+  final int end =
+      next == null ? source.length : start + startToken.length + next.start + 1;
+  return source.substring(start, end);
+}
+
+/// 剥掉整行注释（含行内 `//` 到行尾）：断言字面量写进注释不得让守卫假绿。
+String _stripLineComments(String source) {
+  return source
+      .split('\n')
+      .map((String line) => line.replaceFirst(RegExp(r'//.*$'), ''))
+      .join('\n');
+}

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -720,15 +720,23 @@ void main() {
     await pumpDashboard(tester);
 
     expect(tester.takeException(), isNull);
-    // 修复前游戏走「回退原类型图标」分支，时间轴上不会有任何 Image.file。
+    // 修复前游戏走「回退原类型图标」分支，时间轴上不会有任何文件封面。
     // 必须收进「活动」区块：同一只游戏同时在「继续」与「最近添加」里各有一张
-    // `_gameCover`，裸 FileImage 谓词会被它们兜住——把 _activityLeading 的 game 分支
+    // `_gameCover`，裸文件封面谓词会被它们兜住——把 _activityLeading 的 game 分支
     // 删光也照样绿（实测过的假阳性）。
-    final Finder fileImages = inSection(
-      t.home_activity,
-      find.byWidgetPredicate((Widget w) => w is Image && w.image is FileImage),
-    );
-    expect(fileImages, findsOneWidget,
+    // BUG-1262 后 `_gameCover` 走 resizedFileImage（ResizeImage 包 FileImage）+
+    // PortraitCoverImage（不合槽时同图再渲染一张模糊垫底），谓词解包 ResizeImage、
+    // 数量断言放宽为 ≥1。
+    bool isFileCover(Widget w) {
+      if (w is! Image) return false;
+      final ImageProvider provider = w.image;
+      return provider is FileImage ||
+          (provider is ResizeImage && provider.imageProvider is FileImage);
+    }
+
+    final Finder fileImages =
+        inSection(t.home_activity, find.byWidgetPredicate(isFileCover));
+    expect(fileImages, findsWidgets,
         reason: '游戏活动条应渲染 galgames.coverPath 封面（BUG-1112）');
   });
 

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -724,7 +724,7 @@ void main() {
     // 必须收进「活动」区块：同一只游戏同时在「继续」与「最近添加」里各有一张
     // `_gameCover`，裸文件封面谓词会被它们兜住——把 _activityLeading 的 game 分支
     // 删光也照样绿（实测过的假阳性）。
-    // BUG-1262 后 `_gameCover` 走 resizedFileImage（ResizeImage 包 FileImage）+
+    // BUG-1272 后 `_gameCover` 走 resizedFileImage（ResizeImage 包 FileImage）+
     // PortraitCoverImage（不合槽时同图再渲染一张模糊垫底），谓词解包 ResizeImage、
     // 数量断言放宽为 ≥1。
     bool isFileCover(Widget w) {

--- a/hibiki/test/widgets/portrait_cover_image_test.dart
+++ b/hibiki/test/widgets/portrait_cover_image_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/video/cover_ui/portrait_cover_image.dart';
 
-/// BUG-1262：[PortraitCoverImage] 槽向自适应行为（此前该组件零测试覆盖）。
+/// BUG-1272：[PortraitCoverImage] 槽向自适应行为（此前该组件零测试覆盖）。
 ///
 /// 四象限契约：
 /// - 竖槽 + 竖图（海报 2:3）→ `BoxFit.cover` 铺满，无模糊垫底；
@@ -85,7 +85,7 @@ void main() {
     expect(find.byType(ImageFiltered), findsNothing);
   });
 
-  testWidgets('横槽 + 竖图（BUG-1262 主诉）：模糊垫底 + contain，不再裁成中间一条',
+  testWidgets('横槽 + 竖图（BUG-1272 主诉）：模糊垫底 + contain，不再裁成中间一条',
       (WidgetTester tester) async {
     await pumpCover(tester,
         imageWidth: 20, imageHeight: 30, landscapeSlot: true);

--- a/hibiki/test/widgets/portrait_cover_image_test.dart
+++ b/hibiki/test/widgets/portrait_cover_image_test.dart
@@ -1,0 +1,104 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/cover_ui/portrait_cover_image.dart';
+
+/// BUG-1262：[PortraitCoverImage] 槽向自适应行为（此前该组件零测试覆盖）。
+///
+/// 四象限契约：
+/// - 竖槽 + 竖图（海报 2:3）→ `BoxFit.cover` 铺满，无模糊垫底；
+/// - 竖槽 + 横图（16:9 截帧）→ 模糊垫底 + 前景 `BoxFit.contain`；
+/// - 横槽（[PortraitCoverImage.landscapeSlot]）+ 横图 → cover 铺满，无垫底；
+/// - 横槽 + 竖图 → 垫底 + contain（合集详情 16:9 缩略图里的刮削海报）。
+void main() {
+  const Key fgKey = Key('portrait_cover_foreground');
+
+  /// 生成 [width]×[height] 的纯色 PNG（真实可解码，供 [MemoryImage] 用）。
+  Future<Uint8List> pngBytes(int width, int height) async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    ui.Canvas(recorder).drawRect(
+      ui.Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+      ui.Paint()..color = const ui.Color(0xFF3355FF),
+    );
+    final ui.Image image = await recorder.endRecording().toImage(width, height);
+    final ByteData? data =
+        await image.toByteData(format: ui.ImageByteFormat.png);
+    return data!.buffer.asUint8List();
+  }
+
+  /// 装配组件并等真实解码完成（[ImageStream] 尺寸回调驱动 rebuild）。
+  Future<void> pumpCover(
+    WidgetTester tester, {
+    required int imageWidth,
+    required int imageHeight,
+    required bool landscapeSlot,
+  }) async {
+    final Uint8List? bytes = await tester.runAsync<Uint8List>(
+      () => pngBytes(imageWidth, imageHeight),
+    );
+    final MemoryImage provider = MemoryImage(bytes!);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Center(
+          child: SizedBox(
+            width: landscapeSlot ? 96 : 100,
+            height: landscapeSlot ? 54 : 150,
+            child: PortraitCoverImage(
+              image: provider,
+              imageKey: fgKey,
+              landscapeSlot: landscapeSlot,
+            ),
+          ),
+        ),
+      ),
+    );
+    // 真实异步解码在 runAsync 区里完成，随后 pump 应用尺寸回调的 setState。
+    await tester.runAsync<void>(
+      () => precacheImage(provider, tester.element(find.byKey(fgKey))),
+    );
+    await tester.pump();
+  }
+
+  BoxFit? foregroundFit(WidgetTester tester) =>
+      tester.widget<Image>(find.byKey(fgKey)).fit;
+
+  testWidgets('竖槽 + 竖图：cover 铺满，无模糊垫底', (WidgetTester tester) async {
+    await pumpCover(tester,
+        imageWidth: 20, imageHeight: 30, landscapeSlot: false);
+    expect(foregroundFit(tester), BoxFit.cover);
+    expect(find.byType(ImageFiltered), findsNothing);
+  });
+
+  testWidgets('竖槽 + 横图：模糊垫底 + contain 前景', (WidgetTester tester) async {
+    await pumpCover(tester,
+        imageWidth: 32, imageHeight: 18, landscapeSlot: false);
+    expect(foregroundFit(tester), BoxFit.contain);
+    expect(find.byType(ImageFiltered), findsOneWidget);
+  });
+
+  testWidgets('横槽 + 横图：cover 铺满，无模糊垫底', (WidgetTester tester) async {
+    await pumpCover(tester,
+        imageWidth: 32, imageHeight: 18, landscapeSlot: true);
+    expect(foregroundFit(tester), BoxFit.cover);
+    expect(find.byType(ImageFiltered), findsNothing);
+  });
+
+  testWidgets('横槽 + 竖图（BUG-1262 主诉）：模糊垫底 + contain，不再裁成中间一条',
+      (WidgetTester tester) async {
+    await pumpCover(tester,
+        imageWidth: 20, imageHeight: 30, landscapeSlot: true);
+    expect(foregroundFit(tester), BoxFit.contain);
+    expect(find.byType(ImageFiltered), findsOneWidget);
+  });
+
+  testWidgets('方图两种槽向都不合槽：均走垫底（cover 会裁掉四成以上）', (WidgetTester tester) async {
+    await pumpCover(tester,
+        imageWidth: 24, imageHeight: 24, landscapeSlot: false);
+    expect(foregroundFit(tester), BoxFit.contain);
+    await pumpCover(tester,
+        imageWidth: 24, imageHeight: 24, landscapeSlot: true);
+    expect(foregroundFit(tester), BoxFit.contain);
+  });
+}


### PR DESCRIPTION
## 问题（用户截图报告）
刮削会把 2:3 竖版海报写进 `video_books.cover_path`（与 16:9 抽帧封面同列、无横竖标记），但三处消费端都是硬编码横版槽 + 固定 fit：
- 首页「继续」卡：视频条目 234×132 的 16:9 槽 + `BoxFit.cover` → 海报被裁成中间一条
- 视频首页「继续观看」hero：148×84 + `BoxFit.contain` → 海报两侧露宽灰带
- 合集详情单集缩略图：96×54 + `BoxFit.cover` → 同样裁烂

## 根因修复
- `PortraitCoverImage` 从「竖槽专用」推广为**槽向自适应**：新增 `landscapeSlot`，朝向合槽 → cover 铺满；不合槽 → 同图模糊垫底 + contain（阈值：竖槽 0.85 / 横槽 1.2）
- 首页「继续」卡：**消灭视频专属宽度特例**，书/视频/游戏统一 94×132 竖版海报槽（与视频库主网格同源，顺带满足用户「继续区换成竖版海报卡」的期望样式）；视频/游戏/远端封面全部接 `PortraitCoverImage`（+`resizedFileImage` 解码上限）
- 「继续观看」hero（本地 + 远端）：改 80×120 竖版槽，走既有 `poster: true` 路径
- 合集详情 `_episodeThumb`：保留 96×54 横槽，`landscapeSlot: true` 自适应
- 活动时间轴视频缩略（68×40 横槽，复用 `_videoCover`）：槽向参数穿透，判定方向随槽走
- 修正 `media_cover_source.dart` 分工注释里指错的类名（PosterCoverImage → PortraitCoverImage）

## 测试
- 新增 `test/widgets/portrait_cover_image_test.dart`：组件四象限行为（此前该组件零覆盖），真实 PNG 解码驱动
- 新增 `test/pages/continue_cover_portrait_guard_test.dart`：三处消费端布线守卫（剥注释后断言；已做变异实测：等价回退写法 + 断言字面量塞注释，三处守卫全部变红）
- 更新 BUG-1112 活动封面测试谓词（解包 ResizeImage）
- `flutter analyze` 全量无告警；定向套件（dashboard/合集详情/视频首页/两个既有封面守卫）全绿

## Bug 跟踪
docs/bugs/BUG-1272-continue-cover-portrait-crop.md（①修复 ②测试 均勾）

https://claude.ai/code/session_019JWmevijDXYzSDMAmzr1MN
