### PR TITLE
test(guard): 守卫健壮性收尾两项——B 类要求型锚点抬到契约 + 17 份手写注释剥离迁到词法扫描 (TODO-2457 / TODO-2473)

### DIFF
--- a/hibiki/test/anki/lapis_settings_page_guard_test.dart
+++ b/hibiki/test/anki/lapis_settings_page_guard_test.dart
@@ -10,17 +10,14 @@
 //
 // 这两条都是时序/生命周期，widget 测试要真跑整个 Anki 设置页（依赖 AppModel /
 // 平台通道），源码扫描是本仓能落地的最强层。
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 
 /// 去掉整行 `//` 注释：本守卫按「先后顺序」判定，注释里出现 `await` /
 /// `dispose` 这些词会污染下标比较（守卫自己的说明文字就带这些词）。
-String _stripLineComments(String source) => const LineSplitter()
-    .convert(source)
-    .where((String line) => !line.trimLeft().startsWith('//'))
-    .join(' ');
+String _stripLineComments(String source) => maskComments(source);
 
 /// 从 [source] 里截取名为 [name] 的方法体（从签名行到与之配对的右花括号）。
 ///

--- a/hibiki/test/helpers/source_guard.dart
+++ b/hibiki/test/helpers/source_guard.dart
@@ -187,6 +187,32 @@ String maskCssComments(String source) => _mask(
       maskStringContent: false,
     );
 
+/// [maskComments] 的保守超集：额外把**整行以 `//` 开头**的行也掩成等长空白，
+/// 包括落在 Dart 三引号串里的那些。
+///
+/// 为什么需要它：本仓有一批 Dart 文件把大段 JS/CSS 放在三引号串里
+/// （`reader_hibiki/webview.part.dart`、`reader_visual_novel_scripts.dart`、
+/// `reader_content_styles.dart`）。[maskComments] **按设计保留串内容**（这样
+/// `'https://x'` 里的 `//` 才不会被当注释砍掉），代价是串内的 JS 注释也原样留着，
+/// 于是扫描这些语料的守卫会被一条 JS 注释骗绿 / 误红。
+///
+/// 这些守卫原来手写的剥离是「整行以 `//` 开头就丢掉」，正好能吃掉串内 JS 注释，
+/// 但既不认块注释、也不认行尾注释。本函数取两者的并集：Dart 词法掩码 **加**
+/// 整行 `//`，两侧都不放松，且仍然等长。
+///
+/// 它**不是**完整的 JS 词法器：JS 的行尾注释、模板串、正则字面量（`/^a\/\//i`
+/// 里的 `//`）都不处理。要在 JS 上做逐 token 判定，需要单独的 JS 掩码原语。
+String maskCommentsAndScriptLines(String source) {
+  final List<String> masked = maskComments(source).split('\n');
+  final List<String> original = source.split('\n');
+  for (int i = 0; i < masked.length; i++) {
+    if (original[i].trimLeft().startsWith('//')) {
+      masked[i] = ' ' * masked[i].length;
+    }
+  }
+  return masked.join('\n');
+}
+
 // ---------------------------------------------------------------------------
 // 窗口原语
 // ---------------------------------------------------------------------------

--- a/hibiki/test/helpers/source_guard.dart
+++ b/hibiki/test/helpers/source_guard.dart
@@ -306,6 +306,179 @@ bool containsIdentifierCall(
   ).hasMatch(maskComments(source));
 }
 
+/// 一次调用 `Name(...)` 的结构切片。
+class EnclosingCall {
+  const EnclosingCall({
+    required this.name,
+    required this.text,
+    required this.start,
+    required this.end,
+  });
+
+  /// 被调标识符，含命名构造器（`SettingsCustomItem` / `EdgeInsets.symmetric`）。
+  /// 匿名调用（`(fn)(x)`）取不到名字时是空串。
+  final String name;
+
+  /// `Name(...)` 的完整原文切片（含结尾右括号）。
+  final String text;
+
+  /// [text] 在原串中的起止下标（[end] 为右括号后一位）。
+  final int start;
+  final int end;
+}
+
+/// 取 [src] 中下标 [index] 所在的**最内层调用**。
+///
+/// 用来替掉两类塌陷窗口：
+/// - `src.substring(anchor, anchor + 520)` 这种**定长字符窗口**——被守的那一项一旦
+///   多写两行属性，`group:` 就漂出窗口、守卫凭空变假；反过来项变短又会把**下一项**
+///   的属性读进来，断言指向错误对象。
+/// - `'SettingsCustomItem(\n            id: ...'` 这种把**缩进与换行写进锚点**的
+///   字面量——`dart format` 重排或多包一层就红，而守的根本不是格式。
+///
+/// 换成本函数后窗口由括号配对给出：断言的是「这个 id 落在哪个构造器里 / 这个构造器
+/// 体内有什么」，与长度、缩进、属性顺序全部无关。
+///
+/// 配对跑在掩码串上，注释与字符串里的括号不参与。方括号 / 花括号忽略不计——它们在
+/// 实参内部总是配平的，跳过后拿到的就是最近一层**调用**括号。
+EnclosingCall enclosingCall(String src, int index) {
+  final String structural = maskCommentsAndStrings(src);
+  if (index < 0 || index >= structural.length) {
+    fail('enclosingCall 的下标越界：$index');
+  }
+  int depth = 0;
+  int open = -1;
+  for (int i = index - 1; i >= 0; i--) {
+    final String c = structural[i];
+    if (c == ')') depth++;
+    if (c == '(') {
+      if (depth == 0) {
+        open = i;
+        break;
+      }
+      depth--;
+    }
+  }
+  if (open < 0) {
+    fail('下标 $index 不在任何调用的实参里（找不到未配对的左括号）');
+  }
+  // 名字：跳过空白 →（可选）泛型实参 → 标识符 / 点链。
+  int nameEnd = open;
+  while (nameEnd > 0 && structural[nameEnd - 1].trim().isEmpty) {
+    nameEnd--;
+  }
+  if (nameEnd > 0 && structural[nameEnd - 1] == '>') {
+    int generic = 0;
+    while (nameEnd > 0) {
+      final String c = structural[nameEnd - 1];
+      if (c == '>') generic++;
+      if (c == '<') {
+        generic--;
+        if (generic == 0) {
+          nameEnd--;
+          break;
+        }
+      }
+      nameEnd--;
+    }
+    while (nameEnd > 0 && structural[nameEnd - 1].trim().isEmpty) {
+      nameEnd--;
+    }
+  }
+  int nameStart = nameEnd;
+  while (nameStart > 0 &&
+      (_identifierChar.hasMatch(structural[nameStart - 1]) ||
+          structural[nameStart - 1] == '.')) {
+    nameStart--;
+  }
+  int close = -1;
+  int forward = 0;
+  for (int i = open; i < structural.length; i++) {
+    if (structural[i] == '(') forward++;
+    if (structural[i] == ')') {
+      forward--;
+      if (forward == 0) {
+        close = i;
+        break;
+      }
+    }
+  }
+  if (close < 0) {
+    fail('下标 $index 所在调用的括号不配对');
+  }
+  final String name =
+      nameStart < nameEnd ? src.substring(nameStart, nameEnd) : '';
+  final int start = nameStart < nameEnd ? nameStart : open;
+  return EnclosingCall(
+    name: name,
+    text: src.substring(start, close + 1),
+    start: start,
+    end: close + 1,
+  );
+}
+
+/// [enclosingCall] 的定位版：先在**代码**里找 [anchor]（注释/字符串内容里的同名
+/// 文本不算数），再取它所在的调用。
+///
+/// [anchor] 找不到直接 `fail`，不会像 `indexOf` 返回 -1 那样把 `substring` 变成
+/// RangeError 或把窗口静默锚到文件头。
+EnclosingCall enclosingCallOf(String src, String anchor, {int searchFrom = 0}) {
+  final int index = maskComments(src).indexOf(anchor, searchFrom);
+  if (index < 0) {
+    fail('源码中找不到锚点（注释内的同名文本不算）：$anchor');
+  }
+  return enclosingCall(src, index);
+}
+
+/// 取 [src] 里所有以**实参身份**出现的命名参数 `label:` 的实参表达式原文。
+///
+/// 用于把「间距必须来自设计令牌」这类契约从**逐条字面量拼写**抬上来。旧写法要
+/// `contains('insetPadding: EdgeInsets.symmetric(')` 加 `contains('horizontal:
+/// tokens.spacing.card')` 三条各自扫全文件（三条命中的还可能是三个互不相干的位置），
+/// 外加一串 `isNot(contains('const EdgeInsets.symmetric(horizontal: 16, vertical:
+/// 16)'))` —— 后者只堵住**一种**拼写，把 16 改成 20 就静默放行。
+///
+/// 拿到实参表达式后直接断言「里面没有数字字面量」「引用了 tokens.spacing.」，与
+/// 换行、参数顺序、用哪个 `EdgeInsets` 构造器全部无关。
+///
+/// 只认实参位置（前一个非空白字符是 `(` / `,` / `{`），因此
+/// `cond ? insetPadding : other` 这类表达式里的同名标识符不会被误当命名参数；
+/// map 字面量的 `'insetPadding':` 因为键是字符串、已被掩码，同样不会命中。
+List<String> namedArgumentValues(String src, String label) {
+  final String structural = maskCommentsAndStrings(src);
+  final List<String> values = <String>[];
+  final RegExp pattern = RegExp(
+    r'(?<![A-Za-z0-9_$])' + RegExp.escape(label) + r'\s*:',
+  );
+  for (final RegExpMatch match in pattern.allMatches(structural)) {
+    int before = match.start;
+    while (before > 0 && structural[before - 1].trim().isEmpty) {
+      before--;
+    }
+    if (before == 0) continue;
+    final String prev = structural[before - 1];
+    if (prev != '(' && prev != ',' && prev != '{') continue;
+    int i = match.end;
+    while (i < structural.length && structural[i].trim().isEmpty) {
+      i++;
+    }
+    final int valueStart = i;
+    int depth = 0;
+    while (i < structural.length) {
+      final String c = structural[i];
+      if (c == '(' || c == '[' || c == '{') depth++;
+      if (c == ')' || c == ']' || c == '}') {
+        if (depth == 0) break;
+        depth--;
+      }
+      if (c == ',' && depth == 0) break;
+      i++;
+    }
+    values.add(src.substring(valueStart, i));
+  }
+  return values;
+}
+
 /// 截出 `switch` 里某个 `case` 标签到**下一个 case / default / switch 结束**之间
 /// 的分支体。
 ///

--- a/hibiki/test/helpers/source_guard_lexer_test.dart
+++ b/hibiki/test/helpers/source_guard_lexer_test.dart
@@ -179,4 +179,99 @@ final b = \'\'\'{ js }\'\'\';
       );
     });
   });
+
+  group('enclosingCall：窗口由括号配对给出，不靠定长/相邻声明', () {
+    const String src = '''
+    SettingsCustomItem(
+      // 说明：换行与缩进都不该进契约
+      id: 'sync.mode',
+      title: t.sync_mode,
+      children: <Widget>[
+        Text('sync.mode'),
+      ],
+    ),
+    SettingsSwitchItem(
+      id: 'sync.statistics',
+    ),
+''';
+
+    test('取到最内层调用的名字（跨注释、跨嵌套集合字面量）', () {
+      expect(
+          enclosingCallOf(src, "id: 'sync.mode'").name, 'SettingsCustomItem');
+      expect(
+        enclosingCallOf(src, "id: 'sync.statistics'").name,
+        'SettingsSwitchItem',
+      );
+    });
+
+    test('窗口止于该调用的右括号，不会读进下一项', () {
+      final String body = enclosingCallOf(src, "id: 'sync.mode'").text;
+      expect(body.contains('t.sync_mode'), isTrue);
+      expect(body.contains("id: 'sync.statistics'"), isFalse);
+    });
+
+    test('锚点只认代码，注释里的同名文本不算数', () {
+      const String commented = '''
+    Wrapper(
+      // id: 'sync.mode' 这是注释
+      other: 1,
+    ),
+    RealItem(
+      id: 'sync.mode',
+    ),
+''';
+      expect(enclosingCallOf(commented, "id: 'sync.mode'").name, 'RealItem');
+    });
+
+    test('命名构造器与泛型实参都算进名字', () {
+      const String generic = 'AdaptiveRow<int>(value: 1)';
+      expect(enclosingCallOf(generic, 'value:').name, 'AdaptiveRow');
+      const String named = 'EdgeInsets.symmetric(horizontal: 4)';
+      expect(
+          enclosingCallOf(named, 'horizontal:').name, 'EdgeInsets.symmetric');
+    });
+
+    test('找不到锚点时 fail，绝不静默锚到文件头', () {
+      expect(
+        () => enclosingCallOf('Foo(bar: 1)', 'nope:'),
+        throwsA(isA<TestFailure>()),
+      );
+    });
+  });
+
+  group('namedArgumentValues：取实参表达式而不是拼写', () {
+    test('跨换行取整段实参，顶层逗号定右边界', () {
+      const String src = '''
+      Dialog(
+        insetPadding: EdgeInsets.symmetric(
+          horizontal: tokens.spacing.card,
+          vertical: tokens.spacing.gap,
+        ),
+        child: body,
+      )
+''';
+      final List<String> values = namedArgumentValues(src, 'insetPadding');
+      expect(values.length, 1);
+      expect(values.single.contains('tokens.spacing.card'), isTrue);
+      expect(values.single.contains('child: body'), isFalse);
+    });
+
+    test('注释与字符串里的同名参数不算数', () {
+      const String src = '''
+      Dialog(
+        // insetPadding: EdgeInsets.all(16),
+        title: 'insetPadding: EdgeInsets.all(16)',
+        insetPadding: EdgeInsets.zero,
+      )
+''';
+      final List<String> values = namedArgumentValues(src, 'insetPadding');
+      expect(values.length, 1);
+      expect(values.single, 'EdgeInsets.zero');
+    });
+
+    test('非实参位置的同名标识符不算数（三元表达式）', () {
+      const String src = 'final x = flag ? insetPadding : other;';
+      expect(namedArgumentValues(src, 'insetPadding'), isEmpty);
+    });
+  });
 }

--- a/hibiki/test/helpers/source_guard_lexer_test.dart
+++ b/hibiki/test/helpers/source_guard_lexer_test.dart
@@ -274,4 +274,33 @@ final b = \'\'\'{ js }\'\'\';
       expect(namedArgumentValues(src, 'insetPadding'), isEmpty);
     });
   });
+
+  group('maskCommentsAndScriptLines：吃掉三引号串里的整行 JS 注释', () {
+    const String src = '''
+final String js = \'\'\'
+  // window.hoshiReader.paginate('forward')
+  const url = 'https://hoshi.local/x';
+\'\'\';
+''';
+
+    test('等长且行数守恒', () {
+      expect(maskCommentsAndScriptLines(src).length, src.length);
+      expect(
+        maskCommentsAndScriptLines(src).split('\n').length,
+        src.split('\n').length,
+      );
+    });
+
+    test('串内整行 JS 注释被掩掉（maskComments 会原样保留）', () {
+      expect(maskComments(src).contains('paginate'), isTrue);
+      expect(maskCommentsAndScriptLines(src).contains('paginate'), isFalse);
+    });
+
+    test('串里的 URL 不被砍（旧手写「按首个 // 截断」会砍）', () {
+      expect(
+        maskCommentsAndScriptLines(src).contains('https://hoshi.local/x'),
+        isTrue,
+      );
+    });
+  });
 }

--- a/hibiki/test/lookup/global_lookup_hotkey_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_hotkey_guard_test.dart
@@ -1,7 +1,7 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 
 /// BUG-518 / TODO-1086 — source-scan guards for the app-OUTSIDE global lookup
 /// hotkey (Ctrl+Alt+D) reliability on Windows.
@@ -196,11 +196,4 @@ void main() {
 /// Removes `//` line comments so a source-scan assertion inspects CODE only
 /// (doc comments may legitimately mention a forbidden call to explain its
 /// removal).
-String _stripLineComments(String source) {
-  final StringBuffer out = StringBuffer();
-  for (final String line in const LineSplitter().convert(source)) {
-    final int c = line.indexOf('//');
-    out.writeln(c >= 0 ? line.substring(0, c) : line);
-  }
-  return out.toString();
-}
+String _stripLineComments(String source) => maskComments(source);

--- a/hibiki/test/media/audiobook/image_chapter_pause_cancel_test.dart
+++ b/hibiki/test/media/audiobook/image_chapter_pause_cancel_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:just_audio_platform_interface/just_audio_platform_interface.dart';
+import '../../helpers/source_guard.dart';
 
 /// TODO-2389 / TODO-2369：`AudiobookPlayerController.awaitImageChapterPause`
 /// 的两个坑。
@@ -265,59 +266,7 @@ void main() {
 
 /// 把 Dart 源码里的行注释 / 块注释替换成等长空白（保持偏移可读），字符串字面量
 /// 内的 `//` 不当注释。
-String _stripDartComments(String source) {
-  final StringBuffer out = StringBuffer();
-  int i = 0;
-  while (i < source.length) {
-    final String ch = source[i];
-    if (ch == '/' && i + 1 < source.length) {
-      final String next = source[i + 1];
-      if (next == '/') {
-        while (i < source.length && source[i] != '\n') {
-          out.write(' ');
-          i++;
-        }
-        continue;
-      }
-      if (next == '*') {
-        while (i < source.length &&
-            !(source[i] == '*' &&
-                i + 1 < source.length &&
-                source[i + 1] == '/')) {
-          out.write(source[i] == '\n' ? '\n' : ' ');
-          i++;
-        }
-        if (i < source.length) {
-          out.write('  ');
-          i += 2;
-        }
-        continue;
-      }
-    }
-    if (ch == "'" || ch == '"') {
-      final String quote = ch;
-      out.write(ch);
-      i++;
-      while (i < source.length) {
-        if (source[i] == r'\') {
-          out.write(source[i]);
-          if (i + 1 < source.length) out.write(source[i + 1]);
-          i += 2;
-          continue;
-        }
-        out.write(source[i]);
-        final bool closing = source[i] == quote;
-        final bool lineBreak = source[i] == '\n';
-        i++;
-        if (closing || lineBreak) break;
-      }
-      continue;
-    }
-    out.write(ch);
-    i++;
-  }
-  return out.toString();
-}
+String _stripDartComments(String source) => maskComments(source);
 
 class _Harness {
   _Harness({

--- a/hibiki/test/pages/continue_cover_portrait_guard_test.dart
+++ b/hibiki/test/pages/continue_cover_portrait_guard_test.dart
@@ -129,9 +129,4 @@ String _functionSource(String source, String startToken) {
 }
 
 /// 剥掉整行注释（含行内 `//` 到行尾）：断言字面量写进注释不得让守卫假绿。
-String _stripLineComments(String source) {
-  return source
-      .split('\n')
-      .map((String line) => line.replaceFirst(RegExp(r'//.*$'), ''))
-      .join('\n');
-}
+String _stripLineComments(String source) => maskComments(source);

--- a/hibiki/test/pages/reader_appearance_sheet_no_sync_guard_static_test.dart
+++ b/hibiki/test/pages/reader_appearance_sheet_no_sync_guard_static_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'reader_hibiki_page_source_corpus.dart';
+import '../helpers/source_guard.dart';
 
 void main() {
   // BUG-021: 阅读器底栏「调整」面板打开慢半拍。
@@ -62,9 +63,4 @@ String _functionSource(String source, String start, String end) {
   return source.substring(startIndex, endIndex);
 }
 
-String _stripLineComments(String source) {
-  return source.split('\n').map((String line) {
-    final int i = line.indexOf('//');
-    return i >= 0 ? line.substring(0, i) : line;
-  }).join('\n');
-}
+String _stripLineComments(String source) => maskCommentsAndScriptLines(source);

--- a/hibiki/test/pages/reader_appearance_sheet_reentrancy_guard_static_test.dart
+++ b/hibiki/test/pages/reader_appearance_sheet_reentrancy_guard_static_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'reader_hibiki_page_source_corpus.dart';
+import '../helpers/source_guard.dart';
 
 void main() {
   // BUG-026: 快速连点底栏「调整」会弹出两个面板。
@@ -72,9 +73,4 @@ String _functionSource(String source, String start, String end) {
   return source.substring(startIndex, endIndex);
 }
 
-String _stripLineComments(String source) {
-  return source.split('\n').map((String line) {
-    final int i = line.indexOf('//');
-    return i >= 0 ? line.substring(0, i) : line;
-  }).join('\n');
-}
+String _stripLineComments(String source) => maskCommentsAndScriptLines(source);

--- a/hibiki/test/pages/reader_focus_chrome_excluded_static_test.dart
+++ b/hibiki/test/pages/reader_focus_chrome_excluded_static_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 
 /// TODO-700 T8 源码守卫：阅读器底栏退出焦点遍历池（焦点的唯一家是正文）。
 ///
@@ -16,20 +17,20 @@ import 'package:flutter_test/flutter_test.dart';
 /// 整页含真实 `InAppWebView` 平台视图，widget 测试无法挂载整页观测真实焦点遍历，
 /// 故以源码结构守卫钉死不变式；任一退回，对应断言红。
 void main() {
-  String chromeSource() => File(
+  /// 四个 test 一律扫**掩码后**的源。
+  ///
+  /// 本文件守的是「死分支必须整段删除」，而记录这些删除的散文注释天然会复述被删
+  /// 写法（chrome.part.dart 里 `ExcludeFocus` 有 3 处出现在注释里）。原来只有最后
+  /// 一个 test 剥了注释，另外三个裸扫：`allMatches(...).length == 1` 这条计数断言
+  /// 当时之所以没红，仅仅因为其中一条注释恰好写成 `ExcludeFocus (see`——括号前多了
+  /// 一个空格。删掉那个空格守卫立刻假红。掩码等长，计数语义不变。
+  String chromeSource() => maskCommentsAndScriptLines(File(
         'lib/src/pages/implementations/reader_hibiki/chrome.part.dart',
-      ).readAsStringSync().replaceAll('\r\n', '\n');
+      ).readAsStringSync().replaceAll('\r\n', '\n'));
 
-  String caretSource() => File(
+  String caretSource() => maskCommentsAndScriptLines(File(
         'lib/src/pages/implementations/reader_hibiki/caret.part.dart',
-      ).readAsStringSync().replaceAll('\r\n', '\n');
-
-  // 去掉 `//` 行注释，使断言匹配真实代码而非记录被删路径的散文
-  // （散文里会出现 `moveFocusToChrome` 字样）。
-  String stripLineComments(String source) => source
-      .split('\n')
-      .where((String line) => !line.trimLeft().startsWith('//'))
-      .join('\n');
+      ).readAsStringSync().replaceAll('\r\n', '\n'));
 
   test('两条底栏（有声书条 + 设置条）经单一 _wrapBottomChromeBar 外壳被 ExcludeFocus 包住', () {
     final String chrome = chromeSource();
@@ -91,7 +92,7 @@ void main() {
   });
 
   test('_toggleChrome 不再把焦点搬进底栏（moveFocusToChrome 路径已删）', () {
-    final String chrome = stripLineComments(chromeSource());
+    final String chrome = chromeSource();
     expect(
       chrome.contains('moveFocusToChrome'),
       isFalse,

--- a/hibiki/test/pages/webview2_event_handler_alive_guard_static_test.dart
+++ b/hibiki/test/pages/webview2_event_handler_alive_guard_static_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 
 /// Source-level guard for BUG-457 / TODO-964 — WebView2 event handlers in the
 /// Windows inappwebview fork dereferencing a freed `this` after
@@ -124,11 +125,4 @@ void main() {
 /// real code, not the prose documenting the guards (which mentions the very
 /// symbols we assert on, e.g. a commented-out add_ServerCertificateErrorDetected
 /// block).
-String _stripCppComments(String source) {
-  final String noBlock =
-      source.replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '');
-  return noBlock
-      .split('\n')
-      .where((String line) => !line.trimLeft().startsWith('//'))
-      .join('\n');
-}
+String _stripCppComments(String source) => maskComments(source);

--- a/hibiki/test/pages/webview_controller_double_dispose_static_test.dart
+++ b/hibiki/test/pages/webview_controller_double_dispose_static_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'reader_hibiki_page_source_corpus.dart';
+import '../helpers/source_guard.dart';
 
 /// Codebase-wide invariant guard (all platforms).
 ///
@@ -69,9 +70,4 @@ void main() {
 
 /// Drops `//` line comments so source-text assertions match real code, not the
 /// explanatory prose that documents the removed call.
-String _stripLineComments(String source) {
-  return source
-      .split('\n')
-      .where((String line) => !line.trimLeft().startsWith('//'))
-      .join('\n');
-}
+String _stripLineComments(String source) => maskCommentsAndScriptLines(source);

--- a/hibiki/test/reader/reader_image_lazy_pipeline_guard_test.dart
+++ b/hibiki/test/reader/reader_image_lazy_pipeline_guard_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_resource_sanitizer.dart';
+import '../helpers/source_guard.dart';
 
 /// BUG-1140 第二轮守卫：`loading` 属性的**Dart 侧**流水线。
 ///
@@ -26,10 +27,7 @@ void main() {
 
   /// 去掉 `//` 行注释再扫——否则「注释里写了 `loading="eager"`」也能让守卫变绿，
   /// 而真正 emit 的标签已经没有这个属性了（本守卫的负向验证踩过这个坑）。
-  String stripLineComments(String s) => s
-      .split('\n')
-      .where((String l) => !l.trimLeft().startsWith('//'))
-      .join('\n');
+  String stripLineComments(String s) => maskCommentsAndScriptLines(s);
 
   group('TODO-1339：合并前导插图的 eager 不再靠调用顺序', () {
     test('_injectMergedChapterImages 注入的 <img> 自带 loading="eager"', () {

--- a/hibiki/test/reader/reader_mining_race_guard_test.dart
+++ b/hibiki/test/reader/reader_mining_race_guard_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import '../pages/reader_hibiki_page_source_corpus.dart';
+import '../helpers/source_guard.dart';
 
 /// TODO-644 / BUG-357 回归守卫：制卡并发 race（句子/cue 句 + 加粗偏移错配）。
 ///
@@ -13,12 +14,7 @@ import '../pages/reader_hibiki_page_source_corpus.dart';
 ///    两次 prepare→mine 在 await 处交错。
 /// 去掉每行 `//` 之后的内容（足以避免说明性注释里出现的标识符被源码守卫误命中；
 /// 字符串字面量里的 `//` 在本文件扫描的目标区域不出现，无需更复杂的词法分析）。
-String _stripLineComments(String code) {
-  return code.split('\n').map((String line) {
-    final int slash = line.indexOf('//');
-    return slash >= 0 ? line.substring(0, slash) : line;
-  }).join('\n');
-}
+String _stripLineComments(String code) => maskCommentsAndScriptLines(code);
 
 void main() {
   late String source;

--- a/hibiki/test/reader/vn_view_mode_three_state_guard_test.dart
+++ b/hibiki/test/reader/vn_view_mode_three_state_guard_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
+import '../helpers/source_guard.dart';
 
 /// TODO-909 源码守卫（源码扫描，沿用仓库既有 `File(...).readAsStringSync()` +
 /// `contains` 模式）。
@@ -332,12 +333,7 @@ String _extractCssBlock(String css, String selector) {
   return css.substring(selIdx, endIdx + 1);
 }
 
-String _stripLineComments(String source) {
-  return source.split('\n').map((String line) {
-    final int idx = line.indexOf('//');
-    return idx >= 0 ? line.substring(0, idx) : line;
-  }).join('\n');
-}
+String _stripLineComments(String source) => maskCommentsAndScriptLines(source);
 
 bool _hasGenerationAwareRestoreCall(String source) {
   return RegExp(

--- a/hibiki/test/settings/md3_dialog_chrome_merged_static_test.dart
+++ b/hibiki/test/settings/md3_dialog_chrome_merged_static_test.dart
@@ -1,287 +1,400 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
 import '../pages/reader_history_source_corpus.dart';
 
 /// 合并守卫：MD3 对话框壳（HibikiDialogFrame / HibikiModalSheetFrame / 设计令牌）
 /// 一致性静态守卫。原来每个对话框各占一个 *_md3_static_test.dart 文件，断言同形但
-/// 各自钉死本文件差异化的 inline-state spacing / insetPadding / EdgeInsets 切片标记，
-/// 无法用共享断言列表替代。此文件把每个源文件的全部 test() 块**逐字**搬进来，用
-/// group() 按源文件包裹以保失败隔离，断言与 reason 文案一律原样保留。
+/// 各自钉死本文件差异化的 inline-state spacing / insetPadding / EdgeInsets 切片标记。
+///
+/// 【B 类要求型锚点整改，2026-08-01】本文件原来 43 条断言全部是
+/// `expect(rawSource, contains('实现写法字面量'))`，四类塌陷同时存在：
+///
+/// 1. **零词法防护**：读的是原始源码。把 `HibikiDialogFrame(` 写进任意一条注释，
+///    整组要求型断言当场变绿——要求型锚点最典型的假绿。现在一律先过
+///    [maskCommentsAndStrings]（本文件锚点全是代码标识符，没有一条需要读串内容）。
+/// 2. **锚点即写法**：`'HibikiDialogFrame('` 漏命名构造器形态、又被
+///    `XxxHibikiDialogFrame(` 假命中；`'HibikiDesignTokens.of(context)'` 把**局部
+///    变量名** `context` 写进了契约；`'return IconButton(' / 'child: IconButton(' /
+///    'trailing: IconButton(' / 'suffixIcon: IconButton('` 四条前缀只是为了绕开
+///    `HibikiIconButton(` 含子串 `IconButton(`，换个调用位置就整条漏。全部换成带
+///    标识符边界的 [containsIdentifierCall]，四条前缀合并成一条「不得裸用
+///    IconButton（含 `IconButton.filledTonal(`）」。
+/// 3. **间距契约钉死拼写**：`contains('insetPadding: EdgeInsets.symmetric(')` +
+///    `contains('horizontal: tokens.spacing.card')` + `contains('vertical: …')`
+///    三条各自扫全文件（可以命中三个互不相干的位置），配一串
+///    `isNot(contains('const EdgeInsets.symmetric(horizontal: 16, vertical: 16)'))`
+///    ——后者只堵一种拼写，16 改成 20 就静默放行。换成 [namedArgumentValues] 取出
+///    每个 `insetPadding:` / `padding:` / `margin:` 的**实参表达式**，断言它取自
+///    `tokens.spacing.` 且没有裸数字实参：与换行、参数顺序、哪个 EdgeInsets 构造器
+///    全部无关，且覆盖所有硬编码拼写而不是枚举出来的那几种。
+/// 4. **窗口靠相邻声明**：`substring(0, indexOf('Widget _buildFetchTile'))` 把
+///    **返回类型**写进了锚点（改成 `Future<Widget>` 就 `indexOf` 返回 -1 →
+///    `substring(0, -1)` 抛 RangeError）；`_between(…, '下一个类名')` 只要下一个类
+///    改名或中间插一个类就整体漂移。换成 [methodBody] 按花括号配对取**类体**，
+///    并把「谁负责什么」拆成各自作用域的断言。
 void main() {
   group('anki_handlebar_picker_dialog_md3_static', () {
     test('anki settings page uses MD3 spacing tokens for inline states', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/anki_settings_page.dart',
-      ).readAsStringSync();
-      final String pageSource =
-          source.substring(0, source.indexOf('Widget _buildFetchTile'));
+      );
+      // 契约是「设置页正文（含 inline state 行）的间距走令牌」，作用域就是页面
+      // 的 State 类，而不是「文件开头到某个 helper 首现处」这段偶然切片。
+      final String pageCode = methodBody(code, 'class _AnkiSettingsBodyState');
 
-      expect(pageSource, contains('HibikiDesignTokens.of(context)'));
       expect(
-        pageSource,
-        isNot(contains('padding: const EdgeInsets.fromLTRB(12, 0, 12, 12)')),
+        containsIdentifierCall(pageCode, 'HibikiDesignTokens'),
+        isTrue,
+        reason: 'Anki 设置页正文的尺寸必须取自设计令牌',
       );
-      expect(
-        pageSource,
-        isNot(contains('padding: const EdgeInsets.fromLTRB(16, 8, 16, 20)')),
-      );
+      _expectTokenDerivedSpacing(pageCode, 'Anki 设置页正文');
     });
 
     test(
         'anki handlebar picker dialog uses shared MD3 dialog chrome and tokens',
         () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/anki_settings_page.dart',
-      ).readAsStringSync();
-      final String dialogSource =
-          source.substring(source.indexOf('class AnkiHandlebarPickerDialog'));
-
-      expect(dialogSource, contains('HibikiDialogFrame('));
-      expect(dialogSource, contains('HibikiModalSheetFrame('));
-      expect(dialogSource, contains('HibikiDesignTokens.of(context)'));
-      expect(dialogSource, contains('insetPadding: EdgeInsets.symmetric('));
-      expect(dialogSource, contains('horizontal: tokens.spacing.card'));
-      expect(dialogSource, contains('vertical: tokens.spacing.gap'));
-      expect(dialogSource, isNot(contains('adaptiveAlertDialog(')));
-      expect(
-        dialogSource,
-        isNot(
-          contains('const EdgeInsets.symmetric(horizontal: 12, vertical: 8)'),
-        ),
       );
+      // 壳与 insetPadding 都在 State 类的 build 里；StatefulWidget 外壳类本身
+      // 不含任何 chrome，锚到它会扫到空窗口。
+      final String dialogCode =
+          methodBody(code, 'class _AnkiHandlebarPickerDialogState');
+
+      _expectMd3DialogChrome(dialogCode, 'Anki handlebar 选择对话框');
+      _expectTokenDerivedInsetPadding(dialogCode, 'Anki handlebar 选择对话框');
+      _expectTokenDerivedSpacing(dialogCode, 'Anki handlebar 选择对话框');
     });
   });
 
   group('audio_recorder_dialog_md3_static', () {
     test('audio recorder dialog uses shared MD3 dialog chrome and tokens', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/audio_recorder_page.dart',
-      ).readAsStringSync();
-
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiDesignTokens.of(context)'));
-      expect(source, contains('insetPadding: EdgeInsets.symmetric('));
-      expect(source, contains('horizontal: tokens.spacing.card'));
-      expect(source, contains('vertical: tokens.spacing.card'));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(source, isNot(contains('Spacing.of(context)')));
-      expect(
-        source,
-        isNot(
-          contains('const EdgeInsets.symmetric(horizontal: 16, vertical: 16)'),
-        ),
       );
-      expect(source, isNot(contains('const EdgeInsets.all(16)')));
+
+      _expectMd3DialogChrome(code, '录音对话框');
+      _expectNoLegacySpacingFacade(code, '录音对话框');
+      _expectTokenDerivedInsetPadding(code, '录音对话框');
+      _expectTokenDerivedSpacing(code, '录音对话框');
     });
 
     test('audio recorder player controls use shared MD3 icon buttons', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/audio_recorder_page.dart',
-      ).readAsStringSync();
+      );
 
-      expect(source, contains('HibikiIconButton('));
-      expect(source, isNot(contains('return IconButton(')));
-      expect(source, isNot(contains('child: IconButton(')));
+      _expectSharedIconButtons(code, '录音对话框');
     });
   });
 
   group('book_profile_dialog_md3_static', () {
     test('book profile dialog owns shared MD3 dialog and sheet chrome', () {
-      final String source = readReaderHistorySource();
-      final String dialogSource = _between(
-        source,
-        'class _BookProfileDialog extends StatefulWidget',
-        'class BookProfileDialogContent extends StatelessWidget',
-      );
+      final String code = maskCommentsAndStrings(readReaderHistorySource());
+      // 旧写法把「State 类 + Frame 类」拼成一段偶然区间（起点是 StatefulWidget、
+      // 终点是**下一个**类名），谁改名都会漂。改成各自作用域各断言其职责。
+      final String stateCode =
+          methodBody(code, 'class _BookProfileDialogState');
+      final String frameCode = methodBody(code, 'class BookProfileDialogFrame');
 
-      expect(dialogSource, contains('BookProfileDialogFrame('));
-      expect(dialogSource, contains('HibikiDialogFrame('));
-      expect(dialogSource, contains('HibikiModalSheetFrame('));
-      expect(dialogSource, isNot(contains('adaptiveAlertDialog(')));
+      expect(
+        containsIdentifierCall(stateCode, 'BookProfileDialogFrame'),
+        isTrue,
+        reason: '书籍 Profile 对话框必须经由共享 Frame 出壳',
+      );
+      expect(
+        containsIdentifierCall(stateCode, 'adaptiveAlertDialog'),
+        isFalse,
+        reason: '书籍 Profile 对话框不得回到旧 adaptiveAlertDialog 工厂',
+      );
+      _expectMd3DialogChrome(
+        frameCode,
+        'BookProfileDialogFrame',
+        requireTokens: false,
+      );
     });
   });
 
   group('crop_image_dialog_md3_static', () {
     test('crop image dialog uses shared MD3 dialog chrome and token spacing',
         () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/crop_image_dialog_page.dart',
-      ).readAsStringSync();
+      );
 
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiDesignTokens.of(context)'));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(source, isNot(contains('Spacing.of(context)')));
+      _expectMd3DialogChrome(code, '裁剪图片对话框');
+      _expectNoLegacySpacingFacade(code, '裁剪图片对话框');
     });
   });
 
   group('dictionary_settings_dialog_md3_static', () {
     test('dictionary settings dialogs use shared MD3 dialog chrome and tokens',
         () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/dictionary_settings_dialog_page.dart',
-      ).readAsStringSync();
-
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiDesignTokens.of(context)'));
-      expect(source, contains('insetPadding: EdgeInsets.symmetric('));
-      expect(source, contains('horizontal: tokens.spacing.card'));
-      expect(source, contains('vertical: tokens.spacing.card'));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(
-        source,
-        isNot(
-          contains('const EdgeInsets.symmetric(horizontal: 16, vertical: 16)'),
-        ),
       );
+
+      _expectMd3DialogChrome(code, '词典设置对话框');
+      _expectTokenDerivedInsetPadding(code, '词典设置对话框');
+      _expectTokenDerivedSpacing(code, '词典设置对话框');
     });
 
     test('audio source controls use shared MD3 icon buttons', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/dictionary_settings_dialog_page.dart',
-      ).readAsStringSync();
+      );
 
-      expect(source, contains('HibikiIconButton('));
-      expect(source, isNot(contains('trailing: IconButton(')));
-      expect(source, isNot(contains('suffixIcon: IconButton(')));
-      expect(source, isNot(contains('visualDensity: VisualDensity.compact')));
+      _expectSharedIconButtons(code, '词典设置对话框');
+      expect(
+        code.contains('VisualDensity.compact'),
+        isFalse,
+        reason: '词典设置对话框的行密度由共享组件决定，不得逐处压缩',
+      );
     });
   });
 
   group('media_source_picker_dialog_md3_static', () {
     test('media source picker uses shared MD3 dialog shell', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/media_source_picker_dialog_page.dart',
-      ).readAsStringSync();
+      );
 
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiListItem('));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(source, isNot(contains('Spacing.of(context)')));
+      _expectMd3DialogChrome(code, '媒体来源选择对话框', requireTokens: false);
+      expect(
+        containsIdentifierCall(code, 'HibikiListItem'),
+        isTrue,
+        reason: '媒体来源选择对话框的行必须用共享 HibikiListItem',
+      );
+      _expectNoLegacySpacingFacade(code, '媒体来源选择对话框');
     });
   });
 
   group('example_sentences_dialog_md3_static', () {
     test('example sentences dialog uses shared MD3 dialog and card chrome', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/example_sentences_dialog_page.dart',
-      ).readAsStringSync();
+      );
 
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiCard('));
-      expect(source, contains('HibikiDesignTokens.of(context)'));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(source, isNot(contains('Spacing.of(context)')));
-      expect(source, isNot(contains('GestureDetector(')));
-      expect(source, isNot(contains('Container(')));
+      _expectMd3DialogChrome(code, '例句对话框');
+      expect(
+        containsIdentifierCall(code, 'HibikiCard'),
+        isTrue,
+        reason: '例句卡片必须用共享 HibikiCard',
+      );
+      _expectNoLegacySpacingFacade(code, '例句对话框');
+      // 裸 Container / GestureDetector 是「自己糊一套卡片与点击态」的形态；
+      // 带标识符边界后不再顺带禁掉 AnimatedContainer 这类不相干的更长名字。
+      expect(
+        containsIdentifierCall(code, 'Container'),
+        isFalse,
+        reason: '例句对话框不得用裸 Container 自造卡片外观',
+      );
+      expect(
+        containsIdentifierCall(code, 'GestureDetector'),
+        isFalse,
+        reason: '例句对话框的点击态必须走共享组件的水波纹',
+      );
     });
   });
 
   group('profile_management_dialog_md3_static', () {
     test('profile management dialogs use shared MD3 dialog chrome and tokens',
         () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/profile_management_page.dart',
-      ).readAsStringSync();
-
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiDesignTokens.of(context)'));
-      expect(source, contains('insetPadding: EdgeInsets.symmetric('));
-      expect(source, contains('horizontal: tokens.spacing.card'));
-      expect(source, contains('vertical: tokens.spacing.card'));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(
-        source,
-        isNot(
-          contains('const EdgeInsets.symmetric(horizontal: 16, vertical: 16)'),
-        ),
       );
+
+      _expectMd3DialogChrome(code, 'Profile 管理对话框');
+      _expectTokenDerivedInsetPadding(code, 'Profile 管理对话框');
+      _expectTokenDerivedSpacing(code, 'Profile 管理对话框');
     });
 
     test('profile action buttons use shared MD3 icon buttons', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/profile_management_page.dart',
-      ).readAsStringSync();
+      );
+      // 旧窗口终点是 `indexOf('@visibleForTesting', …)`——一个与本类无关的注解，
+      // 谁在后面加/删一个 @visibleForTesting 就整体改形。
+      final String actionCode = methodBody(code, 'class _ProfileActionButton');
 
-      final int actionStart = source.indexOf('class _ProfileActionButton');
-      final int deleteStart = source.indexOf('@visibleForTesting', actionStart);
-      final String actionSource = source.substring(actionStart, deleteStart);
-
-      expect(actionSource, contains('HibikiIconButton('));
-      expect(actionSource, isNot(contains('return IconButton(')));
-      expect(actionSource, isNot(contains('VisualDensity.compact')));
+      _expectSharedIconButtons(actionCode, 'Profile 操作按钮');
+      expect(
+        actionCode.contains('VisualDensity.compact'),
+        isFalse,
+        reason: 'Profile 操作按钮的密度由共享 HibikiIconButton 决定',
+      );
     });
   });
 
   group('tag_management_dialog_md3_static', () {
     test('tag management dialogs use shared MD3 dialog chrome and tokens', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/tag_management_page.dart',
-      ).readAsStringSync();
+      );
 
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiDesignTokens.of(context)'));
-      expect(source, contains('insetPadding: EdgeInsets.symmetric('));
-      expect(source, contains('horizontal: tokens.spacing.card'));
-      expect(source, contains('vertical: tokens.spacing.card'));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(
-        source,
-        isNot(
-          contains('const EdgeInsets.symmetric(horizontal: 16, vertical: 16)'),
-        ),
-      );
-      expect(
-        source,
-        isNot(
-          contains('const EdgeInsets.symmetric(horizontal: 12, vertical: 8)'),
-        ),
-      );
+      _expectMd3DialogChrome(code, '标签管理对话框');
+      _expectTokenDerivedInsetPadding(code, '标签管理对话框');
+      _expectTokenDerivedSpacing(code, '标签管理对话框');
     });
   });
 
   group('text_segmentation_dialog_md3_static', () {
     test('text segmentation dialog uses shared MD3 dialog and chip chrome', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/text_segmentation_dialog_page.dart',
-      ).readAsStringSync();
+      );
 
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiSelectableChip('));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(source, isNot(contains('Spacing.of(context)')));
-      expect(source, isNot(contains('Container(')));
+      _expectMd3DialogChrome(code, '分词对话框', requireTokens: false);
+      expect(
+        containsIdentifierCall(code, 'HibikiSelectableChip'),
+        isTrue,
+        reason: '分词对话框的词块必须用共享 HibikiSelectableChip',
+      );
+      _expectNoLegacySpacingFacade(code, '分词对话框');
+      expect(
+        containsIdentifierCall(code, 'Container'),
+        isFalse,
+        reason: '分词对话框不得用裸 Container 自造词块外观',
+      );
     });
   });
 
   group('websocket_dialog_md3_static', () {
     test('websocket dialog uses shared MD3 dialog chrome', () {
-      final String source = File(
+      final String code = _readCode(
         'lib/src/pages/implementations/websocket_dialog_page.dart',
-      ).readAsStringSync();
+      );
 
-      expect(source, contains('HibikiDialogFrame('));
-      expect(source, contains('HibikiModalSheetFrame('));
-      expect(source, contains('HibikiDesignTokens.of(context)'));
-      expect(source, isNot(contains('adaptiveAlertDialog(')));
-      expect(source, isNot(contains('Spacing.of(context)')));
+      _expectMd3DialogChrome(code, 'WebSocket 对话框');
+      _expectNoLegacySpacingFacade(code, 'WebSocket 对话框');
     });
   });
 }
 
-String _between(String source, String start, String end) {
-  final int startIndex = source.indexOf(start);
-  final int endIndex = source.indexOf(end, startIndex);
-  expect(startIndex, isNonNegative, reason: 'Missing source marker: $start');
-  expect(endIndex, isNonNegative, reason: 'Missing source marker: $end');
-  return source.substring(startIndex, endIndex);
+/// 读源码并把**注释和字符串内容**一起掩成等长空白。
+///
+/// 本文件的锚点全是代码标识符，没有一条需要读字符串内容，所以掩得越干净越好：
+/// 注释里的 `HibikiDialogFrame(`、串里的 `'adaptiveAlertDialog('` 都不该算数。
+String _readCode(String path) =>
+    maskCommentsAndStrings(File(path).readAsStringSync());
+
+/// 「整个实参槽位就是一个数字字面量」的形态：`EdgeInsets.all(16)` /
+/// `symmetric(horizontal: 16, vertical: 16)` / `fromLTRB(12, 0, 12, 12)`。
+final RegExp _numericArgument = RegExp(r'[(,:]\s*(-?\d+(?:\.\d+)?)\s*[,)]');
+
+/// [expr] 里是否有**硬编码的非零间距**。
+///
+/// 两个有意的放行：
+/// - `0`：零不是「魔法尺寸」，是「此边不留白」，写 `tokens.spacing.none` 没有意义；
+/// - `tokens.spacing.card * 2`：以令牌为基准的算式仍然是令牌派生的，只有裸数字
+///   占满一整个实参槽位才算硬编码。
+///
+/// 契约是「间距来自设计令牌」，不是「表达式里不许出现数字」——后者会在下一次
+/// 合法重构时变成假红。
+bool _hasHardcodedSpacing(String expr) {
+  for (final RegExpMatch match in _numericArgument.allMatches(expr)) {
+    final double? value = double.tryParse(match.group(1)!);
+    if (value != null && value != 0) return true;
+  }
+  return false;
+}
+
+/// 该作用域内所有 `EdgeInsets` 构造都不得带裸数字实参。
+///
+/// 这一条顶掉旧守卫里逐条枚举的禁止型字面量
+/// （`const EdgeInsets.symmetric(horizontal: 16, vertical: 16)` /
+/// `fromLTRB(12, 0, 12, 12)` / `all(16)` …）：那些只堵住**被枚举到的那几种拼写**，
+/// 把 16 改成 20、或换一个构造器就静默放行。改成对每个 `EdgeInsets` 调用做结构判据，
+/// 覆盖全部硬编码写法，且不因换行/参数顺序变假。
+void _expectTokenDerivedSpacing(String code, String label) {
+  for (final RegExpMatch match
+      in identifierCall('EdgeInsets').allMatches(code)) {
+    final EnclosingCall call = enclosingCall(code, match.end);
+    expect(
+      _hasHardcodedSpacing(call.text),
+      isFalse,
+      reason: '$label 的间距不得硬编码（一律走 tokens.spacing），实际是：${call.text}',
+    );
+  }
+}
+
+void _expectMd3DialogChrome(
+  String code,
+  String label, {
+  bool requireTokens = true,
+}) {
+  expect(
+    containsIdentifierCall(code, 'HibikiDialogFrame'),
+    isTrue,
+    reason: '$label 必须用共享 MD3 对话框壳',
+  );
+  expect(
+    containsIdentifierCall(code, 'HibikiModalSheetFrame'),
+    isTrue,
+    reason: '$label 必须用共享 MD3 底部弹层壳',
+  );
+  expect(
+    containsIdentifierCall(code, 'adaptiveAlertDialog'),
+    isFalse,
+    reason: '$label 不得回到旧 adaptiveAlertDialog 工厂',
+  );
+  if (requireTokens) {
+    expect(
+      containsIdentifierCall(code, 'HibikiDesignTokens'),
+      isTrue,
+      reason: '$label 的尺寸必须取自设计令牌（`.of(context)` 的变量名不入契约）',
+    );
+  }
+}
+
+/// 对话框的 `insetPadding` 必须取自设计令牌。
+///
+/// 断言的是**实参表达式本身**，不是它在文件里的拼写：既覆盖所有硬编码写法
+/// （不止旧守卫枚举的那两三种），也不会因为换行、参数顺序或换个 EdgeInsets
+/// 构造器而变假。
+void _expectTokenDerivedInsetPadding(String code, String label) {
+  final List<String> values = namedArgumentValues(code, 'insetPadding');
+  expect(
+    values,
+    isNotEmpty,
+    reason: '$label 的对话框必须显式给出 insetPadding',
+  );
+  for (final String value in values) {
+    expect(
+      value.contains('tokens.spacing.'),
+      isTrue,
+      reason: '$label 的 insetPadding 必须取自 tokens.spacing，实际是：$value',
+    );
+  }
+}
+
+/// 旧的 `Spacing.of(context)` 间距门面已被设计令牌取代，不得复活。
+void _expectNoLegacySpacingFacade(String code, String label) {
+  expect(
+    containsIdentifierCall(code, 'Spacing'),
+    isFalse,
+    reason: '$label 不得回到旧 Spacing 门面，间距统一走 HibikiDesignTokens',
+  );
+}
+
+/// 图标按钮必须走共享 [HibikiIconButton]。
+///
+/// 旧守卫写成 `isNot(contains('return IconButton('))` 等四条**调用位置前缀**，
+/// 唯一目的是绕开「`HibikiIconButton(` 含子串 `IconButton(`」；代价是换个调用位置
+/// （`actions: <Widget>[IconButton(...)]`）就整条漏，也匹配不到
+/// `IconButton.filledTonal(`。带标识符边界后一条顶四条，且严格更强。
+void _expectSharedIconButtons(String code, String label) {
+  expect(
+    containsIdentifierCall(code, 'HibikiIconButton'),
+    isTrue,
+    reason: '$label 必须用共享 HibikiIconButton',
+  );
+  expect(
+    containsIdentifierCall(code, 'IconButton'),
+    isFalse,
+    reason: '$label 不得裸用 IconButton（含 IconButton.filledTonal 等命名构造器）',
+  );
 }

--- a/hibiki/test/settings/settings_redesign_static_test.dart
+++ b/hibiki/test/settings/settings_redesign_static_test.dart
@@ -5,8 +5,19 @@ import 'package:flutter_test/flutter_test.dart';
 import '../helpers/source_guard.dart';
 import '../sync/sync_settings_schema_source_corpus.dart';
 
+/// 读源码并把**注释**掩成等长空白，字符串字面量原样保留。
+///
+/// 【B 类要求型锚点整改，2026-08-01】本文件原来所有断言都跑在原始源码上，
+/// `expect(source, contains('X'))` 只要 X 出现在任意一条注释里就绿。整改时这条
+/// 掩码当场抓出一个**活的假绿**：`settings_home_page.dart` 要求包含
+/// `'master-detail'`，而全文件里这个词只出现在
+/// `false, // master-detail keeps selection in-pane.` 这条散文注释里——
+/// 那条断言从来没有守住任何东西。已换成真实结构锚点 `SettingsDetailPage(`。
+///
+/// 这里用 [maskComments] 而不是 [maskCommentsAndStrings]：本文件有大量
+/// `id: 'lookup.popup_instant_scroll'` 这类**要读字符串内容**的锚点。
 String readNormalizedSource(String path) {
-  return File(path).readAsStringSync().replaceAll('\r\n', '\n');
+  return maskComments(File(path).readAsStringSync().replaceAll('\r\n', '\n'));
 }
 
 /// TODO-586：settings_schema.dart 已按领域拆成 8 个 destination 文件 + 1 个共享
@@ -130,7 +141,10 @@ void main() {
     'lib/src/settings/settings_home_page.dart': <String>[
       'class SettingsHomePage',
       'DesktopContentKind.settings',
-      'master-detail',
+      // 旧锚点是散文词 'master-detail'，它在本文件里**只出现在一条注释**里
+      // （`false, // master-detail keeps selection in-pane.`）——掩掉注释后当场
+      // 露馅。主从布局的真实结构证据是它会把 destination 推进详情页。
+      'SettingsDetailPage(',
     ],
     'lib/src/settings/settings_detail_page.dart': <String>[
       'class SettingsDetailPage',
@@ -146,13 +160,13 @@ void main() {
       // TODO-585: sync_settings_schema 拆成主库 + 5 个 part；该键读合并语料，
       // 让 runManualFullSync 等搬进 part 的标记仍被命中。
       final String source = entry.key.endsWith('sync_settings_schema.dart')
-          ? readSyncSettingsSchemaSource()
+          ? maskComments(readSyncSettingsSchemaSource())
           : readNormalizedSource(entry.key);
       for (final String token in entry.value) {
         expect(
           source,
           contains(token),
-          reason: '${entry.key} must contain $token',
+          reason: '${entry.key} must contain $token（注释里的同名文本不算数）',
         );
       }
     }
@@ -174,10 +188,11 @@ void main() {
     final String source = readNormalizedSource(
         'lib/src/pages/implementations/hibiki_settings_page.dart');
 
-    expect(source, contains('HibikiDialogFrame('));
-    expect(source, contains('HibikiModalSheetFrame('));
-    expect(source, contains('HibikiDesignTokens.of(context)'));
-    expect(source, isNot(contains('adaptiveAlertDialog(')));
+    expect(containsIdentifierCall(source, 'HibikiDialogFrame'), isTrue);
+    expect(containsIdentifierCall(source, 'HibikiModalSheetFrame'), isTrue);
+    // 旧锚点把局部变量名 `context` 写进了契约（`HibikiDesignTokens.of(context)`）。
+    expect(containsIdentifierCall(source, 'HibikiDesignTokens'), isTrue);
+    expect(containsIdentifierCall(source, 'adaptiveAlertDialog'), isFalse);
   });
 
   test('settings shared actions use MD3 dialog chrome', () {
@@ -185,16 +200,26 @@ void main() {
         readNormalizedSource('lib/src/settings/settings_actions.dart');
     // TODO-586：schema 拆成多领域文件，adaptiveAlertDialog 禁令要扫全部领域文件。
     final String schemaSource = readSettingsSchemaCombined();
-    final String syncSource = readSyncSettingsSchemaSource();
+    final String syncSource = maskComments(readSyncSettingsSchemaSource());
     final String combined = '$actionsSource\n$schemaSource\n$syncSource';
 
-    expect(actionsSource, contains('HibikiDialogFrame('));
-    expect(actionsSource, contains('HibikiModalSheetFrame('));
+    expect(containsIdentifierCall(actionsSource, 'HibikiDialogFrame'), isTrue);
+    expect(
+      containsIdentifierCall(actionsSource, 'HibikiModalSheetFrame'),
+      isTrue,
+    );
 
-    expect(actionsSource, isNot(contains('adaptiveAlertDialog(')));
-    expect(schemaSource, isNot(contains('adaptiveAlertDialog(')));
-    expect(syncSource, isNot(contains('adaptiveAlertDialog(')));
-    expect(combined, contains('showSettingsConfirmationDialog('));
+    for (final String source in <String>[
+      actionsSource,
+      schemaSource,
+      syncSource,
+    ]) {
+      expect(containsIdentifierCall(source, 'adaptiveAlertDialog'), isFalse);
+    }
+    expect(
+      containsIdentifierCall(combined, 'showSettingsConfirmationDialog'),
+      isTrue,
+    );
   });
 
   test('settings renderers use shared MD3 spacing tokens', () {
@@ -203,31 +228,27 @@ void main() {
     final String cupertinoSource = readNormalizedSource(
         'lib/src/settings/cupertino_settings_renderer.dart');
 
-    expect(materialSource, contains('HibikiDesignTokens.of(context)'));
-    expect(cupertinoSource, contains('HibikiDesignTokens.of('));
+    expect(
+        containsIdentifierCall(materialSource, 'HibikiDesignTokens'), isTrue);
+    expect(
+      containsIdentifierCall(cupertinoSource, 'HibikiDesignTokens'),
+      isTrue,
+    );
 
-    for (final String source in <String>[materialSource, cupertinoSource]) {
-      expect(source, isNot(contains('EdgeInsets.fromLTRB(16, 8, 16, 16)')));
-      expect(
-          source, isNot(contains('const EdgeInsets.symmetric(horizontal: 16')));
-      expect(
-          source, isNot(contains('const EdgeInsets.symmetric(horizontal: 8')));
-      expect(source, isNot(contains('const EdgeInsets.only(bottom: 12)')));
-      expect(source, isNot(contains('const EdgeInsets.only(bottom: 6)')));
-      expect(
-          source, isNot(contains('const EdgeInsets.fromLTRB(12, 6, 12, 0)')));
-      expect(source, isNot(contains('const EdgeInsets.only(right: 12)')));
-      expect(source, isNot(contains('const EdgeInsets.only(top: 8)')));
-      expect(source, isNot(contains('const SizedBox(height: 4)')));
-    }
+    // 旧写法是 9 条 `isNot(contains('const EdgeInsets.fromLTRB(16, 8, 16, 16)'))`
+    // 这样的**逐条拼写**禁令：只堵住被枚举到的那几种，16 改 20、换个构造器、
+    // 换行重排全都静默放行。改成结构判据——渲染器里任何 EdgeInsets / SizedBox
+    // 构造都不得带非零裸数字实参。
+    expectTokenDerivedSpacing(materialSource, 'Material 设置渲染器');
+    expectTokenDerivedSpacing(cupertinoSource, 'Cupertino 设置渲染器');
   });
 
   test('legacy adaptive alert factory is removed', () {
     final String source =
         readNormalizedSource('lib/src/utils/adaptive/adaptive_widgets.dart');
 
-    expect(source, isNot(contains('adaptiveAlertDialog(')));
-    expect(source, isNot(contains('CupertinoAlertDialog(')));
+    expect(containsIdentifierCall(source, 'adaptiveAlertDialog'), isFalse);
+    expect(containsIdentifierCall(source, 'CupertinoAlertDialog'), isFalse);
     // 裸子串 'AlertDialog(' 有两个毛病：① 它同时被上面两个更长的名字包含，把两条
     // 断言变成冗余；② 它匹配不到 `AlertDialog.adaptive(`（本仓真实在用的写法，
     // 见 media_sources_view.dart / log_uploader.dart），旧工厂以命名构造器形式
@@ -261,7 +282,7 @@ void main() {
     final String destinationSource =
         readNormalizedSource('lib/src/settings/settings_destination.dart');
     final String schemaSource = readSettingsSchemaCombined();
-    final String syncSource = readSyncSettingsSchemaSource();
+    final String syncSource = maskComments(readSyncSettingsSchemaSource());
     final String combined = '$destinationSource\n$schemaSource\n$syncSource';
 
     for (final String token in <String>[
@@ -330,41 +351,24 @@ void main() {
     expect(sheetSource, contains("page: 'lookup'"));
     expect(sheetSource, contains('ReaderGroup.lookup'));
 
-    final int autoReadStart =
-        lookupSource.indexOf("id: 'lookup.auto_read_on_lookup'");
-    final int pauseStart = lookupSource.indexOf("id: 'lookup.pause_on_lookup'");
-    expect(autoReadStart, isNonNegative);
-    expect(pauseStart, isNonNegative);
-
-    final String autoReadSource =
-        lookupSource.substring(autoReadStart, pauseStart);
-    final String pauseSource =
-        lookupSource.substring(pauseStart, pauseStart + 520);
-    expect(autoReadSource, contains('group: ReaderGroup.lookup'));
-    expect(pauseSource, contains('group: ReaderGroup.lookup'));
-    expect(autoReadSource, isNot(contains('group: ReaderGroup.behavior')));
-    expect(pauseSource, isNot(contains('group: ReaderGroup.behavior')));
-
-    // TODO-436：「滑动关闭弹窗」是查词弹窗手势行为，归查词分组（ReaderGroup.lookup），
-    // 不得回到阅读控制（ReaderGroup.behavior）。
-    final int swipeCloseStart =
-        lookupSource.indexOf("id: 'reading_controls.enable_swipe_to_close'");
-    expect(swipeCloseStart, isNonNegative);
-    final String swipeCloseSource =
-        lookupSource.substring(swipeCloseStart, swipeCloseStart + 360);
-    expect(swipeCloseSource, contains('group: ReaderGroup.lookup'));
-    expect(swipeCloseSource, isNot(contains('group: ReaderGroup.behavior')));
-
-    // TODO-625：「滑动关闭灵敏度」与上面的开关配套，同属查词弹窗手势行为，
-    // 归查词分组（ReaderGroup.lookup），不得滞留在阅读控制（ReaderGroup.behavior）。
-    final int swipeSensitivityStart = lookupSource
-        .indexOf("id: 'reading_controls.dismiss_swipe_sensitivity'");
-    expect(swipeSensitivityStart, isNonNegative);
-    final String swipeSensitivitySource = lookupSource.substring(
-        swipeSensitivityStart, swipeSensitivityStart + 360);
-    expect(swipeSensitivitySource, contains('group: ReaderGroup.lookup'));
-    expect(
-        swipeSensitivitySource, isNot(contains('group: ReaderGroup.behavior')));
+    // 旧写法是 `substring(anchor, anchor + 520)` / `+ 360` 三个定长字符窗口：
+    // 被守的那一项多写两行属性，`group:` 就漂出窗口、断言凭空变假；项变短又会把
+    // **下一项**的属性读进来，断言指向错误对象。改成按括号配对取该 item 的
+    // 构造器调用体，窗口由结构决定。
+    for (final String itemId in <String>[
+      "id: 'lookup.auto_read_on_lookup'",
+      "id: 'lookup.pause_on_lookup'",
+      // TODO-436：「滑动关闭弹窗」是查词弹窗手势行为，归查词分组。
+      "id: 'reading_controls.enable_swipe_to_close'",
+      // TODO-625：「滑动关闭灵敏度」与上面的开关配套，同属查词弹窗手势行为。
+      "id: 'reading_controls.dismiss_swipe_sensitivity'",
+    ]) {
+      final String itemBody = enclosingCallOf(lookupSource, itemId).text;
+      expect(itemBody, contains('group: ReaderGroup.lookup'),
+          reason: '$itemId 必须归查词分组');
+      expect(itemBody, isNot(contains('group: ReaderGroup.behavior')),
+          reason: '$itemId 不得滞留在阅读控制分组');
+    }
   });
 
   test('popup instant scroll is a global lookup display setting', () {
@@ -372,24 +376,28 @@ void main() {
         readNormalizedSource('lib/src/settings/settings_schema_lookup.dart');
     // 「查词显示」拆成「词条内容 / 弹窗窗口」两组后，popup_instant_scroll 归弹窗
     // 窗口组；组尾还有带 ReaderPlacement 的滑动关闭手势对（TODO-436/625，本就
-    // 该出现在书内快捷面板），故切片上界取到滑动关闭项之前，只覆盖
-    // instant_scroll 所在的窗口尺寸/停靠段。
+    // 该出现在书内快捷面板），所以既要断言它落在窗口组段内，也要断言它自身不是
+    // reader-only。旧写法用一个跨两个标记的字符窗口同时表达这两件事，item 一长
+    // 就会把邻项读进来；现在拆成「顺序」+「item 自身」两条独立判据。
     final int displayStart = lookupSource.indexOf(
       'title: t.settings_section_lookup_popup_window',
     );
+    final int instantScrollStart =
+        lookupSource.indexOf("id: 'lookup.popup_instant_scroll'");
     final int swipeStart =
         lookupSource.indexOf("id: 'reading_controls.enable_swipe_to_close'");
     expect(displayStart, isNonNegative);
-    expect(swipeStart, greaterThan(displayStart));
+    expect(instantScrollStart, greaterThan(displayStart),
+        reason: 'popup_instant_scroll 必须落在「弹窗窗口」分组段内');
+    expect(swipeStart, greaterThan(instantScrollStart));
 
-    final String displaySource =
-        lookupSource.substring(displayStart, swipeStart);
-    expect(displaySource, contains("id: 'lookup.popup_instant_scroll'"));
-    expect(displaySource, contains('t.popup_instant_scroll'));
-    expect(displaySource, contains('popupInstantScroll'));
+    final String itemBody =
+        enclosingCall(lookupSource, instantScrollStart).text;
+    expect(itemBody, contains('t.popup_instant_scroll'));
+    expect(itemBody, contains('popupInstantScroll'));
     expect(
-      displaySource,
-      isNot(contains('ReaderPlacement(')),
+      containsIdentifierCall(itemBody, 'ReaderPlacement'),
+      isFalse,
       reason:
           'This controls shared lookup popup behavior across reader, video, '
           'and dictionary surfaces, so it must not become reader-only.',
@@ -403,26 +411,27 @@ void main() {
         readNormalizedSource('lib/src/settings/settings_actions.dart');
 
     expect(actionsSource, contains('Widget buildThemeSelector'));
-    expect(
-        sheetSource, contains('buildThemeSelector(_themeSettingsContext())'));
+    // 旧锚点把**实参写法** `_themeSettingsContext()` 也写进了契约；契约只是
+    // 「快捷面板复用共享主题选择器」。
+    expect(containsIdentifierCall(sheetSource, 'buildThemeSelector'), isTrue);
     expect(sheetSource, isNot(contains('TtuReaderSettings.availableThemes')));
-    expect(sheetSource, isNot(contains('buildReaderThemeChip(')));
+    expect(
+        containsIdentifierCall(sheetSource, 'buildReaderThemeChip'), isFalse);
   });
 
   test('sync backup settings use standard schema rows for options', () {
-    final String source = readSyncSettingsSchemaSource();
+    final String source = maskComments(readSyncSettingsSchemaSource());
 
+    // 旧锚点是 `"SettingsCustomItem(\n            id: 'sync.mode'"`——把 12 个
+    // 空格的缩进和一个换行写进了契约，`dart format` 重排或多包一层就红，而守的
+    // 根本不是格式。契约是「这个 id 属于哪种 schema 行类型」。
     expect(
-        source, contains("SettingsCustomItem(\n            id: 'sync.mode'"));
-    expect(source,
-        contains("SettingsSwitchItem(\n            id: 'sync.statistics'"));
-    expect(
-        source,
-        isNot(
-            contains("SettingsSwitchItem(\n            id: 'sync.audiobook'")));
+        enclosingCallOf(source, "id: 'sync.mode'").name, 'SettingsCustomItem');
+    expect(enclosingCallOf(source, "id: 'sync.statistics'").name,
+        'SettingsSwitchItem');
+    expect(enclosingCallOf(source, "id: 'sync.dictionary'").name,
+        'SettingsSwitchItem');
     expect(source, isNot(contains("id: 'sync.audiobook'")));
-    expect(source,
-        contains("SettingsSwitchItem(\n            id: 'sync.dictionary'"));
     expect(source, isNot(contains("id: 'sync.options'")));
     expect(source, isNot(contains('class _SyncOptionsWidget')));
   });
@@ -449,9 +458,11 @@ void main() {
   });
 
   test('Cupertino icon font is bundled when CupertinoIcons are used', () {
-    final String pubspec = readNormalizedSource('pubspec.yaml');
+    // pubspec 是 YAML，`maskComments` 是 Dart 词法（会把 `https://` 当行注释），
+    // 这里按 YAML 的 `#` 注释规则剥。否则一条被注释掉的依赖行也能让断言变绿。
+    final String pubspec = File('pubspec.yaml').readAsStringSync();
 
-    expect(pubspec, contains('cupertino_icons:'));
+    expect(_yamlDeclares(pubspec, 'cupertino_icons:'), isTrue);
   });
 
   test('profile switching waits for reader settings refresh', () {
@@ -459,8 +470,11 @@ void main() {
         readNormalizedSource('lib/src/profile/profile_view_model.dart');
 
     expect(
-      source,
-      contains('await ReaderHibikiSource.readerSettings?.refreshFromDb();'),
+      containsCodeLine(
+        source,
+        'await ReaderHibikiSource.readerSettings?.refreshFromDb()',
+      ),
+      isTrue,
     );
   });
 
@@ -470,16 +484,32 @@ void main() {
     final String source =
         readNormalizedSource('lib/src/settings/settings_home_page.dart');
     // MD3 list-detail: nav pane on tonal token surface (surfaces.group =
-    // surfaceContainerLow), gated to Material via the cupertino branch.
+    // surfaceContainerLow), gated to Material via the cupertino branch。
+    // 旧锚点 `'cupertino ? null :'` 把三元表达式的**排版**写进了契约（换行一改
+    // 就红）。契约是「取 surfaces.group 的那条语句本身被 cupertino 门控」。
     expect(source, contains('tokens.surfaces.group'));
-    expect(source, contains('cupertino ? null :'));
+    final String statement = _statementAround(source, 'tokens.surfaces.group');
+    expect(
+      statement,
+      contains('cupertino'),
+      reason: 'nav pane 的 tonal 底色必须由 cupertino 分支门控，实际语句：$statement',
+    );
   });
 
   test('material destination list uses pill selection + gated chevron', () {
     final String source = readNormalizedSource(
         'lib/src/settings/material_settings_renderer.dart');
     expect(source, contains('HibikiListItemSelectedShape'));
-    expect(source, contains('pushRoutes ? const Icon(Icons.chevron_right)'));
+    // 旧锚点 `'pushRoutes ? const Icon(Icons.chevron_right)'` 同样钉死三元排版。
+    // 契约是「trailing 的雪佛龙由 pushRoutes 门控」。
+    final List<String> trailing = namedArgumentValues(source, 'trailing');
+    expect(
+      trailing.any((String value) =>
+          value.contains('pushRoutes') &&
+          value.contains('Icons.chevron_right')),
+      isTrue,
+      reason: 'destination 行的 chevron 必须由 pushRoutes 门控，实际：$trailing',
+    );
   });
 
   test('settings lists and schema sections opt into contained surfaces', () {
@@ -497,12 +527,12 @@ void main() {
         contains('titlePlacement: SettingsSectionTitlePlacement.inside'),
         reason:
             'schema detail section titles such as System must live inside the section surface');
-    expect(material, contains('AdaptiveSettingsSection('),
+    expect(containsIdentifierCall(material, 'AdaptiveSettingsSection'), isTrue,
         reason: 'Material destination list should be one grouped section');
     expect(material, contains('surfaceColor: tokens.surfaces.card'),
         reason:
             'wide supporting-pane list needs a visible lightweight surface over its tonal pane');
-    expect(material, isNot(contains('ListView.separated(')),
+    expect(containsIdentifierCall(material, 'ListView.separated'), isFalse,
         reason: 'destination rows should not be a bare separated list');
   });
 
@@ -545,21 +575,27 @@ void main() {
     expect(shared, contains('kSettingsPickerDefaultWidth'));
     expect(shared, contains('kSettingsPickerMinInlineWidth'));
     expect(shared, contains('trailingFlexible: !cupertino && !controlBelow'));
-    expect(shared, contains('LayoutBuilder('),
+    expect(containsIdentifierCall(shared, 'LayoutBuilder'), isTrue,
         reason:
             'inline picker controls must be bounded by the settings row width');
     expect(destination, contains('this.controlBelow = true'),
         reason:
             'schema segmented rows default to the readable below-label form');
+    // 裸子串 `'ListTile('` 顺带把 `SwitchListTile(` / `CheckboxListTile(` /
+    // `SettingsListTile(` 一起命中，既让三条禁令互相冗余，又会误伤任何以
+    // ListTile 结尾的共享组件；反过来它匹配不到 `ListTile.adaptive(`。带标识符
+    // 边界后每个名字各管各的，禁令列表就得写全（这才是真实契约）。
     for (final String banned in <String>[
-      'ListTile(',
-      'SwitchListTile(',
-      'ExpansionTile(',
+      'ListTile',
+      'SwitchListTile',
+      'CheckboxListTile',
+      'RadioListTile',
+      'ExpansionTile',
     ]) {
-      expect(shared, isNot(contains(banned)),
+      expect(containsIdentifierCall(shared, banned), isFalse,
           reason: 'settings_shared.dart must keep the shared MD3 row system');
     }
-    expect(shared, isNot(contains('return Card(')),
+    expect(containsIdentifierCall(shared, 'Card'), isFalse,
         reason: 'settings_shared.dart must not use a bare Material Card');
   });
 
@@ -571,7 +607,7 @@ void main() {
     final String shell =
         readNormalizedSource('lib/src/settings/settings_detail_page.dart');
     expect(shell, contains('Widget buildSettingsDetailShell('));
-    expect(shell, contains('renderer.buildDetailPage('));
+    expect(containsIdentifierCall(shell, 'renderer.buildDetailPage'), isTrue);
 
     // Every settings sub-page that the unified detail panel can navigate into
     // must route through that one shell — NOT its own bespoke scaffold — so the
@@ -583,18 +619,83 @@ void main() {
       'lib/src/pages/implementations/miscellaneous_settings_page.dart',
     ]) {
       final String source = readNormalizedSource(path);
-      expect(source, contains('buildSettingsDetailShell('),
+      expect(containsIdentifierCall(source, 'buildSettingsDetailShell'), isTrue,
           reason:
               '$path must render through the unified settings detail shell');
       // No parallel page-shell vocabulary: the converged pages do not stand up
       // their own AdaptiveSettingsScaffold or hand-rolled HibikiPageScaffold.
-      expect(source, isNot(contains('AdaptiveSettingsScaffold(')),
+      expect(
+          containsIdentifierCall(source, 'AdaptiveSettingsScaffold'), isFalse,
           reason: '$path must not reintroduce its own settings scaffold');
-      expect(source, isNot(contains('return HibikiPageScaffold(')),
+      expect(containsIdentifierCall(source, 'HibikiPageScaffold'), isFalse,
           reason: '$path must not hand-roll a page scaffold + bare list');
       // Body content is grouped into the shared section cards.
-      expect(source, contains('AdaptiveSettingsSection('),
+      expect(containsIdentifierCall(source, 'AdaptiveSettingsSection'), isTrue,
           reason: '$path body must use shared AdaptiveSettingsSection cards');
     }
   });
+}
+
+/// 「整个实参槽位就是一个数字字面量」的形态。
+final RegExp _numericArgument = RegExp(r'[(,:]\s*(-?\d+(?:\.\d+)?)\s*[,)]');
+
+/// 会被硬编码间距污染的构造器。
+const List<String> _spacingConstructors = <String>['EdgeInsets', 'SizedBox'];
+
+/// [expr] 里是否有**硬编码的非零间距**。
+///
+/// 零放行（零不是魔法尺寸，是「此边不留白」）；`tokens.spacing.card * 2` 这类以
+/// 令牌为基准的算式也放行——契约是「间距来自设计令牌」，不是「不许出现数字」。
+bool _hasHardcodedSpacing(String expr) {
+  for (final RegExpMatch match in _numericArgument.allMatches(expr)) {
+    final double? value = double.tryParse(match.group(1)!);
+    if (value != null && value != 0) return true;
+  }
+  return false;
+}
+
+/// 该作用域内所有 `EdgeInsets` / `SizedBox` 构造都不得带非零裸数字实参。
+void expectTokenDerivedSpacing(String code, String label) {
+  for (final String name in _spacingConstructors) {
+    for (final RegExpMatch match in identifierCall(name).allMatches(code)) {
+      final EnclosingCall call = enclosingCall(code, match.end);
+      expect(
+        _hasHardcodedSpacing(call.text),
+        isFalse,
+        reason: '$label 的间距不得硬编码（一律走 tokens.spacing），实际是：${call.text}',
+      );
+    }
+  }
+}
+
+/// 取 [needle] 所在的**语句**（上一个 `;` / `{` / `}` 到下一个 `;`）。
+///
+/// 用于「这个取值必须被某个条件门控」这类契约：断言语句里出现门控标识符，与三元
+/// 表达式怎么排版无关。
+String _statementAround(String code, String needle) {
+  final int index = code.indexOf(needle);
+  expect(index, isNonNegative, reason: '源码里找不到：$needle');
+  int start = index;
+  while (start > 0 &&
+      code[start - 1] != ';' &&
+      code[start - 1] != '{' &&
+      code[start - 1] != '}') {
+    start--;
+  }
+  int end = index;
+  while (end < code.length && code[end] != ';') {
+    end++;
+  }
+  return code.substring(start, end);
+}
+
+/// YAML 里是否有一条**未被注释掉**的行含 [key]。
+bool _yamlDeclares(String yaml, String key) {
+  for (final String line in yaml.split('\n')) {
+    if (line.trimLeft().startsWith('#')) continue;
+    final int hash = line.indexOf('#');
+    final String code = hash >= 0 ? line.substring(0, hash) : line;
+    if (code.contains(key)) return true;
+  }
+  return false;
 }

--- a/hibiki/test/sync/pairing/pin_no_plaintext_guard_test.dart
+++ b/hibiki/test/sync/pairing/pin_no_plaintext_guard_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../../helpers/source_guard.dart';
 
 /// TODO-961 M1 §3.6 源码守卫：PIN 绝不明文出现在响应 body / 日志。
 ///
@@ -15,33 +16,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// 2. server 的 pair/v2 响应只含 sessionId / pinRequired / hostNonce（白名单）。
 /// 3. PIN 不进 debugPrint / ErrorLogService 等日志调用。
 
-String _stripComments(String src) {
-  final StringBuffer out = StringBuffer();
-  final int n = src.length;
-  int i = 0;
-  while (i < n) {
-    final String c = src[i];
-    final String next = i + 1 < n ? src[i + 1] : '';
-    if (c == '/' && next == '/') {
-      while (i < n && src[i] != '\n') {
-        i++;
-      }
-      continue;
-    }
-    if (c == '/' && next == '*') {
-      i += 2;
-      while (i < n && !(src[i] == '*' && i + 1 < n && src[i + 1] == '/')) {
-        if (src[i] == '\n') out.write('\n');
-        i++;
-      }
-      i += 2;
-      continue;
-    }
-    out.write(c);
-    i++;
-  }
-  return out.toString();
-}
+String _stripComments(String src) => maskComments(src);
 
 void main() {
   test('pair/v2 响应体只含白名单字段，绝不含 PIN', () {

--- a/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
+++ b/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 
 /// BUG-951 — source-scan guards for the galgame hook overlay's pass-through
 /// design.
@@ -68,11 +69,7 @@ void main() {
 
   /// Drops `// ...` comments so a call-site count cannot be thrown off (in
   /// either direction) by prose that mentions the symbol.
-  String stripLineComments(String source) =>
-      source.split('\n').map((String line) {
-        final int slashes = line.indexOf('//');
-        return slashes < 0 ? line : line.substring(0, slashes);
-      }).join('\n');
+  String stripLineComments(String source) => maskComments(source);
 
   group('BUG-951 · the body window is really click-through', () {
     test('WS_EX_TRANSPARENT is applied, and only from one function', () {

--- a/hibiki/test/tools/itest_focus_navigation_prerequisite_guard_test.dart
+++ b/hibiki/test/tools/itest_focus_navigation_prerequisite_guard_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 
 /// BUG-1106 的防线延伸：**凡是起真 app 又靠 Tab 遍历驱动的集成测试，
 /// 都必须先打开实验「键盘/手柄焦点导航」开关**，否则在全新 profile 上必红。
@@ -93,9 +94,4 @@ void main() {
 
 /// 丢掉行注释（`//` / `///`），使扫描只针对真代码。字符串里的 `//`（如 URL）
 /// 会跟着被截掉，对本守卫的 token 扫描无影响。
-String _stripComments(String source) {
-  return source.split('\n').map((String line) {
-    final int i = line.indexOf('//');
-    return i < 0 ? line : line.substring(0, i);
-  }).join('\n');
-}
+String _stripComments(String source) => maskComments(source);

--- a/hibiki/test/tools/voice_hook_reader_write_access_guard_test.dart
+++ b/hibiki/test/tools/voice_hook_reader_write_access_guard_test.dart
@@ -32,6 +32,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 
 /// 从当前 cwd 向上找含 `hibiki/windows/runner` 的仓库根。
 Directory _repoRoot() {
@@ -49,9 +50,7 @@ Directory _repoRoot() {
 ///
 /// 源码扫描守卫最经典的假绿：真代码改掉、注释里还留着同一串字面量，守卫照绿。本文件上面
 /// 的说明里就反复出现 `FILE_MAP_WRITE` 和 `InterlockedExchange64`，剥完不该再被任何断言看见。
-String _stripComments(String source) => source
-    .replaceAll(RegExp(r'/\*.*?\*/', dotAll: true), '')
-    .replaceAll(RegExp(r'//[^\n]*'), '');
+String _stripComments(String source) => maskComments(source);
 
 /// 取 [source] 中从 [signature] 起到该函数结尾（列 0 的 `}`）的函数体。
 String _functionBody(String source, String signature) {

--- a/hibiki/test/widgets/wgc_pump_tick_agile_guard_test.dart
+++ b/hibiki/test/widgets/wgc_pump_tick_agile_guard_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 
 /// TODO-550 guard: the WGC timer-pump Tick delegate must be AGILE.
 ///
@@ -24,12 +25,7 @@ String _read(List<String> candidates, String name) {
 }
 
 /// 删掉所有 `//` 行注释,只保留真实代码,避免守卫被解释根因的注释误判。
-String _stripLineComments(String src) {
-  return src.split('\n').map((String line) {
-    final int idx = line.indexOf('//');
-    return idx >= 0 ? line.substring(0, idx) : line;
-  }).join('\n');
-}
+String _stripLineComments(String src) => maskComments(src);
 
 void main() {
   test('TODO-550: WGC timer-pump Tick handler is an AGILE delegate', () {


### PR DESCRIPTION
纯 `test/` 改动，零生产代码。两条看板主行的收尾：**TODO-2457**（B 类要求型锚点密集区）+ **TODO-2473**（手写注释剥离第一批）。

## A. B 类要求型锚点抬到契约（TODO-2457，commit `ee2e97b06`）

A 类（禁止型）换匹配器就够，PR#645 已完；**B 类（要求型）换匹配器没用**——失效形态是「生产代码换个等价写法就误报红」，必须把锚点从**实现写法**抬到**契约**。

密集区两个文件 62 条（`md3_dialog_chrome_merged_static_test` 43 + `settings_redesign_static_test` 19）逐条重写。

新增两条共享原语（`test/helpers/source_guard.dart`，**等长掩码硬约束未动**）：
- `enclosingCall` / `enclosingCallOf`：按括号配对取最内层调用（名字 + 调用体）。顶掉两类塌陷窗口——`substring(anchor, anchor + 520)` 定长字符窗口，和 `'SettingsCustomItem(\n            id: ...'` 这种把缩进换行写进锚点的字面量。
- `namedArgumentValues`：取命名实参的**表达式原文**，断言「它取自什么」而不是「它怎么拼」。

四类塌陷：
1. **零词法防护** → `maskCommentsAndStrings`（md3 文件锚点全是代码标识符）/ `maskComments`（settings_redesign 有 `id: 'lookup.xxx'` 这类要读串内容的锚点）。
2. **锚点即写法** → `containsIdentifierCall`。`'HibikiDesignTokens.of(context)'` 把**局部变量名**写进了契约；`'return IconButton(' / 'child:' / 'trailing:' / 'suffixIcon:'` 四条位置前缀只是为了绕开 `HibikiIconButton(` 含子串 `IconButton(`，合并成一条「不得裸用 IconButton」后严格更强（能抓 `IconButton.filledTonal(`）。
3. **间距契约钉死拼写** → 「每个 `EdgeInsets`/`SizedBox` 构造不得带非零裸数字实参 + `insetPadding` 必须引用 `tokens.spacing.`」。旧的 `isNot(contains('const EdgeInsets.symmetric(horizontal: 16, vertical: 16)'))` 只堵被枚举到的拼写，16 改 20 就放行。零与 `tokens.spacing.card * 2` 有意放行。
4. **窗口靠相邻声明** → `methodBody` 取类体，并把「谁负责什么」拆到各自作用域。

**顺带抓出一个活的假绿**：`settings_home_page.dart` 被要求含 `'master-detail'`，而这个词全文件**只出现在一条散文注释里**（`false, // master-detail keeps selection in-pane.`）——那条断言从来没守住任何东西。已换成 `SettingsDetailPage(`。

### 变异实测 10 例（每例同时跑新守卫与 `origin/develop` 旧守卫）

| 变异 | 放置 | NEW | OLD |
|---|---|---|---|
| MUT-1 `HibikiDialogFrame(` | 行尾注释 | RED | GREEN（旧洞坐实） |
| MUT-2 `HibikiIconButton(` | 块注释 | RED | GREEN |
| MUT-3 `HibikiModalSheetFrame(` | 三引号串 | RED | GREEN |
| MUT-7 `HibikiDialogFrame(` | 行尾注释 | RED | GREEN |
| MUT-4 注释提到 `adaptiveAlertDialog(` | 块注释 | GREEN | RED（旧假红） |
| MUT-5b `EdgeInsets.fromLTRB(24, 0, 24, 12)` | 真硬编码 | RED | GREEN（旧只堵 16,16） |
| MUT-6 `IconButton.filledTonal(` | 真复活 | RED | GREEN |
| MUT-8 `id: 'sync.mode'` 前插一行注释 | 合法重构 | GREEN | RED（排版进锚点） |
| MUT-9 重命名相邻类 `BookProfileDialogContent` | 合法重构 | GREEN | RED（窗口塌陷） |

`source_guard_lexer_test` 补 8 条新原语单测（19 → 27）。

## B. 17 份手写注释剥离迁到词法扫描（TODO-2473 第一批，commit `5aea5fb5b`）

新增 `maskCommentsAndScriptLines`：`maskComments` 的保守超集，额外掩掉**整行 `//`**（含三引号串里的 JS/CSS 注释）。本仓一批 Dart 文件把大段 JS 放在三引号里，`maskComments` 按设计保留串内容（这样 `'https://x'` 才不被砍），旧手写剥离恰好能吃掉串内整行 JS 注释但不认块/行尾注释——新原语取并集，扫这些语料的 7 个守卫改用它，**零回退**。

顺带关掉 `reader_focus_chrome_excluded` 的 coverage 洞（原来 4 个 test 只有 1 个剥注释）。

### 变异实测 5 例

| 变异 | NEW | OLD |
|---|---|---|
| B-MUT-1 块注释里出现 `_syncSettingsToHive()` | GREEN | RED（假红） |
| B-MUT-2 行尾注释里出现 `_controller.dispose()` | GREEN | RED（假红） |
| B-MUT-3 真违规 `debugPrint('pair https://\$host/v2 pin=\${session.pin}')` | **RED** | **GREEN**（旧剥离从 `//` 砍到行尾、`pin` 消失 → PIN 明文泄漏静默放行） |
| B-MUT-4 `await enableFocusNavigation(` 改块注释形态 | **RED** | **GREEN**（旧把它当已开开关豁免） |
| B-MUT-5 删掉 `ExcludeFocus (see` 里那**一个空格** | GREEN | RED（`ExcludeFocus` 计数变 2） |

三引号串方向由 `maskCommentsAndScriptLines` 的 3 条单测永久钉住。

## 验证

- `flutter analyze`（含 test）：**No issues found!**
- 本轮相关定向测试：**167 tests passed**（`-r failures-only`，退出码 0，未接管道吞退出码）。
- 变异还原一律用备份回拷 / 反向文本替换，**未对未提交文件跑 `git checkout --`**；`lib/` 与 `integration_test/` 零残留。
- develop 上既有的 `horizontal_drag_scroll_guard` 红归 PR#635，非本 PR 引入。

## 剩余

- 全仓仍有 **15 个**文件手写剥离。其中 `vn_blank_tap_chrome_reveal_bug1195` 与 `word_audio_failure_reason` **迁不动**：需先给 helper 补 JS 词法——`popup.js` 的正则字面量 `/^https?:\/\//i` 会被 Dart 词法误判成行注释起点。
- `vertical_ruby_line_box_contain` 有一条**依赖删除式语义**的元断言（`stripped.length < rawCss.length`），迁到等长掩码前必须先改写。
- 审计还发现若干**定长字符窗口**（`+200` / `+1800` / `+1200`）与**覆盖率洞**（`gal_overlay` 20+ 断言只 1 处剥、`global_lookup_hotkey` 12 条只 1 处、`reader_mining_race` 4 条正向断言裸扫），属独立跟进项，本 PR 未动以保持 diff 可审。