### PR TITLE
fix(video): 让滚动弹幕自然滑出屏幕再消失（BUG-1297）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1240 条。点号进各自文件。
+> 共 1241 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1297](bugs/BUG-1297-danmaku-scroll-exit.md) | ✅ | ✅ | 滚动弹幕退场突兀：没滑出屏幕就被整条抹掉 |
 | [BUG-1291](bugs/BUG-1291-destructive-confirm-checkbox-truncated.md) | ✅ | ✅ | 销毁确认弹窗勾选行文案被单行省略号截断 |
 | [BUG-1290](bugs/BUG-1290-bangumi-dashboard-history.md) | ✅ | ✅ | Bangumi 首页卡把映射误当观看历史且不列待手动关联条目 |
 | [BUG-1289](bugs/BUG-1289-youtube-caption-track-labels-ambiguous.md) | ✅ | ✅ | YouTube 字幕轨标签退化成语言码且人工/ASR 重名，无法分辨选哪条 |

--- a/docs/bugs/BUG-1297-danmaku-scroll-exit.md
+++ b/docs/bugs/BUG-1297-danmaku-scroll-exit.md
@@ -1,0 +1,9 @@
+## BUG-1297 · 滚动弹幕退场突兀：没滑出屏幕就被整条抹掉
+- **报告**：2026-07-31（用户：弹幕消失的时候怪怪的，能不能让他自然到屏幕外面）
+- **真实性**：✅ 真 bug。两个独立根因叠加，都在退场阶段：
+  - **A｜宽度是估算，退场时刻算错**：`hibiki/lib/src/media/video/video_danmaku_layout.dart:174`（旧 `_estimatedWidth`）按「每字 `18 * fontScale`」估宽并 `clamp(36, 720)` 硬封顶，而实际渲染字号是 `20 * fontScale`（`video_danmaku_overlay.dart:211`）。滚动弹幕的行程是 `x = 视口宽 - (视口宽 + 文本宽) * progress`，`progress` 走到 1 的同一刻它离开活动集，于是宽度算少多少、文本右半截就有多少还留在画面里被整条抹掉。widget 层实测：22 字弹幕在停止渲染的那一帧右边缘仍在视口内 **44px**（22 × 少算的 2px）；超过 36 字的弹幕被 720 封顶后残留更多。
+  - **B｜滚动弹幕在画面内渐隐**：`_opacityFor` 对所有模式统一套末段淡出（`progress ≥ 0.88` 线性到 0）。但 `progress = 0.88` 时短弹幕往往还在画面中间（400px 视口、6 字弹幕此时 `x ≈ 40`），于是它是「走到一半淡没了」，而不是滑出去。淡出只对不移动的 top/bottom 固定弹幕有意义。
+  - 附带同源缺陷：`Text` 默认 `inherit: true` 会合并宿主 `DefaultTextStyle`，Material 的 `letterSpacing: 0.25` 让一条 22 字弹幕比纯函数测量侧宽 5.5px——测量与渲染两份真相，几何必然漂移。
+- **[x] ① 已修复** — 新增 `video_danmaku_text_metrics.dart`：`kVideoDanmakuBaseFontSize` + `videoDanmakuTextStyle()`（`inherit: false`，渲染与测量共用的唯一样式真相源）+ `VideoDanmakuTextMetrics`（`TextPainter` 实测宽度，按 `(fontScale, text)` 缓存，超 512 条整体清空）。`VideoDanmakuLayout` 改用实测宽度并把它随 `VideoDanmakuLayoutEntry.width` 带出；`_opacityFor` 收窄为只对固定弹幕生效，滚动弹幕恒不透明、纯靠位移滑出视口由 `Stack(clipBehavior: Clip.hardEdge)` 裁掉。退场时刻与过期时刻自此严丝合缝。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_danmaku_layout_test.dart`（几何层：过期帧文本右边缘 ≤ 视口左边界、过期前一帧仍与视口有交集、滚动弹幕全程 opacity 恒 1、固定弹幕保留淡出、宽度不被 720 封顶且随字号缩放）+ `hibiki/test/media/video/video_danmaku_overlay_test.dart`（真实渲染层：`tester.getRect` 断言最后一帧文本框已整体越过视口左边界、滚动弹幕 `Opacity` 全程为 1）。
+- **备注**：两组守卫均已**变异实测**：退回旧淡出曲线 → layout 层 `positionMs=7100` 处 opacity 0.9375、widget 层 7600ms 处 0.4167，双双转红；退回旧估算宽度 → widget 层残留 44px、layout 层宽度被封在 720，双双转红。几何断言刻意用**独立测得**的宽度而非 `entry.width` 做基准，否则几何一退化断言基准会跟着偏，守卫会自洽成废话（第一版就踩了这个坑）。

--- a/hibiki/lib/src/media/video/video_danmaku_layout.dart
+++ b/hibiki/lib/src/media/video/video_danmaku_layout.dart
@@ -4,6 +4,7 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 
 import 'package:hibiki/src/media/video/video_danmaku_model.dart';
+import 'package:hibiki/src/media/video/video_danmaku_text_metrics.dart';
 
 @immutable
 class VideoDanmakuLayoutEntry {
@@ -11,12 +12,18 @@ class VideoDanmakuLayoutEntry {
     required this.item,
     required this.lane,
     required this.position,
+    required this.width,
     required this.opacity,
   });
 
   final VideoDanmakuItem item;
   final int lane;
   final Offset position;
+
+  /// 文本实测渲染宽度（px）。滚动弹幕右边缘 = `position.dx + width`，是判断
+  /// 「是否真的滑出视口」的唯一依据。
+  final double width;
+
   final double opacity;
 }
 
@@ -44,7 +51,10 @@ class VideoDanmakuLayout {
     Duration fixedDuration = kDefaultVideoDanmakuFixedDuration,
     double fontScale = 1.0,
     double areaFraction = 1.0,
+    VideoDanmakuTextMetrics? metrics,
   }) {
+    final VideoDanmakuTextMetrics textMetrics =
+        metrics ?? VideoDanmakuTextMetrics.shared;
     if (items.isEmpty ||
         viewportSize.width <= 0 ||
         viewportSize.height <= 0 ||
@@ -114,11 +124,12 @@ class VideoDanmakuLayout {
         scrollDuration,
         fixedDuration,
       );
+      // 实测渲染宽度（非估算）：滚动弹幕的行程是「视口宽 + 自身宽」，progress 走到
+      // 1 的同一刻它离开活动集，所以宽度算少了就会在文本右半截还可见时被整条抹掉。
+      final double width = textMetrics.widthOf(activeItem.item.text, fontScale);
       final double x = switch (activeItem.item.mode) {
-        VideoDanmakuMode.scroll => viewportSize.width -
-            (viewportSize.width +
-                    _estimatedWidth(activeItem.item.text, fontScale)) *
-                progress,
+        VideoDanmakuMode.scroll =>
+          viewportSize.width - (viewportSize.width + width) * progress,
         VideoDanmakuMode.top => viewportSize.width * 0.5,
         VideoDanmakuMode.bottom => viewportSize.width * 0.5,
       };
@@ -129,7 +140,8 @@ class VideoDanmakuLayout {
         item: activeItem.item,
         lane: lane,
         position: Offset(x, y),
-        opacity: _opacityFor(progress),
+        width: width,
+        opacity: _opacityFor(activeItem.item.mode, progress),
       ));
       nextFreeMs[lane] = activeItem.item.startMs + 900;
     }
@@ -166,13 +178,16 @@ class VideoDanmakuLayout {
     return (activeItem.elapsedMs / durationMs).clamp(0.0, 1.0).toDouble();
   }
 
-  static double _opacityFor(double progress) {
+  /// 末段淡出**只属于固定弹幕**（top/bottom）：它们不移动，不淡出就是凭空消失。
+  ///
+  /// 滚动弹幕恒为不透明，靠位移一路滑到视口左侧之外、由 Stack 裁掉——这才是自然的
+  /// 退场。旧实现对滚动弹幕也套同一条淡出曲线，而 `progress = 0.88` 时短弹幕往往
+  /// 还在画面里（`x = 视口宽 - (视口宽 + 文本宽) * 0.88`），于是它在屏幕中间就渐隐没了。
+  static double _opacityFor(VideoDanmakuMode mode, double progress) {
+    if (mode == VideoDanmakuMode.scroll) return 1;
     if (progress < 0.88) return 1;
     return ((1 - progress) / 0.12).clamp(0.0, 1.0).toDouble();
   }
-
-  static double _estimatedWidth(String text, double fontScale) =>
-      (text.runes.length * 18.0 * fontScale).clamp(36.0, 720.0).toDouble();
 
   /// 二分（lowerBound）：在按 startMs 升序的 [items] 中返回第一个
   /// `startMs >= target` 的下标；不存在则返回 `items.length`。

--- a/hibiki/lib/src/media/video/video_danmaku_overlay.dart
+++ b/hibiki/lib/src/media/video/video_danmaku_overlay.dart
@@ -3,6 +3,7 @@ import 'package:flutter/scheduler.dart';
 
 import 'package:hibiki/src/media/video/video_danmaku_layout.dart';
 import 'package:hibiki/src/media/video/video_danmaku_model.dart';
+import 'package:hibiki/src/media/video/video_danmaku_text_metrics.dart';
 
 class VideoDanmakuOverlay extends StatefulWidget {
   const VideoDanmakuOverlay({
@@ -206,22 +207,13 @@ class _DanmakuText extends StatelessWidget {
         maxLines: 1,
         overflow: TextOverflow.visible,
         softWrap: false,
-        style: TextStyle(
+        // 与 VideoDanmakuTextMetrics 的测量条件保持逐项一致：字号由弹幕自己的
+        // fontScale 偏好决定，不再叠加系统字体缩放——否则实际渲染比测量宽，
+        // 弹幕会在还没滑出视口时被判过期而突然消失。
+        textScaler: TextScaler.noScaling,
+        style: videoDanmakuTextStyle(
           color: Color(entry.item.colorArgb),
-          fontSize: 20 * fontScale,
-          fontWeight: FontWeight.w700,
-          shadows: const <Shadow>[
-            Shadow(
-              color: Colors.black,
-              blurRadius: 3,
-              offset: Offset(1, 1),
-            ),
-            Shadow(
-              color: Colors.black,
-              blurRadius: 3,
-              offset: Offset(-1, -1),
-            ),
-          ],
+          fontScale: fontScale,
         ),
       ),
     );

--- a/hibiki/lib/src/media/video/video_danmaku_text_metrics.dart
+++ b/hibiki/lib/src/media/video/video_danmaku_text_metrics.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+/// 弹幕基准字号（`fontScale = 1.0` 时的 px）。
+///
+/// 这是**字号唯一真相源**：渲染（[videoDanmakuTextStyle]）与几何测量
+/// （[VideoDanmakuTextMetrics]）共用，避免「按 18px 估宽、按 20px 渲染」这类
+/// 两份真相导致弹幕没滑出屏幕就被判过期而突然截断消失。
+const double kVideoDanmakuBaseFontSize = 20.0;
+
+/// 弹幕文本样式。渲染与测量必须走这同一个构造函数——测量用的字号/字重一旦与渲染
+/// 不一致，出屏时刻就会算错。[color] 不影响几何，测量时传任意值即可。
+///
+/// `inherit: false` 是几何正确性的一部分，不是风格偏好：默认的 `inherit: true` 会
+/// 让 `Text` 把宿主的 `DefaultTextStyle` 合并进来（Material 的 `letterSpacing: 0.25`
+/// 就能让一条 22 字的弹幕多出 5.5px），而纯函数的测量侧拿不到那份主题，两边立刻
+/// 漂开。弹幕外观自给自足，也顺带不再随宿主主题变形。
+TextStyle videoDanmakuTextStyle({
+  required Color color,
+  required double fontScale,
+}) {
+  return TextStyle(
+    inherit: false,
+    color: color,
+    fontSize: kVideoDanmakuBaseFontSize * fontScale,
+    fontWeight: FontWeight.w700,
+    shadows: const <Shadow>[
+      Shadow(color: Colors.black, blurRadius: 3, offset: Offset(1, 1)),
+      Shadow(color: Colors.black, blurRadius: 3, offset: Offset(-1, -1)),
+    ],
+  );
+}
+
+/// 弹幕文本**实测**宽度（含缓存）。
+///
+/// 滚动弹幕的出屏位置是 `x = 视口宽 - (视口宽 + 文本宽) * progress`：`progress`
+/// 走到 1 的同一刻该条弹幕就会离开活动集，所以「文本宽」必须是真实渲染宽度，
+/// 否则文本右半截还留在画面内就被整条抹掉（观感=弹幕走到一半突然消失）。
+///
+/// 每帧最多测几十条且文本高度重复，按 `(fontScale, text)` 缓存后热路径只是一次
+/// Map 查找；缓存超过 [maxEntries] 整体清空（活动窗口只有几十条，重建代价可忽略），
+/// 避免长片累积几万条文本把内存吃掉。
+class VideoDanmakuTextMetrics {
+  VideoDanmakuTextMetrics({this.maxEntries = 512});
+
+  /// 进程级共享实例（弹幕样式全局唯一，缓存跨视频复用即可）。
+  static final VideoDanmakuTextMetrics shared = VideoDanmakuTextMetrics();
+
+  final int maxEntries;
+
+  final Map<String, double> _cache = <String, double>{};
+
+  final TextPainter _painter = TextPainter(
+    textDirection: TextDirection.ltr,
+    maxLines: 1,
+    textScaler: TextScaler.noScaling,
+  );
+
+  /// [text] 在 [fontScale] 下的真实渲染宽度（px）。
+  double widthOf(String text, double fontScale) {
+    if (text.isEmpty) return 0;
+    final String key = '${fontScale.toStringAsFixed(3)}$text';
+    final double? cached = _cache[key];
+    if (cached != null) return cached;
+    _painter
+      ..text = TextSpan(
+        text: text,
+        style: videoDanmakuTextStyle(
+          color: const Color(0xFFFFFFFF),
+          fontScale: fontScale,
+        ),
+      )
+      ..layout();
+    final double width = _painter.width;
+    if (_cache.length >= maxEntries) _cache.clear();
+    _cache[key] = width;
+    return width;
+  }
+
+  @visibleForTesting
+  void clearCache() => _cache.clear();
+}

--- a/hibiki/test/media/video/video_danmaku_layout_test.dart
+++ b/hibiki/test/media/video/video_danmaku_layout_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/video/video_danmaku_layout.dart';
 import 'package:hibiki/src/media/video/video_danmaku_model.dart';
 import 'package:hibiki/src/media/video/video_danmaku_source.dart';
+import 'package:hibiki/src/media/video/video_danmaku_text_metrics.dart';
 
 VideoDanmakuItem _item(int startMs, String text) => VideoDanmakuItem(
       startMs: startMs,
@@ -50,6 +51,100 @@ List<String> _keys(Iterable<VideoDanmakuItem> items) {
 }
 
 void main() {
+  // layout 现在用 TextPainter 实测文本宽度，需要测试 binding 提供字体集合。
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('VideoDanmakuLayout 退场几何（BUG-1297）', () {
+    // 滚动弹幕的行程 = 视口宽 + 自身宽；progress 走到 1 的同一刻它离开活动集。
+    // 因此「宽度」必须是真实渲染宽度，且滚动弹幕不得在画面内被淡出。
+    const Size viewport = Size(400, 200);
+    const int scrollMs = 8000;
+
+    VideoDanmakuLayoutEntry entryAt(String text, int positionMs,
+        {double fontScale = 1.0}) {
+      return VideoDanmakuLayout.layout(
+        items: <VideoDanmakuItem>[_item(0, text)],
+        positionMs: positionMs,
+        viewportSize: viewport,
+        maxActive: 10,
+        maxLanes: 4,
+        fontScale: fontScale,
+      ).entries.single;
+    }
+
+    test('scroll danmaku is fully off-screen on the last frame it renders', () {
+      // 短、中、长三档：旧实现按「每字 18px 且封顶 720px」估宽，长弹幕在右半截
+      // 仍可见时就被判过期，表现为走到一半突然消失。
+      for (final String text in <String>[
+        'あ',
+        '短いコメント',
+        'とても長いコメントです' * 6,
+      ]) {
+        final VideoDanmakuLayoutEntry entry = entryAt(text, scrollMs);
+        // 右边缘用**独立测得**的宽度算，不用 entry.width——否则几何一旦退回估算，
+        // 断言基准会跟着一起偏，守卫自洽成一句废话。
+        final double renderedWidth =
+            VideoDanmakuTextMetrics.shared.widthOf(text, 1.0);
+        expect(
+          entry.position.dx + renderedWidth,
+          lessThanOrEqualTo(0.0),
+          reason: '过期那一帧文本右边缘必须已越过视口左边界（len=${text.length}）',
+        );
+        expect(entry.width, renderedWidth, reason: 'entry.width 必须是实测渲染宽度');
+      }
+    });
+
+    test('scroll danmaku still overlaps the viewport one frame before expiry',
+        () {
+      // 反向守卫：不能靠「提前很久就把弹幕推出屏外」蒙混过关——退场必须刚好衔接。
+      final VideoDanmakuLayoutEntry entry = entryAt('短いコメント', scrollMs - 100);
+      expect(
+        entry.position.dx + entry.width,
+        greaterThan(0.0),
+        reason: '尚未过期时弹幕仍应与视口有交集，退场时刻要与过期时刻严丝合缝',
+      );
+    });
+
+    test('scroll danmaku never fades out inside the viewport', () {
+      for (int positionMs = 0; positionMs <= scrollMs; positionMs += 100) {
+        expect(
+          entryAt('短いコメント', positionMs).opacity,
+          1.0,
+          reason: '滚动弹幕靠位移退场，任何时刻都不得渐隐（positionMs=$positionMs）',
+        );
+      }
+    });
+
+    test('fixed danmaku keeps the tail fade-out', () {
+      // 固定弹幕不移动，不淡出就是凭空消失——淡出只属于它们。
+      double opacityAt(int positionMs, VideoDanmakuMode mode) =>
+          VideoDanmakuLayout.layout(
+            items: <VideoDanmakuItem>[_itemMode(0, 'ピン留め', mode)],
+            positionMs: positionMs,
+            viewportSize: viewport,
+            maxActive: 10,
+            maxLanes: 4,
+          ).entries.single.opacity;
+      for (final VideoDanmakuMode mode in <VideoDanmakuMode>[
+        VideoDanmakuMode.top,
+        VideoDanmakuMode.bottom,
+      ]) {
+        expect(opacityAt(2000, mode), 1.0, reason: '$mode 停留期间完全不透明');
+        expect(opacityAt(3900, mode), lessThan(1.0), reason: '$mode 末段应渐隐');
+        expect(opacityAt(4000, mode), 0.0, reason: '$mode 到期时已淡到全透明');
+      }
+    });
+
+    test('measured width is not capped, and scales with font size', () {
+      // 旧估算把宽度封在 720px：40 个全角字（测试字体每字 = 字号）已经超过它。
+      final VideoDanmakuLayoutEntry long = entryAt('あ' * 40, 0);
+      expect(long.width, greaterThan(720.0), reason: '长弹幕宽度不得被硬上限截断');
+      final VideoDanmakuLayoutEntry small = entryAt('あ' * 10, 0);
+      final VideoDanmakuLayoutEntry big = entryAt('あ' * 10, 0, fontScale: 2.0);
+      expect(big.width, greaterThan(small.width), reason: '宽度随字号缩放');
+    });
+  });
+
   group('VideoDanmakuLayout', () {
     test('does not place simultaneous active comments on the same lane', () {
       final VideoDanmakuLayoutSnapshot snapshot = VideoDanmakuLayout.layout(

--- a/hibiki/test/media/video/video_danmaku_overlay_test.dart
+++ b/hibiki/test/media/video/video_danmaku_overlay_test.dart
@@ -185,8 +185,7 @@ void main() {
 
     final double at1x = await travel(1.0);
     final double at2x = await travel(2.0);
-    expect(at2x, greaterThan(at1x),
-        reason: '倍速时按帧外推更快，弹幕单帧左移更远');
+    expect(at2x, greaterThan(at1x), reason: '倍速时按帧外推更快，弹幕单帧左移更远');
   });
 
   testWidgets('scroll danmaku is monotonic: backward raw jitter never reverses',
@@ -214,8 +213,65 @@ void main() {
     raw = 1950; // 播放器时钟小幅回退（<1s，非 seek）
     await tester.pump(const Duration(milliseconds: 16));
     final double l2 = scrollLeft(tester, 'x');
-    expect(l2, lessThanOrEqualTo(l1),
-        reason: 'raw 小幅回退时弹幕只进不退（消除来回跳动）');
+    expect(l2, lessThanOrEqualTo(l1), reason: 'raw 小幅回退时弹幕只进不退（消除来回跳动）');
+  });
+
+  testWidgets('scroll danmaku has left the viewport on its last rendered frame',
+      (WidgetTester tester) async {
+    // BUG-1297：在**真实渲染宽度**上验证退场——弹幕停止渲染的那一帧，它的文本框
+    // 必须已经整体越过视口左边界，而不是右半截还挂在画面里被整条抹掉。
+    const String text = 'とても長いコメントですとても長いコメントです';
+    await _pump(
+      tester,
+      VideoDanmakuOverlay(
+        items: <VideoDanmakuItem>[_item(0, text)],
+        enabled: true,
+        maxActive: 20,
+        // 暂停：插值冻结在真值，几何完全由 positionMs 决定。
+        positionMs: () => 8000,
+        isPlaying: () => false,
+        speed: () => 1.0,
+      ),
+    );
+
+    final Rect viewport = tester.getRect(find.byType(VideoDanmakuOverlay));
+    final Rect rendered = tester.getRect(find.text(text));
+    expect(
+      rendered.right,
+      lessThanOrEqualTo(viewport.left + 0.01),
+      reason: '最后一帧文本右边缘应已越过视口左边界，下一帧移出活动集才不会突兀',
+    );
+  });
+
+  testWidgets('scroll danmaku stays fully opaque all the way out',
+      (WidgetTester tester) async {
+    Future<double> opacityAt(int positionMs) async {
+      await _pump(
+        tester,
+        VideoDanmakuOverlay(
+          items: <VideoDanmakuItem>[_item(0, 'コメント')],
+          enabled: true,
+          maxActive: 20,
+          positionMs: () => positionMs,
+          isPlaying: () => false,
+          speed: () => 1.0,
+        ),
+      );
+      return tester
+          .widget<Opacity>(
+            find
+                .ancestor(
+                  of: find.text('コメント'),
+                  matching: find.byType(Opacity),
+                )
+                .first,
+          )
+          .opacity;
+    }
+
+    expect(await opacityAt(4000), 1.0);
+    expect(await opacityAt(7600), 1.0, reason: '旧实现在此处已开始渐隐（progress>0.88）');
+    expect(await opacityAt(8000), 1.0, reason: '退场靠位移，不靠渐隐');
   });
 
   testWidgets('large backward raw (seek) re-aligns danmaku position',
@@ -237,7 +293,6 @@ void main() {
     raw = 1000;
     await tester.pump(const Duration(milliseconds: 16));
     final double after = scrollLeft(tester, 'x');
-    expect(after, greaterThan(before),
-        reason: 'seek 回退是真正的位置跳变，弹幕对齐真值（更靠右）');
+    expect(after, greaterThan(before), reason: 'seek 回退是真正的位置跳变，弹幕对齐真值（更靠右）');
   });
 }


### PR DESCRIPTION
用户报：「弹幕消失的时候怪怪的，能不能让他自然到屏幕外面」。沿真实代码路径验真，是真 bug，两个独立根因叠加，都在退场阶段。

## 根因

**A｜宽度是估算，退场时刻算错**
`video_danmaku_layout.dart` 旧 `_estimatedWidth` 按「每字 `18 * fontScale`」估宽并 `clamp(36, 720)` 硬封顶，而实际渲染字号是 `20 * fontScale`。滚动弹幕的行程是 `x = 视口宽 - (视口宽 + 文本宽) * progress`，`progress` 走到 1 的同一刻它离开活动集——宽度算少多少，文本右半截就有多少还留在画面里被整条抹掉。widget 层实测：22 字弹幕在停止渲染的那一帧，右边缘仍在视口内 **44px**（22 × 少算的 2px）；超过 36 字的弹幕被 720 封顶后残留更多。

**B｜滚动弹幕在画面内渐隐**
`_opacityFor` 对所有模式统一套末段淡出（`progress >= 0.88` 线性到 0）。但那时短弹幕往往还在画面中间（400px 视口、6 字弹幕此时 `x ≈ 40`），观感是「走到一半淡没了」，而不是滑出去。淡出只对不移动的 top/bottom 固定弹幕有意义。

**附带同源缺陷**：`Text` 默认 `inherit: true` 会合并宿主 `DefaultTextStyle`，Material 的 `letterSpacing: 0.25` 让一条 22 字弹幕比纯函数测量侧宽 5.5px——测量与渲染两份真相，几何必然漂移。

## 修复

新增 `video_danmaku_text_metrics.dart`：
- `kVideoDanmakuBaseFontSize` + `videoDanmakuTextStyle()`（`inherit: false`）＝ 渲染与测量共用的唯一样式真相源；
- `VideoDanmakuTextMetrics`：`TextPainter` 实测宽度，按 `(fontScale, text)` 缓存，超 512 条整体清空。

`VideoDanmakuLayout` 改用实测宽度并把它随 `VideoDanmakuLayoutEntry.width` 带出；`_opacityFor` 收窄为只对固定弹幕生效，滚动弹幕恒不透明、纯靠位移滑出视口由 `Stack(clipBehavior: Clip.hardEdge)` 裁掉。退场时刻与过期时刻自此严丝合缝：`progress = 1` 时 `x = -文本宽`，右边缘正好压在视口左边界上，下一帧才移出活动集。

## 验证

- `flutter analyze`（全量含 test）：No issues found
- `flutter test test/media/video/ test/pages/video_danmaku_wiring_guard_test.dart --no-pub`：**1945 passed / 0 failed / 2 skipped**
- 新增守卫双层：几何层（`video_danmaku_layout_test.dart`）+ 真实渲染层（`video_danmaku_overlay_test.dart`，`tester.getRect` 断言真实文本框）
- **变异实测**：退回旧淡出曲线 → layout 层 `positionMs=7100` 处 opacity 0.9375、widget 层 7600ms 处 0.4167，双双转红；退回旧估算宽度 → widget 层残留 44px、layout 层宽度被封在 720，双双转红。几何断言刻意用**独立测得**的宽度而非 `entry.width` 做基准，否则几何一退化断言基准会跟着偏、守卫自洽成废话（第一版就踩了这个坑，已修正）。

未做真机复测（本轮只在 widget/几何层验证）。

https://claude.ai/code/session_01Y2oqLwxDbwLo8xdoTdmCmF