### PR TITLE
fix(dict): 引擎结果上限对齐词头预算，砍掉查词冷页段 20 倍白解压（BUG-1307）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1251 条。点号进各自文件。
+> 共 1252 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1308](bugs/BUG-1308-popup-dict-style-node-per-section.md) | 🚧 | 🚧 | 查词弹窗每条目×每词典新建一个 style 节点，触发 10 次全文档样式重算 |
 | [BUG-1307](bugs/BUG-1307-dict-engine-max-results-overshoot.md) | ✅ | ✅ | 查词冷路径白解压 20 倍：引擎结果上限硬编码 200 而 Dart 侧只用 maximumTerms |
 | [BUG-1304](bugs/BUG-1304-engine-freq-pitch-enrich-before-truncate.md) | ✅ | ✅ | 词典引擎 freq/pitch 在截断前富化：中间结果被重复富化约 3 倍（实测微优化，非秒级根因） |
 | [BUG-1303](bugs/BUG-1303-hoshidicts-hash-probe-unbounded.md) | ✅ | ✅ | 词典 hash 探测无界循环 + load() 零边界校验：损坏词典可致查词永久挂死/越界读 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1250 条。点号进各自文件。
+> 共 1251 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1307](bugs/BUG-1307-dict-engine-max-results-overshoot.md) | ✅ | ✅ | 查词冷路径白解压 20 倍：引擎结果上限硬编码 200 而 Dart 侧只用 maximumTerms |
 | [BUG-1304](bugs/BUG-1304-engine-freq-pitch-enrich-before-truncate.md) | ✅ | ✅ | 词典引擎 freq/pitch 在截断前富化：中间结果被重复富化约 3 倍（实测微优化，非秒级根因） |
 | [BUG-1303](bugs/BUG-1303-hoshidicts-hash-probe-unbounded.md) | ✅ | ✅ | 词典 hash 探测无界循环 + load() 零边界校验：损坏词典可致查词永久挂死/越界读 |
 | [BUG-1302](bugs/BUG-1302-lookup-blocking-network-timeouts.md) | ✅ | ✅ | 查词弹窗被网络超时阻塞数秒（远端查词 remote-first + 逐词条 AnkiConnect 查重） |

--- a/docs/bugs/BUG-1307-dict-engine-max-results-overshoot.md
+++ b/docs/bugs/BUG-1307-dict-engine-max-results-overshoot.md
@@ -27,5 +27,12 @@
   （15 个用例三组：输出不变性 / FFI 缓存键带上限 / app_model 接线守卫）。
   变异实测：改回 `maxResults: 200` → 红；`getCachedFfiLookup(searchTerm)` → 红；
   推翻「每 term ≥1 glossary」前提（fixture 造零 glossary 结果）→ 不变性组红。
+- **旁证（降上限是安全的，已在生产里跑了很久）**：Android 独立弹窗进程走另一条引擎
+  入口 `hibiki/android/app/src/main/java/app/hibiki/reader/PopupDictActivity.kt:423`，
+  `maxResults = prefs.maximumSearchResults`，而该值读的偏好键
+  `maximum_dictionary_search_results`（`PopupDbReader.kt:215`）**全仓无人写入**
+  （grep 只此一处），故它一直取默认值 **16**。也就是说同一个引擎、同一份词典，
+  Android 弹窗进程长期以 16 为上限出结果，主进程却是 200 —— 两条入口本就不一致，
+  低上限那条从未被报过结果缺失。
 - **备注**：本条只砍「白干的解压条数」，**没有**动 native 侧的按需分页策略
   （`PrefetchVirtualMemory` / `madvise`）——那是跨平台预取改动，需单独评估。

--- a/docs/bugs/BUG-1307-dict-engine-max-results-overshoot.md
+++ b/docs/bugs/BUG-1307-dict-engine-max-results-overshoot.md
@@ -1,0 +1,31 @@
+## BUG-1307 · 查词冷路径白解压 20 倍：引擎结果上限硬编码 200 而 Dart 侧只用 maximumTerms
+- **报告**：2026-08-01（用户：查词 4-5 秒 / 有时像卡死）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/models/app_model.dart:3919`（旧行号）把
+  `maxResults: maximumDictionarySearchResults`（硬编码 200，`:1248`）传给引擎，而
+  `native/hoshidicts/hoshidicts_src/lookup.cpp:137-147` 是
+  `partial_sort` → `resize(max_results)` → **逐条 `materialize()`**（zstd 解压
+  glossary）。Dart 侧 `buildResultFromLookup` / `buildPopupJsonFromLookup`
+  （`packages/hibiki_dictionary/lib/src/language/language.dart:439` / `:469`）只消费
+  `maximumTerms`（用户真实值 10）条 glossary。⇒ **解压条数是消费条数的 20 倍**。
+  每条 glossary 落在 `blobs.bin`（本机 26 本词典合计 1193MB）的一个随机偏移上，
+  `memory.cpp:30-78` 是纯按需分页 mmap（无预取），冷页实测 180-234us/条（NVMe）。
+  这是「装的词典越多越慢、只有某些用户的电脑慢」的量级来源。
+  连带发现：`_ffiLookupCache` 只按 `searchTerm` 做键（`dictionary_repository.dart:271`），
+  在上限恒为常量时安全，一旦上限跟随 `effectiveMaxTerms` 变动就会让 load-more
+  命中上一轮的短结果集、`allLoaded` 提前置真 —— 修 ① 时必须同步修键。
+- **[x] ① 已修复** — `maxResults` 改传 `effectiveMaxTerms`；删除独立常量
+  `maximumDictionarySearchResults`；新增 `buildFfiLookupCacheKey`（键含上限），
+  `getCachedFfiLookup` / `cacheFfiLookup` 改收 `cacheKey`。
+  输出逐字不变的三条依据（已写进代码注释并被测试锁住）：
+  1. `partial_sort` 比较器未动 ⇒ top-N 集合与顺序不变；
+  2. `query.cpp` 的 `query_raw` 里 `glossaries.push_back` 无条件执行 ⇒ 每个返回的
+     term 至少带一条 glossary，N 个结果必凑够 N 条词头预算；
+  3. `bestLength` 取 `matched` 的最大 UTF-16 长度，而所有 `matched` 都是同一查询串的
+     前缀（`scan_candidates` 只产前缀）⇒「码点最长」与「UTF-16 最长」是同一个元素，
+     必在 `partial_sort` 后排首位、永远落在 top-N 内。
+- **[x] ② 已加自动化测试** — `hibiki/test/models/dict_engine_max_results_alignment_test.dart`
+  （15 个用例三组：输出不变性 / FFI 缓存键带上限 / app_model 接线守卫）。
+  变异实测：改回 `maxResults: 200` → 红；`getCachedFfiLookup(searchTerm)` → 红；
+  推翻「每 term ≥1 glossary」前提（fixture 造零 glossary 结果）→ 不变性组红。
+- **备注**：本条只砍「白干的解压条数」，**没有**动 native 侧的按需分页策略
+  （`PrefetchVirtualMemory` / `madvise`）——那是跨平台预取改动，需单独评估。

--- a/docs/bugs/BUG-1308-popup-dict-style-node-per-section.md
+++ b/docs/bugs/BUG-1308-popup-dict-style-node-per-section.md
@@ -1,0 +1,59 @@
+## BUG-1308 · 查词弹窗每条目×每词典新建一个 style 节点，触发 10 次全文档样式重算
+- **报告**：2026-08-01（查词 4-5 秒调查的顺带产物，主行=BUG-1307）
+- **真实性**：✅ 真 bug（已离线量化）。根因
+  `hibiki/assets/popup/popup.js:3198`（函数 `createGlossarySection`，定义 `:3111`）：
+  ```js
+  dictWrapper.appendChild(el('style', { textContent: styleText }));
+  ```
+  **无条件新建 `<style>`，零去重**。`styleText` 只由 `dictName` +
+  `window.compactGlossaries` + `window.dictionaryStyles[dictName]` 决定，三者在一次
+  弹窗渲染内**恒定**，所以同一本词典在 10 个条目下产出的是 **10 份逐字节相同**的
+  样式表。调用点在 `:3322`（首绘，每条目循环 dictNames）与 `:4120`（增量追加）。
+  用户配置（26 本词典 / `maximum_terms=10` / 3 列 / 自动展开 3×3）实测 **60 个节点、
+  3.39 MB CSS**。
+- **[ ] ① 未修复** — **已量化，等 PM 拍板是否实施**（见下）。
+- **[ ] ② 未加自动化测试** —
+- **备注 · 离线量化（Chrome 150 headless，CDP tracing + 强制 flush 墙钟双口径，
+  2 次热身 + 5 次测量 × 3 轮独立采样，池化中位数）**
+
+  素材是用户真实词典目录 `D:\APP\HIBIKI_date\documents\dictionaryResources` 里
+  26 本中带 `styles.css` 的 6 本（合计 285 KB 原始 / 334 KB 作用域化后），
+  harness 结构对齐 `createGlossarySection`，10 条目 × 6 词典 = 60 次调用。
+
+  | 组 | style 节点数 | 注入 CSS | JS 段 | 浏览器段 | 合计 |
+  |---|---:|---:|---:|---:|---:|
+  | A 现状 | 60 | 3.39 MB | 17.6 ms | **138.8 ms** | 156.4 ms |
+  | B 只加 memo（仍插 60 节点） | 60 | 3.39 MB | 5.8 ms | 134.0 ms | 139.8 ms |
+  | C 按词典去重节点 | 6 | 339 KB | 4.7 ms | **14.1 ms** | 18.8 ms |
+  | E 隔离对照：60 节点但只含小规则 | 60 | 50 KB | 1.4 ms | 103.0 ms | 104.5 ms |
+
+  CDP `UpdateLayoutTree`（Recalculate Style）：A 108-114 ms / C **6.3-8.3 ms**。
+
+  🔴 **贵的是节点数，不是字节数**：E 组只有 A 的 1/67 字节，浏览器段仍要 103 ms。
+  `ParseAuthorStyleSheet` 在三组里**一次都没出现**——Blink 的 inline style 文本缓存
+  已经把 10 份相同副本的**解析**去重了。真正的代价是：每次 `appendChild` 带进新的
+  active stylesheet → Blink 只能做**全文档**样式失效，把已插入的条目全部重算 →
+  10 个条目 = 10 次全量 recalc，规模上 **O(n²)**，load-more 加条目会更差。
+
+  ⇒ **结论：加 memo 只省 ~12 ms（纯 JS 段），浏览器侧一分不省**（memo 后 styleText
+  逐字节相同，浏览器要做的事没变）。**真正的修法是把 60 个节点去重成 6 个**
+  （C 组），省 ~138 ms / 占总代价 88%。
+
+  **推荐修法（未实施）**：`createGlossarySection` 里在计算 `styleText` **之前**先查
+  `container.querySelector('style[data-hibiki-dict-style="<name>"]')`，已存在就整段跳过
+  （连 `constructDictCss` 一起省掉）。用 DOM 查询而不是模块级 Map，因为
+  `container.innerHTML = ''` 会自动失效它，不需要额外的状态同步。
+  级联安全性已核：① 各词典样式各自 scope 在 `[data-dictionary="X"]` 下，互不冲突；
+  ② `@font-face` / `@keyframes` 被 `constructDictCss` 原样透出（全局），但保留「首次
+  出现」与保留「末次出现」的**词典间相对顺序相同**，胜负不变；③ `applyCustomCSS`
+  的节点挂在 `__hibikiOverlayParent()`（body / shadow root）末尾，永远排在
+  `#entries-container` 之后，去重不影响它与词典样式的先后。
+  改动须**手工同步三份 `popup.js`**（`hibiki/assets/popup/`、
+  `hibiki/assets/browser_extension/vendor/`、`tools/browser-extension/vendor/`），
+  守卫 `hibiki/test/build/browser_extension_popup_parity_guard_test.dart:33`。
+
+  **为什么本轮没做**：任务口径是「浏览器侧代价 < 200 ms 就降级为记录不实施」，
+  实测 138.8 ms（桌面 Chrome）低于该阈值；且被点名的修法（memo）经实测只值 12 ms。
+  节点去重是另一个更大也更有价值的改动，超出本轮授权范围，留给 PM 决定。
+  口径边界：测的是桌面 Chrome 150，app 内跑 WebView2 / Android WebView（同引擎族），
+  相对关系成立，**中低端 Android 上绝对值会显著更差**。

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -333,6 +333,22 @@ String buildSearchCacheKey({
   return '${term.length}:$term/$maxTerms/$maxResults';
 }
 
+/// 引擎原始结果（`HoshiDicts.lookup`）缓存键的单一真相。格式：
+/// `<term.length>:<term>/<maxResults>`。
+///
+/// 🔴 **键必须带 [maxResults]**：引擎按该上限 `partial_sort` + `resize` 截断，
+/// 不同上限拿到的是**不同长度**的结果集。此前 `maxResults` 是硬编码常量，键里
+/// 省掉它是安全的；现在它等于调用方的词头预算（load-more 会以「已显示条数 +
+/// maximumTerms」为新上限重查同一个词），若键里不含上限，load-more 就会命中上
+/// 一轮的短结果集、拿不到新条目，`allLoaded` 随即为 true —— load-more 永久失灵。
+@visibleForTesting
+String buildFfiLookupCacheKey({
+  required String term,
+  required int maxResults,
+}) {
+  return '${term.length}:$term/$maxResults';
+}
+
 /// 从 `blobs.bin` 头部字节解码词典实际类型（freq/pitch），供 term 词典的类型回填迁移。
 /// 此前解析与 `RandomAccessFile` 的分次读/定位深交织（[AppModel._migrateDictionaryTypes]），
 /// 无法单测（依赖真文件）。纯逻辑吃**已读入的字节**（调用方负责打开/读盘/关闭），按
@@ -1243,9 +1259,6 @@ class AppModel with ChangeNotifier {
 
   /// Maximum number of dictionary history items.
   int get maximumDictionaryHistoryItems => lowMemoryMode ? 5 : 10;
-
-  /// Maximum number of dictionary search results stored in the database.
-  final int maximumDictionarySearchResults = 200;
 
   /// Maximum number of headwords in a returned dictionary result for
   /// performance purposes.
@@ -3871,10 +3884,16 @@ class AppModel with ChangeNotifier {
       }
     }
 
+    // maxTerms 与 maxResults 现在恒等（引擎上限已对齐词头预算，见下方 lookup 调用
+    // 处），键格式保持不变以免旧键格式守卫漂移。
     final String cacheKey = buildSearchCacheKey(
       term: searchTerm,
       maxTerms: effectiveMaxTerms,
-      maxResults: maximumDictionarySearchResults,
+      maxResults: effectiveMaxTerms,
+    );
+    final String ffiCacheKey = buildFfiLookupCacheKey(
+      term: searchTerm,
+      maxResults: effectiveMaxTerms,
     );
 
     final cached = dictRepo.getCachedSearch(cacheKey);
@@ -3894,7 +3913,7 @@ class AppModel with ChangeNotifier {
     final List<HoshiKanjiResult> kanjiResults = queryKanjiForTerm(searchTerm);
 
     List<HoshiLookupResult>? ffiResults =
-        dictRepo.getCachedFfiLookup(searchTerm);
+        dictRepo.getCachedFfiLookup(ffiCacheKey);
     DictionarySearchResult? result;
 
     if (ffiResults != null) {
@@ -3914,12 +3933,28 @@ class AppModel with ChangeNotifier {
       );
       result = result.withKanjiResults(kanjiResults);
     } else {
+      // 🔴 引擎上限 == 本次真正要消费的词头预算。
+      // `lookup.cpp` 在 `partial_sort` + `resize(max_results)` **之后**才对存活的
+      // 每条结果做 `materialize()`（逐 glossary zstd 解压，每条落在 blobs.bin 的
+      // 一个随机偏移上）。此前这里传硬编码 200，而下面的 buildResultFromLookup /
+      // buildPopupJsonFromLookup 只取 effectiveMaxTerms（默认 10）条 —— 相当于在
+      // 整条链路最贵的按需分页段上白解压 20 倍。
+      //
+      // 输出逐字不变，三条理由（改这里前必须逐条复核）：
+      // 1. `partial_sort` 的比较器没动，top-N 的集合与顺序不变；
+      // 2. `query.cpp` 的 `query_raw` 里 `glossaries.push_back` 无条件执行，故
+      //    每个返回的 term 至少带一条 glossary —— N 个结果必然凑够 N 条，
+      //    buildResultFromLookup 的 maximumTerms 预算先于结果数耗尽；
+      // 3. `bestLength` 取 `matched` 的最大 UTF-16 长度，而所有 `matched` 都是
+      //    同一个查询串的前缀（`scan_candidates` 只产出前缀），故「码点最长」与
+      //    「UTF-16 最长」是同一个元素，它必在 `partial_sort` 后排首位、
+      //    永远落在 top-N 内。
       ffiResults = HoshiDicts.instance.lookup(
         searchTerm,
-        maxResults: maximumDictionarySearchResults,
+        maxResults: effectiveMaxTerms,
       );
       if (ffiResults.isNotEmpty) {
-        dictRepo.cacheFfiLookup(searchTerm, ffiResults);
+        dictRepo.cacheFfiLookup(ffiCacheKey, ffiResults);
         result = buildResultFromLookup(
           searchTerm: searchTerm,
           results: ffiResults,

--- a/hibiki/lib/src/models/dictionary_repository.dart
+++ b/hibiki/lib/src/models/dictionary_repository.dart
@@ -268,14 +268,16 @@ class DictionaryRepository {
     _dictionarySearchCache[searchTerm] = result;
   }
 
-  List<HoshiLookupResult>? getCachedFfiLookup(String searchTerm) =>
-      _ffiLookupCache[searchTerm];
+  /// [cacheKey] 由 `buildFfiLookupCacheKey` 生成，**含引擎结果上限**——不是裸
+  /// searchTerm。上限进了键，load-more 的更大上限才不会命中上一轮的短结果集。
+  List<HoshiLookupResult>? getCachedFfiLookup(String cacheKey) =>
+      _ffiLookupCache[cacheKey];
 
-  void cacheFfiLookup(String searchTerm, List<HoshiLookupResult> results) {
+  void cacheFfiLookup(String cacheKey, List<HoshiLookupResult> results) {
     _ffiLookupCache.maxBytes = _isLowMemory()
         ? ffiLookupCacheMaxBytesLowMemory
         : ffiLookupCacheMaxBytes;
-    _ffiLookupCache[searchTerm] = results;
+    _ffiLookupCache[cacheKey] = results;
   }
 
   // ── dictionary history ───────────────────────────────────────────────

--- a/hibiki/test/models/dict_engine_max_results_alignment_test.dart
+++ b/hibiki/test/models/dict_engine_max_results_alignment_test.dart
@@ -1,0 +1,183 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki_dictionary/hibiki_dictionary.dart';
+
+/// BUG-1307 守卫：交给 C++ 引擎的结果上限必须**等于**本次真正要消费的词头预算
+/// （`effectiveMaxTerms`），不得再是硬编码常量。
+///
+/// 为什么这是性能根因：`native/hoshidicts/hoshidicts_src/lookup.cpp` 里
+/// `partial_sort` + `resize(max_results)` **之后**才对存活结果逐条
+/// `materialize()`（zstd 解压 glossary，每条落在 `blobs.bin` 的一个随机偏移上，
+/// 冷页下 180-234us/条）。传 200 而只消费 10，等于在整条链路最贵的按需分页段上
+/// 白解压 20 倍。
+///
+/// 本文件三组断言各守一件事：
+/// 1. **输出不变性**：把结果集截到词头预算长度，`buildResultFromLookup` /
+///    `buildPopupJsonFromLookup` 的输出（含 `bestLength`）逐字不变——这是「可以
+///    降上限」的全部依据。
+/// 2. **load-more 不被缓存击穿**：引擎原始结果缓存的键必须带上限。
+/// 3. **接线守卫**：`app_model.dart` 真的把 `effectiveMaxTerms` 传给了引擎，
+///    且 FFI 缓存读写走的是带上限的键。
+void main() {
+  HoshiLookupResult makeResult({
+    required String matched,
+    required String expression,
+    required String reading,
+    required List<String> dictNames,
+  }) {
+    return HoshiLookupResult(
+      matched: matched,
+      deinflected: expression,
+      trace: const <HoshiTransformGroup>[],
+      preprocessorSteps: 0,
+      term: HoshiTermResult(
+        expression: expression,
+        reading: reading,
+        rules: '',
+        // 引擎侧 query_raw 的 `glossaries.push_back` 无条件执行：每个返回的 term
+        // 至少带一条 glossary。fixture 必须尊重这个前提，否则守的不是真实契约。
+        glossaries: <HoshiGlossaryEntry>[
+          for (final String d in dictNames)
+            HoshiGlossaryEntry(
+              dictName: d,
+              glossary: jsonEncode('$expression の意味（$d）'),
+              definitionTags: '',
+              termTags: '',
+            ),
+        ],
+        frequencies: const <HoshiFrequencyEntry>[],
+        pitches: const <HoshiPitchEntry>[],
+      ),
+    );
+  }
+
+  /// 模拟引擎按 `max_results` 排序后截断：`matched` 长者在前（partial_sort 的
+  /// 首要比较键），故 fixture 本身按 matched 码点长度降序构造。
+  List<HoshiLookupResult> engineResults({required int count}) {
+    return <HoshiLookupResult>[
+      for (int i = 0; i < count; i++)
+        makeResult(
+          // 全部是同一个查询串「図書館建設計画案」的前缀——scan_candidates 只产出
+          // 前缀，这正是 bestLength 不变的依据。
+          matched: '図書館建設計画案'.substring(0, 8 - (i ~/ 3).clamp(0, 7)),
+          expression: '語$i',
+          reading: 'ご$i',
+          dictNames: <String>['辞書A', '辞書B'],
+        ),
+    ];
+  }
+
+  group('BUG-1307 ① 降上限后输出逐字不变', () {
+    for (final int maxTerms in <int>[1, 3, 10, 25]) {
+      test('maxTerms=$maxTerms：200 条 vs 截到 $maxTerms 条，entries 完全一致', () {
+        final List<HoshiLookupResult> full = engineResults(count: 200);
+        final List<HoshiLookupResult> capped = full.take(maxTerms).toList();
+
+        final DictionarySearchResult fromFull = buildResultFromLookup(
+          searchTerm: '図書館',
+          results: full,
+          maximumTerms: maxTerms,
+        );
+        final DictionarySearchResult fromCapped = buildResultFromLookup(
+          searchTerm: '図書館',
+          results: capped,
+          maximumTerms: maxTerms,
+        );
+
+        expect(fromCapped.entries.length, fromFull.entries.length,
+            reason: '条目数必须不变');
+        for (int i = 0; i < fromFull.entries.length; i++) {
+          expect(fromCapped.entries[i].dictionaryName,
+              fromFull.entries[i].dictionaryName);
+          expect(fromCapped.entries[i].word, fromFull.entries[i].word);
+          expect(fromCapped.entries[i].reading, fromFull.entries[i].reading);
+          expect(fromCapped.entries[i].meaning, fromFull.entries[i].meaning);
+        }
+        // bestLength 是用户可见的整词高亮长度（clipboard_panel_controller）。
+        expect(fromCapped.bestLength, fromFull.bestLength,
+            reason: 'bestLength 变了会让横幅高亮跨度变化');
+      });
+
+      test('maxTerms=$maxTerms：popupJson 逐字节一致', () {
+        final List<HoshiLookupResult> full = engineResults(count: 200);
+        expect(
+          buildPopupJsonFromLookup(
+              results: full.take(maxTerms).toList(), maximumTerms: maxTerms),
+          buildPopupJsonFromLookup(results: full, maximumTerms: maxTerms),
+        );
+      });
+    }
+
+    test('每个 term 至少一条 glossary ⇒ N 个结果必凑够 N 条词头预算', () {
+      // 这是「上限可以从结果数降到词头数」的核心前提：预算先于结果数耗尽。
+      final DictionarySearchResult r = buildResultFromLookup(
+        searchTerm: '図書館',
+        results: engineResults(count: 10),
+        maximumTerms: 10,
+      );
+      expect(r.entries.length, 10);
+    });
+  });
+
+  group('BUG-1307 ② FFI 结果缓存键必须带上限（load-more 回归守卫）', () {
+    test('同词不同上限 ⇒ 不同键', () {
+      expect(
+        buildFfiLookupCacheKey(term: '図書館', maxResults: 10),
+        isNot(buildFfiLookupCacheKey(term: '図書館', maxResults: 20)),
+      );
+    });
+
+    test('键格式 len:term/maxResults，term.length 用 UTF-16 code units', () {
+      expect(buildFfiLookupCacheKey(term: '図書館', maxResults: 10), '3:図書館/10');
+      expect(buildFfiLookupCacheKey(term: '\u{2000B}', maxResults: 1),
+          '2:\u{2000B}/1');
+    });
+
+    test('load-more 的新上限不会命中首查的短结果集', () {
+      // 首查 10 → load-more 20（base_source_page.loadMoreForLayer 的 newMax）。
+      final Map<String, List<HoshiLookupResult>> cache =
+          <String, List<HoshiLookupResult>>{};
+      cache[buildFfiLookupCacheKey(term: '図書館', maxResults: 10)] =
+          engineResults(count: 10);
+      expect(cache[buildFfiLookupCacheKey(term: '図書館', maxResults: 20)], isNull,
+          reason: '若命中，load-more 拿不到新条目、allLoaded 会提前为 true');
+    });
+  });
+
+  group('BUG-1307 ③ 接线守卫：app_model 真的把词头预算传给引擎', () {
+    late String source;
+
+    setUpAll(() {
+      final File f = File('lib/src/models/app_model.dart');
+      expect(f.existsSync(), isTrue, reason: '守卫目标文件必须存在：${f.path}');
+      source = f.readAsStringSync();
+    });
+
+    test('HoshiDicts.instance.lookup 的 maxResults 是 effectiveMaxTerms', () {
+      final RegExp call = RegExp(
+        r'HoshiDicts\.instance\.lookup\(\s*searchTerm,\s*maxResults:\s*([A-Za-z0-9_]+)\s*,',
+        multiLine: true,
+      );
+      final Iterable<RegExpMatch> ms = call.allMatches(source);
+      expect(ms.length, 1, reason: '查词只应有一个引擎调用点');
+      expect(ms.first.group(1), 'effectiveMaxTerms',
+          reason: 'BUG-1307：上限必须等于本次消费的词头预算，不得是硬编码常量');
+    });
+
+    test('不再存在 maximumDictionarySearchResults 这个独立上限常量', () {
+      expect(source.contains('maximumDictionarySearchResults'), isFalse,
+          reason: '独立的 200 常量已被删除；恢复它就是恢复 20 倍白解压');
+    });
+
+    test('FFI 缓存读写都走带上限的 ffiCacheKey', () {
+      expect(
+          source.contains('dictRepo.getCachedFfiLookup(ffiCacheKey)'), isTrue,
+          reason: '读 FFI 缓存必须用带上限的键，否则 load-more 被短结果集击穿');
+      expect(source.contains('dictRepo.cacheFfiLookup(ffiCacheKey,'), isTrue,
+          reason: '写 FFI 缓存必须用带上限的键');
+    });
+  });
+}


### PR DESCRIPTION
## 背景

用户报「查词特别慢，某些电脑要 4-5 秒，有时像卡死」。上一轮调查把根因定在**按需分页的 mmap 冷页**：`memory.cpp:30-78` 全部数据走 `MapViewOfFile` / `mmap` 且无预取，随机 4KB 页冷 67-126μs vs 热 3.3-5.8μs（20-27×）。之前基准测出的「引擎 0.2ms」是预热 400 次后的**全热口径**，按构造把冷路径排除掉了。

本 PR **只做其中最确定、最小、收益最大的一项**：砍掉在冷页段上白干的解压量。**没有**动 native 侧的预取策略。

## 根因

`app_model.dart` 的 `searchDictionary` 把硬编码 `maxResults = 200` 传给引擎，而 `native/hoshidicts/hoshidicts_src/lookup.cpp` 的顺序是：

```
partial_sort(...)  →  resize(max_results)  →  逐条 materialize()   // zstd 解压 glossary
```

`materialize()` 是整条链路最贵的一段：每条 glossary 落在 `blobs.bin`（26 本词典合计 1193MB）的一个**随机偏移**上，冷页实测 180-234 μs/条。

而 Dart 侧 `buildResultFromLookup` / `buildPopupJsonFromLookup` 只消费 `maximumTerms` 条 glossary（用户真实值 **10**）。⇒ **解压条数是消费条数的 20 倍，全部白干，且刚好白干在最贵的那一段。**

## 改动

1. `maxResults` 改传 `effectiveMaxTerms`；删掉独立常量 `maximumDictionarySearchResults`。
2. **连带根因修复**：`_ffiLookupCache` 只按 `searchTerm` 做键。上限恒为常量时这是安全的；一旦上限跟随 `effectiveMaxTerms` 变动，load-more 的更大上限就会命中上一轮的短结果集 → `allLoaded` 提前置真 → **load-more 永久失灵**。新增 `buildFfiLookupCacheKey` 把上限放进键。

## 为什么输出逐字不变

1. `partial_sort` 的比较器没动 ⇒ top-N 的集合与顺序不变；
2. `query.cpp` 的 `query_raw` 里 `glossaries.push_back` **无条件执行** ⇒ 每个返回的 term 至少带一条 glossary，N 个结果必然凑够 N 条词头预算，`maximumTerms` 预算先于结果数耗尽；
3. `bestLength` 取 `matched` 的最大 UTF-16 长度，而所有 `matched` 都是同一查询串的**前缀**（`scan_candidates` 只产前缀）⇒「码点最长」与「UTF-16 最长」是同一个元素，它必在 `partial_sort` 后排首位、永远落在 top-N 内。

**旁证**：Android 独立弹窗进程走另一条引擎入口（`PopupDictActivity.kt:423`），读的偏好键 `maximum_dictionary_search_results` 全仓无人写入，故一直取默认值 **16**。同一引擎同一份词典，Android 弹窗长期以 16 为上限出结果，主进程却是 200——低上限那条从未被报过结果缺失。

## 收益口径

**可数的事实**：每次未命中缓存的查词，引擎 zstd 解压的 glossary 条数从 `min(命中数, 200)` 降到 `min(命中数, 10)`。按调查测得的冷页成本 180-234 μs/条（NVMe），换算 7200rpm 机械盘 ≈ 9-12ms/随机 4K。**没有做冷页口径的端到端前后计时**（需要清 page cache 的受控环境），故不给端到端秒数。

## 验证

- `flutter analyze`（含 test）：`No issues found!`
- 新增 `hibiki/test/models/dict_engine_max_results_alignment_test.dart`（15 用例）：15 passed
- 相邻套件 `test/models/` + `test/dictionary/` + load-more / popup webview 定向：**798 passed，exit 0**
- **变异实测（两个方向）**：
  - 改回 `maxResults: 200` → 红（`Expected 'effectiveMaxTerms' Actual '200'`）；反向还原 → 绿
  - `getCachedFfiLookup(ffiCacheKey)` 退回 `(searchTerm)` → 红；反向还原 → 绿
  - 推翻「每 term ≥1 glossary」前提（fixture 造零 glossary 结果）→ 不变性组红，证明该组不是废话

## 不在本 PR 范围

- native 侧 `PrefetchVirtualMemory` / `madvise` 预取（影响面大、需跨平台评估）
- 弹窗 CSS 注入（`popup.js:3196` 每条目×每词典重跑 `constructDictCss` 并插独立 `<style>`）——单独量化中
- 隐藏的 term 词典仍进引擎（`bucketDictPaths` 的 term 分支）——**需要产品口径拍板，未改**
