### PR TITLE
test(guard): A 类禁止型锚点换 identifierCall + 页头守卫锚点改 methodBody（TODO-2458 / TODO-2388）

### DIFF
--- a/hibiki/test/media/video/video_volume_row_test.dart
+++ b/hibiki/test/media/video/video_volume_row_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/source_guard.dart';
 import '../../pages/video_hibiki_page_source_corpus.dart';
 
 /// 源码守卫（TODO-438）：视频底栏音量控件是「图标锚点 + 上方紧凑浮层」，且布局尺寸
@@ -48,9 +49,15 @@ void main() {
           reason: '音量浮层必须按所在 slot 取得独立锚点，不能共用全局 link');
       expect(build, isNot(contains('_volumeControlPopoverLink')),
           reason: 'volume 不得继续使用单个全局 LayerLink');
-      expect(build, isNot(contains('Slider(')),
-          reason: '底栏按钮内不得内联 Slider，避免占位随需求回退到横向滑条');
-      expect(build, isNot(contains('Row(')),
+      // 判据须带标识符边界：裸子串 `Slider(` 会被仓内 `adaptiveSlider(` /
+      // `buildSlider(` / `_CommitOnReleaseSlider(` / `gamepadSeekableSlider(`，
+      // 尤其是**同域**的 `_setVolumeFromSlider(` 命中——按钮里正常引用一次音量
+      // helper 就假红；`Row(` 同理被仓内几十个 `*Row(` 组件命中。
+      // 反向也堵：`Slider.adaptive(` 是真内联滑条，裸子串匹配不到（默认吃命名构造器）。
+      expect(containsIdentifierCall(build, 'Slider'), isFalse,
+          reason: '底栏按钮内不得内联 Slider（含 Slider.adaptive），'
+              '避免占位随需求回退到横向滑条');
+      expect(containsIdentifierCall(build, 'Row'), isFalse,
           reason: '底栏音量入口只占图标空间，不再渲染图标 + 横滑条 Row');
     });
 

--- a/hibiki/test/pages/history_reader_page_static_test.dart
+++ b/hibiki/test/pages/history_reader_page_static_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/pages/implementations/history_reader_page.dart';
 
+import '../helpers/source_guard.dart';
+
 void main() {
   test('history reader page library compiles', () {
     expect(const HistoryReaderPage(), isA<HistoryReaderPage>());
@@ -16,10 +18,24 @@ void main() {
     expect(source, contains('HibikiDesignTokens.of(context)'));
     expect(source, contains('tokens.spacing'));
     expect(source, contains('tokens.type.metadata'));
-    expect(source, isNot(contains('Card(')));
-    expect(source, isNot(contains('ListTile(')));
-    expect(source, isNot(contains('SwitchListTile(')));
-    expect(source, isNot(contains('CheckboxListTile(')));
+    // 判据必须带标识符边界，裸子串在两个方向上都错：
+    // - 假阳：`Card(` 是 `HibikiCard(` 的子串，而本测试第一条正向断言要的正是
+    //   「共享 MD3 卡片」——书架一旦真用上 HibikiCard，这条守卫立刻假红；
+    //   `ListTile(` 同理被 `HibikiListTile(` 命中。
+    // - 假阴：`SwitchListTile(` 匹配不到本仓真实在用的 `SwitchListTile.adaptive(`
+    //   （`SwitchListTile` 后面是 `.` 不是 `(`），旧写法以命名构造器形式回归就完全绕过。
+    // 原裸子串 `ListTile(` 顺带盖住的 Radio/Cupertino 变体在下面显式补回，
+    // 避免换匹配器时静默削弱守卫强度。
+    expect(containsIdentifierCall(source, 'Card'), isFalse,
+        reason: '书架卡片必须走共享 MD3 卡片，不得裸构造 Card');
+    expect(containsIdentifierCall(source, 'ListTile'), isFalse,
+        reason: '书架行不得裸构造 Material ListTile');
+    expect(containsIdentifierCall(source, 'SwitchListTile'), isFalse,
+        reason: '含 SwitchListTile.adaptive');
+    expect(containsIdentifierCall(source, 'CheckboxListTile'), isFalse,
+        reason: '含 CheckboxListTile.adaptive');
+    expect(containsIdentifierCall(source, 'RadioListTile'), isFalse);
+    expect(containsIdentifierCall(source, 'CupertinoListTile'), isFalse);
     expect(source, isNot(contains('BorderRadius.circular(')));
     expect(source, isNot(contains('fontSize:')));
   });

--- a/hibiki/test/pages/popup_dictionary_page_nested_test.dart
+++ b/hibiki/test/pages/popup_dictionary_page_nested_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 void main() {
   const String pagePath =
       'lib/src/pages/implementations/popup_dictionary_page.dart';
@@ -28,7 +30,9 @@ void main() {
     // 不能再用全屏阅读器语义的 buildNestedPopupLayer / calcPopupPosition
     // 把子弹窗压成小窗。
     expect(src, contains('Positioned.fill'));
-    expect(src, isNot(contains('buildNestedPopupLayer(')),
+    // 裸子串会被**以该名结尾**的更长标识符命中：仓内真实存在私有的
+    // `_buildNestedPopupLayer(`，本页哪天自己落一个同名私有 helper 就假红。
+    expect(containsIdentifierCall(src, 'buildNestedPopupLayer'), isFalse,
         reason: '下钻层改为满卡渲染，不再复用阅读器的贴选区小浮卡');
     expect(src, isNot(contains('calcPopupPosition')), reason: '满卡渲染无需按选区定位');
     // 嵌套层不透明铺满盖住下层（base 透明，nested 用词典色/页面色）。

--- a/hibiki/test/pages/reader_popup_focus_static_test.dart
+++ b/hibiki/test/pages/reader_popup_focus_static_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
 import 'reader_hibiki_page_source_corpus.dart';
 
 /// 查词弹窗焦点系统守卫。
@@ -25,10 +26,16 @@ void main() {
       reason: '查词弹窗 header 是 Flutter 兄弟层，手柄/键盘方向导航只走 '
           'HibikiFocusTarget；裸 IconButton 会被自定义焦点系统跳过。',
     );
+    // 原写法靠 replaceAll 抠掉 HibikiIconButton 再做裸子串匹配——那是白名单，
+    // 白名单永远漏：仓内还有 `_RepeatIconButton(` / `_InBookIconButton(` /
+    // `_CompactSearchIconButton(` 没登记，header 用上任何一个都会假红。
+    // 反向也漏：裸子串匹配不到 `IconButton.filledTonal(`（本仓真实在用），而那
+    // 正是本守卫要拦的「未注册的裸 IconButton」。带标识符边界的匹配免白名单。
     expect(
-      popupHeader.replaceAll('HibikiIconButton(', ''),
-      isNot(contains('IconButton(')),
-      reason: '查词弹窗 header 不得再使用未注册的裸 IconButton。',
+      containsIdentifierCall(popupHeader, 'IconButton'),
+      isFalse,
+      reason: '查词弹窗 header 不得再使用未注册的裸 IconButton'
+          '（含 IconButton.filledTonal 等命名构造器）。',
     );
   });
 

--- a/hibiki/test/pages/video_header_button_order_guard_test.dart
+++ b/hibiki/test/pages/video_header_button_order_guard_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/video/video_control_customization.dart';
 
+import '../helpers/source_guard.dart';
 import 'video_hibiki_page_source_corpus.dart';
 
 /// 守卫（TODO-162）：视频页（HomeVideoPage）顶栏三个动作按钮的排列顺序，必须与
@@ -28,14 +29,24 @@ void main() {
   /// `List<Widget> actions = <Widget>[`（页头统一成 [HibikiPageHeader] 后走后者）。
   /// 区间终点用方括号配对求出，而不是「下一个 `],`」——后者在列表以 `];` 收尾时会
   /// 直接越过方法体，把断言范围放大到整个文件。
+  ///
+  /// 起点必须命中**定义**而不是调用点。两个语料文件里裸名 `_buildPageHeader` 都是
+  /// 先命中调用点（`home_video_page.dart` 的 `if (!isCupertinoPlatform(context))
+  /// _buildPageHeader(canImport)` / `reader_hibiki_history_page.dart` 的
+  /// `_buildPageHeader()`），定义在几百上千行之后。用裸名 `indexOf` 定起点的话，
+  /// 只要将来有人在调用点与定义之间写一个持有 `actions = <Widget>[` 的**无关方法**，
+  /// 切出来的就是那个方法的列表，真实页头的顺序回归会静默漏掉（复核方 MUT_G 已实证
+  /// 此形态下守卫仍绿）。
+  ///
+  /// 这里用 [methodBody] 按花括号配对截出方法体：起点签名带 `Widget ` 前缀，只会命中
+  /// 定义；终点由源码结构给出，不再是裸名 + 全文件后缀。
   String headerActionsBlock(File file) {
-    final String text = file.readAsStringSync();
-    final int headerIdx = text.indexOf('_buildPageHeader');
-    expect(headerIdx, greaterThanOrEqualTo(0),
-        reason: '${file.path} 应定义 _buildPageHeader');
-    int actionsIdx =
-        text.indexOf('List<Widget> actions = <Widget>[', headerIdx);
-    final int inlineIdx = text.indexOf('actions: <Widget>[', headerIdx);
+    final String text = methodBody(
+      file.readAsStringSync(),
+      'Widget _buildPageHeader(',
+    );
+    int actionsIdx = text.indexOf('List<Widget> actions = <Widget>[');
+    final int inlineIdx = text.indexOf('actions: <Widget>[');
     if (actionsIdx < 0 || (inlineIdx >= 0 && inlineIdx < actionsIdx)) {
       actionsIdx = inlineIdx;
     }

--- a/hibiki/test/pages/video_render_fixes_guard_test.dart
+++ b/hibiki/test/pages/video_render_fixes_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 视频渲染三修复的源码守卫（media_kit 驱动的 VideoHibikiPage 无法 headless 行为测试，
 /// 故锁定关键配线）：
 ///  1. 「视频没画面」——所有打开视频页的入口都经 [VideoHibikiPage.neutralized] 在路由层
@@ -31,8 +33,17 @@ void main() {
       final String s = File(path).readAsStringSync();
       expect(s, contains('VideoHibikiPage.neutralized('),
           reason: '$path 必须经 VideoHibikiPage.neutralized 打开视频页');
-      expect(s, isNot(contains('VideoHibikiPage(')),
-          reason: '$path 不得裸用 VideoHibikiPage( 构造（会漏掉缩放中和→无画面）');
+      // 这里必须 allowNamedConstructor: false —— 契约是「只禁裸构造，命名构造器
+      // （.neutralized / .remote / .neutralizedRemote）才是唯一合法入口」。默认
+      // 吃命名构造器的匹配会把上一行正向要求的写法判成违规。
+      // 换匹配器的收益是补上前边界：将来出现任何 `_XxxVideoHibikiPage(` 这类以该名
+      // 结尾的更长标识符时不会假红。
+      expect(
+        containsIdentifierCall(s, 'VideoHibikiPage',
+            allowNamedConstructor: false),
+        isFalse,
+        reason: '$path 不得裸用 VideoHibikiPage( 构造（会漏掉缩放中和→无画面）',
+      );
     }
     // 书架不再打开视频页（视频归「视频」tab 独占，书架视频分区已删），故此处不再
     // 校验书架语料的 VideoHibikiPage.neutralized 接线。

--- a/hibiki/test/reader/reader_chrome_focus_guard_728_test.dart
+++ b/hibiki/test/reader/reader_chrome_focus_guard_728_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// TODO-728 source-scan focus guards (TODO-700 invariant must not regress):
 ///  - The bottom chrome bars stay wrapped in ExcludeFocus (out of the focus
 ///    traversal pool).
@@ -98,7 +100,16 @@ void main() {
       isTrue,
       reason: '顶部进度点击必须路由到 _toggleChrome（挤压）或悬浮唤出/收起',
     );
-    expect(body, isNot(contains('Focus(')));
+    // 裸子串 'Focus(' 会被任何**以 Focus 结尾**的更长标识符命中——本仓真实存在
+    // `requestFocus(` / `ensureFocus(` / `nextFocus(` / `ExcludeFocus(` 等一堆，
+    // 顶部进度条一旦正常调一次 `node.requestFocus()` 这条守卫就假红。
+    // 契约是「不得包一层 Focus widget」，故只匹配裸构造：`Focus.of(context)` 是读取
+    // 祖先节点、不是包装，不该判违规（allowNamedConstructor: false）。
+    expect(
+      containsIdentifierCall(body, 'Focus', allowNamedConstructor: false),
+      isFalse,
+      reason: '顶部进度点击面必须保持纯指针面，不得包 Focus',
+    );
     expect(body, isNot(contains('canRequestFocus')));
   });
 }

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 import '../pages/reader_history_source_corpus.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 import '../sync/sync_settings_schema_source_corpus.dart';
@@ -1632,9 +1633,15 @@ void main() {
 
         expect(section, contains('HibikiFilePickerRow('));
         expect(section, contains('HibikiIconButton('));
+        // 原写法先把 HibikiIconButton 换名再做裸子串匹配 —— 那是白名单，白名单
+        // 永远漏：仓内还有 `_RepeatIconButton(` / `_InBookIconButton(` /
+        // `_CompactSearchIconButton(` 没登记，用上任何一个就假红；反向也漏，裸子串
+        // 匹配不到本仓真实在用的 `IconButton.filledTonal(`。带标识符边界的匹配
+        // 一次堵住两个方向，且不需要维护白名单。
         expect(
-          section.replaceAll('HibikiIconButton(', 'HibikiSharedAction('),
-          isNot(contains('IconButton(')),
+          containsIdentifierCall(section, 'IconButton'),
+          isFalse,
+          reason: '${entry.key} 不得用裸 IconButton（含 IconButton.filledTonal）',
         );
         expect(section, isNot(contains('Theme.of(context).colorScheme')));
         expect(section, isNot(contains('size: 18')));
@@ -2069,7 +2076,9 @@ void main() {
     expect(managerMenu, isNot(contains('Material(')));
     expect(managerMenu, isNot(contains('BorderRadius.circular(24)')));
     expect(managerPopupItem, contains('HibikiPopupMenuItem<VoidCallback>('));
-    expect(managerPopupItem, isNot(contains('Row(')));
+    // 裸子串 `Row(` 会被仓内几十个 `*Row(` 组件（`AdaptiveSettingsSwitchRow(` /
+    // `AudioCueRow(` / `AnkiMappingRow(` …）命中，菜单项引用任何一个就假红。
+    expect(containsIdentifierCall(managerPopupItem, 'Row'), isFalse);
     expect(managerPopupItem, isNot(contains('const SizedBox(width: 8)')));
     expect(managerMenu, isNot(contains('const SizedBox(width: 8)')));
 
@@ -2083,10 +2092,10 @@ void main() {
       'Future<MinePopupResult> onMineFromPopup',
     );
     expect(dictionaryLoading, contains('HibikiCard('));
-    expect(
-      _withoutSharedComponentNames(dictionaryLoading),
-      isNot(contains('Card(')),
-    );
+    // 免白名单：`HibikiCard(` 本身含子串 `Card(`，旧写法靠换名绕开；但仓内还有
+    // `_EndpointCard(` / `_EpisodeRailCard(` / `SeriesShelfCard(` 等一堆以 Card
+    // 结尾的组件没登记。标识符边界匹配只认裸 `Card` 构造。
+    expect(containsIdentifierCall(dictionaryLoading, 'Card'), isFalse);
 
     final String progressContent = File(
       'lib/src/pages/implementations/dictionary_progress_dialog_content.dart',
@@ -2106,8 +2115,8 @@ void main() {
     expect(mineButton, contains('Icons.add_circle_outline'));
     expect(mineButton, contains('tokens.spacing'));
     expect(mineButton, contains('creator_export_card'));
-    expect(_withoutSharedComponentNames(mineButton),
-        isNot(contains('IconButton(')));
+    expect(containsIdentifierCall(mineButton, 'IconButton'), isFalse,
+        reason: '制卡按钮不得用裸 IconButton（含 IconButton.filledTonal）');
     expect(mineButton, isNot(contains("Text('+")));
     expect(mineButton, isNot(contains('HibikiFocusable(')));
 
@@ -2495,18 +2504,20 @@ void main() {
       'Widget _buildItem(_CollectionItem item)',
       'class CollectionItemDialogFrame',
     );
-    final String normalized = _withoutSharedComponentNames(itemSource);
-
     expect(itemSource, contains('HibikiListItem('));
     expect(itemSource, contains('HibikiIconButton('));
     expect(itemSource, contains('tokens.spacing'));
     expect(itemSource, contains('_hasAudio(item)'));
     expect(itemSource, contains('_playItemAudio(item)'));
     expect(itemSource, contains('onLongPress: () => _showItemDialog(item)'));
-    expect(normalized, isNot(contains('IconButton(')));
+    // 三条判据都换成标识符边界匹配，_withoutSharedComponentNames 白名单在此不再需要：
+    // 共享组件（HibikiIconButton / HibikiListTile / HibikiCard）天然不匹配，
+    // 未登记的 `_RepeatIconButton(` / `_EndpointCard(` 也不再假红，
+    // 而 `IconButton.filledTonal(` 这类命名构造器回归反而能被抓到。
+    expect(containsIdentifierCall(itemSource, 'IconButton'), isFalse);
     expect(itemSource, isNot(contains('VisualDensity.compact')));
-    expect(normalized, isNot(contains('ListTile(')));
-    expect(normalized, isNot(contains('Card(')));
+    expect(containsIdentifierCall(itemSource, 'ListTile'), isFalse);
+    expect(containsIdentifierCall(itemSource, 'Card'), isFalse);
   });
 
   test('media item edit dialog uses shared MD3 dialog chrome', () {

--- a/hibiki/test/settings/settings_migration_static_test.dart
+++ b/hibiki/test/settings/settings_migration_static_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 void main() {
   final Map<String, List<String>> migratedPages = <String, List<String>>{
     // anki_settings_page.dart 现在导出的是无脚手架的 AnkiSettingsBody（直接平铺
@@ -60,8 +62,17 @@ void main() {
           reason: '$fileName still uses SwitchListTile');
       expect(source, isNot(contains('adaptiveSwitch(')),
           reason: '$fileName still hand-rolls switch rows');
-      expect(source, isNot(contains('ListTile(')),
+      // 带标识符边界：裸子串 `ListTile(` 会被共享组件 `HibikiListTile(` 命中
+      // （`_withoutSharedComponentNames` 白名单里已把它列为合法共享组件），
+      // 设置页哪天改用共享行组件就假红。Radio/Cupertino 变体在下面显式补回，
+      // 保住原裸子串顺带盖住的范围。
+      expect(containsIdentifierCall(source, 'ListTile'), isFalse,
           reason: '$fileName still uses ListTile instead of settings rows');
+      expect(containsIdentifierCall(source, 'RadioListTile'), isFalse,
+          reason:
+              '$fileName still uses RadioListTile instead of settings rows');
+      expect(containsIdentifierCall(source, 'CupertinoListTile'), isFalse,
+          reason: '$fileName still uses CupertinoListTile');
       expect(source, isNot(contains('ExpansionTile(')),
           reason: '$fileName still uses ExpansionTile instead of sections');
       expect(source, isNot(contains('adaptiveSegmentedButton')),


### PR DESCRIPTION
纯 `hibiki/test/` 改动，**零生产代码**，不建 BUG 号（守卫判据缺陷非产品缺陷）。前置 PR#642（merge `3340cb9ed`）已合入 develop，直接复用它提供的 `identifierCall()` / `containsIdentifierCall()` / `methodBody()`。

## ① A 类禁止型锚点（看板 TODO-2458）

16 条 `isNot(contains('X('))` 裸子串判据换成 `containsIdentifierCall()`。裸子串**两个方向都错**，且碰撞名在仓里**真实存在**：

**假红方向**（被以该名结尾的更长标识符命中）：`HibikiCard(` / `HibikiListTile(` / `requestFocus(` / `ExcludeFocus(` / `_RepeatIconButton(` / `_EndpointCard(` / `_EpisodeRailCard(` / `AudioCueRow(` / `_setVolumeFromSlider(` / `_buildNestedPopupLayer(`。其中 `HibikiCard` / `HibikiListTile` / `_RepeatIconButton` 正是**同一条守卫正向断言要求**的共享组件 —— 守卫会在「代码改对了」的那一刻炸。

**假绿方向**（匹配不到命名构造器）：`SwitchListTile.adaptive(` / `CheckboxListTile.adaptive(` / `Slider.adaptive(` / `Card.filled(` / `IconButton.filledTonal(`，全部在仓内真实在用。

顺带删掉三处**白名单 hack**：`section.replaceAll('HibikiIconButton(', 'HibikiSharedAction(')`、`popupHeader.replaceAll('HibikiIconButton(', '')`、以及 `_withoutSharedComponentNames()` 的三个调用点。白名单永远漏登记（`_RepeatIconButton` / `_EndpointCard` / `_EpisodeRailCard` 都不在里面），标识符边界匹配免维护。

`VideoHibikiPage` 那条特意用 `allowNamedConstructor: false` —— 契约是「只禁裸构造，`.neutralized(` / `.remote(` 才是唯一合法入口」，默认吃命名构造器会把上一行**正向要求**的写法判成违规。

改动文件：`history_reader_page_static_test` / `reader_chrome_focus_guard_728_test` / `video_volume_row_test` / `popup_dictionary_page_nested_test` / `reader_popup_focus_static_test` / `settings_migration_static_test` / `md3_design_system_static_test` / `video_render_fixes_guard_test`。

换匹配器会让原裸子串**顺带**盖住的 `RadioListTile` / `CupertinoListTile` 落空，故在两处显式补回，不静默削弱强度。

## ② `headerActionsBlock()` 锚点（看板 TODO-2388）

`video_header_button_order_guard_test.dart` 原来用 `indexOf('_buildPageHeader')` 定起点，而两个语料文件里裸名都**先命中调用点**：`home_video_page.dart:1995`（定义在 `:3024`）、`reader_hibiki_history_page.dart:511`（定义在 `:639`）。只要有人在调用点与定义之间写一个持有 `actions = <Widget>[` 的**无关方法**，切出来的就是那个方法的列表。

改用 `methodBody(text, 'Widget _buildPageHeader(')`：签名带返回类型只命中定义，终点按花括号配对。

三引号限制（主行=2358 的 D5）**未命中**：两个语料文件 `'''` / `"""` 计数均为 0，方法体内无携花括号的字符串字面量。

## 验证

- `flutter analyze`（含 test）：`No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub <9 个守卫文件>`：`FLUTTER TEST VERDICT: PASSED - 91 tests ran`，退出码 0
- **变异实测 50 例**（真阳每条**两种**等价写法 + 假阳用仓内真实碰撞名）：49 例符合预期；1 例（`ExcludeFocus(` 探针）转红是**探针撞了同文件另一条计数型断言** `bottom chrome bars remain ExcludeFocus`，非本判据 —— 换 `nextFocus(` / `previousFocus(` 重跑 EXIT=0。
- **对照 origin/develop 原判据 9 例**：5 例证实假红炸弹（EXIT=1）、4 例证实假绿漏网（EXIT=0），坐实这些不是理论风险。
- **MUT_G 前后对照**：在同一棵被污染的树上，原判据 EXIT=0（4 tests passed，真实页头顺序已回归却全绿），改后 EXIT=1 且失败断言正是 `TODO-162：视频导入按钮应在收藏夹之前`。另做 shelf 基准 mutation（收藏夹↔统计对调）确认另一条 test 仍能咬红。
- 所有变异还原走**文件拷贝回写 / 反向文本替换**，未对未提交文件跑 `git checkout --`；还原后 `git diff -- hibiki/lib` 为空。
