### PR TITLE
fix(audio): pair image-chapter pause timer with its completer (TODO-2389 / TODO-2369 / TODO-2337)

### DIFF
--- a/hibiki/test/media/audiobook/image_chapter_pause_cancel_test.dart
+++ b/hibiki/test/media/audiobook/image_chapter_pause_cancel_test.dart
@@ -1,0 +1,549 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
+
+/// TODO-2389 / TODO-2369：`AudiobookPlayerController.awaitImageChapterPause`
+/// 的两个坑。
+///
+/// TODO-2389（用户可感）：停留用的 Completer 原本是局部变量，只由
+/// `_imagePauseTimer` 回调完成，而该定时器在 7 处被 cancel 却不 complete
+/// （triggerImagePause / 自身重入 / load / play / pause / stopPlayback /
+/// _teardownForDispose）。任一取消点命中 → `await done.future` 永久挂起 →
+/// reader `_pauseThroughImageOnlyChapters` 的 finally 永不执行 →
+/// `setImageChapterPauseActive(false)` 不执行 → 进程级 `_imageChapterPauseActive`
+/// 卡 true → `notifySectionRestoreCompleted` 永久早退 → cue 驱动的跨章推进直到
+/// 下次 load 新有声书前彻底失效。
+///
+/// TODO-2369：停留结束的恢复播放原本是 `await _activateMainPlayer()`，把
+/// 「停留结束」和「播放已重新建立」绑死。just_audio 的 `play()` Future 在寻常
+/// 路径上可以永远不完成（音频会话激活被拒时 playCompleter 从不 complete；
+/// `_sendPlayRequest` 在 playing 已翻回 false 时 defensive-return 丢掉
+/// completer），一旦挂住同样把 reader 的 finally 永久钉死。
+///
+/// harness 注意：mock `load` 必须返回 LoadResponse 并发 ready 事件，否则
+/// `_player.pause()` 会卡在平台激活上，测试被 harness 自身挂住而误判。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  /// 停留 1 秒；取消类用例在 200ms 处触发取消，随后必须在远小于剩余停留时长
+  /// 的窗口内返回。
+  const Duration pauseWindow = Duration(seconds: 1);
+  const Duration beforeCancel = Duration(milliseconds: 200);
+  const Duration settleAfterCancel = Duration(milliseconds: 400);
+
+  group('TODO-2389 awaitImageChapterPause 在每个取消点都必须返回', () {
+    test('对照组：无人取消 → 停留到点 → 恢复播放 → Future 完成', () async {
+      final _Harness h = await _Harness.create();
+      h.controller.imagePauseSec.value = 1;
+      h.platform.playCalls = 0;
+
+      bool done = false;
+      unawaited(h.controller.awaitImageChapterPause().then((_) => done = true));
+      await Future<void>.delayed(pauseWindow + settleAfterCancel);
+
+      expect(done, isTrue, reason: '对照组必须完成，证明取消用例断的不是死分支');
+      expect(h.platform.playCalls, greaterThan(0), reason: '停留结束应恢复播放');
+      h.controller.dispose();
+    });
+
+    test('取消点 pause()：用户在插图停留期按暂停', () async {
+      final _Harness h = await _Harness.create();
+      h.controller.imagePauseSec.value = 1;
+
+      bool done = false;
+      unawaited(h.controller.awaitImageChapterPause().then((_) => done = true));
+      await Future<void>.delayed(beforeCancel);
+      h.platform.playCalls = 0;
+      await h.controller.pause();
+      await Future<void>.delayed(settleAfterCancel);
+
+      expect(done, isTrue, reason: 'pause() 必须成对完成 Completer，await 不得挂起');
+      expect(h.platform.playCalls, 0,
+          reason: '失效续体绝不能把用户刚暂停的播放又恢复回去（先递增 epoch 再 complete）');
+      h.controller.dispose();
+    });
+
+    test('取消点 stopPlayback()：退出阅读器', () async {
+      final _Harness h = await _Harness.create();
+      h.controller.imagePauseSec.value = 1;
+
+      bool done = false;
+      unawaited(h.controller.awaitImageChapterPause().then((_) => done = true));
+      await Future<void>.delayed(beforeCancel);
+      h.platform.playCalls = 0;
+      unawaited(h.controller.stopPlayback().catchError((Object _) {}));
+      await Future<void>.delayed(settleAfterCancel);
+
+      expect(done, isTrue, reason: 'stopPlayback() 必须成对完成 Completer');
+      expect(h.platform.playCalls, 0, reason: '退出后不得恢复播放');
+      h.controller.dispose();
+    });
+
+    test('取消点 play()：用户在停留期按播放', () async {
+      final _Harness h = await _Harness.create();
+      h.controller.imagePauseSec.value = 1;
+
+      bool done = false;
+      unawaited(h.controller.awaitImageChapterPause().then((_) => done = true));
+      await Future<void>.delayed(beforeCancel);
+      await h.controller.play();
+      await Future<void>.delayed(settleAfterCancel);
+
+      expect(done, isTrue, reason: 'play() 必须成对完成 Completer');
+      h.controller.dispose();
+    });
+
+    test('取消点 load()：停留期换书', () async {
+      final _Harness h = await _Harness.create();
+      h.controller.imagePauseSec.value = 1;
+
+      bool done = false;
+      unawaited(h.controller.awaitImageChapterPause().then((_) => done = true));
+      await Future<void>.delayed(beforeCancel);
+      h.platform.playCalls = 0;
+      await h.controller.load(
+        audiobook: _audiobook(),
+        audioFiles: <File>[h.audioFile],
+      );
+      await Future<void>.delayed(settleAfterCancel);
+
+      expect(done, isTrue, reason: 'load() 必须成对完成 Completer');
+      expect(h.platform.playCalls, 0, reason: '换书后旧续体不得恢复播放');
+      h.controller.dispose();
+    });
+
+    test('取消点 dispose()：控制器销毁', () async {
+      final _Harness h = await _Harness.create();
+      h.controller.imagePauseSec.value = 1;
+
+      bool done = false;
+      unawaited(h.controller.awaitImageChapterPause().then((_) => done = true));
+      await Future<void>.delayed(beforeCancel);
+      h.platform.playCalls = 0;
+      h.controller.dispose();
+      await Future<void>.delayed(settleAfterCancel);
+
+      expect(done, isTrue, reason: 'dispose() 必须成对完成 Completer');
+      expect(h.platform.playCalls, 0,
+          reason: '销毁后续体不得恢复播放，也不得对已 dispose 的 notifier notify');
+    });
+
+    test('取消点 awaitImageChapterPause 自身重入：上一轮停留必须被放行', () async {
+      final _Harness h = await _Harness.create();
+      h.controller.imagePauseSec.value = 1;
+
+      bool firstDone = false;
+      bool secondDone = false;
+      unawaited(
+        h.controller.awaitImageChapterPause().then((_) => firstDone = true),
+      );
+      await Future<void>.delayed(beforeCancel);
+      unawaited(
+        h.controller.awaitImageChapterPause().then((_) => secondDone = true),
+      );
+      await Future<void>.delayed(settleAfterCancel);
+
+      expect(firstDone, isTrue, reason: '被重入顶掉的上一轮必须立刻返回，不得挂起');
+      expect(secondDone, isFalse, reason: '新一轮仍在停留中');
+      await Future<void>.delayed(pauseWindow);
+      expect(secondDone, isTrue, reason: '新一轮到点后正常完成');
+      h.controller.dispose();
+    });
+  });
+
+  group('TODO-2369 停留结束不得阻塞到播放停止', () {
+    test('平台 play 请求永不解析时，awaitImageChapterPause 仍准时返回', () async {
+      final _Harness h = await _Harness.create();
+      h.controller.imagePauseSec.value = 1;
+      // 模拟 just_audio `play()` Future 永不完成的那一类寻常路径（音频会话激活
+      // 被拒 / play 请求被 defensive-return 丢掉 completer）。
+      h.platform.hangPlay = true;
+      h.platform.playCalls = 0;
+
+      bool done = false;
+      final Stopwatch sw = Stopwatch()..start();
+      unawaited(h.controller.awaitImageChapterPause().then((_) {
+        done = true;
+        sw.stop();
+      }));
+      await Future<void>.delayed(pauseWindow + settleAfterCancel);
+
+      expect(done, isTrue, reason: '停留结束的契约是「这张插图看完了」，不能押在播放激活上');
+      expect(sw.elapsed, lessThan(pauseWindow + settleAfterCancel),
+          reason: '必须在停留窗口结束后立刻返回');
+      expect(h.platform.playCalls, greaterThan(0),
+          reason: '仍必须真的发起恢复播放（只是不 await）');
+      h.controller.dispose();
+    });
+
+    test('恢复播放仍走 _activateMainPlayer：stopPlayback 后的门必须挡住', () async {
+      final _Harness h = await _Harness.create();
+      await h.controller.stopPlayback().catchError((Object _) {});
+      h.platform.playCalls = 0;
+      await h.controller.play();
+      await Future<void>.delayed(settleAfterCancel);
+
+      expect(h.platform.playCalls, 0,
+          reason:
+              '_stopRequested 门只存在于 _activateMainPlayer，退回裸 _player.play() 会倒退掉它');
+      h.controller.dispose();
+    });
+  });
+
+  group('结构守卫：Timer 与 Completer 必须成对处理', () {
+    // 必须扫「去掉注释后的代码」：本文件断言的字面量（裸 cancel、_player.play）
+    // 恰好也出现在被测文件的说明性注释里，直接扫原文会把注释当成违规/合规证据，
+    // 两个方向的假绿假红都可能。
+    final String src = _stripDartComments(
+      File(
+        '../packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart',
+      ).readAsStringSync(),
+    );
+
+    test('全文只允许 _invalidateImageChapterPause 里那一处 cancel', () {
+      final int helperIdx =
+          src.indexOf('void _invalidateImageChapterPause() {');
+      expect(helperIdx, isNonNegative, reason: '成对作废的唯一入口必须存在');
+      final int helperEnd = src.indexOf('\n  }', helperIdx);
+      expect(helperEnd, greaterThan(helperIdx));
+
+      final RegExp cancelSite = RegExp(r'_imagePauseTimer[?!]?\.cancel\(\)');
+      final List<int> offsets = cancelSite
+          .allMatches(src)
+          .map((RegExpMatch m) => m.start)
+          .toList(growable: false);
+      expect(offsets, isNotEmpty);
+      for (final int offset in offsets) {
+        expect(
+          offset > helperIdx && offset < helperEnd,
+          isTrue,
+          reason: '裸 cancel（不 complete Completer）会让 awaitImageChapterPause '
+              '永久挂起；所有取消点必须走 _invalidateImageChapterPause / '
+              '_invalidateReaderTransition。越界位置 offset=$offset',
+        );
+      }
+    });
+
+    test('作废顺序必须是「先递增 epoch，再 complete」', () {
+      final int helperIdx =
+          src.indexOf('void _invalidateImageChapterPause() {');
+      final int helperEnd = src.indexOf('\n  }', helperIdx);
+      final String body = src.substring(helperIdx, helperEnd);
+      final int epochBump = body.indexOf('_imageChapterPauseEpoch++;');
+      final int complete = body.indexOf('pending.complete();');
+      expect(epochBump, isNonNegative);
+      expect(complete, greaterThan(epochBump),
+          reason: '顺序反了的话，被唤醒的旧续体会通过 epoch 校验并恢复播放/改状态');
+    });
+
+    test('awaitImageChapterPause 的恢复播放必须 unawaited 且走 _activateMainPlayer', () {
+      final int start =
+          src.indexOf('Future<void> awaitImageChapterPause() async {');
+      expect(start, isNonNegative);
+      final int end = src.indexOf('\n  void holdChapterTransition()', start);
+      expect(end, greaterThan(start));
+      final String body = src.substring(start, end);
+
+      expect(body.contains('unawaited(_activateMainPlayer());'), isTrue,
+          reason: 'await 会把 reader 跨章 finally 押在播放激活上（TODO-2369）');
+      expect(body.contains('await _activateMainPlayer()'), isFalse,
+          reason: '不得再出现阻塞形态');
+      expect(body.contains('_player.play('), isFalse,
+          reason:
+              '退回裸 _player.play() 会倒退掉 _stopRequested 门与 _playActivationTail 串行化');
+    });
+  });
+}
+
+/// 把 Dart 源码里的行注释 / 块注释替换成等长空白（保持偏移可读），字符串字面量
+/// 内的 `//` 不当注释。
+String _stripDartComments(String source) {
+  final StringBuffer out = StringBuffer();
+  int i = 0;
+  while (i < source.length) {
+    final String ch = source[i];
+    if (ch == '/' && i + 1 < source.length) {
+      final String next = source[i + 1];
+      if (next == '/') {
+        while (i < source.length && source[i] != '\n') {
+          out.write(' ');
+          i++;
+        }
+        continue;
+      }
+      if (next == '*') {
+        while (i < source.length &&
+            !(source[i] == '*' &&
+                i + 1 < source.length &&
+                source[i + 1] == '/')) {
+          out.write(source[i] == '\n' ? '\n' : ' ');
+          i++;
+        }
+        if (i < source.length) {
+          out.write('  ');
+          i += 2;
+        }
+        continue;
+      }
+    }
+    if (ch == "'" || ch == '"') {
+      final String quote = ch;
+      out.write(ch);
+      i++;
+      while (i < source.length) {
+        if (source[i] == r'\') {
+          out.write(source[i]);
+          if (i + 1 < source.length) out.write(source[i + 1]);
+          i += 2;
+          continue;
+        }
+        out.write(source[i]);
+        final bool closing = source[i] == quote;
+        final bool lineBreak = source[i] == '\n';
+        i++;
+        if (closing || lineBreak) break;
+      }
+      continue;
+    }
+    out.write(ch);
+    i++;
+  }
+  return out.toString();
+}
+
+class _Harness {
+  _Harness({
+    required this.controller,
+    required this.platform,
+    required this.audioFile,
+  });
+
+  final AudiobookPlayerController controller;
+  final _FakeAudioPlayerPlatform platform;
+  final File audioFile;
+
+  static Future<_Harness> create() async {
+    final _FakeJustAudioPlatform registry = _installFakeAudioPlatform();
+    final AudiobookPlayerController controller = AudiobookPlayerController();
+    final File audioFile = File(
+      '${Directory.systemTemp.path}/hibiki-image-chapter-pause-2389.mp3',
+    );
+    if (!audioFile.existsSync()) {
+      audioFile.writeAsBytesSync(const <int>[0]);
+    }
+    addTearDown(() {
+      if (audioFile.existsSync()) audioFile.deleteSync();
+    });
+    await controller.load(
+      audiobook: _audiobook(),
+      audioFiles: <File>[audioFile],
+    );
+    final List<AudioCue> cues = <AudioCue>[_sasayakiCue(0, section: 5)];
+    controller.setAllBookCues(cues);
+    controller.setChapterCues(cues);
+    controller.followAudio.value = true;
+    await controller.play();
+    return _Harness(
+      controller: controller,
+      platform: registry.player!,
+      audioFile: audioFile,
+    );
+  }
+}
+
+AudioCue _sasayakiCue(int startMs, {required int section}) {
+  return AudioCue()
+    ..id = null
+    ..bookKey = 'book'
+    ..chapterHref = 'chapter'
+    ..sentenceIndex = startMs ~/ 1000
+    ..textFragmentId = SasayakiMatchCodec.encodeHit(
+      sectionIndex: section,
+      normCharStart: 0,
+      normCharEnd: 10,
+    )
+    ..text = 'cue $startMs'
+    ..startMs = startMs
+    ..endMs = startMs + 1000
+    ..audioFileIndex = 0;
+}
+
+Audiobook _audiobook() {
+  return Audiobook()
+    ..bookKey = 'book'
+    ..audioPaths = const <String>[]
+    ..audioRoot = null
+    ..alignmentFormat = 'srt'
+    ..alignmentPath = '';
+}
+
+_FakeJustAudioPlatform _installFakeAudioPlatform() {
+  const MethodChannel audioSessionChannel =
+      MethodChannel('com.ryanheise.audio_session');
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(audioSessionChannel, (_) async => null);
+  addTearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(audioSessionChannel, null);
+  });
+
+  final JustAudioPlatform previousPlatform = JustAudioPlatform.instance;
+  final _FakeJustAudioPlatform platform = _FakeJustAudioPlatform();
+  JustAudioPlatform.instance = platform;
+  addTearDown(() {
+    JustAudioPlatform.instance = previousPlatform;
+  });
+  return platform;
+}
+
+class _FakeJustAudioPlatform extends JustAudioPlatform {
+  _FakeAudioPlayerPlatform? player;
+
+  @override
+  Future<AudioPlayerPlatform> init(InitRequest request) async {
+    player ??= _FakeAudioPlayerPlatform(request.id);
+    return player!;
+  }
+
+  @override
+  Future<DisposePlayerResponse> disposePlayer(
+    DisposePlayerRequest request,
+  ) async {
+    await player?.dispose(DisposeRequest());
+    return DisposePlayerResponse();
+  }
+
+  @override
+  Future<DisposeAllPlayersResponse> disposeAllPlayers(
+    DisposeAllPlayersRequest request,
+  ) async {
+    await player?.dispose(DisposeRequest());
+    return DisposeAllPlayersResponse();
+  }
+}
+
+class _FakeAudioPlayerPlatform extends AudioPlayerPlatform {
+  _FakeAudioPlayerPlatform(super.id);
+
+  final StreamController<PlaybackEventMessage> _events =
+      StreamController<PlaybackEventMessage>.broadcast();
+
+  int playCalls = 0;
+  int pauseCalls = 0;
+
+  /// 平台 play 请求永不解析，模拟 just_audio 里 playCompleter 从不 complete 的
+  /// 那一类路径（TODO-2369）。
+  bool hangPlay = false;
+
+  @override
+  Stream<PlaybackEventMessage> get playbackEventMessageStream => _events.stream;
+
+  @override
+  Future<LoadResponse> load(LoadRequest request) async {
+    if (!_events.isClosed) {
+      _events.add(PlaybackEventMessage(
+        processingState: ProcessingStateMessage.ready,
+        updateTime: DateTime.now(),
+        updatePosition: Duration.zero,
+        bufferedPosition: Duration.zero,
+        duration: const Duration(seconds: 30),
+        icyMetadata: null,
+        currentIndex: 0,
+        androidAudioSessionId: null,
+      ));
+    }
+    return LoadResponse(duration: const Duration(seconds: 30));
+  }
+
+  @override
+  Future<PauseResponse> pause(PauseRequest request) async {
+    pauseCalls++;
+    return PauseResponse();
+  }
+
+  @override
+  Future<PlayResponse> play(PlayRequest request) {
+    playCalls++;
+    if (hangPlay) return Completer<PlayResponse>().future;
+    return Future<PlayResponse>.value(PlayResponse());
+  }
+
+  @override
+  Future<SeekResponse> seek(SeekRequest request) async => SeekResponse();
+
+  @override
+  Future<SetAndroidAudioAttributesResponse> setAndroidAudioAttributes(
+    SetAndroidAudioAttributesRequest request,
+  ) async =>
+      SetAndroidAudioAttributesResponse();
+
+  @override
+  Future<SetAutomaticallyWaitsToMinimizeStallingResponse>
+      setAutomaticallyWaitsToMinimizeStalling(
+    SetAutomaticallyWaitsToMinimizeStallingRequest request,
+  ) async =>
+          SetAutomaticallyWaitsToMinimizeStallingResponse();
+
+  @override
+  Future<SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse>
+      setCanUseNetworkResourcesForLiveStreamingWhilePaused(
+    SetCanUseNetworkResourcesForLiveStreamingWhilePausedRequest request,
+  ) async =>
+          SetCanUseNetworkResourcesForLiveStreamingWhilePausedResponse();
+
+  @override
+  Future<SetLoopModeResponse> setLoopMode(SetLoopModeRequest request) async =>
+      SetLoopModeResponse();
+
+  @override
+  Future<SetPitchResponse> setPitch(SetPitchRequest request) async =>
+      SetPitchResponse();
+
+  @override
+  Future<SetPreferredPeakBitRateResponse> setPreferredPeakBitRate(
+    SetPreferredPeakBitRateRequest request,
+  ) async =>
+      SetPreferredPeakBitRateResponse();
+
+  @override
+  Future<SetShuffleModeResponse> setShuffleMode(
+    SetShuffleModeRequest request,
+  ) async =>
+      SetShuffleModeResponse();
+
+  @override
+  Future<SetShuffleOrderResponse> setShuffleOrder(
+    SetShuffleOrderRequest request,
+  ) async =>
+      SetShuffleOrderResponse();
+
+  @override
+  Future<SetSkipSilenceResponse> setSkipSilence(
+    SetSkipSilenceRequest request,
+  ) async =>
+      SetSkipSilenceResponse();
+
+  @override
+  Future<SetSpeedResponse> setSpeed(SetSpeedRequest request) async =>
+      SetSpeedResponse();
+
+  @override
+  Future<SetVolumeResponse> setVolume(SetVolumeRequest request) async =>
+      SetVolumeResponse();
+
+  @override
+  Future<SetWebCrossOriginResponse> setWebCrossOrigin(
+    SetWebCrossOriginRequest request,
+  ) async =>
+      SetWebCrossOriginResponse();
+
+  @override
+  Future<DisposeResponse> dispose(DisposeRequest request) async {
+    if (!_events.isClosed) await _events.close();
+    return DisposeResponse();
+  }
+}

--- a/hibiki/test/media/audiobook/image_chapter_pause_cancel_test.dart
+++ b/hibiki/test/media/audiobook/image_chapter_pause_cancel_test.dart
@@ -236,8 +236,12 @@ void main() {
       final int epochBump = body.indexOf('_imageChapterPauseEpoch++;');
       final int complete = body.indexOf('pending.complete();');
       expect(epochBump, isNonNegative);
+      // 形态不变量（非当前行为差异）：`Completer.complete()` 走微任务，续体总在
+      // 本同步块之后才跑，所以今天两种顺序行为相同。锁住它是为了防未来把
+      // Completer 换成 `Completer.sync()` / 在两句之间插入 await——那时顺序立刻
+      // 变成 load-bearing：旧续体会通过 epoch 校验并把用户刚暂停的播放恢复回去。
       expect(complete, greaterThan(epochBump),
-          reason: '顺序反了的话，被唤醒的旧续体会通过 epoch 校验并恢复播放/改状态');
+          reason: '作废必须先递增 epoch 再 complete，否则同步唤醒的旧续体会通过 epoch 校验');
     });
 
     test('awaitImageChapterPause 的恢复播放必须 unawaited 且走 _activateMainPlayer', () {

--- a/hibiki/test/pages/reader_navigation_dispose_guard_test.dart
+++ b/hibiki/test/pages/reader_navigation_dispose_guard_test.dart
@@ -21,6 +21,30 @@ void main() {
     return source.substring(startIndex, endIndex);
   }
 
+  /// TODO-2337：断言**早退语义**而不是「字面量按顺序都在」。
+  ///
+  /// 旧版三个断言只用 `indexOf` 检查四个字面量存在且有序——把守卫体里的
+  /// `return;` 单独删掉（保留 if 体与 `cancelChapterTransition()`，即 dispose 后
+  /// 照样往下走进 `_navigateToChapter`，正是原缺陷的完整复现）时守卫仍然全绿。
+  /// 这里改成花括号配对切出守卫块本体，断言块内确实早退、且被守卫的动作**不在**
+  /// 块内继续发生。
+  String guardBlockBody(String body, String guardHead) {
+    final int headIndex = body.indexOf(guardHead);
+    expect(headIndex, isNonNegative, reason: '找不到生命周期守卫：$guardHead');
+    final int open = body.indexOf('{', headIndex + guardHead.length - 1);
+    expect(open, isNonNegative, reason: '守卫必须是带花括号的块：$guardHead');
+    int depth = 0;
+    for (int i = open; i < body.length; i++) {
+      final String ch = body[i];
+      if (ch == '{') depth++;
+      if (ch == '}') {
+        depth--;
+        if (depth == 0) return body.substring(open + 1, i);
+      }
+    }
+    fail('守卫块花括号未闭合：$guardHead');
+  }
+
   test('_rebuild 在统一 setState 转发边界拒绝已销毁 State', () {
     final String body = bodyBetween(
       readerPage,
@@ -52,6 +76,19 @@ void main() {
       beginNavigation,
       greaterThan(mountedGuard),
       reason: '所有导航入口都必须先验证 State 仍 mounted，再初始化导航代际并重绘',
+    );
+
+    // TODO-2337：守卫必须真的早退，而不是只把条件写出来。
+    final String guardBody = guardBlockBody(body, 'if (!mounted ||');
+    expect(
+      guardBody.contains('return;'),
+      isTrue,
+      reason: '已销毁 State 命中守卫后必须 return，否则照样跑到 _beginNavigation/setState',
+    );
+    expect(
+      guardBody.contains('_beginNavigation('),
+      isFalse,
+      reason: '守卫块内不得继续初始化导航代际',
     );
   });
 
@@ -85,6 +122,24 @@ void main() {
       finalNavigation,
       greaterThan(cancelTransition),
       reason: '最终跨章导航只能发生在 await 后的生命周期复检与清理分支之后',
+    );
+
+    // TODO-2337：这才是缺陷本身——dispose 后必须**早退**，而不是清完 transition
+    // 继续往下走进 _navigateToChapter/setState。只删守卫块里的 `return;`（旧版
+    // 守卫对此全绿）在这里必须转红。
+    final String guardBody = guardBlockBody(
+      body.substring(pauseAwait),
+      'if (!mounted || _controller == null)',
+    );
+    expect(
+      guardBody.contains('return;'),
+      isTrue,
+      reason: 'dispose 后不得继续执行——守卫块必须 return，否则仍会进入 _navigateToChapter',
+    );
+    expect(
+      guardBody.contains('_navigateToChapter('),
+      isFalse,
+      reason: '守卫块内不得再发起导航',
     );
   });
 }

--- a/packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart
+++ b/packages/hibiki_audio/lib/src/audiobook/audiobook_controller.dart
@@ -340,8 +340,67 @@ class AudiobookPlayerController extends ChangeNotifier {
 
   Timer? _imagePauseTimer;
 
+  /// TODO-2389：[awaitImageChapterPause] 的在途 Completer。它必须是控制器字段而
+  /// 不是局部变量——否则唯一能完成它的只有 [_imagePauseTimer] 回调，而该定时器在
+  /// 全文 7 处被 cancel（[triggerImagePause] / [awaitImageChapterPause] 自身重入 /
+  /// [load] / [play] / [pause] / [stopPlayback] / [_teardownForDispose]），每一处
+  /// 都会让 `await done.future` 永久挂起 → reader 的
+  /// `_pauseThroughImageOnlyChapters` 的 finally 永不执行 →
+  /// `setImageChapterPauseActive(false)` 不执行 → 进程级 `_imageChapterPauseActive`
+  /// 卡 true → [notifySectionRestoreCompleted] 永久早退 → cue 驱动的跨章推进直到
+  /// 下次 [load] 新有声书前彻底失效。
+  Completer<void>? _imageChapterPauseCompleter;
+
+  /// TODO-2389：双 epoch。reader 级（换书/停止/销毁）与单次图片章停留级各一个。
+  /// 作废一轮停留时**先递增 epoch 再 complete**，被唤醒的旧续体只能收尾返回，
+  /// 不得恢复播放或改状态（否则「取消」变成「立刻恢复播放」）。
+  int _readerTransitionEpoch = 0;
+  int _imageChapterPauseEpoch = 0;
+
   /// 当前是否处于图片暂停等待中。
-  bool get isImagePaused => _imagePauseTimer?.isActive ?? false;
+  ///
+  /// 跨章停留（[awaitImageChapterPause]）在「已 pause、定时器尚未武装」的窗口里
+  /// 没有 Timer，只有 Completer，也必须算作等待中。
+  bool get isImagePaused =>
+      (_imagePauseTimer?.isActive ?? false) ||
+      _imageChapterPauseCompleter != null;
+
+  bool _ownsImageChapterPause({
+    required int readerTransitionEpoch,
+    required int imageChapterPauseEpoch,
+  }) {
+    return readerTransitionEpoch == _readerTransitionEpoch &&
+        imageChapterPauseEpoch == _imageChapterPauseEpoch;
+  }
+
+  /// 结束当前 await-based 图片章停留，但绝不由失效 continuation 恢复播放。
+  ///
+  /// Timer 与 Completer 必须成对处理：只 cancel Timer 会让
+  /// [awaitImageChapterPause] 永久挂起；只 complete Completer 又会让旧 await 续体
+  /// 继续跑到恢复播放。先递增 epoch，再 complete，使续体只能收尾返回。
+  ///
+  /// **所有** cancel [_imagePauseTimer] 的位置都必须走本方法（或
+  /// [_invalidateReaderTransition]），不得再出现裸 `_imagePauseTimer?.cancel()`；
+  /// 守卫见 `test/media/audiobook/image_chapter_pause_cancel_test.dart`。
+  void _invalidateImageChapterPause() {
+    _imageChapterPauseEpoch++;
+    _imagePauseTimer?.cancel();
+    _imagePauseTimer = null;
+    final Completer<void>? pending = _imageChapterPauseCompleter;
+    _imageChapterPauseCompleter = null;
+    if (pending != null && !pending.isCompleted) {
+      pending.complete();
+    }
+  }
+
+  /// reader 级作废：换书 / 停止播放 / 销毁控制器。控制器是进程级会话对象，
+  /// 可被相邻两个 reader State 复用，此处递增 reader epoch 让上一个 owner 的
+  /// 在途停留续体彻底失效。
+  void _invalidateReaderTransition() {
+    _readerTransitionEpoch++;
+    _invalidateImageChapterPause();
+    _readerMovedDuringImagePause = false;
+  }
 
   /// BUG-890：图片等待（自动暂停）窗口内用户是否手动翻页离开了插图那句。
   /// 图片等待到点自动恢复播放时，若为真则**不**强制把 reader 拽回音频位
@@ -372,7 +431,8 @@ class AudiobookPlayerController extends ChangeNotifier {
   void triggerImagePause() {
     final int sec = imagePauseSec.value;
     if (sec <= 0 || !_player.playing) return;
-    _imagePauseTimer?.cancel();
+    // TODO-2389：成对作废（cancel Timer + complete 在途 Completer）。
+    _invalidateImageChapterPause();
     // BUG-890：新一轮图片等待开始，复位“窗口内是否手动翻页”标志。
     _readerMovedDuringImagePause = false;
     unawaited(_player.pause());
@@ -419,24 +479,71 @@ class AudiobookPlayerController extends ChangeNotifier {
   /// 本方法主动 `pause()`→等待→`play()`，不照搬那条「非播放即早退」守卫（它防的是
   /// 用户已手动暂停时不该再被图片暂停二次接管，与本路径语义不同）。仍受
   /// `imagePauseSec > 0` 门控：等于 0（图片等待关）时直接返回，调用方按原跨章直跳。
+  ///
+  /// TODO-2389（挂起根因）：本方法必须在**任何**取消点都能返回，否则 reader 的
+  /// `_pauseThroughImageOnlyChapters` 的 finally 永不执行，跨章推进永久失效。
+  /// 在途状态记在 [_imageChapterPauseCompleter] + 双 epoch 上，取消点统一走
+  /// [_invalidateImageChapterPause] / [_invalidateReaderTransition]。
+  ///
+  /// TODO-2369（不得阻塞到播放停止）：末尾恢复播放用 `unawaited`，见那里的注释。
   Future<void> awaitImageChapterPause() async {
     final int sec = imagePauseSec.value;
     if (sec <= 0) return;
-    _imagePauseTimer?.cancel();
+    // 自身重入：上一轮停留成对作废，本轮拿新 epoch。
+    _invalidateImageChapterPause();
+    final int readerTransitionEpoch = _readerTransitionEpoch;
+    final int imageChapterPauseEpoch = _imageChapterPauseEpoch;
+    final Completer<void> done = Completer<void>();
+    _imageChapterPauseCompleter = done;
+
     if (_player.playing) {
-      await _player.pause();
+      // `_player.pause()` 要等平台确认；本轮若在这段窗口里被作废（用户按暂停 /
+      // 退出阅读器 / 换书），done 已被完成，这里不再干等平台。
+      await Future.any<void>(<Future<void>>[
+        _player.pause(),
+        done.future,
+      ]);
+    }
+    if (!_ownsImageChapterPause(
+      readerTransitionEpoch: readerTransitionEpoch,
+      imageChapterPauseEpoch: imageChapterPauseEpoch,
+    )) {
+      return;
     }
     notifyListeners();
-    final Completer<void> done = Completer<void>();
     _imagePauseTimer = Timer(Duration(seconds: sec), () {
+      if (!_ownsImageChapterPause(
+        readerTransitionEpoch: readerTransitionEpoch,
+        imageChapterPauseEpoch: imageChapterPauseEpoch,
+      )) {
+        return;
+      }
       _imagePauseTimer = null;
+      if (identical(_imageChapterPauseCompleter, done)) {
+        _imageChapterPauseCompleter = null;
+      }
       if (!done.isCompleted) done.complete();
     });
     await done.future;
+    if (!_ownsImageChapterPause(
+      readerTransitionEpoch: readerTransitionEpoch,
+      imageChapterPauseEpoch: imageChapterPauseEpoch,
+    )) {
+      return;
+    }
     // 停留结束恢复播放，让 cue 推进继续把文字带到下一章。reader 侧在跨章序列收尾
     // 时统一 notify / reanchor，这里只负责恢复播放时钟。
     if (!_player.playing) {
-      await _activateMainPlayer();
+      // TODO-2369：不能 await。本方法的契约是「这一张整章插图停留结束」，不是
+      // 「播放已重新建立」；把二者绑在一起就把 reader 的跨章 finally 押在了播放
+      // 激活上。just_audio 的 `play()` Future 在若干寻常路径上**永远不会完成**：
+      // 音频会话激活被拒（来电/音频焦点被抢）时走 else 分支，playCompleter 从不
+      // complete 而末尾仍 `await playCompleter.future`；`_sendPlayRequest` 也会在
+      // `playing` 已翻回 false 时 defensive-return 丢掉 completer。一旦挂住，
+      // `setImageChapterPauseActive(false)` 永不执行，跨章推进永久失效。
+      // 仍然走 [_activateMainPlayer]（不得退回裸 `_player.play()`），保留
+      // `_stopRequested` 门与 `_playActivationTail` 串行化（BUG-1240）。
+      unawaited(_activateMainPlayer());
     }
     notifyListeners();
   }
@@ -556,11 +663,11 @@ class AudiobookPlayerController extends ChangeNotifier {
     followAudio.value = initialFollowAudio;
     delayMs.value = initialDelayMs;
     imagePauseSec.value = initialImagePauseSec;
-    _imagePauseTimer?.cancel();
-    _imagePauseTimer = null;
+    // TODO-2389：换书是 reader 级作废——成对处理 Timer/Completer 并让上一本书的
+    // 在途停留续体彻底失效（顺带复位 _readerMovedDuringImagePause）。
+    _invalidateReaderTransition();
     _hasPlayedOnce = false;
     _forceNextReveal = false;
-    _readerMovedDuringImagePause = false;
     _chapterTransition = false;
     _imageChapterPauseActive = false;
 
@@ -784,9 +891,10 @@ class AudiobookPlayerController extends ChangeNotifier {
     // 用户在图片自动暂停窗口内手动播放：取消待恢复计时器并把视口从插图拉回当前
     // cue（否则计时器到点见已在播放而跳过 snap，视口卡在插图上直到下次 cue 推进）。
     // 手动按播放是显式“继续听书”手势，仍 snap；只复位 BUG-890 的窗口内翻页标志。
-    if (_imagePauseTimer != null) {
-      _imagePauseTimer!.cancel();
-      _imagePauseTimer = null;
+    // TODO-2389：跨章停留在「已 pause、定时器未武装」的窗口里只有 Completer 没有
+    // Timer，用 isImagePaused 覆盖两种在途形态，并成对作废。
+    if (isImagePaused) {
+      _invalidateImageChapterPause();
       _readerMovedDuringImagePause = false;
       snapReaderToAudio();
     }
@@ -807,8 +915,9 @@ class AudiobookPlayerController extends ChangeNotifier {
   }
 
   Future<void> pause() async {
-    _imagePauseTimer?.cancel();
-    _imagePauseTimer = null;
+    // TODO-2389：用户在插图停留期按暂停——成对作废，让 awaitImageChapterPause
+    // 的 await 立刻返回（且续体因 epoch 不匹配不会把播放又恢复回去）。
+    _invalidateImageChapterPause();
     _readerMovedDuringImagePause = false;
     _resumeMainAfterClip = false;
     await _player.pause();
@@ -1608,8 +1717,9 @@ class AudiobookPlayerController extends ChangeNotifier {
   }
 
   Future<void> _stopPlaybackOnce() async {
-    _imagePauseTimer?.cancel();
-    _imagePauseTimer = null;
+    // TODO-2389：退出阅读器是 reader 级作废（`_stopRequested` 已同步立起，续体
+    // 即便被唤醒也不得恢复播放）。
+    _invalidateReaderTransition();
     _resumeMainAfterClip = false;
     final AudioPlayer? clip = _clipPlayer;
 
@@ -1726,7 +1836,9 @@ class AudiobookPlayerController extends ChangeNotifier {
     if (!_stopRequested) {
       _maybeSavePosition(force: true);
     }
-    _imagePauseTimer?.cancel();
+    // TODO-2389：销毁是 reader 级作废；只 cancel Timer 会让在途
+    // awaitImageChapterPause 永久挂起（且它的续体绝不能在 dispose 后 notify）。
+    _invalidateReaderTransition();
     _positionSub?.cancel();
     _playingSub?.cancel();
     _noisySub?.cancel();

--- a/packages/hibiki_audio/test/audiobook/image_pause_resume_reveal_test.dart
+++ b/packages/hibiki_audio/test/audiobook/image_pause_resume_reveal_test.dart
@@ -25,8 +25,14 @@ void main() {
     expect(idx, greaterThan(-1), reason: 'play() 必须存在');
     final int end = src.indexOf('Future<void> pause()', idx);
     final String body = src.substring(idx, end > idx ? end : idx + 600);
-    expect(body, contains('_imagePauseTimer'),
-        reason: '手动 play 须取消待恢复的图片暂停计时器（否则计时器到点不 snap）');
+    // TODO-2389：判据从「碰过 _imagePauseTimer」升级为「成对作废」。只 cancel
+    // Timer 不 complete Completer 会让 awaitImageChapterPause 永久挂起，所以取消
+    // 动作统一收敛到 _invalidateImageChapterPause()。
+    expect(body, contains('_invalidateImageChapterPause()'),
+        reason: '手动 play 须成对作废待恢复的图片暂停（Timer + Completer），'
+            '否则计时器到点不 snap，且跨章停留的 await 永久挂起');
+    expect(body, contains('isImagePaused'),
+        reason: '在途判据须覆盖「已 pause、定时器尚未武装」的 Completer-only 窗口');
     expect(body, contains('snapReaderToAudio'),
         reason: '手动 play 须把视口从插图拉回当前 cue');
   });


### PR DESCRIPTION
## 根因

`AudiobookPlayerController.awaitImageChapterPause` 的两个坑（同一函数，必须一起改）。

### TODO-2389（用户可感）：`done` Completer 永不完成

停留用的 Completer 是**局部变量**，只由 `_imagePauseTimer` 回调完成；而该定时器在 **7 处被 cancel 却不 complete**。任一取消点命中：

`await done.future` 永久挂起 → reader `_pauseThroughImageOnlyChapters` 的 `finally` 永不执行 → `setImageChapterPauseActive(false)` 不执行 → 进程级 `_imageChapterPauseActive` 卡 `true` → `notifySectionRestoreCompleted` 永久早退 → **cue 驱动的跨章推进直到下次 load 新有声书前彻底失效**。

触发条件：图片章停留的 `imagePauseSec` 秒内，用户按播放 / 按暂停 / 退出阅读器 / 换书。

修法：Completer 提升为控制器字段，7 处取消点统一走 `_invalidateImageChapterPause()` / `_invalidateReaderTransition()`，采用 **epoch 语义——先递增 epoch 再 complete**，被唤醒的旧续体只能收尾返回，不得恢复播放或改状态（否则「用户按暂停」变成「立刻又播起来」）。`isImagePaused` 同时覆盖「已 pause、定时器尚未武装」的 Completer-only 窗口。

| # | 位置 | 原 | 现 |
|---|---|---|---|
| 1 | `triggerImagePause` | 裸 cancel | `_invalidateImageChapterPause()` |
| 2 | `awaitImageChapterPause` 自身重入 | 裸 cancel | `_invalidateImageChapterPause()` |
| 3 | `load` | 裸 cancel + 置 null | `_invalidateReaderTransition()` |
| 4 | `play` | `if (_imagePauseTimer != null)` + 裸 cancel | `if (isImagePaused)` + `_invalidateImageChapterPause()` |
| 5 | `pause` | 裸 cancel + 置 null | `_invalidateImageChapterPause()` |
| 6 | `_stopPlaybackOnce` | 裸 cancel + 置 null | `_invalidateReaderTransition()` |
| 7 | `_teardownForDispose` | 裸 cancel | `_invalidateReaderTransition()` |

全文现在只剩 `_invalidateImageChapterPause()` 内那一处 `cancel()`，由结构守卫锁死。

### TODO-2369：恢复播放不得阻塞

原来是 `await _activateMainPlayer()`，把「这张插图停留结束」和「播放已重新建立」绑死。

⚠️ **对立项前提的更正**：立项说的机制是「just_audio 的 `play()` Future 要到暂停或播放结束才完成」。查 **just_audio 0.9.42**（本仓 lock 版本）源码，这是**不准确的**——`playCompleter` 由 `_sendPlayRequest` 在平台接受 play 请求时就完成。真正的危险是另一类：`play()` 的 Future 在若干寻常路径上**根本不会完成**——音频会话激活被拒（来电 / 音频焦点被抢）时走 `else` 分支，`playCompleter` 从不 complete 而末尾仍 `await playCompleter.future`；`_sendPlayRequest` 也会在 `playing` 已翻回 false 时 defensive-return 丢掉 completer。一旦挂住，后果与 TODO-2389 完全一样（reader 的 `finally` 永久钉死）。**结论：坑是真的，修法不变，理由要改。**

改为 `unawaited(_activateMainPlayer())`——**仍走 activation 通道**，保留 `_stopRequested` 门与 `_playActivationTail` 串行化（BUG-1240），不退回裸 `_player.play()`。

**`play()` 里 793 处的判定**：同属「`play()` Future 可能不完成」这一类，但**不同病**——`play()` 是公共播放 API，其 Future 是调用方（`togglePlayPause` / 测试）排序后续动作的唯一手段，且它身后没有被 `finally` 押住的跨章状态。改它是公共语义变更，超出本 PR 爆炸半径，**不动**；`awaitImageChapterPause` 已不再依赖它。

### TODO-2337：dispose 守卫是摆设

`reader_navigation_dispose_guard_test.dart` 只按 `indexOf` 顺序断言四个字面量存在，**从不断言早退语义**：只删 `return;`（保留 if 体与 `cancelChapterTransition()`，即原缺陷完整复现）守卫仍 PASSED / 退出码 0。

改为花括号配对切出守卫块本体，断言**块内必须 `return;`、块内不得再导航**（`_handleCueCrossChapter` 与 `_navigateToChapter` 两处一起改）。

## 证据

**修前红**（把 controller 单独 checkout 回 `b51ec56a3` 跑新测试）：
`FLUTTER TEST VERDICT: FAILED ... (tests completed: 12, flutter exit code: 1)`，退出码 1。6 个可达取消点（pause / stopPlayback / play / load / dispose / 自身重入）全红 + TODO-2369 全红；**对照组「无人取消 → 停留到点 → 恢复播放 → Future 完成」与「`_stopRequested` 门」两条绿**，证明断的不是死分支。

**修后绿**：`FLUTTER TEST VERDICT: PASSED - 15 tests ran`，退出码 0。

**变异实测**（每条都真跑，反向替换还原）：

| 变异 | 结果 | 退出码 |
|---|---|---|
| 守卫「只删 `return;`」（旧守卫此处假绿） | FAILED，`有声书跨图片章 await 返回后复检生命周期并释放 transition` 转红 | 1 |
| 单点回退：`pause()` 改回裸 cancel | FAILED，行为测试 + 结构守卫双双转红 | 1 |
| 作废顺序调换（epoch 后置） | FAILED，顺序守卫转红 | 1 |

> 顺序守卫是**形态不变量**：`Completer.complete()` 走微任务，今天两种顺序行为相同；锁它是防未来换成 `Completer.sync()` 或中间插 `await`。已在测试里注明，不冒充行为证据。

写守卫时踩到并修掉的自坑：断言字面量恰好出现在被测文件的说明性注释里 → 扫描前先 `_stripDartComments`。

**回归**：
- `flutter analyze`（hibiki，含 test）`No issues found!`；`packages/hibiki_audio` `No issues found!`
- `test/media/audiobook` + reader 相邻守卫：`PASSED - 874 tests ran`，退出码 0
- `packages/hibiki_audio/test`：`PASSED - 72 tests ran`，退出码 0

**契约变更（非回归）**：`image_pause_resume_reveal_test` 原来断言 `play()` 体内出现字面量 `_imagePauseTimer`。取消动作收敛到 `_invalidateImageChapterPause()` 后该字面量消失，判据已升级为「成对作废 + `isImagePaused` 覆盖 Completer-only 窗口」，语义更强。

## 未做

- 未动 `hibiki/pubspec.yaml` 的 `+build`（由 integration owner 合并前统一领）。
- 未动 BUG 号。
- 未做真机 / 长编译验证。
