### PR TITLE
fix(ui): 界面字体按显示语言构造回退链，排版分区不再默认折叠 (BUG-1325)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1269 条。点号进各自文件。
+> 共 1270 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1325](bugs/BUG-1325-ui-font-chain-collapsed-to-single-family.md) | ✅ | ✅ | 界面字体回退链被压成单值：中文默认字形难看、日文缺字逐字乱回退、用户第2条字体永不生效 |
 | [BUG-1324](bugs/BUG-1324-sync-report-auth-failure-untyped.md) | ✅ | ✅ | 同步报告把鉴权失败压成一行字符串：UI 只剩「N 项失败」 |
 | [BUG-1323](bugs/BUG-1323-sync-401-403-flattened.md) | ✅ | ✅ | webdav_ops 把 401/403 压成同一个 SyncAuthError：403 被谎报成登录过期还触发登出 |
 | [BUG-1322](bugs/BUG-1322-clip-export-mobile-mjpeg-unplayable.md) | ✅ | ✅ | 移动端导出片段MJPEG-MOV体积巨大且普遍无法播放 |

--- a/docs/bugs/BUG-1325-ui-font-chain-collapsed-to-single-family.md
+++ b/docs/bugs/BUG-1325-ui-font-chain-collapsed-to-single-family.md
@@ -22,7 +22,7 @@
 
 ### 修复
 
-- **[x] ① 已修复** — commit `PENDING_COMMIT`
+- **[x] ① 已修复** — commit `f87d7c40a`
   - 新增 `hibiki/lib/src/models/app_ui_font_chain.dart`：纯函数 `appUiFontChain()`，按
     `[用户自定义字体（全部，按序）] + [显示语言的系统字体] + [其余 CJK 语言字体]` 构造链，
     平台可注入（Windows / Apple / Noto 三套家族名，繁简分开）。

--- a/docs/bugs/BUG-1325-ui-font-chain-collapsed-to-single-family.md
+++ b/docs/bugs/BUG-1325-ui-font-chain-collapsed-to-single-family.md
@@ -1,0 +1,56 @@
+## BUG-1325 · 界面字体回退链被压成单值：中文默认字形难看、日文缺字逐字乱回退、用户第2条字体永不生效
+
+- **报告**：2026-08-01（用户：中文默认字体很烂；日语缺字会导致回退；希望默认按语言用对应字体）
+- **真实性**：✅ 真 bug，三个症状同一根因——字体本质是**有序回退链**，实现把它压成了单值。
+
+### 根因（三处，同一个数据结构缺陷）
+
+1. `hibiki/lib/src/models/app_font_loader.dart:43`（旧 `resolveAndLoad`）
+   命中第一个 enabled 条目就 `return`，**丢弃列表其余全部条目**。用户在「外观 · 排版 · 字体库」
+   里排的是一个有序列表（UI 上就是回退顺序），排第 2、3 位的字体从来没有机会参与缺字回退。
+2. `hibiki/lib/src/models/app_model.dart:1511`（旧 `textStyle`）
+   只设 `fontFamily`，**从不设 `fontFamilyFallback`**。主字体缺字时逐字掉进引擎默认 fallback：
+   日文 face 缺简中「们/东/为」、中文 face 缺假名，同一行里字形忽宽忽窄。
+   视频字幕层早已承认这个事实并加了链（TODO-088 `subtitleCjkFontFallbacks`），界面层没跟上。
+3. 同上，未配自定义字体时 `fontFamily == null`，CJK 字形完全交给引擎默认 fallback。
+   该回退不看 `TextStyle.locale`（Windows/Skia 尤甚），中文界面常落到并非为简中优化的 face
+   上——即用户所说的「中文默认字体很烂」。BUG-068 已把「界面字形跟显示语言」定为规矩，
+   但当时只解开了 `ja` 硬钉，没有正面给出各语言的字体。
+
+附带（同一页面的可用性问题）：`settings_schema_appearance.dart` 的「排版」分区
+`collapsedByDefault: true`，让高频的改字体操作每次多一次展开点击。
+
+### 修复
+
+- **[x] ① 已修复** — commit `PENDING_COMMIT`
+  - 新增 `hibiki/lib/src/models/app_ui_font_chain.dart`：纯函数 `appUiFontChain()`，按
+    `[用户自定义字体（全部，按序）] + [显示语言的系统字体] + [其余 CJK 语言字体]` 构造链，
+    平台可注入（Windows / Apple / Noto 三套家族名，繁简分开）。
+  - `AppFontLoader.resolveAndLoadAll()`：解析并注册**整张**列表（未注册的家族名在 Flutter
+    回退链里是死名，所以注册必须覆盖全列表）。单家族目标（视频字幕，自带 CJK 链且与
+    mpv/libass 字号换算耦合，见 BUG-929）仍用 `resolveAndLoad` 保持懒解析。
+  - `AppModel.textStyle` 输出 `fontFamily` + `fontFamilyFallback`；链按 (locale, 自定义列表) memo。
+  - 「排版」分区去掉 `collapsedByDefault`，默认展开。
+  - **刻意不做**：显示语言非 CJK 且无自定义字体 → 返回空链，双 null，与改造前逐像素一致。
+    因为 `fontFamily == null` 时引擎把 fallback 首项当主字体（拉丁字形也归它管），强塞 CJK 链
+    会把一个 CJK 缺字问题换成全语言排版问题。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/models/app_ui_font_chain_test.dart`（新，13 例）：链构造规则的行为契约——
+    显示语言决定链首、繁简分流、非 CJK 界面不被接管、自定义列表整条进链、去重与裁空白、
+    日文兜底排在其余 CJK 之前、平台家族不混淆、链不可变。
+  - `hibiki/test/models/app_ui_font_locale_guard_test.dart`（扩充）：钉住 `textStyle` 的接线
+    （`fontFamilyFallback: appFontFallbacks` + 链由 `appUiFontChain` 构造 + appUi 走
+    `resolveAndLoadAll`）。
+  - `hibiki/test/reader/font_targets_wiring_guard_test.dart`（更新）：appUi 目标必须走
+    `resolveAndLoadAll`（`resolveAndLoad` 会静默丢掉用户自己排的回退顺序）。
+  - 三处守卫均做过**变异实测**：删 `fontFamilyFallback` 行、把 appUi 改回 `resolveAndLoad`、
+    把日文挪到繁中之后——各自都能让对应断言变红（首版的「日文在显示语言之后」是自洽废话，
+    抓不到第三处变异，已改成「日文在兜底段内部排第一」）。
+
+### 备注
+
+- 未做真机目视复核：字体链的实际字形只有装了对应系统字体的真机能看到，链本身
+  （顺序 / 平台家族 / locale 分流）已被上述纯函数测试覆盖。
+- 未涉及：词典弹窗（`assets/popup/popup.css` 默认 `"Hiragino Sans", ...` 硬编码日文链）与
+  阅读器正文（body target）仍各自沿用原默认。它们的语言由**内容**而非界面语言决定，
+  与本条的界面链不是同一个判据，需要单独立项。

--- a/hibiki/lib/src/models/app_font_loader.dart
+++ b/hibiki/lib/src/models/app_font_loader.dart
@@ -16,9 +16,11 @@ import 'package:path/path.dart' as p;
 /// The reader serves font files to its WebView via CSS `@font-face`; that path
 /// never touches the Flutter engine. To make a font file usable by Flutter
 /// widgets it must be loaded at runtime through [FontLoader] — there is no
-/// pubspec asset declaration for user files. This helper resolves the first
-/// enabled entry from the passed font list (TODO-049: the app-wide UI target,
-/// `appUiFonts`) and returns the family name to feed into `TextStyle.fontFamily`.
+/// pubspec asset declaration for user files. This helper resolves entries from
+/// the passed font list (TODO-049: the app-wide UI target, `appUiFonts`) and
+/// returns the family name(s) to feed into `TextStyle.fontFamily` /
+/// `fontFamilyFallback`: [resolveAndLoadAll] for targets that consume the whole
+/// ordered list as a fallback chain, [resolveAndLoad] for single-family targets.
 class AppFontLoader {
   AppFontLoader._();
 
@@ -40,68 +42,104 @@ class AppFontLoader {
   /// each entry `{name, path, enabled}`), registering its file with the engine
   /// when needed. Returns the family name to use, or `null` when no usable
   /// custom font is set — the caller then falls back to the language default.
+  ///
+  /// Stops at the first usable entry: targets that render with a single family
+  /// (video subtitles, which carry their own CJK fallback chain) must not pay
+  /// for registering fonts they will never reference. Targets that DO consume
+  /// the whole ordered list use [resolveAndLoadAll].
   static Future<String?> resolveAndLoad(
     List<Map<String, dynamic>> fonts,
   ) async {
     for (final Map<String, dynamic> font in fonts) {
-      final bool enabled = font['enabled'] as bool? ?? true;
-      if (!enabled) continue;
-
-      final String? rawName = font['name'] as String?;
-      if (rawName == null || rawName.trim().isEmpty) continue;
-
-      // Use the SAME family identifier the reader uses (underscores → spaces)
-      // so the App UI and the reader WebView reference one font under one name.
-      final String family =
-          ReaderCustomFontCss.normalizedFontFamilyName(rawName);
-      if (family.isEmpty) continue;
-
-      final String? path = font['path'] as String?;
-
-      // System font (no imported file): the platform resolves it by family
-      // name directly, no FontLoader registration is possible or needed.
-      if (path == null) {
-        return family;
-      }
-
-      final String ext = p.extension(path).toLowerCase();
-      final bool isWoff = ext == _woffExtension;
-      final bool isWoff2 = ext == _woff2Extension;
-      if (!_directExtensions.contains(ext) && !isWoff && !isWoff2) continue;
-
-      final File file = File(path);
-      if (!file.existsSync()) continue;
-
-      if (!_loadedFamilies.contains(family)) {
-        try {
-          Uint8List bytes = await file.readAsBytes();
-          if (isWoff || isWoff2) {
-            // FontLoader only accepts raw sfnt, so unwrap the web-font
-            // container (WOFF2 first, then WOFF 1.0).
-            final Uint8List? sfnt = isWoff2
-                ? Woff2Decoder.toSfnt(bytes)
-                : FontDecoder.woffToSfnt(bytes);
-            if (sfnt == null) continue;
-            bytes = sfnt;
-          }
-          final FontLoader loader = FontLoader(family)
-            ..addFont(Future<ByteData>.value(bytes.buffer
-                .asByteData(bytes.offsetInBytes, bytes.lengthInBytes)));
-          await loader.load();
-          _loadedFamilies.add(family);
-          // BUG-897：自定义字体不在系统字体目录（扫描不到），把字节同步喂进 ASS 字号
-          // 换算索引（OS/2 win cell 语义），别名=本处注册的家族名——视频字幕用自定义
-          // 字体时字号也与 mpv/libass 同源。
-          AssFontCellIndex.instance
-              .registerFontBytes(bytes, aliases: <String>[family]);
-        } catch (e, stack) {
-          ErrorLogService.instance
-              .log('AppFontLoader.resolveAndLoad', e, stack);
-          continue;
-        }
-      }
-      return family;
+      final String? family = await _resolveEntry(font);
+      if (family != null) return family;
     }
     return null;
+  }
+
+  /// Resolves **every** usable entry of [fonts], in the user's order, and
+  /// registers each one with the engine.
+  ///
+  /// The font library is an ordered list, and for the app-UI target that order
+  /// IS the fallback chain (`TextStyle.fontFamily` + `fontFamilyFallback`, see
+  /// `app_ui_font_chain.dart`). [resolveAndLoad] returning only the first entry
+  /// silently dropped every later one — a user whose primary font lacks a glyph
+  /// never reached their own second choice, the engine's default fallback took
+  /// over instead. A family that is never registered here is a dead name in a
+  /// Flutter fallback chain, so registration must cover the whole list.
+  ///
+  /// Unusable entries (disabled / unnamed / unreadable / undecodable) are
+  /// skipped, never throwing; the result keeps the surviving entries' order.
+  static Future<List<String>> resolveAndLoadAll(
+    List<Map<String, dynamic>> fonts,
+  ) async {
+    final List<String> families = <String>[];
+    for (final Map<String, dynamic> font in fonts) {
+      final String? family = await _resolveEntry(font);
+      // 同名条目只保留一次：重复家族名在回退链里没有意义（引擎按名解析），
+      // 只会让「第几个生效」变得无法推理。
+      if (family != null && !families.contains(family)) families.add(family);
+    }
+    return families;
+  }
+
+  /// Resolves one `{name, path, enabled}` entry to a registered family name, or
+  /// null when the entry is unusable. Registration is idempotent per family.
+  static Future<String?> _resolveEntry(Map<String, dynamic> font) async {
+    final bool enabled = font['enabled'] as bool? ?? true;
+    if (!enabled) return null;
+
+    final String? rawName = font['name'] as String?;
+    if (rawName == null || rawName.trim().isEmpty) return null;
+
+    // Use the SAME family identifier the reader uses (underscores → spaces)
+    // so the App UI and the reader WebView reference one font under one name.
+    final String family = ReaderCustomFontCss.normalizedFontFamilyName(rawName);
+    if (family.isEmpty) return null;
+
+    final String? path = font['path'] as String?;
+
+    // System font (no imported file): the platform resolves it by family
+    // name directly, no FontLoader registration is possible or needed.
+    if (path == null) {
+      return family;
+    }
+
+    final String ext = p.extension(path).toLowerCase();
+    final bool isWoff = ext == _woffExtension;
+    final bool isWoff2 = ext == _woff2Extension;
+    if (!_directExtensions.contains(ext) && !isWoff && !isWoff2) return null;
+
+    final File file = File(path);
+    if (!file.existsSync()) return null;
+
+    if (_loadedFamilies.contains(family)) return family;
+
+    try {
+      Uint8List bytes = await file.readAsBytes();
+      if (isWoff || isWoff2) {
+        // FontLoader only accepts raw sfnt, so unwrap the web-font
+        // container (WOFF2 first, then WOFF 1.0).
+        final Uint8List? sfnt = isWoff2
+            ? Woff2Decoder.toSfnt(bytes)
+            : FontDecoder.woffToSfnt(bytes);
+        if (sfnt == null) return null;
+        bytes = sfnt;
+      }
+      final FontLoader loader = FontLoader(family)
+        ..addFont(Future<ByteData>.value(
+            bytes.buffer.asByteData(bytes.offsetInBytes, bytes.lengthInBytes)));
+      await loader.load();
+      _loadedFamilies.add(family);
+      // BUG-897：自定义字体不在系统字体目录（扫描不到），把字节同步喂进 ASS 字号
+      // 换算索引（OS/2 win cell 语义），别名=本处注册的家族名——视频字幕用自定义
+      // 字体时字号也与 mpv/libass 同源。
+      AssFontCellIndex.instance
+          .registerFontBytes(bytes, aliases: <String>[family]);
+    } catch (e, stack) {
+      ErrorLogService.instance.log('AppFontLoader.resolveAndLoad', e, stack);
+      return null;
+    }
+    return family;
   }
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -33,6 +33,7 @@ import 'package:hibiki/src/pages/implementations/popup_dictionary_page.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 import 'package:hibiki/src/media/floating_dict_channel.dart';
 import 'package:hibiki/src/models/app_font_loader.dart';
+import 'package:hibiki/src/models/app_ui_font_chain.dart';
 import 'package:hibiki/src/models/builtin_tags.dart';
 import 'package:hibiki/src/epub/book_title_conflict.dart';
 import 'package:hibiki/src/epub/epub_importer.dart';
@@ -1457,11 +1458,48 @@ class AppModel with ChangeNotifier {
   MediaItem? get currentMediaItem => _currentMediaItem;
   MediaItem? _currentMediaItem;
 
-  /// The user's custom app-wide UI font family, or null to use the language
-  /// default. Resolved and registered with the Flutter engine by
-  /// [refreshAppFont]; see [AppFontLoader].
-  String? _appFontFamily;
-  String? get appFontFamily => _appFontFamily;
+  /// The user's custom app-wide UI fonts, in the order they appear in the font
+  /// library's `appUi` target — an ordered **fallback chain**, not a single
+  /// face. Resolved and registered with the Flutter engine by [refreshAppFont];
+  /// see [AppFontLoader.resolveAndLoadAll]. Empty means "no custom font", which
+  /// hands the choice to the display language's system chain
+  /// ([appUiFontChain]).
+  List<String> _appFontFamilies = const <String>[];
+
+  /// Primary app-chrome family = head of the resolved chain ([appFontChain]).
+  /// Null keeps the platform default (non-CJK UI language with no custom font).
+  String? get appFontFamily => appFontChain.isEmpty ? null : appFontChain.first;
+
+  /// Everything after the primary family — feeds `TextStyle.fontFamilyFallback`.
+  /// Null (not an empty list) when there is nothing to fall back to, so the
+  /// style stays byte-identical to the pre-chain behaviour.
+  List<String>? get appFontFallbacks {
+    final List<String> chain = appFontChain;
+    return chain.length > 1 ? chain.sublist(1) : null;
+  }
+
+  /// The full app-chrome font chain for the current display language, memoised
+  /// on (locale, custom families) — [textStyle] is read on every theme rebuild,
+  /// and rebuilding a dozen-entry chain each time is pure garbage.
+  List<String> get appFontChain {
+    final Locale uiLocale = appLocale;
+    if (_cachedFontChainLocale == uiLocale &&
+        identical(_cachedFontChainSource, _appFontFamilies)) {
+      return _cachedFontChain;
+    }
+    _cachedFontChain = appUiFontChain(
+      customFamilies: _appFontFamilies,
+      locale: uiLocale,
+      platform: defaultTargetPlatform,
+    );
+    _cachedFontChainLocale = uiLocale;
+    _cachedFontChainSource = _appFontFamilies;
+    return _cachedFontChain;
+  }
+
+  List<String> _cachedFontChain = const <String>[];
+  Locale? _cachedFontChainLocale;
+  List<String>? _cachedFontChainSource;
 
   /// The user's custom video-subtitle font family, or null to use the platform
   /// default (+ CJK fallback chain). Resolved/registered with the Flutter
@@ -1470,27 +1508,31 @@ class AppModel with ChangeNotifier {
   String? _subtitleFontFamily;
   String? get subtitleFontFamily => _subtitleFontFamily;
 
-  /// Loads the first enabled entry from the reader's `customFonts` list as the
-  /// app-wide UI font (registering the file with the Flutter engine via
-  /// [AppFontLoader]) and rebuilds the theme. Falls back to the language
-  /// default when none is usable. Safe to call repeatedly — a no-op when the
-  /// resolved family is unchanged.
+  /// Loads **all** enabled entries of the `appUiFonts` target as the app-wide UI
+  /// font chain (registering each file with the Flutter engine via
+  /// [AppFontLoader]) and rebuilds the theme. Falls back to the display
+  /// language's system fonts when none is usable. Safe to call repeatedly — a
+  /// no-op when the resolved chain is unchanged.
   Future<void> refreshAppFont() async {
     final ReaderSettings settings = ReaderSettings(_database);
     await settings.refreshFromDb();
     // TODO-049: 软件系统字体走独立的 appUiFonts 目标，与小说正文(customFonts)、
-    // 词典字体相互独立。
-    final String? family =
-        await AppFontLoader.resolveAndLoad(settings.appUiFonts);
+    // 词典字体相互独立。整张列表都进链（不再只取第一条），用户排第 2、3 位的字体
+    // 才真正参与缺字回退。
+    final List<String> families =
+        await AppFontLoader.resolveAndLoadAll(settings.appUiFonts);
     // TODO-864: 视频字幕字体走独立的 videoSubtitle 目标；复用同一次
     // refreshFromDb 一起解析。两个 target 都解析完再判是否 notify，否则
     // 只改字幕字体（appUi 未变）时 early-return 会吞掉刷新。
+    // 字幕层自带 CJK 回退链（TODO-088）且与 mpv/libass 字号换算耦合（BUG-929），
+    // 故仍取单个家族，不走链。
     final String? subtitleFamily =
         await AppFontLoader.resolveAndLoad(settings.videoSubtitleFonts);
-    if (family == _appFontFamily && subtitleFamily == _subtitleFontFamily) {
+    if (listEquals(families, _appFontFamilies) &&
+        subtitleFamily == _subtitleFontFamily) {
       return;
     }
-    _appFontFamily = family;
+    _appFontFamilies = families;
     _subtitleFontFamily = subtitleFamily;
     notifyListeners();
   }
@@ -1509,6 +1551,11 @@ class AppModel with ChangeNotifier {
     final Locale uiLocale = appLocale;
     return TextStyle(
       fontFamily: appFontFamily,
+      // 缺字回退链（[appUiFontChain]）：用户列表里剩下的字体 + 显示语言的系统
+      // CJK 字体 + 其余 CJK 语言。没有它时，主字体缺字（典型如日文 face 上的
+      // 简中「们/东」、中文 face 上的日文假名）会逐字掉进引擎默认 fallback，
+      // 同一行里字形忽宽忽窄。
+      fontFamilyFallback: appFontFallbacks,
       fontFeatures: const [FontFeature('liga', 0)],
       locale: uiLocale,
       textBaseline: _isIdeographicLocale(uiLocale)
@@ -2184,11 +2231,12 @@ class AppModel with ChangeNotifier {
       } catch (e, stack) {
         ErrorLogService.instance.log('AppModel.healFontPaths', e, stack);
       }
-      // Register the user's custom app-wide font (first enabled entry) before
-      // first paint so the global theme uses it without a flash. Reuses the
+      // Register the user's custom app-wide fonts (every enabled entry, in
+      // order — the chain feeds fontFamily + fontFamilyFallback) before first
+      // paint so the global theme uses them without a flash. Reuses the
       // settings just loaded above to avoid a second prefs read.
-      _appFontFamily =
-          await AppFontLoader.resolveAndLoad(readerSettings.appUiFonts);
+      _appFontFamilies =
+          await AppFontLoader.resolveAndLoadAll(readerSettings.appUiFonts);
       // TODO-864: 视频字幕字体同样在首帧前从 videoSubtitle 目标解析。
       _subtitleFontFamily =
           await AppFontLoader.resolveAndLoad(readerSettings.videoSubtitleFonts);

--- a/hibiki/lib/src/models/app_ui_font_chain.dart
+++ b/hibiki/lib/src/models/app_ui_font_chain.dart
@@ -1,0 +1,174 @@
+/// 应用界面（app chrome）文字的**字体回退链**。
+///
+/// ## 为什么需要「链」而不是单个家族名
+///
+/// 字体选择的本质是有序回退：一个 face 只覆盖部分码位，缺字时引擎按链向后找。
+/// 但历史实现把链压成了单值，一处压缩产生了三个症状：
+///
+/// 1. 用户在「外观 · 排版 · 字体库」里配的是一个**有序列表**，
+///    `AppFontLoader.resolveAndLoad` 却只返回第一个 enabled 条目，其余全部丢弃——
+///    用户排在第 2、3 位的字体从来没有机会参与缺字回退。
+/// 2. 没配自定义字体时 `fontFamily` 为 null，CJK 字形完全交给引擎默认 fallback。
+///    该回退不看 [Locale]（Windows/Skia 尤甚），中文界面常落到一套并非为简中优化
+///    的 face 上——用户口中的「中文默认字体很烂」。
+/// 3. 主字体是日文 face 时（本 app 的典型配置），简中特有汉字（们/东/为…）在日文
+///    字体里缺字，逐字掉到引擎默认 face：同一行里字形忽宽忽窄、忽粗忽细。
+///
+/// 视频字幕层早就承认了这个事实（TODO-088 的 `subtitleCjkFontFallbacks`），但那条链
+/// 是**字幕专用**且只面向日文（顺序还要与 mpv/libass 对齐，见 BUG-929），不能直接
+/// 复用为界面链——界面链必须跟随**显示语言**（BUG-068 定下的规矩：界面字形跟
+/// `appLocale`，不跟固定的日语阅读语言）。
+///
+/// ## 链的构造规则（[appUiFontChain]）
+///
+/// ```
+/// [用户自定义字体（全部 enabled，按序）] + [显示语言的系统字体] + [其余 CJK 语言字体]
+/// ```
+///
+/// 关键的一条**不做**：显示语言不是 CJK 且用户没配自定义字体时，返回空链，
+/// `fontFamily`/`fontFamilyFallback` 双 null，与改造前逐像素一致。原因是
+/// `fontFamily == null` 时引擎会把 fallback 的第一项**当作主字体**（拉丁字形也归它
+/// 管），此时若强塞一条 CJK 链，英文/法文界面的拉丁文字就会被 CJK 字体的拉丁部分
+/// 接管——把一个 CJK 缺字问题换成一个全语言排版问题。有主字体时链只在缺字时生效，
+/// 不影响拉丁，所以可以放心追加。
+library;
+
+import 'dart:ui' show Locale;
+
+import 'package:flutter/foundation.dart' show TargetPlatform;
+
+/// CJK 显示语言的系统字体链（按平台）。
+///
+/// 家族名按「该平台上的实际安装名」写。引擎解析时会自动跳过当前平台不存在的名字，
+/// 因此多写一两个同族别名是安全的，只影响解析时的字符串比较成本。
+const Map<_CjkScript, List<String>> _kWindowsCjkFonts =
+    <_CjkScript, List<String>>{
+  _CjkScript.japanese: <String>[
+    'Yu Gothic UI',
+    'Yu Gothic',
+    'Meiryo',
+    'MS Gothic',
+  ],
+  _CjkScript.simplifiedChinese: <String>[
+    'Microsoft YaHei UI',
+    'Microsoft YaHei',
+  ],
+  _CjkScript.traditionalChinese: <String>[
+    'Microsoft JhengHei UI',
+    'Microsoft JhengHei',
+  ],
+  _CjkScript.korean: <String>['Malgun Gothic'],
+};
+
+const Map<_CjkScript, List<String>> _kAppleCjkFonts =
+    <_CjkScript, List<String>>{
+  _CjkScript.japanese: <String>['Hiragino Sans', 'Hiragino Kaku Gothic ProN'],
+  _CjkScript.simplifiedChinese: <String>['PingFang SC', 'Heiti SC'],
+  _CjkScript.traditionalChinese: <String>['PingFang TC', 'Heiti TC'],
+  _CjkScript.korean: <String>['Apple SD Gothic Neo'],
+};
+
+/// Android / Linux / Fuchsia：Noto CJK 是这些平台的事实标准。
+const Map<_CjkScript, List<String>> _kNotoCjkFonts = <_CjkScript, List<String>>{
+  _CjkScript.japanese: <String>['Noto Sans CJK JP', 'Noto Sans JP'],
+  _CjkScript.simplifiedChinese: <String>[
+    'Noto Sans CJK SC',
+    'Noto Sans SC',
+    'Source Han Sans SC',
+  ],
+  _CjkScript.traditionalChinese: <String>['Noto Sans CJK TC', 'Noto Sans TC'],
+  _CjkScript.korean: <String>['Noto Sans CJK KR', 'Noto Sans KR'],
+};
+
+/// 界面链的 CJK 书写系统。繁简分开：Han 统一码位下二者字形差异对读者可见
+/// （门/門、发/發），共用一条链等于放弃字形正确性。
+enum _CjkScript { japanese, simplifiedChinese, traditionalChinese, korean }
+
+/// 缺字续接顺序：显示语言的字体排完后，按此序补齐其余 CJK 语言。
+///
+/// 日文排第一是产品事实而非偏好——本 app 的内容（书名 / 字幕 / 词条 / 例句）以日文
+/// 为主，界面语言却常是中文；日文假名和日文专用汉字在中文字体里缺字率最高，让它紧
+/// 跟在显示语言之后，能把最常见的缺字挡在**受控的 face** 上，而不是引擎随机挑选。
+const List<_CjkScript> _kFallbackScriptOrder = <_CjkScript>[
+  _CjkScript.japanese,
+  _CjkScript.simplifiedChinese,
+  _CjkScript.traditionalChinese,
+  _CjkScript.korean,
+];
+
+/// 构造界面文字的完整字体链：`[0]` 是主字体（喂 `TextStyle.fontFamily`），其余喂
+/// `TextStyle.fontFamilyFallback`。
+///
+/// - [customFamilies]：用户在字体库 `appUi` 目标里启用的家族名，**按用户排序**，
+///   已由 `AppFontLoader` 注册进引擎。
+/// - [locale]：显示语言（`AppModel.appLocale`），不是日语阅读语言。
+/// - [platform]：解析系统字体名用的平台，测试可注入。
+///
+/// 返回空列表表示「保持平台默认」——调用方应把 fontFamily 与 fontFamilyFallback
+/// 都留成 null。
+List<String> appUiFontChain({
+  required List<String> customFamilies,
+  required Locale locale,
+  required TargetPlatform platform,
+}) {
+  // LinkedHashSet 语义：保序 + 去重。用户把某个系统字体名手动加进字体库时，不该在
+  // 链里出现第二次（重复项只会拖慢引擎解析，且让「第几个生效」变得难以推理）。
+  final Set<String> chain = <String>{};
+  for (final String family in customFamilies) {
+    final String trimmed = family.trim();
+    if (trimmed.isNotEmpty) chain.add(trimmed);
+  }
+
+  final Map<_CjkScript, List<String>> fonts = _cjkFontsForPlatform(platform);
+  final _CjkScript? uiScript = _cjkScriptForLocale(locale);
+  if (uiScript != null) {
+    chain.addAll(fonts[uiScript]!);
+  }
+
+  // 非 CJK 界面 + 无自定义字体 → 不接管平台默认（见 library 注释）。
+  if (chain.isEmpty) return const <String>[];
+
+  for (final _CjkScript script in _kFallbackScriptOrder) {
+    chain.addAll(fonts[script]!);
+  }
+  return List<String>.unmodifiable(chain);
+}
+
+Map<_CjkScript, List<String>> _cjkFontsForPlatform(TargetPlatform platform) {
+  switch (platform) {
+    case TargetPlatform.windows:
+      return _kWindowsCjkFonts;
+    case TargetPlatform.macOS:
+    case TargetPlatform.iOS:
+      return _kAppleCjkFonts;
+    case TargetPlatform.android:
+    case TargetPlatform.linux:
+    case TargetPlatform.fuchsia:
+      return _kNotoCjkFonts;
+  }
+}
+
+/// 显示语言对应的 CJK 书写系统；非 CJK 语言返回 null。
+_CjkScript? _cjkScriptForLocale(Locale locale) {
+  switch (locale.languageCode) {
+    case 'ja':
+      return _CjkScript.japanese;
+    case 'ko':
+      return _CjkScript.korean;
+    case 'zh':
+      return _isTraditionalChinese(locale)
+          ? _CjkScript.traditionalChinese
+          : _CjkScript.simplifiedChinese;
+    default:
+      return null;
+  }
+}
+
+/// 繁简判定：显式 script 子标签优先（`zh-Hant` / `zh-Hans`），否则按地区推断。
+/// 本 app 出货的 `zh-HK` 走繁体，`zh-CN` 走简体。
+bool _isTraditionalChinese(Locale locale) {
+  final String? script = locale.scriptCode;
+  if (script == 'Hant') return true;
+  if (script == 'Hans') return false;
+  return const <String>{'TW', 'HK', 'MO'}.contains(locale.countryCode);
+}

--- a/hibiki/lib/src/settings/settings_schema_appearance.dart
+++ b/hibiki/lib/src/settings/settings_schema_appearance.dart
@@ -86,8 +86,9 @@ SettingsDestination buildAppearanceDestination() {
         ],
       ),
       SettingsSection(
+        // 排版分区**不折叠**：改字体是外观页的高频操作（用户显式反馈），折叠让每次
+        // 改字体都多一次展开点击，收益（省一行高度）远小于代价。
         title: t.section_typography,
-        collapsedByDefault: true,
         items: <SettingsItem>[
           // TODO-231: one visible font library; each row manages app UI /
           // body / dictionary target membership via font_catalog/font_targets.

--- a/hibiki/test/models/app_ui_font_chain_test.dart
+++ b/hibiki/test/models/app_ui_font_chain_test.dart
@@ -1,0 +1,182 @@
+import 'dart:ui' show Locale;
+
+import 'package:flutter/foundation.dart' show TargetPlatform;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/models/app_ui_font_chain.dart';
+
+/// 界面字体回退链的行为契约。
+///
+/// 背景：字体本质是**有序回退链**，旧实现把它压成单值（`AppFontLoader` 只返回第一个
+/// enabled 条目、无自定义字体时 fontFamily 为 null 完全交给引擎默认 fallback），
+/// 由此产生三个用户可见症状：中文默认字体难看、日文 face 缺简中字时逐字乱回退、
+/// 用户排在第 2 位的字体永远轮不到。本文件钉住修复后的链构造规则。
+void main() {
+  List<String> chain({
+    List<String> custom = const <String>[],
+    String locale = 'zh',
+    String? country,
+    String? script,
+    TargetPlatform platform = TargetPlatform.windows,
+  }) =>
+      appUiFontChain(
+        customFamilies: custom,
+        locale: Locale.fromSubtags(
+          languageCode: locale,
+          scriptCode: script,
+          countryCode: country,
+        ),
+        platform: platform,
+      );
+
+  group('显示语言决定链首（BUG-068：界面字形跟 appLocale，不跟日语阅读语言）', () {
+    test('zh-CN 界面 → 简中字体打头，而不是日文字体', () {
+      final List<String> windows = chain(locale: 'zh', country: 'CN');
+      expect(windows.first, 'Microsoft YaHei UI');
+
+      final List<String> android =
+          chain(locale: 'zh', country: 'CN', platform: TargetPlatform.android);
+      expect(android.first, 'Noto Sans CJK SC');
+
+      final List<String> mac =
+          chain(locale: 'zh', country: 'CN', platform: TargetPlatform.macOS);
+      expect(mac.first, 'PingFang SC');
+    });
+
+    test('zh-HK / zh-TW → 繁体字形，不与简体共用一条链', () {
+      // Han 统一码位下繁简字形对读者可见（门/門），共用一条链等于放弃字形正确性。
+      expect(chain(locale: 'zh', country: 'HK').first, 'Microsoft JhengHei UI');
+      expect(
+        chain(locale: 'zh', country: 'TW', platform: TargetPlatform.macOS)
+            .first,
+        'PingFang TC',
+      );
+      // 显式 script 子标签优先于地区推断。
+      expect(
+        chain(locale: 'zh', script: 'Hant', country: 'CN').first,
+        'Microsoft JhengHei UI',
+      );
+      expect(
+        chain(locale: 'zh', script: 'Hans', country: 'TW').first,
+        'Microsoft YaHei UI',
+      );
+    });
+
+    test('ja / ko 界面各自打头', () {
+      expect(chain(locale: 'ja').first, 'Yu Gothic UI');
+      expect(chain(locale: 'ko').first, 'Malgun Gothic');
+      expect(
+        chain(locale: 'ja', platform: TargetPlatform.iOS).first,
+        'Hiragino Sans',
+      );
+    });
+  });
+
+  group('非 CJK 界面语言不被接管（防「修 CJK 缺字反而毁拉丁排版」）', () {
+    test('en 界面 + 无自定义字体 → 空链（保持平台默认，与改造前一致）', () {
+      // fontFamily 为 null 时引擎把 fallback 首项当主字体，拉丁字形也归它管。
+      // 此时强塞 CJK 链会让英文界面整体被 CJK 字体的拉丁部分接管。
+      expect(chain(locale: 'en'), isEmpty);
+      expect(chain(locale: 'fr', platform: TargetPlatform.macOS), isEmpty);
+    });
+
+    test('en 界面 + 有自定义字体 → 自定义打头，CJK 只做缺字兜底', () {
+      final List<String> result =
+          chain(custom: <String>['Inter'], locale: 'en');
+      expect(result.first, 'Inter');
+      // 主字体存在 → 链只在缺字时生效，不影响拉丁，可以放心追加 CJK。
+      expect(result, contains('Yu Gothic UI'));
+      expect(result, contains('Microsoft YaHei UI'));
+    });
+  });
+
+  group('用户自定义列表整条进链（旧实现只取第一条，其余全丢）', () {
+    test('多条自定义字体按用户顺序排在最前', () {
+      final List<String> result = chain(
+        custom: <String>['My Serif', 'My Gothic', 'My Mincho'],
+        locale: 'zh',
+        country: 'CN',
+      );
+      expect(result.take(3), <String>['My Serif', 'My Gothic', 'My Mincho']);
+      // 用户字体之后才是显示语言的系统字体。
+      expect(result[3], 'Microsoft YaHei UI');
+    });
+
+    test('空白名被跳过，重复项只保留第一次出现的位置', () {
+      final List<String> result = chain(
+        custom: <String>['My Gothic', '   ', 'My Gothic', 'Microsoft YaHei UI'],
+        locale: 'zh',
+        country: 'CN',
+      );
+      expect(result.take(2), <String>['My Gothic', 'Microsoft YaHei UI']);
+      expect(
+        result.where((String f) => f == 'My Gothic').length,
+        1,
+        reason: '重复家族名只会拖慢解析，且让「第几个生效」无法推理',
+      );
+      expect(result.where((String f) => f == 'Microsoft YaHei UI').length, 1,
+          reason: '用户手动加的系统字体名不该在语言链里再出现一次');
+      expect(result, isNot(contains('   ')));
+      expect(result, isNot(contains('')));
+    });
+
+    test('自定义字体名两端空白被裁掉（否则引擎按原样比对家族名，永远解析不到）', () {
+      expect(chain(custom: <String>['  My Gothic  '], locale: 'en').first,
+          'My Gothic');
+    });
+  });
+
+  group('缺字兜底覆盖全部 CJK 语言', () {
+    test('中文界面下日文兜底排在其余 CJK 之前（本 app 内容以日文为主）', () {
+      final List<String> result = chain(locale: 'zh', country: 'CN');
+      final int yahei = result.indexOf('Microsoft YaHei UI');
+      final int yuGothic = result.indexOf('Yu Gothic UI');
+      expect(yahei, isNonNegative);
+      expect(yuGothic, greaterThan(yahei), reason: '显示语言的字体必须排在兜底之前');
+      // 弱断言「日文在显示语言之后」是废话——显示语言本来就在最前。真正要钉住的是
+      // 日文在**兜底段内部**排第一：假名与日文专用汉字在中文字体里缺字率最高，把它
+      // 挪到繁中/韩文之后，最常见的缺字就会先撞上两套不相干的 face。
+      expect(yuGothic, lessThan(result.indexOf('Microsoft JhengHei UI')),
+          reason: '日文兜底必须排在繁中之前');
+      expect(yuGothic, lessThan(result.indexOf('Malgun Gothic')),
+          reason: '日文兜底必须排在韩文之前');
+    });
+
+    test('日文界面链尾含简中字体（中文书名/界面文案的缺字兜底）', () {
+      final List<String> result = chain(locale: 'ja');
+      expect(result.first, 'Yu Gothic UI');
+      expect(result, contains('Microsoft YaHei UI'));
+    });
+
+    test('四种 CJK 书写系统在任一 CJK 界面下都出现', () {
+      for (final String lang in <String>['zh', 'ja', 'ko']) {
+        final List<String> result = chain(locale: lang);
+        expect(result, contains('Yu Gothic UI'), reason: '$lang 缺日文兜底');
+        expect(result, contains('Microsoft YaHei UI'), reason: '$lang 缺简中兜底');
+        expect(result, contains('Microsoft JhengHei UI'),
+            reason: '$lang 缺繁中兜底');
+        expect(result, contains('Malgun Gothic'), reason: '$lang 缺韩文兜底');
+      }
+    });
+
+    test('每个平台只产出该平台的字体名，不混入别平台的家族', () {
+      final List<String> windows = chain(locale: 'zh', country: 'CN');
+      expect(windows, isNot(contains('PingFang SC')));
+      expect(windows, isNot(contains('Noto Sans CJK SC')));
+
+      final List<String> apple =
+          chain(locale: 'zh', country: 'CN', platform: TargetPlatform.macOS);
+      expect(apple, isNot(contains('Microsoft YaHei UI')));
+      expect(apple, contains('Hiragino Sans'));
+
+      final List<String> linux =
+          chain(locale: 'zh', country: 'CN', platform: TargetPlatform.linux);
+      expect(linux, isNot(contains('Microsoft YaHei UI')));
+      expect(linux, contains('Noto Sans CJK JP'));
+    });
+  });
+
+  test('链不可变（调用方拿到的是快照，不能就地改写共享常量）', () {
+    final List<String> result = chain(locale: 'zh', country: 'CN');
+    expect(() => result.add('X'), throwsUnsupportedError);
+  });
+}

--- a/hibiki/test/models/app_ui_font_locale_guard_test.dart
+++ b/hibiki/test/models/app_ui_font_locale_guard_test.dart
@@ -94,6 +94,27 @@ void main() {
     );
   });
 
+  test('textStyle carries the locale-aware fallback chain, not a bare family',
+      () {
+    // 字体本质是有序回退链。只设 fontFamily 时，主字体缺字（日文 face 上的简中
+    // 「们/东」、中文 face 上的假名）会逐字掉进引擎默认 fallback —— 同一行里字形
+    // 忽宽忽窄，且用户在字体库里排第 2、3 位的字体永远轮不到。
+    expect(
+      textStyleSource,
+      contains('fontFamilyFallback: appFontFallbacks,'),
+      reason:
+          'textStyle must feed the resolved chain tail to fontFamilyFallback',
+    );
+    // 链本身必须由 appUiFontChain 构造（跟随显示语言），不能在 textStyle 里
+    // 就地硬编码一串家族名。
+    final String source =
+        File('lib/src/models/app_model.dart').readAsStringSync();
+    expect(source, contains('appUiFontChain('));
+    // appUi 目标消费整张有序列表；resolveAndLoad（只取第一条）会静默丢掉用户
+    // 自己排的回退顺序。
+    expect(source, contains('AppFontLoader.resolveAndLoadAll('));
+  });
+
   test('textBaseline is derived from the UI locale, not pinned to Japanese',
       () {
     expect(

--- a/hibiki/test/reader/font_targets_wiring_guard_test.dart
+++ b/hibiki/test/reader/font_targets_wiring_guard_test.dart
@@ -18,13 +18,17 @@ void main() {
     // refresh resolves appUi + videoSubtitle; init resolves appUi + videoSubtitle
     // => four AppFontLoader call sites total (TODO-864).
     expect(
-      'AppFontLoader.resolveAndLoad('.allMatches(src).length,
+      'AppFontLoader.resolveAndLoad'.allMatches(src).length,
       greaterThanOrEqualTo(4),
       reason: 'expected the four AppFontLoader call sites '
           '(refresh appUi+videoSub, init appUi+videoSub)',
     );
-    expect(src.contains('resolveAndLoad(settings.appUiFonts)'), isTrue);
-    expect(src.contains('resolveAndLoad(readerSettings.appUiFonts)'), isTrue);
+    // The appUi target consumes the WHOLE ordered list (fallback chain), so it
+    // must go through resolveAndLoadAll — resolveAndLoad drops every entry after
+    // the first, which silently kills the user's own fallback order.
+    expect(src.contains('resolveAndLoadAll(settings.appUiFonts)'), isTrue);
+    expect(
+        src.contains('resolveAndLoadAll(readerSettings.appUiFonts)'), isTrue);
     // It must NOT be fed the body list any more.
     expect(src.contains('resolveAndLoad(settings.customFonts)'), isFalse);
     expect(src.contains('resolveAndLoad(readerSettings.customFonts)'), isFalse);


### PR DESCRIPTION
## 用户报告

> 外观里面的排版不要折叠，改字体很重要啊。还有中文默认字体很烂，有什么办法。因为日语缺字会导致回退。能不能默认应用排版使用语言对应的字体

## 判断：三个症状，一个根因

字体本质是**有序回退链**，实现把它压成了单值。一处压缩产生三个用户可见症状：

| 症状 | 根因位置 |
|---|---|
| 字体库里排第 2、3 位的字体永不生效 | `app_font_loader.dart` 旧 `resolveAndLoad` 命中第一个 enabled 条目就 `return`，其余全丢 |
| 日文字体缺简中字（们/东/为）时逐字乱回退、一行里字形忽宽忽窄 | `app_model.dart` 旧 `textStyle` 只设 `fontFamily`，**从不设 `fontFamilyFallback`** |
| 中文默认字体难看 | 无自定义字体时 `fontFamily == null`，CJK 字形全交给引擎默认 fallback，它基本不看 `TextStyle.locale`（Windows/Skia 尤甚） |

视频字幕层早就承认了这个事实（TODO-088 `subtitleCjkFontFallbacks`），界面层一直没跟上。BUG-068 当年只解开了 `ja` 硬钉，没有正面给出各语言该用什么字体。

## 改法

新增纯函数 `hibiki/lib/src/models/app_ui_font_chain.dart`：

```
[用户自定义字体（全部 enabled，按序）] + [显示语言的系统字体] + [其余 CJK 语言字体]
```

- 三套平台家族名：Windows（雅黑 / 游ゴ / 正黑 / Malgun）、Apple（苹方 / ヒラギノ）、Android+Linux（Noto CJK）。
- **繁简分流**：`zh-CN` → 雅黑，`zh-HK` → 正黑。Han 统一码位下繁简字形对读者可见（门/門），共用一条链等于放弃字形正确性。
- 兜底段内部固定 日 → 简中 → 繁中 → 韩：本 app 内容以日文为主，假名与日文专用汉字在中文字体里缺字率最高。
- `AppFontLoader.resolveAndLoadAll()` 注册**整张**列表——未注册的家族名在 Flutter 回退链里是死名。单家族目标（视频字幕，自带 CJK 链且与 mpv/libass 字号换算耦合，BUG-929）仍走懒解析的 `resolveAndLoad`。

### 刻意不做的一件事

显示语言非 CJK 且用户没配字体 → 返回**空链**，`fontFamily`/`fontFamilyFallback` 双 null，与改造前逐像素一致。

因为 `fontFamily == null` 时引擎会把 fallback 首项**当作主字体**（拉丁字形也归它管），此时强塞一条 CJK 链，英文/法文界面的拉丁文字就会被 CJK 字体的拉丁部分接管——把一个 CJK 缺字问题换成一个全语言排版问题。有主字体时链只在缺字时生效，才可以放心追加。

### 顺带

外观页「排版」分区去掉 `collapsedByDefault`，默认展开。

## 测试

- `test/models/app_ui_font_chain_test.dart`（新，13 例）：显示语言决定链首、繁简分流、非 CJK 界面不被接管、自定义列表整条进链、去重与裁空白、日文兜底排在其余 CJK 之前、平台家族不混淆、链不可变。
- `test/models/app_ui_font_locale_guard_test.dart` 扩充、`test/reader/font_targets_wiring_guard_test.dart` 更新（appUi 必须走 `resolveAndLoadAll`）。
- **三处守卫都做了变异实测**：删 `fontFamilyFallback` 行 / 把 appUi 改回 `resolveAndLoad` / 把日文挪到繁中之后——各自都能让对应断言变红。首版的「日文在显示语言之后」是自洽废话（抓不到第三处变异），已改成「日文在兜底段内部排第一」。

## 验证

- `flutter analyze`（含 test）：**No issues found**。
- `dart run tool/flutter_test_failures.dart --no-pub test/models test/goldens test/widgets test/settings test/reader test/pages test/media/video`：7055 用例，唯一失败是 `horizontal_drag_scroll_guard_test.dart` 指向 `video_episode_rail.dart`（选集轨漏包共享横滚件），该文件本 PR 一行未碰，是 develop 既有红（BUG-1306，PR#635 在处理）。
- 未做真机目视复核：字体链的实际字形只有装了对应系统字体的真机能看到；链本身（顺序 / 平台家族 / locale 分流）已被纯函数测试覆盖。

## 不在范围内

词典弹窗（`assets/popup/popup.css` 硬编码 `"Hiragino Sans", ...`）与阅读器正文（body target）仍沿用各自默认。它们的语言由**内容**而非界面语言决定，判据不同，需要单独立项。

https://claude.ai/code/session_01LFYaQFViAaz73CvZLiv5Za
