### PR TITLE
fix(gal,sync): 线程门控别连坐无身份的行 + 明文 host 不问 service-config（BUG-1315/1311）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,8 +33,8 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1315](bugs/BUG-1315-texthooker-threadless-lines-never-published.md) | ✅ | ✅ | 未选线程门控把无线程身份的行（WebSocket/Textractor 端点）永久丢弃 |
 | [BUG-1311](bugs/BUG-1311-interconnect-service-config-403-on-plaintext.md) | ✅ | ✅ | 互联同步每轮都报「认证失败」：明文 host 上无条件请求 service-config |
-| [BUG-1309](bugs/BUG-1309-texthooker-threadless-lines-never-published.md) | ✅ | ✅ | 未选线程门控把无线程身份的行（WebSocket/Textractor 端点）永久丢弃 |
 | [BUG-1305](bugs/BUG-1305-delete-confirm-disclosure.md) | ✅ | ✅ | 删除确认文案与真实删除范围对不上（书架递归删解压目录+有声书；合集正文说反话） |
 | [BUG-1304](bugs/BUG-1304-engine-freq-pitch-enrich-before-truncate.md) | ✅ | ✅ | 词典引擎 freq/pitch 在截断前富化：中间结果被重复富化约 3 倍（实测微优化，非秒级根因） |
 | [BUG-1303](bugs/BUG-1303-hoshidicts-hash-probe-unbounded.md) | ✅ | ✅ | 词典 hash 探测无界循环 + load() 零边界校验：损坏词典可致查词永久挂死/越界读 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1253 条。点号进各自文件。
+> 共 1255 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1311](bugs/BUG-1311-interconnect-service-config-403-on-plaintext.md) | ✅ | ✅ | 互联同步每轮都报「认证失败」：明文 host 上无条件请求 service-config |
+| [BUG-1309](bugs/BUG-1309-texthooker-threadless-lines-never-published.md) | ✅ | ✅ | 未选线程门控把无线程身份的行（WebSocket/Textractor 端点）永久丢弃 |
 | [BUG-1305](bugs/BUG-1305-delete-confirm-disclosure.md) | ✅ | ✅ | 删除确认文案与真实删除范围对不上（书架递归删解压目录+有声书；合集正文说反话） |
 | [BUG-1304](bugs/BUG-1304-engine-freq-pitch-enrich-before-truncate.md) | ✅ | ✅ | 词典引擎 freq/pitch 在截断前富化：中间结果被重复富化约 3 倍（实测微优化，非秒级根因） |
 | [BUG-1303](bugs/BUG-1303-hoshidicts-hash-probe-unbounded.md) | ✅ | ✅ | 词典 hash 探测无界循环 + load() 零边界校验：损坏词典可致查词永久挂死/越界读 |

--- a/docs/bugs/BUG-1309-texthooker-threadless-lines-never-published.md
+++ b/docs/bugs/BUG-1309-texthooker-threadless-lines-never-published.md
@@ -1,0 +1,42 @@
+## BUG-1309 · 未选线程门控把无线程身份的行（WebSocket/Textractor 端点）永久丢弃
+- **报告**：2026-08-01（用户：develop 全量体检，主行=2452 第①②④组）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/mining/gal_hook_session_controller.dart:678-690`
+  （修复前）的 `workbenchLines`：`if (selectedKey == null) return const <TexthookerLineEntry>[];`
+  以及 `:713-723` 的 `selectedSessionLines` 同款早退。
+  PR#555（`a835ed93c` feat(gal): IPC v12 线程预览区 + 取消自动选文本线程，BUG-1193）
+  把「未选线程」的语义从**全部线程**改成**一行都不发布**。这个契约变更对**带线程身份
+  的行**是有意且正确的（Luna 中日文混流必须由用户显式选）。
+  但它把判据写成了「有没有选过线程」而不是「这一行归不归一条被排除的线程」，于是
+  **不带线程身份的行**被连坐：
+  - `hibiki/lib/src/sync/texthooker_ws_client.dart:118-122`
+    （WebSocket / Textractor / mpv WS 源）appendLine 时**不传** `textThreadKey`；
+  - `hibiki/lib/src/mining/galgame_audio_source.dart:1968-1969`
+    `threadId == 0` 时 `textThreadKey` 也为 `null`。
+  这类行永远不进线程目录（`texthooker_service.dart:395-398` 显式跳过 null/空 key），
+  也就永远没有下拉项能选中它；而选择器本身按
+  `texthooker_page.dart:1409` 的 `enabled: textThreads.isNotEmpty` 置灰。
+  **结果是一个用户无法自救的死角**：纯 WS/Textractor 用户的捕获工作台永久空白，
+  浮窗与制卡（`gal_hook_text_overlay_controller.dart:322` 消费 `selectedSessionLines`）
+  一并归零。这不在 BUG-1193 的意图范围内——没有线程身份的行本就没有歧义可消。
+- **[x] ① 已修复** — `hibiki/lib/src/mining/gal_hook_session_controller.dart`
+  新增 `_publishesUnderSelection(entry, selectedKey)` 单一谓词，取消
+  `selectedKey == null` 的早退分支，`workbenchLines` 与 `selectedSessionLines` 共用它：
+  带线程身份的行仍须 `key == selectedKey`（BUG-1193 契约逐字保持），
+  无线程身份的行无条件放行。四种组合由一条谓词覆盖，特殊情况消失。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/texthooker_page_test.dart`
+  新增「BUG-1309：无线程身份的行不受线程选择门控，未选线程也必须发布」：
+  同一页面同时喂一条带 `textThreadKey` 的 hook 行和一条 WebSocket 行，
+  断言前者**不可见**（守住 BUG-1193）、后者**可见**（守住本 bug）。
+  两条断言同在一个用例里，任一方向的回归都会红。
+  变异实测：把谓词的 `return true` 改成 `return false` → 该用例连同
+  `renders incoming lines reactively` / `clear button empties the list` /
+  `embedded mode reuses parent scaffold` 共 4 条转红；反向替换还原后 15/15 转绿。
+- **备注**：同一根因还连带修好了 develop 上另外 6 条既有红——
+  `test/lookup/gal_hook_text_overlay_controller_test.dart`（5 条，症状是
+  `asynchronous overlay state did not settle`）和
+  `test/lookup/gal_hook_overlay_voice_controls_test.dart`（1 条），
+  它们都用不带 thread key 的 `appendLine` 喂行，浮窗因 `selectedSessionLines`
+  恒空而永不 settle。体检报告（主行=2452）把它们分在①②组，实为同一个 bug。
+  `test/mining/gal_capture_audio_integrity_test.dart:376-388` 的 v12 契约守卫
+  （`selectTextThread(null)` 后 `workbenchLines` / `selectedSessionLines` 必须为空）
+  用的是 `threadId: 7` 的带身份行，修复后仍然绿——契约没有被松动。

--- a/docs/bugs/BUG-1311-interconnect-service-config-403-on-plaintext.md
+++ b/docs/bugs/BUG-1311-interconnect-service-config-403-on-plaintext.md
@@ -1,0 +1,41 @@
+## BUG-1311 · 互联同步每轮都报「认证失败」：明文 host 上无条件请求 service-config
+- **报告**：2026-08-01（用户：develop 全量体检，主行=2452 第⑤组）
+- **真实性**：✅ 真 bug，生产回归。根因 `hibiki/lib/src/sync/sync_orchestrator.dart:366`
+  对每条互联通道无条件调用 `_syncServiceConfigLive`，而
+  `hibiki/lib/src/sync/interconnect_sync_backend.dart:685` 的
+  `getRemoteServiceConfig()` 只对 404 降级、不判传输是否为 HTTPS。
+  host 侧 `hibiki/lib/src/sync/hibiki_sync_server.dart:2197-2199` 在
+  `_securityContext == null`（明文 HTTP）时**必然**返回
+  `403 HTTPS required for service config`——这是有意拒绝（API key 不得降级到明文），
+  不是故障。403 经 `hibiki/lib/src/sync/webdav_ops.dart:259-262` 的 `checkStatus`
+  被压成 `SyncAuthError('Authentication failed')`（body 里的真实原因被丢弃），
+  再由 `sync_orchestrator.dart:527` 的裸 `catch (e)` 降级成一条
+  `report.errors` 日志行。
+  **爆炸半径**：TLS 默认是关的——`sync_repository.dart:619-620` 的
+  `getServerTlsEnabled()` 默认 `false`，且 `applyFirstHostingTlsDefault()`
+  只对全新设备置 true，存量 host 一律保持明文。故**所有存量明文互联用户**从
+  `df660a55e`（feat(sync): share service config over interconnect）起，每一轮同步
+  都稳定拿到一条 `service config live sync: SyncAuthError: Authentication failed`：
+  设置页「立即同步」副标题恒显「N 项失败」（`manual_sync_ui.dart:37-39`），
+  每轮自动同步向 `ErrorLogService` 打一条噪音（`sync_auto_trigger.dart:121-125`），
+  并把用户引去反复重配 token——而 token 根本没问题。
+  引入 commit `df660a55e` 新增了无门控调用却没碰
+  `hibiki/test/sync/sync_orchestrator_live_*.dart`，故这三条红精确地从它开始。
+- **[x] ① 已修复** — `hibiki/lib/src/sync/interconnect_sync_backend.dart`
+  `getRemoteServiceConfig()` 开头按会话 scheme 门控：非 `https` 直接返回 `null`，
+  不发请求。答案本地就已知，别问。`null` 与「旧 host 404」「host 关掉该能力 404」
+  归一到同一条「对端不提供此能力」语义，和 host 自己在 `/api/capabilities` 广播的
+  `'serviceConfig': _securityContext != null && ...`
+  （`hibiki_sync_server.dart:1188-1189`）逐字一致。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/interconnect_service_config_test.dart`
+  新增「明文互联会话不得请求 service-config」：起一台会记录命中路径的明文 HTTP host，
+  断言 `getRemoteServiceConfig()` 返回 `null` **且该路径命中数为 0**（不是只断返回值——
+  只断返回值的话，把门控删掉换成 `catch` 吞异常也能骗过）。
+  同时 `sync_orchestrator_live_{audio,book,progress}_test.dart` 的
+  `expect(report.errors, isEmpty)` 由红转绿，是同一根因的端到端复现。
+- **备注**：本轮**未**动 `webdav_ops.dart:259-262` 把 401/403 一律压成
+  `SyncAuthError('Authentication failed')` 这一层——它被 webdav/ftp/sftp 等多个 backend
+  共用，改动面远大于本 bug，且修好门控后该路径在正常配置下不再触发。但它确实是独立缺陷：
+  403「策略不允许」和 401「认证失败」语义不同，且 response body 里的真实原因被丢弃。
+  另：`sync_orchestrator.dart:527` 是全仓唯一对 `SyncAuthError` 完全不分流、
+  与普通网络抖动一视同仁的 catch 点，一并留作后续清理条件。

--- a/docs/bugs/BUG-1315-texthooker-threadless-lines-never-published.md
+++ b/docs/bugs/BUG-1315-texthooker-threadless-lines-never-published.md
@@ -1,4 +1,4 @@
-## BUG-1309 · 未选线程门控把无线程身份的行（WebSocket/Textractor 端点）永久丢弃
+## BUG-1315 · 未选线程门控把无线程身份的行（WebSocket/Textractor 端点）永久丢弃
 - **报告**：2026-08-01（用户：develop 全量体检，主行=2452 第①②④组）
 - **真实性**：✅ 真 bug。根因 `hibiki/lib/src/mining/gal_hook_session_controller.dart:678-690`
   （修复前）的 `workbenchLines`：`if (selectedKey == null) return const <TexthookerLineEntry>[];`
@@ -24,7 +24,7 @@
   带线程身份的行仍须 `key == selectedKey`（BUG-1193 契约逐字保持），
   无线程身份的行无条件放行。四种组合由一条谓词覆盖，特殊情况消失。
 - **[x] ② 已加自动化测试** — `hibiki/test/pages/texthooker_page_test.dart`
-  新增「BUG-1309：无线程身份的行不受线程选择门控，未选线程也必须发布」：
+  新增「BUG-1315：无线程身份的行不受线程选择门控，未选线程也必须发布」：
   同一页面同时喂一条带 `textThreadKey` 的 hook 行和一条 WebSocket 行，
   断言前者**不可见**（守住 BUG-1193）、后者**可见**（守住本 bug）。
   两条断言同在一个用例里，任一方向的回归都会红。

--- a/hibiki/lib/src/mining/gal_hook_session_controller.dart
+++ b/hibiki/lib/src/mining/gal_hook_session_controller.dart
@@ -673,14 +673,35 @@ class GalHookSessionController extends ChangeNotifier {
   List<TexthookerTextThread> get textThreads =>
       _textService.textThreadsSince(_state.sessionStartedAt);
 
-  /// 捕获工作台当前应展示的正式行。没有选择时只允许下拉里的候选预览可见，
-  /// 正式台词、浮窗、配对和制卡都必须为空；底层诊断 buffer 不删。
+  /// 这一行能否进入正式消费面（工作台 / 浮窗 / 配对 / 制卡）。
+  ///
+  /// v12 起「未选线程」不再等于「全部线程」：**带线程身份的行**必须由用户显式
+  /// 选中才发布（BUG-1193），没选就只在下拉的候选预览里可见，底层诊断 buffer
+  /// 不删。
+  ///
+  /// 但判据是「这一行归不归一条被排除的线程」，而不是「有没有选过线程」。
+  /// **不带线程身份的行**（`textThreadKey == null`：WebSocket / Textractor 端点
+  /// 的行，以及 `threadId == 0` 的降级 hook 行）从来不进线程目录，也就永远不会
+  /// 出现在选择器里——拿选择状态去门控它们等于永久丢弃，而且用户无法自救（下拉
+  /// 本身按 `textThreads.isNotEmpty` 置灰）。所以它们无条件放行。
+  static bool _publishesUnderSelection(
+    TexthookerLineEntry entry,
+    String? selectedKey,
+  ) {
+    final String? key = entry.textThreadKey;
+    if (key == null || key.isEmpty) return true;
+    return key == selectedKey;
+  }
+
+  /// 捕获工作台当前应展示的正式行。过滤判据见 [_publishesUnderSelection]；
+  /// 捕获中额外只看本次会话，避免上一个进程的台词混进当前工作台。
   List<TexthookerLineEntry> get workbenchLines {
     final String? selectedKey = selectedTextThreadKey;
-    if (selectedKey == null) return const <TexthookerLineEntry>[];
     final DateTime? startedAt = _state.sessionStartedAt;
-    Iterable<TexthookerLineEntry> scoped =
-        _textService.entriesForTextThread(selectedKey);
+    Iterable<TexthookerLineEntry> scoped = _textService.entries.where(
+      (TexthookerLineEntry entry) =>
+          _publishesUnderSelection(entry, selectedKey),
+    );
     if (startedAt != null) {
       scoped = scoped.where(
         (TexthookerLineEntry entry) => !entry.receivedAt.isBefore(startedAt),
@@ -712,14 +733,14 @@ class GalHookSessionController extends ChangeNotifier {
   /// 制卡只允许消费这里的行，防止跨会话或跨线程借用上下文。
   List<TexthookerLineEntry> get selectedSessionLines {
     final DateTime? startedAt = _state.sessionStartedAt;
+    if (startedAt == null) return const <TexthookerLineEntry>[];
     final String? selectedKey = selectedTextThreadKey;
-    if (startedAt == null || selectedKey == null) {
-      return const <TexthookerLineEntry>[];
-    }
     return List<TexthookerLineEntry>.unmodifiable(
-      _textService
-          .entriesForTextThread(selectedKey)
-          .where((entry) => !entry.receivedAt.isBefore(startedAt)),
+      _textService.entries.where(
+        (TexthookerLineEntry entry) =>
+            _publishesUnderSelection(entry, selectedKey) &&
+            !entry.receivedAt.isBefore(startedAt),
+      ),
     );
   }
 

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -684,6 +684,17 @@ class InterconnectSyncBackend extends SyncBackend
   /// downgrading API keys to plaintext transport.
   Future<InterconnectServiceConfigSnapshot?> getRemoteServiceConfig() async {
     await _ensureResolved();
+    // 明文会话上这个端点**必然**是 403（host 侧 `HTTPS required for service
+    // config`），因为 API key 不允许降级到明文传输——这是有意的拒绝，不是故障。
+    // 而 TLS 默认是关的（`SyncRepository.getServerTlsEnabled()` 默认 false，存量
+    // host 一律保持明文），照样发请求只会让每一轮同步都收到一条
+    // `SyncAuthError: Authentication failed`，把「同步完成」永久挂上「N 项失败」，
+    // 并且把用户引去反复重配 token——而 token 根本没问题（BUG-1311）。
+    //
+    // 答案本地就已知，别问。返回 null 与「旧 host 404」「host 关掉了该能力 404」
+    // 归一到同一条「对端不提供此能力」语义，和 host 自己在 /api/capabilities 上
+    // 广播的 `serviceConfig: _securityContext != null && ...` 逐字一致。
+    if (Uri.tryParse(_apiBase)?.scheme != 'https') return null;
     final HttpClientRequest req = await _ops!.buildRequest(
       'GET',
       '$_apiBase/api/interconnect/service-config',

--- a/hibiki/test/pages/texthooker_page_test.dart
+++ b/hibiki/test/pages/texthooker_page_test.dart
@@ -104,13 +104,21 @@ void main() {
       find.byKey(const ValueKey<String>('game-text-thread-selector')),
       findsOneWidget,
     );
-    // followLive 首帧定位到最新一行：视口高度有限（筛选 chips 占位后更矮），
-    // 旧行「坏线程文本」在视口外不参与懒构建，改在服务层断言其存在。
+    // v12 契约（BUG-1193）：带线程身份的行在用户显式选中之前一行都不发布。
+    // 两条行仍在诊断 buffer 里（它们正是选择器的原材料），但工作台此刻
+    // 必须是空的。旧断言在这里期望「干净台词」已经可见，那是 v12 之前
+    // 「不选 = 全部线程」的旧语义。
     expect(
       TexthookerService.instance.lines,
       contains('坏线程文本'),
     );
-    expect(find.textContaining('干'), findsWidgets);
+    expect(
+      TexthookerService.instance.lines,
+      contains('干净台词'),
+    );
+    expect(find.textContaining('干'), findsNothing,
+        reason: 'v12：未显式选线程时带线程身份的行一行也不得发布');
+    expect(find.textContaining('坏'), findsNothing);
 
     await tester.tap(
       find.byKey(const ValueKey<String>('game-text-thread-selector')),
@@ -129,6 +137,35 @@ void main() {
 
     expect(find.textContaining('干'), findsWidgets);
     expect(find.textContaining('坏'), findsNothing);
+  });
+
+  testWidgets('BUG-1309：无线程身份的行不受线程选择门控，未选线程也必须发布',
+      (WidgetTester tester) async {
+    // 带线程身份的行：v12 起未被显式选中就不发布。
+    TexthookerService.instance.appendLine(
+      'フックした台詞',
+      textThreadKey: 'luna:hooked',
+      textThreadLabel: 'LunaHook 0x3000',
+      textHookCode: 'HS932@3000',
+      nativeTextThreadId: 0x3000,
+    );
+    // WebSocket / Textractor 端点的行不带 textThreadKey，永远进不了线程目录，
+    // 也就永远没有下拉项能选中它。拿「有没有选线程」去门控它等于永久丢弃，
+    // 而且用户无法自救——下拉里只会有上面那条 hook 线程。
+    TexthookerService.instance.appendLine(
+      'ソケット行',
+      source: TexthookerLineSource.websocket,
+      sourceLabel: 'ws://127.0.0.1:6677',
+    );
+    await tester.pumpWidget(
+      _wrapPage(const TexthookerPage()),
+    );
+    await tester.pump();
+
+    expect(find.textContaining('ソ'), findsWidgets,
+        reason: '无线程身份的行不归属任何候选线程，必须无条件进入工作台');
+    expect(find.textContaining('詞'), findsNothing,
+        reason: 'v12：带线程身份的行未被显式选中就不发布（BUG-1193 契约不得松动）');
   });
 
   testWidgets('thread selector lists discovered TextRender before any output',

--- a/hibiki/test/pages/texthooker_page_test.dart
+++ b/hibiki/test/pages/texthooker_page_test.dart
@@ -139,7 +139,7 @@ void main() {
     expect(find.textContaining('坏'), findsNothing);
   });
 
-  testWidgets('BUG-1309：无线程身份的行不受线程选择门控，未选线程也必须发布',
+  testWidgets('BUG-1315：无线程身份的行不受线程选择门控，未选线程也必须发布',
       (WidgetTester tester) async {
     // 带线程身份的行：v12 起未被显式选中就不发布。
     TexthookerService.instance.appendLine(

--- a/hibiki/test/sync/interconnect_service_config_test.dart
+++ b/hibiki/test/sync/interconnect_service_config_test.dart
@@ -1,6 +1,11 @@
+import 'dart:async';
+import 'dart:io';
+
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/sync/interconnect_service_config.dart';
+import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 void main() {
@@ -102,6 +107,47 @@ void main() {
         'preferences': <String, Object?>{},
       }),
       throwsFormatException,
+    );
+  });
+
+  test('BUG-1311：明文互联会话不得请求 service-config（403 必然，问了只是伪造失败）', () async {
+    // 复刻真实 host 在明文会话上的行为：`hibiki_sync_server.dart` 的
+    // `_handleInterconnectServiceConfig` 在 `_securityContext == null` 时恒返回
+    // `403 HTTPS required for service config`。而 TLS 默认是关的，存量 host 一律
+    // 走这条分支——客户端照发请求就会每轮同步收一条 SyncAuthError。
+    final List<String> hits = <String>[];
+    final HttpServer server =
+        await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+    unawaited(server.forEach((HttpRequest request) async {
+      hits.add(request.uri.path);
+      request.response.statusCode = HttpStatus.forbidden;
+      request.response.write('HTTPS required for service config');
+      await request.response.close();
+    }));
+
+    final SyncRepository repo = SyncRepository(db);
+    await repo.setHibikiClientUrls(<HibikiClientUrl>[
+      HibikiClientUrl(url: 'http://127.0.0.1:${server.port}', enabled: true),
+    ]);
+    await repo.setHibikiClientToken('peer-token');
+    final InterconnectSyncBackend backend =
+        InterconnectSyncBackend.withProbe((String u, String t) async => true);
+    await backend.restoreAuth(repo);
+    await backend.authenticate(repo: repo);
+
+    expect(
+      await backend.getRemoteServiceConfig(),
+      isNull,
+      reason: '明文 host 不提供该能力，语义与「旧 host 404」「能力关闭 404」归一',
+    );
+    // 只断返回值不够——把门控换成「照发请求 + catch 吞掉异常」同样会返回 null。
+    // 必须断请求根本没发出去：否则每一轮同步仍会打一次注定 403 的往返，
+    // 并把 403 经 webdav_ops.checkStatus 压成 SyncAuthError 挂进 report.errors。
+    expect(
+      hits,
+      isEmpty,
+      reason: '明文会话上 service-config 必然 403，这一次请求就不该发出去',
     );
   });
 }


### PR DESCRIPTION
> ⚠️ **改号说明**：本 PR 原用 BUG-1309，与 `fix/existing-red-group3-6`（commit 05:31，早于本分支 05:44）撞号，已让号改为 **BUG-1315**。未用 `bug.dart renumber`（撞号态抛错 + 全仓盲替换会改坏无关同号条目），手工改齐文件名/正文 H2/正文引用/测试名四处，`bug.dart check` 自校验零残留。

修 develop 上**先于本批 12 个 PR 就已存在**的两组红（体检 主行=2452 的第④⑤组）。逐条先分清「测试判据坏」vs「功能真坏」，**没有走「改测试消红」**。

## 结论速览

| 组 | 条数 | 判定 | 处置 |
|---|---|---|---|
| ④ texthooker 3 条 | 3 | **功能真坏** → BUG-1315 | 根因修复 + 新守卫 |
| ④ texthooker 1 条（Luna-style） | 1 | **契约已变更、旧断言过时** | 改判据，说清新旧契约 |
| ⑤ sync 3 条 | 3 | **功能真坏（不是缺凭据）** → BUG-1311 | 根因修复 + 新守卫 |
| ①② gal overlay 6 条（未派发） | 6 | 与 BUG-1315 **同一根因** | 顺带转绿，未额外改动 |

## BUG-1315 · 线程选择门控连坐了无线程身份的行

PR#555（`a835ed93c`，BUG-1193）把「未选线程」从**全部线程**改成**一行都不发布**。这个契约变更对**带线程身份的行**是有意且正确的（Luna 中日文混流必须由用户显式选）。

但判据被写成「有没有选过线程」，而不是「这一行归不归一条被排除的线程」：

\`\`\`dart
// gal_hook_session_controller.dart:679-680（修复前）
final String? selectedKey = selectedTextThreadKey;
if (selectedKey == null) return const <TexthookerLineEntry>[];
\`\`\`

于是**不带 \`textThreadKey\` 的行**被连坐：

- \`texthooker_ws_client.dart:118-122\` —— WebSocket / Textractor / mpv WS 源，appendLine **不传** thread key；
- \`galgame_audio_source.dart:1968-1969\` —— \`threadId == 0\` 时 key 也是 \`null\`。

这类行永远不进线程目录（\`texthooker_service.dart:395-398\` 显式跳过 null key），也就**永远没有下拉项能选中它**；而选择器本身按 \`texthooker_page.dart:1409\` 的 \`enabled: textThreads.isNotEmpty\` 置灰。**纯 WS/Textractor 用户的捕获工作台永久空白且无法自救**，浮窗与制卡（\`gal_hook_text_overlay_controller.dart:322\` 消费 \`selectedSessionLines\`）一并归零。没有线程身份的行本就没有歧义可消，不在 BUG-1193 的意图范围内。

**修法**：抽一条谓词，取消 \`selectedKey == null\` 早退，两个消费面共用：

\`\`\`dart
static bool _publishesUnderSelection(TexthookerLineEntry entry, String? selectedKey) {
  final String? key = entry.textThreadKey;
  if (key == null || key.isEmpty) return true;
  return key == selectedKey;
}
\`\`\`

四种组合由一条谓词覆盖，特殊情况消失。带身份的行仍须 \`key == selectedKey\` —— **BUG-1193 契约逐字保持**，\`gal_capture_audio_integrity_test.dart:376-388\` 的 v12 守卫（用 \`threadId: 7\` 的带身份行）修复后仍绿。

## BUG-1311 · 明文 host 上无条件请求 service-config，把「有意拒绝」当成「认证失败」

**明确回答体检的提问：`SyncAuthError` 不是测试环境缺凭据，是被压平的真错误。**

自证：同目录 \`sync_orchestrator_live_dict_test.dart\` / \`_aggregate_test.dart\` 用**完全相同**的 fake 环境和凭据却是绿的 —— 红绿分界线恰好是「有没有调 \`run()\`」，而 \`_syncServiceConfigLive\` 挂在 \`run()\` 上。凭据是共用的。

链路：

\`\`\`
sync_orchestrator.dart:366   每条互联通道无条件调用（无门控）
└─ getRemoteServiceConfig()  interconnect_sync_backend.dart:685，只对 404 降级
   └─ host: _securityContext == null → 403 'HTTPS required for service config'
                                       hibiki_sync_server.dart:2197-2199（有意拒绝）
      └─ webdav_ops.dart:259-262 checkStatus 把 401/403 一律压成
         SyncAuthError('Authentication failed')，body 里的真实原因被丢弃
         └─ sync_orchestrator.dart:527 裸 catch (e) → report.errors
\`\`\`

**爆炸半径**：TLS 默认是关的 —— \`sync_repository.dart:619-620\` 默认 \`false\`，\`applyFirstHostingTlsDefault()\` 只对全新设备置 true，存量 host 一律明文（注释明写「保持明文现状（Never break userspace）」）。所以**所有存量明文互联用户**从 \`df660a55e\` 起每轮同步都恒挂「N 项失败」（\`manual_sync_ui.dart:37-39\`）+ 每轮往 ErrorLogService 打噪音（\`sync_auto_trigger.dart:121-125\`），并被引去反复重配**根本没问题的 token**。

最强证据在引入 commit 自己新加的测试里：\`hibiki_sync_server_peer_token_test.dart\` 有 \`'service config refuses plaintext HTTP even for a paired peer'\` 断言 403 —— 服务端契约测到位了，客户端调用侧的门控漏了。

**修法**：\`getRemoteServiceConfig()\` 按会话 scheme 门控，非 \`https\` 直接返回 \`null\` 不发请求。答案本地就已知，别问。\`null\` 与「旧 host 404」「能力关闭 404」归一到同一条「对端不提供此能力」语义，和 host 自己在 \`/api/capabilities\` 广播的 \`'serviceConfig': _securityContext != null && ...\`（\`hibiki_sync_server.dart:1188-1189\`）逐字一致。「能力关闭」那一支服务端已返回 404，本就落在既有分支上。

## 契约已变更：Luna-style 用例的旧断言

\`texthooker_page_test.dart:113\`（旧）在**选线程之前**断言「干净台词」已可见 —— 锁的是 v12 之前「不选 = 全部线程」的语义。改成：选之前**一行都不发布**、诊断 buffer 仍留着两条（它们是选择器的原材料），选之后只剩选中线程。**新断言锁的是现在真正想要的行为**，且比旧断言更强（多了「坏线程也不可见」这一半）。

## 变异实测（双向，非整块删除）

| 变异 | 结果 |
|---|---|
| \`_publishesUnderSelection\` 的 \`return true\` → \`return false\` | texthooker 4 条转红（含新守卫）|
| 反向文本替换还原 | 15/15 转绿 |
| \`scheme != 'https'\` → \`scheme != 'http'\`（反转门控） | 新守卫 + \`live_progress\` 原始红用例 双双转红 |
| 反向文本替换还原 | 40/40 转绿 |

新守卫刻意**不只断返回值**：\`expect(hits, isEmpty)\` 断请求根本没发出去 —— 否则「照发 + catch 吞掉」也能返回 null 骗过。

## 验证

- \`flutter analyze\`（含 test）：**No issues found!**
- \`flutter test test/sync test/mining test/lookup test/tools/bugs_per_file_guard_test.dart --no-pub\` → **3288 tests，All tests passed!**
- \`dart run tool/bug.dart check\` → 通过，1255 条号唯一索引同步。

## 未做（有意留出，已写进 BUG-1311 备注）

- **没动** \`webdav_ops.dart:259-262\` 把 401/403 一律压成 \`SyncAuthError\` —— 它被 webdav/ftp/sftp 多个 backend 共用，改动面远大于本 bug，且修好门控后正常配置下不再触发。但它确实是独立缺陷：403「策略不允许」≠ 401「认证失败」，且 body 里的真实原因被丢弃。
- **没动** \`sync_orchestrator.dart:527\` —— 全仓唯一对 \`SyncAuthError\` 完全不分流的 catch 点。
- \`+build\` 未 bump（按分工）。

## 范围声明

只做④⑤组。③⑥组（下载弹窗 5 条 + 临时目录占用 1 条）另有线程在做，**未触碰**；⑦ \`horizontal_drag_scroll_guard\` 等 #635；\`unified_collections_architecture_guard_test.dart:170\` 的真回归另有线程在修。①② 那 6 条不是本轮改动目标，是 BUG-1315 同根因的连带结果。
