### PR TITLE
ui(interconnect): 互联设置页补角色用法说明与对端列表标题/空态

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 47243 (2779 per locale)
+/// Strings: 47294 (2782 per locale)
 ///
-/// Built on 2026-07-31 at 10:28 UTC
+/// Built on 2026-07-31 at 11:26 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3737,6 +3737,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anime_download_streaming_ready =>
       'In library · download continues';
   String get anime_download_unfiltered => 'No Trusted filter';
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  String get interconnect_peer_list_title => 'Added peers';
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -10101,6 +10106,14 @@ class _StringsAr extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -16533,6 +16546,14 @@ class _StringsDe extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -22981,6 +23002,14 @@ class _StringsEs extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -29440,6 +29469,14 @@ class _StringsFr extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -35828,6 +35865,14 @@ class _StringsId extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -42262,6 +42307,14 @@ class _StringsIt extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -48513,6 +48566,14 @@ class _StringsJa extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -54766,6 +54827,14 @@ class _StringsKo extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -61180,6 +61249,14 @@ class _StringsNl extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -67607,6 +67684,14 @@ class _StringsPtBr extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -74018,6 +74103,14 @@ class _StringsRu extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -80377,6 +80470,14 @@ class _StringsTh extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -86768,6 +86869,14 @@ class _StringsTr extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -93144,6 +93253,14 @@ class _StringsVi extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 // Path: <root>
@@ -99068,6 +99185,14 @@ class _StringsZhCn extends _StringsEn {
   String get anime_download_streaming_ready => '已入库 · 下载继续';
   @override
   String get anime_download_unfiltered => '未启用 Trusted 筛选';
+  @override
+  String get interconnect_enable_footer =>
+      '用法：在存放内容的那台设备上开启下方的同步服务器开关；在另一台设备上添加该服务器的地址完成配对。同一台设备同一时间只能担任服务器或客户端其中一种角色。';
+  @override
+  String get interconnect_peer_list_title => '已添加的对端';
+  @override
+  String get interconnect_peer_list_empty =>
+      '尚未添加任何对端。可在下方的局域网设备列表中点击发现的设备自动配对，或手动添加对端地址。';
 }
 
 // Path: <root>
@@ -105240,6 +105365,14 @@ class _StringsZhHk extends _StringsEn {
       'In library · download continues';
   @override
   String get anime_download_unfiltered => 'No Trusted filter';
+  @override
+  String get interconnect_enable_footer =>
+      'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+  @override
+  String get interconnect_peer_list_title => 'Added peers';
+  @override
+  String get interconnect_peer_list_empty =>
+      'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
 }
 
 /// Flat map(s) containing all translations.
@@ -110935,6 +111068,12 @@ extension on _StringsEn {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -116628,6 +116767,12 @@ extension on _StringsAr {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -122342,6 +122487,12 @@ extension on _StringsDe {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -128055,6 +128206,12 @@ extension on _StringsEs {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -133774,6 +133931,12 @@ extension on _StringsFr {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -139475,6 +139638,12 @@ extension on _StringsId {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -145191,6 +145360,12 @@ extension on _StringsIt {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -150869,6 +151044,12 @@ extension on _StringsJa {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -156551,6 +156732,12 @@ extension on _StringsKo {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -162260,6 +162447,12 @@ extension on _StringsNl {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -167966,6 +168159,12 @@ extension on _StringsPtBr {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -173677,6 +173876,12 @@ extension on _StringsRu {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -179372,6 +179577,12 @@ extension on _StringsTh {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -185076,6 +185287,12 @@ extension on _StringsTr {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -190775,6 +190992,12 @@ extension on _StringsVi {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }
@@ -196426,6 +196649,12 @@ extension on _StringsZhCn {
         return '已入库 · 下载继续';
       case 'anime_download_unfiltered':
         return '未启用 Trusted 筛选';
+      case 'interconnect_enable_footer':
+        return '用法：在存放内容的那台设备上开启下方的同步服务器开关；在另一台设备上添加该服务器的地址完成配对。同一台设备同一时间只能担任服务器或客户端其中一种角色。';
+      case 'interconnect_peer_list_title':
+        return '已添加的对端';
+      case 'interconnect_peer_list_empty':
+        return '尚未添加任何对端。可在下方的局域网设备列表中点击发现的设备自动配对，或手动添加对端地址。';
       default:
         return null;
     }
@@ -202099,6 +202328,12 @@ extension on _StringsZhHk {
         return 'In library · download continues';
       case 'anime_download_unfiltered':
         return 'No Trusted filter';
+      case 'interconnect_enable_footer':
+        return 'How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.';
+      case 'interconnect_peer_list_title':
+        return 'Added peers';
+      case 'interconnect_peer_list_empty':
+        return 'No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "服务已正常响应，但按当前条件返回 0 条。查询：$query；筛选：$filters。请尝试别名或放宽筛选。",
   "anime_download_streaming_ready": "已入库 · 下载继续",
   "anime_download_unfiltered": "未启用 Trusted 筛选",
-  "interconnect_enable_footer": "用法：在存放内容的那台设备上开启下方「本机作为同步服务器」，再在另一台设备的「连接到其他设备」里完成配对。同一台设备同一时间只能担任服务器或客户端其中一种角色。",
+  "interconnect_enable_footer": "用法：在存放内容的那台设备上开启下方的同步服务器开关；在另一台设备上添加该服务器的地址完成配对。同一台设备同一时间只能担任服务器或客户端其中一种角色。",
   "interconnect_peer_list_title": "已添加的对端",
-  "interconnect_peer_list_empty": "尚未添加任何对端。可在下方「局域网设备」中点击发现的设备自动配对，或点「添加」手动输入对端地址。"
+  "interconnect_peer_list_empty": "尚未添加任何对端。可在下方的局域网设备列表中点击发现的设备自动配对，或手动添加对端地址。"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "上次同步：失败",
   "anime_download_no_results_detail": "服务已正常响应，但按当前条件返回 0 条。查询：$query；筛选：$filters。请尝试别名或放宽筛选。",
   "anime_download_streaming_ready": "已入库 · 下载继续",
-  "anime_download_unfiltered": "未启用 Trusted 筛选"
+  "anime_download_unfiltered": "未启用 Trusted 筛选",
+  "interconnect_enable_footer": "用法：在存放内容的那台设备上开启下方「本机作为同步服务器」，再在另一台设备的「连接到其他设备」里完成配对。同一台设备同一时间只能担任服务器或客户端其中一种角色。",
+  "interconnect_peer_list_title": "已添加的对端",
+  "interconnect_peer_list_empty": "尚未添加任何对端。可在下方「局域网设备」中点击发现的设备自动配对，或点「添加」手动输入对端地址。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2778,7 +2778,7 @@
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
   "anime_download_unfiltered": "No Trusted filter",
-  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_enable_footer": "How to use: on the device that holds your library, turn on the sync server switch below; on your other device, add the address of that server to pair with it. A device can act as only one role at a time — server or client.",
   "interconnect_peer_list_title": "Added peers",
-  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
+  "interconnect_peer_list_empty": "No peers added yet. Pick a discovered device from the LAN device list below to pair automatically, or add a peer address manually."
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2777,5 +2777,8 @@
   "sync_last_failed": "Last sync: failed",
   "anime_download_no_results_detail": "The service responded successfully but returned 0 items. Query: $query; filters: $filters. Try another title or loosen the filters.",
   "anime_download_streaming_ready": "In library · download continues",
-  "anime_download_unfiltered": "No Trusted filter"
+  "anime_download_unfiltered": "No Trusted filter",
+  "interconnect_enable_footer": "How to use: turn on \"Host server\" below on the device that holds your library, then pair from \"Connect to other devices\" on the other device. Each device can act as only one role at a time — server or client.",
+  "interconnect_peer_list_title": "Added peers",
+  "interconnect_peer_list_empty": "No peers added yet. Tap a device under \"LAN devices\" below to pair automatically, or tap \"Add\" to enter an address manually."
 }

--- a/hibiki/lib/src/sync/sync_settings_schema.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema.dart
@@ -383,8 +383,11 @@ SettingsDestination buildInterconnectDestination() {
     icon: Icons.devices_outlined,
     sections: <SettingsSection>[
       // 互联总开关（独立于云备份后端，二者可并存）。开关常显；关闭时下方配置区隐藏，
-      // 副标题说明互联与云同步互不排斥。
+      // 副标题说明互联与云同步互不排斥。footer 用一句话讲清角色模型（哪台开服务器、
+      // 哪台连接、角色互斥）——此前整页没有任何地方交代这一点，用户面对平铺的
+      // client/host 两大区不知道该在哪台设备上动哪个开关。
       SettingsSection(
+        footer: t.interconnect_enable_footer,
         items: <SettingsItem>[
           SettingsSwitchItem(
             id: 'interconnect.enabled',

--- a/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
+++ b/hibiki/lib/src/sync/sync_settings_schema/interconnect.part.dart
@@ -351,6 +351,19 @@ class _HibikiServerConfigWidgetState extends State<_HibikiServerConfigWidget>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
+          // 列表标题与下方 _LanDiscoveryWidget 的「局域网设备」同级对齐：section 标题
+          // 「连接到其他设备」罩着两个 widget，此前本列表裸露无题，空列表时更是只剩一个
+          // 孤零零的「添加」按钮，用户不知道这块是什么、该怎么连。
+          Text(t.interconnect_peer_list_title,
+              style: theme.textTheme.titleSmall),
+          const SizedBox(height: 8),
+          if (_urls.isEmpty)
+            Text(
+              t.interconnect_peer_list_empty,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
           if (_urls.isNotEmpty)
             // 自实现的 HibikiReorderableColumn 而非 SDK ReorderableListView：
             // 整棵树活在 HibikiAppUiScale 的 Transform.scale 之下，而 SDK 的

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1018
+version: 1.3.1+1019
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/sync/sync_settings_visibility_test.dart
+++ b/hibiki/test/sync/sync_settings_visibility_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/src/settings/settings_schema_card_creation.dart';
 import 'package:hibiki/src/settings/settings_schema_system.dart';
@@ -316,10 +317,19 @@ void main() {
       expect(idsOf(dest.sections[0]), <String>['interconnect.enabled']);
       expect(dest.sections[0].visible, isNull,
           reason: 'the enable toggle must always be visible');
-      // 角色模型用法说明（哪台开服务器、哪台连接、角色互斥）挂在总开关区 footer，
-      // 是整页唯一一处讲清 client/host 分工的文案，不得静默丢失。
-      expect(dest.sections[0].footer, isNotNull,
+      // 角色模型用法说明（哪台开服务器、哪台连接配对、角色互斥）挂在总开关区
+      // footer，是整页唯一一处讲清 client/host 分工的文案。只断 isNotNull 挡不住
+      // 「换成任何别的字符串」，所以两层守：① 绑定到 interconnect_enable_footer
+      // 这条 key（换成别的 key 或裸串即红）；② 断言语义锚点 server + pair（文案被
+      // 换成不相干内容即红）。刻意不做整串字面量全匹配——润色措辞不该误红。
+      final String? enableFooter = dest.sections[0].footer;
+      expect(enableFooter, t.interconnect_enable_footer,
           reason: 'the enable section must keep the role-model usage note');
+      final String enableFooterText = (enableFooter ?? '').toLowerCase();
+      expect(enableFooterText, contains('server'),
+          reason: 'the note must say which device runs the sync server');
+      expect(enableFooterText, contains('pair'),
+          reason: 'the note must say the other device pairs with that server');
       expect(idsOf(dest.sections[1]),
           <String>['sync.hibiki_server_config', 'sync.lan_devices']);
       expect(dest.sections[1].visible, isNotNull);
@@ -340,6 +350,24 @@ void main() {
       expect(dest.sections[3].visible, isNotNull);
       expect(idsOf(dest.sections[4]), <String>['sync.server_mode']);
       expect(dest.sections[4].visible, isNotNull);
+    });
+
+    test('peer address list keeps its title and empty-state guidance', () {
+      // 对端地址列表的标题与空态引导是 _HibikiServerConfigWidget 内的纯 widget
+      // 文案，进不了 SettingsSection 树，只能源码扫描守：任一处被删即红。同样只断
+      // key 引用 + 语义锚点，不做整串字面量匹配。
+      final String source = File(
+        'lib/src/sync/sync_settings_schema/interconnect.part.dart',
+      ).readAsStringSync();
+      expect(source, contains('t.interconnect_peer_list_title'),
+          reason: 'the peer address list must keep its title');
+      expect(source, contains('t.interconnect_peer_list_empty'),
+          reason: 'an empty peer address list must keep its guidance text');
+      final String emptyHint = t.interconnect_peer_list_empty.toLowerCase();
+      expect(emptyHint, contains('peer'),
+          reason: 'the empty-state text must name what the list holds');
+      expect(emptyHint, contains('pair'),
+          reason: 'the empty-state text must point at how to get a peer in');
     });
 
     test('delegate section lives with interconnect, not in card creation', () {

--- a/hibiki/test/sync/sync_settings_visibility_test.dart
+++ b/hibiki/test/sync/sync_settings_visibility_test.dart
@@ -316,6 +316,10 @@ void main() {
       expect(idsOf(dest.sections[0]), <String>['interconnect.enabled']);
       expect(dest.sections[0].visible, isNull,
           reason: 'the enable toggle must always be visible');
+      // 角色模型用法说明（哪台开服务器、哪台连接、角色互斥）挂在总开关区 footer，
+      // 是整页唯一一处讲清 client/host 分工的文案，不得静默丢失。
+      expect(dest.sections[0].footer, isNotNull,
+          reason: 'the enable section must keep the role-model usage note');
       expect(idsOf(dest.sections[1]),
           <String>['sync.hibiki_server_config', 'sync.lan_devices']);
       expect(dest.sections[1].visible, isNotNull);


### PR DESCRIPTION
## 背景

用户反馈「hibiki 互联配置有点看不明白」。排查后确认根因在信息架构：互联设置页平铺 client（连接到其他设备）/ host（本机作为同步服务器）两大区，但整页没有一处交代角色模型——哪台设备该开服务器、哪台该连接、两角色互斥只在触发互斥锁时才以被动提示出现。「连接到其他设备」区里的对端地址列表也裸露无标题，空列表时只剩一个孤零零的「添加」按钮。

## 改动（纯显示，零行为变更）

- **总开关区加用法说明 footer**（`interconnect_enable_footer`）：一句话讲清在存内容的设备开服务器、另一台配对连接、同机同刻只能担任一种角色。
- **对端地址列表加标题「已添加的对端」**，与下方 `_LanDiscoveryWidget` 的「局域网设备」标题同级对齐。
- **空列表时显示引导文案**（`interconnect_peer_list_empty`）：指向局域网发现自动配对与「添加」手动输入两条路径。
- 新增 3 个 i18n key 经 `tool/i18n_sync.dart --add` 同步 17 语言，`dart run slang` 重新生成。
- `sync_settings_visibility_test` 补 footer 守卫断言。

## 验证

- `flutter analyze` 全量：No issues found
- `flutter test test/sync/sync_settings_visibility_test.dart test/i18n --no-pub`：43 项全部通过（含 17 语言完整性 / 孤儿 key / 插值一致性守卫）

https://claude.ai/code/session_01XJ5ZvbW246oWzazN4jho2C