### PR TITLE
fix(sync): 401/403 分流 + 鉴权失败带类型进报告（BUG-1323 / BUG-1324）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1260 条。点号进各自文件。
+> 共 1262 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1324](bugs/BUG-1324-sync-report-auth-failure-untyped.md) | ✅ | ✅ | 同步报告把鉴权失败压成一行字符串：UI 只剩「N 项失败」 |
+| [BUG-1323](bugs/BUG-1323-sync-401-403-flattened.md) | ✅ | ✅ | webdav_ops 把 401/403 压成同一个 SyncAuthError：403 被谎报成登录过期还触发登出 |
 | [BUG-1319](bugs/BUG-1319-collection-delete-cover-leak.md) | ✅ | ✅ | 删合集只有 1/6 入口回收自有封面：其余五条只删 DB 行，路径随行永久丢失、GC 又扫不到该子目录 = 确定性空间泄漏 |
 | [BUG-1315](bugs/BUG-1315-texthooker-threadless-lines-never-published.md) | ✅ | ✅ | 未选线程门控把无线程身份的行（WebSocket/Textractor 端点）永久丢弃 |
 | [BUG-1311](bugs/BUG-1311-interconnect-service-config-403-on-plaintext.md) | ✅ | ✅ | 互联同步每轮都报「认证失败」：明文 host 上无条件请求 service-config |

--- a/docs/bugs/BUG-1323-sync-401-403-flattened.md
+++ b/docs/bugs/BUG-1323-sync-401-403-flattened.md
@@ -1,0 +1,76 @@
+## BUG-1323 · webdav_ops 把 401/403 压成同一个 SyncAuthError：403 被谎报成登录过期还触发登出
+- **报告**：2026-08-01（TODO-2462；PR#644 修 BUG-1311 时有意留下的清理条件）
+- **真实性**：✅ 真 bug，独立缺陷。根因 `hibiki/lib/src/sync/webdav_ops.dart:259-262`：
+  ```dart
+  if (statusCode == 401 || statusCode == 403) {
+    throw SyncAuthError('Authentication failed');
+  }
+  ```
+  401（凭据不被接受）和 403（凭据**已被接受**，服务端按策略拒绝这一次请求）是两件不同
+  的事，被压成同一个异常 + 同一句常量字符串；`context` 参数在这条分支里连带丢掉，
+  响应体（服务端唯一说明「为什么」的地方）从来没被读过。同文件另有两处独立的
+  401∨403 合并：`webdav_ops.dart:91`（`testConnection`）、`:131`（`propfindChildren`）。
+  这层被 **webdav + interconnect（28 处 `checkStatus`）+ media/source_library（2 处）**
+  共用，故一处压平污染全部 HTTP 同步路径（ftp/sftp/OAuth 系不经此处）。
+
+  **两层用户可见后果**：
+  1. **文案说谎**：`hibiki/lib/src/sync/sync_error_messages.dart:61-63` 的
+     `error is SyncAuthError && l.contains('auth')` 对 `'authentication failed'` 恒真，
+     于是 403 被渲染成 `t.sync_err_auth_expired`「登录已过期，请重新登录」，把用户引去
+     反复重配一个根本没问题的凭据——BUG-1311 的原始症状。
+  2. **毁会话**：`hibiki/lib/src/sync/manual_sync_ui.dart:178-193` 的
+     `on SyncAuthError catch` **无条件** `backend.signOut(repo:) + clearCache() +
+     clearFolderCache()`。一条服务端策略（如 host 对明文会话返回
+     `403 HTTPS required for service config`，`hibiki_sync_server.dart:2197-2199`）
+     就能把用户一个好端端的会话踢下线。
+- **[x] ① 已修复** —
+  - `hibiki/lib/src/sync/sync_backend.dart:37-48`：新增 `enum SyncAuthFailureKind
+    { credentials, forbidden }`；`SyncAuthError` 加 `kind`（默认 `credentials`）与
+    `serverReason` 两个字段 + `isForbidden` getter。
+    **粒度判断：加字段而不是拆新异常类**——仓库里 20 处 `on SyncAuthError` /
+    `is SyncAuthError` 全是 rethrow / 短路 / 登出语义（`ftp_sync_backend.dart` 13 处、
+    `sftp_sync_backend.dart:526` `_guarded`、`interconnect_sync_backend.dart:72/98`
+    探测短路、`sync_manager.dart:204`）。拆新类会让它们**静默停止捕获** 403，把
+    「短路/上报」悄悄变成「吞掉/继续轮询」——那是把错误吞得更深，正好反向。
+    另外 `hibiki/test/sync/pull_to_sync_wiring_guard_test.dart:99` 源码扫描守卫硬断言
+    `manual_sync_ui.dart` 里必须有字面量 `on SyncAuthError catch`，改名即 CI 红。
+    默认值让 30 余处既有抛出点（OAuth / 未配置 / FTP/SFTP 协议层）行为逐字不变。
+  - `webdav_ops.dart:294-317`：`checkStatus(int, String, {String? serverReason})`
+    401 → `credentials`（消息逐字不变）、403 → `forbidden` + `'Server refused (403):
+    $context'`（把以前丢掉的 context 带回来）+ `serverReason`。可选具名参数 ⇒ 既有
+    33 处调用点一行不改。
+  - `webdav_ops.dart:44-64`：新增 `readSyncErrorBody(HttpClientResponse)`——**永不抛**
+    （读原因失败绝不能盖掉原本要报的错）、**截到 300 字**（错误体可能是整页 HTML）、
+    **5s 超时**（挂死的流不许拖住整轮同步）。
+  - `webdav_ops.dart:117-131`（`testConnection`）、`:158-170`（`propfindChildren`）：
+    403 分支改为读响应体当 `serverReason`。401 的判定仍**先于**任何流读取——反过来的话
+    一个畸形错误体就能把鉴权失败盖成 `FormatException`。
+  - `interconnect_sync_backend.dart:707-717`（BUG-1311 的现场 service-config GET）与
+    `:775-782`（通用 `_listRemote`）：错误路径读体后传 `serverReason`。
+  - `sync_error_messages.dart:6-14`：**类型分支放在 `_friendlyClause` 最前**，403 不再
+    落进底下的字符串猜测；新 `friendlySyncAuthFailure(kind, serverReason)` 让异常路径与
+    报告路径共用同一套措辞。新增 i18n `sync_err_forbidden` /
+    `sync_err_forbidden_detail`（经 `tool/i18n_sync.dart --add`，17 语言 + `dart run slang`）。
+  - `manual_sync_ui.dart:60-70`：抽出纯函数 `shouldSignOutOnAuthError(SyncAuthError)
+    => !error.isForbidden`，catch 块改调它。403 不再登出；提示照常给，只是不动会话。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/sync_auth_error_kind_test.dart`
+  （27 test 全绿）。关键在于**钉住用户在两种情况下分别看到什么**，而不是只断类型：
+  - 起真 `HttpServer` 回 403 + 响应体，断言 `testConnection()` / `propfindChildren()`
+    把 `HTTPS required for service config` 原样带回；401 仍是 `credentials` 且消息逐字不变。
+  - `friendlySyncError`：401 → `t.sync_err_auth_expired`（逐字未变）；403 有原因 →
+    `t.sync_err_forbidden_detail(reason:)` 且 **`isNot(equals(t.sync_err_auth_expired))`**；
+    403 无原因 → `t.sync_err_forbidden`。
+  - 「403 的分流按类型走，不靠消息里有没有 auth 字样」：故意用 message
+    `'authentication context: refused'`——把类型分支删掉它就会被字符串层抓成「登录已过期」。
+  - `shouldSignOutOnAuthError`：credentials → true（TODO-836 契约不回归）、forbidden → false。
+  - 负向：Google Drive 的 `insufficient_scope`（不经 `checkStatus`，kind 保持默认）仍走
+    `t.sync_err_scope_upgrade`；404/5xx/2xx 契约不变。
+  - **变异实测两方向**见 PR 描述：把 403 分支还原成 `401 || 403` 合并 → 6 red；
+    删掉 `_friendlyClause` 的类型分支 → 3 red；`shouldSignOutOnAuthError` 改成
+    `=> true` → 1 red；逐条反向替换还原 → 27 全绿。
+- **备注**：**未做**的部分——`checkStatus` 的 33 个调用点里有 18 个在调用前已
+  `await res.drain()`，它们的 403 仍拿不到服务端原文（只拿到状态码 + context，仍比改动前
+  多）。把它们全改成「错误路径先捕体再 drain」需要逐个动上传/删除路径的流处理，与本缺陷
+  无关且风险不成比例；本轮只做了本来就把体读出来的 GET 路径。`checkStatus` 保持同步签名
+  （改成 `Future<void> checkStatus(HttpClientResponse, ...)` 会强制 33 处 `await` 并波及
+  `media/source_library/source_file_system.dart` 两个 sync 层之外的调用方）。

--- a/docs/bugs/BUG-1324-sync-report-auth-failure-untyped.md
+++ b/docs/bugs/BUG-1324-sync-report-auth-failure-untyped.md
@@ -1,0 +1,55 @@
+## BUG-1324 · 同步报告把鉴权失败压成一行字符串：UI 只剩「N 项失败」
+- **报告**：2026-08-01（TODO-2462；PR#644 修 BUG-1311 时有意留下的清理条件）
+- **真实性**：✅ 真 bug，独立缺陷。根因是**数据结构**：
+  `hibiki/lib/src/sync/sync_orchestrator.dart:190` 的 `final List<String> errors`。
+  逐维度 `catch (e) { report.errors.add('<label>: $e'); }`（全文 35 处）在 `$e` 被拼进
+  字符串的那一刻，异常类型就死了；`SyncAuthError` 与网络抖动、404、JSON 解析失败同格。
+  BUG-1311 点名的 `:527`（`_syncServiceConfigLive`）只是最稳定复现的那一处——host 对明文
+  会话**必然**返回 403，于是每一轮同步都稳定产出一条
+  `service config live sync: SyncAuthError: Authentication failed`。
+
+  唯一的用户可见消费方是 `hibiki/lib/src/sync/manual_sync_ui.dart:37-39`：
+  ```dart
+  return r.errors.isEmpty ? done
+      : '$done${t.sync_now_failed_suffix(count: r.errors.length)}';
+  ```
+  **只读 `errors.length`**。所以无论错误里写了什么，用户永远只看到「同步完成 · 无新增 ·
+  1 项失败」——一句不含任何可操作信息的话。另一个消费方
+  `sync_auto_trigger.dart:120-126` 把字符串扔进 `ErrorLogService`，用户看不到。
+- **[x] ① 已修复** — 修数据结构，不给 `:527` 打特例补丁：
+  - `sync_orchestrator.dart:191-197`：`SyncRunReport` 新增
+    `final List<SyncAuthFailure> authFailures`，与 `errors` **并存**（日志行一字不变，
+    信息只增不减）。
+  - `sync_orchestrator.dart:240-268`：新增 `noteError(String label, Object error)`——
+    字符串照旧 `errors.add('$label: $error')`，若它是 `SyncAuthError` 则**额外**在
+    `authFailures` 留一份带 `kind` / `serverReason` 的值；`_addAuthFailure` 按
+    (kind, message, serverReason) 去重（一次 401 会让一轮几百本书逐本失败，用户只需要
+    知道「凭据被拒了」一次）。`mergeFrom` 同步合并并去重（option B 双通道）。
+  - `sync_orchestrator.dart` 全文 **31 处** `report.errors.add('<label>: $e')` 机械改为
+    `report.noteError('<label>', e)`，产出的字符串逐字节相同。
+    **粒度判断**：改的是「每一个持有异常对象的 catch 点」，不是「所有 35 处」——
+    剩下 5 处（`:800/:1064/:1926/:2123/:2180`）压根没有异常对象（「host 没有该端点」
+    「本地文件不存在」这类自述性错误），没有类型可分流，保持原样。这条界线是
+    「有没有异常」，不是「改到哪算够」，所以不会留下「为什么这个特殊」的问题。
+  - `manual_sync_ui.dart:37-52`：`summarizeSyncReport` 在「N 项失败」后追加一句
+    `friendlySyncAuthFailure(auth.kind, auth.serverReason)`（取去重后的第一条）。
+    无鉴权失败时输出**逐字不变**。
+  - 措辞与 BUG-1323 的异常路径共用 `sync_error_messages.friendlySyncAuthFailure`，
+    同一件事不会在两条路径上说两种话。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/sync_auth_error_kind_test.dart`
+  的后两个 group（`BUG-1324 鉴权失败必须带类型活到 UI` /
+  `BUG-1324 「N 项失败」不再是唯一一句话`，共 11 test）：
+  - **契约护栏**：`noteError` 产出的日志行与改动前逐字相同
+    （`'service config live sync: SyncAuthError: Authentication failed'`）；零失败与
+    非鉴权失败时 `summarizeSyncReport` 输出逐字不变。
+  - **不许扩大化**：`SyncBackendError` / `FormatException` 不进 `authFailures`。
+  - 去重：200 条同因失败 → `errors` 200 条、`authFailures` 1 条；不同原因分别留一条；
+    `mergeFrom` 双通道合并后仍去重。
+  - **用户看到什么**：403 时摘要里出现 `HTTPS required for service config` 且
+    **不含** `t.sync_err_auth_expired`；401 时摘要含 `t.sync_err_auth_expired`。
+  - **变异实测两方向**见 PR 描述：把 `noteError` 里的 `if (error is! SyncAuthError)
+    return;` 改成无条件 `return`（等价于回到裸 `errors.add`）→ 8 red；反向替换还原 → 全绿。
+- **备注**：`SyncRunReport.errors` 的 `List<String>` 类型**没有**改成结构化列表——
+  `sync_auto_trigger.logSyncReportErrors`、`summarizeSyncReport` 以及十余个测试
+  （`sync_orchestrator_live_*.dart` 的 `expect(report.errors, isEmpty)` 等）都依赖它，
+  换类型的收益全部可以由并存的 `authFailures` 拿到，代价却是一大片无关改动。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 48773 (2869 per locale)
+/// Strings: 48807 (2871 per locale)
 ///
-/// Built on 2026-07-31 at 19:42 UTC
+/// Built on 2026-07-31 at 23:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3877,6 +3877,10 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Only the grouping is removed. The items in it are kept.';
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -10472,6 +10476,12 @@ class _StringsAr extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -17134,6 +17144,12 @@ class _StringsDe extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -23812,6 +23828,12 @@ class _StringsEs extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -30501,6 +30523,12 @@ class _StringsFr extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -37119,6 +37147,12 @@ class _StringsId extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -43783,6 +43817,12 @@ class _StringsIt extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -50264,6 +50304,12 @@ class _StringsJa extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -56747,6 +56793,12 @@ class _StringsKo extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -63391,6 +63443,12 @@ class _StringsNl extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -70048,6 +70106,12 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -76689,6 +76753,12 @@ class _StringsRu extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -83278,6 +83348,12 @@ class _StringsTh extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -89899,6 +89975,12 @@ class _StringsTr extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -96505,6 +96587,12 @@ class _StringsVi extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 // Path: <root>
@@ -102640,6 +102728,11 @@ class _StringsZhCn extends _StringsEn {
   String get delete_collection_confirm => '只解除分组，其中的条目会保留。';
   @override
   String get shortcut_action_video_enter_caret => '进入字幕选词光标';
+  @override
+  String get sync_err_forbidden => '服务端拒绝了这次请求。登录没问题，请检查服务端设置。';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      '服务端拒绝了这次请求：${reason}（登录没问题）';
 }
 
 // Path: <root>
@@ -109042,6 +109135,12 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get shortcut_action_video_enter_caret =>
       'Enter subtitle lookup cursor';
+  @override
+  String get sync_err_forbidden =>
+      'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+  @override
+  String sync_err_forbidden_detail({required Object reason}) =>
+      'The server refused this request: ${reason} (your sign-in is fine)';
 }
 
 /// Flat map(s) containing all translations.
@@ -114928,6 +115027,11 @@ extension on _StringsEn {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -120812,6 +120916,11 @@ extension on _StringsAr {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -126718,6 +126827,11 @@ extension on _StringsDe {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -132623,6 +132737,11 @@ extension on _StringsEs {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -138534,6 +138653,11 @@ extension on _StringsFr {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -144427,6 +144551,11 @@ extension on _StringsId {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -150334,6 +150463,11 @@ extension on _StringsIt {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -156203,6 +156337,11 @@ extension on _StringsJa {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -162076,6 +162215,11 @@ extension on _StringsKo {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -167977,6 +168121,11 @@ extension on _StringsNl {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -173875,6 +174024,11 @@ extension on _StringsPtBr {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -179778,6 +179932,11 @@ extension on _StringsRu {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -185664,6 +185823,11 @@ extension on _StringsTh {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -191559,6 +191723,11 @@ extension on _StringsTr {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -197450,6 +197619,11 @@ extension on _StringsVi {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }
@@ -203289,6 +203463,10 @@ extension on _StringsZhCn {
         return '只解除分组，其中的条目会保留。';
       case 'shortcut_action_video_enter_caret':
         return '进入字幕选词光标';
+      case 'sync_err_forbidden':
+        return '服务端拒绝了这次请求。登录没问题，请检查服务端设置。';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) => '服务端拒绝了这次请求：${reason}（登录没问题）';
       default:
         return null;
     }
@@ -209153,6 +209331,11 @@ extension on _StringsZhHk {
         return 'Only the grouping is removed. The items in it are kept.';
       case 'shortcut_action_video_enter_caret':
         return 'Enter subtitle lookup cursor';
+      case 'sync_err_forbidden':
+        return 'The server refused this request. Your sign-in is fine - check the server\'s settings.';
+      case 'sync_err_forbidden_detail':
+        return ({required Object reason}) =>
+            'The server refused this request: ${reason} (your sign-in is fine)';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "删除有声书",
   "audiobook_delete_confirm": "删除已附加的有声书？它的音频文件会从本机删除。",
   "delete_collection_confirm": "只解除分组，其中的条目会保留。",
-  "shortcut_action_video_enter_caret": "进入字幕选词光标"
+  "shortcut_action_video_enter_caret": "进入字幕选词光标",
+  "sync_err_forbidden": "服务端拒绝了这次请求。登录没问题，请检查服务端设置。",
+  "sync_err_forbidden_detail": "服务端拒绝了这次请求：$reason（登录没问题）"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2867,5 +2867,7 @@
   "audiobook_delete": "Delete audiobook",
   "audiobook_delete_confirm": "Delete the attached audiobook? Its audio files are removed from this device.",
   "delete_collection_confirm": "Only the grouping is removed. The items in it are kept.",
-  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor"
+  "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
+  "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
 }

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -704,10 +704,17 @@ class InterconnectSyncBackend extends SyncBackend
       await res.drain<void>();
       return null;
     }
-    _ops!.checkStatus(
-      res.statusCode,
-      'GET /api/interconnect/service-config',
-    );
+    if (res.statusCode >= 400) {
+      // BUG-1323：host 对这个端点的拒绝是**有理由的**（明文 → `HTTPS required for
+      // service config`；未配对 → `Paired-device token required`）。把响应体读出来
+      // 当拒绝原因传下去，否则用户只会看到一句与事实不符的「登录已过期」。
+      // 只在错误路径读——成功路径下面那行还要拿完整 body 解 JSON。
+      _ops!.checkStatus(
+        res.statusCode,
+        'GET /api/interconnect/service-config',
+        serverReason: await readSyncErrorBody(res),
+      );
+    }
     final String body = await res.transform(utf8.decoder).join();
     final Object? decoded = jsonDecode(body);
     if (decoded is! Map) {
@@ -762,7 +769,14 @@ class InterconnectSyncBackend extends SyncBackend
       await res.drain<void>();
       return <T>[];
     }
-    _ops!.checkStatus(res.statusCode, 'GET $path');
+    if (res.statusCode >= 400) {
+      // BUG-1323：错误路径把服务端给的原因带上（成功路径下面才读完整 body）。
+      _ops!.checkStatus(
+        res.statusCode,
+        'GET $path',
+        serverReason: await readSyncErrorBody(res),
+      );
+    }
     final Future<String> reading = res.transform(utf8.decoder).join();
     final String body =
         timeout == null ? await reading : await reading.timeout(timeout);

--- a/hibiki/lib/src/sync/manual_sync_ui.dart
+++ b/hibiki/lib/src/sync/manual_sync_ui.dart
@@ -34,10 +34,28 @@ String summarizeSyncReport(SyncRunReport r) {
   ];
   final String head = parts.isEmpty ? t.sync_now_no_changes : parts.join(' · ');
   final String done = t.sync_now_done(detail: head);
-  return r.errors.isEmpty
-      ? done
-      : '$done${t.sync_now_failed_suffix(count: r.errors.length)}';
+  if (r.errors.isEmpty) return done;
+  final String failed =
+      '$done${t.sync_now_failed_suffix(count: r.errors.length)}';
+  // BUG-1324：鉴权类失败不能和网络抖动一样只计进「N 项失败」——那句话里
+  // 没有任何可操作信息。「凭据不被接受」要说去重新登录；「服务端拒绝」要把
+  // 服务端给的原因原样摆出来，并说明这不是登录问题（否则用户会去反复重配
+  // 一个根本没问题的 token，BUG-1311 的原始症状）。只拿第一条：报告已去重，
+  // 同一轮里同因的几百条只会剩一条。
+  if (r.authFailures.isEmpty) return failed;
+  final SyncAuthFailure auth = r.authFailures.first;
+  return '$failed · '
+      '${friendlySyncAuthFailure(auth.kind, auth.serverReason)}';
 }
+
+/// 鉴权失败后是否应当登出。这是一个**判断**，不是一个副作用，故抽成纯函数：
+/// 登出会毁掉用户的会话，它的判据必须能被直接钉住（BUG-1323）。
+///
+/// - [SyncAuthFailureKind.credentials]（401 / 未配置 / OAuth 失效）：会话真的完了，
+///   必须登出，否则账号行不退回「未登录」，用户无从重新登录（TODO-836）。
+/// - [SyncAuthFailureKind.forbidden]（403）：凭据已被接受，只是服务端拒了这一次
+///   请求。登出就是用一条服务端策略抢先毁掉一个好端端的会话。
+bool shouldSignOutOnAuthError(SyncAuthError error) => !error.isForbidden;
 
 /// 本地化的同步阶段名（进度行用）。
 String syncPhaseLabel(SyncPhase phase) {
@@ -176,18 +194,25 @@ Future<ManualSyncOutcome> runManualSyncWithFeedback({
     }
     return result.outcome;
   } on SyncAuthError catch (e) {
-    // TODO-836: insufficient_scope（或任何鉴权错误）—— 存下来的会话已经不可用了。
-    // 先登出，让账号行退回「未登录」（登录按钮重新出现），再提示重新登录。登出
-    // 序列与 account.part.dart 里的手动登出路径一致。
-    final SyncRepository repo = SyncRepository(appModel.database);
-    try {
-      final SyncBackend backend =
-          resolveSyncBackend(await repo.getBackendType());
-      await backend.signOut(repo: repo);
-      backend.clearCache();
-      await repo.clearFolderCache();
-    } catch (_) {
-      // 尽力登出；绝不因此盖掉原本要给用户的重新登录提示。
+    // TODO-836: insufficient_scope（或任何**凭据类**鉴权错误）—— 存下来的会话
+    // 已经不可用了。先登出，让账号行退回「未登录」（登录按钮重新出现），再提示
+    // 重新登录。登出序列与 account.part.dart 里的手动登出路径一致。
+    //
+    // BUG-1323：403 是例外。凭据**已经被接受**，是服务端按策略拒绝了这一次
+    // 请求（如 host 对明文会话拒发 service config）。把它当凭据失效去 signOut，
+    // 等于用一条服务端策略毁掉用户一个好端端的会话，还要他去重配一个没问题的
+    // token——正是 BUG-1311 里用户抱怨的那个循环。提示照常给，只是不动会话。
+    if (shouldSignOutOnAuthError(e)) {
+      final SyncRepository repo = SyncRepository(appModel.database);
+      try {
+        final SyncBackend backend =
+            resolveSyncBackend(await repo.getBackendType());
+        await backend.signOut(repo: repo);
+        backend.clearCache();
+        await repo.clearFolderCache();
+      } catch (_) {
+        // 尽力登出；绝不因此盖掉原本要给用户的重新登录提示。
+      }
     }
     if (context.mounted) showSyncMessage(context, friendlySyncError(e));
     return ManualSyncOutcome.notConfigured;

--- a/hibiki/lib/src/sync/sync_backend.dart
+++ b/hibiki/lib/src/sync/sync_backend.dart
@@ -34,12 +34,50 @@ class SyncBackendError implements Exception {
   String toString() => 'SyncBackendError: $message';
 }
 
+/// 鉴权类失败的两种**互不相同**的语义（BUG-1323）。
+///
+/// 压成同一条 `SyncAuthError('Authentication failed')` 会把 [forbidden] 误报成
+/// [credentials]：「服务端按策略拒绝了这次请求」被说成「登录已过期」，
+/// 把用户引去反复重配一个根本没问题的凭据（BUG-1311 的用户可见症状）。
+enum SyncAuthFailureKind {
+  /// 凭据本身不被接受：HTTP 401、凭据未配置、OAuth 授权过期/被撤销/被拒。
+  /// 可操作项 = 重新登录 / 重新填凭据。**会话已经不可用**，登出是正确反应。
+  credentials,
+
+  /// 凭据**已经被接受**，但服务端按策略拒绝了这一次请求：HTTP 403。
+  /// 可操作项 = 看服务端给出的原因（如「service config 必须走 HTTPS」），
+  /// **不是**去动凭据；把用户登出只会毁掉一个好端端的会话。
+  forbidden,
+}
+
 class SyncAuthError implements Exception {
-  SyncAuthError(this.message);
+  SyncAuthError(
+    this.message, {
+    this.kind = SyncAuthFailureKind.credentials,
+    this.serverReason,
+  });
+
   final String message;
 
+  /// 见 [SyncAuthFailureKind]。默认 [SyncAuthFailureKind.credentials] —— 仓库里既有的
+  /// 三十余处抛出点（OAuth 流程、「credentials not configured」、FTP/SFTP 协议层拒绝）
+  /// 语义上全是「凭据不被接受」，故默认值让它们的行为逐字不变；只有真正
+  /// 知道自己拿到 403 的抛出点才显式传 [SyncAuthFailureKind.forbidden]。
+  final SyncAuthFailureKind kind;
+
+  /// 服务端在响应体里给出的拒绝原因原文（如 `HTTPS required for service config`）。
+  /// 只在服务端真的说了话时非空；`checkStatus` 以前把它整个丢掉。
+  final String? serverReason;
+
+  /// 服务端拒绝（403），而不是凭据不被接受（401）。
+  bool get isForbidden => kind == SyncAuthFailureKind.forbidden;
+
   @override
-  String toString() => 'SyncAuthError: $message';
+  String toString() {
+    final String? reason = serverReason;
+    if (reason == null || reason.isEmpty) return 'SyncAuthError: $message';
+    return 'SyncAuthError: $message ($reason)';
+  }
 }
 
 /// The per-book sync folder name for [bookTitle] (its sanitized title), or throw

--- a/hibiki/lib/src/sync/sync_error_messages.dart
+++ b/hibiki/lib/src/sync/sync_error_messages.dart
@@ -4,6 +4,12 @@ import 'package:hibiki/utils.dart';
 /// Localized friendly clause for a known error class, or null if the error is
 /// not one we recognize (caller decides the fallback).
 String? _friendlyClause(Object error) {
+  // BUG-1323：403「服务端按策略拒绝」有类型可用，不必再猜字符串。必须放在
+  // 最前面：下面那条 `error is SyncAuthError && l.contains('auth')` 会把任何带
+  // 'auth' 字样的鉴权错误都说成「登录已过期」——而 403 的凭据是好的。
+  if (error is SyncAuthError && error.isForbidden) {
+    return friendlySyncAuthFailure(error.kind, error.serverReason);
+  }
   final String msg =
       error is SyncBackendError ? error.message : _rawMessage(error);
   final String l = msg.toLowerCase();
@@ -80,6 +86,18 @@ String? _friendlyClause(Object error) {
     return t.sync_err_network;
   }
   return null;
+}
+
+/// 一条鉴权失败的**可操作**句子。抛出的 [SyncAuthError] 与报告里沉淀下来的
+/// `SyncAuthFailure` 共用同一套措辞，免得同一件事在两条路径上说两种话。
+///
+/// 参数只取 [SyncAuthFailureKind] 与服务端原因两个基元，故本文件不需要反向
+/// 依赖 sync_orchestrator（错误文案层不该知道同步编排层的存在）。
+String friendlySyncAuthFailure(SyncAuthFailureKind kind, String? serverReason) {
+  if (kind != SyncAuthFailureKind.forbidden) return t.sync_err_auth_expired;
+  final String? reason = serverReason;
+  if (reason == null || reason.isEmpty) return t.sync_err_forbidden;
+  return t.sync_err_forbidden_detail(reason: reason);
 }
 
 String _rawMessage(Object error) => error is SyncBackendError

--- a/hibiki/lib/src/sync/sync_orchestrator.dart
+++ b/hibiki/lib/src/sync/sync_orchestrator.dart
@@ -188,6 +188,15 @@ class SyncRunReport {
   int serviceConfigsImported = 0;
 
   final List<String> errors = <String>[];
+
+  /// 本轮遇到的**鉴权类**失败，带类型（去重后）。BUG-1324。
+  ///
+  /// [errors] 是扇平成字符串的日志行：异常一旦拼进去，「凭据真的不对」和
+  /// 「服务端因别的原因拒绝」就再也分不出来了；而 UI 只数了个
+  /// `errors.length` 就变成「N 项失败」，等于把两件事押成同一句废话。
+  /// 本列表把类型保留到 UI，与 [errors] **并存**（日志行一字不变）。
+  final List<SyncAuthFailure> authFailures = <SyncAuthFailure>[];
+
   final List<SyncConflict> conflicts = <SyncConflict>[];
 
   /// 本轮消费远端删除标记算出的 deleteLocal 候选（远端已删 ∧ 本地仍在库，且
@@ -230,9 +239,64 @@ class SyncRunReport {
     collectionsUpdated += other.collectionsUpdated;
     serviceConfigsImported += other.serviceConfigsImported;
     errors.addAll(other.errors);
+    for (final SyncAuthFailure f in other.authFailures) {
+      _addAuthFailure(f);
+    }
     conflicts.addAll(other.conflicts);
     deletionCandidates.addAll(other.deletionCandidates);
   }
+
+  /// 记一条维度/条目级失败。
+  ///
+  /// 字符串照旧进 [errors]（`'$label: $error'` —— 与改动前逐字相同，
+  /// 既有日志/断言一行不变）；它若是 [SyncAuthError]，**额外**在
+  /// [authFailures] 里留一份带类型的。信息只增不减。
+  void noteError(String label, Object error) {
+    errors.add('$label: $error');
+    if (error is! SyncAuthError) return;
+    _addAuthFailure(SyncAuthFailure(
+      label: label,
+      kind: error.kind,
+      message: error.message,
+      serverReason: error.serverReason,
+    ));
+  }
+
+  /// 按（kind, message, serverReason）去重：一次 401 会让一轮里几百本书逐本
+  /// 失败，用户只需要知道「凭据被拒了」一次。label 不进去重键（它只是
+  /// 第一个撞上的现场），否则去重就形同虚设。
+  void _addAuthFailure(SyncAuthFailure failure) {
+    final bool seen = authFailures.any((SyncAuthFailure f) =>
+        f.kind == failure.kind &&
+        f.message == failure.message &&
+        f.serverReason == failure.serverReason);
+    if (!seen) authFailures.add(failure);
+  }
+}
+
+/// 一次鉴权类同步失败，带着它的真实语义（BUG-1324）。
+///
+/// 与 [SyncAuthError] 同形，但是一个**值**：它要跨 orchestrator → 报告 → UI
+/// 三层活下来，而异常在第一个 catch 里就死了。
+class SyncAuthFailure {
+  const SyncAuthFailure({
+    required this.label,
+    required this.kind,
+    required this.message,
+    this.serverReason,
+  });
+
+  /// 出错的维度/条目标签，与 [SyncRunReport.errors] 里那一行同前缀。
+  final String label;
+
+  final SyncAuthFailureKind kind;
+  final String message;
+
+  /// 服务端给出的拒绝原因原文（只有 403 常带）。
+  final String? serverReason;
+
+  /// 服务端按策略拒绝（403），而不是凭据不被接受（401）。
+  bool get isForbidden => kind == SyncAuthFailureKind.forbidden;
 }
 
 /// Orchestrates sync across any [SyncBackend].
@@ -508,7 +572,7 @@ class SyncOrchestrator {
         deviceId: deviceId,
       );
     } catch (e) {
-      report.errors.add('aggregate sync: $e');
+      report.noteError('aggregate sync', e);
     }
   }
 
@@ -524,7 +588,7 @@ class SyncOrchestrator {
       if (snapshot == null) return;
       report.serviceConfigsImported += await snapshot.applyTo(_db);
     } catch (e) {
-      report.errors.add('service config live sync: $e');
+      report.noteError('service config live sync', e);
     }
   }
 
@@ -548,7 +612,7 @@ class SyncOrchestrator {
         pushMerged: backend.putRemoteAggregate,
       );
     } catch (e) {
-      report.errors.add('aggregate live sync: $e');
+      report.noteError('aggregate live sync', e);
     }
   }
 
@@ -642,12 +706,16 @@ class SyncOrchestrator {
           // 基线越过未读知识造成误判）。任一情况都绝不整轮 return。
           if (isOwn) {
             ownCorrupt = true;
-            report.errors.add('own collections manifest "${e.name}" unreadable;'
-                ' republishing from local+peers this run (self-heal): $err');
+            report.noteError(
+                'own collections manifest "${e.name}" unreadable;'
+                ' republishing from local+peers this run (self-heal)',
+                err);
           } else {
             skippedPeer = true;
-            report.errors.add('peer collections manifest "${e.name}" '
-                'unreadable; skipped this run (baseline held): $err');
+            report.noteError(
+                'peer collections manifest "${e.name}" '
+                'unreadable; skipped this run (baseline held)',
+                err);
           }
         }
       }
@@ -700,7 +768,7 @@ class SyncOrchestrator {
         await repo.setCollectionsSyncBaselineMs(nextBaseline);
       }
     } catch (e) {
-      report.errors.add('collections sync: $e');
+      report.noteError('collections sync', e);
     }
   }
 
@@ -761,7 +829,7 @@ class SyncOrchestrator {
       }
       await repo.setCollectionsSyncBaselineMs(nextBaseline);
     } catch (e) {
-      report.errors.add('collections live sync: $e');
+      report.noteError('collections live sync', e);
     }
   }
 
@@ -853,7 +921,7 @@ class SyncOrchestrator {
         try {
           json = await _backend.getJsonAsset(e.id);
         } catch (err) {
-          report.errors.add('deletion tombstone "${e.name}" unreadable: $err');
+          report.noteError('deletion tombstone "${e.name}" unreadable', err);
           continue;
         }
         final parsed = parseDeletionTombstoneJson(json);
@@ -892,7 +960,7 @@ class SyncOrchestrator {
         }
       }
     } catch (e) {
-      report.errors.add('deletion tombstones sync: $e');
+      report.noteError('deletion tombstones sync', e);
     }
   }
 
@@ -945,7 +1013,7 @@ class SyncOrchestrator {
         }
       }
     } catch (e) {
-      report.errors.add('deletion tombstones live sync: $e');
+      report.noteError('deletion tombstones live sync', e);
     }
   }
 
@@ -1096,7 +1164,7 @@ class SyncOrchestrator {
             tagTombstones: mergedTagTombstones,
           );
         } catch (e) {
-          report.errors.add('video "${v.title}": $e');
+          report.noteError('video "${v.title}"', e);
         }
         index++;
       }
@@ -1113,7 +1181,7 @@ class SyncOrchestrator {
             ns, kSyncVideosManifestName, merged.toJson());
       }
     } catch (e) {
-      report.errors.add('video assets sync: $e');
+      report.noteError('video assets sync', e);
     }
   }
 
@@ -1199,7 +1267,7 @@ class SyncOrchestrator {
           report.booksImported++;
         }
       } catch (e) {
-        report.errors.add('import book "${folder.name}": $e');
+        report.noteError('import book "${folder.name}"', e);
       }
     }
   }
@@ -1284,7 +1352,7 @@ class SyncOrchestrator {
               fileFraction: f),
         );
       } catch (e) {
-        report.errors.add('live push book "$title": $e');
+        report.noteError('live push book "$title"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -1356,7 +1424,7 @@ class SyncOrchestrator {
           report.localBookProgressPulled++;
         }
       } catch (e) {
-        report.errors.add('live book progress "${book.title}": $e');
+        report.noteError('live book progress "${book.title}"', e);
       }
     }
   }
@@ -1414,7 +1482,7 @@ class SyncOrchestrator {
           await writeBackLocal(key, winner.positionMs, winner.updatedAtMs);
         }
       } catch (e) {
-        report.errors.add('$errorLabel "$key": $e');
+        report.noteError('$errorLabel "$key"', e);
       }
     }
   }
@@ -1659,7 +1727,7 @@ class SyncOrchestrator {
         );
         report.dictionariesImported++;
       } catch (e) {
-        report.errors.add('pull dictionary "$name": $e');
+        report.noteError('pull dictionary "$name"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -1685,7 +1753,7 @@ class SyncOrchestrator {
                 fileFraction: f));
         report.dictionariesExported++;
       } catch (e) {
-        report.errors.add('push dictionary "$name": $e');
+        report.noteError('push dictionary "$name"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -1745,7 +1813,7 @@ class SyncOrchestrator {
                 fileFraction: f));
         report.dictionariesExported++;
       } catch (e) {
-        report.errors.add('export dictionary "${d.name}": $e');
+        report.noteError('export dictionary "${d.name}"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -1777,7 +1845,7 @@ class SyncOrchestrator {
         );
         report.dictionariesImported++;
       } catch (err) {
-        report.errors.add('import dictionary "${e.name}": $err');
+        report.noteError('import dictionary "${e.name}"', err);
       } finally {
         _safeDelete(tmp);
       }
@@ -1839,7 +1907,7 @@ class SyncOrchestrator {
           report.localAudioImported++;
         }
       } catch (e) {
-        report.errors.add('live pull local audio "$name": $e');
+        report.noteError('live pull local audio "$name"', e);
       } finally {
         _safeDelete(tmp);
         _safeDelete(stagingDb);
@@ -1880,7 +1948,7 @@ class SyncOrchestrator {
         );
         report.localAudioExported++;
       } catch (e) {
-        report.errors.add('live push local audio "$name": $e');
+        report.noteError('live push local audio "$name"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -1980,7 +2048,7 @@ class SyncOrchestrator {
         );
         report.audiobooksExported++;
       } catch (e) {
-        report.errors.add('live push audiobook "$key": $e');
+        report.noteError('live push audiobook "$key"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -2009,7 +2077,7 @@ class SyncOrchestrator {
         );
         report.audiobooksImported++;
       } catch (e) {
-        report.errors.add('live pull audiobook "$key": $e');
+        report.noteError('live pull audiobook "$key"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -2101,7 +2169,7 @@ class SyncOrchestrator {
           report.videosExported++;
           videoOk = true;
         } catch (e) {
-          report.errors.add('live push video "${v.title}": $e');
+          report.noteError('live push video "${v.title}"', e);
         }
       }
       // 字幕跟着视频走：视频本轮失败就不推字幕（host 侧无行可挂）。
@@ -2141,7 +2209,7 @@ class SyncOrchestrator {
             .putRemoteVideoSubtitle(row.bookUid, sub, suffix: suffix);
         if (!supported) return false;
       } catch (e) {
-        report.errors.add('live push subtitle "${p.basename(sub.path)}": $e');
+        report.noteError('live push subtitle "${p.basename(sub.path)}"', e);
       }
     }
     return true;
@@ -2235,7 +2303,7 @@ class SyncOrchestrator {
                 fileFraction: f));
         report.localAudioExported++;
       } catch (e) {
-        report.errors.add('export local audio "${d.displayName}": $e');
+        report.noteError('export local audio "${d.displayName}"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -2271,7 +2339,7 @@ class SyncOrchestrator {
           report.localAudioImported++;
         }
       } catch (err) {
-        report.errors.add('import local audio "${e.name}": $err');
+        report.noteError('import local audio "${e.name}"', err);
       } finally {
         _safeDelete(tmp);
         _safeDelete(stagingDb);
@@ -2330,7 +2398,7 @@ class SyncOrchestrator {
           report.audiobooksExported++;
         }
       } catch (e) {
-        report.errors.add('audiobook "${book.title}": $e');
+        report.noteError('audiobook "${book.title}"', e);
       } finally {
         _safeDelete(tmp);
       }
@@ -2359,7 +2427,7 @@ class SyncOrchestrator {
     try {
       children = await _backend.listChildren(root);
     } catch (e) {
-      report.errors.add('prune root spill (list root): $e');
+      report.noteError('prune root spill (list root)', e);
       return;
     }
     for (final AssetEntry e in children) {
@@ -2368,7 +2436,7 @@ class SyncOrchestrator {
         await _backend.deleteAsset(e.id);
         report.rootSpillFilesRemoved++;
       } catch (err) {
-        report.errors.add('prune root spill "${e.name}": $err');
+        report.noteError('prune root spill "${e.name}"', err);
       }
     }
   }

--- a/hibiki/lib/src/sync/webdav_ops.dart
+++ b/hibiki/lib/src/sync/webdav_ops.dart
@@ -7,6 +7,33 @@ import 'package:hibiki/src/sync/tls/hibiki_pinning_http.dart';
 import 'package:hibiki/src/sync/sync_utils.dart';
 import 'package:hibiki/src/sync/sync_file_ref.dart';
 
+/// 服务端在错误响应体里给出的拒绝原因（截断后的），读不出来就返回 null。
+///
+/// BUG-1323：以前所有 4xx 响应体都被 `drain()` 丢掉，403 的「HTTPS required for
+/// service config」这种**唯一可操作的信息**从来没到过用户面前。
+///
+/// 三条纪律：
+/// - **永不抛**。读原因失败绝不能盖掉原本要报的那个错——那才是用户要看的。
+/// - **有上限**。错误体可能是一整页 HTML；截到 [_kMaxServerReasonChars] 字符，
+///   免得把 SnackBar / 日志行撑爆。
+/// - **有超时**。挂死的响应流不能把同步整轮拖住。
+Future<String?> readSyncErrorBody(HttpClientResponse response) async {
+  try {
+    final String body = await response
+        .transform(utf8.decoder)
+        .join()
+        .timeout(const Duration(seconds: 5));
+    final String trimmed = body.trim();
+    if (trimmed.isEmpty) return null;
+    if (trimmed.length <= _kMaxServerReasonChars) return trimmed;
+    return '${trimmed.substring(0, _kMaxServerReasonChars)}...';
+  } catch (_) {
+    return null;
+  }
+}
+
+const int _kMaxServerReasonChars = 300;
+
 class DavEntry {
   const DavEntry({
     required this.href,
@@ -86,11 +113,22 @@ class WebDavOps {
       request.headers.set('Content-Type', 'application/xml; charset=utf-8');
       request.add(utf8.encode(propfindBody));
       final response = await request.close();
-      await response.drain<void>();
 
-      if (response.statusCode == 401 || response.statusCode == 403) {
+      if (response.statusCode == 401) {
+        await response.drain<void>();
         throw SyncAuthError('Authentication failed');
       }
+      // BUG-1323：403 是服务端的策略拒绝，用户要看到的是**服务端说了什么**，而不是
+      // 「登录已过期，请重新登录」。「测试连接」正是最该把原文摆出来的地方，故这条
+      // 分支不 drain，先把响应体读成拒绝原因。
+      if (response.statusCode == 403) {
+        throw SyncAuthError(
+          'Server refused (403): PROPFIND $_baseUrl',
+          kind: SyncAuthFailureKind.forbidden,
+          serverReason: await readSyncErrorBody(response),
+        );
+      }
+      await response.drain<void>();
       if (response.statusCode >= 400) {
         throw SyncBackendError('Server returned ${response.statusCode}');
       }
@@ -128,8 +166,18 @@ class WebDavOps {
     request.add(utf8.encode(propfindBody));
     final response = await request.close();
 
-    if (response.statusCode == 401 || response.statusCode == 403) {
+    if (response.statusCode == 401) {
       throw SyncAuthError('Authentication failed');
+    }
+    // BUG-1323：403 带上服务端原文。读响应体放在这条分支里而不是提前统一读——
+    // 401 的判定必须先于任何可能抛异常的流读取，否则一个畸形错误体就能把鉴权
+    // 失败盖成 FormatException。
+    if (response.statusCode == 403) {
+      throw SyncAuthError(
+        'Server refused (403): PROPFIND $path',
+        kind: SyncAuthFailureKind.forbidden,
+        serverReason: await readSyncErrorBody(response),
+      );
     }
 
     final body = await response.transform(utf8.decoder).join();
@@ -256,9 +304,26 @@ class WebDavOps {
     }
   }
 
-  void checkStatus(int statusCode, String context) {
-    if (statusCode == 401 || statusCode == 403) {
+  /// HTTP 状态码 → 同步层异常契约。webdav / interconnect / source_library 共用。
+  ///
+  /// [serverReason] 是服务端在响应体里给出的拒绝原因（调用方读得到就传，读不到就
+  /// 不传）。本方法是同步的、拿不到响应流，故不能自己读；已有的三十余处调用点
+  /// 一行都不用改。
+  void checkStatus(int statusCode, String context, {String? serverReason}) {
+    if (statusCode == 401) {
       throw SyncAuthError('Authentication failed');
+    }
+    // BUG-1323：403 ≠ 401。403 是「凭据已被接受，但服务端按策略拒绝了这一次请求」
+    // （host 对明文会话返回 `HTTPS required for service config` 就是有意拒绝，不是
+    // 故障）。压成同一条 'Authentication failed' 有两个后果：文案把用户引去重配一个
+    // 根本没问题的凭据；上层 manual_sync_ui 还会把好端端的会话 signOut 掉。
+    // 顺带把 [context] 带上——以前这条分支连它一起丢了。
+    if (statusCode == 403) {
+      throw SyncAuthError(
+        'Server refused (403): $context',
+        kind: SyncAuthFailureKind.forbidden,
+        serverReason: serverReason,
+      );
     }
     if (statusCode == 404) {
       throw SyncBackendError('Not found: $context', isRetryable: true);

--- a/hibiki/test/sync/sync_auth_error_kind_test.dart
+++ b/hibiki/test/sync/sync_auth_error_kind_test.dart
@@ -1,0 +1,352 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/sync/manual_sync_ui.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_error_messages.dart';
+import 'package:hibiki/src/sync/sync_orchestrator.dart';
+import 'package:hibiki/src/sync/webdav_ops.dart';
+
+/// BUG-1323 / BUG-1324：同步层两处「把错误压平」的独立缺陷。
+///
+/// - BUG-1323：`WebDavOps.checkStatus` 把 401（凭据不被接受）和 403（凭据没问题，
+///   服务端按策略拒绝这一次请求）一律压成 `SyncAuthError('Authentication failed')`，
+///   服务端在响应体里写的真实原因被整个丢弃。后果有两层：文案把用户引去重配一个
+///   根本没问题的凭据；`manual_sync_ui` 还会据此把好端端的会话 signOut 掉。
+/// - BUG-1324：`SyncRunReport.errors` 是扁平字符串，鉴权失败在拼进字符串那一刻就
+///   没法再分辨，UI 只数了个 `errors.length` 变成「N 项失败」。
+///
+/// 这里逐条钉住**用户在两种情况下分别看到什么**。文案一律与 i18n getter 比较
+/// （语言无关），不硬编码英文。
+void main() {
+  group('BUG-1323 checkStatus：401 与 403 不再是同一件事', () {
+    final WebDavOps ops = WebDavOps(
+      baseUrl: 'http://127.0.0.1:1/dav',
+      username: 'u',
+      password: 'p',
+    );
+
+    test('401 保持 credentials，措辞与改动前逐字相同', () {
+      SyncAuthError? caught;
+      try {
+        ops.checkStatus(401, 'GET /x');
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught, isNotNull);
+      expect(caught!.kind, SyncAuthFailureKind.credentials);
+      expect(caught.isForbidden, isFalse);
+      expect(caught.message, 'Authentication failed');
+      expect(caught.serverReason, isNull);
+      expect(caught.toString(), 'SyncAuthError: Authentication failed');
+    });
+
+    test('403 变 forbidden，且把以前被丢掉的操作上下文带上', () {
+      SyncAuthError? caught;
+      try {
+        ops.checkStatus(403, 'GET /api/interconnect/service-config');
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught, isNotNull);
+      expect(caught!.kind, SyncAuthFailureKind.forbidden);
+      expect(caught.isForbidden, isTrue);
+      expect(caught.message, contains('403'));
+      expect(caught.message, contains('/api/interconnect/service-config'));
+      expect(caught.message, isNot(equals('Authentication failed')));
+    });
+
+    test('403 的服务端原因原样保留，并进 toString', () {
+      SyncAuthError? caught;
+      try {
+        ops.checkStatus(403, 'GET /svc',
+            serverReason: 'HTTPS required for service config');
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught!.serverReason, 'HTTPS required for service config');
+      expect(caught.toString(), contains('HTTPS required for service config'));
+    });
+
+    test('404 / 5xx / 2xx 契约不变（都不是鉴权错误）', () {
+      expect(
+        () => ops.checkStatus(404, 'GET /x'),
+        throwsA(isA<SyncBackendError>().having(
+            (SyncBackendError e) => e.isRetryable, 'isRetryable', isTrue)),
+      );
+      expect(() => ops.checkStatus(500, 'GET /x'),
+          throwsA(isA<SyncBackendError>()));
+      expect(() => ops.checkStatus(207, 'PROPFIND /x'), returnsNormally);
+    });
+  });
+
+  group('BUG-1323 真实 HTTP 响应：服务端说的原因必须活着到达上层', () {
+    late HttpServer server;
+    late String base;
+    late int status;
+    late String body;
+
+    setUp(() async {
+      status = 403;
+      body = 'HTTPS required for service config';
+      server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      base = 'http://127.0.0.1:${server.port}/dav';
+      server.listen((HttpRequest req) async {
+        req.response.statusCode = status;
+        req.response.write(body);
+        await req.response.close();
+      });
+    });
+
+    tearDown(() async => server.close(force: true));
+
+    WebDavOps opsFor() =>
+        WebDavOps(baseUrl: base, username: 'u', password: 'p');
+
+    test('testConnection 的 403 把响应体当拒绝原因带回来', () async {
+      SyncAuthError? caught;
+      try {
+        await opsFor().testConnection();
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught, isNotNull);
+      expect(caught!.isForbidden, isTrue);
+      expect(caught.serverReason, 'HTTPS required for service config');
+    });
+
+    test('testConnection 的 401 仍是 credentials，措辞不变', () async {
+      status = 401;
+      SyncAuthError? caught;
+      try {
+        await opsFor().testConnection();
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught, isNotNull);
+      expect(caught!.kind, SyncAuthFailureKind.credentials);
+      expect(caught.message, 'Authentication failed');
+    });
+
+    test('propfindChildren 的 403 同样带回原因', () async {
+      SyncAuthError? caught;
+      try {
+        await opsFor().propfindChildren('$base/sub');
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught, isNotNull);
+      expect(caught!.isForbidden, isTrue);
+      expect(caught.serverReason, 'HTTPS required for service config');
+    });
+
+    test('403 但服务端一个字都没说：serverReason 为 null，不编造原因', () async {
+      body = '   ';
+      SyncAuthError? caught;
+      try {
+        await opsFor().testConnection();
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught!.isForbidden, isTrue);
+      expect(caught.serverReason, isNull);
+    });
+
+    test('超长错误体被截断，不把整页 HTML 灌进提示', () async {
+      body = 'x' * 5000;
+      SyncAuthError? caught;
+      try {
+        await opsFor().testConnection();
+      } on SyncAuthError catch (e) {
+        caught = e;
+      }
+      expect(caught!.serverReason, isNotNull);
+      expect(caught.serverReason!.length, lessThan(400));
+      expect(caught.serverReason, endsWith('...'));
+    });
+  });
+
+  group('BUG-1323 用户到底看到什么', () {
+    test('凭据错（401）看到「登录已过期，请重新登录」，逐字未变', () {
+      final SyncAuthError e = SyncAuthError('Authentication failed');
+      expect(friendlySyncError(e), t.sync_err_auth_expired);
+    });
+
+    test('服务端拒绝（403）且说了原因：原因原样出现，且不再谎称登录过期', () {
+      final SyncAuthError e = SyncAuthError(
+        'Server refused (403): GET /api/interconnect/service-config',
+        kind: SyncAuthFailureKind.forbidden,
+        serverReason: 'HTTPS required for service config',
+      );
+      final String shown = friendlySyncError(e);
+      expect(shown, contains('HTTPS required for service config'));
+      expect(shown, isNot(equals(t.sync_err_auth_expired)));
+      expect(
+        shown,
+        t.sync_err_forbidden_detail(
+            reason: 'HTTPS required for service config'),
+      );
+    });
+
+    test('服务端拒绝但没给原因：明说这不是登录问题', () {
+      final SyncAuthError e = SyncAuthError(
+        'Server refused (403): GET /x',
+        kind: SyncAuthFailureKind.forbidden,
+      );
+      expect(friendlySyncError(e), t.sync_err_forbidden);
+      expect(friendlySyncError(e), isNot(equals(t.sync_err_auth_expired)));
+    });
+
+    test('403 的分流按类型走，不靠消息里有没有 auth 字样', () {
+      // 防回归：把类型分支删掉后，这个 message 会被字符串层的
+      // `error is SyncAuthError && l.contains('auth')` 抓成「登录已过期」。
+      final SyncAuthError e = SyncAuthError(
+        'authentication context: refused',
+        kind: SyncAuthFailureKind.forbidden,
+        serverReason: 'policy',
+      );
+      expect(friendlySyncError(e), isNot(equals(t.sync_err_auth_expired)));
+      expect(friendlySyncError(e), contains('policy'));
+    });
+
+    test('Google Drive 的 403 insufficient_scope 仍走重新授权（TODO-836 不回归）', () {
+      // 它不经 checkStatus，kind 保持默认 credentials，故仍落在 scope 分支。
+      final SyncAuthError e = SyncAuthError('insufficient_scope');
+      expect(friendlySyncError(e), t.sync_err_scope_upgrade);
+    });
+  });
+
+  group('BUG-1323 403 不得毁掉一个好端端的会话', () {
+    test('凭据类失败必须登出（TODO-836 契约）', () {
+      expect(shouldSignOutOnAuthError(SyncAuthError('Authentication failed')),
+          isTrue);
+      expect(shouldSignOutOnAuthError(SyncAuthError('insufficient_scope')),
+          isTrue);
+    });
+
+    test('服务端拒绝不得登出', () {
+      expect(
+        shouldSignOutOnAuthError(SyncAuthError(
+          'Server refused (403): GET /svc',
+          kind: SyncAuthFailureKind.forbidden,
+          serverReason: 'HTTPS required for service config',
+        )),
+        isFalse,
+      );
+    });
+
+    test('手动同步的 catch 走的是这个判断，不是自己再写一遍', () {
+      final String src =
+          File('lib/src/sync/manual_sync_ui.dart').readAsStringSync();
+      expect(src, contains('on SyncAuthError catch'));
+      expect(src, contains('if (shouldSignOutOnAuthError(e)) {'));
+      expect(src, contains('await backend.signOut(repo: repo)'));
+    });
+  });
+
+  group('BUG-1324 鉴权失败必须带类型活到 UI', () {
+    test('日志行与改动前逐字相同（errors 的既有契约不动）', () {
+      final SyncRunReport r = SyncRunReport();
+      r.noteError(
+          'service config live sync', SyncAuthError('Authentication failed'));
+      expect(r.errors, <String>[
+        'service config live sync: SyncAuthError: Authentication failed',
+      ]);
+    });
+
+    test('SyncAuthError 额外留一份带类型的', () {
+      final SyncRunReport r = SyncRunReport();
+      r.noteError(
+        'service config live sync',
+        SyncAuthError('Server refused (403): GET /svc',
+            kind: SyncAuthFailureKind.forbidden,
+            serverReason: 'HTTPS required for service config'),
+      );
+      expect(r.authFailures, hasLength(1));
+      expect(r.authFailures.single.isForbidden, isTrue);
+      expect(r.authFailures.single.label, 'service config live sync');
+      expect(r.authFailures.single.serverReason,
+          'HTTPS required for service config');
+    });
+
+    test('非鉴权错误不进 authFailures（不许扩大化）', () {
+      final SyncRunReport r = SyncRunReport();
+      r.noteError('video assets sync', SyncBackendError('500'));
+      r.noteError('import book "x"', const FormatException('bad json'));
+      expect(r.errors, hasLength(2));
+      expect(r.authFailures, isEmpty);
+    });
+
+    test('同因失败去重：一轮几百本书只留一条', () {
+      final SyncRunReport r = SyncRunReport();
+      for (int i = 0; i < 200; i++) {
+        r.noteError(
+            'import book "b$i"', SyncAuthError('Authentication failed'));
+      }
+      expect(r.errors, hasLength(200));
+      expect(r.authFailures, hasLength(1));
+      expect(r.authFailures.single.label, 'import book "b0"');
+    });
+
+    test('不同原因分别留一条', () {
+      final SyncRunReport r = SyncRunReport();
+      r.noteError('a', SyncAuthError('Authentication failed'));
+      r.noteError(
+          'b',
+          SyncAuthError('Server refused (403): x',
+              kind: SyncAuthFailureKind.forbidden));
+      expect(r.authFailures, hasLength(2));
+    });
+
+    test('mergeFrom 合并双通道的 authFailures 并去重', () {
+      final SyncRunReport cloud = SyncRunReport()
+        ..noteError('a', SyncAuthError('Authentication failed'));
+      final SyncRunReport live = SyncRunReport()
+        ..noteError('b', SyncAuthError('Authentication failed'))
+        ..noteError(
+            'c',
+            SyncAuthError('Server refused (403): x',
+                kind: SyncAuthFailureKind.forbidden));
+      cloud.mergeFrom(live);
+      expect(cloud.errors, hasLength(3));
+      expect(cloud.authFailures, hasLength(2));
+    });
+  });
+
+  group('BUG-1324 「N 项失败」不再是唯一一句话', () {
+    test('零失败时摘要逐字不变', () {
+      expect(summarizeSyncReport(SyncRunReport()),
+          t.sync_now_done(detail: t.sync_now_no_changes));
+    });
+
+    test('非鉴权失败时摘要逐字不变（回归护栏）', () {
+      final SyncRunReport r = SyncRunReport()
+        ..noteError('video assets sync', SyncBackendError('500'));
+      expect(
+        summarizeSyncReport(r),
+        '${t.sync_now_done(detail: t.sync_now_no_changes)}'
+        '${t.sync_now_failed_suffix(count: 1)}',
+      );
+    });
+
+    test('服务端拒绝时摘要把服务端给的原因摆出来', () {
+      final SyncRunReport r = SyncRunReport()
+        ..noteError(
+          'service config live sync',
+          SyncAuthError('Server refused (403): GET /svc',
+              kind: SyncAuthFailureKind.forbidden,
+              serverReason: 'HTTPS required for service config'),
+        );
+      final String shown = summarizeSyncReport(r);
+      expect(shown, contains('HTTPS required for service config'));
+      expect(shown, isNot(contains(t.sync_err_auth_expired)));
+    });
+
+    test('凭据错时摘要说去重新登录', () {
+      final SyncRunReport r = SyncRunReport()
+        ..noteError('import book "x"', SyncAuthError('Authentication failed'));
+      expect(summarizeSyncReport(r), contains(t.sync_err_auth_expired));
+    });
+  });
+}


### PR DESCRIPTION
TODO-2462。修 PR#644 修 BUG-1311 时**有意未做**、并写进其清理条件的两处独立缺陷。
两条的价值都是**让错误说真话**，不是重构。

## ① BUG-1323 · webdav_ops 把 401/403 压成同一件事

**值得改。粒度 = 给 `SyncAuthError` 加字段，不拆新异常类。**

401（凭据不被接受）和 403（凭据**已被接受**、服务端按策略拒绝这一次请求）压成同一个
`SyncAuthError('Authentication failed')`，`context` 连带丢掉，响应体（服务端唯一说明
「为什么」的地方）从来没被读过。两层用户可见后果：

1. `sync_error_messages.dart` 的 `error is SyncAuthError && l.contains('auth')` 对
   `'authentication failed'` 恒真 → 403 被渲染成「登录已过期，请重新登录」。
2. `manual_sync_ui.dart` 的 `on SyncAuthError catch` **无条件** `signOut` —— 一条服务端
   策略就能把用户好端端的会话踢下线。

**为什么不拆类**：仓库里 20 处 `on SyncAuthError` / `is SyncAuthError` 全是 rethrow /
候选轮询短路 / 登出语义（`ftp_sync_backend.dart` 13 处、`sftp_sync_backend.dart:526`
`_guarded`、`interconnect_sync_backend.dart:72/98` 探测短路、`sync_manager.dart:204`）。
拆新类会让它们**静默停止捕获 403**，把「短路/上报」悄悄变成「吞掉/继续轮询」——
那正是把错误吞得更深。另外 `test/sync/pull_to_sync_wiring_guard_test.dart:99` 源码扫描
守卫硬断言 `manual_sync_ui.dart` 里必须有字面量 `on SyncAuthError catch`，改名即 CI 红。

加一个有默认值的具名字段让 30 余处既有抛出点（OAuth / 未配置 / FTP/SFTP 协议层）行为
逐字不变，`checkStatus` 的可选具名参数让 33 处调用点一行不改。

改法：
- `lib/src/sync/sync_backend.dart:37-92` — `enum SyncAuthFailureKind { credentials,
  forbidden }`；`SyncAuthError` 加 `kind`（默认 `credentials`）/ `serverReason` / `isForbidden`。
- `lib/src/sync/webdav_ops.dart:294-317` — `checkStatus(int, String, {String? serverReason})`：
  401 措辞逐字不变；403 → `forbidden` + `'Server refused (403): $context'`（把以前丢掉的
  context 带回来）+ `serverReason`。
- `lib/src/sync/webdav_ops.dart:44-64` — 新增 `readSyncErrorBody()`：**永不抛**（读原因失败
  绝不能盖掉原本要报的错）、**截到 300 字**、**5s 超时**。
- `lib/src/sync/webdav_ops.dart:117-131` / `:158-170` — `testConnection` / `propfindChildren`
  的 403 读体当原因。401 的判定仍**先于**任何流读取（反过来一个畸形错误体就能把鉴权失败
  盖成 `FormatException`）。
- `lib/src/sync/interconnect_sync_backend.dart:707-717`（BUG-1311 现场）/ `:775-782` — 错误
  路径传 `serverReason`。
- `lib/src/sync/sync_error_messages.dart:6-14` — **类型分支放 `_friendlyClause` 最前**；新
  `friendlySyncAuthFailure(kind, serverReason)` 让异常路径与报告路径共用同一套措辞。
- `lib/src/sync/manual_sync_ui.dart:60-70` — 抽出纯函数
  `shouldSignOutOnAuthError(e) => !e.isForbidden`。403 不再登出，提示照常给。
- 新 i18n `sync_err_forbidden` / `sync_err_forbidden_detail`（`tool/i18n_sync.dart --add` +
  `dart run slang`，17 语言）。

**未做（说清楚而不是硬做）**：`checkStatus` 的 33 个调用点里 18 个在调用前已
`await res.drain()`，它们的 403 仍拿不到服务端原文（但仍拿到状态码 + context，比改动前多）。
把它们全改成「错误路径先捕体再 drain」要逐个动上传/删除路径的流处理，与本缺陷无关且风险
不成比例。`checkStatus` 也保持同步签名——改成 `Future<void> checkStatus(HttpClientResponse,
...)` 会强制 33 处 `await`，并波及 `media/source_library/source_file_system.dart` 两个 sync
层之外的调用方。

## ② BUG-1324 · sync_orchestrator 把鉴权失败压成一行字符串

**值得改。粒度 = 修数据结构，不给 `:527` 打特例补丁。**

根因不是那一行 catch，是 `SyncRunReport.errors` 的 `List<String>`：`$e` 拼进字符串的那一刻
类型就死了。而唯一的用户可见消费方 `summarizeSyncReport` **只读 `errors.length`** ——
所以无论错误里写了什么，用户永远只看到「同步完成 · 无新增 · 1 项失败」。

改法：
- `lib/src/sync/sync_orchestrator.dart:191-197` — 新增 `List<SyncAuthFailure> authFailures`，
  与 `errors` **并存**（日志行一字不变，信息只增不减）。
- `:240-268` — `noteError(String label, Object error)`：字符串照旧
  `errors.add('$label: $error')`，若是 `SyncAuthError` 则**额外**留一份带类型的；按
  (kind, message, serverReason) 去重（一次 401 会让几百本书逐本失败，用户只需知道一次）。
  `mergeFrom` 同步合并去重。
- 全文 **31 处** `report.errors.add('<label>: $e')` 机械改为 `report.noteError('<label>', e)`，
  产出字符串逐字节相同。界线是「这个 catch 手里有没有异常对象」：剩下 5 处
  （`:800/:1064/:1926/:2123/:2180`）压根没有异常（「host 没有该端点」「本地文件不存在」这类
  自述性错误），没有类型可分流，保持原样。
- `lib/src/sync/manual_sync_ui.dart:37-52` — `summarizeSyncReport` 在「N 项失败」后追加那句
  可操作的话。无鉴权失败时输出**逐字不变**。

**未做**：`errors` 没有换成结构化列表——`logSyncReportErrors`、`summarizeSyncReport` 和十余个
`expect(report.errors, isEmpty)` 都依赖它，收益全部可由并存的 `authFailures` 拿到。

## 用户在两种情况下分别看到什么

| | 凭据错（401 / 未配置 / OAuth 失效） | 服务端拒绝（403） |
|---|---|---|
| 弹出提示 | `sync_err_auth_expired`「登录已过期，请重新登录。」**逐字未变** | `sync_err_forbidden_detail`「服务端拒绝了这次请求：**HTTPS required for service config**（登录没问题）」；服务端没说话时 `sync_err_forbidden`「…登录没问题，请检查服务端设置。」 |
| 会话 | `signOut` + `clearCache` + `clearFolderCache`（TODO-836 契约不变） | **不动**。凭据是好的，不该被一条服务端策略毁掉 |
| 同步摘要 | 「同步完成 · 无新增 · 1 项失败 · 登录已过期，请重新登录。」 | 「同步完成 · 无新增 · 1 项失败 · 服务端拒绝了这次请求：HTTPS required for service config（登录没问题）」 |
| 异常里留下什么 | `kind: credentials`，message 逐字不变 | `kind: forbidden`、`'Server refused (403): <操作>'`、`serverReason: <服务端原文>` |

## 测试

新增 `hibiki/test/sync/sync_auth_error_kind_test.dart`（**27 test**）。不只断类型——起真
`HttpServer` 回 403 + 响应体，验原文一路到达；文案一律与 i18n getter 比较（语言无关）。
含负向：Google Drive 的 `insufficient_scope`（不经 `checkStatus`）仍走
`sync_err_scope_upgrade`；404/5xx/2xx 契约不变；`SyncBackendError` / `FormatException`
不进 `authFailures`；零失败与非鉴权失败时摘要逐字不变。

「403 的分流按类型走，不靠消息里有没有 auth 字样」这条故意用 message
`'authentication context: refused'` —— 把类型分支删掉它就会被字符串层抓成「登录已过期」。

### 变异实测（5 组，两个方向；还原一律用反向文本替换，未对未提交文件 `git checkout --`）

| # | 变异 | 结果 |
|---|---|---|
| 1 | `checkStatus` 的 403 合并回 `401 \|\| 403` | **+25 -2** red |
| 2 | 删掉 `_friendlyClause` 的类型分支 | **+22 -3** red |
| 3 | `shouldSignOutOnAuthError` 改成 `=> true` | **+26 -1** red |
| 4 | `noteError` 丢弃鉴权类型（等价回到裸 `errors.add`） | **+21 -6** red |
| 5 | `testConnection` 的 403 不读响应体（`serverReason: null`） | **+25 -2** red |
| — | 逐条反向替换还原 | `git status --short` 与 `git diff --stat` **均为空**，**27 全绿** |

### 验证

- `flutter analyze`（含 test）→ `No issues found!`
- `flutter test test/sync test/anki --no-pub` → **`+2059: All tests passed!`**
- develop 上既有的 `horizontal_drag_scroll_guard` 红（等 PR#635）不在本次触及范围。

真机验证未做。
