### PR TITLE
fix(gamepad): 手柄 B 完全交回注册表 + 视频页慢路径补焦点回收（BUG-1266）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1201 条。点号进各自文件。
+> 共 1202 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1266](bugs/BUG-1266-gamepad-b-hijacked-by-back.md) | ✅ | ✅ | 手柄 B 被 Android 系统返回兜底抢占，改键无效；视频页首帧就绪前手柄键全失灵 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/bugs/BUG-1266-gamepad-b-hijacked-by-back.md
+++ b/docs/bugs/BUG-1266-gamepad-b-hijacked-by-back.md
@@ -50,7 +50,7 @@ attach，却**没有人再请求一次焦点**。于是焦点整段滞留在页�
 快路径（`load()` 返回即出画）不进 `_promoteVideoReady`，其 contentReady 回收时
 `Video` 已挂载、本就有效，行为不变。
 
-- **[x] ① 已修复** — 提交 `e88c569e0`
+- **[x] ① 已修复** — 提交 `d7b474b40`
   - A：手柄按钮分发 + 注册表 `globalBack` 移出 `focusNavigationEnabled` 门控，
     门控范围收窄到只剩方向键移焦（`global_navigation.dart`）。
   - B：新增 `gamepadBackMustBeSwallowed`，在最外层就地消费**没有任何处理器认领**的

--- a/docs/bugs/BUG-1266-gamepad-b-hijacked-by-back.md
+++ b/docs/bugs/BUG-1266-gamepad-b-hijacked-by-back.md
@@ -1,0 +1,74 @@
+## BUG-1266 · 手柄 B 被 Android 系统返回兜底抢占，改键无效；视频页首帧就绪前手柄键全失灵
+
+- **报告**：2026-07-31（用户：）
+- **真实性**：✅ 真 bug（两个独立根因叠加，症状互相放大）
+
+用户原话：「进视频一开始不论是我映射了上一句的 b 还是下一句的 x 都按了也不会有反应，必须先按一下暂停才能正常上下句」「就算全局里设置了 rb 才是返回键，b 也依旧在起作用」「进视频想先回退两句然后直接回退到手机桌面去了」。阅读器（小说）同源。
+
+### 根因 A：手柄按钮分发被压在默认关闭的实验开关下
+
+`lib/src/shortcuts/global_navigation.dart` 的 `wrapWithGlobalNavigation` 把
+`dispatchNativeGamepadButtonIntent` 与注册表 `globalBack` 解析整块放进
+`if (focusNavigationEnabled)`，而该开关读的是
+`preferences_repository.dart:376` 的 `experimental_focus_navigation_enabled`，
+**默认 `false`**。于是默认安装上注册表 `globalBack` 根本不参与解析。
+
+手柄改键是正式功能（快捷键设置有完整 UI + 默认绑定表 `shortcut_defaults.dart:158`），
+却被挂在一个实验性「方向键/摇杆移焦」开关上——这是错误耦合。
+
+### 根因 B：Android 的 `BUTTON_B → fallback BACK` 是一条绕过注册表的隐形返回路径
+
+Android `Generic.kcm` 为游戏手柄的 `BUTTON_B` 定义了 `fallback BACK`：app 的 view 层
+不消费 `KEYCODE_BUTTON_B` 时，系统**另外合成一个 `KEYCODE_BACK`** 派发下来。
+
+叠加根因 A，默认安装上「B = 返回」实际一直由这条系统兜底提供，而不是 Hibiki 的绑定。
+所以用户把「返回」改绑到 RB 之后，B 依旧退出页面——改键在 B 上从来就是假的。
+
+对照可验证该边界只在 B：`BUTTON_A` 的兜底是 `DPAD_CENTER`（确认焦点控件，有益，保留），
+X/Y/LB/RB/扳机/Start/Select 在 `Generic.kcm` 里没有 fallback，D-pad 也没有。
+
+### 根因 C：视频页慢路径挂载 `Video` 后没有补焦点回收
+
+`_videoFocusNode` 挂在 `Video` 上（`video_hibiki/layout.part.dart:69`），而
+`_buildScaffold`（`video_hibiki_page.dart:5961-5964`）用 `!_videoReadyToShow` 把
+**首帧未就绪的首开**挡在 `_buildLoadingBody` 分支——此刻 `Video` 尚未挂载、节点未
+attach 到焦点树。`_applyLoad` 结尾那次
+`_focusOwnership.reclaimAfterFrame(FocusReclaimCause.contentReady)`
+（`video_hibiki_page.dart:2822`）正落在这个窗口里，对孤儿节点 `requestFocus()` 是
+**静默 no-op**（请求丢失，无任何报错）。
+
+随后 `_promoteVideoReady()`（`video_hibiki_page.dart:1826`）把 `Video` 挂上、节点终于
+attach，却**没有人再请求一次焦点**。于是焦点整段滞留在页面之外：
+
+- 手柄按键不冒泡经过 `_wrapVideoGamepadControls`，本页全部手柄绑定失灵
+  → 「B（上一句）/ X（下一句）按了没反应」；
+- 这段窗口里 B 没人消费 → 触发根因 B 的系统兜底 → 直接退页
+  → 「想回退两句，结果一路退回桌面」；
+- 用户点一下画面（暂停）触发 `FocusReclaimCause.gesture` 回收后一切正常
+  → 「必须先按一下暂停才能正常上下句」。
+
+快路径（`load()` 返回即出画）不进 `_promoteVideoReady`，其 contentReady 回收时
+`Video` 已挂载、本就有效，行为不变。
+
+- **[x] ① 已修复** — 提交 `e88c569e0`
+  - A：手柄按钮分发 + 注册表 `globalBack` 移出 `focusNavigationEnabled` 门控，
+    门控范围收窄到只剩方向键移焦（`global_navigation.dart`）。
+  - B：新增 `gamepadBackMustBeSwallowed`，在最外层就地消费**没有任何处理器认领**的
+    手柄 B（DOWN/UP/REPEAT 三个边沿都消费——Android 的返回动作发生在 ACTION_UP，
+    只吞按下边沿等于没修）。只吞 B，A / D-pad / 其余键原样放行。
+  - C：`_promoteVideoReady()` 补一次
+    `_focusOwnership.reclaimAfterFrame(FocusReclaimCause.contentReady)`。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/shortcuts/gamepad_back_not_gated_test.dart`（新增，9 例）：
+    焦点导航关闭时 B 仍按注册表返回 / 改绑 RB 后 RB 返回且 B 绝不返回 /
+    未绑定的 B 被就地消费 / 吞键边界（B 三边沿吞，A、手柄 D-pad 三种来源、
+    键盘键、其余手柄键均不吞）。
+  - `hibiki/test/pages/video_page_keyboard_focus_static_test.dart`（+1 例）：
+    `_promoteVideoReady` 方法体必须补 contentReady 回收。
+  - 三个变异实测均精确命中：删吞键调用 → 只有「未绑定的 B 被就地消费」红；
+    把 globalBack 解析放回门控 → 根因 A 两例红；删真实回收调用但**保留注释**
+    → 视频守卫红（证明守卫读的是代码不是注释）。
+- **备注**：本轮取消真机验证（无设备）。判绿依据为 `flutter analyze` 全量 +
+  `flutter_test_failures.dart` 全量 VERDICT。与 Windows 侧「国产手柄方向键以 HID 键盘
+  身份到达、`deviceType` 在非 Android 恒为 keyboard 故永不被识别为 D-pad」是**另一个**
+  独立问题，未在本 BUG 内处理。

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -1835,6 +1835,23 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     _controller?.removeListener(_promoteVideoReadyOnFirstFrame);
     if (!mounted) return;
     setState(() => _videoReadyToShow = true);
+    // BUG-1266：慢路径必须在这里**补一次**焦点回收，否则本页整段时间都没有键盘所有者。
+    //
+    // [_videoFocusNode] 挂在 [Video] 上（`layout.part.dart`），而 [_buildScaffold] 用
+    // `!_videoReadyToShow` 把首帧未就绪的首开挡在 [_buildLoadingBody] 分支——此刻
+    // [Video] 尚未挂载，节点还没 attach 到焦点树。`_openVideo` 结尾那次
+    // `reclaimAfterFrame(contentReady)` 正好落在这个窗口里，对孤儿节点
+    // `requestFocus()` 是**静默 no-op**（请求直接丢失，无任何报错）。等这里把
+    // [Video] 挂上、节点终于 attach 时，却没有人再请求一次焦点，于是焦点滞留在
+    // 页面之外：手柄按键不冒泡经过 [_wrapVideoGamepadControls]，本页所有手柄绑定
+    // （上一句/下一句/播放暂停…）全部失灵，直到用户随便点一下画面触发
+    // [FocusReclaimCause.gesture] 才恢复——正是用户报的「必须先按一下暂停才能
+    // 正常上下句」。更糟的是这段窗口里手柄 B 没人消费，会被 Android 合成成 BACK
+    // 直接退页（见 [_swallowUnboundGamepadBack]）。
+    //
+    // 快路径（load 返回即出画）不进本方法，其 contentReady 那次回收时 [Video] 已挂载、
+    // 本就有效，行为不变。
+    _focusOwnership.reclaimAfterFrame(FocusReclaimCause.contentReady);
     // BUG-839：慢路径就绪后触发「换集保持全屏」的重进全屏（仅 initialFullscreen 新页生效）。
     _scheduleInitialFullscreenIfNeeded();
   }

--- a/hibiki/lib/src/shortcuts/global_navigation.dart
+++ b/hibiki/lib/src/shortcuts/global_navigation.dart
@@ -99,8 +99,10 @@ KeyEventResult _handleGlobalEscape(
 ///    a bound page-turn / seek shortcut. The home page handles its own arrows and
 ///    consumes them before they reach here; this catches every other managed
 ///    page (settings, dialogs, reader chrome) uniformly. Disabled entirely when
-///    [focusNavigationEnabled] is off (the whole arrow/gamepad block is gated by
-///    the caller), so the default build is unchanged.
+///    [focusNavigationEnabled] is off, so the default build is unchanged.
+///    BUG-1266：门控范围已收窄到**只剩方向键移焦这一件事**——同一个 `if` 里原本还
+///    压着手柄按钮分发与注册表 globalBack，它们与「实验性焦点导航」无关，现已移到
+///    门控之外常驻生效。
 KeyEventResult _handleGlobalArrowFocus(
   GlobalKey<NavigatorState> navigatorKey,
   KeyEvent event,
@@ -213,6 +215,32 @@ KeyEventResult _handleGlobalBack(
   nav.maybePop();
   return KeyEventResult.handled;
 }
+
+/// BUG-1266：吞掉**没有任何处理器认领**的手柄 B，阻断 Android 的系统级按键兜底。
+///
+/// Android 的 `Generic.kcm` 为游戏手柄的 `BUTTON_B` 定义了 `fallback BACK`：当 app
+/// 的 view 层不消费 `KEYCODE_BUTTON_B` 时，系统会**另外合成一个 `KEYCODE_BACK`** 派发
+/// 下来。那条兜底路径完全绕过 Hibiki 的快捷键注册表，于是：
+///   * 用户把「返回」改绑到 RB 后，B 仍然退出页面（改键在 B 上根本是假的）；
+///   * 页面尚未拿到键盘焦点时（如视频页首帧未就绪），B 连页面自己的绑定都还没轮到，
+///     就被系统直接判成返回——用户「进视频想回退两句，结果一路退回桌面」正是它。
+/// 把 B 在最外层就地消费，等于把「B 是不是返回键」的决定权完整交回注册表：绑了
+/// globalBack 就在上面的 [_handleGlobalBack] 里 pop（默认绑定，行为不变），改绑走了
+/// 就静默无操作，绝不再有第二条隐形返回路径。
+///
+/// 只针对 B，不扩大到别的手柄键，因为只有它有 BACK 兜底：
+///   * `BUTTON_A` 的兜底是 `DPAD_CENTER`（= 确认焦点控件），是有益能力，保留；
+///   * D-pad 无按键兜底，且仍需放行给方向焦点移动，绝不能在此吞掉；
+///   * X/Y/LB/RB/扳机/Start/Select 在 `Generic.kcm` 里没有 fallback，吞不吞等价。
+///
+/// DOWN / UP / REPEAT 三个边沿都要消费：Android 的返回动作实际发生在 **ACTION_UP**，
+/// 只吞按下边沿会让抬起边沿照样合成出 BACK，等于没修。
+///
+/// 判据独立成可单测的纯函数，让「吞哪些键」这条边界有直接断言，而不是只能从
+/// widget 行为反推。
+@visibleForTesting
+bool gamepadBackMustBeSwallowed(KeyEvent event) =>
+    GamepadButton.fromKeyEvent(event) == GamepadButton.b;
 
 /// Desktop window-level fullscreen toggle for the remappable
 /// [ShortcutAction.globalToggleFullscreen] key (TODO-1093). Distinct from the
@@ -331,8 +359,11 @@ Future<void> _toggleWindowFullscreen() async {
 ///   framework's own Escape handling.
 /// * The gamepad B button triggers a global back/dismiss.
 /// * [focusNavigationEnabled] 为实验性「键盘/手柄焦点导航」总开关（默认关闭，见
-///   AppModel.experimentalFocusNavigationEnabled）。它控制手柄按钮分发、方向键
-///   移焦、手柄 B 返回；关闭时这些一律不挂。**关闭时还把 Tab / Shift+Tab 中和成
+///   AppModel.experimentalFocusNavigationEnabled）。它只控制**方向键/摇杆移焦**这
+///   套实验性焦点导航；**手柄按钮分发与注册表 globalBack 不再受它门控**（BUG-1266）：
+///   手柄改键是正式功能（快捷键设置里有完整 UI 与默认绑定表），把它挂在一个默认关闭
+///   的实验开关上，等于在默认安装上「配了手柄绑定却永不解析」。**关闭时还把
+///   Tab / Shift+Tab 中和成
 ///   [DoNothingIntent]**，停掉 Flutter [WidgetsApp] 内建的 Tab 焦点遍历——用户裁定
 ///   没开焦点导航时按 Tab 不该有动作（TODO-112）。开启时不中和，原生 Tab 遍历照常。
 ///   与焦点导航无关、始终生效的两件事不受其影响：
@@ -377,20 +408,26 @@ Widget wrapWithGlobalNavigation({
       if (_neutralizeBareSpace(event) == KeyEventResult.handled) {
         return KeyEventResult.handled;
       }
+      // BUG-1266：手柄按钮分发**不受** [focusNavigationEnabled] 门控。该开关默认
+      // 关闭，此前把整块手柄逻辑一起关掉，导致默认安装上「注册表 globalBack」根本
+      // 不参与解析——Android 上按 B 之所以还能返回，靠的是系统兜底（见下），于是
+      // 用户把「返回」改绑到 RB 后 B 依旧退出页面。
+      final KeyEventResult gamepadResult =
+          dispatchNativeGamepadButtonIntent(event);
+      if (gamepadResult == KeyEventResult.handled) return gamepadResult;
       if (focusNavigationEnabled) {
-        final KeyEventResult gamepadResult =
-            dispatchNativeGamepadButtonIntent(event);
-        if (gamepadResult == KeyEventResult.handled) return gamepadResult;
         final KeyEventResult arrowResult =
             _handleGlobalArrowFocus(navigatorKey, event);
         if (arrowResult == KeyEventResult.handled) return arrowResult;
-        // TODO-700 T1：注册表驱动的全局返回回退（B 或用户改键后的「返回」键）。仅
-        // 对未自解析 globalBack 的页面（设置/对话框）生效；home/reader 已在更近的
-        // 处理器消费。registry 为空（测试 / 未注入）时跳过，回退到 Escape。
-        if (registry != null) {
-          final KeyEventResult backResult =
-              _handleGlobalBack(navigatorKey, registry, event);
-          if (backResult == KeyEventResult.handled) return backResult;
+      }
+      // TODO-700 T1：注册表驱动的全局返回回退（B 或用户改键后的「返回」键）。仅
+      // 对未自解析 globalBack 的页面（设置/对话框）生效；home/reader 已在更近的
+      // 处理器消费。registry 为空（测试 / 未注入）时跳过，回退到 Escape。
+      if (registry != null) {
+        final KeyEventResult backResult =
+            _handleGlobalBack(navigatorKey, registry, event);
+        if (backResult == KeyEventResult.handled) return backResult;
+        if (focusNavigationEnabled) {
           // TODO-1093：注册表驱动的窗口级全屏切换（默认 F11）。放在 globalBack 之后、
           // Escape 之前；仅桌面有窗口时真正 toggle，移动端 no-op（见下）。
           final KeyEventResult fullscreenResult =
@@ -400,6 +437,9 @@ Widget wrapWithGlobalNavigation({
           }
         }
       }
+      // BUG-1266：走到这里说明**没有任何**处理器认领这次手柄按键。对手柄 B 必须
+      // 就地消费，绝不能放行——见 [gamepadBackMustBeSwallowed] 的完整理由。
+      if (gamepadBackMustBeSwallowed(event)) return KeyEventResult.handled;
       return _handleGlobalEscape(navigatorKey, event);
     },
     child: Shortcuts(

--- a/hibiki/test/pages/video_page_keyboard_focus_static_test.dart
+++ b/hibiki/test/pages/video_page_keyboard_focus_static_test.dart
@@ -47,6 +47,27 @@ void main() {
         reason: '非全屏进入视频页后若没有主动聚焦，空格会冒泡到全局 DoNothingIntent 而不是播放/暂停');
   });
 
+  test('慢路径挂载 Video 后必须补一次焦点回收（BUG-1266）', () {
+    // 根因：[_videoFocusNode] 挂在 [Video] 上，而首帧未就绪的首开被 `!_videoReadyToShow`
+    // 挡在 `_buildLoadingBody` 分支——此刻 Video 尚未挂载、节点未 attach，`_applyLoad`
+    // 结尾那次 contentReady 回收对孤儿节点是静默 no-op（请求直接丢失）。若
+    // [_promoteVideoReady] 把 Video 挂上后不补一次回收，焦点会整段滞留在页面之外：
+    // 手柄按键不冒泡经过本页，所有手柄绑定失灵，且没人消费的 B 会被 Android 合成成
+    // BACK 直接退页（用户报「必须先按一下暂停才能正常上下句」「进视频想回退两句却退回桌面」）。
+    final int start = src.indexOf('void _promoteVideoReady() {');
+    expect(start, greaterThanOrEqualTo(0),
+        reason: '慢路径提升汇聚点 _promoteVideoReady 应存在');
+    final int end = src.indexOf('Future<void> _init() async {', start);
+    expect(end, greaterThan(start));
+    final String body = src.substring(start, end);
+
+    expect(
+        body,
+        contains(
+            '_focusOwnership.reclaimAfterFrame(FocusReclaimCause.contentReady)'),
+        reason: '慢路径把 Video 挂上后必须补一次焦点回收，否则本页整段没有键盘所有者');
+  });
+
   test('存在统一的焦点所有者与判据', () {
     expect(src, contains('PageFocusOwnership _focusOwnership'),
         reason: '归还焦点必须走单一所有者 _focusOwnership，不再各处手写 requestFocus');

--- a/hibiki/test/shortcuts/gamepad_back_not_gated_test.dart
+++ b/hibiki/test/shortcuts/gamepad_back_not_gated_test.dart
@@ -1,0 +1,228 @@
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/shortcuts/global_navigation.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
+
+/// BUG-1266 回归：手柄「返回」必须完全由快捷键注册表决定。
+///
+/// 两个根因各一组断言：
+///  1. 手柄按钮分发曾整块压在 [wrapWithGlobalNavigation] 的 `focusNavigationEnabled`
+///     门控里，而该开关（experimental_focus_navigation_enabled）**默认关闭**——于是
+///     默认安装上注册表 globalBack 根本不参与解析。
+///  2. 没人认领的手柄 B 会被 Android 的 `Generic.kcm`（`BUTTON_B` → `fallback BACK`）
+///     合成成一个 KEYCODE_BACK，绕过注册表直接退页；用户把「返回」改绑到 RB 后 B
+///     依旧返回，正是这条系统兜底路径。
+void main() {
+  KeyDownEvent keyDown(
+    LogicalKeyboardKey key, [
+    ui.KeyEventDeviceType deviceType = ui.KeyEventDeviceType.keyboard,
+  ]) =>
+      KeyDownEvent(
+        physicalKey: const PhysicalKeyboardKey(0),
+        logicalKey: key,
+        timeStamp: Duration.zero,
+        deviceType: deviceType,
+      );
+
+  KeyUpEvent keyUp(LogicalKeyboardKey key) => KeyUpEvent(
+        physicalKey: const PhysicalKeyboardKey(0),
+        logicalKey: key,
+        timeStamp: Duration.zero,
+      );
+
+  HibikiShortcutRegistry registryWithBackOn(GamepadButton button) {
+    final HibikiShortcutRegistry registry = HibikiShortcutRegistry()
+      ..loadDefaults(TargetPlatform.android)
+      ..updateBinding(
+        ShortcutAction.globalBack,
+        ShortcutBindingSet(
+          gamepadBindings: <GamepadBinding>[GamepadBinding(button)],
+        ),
+      );
+    return registry;
+  }
+
+  /// 建一棵「首页 + 已 push 的第二页」，全局导航层按 [focusNavigationEnabled] 挂载。
+  Future<GlobalKey<NavigatorState>> pumpTwoRoutes(
+    WidgetTester tester, {
+    required HibikiShortcutRegistry registry,
+    required bool focusNavigationEnabled,
+  }) async {
+    final GlobalKey<NavigatorState> navKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(MaterialApp(
+      navigatorKey: navKey,
+      home: const Scaffold(body: Text('home')),
+      builder: (BuildContext context, Widget? child) =>
+          wrapWithGlobalNavigation(
+        navigatorKey: navKey,
+        registry: registry,
+        focusNavigationEnabled: focusNavigationEnabled,
+        child: child!,
+      ),
+    ));
+    navKey.currentState!.push(MaterialPageRoute<void>(
+      builder: (_) => const Scaffold(body: Text('second')),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.text('second'), findsOneWidget);
+    return navKey;
+  }
+
+  group('根因1：手柄绑定不再被实验性焦点导航开关吞掉', () {
+    testWidgets('焦点导航关闭（默认安装）时，B 绑 globalBack 仍能返回',
+        (WidgetTester tester) async {
+      await pumpTwoRoutes(
+        tester,
+        registry: registryWithBackOn(GamepadButton.b),
+        focusNavigationEnabled: false,
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.gameButtonB);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('second'),
+        findsNothing,
+        reason: '默认安装（焦点导航关闭）下 B 也必须经注册表 globalBack 返回',
+      );
+      expect(find.text('home'), findsOneWidget);
+    });
+
+    testWidgets('焦点导航关闭时，改绑到 RB 后按 RB 返回', (WidgetTester tester) async {
+      await pumpTwoRoutes(
+        tester,
+        registry: registryWithBackOn(GamepadButton.rb),
+        focusNavigationEnabled: false,
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.gameButtonRight1);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('second'),
+        findsNothing,
+        reason: '用户把「返回」改绑到 RB，RB 就该返回',
+      );
+    });
+  });
+
+  group('根因2：改绑走的 B 不再有第二条隐形返回路径', () {
+    testWidgets('返回改绑 RB 后，按 B 绝不返回', (WidgetTester tester) async {
+      await pumpTwoRoutes(
+        tester,
+        registry: registryWithBackOn(GamepadButton.rb),
+        focusNavigationEnabled: false,
+      );
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.gameButtonB);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('second'),
+        findsOneWidget,
+        reason: 'B 已不是返回键，按它必须留在当前页',
+      );
+    });
+
+    testWidgets('未绑定的 B 被就地消费（不放行给 Android 的 BACK 兜底）',
+        (WidgetTester tester) async {
+      await pumpTwoRoutes(
+        tester,
+        registry: registryWithBackOn(GamepadButton.rb),
+        focusNavigationEnabled: false,
+      );
+
+      final bool handled =
+          await tester.sendKeyEvent(LogicalKeyboardKey.gameButtonB);
+
+      expect(
+        handled,
+        isTrue,
+        reason: 'B 未被任何处理器认领时必须由全局层吞掉，'
+            '否则 Android 会合成 KEYCODE_BACK 绕过注册表退页',
+      );
+    });
+  });
+
+  group('吞键边界：只吞 B，其余通道原样放行', () {
+    test('B 的三个边沿都吞（返回动作发生在抬起边沿，只吞按下等于没修）', () {
+      expect(
+        gamepadBackMustBeSwallowed(keyDown(LogicalKeyboardKey.gameButtonB)),
+        isTrue,
+      );
+      expect(
+        gamepadBackMustBeSwallowed(keyUp(LogicalKeyboardKey.gameButtonB)),
+        isTrue,
+        reason: 'Android 的返回发生在 ACTION_UP，抬起边沿放行会照样合成出 BACK',
+      );
+      expect(
+        gamepadBackMustBeSwallowed(
+          KeyRepeatEvent(
+            physicalKey: const PhysicalKeyboardKey(0),
+            logicalKey: LogicalKeyboardKey.gameButtonB,
+            timeStamp: Duration.zero,
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('A 不吞：它的系统兜底是 DPAD_CENTER（确认焦点控件），是有益能力', () {
+      expect(
+        gamepadBackMustBeSwallowed(keyDown(LogicalKeyboardKey.gameButtonA)),
+        isFalse,
+      );
+    });
+
+    test('手柄来源的 D-pad 不吞：仍须放行给方向焦点移动', () {
+      for (final ui.KeyEventDeviceType source in <ui.KeyEventDeviceType>[
+        ui.KeyEventDeviceType.gamepad,
+        ui.KeyEventDeviceType.directionalPad,
+        ui.KeyEventDeviceType.joystick,
+      ]) {
+        for (final LogicalKeyboardKey arrow in <LogicalKeyboardKey>[
+          LogicalKeyboardKey.arrowUp,
+          LogicalKeyboardKey.arrowDown,
+          LogicalKeyboardKey.arrowLeft,
+          LogicalKeyboardKey.arrowRight,
+        ]) {
+          expect(
+            gamepadBackMustBeSwallowed(keyDown(arrow, source)),
+            isFalse,
+            reason: '$source 的 $arrow 被吞会废掉手柄方向键移焦',
+          );
+        }
+      }
+    });
+
+    test('键盘键一律不吞（含方向键与 Escape）', () {
+      for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+        LogicalKeyboardKey.arrowUp,
+        LogicalKeyboardKey.arrowLeft,
+        LogicalKeyboardKey.escape,
+        LogicalKeyboardKey.space,
+        LogicalKeyboardKey.keyB,
+      ]) {
+        expect(gamepadBackMustBeSwallowed(keyDown(key)), isFalse);
+      }
+    });
+
+    test('其它手柄键不吞（Generic.kcm 里它们没有 BACK 兜底）', () {
+      for (final LogicalKeyboardKey key in <LogicalKeyboardKey>[
+        LogicalKeyboardKey.gameButtonX,
+        LogicalKeyboardKey.gameButtonY,
+        LogicalKeyboardKey.gameButtonLeft1,
+        LogicalKeyboardKey.gameButtonRight1,
+        LogicalKeyboardKey.gameButtonStart,
+        LogicalKeyboardKey.gameButtonSelect,
+      ]) {
+        expect(gamepadBackMustBeSwallowed(keyDown(key)), isFalse);
+      }
+    });
+  });
+}


### PR DESCRIPTION
用户报告（Android，手柄）：

> 进视频一开始不论是我映射了上一句的 b 还是下一句的 x 都按了也不会有反应，必须先按一下暂停才能正常上下句
> 就算全局里设置了 rb 才是返回键，b 也依旧在起作用
> 进视频想先回退两句然后直接回退到手机桌面去了

三个叠加根因，症状互相放大。

## 根因 A：手柄按钮分发被压在默认关闭的实验开关下

`wrapWithGlobalNavigation` 把 `dispatchNativeGamepadButtonIntent` 与注册表 `globalBack` 解析整块放进 `if (focusNavigationEnabled)`，而该开关读的 `experimental_focus_navigation_enabled` **默认 `false`**（`preferences_repository.dart:376`）。默认安装上注册表 `globalBack` 根本不参与解析。

手柄改键是正式功能（快捷键设置有完整 UI + 默认绑定表），却被挂在实验性「方向键/摇杆移焦」开关上 —— 错误耦合。**修复**：手柄分发与 globalBack 移出门控，门控范围收窄到只剩方向键移焦。

## 根因 B：`BUTTON_B → fallback BACK` 是绕过注册表的隐形返回路径

Android `Generic.kcm` 为手柄 `BUTTON_B` 定义了 `fallback BACK`：app 不消费该键时系统**另外合成一个 `KEYCODE_BACK`**。叠加根因 A，默认安装上「B = 返回」一直由这条系统兜底提供，而非 Hibiki 的绑定 —— 所以改绑 RB 后 B 依旧返回，**改键在 B 上从来就是假的**。

**修复**：新增 `gamepadBackMustBeSwallowed`，在最外层就地消费无人认领的 B。DOWN/UP/REPEAT 三个边沿都消费（Android 的返回动作发生在 ACTION_UP，只吞按下等于没修）。

边界只在 B：`BUTTON_A` 的兜底是 `DPAD_CENTER`（确认焦点控件，有益，保留）；D-pad 需放行给焦点移动；X/Y/LB/RB/扳机/Start/Select 无 fallback。

## 根因 C：视频页慢路径挂载 Video 后没有补焦点回收

`_videoFocusNode` 挂在 `Video` 上，而首帧未就绪的首开被 `!_videoReadyToShow` 挡在 `_buildLoadingBody` 分支 —— 此刻 `Video` 未挂载、节点未 attach，`_applyLoad` 结尾那次 `reclaimAfterFrame(contentReady)` 对孤儿节点是**静默 no-op**。随后 `_promoteVideoReady()` 挂上 `Video`，却没人再请求一次焦点，焦点整段滞留页面之外：

- 手柄键不冒泡经过本页 → B/X 全无反应；
- 无人消费的 B 触发根因 B → 一路退回桌面；
- 点一下画面触发 `gesture` 回收后恢复 → 「必须先按一下暂停」。

快路径不进此方法，行为不变。

## 测试

- 新增 `hibiki/test/shortcuts/gamepad_back_not_gated_test.dart`（9 例）：门控解耦、改绑 RB 后 RB 返回且 B 绝不返回、未绑定 B 被就地消费、吞键边界（B 三边沿吞；A、三种来源的 D-pad、键盘键、其余手柄键均不吞）。
- `hibiki/test/pages/video_page_keyboard_focus_static_test.dart` +1 例。
- **三个变异实测均精确命中**：删吞键调用 → 只有「未绑定的 B 被就地消费」红；把 globalBack 放回门控 → 根因 A 两例红；删真实回收调用但**保留注释** → 视频守卫红（证明守卫读代码不读注释）。

## 验证

- `flutter analyze` 全量：`No issues found`
- 定向套件：`FLUTTER TEST VERDICT: PASSED - 524 tests ran`
- 本轮无真机验证（用户无设备）。

## 未在本 PR 处理

Windows 侧另一个独立问题：国产手柄方向键以 HID 键盘身份到达，而 Flutter 的 `KeyEvent.deviceType` 只有 Android 会填（非 Android 恒为 `keyboard`），故 `GamepadButton.fromKeyEvent` 在桌面永不把方向键识别为 D-pad。

https://claude.ai/code/session_01JFMn9EhnGzpX4WDk1Ji17z