### PR TITLE
fix(reader): 跳回原文按当前 format 选阅读器（BUG-1316）+ TODO-2150 四条前置定性

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,13 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1255 条。点号进各自文件。
+> 共 1258 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1318](bugs/BUG-1318-tracking-mapping-stale-after-format-change.md) | 🚧 | 🚧 | 转化后 Bangumi 映射不复核：epub→manga 后进度静默永久停报 |
+| [BUG-1317](bugs/BUG-1317-override-title-key-source-asymmetry.md) | 🚧 | 🚧 | 漫画/PDF 书改名后首页与统计仍显示旧名：override 键读写不同源 |
+| [BUG-1316](bugs/BUG-1316-reader-route-ignores-live-format.md) | ✅ | ✅ | 跳回原文按写死的 EPUB 源打开：漫画/PDF 书用错阅读器 |
 | [BUG-1308](bugs/BUG-1308-popup-dict-style-node-per-section.md) | 🚧 | 🚧 | 查词弹窗每条目×每词典新建一个 style 节点，触发 10 次全文档样式重算 |
 | [BUG-1307](bugs/BUG-1307-dict-engine-max-results-overshoot.md) | ✅ | ✅ | 查词冷路径白解压 20 倍：引擎结果上限硬编码 200 而 Dart 侧只用 maximumTerms |
 | [BUG-1305](bugs/BUG-1305-delete-confirm-disclosure.md) | ✅ | ✅ | 删除确认文案与真实删除范围对不上（书架递归删解压目录+有声书；合集正文说反话） |

--- a/docs/bugs/BUG-1316-reader-route-ignores-live-format.md
+++ b/docs/bugs/BUG-1316-reader-route-ignores-live-format.md
@@ -1,0 +1,63 @@
+## BUG-1316 · 跳回原文按写死的 EPUB 源打开：漫画/PDF 书用错阅读器
+- **报告**：2026-08-01（用户：PR#502 阶段二前置审查项②）
+- **真实性**：✅ 真 bug，**且不是转化引入的**——原生漫画 / PDF 书**今天**就已经踩到。
+
+  阅读器路由的唯一真相源是 `EpubBooks.format`，它只在 `_bookToMediaItem`
+  （`hibiki/lib/src/media/sources/reader_hibiki_source.dart:506`）被翻译成
+  `MediaItem.mediaSourceIdentifier`（`reader_ttu` / `reader_pdf` / `reader_manga`）。
+  三种书共用 `mediaIdentifier = hoshi://book/<bookKey>`，路由**只认**
+  `mediaSourceIdentifier`。凡是绕过这处翻译、手上只有 `bookKey` 就自己造 `MediaItem`
+  的入口，都会把书当成 EPUB 打开。
+
+  根因两处（均为写死 EPUB 源、从不查 format）：
+
+  1. **收藏句 / 制卡句「跳回原文」** —
+     `hibiki/lib/src/pages/implementations/collections_page.dart:92-105`
+     （`buildCollectionReaderMediaItem` 写死
+     `mediaSourceIdentifier: ReaderHibikiSource.instance.uniqueKey`）
+     + `collections_page.dart:465-470`（`openMedia(mediaSource:
+     ReaderHibikiSource.instance)` 再写死一次）。该页从不读 `EpubBooks`，
+     `_load()` 只装 SRT 书标题。
+     → 在漫画里制的卡，从收藏/制卡列表点「跳回原文」**永远**打开 EPUB 阅读器；
+     而漫画行的 `epubPath` 是 `manga.json`、`chaptersJson` 是 `'[]'`，EPUB 阅读器
+     在解析路径直接失败。PDF 同理。
+  2. **首页「正在听书」迷你条「回到书」** —
+     `hibiki/lib/src/models/app_model.dart:4661-4667`：第 4665 行已经通过
+     `mediaItemForBookKey` 拿到 format 正确的 `MediaItem`，却把
+     `mediaSource: ReaderHibikiSource.instance` 写死传给 `openMedia`。
+
+  「书 ↔ 漫画转化」（PR#502 落库层 `updateEpubBookFormat`，
+  `packages/hibiki_core/lib/src/database/database.dart:4797`）不会新增这个缺陷，
+  只会把它从「导入即错」放大成「转化后突然错」——因为它就地改 `format` 而
+  `bookKey` / `mediaIdentifier` 全不变。
+
+- **[x] ① 已修复** — 把「format → 阅读器源键」收敛成唯一派生点
+  `ReaderHibikiSource.mediaSourceKeyFor(BookFormat)`
+  （`hibiki/lib/src/media/sources/reader_hibiki_source.dart`），书架列书与两个
+  「跳回原文」入口共用它：
+  - `_bookToMediaItem` 改调 `mediaSourceKeyFor(format)`（原地内联的三元删除）；
+  - `buildCollectionReaderMediaItem` 新增 **required** `BookFormat format` 参数
+    （必填、不给默认值——默认成 EPUB 就是把缺陷改写成静默回退），`_openBook`
+    改为 async、现查 `getEpubBook(bookKey)` 得到**当前** format，并用
+    `mediaItem.getMediaSource(appModel:)` 反查源，不再写死；
+  - `openBackgroundListeningBook` 改用 `item.getMediaSource(appModel: this)`。
+
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/media/sources/collections_open_book_test.dart`：三种 format
+    各自的源键、`mediaIdentifier` 与 format 无关、且与 `mediaSourceKeyFor`
+    逐一相等（钉住「两条入口不得各写各的」）；`mediaSourceKeyFor` 三态互异。
+  - `hibiki/test/media/manga_routing_guard_test.dart` /
+    `hibiki/test/media/reader_pdf_routing_guard_test.dart`：原「源码里必须有那串
+    三元」的语料锚点升级成**直接调公开派生函数**的行为断言（语料锚点会被等价
+    改写绕过），另加一条扫描守卫钉住 `_bookToMediaItem` 必须走
+    `mediaSourceKeyFor(format)`、不得再内联。
+
+- **备注**：同源但**未在本条修复**的两处，各自独立记档（BUG-1317 / BUG-1318）：
+  - override 书名 / 自定义封面的偏好键把源键烧进去了
+    （`hibiki/lib/src/media/media_source.dart:440,449`），而读取侧
+    `reader_hibiki_source.dart` 的 `_overrideTitleForIdentifier` 恒用 `reader_ttu`
+    合成键，与编辑弹窗按真实源写入的键不一致 → 漫画/PDF 书改名后首页/统计/通知
+    显示旧名。
+  - `media_items.unique_key = '<源键>/<mediaIdentifier>'`
+    （`hibiki/lib/src/media/media_item.dart:49`）把源键烧进历史身份；书今天不落该表
+    （三个书源 `implementsHistory: false`），阶段二若改为落表则转化必然分裂成两条。

--- a/docs/bugs/BUG-1317-override-title-key-source-asymmetry.md
+++ b/docs/bugs/BUG-1317-override-title-key-source-asymmetry.md
@@ -1,0 +1,44 @@
+## BUG-1317 · 漫画/PDF 书改名后首页与统计仍显示旧名：override 键读写不同源
+- **报告**：2026-08-01（用户：BUG-1316 调查旁支）
+- **真实性**：✅ 真 bug（今天可复现，与「书↔漫画转化」无关，但转化会新增一种触发路径）。
+
+  override 书名的偏好键把**阅读器源键**烧进去了：
+  `hibiki/lib/src/media/media_source.dart:439-441`
+  ```dart
+  String getOverrideTitleKey(MediaItem item) =>
+      'override_title://${item.mediaSourceIdentifier}/${item.uniqueKey}';
+  ```
+  （`MediaItem.uniqueKey` 本身又是 `'<源键>/<mediaIdentifier>'`，
+  `hibiki/lib/src/media/media_item.dart:49`，所以源键在键里出现两次。）
+  自定义封面同理：`media_source.dart:444-454` 的
+  `getOverrideThumbnailFilename` 用 `'<mediaIdentifier>/<源键>/override_thumbnail'`
+  的 hashCode 当文件名。
+
+  **写**：编辑弹窗按条目真实的源解析
+  （`hibiki/lib/src/pages/implementations/media_item_edit_dialog_page.dart:28`
+  的 `widget.item.getMediaSource(appModel: appModel)`）→ 漫画书写进
+  `override_title://reader_manga/...`。
+
+  **读**：`hibiki/lib/src/media/sources/reader_hibiki_source.dart` 的
+  `_overrideTitleForIdentifier` 合成一个**恒为 EPUB 源**的临时 `MediaItem`
+  （`mediaSourceIdentifier: uniqueKey`，即 `reader_ttu`）去取键 →
+  读的是 `override_title://reader_ttu/...`。
+
+  两侧键不同 → 消费 `overrideTitleForBookKey` 的界面全部读不到用户改的名字：
+  `hibiki/lib/src/media/display_title.dart:67`（首页「继续阅读」/ 活动流 / 阅读统计）
+  与 `hibiki/lib/src/media/audiobook/audiobook_session_launcher.dart:64,105`
+  （有声书通知栏标题）。书架页因为 item 来自 `_bookToMediaItem`、源键正确，
+  显示的是新名 —— 于是同一本漫画在书架叫新名、在首页叫旧名。
+
+  转化新增的触发路径：一本 EPUB 书改过名后转成漫画，键从 `reader_ttu` 变成
+  `reader_manga`，**书架侧也读不到了**，用户自定义书名与封面静默丢失。
+
+- **[ ] ① 未修复** — 正确语义是「override 跟着**书**走，不跟着阅读器走」，
+  故键里不该有源键。但 `override_title://...` 与缩略图 hashCode 文件名都是**存量
+  持久化键**，直接改会让所有既有 override 读不回来，需要迁移或读取期回退（读新
+  规范键 → 回退依次尝试三个旧源键）。属独立改动，不并进 BUG-1316。
+
+- **[ ] ② 未加自动化测试** —
+
+- **备注**：`ReaderHibikiSource` 一侧还有个更小的自洽问题：`_overrideTitleForIdentifier`
+  即使不改键规范，也应按 bookKey 现查 format 后合成正确的源键，而不是恒 `reader_ttu`。

--- a/docs/bugs/BUG-1318-tracking-mapping-stale-after-format-change.md
+++ b/docs/bugs/BUG-1318-tracking-mapping-stale-after-format-change.md
@@ -1,0 +1,50 @@
+## BUG-1318 · 转化后 Bangumi 映射不复核：epub→manga 后进度静默永久停报
+- **报告**：2026-08-01（用户：PR#502 阶段二前置审查项④ 的**剩余**部分）
+- **真实性**：✅ 真 bug（阶段二接线后必现；今天需要手工改 `format` 才能触发）。
+
+  先澄清：审查项④ 原本的症状「按漫画的话数报了书的章数」**已经修完**，
+  由 PR#556（`44116c29d`）+ PR#577 收敛到唯一裁决点
+  `resolveBookTrackingLocalProgress`
+  （`hibiki/lib/src/media/tracking/media_tracking_repository.dart:107-122`），
+  四个上报调用点全部经它按**当前** `BookFormat.isPagedImageBook` 门控，
+  两个生产者（即时阅读事件 / 持久化补发）+ 两个消费者（手动关联补发 / 水位对账）
+  结构上不会再漂开。本条记的是它**没覆盖**的另一半。
+
+  根因：映射一旦建立就**永不按当前 format 复核**。
+  `hibiki/lib/src/media/tracking/media_tracking_service.dart:812-819`
+  ```dart
+  final MediaTrackingMappingRow? existing = await _repository.findMapping(
+      mediaType: TrackingMediaType.book, mediaKey: bookKey);
+  if (existing != null) return existing;   // ← 命中即原样返回
+  ```
+  而 `kind`（novel/manga）、`progressMode`（chapter/volume）、`progressOffset`、
+  以及 `subjectId`（**按 kind 搜出来的 Bangumi 条目**）全都是建映射当时按 format
+  算死的（`media_tracking_service.dart:827-857`）。映射表的唯一键是
+  `{provider, mediaType, mediaKey}`（`packages/hibiki_core/lib/src/database/tables.dart:315-317`），
+  `kind` 不在身份里，所以转化**不会**分裂出第二条映射 —— 它只会让那唯一一条
+  永久保持旧口径。
+
+  后果分两种，都用户可见：
+  - **epub → manga**：旧映射是 `progressMode='chapter'`。转化后
+    `resolveBookTrackingLocalProgress` 走 `case chapter: return
+    format.isPagedImageBook ? null : chapterProgress` → **恒 null → 整条不发**。
+    Bangumi 从此再不更新，界面上却仍显示「已连接」，与「从没跑过」同形
+    （与 BUG-1220 同一类可见性缺陷）。
+  - **manga → epub**：旧映射是 `kind='manga'`、`progressMode='volume'`、
+    `progressOffset=<卷号>`、`subjectId=<漫画条目>`。转化后本地已是有章节的文字书，
+    却继续按漫画卷号往漫画条目上报；且 `media_tracking_service.dart:662-666` 的
+    章节伴随映射要求 `mapping.kind == novel`，故转成书之后也永远不会建章节映射。
+
+- **[ ] ① 未修复** — **需要产品口径拍板**，因为这条会写到**外部服务**：
+  转化后应当 (a) 就地重建映射（重新按新 kind 搜条目，可能换成另一个 Bangumi 条目，
+  旧条目上已上报的进度留在远端不动）、(b) 解绑并提示用户手动重连、还是
+  (c) 保留旧映射但在 UI 明示「口径与当前格式不符，已暂停上报」。
+  在拍板前不做代码改动，避免自作主张改远端收藏数据。
+
+- **[ ] ② 未加自动化测试** —
+
+- **备注**：现有 tracking 守卫
+  （`hibiki/test/media/tracking/media_tracking_repository_test.dart`、
+  `hibiki/test/media/tracking/media_tracking_service_test.dart`）覆盖的是
+  「上报值按当前 format 门控」，全部继续绿；它们**测不到**本条，因为本条的问题
+  在映射元数据，不在上报值。

--- a/hibiki/lib/src/media/sources/reader_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/reader_hibiki_source.dart
@@ -178,6 +178,27 @@ class ReaderHibikiSource extends ReaderMediaSource {
   static String mediaIdentifierFor(String bookKey) =>
       '$_bookIdentifierPrefix$bookKey';
 
+  /// 「这本书该用哪个阅读器打开」的**唯一派生点**：`EpubBooks.format` →
+  /// `MediaItem.mediaSourceIdentifier`。
+  ///
+  /// 三种书共用 `mediaIdentifier`（`hoshi://book/<bookKey>`，与 format 无关），
+  /// 路由只认 `mediaSourceIdentifier`，而它**只能**由**当前**的 `format` 现算。
+  /// 书架列书（[_bookToMediaItem]）与所有「手上只有 bookKey、要跳回原文」的入口
+  /// （收藏句 / 制卡句）必须共用本函数：任何自己写死 `ReaderHibikiSource.instance`
+  /// 的入口，在漫画 / PDF 书上**今天就已经**用错阅读器打开（漫画行的 `epubPath`
+  /// 是 `manga.json`、`chaptersJson` 是 `'[]'`，落到 EPUB 阅读器直接在解析路径
+  /// 出错），书 ↔ 漫画转化只是把它从「导入即错」放大成「转化后突然错」。
+  static String mediaSourceKeyFor(BookFormat format) {
+    switch (format) {
+      case BookFormat.pdf:
+        return ReaderPdfSource.kUniqueKey;
+      case BookFormat.manga:
+        return MangaHibikiSource.kUniqueKey;
+      case BookFormat.epub:
+        return instance.uniqueKey;
+    }
+  }
+
   // HBK-AUDIT-127: percent-encode the href when building the URL so it is
   // symmetric with the consumer side, which decodes the whole post-'/epub/'
   // path with Uri.decodeComponent (reader_hibiki_page.dart, epub_book.dart).
@@ -504,10 +525,8 @@ class ReaderHibikiSource extends ReaderMediaSource {
     // 共用 `hoshi://book/<bookKey>`（bookKey 是主键、与 format 无关），路由只认
     // mediaSourceIdentifier。
     final BookFormat format = BookFormat.parseOrEpub(book.format);
-    final bool isPdf = format == BookFormat.pdf;
-    final bool isManga = format == BookFormat.manga;
     // 页码型书（PDF/漫画）：进度单位是页而非章内字数。
-    final bool pageBased = isPdf || isManga;
+    final bool pageBased = format.isPagedImageBook;
 
     // TODO-1346：进度纳入当前章内 charOffset（与章字数同单位），并对老书无字数时
     // 回退章级粗粒度，避免书架恒显 0%。见 [computeBookProgress]。
@@ -545,11 +564,7 @@ class ReaderHibikiSource extends ReaderMediaSource {
       author: book.author,
       imageUrl: imageUrl,
       mediaTypeIdentifier: mediaType.uniqueKey,
-      mediaSourceIdentifier: isPdf
-          ? ReaderPdfSource.kUniqueKey
-          : isManga
-              ? MangaHibikiSource.kUniqueKey
-              : uniqueKey,
+      mediaSourceIdentifier: mediaSourceKeyFor(format),
       position: position,
       duration: duration,
       canDelete: false,

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -4661,10 +4661,16 @@ class AppModel with ChangeNotifier {
   Future<void> openBackgroundListeningBook(WidgetRef ref) async {
     final SessionBookInfo? info = audiobookSession.book;
     if (info == null) return;
-    final ReaderHibikiSource source = ReaderHibikiSource.instance;
-    final MediaItem? item = await source.mediaItemForBookKey(info.bookKey);
+    final MediaItem? item =
+        await ReaderHibikiSource.instance.mediaItemForBookKey(info.bookKey);
     if (item == null) return;
-    await openMedia(ref: ref, mediaSource: source, item: item);
+    // 源必须跟着 item 自己的 mediaSourceIdentifier 走（它已按当前 format 现算）：
+    // 写死 ReaderHibikiSource 会让漫画 / PDF 书用 EPUB 阅读器打开。
+    await openMedia(
+      ref: ref,
+      mediaSource: item.getMediaSource(appModel: this),
+      item: item,
+    );
   }
 
   // ── search & dictionary display (delegated to PreferencesRepository) ─

--- a/hibiki/lib/src/pages/implementations/collections_page.dart
+++ b/hibiki/lib/src/pages/implementations/collections_page.dart
@@ -89,15 +89,22 @@ enum _CollectionType { sentence, mined, word }
   }
 }
 
+/// 用「跳回原文」所需的最小信息重建一条 [MediaItem]。
+///
+/// [format] 必须是**当前** `EpubBooks.format`（调用方现查），不能省略也不能默认成
+/// EPUB：`mediaSourceIdentifier` 决定打开哪个阅读器，写死成 `reader_ttu` 会让漫画 /
+/// PDF 书落进 EPUB 阅读器并在解析路径出错。派生走 [ReaderHibikiSource.mediaSourceKeyFor]
+/// 这一唯一真相源，与书架列书同一条路径。
 MediaItem buildCollectionReaderMediaItem({
   required String bookKey,
   required String title,
+  required BookFormat format,
 }) {
   return MediaItem(
     mediaIdentifier: ReaderHibikiSource.mediaIdentifierFor(bookKey),
     title: title,
     mediaTypeIdentifier: ReaderHibikiSource.instance.mediaType.uniqueKey,
-    mediaSourceIdentifier: ReaderHibikiSource.instance.uniqueKey,
+    mediaSourceIdentifier: ReaderHibikiSource.mediaSourceKeyFor(format),
     position: 0,
     duration: 1,
     canDelete: false,
@@ -422,9 +429,15 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
         rawSnapshot: item.bookTitle,
       );
 
-  void _openBook(_CollectionItem item) {
+  Future<void> _openBook(_CollectionItem item) async {
     final String? bookKey = item.bookKey;
     if (bookKey == null || bookKey.isEmpty) return;
+
+    // 阅读器路由的真相源是**当前** `EpubBooks.format`，这里只有 bookKey，必须现查。
+    // 书行查不到（书已删、收藏还在）时按 EPUB 回退，与路由层 parseOrEpub 的既有
+    // 回退一致——反正随后阅读器自己会报「书不存在」，不在这里造第二种失败形态。
+    final EpubBookRow? book = await appModel.database.getEpubBook(bookKey);
+    final BookFormat format = BookFormat.parseOrEpub(book?.format);
 
     // 标题仅作展示（身份走 mediaIdentifier=bookKey），过门面显示改名后书名。
     final String title = _displayBookTitleFor(
@@ -437,6 +450,7 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
     final MediaItem mediaItem = buildCollectionReaderMediaItem(
       bookKey: bookKey,
       title: title,
+      format: format,
     );
 
     // BUG-459: 三类行的 normCharOffset 计量不同——
@@ -462,9 +476,11 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
           )
         : null;
 
-    appModel.openMedia(
+    if (!mounted) return;
+    await appModel.openMedia(
       ref: ref,
-      mediaSource: ReaderHibikiSource.instance,
+      // 由 item 自己的 mediaSourceIdentifier 反查源，不写死 EPUB 阅读器。
+      mediaSource: mediaItem.getMediaSource(appModel: appModel),
       item: mediaItem,
       initialBookmarkJump: bookmark,
     );

--- a/hibiki/test/media/manga_routing_guard_test.dart
+++ b/hibiki/test/media/manga_routing_guard_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/media.dart';
+import 'package:hibiki_core/hibiki_core.dart';
 
 /// 漫画 OCR P1 的接线守卫（源码扫描 + 键不变量），与 PDF 的
 /// `reader_pdf_routing_guard_test.dart` 同纪律。
@@ -27,16 +28,24 @@ void main() {
   });
 
   test('书架列书按 format 路由：format==manga 的行带 MangaHibikiSource 源标识', () {
-    final String src = read('lib/src/media/sources/reader_hibiki_source.dart');
-    // 判据统一走 BookFormat 枚举后，锚点跟着走（裸字符串比较已被
-    // book_format_discipline_guard 禁掉——它正是「只挡 manga、漏掉 pdf」的温床）。
-    expect(src.contains('format == BookFormat.manga'), isTrue,
-        reason: '_bookToMediaItem 应按 BookFormat.manga 分流');
-    expect(src.contains('MangaHibikiSource.kUniqueKey'), isTrue,
+    // BUG-1316：路由派生已收敛成公开的具名函数，故判据从「源码里有那串三元」升级
+    // 成**直接调它**——行为断言比语料锚点强，也不会被等价改写绕过。
+    expect(ReaderHibikiSource.mediaSourceKeyFor(BookFormat.manga),
+        MangaHibikiSource.kUniqueKey,
         reason: '漫画行 mediaSourceIdentifier 应取 MangaHibikiSource.kUniqueKey');
     // PDF 分流不能被漫画分流破坏（向后兼容守卫）。
-    expect(src.contains('format == BookFormat.pdf'), isTrue);
-    expect(src.contains('ReaderPdfSource.kUniqueKey'), isTrue);
+    expect(ReaderHibikiSource.mediaSourceKeyFor(BookFormat.pdf),
+        ReaderPdfSource.kUniqueKey);
+    expect(ReaderHibikiSource.mediaSourceKeyFor(BookFormat.epub),
+        ReaderHibikiSource.instance.uniqueKey);
+  });
+
+  test('_bookToMediaItem 走共享派生点，不得再内联自己的一套三元', () {
+    final String src = read('lib/src/media/sources/reader_hibiki_source.dart');
+    expect(src.contains('mediaSourceIdentifier: mediaSourceKeyFor(format)'),
+        isTrue,
+        reason: '书架列书必须与「跳回原文」入口共用 mediaSourceKeyFor：'
+            '两条各写各的，漫画/PDF 就会在其中一条上永远用错阅读器');
   });
 
   test('AppModel 注册 MangaHibikiSource.instance（否则打开漫画崩于 map 空断言）', () {

--- a/hibiki/test/media/reader_pdf_routing_guard_test.dart
+++ b/hibiki/test/media/reader_pdf_routing_guard_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/media.dart';
+import 'package:hibiki_core/hibiki_core.dart';
 
 /// PDF 阅读器 Phase 1 的接线守卫（源码扫描 + 键不变量）。
 ///
@@ -26,14 +27,15 @@ void main() {
   });
 
   test('书架列书按 format 路由：format==pdf 的行带 ReaderPdfSource 源标识', () {
-    final String src = read('lib/src/media/sources/reader_hibiki_source.dart');
     // _bookToMediaItem 必须按 format 分流 mediaSourceIdentifier；缺这条 → PDF 行用
     // 'reader_ttu' 打开 → EPUB 阅读器解析 PDF → 崩。
-    // 判据统一走 BookFormat 枚举后，锚点跟着走（见 book_format_discipline_guard）。
-    expect(src.contains('format == BookFormat.pdf'), isTrue,
-        reason: '_bookToMediaItem 应按 BookFormat.pdf 分流');
-    expect(src.contains('ReaderPdfSource.kUniqueKey'), isTrue,
+    // BUG-1316：派生已收敛成公开具名函数，判据从源码语料升级成直接调它。
+    expect(ReaderHibikiSource.mediaSourceKeyFor(BookFormat.pdf),
+        ReaderPdfSource.kUniqueKey,
         reason: 'PDF 行 mediaSourceIdentifier 应取 ReaderPdfSource.kUniqueKey');
+    expect(ReaderHibikiSource.mediaSourceKeyFor(BookFormat.epub),
+        isNot(ReaderPdfSource.kUniqueKey),
+        reason: 'EPUB 不得塌缩到 PDF 源');
   });
 
   test('AppModel 注册 ReaderPdfSource.instance（否则打开 PDF 崩于 map 空断言）', () {

--- a/hibiki/test/media/sources/collections_open_book_test.dart
+++ b/hibiki/test/media/sources/collections_open_book_test.dart
@@ -1,24 +1,80 @@
+/// 收藏句 / 制卡句「跳回原文」的**阅读器路由**契约（BUG-1316）。
+///
+/// 此前本文件断言 `mediaSourceIdentifier` 恒等于 `reader_ttu`——那正是缺陷本身：
+/// 收藏页手工伪造 `MediaItem` 时写死 EPUB 源，漫画 / PDF 书从收藏页跳回原文永远
+/// 打开 EPUB 阅读器（漫画行的 `epubPath` 是 `manga.json`、`chaptersJson` 是 `'[]'`，
+/// 落进 EPUB 阅读器直接在解析路径出错）。契约已改为「按当前 `EpubBooks.format`
+/// 派生」，故那条旧断言必红——是契约变更，不是回归。
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/media.dart';
 import 'package:hibiki/src/pages/implementations/collections_page.dart';
+import 'package:hibiki_core/hibiki_core.dart';
 
 void main() {
   group('buildCollectionReaderMediaItem', () {
-    test('generates hoshi URL matching bookshelf format', () {
-      final MediaItem opened = buildCollectionReaderMediaItem(
-        bookKey: 'MyBook',
-        title: 'MyBook',
-      );
+    test('mediaIdentifier 与书架同构，且与 format 无关', () {
+      for (final BookFormat format in BookFormat.values) {
+        final MediaItem opened = buildCollectionReaderMediaItem(
+          bookKey: 'MyBook',
+          title: 'MyBook',
+          format: format,
+        );
+        expect(opened.mediaIdentifier, 'hoshi://book/MyBook',
+            reason: '身份是 bookKey，转化前后必须一致（$format）');
+        expect(opened.title, 'MyBook');
+      }
+    });
 
+    test('阅读器源按当前 format 三态分流（漫画/PDF 不得落进 EPUB 阅读器）', () {
       expect(
-        opened.mediaIdentifier,
-        'hoshi://book/MyBook',
-      );
-      expect(opened.title, 'MyBook');
-      expect(
-        opened.mediaSourceIdentifier,
+        buildCollectionReaderMediaItem(
+          bookKey: 'k',
+          title: 't',
+          format: BookFormat.epub,
+        ).mediaSourceIdentifier,
         ReaderHibikiSource.instance.uniqueKey,
       );
+      expect(
+        buildCollectionReaderMediaItem(
+          bookKey: 'k',
+          title: 't',
+          format: BookFormat.manga,
+        ).mediaSourceIdentifier,
+        MangaHibikiSource.kUniqueKey,
+      );
+      expect(
+        buildCollectionReaderMediaItem(
+          bookKey: 'k',
+          title: 't',
+          format: BookFormat.pdf,
+        ).mediaSourceIdentifier,
+        ReaderPdfSource.kUniqueKey,
+      );
+    });
+
+    test('与书架列书共用同一派生点 ReaderHibikiSource.mediaSourceKeyFor', () {
+      for (final BookFormat format in BookFormat.values) {
+        expect(
+          buildCollectionReaderMediaItem(
+            bookKey: 'k',
+            title: 't',
+            format: format,
+          ).mediaSourceIdentifier,
+          ReaderHibikiSource.mediaSourceKeyFor(format),
+          reason: '两条入口一旦各写各的，漫画/PDF 就会在其中一条上永远错（$format）',
+        );
+      }
+    });
+  });
+
+  group('ReaderHibikiSource.mediaSourceKeyFor', () {
+    test('三种 format 各自映射到不同的源键（不得出现两态合并）', () {
+      final Set<String> keys =
+          BookFormat.values.map(ReaderHibikiSource.mediaSourceKeyFor).toSet();
+      expect(keys.length, BookFormat.values.length,
+          reason: '任意两种 format 共用一个源键 = 其中一种被用错阅读器打开');
     });
   });
 }


### PR DESCRIPTION
TODO-2150「书 ↔ 漫画转化 阶段二」的四条前置缺陷。**只改了其中一条**（②），另外三条各自定性并记档，理由见下。

## 逐条结论

| # | 判定 | 依据 |
|---|---|---|
| ① `format` 无 CHECK / 裸 String | **设计如此（CHECK 不加）** + 守卫有洞 | `packages/hibiki_core/lib/src/database/book_format.dart:14-21` |
| ② 转化后跳回原文用错阅读器 | **真缺陷，本 PR 已修** | BUG-1316 |
| ③ 历史条目一分为二 | **今天不可复现**，需产品口径 | 见下 |
| ④ 追踪上报错误章数 | **原症状已修完**（PR#556/#577）；剩余映射不复核 | BUG-1318 |

## ① CHECK 约束：不加，也不需要 schema 迁移

`BookFormat` 枚举已随 PR#556 落地，合法值 `epub`/`pdf`/`manga`（`book_format.dart:25-33`），落库入口 `updateEpubBookFormat` 已收枚举，`format` 在编译期不可写进未知值。

**不加 CHECK 是刻意取舍，不是遗漏**：SQLite 不支持 `ALTER TABLE ADD CONSTRAINT`，加 CHECK 只能重建 `epub_books` 这张核心书表，任何越界行都会让老库升级中断、app 直接打不开；而落库点只有三个（两个常量 + 列默认值），实测生产库 19 行全 `'epub'`、零越界。这条决策连同判据被 `test/tools/book_format_discipline_guard_test.dart:155-160` 钉住。**所以本 PR 不动 schema，不占版本号。**

残留（**未在本 PR 修**，因为落在其它线程正在改的 `test/` 守卫判据里）：守卫的两条正则各有一个洞——`format:\s*(const\s+)?Value\s*\(\s*['"]` 匹配不到 `Value<String>('pdf')`，`\.format\s*[!=]=\s*['"]` 匹配不到 `.format.equals(...)`。已经导致 PR#556 之后新写的 `test/media/tracking/media_tracking_service_test.dart:942,1040,1085` 从洞里漏回去。生产侧两处裸串（`database.dart:2722` `.format.equals('manga')`、`stat_source_totals.dart:61` `== 'manga'`）**语义正确**（只有 manga 有独立桶/kind，PDF 归书是对的），是纪律问题不是缺陷。

## ② 真缺陷，已修（BUG-1316）

**而且不是转化引入的——原生漫画/PDF 书今天就已经错。**

路由真相源是 `EpubBooks.format`，但它只在 `_bookToMediaItem`（`reader_hibiki_source.dart:506`）被翻译成 `mediaSourceIdentifier`。两个「手上只有 bookKey 就自己造 `MediaItem`」的入口绕过它、写死 EPUB 源：

1. `collections_page.dart:92-105` + `:465-470` —— 收藏句/制卡句「跳回原文」。漫画里制的卡跳回去永远开 EPUB 阅读器，而漫画行 `epubPath` 是 `manga.json`、`chaptersJson` 是 `'[]'`，直接在解析路径失败。
2. `app_model.dart:4661-4667` —— 「正在听书」迷你条「回到书」，已拿到正确 item 却把 source 写死。

**修法**：消除第二处派生。新增唯一派生点 `ReaderHibikiSource.mediaSourceKeyFor(BookFormat)`，书架列书与两个跳回入口共用；`buildCollectionReaderMediaItem` 的 `format` 设为 **required 且无默认值**（默认成 EPUB 只是把缺陷改写成静默回退）；`_openBook` 现查 `getEpubBook(bookKey)` 拿当前 format，再由 `item.getMediaSource()` 反查源。

## ③ 历史一分为二：今天不可复现，语义待拍板

`media_items.unique_key = '<源键>/<mediaIdentifier>'`（`media_item.dart:49`）确实把源键烧进了历史身份，转化改 format → 源键变 → `addMediaItem` 的按 uniqueKey 去重删不掉旧行 → 分裂。**但书今天根本不落这张表**：唯一生产写入点 `app_model.dart:4175` 被 `mediaSource.implementsHistory` 门控，而三个书源全是 `implementsHistory: false`。书的书架/最近/继续全部由 `EpubBooks` + `ReaderPositions` 按 `bookKey` 现算，format-agnostic；`ShelfEntries`/合集/标签/统计/活动流也都按 `bookKey`（`MediaKind` 里根本没有 manga，漫画就是 epub 行）。

所以这是**阶段二的结构性风险**，不是当前缺陷。正确语义应为「同一本书延续一条」，故建议在阶段二编排层做级联迁移，而不是现在往落库层加一段今天永远走不到的死代码。已记进 BUG-1316 备注。**需要确认这条语义。**

## ④ 原症状已修完，剩余是映射不复核（BUG-1318）

「按漫画的话数报了书的章数」已由 PR#556 `44116c29d` + PR#577 收敛到唯一裁决点 `resolveBookTrackingLocalProgress`（`media_tracking_repository.dart:107-122`），四个上报调用点（即时事件/持久化补发/手动关联补发/水位对账）全部按**当前** `isPagedImageBook` 门控，结构上不会再漂开。

**剩余**：`_ensureAutoBookMapping`（`media_tracking_service.dart:812-819`）命中已有映射即原样返回，从不按当前 format 复核 `kind`/`progressMode`/`progressOffset`/`subjectId`。epub→manga 后 chapter 模式映射被门控恒返 null → **Bangumi 静默永久停报**，UI 仍显示「已连接」。这条会写外部服务，且「转化后该重建映射 / 解绑 / 还是暂停并明示」是产品口径，**未改代码，等拍板**。

## 验证

- `flutter analyze`（含 test）：**No issues found!**
- 定向 `dart run tool/flutter_test_failures.dart --no-pub`：
  - 路由 + format 纪律 + tracking：**PASSED - 104 tests ran**
  - collections 与 sources 邻域：**PASSED - 109 tests ran**
- **变异实测三处，两方向**：
  - A `collections_page` 源派生退回写死 `reader_ttu` → 2 条断言转红（`Expected 'reader_manga' Actual 'reader_ttu'`）；反向替换还原 → 绿。
  - B `mediaSourceKeyFor(manga)` 塌缩成 EPUB 源 → 3 条转红（含「三态不得合并」`Expected <3> Actual <2>`）；还原 → 绿。
  - C `_bookToMediaItem` 重新内联**行为等价**的三元 → 行为断言全绿、**只有扫描守卫转红**（证明该守卫不是自洽废话，能抓等价改写）；还原 → 绿。
  - 还原一律用反向文本替换，未对未提交文件 `git checkout --`。

## 不在本 PR 的记档

- **BUG-1317** override 书名/封面的持久化键把源键烧进去（`media_source.dart:439-441,444-454`），写侧按真实源、读侧 `_overrideTitleForIdentifier` 恒 `reader_ttu` → 漫画/PDF 书改名后书架显示新名、首页/统计/通知显示旧名。修它要动存量持久化键，需迁移或读取期回退。
- **BUG-1318** 见上。
