### PR TITLE
fix(torrent): 内置引擎速度≈0（upload_mode 语义反转）+ 任务行速度/流量 + qb 连接失败可自查

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1241 条。点号进各自文件。
+> 共 1244 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1295](bugs/BUG-1295-qb-test-connection-undiagnosable.md) | ✅ | ✅ | qB测试连接失败无法自查且本机免密被登录门卡死 |
+| [BUG-1294](bugs/BUG-1294-download-tasks-no-speed-traffic.md) | ✅ | ✅ | 下载任务行无速度与流量显示 |
+| [BUG-1293](bugs/BUG-1293-embedded-upload-mode-kills-download.md) | ✅ | ✅ | 内置引擎默认关上传误用upload_mode掐死下载 |
 | [BUG-1292](bugs/BUG-1292-magpie-bundled-only.md) | ✅ | ✅ | Magpie 内置后仍显示并保留下载路径 |
 | [BUG-1291](bugs/BUG-1291-destructive-confirm-checkbox-truncated.md) | ✅ | ✅ | 销毁确认弹窗勾选行文案被单行省略号截断 |
 | [BUG-1290](bugs/BUG-1290-bangumi-dashboard-history.md) | ✅ | ✅ | Bangumi 首页卡把映射误当观看历史且不列待手动关联条目 |

--- a/docs/bugs/BUG-1293-embedded-upload-mode-kills-download.md
+++ b/docs/bugs/BUG-1293-embedded-upload-mode-kills-download.md
@@ -1,0 +1,38 @@
+## BUG-1293 · 内置引擎默认关上传误用upload_mode掐死下载
+- **报告**：2026-07-31（用户：内置引擎下载速度几乎为 0，进度不涨）
+- **真实性**：✅ 真 bug。链路：默认配置 `uploadEnabled = false`
+  （`hibiki/lib/src/media/torrent/anime_download_config.dart:20`）→
+  `shouldAllowUpload` 对所有种子返回 false
+  （`hibiki/lib/src/media/torrent/torrent_upload_policy.dart:42`）→
+  `EmbeddedTorrentHost.sweepUploadPolicy` 每 20s tick 下发
+  `setUploadMode(enabled: false)`（`embedded_torrent_host.dart` 旧 `:447-451`）→
+  native `ht_set_upload_mode` 给种子置 `lt::torrent_flags::upload_mode`
+  （`native/hibiki_torrent/hibiki_torrent_ffi.cpp` 旧 `:546-552`）。
+  **libtorrent 的 `upload_mode` 语义是「不再发出任何 piece 请求」= 只上不下、
+  停止下载**（官方文档；引擎在磁盘写失败时用它停下载保做种），与
+  `hibiki_torrent.h` 旧 `:74-78` 注释宣称的「只下不上」正好相反。于是默认
+  配置的用户所有种子在 add 后一个 tick 内被打上该 flag → 下载速率归零、
+  进度不涨（auto_managed 偶发短暂退出该模式，表现为「几乎为 0」偶尔蹦一下）。
+  该 flag 还会随 resume data 持久化，重启复发。
+- **[x] ① 已修复** — 停用 upload_mode 表达「关上传」，换正确原语：
+  - native：`ht_set_upload_mode` 改为 enabled=1 只清 flag（治愈残留）、0 为
+    no-op 恒成功；新增 `ht_set_unchoke_slots`（会话级 0 槽位 = 停上传
+    payload，下载不受影响）与 `ht_pause_torrent`（清 auto_managed + pause，
+    做种停止）；`add_with_params` / `ht_load_resume_dir` 加载时清 upload_mode
+    残留（治愈已升级用户的 resume）。
+  - Dart：`EmbeddedTorrentSession.setUnchokeSlots` / `pauseTorrent` /
+    `supportsUploadControl`（探符号，老 DLL 整体降级为不动作，绝不回退
+    upload_mode）；`EmbeddedTorrentHost.sweepUploadPolicy` 重写——总开关走
+    会话级 unchoke（开启时还原 maxUploadSlots/默认），做种超时/分享率达标
+    走 per-torrent pause，**绝不 pause 未完成种子**；`applySessionSettings`
+    后失效缓存重新裁决（native 会用 maxUploadSlots 覆盖 unchoke 槽位）。
+- **[x] ② 已加自动化测试** —
+  - 无 DLL 必跑守卫：`hibiki/test/media/torrent/upload_policy_dispatch_guard_test.dart`
+    （fromLookup 假绑定断言 C 入参：关上传绝不下发 upload_mode=0、unchoke
+    清零、只 pause 已完成种子、老 DLL 降级不动作）。
+  - DLL 行为闭环：`packages/hibiki_torrent/test/upload_off_download_test.dart`
+    （本地 rig：unchoke=0 钉死后下载仍从 0 推进到完成——旧语义下必超时红）。
+- **备注**：`ht_apply_session_settings` 的 `max_upload_slots` 与本修复共用
+  unchoke_slots_limit，顺序由 AppModel 保证（applySessionSettings 后紧跟
+  setUploadPolicy）。墙内 swarm 下反吸血默认封禁迅雷系 peer、内置引擎无代理
+  入口，是速度偏低的次要结构性因素，不在本 bug 范围。

--- a/docs/bugs/BUG-1294-download-tasks-no-speed-traffic.md
+++ b/docs/bugs/BUG-1294-download-tasks-no-speed-traffic.md
@@ -1,0 +1,28 @@
+## BUG-1294 · 下载任务行无速度与流量显示
+- **报告**：2026-07-31（用户：内置引擎「没有进度、流量显示」）
+- **真实性**：✅ 真 bug（缺失链断在抽象层）。native `ht_list_torrents` 一直导出
+  `down_rate/up_rate/uploaded/downloaded/num_peers`
+  （`native/hibiki_torrent/hibiki_torrent_ffi.cpp:659-711`），Dart FFI
+  `HtTorrentStatus` 也全解析（`packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart:231-235`），
+  但 `EmbeddedTorrentBackend._toSnapshot`（`embedded_torrent_backend.dart` 旧
+  `:154-164`）投影到 `TorrentSnapshot` 时整体丢弃——`TorrentSnapshot`
+  （`torrent_backend.dart` 旧 `:7-16`）压根没有这些字段；qb 侧
+  `parseQbTorrentInfos` 同样没解析 `dlspeed/upspeed`。服务层只发布
+  `Map<String, double>` 百分比、20s 一 tick，UI 任务行只有一个进度环 +
+  百分比，速度/流量从未进过 UI。
+- **[x] ① 已修复** —
+  - `TorrentSnapshot` 补 `downRateBps/upRateBps/downloadedBytes/uploadedBytes/numPeers`
+    （缺省 0，向后兼容）；内置/qb 两后端各自填充。
+  - `AnimeDownloadService` 新增 `downloadStats`（planId → `DownloadTaskStats`，
+    值相等性去抖）；轮询周期自适应：内置引擎 + 有活跃下载时 3s
+    （`resolvePollInterval` 纯函数；外接 qb 保持 20s——每 tick 都是全新
+    WebUI 登录，提频会放大 qb 认证失败计数，见 BUG-1295）。
+  - 任务行订阅 `downloadStats`，显示 `37% · ↓ 1.0 MB/s · ↑ 2.0 KB/s · 4.0 KB`
+    （`HibikiByteFormat`，纯数字/符号，零新增 i18n key）。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/torrent/anime_download_service_progress_test.dart`：stats
+    发布/清空与 progress 键集合一致；`resolvePollInterval` 决策表。
+  - `hibiki/test/torrent/qbittorrent_client_test.dart`：qb 速度/流量/peer
+    字段解析 + 缺省安全 0。
+- **备注**：外接 qb 此前同样没有速度显示（用户可开 qb 自带 WebUI 兜底），
+  本修复两后端同时受益。

--- a/docs/bugs/BUG-1295-qb-test-connection-undiagnosable.md
+++ b/docs/bugs/BUG-1295-qb-test-connection-undiagnosable.md
@@ -1,0 +1,31 @@
+## BUG-1295 · qB测试连接失败无法自查且本机免密被登录门卡死
+- **报告**：2026-07-31（用户截图：`http://127.0.0.1:8080/` 测试连接报
+  「连接失败，请检查地址与账号密码」）
+- **真实性**：✅ 真 bug（两层）。
+  1. **单 bool 折叠**：设置页只判 `version == null`
+     （`hibiki/lib/src/pages/implementations/torrent_settings_section.dart`
+     旧 `:90-92`），而网络不通/账密错（qb 返 200 `Fails.`）/qb 登录失败 5 次
+     封 IP（403 banned）/无 SID cookie 全部被
+     `qbittorrent_client.dart` 的 `catch (_)`（旧 `:125-127`、`:276-278`）吞成
+     同一个 null → 同一句泛化文案，用户无从自查。
+  2. **免密被登录门卡死**：qb 开「对本地主机的客户端跳过身份验证」时业务
+     接口匿名可用，但 `POST /auth/login` 仍校验账密；客户端 `_request` 强制
+     先登录（旧 `:267`），账密不对/留空 → 直接判失败——明明 API 可用。
+     与已修的 BUG-1016（WebDAV 空账密匿名）同类缺陷。反复点测试连接还会
+     触发 qb 失败计数封 IP（默认 5 次封 1 小时），之后填对账密也一直失败。
+- **[x] ① 已修复** —
+  - `QBittorrentClient.lastFailure` 结构化记录失败原因（网络异常原文/
+    `login rejected`/`IP banned…` 单独识别 403 banned/无 SID/HTTP 状态）；
+  - 登录失败后匿名探测 `/app/version`，通了缓存匿名态免登录直连
+    （`_authenticate`；不再反复撞登录门放大封禁计数）；
+  - `QbTorrentBackend.lastProbeFailure` 透传；设置页新 i18n key
+    `download_test_connection_failed_reason`（`连接失败：$message`）显示
+    具体原因，拿不到原因时回退旧文案。
+- **[x] ② 已加自动化测试** — `hibiki/test/torrent/qbittorrent_client_test.dart`：
+  匿名回退（login `Fails.` + 版本接口 200 → 成功且不带 Cookie、匿名态缓存
+  只撞一次登录门）；banned 403 原因识别；网络异常原因透出；两路都不通时
+  保留登录失败原因。
+- **备注**：已排除方向——URL 尾斜杠已归一化（有单测）、Referer/CSRF 已正确、
+  qb 请求走裸 `http.Client()` 不吃系统代理（127.0.0.1:34151 不劫持）。地址框
+  缺 scheme 校验（填 `127.0.0.1:8080` 会因无 scheme 异常）现在会以异常原文
+  透出，可自查；未做自动补 `http://`。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 48569 (2857 per locale)
+/// Strings: 48586 (2858 per locale)
 ///
-/// Built on 2026-07-31 at 15:33 UTC
+/// Built on 2026-07-31 at 16:20 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3855,6 +3855,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -10416,6 +10418,9 @@ class _StringsAr extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -17044,6 +17049,9 @@ class _StringsDe extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -23688,6 +23696,9 @@ class _StringsEs extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -30343,6 +30354,9 @@ class _StringsFr extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -36927,6 +36941,9 @@ class _StringsId extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -43557,6 +43574,9 @@ class _StringsIt extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -50004,6 +50024,9 @@ class _StringsJa extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -56453,6 +56476,9 @@ class _StringsKo extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -63063,6 +63089,9 @@ class _StringsNl extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -69686,6 +69715,9 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -76293,6 +76325,9 @@ class _StringsRu extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -82848,6 +82883,9 @@ class _StringsTh extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -89435,6 +89473,9 @@ class _StringsTr extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -96007,6 +96048,9 @@ class _StringsVi extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 // Path: <root>
@@ -102117,6 +102161,9 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       '内置 Magpie 组件已损坏或校验失败。请重新安装或更新 Hibiki。';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      '连接失败：${message}';
 }
 
 // Path: <root>
@@ -108485,6 +108532,9 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get game_upscaling_error_bundle_invalid =>
       'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+  @override
+  String download_test_connection_failed_reason({required Object message}) =>
+      'Connection failed: ${message}';
 }
 
 /// Flat map(s) containing all translations.
@@ -114347,6 +114397,8 @@ extension on _StringsEn {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -120207,6 +120259,8 @@ extension on _StringsAr {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -126089,6 +126143,8 @@ extension on _StringsDe {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -131970,6 +132026,8 @@ extension on _StringsEs {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -137857,6 +137915,8 @@ extension on _StringsFr {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -143726,6 +143786,8 @@ extension on _StringsId {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -149609,6 +149671,8 @@ extension on _StringsIt {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -155454,6 +155518,8 @@ extension on _StringsJa {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -161303,6 +161369,8 @@ extension on _StringsKo {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -167180,6 +167248,8 @@ extension on _StringsNl {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -173054,6 +173124,8 @@ extension on _StringsPtBr {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -178933,6 +179005,8 @@ extension on _StringsRu {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -184795,6 +184869,8 @@ extension on _StringsTh {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -190666,6 +190742,8 @@ extension on _StringsTr {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -196533,6 +196611,8 @@ extension on _StringsVi {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }
@@ -202348,6 +202428,8 @@ extension on _StringsZhCn {
         return 'Hibiki 安装包不完整：缺少内置 Magpie 组件。请重新安装或更新 Hibiki。';
       case 'game_upscaling_error_bundle_invalid':
         return '内置 Magpie 组件已损坏或校验失败。请重新安装或更新 Hibiki。';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => '连接失败：${message}';
       default:
         return null;
     }
@@ -208188,6 +208270,8 @@ extension on _StringsZhHk {
         return 'Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.';
       case 'game_upscaling_error_bundle_invalid':
         return 'The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.';
+      case 'download_test_connection_failed_reason':
+        return ({required Object message}) => 'Connection failed: ${message}';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "仅在保留多段释义的卡片上可见；只有一段释义的卡片不会显示。",
   "anki_lapis_visual_field_dictionary_name_note": "Hibiki 生成的卡片把词性标签和词典名放在同一个标签里，两者无法分开设置样式。",
   "game_upscaling_error_bundle_missing": "Hibiki 安装包不完整：缺少内置 Magpie 组件。请重新安装或更新 Hibiki。",
-  "game_upscaling_error_bundle_invalid": "内置 Magpie 组件已损坏或校验失败。请重新安装或更新 Hibiki。"
+  "game_upscaling_error_bundle_invalid": "内置 Magpie 组件已损坏或校验失败。请重新安装或更新 Hibiki。",
+  "download_test_connection_failed_reason": "连接失败：$message"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2855,5 +2855,6 @@
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
   "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
   "game_upscaling_error_bundle_missing": "Hibiki installation is incomplete: the bundled Magpie component is missing. Reinstall or update Hibiki.",
-  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki."
+  "game_upscaling_error_bundle_invalid": "The bundled Magpie component is corrupted or did not pass verification. Reinstall or update Hibiki.",
+  "download_test_connection_failed_reason": "Connection failed: $message"
 }

--- a/hibiki/lib/src/media/torrent/anime_download_service.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_service.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/foundation.dart' show ValueNotifier, mapEquals;
+import 'package:flutter/foundation.dart'
+    show ValueNotifier, immutable, mapEquals;
 import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
@@ -19,6 +20,66 @@ class AnimeDownloadImportOutcome {
   const AnimeDownloadImportOutcome({required this.collectionId});
 
   final int collectionId;
+}
+
+/// 单个下载中任务的实时观测值（BUG-1294：进度之外补上速度/流量/peer 数）。
+///
+/// 值语义相等（==/hashCode），供「内容没变不通知」的发布路径用。
+@immutable
+class DownloadTaskStats {
+  const DownloadTaskStats({
+    required this.progress,
+    required this.downRateBps,
+    required this.upRateBps,
+    required this.downloadedBytes,
+    required this.uploadedBytes,
+    required this.numPeers,
+  });
+
+  /// 从后端快照投影。
+  factory DownloadTaskStats.fromSnapshot(TorrentSnapshot info) {
+    return DownloadTaskStats(
+      progress: info.progress.clamp(0.0, 1.0).toDouble(),
+      downRateBps: info.downRateBps,
+      upRateBps: info.upRateBps,
+      downloadedBytes: info.downloadedBytes,
+      uploadedBytes: info.uploadedBytes,
+      numPeers: info.numPeers,
+    );
+  }
+
+  /// 下载进度 0.0 ~ 1.0。
+  final double progress;
+
+  /// 实时下载速率（字节/秒）。
+  final int downRateBps;
+
+  /// 实时上传速率（字节/秒）。
+  final int upRateBps;
+
+  /// 累计下载字节。
+  final int downloadedBytes;
+
+  /// 累计上传字节。
+  final int uploadedBytes;
+
+  /// 当前连接的 peer 数。
+  final int numPeers;
+
+  @override
+  bool operator ==(Object other) {
+    return other is DownloadTaskStats &&
+        other.progress == progress &&
+        other.downRateBps == downRateBps &&
+        other.upRateBps == upRateBps &&
+        other.downloadedBytes == downloadedBytes &&
+        other.uploadedBytes == uploadedBytes &&
+        other.numPeers == numPeers;
+  }
+
+  @override
+  int get hashCode => Object.hash(progress, downRateBps, upRateBps,
+      downloadedBytes, uploadedBytes, numPeers);
 }
 
 /// 把种子文件列表解析为视频绝对路径列表。纯函数。
@@ -210,24 +271,84 @@ class AnimeDownloadService {
   final ValueNotifier<Map<String, double>> downloadProgress =
       ValueNotifier<Map<String, double>>(const <String, double>{});
 
-  /// 发布新一轮进度快照；内容没变不通知（避免每 20s 无谓重建任务行）。
-  void _publishProgress(Map<String, double> next) {
+  /// 下载中计划的实时观测值（planId → 速度/流量/peer 数；BUG-1294）。
+  /// 键集合与 [downloadProgress] 一致，UI 任务行用它渲染速度与流量。
+  final ValueNotifier<Map<String, DownloadTaskStats>> downloadStats =
+      ValueNotifier<Map<String, DownloadTaskStats>>(
+          const <String, DownloadTaskStats>{});
+
+  /// 发布新一轮进度快照；内容没变不通知（避免无谓重建任务行）。
+  void _publishProgress(
+    Map<String, double> next, [
+    Map<String, DownloadTaskStats> stats = const <String, DownloadTaskStats>{},
+  ]) {
+    if (!mapEquals(downloadStats.value, stats)) {
+      downloadStats.value = Map<String, DownloadTaskStats>.unmodifiable(stats);
+    }
     if (mapEquals(downloadProgress.value, next)) return;
     downloadProgress.value = Map<String, double>.unmodifiable(next);
   }
 
-  /// 启动周期轮询（先立即 tick 一次，再每 [interval] 一次）。
+  /// 有活跃下载（内置引擎）时的加密轮询间隔。20s 的常规 tick 对「速度/进度在
+  /// 动」的观感来说等于静止（BUG-1294）；内置引擎的 listTorrents 是本进程内
+  /// 同步 FFI，3s 一次开销可忽略。外接 qb 保持 [interval]：每 tick 都是一次
+  /// 全新 WebUI 登录，提频会放大认证失败计数（qb 默认 5 次封 IP 一小时）。
+  static const Duration activeInterval = Duration(seconds: 3);
+
+  /// 当前定时器的周期（诊断/测试用；未启动为 null）。
+  Duration? get currentPollInterval => _currentPeriod;
+  Duration? _currentPeriod;
+
+  /// 启动周期轮询（先立即 tick 一次，再按周期轮询）。
   void start() {
     if (_timer != null) return;
-    _timer = Timer.periodic(interval, (_) => unawaited(tick()));
+    _startTimer(interval);
     unawaited(tick());
+  }
+
+  void _startTimer(Duration period) {
+    _currentPeriod = period;
+    _timer = Timer.periodic(period, (_) => unawaited(tick()));
   }
 
   /// 停止周期轮询（进行中的 tick 自然收尾，不打断）。
   void stop() {
     _timer?.cancel();
     _timer = null;
+    _currentPeriod = null;
   }
+
+  /// 轮询周期决策（纯函数，可无定时器单测）：只有「内置引擎 + 有活跃下载」
+  /// 才提频到 [active]；外接 qb 恒用 [idle]（见 [activeInterval] 注释）。
+  static Duration resolvePollInterval({
+    required QbConnectionConfig? config,
+    required bool hasActiveDownloads,
+    required bool isDesktop,
+    required Duration idle,
+    Duration active = activeInterval,
+  }) {
+    final bool embedded = config != null &&
+        config.resolveBackend(isDesktop: isDesktop) ==
+            QbConnectionConfig.backendEmbedded;
+    return embedded && hasActiveDownloads ? active : idle;
+  }
+
+  /// tick 后按 [resolvePollInterval] 重排定时器周期。
+  void _reschedule() {
+    if (_timer == null) return; // 未 start / 已 stop：不自启。
+    final Duration want = resolvePollInterval(
+      config: _configProvider(),
+      hasActiveDownloads: downloadProgress.value.isNotEmpty,
+      isDesktop: _isDesktop(),
+      idle: interval,
+    );
+    if (want == _currentPeriod) return;
+    _timer?.cancel();
+    _startTimer(want);
+  }
+
+  static bool _isDesktop() =>
+      Platform.isWindows || Platform.isLinux || Platform.isMacOS;
 
   /// 轮询一次（可单独调用；测试用）。内置防重入：上一 tick 未完成则跳过。
   /// 整体容错：网络/文件系统异常静默跳过，下轮再试。
@@ -241,6 +362,7 @@ class AnimeDownloadService {
     } finally {
       _ticking = false;
     }
+    _reschedule();
   }
 
   /// 边下边播（提前入库）：不等种子完成，立刻按计划入库。顺序下载模式下视频
@@ -398,7 +520,14 @@ class AnimeDownloadService {
               when !info.isComplete && !info.isFailure)
             plan.id: info.progress.clamp(0.0, 1.0).toDouble(),
       };
-      _publishProgress(progressNext);
+      final Map<String, DownloadTaskStats> statsNext =
+          <String, DownloadTaskStats>{
+        for (final AnimeDownloadPlan plan in pending)
+          if (byHash[plan.id.toLowerCase()] case final TorrentSnapshot info
+              when !info.isComplete)
+            plan.id: DownloadTaskStats.fromSnapshot(info),
+      };
+      _publishProgress(progressNext, statsNext);
 
       for (final AnimeDownloadPlan plan in pending) {
         final TorrentSnapshot? info = byHash[plan.id.toLowerCase()];

--- a/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
@@ -177,6 +177,12 @@ class EmbeddedTorrentBackend implements TorrentRemovalBackend {
       savePath: t.savePath,
       contentPath: t.contentPath,
       amountLeft: t.left,
+      // BUG-1294：native 一直导出速率/流量/peer 数，此前在这里被丢弃。
+      downRateBps: t.downRate,
+      upRateBps: t.upRate,
+      downloadedBytes: t.downloaded,
+      uploadedBytes: t.uploaded,
+      numPeers: t.numPeers,
     );
   }
 }

--- a/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
@@ -106,8 +106,20 @@ class EmbeddedTorrentHost {
   /// 每个种子进入做种阶段的时刻（做种时长上限判定基准）。
   final Map<String, int> _seedStartMs = <String, int>{};
 
-  /// 已下发的 per-torrent 上传模式（避免无变化时重复 FFI 调用）。
-  final Map<String, bool> _appliedUpload = <String, bool>{};
+  /// 已下发的会话级上传开关（null = 尚未下发；避免每 tick 重复 FFI）。
+  /// BUG-1293：「关上传」的正确原语是会话级 unchoke 槽位清零，不是
+  /// upload_mode（那是「停止下载」，正好相反）。
+  bool? _appliedSessionUploadEnabled;
+
+  /// 已下发的 per-torrent 暂停状态（做种超限/关上传时停止做种用）。
+  final Map<String, bool> _appliedPaused = <String, bool>{};
+
+  /// 是否已做过一次性「清 upload_mode 残留」治愈（BUG-1293：旧版本给种子打上
+  /// 的 upload_mode flag 会随 resume 复活，掐死下载；开机清一次即可）。
+  bool _healedUploadMode = false;
+
+  /// 底层 DLL 不支持上传策略原语时只记一次日志（避免每 tick 刷屏）。
+  bool _loggedUploadControlUnsupported = false;
 
   /// 底层引擎版本串（诊断/probe 用）。
   String get libtorrentVersion => _engine.libtorrentVersion();
@@ -158,6 +170,28 @@ class EmbeddedTorrentHost {
   }
 
   static int _defaultClockMs() => DateTime.now().millisecondsSinceEpoch;
+
+  /// 仅测试用：用现成 engine/session（可为 fromLookup 假绑定）构造宿主，
+  /// 跳过 DLL 加载与 resume 恢复。存在的理由与
+  /// `apply_limits_local_peers_test` 相同：要 DLL 的用例在 CI 整组 skip，
+  /// 上传策略「绝不下发 upload_mode、关上传走 unchoke/pause」这条命脉
+  /// （BUG-1293）必须有任何环境都会跑的用例守着。
+  @visibleForTesting
+  static EmbeddedTorrentHost forTesting({
+    required EmbeddedTorrentEngine engine,
+    required EmbeddedTorrentSession session,
+    required String baseSavePath,
+    required String resumeDir,
+    int Function()? clockMs,
+  }) {
+    return EmbeddedTorrentHost._(
+      engine: engine,
+      session: session,
+      saveRoots: TorrentSaveRoots(active: baseSavePath),
+      resumeDir: resumeDir,
+      clockMs: clockMs ?? _defaultClockMs,
+    );
+  }
 
   /// 缓存的能力探测结果（DLL 只需加载一次，`DynamicLibrary` 也无法卸载）。
   static bool? _availabilityCache;
@@ -305,7 +339,12 @@ class EmbeddedTorrentHost {
 
   /// 应用会话级设置（qb 关键项：端口/DHT/LSD/UPnP/NAT-PMP/加密/匿名/活跃数/
   /// 上传槽）到常驻 session。config 变更/启动时由 AppModel 调用。
+  ///
+  /// native 侧会把 `maxUploadSlots > 0` 写进 unchoke_slots_limit——这会覆盖
+  /// [sweepUploadPolicy] 下发的「关上传 = 0 槽位」，所以这里把已下发缓存置空，
+  /// 让下一次 sweep（AppModel 在本调用之后紧接着 setUploadPolicy）重新裁决。
   bool applySessionSettings(QbConnectionConfig config) {
+    _appliedSessionUploadEnabled = null;
     return _session.applySessionSettings(
       listenPort: config.listenPort,
       enableDht: config.enableDht,
@@ -419,20 +458,72 @@ class EmbeddedTorrentHost {
     sweepUploadPolicy();
   }
 
-  /// 上传/做种策略扫描：按 [torrent_upload_policy] 算出每个种子的期望上传状态
-  /// （总开关关 / 做种超时 / 分享率达标 → 停传），仅在期望状态变化时下发
-  /// `setUploadMode`（避免每 tick 重复 FFI）。返回本轮实际改变的种子数。
-  /// 与 [sweepAntiLeech] 同在 `AnimeDownloadService` 每 tick 调用。异常静默吞。
+  /// 上传/做种策略扫描（BUG-1293 重写）。
+  ///
+  /// 旧实现把「不上传」翻译成 per-torrent `setUploadMode(enabled: false)`，而
+  /// libtorrent 的 `upload_mode` flag 语义是「不再发出 piece 请求」= **停止
+  /// 下载**——默认关上传的用户所有种子在 add 后一个 tick 内下载速率归零。
+  ///
+  /// 现映射（policy 本身不变，见 [shouldAllowUpload]）：
+  /// - **会话级**：总开关 [QbConnectionConfig.uploadEnabled] 关 →
+  ///   [EmbeddedTorrentSession.setUnchokeSlots] 清零（不给任何 peer unchoke
+  ///   槽位 = 停止上传 payload；我们的下载请求是协议消息，不受影响）。开 →
+  ///   还原为用户的 maxUploadSlots（未设则 libtorrent 默认）。
+  ///   下载中种子的「不上传」只会由总开关触发（policy 对下载中恒 allow），
+  ///   所以会话级开关足以覆盖，无需 per-torrent 原语。
+  /// - **per-torrent**：做种（isFinished）超时/分享率达标/总开关关 →
+  ///   [EmbeddedTorrentSession.pauseTorrent]（数据已完整，暂停只停做种，
+  ///   与 qb 到达分享率后暂停同语义）；条件解除 → resume。
+  ///   **绝不 pause 未完成的种子**（那才是真的掐死下载）。
+  ///
+  /// 老 DLL 没有新原语时整体降级为不动作（宁可上传也不掐下载），只记一次日志。
+  /// 每 tick 由 `AnimeDownloadService` 调用；仅状态变化时下发 FFI。异常静默吞。
+  /// 返回本轮实际改变的对象数（会话开关算 1，每个种子算 1）。
   int sweepUploadPolicy() {
     try {
       final int nowMs = _clockMs();
       int changed = 0;
+
+      // 一次性治愈：清掉旧版本/旧 resume 打在种子上的 upload_mode 残留
+      // （新旧 DLL 对 enabled: true 都是「只清 flag」，幂等且无副作用）。
+      if (!_healedUploadMode) {
+        if (_session.setUploadMode(enabled: true)) {
+          _healedUploadMode = true;
+        }
+      }
+
+      if (!_session.supportsUploadControl) {
+        if (!_loggedUploadControlUnsupported) {
+          _loggedUploadControlUnsupported = true;
+          debugPrint('[torrent] upload policy skipped: bundled DLL lacks '
+              'ht_set_unchoke_slots/ht_pause_torrent (upload stays enabled; '
+              'downloads unaffected)');
+        }
+        return 0;
+      }
+
+      // ① 会话级总开关。
+      final bool uploadEnabled = _uploadConfig.uploadEnabled;
+      if (_appliedSessionUploadEnabled != uploadEnabled) {
+        final int slots = uploadEnabled
+            ? (_uploadConfig.maxUploadSlots > 0
+                ? _uploadConfig.maxUploadSlots
+                : -1)
+            : 0;
+        if (_session.setUnchokeSlots(slots)) {
+          _appliedSessionUploadEnabled = uploadEnabled;
+          changed++;
+        }
+      }
+
+      // ② per-torrent：只对已完成（做种）种子暂停/恢复。
       final Set<String> live = <String>{};
       for (final HtTorrentStatus t in _session.listTorrents()) {
         live.add(t.id);
         if (t.isSeeding) {
           _seedStartMs.putIfAbsent(t.id, () => nowMs);
         }
+        if (!t.isFinished) continue;
         final int? startMs = _seedStartMs[t.id];
         final int elapsedMs = startMs == null ? 0 : nowMs - startMs;
         final bool allow = shouldAllowUpload(
@@ -444,16 +535,17 @@ class EmbeddedTorrentHost {
             seedingElapsedMs: elapsedMs,
           ),
         );
-        if (_appliedUpload[t.id] != allow) {
-          if (_session.setUploadMode(infoHash: t.id, enabled: allow)) {
-            _appliedUpload[t.id] = allow;
+        final bool wantPaused = !allow;
+        if (_appliedPaused[t.id] != wantPaused) {
+          if (_session.pauseTorrent(t.id, pause: wantPaused)) {
+            _appliedPaused[t.id] = wantPaused;
             changed++;
           }
         }
       }
       // 清理已移除种子的残留状态。
       _seedStartMs.removeWhere((String k, int v) => !live.contains(k));
-      _appliedUpload.removeWhere((String k, bool v) => !live.contains(k));
+      _appliedPaused.removeWhere((String k, bool v) => !live.contains(k));
       return changed;
     } on Object {
       return 0;

--- a/hibiki/lib/src/media/torrent/qb_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/qb_torrent_backend.dart
@@ -12,6 +12,10 @@ class QbTorrentBackend implements TorrentRemovalBackend {
   @override
   Future<String?> probeConnection() => _client.fetchVersion();
 
+  /// 最近一次连接/登录失败的可读原因（BUG-1295：设置页测试连接透传显示，
+  /// 不再把网络不通/账密错/IP 被封折叠成同一句话）。
+  String? get lastProbeFailure => _client.lastFailure;
+
   /// 确保分类存在（qb 侧 409 已存在也算成功）。
   @override
   Future<bool> prepareCategory(String category) =>

--- a/hibiki/lib/src/media/torrent/qbittorrent_client.dart
+++ b/hibiki/lib/src/media/torrent/qbittorrent_client.dart
@@ -39,19 +39,23 @@ List<TorrentSnapshot> parseQbTorrentInfos(String body) {
       if (e is! Map) continue;
       final dynamic hash = e['hash'];
       if (hash is! String || hash.isEmpty) continue;
-      out.add(
-        TorrentSnapshot(
-          hash: hash,
-          name: e['name'] is String ? e['name'] as String : '',
-          progress:
-              e['progress'] is num ? (e['progress'] as num).toDouble() : 0,
-          state: e['state'] is String ? e['state'] as String : '',
-          savePath: e['save_path'] is String ? e['save_path'] as String : '',
-          contentPath:
-              e['content_path'] is String ? e['content_path'] as String : '',
-          amountLeft: e['amount_left'] is int ? e['amount_left'] as int : -1,
-        ),
-      );
+      out.add(TorrentSnapshot(
+        hash: hash,
+        name: e['name'] is String ? e['name'] as String : '',
+        progress: e['progress'] is num ? (e['progress'] as num).toDouble() : 0,
+        state: e['state'] is String ? e['state'] as String : '',
+        savePath: e['save_path'] is String ? e['save_path'] as String : '',
+        contentPath:
+            e['content_path'] is String ? e['content_path'] as String : '',
+        amountLeft: e['amount_left'] is int ? e['amount_left'] as int : -1,
+        // BUG-1294：qb 一直返回这些字段，此前解析时被丢弃。
+        downRateBps: e['dlspeed'] is int ? e['dlspeed'] as int : 0,
+        upRateBps: e['upspeed'] is int ? e['upspeed'] as int : 0,
+        downloadedBytes: e['downloaded'] is int ? e['downloaded'] as int : 0,
+        uploadedBytes: e['uploaded'] is int ? e['uploaded'] as int : 0,
+        numPeers: (e['num_seeds'] is int ? e['num_seeds'] as int : 0) +
+            (e['num_leechs'] is int ? e['num_leechs'] as int : 0),
+      ));
     }
     return out;
   } catch (_) {
@@ -113,7 +117,19 @@ class QBittorrentClient {
   /// 当前会话 cookie；null = 尚未登录或已失效。
   String? _sid;
 
-  /// 登录并缓存 SID cookie。成功返回 true；凭据错误/网络异常返回 false。
+  /// qBittorrent 开着「对本地主机的客户端跳过身份验证」时，登录接口仍校验
+  /// 账密（用户往往根本没设/记不得），但业务接口匿名即可用。BUG-1295：
+  /// 登录失败后做一次匿名探测，通了就免登录直连，别把可用的 API 卡死在
+  /// 登录门外。true = 已验证匿名可用。
+  bool _anonymousOk = false;
+
+  /// 最近一次连接/登录失败的可读原因（英文原样，探测 UI 透传显示）；
+  /// 成功后清空。BUG-1295：此前所有失败路径都折叠成一个 null，用户无从自查。
+  String? get lastFailure => _lastFailure;
+  String? _lastFailure;
+
+  /// 登录并缓存 SID cookie。成功返回 true；凭据错误/网络异常返回 false
+  /// （原因落 [lastFailure]）。
   Future<bool> login() async {
     _sid = null;
     try {
@@ -123,23 +139,72 @@ class QBittorrentClient {
         headers: <String, String>{'Referer': baseUrl},
         body: <String, String>{'username': username, 'password': password},
       ).timeout(requestTimeout);
+      final String body = res.body.trim();
+      // 登录失败超限（默认 5 次）后 qb 返回 403 + "…banned…"，解封前填对
+      // 账密也进不去——必须单独说清，否则用户会反复重试把封禁续期。
+      if (res.statusCode == 403) {
+        _lastFailure = body.toLowerCase().contains('banned')
+            ? 'IP banned by qBittorrent after too many failed logins '
+                '(unban: restart qBittorrent or wait, default 1 hour)'
+            : 'HTTP 403: $body';
+        return false;
+      }
       // 成功是 200 + body `Ok.`；密码错误也是 200 但 body `Fails.`。
-      if (res.statusCode != 200 || !res.body.trim().startsWith('Ok')) {
+      if (res.statusCode != 200) {
+        _lastFailure = 'HTTP ${res.statusCode}${body.isEmpty ? '' : ': $body'}';
+        return false;
+      }
+      if (!body.startsWith('Ok')) {
+        _lastFailure = 'login rejected (wrong username/password)';
         return false;
       }
       _sid = extractSidCookie(res.headers['set-cookie']);
-      return _sid != null;
-    } catch (_) {
+      if (_sid == null) {
+        _lastFailure = 'login ok but no SID cookie in response';
+        return false;
+      }
+      _lastFailure = null;
+      return true;
+    } catch (e) {
+      _lastFailure = e.toString();
       return false;
     }
   }
 
-  /// 连接测试：`GET /api/v2/app/version` → 形如 `v4.6.5`；失败返回 null。
+  /// 匿名探测：不带 Cookie 直接拉版本号。qb 的 localhost 免密（或整体关闭
+  /// 认证）时可用。成功则清空 [lastFailure]（连接本身是通的）。
+  Future<bool> _probeAnonymous() async {
+    try {
+      final http.Response res = await _client.get(
+        Uri.parse('$baseUrl/api/v2/app/version'),
+        headers: <String, String>{'Referer': baseUrl},
+      ).timeout(requestTimeout);
+      if (res.statusCode == 200 && res.body.trim().isNotEmpty) {
+        _lastFailure = null;
+        return true;
+      }
+      return false;
+    } catch (_) {
+      // 保留 login() 已记下的失败原因（网络不通时两边是同一个原因）。
+      return false;
+    }
+  }
+
+  /// 连接测试：`GET /api/v2/app/version` → 形如 `v4.6.5`；失败返回 null
+  /// （原因见 [lastFailure]）。
   Future<String?> fetchVersion() async {
     final http.Response? res = await _request('GET', '/api/v2/app/version');
-    if (res == null || res.statusCode != 200) return null;
+    if (res == null) return null;
+    if (res.statusCode != 200) {
+      _lastFailure = 'HTTP ${res.statusCode} from /api/v2/app/version';
+      return null;
+    }
     final String version = res.body.trim();
-    return version.isEmpty ? null : version;
+    if (version.isEmpty) {
+      _lastFailure = 'empty version response';
+      return null;
+    }
+    return version;
   }
 
   /// 添加下载：[urls] 是 magnet 链接或 .torrent URL（多个换行连接）。
@@ -276,8 +341,8 @@ class QBittorrentClient {
     return (false, body.isEmpty ? 'HTTP ${res.statusCode}' : body);
   }
 
-  /// 带会话编排的请求：懒登录 → 发请求 → 403 时重新登录一次并重试。
-  /// 任何异常/登录失败返回 null。
+  /// 带会话编排的请求：懒登录（登录失败退匿名探测，BUG-1295）→ 发请求 →
+  /// 403 时重新认证一次并重试。任何异常/认证失败返回 null。
   Future<http.Response?> _request(
     String method,
     String path, {
@@ -285,18 +350,29 @@ class QBittorrentClient {
     Map<String, String>? form,
   }) async {
     try {
-      if (_sid == null && !await login()) return null;
+      if (_sid == null && !_anonymousOk && !await _authenticate()) return null;
       http.Response res = await _send(method, path, query: query, form: form);
       if (res.statusCode == 403) {
-        // 会话过期：只重登一次，仍失败就把 403 交给调用方按失败处理。
+        // 会话过期 / 免密开关被关掉：只重认证一次，仍失败就把 403 交给
+        // 调用方按失败处理。
         _sid = null;
-        if (!await login()) return null;
+        _anonymousOk = false;
+        if (!await _authenticate()) return null;
         res = await _send(method, path, query: query, form: form);
       }
       return res;
-    } catch (_) {
+    } catch (e) {
+      _lastFailure = e.toString();
       return null;
     }
+  }
+
+  /// 认证编排：正常登录优先；登录失败（典型：qb localhost 免密下账密没配）
+  /// 再匿名探测一次，通了就免登录直连。
+  Future<bool> _authenticate() async {
+    if (await login()) return true;
+    _anonymousOk = await _probeAnonymous();
+    return _anonymousOk;
   }
 
   /// 发一次裸请求（带 SID cookie 与 Referer）。

--- a/hibiki/lib/src/media/torrent/torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/torrent_backend.dart
@@ -13,6 +13,11 @@ class TorrentSnapshot {
     required this.savePath,
     required this.contentPath,
     required this.amountLeft,
+    this.downRateBps = 0,
+    this.upRateBps = 0,
+    this.downloadedBytes = 0,
+    this.uploadedBytes = 0,
+    this.numPeers = 0,
   });
 
   /// 种子 infohash（小写十六进制），后续查文件列表用。
@@ -35,6 +40,22 @@ class TorrentSnapshot {
 
   /// 剩余待下载字节数；解析不出为 -1（= 未知，不当作完成）。
   final int amountLeft;
+
+  /// 实时下载速率（字节/秒）。BUG-1294：native/qb 一直导出这些字段，此前在
+  /// 本抽象层被整体丢弃，UI 无从显示速度/流量。
+  final int downRateBps;
+
+  /// 实时上传速率（字节/秒）。
+  final int upRateBps;
+
+  /// 累计下载字节（流量显示用）。
+  final int downloadedBytes;
+
+  /// 累计上传字节。
+  final int uploadedBytes;
+
+  /// 当前连接的 peer 数。
+  final int numPeers;
 
   /// 做种/完成类状态：数据已全部落盘，只在做种或做种停止。
   static const Set<String> _seedingStates = <String>{

--- a/hibiki/lib/src/media/torrent/torrent_upload_policy.dart
+++ b/hibiki/lib/src/media/torrent/torrent_upload_policy.dart
@@ -23,8 +23,10 @@ class TorrentUploadMetrics {
 }
 
 /// 判定某种子当前是否应允许上传/做种。纯函数，无副作用，便于单测——
-/// 内置引擎宿主 tick 用它算出每个种子的期望上传状态，再落到
-/// `setUploadMode`。语义（用户诉求：默认关上传、开启后可设做种时长/分享率）：
+/// 内置引擎宿主 tick 用它算出每个种子的期望上传状态，再落到正确原语
+/// （BUG-1293：总开关走会话级 `setUnchokeSlots`，做种停止走 `pauseTorrent`；
+/// **绝不用 upload_mode**——那个 flag 是「停止下载」，与关上传正好相反）。
+/// 语义（用户诉求：默认关上传、开启后可设做种时长/分享率）：
 ///
 /// - 总开关 [QbConnectionConfig.uploadEnabled] 关 → 一律不上传（返回 false）；
 /// - 开启后，做种时长超过 [QbConnectionConfig.seedTimeLimitMinutes]（>0 生效）

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -2205,10 +2205,12 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       final AnimeDownloadService? service =
           ref.read(appProvider).animeDownloadService;
       if (service != null) {
-        return ValueListenableBuilder<Map<String, double>>(
-          valueListenable: service.downloadProgress,
-          builder: (BuildContext context, Map<String, double> progress, _) =>
-              _buildPlanRowInner(theme, plan, progress[plan.id]),
+        // BUG-1294：订阅完整观测值（进度 + 速度/流量），不再只有百分比。
+        return ValueListenableBuilder<Map<String, DownloadTaskStats>>(
+          valueListenable: service.downloadStats,
+          builder:
+              (BuildContext context, Map<String, DownloadTaskStats> stats, _) =>
+                  _buildPlanRowInner(theme, plan, stats[plan.id]),
         );
       }
     }
@@ -2216,10 +2218,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   }
 
   Widget _buildPlanRowInner(
-    ThemeData theme,
-    AnimeDownloadPlan plan,
-    double? progress,
-  ) {
+      ThemeData theme, AnimeDownloadPlan plan, DownloadTaskStats? stats) {
+    final double? progress = stats?.progress;
     final ColorScheme scheme = theme.colorScheme;
     final bool eink = isEinkTheme(context);
     final bool downloading = plan.status == AnimeDownloadPlan.statusDownloading;
@@ -2249,8 +2249,13 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
               ),
             ),
     };
-    final String? progressText = (downloading && progress != null)
-        ? '${(progress * 100).toStringAsFixed(0)}%'
+    // BUG-1294：进度百分比之外补速度与累计流量（单位串是纯数字/符号，无需
+    // i18n key）。速率为 0 时仍显示（「0 B/s 卡住了」本身就是有效信息）。
+    final String? progressText = (downloading && stats != null)
+        ? '${(stats.progress * 100).toStringAsFixed(0)}% · '
+            '↓ ${HibikiByteFormat.speed(stats.downRateBps.toDouble())} · '
+            '↑ ${HibikiByteFormat.speed(stats.upRateBps.toDouble())} · '
+            '${HibikiByteFormat.bytes(stats.downloadedBytes)}'
         : null;
     final String? failReason =
         (failed && (plan.failReason?.isNotEmpty ?? false))

--- a/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/torrent/download_network_proxy.dart';
 import 'package:hibiki/src/media/torrent/download_save_root.dart';
+import 'package:hibiki/src/media/torrent/qb_torrent_backend.dart';
 import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/utils.dart';
@@ -78,25 +79,35 @@ class _TorrentSettingsSectionState
   }
 
   /// 测试与下载后端的连通性（按当前配置解析后端；qb = WebUI 版本号）。
-  /// 成功 snack 显示版本，失败提示检查地址/账号。
+  /// 成功 snack 显示版本；失败时透传后端给的具体原因（BUG-1295：网络不通/
+  /// 账密错/qb 封 IP 此前折叠成同一句「检查地址与账号密码」，无从自查）。
   Future<void> _probeConnection() async {
     if (_probing) return;
     setState(() => _probing = true);
     final TorrentBackend backend =
         ref.read(appProvider).createTorrentBackend(_config);
     String? version;
+    String? failure;
     try {
       version = await backend.probeConnection();
     } finally {
+      if (version == null && backend is QbTorrentBackend) {
+        failure = backend.lastProbeFailure;
+      }
       backend.close();
     }
     if (!mounted) return;
     setState(() => _probing = false);
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-      content: Text(version == null
-          ? t.download_test_connection_failed
-          : t.download_test_connection_ok(version: version)),
-    ));
+    final String message;
+    if (version != null) {
+      message = t.download_test_connection_ok(version: version);
+    } else if (failure != null && failure.isNotEmpty) {
+      message = t.download_test_connection_failed_reason(message: failure);
+    } else {
+      message = t.download_test_connection_failed;
+    }
+    ScaffoldMessenger.of(context)
+        .showSnackBar(SnackBar(content: Text(message)));
   }
 
   /// TODO-1961：选新的下载目录。校验不过**不写**配置，直接 snack 报原因（不静默）。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1053
+version: 1.3.1+1054
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/torrent/upload_policy_dispatch_guard_test.dart
+++ b/hibiki/test/media/torrent/upload_policy_dispatch_guard_test.dart
@@ -1,0 +1,262 @@
+// BUG-1293 守卫：上传策略的 FFI 下发链 —— **不需要 native DLL**。
+//
+// 事故本体：旧实现把「关上传」（默认配置 uploadEnabled=false）翻译成给每个
+// 种子置 libtorrent 的 `torrent_flags::upload_mode`，而该 flag 的真实语义是
+// 「不再发出任何 piece 请求」= 只上不下、停止下载 —— 所有种子在 add 后一个
+// tick 内下载速率归零，用户报「内置引擎速度几乎为 0」。
+//
+// 本守卫用 `Pointer.fromFunction` 伪造 C ABI（与 apply_limits_local_peers_test
+// 同范式），经 `HibikiTorrentBindings.fromLookup` + `EmbeddedTorrentHost.forTesting`
+// 断言整条 sweepUploadPolicy → session → C 入参：
+// ① 关上传绝不下发 upload_mode=0（那是停止下载）；
+// ② 关上传走会话级 unchoke 槽位清零；
+// ③ 只有已完成（做种）的种子会被 pause，下载中的绝不 pause；
+// ④ 老 DLL（无新符号）整体降级为不动作，绝不回退到 upload_mode。
+//
+// 要 DLL 的行为闭环（unchoke=0 时下载仍推进）在
+// packages/hibiki_torrent/test/upload_off_download_test.dart（缺 DLL skip）。
+
+import 'dart:convert';
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/torrent/anime_download_config.dart';
+import 'package:hibiki/src/media/torrent/embedded_torrent_host.dart';
+import 'package:hibiki_torrent/hibiki_torrent.dart';
+
+final Pointer<Void> _fakeSession = Pointer<Void>.fromAddress(0xF00D);
+
+/// 进入 C ABI 的调用记录（symbol + 关键入参）。
+final List<String> _calls = <String>[];
+
+/// ht_list_torrents 每次返回的 JSON（测试逐场景设置）。
+String _torrentsJson = '[]';
+
+Pointer<Void> _fakeSessionCreate(Pointer<Char> listen, int enableDht) =>
+    _fakeSession;
+
+Pointer<Char> _fakeListTorrents(Pointer<Void> session) =>
+    _torrentsJson.toNativeUtf8().cast<Char>();
+
+void _fakeFreeString(Pointer<Char> s) {
+  if (s != nullptr) malloc.free(s);
+}
+
+int _fakeSetUploadMode(
+    Pointer<Void> session, Pointer<Char> infoHash, int enabled) {
+  _calls.add('ht_set_upload_mode('
+      '${infoHash == nullptr ? '' : infoHash.cast<Utf8>().toDartString()},'
+      '$enabled)');
+  return 1;
+}
+
+int _fakeSetUnchokeSlots(Pointer<Void> session, int slots) {
+  _calls.add('ht_set_unchoke_slots($slots)');
+  return 1;
+}
+
+int _fakePauseTorrent(
+    Pointer<Void> session, Pointer<Char> infoHash, int pause) {
+  _calls.add('ht_pause_torrent('
+      '${infoHash == nullptr ? '' : infoHash.cast<Utf8>().toDartString()},'
+      '$pause)');
+  return 1;
+}
+
+/// [withUploadControl] = false 精确复刻「Dart 更新了、随包预编译 DLL 还是旧的」
+/// 部署形态（查不到 ht_set_unchoke_slots / ht_pause_torrent）。
+HibikiTorrentBindings _fakeBindings({required bool withUploadControl}) {
+  Pointer<T> lookup<T extends NativeType>(String symbol) {
+    switch (symbol) {
+      case 'ht_session_create':
+        return Pointer.fromFunction<Pointer<Void> Function(Pointer<Char>, Int)>(
+                _fakeSessionCreate)
+            .cast<T>();
+      case 'ht_list_torrents':
+        return Pointer.fromFunction<Pointer<Char> Function(Pointer<Void>)>(
+                _fakeListTorrents)
+            .cast<T>();
+      case 'ht_free_string':
+        return Pointer.fromFunction<Void Function(Pointer<Char>)>(
+                _fakeFreeString)
+            .cast<T>();
+      case 'ht_set_upload_mode':
+        return Pointer.fromFunction<
+            Int Function(Pointer<Void>, Pointer<Char>, Int)>(
+          _fakeSetUploadMode,
+          0,
+        ).cast<T>();
+      case 'ht_set_unchoke_slots':
+        if (!withUploadControl) {
+          throw ArgumentError("Failed to lookup symbol '$symbol'");
+        }
+        return Pointer.fromFunction<Int Function(Pointer<Void>, Int)>(
+          _fakeSetUnchokeSlots,
+          0,
+        ).cast<T>();
+      case 'ht_pause_torrent':
+        if (!withUploadControl) {
+          throw ArgumentError("Failed to lookup symbol '$symbol'");
+        }
+        return Pointer.fromFunction<
+            Int Function(Pointer<Void>, Pointer<Char>, Int)>(
+          _fakePauseTorrent,
+          0,
+        ).cast<T>();
+    }
+    throw ArgumentError("Failed to lookup symbol '$symbol'");
+  }
+
+  return HibikiTorrentBindings.fromLookup(lookup);
+}
+
+EmbeddedTorrentHost _host({required bool withUploadControl}) {
+  final EmbeddedTorrentEngine engine = EmbeddedTorrentEngine.fromBindings(
+      _fakeBindings(withUploadControl: withUploadControl));
+  final EmbeddedTorrentSession? session = EmbeddedTorrentSession.open(engine);
+  expect(session, isNotNull);
+  return EmbeddedTorrentHost.forTesting(
+    engine: engine,
+    session: session!,
+    baseSavePath: '/tmp/content',
+    resumeDir: '/tmp/resume',
+    clockMs: () => 1000,
+  );
+}
+
+String _torrent({
+  required String id,
+  required bool finished,
+  double progress = 0.5,
+  int uploaded = 0,
+  int downloaded = 1,
+}) {
+  return jsonEncode(<String, Object>{
+    'id': id,
+    'name': id,
+    'progress': progress,
+    'state': finished ? 'seeding' : 'downloading',
+    'save_path': '/tmp/content/hibiki',
+    'content_path': '',
+    'total': 100,
+    'done': finished ? 100 : 50,
+    'left': finished ? 0 : 50,
+    'down_rate': 0,
+    'up_rate': 0,
+    'uploaded': uploaded,
+    'downloaded': downloaded,
+    'num_peers': 1,
+    'has_metadata': true,
+    'is_finished': finished,
+    'is_seeding': finished,
+    'sequential': false,
+  });
+}
+
+void main() {
+  setUp(() {
+    _calls.clear();
+    _torrentsJson = '[]';
+  });
+
+  group('BUG-1293：关上传绝不下发 upload_mode（那是「停止下载」）', () {
+    test('默认配置（uploadEnabled=false）+ 下载中种子：unchoke 清零、不碰种子', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      host.setUploadPolicy(const QbConnectionConfig());
+      _torrentsJson = '[${_torrent(id: 'aaa', finished: false)}]';
+      host.sweepUploadPolicy();
+
+      // 靶心：把 sweep 改回旧的 setUploadMode(enabled: false) 这条必红。
+      expect(_calls.where((String c) => c.endsWith(',0)')).toList(),
+          isNot(contains('ht_set_upload_mode(aaa,0)')),
+          reason: 'upload_mode=0 = 停止下载，绝不允许下发');
+      expect(_calls, isNot(contains('ht_set_upload_mode(,0)')));
+      expect(_calls, contains('ht_set_unchoke_slots(0)'),
+          reason: '关上传的正确原语是会话级 unchoke 槽位清零');
+      expect(
+          _calls.where((String c) => c.startsWith('ht_pause_torrent')), isEmpty,
+          reason: '下载中的种子绝不 pause（那才是真的掐死下载）');
+    });
+
+    test('关上传 + 已完成种子：pause（停止做种），不置 upload_mode', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      host.setUploadPolicy(const QbConnectionConfig());
+      _torrentsJson = '[${_torrent(id: 'bbb', finished: true)}]';
+      host.sweepUploadPolicy();
+
+      expect(_calls, contains('ht_pause_torrent(bbb,1)'));
+      expect(_calls, isNot(contains('ht_set_upload_mode(bbb,0)')));
+    });
+
+    test('开上传：unchoke 还原（maxUploadSlots 未设 → -1 = 引擎默认）', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      host.setUploadPolicy(const QbConnectionConfig(uploadEnabled: true));
+      expect(_calls, contains('ht_set_unchoke_slots(-1)'));
+      expect(_calls, isNot(contains('ht_set_unchoke_slots(0)')));
+    });
+
+    test('开上传 + maxUploadSlots=4：unchoke 还原为用户值', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      host.setUploadPolicy(
+          const QbConnectionConfig(uploadEnabled: true, maxUploadSlots: 4));
+      expect(_calls, contains('ht_set_unchoke_slots(4)'));
+    });
+
+    test('开上传 + 分享率达标的做种种子：pause；未达标不 pause', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      host.setUploadPolicy(const QbConnectionConfig(
+        uploadEnabled: true,
+        seedRatioLimit: 2.0,
+      ));
+      _torrentsJson = '['
+          '${_torrent(id: 'hit', finished: true, uploaded: 200, downloaded: 100)},'
+          '${_torrent(id: 'low', finished: true, uploaded: 10, downloaded: 100)}'
+          ']';
+      host.sweepUploadPolicy();
+
+      expect(_calls, contains('ht_pause_torrent(hit,1)'));
+      expect(_calls, isNot(contains('ht_pause_torrent(low,1)')));
+    });
+
+    test('状态不变时不重复下发（每 tick 幂等）', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      host.setUploadPolicy(const QbConnectionConfig());
+      _torrentsJson = '[${_torrent(id: 'ccc', finished: true)}]';
+      host.sweepUploadPolicy();
+      final int after = _calls.length;
+      host.sweepUploadPolicy();
+      host.sweepUploadPolicy();
+      expect(_calls.length, after, reason: '无状态变化不应再发 FFI');
+    });
+  });
+
+  group('旧 DLL（无 ht_set_unchoke_slots / ht_pause_torrent 符号）降级', () {
+    test('探针如实报告', () {
+      final EmbeddedTorrentEngine engine = EmbeddedTorrentEngine.fromBindings(
+          _fakeBindings(withUploadControl: false));
+      final EmbeddedTorrentSession session =
+          EmbeddedTorrentSession.open(engine)!;
+      expect(session.supportsUploadControl, isFalse);
+    });
+
+    test('不崩、不动作，且绝不回退到 upload_mode=0', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: false);
+      host.setUploadPolicy(const QbConnectionConfig());
+      _torrentsJson = '[${_torrent(id: 'ddd', finished: false)}]';
+      expect(host.sweepUploadPolicy(), 0);
+
+      expect(
+          _calls.where((String c) =>
+              c.startsWith('ht_set_upload_mode') && c.endsWith(',0)')),
+          isEmpty,
+          reason: '老 DLL 的 upload_mode=0 会真的置 flag 掐死下载，绝不允许');
+    });
+
+    test('治愈调用照常发出（enabled=1 清历史残留 flag，新旧 DLL 都安全）', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: false);
+      host.setUploadPolicy(const QbConnectionConfig());
+      expect(_calls, contains('ht_set_upload_mode(,1)'));
+    });
+  });
+}

--- a/hibiki/test/torrent/anime_download_service_progress_test.dart
+++ b/hibiki/test/torrent/anime_download_service_progress_test.dart
@@ -58,7 +58,13 @@ class _FakeBackend implements TorrentBackend {
       const TorrentStorageResult.failure('not supported by fake');
 }
 
-TorrentSnapshot _snapshot({required double progress, required String state}) {
+TorrentSnapshot _snapshot({
+  required double progress,
+  required String state,
+  int downRateBps = 0,
+  int upRateBps = 0,
+  int downloadedBytes = 0,
+}) {
   return TorrentSnapshot(
     hash: _kHash,
     name: 'torrent',
@@ -67,6 +73,9 @@ TorrentSnapshot _snapshot({required double progress, required String state}) {
     savePath: '',
     contentPath: '',
     amountLeft: state == 'downloading' ? 100 : 0,
+    downRateBps: downRateBps,
+    upRateBps: upRateBps,
+    downloadedBytes: downloadedBytes,
   );
 }
 
@@ -137,6 +146,76 @@ void main() {
     // pending 清零后，下一轮 tick 保持空表。
     await service.tick();
     expect(service.downloadProgress.value, isEmpty);
+  });
+
+  test('tick 同步发布速度/流量观测值到 downloadStats（BUG-1294）', () async {
+    backend.torrents = <TorrentSnapshot>[
+      _snapshot(
+        progress: 0.42,
+        state: 'downloading',
+        downRateBps: 1048576,
+        upRateBps: 2048,
+        downloadedBytes: 4096,
+      ),
+    ];
+    await service.tick();
+    final DownloadTaskStats stats = service.downloadStats.value[_kHash]!;
+    expect(stats.progress, 0.42);
+    expect(stats.downRateBps, 1048576);
+    expect(stats.upRateBps, 2048);
+    expect(stats.downloadedBytes, 4096);
+
+    // 种子从后端消失 → stats 同步清空（与 downloadProgress 键集合一致）。
+    backend.torrents = <TorrentSnapshot>[];
+    await service.tick();
+    expect(service.downloadStats.value, isEmpty);
+  });
+
+  test('轮询周期决策：内置引擎 + 有活跃下载才提频（BUG-1294）', () {
+    const QbConnectionConfig embedded =
+        QbConnectionConfig(backend: QbConnectionConfig.backendEmbedded);
+    const Duration idle = Duration(seconds: 20);
+
+    expect(
+      AnimeDownloadService.resolvePollInterval(
+        config: embedded,
+        hasActiveDownloads: true,
+        isDesktop: true,
+        idle: idle,
+      ),
+      AnimeDownloadService.activeInterval,
+    );
+    // 无活跃下载 → 保持常规周期。
+    expect(
+      AnimeDownloadService.resolvePollInterval(
+        config: embedded,
+        hasActiveDownloads: false,
+        isDesktop: true,
+        idle: idle,
+      ),
+      idle,
+    );
+    // 外接 qb：每 tick 都是一次全新 WebUI 登录，提频会放大失败计数
+    // （qb 默认 5 次封 IP），恒用常规周期。
+    expect(
+      AnimeDownloadService.resolvePollInterval(
+        config: _kConfig,
+        hasActiveDownloads: true,
+        isDesktop: true,
+        idle: idle,
+      ),
+      idle,
+    );
+    // 未配置 → 常规周期。
+    expect(
+      AnimeDownloadService.resolvePollInterval(
+        config: null,
+        hasActiveDownloads: true,
+        isDesktop: true,
+        idle: idle,
+      ),
+      idle,
+    );
   });
 
   test('后端未配置时清空进度表', () async {

--- a/hibiki/test/torrent/qbittorrent_client_test.dart
+++ b/hibiki/test/torrent/qbittorrent_client_test.dart
@@ -123,11 +123,16 @@ void main() {
         baseUrl: 'http://qb.local:8080',
         username: 'admin',
         password: 'wrong',
-        client: MockClient(
-            (http.Request request) async => http.Response('Fails.', 200)),
+        // 真实 qb：登录失败回 200 Fails.；未认证访问业务接口回 403。
+        client: MockClient((http.Request request) async =>
+            request.url.path == '/api/v2/auth/login'
+                ? http.Response('Fails.', 200)
+                : http.Response('Forbidden', 403)),
       );
       expect(await client.login(), isFalse);
-      // 登录失败后依赖会话的调用也应失败而不是抛异常。
+      // BUG-1295：失败原因可读，不再折叠成裸 null。
+      expect(client.lastFailure, contains('rejected'));
+      // 登录失败 + 匿名也 403 → 依赖会话的调用失败而不是抛异常。
       expect(await client.fetchVersion(), isNull);
       client.close();
     });
@@ -142,9 +147,71 @@ void main() {
         }),
       );
       expect(await client.login(), isFalse);
+      // BUG-1295：网络异常原样透出（与账密错区分开）。
+      expect(client.lastFailure, contains('connection refused'));
       expect(await client.fetchVersion(), isNull);
       expect(await client.addTorrents(<String>['magnet:?xt=x']), isFalse);
       expect(await client.fetchTorrents(), isEmpty);
+      client.close();
+    });
+
+    test('reports qBittorrent IP ban distinctly (BUG-1295)', () async {
+      final QBittorrentClient client = QBittorrentClient(
+        baseUrl: 'http://qb.local:8080',
+        username: 'admin',
+        password: 'secret',
+        client: MockClient((http.Request request) async => http.Response(
+            'Your IP address has been banned after too many failed '
+            'authentication attempts.',
+            403)),
+      );
+      expect(await client.fetchVersion(), isNull);
+      expect(client.lastFailure, contains('banned'));
+      client.close();
+    });
+  });
+
+  group('anonymous fallback（qb localhost 免密，BUG-1295）', () {
+    test('login Fails. 但接口匿名可用 → 探测成功且不带 Cookie', () async {
+      final List<http.Request> versionRequests = <http.Request>[];
+      int loginAttempts = 0;
+      final QBittorrentClient client = QBittorrentClient(
+        baseUrl: 'http://qb.local:8080',
+        username: '',
+        password: '',
+        client: MockClient((http.Request request) async {
+          if (request.url.path == '/api/v2/auth/login') {
+            loginAttempts++;
+            // localhost bypass 下登录接口仍校验账密：空账密 = Fails.
+            return http.Response('Fails.', 200);
+          }
+          expect(request.url.path, '/api/v2/app/version');
+          versionRequests.add(request);
+          return http.Response('v5.0.4', 200);
+        }),
+      );
+      expect(await client.fetchVersion(), 'v5.0.4');
+      for (final http.Request r in versionRequests) {
+        expect(_header(r, 'Cookie'), isNull, reason: '匿名直连不应带 SID cookie');
+      }
+      // 匿名态被缓存：后续调用不再反复撞登录门（避免触发 qb 失败计数封 IP）。
+      expect(await client.fetchVersion(), 'v5.0.4');
+      expect(loginAttempts, 1);
+      client.close();
+    });
+
+    test('登录与匿名都不通 → null + 保留登录失败原因', () async {
+      final QBittorrentClient client = QBittorrentClient(
+        baseUrl: 'http://qb.local:8080',
+        username: 'admin',
+        password: 'wrong',
+        client: MockClient((http.Request request) async =>
+            request.url.path == '/api/v2/auth/login'
+                ? http.Response('Fails.', 200)
+                : http.Response('Forbidden', 403)),
+      );
+      expect(await client.fetchVersion(), isNull);
+      expect(client.lastFailure, contains('rejected'));
       client.close();
     });
   });
@@ -354,6 +421,35 @@ void main() {
       ]);
       final List<TorrentSnapshot> infos = parseQbTorrentInfos(body);
       expect(infos.single.progress, 1.0);
+    });
+
+    test('parses speed/traffic/peer fields (BUG-1294)', () {
+      final String body = jsonEncode(<Map<String, dynamic>>[
+        <String, dynamic>{
+          'hash': 'h1',
+          'state': 'downloading',
+          'dlspeed': 1048576,
+          'upspeed': 2048,
+          'downloaded': 734003200,
+          'uploaded': 1024,
+          'num_seeds': 3,
+          'num_leechs': 2,
+        },
+      ]);
+      final TorrentSnapshot info = parseQbTorrentInfos(body).single;
+      expect(info.downRateBps, 1048576);
+      expect(info.upRateBps, 2048);
+      expect(info.downloadedBytes, 734003200);
+      expect(info.uploadedBytes, 1024);
+      expect(info.numPeers, 5);
+      // 字段缺省 → 安全 0，不影响老响应。
+      final TorrentSnapshot bare =
+          parseQbTorrentInfos('[{"hash":"h2"}]').single;
+      expect(bare.downRateBps, 0);
+      expect(bare.upRateBps, 0);
+      expect(bare.downloadedBytes, 0);
+      expect(bare.uploadedBytes, 0);
+      expect(bare.numPeers, 0);
     });
 
     test('tolerates bad JSON, non-list JSON and missing fields', () {

--- a/native/hibiki_torrent/hibiki_torrent_ffi.cpp
+++ b/native/hibiki_torrent/hibiki_torrent_ffi.cpp
@@ -338,6 +338,9 @@ char* add_with_params(lt::session* ses, lt::add_torrent_params params,
   // add 即启动：默认旗标带 paused，起始瞬间会丢弃 connect_peer 且无
   // tracker/DHT 时无从再发现 peer；本引擎的 add 语义就是「开始下载」。
   params.flags &= ~lt::torrent_flags::paused;
+  // BUG-1293：upload_mode = 「只上不下」（停止下载）。旧版本误用它表达
+  // 「关上传」，用户的 resume/重复 add 参数里可能带着残留，进来一律清掉。
+  params.flags &= ~lt::torrent_flags::upload_mode;
   lt::error_code ec;
   lt::torrent_handle h = ses->add_torrent(std::move(params), ec);
   if (ec == lt::errors::duplicate_torrent && h.is_valid()) {
@@ -541,14 +544,68 @@ HT_EXPORT int ht_set_upload_mode(void* session, const char* info_hash,
                                  int upload_enabled) {
   if (session == nullptr) return 0;
   try {
+    // BUG-1293：torrent_flags::upload_mode 的 libtorrent 语义是「不再发出任何
+    // piece 请求」= 只上不下（磁盘写失败时引擎自己会置它以停止下载保做种），
+    // 与旧实现宣称的「只下不上」正好相反 —— 置上它 = 掐死下载。
+    // 因此本函数：允许上传时**清除**该 flag（治愈历史 resume/旧版本留下的
+    // 残留）；禁止上传时 no-op 恒成功（正确原语是 ht_set_unchoke_slots /
+    // ht_pause_torrent，旧 Dart 调进来时宁可继续上传也绝不掐死下载）。
     const bool allow = upload_enabled != 0;
-    // upload_mode = 只下不上：allow 时清除、否则置位。
     const auto apply = [allow](lt::torrent_handle h) {
       if (!h.is_valid()) return;
-      if (allow) {
-        h.unset_flags(lt::torrent_flags::upload_mode);
+      if (allow) h.unset_flags(lt::torrent_flags::upload_mode);
+    };
+    const bool all = info_hash == nullptr || info_hash[0] == '\0';
+    if (all) {
+      for (lt::torrent_handle h : as_session(session)->get_torrents()) {
+        apply(h);
+      }
+      return 1;
+    }
+    lt::torrent_handle h = find_torrent(as_session(session), info_hash);
+    if (!h.is_valid()) return 0;
+    apply(h);
+    return 1;
+  } catch (...) {
+    return 0;
+  }
+}
+
+HT_EXPORT int ht_set_unchoke_slots(void* session, int slots) {
+  if (session == nullptr) return 0;
+  try {
+    lt::settings_pack sp;
+    if (slots < 0) {
+      sp.set_int(lt::settings_pack::unchoke_slots_limit,
+                 lt::default_settings().get_int(
+                     lt::settings_pack::unchoke_slots_limit));
+    } else {
+      // 0 = 不给任何 peer unchoke 槽位 = 会话级停止上传 payload。我们发出的
+      // piece 请求是协议消息、不占 unchoke 槽，下载不受影响（BUG-1293 的
+      // 「关上传」正确原语；upload_mode 是反的，见 ht_set_upload_mode）。
+      sp.set_int(lt::settings_pack::unchoke_slots_limit, slots);
+    }
+    as_session(session)->apply_settings(std::move(sp));
+    return 1;
+  } catch (...) {
+    return 0;
+  }
+}
+
+HT_EXPORT int ht_pause_torrent(void* session, const char* info_hash,
+                               int pause) {
+  if (session == nullptr) return 0;
+  try {
+    const bool want_pause = pause != 0;
+    const auto apply = [want_pause](lt::torrent_handle h) {
+      if (!h.is_valid()) return;
+      if (want_pause) {
+        // auto_managed 的种子会被队列管理器自动 resume，必须先清。
+        h.unset_flags(lt::torrent_flags::auto_managed);
+        h.pause();
       } else {
-        h.set_flags(lt::torrent_flags::upload_mode);
+        h.set_flags(lt::torrent_flags::auto_managed);
+        h.resume();
       }
     };
     const bool all = info_hash == nullptr || info_hash[0] == '\0';
@@ -1185,6 +1242,9 @@ HT_EXPORT char* ht_load_resume_dir(void* session, const char* dir) {
       // 与 add_with_params 同一语义：本引擎的 add = 「开始跑」。resume 里
       // 存的 paused 旗标必须清掉，否则加回来是暂停态，既不续传也不做种。
       params.flags &= ~lt::torrent_flags::paused;
+      // BUG-1293：旧版本把「关上传」误写成置 upload_mode（实际语义是停止
+      // 下载），已升级用户的 resume 里可能带着残留 flag，加载时一律治愈。
+      params.flags &= ~lt::torrent_flags::upload_mode;
       lt::error_code add_ec;
       lt::torrent_handle h = ses->add_torrent(std::move(params), add_ec);
       if ((add_ec && add_ec != lt::errors::duplicate_torrent) ||

--- a/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
+++ b/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
@@ -71,14 +71,30 @@ HT_EXPORT int ht_apply_limits_ex(void* session, int download_bps,
                                  int upload_bps, int connections_limit,
                                  int limit_local_peers);
 
-// 设置上传模式（做种/上传总开关，per-torrent 或全量）：
-// [info_hash] 为空串/NULL = 对 session 内所有种子生效；否则仅该种子。
-// [upload_enabled] 非 0 = 允许上传（清除 upload_mode）；0 = 停止上传但保持
-// 连接与下载（置 torrent_flags::upload_mode，libtorrent 正规「只下不上」）。
-// 注意：速率设 0 是「不限速」而非「禁传」，真正关上传必须走本函数。
-// 返回 1 成功、0 失败（session 无效 / 指定种子不存在）。
+// 【已废弃，勿在新代码调用】历史上传开关。BUG-1293：旧实现把「关上传」翻译成
+// 置 torrent_flags::upload_mode，但该 flag 的 libtorrent 语义是「不再发出任何
+// piece 请求」= **只上不下、停止下载**，与本函数宣称的「只下不上」正好相反 ——
+// 默认关上传的用户所有种子在 add 后 20s 内被打上此 flag，下载速率归零。
+// 现实现：[upload_enabled] 非 0 = 清除 upload_mode（治愈历史 resume 里的残留
+// flag）；0 = **no-op 恒成功**（绝不再置 upload_mode——宁可上传也不能掐死下载；
+// 旧 Dart + 新 DLL 的组合按此降级）。正确原语见 ht_set_unchoke_slots（会话级
+// 停上传）与 ht_pause_torrent（做种停止）。返回 1 成功、0 失败。
 HT_EXPORT int ht_set_upload_mode(void* session, const char* info_hash,
                                  int upload_enabled);
+
+// 会话级 unchoke 槽位（BUG-1293 的「关上传」正确原语）：
+// [slots] >= 0 精确设置 settings_pack::unchoke_slots_limit（0 = 不给任何 peer
+// unchoke 槽位 = 会话级停止上传 payload；我们发出的 piece 请求是协议消息，
+// 不占 unchoke 槽，下载不受影响）；[slots] < 0 恢复 libtorrent 出厂默认。
+// 返回 1 成功、0 失败。
+HT_EXPORT int ht_set_unchoke_slots(void* session, int slots);
+
+// 种子暂停/恢复（做种停止的正确原语；per-torrent 或全量）：
+// [info_hash] 空串/NULL = 对 session 内所有种子生效；否则仅该种子。
+// [pause] 非 0 = 清 auto_managed 再 pause（不清的话队列管理器会自动恢复）；
+// 0 = 恢复 auto_managed 并 resume。返回 1 成功、0 失败（种子不存在）。
+HT_EXPORT int ht_pause_torrent(void* session, const char* info_hash,
+                               int pause);
 
 // 应用内存占用相关 session 设置（把 libtorrent 压进内存预算，避免「有多少内存
 // 吃多少」）：各字段 <=0 时保持 libtorrent 默认，>0 时设置。

--- a/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
+++ b/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
@@ -508,14 +508,41 @@ class EmbeddedTorrentSession {
         1;
   }
 
-  /// 上传模式开关（做种/上传总开关）。[infoHash] 空串 = 对所有种子生效；
-  /// [enabled] false = 停止上传但保持连接与下载（libtorrent upload_mode，
-  /// 「只下不上」的正规做法；限速设 0 是不限而非禁传）。1 成功 0 失败。
+  /// 【已废弃，仅存量兼容】历史上传开关。BUG-1293：libtorrent 的
+  /// `upload_mode` flag 语义是「不再发出 piece 请求」= **停止下载**，与旧
+  /// 注释宣称的「只下不上」正好相反——旧 DLL 的 `enabled: false` 会掐死下载。
+  /// 新代码一律走 [setUnchokeSlots]（会话级停上传）/ [pauseTorrent]（做种停止）；
+  /// 新 DLL 里本函数 `enabled: true` 只清 flag（治愈残留）、false 为 no-op。
   bool setUploadMode({String infoHash = '', required bool enabled}) {
     if (isClosed) return false;
     final Pointer<Char> id = infoHash.toNativeUtf8().cast<Char>();
     try {
       return _b.ht_set_upload_mode(_session, id, enabled ? 1 : 0) == 1;
+    } finally {
+      malloc.free(id);
+    }
+  }
+
+  /// 底层库是否支持上传策略正确原语（[setUnchokeSlots] + [pauseTorrent]）。
+  /// 旧的预编译 DLL 没有这两个符号时为 false，上传策略应整体降级为不动作。
+  bool get supportsUploadControl => _b.hasUploadControl;
+
+  /// 会话级 unchoke 槽位：[slots] >= 0 精确设置（0 = 不给任何 peer unchoke
+  /// 槽位 = 停止上传 payload，下载不受影响——piece 请求是协议消息不占槽）；
+  /// [slots] < 0 恢复 libtorrent 出厂默认。库不支持（老 DLL）返回 false。
+  bool setUnchokeSlots(int slots) {
+    if (isClosed || !_b.hasUploadControl) return false;
+    return _b.ht_set_unchoke_slots(_session, slots) == 1;
+  }
+
+  /// 种子暂停/恢复（做种停止的正确原语）。[infoHash] 空串 = 全量；
+  /// [pause] true = 清 auto_managed 再 pause（否则队列管理器自动恢复）、
+  /// false = 恢复 auto_managed 并 resume。库不支持（老 DLL）返回 false。
+  bool pauseTorrent(String infoHash, {required bool pause}) {
+    if (isClosed || !_b.hasUploadControl) return false;
+    final Pointer<Char> id = infoHash.toNativeUtf8().cast<Char>();
+    try {
+      return _b.ht_pause_torrent(_session, id, pause ? 1 : 0) == 1;
     } finally {
       malloc.free(id);
     }

--- a/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
+++ b/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
@@ -151,8 +151,9 @@ class HibikiTorrentBindings {
     }
   }
 
-  /// 上传模式开关（做种总开关，per-torrent 或全量）。info_hash 空串=全量；
-  /// upload_enabled 非 0=允许上传、0=停止上传但保连接。1 成功 0 失败。
+  /// 【已废弃】历史上传开关（BUG-1293：旧 DLL 把 0 实现成置 upload_mode =
+  /// 停止下载）。新 DLL 里 upload_enabled 非 0 = 清 upload_mode（治愈残留）、
+  /// 0 = no-op。新代码走 [ht_set_unchoke_slots] / [ht_pause_torrent]。
   int ht_set_upload_mode(
     ffi.Pointer<ffi.Void> session,
     ffi.Pointer<ffi.Char> info_hash,
@@ -167,6 +168,64 @@ class HibikiTorrentBindings {
               ffi.Int)>>('ht_set_upload_mode');
   late final _ht_set_upload_mode = _ht_set_upload_modePtr.asFunction<
       int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, int)>();
+
+  /// 会话级 unchoke 槽位（BUG-1293 的「关上传」正确原语）：slots >= 0 精确
+  /// 设置（0 = 停止上传 payload，下载不受影响）；slots < 0 恢复默认。
+  /// 1 成功 0 失败。调用前必须先看 [hasUploadControl]（旧 DLL 无此符号）。
+  int ht_set_unchoke_slots(
+    ffi.Pointer<ffi.Void> session,
+    int slots,
+  ) {
+    return _ht_set_unchoke_slots(session, slots);
+  }
+
+  late final _ht_set_unchoke_slotsPtr = _lookup<
+          ffi.NativeFunction<ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Int)>>(
+      'ht_set_unchoke_slots');
+  late final _ht_set_unchoke_slots = _ht_set_unchoke_slotsPtr
+      .asFunction<int Function(ffi.Pointer<ffi.Void>, int)>();
+
+  /// 种子暂停/恢复（做种停止的正确原语）。info_hash 空串 = 全量；pause 非 0 =
+  /// 清 auto_managed 再 pause、0 = 恢复 auto_managed 并 resume。1 成功 0 失败。
+  /// 调用前必须先看 [hasUploadControl]（旧 DLL 无此符号）。
+  int ht_pause_torrent(
+    ffi.Pointer<ffi.Void> session,
+    ffi.Pointer<ffi.Char> info_hash,
+    int pause,
+  ) {
+    return _ht_pause_torrent(session, info_hash, pause);
+  }
+
+  late final _ht_pause_torrentPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>,
+              ffi.Int)>>('ht_pause_torrent');
+  late final _ht_pause_torrent = _ht_pause_torrentPtr.asFunction<
+      int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, int)>();
+
+  /// 已加载的库里是否同时有 [ht_set_unchoke_slots] 与 [ht_pause_torrent]
+  /// （上传策略两个原语一起用，缺一即整体降级）。
+  ///
+  /// 与 [hasApplyLimitsEx] 同理：随包 DLL 是 vendored 预编译产物，Dart 侧
+  /// 更新了、DLL 没重编的组合真实存在。符号缺失时上传策略降级为「不动
+  /// 任何 flag」——宁可继续上传，也绝不用 upload_mode 掐死下载（BUG-1293）。
+  late final bool hasUploadControl = _probeUploadControl();
+
+  bool _probeUploadControl() {
+    try {
+      _lookup<
+          ffi.NativeFunction<
+              ffi.Int Function(
+                  ffi.Pointer<ffi.Void>, ffi.Int)>>('ht_set_unchoke_slots');
+      _lookup<
+          ffi.NativeFunction<
+              ffi.Int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>,
+                  ffi.Int)>>('ht_pause_torrent');
+      return true;
+    } on ArgumentError {
+      return false;
+    }
+  }
 
   /// 应用内存占用设置（<=0 保持默认）。1 成功 0 失败。
   int ht_apply_memory_settings(

--- a/packages/hibiki_torrent/test/upload_off_download_test.dart
+++ b/packages/hibiki_torrent/test/upload_off_download_test.dart
@@ -1,0 +1,113 @@
+// BUG-1293 行为闭环：「关上传」的正确原语不影响下载。
+//
+// 事故本体：旧实现用 torrent_flags::upload_mode 表达「关上传」，而该 flag 的
+// libtorrent 语义是「不再发出任何 piece 请求」= 停止下载 —— 默认关上传的用户
+// 内置引擎速度恒 ≈ 0。本测试用本地 rig 证明新原语（会话级 unchoke 槽位清零）
+// 下下载仍能从 0 推进到完成；旧语义（置 upload_mode）下本用例必然超时红。
+//
+// 全本地确定性（127.0.0.1 做种、零外网）；缺 DLL 整组 skip。
+
+import 'dart:io';
+
+import 'package:hibiki_torrent/hibiki_torrent.dart';
+import 'package:hibiki_torrent/testing.dart';
+import 'package:test/test.dart';
+
+String? _resolveLibPath() {
+  final String? env = Platform.environment['HIBIKI_TORRENT_LIB'];
+  if (env != null && env.isNotEmpty) {
+    return File(env).existsSync() ? env : null;
+  }
+  return null;
+}
+
+Future<void> _pollUntil(
+  bool Function() done, {
+  required Duration timeout,
+  required String what,
+  void Function()? onTick,
+}) async {
+  final Stopwatch sw = Stopwatch()..start();
+  while (!done()) {
+    if (sw.elapsed > timeout) fail('timeout waiting for $what');
+    onTick?.call();
+    await Future<void>.delayed(const Duration(milliseconds: 100));
+  }
+}
+
+void main() {
+  final String? explicit = _resolveLibPath();
+
+  EmbeddedTorrentEngine? tryOpen() {
+    try {
+      return EmbeddedTorrentEngine.open(libraryPath: explicit);
+    } on ArgumentError {
+      return null;
+    }
+  }
+
+  final EmbeddedTorrentEngine? engine = tryOpen();
+  final String? skip =
+      engine == null ? 'hibiki_torrent_ffi native lib not built' : null;
+
+  late Directory tempDir;
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('ht_upload_off_');
+  });
+
+  tearDown(() {
+    try {
+      tempDir.deleteSync(recursive: true);
+    } on FileSystemException {
+      // Windows 偶发句柄未释放；留给系统临时目录清理。
+    }
+  });
+
+  test(
+    'download completes with unchoke slots pinned to 0 (upload disabled)',
+    () async {
+      final LocalSeedRig rig = await LocalSeedRig.start(
+          engine: engine!, workDir: tempDir, contentBytes: 2 * 1024 * 1024);
+      addTearDown(rig.dispose);
+
+      final EmbeddedTorrentSession? leecher =
+          EmbeddedTorrentSession.open(engine, listenInterfaces: '127.0.0.1:0');
+      expect(leecher, isNotNull);
+      addTearDown(leecher!.close);
+
+      expect(leecher.supportsUploadControl, isTrue,
+          reason: '新构建的 DLL 必须带上传策略原语');
+      // 关上传（BUG-1293 的正确原语）：**下载开始前**就钉死 0 槽位。
+      expect(leecher.setUnchokeSlots(0), isTrue);
+
+      final Directory dlDir = Directory('${tempDir.path}/dl')..createSync();
+      final HtAddResult added =
+          leecher.addMagnet(rig.magnetUri, savePath: dlDir.path);
+      expect(added.ok, isTrue, reason: 'addMagnet: ${added.error}');
+      expect(leecher.connectPeer(rig.infoHash, '127.0.0.1', rig.seederPort),
+          isTrue);
+
+      // 旧语义（upload_mode 置位）下这里永远等不到：leecher 不再发 piece
+      // 请求。新语义（unchoke=0）只停上传 payload，下载照常完成。
+      await _pollUntil(
+        () => leecher
+            .listTorrents()
+            .any((HtTorrentStatus t) => t.id == rig.infoHash && t.isFinished),
+        timeout: const Duration(seconds: 60),
+        what: 'download completion with upload disabled',
+        onTick: () =>
+            leecher.connectPeer(rig.infoHash, '127.0.0.1', rig.seederPort),
+      );
+
+      // 做种停止原语：完成后可 pause（清 auto_managed）与 resume，均成功。
+      expect(leecher.pauseTorrent(rig.infoHash, pause: true), isTrue);
+      expect(leecher.pauseTorrent(rig.infoHash, pause: false), isTrue);
+
+      // 治愈入口：enabled=true 清 upload_mode 残留（幂等、恒成功）。
+      expect(leecher.setUploadMode(enabled: true), isTrue);
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 3)),
+  );
+}


### PR DESCRIPTION
## 用户反馈
- 「内置的速度几乎为 0，不知道为什么，并且没有进度、流量显示」
- 设置页外接 qBittorrent 测试连接一直报「连接失败，请检查地址与账号密码」

## 三个真 bug（一 bug 一文件，docs/bugs/）

### BUG-1262 · 关上传误用 upload_mode 掐死内置引擎下载（速度≈0 的根因）
默认 `uploadEnabled=false` → 策略层给每个种子置 `torrent_flags::upload_mode`，而该 flag 的 libtorrent 语义是「不再发出任何 piece 请求」= **只上不下、停止下载**，与头文件注释宣称的「只下不上」正好相反。种子 add 后一个 tick（20s）内被打上 flag → 下载归零、进度不涨，且随 resume 持久化、重启复发。

修法（native + Dart 同 PR 落地）：
- 新增 `ht_set_unchoke_slots`（会话级 0 槽位 = 停上传 payload，下载不受影响）与 `ht_pause_torrent`（清 auto_managed + pause，做种停止）；
- `ht_set_upload_mode` 改为 enabled=1 只清 flag（治愈残留）、0 为 no-op；`add`/`load_resume` 加载时清残留 flag（治愈已升级用户）；
- `sweepUploadPolicy` 重写：总开关走会话级 unchoke（开启时还原 maxUploadSlots/默认），做种超时/分享率达标走 per-torrent pause，**绝不 pause 未完成种子**；
- 老 DLL 探符号（`hasUploadControl`，沿 `hasApplyLimitsEx` 先例）整体降级为不动作——宁可上传也绝不掐死下载。

### BUG-1263 · 下载任务行无速度/流量显示
native/qb 一直导出 `down_rate/up_rate/downloaded/uploaded/num_peers`，在 `TorrentSnapshot` 投影层被整体丢弃。快照补字段（两后端各自填充）、服务发布 `downloadStats`（值相等去抖）、任务行显示 `37% · ↓ 1.0 MB/s · ↑ 2.0 KB/s · 4.0 KB`（零新增 i18n key）、内置引擎有活跃下载时轮询 20s→3s（qb 保持 20s：每 tick 全新登录，提频会放大 qb 认证失败计数）。

### BUG-1264 · qb 测试连接失败无法自查 + 本机免密被登录门卡死
网络错/账密错（200 `Fails.`）/qb 失败 5 次封 IP（403 banned）/无 SID 全部折叠成同一句「连接失败，请检查地址与账号密码」；且 qb「本地主机免密」下业务接口匿名可用、登录接口仍校验账密，客户端强制先登录 → 可用的 API 被卡死（与已修 BUG-1016 同类）。修：失败原因结构化 `lastFailure` 透传到设置页（新 key `download_test_connection_failed_reason` 带 $message 槽），登录失败后匿名探测回退并缓存（不再反复撞登录门放大封禁计数），403 banned 单独识别。

## 验证
- `flutter analyze` 全量（含 test）No issues found
- 无 DLL 必跑守卫：`upload_policy_dispatch_guard_test.dart`（fromLookup 假绑定断言 C 入参）；**已变异实测**——把 sweep 改回 upload_mode/去掉 unchoke 下发，5 用例红
- 本机 vcpkg 现编新 DLL：`packages/hibiki_torrent` 全量 dart test 23 过（含新 `upload_off_download_test`：unchoke=0 钉死后 2MB 本地 rig 下载 10s 完成——旧语义下必超时）
- `flutter test test/media/torrent test/torrent`（带 DLL 113 过零 skip）、`test/settings test/i18n` 337 过、bugs per-file 守卫过
- FFI 头文件↔绑定 parity 守卫覆盖新符号

## 风险
- 随包预编译 DLL 未重编前（旧 DLL + 新 Dart）：上传开关暂不生效（保持上传），下载正常——发布 workflow 现编 DLL 后自动补齐
- `ht_apply_session_settings` 的 maxUploadSlots 与 unchoke 槽位共用一个 settings 项，应用后由 sweep 重新裁决（缓存失效已处理）

https://claude.ai/code/session_01EajzwAd1c3iMmJBTp2ZhEi