### PR TITLE
perf(reader): 开书路径根因优化 + 阅读器页首个 widget 冒烟测试（渐进重建 phase1）

### DIFF
--- a/hibiki/lib/src/epub/epub_book.dart
+++ b/hibiki/lib/src/epub/epub_book.dart
@@ -39,9 +39,33 @@ class EpubBook {
   /// by spine (reading order) then by DOM order within each chapter. Built once
   /// on first [images] access and cached; the illustration set is immutable for
   /// the lifetime of an opened book. Kept *out* of the constructor so [EpubBook]
-  /// stays an immutable value type (all declared fields final) -- this is the one
-  /// derived cache, never assigned from outside.
+  /// stays an immutable value type (all declared fields final) -- derived caches
+  /// like this one and [_imageOnlyChapterMemo] are never constructor inputs.
   List<EpubImageRef>? _images;
+
+  /// 按章号记忆化的 [isImageOnlyChapter] 结果。章节文件在一本已打开的书的生命周期
+  /// 内不变，答案恒定；spread 配对（[EpubSpreadMap]）、边缘分析
+  /// （EpubSpreadAnalyzer）、章节服务与预取会对同一章反复提问，未记忆化时每问一次
+  /// 就是一次整章 html_parser 全 DOM 解析（主 isolate）。缓存收在数据拥有者这里，
+  /// 所有调用方（含旧页面级缓存覆盖不到的 spread/analyzer 路径）统一受益。
+  final Map<int, bool> _imageOnlyChapterMemo = <int, bool>{};
+
+  /// 每章「实义字符数」提示（[kChapterCharCountCaliber] 当前口径，见
+  /// [chapterCharacterCount]），用于 [isImageOnlyChapter] 免解析短路。
+  ///
+  /// 方向安全性：该口径只数假名/汉字/字母数字（标点/空白剔除、振假名剥离），
+  /// 恒 ≤ [_chapterPlainTextFromBody] 的纯文本长度；因此
+  /// `hint > _imageChapterMaxTextChars` ⇒ 纯文本必超阈值 ⇒ 必非纯图片章，
+  /// 无需读盘/解析。hint ≤ 阈值（含 0 占位）不能反推，回落全量解析。
+  /// **只接受当前口径的计数**——旧口径可能计入振假名等而高估，破坏上述单向推理。
+  List<int>? _charCountHints;
+
+  /// 注入 [kChapterCharCountCaliber] 当前口径的每章字数（来自导入期落库的
+  /// chaptersJson 或后台重算），供 [isImageOnlyChapter] 免解析短路。调用方负责
+  /// 保证口径正确；长度与 [chapters] 不符时超界章节按无提示处理。
+  void setChapterCharCountHints(List<int> counts) {
+    _charCountHints = counts;
+  }
 
   Uint8List? readResource(String path) {
     final String normalized = normalizeHref(path);
@@ -122,10 +146,21 @@ class EpubBook {
   /// a real prose chapter from ever being absorbed.
   bool isImageOnlyChapter(int index) {
     if (index < 0 || index >= chapters.length) return false;
+    final bool? memo = _imageOnlyChapterMemo[index];
+    if (memo != null) return memo;
+    // 字数提示短路（方向安全性见 [_charCountHints]）：实义字数已超阈值的正文章
+    // 直接判非纯图片章，免去读盘 + 全 DOM 解析——纯文字书的 spread 分析由此
+    // 从「逐章解析全书」降为纯内存比较。
+    final List<int>? hints = _charCountHints;
+    if (hints != null &&
+        index < hints.length &&
+        hints[index] > _imageChapterMaxTextChars) {
+      return _imageOnlyChapterMemo[index] = false;
+    }
     final html_dom.Document doc = html_parser.parse(chapters[index].html);
-    if (_chapterImageRefs(doc).isEmpty) return false;
-    return _chapterPlainTextFromBody(doc.body).length <=
-        _imageChapterMaxTextChars;
+    final bool value = _chapterImageRefs(doc).isNotEmpty &&
+        _chapterPlainTextFromBody(doc.body).length <= _imageChapterMaxTextChars;
+    return _imageOnlyChapterMemo[index] = value;
   }
 
   /// The first chapter-relative image reference of chapter [index] (see

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4061,7 +4061,14 @@ class AppModel with ChangeNotifier {
 
     mediaSource.clearCurrentSentence();
     mediaSource.clearExtraData();
-    await initialiseAudioHandler();
+    // TODO-perf（开媒体反馈）：audio_service 冷启是平台通道重活（冷路径可达数百
+    // ms），此前串行挡在 Navigator.push 之前——点下卡片后到路由动画开始前屏幕零
+    // 反馈的那段就在这里。改为起跑不阻塞导航：AudioController.initialiseHandler
+    // 记忆化在飞 future（并发安全），真正需要 handler 的消费端（reader 的
+    // _resolveAudioSlot、书架后台听书 startBackgroundListening）await 同一份，
+    // 「会话挂通知前 handler 必就绪」的时序契约不变。方法自带兜底构造、永不抛，
+    // unawaited 安全。
+    unawaited(initialiseAudioHandler());
 
     _currentMediaSource = mediaSource;
     if (item != null) {

--- a/hibiki/lib/src/models/audio_controller.dart
+++ b/hibiki/lib/src/models/audio_controller.dart
@@ -47,7 +47,17 @@ class AudioController {
 
   void emitMediaPause() => _mediaPauseController.add(null);
 
-  Future<void> initialiseHandler() async {
+  /// 在飞/已完成的初始化 future（并发安全 + 可重复 await 的单次初始化）。
+  /// openMedia 只起跑不 await（audio_service 冷启不再阻塞导航）；真正需要
+  /// handler 的消费端（audiobook 会话 attach/start、书架后台听书）各自 await
+  /// 同一份。方法体自带 catch 兜底（构造本地 handler）、永不失败，故无需
+  /// 失败重置。旧实现只查 `_audioHandler != null`，并发双调会双跑
+  /// AudioService.init。
+  Future<void>? _handlerInit;
+
+  Future<void> initialiseHandler() => _handlerInit ??= _initialiseHandlerOnce();
+
+  Future<void> _initialiseHandlerOnce() async {
     if (_audioHandler != null) return;
 
     try {

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
@@ -245,6 +245,11 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
       _srtBookUid = null;
       _srtCueChapterMap = null;
       _srtChapterRanges = null;
+      // 缓存生命周期 = 音频槽绑定：detach 即失效，重接后由
+      // _primeAudioCuesForCurrentBook 重灌（_prepareSasayakiCuesJson 复用它，
+      // 不再每章重查全书 cue）。
+      _cachedAllCues = null;
+      _cachedSasayaki = false;
     }
     if (forceReload && session.isActive) {
       // 导入了新音频：必须重 load，stop 旧会话让 session.start 走全新加载分支。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
@@ -235,6 +235,10 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
   /// [forceReload] = true 时（导入新音频后重解析）先 stop 旧会话，逼 session 重新 load
   /// 新音频；首次开书 = false，优先复用既有后台会话。
   Future<void> _resolveAudioSlot({bool forceReload = false}) async {
+    // TODO-perf（开媒体反馈）：openMedia 已改为不阻塞等 audio_service 冷启，这里
+    // 是 handler 的真正消费点（session attach/start 挂媒体通知与控制流）——await
+    // 同一份记忆化 future 补齐时序契约；已就绪时立即返回，零额外开销。
+    await appModel.initialiseAudioHandler();
     final AudiobookSession session = appModel.audiobookSession;
     final AudiobookPlayerController? old = _audiobookController;
     if (old != null) {

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart
@@ -432,9 +432,6 @@ extension _ReaderMining on _ReaderHibikiPageState {
   }
 
   Future<String?> _prepareSasayakiCuesJson() async {
-    _cachedAllCues = null;
-    _cachedSasayaki = false;
-
     // BUG-395：逐句高亮策略判据归一到「cue 是否 sasayaki 编码」（与 playback 端
     // SasayakiMatchCodec.tryDecode 同一判据），不再用 _srtBookUid（音频格式=srt）
     // 当代理。旧代码在 _srtBookUid!=null 时**无条件 return null**：但「普通 EPUB +
@@ -443,16 +440,26 @@ extension _ReaderMining on _ReaderHibikiPageState {
     // 恒空）→ 每次 highlightSasayakiCue 都 RETURN_NULL_no_segments，正文无任何跟随
     // 高亮（章节级跟随仍正常，因其走 cue 解码的 sectionIndex，不依赖 DOM range）。
     // SRT 与普通有声书两源在 _loadHighlightCues 之后判据完全一致。
-    final List<AudioCue>? allCues = await _loadHighlightCues();
+    //
+    // 性能（首帧路径）：全书 cue 在 _resolveAudioSlot → _primeAudioCuesForCurrentBook
+    // 已查过并缓存进 _cachedAllCues；本方法此前每次章节加载都先清缓存再重查一遍
+    // 全书 cue（纯重复 DB 往返，串行挡在引擎注入之前），且清缓存后若加载失败会让
+    // _injectAudiobookBridge 静默拿到 null 跳过 cue 装载。缓存生命周期 = 音频槽绑定
+    // （_resolveAudioSlot 的 detach 块清、prime 重灌），这里直接复用，仅缓存缺失时
+    // 兜底加载。
+    List<AudioCue>? allCues = _cachedAllCues;
     if (allCues == null) {
-      debugPrint('[sasayaki-hl] prepareCues path=NONE '
-          '(srtUid=null, audiobookKey=null) -> return null');
-      return null;
+      allCues = await _loadHighlightCues();
+      if (allCues == null) {
+        debugPrint('[sasayaki-hl] prepareCues path=NONE '
+            '(srtUid=null, audiobookKey=null) -> return null');
+        return null;
+      }
+      _cachedAllCues = allCues;
+      _cachedSasayaki = allCues.any(
+        (c) => SasayakiMatchCodec.tryDecode(c.textFragmentId) != null,
+      );
     }
-    _cachedAllCues = allCues;
-    _cachedSasayaki = allCues.any(
-      (c) => SasayakiMatchCodec.tryDecode(c.textFragmentId) != null,
-    );
 
     final String pathTag = _srtBookUid != null ? 'SRT' : 'AUDIOBOOK';
     if (!_cachedSasayaki) {

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -1097,23 +1097,28 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     _lastSavedSection = section;
     _lastSavedProgress = progress;
 
-    final int normOffset = (progress * 10000).round();
+    // BUG-162/BUG-285：量化 + 精确锚取舍已凿进纯函数 readerPositionSaveArgs
+    // （有真行为测），此处只做接线。
+    final ({int normCharOffset, int? charOffset}) saveArgs =
+        readerPositionSaveArgs(progress: progress, charOffset: charOffset);
     debugPrint('[ReaderHibiki] save position: bookKey=${widget.bookKey} '
-        'section=$section normOffset=$normOffset charOffset=$charOffset');
+        'section=$section normOffset=${saveArgs.normCharOffset} '
+        'charOffset=$charOffset');
     final ReaderPositionRepository repo =
         ReaderPositionRepository(appModel.database);
     try {
       await repo.save(
         bookKey: widget.bookKey,
         sectionIndex: section,
-        normCharOffset: normOffset,
+        normCharOffset: saveArgs.normCharOffset,
         // BUG-162: >=0 写精确锚（char_offset 列）。<0（WebView 当帧算不出精确偏移）
         // 传 null → ReaderPositionRepository.save 在同 section 保留既有精确锚、仅跨
         // section 失效。BUG-285 回归：TODO-265 误改成直接传 -1，使 _refreshProgress /
         // _syncPositionFromWebViewProgress 在重排或竖排边缘拿到 -1 时把同 section 的
         // 精确锚覆盖成 -1 → 恢复/有声书跨章重锚退化成「章首分数」（章节粒度），不再
-        // 逐句跟随。还原 null 守卫，把同/跨 section 的取舍交回 repo.save。
-        charOffset: charOffset >= 0 ? charOffset : null,
+        // 逐句跟随。取舍语义在 readerPositionSaveArgs 纯函数里（-1 → null），把
+        // 同/跨 section 的保留/失效决策交回 repo.save。
+        charOffset: saveArgs.charOffset,
       );
     } catch (e, stack) {
       // fail-open：本次位置未落盘（后续 debounce/flush 会重试），补日志便于诊断。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -453,10 +453,16 @@ extension _ReaderWebView on _ReaderHibikiPageState {
 
   // BUG-270: warm the LRU with the next chapter (in reading direction) so a
   // forward page-turn that crosses a chapter boundary hits the cache instead of
-  // paying disk read + decode + sanitize + inject. Runs off the UI frame; skips
-  // when already cached, already in flight, or settings/book not ready. Reads on
-  // the main isolate (sanitizeXhtml is sync) but only one chapter at a time, and
-  // the result is dropped if the page was disposed or styles changed meanwhile.
+  // paying disk read + decode + sanitize + inject. Skips when already cached,
+  // already in flight, or settings/book not ready.
+  //
+  // 调度纪律（渐进重建 phase2）：旧实现用 scheduleMicrotask + 同步读盘——microtask
+  // 在当前任务展开后**立刻**执行，读盘+净化全落在同一帧内（还恰好在等
+  // onRestoreComplete 的窗口里），「Runs off the UI frame」是错觉；同步执行也让
+  // _prefetchingHtmlPath 在飞守卫形同虚设（同步不可能重入）。现改事件队列任务 +
+  // 异步 IO：当前帧先收尾，IO 让出主 isolate，净化（单章 ms 级 sync CPU）保留；
+  // 真异步后按 _styleEpoch 丢弃跨样式失效的过期结果（styleTag 烤进缓存条目），
+  // 在飞守卫此时才真正有防重入意义。
   void _prefetchAdjacentChapter(int index) {
     if (_settings == null) return;
     final String? filePath = _chapterFilePath(index);
@@ -464,16 +470,18 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     if (_sanitizedHtmlCache.containsKey(filePath)) return;
     if (_prefetchingHtmlPath == filePath) return;
     _prefetchingHtmlPath = filePath;
-    scheduleMicrotask(() {
+    final int styleEpochAtStart = _styleEpoch;
+    unawaited(Future<void>(() async {
       try {
         if (!mounted || _settings == null) return;
         if (_sanitizedHtmlCache.containsKey(filePath)) return;
         final File file = File(filePath);
-        if (!file.existsSync()) return;
-        final Uint8List raw = file.readAsBytesSync();
+        if (!await file.exists()) return;
+        final Uint8List raw = await file.readAsBytes();
+        if (!mounted || _settings == null) return;
         final Uint8List built =
             _buildSanitizedChapterHtmlBytes(raw, chapterIndex: index);
-        if (!mounted) return;
+        if (!mounted || _styleEpoch != styleEpochAtStart) return;
         _putChapterHtml(filePath, built);
       } catch (e, stack) {
         ErrorLogService.instance
@@ -483,7 +491,7 @@ extension _ReaderWebView on _ReaderHibikiPageState {
           _prefetchingHtmlPath = null;
         }
       }
-    });
+    }));
   }
 
   /// 章号非法 / 书未就绪时返回 true（保守走 eager，宁可慢一点也不冒「该 eager 的图

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -202,6 +202,12 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     final String mime = isHtmlDocument ? 'text/html' : extMime;
 
     if (mime == 'text/css') {
+      // 插入后按插入序逐出最老条目（[_kSanitizedCssCacheLimit] 封顶，见字段注释）。
+      while (_sanitizedCssCache.length >=
+              _ReaderHibikiPageState._kSanitizedCssCacheLimit &&
+          !_sanitizedCssCache.containsKey(filePath)) {
+        _sanitizedCssCache.remove(_sanitizedCssCache.keys.first);
+      }
       data = _sanitizedCssCache.putIfAbsent(filePath, () {
         // HBK-AUDIT-118: tolerate non-UTF-8 CSS bytes instead of throwing.
         final String cssText = utf8.decode(data, allowMalformed: true);
@@ -480,18 +486,15 @@ extension _ReaderWebView on _ReaderHibikiPageState {
     });
   }
 
-  /// [EpubBook.isImageOnlyChapter] 要 parse 整章 HTML，而章节 HTML 在一次阅读会话里
-  /// 不变，故按章号记忆化。章号非法 / 书未就绪时返回 true（保守走 eager，宁可慢一点也
-  /// 不冒「该 eager 的图被挂 lazy」导致分页几何塌缩的风险）。
+  /// 章号非法 / 书未就绪时返回 true（保守走 eager，宁可慢一点也不冒「该 eager 的图
+  /// 被挂 lazy」导致分页几何塌缩的风险）；其余委托 [EpubBook.isImageOnlyChapter]——
+  /// 记忆化已下沉到数据拥有者，本拦截器热路径与 spread 配对 / 边缘分析 / 预取共享
+  /// 同一份按章缓存，不再各存一份。
   bool _isImageOnlyChapterCached(int chapterIndex) {
     if (chapterIndex < 0) return true;
     final EpubBook? book = _book;
     if (book == null) return true;
-    final bool? cached = _imageOnlyChapterCache[chapterIndex];
-    if (cached != null) return cached;
-    final bool value = book.isImageOnlyChapter(chapterIndex);
-    _imageOnlyChapterCache[chapterIndex] = value;
-    return value;
+    return book.isImageOnlyChapter(chapterIndex);
   }
 
   /// TODO-perf（跨章·图片）：把下一章的插图预热进 WebView 的 HTTP 缓存。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -885,6 +885,24 @@ bool chaptersJsonCharCaliberIsCurrent(
   return true;
 }
 
+/// BUG-285 / BUG-162（TODO-575 路线·渐进重建 phase2）：位置落库参数归一化，从
+/// `_persistPosition` 凿出的纯函数（替换脆弱源码扫描守卫，真行为测见
+/// reader_position_save_args_test.dart）。
+/// - 分数进度量化为 normCharOffset ∈ [0,10000]（round 定点，恢复端 /10000 还原）。
+/// - charOffset >= 0 写精确锚；< 0（WebView 当帧算不出精确偏移的瞬态）必须映射成
+///   null——ReaderPositionRepository.save 收到 null 才会「同 section 保留既有精确
+///   锚、仅跨 section 失效」；透传 -1 会把精确锚覆盖成 -1，恢复/有声书跨章重锚
+///   退化到章首分数粒度（BUG-285 的回归形态）。
+({int normCharOffset, int? charOffset}) readerPositionSaveArgs({
+  required double progress,
+  required int charOffset,
+}) {
+  return (
+    normCharOffset: (progress * 10000).round(),
+    charOffset: charOffset >= 0 ? charOffset : null,
+  );
+}
+
 /// TODO-575 批1: 把 reader 里散落的 5 处 `rgba(...)` 生成统一成一个纯函数。
 ///
 /// 契约对齐（零行为变化）：通道一律 `(channel * 255.0).round().clamp(0, 255)`
@@ -1252,6 +1270,11 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   String? _prefetchingHtmlPath;
 
   String? _cachedStyleTag;
+
+  /// 样式代际：[_invalidateStyleCache] 每次自增。真异步预取（读盘/净化期间样式
+  /// 可能变更）据此丢弃过期结果——styleTag 烤进缓存条目，旧代际结果入缓存=脏数据
+  /// （用户刚换的字号/主题被预取章悄悄换回旧样式）。
+  int _styleEpoch = 0;
 
   Timer? _saveDebounce;
 
@@ -1636,6 +1659,12 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       ErrorLogService.instance.log('ReaderHibiki._initBook', e, stack);
       if (!mounted) return;
       HibikiToast.show(msg: t.reader_open_failed);
+      // BUG-782 同款并发退出合流：init 失败自动退与用户手动退（PopScope 的
+      // onPopInvokedWithResult）可能同窗竞发，两条各自 pop 会连退两级把书架也
+      // 弹掉。共用同一把 _popInProgress 锁：用户已在退出就让用户路径收尾，这里
+      // 不再补刀；本路径 pop 后页面随即 dispose，锁无需复位。
+      if (_popInProgress) return;
+      _popInProgress = true;
       Navigator.of(context).pop();
     }
   }
@@ -1679,6 +1708,9 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
     if (!located.exists) {
       debugPrint('[ReaderHibiki] book ${widget.bookKey} not found on disk');
       HibikiToast.show(msg: t.book_file_not_found);
+      // 与 _initBook catch 同款 _popInProgress 合流（防与用户手动退出竞发连退两级）。
+      if (_popInProgress) return;
+      _popInProgress = true;
       Navigator.of(context).pop();
       return;
     }
@@ -2588,6 +2620,7 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
 
   void _invalidateStyleCache() {
     _cachedStyleTag = null;
+    _styleEpoch++;
     // BUG-270: cached chapter HTML bakes in the styleTag, so any style change
     // must drop it — the next served chapter then rebuilds with the fresh tag.
     _sanitizedHtmlCache.clear();

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1218,6 +1218,11 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   List<int> _chapterCharCounts = [];
   List<int> _chapterCumulativeChars = [];
 
+  /// 书自带 CSS 的净化结果缓存（拦截器热路径，键 = 文件绝对路径）。与
+  /// [_sanitizedHtmlCache] 对称封顶：HTML 侧早有 LRU 上限，这侧此前无上限，
+  /// 超多 CSS 的书翻遍全书后按路径无限累积。CSS 不随主题/字号变
+  /// （_reloadWithCurrentSettings 整体清），逐出后重算无正确性影响。
+  static const int _kSanitizedCssCacheLimit = 24;
   final Map<String, Uint8List> _sanitizedCssCache = {};
 
   // BUG-270 (TODO-296 B): cross-chapter LRU cache of fully sanitized + style-
@@ -1229,11 +1234,6 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   static const int _kChapterHtmlCacheLimit = 6;
   final LinkedHashMap<String, Uint8List> _sanitizedHtmlCache =
       LinkedHashMap<String, Uint8List>();
-
-  /// TODO-perf（跨章·图片）：`EpubBook.isImageOnlyChapter` 每次都要 parse 整章 HTML，
-  /// 而它的答案在一次阅读会话里不变（章节文件不变）。按章号记忆化，避免拦截器热路径
-  /// （每次跨章 + 每次预取）重复解析。换书会连同本 State 一起重建。
-  final Map<int, bool> _imageOnlyChapterCache = <int, bool>{};
 
   /// TODO-perf（跨章·图片）预热配额（PR#469 审查）：`_prefetchAdjacentChapterImages`
   /// 把整解码后的位图塞进 WebView 图片缓存，整页插图书（1600×2400 PNG × N）在移动端
@@ -1660,6 +1660,15 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
     // 并行起跑把 profile/settings 的 DB 往返与 EPUB 解析 isolate 重叠，缩短白屏。
     final Future<void> profileSettingsFuture = _resolveProfileAndSettings(db);
     final Future<_BookLocateResult> bookLocateFuture = _locateBookOnDisk(db);
+    // TODO-131 同思路：恢复位置只按 bookKey 查（与 profile / EPUB 解析 / 音频槽
+    // 均无依赖），此前却串行排在整条 init 链末尾。提前起跑与解析重叠，消费点仍在
+    // 原位置 await（书签跳转分支不消费）。ignore() 防「书不在盘上」等早退路径把
+    // 它留成未处理异步错误；正常路径 await 时错误照常抛给 _initBook 的兜底。
+    final Future<ReaderPosition?> savedPositionFuture =
+        widget.initialBookmarkJump != null
+            ? Future<ReaderPosition?>.value(null)
+            : ReaderPositionRepository(db).findByBookKey(widget.bookKey);
+    savedPositionFuture.ignore();
 
     await profileSettingsFuture;
     if (!mounted) return;
@@ -1711,8 +1720,13 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       // 使书架总字数与后续统计随之对齐 hoshi。
       _applyCharCounts(charsFromDb);
       if (bookRow != null &&
-          !chaptersJsonCharCaliberIsCurrent(
+          chaptersJsonCharCaliberIsCurrent(
               bookRow.chaptersJson, _book!.chapters.length)) {
+        // 当前口径计数兼作 isImageOnlyChapter 的免解析短路提示（方向安全性见
+        // [EpubBook.setChapterCharCountHints]）；旧口径方向无保证，不注入，
+        // 等后台重算落定后由 _recomputeCharCountsInBackground 补上。
+        _book!.setChapterCharCountHints(charsFromDb);
+      } else {
         _recomputeCharCountsInBackground();
       }
     } else {
@@ -1767,8 +1781,7 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
           'charAnchor=$_initialCharOffset '
           'preserveSavedPosition=$_suppressPositionPersist');
     } else {
-      final ReaderPositionRepository repo = ReaderPositionRepository(db);
-      final ReaderPosition? saved = await repo.findByBookKey(widget.bookKey);
+      final ReaderPosition? saved = await savedPositionFuture;
       if (!mounted) return;
       debugPrint('[ReaderHibiki] restore lookup: bookKey=${widget.bookKey} '
           'saved=$saved section=${saved?.sectionIndex} '
@@ -1871,6 +1884,9 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
         return;
       }
       _applyCharCounts(counts);
+      // 新口径计数落定：补注 isImageOnlyChapter 的免解析短路提示（开书时旧口径
+      // 未注入的书由此补齐，后续 spread 重建/预取不再逐章解析）。
+      book.setChapterCharCountHints(counts);
       _sessionMaxAbsoluteChars = _absoluteCharPosition(_lastProgressValue);
       // TODO-1192: 把新口径计数回写 chaptersJson（含 charCaliber 标记），使书架总
       // 字数与下次开书都用新口径，避免每次开书都重算（旧书 / v1 书一次性升级）。

--- a/hibiki/test/epub/epub_image_only_chapter_test.dart
+++ b/hibiki/test/epub/epub_image_only_chapter_test.dart
@@ -133,6 +133,44 @@ void main() {
     });
   });
 
+  group('isImageOnlyChapter — 字数提示免解析短路（开书性能）', () {
+    // 提示口径（kChapterCharCountCaliber 实义字数）恒 ≤ 纯文本长度，因此
+    // hint > 阈值 ⇒ 必非纯图片章，无需解析。这里用「HTML 本身会被判为插图页、
+    // 提示却超阈值」的矛盾构造观察短路真的生效（真实数据中该矛盾不会出现，
+    // 因为插图页的实义字数必 ≤ 纯文本长度 ≤ 20）。
+    const String illustrationHtml =
+        '<html><body><img src="p1.jpg"/></body></html>';
+
+    test('hint > 阈值：免解析直接判非插图页（短路生效的可观测证据）', () {
+      final EpubBook book = _book(illustrationHtml);
+      book.setChapterCharCountHints(<int>[100]);
+      expect(book.isImageOnlyChapter(0), isFalse,
+          reason: '实义字数超阈值的章必是正文章，不该再读盘/解析');
+    });
+
+    test('hint ≤ 阈值：不能反推，回落全量解析（插图页仍被识别）', () {
+      final EpubBook book = _book(illustrationHtml);
+      book.setChapterCharCountHints(<int>[0]);
+      expect(book.isImageOnlyChapter(0), isTrue,
+          reason: '低字数只是必要条件，仍需解析确认「有图 + 短文本」');
+    });
+
+    test('hints 长度不足：超界章节按无提示处理（回落解析）', () {
+      final EpubBook book = _book(illustrationHtml);
+      book.setChapterCharCountHints(const <int>[]);
+      expect(book.isImageOnlyChapter(0), isTrue);
+    });
+
+    test('记忆化：注入提示前已解析过的章保持原判定（答案会话内恒定）', () {
+      final EpubBook book = _book(illustrationHtml);
+      expect(book.isImageOnlyChapter(0), isTrue);
+      // 后注入的矛盾提示不翻转已记忆化的结果——章节文件在一次会话内不变，
+      // 判定恒定；这同时证明第二次调用走的是缓存而非重新解析。
+      book.setChapterCharCountHints(<int>[100]);
+      expect(book.isImageOnlyChapter(0), isTrue);
+    });
+  });
+
   group('chapterImageSrc / chapterImageSrcs — feed the merge renderer', () {
     test('first <img> src', () {
       final EpubBook book =

--- a/hibiki/test/media/audiobook/image_only_chapter_pause_test.dart
+++ b/hibiki/test/media/audiobook/image_only_chapter_pause_test.dart
@@ -200,8 +200,11 @@ void main() {
           reason: 'imagePauseSec=0 时不停留');
       expect(body.contains('_imagePauseTimer'), isTrue,
           reason: '复用 triggerImagePause 同一 Timer 字段，不新造定时器语义');
+      // 恢复原语随 PR#583 审查从 `_player.play()` 改为 `_activateMainPlayer()`
+      // （统一主播放器激活入口），守卫跟进锚点；不变量不变：主动暂停→等待→恢复。
       expect(
-          body.contains('_player.pause()') && body.contains('_player.play()'),
+          body.contains('_player.pause()') &&
+              body.contains('_activateMainPlayer()'),
           isTrue,
           reason: '主动暂停→等待→恢复，复用同一暂停/恢复原语');
     });

--- a/hibiki/test/models/open_media_audio_handler_nonblocking_guard_test.dart
+++ b/hibiki/test/models/open_media_audio_handler_nonblocking_guard_test.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../pages/reader_hibiki_page_source_corpus.dart';
+
+/// 开媒体反馈守卫（渐进重建 phase2）：audio_service 冷启不得阻塞 Navigator.push。
+///
+/// 旧 openMedia 在 push 之前 `await initialiseAudioHandler()`——冷路径数百 ms 的
+/// 平台通道重活，表现为「点下书/视频卡片后屏幕毫无反应的那段」。修复后的时序
+/// 契约拆成三条不变量，缺一即回归：
+///  ① openMedia 只起跑不 await（导航立即开始）；
+///  ② AudioController.initialiseHandler 记忆化在飞 future（并发安全、可重复
+///     await——没有这条，② 的消费端 await 与 ① 的起跑会双跑 AudioService.init）；
+///  ③ handler 的真正消费端补 await：reader `_resolveAudioSlot`（session
+///     attach/start 挂媒体通知前）与书架后台听书 `startBackgroundListening`。
+///
+/// 行为驱动需要真平台通道（AudioService.init），host 测试不可用，落源码语料层。
+void main() {
+  final String appModelSrc = File('lib/src/models/app_model.dart')
+      .readAsStringSync()
+      .replaceAll('\r\n', '\n');
+  final String audioCtrlSrc = File('lib/src/models/audio_controller.dart')
+      .readAsStringSync()
+      .replaceAll('\r\n', '\n');
+  final String readerSrc = readReaderPageSource();
+
+  test('① openMedia 不再 await audio handler 冷启（起跑不阻塞导航）', () {
+    final int start = appModelSrc.indexOf('Future<void> openMedia({');
+    final int end = appModelSrc.indexOf('Future<void> closeMedia({');
+    expect(start, greaterThanOrEqualTo(0));
+    expect(end, greaterThan(start));
+    final String body = appModelSrc.substring(start, end);
+    expect(body.contains('await initialiseAudioHandler()'), isFalse,
+        reason: 'push 前 await 冷启 = 点击后零反馈的那段，禁止回归');
+    expect(body.contains('unawaited(initialiseAudioHandler())'), isTrue,
+        reason: '必须仍在 openMedia 起跑（尽早并行热身），只是不阻塞');
+  });
+
+  test('② initialiseHandler 记忆化在飞 future（并发安全单次初始化）', () {
+    expect(audioCtrlSrc.contains('_handlerInit ??= _initialiseHandlerOnce()'),
+        isTrue,
+        reason: '无记忆化时「openMedia 起跑 + 消费端 await」并发双跑 '
+            'AudioService.init');
+  });
+
+  test('③ reader _resolveAudioSlot 在会话操作前 await handler 就绪', () {
+    final int slotStart = readerSrc
+        .indexOf('Future<void> _resolveAudioSlot({bool forceReload = false})');
+    final int sessionUse = readerSrc.indexOf(
+        'final AudiobookSession session = appModel.audiobookSession;',
+        slotStart);
+    expect(slotStart, greaterThanOrEqualTo(0));
+    expect(sessionUse, greaterThan(slotStart));
+    final String beforeSession = readerSrc.substring(slotStart, sessionUse);
+    expect(beforeSession.contains('await appModel.initialiseAudioHandler();'),
+        isTrue,
+        reason: 'session attach/start 挂媒体通知前 handler 必须就绪——'
+            'openMedia 不再兜底这个时序，消费端自己 await');
+  });
+
+  test('③ 书架后台听书入口仍 await handler 就绪', () {
+    final int start = appModelSrc
+        .indexOf('Future<BackgroundListenResult> startBackgroundListening(');
+    expect(start, greaterThanOrEqualTo(0));
+    final String body = appModelSrc.substring(start, start + 800);
+    expect(body.contains('await initialiseAudioHandler();'), isTrue);
+  });
+}

--- a/hibiki/test/pages/reader_chapter_html_cache_test.dart
+++ b/hibiki/test/pages/reader_chapter_html_cache_test.dart
@@ -106,8 +106,18 @@ void main() {
       expect(prefBody.contains('_sanitizedHtmlCache.containsKey(filePath)'),
           isTrue,
           reason: '已缓存就跳过预取');
-      expect(prefBody.contains('scheduleMicrotask'), isTrue,
-          reason: '预取走后台，不阻塞当前帧');
+      // 渐进重建 phase2：旧断言钉的 scheduleMicrotask 恰是问题本身——microtask
+      // 在当前任务展开后立刻同步执行，读盘+净化全落在同一帧内（假「后台」）。
+      // 现钉事件队列任务 + 异步 IO + style epoch 过期丢弃三件套。
+      expect(prefBody.contains('scheduleMicrotask'), isFalse,
+          reason: 'microtask 同帧同步执行会阻塞 UI，预取必须走事件队列任务');
+      expect(prefBody.contains('unawaited(Future<void>(()'), isTrue,
+          reason: '预取走事件队列任务（当前帧先收尾）+ 异步读盘');
+      expect(prefBody.contains('await file.readAsBytes()'), isTrue,
+          reason: 'IO 必须异步，让出主 isolate');
+      expect(prefBody.contains('_styleEpoch != styleEpochAtStart'), isTrue,
+          reason: '真异步后必须按 style epoch 丢弃跨样式失效的过期结果'
+              '（styleTag 烤进缓存条目，旧代际入缓存=脏样式）');
     });
   });
 

--- a/hibiki/test/pages/reader_hibiki_page_smoke_test.dart
+++ b/hibiki/test/pages/reader_hibiki_page_smoke_test.dart
@@ -1,0 +1,93 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/anki/anki_view_model.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/models/theme_notifier.dart';
+import 'package:hibiki/src/pages/implementations/reader_hibiki_page.dart';
+import 'package:hibiki/src/platform/platform_providers.dart';
+import 'package:hibiki/src/platform/platform_services.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/fake_anki_repository.dart';
+import '../helpers/test_platform_services.dart';
+
+/// ReaderHibikiPage 首个 widget 冒烟测试（阅读器渐进重建 phase1）。
+///
+/// 背景：13000+ 行的阅读器页此前**零运行时覆盖**——全部依赖源码字符串守卫，
+/// 对「代码被搬走/重写但行为变了」几乎无效。本文件对齐
+/// video_hibiki_page_smoke_test.dart 的骨架，把「页面挂载编排彻底坏掉」这类
+/// 灾难从真机提前到 CI。
+///
+/// 锁定 BUG-437 的恢复契约：init 链上任何一步失败（这里用「书不存在」这个最
+/// 容易确定性构造的失败）都必须确定性归还加载态——toast + pop 退回上一页，
+/// 绝不让 spinner 永挂。
+void main() {
+  testWidgets('missing book pops back to shelf instead of a stuck loader',
+      (WidgetTester tester) async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final PlatformServices platformServices = testPlatformServices();
+    final PreferencesRepository prefsRepo = PreferencesRepository(db);
+    await prefsRepo.loadFromDb();
+    final Directory tmpDir =
+        Directory.systemTemp.createTempSync('hibiki_reader_smoke_');
+    addTearDown(() {
+      try {
+        tmpDir.deleteSync(recursive: true);
+      } catch (_) {}
+    });
+    final AppModel appModel = AppModel(platformServices)
+      ..wireDatabaseForTesting(db)
+      // 阅读器 post-frame 读 lowMemoryMode、dispose 读 audiobookBackgroundPlay，
+      // 都走 prefsRepo（late）——按 video_quick_settings_harness 同款精简接线。
+      ..wireLocalAudioForTesting(
+          prefsRepo: prefsRepo, databaseDirectory: tmpDir);
+    // 阅读器 build 读 appThemeKey → themeNotifier（late，正常由 initialise() 构造，
+    // 见 HBK-AUDIT-003 同款接线）；测试走精简接线，与 popup 分支同参构造。
+    appModel.themeNotifier = ThemeNotifier(db, () => appModel.textTheme);
+    final FakeAnkiRepository ankiRepository = FakeAnkiRepository();
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[
+        platformServicesProvider.overrideWithValue(platformServices),
+        ankiRepositoryProvider.overrideWithValue(ankiRepository),
+        appProvider.overrideWith((ref) => appModel),
+      ],
+      child: MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) => Scaffold(
+            body: Center(
+              child: TextButton(
+                onPressed: () {
+                  Navigator.of(context).push(MaterialPageRoute<void>(
+                    builder: (_) =>
+                        const ReaderHibikiPage(bookKey: 'no/such-book'),
+                  ));
+                },
+                child: const Text('open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('open'));
+    await tester.pump();
+    // init 链（profile/settings 并行 + 书本定位）跑完：书不在盘上 → toast + pop。
+    await tester.pumpAndSettle();
+
+    expect(find.byType(ReaderHibikiPage), findsNothing,
+        reason: 'BUG-437 契约：init 失败必须 pop 退回上一页');
+    expect(find.byType(CircularProgressIndicator), findsNothing,
+        reason: '不允许把 spinner 永挂在屏幕上');
+    expect(find.text('open'), findsOneWidget, reason: 'pop 后应回到出发页');
+    expect(tester.takeException(), isNull, reason: '恢复路径不得向框架抛未处理异常');
+  });
+}

--- a/hibiki/test/pages/reader_hibiki_vertical_test.dart
+++ b/hibiki/test/pages/reader_hibiki_vertical_test.dart
@@ -21,12 +21,19 @@ void main() {
       '  void _syncPositionFromCurrentCue()',
     );
 
+    // 渐进重建 phase2：-1→null 的取舍语义凿进纯函数 readerPositionSaveArgs
+    // （真行为测在 test/reader/reader_position_save_args_test.dart），本守卫降级为
+    // 只钉接线：_persistPosition 必须经该纯函数落库，不得绕开手写参数。
     expect(
       persist,
-      contains('charOffset: charOffset >= 0 ? charOffset : null'),
-      reason: 'A transient charOffset=-1 must map to null so '
-          'ReaderPositionRepository.save keeps the existing same-section exact '
-          'anchor instead of overwriting it with -1 (chapter granularity).',
+      contains('readerPositionSaveArgs(progress: progress'),
+      reason: '_persistPosition 必须经 readerPositionSaveArgs 归一化落库参数——'
+          '绕开它手写 charOffset 正是 BUG-285 的回归入口。',
+    );
+    expect(
+      persist,
+      contains('charOffset: saveArgs.charOffset'),
+      reason: 'repo.save 的精确锚必须来自纯函数结果（-1 已映射 null）。',
     );
     expect(
       persist,

--- a/hibiki/test/pages/reader_init_hang_recovery_guard_static_test.dart
+++ b/hibiki/test/pages/reader_init_hang_recovery_guard_static_test.dart
@@ -58,6 +58,10 @@ void main() {
         reason: 'catch 必须提示用户打开失败');
     expect(catchBody.contains('Navigator.of(context).pop()'), isTrue,
         reason: 'catch 必须退回书架，不让 spinner 永挂');
+    // 渐进重建 phase2：init 失败自动退与用户手动退（PopScope onWillPop）同窗竞发
+    // 时不得连退两级——失败路径的 pop 必须共用 _popInProgress 锁（BUG-782 同款）。
+    expect(catchBody.contains('if (_popInProgress) return;'), isTrue,
+        reason: 'init 失败 pop 必须与用户退出共用 _popInProgress 合流锁');
     expect(
         catchBody.contains('debugPrint(') ||
             catchBody.contains('ErrorLogService.instance.log('),

--- a/hibiki/test/pages/reader_sasayaki_cue_cache_reuse_guard_test.dart
+++ b/hibiki/test/pages/reader_sasayaki_cue_cache_reuse_guard_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'reader_hibiki_page_source_corpus.dart';
+
+/// 开书/跨章性能守卫（阅读器渐进重建 phase1）：`_prepareSasayakiCuesJson` 不得
+/// 每次章节加载都重查全书 cue。
+///
+/// 旧实现方法开头 `_cachedAllCues = null;` 主动丢弃缓存再 `_loadHighlightCues()`
+/// 全书重查——而 `_resolveAudioSlot → _primeAudioCuesForCurrentBook` 在开书时
+/// 已查过同一份并灌进 `_cachedAllCues`。这个重复查询串行挡在每次引擎注入之前
+/// （首帧路径），且清缓存后若加载失败，`_injectAudiobookBridge` 会静默拿到 null
+/// 跳过 cue 装载（竞态隐患）。
+///
+/// 修复后的不变量：
+///  ① prepare 先复用 `_cachedAllCues`，仅缓存缺失时兜底加载；
+///  ② 缓存生命周期 = 音频槽绑定：`_resolveAudioSlot` 的 detach 块清缓存，
+///     prime 重灌——不靠每章丢弃换正确性。
+///
+/// 页面私有方法无法在 host widget 测试里行为驱动（需真 InAppWebView + 音频会话），
+/// 落在源码语料层（与 reader_sasayaki_payload_source_guard_test 同纪律）。
+void main() {
+  final String src = readReaderPageSource();
+
+  final int prepStart =
+      src.indexOf('Future<String?> _prepareSasayakiCuesJson() async {');
+  final int injectStart =
+      src.indexOf('Future<void> _injectAudiobookBridge() async {');
+
+  test('方法边界可定位（防守卫因重命名失效）', () {
+    expect(prepStart, greaterThanOrEqualTo(0));
+    expect(injectStart, greaterThan(prepStart));
+  });
+
+  final String prepBody = prepStart >= 0 && injectStart > prepStart
+      ? src.substring(prepStart, injectStart)
+      : src;
+
+  test('① prepare 复用 _cachedAllCues，不再每章先清缓存', () {
+    expect(prepBody.contains('_cachedAllCues = null'), isFalse,
+        reason: '方法内不得丢弃缓存——丢弃即退回「每章全书重查 + 失败静默跳过」');
+    expect(prepBody.contains('= _cachedAllCues;'), isTrue,
+        reason: '必须先读缓存（复用 _primeAudioCuesForCurrentBook 已查的全书 cue）');
+    expect(prepBody.contains('allCues = await _loadHighlightCues();'), isTrue,
+        reason: '缓存缺失时仍要兜底加载（不变量是复用，不是砍掉加载能力）');
+  });
+
+  test('② 缓存生命周期 = 音频槽绑定：detach 块失效、prime 重灌', () {
+    final int slotStart = src
+        .indexOf('Future<void> _resolveAudioSlot({bool forceReload = false})');
+    final int attachStart = src.indexOf(
+        'Future<void> _attachExistingSession(AudiobookSession session)');
+    expect(slotStart, greaterThanOrEqualTo(0));
+    expect(attachStart, greaterThan(slotStart));
+    final String slotBody = src.substring(slotStart, attachStart);
+    expect(slotBody.contains('_cachedAllCues = null;'), isTrue,
+        reason: 'detach 旧音频槽时必须失效 cue 缓存（换音频源后不得用旧 cue）');
+
+    final int primeStart =
+        src.indexOf('Future<void> _primeAudioCuesForCurrentBook() async {');
+    expect(primeStart, greaterThanOrEqualTo(0));
+    final String primeBody = src.substring(primeStart, primeStart + 2400);
+    expect(primeBody.contains('_cachedAllCues = '), isTrue,
+        reason: 'prime 必须重灌缓存（prepare 复用的就是这份）');
+  });
+}

--- a/hibiki/test/reader/reader_position_save_args_test.dart
+++ b/hibiki/test/reader/reader_position_save_args_test.dart
@@ -1,0 +1,141 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/reader_hibiki_page.dart'
+    show readerPositionSaveArgs;
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// BUG-285 / BUG-162（渐进重建 phase2）：`_persistPosition` 落库参数归一化凿成
+/// 纯函数 [readerPositionSaveArgs] 后的真行为测——替换旧的
+/// `charOffset: charOffset >= 0 ? charOffset : null` 字符串扫描守卫（那种守卫在
+/// 写法等价重构时假红、逻辑搬走时真空绿）。
+///
+/// 三层不变量：
+///  1. 纯函数语义：-1/负值 → null（瞬态不覆写精确锚）、>=0 原样、进度定点量化。
+///  2. 端到端往返：页面归一化 → repo.save → repo.load → 页面恢复端映射
+///     （`saved.charOffset ?? -1` / `normCharOffset / 10000`）是不动点。
+///  3. BUG-285 全链：同 section 的 -1 瞬态经归一化+repo 后不吃掉既有精确锚。
+void main() {
+  group('readerPositionSaveArgs 纯函数语义', () {
+    test('charOffset >= 0 原样写精确锚', () {
+      expect(
+        readerPositionSaveArgs(progress: 0.5, charOffset: 777),
+        (normCharOffset: 5000, charOffset: 777),
+      );
+      expect(
+        readerPositionSaveArgs(progress: 0.0, charOffset: 0),
+        (normCharOffset: 0, charOffset: 0),
+      );
+    });
+
+    test('charOffset < 0（瞬态）必须映射 null，不许透传（BUG-285）', () {
+      expect(
+        readerPositionSaveArgs(progress: 0.25, charOffset: -1).charOffset,
+        isNull,
+      );
+      expect(
+        readerPositionSaveArgs(progress: 0.25, charOffset: -42).charOffset,
+        isNull,
+      );
+    });
+
+    test('进度按 0..10000 round 定点量化，端点无损', () {
+      expect(
+          readerPositionSaveArgs(progress: 0.0, charOffset: -1).normCharOffset,
+          0);
+      expect(
+          readerPositionSaveArgs(progress: 1.0, charOffset: -1).normCharOffset,
+          10000);
+      expect(
+          readerPositionSaveArgs(progress: 0.33335, charOffset: -1)
+              .normCharOffset,
+          3334);
+    });
+
+    test('往返误差不超过半个量化步长（1/20000）', () {
+      for (final double p in <double>[0.0, 0.1234, 0.5, 0.66667, 0.9999, 1.0]) {
+        final int quantized =
+            readerPositionSaveArgs(progress: p, charOffset: -1).normCharOffset;
+        final double restored = quantized / 10000.0;
+        expect((restored - p).abs(), lessThanOrEqualTo(0.00005),
+            reason: 'progress=$p 量化往返漂移超界');
+      }
+    });
+  });
+
+  group('端到端往返（归一化 → 真 repo → 恢复端映射）', () {
+    late HibikiDatabase db;
+    late ReaderPositionRepository repo;
+
+    setUp(() {
+      db = HibikiDatabase.forTesting(NativeDatabase.memory());
+      repo = ReaderPositionRepository(db);
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    Future<void> saveVia({
+      required String bookKey,
+      required int section,
+      required double progress,
+      required int charOffset,
+    }) async {
+      final ({int normCharOffset, int? charOffset}) args =
+          readerPositionSaveArgs(progress: progress, charOffset: charOffset);
+      await repo.save(
+        bookKey: bookKey,
+        sectionIndex: section,
+        normCharOffset: args.normCharOffset,
+        charOffset: args.charOffset,
+      );
+    }
+
+    test('精确锚往返不动点：save(p, c>=0) → load → (c, p±量化)', () async {
+      await saveVia(
+          bookKey: 'rt-book', section: 3, progress: 0.5, charOffset: 777);
+      final ReaderPosition? saved = await repo.findByBookKey('rt-book');
+      expect(saved, isNotNull);
+      // 页面恢复端映射（_initBookInner）：charOffset ?? -1、normCharOffset/10000。
+      expect(saved!.charOffset ?? -1, 777);
+      expect(saved.sectionIndex, 3);
+      expect(saved.normCharOffset / 10000.0, closeTo(0.5, 0.00005));
+    });
+
+    test('BUG-285 全链：同 section 原地 -1 瞬态不吃掉既有精确锚', () async {
+      await saveVia(
+          bookKey: 'rt-book', section: 3, progress: 0.5, charOffset: 777);
+      // 重排/竖排边缘采样的瞬态：charOffset=-1，位置未移动（分数不变）。
+      await saveVia(
+          bookKey: 'rt-book', section: 3, progress: 0.5, charOffset: -1);
+      final ReaderPosition? saved = await repo.findByBookKey('rt-book');
+      expect(saved!.charOffset ?? -1, 777,
+          reason: '同 section 原地瞬态 -1 → null → repo 保留既有精确锚');
+      expect(saved.normCharOffset, 5000);
+    });
+
+    test('TODO-1292 全链：同 section 分数移动且无新精确锚 → 旧锚失效回退分数', () async {
+      await saveVia(
+          bookKey: 'rt-book', section: 3, progress: 0.5, charOffset: 777);
+      // 位置真的推进了（0.5→0.6）但当帧测不到精确偏移：旧锚已陈旧，必须失效——
+      // 否则恢复优先精确锚会跳回旧位置（「退出图1重进图2」的根因）。
+      await saveVia(
+          bookKey: 'rt-book', section: 3, progress: 0.6, charOffset: -1);
+      final ReaderPosition? saved = await repo.findByBookKey('rt-book');
+      expect(saved!.charOffset ?? -1, -1,
+          reason: '精确锚绝不能比分数陈旧：分数移动+无新锚 ⇒ 旧锚失效');
+      expect(saved.normCharOffset, 6000, reason: '分数进度照常前移，恢复回退分数粒度');
+    });
+
+    test('跨 section 后旧精确锚失效（repo 侧决策经归一化漏斗仍生效）', () async {
+      await saveVia(
+          bookKey: 'rt-book', section: 3, progress: 0.5, charOffset: 777);
+      await saveVia(
+          bookKey: 'rt-book', section: 4, progress: 0.1, charOffset: -1);
+      final ReaderPosition? saved = await repo.findByBookKey('rt-book');
+      expect(saved!.sectionIndex, 4);
+      expect(saved.charOffset ?? -1, -1, reason: '跨 section 精确锚必须失效，恢复端回退分数粒度');
+    });
+  });
+}


### PR DESCRIPTION
## 背景

用户诉求：小说部分 bug 多、加载慢，想重写但怕炸现有功能。结论：不整页重写，走渐进重建（strangler fig）。本 PR 是 phase1：先把「加载慢」的已坐实根因修掉 + 给零运行时覆盖的阅读器页补上第一个 widget 冒烟测试。

三份前置调查结论（bug 盘点 / 测试覆盖 / 加载路径逐段分析）要点：
- 阅读器真正未修复缺陷只有 2 条（BUG-1017 待设备定位、BUG-1041 属查词浮窗）；「bug 多」主要是历史存量，均已修且各带隐含契约——这正是整页重写必炸的原因。
- 13603 行的 ReaderHibikiPage 零 widget 测试，全靠 91 个源码字符串守卫。
- 开书链路逐段分析定位出 8 个慢点候选，本 PR 修其中爆炸半径最小、收益确定的 4 个。

## 改动

### 1. 图片章判定：记忆化下沉 EpubBook + DB 字数免解析短路（最大头）
默认 `spreadMode='auto'` 下**每本书第一次打开**都会触发 EpubSpreadAnalyzer 分类循环：在主 isolate 对全书逐章「读盘 + html_parser 全 DOM 解析」，纯文字小说也不能幸免。页面级 `_imageOnlyChapterCache` 只覆盖拦截器路径，spread 配对 / 边缘分析 / audiobook 跨章 / 导航各自裸调无缓存方法（同一章一次开书最多被解析 4-6 遍）。

修法（消特例）：记忆化下沉到数据拥有者 `EpubBook`，删页面级重复缓存；并注入 DB 已存的当前口径每章字数作免解析短路——实义字数 > 20 必非纯图片章（口径恒 ≤ 纯文本长度，方向安全），文字书的整书分类从「逐章读盘+解析」降为纯内存比较。旧口径不注入，等后台重算落定后补注。

### 2. sasayaki cue 缓存复用（每章一次全书 DB 重查消除）
`_prepareSasayakiCuesJson` 此前每次章节加载先 `_cachedAllCues = null` 再全书重查——而 `_resolveAudioSlot → _primeAudioCuesForCurrentBook` 开书时已查过同一份。重复查询串行挡在引擎注入（首帧路径）之前；清缓存还带「加载失败 → `_injectAudiobookBridge` 静默拿 null 跳过 cue 装载」的竞态。现在缓存生命周期 = 音频槽绑定（detach 失效、prime 重灌），prepare 只复用。

### 3. 恢复位置查询提前并行
`findByBookKey` 只按 bookKey 查、与 profile/解析/音频槽全无依赖，却串行排在 init 链末尾；提前与两条并行链同时起跑，消费点不动。

### 4. `_sanitizedCssCache` 补上限
HTML 侧早有 LRU 封顶，CSS 侧无上限（超多 CSS 书翻遍全书纯内存累积），对称补插入序封顶。

### 测试
- **新增阅读器页首个 widget 冒烟测试**：书不存在 → toast + pop（BUG-437 恢复契约），不许 spinner 永挂、无未处理异常。pump 基础设施（全局 fake InAppWebView）本就现成，只是从没用在 reader 上。
- **新增 sasayaki cue 缓存复用守卫**（两处不变量均已做变异实测：植入回归写法确认真能红后还原）。
- 扩展 `epub_image_only_chapter_test`：hint 短路 / 回落解析 / 越界 / 记忆化四例。
- 顺手修正 `image_only_chapter_pause_test` 陈旧锚点：恢复原语已随 PR#583 改为 `_activateMainPlayer()`，守卫仍断言旧 `_player.play()`——**基底既有红**，非本 PR 回归（audiobook_controller.dart 本 PR 零改动）。

## 冻结契约（本 PR 未动）
`window.hoshiReader` JS 桥、持久化 key（`ttu_*` 等）、`AppModel` 接口、分页/恢复语义全部不动。

## 验证
- `flutter analyze` 全量：No issues found
- 定向测试 117 个全绿（epub 分类/spread map/sasayaki 三守卫/冒烟/开书接线守卫/图片懒加载守卫/语料元守卫等）
- 本地全量套件 `dart run tool/flutter_test_failures.dart --no-pub` 结果稍后追评

## 后续批次（phase2 候选，另开 PR）
- openMedia 在 Navigator.push 前串行 await 音频服务冷启（「点了没反应」段，影响所有媒体类型）
- 首帧遮罩两级化（install 即显示章首文字，恢复完成再校正）
- 147K 单次注入拆分/UserScript 化
- 连续模式每 50ms 全章 DOM 遍历刷进度（BUG-969 遗留）

https://claude.ai/code/session_01D8xveszki5tYLNRz9AqtLr
