### PR TITLE
fix(reader): 双页 spread 页唤不出底栏、退不出书（BUG-1280）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1207 条。点号进各自文件。
+> 共 1208 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1280](bugs/BUG-1280-spread-chrome-unreachable.md) | ✅ | ✅ | 双页 spread 页唤不出底栏、退不出书 |
 | [BUG-1279](bugs/BUG-1279-ext-nested-lookup-inplace.md) | ✅ | ✅ | 浏览器扩展嵌套查词会关掉旧弹窗、跳位并重画原文高亮 |
 | [BUG-1278](bugs/BUG-1278-download-settings-content-left.md) | ✅ | ✅ | 下载设置宽屏内容整体贴左且开关被推到远端 |
 | [BUG-1277](bugs/BUG-1277-reader-navigation-after-dispose.md) | ✅ | ✅ | 有声书跨章等待后触发已销毁 State 重绘 |

--- a/docs/bugs/BUG-1280-spread-chrome-unreachable.md
+++ b/docs/bugs/BUG-1280-spread-chrome-unreachable.md
@@ -1,0 +1,43 @@
+## BUG-1280 · 双页 spread 页唤不出底栏、退不出书
+- **报告**：2026-07-31（用户："书架里面打开，然后自动变成双页漫画" → 唤不出菜单、退不出去）
+- **真实性**：✅ 真 bug。根因两层，各自独立致命：
+  - ① `hibiki/lib/src/pages/implementations/reader_hibiki_page.dart:494` `buildSpreadPageHtml`
+    生成的双页展开页是**独立文档**（继歌词 BUG-756、VN BUG-1195 之后的第四种），不含正文
+    `hoshiReader`。它此前唯一的手势是 `img.click → onImageTap`（弹图片查看器）。正文有
+    `onTapEmpty`、歌词有 `onLyricsTapEmpty`、VN 有 `onVnBlankTap`，**spread 一个唤出底栏的
+    通道都没有**——底栏一收起（悬浮模式 / 「点空白隐藏控制栏」）就再也唤不回来，用户看不到
+    返回按钮，退不出这本书、回不到书架。
+  - ② `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart` 的 `onImageTap`
+    处理器是全阅读器**唯一**没有 `_focusOwnership.reclaim` 的手势入口（`onTapEmpty` /
+    `onLyricsTapEmpty` / `onSwipe` 都有），OS 焦点留在 WebView → ESC 全局退出失效
+    （BUG-136 同族）。spread 页两张整页图铺满视口，点击几乎必然命中 img，于是「唤不出
+    底栏」与「ESC 失效」同时成立，两条退出通道一起死 = 卡死在书里。
+  - 触发前提：`ReaderSettings.spreadMode` 默认 `'auto'`，打开书时按 OPF 元数据 / 边缘匹配
+    **自动**把相邻整页图章节配对成双页——用户从没主动选过这个模式。
+- **[x] ① 已修复** — 三处根因修复：
+  - spread 文档补「图片以外的点击」专桥 `onSpreadTapEmpty`（文档级监听 + `IMG` 短路，
+    点图片仍走原有查看器）：`reader_hibiki_page.dart` `buildSpreadPageHtml`。
+  - Dart 侧接上该桥，镜像歌词 `onLyricsTapEmpty` 的语义：有查词弹窗先清栈；悬浮态走
+    `_handleFloatingChromeReveal`、挤压态 `_toggleChrome`，**不看** `tapEmptyToHideChrome`
+    （spread 没有别的唤出途径，不能被那个开关关死）；收尾 `reclaim` 阅读焦点。
+  - `onImageTap` 补 `_focusOwnership.reclaim(FocusReclaimCause.gesture)`，看完图 pop 回来
+    后 ESC 仍能退出（正文内联图片同样受益）。
+  - 按用户要求禁用自动进入：`spreadMode` 默认 `'auto'` → `'off'`
+    （`reader_settings.dart` 与 `reader_hibiki_source.dart` 两处兜底同步改，否则
+    readerSettings 未就绪时读到的默认与阅读器实际用的相反）。双页展开**选项完整保留**
+    （设置里 off/on/auto 三选一），只是不再是没设置过的用户的默认落点；已显式设过本键的
+    用户读到的仍是自己的存值。
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/spread_chrome_escape_guard_test.dart`（7 条）：
+  生成器断言（空白桥存在 / IMG 短路在回传之前 / 不吃掉 onImageTap / TODO-1229 就绪门控不
+  回退）+ 源码接线守卫（`onSpreadTapEmpty` 处理器含两条唤出分支与 reclaim、且不含
+  `tapEmptyToHideChrome`；`onImageTap` 含 reclaim）+ `ReaderSettings` 真行为测试
+  （默认 `off`；显式设 auto/on/off 照旧生效）。
+  **变异实测**（5 次，逐条撤回 → 对应用例转红，无假绿）：删空白桥 → 2 红；删 IMG 短路 →
+  1 红；删 `onSpreadTapEmpty` 的 reclaim → 1 红；删 `onImageTap` 的 reclaim → 1 红；
+  默认值改回 `auto` → 1 红。
+- **备注**：
+  - 已知相邻缺口（本轮未扩大范围）：spread 独立文档同样没有 `onSwipe` 脚本，触屏在双页页面
+    上无法滑动翻页，只能靠唤出底栏后用底栏按钮 / 键盘。修好唤出通道后已不再卡死，但手势
+    契约仍与正文不对齐。
+  - 真机复测（Android / Windows 原始路径：书架 → 打开含整页图的书 → 显式设 spreadMode=on →
+    收起底栏 → 点 letterbox 留白）未做。

--- a/docs/bugs/BUG-1280-spread-chrome-unreachable.md
+++ b/docs/bugs/BUG-1280-spread-chrome-unreachable.md
@@ -41,12 +41,23 @@
     真正被卷进去的是**图片型 EPUB**：扫描版漫画以 `format='epub'` 导入后走 reader 路径
     （`reader_hibiki_source.dart:506-508, 548-552` 只把 `pdf`/`manga` 分流走），以及带
     `rendition:spread` 的轻小说彩插页。用户说的「变成双页漫画」正是这一类。
-  - **为什么不做「按媒体类型门控」**：reader 页拿不到可用的区分信号。`manga`/`pdf` 在打开
-    前已被路由分走，reader 内 `BookFormat` 事实上恒为 `epub`；`MediaKind`
-    （`packages/hibiki_core/lib/src/database/media_kind.dart:29-40`）同样只有
-    epub/srt/video/game，区分不出「图片型 EPUB」。要加门控只能新造信号（如整本 image-only
-    章占比阈值），属于新功能而非本 bug 的根因修复。既然小说本就不会进，把默认改成 `off`
-    已经**完整覆盖**用户诉求：没主动选过的用户不再被自动切进双页。
+  - **为什么不做「按媒体类型门控」**（口径更正：不是「拿不到信号」）：
+    本仓**确实已有**可用信号——`MangaArchiveImporter._isPureImageEpub`
+    （`hibiki/lib/src/media/manga/import/manga_archive_importer.dart:220-239`），入参正是
+    reader 已持有的 `EpubBook`，且已产品化为 `BookConvertBlocker.textOnlyBook`
+    （`book_format_convert.dart:42, 117`）；另有 DB 侧逐章 `chaptersJson.characters`。
+    不做门控的真实理由是**它对本 bug 零增量、且不修根因**：
+    - `_isPureImageEpub` 要求**所有** linear 非 nav 章都 image-only（`:226-227` 一章不满足
+      就 false）。用户实际撞的是「**轻小说彩插 + `rendition:spread`**」——正文章节是文字，
+      这类书会被判成**文字书**。按它正向门控 ⇒ 这类书本来就不符合，等于什么都没挡（零
+      增量）；反向门控（只在纯图书上启用 spread）⇒ 彩插书原样复发。两个方向都不解决用户
+      报的那本书。
+    - 更根本的是：门控只是把「手势契约不同的独立文档」**精准投递**给会触发它的书，
+      spread 文档本身的手势缺口一点没修。根因修复是 ①③（补唤出通道 + 堵掉误注入），
+      默认改 `off` 是「不让没选过的用户撞上」，两者已覆盖用户诉求。
+    - 相邻空白（本轮不做，留 TODO）：`rendition:layout` / `pre-paginated` **全仓未解析**
+      （`grep` 零命中），`hibiki/lib/src/epub/epub_parser.dart:794-805` 解析 `rendition:spread`
+      处是唯一的补点。真要做「按书判断该不该双页」，那才是正确的信号来源。
 - **[x] ① 已修复** — 四处根因修复：
   - spread 文档补「图片以外的点击」专桥 `onSpreadTapEmpty`（文档级监听 + `IMG` 短路，
     点图片仍走原有查看器）：`reader_hibiki_page.dart` `buildSpreadPageHtml`。
@@ -85,9 +96,16 @@
     其中 ③ 第一版守卫**假绿**（`return;` 的搜索窗口从守卫一直到注入点，混进了歌词分支自己
     的 `return;`），已收紧为 if 块自身再复测转红——变异实测当场抓到的假绿。
 - **备注**：
-  - 已知相邻缺口（本轮未扩大范围）：spread 独立文档同样没有 `onSwipe` 脚本，触屏在双页页面
-    上无法滑动翻页，只能靠唤出底栏后用底栏按钮 / 键盘。修好唤出通道后已不再卡死，但手势
-    契约仍与正文不对齐。
+  - 🔴 **本次修复在 Android 上有一处真实的能力损失，必须记账**：③ 的守卫堵掉的那份误注入，
+    此前**顺带**给 Android 的 spread 页提供过 `onSwipe` 滑动翻页与键盘桥（正文引擎自带）。
+    守卫生效后它们一并消失 ⇒ **Android 用户在双页页面上会失去滑动翻页**，只能唤出底栏后用
+    底栏按钮 / 键盘 / 手柄翻页。这不是「单纯修好一个 bug」，是拿「双触发导致底栏彻底唤不出
+    （退不出书）」换「少一种翻页手势」——卡死是致命的、少一种手势是可降级的，所以这笔交易
+    值得做，但**不得淡化**。
+    Windows 侧无此损失（那边从来就没被注入过，本来就没有 spread 滑动翻页）。
+  - **TODO（跟进补回）**：给 spread 独立文档补它自己的 `onSwipe` 脚本 + 键桥，与歌词 / VN
+    独立文档同款自带手势，而不是靠正文引擎误注入白捡。补回后两个平台的 spread 手势契约才
+    真正对齐（目前是「两平台一致地少了滑动翻页」）。
   - 真机复测（Android / Windows 原始路径：书架 → 打开含整页图的书 → 显式设 spreadMode=on →
     收起底栏 → 点 letterbox 留白）未做；③ 的平台分叉是静态证据链（Dart 调用点 + 两侧原生
     实现 + 陈旧判据三处对齐），未在真机上观测过双触发。

--- a/docs/bugs/BUG-1280-spread-chrome-unreachable.md
+++ b/docs/bugs/BUG-1280-spread-chrome-unreachable.md
@@ -1,43 +1,93 @@
 ## BUG-1280 · 双页 spread 页唤不出底栏、退不出书
 - **报告**：2026-07-31（用户："书架里面打开，然后自动变成双页漫画" → 唤不出菜单、退不出去）
-- **真实性**：✅ 真 bug。根因两层，各自独立致命：
+- **真实性**：✅ 真 bug。根因三层，各自独立：
   - ① `hibiki/lib/src/pages/implementations/reader_hibiki_page.dart:494` `buildSpreadPageHtml`
-    生成的双页展开页是**独立文档**（继歌词 BUG-756、VN BUG-1195 之后的第四种），不含正文
-    `hoshiReader`。它此前唯一的手势是 `img.click → onImageTap`（弹图片查看器）。正文有
-    `onTapEmpty`、歌词有 `onLyricsTapEmpty`、VN 有 `onVnBlankTap`，**spread 一个唤出底栏的
-    通道都没有**——底栏一收起（悬浮模式 / 「点空白隐藏控制栏」）就再也唤不回来，用户看不到
+    生成的双页展开页是**独立文档**（继歌词 BUG-756、VN BUG-1195 之后的第四种），HTML 本身
+    不含正文 `hoshiReader`，自带手势只有 `img.click → onImageTap`（弹图片查看器）。正文有
+    `onTapEmpty`、歌词有 `onLyricsTapEmpty`、VN 有 `onVnBlankTap`，spread 页 HTML 一条唤出
+    通道都没有——底栏一收起（悬浮模式 / 「点空白隐藏控制栏」）就再也唤不回来，用户看不到
     返回按钮，退不出这本书、回不到书架。
   - ② `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart` 的 `onImageTap`
-    处理器是全阅读器**唯一**没有 `_focusOwnership.reclaim` 的手势入口（`onTapEmpty` /
-    `onLyricsTapEmpty` / `onSwipe` 都有），OS 焦点留在 WebView → ESC 全局退出失效
+    处理器没有 `_focusOwnership.reclaim`，OS 焦点留在 WebView → ESC 全局退出失效
     （BUG-136 同族）。spread 页两张整页图铺满视口，点击几乎必然命中 img，于是「唤不出
     底栏」与「ESC 失效」同时成立，两条退出通道一起死 = 卡死在书里。
+    **口径更正**：`onImageTap` 不是「全阅读器唯一没 reclaim 的手势入口」。同族至今仍有
+    7 处 JS 桥零 reclaim——`onSelectionMenu` / `onImageRevealed` / `onImageContextMenu` /
+    `onImageLongPress` / `onCueTap` / `onPointerSeek` / `onLyricsPointerSeek`，其中前四个
+    连兄弟桥兜底都没有。本轮只修 spread 退出路径必经的 `onImageTap`，其余未覆盖。
+  - ③ **平台分叉（复核阶段新发现，比 ① 更隐蔽）**：`_loadSpreadPage`
+    （`reader_hibiki/navigation.part.dart`）传给 `loadData` 的 baseUrl 与
+    `_chapterUrl(_currentChapter)` **逐字相同**，而 `onLoadStop` 的陈旧判据只比 `Uri.path`
+    （`webview.part.dart:2362-2368`）→ 该判据**分不出** spread 文档和正文章节。
+    - Windows fork 的 `loadData` 原生侧只取 data、丢掉 baseUrl
+      （`webview_channel_delegate.cpp:104-106` → `NavigateToString`），文档 URL 变
+      `about:blank`，path 为空 → 判 stale → 正文引擎从不注入；
+    - Android 的 `loadDataWithBaseURL`（`WebViewChannelDelegate.java:117`）保留 baseUrl，
+      path 完全相等 → 判据放行 → `_onChapterLoadComplete` **无条件**把整份
+      `readerEngineSource`（含 `onTapEmpty` 手势链）注进 spread 文档。
+    - 后果：若只做 ① 的修复，Android 上 spread 文档会**同时**挂着 `onTapEmpty` 与新加的
+      `onSpreadTapEmpty`。一次空白点两个桥都收到：`onSpreadTapEmpty` 无条件翻转底栏，
+      `onTapEmpty` 在悬浮态 / 开了「点空白隐藏控制栏」时也翻转一次 → 两次翻转互相抵消 →
+      底栏仍然唤不出来，且比修复前更难查。所以 ① 的修复必须与 ③ 的守卫同批落地。
   - 触发前提：`ReaderSettings.spreadMode` 默认 `'auto'`，打开书时按 OPF 元数据 / 边缘匹配
     **自动**把相邻整页图章节配对成双页——用户从没主动选过这个模式。
-- **[x] ① 已修复** — 三处根因修复：
+- **自动配对到底会卷进哪些书（用户「书架里的书就不应该能变成双页漫画」的核实结果）**：
+  - `EpubSpreadMap._shouldPairAuto`（`hibiki/lib/src/epub/epub_spread_map.dart:241-280`）三条
+    判据（OPF `page-spread-left/right` 成对 / 书级 `rendition:spread` / 边缘像素匹配）
+    **每一条都 `&& isImageOnlyChapter(i) && isImageOnlyChapter(i+1)`**
+    （`:259, :266-267, :274-275`）。`isImageOnlyChapter`（`epub_book.dart:123-129`）要求
+    章节正文纯文本 ≤ 20 字且含图片引用。
+  - 结论：**纯文字 EPUB 小说在 `auto` 下不会进 spread**（正文 >20 字 → 判据直接 false）。
+    真正被卷进去的是**图片型 EPUB**：扫描版漫画以 `format='epub'` 导入后走 reader 路径
+    （`reader_hibiki_source.dart:506-508, 548-552` 只把 `pdf`/`manga` 分流走），以及带
+    `rendition:spread` 的轻小说彩插页。用户说的「变成双页漫画」正是这一类。
+  - **为什么不做「按媒体类型门控」**：reader 页拿不到可用的区分信号。`manga`/`pdf` 在打开
+    前已被路由分走，reader 内 `BookFormat` 事实上恒为 `epub`；`MediaKind`
+    （`packages/hibiki_core/lib/src/database/media_kind.dart:29-40`）同样只有
+    epub/srt/video/game，区分不出「图片型 EPUB」。要加门控只能新造信号（如整本 image-only
+    章占比阈值），属于新功能而非本 bug 的根因修复。既然小说本就不会进，把默认改成 `off`
+    已经**完整覆盖**用户诉求：没主动选过的用户不再被自动切进双页。
+- **[x] ① 已修复** — 四处根因修复：
   - spread 文档补「图片以外的点击」专桥 `onSpreadTapEmpty`（文档级监听 + `IMG` 短路，
     点图片仍走原有查看器）：`reader_hibiki_page.dart` `buildSpreadPageHtml`。
   - Dart 侧接上该桥，镜像歌词 `onLyricsTapEmpty` 的语义：有查词弹窗先清栈；悬浮态走
     `_handleFloatingChromeReveal`、挤压态 `_toggleChrome`，**不看** `tapEmptyToHideChrome`
-    （spread 没有别的唤出途径，不能被那个开关关死）；收尾 `reclaim` 阅读焦点。
+    （该开关的真实语义是「底栏悬浮 vs 挤压」，不是「允不允许唤栏」；spread 没有别的唤出
+    途径，不能被它关死。歌词 `onLyricsTapEmpty` 已立同款先例）；收尾 `reclaim` 阅读焦点。
   - `onImageTap` 补 `_focusOwnership.reclaim(FocusReclaimCause.gesture)`，看完图 pop 回来
     后 ESC 仍能退出（正文内联图片同样受益）。
+  - **平台分叉守卫**：新增状态 `_spreadDocumentLoaded`（`reader_hibiki_page.dart`），只有
+    两个写点、正好是 WebView 的两个装载原语——`_loadSpreadPage` 置位、`_loadChapterDirectly`
+    复位（spread 缺图降级回正文也经过后者，标记不会泄漏）。`_onChapterLoadComplete` 据此
+    早退，spread 独立文档不再注入正文引擎 / 有声书桥 / 章节高亮。这是把 Android 拉齐到
+    Windows 早已是的行为，而不是给 Android 加特例；对「两张整页图、正文 ≤20 字」的
+    image-only 章，那些注入本来就无意义。
   - 按用户要求禁用自动进入：`spreadMode` 默认 `'auto'` → `'off'`
     （`reader_settings.dart` 与 `reader_hibiki_source.dart` 两处兜底同步改，否则
     readerSettings 未就绪时读到的默认与阅读器实际用的相反）。双页展开**选项完整保留**
     （设置里 off/on/auto 三选一），只是不再是没设置过的用户的默认落点；已显式设过本键的
     用户读到的仍是自己的存值。
-- **[x] ② 已加自动化测试** — `hibiki/test/reader/spread_chrome_escape_guard_test.dart`（7 条）：
-  生成器断言（空白桥存在 / IMG 短路在回传之前 / 不吃掉 onImageTap / TODO-1229 就绪门控不
-  回退）+ 源码接线守卫（`onSpreadTapEmpty` 处理器含两条唤出分支与 reclaim、且不含
-  `tapEmptyToHideChrome`；`onImageTap` 含 reclaim）+ `ReaderSettings` 真行为测试
-  （默认 `off`；显式设 auto/on/off 照旧生效）。
-  **变异实测**（5 次，逐条撤回 → 对应用例转红，无假绿）：删空白桥 → 2 红；删 IMG 短路 →
-  1 红；删 `onSpreadTapEmpty` 的 reclaim → 1 红；删 `onImageTap` 的 reclaim → 1 红；
-  默认值改回 `auto` → 1 红。
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/spread_chrome_escape_guard_test.dart`（10 条）：
+  - **行为级**：把生产 `buildSpreadPageHtml` 里的 `<script>` 原样丢进 node 真跑（最小假
+    DOM + 模拟冒泡），断言点 IMG 只出 `onImageTap`、点留白才出 `onSpreadTapEmpty`。
+    纯位置断言挡不住「保留 `tagName === 'IMG'` 判断、只删 `return;`」这种变异，这条挡得住。
+  - **源码守卫**：`onSpreadTapEmpty` 处理器含两条唤出分支与 reclaim、且代码行不含
+    `tapEmptyToHideChrome`；`onImageTap` 含 reclaim；`_onChapterLoadComplete` 的 spread 守卫
+    在正文引擎注入之前、且 if 块**自身**含 `return;`（窗口用花括号配对，不用字符距离）；
+    `_spreadDocumentLoaded` 的置位/复位两个写点都在。
+  - **跨文件一致性**：`ttu_spread_mode` 两处兜底默认必须相等且为 `off`（只改其中一处的
+    变异会被这条抓住）。
+  - **真行为**：`ReaderSettings` 默认 `off`；显式设 auto/on/off 照旧生效。
+  - **变异实测 5 次，全部转红（退出码 1）**：① 保留 IMG 判断只删 `return;` → 行为级用例红；
+    ② 只把 `reader_hibiki_source.dart` 的默认改回 `'auto'` → 一致性用例红；
+    ③ 保留 spread 守卫的 if 只删 `return;` → 红；④ 删 `_loadChapterDirectly` 的复位 → 红；
+    ⑤ 删 `_loadSpreadPage` 的置位 → 红。
+    其中 ③ 第一版守卫**假绿**（`return;` 的搜索窗口从守卫一直到注入点，混进了歌词分支自己
+    的 `return;`），已收紧为 if 块自身再复测转红——变异实测当场抓到的假绿。
 - **备注**：
   - 已知相邻缺口（本轮未扩大范围）：spread 独立文档同样没有 `onSwipe` 脚本，触屏在双页页面
     上无法滑动翻页，只能靠唤出底栏后用底栏按钮 / 键盘。修好唤出通道后已不再卡死，但手势
     契约仍与正文不对齐。
   - 真机复测（Android / Windows 原始路径：书架 → 打开含整页图的书 → 显式设 spreadMode=on →
-    收起底栏 → 点 letterbox 留白）未做。
+    收起底栏 → 点 letterbox 留白）未做；③ 的平台分叉是静态证据链（Dart 调用点 + 两侧原生
+    实现 + 陈旧判据三处对齐），未在真机上观测过双触发。

--- a/hibiki/lib/src/media/sources/reader_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/reader_hibiki_source.dart
@@ -1577,9 +1577,11 @@ class ReaderHibikiSource extends ReaderMediaSource {
     onSettingsChangedLive?.call();
   }
 
+  // BUG-1280：默认与 [ReaderSettings.spreadMode] 同为 'off'（两处必须一致，否则
+  // readerSettings 未就绪时读到的默认与阅读器实际用的默认相反）。
   String get ttuSpreadMode =>
       readerSettings?.spreadMode ??
-      getPreference<String>(key: 'ttu_spread_mode', defaultValue: 'auto');
+      getPreference<String>(key: 'ttu_spread_mode', defaultValue: 'off');
   Future<void> setTtuSpreadMode(String v) async {
     await (readerSettings?.setSpreadMode(v) ??
         setPreference<String>(key: 'ttu_spread_mode', value: v));

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/lyrics.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/lyrics.part.dart
@@ -182,6 +182,12 @@ extension _ReaderLyrics on _ReaderHibikiPageState {
       blur: ReaderHibikiSource.instance.lyricsBlur,
     );
 
+    // BUG-1280：歌词是第三个把文档交给 WebView 的地方（另两个是
+    // `_loadChapterDirectly` 和 `_loadSpreadPage`）。不在这里复位，从双页页面切进
+    // 歌词模式时 `_spreadDocumentLoaded` 会残留为真，`_onChapterLoadComplete` 的
+    // spread 守卫把歌词分支一起挡掉 → 歌词永远不就绪。标记的含义是「WebView 里
+    // 现在是不是 spread 文档」，所以每个装载点都必须写它。
+    _spreadDocumentLoaded = false;
     await _controller!.loadData(
       data: html,
       mimeType: 'text/html',

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -818,6 +818,9 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     final String html =
         buildSpreadPageHtml(leftUrl: leftUrl, rightUrl: rightUrl);
 
+    // BUG-1280：置位必须在 loadData 之前——`onLoadStop` 可能在 await 返回前就
+    // 派发，晚置位等于守卫对这一次加载失效。
+    _spreadDocumentLoaded = true;
     _isNavigatingToChapter = true;
     try {
       await _controller!.loadData(

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -47,6 +47,10 @@ extension _ReaderWebView on _ReaderHibikiPageState {
 
   Future<void> _loadChapterDirectly(int index) async {
     final String url = _chapterUrl(index);
+    // BUG-1280：交给 WebView 的是正文章节文档，清 spread 标记（见字段注释）。
+    // spread 的兜底降级路径 `_loadSpreadPage` → `_loadChapterDirectly` 也经过
+    // 这里，所以标记不会泄漏成「以为还在双页」。
+    _spreadDocumentLoaded = false;
     _isNavigatingToChapter = true;
     try {
       await _controller!.loadUrl(
@@ -2024,9 +2028,12 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
         );
 
         // BUG-1280：双页 spread 空白点击的专用桥，与上面的歌词桥同族。spread 是
-        // [buildSpreadPageHtml] 生成的独立文档，没有正文 hoshiReader 的
-        // onTap/onTapEmpty，此前唯一手势是「点图片 → onImageTap」（弹图片查看器）。
-        // 底栏一收起，spread 页就再没有任何唤出通道 → 看不到返回按钮 → 退不出书。
+        // [buildSpreadPageHtml] 生成的独立文档，HTML 本身不含正文 hoshiReader 的
+        // onTap/onTapEmpty，自带手势只有「点图片 → onImageTap」（弹图片查看器）。
+        // 底栏一收起，spread 页就再没有唤出通道 → 看不到返回按钮 → 退不出书。
+        // （修复前 Android 因 baseUrl 被保留而被误注入过正文引擎，见
+        // _onChapterLoadComplete 的 spread 守卫；那条误注入已堵掉，本桥现在是两个
+        // 平台上唯一且语义一致的唤出通道。）
         // 与歌词同理，这里对隐藏的底栏**无条件唤出/收起**——不看
         // tapEmptyToHideChrome（那开关管的是正文点空白是否收起底栏；spread 没有别的
         // 唤出途径，绝不能被它关死）。收尾 reclaim 阅读焦点：本次 pointer 手势把 OS
@@ -2195,10 +2202,17 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
           handlerName: 'onImageTap',
           callback: (args) {
             if (args.isEmpty) return;
-            // BUG-1280：点图片同样把 OS 焦点交给了 WebView，此前这条路径是全阅读器
-            // 唯一没 reclaim 的手势入口 → 看完图 pop 回来后 ESC 退不出书（BUG-136
-            // 同族）。在 spread 页尤其致命：两张整页图铺满视口，点击几乎必然命中
-            // img，于是「唤不出底栏」与「ESC 失效」同时成立，两条退出通道一起死。
+            // BUG-1280：点图片同样把 OS 焦点交给了 WebView，不 reclaim 则看完图
+            // pop 回来后 ESC 退不出书（BUG-136 同族）。在 spread 页尤其致命：两张
+            // 整页图铺满视口，点击几乎必然命中 img，于是「唤不出底栏」与「ESC 失效」
+            // 同时成立，两条退出通道一起死——所以本轮先修这一条。
+            //
+            // 口径更正：onImageTap **不是**「全阅读器唯一没 reclaim 的手势入口」。
+            // 同族至今仍有 7 处 JS 桥零 reclaim：onSelectionMenu、onImageRevealed、
+            // onImageContextMenu、onImageLongPress、onCueTap、onPointerSeek、
+            // onLyricsPointerSeek。其中 onImageRevealed / onImageContextMenu /
+            // onImageLongPress / onCueTap 连兄弟桥兜底都没有。本轮只修 spread 退出
+            // 路径必经的这一条，其余未覆盖——别把这里当作「此族已清干净」的证据。
             _focusOwnership.reclaim(FocusReclaimCause.gesture);
             _openImageViewer(args[0] as String);
           },
@@ -2436,6 +2450,30 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
   }
 
   Future<void> _onChapterLoadComplete(InAppWebViewController controller) async {
+    // BUG-1280（平台分叉守卫）：spread 独立文档绝不注入正文引擎。
+    //
+    // `_loadSpreadPage` 传给 `loadData` 的 baseUrl 与 `_chapterUrl(_currentChapter)`
+    // **逐字相同**，而上面 `onLoadStop` 的陈旧判据只比 `Uri.path`。于是同一份代码
+    // 在两个平台走出相反的分支：
+    //   - Windows fork 的 `loadData` 原生侧只取 data、丢掉 baseUrl
+    //     （`webview_channel_delegate.cpp` → `NavigateToString`），文档 URL 变
+    //     `about:blank`，path 为空 → 判 stale → 从来没走到这里；
+    //   - Android 的 `loadDataWithBaseURL` 保留 baseUrl，path 完全相等 → 判据放行
+    //     → 此前会把整份 `readerEngineSource` 注进 spread 文档。
+    // 后果是 spread 文档上同时挂着引擎的 `onTapEmpty` 和本页自带的
+    // `onSpreadTapEmpty`：一次空白点两个桥都收到，`onSpreadTapEmpty` 无条件翻转、
+    // `onTapEmpty` 在悬浮态/开了「点空白隐藏控制栏」时也翻转一次，两次翻转互相抵消
+    // → 底栏还是唤不出来，比没修更难查。
+    //
+    // 正确的模型是：spread 是独立文档（同歌词、VN），它的就绪与手势由它自己的
+    // `spreadReady` / `onSpreadTapEmpty` 桥负责，正文引擎、有声书桥、章节高亮对
+    // 「两张整页图、正文 ≤20 字」的 image-only 章都无意义。Windows 早就是这个行为，
+    // 这里把 Android 拉齐，而不是给 Android 再加一层特例。
+    if (_spreadDocumentLoaded) {
+      debugPrint('[ReaderHibiki] onChapterLoadComplete: spread document, '
+          'skipping body engine injection');
+      return;
+    }
     if (_lyricsMode) {
       if (!_readerContentReady) {
         // BUG-438 / TODO-889：歌词模式内容就绪，清兜底 deadline，下次导航拿新窗口。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -2023,6 +2023,30 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
           },
         );
 
+        // BUG-1280：双页 spread 空白点击的专用桥，与上面的歌词桥同族。spread 是
+        // [buildSpreadPageHtml] 生成的独立文档，没有正文 hoshiReader 的
+        // onTap/onTapEmpty，此前唯一手势是「点图片 → onImageTap」（弹图片查看器）。
+        // 底栏一收起，spread 页就再没有任何唤出通道 → 看不到返回按钮 → 退不出书。
+        // 与歌词同理，这里对隐藏的底栏**无条件唤出/收起**——不看
+        // tapEmptyToHideChrome（那开关管的是正文点空白是否收起底栏；spread 没有别的
+        // 唤出途径，绝不能被它关死）。收尾 reclaim 阅读焦点：本次 pointer 手势把 OS
+        // 焦点交给了 WebView，不夺回 Flutter _focusNode 就收不到 ESC（BUG-136）。
+        controller.addJavaScriptHandler(
+          handlerName: 'onSpreadTapEmpty',
+          callback: (_) {
+            if (isDictionaryShown) {
+              clearDictionaryResult();
+              return;
+            }
+            if (_anyChromeFloating) {
+              _handleFloatingChromeReveal();
+            } else {
+              _toggleChrome();
+            }
+            _focusOwnership.reclaim(FocusReclaimCause.gesture);
+          },
+        );
+
         controller.addJavaScriptHandler(
           handlerName: 'onSwipe',
           callback: (List<dynamic> args) {
@@ -2171,6 +2195,11 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
           handlerName: 'onImageTap',
           callback: (args) {
             if (args.isEmpty) return;
+            // BUG-1280：点图片同样把 OS 焦点交给了 WebView，此前这条路径是全阅读器
+            // 唯一没 reclaim 的手势入口 → 看完图 pop 回来后 ESC 退不出书（BUG-136
+            // 同族）。在 spread 页尤其致命：两张整页图铺满视口，点击几乎必然命中
+            // img，于是「唤不出底栏」与「ESC 失效」同时成立，两条退出通道一起死。
+            _focusOwnership.reclaim(FocusReclaimCause.gesture);
             _openImageViewer(args[0] as String);
           },
         );

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1121,10 +1121,14 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   /// BUG-1280：**上一次交给 WebView 的文档是不是 spread 独立文档**
   /// （[buildSpreadPageHtml]，两张整页 `<img>`，无正文 `hoshiReader`）。
   ///
-  /// 只有两个写点，正好是 WebView 的两个装载原语：`_loadSpreadPage` 置位、
-  /// `_loadChapterDirectly` 复位——所以它跟踪的是「WebView 里现在是什么文档」，
-  /// 而不是「spread map 存不存在」（`_spreadMap != null` 在整本书生命周期为真，
-  /// 分不出当前这一页是双页还是普通章）。
+  /// 写点是**三个**，正好是把文档交给 WebView 的三个装载原语：`_loadSpreadPage`
+  /// 置位，`_loadChapterDirectly` 与 **`_loadLyricsPage`** 复位。所以它跟踪的是
+  /// 「WebView 里现在是什么文档」，而不是「spread map 存不存在」
+  /// （`_spreadMap != null` 在整本书生命周期为真，分不出当前这一页是双页还是普通章）。
+  ///
+  /// **歌词那处最容易漏，本 PR 实现时就漏过**：不在 `_loadLyricsPage` 复位，从双页
+  /// 页面切进歌词模式时本标记会残留为真，`_onChapterLoadComplete` 的 spread 守卫把
+  /// 歌词分支一起挡掉 → 歌词永远不就绪。新增装载点必须同步写它。
   ///
   /// 存在的理由是 `onLoadStop` 的陈旧判据只比 URL 的 path，而 `_loadSpreadPage`
   /// 传的 baseUrl 与 `_chapterUrl(_currentChapter)` 逐字相同 → 该判据**分不出**

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -520,6 +520,15 @@ html,body{width:100vw;height:100vh;overflow:hidden;background:#000}
       window.flutter_inappwebview.callHandler('onImageTap',img.src);
     });
   });
+  // BUG-1280：spread 是第四种独立文档（继歌词 BUG-756、VN BUG-1195 之后），没有正文
+  // hoshiReader 的 onTap/onTapEmpty。此前它唯一的手势是「点图片 → onImageTap」，
+  // 于是底栏一收起就再没有任何唤出通道——用户看不到返回按钮，就退不出这本书。
+  // 修法镜像歌词的 onLyricsTapEmpty：图片以外（letterbox 留白 / 页缝）的点击走专桥
+  // 给 Dart，由 Dart 判唤出还是收起（chrome 可见性的真值只在 Dart 侧）。
+  document.addEventListener('click', function(e){
+    if (e && e.target && e.target.tagName === 'IMG') return;
+    window.flutter_inappwebview.callHandler('onSpreadTapEmpty');
+  });
   var signaled = false;
   function signalReady(){
     if (signaled) return;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -520,9 +520,16 @@ html,body{width:100vw;height:100vh;overflow:hidden;background:#000}
       window.flutter_inappwebview.callHandler('onImageTap',img.src);
     });
   });
-  // BUG-1280：spread 是第四种独立文档（继歌词 BUG-756、VN BUG-1195 之后），没有正文
-  // hoshiReader 的 onTap/onTapEmpty。此前它唯一的手势是「点图片 → onImageTap」，
-  // 于是底栏一收起就再没有任何唤出通道——用户看不到返回按钮，就退不出这本书。
+  // BUG-1280：spread 是第四种独立文档（继歌词 BUG-756、VN BUG-1195 之后），HTML 本身
+  // 不含正文 hoshiReader 的 onTap/onTapEmpty，自带的手势只有「点图片 → onImageTap」。
+  // 底栏一收起就没有唤出通道 → 看不到返回按钮 → 退不出这本书。
+  //
+  // 注意这条在修复前**分平台**：Windows 的 loadData 丢 baseUrl，onLoadStop 判 stale，
+  // 正文引擎从不注入，spread 页确实一个唤出通道都没有；Android 保留 baseUrl，判据放行，
+  // 正文引擎（含 onTapEmpty）被误注进来，反而"意外"有过一条受 tapEmptyToHideChrome
+  // 门控的通道。那条误注入已由 _onChapterLoadComplete 的 spread 守卫堵掉（见其注释），
+  // 所以两个平台现在都只剩下面这一条、且语义一致的专桥。
+  //
   // 修法镜像歌词的 onLyricsTapEmpty：图片以外（letterbox 留白 / 页缝）的点击走专桥
   // 给 Dart，由 Dart 判唤出还是收起（chrome 可见性的真值只在 Dart 侧）。
   document.addEventListener('click', function(e){
@@ -1110,6 +1117,20 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   ({String? bookKey, String? title})? get lookupBookIdentity =>
       (bookKey: widget.bookKey, title: _book?.title);
   EpubSpreadMap? _spreadMap;
+
+  /// BUG-1280：**上一次交给 WebView 的文档是不是 spread 独立文档**
+  /// （[buildSpreadPageHtml]，两张整页 `<img>`，无正文 `hoshiReader`）。
+  ///
+  /// 只有两个写点，正好是 WebView 的两个装载原语：`_loadSpreadPage` 置位、
+  /// `_loadChapterDirectly` 复位——所以它跟踪的是「WebView 里现在是什么文档」，
+  /// 而不是「spread map 存不存在」（`_spreadMap != null` 在整本书生命周期为真，
+  /// 分不出当前这一页是双页还是普通章）。
+  ///
+  /// 存在的理由是 `onLoadStop` 的陈旧判据只比 URL 的 path，而 `_loadSpreadPage`
+  /// 传的 baseUrl 与 `_chapterUrl(_currentChapter)` 逐字相同 → 该判据**分不出**
+  /// spread 文档和正文章节，于是在保留 baseUrl 的平台上会把整份正文引擎注进
+  /// spread 文档。详见 `_onChapterLoadComplete` 的守卫注释。
+  bool _spreadDocumentLoaded = false;
   ReaderSettings? _settings;
   String? _extractDir;
 

--- a/hibiki/lib/src/reader/reader_settings.dart
+++ b/hibiki/lib/src/reader/reader_settings.dart
@@ -319,7 +319,13 @@ class ReaderSettings {
   Future<void> setPageColumns(int v) => _set<int>('ttu_page_columns', v);
 
   /// `off`, `on`, or `auto`.
-  String get spreadMode => _get<String>('ttu_spread_mode', 'auto');
+  ///
+  /// BUG-1280：默认从 `auto` 改为 `off`。`auto` 会在打开书时按 OPF 元数据 /
+  /// 边缘匹配**自动**把相邻整页图章节配对成双页展开，用户没主动选过就被切进一种
+  /// 手势契约完全不同的独立文档（[buildSpreadPageHtml]，无正文 hoshiReader）。
+  /// 双页展开保留为显式选项（阅读器快捷设置里的 off/on/auto 三选一），只是不再
+  /// 是没设置过的用户的默认落点。已显式设过本键的用户读到的是自己的存值，不受影响。
+  String get spreadMode => _get<String>('ttu_spread_mode', 'off');
   Future<void> setSpreadMode(String v) => _set<String>('ttu_spread_mode', v);
 
   /// `ltr` or `rtl`.

--- a/hibiki/test/reader/spread_chrome_escape_guard_test.dart
+++ b/hibiki/test/reader/spread_chrome_escape_guard_test.dart
@@ -1,0 +1,120 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/reader_hibiki_page.dart'
+    show buildSpreadPageHtml;
+import 'package:hibiki/src/reader/reader_settings.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../pages/reader_hibiki_page_source_corpus.dart';
+
+/// BUG-1280 守卫：从书架打开书后自动切进「双页漫画」（spread）展开，就再也唤不出
+/// 底栏、退不出这本书。
+///
+/// 根因有两层，各自独立致命：
+/// ① spread 页是 [buildSpreadPageHtml] 生成的**独立文档**（继歌词 BUG-756、VN
+///    BUG-1195 之后的第四种），没有正文 hoshiReader 的 onTap/onTapEmpty。它此前
+///    唯一的手势是「点图片 → 弹图片查看器」，于是底栏一收起就再没有任何唤出通道，
+///    用户看不到返回按钮 → 退不出书 → 回不到书架。
+/// ② 点图片的 Dart 处理器是全阅读器唯一没有 reclaim 阅读焦点的手势入口，OS 焦点
+///    留在 WebView，ESC 全局退出也失效（BUG-136 同族）。两张整页图铺满视口时点击
+///    几乎必然命中图片，于是两条退出通道同时死掉。
+///
+/// 修法：spread 文档补「图片以外的点击」专桥交给 Dart 判唤出/收起（镜像歌词），
+/// 点图片路径补 reclaim；并把 `spreadMode` 默认从 auto 改成 off——不再让没主动选过
+/// 的用户被自动切进这套手势契约不同的文档（选项本身完整保留）。
+void main() {
+  const String kEmptyTapBridge = 'onSpreadTapEmpty';
+
+  group('spread 文档有唤出底栏的通道 (BUG-1280)', () {
+    const String leftUrl = 'hoshi.local/OEBPS/img/left.png';
+    const String rightUrl = 'hoshi.local/OEBPS/img/right.png';
+    final String html =
+        buildSpreadPageHtml(leftUrl: leftUrl, rightUrl: rightUrl);
+
+    test('图片以外的点击有专桥回传 Dart', () {
+      expect(html, contains("callHandler('$kEmptyTapBridge')"),
+          reason: 'spread 页没有这条桥就没有任何唤出底栏的手势 → 退不出书');
+      expect(html, contains("document.addEventListener('click'"),
+          reason: '专桥必须挂在文档级，才能收到 letterbox 留白 / 页缝上的点击');
+    });
+
+    test('点在图片上仍走图片查看器，不误报成空白点', () {
+      // 图片的 click 会冒泡到文档级监听；没有这条短路，点图片会同时弹查看器和
+      // 翻转底栏。撤回短路 → 转红。
+      final int bridgeIdx = html.indexOf("callHandler('$kEmptyTapBridge')");
+      final int guardIdx = html.indexOf("tagName === 'IMG'");
+      expect(guardIdx, greaterThan(0), reason: '缺少 IMG 短路');
+      expect(guardIdx, lessThan(bridgeIdx),
+          reason: 'IMG 短路必须在回传之前，否则点图片会被当成空白点');
+      expect(html, contains("callHandler('onImageTap'"),
+          reason: '点图片查看原图是既有行为，不得被本次修复吃掉');
+    });
+
+    test('空白桥与 spreadReady 就绪门控互不干扰 (TODO-1229 不回退)', () {
+      expect(html, contains("callHandler('spreadReady')"));
+      expect(html, contains('function signalReady'));
+      expect("callHandler('spreadReady')".allMatches(html).length, 1);
+    });
+  });
+
+  group('Dart 侧接线 (BUG-1280)', () {
+    final String source = readReaderPageSource();
+
+    test('注册了 $kEmptyTapBridge 处理器，且无条件翻转底栏 + 夺回焦点', () {
+      final int idx = source.indexOf("handlerName: '$kEmptyTapBridge'");
+      expect(idx, greaterThan(0), reason: 'JS 发了桥而 Dart 不接 = 桥是死的');
+      // 切到下一个 handler 注册为止，只看本处理器函数体。
+      final int end = source.indexOf('addJavaScriptHandler', idx + 1);
+      expect(end, greaterThan(idx));
+      final String body = source.substring(idx, end);
+
+      expect(body, contains('_handleFloatingChromeReveal()'),
+          reason: '悬浮态必须走唤出/收起状态机');
+      expect(body, contains('_toggleChrome()'), reason: '挤压态必须能翻转底栏');
+      expect(body, contains('FocusReclaimCause.gesture'),
+          reason: '不夺回 Flutter 焦点则 ESC 退出仍然失效（BUG-136）');
+      expect(body.contains('tapEmptyToHideChrome'), isFalse,
+          reason: 'spread 没有别的唤出途径，绝不能被「点空白隐藏控制栏」开关关死');
+    });
+
+    test('点图片路径夺回阅读焦点，ESC 仍能退出', () {
+      final int idx = source.indexOf("handlerName: 'onImageTap'");
+      expect(idx, greaterThan(0));
+      final int end = source.indexOf('addJavaScriptHandler', idx + 1);
+      expect(end, greaterThan(idx));
+      final String body = source.substring(idx, end);
+
+      expect(body, contains('FocusReclaimCause.gesture'),
+          reason: '点图片把 OS 焦点交给 WebView，不 reclaim 则看完图后 ESC 退不出书');
+      expect(body, contains('_openImageViewer('),
+          reason: '查看原图是既有行为，reclaim 不得取代它');
+    });
+  });
+
+  group('spreadMode 默认不再自动进双页 (BUG-1280)', () {
+    late HibikiDatabase db;
+
+    setUp(() {
+      db = HibikiDatabase.forTesting(
+        DatabaseConnection(NativeDatabase.memory()),
+      );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('没设置过的用户默认 off', () {
+      expect(ReaderSettings(db).spreadMode, 'off');
+    });
+
+    test('显式设过的值照旧生效（选项没被删掉）', () async {
+      final ReaderSettings settings = ReaderSettings(db);
+      for (final String mode in <String>['auto', 'on', 'off']) {
+        await settings.setSpreadMode(mode);
+        expect(settings.spreadMode, mode);
+      }
+    });
+  });
+}

--- a/hibiki/test/reader/spread_chrome_escape_guard_test.dart
+++ b/hibiki/test/reader/spread_chrome_escape_guard_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:io';
+
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -6,23 +9,28 @@ import 'package:hibiki/src/pages/implementations/reader_hibiki_page.dart'
 import 'package:hibiki/src/reader/reader_settings.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
+import '../helpers/source_guard.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 
 /// BUG-1280 守卫：从书架打开书后自动切进「双页漫画」（spread）展开，就再也唤不出
 /// 底栏、退不出这本书。
 ///
-/// 根因有两层，各自独立致命：
 /// ① spread 页是 [buildSpreadPageHtml] 生成的**独立文档**（继歌词 BUG-756、VN
-///    BUG-1195 之后的第四种），没有正文 hoshiReader 的 onTap/onTapEmpty。它此前
-///    唯一的手势是「点图片 → 弹图片查看器」，于是底栏一收起就再没有任何唤出通道，
-///    用户看不到返回按钮 → 退不出书 → 回不到书架。
-/// ② 点图片的 Dart 处理器是全阅读器唯一没有 reclaim 阅读焦点的手势入口，OS 焦点
-///    留在 WebView，ESC 全局退出也失效（BUG-136 同族）。两张整页图铺满视口时点击
-///    几乎必然命中图片，于是两条退出通道同时死掉。
+///    BUG-1195 之后的第四种），HTML 本身不含正文 hoshiReader 的 onTap/onTapEmpty，
+///    自带手势只有「点图片 → 弹图片查看器」。底栏一收起就没有唤出通道，用户看不到
+///    返回按钮 → 退不出书 → 回不到书架。
+/// ② 点图片的 Dart 处理器没有 reclaim 阅读焦点，OS 焦点留在 WebView，ESC 全局退出
+///    也失效（BUG-136 同族）。两张整页图铺满视口时点击几乎必然命中图片，于是两条
+///    退出通道同时死掉。
+/// ③ 平台分叉：`_loadSpreadPage` 的 baseUrl 与 `_chapterUrl(_currentChapter)` 逐字
+///    相同，而 onLoadStop 的陈旧判据只比 `Uri.path`。Windows 的 loadData 丢 baseUrl
+///    → 判 stale → 不注入；Android 的 loadDataWithBaseURL 保留 baseUrl → 判据放行
+///    → 整份正文引擎（含 onTapEmpty）被注进 spread 文档，与本修复的专桥双触发、
+///    互相抵消。必须有守卫钉住「spread 文档不注入正文引擎」。
 ///
 /// 修法：spread 文档补「图片以外的点击」专桥交给 Dart 判唤出/收起（镜像歌词），
-/// 点图片路径补 reclaim；并把 `spreadMode` 默认从 auto 改成 off——不再让没主动选过
-/// 的用户被自动切进这套手势契约不同的文档（选项本身完整保留）。
+/// 点图片路径补 reclaim，`_onChapterLoadComplete` 加 spread 分支守卫；并把
+/// `spreadMode` 默认从 auto 改成 off（选项本身完整保留）。
 void main() {
   const String kEmptyTapBridge = 'onSpreadTapEmpty';
 
@@ -39,9 +47,7 @@ void main() {
           reason: '专桥必须挂在文档级，才能收到 letterbox 留白 / 页缝上的点击');
     });
 
-    test('点在图片上仍走图片查看器，不误报成空白点', () {
-      // 图片的 click 会冒泡到文档级监听；没有这条短路，点图片会同时弹查看器和
-      // 翻转底栏。撤回短路 → 转红。
+    test('点在图片上仍走图片查看器，不误报成空白点（位置断言）', () {
       final int bridgeIdx = html.indexOf("callHandler('$kEmptyTapBridge')");
       final int guardIdx = html.indexOf("tagName === 'IMG'");
       expect(guardIdx, greaterThan(0), reason: '缺少 IMG 短路');
@@ -49,6 +55,36 @@ void main() {
           reason: 'IMG 短路必须在回传之前，否则点图片会被当成空白点');
       expect(html, contains("callHandler('onImageTap'"),
           reason: '点图片查看原图是既有行为，不得被本次修复吃掉');
+    });
+
+    // 上一条只断言字面量的**位置**，把 `if (...) return;` 改成空块（保留判断、删掉
+    // `return;`）它照样绿——而那个变异会让点图片同时弹查看器 + 翻转底栏。这里把
+    // 生产 HTML 里的脚本原样丢进 node 真跑，断言的是**短路真的生效**：模拟冒泡，
+    // 点 IMG 只能出 onImageTap，点留白才出 onSpreadTapEmpty。
+    test('spread 脚本真跑：IMG 短路真生效，点图片不翻底栏（行为级）', () {
+      final String payload = jsonEncode(<String, String>{'html': html});
+      final Directory temp =
+          Directory.systemTemp.createTempSync('hibiki-spread-js-');
+      final File payloadFile = File('${temp.path}/payload.json')
+        ..writeAsStringSync(payload);
+      late final ProcessResult result;
+      try {
+        result = Process.runSync(
+          'node',
+          <String>['-e', _spreadBehaviorRunner, payloadFile.path],
+          stdoutEncoding: utf8,
+          stderrEncoding: utf8,
+        );
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+      expect(
+        result.exitCode,
+        0,
+        reason: 'spread JS behavior runner failed:\n'
+            'stdout=${result.stdout}\nstderr=${result.stderr}',
+      );
+      expect(result.stdout.toString().trim(), 'OK');
     });
 
     test('空白桥与 spreadReady 就绪门控互不干扰 (TODO-1229 不回退)', () {
@@ -74,7 +110,7 @@ void main() {
       expect(body, contains('_toggleChrome()'), reason: '挤压态必须能翻转底栏');
       expect(body, contains('FocusReclaimCause.gesture'),
           reason: '不夺回 Flutter 焦点则 ESC 退出仍然失效（BUG-136）');
-      expect(body.contains('tapEmptyToHideChrome'), isFalse,
+      expect(containsCodeLine(body, 'tapEmptyToHideChrome'), isFalse,
           reason: 'spread 没有别的唤出途径，绝不能被「点空白隐藏控制栏」开关关死');
     });
 
@@ -89,6 +125,51 @@ void main() {
           reason: '点图片把 OS 焦点交给 WebView，不 reclaim 则看完图后 ESC 退不出书');
       expect(body, contains('_openImageViewer('),
           reason: '查看原图是既有行为，reclaim 不得取代它');
+    });
+
+    // 平台分叉守卫：Android 的 loadDataWithBaseURL 保留 baseUrl，onLoadStop 只比
+    // path 的陈旧判据分不出 spread 文档，会把整份正文引擎（含 onTapEmpty）注进来，
+    // 与专桥双触发互相抵消。Windows 因 NavigateToString 丢 baseUrl 天然不会。
+    test('spread 独立文档不注入正文引擎（Android/Windows 行为拉齐）', () {
+      final String body =
+          methodBody(source, 'Future<void> _onChapterLoadComplete(');
+      expect(containsCodeLine(body, '_spreadDocumentLoaded'), isTrue,
+          reason: 'spread 文档必须在注入正文引擎之前被挡下');
+
+      final int guardIdx = body.indexOf('if (_spreadDocumentLoaded)');
+      final int injectIdx = body.indexOf('readerEngineSource(');
+      expect(guardIdx, greaterThan(0), reason: '守卫必须是真分支，不是提一嘴的注释');
+      expect(injectIdx, greaterThan(0), reason: '正文引擎注入点没了，本守卫需要跟着重写');
+      expect(guardIdx, lessThan(injectIdx), reason: '守卫必须在注入之前，放在后面等于没有');
+
+      // 光有判断不够，必须真的短路掉后续注入。窗口只能是 if 块**自身**（花括号
+      // 配对）：早先写成 `body.substring(guardIdx, injectIdx)` 时，窗口里混进了
+      // 歌词分支自己的 `return;`，把「删掉守卫的 return」这个变异放了过去（实测
+      // 假绿）。
+      final String guardBlock = methodBody(body, 'if (_spreadDocumentLoaded)');
+      expect(containsCodeLine(guardBlock, 'return;'), isTrue,
+          reason: '判到 spread 却不 return，正文引擎照样注进去');
+
+      // 两个写点必须都在：置位在 spread 装载原语，复位在正文章节装载原语。
+      // 少任何一个，标记要么永远为假（守卫真空通过）、要么置位后再不复位
+      // （正文章节从此不再注入引擎 = 整个阅读器废掉）。
+      final String setBody =
+          methodBody(source, 'Future<void> _loadSpreadPage(SpreadEntry entry)');
+      expect(containsCodeLine(setBody, '_spreadDocumentLoaded = true'), isTrue,
+          reason: 'spread 装载原语必须置位，否则守卫永远看不到 spread');
+      final String clearBody =
+          methodBody(source, 'Future<void> _loadChapterDirectly(int index)');
+      expect(
+          containsCodeLine(clearBody, '_spreadDocumentLoaded = false'), isTrue,
+          reason: '正文章节装载原语必须复位，否则翻回正文后引擎再不注入');
+
+      // 第三个装载点：歌词。漏掉它 → 从双页页面切进歌词模式时标记残留为真，
+      // spread 守卫把歌词分支一起挡掉 → 歌词永远不就绪。
+      final String lyricsBody =
+          methodBody(source, 'Future<void> _loadLyricsPage()');
+      expect(
+          containsCodeLine(lyricsBody, '_spreadDocumentLoaded = false'), isTrue,
+          reason: '歌词装载点必须复位，否则从双页切歌词会被 spread 守卫挡死');
     });
   });
 
@@ -116,5 +197,118 @@ void main() {
         expect(settings.spreadMode, mode);
       }
     });
+
+    // `ttu_spread_mode` 有两处兜底默认：[ReaderSettings.spreadMode] 是阅读器真正
+    // 读的那个，[ReaderHibikiSource.ttuSpreadMode] 是 readerSettings 未就绪时
+    // （设置页 / 冷启动）读的那个。两处漂开 = 设置页显示的默认与阅读器实际用的默认
+    // 相反。上面两条真行为测试只覆盖 ReaderSettings，单独把 source 那处改回 auto
+    // 全套照样绿——所以必须有这条跨文件一致性断言。
+    test('两处兜底默认必须一致，且都是 off', () {
+      const String kSettingsFile = 'lib/src/reader/reader_settings.dart';
+      const String kSourceFile =
+          'lib/src/media/sources/reader_hibiki_source.dart';
+      final String settingsSrc = File(kSettingsFile).readAsStringSync();
+      final String sourceSrc = File(kSourceFile).readAsStringSync();
+
+      final RegExpMatch? settingsHit = RegExp(
+        r"_get<String>\(\s*'ttu_spread_mode'\s*,\s*'([a-z]+)'\s*\)",
+      ).firstMatch(settingsSrc);
+      final RegExpMatch? sourceHit = RegExp(
+        r"key:\s*'ttu_spread_mode'\s*,\s*defaultValue:\s*'([a-z]+)'",
+      ).firstMatch(sourceSrc);
+
+      // `isNotNull` 在本文件里与 drift 的同名符号撞车（两边都被 import），
+      // 故用显式 `!= null`，语义相同。
+      expect(settingsHit != null, isTrue,
+          reason: '$kSettingsFile 里找不到 ttu_spread_mode 的兜底默认，守卫已失效');
+      expect(sourceHit != null, isTrue,
+          reason: '$kSourceFile 里找不到 ttu_spread_mode 的兜底默认，守卫已失效');
+
+      final String settingsDefault = settingsHit!.group(1)!;
+      final String sourceDefault = sourceHit!.group(1)!;
+      expect(sourceDefault, settingsDefault,
+          reason: '两处兜底默认漂开：$kSettingsFile=$settingsDefault / '
+              '$kSourceFile=$sourceDefault');
+      expect(settingsDefault, 'off', reason: 'BUG-1280：没设置过的用户不得被自动切进双页展开');
+    });
   });
 }
+
+/// 把生产 spread HTML 里的 `<script>` 原样丢进 node 跑，用最小假 DOM 复现「点图片」
+/// 与「点留白」两条真实路径（含冒泡：真浏览器里 img 的 click 一定会冒到文档级监听）。
+const String _spreadBehaviorRunner = r"""
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+function assert(value, message) {
+  if (!value) throw new Error(message);
+}
+const html = data.html;
+const open = html.indexOf('<script>');
+const close = html.indexOf('</script>', open);
+assert(open >= 0 && close > open, 'spread script block missing');
+const script = html.slice(open + '<script>'.length, close);
+
+function node(tagName, src) {
+  return {
+    tagName: tagName,
+    src: src,
+    listeners: {},
+    complete: true,
+    naturalWidth: 100,
+    addEventListener(type, fn) {
+      (this.listeners[type] = this.listeners[type] || []).push(fn);
+    },
+    removeEventListener(type, fn) {
+      const list = this.listeners[type] || [];
+      this.listeners[type] = list.filter(f => f !== fn);
+    }
+  };
+}
+
+const imgs = [node('IMG', 'L'), node('IMG', 'R')];
+const docListeners = {};
+const document = {
+  querySelectorAll(selector) {
+    assert(selector === 'img', 'unexpected selector ' + selector);
+    return imgs;
+  },
+  addEventListener(type, fn) {
+    (docListeners[type] = docListeners[type] || []).push(fn);
+  }
+};
+const calls = [];
+const window = {
+  flutter_inappwebview: {callHandler: (...args) => calls.push(args)}
+};
+new Function('window', 'document', script)(window, document);
+
+assert(calls.length === 1 && calls[0][0] === 'spreadReady',
+  'already-decoded images must signal spreadReady once, got ' +
+  JSON.stringify(calls));
+assert((docListeners['click'] || []).length === 1,
+  'spread document-level click listener missing');
+
+// 真浏览器语义：先跑目标自己的监听，再冒泡到文档级监听，同一个 event 对象。
+function clickOn(target) {
+  const ev = {target: target};
+  (target.listeners['click'] || []).slice().forEach(fn => fn(ev));
+  (docListeners['click'] || []).slice().forEach(fn => fn(ev));
+}
+
+calls.length = 0;
+clickOn(imgs[0]);
+assert(calls.length === 1,
+  'clicking an image must fire exactly one bridge, got ' +
+  JSON.stringify(calls));
+assert(calls[0][0] === 'onImageTap' && calls[0][1] === 'L',
+  'clicking an image must open the image viewer, got ' +
+  JSON.stringify(calls));
+
+calls.length = 0;
+clickOn(node('DIV', null));
+assert(calls.length === 1 && calls[0][0] === 'onSpreadTapEmpty',
+  'clicking the letterbox must reach the chrome-reveal bridge, got ' +
+  JSON.stringify(calls));
+
+process.stdout.write('OK');
+""";


### PR DESCRIPTION
## 问题

用户报："书架里面打开，然后自动变成双页漫画……书架唤不出菜单退不出去了"。

## 根因（三层，各自独立）

① **spread 页 HTML 没有唤出底栏的通道**
`buildSpreadPageHtml` 生成的双页展开页是**独立文档**（继歌词 BUG-756、VN BUG-1195 之后的第四种），HTML 本身不含正文 `hoshiReader`，自带手势只有 `img.click → onImageTap`（弹图片查看器）。正文有 `onTapEmpty`、歌词有 `onLyricsTapEmpty`、VN 有 `onVnBlankTap`——spread 一个都没有。底栏一收起就再也唤不回来，用户看不到返回按钮 → 退不出这本书 → 回不到书架。

② **`onImageTap` 没有 reclaim 焦点**
OS 焦点留在 WebView → ESC 全局退出失效（BUG-136 同族）。spread 页两张整页图铺满视口，点击几乎必然命中 img，于是「唤不出底栏」与「ESC 失效」**同时**成立，两条退出通道一起死。

③ **平台分叉（复核阶段新发现，比 ① 更隐蔽）**
`_loadSpreadPage` 传给 `loadData` 的 baseUrl 与 `_chapterUrl(_currentChapter)` **逐字相同**，而 `onLoadStop` 的陈旧判据只比 `Uri.path` → 判据**分不出** spread 文档和正文章节：

- **Windows** fork 的 `loadData` 原生侧只取 data、丢掉 baseUrl（`webview_channel_delegate.cpp:104-106` → `NavigateToString`）→ 文档 URL 变 `about:blank`，path 为空 → 判 stale → 正文引擎从不注入；
- **Android** 的 `loadDataWithBaseURL`（`WebViewChannelDelegate.java:117`）保留 baseUrl → path 完全相等 → 判据放行 → `_onChapterLoadComplete`（无 spread 分支守卫）**无条件**注入整份 `readerEngineSource`（含 `onTapEmpty`）。

**若只做 ①，Android 会比修复前更糟**：spread 文档同时挂着 `onTapEmpty` 和新加的 `onSpreadTapEmpty`，一次空白点两个桥都收到——`onSpreadTapEmpty` 无条件翻转，`onTapEmpty` 在悬浮态 / 开了「点空白隐藏控制栏」时也翻转一次 → 两次翻转互相抵消 → 底栏仍然唤不出来。所以 ① 与 ③ 必须同批落地。

④ 触发前提：`spreadMode` 默认 `auto`，打开书时按 OPF 元数据 / 边缘匹配**自动**配对成双页——用户从没主动选过。

## 「书架里的书就不应该能变成双页漫画」——类型门控的核实结果

用户诉求指向「书架里的书」不该变成「双页**漫画**」，所以专门核实了自动配对的作用域：

- `EpubSpreadMap._shouldPairAuto`（`epub_spread_map.dart:241-280`）的三条判据（OPF `page-spread-left/right` 成对 / 书级 `rendition:spread` / 边缘像素匹配）**每一条都带 `&& isImageOnlyChapter(i) && isImageOnlyChapter(i+1)`**（`:259, :266-267, :274-275`）；`isImageOnlyChapter`（`epub_book.dart:123-129`）要求章节正文纯文本 ≤ 20 字。
- ⇒ **纯文字 EPUB 小说在 `auto` 下不会进 spread**（正文 >20 字直接 false）。真正被卷进去的是**图片型 EPUB**：扫描版漫画以 `format='epub'` 导入后走 reader 路径（`reader_hibiki_source.dart:506-508, 548-552` 只把 `pdf`/`manga` 分流走），以及带 `rendition:spread` 的轻小说彩插页。用户说的「变成双页漫画」正是这一类。
- **为什么不加按媒体类型门控**（口径更正：**不是**「拿不到信号」）：本仓确实**已有**可用信号——`MangaArchiveImporter._isPureImageEpub`（`manga_archive_importer.dart:220-239`，入参正是 reader 已持有的 `EpubBook`，已产品化为 `BookConvertBlocker.textOnlyBook`），另有 DB 逐章 `chaptersJson.characters`。不做门控的真实理由是**零增量 + 不修根因**：
  - `_isPureImageEpub` 要求**所有** linear 非 nav 章都 image-only（`:226-227` 一章不满足就 false）。用户实际撞的是「**轻小说彩插 + `rendition:spread`**」，正文是文字 → 这类书被判成**文字书**。正向门控 ⇒ 本来就不符合，等于没挡（零增量）；反向门控（只在纯图书上开 spread）⇒ 彩插书原样复发。**两个方向都救不了用户报的那本书。**
  - 更根本的是：门控只是把「手势契约不同的独立文档」**精准投递**给会触发它的书，spread 自己的手势缺口一点没修。根因修复是 ①③（补唤出通道 + 堵掉误注入），默认改 `off` 是「不让没选过的用户撞上」。
  - 相邻空白（**本轮不做，留 TODO**）：`rendition:layout` / `pre-paginated` **全仓未解析**（grep 零命中），`epub_parser.dart:794-805` 解析 `rendition:spread` 处是唯一补点。真要「按书判断该不该双页」，那才是正确的信号来源。
- ⇒ 原改动（默认 `auto` → `off`）保留，不加门控。

## 修复

- spread 文档补「图片以外的点击」专桥 `onSpreadTapEmpty`（文档级监听 + `IMG` 短路，点图片仍走原有查看器）。
- Dart 接上该桥，镜像歌词 `onLyricsTapEmpty` 语义：有查词弹窗先清栈；悬浮态走 `_handleFloatingChromeReveal`、挤压态 `_toggleChrome`，**不看** `tapEmptyToHideChrome`（该开关真实语义是「底栏悬浮 vs 挤压」，不是「允不允许唤栏」；spread 没有别的唤出途径，不能被它关死——歌词已立同款先例）；收尾 reclaim 阅读焦点。
- `onImageTap` 补 `_focusOwnership.reclaim(FocusReclaimCause.gesture)`（正文内联图片同样受益）。
- **平台分叉守卫**：新增 `_spreadDocumentLoaded`，写点正好是 WebView 的三个装载原语——`_loadSpreadPage` 置位，`_loadChapterDirectly` / `_loadLyricsPage` 复位（spread 缺图降级回正文经过前者，标记不会泄漏；漏掉歌词那处会让「从双页切歌词」被守卫挡死，已在实现中一并修）。`_onChapterLoadComplete` 据此早退：spread 独立文档不再注入正文引擎 / 有声书桥 / 章节高亮。**这是把 Android 拉齐到 Windows 早已是的行为，不是给 Android 加特例**——对「两张整页图、正文 ≤20 字」的 image-only 章，那些注入本来就无意义。
- `spreadMode` 默认 `auto` → `off`（`reader_settings.dart` 与 `reader_hibiki_source.dart` 两处兜底同步改）。**双页展开选项完整保留**（off/on/auto 三选一），只是不再是没设置过的用户的默认落点；已显式设过本键的用户读到的仍是自己的存值。

## 口径更正

之前写的「`onImageTap` 是**全阅读器唯一**没有 reclaim 焦点的手势入口」**是错的**，注释与 BUG 文档已改。同族至今仍有 **7 处** JS 桥零 reclaim：`onSelectionMenu`、`onImageRevealed`、`onImageContextMenu`、`onImageLongPress`、`onCueTap`、`onPointerSeek`、`onLyricsPointerSeek`——其中 `onImageRevealed` / `onImageContextMenu` / `onImageLongPress` / `onCueTap` 连兄弟桥兜底都没有。本轮只修 spread 退出路径必经的 `onImageTap`，**不留「此族已清干净」的假象**。同理，「spread 一个唤出通道都没有」也补了平台限定（修复前 Android 因误注入而"意外"有过一条受开关门控的通道）。

## 验证

`hibiki/test/reader/spread_chrome_escape_guard_test.dart`（**10 条**）：

- **行为级（新增）**：把生产 `buildSpreadPageHtml` 的 `<script>` 原样丢进 node 真跑（最小假 DOM + **模拟冒泡**），断言点 IMG 只出 `onImageTap`、点留白才出 `onSpreadTapEmpty`。
- **跨文件一致性（新增）**：`ttu_spread_mode` 两处兜底默认必须相等且为 `off`。
- **平台分叉守卫（新增）**：spread 守卫在正文引擎注入之前、if 块**自身**含 `return;`（窗口用花括号配对，不用字符距离）；三个装载点的置位/复位都在。
- 原有生成器断言 / 源码接线守卫 / `ReaderSettings` 真行为测试保留。

**变异实测 6 次，全部转红（退出码 1）**：

| 变异 | 结果 |
|---|---|
| 保留 `tagName === 'IMG'` 判断、只删 `return;` | 🔴 exit 1（旧守卫此变异下 7/7 全绿） |
| 只把 `reader_hibiki_source.dart` 的默认改回 `'auto'` | 🔴 exit 1（旧守卫此变异下 7/7 全绿） |
| 保留 spread 守卫的 `if`、只删 `return;` | 🔴 exit 1 |
| 删 `_loadChapterDirectly` 的复位 | 🔴 exit 1 |
| 删 `_loadSpreadPage` 的置位 | 🔴 exit 1 |
| 删 `_loadLyricsPage` 的复位 | 🔴 exit 1 |

其中第 3 条**第一版守卫假绿**（`return;` 的搜索窗口从守卫一直到注入点，混进了歌词分支自己的 `return;`），当场收紧为 if 块自身后复测转红。

- `flutter analyze`（含 test）：**No issues found**。
- 定向 + 相邻：`test/reader` + `test/epub` + reader dispose guard → `FLUTTER TEST VERDICT: PASSED - 1501 tests ran, all tests passed`。
- `test/pages` 2397 条中 `home_video_remote_download_register_test.dart` 1 条在并发下红、**单跑绿**（真实 socket 族既有 flaky，与本改动路径无关）。

## 已知缺口

- 🔴 **Android 上有一处真实能力损失，必须披露**：③ 的守卫堵掉的那份误注入，此前**顺带**给 Android 的 spread 页提供过 `onSwipe` 滑动翻页与键盘桥（正文引擎自带）。守卫生效后它们一并消失 ⇒ **Android 用户在双页页面上会失去滑动翻页**，只能唤出底栏后用按钮 / 键盘 / 手柄。这不是「单纯修好一个 bug」，而是拿「双触发导致底栏彻底唤不出、退不出书」换「少一种翻页手势」——卡死是致命的、少一种手势是可降级的，所以这笔交易值得做，但**不淡化**。Windows 侧无此损失（那边从来没被注入过，本来就没有 spread 滑动翻页）。
- **TODO（跟进补回）**：给 spread 独立文档补它自己的 `onSwipe` + 键桥，与歌词 / VN 独立文档同款自带手势，而不是靠正文引擎误注入白捡。补回后两平台的 spread 手势契约才真正对齐（目前是「两平台一致地少了滑动翻页」）。
- ③ 的平台分叉是**静态证据链**（Dart 调用点 + 两侧原生实现 + 陈旧判据三处对齐），未在真机上观测过双触发。真机复测（书架 → 打开含整页图的书 → 显式设 `spreadMode=on` → 收起底栏 → 点 letterbox 留白）未做。

