### PR TITLE
fix(pr-sweep): 落地判据从 commit SHA 改成内容判据（git cherry / patch-id）

### DIFF
--- a/tool/pr_sweep.sh
+++ b/tool/pr_sweep.sh
@@ -24,6 +24,23 @@
 # 否则「关掉重复/已完成行」这个清理动作本身就是循环的燃料——下轮 sweep 看不到任何行，
 # 又建一条一模一样的（2026-07-31 实测 PR#539/#602/#608/#618/#619 全被复制成 2~3 条，
 # 已合并的 PR#615 更是关一次涨一次 behind 地重建）。head 真变了仍照建增量单。
+#
+# **「内容有没有进 $BASE」按内容判，不按 commit SHA 判**：本仓 integration 大量走
+# rebase / cherry-pick / 自建 merge commit，PR 分支上的 commit SHA 与真正落进 $BASE
+# 的 SHA 系统性对不上。`gh api compare` 的 ahead_by 是按 commit 图算的，对 rebase 后
+# 的等价提交照样算 ahead>0，于是「内容没落地」永远为真，配上假完成重捞就每轮重建：
+#   · PR#539 head 已是 $BASE 祖先（走 rebase + 自建 merge commit），PR 却仍 open；
+#   · PR#514 三个 commit 全部以不同 SHA 落地，compare 仍报 ahead 3。
+# 判据换成 `git cherry`（patch-id 等价）：分支相对 merge-base 的每个非 merge commit，
+# 在 $BASE 上找得到 patch-id 等价物就算已落地；一个不缺 = 内容已全部落地 -> 不落板，
+# 只在「内容已全部落地」区单列（该关 PR / 删远端分支，不是该审查合并）。
+# patch-id 覆盖不到的一类：落地时补丁本身被改写（PR#503 落地时 BUG 号 1175~1178 被重编成
+# 1180~1183，代码等价但注释/文档字节不同 -> patch-id 必然不等，内容确实已在 $BASE）。这类
+# 只能人核，核完在该 PR 的**任一**看板行里写显式标记 `[landed <当时的 head sha>]`，落板阶段
+# 见到即跳过（标记锚在不可变的 head sha 上，不随行的死活变化；head 真变了标记自动失效）。
+# 🔴 判据不可用一律 fail-open（无 git / fetch 不到 objects / $BASE 解析不出 -> 按未落地走
+# 旧行为）。「PR 关了但改动没进 $BASE」必须照旧被重新落板（PR#41 教训），绝不允许为了
+# 消噪音把这条护栏一起关掉。
 set -uo pipefail
 
 FILE_MODE=0
@@ -57,42 +74,90 @@ export PYTHONUTF8=1   # Windows GBK 控制台下内嵌 python 打中文不乱码
 # 非 Windows/无 cygpath 时保持原路径（Linux/Mac 上 mktemp 路径本就通用）。
 AUTO_TSV="$(mktemp)"
 AUTO_TSV="$(cygpath -m "$AUTO_TSV" 2>/dev/null || echo "$AUTO_TSV")"
-trap 'rm -f "$AUTO_TSV"' EXIT
+MINE_TSV="$(mktemp)"
+MINE_TSV="$(cygpath -m "$MINE_TSV" 2>/dev/null || echo "$MINE_TSV")"
+EXT_TXT="$(mktemp)"
+EXT_TXT="$(cygpath -m "$EXT_TXT" 2>/dev/null || echo "$EXT_TXT")"
+trap 'rm -f "$AUTO_TSV" "$MINE_TSV" "$EXT_TXT"' EXIT
+
+# 内容落地判据：`git cherry <base> <head>` 把 merge-base..head 的每个**非 merge** commit
+# 按 patch-id 拿去 base 上找等价物，找不到打 `+`、找到打 `-`；`+` 数 = 真正没落地的 commit
+# 数。这是 git 自带的内容判据，天然吃 rebase / cherry-pick / 换 SHA。
+# 需要本地有 objects：`git fetch <remote> <ref>` **不带 refspec** 只更新 FETCH_HEAD + 拉
+# objects，不动任何本地分支、不碰工作区、不抢 index.lock，在共享 checkout 里跑是安全的。
+# 仓库根锚**脚本自身位置**，不吃 cwd：面板任务从任意目录调本脚本，cwd 不在仓库里时
+# 裸 `git` 直接失败 -> 判据静默停用 -> 又退回按 SHA 判的老毛病（实测踩到过）。
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GIT_REMOTE="${PR_SWEEP_REMOTE:-origin}"
+BASE_SHA=""
+if git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1 \
+   && git -C "$ROOT" fetch --no-tags -q "$GIT_REMOTE" "$BASE" >/dev/null 2>&1; then
+  BASE_SHA="$(git -C "$ROOT" rev-parse FETCH_HEAD 2>/dev/null)" || BASE_SHA=""
+fi
+case "$BASE_SHA" in *[!0-9a-f]*|"") BASE_SHA="";; esac   # 解析不出 -> 判据整体停用
+[ -n "$BASE_SHA" ] || echo "（内容落地判据不可用：取不到 $GIT_REMOTE/$BASE——本轮一律按未落地处理）" >&2
+
+# 未落地 commit 数；**判不出来输出 "?"**（调用方按未落地走旧行为，绝不静默吞掉真缺口）
+unlanded_count() {
+  local head="$1" branch="$2"
+  [ -n "$BASE_SHA" ] && [ -n "$head" ] || { echo "?"; return; }
+  if ! git -C "$ROOT" cat-file -e "${head}^{commit}" 2>/dev/null; then
+    git -C "$ROOT" fetch --no-tags -q "$GIT_REMOTE" "$branch" >/dev/null 2>&1
+    git -C "$ROOT" cat-file -e "${head}^{commit}" 2>/dev/null || { echo "?"; return; }  # fork/已删
+  fi
+  git -C "$ROOT" cherry "$BASE_SHA" "$head" 2>/dev/null | grep -c "^+"
+}
+
+# 「内容已全部落地」项：不落板，末尾单列一节（该关 PR / 删远端分支，不是该审查合并）
+LANDED_REPORT=""
 
 open_json=$(gh pr list --repo "$REPO" --state open \
   --json number,title,headRefName,headRefOid,author,updatedAt 2>/dev/null) || {
   echo "（gh 拉取失败——先核代理/网络，别当成没有 PR）"; exit 3; }
 
-echo "=== OPEN PR·自动处理（作者=$SELF：无对应看板 todo 就建 → 审查→复测→integration owner 合并→关 PR）==="
-# 注意：只有 mine（作者=SELF）写进 TSV；ext（外部作者）只打印、绝不进落板管道。
+# python 只做拆分：mine 写 TSV 交给下面的 bash 逐条过内容判据，ext 直接渲染成整行。
+# 注意：只有 mine（作者=SELF）会进落板管道；ext（外部作者）只打印、绝不落板。
 echo "$open_json" | python -c '
 import json, sys
-self_login, tsv_path = sys.argv[1], sys.argv[2]
+self_login, mine_path, ext_path = sys.argv[1], sys.argv[2], sys.argv[3]
 rows = json.load(sys.stdin)
-mine = [r for r in rows if r["author"]["login"] == self_login]
-ext  = [r for r in rows if r["author"]["login"] != self_login]
 def clean(s: str) -> str:
     return " ".join(str(s).split())  # 去掉标题里的 tab/换行，保 TSV 一行一项
-with open(tsv_path, "a", encoding="utf-8") as f:
-    for r in mine:  # 8 列（kind num title branch ahead oldsha newsha behind）；
-                    # open 项 newsha 列 = 当前 head 短 sha（落板记录 + 更新检测判据）
-        f.write("open\t%s\t%s\t%s\t\t\t%s\t\n"
-                % (r["number"], clean(r["title"]), clean(r["headRefName"]),
-                   str(r.get("headRefOid") or "")[:9]))
-for r in mine:
-    print("#%s %s | head=%s@%s | updated=%s"
-          % (r["number"], r["title"], r["headRefName"],
-             str(r.get("headRefOid") or "?")[:9], r["updatedAt"]))
-if not mine:
-    print("（无）")
-print()
-print("=== OPEN PR·外部作者（不自动处理·不建 todo·不合并——仅列出等用户明示）===")
-for r in ext:
-    print("#%s [%s] %s | head=%s | updated=%s"
-          % (r["number"], r["author"]["login"], r["title"], r["headRefName"], r["updatedAt"]))
-if not ext:
-    print("（无）")
-' "$SELF" "$AUTO_TSV"
+with open(mine_path, "w", encoding="utf-8") as fm, \
+     open(ext_path, "w", encoding="utf-8") as fe:
+    for r in rows:
+        if r["author"]["login"] == self_login:
+            fm.write("%s\t%s\t%s\t%s\t%s\n"
+                     % (r["number"], clean(r["title"]), clean(r["headRefName"]),
+                        str(r.get("headRefOid") or ""), r["updatedAt"]))
+        else:
+            fe.write("#%s [%s] %s | head=%s | updated=%s\n"
+                     % (r["number"], r["author"]["login"], clean(r["title"]),
+                        clean(r["headRefName"]), r["updatedAt"]))
+' "$SELF" "$MINE_TSV" "$EXT_TXT"
+
+echo "=== OPEN PR·自动处理（作者=$SELF：无对应看板 todo 就建 -> 审查->复测->integration owner 合并->关 PR）==="
+mine_found=0
+while IFS=$'\t' read -r num title branch oid updated; do
+  [ -n "$num" ] || continue
+  # 内容已全部落地的 open PR 没有可合并的东西，落「审查合并」todo 是事实错误 -> 不落板。
+  unlanded="$(unlanded_count "$oid" "$branch" </dev/null)"
+  if [ "$unlanded" = "0" ]; then
+    LANDED_REPORT="${LANDED_REPORT}#$num（open·$branch @ ${oid:0:9}）$title
+"
+    continue
+  fi
+  echo "#$num $title | head=$branch@${oid:0:9} | 未落地 commit $unlanded | updated=$updated"
+  # 8 列（kind num title branch ahead oldsha newsha behind）；
+  # open 项 newsha 列 = 当前 head 短 sha（落板记录 + 更新检测判据）
+  printf 'open\t%s\t%s\t%s\t\t\t%s\t\n' "$num" "$title" "$branch" "${oid:0:9}" >> "$AUTO_TSV"
+  mine_found=1
+done < "$MINE_TSV"
+[ "$mine_found" = "0" ] && echo "（无）"
+
+echo ""
+echo "=== OPEN PR·外部作者（不自动处理·不建 todo·不合并——仅列出等用户明示）==="
+if [ -s "$EXT_TXT" ]; then cat "$EXT_TXT"; else echo "（无）"; fi
 
 echo ""
 echo "=== 已合并 PR 的合并后更新（作者=$SELF：源分支有 commit 不在 $BASE → 建「再合并」todo）==="
@@ -108,7 +173,15 @@ while IFS=$'\t' read -r num author owner repo branch oid; do
   case "$ahead" in ""|*[!0-9]*) ahead="?";; esac
   case "$behind" in ""|*[!0-9]*) behind="?";; esac
   [ "$ahead" = "0" ] && continue                        # 新 commit 已在 $BASE（被直接合过）
-  echo "#$num $owner:$branch ahead $ahead / behind $behind（相对 $BASE·merge 时 ${oid:0:9} → 现 ${cur:0:9}）——核实内容是否已落地：未进则再合并，已进/被取代则删远端分支"
+  # ahead>0 只说明 commit **图**上对不上，不代表内容没进 $BASE（rebase/cherry-pick 换了
+  # SHA）。内容判据说一个不缺 -> 不落板，末尾单列（该删远端分支）；"?" 判不出来按未落地走。
+  unlanded="$(unlanded_count "$cur" "$branch" </dev/null)"
+  if [ "$unlanded" = "0" ]; then
+    LANDED_REPORT="${LANDED_REPORT}#$num（merged·$owner:$branch @ ${cur:0:9}）ahead 的 $ahead 个 commit 已全部以等价补丁进 $BASE
+"
+    continue
+  fi
+  echo "#$num $owner:$branch ahead $ahead（未落地 $unlanded）/ behind $behind（相对 $BASE·merge 时 ${oid:0:9} -> 现 ${cur:0:9}）——核实内容是否已落地：未进则再合并，已进/被取代则删远端分支"
   printf 'merged\t%s\t\t%s\t%s\t%s\t%s\t%s\n' \
     "$num" "$owner:$branch" "$ahead" "${oid:0:9}" "${cur:0:9}" "$behind" >> "$AUTO_TSV"
   found=1
@@ -117,12 +190,16 @@ done < <(gh pr list --repo "$REPO" --state merged --limit "$LIMIT" \
   --jq '.[] | [.number, .author.login, .headRepositoryOwner.login, .headRepository.name, .headRefName, .headRefOid] | @tsv')
 [ "$found" = "0" ] && echo "（无合并后更新）"
 
+echo ""
+echo "=== 内容已全部落地（patch-id 等价·不落板——该关 PR / 删远端分支，不是该审查合并）==="
+if [ -n "$LANDED_REPORT" ]; then printf '%s' "$LANDED_REPORT"; else echo "（无）"; fi
+
 # --file 模式：把 TSV 里的自动处理项落 vibe-coxswain 看板（去重后 add + set 三字段）。
 if [ "$FILE_MODE" = "1" ]; then
   echo ""
   echo "=== --file 落板（vibe-coxswain）==="
   # DB 锚定脚本所在仓库根的绝对路径（错 cwd 不落错库）；须已存在，绝不静默新建。
-  ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  # $ROOT 在上面（内容落地判据）已按 $BASH_SOURCE 算好，这里复用同一份真值。
   DB="${VIBE_COXSWAIN_DB:-$ROOT/.vibe-coxswain/board.db}"
   if [ ! -f "$DB" ]; then
     echo "落板中止：看板 DB 不存在：$DB（拒绝静默新建空库）" >&2
@@ -197,6 +274,15 @@ _PR_TODO_RE = re.compile(r"\] TODO-(\d+) PR#(\d+)(?![0-9])")
 _HEAD_RE = re.compile(r"\[head ([0-9a-f]{7,40})\]")
 
 
+# 人工核实后写在该 PR **任一**看板行里的显式落地标记（`[landed <当时的 head sha>]`）。
+# 给内容判据（bash 侧 git cherry / patch-id）判不出来的那一类兜底：落地时补丁本身被改写，
+# 内容等价但字节不同（PR#503 落地时 BUG 号 1175~1178 被重编成 1180~1183 就是这种）。
+# 标记锚在**不可变的 head sha** 上，不锚在行的死活上：那行 todo/done/归档都算数，
+# head 真变了（推了新 commit）标记自动失效、照常重新落板。写标记前必须人工核过内容确已在
+# base——它是「我核过了」的断言，不是「这条别烦我」的开关。
+_LANDED_RE = re.compile(r"\[landed ([0-9a-f]{7,40})\]")
+
+
 def entries(num: str) -> list:
     """看板上该 PR 号的所有 todo：[(todo_num, head_sha|None, is_done)]。
 
@@ -219,9 +305,10 @@ def entries(num: str) -> list:
 def prior_done(num: str) -> bool:
     """该 PR 曾有 done 单却又被检出未落地 = 那条是假完成（关了但 commit 没进 base）。
 
-    只给 merged 路径的「非陈旧分支」用：那里 ahead>0 表示确有内容不在 base，被标 done
-    就是真假完成（PR#41 教训）。open 路径和陈旧分支不看这个——它们的重复落板本身
-    就是噪音源。
+    只给 merged 路径的「非陈旧分支」用：能走到这里说明**内容判据**（bash 侧 git cherry）
+    已经认定确有 commit 的内容不在 base（不是「SHA 对不上」，是 patch-id 也找不到等价物），
+    这时还被标 done 就是真假完成，必须重新落板（PR#41 教训）。open 路径和陈旧分支不看
+    这个——它们的重复落板本身就是噪音源。
     """
     return any(done for _t, _s, done in entries(num))
 
@@ -229,6 +316,19 @@ def prior_done(num: str) -> bool:
 def same_head(a: str, b: str) -> bool:
     """短/长 sha 前缀互认（本脚本记 9 位；防历史/手改单长度不一时误判「更新了」）。"""
     return a.startswith(b) or b.startswith(a)
+
+
+def landed_marked(num: str, cur: str) -> bool:
+    """该 PR 的看板行里有没有针对**当前 head** 的人工落地标记 `[landed <sha>]`。"""
+    if not cur:
+        return False
+    for line in listing.splitlines() + archived_listing.splitlines():
+        m = _PR_TODO_RE.search(line)
+        if m is None or m.group(2) != num:
+            continue
+        if any(same_head(s, cur) for s in _LANDED_RE.findall(line)):
+            return True
+    return False
 
 today: str = datetime.date.today().isoformat()
 added: list = []
@@ -239,6 +339,11 @@ try:
 except ValueError:
     stale_behind = 20  # 环境变量给了非数字：退回默认，绝不因此崩落板
 for kind, num, title, branch, ahead, oldsha, newsha, behind in rows:
+    # 人工已核「内容由等价补丁落地」（bash 侧内容判据判不出来的那类）→ 本 head 不再落板。
+    # 放在最前面：它是对事实的断言，比任何 head/done 推断都强。
+    if landed_marked(num, newsha):
+        skipped += 1
+        continue
     tracked = entries(num)                        # 该 PR 的**所有**既有 todo（含 done）
     live = [e for e in tracked if not e[2]]       # 其中未 done 的
     fresh_update = False  # open PR 落板后又推新 commit 的增量单（不加重捞后缀）


### PR DESCRIPTION
接 PR#633（去重按 head 是否落过板判）之后的**第二个判据缺口**：落地与否用「PR 的 commit SHA 在不在 base」判，而本仓 integration 大量走 rebase / cherry-pick / 自建 merge commit，两者系统性对不上。看板主行=2406。

## 根因（自查复核）

`gh api compare` 的 `ahead_by` 按 commit **图**算，对 rebase 后的等价提交照样算 `ahead>0`：

| PR | 实况 | 旧判据 |
|---|---|---|
| #539 | head `13a45c6d8` 经 `git merge-base --is-ancestor` 验证**已是 develop 祖先**，compare `ahead=0`，只是 PR 没关 | 无落地判据，照旧当「待审查合并」落板 |
| #514 | 3 个 commit 全部以不同 SHA 落地，`git cherry` 全 `-` | compare 仍报 `ahead=3` |
| #503 | 5 个 commit 内容全在 develop（3 个 patch-id 等价；2 个落地时 BUG 号 1175~1178 被重编成 1180~1183，代码等价但字节不同） | 永远判成未落地 |

⚠️ 顺带查实：**每小时跑 sweep 的主 checkout 停在 `a2011e7e1`，不含 PR#633（`38cf17a92`）**。看板上 2435/2436 被原样重建，是旧脚本的 `done_nums` 整行 findall 误伤活行所致（#633 已修的根因 1），不是 `prior_done` 干的。已 A/B 复现，详见下方。

## 改法（选项 3：内容判据 + 显式标记兜底）

1. **内容判据**用 git 自带的 `git cherry <base> <head>`（patch-id 等价）：`+` 数 = 真正没落地的 commit 数。天然吃 rebase / cherry-pick / 换 SHA，天然跳过 merge commit，比手搓 patch-id 集快一个数量级（14 个分支 35s → 4s）。open / merged 两条路径共用同一判据，无特例分支。
2. **全部落地的 PR 不落板**，改在「内容已全部落地」区单列——该关 PR / 删远端分支，不是该审查合并。
3. **显式标记 `[landed <head sha>]`** 兜底 patch-id 判不出来的一类（落地时补丁本身被改写）。人核后写在该 PR 任一看板行里即可，锚在不可变的 head sha 上，不随行的死活变化；head 真变了自动失效。
4. `git` 一律 `git -C "$ROOT"`：面板任务从任意目录调本脚本，裸 `git` 会失败导致判据**静默停用**（实测在测试里踩到）。
5. **判据不可用一律 fail-open**（输出 `?` 按未落地走旧行为）。

## 双向实证（全部对 `sqlite3 backup` 出来的看板副本跑，真看板零写入）

**误报侧**——把 #503/#539 的看板行**清到一条不剩**（比设 done 更极端）：

| 场景 | 旧（develop `aad275ec4`） | 新 |
|---|---|---|
| #539 | 重建 `PR#539 审查合并 [head 13a45c6d8]` | **不重建**，进「内容已全部落地」区 |
| #514 | — | **不重建**，进「内容已全部落地」区 |
| #503 无标记 | 重建 | 仍重建（patch-id 判不出来，行为正确） |
| #503 带 `[landed 1c4fa3bf9]` | — | **跳过**（对照组：同一行去掉标记即建增量单） |

幂等：第 1 轮落板 4 条（PR#637/#636/#635 新 PR + PR#630 真推了新 commit），把这 4 条全设 done 后第 2 轮 **落板 0 条 / 跳过 14 条**。

**护栏侧**——真·假完成必须仍被抓出来：#615 全部看板行设 done，`git cherry` 实测 2 个 commit 内容确实不在 develop：

```
已落板 5 条：… TODO-2441
验收: 【验收】逐个 commit 核实内容是否已以其它形式进 develop：…
（⚠️重捞：此 PR 之前有 done 单，但 commit 仍不在 develop——上次「已完成」是假完成，本轮按当前 head 重新落板。）
```

**fail-open**：`PR_SWEEP_REMOTE=no-such-remote` → stderr 打「内容落地判据不可用」，`未落地 commit ?`，#539 照旧重新落板。判据不可用绝不静默吞缺口。

## 纪律

- `bash -n tool/pr_sweep.sh` 通过；两段内嵌 python（`python -c` 段 15 行 / heredoc 段 226 行）各自 `compile()` 通过。
- 控制字符 + CRLF 终检：`异常控制字符: []`、`CRLF: 0`（上次改这个脚本踩过 `\b` 被写成字面 `\x08`）。
- 只 stage `tool/pr_sweep.sh`。
