### PR TITLE
test(settings): 登记副字幕垂直位置的 effect 归属并补接线守卫（修 develop 既存红）

### DIFF
--- a/hibiki/test/media/video/video_subtitle_secondary_position_test.dart
+++ b/hibiki/test/media/video/video_subtitle_secondary_position_test.dart
@@ -1,9 +1,13 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/video/video_player_controller.dart';
 import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
 import 'package:hibiki/src/media/video/video_subtitle_style.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
+
+import '../../pages/video_hibiki_page_source_corpus.dart';
 
 /// 主字幕与副字幕的垂直位置**各自独立**（用户诉求：「主字幕和副字幕能支持分开高度调节」）。
 ///
@@ -176,6 +180,57 @@ void main() {
           VideoSubtitleStyle.defaults.copyWith(secondaryBottomPadding: 150);
       expect(s.secondaryBottomPadding, 150);
       expect(s.bottomPadding, VideoSubtitleStyle.defaults.bottomPadding);
+    });
+  });
+
+  // ①②③ 只证明「overlay 拿到 secondaryBottomPadding 后几何正确」。设置页滑杆 →
+  // VideoSubtitleStyle → 视频页 → overlay 这条**接线**若断掉（删掉滑杆、或
+  // layout.part.dart 不再往 overlay 传该参数），上面 8 项照样全绿、用户拖滑杆却
+  // 毫无反应——这正是 settings_schema_coverage_test 的 kCoveredElsewhere 登记
+  // 'video/Secondary subtitle position' 所声称要覆盖的那半。视频页要真播放器 +
+  // media_kit，widget harness 起不来，故这半用源码守卫咬住（与主字幕位置的
+  // video_subtitle_push_up_guard_test.dart 同范式）。
+  group('④ 设置滑杆 → style → 视频页 → overlay 接线（源码守卫）', () {
+    late String schemaSrc;
+    late String pageSrc;
+    setUpAll(() {
+      final File schema = File('lib/src/settings/settings_schema_video.dart');
+      expect(schema.existsSync(), isTrue, reason: '视频设置 schema 源文件应存在');
+      schemaSrc = schema.readAsStringSync().replaceAll('\r\n', '\n');
+      pageSrc = readVideoHibikiSource();
+    });
+
+    test('设置页有独立的副字幕位置滑杆，且写的是 secondaryBottomPadding', () {
+      expect(schemaSrc, contains("id: 'video.subtitle.position_secondary'"),
+          reason: '副字幕垂直位置必须有自己的滑杆，否则用户没有解耦入口');
+      expect(schemaSrc, contains('t.video_setting_subtitle_position_secondary'),
+          reason: '滑杆标题必须走 i18n key，不能裸字符串');
+      // 拖动预览 + 松手落盘两处都必须改副字幕字段；只改一处 = 拖着有效松手回弹
+      // 或拖着不动松手才跳。
+      expect(
+        'copyWith(secondaryBottomPadding: v)'.allMatches(schemaSrc).length,
+        greaterThanOrEqualTo(2),
+        reason: 'onChanged 预览与 onChangeEnd 落盘都必须写 secondaryBottomPadding',
+      );
+      // 未单独调过时滑杆显示主字幕当前值（「跟随」语义），不能显示成 0。
+      expect(schemaSrc, contains('s.secondaryBottomPadding ?? s.bottomPadding'),
+          reason: '未解耦时滑杆初值必须回落到主字幕基线');
+    });
+
+    test('主字幕滑杆只写 bottomPadding，不再连带改副字幕', () {
+      expect(schemaSrc, contains("id: 'video.subtitle.position'"),
+          reason: '主字幕位置滑杆必须保留');
+      expect(schemaSrc, isNot(contains('copyWith(bottomPadding: v, ')),
+          reason: '主字幕滑杆一次只准改 bottomPadding，联动改副字幕就是本 bug 的回归');
+    });
+
+    test('视频页把 style 的副字幕基线真传给 overlay', () {
+      expect(pageSrc, contains('secondaryBottomPadding:'),
+          reason: 'overlay 必须接上副字幕基线参数，否则滑杆写穿 DB 也不生效');
+      expect(pageSrc, contains('_subtitleStyle.secondaryBottomPadding'),
+          reason: '传给 overlay 的必须是 style 里的真值，不能钉常量或恒 null');
+      expect(pageSrc, contains('bottomPadding: _subtitleStyle.bottomPadding'),
+          reason: '主字幕基线接线同时保持不变（相邻功能不被带坏）');
     });
   });
 }

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -300,6 +300,16 @@ const Map<String, String> kCoveredElsewhere = <String, String>{
   'video/Background opacity': 'test/media/video/video_subtitle_style_test.dart',
   'video/Vertical position':
       'test/media/video/video_subtitle_style_test.dart + test/pages/video_subtitle_push_up_guard_test.dart',
+  // PR#610「主/副字幕垂直位置分开调节」新增的副字幕位置滑杆（与上面主字幕
+  // 'Vertical position' 同量纲、各自独立）。写 prefsRepo（changed=true），生效点在
+  // VideoSubtitleOverlay 副字幕层的真几何（_layerBaseline），需真播放器 + media_kit，
+  // 本 harness 的 video 分组无适用探针（主字幕位置同理登记）。由专项测试四层咬住：
+  // overlay 真几何两层各吃各自基线 / 改一层不牵动另一层 / null=跟随主字幕 /
+  // 持久化 round-trip，外加「设置滑杆 → style → 视频页 → overlay」接线源码守卫
+  // （群④）——否则删掉滑杆或断掉 layout.part.dart 传参时几何测试照样全绿。
+  'video/Secondary subtitle position':
+      'test/media/video/video_subtitle_secondary_position_test.dart '
+          '(①②③ overlay 真几何/跟随/持久化 + ④ 设置滑杆→视频页→overlay 接线守卫)',
   'video/Show danmaku':
       'test/media/video/video_danmaku_settings_test.dart + test/pages/video_danmaku_wiring_guard_test.dart',
   'video/Online Dandanplay match':


### PR DESCRIPTION
## 修的红

`hibiki/test/settings/settings_schema_coverage_test.dart` → `all settings destinations: focus-driven, change persists and takes effect`

```
ItemVerdict:[slider] video/Secondary subtitle position reached=true changed=true persisted=true effect=false restored=true FAIL
[schema-coverage] STILL-UNACCOUNTED: video/Secondary subtitle position (slider) — 既无探针也未登记 backlog
[schema-coverage] coverage accounting: effectVerified=16 coveredElsewhere=134 stillUnaccounted=1
```

引入来源 `06658fb36`（PR#610「主/副字幕垂直位置分开调节」），是既存红，非本轮新引入。

## 判定：A（登记遗漏），不是功能缺陷

沿真实代码路径逐段核过，副字幕垂直位置**确实作用到渲染**：

| 段 | 位置 | 事实 |
|---|---|---|
| 滑杆写入 | `settings_schema_video.dart:864-892` | `id: 'video.subtitle.position_secondary'`，onChanged 预览 + onChangeEnd 落盘两处都 `copyWith(secondaryBottomPadding: v)` |
| 落盘 | `video_settings_actions.dart:112-126` | `commitVideoSubtitleStyle` → `setVideoSubtitleStyle(VideoSubtitleStyle.encode(next))` |
| 序列化 | `video_subtitle_style.dart:376` / `437-438` | encode 写该字段、decode 读回并夹进 `[0,400]`，缺字段 → null |
| 读回 | `video_hibiki_page.dart:1958` / `2022` | `_subtitleStyle = VideoSubtitleStyle.decode(appModel.videoSubtitleStyle)` |
| 传给渲染 | `video_hibiki/layout.part.dart:393-394` | `secondaryBottomPadding: _subtitleStyle.secondaryBottomPadding` |
| 真几何 | `video_subtitle_overlay.dart:2218-2221` + `2239-2288` | `_layerBaseline(isSecondary)` 单一取值点，`_paddingFor` 顶部分支用它 |

红的真实原因：`settings_schema_coverage_test` 里 video 分组**没有适用的 effect 探针**（要真播放器 + media_kit，widget harness 起不来），同分组主字幕 `video/Vertical position` 早就登记在 `kCoveredElsewhere`，PR#610 新加的这条滑杆漏登记 → `stillUnaccounted=1`。

## 改法（2 个测试文件，零 lib 改动）

1. **`test/settings/settings_schema_coverage_test.dart`**：`kCoveredElsewhere` 补 `'video/Secondary subtitle position'`，指名 `test/media/video/video_subtitle_secondary_position_test.dart`。

2. **`test/media/video/video_subtitle_secondary_position_test.dart`**：补群 ④「设置滑杆 → style → 视频页 → overlay 接线（源码守卫）」3 项。

   为什么不能只补登记：原有 ①②③ 只验「overlay 拿到 `secondaryBottomPadding` 后几何正确」。**删掉滑杆、或断掉 `layout.part.dart` 的传参，8 项照样全绿**，用户拖滑杆毫无反应——那样的登记就是假的。群 ④ 补上从设置页到 overlay 的接线断言，登记才真覆盖 effect。范式与主字幕位置的 `video_subtitle_push_up_guard_test.dart` 一致。

   群 ④ 同时断言主字幕滑杆仍只写 `bottomPadding`（`isNot(contains('copyWith(bottomPadding: v, '))`）、`bottomPadding: _subtitleStyle.bottomPadding` 接线不变。

## 验证

**定向（修复后）**

```
00:00 +11: All tests passed!     test/media/video/video_subtitle_secondary_position_test.dart
```
```
[schema-coverage] coverage accounting: effectVerified=16 coveredElsewhere=135 stillUnaccounted=0
00:12 +2: All tests passed!      test/settings/settings_schema_coverage_test.dart   EXIT=0
```

**反向验证 1 — 拿掉登记（用备份 cp 还原，未用 `git checkout --`）**

```
MUTATION EXIT=1
[schema-coverage] STILL-UNACCOUNTED: video/Secondary subtitle position (slider) — 既无探针也未登记 backlog
[schema-coverage] coverage accounting: effectVerified=16 coveredElsewhere=134 stillUnaccounted=1
00:13 +1 -1: Some tests failed.
```

**反向验证 2 — 断掉 `layout.part.dart` 的 `secondaryBottomPadding:` 传参**（证明群 ④ 真咬住、且 ①②③ 咬不住）

```
Which: does not contain 'secondaryBottomPadding:'
overlay 必须接上副字幕基线参数，否则滑杆写穿 DB 也不生效
00:00 +10 -1: Some tests failed.
Failing tests: ④ … 视频页把 style 的副字幕基线真传给 overlay
```
注意 `+10 -1`：①②③ 全部照样绿，只有群 ④ 变红——这正是原先的覆盖缺口。

**反向验证 3 — 把 onChangeEnd 改成 `copyWith(bottomPadding: v)`**

```
Which: is not a value greater than or equal to <2>
onChanged 预览与 onChangeEnd 落盘都必须写 secondaryBottomPadding
00:00 +10 -1: Some tests failed.
```

三处变异全部 `cp` 备份还原后重跑 → `+11 All tests passed!`。

**analyze（含 test 目录）**

```
Analyzing hibiki...
No issues found! (ran in 51.1s)
```

**相邻功能（主字幕不被带坏）**

```
00:06 +83: All tests passed!
```
（`video_subtitle_push_up_guard_test.dart` + `video_subtitle_overlay_test.dart` + `video_subtitle_style_test.dart` + `video_settings_schema_guard_test.dart`）

## 对主字幕的影响

零。本 PR 不改任何 `lib/` 文件，纯测试侧；且群 ④ 新增两条断言反过来把主字幕接线（`bottomPadding: _subtitleStyle.bottomPadding`、主滑杆只写 `bottomPadding` 不联动副字幕）钉住，主字幕行为只被加固、不被改动。

`+build` 未 bump（由 integration owner 统一处理）。
