### PR TITLE
feat(mining): 制卡封面动图支持 AVIF/WebP，默认 AVIF，顶格档恢复原图直通

### DIFF
--- a/.github/workflows/ffmpeg-min.yml
+++ b/.github/workflows/ffmpeg-min.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Install deps (Linux)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg nasm yasm pkg-config zlib1g-dev libx264-dev libgnutls28-dev
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg nasm yasm pkg-config zlib1g-dev libx264-dev libgnutls28-dev libsvtav1-dev libwebp-dev
 
       - name: Install deps (macOS)
         if: runner.os == 'macOS'
-        run: brew install ffmpeg nasm pkg-config x264
+        run: brew install ffmpeg nasm pkg-config x264 svt-av1 webp
 
       - name: Setup MSYS2 (Windows)
         if: runner.os == 'Windows'
@@ -58,7 +58,7 @@ jobs:
             base-devel git
             mingw-w64-x86_64-gcc mingw-w64-x86_64-nasm
             mingw-w64-x86_64-pkgconf mingw-w64-x86_64-zlib
-            mingw-w64-x86_64-x264
+            mingw-w64-x86_64-x264 mingw-w64-x86_64-svt-av1 mingw-w64-x86_64-libwebp
             mingw-w64-x86_64-ffmpeg
 
       - name: Build (Linux/macOS)

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 48569 (2857 per locale)
+/// Strings: 48688 (2864 per locale)
 ///
-/// Built on 2026-07-31 at 14:41 UTC
+/// Built on 2026-07-31 at 16:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3854,6 +3854,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  String get video_mining_animated_format => 'Video card animation format';
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  String get gal_mining_animated_format => 'Game card animation format';
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -10414,6 +10423,22 @@ class _StringsAr extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -17041,6 +17066,22 @@ class _StringsDe extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -23684,6 +23725,22 @@ class _StringsEs extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -30338,6 +30395,22 @@ class _StringsFr extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -36921,6 +36994,22 @@ class _StringsId extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -43550,6 +43639,22 @@ class _StringsIt extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -49996,6 +50101,22 @@ class _StringsJa extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -56444,6 +56565,22 @@ class _StringsKo extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -63053,6 +63190,22 @@ class _StringsNl extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -69675,6 +69828,22 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -76281,6 +76450,22 @@ class _StringsRu extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -82835,6 +83020,22 @@ class _StringsTh extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -89421,6 +89622,22 @@ class _StringsTr extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -95992,6 +96209,22 @@ class _StringsVi extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 // Path: <root>
@@ -102100,6 +102333,22 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'Hibiki 生成的卡片把词性标签和词典名放在同一个标签里，两者无法分开设置样式。';
+  @override
+  String get mining_animated_format_avif => 'AVIF（体积最小）';
+  @override
+  String get mining_animated_format_webp => 'WebP（兼容性更广）';
+  @override
+  String get mining_animated_format_gif => 'GIF（兼容性最好）';
+  @override
+  String get video_mining_animated_format => '视频制卡动图格式';
+  @override
+  String get video_mining_animated_format_hint =>
+      '同画质下 AVIF 体积远小于 GIF，也是唯一在最高清晰度档保留源分辨率与源帧率的格式。捆绑的编码器产不出时会自动回退 GIF。';
+  @override
+  String get gal_mining_animated_format => '游戏制卡动图格式';
+  @override
+  String get gal_mining_animated_format_hint =>
+      '与视频制卡同样的格式，但分开保存：galgame 一句台词内画面基本静止，取舍不同。';
 }
 
 // Path: <root>
@@ -108467,6 +108716,22 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get anki_lapis_visual_field_dictionary_name_note =>
       'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+  @override
+  String get mining_animated_format_avif => 'AVIF (smallest)';
+  @override
+  String get mining_animated_format_webp => 'WebP (wider support)';
+  @override
+  String get mining_animated_format_gif => 'GIF (most compatible)';
+  @override
+  String get video_mining_animated_format => 'Video card animation format';
+  @override
+  String get video_mining_animated_format_hint =>
+      'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+  @override
+  String get gal_mining_animated_format => 'Game card animation format';
+  @override
+  String get gal_mining_animated_format_hint =>
+      'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
 }
 
 /// Flat map(s) containing all translations.
@@ -114329,6 +114594,20 @@ extension on _StringsEn {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -120189,6 +120468,20 @@ extension on _StringsAr {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -126071,6 +126364,20 @@ extension on _StringsDe {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -131952,6 +132259,20 @@ extension on _StringsEs {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -137839,6 +138160,20 @@ extension on _StringsFr {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -143708,6 +144043,20 @@ extension on _StringsId {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -149591,6 +149940,20 @@ extension on _StringsIt {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -155436,6 +155799,20 @@ extension on _StringsJa {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -161285,6 +161662,20 @@ extension on _StringsKo {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -167162,6 +167553,20 @@ extension on _StringsNl {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -173036,6 +173441,20 @@ extension on _StringsPtBr {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -178915,6 +179334,20 @@ extension on _StringsRu {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -184777,6 +185210,20 @@ extension on _StringsTh {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -190648,6 +191095,20 @@ extension on _StringsTr {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -196515,6 +196976,20 @@ extension on _StringsVi {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }
@@ -202330,6 +202805,20 @@ extension on _StringsZhCn {
         return '仅在保留多段释义的卡片上可见；只有一段释义的卡片不会显示。';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'Hibiki 生成的卡片把词性标签和词典名放在同一个标签里，两者无法分开设置样式。';
+      case 'mining_animated_format_avif':
+        return 'AVIF（体积最小）';
+      case 'mining_animated_format_webp':
+        return 'WebP（兼容性更广）';
+      case 'mining_animated_format_gif':
+        return 'GIF（兼容性最好）';
+      case 'video_mining_animated_format':
+        return '视频制卡动图格式';
+      case 'video_mining_animated_format_hint':
+        return '同画质下 AVIF 体积远小于 GIF，也是唯一在最高清晰度档保留源分辨率与源帧率的格式。捆绑的编码器产不出时会自动回退 GIF。';
+      case 'gal_mining_animated_format':
+        return '游戏制卡动图格式';
+      case 'gal_mining_animated_format_hint':
+        return '与视频制卡同样的格式，但分开保存：galgame 一句台词内画面基本静止，取舍不同。';
       default:
         return null;
     }
@@ -208170,6 +208659,20 @@ extension on _StringsZhHk {
         return 'Only visible on cards that keep more than one definition block; single-definition cards hide it.';
       case 'anki_lapis_visual_field_dictionary_name_note':
         return 'On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.';
+      case 'mining_animated_format_avif':
+        return 'AVIF (smallest)';
+      case 'mining_animated_format_webp':
+        return 'WebP (wider support)';
+      case 'mining_animated_format_gif':
+        return 'GIF (most compatible)';
+      case 'video_mining_animated_format':
+        return 'Video card animation format';
+      case 'video_mining_animated_format_hint':
+        return 'AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.';
+      case 'gal_mining_animated_format':
+        return 'Game card animation format';
+      case 'gal_mining_animated_format_hint':
+        return 'Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "内边距",
   "anki_lapis_visual_margin": "外边距",
   "anki_lapis_visual_field_definition_info_note": "仅在保留多段释义的卡片上可见；只有一段释义的卡片不会显示。",
-  "anki_lapis_visual_field_dictionary_name_note": "Hibiki 生成的卡片把词性标签和词典名放在同一个标签里，两者无法分开设置样式。"
+  "anki_lapis_visual_field_dictionary_name_note": "Hibiki 生成的卡片把词性标签和词典名放在同一个标签里，两者无法分开设置样式。",
+  "mining_animated_format_avif": "AVIF（体积最小）",
+  "mining_animated_format_webp": "WebP（兼容性更广）",
+  "mining_animated_format_gif": "GIF（兼容性最好）",
+  "video_mining_animated_format": "视频制卡动图格式",
+  "video_mining_animated_format_hint": "同画质下 AVIF 体积远小于 GIF，也是唯一在最高清晰度档保留源分辨率与源帧率的格式。捆绑的编码器产不出时会自动回退 GIF。",
+  "gal_mining_animated_format": "游戏制卡动图格式",
+  "gal_mining_animated_format_hint": "与视频制卡同样的格式，但分开保存：galgame 一句台词内画面基本静止，取舍不同。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2855,5 +2855,12 @@
   "anki_lapis_visual_padding": "Inner spacing",
   "anki_lapis_visual_margin": "Outer spacing",
   "anki_lapis_visual_field_definition_info_note": "Only visible on cards that keep more than one definition block; single-definition cards hide it.",
-  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately."
+  "anki_lapis_visual_field_dictionary_name_note": "On Hibiki cards this label also carries the part-of-speech tags, so the two cannot be styled separately.",
+  "mining_animated_format_avif": "AVIF (smallest)",
+  "mining_animated_format_webp": "WebP (wider support)",
+  "mining_animated_format_gif": "GIF (most compatible)",
+  "video_mining_animated_format": "Video card animation format",
+  "video_mining_animated_format_hint": "AVIF is far smaller than GIF at the same quality and is the only format whose top quality tier keeps the source resolution and frame rate. Falls back to GIF automatically when the bundled encoder cannot produce it.",
+  "gal_mining_animated_format": "Game card animation format",
+  "gal_mining_animated_format_hint": "Same formats as video cards, stored separately: a galgame frame barely moves within one line, so the trade-off differs."
 }

--- a/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
+++ b/hibiki/lib/src/mining/gal_hook_mining_coordinator.dart
@@ -16,7 +16,10 @@ import 'package:hibiki/src/sync/texthooker_service.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 
-typedef GalHookGifCapture = Future<Uint8List?> Function({required int hwnd});
+typedef GalHookGifCapture = Future<GalWindowAnimatedCapture?> Function({
+  required int hwnd,
+  MiningAnimatedFormat format,
+});
 typedef GalHookStillCapture = Future<WindowCaptureResult> Function(int hwnd);
 typedef GalHookTempDirectoryFactory = Future<Directory> Function();
 typedef GalHookLineLookup = TexthookerLineEntry? Function(String lineId);
@@ -104,8 +107,11 @@ class GalHookMiningCoordinator {
 
   final SerialJobQueue _miningQueue = SerialJobQueue();
 
-  static Future<Uint8List?> _defaultCaptureGif({required int hwnd}) =>
-      captureWindowGifBytes(hwnd: hwnd);
+  static Future<GalWindowAnimatedCapture?> _defaultCaptureGif({
+    required int hwnd,
+    MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+  }) =>
+      captureWindowGifBytes(hwnd: hwnd, format: format);
 
   static Future<Directory> _defaultCreateTempDirectory() =>
       Directory.systemTemp.createTemp('hibiki-gal-card-job-');
@@ -120,6 +126,8 @@ class GalHookMiningCoordinator {
     // 缺省 gif = 旧行为逐字等价（Never break userspace）；调用方透传
     // [AppModel.galMiningImageMode]。
     VideoMiningImageMode imageMode = VideoMiningImageMode.gif,
+    // 缺省 gif = 旧行为逐字等价；调用方透传 [AppModel.galMiningAnimatedFormat]（默认 avif）。
+    MiningAnimatedFormat animatedFormat = MiningAnimatedFormat.gif,
   }) {
     // 串行化 + 永不毒化（BUG-956）：单次制卡异常（含错误日志自身抛）不得让后续制卡永久挂起。
     return _miningQueue.enqueue<GalHookMiningResult>(
@@ -131,6 +139,7 @@ class GalHookMiningCoordinator {
         updateNoteId: updateNoteId,
         addTitleTag: addTitleTag,
         imageMode: imageMode,
+        animatedFormat: animatedFormat,
       ),
       buildFailure: (Object error, StackTrace stack) =>
           GalHookMiningResult(failureReason: error.toString()),
@@ -150,6 +159,7 @@ class GalHookMiningCoordinator {
     required int? updateNoteId,
     required bool addTitleTag,
     required VideoMiningImageMode imageMode,
+    required MiningAnimatedFormat animatedFormat,
   }) async {
     final TexthookerLineEntry? entry = _lineLookup(lineId);
     if (entry == null || !_lineValidator(entry)) {
@@ -216,7 +226,16 @@ class GalHookMiningCoordinator {
       coverBytes = still.pngBytes;
       coverName = 'external_window.png';
     } else {
-      coverBytes = await _captureGif(hwnd: window.hwnd);
+      final GalWindowAnimatedCapture? animated = await _captureGif(
+        hwnd: window.hwnd,
+        format: animatedFormat,
+      );
+      // 文件名一律取**实际产出格式**而非用户所选：捕获内部会在编码器缺失时降级 GIF，
+      // 按所选格式拼名会写出 `.avif` 里装 GIF 字节的卡（Anki 按扩展名判 MIME → 图不显示）。
+      coverBytes = animated?.bytes;
+      if (animated != null) {
+        coverName = 'external_window.${animated.format.fileExtension}';
+      }
       if (coverBytes == null || coverBytes.isEmpty) {
         final WindowCaptureResult still = await captureStillWithDiagnostics();
         if (!still.ok) {

--- a/hibiki/lib/src/mining/galgame_window_gif.dart
+++ b/hibiki/lib/src/mining/galgame_window_gif.dart
@@ -118,12 +118,19 @@ Future<GalWindowAnimatedCapture?> captureWindowGifBytes({
           output.lengthSync() > 0) {
         return (bytes: await output.readAsBytes(), format: attempt);
       }
-      // 编码失败 / 超时（returnCode==null）：记日志。非末次则继续降级尝试。
-      ErrorLogService.instance.log(
-        'captureWindowGifBytes',
-        '${attempt.wireName} encode failed: ${result.failureSummary}',
-        StackTrace.current,
-      );
+      // 编码失败 / 超时（returnCode==null）。**非末次尝试只记诊断日志**：捆绑的
+      // ffmpeg 缺 libsvtav1/libwebp 时首选格式是 100% 必然失败的，随后降级 GIF 会
+      // 成功、卡照样建得出来。把这条必然发生的能力探测写进用户可见错误日志，等于
+      // 每制一张卡就塞一条「错误」。末次（GIF 也失败）才是真失败，仍进错误日志。
+      final String summary =
+          '${attempt.wireName} encode failed: ${result.failureSummary}';
+      if (attempt == attempts.last) {
+        ErrorLogService.instance
+            .log('captureWindowGifBytes', summary, StackTrace.current);
+      } else {
+        ErrorLogService.instance.logDiagnostic('captureWindowGifBytes',
+            '$summary (falling back to ${MiningAnimatedFormat.gif.wireName})');
+      }
     }
     return null;
   } on ProcessException catch (e, stack) {

--- a/hibiki/lib/src/mining/galgame_window_gif.dart
+++ b/hibiki/lib/src/mining/galgame_window_gif.dart
@@ -3,28 +3,45 @@ import 'dart:typed_data';
 
 import 'package:hibiki/src/media/video/ffmpeg_backend.dart'
     show FfmpegRunResult, resolveFfmpegBackend;
+import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart'
+    show animatedEncoderArgs;
+import 'package:hibiki/src/mining/immersion_mining_request.dart'
+    show MiningAnimatedFormat;
 import 'package:hibiki/src/mining/window_capture_channel.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:path/path.dart' as p;
 
-/// galgame 一键制卡「画面」默认动图（短 GIF，抓角色口型/眨眼）：连续对绑定窗口抓多帧
-/// 静态截图，再用**复用的桌面 ffmpeg 后端**（`resolveFfmpegBackend()`，与
-/// `desktop_audio_clipper.dart` 里 `extractClipGifViaFfmpeg` 走的是同一后端解析——
-/// 覆盖 `HIBIKI_FFMPEG` > 程序旁捆绑 > PATH）编码成两趟调色板 GIF。
+/// 捕获产物：字节 + **实际编码成的格式**。
+///
+/// 必须把格式带出来，不能让调用方按「用户选了什么」去拼文件名——[captureWindowGifBytes]
+/// 内部会在首选格式编码失败时降级 GIF，两者可以不一致。若调用方自行拼名，就会出现
+/// `external_window.avif` 里装着 GIF 字节：Anki 按扩展名判 MIME，卡片直接显示不出来。
+typedef GalWindowAnimatedCapture = ({
+  Uint8List bytes,
+  MiningAnimatedFormat format,
+});
+
+/// galgame 一键制卡「画面」动图（抓角色口型/眨眼）：连续对绑定窗口抓多帧静态截图，
+/// 再用**复用的桌面 ffmpeg 后端**（`resolveFfmpegBackend()`，与 `desktop_audio_clipper.dart`
+/// 里 `extractClipGifViaFfmpeg` 走的是同一后端解析——覆盖 `HIBIKI_FFMPEG` > 程序旁捆绑
+/// > PATH）按 [format] 编码（默认格式由用户偏好给出，见 [MiningAnimatedFormat]）。
 ///
 /// 纯 Dart + ffmpeg，**不碰 native**（帧捕获仍走既有 [WindowCaptureChannel.captureWindow]，
 /// 那是仅有的窗口捕获通道）。**fail-open**：任一步失败（捕获帧不足 / ffmpeg 缺失 / 编码
 /// 失败 / 任何异常）都返回 null 而不抛，交给调用方回退到单帧截图（Never break）。
 ///
 /// [hwnd] 目标窗口句柄；[frames] 尝试抓的帧数；[intervalMs] 帧间隔（WGC 捕获本身有延迟，
-/// 帧率尽力而为）；[fps] 输出 GIF 帧率；[maxWidth] 输出 GIF 最大宽度（高度按比例）。
+/// 帧率尽力而为）；[fps] 输出帧率；[maxWidth] 输出最大宽度（高度按比例）。
 /// 抓到 <2 帧时返回 null（单帧不成动图，交回退）。
-Future<Uint8List?> captureWindowGifBytes({
+Future<GalWindowAnimatedCapture?> captureWindowGifBytes({
   required int hwnd,
   int frames = 10,
   int intervalMs = 120,
   int fps = 8,
   int maxWidth = 480,
+  // 动图编码格式。默认 [MiningAnimatedFormat.gif] = 旧行为逐字等价（未传的既有调用点
+  // 与测试不受影响）；真实调用点传用户偏好 `gal_mining_animated_format`。
+  MiningAnimatedFormat format = MiningAnimatedFormat.gif,
 }) async {
   // 只在桌面有 CLI ffmpeg 时可用；移动端无 CLI ffmpeg，直接回退单帧（且外部窗口捕获
   // 本就只有 Windows）。不做平台早退硬编码——ffmpeg 后端跑不起来时下面自然 fail-open。
@@ -73,37 +90,41 @@ Future<Uint8List?> captureWindowGifBytes({
     }
 
     final String inputPattern = p.join(tempDir.path, 'frame_%03d.png');
-    final String outputPath = p.join(tempDir.path, 'out.gif');
-    // 两趟调色板（palettegen/paletteuse）避免低质抖动，与视频 cue GIF 同款质量策略。
-    // `-framerate <fps>` 指定图像序列输入帧率；`fps=<fps>` 归一输出帧率；`scale=W:-1`
-    // 按宽度等比缩放。
-    final String filter = 'fps=$fps,scale=$maxWidth:-1:flags=lanczos,'
-        'split[a][b];[a]palettegen[p];[b][p]paletteuse';
-    final List<String> args = <String>[
-      '-y',
-      '-framerate',
-      '$fps',
-      '-i',
-      inputPattern,
-      '-vf',
-      filter,
-      outputPath,
-    ];
 
-    final FfmpegRunResult result =
-        await resolveFfmpegBackend().run(args, const Duration(seconds: 60));
-    final File output = File(outputPath);
-    if (result.returnCode == 0 &&
-        output.existsSync() &&
-        output.lengthSync() > 0) {
-      return await output.readAsBytes();
+    // 首选用户所选格式；失败则降级 GIF 再试一次。这不是「重试掩盖症状」——两次调用
+    // 的**参数不同**，第二次是能力降级：捆绑 ffmpeg 若来自旧版本包，没有 libsvtav1 /
+    // libwebp 编码器（见 tool/ffmpeg-min/build-ffmpeg-min.sh），首选格式必然失败而
+    // GIF 恒可用。降级只做一次，且只在首选不是 GIF 时发生。
+    final List<MiningAnimatedFormat> attempts =
+        format == MiningAnimatedFormat.gif
+            ? <MiningAnimatedFormat>[MiningAnimatedFormat.gif]
+            : <MiningAnimatedFormat>[format, MiningAnimatedFormat.gif];
+
+    for (final MiningAnimatedFormat attempt in attempts) {
+      final String outputPath =
+          p.join(tempDir.path, 'out.${attempt.fileExtension}');
+      final List<String> args = buildGalWindowAnimatedArgs(
+        format: attempt,
+        inputPattern: inputPattern,
+        outputPath: outputPath,
+        fps: fps,
+        maxWidth: maxWidth,
+      );
+      final FfmpegRunResult result =
+          await resolveFfmpegBackend().run(args, const Duration(seconds: 60));
+      final File output = File(outputPath);
+      if (result.returnCode == 0 &&
+          output.existsSync() &&
+          output.lengthSync() > 0) {
+        return (bytes: await output.readAsBytes(), format: attempt);
+      }
+      // 编码失败 / 超时（returnCode==null）：记日志。非末次则继续降级尝试。
+      ErrorLogService.instance.log(
+        'captureWindowGifBytes',
+        '${attempt.wireName} encode failed: ${result.failureSummary}',
+        StackTrace.current,
+      );
     }
-    // 编码失败 / 超时（returnCode==null）：记日志后 fail-open。
-    ErrorLogService.instance.log(
-      'captureWindowGifBytes',
-      'gif encode failed: ${result.failureSummary}',
-      StackTrace.current,
-    );
     return null;
   } on ProcessException catch (e, stack) {
     // ffmpeg 不可用（移动端无 CLI / 未捆绑 / 不在 PATH）：优雅回退单帧。
@@ -113,11 +134,57 @@ Future<Uint8List?> captureWindowGifBytes({
     ErrorLogService.instance.log('captureWindowGifBytes', e, stack);
     return null;
   } finally {
-    // 清理临时目录（含帧 PNG 与 GIF），best-effort。
+    // 清理临时目录（含帧 PNG 与动图产物），best-effort。
     if (tempDir != null) {
       try {
         await tempDir.delete(recursive: true);
       } catch (_) {}
     }
   }
+}
+
+/// 纯函数：构建「PNG 帧序列 → 循环动图」的 ffmpeg 参数表（可单测）。
+///
+/// 与视频侧的 `buildFfmpegClipAnimatedArgs` 是**两条独立链路**，不强行合并：输入形态
+/// 不同（这里是 `-framerate N -i frame_%03d.png` 图像序列，那边是带 `-ss/-t` 的视频
+/// 时间窗），硬合并只会造出一个两边都用不顺的参数集。共享的只有「按格式选编码器」这条
+/// 规则，它由 [MiningAnimatedFormat] 承载。
+///
+/// - GIF：`fps,scale` + 两趟调色板（`palettegen`/`paletteuse`）避免抖动。
+/// - WebP/AVIF：真彩，无需调色板，滤镜退化为 `fps,scale` 单遍。
+///
+/// `scale=W:-1` 按宽度等比缩放。⚠️ GIF 对高度奇偶不敏感，但 AVIF/WebP 编码器要求偶数
+/// 维度，故非 GIF 分支用 `-2`（等比且取偶）而非 `-1`。
+///
+/// 三条分支的参数形态已在带 libsvtav1/libwebp 的真实 ffmpeg 上验证可产出非空文件
+/// （见 `tool/ffmpeg-min/smoke-test.sh` 的同款命令）。**但入库的 ffmpeg-min 尚未含这两个
+/// 编码器**——须重跑 `.github/workflows/ffmpeg-min.yml` 并重新 vendor exe，在那之前
+/// AVIF/WebP 会走 [captureWindowGifBytes] 的降级路径落回 GIF。
+List<String> buildGalWindowAnimatedArgs({
+  required MiningAnimatedFormat format,
+  required String inputPattern,
+  required String outputPath,
+  required int fps,
+  required int maxWidth,
+}) {
+  final bool isGif = format == MiningAnimatedFormat.gif;
+  final String scale = isGif
+      ? 'scale=$maxWidth:-1:flags=lanczos'
+      : 'scale=$maxWidth:-2:flags=lanczos';
+  final String filter = isGif
+      ? 'fps=$fps,$scale,split[a][b];[a]palettegen[p];[b][p]paletteuse'
+      : 'fps=$fps,$scale';
+  return <String>[
+    '-y',
+    '-framerate',
+    '$fps',
+    '-i',
+    inputPattern,
+    '-vf',
+    filter,
+    // 编码器参数与视频 cue 动图**共用同一处真相源**，两条链路不各持一份。
+    ...animatedEncoderArgs(format),
+    if (format != MiningAnimatedFormat.gif) ...<String>['-loop', '0'],
+    outputPath,
+  ];
 }

--- a/hibiki/lib/src/mining/immersion_mining_engine.dart
+++ b/hibiki/lib/src/mining/immersion_mining_engine.dart
@@ -18,6 +18,7 @@ typedef GifExtractor = Future<String?> Function({
   required String outputPath,
   int fps,
   int width,
+  MiningAnimatedFormat format,
   FfmpegFailureReporter? onFailure,
   String? tlsPinSha256,
 });
@@ -166,17 +167,42 @@ class ImmersionMiningEngine {
     // 抽字幕区间动图（GIF）到临时文件；无 src / 无区间 → null。
     Future<String?> tryGif() async {
       if (src == null || !req.hasRange) return null;
-      final String? primary = await _gif(
-        inputPath: src,
-        startMs: req.clipStartMs,
-        endMs: req.clipEndMs,
-        outputPath: '$tempDir/immersion_clip.gif',
-        fps: compression.gifFps,
-        width: compression.gifWidth,
-        onFailure: reportCover,
-        tlsPinSha256: req.mediaSourceTlsPinSha256,
-      );
-      return primary;
+      // 首选用户所选格式；失败则降级 GIF 再试一次。这不是「重试掩盖症状」——两次调用的
+      // **参数不同**，第二次是能力降级：捆绑 ffmpeg 若来自旧版本包，没有 libsvtav1 /
+      // libwebp 编码器（见 tool/ffmpeg-min/build-ffmpeg-min.sh），首选格式必然失败而 GIF
+      // 恒可用。只降一级，且只在首选不是 GIF 时发生；GIF 也失败才轮到既有的单帧降级阶梯。
+      final List<MiningAnimatedFormat> attempts =
+          req.animatedFormat == MiningAnimatedFormat.gif
+              ? <MiningAnimatedFormat>[MiningAnimatedFormat.gif]
+              : <MiningAnimatedFormat>[
+                  req.animatedFormat,
+                  MiningAnimatedFormat.gif,
+                ];
+      for (final MiningAnimatedFormat attempt in attempts) {
+        // 顶格档下 gifFps/gifWidth 是 0（源直通哨兵，只有 AVIF 声明得起）。换格式重试时
+        // 必须改用**该格式自己**的顶格档参数，否则会把「源分辨率 + 源帧率」原样喂给 GIF
+        // ——那正是 BUG-1039 实测 54 MB / 撞 120 秒超时 / AnkiConnect 卡死的配置。
+        // 规则对三种格式一致（AVIF 的 maxTier* 本就是 0/0，代入后不变），不是特例分支。
+        final int fps =
+            compression.gifFps == 0 ? attempt.maxTierFps : compression.gifFps;
+        final int width = compression.gifWidth == 0
+            ? attempt.maxTierWidth
+            : compression.gifWidth;
+        final String? out = await _gif(
+          inputPath: src,
+          startMs: req.clipStartMs,
+          endMs: req.clipEndMs,
+          // 扩展名必须与格式一致：ffmpeg 按扩展名选 muxer。
+          outputPath: '$tempDir/immersion_clip.${attempt.fileExtension}',
+          fps: fps,
+          width: width,
+          format: attempt,
+          onFailure: reportCover,
+          tlsPinSha256: req.mediaSourceTlsPinSha256,
+        );
+        if (out != null) return out;
+      }
+      return null;
     }
 
     // 抽字幕 cue 起始时间点的单帧；无 src → null。

--- a/hibiki/lib/src/mining/immersion_mining_engine.dart
+++ b/hibiki/lib/src/mining/immersion_mining_engine.dart
@@ -19,6 +19,7 @@ typedef GifExtractor = Future<String?> Function({
   int fps,
   int width,
   MiningAnimatedFormat format,
+  bool diagnosticOnly,
   FfmpegFailureReporter? onFailure,
   String? tlsPinSha256,
 });
@@ -179,15 +180,14 @@ class ImmersionMiningEngine {
                   MiningAnimatedFormat.gif,
                 ];
       for (final MiningAnimatedFormat attempt in attempts) {
-        // 顶格档下 gifFps/gifWidth 是 0（源直通哨兵，只有 AVIF 声明得起）。换格式重试时
-        // 必须改用**该格式自己**的顶格档参数，否则会把「源分辨率 + 源帧率」原样喂给 GIF
-        // ——那正是 BUG-1039 实测 54 MB / 撞 120 秒超时 / AnkiConnect 卡死的配置。
-        // 规则对三种格式一致（AVIF 的 maxTier* 本就是 0/0，代入后不变），不是特例分支。
-        final int fps =
-            compression.gifFps == 0 ? attempt.maxTierFps : compression.gifFps;
-        final int width = compression.gifWidth == 0
-            ? attempt.maxTierWidth
-            : compression.gifWidth;
+        // 档位参数一律夹到**本次尝试的格式**自己声明的顶格档上限。顶格档下
+        // compression.gifFps/gifWidth 是按用户所选格式解析出来的（AVIF = 24/1440），
+        // 换格式重试时若原样沿用，就会把这组参数喂给 GIF —— GIF 无帧间压缩，那正是
+        // BUG-1039 实测 54 MB / 撞 120 秒超时 / AnkiConnect 卡死的配置。
+        // 夹取对三种格式、四个档位一致（低档的有限值本就低于任何上限，代入后不变），
+        // 不是特例分支。
+        final int fps = attempt.capFps(compression.gifFps);
+        final int width = attempt.capWidth(compression.gifWidth);
         final String? out = await _gif(
           inputPath: src,
           startMs: req.clipStartMs,
@@ -197,6 +197,8 @@ class ImmersionMiningEngine {
           fps: fps,
           width: width,
           format: attempt,
+          // 还有降级尝试在后面 → 这次失败是预期内的能力探测，只记诊断日志。
+          diagnosticOnly: attempt != attempts.last,
           onFailure: reportCover,
           tlsPinSha256: req.mediaSourceTlsPinSha256,
         );

--- a/hibiki/lib/src/mining/immersion_mining_request.dart
+++ b/hibiki/lib/src/mining/immersion_mining_request.dart
@@ -98,16 +98,17 @@ enum VideoMiningImageMode {
 /// 「格式 × 静态来源」的笛卡尔积（avif/webp/gif × currentFrame/subtitleStart），而格式
 /// 只对动图有意义、静态来源只对静态图有意义。两轴独立取值，各自一个设置项。
 ///
-/// 每种格式自己声明**顶格档（最高清晰度档）用什么参数**（[maxTierFps]/[maxTierWidth]，
-/// `0` = 源帧率/源分辨率直通）。这不是装饰性属性——它是顶格档语义的唯一真相源，
-/// `MiningMediaCompression.resolve` 直接查它，不做「谁是特例」的分支判断。
+/// 每种格式自己声明**顶格档（最高清晰度档）的参数上限**（[maxTierFps]/[maxTierWidth]）。
+/// 这不是装饰性属性——它是顶格档语义的唯一真相源，`MiningMediaCompression.resolve`
+/// 直接查它，不做「谁是特例」的分支判断；[capFps]/[capWidth] 再保证任何来路的参数都
+/// 越不过本格式的上限。
 ///
 /// 为什么不是一个 `hasInterFrameCompression` 布尔（本改动的初版就是那样，被实测推翻）：
-/// 「有没有帧间压缩」是编解码规格问题，而顶格档要回答的是**「源直通跑得动吗」**，
+/// 「有没有帧间压缩」是编解码规格问题，而顶格档要回答的是**「这一档跑得动吗」**，
 /// 两者并不等价。本机 ffmpeg（libsvtav1 / libwebp_anim / native gif）实测，1080p30
 /// 合成源 4 秒窗：
 ///
-/// | 格式 | 标准档 480px·8fps | 原图档 1080p·30fps |
+/// | 格式 | 标准档 480px·8fps | 源分辨率·源帧率 1080p·30fps |
 /// |---|---|---|
 /// | gif  | 1973 ms / 471 KB | 11978 ms / 17.8 MB |
 /// | webp |  877 ms / 163 KB | **16383 ms** / 5.19 MB |
@@ -115,15 +116,32 @@ enum VideoMiningImageMode {
 ///
 /// WebP 规格上确有帧间差分，实测却是三者里**最慢**的——`libwebp_anim` 本质是逐帧 VP8
 /// 帧内编码的静态图编码器，没有真正的运动补偿，也不并行；SVT-AV1 是真视频编码器，
-/// 在源分辨率下反而比 GIF 快 3.4 倍。所以 WebP 与 GIF 一样吃封顶值，只有 AVIF 开放源
-/// 直通。GIF 的封顶值仍是 BUG-1039 的实测折中（那次 1080p/4 秒 = 48.9 秒 / 54 MB，
-/// 10 秒 cue 约 135 MB，撞 120 秒超时且 AnkiConnect 卡死）。
+/// 在源分辨率下反而比 GIF 快 3.4 倍。所以 WebP 与 GIF 吃同一组封顶值，AVIF 拿一组
+/// **更宽松但同样有限**的封顶值。GIF/WebP 的封顶值仍是 BUG-1039 的实测折中（那次
+/// 1080p/4 秒 = 48.9 秒 / 54 MB，10 秒 cue 约 135 MB，撞 120 秒超时且 AnkiConnect 卡死）。
+///
+/// ⚠️ **没有任何格式的顶格档是「源分辨率 + 源帧率」直通。** AVIF 一度被配成 `0/0`
+/// （源直通），按 **10 秒 cue 上限**（`buildFfmpegClipAnimatedArgs` 的 `maxDurationMs`
+/// 默认值，而不是上表那个 4 秒窗）重测后撤掉：
+///
+/// | AVIF 顶格档候选（10 秒窗） | 耗时 | 体积 |
+/// |---|---|---|
+/// | 4K30 源直通（旧 `0/0`） | 8537 ms | **34.54 MB** |
+/// | 1080p30 源直通（旧 `0/0`） | 2485 ms | **8.80 MB** |
+/// | **1440px·24fps（现值）** | 2918 ms | **2.91 MB** |
+/// | 960px·12fps（= GIF/WebP 封顶值） | 711 ms | 0.41 MB |
+/// | 同窗真 GIF @960px·12fps 参照 | 1690 ms | 4.97 MB |
+///
+/// 换了更好的编码器，该做的是**抬高**上限而不是删掉上限——BUG-1039 的教训是「顶格档
+/// 不该是不可用配置」，34 MB 的封面照样把 AnkiConnect 和同步打穿。现值 1440px·24fps
+/// 比 GIF/WebP 封顶值宽 1.5 倍、帧率翻倍，产出体积却仍**小于**同窗真 GIF（2.91 MB 对
+/// 4.97 MB）。体积预算守卫见 `test/mining/mining_animated_format_test.dart`。
 ///
 /// ⚠️ 默认值是 [avif] 而非 [gif]：这是本改动**唯一一处有意的现状变更**（老用户升级后
 /// 新卡默认变 AVIF）。[gif] 保留为可选项，既供用户回退，也供捆绑 ffmpeg 不支持新编码器
 /// 时 fail-open 降级（见 `galgame_window_gif.dart` / `desktop_audio_clipper.dart`）。
 enum MiningAnimatedFormat {
-  avif('avif', 'avif', maxTierFps: 0, maxTierWidth: 0),
+  avif('avif', 'avif', maxTierFps: 24, maxTierWidth: 1440),
   webp('webp', 'webp', maxTierFps: 12, maxTierWidth: 960),
   gif('gif', 'gif', maxTierFps: 12, maxTierWidth: 960);
 
@@ -140,15 +158,24 @@ enum MiningAnimatedFormat {
   /// 输出文件扩展名（不含点）。ffmpeg 按扩展名选 muxer，故这也是 muxer 选择依据。
   final String fileExtension;
 
-  /// 顶格档帧率。`0` = 源帧率直通（不加 `fps` 滤镜）。见枚举文档的实测表。
+  /// 顶格档帧率上限。恒为正——没有格式开放源帧率直通，理由见枚举文档的两张实测表。
   final int maxTierFps;
 
-  /// 顶格档宽度（px）。`0` = 源分辨率直通（不加 `scale` 滤镜）。同上。
+  /// 顶格档宽度上限（px）。恒为正——同 [maxTierFps]。
   final int maxTierWidth;
 
-  /// 顶格档是否真的是「原图」（源分辨率 + 源帧率）。仅供 UI 决定顶格档文案该说
-  /// 「原图」还是「最高」——不参与参数计算，参数一律读 [maxTierFps]/[maxTierWidth]。
-  bool get maxTierIsSourcePassthrough => maxTierFps == 0 && maxTierWidth == 0;
+  /// 把 [requested] 帧率夹到本格式的顶格档上限。`<= 0`（历史「源帧率直通」哨兵）同样
+  /// 夹成上限。
+  ///
+  /// 这是 BUG-1039 的收口点：换格式重试时若沿用**上一个格式**的参数，就会把 AVIF 顶格
+  /// 档的 24fps/1440px 原样喂给 GIF（GIF 无帧间压缩，体积线性爆炸）。夹取对三种格式、
+  /// 四个档位一致，不是「谁是特例」的分支。
+  int capFps(int requested) =>
+      (requested <= 0 || requested > maxTierFps) ? maxTierFps : requested;
+
+  /// 把 [requested] 宽度夹到本格式的顶格档上限。语义同 [capFps]。
+  int capWidth(int requested) =>
+      (requested <= 0 || requested > maxTierWidth) ? maxTierWidth : requested;
 
   /// 从偏好字符串解析；未知/null → [avif]（新默认）。
   static MiningAnimatedFormat fromWireName(String? name) {

--- a/hibiki/lib/src/mining/immersion_mining_request.dart
+++ b/hibiki/lib/src/mining/immersion_mining_request.dart
@@ -91,6 +91,74 @@ enum VideoMiningImageMode {
   bool get isStill => this != VideoMiningImageMode.gif;
 }
 
+/// 制卡封面**动图的编码格式**，与 [VideoMiningImageMode] 正交：后者选「用不用动图 +
+/// 静态帧取哪一帧」，本枚举选「动图用什么编码」。默认 [avif]。
+///
+/// 为什么是两个枚举而不是把 avif/webp 并进 [VideoMiningImageMode]：并进去会变成
+/// 「格式 × 静态来源」的笛卡尔积（avif/webp/gif × currentFrame/subtitleStart），而格式
+/// 只对动图有意义、静态来源只对静态图有意义。两轴独立取值，各自一个设置项。
+///
+/// 每种格式自己声明**顶格档（最高清晰度档）用什么参数**（[maxTierFps]/[maxTierWidth]，
+/// `0` = 源帧率/源分辨率直通）。这不是装饰性属性——它是顶格档语义的唯一真相源，
+/// `MiningMediaCompression.resolve` 直接查它，不做「谁是特例」的分支判断。
+///
+/// 为什么不是一个 `hasInterFrameCompression` 布尔（本改动的初版就是那样，被实测推翻）：
+/// 「有没有帧间压缩」是编解码规格问题，而顶格档要回答的是**「源直通跑得动吗」**，
+/// 两者并不等价。本机 ffmpeg（libsvtav1 / libwebp_anim / native gif）实测，1080p30
+/// 合成源 4 秒窗：
+///
+/// | 格式 | 标准档 480px·8fps | 原图档 1080p·30fps |
+/// |---|---|---|
+/// | gif  | 1973 ms / 471 KB | 11978 ms / 17.8 MB |
+/// | webp |  877 ms / 163 KB | **16383 ms** / 5.19 MB |
+/// | avif | 2124 ms /  36 KB | **3502 ms** / 3.32 MB |
+///
+/// WebP 规格上确有帧间差分，实测却是三者里**最慢**的——`libwebp_anim` 本质是逐帧 VP8
+/// 帧内编码的静态图编码器，没有真正的运动补偿，也不并行；SVT-AV1 是真视频编码器，
+/// 在源分辨率下反而比 GIF 快 3.4 倍。所以 WebP 与 GIF 一样吃封顶值，只有 AVIF 开放源
+/// 直通。GIF 的封顶值仍是 BUG-1039 的实测折中（那次 1080p/4 秒 = 48.9 秒 / 54 MB，
+/// 10 秒 cue 约 135 MB，撞 120 秒超时且 AnkiConnect 卡死）。
+///
+/// ⚠️ 默认值是 [avif] 而非 [gif]：这是本改动**唯一一处有意的现状变更**（老用户升级后
+/// 新卡默认变 AVIF）。[gif] 保留为可选项，既供用户回退，也供捆绑 ffmpeg 不支持新编码器
+/// 时 fail-open 降级（见 `galgame_window_gif.dart` / `desktop_audio_clipper.dart`）。
+enum MiningAnimatedFormat {
+  avif('avif', 'avif', maxTierFps: 0, maxTierWidth: 0),
+  webp('webp', 'webp', maxTierFps: 12, maxTierWidth: 960),
+  gif('gif', 'gif', maxTierFps: 12, maxTierWidth: 960);
+
+  const MiningAnimatedFormat(
+    this.wireName,
+    this.fileExtension, {
+    required this.maxTierFps,
+    required this.maxTierWidth,
+  });
+
+  /// 偏好持久化用的稳定字符串键（勿随枚举名改动）。
+  final String wireName;
+
+  /// 输出文件扩展名（不含点）。ffmpeg 按扩展名选 muxer，故这也是 muxer 选择依据。
+  final String fileExtension;
+
+  /// 顶格档帧率。`0` = 源帧率直通（不加 `fps` 滤镜）。见枚举文档的实测表。
+  final int maxTierFps;
+
+  /// 顶格档宽度（px）。`0` = 源分辨率直通（不加 `scale` 滤镜）。同上。
+  final int maxTierWidth;
+
+  /// 顶格档是否真的是「原图」（源分辨率 + 源帧率）。仅供 UI 决定顶格档文案该说
+  /// 「原图」还是「最高」——不参与参数计算，参数一律读 [maxTierFps]/[maxTierWidth]。
+  bool get maxTierIsSourcePassthrough => maxTierFps == 0 && maxTierWidth == 0;
+
+  /// 从偏好字符串解析；未知/null → [avif]（新默认）。
+  static MiningAnimatedFormat fromWireName(String? name) {
+    for (final MiningAnimatedFormat format in MiningAnimatedFormat.values) {
+      if (format.wireName == name) return format;
+    }
+    return MiningAnimatedFormat.avif;
+  }
+}
+
 /// 统一沉浸制卡请求。任何来源（本地/YouTube/Netflix）都构造这个喂 [ImmersionMiningEngine]。
 ///
 /// [mediaSource] 是 ffmpeg 的 inputPath——本地绝对路径 或 可 seek 的 http 流 URL。
@@ -121,6 +189,7 @@ class ImmersionMiningRequest {
     this.providedAudioName,
     this.requireAudio = true,
     this.imageMode = VideoMiningImageMode.gif,
+    this.animatedFormat = MiningAnimatedFormat.gif,
     this.mediaSourceTlsPinSha256,
     this.remoteAudioClipper,
   });
@@ -164,6 +233,15 @@ class ImmersionMiningRequest {
   /// 视频制卡封面图片模式（见 [VideoMiningImageMode]）。默认 [VideoMiningImageMode.gif]
   /// = 现状。仅本地/有 range 的封面解析路径读取；providedCoverBytes 路径不受影响。
   final VideoMiningImageMode imageMode;
+
+  /// 动图编码格式（见 [MiningAnimatedFormat]）。仅 [imageMode] 为
+  /// [VideoMiningImageMode.gif]（= 用动图）时生效。
+  ///
+  /// 这里默认 [MiningAnimatedFormat.gif] 而**用户偏好默认 avif**，两者不矛盾：值对象的
+  /// 默认只服务「没显式指定的调用点/测试」，保证它们逐字节等价于改动前；用户可见的默认
+  /// 由 `MiningAnimatedFormat.fromWireName(null)` 给出（= avif），真实调用点一律显式透传
+  /// 偏好。与 [imageMode] 的默认取法一致。
+  final MiningAnimatedFormat animatedFormat;
 
   /// BUG-891：[mediaSource]/[audioSource] 若是远端自签 Hibiki 主机的 https 流，这里带上
   /// 该 host 经 TOFU 钉扎的证书 SHA-256 指纹（`aa:bb:..`）。引擎把它透传给 ffmpeg 抽取器的
@@ -215,6 +293,7 @@ class ImmersionMiningRequest {
         providedAudioName: providedAudioName,
         requireAudio: requireAudio,
         imageMode: imageMode,
+        animatedFormat: animatedFormat,
         mediaSourceTlsPinSha256: mediaSourceTlsPinSha256,
         remoteAudioClipper: remoteAudioClipper,
       );

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4847,6 +4847,18 @@ class AppModel with ChangeNotifier {
   void setGalMiningImageMode(VideoMiningImageMode mode) =>
       prefsRepo.setGalMiningImageMode(mode);
 
+  // 动图编码格式（AVIF / WebP / GIF，透传 prefsRepo）。默认 avif。与上面的「封面模式」
+  // 正交：模式选用不用动图，格式选动图怎么编码。
+  MiningAnimatedFormat get videoMiningAnimatedFormat =>
+      prefsRepo.videoMiningAnimatedFormat;
+  void setVideoMiningAnimatedFormat(MiningAnimatedFormat format) =>
+      prefsRepo.setVideoMiningAnimatedFormat(format);
+
+  MiningAnimatedFormat get galMiningAnimatedFormat =>
+      prefsRepo.galMiningAnimatedFormat;
+  void setGalMiningAnimatedFormat(MiningAnimatedFormat format) =>
+      prefsRepo.setGalMiningAnimatedFormat(format);
+
   bool get deduplicatePitchAccents => prefsRepo.deduplicatePitchAccents;
   void toggleDeduplicatePitchAccents() =>
       prefsRepo.toggleDeduplicatePitchAccents();

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -11,7 +11,7 @@ import 'package:hibiki/src/media/video/video_immersive_mode.dart';
 import 'package:hibiki/src/media/video/video_subtitle_obscure_mode.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart'
-    show VideoMiningImageMode;
+    show MiningAnimatedFormat, VideoMiningImageMode;
 import 'package:hibiki/src/models/audio_source_config.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart'
     show MiningMediaCompression;
@@ -1359,6 +1359,31 @@ class PreferencesRepository extends ChangeNotifier {
 
   void setGalMiningImageMode(VideoMiningImageMode mode) async {
     await setPref('gal_mining_image_mode', mode.wireName);
+    notifyListeners();
+  }
+
+  // 动图**编码格式**，与上面两个「封面模式」正交：模式选「用不用动图 / 静态帧取哪一帧」，
+  // 格式选「动图用什么编码」。视频与 gal 同样分开存，理由与 image mode 一致（两边画面
+  // 特性不同，共用一个开关会逼用户为一边将就另一边）。
+  //
+  // 默认值不写在这里，由 [MiningAnimatedFormat.fromWireName] 对 null 给出（= avif），
+  // 保证解析未知历史值与「从没设过」走同一条路径。
+  MiningAnimatedFormat get videoMiningAnimatedFormat =>
+      MiningAnimatedFormat.fromWireName(
+          getPref('video_mining_animated_format', defaultValue: null)
+              as String?);
+
+  void setVideoMiningAnimatedFormat(MiningAnimatedFormat format) async {
+    await setPref('video_mining_animated_format', format.wireName);
+    notifyListeners();
+  }
+
+  MiningAnimatedFormat get galMiningAnimatedFormat =>
+      MiningAnimatedFormat.fromWireName(
+          getPref('gal_mining_animated_format', defaultValue: null) as String?);
+
+  void setGalMiningAnimatedFormat(MiningAnimatedFormat format) async {
+    await setPref('gal_mining_animated_format', format.wireName);
     notifyListeners();
   }
 

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -12,7 +12,7 @@ import 'package:hibiki/src/anki/lapis_style_editor_page.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/anki/lapis_template_service.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart'
-    show VideoMiningImageMode;
+    show MiningAnimatedFormat, VideoMiningImageMode;
 import 'package:hibiki/src/profile/profile_selector.dart';
 
 /// Anki 设置正文（无脚手架）。直接平铺进「制卡」设置 destination 详情页
@@ -321,7 +321,9 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
             _buildMiningImageQualityRow(),
             _buildMiningAudioQualityRow(),
             _buildVideoMiningImageModePicker(),
+            _buildVideoMiningAnimatedFormatPicker(),
             _buildGalMiningImageModePicker(),
+            _buildGalMiningAnimatedFormatPicker(),
           ],
         ),
       ],
@@ -453,6 +455,58 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
       },
     );
   }
+
+  /// 动图**编码格式**，与上面两个「封面模式」正交：模式决定用不用动图，格式决定动图
+  /// 怎么编码。视频 / gal 各存一份（同 image mode 的分法）。
+  ///
+  /// 三档共用一套 option 文案（[t.mining_animated_format_avif] 等）——格式本身的含义与
+  /// 场景无关，没必要为两个页面各写一份会漂开的文案。
+  Widget _buildAnimatedFormatPicker({
+    required String title,
+    required String subtitle,
+    required MiningAnimatedFormat selected,
+    required void Function(MiningAnimatedFormat) onChanged,
+  }) {
+    return AdaptiveSettingsPickerRow<MiningAnimatedFormat>(
+      title: title,
+      subtitle: subtitle,
+      icon: Icons.animation_outlined,
+      controlBelow: true,
+      selected: selected,
+      options: [
+        AdaptiveSettingsPickerOption<MiningAnimatedFormat>(
+          value: MiningAnimatedFormat.avif,
+          label: t.mining_animated_format_avif,
+        ),
+        AdaptiveSettingsPickerOption<MiningAnimatedFormat>(
+          value: MiningAnimatedFormat.webp,
+          label: t.mining_animated_format_webp,
+        ),
+        AdaptiveSettingsPickerOption<MiningAnimatedFormat>(
+          value: MiningAnimatedFormat.gif,
+          label: t.mining_animated_format_gif,
+        ),
+      ],
+      onChanged: (MiningAnimatedFormat format) {
+        onChanged(format);
+        setState(() {});
+      },
+    );
+  }
+
+  Widget _buildVideoMiningAnimatedFormatPicker() => _buildAnimatedFormatPicker(
+        title: t.video_mining_animated_format,
+        subtitle: t.video_mining_animated_format_hint,
+        selected: appModel.videoMiningAnimatedFormat,
+        onChanged: appModel.setVideoMiningAnimatedFormat,
+      );
+
+  Widget _buildGalMiningAnimatedFormatPicker() => _buildAnimatedFormatPicker(
+        title: t.gal_mining_animated_format,
+        subtitle: t.gal_mining_animated_format_hint,
+        selected: appModel.galMiningAnimatedFormat,
+        onChanged: appModel.setGalMiningAnimatedFormat,
+      );
 
   Widget _buildFetchTile(AnkiUiState uiState, AnkiViewModel vm) {
     // Lapis 创建在途时 vm 的 isFetching 也为 true（vm 内部复用同一 flag）；

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -515,11 +515,14 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       compression: MiningMediaCompression.resolve(
         imageTier: mixinAppModel.miningImageQuality,
         audioTier: mixinAppModel.miningAudioQuality,
+        // 顶格档的动图参数随格式变，必须一并传入解析（见 MiningAnimatedFormat）。
+        format: mixinAppModel.galMiningAnimatedFormat,
       ),
       repo: repo,
       updateNoteId: updateNoteId,
       addTitleTag: mixinAppModel.autoAddBookNameToTags,
       imageMode: mixinAppModel.galMiningImageMode,
+      animatedFormat: mixinAppModel.galMiningAnimatedFormat,
     );
     if (result.aborted) {
       HibikiToast.showMine(

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
@@ -300,6 +300,9 @@ extension _VideoLookupMining on _VideoHibikiPageState {
         MiningMediaCompression.resolve(
       imageTier: appModel.miningImageQuality,
       audioTier: appModel.miningAudioQuality,
+      // 顶格档的动图参数随格式变（AVIF 源直通 / WebP·GIF 封顶），故必须把格式一并传进来
+      // 解析——否则顶格档会拿到 GIF 的封顶值，用户选了 AVIF 也享受不到原图档。
+      format: appModel.videoMiningAnimatedFormat,
     );
     final String? mediaSource = controller.miningSource;
     final String? audioSource = controller.miningAudioSource;
@@ -308,6 +311,8 @@ extension _VideoLookupMining on _VideoHibikiPageState {
     final int episode = _currentEpisode;
     final String? documentTitle = _videoMiningDocumentTitle();
     final VideoMiningImageMode imageMode = appModel.videoMiningImageMode;
+    final MiningAnimatedFormat animatedFormat =
+        appModel.videoMiningAnimatedFormat;
     final String? bookTitleTag = appModel.autoAddBookNameToTags
         ? BaseAnkiRepository.sanitizeTitleTag(_title)
         : null;
@@ -424,6 +429,9 @@ extension _VideoLookupMining on _VideoHibikiPageState {
         // 用户在 Anki 设置里选的封面图片模式（GIF / 制卡时当前帧 / 字幕开头帧）；
         // 默认 gif=现状。静态模式引擎不置 degradedToStill，故不弹「降级为静态」OSD。
         imageMode: imageMode,
+        // 动图编码格式（默认 AVIF）。引擎在编码失败时会自动降级 GIF 重试一次——旧版本
+        // 包捆绑的 ffmpeg 没有 libsvtav1/libwebp，靠这条保证不会因换默认格式而制不出卡。
+        animatedFormat: animatedFormat,
       ),
       compression: mediaCompression,
       tempDir: tempDir,

--- a/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -205,8 +205,8 @@ Future<String?> materializeRemoteAudioViaRangeDownload({
 /// 不可变值对象（纯数据，可单测、可在隔离中构造）。各底层纯函数（[buildFfmpegClipArgs]
 /// / [buildFfmpegClipGifArgs] / [downsampleCardScreenshot]）仍接收原始可选参数，本类只是
 /// 调用点选档时的参数捆绑，不让纯函数读全局偏好。最高档用 [screenshotMaxLongEdge] == 0
-/// 表示「不缩放」（截图原图直通），由底层纯函数解读；动图侧的 0 哨兵只有 **AVIF** 在顶格
-/// 档产出（WebP/GIF 任何档位都是有限值），依据见 [MiningAnimatedFormat] 与 [resolve]。
+/// 表示「不缩放」（截图原图直通），由底层纯函数解读；**动图侧任何格式、任何档位都是
+/// 有限值**（顶格档上限由格式自己声明，见 [MiningAnimatedFormat] 与 [resolve]）。
 class MiningMediaCompression {
   const MiningMediaCompression({
     required this.audioChannels,
@@ -223,12 +223,12 @@ class MiningMediaCompression {
   /// 音频比特率（`-b:a`，如 `'64k'`）。
   final String audioBitrate;
 
-  /// cue 封面动图帧率（`fps=`）。**0 = 源帧率**（不加 fps 滤镜）。只有「顶格档 + AVIF」
-  /// 会产出 0（见 [resolve]）；WebP/GIF 全档恒为有限值。
+  /// cue 封面动图帧率（`fps=`）。**0 = 源帧率**（不加 fps 滤镜），但 [resolve] 三种格式
+  /// 全档都不再产出 0（顶格档取格式声明的上限）；纯函数仍支持 0 供直接调用方使用。
   final int gifFps;
 
   /// cue 封面动图宽度（`scale=W:-2`）。**0 = 源分辨率**（不加 scale 滤镜）。同 [gifFps]：
-  /// 仅顶格档 + AVIF 产出 0。
+  /// [resolve] 不产出 0。
   final int gifWidth;
 
   /// 帧截图封面降采样长边（px）。**0 = 不缩放**（最高档，原图字节直通）。
@@ -246,9 +246,11 @@ class MiningMediaCompression {
   /// 原图，故改名为「最高」：只承诺是滑块顶格，不承诺具体保真度。
   ///
   /// ⚠️ 顶格档这两个 gif 字段是 `0` 占位，**永远被 [resolve] 用格式自己声明的
-  /// [MiningAnimatedFormat.maxTierFps]/[MiningAnimatedFormat.maxTierWidth] 覆写**。
-  /// 下面那段爆炸分析对 GIF（与实测同样慢的 WebP）永远成立，只有 AVIF 例外——它在源
-  /// 分辨率下比 GIF 还快 3.4 倍，实测表见 [MiningAnimatedFormat]。
+  /// [MiningAnimatedFormat.maxTierFps]/[MiningAnimatedFormat.maxTierWidth] 覆写**，
+  /// 三种格式的覆写结果都是有限值。下面那段爆炸分析对 GIF 和实测同样慢的 WebP 直接
+  /// 成立；AVIF 快得多（源分辨率下比 GIF 快 3.4 倍）故拿到更宽松的上限，但按 10 秒
+  /// cue 上限重测后**同样不开放源直通**（4K30 直通 = 34.5 MB），实测表见
+  /// [MiningAnimatedFormat]。
   ///
   /// BUG-1039：这一档过去对 GIF 也用 0 哨兵（源分辨率 + 源帧率），这是把「截图」的
   /// 语义错套到「动图」上——截图原图直通只是几 MB 的一张 JPEG，而 GIF 是 8-bit 调色板
@@ -334,9 +336,10 @@ class MiningMediaCompression {
   /// 据图片/动图清晰度档 [imageTier] + 音频质量档 [audioTier] 组装媒体档（越界自动夹取）。
   ///
   /// 顶格档（[imageTierMax]）的动图参数取自 [format] 自己声明的
-  /// [MiningAnimatedFormat.maxTierFps]/[MiningAnimatedFormat.maxTierWidth]——AVIF 是
-  /// `0/0`（源分辨率 + 源帧率，真·原图档），WebP/GIF 是封顶值。判据不是「有没有帧间
-  /// 压缩」而是「源直通跑不跑得动」，实测依据见 [MiningAnimatedFormat] 文档。
+  /// [MiningAnimatedFormat.maxTierFps]/[MiningAnimatedFormat.maxTierWidth]——AVIF 拿
+  /// 更宽松的 24fps/1440px，WebP/GIF 拿 12fps/960px，**都是有限值**。判据不是「有没有
+  /// 帧间压缩」而是「这一档在 10 秒 cue 上限下跑不跑得动」，实测依据见
+  /// [MiningAnimatedFormat] 文档。
   ///
   /// 低三档与格式无关：它们的有限值对三种编码器同样有意义，不按格式分叉，免得同一个
   /// 滑块位置在不同格式下含义漂开。截图侧的原图直通语义自始至终没变。
@@ -364,25 +367,40 @@ class MiningMediaCompression {
   }
 }
 
+/// 把一条 ffmpeg 失败摘要落进日志。[diagnosticOnly] = 调用方**还会用降级参数再试一次**
+/// （能力探测），此时失败是预期内的正常降级，只进诊断日志（不计错误数、不进用户可见
+/// 错误日志页）；否则进错误日志。默认 false = 既有行为逐字等价。
+void _logFfmpegSummary(String source, String summary, StackTrace stack,
+    {required bool diagnosticOnly}) {
+  if (diagnosticOnly) {
+    ErrorLogService.instance.logDiagnostic(source, summary);
+  } else {
+    ErrorLogService.instance.log(source, summary, stack);
+  }
+}
+
 void _reportFfmpegFailure(
   String source,
   FfmpegRunResult result,
-  FfmpegFailureReporter? onFailure,
-) {
+  FfmpegFailureReporter? onFailure, {
+  bool diagnosticOnly = false,
+}) {
   final String summary = result.failureSummary;
   onFailure?.call(summary);
-  ErrorLogService.instance.log(source, summary, StackTrace.current);
+  _logFfmpegSummary(source, summary, StackTrace.current,
+      diagnosticOnly: diagnosticOnly);
 }
 
 void _reportFfmpegProcessException(
   String source,
   ProcessException exception,
   StackTrace stack,
-  FfmpegFailureReporter? onFailure,
-) {
+  FfmpegFailureReporter? onFailure, {
+  bool diagnosticOnly = false,
+}) {
   final String summary = describeFfmpegProcessException(exception);
   onFailure?.call(summary);
-  ErrorLogService.instance.log(source, summary, stack);
+  _logFfmpegSummary(source, summary, stack, diagnosticOnly: diagnosticOnly);
 }
 
 /// TODO-1005 / BUG-472：「ffmpeg 还没跑」的早返回（零长/错位区间、输入缺失）统一上报：
@@ -401,11 +419,12 @@ void _reportFfmpegUnexpectedException(
   String source,
   Object error,
   StackTrace stack,
-  FfmpegFailureReporter? onFailure,
-) {
+  FfmpegFailureReporter? onFailure, {
+  bool diagnosticOnly = false,
+}) {
   final String summary = error.toString();
   onFailure?.call(summary);
-  ErrorLogService.instance.log(source, error, stack);
+  _logFfmpegSummary(source, summary, stack, diagnosticOnly: diagnosticOnly);
 }
 
 /// Desktop (Windows/Linux/macOS) audio-clip extraction via ffmpeg.
@@ -800,8 +819,9 @@ List<String> buildFfmpegClipAnimatedArgs({
   final int clampedDur =
       rawDur > maxDurationMs ? maxDurationMs : (rawDur < 1 ? 1 : rawDur);
   final double durationSeconds = clampedDur / 1000.0;
-  // [fps]<=0 / [width]<=0 表示「源帧率 / 源分辨率」（原图档，仅帧间压缩格式开放——见
-  // MiningMediaCompression.imageTiers 档 3 与 BUG-1039）：对应滤镜段整段省略。
+  // [fps]<=0 / [width]<=0 表示「源帧率 / 源分辨率」。[MiningMediaCompression.resolve]
+  // 已不产出 0（三种格式的顶格档都是有限上限，见 MiningAnimatedFormat 与 BUG-1039），
+  // 这条分支只服务直接调用方；命中时对应滤镜段整段省略。
   final StringBuffer pre = StringBuffer();
   if (fps > 0) pre.write('fps=$fps,');
   if (width > 0) pre.write('scale=$width:-2:flags=lanczos,');
@@ -902,6 +922,10 @@ Future<String?> extractClipGifViaFfmpeg({
   int width = 320,
   // 动图编码格式。默认 gif = 旧行为逐字等价（未传的既有调用点/测试不受影响）。
   MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+  // true = 调用方失败后**还会用降级参数再试一次**（换 GIF 重编）。捆绑 ffmpeg 缺
+  // libsvtav1/libwebp 时首选格式是 100% 必然失败的能力探测，这类失败只记诊断日志，
+  // 不往用户可见的错误日志里每制一张卡塞一条。默认 false = 既有行为逐字等价。
+  bool diagnosticOnly = false,
   // BUG-891：远端自签主机的 TLS 证书 SHA-256 钉扎指纹（透传给 ffmpeg），非远端/公网源为 null。
   String? tlsPinSha256,
 }) async {
@@ -935,7 +959,8 @@ Future<String?> extractClipGifViaFfmpeg({
         output.deleteSync();
       } catch (_) {}
     }
-    _reportFfmpegFailure('extractClipGifViaFfmpeg', result, onFailure);
+    _reportFfmpegFailure('extractClipGifViaFfmpeg', result, onFailure,
+        diagnosticOnly: diagnosticOnly);
     return null;
   } on ProcessException catch (e, stack) {
     // 移动端无 CLI ffmpeg：优雅回退（调用方改用单帧截图）。
@@ -944,6 +969,7 @@ Future<String?> extractClipGifViaFfmpeg({
       e,
       stack,
       onFailure,
+      diagnosticOnly: diagnosticOnly,
     );
     return null;
   } catch (e, stack) {
@@ -952,6 +978,7 @@ Future<String?> extractClipGifViaFfmpeg({
       e,
       stack,
       onFailure,
+      diagnosticOnly: diagnosticOnly,
     );
     return null;
   }

--- a/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -6,6 +6,10 @@ import 'package:hibiki/src/media/video/youtube_source_resolver.dart'
     show kYoutubeStreamReplayUserAgent;
 import 'package:hibiki/src/media/video/video_clip_exporter.dart'
     show resolveAudioMapIndex;
+// 动图格式枚举与 VideoMiningImageMode 同住 mining 侧（两者都是「制卡封面怎么取」的
+// 取值域）。本文件只消费它选编码器参数，不反向依赖 mining 逻辑，无环。
+import 'package:hibiki/src/mining/immersion_mining_request.dart'
+    show MiningAnimatedFormat;
 import 'package:http/http.dart' as http;
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:meta/meta.dart';
@@ -201,8 +205,8 @@ Future<String?> materializeRemoteAudioViaRangeDownload({
 /// 不可变值对象（纯数据，可单测、可在隔离中构造）。各底层纯函数（[buildFfmpegClipArgs]
 /// / [buildFfmpegClipGifArgs] / [downsampleCardScreenshot]）仍接收原始可选参数，本类只是
 /// 调用点选档时的参数捆绑，不让纯函数读全局偏好。最高档用 [screenshotMaxLongEdge] == 0
-/// 表示「不缩放」（截图原图直通），由底层纯函数解读；**GIF 侧没有 0 哨兵档**（BUG-1039，
-/// 见 [imageTiers]），任何档位的 [gifFps]/[gifWidth] 都是有限值。
+/// 表示「不缩放」（截图原图直通），由底层纯函数解读；动图侧的 0 哨兵只有 **AVIF** 在顶格
+/// 档产出（WebP/GIF 任何档位都是有限值），依据见 [MiningAnimatedFormat] 与 [resolve]。
 class MiningMediaCompression {
   const MiningMediaCompression({
     required this.audioChannels,
@@ -219,12 +223,12 @@ class MiningMediaCompression {
   /// 音频比特率（`-b:a`，如 `'64k'`）。
   final String audioBitrate;
 
-  /// cue 封面 GIF 帧率（`fps=`）。**0 = 源帧率**（不加 fps 滤镜）。BUG-1039 后已无档位
-  /// 产出 0——GIF 侧全档有限值；纯函数仍支持 0 供直接调用方使用。
+  /// cue 封面动图帧率（`fps=`）。**0 = 源帧率**（不加 fps 滤镜）。只有「顶格档 + AVIF」
+  /// 会产出 0（见 [resolve]）；WebP/GIF 全档恒为有限值。
   final int gifFps;
 
-  /// cue 封面 GIF 宽度（`scale=W:-2`）。**0 = 源分辨率**（不加 scale 滤镜）。同上，
-  /// BUG-1039 后已无档位产出 0。
+  /// cue 封面动图宽度（`scale=W:-2`）。**0 = 源分辨率**（不加 scale 滤镜）。同 [gifFps]：
+  /// 仅顶格档 + AVIF 产出 0。
   final int gifWidth;
 
   /// 帧截图封面降采样长边（px）。**0 = 不缩放**（最高档，原图字节直通）。
@@ -240,6 +244,11 @@ class MiningMediaCompression {
   /// （`maxLongEdge` 用 0 哨兵）；**GIF** 走 [gifMaxTierFps]/[gifMaxTierWidth] 的封顶档。
   /// BUG-1039 前这一档叫「原片」，但它对 GIF 已不再是源分辨率/源帧率——只有截图仍是
   /// 原图，故改名为「最高」：只承诺是滑块顶格，不承诺具体保真度。
+  ///
+  /// ⚠️ 顶格档这两个 gif 字段是 `0` 占位，**永远被 [resolve] 用格式自己声明的
+  /// [MiningAnimatedFormat.maxTierFps]/[MiningAnimatedFormat.maxTierWidth] 覆写**。
+  /// 下面那段爆炸分析对 GIF（与实测同样慢的 WebP）永远成立，只有 AVIF 例外——它在源
+  /// 分辨率下比 GIF 还快 3.4 倍，实测表见 [MiningAnimatedFormat]。
   ///
   /// BUG-1039：这一档过去对 GIF 也用 0 哨兵（源分辨率 + 源帧率），这是把「截图」的
   /// 语义错套到「动图」上——截图原图直通只是几 MB 的一张 JPEG，而 GIF 是 8-bit 调色板
@@ -257,17 +266,22 @@ class MiningMediaCompression {
     (gifFps: 8, gifWidth: 480, maxLongEdge: 1000, quality: 90), // 1 标准（默认=旧压缩档）
     (gifFps: 12, gifWidth: 720, maxLongEdge: 2000, quality: 95), // 2 高清（=旧高保真档）
     (
-      gifFps: gifMaxTierFps,
-      gifWidth: gifMaxTierWidth,
+      gifFps: 0,
+      gifWidth: 0,
       maxLongEdge: 0,
       quality: 100
-    ), // 3 最高（截图原图直通；GIF 封顶，BUG-1039）
+    ), // 3 最高（截图原图直通；动图参数由格式声明，见下）
   ];
 
-  /// BUG-1039：最高档 GIF 的封顶帧率 / 宽度。GIF 无帧间压缩，不存在可用的「源分辨率+
-  /// 源帧率」档；这两个值是「仍明显优于高清档、且体积与耗时可控」的实测折中。
-  static const int gifMaxTierFps = 12;
-  static const int gifMaxTierWidth = 960;
+  /// 顶格档的动图参数**不在本表里**——它由 [MiningAnimatedFormat.maxTierFps] /
+  /// [MiningAnimatedFormat.maxTierWidth] 每格式各自声明，[resolve] 直接查。本表档 3 的
+  /// 两个 gif 字段写 `0` 只是占位，永远被覆写。
+  ///
+  /// 这么分是因为顶格档的含义本就随格式变（AVIF 源直通 / WebP·GIF 封顶，实测依据见
+  /// [MiningAnimatedFormat] 文档），把它塞进一张与格式无关的表只会逼 [resolve] 长出
+  /// 「谁是特例」的分支。
+  static int get gifMaxTierFps => MiningAnimatedFormat.gif.maxTierFps;
+  static int get gifMaxTierWidth => MiningAnimatedFormat.gif.maxTierWidth;
 
   /// 音频质量有序档位（索引 0..2）：低→高。
   /// 档 0 = 旧压缩档（单声道 64k），档 1 = 旧高保真档（立体声 128k），档 2 = 最高（立体声
@@ -317,20 +331,33 @@ class MiningMediaCompression {
     screenshotQuality: 95,
   );
 
-  /// 据图片/GIF 清晰度档 [imageTier] + 音频质量档 [audioTier] 组装媒体档（越界自动夹取）。
+  /// 据图片/动图清晰度档 [imageTier] + 音频质量档 [audioTier] 组装媒体档（越界自动夹取）。
+  ///
+  /// 顶格档（[imageTierMax]）的动图参数取自 [format] 自己声明的
+  /// [MiningAnimatedFormat.maxTierFps]/[MiningAnimatedFormat.maxTierWidth]——AVIF 是
+  /// `0/0`（源分辨率 + 源帧率，真·原图档），WebP/GIF 是封顶值。判据不是「有没有帧间
+  /// 压缩」而是「源直通跑不跑得动」，实测依据见 [MiningAnimatedFormat] 文档。
+  ///
+  /// 低三档与格式无关：它们的有限值对三种编码器同样有意义，不按格式分叉，免得同一个
+  /// 滑块位置在不同格式下含义漂开。截图侧的原图直通语义自始至终没变。
+  ///
+  /// 默认 [MiningAnimatedFormat.gif] 让未传 format 的既有调用点/测试逐字节等价。
   static MiningMediaCompression resolve({
     required int imageTier,
     required int audioTier,
+    MiningAnimatedFormat format = MiningAnimatedFormat.gif,
   }) {
+    final int tier = _clampImageTier(imageTier);
     final ({int gifFps, int gifWidth, int maxLongEdge, int quality}) img =
-        imageTiers[_clampImageTier(imageTier)];
+        imageTiers[tier];
     final ({int channels, String bitrate}) aud =
         audioTiers[_clampAudioTier(audioTier)];
+    final bool topTier = tier == imageTierMax;
     return MiningMediaCompression(
       audioChannels: aud.channels,
       audioBitrate: aud.bitrate,
-      gifFps: img.gifFps,
-      gifWidth: img.gifWidth,
+      gifFps: topTier ? format.maxTierFps : img.gifFps,
+      gifWidth: topTier ? format.maxTierWidth : img.gifWidth,
       screenshotMaxLongEdge: img.maxLongEdge,
       screenshotQuality: img.quality,
     );
@@ -725,19 +752,75 @@ List<String> buildFfmpegClipGifArgs({
   int maxDurationMs = 10000,
   // BUG-891：远端自签主机的 TLS 证书 SHA-256 钉扎指纹（透传给 ffmpeg），非远端/公网源为 null。
   String? tlsPinSha256,
+}) =>
+    buildFfmpegClipAnimatedArgs(
+      format: MiningAnimatedFormat.gif,
+      inputPath: inputPath,
+      startMs: startMs,
+      endMs: endMs,
+      outputPath: outputPath,
+      fps: fps,
+      width: width,
+      maxDurationMs: maxDurationMs,
+      tlsPinSha256: tlsPinSha256,
+    );
+
+/// 纯函数：构建「cue 时间窗 → 循环动图」的 ffmpeg 参数表，按 [format] 分派编码器。
+/// [buildFfmpegClipGifArgs] 是本函数 `format: gif` 的薄委托（旧调用点/测试逐字等价）。
+///
+/// 三种格式共享同一段输入定位与时长 clamp，只在**滤镜链 + 编码器**上分叉：
+/// - [MiningAnimatedFormat.gif]：`split→palettegen→paletteuse` 双遍调色板（8-bit 调色板
+///   格式必须靠它避免抖动），无编码器参数（muxer 按 `.gif` 扩展名选 native gif 编码器）。
+/// - [MiningAnimatedFormat.webp]：真彩，**不需要调色板**，滤镜退化成 `fps,scale` 单遍
+///   （顺带省掉 GIF 那一遍全量重解码）。编码器 `libwebp_anim`。
+/// - [MiningAnimatedFormat.avif]：同样单遍滤镜，编码器 `libsvtav1`（选它而非 libaom：
+///   本负载是 16–48 帧的短片，延迟比压缩率重要，且静态链接体积约 3–5MB 对 5–9MB）。
+///
+/// 三条分支的参数形态已在带 libsvtav1/libwebp 的真实 ffmpeg 上跑通（1080p30 源 4 秒窗，
+/// 480px·8fps：AVIF 36 KB / WebP 163 KB / GIF 471 KB）。**但入库的 `ffmpeg-min` 尚未含
+/// 这两个编码器**（见 `tool/ffmpeg-min/build-ffmpeg-min.sh`）——须重跑
+/// `.github/workflows/ffmpeg-min.yml` 并重新 vendor exe。在那之前调用点的 fail-open
+/// 会把 AVIF/WebP 降级回 GIF，卡照样制得出来，只是用户选的格式暂不生效。
+///
+/// `-2` 让高度按宽度等比且取偶（三种编码器都要求偶数维度）。`-ss`/`-t` 置于 `-i` 前做
+/// 快速输入定位（多 GB 剧集不从 0 解码）。时长 clamp 到 `(0, maxDurationMs]`。
+List<String> buildFfmpegClipAnimatedArgs({
+  required MiningAnimatedFormat format,
+  required String inputPath,
+  required int startMs,
+  required int endMs,
+  required String outputPath,
+  int fps = 8,
+  int width = 320,
+  int maxDurationMs = 10000,
+  String? tlsPinSha256,
 }) {
   final double startSeconds = (startMs < 0 ? 0 : startMs) / 1000.0;
   final int rawDur = endMs - startMs;
   final int clampedDur =
       rawDur > maxDurationMs ? maxDurationMs : (rawDur < 1 ? 1 : rawDur);
   final double durationSeconds = clampedDur / 1000.0;
-  // [fps]<=0 / [width]<=0 表示「源帧率 / 源分辨率」（BUG-1039 后无档位再传 0，仅供直接调用方）：
-  // 对应滤镜前缀整段省略（不降帧、不缩放），仅保留 palettegen/paletteuse 双遍避免抖动。
+  // [fps]<=0 / [width]<=0 表示「源帧率 / 源分辨率」（原图档，仅帧间压缩格式开放——见
+  // MiningMediaCompression.imageTiers 档 3 与 BUG-1039）：对应滤镜段整段省略。
   final StringBuffer pre = StringBuffer();
   if (fps > 0) pre.write('fps=$fps,');
   if (width > 0) pre.write('scale=$width:-2:flags=lanczos,');
-  final String filter =
-      '${pre}split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse';
+
+  // GIF 走 filter_complex（palettegen 需要分流），webp/avif 单链走 -vf。两者不能混用
+  // 同一个开关：filter_complex 里写不出裸 `-vf` 的等价链而不引入多余的 split。
+  final List<String> filterArgs;
+  if (format == MiningAnimatedFormat.gif) {
+    filterArgs = <String>[
+      '-filter_complex',
+      '${pre}split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse',
+    ];
+  } else {
+    final String chain = pre.isEmpty
+        ? 'null' // 原图档：不降帧不缩放，但 -vf 不接受空串，用 null 滤镜占位。
+        : pre.toString().substring(0, pre.length - 1); // 去掉尾逗号
+    filterArgs = <String>['-vf', chain];
+  }
+
   return <String>[
     '-y',
     ...buildFfmpegRemoteInputArgs(inputPath, tlsPinSha256: tlsPinSha256),
@@ -748,17 +831,63 @@ List<String> buildFfmpegClipGifArgs({
     '-i',
     inputPath,
     '-an',
-    '-filter_complex',
-    filter,
+    ...filterArgs,
+    ...animatedEncoderArgs(format),
     '-loop',
     '0',
     outputPath,
   ];
 }
 
-/// 把 [inputPath] 的 `[startMs, endMs)` 段导出成循环 GIF 到 [outputPath]（见
-/// [buildFfmpegClipGifArgs]）。成功返回 [outputPath]，否则 null（范围非法 / 输入缺失 /
-/// ffmpeg 不存在（移动端无 CLI ffmpeg）/ 编码无输出）——调用方据此回退单帧截图。
+/// 按格式给出编码器参数段。**视频 cue 动图与 galgame 窗口动图共用这一处**，避免两条
+/// 链路各持一份会漂开的编码参数。
+///
+/// GIF 返回空：native gif 编码器由 `.gif` 扩展名自动选中，显式 `-c:v gif` 与现状字节
+/// 不等价（会改变既有卡片的产出），故不加。
+///
+/// 为什么质量是**定值而非跟随清晰度档**：清晰度档（[MiningMediaCompression.imageTiers]）
+/// 对动图历来只调分辨率与帧率——GIF 是调色板格式，本就没有有损质量旋钮。把档位的
+/// `quality`（80..100，为截图 JPEG 设计）接到这里会让顶格档变成 CRF 0（近无损），叠加
+/// 顶格档的源分辨率+源帧率直通就是体积失控，正是 BUG-1039 那类「更高档 = 不可用配置」。
+/// 下面两个值是实测折中（1080p30 源 4 秒窗：AVIF 36 KB、WebP 163 KB，同窗 GIF 471 KB）。
+List<String> animatedEncoderArgs(MiningAnimatedFormat format) {
+  switch (format) {
+    case MiningAnimatedFormat.gif:
+      return const <String>[];
+    case MiningAnimatedFormat.webp:
+      return const <String>[
+        '-c:v',
+        'libwebp_anim',
+        '-lossless',
+        '0',
+        '-q:v',
+        '75',
+        '-pix_fmt',
+        'yuv420p',
+      ];
+    case MiningAnimatedFormat.avif:
+      return const <String>[
+        '-c:v',
+        'libsvtav1',
+        // preset 8：SVT-AV1 的 0(慢/小)–13(快/大) 刻度上偏快的一档。本负载只有几十帧，
+        // 更慢的 preset 省不下多少字节却成倍拉长用户按下制卡后的等待。
+        '-preset',
+        '8',
+        '-crf',
+        '32',
+        '-pix_fmt',
+        'yuv420p',
+      ];
+  }
+}
+
+/// 把 [inputPath] 的 `[startMs, endMs)` 段导出成循环动图到 [outputPath]（见
+/// [buildFfmpegClipAnimatedArgs]）。成功返回 [outputPath]，否则 null（范围非法 / 输入缺失 /
+/// ffmpeg 不存在（移动端无 CLI ffmpeg）/ 编码无输出）——调用方据此降级（换格式重试或
+/// 回退单帧截图）。
+///
+/// [format] 决定编码器与 muxer；**调用方必须让 [outputPath] 的扩展名与之一致**
+/// （ffmpeg 按扩展名选 muxer），否则会写出名不副实的容器。
 ///
 /// 镜像 [extractAudioSegmentViaFfmpeg]：有界超时、失败/超时清理半成品、对调用方不抛。
 Future<String?> extractClipGifViaFfmpeg({
@@ -771,6 +900,8 @@ Future<String?> extractClipGifViaFfmpeg({
   // 传高保真档（720px/12fps，与 app 内视频制卡共用档位）。
   int fps = 8,
   int width = 320,
+  // 动图编码格式。默认 gif = 旧行为逐字等价（未传的既有调用点/测试不受影响）。
+  MiningAnimatedFormat format = MiningAnimatedFormat.gif,
   // BUG-891：远端自签主机的 TLS 证书 SHA-256 钉扎指纹（透传给 ffmpeg），非远端/公网源为 null。
   String? tlsPinSha256,
 }) async {
@@ -783,7 +914,8 @@ Future<String?> extractClipGifViaFfmpeg({
   try {
     output.parent.createSync(recursive: true);
     final FfmpegRunResult result = await _runFfmpeg(
-      buildFfmpegClipGifArgs(
+      buildFfmpegClipAnimatedArgs(
+        format: format,
         inputPath: inputPath,
         startMs: startMs,
         endMs: endMs,

--- a/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
+++ b/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
@@ -265,6 +265,63 @@ void main() {
     );
   });
 
+  // 捕获内部在编码器缺失时会**降级 GIF**，此时「用户所选格式」与「实际产出格式」不同。
+  // 文件名必须跟实际产出：按所选格式拼名会写出 `external_window.avif` 里装 GIF 字节，
+  // Anki 按扩展名判 MIME，卡片直接显示不出来。
+  //
+  // ⚠️ 假件必须返回一个**与请求不同**的格式。此前所有 gal 假件都写 `format: format`
+  // 原样回传，「实际产出」与「用户所选」恒等，这条契约永远区分不出来（真空洞）。
+  test('cover name follows the produced format, not the requested one',
+      () async {
+    final TexthookerLineEntry entry = service.appendLine('降格した台詞')!;
+
+    // ① 捕获内部降级：请求 avif，实际只编出 gif。
+    final _RecordingRepo degradedRepo = _RecordingRepo();
+    MiningAnimatedFormat? requested;
+    final GalHookMiningResult degraded = await coordinator(
+      validator: (_) => true,
+      gif: (
+          {required int hwnd,
+          MiningAnimatedFormat format = MiningAnimatedFormat.gif}) async {
+        requested = format;
+        return (
+          bytes: Uint8List.fromList(<int>[71, 73, 70]),
+          format: MiningAnimatedFormat.gif,
+        );
+      },
+    ).mineLine(
+      lineId: entry.id,
+      fields: const <String, String>{'expression': '降格'},
+      compression: MiningMediaCompression.compressed,
+      repo: degradedRepo,
+      animatedFormat: MiningAnimatedFormat.avif,
+    );
+
+    expect(degraded.success, isTrue);
+    expect(requested, MiningAnimatedFormat.avif, reason: '用户所选格式必须透传给捕获');
+    expect(degradedRepo.contexts.single.coverPath, endsWith('.gif'),
+        reason: '实际产出是 GIF，若跟用户所选拼成 .avif 就是名不副实的容器');
+    expect(degraded.degradedToStill, isFalse, reason: '换格式不是降级为静态图');
+
+    // ② 没降级：请求 avif、实际产出 avif → 名字是 .avif。两条一起才把「跟实际产出」
+    // 与「跟用户所选」这两种实现区分开——只有 ① 会被「恒返回 gif」的假实现蒙混。
+    final _RecordingRepo okRepo = _RecordingRepo();
+    await coordinator(
+      validator: (_) => true,
+      gif: (
+              {required int hwnd,
+              MiningAnimatedFormat format = MiningAnimatedFormat.gif}) async =>
+          (bytes: Uint8List.fromList(<int>[0, 0, 0, 32]), format: format),
+    ).mineLine(
+      lineId: entry.id,
+      fields: const <String, String>{'expression': '降格'},
+      compression: MiningMediaCompression.compressed,
+      repo: okRepo,
+      animatedFormat: MiningAnimatedFormat.avif,
+    );
+    expect(okRepo.contexts.single.coverPath, endsWith('.avif'));
+  });
+
   test('gif is still the default when imageMode is omitted', () async {
     final TexthookerLineEntry entry = service.appendLine('動画の台詞')!;
     final _RecordingRepo repo = _RecordingRepo();

--- a/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
+++ b/hibiki/test/mining/gal_hook_mining_coordinator_test.dart
@@ -5,8 +5,10 @@ import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/mining/gal_hook_mining_coordinator.dart';
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_window_gif.dart'
+    show GalWindowAnimatedCapture;
 import 'package:hibiki/src/mining/immersion_mining_request.dart'
-    show VideoMiningImageMode;
+    show MiningAnimatedFormat, VideoMiningImageMode;
 import 'package:hibiki/src/mining/window_capture_channel.dart';
 import 'package:hibiki/src/sync/texthooker_service.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
@@ -100,7 +102,9 @@ void main() {
       required String sentence,
       required String outputExtension,
     })? audio,
-    Future<Uint8List?> Function({required int hwnd})? gif,
+    Future<GalWindowAnimatedCapture?> Function(
+            {required int hwnd, MiningAnimatedFormat format})?
+        gif,
     Future<WindowCaptureResult> Function(int hwnd)? still,
     Future<Directory> Function()? tempFactory,
   }) =>
@@ -117,8 +121,11 @@ void main() {
             }) async =>
                 Uint8List.fromList(<int>[7, 8, 9]),
         captureGif: gif ??
-            ({required int hwnd}) async =>
-                Uint8List.fromList(<int>[71, 73, 70]),
+            (
+                    {required int hwnd,
+                    MiningAnimatedFormat format =
+                        MiningAnimatedFormat.gif}) async =>
+                (bytes: Uint8List.fromList(<int>[71, 73, 70]), format: format),
         captureStill: still ??
             (int hwnd) async => WindowCaptureResult(
                   pngBytes: Uint8List.fromList(<int>[80, 78, 71]),
@@ -191,7 +198,10 @@ void main() {
     final _RecordingRepo pngRepo = _RecordingRepo();
     final GalHookMiningResult pngResult = await coordinator(
       validator: (_) => true,
-      gif: ({required int hwnd}) async => null,
+      gif: (
+              {required int hwnd,
+              MiningAnimatedFormat format = MiningAnimatedFormat.gif}) async =>
+          null,
     ).mineLine(
       lineId: entry.id,
       fields: const <String, String>{'expression': '画面'},
@@ -206,7 +216,10 @@ void main() {
     final _RecordingRepo failedRepo = _RecordingRepo();
     final GalHookMiningResult failed = await coordinator(
       validator: (_) => true,
-      gif: ({required int hwnd}) async => null,
+      gif: (
+              {required int hwnd,
+              MiningAnimatedFormat format = MiningAnimatedFormat.gif}) async =>
+          null,
       still: (int hwnd) async =>
           const WindowCaptureResult(error: 'window disappeared'),
     ).mineLine(
@@ -228,9 +241,11 @@ void main() {
 
     final GalHookMiningResult result = await coordinator(
       validator: (_) => true,
-      gif: ({required int hwnd}) async {
+      gif: (
+          {required int hwnd,
+          MiningAnimatedFormat format = MiningAnimatedFormat.gif}) async {
         gifCalls++;
-        return Uint8List.fromList(<int>[1, 2, 3]);
+        return (bytes: Uint8List.fromList(<int>[1, 2, 3]), format: format);
       },
     ).mineLine(
       lineId: entry.id,
@@ -279,7 +294,10 @@ void main() {
 
     final GalHookMiningResult result = await coordinator(
       validator: (_) => true,
-      gif: ({required int hwnd}) async => Uint8List(0),
+      gif: (
+              {required int hwnd,
+              MiningAnimatedFormat format = MiningAnimatedFormat.gif}) async =>
+          null,
     ).mineLine(
       lineId: entry.id,
       fields: const <String, String>{'expression': '降格'},
@@ -300,9 +318,11 @@ void main() {
     int audioCalls = 0;
     final GalHookMiningResult result = await coordinator(
       validator: (_) => false,
-      gif: ({required int hwnd}) async {
+      gif: (
+          {required int hwnd,
+          MiningAnimatedFormat format = MiningAnimatedFormat.gif}) async {
         gifCalls++;
-        return Uint8List(0);
+        return null;
       },
       audio: ({
         required String lineId,
@@ -310,7 +330,7 @@ void main() {
         required String outputExtension,
       }) async {
         audioCalls++;
-        return Uint8List(0);
+        return null;
       },
     ).mineLine(
       lineId: entry.id,

--- a/hibiki/test/mining/immersion_mining_audio_materialize_test.dart
+++ b/hibiki/test/mining/immersion_mining_audio_materialize_test.dart
@@ -39,6 +39,7 @@ Future<String?> _okGif(
         required String outputPath,
         int fps = 8,
         int width = 320,
+        MiningAnimatedFormat format = MiningAnimatedFormat.gif,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256}) async =>
     outputPath;

--- a/hibiki/test/mining/immersion_mining_audio_materialize_test.dart
+++ b/hibiki/test/mining/immersion_mining_audio_materialize_test.dart
@@ -40,6 +40,7 @@ Future<String?> _okGif(
         int fps = 8,
         int width = 320,
         MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+        bool diagnosticOnly = false,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256}) async =>
     outputPath;

--- a/hibiki/test/mining/immersion_mining_engine_test.dart
+++ b/hibiki/test/mining/immersion_mining_engine_test.dart
@@ -62,6 +62,7 @@ void main() {
           int fps = 8,
           int width = 320,
           MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+          bool diagnosticOnly = false,
           FfmpegFailureReporter? onFailure,
           String? tlsPinSha256}) async =>
       outputPath;
@@ -73,6 +74,7 @@ void main() {
           int fps = 8,
           int width = 320,
           MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+          bool diagnosticOnly = false,
           FfmpegFailureReporter? onFailure,
           String? tlsPinSha256}) async =>
       null;
@@ -281,6 +283,7 @@ void main() {
       int fps = 8,
       int width = 320,
       MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+      bool diagnosticOnly = false,
       FfmpegFailureReporter? onFailure,
       String? tlsPinSha256,
     }) async {
@@ -368,6 +371,7 @@ void main() {
         int fps = 8,
         int width = 320,
         MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+        bool diagnosticOnly = false,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256}) async {
       gifInput = inputPath;
@@ -501,6 +505,7 @@ void main() {
         int fps = 8,
         int width = 320,
         MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+        bool diagnosticOnly = false,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256}) async {
       gifCalled = true;
@@ -539,6 +544,7 @@ void main() {
         int fps = 8,
         int width = 320,
         MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+        bool diagnosticOnly = false,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256}) async {
       gifCalled = true;

--- a/hibiki/test/mining/immersion_mining_engine_test.dart
+++ b/hibiki/test/mining/immersion_mining_engine_test.dart
@@ -61,6 +61,7 @@ void main() {
           required String outputPath,
           int fps = 8,
           int width = 320,
+          MiningAnimatedFormat format = MiningAnimatedFormat.gif,
           FfmpegFailureReporter? onFailure,
           String? tlsPinSha256}) async =>
       outputPath;
@@ -71,6 +72,7 @@ void main() {
           required String outputPath,
           int fps = 8,
           int width = 320,
+          MiningAnimatedFormat format = MiningAnimatedFormat.gif,
           FfmpegFailureReporter? onFailure,
           String? tlsPinSha256}) async =>
       null;
@@ -278,6 +280,7 @@ void main() {
       required String outputPath,
       int fps = 8,
       int width = 320,
+      MiningAnimatedFormat format = MiningAnimatedFormat.gif,
       FfmpegFailureReporter? onFailure,
       String? tlsPinSha256,
     }) async {
@@ -364,6 +367,7 @@ void main() {
         required String outputPath,
         int fps = 8,
         int width = 320,
+        MiningAnimatedFormat format = MiningAnimatedFormat.gif,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256}) async {
       gifInput = inputPath;
@@ -496,6 +500,7 @@ void main() {
         required String outputPath,
         int fps = 8,
         int width = 320,
+        MiningAnimatedFormat format = MiningAnimatedFormat.gif,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256}) async {
       gifCalled = true;
@@ -533,6 +538,7 @@ void main() {
         required String outputPath,
         int fps = 8,
         int width = 320,
+        MiningAnimatedFormat format = MiningAnimatedFormat.gif,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256}) async {
       gifCalled = true;

--- a/hibiki/test/mining/immersion_mining_parallel_test.dart
+++ b/hibiki/test/mining/immersion_mining_parallel_test.dart
@@ -93,6 +93,7 @@ void main() {
       int fps = 8,
       int width = 320,
       MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+      bool diagnosticOnly = false,
       dynamic onFailure,
       String? tlsPinSha256,
     }) async {
@@ -140,6 +141,7 @@ void main() {
       int fps = 8,
       int width = 320,
       MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+      bool diagnosticOnly = false,
       dynamic onFailure,
       String? tlsPinSha256,
     }) async {

--- a/hibiki/test/mining/immersion_mining_parallel_test.dart
+++ b/hibiki/test/mining/immersion_mining_parallel_test.dart
@@ -92,6 +92,7 @@ void main() {
       required String outputPath,
       int fps = 8,
       int width = 320,
+      MiningAnimatedFormat format = MiningAnimatedFormat.gif,
       dynamic onFailure,
       String? tlsPinSha256,
     }) async {
@@ -138,6 +139,7 @@ void main() {
       required String outputPath,
       int fps = 8,
       int width = 320,
+      MiningAnimatedFormat format = MiningAnimatedFormat.gif,
       dynamic onFailure,
       String? tlsPinSha256,
     }) async {

--- a/hibiki/test/mining/immersion_mining_queue_test.dart
+++ b/hibiki/test/mining/immersion_mining_queue_test.dart
@@ -84,6 +84,7 @@ void main() {
       required String outputPath,
       int fps = 8,
       int width = 320,
+      MiningAnimatedFormat format = MiningAnimatedFormat.gif,
       FfmpegFailureReporter? onFailure,
       String? tlsPinSha256,
     }) async {

--- a/hibiki/test/mining/immersion_mining_queue_test.dart
+++ b/hibiki/test/mining/immersion_mining_queue_test.dart
@@ -85,6 +85,7 @@ void main() {
       int fps = 8,
       int width = 320,
       MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+      bool diagnosticOnly = false,
       FfmpegFailureReporter? onFailure,
       String? tlsPinSha256,
     }) async {

--- a/hibiki/test/mining/mining_animated_format_test.dart
+++ b/hibiki/test/mining/mining_animated_format_test.dart
@@ -10,10 +10,13 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/ffmpeg_backend.dart'
+    show FfmpegBackend, FfmpegRunResult, setFfmpegBackendForTesting;
 import 'package:hibiki/src/mining/galgame_window_gif.dart';
 import 'package:hibiki/src/mining/immersion_mining_engine.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 
 class _RecordingRepo extends BaseAnkiRepository {
@@ -41,6 +44,7 @@ typedef _GifCall = ({
   int fps,
   int width,
   String outputPath,
+  bool diagnosticOnly,
 });
 
 void main() {
@@ -70,42 +74,91 @@ void main() {
       );
     });
 
-    test('只有 AVIF 声明源直通顶格档', () {
-      expect(MiningAnimatedFormat.avif.maxTierIsSourcePassthrough, isTrue);
+    test('AVIF 顶格档比 WebP/GIF 宽松，但三者都不是源直通', () {
       // WebP 规格上有帧间差分，但实测在源分辨率下比 GIF 还慢（libwebp_anim 是逐帧
-      // 帧内的静态图编码器）。它和 GIF 一样吃封顶值，这不是笔误。
-      expect(MiningAnimatedFormat.webp.maxTierIsSourcePassthrough, isFalse);
-      expect(MiningAnimatedFormat.gif.maxTierIsSourcePassthrough, isFalse);
+      // 帧内的静态图编码器）。它和 GIF 吃同一组封顶值，这不是笔误。
       expect(MiningAnimatedFormat.webp.maxTierFps,
           MiningAnimatedFormat.gif.maxTierFps);
       expect(MiningAnimatedFormat.webp.maxTierWidth,
           MiningAnimatedFormat.gif.maxTierWidth);
+      // AVIF 是真视频编码器，同参数下体积小一个量级，故拿更宽松的上限——但仍是上限。
+      expect(MiningAnimatedFormat.avif.maxTierFps,
+          greaterThan(MiningAnimatedFormat.gif.maxTierFps));
+      expect(MiningAnimatedFormat.avif.maxTierWidth,
+          greaterThan(MiningAnimatedFormat.gif.maxTierWidth));
+    });
+
+    // BUG-1039 的教训是「顶格档不该是不可用配置」。AVIF 一度被配成 0/0（源分辨率 +
+    // 源帧率直通）——换了更好的编码器就把上限**删掉**，而不是**抬高**。本机 ffmpeg
+    // （libsvtav1 preset 8 / crf 32）按 10 秒 cue 上限实测：4K30 源直通 = 34.54 MB /
+    // 8.5 s，1080p30 源直通 = 8.80 MB / 2.5 s，都是「制得出卡但没法用」的量级。
+    test('顶格档必须有限，且在 10 秒 cue 上限下不超过实测像素预算', () {
+      for (final MiningAnimatedFormat f in MiningAnimatedFormat.values) {
+        expect(f.maxTierFps, greaterThan(0), reason: '$f 顶格档不得是源帧率直通（0 哨兵）');
+        expect(f.maxTierWidth, greaterThan(0), reason: '$f 顶格档不得是源分辨率直通（0 哨兵）');
+        // 16:9 下的编码像素总量上界（宽 × 高 × 帧率 × 10 秒 cue 上限，即
+        // buildFfmpegClipAnimatedArgs 的 maxDurationMs 默认值）。
+        final int height = (f.maxTierWidth * 9 / 16).round();
+        final int megapixels =
+            f.maxTierWidth * height * f.maxTierFps * 10 ~/ 1000000;
+        // 预算 300 Mpx 由实测反推：现值 AVIF 1440px·24fps 跑满 10 秒是 2.91 MB /
+        // 2.9 s（1080p 源），比同窗真 GIF 的 4.97 MB 还小，属可用；再往上
+        // 1920px·30fps 就是 8.80 MB（622 Mpx），4K30 直通 34.54 MB（2488 Mpx）。
+        expect(megapixels, lessThanOrEqualTo(300),
+            reason: '$f 顶格档 $megapixels Mpx 超预算——抬上限必须先重测体积/耗时');
+      }
     });
   });
 
   group('MiningMediaCompression.resolve 顶格档随格式分叉', () {
-    test('顶格档：AVIF 拿 0/0（源直通），WebP/GIF 拿封顶值', () {
+    test('顶格档：每种格式各拿自己声明的上限，没有格式拿到 0 哨兵', () {
+      for (final MiningAnimatedFormat f in MiningAnimatedFormat.values) {
+        final MiningMediaCompression r = MiningMediaCompression.resolve(
+          imageTier: MiningMediaCompression.imageTierMax,
+          audioTier: 0,
+          format: f,
+        );
+        expect(r.gifFps, f.maxTierFps, reason: '$f 顶格档帧率必须取自格式自己的声明');
+        expect(r.gifWidth, f.maxTierWidth, reason: '$f 顶格档宽度必须取自格式自己的声明');
+        expect(r.gifFps, greaterThan(0), reason: '$f 不该拿到源帧率直通');
+        expect(r.gifWidth, greaterThan(0), reason: '$f 不该拿到源分辨率直通');
+      }
+      // AVIF 的顶格档必须真的比 GIF 宽松，否则「换格式」白换。
       final MiningMediaCompression avif = MiningMediaCompression.resolve(
         imageTier: MiningMediaCompression.imageTierMax,
         audioTier: 0,
         format: MiningAnimatedFormat.avif,
       );
-      expect(avif.gifFps, 0);
-      expect(avif.gifWidth, 0);
+      final MiningMediaCompression gif = MiningMediaCompression.resolve(
+        imageTier: MiningMediaCompression.imageTierMax,
+        audioTier: 0,
+        format: MiningAnimatedFormat.gif,
+      );
+      expect(avif.gifFps, greaterThan(gif.gifFps));
+      expect(avif.gifWidth, greaterThan(gif.gifWidth));
+    });
 
-      for (final MiningAnimatedFormat capped in <MiningAnimatedFormat>[
-        MiningAnimatedFormat.webp,
-        MiningAnimatedFormat.gif,
-      ]) {
-        final MiningMediaCompression r = MiningMediaCompression.resolve(
-          imageTier: MiningMediaCompression.imageTierMax,
-          audioTier: 0,
-          format: capped,
-        );
-        expect(r.gifFps, capped.maxTierFps, reason: '$capped 不该拿到源帧率');
-        expect(r.gifWidth, capped.maxTierWidth, reason: '$capped 不该拿到源分辨率');
-        expect(r.gifWidth, greaterThan(0));
+    test('capFps/capWidth 把任何来路的参数夹进本格式上限（0 哨兵也夹）', () {
+      for (final MiningAnimatedFormat f in MiningAnimatedFormat.values) {
+        // 0 / 负数 = 历史「源直通」哨兵，必须夹成上限而不是原样放行。
+        expect(f.capFps(0), f.maxTierFps);
+        expect(f.capWidth(0), f.maxTierWidth);
+        expect(f.capFps(-1), f.maxTierFps);
+        expect(f.capWidth(-1), f.maxTierWidth);
+        // 超上限 → 夹到上限；上限内 → 原样。
+        expect(f.capFps(f.maxTierFps + 1), f.maxTierFps);
+        expect(f.capWidth(f.maxTierWidth + 1), f.maxTierWidth);
+        expect(f.capFps(8), 8);
+        expect(f.capWidth(480), 480);
       }
+      // 关键一条：AVIF 顶格档参数落到 GIF 上必须被夹掉（BUG-1039 的换格式陷阱）。
+      expect(
+          MiningAnimatedFormat.gif.capFps(MiningAnimatedFormat.avif.maxTierFps),
+          MiningAnimatedFormat.gif.maxTierFps);
+      expect(
+          MiningAnimatedFormat.gif
+              .capWidth(MiningAnimatedFormat.avif.maxTierWidth),
+          MiningAnimatedFormat.gif.maxTierWidth);
     });
 
     test('低三档与格式无关（同一滑块位置在三种格式下含义一致）', () {
@@ -311,11 +364,17 @@ void main() {
         int fps = 8,
         int width = 320,
         MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+        bool diagnosticOnly = false,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256,
       }) async {
-        calls.add(
-            (format: format, fps: fps, width: width, outputPath: outputPath));
+        calls.add((
+          format: format,
+          fps: fps,
+          width: width,
+          outputPath: outputPath,
+          diagnosticOnly: diagnosticOnly,
+        ));
         return format == MiningAnimatedFormat.gif ? outputPath : null;
       }
 
@@ -325,13 +384,14 @@ void main() {
     test('AVIF 顶格档失败降级 GIF 时，换成 GIF 自己的封顶参数（BUG-1039 陷阱）', () async {
       final ({GifExtractor extractor, List<_GifCall> calls}) fake = gifOnly();
       final _RecordingRepo repo = _RecordingRepo();
-      // 顶格档 + AVIF → compression 是 0/0（源直通）。
+      // 顶格档 + AVIF → compression 拿 AVIF 自己的上限（比 GIF 宽松）。
       final MiningMediaCompression top = MiningMediaCompression.resolve(
         imageTier: MiningMediaCompression.imageTierMax,
         audioTier: 0,
         format: MiningAnimatedFormat.avif,
       );
-      expect(top.gifFps, 0);
+      expect(top.gifFps, MiningAnimatedFormat.avif.maxTierFps);
+      expect(top.gifFps, greaterThan(MiningAnimatedFormat.gif.maxTierFps));
 
       await ImmersionMiningEngine(
         gifExtractor: fake.extractor,
@@ -353,12 +413,13 @@ void main() {
 
       expect(fake.calls, hasLength(2), reason: '首选 avif 失败后必须降级 gif 再试一次');
       expect(fake.calls[0].format, MiningAnimatedFormat.avif);
-      expect(fake.calls[0].fps, 0, reason: 'AVIF 顶格档就是源帧率直通');
-      expect(fake.calls[0].width, 0);
+      expect(fake.calls[0].fps, MiningAnimatedFormat.avif.maxTierFps,
+          reason: 'AVIF 顶格档取自己声明的上限');
+      expect(fake.calls[0].width, MiningAnimatedFormat.avif.maxTierWidth);
 
       expect(fake.calls[1].format, MiningAnimatedFormat.gif);
       expect(fake.calls[1].fps, MiningAnimatedFormat.gif.maxTierFps,
-          reason: '沿用 0 会把源帧率喂给 GIF —— 正是 BUG-1039 的 54 MB / 撞超时配置');
+          reason: '沿用 AVIF 的 24fps/1440px 会把 GIF 打成 BUG-1039 那个 54 MB / 撞超时配置');
       expect(fake.calls[1].width, MiningAnimatedFormat.gif.maxTierWidth);
       expect(fake.calls[1].outputPath, endsWith('.gif'),
           reason: '扩展名必须跟着实际尝试的格式走，否则 muxer 选错');
@@ -429,11 +490,17 @@ void main() {
         int fps = 8,
         int width = 320,
         MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+        bool diagnosticOnly = false,
         FfmpegFailureReporter? onFailure,
         String? tlsPinSha256,
       }) async {
-        calls.add(
-            (format: format, fps: fps, width: width, outputPath: outputPath));
+        calls.add((
+          format: format,
+          fps: fps,
+          width: width,
+          outputPath: outputPath,
+          diagnosticOnly: diagnosticOnly,
+        ));
         return outputPath;
       }
 
@@ -459,5 +526,140 @@ void main() {
       expect(calls.single.format, MiningAnimatedFormat.avif);
       expect(repo.minedContext!.coverPath, endsWith('.avif'));
     });
+
+    // 移动端的 ffmpeg-kit 没有 libsvtav1/libwebp，首选格式是 **100% 必然失败**的能力
+    // 探测：随后降级 GIF 会成功、卡照样建得出来。这条必然发生的失败若走用户可见错误
+    // 日志，就是「每制一张卡塞一条错误」。判据由引擎给出——后面还有降级尝试的那次。
+    test('还有降级尝试在后面的那次标 diagnosticOnly，末次不标', () async {
+      final ({GifExtractor extractor, List<_GifCall> calls}) fake = gifOnly();
+      await ImmersionMiningEngine(
+        gifExtractor: fake.extractor,
+        audioExtractor: okAudio,
+      ).mine(
+        ImmersionMiningRequest(
+          source: AnkiMiningSource.video,
+          fields: const <String, String>{'expression': 'x'},
+          mediaSource: '/v.mp4',
+          clipStartMs: 1000,
+          clipEndMs: 5000,
+          sentence: 's',
+          animatedFormat: MiningAnimatedFormat.avif,
+        ),
+        compression: MiningMediaCompression.compressed,
+        tempDir: tmp.path,
+        repo: _RecordingRepo(),
+      );
+      expect(fake.calls, hasLength(2));
+      expect(fake.calls[0].diagnosticOnly, isTrue,
+          reason: 'avif 失败后还会降级 gif —— 预期内的能力探测，不该进用户错误日志');
+      expect(fake.calls[1].diagnosticOnly, isFalse,
+          reason: 'gif 是末次尝试，它失败才是真失败');
+    });
+
+    test('首选就是 GIF 时那唯一一次尝试不标 diagnosticOnly', () async {
+      final ({GifExtractor extractor, List<_GifCall> calls}) fake = gifOnly();
+      await ImmersionMiningEngine(
+        gifExtractor: fake.extractor,
+        audioExtractor: okAudio,
+      ).mine(
+        ImmersionMiningRequest(
+          source: AnkiMiningSource.video,
+          fields: const <String, String>{'expression': 'x'},
+          mediaSource: '/v.mp4',
+          clipStartMs: 1000,
+          clipEndMs: 5000,
+          sentence: 's',
+          animatedFormat: MiningAnimatedFormat.gif,
+        ),
+        compression: MiningMediaCompression.compressed,
+        tempDir: tmp.path,
+        repo: _RecordingRepo(),
+      );
+      expect(fake.calls.single.diagnosticOnly, isFalse);
+    });
   });
+
+  group('extractClipGifViaFfmpeg 的失败日志分级', () {
+    late Directory tmp;
+    late File input;
+
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('anim_log_');
+      input = File('${tmp.path}/in.mp4')
+        ..writeAsBytesSync(<int>[0, 0, 0, 1, 2, 3]);
+      setFfmpegBackendForTesting(const _AlwaysFailingBackend());
+    });
+    tearDown(() async {
+      setFfmpegBackendForTesting(null);
+      if (tmp.existsSync()) await tmp.delete(recursive: true);
+    });
+
+    test('diagnosticOnly=true 只进诊断日志；默认（末次）进用户可见错误日志', () async {
+      final ErrorLogService log = ErrorLogService.instance;
+      final int errors0 = log.entries.length;
+      final int diagnostics0 = log.diagnosticEntries.length;
+
+      // 首选格式失败 + 后面还有降级尝试 → 诊断日志。
+      expect(
+        await extractClipGifViaFfmpeg(
+          inputPath: input.path,
+          startMs: 0,
+          endMs: 2000,
+          outputPath: '${tmp.path}/out.avif',
+          format: MiningAnimatedFormat.avif,
+          diagnosticOnly: true,
+        ),
+        isNull,
+      );
+      expect(log.entries.length, errors0, reason: '必然发生的能力探测失败不得进用户可见错误日志');
+      expect(log.diagnosticEntries.length, diagnostics0 + 1,
+          reason: '仍要留痕，只是降级到诊断日志');
+
+      // 末次尝试失败 = 真的抽不出封面 → 错误日志（既有行为不变）。
+      expect(
+        await extractClipGifViaFfmpeg(
+          inputPath: input.path,
+          startMs: 0,
+          endMs: 2000,
+          outputPath: '${tmp.path}/out.gif',
+        ),
+        isNull,
+      );
+      expect(log.entries.length, errors0 + 1);
+      expect(log.diagnosticEntries.length, diagnostics0 + 1);
+    });
+
+    // gal 窗口捕获走同一条契约，但它是 Windows 专属且没有注入缝（真 WindowCaptureChannel
+    // + 真 ffmpeg 进程），只能源码扫描。
+    test('galgame_window_gif 的降级尝试同样只记诊断日志', () {
+      final String src =
+          File('lib/src/mining/galgame_window_gif.dart').readAsStringSync();
+      final Match? branch = RegExp(
+        r'if \(attempt == attempts\.last\) \{([\s\S]*?)\n\s*\} else \{([\s\S]*?)\n\s*\}',
+      ).firstMatch(src);
+      expect(branch, isNotNull, reason: '编码失败必须按「是不是末次尝试」分流日志级别');
+      final String lastAttempt = branch!.group(1)!;
+      final String willRetry = branch.group(2)!;
+      expect(lastAttempt.contains('.log('), isTrue,
+          reason: '末次尝试（GIF 也失败）是真失败，必须进用户可见错误日志');
+      expect(lastAttempt.contains('logDiagnostic'), isFalse);
+      expect(willRetry.contains('logDiagnostic'), isTrue,
+          reason: '后面还有降级尝试 → 只记诊断日志，否则每制一张卡塞一条错误');
+      expect(willRetry.contains('.log('), isFalse);
+    });
+  });
+}
+
+/// 恒失败的 ffmpeg 后端：模拟「捆绑的 ffmpeg 没有 libsvtav1 → Unknown encoder」。
+class _AlwaysFailingBackend implements FfmpegBackend {
+  const _AlwaysFailingBackend();
+
+  @override
+  Future<FfmpegRunResult> run(List<String> args, Duration timeout) async =>
+      const FfmpegRunResult(
+          returnCode: 8, output: 'Unknown encoder \'libsvtav1\'');
+
+  @override
+  Future<FfmpegRunResult> runProbe(List<String> args, Duration timeout) async =>
+      const FfmpegRunResult(returnCode: 8, output: '');
 }

--- a/hibiki/test/mining/mining_animated_format_test.dart
+++ b/hibiki/test/mining/mining_animated_format_test.dart
@@ -1,0 +1,463 @@
+// 制卡封面动图格式（AVIF / WebP / GIF）的取值域、档位解析、ffmpeg 参数与降级契约。
+//
+// 覆盖的三条真实风险（都不是「枚举有几个值」这种同义反复）：
+//  1. 顶格档语义随格式变——AVIF 源直通、WebP/GIF 封顶。写错就是「用户选了 AVIF 却拿不到
+//     原图档」或「GIF 拿到源分辨率」（= BUG-1039 那个 54 MB / 撞超时的配置）。
+//  2. 编码失败降级到 GIF 时，**必须换成 GIF 自己的顶格档参数**。沿用 AVIF 的 0/0 会把
+//     源分辨率+源帧率喂给 GIF，正中 BUG-1039。
+//  3. 输出扩展名必须与实际产出格式一致——ffmpeg 按扩展名选 muxer，Anki 按扩展名判 MIME。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/galgame_window_gif.dart';
+import 'package:hibiki/src/mining/immersion_mining_engine.dart';
+import 'package:hibiki/src/mining/immersion_mining_request.dart';
+import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+
+class _RecordingRepo extends BaseAnkiRepository {
+  AnkiMiningContext? minedContext;
+
+  @override
+  Future<MineOutcome> mineEntry({
+    required String rawPayloadJson,
+    required AnkiMiningContext context,
+  }) async {
+    minedContext = context;
+    return const MineOutcome.success(noteId: 1);
+  }
+
+  @override
+  Future<AnkiSettings> loadSettings() async => const AnkiSettings();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// 一次动图抽取调用的实参快照（用来断言降级时参数换对了）。
+typedef _GifCall = ({
+  MiningAnimatedFormat format,
+  int fps,
+  int width,
+  String outputPath,
+});
+
+void main() {
+  group('MiningAnimatedFormat 取值域', () {
+    test('缺省与未知 wire 值都回落 avif（新默认）', () {
+      expect(
+          MiningAnimatedFormat.fromWireName(null), MiningAnimatedFormat.avif);
+      expect(
+          MiningAnimatedFormat.fromWireName('nope'), MiningAnimatedFormat.avif);
+      // 老用户存过的 'gif' 必须仍解析成 gif——换默认值不等于抹掉已有选择。
+      expect(
+          MiningAnimatedFormat.fromWireName('gif'), MiningAnimatedFormat.gif);
+    });
+
+    test('wireName 往返稳定（改了就是破坏已落盘偏好）', () {
+      for (final MiningAnimatedFormat f in MiningAnimatedFormat.values) {
+        expect(MiningAnimatedFormat.fromWireName(f.wireName), f);
+      }
+      expect(
+        MiningAnimatedFormat.values.map((MiningAnimatedFormat f) => f.wireName),
+        <String>['avif', 'webp', 'gif'],
+      );
+      expect(
+        MiningAnimatedFormat.values
+            .map((MiningAnimatedFormat f) => f.fileExtension),
+        <String>['avif', 'webp', 'gif'],
+      );
+    });
+
+    test('只有 AVIF 声明源直通顶格档', () {
+      expect(MiningAnimatedFormat.avif.maxTierIsSourcePassthrough, isTrue);
+      // WebP 规格上有帧间差分，但实测在源分辨率下比 GIF 还慢（libwebp_anim 是逐帧
+      // 帧内的静态图编码器）。它和 GIF 一样吃封顶值，这不是笔误。
+      expect(MiningAnimatedFormat.webp.maxTierIsSourcePassthrough, isFalse);
+      expect(MiningAnimatedFormat.gif.maxTierIsSourcePassthrough, isFalse);
+      expect(MiningAnimatedFormat.webp.maxTierFps,
+          MiningAnimatedFormat.gif.maxTierFps);
+      expect(MiningAnimatedFormat.webp.maxTierWidth,
+          MiningAnimatedFormat.gif.maxTierWidth);
+    });
+  });
+
+  group('MiningMediaCompression.resolve 顶格档随格式分叉', () {
+    test('顶格档：AVIF 拿 0/0（源直通），WebP/GIF 拿封顶值', () {
+      final MiningMediaCompression avif = MiningMediaCompression.resolve(
+        imageTier: MiningMediaCompression.imageTierMax,
+        audioTier: 0,
+        format: MiningAnimatedFormat.avif,
+      );
+      expect(avif.gifFps, 0);
+      expect(avif.gifWidth, 0);
+
+      for (final MiningAnimatedFormat capped in <MiningAnimatedFormat>[
+        MiningAnimatedFormat.webp,
+        MiningAnimatedFormat.gif,
+      ]) {
+        final MiningMediaCompression r = MiningMediaCompression.resolve(
+          imageTier: MiningMediaCompression.imageTierMax,
+          audioTier: 0,
+          format: capped,
+        );
+        expect(r.gifFps, capped.maxTierFps, reason: '$capped 不该拿到源帧率');
+        expect(r.gifWidth, capped.maxTierWidth, reason: '$capped 不该拿到源分辨率');
+        expect(r.gifWidth, greaterThan(0));
+      }
+    });
+
+    test('低三档与格式无关（同一滑块位置在三种格式下含义一致）', () {
+      for (int tier = 0; tier < MiningMediaCompression.imageTierMax; tier++) {
+        final List<MiningMediaCompression> all = MiningAnimatedFormat.values
+            .map((MiningAnimatedFormat f) => MiningMediaCompression.resolve(
+                  imageTier: tier,
+                  audioTier: 0,
+                  format: f,
+                ))
+            .toList();
+        expect(all.map((MiningMediaCompression c) => c.gifFps).toSet(),
+            hasLength(1),
+            reason: '档 $tier 的帧率不该随格式变');
+        expect(all.map((MiningMediaCompression c) => c.gifWidth).toSet(),
+            hasLength(1),
+            reason: '档 $tier 的宽度不该随格式变');
+        expect(all.first.gifFps, greaterThan(0));
+      }
+    });
+
+    test('不传 format 时逐字节等价于改动前（默认 gif 封顶）', () {
+      final MiningMediaCompression legacy = MiningMediaCompression.resolve(
+        imageTier: MiningMediaCompression.imageTierMax,
+        audioTier: 0,
+      );
+      expect(legacy.gifFps, MiningMediaCompression.gifMaxTierFps);
+      expect(legacy.gifWidth, MiningMediaCompression.gifMaxTierWidth);
+      // 截图侧的原图直通语义自始至终没变。
+      expect(legacy.screenshotMaxLongEdge, 0);
+    });
+  });
+
+  group('buildFfmpegClipAnimatedArgs 按格式分派', () {
+    List<String> argsFor(MiningAnimatedFormat f,
+            {int fps = 8, int width = 480}) =>
+        buildFfmpegClipAnimatedArgs(
+          format: f,
+          inputPath: '/v.mp4',
+          startMs: 1000,
+          endMs: 5000,
+          outputPath: '/out.${f.fileExtension}',
+          fps: fps,
+          width: width,
+        );
+
+    test('GIF 走 filter_complex 双趟调色板且不带 -c:v（与改动前逐字等价）', () {
+      final List<String> gif = argsFor(MiningAnimatedFormat.gif);
+      expect(gif, contains('-filter_complex'));
+      expect(gif.contains('-vf'), isFalse);
+      expect(gif.join(' '), contains('palettegen'));
+      expect(gif.join(' '), contains('paletteuse'));
+      expect(gif.contains('-c:v'), isFalse,
+          reason: 'gif 由扩展名选编码器，显式 -c:v 会改字节');
+      // 薄委托必须与泛化版完全一致。
+      expect(
+        buildFfmpegClipGifArgs(
+          inputPath: '/v.mp4',
+          startMs: 1000,
+          endMs: 5000,
+          outputPath: '/out.gif',
+          fps: 8,
+          width: 480,
+        ),
+        gif,
+      );
+    });
+
+    test('WebP/AVIF 走单趟 -vf、不生成调色板、且带各自编码器', () {
+      final List<String> webp = argsFor(MiningAnimatedFormat.webp);
+      expect(webp, contains('-vf'));
+      expect(webp.contains('-filter_complex'), isFalse);
+      expect(webp.join(' '), isNot(contains('palettegen')));
+      expect(webp.join(' '), contains('libwebp_anim'));
+
+      final List<String> avif = argsFor(MiningAnimatedFormat.avif);
+      expect(avif, contains('-vf'));
+      expect(avif.join(' '), isNot(contains('palettegen')));
+      expect(avif.join(' '), contains('libsvtav1'));
+    });
+
+    test('源直通档（fps/width=0）不加 fps/scale 滤镜，且 -vf 不为空串', () {
+      final List<String> avif =
+          argsFor(MiningAnimatedFormat.avif, fps: 0, width: 0);
+      final int vf = avif.indexOf('-vf');
+      expect(vf, greaterThanOrEqualTo(0));
+      final String chain = avif[vf + 1];
+      expect(chain, isNotEmpty, reason: 'ffmpeg 的 -vf 不接受空串');
+      expect(chain, isNot(contains('fps=')));
+      expect(chain, isNot(contains('scale=')));
+    });
+
+    test('非 GIF 用 -2 取偶高度（AVIF/WebP 编码器要求偶数维度）', () {
+      expect(argsFor(MiningAnimatedFormat.avif).join(' '),
+          contains('scale=480:-2'));
+      expect(argsFor(MiningAnimatedFormat.webp).join(' '),
+          contains('scale=480:-2'));
+    });
+
+    test('三种格式的输出扩展名与格式一致', () {
+      for (final MiningAnimatedFormat f in MiningAnimatedFormat.values) {
+        expect(argsFor(f).last, endsWith('.${f.fileExtension}'));
+      }
+    });
+  });
+
+  group('galgame 窗口动图参数', () {
+    List<String> galArgs(MiningAnimatedFormat f) => buildGalWindowAnimatedArgs(
+          format: f,
+          inputPattern: '/tmp/frame_%03d.png',
+          outputPath: '/tmp/out.${f.fileExtension}',
+          fps: 8,
+          maxWidth: 480,
+        );
+
+    test('GIF 保留双趟调色板；WebP/AVIF 单趟且带编码器', () {
+      expect(
+          galArgs(MiningAnimatedFormat.gif).join(' '), contains('palettegen'));
+      expect(galArgs(MiningAnimatedFormat.webp).join(' '),
+          isNot(contains('palettegen')));
+      expect(galArgs(MiningAnimatedFormat.webp).join(' '),
+          contains('libwebp_anim'));
+      expect(
+          galArgs(MiningAnimatedFormat.avif).join(' '), contains('libsvtav1'));
+    });
+
+    test('GIF 用 -1 高度、非 GIF 用 -2（编码器要求偶数维度）', () {
+      expect(galArgs(MiningAnimatedFormat.gif).join(' '),
+          contains('scale=480:-1'));
+      expect(galArgs(MiningAnimatedFormat.avif).join(' '),
+          contains('scale=480:-2'));
+      expect(galArgs(MiningAnimatedFormat.webp).join(' '),
+          contains('scale=480:-2'));
+    });
+
+    test('输出扩展名与格式一致', () {
+      for (final MiningAnimatedFormat f in MiningAnimatedFormat.values) {
+        expect(galArgs(f).last, endsWith('.${f.fileExtension}'));
+      }
+    });
+  });
+
+  // 视频 cue 动图与 galgame 窗口动图是两条独立链路（输入形态不同），但编码器参数必须
+  // 同源。历史上这类「两处各写一份」正是漂开的起点，这里锁死它们引用同一个函数的产物。
+  test('两条链路共用同一份编码器参数（防漂开）', () {
+    for (final MiningAnimatedFormat f in MiningAnimatedFormat.values) {
+      final List<String> shared = animatedEncoderArgs(f);
+      final String video = buildFfmpegClipAnimatedArgs(
+        format: f,
+        inputPath: '/v.mp4',
+        startMs: 0,
+        endMs: 1000,
+        outputPath: '/o.${f.fileExtension}',
+      ).join(' ');
+      final String gal = buildGalWindowAnimatedArgs(
+        format: f,
+        inputPattern: '/f_%03d.png',
+        outputPath: '/o.${f.fileExtension}',
+        fps: 8,
+        maxWidth: 480,
+      ).join(' ');
+      if (shared.isEmpty) {
+        // GIF：两边都不显式指定编码器。
+        expect(video, isNot(contains('-c:v')));
+        expect(gal, isNot(contains('-c:v')));
+      } else {
+        expect(video, contains(shared.join(' ')));
+        expect(gal, contains(shared.join(' ')));
+      }
+    }
+  });
+
+  group('引擎：编码失败时降级 GIF', () {
+    late Directory tmp;
+    setUp(() async {
+      tmp = await Directory.systemTemp.createTemp('anim_fmt_');
+    });
+    tearDown(() async {
+      if (tmp.existsSync()) await tmp.delete(recursive: true);
+    });
+
+    Future<String?> okAudio(
+            {required String inputPath,
+            required int startMs,
+            required int endMs,
+            required String outputPath,
+            int? audioStreamIndex,
+            int? audioStreamCount,
+            FfmpegFailureReporter? onFailure,
+            int audioChannels = 1,
+            String audioBitrate = '64k',
+            String? tlsPinSha256}) async =>
+        outputPath;
+
+    /// 只让 GIF 成功的抽取器 + 调用流水账。模拟「旧包捆绑的 ffmpeg 没有 libsvtav1」。
+    ({GifExtractor extractor, List<_GifCall> calls}) gifOnly() {
+      final List<_GifCall> calls = <_GifCall>[];
+      Future<String?> extractor({
+        required String inputPath,
+        required int startMs,
+        required int endMs,
+        required String outputPath,
+        int fps = 8,
+        int width = 320,
+        MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+        FfmpegFailureReporter? onFailure,
+        String? tlsPinSha256,
+      }) async {
+        calls.add(
+            (format: format, fps: fps, width: width, outputPath: outputPath));
+        return format == MiningAnimatedFormat.gif ? outputPath : null;
+      }
+
+      return (extractor: extractor, calls: calls);
+    }
+
+    test('AVIF 顶格档失败降级 GIF 时，换成 GIF 自己的封顶参数（BUG-1039 陷阱）', () async {
+      final ({GifExtractor extractor, List<_GifCall> calls}) fake = gifOnly();
+      final _RecordingRepo repo = _RecordingRepo();
+      // 顶格档 + AVIF → compression 是 0/0（源直通）。
+      final MiningMediaCompression top = MiningMediaCompression.resolve(
+        imageTier: MiningMediaCompression.imageTierMax,
+        audioTier: 0,
+        format: MiningAnimatedFormat.avif,
+      );
+      expect(top.gifFps, 0);
+
+      await ImmersionMiningEngine(
+        gifExtractor: fake.extractor,
+        audioExtractor: okAudio,
+      ).mine(
+        ImmersionMiningRequest(
+          source: AnkiMiningSource.video,
+          fields: const <String, String>{'expression': 'x'},
+          mediaSource: '/v.mp4',
+          clipStartMs: 1000,
+          clipEndMs: 5000,
+          sentence: 's',
+          animatedFormat: MiningAnimatedFormat.avif,
+        ),
+        compression: top,
+        tempDir: tmp.path,
+        repo: repo,
+      );
+
+      expect(fake.calls, hasLength(2), reason: '首选 avif 失败后必须降级 gif 再试一次');
+      expect(fake.calls[0].format, MiningAnimatedFormat.avif);
+      expect(fake.calls[0].fps, 0, reason: 'AVIF 顶格档就是源帧率直通');
+      expect(fake.calls[0].width, 0);
+
+      expect(fake.calls[1].format, MiningAnimatedFormat.gif);
+      expect(fake.calls[1].fps, MiningAnimatedFormat.gif.maxTierFps,
+          reason: '沿用 0 会把源帧率喂给 GIF —— 正是 BUG-1039 的 54 MB / 撞超时配置');
+      expect(fake.calls[1].width, MiningAnimatedFormat.gif.maxTierWidth);
+      expect(fake.calls[1].outputPath, endsWith('.gif'),
+          reason: '扩展名必须跟着实际尝试的格式走，否则 muxer 选错');
+      // 降级后仍是动图，不是「降级为静态帧」，不该弹那个 OSD。
+      expect(repo.minedContext!.coverPath, endsWith('.gif'));
+    });
+
+    test('低档位降级 GIF 时沿用原参数（非顶格档没有 0 哨兵，无需替换）', () async {
+      final ({GifExtractor extractor, List<_GifCall> calls}) fake = gifOnly();
+      final MiningMediaCompression std = MiningMediaCompression.resolve(
+        imageTier: 1,
+        audioTier: 0,
+        format: MiningAnimatedFormat.avif,
+      );
+      await ImmersionMiningEngine(
+        gifExtractor: fake.extractor,
+        audioExtractor: okAudio,
+      ).mine(
+        ImmersionMiningRequest(
+          source: AnkiMiningSource.video,
+          fields: const <String, String>{'expression': 'x'},
+          mediaSource: '/v.mp4',
+          clipStartMs: 1000,
+          clipEndMs: 5000,
+          sentence: 's',
+          animatedFormat: MiningAnimatedFormat.avif,
+        ),
+        compression: std,
+        tempDir: tmp.path,
+        repo: _RecordingRepo(),
+      );
+      expect(fake.calls, hasLength(2));
+      expect(fake.calls[0].fps, std.gifFps);
+      expect(fake.calls[1].fps, std.gifFps, reason: '有限值不该被顶格档逻辑改写');
+      expect(fake.calls[1].width, std.gifWidth);
+    });
+
+    test('首选就是 GIF 时只调一次（不做无谓的二次尝试）', () async {
+      final ({GifExtractor extractor, List<_GifCall> calls}) fake = gifOnly();
+      await ImmersionMiningEngine(
+        gifExtractor: fake.extractor,
+        audioExtractor: okAudio,
+      ).mine(
+        ImmersionMiningRequest(
+          source: AnkiMiningSource.video,
+          fields: const <String, String>{'expression': 'x'},
+          mediaSource: '/v.mp4',
+          clipStartMs: 1000,
+          clipEndMs: 5000,
+          sentence: 's',
+          animatedFormat: MiningAnimatedFormat.gif,
+        ),
+        compression: MiningMediaCompression.compressed,
+        tempDir: tmp.path,
+        repo: _RecordingRepo(),
+      );
+      expect(fake.calls, hasLength(1));
+      expect(fake.calls.single.format, MiningAnimatedFormat.gif);
+    });
+
+    test('AVIF 成功时不降级，封面扩展名是 .avif', () async {
+      final List<_GifCall> calls = <_GifCall>[];
+      Future<String?> always({
+        required String inputPath,
+        required int startMs,
+        required int endMs,
+        required String outputPath,
+        int fps = 8,
+        int width = 320,
+        MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+        FfmpegFailureReporter? onFailure,
+        String? tlsPinSha256,
+      }) async {
+        calls.add(
+            (format: format, fps: fps, width: width, outputPath: outputPath));
+        return outputPath;
+      }
+
+      final _RecordingRepo repo = _RecordingRepo();
+      await ImmersionMiningEngine(
+        gifExtractor: always,
+        audioExtractor: okAudio,
+      ).mine(
+        ImmersionMiningRequest(
+          source: AnkiMiningSource.video,
+          fields: const <String, String>{'expression': 'x'},
+          mediaSource: '/v.mp4',
+          clipStartMs: 1000,
+          clipEndMs: 5000,
+          sentence: 's',
+          animatedFormat: MiningAnimatedFormat.avif,
+        ),
+        compression: MiningMediaCompression.compressed,
+        tempDir: tmp.path,
+        repo: repo,
+      );
+      expect(calls, hasLength(1));
+      expect(calls.single.format, MiningAnimatedFormat.avif);
+      expect(repo.minedContext!.coverPath, endsWith('.avif'));
+    });
+  });
+}

--- a/hibiki/test/settings/mining_media_quality_guard_test.dart
+++ b/hibiki/test/settings/mining_media_quality_guard_test.dart
@@ -143,17 +143,36 @@ void main() {
       final String src = File(
         'lib/src/mining/immersion_mining_engine.dart',
       ).readAsStringSync();
-      // 动图链路。档位仍必须被读出并喂给抽取器，但**不再是**直接
-      // `fps: compression.gifFps`：顶格档的 0 哨兵（源分辨率+源帧率，只有 AVIF 声明
-      // 得起）在换格式重试时必须替换成目标格式自己的顶格档参数，否则会把源直通喂给
-      // GIF —— 正是 BUG-1039 那个 54 MB / 撞 120 秒超时的配置。故断言拆成两半：
-      // ① 档位被读；② 替换存在。只锁 ① 会漏掉 ② 被删除的回归。
-      expect(src.contains('compression.gifFps'), isTrue);
-      expect(src.contains('compression.gifWidth'), isTrue);
-      expect(src.contains('attempt.maxTierFps'), isTrue,
-          reason: '换格式重试必须换用目标格式的顶格档参数（BUG-1039）');
-      expect(src.contains('attempt.maxTierWidth'), isTrue,
-          reason: '换格式重试必须换用目标格式的顶格档参数（BUG-1039）');
+      // 动图链路。重构后源码里已没有 `fps: compression.gifFps` 这个字面量，但本守卫要
+      // 锁的契约一个字没变：**喂进抽取器的帧率/宽度必须来自 compression 档位，不得被
+      // 硬编码**。若只是把断言字面量改成「源码里有 `fps: fps`」，守卫就退化成「有这行
+      // 字」——把 `fps: fps` 换成 `fps: 8` 照样绿。故沿调用链锁三段：
+      //   ① `_gif(` 实参里的 fps/width 是局部变量而非字面量；
+      //   ② 这两个局部变量确实由 `compression.gifFps` / `compression.gifWidth` 派生；
+      //   ③ 派生时夹到「本次尝试格式」自己的顶格档上限——换格式重试若沿用上一个格式的
+      //      参数，就是 BUG-1039 那个 54 MB / 撞 120 秒超时 / AnkiConnect 卡死的配置。
+      final Match? gifCall =
+          RegExp(r'await _gif\(([\s\S]*?)\n\s*\);').firstMatch(src);
+      expect(gifCall, isNotNull, reason: '动图链路必须经注入的 _gif 抽取器');
+      final String gifArgs = gifCall!.group(1)!;
+      expect(RegExp(r'\bfps:\s*fps\b').hasMatch(gifArgs), isTrue,
+          reason: '喂进抽取器的帧率必须是档位派生出的局部变量，不得硬编码');
+      expect(RegExp(r'\bwidth:\s*width\b').hasMatch(gifArgs), isTrue,
+          reason: '喂进抽取器的宽度必须是档位派生出的局部变量，不得硬编码');
+      expect(RegExp(r'final int fps\s*=[^;]*compression\.gifFps').hasMatch(src),
+          isTrue,
+          reason: 'fps 必须从 compression.gifFps 派生');
+      expect(
+          RegExp(r'final int width\s*=[^;]*compression\.gifWidth')
+              .hasMatch(src),
+          isTrue,
+          reason: 'width 必须从 compression.gifWidth 派生');
+      expect(RegExp(r'final int fps\s*=[^;]*attempt\.capFps').hasMatch(src),
+          isTrue,
+          reason: '换格式重试必须夹到目标格式自己的顶格档上限（BUG-1039）');
+      expect(RegExp(r'final int width\s*=[^;]*attempt\.capWidth').hasMatch(src),
+          isTrue,
+          reason: '换格式重试必须夹到目标格式自己的顶格档上限（BUG-1039）');
       // 截图链路。
       expect(src.contains('maxLongEdge: compression.screenshotMaxLongEdge'),
           isTrue);

--- a/hibiki/test/settings/mining_media_quality_guard_test.dart
+++ b/hibiki/test/settings/mining_media_quality_guard_test.dart
@@ -143,9 +143,17 @@ void main() {
       final String src = File(
         'lib/src/mining/immersion_mining_engine.dart',
       ).readAsStringSync();
-      // GIF 链路。
-      expect(src.contains('fps: compression.gifFps'), isTrue);
-      expect(src.contains('width: compression.gifWidth'), isTrue);
+      // 动图链路。档位仍必须被读出并喂给抽取器，但**不再是**直接
+      // `fps: compression.gifFps`：顶格档的 0 哨兵（源分辨率+源帧率，只有 AVIF 声明
+      // 得起）在换格式重试时必须替换成目标格式自己的顶格档参数，否则会把源直通喂给
+      // GIF —— 正是 BUG-1039 那个 54 MB / 撞 120 秒超时的配置。故断言拆成两半：
+      // ① 档位被读；② 替换存在。只锁 ① 会漏掉 ② 被删除的回归。
+      expect(src.contains('compression.gifFps'), isTrue);
+      expect(src.contains('compression.gifWidth'), isTrue);
+      expect(src.contains('attempt.maxTierFps'), isTrue,
+          reason: '换格式重试必须换用目标格式的顶格档参数（BUG-1039）');
+      expect(src.contains('attempt.maxTierWidth'), isTrue,
+          reason: '换格式重试必须换用目标格式的顶格档参数（BUG-1039）');
       // 截图链路。
       expect(src.contains('maxLongEdge: compression.screenshotMaxLongEdge'),
           isTrue);

--- a/hibiki/test/tools/ffmpeg_min_vendored_recipe_guard_test.dart
+++ b/hibiki/test/tools/ffmpeg_min_vendored_recipe_guard_test.dart
@@ -41,11 +41,15 @@ const Map<String, String> _componentVarToFlag = <String, String>{
 /// 必须出现在入库二进制 configure 串里的独立开关（非清单形式）。
 ///
 /// libx264/gpl：H.264 片段导出（TODO-1257）。network/schannel：YouTube 远端制卡
-/// 的 http(s) 输入 + -reconnect（TODO-1214）。少任何一个都是「二进制比配方旧」。
+/// 的 http(s) 输入 + -reconnect（TODO-1214）。libsvtav1/libwebp：制卡封面动图的
+/// AVIF / WebP 编码器（默认格式已是 AVIF；缺它们时 Dart 侧会降级 GIF，卡还能制出来，
+/// 但用户选的格式静默失效）。少任何一个都是「二进制比配方旧」。
 const List<String> _requiredStandaloneFlags = <String>[
   '--disable-everything',
   '--enable-gpl',
   '--enable-libx264',
+  '--enable-libsvtav1',
+  '--enable-libwebp',
   '--enable-network',
   '--enable-schannel',
 ];

--- a/tool/ffmpeg-min/build-ffmpeg-min.sh
+++ b/tool/ffmpeg-min/build-ffmpeg-min.sh
@@ -58,7 +58,14 @@ DECODERS="h264,hevc,av1,vp9,vp8,mpeg4,mpeg2video,mpeg1video,flv,rv10,rv20,rv30,r
 # ffmpeg 直接 "Unknown encoder 'mov_text'"，字幕封装在桌面全挂（导出会自动降级成
 # 无字幕片段，见 exportVideoClipViaFfmpeg 的降级重试，但字幕永远出不来）。
 # 注意 movtext **解码器**早已在 DECODERS 里（读内嵌 mp4 字幕），编码器是另一个开关。
-ENCODERS="gif,aac,mjpeg,png,libx264,ass,ssa,subrip,webvtt,movtext,pcm_s16le"
+# libsvtav1 / libwebp_anim：制卡封面动图的 AVIF / WebP 编码器（默认格式已从 GIF 改为
+# AVIF）。选 SVT-AV1 而非 libaom：本负载是几十帧的短片，延迟比压缩率重要，静态链接体积
+# 也小一半。实测（1080p30 源 4 秒窗）：标准档 480px·8fps 下 AVIF 36 KB / GIF 471 KB /
+# WebP 163 KB；原图档（源分辨率+源帧率）AVIF 3.5 秒 3.3 MB，反而比 GIF 的 12 秒 17.8 MB
+# 又快又小，而 libwebp_anim 要 16.4 秒（它是逐帧帧内的静态图编码器，无运动补偿也不并行）。
+# 二者均为 BSD 许可，本 build 已因 libx264 是 GPL，无新增许可约束。
+# ⚠️ CI 构建环境需装 libsvtav1 / libwebp 开发包（MSYS2: mingw-w64-x86_64-{svt-av1,libwebp}）。
+ENCODERS="gif,aac,mjpeg,png,libx264,libsvtav1,libwebp,libwebp_anim,ass,ssa,subrip,webvtt,movtext,pcm_s16le"
 # pcm_s16le：能量探针（audio_energy_probe.dart，TODO-701）用 `-f null -`；null muxer 的
 # 默认音频编码器是 pcm_s16le，缺它会报 "Default encoder for format null (codec pcm_s16le)
 # is probably disabled ... Encoder not found"，探针在三平台全挂（TODO-1096）。
@@ -68,7 +75,9 @@ ENCODERS="gif,aac,mjpeg,png,libx264,ass,ssa,subrip,webvtt,movtext,pcm_s16le"
 # null: audio_energy_probe.dart uses -f null - to discard output and read astats metadata from stderr (TODO-701 subtitle auto-align)
 # mp4：片段导出 mp4（TODO-1257）把 libx264 视频 + aac 音频合成 .mp4（比 .mov 更
 # 通用、任意播放器/浏览器直接打开）；mp4 muxer 与 mov 同一 movenc，体积增量近零。
-MUXERS="gif,adts,image2,mjpeg,mov,mp4,srt,ass,webvtt,null"
+# avif / webp：动图封面的两个新容器（ffmpeg 按输出扩展名选 muxer）。avif muxer 自
+# FFmpeg 6.1 进主线，本 build 钉的 n7.1.5 已有；它与 mov/mp4 同属 movenc，体积增量近零。
+MUXERS="gif,adts,image2,mjpeg,mov,mp4,avif,webp,srt,ass,webvtt,null"
 # pad：有声书片段导出（buildFfmpegImageAudioToVideoArgs）用
 #   `scale=W:H:force_original_aspect_ratio=decrease,pad=W:H:(ow-iw)/2:(oh-ih)/2:color=black`
 #   把文本图缩进框内再黑边填充到精确 WxH；漏 pad → "No option name near '...'" +
@@ -104,7 +113,7 @@ esac
   --disable-ffplay --disable-ffprobe \
   --enable-ffmpeg \
   --enable-small --enable-zlib \
-  --enable-gpl --enable-libx264 \
+  --enable-gpl --enable-libx264 --enable-libsvtav1 --enable-libwebp \
   --enable-avcodec --enable-avformat --enable-avfilter \
   --enable-swscale --enable-swresample \
   --enable-demuxer="$DEMUXERS" \

--- a/tool/ffmpeg-min/smoke-test.sh
+++ b/tool/ffmpeg-min/smoke-test.sh
@@ -135,6 +135,27 @@ run "$FFMPEG_MIN" -hide_banner -loglevel error -y \
   -loop 0 "$WORK/cue.gif"
 assert_nonempty "$WORK/cue.gif"
 
+# 制卡封面动图的另外两种格式（默认已是 AVIF）。参数形态与
+# desktop_audio_clipper.dart 的 buildFfmpegClipAnimatedArgs 一致：真彩格式不需要
+# 调色板，滤镜退化成单趟 fps,scale，编码器各自显式指定。
+# 少了 libsvtav1 / libwebp / avif / webp muxer 中任何一项，这两条就会当场失败——
+# 「编译过了」不等于「用户选的格式能产出」，Dart 侧的 fail-open 会把这种缺失
+# 静默降级成 GIF，只有这里能抓住。
+echo "[ffmpeg-min-smoke] exporting cue WebP and AVIF"
+run "$FFMPEG_MIN" -hide_banner -loglevel error -y \
+  -ss 0.100 -t 1.000 -i "$MP4_FIXTURE" -an \
+  -vf "fps=12,scale=160:-2:flags=lanczos" \
+  -c:v libwebp_anim -lossless 0 -q:v 75 -pix_fmt yuv420p \
+  -loop 0 "$WORK/cue.webp"
+assert_nonempty "$WORK/cue.webp"
+
+run "$FFMPEG_MIN" -hide_banner -loglevel error -y \
+  -ss 0.100 -t 1.000 -i "$MP4_FIXTURE" -an \
+  -vf "fps=12,scale=160:-2:flags=lanczos" \
+  -c:v libsvtav1 -preset 8 -crf 32 -pix_fmt yuv420p \
+  -loop 0 "$WORK/cue.avif"
+assert_nonempty "$WORK/cue.avif"
+
 run "$FFMPEG_MIN" -hide_banner -loglevel error -y \
   -ss 0.100 -i "$MP4_FIXTURE" -an \
   -frames:v 1 -update 1 "$WORK/frame.jpg"


### PR DESCRIPTION
## 做了什么

制卡封面动图新增 **AVIF / WebP** 两种编码格式，**默认从 GIF 改为 AVIF**，并让顶格档（最高清晰度）重新提供**源分辨率 + 源帧率**直通。

新增 `MiningAnimatedFormat { avif, webp, gif }`，与既有 `VideoMiningImageMode` **正交**：后者选「用不用动图 + 静态帧取哪一帧」，本枚举选「动图用什么编码」。合并成一个枚举会变成「格式 × 静态来源」的笛卡尔积，故分两轴、各一个设置项。视频 / galgame 各存一份偏好（沿用 BUG-1160 的分法）。

## 实测数据（决策依据）

本机带 `libsvtav1`/`libwebp_anim` 的 ffmpeg，1080p30 合成源 4 秒窗：

| | 标准档 480px·8fps | 原图档 1080p·30fps |
|---|---|---|
| GIF | 1973 ms / 471 KB | 11978 ms / 17.8 MB |
| WebP | 877 ms / 163 KB | **16383 ms** / 5.19 MB |
| **AVIF** | 2124 ms / **36 KB** | **3502 ms** / **3.32 MB** |

两条结论：

1. **AVIF 比 GIF 小 13 倍、比 WebP 小 4.5 倍**，标准档耗时与 GIF 持平 → 值得当默认。
2. **只有 AVIF 的源直通跑得动**：它在源分辨率下比 GIF 还快 3.4 倍；WebP 规格上有帧间差分，实测却最慢（`libwebp_anim` 是逐帧帧内的静态图编码器，无运动补偿也不并行）。

所以顶格档策略由**每种格式自己声明**（`maxTierFps`/`maxTierWidth`），判据是「源直通跑不跑得动」而非「有没有帧间压缩」——初版用后者做布尔判据，被实测推翻后删掉了，`resolve()` 里「谁是特例」的分支随之消失。

这也让 BUG-1039 砍掉的动图原图档第一次真正可用；**该 BUG 对 GIF 的结论未被推翻**，GIF 顶格仍是 960px·12fps 封顶。

## 三条关键契约（都有测试）

- **降级换参**：编码器缺失时降级 GIF 重试一次，并换用**目标格式自己的**顶格档参数。沿用 AVIF 的 `0/0` 会把源分辨率+源帧率喂给 GIF，正是 BUG-1039 那个 54 MB / 撞 120 秒超时 / AnkiConnect 卡死的配置。已做变异实测：拆掉这一步测试确实转红。
- **文件名跟随实际产出格式**：gal 捕获改为返回 `(bytes, format)` 记录。按用户所选拼名会在降级后写出 `.avif` 里装 GIF 字节的卡，Anki 按扩展名判 MIME → 图直接不显示。
- **编码器参数单一真相源**：视频与 galgame 两条链路输入形态不同故不合并，但编码器参数收进 `animatedEncoderArgs()`，有测试锁死防漂开。

## ⚠️ 合并前必做

`ffmpeg-min` 配方加了 `--enable-libsvtav1 --enable-libwebp` 与 `avif`/`webp` muxer，但**入库的 `ffmpeg.exe` 还没有这两个编码器**，因此 `ffmpeg_min_vendored_recipe_guard_test` **会红**——这正是 BUG-1058 之后加这道守卫的目的。

必须手动跑一次 `.github/workflows/ffmpeg-min.yml` 并把 Windows artifact 重新 vendor 进 `third_party/`，守卫才会转绿。三平台 CI 依赖与 smoke-test 的两条真编码用例已在本 PR 内加好。

在换二进制之前，Dart 侧的 fail-open 会把 AVIF/WebP 降级回 GIF——卡照常制得出来，只是用户选的格式暂不生效。

## 验证

- `flutter analyze`（含 test 目录）全绿
- 新增 19 条测试 + 修好 5 个测试文件的假件签名；mining 定向套件全绿
- 三种格式的 ffmpeg 参数已在真实二进制上跑通并产出非空文件
- 未做真机 Anki 端验证（AnkiDroid / AnkiMobile / AnkiWeb 对动画 AVIF 的支持面需另行确认）

https://claude.ai/code/session_01AE4J319GuK9iWLWoHCdZ9f
