### PR TITLE
fix(video): 恢复位置改走 libmpv start 加载参数，修安卓进视频被踢回开头 (BUG-1270)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1186 条。点号进各自文件。
+> 共 1187 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1270](bugs/BUG-1270-android-video-resume-seek-overwritten.md) | ✅ | ✅ | 安卓视频进入后被踢回开头：恢复 seek 被 loadfile 覆盖 |
 | [BUG-1225](bugs/BUG-1225-shm-reader-write-access-must-stay.md) | ✅ | ✅ | 读端共享内存写权限不可收紧：SelectTextThread 的原子写落在只读页上会崩 |
 | [BUG-1221](bugs/BUG-1221-manga-path-case-folded.md) | ✅ | ✅ | 漫画页图解析把路径折成小写，制卡封面名被小写化且大小写敏感平台缺页 |
 | [BUG-1220](bugs/BUG-1220-bangumi-sync-invisible.md) | ✅ | ✅ | Bangumi 同步链路全静默：看完了没反应且无处查看 |

--- a/docs/bugs/BUG-1270-android-video-resume-seek-overwritten.md
+++ b/docs/bugs/BUG-1270-android-video-resume-seek-overwritten.md
@@ -1,0 +1,53 @@
+## BUG-1270 · 安卓视频进入后被踢回开头：恢复 seek 被 loadfile 覆盖
+- **报告**：2026-07-31（用户：手机上进视频「进去就直接给我踢开头去了。明明在外面看着还是有显示我上次观看进度的……点进去一瞬间还能看到我原本进度的一帧，然后踢回开头」）
+- **真实性**：✅ 真 bug，Android 模拟器 100% 复现。根因 `hibiki/lib/src/media/video/video_player_controller.dart` 的 `load()`——恢复位置走「`open()` 之后再 `seek`」，而该 seek 会被 libmpv 尚未结束的 loadfile 流程按 `start`（默认 0）覆盖。
+
+### 复现证据（Android 模拟器 emulator-5556，真实 libmpv）
+`hibiki/integration_test/video_resume_seek_lands_test.dart`：90s 视频、`lastPositionMs=45000`，打开播放页后密集采样 8s 位置：
+
+```
+duration=90023
+samples=[1746, 2716, 3742, 4004, ..., 17404, 17574, 17886]
+```
+
+- `duration=90023` **完全正确** → `resolveEpisodeStart` 的 near-end 分支未触发（`45000/90023=0.5`，remaining 45s），解析出的目标必然是 `45000`，即 **seek 确实发出了**；
+- 但位置从 ~0 单调递增到 17.9s，**全程从未到达 45s** → seek 没有保住。
+
+用户「看到原本进度的一帧又跳回开头」正是这个过程的肉眼表现：seek 让 mpv 渲染出断点那一帧，随后 loadfile 收尾把播放位置定位回 `start`（0）。
+
+### 根因
+- **数据流**：`VideoHibikiPage._loadSingle` 读 `VideoBooks.lastPositionMs` → `_applyLoad(initialPositionMs:)` → `VideoPlayerController.load()`。DB 侧完好——已核过全部写入点，打开视频时没有任何路径会把 `lastPositionMs` 清零（`upsertVideoBook` 是 `DoUpdate` 按列 upsert，`updateVideoBookPosition` 是单列 update）。这解释了用户「外面还显示上次进度、进去却从头」为何不矛盾：**DB 是对的，是播放器没保住 seek**。
+- **缺陷**：`load()` 用 `_waitUntilSeekable`（等 `duration > 0`）当作「可以 seek 了」的判据，然后 `player.seek(target)`。但 media_kit 的 `open()` 把真正触发加载的 `playlist-pos` 写在整个命令序列的**最后**（`media_kit-1.2.6` `lib/src/player/native/player/real.dart:228`，其前是 `stop`/`playlist-clear`/`playlist-play-index none` → `pause=yes` → `loadlist append`），**且不等它完成就返回**。`duration` 属性只说明容器头解析完了（media_kit 经 `mpv_observe_property('duration')` 推送，`real.dart:1574-1581`），不代表 loadfile 流程结束。此时发出的 seek 会被随后完成的加载按 `start` 覆盖。
+- **为何 media_kit 给不出正确判据**：它 observe 的 19 个属性里（`real.dart:2458-2477`）**没有 `seekable`**，所以除了 `duration>0` 之外拿不到更好的信号——这不是随手写错，是被上游接口逼出来的。
+- **与 BUG-179 的关系**：同一个洞。BUG-179 只给恢复守护补了有界宽限（避免 seek 失败时守护永久吞掉进度写入），**没有修 seek 落地本身**，其文档第 22 行自陈「根因仍需真机复测」。本次补上的正是那一步。
+- **为何 Android 明显、桌面偶发**：桌面 libmpv 命令消化快，seek 常常赶在 loadfile 收尾之后；Android/模拟器主循环慢，必现。
+
+根因 `file:line`（修复前语义）：`hibiki/lib/src/media/video/video_player_controller.dart` 的 `load()`——恢复位置在 `player.open()` **之后**才 seek，判据 `_waitUntilSeekable`（`duration>0`）不足以证明 loadfile 已结束。
+
+### ① 修复
+- **[x] ① 已修复** — 把「从哪开始」从**加载后的操作**改成**加载参数**，竞态窗口直接消失（不是加延迟/重试掩盖症状）：
+  1. 新增 `applyMpvStartPosition(player, positionMs)` / `clearMpvStartPosition(player)` / `formatMpvStartSeconds(ms)`（`hibiki/lib/src/media/video/video_mpv_config.dart` 末尾），经既有 `native.setProperty` best-effort 范式写 libmpv `start` 选项；
+  2. `load()` 在 `player.open()` **之前**按 intent 算出 `preloadStartMs`（`resolveEpisodeStart(..., null)`，该分支已把 `manualPrevious`/`autoAdvance` 归 0，不会给「本就该从头」的入口设 start）并下发 `start` → mpv 在 loadfile 时就定位到断点；
+  3. open 之后用真实 duration 复核 near-end；`start` 是**全局选项**（换集/画质切档复用同一 `Player`），复核完立即 `clearMpvStartPosition` 复位，绝不让下一集继承上一集的起播秒数；
+  4. near-end 复核翻转时（open 前按断点设了 start，真实 duration 显示已快看完）显式 `seek(Duration.zero)` 把 mpv 拉回开头，保住 near-end 语义；
+  5. 非 libmpv 后端 `applyMpvStartPosition` 返回 false，**回退到既有的 open 后 seek 路径**，行为与修复前一致；`_restoreTargetMs` 守护与 BUG-179 的有界宽限全部保留（它挡的是「seek 未落地期间用过渡期小值覆盖真实进度」，与本修复正交）。
+- 修复 `file:line`：`hibiki/lib/src/media/video/video_mpv_config.dart`（`formatMpvStartSeconds` / `applyMpvStartPosition` / `clearMpvStartPosition`）；`hibiki/lib/src/media/video/video_player_controller.dart:1120-1140`（open 前下发 start）、`:1205-1245`（duration 复核 + 复位 + near-end 拉回 0 + 回退 seek）。
+- 提交：见分支 `worktree-video-resume-seek-race`。
+
+### ② 测试
+- **[x] ② 已加自动化测试** —
+  - **真机行为门**：`hibiki/integration_test/video_resume_seek_lands_test.dart`（新增）。跑真实 libmpv：90s 视频 + `lastPositionMs=45000` → 打开播放页 → 密集采样 8s → 断言 ①恢复 seek 至少落地过一次（出现过 ≥40s），②落地后不得回落到开头（<5s）。Android 模拟器 emulator-5556 实测：
+
+    | | `samples`（位置采样，ms） | 结果 |
+    |---|---|---|
+    | 修复前 | `[1746, 2716, …, 17886]` — 从 0 播，全程未达 45s | ❌ 红：「恢复 seek 从未落地」 |
+    | 修复后 | `[46200, 46959, …, 63074]` — 从 46.2s 起播，无回落 | ✅ 绿：`All tests passed!` |
+
+    两次 `duration` 均报 90023（正确），佐证失败与 near-end 误判无关，就是 seek 没保住。
+    - 素材：Android 模拟器（x86_64）没有 FFmpegKit native 库，`generateTestVideo` 必失败，故测试优先读 `adb push` 到 `/sdcard/Android/data/app.hibiki.reader/files/resume_probe.mp4` 的预置素材（app 外部文件目录，无需存储权限），桌面/有 ffmpeg 环境仍自给自足。
+  - **host 侧守卫**：`hibiki/test/media/video/video_mpv_start_position_test.dart`（新增，5 用例，进 CI 单测门）。`start` 值格式化 + **顺序契约源码扫描**：`applyMpvStartPosition` 必须排在 `player.open(` 之前、必须有 `clearMpvStartPosition`、near-end 翻转必须 `seek(Duration.zero)`。顺序一旦被后来的重构挪动，修复会静默失效且任何 host 侧行为测试都抓不到，故用源码守卫钉死。
+- **变异实测**（守卫防假绿）：① 把 `applyMpvStartPosition` 调用挪到 `player.open(` 之后 → 「start 下发排在 player.open( 之前」转红；② 删掉 `clearMpvStartPosition(player)` 调用 → 「start 用完必须复位」转红。两次变异后均还原源码并复跑全绿。
+- **备注**：headless 单测跑不了真实 libmpv loadfile，故行为验证只能落在集成测试；host 侧守卫只保顺序契约不保行为，两者互补。
+
+### 相邻问题（本 bug 不含，另行跟踪）
+用户同报「字幕记录也无了得重新选」。已排查并**排除**两条嫌疑：来源库重扫（`source_library_scanner.dart:583-586` 对已入库路径有显式跳过，且扫描全靠手动触发）、合集各集字幕不落库（`subtitle.part.dart:934/977/1004` 的 else 分支确实调了 `updateSubtitleSource`）。尚无确凿根因，待单独立项。

--- a/hibiki/integration_test/video_resume_seek_lands_test.dart
+++ b/hibiki/integration_test/video_resume_seek_lands_test.dart
@@ -1,0 +1,168 @@
+// 真机/模拟器集成测试：打开有断点的视频后，恢复 seek 必须**落地并保持**。
+//
+// 复现用户报告（Android）：「点进去一瞬间还能看到我原本进度的一帧，然后踢回开头」。
+// 症状是恢复 seek 已经生效（画面跳到断点帧）但随后位置被重置回 0 —— 与 BUG-179
+// 记录的「seek 落不了地」是同一根因的两种表现（那次只补了守护宽限，没修 seek 本身）。
+//
+// 本测试跑真实 libmpv：造一段 90s 视频 → seed `lastPositionMs=45000` 的 VideoBook →
+// 打开 [VideoHibikiPage] → 密集采样 8s 位置序列 → 断言
+//   ① 恢复 seek 至少落地过一次（出现过 >=40s 的位置）；
+//   ② 落地之后位置**不得**回落到开头（<5s）。
+// ② 正是用户症状：seek 落地后被 media_kit `open()` 尾部的 `playlist-pos` 重载踢回 0。
+//
+// 运行（Android 模拟器 / 真机）——素材必须在**安装之后**推，`flutter test -d` 在 APK
+// 变更时会卸载重装、清空 app 外部文件目录：
+//   ffmpeg -y -f lavfi -i testsrc=size=320x240:rate=10 -f lavfi -i anullsrc=r=44100:cl=mono \
+//          -t 90 -c:v mpeg4 -c:a aac resume_probe.mp4
+//   flutter build apk --debug --target-platform android-x64 --no-pub
+//   adb install -r -t build/app/outputs/flutter-apk/app-debug.apk
+//   adb push resume_probe.mp4 /sdcard/Android/data/app.hibiki.reader/files/resume_probe.mp4
+//   flutter test integration_test/video_resume_seek_lands_test.dart -d emulator-5556 --no-pub
+// 运行（Windows 离屏，素材由 ffmpeg 现造，无需预置）：
+//   .\hibiki\tool\run_windows_itest.ps1 integration_test\video_resume_seek_lands_test.dart
+import 'dart:async';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'package:hibiki/main.dart' as app;
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/pages/implementations/video_hibiki_page.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import 'helpers/media_fixtures.dart';
+import 'test_helpers.dart';
+
+/// 断点位置：距片头足够远，回落到开头无法与「seek 未落地」混淆。
+const int _kResumeMs = 45000;
+
+/// 判定「seek 已落地」的阈值（略低于断点，容忍解码对齐到关键帧的回退）。
+const int _kLandedMs = 40000;
+
+/// 判定「被踢回开头」的阈值。
+const int _kRewoundMs = 5000;
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'resume seek lands and is not rewound to the start',
+    (WidgetTester tester) async {
+      final List<String> caught = <String>[];
+      final FlutterExceptionHandler? oldHandler = FlutterError.onError;
+      FlutterError.onError = (FlutterErrorDetails details) {
+        caught.add(details.exceptionAsString());
+      };
+      try {
+        app.main(const <String>[]);
+        expect(await waitForHome(tester), isTrue);
+        await tester.pump(const Duration(seconds: 2));
+
+        final ProviderContainer container = ProviderScope.containerOf(
+          tester.element(find.byType(MaterialApp).first),
+        );
+        final AppModel appModel = container.read(appProvider);
+        final VideoBookRepository repo = VideoBookRepository(appModel.database);
+
+        // 90s 测试视频：断点 45s 处在片中，seek 目标明确。
+        //
+        // Android 模拟器（x86_64）没有 FFmpegKit native 库，[generateTestVideo] 必失败，
+        // 故优先用外部预置素材（`adb push` 到 app 外部文件目录，无需存储权限即可读）：
+        //   adb push resume_probe.mp4 \
+        //     /sdcard/Android/data/app.hibiki.reader/files/resume_probe.mp4
+        // 桌面/有 ffmpeg 的环境仍走 [generateTestVideo] 自给自足。
+        const String prepushed =
+            '/sdcard/Android/data/app.hibiki.reader/files/resume_probe.mp4';
+        final File videoFile;
+        if (Platform.isAndroid) {
+          // Android 上**只**认预置素材：FFmpegKit 在模拟器必失败，落回
+          // [generateTestVideo] 只会抛出与本 bug 无关的异常，把「素材没准备好」
+          // 伪装成「修复失效」。缺素材时明确 fail 并给出准备命令，不误导判绿。
+          //
+          // 注意 `flutter test -d` 在 APK 变更时会卸载重装，app 外部文件目录随之
+          // 清空 —— 素材必须在**安装之后**推：
+          //   adb install -r -t build/app/outputs/flutter-apk/app-debug.apk
+          //   adb push resume_probe.mp4 $prepushed
+          expect(File(prepushed).existsSync(), isTrue,
+              reason: '缺测试素材 $prepushed。先 adb install 再 adb push（重装会清空该目录）；'
+                  '素材 = 90s testsrc mp4，见本文件头部注释。');
+          videoFile = File(prepushed);
+        } else {
+          final Directory dir =
+              await Directory.systemTemp.createTemp('hibiki_resume_seek_');
+          videoFile = await generateTestVideo(
+            outPath: '${dir.path}${Platform.pathSeparator}resume_probe.mp4',
+            duration: const Duration(seconds: 90),
+          );
+        }
+        const String bookUid = 'video/itest-resume-seek-lands';
+        await repo.saveVideoBook(VideoBooksCompanion(
+          bookUid: const Value(bookUid),
+          title: const Value('resume seek probe'),
+          videoPath: Value(videoFile.absolute.path),
+          lastPositionMs: const Value(_kResumeMs),
+        ));
+
+        final NavigatorState navigator =
+            tester.state<NavigatorState>(find.byType(Navigator).first);
+        unawaited(navigator.push<void>(MaterialPageRoute<void>(
+          builder: (_) => VideoHibikiPage(bookUid: bookUid, repo: repo),
+        )));
+
+        VideoHibikiTestHooks? readHooks() {
+          if (find.byType(VideoHibikiPage).evaluate().isEmpty) return null;
+          return tester.state<State<VideoHibikiPage>>(
+              find.byType(VideoHibikiPage)) as VideoHibikiTestHooks;
+        }
+
+        bool ready = false;
+        for (int i = 0; i < 80; i++) {
+          await tester.pump(const Duration(milliseconds: 250));
+          if (readHooks()?.debugPositionMs != null) {
+            ready = true;
+            break;
+          }
+        }
+        expect(ready, isTrue, reason: '控制器应在 load 后就绪');
+
+        // 密集采样 8s（覆盖 _waitUntilSeekable 5s 上限 + seek 落地 + 起播）。
+        // 页面 _applyLoad 传 autoPlay:true，无需手动 play。
+        final List<int> samples = <int>[];
+        for (int i = 0; i < 64; i++) {
+          await tester.pump(const Duration(milliseconds: 125));
+          final int? pos = readHooks()?.debugPositionMs;
+          if (pos != null) samples.add(pos);
+        }
+        debugPrint('[resume-seek] duration=${readHooks()?.debugDurationMs} '
+            'samples=$samples');
+
+        final int landedAt = samples.indexWhere((int p) => p >= _kLandedMs);
+        expect(landedAt, greaterThanOrEqualTo(0),
+            reason: '恢复 seek 从未落地（位置从未到达 ${_kLandedMs}ms）。samples=$samples');
+
+        final List<int> afterLanding = samples.sublist(landedAt);
+        final int rewoundAt =
+            afterLanding.indexWhere((int p) => p < _kRewoundMs);
+        expect(rewoundAt, -1,
+            reason: 'seek 落地后位置被踢回开头（第 $rewoundAt 个采样 = '
+                '${rewoundAt >= 0 ? afterLanding[rewoundAt] : -1}ms）。'
+                'samples=$samples');
+
+        await navigator.maybePop();
+        for (int i = 0; i < 20; i++) {
+          await tester.pump(const Duration(milliseconds: 100));
+          if (find.byType(VideoHibikiPage).evaluate().isEmpty) break;
+        }
+        debugPrint('[resume-seek] non-fatal framework errors=${caught.length}');
+      } finally {
+        FlutterError.onError = oldHandler;
+      }
+    },
+  );
+}

--- a/hibiki/lib/src/media/video/video_mpv_config.dart
+++ b/hibiki/lib/src/media/video/video_mpv_config.dart
@@ -688,3 +688,61 @@ Future<void> applyHttpHeaderFieldsToPlayer(
     }
   }
 }
+
+// ── 恢复起播位置：作为**加载参数**下发（BUG-1270）──────────────────────────────
+
+/// 把 [positionMs] 格式化成 libmpv `start` 选项接受的秒值字符串（`45.000`）。
+///
+/// 纯函数，供 [applyMpvStartPosition] 与单测共用。负值 clamp 到 0。
+String formatMpvStartSeconds(int positionMs) {
+  final int ms = positionMs < 0 ? 0 : positionMs;
+  return (ms / 1000).toStringAsFixed(3);
+}
+
+/// 把「本次 loadfile 的起播位置」作为**加载参数**下发给 libmpv（`start` 选项）。
+///
+/// 根因（BUG-1270）：media_kit 的 `open()` 把 `playlist-pos` 写在整个命令序列的**最后**
+/// （media_kit-1.2.6 `player/native/player/real.dart:228`），那才是真正触发 mpv 加载文件
+/// 的一步，而 `open()` **不等它完成**就返回。此时 `duration` 属性可能已就绪（旧实现的
+/// [VideoPlayerController] 据此判定「可以 seek 了」），但 mpv 仍在 loadfile 流程中——发过去
+/// 的 seek 会被随后完成的加载按 `start`（默认 0）覆盖，表现为「画面闪过断点那一帧又跳回
+/// 开头」。Android 模拟器实测必现（断点 45s，位置从 0 一路播到 17.9s，duration 报的
+/// 90023 完全正确、near-end 判定未触发，即 seek 确已发出却没保住）；桌面因命令消化快
+/// 而只是偶发，这正是 BUG-179「Android 尤甚」的同一个洞——那次只补了守护宽限，没修
+/// seek 落地本身。
+///
+/// 修法是把「从哪开始」从**加载后的操作**改成**加载参数**：mpv 在 loadfile 完成时本就
+/// 按 `start` 定位，写进去就没有「加载完再 seek」的竞态窗口可言。不是加延迟/重试掩盖
+/// 症状，而是让这个特殊情况不存在。
+///
+/// 仅 libmpv 后端有效。非 libmpv（`player.platform` 无 `setProperty`）或属性被拒时返回
+/// false，调用方回退到既有的「open 后 seek」路径，行为与修复前一致。
+Future<bool> applyMpvStartPosition(Player player, int positionMs) async {
+  if (positionMs <= 0) return false;
+  final dynamic native = player.platform;
+  if (native == null) return false;
+  try {
+    await native.setProperty('start', formatMpvStartSeconds(positionMs));
+    return true;
+  } catch (_) {
+    return false; // 非 libmpv / 属性被拒：调用方回退到 open 后 seek。
+  }
+}
+
+/// 复位 `start`（`none` = mpv 默认从头）。
+///
+/// `start` 是**全局选项**，一旦写入会影响该 [Player] 后续**每一次** loadfile；换集与画质
+/// 切档都复用同一个 Player 实例（见 [VideoPlayerController.load] 的复用注释），不清掉会
+/// 让下一集也从上一集的断点秒数起播。故本次加载定位完成后必须立即清除。
+///
+/// best-effort：与 [applyMpvConfigToPlayer] 同范式，失败静默吞掉（清不掉最坏是下次
+/// loadfile 多一次起播位置，由调用方的 near-end/seek 兜底修正）。
+Future<void> clearMpvStartPosition(Player player) async {
+  final dynamic native = player.platform;
+  if (native == null) return;
+  try {
+    await native.setProperty('start', 'none');
+  } catch (_) {
+    // 非 libmpv / 属性被拒：no-op。
+  }
+}

--- a/hibiki/lib/src/media/video/video_player_controller.dart
+++ b/hibiki/lib/src/media/video/video_player_controller.dart
@@ -1118,6 +1118,22 @@ class VideoPlayerController extends ChangeNotifier
       buildSubtitleSuppressionProperties(),
     );
     if (!_isCurrentLoad(player, loadToken)) return; // open 前抑制下发后换片/销毁。
+
+    // BUG-1270：恢复位置必须在 **open 之前**作为加载参数（libmpv `start`）下发，而不是
+    // 等 open 返回后再 seek。media_kit 的 `open()` 把真正触发加载的 `playlist-pos` 写在
+    // 命令序列最后且不等它完成；open 后发的 seek 会被随后完成的 loadfile 按 `start`
+    // （默认 0）覆盖 → 「闪过断点那一帧又跳回开头」。详见 [applyMpvStartPosition] 文档。
+    //
+    // 此处 duration 尚不可知，故按 intent 先算一次（[resolveEpisodeStart] 的 duration=null
+    // 分支已把 manualPrevious/autoAdvance 归 0，不会给「本就该从头」的入口设 start）；
+    // near-end 判定要等 open 后真实 duration，在下面复核并按需拉回 0。
+    final int requestedStartMs = initialPositionMs < 0 ? 0 : initialPositionMs;
+    final int preloadStartMs =
+        resolveEpisodeStart(startIntent, requestedStartMs, null);
+    final bool startArmed =
+        await applyMpvStartPosition(player, preloadStartMs);
+    if (!_isCurrentLoad(player, loadToken)) return; // start 下发后换片/销毁。
+
     await player.open(
       Media(
         sourceUri,
@@ -1190,17 +1206,14 @@ class VideoPlayerController extends ChangeNotifier
     _lastSpeed = initialSpeed;
     await player.setRate(initialSpeed);
     if (!_isCurrentLoad(player, loadToken)) return; // 设速率后换片/销毁。
-    // 恢复上次位置。media_kit 在 open(play:false) 后 player 未必立即可 seek（内部
-    // position 仍 0），此时 seek 会被丢弃，随后 tick 读到 0 会把真实进度覆盖成 0。
-    // 故：① 等 player 可 seek（duration ready），用真实 duration 按入口 intent
-    //     决定目标集是否应从头开始；② 设 _restoreTargetMs 守护，seek 落地前禁止
-    //     任何写入点用过渡期小值覆盖真实进度。
-    final int requestedStartMs = initialPositionMs < 0 ? 0 : initialPositionMs;
-    int resolvedStartMs = resolveEpisodeStart(
-      startIntent,
-      requestedStartMs,
-      null,
-    );
+    // 恢复上次位置。主路径已由上面的 `start` 加载参数（[applyMpvStartPosition]）完成
+    // ——mpv 在 loadfile 时就定位到断点，不存在「加载完再 seek」的竞态。这里只做两件
+    // 收尾：① 用真实 duration 复核 near-end（open 前不可知），命中则把 mpv 拉回 0；
+    // ② 非 libmpv 后端（[startArmed] 为 false）回退到既有的 open 后 seek 路径。
+    //
+    // [_restoreTargetMs] 守护保留：它挡的是「seek 未落地期间用过渡期小值覆盖真实进度」，
+    // 与本次修复正交，回退路径与慢设备仍需要它（BUG-179 的有界宽限一并保留）。
+    int resolvedStartMs = preloadStartMs;
     if (resolvedStartMs > 0) {
       await _waitUntilSeekable(player);
       if (!_isCurrentLoad(player, loadToken)) return; // 等待期间换片：放弃这次恢复
@@ -1210,11 +1223,25 @@ class VideoPlayerController extends ChangeNotifier
         player.state.duration.inMilliseconds,
       );
     }
+    // `start` 是全局选项，会影响该 Player 后续每一次 loadfile（换集 / 画质切档复用同一
+    // 实例）。本次定位已由 open 消费掉，立即复位，绝不让下一集继承上一集的起播秒数。
+    if (startArmed) {
+      await clearMpvStartPosition(player);
+      if (!_isCurrentLoad(player, loadToken)) return; // 复位后换片/销毁。
+    }
     if (resolvedStartMs > 0) {
       _restoreTargetMs = resolvedStartMs;
       _restoreGuardTicksLeft = _restoreGuardGraceTicks;
+      // startArmed 时 mpv 已停在断点，这次 seek 是幂等对齐（position 已到位，守护会在
+      // 首个 tick 立即解除）；非 libmpv 回退路径则靠它完成恢复。
       await player.seek(Duration(milliseconds: resolvedStartMs));
     } else {
+      // near-end 复核翻转（open 前按断点设了 start，真实 duration 显示已快看完）：
+      // mpv 此刻停在断点，必须显式拉回 0，否则用户看到的是「从结尾几秒开始」。
+      if (startArmed) {
+        await player.seek(Duration.zero);
+        if (!_isCurrentLoad(player, loadToken)) return; // 拉回 0 后换片/销毁。
+      }
       _restoreTargetMs = null;
       _restoreGuardTicksLeft = 0;
     }

--- a/hibiki/test/media/video/video_mpv_start_position_test.dart
+++ b/hibiki/test/media/video/video_mpv_start_position_test.dart
@@ -1,0 +1,68 @@
+// BUG-1270：恢复起播位置改走 libmpv `start` 加载参数后的纯函数 + 源码契约守卫。
+//
+// 真正的行为验证在真机集成测试 `integration_test/video_resume_seek_lands_test.dart`
+// （headless 跑不了真实 libmpv loadfile）。本文件守住两件可在 host 验的事：
+//   ① `start` 值的格式化（喂给 mpv 的字符串）；
+//   ② `load()` 里的**顺序契约**——`start` 必须在 `player.open(` 之前下发、且必须复位。
+//      顺序一旦被后来的重构挪动，修复就静默失效（回到「open 后 seek 被 loadfile 覆盖」），
+//      而任何 host 侧行为测试都抓不到，故用源码扫描守卫钉死。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_mpv_config.dart';
+
+/// 被守卫的源文件（相对 `hibiki/` 包根，`flutter test` 的 cwd）。
+const String _kControllerPath = 'lib/src/media/video/video_player_controller.dart';
+
+void main() {
+  group('BUG-1270 formatMpvStartSeconds', () {
+    test('毫秒转 mpv 秒值字符串', () {
+      expect(formatMpvStartSeconds(45000), '45.000');
+      expect(formatMpvStartSeconds(0), '0.000');
+      expect(formatMpvStartSeconds(1), '0.001');
+      expect(formatMpvStartSeconds(3661500), '3661.500');
+    });
+
+    test('负值 clamp 到 0（不给 mpv 喂负 start）', () {
+      expect(formatMpvStartSeconds(-1), '0.000');
+      expect(formatMpvStartSeconds(-45000), '0.000');
+    });
+  });
+
+  group('BUG-1270 load() 顺序契约（源码守卫）', () {
+    late String source;
+
+    setUpAll(() {
+      final File f = File(_kControllerPath);
+      expect(f.existsSync(), isTrue,
+          reason: '守卫目标不存在：$_kControllerPath（测试 cwd 应为 hibiki/ 包根）');
+      source = f.readAsStringSync();
+    });
+
+    test('start 下发排在 player.open( 之前', () {
+      final int armIdx = source.indexOf('applyMpvStartPosition(');
+      final int openIdx = source.indexOf('player.open(');
+      expect(armIdx, greaterThanOrEqualTo(0),
+          reason: 'load() 必须经 applyMpvStartPosition 把恢复位置作为加载参数下发；'
+              '缺失即回退到「open 后 seek」，Android 上必被 loadfile 覆盖。');
+      expect(openIdx, greaterThanOrEqualTo(0), reason: '找不到 player.open( 调用');
+      expect(armIdx, lessThan(openIdx),
+          reason: 'applyMpvStartPosition 必须在 player.open( **之前**调用。'
+              'mpv 的 `start` 只对随后的 loadfile 生效，写在 open 之后等于没写。');
+    });
+
+    test('start 用完必须复位（否则下一集继承上一集的起播秒数）', () {
+      expect(source.contains('clearMpvStartPosition('), isTrue,
+          reason: '`start` 是全局选项，换集/画质切档复用同一 Player；'
+              '不复位会让下一次 loadfile 从上一集断点起播。');
+    });
+
+    test('near-end 复核翻转时把 mpv 拉回 0', () {
+      // startArmed 分支里必须有 seek(Duration.zero)：open 前按断点设了 start，若真实
+      // duration 显示已快看完，mpv 已停在断点，不显式拉回就会「从结尾几秒开始」。
+      expect(source.contains('player.seek(Duration.zero)'), isTrue,
+          reason: 'near-end 复核翻转时必须 seek(Duration.zero) 把已按 start 定位的 mpv '
+              '拉回开头，否则 near-end 语义在 start 路径下失效。');
+    });
+  });
+}


### PR DESCRIPTION
## 用户报告

手机上进视频直接跳开头，书架里却还显示着上次进度，且「点进去一瞬间还能看到原本进度的一帧，然后踢回开头」；字幕选择也需要重选。

## 根因

**不在 DB。** 已核过 `lastPositionMs` 的全部写入点：打开视频时没有任何路径会把它清零（`upsertVideoBook` 是 `DoUpdate` 按列 upsert，`updateVideoBookPosition` 是单列 update）。所以「外面有进度、进去从头」并不矛盾——是播放器没保住 seek。

洞在 `VideoPlayerController.load()`：恢复位置走「`open()` 之后再 `seek`」，判据是 `_waitUntilSeekable` 的 `duration > 0`。但 media_kit 的 `open()` 把真正触发加载的 `playlist-pos` 写在命令序列**最后**（`media_kit-1.2.6` `real.dart:228`）且**不等它完成**；`duration` 只说明容器头解析完了，不代表 loadfile 结束。此时发出的 seek 会被随后完成的加载按 `start`（默认 0）覆盖——用户看到的那一帧正是 seek 渲染出来又被抹掉的结果。

media_kit observe 的 19 个属性里**没有 `seekable`**（`real.dart:2458-2477`），所以旧判据是被上游接口逼出来的，不是随手写错。

与 **BUG-179 是同一个洞**：那次只补了守护宽限（避免 seek 失败时进度被永久吞掉），没修 seek 落地本身，其文档第 22 行也自陈根因未真机验证。

## 修法

把「从哪开始」从**加载后的操作**改成**加载参数**，竞态窗口直接消失，而不是加延迟/重试掩盖症状：

1. 新增 `applyMpvStartPosition` / `clearMpvStartPosition` / `formatMpvStartSeconds`，经既有 `native.setProperty` best-effort 范式写 libmpv `start` 选项；
2. `load()` 在 `player.open()` **之前**按 intent 下发 `start`，mpv 在 loadfile 时就定位到断点；
3. open 后用真实 duration 复核 near-end，并**立即复位 `start`**（全局选项，换集/画质切档复用同一 `Player`，不复位会让下一集继承上一集的起播秒数）；
4. near-end 复核翻转时显式 `seek(0)` 拉回开头，保住原语义；
5. 非 libmpv 后端**回退**到既有路径；`_restoreTargetMs` 守护与 BUG-179 的有界宽限**全部保留**（挡的是另一回事，与本修复正交）。

## 验证

Android 模拟器实测（90s 视频，断点 45000ms，`duration` 两次均正确报 90023）：

| | `samples`（位置采样，ms） | 结果 |
|---|---|---|
| 修复前 | `[1746, 2716, …, 17886]` — 从 0 播，断点从未到达 | ❌ 红 |
| 修复后 | `[46200, 46959, …, 63074]` — 从 46.2s 起播，无回落 | ✅ 绿 |

- `flutter analyze` 全量（含 test）：**No issues found**
- `dart run tool/flutter_test_failures.dart test/media/video` → **`FLUTTER TEST VERDICT: PASSED - 1884 tests ran`**

## 测试

- `integration_test/video_resume_seek_lands_test.dart`（新增）：真实 libmpv 行为门，修复前红、修复后绿。Android 需预置素材（模拟器无 FFmpegKit），缺素材时**明确 fail 并给出准备命令**，不把「素材没准备好」伪装成「修复失效」。
- `test/media/video/video_mpv_start_position_test.dart`（新增 5 用例，进 CI 单测门）：`start` 值格式化 + `load()` **顺序契约源码守卫**（`start` 必须排在 `player.open(` 之前、必须复位、near-end 翻转必须 `seek(0)`）。顺序被重构挪动会让修复静默失效且 host 侧行为测试抓不到，故用源码守卫钉死。
- **变异实测**（防假绿）：① 把 `applyMpvStartPosition` 挪到 `open(` 之后 → 顺序守卫转红；② 删掉 `clearMpvStartPosition` → 复位守卫转红。两次还原后全绿。

## 未包含

用户同报的「字幕记录也无了得重新选」是**独立问题**，本 PR 不含。已排查并排除两条嫌疑：来源库重扫（`source_library_scanner.dart:583-586` 对已入库路径有显式跳过，且扫描全靠手动触发）、合集各集字幕不落库（`subtitle.part.dart` 的 else 分支确实调了 `updateSubtitleSource`）。尚无确凿根因，待单独立项。

https://claude.ai/code/session_019XPyGfDo7nDEm5MDFPQf53
