### PR TITLE
fix(video): 关闭「尊重字幕自带样式」后 OP 字幕变黑（BUG-1264）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1201 条。点号进各自文件。
+> 共 1202 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1264](bugs/BUG-1264-subtitle-plain-mode-inline-color.md) | ✅ | ✅ | 纯字幕模式下行内 \c 主色穿透导致 OP 字幕变黑 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/bugs/BUG-1264-subtitle-plain-mode-inline-color.md
+++ b/docs/bugs/BUG-1264-subtitle-plain-mode-inline-color.md
@@ -1,0 +1,56 @@
+## BUG-1264 · 纯字幕模式下行内 \c 主色穿透导致 OP 字幕变黑
+
+- **报告**：2026-07-31（用户：关掉「尊重字幕自带样式」后，OP 字幕变黑了，附截图）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:1847`（修复前）
+  —— `_styleForGrapheme` 里行内 `\c`/`\1c` 主色 **未按 `respectAssStyle` 门控**：
+
+  ```dart
+  Color? spanColor = span.colorArgb != null ? Color(span.colorArgb!) : null;
+  ```
+
+  它是纯字幕模式（`respectAssStyle` 关，BUG-915 定义的 asbplayer 语义）里**最后一条漏网的
+  颜色通道**。同族属性早已全部门控：
+
+  | 通道 | 门控位置 |
+  |---|---|
+  | `\3c` 描边色 | `_resolveStroke` `video_subtitle_overlay.dart:1678` |
+  | `\1a` 填充透明度 | `_styleForGrapheme` `:1846` |
+  | cueStyle 主色（V4+ Styles PrimaryColour） | `_styleForGrapheme` `:1767` |
+  | `\t` 颜色动画 | `_applyDynamicFill` `:1896` |
+  | 卡拉 OK SecondaryColour | `_applyDynamicFill` `:1896` |
+  | **行内 `\c` / `\1c` 主色** | **无（本 bug）** |
+
+  **失败链条**（OP 歌词是多层卡拉 OK ASS，一句拆成多条同时事件）：
+
+  1. `respectAssStyle` 关 → 走纯字幕模式，`_buildSubtitleLayer` `:772` 用
+     `_uniqueByText(cues)` 按文本去重，**只保留发现顺序第一条**（cue 文件序号最小者，
+     通常是最底的描边/光晕层）。
+  2. 该层的 `\c` 是黑色（它在原设计里靠上面的文字层盖住，自己只提供描边/辉光）。
+  3. 本该给它兜底的白描边 `\3c` 与透明填充 `\1a` **都被正确门控掉了**，唯独黑色 `\c`
+     穿透生效。
+  4. → 整句渲染成裸黑字。普通对白无行内 `\c`，所以只有 OP 黑——与用户观察一致。
+
+  同时这与开关自身的契约冲突：i18n `video_setting_subtitle_respect_ass_hint` 明写
+  「关闭则**一律使用你的外观设置**」。旧行为被 `video_subtitle_overlay_markup_test.dart`
+  以 "Inline \c red is a legacy span style -> applies even when off" 固化，但该测试标题
+  写的却是 `OFF: unified style wins`，自相矛盾。
+
+- **[x] ① 已修复** — `video_subtitle_overlay.dart` `_styleForGrapheme`：行内 `\c`/`\1c` 与
+  兄弟通道同源门控 `(respect && span.colorArgb != null)`，关时回落 `baseColor`（用户
+  `textColor`）。同步改写方法文档：纯字幕模式 = 颜色语义整体归零，只保留 `\i \b \u \s`
+  文本语义与历史 `\fs` 裸像素字号。提交见分支
+  `worktree-bug-subtitle-plain-mode-inline-color`。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_text_color_test.dart`
+  新增 group「BUG-1264 纯字幕模式颜色语义归零（行内 \c 不穿透）」三条 widget 测试：
+  ① OFF + 行内 `\c` 黑 → 填充恒用户 textColor；② **OFF + 多层卡拉 OK 同句去重（原始失败
+  路径）** → 任何一层拷贝都不得带进 ASS 黑色；③ ON + 行内 `\c` → ASS 主色照常优先（防
+  反向破坏尊重路径）。并改正 `video_subtitle_overlay_markup_test.dart` 里固化旧行为的
+  断言（契约变更，非回归）。
+  **变异实测**：临时回退门控后，上述 ①②与 markup_test 共 3 条立刻转红
+  （`FLUTTER TEST VERDICT: FAILED`），确认守卫不是假绿。
+- **备注**：
+  - 相邻隐患（本次未改，未获用户确认前不扩大范围）：同一段 `:1862` 的行内 `\fs` 在
+    `respectAssStyle` 关时仍按**裸像素**穿透（ASS 的 fs 是 PlayRes 空间像素，直接当 Flutter
+    逻辑像素用，且与用户字号滑块完全脱钩）。按「关闭则一律使用你的外观设置」的契约，它
+    同属应归零的外观通道；用户本次只报颜色，故留档待定。
+  - 未做真机复验（本轮只有 widget 层证据 + 用户截图）。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -1736,8 +1736,11 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 投影由 [_buildSubtitleChar] 挂到本样式上；尊重 .ass 时描边由其底层 stroke [Text] 单独
   /// 承载、.ass \shad 硬投影由本方法的 `shadows` 提供（BUG-323 / TODO-569 / TODO-1105）。
   ///
-  /// respectAssStyle 关：只应用行内 `\i \b \u \s \c \fs` 这些历史就支持的 span 样式，字体 /
-  /// 字号 / 颜色的基线恒为用户统一样式，与历史像素级一致。
+  /// respectAssStyle 关 = **纯字幕模式**（BUG-915/1264）：**颜色语义整体归零**——行内 `\c`
+  /// / `\1c` 主色与 `\3c` 描边色（[_resolveStroke]）、`\1a` 填充透明度、cueStyle 主色、`\t`
+  /// 颜色动画、卡拉 OK SecondaryColour（[_applyDynamicFill]）同源门控，一律回落用户
+  /// textColor。只保留行内 `\i \b \u \s` 这些**文本语义**与历史 `\fs` 裸像素字号；字体 /
+  /// 字号 / 颜色的基线恒为用户统一样式。
   /// respectAssStyle 开：字体名 / 主色 / 字号 / 粗斜下删线优先取 .ass 值（行内 span >
   /// [SubtitleCueStyle] cue 默认 > 用户统一样式，TODO-1105）。字体缺字时仍挂
   /// [_subtitleCjkFallback] 兜底。
@@ -1844,7 +1847,15 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     // 基线色）。多层卡拉 OK 光晕层 `\1a&HFF&` 抹透明填充、只留模糊描边成辉光；描边层
     // 由 [_buildSubtitleChar] 单独构建，不受本透明度影响（ASS \1a 仅主填充语义）。
     final double? fillOp = respect ? span.fillOpacity : null;
-    Color? spanColor = span.colorArgb != null ? Color(span.colorArgb!) : null;
+    // 行内 `\c`/`\1c` 主色**必须与 respect 同源门控**（BUG-1264）：纯字幕模式下这是最后一条
+    // 穿透的颜色通道——兄弟属性（\3c 描边色、\1a 填充透明度、cueStyle 主色、\t 颜色动画、
+    // 卡拉 OK SecondaryColour）早已全部门控，唯独它按「历史 span 样式」放行。多层卡拉 OK
+    // 的 OP 歌词被 [_uniqueByText] 去重后只留发现顺序第一条（通常是最底的描边/光晕层），
+    // 那层的 `\c` 是黑色、而给它兜底的白描边 \3c 与透明填充 \1a 又都被正确门控掉 → 整句
+    // 渲染成裸黑字（用户报「关掉尊重字幕自带样式后 OP 字幕变黑」）。开关文案明示「关闭则
+    // 一律使用你的外观设置」，故这里归零回落 baseColor（用户 textColor）。
+    Color? spanColor =
+        (respect && span.colorArgb != null) ? Color(span.colorArgb!) : null;
     if (fillOp != null) {
       spanColor = (spanColor ?? baseColor).withValues(alpha: fillOp);
     }

--- a/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
+++ b/hibiki/test/media/video/video_subtitle_overlay_markup_test.dart
@@ -120,8 +120,11 @@ void main() {
     Text fillOff = tester
         .widgetList<Text>(find.text('A'))
         .firstWhere((Text t) => t.style?.foreground == null);
-    // Inline \c red is a legacy span style -> applies even when off.
-    expect(fillOff.style?.color, const Color(0xFFFF0000));
+    // BUG-1264 契约变更：inline \c 曾作为「legacy span style」在 OFF 时照样生效——那是纯
+    // 字幕模式里最后一条穿透的颜色通道（\3c/\1a/cueStyle 主色/\t/卡拉 OK 副色早已全部
+    // 门控），多层卡拉 OK 的 OP 歌词因此被渲染成黑字。OFF 现在一律用用户 textColor。
+    expect(fillOff.style?.color, const Color(0xFF112233),
+        reason: 'OFF = 纯字幕模式：行内 \\c 不得穿透，填充色恒为用户 textColor');
     // \fn is gated by respectAssStyle -> off keeps unified font family.
     expect(fillOff.style?.fontFamily, 'UnifiedFont');
 

--- a/hibiki/test/media/video/video_subtitle_text_color_test.dart
+++ b/hibiki/test/media/video/video_subtitle_text_color_test.dart
@@ -40,6 +40,29 @@ AudioCue _markupCue(String text, SubtitleMarkup markup) {
   return _plainCue(text)..markup = markup;
 }
 
+/// 真 ASS 覆盖标签（`{\c&H..&}` 等）经解析器产出的 cue——与 markup_test 同款造法，避免
+/// 手搓 [SubtitleSpan] 漏掉解析器真实行为。[index] 区分同句多层拷贝的事件。
+AudioCue _assCue(String raw, {int index = 0}) {
+  final SubtitleMarkup m = parseSubtitleMarkup(raw);
+  return AudioCue()
+    ..bookKey = 'b'
+    ..chapterHref = 'c'
+    ..sentenceIndex = index
+    ..textFragmentId = '[data-cue-id="$index"]'
+    ..text = m.plainText
+    ..markup = m
+    ..startMs = 0
+    ..endMs = 5000
+    ..audioFileIndex = 0;
+}
+
+VideoPlayerController _stubWithCues(List<AudioCue> cues) {
+  final VideoPlayerController c = VideoPlayerController();
+  c.setCues(cues);
+  c.debugUpdateCueForPosition(cues.first.startMs + 1);
+  return c;
+}
+
 /// 读某字符 stroke+fill 双层里的**填充层**（`foreground == null`）；描边层是
 /// `foreground != null`（[buildSubtitleStrokePaint] 的画笔）。与 markup_test 同款读法。
 Text _fillText(WidgetTester tester, String char) {
@@ -94,6 +117,78 @@ void main() {
     await tester.pump();
     expect(_fillText(tester, 'A').style?.color, userColor,
         reason: 'respect 开但 ASS 无主色时应回退用户文字颜色（不冲突、不吞掉用户设置）');
+  });
+
+  /// BUG-1264（用户报「OP 字幕关闭尊重字幕自带样式变黑了」）：纯字幕模式（respectAssStyle
+  /// 关）下行内 `\c`/`\1c` 主色曾以「历史 span 样式」之名不受门控一路穿透——它是这个模式里
+  /// 最后一条漏网的颜色通道（`\3c` 描边色、`\1a` 填充透明度、cueStyle 主色、`\t` 颜色动画、
+  /// 卡拉 OK SecondaryColour 早已全部按 respect 门控）。多层卡拉 OK 的 OP 歌词把一句拆成多
+  /// 条同文本事件，纯字幕模式按文本去重只留发现顺序第一条＝最底的描边/光晕层，那层 `\c`
+  /// 是黑色，而本该给它兜底的白描边 `\3c` 与透明填充 `\1a` 又都被正确门控掉 → 整句裸黑字。
+  group('BUG-1264 纯字幕模式颜色语义归零（行内 \\c 不穿透）', () {
+    testWidgets('OFF: 行内 \\c 黑色不生效，填充恒为用户 textColor',
+        (WidgetTester tester) async {
+      const Color userColor = Color(0xFF00E5FF);
+      final VideoPlayerController c = _stubWithCue(_assCue(r'{\c&H000000&}歌'));
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: VideoSubtitleOverlay(
+            controller: c,
+            textColor: userColor,
+            respectAssStyle: false,
+          ),
+        ),
+      ));
+      await tester.pump();
+      expect(_fillText(tester, '歌').style?.color, userColor,
+          reason: '开关文案明示「关闭则一律使用你的外观设置」，行内 \\c 不得穿透');
+    });
+
+    testWidgets('OFF: 多层卡拉 OK 同句去重后不落到底层黑色（原始失败路径）',
+        (WidgetTester tester) async {
+      const Color userColor = Color(0xFF00E5FF);
+      // OP 歌词的真实形态：同一句拆成多条同时事件——底层描边/光晕层（黑填充 + 白描边）在
+      // 前、文字层在后。纯字幕模式按文本去重只保留第一条，正是黑填充那条。
+      final VideoPlayerController c = _stubWithCues(<AudioCue>[
+        _assCue(r'{\c&H000000&\3c&HFFFFFF&\bord4}歌', index: 0),
+        _assCue(r'{\c&HFFFFFF&}歌', index: 1),
+      ]);
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: VideoSubtitleOverlay(
+            controller: c,
+            textColor: userColor,
+            respectAssStyle: false,
+          ),
+        ),
+      ));
+      await tester.pump();
+      final Iterable<Text> fills = tester
+          .widgetList<Text>(find.text('歌'))
+          .where((Text t) => t.style?.foreground == null);
+      expect(fills, isNotEmpty, reason: '去重后仍应渲染该句');
+      for (final Text t in fills) {
+        expect(t.style?.color, userColor, reason: '任何一层拷贝都不得把 ASS 黑色主色带进纯字幕模式');
+      }
+    });
+
+    testWidgets('ON: 行内 \\c 照常生效（尊重语义未被误伤）', (WidgetTester tester) async {
+      const Color userColor = Color(0xFF00E5FF);
+      final VideoPlayerController c = _stubWithCue(_assCue(r'{\c&H0000FF&}歌'));
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: VideoSubtitleOverlay(
+            controller: c,
+            textColor: userColor,
+            respectAssStyle: true,
+          ),
+        ),
+      ));
+      await tester.pump();
+      // ASS 是 &HBBGGRR：&H0000FF& = 红。
+      expect(_fillText(tester, '歌').style?.color, const Color(0xFFFF0000),
+          reason: '开关打开时 ASS 主色必须优先，修复不得反向破坏尊重路径');
+    });
   });
 
   test(


### PR DESCRIPTION
## 用户报告

关掉「尊重字幕自带样式」后，OP 字幕变成黑色（附截图：`る事はなかれと` 渲染成纯黑）。

## 根因

`hibiki/lib/src/media/video/video_subtitle_overlay.dart` `_styleForGrapheme` 里行内 `\c`/`\1c` **主色未按 `respectAssStyle` 门控**：

```dart
Color? spanColor = span.colorArgb != null ? Color(span.colorArgb!) : null;
```

它是纯字幕模式（`respectAssStyle` 关，BUG-915 定义的 asbplayer 语义）里**最后一条漏网的颜色通道**——同族属性早已全部门控：`\3c` 描边色（`_resolveStroke`）、`\1a` 填充透明度、cueStyle 主色（V4+ Styles PrimaryColour）、`\t` 颜色动画、卡拉 OK SecondaryColour（`_applyDynamicFill`）。

失败链条（OP 歌词是多层卡拉 OK ASS，一句拆成多条同时事件）：

1. 关开关 → 纯字幕模式用 `_uniqueByText(cues)` 按文本去重，**只保留发现顺序第一条**（通常是最底的描边/光晕层）；
2. 那层的 `\c` 是黑色（原设计里靠上面的文字层盖住，自己只提供描边/辉光）；
3. 本该给它兜底的白描边 `\3c` 与透明填充 `\1a` **都被正确门控掉了**，唯独黑色 `\c` 穿透；
4. → 整句裸黑字。普通对白无行内 `\c`，所以只有 OP 黑，与用户观察一致。

同时这与开关自身契约冲突：i18n `video_setting_subtitle_respect_ass_hint` 明写「关闭则**一律使用你的外观设置**」。旧行为被 `video_subtitle_overlay_markup_test.dart` 以 "Inline \c red is a legacy span style -> applies even when off" 固化，而该测试标题写的却是 `OFF: unified style wins`，自相矛盾。

## 修复

行内主色与兄弟通道同源门控，关时回落 `baseColor`（用户 `textColor`）：

```dart
Color? spanColor =
    (respect && span.colorArgb != null) ? Color(span.colorArgb!) : null;
```

并改写方法文档：纯字幕模式 = 颜色语义整体归零，只保留 `\i \b \u \s` 文本语义与历史 `\fs` 裸像素字号。

## 测试

`video_subtitle_text_color_test.dart` 新增 group「BUG-1264 纯字幕模式颜色语义归零」三条 widget 守卫：

1. OFF + 行内 `\c` 黑 → 填充恒用户 textColor；
2. **OFF + 多层卡拉 OK 同句去重（原始失败路径）** → 任何一层拷贝都不得带进 ASS 黑色；
3. ON + 行内 `\c` → ASS 主色照常优先（防反向破坏尊重路径）。

并改正 `markup_test` 中固化旧行为的断言（**契约变更，非回归**）。

**变异实测**：临时回退门控后，①②与 markup_test 共 3 条立刻转红（`FLUTTER TEST VERDICT: FAILED`），确认守卫不是假绿。

## 验证

- `flutter analyze`（含 test 目录）：`No issues found`
- `dart run tool/flutter_test_failures.dart --no-pub test/media/video/`：`FLUTTER TEST VERDICT: PASSED - 1888 tests ran`
- 未做真机复验（本轮只有 widget 层证据 + 用户截图）

## 留档：相邻隐患（本次未改）

同一段的行内 `\fs` 在 `respectAssStyle` 关时仍按**裸像素**穿透（ASS 的 fs 是 PlayRes 空间像素，直接当 Flutter 逻辑像素用，且与用户字号滑块完全脱钩）。按同一句契约它同属应归零的外观通道；用户本次只报颜色，故未扩大范围，记在 `docs/bugs/BUG-1264-*.md` 备注里待定。

https://claude.ai/code/session_012oearWVF6fEamtNXeb9B8W
