### PR TITLE
fix(anki): 词典外字取不到字节时降级而非中止整次制卡 (BUG-1265)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1201 条。点号进各自文件。
+> 共 1202 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1265](bugs/BUG-1265-anki-gaiji-cache-miss-aborts-mine.md) | ✅ | ✅ | AnkiConnect 制卡：词典外字缓存缺失导致整张卡建不出来 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/bugs/BUG-1265-anki-gaiji-cache-miss-aborts-mine.md
+++ b/docs/bugs/BUG-1265-anki-gaiji-cache-miss-aborts-mine.md
@@ -1,0 +1,31 @@
+## BUG-1265 · AnkiConnect 制卡：词典外字缓存缺失导致整张卡建不出来
+- **报告**：2026-07-31（用户：报错日志 `2026-07-30 23:29:45` `Anki.mineEntry`）
+- **真实性**：✅ 真 bug。根因两层：
+  - **① 读取方硬失败（真正杀掉整张卡的）**：`packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart:1635`（修前）在缓存文件缺失时 `throw FileSystemException`，经 `_renderMinedFields` 的 `Future.wait` 抛穿 `mineEntry`，整次制卡失败、`addNote` 从未被调用。
+    但共享契约 `BaseAnkiRepository.buildDictionaryMediaTags`（`packages/hibiki_anki/lib/src/base_anki_repository.dart:386`）收的是 `Future<String?>`——**返回 null = 跳过这条媒体**；AnkiDroid `packages/hibiki_anki/lib/src/ankidroid/anki_repository.dart:704`（`if (!file.existsSync()) return null;`）与 AnkiMobile `hibiki/lib/src/anki/ankimobile_repository.dart:449` 一直是优雅降级。只有 AnkiConnect 破契约。
+    回溯：commit `35e8c96b5 fix(anki): require media before adding cards` 把封面/句子音频的「缺媒体就别建卡」策略**误扫**到了装饰性的词典外字上（同一个 commit 把 `return null` 改成了 `throw`）。
+  - **② 写入方静默跳过（为什么缓存里会没有这个文件）**：`hibiki/lib/src/pages/implementations/dictionary_webview_media.dart:29` 的 `writeDictionaryMediaCache` 按设计尽力而为——`HoshiDicts` 未初始化、`getMediaFile` 取不到字节（分卷 MDD 未挂载 / 词典里本就没这个资源 / 词典删除重导）、写盘失败，三条路径全部静默跳过（前两条连 `debugPrint` 都没有），文档写明契约是「该条媒体退回 alt 文本，不阻断制卡」。
+    于是「缓存里没有这个文件」在用户上传的日志里毫无前因，只剩下游一句 `Dictionary media file is missing`。
+
+  用户侧栈（Windows / AnkiConnect / 视频页沉浸制卡）：
+  ```
+  Anki.mineEntry  FileSystemException: Dictionary media file is missing,
+    path = 'C:\Users\…\Temp/anki-media/hibiki_dict_aea8ccb2….svg'
+  #0 AnkiConnectRepository._storeDictionaryMedia (…:1635)
+  #1 AnkiConnectRepository._renderMinedFields.<anonymous closure> (…:795)
+  #2 BaseAnkiRepository.buildDictionaryMediaTags (…:386)
+  #4 AnkiConnectRepository._renderMinedFields (…:799)
+  #5 AnkiConnectRepository._mineEntryInner (…:662)
+  #7 ImmersionMiningEngine._mineNow (…:296)
+  ```
+
+- **[x] ① 已修复** — commit 见下。两处：
+  - `ankiconnect_repository.dart` `_storeDictionaryMedia` 改回 `Future<String?>`，缺失时带上下文 `debugPrint` 后 `return null`，与另两个 backend 同契约。封面/句子音频仍由 `_storeLocalMedia` 抛异常拦住（缺了卡片没价值），**两套策略故意不同，不要再合并**。
+  - `dictionary_webview_media.dart` 的三条跳过路径全部改为带原因留痕（`debugPrint` + `ErrorLogService.log('DictionaryMedia.cache', …)`），下次用户报错时能直接判断是「词典取不到字节」还是「根本没走到写入方」。另把 `HoshiDicts.isInitialized` 判断挪到「确实有媒体要写」之后，无媒体时不产生噪音日志。
+- **[x] ② 已加自动化测试** — `packages/hibiki_anki/test/dictionary_media_missing_degrades_test.dart`（3 条，走完整 `mineEntry` 落卡链）：
+  1. 缓存缺失 → `MineResult.success` + `addNote` 真被调用 + 占位符保持原样（降级）+ 封面照常上传；
+  2. 混排（一条有缓存 / 一条没有）→ 有的正常替换成 `hibiki_dict_<sha1>.svg`，没有的单独降级，不拖累邻居；
+  3. 对比组：封面缺失**仍然** `MineResult.error`，锁死两套策略的差异。
+
+  变异实测：把 `return null` 改回 `throw FileSystemException` 后，第 1、2 条立刻转红（`Expected: MineResult.success / Actual: MineResult.error`），第 3 条保持绿——测试确实咬住了根因，不是假绿。
+- **备注**：降级后卡片里留的是未替换的 `<img src="hoshi_dict_N.ext">` 占位符（等价于 alt 文本），与 AnkiDroid/AnkiMobile 行为一致，属既有契约。若要进一步把无法解析的占位符从字段里剥掉，是**三个 backend 共同**的独立改动，不在本 bug 范围内。

--- a/docs/bugs/BUG-1265-anki-gaiji-cache-miss-aborts-mine.md
+++ b/docs/bugs/BUG-1265-anki-gaiji-cache-miss-aborts-mine.md
@@ -19,7 +19,7 @@
   #7 ImmersionMiningEngine._mineNow (…:296)
   ```
 
-- **[x] ① 已修复** — commit 见下。两处：
+- **[x] ① 已修复** — commit `30dc387e5`。两处：
   - `ankiconnect_repository.dart` `_storeDictionaryMedia` 改回 `Future<String?>`，缺失时带上下文 `debugPrint` 后 `return null`，与另两个 backend 同契约。封面/句子音频仍由 `_storeLocalMedia` 抛异常拦住（缺了卡片没价值），**两套策略故意不同，不要再合并**。
   - `dictionary_webview_media.dart` 的三条跳过路径全部改为带原因留痕（`debugPrint` + `ErrorLogService.log('DictionaryMedia.cache', …)`），下次用户报错时能直接判断是「词典取不到字节」还是「根本没走到写入方」。另把 `HoshiDicts.isInitialized` 判断挪到「确实有媒体要写」之后，无媒体时不产生噪音日志。
 - **[x] ② 已加自动化测试** — `packages/hibiki_anki/test/dictionary_media_missing_degrades_test.dart`（3 条，走完整 `mineEntry` 落卡链）：
@@ -29,3 +29,4 @@
 
   变异实测：把 `return null` 改回 `throw FileSystemException` 后，第 1、2 条立刻转红（`Expected: MineResult.success / Actual: MineResult.error`），第 3 条保持绿——测试确实咬住了根因，不是假绿。
 - **备注**：降级后卡片里留的是未替换的 `<img src="hoshi_dict_N.ext">` 占位符（等价于 alt 文本），与 AnkiDroid/AnkiMobile 行为一致，属既有契约。若要进一步把无法解析的占位符从字段里剥掉，是**三个 backend 共同**的独立改动，不在本 bug 范围内。
+- **验证**：`flutter analyze`（hibiki + hibiki_anki）均 No issues found；`packages/hibiki_anki` 282 条、`hibiki/test/anki` 187 条全绿；全量套件 18469 条执行、13 条失败，其中 11 条在把两个 lib 文件还原到基底 `72a3b942a` 后**同样红**（既有红，与本改动无关，且这 13 个测试文件均不引用本次改动的任何符号），另 2 条（`local_audio_manager_test` / `home_video_remote_download_register_test`）带本修复孤立复跑 21 条全过，属全量下的串扰。

--- a/hibiki/lib/src/pages/implementations/dictionary_webview_media.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_webview_media.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:hibiki/src/dictionary/dictionary_media_types.dart';
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:hibiki_dictionary/hibiki_dictionary.dart';
 
@@ -24,23 +25,38 @@ const List<String> dictionaryMediaCustomSchemes = <String>[
 /// 读不到、外字退化成 alt 文本（明鏡义项序号显示成烂 alt「3分の2」）。本函数补上写缓存
 /// 这一环：用 [HoshiDicts.getMediaFile] 取字节、按与 repo 共用的命名写盘。
 ///
-/// 幂等：已存在的缓存文件跳过。HoshiDicts 未初始化 / 字节取不到 / 写盘失败均静默跳过
+/// 幂等：已存在的缓存文件跳过。HoshiDicts 未初始化 / 字节取不到 / 写盘失败均跳过
 /// （该条媒体退回 alt 文本，不阻断制卡）。
+///
+/// BUG-1265：跳过**必须留痕**。这三条跳过路径以前只有一句不含原因的 debugPrint
+/// （甚至直接 `return`），于是「缓存里没有这个文件」在日志里毫无前因；下游 repo 报
+/// 「Dictionary media file is missing」时无从判断是词典取不到字节、还是根本没走到
+/// 写入方。现在每条跳过都带原因进 [ErrorLogService]（用户上传的报错日志里能看到），
+/// 一条媒体一行，只在真出问题时才产生。
 Future<void> writeDictionaryMediaCache(String dictionaryMediaJson) async {
   if (dictionaryMediaJson.isEmpty || dictionaryMediaJson == '[]') return;
-  if (!HoshiDicts.isInitialized) return;
   final List<dynamic> entries;
   try {
     entries = jsonDecode(dictionaryMediaJson) as List<dynamic>;
-  } catch (_) {
+  } catch (e, stack) {
+    _logDictionaryMediaSkip('payload JSON 解析失败: $e', stack);
     return;
   }
   if (entries.isEmpty) return;
 
+  // 未初始化的判断放在「确实有媒体要写」之后：无媒体时不该产生噪音日志。
+  if (!HoshiDicts.isInitialized) {
+    _logDictionaryMediaSkip(
+      'HoshiDicts 未初始化，${entries.length} 条词典媒体未落盘（卡片将缺外字）',
+    );
+    return;
+  }
+
   final Directory dir = Directory(ankiDictionaryMediaCacheDirPath());
   try {
     if (!dir.existsSync()) dir.createSync(recursive: true);
-  } catch (_) {
+  } catch (e, stack) {
+    _logDictionaryMediaSkip('缓存目录 ${dir.path} 创建失败: $e', stack);
     return;
   }
 
@@ -48,19 +64,33 @@ Future<void> writeDictionaryMediaCache(String dictionaryMediaJson) async {
     if (raw is! Map) continue;
     final String dict = raw['dictionary']?.toString() ?? '';
     final String path = raw['path']?.toString() ?? '';
-    if (dict.isEmpty || path.isEmpty) continue;
+    if (dict.isEmpty || path.isEmpty) {
+      _logDictionaryMediaSkip('媒体条目缺 dictionary/path，无法定位字节: $raw');
+      continue;
+    }
     final File file =
         File('${dir.path}/${ankiDictionaryMediaCacheFilename(dict, path)}');
     if (file.existsSync()) continue; // 幂等：已缓存。
     try {
       final Uint8List? bytes = HoshiDicts.instance.getMediaFile(dict, path);
-      if (bytes != null && bytes.isNotEmpty) {
-        await file.writeAsBytes(bytes, flush: true);
+      if (bytes == null || bytes.isEmpty) {
+        // 最常见的一条：词典里取不到这个资源（分卷 MDD 未挂载、资源名对不上、
+        // 词典已删除重导）。以前这里连 debugPrint 都没有。
+        _logDictionaryMediaSkip('词典「$dict」取不到媒体字节: $path');
+        continue;
       }
-    } catch (e) {
-      debugPrint('[DictionaryMedia] cache write failed for $dict/$path: $e');
+      await file.writeAsBytes(bytes, flush: true);
+    } catch (e, stack) {
+      _logDictionaryMediaSkip('写盘失败 $dict/$path: $e', stack);
     }
   }
+}
+
+/// 词典媒体落盘跳过的统一留痕口：debugPrint（开发期）+ [ErrorLogService]（随用户
+/// 上传的报错日志一起回来）。跳过只降级这一条媒体，不抛、不阻断制卡。
+void _logDictionaryMediaSkip(String reason, [StackTrace? stack]) {
+  debugPrint('[DictionaryMedia] $reason');
+  ErrorLogService.instance.log('DictionaryMedia.cache', reason, stack);
 }
 
 WebResourceResponse? dictionaryMediaWebResourceResponse(Uri url) {

--- a/hibiki/test/anki/anki_dict_media_embed_test.dart
+++ b/hibiki/test/anki/anki_dict_media_embed_test.dart
@@ -135,8 +135,11 @@ void main() {
         '../packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart',
       ).readAsStringSync().replaceAll('\r\n', '\n');
       // 锚定方法定义（而非调用点 `_storeDictionaryMedia(service, media)`）。
-      final int start = src.indexOf('Future<String> _storeDictionaryMedia(');
-      expect(start, greaterThan(0));
+      // BUG-1265：返回类型是 `Future<String?>`——null = 这条词典媒体嵌不进去，
+      // 只降级它一条，与 AnkiDroid/AnkiMobile 及 buildDictionaryMediaTags 同契约。
+      final int start = src.indexOf('Future<String?> _storeDictionaryMedia(');
+      expect(start, greaterThan(0),
+          reason: '_storeDictionaryMedia 必须返回 Future<String?>（BUG-1265 降级契约）');
       // This is the final method in the repository class. Match its closing
       // brace plus the class brace so an inner guard block cannot truncate the
       // extracted method body.
@@ -147,6 +150,12 @@ void main() {
       // 不允许把完整 <img>/[sound:] 标签直接塞进 dictionaryMediaTags。
       expect(body, isNot(contains("return '<img")));
       expect(body, isNot(contains("return '[sound:")));
+      // BUG-1265：缓存缺失只能 return null 降级这一条，绝不能抛异常拖垮整次制卡
+      // （封面/句子音频的「缺媒体就别建卡」策略在 _storeLocalMedia，两者不是一回事）。
+      expect(body, isNot(contains('throw ')),
+          reason: '词典媒体缺失必须降级返回 null，不得抛异常中止 mineEntry（BUG-1265）');
+      expect(body, contains('return null;'),
+          reason: '缺失分支必须显式 return null，交给 buildDictionaryMediaTags 跳过');
     });
   });
 

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -1621,7 +1621,22 @@ class AnkiConnectRepository extends BaseAnkiRepository {
     return 'mp3';
   }
 
-  Future<String> _storeDictionaryMedia(
+  /// BUG-1265：返回 `null` 表示「这条词典媒体嵌不进去」，**不是**整次制卡失败。
+  ///
+  /// 词典媒体（gaiji 外字、义项内嵌图）是**装饰性**的，写入方
+  /// `writeDictionaryMediaCache` 按设计就是尽力而为：HoshiDicts 未初始化、
+  /// `getMediaFile` 取不到字节（分卷 MDD 未挂载、词典里本就没这个资源）、写盘失败，
+  /// 三种情况都跳过不写盘，契约是「该条退回 alt 文本，不阻断制卡」。共享的
+  /// [BaseAnkiRepository.buildDictionaryMediaTags] 也据此收 `Future<String?>`：
+  /// null 就不进映射表。AnkiDroid（`_addDictionaryMedia`）与 AnkiMobile
+  /// （`_dictionaryMediaUrl`）都按这个契约返回 null 优雅降级。
+  ///
+  /// 此处曾 `throw FileSystemException`（commit 35e8c96b5「require media before
+  /// adding cards」把封面/句子音频的「缺媒体就别建卡」策略**误扫**到装饰性外字上）：
+  /// 一个取不到字节的外字就让 `mineEntry` 整个抛穿，用户一张卡都建不出来，而同一
+  /// 词条在 AnkiDroid/AnkiMobile 上照常建卡。封面与句子音频仍由 [_storeLocalMedia]
+  /// 抛异常拦住（那两个缺了卡片就没价值），二者是**不同**策略，不要再合并。
+  Future<String?> _storeDictionaryMedia(
     AnkiConnectService service,
     _MediaUploadTransaction mediaTransaction,
     DictionaryMedia media,
@@ -1632,7 +1647,12 @@ class AnkiConnectRepository extends BaseAnkiRepository {
         ankiDictionaryMediaCacheFilename(media.dictionary, media.path);
     final file = File('${ankiDictionaryMediaCacheDirPath()}/$filename');
     if (!file.existsSync()) {
-      throw FileSystemException('Dictionary media file is missing', file.path);
+      debugPrint(
+        'AnkiConnectRepository._storeDictionaryMedia: cache miss for '
+        '${media.dictionary}/${media.path} (${file.path}); '
+        'embedding skipped, card still created',
+      );
+      return null;
     }
     await _uploadLocalFile(
       service,

--- a/packages/hibiki_anki/test/dictionary_media_missing_degrades_test.dart
+++ b/packages/hibiki_anki/test/dictionary_media_missing_degrades_test.dart
@@ -1,0 +1,249 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+/// BUG-1265 守卫：AnkiConnect 制卡时**取不到词典媒体（外字 gaiji / 义项内嵌图）
+/// 必须降级这一条，绝不能把整张卡拖垮**。
+///
+/// 用户报错：
+/// ```
+/// Anki.mineEntry  FileSystemException: Dictionary media file is missing,
+///   path = '…/Temp/anki-media/hibiki_dict_<sha1>.svg'
+///   AnkiConnectRepository._storeDictionaryMedia (…:1635)
+/// ```
+/// 卡片一张都建不出来。
+///
+/// 根因两层：
+/// 1. 写入方 `writeDictionaryMediaCache`（主 app）**按设计就是尽力而为**：HoshiDicts
+///    未初始化 / `getMediaFile` 取不到字节（分卷 MDD 未挂载、词典里本就没这个资源、
+///    词典删除重导）/ 写盘失败，三种情况都跳过不落盘，契约是「该条退回 alt 文本，
+///    不阻断制卡」。
+/// 2. 读取方 `AnkiConnectRepository._storeDictionaryMedia` 却在文件缺失时
+///    `throw FileSystemException`，抛穿 `Future.wait` → `_renderMinedFields` →
+///    `mineEntry`，整次制卡失败。commit 35e8c96b5「require media before adding
+///    cards」把封面/句子音频的「缺媒体就别建卡」策略**误扫**到了装饰性词典媒体上。
+///    AnkiDroid `_addDictionaryMedia` 与 AnkiMobile `_dictionaryMediaUrl` 一直是
+///    返回 null 优雅降级，只有 AnkiConnect 破了共享契约
+///    （`buildDictionaryMediaTags` 收的就是 `Future<String?>`）。
+///
+/// 本测锁死修复后的三条边界：缺媒体只降级这一条；能取到的照常嵌入（混排时不被邻居
+/// 拖累）；封面/句子音频缺失**仍然**中止制卡（两套策略故意不同，别再合并）。
+void main() {
+  const String dictName = '明鏡国語辞典 第三版';
+  const String gaijiPath = 'gaiji/hibiki_bug1264.svg';
+  const String placeholder = 'hoshi_dict_0.svg';
+  const String secondGaijiPath = 'gaiji/hibiki_bug1264_second.svg';
+  const String secondPlaceholder = 'hoshi_dict_1.svg';
+
+  final String cacheDir = ankiDictionaryMediaCacheDirPath();
+  final String cachedName =
+      ankiDictionaryMediaCacheFilename(dictName, gaijiPath);
+  final String secondCachedName =
+      ankiDictionaryMediaCacheFilename(dictName, secondGaijiPath);
+
+  late Directory tempDir;
+  late File gif;
+
+  /// 制卡负载：义项 HTML 里带一个未替换的占位符 `<img src="hoshi_dict_0.svg">`，
+  /// 并在 dictionaryMedia 登记它——与 popup.js 真实产出的形状一致。
+  String payloadWith(List<({String path, String filename})> media) {
+    final String glossaryImgs = media
+        .map((m) => '<img class=\\"gloss-image\\" src=\\"${m.filename}\\">')
+        .join();
+    final String mediaJson = media
+        .map((m) =>
+            '{\\"dictionary\\":\\"$dictName\\",\\"path\\":\\"${m.path}\\",'
+            '\\"filename\\":\\"${m.filename}\\"}')
+        .join(',');
+    return '{"expression":"言葉",'
+        '"glossary":"$glossaryImgs意味",'
+        '"dictionaryMedia":"[$mediaJson]"}';
+  }
+
+  AnkiSettings settings() => AnkiSettings(
+        selectedDeckId: 1,
+        selectedNoteTypeId: 2,
+        availableDecks: const <AnkiDeck>[AnkiDeck(id: 1, name: 'Mining')],
+        availableNoteTypes: const <AnkiNoteType>[
+          AnkiNoteType(
+            id: 2,
+            name: 'Hibiki',
+            fields: <String>['Expression', 'Meaning', 'Picture'],
+          ),
+        ],
+        fieldMappings: const <String, String>{
+          'Expression': '{expression}',
+          'Meaning': '{glossary}',
+          'Picture': '{card-image}',
+        },
+        allowDupes: true,
+      );
+
+  void removeCached() {
+    for (final String name in <String>[cachedName, secondCachedName]) {
+      final File f = File('$cacheDir/$name');
+      if (f.existsSync()) f.deleteSync();
+    }
+  }
+
+  setUp(() {
+    tempDir = Directory.systemTemp.createTempSync('hibiki_bug1264');
+    gif = File('${tempDir.path}/cover.gif')
+      ..writeAsBytesSync(<int>[0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+    removeCached();
+  });
+
+  tearDown(() {
+    removeCached();
+    if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+  });
+
+  test('词典媒体缓存缺失：卡片照常创建，只有这一条媒体降级', () async {
+    final service = _RecordingAnkiConnectService();
+    final repo = _ConfiguredAnkiConnectRepository(
+      service: service,
+      settings: settings(),
+    );
+
+    final MineOutcome outcome = await repo.mineEntry(
+      rawPayloadJson: payloadWith(
+        <({String path, String filename})>[
+          (path: gaijiPath, filename: placeholder),
+        ],
+      ),
+      context: AnkiMiningContext(
+        sentence: 'これは言葉です。',
+        coverPath: gif.path,
+      ),
+    );
+
+    expect(outcome.result, MineResult.success,
+        reason: '一个取不到字节的外字不得让整次制卡失败（BUG-1265）');
+    expect(service.addedFields, hasLength(1), reason: 'addNote 必须真的被调用，卡片要落地');
+    // 这条媒体降级：占位符保持原样（等价于 alt 文本），不会指向不存在的 Anki 媒体。
+    expect(service.addedFields.single['Meaning'], contains(placeholder));
+    expect(service.addedFields.single['Meaning'], contains('意味'));
+    expect(
+      service.storedMedia.map((e) => e.filename),
+      isNot(contains(cachedName)),
+      reason: '缺失的词典媒体不该被上传',
+    );
+    // 封面这类必需媒体不受影响，照常上传。
+    expect(
+      service.storedMedia.where((e) => e.filename.startsWith('hibiki_cover_')),
+      hasLength(1),
+    );
+  });
+
+  test('混排时：能取到的外字照常嵌入，取不到的那条单独降级', () async {
+    Directory(cacheDir).createSync(recursive: true);
+    File('$cacheDir/$cachedName').writeAsBytesSync(
+      '<svg xmlns="http://www.w3.org/2000/svg"/>'.codeUnits,
+    );
+
+    final service = _RecordingAnkiConnectService();
+    final repo = _ConfiguredAnkiConnectRepository(
+      service: service,
+      settings: settings(),
+    );
+
+    final MineOutcome outcome = await repo.mineEntry(
+      rawPayloadJson: payloadWith(
+        <({String path, String filename})>[
+          (path: gaijiPath, filename: placeholder),
+          // 第二条没有缓存文件：以前它会把第一条也一起拖垮。
+          (path: secondGaijiPath, filename: secondPlaceholder),
+        ],
+      ),
+      context: const AnkiMiningContext(sentence: 'これは言葉です。'),
+    );
+
+    expect(outcome.result, MineResult.success);
+    final String meaning = service.addedFields.single['Meaning']!;
+    expect(meaning, contains(cachedName), reason: '有缓存的那条外字必须被替换成真实媒体文件名');
+    expect(meaning, isNot(contains(placeholder)));
+    expect(meaning, contains(secondPlaceholder),
+        reason: '缺失的那条保持占位符（降级），不影响邻居');
+    expect(
+      service.storedMedia.map((e) => e.filename),
+      contains(cachedName),
+    );
+  });
+
+  test('对比组：封面缺失仍然中止制卡（两套媒体策略故意不同，别再合并）', () async {
+    final service = _RecordingAnkiConnectService();
+    final repo = _ConfiguredAnkiConnectRepository(
+      service: service,
+      settings: settings(),
+    );
+
+    final MineOutcome outcome = await repo.mineEntry(
+      rawPayloadJson: payloadWith(const <({String path, String filename})>[]),
+      context: AnkiMiningContext(
+        sentence: 'これは言葉です。',
+        coverPath: '${tempDir.path}/does_not_exist.gif',
+      ),
+    );
+
+    expect(outcome.result, MineResult.error,
+        reason: '封面/句子音频缺失的卡片没有价值，必须继续拦住（35e8c96b5 的本意）');
+    expect(service.addedFields, isEmpty);
+  });
+}
+
+class _ConfiguredAnkiConnectRepository extends AnkiConnectRepository {
+  _ConfiguredAnkiConnectRepository({
+    required AnkiConnectService service,
+    required this.settings,
+  }) : super(service: service);
+
+  final AnkiSettings settings;
+
+  @override
+  Future<AnkiSettings> loadSettings() async => settings;
+}
+
+class _RecordingAnkiConnectService extends AnkiConnectService {
+  _RecordingAnkiConnectService({String host = 'localhost'}) : super(host: host);
+
+  final List<Map<String, String>> addedFields = <Map<String, String>>[];
+  final List<({String filename, String? data, String? path})> storedMedia =
+      <({String filename, String? data, String? path})>[];
+  final Set<String> existingMedia = <String>{};
+  final List<String> deletedMedia = <String>[];
+
+  @override
+  Future<bool> mediaFileExists(String filename) async =>
+      existingMedia.contains(filename);
+
+  @override
+  Future<void> storeMediaFile({
+    required String filename,
+    String? data,
+    String? path,
+  }) async {
+    storedMedia.add((filename: filename, data: data, path: path));
+    existingMedia.add(filename);
+  }
+
+  @override
+  Future<void> deleteMediaFile(String filename) async {
+    deletedMedia.add(filename);
+    existingMedia.remove(filename);
+  }
+
+  @override
+  Future<int?> addNote({
+    required String deckName,
+    required String modelName,
+    required Map<String, String> fields,
+    List<String>? tags,
+    Map<String, String>? mediaFiles,
+    bool allowDuplicate = false,
+    AnkiDuplicateScope duplicateScope = AnkiDuplicateScope.deck,
+  }) async {
+    addedFields.add(Map<String, String>.from(fields));
+    return addedFields.length;
+  }
+}


### PR DESCRIPTION
## 用户报错

```
Anki.mineEntry  FileSystemException: Dictionary media file is missing,
  path = 'C:\Users\…\AppData\Local\Temp/anki-media/hibiki_dict_aea8ccb2….svg'
#0 AnkiConnectRepository._storeDictionaryMedia (…:1635)
#2 BaseAnkiRepository.buildDictionaryMediaTags (…:386)
#5 AnkiConnectRepository._mineEntryInner (…:662)
#7 ImmersionMiningEngine._mineNow (…:296)
```

一个取不到字节的词典外字（gaiji），让**整张卡建不出来**（`addNote` 从未被调用）。

## 根因（两层）

**① 读取方破契约（真正杀掉整张卡的）**

共享契约 `BaseAnkiRepository.buildDictionaryMediaTags` 收的是 `Future<String?>`——**返回 null = 跳过这条媒体**。AnkiDroid `_addDictionaryMedia`（`if (!file.existsSync()) return null;`）与 AnkiMobile `_dictionaryMediaUrl` 一直按这个契约优雅降级，只有 AnkiConnect 在缺文件时 `throw FileSystemException`，抛穿 `Future.wait` → `_renderMinedFields` → `mineEntry`。

回溯到 `35e8c96b5 fix(anki): require media before adding cards`——那次的本意是「封面/句子音频缺失就别建无图卡」，把**装饰性**的词典外字一起扫进了硬失败策略（同一 commit 把 `return null` 改成了 `throw`）。

**② 写入方静默跳过（为什么缓存里会没有这个文件）**

`writeDictionaryMediaCache` 按设计就是尽力而为：`HoshiDicts` 未初始化、`getMediaFile` 取不到字节（分卷 MDD 未挂载 / 词典里本就没这个资源 / 删除重导）、写盘失败——三条路径全部静默跳过（前两条连 `debugPrint` 都没有），文档写明契约是「该条退回 alt 文本，不阻断制卡」。于是「缓存里没这个文件」在用户上传的日志里**毫无前因**。

## 修复

- `_storeDictionaryMedia` 改回 `Future<String?>`，缺失时带上下文 `debugPrint` 后 `return null`，与另两个 backend 同契约。
  **封面/句子音频仍由 `_storeLocalMedia` 抛异常拦住**（缺了卡片没价值）——两套策略故意不同，注释里写死了别再合并。
- `writeDictionaryMediaCache` 三条跳过路径改为带原因留痕（`debugPrint` + `ErrorLogService.log('DictionaryMedia.cache', …)`），下次报错能直接区分「词典取不到字节」还是「根本没走到写入方」。顺带把 `isInitialized` 判断挪到「确实有媒体要写」之后，无媒体时不产噪音。

## 测试

新增 `packages/hibiki_anki/test/dictionary_media_missing_degrades_test.dart`（3 条，走完整 `mineEntry` 落卡链）：

1. 缓存缺失 → `MineResult.success` + `addNote` 真被调用 + 占位符保持原样 + 封面照常上传；
2. 混排（一条有缓存 / 一条没有）→ 有的正常替换成 `hibiki_dict_<sha1>.svg`，没有的单独降级，不拖累邻居；
3. 对比组：封面缺失**仍然** `MineResult.error`。

外加收紧 `anki_dict_media_embed_test` 的源码守卫（锚点跟随 `Future<String?>`，并断言方法体内不得出现 `throw`）。

**变异实测**：把 `return null` 改回 `throw FileSystemException` 后，行为测试第 1/2 条与源码守卫立刻转红，对比组保持绿——不是假绿。

## 验证

- `flutter analyze`（hibiki + hibiki_anki）：No issues found
- `packages/hibiki_anki` 282 条、`hibiki/test/anki` 187 条：全绿
- 全量套件：18469 条执行、13 条失败。其中 **11 条在把两个 lib 文件还原到基底 `72a3b942a` 后同样红**（既有红；这 13 个测试文件均不引用本次改动的任何符号）；另 2 条（`local_audio_manager_test` / `home_video_remote_download_register_test`）带本修复孤立复跑 21 条全过，属全量下的串扰。

> 未 bump `pubspec.yaml` 的 `+build`：本 PR 不是发布，且当前并发 PR 较多，按惯例交给 integration owner 在落地时统一处理。

BUG 文档：`docs/bugs/BUG-1265-anki-gaiji-cache-miss-aborts-mine.md`
（原取号 1264 与并发会话的 PR #606 撞车，已用 `bug.dart renumber` 改为 1265，自校验零残留。）

https://claude.ai/code/session_01E2soWp5zVjRcqMxoVTV364
