### PR TITLE
feat(video): 主/副字幕垂直位置分开调节

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 47022 (2766 per locale)
+/// Strings: 47039 (2767 per locale)
 ///
-/// Built on 2026-07-29 at 08:08 UTC
+/// Built on 2026-07-31 at 05:49 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3718,6 +3718,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get selection_web_search => 'Search the web';
   String get selection_web_search_unavailable => 'No app can search the web.';
   String get selection_share_failed => 'Could not open the share sheet.';
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -10050,6 +10052,9 @@ class _StringsAr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -16450,6 +16455,9 @@ class _StringsDe extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -22866,6 +22874,9 @@ class _StringsEs extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -29293,6 +29304,9 @@ class _StringsFr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -35649,6 +35663,9 @@ class _StringsId extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -42051,6 +42068,9 @@ class _StringsIt extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -48270,6 +48290,9 @@ class _StringsJa extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -54491,6 +54514,9 @@ class _StringsKo extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -60873,6 +60899,9 @@ class _StringsNl extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -67268,6 +67297,9 @@ class _StringsPtBr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -73647,6 +73679,9 @@ class _StringsRu extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -79974,6 +80009,9 @@ class _StringsTh extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -86333,6 +86371,9 @@ class _StringsTr extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -92677,6 +92718,9 @@ class _StringsVi extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 // Path: <root>
@@ -98572,6 +98616,8 @@ class _StringsZhCn extends _StringsEn {
   String get selection_web_search_unavailable => '没有可用的网页搜索应用。';
   @override
   String get selection_share_failed => '无法打开分享面板。';
+  @override
+  String get video_setting_subtitle_position_secondary => '副字幕垂直位置';
 }
 
 // Path: <root>
@@ -104712,6 +104758,9 @@ class _StringsZhHk extends _StringsEn {
   String get selection_web_search_unavailable => 'No app can search the web.';
   @override
   String get selection_share_failed => 'Could not open the share sheet.';
+  @override
+  String get video_setting_subtitle_position_secondary =>
+      'Secondary subtitle position';
 }
 
 /// Flat map(s) containing all translations.
@@ -110379,6 +110428,8 @@ extension on _StringsEn {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -116044,6 +116095,8 @@ extension on _StringsAr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -121730,6 +121783,8 @@ extension on _StringsDe {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -127415,6 +127470,8 @@ extension on _StringsEs {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -133106,6 +133163,8 @@ extension on _StringsFr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -138779,6 +138838,8 @@ extension on _StringsId {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -144467,6 +144528,8 @@ extension on _StringsIt {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -150117,6 +150180,8 @@ extension on _StringsJa {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -155771,6 +155836,8 @@ extension on _StringsKo {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -161452,6 +161519,8 @@ extension on _StringsNl {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -167130,6 +167199,8 @@ extension on _StringsPtBr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -172813,6 +172884,8 @@ extension on _StringsRu {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -178480,6 +178553,8 @@ extension on _StringsTh {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -184156,6 +184231,8 @@ extension on _StringsTr {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -189827,6 +189904,8 @@ extension on _StringsVi {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }
@@ -195451,6 +195530,8 @@ extension on _StringsZhCn {
         return '没有可用的网页搜索应用。';
       case 'selection_share_failed':
         return '无法打开分享面板。';
+      case 'video_setting_subtitle_position_secondary':
+        return '副字幕垂直位置';
       default:
         return null;
     }
@@ -201096,6 +201177,8 @@ extension on _StringsZhHk {
         return 'No app can search the web.';
       case 'selection_share_failed':
         return 'Could not open the share sheet.';
+      case 'video_setting_subtitle_position_secondary':
+        return 'Secondary subtitle position';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "「$name」是漫画文件，将走漫画导入流程，而不是书籍导入流程。",
   "selection_web_search": "网页搜索",
   "selection_web_search_unavailable": "没有可用的网页搜索应用。",
-  "selection_share_failed": "无法打开分享面板。"
+  "selection_share_failed": "无法打开分享面板。",
+  "video_setting_subtitle_position_secondary": "副字幕垂直位置"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2764,5 +2764,6 @@
   "manga_import_detected_message": "\"$name\" is a manga file, so it will go through the manga importer instead of the book importer.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
-  "selection_share_failed": "Could not open the share sheet."
+  "selection_share_failed": "Could not open the share sheet.",
+  "video_setting_subtitle_position_secondary": "Secondary subtitle position"
 }

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -171,6 +171,7 @@ class VideoSubtitleOverlay extends StatefulWidget {
     this.backgroundColor,
     this.backgroundOpacity = 0,
     this.bottomPadding = 75,
+    this.secondaryBottomPadding,
     this.controlsVisible,
     this.controlsBottomReserve = kVideoControlsBottomReserve,
     this.controlsTopReserve = kVideoControlsTopReserve,
@@ -260,6 +261,14 @@ class VideoSubtitleOverlay extends StatefulWidget {
   /// [controlsVisible] 在控制条可见时对 [controlsBottomReserve] 取下限（max），此处只是
   /// 用户手选的基线位置。
   final double bottomPadding;
+
+  /// 副字幕层的**独立**位置基线（[VideoSubtitleStyle.secondaryBottomPadding]）。
+  ///
+  /// null = 跟随 [bottomPadding]（历史行为）。非 null 时副字幕层的锚点边距改用本值：
+  /// 强制置顶的纯 SRT 副字幕用它当**顶距**，带自带底部锚点的副字幕用它当底距。主字幕层
+  /// 恒用 [bottomPadding]，两层不再互相牵动（此前共用一个字段，调主字幕位置会把副字幕
+  /// 一起挪走）。控制条 / 顶栏避让照旧对各自基线取下限（max），语义不变。
+  final double? secondaryBottomPadding;
 
   /// media_kit 控制条当前是否可见（TODO-129/161）。非 null 时驱动字幕动态避让：可见时
   /// 字幕底部 padding 取 `max([bottomPadding], [controlsBottomReserve])`（字幕底缘骑到
@@ -768,7 +777,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
         // （KFX/多层特效把一句拆成多条同时事件，样式被统一后只剩裸文本拷贝，同位叠印成
         // 乱字——正是「样式不尊重、位置却尊重」的半吊子语义的病根；文本互异的堆叠分行）。
         final List<(String, List<AudioCue>)> groups = widget.respectAssStyle
-            ? _groupMainCuesByPosition(cues)
+            ? _groupMainCuesByPosition(cues, isSecondary: isSecondary)
             : <(String, List<AudioCue>)>[('plain', _uniqueByText(cues))];
 
         final List<(String, Widget)> positioned = <(String, Widget)>[
@@ -845,11 +854,15 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 顺序。同组的 cue 共享一个位置、竖排堆叠；不同组各自独立定位，从而顶部歌词与底部对白
   /// 不再被裹挟到同一处。返回每组的 (分组键, cue 列表)（组内顺序即活动集顺序；分组键给
   /// [_syncGroupSlots] 作跨帧槽位状态的身份，TODO-1372）。
-  List<(String, List<AudioCue>)> _groupMainCuesByPosition(List<AudioCue> cues) {
+  /// [isSecondary]：本次分组属于哪一层——底部基线折叠判据要拿**该层**的用户基线
+  /// （[_layerBaseline]）当阈值，否则副字幕的分组会钉在主字幕基线上、与它自己的渲染基线
+  /// 脱节。分组键只在层内使用（调用方已加 `m|` / `s|` 前缀），两层同形键不会互串。
+  List<(String, List<AudioCue>)> _groupMainCuesByPosition(List<AudioCue> cues,
+      {required bool isSecondary}) {
     final Map<String, List<AudioCue>> byKey = <String, List<AudioCue>>{};
     final List<(String, List<AudioCue>)> order = <(String, List<AudioCue>)>[];
     for (final AudioCue cue in cues) {
-      final String key = _positionKey(cue.markup);
+      final String key = _positionKey(cue.markup, isSecondary: isSecondary);
       final List<AudioCue>? existing = byKey[key];
       if (existing != null) {
         existing.add(cue);
@@ -866,7 +879,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     // 一个堆叠组（竖排分行）；同文本的多层拷贝（卡拉OK特效层，BUG-833，通常 \pos / 顶部锚点，
     // 不落底部基线桶）不合并，仍各自成组同位叠画出特效。
     final List<(String, List<AudioCue>)> grouped =
-        _mergeBottomBaselineGroups(order);
+        _mergeBottomBaselineGroups(order, isSecondary: isSecondary);
     // 组内按 MarginV 升序稳定排序：折进同一基线桶的底部双语（JP MarginV=4 + CH MarginV=30）
     // 竖排堆叠时，MarginV 小的贴锚点（底部锚组 slot0 在底）、大的在上，复现 libass「MarginV
     // 越大离底越远」的相对次序，不再依赖字幕文件里 JP/CH 的书写先后（本 BUG 的次序保证）。
@@ -901,8 +914,10 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 桶内出现重复文本（同句多层拷贝=卡拉OK特效层，应同位叠画不拆行）则整桶不合并，保持
   /// [_positionKey] 原分组（各层同位叠画，BUG-833 不回归）。非底部 / 带显式位置的组原样保留。
   List<(String, List<AudioCue>)> _mergeBottomBaselineGroups(
-    List<(String, List<AudioCue>)> order,
-  ) {
+    List<(String, List<AudioCue>)> order, {
+    required bool isSecondary,
+  }) {
+    final double userBase = _layerBaseline(isSecondary);
     bool isBottomBaselineFolded(AudioCue cue) {
       final SubtitleMarkup? m = cue.markup;
       if (m == null) return true; // 纯 SRT / 无 markup：底部居中、无 MarginV → 折叠
@@ -912,7 +927,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       if (v != SubtitleVAlign.bottom) return false;
       final double? mv = m.cueStyle?.marginV;
       if (mv == null || mv <= 0) return true;
-      return mv <= widget.bottomPadding;
+      return mv <= userBase;
     }
 
     // 按水平锚点分桶收集底部基线折叠组的 order 下标（组内 cue 同键、同折叠态，取代表判断）。
@@ -987,7 +1002,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 使它们同组、竖排堆叠（libass 的碰撞下推同效果），不再叠印。真正超出基线（标题
   /// MarginV=400 等）才保留各自 authored 高度（TODO-1341 行为不变）。顶部/中部锚点无 max
   /// 夹逻辑（[_paddingFor] 直接用 scaledMarginV），保持按原始 MarginV 分键。
-  String _positionKey(SubtitleMarkup? markup) {
+  String _positionKey(SubtitleMarkup? markup, {required bool isSecondary}) {
     final SubtitlePos? pf = markup?.posFraction;
     final SubtitleAnchor? a = markup?.anchor;
     final int av = (a?.vertical ?? SubtitleVAlign.bottom).index;
@@ -1026,7 +1041,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       // 碰撞下推同效果），只有真正的高位标题（大 MarginV，如 400）才独立占 authored 高度
       // （TODO-1341 不回归）。以原始值入键（而非缩放 round），组身份也不随显示尺寸漂移，
       // 跨帧槽位状态（[_syncGroupSlots]）不因窗口缩放churn。
-      mv = mvRaw <= widget.bottomPadding ? -1 : mvRaw.round();
+      mv = mvRaw <= _layerBaseline(isSecondary) ? -1 : mvRaw.round();
     } else {
       mv = mvRaw.round();
     }
@@ -1186,7 +1201,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     return Align(
       alignment: _alignFor(anchor),
       child: _anchoredPadded(
-          anchor, content, scaledMarginV, scaledMarginL, scaledMarginR),
+          anchor, content, scaledMarginV, scaledMarginL, scaledMarginR,
+          isSecondary: isSecondary),
     );
   }
 
@@ -2184,6 +2200,15 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     return Alignment(x, y);
   }
 
+  /// 该层的**用户位置基线**：主字幕恒 [VideoSubtitleOverlay.bottomPadding]，副字幕在用户
+  /// 单独调过（[VideoSubtitleOverlay.secondaryBottomPadding] 非 null）时用自己的值、否则
+  /// 跟随主字幕（历史行为）。位置计算全部经此取值，不再有第二处直读 `widget.bottomPadding`
+  /// 的层无关分支——这正是「调主字幕位置把副字幕一起挪走」的根因。
+  double _layerBaseline(bool isSecondary) =>
+      isSecondary && widget.secondaryBottomPadding != null
+          ? widget.secondaryBottomPadding!
+          : widget.bottomPadding;
+
   /// 顶部锚点用顶部 padding、中部不加、底部按 [controlsVisible] 取避让下限。
   ///
   /// 底部锚点避让是「字幕底缘 ≥ 控制条顶缘」的约束，故控制条可见时底部 padding 取
@@ -2195,14 +2220,19 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 在控制条可见时真正被抬升盖过被抬高的移动进度条。用户手选高位（> reserve）时 max 取其
   /// 值、不被避让改写；手选低位（< reserve）时控制条可见仍抬到 reserve 躲进度条、隐藏落回
   /// 原值。避让只对底部锚点生效——控制条在底部，顶部 / 中部字幕不会被进度条遮挡。
+  ///
+  /// [isSecondary] 决定取哪条用户基线（[_layerBaseline]）：主字幕恒 [bottomPadding]，
+  /// 副字幕在用户单独调过后用 [secondaryBottomPadding]。避让/MarginV 的 max 语义两层同构。
   EdgeInsets _paddingFor(SubtitleAnchor? a, bool controlsVisible,
-      double? scaledMarginV, double? scaledMarginL, double? scaledMarginR) {
+      double? scaledMarginV, double? scaledMarginL, double? scaledMarginR,
+      {required bool isSecondary}) {
     final SubtitleVAlign v = a?.vertical ?? SubtitleVAlign.bottom;
-    // 底部锚点基线：用户 bottomPadding 与 ASS 缩放 MarginV 取**较大值**（单调抬升——绝不低于
+    // 本层的用户基线：主字幕恒 bottomPadding，副字幕在用户单独调过时用自己的基线。
+    final double userBase = _layerBaseline(isSecondary);
+    // 底部锚点基线：用户基线与 ASS 缩放 MarginV 取**较大值**（单调抬升——绝不低于
     // 用户基线，保 TODO-129/161/238 控制条避让不回归；作者用大 MarginV 要求更高时才抬）。
-    final double bottomBase = scaledMarginV == null
-        ? widget.bottomPadding
-        : math.max(widget.bottomPadding, scaledMarginV);
+    final double bottomBase =
+        scaledMarginV == null ? userBase : math.max(userBase, scaledMarginV);
     // ASS MarginL/MarginR 水平边距：Align 内侧 padding 恰是 ASS 排版盒语义——居中对齐时
     // 盒宽 = 文本 + L + R、Align 居中该盒 → 文本中心右移 (L-R)/2；左/右对齐时文本起点 /
     // 终点分别落在 L / 宽-R。无边距恒 0（srt/vtt 像素级不变）。
@@ -2225,7 +2255,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
           left: left,
           right: right,
           top: () {
-            final double topBase = scaledMarginV ?? widget.bottomPadding;
+            final double topBase = scaledMarginV ?? userBase;
             return controlsVisible
                 ? math.max(topBase, widget.controlsTopReserve)
                 : topBase;
@@ -2243,12 +2273,14 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
   /// 见 [_paddingFor]）。取下限而非加法，故基线 < 控制条高时不会把字幕顶飞、手选高位也
   /// 不被改写（同一字段无特例分支）。
   Widget _anchoredPadded(SubtitleAnchor? anchor, Widget child,
-      double? scaledMarginV, double? scaledMarginL, double? scaledMarginR) {
+      double? scaledMarginV, double? scaledMarginL, double? scaledMarginR,
+      {required bool isSecondary}) {
     final ValueListenable<bool>? visible = widget.controlsVisible;
     if (visible == null) {
       return Padding(
           padding: _paddingFor(
-              anchor, false, scaledMarginV, scaledMarginL, scaledMarginR),
+              anchor, false, scaledMarginV, scaledMarginL, scaledMarginR,
+              isSecondary: isSecondary),
           child: child);
     }
     return ValueListenableBuilder<bool>(
@@ -2259,7 +2291,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
           duration: const Duration(milliseconds: 200),
           curve: Curves.easeOut,
           padding: _paddingFor(anchor, controlsVisible, scaledMarginV,
-              scaledMarginL, scaledMarginR),
+              scaledMarginL, scaledMarginR,
+              isSecondary: isSecondary),
           child: padded,
         );
       },

--- a/hibiki/lib/src/media/video/video_subtitle_style.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_style.dart
@@ -222,6 +222,7 @@ class VideoSubtitleStyle {
     required this.backgroundColor,
     required this.backgroundOpacity,
     required this.bottomPadding,
+    this.secondaryBottomPadding,
   });
 
   static const int defaultFontWeight = 700;
@@ -282,6 +283,17 @@ class VideoSubtitleStyle {
   final double backgroundOpacity;
   final double bottomPadding;
 
+  /// 副字幕层的**独立**位置基线（距其锚点边的距离；纯 SRT 副字幕强制置顶时即顶距）。
+  ///
+  /// null = 跟随 [bottomPadding]（历史行为、旧数据零迁移）：此前主副两层共用同一个
+  /// [bottomPadding] 字段——主字幕拿它当底距、副字幕（强制置顶）拿它当顶距，调一个
+  /// 必然把另一个也拽走，用户没法把主字幕压低同时把副字幕抬高。分成两条基线后，
+  /// [VideoSubtitleOverlay] 按层取值（见 `_layerBaseline`），两层各自独立。
+  ///
+  /// 只有用户真正拖过「副字幕垂直位置」才写具体值；没拖过恒为 null、逐字沿用主字幕
+  /// 位置（Never break userspace：老用户外观像素级不变）。
+  final double? secondaryBottomPadding;
+
   VideoSubtitleStyle copyWith({
     double? fontSize,
     Color? textColor,
@@ -291,6 +303,9 @@ class VideoSubtitleStyle {
     Color? backgroundColor,
     double? backgroundOpacity,
     double? bottomPadding,
+    // null = 不改（保持当前值，含「仍跟随主字幕」的 null 态）。设置面板拖动副字幕位置
+    // 时才传具体值；无「改回跟随」的入口，故不需要 backgroundColor 那样的 reset 标志。
+    double? secondaryBottomPadding,
     // [backgroundColor] 与 null 语义冲突：`null` 既是「不改」又是「显式清空跟随默认黑」。
     // 用显式 [resetBackgroundColor] 标志区分——true 时把 [backgroundColor] 强制清成 null
     // （回到 [kDefaultSubtitleBackgroundColor] 固定默认），供设置面板「默认（黑）」选项用。
@@ -307,6 +322,8 @@ class VideoSubtitleStyle {
           : (backgroundColor ?? this.backgroundColor),
       backgroundOpacity: backgroundOpacity ?? this.backgroundOpacity,
       bottomPadding: bottomPadding ?? this.bottomPadding,
+      secondaryBottomPadding:
+          secondaryBottomPadding ?? this.secondaryBottomPadding,
     );
   }
 
@@ -341,6 +358,8 @@ class VideoSubtitleStyle {
         'backgroundColor': s.backgroundColor?.toARGB32(),
         'backgroundOpacity': s.backgroundOpacity,
         'bottomPadding': s.bottomPadding,
+        // null（从未单独调过副字幕位置）也照写：decode 侧 null → 继续跟随主字幕。
+        'secondaryBottomPadding': s.secondaryBottomPadding,
       });
 
   static VideoSubtitleStyle decode(String? json) {
@@ -400,6 +419,13 @@ class VideoSubtitleStyle {
         ).clamp(0.0, 1.0),
         bottomPadding:
             num2d(d['bottomPadding'], defaults.bottomPadding).clamp(0, 400),
+        // 缺字段（旧数据）/ 非数字 → null = 副字幕继续跟随主字幕位置（旧外观不变）。
+        secondaryBottomPadding: d['secondaryBottomPadding'] is num
+            ? (d['secondaryBottomPadding'] as num)
+                .toDouble()
+                .clamp(0, 400)
+                .toDouble()
+            : null,
       );
     } catch (_) {
       return defaults;

--- a/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/layout.part.dart
@@ -387,6 +387,11 @@ extension _VideoLayout on _VideoHibikiPageState {
                           ),
                           backgroundOpacity: _subtitleStyle.backgroundOpacity,
                           bottomPadding: _subtitleStyle.bottomPadding,
+                          // 副字幕独立位置：null = 用户没单独调过，overlay 内回落到
+                          // bottomPadding（历史行为）。非 null 时副字幕层用自己的基线，
+                          // 主字幕位置滑杆不再把副字幕一起挪走。
+                          secondaryBottomPadding:
+                              _subtitleStyle.secondaryBottomPadding,
                           // 控制条可见性驱动动态避让（TODO-129）：进度条出现时字幕底缘对
                           // 进度条上缘取下限（max，非加法——BUG-226 防顶飞）、隐藏落回。全屏
                           // 复用同一 builder + ValueNotifier，故窗口与全屏都跟随（BUG-120 同源）。

--- a/hibiki/lib/src/settings/settings_schema_video.dart
+++ b/hibiki/lib/src/settings/settings_schema_video.dart
@@ -856,6 +856,41 @@ SettingsDestination buildVideoDestination() {
               );
             },
           ),
+          // 副字幕垂直位置：与上面的主字幕位置**同量纲、各自独立**（此前两层共用
+          // `bottomPadding` 一个字段——主字幕拿它当底距、置顶的副字幕拿它当顶距，调一个
+          // 必然把另一个也拽走）。value 在用户没单独调过时回落到主字幕位置（显示成
+          // 「当前跟随主字幕」的那个值），一拖即写入 secondaryBottomPadding、从此解耦。
+          SettingsSliderItem(
+            id: 'video.subtitle.position_secondary',
+            title: t.video_setting_subtitle_position_secondary,
+            icon: Icons.height_outlined,
+            video: VideoPlacement(
+              group: VideoGroup.subtitle,
+              order: 145,
+              section: t.video_setting_subtitle_appearance,
+            ),
+            min: 0,
+            max: 240,
+            divisions: 24,
+            value: (SettingsContext settingsContext) {
+              final VideoSubtitleStyle s =
+                  currentVideoSubtitleStyle(settingsContext);
+              return (s.secondaryBottomPadding ?? s.bottomPadding)
+                  .clamp(0, 240);
+            },
+            onChanged: (SettingsContext settingsContext, double v) {
+              previewVideoSubtitleStyle(
+                settingsContext,
+                (VideoSubtitleStyle s) => s.copyWith(secondaryBottomPadding: v),
+              );
+            },
+            onChangeEnd: (SettingsContext settingsContext, double v) async {
+              await commitVideoSubtitleStyle(
+                settingsContext,
+                (VideoSubtitleStyle s) => s.copyWith(secondaryBottomPadding: v),
+              );
+            },
+          ),
           // ── Jimaku（在线字幕源）───────────────────────────────────────────
           // 此前 API key 只能在三个对话框（视频字幕 / 番剧下载 / 批量匹配）里就地填，
           // 设置页压根没有入口；下载对话框那个还只在 key 为空时才显示，key 填错了

--- a/hibiki/test/media/video/video_subtitle_secondary_position_test.dart
+++ b/hibiki/test/media/video/video_subtitle_secondary_position_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki/src/media/video/video_subtitle_style.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+/// 主字幕与副字幕的垂直位置**各自独立**（用户诉求：「主字幕和副字幕能支持分开高度调节」）。
+///
+/// 根因：此前两层共用 [VideoSubtitleStyle.bottomPadding] 一个字段——主字幕拿它当底距、
+/// 强制置顶的副字幕拿它当**顶距**（`_paddingFor` 的顶部分支 `scaledMarginV ?? bottomPadding`），
+/// 所以拖「垂直位置」滑杆必然把两层一起挪走。修复：新增
+/// [VideoSubtitleStyle.secondaryBottomPadding]（null = 跟随主字幕，旧数据零迁移），
+/// overlay 按层取基线（`_layerBaseline`）。
+///
+/// 分三层验证：
+///  ① overlay 真几何——两层同屏时各自吃各自的基线，改主字幕基线不动副字幕。
+///  ② 未设置副字幕基线（null）时逐字沿用主字幕基线（历史外观不回归）。
+///  ③ 持久化——新字段 round-trip，旧 JSON（无该字段）解码成 null。
+AudioCue _cue(String text, int startMs, int endMs) => AudioCue()
+  ..bookKey = 'b'
+  ..chapterHref = 'ch'
+  ..sentenceIndex = 0
+  ..textFragmentId = ''
+  ..text = text
+  ..startMs = startMs
+  ..endMs = endMs
+  ..audioFileIndex = 0;
+
+Future<void> _pumpOverlay(
+  WidgetTester tester,
+  VideoPlayerController c, {
+  required double bottomPadding,
+  double? secondaryBottomPadding,
+}) async {
+  await tester.pumpWidget(MaterialApp(
+    home: Scaffold(
+      body: VideoSubtitleOverlay(
+        controller: c,
+        bottomPadding: bottomPadding,
+        secondaryBottomPadding: secondaryBottomPadding,
+      ),
+    ),
+  ));
+  await tester.pump();
+}
+
+/// 该层字幕盒的**外层** padding：主字幕层看 bottom、副字幕层（强制置顶）看 top。
+/// controlsVisible 为 null（本测试不挂控制条）时 `_anchoredPadded` 走静态 [Padding]，
+/// 故从字幕文本向上找祖先 [Padding]，取该方向上最大的一个（内层字符盒 padding 恒 0/小）。
+double _outerPadding(
+  WidgetTester tester,
+  String text, {
+  required bool top,
+}) {
+  final Iterable<Padding> pads = tester.widgetList<Padding>(
+    find.ancestor(of: find.text(text).first, matching: find.byType(Padding)),
+  );
+  return pads.map((Padding p) {
+    final EdgeInsets e = p.padding.resolve(TextDirection.ltr);
+    return top ? e.top : e.bottom;
+  }).fold<double>(0, (double a, double b) => b > a ? b : a);
+}
+
+void main() {
+  group('① 主/副字幕位置各自独立（overlay 真几何）', () {
+    testWidgets('两层同屏：主字幕吃 bottomPadding，副字幕吃 secondaryBottomPadding',
+        (WidgetTester tester) async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 0, 6000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('副', 0, 6000)]);
+      c.debugUpdateCueForPosition(1000);
+
+      await _pumpOverlay(tester, c,
+          bottomPadding: 20, secondaryBottomPadding: 160);
+
+      expect(_outerPadding(tester, '主', top: false), 20,
+          reason: '主字幕底距 = 主字幕基线');
+      expect(_outerPadding(tester, '副', top: true), 160,
+          reason: '副字幕顶距 = 副字幕自己的基线，不再复用主字幕的 20');
+    });
+
+    testWidgets('改主字幕基线不牵动副字幕（本诉求的直接守卫）', (WidgetTester tester) async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 0, 6000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('副', 0, 6000)]);
+      c.debugUpdateCueForPosition(1000);
+
+      await _pumpOverlay(tester, c,
+          bottomPadding: 20, secondaryBottomPadding: 160);
+      expect(_outerPadding(tester, '副', top: true), 160);
+
+      // 只把主字幕位置拖高：副字幕顶距必须一动不动（回归即两层重新耦合）。
+      await _pumpOverlay(tester, c,
+          bottomPadding: 200, secondaryBottomPadding: 160);
+      expect(_outerPadding(tester, '主', top: false), 200,
+          reason: '主字幕跟随自己的新基线');
+      expect(_outerPadding(tester, '副', top: true), 160,
+          reason: '副字幕不被主字幕位置牵动');
+    });
+
+    testWidgets('改副字幕基线不牵动主字幕（反向守卫）', (WidgetTester tester) async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 0, 6000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('副', 0, 6000)]);
+      c.debugUpdateCueForPosition(1000);
+
+      await _pumpOverlay(tester, c,
+          bottomPadding: 30, secondaryBottomPadding: 40);
+      await _pumpOverlay(tester, c,
+          bottomPadding: 30, secondaryBottomPadding: 220);
+
+      expect(_outerPadding(tester, '主', top: false), 30,
+          reason: '主字幕底距不被副字幕位置牵动');
+      expect(_outerPadding(tester, '副', top: true), 220);
+    });
+  });
+
+  group('② null = 跟随主字幕（历史外观不回归）', () {
+    testWidgets('secondaryBottomPadding 未设置时副字幕顶距 = 主字幕基线',
+        (WidgetTester tester) async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue('主', 0, 6000)]);
+      c.setSecondaryCues(<AudioCue>[_cue('副', 0, 6000)]);
+      c.debugUpdateCueForPosition(1000);
+
+      await _pumpOverlay(tester, c, bottomPadding: 90);
+
+      expect(_outerPadding(tester, '主', top: false), 90);
+      expect(_outerPadding(tester, '副', top: true), 90,
+          reason: '老用户（没单独调过副字幕）外观与历史像素级一致');
+    });
+  });
+
+  group('③ 持久化', () {
+    test('新字段 round-trip', () {
+      const VideoSubtitleStyle s = VideoSubtitleStyle(
+        fontSize: 36,
+        textColor: Color(0xFFFFFFFF),
+        fontWeight: null,
+        shadowColor: Color(0xE6000000),
+        shadowThickness: null,
+        backgroundColor: null,
+        backgroundOpacity: 0,
+        bottomPadding: 75,
+        secondaryBottomPadding: 130,
+      );
+      final VideoSubtitleStyle back =
+          VideoSubtitleStyle.decode(VideoSubtitleStyle.encode(s));
+      expect(back.secondaryBottomPadding, 130);
+      expect(back.bottomPadding, 75);
+    });
+
+    test('旧 JSON（无该字段）解码成 null = 继续跟随主字幕', () {
+      final VideoSubtitleStyle old = VideoSubtitleStyle.decode(
+        '{"_v":2,"fontSize":36,"backgroundOpacity":0,"bottomPadding":110}',
+      );
+      expect(old.bottomPadding, 110);
+      expect(old.secondaryBottomPadding, isNull,
+          reason: '缺字段必须回落到「跟随主字幕」，不能凭空钉一个默认值');
+    });
+
+    test('越界值被夹进 [0,400]', () {
+      final VideoSubtitleStyle s = VideoSubtitleStyle.decode(
+        '{"_v":2,"bottomPadding":75,"secondaryBottomPadding":9999}',
+      );
+      expect(s.secondaryBottomPadding, 400);
+    });
+
+    test('copyWith 只改副字幕基线时不动主字幕', () {
+      final VideoSubtitleStyle s =
+          VideoSubtitleStyle.defaults.copyWith(secondaryBottomPadding: 150);
+      expect(s.secondaryBottomPadding, 150);
+      expect(s.bottomPadding, VideoSubtitleStyle.defaults.bottomPadding);
+    });
+  });
+}


### PR DESCRIPTION
## 诉求
「主字幕和副字幕能支持分开高度调节」。

## 根因
主副两层共用 `VideoSubtitleStyle.bottomPadding` **一个**字段：主字幕拿它当底距，强制置顶的副字幕拿它当**顶距**（`video_subtitle_overlay.dart` 的 `_paddingFor` 顶部分支 `scaledMarginV ?? bottomPadding`）。所以拖「垂直位置」滑杆一定把两层一起挪走——没有第二条基线可调。

## 修法
- `VideoSubtitleStyle` 增 `secondaryBottomPadding`（`double?`，**null = 跟随主字幕**）；encode/decode round-trip，旧数据缺字段解成 null，老用户外观像素级不变。
- `VideoSubtitleOverlay` 增同名参数 + `_layerBaseline(isSecondary)` 作**唯一取值点**；`_paddingFor` / `_anchoredPadded` / `_positionKey` / `_mergeBottomBaselineGroups` 全部按层取基线，消掉层无关直读 `bottomPadding` 的分支（不是加特例 if，是把「基线」这个概念补成每层一份）。
- 设置页字幕外观区新增「副字幕垂直位置」滑杆（`video.subtitle.position_secondary`，order 145，紧邻主字幕位置），未单独调过时显示主字幕当前值、一拖即解耦。
- i18n 走 `tool/i18n_sync.dart` 新增 key（17 语言）+ `dart run slang` 重新生成。

控制条 / 顶栏避让语义不变：仍对**各自**基线取 `max` 下限（非加法），BUG-226 / BUG-1069 不回归。

## 验证
- 新增 `hibiki/test/media/video/video_subtitle_secondary_position_test.dart`（8 项）：两层同屏各吃各的基线、改主不动副、改副不动主、null 跟随、持久化 round-trip / 越界夹取。
- **变异实测**：把 `_layerBaseline` 退回恒 `bottomPadding`，3 项立即变红（断言真的咬住根因），随后复原。
- `flutter analyze` 全量 `No issues found!`。
- 相邻定向套件（`test/media/video` 全量 + 字幕 widget + 设置 schema 守卫 + push-up 守卫 + i18n）：`FLUTTER TEST VERDICT: PASSED - 1942 tests ran`。
- 未 bump `pubspec.yaml` 的 `+build`（留给集成方按发布序列统一处理）。

https://claude.ai/code/session_011bfJ6darFgYFqPRDtT6Vg5