### PR TITLE
fix(library): 卡片长标题溢出可看全名（TODO-2490）

### DIFF
--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2690,12 +2690,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
               children: <Widget>[
                 Padding(
                   padding: const EdgeInsets.fromLTRB(8, 6, 8, 2),
-                  child: Text(
-                    collection.name,
-                    // BUG-1184：与同网格的散卡标题同规格（两行）。
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
+                  // TODO-2490：两行仍放不下时，桌面悬停显示完整合集名。
+                  child: ShelfTitleOverflowTooltip(
+                    title: collection.name,
                     style: Theme.of(context).textTheme.bodyMedium,
+                    maxLines: 2,
+                    child: Text(
+                      collection.name,
+                      // BUG-1184：与同网格的散卡标题同规格（两行）。
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
                   ),
                 ),
                 Flexible(
@@ -2910,12 +2916,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                 Padding(
                   padding:
                       const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-                  child: Text(
-                    video.title,
-                    // BUG-1184：远端视频占位卡与本地散卡同规格（两行）。
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
+                  // TODO-2490：两行仍放不下时，桌面悬停显示完整标题。
+                  child: ShelfTitleOverflowTooltip(
+                    title: video.title,
                     style: Theme.of(context).textTheme.bodyMedium,
+                    maxLines: 2,
+                    child: Text(
+                      video.title,
+                      // BUG-1184：远端视频占位卡与本地散卡同规格（两行）。
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
                   ),
                 ),
               ],
@@ -3640,13 +3652,20 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
               children: <Widget>[
                 Padding(
                   padding: const EdgeInsets.fromLTRB(8, 6, 8, 2),
-                  child: Text(
-                    book.title,
-                    // BUG-1184：窄屏卡宽只有约 154px，单行放不下一个日文剧名。
-                    // 文字块高度已按两行标题算出（[_videoCardTextBlock]）。
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
+                  // TODO-2490：两行仍放不下时，桌面悬停显示完整标题；触屏长按
+                  // 菜单（MediaItemDialogFrame 标题不限行）看全名。
+                  child: ShelfTitleOverflowTooltip(
+                    title: book.title,
                     style: Theme.of(context).textTheme.bodyMedium,
+                    maxLines: 2,
+                    child: Text(
+                      book.title,
+                      // BUG-1184：窄屏卡宽只有约 154px，单行放不下一个日文剧名。
+                      // 文字块高度已按两行标题算出（[_videoCardTextBlock]）。
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
                   ),
                 ),
                 // UI v2 Phase D：观看进度文字外显（mockup 卡片下的进度/上次观看行）。

--- a/hibiki/lib/src/pages/implementations/media_item_dialog_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_item_dialog_page.dart
@@ -295,8 +295,9 @@ class MediaItemDialogFrame extends StatelessWidget {
               children: <Widget>[
                 Text(
                   title,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
+                  // TODO-2490：本弹窗是库页卡片长按/右键「看全名」的兜底路径——
+                  // 卡上标题最多两行省略，这里再截断则超长条目名到处都看不全。
+                  // 外层 HibikiDialogFrame 默认可滚动且限高，不会撑出屏。
                   style: tokens.type.pageTitle.copyWith(
                     color: colors.onSurface,
                     fontWeight: FontWeight.w700,

--- a/hibiki/lib/src/utils/components/galgame_poster_card.dart
+++ b/hibiki/lib/src/utils/components/galgame_poster_card.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/focus/hibiki_focus_target.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
+import 'package:hibiki/src/utils/components/shelf_card_widgets.dart';
 
 /// galgame 竖版海报卡（对齐 ReinaManager 库页/首页的卡片观感，见
 /// `docs/design/galgame-library-reina-visual-parity.md` §1）。
@@ -81,18 +82,26 @@ class _GalgamePosterCardState extends State<GalgamePosterCard> {
 
     final Widget cover = _buildCover(context, colors);
 
+    final TextStyle? titleStyle = theme.textTheme.titleSmall?.copyWith(
+      fontWeight: FontWeight.w600,
+      color: widget.selected ? colors.primary : colors.onSurface,
+    );
     final Widget titleText = Padding(
       padding: const EdgeInsets.fromLTRB(6, 8, 6, 2),
-      child: Text(
-        widget.title,
-        // BUG-1184：galgame 名普遍 20 字以上，窄屏卡宽只有约 136px，单行只看得到
-        // 开头六七个字。封面在 [Flexible] 里，标题变高只是等量压缩封面、不会溢出。
+      // TODO-2490：两行仍放不下的长游戏名，桌面悬停显示完整标题；触屏走卡片
+      // 长按菜单（标题不限行）看全名。
+      child: ShelfTitleOverflowTooltip(
+        title: widget.title,
+        style: titleStyle,
         maxLines: 2,
-        overflow: TextOverflow.ellipsis,
-        textAlign: TextAlign.center,
-        style: theme.textTheme.titleSmall?.copyWith(
-          fontWeight: FontWeight.w600,
-          color: widget.selected ? colors.primary : colors.onSurface,
+        child: Text(
+          widget.title,
+          // BUG-1184：galgame 名普遍 20 字以上，窄屏卡宽只有约 136px，单行只看得到
+          // 开头六七个字。封面在 [Flexible] 里，标题变高只是等量压缩封面、不会溢出。
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          textAlign: TextAlign.center,
+          style: titleStyle,
         ),
       ),
     );

--- a/hibiki/lib/src/utils/components/shelf_card_widgets.dart
+++ b/hibiki/lib/src/utils/components/shelf_card_widgets.dart
@@ -45,6 +45,10 @@ class ShelfCardFooter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
+    final TextStyle style = tokens.type.metadata.copyWith(
+      color: tokens.surfaces.onSurface,
+      fontWeight: FontWeight.w600,
+    );
     return Padding(
       padding: EdgeInsetsDirectional.fromSTEB(
         tokens.spacing.gap * 0.75,
@@ -54,15 +58,19 @@ class ShelfCardFooter extends StatelessWidget {
       ),
       child: Align(
         alignment: Alignment.topCenter,
-        child: Text(
-          title,
-          overflow: TextOverflow.ellipsis,
+        // TODO-2490：两行仍放不下的长书名，桌面悬停显示完整标题；触屏侧的全名
+        // 兜底是长按菜单（MediaItemDialogFrame 标题已不限行）。
+        child: ShelfTitleOverflowTooltip(
+          title: title,
+          style: style,
           maxLines: 2,
-          textAlign: TextAlign.center,
-          softWrap: true,
-          style: tokens.type.metadata.copyWith(
-            color: tokens.surfaces.onSurface,
-            fontWeight: FontWeight.w600,
+          child: Text(
+            title,
+            overflow: TextOverflow.ellipsis,
+            maxLines: 2,
+            textAlign: TextAlign.center,
+            softWrap: true,
+            style: style,
           ),
         ),
       ),
@@ -205,6 +213,66 @@ class ShelfFileCover extends StatelessWidget {
       image: resizedFileImage(File(path)),
       alignment: alignment,
       fit: fit,
+    );
+  }
+}
+
+/// 卡片标题溢出提示（TODO-2490）：三库页卡片标题统一「最多两行 + 省略号」
+/// （BUG-1184），但两行仍放不下的长名此前没有任何看全名的途径。本组件用与
+/// 内部 [Text] 相同的 [style] / [maxLines] 先测量
+/// （[TextPainter.didExceedMaxLines]，与 `hibiki_marquee.dart` 的溢出探测同
+/// 范式），**仅溢出时**才包 [Tooltip]：
+///
+/// - 桌面：鼠标悬停气泡显示完整标题；
+/// - 触屏：不新造交互——`triggerMode: manual` 不注册点按/长按识别器，不与
+///   卡片自身的长按菜单抢手势竞技场；长按菜单（`MediaItemDialogFrame`）标题
+///   不限行，是触屏侧的看全名路径；
+/// - 读屏：[Text] 语义本就携带完整字符串，`excludeFromSemantics` 避免重复播报。
+class ShelfTitleOverflowTooltip extends StatelessWidget {
+  const ShelfTitleOverflowTooltip({
+    required this.title,
+    required this.style,
+    required this.maxLines,
+    required this.child,
+    super.key,
+  });
+
+  /// 完整标题（Tooltip 消息），与 [child] 里 Text 的 data 同源。
+  final String title;
+
+  /// 与 [child] 里 Text 相同的样式——测量必须同参，否则溢出判定失真。
+  final TextStyle? style;
+
+  /// 与 [child] 里 Text 相同的行数上限。
+  final int maxLines;
+
+  /// 实际渲染的标题 [Text]（省略号截断的那份）。
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        if (!constraints.hasBoundedWidth) return child;
+        // 与 [Text] 相同的样式合成路径（inherit 时并入 DefaultTextStyle）。
+        final TextStyle effective =
+            DefaultTextStyle.of(context).style.merge(style);
+        final TextPainter painter = TextPainter(
+          text: TextSpan(text: title, style: effective),
+          maxLines: maxLines,
+          textDirection: Directionality.of(context),
+          textScaler: MediaQuery.textScalerOf(context),
+        )..layout(maxWidth: constraints.maxWidth);
+        final bool overflowed = painter.didExceedMaxLines;
+        painter.dispose();
+        if (!overflowed) return child;
+        return Tooltip(
+          message: title,
+          triggerMode: TooltipTriggerMode.manual,
+          excludeFromSemantics: true,
+          child: child,
+        );
+      },
     );
   }
 }

--- a/hibiki/test/widgets/shelf_title_overflow_tooltip_test.dart
+++ b/hibiki/test/widgets/shelf_title_overflow_tooltip_test.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/pages/implementations/media_item_dialog_page.dart';
+import 'package:hibiki/src/utils/components/galgame_poster_card.dart';
+import 'package:hibiki/src/utils/components/shelf_card_widgets.dart';
+
+/// TODO-2490：库页卡片标题「显示不全」——两行省略号之外必须有看全名的途径。
+///
+/// 共享件 [ShelfTitleOverflowTooltip] 只在标题真溢出 [Text] 的行数上限时挂
+/// [Tooltip]（桌面悬停显示全名），不溢出时不添加任何节点；触屏路径的全名兜底
+/// 是长按菜单 [MediaItemDialogFrame]（标题不限行）。测试字体 Ahem 每字符
+/// 方块宽 = fontSize，行高 = fontSize，几何可精确推算。
+void main() {
+  const String longTitle = '魔法少女まどか☆マギカ劇場版総集編前編始まりの物語後編永遠の物語完全生産限定版';
+  const String shortTitle = '短名';
+
+  Widget host({required double width, required Widget child}) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(child: SizedBox(width: width, child: child)),
+      ),
+    );
+  }
+
+  group('ShelfTitleOverflowTooltip', () {
+    testWidgets('两行放不下的长标题挂 Tooltip，消息为完整标题', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        host(
+          width: 140,
+          child: const ShelfTitleOverflowTooltip(
+            title: longTitle,
+            style: TextStyle(fontSize: 14),
+            maxLines: 2,
+            child: Text(
+              longTitle,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(fontSize: 14),
+            ),
+          ),
+        ),
+      );
+      final Tooltip tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, longTitle, reason: '悬停气泡必须给出完整标题，不是截断后的那份');
+      expect(tooltip.triggerMode, TooltipTriggerMode.manual,
+          reason: '不得注册点按/长按识别器与卡片手势抢竞技场');
+      // 标题真渲染成两行（完整前缀可见），不是单行省略：Ahem 行高 = fontSize，
+      // 两行高度必然超过 1.5 倍行高。
+      final Size textSize = tester.getSize(find.text(longTitle));
+      expect(textSize.height, greaterThan(14 * 1.5),
+          reason: '长标题必须完整换行到第二行，而非单行省略');
+    });
+
+    testWidgets('不溢出的短标题不挂 Tooltip', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        host(
+          width: 140,
+          child: const ShelfTitleOverflowTooltip(
+            title: shortTitle,
+            style: TextStyle(fontSize: 14),
+            maxLines: 2,
+            child: Text(
+              shortTitle,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(fontSize: 14),
+            ),
+          ),
+        ),
+      );
+      expect(find.byType(Tooltip), findsNothing,
+          reason: '放得下的标题不该有悬停气泡（零额外节点）');
+    });
+  });
+
+  group('三库卡片标题接线', () {
+    testWidgets('ShelfCardFooter 长书名溢出时可悬停看全名', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        host(
+          width: 140,
+          child: const SizedBox(
+            height: 48,
+            child: ShelfCardFooter(title: longTitle),
+          ),
+        ),
+      );
+      final Tooltip tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, longTitle);
+    });
+
+    testWidgets('GalgamePosterCard 长名溢出挂 Tooltip 且不吞卡片长按',
+        (WidgetTester tester) async {
+      int longPressed = 0;
+      await tester.pumpWidget(
+        host(
+          width: 140,
+          child: GalgamePosterCard(
+            cover: const ColoredBox(color: Colors.black26),
+            title: longTitle,
+            onLongPress: () => longPressed++,
+          ),
+        ),
+      );
+      final Tooltip tooltip = tester.widget<Tooltip>(find.byType(Tooltip));
+      expect(tooltip.message, longTitle);
+      // triggerMode=manual 不注册长按识别器：标题区长按仍走卡片长按菜单。
+      await tester.longPress(find.byType(Tooltip), warnIfMissed: false);
+      await tester.pumpAndSettle();
+      expect(longPressed, 1, reason: 'Tooltip 不得吃掉卡片的长按（长按菜单是触屏看全名路径）');
+    });
+
+    testWidgets('长按菜单 MediaItemDialogFrame 标题不限行显示全名',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: MediaItemDialogFrame(
+                title: longTitle,
+                showLaunchAction: false,
+              ),
+            ),
+          ),
+        ),
+      );
+      final Text titleText = tester.widget<Text>(find.text(longTitle));
+      expect(titleText.maxLines, isNull, reason: '弹窗是卡片长标题「看全名」的兜底路径，不得再截断');
+      expect(titleText.overflow, isNot(TextOverflow.ellipsis));
+    });
+  });
+}


### PR DESCRIPTION
## 背景（TODO-2490）

用户报视频库页部分卡片名字显示不全。沿真实渲染路径核查发现：**「标题限成一行」的前提已不成立**——BUG-1184 已把三库页（视频散卡/合集卡/远端卡、书架 ShelfCardFooter、游戏 GalgamePosterCard）标题全部改成 `maxLines: 2` + 按真实行高（textLineHeight + kTextBlockSlack）预留文字块。真正剩余缺口：

1. **两行仍放不下的长名没有任何看全名途径**（全仓无标题溢出 Tooltip）；
2. **长按菜单标题自己也是两行省略号**（media_item_dialog_page.dart:298 `maxLines: 2`）——视频卡与游戏卡长按共用该 MediaItemDialogFrame，长按也看不到全名。

## 改动

- 新共享件 `ShelfTitleOverflowTooltip`（shelf_card_widgets.dart）：用与内部 Text 相同 style/maxLines 先 TextPainter 测量（与 hibiki_marquee 溢出探测同范式），**仅真溢出时**挂 Tooltip；`triggerMode: manual` 只响应桌面悬停，不注册点按/长按识别器、不与卡片长按菜单抢手势竞技场；`excludeFromSemantics` 防读屏重复播报（Text 语义本就含完整字符串）。
- 接线五处标题：视频页散卡/合集封面卡/远端占位卡（home_video_page.dart）、书架 ShelfCardFooter、游戏 GalgamePosterCard。**既有 Text 原样保留**（maxLines: 2 字面量守卫不受影响），只外包一层。
- `MediaItemDialogFrame` 标题放开行数限制：长按/右键菜单成为触屏侧看全名兜底；外层 HibikiDialogFrame 默认可滚动 + 限高 0.82 屏，超长名安全。
- 封面 2:3 / 3:4 比例、网格 extent、布局常量全部不动。

## 测试

- 新增 `test/widgets/shelf_title_overflow_tooltip_test.dart`（5 例）：溢出挂 Tooltip 且消息为全名 + 长标题真渲染两行、不溢出零节点、ShelfCardFooter/GalgamePosterCard 接线、Tooltip 不吞卡片长按、弹窗标题不限行。
- `flutter analyze` 全量：No issues found。
- 定向测试 11 个文件（含 video_card_cover_aspect_guard、reader_bookshelf_card_layout_static、md3_design_system_static、media_item_dialog 三件套、games_library_cover_menu）：`00:10 +125: All tests passed!`，退出码 0。

https://claude.ai/code/session_017ZUDdFKDGNxpH4r5UcdWj4