### PR TITLE
tool(pr-sweep): 同一 PR 同一 head commit 只落板一次（持久发布台账）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ third_party/media_kit_video/macos/Headers/
 
 # Magpie 精简包的组包产物（tools/build_magpie_slim.ps1 生成，随主包发行不入库）
 /dist/
+
+# 本地 vibe-coxswain 看板（board.db + 公开页 share_token + 任务日志 + pr_sweep 发布台账）——
+# 纯本机运行时状态，含私密 token，绝不入库
+/.vibe-coxswain/

--- a/tool/pr_sweep.sh
+++ b/tool/pr_sweep.sh
@@ -16,10 +16,11 @@
 #           PR_SWEEP_SELF（默认 hajisensai）/ PR_SWEEP_LIMIT（默认 40）
 # 输出供值班 PM 与看板对照：「自动处理」区每行都应有对应 todo（按 PR 号/分支名
 # grep 看板），没有就建（--file 已自动建）；「外部 PR」区只读不动。
-# open PR 的 todo 标题尾部记录落板时的 head commit（`[head <sha9>]`，机器可反解）；
-# 后续巡检发现同一 PR head 变了（推了新 commit）→ 落一条「有新 commit」增量 todo，
-# 引用原 TODO 和 old→new sha，让更新不被「已有 todo」去重吞掉。旧格式（无 [head]）
-# 的存量 todo 保持原去重行为（视为已跟踪，不刷屏），关掉后下轮自然换成带 sha 的新单。
+# 落板的 todo 标题尾部记录 head commit（`[head <sha9>]`，机器可反解，open/merged 同）。
+# 去重判据（2026-08-01 定）：**同一 PR 的同一 head commit 只落板一次，有新 commit
+# 才再发**——已发布 (PR, sha) 对持久记在 DB 同目录的 pr_sweep_published.tsv 台账，
+# 与看板行状态解耦（done/归档/删行都不再触发重建）。open PR 在原 todo 未 done 时
+# 推了新 commit → 落「有新 commit」增量 todo，引用原 TODO 和 old→new sha。
 set -uo pipefail
 
 FILE_MODE=0
@@ -157,12 +158,16 @@ if not rows:
     print("已落板 0 条；已存在跳过 0 条（本轮无自动处理项）")
     sys.exit(0)
 
-# 去重：一次 list（全部未归档行，含 done 未归档）复用给所有项。
-# 判据 = PR 号紧跟「] TODO-N 」出现在标题开头（别的 todo 正文顺带提及 "PR#42"
-# 不算已跟踪，对抗审查抓过的误抑制），**且该 todo 未 done**——只被 done 单跟踪的 PR
-# 会被重新落板：done 只代表「有人关了这条」，不代表 commit 真进了 develop（PR#41 假
-# 完成教训：原始合并落了 v38、合并后新推的 v39 没落却被手动标 done，旧去重把 done 单
-# 当已跟踪永久抑制，缺口再没被重捞）。只要检测阶段判定 commit 不在 base，就持续建 todo。
+# 去重（2026-08-01 判据重定）：**同一 PR 的同一 head commit 只落板一次，有新
+# commit 才再发**。已发布 (PR, sha) 对持久记在 DB 同目录的 pr_sweep_published.tsv
+# 台账（append-only），与看板行状态解耦：done/归档/删行都不再触发重建。此前判据
+# 只认未 done 行、done 单按当前 head 重捞（PR#41 假完成教训的过度矫正），结果把
+# 重复行清成 done 反而喂出重建循环（清掉→下轮判「从没落过板」→原样重建；已 MERGED
+# 的 PR 反复被捞成疑似陈旧，behind 上涨只是 develop 自己在前进）。假完成防护改由
+# sha 承担：同 commit 标 done 视为已处置不复捞，分支真有新 commit 必然再发新单。
+# PR 号匹配仍要求紧跟「] TODO-N 」出现在标题开头（正文顺带提及 "PR#42" 不算），
+# 一次 list（全部未归档行，含 done 未归档）复用给所有项。
+# 台账缺失/不全时用看板既有 [head] 标记 + 旧格式单按当前 head 补记（seed）平滑迁移。
 lp = run_cli(["list"])
 if lp.returncode != 0:
     sys.stderr.write("vibe-coxswain list 失败（rc=%s）：%s\n"
@@ -177,8 +182,8 @@ done_nums = set(re.findall(r"TODO-(\d+)", dlp.stdout)) if dlp.returncode == 0 el
 
 # PR#41 不得匹配 PR#410：号后接非数字守卫（空格/全角括号/半角括号/句读都放行）。
 _PR_TODO_RE = re.compile(r"\] TODO-(\d+) PR#(\d+)(?![0-9])")
-# open todo 标题尾部记录的落板 head（`[head <sha>]`）；取行内**最后一个**匹配，
-# 防 PR 标题正文恰好包含同格式片段时读错。
+# 落板 todo 标题尾部记录的 head（`[head <sha>]`，open/merged 同）；取行内**最后
+# 一个**匹配，防 PR 标题正文恰好包含同格式片段时读错。
 _HEAD_RE = re.compile(r"\[head ([0-9a-f]{7,40})\]")
 
 
@@ -199,16 +204,46 @@ def entries(num: str) -> list:
     return out
 
 
-def prior_done(num: str) -> bool:
-    """该 PR 曾有 done 单却又被检出未落地 = 那条是假完成（关了但 commit 没进 base）。"""
-    return any(done for _t, _s, done in entries(num))
-
-
 def same_head(a: str, b: str) -> bool:
     """短/长 sha 前缀互认（本脚本记 9 位；防历史/手改单长度不一时误判「更新了」）。"""
     return a.startswith(b) or b.startswith(a)
 
 today: str = datetime.date.today().isoformat()
+
+# 发布台账：与 board.db 同目录，行 = PR号\tsha\tTODO-N\t来源\t日期（append-only）。
+ledger_path: str = os.path.join(os.path.dirname(os.path.abspath(db_path)),
+                                "pr_sweep_published.tsv")
+published: dict = {}  # PR 号 -> 已发布过的 head sha 集合
+try:
+    with open(ledger_path, encoding="utf-8") as fh:
+        for _ln in fh:
+            _p = _ln.rstrip("\n").split("\t")
+            if len(_p) >= 2 and _p[0] and _p[1]:
+                published.setdefault(_p[0], set()).add(_p[1])
+except OSError:
+    pass  # 首轮无台账：由 seed 从看板既有单补记
+
+
+def ledger_add(num: str, sha: str, todo: str, note: str) -> None:
+    """记账 (PR, sha) 已发布。写失败只警告不中断：本轮照常落板，下轮至多重发一条。"""
+    published.setdefault(num, set()).add(sha)
+    try:
+        with open(ledger_path, "a", encoding="utf-8") as fh:
+            fh.write("%s\t%s\tTODO-%s\t%s\t%s\n" % (num, sha, todo, note, today))
+    except OSError as exc:
+        sys.stderr.write("台账写入失败 %s：%s\n" % (ledger_path, exc))
+
+
+def covered(num: str, cur: str) -> bool:
+    """(PR, cur) 是否已发布过：先查台账，再查看板标题里的 [head] 记录（迁移期
+    台账缺该对时补记，防这些行日后归档、台账失忆重发）。"""
+    if any(same_head(s, cur) for s in published.get(num, ())):
+        return True
+    for t, sha, _d in entries(num):
+        if sha is not None and same_head(sha, cur):
+            ledger_add(num, cur, t, "seed-board")
+            return True
+    return False
 added: list = []
 skipped: int = 0
 failed: int = 0
@@ -217,17 +252,27 @@ try:
 except ValueError:
     stale_behind = 20  # 环境变量给了非数字：退回默认，绝不因此崩落板
 for kind, num, title, branch, ahead, oldsha, newsha, behind in rows:
-    live = [e for e in entries(num) if not e[2]]  # 未 done 的既有 todo
-    fresh_update = False  # open PR 落板后又推新 commit 的增量单（不加重捞后缀）
+    cur = newsha  # 检测阶段写进 newsha 列的当前 head 短 sha（open/merged 同列）
+    ents = entries(num)
+    live = [e for e in ents if not e[2]]   # 未 done 的既有 todo
+    done_ents = [e for e in ents if e[2]]  # 已 done（未归档）的既有 todo
+    if cur and covered(num, cur):  # 同 PR 同 commit 只发布一次——发过即永久跳过
+        skipped += 1
+        continue
+    fresh_update = False  # open PR 原单未 done 又推新 commit 的增量单
+    _done_with_sha = [e for e in done_ents if e[1] is not None]
+    # 同 PR 最近一条带 sha 的 done 单：head 又前进时新单只覆盖其后 commit
+    prev_done = max(_done_with_sha, key=lambda e: int(e[0])) if _done_with_sha else None
     if kind == "open":
-        cur = newsha  # 检测阶段写进 newsha 列的当前 head 短 sha
         if live:
-            # 任一既有 todo 无 sha 记录（旧格式，无从判断）或 sha 未变 → 已跟踪，跳过
-            if not cur or any(sha is None or same_head(sha, cur)
-                              for _t, sha, _d in live):
+            if not cur or any(sha is None for _t, sha, _d in live):
+                # 旧格式 live 单（无 sha 记录）：视为已跟踪；补记台账，让它被
+                # 关掉/归档后同一 commit 也不再重建
+                if cur:
+                    ledger_add(num, cur, live[-1][0], "seed-live")
                 skipped += 1
                 continue
-            # 全部记录的 head 都不是当前 head = 落板后又推了新 commit → 增量 todo
+            # live 单的 sha 全不是当前 head（相同的已被 covered 挡掉）→ 增量 todo
             fresh_update = True
             prev_todo, prev_sha, _d = max(live, key=lambda e: int(e[0]))
             todo_title = ("PR#%s 有新 commit：%s（head %s→%s）[head %s]"
@@ -239,6 +284,13 @@ for kind, num, title, branch, ahead, oldsha, newsha, behind in rows:
                           % (num, prev_todo, prev_sha, cur, today))
             next_val = ("分支 %s @ %s（原 TODO-%s @ %s）"
                         % (branch, cur, prev_todo, prev_sha))
+        elif done_ents and cur and not _done_with_sha and num not in published:
+            # 全是旧格式 done 单（无 sha 可比）且台账对该 PR 零记录（迁移期一次性）：
+            # 用户已处置——按当前 head 记账跳过，不再重建（此前这里被判「从没落过板」
+            # 而原样重捞，用户清理反而喂循环）。台账一旦有记录，新 head 走正常发布。
+            ledger_add(num, cur, done_ents[-1][0], "seed-done")
+            skipped += 1
+            continue
         else:
             todo_title = "PR#%s 审查合并：%s" % (num, title)
             if cur:  # 标题尾部记录落板时 head，供后续巡检做更新检测
@@ -247,7 +299,16 @@ for kind, num, title, branch, ahead, oldsha, newsha, behind in rows:
                           "integration owner 合并 %s → CI 绿 → 关 PR、清远端分支。"
                           "来源：pr_sweep --file 自动落板 %s。" % (base, today))
             next_val = "分支 %s" % branch + (" @ %s" % cur if cur else "")
-    elif live:  # merged：与旧行为一致，有未 done todo 即跳过
+    elif live:  # merged：有未 done todo 即已跟踪；补记台账（关单后同 commit 不重建）
+        if cur:
+            ledger_add(num, cur, live[-1][0], "seed-live")
+        skipped += 1
+        continue
+    elif done_ents and cur and not _done_with_sha and num not in published:
+        # merged 旧格式 done 单（历史 merged 单不带 [head]）且台账零记录（迁移期
+        # 一次性）：按当前 head 记账跳过——这正是「已 MERGED 却每轮被重捞成疑似
+        # 陈旧」死循环的断点；台账有记录后分支再推新 commit 走正常发布。
+        ledger_add(num, cur, done_ents[-1][0], "seed-done")
         skipped += 1
         continue
     else:  # merged：合并后更新。behind 大 = 分支陈旧/被后续工作取代（PR#68 死循环教训）：
@@ -267,11 +328,14 @@ for kind, num, title, branch, ahead, oldsha, newsha, behind in rows:
             acceptance = ("【验收】逐个 commit 核实内容是否已以其它形式进 %s："
                           "未进 → 走门禁再合并；已进/已废弃 → 删远端分支并注明。"
                           "来源：pr_sweep --file 自动落板 %s。" % (base, today))
+        if cur:  # 标题尾部记录分支现 head：归档后台账 + 标题双源判重
+            todo_title += " [head %s]" % cur
         next_val = "%s→%s（behind %s）" % (oldsha, newsha, behind)
-    # 增量单不算重捞（原 todo 还活着，只是 head 前进了）；其余路径维持旧行为
-    if not fresh_update and prior_done(num):  # 曾被标 done 又检出未落地 → 明说是假完成重捞，别让人以为是新单
-        acceptance += ("（⚠️重捞：此 PR 之前有 done 单，但 commit 仍不在 %s——"
-                       "上次「已完成」是假完成，本轮按当前 head 重新落板。）" % base)
+    # 有带 sha 的 done 前单而 head 又前进了 → 新单只覆盖增量，别推翻已处置结论
+    if not fresh_update and prev_done is not None:
+        acceptance += ("（此 PR 的 TODO-%s 已按 head %s 处置过（done），本单只因其后"
+                       "又推了新 commit（现 head %s）——只看增量 diff。）"
+                       % (prev_done[0], prev_done[1], cur or "?"))
     ap = run_cli(["add", todo_title, "--status", "todo"])
     m = re.search(r"TODO-(\d+)", ap.stdout or "")
     if ap.returncode != 0 or m is None:
@@ -287,6 +351,8 @@ for kind, num, title, branch, ahead, oldsha, newsha, behind in rows:
                              % (field, todo_num, (sp.stderr or sp.stdout).strip()))
             failed += 1
     added.append("TODO-" + todo_num)
+    if cur:  # 记账：此 (PR, head) 已发布——之后该单无论 done/归档/删都不重建
+        ledger_add(num, cur, todo_num, kind)
     # 同轮防重：追加完整标题（带 PR 号 + [head sha]），entries() 重扫时能读到
     listing += "\n] TODO-%s %s" % (todo_num, todo_title)
 


### PR DESCRIPTION
## 问题（用户实测的看板噪音循环）

sweep 去重只认「未 done」行：用户把重复行清成 done，下一轮 sweep 判「这个 PR 从没落过板」原样重建——清理动作反而喂循环。实测：#539/#602/#608/#619/#618 清掉后同日重建；已 MERGED 的 #615 反复被捞成「疑似陈旧分支」（behind 125→130 只是 develop 自己在前进）；#531 一条 PR 被记成 4 条。根因是旧判据把 done 单一律当假完成按当前 head 重捞（PR#41 教训的过度矫正），且 merged 项标题不记 sha、完全无从判重。

## 修法：同一 (PR, head commit) 只发布一次，有新 commit 才再发

- 已发布 `(PR, sha)` 对持久记在 DB 同目录 `.vibe-coxswain/pr_sweep_published.tsv` 台账（append-only，运行时状态不入库），与看板行状态彻底解耦：done/归档/删行都不再触发重建。
- merged 项标题补记 `[head <sha9>]`，与 open 同源判重。
- 迁移期 seed：台账缺失时用板上既有 `[head]` 标记补记（seed-board）；旧格式无 sha 的 live/done 单按当前 head 一次性补记（seed-live/seed-done）——台账对该 PR 有记录后，新 head 一律走正常发布，不会因遗留单永久失聪。
- 假完成防护改由 sha 承担：同 commit 标 done 视为已处置不复捞；分支真推新 commit 必然再发（open 原单未 done 时仍走「有新 commit」增量单；done 后则发新单并注明只看增量）。

## 验证

1. 抽出内嵌 python，用临时看板 DB 跑 11 个场景全过：首发→落板 / 同 commit 重跑→跳过 / **done 后同 commit→跳过（旧逻辑重捞，本修核心）** / done 后新 commit→发新单带增量注记 / live 单在推新 commit→增量单 / merged 遗留 done 单（无 [head]）首见→seed 跳过 / **仅 behind 上涨→跳过（#615 死循环断点）** / 分支真推新 commit→发新单 / 旧格式 live 单→seed 跳过。
2. 真实 board.db 副本 + 真实 gh 数据端到端 `--file` 演练两轮：首轮仅新发 1 条真新 PR（#630），13 条全部 seed 进台账跳过（含 #615）；次轮 13 条稳定跳过，唯一新发是 #630 在两轮间真推了新 commit 的增量单（正是「后续再有再发」）。真实看板零写入。

## 生效说明

面板任务从主 checkout 跑 `tool/pr_sweep.sh`——合并后需让主 checkout 的这份文件更新（如 `git checkout origin/develop -- tool/pr_sweep.sh`），否则线上仍是旧判据。ci_sweep 判据是 workflow@branch、与 commit 无关，本次不动。

https://claude.ai/code/session_01QZw7wGSTLv9KaLZfLMSdmM