### PR TITLE
fix(ui): 销毁确认弹窗勾选文案换行显示完整（BUG-1289）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1231 条。点号进各自文件。
+> 共 1232 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1289](bugs/BUG-1289-destructive-confirm-checkbox-truncated.md) | ✅ | ✅ | 销毁确认弹窗勾选行文案被单行省略号截断 |
 | [BUG-1288](bugs/BUG-1288-android-video-resume-seek-overwritten.md) | ✅ | ✅ | 安卓视频进入后被踢回开头：恢复 seek 被 loadfile 覆盖 |
 | [BUG-1287](bugs/BUG-1287-gal-loopback-flush-no-settle.md) | ✅ | ✅ | galgame 查词/制卡时语音只到句子前半段：loopback 提前收束后不再补全 |
 | [BUG-1286](bugs/BUG-1286-gal-lookup-hook-revoked.md) | ✅ | ✅ | galgame 查词浮窗点击失效：低级鼠标钩子被系统吊销后不再重装 |

--- a/docs/bugs/BUG-1289-destructive-confirm-checkbox-truncated.md
+++ b/docs/bugs/BUG-1289-destructive-confirm-checkbox-truncated.md
@@ -1,0 +1,48 @@
+## BUG-1289 · 销毁确认弹窗勾选行文案被单行省略号截断
+
+- **报告**：2026-07-31（用户：截图「删除合集」弹窗，勾选行显示为「同时删除其中的视频（保留你的原始视…」）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/utils/components/hibiki_destructive_confirm_dialog.dart:90`（勾选行）
+  + `hibiki/lib/src/utils/components/hibiki_material_components.dart:153,245`（`HibikiListItem.titleMaxLines` 默认 1 + `TextOverflow.ellipsis`）
+
+### 根因
+
+`HibikiDestructiveConfirmDialog` 的可选勾选行直接把整句解释文案塞进 `HibikiListItem.title`。
+`HibikiListItem` 是为**列表标题短语**设计的：`titleMaxLines` 默认 1，且外层
+`DefaultTextStyle.merge(maxLines: 1, overflow: TextOverflow.ellipsis)` 强制单行省略。
+
+对话框 `maxWidth: 420`，扣掉 body 内边距与 Checkbox 宽度后，可用文本宽度装不下
+「同时删除其中的视频（保留你的原始视频文件）」，于是括号里的免责说明——恰好是用户
+最需要看清的那半句（「原始视频文件不会被删」）——被整段吃掉，只剩「…保留你的原始视…」。
+
+同一弹窗的正文 `message` 是裸 `Text`，没有行数限制，所以只有勾选行被截断，视觉上像是
+「这一行本来就该这么短」，不易察觉是截断。
+
+`titleMaxLines` 的默认值 1 是 BUG-1184 有意保留的（部分调用点把列表项放在固定高度容器
+里，换行会撑破父容器），其注释明确要求「放宽必须逐调用点显式进行」。因此根治点在调用方，
+而不是改默认值。本调用点的父容器高度自由：外层 `HibikiDialogFrame.scrollable` 默认 true
+（`hibiki_material_components.dart:1184,1230`），整个 sheet 被 `SingleChildScrollView` 包裹，
+放开行数不会 overflow。
+
+**影响范围**：所有传 `checkboxLabel` 的销毁确认路径，共 5 处调用，全部是同类整句文案——
+- `home_video_page.dart:3363` / `reader_hibiki_history_page.dart:1699`（两个库页的合集长按菜单，经 `collection_context_dialog.dart:210`）
+- `media_collection_detail_page.dart:257`（视频合集详情页）
+- `media_collection_grid_detail_page.dart:148`（书籍合集详情页）
+- `collection_detail_shared.dart:124`（详情页共享删除流程）
+
+### 修复
+
+- **[x] ① 已修复** — `hibiki/lib/src/utils/components/hibiki_destructive_confirm_dialog.dart`
+  勾选行显式传 `titleMaxLines: 3`，文案改为换行显示完整。一处修复覆盖上列全部 5 条路径。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/widgets/hibiki_destructive_confirm_dialog_test.dart`
+  新增用例「BUG-1289 长勾选文案换行显示完整，不被省略号截断」，widget 行为层双断言：
+  1. `RenderParagraph.didExceedMaxLines == false`（文案没被省略号截断）；
+  2. 长文案渲染高度 > 短文案高度（证明该宽度下**确实发生了换行**，堵死「哪天对话框变宽
+     到一行装得下，maxLines 退回 1 也照样绿」的假绿）。
+
+  **变异实测**：把 `titleMaxLines: 3` 改回 `1` 重跑，用例在断言 ① 处失败（`+3 -1`）；
+  还原后 4/4 绿。守卫有效。
+
+### 备注
+
+不改 `HibikiListItem.titleMaxLines` 默认值——那正是 BUG-1184 回退过的动作。

--- a/hibiki/lib/src/utils/components/hibiki_destructive_confirm_dialog.dart
+++ b/hibiki/lib/src/utils/components/hibiki_destructive_confirm_dialog.dart
@@ -90,6 +90,14 @@ class _HibikiDestructiveConfirmDialogState
               HibikiListItem(
                 density: HibikiListDensity.compact,
                 padding: EdgeInsets.zero,
+                // BUG-1289：勾选文案是整句解释（「同时删除其中的视频（保留你的
+                // 原始视频文件）」），不是列表里的标题短语。[HibikiListItem] 的
+                // titleMaxLines 默认 1 + ellipsis，在 420 宽的对话框里会把括号
+                // 里的免责说明整段吃掉，用户读到的是「…保留你的原始视…」——恰好
+                // 是最需要看清的那半句。此处父容器高度自由（外层
+                // [HibikiDialogFrame] 默认 scrollable），放开行数不会像
+                // BUG-1184 的固定高容器那样撑破布局。
+                titleMaxLines: 3,
                 title: Text(widget.checkboxLabel!),
                 // 勾选状态由整行 onTap 驱动；Checkbox 本身既不接指针也不进
                 // 焦点遍历（单站点契约，行即唯一停靠点）。

--- a/hibiki/test/widgets/hibiki_destructive_confirm_dialog_test.dart
+++ b/hibiki/test/widgets/hibiki_destructive_confirm_dialog_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/utils/components/hibiki_destructive_confirm_dialog.dart';
 
@@ -64,5 +65,42 @@ void main() {
     await tester.tap(find.text('DELETE'));
     await tester.pumpAndSettle();
     expect((await dialogResult)!.checked, isTrue);
+  });
+
+  // BUG-1289：勾选文案是整句解释而非标题短语，被 [HibikiListItem] 默认的
+  // titleMaxLines: 1 + ellipsis 切成「…保留你的原始视…」，括号里的免责说明
+  // （最需要看清的那半句）整段看不到。
+  //
+  // 断言分两半，缺一不可：
+  // ① didExceedMaxLines == false —— 文案没有被省略号截断；
+  // ② 长文案比短文案更高 —— 证明在这个宽度下**确实发生了换行**。少了 ②，
+  //    哪天对话框变宽到一行放得下，maxLines 退回 1 也照样绿（假绿）。
+  testWidgets('BUG-1289 长勾选文案换行显示完整，不被省略号截断', (WidgetTester tester) async {
+    const String longLabel = '同时删除其中的视频（保留你的原始视频文件）';
+    await openDialog(tester, checkboxLabel: longLabel);
+
+    final RenderParagraph paragraph =
+        tester.renderObject<RenderParagraph>(find.text(longLabel));
+    expect(
+      paragraph.didExceedMaxLines,
+      isFalse,
+      reason: '勾选文案被截断了，用户看不到括号里的免责说明',
+    );
+    final double longHeight = tester.getSize(find.text(longLabel)).height;
+
+    // 同一个 [MaterialApp] element 会被复用，上一个 dialog route 仍压在
+    // Navigator 栈上会挡住 open 按钮，先关掉再开第二个。
+    await tester.tap(find.text('CANCEL'));
+    await tester.pumpAndSettle();
+
+    const String shortLabel = '删除';
+    await openDialog(tester, checkboxLabel: shortLabel);
+    final double shortHeight = tester.getSize(find.text(shortLabel)).height;
+
+    expect(
+      longHeight,
+      greaterThan(shortHeight),
+      reason: '此宽度下长文案没有换行，本用例已失去守卫意义，需重新挑选文案或宽度',
+    );
   });
 }


### PR DESCRIPTION
## 问题

用户报「删除合集」弹窗显示不全：勾选行渲染成「同时删除其中的视频（保留你的原始视…」，括号里的免责说明——恰好是最需要看清的那半句（原始视频文件不会被删）——被省略号整段吃掉。

## 根因

`HibikiDestructiveConfirmDialog` 的可选勾选行把整句解释文案塞进 `HibikiListItem.title`，而 `HibikiListItem` 是为**列表标题短语**设计的：`titleMaxLines` 默认 1，且强制 `TextOverflow.ellipsis`（`hibiki_material_components.dart:153,245`）。对话框 `maxWidth: 420`，扣掉内边距与 Checkbox 后装不下这句话。

同弹窗的正文 `message` 是裸 `Text` 没有行数限制，所以只有勾选行被截断，看起来像「这行本来就该这么短」，不易察觉。

`titleMaxLines` 默认 1 是 **BUG-1184 有意保留**的（部分调用点把列表项放在固定高度容器里，换行会撑破父容器），其注释明确要求「放宽必须逐调用点显式进行」。所以根治点在调用方，不动默认值。

## 修复

本调用点父容器高度自由——外层 `HibikiDialogFrame.scrollable` 默认 true，整个 sheet 被 `SingleChildScrollView` 包裹——显式传 `titleMaxLines: 3`。

一处修复覆盖全部 5 条销毁确认路径：
- `home_video_page.dart:3363` / `reader_hibiki_history_page.dart:1699`（两个库页的合集长按菜单）
- `media_collection_detail_page.dart:257`（视频合集详情页）
- `media_collection_grid_detail_page.dart:148`（书籍合集详情页）
- `collection_detail_shared.dart:124`（详情页共享删除流程）

## 测试

`test/widgets/hibiki_destructive_confirm_dialog_test.dart` 新增 widget 行为用例，双断言：

1. `RenderParagraph.didExceedMaxLines == false` —— 文案没被省略号截断；
2. 长文案渲染高度 > 短文案高度 —— 证明该宽度下**确实发生了换行**。少了这条，哪天对话框变宽到一行装得下，`maxLines` 退回 1 也照样绿（假绿）。

**变异实测**：把 `titleMaxLines: 3` 改回 `1` 重跑 → 用例在断言 ① 处失败（`+3 -1`）；还原后 4/4 绿。守卫有效。

## 验证

- `flutter analyze`（含 test 目录）：**No issues found**
- 定向测试 8 个文件（本弹窗 + `HibikiListItem` 系列 + `narrow_screen_overflow` + `md3_design_system_static` + `port_kill_confirm_dialog`）：**130 passed，退出码 0**

未做真机验证（纯布局约束改动，widget 层行为断言已覆盖渲染结果）。

https://claude.ai/code/session_01AJmGnHtMWnjWusTKZc2TKm
