### PR TITLE
fix(gal): 查词钩子存活性 + loopback 补全 + attach 补装 PC hooks (BUG-1265/1266/1267)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1201 条。点号进各自文件。
+> 共 1204 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1267](bugs/BUG-1267-gal-attach-missing-luna-pchooks.md) | ✅ | ✅ | 捕获窗口(attach)模式硬编码不装 LunaHook PC hooks，Unity 游戏中途对接抓不到文本 |
+| [BUG-1266](bugs/BUG-1266-gal-loopback-flush-no-settle.md) | ✅ | ✅ | galgame 查词/制卡时语音只到句子前半段：loopback 提前收束后不再补全 |
+| [BUG-1265](bugs/BUG-1265-gal-lookup-hook-revoked.md) | ✅ | ✅ | galgame 查词浮窗点击失效：低级鼠标钩子被系统吊销后不再重装 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |
 | [BUG-1244](bugs/BUG-1244-vn-media-screen-skipped.md) | ✅ | ✅ | VN独立图片屏被逐句跳转永久略过 |

--- a/docs/bugs/BUG-1265-gal-lookup-hook-revoked.md
+++ b/docs/bugs/BUG-1265-gal-lookup-hook-revoked.md
@@ -1,0 +1,42 @@
+## BUG-1265 · galgame 查词浮窗点击失效：低级鼠标钩子被系统吊销后不再重装
+- **报告**：2026-07-31（用户：玩 gal 时点查词没反应，浮窗卡住台词，甚至关不掉只能任务管理器结束；查词点不动了，但还在跟着 gal 的台词变）
+- **真实性**：✅ 真 bug，根因 `hibiki/windows/runner/low_level_mouse_hook.cpp:111`（旧实现的 `HookThreadMain` 消息循环）
+- **[x] ① 已修复** — `hibiki/windows/runner/low_level_mouse_hook.cpp`
+
+  查词卡是 `WS_EX_NOACTIVATE` 的 topmost 窗，它的点击**唯一**来源是 `WH_MOUSE_LL` 回调
+  投递的 `kLowLevelMouseClickMessage`（消费端 `hibiki/windows/runner/global_lookup_window.cpp:1955`）。
+  而 `WH_MOUSE_LL` 是 Windows 会**主动吊销**的资源：回调超过 `LowLevelHooksTimeout`
+  （`HKCU\Control Panel\Desktop`，默认 300ms）没返回，系统直接把它从钩子链上摘掉，既不
+  通知也不让 `HHOOK` 失效。旧实现只在 Arm 时装一次，此后 `hook != nullptr` 恒为真，被摘
+  之后永远不会重装——于是浮窗**看得见、点不动**，而台词照常刷新（那条走 IPC→ExecuteScript，
+  与钩子无关）。这正是用户描述的「查词点不动了，但还在跟着 gal 的台词变」，且不可自愈，
+  只能重启。玩 galgame 时进程内同时有词典 FFI、WebView2 COM、语音捕获与转码在抢核，
+  `THREAD_PRIORITY_TIME_CRITICAL` 也不能保证回调在 300ms 内被调度。
+
+  修法不是加重试或延时，而是**把 armed 的真值收敛到 `g_target`**：钩子线程常驻一只
+  1s 的核对定时器，每拍把实际钩子状态收敛到 `g_target`。这一条同时消掉三类静默失败，
+  不再各需一套特例分支：
+  - `SetWindowsHookEx` 返回 nullptr（旧实现不检查）→ 下一拍补装；
+  - `PostThreadMessage(kThreadArm)` 投递失败（旧实现不检查返回值）→ 下一拍补装；
+  - 系统摘钩 → 判定后先 `UnhookWindowsHookEx` 再重装。
+
+  吊销判据用**光标位移 + 回调未跑**的合取，零误报：光标位置变了说明系统必然投递过
+  `WM_MOUSEMOVE`，而回调一次没跑，那它只可能已不在链上。只看「N 秒没事件」会把「用户
+  没动鼠标」误判成吊销，空闲时反复重装全局钩子本身就是一次次全系统输入抖动。存活证据
+  `g_callback_tick` 记在 `HookProc` 最前面（早于 `code < 0` 过滤分支），因为**移动事件**
+  才是每秒都有的那类；记在过滤之后就只剩点击/滚轮能刷新，判据当场失效。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_lookup_hook_liveness_guard_test.dart`
+
+  钩子逻辑在 C++ runner 里，Dart 侧无法驱动，故取最强可落地层：源码扫描守卫。扫描前
+  **剥掉注释**，防「把断言要找的字面量写进注释」的假绿。三条断言：存活证据的记录位置
+  早于过滤分支（位置关系，不是 contains）、核对分支以 `g_target` 为 armed 真值且覆盖
+  补装/重装两条路径、吊销判据同时包含光标位移比较与「回调一次没跑」。
+
+  变异实测已做：把 `g_callback_tick.store` 挪到过滤分支之后、同时在注释里留下守卫要找
+  的字面量 → 守卫如期变红（`is not a value less than <808>`），证明它既捕获真实退化，
+  也不被注释蒙混。
+
+- **备注**：native 改动，Dart 侧 `flutter analyze` / `flutter test` 覆盖不到编译；本轮
+  未做 Windows 真机构建验证，合入后需在 Windows 出包路径上复验（相邻功能：BUG-1166 的
+  滚轮吞掉逻辑与 BUG-1077 的 Disarm 宽限期均未改动语义）。

--- a/docs/bugs/BUG-1266-gal-loopback-flush-no-settle.md
+++ b/docs/bugs/BUG-1266-gal-loopback-flush-no-settle.md
@@ -1,0 +1,39 @@
+## BUG-1266 · galgame 查词/制卡时语音只到句子前半段：loopback 提前收束后不再补全
+- **报告**：2026-07-31（用户：我查一个词，它在句子的中后段，然后语音只到前半段就中断了）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/mining/gal_hook_session_controller.dart` 的
+  `_flushLoopbackFreeze`（修复前：`timer.cancel()` 之后不再补排任何回取）
+- **[x] ① 已修复** — `hibiki/lib/src/mining/gal_hook_session_controller.dart`
+
+  Loopback 抓音是「台词到达后等 `loopbackFreezeDelay`（默认 4s）再回取整句」（BUG-1101）。
+  用户在台词播到中后段才查词/制卡时，`captureAudioBytes` → `_captureAudioBytesNow` 会调
+  `_flushLoopbackFreeze` 提前收束：它 `timer.cancel()` 把完整窗口的定时器**永久取消**，
+  只按 `elapsedMs + preRoll` 回取——用户 1.5s 时查词就只有 1.5s，写进 `_lineVoiceCache`
+  后**再没有任何补全机制**。也就是把「用户现在就要声音」实现成了「就此永久定格」，那半
+  句话被钉死。引擎 PCM 那条路早有重取补全（`_settleLineUtterance`，BUG-1109），Loopback
+  缺了对称的一半。
+
+  修法：收束之后按**原到期时刻**补排一次补全（新增 `_scheduleLoopbackSettle`）——立刻给
+  出能用的，窗口真正到点后再取一次完整 `delay + preRoll`，拿到更长的才覆盖。补全定时器
+  仍装在 `_loopbackFreezeTimers` 里，因此会话结束 / 禁止降级（`_cancelLoopbackFreezes`）、
+  用户补录与选轨都能像取消普通冻结一样取消它，不需要第二套生命周期。
+
+  两处边界：
+  - `_cacheLoopbackForLine` 新增 `onlyIfLonger`——补全取空或取短都保持已冻结结果不动，
+    **且不标 missing**：一次失败的加取不该毁掉一份已经能用的音频。
+  - `_flushAllLoopbackFreezes`（音源即将被换走时调用）传 `settle: false`——补全靠的正是
+    这个 Loopback 源再多录一会儿，调用方下一步就是把它换掉，排了也只会被音源检查挡掉。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_attach_pchooks_loopback_settle_test.dart`
+
+  - 「提前收束后仍按原窗口补全」：断言首次回取窗口 < `delay + preRoll`（确实只拿到前半
+    段），随后出现一次完整窗口回取，且写回的 `audioDurationMs` 严格长于收束那一段。
+  - 「补全取空时保留已冻结的短切片」：让补全那一次（按 **backMs 值**精确定位，不用调用
+    序号——`captureAudioBytes` 内部还会为别的用途取音频）返回 null，断言时长原封不动。
+
+  变异实测已做：摘掉 `_scheduleLoopbackSettle` 调用 → 核心测试如期变红
+  （`does not contain <1400>`）。
+
+- **备注**：断言刻意落在**最终状态**而非「收束瞬间」——`captureAudioBytes` 内部还有资源
+  等待，返回时补全可能早已跑完，按时机读会拿到补全后的值（这一点在首版测试里真实踩到）。
+  另：该测试不断言 `audioStatus`，因为测试装置里 `captureAudioBytes` 注定产不出字节，
+  它自己的失败路径会把行标成 missing，与补全无关；真正的证据是时长。

--- a/docs/bugs/BUG-1267-gal-attach-missing-luna-pchooks.md
+++ b/docs/bugs/BUG-1267-gal-attach-missing-luna-pchooks.md
@@ -1,0 +1,44 @@
+## BUG-1267 · 捕获窗口(attach)模式硬编码不装 LunaHook PC hooks，Unity 游戏中途对接抓不到文本
+- **报告**：2026-07-31（用户：helper 本身支持中途注入，但 hibiki 客户端没法中途对接；
+  只能自己用 LE 启动后在 hibiki 里捕获窗口。用户手动跑 `hibiki_voice_injector.exe --pid 42504`
+  的输出为 `[session] reusing live hook mapping pid=42504 text=0 audioBytes=0` /
+  `[unity-audio] resource extractor runtime missing` / `OK hooked pid=42504 hooked=1`）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/mining/gal_hook_session_controller.dart`
+  attach 两个调用点（`startAttachedCapture` 与 `_retryEngineAttach`）修复前均写死
+  `lunaPcHooks: false`
+- **[x] ① 已修复** — `hibiki/lib/src/mining/gal_hook_session_controller.dart`
+
+  用户的判断需要更正一半：能力在 native 侧是齐的（injector 的 `--pid` 中途注入存在，
+  用户手动跑也确实 `hooked=1`），客户端也**有** attach 模式（`buildEngineHookInjectorArguments`
+  会发 `--pid`）。真正缺的是 `--luna-pchooks`。
+
+  `shouldUseLunaPcHooksForExecutable`（`hibiki/lib/src/mining/galgame_audio_source.dart:729`）
+  的判据只认 exe 路径：basename 白名单（manosaba / siglusengine），或同目录有
+  `UnityPlayer.dll` **且**有 IL2CPP（`GameAssembly.dll` / `global-metadata.dat`）或 Mono
+  证据。launch 路径有 exe 路径可喂，attach 路径没有——于是两个调用点直接写死 `false`，
+  把**「判据取不到」实现成了「判为否」**。后果：Unity/IL2CPP 与 Siglus 目标只要不是由
+  Hibiki 亲自拉起，就永远不补装 LunaHook 通用 PC hooks，文本线程一条都建不起来，
+  injector 报 `text=0`——正是用户看到的「捕获上了但什么都不出」。用户截图里的
+  `[unity-audio] resource extractor runtime missing` 也印证目标就是 Unity 游戏。
+
+  修法：exe 路径本来就能从 PID 拿到。新增 `GalTargetImagePathProbe`（默认实现复用既有的
+  `GalgameWindowsProcessProbe.processImagePath`，即 `QueryFullProcessImageNameW`，不再写
+  第四份 FFI 封装），attach 两处改走 `_lunaPcHooksForPid(pid)`，与 launch **共用同一套
+  判据**。查不到路径时返回 false，与修复前行为一致——探测失败不会比旧版更糟。
+
+  `GalgameWindowsProcessProbe` 会 `DynamicLibrary.open`，故默认实现懒实例化并缓存，非
+  Windows 直接返回 null，不影响 Linux CI。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/gal_attach_pchooks_loopback_settle_test.dart`
+
+  四条，全部经 attach 真实入口 `startAttachedCapture`，断言工厂实际收到的 `lunaPcHooks`：
+  Unity/IL2CPP 目录 → true；非 Unity → false；只有 `UnityPlayer.dll` 而无 IL2CPP/Mono
+  证据 → false（判据两者缺一不可）；PID 查不到 exe → false 且不崩。
+
+  变异实测已做：把 attach 调用点改回 `lunaPcHooks: false` → Unity 那条如期变红。
+
+- **备注**：本轮只修了「中途对接抓不到文本」。用户同时报告的「hibiki 里一键启动会报
+  fatal error」**未处理**——尚未拿到报错原文，无法确认是否即
+  `native/galgame_hook/hook/il2cpp_thread_scope.h` 记录的 Unity IL2CPP
+  `"Fatal error in GC: Collecting from unknown thread"`（该守卫代码已存在，但 helper 是
+  单独发布的，用户侧版本可能落后于主包）。需要用户提供报错文本后另开 BUG。

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -8,6 +8,7 @@ import 'package:hibiki/src/mining/galgame_audio_encode.dart';
 import 'package:hibiki/src/mining/galgame_char_count.dart';
 import 'package:hibiki/src/mining/galgame_audio_source.dart';
 import 'package:hibiki/src/mining/galgame_hook_code_profile.dart';
+import 'package:hibiki/src/mining/galgame_play_tracker.dart';
 import 'package:hibiki/src/mining/serial_job_queue.dart';
 import 'package:hibiki/src/mining/galgame_system_ui_filter.dart';
 import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
@@ -530,6 +531,17 @@ typedef GalEngineSourceFactory = EngineHookGalAudioSource Function({
 typedef GalLoopbackSourceFactory = LoopbackGalAudioSource Function();
 typedef GalTargetWow64Probe = Future<bool?> Function(int pid);
 typedef GalExe32BitProbe = Future<bool?> Function(String path);
+
+/// BUG-1267 — 由 **PID** 反查目标进程的 exe 绝对路径。
+///
+/// attach（捕获窗口 / 引擎重试）路径此前没有这条查询，于是
+/// [shouldUseLunaPcHooksForExecutable] 唯一的输入拿不到，两个调用点就把
+/// `lunaPcHooks` 直接写死成 `false`——**「判据取不到」被实现成了「判为否」**。
+/// 后果是 Unity/IL2CPP 与 Siglus 目标只要不是由 Hibiki 亲自拉起，就永远不补装
+/// LunaHook 通用 PC hooks，文本线程一条都抓不到（injector 报 `text=0`）。
+/// exe 路径本来就能从 PID 拿到（`QueryFullProcessImageNameW`），补上这条查询即可
+/// 让两条路径共用同一套判据，而不是各自猜。
+typedef GalTargetImagePathProbe = String? Function(int pid);
 typedef GalWindowListLoader = Future<List<ExternalWindowInfo>> Function();
 typedef GalInjectorResolver = String? Function({required bool is32Bit});
 
@@ -543,6 +555,7 @@ class GalHookSessionController extends ChangeNotifier {
     GalEngineSourceFactory? engineSourceFactory,
     GalLoopbackSourceFactory? loopbackSourceFactory,
     GalTargetWow64Probe? targetWow64Probe,
+    GalTargetImagePathProbe? targetImagePathProbe,
     GalExe32BitProbe? exe32BitProbe,
     GalWindowListLoader? windowListLoader,
     GalInjectorResolver? injectorResolver,
@@ -582,6 +595,7 @@ class GalHookSessionController extends ChangeNotifier {
             loopbackSourceFactory ?? LoopbackGalAudioSource.new,
         _targetWow64Probe =
             targetWow64Probe ?? EngineHookGalAudioSource.targetIsWow64,
+        _targetImagePathProbe = targetImagePathProbe ?? _defaultTargetImagePath,
         _exe32BitProbe = exe32BitProbe ?? EngineHookGalAudioSource.exeIs32Bit,
         _windowListLoader =
             windowListLoader ?? WindowCaptureChannel.listWindows,
@@ -633,6 +647,7 @@ class GalHookSessionController extends ChangeNotifier {
   final GalEngineSourceFactory _engineSourceFactory;
   final GalLoopbackSourceFactory _loopbackSourceFactory;
   final GalTargetWow64Probe _targetWow64Probe;
+  final GalTargetImagePathProbe _targetImagePathProbe;
   final GalExe32BitProbe _exe32BitProbe;
   final GalWindowListLoader _windowListLoader;
   final GalInjectorResolver _injectorResolver;
@@ -851,6 +866,33 @@ class GalHookSessionController extends ChangeNotifier {
     );
   }
 
+  /// 复用 [GalgameWindowsProcessProbe]（`QueryFullProcessImageNameW`）而不是再写
+  /// 第四份 FFI 封装。probe 会 `DynamicLibrary.open`，因此**只在真的要查时**才实例化
+  /// 并缓存——非 Windows 直接返回 null，让判据回落到与旧行为一致的「不装 PC hooks」。
+  static GalgameProcessProbe? _sharedProcessProbe;
+
+  static String? _defaultTargetImagePath(int pid) {
+    if (!Platform.isWindows || pid <= 0) return null;
+    try {
+      return (_sharedProcessProbe ??= GalgameWindowsProcessProbe())
+          .processImagePath(pid);
+    } on Object {
+      return null;
+    }
+  }
+
+  /// BUG-1267 — attach 路径的 `lunaPcHooks` 判据。
+  ///
+  /// 与 launch 路径**共用** [shouldUseLunaPcHooksForExecutable]：判据本身只认 exe
+  /// 路径（basename 白名单 + 同目录 `UnityPlayer.dll`），launch 有路径、attach 也能
+  /// 从 PID 查到，没有任何理由让两条路径给出不同答案。查不到路径时返回 false —— 这
+  /// 与修复前的硬编码行为一致，所以「探测失败」不会比旧版更糟，只会不再更好。
+  bool _lunaPcHooksForPid(int pid) {
+    final String? imagePath = _targetImagePathProbe(pid);
+    if (imagePath == null || imagePath.isEmpty) return false;
+    return shouldUseLunaPcHooksForExecutable(imagePath);
+  }
+
   static String? defaultInjectorResolver({required bool is32Bit}) {
     if (!Platform.isWindows) return null;
     try {
@@ -960,7 +1002,8 @@ class GalHookSessionController extends ChangeNotifier {
         targetPid: window.pid,
         launchExe: null,
         injectorPath: injector,
-        lunaPcHooks: false,
+        // BUG-1267 — 从 PID 反查 exe 后走与 launch 相同的判据，别再写死 false。
+        lunaPcHooks: _lunaPcHooksForPid(window.pid),
       );
       await _attachPersistedHookProfiles(engine);
       final PcmFormat? format = await engine.start();
@@ -3058,7 +3101,8 @@ class GalHookSessionController extends ChangeNotifier {
         targetPid: pid,
         launchExe: null,
         injectorPath: injector,
-        lunaPcHooks: false,
+        // BUG-1267 — 引擎重试同样走 PID→exe 判据，否则重试会把首次的 PC hooks 丢掉。
+        lunaPcHooks: _lunaPcHooksForPid(pid),
       );
       await _attachPersistedHookProfiles(engine);
       final PcmFormat? format = await engine.start();
@@ -3909,7 +3953,14 @@ class GalHookSessionController extends ChangeNotifier {
   /// 提前收束 [lineId] 的延迟冻结：按**真实已等待时长**回取，而不是白等满窗口。
   /// 制卡（用户现在就要这段声音）与引擎 PCM 升格（音源即将换走）都用它。
   /// 已经冻过 / 没排过的行是 no-op。
-  Future<void> _flushLoopbackFreeze(String lineId) async {
+  ///
+  /// BUG-1266 — 「现在就要」不等于「就此定格」。用户在台词播到中后段才查词/制卡时，
+  /// elapsedMs 可能只有一秒多，回取到的自然只有这句语音的前半段。旧实现在这里
+  /// `timer.cancel()` 之后就再也不碰这一行，那半句话被永久钉死。因此收束之后按**原
+  /// 到期时刻**补排一次补全（[_scheduleLoopbackSettle]）：立刻给出能用的，窗口真正
+  /// 到点后若拿到更长的再覆盖。这与引擎 PCM 路径的 [_settleLineUtterance] 是同一条
+  /// 纪律，Loopback 此前缺了对称的这一半。
+  Future<void> _flushLoopbackFreeze(String lineId, {bool settle = true}) async {
     final Timer? timer = _loopbackFreezeTimers.remove(lineId);
     if (timer == null) return;
     timer.cancel();
@@ -3925,12 +3976,66 @@ class GalHookSessionController extends ChangeNotifier {
         .clamp(_loopbackMinBackMs, _loopbackRingCapacityMs)
         .toInt();
     await _cacheLoopbackForLine(entry, backMs: backMs);
+    if (settle) {
+      _scheduleLoopbackSettle(entry, elapsedMs: elapsedMs);
+    }
+  }
+
+  /// BUG-1266 — 为提前收束过的 [entry] 补排「窗口到点再取一次完整长度」。
+  ///
+  /// 复用 [_loopbackFreezeTimers] 装这只定时器，因此会话结束 / 禁止降级
+  /// （[_cancelLoopbackFreezes]）、用户补录与选轨（各自 remove 该 lineId）都能像取消
+  /// 普通冻结一样把它取消掉，不需要第二套生命周期。
+  void _scheduleLoopbackSettle(
+    TexthookerLineEntry entry, {
+    required int elapsedMs,
+  }) {
+    // 已经等满窗口才收束的，补全取不到任何新东西。
+    final int remainingMs = _loopbackFreezeDelay.inMilliseconds - elapsedMs;
+    if (remainingMs <= 0) return;
+    if (!_state.audioFallbackPolicy.allowsLoopback ||
+        _audioSource is! LoopbackGalAudioSource ||
+        !isLineInCurrentSession(entry) ||
+        _isUserAdjudicated(entry.id) ||
+        _loopbackFreezeTimers.containsKey(entry.id)) {
+      return;
+    }
+    // 完整窗口 = 原本延迟冻结会用的 backMs，等价于取 `[t0-preRoll, t0+delay]`。
+    final int fullBackMs =
+        _loopbackFreezeDelay.inMilliseconds + _loopbackPreRollMs;
+    _loopbackFreezeTimers[entry.id] =
+        Timer(Duration(milliseconds: remainingMs), () {
+      _loopbackFreezeTimers.remove(entry.id);
+      unawaited(
+        _audioQueue.enqueue<bool>(
+          () async {
+            await _cacheLoopbackForLine(
+              entry,
+              backMs: fullBackMs,
+              onlyIfLonger: true,
+            );
+            return true;
+          },
+          buildFailure: (Object error, StackTrace stack) => false,
+          onError: (Object error, StackTrace stack) => _record(
+            GalHookEventSeverity.error,
+            'match',
+            'audio.loopback_settle_exception',
+            'Delayed loopback settle failed',
+            details: <String, Object?>{'lineId': entry.id, 'error': '$error'},
+          ),
+        ),
+      );
+    });
   }
 
   /// 收束所有待冻结行（音源即将被换走时调用；此刻还持有旧 Loopback）。
+  ///
+  /// 这里**不补排** BUG-1266 的补全：补全靠的就是这个 Loopback 源再多录一会儿，而
+  /// 调用方的下一步正是把它换掉——排了也只会在到点时被音源检查挡掉，白留一只定时器。
   Future<void> _flushAllLoopbackFreezes() async {
     for (final String lineId in _loopbackFreezeTimers.keys.toList()) {
-      await _flushLoopbackFreeze(lineId);
+      await _flushLoopbackFreeze(lineId, settle: false);
     }
   }
 
@@ -3946,6 +4051,9 @@ class GalHookSessionController extends ChangeNotifier {
   Future<void> _cacheLoopbackForLine(
     TexthookerLineEntry entry, {
     required int backMs,
+    // BUG-1266 — 补全模式（[_scheduleLoopbackSettle]）：这一取是**锦上添花**，只有
+    // 拿到更长的切片才覆盖，取空或取短都保持已冻结的结果不动。普通冻结走 false。
+    bool onlyIfLonger = false,
   }) async {
     final GalAudioSource? source = _audioSource;
     if (source is! LoopbackGalAudioSource ||
@@ -3960,8 +4068,18 @@ class GalHookSessionController extends ChangeNotifier {
     try {
       final GalAudioSlice? slice = await source.grabRecent(backMs);
       if (slice == null || slice.isEmpty || _audioSource != source) {
-        _markLineAudioMissing(entry.id, 'loopback_line_slice_unavailable');
+        // BUG-1266 — 补全取空只说明「这次没拿到更好的」，提前收束时冻下来的那段短
+        // 语音仍然有效。把它标 missing 等于用一次失败的加取，毁掉一份已经能用的音频。
+        if (!onlyIfLonger) {
+          _markLineAudioMissing(entry.id, 'loopback_line_slice_unavailable');
+        }
         return;
+      }
+      if (onlyIfLonger) {
+        final GalAudioSlice? existing = _lineVoiceCache[entry.id];
+        if (existing != null && slice.pcm.length <= existing.pcm.length) {
+          return;
+        }
       }
       _lineVoiceCache[entry.id] = slice;
       _trimCache(_lineVoiceCache);

--- a/hibiki/test/mining/gal_attach_pchooks_loopback_settle_test.dart
+++ b/hibiki/test/mining/gal_attach_pchooks_loopback_settle_test.dart
@@ -1,0 +1,431 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_audio_encode.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/mining/window_capture_channel.dart';
+import 'package:hibiki/src/sync/texthooker_service.dart';
+import 'package:hibiki/src/sync/texthooker_ws_client.dart';
+
+/// BUG-1267 attach 路径不装 LunaHook PC hooks / BUG-1266 提前收束的 loopback 不补全。
+///
+/// 两条都是「用户中途接管一局已经在跑的游戏」时才暴露的缺陷：
+///  ① attach（捕获窗口 / 引擎重试）此前把 `lunaPcHooks` 硬编码成 false，因为它没有
+///     exe 路径可喂给 [shouldUseLunaPcHooksForExecutable]——「判据取不到」被写成了
+///     「判为否」，于是 Unity/Siglus 目标只要不是 Hibiki 亲自拉起就永远抓不到文本。
+///  ② 用户在台词播到中后段才查词/制卡时，[GalHookSessionController.captureAudioBytes]
+///     会提前收束那一行的 loopback 冻结；旧实现收束后就再也不碰它，半句话被永久钉死。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<void> waitUntil(bool Function() done, {int ticks = 400}) async {
+    for (int i = 0; i < ticks && !done(); i++) {
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+  }
+
+  group('BUG-1267 attach 模式按 PID→exe 判定 LunaHook PC hooks', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('hibiki_pchooks_test');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    /// 跑一次 attach 捕获，回报工厂实际收到的 `lunaPcHooks`。
+    Future<bool?> captureLunaPcHooksForAttach({
+      required String? imagePath,
+    }) async {
+      final TexthookerService service = TexthookerService.test();
+      final ChangeNotifier endpoints = ChangeNotifier();
+      final _AttachEngine engine = _AttachEngine();
+      bool? seen;
+      final GalHookSessionController controller = GalHookSessionController(
+        textService: service,
+        isWindows: true,
+        targetWow64Probe: (_) async => false,
+        targetImagePathProbe: (_) => imagePath,
+        injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+        engineSourceFactory: ({
+          required int targetPid,
+          required String? launchExe,
+          required String injectorPath,
+          required bool lunaPcHooks,
+          int? lunaCodepage,
+          List<String> launchArguments = const <String>[],
+          String launchWorkdir = '',
+        }) {
+          seen = lunaPcHooks;
+          return engine;
+        },
+        loopbackSourceFactory: () => _QuietLoopback(),
+        textPollInterval: const Duration(milliseconds: 5),
+        endpointListenable: endpoints,
+        endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+      );
+
+      await controller.startAttachedCapture(
+        const ExternalWindowInfo(hwnd: 21, pid: 4242, title: 'Attached game'),
+      );
+      await waitUntil(() => seen != null);
+      await controller.close();
+      endpoints.dispose();
+      return seen;
+    }
+
+    test('Unity/IL2CPP 目标中途接管时补装 PC hooks', () async {
+      final String sep = Platform.pathSeparator;
+      final String exePath = '${tempDir.path}${sep}game.exe';
+      File(exePath).writeAsStringSync('stub');
+      // 判据要 UnityPlayer.dll **加上** IL2CPP/Mono 证据，两者缺一不算 Unity 目标。
+      File('${tempDir.path}${sep}UnityPlayer.dll').writeAsStringSync('stub');
+      File('${tempDir.path}${sep}GameAssembly.dll').writeAsStringSync('stub');
+
+      // 修复前这里恒为 false：injector 拿不到 --luna-pchooks，Unity 的文本线程一条
+      // 都建不起来，用户侧表现就是 `text=0`「捕获上了但什么都不出」。
+      expect(await captureLunaPcHooksForAttach(imagePath: exePath), isTrue);
+    });
+
+    test('非 Unity 目标不会平白多装 PC hooks', () async {
+      final String exePath = '${tempDir.path}${Platform.pathSeparator}game.exe';
+      File(exePath).writeAsStringSync('stub');
+
+      expect(await captureLunaPcHooksForAttach(imagePath: exePath), isFalse);
+    });
+
+    test('只有 UnityPlayer.dll 而无 IL2CPP/Mono 证据时不算 Unity 目标', () async {
+      final String sep = Platform.pathSeparator;
+      final String exePath = '${tempDir.path}${sep}game.exe';
+      File(exePath).writeAsStringSync('stub');
+      File('${tempDir.path}${sep}UnityPlayer.dll').writeAsStringSync('stub');
+
+      expect(await captureLunaPcHooksForAttach(imagePath: exePath), isFalse);
+    });
+
+    test('PID 查不到 exe 路径时回落到旧行为，不装也不崩', () async {
+      expect(await captureLunaPcHooksForAttach(imagePath: null), isFalse);
+    });
+  });
+
+  test('BUG-1266 提前收束后仍按原窗口补全，半句话不再被永久钉死', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    // 台词到达 → 排一次 400ms 后到点的冻结（完整窗口 backMs = 400 + preRoll 1000）。
+    const Duration freezeDelay = Duration(milliseconds: 400);
+    final _AttachEngine engine = _AttachEngine(
+      lines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 1,
+          timestampMs: 3000,
+          text: 'まだ声の途中で辞書を引いた',
+          threadId: 5,
+          hookName: 'fake',
+        ),
+      ],
+    );
+    final _ProportionalLoopback loopback = _ProportionalLoopback();
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      targetWow64Probe: (_) async => false,
+      targetImagePathProbe: (_) => null,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+        List<String> launchArguments = const <String>[],
+        String launchWorkdir = '',
+      }) =>
+          engine,
+      loopbackSourceFactory: () => loopback,
+      textPollInterval: const Duration(milliseconds: 5),
+      loopbackFreezeDelay: freezeDelay,
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 21, pid: 4242, title: 'Attached game'),
+    );
+    await waitUntil(() => service.entries.isNotEmpty);
+    final String lineId = service.entries.single.id;
+
+    // 语音还在播（窗口远未到点）时就查词/制卡——这正是用户报的那一刻。
+    await controller.captureAudioBytes(
+      lineId: lineId,
+      sentence: service.entries.single.text,
+      outputExtension: 'wav',
+    );
+    await waitUntil(() => loopback.backMsCalls.isNotEmpty);
+
+    // 断言全部落在**最终状态**上，不依赖读取时机：captureAudioBytes 内部还有资源等待，
+    // 返回时补全可能早已跑完，此刻去读「收束瞬间的时长」拿到的会是补全后的值。
+    const int fullBackMs = 400 + 1000; // freezeDelay + _loopbackPreRollMs
+    final int flushedBackMs = loopback.backMsCalls.first;
+    expect(
+      flushedBackMs,
+      lessThan(fullBackMs),
+      reason: '提前收束只能按已等待时长回取，拿到的必然是这句语音的前半段',
+    );
+
+    // 修复前到此为止：定时器被 cancel，这一行再也不会被回取，半句话就是最终结果。
+    await waitUntil(
+      () => loopback.backMsCalls.contains(fullBackMs),
+      ticks: 400,
+    );
+    expect(
+      loopback.backMsCalls,
+      contains(fullBackMs),
+      reason: '原窗口到点后必须再取一次完整长度 delay + preRoll',
+    );
+
+    await waitUntil(
+      () => service.entries.single.audioDurationMs == fullBackMs,
+      ticks: 400,
+    );
+    expect(
+      service.entries.single.audioDurationMs,
+      fullBackMs,
+      reason: '补全必须把更长的整句写回去，否则用户听到的还是半句',
+    );
+    expect(
+      service.entries.single.audioDurationMs,
+      greaterThan(flushedBackMs),
+      reason: '写回的必须严格长于提前收束那一段',
+    );
+
+    await controller.close();
+    endpoints.dispose();
+  });
+
+  test('BUG-1266 补全取空时保留已冻结的短切片，不清空也不缩短', () async {
+    final TexthookerService service = TexthookerService.test();
+    final ChangeNotifier endpoints = ChangeNotifier();
+    const Duration freezeDelay = Duration(milliseconds: 400);
+    final _AttachEngine engine = _AttachEngine(
+      lines: const <GalHookedLine>[
+        GalHookedLine(
+          seq: 1,
+          timestampMs: 3000,
+          text: '補完だけ空振りする場合',
+          threadId: 5,
+          hookName: 'fake',
+        ),
+      ],
+    );
+    // 让**补全那一次**（完整窗口 400+1000）取空：环里这一段已被后续音频挤掉。
+    final _ProportionalLoopback loopback =
+        _ProportionalLoopback(nullWhenBackMs: 1400);
+    final GalHookSessionController controller = GalHookSessionController(
+      textService: service,
+      isWindows: true,
+      targetWow64Probe: (_) async => false,
+      targetImagePathProbe: (_) => null,
+      injectorResolver: ({required bool is32Bit}) => 'injector.exe',
+      engineSourceFactory: ({
+        required int targetPid,
+        required String? launchExe,
+        required String injectorPath,
+        required bool lunaPcHooks,
+        int? lunaCodepage,
+        List<String> launchArguments = const <String>[],
+        String launchWorkdir = '',
+      }) =>
+          engine,
+      loopbackSourceFactory: () => loopback,
+      textPollInterval: const Duration(milliseconds: 5),
+      loopbackFreezeDelay: freezeDelay,
+      endpointListenable: endpoints,
+      endpointStatusLoader: () => const <TexthookerEndpointStatus>[],
+    );
+
+    await controller.startAttachedCapture(
+      const ExternalWindowInfo(hwnd: 21, pid: 4242, title: 'Attached game'),
+    );
+    await waitUntil(() => service.entries.isNotEmpty);
+    final String lineId = service.entries.single.id;
+
+    await controller.captureAudioBytes(
+      lineId: lineId,
+      sentence: service.entries.single.text,
+      outputExtension: 'wav',
+    );
+    await waitUntil(() => loopback.backMsCalls.isNotEmpty);
+    final int frozenBackMs = loopback.backMsCalls.first;
+
+    // 等补全那一次真的发生过（它会取空）。
+    await waitUntil(() => loopback.backMsCalls.contains(1400), ticks: 400);
+    // 再等几拍，确认没有任何异步回调把这一行翻成 missing。
+    await Future<void>.delayed(const Duration(milliseconds: 60));
+
+    // 只断言时长而**不**断言 audioStatus：本装置里 captureAudioBytes 注定产不出字节
+    // （没有真实编码器/资源），它自己那条失败路径会把行标成 missing，与补全无关。
+    // 「补全取空有没有毁掉已冻结的那段」的真正证据就是时长原封不动。
+    // ±1ms 是 PCM 字节数两次整除的舍入（backMs→bytes→durationMs），不是长度变化。
+    expect(
+      service.entries.single.audioDurationMs,
+      closeTo(frozenBackMs, 1),
+      reason: '补全取空时必须原样保留提前收束冻下来的那段，不能被清掉或缩短',
+    );
+
+    await controller.close();
+    endpoints.dispose();
+  });
+}
+
+/// attach 路径用的引擎替身：握手时没有 PCM 格式，于是控制器走「文本 + Loopback」，
+/// 正是用户「LE 启动 → hibiki 捕获窗口」那条链。
+class _AttachEngine extends EngineHookGalAudioSource {
+  _AttachEngine({List<GalHookedLine> lines = const <GalHookedLine>[]})
+      : _pending = List<GalHookedLine>.of(lines),
+        super(targetPid: 0, launchExe: null, injectorPath: 'fake.exe');
+
+  final List<GalHookedLine> _pending;
+
+  @override
+  int? get gamePid => 4242;
+
+  @override
+  bool get textHookReady => true;
+
+  @override
+  bool get rawVoiceReady => false;
+
+  @override
+  PcmFormat? get readyPcmFormat => null;
+
+  @override
+  bool get pcmReady => false;
+
+  @override
+  Future<PcmFormat?> start() async => null;
+
+  @override
+  Future<bool> refreshReadiness() async => false;
+
+  @override
+  Future<GalTextPoll?> pollText(int fromSeq) async {
+    final List<GalHookedLine> fresh = _pending
+        .where((GalHookedLine line) => line.seq > fromSeq)
+        .toList(growable: false);
+    return GalTextPoll(count: _pending.length, lines: fresh);
+  }
+
+  @override
+  Future<bool> selectTextThread(int? threadId) async => true;
+
+  @override
+  Future<GalAudioSlice?> grabUtterance(
+    int tsMs, {
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async =>
+      null;
+
+  @override
+  Future<GalAudioSlice?> grabClipNear(
+    int tsMs, {
+    int tolMs = 8000,
+    int? sourcePtr,
+    List<int>? exclude,
+  }) async =>
+      null;
+
+  @override
+  Future<List<GalAudioTrack>> listAudioTracks(int tsMs) async =>
+      const <GalAudioTrack>[];
+
+  @override
+  String? findPairedVoiceResourceId(
+    int textTsMs, {
+    int? textEventId,
+    bool allowLatestSessionFallback = true,
+  }) =>
+      null;
+
+  @override
+  Future<Uint8List?> grabPairedVoiceBytes(
+    int textTsMs, {
+    required String outputExtension,
+    int? textEventId,
+    String? resourceId,
+    bool allowLatestSessionFallback = true,
+  }) async =>
+      null;
+
+  @override
+  Future<void> pruneVoiceDump({
+    int keepNewest = 400,
+    Duration maxAge = const Duration(minutes: 30),
+  }) async {}
+
+  @override
+  Future<void> stop() async {}
+}
+
+/// 只需要给得出格式的安静 loopback（PC hooks 判据与环里有没有声音无关）。
+class _QuietLoopback extends LoopbackGalAudioSource {
+  @override
+  Future<PcmFormat?> start() async => const PcmFormat(
+        sampleRate: 44100,
+        channels: 2,
+        bitsPerSample: 16,
+        isFloat: false,
+      );
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<GalAudioSlice?> grabRecent(int backMs) async => null;
+}
+
+/// 回取长度与请求窗口成正比的 loopback：`grabRecent(backMs)` 给出 backMs 毫秒的 PCM。
+/// 这样「补全后的切片是否真的更长」可以直接从 `audioDurationMs` 上断言，而不是只看
+/// 调用次数——次数对了但写回的还是旧的短切片，同样是没修好。
+class _ProportionalLoopback extends LoopbackGalAudioSource {
+  _ProportionalLoopback({this.nullWhenBackMs});
+
+  /// 恰好这个回取窗口返回 null。按 **backMs 值**而不是调用序号来定位，才能精确命中
+  /// 「补全那一次」——captureAudioBytes 内部还会为别的用途取音频，按序号会误伤。
+  final int? nullWhenBackMs;
+
+  final List<int> backMsCalls = <int>[];
+
+  static const PcmFormat _format = PcmFormat(
+    sampleRate: 44100,
+    channels: 2,
+    bitsPerSample: 16,
+    isFloat: false,
+  );
+
+  @override
+  Future<PcmFormat?> start() async => _format;
+
+  @override
+  Future<void> stop() async {}
+
+  @override
+  Future<GalAudioSlice?> grabRecent(int backMs) async {
+    backMsCalls.add(backMs);
+    if (nullWhenBackMs != null && backMs == nullWhenBackMs) {
+      return null;
+    }
+    // byteRate = 44100 * 2ch * 2B = 176400 B/s，故 backMs 毫秒 = backMs * 176.4 B。
+    final int bytes = (backMs * _format.byteRate) ~/ 1000;
+    return GalAudioSlice(
+      pcm: Uint8List.fromList(List<int>.filled(bytes, 9)),
+      format: _format,
+    );
+  }
+}

--- a/hibiki/test/mining/gal_lookup_hook_liveness_guard_test.dart
+++ b/hibiki/test/mining/gal_lookup_hook_liveness_guard_test.dart
@@ -1,0 +1,130 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1265 守卫：查词卡的低级鼠标钩子必须**持续**在线，而不是「装一次就当永远有效」。
+///
+/// `WH_MOUSE_LL` 是 Windows 会主动吊销的资源：回调超过 `LowLevelHooksTimeout`
+/// （HKCU\Control Panel\Desktop，默认 300ms）没返回，系统就把它从钩子链上摘掉，既不
+/// 通知也不让 `HHOOK` 失效。查词卡是 `WS_EX_NOACTIVATE` 的 topmost 窗，点击**只能**
+/// 靠这条钩子投递（`global_lookup_window.cpp` 的 `kLowLevelMouseClickMessage`），所以
+/// 钩子一旦被摘就再也点不动——而台词照常刷新（那条走 IPC→ExecuteScript），表现成
+/// 「浮窗看得见、点不动，只能重启」。玩 galgame 时进程内同时有词典 FFI、WebView2 COM、
+/// 语音捕获与转码在抢核，超时是现实会发生的。
+///
+/// 这条守卫扫源码而不是跑行为：钩子逻辑在 C++ runner 里，Dart 侧无法驱动。为避免
+/// 「注释里写了字面量就算过」的假绿，扫描前先剥掉注释。
+void main() {
+  late String source;
+
+  setUpAll(() {
+    final File file = File('windows/runner/low_level_mouse_hook.cpp');
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason: '守卫的目标文件不存在，说明钩子实现被挪走了，必须同步更新本测试',
+    );
+    source = _stripComments(file.readAsStringSync());
+  });
+
+  test('回调在任何过滤分支之前就记录存活证据', () {
+    final int tickStore = source.indexOf('g_callback_tick.store(');
+    expect(
+      tickStore,
+      greaterThanOrEqualTo(0),
+      reason: '回调必须留下「我被调用过」的证据，否则无从判断钩子是否还在链上',
+    );
+
+    // 存活证据必须由**移动事件**刷新——它才是每秒都有的那类。记在 `code < 0` /
+    // 非点击非滚轮的提前 return 之后，就只剩点击和滚轮能刷新，判据当场失效。
+    final int earlyReturn = source.indexOf('if (code < 0');
+    expect(earlyReturn, greaterThanOrEqualTo(0));
+    expect(
+      tickStore,
+      lessThan(earlyReturn),
+      reason: '存活证据必须记在过滤分支之前，否则移动事件刷新不到它',
+    );
+  });
+
+  test('钩子线程按周期把实际钩子状态收敛到 g_target', () {
+    expect(
+      source.contains('kLivenessIntervalMs'),
+      isTrue,
+      reason: '必须有周期性的存活性核对，而不是只在 Arm 时装一次',
+    );
+    expect(
+      RegExp(r'SetTimer\(nullptr, 0, kLivenessIntervalMs').hasMatch(source),
+      isTrue,
+      reason: '核对定时器必须真的被建起来',
+    );
+
+    // armed（g_target 非空）却没有钩子时补装：这一条同时兜住 SetWindowsHookEx 失败
+    // 与 kThreadArm 消息根本没送达（PostThreadMessage 会失败且旧实现不检查返回值）。
+    final int livenessBranch = source.indexOf('msg.wParam == liveness_timer');
+    expect(
+      livenessBranch,
+      greaterThanOrEqualTo(0),
+      reason: '必须有独立的存活性核对分支',
+    );
+    final String livenessBody = source.substring(livenessBranch);
+    expect(
+      livenessBody.contains('g_target.load'),
+      isTrue,
+      reason: '核对必须以 g_target 为 armed 真值，而不是另建一套状态',
+    );
+
+    // 核对分支里必须既能补装、又能先卸后重装（被系统摘掉时 HHOOK 仍非空）。
+    final int nextBranch = livenessBody.indexOf('} else if (msg.message ==');
+    final String scoped =
+        nextBranch > 0 ? livenessBody.substring(0, nextBranch) : livenessBody;
+    expect(
+      RegExp('SetWindowsHookEx').allMatches(scoped).length,
+      greaterThanOrEqualTo(2),
+      reason: '核对分支要覆盖「补装」和「重装」两条路径',
+    );
+    expect(
+      scoped.contains('UnhookWindowsHookEx'),
+      isTrue,
+      reason: '重装前必须先卸掉旧句柄，否则泄漏钩子',
+    );
+  });
+
+  test('吊销判据用光标位移，不是「一段时间没事件」', () {
+    final int livenessBranch = source.indexOf('msg.wParam == liveness_timer');
+    expect(livenessBranch, greaterThanOrEqualTo(0));
+    final String livenessBody = source.substring(livenessBranch);
+    final int nextBranch = livenessBody.indexOf('} else if (msg.message ==');
+    final String scoped =
+        nextBranch > 0 ? livenessBody.substring(0, nextBranch) : livenessBody;
+
+    // 「光标动了但回调一次没跑」才是零误报判据。只看「N 秒没事件」会把「用户没动
+    // 鼠标」误判成吊销，于是空闲时反复重装全局钩子——那本身就是一次次全系统输入抖动。
+    expect(
+      scoped.contains('GetCursorPos'),
+      isTrue,
+      reason: '判据必须包含光标位移，否则空闲会被误判成吊销',
+    );
+    expect(
+      RegExp(r'cursor\.x != last_cursor\.x').hasMatch(scoped),
+      isTrue,
+      reason: '必须真的比较光标坐标',
+    );
+    expect(
+      RegExp(r'seen_tick == last_seen_tick').hasMatch(scoped),
+      isTrue,
+      reason: '必须同时要求「回调一次都没跑」，两个条件缺一都会误判',
+    );
+  });
+}
+
+/// 剥掉 `//` 行注释与 `/* */` 块注释。
+///
+/// 不剥就等于允许「把断言要找的字面量写进注释」蒙混过关——本仓库出过这类假绿。
+String _stripComments(String source) {
+  final String withoutBlocks =
+      source.replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '');
+  return withoutBlocks.split('\n').map((String line) {
+    final int idx = line.indexOf('//');
+    return idx >= 0 ? line.substring(0, idx) : line;
+  }).join('\n');
+}

--- a/hibiki/windows/runner/low_level_mouse_hook.cpp
+++ b/hibiki/windows/runner/low_level_mouse_hook.cpp
@@ -20,9 +20,24 @@ constexpr UINT kThreadDisarm = WM_APP + 0x61;
 // 维持「不查词不留全局钩子」的承诺。
 constexpr UINT kDisarmGraceMs = 3000;
 
+// BUG-1265 — 钩子存活性核对间隔（毫秒）。
+//
+// WH_MOUSE_LL 不是「装上就永远有效」的资源：回调若超过 HKCU\Control Panel\Desktop
+// 的 LowLevelHooksTimeout（默认 300ms）没返回，**系统会直接把这个钩子从链上摘掉**，
+// 既不通知也不让 HHOOK 失效。旧实现只在 Arm 时装一次，之后 `hook != nullptr` 永远为
+// 真，于是被摘掉之后再也不会重装——查词卡从此收不到任何点击，而台词照常更新（那条路
+// 走 IPC→ExecuteScript，与钩子无关），表现成「浮窗看得见、点不动，只能重启」。玩 gal
+// 时进程内同时有词典 FFI、WebView2 COM、语音捕获与转码在抢核，超时是现实会发生的。
+constexpr UINT kLivenessIntervalMs = 1000;
+
 // 钩子线程与调用线程共享的唯一可变状态：目标窗口。回调只读它，故用 atomic 而不是锁——
 // 钩子回调必须尽快返回，任何可能阻塞（锁竞争、堆分配）的东西都不该出现在这条路径上。
 std::atomic<HWND> g_target{nullptr};
+
+// BUG-1265 — 回调最近一次被调用的时刻。存活性判据的一半（另一半是光标是否移动过）。
+// 只在回调里写、只在钩子线程的定时器里读，relaxed 足够：判据比较的是「有没有变化」，
+// 不依赖它与其他内存的顺序关系。
+std::atomic<ULONGLONG> g_callback_tick{0};
 
 std::mutex g_thread_mutex;
 std::atomic<DWORD> g_thread_id{0};
@@ -30,6 +45,10 @@ std::atomic<DWORD> g_thread_id{0};
 HANDLE g_thread_ready = nullptr;
 
 LRESULT CALLBACK HookProc(int code, WPARAM wparam, LPARAM lparam) {
+  // BUG-1265 — 存活证据必须记在最前面：**移动事件**才是每秒都有的那类，用它证明
+  // 钩子还在链上；记在过滤分支之后就只剩点击/滚轮能刷新，判据立刻失效。
+  // GetTickCount64 是读共享页的纯计算，没有系统调用开销。
+  g_callback_tick.store(GetTickCount64(), std::memory_order_relaxed);
   // 只关心「按下」和「滚轮」：移动直接放行（这条分支每秒会跑上千次，在任何系统
   // 调用之前必须先被纯比较挡掉）。
   const bool is_click =
@@ -108,6 +127,14 @@ void HookThreadMain() {
   HHOOK hook = nullptr;
   // 宽限期卸载定时器（线程定时器，WM_TIMER 走本线程消息队列）。0 = 未挂起。
   UINT_PTR disarm_timer = 0;
+  // BUG-1265 — 存活性核对定时器：常驻，不随 Arm/Disarm 起停。armed 状态的真值是
+  // g_target，Arm/Disarm 消息只是「立刻生效」的快路径；让这只定时器周期性地把实际
+  // 钩子状态收敛到 g_target，SetWindowsHookEx 失败、PostThreadMessage 丢失、系统
+  // 摘钩这三类静默失败就都只是「下一拍自动补上」，不再各需一套特例分支。
+  UINT_PTR liveness_timer = SetTimer(nullptr, 0, kLivenessIntervalMs, nullptr);
+  POINT last_cursor{};
+  GetCursorPos(&last_cursor);
+  ULONGLONG last_seen_tick = g_callback_tick.load(std::memory_order_relaxed);
   while (GetMessage(&msg, nullptr, 0, 0) > 0) {
     if (msg.message == kThreadArm) {
       if (disarm_timer != 0) {
@@ -118,6 +145,35 @@ void HookThreadMain() {
         hook = SetWindowsHookEx(WH_MOUSE_LL, &HookProc,
                                 GetModuleHandle(nullptr), 0);
       }
+    } else if (msg.message == WM_TIMER && liveness_timer != 0 &&
+               msg.wParam == liveness_timer) {
+      POINT cursor{};
+      const BOOL got_cursor = GetCursorPos(&cursor);
+      const ULONGLONG seen_tick =
+          g_callback_tick.load(std::memory_order_relaxed);
+      if (g_target.load(std::memory_order_relaxed) != nullptr) {
+        if (hook == nullptr) {
+          // armed 但没有钩子：Arm 那次 SetWindowsHookEx 失败，或 kThreadArm 根本没
+          // 送达（PostThreadMessage 会失败，旧实现没检查返回值）。补装。
+          hook = SetWindowsHookEx(WH_MOUSE_LL, &HookProc,
+                                  GetModuleHandle(nullptr), 0);
+        } else if (got_cursor &&
+                   (cursor.x != last_cursor.x || cursor.y != last_cursor.y) &&
+                   seen_tick == last_seen_tick) {
+          // 判据零误报：光标位置变了，说明这一秒里系统一定投递过 WM_MOUSEMOVE；
+          // 而我们的回调一次都没跑，那它只可能已经不在钩子链上了（被系统摘掉，或被
+          // 链上更靠前的钩子吞掉——后者重装排到链首同样是正解）。
+          // 反向不成立的那半（光标没动 → 本就无事件）已被 cursor 比较排除，因此
+          // 「用户只是没动鼠标」永远不会触发重装。
+          UnhookWindowsHookEx(hook);
+          hook = SetWindowsHookEx(WH_MOUSE_LL, &HookProc,
+                                  GetModuleHandle(nullptr), 0);
+        }
+      }
+      if (got_cursor) {
+        last_cursor = cursor;
+      }
+      last_seen_tick = seen_tick;
     } else if (msg.message == kThreadDisarm) {
       // g_target 已由 Disarm 侧清空（回调此刻起纯放行）；这里只安排宽限期后的
       // 真正卸载。已有挂起定时器就沿用原先的到期时间。
@@ -136,6 +192,9 @@ void HookThreadMain() {
         hook = nullptr;
       }
     }
+  }
+  if (liveness_timer != 0) {
+    KillTimer(nullptr, liveness_timer);
   }
   if (hook != nullptr) {
     UnhookWindowsHookEx(hook);


### PR DESCRIPTION
用户报的四个 galgame 问题，本 PR 修其中三个。三条的共同形态是**把「取不到 / 还没到」当成了「就是没有 / 到此为止」**。

## BUG-1265 查词点不动、整个 app 像卡死

用户原话：「点查词没反应，然后卡住台词了，甚至关不掉，直接任务管理器关的。查词点不动了，但是还在跟着 gal 的台词变」。

查词卡是 `WS_EX_NOACTIVATE` 的 topmost 窗，点击**唯一**来源是 `WH_MOUSE_LL` 回调投递的 `kLowLevelMouseClickMessage`。而 `WH_MOUSE_LL` 是 Windows 会**主动吊销**的资源：回调超过 `LowLevelHooksTimeout`（默认 300ms）没返回，系统直接摘链，既不通知也不让 `HHOOK` 失效。旧实现只在 Arm 时装一次，`hook != nullptr` 恒为真，被摘后永不重装 —— 浮窗看得见点不动，台词却照常刷新（那条走 IPC→ExecuteScript，与钩子无关），且不可自愈只能重启。玩 gal 时词典 FFI、WebView2 COM、语音转码一起抢核，`TIME_CRITICAL` 也保证不了 300ms 内被调度。

修法不是重试或延时，而是**把 armed 的真值收敛到 `g_target`**：钩子线程常驻 1s 核对定时器，每拍收敛实际钩子状态。一条机制同时消掉三类静默失败（`SetWindowsHookEx` 返回 null、`PostThreadMessage` 投递失败、系统摘钩），不再各需特例分支。

吊销判据是**光标位移 ∧ 回调未跑**，零误报：光标动了说明系统必然投递过 `WM_MOUSEMOVE`，回调却一次没跑，那它只可能已不在链上。只看「N 秒没事件」会把「用户没动鼠标」误判成吊销，空闲反复重装全局钩子本身就是一次次全系统输入抖动。存活证据记在 `HookProc` 最前面（早于 `code < 0` 过滤），因为移动事件才是每秒都有的那类。

## BUG-1266 查词时语音只到句子前半段

用户原话：「我查一个词，它在句子的中后段，然后语音只到前半段就中断了」。

`_flushLoopbackFreeze` 提前收束时 `timer.cancel()` 把完整窗口定时器**永久取消**，只按 `elapsedMs + preRoll` 回取，之后**再没有任何补全** —— 把「用户现在就要声音」实现成了「就此永久定格」。引擎 PCM 那条路早有 `_settleLineUtterance`，Loopback 缺了对称的一半。

改为收束后按**原到期时刻**补排 `_scheduleLoopbackSettle`：立刻给能用的，窗口到点再取完整长度，更长才覆盖。补全定时器仍装在 `_loopbackFreezeTimers` 里，会话结束/禁止降级/补录/选轨都能像取消普通冻结一样取消它。边界：补全取空**不标 missing**（一次失败的加取不该毁掉已经能用的音频）；音源即将换走时 (`_flushAllLoopbackFreezes`) 不补排。

## BUG-1267 中途对接抓不到文本

用户问「helper 支持中途注入，为什么客户端没法中途对接」，并附了手动跑 injector 的输出：`[session] reusing live hook mapping pid=42504 text=0 audioBytes=0` / `[unity-audio] resource extractor runtime missing` / `OK hooked pid=42504 hooked=1`。

能力其实是齐的：injector 有 `--pid`，客户端也有 attach 模式。缺的是 `--luna-pchooks`。`shouldUseLunaPcHooksForExecutable` 的判据只认 exe 路径（basename 白名单，或同目录 `UnityPlayer.dll` **且**有 IL2CPP/Mono 证据），launch 有路径、attach 没有，于是两个调用点直接写死 `false` —— **「判据取不到」被实现成「判为否」**。后果是 Unity/IL2CPP 与 Siglus 目标只要不是 Hibiki 亲自拉起就永不补装 PC hooks，injector 报 `text=0`，正是用户看到的「捕获上了但什么都不出」（那行 `[unity-audio]` 也印证目标是 Unity）。

exe 路径本来就能从 PID 拿到。新增 `GalTargetImagePathProbe`（默认实现复用既有的 `GalgameWindowsProcessProbe.processImagePath` / `QueryFullProcessImageNameW`，不写第四份 FFI 封装），attach 两处改走 `_lunaPcHooksForPid(pid)`，与 launch 共用同一套判据。查不到路径返回 false，与修复前一致 —— 探测失败不会比旧版更糟。probe 懒实例化，非 Windows 返回 null，不影响 Linux CI。

## 测试

- 6 条行为测试（`gal_attach_pchooks_loopback_settle_test.dart`）：attach 的 `lunaPcHooks` 四个方向（Unity/IL2CPP、非 Unity、只有 UnityPlayer.dll 无 IL2CPP 证据、PID 查不到）；loopback 补全与「补全取空保留已冻结切片」。
- 3 条 native 源码守卫（`gal_lookup_hook_liveness_guard_test.dart`）：钩子逻辑在 C++ runner，Dart 无法驱动，取最强可落地层。**扫描前剥注释**，防「把断言字面量写进注释」的假绿。
- **三条修复均做过变异实测**：摘掉 `_scheduleLoopbackSettle` → 核心断言红；attach 改回 `lunaPcHooks: false` → Unity 那条红；把存活证据挪到过滤分支之后并在注释里留下字面量 → 守卫红（证明剥注释有效）。

`flutter analyze` 全量干净。全量 15864 测试跑完 5 个失败，已在**同一 worktree 的基线**上逐个复现为既有红（`texthooker_page` / `remote_card_longpress_dialog` / `video_playlist_mining_title` / `video_statusbar_immersive_guard` / `vn_view_mode_three_state_guard`），与本改动无关。

## 未处理 / 待确认

- **一键启动报 fatal error 未修** —— 缺报错原文。已查明：整个 native 代码库里 "fatal" 只出现在 `native/galgame_hook/hook/il2cpp_thread_scope.h` 的注释，即 Unity 的 `Fatal error in GC: Collecting from unknown thread`；injector 自己不会打印 "fatal error"。这能解释「一键启动崩、LE 启动后 attach 不崩」（前者是 `CREATE_SUSPENDED` 早注入，撞在 IL2CPP 运行时初始化之前），但仍是推断，需用户提供弹窗标题/正文后另开 BUG。
- **BUG-1265 是 native 改动，本轮未做 Windows 真机构建验证**，Dart 侧 analyze/test 覆盖不到它的编译。合入前需在 Windows 出包路径上复验。

https://claude.ai/code/session_01LA7brHxPnxZSpE6D48VBd9
