### PR TITLE
fix(video): 合集 hero 按封面朝向分流，竖版刮削海报不再被裁成中间一条（BUG-1298）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1240 条。点号进各自文件。
+> 共 1241 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1298](bugs/BUG-1298-collection-hero-portrait-cover.md) | ✅ | ✅ | 合集详情页 hero 用竖版刮削海报时被 BoxFit.cover 裁成中间一条 |
 | [BUG-1291](bugs/BUG-1291-destructive-confirm-checkbox-truncated.md) | ✅ | ✅ | 销毁确认弹窗勾选行文案被单行省略号截断 |
 | [BUG-1290](bugs/BUG-1290-bangumi-dashboard-history.md) | ✅ | ✅ | Bangumi 首页卡把映射误当观看历史且不列待手动关联条目 |
 | [BUG-1289](bugs/BUG-1289-youtube-caption-track-labels-ambiguous.md) | ✅ | ✅ | YouTube 字幕轨标签退化成语言码且人工/ASR 重名，无法分辨选哪条 |

--- a/docs/bugs/BUG-1298-collection-hero-portrait-cover.md
+++ b/docs/bugs/BUG-1298-collection-hero-portrait-cover.md
@@ -1,0 +1,48 @@
+## BUG-1298 · 合集详情页 hero 用竖版刮削海报时被 BoxFit.cover 裁成中间一条
+- **报告**：2026-07-31（用户：截图「刮削封面以后成这样了」，合集 `Tensei Oujo to Tensai Reijou no Mahou Kakumei v2 播放列表`）
+- **真实性**：✅ 真 bug — 根因 `hibiki/lib/src/pages/implementations/media_collection_detail_page.dart:325`（修复前 `_buildHero` 内无条件 `Image(image: cover, fit: BoxFit.cover)`）
+
+  合集详情页 hero 是宽幅槽：宽 = 整屏，高 = `(screenH * 0.62).clamp(400, 600)`，比例约 **2.7:1**。
+  它的图源 `_heroCover` **第一优先**取 `MediaCollections.coverPath`——而刮削正是往这一列写**竖版海报**。
+  用户生产库实测：`media_collections.id=69` → `video_covers/collections/69.jpg` = **853×1200（2:3，比例 0.711）**。
+
+  `BoxFit.cover` 把 2:3 海报铺进 2.7:1 槽，缩放因子取 `max(3840/853, 1400/1200) = 4.5`，
+  缩放后 3840×5400，垂直裁掉 4000px —— **只剩海报中间 26% 的高度带**，于是画面成了一条糊满
+  人脸、头顶被切的横带，正是用户截图所见。
+
+  刮削**前** `cover_path` 为 NULL，`_heroCover` 回落到成员抽帧（16:9≈1.78），cover 只裁掉约 35%，
+  看着正常 —— 所以现象精确表现为「刮削封面以后成这样了」，而不是一直就坏。
+
+  更深一层：`media_collections` 只有单一 `cover_path` 列（无 backdrop 列），一个列同时服务
+  2:3 网格卡与 2.7:1 hero 两种朝向。朝向矛盾在数据层无处安放，故判定必须落在渲染层。
+
+- **[x] ① 已修复** — 新增 `hibiki/lib/src/media/video/cover_ui/landscape_cover_image.dart`
+  （`LandscapeCoverImage`，既有 `PortraitCoverImage` 的镜像：那个管「竖槽装横图」，这个管
+  「横槽装竖图」），并在 `_buildHero` 接入：
+  - 横图（宽高比 ≥ 1.2，抽帧 16:9）→ 仍 `BoxFit.cover` 铺满，**与修复前逐像素相同**；
+  - 竖图（刮削海报 2:3）→ 同图模糊垫底（sigma 28）+ 压暗 + 前景 `BoxFit.contain` 完整显示，
+    按 `foregroundAlignment` 靠尾侧（LTR 下 = 右）避让 hero 左下的标题/进度/播放按钮；
+  - 首帧解码前尺寸未知 → 按横图渲染（= 修复前行为），`ImageStream` 拿到固有尺寸后再切，不闪换；
+  - hero 那两层可读性渐变改为 `overlays` 参数注入组件，由组件排层序：渐变压在模糊垫底**之上**
+    （保住文字可读），但压在清晰海报**之下**——否则 hero 底部浓到 `0xE8` 的渐变会把海报下半截
+    压成一片黑，等于换个方式毁掉海报。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/collection_hero_cover_orientation_test.dart`（4 例）：
+  横图仍 cover 且无模糊垫底 / 竖图（用实测的 853×1200）有模糊垫底且前景 contain / 竖图层序
+  （垫底 < 遮罩 < 清晰海报）/ 源码守卫锁 `_buildHero` 调用点不得回退裸 `Image`。
+
+  **变异实测**（防假绿，4 轮全部按预期红/绿）：
+  1. 阈值 `1.2 → 0.5`（竖图被误判成横图）→ 竖图 2 例红、横图与源码守卫绿；
+  2. `overlays` 与前景 Padding 对调（渐变压到海报上）→ 仅层序 1 例红；
+  3. / 4. 调用点换回裸 `Image(image: cover ...)` → 源码守卫红。
+
+  变异期间抓到守卫**自身**的缺陷并已修：原正则 `Image\(\s*image: cover` 会匹配
+  `LandscapeCoverImage(` 的尾部（它就以 `Image(` 结尾），当时之所以绿只是因为中间恰好隔了一行
+  `key:`；删掉 `key:` 行这一**等价正确写法**会被误判成回归。已收紧为
+  `(?<![A-Za-z_])Image\(\s*image: cover`，并实测「删 key 行仍绿 / 裸 Image 仍红」。
+
+- **备注**：本次只做渲染层根因修复，对已刮削的存量数据立即生效、零迁移。
+  数据层的彻底解法（`media_collections` 增独立横版 backdrop 列、刮削同时抓 backdrop、hero 优先
+  用 backdrop 而海报只喂 2:3 网格卡）需要 schema bump + 刮削源改造，未在本轮范围内；本修复是那条
+  路落地后的天然回落路径，不冲突。
+
+  同源但不同槽向的既有条目见 BUG-1272（三处硬编码封面槽绕过 `PortraitCoverImage`）。

--- a/hibiki/lib/src/media/video/cover_ui/landscape_cover_image.dart
+++ b/hibiki/lib/src/media/video/cover_ui/landscape_cover_image.dart
@@ -1,0 +1,206 @@
+import 'dart:ui' show ImageFilter;
+
+import 'package:flutter/material.dart';
+
+/// 宽幅（约 2.7:1）封面槽的填充组件 —— [PortraitCoverImage] 的镜像。
+///
+/// 竖版槽装横图由 `PortraitCoverImage` 负责；本组件负责相反的一侧：**横幅槽装竖
+/// 图**。合集详情页 hero 就是这样一个槽：它跨整屏宽、高 400~600，比例约 2.7:1，
+/// 而它的图源只有一个 `MediaCollections.coverPath` 列——既可能是导入抽帧的 16:9
+/// 横图，也可能是刮削写入的 2:3 竖版海报（BUG-1298）。一个列服务两种朝向，所以
+/// 朝向判定必须落在渲染层。
+///
+/// * 横图（宽高比 ≥ [landscapeAspectThreshold]，抽帧 16:9≈1.78）→ 直接
+///   `BoxFit.cover` 铺满，[overlays] 压在其上。**与本组件引入前逐像素相同。**
+/// * 竖图（刮削海报 2:3≈0.71）→ 同图两层：底层 `cover` 放大 + 高斯模糊 + 半透明
+///   压暗垫底，前景 `contain` 完整显示、按 [foregroundAlignment] 靠边避让 hero
+///   文字。直接 `cover` 一张 2:3 海报进 2.7:1 槽要放大 4.5 倍、只剩中间 26% 的
+///   高度带（人脸糊满屏、头顶被切），正是 BUG-1298 的现象。
+/// * 尺寸未知（首帧解码前）先按 `cover` 渲染，[ImageStream] 拿到尺寸后再切换，
+///   避免先占位后闪换（与 `PortraitCoverImage` 同一策略）。
+/// * 加载/解码失败 → [errorBuilder]。
+///
+/// [overlays] 是压在封面之上、**清晰前景之下**的遮罩层（hero 那两层可读性渐变）。
+/// 层序是本组件的存在理由之一：渐变要盖住模糊垫底（否则文字压在花花绿绿的背景上
+/// 不可读），但**不能**盖住清晰海报（hero 底部渐变浓到 0xE8，海报下半截会被压成
+/// 一片黑）。调用方自己拼 Stack 做不到这个层序，除非把朝向判定抄一遍。
+///
+/// 宽高比判定不异步 decode 整图：前景 [Image] 与尺寸探测共用同一个 [ImageProvider]
+/// （同一 [ImageStream]），零额外解码成本。
+class LandscapeCoverImage extends StatefulWidget {
+  const LandscapeCoverImage({
+    super.key,
+    required this.image,
+    this.imageKey,
+    this.overlays = const <Widget>[],
+    this.foregroundAlignment = AlignmentDirectional.centerEnd,
+    this.foregroundPadding = EdgeInsets.zero,
+    this.errorBuilder,
+  });
+
+  /// 已解析好的图片源。本地文件请自带解码上限（如 `resizedFileImage`）——垫底与
+  /// 前景共享同一 provider 的解码缓存。
+  final ImageProvider image;
+
+  /// 主 [Image] 的 key（widget 测试按此定位）。
+  final Key? imageKey;
+
+  /// 压在封面之上、清晰前景之下的遮罩层（自下而上）。
+  final List<Widget> overlays;
+
+  /// 竖图前景的对齐方式；默认靠尾侧（LTR 下 = 右），避让 hero 左下的标题/按钮。
+  final AlignmentGeometry foregroundAlignment;
+
+  /// 竖图前景的内边距（避让 AppBar 与底部安全区）。横图路径不受影响。
+  final EdgeInsetsGeometry foregroundPadding;
+
+  /// 加载/解码失败时的替代内容。
+  final WidgetBuilder? errorBuilder;
+
+  /// 横图判定阈值：宽高比 ≥ 此值直接 cover。抽帧 16:9≈1.78 是横图；刮削海报
+  /// 2:3≈0.71 与方图 1.0 都要走模糊垫底（方图 cover 进 2.7:1 槽也要裁掉 63%）。
+  static const double landscapeAspectThreshold = 1.2;
+
+  /// 竖图垫底的模糊强度（sigma）。比竖版槽的 14 更强：这里垫底被放大 4.5 倍，
+  /// 同样的 sigma 相对画面显得太锐。
+  static const double backdropBlurSigma = 28;
+
+  /// 竖图垫底之上的压暗层（与 `PortraitCoverImage` 同值）。
+  static const Color backdropDimColor = Color(0x59000000);
+
+  @override
+  State<LandscapeCoverImage> createState() => _LandscapeCoverImageState();
+}
+
+class _LandscapeCoverImageState extends State<LandscapeCoverImage> {
+  ImageStream? _stream;
+  ImageStreamListener? _listener;
+
+  /// 图片固有宽高比（宽 / 高）；null = 首帧前尺寸未知。
+  double? _aspect;
+  bool _failed = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _resolveImage();
+  }
+
+  @override
+  void didUpdateWidget(LandscapeCoverImage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.image != oldWidget.image) {
+      _aspect = null;
+      _failed = false;
+      _resolveImage();
+    }
+  }
+
+  @override
+  void dispose() {
+    _detachListener();
+    super.dispose();
+  }
+
+  void _detachListener() {
+    final ImageStreamListener? listener = _listener;
+    if (listener != null) _stream?.removeListener(listener);
+    _stream = null;
+    _listener = null;
+  }
+
+  void _resolveImage() {
+    final ImageStream newStream =
+        widget.image.resolve(createLocalImageConfiguration(context));
+    if (newStream.key == _stream?.key) return;
+    _detachListener();
+    final ImageStreamListener listener =
+        ImageStreamListener(_onImage, onError: _onError);
+    _stream = newStream;
+    _listener = listener;
+    newStream.addListener(listener);
+  }
+
+  void _onImage(ImageInfo info, bool syncCall) {
+    final double aspect = info.image.width / info.image.height;
+    info.dispose();
+    if (!mounted || _aspect == aspect) return;
+    setState(() {
+      _aspect = aspect;
+      _failed = false;
+    });
+  }
+
+  void _onError(Object exception, StackTrace? stackTrace) {
+    if (!mounted || _failed) return;
+    setState(() => _failed = true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_failed) {
+      return widget.errorBuilder?.call(context) ?? const SizedBox.shrink();
+    }
+    final double? aspect = _aspect;
+    // 首帧前 aspect 未知 → 按横图走（= 引入本组件前的行为），拿到尺寸再切。
+    final bool portrait =
+        aspect != null && aspect < LandscapeCoverImage.landscapeAspectThreshold;
+
+    if (!portrait) {
+      return ClipRect(
+        child: Stack(
+          fit: StackFit.expand,
+          children: <Widget>[
+            Image(
+              key: widget.imageKey,
+              image: widget.image,
+              fit: BoxFit.cover,
+              errorBuilder: widget.errorBuilder == null
+                  ? null
+                  : (BuildContext context, Object _, StackTrace? __) =>
+                      widget.errorBuilder!(context),
+            ),
+            ...widget.overlays,
+          ],
+        ),
+      );
+    }
+
+    return ClipRect(
+      child: Stack(
+        fit: StackFit.expand,
+        children: <Widget>[
+          // 垫底：同图放大模糊（blur 溢出由外层 ClipRect 收口）。
+          ImageFiltered(
+            imageFilter: ImageFilter.blur(
+              sigmaX: LandscapeCoverImage.backdropBlurSigma,
+              sigmaY: LandscapeCoverImage.backdropBlurSigma,
+            ),
+            child: Image(
+              image: widget.image,
+              fit: BoxFit.cover,
+              // 垫底解码失败不接管整块（前景/流监听兜底），静默留空。
+              errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+            ),
+          ),
+          const ColoredBox(color: LandscapeCoverImage.backdropDimColor),
+          // 遮罩压在模糊垫底上（保证文字可读），但压不到下面的清晰海报。
+          ...widget.overlays,
+          Padding(
+            padding: widget.foregroundPadding,
+            child: Image(
+              key: widget.imageKey,
+              image: widget.image,
+              fit: BoxFit.contain,
+              alignment: widget.foregroundAlignment,
+              errorBuilder: widget.errorBuilder == null
+                  ? null
+                  : (BuildContext context, Object _, StackTrace? __) =>
+                      widget.errorBuilder!(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -5,6 +5,7 @@ import 'package:hibiki/src/focus/hibiki_focus_target.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_one_key_sort.dart'
     show CollectionSortMeta, compareCollectionMembers;
+import 'package:hibiki/src/media/video/cover_ui/landscape_cover_image.dart';
 import 'package:hibiki/src/media/media_cover_source.dart';
 import 'package:hibiki/src/media/video/video_episode_rail.dart';
 import 'package:hibiki/src/pages/implementations/collection_detail_shared.dart';
@@ -315,48 +316,63 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     final ImageProvider? cover = _heroCover;
     final VideoBookRow episode = _members[_continueIndex];
     final bool rtl = Directionality.of(context) == TextDirection.rtl;
+    // 可读性渐变：压在封面之上、竖版海报前景之下（层序由 [LandscapeCoverImage]
+    // 保证，见该组件文档）。无封面时直接铺在底色上，与引入组件前一致。
+    final List<Widget> overlays = <Widget>[
+      const DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            stops: <double>[0, 0.48, 1],
+            colors: <Color>[
+              Color(0x52000000),
+              Color(0x22000000),
+              Color(0xE8000000),
+            ],
+          ),
+        ),
+      ),
+      DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: rtl ? Alignment.centerRight : Alignment.centerLeft,
+            end: rtl ? Alignment.centerLeft : Alignment.centerRight,
+            stops: const <double>[0, 0.66, 1],
+            colors: const <Color>[
+              Color(0xC9000000),
+              Color(0x26000000),
+              Color(0x7A000000),
+            ],
+          ),
+        ),
+      ),
+    ];
     return SizedBox(
       height: height,
       child: Stack(
         fit: StackFit.expand,
         children: <Widget>[
           ColoredBox(color: cs.surfaceContainerHighest),
+          // 合集封面列（`MediaCollections.coverPath`）同时承载导入抽帧的 16:9 横图
+          // 与刮削写入的 2:3 竖版海报，故朝向判定交给 [LandscapeCoverImage]：横图
+          // 照旧 cover 铺满，竖版海报走模糊垫底 + 靠右完整显示（BUG-1298）。
           if (cover != null)
-            Image(
+            LandscapeCoverImage(
+              key: const ValueKey<String>('collection-hero-cover'),
               image: cover,
-              fit: BoxFit.cover,
-              alignment: Alignment.center,
-              errorBuilder: (_, __, ___) =>
+              overlays: overlays,
+              // 竖版海报避让顶部 AppBar 与底部内容区，靠右不压左下标题/播放按钮。
+              foregroundPadding: EdgeInsetsDirectional.only(
+                top: kToolbarHeight,
+                bottom: tokens.spacing.section,
+                end: tokens.spacing.page,
+              ),
+              errorBuilder: (BuildContext _) =>
                   ColoredBox(color: cs.surfaceContainerHighest),
-            ),
-          const DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topCenter,
-                end: Alignment.bottomCenter,
-                stops: <double>[0, 0.48, 1],
-                colors: <Color>[
-                  Color(0x52000000),
-                  Color(0x22000000),
-                  Color(0xE8000000),
-                ],
-              ),
-            ),
-          ),
-          DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: rtl ? Alignment.centerRight : Alignment.centerLeft,
-                end: rtl ? Alignment.centerLeft : Alignment.centerRight,
-                stops: const <double>[0, 0.66, 1],
-                colors: const <Color>[
-                  Color(0xC9000000),
-                  Color(0x26000000),
-                  Color(0x7A000000),
-                ],
-              ),
-            ),
-          ),
+            )
+          else
+            ...overlays,
           SafeArea(
             bottom: false,
             child: Padding(

--- a/hibiki/test/pages/collection_hero_cover_orientation_test.dart
+++ b/hibiki/test/pages/collection_hero_cover_orientation_test.dart
@@ -1,0 +1,226 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/cover_ui/landscape_cover_image.dart';
+
+/// BUG-1298 守卫：合集详情页 hero 是宽幅槽（整屏宽 × 400~600 高，约 2.7:1），
+/// 而它的图源 `MediaCollections.coverPath` 一个列同时承载两种朝向——导入抽帧的
+/// 16:9 横图，与刮削写入的 2:3 竖版海报。
+///
+/// 根因：hero 原先无条件 `BoxFit.cover`。竖版海报（实测 853×1200）铺进 2.7:1 槽
+/// 要放大 4.5 倍、只保留中间 **26%** 的高度带——用户刮削封面后 hero 就成了一条
+/// 糊满人脸、头顶被切的横带。刮削前该列为 NULL、回落成员抽帧（16:9）才看着正常，
+/// 所以现象表现为「刮削封面以后成这样了」。
+///
+/// 修复：[LandscapeCoverImage] 按图片固有宽高比分流（`PortraitCoverImage` 的镜像）。
+/// 本文件锁三件事：
+///  1. 横图仍 `BoxFit.cover` 铺满、不引入模糊垫底（Never break userspace）；
+///  2. 竖图走模糊垫底 + `BoxFit.contain` 完整前景；
+///  3. 遮罩层序——渐变压在模糊垫底之上、清晰海报之下（否则 hero 底部 0xE8 的渐变
+///     会把海报下半截压成一片黑，等于换个方式毁掉海报）。
+void main() {
+  group('LandscapeCoverImage 按图片朝向分流 — BUG-1298', () {
+    testWidgets('横图（16:9 抽帧）仍 cover 铺满，不加模糊垫底', (WidgetTester tester) async {
+      final MemoryImage provider =
+          MemoryImage(await _solidPngBytes(tester, 1600, 900));
+      await _pumpHero(tester, provider);
+
+      expect(
+        _fitOfImageWith(tester, BoxFit.cover),
+        isTrue,
+        reason: '横图必须 BoxFit.cover 铺满宽幅槽——这是本组件引入前的行为，'
+            '不得回归',
+      );
+      expect(
+        find.byType(ImageFiltered),
+        findsNothing,
+        reason: '横图不需要模糊垫底；出现垫底说明朝向判定把横图误判成竖图',
+      );
+    });
+
+    testWidgets('竖版海报（2:3 刮削）走模糊垫底 + contain 完整前景',
+        (WidgetTester tester) async {
+      // 用户实际刮到的海报尺寸（853×1200），不是随手编的比例。
+      final MemoryImage provider =
+          MemoryImage(await _solidPngBytes(tester, 853, 1200));
+      await _pumpHero(tester, provider);
+
+      expect(
+        find.byType(ImageFiltered),
+        findsOneWidget,
+        reason: '竖版海报必须有模糊垫底填满宽幅槽的两侧，否则要么黑边要么被裁',
+      );
+      expect(
+        _fitOfImageWith(tester, BoxFit.contain),
+        isTrue,
+        reason: '竖版海报前景必须 contain 完整显示——cover 会放大 4.5 倍只剩'
+            '中间 26%，正是 BUG-1298 的现象',
+      );
+    });
+
+    testWidgets('竖图路径下遮罩压在垫底之上、清晰海报之下', (WidgetTester tester) async {
+      final MemoryImage provider =
+          MemoryImage(await _solidPngBytes(tester, 853, 1200));
+      await _pumpHero(tester, provider);
+
+      // 取渲染出竖图三层的那个 Stack（含 ImageFiltered 垫底的那个）。
+      final Stack stack = tester
+          .widgetList<Stack>(find.byType(Stack))
+          .firstWhere(
+              (Stack s) => s.children.any((Widget w) => w is ImageFiltered));
+
+      final int overlayIndex =
+          stack.children.indexWhere((Widget w) => w.key == _overlayKey);
+      final int blurIndex =
+          stack.children.indexWhere((Widget w) => w is ImageFiltered);
+      final int foregroundIndex =
+          stack.children.indexWhere((Widget w) => w is Padding);
+
+      expect(overlayIndex, isNonNegative, reason: 'overlays 没被渲染进 Stack');
+      expect(foregroundIndex, isNonNegative, reason: '清晰前景没被渲染进 Stack');
+      expect(
+        blurIndex < overlayIndex,
+        isTrue,
+        reason: '遮罩必须压在模糊垫底之上，否则 hero 文字压在花背景上不可读',
+      );
+      expect(
+        overlayIndex < foregroundIndex,
+        isTrue,
+        reason: '遮罩绝不能压在清晰海报之上——hero 底部渐变浓到 0xE8，会把海报'
+            '下半截压成一片黑（等于换个方式毁掉海报）',
+      );
+    });
+  });
+
+  // 组件写对了，页面没接上去照样是坏的。这条锁调用点。
+  test('合集详情页 hero 必须走 LandscapeCoverImage，不得回退裸 cover — BUG-1298', () {
+    const String path =
+        'lib/src/pages/implementations/media_collection_detail_page.dart';
+    final String body = _functionSource(
+      File(path).readAsStringSync(),
+      'Widget _buildHero(',
+    );
+
+    expect(
+      body,
+      contains('LandscapeCoverImage('),
+      reason: 'hero 封面必须经 LandscapeCoverImage 按朝向分流；直接 Image(...) '
+          '会把 2:3 刮削海报裁成中间一条（BUG-1298）',
+    );
+    // 词边界不可省：`LandscapeCoverImage(` 本身就以 `Image(` 结尾，不加负向后行
+    // 断言的话，正确写法只要把 `key:` 行删掉就会被误判成回归（变异实测抓到的）。
+    expect(
+      body,
+      isNot(contains(RegExp(r'(?<![A-Za-z_])Image\(\s*image: cover'))),
+      reason: 'hero 不得绕过 LandscapeCoverImage 直接渲染 cover——那正是 '
+          'BUG-1298 的原始写法',
+    );
+    expect(
+      body,
+      contains('overlays: overlays'),
+      reason: '两层可读性渐变必须作为 overlays 交给 LandscapeCoverImage 排层序，'
+          '留在 hero 自己的 Stack 里会压黑竖版海报',
+    );
+  });
+}
+
+const ValueKey<String> _overlayKey = ValueKey<String>('test-overlay');
+
+/// 把组件放进一个与真实 hero 同比例（2.7:1）的槽里 pump，并等图片解码完成。
+Future<void> _pumpHero(WidgetTester tester, ImageProvider provider) async {
+  // 先把图解码进 ImageCache（真实事件循环内），这样组件 resolve 时同步命中，
+  // 首帧就能拿到固有尺寸，避免测试依赖「等几毫秒」这类时序偶然。
+  await tester.runAsync(() => _awaitDecode(provider));
+
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 1080,
+            height: 400,
+            child: LandscapeCoverImage(
+              image: provider,
+              overlays: const <Widget>[
+                DecoratedBox(
+                  key: _overlayKey,
+                  decoration: BoxDecoration(color: Color(0x52000000)),
+                ),
+              ],
+              foregroundPadding: const EdgeInsetsDirectional.only(
+                top: kToolbarHeight,
+                bottom: 24,
+                end: 16,
+              ),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+/// 是否存在一个采用 [fit] 的 [Image]（前景/垫底共用同一 provider，故按 fit 判定）。
+bool _fitOfImageWith(WidgetTester tester, BoxFit fit) => tester
+    .widgetList<Image>(find.byType(Image))
+    .any((Image image) => image.fit == fit);
+
+/// 解码 [provider] 并在首帧到达后完成（须在 `runAsync` 内调用）。
+Future<void> _awaitDecode(ImageProvider provider) {
+  final Completer<void> completer = Completer<void>();
+  final ImageStream stream = provider.resolve(ImageConfiguration.empty);
+  late final ImageStreamListener listener;
+  listener = ImageStreamListener(
+    (ImageInfo info, bool _) {
+      info.dispose();
+      stream.removeListener(listener);
+      if (!completer.isCompleted) completer.complete();
+    },
+    onError: (Object error, StackTrace? stackTrace) {
+      stream.removeListener(listener);
+      if (!completer.isCompleted) completer.completeError(error);
+    },
+  );
+  stream.addListener(listener);
+  return completer.future;
+}
+
+/// 生成 [w]×[h] 的实色 PNG 字节（须在 `runAsync` 内调用：走真实 GPU/IO 事件循环）。
+Future<Uint8List> _solidPngBytes(WidgetTester tester, int w, int h) async {
+  Uint8List? bytes;
+  await tester.runAsync(() async {
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    final Canvas canvas = Canvas(recorder);
+    canvas.drawRect(
+      Rect.fromLTWH(0, 0, w.toDouble(), h.toDouble()),
+      Paint()..color = const Color(0xFF3366AA),
+    );
+    final ui.Picture picture = recorder.endRecording();
+    final ui.Image image = await picture.toImage(w, h);
+    final ByteData? data =
+        await image.toByteData(format: ui.ImageByteFormat.png);
+    image.dispose();
+    picture.dispose();
+    bytes = data!.buffer.asUint8List();
+  });
+  expect(bytes, isNotNull, reason: 'PNG 生成失败，测试无效');
+  return bytes!;
+}
+
+/// 截取从 [startToken] 起到下一个顶层 `  Widget xxx(` 方法定义之前的源码片段。
+String _functionSource(String source, String startToken) {
+  final int start = source.indexOf(startToken);
+  expect(start, isNonNegative, reason: 'missing $startToken');
+  final RegExp nextWidget = RegExp(r'\n  Widget [_A-Za-z0-9]+\(');
+  final RegExpMatch? next = nextWidget.firstMatch(
+    source.substring(start + startToken.length),
+  );
+  final int end =
+      next == null ? source.length : start + startToken.length + next.start + 1;
+  return source.substring(start, end);
+}


### PR DESCRIPTION
## 用户报告

截图「刮削封面以后成这样了」——合集 `Tensei Oujo to Tensai Reijou no Mahou Kakumei v2 播放列表` 的详情页 hero 变成一条糊满人脸、头顶被切的横带。

## 根因

`media_collection_detail_page.dart` 的 `_buildHero` 是**宽幅槽**：宽 = 整屏，高 = `(screenH * 0.62).clamp(400, 600)`，比例约 **2.7:1**。它的图源 `_heroCover` **第一优先**取 `MediaCollections.coverPath` —— 而刮削正是往这一列写**竖版海报**。

用户生产库实测：`media_collections.id=69` → `video_covers/collections/69.jpg` = **853×1200（2:3，比例 0.711）**。

原先无条件 `BoxFit.cover`：缩放因子取 `max(3840/853, 1400/1200) = 4.5`，缩放后 3840×5400，垂直裁掉 4000px —— **只剩海报中间 26% 的高度带**。

刮削**前** `cover_path` 为 NULL，回落到成员抽帧（16:9≈1.78），cover 只裁掉约 35%，看着正常 —— 所以现象精确表现为「刮削封面以后成这样了」，而不是一直就坏。

更深一层：`media_collections` 只有单一 `cover_path` 列（无 backdrop 列），一个列同时服务 2:3 网格卡与 2.7:1 hero 两种朝向，矛盾在数据层无处安放，故朝向判定必须落在渲染层。

## 修复

新增 `LandscapeCoverImage` —— 既有 `PortraitCoverImage` 的**镜像**（那个管「竖槽装横图」，这个管「横槽装竖图」）：

- 横图（宽高比 ≥ 1.2，抽帧 16:9）→ 仍 `BoxFit.cover` 铺满，**与修复前逐像素相同**；
- 竖图（刮削海报 2:3）→ 同图模糊垫底（sigma 28）+ 压暗 + 前景 `contain` 完整显示，靠尾侧避让 hero 左下的标题/进度/播放按钮；
- 首帧解码前尺寸未知 → 按横图渲染（= 修复前行为），`ImageStream` 拿到固有尺寸后再切，不闪换；
- hero 两层可读性渐变改为 `overlays` 注入组件排层序：渐变压在模糊垫底**之上**（保住文字可读）、清晰海报**之下**（否则底部 `0xE8` 的渐变把海报下半截压成一片黑，等于换个方式毁掉海报）。

## 测试

`hibiki/test/pages/collection_hero_cover_orientation_test.dart`（4 例）：横图仍 cover 且无垫底 / 竖图（用实测 853×1200）有垫底且前景 contain / 竖图层序 / 源码守卫锁调用点不得回退裸 `Image`。

**变异实测**（防假绿，4 轮全部按预期红/绿）：
1. 阈值 `1.2 → 0.5` → 竖图 2 例红、横图与源码守卫绿；
2. `overlays` 与前景对调 → 仅层序 1 例红；
3. / 4. 调用点换回裸 `Image` → 源码守卫红。

变异中抓到守卫**自身**的缺陷并已修：原正则 `Image\(\s*image: cover` 会匹配 `LandscapeCoverImage(` 的尾部（它就以 `Image(` 结尾），当时之所以绿只是因为中间恰好隔了一行 `key:`；删掉 `key:` 行这一**等价正确写法**会被误判成回归。已收紧为 `(?<![A-Za-z_])Image\(\s*image: cover`，并实测「删 key 行仍绿 / 裸 Image 仍红」。

## 验证

- `flutter analyze`（全量，含 test）→ No issues found
- `dart run tool/flutter_test_failures.dart --no-pub` 跑本用例 + 8 个相邻合集/封面测试 → `FLUTTER TEST VERDICT: PASSED - 51 tests ran`

未做真机目视复核（本轮按会话纪律不做真机验证），视觉效果仅由上述结构断言保证。

## 范围说明

本轮只做渲染层根因修复，对存量已刮削数据立即生效、零迁移。数据层的彻底解法（`media_collections` 增独立横版 backdrop 列、刮削同时抓 backdrop、hero 优先用 backdrop 而海报只喂 2:3 网格卡）需要 schema bump + 刮削源改造，**未在本轮范围内**；本修复是那条路落地后的天然回落路径，不冲突。

同源但不同槽向的既有条目见 BUG-1272。

https://claude.ai/code/session_019NLAP1UZArhBVCnhTMLgDx