### PR TITLE
test(md3): allowlist danmaku text metrics as video content typography

### DIFF
--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -889,6 +889,21 @@ void main() {
               'adaptiveSlider / AdaptiveSettingsTextField).',
       'lib/src/media/video/video_danmaku_overlay.dart':
           'Danmaku overlay renders timed video content text, not app chrome.',
+      'lib/src/media/video/video_danmaku_text_metrics.dart':
+          'BUG-1297/PR#627 danmaku font-size single source of truth, shared '
+              'by rendering (video_danmaku_overlay) and geometry measurement '
+              '(VideoDanmakuTextMetrics.widthOf -> video_danmaku_layout). The '
+              'file is headless: no Widget/build/BuildContext/Theme.of at all, '
+              'and its only fontSize: is kVideoDanmakuBaseFontSize * the user '
+              'fontScale preference inside the videoDanmakuTextStyle factory - '
+              'timed video content typography, the same reviewed exception '
+              'class as the video_danmaku_overlay entry it was extracted from '
+              'and the user-configurable subtitle caption font size in '
+              'video_hibiki/layout.part.dart. Routing it through a shared MD3 '
+              'type role would break the contract the file documents '
+              '(inherit: false, so the host DefaultTextStyle cannot desync '
+              'measurement from render) and reintroduce the measure-18px / '
+              'render-20px drift that made danmaku vanish mid-screen.',
       'lib/src/media/video/video_thumbnail_preview_overlay.dart':
           'TODO-669 hover/seek thumbnail preview overlay: thumbnail frame corner '
               'radius (BorderRadius.circular(6*uiScale)) and timestamp bubble '


### PR DESCRIPTION
修 develop 上的测试红（看板主行=2439）。

## 红的事实

`hibiki/test/settings/md3_design_system_static_test.dart` 的
`ordinary page chrome does not reopen local MD3 decisions` 在 develop `aad275ec4` 上红：

```
Expected: empty
  Actual: ['lib/src/media/video/video_danmaku_text_metrics.dart: fontSize:']
```

引入来源是弹幕 PR#627（`8927d344d`）新增的
`hibiki/lib/src/media/video/video_danmaku_text_metrics.dart`，
allowlist 里有兄弟文件 `video_danmaku_overlay.dart` / `danmaku_manual_match_panel.dart`，唯独没有它。

## 性质判定：合理豁免（不是真违规）

命中点 `video_danmaku_text_metrics.dart:24` → `fontSize: kVideoDanmakuBaseFontSize * fontScale,`，
位于 `videoDanmakuTextStyle()` 这个纯 `TextStyle` 工厂里。判据：

1. **文件是 headless 的，根本不做页面 chrome。** 全文件 85 行，`Widget` / `build(` /
   `BuildContext` / `Scaffold` / `Theme.of` / `Decoration` 各 0 处 —— 它只有一个常量、
   一个 `TextStyle` 工厂、一个 `TextPainter` 宽度测量缓存。这条守卫针对的是页面外壳装饰。
2. **它的职责是弹幕字号的唯一真相源。** 渲染侧 `video_danmaku_overlay.dart:214`
   （已豁免：`Danmaku overlay renders timed video content text, not app chrome.`）
   与几何测量侧 `VideoDanmakuTextMetrics.widthOf` → `video_danmaku_layout.dart:56` 共用它。
   PR#627/BUG-1297 抽出这个文件，正是为了消灭「按 18px 估宽、按 20px 渲染」的两份真相。
3. **字号由用户的弹幕 `fontScale` 偏好驱动**（`video_danmaku_overlay.dart:163/180` 的 `style.fontScale`），
   与已豁免的用户可配字幕字号（`video_hibiki/layout.part.dart`、`settings_schema_video.dart`）同类。
4. **改成走共享 MD3 字号 token 会主动制造回归。** 文件自己的文档注释写明
   `inherit: false` 是几何正确性的一部分：一旦让宿主 `DefaultTextStyle`（Material 的
   `letterSpacing: 0.25`）参与，测量侧拿不到那份主题，两边立刻漂开 —— 正是 PR#627 修掉的
   「弹幕没滑出屏幕就被判过期而突然消失」。

所以这里加 allowlist 条目 + 豁免理由，不改生产代码。

## 关掉守卫的副作用已核查

豁免等于在这个文件上关掉守卫，因此逐项扫了守卫的全部 11 个违禁 token：
`fontSize:` 命中 1 处（即上述唯一一处），
`BorderRadius.circular(` / `VisualDensity.compact` / `surfaceContainerLow` /
`surfaceContainerHigh` / `surfaceContainerHighest` / `Card(` / `ListTile(` /
`SwitchListTile(` / `CheckboxListTile(` / `PopupMenuButton(` 全部 0 处。
文件里没有任何 widget 构建代码，结构上也长不出页面 chrome。

## 验证

- 定向：`flutter test test/settings/md3_design_system_static_test.dart --no-pub` → `+60: All tests passed!`（exit 0）
- 反向验证（两个方向）：
  - 删掉本 PR 新增的 allowlist 条目 → 转红，`Actual: ['lib/src/media/video/video_danmaku_text_metrics.dart: fontSize:']`，exit 255
  - 反向文本替换还原（未用 `git checkout --`）→ `git diff --exit-code` 与提交字节一致，重跑转绿，exit 0
- `flutter analyze`（含 test）→ `No issues found!`
- 顺带扫红：`dart run tool/flutter_test_failures.dart test/settings test/media --no-pub`
  → `FLUTTER TEST VERDICT: PASSED - 4099 tests ran, all tests passed`（exit 0）。
  **未跑**全量套件其余目录（database / epub / creator / reader / pages / widgets / goldens / i18n 等），由 PR CI 兜底。
