### PR TITLE
fix(download): 清 develop 既有红第③组（下载弹窗 5 条）+ 核实第⑥组

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1253 条。点号进各自文件。
+> 共 1255 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1309](bugs/BUG-1309-anime-download-confirm-subs-squeezed.md) | ✅ | ✅ | 下载弹窗确认阶段：Jimaku 选择器挤掉字幕列表，RenderFlex 溢出 10px 且只剩不到一条可见 |
 | [BUG-1305](bugs/BUG-1305-delete-confirm-disclosure.md) | ✅ | ✅ | 删除确认文案与真实删除范围对不上（书架递归删解压目录+有声书；合集正文说反话） |
 | [BUG-1304](bugs/BUG-1304-engine-freq-pitch-enrich-before-truncate.md) | ✅ | ✅ | 词典引擎 freq/pitch 在截断前富化：中间结果被重复富化约 3 倍（实测微优化，非秒级根因） |
 | [BUG-1303](bugs/BUG-1303-hoshidicts-hash-probe-unbounded.md) | ✅ | ✅ | 词典 hash 探测无界循环 + load() 零边界校验：损坏词典可致查词永久挂死/越界读 |
@@ -42,6 +43,7 @@
 | [BUG-1299](bugs/BUG-1299-continue-cover-portrait-crop.md) | ✅ | ✅ | 竖版海报封面在继续/继续观看/合集详情被裁切或留灰带 |
 | [BUG-1298](bugs/BUG-1298-collection-hero-portrait-cover.md) | ✅ | ✅ | 合集详情页 hero 用竖版刮削海报时被 BoxFit.cover 裁成中间一条 |
 | [BUG-1297](bugs/BUG-1297-danmaku-scroll-exit.md) | ✅ | ✅ | 滚动弹幕退场突兀：没滑出屏幕就被整条抹掉 |
+| [BUG-1296](bugs/BUG-1296-anime-download-task-row-progress-lost.md) | ✅ | ✅ | 下载任务行百分比/确定进度环依赖 downloadStats，「立即导入」一跑就整列消失 |
 | [BUG-1295](bugs/BUG-1295-qb-test-connection-undiagnosable.md) | ✅ | ✅ | qB测试连接失败无法自查且本机免密被登录门卡死 |
 | [BUG-1294](bugs/BUG-1294-download-tasks-no-speed-traffic.md) | ✅ | ✅ | 下载任务行无速度与流量显示 |
 | [BUG-1293](bugs/BUG-1293-embedded-upload-mode-kills-download.md) | ✅ | ✅ | 内置引擎默认关上传误用upload_mode掐死下载 |

--- a/docs/bugs/BUG-1296-anime-download-task-row-progress-lost.md
+++ b/docs/bugs/BUG-1296-anime-download-task-row-progress-lost.md
@@ -1,0 +1,8 @@
+## BUG-1296 · 下载任务行百分比/确定进度环依赖 downloadStats，「立即导入」一跑就整列消失
+- **报告**：2026-08-01（用户：develop 全量体检既有红，主行=2453 第③组）
+- **真实性**：✅ 真 bug。根因两处：
+  - `hibiki/lib/src/pages/implementations/anime_download_dialog.dart:2206`（`_buildPlanRow` 只订阅 `service.downloadStats`）+ `:2213`（`_buildPlanRowInner` 用 `stats?.progress` 当唯一进度来源）——BUG-1294（`708704bbf`）把任务行从 `downloadProgress` 换到 `downloadStats` 之后，百分比与确定进度环的存活条件从「有进度」收紧成「有完整观测值」。
+  - `hibiki/lib/src/media/torrent/anime_download_service.dart:420`（`_importNowUnlocked`）调 `_publishProgress` 只传进度、`stats` 走默认空 map，而 `_publishProgress:285` 是无条件覆盖 → **「立即导入」路径把全表的 `downloadStats` 清空**，直到下一轮 tick（内置引擎 3s、外接 qb 20s）才恢复。期间任务行退成不定进度环 + 无百分比，与 `downloadProgress:271-274` 注释声明的契约（「UI 任务行订阅它换成确定进度环 + 百分比」）以及 `downloadStats:275` 注释声明的「键集合与 downloadProgress 一致」都相矛盾。
+- **[x] ① 已修复** — 进度只认 `downloadProgress`（恒发布的规范通道），`downloadStats` 退回「有就补速度/流量，没有也不影响百分比」的增强位；同时让 `_importNowUnlocked` 带上它手里已有的 `TorrentSnapshot`，不再清空别的计划的观测值。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/anime_download_dialog_embedded_push_test.dart`（既有 `early task 在 800x600/窄屏…` 用例恢复为真判据，且补一条「有 stats 时百分比后接速度/流量」）+ `hibiki/test/torrent/anime_download_service_progress_test.dart` 新增「importNow 不清空 downloadStats」用例。
+- **备注**：原 `find.text('55%')` 断言之所以红，正是因为该契约被打破；修复后只喂 `downloadProgress` 就能渲染出纯 `55%`，断言无需改动即恢复绿——这是「测试判据本来是对的，是功能坏了」的直接证据。

--- a/docs/bugs/BUG-1309-anime-download-confirm-subs-squeezed.md
+++ b/docs/bugs/BUG-1309-anime-download-confirm-subs-squeezed.md
@@ -1,0 +1,9 @@
+## BUG-1309 · 下载弹窗确认阶段：Jimaku 选择器挤掉字幕列表，RenderFlex 溢出 10px 且只剩不到一条可见
+- **报告**：2026-08-01（用户：develop 全量体检既有红，主行=2453 第③组）
+- **真实性**：✅ 真 bug（800x600 起就复现，越窄越严重）。根因：
+  `hibiki/lib/src/pages/implementations/anime_download_dialog.dart:1731` 的 `_buildConfirmStage` 把「返回行 + 手动搜索框 + Jimaku 条目选择器（`ConstrainedBox(maxHeight: 148)`）+ 语言选择器 + 开关 + 底部按钮组」全部按自然高度排掉，只给字幕列表留一个 `Expanded`（`:1785`）吃剩下的空间。`384ccc09f`（MD3 chrome 统一）把 `JimakuEntryPicker` 从紧凑 `ChoiceChip` 换成整宽 `HibikiCard`（单选圆点 + 两行标题 + 库存摘要，见 `jimaku_entry_picker.dart:59`）后，这块从几十像素涨到接近 148 上限，字幕列表的剩余高度被压到 **62px**。
+  62px 里 `_buildChosenSubsList:2023` 的 `Column` 还要先放说明行：整季包时是两行（时序 + 「集号未核对」），文案在该宽度下各折两行 ≈ 36px×2 = 72px > 62px → **`RenderFlex overflowed by 10.0 pixels`**（用户看到黄黑溢出条纹），且 `Expanded(ListView)` 拿到 0 高度 → 字幕一条都不显示；单行说明时列表只剩 26px，第 2 条起不进 viewport 也就不构建。
+  即：用户在「确认推送」这一步根本看不全要下哪些字幕，而这一步的全部意义就是让他确认字幕。
+- **[x] ① 已修复** — 确认阶段中段（手动搜索 → 条目选择器 → 语言 → 开关 → 字幕列表）收进单一 `Expanded(SingleChildScrollView(...))`，底部按钮组仍贴底；字幕列表改 `shrinkWrap` + `NeverScrollableScrollPhysics` 交由外层滚动。两个互相抢高度的弹性块被消掉，任何窗口高度下都不再有「某一块被压成 0」的特例。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart` 新增「800x600 与 360x600 下确认阶段不溢出且字幕全部可见」用例（同时断言 `tester.takeException()` 为 null，直接钉住 RenderFlex 溢出）。
+- **备注**：同组的「整季包字幕标为集号未核对」「BUG-1206 推送」「季号校验」三条既有红，症状都是 `Found 0 widgets with text "Test Anime - 0N.ja.srt"`，与本条同一根因，随修复一并转绿——它们的判据一直是对的。

--- a/hibiki/lib/src/media/torrent/anime_download_service.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_service.dart
@@ -417,9 +417,15 @@ class AnimeDownloadService {
       final (List<String> videos, _) = _classifyContent(plan, info, files);
       if (videos.isEmpty) return false;
       if (!info.isComplete) {
+        // BUG-1296：这里手上就有完整快照，必须把观测值一起带上。`_publishProgress`
+        // 是无条件覆盖 `downloadStats`，只传进度等于把**全表**的速度/流量清空，
+        // 任务行要一直等到下一轮 tick 才恢复。
         _publishProgress(<String, double>{
           ...downloadProgress.value,
           plan.id: info.progress.clamp(0.0, 1.0).toDouble(),
+        }, <String, DownloadTaskStats>{
+          ...downloadStats.value,
+          plan.id: DownloadTaskStats.fromSnapshot(info),
         });
       }
       await _finishPlan(

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -1750,39 +1750,54 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
           ],
         ),
         const SizedBox(height: 4),
-        _buildJimakuManualSearch(theme),
-        if (_jimakuEntries.isNotEmpty) ...<Widget>[
-          const SizedBox(height: 8),
-          ConstrainedBox(
-            constraints: const BoxConstraints(maxHeight: 148),
-            child: SingleChildScrollView(
-              child: JimakuEntryPicker(
-                entries: _jimakuEntries,
-                selectedEntryId: _selectedJimakuEntry?.id,
-                enabled: !_pushing && !_jimakuLoading,
-                onSelected: _selectJimakuEntry,
-              ),
+        // BUG-1309：中段（手动搜索 → 条目选择器 → 语言 → 开关 → 字幕列表）是
+        // **一个**可滚动区，不是两块互相抢高度的弹性块。此前条目选择器按自然高度
+        // 排（上限 148），字幕列表拿剩下的 `Expanded`；`JimakuEntryPicker` 换成整宽
+        // 卡片后剩余高度掉到 62px，说明行折行就直接 RenderFlex 溢出，列表被压成
+        // 0 高度——用户在「确认推送」这一步反而看不到要下哪些字幕。收进单一滚动区
+        // 后没有任何一块会被压成 0，底部按钮组仍然贴底。
+        Expanded(
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                _buildJimakuManualSearch(theme),
+                if (_jimakuEntries.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: 8),
+                  // BUG-1309：不再套 `ConstrainedBox(maxHeight: 148)` + 内层滚动。
+                  // 那个 148 的窗口本来只是为了给下面的字幕列表腾高度；中段整体可滚
+                  // 之后它就成了纯负担——嵌套滚动，而且第二条起的卡片被 ClipRect 切掉
+                  // 一半，连点都点不中（命中测试落在 RenderClipRect 上）。
+                  JimakuEntryPicker(
+                    entries: _jimakuEntries,
+                    selectedEntryId: _selectedJimakuEntry?.id,
+                    enabled: !_pushing && !_jimakuLoading,
+                    onSelected: _selectJimakuEntry,
+                  ),
+                  const SizedBox(height: 8),
+                  JimakuLanguagePicker(
+                    selectedLanguage: _jimakuPreferredLanguage,
+                    enabled: !_pushing && !_jimakuLoading,
+                    onSelected: _selectJimakuLanguage,
+                  ),
+                ],
+                const SizedBox(height: 4),
+                if (_chosenSubs.isNotEmpty)
+                  SwitchListTile(
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(t.anime_download_include_subs),
+                    value: _includeSubs,
+                    onChanged: _pushing
+                        ? null
+                        : (bool value) => setState(() => _includeSubs = value),
+                  ),
+                _buildChosenSubsList(theme),
+              ],
             ),
           ),
-          const SizedBox(height: 8),
-          JimakuLanguagePicker(
-            selectedLanguage: _jimakuPreferredLanguage,
-            enabled: !_pushing && !_jimakuLoading,
-            onSelected: _selectJimakuLanguage,
-          ),
-        ],
-        const SizedBox(height: 4),
-        if (_chosenSubs.isNotEmpty)
-          SwitchListTile(
-            dense: true,
-            contentPadding: EdgeInsets.zero,
-            title: Text(t.anime_download_include_subs),
-            value: _includeSubs,
-            onChanged: _pushing
-                ? null
-                : (bool value) => setState(() => _includeSubs = value),
-          ),
-        Expanded(child: _buildChosenSubsList(theme)),
+        ),
         const SizedBox(height: 8),
         Builder(
           builder: (BuildContext context) {
@@ -1980,6 +1995,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
           blockedTorrent != null && _jimakuSeasonBlockedFor(blockedTorrent);
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
         children: <Widget>[
           if (seasonBlocked)
             _buildSubsHintRow(
@@ -1989,7 +2005,8 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
                 season: blockedTorrent.season ?? 1,
               ),
             ),
-          Expanded(
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
             child: Center(
               child: Column(
                 mainAxisSize: MainAxisSize.min,
@@ -2022,6 +2039,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
         torrent != null && _subtitleEpisodesUnverified(torrent);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
+      mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         _buildSubsHintRow(
           theme,
@@ -2034,7 +2052,7 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
             Icons.help_outline,
             t.anime_download_subs_episodes_unverified,
           ),
-        Expanded(child: _buildChosenSubsListView(theme)),
+        _buildChosenSubsListView(theme),
       ],
     );
   }
@@ -2062,7 +2080,11 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
   }
 
   Widget _buildChosenSubsListView(ThemeData theme) {
+    // BUG-1309：由确认阶段中段那一个 `SingleChildScrollView` 统一滚动，本列表只
+    // 按内容撑高（否则嵌套两层滚动，且高度不足时条目根本不构建 → 用户看不见）。
     return ListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
       itemCount: _chosenSubs.length,
       itemBuilder: (BuildContext context, int i) {
         final (int? episode, JimakuFile file) = _chosenSubs[i];
@@ -2205,21 +2227,28 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       final AnimeDownloadService? service =
           ref.read(appProvider).animeDownloadService;
       if (service != null) {
-        // BUG-1294：订阅完整观测值（进度 + 速度/流量），不再只有百分比。
-        return ValueListenableBuilder<Map<String, DownloadTaskStats>>(
-          valueListenable: service.downloadStats,
-          builder:
-              (BuildContext context, Map<String, DownloadTaskStats> stats, _) =>
-                  _buildPlanRowInner(theme, plan, stats[plan.id]),
+        // BUG-1296：百分比与确定进度环只认 [AnimeDownloadService.downloadProgress]
+        // ——它是恒发布的规范通道。BUG-1294 的速度/流量走 downloadStats，只是**增强
+        // 位**：拿不到观测值时少一截后缀即可，不能把百分比一起吞掉（`_importNowUnlocked`
+        // 那条路径就会短暂只发进度不发观测值）。
+        return ValueListenableBuilder<Map<String, double>>(
+          valueListenable: service.downloadProgress,
+          builder: (BuildContext context, Map<String, double> progress, _) =>
+              ValueListenableBuilder<Map<String, DownloadTaskStats>>(
+            valueListenable: service.downloadStats,
+            builder: (BuildContext context,
+                    Map<String, DownloadTaskStats> stats, _) =>
+                _buildPlanRowInner(
+                    theme, plan, progress[plan.id], stats[plan.id]),
+          ),
         );
       }
     }
-    return _buildPlanRowInner(theme, plan, null);
+    return _buildPlanRowInner(theme, plan, null, null);
   }
 
-  Widget _buildPlanRowInner(
-      ThemeData theme, AnimeDownloadPlan plan, DownloadTaskStats? stats) {
-    final double? progress = stats?.progress;
+  Widget _buildPlanRowInner(ThemeData theme, AnimeDownloadPlan plan,
+      double? progress, DownloadTaskStats? stats) {
     final ColorScheme scheme = theme.colorScheme;
     final bool eink = isEinkTheme(context);
     final bool downloading = plan.status == AnimeDownloadPlan.statusDownloading;
@@ -2251,11 +2280,16 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     };
     // BUG-1294：进度百分比之外补速度与累计流量（单位串是纯数字/符号，无需
     // i18n key）。速率为 0 时仍显示（「0 B/s 卡住了」本身就是有效信息）。
-    final String? progressText = (downloading && stats != null)
-        ? '${(stats.progress * 100).toStringAsFixed(0)}% · '
-            '↓ ${HibikiByteFormat.speed(stats.downRateBps.toDouble())} · '
-            '↑ ${HibikiByteFormat.speed(stats.upRateBps.toDouble())} · '
-            '${HibikiByteFormat.bytes(stats.downloadedBytes)}'
+    // BUG-1296：百分比只依赖 progress；观测值缺席就只渲染百分比，不整条消失。
+    final String? progressText = (downloading && progress != null)
+        ? <String>[
+            '${(progress * 100).toStringAsFixed(0)}%',
+            if (stats != null) ...<String>[
+              '↓ ${HibikiByteFormat.speed(stats.downRateBps.toDouble())}',
+              '↑ ${HibikiByteFormat.speed(stats.upRateBps.toDouble())}',
+              HibikiByteFormat.bytes(stats.downloadedBytes),
+            ],
+          ].join(' · ')
         : null;
     final String? failReason =
         (failed && (plan.failReason?.isNotEmpty ?? false))

--- a/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_discovery_ux_test.dart
@@ -14,7 +14,10 @@ import 'package:hibiki/src/media/torrent/nyaa_client.dart';
 import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 import 'package:hibiki/src/media/video/anilist_client.dart';
 import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/media/video/jimaku_client.dart';
 import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
+import 'package:hibiki/src/pages/implementations/jimaku_entry_picker.dart';
+import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
 
 import '../helpers/test_platform_services.dart';
 
@@ -544,11 +547,22 @@ void main() {
     });
     await pumpDialog(tester, appModel, torrent: _kTorrent);
 
-    bool selected(String name) => tester
-        .widgetList<ChoiceChip>(find.byType(ChoiceChip))
-        .where((ChoiceChip chip) => (chip.label as Text).data == name)
-        .single
-        .selected;
+    // 判据锚点更新（原契约不变）：条目选择器早已不是 `ChoiceChip` —— `384ccc09f`
+    // 把它统一到共享 `HibikiCard`（单选圆点 + 主色描边），文件里仅剩的 `ChoiceChip`
+    // 是下面的语言选择器，所以按 chip label 取条目必然 `Bad state: No element`。
+    // 要守的契约还是那一条「谁被选中」，换成读用户真正看到的那张卡的 `selected`
+    // （与 `JimakuEntryPicker.selectedEntryId` 同源，且比读 model 更贴近渲染）。
+    bool selected(String name) {
+      final JimakuEntryPicker picker =
+          tester.widget<JimakuEntryPicker>(find.byType(JimakuEntryPicker));
+      final JimakuEntry entry =
+          picker.entries.singleWhere((JimakuEntry e) => e.name == name);
+      return tester
+          .widget<HibikiCard>(
+            find.byKey(ValueKey<String>('jimaku_entry_${entry.id}')),
+          )
+          .selected;
+    }
 
     // 首搜：自动选中首条。
     await tester.tap(find.byTooltip(t.anime_download_search).last);
@@ -862,6 +876,97 @@ void main() {
       find.text(t.anime_download_subs_season_mismatch(season: 1)),
       findsNothing,
     );
+  });
+
+  // BUG-1309：确认阶段中段曾经是「条目选择器按自然高度排 + 字幕列表吃剩余
+  // Expanded」。`JimakuEntryPicker` 换成整宽卡片后剩余高度掉到 62px：说明行一折行
+  // 就 `RenderFlex overflowed by 10.0 pixels`（用户看到黄黑条纹），列表被压成 0 高
+  // 度，一条字幕都不显示——而这一步的全部意义就是让用户确认要下哪些字幕。
+  //
+  // 判据钉两件事，缺一不可：**不许有溢出异常**，且**每一条字幕都真的构建出来**。
+  // 只断言最后一条即可覆盖「列表高度不足 → 后面的条目不进 viewport 也就不构建」。
+  testWidgets('BUG-1309 确认阶段：窄窗口下不溢出，且字幕条目全部可见', (
+    WidgetTester tester,
+  ) async {
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetDevicePixelRatio);
+    addTearDown(tester.view.resetPhysicalSize);
+
+    // 整季包 → 两行说明（时序 + 集号未核对），正是原先撑爆 62px 的组合。
+    const NyaaTorrent seasonPack = NyaaTorrent(
+      title: '[Grp] Test Anime S01 Batch [1080p]',
+      torrentUrl: '',
+      pageUrl: '',
+      infoHash: 'dddddddddddddddddddddddddddddddddddddddd',
+      seeders: 10,
+      leechers: 0,
+      downloads: 0,
+      sizeText: '10 GiB',
+      sizeBytes: null,
+      categoryId: '1_2',
+      trusted: false,
+      remake: false,
+      pubDate: null,
+    );
+
+    for (final Size size in <Size>[
+      const Size(800, 600),
+      const Size(360, 640),
+    ]) {
+      tester.view.physicalSize = size;
+      final _FakeAppModel appModel = _FakeAppModel((http.Request req) async {
+        final String url = req.url.toString();
+        if (url.contains('/entries/search')) {
+          return http.Response.bytes(
+            utf8.encode(
+              jsonEncode(<Map<String, Object>>[
+                // 两个条目：单条目时选择器矮，覆盖不到「选择器把列表挤没」。
+                <String, Object>{'id': 71, 'name': 'Season Entry A'},
+                <String, Object>{'id': 72, 'name': 'Season Entry B'},
+              ]),
+            ),
+            200,
+          );
+        }
+        if (url.contains('/files')) {
+          return http.Response.bytes(
+            utf8.encode(
+              jsonEncode(<Map<String, Object>>[
+                for (int ep = 1; ep <= 3; ep++)
+                  <String, Object>{
+                    'name': 'Test Anime - 0$ep.ja.srt',
+                    'url': 'https://jimaku.cc/f/$ep.srt',
+                  },
+              ]),
+            ),
+            200,
+          );
+        }
+        return http.Response('', 404);
+      });
+
+      await pumpDialog(tester, appModel, torrent: seasonPack);
+      await tester.tap(find.byTooltip(t.anime_download_search).last);
+      await tester.pumpAndSettle();
+
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: '$size：确认阶段不许有 RenderFlex 溢出（用户会看到黄黑溢出条纹）',
+      );
+      expect(
+        find.text(t.anime_download_subs_episodes_unverified),
+        findsOneWidget,
+        reason: '$size：整季包的「集号未核对」说明行必须还在',
+      );
+      for (int ep = 1; ep <= 3; ep++) {
+        expect(
+          find.text('Test Anime - 0$ep.ja.srt'),
+          findsOneWidget,
+          reason: '$size：第 $ep 条字幕必须真的构建出来（列表不能被压成 0 高度）',
+        );
+      }
+    }
   });
 }
 

--- a/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
@@ -293,6 +293,76 @@ void main() {
     }
   });
 
+  // BUG-1296：百分比与确定进度环的存活条件必须是「有进度」，不是「有完整观测
+  // 值」。BUG-1294 把任务行整个搬到 downloadStats 之后，任何只发布进度不发布观测
+  // 值的路径（`importNow`）都会让百分比直接消失。这里正反两面各钉一次。
+  testWidgets('任务行：只有进度也渲染百分比；有观测值才追加速度/流量（BUG-1296）', (
+    WidgetTester tester,
+  ) async {
+    final (_FakeAppModel appModel, GlobalKey<NavigatorState> navKey) =
+        await pumpHost(tester);
+    appModel.store.plans[_kHash] = AnimeDownloadPlan(
+      id: _kHash,
+      createdAtMs: 1,
+      seriesTitle: 'Test Anime',
+      torrentTitle: '[Group] Test Anime - 01 [1080p]',
+      magnet: 'magnet:?xt=urn:btih:$_kHash',
+      qbCategory: 'hibiki',
+      status: AnimeDownloadPlan.statusDownloading,
+    );
+    // 只有进度、没有观测值（= importNow 刚发布完的那一瞬间）。
+    appModel.service.downloadProgress.value = <String, double>{_kHash: 0.55};
+
+    navKey.currentState!.push(
+      MaterialPageRoute<void>(
+        builder: (BuildContext context) => const Scaffold(
+          body: AnimeDownloadDialog(
+            embedded: true,
+            tasksOnly: true,
+            showTasks: false,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(
+      find.text('55%'),
+      findsOneWidget,
+      reason: '观测值缺席时百分比不能跟着消失（只少速度/流量后缀）',
+    );
+    expect(
+      tester
+          .widget<CircularProgressIndicator>(
+            find.byType(CircularProgressIndicator),
+          )
+          .value,
+      0.55,
+      reason: '确定进度环同样只依赖进度',
+    );
+
+    // 观测值到位 → 同一行追加速度与累计流量，百分比仍在最前。
+    appModel.service.downloadStats.value = <String, DownloadTaskStats>{
+      _kHash: const DownloadTaskStats(
+        progress: 0.55,
+        downRateBps: 1048576,
+        upRateBps: 0,
+        downloadedBytes: 0,
+        uploadedBytes: 0,
+        numPeers: 0,
+      ),
+    };
+    await tester.pump();
+
+    expect(find.text('55%'), findsNothing);
+    expect(
+      find.textContaining('55% · ↓ '),
+      findsOneWidget,
+      reason: 'BUG-1294 的速度/流量是百分比之后的追加段，不是替换',
+    );
+  });
+
   testWidgets('独立对话框模式推送成功仍关闭自身（向后兼容）', (WidgetTester tester) async {
     final (_FakeAppModel appModel, GlobalKey<NavigatorState> navKey) =
         await pumpHost(tester);

--- a/hibiki/test/torrent/anime_download_service_progress_test.dart
+++ b/hibiki/test/torrent/anime_download_service_progress_test.dart
@@ -38,9 +38,12 @@ class _FakeBackend implements TorrentBackend {
   Future<List<TorrentSnapshot>> listTorrents({String? category}) async =>
       torrents;
 
+  /// 种子内文件清单；默认空（多数用例只关心进度表）。`importNow` 路径需要至少
+  /// 一个可识别视频，否则服务在发布进度之前就提前返回。
+  List<TorrentFileEntry> files = const <TorrentFileEntry>[];
+
   @override
-  Future<List<TorrentFileEntry>> listFiles(String torrentId) async =>
-      const <TorrentFileEntry>[];
+  Future<List<TorrentFileEntry>> listFiles(String torrentId) async => files;
 
   @override
   void close() {}
@@ -169,6 +172,42 @@ void main() {
     backend.torrents = <TorrentSnapshot>[];
     await service.tick();
     expect(service.downloadStats.value, isEmpty);
+  });
+
+  // BUG-1296：`_publishProgress` 是**无条件覆盖** downloadStats，而 importNow 那条
+  // 路径此前只传进度、stats 走默认空 map → 一次「立即导入」把全表观测值抹掉，
+  // 任务行退成不定进度环（UI 侧的百分比也一并没了）直到下一轮 tick 才恢复。
+  // 契约：任何发布点都不得把别处刚发布的观测值降级成空。
+  test('importNow 发布进度时不清空 downloadStats（BUG-1296）', () async {
+    backend.torrents = <TorrentSnapshot>[
+      _snapshot(
+        progress: 0.42,
+        state: 'downloading',
+        downRateBps: 1048576,
+        upRateBps: 2048,
+        downloadedBytes: 4096,
+      ),
+    ];
+    await service.tick();
+    expect(service.downloadStats.value[_kHash]?.downRateBps, 1048576);
+
+    // 种子里有可识别视频 → importNow 会走到「未完成也先发进度」那一支。
+    backend.files = const <TorrentFileEntry>[
+      TorrentFileEntry(
+          name: 'Test Anime - 01.mkv', size: 100, progress: 0.42, index: 0),
+    ];
+    await service.importNow(_kHash);
+
+    expect(
+      service.downloadProgress.value[_kHash],
+      0.42,
+      reason: 'importNow 仍应发布进度',
+    );
+    expect(
+      service.downloadStats.value[_kHash]?.downRateBps,
+      1048576,
+      reason: 'importNow 手上就有 TorrentSnapshot，不得把观测值清成空表',
+    );
   });
 
   test('轮询周期决策：内置引擎 + 有活跃下载才提频（BUG-1294）', () {


### PR DESCRIPTION
清 develop 上先于最近这批 PR 就存在的既有红（看板 主行=2453 的第③、⑥组）。

## 第③组（5 条）：两条真功能缺陷 + 一条陈旧判据

### BUG-1309（用户可见）确认阶段字幕列表被挤没 + RenderFlex 溢出 10px
`_buildConfirmStage` 中段是「Jimaku 条目选择器按自然高度排（`ConstrainedBox(maxHeight: 148)`）+ 字幕列表吃剩余 `Expanded`」。`384ccc09f` 把 `JimakuEntryPicker` 从紧凑 chip 换成整宽 `HibikiCard` 后，字幕列表的剩余高度掉到 **62px**：

- 整季包要显示两行说明（时序 + 集号未核对），在该宽度下各折两行 ≈ 72px > 62px → `RenderFlex overflowed by 10.0 pixels`，**用户直接看到黄黑溢出条纹**；
- `Expanded(ListView)` 拿到 0 高度 → 一条字幕都不显示；单行说明时只剩 26px，第 2 条起不进 viewport 也就不构建。

即：在「确认推送」这一步用户反而看不到自己要下哪些字幕，而这一步的全部意义就是确认字幕。

**修法**：中段（手动搜索 → 条目选择器 → 语言 → 开关 → 字幕列表）收进**单一** `Expanded(SingleChildScrollView(...))`，底部按钮组仍贴底；字幕列表改 `shrinkWrap` + `NeverScrollableScrollPhysics`。两块互相抢高度的弹性块被消掉，任何窗口高度下都不会有某一块被压成 0。
顺带删掉选择器那层 148px 内嵌滚动窗口——中段整体可滚之后它只剩负作用：嵌套滚动，且第二条起的卡片被 `ClipRect` 切掉、命中测试落在裁剪层上，**根本点不中**。

### BUG-1296 任务行百分比/确定进度环消失
`708704bbf`（BUG-1294）把任务行整个搬到 `downloadStats`，于是百分比与确定进度环的存活条件从「有进度」收紧成「有完整观测值」；而 `_importNowUnlocked` 发布进度时 `stats` 走默认空 map，`_publishProgress` 又是**无条件覆盖** → 一次「立即导入」把**全表**观测值抹掉，任务行退成不定进度环、百分比消失，直到下一轮 tick（内置引擎 3s / 外接 qb 20s）才恢复。这与 `downloadProgress` / `downloadStats` 两处注释各自声明的契约都相矛盾。

**修法**：进度只认 `downloadProgress`（恒发布的规范通道），速度/流量降为**追加段**；`importNow` 把手上已有的 `TorrentSnapshot` 一并发布。

### 判据修正（原契约不变）
`discovery_ux_test` 的 `selected()` 按 `ChoiceChip` label 取条目，但条目选择器早已不是 `ChoiceChip`（文件里仅剩的 `ChoiceChip` 是语言选择器），必然 `Bad state: No element`。改读用户真正看到的那张 `HibikiCard` 的 `selected`（与 `JimakuEntryPicker.selectedEntryId` 同源，比读 model 更贴近渲染）。

## 第⑥组（1 条）：环境耦合，已随僵尸进程清理自愈
`test/sync/hibiki_library_host_service_books_test.dart` 的 `PathAccessException (errno 32)` 在本轮 3 次独立运行中均绿（26/26）。测试自身资源管理是正确的：`setUp/tearDown` 管临时根目录，每个 `exportBook` 用例都 `addTearDown(() => pkg.parent.deleteSync(recursive: true))`。被占用的 `hibiki_book_export*` 是生产 `exportBook` 建的临时目录，锁来自外部僵尸进程。**不需要改代码。**

## 新增守卫
- 窄窗口（800x600 / 360x640）确认阶段不许有溢出异常，且每条字幕都真的构建；
- 任务行只有进度也渲染百分比、有观测值才追加速度/流量；
- `importNow` 不清空 `downloadStats`。

## 变异实测（各两个方向）
| 变异 | 破坏后 | 还原后 |
|---|---|---|
| `SingleChildScrollView` → 等深度 `Builder` 直通 | 7 处 `RenderFlex overflowed`，BUG-1309 守卫等 7 条红 | 14/14 绿 |
| 重新套回 `ConstrainedBox(maxHeight: 148)` + 内层滚动 | 「换番剧名重搜」红（命中测试落在裁剪层） | 14/14 绿 |
| `progressText` 条件与百分比来源改回 `stats` | `early task…` + 新 BUG-1296 守卫红（`Found 0 widgets with text "55%"`） | 5/5 绿 |
| `importNow` 去掉 stats 实参 | `importNow 发布进度时不清空 downloadStats` 红 | 7/7 绿 |

（第一次对 `progressText` 只改条件位撞到编译错误，属弱证据，已换成语义等价的「回到修复前行为」重做。）

## 验证
- `flutter analyze`（含 test）：`No issues found!`
- `anime_download_dialog_discovery_ux_test` + `_embedded_push_test` + `anime_download_service_progress_test`：**26/26 全绿**（修复前 5 红）
- 相邻：`jimaku_default_language_test` / `downloads_page_resize_inset_guard_test` / `hibiki_library_host_service_books_test` 全绿
