### PR TITLE
fix(popup): 折叠开关不再被自动展开覆盖 + 自动展开默认从 9 本改回 3 本（BUG-1264 / BUG-1271）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1201 条。点号进各自文件。
+> 共 1202 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1264](bugs/BUG-1264-popup-perdict-collapse-outranked.md) | ✅ | ✅ | 每本词典的折叠开关对前 N 本无效（被自动展开覆盖） |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1202 条。点号进各自文件。
+> 共 1203 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1271](bugs/BUG-1271-popup-autoexpand-rows-unit-mismatch.md) | ✅ | ✅ | 自动展开默认值按本数写进行数槽位，出厂默认从3本变9本 |
 | [BUG-1264](bugs/BUG-1264-popup-perdict-collapse-outranked.md) | ✅ | ✅ | 每本词典的折叠开关对前 N 本无效（被自动展开覆盖） |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |

--- a/docs/bugs/BUG-1264-popup-perdict-collapse-outranked.md
+++ b/docs/bugs/BUG-1264-popup-perdict-collapse-outranked.md
@@ -1,0 +1,68 @@
+## BUG-1264 · 每本词典的折叠开关对前 N 本无效（被自动展开覆盖）
+
+- **报告**：2026-07-31（用户：截图圈出词典管理里两本已折叠的词典，「这里折叠了没用。还是会展开」）
+- **真实性**：✅ 真 bug，根因 `hibiki/assets/popup/popup.js:3007`（修复前）
+
+### 现象
+
+在「词典管理」里把某本词典按行首开关设为折叠后，查词弹窗里该词典的释义块仍然是展开的，
+折叠开关像是没有生效。
+
+### 根因
+
+展开判定把「批量默认」排在了「显式决定」前面：
+
+```js
+// 修复前 popup.js:3007
+if (autoExpanded || (!window.collapseDictionaries && !perDictCollapsed)) {
+    details.open = true;
+}
+```
+
+`autoExpanded`（= `dictIdx < autoExpandCount(totalDicts)`，见 `autoExpandCount()`）一旦为真就短路，
+`perDictCollapsed` 根本不参与判断。也就是说：**落在自动展开区里的词典，每本折叠开关是空操作**。
+
+自动展开区不是一本，是 `popup_auto_expand_dictionaries`（行数）×
+`popup_dictionary_columns`（列数，经 `effectiveDictColumns()` 视口收敛并按该词条卡片数封顶）。
+报告用户的生产库实测偏好是 **3 行 × 3 列 = 前 9 本**，且 `dictionary_metadata` 里 20 本 term 词典
+`collapsed_languages_json` 全是 `["ja"]`（即全部设了折叠）、`collapse_dictionaries = true`。
+于是前 9 本无论点多少次折叠都照常展开 —— 完全对上用户描述。
+
+数据结构层面的错误是**优先级定反**：`collapsedDictionaryNames` 是用户对某一本的显式决定
+（词典管理里一行一点），`autoExpandRows` 是给「没有任何显式决定的词典」用的批量默认值。
+批量默认压过显式决定，显式开关就必然在该区间内失效。
+
+注入链本身没有问题（`popup_settings_injection.dart:571-574` 按 `Dictionary.isCollapsed` 生成名单，
+`toggleDictionaryCollapsed` 直接改内存对象并持久化），所以不是丢状态、不是名字失配。
+
+### [x] ① 已修复
+
+`popup.js` 三镜像（app popup / 扩展 assets 镜像 / 扩展 tools 镜像）统一改为显式决定短路：
+
+```js
+if (!perDictCollapsed && (autoExpanded || !window.collapseDictionaries)) {
+    details.open = true;
+}
+```
+
+- 标了折叠的词典：永不自动展开（`<details>` 仍可手动点开，不影响随时查看）。
+- 没标折叠的词典：行为与修复前完全一致（落在自动展开区就展开，或全局折叠关时展开），
+  即从不碰折叠开关的老用户零改变。
+
+### [x] ② 已加自动化测试
+
+- 行为级（Node 真执行 `createGlossarySection`）：`hibiki/test/pages/popup_auto_expand_dictionaries_test.js`
+  新增一组断言 —— 3 行 × 3 列 下 idx0 / idx4 标了折叠必须 `open === false`；同批未标折叠的词典
+  在 idx0 / idx8 仍展开、idx9 仍折叠；全局折叠关时标记同样生效；rows=0 未标记仍折叠。
+- 源码级三镜像守卫：`hibiki/test/pages/popup_auto_expand_dictionaries_test.dart` 新增
+  `per-dictionary collapse outranks auto-expand (three mirrors)`，从 `createGlossarySection`
+  **函数体内**取样（不扫全文），避免注释里复述表达式造成假绿。
+
+变异实测（两轮，均按预期变红后恢复变绿）：
+1. 把判定改回修复前写法 → `per-dict collapsed beats auto-expand at idx0` 断言失败（true !== false）。
+2. 把判定改成 `!perDictCollapsed && false`（过度折叠）→ 未标记词典的展开断言失败。
+
+### 备注
+
+- 三镜像必须同改，否则浏览器扩展里的弹窗与 app 内弹窗行为漂开。
+- 全局查词浮窗（Windows native 裸 WebView2）加载的是同一份 `assets/popup/popup.js`，一并覆盖。

--- a/docs/bugs/BUG-1271-popup-autoexpand-rows-unit-mismatch.md
+++ b/docs/bugs/BUG-1271-popup-autoexpand-rows-unit-mismatch.md
@@ -1,0 +1,74 @@
+## BUG-1271 · 自动展开默认值按本数写进行数槽位，出厂默认从3本变9本
+
+- **报告**：2026-07-31（用户在 BUG-1264 结论上追问「为什么默认 3x3，不是默认 3 本吗，列数什么时候变成 3 了」）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/models/app_model.dart:4879`（修复前）
+
+### 现象
+
+查词弹窗出厂默认自动展开 **9 本**词典，而设置里那个滑块读数是 **3**。
+用户拍板的意图是「第一行铺满即展开」= 列数那么多本 = 3 本。
+
+### 根因
+
+单位换算漏改，两个各自正确的改动叠在一起出的错：
+
+1. TODO-1357：`popupDictionaryColumns` 出厂默认抬到 **3**（桌面 + 移动都是 3，真实生效列数
+   再由 popup.js `effectiveDictColumns()` 按每列 ≥170px 视口收敛）。
+2. 用户拍板 2026-07-14：自动展开默认「跟随最多列数」，即第一行铺满。当时这个偏好的单位是
+   **本数**，所以 `popupAutoExpandDictionaries` 未显式设过时返回 `popupDictionaryColumns`
+   —— 返回「列数那么多本」，正确。
+3. TODO-845：把这个偏好的单位从「本数」改成「**行数**」，popup.js 侧
+   `autoExpandCount() = rows × cols`（见 `assets/popup/popup.js` `autoExpandCount`）。
+   **但 Dart 侧那个默认值没跟着换算**。
+
+于是默认值变成 `cols` **行** × `cols` 列 = **cols² 本**：
+
+| 最多列数 | 意图（第一行铺满） | 实际展开 |
+|---|---|---|
+| 1 | 1 本 | 1 本 |
+| 3（出厂默认） | 3 本 | **9 本** |
+| 4 | 4 本 | **16 本** |
+
+TODO-845 当时的兼容性论证写的是「默认列数 1 时 rows × 1 === 旧的绝对本数，老用户零改变」——
+这个论证的前提（列数默认 1）在 TODO-1357 把列数默认改成 3 之后就已经不成立了，只是没人回头核。
+
+这也放大了 BUG-1264：per-dict 折叠开关在自动展开区内失效，而这个区默认就有 9 本，
+基本覆盖一次查词能命中的全部词典 —— 用户的直接感受就是「折叠完全没用」。
+
+### [x] ① 已修复
+
+`app_model.dart` 的默认值改为 **1 行**：
+
+```dart
+int get popupAutoExpandDictionaries =>
+    prefsRepo.hasExplicitPopupAutoExpandDictionaries
+        ? prefsRepo.popupAutoExpandDictionaries
+        : 1;
+```
+
+「跟随列数」的意图**没有变**，只是移到唯一正确的那一层：本数 = 1 × cols = cols 本，
+乘法由 popup.js 的 `autoExpandCount` 单点负责。列数改成 4，默认展开就是 4 本（第一行），
+不再是 16 本。
+
+**存量显式值不做迁移**：`popup_auto_expand_dictionaries` 里已显式存过的值是按旧「本数」
+语义写的，会被当行数读（存 3 → 3 行 × 3 列 = 9 本）。偏好没有写入时间戳，无法区分该值是
+单位变更前还是变更后写的，任何自动换算都会误伤单位变更后设过的用户。该滑块在
+「查词 → 自动展开词典数」可见可自调，故交由用户自行调整，不做静默数据迁移。
+
+### [x] ② 已加自动化测试
+
+`hibiki/test/pages/popup_layout_width_columns_test.dart` 的源码守卫改为断言默认 1 行，
+并显式禁止把 `popupDictionaryColumns` 塞回行数槽位（附本 BUG 号与 cols² 的理由）。
+
+⚠️ 这条守卫原本断言的是「默认 = popupDictionaryColumns」，**改动它是契约变更，不是回归**。
+旧断言锁死的正是本 bug。
+
+变异实测：把默认改回 `popupDictionaryColumns` → 守卫按预期变红
+（`BUG-1271：单位是「行」，默认必须是 1 行` 断言失败）；恢复后绿。
+
+### 备注
+
+- 与 BUG-1264 同 PR 落地：1264 修「折叠开关被自动展开覆盖」，1271 修「自动展开区默认大了 3 倍」。
+  两者独立成因，叠在一起才是用户看到的完整症状。
+- 相邻可疑点（未改）：滑块只显示数字读数，用户看到「3」很难意识到那是 3 行 × 3 列 = 9 本；
+  文案 `popup_auto_expand_dictionaries_hint` 已按「行」描述，但读数本身没有单位提示。

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -2997,14 +2997,23 @@ function autoExpandCount(totalDicts) {
 // to cap the effective column count the same way masonry does. The popup
 // auto-expands the leading `autoExpandCount(totalDicts)` blocks even when
 // collapseDictionaries is on (default 1 row = the historical "only the first
-// dictionary expanded" behaviour at the default single column, where the leading
-// block opened regardless of its per-dictionary collapse flag).
+// dictionary expanded" behaviour at the default single column).
+//
+// BUG-1264: per-dictionary collapse OUTRANKS auto-expand. `collapsedDictionaryNames`
+// is an explicit per-book decision the user made in 词典管理 (one tap per row);
+// autoExpandRows is a bulk default for the books that carry no such decision.
+// Ranking the bulk default first made the per-book toggle a no-op for the leading
+// rows x columns blocks -- at the shipped 3 rows x 3 columns that silently ignored
+// the flag on the first NINE dictionaries, i.e. "I collapsed it and it still opens".
+// So the per-dict flag short-circuits both auto-expand and the global switch; a
+// non-collapsed block still follows the old rule (auto-expanded, or global collapse
+// off). Users can still open a collapsed block by hand -- <details> stays clickable.
 function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts) {
     const details = el('details', { className: 'glossary-group' });
     const perDictCollapsed = (window.collapsedDictionaryNames || []).includes(dictName);
     const autoExpandN = autoExpandCount(totalDicts);
     const autoExpanded = dictIdx < autoExpandN;
-    if (autoExpanded || (!window.collapseDictionaries && !perDictCollapsed)) {
+    if (!perDictCollapsed && (autoExpanded || !window.collapseDictionaries)) {
         details.open = true;
     }
 

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -2997,14 +2997,23 @@ function autoExpandCount(totalDicts) {
 // to cap the effective column count the same way masonry does. The popup
 // auto-expands the leading `autoExpandCount(totalDicts)` blocks even when
 // collapseDictionaries is on (default 1 row = the historical "only the first
-// dictionary expanded" behaviour at the default single column, where the leading
-// block opened regardless of its per-dictionary collapse flag).
+// dictionary expanded" behaviour at the default single column).
+//
+// BUG-1264: per-dictionary collapse OUTRANKS auto-expand. `collapsedDictionaryNames`
+// is an explicit per-book decision the user made in 词典管理 (one tap per row);
+// autoExpandRows is a bulk default for the books that carry no such decision.
+// Ranking the bulk default first made the per-book toggle a no-op for the leading
+// rows x columns blocks -- at the shipped 3 rows x 3 columns that silently ignored
+// the flag on the first NINE dictionaries, i.e. "I collapsed it and it still opens".
+// So the per-dict flag short-circuits both auto-expand and the global switch; a
+// non-collapsed block still follows the old rule (auto-expanded, or global collapse
+// off). Users can still open a collapsed block by hand -- <details> stays clickable.
 function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts) {
     const details = el('details', { className: 'glossary-group' });
     const perDictCollapsed = (window.collapsedDictionaryNames || []).includes(dictName);
     const autoExpandN = autoExpandCount(totalDicts);
     const autoExpanded = dictIdx < autoExpandN;
-    if (autoExpanded || (!window.collapseDictionaries && !perDictCollapsed)) {
+    if (!perDictCollapsed && (autoExpanded || !window.collapseDictionaries)) {
         details.open = true;
     }
 

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4873,13 +4873,22 @@ class AppModel with ChangeNotifier {
   Future<void> setPopupDictionaryColumns(int columns) =>
       prefsRepo.setPopupDictionaryColumns(columns);
 
-  /// 自动展开词典数默认「跟随最多列数」（用户拍板 2026-07-14）：未显式设过时默认 =
-  /// 当前 [popupDictionaryColumns]（一行几列就默认展开几本，第一行铺满即展开）；用户
-  /// 显式设过一律遵从其存储值。列数改动会带动本默认（用户没单独设过展开数时）。
+  /// 自动展开默认「第一行铺满即展开」（用户拍板 2026-07-14）：未显式设过时默认 1 **行**，
+  /// popup.js 再乘当前有效列数（`autoExpandCount` = rows × cols），所以展开本数天然
+  /// 跟随列数——列数 3 就是第一行那 3 本，列数改了默认也跟着改，正是拍板的语义。
+  ///
+  /// BUG-1271：本默认值原本返回 [popupDictionaryColumns]。拍板当时这个偏好的单位是
+  /// 「本数」，返回列数 = 「第一行铺满」是对的；TODO-845 之后把单位改成了「行数」，
+  /// 却没换算这个默认值，于是它变成 cols **行** × cols 列 = cols² 本 —— 出厂默认
+  /// （列数 3）从意图的 3 本膨胀成 9 本，列数调到 4 就是 16 本。单位是行，「第一行
+  /// 铺满」就只能写 1。
+  ///
+  /// 用户显式设过一律遵从其存储值（存量显式值仍按旧「本数」语义写入，会被当成行数
+  /// 读，见 BUG-1271 备注；滑块可见可自调，故不做静默数据迁移）。
   int get popupAutoExpandDictionaries =>
       prefsRepo.hasExplicitPopupAutoExpandDictionaries
           ? prefsRepo.popupAutoExpandDictionaries
-          : popupDictionaryColumns;
+          : 1;
   Future<void> setPopupAutoExpandDictionaries(int count) =>
       prefsRepo.setPopupAutoExpandDictionaries(count);
 

--- a/hibiki/test/pages/popup_auto_expand_dictionaries_test.dart
+++ b/hibiki/test/pages/popup_auto_expand_dictionaries_test.dart
@@ -156,6 +156,54 @@ void main() {
             '(legacy getter name, value is the row count)');
   });
 
+  // BUG-1264: the per-dictionary collapse flag (词典管理 行首开关 →
+  // window.collapsedDictionaryNames) is an EXPLICIT per-book decision;
+  // autoExpandRows is a bulk default for books carrying no such decision.
+  // Ranking auto-expand first silently voided the toggle on the leading
+  // rows × columns blocks (3×3 in the shipped default = the first NINE books).
+  // Asserted on all three popup.js mirrors, and read out of the函数体 (not the
+  // whole file) so a stray comment restating the expression can never fake it.
+  test('per-dictionary collapse outranks auto-expand (three mirrors)', () {
+    const Map<String, String> mirrors = <String, String>{
+      'app popup': 'assets/popup/popup.js',
+      'extension vendor (assets)': 'assets/browser_extension/vendor/popup.js',
+      'extension vendor (tools)': '../tools/browser-extension/vendor/popup.js',
+    };
+
+    for (final MapEntry<String, String> mirror in mirrors.entries) {
+      final File file = File(mirror.value);
+      expect(file.existsSync(), isTrue,
+          reason: '${mirror.key}: ${mirror.value} must exist');
+      final String js = file.readAsStringSync();
+
+      final int fn = js.indexOf('function createGlossarySection(');
+      expect(fn, greaterThanOrEqualTo(0),
+          reason: '${mirror.key}: createGlossarySection must exist');
+      // The open decision sits in the first few lines of the body; slice a
+      // window that excludes the leading doc comment entirely.
+      final String body = js.substring(fn, fn + 700);
+
+      expect(
+        body.contains(
+            'if (!perDictCollapsed && (autoExpanded || !window.collapseDictionaries))'),
+        isTrue,
+        reason: '${mirror.key}: the per-dict collapse flag must short-circuit '
+            'the open decision BEFORE auto-expand / the global switch '
+            '(regression: `autoExpanded || (!collapseDictionaries && '
+            '!perDictCollapsed)` made the per-book toggle a no-op for the '
+            'leading rows x columns blocks)',
+      );
+      // The flag itself must still be sourced from the injected name list.
+      expect(
+        body.contains(
+            'const perDictCollapsed = (window.collapsedDictionaryNames || []).includes(dictName)'),
+        isTrue,
+        reason: '${mirror.key}: perDictCollapsed must read the injected '
+            'collapsedDictionaryNames list',
+      );
+    }
+  });
+
   test('preference clamps 0..6 with default 1 (backward compatible)', () {
     final String prefs = File(
       'lib/src/models/preferences_repository.dart',

--- a/hibiki/test/pages/popup_auto_expand_dictionaries_test.js
+++ b/hibiki/test/pages/popup_auto_expand_dictionaries_test.js
@@ -218,5 +218,54 @@ function isOpen(opts, dictName, dictIdx, totalDicts) {
     assert.strictEqual(isOpen(opts, 'D1', 1, 8), false, 'narrow: idx1 collapsed (1 fitted column)');
   }
 
+  // --- BUG-1264: an explicit per-dictionary collapse OUTRANKS auto-expand. ---
+  // 词典管理 的每行折叠开关是用户对该本书的显式决定；autoExpandRows 只是给
+  // 「没有显式决定」的词典用的批量默认值。让批量默认压过显式决定，等于把折叠
+  // 开关在前 rows×columns 本上变成空操作 —— 用户实际配置 3 行 × 3 列 时，前 9 本
+  // 无论点多少次折叠都照样展开。
+  {
+    const opts = {
+      collapseDictionaries: true,
+      autoExpandRows: 3,
+      dictColumns: 3,
+      collapsedDictionaryNames: ['Meikyou', 'Shougakukan'],
+    };
+    // Inside the auto-expand region (idx 0..8 at 3x3) — the flag must still win.
+    assert.strictEqual(isOpen(opts, 'Meikyou', 0, 9), false,
+      'per-dict collapsed beats auto-expand at idx0');
+    assert.strictEqual(isOpen(opts, 'Shougakukan', 4, 9), false,
+      'per-dict collapsed beats auto-expand mid-region');
+    // Books WITHOUT the flag keep the old auto-expand behaviour (no regression).
+    assert.strictEqual(isOpen(opts, 'Daijirin', 0, 9), true,
+      'unflagged dictionary still auto-expands at idx0');
+    assert.strictEqual(isOpen(opts, 'Daijirin', 8, 9), true,
+      'unflagged dictionary still auto-expands at the last expanded slot');
+    assert.strictEqual(isOpen(opts, 'Daijirin', 9, 12), false,
+      'unflagged dictionary past the region stays collapsed');
+  }
+  // The flag also wins when the GLOBAL collapse switch is off — that path used to
+  // be the only one honouring it, and must keep honouring it.
+  {
+    const opts = {
+      collapseDictionaries: false,
+      autoExpandRows: 1,
+      dictColumns: 1,
+      collapsedDictionaryNames: ['Meikyou'],
+    };
+    assert.strictEqual(isOpen(opts, 'Meikyou', 0, 4), false,
+      'global collapse off: per-dict flag still collapses');
+    assert.strictEqual(isOpen(opts, 'Meikyou', 3, 4), false,
+      'global collapse off: per-dict flag collapses outside the region too');
+    assert.strictEqual(isOpen(opts, 'Daijirin', 3, 4), true,
+      'global collapse off: unflagged dictionary stays open');
+  }
+  // rows=0 + no flags must stay collapsed (guards against the fix accidentally
+  // inverting into "anything unflagged opens").
+  {
+    const opts = { collapseDictionaries: true, autoExpandRows: 0, dictColumns: 3 };
+    assert.strictEqual(isOpen(opts, 'D0', 0, 9), false,
+      'rows=0 unflagged: still collapsed after the precedence fix');
+  }
+
   console.log('popup_auto_expand_dictionaries_test.js: all assertions passed');
 })();

--- a/hibiki/test/pages/popup_layout_width_columns_test.dart
+++ b/hibiki/test/pages/popup_layout_width_columns_test.dart
@@ -183,9 +183,15 @@ void main() {
       );
     });
 
+    // BUG-1271：「自动展开默认跟随列数」的**意图**没变（第一行铺满即展开），变的是
+    // 它在哪一层实现。这个偏好的单位在 TODO-845 之后是「行」，popup.js 的
+    // autoExpandCount 已经在乘有效列数了；Dart 侧再返回列数，就成了 cols 行 × cols 列
+    // = cols² 本（出厂列数 3 → 9 本，列数 4 → 16 本）。单位是行，「第一行铺满」只能是 1，
+    // 乘法交给 popup.js 那一处唯一的 rows × cols。故本守卫从「默认 = 列数」改为
+    // 「默认 = 1 行」，并显式禁止把 popupDictionaryColumns 塞回行数槽位。
     test(
         '源码守卫：popupDictionaryColumns 桌面 + 移动默认都传 3；'
-        '自动展开数默认跟随列数（= popupDictionaryColumns）', () {
+        '自动展开数默认 1 行（本数由 popup.js 的 rows × cols 跟随列数）', () {
       final String src =
           File('lib/src/models/app_model.dart').readAsStringSync();
       // 列数 getter 必须显式把桌面 + 移动默认都抬到 3（宽屏手机也能多列，窄屏视口收敛兜底）。
@@ -198,7 +204,7 @@ void main() {
           reason: '「最多列数」桌面默认必须是 3');
       expect(colBody.contains('mobileDefault: 3'), isTrue,
           reason: '「最多列数」移动默认也放宽到 3（宽屏手机多列、窄屏自动收回）');
-      // 自动展开数 getter：未显式设过时默认 = popupDictionaryColumns（跟随列数）。
+      // 自动展开 getter：未显式设过时默认 1 **行**（BUG-1271）。
       final int expAt = src.indexOf('int get popupAutoExpandDictionaries =>');
       expect(expAt, isNonNegative);
       final int expEnd = src.indexOf(';', expAt);
@@ -206,10 +212,14 @@ void main() {
       final String expBody = src.substring(expAt, expEnd);
       expect(expBody.contains('hasExplicitPopupAutoExpandDictionaries'), isTrue,
           reason: '显式设过一律遵从存储值');
-      expect(expBody.contains('popupDictionaryColumns'), isTrue,
-          reason: '自动展开数默认必须跟随列数（= popupDictionaryColumns）');
+      expect(RegExp(r':\s*1\s*$').hasMatch(expBody.trimRight()), isTrue,
+          reason: 'BUG-1271：单位是「行」，默认必须是 1 行（第一行铺满）；'
+              '本数跟随列数由 popup.js 的 autoExpandCount = rows × cols 负责');
+      expect(expBody.contains('popupDictionaryColumns'), isFalse,
+          reason: 'BUG-1271：把列数塞进行数槽位 → cols 行 × cols 列 = cols² 本，'
+              '出厂列数 3 时默认展开从意图的 3 本膨胀成 9 本');
       expect(expBody.contains('resolvePopupDesktopDefault'), isFalse,
-          reason: '自动展开数不再走平台 2/1 默认，改为跟随列数');
+          reason: '自动展开数不走平台 2/1 默认');
     });
   });
 }

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -2997,14 +2997,23 @@ function autoExpandCount(totalDicts) {
 // to cap the effective column count the same way masonry does. The popup
 // auto-expands the leading `autoExpandCount(totalDicts)` blocks even when
 // collapseDictionaries is on (default 1 row = the historical "only the first
-// dictionary expanded" behaviour at the default single column, where the leading
-// block opened regardless of its per-dictionary collapse flag).
+// dictionary expanded" behaviour at the default single column).
+//
+// BUG-1264: per-dictionary collapse OUTRANKS auto-expand. `collapsedDictionaryNames`
+// is an explicit per-book decision the user made in 词典管理 (one tap per row);
+// autoExpandRows is a bulk default for the books that carry no such decision.
+// Ranking the bulk default first made the per-book toggle a no-op for the leading
+// rows x columns blocks -- at the shipped 3 rows x 3 columns that silently ignored
+// the flag on the first NINE dictionaries, i.e. "I collapsed it and it still opens".
+// So the per-dict flag short-circuits both auto-expand and the global switch; a
+// non-collapsed block still follows the old rule (auto-expanded, or global collapse
+// off). Users can still open a collapsed block by hand -- <details> stays clickable.
 function createGlossarySection(dictName, contents, dictIdx, entryIdx, totalDicts) {
     const details = el('details', { className: 'glossary-group' });
     const perDictCollapsed = (window.collapsedDictionaryNames || []).includes(dictName);
     const autoExpandN = autoExpandCount(totalDicts);
     const autoExpanded = dictIdx < autoExpandN;
-    if (autoExpanded || (!window.collapseDictionaries && !perDictCollapsed)) {
+    if (!perDictCollapsed && (autoExpanded || !window.collapseDictionaries)) {
         details.open = true;
     }
 


### PR DESCRIPTION
用户报「词典管理里折叠了没用，还是会展开」。查下来是**两个独立成因叠在一起**才构成完整症状。

## BUG-1264 · 折叠开关被自动展开无条件覆盖

`popup.js` 的展开判定把**批量默认**排在**显式决定**之前：

```js
// 修复前
if (autoExpanded || (!window.collapseDictionaries && !perDictCollapsed)) {
```

`autoExpanded` 一为真就短路，`perDictCollapsed` 根本不参与判断 → 落在自动展开区里的词典，每本折叠开关是空操作。

改为显式决定短路：

```js
if (!perDictCollapsed && (autoExpanded || !window.collapseDictionaries)) {
```

标了折叠的永不自动展开（`<details>` 仍可手动点开）；没标折叠的行为与修复前完全一致。
`popup.js` 三镜像（app / 扩展 assets / 扩展 tools）同改；全局查词浮窗的 native WebView2 加载同一份 `assets/popup/popup.js`，一并覆盖。

## BUG-1271 · 自动展开区出厂默认大了 3 倍（9 本，不是 3 本）

上面那个「自动展开区」默认有多大？滑块读数是 3，实际是 **9 本**：

| 最多列数 | 意图（第一行铺满） | 修复前实际 |
|---|---|---|
| 3（出厂默认） | 3 本 | **9 本** |
| 4 | 4 本 | **16 本** |

单位换算漏改：用户 2026-07-14 拍板「自动展开跟随最多列数」时这个偏好的单位是**本数**，
`popupAutoExpandDictionaries` 未显式设过时返回 `popupDictionaryColumns` 是对的；
TODO-845 把单位改成**行数**、popup.js 侧 `autoExpandCount = rows × cols` 之后，Dart 侧默认值没跟着换算 → `cols` 行 × `cols` 列 = **cols² 本**。出厂列数 3 是 TODO-1357 抬上去的，于是 9 本。

TODO-845 当时的兼容论证「默认列数 1 时 rows × 1 === 旧本数，老用户零改变」，前提早已被 TODO-1357 推翻。

改为默认 **1 行** —— 「跟随列数」的意图不变，只是乘法交给 popup.js 那唯一一处 `rows × cols`。

**存量显式值不迁移**：旧值按「本数」写入却被当行数读，但偏好无写入时间戳，无法区分它写于单位变更前还是后，自动换算会误伤变更后设过的用户。滑块（查词 → 自动展开词典数）可见可自调。

## 测试

- 行为级（Node 真执行 `createGlossarySection`）：3×3 下标记本必须折叠、未标记本 idx0/idx8 仍展开 idx9 仍折叠、全局折叠关时标记同样生效、rows=0 未标记仍折叠。
- 源码级三镜像守卫：从 `createGlossarySection` **函数体内**取样，注释复述表达式无法假绿。
- `popup_layout_width_columns_test` 的默认值守卫原本断言「默认 = 列数」，**锁死的正是 BUG-1271**，改为断言默认 1 行 —— 契约变更，非回归。
- **变异实测 3 轮**：① 判定改回旧写法 → per-dict 断言红；② 改成 `!perDictCollapsed && false` → 未标记词典展开断言红；③ 默认改回 `popupDictionaryColumns` → BUG-1271 守卫红。均恢复后绿。

## 验证

- `flutter analyze`：No issues found
- 定向测试 7 个 popup 相关文件：**103 tests, All tests passed**（exit 0）

未 bump `pubspec.yaml`：本 PR 不触发发布，版本号交由 integration owner 落地时统一处理，避免并发 PR 各自 bump 在 rebase 时互相吞掉。

BUG 记录：`docs/bugs/BUG-1264-popup-perdict-collapse-outranked.md`、`docs/bugs/BUG-1271-popup-autoexpand-rows-unit-mismatch.md`

https://claude.ai/code/session_011cxpjYk1T4QzcsppoVGKeA