### PR TITLE
fix(collections): 删合集回收自有封面收成单一入口（BUG-1316）+ 收敛两个槽向封面组件的共享内核（TODO-2450/2426）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1255 条。点号进各自文件。
+> 共 1256 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1316](bugs/BUG-1316-collection-delete-cover-leak.md) | ✅ | ✅ | 删合集只有 1/6 入口回收自有封面：其余五条只删 DB 行，路径随行永久丢失、GC 又扫不到该子目录 = 确定性空间泄漏 |
 | [BUG-1308](bugs/BUG-1308-popup-dict-style-node-per-section.md) | 🚧 | 🚧 | 查词弹窗每条目×每词典新建一个 style 节点，触发 10 次全文档样式重算 |
 | [BUG-1307](bugs/BUG-1307-dict-engine-max-results-overshoot.md) | ✅ | ✅ | 查词冷路径白解压 20 倍：引擎结果上限硬编码 200 而 Dart 侧只用 maximumTerms |
 | [BUG-1305](bugs/BUG-1305-delete-confirm-disclosure.md) | ✅ | ✅ | 删除确认文案与真实删除范围对不上（书架递归删解压目录+有声书；合集正文说反话） |

--- a/docs/bugs/BUG-1316-collection-delete-cover-leak.md
+++ b/docs/bugs/BUG-1316-collection-delete-cover-leak.md
@@ -1,0 +1,27 @@
+## BUG-1316 · 删合集只有 1/6 入口回收自有封面：其余五条只删 DB 行，路径随行永久丢失、GC 又扫不到该子目录 = 确定性空间泄漏
+- **报告**：2026-08-01（PR#635 审查时发现，非用户直报）
+- **真实性**：✅ 真 bug，**确定性**泄漏（不是概率性的：每从这五条入口删掉一个刮削过的合集，就永久漏一个文件）。
+  - 合集自有封面唯一落盘路径是 `video_covers/collections/<collectionId>.jpg`（`hibiki/lib/src/media/video/video_storage.dart:55` 目录名 + `:61-62` 目录 + `video_cover_extractor.dart:131-134` 文件名 + `scraper/cover_scraper_service.dart:424-435` 下载），路径记在 `media_collections.cover_path`（`packages/hibiki_core/lib/src/database/tables.dart:846`）。
+  - `HibikiDatabase.deleteMediaCollection`（`packages/hibiki_core/lib/src/database/database.dart:3071-3094`）**零磁盘操作**：删成员引用行 + 删合集行 + 清残留成员墓碑 + 写合集级哨兵墓碑。行一删，`<id>` 与 `cover_path` 同时消失 —— **磁盘上那张图再也无法被任何机制识别**。
+  - 兜底 GC 也接不住：`VideoStorage.gcOrphanCovers`（`video_storage.dart:208-230`）只扫 `video_covers/` 一层（`:219` `covers.list()` 非递归、`:220` `entity is! File` 跳过目录项），保留集是全库 `video_books.cover_path`（`video_book_repository.dart:606-614`）。合集封面既在子目录、又不在那个引用集里，**两重免疫**。这个盲区是**设计意图**（`video_storage.dart:47-55` 明写：同级扁平存放反而会被那轮 GC 当孤儿误删），所以「删合集」是这些文件唯一的回收时机。
+  - **根因不是某个页面忘了删文件，而是回收挂在某个调用点上、没挂在「删合集」这个动作本身**：回收只存在于 `hibiki/lib/src/media/collections/collection_context_dialog.dart:223`（旧 `_reclaimCollectionCover`，`:234-252`），全仓 `deleteCollectionCover` 只有这一个消费者。其余五条删除路径全部裸调 DAO：
+    - `hibiki/lib/src/pages/implementations/media_collection_detail_page.dart:267`（视频合集详情页 `_delete`）
+    - `hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart:163`（网格合集详情页 `_delete`）
+    - `hibiki/lib/src/pages/implementations/home_video_page.dart:778`（视频库页批量解散）、`:1191`（合集合并时解散源合集）
+    - `hibiki/lib/src/pages/implementations/reader_history/books.part.dart:536`（书架页批量解散）、`:805`（书架页合集合并）
+    - `hibiki/lib/src/sync/collection_sync_engine.dart:586`、`:605`（同步删除传播 / 移空自删，走 `deleteMediaCollectionRaw`）
+  - **关于 `<id>_backdrop.jpg`**：这条线索来自 PR#635，但该 PR **尚未合入**。当前 develop 全仓无 backdrop 列、无 backdrop 落盘代码、无 `_backdrop` 文件名规则（`git grep -i backdrop` 命中的全是 `BackdropFilter` / `DWMWA_SYSTEMBACKDROP_TYPE` / media_kit `backdropColor` 等无关物）。所以 backdrop 是这个泄漏**未来的放大版**，今天真实在漏的是 **cover 本身**。修复按「合集自有资产」建模而非按「封面」建模，正是为了让 #635 落地时 backdrop 一行接入、不必重演六处补丁。
+- **[x] ① 已修复** — 新增 `hibiki/lib/src/media/collections/collection_asset_reclaim.dart`，把「删行 + 回收自有资产」收成单一入口：
+  - `deleteMediaCollectionWithAssets(db, id)`：**先取行快照**（路径只能从还活着的行推导）→ `deleteMediaCollection` → 回收。返回值透传被删行数，六个调用点原有的 `removed > 0` 判据零变化。
+  - `reclaimDeletedCollectionAssets(db, rows)`：给「删行在事务里、文件 IO 必须挪到事务外」的同步引擎用。`applyCollectionLocalChanges` 在事务内把被解散的行快照入列 `dissolved`，事务提交后统一回收。
+  - `collectionOwnedAssetPaths(row)`：合集自有资产路径的唯一清单（今天只有 `coverPath`）。将来加 backdrop 列 = 在这里加一行，六条路径同时生效。
+  - **误删护栏（三条同时成立才删，任一不成立静默保留）**：① 路径只来自被删合集自己 DB 行的 `coverPath`，不枚举目录、不猜文件名；② 规范化后必须严格落在合集封面目录内（`VideoStorage.deleteCollectionCover` → `_deleteOwnedAsset` 的 `p.isWithin`，杜绝 `..` / 符号链接越界）；③ 删行后重查全库合集，任何仍存活的合集引用同一规范化路径则保留。
+  - 显式**不做**启动时全盘扫描找孤儿：那既绕过根因，又把「宁可漏删不误删」的判据换成了「目录里没被引用的都删」。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/collections/collection_asset_reclaim_test.dart`（9 例）：行为层 7 例（回收自己的封面 / **别的合集封面一根汗毛不许动** / 两合集共用同一张封面时保留 / 目录外用户图片绝不删 / 无封面零 IO / 合集不存在返回 0 / 批量事务外回收）+ 源码守卫 2 例（生产代码不得裸调 `deleteMediaCollection(`，唯一豁免回收入口自己；同步引擎必须先入列快照再删行、且回收落在事务之后）。
+- **备注**：**变异实测 5 轮，双向都验**（每轮只改语义关键的一位，还原用反向文本替换 + `diff` 对齐备份，未对未提交文件用 `git checkout --`）：
+  - ① 摘掉 `deleteMediaCollectionWithAssets` 里的回收调用 → 2 例红（漏删方向）；
+  - ② `stillReferencedCoverPaths` 传空集 → 「共用同一张封面」1 例红（证明引用护栏是承重的，不是自洽废话）；
+  - ③ 把逐候选删改成目录整扫（最典型的误删写法）→ 3 例红，含「别的合集封面不许动」（误删方向）；
+  - ④ 把详情页调用点退回 `widget.database.deleteMediaCollection(...)` → 源码守卫红，且报出精确文件行；
+  - ⑤ 把同步回收挪进 `db.transaction` 内 → 时序守卫红。
+  - 全部还原后重跑 `FLUTTER TEST VERDICT: PASSED - 9 tests ran`。

--- a/hibiki/lib/src/media/collections/collection_asset_reclaim.dart
+++ b/hibiki/lib/src/media/collections/collection_asset_reclaim.dart
@@ -1,0 +1,113 @@
+import 'dart:io';
+
+import 'package:hibiki/src/media/video/video_storage.dart';
+import 'package:hibiki/utils.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 合集自有磁盘资产的回收（BUG-1316）。
+///
+/// ## 为什么必须是「唯一入口」而不是某个页面的私有 helper
+///
+/// 合集自有封面落在 `video_covers/collections/<id>.jpg`，路径记在
+/// `media_collections.cover_path`。[VideoStorage.gcOrphanCovers] 那轮历史 GC
+/// **故意**扫不到这个子目录（它非递归、且保留集是全库 `video_books.cover_path`，
+/// 合集封面不在其中——见 [VideoStorage.collectionCoversDirName] 注释）。于是
+/// 「删合集」是这些文件**唯一**的回收时机：DB 行一删，`<id>` 与 `cover_path`
+/// 同时消失，磁盘上那张图再也无法被任何机制识别 = 确定性永久泄漏。
+///
+/// 而回收此前只挂在 `collection_context_dialog._deleteCollection` 一个 UI 入口
+/// 上，另外五条删除路径（两个合集详情页 `_delete`、两处库页批量解散、合集合并
+/// 的源合集解散、同步删除传播）全部只删 DB 行不删文件。**根因就是回收挂在某个
+/// 调用点上、而不是挂在「删合集」这个动作本身**：只要还有第二个调用点，新入口
+/// 就天然漏。所以这里把「删行 + 回收」收成一个函数，全部入口调它。
+///
+/// ## 顺序约束
+///
+/// 资产路径只能从**还活着的** DB 行推导。因此 [deleteMediaCollectionWithAssets]
+/// 先取行快照、再删行、最后删文件；调用方不得自己颠倒这个顺序。
+///
+/// ## 误删护栏（三条同时成立才删）
+///
+/// 1. 路径来自被删合集自己 DB 行的 `coverPath`——不枚举目录、不猜文件名；
+/// 2. 规范化后必须**严格落在**合集封面目录内（[VideoStorage.deleteCollectionCover]
+///    内部用 `p.isWithin` 判定，杜绝 `..` / 符号链接越界）——用户外部图片、成员
+///    封面、原始视频文件一律不碰；
+/// 3. 删行后重查全库合集，**任何仍存活的合集引用同一规范化路径则保留**。
+///
+/// 宁可漏删也不误删：三条中任一不成立就静默保留文件。
+
+/// 一行合集快照里「该合集自有、随合集删除一起回收」的磁盘资产路径。
+///
+/// 目前只有封面一项。将来给 `media_collections` 加横版 backdrop 之类的自有图片
+/// 列时，**在这里加一行**就能让全部六条删除路径同时生效——这正是把回收收成单一
+/// 入口的收益（否则新列会原样重演同一个泄漏）。
+List<String?> collectionOwnedAssetPaths(MediaCollectionRow collection) {
+  return <String?>[collection.coverPath];
+}
+
+/// 删除合集的**唯一入口**：删 DB 行（[HibikiDatabase.deleteMediaCollection]，
+/// 清成员引用行 + 写合集级墓碑）→ 回收该合集自有的磁盘资产。
+///
+/// 返回值透传 [HibikiDatabase.deleteMediaCollection]（被删的合集行数），调用方
+/// 原有的 `removed > 0` 判据零变化。
+///
+/// [collectionCoversDirectory] 仅供测试注入；生产走 [VideoStorage] 的真实目录。
+Future<int> deleteMediaCollectionWithAssets(
+  HibikiDatabase db,
+  int collectionId, {
+  Directory? collectionCoversDirectory,
+}) async {
+  // 快照必须在删行**之前**取：行一删，coverPath 就再也推导不出来。
+  final MediaCollectionRow? snapshot =
+      await db.getMediaCollectionById(collectionId);
+  final int removed = await db.deleteMediaCollection(collectionId);
+  await reclaimDeletedCollectionAssets(
+    db,
+    <MediaCollectionRow>[if (snapshot != null) snapshot],
+    collectionCoversDirectory: collectionCoversDirectory,
+  );
+  return removed;
+}
+
+/// 回收 [deletedCollections]（DB 行**已删**的合集快照）各自自有的磁盘资产。
+///
+/// 给「删行发生在事务里、文件 IO 必须挪到事务外」的调用方用（同步删除传播）。
+/// 普通调用方直接用 [deleteMediaCollectionWithAssets]。
+///
+/// 返回实际删掉的文件数（便于测试断言）。删除失败 / 异常不抛——合集已经删掉是
+/// 既成事实，一张残留图不该让整个删除流程报错。
+Future<int> reclaimDeletedCollectionAssets(
+  HibikiDatabase db,
+  Iterable<MediaCollectionRow> deletedCollections, {
+  Directory? collectionCoversDirectory,
+}) async {
+  final List<String> candidates = <String>[
+    for (final MediaCollectionRow collection in deletedCollections)
+      for (final String? path in collectionOwnedAssetPaths(collection))
+        if (path != null && path.isNotEmpty) path,
+  ];
+  // 没有任何自有资产就彻底不碰文件系统（无封面的同步 / 单测路径零 IO）。
+  if (candidates.isEmpty) return 0;
+  int reclaimed = 0;
+  try {
+    final List<MediaCollectionRow> survivors =
+        await db.getAllMediaCollections();
+    final List<String> stillReferenced = <String>[
+      for (final MediaCollectionRow collection in survivors)
+        for (final String? path in collectionOwnedAssetPaths(collection))
+          if (path != null && path.isNotEmpty) path,
+    ];
+    for (final String candidate in candidates) {
+      if (await VideoStorage.deleteCollectionCover(
+        deletedCoverPath: candidate,
+        stillReferencedCoverPaths: stillReferenced,
+        collectionCoversDirectory: collectionCoversDirectory,
+      )) {
+        reclaimed++;
+      }
+    }
+  } catch (e, stack) {
+    ErrorLogService.instance.log('collection.reclaimAssets', e, stack);
+  }
+  return reclaimed;
+}

--- a/hibiki/lib/src/media/collections/collection_context_dialog.dart
+++ b/hibiki/lib/src/media/collections/collection_context_dialog.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'package:hibiki/src/sync/deletion_disclosure.dart';
+import 'package:hibiki/src/media/collections/collection_asset_reclaim.dart';
 import 'package:hibiki/src/media/collections/collection_one_key_sort.dart';
-import 'package:hibiki/src/media/video/video_storage.dart';
 import 'package:hibiki/src/pages/implementations/collection_name_dialog.dart'
     show showCollectionNameDialog;
 import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart';
@@ -18,7 +18,8 @@ import 'package:hibiki_core/hibiki_core.dart';
 /// 上下文菜单（与单卡的长按对话框割裂，用户实报）。本对话框复用单卡同款
 /// [MediaItemDialogFrame] 骨架，动作语义与详情页 AppBar 完全同源：
 /// 重命名走 [HibikiDatabase.renameMediaCollection]，标签走 [TagPickerPage]
-/// （合集路），删除走 [HibikiDatabase.deleteMediaCollection]（纯解链，可选
+/// （合集路），删除走 [deleteMediaCollectionWithAssets]（纯解链 + 回收合集自有
+/// 封面，不删成员本体，可选
 /// 「连同成员本体一起删」勾选，与详情页 `_delete` 同一纪律）。
 ///
 /// [context] 必须是**页面**级 context（对话框内部动作先关自身再用它续跑）。
@@ -187,8 +188,9 @@ Future<void> _sortCollection({
 }
 
 /// 删除合集：确认（可选「连同成员本体一起删」勾选）→ 先删成员本体（调用方注入，
-/// 按媒体域删 DB 行 + 磁盘副本）→ [HibikiDatabase.deleteMediaCollection]
-/// 解散容器（清引用行 + 写合集级墓碑）。与两个合集详情页的 `_delete` 同一顺序。
+/// 按媒体域删 DB 行 + 磁盘副本）→ [deleteMediaCollectionWithAssets] 解散容器
+/// （清引用行 + 写合集级墓碑 + 回收合集自有封面）。与两个合集详情页的 `_delete`
+/// 同一顺序、同一入口（BUG-1316：回收必须挂在删除动作上，不能各入口各写一遍）。
 Future<void> _deleteCollection({
   required BuildContext context,
   required HibikiDatabase db,
@@ -219,34 +221,6 @@ Future<void> _deleteCollection({
   if (result.checked && onDeleteMembersMedia != null) {
     await onDeleteMembersMedia(List<MediaCollectionItemRow>.of(members));
   }
-  await db.deleteMediaCollection(collection.id);
-  await _reclaimCollectionCover(db, collection);
+  await deleteMediaCollectionWithAssets(db, collection.id);
   onChanged();
-}
-
-/// 回收被删合集**自有**封面文件（`MediaCollections.coverPath`，schema v61）。
-///
-/// 合集行删了但那张图还在磁盘上 = 永久泄漏（合集封面不在 `video_books.cover_path`
-/// 引用集里，[VideoStorage.gcOrphanCovers] 那轮历史 GC 也扫不到子目录）。护栏与
-/// [VideoStorage.deleteBookAssets] 同纪律：只删落在合集封面目录内、且不被其余任何
-/// 合集引用的文件。删除失败不抛——合集已经删掉是既成事实，一张残留图不该让整个
-/// 删除流程报错。
-Future<void> _reclaimCollectionCover(
-  HibikiDatabase db,
-  MediaCollectionRow collection,
-) async {
-  final String? cover = collection.coverPath;
-  if (cover == null || cover.isEmpty) return;
-  try {
-    final List<MediaCollectionRow> rest = await db.getAllMediaCollections();
-    await VideoStorage.deleteCollectionCover(
-      deletedCoverPath: cover,
-      stillReferencedCoverPaths: <String>[
-        for (final MediaCollectionRow c in rest)
-          if (c.id != collection.id && c.coverPath != null) c.coverPath!,
-      ],
-    );
-  } catch (e, stack) {
-    ErrorLogService.instance.log('collection.reclaimCover', e, stack);
-  }
 }

--- a/hibiki/lib/src/media/video/cover_ui/cover_aspect_probe.dart
+++ b/hibiki/lib/src/media/video/cover_ui/cover_aspect_probe.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+/// 槽向自适应封面组件的**共享内核**（TODO-2426）。
+///
+/// `PortraitCoverImage`（竖槽，兼横槽变体）与 `LandscapeCoverImage`（宽幅 hero 槽）
+/// 是同一手法的两侧镜像：先拿图片固有宽高比，再决定「直接铺满」还是「模糊垫底 +
+/// contain 前景」。两者**渲染分支不同**（overlays 层序 / 前景 alignment+padding /
+/// 模糊强度），那是各自槽位的真实产品差异，不该硬合成一个组件；但**取宽高比这段
+/// 状态机逐字相同**（ImageStream 生命周期 + 首帧前按合槽渲染 + 解码失败兜底），
+/// 那才是真重复。这里抽的就是后者：零渲染行为变化，两侧 build 各自保留。
+///
+/// 用法：State 类 `with CoverAspectProbe<自己的 Widget>`，实现 [probedImageOf]，
+/// 在 build 里读 [coverAspect] / [coverFailed]。生命周期钩子由本 mixin 提供，
+/// 子类不要再自己写 `didChangeDependencies` / `didUpdateWidget` / `dispose`。
+mixin CoverAspectProbe<T extends StatefulWidget> on State<T> {
+  /// 从 widget 取出要探测的图片源。前景 [Image] 必须用同一个 provider——两者共享
+  /// 同一 [ImageStream]，宽高比探测因此是零额外解码成本。
+  ImageProvider probedImageOf(T widget);
+
+  ImageStream? _stream;
+  ImageStreamListener? _listener;
+  double? _aspect;
+  bool _failed = false;
+
+  /// 图片固有宽高比（宽 / 高）；null = 首帧解码前尺寸未知。
+  ///
+  /// 调用方一律把 null 当「合槽」处理（先按 `cover` 渲染，拿到尺寸再切），避免
+  /// 先占位后闪换。
+  double? get coverAspect => _aspect;
+
+  /// 加载 / 解码是否已失败（调用方据此走 errorBuilder）。
+  bool get coverFailed => _failed;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _resolveProbedImage();
+  }
+
+  @override
+  void didUpdateWidget(covariant T oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (probedImageOf(widget) != probedImageOf(oldWidget)) {
+      _aspect = null;
+      _failed = false;
+      _resolveProbedImage();
+    }
+  }
+
+  @override
+  void dispose() {
+    _detachListener();
+    super.dispose();
+  }
+
+  void _detachListener() {
+    final ImageStreamListener? listener = _listener;
+    if (listener != null) _stream?.removeListener(listener);
+    _stream = null;
+    _listener = null;
+  }
+
+  void _resolveProbedImage() {
+    final ImageStream newStream =
+        probedImageOf(widget).resolve(createLocalImageConfiguration(context));
+    if (newStream.key == _stream?.key) return;
+    _detachListener();
+    final ImageStreamListener listener =
+        ImageStreamListener(_onImage, onError: _onError);
+    _stream = newStream;
+    _listener = listener;
+    newStream.addListener(listener);
+  }
+
+  void _onImage(ImageInfo info, bool syncCall) {
+    final double aspect = info.image.width / info.image.height;
+    info.dispose();
+    if (!mounted || _aspect == aspect) return;
+    setState(() {
+      _aspect = aspect;
+      _failed = false;
+    });
+  }
+
+  void _onError(Object exception, StackTrace? stackTrace) {
+    if (!mounted || _failed) return;
+    setState(() => _failed = true);
+  }
+}
+
+/// 「这是一张横图」的判定阈值：宽高比 ≥ 此值算横图。
+///
+/// **两个槽向组件共用同一个真相源**：抽帧 16:9≈1.78 是横图；刮削海报 2:3≈0.71
+/// 与方图 1.0 都不是。此前竖槽组件与宽幅组件各写了一份 `1.2`，同一个概念两处独立
+/// 常量 —— 改一个不会带动另一个（TODO-2426）。
+const double kCoverLandscapeAspectThreshold = 1.2;
+
+/// 不合槽时压在模糊垫底之上的半透明压暗层颜色（两个槽向组件同值）。
+const Color kCoverBackdropDimColor = Color(0x59000000);

--- a/hibiki/lib/src/media/video/cover_ui/landscape_cover_image.dart
+++ b/hibiki/lib/src/media/video/cover_ui/landscape_cover_image.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
+import 'package:hibiki/src/media/video/cover_ui/cover_aspect_probe.dart';
 
 /// 宽幅（约 2.7:1）封面槽的填充组件 —— [PortraitCoverImage] 的镜像。
 ///
@@ -59,89 +60,32 @@ class LandscapeCoverImage extends StatefulWidget {
 
   /// 横图判定阈值：宽高比 ≥ 此值直接 cover。抽帧 16:9≈1.78 是横图；刮削海报
   /// 2:3≈0.71 与方图 1.0 都要走模糊垫底（方图 cover 进 2.7:1 槽也要裁掉 63%）。
-  static const double landscapeAspectThreshold = 1.2;
+  /// 与 `PortraitCoverImage` 的横槽判定共用同一真相源
+  /// [kCoverLandscapeAspectThreshold]（TODO-2426）。
+  static const double landscapeAspectThreshold = kCoverLandscapeAspectThreshold;
 
   /// 竖图垫底的模糊强度（sigma）。比竖版槽的 14 更强：这里垫底被放大 4.5 倍，
   /// 同样的 sigma 相对画面显得太锐。
   static const double backdropBlurSigma = 28;
 
-  /// 竖图垫底之上的压暗层（与 `PortraitCoverImage` 同值）。
-  static const Color backdropDimColor = Color(0x59000000);
+  /// 竖图垫底之上的压暗层（与 `PortraitCoverImage` 共用 [kCoverBackdropDimColor]）。
+  static const Color backdropDimColor = kCoverBackdropDimColor;
 
   @override
   State<LandscapeCoverImage> createState() => _LandscapeCoverImageState();
 }
 
-class _LandscapeCoverImageState extends State<LandscapeCoverImage> {
-  ImageStream? _stream;
-  ImageStreamListener? _listener;
-
-  /// 图片固有宽高比（宽 / 高）；null = 首帧前尺寸未知。
-  double? _aspect;
-  bool _failed = false;
-
+class _LandscapeCoverImageState extends State<LandscapeCoverImage>
+    with CoverAspectProbe<LandscapeCoverImage> {
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _resolveImage();
-  }
-
-  @override
-  void didUpdateWidget(LandscapeCoverImage oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.image != oldWidget.image) {
-      _aspect = null;
-      _failed = false;
-      _resolveImage();
-    }
-  }
-
-  @override
-  void dispose() {
-    _detachListener();
-    super.dispose();
-  }
-
-  void _detachListener() {
-    final ImageStreamListener? listener = _listener;
-    if (listener != null) _stream?.removeListener(listener);
-    _stream = null;
-    _listener = null;
-  }
-
-  void _resolveImage() {
-    final ImageStream newStream =
-        widget.image.resolve(createLocalImageConfiguration(context));
-    if (newStream.key == _stream?.key) return;
-    _detachListener();
-    final ImageStreamListener listener =
-        ImageStreamListener(_onImage, onError: _onError);
-    _stream = newStream;
-    _listener = listener;
-    newStream.addListener(listener);
-  }
-
-  void _onImage(ImageInfo info, bool syncCall) {
-    final double aspect = info.image.width / info.image.height;
-    info.dispose();
-    if (!mounted || _aspect == aspect) return;
-    setState(() {
-      _aspect = aspect;
-      _failed = false;
-    });
-  }
-
-  void _onError(Object exception, StackTrace? stackTrace) {
-    if (!mounted || _failed) return;
-    setState(() => _failed = true);
-  }
+  ImageProvider probedImageOf(LandscapeCoverImage widget) => widget.image;
 
   @override
   Widget build(BuildContext context) {
-    if (_failed) {
+    if (coverFailed) {
       return widget.errorBuilder?.call(context) ?? const SizedBox.shrink();
     }
-    final double? aspect = _aspect;
+    final double? aspect = coverAspect;
     // 首帧前 aspect 未知 → 按横图走（= 引入本组件前的行为），拿到尺寸再切。
     final bool portrait =
         aspect != null && aspect < LandscapeCoverImage.landscapeAspectThreshold;

--- a/hibiki/lib/src/media/video/cover_ui/portrait_cover_image.dart
+++ b/hibiki/lib/src/media/video/cover_ui/portrait_cover_image.dart
@@ -1,6 +1,7 @@
 import 'dart:ui' show ImageFilter;
 
 import 'package:flutter/material.dart';
+import 'package:hibiki/src/media/video/cover_ui/cover_aspect_probe.dart';
 
 /// 槽向自适应封面（Kazumi 式，用户拍板 2026-07-24 统一竖版；BUG-1299 推广为
 /// 横竖槽通用）。
@@ -45,8 +46,9 @@ class PortraitCoverImage extends StatefulWidget {
   static const double portraitAspectThreshold = 0.85;
 
   /// 横版槽的横图判定阈值：宽高比 ≥ 此值直接 cover（截帧 16:9≈1.78；方图/竖图
-  /// cover 进 16:9 槽会裁掉四成以上，走垫底）。
-  static const double landscapeAspectThreshold = 1.2;
+  /// cover 进 16:9 槽会裁掉四成以上，走垫底）。与 `LandscapeCoverImage` 共用同一
+  /// 真相源 [kCoverLandscapeAspectThreshold]（TODO-2426）。
+  static const double landscapeAspectThreshold = kCoverLandscapeAspectThreshold;
 
   /// 横图垫底的模糊强度（sigma，任务定 12~16 取中）。
   static const double backdropBlurSigma = 14;
@@ -55,76 +57,17 @@ class PortraitCoverImage extends StatefulWidget {
   State<PortraitCoverImage> createState() => _PortraitCoverImageState();
 }
 
-class _PortraitCoverImageState extends State<PortraitCoverImage> {
-  ImageStream? _stream;
-  ImageStreamListener? _listener;
-
-  /// 图片固有宽高比（宽 / 高）；null = 首帧前尺寸未知。
-  double? _aspect;
-  bool _failed = false;
-
+class _PortraitCoverImageState extends State<PortraitCoverImage>
+    with CoverAspectProbe<PortraitCoverImage> {
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    _resolveImage();
-  }
-
-  @override
-  void didUpdateWidget(PortraitCoverImage oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (widget.image != oldWidget.image) {
-      _aspect = null;
-      _failed = false;
-      _resolveImage();
-    }
-  }
-
-  @override
-  void dispose() {
-    _detachListener();
-    super.dispose();
-  }
-
-  void _detachListener() {
-    final ImageStreamListener? listener = _listener;
-    if (listener != null) _stream?.removeListener(listener);
-    _stream = null;
-    _listener = null;
-  }
-
-  void _resolveImage() {
-    final ImageStream newStream =
-        widget.image.resolve(createLocalImageConfiguration(context));
-    if (newStream.key == _stream?.key) return;
-    _detachListener();
-    final ImageStreamListener listener =
-        ImageStreamListener(_onImage, onError: _onError);
-    _stream = newStream;
-    _listener = listener;
-    newStream.addListener(listener);
-  }
-
-  void _onImage(ImageInfo info, bool syncCall) {
-    final double aspect = info.image.width / info.image.height;
-    info.dispose();
-    if (!mounted || _aspect == aspect) return;
-    setState(() {
-      _aspect = aspect;
-      _failed = false;
-    });
-  }
-
-  void _onError(Object exception, StackTrace? stackTrace) {
-    if (!mounted || _failed) return;
-    setState(() => _failed = true);
-  }
+  ImageProvider probedImageOf(PortraitCoverImage widget) => widget.image;
 
   @override
   Widget build(BuildContext context) {
-    if (_failed) {
+    if (coverFailed) {
       return widget.errorBuilder?.call(context) ?? const SizedBox.shrink();
     }
-    final double? aspect = _aspect;
+    final double? aspect = coverAspect;
     // 朝向不合槽 = 垫底 + contain；首帧前（aspect 未知）按合槽 cover 渲染。
     final bool mismatch = aspect != null &&
         (widget.landscapeSlot
@@ -159,7 +102,7 @@ class _PortraitCoverImageState extends State<PortraitCoverImage> {
             ),
           ),
           // 半透明压暗垫底，突出前景。
-          const ColoredBox(color: Color(0x59000000)),
+          const ColoredBox(color: kCoverBackdropDimColor),
           foreground,
         ],
       ),

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -13,6 +13,7 @@ import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
+import 'package:hibiki/src/media/collections/collection_asset_reclaim.dart';
 import 'package:hibiki/src/media/drag_drop/card_drop_registry.dart';
 import 'package:hibiki/src/media/drag_drop/drop_classification.dart';
 import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
@@ -775,7 +776,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final Set<int> toDissolve = Set<int>.of(_selectedCollectionIds);
     int dissolved = 0;
     for (final int id in toDissolve) {
-      final int removed = await db.deleteMediaCollection(id);
+      final int removed = await deleteMediaCollectionWithAssets(db, id);
       if (removed > 0) dissolved++;
     }
     // 再删选中散卡的媒体本体（现状语义）。
@@ -1188,7 +1189,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         // 原样搬家现有成员行：行值可能是对端未知种类，走 raw 版防静默丢成员。
         await db.addToCollectionRaw(targetId, m.mediaType, m.entryKey);
       }
-      await db.deleteMediaCollection(id);
+      await deleteMediaCollectionWithAssets(db, id);
     }
     for (final ShelfEntryRef ref in refs) {
       await db.addToCollection(targetId, ref.mediaType, ref.entryKey);

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/focus/hibiki_focus_target.dart';
+import 'package:hibiki/src/media/collections/collection_asset_reclaim.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_one_key_sort.dart'
     show CollectionSortMeta, compareCollectionMembers;
@@ -260,11 +261,14 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     );
     if (result == null || !mounted) return;
     // 先删各集视频本体（DB 行 + 封面/字幕副本），再解散容器。删视频会连带清各合集
-    // 引用行并自删空合集，故随后的 deleteMediaCollection 多为幂等收尾（写合集级墓碑）。
+    // 引用行并自删空合集，故随后的解散多为幂等收尾（写合集级墓碑）。解散必须走
+    // [deleteMediaCollectionWithAssets]：裸 deleteMediaCollection 只删 DB 行，合集
+    // 自有封面会永久留在磁盘上（BUG-1316）。
     if (result.checked && widget.onDeleteMembersMedia != null) {
       await widget.onDeleteMembersMedia!(List<VideoBookRow>.of(_members));
     }
-    await widget.database.deleteMediaCollection(widget.collection.id);
+    await deleteMediaCollectionWithAssets(
+        widget.database, widget.collection.id);
     if (!mounted) return;
     widget.onChanged();
     Navigator.of(context).maybePop();

--- a/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_grid_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:hibiki/src/sync/deletion_disclosure.dart';
+import 'package:hibiki/src/media/collections/collection_asset_reclaim.dart';
 import 'package:hibiki/src/media/collections/collection_one_key_sort.dart'
     show sortedCollectionRows;
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart'
@@ -155,12 +156,14 @@ class _MediaCollectionGridDetailPageState
     );
     if (result == null || !mounted) return;
     // 先删成员本体（书/有声书/视频 DB 行 + 磁盘副本），再解散容器。删书不动合集引用
-    // 行，故随后的 deleteMediaCollection 负责清掉残留引用 + 写合集级墓碑。
+    // 行，故随后的解散负责清掉残留引用 + 写合集级墓碑 + 回收合集自有封面
+    // （[deleteMediaCollectionWithAssets]，BUG-1316）。
     if (result.checked && widget.onDeleteMembersMedia != null) {
       await widget
           .onDeleteMembersMedia!(List<MediaCollectionItemRow>.of(_rows));
     }
-    await widget.database.deleteMediaCollection(widget.collection.id);
+    await deleteMediaCollectionWithAssets(
+        widget.database, widget.collection.id);
     if (!mounted) return;
     widget.onChanged();
     Navigator.of(context).maybePop();

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -40,6 +40,7 @@ import 'package:hibiki/src/pages/implementations/book_css_editor_page.dart';
 import 'package:hibiki/src/pages/implementations/illustrations_viewer_page.dart';
 import 'package:hibiki/src/media/collections/add_to_collection_dialog.dart';
 import 'package:hibiki/src/media/collections/batch_combine.dart';
+import 'package:hibiki/src/media/collections/collection_asset_reclaim.dart';
 import 'package:hibiki/src/media/collections/collection_context_dialog.dart';
 import 'package:hibiki/src/media/media_cover_service.dart';
 import 'package:hibiki/src/media/metadata/book_cover_scrape_dialog.dart';

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -533,7 +533,8 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     final Set<int> toDissolve = Set<int>.of(_selectedCollectionIds);
     int dissolved = 0;
     for (final int id in toDissolve) {
-      final int removed = await appModel.database.deleteMediaCollection(id);
+      final int removed =
+          await deleteMediaCollectionWithAssets(appModel.database, id);
       if (removed > 0) dissolved++;
     }
 
@@ -802,7 +803,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
         // 原样搬家现有成员行：行值可能是对端未知种类，走 raw 版防静默丢成员。
         await db.addToCollectionRaw(targetId, m.mediaType, m.entryKey);
       }
-      await db.deleteMediaCollection(id);
+      await deleteMediaCollectionWithAssets(db, id);
     }
     for (final ShelfEntryRef ref in refs) {
       await db.addToCollection(targetId, ref.mediaType, ref.entryKey);

--- a/hibiki/lib/src/sync/collection_sync_engine.dart
+++ b/hibiki/lib/src/sync/collection_sync_engine.dart
@@ -1,3 +1,4 @@
+import 'package:hibiki/src/media/collections/collection_asset_reclaim.dart';
 import 'package:hibiki/src/sync/collection_manifest.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -575,6 +576,9 @@ Future<CollectionManifest> loadLocalCollectionManifest(
 Future<int> applyCollectionLocalChanges(
     HibikiDatabase db, CollectionLocalChanges changes) async {
   if (changes.isEmpty) return 0;
+  // 被本轮解散的合集行快照：删行发生在事务里，而回收自有封面是文件 IO，必须挪到
+  // 事务提交之后做（BUG-1316）。路径只能在行还活着时取，故在删之前入列。
+  final List<MediaCollectionRow> dissolved = <MediaCollectionRow>[];
   await db.transaction(() async {
     for (final CollectionManifestEntry e in changes.entries) {
       final MediaCollectionRow? row =
@@ -583,6 +587,7 @@ Future<int> applyCollectionLocalChanges(
       if (e.deletedAt != null) {
         // 目标态 = 已删：删本地行（若有），墓碑表只留哨兵（镜像 deletedAt）。
         if (row != null) {
+          dissolved.add(row);
           await db.deleteMediaCollectionRaw(row.id);
         }
         await db.replaceCollectionTombstonesFor(
@@ -602,6 +607,7 @@ Future<int> applyCollectionLocalChanges(
       if (e.members.isEmpty) {
         // 活壳（全成员被移出）：本地沿用「移空自删」语义，不留 0 成员合集卡。
         if (row != null) {
+          dissolved.add(row);
           await db.deleteMediaCollectionRaw(row.id);
         }
       } else {
@@ -645,6 +651,9 @@ Future<int> applyCollectionLocalChanges(
       ]);
     }
   });
+  // 事务外回收：护栏（落在合集封面目录内 + 不被任何存活合集引用）在 helper 里，
+  // 本轮又新建了合集的话它们的封面自然在存活引用集里，不会被误删。
+  await reclaimDeletedCollectionAssets(db, dissolved);
   return changes.changedCollections;
 }
 

--- a/hibiki/test/media/collections/collection_asset_reclaim_test.dart
+++ b/hibiki/test/media/collections/collection_asset_reclaim_test.dart
@@ -1,0 +1,236 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/collections/collection_asset_reclaim.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+import '../../helpers/source_guard.dart';
+
+/// BUG-1316 守卫：删合集必须回收该合集**自有**的磁盘资产，且**只**回收它自己的。
+///
+/// 两个方向都要锁死：
+/// - 漏删（本 BUG 的症状）：合集封面落在 `video_covers/collections/<id>.jpg`，
+///   `VideoStorage.gcOrphanCovers` 故意扫不到那个子目录，DB 行一删路径就永久
+///   丢失 —— 删除时不回收 = 确定性空间泄漏。
+/// - 误删（修复本身的风险）：这是**删文件**的代码，判据必须精确到「这个文件确实
+///   只属于这个被删的合集」。别的合集的封面、目录外的用户图片一律不许碰。
+Future<HibikiDatabase> _openDb() async {
+  final HibikiDatabase db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  addTearDown(db.close);
+  return db;
+}
+
+Future<Directory> _tempCoversDir() async {
+  final Directory dir =
+      await Directory.systemTemp.createTemp('collection_covers_');
+  addTearDown(() async {
+    if (await dir.exists()) await dir.delete(recursive: true);
+  });
+  return dir;
+}
+
+/// 在合集封面目录内建一个占位封面文件，并把路径写进合集行。
+Future<File> _giveCover(
+  HibikiDatabase db,
+  Directory coversDir,
+  int collectionId,
+) async {
+  final File file = File(p.join(coversDir.path, '$collectionId.jpg'));
+  await file.writeAsBytes(<int>[0xFF, 0xD8, 0xFF]);
+  await db.updateMediaCollectionCoverPath(collectionId, file.path);
+  return file;
+}
+
+void main() {
+  group('deleteMediaCollectionWithAssets', () {
+    test('回收被删合集自己的封面文件，同时删掉 DB 行', () async {
+      final HibikiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final int id = await db.createMediaCollection('A');
+      final File cover = await _giveCover(db, covers, id);
+      expect(cover.existsSync(), isTrue);
+
+      final int removed = await deleteMediaCollectionWithAssets(
+        db,
+        id,
+        collectionCoversDirectory: covers,
+      );
+
+      expect(removed, 1, reason: '返回值必须透传被删的合集行数，调用方判据零变化');
+      expect(await db.getMediaCollectionById(id), isNull);
+      expect(cover.existsSync(), isFalse,
+          reason: '合集自有封面必须随合集一起回收，否则永久泄漏（BUG-1316）');
+    });
+
+    test('别的合集的封面文件一根汗毛都不许动', () async {
+      final HibikiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final int victim = await db.createMediaCollection('victim');
+      final int bystander = await db.createMediaCollection('bystander');
+      final File victimCover = await _giveCover(db, covers, victim);
+      final File bystanderCover = await _giveCover(db, covers, bystander);
+
+      await deleteMediaCollectionWithAssets(
+        db,
+        victim,
+        collectionCoversDirectory: covers,
+      );
+
+      expect(victimCover.existsSync(), isFalse);
+      expect(bystanderCover.existsSync(), isTrue,
+          reason: '同目录里其余合集的封面必须原样保留——这是删文件代码的第一红线');
+      expect((await db.getMediaCollectionById(bystander))!.coverPath,
+          bystanderCover.path);
+    });
+
+    test('两个合集共用同一张封面时，另一个还引用着就保留', () async {
+      final HibikiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final int victim = await db.createMediaCollection('victim');
+      final int sharer = await db.createMediaCollection('sharer');
+      final File shared = await _giveCover(db, covers, victim);
+      await db.updateMediaCollectionCoverPath(sharer, shared.path);
+
+      await deleteMediaCollectionWithAssets(
+        db,
+        victim,
+        collectionCoversDirectory: covers,
+      );
+
+      expect(shared.existsSync(), isTrue, reason: '仍被存活合集引用的文件是活数据，宁可漏删也不能误删');
+    });
+
+    test('落在合集封面目录之外的文件绝不删（用户外部图片）', () async {
+      final HibikiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final Directory outside =
+          await Directory.systemTemp.createTemp('user_pictures_');
+      addTearDown(() async {
+        if (await outside.exists()) await outside.delete(recursive: true);
+      });
+      final File external = File(p.join(outside.path, 'my_photo.jpg'));
+      await external.writeAsBytes(<int>[1, 2, 3]);
+      final int id = await db.createMediaCollection('A');
+      await db.updateMediaCollectionCoverPath(id, external.path);
+
+      await deleteMediaCollectionWithAssets(
+        db,
+        id,
+        collectionCoversDirectory: covers,
+      );
+
+      expect(external.existsSync(), isTrue, reason: '目录外的路径是用户自己的文件，删合集不该动它');
+    });
+
+    test('无封面的合集不碰文件系统，且删除照常完成', () async {
+      final HibikiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final int id = await db.createMediaCollection('A');
+
+      final int removed = await deleteMediaCollectionWithAssets(
+        db,
+        id,
+        collectionCoversDirectory: covers,
+      );
+
+      expect(removed, 1);
+      expect(await db.getMediaCollectionById(id), isNull);
+      expect(covers.listSync(), isEmpty);
+    });
+
+    test('合集不存在时不抛、返回 0', () async {
+      final HibikiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      expect(
+        await deleteMediaCollectionWithAssets(
+          db,
+          4242,
+          collectionCoversDirectory: covers,
+        ),
+        0,
+      );
+    });
+  });
+
+  group('reclaimDeletedCollectionAssets（事务外回收，同步删除传播用）', () {
+    test('批量回收多个已删合集的封面，存活合集的封面不受影响', () async {
+      final HibikiDatabase db = await _openDb();
+      final Directory covers = await _tempCoversDir();
+      final int a = await db.createMediaCollection('A');
+      final int b = await db.createMediaCollection('B');
+      final int keep = await db.createMediaCollection('keep');
+      final File coverA = await _giveCover(db, covers, a);
+      final File coverB = await _giveCover(db, covers, b);
+      final File coverKeep = await _giveCover(db, covers, keep);
+
+      final MediaCollectionRow rowA = (await db.getMediaCollectionById(a))!;
+      final MediaCollectionRow rowB = (await db.getMediaCollectionById(b))!;
+      await db.deleteMediaCollectionRaw(a);
+      await db.deleteMediaCollectionRaw(b);
+
+      final int reclaimed = await reclaimDeletedCollectionAssets(
+        db,
+        <MediaCollectionRow>[rowA, rowB],
+        collectionCoversDirectory: covers,
+      );
+
+      expect(reclaimed, 2);
+      expect(coverA.existsSync(), isFalse);
+      expect(coverB.existsSync(), isFalse);
+      expect(coverKeep.existsSync(), isTrue, reason: '同一轮同步里没被删的合集，封面必须完好');
+    });
+  });
+
+  group('源码守卫：删合集只有一个入口', () {
+    // 根因不是「某个页面忘了删文件」，而是回收挂在某个调用点上、不挂在删除动作上。
+    // 只要生产代码里还允许裸调 DAO 的删除方法，下一个新入口就会重演泄漏。
+    test('生产代码不得裸调 DAO 删合集方法 —— 一律走带回收的入口', () {
+      final Directory lib = Directory('lib');
+      expect(lib.existsSync(), isTrue, reason: '必须在 hibiki/ 包根下跑');
+      // 唯一豁免：回收入口自己，它就是那层包装。
+      const String allowed =
+          'lib/src/media/collections/collection_asset_reclaim.dart';
+      // 前置负向后顾定标识符边界：deleteMediaCollectionWithAssets(（新入口）与
+      // deleteMediaCollectionRaw(（同步引擎另行处理）都不该被这条判据命中。
+      final RegExp bare =
+          RegExp('(?<![A-Za-z0-9_\$])deleteMediaCollection' r'\s*\(');
+      final List<String> offenders = <String>[];
+      for (final FileSystemEntity entity in lib.listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        final String rel = entity.path.replaceAll(r'\', '/');
+        if (rel.endsWith(allowed)) continue;
+        for (final String line in entity.readAsStringSync().split('\n')) {
+          final String trimmed = line.trim();
+          if (trimmed.startsWith('//') || trimmed.startsWith('*')) continue;
+          if (bare.hasMatch(trimmed)) offenders.add('$rel: $trimmed');
+        }
+      }
+      expect(offenders, isEmpty,
+          reason: '这些调用点删了 DB 行却不回收合集自有封面 = 确定性磁盘泄漏'
+              '（BUG-1316）。改调 deleteMediaCollectionWithAssets；'
+              '事务内删行的调用方用 reclaimDeletedCollectionAssets 在事务外收尾。');
+    });
+
+    test('同步删除传播必须在事务外回收被解散合集的资产', () {
+      final String src =
+          File('lib/src/sync/collection_sync_engine.dart').readAsStringSync();
+      final String body = methodBody(
+        src,
+        'Future<int> applyCollectionLocalChanges(',
+      );
+      expect(containsCodeLine(body, 'dissolved.add(row)'), isTrue,
+          reason: '删行前必须入列行快照——行一删 coverPath 就推导不出来了');
+      expect(
+          containsCodeLine(
+              body, 'reclaimDeletedCollectionAssets(db, dissolved)'),
+          isTrue,
+          reason: '同步删除传播同样会解散合集，不回收就同样泄漏');
+      final int txEnd = body.indexOf('});');
+      final int reclaimAt = body.indexOf('reclaimDeletedCollectionAssets(');
+      expect(txEnd >= 0 && reclaimAt > txEnd, isTrue,
+          reason: '文件 IO 必须落在 db.transaction 之后，不能在事务里做');
+    });
+  });
+}

--- a/hibiki/test/widgets/cover_aspect_probe_test.dart
+++ b/hibiki/test/widgets/cover_aspect_probe_test.dart
@@ -1,0 +1,184 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/cover_ui/cover_aspect_probe.dart';
+import 'package:hibiki/src/media/video/cover_ui/landscape_cover_image.dart';
+import 'package:hibiki/src/media/video/cover_ui/portrait_cover_image.dart';
+
+import '../helpers/source_guard.dart';
+
+/// TODO-2426 守卫：两个槽向封面组件收敛到同一内核，且**只**收敛到该收敛的地方。
+///
+/// 结论（依据见 PR 说明）：`PortraitCoverImage` 与 `LandscapeCoverImage` **不合并**
+/// —— 它们的渲染分支是两种槽位的真实产品差异（overlays 层序 / 前景 alignment +
+/// padding / 模糊强度 / 合槽分支要不要包 Stack），硬合会把差异变成一堆构造参数和
+/// `overlays.isEmpty ? ... : ...` 特例。真正重复的是「取图片宽高比」那段逐字相同的
+/// [ImageStream] 状态机，那部分抽成 [CoverAspectProbe]。
+///
+/// 这组守卫锁两件事：
+/// 1. 状态机不许再各写一份（回归 = 两侧生命周期/首帧策略再次漂开）；
+/// 2. 「横图」阈值只有一个真相源（此前两处各写一个 `1.2`，改一个不带动另一个），
+///    但竖槽自己的 0.85 是**不同的判据**，收敛不得把它一并抹平。
+void main() {
+  const String probePath =
+      'lib/src/media/video/cover_ui/cover_aspect_probe.dart';
+  const List<String> componentPaths = <String>[
+    'lib/src/media/video/cover_ui/portrait_cover_image.dart',
+    'lib/src/media/video/cover_ui/landscape_cover_image.dart',
+  ];
+
+  group('共享内核', () {
+    test('两个组件的 State 都 with CoverAspectProbe', () {
+      for (final String path in componentPaths) {
+        final String src = File(path).readAsStringSync();
+        expect(containsCodeLine(src, 'with CoverAspectProbe<'), isTrue,
+            reason: '$path 必须复用共享的宽高比探测内核，不得自建');
+        expect(containsCodeLine(src, 'ImageProvider probedImageOf('), isTrue,
+            reason: '$path 必须实现 probedImageOf，前景与探测共用同一 provider');
+      }
+    });
+
+    test('组件文件里不得再各自实现 ImageStream 状态机', () {
+      // 这些符号是状态机自身的零件；它们只该出现在 cover_aspect_probe.dart 里。
+      const List<String> machineParts = <String>[
+        'ImageStreamListener(',
+        'ImageStream? ',
+        'addListener(',
+        'removeListener(',
+        'void didChangeDependencies()',
+        'void dispose()',
+      ];
+      for (final String path in componentPaths) {
+        final String src = File(path).readAsStringSync();
+        for (final String part in machineParts) {
+          expect(containsCodeLine(src, part), isFalse,
+              reason: '$path 又自建了状态机零件「$part」——两侧生命周期会再次漂开');
+        }
+      }
+      final String probe = File(probePath).readAsStringSync();
+      for (final String part in machineParts) {
+        expect(containsCodeLine(probe, part), isTrue,
+            reason: '状态机零件「$part」必须留在共享内核里，否则上面的禁止判据是空转');
+      }
+    });
+  });
+
+  group('阈值真相源', () {
+    test('横图阈值三处同值，且组件里不得再写裸字面量', () {
+      expect(PortraitCoverImage.landscapeAspectThreshold,
+          kCoverLandscapeAspectThreshold);
+      expect(LandscapeCoverImage.landscapeAspectThreshold,
+          kCoverLandscapeAspectThreshold);
+      for (final String path in componentPaths) {
+        final String src = File(path).readAsStringSync();
+        expect(containsCodeLine(src, 'landscapeAspectThreshold = 1.2'), isFalse,
+            reason: '$path 又把 1.2 抄了一份——改一处不会带动另一处');
+        expect(
+            containsCodeLine(src,
+                'landscapeAspectThreshold = kCoverLandscapeAspectThreshold'),
+            isTrue,
+            reason: '$path 的横图阈值必须指向唯一真相源');
+      }
+    });
+
+    test('压暗色同值，且竖槽自己的 0.85 判据必须保留（不是该收敛的东西）', () {
+      expect(LandscapeCoverImage.backdropDimColor, kCoverBackdropDimColor);
+      expect(PortraitCoverImage.portraitAspectThreshold, 0.85);
+      expect(
+          PortraitCoverImage.portraitAspectThreshold ==
+              kCoverLandscapeAspectThreshold,
+          isFalse,
+          reason: '竖槽默认判据（w/h > 0.85 才垫底）与横图判据是两个不同的东西，'
+              '收敛不得把它一并抹成 1.2');
+    });
+
+    test('两侧模糊强度**有意**不同，收敛不得把它抹平', () {
+      // 宽幅槽的垫底被放大约 4.5 倍，同样 sigma 相对画面显得太锐（组件注释有记）。
+      expect(LandscapeCoverImage.backdropBlurSigma, 28);
+      expect(PortraitCoverImage.backdropBlurSigma, 14);
+    });
+  });
+
+  group('内核行为：换 provider 的生命周期', () {
+    Future<Uint8List> pngBytes(int width, int height) async {
+      final ui.PictureRecorder recorder = ui.PictureRecorder();
+      ui.Canvas(recorder).drawRect(
+        ui.Rect.fromLTWH(0, 0, width.toDouble(), height.toDouble()),
+        ui.Paint()..color = const ui.Color(0xFF3355FF),
+      );
+      final ui.Image image =
+          await recorder.endRecording().toImage(width, height);
+      final ByteData? data =
+          await image.toByteData(format: ui.ImageByteFormat.png);
+      return data!.buffer.asUint8List();
+    }
+
+    const Key fgKey = Key('probe_foreground');
+
+    /// 装上 [provider]；[decode] 为真时等真实解码完成（尺寸回调已应用）。
+    Future<void> pumpWith(
+      WidgetTester tester,
+      MemoryImage provider, {
+      required bool decode,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Center(
+            child: SizedBox(
+              width: 100,
+              height: 150,
+              child: PortraitCoverImage(image: provider, imageKey: fgKey),
+            ),
+          ),
+        ),
+      );
+      if (decode) {
+        await tester.runAsync<void>(
+          () => precacheImage(provider, tester.element(find.byKey(fgKey))),
+        );
+      }
+      await tester.pump();
+    }
+
+    BoxFit? fitOf(WidgetTester tester) =>
+        tester.widget<Image>(find.byKey(fgKey)).fit;
+
+    testWidgets('换成另一朝向的图，解码完成后槽向判定跟着切换', (WidgetTester tester) async {
+      final Uint8List portraitBytes =
+          (await tester.runAsync<Uint8List>(() => pngBytes(20, 30)))!;
+      final Uint8List landscapeBytes =
+          (await tester.runAsync<Uint8List>(() => pngBytes(32, 18)))!;
+
+      await pumpWith(tester, MemoryImage(portraitBytes), decode: true);
+      expect(fitOf(tester), BoxFit.cover);
+      expect(find.byType(ImageFiltered), findsNothing);
+
+      await pumpWith(tester, MemoryImage(landscapeBytes), decode: true);
+      expect(fitOf(tester), BoxFit.contain,
+          reason: '换成横图后竖槽必须切到垫底 + contain（监听要重新挂到新 stream）');
+      expect(find.byType(ImageFiltered), findsOneWidget);
+    });
+
+    testWidgets('换 provider 的那一帧必须先丢掉旧宽高比，不能拿上一张图的朝向渲染',
+        (WidgetTester tester) async {
+      final Uint8List landscapeBytes =
+          (await tester.runAsync<Uint8List>(() => pngBytes(32, 18)))!;
+      final Uint8List otherBytes =
+          (await tester.runAsync<Uint8List>(() => pngBytes(21, 31)))!;
+
+      await pumpWith(tester, MemoryImage(landscapeBytes), decode: true);
+      expect(fitOf(tester), BoxFit.contain, reason: '前置条件：横图进竖槽走垫底');
+
+      // 新 provider 尚未解码：此刻宽高比必须是「未知」，按合槽 cover 渲染。
+      // 若 didUpdateWidget 忘了把旧宽高比清空，这一帧会拿上一张图的朝向渲染，
+      // 用户看到的是「换了图，垫底/裁切却还按旧图来」，直到新图解码完才跳变。
+      await pumpWith(tester, MemoryImage(otherBytes), decode: false);
+      expect(fitOf(tester), BoxFit.cover,
+          reason: '换图未解码完的过渡帧必须回到「尺寸未知 = 合槽 cover」');
+      expect(find.byType(ImageFiltered), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
同区域两件事（合集 / 封面渲染）放在同一个 worktree、同一个 PR，避免与其他线程在这块代码上撞车。

---

## ① 删合集不回收自有封面（BUG-1316，TODO-2450）

### 缺陷成立，但形态与线索不同

线索是「删合集不回收 `<id>_backdrop.jpg`」。**沿真实代码路径核过：backdrop 在 develop 上根本不存在** —— 无 backdrop 列、无落盘代码、无 `_backdrop` 文件名规则（`git grep -i backdrop` 命中的全是 `BackdropFilter` / `DWMWA_SYSTEMBACKDROP_TYPE` / media_kit `backdropColor`）。它只活在**尚未合入**的 PR#635 里。

今天真实在漏的是**合集封面本身**，而且比线索描述的严重：

- 落盘唯一路径 `video_covers/collections/<collectionId>.jpg` —— `video_storage.dart:55/61-62` + `video_cover_extractor.dart:131-134` + `scraper/cover_scraper_service.dart:424-435`；路径只记在 `media_collections.cover_path`（`tables.dart:846`）。
- `deleteMediaCollection`（`database.dart:3071-3094`）**零磁盘操作**。行一删，`<id>` 与 `cover_path` 同时消失 —— 磁盘上那张图再也无法被任何机制识别。
- GC 接不住：`gcOrphanCovers`（`video_storage.dart:208-230`）只扫 `video_covers/` 一层（`:219` 非递归、`:220` 跳过目录项），保留集是全库 `video_books.cover_path`（`video_book_repository.dart:606-614`）。合集封面既在子目录、又不在那个引用集里，**两重免疫**。而且这个盲区是**设计意图**（`video_storage.dart:47-55` 明写：同级扁平存放反而会被那轮 GC 当孤儿误删）。所以「删合集」是这些文件唯一的回收时机。

### 根因

**不是某个页面忘了删文件，而是回收挂在某个调用点上、没挂在「删合集」这个动作本身。** 全仓 `deleteCollectionCover` 只有一个消费者 —— `collection_context_dialog.dart:223`（旧 `_reclaimCollectionCover`）。其余全部裸调 DAO：

| 入口 | 位置 |
|---|---|
| 视频合集详情页 `_delete` | `media_collection_detail_page.dart:267` |
| 网格合集详情页 `_delete` | `media_collection_grid_detail_page.dart:163` |
| 视频库页批量解散 / 合集合并 | `home_video_page.dart:778` / `:1191` |
| 书架页批量解散 / 合集合并 | `reader_history/books.part.dart:536` / `:805` |
| 同步删除传播 / 移空自删 | `collection_sync_engine.dart:586` / `:605` |

只要还有第二个调用点，新入口就天然漏。

### 修法

新增 `hibiki/lib/src/media/collections/collection_asset_reclaim.dart`，把「删行 + 回收自有资产」收成单一入口：

- `deleteMediaCollectionWithAssets(db, id)` — **先取行快照**（路径只能从还活着的行推导）→ 删行 → 回收。返回值透传被删行数，六处调用点原有的 `removed > 0` 判据零变化。
- `reclaimDeletedCollectionAssets(db, rows)` — 给「删行在事务里」的同步引擎用：事务内把被解散的行快照入列 `dissolved`，**事务提交后**统一回收，文件 IO 不进事务。
- `collectionOwnedAssetPaths(row)` — 合集自有资产路径的唯一清单。**#635 落地时 backdrop 只需在这里加一行**，六条删除路径同时生效，不必重演六处补丁。

**显式不做**启动时全盘扫描找孤儿：那既绕过根因，又把「宁可漏删不误删」换成了「目录里没被引用的都删」。

### 误删风险如何排除

这是删文件的代码。三条护栏**同时**成立才删，任一不成立静默保留：

1. 路径只来自被删合集自己 DB 行的 `coverPath` —— 不枚举目录、不猜文件名；
2. 规范化后必须**严格落在**合集封面目录内（`_deleteOwnedAsset` 的 `p.isWithin`，杜绝 `..` / 符号链接越界）—— 用户外部图片、成员封面、原始视频一律不碰；
3. 删行后重查全库合集，**任何仍存活的合集引用同一规范化路径则保留**。

测试直接压这条红线：「别的合集的封面文件一根汗毛都不许动」「两个合集共用同一张封面时保留」「目录外用户图片绝不删」。

### cover 有没有同样的问题

**cover 就是这个问题本身**；backdrop 是它未来的放大版。反过来的问题（换封面产生垃圾）不存在 —— 文件名是 `<id>.jpg`，一合集一文件，覆盖式换封面原地重写。

### 变异实测（5 轮，双向）

每轮只改语义关键的一位；还原用反向文本替换 + `diff` 对齐备份（**未**对未提交文件用 `git checkout --`）。

| # | 变异 | 结果 |
|---|---|---|
| ① | 摘掉 `deleteMediaCollectionWithAssets` 里的回收调用 | 2 例红（漏删方向） |
| ② | `stillReferencedCoverPaths` 传空集 | 「共用同一张封面」红（证明引用护栏承重，不是自洽废话） |
| ③ | 逐候选删改成目录整扫（最典型的误删写法） | 3 例红，含「别的合集封面不许动」（误删方向） |
| ④ | 详情页调用点退回 `widget.database.deleteMediaCollection(...)` | 源码守卫红，报出精确文件行 |
| ⑤ | 同步回收挪进 `db.transaction` 内 | 时序守卫红 |

全部还原后 `FLUTTER TEST VERDICT: PASSED - 9 tests ran`。

---

## ② 收敛重叠的封面组件（TODO-2426）

### 逐项差异

| 维度 | `LandscapeCoverImage` | `PortraitCoverImage(landscapeSlot: true)` | `PortraitCoverImage`（默认） |
|---|---|---|---|
| 阈值 / 方向 | `w/h < 1.2` → 垫底 | `w/h < 1.2` → 垫底 | `w/h > 0.85` → 垫底 |
| 阈值真相源 | 自己的 `= 1.2` | 自己的 `= 1.2`（**两份独立常量**） | `0.85` |
| 合槽分支 | `ClipRect + Stack[Image(cover), ...overlays]` | 裸 `Image(cover)` | 裸 `Image(cover)` |
| 不合槽 blur sigma | 28 | 14 | 14 |
| 压暗层 | `backdropDimColor` 常量 | 内联字面量 `Color(0x59000000)` | 同 |
| `overlays` | 有；插在压暗层之上、清晰前景之下 | 无 | 无 |
| 前景 alignment | 可配（默认 `centerEnd`） | 固定 center | 固定 center |
| 前景 padding | 可配 | 无 | 无 |
| 取宽高比状态机 | ~65 行 | **与左列逐字相同** | 同 |
| 生产调用点 | 1 处 | 2 处 | 6 处 |

`landscapeSlot` 在 `PortraitCoverImage` 里**只影响一个三元表达式**（`:129-132` 选哪个阈值/方向），不改 sigma、alignment、padding、层数。

### 收敛结论：**不合并；抽公共部分 + 统一阈值真相源**

不合并的依据（不是「保守」，是合并会更糟）：

- overlays 的**层序**是 `LandscapeCoverImage` 的存在理由 —— 渐变要盖住模糊垫底（否则文字压在花花绿绿背景上不可读），但不能盖住清晰海报（hero 底部渐变浓到 `0xE8`，海报下半截会被压黑）。为承 overlays，它**合槽分支也必须包 `ClipRect+Stack`**；`PortraitCoverImage` 合槽时返回**裸 `Image`**。
- 合并要么给 `PortraitCoverImage` 加 `overlays`/`alignment`/`padding`/`sigma` 四个参数，再引入 `overlays.isEmpty ? 裸 Image : ClipRect(Stack)` 特例分支；要么统一成「总是包 Stack」—— 后者会改动现有 8 个调用点的渲染树。两条都违反「收敛是重构、不是行为变更」，而这些正是 BUG-1272/1298/1299 的修复成果。
- sigma 28 vs 14 有明确理由（宽幅槽垫底被放大约 4.5 倍）；0.85 与 1.2 是**两个不同判据**，不是同一常量的两份拷贝。

真正重复的只有取宽高比那段**逐字相同**的 `ImageStream` 状态机。抽成 `CoverAspectProbe` mixin（**不是**包一层 widget —— 那会改变 widget 树）。同时把「横图判定」收成唯一真相源 `kCoverLandscapeAspectThreshold`，压暗色收成 `kCoverBackdropDimColor`；两个类的 public static 名保留为别名，零 API 破坏。

**关于改名**：`PortraitCoverImage(landscapeSlot: true)` 名实不符是真的，但改名要动 8 个调用点 + 3 个测试文件的字面量断言，而这块正有 #635 在改 `media_collection_detail_page.dart`。判断是收益不抵冲突成本，**本 PR 不改名**；共享常量落地后，两个类的阈值同源已经消解了大部分歧义。

### 如何证明渲染结果未变

1. **diff 本身**：两个组件文件的非注释 diff 只有 mixin 抽取 + 两处常量改为引用共享真相源。`build()` 内部仅 `_failed`→`coverFailed`、`_aspect`→`coverAspect` 变量改名，以及 `Color(0x59000000)`→同值 `const`。widget 树结构一行未动。
2. **既有渲染断言全绿**：`portrait_cover_image_test`（四象限 `BoxFit` + 垫底有无）、`collection_hero_cover_orientation_test`（blur < overlay < foreground 层序 + 几何）、`continue_cover_portrait_guard_test`、`unified_collections_architecture_guard_test` —— 26 例 PASSED。
3. **新增 mixin 真行为测试**：换 provider 后槽向跟着切换；**换图未解码完的过渡帧必须回到「尺寸未知 = 合槽 cover」**（这条是 `didUpdateWidget` 里 `_aspect = null` 的唯一可观测行为）。

### 与 PR#642 的冲突处理

开工时基底 `b87d506da` 不含 #642。**#642 已在期间合入 develop**（`3340cb9ed` + bump `ba578656c`），本分支已 fast-forward 到 `ba578656c`，直接用它修好的 `identifierCall()` / `_episodeThumb` 锚点，**零冲突**。两个守卫测试在本分支上均绿。

### 变异实测（3 轮）

| # | 变异 | 结果 |
|---|---|---|
| ⑥ | 把 `1.2` 抄回 `portrait_cover_image.dart` | 阈值真相源守卫红 |
| ⑦ | 内核 `didUpdateWidget` 去掉 `_aspect = null` | 第一版**未转红** → 说明测试没覆盖到；改成断言过渡帧后转红（这一轮抓到自己的假绿） |
| ⑧ | 在 `landscape_cover_image.dart` 里重新声明 `ImageStream?` + `didChangeDependencies` | 收敛守卫红 |

---

## 验证

- `flutter analyze`（全量含 test）→ **No issues found!**
- `dart run tool/flutter_test_failures.dart --no-pub`：
  - 本 PR 用例 + 两组件既有渲染断言 + 两个守卫 → `PASSED - 42 tests ran`
  - 相邻面（`test/media/collections`、合集对话框 / 合并 / 续播、`collection_sync_engine` / manifest / orchestrator / backup merge、合集 DAO / 墓碑 / game 成员 / v61 迁移、`video_storage`）→ `PASSED - 116 tests ran`
- `dart run tool/bug.dart check` → 通过，1256 条号唯一索引同步。BUG 号取自跨 1493 分支扫描（本地最大 1308、跨分支最大 1315 → 1316），已避开 `fix/existing-red-group3-6` 占用的 1296 与 PR#635 的 1305/1306。
- 未做真机验证。
- `+build` 未 bump（按分工由集成方处理）。
