### PR TITLE
fix(ui): 修复 develop 上红的 MD3 页面 chrome 守卫（TODO-2403）

### DIFF
--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -310,15 +310,16 @@ class _BangumiWatchedDialogState extends State<_BangumiWatchedDialog> {
               itemBuilder: (BuildContext context, int index) {
                 final BangumiWatchedItem item = watched[index];
                 final String? coverUrl = item.subject.coverUrl;
-                return ListTile(
-                  contentPadding: EdgeInsets.zero,
+                return HibikiListItem(
+                  padding: EdgeInsets.zero,
+                  titleMaxLines: 2,
                   leading: SizedBox(
                     width: 42,
                     height: 56,
                     child: coverUrl == null
                         ? const Icon(Icons.movie_outlined)
                         : ClipRRect(
-                            borderRadius: BorderRadius.circular(4),
+                            borderRadius: HibikiBorderRadius.chip,
                             child: Image.network(
                               coverUrl,
                               fit: BoxFit.cover,

--- a/hibiki/lib/src/pages/implementations/jimaku_entry_picker.dart
+++ b/hibiki/lib/src/pages/implementations/jimaku_entry_picker.dart
@@ -59,69 +59,56 @@ class JimakuEntryPicker extends StatelessWidget {
   Widget _buildEntryChoice(BuildContext context, JimakuEntry entry) {
     final ThemeData theme = Theme.of(context);
     final bool selected = selectedEntryId == entry.id;
-    return Material(
+    return HibikiCard(
       key: ValueKey<String>('jimaku_entry_${entry.id}'),
-      color: selected
-          ? theme.colorScheme.secondaryContainer
-          : theme.colorScheme.surfaceContainerLow,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-        side: BorderSide(
-          color: selected
-              ? theme.colorScheme.primary
-              : theme.colorScheme.outlineVariant,
-        ),
-      ),
-      clipBehavior: Clip.antiAlias,
-      child: InkWell(
-        onTap: enabled ? () => onSelected(entry) : null,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.only(top: 2),
-                child: Icon(
-                  selected
-                      ? Icons.radio_button_checked
-                      : Icons.radio_button_unchecked,
-                  size: 20,
-                  color: selected
-                      ? theme.colorScheme.primary
-                      : theme.colorScheme.onSurfaceVariant,
-                ),
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: <Widget>[
-                    Text(
-                      entry.name,
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                      style: theme.textTheme.bodyLarge,
-                    ),
-                    const SizedBox(height: 2),
-                    Text(
-                      <String>[
-                        'Jimaku #${entry.id}',
-                        if (entry.anilistId != null)
-                          'AniList #${entry.anilistId}',
-                      ].join(' · '),
-                      style: theme.textTheme.labelSmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                    const SizedBox(height: 4),
-                    _buildInventorySummary(theme, entry.id),
-                  ],
-                ),
-              ),
-            ],
+      selected: selected,
+      borderColor: selected
+          ? theme.colorScheme.primary
+          : theme.colorScheme.outlineVariant,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      onTap: enabled ? () => onSelected(entry) : null,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.only(top: 2),
+            child: Icon(
+              selected
+                  ? Icons.radio_button_checked
+                  : Icons.radio_button_unchecked,
+              size: 20,
+              color: selected
+                  ? theme.colorScheme.primary
+                  : theme.colorScheme.onSurfaceVariant,
+            ),
           ),
-        ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  entry.name,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyLarge,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  <String>[
+                    'Jimaku #${entry.id}',
+                    if (entry.anilistId != null) 'AniList #${entry.anilistId}',
+                  ].join(' · '),
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                _buildInventorySummary(theme, entry.id),
+              ],
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## 问题

`hibiki/test/settings/md3_design_system_static_test.dart` 的
`ordinary page chrome does not reopen local MD3 decisions` 在 develop
`a2011e7e1`（build 1052）上是红的。复现命中两个文件（不是 `Card(`——
`HibikiCard(` 被 `_withoutSharedComponentNames` 遮蔽过，13 处全是共享组件）：

```
lib/src/pages/implementations/home_dashboard_page.dart: BorderRadius.circular(, ListTile(
lib/src/pages/implementations/jimaku_entry_picker.dart: BorderRadius.circular(, surfaceContainerLow
```

集成流水线按指示只跑 `flutter analyze` 不跑 `flutter test`，所以这条**测试红**
（analyze 是绿的）一路合进了 develop。

## 修法：两处都改共享组件，不加 allowlist

用例名说的是**页面 chrome**；这两处一个是对话框列表行、一个是选项卡片，
都不是内容/预览/图表渲染，不属于 allowlist 里既有的豁免类，所以走首选路径。

| 文件 | 原写法 | 改成 |
|---|---|---|
| `home_dashboard_page.dart`（Bangumi 已看条目对话框，PR#577 带入） | 裸 `ListTile(contentPadding: zero, ...)`；封面缩略图 `ClipRRect(BorderRadius.circular(4))` | `HibikiListItem(padding: zero, titleMaxLines: 2, ...)`；圆角走 `HibikiBorderRadius.chip` token |
| `jimaku_entry_picker.dart`（字幕条目选择行） | 手抄 `Material(color: selected ? secondaryContainer : surfaceContainerLow, shape: RoundedRectangleBorder(BorderRadius.circular(12), side), clipBehavior) > InkWell > Padding > Row` | `HibikiCard(selected:, borderColor:, padding:, onTap:, child: Row)`——少三层嵌套，圆角/卡面色交给共享组件的 token |

`forbidden` 列表与 `_forbiddenChromeHits` / `_withoutSharedComponentNames`
扫描逻辑**未改动**，全仓覆盖不变。

### 视觉差异（已知且有意）

`jimaku_entry_picker` 的未选中面色从 `surfaceContainerLow` 变成 `HibikiCard`
默认的 `tokens.surfaces.card`（= `surfaceContainer`），圆角从 12 变成
`cardRadius`（10）。这正是守卫要求的「圆角/面色由共享 MD3 决定」，不再由页面
本地重开一套。选中态（`secondaryContainer`）与描边颜色逐字保留；
`ValueKey('jimaku_entry_<id>')` 保留，`test/pages/jimaku_entry_picker_test.dart` 仍绿。

`HibikiCard` 在有 focus root 时会把可点卡片挂进 `HibikiFocusTarget`——
与全仓其它卡片行为一致，属于顺带对齐。

## 验证

- `flutter analyze`（含 test）：`No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/settings test/pages/jimaku_entry_picker_test.dart test/pages/home_dashboard_page_test.dart` → 目标用例已绿。
- **未动** `hibiki/pubspec.yaml` 的 `+build`，**未动**任何 BUG 号。

## develop 上另有一条独立的红（本 PR 不修）

`test/settings/settings_schema_coverage_test.dart` ——
`all settings destinations: focus-driven, change persists and takes effect`

```
ItemVerdict:[slider] video/Secondary subtitle position
  reached=true changed=true persisted=true effect=false restored=true FAIL
```

「主/副字幕垂直位置分开调节」（`06658fb36`，经 **PR#610** 合入）新增了
`video_setting_subtitle_position_secondary` 滑杆，但没在
`kCoveredElsewhere` 里登记 effect 验证归属，守卫按「不允许静默缺口」判红。
已用 `git show HEAD:<file>` 还原基线文件复跑确认：**与本 PR 无关，基线
`a2011e7e1` 上同样红**。
