### PR TITLE
fix(torrent): 反吸血身份黑名单改做种期生效+单IP封禁 (BUG-1274/1275)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1202 条。点号进各自文件。
+> 共 1204 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1275](bugs/BUG-1275-anti-leech-blacklist-range-ban.md) | ✅ | ✅ | 反吸血身份黑名单命中升级整段连坐封禁 |
+| [BUG-1274](bugs/BUG-1274-anti-leech-blacklist-download-phase.md) | ✅ | ✅ | 反吸血身份黑名单下载期无差别封禁 |
 | [BUG-1270](bugs/BUG-1270-youtube-live-subtitle-seek-duplicate.md) | ✅ | ✅ | YouTube 实时字幕回跳后重复且累积成长段 |
 | [BUG-1246](bugs/BUG-1246-galgame-helper-version-drift.md) | ✅ | ✅ | 随包 helper 已更新但完整旧安装被直接放行，native 修复永远不生效 |
 | [BUG-1245](bugs/BUG-1245-vn-reveal-chrome-also-advances.md) | ✅ | ✅ | VN唤出悬浮底栏时误同时推进 |

--- a/docs/bugs/BUG-1274-anti-leech-blacklist-download-phase.md
+++ b/docs/bugs/BUG-1274-anti-leech-blacklist-download-phase.md
@@ -1,0 +1,22 @@
+## BUG-1274 · 反吸血身份黑名单下载期无差别封禁
+- **报告**：2026-07-31（用户：内部审查）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/torrent/anti_leech.dart:438-460`（修复前）：
+  `_evaluatePeer` 规则 ② 的身份黑名单（peer_id 前缀 `-SD/-XF/-DL/-BN/-DT/-QD` +
+  client 关键词 `qqdownload/xfplay/dandanplay/offline` 等）**无条件全相位封禁**，
+  下载期也封。封禁的收益只在「不给它上传」，下载期封 peer 只减少自己的潜在
+  数据源、毫无收益。且同文件里迅雷已有相位特例（仅 `ctx.isSeeding` 才封、
+  下载期放行走行为规则），证明设计者早已认识到相位问题，却没有推广到其余
+  身份；另外 `ignoreByDownloadedBytes` 豁免（喂过我们 ≥100MB 数据不自动封）
+  只在 ④ PCB 生效，身份黑名单不吃豁免——一直在喂数据的 -SD peer 照封。
+- **[x] ① 已修复** — 把迅雷特例的相位逻辑推广为整个身份黑名单的统一规则：
+  `ctx.isSeeding == false` 时跳过全部身份判定（伪造进度仍会被 ④ PCB 封）；
+  身份判定前先吃 `ignoreByDownloadedBytes` 豁免（语义同 PCB，PCB 内原豁免
+  位置不动）。特例分支消除，`-XL`/xunlei/thunder 命中普通
+  `peerIdBlacklist`/`clientBlacklist` 路径；`BanReason.xunleiSeeding` 枚举
+  保留但不再产生（全仓 grep 无引擎外消费方，保留仅为不破坏潜在序列化）。
+- **[x] ② 已加自动化测试** — `hibiki/test/torrent/anti_leech_test.dart`
+  group「身份黑名单相位与粒度（BUG-1274 / BUG-1275）」：下载期 -SD 放行且
+  继续被 PCB 封、下载期 xfplay/dandanplay 放行、做种期同类照封、做种期
+  totalDownload≥豁免阈值不封（豁免关闭时照封）、迅雷 -XL 统一路径与原特例
+  等价（下载期放行/做种期封）。已做变异实测（把相位条件改坏 → 测试红）。
+- **备注**：与 BUG-1275（封禁粒度）同一 PR 修复。

--- a/docs/bugs/BUG-1275-anti-leech-blacklist-range-ban.md
+++ b/docs/bugs/BUG-1275-anti-leech-blacklist-range-ban.md
@@ -1,0 +1,22 @@
+## BUG-1275 · 反吸血身份黑名单命中升级整段连坐封禁
+- **报告**：2026-07-31（用户：内部审查）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/torrent/anti_leech.dart:408`
+  （修复前）：`evaluate()` 里 `_registerBan(verdict.cidr ?? _segmentOf(peer.ip))`，
+  而身份黑名单（peerIdBlacklist/clientBlacklist/xunleiSeeding）的
+  `BanVerdict.cidr` 是 null → 被段默认升级成 IPv4 /24（IPv6 /60）**整段封**，
+  进 `_bannedCidrs` 后又成为 ① AutoRangeBan 连坐源，`banTimeMs` 默认 0 =
+  session 内永久。CGNAT 下一个 /24 后面是成百上千真实用户：一个影音先锋
+  peer 拉黑整段，段内所有正常 peer 被连坐。身份证据只指向单个 peer，
+  不支撑段级爆炸半径（多拨/PCB 行为证据才支撑）。
+- **[x] ① 已修复** — 身份类 ban 的 `BanVerdict` 显式携带单 IP CIDR
+  （复用 `cidrOf`：IPv4 `x.x.x.x/32`、IPv6 `/128`，新 helper
+  `_singleIpCidrOf`），不再落入 `_segmentOf` 段默认。行为类规则粒度不动：
+  multiDialing 仍显式封段（证据强），PCB 各原因 + multiPort 仍走 null →
+  段默认（有意的爆炸半径，`evaluate()` 内已补回退语义注释）。
+- **[x] ② 已加自动化测试** — `hibiki/test/torrent/anti_leech_test.dart`
+  group「身份黑名单相位与粒度（BUG-1274 / BUG-1275）」：身份命中
+  `verdict.cidr == '1.2.3.4/32'`、`bannedCidrs` 含 /32 不含 /24、同段邻居
+  下轮不被 AutoRangeBan 连坐；IPv6 身份命中登记 /128、同 /60 邻居不连坐；
+  行为类（PCB）IPv6 /60 段连坐保持不变。已做变异实测（把单 IP CIDR 改回
+  null → 测试红）。
+- **备注**：与 BUG-1274（相位）同一 PR 修复。

--- a/hibiki/lib/src/media/torrent/anti_leech.dart
+++ b/hibiki/lib/src/media/torrent/anti_leech.dart
@@ -95,7 +95,11 @@ enum BanReason {
   /// 客户端名关键词黑名单命中。
   clientBlacklist,
 
-  /// 迅雷特例：做种时不让迅雷白嫖（不做种时迅雷可能是正常下载者，放行）。
+  /// 【已停产，仅保留兼容】旧「迅雷做种特例」的原因值。BUG-1274 把该特例的
+  /// 相位逻辑（仅做种期封、下载期放行）推广为整个身份黑名单的统一规则后，
+  /// 迅雷（`-XL` / xunlei / thunder）改走普通 [peerIdBlacklist] /
+  /// [clientBlacklist] 路径，引擎不再产生本值；枚举保留是为了不破坏可能
+  /// 持有该值的消费方/序列化数据。
   xunleiSeeding,
 
   /// 多拨/PCDN：同段同种子连接数超容忍值。
@@ -130,8 +134,9 @@ class BanVerdict {
   final bool banned;
   final BanReason? reason;
 
-  /// 连坐/多拨时要封的段（如 `'1.2.3.0/24'`）；单 IP 封时 null（=封该
-  /// peer.ip）。
+  /// 要封的 CIDR：段（如 `'1.2.3.0/24'`，多拨/连坐）或单 IP（如
+  /// `'1.2.3.4/32'`，身份黑名单，BUG-1275）。null = 由
+  /// [AntiLeechEngine.evaluate] 回退到配置前缀的段默认（见其内注释）。
   final String? cidr;
 
   /// 封禁时长；null=用默认长封。
@@ -341,9 +346,11 @@ bool ipInCidr(String ip, String cidr) {
 /// 反吸血判定引擎（有状态：跨 [evaluate] 调用累积峰值/首见/进度/封段）。
 ///
 /// 规则顺序（每 peer 走一遍，第一个命中就 ban 并短路）：
-/// ① AutoRangeBan 连坐 → ② PeerId/ClientName 黑名单（含迅雷做种特例）→
+/// ① AutoRangeBan 连坐 → ② PeerId/ClientName 身份黑名单（仅做种期生效、
+/// 吃 ignoreByDownloadedBytes 豁免、单 IP 封禁，BUG-1274/1275）→
 /// ③ MultiDialing 多拨 → ④ ProgressCheatBlocker（PCB，最后做：最贵且要过
-/// 宽限窗口）。任何新 ban 都把该 IP 的 CIDR 段登记进连坐源。
+/// 宽限窗口）。任何新 ban 都把 verdict 携带的 CIDR（身份类=单 IP，多拨=段）
+/// 登记进连坐源；未携带的行为类判定回退登记所属段。
 class AntiLeechEngine {
   AntiLeechEngine({this.config = const AntiLeechConfig()});
 
@@ -405,6 +412,11 @@ class AntiLeechEngine {
     for (final PeerSnapshot peer in peers) {
       final BanVerdict verdict = _evaluatePeer(peer, ctx, nowMs);
       if (verdict.banned) {
+        // cidr 回退语义（BUG-1275 后）：身份类（peerIdBlacklist/
+        // clientBlacklist）恒带单 IP CIDR，多拨（multiDialing）与连坐
+        // （autoRangeBan）恒带段；只有行为类单 IP 判定（PCB 各原因 +
+        // multiPort）落到 _segmentOf 段默认——行为证据表明该 IP 在吸血，
+        // 段级连坐是有意的爆炸半径。
         _registerBan(verdict.cidr ?? _segmentOf(peer.ip), nowMs);
       }
       out[peer.ip] = verdict;
@@ -435,26 +447,33 @@ class AntiLeechEngine {
       return const BanVerdict.allow();
     }
 
-    // ② PeerId/ClientName 黑名单 + 迅雷特例。
-    final String clientLower = peer.client.toLowerCase();
-    final bool isXunlei = peer.peerId.startsWith('-XL') ||
-        clientLower.startsWith('xunlei') ||
-        clientLower.startsWith('thunder');
-    if (isXunlei) {
-      // 迅雷特例：仅做种时 ban（不做种时迅雷可能是正常下载者），不做种
-      // 则跳过黑名单继续走后续规则。
-      if (ctx.isSeeding) {
-        return const BanVerdict.ban(BanReason.xunleiSeeding);
-      }
-    } else {
+    // ② PeerId/ClientName 身份黑名单 —— 仅做种期生效（BUG-1274）：封禁的
+    // 收益只在「不给它上传」，下载期封 peer 只减少自己的潜在数据源、毫无
+    // 收益，所以下载期跳过全部身份判定、直接走后续行为规则（伪造进度照样
+    // 被 PCB 封）。这是旧「迅雷做种特例」相位逻辑的推广：特例升级为常规
+    // 后特例分支消除，迅雷（-XL/xunlei/thunder）命中普通黑名单路径。
+    // 同时吃 ignoreByDownloadedBytes 豁免（语义同 ④ PCB 内）：确实在喂
+    // 我们数据的 peer 不因身份自动封（PCB 内原豁免位置不动）。
+    // 命中时显式携带单 IP CIDR（BUG-1275）：身份证据只指向该 peer 自身，
+    // 不升级 /24（/60）整段连坐——CGNAT 下一个段后面是成百上千真实用户。
+    final bool fedUsEnough = config.ignoreByDownloadedBytes > 0 &&
+        peer.totalDownload >= config.ignoreByDownloadedBytes;
+    if (ctx.isSeeding && !fedUsEnough) {
       for (final String prefix in config.peerIdBlacklistPrefixes) {
         if (peer.peerId.startsWith(prefix)) {
-          return const BanVerdict.ban(BanReason.peerIdBlacklist);
+          return BanVerdict.ban(
+            BanReason.peerIdBlacklist,
+            cidr: _singleIpCidrOf(peer.ip),
+          );
         }
       }
+      final String clientLower = peer.client.toLowerCase();
       for (final String keyword in config.clientNameKeywords) {
         if (clientLower.contains(keyword)) {
-          return const BanVerdict.ban(BanReason.clientBlacklist);
+          return BanVerdict.ban(
+            BanReason.clientBlacklist,
+            cidr: _singleIpCidrOf(peer.ip),
+          );
         }
       }
     }
@@ -574,4 +593,9 @@ class AntiLeechEngine {
         ipv4Prefix: config.ipv4PrefixLength,
         ipv6Prefix: config.ipv6PrefixLength,
       );
+
+  /// 单 IP CIDR（IPv4 `/32`、IPv6 `/128`）：身份类 ban 专用，不连坐邻居
+  /// （BUG-1275）。
+  String _singleIpCidrOf(String ip) =>
+      cidrOf(ip, ipv4Prefix: 32, ipv6Prefix: 128);
 }

--- a/hibiki/test/torrent/anti_leech_test.dart
+++ b/hibiki/test/torrent/anti_leech_test.dart
@@ -342,15 +342,16 @@ void main() {
       final AntiLeechEngine engine = AntiLeechEngine(
         config: const AntiLeechConfig(banTimeMs: 10000),
       );
+      // BUG-1274/1275 契约变更：身份黑名单仅做种期生效，且登记单 IP /32。
       engine.evaluate(
         <PeerSnapshot>[peer(peerId: '-SD0100-abcdefabcdef')],
-        ctx(),
+        ctx(isSeeding: true),
         nowMs: 1000,
       );
-      expect(engine.bannedCidrs, contains('1.2.3.0/24'));
+      expect(engine.bannedCidrs, contains('1.2.3.4/32'));
       // 未到期（1000+10000=11000）→ 不解封。
       expect(engine.pruneExpired(10999), isFalse);
-      expect(engine.bannedCidrs, contains('1.2.3.0/24'));
+      expect(engine.bannedCidrs, contains('1.2.3.4/32'));
       // 到期 → 解封。
       expect(engine.pruneExpired(11000), isTrue);
       expect(engine.bannedCidrs, isEmpty);
@@ -359,11 +360,11 @@ void main() {
       final AntiLeechEngine perm = AntiLeechEngine();
       perm.evaluate(
         <PeerSnapshot>[peer(peerId: '-SD0100-abcdefabcdef')],
-        ctx(),
+        ctx(isSeeding: true),
         nowMs: 1000,
       );
       expect(perm.pruneExpired(999999999), isFalse);
-      expect(perm.bannedCidrs, contains('1.2.3.0/24'));
+      expect(perm.bannedCidrs, contains('1.2.3.4/32'));
     });
   });
 
@@ -372,14 +373,16 @@ void main() {
 
     setUp(() => engine = AntiLeechEngine());
 
-    test('迅雷 peerId 做种时 → ban(xunleiSeeding)', () {
+    test('迅雷 peerId 做种时 → ban（BUG-1274 后走统一黑名单路径）', () {
+      // 契约变更（BUG-1274）：旧迅雷特例消除，-XL 命中普通 peerIdBlacklist，
+      // 引擎不再产生 BanReason.xunleiSeeding；做种期封的行为与原特例等价。
       final Map<String, BanVerdict> r = engine.evaluate(
         <PeerSnapshot>[peer(peerId: '-XL0012-abcdefabcdef')],
         ctx(isSeeding: true),
         nowMs: 0,
       );
       expect(r['1.2.3.4']!.banned, isTrue);
-      expect(r['1.2.3.4']!.reason, BanReason.xunleiSeeding);
+      expect(r['1.2.3.4']!.reason, BanReason.peerIdBlacklist);
     });
 
     test('迅雷 peerId 非做种 → allow（可能是正常下载者）', () {
@@ -391,7 +394,8 @@ void main() {
       expect(r['1.2.3.4']!.banned, isFalse);
     });
 
-    test('client 以 thunder 开头也走迅雷特例', () {
+    test('client 以 thunder 开头：下载期放行、做种期封（与原特例等价）', () {
+      // 契约变更（BUG-1274）：thunder 关键词命中普通 clientBlacklist。
       final PeerSnapshot p = peer(client: 'Thunder 11.3.1');
       expect(
         engine.evaluate(<PeerSnapshot>[p], ctx(isSeeding: false),
@@ -403,23 +407,31 @@ void main() {
         ctx(isSeeding: true),
         nowMs: 0,
       );
-      expect(r['1.2.4.4']!.reason, BanReason.xunleiSeeding);
+      expect(r['1.2.4.4']!.reason, BanReason.clientBlacklist);
     });
 
-    test('非迅雷 peerId 前缀 -SD 直接 ban（与做种无关）', () {
-      final Map<String, BanVerdict> r = engine.evaluate(
+    test('peerId 前缀 -SD：下载期放行、做种期 ban（BUG-1274 契约变更）', () {
+      // 旧契约「与做种无关直接 ban」已废：下载期封 peer 只减少自己的数据源。
+      final Map<String, BanVerdict> r0 = engine.evaluate(
         <PeerSnapshot>[peer(peerId: '-SD0100-abcdefabcdef')],
         ctx(isSeeding: false),
         nowMs: 0,
       );
-      expect(r['1.2.3.4']!.banned, isTrue);
-      expect(r['1.2.3.4']!.reason, BanReason.peerIdBlacklist);
+      expect(r0['1.2.3.4']!.banned, isFalse);
+      final Map<String, BanVerdict> r1 = engine.evaluate(
+        <PeerSnapshot>[peer(peerId: '-SD0100-abcdefabcdef')],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r1['1.2.3.4']!.banned, isTrue);
+      expect(r1['1.2.3.4']!.reason, BanReason.peerIdBlacklist);
     });
 
-    test('client 含 thunder（非开头）→ ban(clientBlacklist)', () {
+    test('client 含 thunder（非开头）做种期 → ban(clientBlacklist)', () {
+      // BUG-1274 契约变更：身份判定只在做种期跑，用例改为做种上下文。
       final Map<String, BanVerdict> r = engine.evaluate(
         <PeerSnapshot>[peer(client: 'Fake thunder mod')],
-        ctx(isSeeding: false),
+        ctx(isSeeding: true),
         nowMs: 0,
       );
       expect(r['1.2.3.4']!.banned, isTrue);
@@ -508,24 +520,25 @@ void main() {
       expect(r2['1.2.3.5']!.cidr, '1.2.3.0/24');
     });
 
-    test('连坐优先于黑名单：同段黑名单 peer 报 autoRangeBan', () {
-      // 先用黑名单 ban 登记 9.9.9.0/24。
+    test('连坐优先于黑名单：已封 IP 重连报 autoRangeBan', () {
+      // BUG-1275 后身份 ban 只登记 /32，同段邻居不再连坐；改用同 IP 重连
+      // 验证规则 ① 仍优先于 ②。
       engine.evaluate(
         <PeerSnapshot>[peer(ip: '9.9.9.1', peerId: '-SD0100-abcdefabcdef')],
-        ctx(),
+        ctx(isSeeding: true),
         nowMs: 0,
       );
-      // 同段另一个黑名单 peer：规则 ① 先命中。
       final Map<String, BanVerdict> r = engine.evaluate(
-        <PeerSnapshot>[peer(ip: '9.9.9.2', peerId: '-SD0100-abcdefabcdef')],
-        ctx(),
+        <PeerSnapshot>[peer(ip: '9.9.9.1', peerId: '-SD0100-abcdefabcdef')],
+        ctx(isSeeding: true),
         nowMs: 1000,
       );
-      expect(r['9.9.9.2']!.reason, BanReason.autoRangeBan);
+      expect(r['9.9.9.1']!.reason, BanReason.autoRangeBan);
+      expect(r['9.9.9.1']!.cidr, '9.9.9.1/32');
     });
 
-    test('黑名单优先于 PCB 且不受宽限窗口保护', () {
-      // 首见即判（PCB 此时还在宽限窗口内）。
+    test('做种期黑名单优先于 PCB 且不受宽限窗口保护', () {
+      // 首见即判（PCB 此时还在宽限窗口内）。BUG-1274 后需做种上下文。
       final Map<String, BanVerdict> r = engine.evaluate(
         <PeerSnapshot>[
           peer(
@@ -534,27 +547,174 @@ void main() {
             reportedProgress: 0.05,
           ),
         ],
-        ctx(),
+        ctx(isSeeding: true),
         nowMs: 0,
       );
       expect(r['1.2.3.4']!.reason, BanReason.peerIdBlacklist);
     });
 
-    test('IPv6 peer 被 ban 后同 /60 段连坐', () {
-      engine.evaluate(
-        <PeerSnapshot>[
-          peer(ip: '2001:db8:aaaa:bbf5::1', peerId: '-SD0100-abcdefabcdef'),
-        ],
-        ctx(),
-        nowMs: 0,
+    test('IPv6 peer 被行为规则（PCB）ban 后同 /60 段连坐', () {
+      // BUG-1275 后身份 ban 不再登记段；行为类（PCB）仍走段默认。用
+      // progressCheat 驱动，验证 IPv6 /60 连坐对行为类保持不变。
+      final PeerSnapshot cheat = peer(
+        ip: '2001:db8:aaaa:bbf5::1',
+        totalUpload: 50 * kMiB,
+        reportedProgress: 0.05,
       );
+      engine.evaluate(<PeerSnapshot>[cheat], ctx(), nowMs: 0);
+      final Map<String, BanVerdict> r0 =
+          engine.evaluate(<PeerSnapshot>[cheat], ctx(), nowMs: 60000);
+      expect(r0['2001:db8:aaaa:bbf5::1']!.reason, BanReason.progressCheat);
       final Map<String, BanVerdict> r = engine.evaluate(
         <PeerSnapshot>[peer(ip: '2001:db8:aaaa:bbf9::2')],
         ctx(),
-        nowMs: 1000,
+        nowMs: 61000,
       );
       expect(r['2001:db8:aaaa:bbf9::2']!.reason, BanReason.autoRangeBan);
       expect(r['2001:db8:aaaa:bbf9::2']!.cidr, '2001:db8:aaaa:bbf0:0:0:0:0/60');
+    });
+  });
+  group('身份黑名单相位与粒度（BUG-1274 / BUG-1275）', () {
+    const int t0 = 1000;
+    const int t1 = t0 + 60000;
+
+    test('BUG-1274：下载期 -SD 放行且继续走 PCB（伪造进度照样被封）', () {
+      final AntiLeechEngine engine = AntiLeechEngine();
+      // 黑名单身份 + 作弊数值：下载期不因身份封，但 PCB 出宽限后照封。
+      final PeerSnapshot p = peer(
+        peerId: '-SD0100-abcdefabcdef',
+        totalUpload: 50 * kMiB,
+        reportedProgress: 0.05,
+      );
+      final Map<String, BanVerdict> r0 =
+          engine.evaluate(<PeerSnapshot>[p], ctx(isSeeding: false), nowMs: t0);
+      expect(r0['1.2.3.4']!.banned, isFalse);
+      final Map<String, BanVerdict> r1 =
+          engine.evaluate(<PeerSnapshot>[p], ctx(isSeeding: false), nowMs: t1);
+      expect(r1['1.2.3.4']!.reason, BanReason.progressCheat);
+    });
+
+    test('BUG-1274：下载期 xfplay / dandanplay client 放行', () {
+      final AntiLeechEngine engine = AntiLeechEngine();
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[
+          peer(ip: '1.1.1.1', client: 'XfPlay 5.0'),
+          peer(ip: '1.1.1.2', client: 'dandanplay/1.2'),
+        ],
+        ctx(isSeeding: false),
+        nowMs: 0,
+      );
+      expect(r['1.1.1.1']!.banned, isFalse);
+      expect(r['1.1.1.2']!.banned, isFalse);
+    });
+
+    test('BUG-1274：做种期同类身份照封', () {
+      final AntiLeechEngine engine = AntiLeechEngine();
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[
+          peer(ip: '1.1.1.1', peerId: '-SD0100-abcdefabcdef'),
+          peer(ip: '2.1.1.1', client: 'XfPlay 5.0'),
+          peer(ip: '3.1.1.1', client: 'dandanplay/1.2'),
+        ],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r['1.1.1.1']!.reason, BanReason.peerIdBlacklist);
+      expect(r['2.1.1.1']!.reason, BanReason.clientBlacklist);
+      expect(r['3.1.1.1']!.reason, BanReason.clientBlacklist);
+    });
+
+    test('BUG-1274：做种期但 totalDownload≥豁免阈值 → 不因身份封', () {
+      final AntiLeechEngine engine = AntiLeechEngine();
+      // 默认 ignoreByDownloadedBytes = 100MiB；它喂过我们 200MiB。
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[
+          peer(peerId: '-SD0100-abcdefabcdef', totalDownload: 200 * kMiB),
+        ],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r['1.2.3.4']!.banned, isFalse);
+
+      // 豁免关闭（0）时不豁免 → 照封。
+      final AntiLeechEngine noExempt = AntiLeechEngine(
+        config: const AntiLeechConfig(ignoreByDownloadedBytes: 0),
+      );
+      final Map<String, BanVerdict> r2 = noExempt.evaluate(
+        <PeerSnapshot>[
+          peer(peerId: '-SD0100-abcdefabcdef', totalDownload: 200 * kMiB),
+        ],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r2['1.2.3.4']!.reason, BanReason.peerIdBlacklist);
+    });
+
+    test('BUG-1275：身份命中登记单 IP /32，同段其它 IP 不连坐', () {
+      final AntiLeechEngine engine = AntiLeechEngine();
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[peer(peerId: '-SD0100-abcdefabcdef')],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r['1.2.3.4']!.cidr, '1.2.3.4/32');
+      expect(engine.bannedCidrs, contains('1.2.3.4/32'));
+      expect(engine.bannedCidrs, isNot(contains('1.2.3.0/24')));
+      // 同 /24 的正常邻居下轮不被 AutoRangeBan 连坐。
+      final Map<String, BanVerdict> r2 = engine.evaluate(
+        <PeerSnapshot>[peer(ip: '1.2.3.5')],
+        ctx(isSeeding: true),
+        nowMs: 1000,
+      );
+      expect(r2['1.2.3.5']!.banned, isFalse);
+    });
+
+    test('BUG-1275：IPv6 身份命中登记 /128，同 /60 邻居不连坐', () {
+      final AntiLeechEngine engine = AntiLeechEngine();
+      final Map<String, BanVerdict> r = engine.evaluate(
+        <PeerSnapshot>[
+          peer(ip: '2001:db8:aaaa:bbf5::1', peerId: '-SD0100-abcdefabcdef'),
+        ],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(
+        r['2001:db8:aaaa:bbf5::1']!.cidr,
+        '2001:db8:aaaa:bbf5:0:0:0:1/128',
+      );
+      final Map<String, BanVerdict> r2 = engine.evaluate(
+        <PeerSnapshot>[peer(ip: '2001:db8:aaaa:bbf9::2')],
+        ctx(isSeeding: true),
+        nowMs: 1000,
+      );
+      expect(r2['2001:db8:aaaa:bbf9::2']!.banned, isFalse);
+    });
+
+    test('BUG-1274：迅雷 -XL 走统一路径后行为与原特例等价', () {
+      final AntiLeechEngine engine = AntiLeechEngine();
+      // 下载期放行（原特例语义），且作弊数值仍会被 PCB 封。
+      final PeerSnapshot xl = peer(
+        peerId: '-XL0012-abcdefabcdef',
+        totalUpload: 50 * kMiB,
+        reportedProgress: 0.05,
+      );
+      final Map<String, BanVerdict> r0 =
+          engine.evaluate(<PeerSnapshot>[xl], ctx(isSeeding: false), nowMs: t0);
+      expect(r0['1.2.3.4']!.banned, isFalse);
+      final Map<String, BanVerdict> r1 =
+          engine.evaluate(<PeerSnapshot>[xl], ctx(isSeeding: false), nowMs: t1);
+      expect(r1['1.2.3.4']!.reason, BanReason.progressCheat);
+
+      // 做种期封（原特例语义），reason 从 xunleiSeeding 变为统一黑名单值。
+      final AntiLeechEngine seeding = AntiLeechEngine();
+      final Map<String, BanVerdict> r2 = seeding.evaluate(
+        <PeerSnapshot>[peer(ip: '4.3.2.1', peerId: '-XL0012-abcdefabcdef')],
+        ctx(isSeeding: true),
+        nowMs: 0,
+      );
+      expect(r2['4.3.2.1']!.banned, isTrue);
+      expect(r2['4.3.2.1']!.reason, BanReason.peerIdBlacklist);
+      expect(r2['4.3.2.1']!.cidr, '4.3.2.1/32');
     });
   });
 }


### PR DESCRIPTION
## 根因

内置 torrent 反吸血引擎（`hibiki/lib/src/media/torrent/anti_leech.dart`，纯 Dart）身份黑名单的两个设计缺陷：

**BUG-1274 · 相位**：规则 ② 身份黑名单（peer_id 前缀 `-SD/-XF/-DL/-BN/-DT/-QD` + client 关键词 `qqdownload/xfplay/dandanplay/offline` 等）无条件全相位封禁，下载期也封。封禁的收益只在「不给它上传」，下载期封 peer 只减少自己的潜在数据源、毫无收益。同文件里迅雷早有相位特例（仅做种封、下载放行），证明相位问题已被认识到却没推广；且 `ignoreByDownloadedBytes` 豁免（喂过我们 ≥100MB 不自动封）只在 ④ PCB 生效，身份黑名单不吃——一直在喂数据的 -SD peer 照封。

**BUG-1275 · 粒度**：身份类 `BanVerdict.cidr` 为 null，`evaluate()` 里 `_registerBan(verdict.cidr ?? _segmentOf(peer.ip))` 把它升级成 IPv4 /24（IPv6 /60）**整段封**，进 `_bannedCidrs` 后成为 AutoRangeBan 连坐源，`banTimeMs` 默认 0 = session 内永久。CGNAT 下一个 /24 后面是成百上千真实用户：一个影音先锋 peer 拉黑整段。

## 修法

- **消除迅雷特例（好品味：特例变常规）**：把特例的相位逻辑推广为整个身份黑名单的统一规则——非做种期跳过全部身份判定、直接走行为规则（伪造进度照样被 PCB 封）；`-XL`/xunlei/thunder 命中普通 `peerIdBlacklist`/`clientBlacklist` 路径，行为与原特例等价。
- **身份判定前吃 `ignoreByDownloadedBytes` 豁免**（语义同 PCB；PCB 内原豁免位置不动）。
- **身份类 ban 显式携带单 IP CIDR**（复用 `cidrOf`，IPv4 `/32`、IPv6 `/128`，新 helper `_singleIpCidrOf`）。行为类粒度不动：multiDialing 仍显式封段（证据强），PCB 各原因 + multiPort 仍走 null → 段默认（已在 `evaluate()` 补回退语义注释）。
- **`BanReason.xunleiSeeding` 枚举保留但不再产生**：全仓 grep 仅引擎自身与测试消费，保留只为不破坏可能持有该值的序列化/消费方，枚举注释已写明。
- host 侧（`embedded_torrent_host.dart`）已核对：`sweepAntiLeech` 喂 `t.isSeeding` 进 `TorrentContext`、`applyAntiLeechConfig` 均不需改，接口零变更。

## 验证

- `dart format`：0 changed。
- `flutter analyze` 全量：No issues found。
- `flutter test test/torrent test/media/torrent --no-pub`：**325 通过 / 4 skip / 退出码 0**（All tests passed）。
- 旧「下载期黑名单封禁」用例按新契约更新并在注释里写明 BUG 号；新增用例组「身份黑名单相位与粒度（BUG-1274 / BUG-1275）」覆盖：下载期 -SD/xfplay/dandanplay 放行且 PCB 仍可封、做种期照封、豁免阈值（含豁免关闭时照封）、/32 与 /128 登记 + 同段邻居不连坐 + 行为类 /60 连坐不变、迅雷 -XL 统一路径等价性。
- **变异实测 3 项全被测试抓红**：①去掉做种相位条件 → 4 用例红；②身份 ban 不带单 IP CIDR → 4 用例红；③去掉豁免 → 1 用例红。每次变异前已 commit、变异后 `git checkout --` 回退。
- `dart run tool/bug.dart check`：1204 条，号唯一，索引同步。

## 风险

- 契约变更：下载期不再因身份封禁（有意，见根因）；做种期身份封禁 reason 从 `xunleiSeeding` 变为 `peerIdBlacklist`/`clientBlacklist`（引擎外无消费方）。
- 身份封禁从段级收窄到单 IP：同段吸血集群不再被身份规则一次连坐，但多拨集群仍被 multiDialing 段封、行为吸血仍被 PCB 段默认覆盖，防护主力未削弱。

BUG 文件：`docs/bugs/BUG-1274-anti-leech-blacklist-download-phase.md`、`docs/bugs/BUG-1275-anti-leech-blacklist-range-ban.md`

https://claude.ai/code/session_01EajzwAd1c3iMmJBTp2ZhEi
