### PR TITLE
fix(scraper): Bangumi 刮削传输失败自动重试（BUG-1272）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1202 条。点号进各自文件。
+> 共 1203 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1272](bugs/BUG-1272-bangumi-scrape-no-retry.md) | 🚧 | 🚧 | Bangumi 刮削单次请求无重试，链路丢连接直接失败 |
 | [BUG-1270](bugs/BUG-1270-youtube-live-subtitle-seek-duplicate.md) | ✅ | ✅ | YouTube 实时字幕回跳后重复且累积成长段 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |

--- a/docs/bugs/BUG-1272-bangumi-scrape-no-retry.md
+++ b/docs/bugs/BUG-1272-bangumi-scrape-no-retry.md
@@ -1,0 +1,50 @@
+## BUG-1272 · Bangumi 刮削单次请求无重试，链路丢连接直接失败
+
+- **报告**：2026-07-31（用户：封面刮削弹窗报「搜索失败，没能从封面源取到有效响应」，怀疑被 Bangumi 限流；但浏览器打开 bgm.tv 官网正常，网络并不差）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/metadata/bangumi_api_client.dart:169`（原 `_run`：一次请求 = 一次成败，传输失败直接抛，无任何重试）
+
+### 定位过程（先证伪「限流」）
+
+用户展开弹窗详情拿到的原文是 `ScrapeNetworkException: Bangumi search request timed out` —— **timed out，不是 429/403**。逐条实测：
+
+| 实验 | 结果 | 结论 |
+|---|---|---|
+| 带 `hibiki-reader/scraper` UA 请求 | `200` | UA 硬编码**生效** |
+| 不带 UA 请求 | 稳定 `403 Forbidden` | Bangumi 拒裸 UA，但那是 403 不是超时 |
+| 连打 35 次（GET+POST 搜索） | **一次 429 都没有**，无 `Retry-After` | 未触发限流；且 galgame 侧有令牌桶、视频自动刮削串行+600ms |
+| 直连 `api.bgm.tv` 20 次 | **成功 12 / 失败 8** | 失败率约 40% |
+| 同样请求经代理 12 次 | 12/12 成功 | 链路问题，非服务端 |
+| 超时放宽到 30s 再测 15 次 | 成功的 **0.5~0.8s** 返回；失败的**全部卡在 21.0s** | 见下 |
+
+**关键数据是最后一行**：失败一律停在 21 秒（Windows 内核 TCP SYN 重传放弃时间），而不是我设的 30 秒。也就是说要么 0.8 秒回来，要么 SYN 石沉大海——**中间不存在「再多等一会儿就能成」的区间**。所以「把超时调长」对这个失败模式完全无效，只会让用户多盯着转圈。
+
+本机链路环境（FlClash TUN + fake-ip：`api.bgm.tv` 被解析成 `198.18.6.4`）会放大丢连接率，但这不是个例——本 app 用户群普遍挂代理，且任何弱网都有同类表现。
+
+**浏览器为什么「正常」**：它连接复用 + 失败自动重连，把同样的丢连接悄悄补掉了。app 是单发单收，一次丢包整条报废。**根因是这条链路没有任何容错，不是网差。**
+
+### ① 修复
+
+- 新增 `hibiki/lib/src/media/metadata/transport_retry.dart` —— `runWithTransportRetry`，默认 3 次尝试、退避 `400ms * n`，失败时**原样抛最后一次异常与堆栈**，调用方的异常映射/文案零改动。
+- `bangumi_api_client.dart`：`_run` 用重试包住 `_gate(send)`，**包在 gate 外层**——每次重试都重新过一遍限流器，否则重试会绕过令牌桶，把链路抖动变成对公益 API 的连打。单次超时 `15s → 8s`（`kBangumiRequestTimeout`）：这个值不是「等多久算慢」，而是「多快认定连接已死、该换一条」。一处改动覆盖视频刮削 / 书籍刮削 / galgame 元数据三域。
+- `cover_downloader.dart`：海报下载同一根因，同样加重试（幂等 GET，重放安全）；30s 单次超时保留——海报是几百 KB 响应体，不能按建连成败取值。
+- `bangumi_adapter.dart`：默认超时改为引用共享常量。
+
+**正确性前提（写进 `transport_retry.dart` 文件头）**：`package:http` 对非 2xx **不抛异常**，因此在「发一次请求」这层捕获到异常 ⟺ 传输失败。403 / 404 / 429 这类服务端已明确回话的结果根本走不到重试分支——尤其 429，重放只会加重限流。**写操作（收藏、进度上报）不得套用本函数。**
+
+### ② 自动化测试
+
+`hibiki/test/media/metadata/transport_retry_test.dart`（13 例，全绿）：
+
+- 正向：首次失败→重试成功、连失两次→第三次成功、超时同样重试、退避按 `backoff * n` 递增、`maxAttempts=1` 退回旧行为、用尽次数仍抛 `BangumiTransportException`（异常契约不变）。
+- **负向（关键）**：`403` / `429` / `404` 各断言**只发 1 次**——服务端已回话的结果绝不能被重放。
+- 限流不变量：`重试穿过限流 gate` 断言 gate 被调用次数 == 尝试次数。
+
+**变异实测**（按仓库纪律，防假绿）：把 `kTransportMaxAttempts` 改 3→1，**4 个测试立刻转红**；还原后用 `diff` 校验与备份逐字节一致（未用 `git checkout --`，避免抹掉未提交修改）。
+
+相邻测试 `test/media/metadata/ test/media/video/scraper/ test/mining/metadata/` 共 **344 例全绿**。其中 `book_cover_scrape_dialog_test.dart` 的「搜索失败显示错误行」需同步更新：它原本让 mock **只失败一次**来测手动重试，而自动重试现在会把这种情况直接救回来、错误行不再出现（**这正是本次修复的效果**）；改为打满一整轮尝试才判失败，手动重试从下一轮开始成功，测试原意不变。
+
+### 备注 / 未覆盖范围
+
+- **同步侧（`media/tracking/bangumi_api_client.dart`）未纳入**：其 `createCollection` / `patchCollection` / `markEpisodesDone` 是写操作，自动重放需要先做幂等性分析，且已有 outbox 退避兜底。其只读的 `getMe` / `getSubject` / `getCollection` 会被同一根因击中（点「连接并验证」可能失败），值得后续单独处理。
+- `vndb_adapter.dart` 同样是单次请求无重试，属另一站点，本轮未动。
+- 用户可见文案仍是「没能从封面源取到有效响应」，对**超时**而言不够准确（听起来像服务端返回了坏数据）；BUG-1219 的详情展开已能露出真因，文案本身的收敛留待后续。

--- a/hibiki/lib/src/media/metadata/bangumi_api_client.dart
+++ b/hibiki/lib/src/media/metadata/bangumi_api_client.dart
@@ -22,6 +22,7 @@ library;
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:hibiki/src/media/metadata/transport_retry.dart';
 import 'package:http/http.dart' as http;
 
 /// 纯函数：把用户粘贴的 Bangumi 条目 **URL** 解析为 subject id（数字串）。
@@ -104,17 +105,29 @@ typedef BangumiSendGate = Future<http.Response> Function(
   Future<http.Response> Function() send,
 );
 
+/// 单次尝试的超时（BUG-1272）。
+///
+/// 刻意**短**：实测成功的请求 0.5~0.8s 就返回，失败的则是 TCP SYN 石沉大海、等到
+/// 内核重传放弃（Windows 约 21s）——两者之间没有中间地带。所以这里的取值不是「等
+/// 多久算慢」，而是「多快认定这条连接已经死了、该换一条重试」。调长只会拖慢失败
+/// 路径而一条也救不回来。
+const Duration kBangumiRequestTimeout = Duration(seconds: 8);
+
 /// Bangumi API v0 共享传输客户端。
 class BangumiApiClient {
   BangumiApiClient({
     http.Client? client,
     required this.userAgent,
     this.baseUrl = 'https://api.bgm.tv/v0',
-    this.timeout = const Duration(seconds: 15),
+    this.timeout = kBangumiRequestTimeout,
+    this.maxAttempts = kTransportMaxAttempts,
+    this.retryBackoff = kTransportRetryBackoff,
     this.accessToken,
     BangumiSendGate? gate,
+    Future<void> Function(Duration delay)? retrySleep,
   })  : _client = client ?? http.Client(),
         _ownsClient = client == null,
+        _retrySleep = retrySleep,
         _gate = gate ?? _directSend;
 
   final http.Client _client;
@@ -124,7 +137,18 @@ class BangumiApiClient {
   final String userAgent;
 
   final String baseUrl;
+
+  /// **单次尝试**的超时（不是整条请求的总预算）；总耗时上界还要乘 [maxAttempts]。
   final Duration timeout;
+
+  /// 传输失败时的总尝试次数（含首次）。设为 1 即退回「一次定生死」的旧行为。
+  final int maxAttempts;
+
+  /// 重试基础退避，第 n 次重试等 `retryBackoff * n`。
+  final Duration retryBackoff;
+
+  /// 测试注入的等待实现，避免真实退避拖慢单测。
+  final Future<void> Function(Duration delay)? _retrySleep;
 
   /// 可选 access token（Bearer）：只有 R18 条目才必须带（galgame 侧用）。
   final String? accessToken;
@@ -171,7 +195,16 @@ class BangumiApiClient {
   ) async {
     final http.Response response;
     try {
-      response = await _gate(send);
+      // 重试包在 [_gate] **外层**：每次重试都重新过一遍限流器（galgame 侧注入），
+      // 否则重试会绕过令牌桶，把「链路抖动」变成「对公益 API 的连打」。
+      // 只有传输失败（拿不到响应）才会走到 catch —— 见 transport_retry.dart 的
+      // 正确性前提：package:http 对非 2xx 不抛异常，403/404/429 原样返回不重试。
+      response = await runWithTransportRetry<http.Response>(
+        () => _gate(send),
+        maxAttempts: maxAttempts,
+        backoff: retryBackoff,
+        sleep: _retrySleep,
+      );
     } on TimeoutException {
       throw const BangumiTransportException('request timed out');
     } on BangumiTransportException {

--- a/hibiki/lib/src/media/metadata/transport_retry.dart
+++ b/hibiki/lib/src/media/metadata/transport_retry.dart
@@ -1,0 +1,59 @@
+/// 只读元数据请求的**传输层重试**（BUG-1272）。
+///
+/// 背景：刮削链路上一次请求 = 一次成败，没有任何容错。而真实用户链路（尤其挂
+/// 代理 / TUN 的用户）建连本身就会成片丢：实测同一台机器直连 `api.bgm.tv` 20 次
+/// 有 8 次 TCP SYN 没有回应，成功的请求 0.5~0.8s 就返回，失败的一律卡到内核重传
+/// 放弃（Windows 约 21s）。**中间不存在「再多等一会儿就能成」的区间**，所以把超时
+/// 调长毫无用处，只会让用户多盯着转圈；唯一有效的做法是快速失败后**换一条连接重
+/// 试**——浏览器打开同一个站点之所以「正常」，正是因为它连接复用 + 失败自动重连，
+/// 把同样的丢连接悄悄补掉了。
+///
+/// **只重试「没拿到 HTTP 响应」的失败**，这是本模块唯一的正确性前提：
+/// `package:http` 对非 2xx **不抛异常**（状态码原样返回给调用方），因此在「发一次
+/// 请求」这一层捕获到异常 ⟺ 传输失败（连接被丢 / 超时 / TLS 失败）。403、404、429
+/// 这类**服务端已明确回话**的结果永远走不到这里，自然不会被重试——尤其 429，重试
+/// 只会加重限流。调用方若要对状态码做重试，那是另一层的策略，不属于本模块。
+///
+/// 幂等性：调用方必须自行保证被包住的请求可安全重放。当前使用方全部是只读的
+/// GET / 搜索 POST。**写操作（收藏、进度上报）不得直接套用本函数**。
+library;
+
+import 'dart:async';
+
+/// 默认尝试次数（含首次）：3 次。
+///
+/// 按实测单次成功率约 65% 估算，3 次尝试把整体失败率压到 ~4%；再加次数收益迅速
+/// 递减，而最坏等待线性变长，不划算。
+const int kTransportMaxAttempts = 3;
+
+/// 重试前的基础退避，第 n 次重试等 `backoff * n`。
+///
+/// 丢连接不是服务端过载，不需要长退避；退避主要是给瞬时链路抖动一个恢复窗口。
+const Duration kTransportRetryBackoff = Duration(milliseconds: 400);
+
+/// 反复执行 [send]，直到成功或用尽 [maxAttempts] 次尝试。
+///
+/// 全部失败时**原样抛出最后一次的异常与堆栈**（不包装、不改写），使调用方既有的
+/// 异常映射与文案保持不变。[sleep] 供测试注入，避免真实等待。
+Future<T> runWithTransportRetry<T>(
+  Future<T> Function() send, {
+  int maxAttempts = kTransportMaxAttempts,
+  Duration backoff = kTransportRetryBackoff,
+  Future<void> Function(Duration delay)? sleep,
+}) async {
+  assert(maxAttempts > 0, 'maxAttempts 必须为正');
+  final Future<void> Function(Duration delay) delay =
+      sleep ?? (Duration d) => Future<void>.delayed(d);
+
+  for (int attempt = 1;; attempt++) {
+    try {
+      return await send();
+    } catch (error, stack) {
+      // 用尽次数：把最后一次失败原样交还调用方（含堆栈），不吞不换。
+      if (attempt >= maxAttempts) {
+        Error.throwWithStackTrace(error, stack);
+      }
+    }
+    await delay(backoff * attempt);
+  }
+}

--- a/hibiki/lib/src/media/video/scraper/cover_downloader.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_downloader.dart
@@ -16,6 +16,7 @@ import 'dart:io';
 
 import 'package:hibiki/src/media/media_cover_service.dart';
 import 'package:hibiki/src/media/metadata/credential_redaction.dart';
+import 'package:hibiki/src/media/metadata/transport_retry.dart';
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
     show ScrapeNetworkException;
 import 'package:hibiki/src/media/video/video_import_dialog.dart'
@@ -26,10 +27,23 @@ import 'package:path/path.dart' as p;
 
 /// 海报下载器。构造注入 [http.Client]（默认自建），测试用 mock client。
 class CoverDownloader {
-  CoverDownloader({http.Client? client}) : _client = client ?? http.Client();
+  CoverDownloader({
+    http.Client? client,
+    this.maxAttempts = kTransportMaxAttempts,
+    Future<void> Function(Duration delay)? retrySleep,
+  })  : _client = client ?? http.Client(),
+        _retrySleep = retrySleep;
 
   final http.Client _client;
 
+  /// 传输失败时的总尝试次数（含首次）。与搜索同一根因：链路会成片丢连接（BUG-1272）。
+  /// 图片下载是幂等 GET，重放安全。
+  final int maxAttempts;
+
+  final Future<void> Function(Duration delay)? _retrySleep;
+
+  /// 单次尝试超时。比搜索宽：海报是几百 KB 的响应体，慢速链路上传输本身就要时间，
+  /// 这里不能像搜索那样按「建连成败」取值。
   static const Duration _timeout = Duration(seconds: 30);
 
   /// 下载 [url] 指向的海报，落地为 [bookUid] 对应封面，返回**绝对路径**（可直接
@@ -53,7 +67,13 @@ class CoverDownloader {
 
     final http.Response response;
     try {
-      response = await _client.get(Uri.parse(url)).timeout(_timeout);
+      // 只有传输失败（拿不到响应）会重试；下面对非 2xx 的判断在 try 之外，因此
+      // 404 / 403 的坏 URL 依旧一次就失败，不会被重放。
+      response = await runWithTransportRetry<http.Response>(
+        () => _client.get(Uri.parse(url)).timeout(_timeout),
+        maxAttempts: maxAttempts,
+        sleep: _retrySleep,
+      );
     } on TimeoutException {
       throw const ScrapeNetworkException('Poster download timed out');
     } catch (e) {

--- a/hibiki/lib/src/mining/metadata/adapters/bangumi_adapter.dart
+++ b/hibiki/lib/src/mining/metadata/adapters/bangumi_adapter.dart
@@ -35,7 +35,7 @@ class BangumiMetadataAdapter implements GalgameMetadataAdapter {
     GalgameRateLimiter? rateLimiter,
     String? accessToken,
     String baseUrl = 'https://api.bgm.tv/v0',
-    Duration timeout = const Duration(seconds: 15),
+    Duration timeout = kBangumiRequestTimeout,
   }) : _rateLimiter = rateLimiter ?? GalgameRateLimiter() {
     _api = BangumiApiClient(
       client: client,

--- a/hibiki/test/media/metadata/book_cover_scrape_dialog_test.dart
+++ b/hibiki/test/media/metadata/book_cover_scrape_dialog_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/media/metadata/book_cover_scrape_dialog.dart';
 import 'package:hibiki/src/media/metadata/book_metadata_scraper.dart';
+import 'package:hibiki/src/media/metadata/transport_retry.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -63,7 +64,12 @@ void main() {
     final BookMetadataScraper scraper = BookMetadataScraper(
       client: MockClient((http.Request req) async {
         calls++;
-        if (calls == 1) throw http.ClientException('network down');
+        // BUG-1272 起传输失败会自动重试 [kTransportMaxAttempts] 次，所以要让整轮
+        // 搜索都失败，必须打满一整轮尝试；只失败一次的话现在会被自动重试救回来，
+        // 用户根本看不到错误行（这正是本次修复的目的）。手动重试从下一轮开始成功。
+        if (calls <= kTransportMaxAttempts) {
+          throw http.ClientException('network down');
+        }
         return http.Response.bytes(
           utf8.encode('{"data":[{"id":1,"name":"Yotsuba to!",'
               '"images":{"large":"https://i/l.jpg"}}]}'),

--- a/hibiki/test/media/metadata/transport_retry_test.dart
+++ b/hibiki/test/media/metadata/transport_retry_test.dart
@@ -1,0 +1,269 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/metadata/bangumi_api_client.dart';
+import 'package:hibiki/src/media/metadata/transport_retry.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// BUG-1272：刮削链路对「拿不到 HTTP 响应」的失败必须重试，且**只**对这种失败重试。
+void main() {
+  /// 不真实等待：把退避折叠成同步完成，单测才不会被 400ms×N 拖慢。
+  Future<void> noSleep(Duration _) async {}
+
+  group('runWithTransportRetry', () {
+    test('首次失败、第二次成功 → 返回成功值，共发 2 次', () async {
+      int calls = 0;
+      final String result = await runWithTransportRetry<String>(
+        () async {
+          calls++;
+          if (calls == 1) throw const SocketExceptionStub();
+          return 'ok';
+        },
+        sleep: noSleep,
+      );
+
+      expect(result, 'ok');
+      expect(calls, 2);
+    });
+
+    test('全部失败 → 原样抛最后一次异常，且恰好尝试 maxAttempts 次', () async {
+      int calls = 0;
+      await expectLater(
+        runWithTransportRetry<String>(
+          () async {
+            calls++;
+            throw StateError('boom $calls');
+          },
+          maxAttempts: 3,
+          sleep: noSleep,
+        ),
+        throwsA(
+          isA<StateError>().having(
+            (StateError e) => e.message,
+            'message',
+            // 抛的必须是**最后一次**的异常，不是第一次的。
+            'boom 3',
+          ),
+        ),
+      );
+      expect(calls, 3);
+    });
+
+    test('首次即成功 → 不重试，只发 1 次', () async {
+      int calls = 0;
+      await runWithTransportRetry<String>(
+        () async {
+          calls++;
+          return 'ok';
+        },
+        sleep: noSleep,
+      );
+      expect(calls, 1);
+    });
+
+    test('maxAttempts=1 退回「一次定生死」的旧行为', () async {
+      int calls = 0;
+      await expectLater(
+        runWithTransportRetry<String>(
+          () async {
+            calls++;
+            throw const SocketExceptionStub();
+          },
+          maxAttempts: 1,
+          sleep: noSleep,
+        ),
+        throwsA(isA<SocketExceptionStub>()),
+      );
+      expect(calls, 1);
+    });
+
+    test('退避按 backoff * n 递增', () async {
+      final List<Duration> waited = <Duration>[];
+      await expectLater(
+        runWithTransportRetry<String>(
+          () async => throw const SocketExceptionStub(),
+          maxAttempts: 3,
+          backoff: const Duration(milliseconds: 100),
+          sleep: (Duration d) async => waited.add(d),
+        ),
+        throwsA(isA<SocketExceptionStub>()),
+      );
+      expect(waited, <Duration>[
+        const Duration(milliseconds: 100),
+        const Duration(milliseconds: 200),
+      ]);
+    });
+  });
+
+  group('BangumiApiClient 重试语义（BUG-1272）', () {
+    test('搜索：传输失败后重试并最终成功', () async {
+      int calls = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        calls++;
+        if (calls == 1) {
+          throw http.ClientException('Connection closed', req.url);
+        }
+        return http.Response.bytes(utf8.encode('{"data":[]}'), 200);
+      });
+
+      final BangumiRawResponse res = await BangumiApiClient(
+        client: client,
+        userAgent: 'ua/test',
+        retrySleep: noSleep,
+      ).searchSubjects('x', subjectType: kBangumiSubjectTypeAnime);
+
+      expect(res.statusCode, 200);
+      expect(calls, 2);
+    });
+
+    test('详情：传输失败后重试并最终成功', () async {
+      int calls = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        calls++;
+        if (calls < 3) {
+          throw http.ClientException('Connection reset', req.url);
+        }
+        return http.Response.bytes(utf8.encode('{"id":8}'), 200);
+      });
+
+      final BangumiRawResponse res = await BangumiApiClient(
+        client: client,
+        userAgent: 'ua/test',
+        retrySleep: noSleep,
+      ).fetchSubject('8');
+
+      expect(res.statusCode, 200);
+      expect(calls, 3);
+    });
+
+    test('用尽次数仍失败 → 抛 BangumiTransportException（异常契约不变）', () async {
+      int calls = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        calls++;
+        throw http.ClientException('Connection closed', req.url);
+      });
+
+      await expectLater(
+        BangumiApiClient(
+          client: client,
+          userAgent: 'ua/test',
+          retrySleep: noSleep,
+        ).fetchSubject('8'),
+        throwsA(isA<BangumiTransportException>()),
+      );
+      expect(calls, kTransportMaxAttempts);
+    });
+
+    test('超时同样重试，最终仍抛 request timed out', () async {
+      int calls = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        calls++;
+        throw TimeoutException('slow');
+      });
+
+      await expectLater(
+        BangumiApiClient(
+          client: client,
+          userAgent: 'ua/test',
+          retrySleep: noSleep,
+        ).fetchSubject('8'),
+        throwsA(
+          isA<BangumiTransportException>().having(
+            (BangumiTransportException e) => e.message,
+            'message',
+            'request timed out',
+          ),
+        ),
+      );
+      expect(calls, kTransportMaxAttempts);
+    });
+
+    // —— 负向断言：服务端已经回话的结果绝不能被重放 ——
+    test('403 不重试：只发 1 次，状态码原样返回', () async {
+      int calls = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        calls++;
+        return http.Response.bytes(utf8.encode('{"title":"Forbidden"}'), 403);
+      });
+
+      final BangumiRawResponse res = await BangumiApiClient(
+        client: client,
+        userAgent: 'ua/test',
+        retrySleep: noSleep,
+      ).fetchSubject('8');
+
+      expect(res.statusCode, 403);
+      expect(calls, 1, reason: '403 是服务端明确回话，重放没有意义');
+    });
+
+    test('429 不重试：重放只会加重限流', () async {
+      int calls = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        calls++;
+        return http.Response.bytes(utf8.encode('{}'), 429);
+      });
+
+      final BangumiRawResponse res = await BangumiApiClient(
+        client: client,
+        userAgent: 'ua/test',
+        retrySleep: noSleep,
+      ).fetchSubject('8');
+
+      expect(res.statusCode, 429);
+      expect(calls, 1);
+    });
+
+    test('404 不重试：条目不存在是确定结论', () async {
+      int calls = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        calls++;
+        return http.Response.bytes(utf8.encode('{}'), 404);
+      });
+
+      final BangumiRawResponse res = await BangumiApiClient(
+        client: client,
+        userAgent: 'ua/test',
+        retrySleep: noSleep,
+      ).fetchSubject('404404');
+
+      expect(res.statusCode, 404);
+      expect(calls, 1);
+    });
+
+    test('重试穿过限流 gate：每次尝试都过一遍闸门', () async {
+      int calls = 0;
+      int gateCalls = 0;
+      final MockClient client = MockClient((http.Request req) async {
+        calls++;
+        if (calls < 3) {
+          throw http.ClientException('Connection closed', req.url);
+        }
+        return http.Response.bytes(utf8.encode('{"id":8}'), 200);
+      });
+
+      await BangumiApiClient(
+        client: client,
+        userAgent: 'ua/test',
+        retrySleep: noSleep,
+        gate: (Future<http.Response> Function() send) {
+          gateCalls++;
+          return send();
+        },
+      ).fetchSubject('8');
+
+      expect(calls, 3);
+      expect(
+        gateCalls,
+        3,
+        reason: '重试若绕过限流器，链路抖动会变成对公益 API 的连打',
+      );
+    });
+  });
+}
+
+/// 传输层失败的替身（不依赖 dart:io，widget 测试里可用）。
+class SocketExceptionStub implements Exception {
+  const SocketExceptionStub();
+}


### PR DESCRIPTION
## 问题

用户报封面刮削弹窗「搜索失败，没能从封面源取到有效响应」，**怀疑被 Bangumi 限流**；但浏览器打开 bgm.tv 官网正常，网络并不差。

展开详情拿到的原文是 `ScrapeNetworkException: Bangumi search request timed out` —— **timed out，不是 429/403**。

## 先证伪「限流」

| 实验 | 结果 |
|---|---|
| 带 `hibiki-reader/scraper` UA | `200` —— UA 硬编码**生效** |
| 不带 UA | 稳定 `403 Forbidden`（是拒绝，不是超时） |
| 连打 35 次（GET + POST 搜索） | **一次 429 都没有**，无 `Retry-After` |
| 直连 `api.bgm.tv` 20 次 | 成功 12 / **失败 8** |
| 同请求经代理 12 次 | **12/12 成功** |

限流嫌疑排除（且 galgame 侧本就有令牌桶、视频自动刮削串行 + 600ms）。

## 关键数据：为什么调长超时没用

把超时放宽到 **30s** 重测 15 次：

```
成功的请求: 0.5 ~ 0.8 秒返回
失败的请求: 全部卡在 21.0 秒   ← 不是我设的 30s
```

21 秒是 **Windows 内核 TCP SYN 重传放弃**的时间。也就是说要么 0.8 秒回来，要么 SYN 石沉大海——**中间不存在「再多等一会儿就能成」的区间**。把超时调长只会让用户多盯着转圈，一条也救不回来。

**浏览器为什么正常**：连接复用 + 失败自动重连，把同样的丢连接悄悄补掉了。app 单发单收，一次丢包整条报废。**根因是这条链路没有任何容错，不是网差。**

## 修复

- 新增 `transport_retry.dart`：默认 3 次尝试、退避 `400ms * n`，全败时**原样抛最后一次异常与堆栈**，调用方的异常映射/文案零改动。
- `bangumi_api_client._run`：重试包住 `_gate(send)` 且**在 gate 外层**——每次重试重新过一遍限流器，否则重试会绕过令牌桶，把链路抖动变成对公益 API 的连打。单次超时 `15s → 8s`：这个值不是「等多久算慢」，而是「多快认定连接已死、该换一条」。**一处改动覆盖视频刮削 / 书籍刮削 / galgame 元数据三域。**
- `cover_downloader`：海报下载同一根因，幂等 GET 一并加重试（30s 超时保留——响应体是几百 KB，不能按建连成败取值）。

### 正确性前提

`package:http` 对非 2xx **不抛异常**，因此在「发一次请求」这层捕获到异常 ⟺ 传输失败。**403 / 404 / 429 根本走不到重试分支**——尤其 429，重放只会加重限流。**写操作（收藏、进度上报）不得套用本函数。**

## 验证

**真实链路端到端对照**（直连 `api.bgm.tv`，各 12 次）：

```
无重试:  5/12
有重试: 12/12
```

- 新增测试 13 例全绿：正向（失败→重试成功、超时重试、退避递增、`maxAttempts=1` 退回旧行为、异常契约不变）+ **负向**（`403`/`429`/`404` 各断言**只发 1 次**）+ 限流不变量（gate 调用次数 == 尝试次数）。
- **变异实测**（防假绿）：把 `kTransportMaxAttempts` 改 3→1，**4 例立刻转红**；还原后 `diff` 校验逐字节一致。
- 相邻测试 `test/media/metadata/ test/media/video/scraper/ test/mining/metadata/` 共 **344 例全绿**；`flutter analyze` **No issues found**。

`book_cover_scrape_dialog_test` 同步更新：原用例让 mock **只失败一次**来测手动重试，而自动重试现在会把这种情况直接救回来、错误行不再出现（**这正是本修复的效果**）；改为打满一整轮尝试才判失败，测试原意不变。

## 未覆盖范围

- **同步侧 `media/tracking/bangumi_api_client.dart` 未纳入**：其 `createCollection` / `patchCollection` / `markEpisodesDone` 是写操作，自动重放需先做幂等性分析，且已有 outbox 退避兜底。其只读的 `getMe` / `getSubject` / `getCollection` 会被同一根因击中（点「连接并验证」可能失败），值得后续单独处理。
- `vndb_adapter` 同样单次无重试，属另一站点，本轮未动。
- 用户可见文案仍是「没能从封面源取到有效响应」，对**超时**而言不够准确；BUG-1219 的详情展开已能露出真因，文案收敛留待后续。

本地全量套件仍在跑（分支阶段按规范走定向测试 + CI 兜底），结果会补充在评论。

https://claude.ai/code/session_01QYvYZKie4iiAidSXuvLKMG
