### PR TITLE
fix(test): 修源码扫描守卫的裸子串判据（漏真阳 + 报假阳双向错）

### DIFF
--- a/hibiki/test/helpers/source_guard.dart
+++ b/hibiki/test/helpers/source_guard.dart
@@ -52,6 +52,45 @@ bool containsCodeLine(String body, String needle) {
   return false;
 }
 
+/// 构造「以独立标识符身份出现的 [name] 调用/构造」的正则。
+///
+/// 源码守卫里最常见的判据是裸字面量 `contains('Image(')`。这个写法**两个方向都错**：
+/// - **漏真阳**：真实写法多半带命名构造器（`Image.file(` / `Image.memory(` /
+///   `Image.network(` / `Image.asset(`），`Image` 后面是 `.` 不是 `(`，子串匹配不到——
+///   守卫对它声称要防的回归形态零覆盖。
+/// - **报假阳**：`PortraitCoverImage(` / `LandscapeCoverImage(` 这类**以 `Image` 结尾**
+///   的更长标识符本身就含子串 `Image(`，于是正确写法反被判红。本仓已因此两次踩坑
+///   （BUG-1272/1299 守卫、合集 hero 守卫）。
+///
+/// 这里用负向后顾 `(?<![A-Za-z0-9_$])` 定前边界（Dart 标识符合法字符全含），并可选
+/// 吃掉命名构造器和泛型实参，一次把两个方向都堵上：
+/// - `Image(` 命中、`Image.file(` 命中、`Image .memory (` 命中、`Image<T>(` 命中
+/// - `PortraitCoverImage(` 不命中、`resolveMediaCoverImage(` 不命中、`_buildImage(` 不命中
+///
+/// [allowNamedConstructor] 置 false 时只匹配裸调用，用于「命名构造器是合法写法、
+/// 只禁裸构造」的场景。
+RegExp identifierCall(String name, {bool allowNamedConstructor = true}) {
+  return RegExp(
+    r'(?<![A-Za-z0-9_$])' +
+        RegExp.escape(name) +
+        (allowNamedConstructor ? r'(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)?' : '') +
+        r'(?:\s*<[^>]*>)?\s*\(',
+  );
+}
+
+/// [identifierCall] 的 `contains` 形态：[source] 里是否出现以独立标识符身份调用的
+/// [name]。守卫断言一律用它替代裸 `contains('Name(')`。
+bool containsIdentifierCall(
+  String source,
+  String name, {
+  bool allowNamedConstructor = true,
+}) {
+  return identifierCall(
+    name,
+    allowNamedConstructor: allowNamedConstructor,
+  ).hasMatch(source);
+}
+
 /// 截出 `switch` 里某个 `case` 标签到**下一个 `case` / `default` / switch 结束**之间
 /// 的分支体。
 ///

--- a/hibiki/test/media/video/real_path_directory_picker_test.dart
+++ b/hibiki/test/media/video/real_path_directory_picker_test.dart
@@ -10,6 +10,15 @@ import 'package:flutter_test/flutter_test.dart';
 /// 1) 两个导入入口必须调统一的 `pickRealDirectoryPath` / `pickRealFilePath`。
 /// 2) helper 自身按平台分支（安卓走权限 + 原生 SAF 通道，非安卓维持 getDirectoryPath /
 ///    pickFiles），且自绘浏览器 `_RealPathBrowser` 已彻底移除。
+/// 「真实路径入口」的**全部**导出名。单数/复数是两个真实存在的入口
+/// （`pickRealFilePath` / `pickRealFilePaths`），裸子串 `'pickRealFilePath('`
+/// 匹配不到复数版（后面是 `s` 不是 `(`）——回归成 `pickRealFilePaths(...).first`
+/// 会让下面的禁止型断言全部假绿。禁止判据必须逐个名字扫。
+const List<String> kRealPathFileEntries = <String>[
+  'pickRealFilePath(',
+  'pickRealFilePaths(',
+];
+
 void main() {
   group('source guards: import folder uses unified real-path picker', () {
     test('video_import_dialog._pickFolder calls pickRealDirectoryPath', () {
@@ -118,11 +127,13 @@ void main() {
         isTrue,
         reason: '字幕导入即被解析消费，维持系统文件选择器（board 1360 用户诉求）',
       );
-      expect(
-        pickSubtitle.contains('pickRealFilePath('),
-        isFalse,
-        reason: '_pickSubtitle 不得再走真实路径入口（board 1360 回退系统选择器）',
-      );
+      for (final String entry in kRealPathFileEntries) {
+        expect(
+          pickSubtitle.contains(entry),
+          isFalse,
+          reason: '_pickSubtitle 不得再走真实路径入口 $entry（board 1360 回退系统选择器）',
+        );
+      }
     });
 
     test('audiobook audio/subtitle rows use file picker helper', () {
@@ -165,21 +176,25 @@ void main() {
         reason: '有声书对齐字幕/SMIL/JSON 导入即被消费，维持系统文件选择器（board 1360）；'
             'iOS .srt UTI 过滤问题由 helper 内部处理',
       );
-      expect(
-        audiobookAlignment.contains('pickRealFilePath('),
-        isFalse,
-        reason: '_pickAlignment 不得再走真实路径入口（board 1360 回退系统选择器）',
-      );
+      for (final String entry in kRealPathFileEntries) {
+        expect(
+          audiobookAlignment.contains(entry),
+          isFalse,
+          reason: '_pickAlignment 不得再走真实路径入口 $entry（board 1360 回退系统选择器）',
+        );
+      }
       expect(
         bookSubtitle.contains('pickSystemFilePath('),
         isTrue,
         reason: '书籍导入字幕导入即被消费，维持系统文件选择器（board 1360），和视频字幕一致',
       );
-      expect(
-        bookSubtitle.contains('pickRealFilePath('),
-        isFalse,
-        reason: '_pickSubtitle 不得再走真实路径入口（board 1360 回退系统选择器）',
-      );
+      for (final String entry in kRealPathFileEntries) {
+        expect(
+          bookSubtitle.contains(entry),
+          isFalse,
+          reason: '_pickSubtitle 不得再走真实路径入口 $entry（board 1360 回退系统选择器）',
+        );
+      }
     });
 
     test('production code never opens iOS media library via FileType.audio',

--- a/hibiki/test/pages/continue_cover_portrait_guard_test.dart
+++ b/hibiki/test/pages/continue_cover_portrait_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1299 守卫：竖版海报封面在「继续 / 继续观看 / 合集详情」三处消费端必须
 /// 走 [PortraitCoverImage] 槽向自适应，禁止回退成硬编码 fit 的裸 `Image.file`。
 ///
@@ -59,10 +61,17 @@ void main() {
         reason: '$fn 必须委托给 _localCover（统一来源解析 + 槽向自适应渲染），'
             '不得自己另写一套封面渲染（BUG-1299）',
       );
+      // 判据必须用带标识符边界的匹配，不能用裸子串 'Image('：
+      // - 裸子串漏掉 `Image.file(` / `Image.memory(` / `Image.network(` /
+      //   `Image.asset(`（`Image` 后是 `.` 不是 `(`），而 BUG-1272 的原始回归形态
+      //   正是「自己写一条 Image.file(..., fit: BoxFit.cover) 硬编码封面槽特例」；
+      // - 裸子串又会误伤 `PortraitCoverImage(`（含子串 `Image(`），把本守卫要求的
+      //   正确写法判成违规。两个方向都由 [containsIdentifierCall] 堵上。
       expect(
-        body,
-        isNot(contains('Image(')),
-        reason: '$fn 不得绕过 _localCover 直接构造 Image',
+        containsIdentifierCall(body, 'Image'),
+        isFalse,
+        reason: '$fn 不得绕过 _localCover 直接构造 Image'
+            '（含 Image.file / Image.memory / Image.network / Image.asset）',
       );
     }
   });

--- a/hibiki/test/pages/unified_collections_architecture_guard_test.dart
+++ b/hibiki/test/pages/unified_collections_architecture_guard_test.dart
@@ -176,10 +176,10 @@ void main() {
     // 后（语义等价、仍是文件背书的 ImageProvider），锚点凭空消失、守卫误报红。
     final String thumbBody =
         methodBody(detailSrc, 'Widget _episodeThumb(VideoBookRow ep');
-    expect(thumbBody.contains('ep.coverPath'), isTrue,
+    expect(containsCodeLine(thumbBody, 'ep.coverPath'), isTrue,
         reason: '缩略图必须取该集自身的 coverPath（每集独立视频各有封面），'
             '不得回退成整个合集共用一张封面');
-    expect(thumbBody.contains('_thumbPlaceholder('), isTrue,
+    expect(containsCodeLine(thumbBody, '_thumbPlaceholder('), isTrue,
         reason: '无封面 / 读取失败必须退占位图，不得留空或抛');
   });
 

--- a/hibiki/test/pages/unified_collections_architecture_guard_test.dart
+++ b/hibiki/test/pages/unified_collections_architecture_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 统一合集 Phase 6 守卫：锁死「Jellyfin 式统一合集」架构的四条不变量（源码守卫）。
 ///
 /// 书籍 + 视频共用 MediaCollections/MediaCollectionItems 引用表；播放列表 = 合集（本地多
@@ -167,8 +169,18 @@ void main() {
     final String detailSrc = detail.readAsStringSync();
     expect(detailSrc.contains('_episodeThumb'), isTrue,
         reason: 'playlist 详情页剧集行必须带每集封面缩略图');
-    expect(detailSrc.contains('Image.file'), isTrue,
-        reason: '缩略图用集自身 coverPath 的 Image.file（无封面退占位）');
+    // 锚点锁的是**契约**（缩略图取该集自己的 coverPath、无封面退占位），不是某种
+    // 具体渲染写法。旧判据 `contains('Image.file')` 把实现写法当契约：BUG-1299 把
+    // `_episodeThumb` 从裸 `Image.file(...) + BoxFit.cover` 改成
+    // `resolveMediaCoverImage(...)` + `PortraitCoverImage(landscapeSlot: true)`
+    // 后（语义等价、仍是文件背书的 ImageProvider），锚点凭空消失、守卫误报红。
+    final String thumbBody =
+        methodBody(detailSrc, 'Widget _episodeThumb(VideoBookRow ep');
+    expect(thumbBody.contains('ep.coverPath'), isTrue,
+        reason: '缩略图必须取该集自身的 coverPath（每集独立视频各有封面），'
+            '不得回退成整个合集共用一张封面');
+    expect(thumbBody.contains('_thumbPlaceholder('), isTrue,
+        reason: '无封面 / 读取失败必须退占位图，不得留空或抛');
   });
 
   test('排序交互重设计：死权重零读取 + 排序菜单 + 成员序单一真相源 + 详情页就地排序', () {

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -671,10 +671,6 @@ void main() {
           'Token source owns app radii and semantic surface roles.',
       'lib/src/utils/components/hibiki_material_components.dart':
           'Shared MD3 component implementation may map tokens to framework widgets.',
-      'lib/src/utils/components/galgame_poster_card.dart':
-          'Shared galgame poster-card component maps radius/typography/color '
-              'tokens to framework widgets; the class name PosterCard trips the '
-              'crude Card( substring scan.',
       'lib/src/utils/components/settings_shared.dart':
           'Shared adaptive settings primitives own compact settings controls.',
       'lib/src/utils/components/hibiki_dropdown.dart':

--- a/hibiki/test/settings/settings_redesign_static_test.dart
+++ b/hibiki/test/settings/settings_redesign_static_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
 import '../sync/sync_settings_schema_source_corpus.dart';
 
 String readNormalizedSource(String path) {
@@ -227,7 +228,15 @@ void main() {
 
     expect(source, isNot(contains('adaptiveAlertDialog(')));
     expect(source, isNot(contains('CupertinoAlertDialog(')));
-    expect(source, isNot(contains('AlertDialog(')));
+    // 裸子串 'AlertDialog(' 有两个毛病：① 它同时被上面两个更长的名字包含，把两条
+    // 断言变成冗余；② 它匹配不到 `AlertDialog.adaptive(`（本仓真实在用的写法，
+    // 见 media_sources_view.dart / log_uploader.dart），旧工厂以命名构造器形式
+    // 复活就完全绕过。带标识符边界 + 吃命名构造器的匹配同时解决两点。
+    expect(
+      containsIdentifierCall(source, 'AlertDialog'),
+      isFalse,
+      reason: 'adaptive_widgets 不得再自造 AlertDialog（含 AlertDialog.adaptive）',
+    );
   });
 
   test('legacy standalone display settings page is removed', () {


### PR DESCRIPTION
## 背景

看板 TODO-2444（交叉验证线程发现①）+ 值班线程追加的同族缺陷。

源码扫描守卫里用**裸子串字面量**当判据（`contains('Xxx(')`）是一类系统性缺陷，本仓已至少踩坑三次。它有两种形态：

| 形态 | 写法 | 后果 |
|---|---|---|
| **禁止型锚点** | `isNot(contains('Image('))` | ① 漏真阳：`Image.file(` / `Image.memory(` / `Image.network(` / `Image.asset(` 匹配不到；② 报假阳：`PortraitCoverImage(` 含该子串，正确写法反被判红 |
| **要求型锚点** | `contains('Image.file')` isTrue | 生产代码换成等价（甚至更好）的写法后锚点凭空消失，守卫误报红 |

共同根因：**用具体实现写法的字面量当契约锚点**。

## 改动

### 共享判据（`test/helpers/source_guard.dart`）
新增 `identifierCall()` / `containsIdentifierCall()`：负向后顾 `(?<![A-Za-z0-9_$])` 定前边界（含 Dart 标识符全部合法字符），并可选吃掉命名构造器与泛型实参。一次堵住两个方向，不需要维护共享组件白名单。

### 逐条修复
1. **`continue_cover_portrait_guard_test.dart:70`**（禁止型，双向错）—— `isNot(contains('Image('))` → `containsIdentifierCall(body, 'Image')`。BUG-1272 的原始回归形态正是「自己写一条 `Image.file(..., fit: BoxFit.cover)` 硬编码封面槽特例」，恰好是旧判据漏掉的那一类。
2. **`unified_collections_architecture_guard_test.dart:170`**（要求型）—— **该断言在 develop 上已经是红的**。PR#602 把 `_episodeThumb` 从 `Image.file(...) + BoxFit.cover` 改写成 `resolveMediaCoverImage(...)` + `PortraitCoverImage(landscapeSlot: true)`（语义等价、仍是文件背书的 ImageProvider，渲染行为没坏），以实现写法为锚点的 `contains('Image.file')` 失锚。改成锁真正的契约：缩略图取该集自身 `ep.coverPath` + 无封面退 `_thumbPlaceholder(`，并走 `containsCodeLine` 防注释假绿。
3. **`real_path_directory_picker_test.dart`** 三处禁止型断言 —— `pickRealFilePath(` 漏掉真实存在的复数入口 `pickRealFilePaths(`；回归成 `pickRealFilePaths(...).first` 会假绿。改为逐名扫 `kRealPathFileEntries`。
4. **`settings_redesign_static_test.dart:230`** —— `isNot(contains('AlertDialog('))` 漏 `AlertDialog.adaptive(`（本仓在用：`media_sources_view.dart:624` / `log_uploader.dart:135`），且被上面两条更长断言吞成冗余。
5. **`md3_design_system_static_test.dart`** —— 删掉 `galgame_poster_card.dart` 的 allowlist 豁免。它的注释自己写明是「`GalgamePosterCard(` trips the crude `Card(` substring scan」而加的；该扫描早已改用边界匹配 `_forbiddenChromeHits`，豁免只剩「整文件对全部 11 个 forbidden token 免检」这一副作用。实测边界匹配下该文件零命中。

## 变异实测（每个方向多写法覆盖）

### `continue_cover_portrait_guard_test.dart` — 6 变异全通过

| 变异 | 期望 | 实测 | 旧判据 `contains('Image(')` | 新判据 |
|---|---|---|---|---|
| TP1 `Image(` | RED | RED | True（旧判据唯一抓得到的形态） | True |
| TP2 `Image.file(` | RED | RED | **False（旧判据漏网）** | True |
| TP3 `Image.memory(` | RED | RED | **False（旧判据漏网）** | True |
| TP4 `Image.network(` | RED | RED | **False（旧判据漏网）** | True |
| FP1 `PortraitCoverImage(` | GREEN | GREEN | **True（旧判据误红）** | False |
| FP2 `LandscapeCoverImage(` | GREEN | GREEN | **True（旧判据误红）** | False |

上一批自报的「已做变异实测」只试了 TP1 这一种最直觉的写法，恰好是唯一能被旧判据抓到的。

### `unified_collections_architecture_guard_test.dart` — 5 变异全通过
- 基线（未变异）上 `contains('Image.file')` = **False** → 旧断言在 develop 上就是红的
- TP-A 回退成合集级共用封面（不读 `ep.coverPath`）→ RED
- TP-B 去掉无封面退占位 → RED
- TP-C 把锚点降级成注释 → RED
- FP-A 等价改回裸 `Image.file` 文件背书写法 → GREEN
- FP-B 等价换成 `LandscapeCoverImage` → GREEN

### 次要修复
- §3 TP 注入 `pickRealFilePaths(` → RED（旧判据命中 = False）
- §4 TP 注入 `AlertDialog.adaptive(` → RED（旧判据命中 = False）
- §4 FP 注入更长标识符 `HibikiAlertDialog(` → GREEN（旧判据命中 = True，会误红）

全部变异还原走**反向文本替换**，逐条 assert 源文件与基线逐字节相同。

## 验证
- `flutter analyze`（含 test）：`No issues found!`
- 定向：5 个改动守卫 + `source_guard.dart` 全部消费方 + `portrait_cover_image_test.dart` = **142 tests, All tests passed, EXIT=0**

## 未在本 PR 处理（同类判据清单见看板 TODO-2444 solution）
另有 ~18 处「理论有风险、仓内当前扫描区段暂无触发标识符」的同类裸子串判据（`Focus(` / `Card(` / `ListTile(` / `Row(` / `Container(` / `Slider(` / `Wrap(` / `TextField(` / `HttpClient(` 等），碰撞标识符在本仓真实存在，任何一次正常重构就会引爆假红。统一归 TODO-2358（守卫 helper 统一）处理更合适，未在本 PR 扩大范围。
