### PR TITLE
feat(torrent): 下载任务行 ETA/分享率/状态文本 + 暂停/恢复（TODO-2481 D1）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 48824 (2872 per locale)
+/// Strings: 49079 (2887 per locale)
 ///
-/// Built on 2026-08-01 at 00:46 UTC
+/// Built on 2026-08-01 at 04:50 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3883,6 +3883,21 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'The server refused this request. Your sign-in is fine - check the server\'s settings.';
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  String get download_task_status_stalled => 'Stalled';
+  String get download_task_status_checking => 'Checking';
+  String get download_task_status_metadata => 'Fetching metadata';
+  String get download_task_status_moving => 'Moving';
+  String get download_task_status_error => 'Error';
+  String get download_task_pause => 'Pause';
+  String get download_task_resume => 'Resume';
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  String get download_task_eta => 'ETA';
+  String get download_task_ratio => 'Ratio';
+  String get download_task_status_downloading => 'Downloading';
+  String get download_task_status_seeding => 'Seeding';
+  String get download_task_status_completed => 'Completed';
+  String get download_task_status_paused => 'Paused';
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -10487,6 +10502,36 @@ class _StringsAr extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -17158,6 +17203,36 @@ class _StringsDe extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -23845,6 +23920,36 @@ class _StringsEs extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -30543,6 +30648,36 @@ class _StringsFr extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -37170,6 +37305,36 @@ class _StringsId extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -43843,6 +44008,36 @@ class _StringsIt extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -50333,6 +50528,36 @@ class _StringsJa extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -56825,6 +57050,36 @@ class _StringsKo extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -63478,6 +63733,36 @@ class _StringsNl extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -70144,6 +70429,36 @@ class _StringsPtBr extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -76794,6 +77109,36 @@ class _StringsRu extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -83392,6 +83737,36 @@ class _StringsTh extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -90022,6 +90397,36 @@ class _StringsTr extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -96637,6 +97042,36 @@ class _StringsVi extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 // Path: <root>
@@ -102779,6 +103214,36 @@ class _StringsZhCn extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       '服务端拒绝了这次请求：${reason}（登录没问题）';
+  @override
+  String get download_task_status_stalled => '等待资源';
+  @override
+  String get download_task_status_checking => '校验中';
+  @override
+  String get download_task_status_metadata => '获取元数据';
+  @override
+  String get download_task_status_moving => '移动中';
+  @override
+  String get download_task_status_error => '出错';
+  @override
+  String get download_task_pause => '暂停';
+  @override
+  String get download_task_resume => '恢复';
+  @override
+  String get download_task_toggle_failed => '暂停/恢复操作失败';
+  @override
+  String get download_task_eta => '剩余';
+  @override
+  String get download_task_ratio => '分享率';
+  @override
+  String get download_task_status_downloading => '下载中';
+  @override
+  String get download_task_status_seeding => '做种中';
+  @override
+  String get download_task_status_completed => '已完成';
+  @override
+  String get download_task_status_paused => '已暂停';
+  @override
+  String get download_task_status_queued => '排队中';
 }
 
 // Path: <root>
@@ -109190,6 +109655,36 @@ class _StringsZhHk extends _StringsEn {
   @override
   String sync_err_forbidden_detail({required Object reason}) =>
       'The server refused this request: ${reason} (your sign-in is fine)';
+  @override
+  String get download_task_status_stalled => 'Stalled';
+  @override
+  String get download_task_status_checking => 'Checking';
+  @override
+  String get download_task_status_metadata => 'Fetching metadata';
+  @override
+  String get download_task_status_moving => 'Moving';
+  @override
+  String get download_task_status_error => 'Error';
+  @override
+  String get download_task_pause => 'Pause';
+  @override
+  String get download_task_resume => 'Resume';
+  @override
+  String get download_task_toggle_failed => 'Pause/resume failed';
+  @override
+  String get download_task_eta => 'ETA';
+  @override
+  String get download_task_ratio => 'Ratio';
+  @override
+  String get download_task_status_downloading => 'Downloading';
+  @override
+  String get download_task_status_seeding => 'Seeding';
+  @override
+  String get download_task_status_completed => 'Completed';
+  @override
+  String get download_task_status_paused => 'Paused';
+  @override
+  String get download_task_status_queued => 'Queued';
 }
 
 /// Flat map(s) containing all translations.
@@ -115083,6 +115578,36 @@ extension on _StringsEn {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -120974,6 +121499,36 @@ extension on _StringsAr {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -126887,6 +127442,36 @@ extension on _StringsDe {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -132799,6 +133384,36 @@ extension on _StringsEs {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -138717,6 +139332,36 @@ extension on _StringsFr {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -144617,6 +145262,36 @@ extension on _StringsId {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -150531,6 +151206,36 @@ extension on _StringsIt {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -156407,6 +157112,36 @@ extension on _StringsJa {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -162287,6 +163022,36 @@ extension on _StringsKo {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -168195,6 +168960,36 @@ extension on _StringsNl {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -174100,6 +174895,36 @@ extension on _StringsPtBr {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -180010,6 +180835,36 @@ extension on _StringsRu {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -185903,6 +186758,36 @@ extension on _StringsTh {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -191805,6 +192690,36 @@ extension on _StringsTr {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -197703,6 +198618,36 @@ extension on _StringsVi {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }
@@ -203548,6 +204493,36 @@ extension on _StringsZhCn {
         return '服务端拒绝了这次请求。登录没问题，请检查服务端设置。';
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) => '服务端拒绝了这次请求：${reason}（登录没问题）';
+      case 'download_task_status_stalled':
+        return '等待资源';
+      case 'download_task_status_checking':
+        return '校验中';
+      case 'download_task_status_metadata':
+        return '获取元数据';
+      case 'download_task_status_moving':
+        return '移动中';
+      case 'download_task_status_error':
+        return '出错';
+      case 'download_task_pause':
+        return '暂停';
+      case 'download_task_resume':
+        return '恢复';
+      case 'download_task_toggle_failed':
+        return '暂停/恢复操作失败';
+      case 'download_task_eta':
+        return '剩余';
+      case 'download_task_ratio':
+        return '分享率';
+      case 'download_task_status_downloading':
+        return '下载中';
+      case 'download_task_status_seeding':
+        return '做种中';
+      case 'download_task_status_completed':
+        return '已完成';
+      case 'download_task_status_paused':
+        return '已暂停';
+      case 'download_task_status_queued':
+        return '排队中';
       default:
         return null;
     }
@@ -209419,6 +210394,36 @@ extension on _StringsZhHk {
       case 'sync_err_forbidden_detail':
         return ({required Object reason}) =>
             'The server refused this request: ${reason} (your sign-in is fine)';
+      case 'download_task_status_stalled':
+        return 'Stalled';
+      case 'download_task_status_checking':
+        return 'Checking';
+      case 'download_task_status_metadata':
+        return 'Fetching metadata';
+      case 'download_task_status_moving':
+        return 'Moving';
+      case 'download_task_status_error':
+        return 'Error';
+      case 'download_task_pause':
+        return 'Pause';
+      case 'download_task_resume':
+        return 'Resume';
+      case 'download_task_toggle_failed':
+        return 'Pause/resume failed';
+      case 'download_task_eta':
+        return 'ETA';
+      case 'download_task_ratio':
+        return 'Ratio';
+      case 'download_task_status_downloading':
+        return 'Downloading';
+      case 'download_task_status_seeding':
+        return 'Seeding';
+      case 'download_task_status_completed':
+        return 'Completed';
+      case 'download_task_status_paused':
+        return 'Paused';
+      case 'download_task_status_queued':
+        return 'Queued';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "进入字幕选词光标",
   "audiobook_export_clip_too_long": "选区音频过长，暂不支持导出（上限 5 分钟）",
   "sync_err_forbidden": "服务端拒绝了这次请求。登录没问题，请检查服务端设置。",
-  "sync_err_forbidden_detail": "服务端拒绝了这次请求：$reason（登录没问题）"
+  "sync_err_forbidden_detail": "服务端拒绝了这次请求：$reason（登录没问题）",
+  "download_task_status_stalled": "等待资源",
+  "download_task_status_checking": "校验中",
+  "download_task_status_metadata": "获取元数据",
+  "download_task_status_moving": "移动中",
+  "download_task_status_error": "出错",
+  "download_task_pause": "暂停",
+  "download_task_resume": "恢复",
+  "download_task_toggle_failed": "暂停/恢复操作失败",
+  "download_task_eta": "剩余",
+  "download_task_ratio": "分享率",
+  "download_task_status_downloading": "下载中",
+  "download_task_status_seeding": "做种中",
+  "download_task_status_completed": "已完成",
+  "download_task_status_paused": "已暂停",
+  "download_task_status_queued": "排队中"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2870,5 +2870,20 @@
   "shortcut_action_video_enter_caret": "Enter subtitle lookup cursor",
   "audiobook_export_clip_too_long": "Selection audio is too long to export (limit: 5 minutes)",
   "sync_err_forbidden": "The server refused this request. Your sign-in is fine - check the server's settings.",
-  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)"
+  "sync_err_forbidden_detail": "The server refused this request: $reason (your sign-in is fine)",
+  "download_task_status_stalled": "Stalled",
+  "download_task_status_checking": "Checking",
+  "download_task_status_metadata": "Fetching metadata",
+  "download_task_status_moving": "Moving",
+  "download_task_status_error": "Error",
+  "download_task_pause": "Pause",
+  "download_task_resume": "Resume",
+  "download_task_toggle_failed": "Pause/resume failed",
+  "download_task_eta": "ETA",
+  "download_task_ratio": "Ratio",
+  "download_task_status_downloading": "Downloading",
+  "download_task_status_seeding": "Seeding",
+  "download_task_status_completed": "Completed",
+  "download_task_status_paused": "Paused",
+  "download_task_status_queued": "Queued"
 }

--- a/hibiki/lib/src/media/torrent/anime_download_service.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_service.dart
@@ -34,6 +34,8 @@ class DownloadTaskStats {
     required this.downloadedBytes,
     required this.uploadedBytes,
     required this.numPeers,
+    required this.state,
+    required this.amountLeft,
   });
 
   /// 从后端快照投影。
@@ -45,6 +47,8 @@ class DownloadTaskStats {
       downloadedBytes: info.downloadedBytes,
       uploadedBytes: info.uploadedBytes,
       numPeers: info.numPeers,
+      state: info.state,
+      amountLeft: info.amountLeft,
     );
   }
 
@@ -66,6 +70,13 @@ class DownloadTaskStats {
   /// 当前连接的 peer 数。
   final int numPeers;
 
+  /// 后端状态字符串（TODO-2481：此前投影时被丢弃。qb 与内置引擎词汇不同，
+  /// UI 一律经 `torrent_task_display.dart` 的纯函数映射，不裸比较）。
+  final String state;
+
+  /// 剩余待下载字节；-1 = 未知（TODO-2481：ETA 分子，此前投影时被丢弃）。
+  final int amountLeft;
+
   @override
   bool operator ==(Object other) {
     return other is DownloadTaskStats &&
@@ -74,12 +85,14 @@ class DownloadTaskStats {
         other.upRateBps == upRateBps &&
         other.downloadedBytes == downloadedBytes &&
         other.uploadedBytes == uploadedBytes &&
-        other.numPeers == numPeers;
+        other.numPeers == numPeers &&
+        other.state == state &&
+        other.amountLeft == amountLeft;
   }
 
   @override
   int get hashCode => Object.hash(progress, downRateBps, upRateBps,
-      downloadedBytes, uploadedBytes, numPeers);
+      downloadedBytes, uploadedBytes, numPeers, state, amountLeft);
 }
 
 /// 把种子文件列表解析为视频绝对路径列表。纯函数。

--- a/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_backend.dart
@@ -18,16 +18,26 @@ import 'package:hibiki_torrent/hibiki_torrent.dart';
 ///   记入 [_pendingFirstLast]，在每次 [listTorrents] 轮询时补应用 ——
 ///   上层服务本就以 20s tick 轮询，无需额外定时器。
 /// - close 只关本后端持有的 session；引擎（DLL）进程级共享不关。
-class EmbeddedTorrentBackend implements TorrentRemovalBackend {
+class EmbeddedTorrentBackend
+    implements TorrentRemovalBackend, TorrentPauseBackend {
   EmbeddedTorrentBackend({
     required EmbeddedTorrentSession session,
     required TorrentSaveRoots saveRoots,
     bool closesSession = true,
+    EmbeddedPauseControl? pauseControl,
   })  : _session = session,
         _saveRoots = saveRoots,
-        _closesSession = closesSession;
+        _closesSession = closesSession,
+        _pauseControl = pauseControl;
 
   final EmbeddedTorrentSession _session;
+
+  /// TODO-2481：宿主注入的暂停控制通道；null = standalone（自持 session），
+  /// 退化为直接调 session + 自持暂停集合（backend 与 session 同寿命）。
+  final EmbeddedPauseControl? _pauseControl;
+
+  /// standalone 形态下自持的「已知暂停」集合（infohash 小写）。
+  final Set<String> _localPaused = <String>{};
 
   /// 活动根 + 历史根。写入只用活动根，列表认全部（见类注释）。
   final TorrentSaveRoots _saveRoots;
@@ -133,6 +143,36 @@ class EmbeddedTorrentBackend implements TorrentRemovalBackend {
   }) async =>
       _session.removeTorrent(torrentId, deleteFiles: deleteFiles);
 
+  /// 暂停/恢复原语与上传策略同一组 DLL 符号；老随包 DLL 缺符号时 false。
+  @override
+  bool get pauseControlAvailable =>
+      _pauseControl?.available() ?? _session.supportsUploadControl;
+
+  @override
+  Future<bool> pauseTorrent(String torrentId) async {
+    final EmbeddedPauseControl? control = _pauseControl;
+    if (control != null) return control.pause(torrentId);
+    final String id = torrentId.toLowerCase();
+    if (!_session.pauseTorrent(id, pause: true)) return false;
+    _localPaused.add(id);
+    return true;
+  }
+
+  @override
+  Future<bool> resumeTorrent(String torrentId) async {
+    final EmbeddedPauseControl? control = _pauseControl;
+    if (control != null) return control.resume(torrentId);
+    final String id = torrentId.toLowerCase();
+    if (!_session.pauseTorrent(id, pause: false)) return false;
+    _localPaused.remove(id);
+    return true;
+  }
+
+  /// 该种子是否已知处于暂停态（宿主真相优先；standalone 用自持集合）。
+  bool _isPausedForDisplay(String infoHash) =>
+      _pauseControl?.isPaused(infoHash) ??
+      _localPaused.contains(infoHash.toLowerCase());
+
   @override
   Future<TorrentStorageResult> renameFile(
     String torrentId,
@@ -169,11 +209,18 @@ class EmbeddedTorrentBackend implements TorrentRemovalBackend {
   }
 
   TorrentSnapshot _toSnapshot(HtTorrentStatus t) {
+    // TODO-2481：native 的 state_label 不导出 paused（libtorrent 里 paused
+    // 是 flag 不是 state），已知暂停的种子把 state 覆写成 qb 词汇
+    // pausedDL/pausedUP —— UI 状态文本与 [TorrentSnapshot.isComplete]
+    // （pausedUP 属做种类）吃的都是这个词。
+    final String state = _isPausedForDisplay(t.id)
+        ? (t.isFinished ? 'pausedUP' : 'pausedDL')
+        : t.state;
     return TorrentSnapshot(
       hash: t.id,
       name: t.name,
       progress: t.progress,
-      state: t.state,
+      state: state,
       savePath: t.savePath,
       contentPath: t.contentPath,
       amountLeft: t.left,
@@ -185,4 +232,28 @@ class EmbeddedTorrentBackend implements TorrentRemovalBackend {
       numPeers: t.numPeers,
     );
   }
+}
+
+/// TODO-2481：宿主注入的暂停控制通道。暂停状态的真相在常驻
+/// `EmbeddedTorrentHost`（短命适配器每 tick 重建，自持状态活不过一轮），
+/// backend 只做转发；standalone 场景不传，backend 退化为直连 session。
+class EmbeddedPauseControl {
+  const EmbeddedPauseControl({
+    required this.available,
+    required this.pause,
+    required this.resume,
+    required this.isPaused,
+  });
+
+  /// 运行时能力位（老 DLL 缺 `ht_pause_torrent` 符号时 false）。
+  final bool Function() available;
+
+  /// 暂停一个种子（入参 infohash），返回是否成功。
+  final bool Function(String infoHash) pause;
+
+  /// 恢复一个种子，返回是否成功。
+  final bool Function(String infoHash) resume;
+
+  /// 该种子当前是否已知处于暂停态（用户或策略）。
+  final bool Function(String infoHash) isPaused;
 }

--- a/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
@@ -114,6 +114,13 @@ class EmbeddedTorrentHost {
   /// 已下发的 per-torrent 暂停状态（做种超限/关上传时停止做种用）。
   final Map<String, bool> _appliedPaused = <String, bool>{};
 
+  /// TODO-2481：用户显式暂停的种子（infohash 小写）。与策略暂停
+  /// [_appliedPaused] 分开记：[sweepUploadPolicy] 对这里的种子整体跳过，
+  /// 不得替用户 resume。仅内存态 —— 重启后 `ht_load_resume_dir` 会清
+  /// paused 旗标（native 契约「加回来即开始跑」），暂停不跨会话持久，
+  /// 持久化留给 D2（native 导出 is_paused / 计划级落盘）。
+  final Set<String> _userPaused = <String>{};
+
   /// 是否已做过一次性「清 upload_mode 残留」治愈（BUG-1293：旧版本给种子打上
   /// 的 upload_mode flag 会随 resume 复活，掐死下载；开机清一次即可）。
   bool _healedUploadMode = false;
@@ -376,12 +383,53 @@ class EmbeddedTorrentHost {
 
   /// 派发一个短命后端适配器（共享常驻 session；其 close 不销毁会话）。
   /// 供 `AnimeDownloadService.backendFactory` 每 tick 调用。
+  ///
+  /// TODO-2481：暂停状态的真相在本宿主（适配器每 tick 重建，自持状态活
+  /// 不过一轮），暂停/恢复/显示查询经 [EmbeddedPauseControl] 回注宿主。
   EmbeddedTorrentBackend backendView() {
     return EmbeddedTorrentBackend(
       session: _session,
       saveRoots: _saveRoots,
       closesSession: false,
+      pauseControl: EmbeddedPauseControl(
+        available: () => supportsPauseControl,
+        pause: pauseTorrentByUser,
+        resume: resumeTorrentByUser,
+        isPaused: isTorrentPausedForDisplay,
+      ),
     );
+  }
+
+  /// TODO-2481：底层 DLL 是否具备 per-torrent 暂停/恢复原语
+  /// （与上传策略同一组符号；老随包 DLL 没有）。
+  bool get supportsPauseControl => _session.supportsUploadControl;
+
+  /// TODO-2481：用户显式暂停一个种子（清 auto_managed 再 pause，
+  /// 否则队列管理器会自动恢复）。成功后记入 [_userPaused]。
+  bool pauseTorrentByUser(String infoHash) {
+    final String id = infoHash.toLowerCase();
+    if (!_session.pauseTorrent(id, pause: true)) return false;
+    _userPaused.add(id);
+    return true;
+  }
+
+  /// TODO-2481：用户显式恢复。同时清掉策略暂停记录 [_appliedPaused]，
+  /// 让 [sweepUploadPolicy] 下一轮重新裁决 —— 做种超限的种子会被策略再次
+  /// 暂停，这是策略语义使然，不是抢用户的手。
+  bool resumeTorrentByUser(String infoHash) {
+    final String id = infoHash.toLowerCase();
+    if (!_session.pauseTorrent(id, pause: false)) return false;
+    _userPaused.remove(id);
+    _appliedPaused.remove(id);
+    return true;
+  }
+
+  /// TODO-2481：该种子当前是否处于（用户或策略）暂停态。native 的
+  /// state_label 不导出 paused（libtorrent 里 paused 是 flag 不是 state），
+  /// 快照层据此把 state 覆写成 pausedDL/pausedUP 供 UI 显示。
+  bool isTorrentPausedForDisplay(String infoHash) {
+    final String id = infoHash.toLowerCase();
+    return _userPaused.contains(id) || _appliedPaused[id] == true;
   }
 
   /// 当前下载根集合（活动根 + 历史根）。诊断/设置页展示用。
@@ -520,6 +568,9 @@ class EmbeddedTorrentHost {
       final Set<String> live = <String>{};
       for (final HtTorrentStatus t in _session.listTorrents()) {
         live.add(t.id);
+        // TODO-2481：用户显式暂停的种子策略整体跳过 —— 既不重复 pause，
+        // 也绝不替用户 resume（否则下一 tick 就把用户按下的暂停偷偷抢回）。
+        if (_userPaused.contains(t.id)) continue;
         if (t.isSeeding) {
           _seedStartMs.putIfAbsent(t.id, () => nowMs);
         }
@@ -546,6 +597,7 @@ class EmbeddedTorrentHost {
       // 清理已移除种子的残留状态。
       _seedStartMs.removeWhere((String k, int v) => !live.contains(k));
       _appliedPaused.removeWhere((String k, bool v) => !live.contains(k));
+      _userPaused.removeWhere((String k) => !live.contains(k));
       return changed;
     } on Object {
       return 0;

--- a/hibiki/lib/src/media/torrent/qb_torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/qb_torrent_backend.dart
@@ -3,10 +3,23 @@ import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 
 /// [TorrentBackend] 的外接 qBittorrent 实现：纯转发适配器，把接口语义
 /// 一一映射到 [QBittorrentClient] 的 WebUI 调用，不加任何额外逻辑。
-class QbTorrentBackend implements TorrentRemovalBackend {
+class QbTorrentBackend implements TorrentRemovalBackend, TorrentPauseBackend {
   QbTorrentBackend(this._client);
 
   final QBittorrentClient _client;
+
+  /// qb WebUI 一直有暂停/恢复端点（4.x pause/resume、5.x stop/start，
+  /// 客户端已双名兼容），能力恒可用。
+  @override
+  bool get pauseControlAvailable => true;
+
+  @override
+  Future<bool> pauseTorrent(String torrentId) =>
+      _client.pauseTorrent(torrentId);
+
+  @override
+  Future<bool> resumeTorrent(String torrentId) =>
+      _client.resumeTorrent(torrentId);
 
   /// 连接测试 = 拉 WebUI 版本号（如 `v4.6.5`）；失败返回 null。
   @override

--- a/hibiki/lib/src/media/torrent/qbittorrent_client.dart
+++ b/hibiki/lib/src/media/torrent/qbittorrent_client.dart
@@ -288,6 +288,42 @@ class QBittorrentClient {
     return res != null && res.statusCode == 200;
   }
 
+  /// TODO-2481：暂停单个种子：`POST /api/v2/torrents/pause`（form 参数
+  /// hashes）。qBittorrent 5.0（WebUI API ≥ 2.11）把端点改名成
+  /// `/torrents/stop` 并移除旧名 —— 404 时回退新名（外部系统版本差异，
+  /// 本客户端无从根治，只能双名兼容）。
+  Future<bool> pauseTorrent(String hash) =>
+      _postTorrentsToggle(hash, primary: 'pause', renamed: 'stop');
+
+  /// TODO-2481：恢复单个种子：`POST /api/v2/torrents/resume`；qb 5.0 改名
+  /// `/torrents/start`，404 回退，同 [pauseTorrent]。
+  Future<bool> resumeTorrent(String hash) =>
+      _postTorrentsToggle(hash, primary: 'resume', renamed: 'start');
+
+  /// 暂停/恢复的公共发送路径：先老端点 [primary]，404（qb 5.0 移除旧名）
+  /// 再试新端点 [renamed]。两名皆失败返回 false。
+  Future<bool> _postTorrentsToggle(
+    String hash, {
+    required String primary,
+    required String renamed,
+  }) async {
+    if (hash.isEmpty) return false;
+    final Map<String, String> form = <String, String>{'hashes': hash};
+    final http.Response? res = await _request(
+      'POST',
+      '/api/v2/torrents/$primary',
+      form: form,
+    );
+    if (res != null && res.statusCode == 200) return true;
+    if (res == null || res.statusCode != 404) return false;
+    final http.Response? retry = await _request(
+      'POST',
+      '/api/v2/torrents/$renamed',
+      form: form,
+    );
+    return retry != null && retry.statusCode == 200;
+  }
+
   /// TODO-1961-c：改名种子内文件：`POST /api/v2/torrents/renameFile`
   /// （qb ≥ 4.2.1，参数 hash / oldPath / newPath）。
   ///

--- a/hibiki/lib/src/media/torrent/torrent_backend.dart
+++ b/hibiki/lib/src/media/torrent/torrent_backend.dart
@@ -89,6 +89,25 @@ abstract interface class TorrentRemovalBackend implements TorrentBackend {
   Future<bool> removeTorrent(String torrentId, {bool deleteFiles = false});
 }
 
+/// TODO-2481：支持暂停/恢复单个种子的后端能力。与 [TorrentRemovalBackend]
+/// 同姿态的可选能力接口：UI 用 `backend is TorrentPauseBackend` 探测，
+/// 只读 fake 不被迫伪造支持。
+///
+/// qBittorrent 与内置引擎都实现；内置引擎在随包 DLL 过旧（缺
+/// `ht_pause_torrent` 符号）时 [pauseControlAvailable] 为 false ——
+/// 类型探测过了也要看这一位，否则按钮点了永远失败。
+abstract interface class TorrentPauseBackend implements TorrentBackend {
+  /// 运行时能力位：底层是否真的具备暂停/恢复原语。
+  bool get pauseControlAvailable;
+
+  /// 暂停种子（qb：stop/pause；内置：清 auto_managed 再 pause）。
+  /// 失败（种子不存在/后端不支持）返回 false，绝不抛。
+  Future<bool> pauseTorrent(String torrentId);
+
+  /// 恢复种子（qb：start/resume；内置：恢复 auto_managed 并 resume）。
+  Future<bool> resumeTorrent(String torrentId);
+}
+
 /// 种子内的单个文件（后端无关）。
 class TorrentFileEntry {
   const TorrentFileEntry({

--- a/hibiki/lib/src/media/torrent/torrent_task_display.dart
+++ b/hibiki/lib/src/media/torrent/torrent_task_display.dart
@@ -1,0 +1,134 @@
+/// TODO-2481：下载任务行的显示格式化 —— 全部纯函数，UI 与后端都不 import
+/// 这里以外的东西（无 Flutter 依赖，单测直跑）。
+///
+/// 后端 state 词汇不统一（qb：`downloading`/`stalledDL`/`pausedUP`…；
+/// 内置引擎：`metadata`/`checking`/`downloading`/`finished`/`seeding`/`error`
+/// + 快照层合成的 `pausedDL`/`pausedUP`），UI 一律先经 [torrentDisplayStatusFor]
+/// 折叠成 [TorrentDisplayStatus] 再挑 i18n 文案，绝不裸比较字符串。
+library;
+
+/// 任务行状态文本的后端无关值域。
+enum TorrentDisplayStatus {
+  /// 正在下载（含强制下载）。
+  downloading,
+
+  /// 做种/上传中（数据已完整）。
+  seeding,
+
+  /// 已完成（内置引擎 `finished`：下载完但未在做种）。
+  completed,
+
+  /// 已暂停/停止（qb 4.x paused* / qb 5.x stopped* / 合成 paused*）。
+  paused,
+
+  /// 排队等待（下载或做种队列）。
+  queued,
+
+  /// 等待资源（连不上可用 peer，qb stalled*）。
+  stalled,
+
+  /// 校验文件中（含分配磁盘空间）。
+  checking,
+
+  /// 拉取元数据中（磁力链接起步阶段）。
+  fetchingMetadata,
+
+  /// 移动存储中（qb moving）。
+  moving,
+
+  /// 出错（含文件丢失）。
+  error,
+
+  /// 未知状态（新版本后端的新词）——UI 不显示状态段。
+  unknown,
+}
+
+/// 后端 state 字符串 → 显示状态。未知词返回 [TorrentDisplayStatus.unknown]。
+TorrentDisplayStatus torrentDisplayStatusFor(String state) {
+  switch (state) {
+    // 下载中：qb + 内置引擎共用 `downloading`。
+    case 'downloading':
+    case 'forcedDL':
+      return TorrentDisplayStatus.downloading;
+    // 做种：qb uploading/stalledUP 数据已完整、正在（或随时可）上传；
+    // 内置引擎 seeding。
+    case 'uploading':
+    case 'forcedUP':
+    case 'stalledUP':
+    case 'seeding':
+      return TorrentDisplayStatus.seeding;
+    case 'finished':
+      return TorrentDisplayStatus.completed;
+    // 暂停：qb 4.x paused* / qb 5.x stopped* / 内置引擎快照层合成 paused*。
+    case 'pausedDL':
+    case 'pausedUP':
+    case 'stoppedDL':
+    case 'stoppedUP':
+      return TorrentDisplayStatus.paused;
+    case 'queuedDL':
+    case 'queuedUP':
+      return TorrentDisplayStatus.queued;
+    case 'stalledDL':
+      return TorrentDisplayStatus.stalled;
+    // 校验：qb checking* / allocating（磁盘准备）与内置引擎 checking。
+    case 'checkingDL':
+    case 'checkingUP':
+    case 'checkingResumeData':
+    case 'allocating':
+    case 'checking':
+      return TorrentDisplayStatus.checking;
+    // 元数据：qb metaDL / forcedMetaDL 与内置引擎 metadata。
+    case 'metaDL':
+    case 'forcedMetaDL':
+    case 'metadata':
+      return TorrentDisplayStatus.fetchingMetadata;
+    case 'moving':
+      return TorrentDisplayStatus.moving;
+    case 'error':
+    case 'missingFiles':
+      return TorrentDisplayStatus.error;
+    default:
+      return TorrentDisplayStatus.unknown;
+  }
+}
+
+/// ETA 上限：超过 100 天的估算只剩噪声（qb 同类场景显示 ∞），不显示。
+const Duration kTorrentEtaDisplayCap = Duration(days: 100);
+
+/// 剩余时间估算：`amountLeft / downRateBps`，返回 `12m34s` 一类紧凑串。
+///
+/// 不可估算一律返回 null（调用方整段不渲染）：
+/// - [amountLeft] < 0 = 未知、== 0 = 已完成；
+/// - [downRateBps] <= 0 = 速度为 0（除零且「卡住」本身由速度段表达）；
+/// - 估值超过 [kTorrentEtaDisplayCap]。
+String? formatTorrentEta({required int amountLeft, required int downRateBps}) {
+  if (amountLeft <= 0 || downRateBps <= 0) return null;
+  final int seconds = (amountLeft / downRateBps).ceil();
+  if (seconds > kTorrentEtaDisplayCap.inSeconds) return null;
+  return formatCompactDuration(Duration(seconds: seconds));
+}
+
+/// 紧凑时长串：取最高两级单位，次级补零两位（`45s` / `12m34s` / `1h02m` /
+/// `2d07h`）。[duration] 为负按 0 处理。
+String formatCompactDuration(Duration duration) {
+  final int total = duration.inSeconds < 0 ? 0 : duration.inSeconds;
+  final int days = total ~/ 86400;
+  final int hours = (total % 86400) ~/ 3600;
+  final int minutes = (total % 3600) ~/ 60;
+  final int seconds = total % 60;
+  if (days > 0) return '${days}d${hours.toString().padLeft(2, '0')}h';
+  if (hours > 0) return '${hours}h${minutes.toString().padLeft(2, '0')}m';
+  if (minutes > 0) return '${minutes}m${seconds.toString().padLeft(2, '0')}s';
+  return '${seconds}s';
+}
+
+/// 分享率：`uploadedBytes / downloadedBytes`，两位小数（qb 同款）。
+/// 分母 <= 0（尚未下到任何字节）返回 null，不显示。
+String? formatShareRatio({
+  required int uploadedBytes,
+  required int downloadedBytes,
+}) {
+  if (downloadedBytes <= 0) return null;
+  final double ratio = uploadedBytes / downloadedBytes;
+  return ratio.toStringAsFixed(2);
+}

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -14,6 +14,7 @@ import 'package:hibiki/src/media/torrent/download_network_proxy.dart'
 import 'package:hibiki/src/media/torrent/download_relocate_service.dart';
 import 'package:hibiki/src/media/torrent/nyaa_client.dart';
 import 'package:hibiki/src/media/torrent/torrent_backend.dart';
+import 'package:hibiki/src/media/torrent/torrent_task_display.dart';
 import 'package:hibiki/src/media/video/anilist_client.dart';
 import 'package:hibiki/src/media/video/jimaku_client.dart';
 import 'package:hibiki/src/models/app_model.dart';
@@ -2215,6 +2216,77 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     await _reloadPlans();
   }
 
+  /// TODO-2481：当前后端是否支持暂停/恢复。探测 = `is TorrentPauseBackend`
+  /// + 运行时能力位（内置引擎老 DLL 缺原语时类型过了也点不动）。对话框
+  /// 生命周期内缓存一次 —— 只在任务行确实处于下载中时才会走到这里，此时
+  /// 轮询服务本就每 tick 建同款后端，探测不会额外拉起会话。
+  bool? _pauseCapableCache;
+
+  bool get _pauseCapable {
+    final bool? cached = _pauseCapableCache;
+    if (cached != null) return cached;
+    if (!_backendReady) return false;
+    final AppModel appModel = ref.read(appProvider);
+    final TorrentBackend backend = appModel.createTorrentBackend(
+      effectiveTorrentConfig(appModel.qbConnectionConfig),
+    );
+    bool capable = false;
+    try {
+      capable = backend is TorrentPauseBackend && backend.pauseControlAvailable;
+    } finally {
+      backend.close();
+    }
+    _pauseCapableCache = capable;
+    return capable;
+  }
+
+  /// TODO-2481：暂停/恢复单个任务；成功即踢一轮 tick 刷新快照与状态文本。
+  Future<void> _togglePausePlan(
+    AnimeDownloadPlan plan, {
+    required bool pause,
+  }) async {
+    final AppModel appModel = ref.read(appProvider);
+    if (!torrentBackendReady(appModel)) {
+      _snack(t.download_backend_not_configured);
+      return;
+    }
+    final TorrentBackend backend = appModel.createTorrentBackend(
+      effectiveTorrentConfig(appModel.qbConnectionConfig),
+    );
+    bool ok = false;
+    try {
+      if (backend is TorrentPauseBackend) {
+        ok = pause
+            ? await backend.pauseTorrent(plan.id)
+            : await backend.resumeTorrent(plan.id);
+      }
+    } finally {
+      backend.close();
+    }
+    if (!ok) {
+      _snack(t.download_task_toggle_failed);
+      return;
+    }
+    unawaited(appModel.animeDownloadService?.tick());
+  }
+
+  /// TODO-2481：显示状态 → i18n 文案；unknown 返回 null（该段不渲染）。
+  String? _torrentStatusLabel(TorrentDisplayStatus status) {
+    return switch (status) {
+      TorrentDisplayStatus.downloading => t.download_task_status_downloading,
+      TorrentDisplayStatus.seeding => t.download_task_status_seeding,
+      TorrentDisplayStatus.completed => t.download_task_status_completed,
+      TorrentDisplayStatus.paused => t.download_task_status_paused,
+      TorrentDisplayStatus.queued => t.download_task_status_queued,
+      TorrentDisplayStatus.stalled => t.download_task_status_stalled,
+      TorrentDisplayStatus.checking => t.download_task_status_checking,
+      TorrentDisplayStatus.fetchingMetadata => t.download_task_status_metadata,
+      TorrentDisplayStatus.moving => t.download_task_status_moving,
+      TorrentDisplayStatus.error => t.download_task_status_error,
+      TorrentDisplayStatus.unknown => null,
+    };
+  }
+
   /// 单条任务行（[HibikiListItem] compact，自动接焦点系统）。
   ///
   /// - 下载中：轮询服务透传的真实进度（[AnimeDownloadService.downloadProgress]）
@@ -2281,14 +2353,35 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
     // BUG-1294：进度百分比之外补速度与累计流量（单位串是纯数字/符号，无需
     // i18n key）。速率为 0 时仍显示（「0 B/s 卡住了」本身就是有效信息）。
     // BUG-1296：百分比只依赖 progress；观测值缺席就只渲染百分比，不整条消失。
+    // TODO-2481：再补状态文本 / ETA / 分享率 —— 三者都是增强位，算不出
+    // （未知词 / 零速度 / 零分母）就整段不渲染，绝不把百分比一起吞掉。
+    final TorrentDisplayStatus? displayStatus =
+        stats == null ? null : torrentDisplayStatusFor(stats.state);
+    final String? statusLabel =
+        displayStatus == null ? null : _torrentStatusLabel(displayStatus);
+    final String? etaText = stats == null
+        ? null
+        : formatTorrentEta(
+            amountLeft: stats.amountLeft,
+            downRateBps: stats.downRateBps,
+          );
+    final String? ratioText = stats == null
+        ? null
+        : formatShareRatio(
+            uploadedBytes: stats.uploadedBytes,
+            downloadedBytes: stats.downloadedBytes,
+          );
     final String? progressText = (downloading && progress != null)
         ? <String>[
             '${(progress * 100).toStringAsFixed(0)}%',
+            if (statusLabel != null) statusLabel,
             if (stats != null) ...<String>[
               '↓ ${HibikiByteFormat.speed(stats.downRateBps.toDouble())}',
               '↑ ${HibikiByteFormat.speed(stats.upRateBps.toDouble())}',
               HibikiByteFormat.bytes(stats.downloadedBytes),
             ],
+            if (etaText != null) '${t.download_task_eta} $etaText',
+            if (ratioText != null) '${t.download_task_ratio} $ratioText',
           ].join(' · ')
         : null;
     final String? failReason =
@@ -2358,6 +2451,23 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[
+          // TODO-2481：暂停/恢复（仅后端具备该能力时显示）。图标随当前
+          // 状态切换；操作成功由 tick 刷出新状态，无本地乐观态。
+          if (downloading && _pauseCapable)
+            if (displayStatus == TorrentDisplayStatus.paused)
+              HibikiIconButton(
+                tooltip: t.download_task_resume,
+                icon: Icons.play_arrow_outlined,
+                size: 20,
+                onTap: () => _togglePausePlan(plan, pause: false),
+              )
+            else
+              HibikiIconButton(
+                tooltip: t.download_task_pause,
+                icon: Icons.pause_circle_outline,
+                size: 20,
+                onTap: () => _togglePausePlan(plan, pause: true),
+              ),
           if (downloading && !plan.importedEarly)
             HibikiIconButton(
               tooltip: t.anime_download_play_now,

--- a/hibiki/test/media/torrent/torrent_task_display_test.dart
+++ b/hibiki/test/media/torrent/torrent_task_display_test.dart
@@ -1,0 +1,131 @@
+// TODO-2481：下载任务行显示格式化纯函数 —— ETA / 分享率 / 状态映射。
+//
+// 边界是主角：零速度、未知剩余（-1）、已完成（0）、零分母、超上限估算、
+// 未知状态词。这些分支一旦回归，UI 会显示「ETA ∞」「NaN」或裸英文状态词。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/torrent/torrent_task_display.dart';
+
+void main() {
+  group('torrentDisplayStatusFor', () {
+    test('qb 下载词族', () {
+      expect(torrentDisplayStatusFor('downloading'),
+          TorrentDisplayStatus.downloading);
+      expect(torrentDisplayStatusFor('forcedDL'),
+          TorrentDisplayStatus.downloading);
+      expect(
+          torrentDisplayStatusFor('stalledDL'), TorrentDisplayStatus.stalled);
+      expect(torrentDisplayStatusFor('queuedDL'), TorrentDisplayStatus.queued);
+      expect(torrentDisplayStatusFor('metaDL'),
+          TorrentDisplayStatus.fetchingMetadata);
+    });
+
+    test('qb 做种/完成词族', () {
+      expect(
+          torrentDisplayStatusFor('uploading'), TorrentDisplayStatus.seeding);
+      expect(
+          torrentDisplayStatusFor('stalledUP'), TorrentDisplayStatus.seeding);
+      expect(torrentDisplayStatusFor('forcedUP'), TorrentDisplayStatus.seeding);
+      expect(torrentDisplayStatusFor('queuedUP'), TorrentDisplayStatus.queued);
+      expect(
+          torrentDisplayStatusFor('checkingUP'), TorrentDisplayStatus.checking);
+      expect(torrentDisplayStatusFor('moving'), TorrentDisplayStatus.moving);
+    });
+
+    test('暂停词族：qb 4.x paused* 与 qb 5.x stopped* 同义', () {
+      for (final String s in <String>[
+        'pausedDL',
+        'pausedUP',
+        'stoppedDL',
+        'stoppedUP',
+      ]) {
+        expect(torrentDisplayStatusFor(s), TorrentDisplayStatus.paused,
+            reason: s);
+      }
+    });
+
+    test('内置引擎词族（native state_label 全集）', () {
+      expect(torrentDisplayStatusFor('metadata'),
+          TorrentDisplayStatus.fetchingMetadata);
+      expect(
+          torrentDisplayStatusFor('checking'), TorrentDisplayStatus.checking);
+      expect(torrentDisplayStatusFor('downloading'),
+          TorrentDisplayStatus.downloading);
+      expect(
+          torrentDisplayStatusFor('finished'), TorrentDisplayStatus.completed);
+      expect(torrentDisplayStatusFor('seeding'), TorrentDisplayStatus.seeding);
+      expect(torrentDisplayStatusFor('error'), TorrentDisplayStatus.error);
+    });
+
+    test('错误词族与未知词', () {
+      expect(
+          torrentDisplayStatusFor('missingFiles'), TorrentDisplayStatus.error);
+      expect(
+          torrentDisplayStatusFor('allocating'), TorrentDisplayStatus.checking);
+      expect(torrentDisplayStatusFor(''), TorrentDisplayStatus.unknown);
+      expect(torrentDisplayStatusFor('someFutureState'),
+          TorrentDisplayStatus.unknown);
+    });
+  });
+
+  group('formatTorrentEta', () {
+    test('速度为 0 不显示（除零 + 「卡住」由速度段表达）', () {
+      expect(formatTorrentEta(amountLeft: 1024, downRateBps: 0), isNull);
+      expect(formatTorrentEta(amountLeft: 1024, downRateBps: -1), isNull);
+    });
+
+    test('剩余未知（-1）或已完成（0）不显示', () {
+      expect(formatTorrentEta(amountLeft: -1, downRateBps: 100), isNull);
+      expect(formatTorrentEta(amountLeft: 0, downRateBps: 100), isNull);
+    });
+
+    test('常规估算：向上取整', () {
+      // 1000 / 100 = 10s。
+      expect(formatTorrentEta(amountLeft: 1000, downRateBps: 100), '10s');
+      // 1001 / 100 = 10.01 → 11s（宁多勿少）。
+      expect(formatTorrentEta(amountLeft: 1001, downRateBps: 100), '11s');
+    });
+
+    test('超过 100 天上限不显示（估算只剩噪声）', () {
+      final int capSeconds = kTorrentEtaDisplayCap.inSeconds;
+      expect(
+        formatTorrentEta(amountLeft: capSeconds, downRateBps: 1),
+        isNotNull,
+      );
+      expect(
+        formatTorrentEta(amountLeft: capSeconds + 1, downRateBps: 1),
+        isNull,
+      );
+    });
+  });
+
+  group('formatCompactDuration', () {
+    test('最高两级单位，次级补零', () {
+      expect(formatCompactDuration(Duration.zero), '0s');
+      expect(formatCompactDuration(const Duration(seconds: 45)), '45s');
+      expect(formatCompactDuration(const Duration(minutes: 12, seconds: 34)),
+          '12m34s');
+      expect(
+          formatCompactDuration(const Duration(hours: 1, minutes: 2)), '1h02m');
+      expect(formatCompactDuration(const Duration(days: 2, hours: 7)), '2d07h');
+    });
+
+    test('负时长按 0 处理', () {
+      expect(formatCompactDuration(const Duration(seconds: -5)), '0s');
+    });
+  });
+
+  group('formatShareRatio', () {
+    test('分母 0 / 负数不显示', () {
+      expect(formatShareRatio(uploadedBytes: 100, downloadedBytes: 0), isNull);
+      expect(formatShareRatio(uploadedBytes: 100, downloadedBytes: -1), isNull);
+    });
+
+    test('两位小数（qb 同款）', () {
+      expect(formatShareRatio(uploadedBytes: 35, downloadedBytes: 100), '0.35');
+      expect(formatShareRatio(uploadedBytes: 0, downloadedBytes: 100), '0.00');
+      expect(
+          formatShareRatio(uploadedBytes: 300, downloadedBytes: 100), '3.00');
+    });
+  });
+}

--- a/hibiki/test/media/torrent/upload_policy_dispatch_guard_test.dart
+++ b/hibiki/test/media/torrent/upload_policy_dispatch_guard_test.dart
@@ -23,6 +23,7 @@ import 'package:ffi/ffi.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/torrent/embedded_torrent_host.dart';
+import 'package:hibiki/src/media/torrent/torrent_backend.dart';
 import 'package:hibiki_torrent/hibiki_torrent.dart';
 
 final Pointer<Void> _fakeSession = Pointer<Void>.fromAddress(0xF00D);
@@ -257,6 +258,90 @@ void main() {
       final EmbeddedTorrentHost host = _host(withUploadControl: false);
       host.setUploadPolicy(const QbConnectionConfig());
       expect(_calls, contains('ht_set_upload_mode(,1)'));
+    });
+  });
+
+  group('TODO-2481：用户暂停/恢复与策略 sweep 的边界', () {
+    test('pauseTorrentByUser 下发 pause=1；isTorrentPausedForDisplay 置位', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      expect(host.pauseTorrentByUser('AAA'), isTrue);
+      expect(_calls, contains('ht_pause_torrent(aaa,1)'),
+          reason: 'infohash 统一小写下发');
+      expect(host.isTorrentPausedForDisplay('aaa'), isTrue);
+      expect(host.isTorrentPausedForDisplay('AAA'), isTrue,
+          reason: '大小写只是书写差异');
+    });
+
+    test('靶心：sweep 绝不替用户 resume（把 skip 删掉这条必红）', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      // 开上传 + 无做种上限 → 策略对已完成种子的裁决是「继续做种」。
+      host.setUploadPolicy(const QbConnectionConfig(uploadEnabled: true));
+      _torrentsJson = '[${_torrent(id: 'bbb', finished: true)}]';
+      expect(host.pauseTorrentByUser('bbb'), isTrue);
+      _calls.clear();
+      host.sweepUploadPolicy();
+      host.sweepUploadPolicy();
+      expect(
+          _calls.where((String c) => c.startsWith('ht_pause_torrent')), isEmpty,
+          reason: '用户暂停的种子策略既不重复 pause 也不 resume');
+    });
+
+    test('resumeTorrentByUser 下发 pause=0 并清除暂停显示态', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      expect(host.pauseTorrentByUser('ccc'), isTrue);
+      expect(host.resumeTorrentByUser('ccc'), isTrue);
+      expect(_calls, contains('ht_pause_torrent(ccc,0)'));
+      expect(host.isTorrentPausedForDisplay('ccc'), isFalse);
+    });
+
+    test('用户恢复后策略重新裁决：关上传的已完成种子会被策略再次暂停', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      host.setUploadPolicy(const QbConnectionConfig()); // uploadEnabled=false
+      _torrentsJson = '[${_torrent(id: 'ddd', finished: true)}]';
+      host.sweepUploadPolicy();
+      expect(_calls, contains('ht_pause_torrent(ddd,1)'),
+          reason: '前置：策略先按关上传暂停了做种');
+      // 用户手动恢复（清掉策略已下发记录）→ 下一轮 sweep 按策略重新暂停。
+      expect(host.resumeTorrentByUser('ddd'), isTrue);
+      _calls.clear();
+      host.sweepUploadPolicy();
+      expect(_calls, contains('ht_pause_torrent(ddd,1)'),
+          reason: '策略语义使然：resume 清的是记录，不是豁免');
+    });
+
+    test('老 DLL：supportsPauseControl=false 且用户暂停如实失败', () {
+      final EmbeddedTorrentHost host = _host(withUploadControl: false);
+      expect(host.supportsPauseControl, isFalse);
+      expect(host.pauseTorrentByUser('eee'), isFalse);
+      expect(host.isTorrentPausedForDisplay('eee'), isFalse);
+      expect(host.backendView().pauseControlAvailable, isFalse,
+          reason: '能力位经 backendView 透传，UI 据此隐藏按钮');
+    });
+
+    test('backendView 快照：已知暂停的种子 state 覆写为 pausedDL/pausedUP', () async {
+      final EmbeddedTorrentHost host = _host(withUploadControl: true);
+      _torrentsJson = '['
+          '${_torrent(id: 'dl1', finished: false)},'
+          '${_torrent(id: 'up1', finished: true)}'
+          ']';
+      expect(host.pauseTorrentByUser('dl1'), isTrue);
+      expect(host.pauseTorrentByUser('up1'), isTrue);
+      final Map<String, String> stateByHash = <String, String>{
+        for (final TorrentSnapshot s in await host.backendView().listTorrents())
+          s.hash: s.state,
+      };
+      expect(stateByHash['dl1'], 'pausedDL',
+          reason: 'native state_label 不导出 paused，覆写发生在快照层');
+      expect(stateByHash['up1'], 'pausedUP',
+          reason: 'pausedUP 属做种类，isComplete 判定不受暂停影响');
+
+      // 恢复后回落 native 原词。
+      expect(host.resumeTorrentByUser('dl1'), isTrue);
+      final Map<String, String> after = <String, String>{
+        for (final TorrentSnapshot s in await host.backendView().listTorrents())
+          s.hash: s.state,
+      };
+      expect(after['dl1'], 'downloading');
     });
   });
 }

--- a/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
+++ b/hibiki/test/pages/anime_download_dialog_embedded_push_test.dart
@@ -351,6 +351,9 @@ void main() {
         downloadedBytes: 0,
         uploadedBytes: 0,
         numPeers: 0,
+        // TODO-2481：state 未知词 → 状态段不渲染，本用例仍只看速度段。
+        state: '',
+        amountLeft: -1,
       ),
     };
     await tester.pump();

--- a/hibiki/test/torrent/qbittorrent_client_test.dart
+++ b/hibiki/test/torrent/qbittorrent_client_test.dart
@@ -354,6 +354,94 @@ void main() {
     });
   });
 
+  group('pauseTorrent / resumeTorrent（TODO-2481）', () {
+    test('posts hashes to /torrents/pause and /torrents/resume', () async {
+      final List<int> logins = <int>[];
+      final List<String> paths = <String>[];
+      late http.Request seen;
+      final QBittorrentClient client = QBittorrentClient(
+        baseUrl: 'http://qb.local:8080',
+        username: 'admin',
+        password: 'secret',
+        client: _mockWithLogin(logins, (http.Request request) async {
+          paths.add(request.url.path);
+          seen = request;
+          return http.Response('', 200);
+        }),
+      );
+      expect(await client.pauseTorrent('abc123'), isTrue);
+      expect(paths.last, '/api/v2/torrents/pause');
+      expect(seen.bodyFields, <String, String>{'hashes': 'abc123'});
+      expect(await client.resumeTorrent('abc123'), isTrue);
+      expect(paths.last, '/api/v2/torrents/resume');
+      expect(seen.bodyFields, <String, String>{'hashes': 'abc123'});
+      client.close();
+    });
+
+    test('qb 5.0 移除旧端点：404 时回退 /torrents/stop 与 /torrents/start', () async {
+      final List<int> logins = <int>[];
+      final List<String> paths = <String>[];
+      final QBittorrentClient client = QBittorrentClient(
+        baseUrl: 'http://qb.local:8080',
+        username: 'admin',
+        password: 'secret',
+        client: _mockWithLogin(logins, (http.Request request) async {
+          paths.add(request.url.path);
+          final bool renamed = request.url.path.endsWith('/stop') ||
+              request.url.path.endsWith('/start');
+          return http.Response('', renamed ? 200 : 404);
+        }),
+      );
+      expect(await client.pauseTorrent('abc123'), isTrue);
+      expect(
+        paths,
+        <String>['/api/v2/torrents/pause', '/api/v2/torrents/stop'],
+      );
+      paths.clear();
+      expect(await client.resumeTorrent('abc123'), isTrue);
+      expect(
+        paths,
+        <String>['/api/v2/torrents/resume', '/api/v2/torrents/start'],
+      );
+      client.close();
+    });
+
+    test('双端点都失败 / 空 hash 返回 false', () async {
+      final List<int> logins = <int>[];
+      final QBittorrentClient client = QBittorrentClient(
+        baseUrl: 'http://qb.local:8080',
+        username: 'admin',
+        password: 'secret',
+        client: _mockWithLogin(
+          logins,
+          (http.Request request) async => http.Response('', 404),
+        ),
+      );
+      expect(await client.pauseTorrent('abc123'), isFalse);
+      expect(await client.pauseTorrent(''), isFalse);
+      expect(await client.resumeTorrent(''), isFalse);
+      client.close();
+    });
+
+    test('非 404 失败（如 403 后重登仍失败）不再重试新端点', () async {
+      final List<int> logins = <int>[];
+      final List<String> paths = <String>[];
+      final QBittorrentClient client = QBittorrentClient(
+        baseUrl: 'http://qb.local:8080',
+        username: 'admin',
+        password: 'secret',
+        client: _mockWithLogin(logins, (http.Request request) async {
+          paths.add(request.url.path);
+          return http.Response('', 500);
+        }),
+      );
+      expect(await client.pauseTorrent('abc123'), isFalse);
+      expect(paths, <String>['/api/v2/torrents/pause'],
+          reason: '500 不是「端点已改名」的证据，盲目重试只会放大故障');
+      client.close();
+    });
+  });
+
   group('ensureCategory', () {
     test('200 and 409 (already exists) both count as success', () async {
       final List<int> logins = <int>[];


### PR DESCRIPTION
## TODO-2481 下载任务列表升级（D1 批次，纯 Dart 侧）

### 改动

**1. 暂停/恢复抬到 `TorrentBackend` 能力接口**
- 新增 `TorrentPauseBackend`（同 `TorrentRemovalBackend` 的可选能力接口模式）：`pauseTorrent(hash)` / `resumeTorrent(hash)` + `pauseControlAvailable` 运行时能力位。UI 探测 = `backend is TorrentPauseBackend && pauseControlAvailable`——内置引擎的老随包 DLL 缺 `ht_pause_torrent` 符号时类型探测会过、原语点不动，必须看能力位。
- qBittorrent：`POST /api/v2/torrents/pause|resume`（form `hashes`）；qb 5.0（API ≥2.11）把端点改名 `stop`/`start` 并移除旧名，404 时回退新名（外部系统版本差异，无法根治，双名兼容 + 测试钉住「非 404 不盲目重试」）。
- 内置引擎：native 已有 `ht_pause_torrent(session, hash, pause)`，`pause=0` 即恢复原语（清 auto_managed 并 resume）——**恢复无需留给 D2，本批双向落地**。暂停真相收在常驻 `EmbeddedTorrentHost`（短命 backend 适配器每 tick 重建，自持状态活不过一轮），经 `EmbeddedPauseControl` 回注适配器。
- 关键边界：`sweepUploadPolicy`（BUG-1293 做种策略）对用户暂停的种子**整体跳过**，否则下一 tick 策略会把用户按下的暂停偷偷 resume（守卫测试已钉靶心，变异实测删掉 skip 必红）。用户 resume 会清策略已下发记录，让策略重新裁决（做种超限会被再次暂停，是策略语义不是抢手）。

**2. 任务行信息升级**
- `DownloadTaskStats` 投影补 `state` / `amountLeft`（`TorrentSnapshot` 一直有、投影时被丢弃），==/hashCode 同步。
- 新文件 `torrent_task_display.dart`：全部纯函数、全类型注解、无 Flutter 依赖——`torrentDisplayStatusFor`（qb + 内置引擎 + 合成 paused 词族 → 统一枚举，绝不裸比较）、`formatTorrentEta`（零速度/剩余未知(-1)/已完成(0)/超 100 天上限 → null 不显示）、`formatShareRatio`（分母 ≤0 → null）、`formatCompactDuration`。
- 行内新增：状态文本 · ETA · 分享率（全部增强位，算不出整段不渲染，绝不吞掉百分比——延续 BUG-1296 契约）；暂停/恢复 IconButton（仅能力位真时显示，图标随 paused 态切换，操作后踢 tick 刷新）。
- 内置引擎暂停态显示：native `state_label` 不导出 paused（libtorrent 里 paused 是 flag 不是 state），快照层把已知暂停覆写成 `pausedDL`/`pausedUP`（qb 词汇；`pausedUP` 属既有做种类集合，`isComplete` 判定不受影响）。顺带修复策略暂停（做种超限）在 UI 显示成「做种中」的既有显示缺口。

**3. i18n**：`download_task_*` 15 键全部经 `dart run tool/i18n_sync.dart --add`（17 语言）+ `dart run slang` + `dart format` 生成文件，零手改 json。

### 测试证据
- `flutter analyze` 全量：No issues found!（warning 视为致命）
- 定向 + 相邻：`dart run tool/flutter_test_failures.dart --no-pub test/media/torrent test/torrent test/pages/anime_download_dialog_embedded_push_test.dart`
  → `FLUTTER TEST VERDICT: PASSED - 380 tests ran, all tests passed`
- 邻域再跑 `anime_download_dialog_discovery_ux / download_subscriptions_panel / downloads_page_resize_inset_guard / settings_schema_coverage`：exit 0，21 过。
- 新用例：纯函数边界（零速度/零分母/-1/超上限/未知词/qb 4.x-5.x 双词族）；guard 测试新组 6 例（用户暂停下发、sweep 不抢手【已变异实测】、恢复后策略重裁决、老 DLL 如实降级、快照 state 覆写经 backendView 端到端）；qb 客户端 4 例（端点、404 回退、非 404 不重试、空 hash）。

### 留给 D2
- **暂停态不跨会话持久**：`ht_load_resume_dir` 按 native 契约「清 paused 旗标，加回来即开始跑」，重启后用户暂停的种子会自动恢复。根治需 native 导出 is_paused/在 resume 加载时保留旗标（本批禁改 C/C++），或计划级落盘暂停意图。
- native `ht_list_torrents` 不导出 paused 旗标：Dart 侧覆写只认「本会话内经宿主暂停」的种子；外部原因（libtorrent 自动暂停等）仍显示原 state。D2 在 C ABI 导出 `is_paused` 后可删掉快照层合成。
- qb 式任务详情页（本批只做行内信息）。

https://claude.ai/code/session_017ZUDdFKDGNxpH4r5UcdWj4
