### PR TITLE
fix(lookup): 对话框期间撤掉根 Overlay dismiss barrier + 修回点词条索引 (BUG-1325/1326)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1268 条。点号进各自文件。
+> 共 1270 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1326](bugs/BUG-1326-popup-ctx-modal-args-stringified.md) | ✅ | ✅ | 调整上下文回点制卡永远点第一个词条 |
+| [BUG-1325](bugs/BUG-1325-video-context-dialog-barrier.md) | ✅ | ✅ | 视频页制卡上下文对话框被查词浮层 barrier 吃掉点击 |
 | [BUG-1324](bugs/BUG-1324-sync-report-auth-failure-untyped.md) | ✅ | ✅ | 同步报告把鉴权失败压成一行字符串：UI 只剩「N 项失败」 |
 | [BUG-1323](bugs/BUG-1323-sync-401-403-flattened.md) | ✅ | ✅ | webdav_ops 把 401/403 压成同一个 SyncAuthError：403 被谎报成登录过期还触发登出 |
 | [BUG-1322](bugs/BUG-1322-clip-export-mobile-mjpeg-unplayable.md) | ✅ | ✅ | 移动端导出片段MJPEG-MOV体积巨大且普遍无法播放 |

--- a/docs/bugs/BUG-1325-video-context-dialog-barrier.md
+++ b/docs/bugs/BUG-1325-video-context-dialog-barrier.md
@@ -1,0 +1,32 @@
+## BUG-1325 · 视频页制卡上下文对话框被查词浮层 barrier 吃掉点击
+
+- **报告**：2026-08-01（用户：视频里点「上下句」调整后点制卡没反应，而且制卡把查词弹窗关了）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/video_hibiki_page.dart:3981`（修复前的 `if (_hasVisiblePopup || _popup.isSearchingUi)`）。
+
+  视频页 / 首页词典页 / texthooker 把整棵查词浮层子树挂在**根 Overlay**
+  （`Overlay.of(context, rootOverlay: true).insert(...)`，`video_hibiki_page.dart:3938`、
+  `home_dictionary_page.dart:887`、`texthooker_page.dart:1709`；动机是盖过 media_kit 全屏路由）。
+  根 Overlay 里手动 `insert` 的 entry 排在 `showAppDialog` 推的路由**之上**（Navigator 推
+  route 时是 `insertAll(above: 上一个 route 的最后一个 entry)`，够不到手动 entry）。浮层子树
+  里那层整屏 dismiss barrier 是 `Positioned.fill` + `HitTestBehavior.translucent`，于是把落在
+  对话框上的点击整个吃掉：
+  - 点「确认制卡」→ 按钮收不到点击 = 用户看到的「没反应」；
+  - 同一下被 `_onDismissBarrierTap` 判成「点浮层外面」→ `_popNestedPopupAt(0)` 清整栈
+    = 用户看到的「制卡把我查词弹窗关了」。
+
+  BUG-797 当初只把弹窗 WebView 停到屏外（`parkedPopupLayer` 的 `visible` 接了
+  `_popupHidingDialogDepth`），解决了「对话框看得见」，**命中测试这一半漏了**：barrier 的
+  渲染条件从来没接这个门控。影响面是三个根 Overlay 表面上所有 `runWithLookupPopupHidden`
+  的对话框——句子上下文对话框、点 ✓ 的已制卡操作单（BUG-1040）、「在 Anki 中打开」的多卡
+  选择框。阅读器/有声书车道不受影响（浮层画在页面 `Stack` 里，对话框路由在其之上）。
+
+- **[x] ① 已修复** — `DictionaryPageMixin` 暴露 `lookupPopupHiddenByDialog`
+  （`dictionary_page_mixin.dart`），barrier 判据收口成纯函数
+  `shouldShowLookupDismissBarrier`（`dictionary_popup_layer.dart`），视频页 / 首页词典页 /
+  texthooker 三处 barrier 改用它 → 对话框期间浮层既不显示也不拦点击。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/lookup_dismiss_barrier_dialog_test.dart`：
+  最小 harness 复现根 Overlay 与对话框的真实层序（barrier 挂着时点按钮落到 barrier、
+  confirm 不触发；撤掉 barrier 后 confirm 触发且 barrier 不吃点击）+ 判据真值表 + 三宿主页
+  源码守卫（含「裸条件复发即红」的负向断言）。
+- **备注**：与 BUG-1326（同一操作路径上的第二个缺陷：`openSentenceContextModal` 参数被
+  `JSON.stringify`，entryIndex 恒 0）同 PR 修复。

--- a/docs/bugs/BUG-1326-popup-ctx-modal-args-stringified.md
+++ b/docs/bugs/BUG-1326-popup-ctx-modal-args-stringified.md
@@ -1,0 +1,33 @@
+## BUG-1326 · 调整上下文回点制卡永远点第一个词条
+
+- **报告**：2026-08-01（用户：视频里点「上下句」调整后点制卡没反应）
+- **真实性**：✅ 真 bug。根因 `hibiki/assets/popup/popup.js:2862`（修复前）：
+
+  ```js
+  window.flutter_inappwebview.callHandler(
+      'openSentenceContextModal',
+      JSON.stringify({ entryIndex: idx, matched: matched }));
+  ```
+
+  这是 popup.js 里**唯一**一处把 `callHandler` 参数 `JSON.stringify` 的调用（其余
+  `duplicateCheck` / `setSentenceContext` / `favoriteEntry` … 全部原样传对象），而宿主
+  handler 只认 Map（`dictionary_popup_webview.dart:1870` 的 `args[0] is Map`）。参数落成
+  String → 整个 `if` 不进 → `entryIndex` 恒退化成 `0`、`matched` 恒为空：
+
+  - 「确认制卡」经 `mineEntryByIndex(0)` 永远去点**第一个词条**的 `.mine-button`。用户在第
+    2、3 个词条上点「调整上下文」，确认后自己那条毫无变化 = 「没反应」（而第一个词条可能
+    被莫名制了一张卡，或弹出它的已制卡操作单）。
+  - 对话框里「当前句」中查到的词不高亮（`matched` 为空，`SentenceContextDialog` 退化）。
+
+  既有守卫 `test/pages/sentence_context_modal_guard_test.dart` 只 `contains('entryIndex')`
+  字符串扫描，抓不到参数被包了一层 —— 典型的源码扫描假绿。
+
+- **[x] ① 已修复** — popup.js **三镜像**（`hibiki/assets/popup/popup.js`、
+  `hibiki/assets/browser_extension/vendor/popup.js`、`tools/browser-extension/vendor/popup.js`）
+  改为原样传 `{ entryIndex, matched }` 对象；宿主侧新增纯函数 `decodeBridgeMap`
+  （`dictionary_popup_webview.dart`）兼容 Map 与 JSON 字符串两种形态，使用户浏览器里**未同步
+  更新的老扩展 vendor 副本**也不会再静默退化。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/lookup_dismiss_barrier_dialog_test.dart`：
+  `decodeBridgeMap` 三形态单测（对象 / JSON 串 / null·非法串·数组）+ 三镜像源码守卫（正则
+  钉死「不得 stringify」且「必须传对象字面量」）。
+- **备注**：与 BUG-1325（同一操作路径上的主因：根 Overlay barrier 吃掉对话框点击）同 PR 修复。

--- a/hibiki/assets/browser_extension/vendor/popup.js
+++ b/hibiki/assets/browser_extension/vendor/popup.js
@@ -2859,9 +2859,14 @@ function createEntryHeader(entry, idx) {
                     idx = Array.prototype.indexOf.call(siblings, entryEl);
                     if (idx < 0) idx = 0;
                 }
+                // BUG-1326：参数必须原样传**对象**（与本文件其余 callHandler 一致）。
+                // 之前这里独一份地 JSON.stringify 了，宿主 handler 只认 Map（args[0] is
+                // Map），于是 entryIndex 恒退化成 0、matched 恒为空——「确认制卡」永远去
+                // 点第一个词条的按钮（用户在第 2+ 个词条上点，看到的就是「没反应」），
+                // 当前句里的词也不高亮。
                 window.flutter_inappwebview.callHandler(
                     'openSentenceContextModal',
-                    JSON.stringify({ entryIndex: idx, matched: matched }));
+                    { entryIndex: idx, matched: matched });
             },
         });
         setButtonIcon(adjustBtn, 'tune');

--- a/hibiki/assets/popup/popup.js
+++ b/hibiki/assets/popup/popup.js
@@ -2859,9 +2859,14 @@ function createEntryHeader(entry, idx) {
                     idx = Array.prototype.indexOf.call(siblings, entryEl);
                     if (idx < 0) idx = 0;
                 }
+                // BUG-1326：参数必须原样传**对象**（与本文件其余 callHandler 一致）。
+                // 之前这里独一份地 JSON.stringify 了，宿主 handler 只认 Map（args[0] is
+                // Map），于是 entryIndex 恒退化成 0、matched 恒为空——「确认制卡」永远去
+                // 点第一个词条的按钮（用户在第 2+ 个词条上点，看到的就是「没反应」），
+                // 当前句里的词也不高亮。
                 window.flutter_inappwebview.callHandler(
                     'openSentenceContextModal',
-                    JSON.stringify({ entryIndex: idx, matched: matched }));
+                    { entryIndex: idx, matched: matched });
             },
         });
         setButtonIcon(adjustBtn, 'tune');

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -144,6 +144,16 @@ mixin DictionaryPageMixin {
   /// bool 会被内层的 `finally` 提前复位、外层对话框当场被弹窗盖住。计数天然支持嵌套。
   int _popupHidingDialogDepth = 0;
 
+  /// 是否有「必须盖住查词弹窗」的对话框正开着（[runWithLookupPopupHidden] 期间为真）。
+  ///
+  /// BUG-1325：宿主页除了弹窗层本身，还会画**整屏 dismiss barrier**（点弹窗外面关栈）。
+  /// 视频页把整棵浮层子树挂在**根 Overlay**（为了盖过 media_kit 全屏路由），而根 Overlay
+  /// 里手动 `insert` 的 entry 永远排在 `showAppDialog` 推的路由之上——对话框看得见却点不
+  /// 着：点击先被 barrier 吃掉，再被判成「点弹窗外面」直接清整栈。故 barrier 必须与
+  /// [parkedPopupLayer] 的 `visible` 共用同一门控：对话框期间整棵浮层既不显示也不拦点击。
+  @protected
+  bool get lookupPopupHiddenByDialog => _popupHidingDialogDepth > 0;
+
   /// BUG-1040：在 [body] 执行期间把查词弹窗停靠屏外的统一入口（收口 setState 增减，杜绝
   /// 各调用点各写一份 try/finally 漏复位）。[body] 抛错时照常复位。
   Future<T> runWithLookupPopupHidden<T>(Future<T> Function() body) async {

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_layer.dart
@@ -265,6 +265,24 @@ Rect anchorPopupTopLeft({
   return Rect.fromLTWH(left, top, width, height);
 }
 
+/// 查词浮层的整屏 dismiss barrier（点浮层外面关栈）这一帧要不要挂。
+///
+/// 三个走**根 Overlay** 的表面（视频页 / 首页词典页 / texthooker）各写一份这条件，
+/// BUG-1325 就是漏项：barrier 只看了「有可见层或正在搜索」，没接
+/// [DictionaryPageMixin.lookupPopupHiddenByDialog]。根 Overlay 里手动 `insert` 的 entry
+/// 永远排在 `showAppDialog` 推的路由之上，全屏 + translucent 的 barrier 于是把落在对话框
+/// 上的点击整个吃掉：用户点「确认制卡」既点不到按钮，还被判成「点浮层外面」→ 清整栈
+/// （用户报「制卡没反应，而且把我查词弹窗关了」）。BUG-797 当时只把 WebView 停到屏外，
+/// 解决了「看得见」，命中测试这一半漏了。
+///
+/// 收口成纯函数，让三处共用同一真值表、不再漂移，也便于单测。
+bool shouldShowLookupDismissBarrier({
+  required bool hasVisiblePopup,
+  required bool isSearching,
+  required bool hiddenByDialog,
+}) =>
+    (hasVisiblePopup || isSearching) && !hiddenByDialog;
+
 /// 把一个弹窗层 [child] 按 [pos] 摆放；隐藏层（[visible]=false，即 BUG-094 常驻热槽 /
 /// TODO-058 挂起冷层）停到屏幕右外侧 `(screen.width + 8, 0)` 继续预热。
 ///

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -1867,8 +1867,12 @@ JSON.stringify((function(){
                 if (widget.onOpenSentenceContextModal == null) return null;
                 int entryIndex = 0;
                 String matched = '';
-                if (args.isNotEmpty && args[0] is Map) {
-                  final Map<dynamic, dynamic> data = args[0] as Map;
+                // BUG-1326：popup.js 现在传对象；老的扩展 vendor 副本（用户装在浏览器
+                // 里、与 app 不同步更新）还可能传 JSON 字符串。两种形态都解析，否则
+                // entryIndex 静默退化成 0 → 确认制卡永远点第一个词条。
+                final Map<dynamic, dynamic>? data =
+                    decodeBridgeMap(args.isEmpty ? null : args[0]);
+                if (data != null) {
                   entryIndex = (data['entryIndex'] as num?)?.toInt() ?? 0;
                   matched = data['matched']?.toString() ?? '';
                 }
@@ -2347,6 +2351,28 @@ JSON.stringify((function(){
 /// `{source, message, stack}`）。source 前缀成 `PopupJs.<source>` 写进 [ErrorLogService]，
 /// stack 非空时经 [StackTrace.fromString] 还原成栈（[ErrorLogService.log] 会序列化落盘，
 /// 复用 TODO-1383 的串行落盘链），空则不带栈。绝不吞——目的就是让 JS 报错在错误日志页可见。
+/// BUG-1326：把 JS 桥送来的单个参数解析成 Map。
+///
+/// popup.js 的 `callHandler` 一律传**对象**，宿主收到 `Map`。但浏览器扩展的 vendor 副本
+/// 是用户自己装在浏览器里的、与 app 不同步更新，老副本可能仍传 `JSON.stringify(...)` 的
+/// 字符串；只认 `is Map` 会让字段静默退化成默认值（`openSentenceContextModal` 的
+/// `entryIndex` 退化成 0 → 确认制卡永远点第一个词条，用户只看到「没反应」）。
+///
+/// 认三种形态：`Map` 原样、JSON 对象字符串解出 Map、其余（含 null / JSON 数组 / 非法串）
+/// 返回 null 让调用方走自己的默认值。纯函数、可单测。
+Map<dynamic, dynamic>? decodeBridgeMap(Object? raw) {
+  if (raw is Map) return raw;
+  if (raw is String && raw.isNotEmpty) {
+    try {
+      final Object? decoded = jsonDecode(raw);
+      if (decoded is Map) return decoded;
+    } catch (_) {
+      // 不是 JSON：按「没有参数」处理，调用方用默认值。
+    }
+  }
+  return null;
+}
+
 void logPopupJsError(ErrorLogService errorLogService, List<dynamic> rawArgs) {
   final Object? raw = rawArgs.isNotEmpty ? rawArgs.first : null;
   final Map<Object?, Object?> payload =

--- a/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
@@ -915,7 +915,14 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
               // 屏外照常预热又不被裁；飘出窗的弹窗同理不裁。
               clipBehavior: Clip.none,
               children: <Widget>[
-                if (_hasVisiblePopup || _popup.isSearchingUi)
+                // BUG-1325：对话框期间连 barrier 一起撤——浮层子树挂在根 Overlay，排在
+                // showAppDialog 推的路由之上，全屏 barrier 会把落在对话框上的点击吃掉并
+                // 判成「点弹窗外面」关栈。判据收口在 [shouldShowLookupDismissBarrier]。
+                if (shouldShowLookupDismissBarrier(
+                  hasVisiblePopup: _hasVisiblePopup,
+                  isSearching: _popup.isSearchingUi,
+                  hiddenByDialog: lookupPopupHiddenByDialog,
+                ))
                   Positioned.fill(
                     child: GestureDetector(
                       behavior: HitTestBehavior.translucent,

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -25,6 +25,7 @@ import 'package:hibiki/src/mining/window_capture_channel.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_page_mixin.dart';
 import 'package:hibiki/src/pages/implementations/game_shared.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_controller.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_layer.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart'
     show MinePopupResult;
 import 'package:hibiki/src/sync/texthooker_service.dart';
@@ -1647,7 +1648,14 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       // TODO-1052：查词浮层显示（或搜索中）时叠一层全屏 dismiss barrier——点真空白关一层
       // （逐层关，与其它表面同语义），桌面开滑动关闭时水平拖过阈亦关一层。texthooker 原
       // 先无 barrier（点外面关不掉浮层）；本层是附加的关闭手势，不改逐词查词点击本身。
-      if (_popup.hasVisiblePopup || _popup.isSearchingUi)
+      // BUG-1325：对话框期间连 barrier 一起撤——浮层子树挂在根 Overlay，排在
+      // showAppDialog 推的路由之上，全屏 barrier 会把落在对话框上的点击吃掉并判成
+      // 「点弹窗外面」关栈。判据收口在 [shouldShowLookupDismissBarrier]。
+      if (shouldShowLookupDismissBarrier(
+        hasVisiblePopup: _popup.hasVisiblePopup,
+        isSearching: _popup.isSearchingUi,
+        hiddenByDialog: lookupPopupHiddenByDialog,
+      ))
         Positioned.fill(
           child: GestureDetector(
             behavior: HitTestBehavior.translucent,

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -118,6 +118,7 @@ import 'package:hibiki/src/profile/profile_repository.dart';
 import 'package:hibiki/src/profile/profile_view_model.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_controller.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_input_bridge.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_layer.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_page_mixin.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart'
     show MinePopupResult, DictionaryPopupWebViewState;
@@ -3978,7 +3979,15 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
                 // Dismiss barrier while a popup is visible OR a lookup is
                 // searching (搜索→就绪才显示：搜索期浮层还没显示，barrier 仍要拦点击
                 // 并支持点同句另一字切换查词)。仅剩隐藏热槽时不拦，放行给视频。
-                if (_hasVisiblePopup || _popup.isSearchingUi)
+                //
+                // BUG-1325：对话框期间（[lookupPopupHiddenByDialog]）连 barrier 一起撤，
+                // 否则它把落在对话框上的点击吃掉、还判成「点弹窗外面」清整栈。判据收口在
+                // [shouldShowLookupDismissBarrier]（三个根 Overlay 表面共用）。
+                if (shouldShowLookupDismissBarrier(
+                  hasVisiblePopup: _hasVisiblePopup,
+                  isSearching: _popup.isSearchingUi,
+                  hiddenByDialog: lookupPopupHiddenByDialog,
+                ))
                   Positioned.fill(
                     // BUG-861：barrier 外层挂 Listener 转发 hover——首弹后 barrier 盖住字幕，
                     // 字幕盒 MouseRegion 收不到 hover，此处是「按住 Shift 连续切换查词」唯一

--- a/hibiki/test/pages/home_dictionary_pull_preserve_query_test.dart
+++ b/hibiki/test/pages/home_dictionary_pull_preserve_query_test.dart
@@ -228,12 +228,22 @@ void main() {
           'touch drags.',
     );
     // TODO-931：外点遮罩同样改用 _hasVisiblePopup（隐藏热槽不该挂遮罩）。
+    // BUG-1325：判据收口到 shouldShowLookupDismissBarrier，并额外接对话框门控
+    // （对话框期间浮层挂在根 Overlay 会把落在对话框上的点击吃掉）。原意图不变：
+    // 遮罩只为「可见弹窗 / 搜索中」而挂，不是结果区的通用手势捕手。
     expect(
       resultBody,
-      contains('_hasVisiblePopup || _popup.isSearchingUi'),
+      contains('shouldShowLookupDismissBarrier('),
       reason:
           'The outside-tap shield should exist only for visible popup state, '
           'not as a general result-body gesture catcher.',
+    );
+    expect(resultBody, contains('hasVisiblePopup: _hasVisiblePopup'));
+    expect(resultBody, contains('isSearching: _popup.isSearchingUi'));
+    expect(
+      resultBody,
+      contains('hiddenByDialog: lookupPopupHiddenByDialog'),
+      reason: 'BUG-1325：对话框打开期间必须连遮罩一起撤，否则对话框点不动且一点就关栈。',
     );
   });
 

--- a/hibiki/test/pages/lookup_dismiss_barrier_dialog_test.dart
+++ b/hibiki/test/pages/lookup_dismiss_barrier_dialog_test.dart
@@ -1,0 +1,277 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_layer.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_webview.dart';
+
+/// BUG-1325 / BUG-1326：「制卡·选择句子上下文」对话框点不动 + 一点就把查词浮层关掉。
+///
+/// BUG-1325 根因：视频页 / 首页词典页 / texthooker 把整棵查词浮层子树挂在**根 Overlay**
+/// （手动 `Overlay.of(context, rootOverlay: true).insert(...)`，为了盖过 media_kit 全屏
+/// 路由）。根 Overlay 里手动 insert 的 entry 永远排在 `showDialog` 推的路由**之上**，而
+/// 浮层子树里那层整屏 dismiss barrier（`Positioned.fill` + `HitTestBehavior.translucent`）
+/// 会把落在对话框上的点击整个吃掉：用户点「确认制卡」既点不到按钮，还被 barrier 判成
+/// 「点浮层外面」→ 清整栈。BUG-797 当时只把弹窗 WebView 停到屏外（解决「看得见」），
+/// 命中测试这一半漏了。
+///
+/// 本文件用一个**最小 harness** 复现该层序（不拉起真视频页）：手动往根 Overlay insert
+/// 一个带 barrier 的 entry，再 `showDialog` 一个带按钮的对话框，直接观测点击落到谁身上。
+/// 第一条测试钉死「barrier 挂着时对话框确实点不动」（若哪天框架层序变了，它会红——
+/// 那说明本修复的前提没了）；第二条钉死修复后的行为。
+void main() {
+  group('shouldShowLookupDismissBarrier 真值表（BUG-1325）', () {
+    test('对话框打开时一律不挂 barrier', () {
+      expect(
+        shouldShowLookupDismissBarrier(
+          hasVisiblePopup: true,
+          isSearching: false,
+          hiddenByDialog: true,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldShowLookupDismissBarrier(
+          hasVisiblePopup: false,
+          isSearching: true,
+          hiddenByDialog: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('无对话框时保持原语义：有可见层或正在搜索就挂', () {
+      expect(
+        shouldShowLookupDismissBarrier(
+          hasVisiblePopup: true,
+          isSearching: false,
+          hiddenByDialog: false,
+        ),
+        isTrue,
+      );
+      expect(
+        shouldShowLookupDismissBarrier(
+          hasVisiblePopup: false,
+          isSearching: true,
+          hiddenByDialog: false,
+        ),
+        isTrue,
+      );
+      // 仅剩隐藏热槽（无可见层、没在搜索）：不拦，放行给页面本体。
+      expect(
+        shouldShowLookupDismissBarrier(
+          hasVisiblePopup: false,
+          isSearching: false,
+          hiddenByDialog: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('根 Overlay barrier 与对话框的层序（BUG-1325）', () {
+    /// 搭一个和三个宿主页同构的最小场景：根 Overlay 上手动 insert 一层浮层子树
+    /// （只含 dismiss barrier），再弹一个对话框。[barrierEnabled] 模拟修复前后的门控。
+    Future<void> pumpHarness(
+      WidgetTester tester, {
+      required bool barrierEnabled,
+      required VoidCallback onBarrierTap,
+      required VoidCallback onConfirmTap,
+    }) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (BuildContext context) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  child: const Text('open'),
+                  onPressed: () {
+                    // 浮层子树：与宿主页一样手动挂到根 Overlay。
+                    Overlay.of(context, rootOverlay: true).insert(
+                      OverlayEntry(
+                        builder: (_) => Stack(
+                          children: <Widget>[
+                            if (barrierEnabled)
+                              Positioned.fill(
+                                child: GestureDetector(
+                                  behavior: HitTestBehavior.translucent,
+                                  onTap: onBarrierTap,
+                                  child: const ColoredBox(
+                                      color: Colors.transparent),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    );
+                    showDialog<void>(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        content: const Text('ctx'),
+                        actions: <Widget>[
+                          FilledButton(
+                            onPressed: onConfirmTap,
+                            child: const Text('confirm-mine'),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('barrier 挂着时，点「确认制卡」落到 barrier 而不是按钮（复现）',
+        (WidgetTester tester) async {
+      int barrierTaps = 0;
+      int confirmTaps = 0;
+      await pumpHarness(
+        tester,
+        barrierEnabled: true,
+        onBarrierTap: () => barrierTaps++,
+        onConfirmTap: () => confirmTaps++,
+      );
+      // 对话框是可见的（BUG-797 已把 WebView 停屏外），但点击进不去。
+      expect(find.text('confirm-mine'), findsOneWidget);
+      await tester.tap(find.text('confirm-mine'), warnIfMissed: false);
+      await tester.pumpAndSettle();
+      expect(confirmTaps, 0, reason: '根 Overlay 的 barrier 排在对话框路由之上，点击被它吃掉');
+      expect(barrierTaps, 1, reason: '这一下还会被判成「点浮层外面」→ 宿主清整栈（弹窗被关）');
+    });
+
+    testWidgets('对话框期间撤掉 barrier，点「确认制卡」真的点到按钮（修复）',
+        (WidgetTester tester) async {
+      int barrierTaps = 0;
+      int confirmTaps = 0;
+      await pumpHarness(
+        tester,
+        // 修复后 shouldShowLookupDismissBarrier 在 hiddenByDialog 时返回 false。
+        barrierEnabled: shouldShowLookupDismissBarrier(
+          hasVisiblePopup: true,
+          isSearching: false,
+          hiddenByDialog: true,
+        ),
+        onBarrierTap: () => barrierTaps++,
+        onConfirmTap: () => confirmTaps++,
+      );
+      await tester.tap(find.text('confirm-mine'));
+      await tester.pumpAndSettle();
+      expect(confirmTaps, 1, reason: '对话框按钮必须能被点到');
+      expect(barrierTaps, 0, reason: '浮层不该再吃这一下点击，更不该关栈');
+    });
+  });
+
+  group('三个根 Overlay 宿主页都走同一门控（BUG-1325 守卫）', () {
+    String read(String relativePath) {
+      final File file = File(relativePath);
+      expect(file.existsSync(), isTrue, reason: 'missing $relativePath');
+      return file.readAsStringSync();
+    }
+
+    test('mixin 暴露 lookupPopupHiddenByDialog（barrier 与 parked visible 同源）', () {
+      final String src =
+          read('lib/src/pages/implementations/dictionary_page_mixin.dart');
+      expect(src.contains('bool get lookupPopupHiddenByDialog'), isTrue,
+          reason: '宿主页要拿到「对话框正开着」才能同时撤掉 barrier');
+      expect(src.contains('_popupHidingDialogDepth > 0'), isTrue);
+    });
+
+    for (final ({String path, String name}) page
+        in const <({String path, String name})>[
+      (
+        path: 'lib/src/pages/implementations/video_hibiki_page.dart',
+        name: '视频页'
+      ),
+      (
+        path: 'lib/src/pages/implementations/home_dictionary_page.dart',
+        name: '首页词典页'
+      ),
+      (
+        path: 'lib/src/pages/implementations/texthooker_page.dart',
+        name: 'texthooker'
+      ),
+    ]) {
+      test('${page.name} barrier 走 shouldShowLookupDismissBarrier', () {
+        final String src = read(page.path);
+        expect(src.contains('shouldShowLookupDismissBarrier('), isTrue,
+            reason: '${page.name}的 dismiss barrier 必须走收口判据，别再手写裸条件');
+        expect(
+            src.contains('hiddenByDialog: lookupPopupHiddenByDialog'), isTrue,
+            reason: '${page.name}漏接对话框门控 → 对话框点不动且一点就关栈（BUG-1325）');
+        // 裸条件（不带门控）复发即红。只盯 barrier 本身——正则要求这个 if 紧跟着
+        // `Positioned.fill(`，避免误伤同文件里其它「有可见层 || 正在搜索」的判断
+        // （如首页词典页下拉刷新的 _clearSearchFromResultPull）。
+        expect(
+          RegExp(r'if \([^)]*isSearchingUi\)\s*Positioned\.fill\(')
+              .hasMatch(src),
+          isFalse,
+          reason: '${page.name}又出现漏门控的裸 barrier 条件（BUG-1325）',
+        );
+      });
+    }
+  });
+
+  group('openSentenceContextModal 参数形态三镜像（BUG-1326 守卫）', () {
+    // popup.js 三镜像：app 内 assets + app 内扩展 vendor + 仓库根扩展 vendor。
+    const List<String> mirrors = <String>[
+      'assets/popup/popup.js',
+      'assets/browser_extension/vendor/popup.js',
+      '../tools/browser-extension/vendor/popup.js',
+    ];
+
+    for (final String path in mirrors) {
+      test('$path 传对象而不是 JSON 字符串', () {
+        final File file = File(path);
+        expect(file.existsSync(), isTrue, reason: 'missing $path');
+        final String js = file.readAsStringSync();
+        expect(
+          RegExp(r"callHandler\(\s*'openSentenceContextModal',\s*JSON\.stringify")
+              .hasMatch(js),
+          isFalse,
+          reason: '$path 又把参数 stringify 了：宿主 handler 只认 Map，'
+              'entryIndex 会静默退化成 0 → 确认制卡永远点第一个词条（BUG-1326）',
+        );
+        expect(
+          RegExp(r"callHandler\(\s*'openSentenceContextModal',\s*"
+                  r'\{ entryIndex: idx, matched: matched \}\)')
+              .hasMatch(js),
+          isTrue,
+          reason: '$path 的「调整上下文」按钮必须原样传 {entryIndex, matched} 对象',
+        );
+      });
+    }
+  });
+
+  group('decodeBridgeMap：JS 桥参数形态（BUG-1326）', () {
+    test('对象原样解析（popup.js 现行契约）', () {
+      final Map<dynamic, dynamic>? m =
+          decodeBridgeMap(<String, Object?>{'entryIndex': 2, 'matched': '見る'});
+      expect(m, isNotNull);
+      expect((m!['entryIndex'] as num).toInt(), 2);
+      expect(m['matched'], '見る');
+    });
+
+    test('JSON 字符串也解析（老扩展 vendor 副本仍会 stringify）', () {
+      final Map<dynamic, dynamic>? m =
+          decodeBridgeMap('{"entryIndex":3,"matched":"読む"}');
+      expect(m, isNotNull);
+      expect((m!['entryIndex'] as num).toInt(), 3,
+          reason: '若只认 Map，entryIndex 会静默退化成 0 → 确认制卡永远点第一个词条');
+      expect(m['matched'], '読む');
+    });
+
+    test('null / 非法串 / JSON 数组 → null，由调用方走默认值', () {
+      expect(decodeBridgeMap(null), isNull);
+      expect(decodeBridgeMap(''), isNull);
+      expect(decodeBridgeMap('not json'), isNull);
+      expect(decodeBridgeMap('[1,2]'), isNull);
+      expect(decodeBridgeMap(42), isNull);
+    });
+  });
+}

--- a/tools/browser-extension/vendor/popup.js
+++ b/tools/browser-extension/vendor/popup.js
@@ -2859,9 +2859,14 @@ function createEntryHeader(entry, idx) {
                     idx = Array.prototype.indexOf.call(siblings, entryEl);
                     if (idx < 0) idx = 0;
                 }
+                // BUG-1326：参数必须原样传**对象**（与本文件其余 callHandler 一致）。
+                // 之前这里独一份地 JSON.stringify 了，宿主 handler 只认 Map（args[0] is
+                // Map），于是 entryIndex 恒退化成 0、matched 恒为空——「确认制卡」永远去
+                // 点第一个词条的按钮（用户在第 2+ 个词条上点，看到的就是「没反应」），
+                // 当前句里的词也不高亮。
                 window.flutter_inappwebview.callHandler(
                     'openSentenceContextModal',
-                    JSON.stringify({ entryIndex: idx, matched: matched }));
+                    { entryIndex: idx, matched: matched });
             },
         });
         setButtonIcon(adjustBtn, 'tune');


### PR DESCRIPTION
用户报「视频里点上下句调整后点制卡没反应，而且制卡把查词弹窗关了」——同一操作路径上的两个独立缺陷。

## BUG-1325（主因，两个症状同源）

视频页 / 首页词典页 / texthooker 把整棵查词浮层子树挂在**根 Overlay**（手动 `insert`，动机是盖过 media_kit 全屏路由），它永远排在 `showAppDialog` 推的路由**之上**。浮层里那层整屏 dismiss barrier 是 `Positioned.fill` + `HitTestBehavior.translucent`，于是把落在对话框上的点击整个吃掉：

- 「确认制卡」按钮收不到点击 → 用户看到的「没反应」；
- 同一下被 `_onDismissBarrierTap` 判成「点浮层外面」→ `_popNestedPopupAt(0)` 清整栈 → 用户看到的「制卡把我查词弹窗关了」。

BUG-797 当时只把弹窗 WebView 停到屏外（`parkedPopupLayer` 的 `visible` 接了 `_popupHidingDialogDepth`），解决了「对话框看得见」，**命中测试这一半漏了**。影响面是三个根 Overlay 表面上所有 `runWithLookupPopupHidden` 的对话框：句子上下文对话框、点 ✓ 的已制卡操作单（BUG-1040）、「在 Anki 中打开」的多卡选择。阅读器/有声书不受影响（浮层画在页面 `Stack` 里）。

**修复**：`DictionaryPageMixin` 暴露 `lookupPopupHiddenByDialog`；barrier 判据收口成纯函数 `shouldShowLookupDismissBarrier`（`dictionary_popup_layer.dart`），三处共用，不再各写一份漂移。

## BUG-1326（次因）

`popup.js` 里**唯一**一处把 `callHandler` 参数 `JSON.stringify` 的调用就是 `openSentenceContextModal`，而宿主 handler 只认 `args[0] is Map` → `entryIndex` 恒退化成 0、`matched` 恒为空：确认制卡永远去点**第一个词条**的按钮（用户在第 2+ 个词条上点，看到的就是「没反应」），对话框里当前句的词也不高亮。既有守卫只 `contains('entryIndex')`，属源码扫描假绿。

**修复**：popup.js 三镜像改回原样传对象（三份 SHA-256 仍逐字节一致）；宿主侧新增纯函数 `decodeBridgeMap`，兼容用户浏览器里未同步更新的老扩展 vendor 副本。

## 测试

新增 `hibiki/test/pages/lookup_dismiss_barrier_dialog_test.dart`：

- **层序复现**（最小 harness，不拉真视频页）：barrier 挂着时点对话框按钮 → 按钮零触发、点击落到 barrier；撤掉 barrier 后按钮才真被点到。这条直接证明根因，也钉死修复前提。
- 判据真值表 + `decodeBridgeMap` 三形态（对象 / JSON 串 / null·非法串·数组）。
- 三宿主页 + 三镜像源码守卫，含「裸条件复发即红」的负向断言。**两个守卫均已变异实测**：改回旧写法当场变红，反向替换还原后哈希与变异前一致。

既有 `home_dictionary_pull_preserve_query_test` 的遮罩断言随契约更新（多了对话框门控）。

## 验证

- `flutter analyze`（含 test 目录）：No issues found。
- `test/pages test/build test/dictionary`：2937 项，唯一一处红是上面那条契约变更的既有守卫，更新后复跑通过。
- `test/media test/lookup test/shortcuts test/anki`：`FLUTTER TEST VERDICT: PASSED - 5136 tests ran`。
- 本地全量套件起过一次但被环境 kill（本机另有会话在并发跑测试），未跑完；合入前需补一次全量 `dart run tool/flutter_test_failures.dart --no-pub`，CI 的 APK unit test 门同样兜底。
- 未做真机复测。

https://claude.ai/code/session_016sTxaKCEzHV3kCLD1kGWJx