### PR TITLE
feat(scraper): 多源聚合匹配 + 内置 TMDB key，去掉数据源手动选择

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -130,6 +130,24 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
+      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
+      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
+      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
+      # bake the real value in so released builds scrape TMDB covers/metadata out of
+      # the box (no manual API key entry). Only the const line is rewritten, so the
+      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
+      - name: Provide gitignored TMDB API key stub
+        shell: bash
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          dst=hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+          if [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+          fi
+          if [ -n "$TMDB_API_KEY" ]; then
+            sed -i "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+          fi
       # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
       # is idempotent so a warm cache is safe).
       - name: Cache pub packages
@@ -294,6 +312,24 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
+      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
+      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
+      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
+      # bake the real value in so released builds scrape TMDB covers/metadata out of
+      # the box (no manual API key entry). Only the const line is rewritten, so the
+      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
+      - name: Provide gitignored TMDB API key stub
+        shell: bash
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          dst=hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+          if [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+          fi
+          if [ -n "$TMDB_API_KEY" ]; then
+            sed -i "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+          fi
       # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
       # is idempotent so a warm cache is safe).
       - name: Cache pub packages
@@ -456,6 +492,24 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
+      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
+      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
+      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
+      # bake the real value in so released builds scrape TMDB covers/metadata out of
+      # the box (no manual API key entry). Only the const line is rewritten, so the
+      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
+      - name: Provide gitignored TMDB API key stub
+        shell: bash
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          dst=hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+          if [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+          fi
+          if [ -n "$TMDB_API_KEY" ]; then
+            sed -i "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+          fi
       # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
       # is idempotent so a warm cache is safe).
       - name: Cache pub packages
@@ -585,6 +639,24 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
+      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
+      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
+      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
+      # bake the real value in so released builds scrape TMDB covers/metadata out of
+      # the box (no manual API key entry). Only the const line is rewritten, so the
+      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
+      - name: Provide gitignored TMDB API key stub
+        shell: bash
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          dst=hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+          if [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+          fi
+          if [ -n "$TMDB_API_KEY" ]; then
+            sed -i "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+          fi
       # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
       # is idempotent so a warm cache is safe).
       - name: Cache pub packages
@@ -702,6 +774,24 @@ jobs:
               > "$dst"
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
+          fi
+      # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
+      # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
+      # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
+      # bake the real value in so released builds scrape TMDB covers/metadata out of
+      # the box (no manual API key entry). Only the const line is rewritten, so the
+      # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
+      - name: Provide gitignored TMDB API key stub
+        shell: bash
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: |
+          dst=hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+          if [ ! -f "$dst" ]; then
+            cp hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+          fi
+          if [ -n "$TMDB_API_KEY" ]; then
+            sed -i "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
           fi
       # TODO-1208: Windows Dart pub cache defaults to %LOCALAPPDATA%\Pub\Cache.
       - name: Cache pub packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -125,6 +125,24 @@ jobs:
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
         fi
+    # tmdb_default_key.dart ships a committed empty placeholder (key = '') so a
+    # fresh clone compiles and TMDB scraping degrades to "not configured" (Bangumi
+    # / AniList / MAL sources still work). When the TMDB_API_KEY repo secret is set,
+    # bake the real value in so released builds scrape TMDB covers/metadata out of
+    # the box (no manual API key entry). Only the const line is rewritten, so the
+    # file's comments, the pref-key const and resolveTmdbApiKey() all survive.
+    - name: Provide gitignored TMDB API key stub
+      shell: bash
+      env:
+        TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+      run: |
+        dst=hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+        if [ ! -f "$dst" ]; then
+          cp hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart "$dst"
+        fi
+        if [ -n "$TMDB_API_KEY" ]; then
+          sed -i "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
+        fi
 
     # TODO-1208: cache the resolved pub packages so pub get is near-instant on a
     # warm runner. apply-patches.sh is idempotent (cp -r overwrite), so a restored

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 49249 (2897 per locale)
+/// Strings: 49232 (2896 per locale)
 ///
-/// Built on 2026-08-01 at 05:20 UTC
+/// Built on 2026-08-01 at 05:54 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3089,9 +3089,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_scrape_source_offline => 'Offline';
   String get video_scrape_summary => 'Synopsis';
   String get video_scrape_tags => 'Tags';
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API key';
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  String get video_scrape_tmdb_key_save => 'Save';
   String get video_scrape_use => 'Use';
   String get video_scrape_view_subject => 'View on Bangumi';
   String get video_screenshot => 'Screenshot';
@@ -3746,8 +3743,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   String get selection_web_search => 'Search the web';
@@ -3922,6 +3917,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'New name: ${name}';
   String get video_scrape_collection_rename_keep => 'Keep current name';
   String get video_scrape_collection_rename_confirm => 'Rename';
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -9169,12 +9169,6 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -10295,9 +10289,6 @@ class _StringsAr extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -10590,6 +10581,14 @@ class _StringsAr extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -15895,12 +15894,6 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -17030,9 +17023,6 @@ class _StringsDe extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -17325,6 +17315,14 @@ class _StringsDe extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -22644,12 +22642,6 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -23781,9 +23773,6 @@ class _StringsEs extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -24076,6 +24065,14 @@ class _StringsEs extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -29406,12 +29403,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -30543,9 +30534,6 @@ class _StringsFr extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -30838,6 +30826,14 @@ class _StringsFr extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -36106,12 +36102,6 @@ class _StringsId extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -37234,9 +37224,6 @@ class _StringsId extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -37529,6 +37516,14 @@ class _StringsId extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -42836,12 +42831,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -43971,9 +43960,6 @@ class _StringsIt extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -44266,6 +44252,14 @@ class _StringsIt extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -49418,12 +49412,6 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -50525,9 +50513,6 @@ class _StringsJa extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -50820,6 +50805,14 @@ class _StringsJa extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -55971,12 +55964,6 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -57081,9 +57068,6 @@ class _StringsKo extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -57376,6 +57360,14 @@ class _StringsKo extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -62667,12 +62659,6 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -63798,9 +63784,6 @@ class _StringsNl extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -64093,6 +64076,14 @@ class _StringsNl extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -69394,12 +69385,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -70528,9 +70513,6 @@ class _StringsPtBr extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -70823,6 +70805,14 @@ class _StringsPtBr extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -76112,12 +76102,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -77242,9 +77226,6 @@ class _StringsRu extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -77537,6 +77518,14 @@ class _StringsRu extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -82780,12 +82769,6 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -83904,9 +83887,6 @@ class _StringsTh extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -84199,6 +84179,14 @@ class _StringsTh extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -89470,12 +89458,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -90598,9 +90580,6 @@ class _StringsTr extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -90893,6 +90872,14 @@ class _StringsTr extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -96153,12 +96140,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -97277,9 +97258,6 @@ class _StringsVi extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -97572,6 +97550,14 @@ class _StringsVi extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -102473,12 +102459,6 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_scrape_tags => '标签';
   @override
-  String get video_scrape_tmdb_key_hint => '输入 TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB 需要 API Key';
-  @override
-  String get video_scrape_tmdb_key_save => '保存';
-  @override
   String get video_scrape_use => '使用';
   @override
   String get video_scrape_view_subject => '在 Bangumi 查看';
@@ -103505,9 +103485,6 @@ class _StringsZhCn extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       '这会把同一张封面写到每一集；只有确实需要统一单集封面时才开启。';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      '先保存 TMDB API Key，再点“搜索”。这里不会混入其他来源的结果。';
-  @override
   String get manga_online_source_disabled => '此互联网来源已关闭，请在「来源」中开启后浏览目录。';
   @override
   String get selection_web_search => '网页搜索';
@@ -103777,6 +103754,14 @@ class _StringsZhCn extends _StringsEn {
   String get video_scrape_collection_rename_keep => '保留当前名称';
   @override
   String get video_scrape_collection_rename_confirm => '重命名';
+  @override
+  String get video_setting_tmdb_key => '自定义 TMDB API Key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      '可留空，默认用内置 Key。仅当刮削失效或你想用自己的配额时才需要填写。';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 // Path: <root>
@@ -108859,12 +108844,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_scrape_tags => 'Tags';
   @override
-  String get video_scrape_tmdb_key_hint => 'Enter TMDB API Key';
-  @override
-  String get video_scrape_tmdb_key_required => 'TMDB requires an API key';
-  @override
-  String get video_scrape_tmdb_key_save => 'Save';
-  @override
   String get video_scrape_use => 'Use';
   @override
   String get video_scrape_view_subject => 'View on Bangumi';
@@ -109957,9 +109936,6 @@ class _StringsZhHk extends _StringsEn {
   String get video_scrape_apply_to_collection_hint =>
       'This writes the same cover to every episode. Leave it off unless that is intentional.';
   @override
-  String get video_scrape_tmdb_key_empty =>
-      'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
-  @override
   String get manga_online_source_disabled =>
       'This internet source is disabled. Enable it in Sources to browse the catalog.';
   @override
@@ -110252,6 +110228,14 @@ class _StringsZhHk extends _StringsEn {
   String get video_scrape_collection_rename_keep => 'Keep current name';
   @override
   String get video_scrape_collection_rename_confirm => 'Rename';
+  @override
+  String get video_setting_tmdb_key => 'Custom TMDB API key';
+  @override
+  String get video_setting_tmdb_key_hint =>
+      'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+  @override
+  String get about_tmdb_attribution =>
+      'This product uses the TMDB API but is not endorsed or certified by TMDB.';
 }
 
 /// Flat map(s) containing all translations.
@@ -114980,12 +114964,6 @@ extension on _StringsEn {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -115949,8 +115927,6 @@ extension on _StringsEn {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -116202,6 +116178,12 @@ extension on _StringsEn {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -120927,12 +120909,6 @@ extension on _StringsAr {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -121897,8 +121873,6 @@ extension on _StringsAr {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -122150,6 +122124,12 @@ extension on _StringsAr {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -126896,12 +126876,6 @@ extension on _StringsDe {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -127867,8 +127841,6 @@ extension on _StringsDe {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -128120,6 +128092,12 @@ extension on _StringsDe {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -132866,12 +132844,6 @@ extension on _StringsEs {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -133836,8 +133808,6 @@ extension on _StringsEs {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -134089,6 +134059,12 @@ extension on _StringsEs {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -138840,12 +138816,6 @@ extension on _StringsFr {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -139811,8 +139781,6 @@ extension on _StringsFr {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -140064,6 +140032,12 @@ extension on _StringsFr {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -144798,12 +144772,6 @@ extension on _StringsId {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -145768,8 +145736,6 @@ extension on _StringsId {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -146021,6 +145987,12 @@ extension on _StringsId {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -150768,12 +150740,6 @@ extension on _StringsIt {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -151739,8 +151705,6 @@ extension on _StringsIt {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -151992,6 +151956,12 @@ extension on _StringsIt {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -156704,12 +156674,6 @@ extension on _StringsJa {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -157672,8 +157636,6 @@ extension on _StringsJa {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -157925,6 +157887,12 @@ extension on _StringsJa {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -162640,12 +162608,6 @@ extension on _StringsKo {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -163609,8 +163571,6 @@ extension on _StringsKo {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -163862,6 +163822,12 @@ extension on _StringsKo {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -168602,12 +168568,6 @@ extension on _StringsNl {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -169574,8 +169534,6 @@ extension on _StringsNl {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -169827,6 +169785,12 @@ extension on _StringsNl {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -174566,12 +174530,6 @@ extension on _StringsPtBr {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -175536,8 +175494,6 @@ extension on _StringsPtBr {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -175789,6 +175745,12 @@ extension on _StringsPtBr {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -180533,12 +180495,6 @@ extension on _StringsRu {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -181503,8 +181459,6 @@ extension on _StringsRu {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -181756,6 +181710,12 @@ extension on _StringsRu {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -186483,12 +186443,6 @@ extension on _StringsTh {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -187453,8 +187407,6 @@ extension on _StringsTh {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -187706,6 +187658,12 @@ extension on _StringsTh {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -192441,12 +192399,6 @@ extension on _StringsTr {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -193412,8 +193364,6 @@ extension on _StringsTr {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -193665,6 +193615,12 @@ extension on _StringsTr {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -198397,12 +198353,6 @@ extension on _StringsVi {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -199367,8 +199317,6 @@ extension on _StringsVi {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -199620,6 +199568,12 @@ extension on _StringsVi {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -204311,12 +204265,6 @@ extension on _StringsZhCn {
         return '简介';
       case 'video_scrape_tags':
         return '标签';
-      case 'video_scrape_tmdb_key_hint':
-        return '输入 TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB 需要 API Key';
-      case 'video_scrape_tmdb_key_save':
-        return '保存';
       case 'video_scrape_use':
         return '使用';
       case 'video_scrape_view_subject':
@@ -205272,8 +205220,6 @@ extension on _StringsZhCn {
         return '这里只替换合集封面，不会修改各集封面或条目资料。切换来源后，点“搜索”才会请求该来源。';
       case 'video_scrape_apply_to_collection_hint':
         return '这会把同一张封面写到每一集；只有确实需要统一单集封面时才开启。';
-      case 'video_scrape_tmdb_key_empty':
-        return '先保存 TMDB API Key，再点“搜索”。这里不会混入其他来源的结果。';
       case 'manga_online_source_disabled':
         return '此互联网来源已关闭，请在「来源」中开启后浏览目录。';
       case 'selection_web_search':
@@ -205522,6 +205468,12 @@ extension on _StringsZhCn {
         return '保留当前名称';
       case 'video_scrape_collection_rename_confirm':
         return '重命名';
+      case 'video_setting_tmdb_key':
+        return '自定义 TMDB API Key';
+      case 'video_setting_tmdb_key_hint':
+        return '可留空，默认用内置 Key。仅当刮削失效或你想用自己的配额时才需要填写。';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }
@@ -210230,12 +210182,6 @@ extension on _StringsZhHk {
         return 'Synopsis';
       case 'video_scrape_tags':
         return 'Tags';
-      case 'video_scrape_tmdb_key_hint':
-        return 'Enter TMDB API Key';
-      case 'video_scrape_tmdb_key_required':
-        return 'TMDB requires an API key';
-      case 'video_scrape_tmdb_key_save':
-        return 'Save';
       case 'video_scrape_use':
         return 'Use';
       case 'video_scrape_view_subject':
@@ -211197,8 +211143,6 @@ extension on _StringsZhHk {
         return 'This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.';
       case 'video_scrape_apply_to_collection_hint':
         return 'This writes the same cover to every episode. Leave it off unless that is intentional.';
-      case 'video_scrape_tmdb_key_empty':
-        return 'Save a TMDB API key, then press Search. Results from other sources are not shown here.';
       case 'manga_online_source_disabled':
         return 'This internet source is disabled. Enable it in Sources to browse the catalog.';
       case 'selection_web_search':
@@ -211450,6 +211394,12 @@ extension on _StringsZhHk {
         return 'Keep current name';
       case 'video_scrape_collection_rename_confirm':
         return 'Rename';
+      case 'video_setting_tmdb_key':
+        return 'Custom TMDB API key';
+      case 'video_setting_tmdb_key_hint':
+        return 'Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.';
+      case 'about_tmdb_attribution':
+        return 'This product uses the TMDB API but is not endorsed or certified by TMDB.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Screenshot",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "لقطة شاشة",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Screenshot",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Captura de pantalla",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Capture d'écran",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Tangkapan layar",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Screenshot",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "スクリーンショット",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "스크린샷",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Schermafbeelding",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Captura de tela",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Скриншот",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "ภาพหน้าจอ",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Ekran görüntüsü",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "Chụp màn hình",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "离线库",
   "video_scrape_summary": "简介",
   "video_scrape_tags": "标签",
-  "video_scrape_tmdb_key_hint": "输入 TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB 需要 API Key",
-  "video_scrape_tmdb_key_save": "保存",
   "video_scrape_use": "使用",
   "video_scrape_view_subject": "在 Bangumi 查看",
   "video_screenshot": "截图",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "手动匹配会替换本集封面，并保存来源映射和条目资料。切换来源后，点“搜索”才会请求该来源。",
   "video_scrape_collection_match_hint": "这里只替换合集封面，不会修改各集封面或条目资料。切换来源后，点“搜索”才会请求该来源。",
   "video_scrape_apply_to_collection_hint": "这会把同一张封面写到每一集；只有确实需要统一单集封面时才开启。",
-  "video_scrape_tmdb_key_empty": "先保存 TMDB API Key，再点“搜索”。这里不会混入其他来源的结果。",
   "manga_online_source_disabled": "此互联网来源已关闭，请在「来源」中开启后浏览目录。",
   "selection_web_search": "网页搜索",
   "selection_web_search_unavailable": "没有可用的网页搜索应用。",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "当前名称：$name",
   "video_scrape_collection_rename_to": "新名称：$name",
   "video_scrape_collection_rename_keep": "保留当前名称",
-  "video_scrape_collection_rename_confirm": "重命名"
+  "video_scrape_collection_rename_confirm": "重命名",
+  "video_setting_tmdb_key": "自定义 TMDB API Key",
+  "video_setting_tmdb_key_hint": "可留空，默认用内置 Key。仅当刮削失效或你想用自己的配额时才需要填写。",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2309,9 +2309,6 @@
   "video_scrape_source_offline": "Offline",
   "video_scrape_summary": "Synopsis",
   "video_scrape_tags": "Tags",
-  "video_scrape_tmdb_key_hint": "Enter TMDB API Key",
-  "video_scrape_tmdb_key_required": "TMDB requires an API key",
-  "video_scrape_tmdb_key_save": "Save",
   "video_scrape_use": "Use",
   "video_scrape_view_subject": "View on Bangumi",
   "video_screenshot": "截圖",
@@ -2776,7 +2773,6 @@
   "video_scrape_manual_match_hint": "Manual matching replaces this episode cover and saves its source mapping and title metadata. Switching sources does not search until you press Search.",
   "video_scrape_collection_match_hint": "This only replaces the collection cover. Episode covers and title metadata are not changed. Switching sources does not search until you press Search.",
   "video_scrape_apply_to_collection_hint": "This writes the same cover to every episode. Leave it off unless that is intentional.",
-  "video_scrape_tmdb_key_empty": "Save a TMDB API key, then press Search. Results from other sources are not shown here.",
   "manga_online_source_disabled": "This internet source is disabled. Enable it in Sources to browse the catalog.",
   "selection_web_search": "Search the web",
   "selection_web_search_unavailable": "No app can search the web.",
@@ -2895,5 +2891,8 @@
   "video_scrape_collection_rename_from": "Current name: $name",
   "video_scrape_collection_rename_to": "New name: $name",
   "video_scrape_collection_rename_keep": "Keep current name",
-  "video_scrape_collection_rename_confirm": "Rename"
+  "video_scrape_collection_rename_confirm": "Rename",
+  "video_setting_tmdb_key": "Custom TMDB API key",
+  "video_setting_tmdb_key_hint": "Optional. Leave empty to use the built-in key. Fill in your own only if scraping stops working or you want to use your own quota.",
+  "about_tmdb_attribution": "This product uses the TMDB API but is not endorsed or certified by TMDB."
 }

--- a/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
+++ b/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
@@ -14,13 +14,8 @@ import 'package:hibiki/src/media/video/scraper/collection_scrape_apply.dart'
     show proposedCollectionRename;
 import 'package:hibiki/src/media/video/scraper/cover_scraper_service.dart';
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
-import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
-import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart' show VideoBookRow;
-
-/// TMDB API key 偏好键（存 Drift `preferences` 表，不改 schema）。
-const String kVideoScraperTmdbApiKeyPref = 'video_scraper_tmdb_api_key';
 
 /// 「在线匹配封面」弹窗打开时的**合集入口**标识（BUG-1211）。
 ///
@@ -63,9 +58,14 @@ class CoverMatchCollectionTarget {
 
 /// 「在线匹配封面」弹窗。
 ///
-/// 搜索框预填**解析后的标题**（非原始文件名）；数据源分段选择 Bangumi / TMDB /
-/// 离线库（已装载才出现）；候选列表带海报缩略图 + 标题 + 年份/类型 + 评分 + 置信度
-/// 徽标（对每个候选跑 [MatchScorer.score]），「使用」即下载落封面。
+/// 搜索框预填**解析后的标题**（非原始文件名）；**并发查全部可用数据源**（离线库 /
+/// Bangumi / TMDB / AniList / MAL）并按置信度合并排序 —— 用户不选源、也不配 key。
+/// 候选列表带海报缩略图 + 标题 + 来源 + 年份/类型 + 评分 + 置信度徽标（对每个候选跑
+/// [MatchScorer.score]），「使用」即下载落封面。
+///
+/// 「不让用户选源」是**有意的产品决定**：选源要求用户预先知道「这部番在哪个站收录得
+/// 更全」，那是本该由程序承担的知识。来源仍显示在每条候选上（配错可溯源），只是不再
+/// 是一个必须先做的**选择**。
 ///
 /// 两种入口语义**互斥**：
 /// - [collection] 非 null = 合集入口：只写合集自有封面，成员一个不动；
@@ -127,8 +127,6 @@ class CoverMatchDialog extends ConsumerStatefulWidget {
 
 class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   late final TextEditingController _queryCtrl;
-  late final TextEditingController _tmdbKeyCtrl;
-  late ScrapeSource _source;
   ParsedMediaName? _parsed;
 
   List<ScrapeCandidate> _results = const <ScrapeCandidate>[];
@@ -145,7 +143,6 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   /// 事，失败必须有出口——失败态在结果区显示错误行 + 可行动原因，绝不塌缩成
   /// 「无匹配」空态骗用户以为条目不存在。
   Object? _searchFailure;
-  bool _showTmdbKeyField = false;
 
   /// 单集入口下「同时应用到本合集全部 N 集」勾选态。合集入口不显示该勾选、也不读它
   /// （合集入口只改合集自有封面，BUG-1211）。
@@ -166,9 +163,6 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     final String prefill =
         _parsed?.title.isNotEmpty == true ? _parsed!.title : widget.book.title;
     _queryCtrl = TextEditingController(text: prefill);
-    _tmdbKeyCtrl = TextEditingController(text: _storedTmdbKey());
-    // 默认数据源：Bangumi（主源）。
-    _source = ScrapeSource.bangumi;
     // 首帧后自动搜一次（预填标题直接出结果，省一次手动点击）。
     WidgetsBinding.instance.addPostFrameCallback((_) => _search());
   }
@@ -176,30 +170,15 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
   @override
   void dispose() {
     _queryCtrl.dispose();
-    _tmdbKeyCtrl.dispose();
     super.dispose();
-  }
-
-  String _storedTmdbKey() {
-    final AppModel app = ref.read(appProvider);
-    return app.prefsRepo.getPref(kVideoScraperTmdbApiKeyPref, defaultValue: '')
-        as String;
-  }
-
-  Future<void> _saveTmdbKey(String key) async {
-    await ref
-        .read(appProvider)
-        .prefsRepo
-        .setPref(kVideoScraperTmdbApiKeyPref, key.trim());
   }
 
   Future<void> _search() async {
     final String keyword = _queryCtrl.text.trim();
     if (keyword.isEmpty) return;
     final int generation = ++_searchGeneration;
-    final ScrapeSource source = _source;
-    // 添加/修改 Bangumi 映射：贴条目 URL = 直接按 id 取该条目改绑（跳过关键词
-    // 搜索与 TMDB key 门，无论当前在哪个数据源分段）。
+    // 添加/修改 Bangumi 映射：贴条目 URL = 直接按 id 取该条目改绑（跳过多源搜索，
+    // 用户已经显式指名了要哪一条）。
     final String? mappedSubjectId = parseBangumiSubjectUrl(keyword);
     if (mappedSubjectId != null) {
       setState(() {
@@ -232,19 +211,6 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
       });
       return;
     }
-    // TMDB 分段但无 key：展开输入行，不搜。
-    if (source == ScrapeSource.tmdb && _storedTmdbKey().isEmpty) {
-      setState(() {
-        _showTmdbKeyField = true;
-        _results = const <ScrapeCandidate>[];
-        _scoringQuery = null;
-        _searched = false;
-        _searchFailure = null;
-        _applyFailure = null;
-      });
-      HibikiToast.show(msg: t.video_scrape_tmdb_key_required);
-      return;
-    }
     setState(() {
       _searching = true;
       _searched = true;
@@ -254,7 +220,14 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     List<ScrapeCandidate> results = const <ScrapeCandidate>[];
     Object? failure;
     try {
-      results = await _searchSource(keyword, source);
+      final ({List<ScrapeCandidate> results, Object? failure}) outcome =
+          await _searchAllSources(keyword);
+      results = outcome.results;
+      failure = outcome.failure;
+      if (failure != null) {
+        ErrorLogService.instance
+            .log('CoverMatchDialog.search', failure, StackTrace.current);
+      }
     } catch (e, stack) {
       // 同上：搜索失败与「零结果」必须分开，否则用户以为片名搜不到而放弃重试。
       ErrorLogService.instance.log('CoverMatchDialog.search', e, stack);
@@ -278,77 +251,122 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     return status == null ? t.scrape_reason_network : t.scrape_reason_server;
   }
 
-  /// TMDB 分段用当前 key 现建 client 搜索（服务注入的 client 可能因启动时无 key 而为
-  /// null；此处支持用户中途填入 key 后立即可搜）；其余源走注入的 service。
-  Future<List<ScrapeCandidate>> _searchSource(
+  /// **并发查全部可用源并合并排序** —— 用户不必再挑数据源。
+  ///
+  /// 部分源失败只留取证痕迹、静默降级（其余源结果照常展示）；**全部源都失败**才把
+  /// 异常抛给 [_search] 出可见失败态。这条分界是 BUG-1176 的「搜不到 ≠ 搜不了」在
+  /// 多源下的推广：任一源还活着，用户就该看到它的候选，而不是一句「搜索失败」。
+  /// 返回值里的 `failure` 非 null = **全部源都失败**（真搜不了）。刻意用返回值而非
+  /// 抛异常：各源的失败原因是 `Object`（底层异常类型不受本层约束），把它重新 throw
+  /// 出去既触发 `only_throw_errors`，也让「全失败」这个**正常控制流**伪装成异常。
+  Future<({List<ScrapeCandidate> results, Object? failure})> _searchAllSources(
     String keyword,
-    ScrapeSource source,
   ) async {
-    if (source == ScrapeSource.tmdb) {
-      final String key = _storedTmdbKey();
-      if (key.isEmpty) return const <ScrapeCandidate>[];
-      final TmdbClient client = TmdbClient(apiKey: key);
-      try {
-        return await client.search(keyword, year: _parsed?.year);
-      } finally {
-        client.close();
-      }
+    final AggregatedSearchResult aggregated =
+        await widget.service.searchAllSources(
+      keyword: keyword,
+      year: _parsed?.year,
+    );
+
+    // 逐源失败明细进诊断日志：界面上看不见（不打扰），但「某源结果时有时无」必须可查。
+    for (final MapEntry<ScrapeSource, Object> entry
+        in aggregated.failures.entries) {
+      ErrorLogService.instance.logDiagnostic(
+        'CoverMatchDialog.searchAllSources',
+        '${entry.key.name} search failed: ${entry.value}',
+      );
     }
-    // 纯数字输入既可能是 Bangumi subject id（用户改绑映射）也可能就是标题
-    // （如动画《86》）：两路依次都试，id 直取命中置顶、与同 id 搜索结果去重——
-    // 不牺牲任何一种意图。
-    if (source == ScrapeSource.bangumi && RegExp(r'^\d+$').hasMatch(keyword)) {
-      List<ScrapeCandidate> searched = const <ScrapeCandidate>[];
-      Object? searchError;
-      StackTrace? searchStack;
-      try {
-        searched = await widget.service
-            .searchCandidates(source: source, keyword: keyword);
-      } catch (e, stack) {
-        // 单路失败只是降级（另一路还可能有结果），不打扰用户；但要留取证痕迹，
-        // 否则「数字关键词结果时多时少」无从查起。
-        searchError = e;
-        searchStack = stack;
-        ErrorLogService.instance.logDiagnostic(
-          'CoverMatchDialog.searchCandidates',
-          'numeric keyword search failed: $e',
-        );
-      }
+    if (aggregated.allFailed) {
+      return (
+        results: const <ScrapeCandidate>[],
+        failure: aggregated.anyFailure
+      );
+    }
+
+    List<ScrapeCandidate> results =
+        _sortByScore(aggregated.candidates, keyword);
+
+    // 纯数字输入既可能是 Bangumi subject id（用户改绑映射）也可能就是标题（如动画
+    // 《86》）：关键词搜索已在上面跑过，这里再补一次 id 直取，命中则置顶去重——
+    // 不牺牲任何一种意图。直取失败只是降级（关键词那路可能已有结果），不抛。
+    if (RegExp(r'^\d+$').hasMatch(keyword)) {
       ScrapeCandidate? direct;
-      Object? directError;
       try {
         direct = await widget.service.fetchBangumiCandidateById(keyword);
       } catch (e) {
-        directError = e;
         ErrorLogService.instance.logDiagnostic(
           'CoverMatchDialog.fetchBangumiCandidateById',
           'numeric keyword direct fetch failed: $e',
         );
       }
-      // 两路都失败 = 真搜不了：带原始栈重抛给 _search 出可见失败态；只有一路失败
-      // 才算可静默降级。
-      if (searchError != null && directError != null) {
-        Error.throwWithStackTrace(
-            searchError, searchStack ?? StackTrace.current);
+      if (direct != null) {
+        final String directKey = '${direct.source.name}/${direct.entryId}';
+        results = <ScrapeCandidate>[
+          direct,
+          ...results.where((ScrapeCandidate c) =>
+              '${c.source.name}/${c.entryId}' != directKey),
+        ];
       }
-      if (direct == null) return searched;
-      final String directId = direct.entryId;
-      return <ScrapeCandidate>[
-        direct,
-        ...searched.where((ScrapeCandidate c) => c.entryId != directId),
-      ];
     }
-    return widget.service.searchCandidates(source: source, keyword: keyword);
+    return (results: results, failure: null);
   }
 
-  MatchConfidence? _confidenceFor(ScrapeCandidate candidate) {
+  /// 按「置信度 → 标题相似度」降序重排聚合结果。
+  ///
+  /// 排序是「用户不用关心数据源」的**前提**：聚合后候选天然按源分块，不排的话用户
+  /// 要在几十条里自己找，等于把选源的负担换成了翻列表的负担。排序替他做了选择。
+  ///
+  /// 稳定排序（[List.sort] 非稳定，故显式带 index 兜底）：同分候选保持源顺序，
+  /// 否则每次搜索同一关键词的列表次序都可能变，用户会以为结果在跳。
+  List<ScrapeCandidate> _sortByScore(
+    List<ScrapeCandidate> candidates,
+    String keyword,
+  ) {
+    final ParsedMediaName scoringParsed = _scoringParsedFor(keyword);
+    final List<({ScrapeCandidate candidate, MatchDecision decision, int index})>
+        scored =
+        <({ScrapeCandidate candidate, MatchDecision decision, int index})>[];
+    for (int i = 0; i < candidates.length; i++) {
+      scored.add((
+        candidate: candidates[i],
+        decision: widget.service
+            .scoreCandidate(parsed: scoringParsed, candidate: candidates[i]),
+        index: i,
+      ));
+    }
+    scored.sort((
+      ({ScrapeCandidate candidate, MatchDecision decision, int index}) a,
+      ({ScrapeCandidate candidate, MatchDecision decision, int index}) b,
+    ) {
+      // MatchConfidence 声明序即 high → medium → low，index 直接就是优先级。
+      final int byConfidence =
+          a.decision.confidence.index.compareTo(b.decision.confidence.index);
+      if (byConfidence != 0) return byConfidence;
+      final int byScore =
+          b.decision.titleScore.compareTo(a.decision.titleScore);
+      if (byScore != 0) return byScore;
+      return a.index.compareTo(b.index);
+    });
+    return scored
+        .map((({
+                  ScrapeCandidate candidate,
+                  MatchDecision decision,
+                  int index
+                }) e) =>
+            e.candidate)
+        .toList();
+  }
+
+  /// 构造打分用的 [ParsedMediaName]：标题取 [query]（用户对「要匹配什么」的显式
+  /// 纠正），年份/季/集等结构化线索仍沿用路径解析结果。
+  ///
+  /// 抽出来是因为**排序与徽标必须用同一份打分输入**——两处各拼一次的话，一旦有人
+  /// 只改了其中一处，就会出现「列表按 A 排、徽标按 B 显示」的自相矛盾。
+  ParsedMediaName _scoringParsedFor(String query) {
     final ParsedMediaName? parsed = _parsed;
-    final String query = _scoringQuery?.trim() ?? '';
-    if (parsed == null && query.isEmpty) return null;
-    final ParsedMediaName scoringParsed = ParsedMediaName(
-      // 手动搜索是用户对“要匹配什么”的显式纠正，置信度必须按搜索框当前值算；
-      // 年份/季/集等结构化线索仍沿用路径解析结果。
-      title: query.isNotEmpty ? query : parsed!.title,
+    final String trimmed = query.trim();
+    return ParsedMediaName(
+      title: trimmed.isNotEmpty ? trimmed : (parsed?.title ?? ''),
       secondaryTitle: parsed?.secondaryTitle,
       episode: parsed?.episode,
       season: parsed?.season,
@@ -357,8 +375,17 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
       resolution: parsed?.resolution,
       isMovieHint: parsed?.isMovieHint ?? false,
     );
+  }
+
+  MatchConfidence? _confidenceFor(ScrapeCandidate candidate) {
+    final ParsedMediaName? parsed = _parsed;
+    final String query = _scoringQuery?.trim() ?? '';
+    if (parsed == null && query.isEmpty) return null;
     return widget.service
-        .scoreCandidate(parsed: scoringParsed, candidate: candidate)
+        .scoreCandidate(
+          parsed: _scoringParsedFor(query),
+          candidate: candidate,
+        )
         .confidence;
   }
 
@@ -463,8 +490,6 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
             _buildSearchRow(),
-            const SizedBox(height: 8),
-            _buildSourceSelector(),
             const SizedBox(height: 6),
             Text(
               collection == null
@@ -474,13 +499,9 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
                 color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
-            if (_showTmdbKeyField) ...<Widget>[
-              const SizedBox(height: 8),
-              _buildTmdbKeyRow(),
-            ],
             const SizedBox(height: 8),
             // Flexible（而非固定高）：AlertDialog content 高度受视口上界约束，固定
-            // 320 会与搜索行/分段/勾选叠加溢出；让结果区吃剩余空间即可。
+            // 320 会与搜索行/勾选叠加溢出；让结果区吃剩余空间即可。
             Flexible(
               child: ConstrainedBox(
                 constraints: const BoxConstraints(minHeight: 120),
@@ -538,100 +559,9 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     );
   }
 
-  Widget _buildSourceSelector() {
-    final List<ButtonSegment<ScrapeSource>> segments =
-        <ButtonSegment<ScrapeSource>>[
-      const ButtonSegment<ScrapeSource>(
-        value: ScrapeSource.bangumi,
-        label: Text('Bangumi'),
-      ),
-      const ButtonSegment<ScrapeSource>(
-        value: ScrapeSource.tmdb,
-        label: Text('TMDB'),
-      ),
-      if (widget.service.hasOfflineIndex)
-        ButtonSegment<ScrapeSource>(
-          value: ScrapeSource.offlineDb,
-          label: Text(t.video_scrape_source_offline),
-        ),
-    ];
-    return SizedBox(
-      width: double.infinity,
-      child: SegmentedButton<ScrapeSource>(
-        segments: segments,
-        selected: <ScrapeSource>{_source},
-        showSelectedIcon: false,
-        onSelectionChanged: (Set<ScrapeSource> selected) {
-          final ScrapeSource next = selected.first;
-          if (next == _source) return;
-          setState(() {
-            // 切来源只改变搜索目标，不替用户立刻发网络请求。旧来源结果必须同时清空，
-            // 否则 TMDB 无 key 时仍挂着 Bangumi 候选，看起来像「TMDB 也有数据」。
-            _searchGeneration++;
-            _source = next;
-            _results = const <ScrapeCandidate>[];
-            _scoringQuery = null;
-            _searching = false;
-            _searched = false;
-            _searchFailure = null;
-            _applyFailure = null;
-            _showTmdbKeyField =
-                next == ScrapeSource.tmdb && _storedTmdbKey().isEmpty;
-          });
-        },
-      ),
-    );
-  }
-
-  Widget _buildTmdbKeyRow() {
-    return Row(
-      children: <Widget>[
-        Expanded(
-          child: TextField(
-            controller: _tmdbKeyCtrl,
-            decoration: InputDecoration(
-              isDense: true,
-              hintText: t.video_scrape_tmdb_key_hint,
-              border: const OutlineInputBorder(),
-            ),
-          ),
-        ),
-        const SizedBox(width: 8),
-        FilledButton(
-          onPressed: () async {
-            final String key = _tmdbKeyCtrl.text;
-            final ScrapeSource source = _source;
-            final int generation = _searchGeneration;
-            await _saveTmdbKey(key);
-            if (!mounted ||
-                source != _source ||
-                generation != _searchGeneration) {
-              return;
-            }
-            setState(() => _showTmdbKeyField = key.trim().isEmpty);
-            await _search();
-          },
-          child: Text(t.video_scrape_tmdb_key_save),
-        ),
-      ],
-    );
-  }
-
   Widget _buildResults(ThemeData theme) {
     if (_searching) {
       return const Center(child: CircularProgressIndicator());
-    }
-    if (_source == ScrapeSource.tmdb &&
-        _storedTmdbKey().isEmpty &&
-        !_searched) {
-      return Center(
-        child: Text(
-          t.video_scrape_tmdb_key_empty,
-          textAlign: TextAlign.center,
-          style: theme.textTheme.bodyMedium
-              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-        ),
-      );
     }
     final Object? failure = _searchFailure;
     if (failure != null) return _buildSearchFailure(failure);
@@ -730,12 +660,16 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     );
   }
 
+  /// 结果行的来源标签。用户**不用选**数据源，但必须**看得见**候选来自哪——配错时
+  /// 能溯源，也解释了「为什么同一部片出现了两条」（不同源的不同语言条目）。
+  ///
+  /// 站点专有名词统一取 [kScrapeSourceLabels]（不进 i18n，17 种语言写法相同）；
+  /// 离线库是本地概念，是这里唯一需要翻译的一项。
   String _sourceLabel(ScrapeSource source) {
     return switch (source) {
-      ScrapeSource.bangumi => 'Bangumi',
-      ScrapeSource.tmdb => 'TMDB',
       ScrapeSource.offlineDb => t.video_scrape_source_offline,
       ScrapeSource.manualUrl => 'URL',
+      _ => kScrapeSourceLabels[source] ?? source.name,
     };
   }
 

--- a/hibiki/lib/src/media/video/scraper/anilist_client.dart
+++ b/hibiki/lib/src/media/video/scraper/anilist_client.dart
@@ -1,0 +1,263 @@
+/// AniList 在线搜索客户端 —— 动画/剧场版的**补充源**（GraphQL，零 key 门槛）。
+///
+/// 端点 `POST https://graphql.anilist.co`，公开 API 无需注册、无需 key，这正是它被
+/// 选作补充源的原因：不给用户增加任何配置负担（对比 TMDB 要内置 key、TVDB 要申请）。
+///
+/// 标题策略：本 app 面向日语学习，**主标题取 `native`（日文原题）**，romaji / english /
+/// synonyms 全部进 [ScrapeCandidate.aliases] 参与打分。这与 Bangumi（中文优先）互补：
+/// 同一部作品在两源各出一条候选，用户看到的是不同语言的同一部片，不是重复项。
+///
+/// 网络异常复用 bangumi_client 定义的 [ScrapeNetworkException]（不重复定义）。
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
+    show ScrapeNetworkException;
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:http/http.dart' as http;
+
+/// AniList GraphQL 搜索客户端。构造可注入 [http.Client]（默认自建）。
+class AniListClient {
+  AniListClient({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(seconds: 15);
+
+  static const String endpoint = 'https://graphql.anilist.co';
+
+  /// 单次搜索返回条数上限。15 与 Bangumi/TMDB 量级对齐：聚合视图里每源都吐 50 条会
+  /// 把列表淹掉，而打分层真正会被用户看的只有头部若干条。
+  static const int _perPage = 15;
+
+  /// 搜索查询。`sort: SEARCH_MATCH` 让 AniList 自己按匹配度排（我们再用
+  /// [MatchScorer] 统一重排，但源侧先排能保证 15 条窗口里装的是最相关的）。
+  static const String _query = r'''
+query ($search: String, $perPage: Int) {
+  Page(perPage: $perPage) {
+    media(search: $search, type: ANIME, sort: SEARCH_MATCH) {
+      id
+      title { romaji english native }
+      synonyms
+      startDate { year }
+      format
+      episodes
+      averageScore
+      description(asHtml: false)
+      coverImage { extraLarge large }
+      bannerImage
+      siteUrl
+    }
+  }
+}
+''';
+
+  /// 搜索关键词 [keyword]（[year] 当前不参与查询，保留与其他源同形的签名）。
+  ///
+  /// 网络失败 / 非 2xx / JSON 异常 → 抛 [ScrapeNetworkException]。
+  Future<List<ScrapeCandidate>> search(String keyword, {int? year}) async {
+    final http.Response response;
+    try {
+      response = await _client
+          .post(
+            Uri.parse(endpoint),
+            headers: const <String, String>{
+              'Content-Type': 'application/json',
+              'Accept': 'application/json',
+            },
+            body: jsonEncode(<String, Object?>{
+              'query': _query,
+              'variables': <String, Object?>{
+                'search': keyword,
+                'perPage': _perPage,
+              },
+            }),
+          )
+          .timeout(_timeout);
+    } on TimeoutException {
+      throw const ScrapeNetworkException('AniList search timed out');
+    } catch (e) {
+      // AniList 无 key，URL 里不含凭据，无需脱敏（对比 tmdb_client 的 key-in-query）。
+      throw ScrapeNetworkException('AniList request failed: $e');
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ScrapeNetworkException(
+        'AniList search HTTP ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+
+    return parseAniListResponse(utf8.decode(response.bodyBytes));
+  }
+
+  /// 关闭内部 client（若为默认自建）。
+  void close() => _client.close();
+}
+
+/// 纯函数：解析 AniList GraphQL 响应。缺封面的条目跳过（对封面刮削无用）。
+///
+/// GraphQL 的错误是 **200 + body.errors**，不是 HTTP 非 2xx —— 只看 statusCode 会把
+/// 「查询被拒」当成「零结果」，故此处显式检查 `errors`。
+List<ScrapeCandidate> parseAniListResponse(String body) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(body);
+  } catch (e) {
+    throw ScrapeNetworkException('AniList JSON decode failed: $e');
+  }
+  if (decoded is! Map<String, Object?>) {
+    throw const ScrapeNetworkException('AniList response not a JSON object');
+  }
+
+  final Object? errors = decoded['errors'];
+  if (errors is List<Object?> && errors.isNotEmpty) {
+    final Object? first = errors.first;
+    final String message = first is Map<String, Object?>
+        ? '${first['message'] ?? first}'
+        : '$first';
+    throw ScrapeNetworkException('AniList GraphQL error: $message');
+  }
+
+  final Object? data = decoded['data'];
+  if (data is! Map<String, Object?>) return const <ScrapeCandidate>[];
+  final Object? page = data['Page'];
+  if (page is! Map<String, Object?>) return const <ScrapeCandidate>[];
+  final Object? media = page['media'];
+  if (media is! List<Object?>) return const <ScrapeCandidate>[];
+
+  final List<ScrapeCandidate> candidates = <ScrapeCandidate>[];
+  for (final Object? item in media) {
+    if (item is! Map<String, Object?>) continue;
+    final ScrapeCandidate? candidate = _mapAniListMedia(item);
+    if (candidate != null) candidates.add(candidate);
+  }
+  return candidates;
+}
+
+/// 映射单条 AniList media；缺封面返回 null。
+ScrapeCandidate? _mapAniListMedia(Map<String, Object?> media) {
+  final Object? coverImage = media['coverImage'];
+  final String? posterUrl = coverImage is Map<String, Object?>
+      ? _nonEmptyString(coverImage['extraLarge']) ??
+          _nonEmptyString(coverImage['large'])
+      : null;
+  if (posterUrl == null) return null;
+
+  final Object? titleNode = media['title'];
+  final String? native = titleNode is Map<String, Object?>
+      ? _nonEmptyString(titleNode['native'])
+      : null;
+  final String? romaji = titleNode is Map<String, Object?>
+      ? _nonEmptyString(titleNode['romaji'])
+      : null;
+  final String? english = titleNode is Map<String, Object?>
+      ? _nonEmptyString(titleNode['english'])
+      : null;
+
+  // 日文原题优先（本 app 的用户看的是日文原片）；缺则退 romaji → english。
+  final String? title = native ?? romaji ?? english;
+  if (title == null) return null;
+
+  // 其余标题与 synonyms 全进别名：打分层靠它们跨语言命中文件名里的任意一种写法。
+  final List<String> aliases = <String>[];
+  for (final String? alt in <String?>[native, romaji, english]) {
+    if (alt != null && alt != title && !aliases.contains(alt)) aliases.add(alt);
+  }
+  final Object? synonyms = media['synonyms'];
+  if (synonyms is List<Object?>) {
+    for (final Object? synonym in synonyms) {
+      final String? value = _nonEmptyString(synonym);
+      if (value != null && value != title && !aliases.contains(value)) {
+        aliases.add(value);
+      }
+    }
+  }
+
+  final Object? startDate = media['startDate'];
+  final int? year =
+      startDate is Map<String, Object?> ? _asInt(startDate['year']) : null;
+
+  final int? episodes = _asInt(media['episodes']);
+
+  // averageScore 是 0~100 整数，与其余源的 0~10 不同量纲，必须换算后再展示/存储，
+  // 否则同一列表里 AniList 条目会显示成「85 分」而 Bangumi 是「8.1 分」。
+  final int? averageScore = _asInt(media['averageScore']);
+  final double? rating =
+      averageScore != null && averageScore > 0 ? averageScore / 10.0 : null;
+
+  final String entryId = '${media['id']}';
+
+  return ScrapeCandidate(
+    source: ScrapeSource.anilist,
+    entryId: entryId,
+    title: title,
+    aliases: aliases,
+    year: year,
+    type: _mapFormat(_nonEmptyString(media['format'])),
+    episodeCount: episodes != null && episodes > 0 ? episodes : null,
+    posterUrl: posterUrl,
+    // bannerImage 是超宽横幅（约 1900x400），比 2:3 海报更适合详情页 hero 宽槽；
+    // 冷门条目常无 banner，故 nullable 而非跳过该候选（BUG-1298 同理）。
+    backdropUrl: _nonEmptyString(media['bannerImage']),
+    summary: _stripHtml(_nonEmptyString(media['description'])),
+    rating: rating,
+    detailUrl: _nonEmptyString(media['siteUrl']) ??
+        'https://anilist.co/anime/$entryId',
+    ratingText: rating != null ? 'AniList ${rating.toStringAsFixed(1)}' : null,
+  );
+}
+
+/// AniList `format` → 共享条目类型。
+///
+/// ONA/MUSIC 刻意归 unknown 而非硬塞进某一类：打分层对 unknown 是「不参与类型校验」，
+/// 而错误分类会**主动扣分**——宁可不判，不可判错。
+ScrapeEntryType _mapFormat(String? format) {
+  switch (format) {
+    case 'TV':
+    case 'TV_SHORT':
+      return ScrapeEntryType.tv;
+    case 'MOVIE':
+      return ScrapeEntryType.movie;
+    case 'OVA':
+      return ScrapeEntryType.ova;
+    case 'SPECIAL':
+      return ScrapeEntryType.special;
+    default:
+      return ScrapeEntryType.unknown;
+  }
+}
+
+/// 去掉 AniList 简介里的 HTML 标签。
+///
+/// `description(asHtml: false)` 仍会保留 `<br>` / `<i>` 等内联标签（AniList 的
+/// asHtml=false 只是不做 markdown→html 转换，不等于纯文本），直接展示会看到裸标签。
+String? _stripHtml(String? value) {
+  if (value == null) return null;
+  final String text = value
+      .replaceAll(RegExp(r'<br\s*/?>', caseSensitive: false), '\n')
+      .replaceAll(RegExp(r'<[^>]+>'), '')
+      .replaceAll('&quot;', '"')
+      .replaceAll('&#039;', "'")
+      .replaceAll('&amp;', '&')
+      .replaceAll('&lt;', '<')
+      .replaceAll('&gt;', '>')
+      .trim();
+  return text.isEmpty ? null : text;
+}
+
+/// 取非空去空白字符串，空/非 String 返回 null。
+String? _nonEmptyString(Object? value) {
+  if (value is! String) return null;
+  final String trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+/// 容错取 int（接受 num 或数字字符串）。
+int? _asInt(Object? value) {
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value.trim());
+  return null;
+}

--- a/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
@@ -17,7 +17,9 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart' show compute;
 import 'package:hibiki/src/media/video/scraper/alias_cache.dart';
+import 'package:hibiki/src/media/video/scraper/anilist_client.dart';
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
+import 'package:hibiki/src/media/video/scraper/jikan_client.dart';
 import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
 import 'package:hibiki/src/media/video/scraper/filename_parser.dart';
 import 'package:hibiki/src/media/video/scraper/match_scorer.dart';
@@ -156,6 +158,8 @@ class CoverScraperService {
     required BangumiClient bangumiClient,
     required CoverDownloader coverDownloader,
     TmdbClient? tmdbClient,
+    AniListClient? aniListClient,
+    JikanClient? jikanClient,
     OfflineIndex? offlineIndex,
     bool enableSidecar = true,
     Directory? coversDirectory,
@@ -167,6 +171,8 @@ class CoverScraperService {
         _bangumi = bangumiClient,
         _downloader = coverDownloader,
         _tmdb = tmdbClient,
+        _anilist = aniListClient,
+        _jikan = jikanClient,
         _offline = offlineIndex,
         _enableSidecar = enableSidecar,
         _coversDirectory = coversDirectory;
@@ -177,6 +183,10 @@ class CoverScraperService {
   final BangumiClient _bangumi;
   final CoverDownloader _downloader;
   final TmdbClient? _tmdb;
+
+  /// AniList / Jikan：零 key 门槛的动画补充源。null = 未注入（测试或显式禁用）。
+  final AniListClient? _anilist;
+  final JikanClient? _jikan;
   final OfflineIndex? _offline;
   final bool _enableSidecar;
   final Directory? _coversDirectory;
@@ -413,9 +423,77 @@ class CoverScraperService {
         return _bangumi.search(keyword);
       case ScrapeSource.tmdb:
         return _tmdb?.search(keyword, year: year) ?? const <ScrapeCandidate>[];
+      case ScrapeSource.anilist:
+        return _anilist?.search(keyword, year: year) ??
+            const <ScrapeCandidate>[];
+      case ScrapeSource.jikan:
+        return _jikan?.search(keyword, year: year) ?? const <ScrapeCandidate>[];
       case ScrapeSource.manualUrl:
         return const <ScrapeCandidate>[];
     }
+  }
+
+  /// 本次构建**真正可用**的搜索源（按查询代价升序：本地内存 → 各在线源）。
+  ///
+  /// 未注入的 client（TMDB 无 key、测试没给假实现）不在列——这样调用方不必再写
+  /// 「这个源配了吗」的分支，「可用性」只在这一个地方判定。
+  List<ScrapeSource> get availableSearchSources => <ScrapeSource>[
+        if (_offline != null) ScrapeSource.offlineDb,
+        ScrapeSource.bangumi,
+        if (_tmdb != null) ScrapeSource.tmdb,
+        if (_anilist != null) ScrapeSource.anilist,
+        if (_jikan != null) ScrapeSource.jikan,
+      ];
+
+  /// **并发查全部可用源并合并**（手动匹配弹窗用）。
+  ///
+  /// 与 [_resolveBestDecision]（自动刮削）的分工是有意的、不是重复实现：
+  /// - 自动刮削按代价**逐层兜底**，命中 high 立即停 —— 批量刮 500 本时不能每本都
+  ///   发 4 个请求；
+  /// - 手动匹配是用户已经盯着屏幕在等，要的是**一次看全**，所以并发全查。
+  ///
+  /// 失败策略：**部分源失败只降级不报错**（其余源的结果照常展示，失败明细留在
+  /// [AggregatedSearchResult.failures] 供取证）；只有**全部源都失败**才算「搜不了」，
+  /// 由 UI 出可见失败态。这保住了 BUG-1176 的「搜不到 ≠ 搜不了」分界。
+  Future<AggregatedSearchResult> searchAllSources({
+    required String keyword,
+    int? year,
+  }) async {
+    final List<ScrapeSource> sources = availableSearchSources;
+    final Map<ScrapeSource, Object> failures = <ScrapeSource, Object>{};
+
+    final List<List<ScrapeCandidate>> perSource =
+        await Future.wait(sources.map((ScrapeSource source) async {
+      try {
+        return await searchCandidates(
+          source: source,
+          keyword: keyword,
+          year: year,
+        );
+      } catch (e) {
+        failures[source] = e;
+        return const <ScrapeCandidate>[];
+      }
+    }));
+
+    // 合并去重：**只在同源内按 entryId 去重**。跨源刻意不去重——Bangumi 的中文条目
+    // 与 AniList 的日文条目是同一部作品的不同表示（标题语言、评分体系、海报都不同），
+    // 合并会丢掉用户正想要的那一个。用户看到「同一部片的几种版本」是特性不是 bug。
+    final List<ScrapeCandidate> merged = <ScrapeCandidate>[];
+    final Set<String> seen = <String>{};
+    for (final List<ScrapeCandidate> batch in perSource) {
+      for (final ScrapeCandidate candidate in batch) {
+        final String key = '${candidate.source.name}/${candidate.entryId}';
+        if (!seen.add(key)) continue;
+        merged.add(candidate);
+      }
+    }
+
+    return AggregatedSearchResult(
+      candidates: merged,
+      failures: failures,
+      queriedSources: sources,
+    );
   }
 
   /// 添加/修改 Bangumi 映射：按 subject id 直取条目映射为候选（用户贴 ID/URL
@@ -759,6 +837,19 @@ class CoverScraperService {
     // TMDB 补充源（有 key，或有电影提示时优先补 TMDB）。
     if (_tmdb != null) {
       consider(await _tmdb.search(parsed.title, year: parsed.year));
+      if (best?.confidence == MatchConfidence.high) return finish();
+    }
+
+    // AniList / Jikan 补充源（零 key，动画向）。仍然逐层兜底而非并发全查：批量刮削
+    // 可能是 500 本起步，每本都并发 5 个请求会把 Bangumi/Jikan 的限流直接打爆，而
+    // 绝大多数条目在前两层就已命中 high。手动匹配弹窗要的是「一次看全」，那条路走
+    // [searchAllSources] 并发——两种代价模型服务两种场景，是有意的分工。
+    if (_anilist != null) {
+      consider(await _anilist.search(parsed.title, year: parsed.year));
+      if (best?.confidence == MatchConfidence.high) return finish();
+    }
+    if (_jikan != null) {
+      consider(await _jikan.search(parsed.title, year: parsed.year));
     }
     return finish();
   }

--- a/hibiki/lib/src/media/video/scraper/jikan_client.dart
+++ b/hibiki/lib/src/media/video/scraper/jikan_client.dart
@@ -1,0 +1,211 @@
+/// Jikan（MyAnimeList 非官方 API）搜索客户端 —— 动画的**补充源**（零 key 门槛）。
+///
+/// 端点 `GET https://api.jikan.moe/v4/anime`，无需注册、无需 key。与 AniList 的关系
+/// 是互补而非重复：MAL 的条目粒度、别名（`titles[]` 含 Synonym/Japanese/English）和
+/// 收录范围与 AniList 不完全一致，冷门作品常一方有一方无。
+///
+/// 限流：Jikan 公开限速约 3 req/s、60 req/min。本客户端**不自实现限流**——聚合搜索
+/// 每次只发 1 个请求，批量刮削已由上层逐层兜底（命中 high 就不会走到这一源）。
+///
+/// 网络异常复用 bangumi_client 定义的 [ScrapeNetworkException]（不重复定义）。
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
+    show ScrapeNetworkException;
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:http/http.dart' as http;
+
+/// Jikan 搜索客户端。构造可注入 [http.Client]（默认自建）。
+class JikanClient {
+  JikanClient({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  static const Duration _timeout = Duration(seconds: 15);
+
+  /// 单次搜索返回条数上限，与 AniList/Bangumi 量级对齐。
+  static const int _limit = 15;
+
+  /// 搜索关键词 [keyword]（[year] 当前不参与查询，保留与其他源同形的签名）。
+  ///
+  /// 网络失败 / 非 2xx / JSON 异常 → 抛 [ScrapeNetworkException]。
+  Future<List<ScrapeCandidate>> search(String keyword, {int? year}) async {
+    final Uri uri = Uri.parse('https://api.jikan.moe/v4/anime')
+        .replace(queryParameters: <String, String>{
+      'q': keyword,
+      'limit': '$_limit',
+      // sfw：滤掉成人向条目。刮削是给用户的媒体库配图，默认不该往里塞 R18 海报。
+      'sfw': 'true',
+    });
+
+    final http.Response response;
+    try {
+      response = await _client.get(
+        uri,
+        headers: const <String, String>{'Accept': 'application/json'},
+      ).timeout(_timeout);
+    } on TimeoutException {
+      throw const ScrapeNetworkException('Jikan search timed out');
+    } catch (e) {
+      // Jikan 无 key，URL 里不含凭据，无需脱敏（对比 tmdb_client 的 key-in-query）。
+      throw ScrapeNetworkException('Jikan request failed: $e');
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ScrapeNetworkException(
+        'Jikan search HTTP ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+
+    return parseJikanResponse(utf8.decode(response.bodyBytes));
+  }
+
+  /// 关闭内部 client（若为默认自建）。
+  void close() => _client.close();
+}
+
+/// 纯函数：解析 Jikan `/v4/anime` 响应。缺封面的条目跳过（对封面刮削无用）。
+List<ScrapeCandidate> parseJikanResponse(String body) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(body);
+  } catch (e) {
+    throw ScrapeNetworkException('Jikan JSON decode failed: $e');
+  }
+  if (decoded is! Map<String, Object?>) {
+    throw const ScrapeNetworkException('Jikan response not a JSON object');
+  }
+  final Object? data = decoded['data'];
+  if (data is! List<Object?>) return const <ScrapeCandidate>[];
+
+  final List<ScrapeCandidate> candidates = <ScrapeCandidate>[];
+  for (final Object? item in data) {
+    if (item is! Map<String, Object?>) continue;
+    final ScrapeCandidate? candidate = _mapJikanAnime(item);
+    if (candidate != null) candidates.add(candidate);
+  }
+  return candidates;
+}
+
+/// 映射单条 Jikan anime；缺封面返回 null。
+ScrapeCandidate? _mapJikanAnime(Map<String, Object?> anime) {
+  final String? posterUrl = _posterFrom(anime['images']);
+  if (posterUrl == null) return null;
+
+  // 日文原题优先（本 app 的用户看的是日文原片）；缺则退默认 title（罗马音）。
+  final String? japanese = _nonEmptyString(anime['title_japanese']);
+  final String? romaji = _nonEmptyString(anime['title']);
+  final String? english = _nonEmptyString(anime['title_english']);
+  final String? title = japanese ?? romaji ?? english;
+  if (title == null) return null;
+
+  final List<String> aliases = <String>[];
+  void addAlias(String? value) {
+    if (value == null || value == title || aliases.contains(value)) return;
+    aliases.add(value);
+  }
+
+  addAlias(japanese);
+  addAlias(romaji);
+  addAlias(english);
+  // `titles[]` 是 MAL 的全量标题表（Default / Japanese / English / Synonym），别名
+  // 命中率主要靠它——文件名里常见的是 Synonym 而不是任何一个主标题。
+  final Object? titles = anime['titles'];
+  if (titles is List<Object?>) {
+    for (final Object? entry in titles) {
+      if (entry is! Map<String, Object?>) continue;
+      addAlias(_nonEmptyString(entry['title']));
+    }
+  }
+
+  final int? episodes = _asInt(anime['episodes']);
+  final double? score = _asDouble(anime['score']);
+  final int? scoredBy = _asInt(anime['scored_by']);
+  final int malId = _asInt(anime['mal_id']) ?? 0;
+  if (malId <= 0) return null;
+
+  return ScrapeCandidate(
+    source: ScrapeSource.jikan,
+    entryId: '$malId',
+    title: title,
+    aliases: aliases,
+    year: _yearFrom(anime['aired']),
+    type: _mapType(_nonEmptyString(anime['type'])),
+    episodeCount: episodes != null && episodes > 0 ? episodes : null,
+    posterUrl: posterUrl,
+    // MAL 没有横版背景图，backdropUrl 恒 null：详情页 hero 会回落到其它源/抽帧，
+    // 不编造一张不存在的图（BUG-1298 的教训是宁可没有也不要塞 2:3 海报进宽槽）。
+    summary: _nonEmptyString(anime['synopsis']),
+    rating: score != null && score > 0 ? score : null,
+    ratingCount: scoredBy != null && scoredBy > 0 ? scoredBy : null,
+    detailUrl:
+        _nonEmptyString(anime['url']) ?? 'https://myanimelist.net/anime/$malId',
+    ratingText:
+        score != null && score > 0 ? 'MAL ${score.toStringAsFixed(1)}' : null,
+  );
+}
+
+/// 从 `images` 取最高档海报：`jpg.large_image_url` → `jpg.image_url` → webp 同名。
+String? _posterFrom(Object? images) {
+  if (images is! Map<String, Object?>) return null;
+  for (final String format in <String>['jpg', 'webp']) {
+    final Object? node = images[format];
+    if (node is! Map<String, Object?>) continue;
+    final String? url = _nonEmptyString(node['large_image_url']) ??
+        _nonEmptyString(node['image_url']);
+    if (url != null) return url;
+  }
+  return null;
+}
+
+/// 从 `aired.from`（ISO8601）取年份。
+int? _yearFrom(Object? aired) {
+  if (aired is! Map<String, Object?>) return null;
+  final String? from = _nonEmptyString(aired['from']);
+  if (from == null || from.length < 4) return null;
+  return int.tryParse(from.substring(0, 4));
+}
+
+/// MAL `type` → 共享条目类型。
+///
+/// ONA/Music 归 unknown 而非硬塞：打分层对 unknown 是「不参与类型校验」，错误分类会
+/// **主动扣分**——宁可不判，不可判错（与 anilist_client 同一取舍）。
+ScrapeEntryType _mapType(String? type) {
+  switch (type) {
+    case 'TV':
+      return ScrapeEntryType.tv;
+    case 'Movie':
+      return ScrapeEntryType.movie;
+    case 'OVA':
+      return ScrapeEntryType.ova;
+    case 'Special':
+      return ScrapeEntryType.special;
+    default:
+      return ScrapeEntryType.unknown;
+  }
+}
+
+/// 取非空去空白字符串，空/非 String 返回 null。
+String? _nonEmptyString(Object? value) {
+  if (value is! String) return null;
+  final String trimmed = value.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+/// 容错取 int（接受 num 或数字字符串）。
+int? _asInt(Object? value) {
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value.trim());
+  return null;
+}
+
+/// 容错取 double（接受 num 或数字字符串）。
+double? _asDouble(Object? value) {
+  if (value is num) return value.toDouble();
+  if (value is String) return double.tryParse(value.trim());
+  return null;
+}

--- a/hibiki/lib/src/media/video/scraper/scraper_types.dart
+++ b/hibiki/lib/src/media/video/scraper/scraper_types.dart
@@ -4,13 +4,20 @@
 /// ① sidecar 识别（poster.jpg / tvshow.nfo，零网络）
 /// ② 文件名/目录名解析（anitomy 式规则，产出 [ParsedMediaName]）
 /// ③ 标题归一化（繁简/全半角/罗马数字季度/副标题拆分）
-/// ④ 匹配（离线别名库 → Bangumi → TMDB，产出 [ScrapeCandidate]）
+/// ④ 匹配（离线别名库 → Bangumi → TMDB → AniList → Jikan，产出 [ScrapeCandidate]）
 /// ⑤ 打分校验（[MatchScorer] 产出 [MatchDecision]，置信度分级）
+///
+/// 第 ④ 层有**两种代价模型**，服务两种场景，不要合并：
+/// - 自动刮削按上面的顺序**逐层兜底**、命中 high 立即停（批量刮 500 本不能每本发 5 个
+///   请求）——`CoverScraperService._resolveBestDecision`；
+/// - 手动匹配弹窗**并发查全部可用源**再合并排序（用户在等，要一次看全）——
+///   `CoverScraperService.searchAllSources`，产出 [AggregatedSearchResult]。
 ///
 /// 本文件只放跨模块共享的纯数据类型，**不放任何实现逻辑**；
 /// 各层实现见同目录 `filename_parser.dart` / `title_normalizer.dart` /
 /// `offline_index.dart` / `match_scorer.dart` / `bangumi_client.dart` /
-/// `tmdb_client.dart` / `sidecar_scanner.dart` / `cover_scraper_service.dart`。
+/// `tmdb_client.dart` / `anilist_client.dart` / `jikan_client.dart` /
+/// `sidecar_scanner.dart` / `cover_scraper_service.dart`。
 library;
 
 /// 从文件名/目录名解析出的结构化信息（解析层输出）。
@@ -52,7 +59,23 @@ class ParsedMediaName {
 }
 
 /// 候选条目来源。
-enum ScrapeSource { offlineDb, bangumi, tmdb, manualUrl }
+///
+/// 全部持久化都按 **name** 走（`ScrapeSource.values.asNameMap()`，见 [CoverMeta]、
+/// `alias_cache.dart`、`video_book_repository.dart`），不按 index —— 因此新增来源
+/// 可插在任意位置，旧数据不会错位。
+enum ScrapeSource { offlineDb, bangumi, tmdb, anilist, jikan, manualUrl }
+
+/// 各来源的展示名（结果列表来源徽标用）。
+///
+/// 刻意**不进 i18n**：这些是第三方站点的专有名词，17 种语言里都是同一个拉丁字母
+/// 写法，翻译它们只会让 `i18n_sync` 多 17 份完全一样的值。离线库是本地概念，是
+/// 唯一需要翻译的，故由调用方单独取 `t.video_scrape_source_offline`。
+const Map<ScrapeSource, String> kScrapeSourceLabels = <ScrapeSource, String>{
+  ScrapeSource.bangumi: 'Bangumi',
+  ScrapeSource.tmdb: 'TMDB',
+  ScrapeSource.anilist: 'AniList',
+  ScrapeSource.jikan: 'MAL',
+};
 
 /// 条目类型（用于打分时与 [ParsedMediaName.isMovieHint] 互验）。
 enum ScrapeEntryType { tv, movie, ova, special, unknown }
@@ -249,6 +272,36 @@ class CollectionScrapeResult {
 
   /// 条目资料（Bangumi 走详情端点取全量；其余源由候选自身降级拼出）。
   final ScrapeMetadata metadata;
+}
+
+/// 多源并发聚合搜索的结果（手动匹配弹窗用）。
+///
+/// 存在的理由是**把「部分源挂了」与「全部源都挂了」分开**：前者只是降级（其余源的
+/// 候选照常可用，用户根本不需要知道），后者才是「搜不了」必须给可见失败态
+/// （BUG-1176 的分界）。把失败折成一个 `bool hasError` 就会二选一地丢掉其中一半语义。
+class AggregatedSearchResult {
+  const AggregatedSearchResult({
+    required this.candidates,
+    required this.failures,
+    required this.queriedSources,
+  });
+
+  /// 合并后的候选（同源内按 entryId 去重，跨源不去重）。
+  final List<ScrapeCandidate> candidates;
+
+  /// 失败的源 → 原始异常。空 map = 全部源都成功。
+  final Map<ScrapeSource, Object> failures;
+
+  /// 本轮真正查过的源。判「全失败」必须拿它当分母——用全体枚举当分母会把
+  /// 「压根没配 TMDB」误算成「TMDB 失败了」。
+  final List<ScrapeSource> queriedSources;
+
+  /// 是否全部查过的源都失败了（= 真的搜不了，UI 出失败态）。
+  bool get allFailed =>
+      queriedSources.isNotEmpty && failures.length == queriedSources.length;
+
+  /// 任取一个失败异常（全失败时给 UI 折成可行动原因用）。
+  Object? get anyFailure => failures.isEmpty ? null : failures.values.first;
 }
 
 /// 打分置信度分级。

--- a/hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+++ b/hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
@@ -1,0 +1,35 @@
+// 入库默认值（空占位，保证任何 clone/worktree 都能直接编译）。模板见
+// tmdb_default_key.example.dart。
+//
+// 内置 TMDB API key（v3 auth）——让封面/元数据刮削开箱即用，用户不必自己去
+// themoviedb.org 申请再粘贴。key 会编译进二进制（客户端密钥本质会随包分发），故
+// **不入库真值**，以免被密钥扫描器反复告警、也避免轮换后的新值随每次 commit 重新公开。
+// 同 google_oauth_secret.dart / dandanplay_secret.dart 的既有约定。
+//
+// 本机要启用内置 key 时：把真值填到本文件，再执行一次——
+//   git update-index --skip-worktree hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+// 真值只留本地、不显示 dirty、永不提交。CI 发布构建从 GitHub Actions secret
+// TMDB_API_KEY 注入（见 main.yml / build-multiplatform.yml）。
+//
+// 留空时 TMDB 源自动降级为「未配置」：不构造 client、UI 不出 TMDB 候选，其余数据源
+// （Bangumi / AniList / Jikan / 离线库）照常工作。fork 构建请填自己申请的 key。
+//
+// ⚠️ 使用本 key 附带合约义务（TMDB Terms of Use）：应用内须展示 TMDB logo 与
+// "This product uses the TMDB API but is not endorsed or certified by TMDB."
+// ——见「关于」页署名区。删 key 前不要先删署名，反之亦然。
+const String kBuiltinTmdbApiKey = '';
+
+/// 用户自定义 TMDB API key 的偏好键（存 Drift `preferences` 表，不改 schema）。
+///
+/// 与 [kBuiltinTmdbApiKey] 同住一个文件是有意的：「这次请求用哪把 key」的全部输入
+/// 就是这两者，分散在 UI 文件里会让人以为改弹窗就能改取值规则。
+const String kVideoScraperTmdbApiKeyPref = 'video_scraper_tmdb_api_key';
+
+/// 解析实际生效的 TMDB key：**用户自填优先，其次内置**。
+///
+/// 两者皆空 → 返回空串，调用方据此判定「TMDB 未配置」并跳过该源。返回空串是**正常
+/// 降级路径不是错误**：fresh clone / fork 构建本就没有内置 key。
+String resolveTmdbApiKey(String userKey) {
+  final String trimmed = userKey.trim();
+  return trimmed.isEmpty ? kBuiltinTmdbApiKey.trim() : trimmed;
+}

--- a/hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart
+++ b/hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart
@@ -1,0 +1,21 @@
+// 模板（入库）。把真值填进同目录的 `tmdb_default_key.dart`，再执行一次：
+//   git update-index --skip-worktree hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+// 真值只留本地、不显示 dirty、永不提交。
+//
+// 真值来源：https://www.themoviedb.org/settings/api → Developer Plan（免费，非商业）
+//   - 应用名称：Hibiki
+//   - 应用网址：https://github.com/hajisensai/hibiki
+//   - 使用类型：按实际分发面选 Desktop / Mobile Application（**不要选 Personal**，
+//     本项目是公开分发的应用，不是个人自用）
+//   - 拿「API 密钥」那一串 32 位十六进制（v3 auth），不是 v4 读访问令牌
+//
+// CI 发布构建从 GitHub Actions secret TMDB_API_KEY 注入，无需改本文件。
+//
+// 留空时 TMDB 源自动降级为「未配置」，其余数据源照常工作。
+const String kBuiltinTmdbApiKey = '';
+
+/// 解析实际生效的 TMDB key：用户自填优先，其次内置。两者皆空 = TMDB 未配置。
+String resolveTmdbApiKey(String userKey) {
+  final String trimmed = userKey.trim();
+  return trimmed.isEmpty ? kBuiltinTmdbApiKey.trim() : trimmed;
+}

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -23,8 +23,10 @@ import 'package:hibiki/src/media/video/cover_ui/cover_match_dialog.dart';
 import 'package:hibiki/src/media/video/cover_ui/scrape_info_dialog.dart';
 import 'package:hibiki/src/media/metadata/scrape_batch.dart';
 import 'package:hibiki/src/media/video/scraper/alias_cache.dart';
+import 'package:hibiki/src/media/video/scraper/anilist_client.dart';
 import 'package:hibiki/src/media/video/scraper/auto_scrape_service.dart';
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
+import 'package:hibiki/src/media/video/scraper/jikan_client.dart';
 import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
 import 'package:hibiki/src/media/video/scraper/offline_index.dart';
 import 'package:hibiki/src/media/video/scraper/cover_downloader.dart';
@@ -32,6 +34,7 @@ import 'package:hibiki/src/media/video/scraper/collection_scrape_apply.dart';
 import 'package:hibiki/src/media/video/scraper/cover_scraper_service.dart';
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
 import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_default_key.dart';
 import 'package:hibiki/src/media/media_cover_service.dart';
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
@@ -1797,10 +1800,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final Directory scraperDir =
         Directory(p.join(covers.parent.path, 'video_scraper'));
     await scraperDir.create(recursive: true);
-    final String tmdbKey = ref
+    // 用户自填 key 优先，其次内置 key（[resolveTmdbApiKey]）。两者皆空才没有 TMDB
+    // 源——fresh clone / fork 构建没内置 key 时的正常降级，不是错误。
+    final String userTmdbKey = ref
         .read(appProvider)
         .prefsRepo
         .getPref(kVideoScraperTmdbApiKeyPref, defaultValue: '') as String;
+    final String tmdbKey = resolveTmdbApiKey(userTmdbKey);
     CoverScraperService make(OfflineIndex? offline) => CoverScraperService(
           repository: widget.repo,
           coverMetaStore: CoverMetaStore(covers),
@@ -1808,6 +1814,9 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           bangumiClient: BangumiClient(),
           coverDownloader: CoverDownloader(),
           tmdbClient: tmdbKey.isEmpty ? null : TmdbClient(apiKey: tmdbKey),
+          // AniList / Jikan 零 key 门槛，恒可用——没有「配了才有」这回事。
+          aniListClient: AniListClient(),
+          jikanClient: JikanClient(),
           offlineIndex: offline,
           coversDirectory: covers,
         );

--- a/hibiki/lib/src/settings/settings_schema_system.dart
+++ b/hibiki/lib/src/settings/settings_schema_system.dart
@@ -101,6 +101,27 @@ SettingsDestination buildSystemDestination() {
               );
             },
           ),
+          // TMDB 署名 —— **合约义务，不是可选的致谢**。
+          //
+          // 视频封面/元数据刮削使用 TMDB API（内置 key，见 tmdb_default_key.dart），
+          // 其 Terms of Use 要求应用内显著位置展示 TMDB 标识与下面这句原文免责声明。
+          // 声明句**刻意不翻译**：TMDB 要求逐字展示该英文原句，17 种语言都用同一份。
+          //
+          // ⚠️ 尚缺官方 logo 图：条款同时要求展示 TMDB logo（须从
+          // themoviedb.org/about/logos-attribution 取原图，不得改色/改比例/翻转/旋转）。
+          // 补上 logo 资源后把这一项换成带图的行；在那之前本行只满足了文字部分。
+          SettingsActionItem(
+            id: 'system.tmdb_attribution',
+            title: 'TMDB',
+            subtitle: t.about_tmdb_attribution,
+            icon: Icons.movie_outlined,
+            onTap: (_) async {
+              await launchUrl(
+                Uri.parse('https://www.themoviedb.org/'),
+                mode: LaunchMode.externalApplication,
+              );
+            },
+          ),
         ],
       ),
       // 「数据存储位置」从同步备份大类挪来（用户拍板：数据根是设备级存储配置，

--- a/hibiki/lib/src/settings/settings_schema_video.dart
+++ b/hibiki/lib/src/settings/settings_schema_video.dart
@@ -7,6 +7,7 @@ import 'package:hibiki/src/media/video/video_immersive_mode.dart';
 import 'package:hibiki/src/media/video/video_mpv_config.dart';
 import 'package:hibiki/src/media/video/video_settings_actions.dart';
 import 'package:hibiki/src/media/video/video_subtitle_obscure_mode.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_default_key.dart';
 import 'package:hibiki/src/media/video/video_subtitle_style.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
@@ -234,6 +235,29 @@ SettingsDestination buildVideoDestination() {
             onChanged: (SettingsContext settingsContext, bool value) async {
               await settingsContext.appModel.setVideoAutoScrape(value);
             },
+          ),
+          // 自定义 TMDB API key —— **内置 key 的逃生口**，不是必填项。
+          //
+          // 刮削默认用随包内置的项目 key（见 tmdb_default_key.dart），绝大多数用户
+          // 永远不需要碰这里。留这个入口只为两种情况：① 内置 key 被 TMDB 吊销/限流
+          // 时用户能自救；② 用户想用自己的配额。留空 = 用内置 key。
+          //
+          // secret: true → 明文遮蔽 + 眼睛按钮，与其它 API key 项一致。
+          SettingsTextItem(
+            id: 'video.library.tmdb_api_key',
+            title: t.video_setting_tmdb_key,
+            subtitle: t.video_setting_tmdb_key_hint,
+            icon: Icons.key_outlined,
+            secret: true,
+            value: (SettingsContext settingsContext) => settingsContext
+                    .appModel.prefsRepo
+                    .getPref(kVideoScraperTmdbApiKeyPref, defaultValue: '')
+                as String,
+            onChanged: (SettingsContext settingsContext, String value) async =>
+                settingsContext.appModel.prefsRepo.setPref(
+              kVideoScraperTmdbApiKeyPref,
+              value.trim(),
+            ),
           ),
         ],
       ),

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1087
+version: 1.3.1+1088
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/video/scraper/anilist_jikan_client_test.dart
+++ b/hibiki/test/media/video/scraper/anilist_jikan_client_test.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/anilist_client.dart';
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart'
+    show ScrapeNetworkException;
+import 'package:hibiki/src/media/video/scraper/jikan_client.dart';
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_default_key.dart';
+
+/// AniList / Jikan 解析层 + TMDB key 取值链的纯函数测试。
+///
+/// 打在解析函数而非 client 上：网络那层没有分支可言（发请求、判状态码、解码），真正
+/// 会错的是字段映射——标题语言优先级、评分量纲换算、GraphQL 的「200 + errors」。
+void main() {
+  group('AniList 解析', () {
+    String bodyWith(List<Object?> media) => jsonEncode(<String, Object?>{
+          'data': <String, Object?>{
+            'Page': <String, Object?>{'media': media},
+          },
+        });
+
+    test('日文原题优先作标题，其余标题与 synonyms 全进别名', () {
+      final List<ScrapeCandidate> result = parseAniListResponse(bodyWith(
+        <Object?>[
+          <String, Object?>{
+            'id': 21,
+            'title': <String, Object?>{
+              'romaji': 'Mai Anime',
+              'english': 'My Anime',
+              'native': 'マイアニメ',
+            },
+            'synonyms': <Object?>['MA', 'まいあにめ'],
+            'startDate': <String, Object?>{'year': 2021},
+            'format': 'TV',
+            'episodes': 12,
+            'averageScore': 85,
+            'coverImage': <String, Object?>{
+              'extraLarge': 'https://img/xl.png',
+              'large': 'https://img/l.png',
+            },
+            'bannerImage': 'https://img/banner.png',
+            'siteUrl': 'https://anilist.co/anime/21',
+          },
+        ],
+      ));
+
+      expect(result, hasLength(1));
+      final ScrapeCandidate c = result.single;
+      expect(c.source, ScrapeSource.anilist);
+      expect(c.entryId, '21');
+      // 日语学习 app：主标题取 native，不是 romaji/english。
+      expect(c.title, 'マイアニメ');
+      expect(c.aliases,
+          containsAll(<String>['Mai Anime', 'My Anime', 'MA', 'まいあにめ']));
+      // 主标题自身不重复进别名。
+      expect(c.aliases.where((String a) => a == 'マイアニメ'), isEmpty);
+      expect(c.year, 2021);
+      expect(c.type, ScrapeEntryType.tv);
+      expect(c.episodeCount, 12);
+      // extraLarge 优先于 large。
+      expect(c.posterUrl, 'https://img/xl.png');
+      expect(c.backdropUrl, 'https://img/banner.png');
+    });
+
+    test('averageScore 0~100 换算成 0~10（与其余源同量纲）', () {
+      final ScrapeCandidate c = parseAniListResponse(bodyWith(<Object?>[
+        <String, Object?>{
+          'id': 1,
+          'title': <String, Object?>{'native': 'X'},
+          'averageScore': 85,
+          'coverImage': <String, Object?>{'large': 'https://img/x.png'},
+        },
+      ])).single;
+      expect(c.rating, 8.5);
+      expect(c.ratingText, 'AniList 8.5');
+    });
+
+    test('简介剥离 HTML 标签与实体（asHtml:false 仍会留 <br> / <i>）', () {
+      final ScrapeCandidate c = parseAniListResponse(bodyWith(<Object?>[
+        <String, Object?>{
+          'id': 1,
+          'title': <String, Object?>{'native': 'X'},
+          'description': '第一行<br>第二行 <i>斜体</i> &amp; 收尾',
+          'coverImage': <String, Object?>{'large': 'https://img/x.png'},
+        },
+      ])).single;
+      expect(c.summary, '第一行\n第二行 斜体 & 收尾');
+    });
+
+    test('缺封面的条目跳过（对封面刮削无用）', () {
+      expect(
+        parseAniListResponse(bodyWith(<Object?>[
+          <String, Object?>{
+            'id': 1,
+            'title': <String, Object?>{'native': 'X'},
+          },
+        ])),
+        isEmpty,
+      );
+    });
+
+    test('ONA / MUSIC 归 unknown 而非硬塞类型（错误分类会主动扣分）', () {
+      for (final String format in <String>['ONA', 'MUSIC', 'WHATEVER']) {
+        final ScrapeCandidate c = parseAniListResponse(bodyWith(<Object?>[
+          <String, Object?>{
+            'id': 1,
+            'title': <String, Object?>{'native': 'X'},
+            'format': format,
+            'coverImage': <String, Object?>{'large': 'https://img/x.png'},
+          },
+        ])).single;
+        expect(c.type, ScrapeEntryType.unknown, reason: 'format=$format');
+      }
+    });
+
+    test('GraphQL 错误是 200 + body.errors —— 必须抛，不得当成零结果', () {
+      // 这条是本客户端最容易写错的地方：只看 statusCode 会把「查询被拒」静默变成
+      // 「这部片不存在」，用户永远查不出为什么 AniList 一条都不出。
+      expect(
+        () => parseAniListResponse(jsonEncode(<String, Object?>{
+          'errors': <Object?>[
+            <String, Object?>{'message': 'Too Many Requests'},
+          ],
+        })),
+        throwsA(isA<ScrapeNetworkException>()),
+      );
+    });
+
+    test('结构缺失（无 data/Page/media）返回空表而非抛', () {
+      expect(parseAniListResponse(jsonEncode(<String, Object?>{})), isEmpty);
+      expect(
+        parseAniListResponse(
+            jsonEncode(<String, Object?>{'data': <String, Object?>{}})),
+        isEmpty,
+      );
+    });
+  });
+
+  group('Jikan 解析', () {
+    String bodyWith(List<Object?> data) =>
+        jsonEncode(<String, Object?>{'data': data});
+
+    test('日文原题优先，titles[] 全量进别名，aired.from 取年份', () {
+      final ScrapeCandidate c = parseJikanResponse(bodyWith(<Object?>[
+        <String, Object?>{
+          'mal_id': 5114,
+          'title': 'Mai Anime',
+          'title_japanese': 'マイアニメ',
+          'title_english': 'My Anime',
+          'titles': <Object?>[
+            <String, Object?>{'type': 'Synonym', 'title': 'MA'},
+            <String, Object?>{'type': 'Default', 'title': 'Mai Anime'},
+          ],
+          'type': 'TV',
+          'episodes': 64,
+          'score': 9.1,
+          'scored_by': 2000,
+          'aired': <String, Object?>{'from': '2009-04-05T00:00:00+00:00'},
+          'images': <String, Object?>{
+            'jpg': <String, Object?>{
+              'large_image_url': 'https://img/large.jpg',
+              'image_url': 'https://img/small.jpg',
+            },
+          },
+          'url': 'https://myanimelist.net/anime/5114',
+          'synopsis': '简介文本',
+        },
+      ])).single;
+
+      expect(c.source, ScrapeSource.jikan);
+      expect(c.entryId, '5114');
+      expect(c.title, 'マイアニメ');
+      expect(c.aliases, containsAll(<String>['Mai Anime', 'My Anime', 'MA']));
+      expect(c.year, 2009);
+      expect(c.type, ScrapeEntryType.tv);
+      expect(c.episodeCount, 64);
+      expect(c.rating, 9.1);
+      expect(c.ratingCount, 2000);
+      expect(c.ratingText, 'MAL 9.1');
+      // large_image_url 优先于 image_url。
+      expect(c.posterUrl, 'https://img/large.jpg');
+      // MAL 无横版图，恒 null（不编造一张不存在的图去填 hero 宽槽）。
+      expect(c.backdropUrl, isNull);
+      expect(c.summary, '简介文本');
+    });
+
+    test('缺封面 / 缺 mal_id 的条目跳过', () {
+      expect(
+        parseJikanResponse(bodyWith(<Object?>[
+          <String, Object?>{'mal_id': 1, 'title': 'X'},
+        ])),
+        isEmpty,
+      );
+      expect(
+        parseJikanResponse(bodyWith(<Object?>[
+          <String, Object?>{
+            'title': 'X',
+            'images': <String, Object?>{
+              'jpg': <String, Object?>{'image_url': 'https://img/x.jpg'},
+            },
+          },
+        ])),
+        isEmpty,
+      );
+    });
+
+    test('jpg 缺失时回落 webp', () {
+      final ScrapeCandidate c = parseJikanResponse(bodyWith(<Object?>[
+        <String, Object?>{
+          'mal_id': 7,
+          'title': 'X',
+          'images': <String, Object?>{
+            'webp': <String, Object?>{'large_image_url': 'https://img/x.webp'},
+          },
+        },
+      ])).single;
+      expect(c.posterUrl, 'https://img/x.webp');
+    });
+
+    test('data 缺失返回空表而非抛', () {
+      expect(parseJikanResponse(jsonEncode(<String, Object?>{})), isEmpty);
+    });
+  });
+
+  group('TMDB key 取值链', () {
+    test('用户自填优先于内置', () {
+      expect(resolveTmdbApiKey('user-key'), 'user-key');
+      expect(resolveTmdbApiKey('  user-key  '), 'user-key');
+    });
+
+    test('用户留空 → 回落内置（入库占位为空串，即「TMDB 未配置」的正常降级）', () {
+      // 断言的是**取值规则**而非具体 key 值：内置值在 CI 由 secret 注入、本机由
+      // skip-worktree 真值覆盖，把字面量写进断言会让这条测试随构建环境变红。
+      expect(resolveTmdbApiKey(''), kBuiltinTmdbApiKey.trim());
+      expect(resolveTmdbApiKey('   '), kBuiltinTmdbApiKey.trim());
+    });
+  });
+}

--- a/hibiki/test/media/video/scraper/cover_match_dialog_test.dart
+++ b/hibiki/test/media/video/scraper/cover_match_dialog_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
@@ -66,6 +65,26 @@ class _StubScraperService extends CoverScraperService {
   final List<Object?> applyErrors = <Object?>[];
   int searchCalls = 0;
 
+  /// 多源聚合用的**逐源**桩数据。非空时接管 [searchCandidates]，[candidates] /
+  /// [searchErrors] 那条单源老路径不再生效——两套刻意不混用，否则「这条断言到底
+  /// 命中哪条桩」要靠猜。
+  final Map<ScrapeSource, List<ScrapeCandidate>> perSourceCandidates =
+      <ScrapeSource, List<ScrapeCandidate>>{};
+
+  /// 逐源失败注入：命中的源抛该异常，其余源照常返回候选。
+  final Map<ScrapeSource, Object> perSourceErrors = <ScrapeSource, Object>{};
+
+  /// 覆盖「本次构建有哪些可用源」。基类按注入的 client 是否为 null 推导，桩里不真
+  /// 造 client，故直接给答案。
+  List<ScrapeSource>? sourcesOverride;
+
+  /// 记录每个源各被查了几次（断言「一次搜索把所有源都查了」）。
+  final Map<ScrapeSource, int> searchCallsBySource = <ScrapeSource, int>{};
+
+  @override
+  List<ScrapeSource> get availableSearchSources =>
+      sourcesOverride ?? super.availableSearchSources;
+
   @override
   Future<List<ScrapeCandidate>> searchCandidates({
     required ScrapeSource source,
@@ -73,6 +92,12 @@ class _StubScraperService extends CoverScraperService {
     int? year,
   }) async {
     searchCalls++;
+    searchCallsBySource[source] = (searchCallsBySource[source] ?? 0) + 1;
+    if (perSourceCandidates.isNotEmpty || perSourceErrors.isNotEmpty) {
+      final Object? error = perSourceErrors[source];
+      if (error != null) Error.throwWithStackTrace(error, StackTrace.current);
+      return perSourceCandidates[source] ?? const <ScrapeCandidate>[];
+    }
     final Object? error =
         searchErrors.isEmpty ? null : searchErrors.removeAt(0);
     if (error != null) Error.throwWithStackTrace(error, StackTrace.current);
@@ -92,21 +117,6 @@ class _StubScraperService extends CoverScraperService {
     for (final String uid in bookUids) {
       await repo.updateCover(uid, 'stub-applied-${candidate.entryId}.jpg');
     }
-  }
-}
-
-class _DelayedPreferencesRepository extends PreferencesRepository {
-  _DelayedPreferencesRepository(super.database);
-
-  Completer<void>? tmdbKeyWriteGate;
-
-  @override
-  Future<void> setPref(String key, dynamic value) async {
-    final Completer<void>? gate = tmdbKeyWriteGate;
-    if (key == kVideoScraperTmdbApiKeyPref && gate != null) {
-      await gate.future;
-    }
-    await super.setPref(key, value);
   }
 }
 
@@ -137,7 +147,7 @@ void main() {
   late VideoBookRepository repo;
   late Directory tmp;
   late AppModel appModel;
-  late _DelayedPreferencesRepository prefs;
+  late PreferencesRepository prefs;
   late PlatformServices platformServices;
 
   setUp(() async {
@@ -146,7 +156,7 @@ void main() {
     db = HibikiDatabase.forTesting(NativeDatabase.memory());
     repo = VideoBookRepository(db);
     tmp = await Directory.systemTemp.createTemp('hibiki_poster_match_');
-    prefs = _DelayedPreferencesRepository(db);
+    prefs = PreferencesRepository(db);
     await prefs.loadFromDb();
     platformServices = testPlatformServices();
     appModel = AppModel(platformServices)
@@ -296,10 +306,51 @@ void main() {
     expect(find.text(t.video_scrape_use), findsNothing);
   });
 
-  testWidgets('BUG-1234 切换来源清空旧结果且不自动搜索；TMDB 无 key 不显示 Bangumi 数据',
-      (WidgetTester tester) async {
+  // 契约变更（取代旧的两条 BUG-1234「切换来源 / TMDB key 输入」用例）：数据源选择器
+  // 与 TMDB key 输入行已从弹窗移除——用户不再选源、也不在这里配 key（内置 key +
+  // 设置页逃生口）。旧用例守的是已不存在的行为，故删除而非修补。
+  testWidgets('多源聚合：一次搜索查全部可用源，候选合并进同一列表且无来源选择器', (WidgetTester tester) async {
     final VideoBookRow book = await seed();
     final _StubScraperService service = buildService();
+    service.sourcesOverride = <ScrapeSource>[
+      ScrapeSource.bangumi,
+      ScrapeSource.tmdb,
+      ScrapeSource.anilist,
+      ScrapeSource.jikan,
+    ];
+    service.perSourceCandidates
+      ..[ScrapeSource.bangumi] = const <ScrapeCandidate>[
+        ScrapeCandidate(
+          source: ScrapeSource.bangumi,
+          entryId: '42',
+          title: 'My Anime',
+          posterUrl: 'https://img/b42.png',
+        ),
+      ]
+      ..[ScrapeSource.tmdb] = const <ScrapeCandidate>[
+        ScrapeCandidate(
+          source: ScrapeSource.tmdb,
+          entryId: '77',
+          title: 'My Anime',
+          posterUrl: 'https://img/t77.png',
+        ),
+      ]
+      ..[ScrapeSource.anilist] = const <ScrapeCandidate>[
+        ScrapeCandidate(
+          source: ScrapeSource.anilist,
+          entryId: '99',
+          title: 'マイアニメ',
+          posterUrl: 'https://img/a99.png',
+        ),
+      ]
+      ..[ScrapeSource.jikan] = const <ScrapeCandidate>[
+        ScrapeCandidate(
+          source: ScrapeSource.jikan,
+          entryId: '55',
+          title: 'マイアニメ',
+          posterUrl: 'https://img/j55.png',
+        ),
+      ];
 
     await tester.pumpWidget(wrap(CoverMatchDialog(
       service: service,
@@ -308,56 +359,56 @@ void main() {
       onApplied: () {},
     )));
     await tester.pumpAndSettle();
-    expect(service.searchCalls, 1);
-    expect(
-      find.byKey(
-        const ValueKey<String>('cover_match_candidate_bangumi_42'),
-      ),
-      findsOneWidget,
-    );
-    expect(find.text(t.video_scrape_manual_match_hint), findsOneWidget);
 
-    await tester.tap(find.text('TMDB'));
-    await tester.pump();
+    // 一次搜索 = 每个可用源各查一次（不是只查「当前选中的那个」）。
+    expect(service.searchCallsBySource[ScrapeSource.bangumi], 1);
+    expect(service.searchCallsBySource[ScrapeSource.tmdb], 1);
+    expect(service.searchCallsBySource[ScrapeSource.anilist], 1);
+    expect(service.searchCallsBySource[ScrapeSource.jikan], 1);
 
-    // 切换本身不发请求，旧 Bangumi 候选也不能冒充 TMDB 结果。
-    expect(service.searchCalls, 1);
-    expect(
-      find.byKey(
-        const ValueKey<String>('cover_match_candidate_bangumi_42'),
-      ),
-      findsNothing,
-    );
-    expect(find.text(t.video_scrape_tmdb_key_empty), findsOneWidget);
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) =>
-            widget is TextField &&
-            widget.decoration?.hintText == t.video_scrape_tmdb_key_hint,
-      ),
-      findsOneWidget,
-    );
+    // 四个源的候选同时在列表里（跨源不去重：同一部片的不同语言条目都要留）。
+    //
+    // 必须 scrollUntilVisible 而非直接 find：结果区是 ListView.separated（懒构建），
+    // 四条候选高于弹窗可视区，末条根本没被 build——直接断言会把「渲染在下面」误判成
+    // 「没合并进来」。断言顺序与排序后的列表顺序一致（同分按源顺序稳定排），故一路
+    // 向下滚即可，不必来回找。
+    final Finder resultList = find.byType(Scrollable).last;
+    for (final String key in <String>[
+      'cover_match_candidate_bangumi_42',
+      'cover_match_candidate_tmdb_77',
+      'cover_match_candidate_anilist_99',
+      'cover_match_candidate_jikan_55',
+    ]) {
+      await tester.scrollUntilVisible(
+        find.byKey(ValueKey<String>(key)),
+        120,
+        scrollable: resultList,
+      );
+      expect(find.byKey(ValueKey<String>(key)), findsOneWidget,
+          reason: '$key 应出现在聚合列表里');
+    }
 
-    // 切回 Bangumi 仍等用户明确点搜索，不暗中再次请求。
-    await tester.tap(find.text('Bangumi'));
-    await tester.pump();
-    expect(service.searchCalls, 1);
-    expect(find.text(t.video_scrape_tmdb_key_empty), findsNothing);
-    await tester.tap(find.text(t.video_scrape_search));
-    await tester.pumpAndSettle();
-    expect(service.searchCalls, 2);
-    expect(
-      find.byKey(
-        const ValueKey<String>('cover_match_candidate_bangumi_42'),
-      ),
-      findsOneWidget,
-    );
+    // 来源选择器必须不复存在——它正是本次要消除的那个「用户必须先做的选择」。
+    expect(find.byType(SegmentedButton<ScrapeSource>), findsNothing);
   });
 
-  testWidgets('BUG-1234 保存 TMDB key 未完成时切来源，旧 continuation 不得搜索新来源',
-      (WidgetTester tester) async {
+  testWidgets('多源聚合：部分源失败只降级，其余源候选照常展示且不出失败行', (WidgetTester tester) async {
     final VideoBookRow book = await seed();
     final _StubScraperService service = buildService();
+    service.sourcesOverride = <ScrapeSource>[
+      ScrapeSource.bangumi,
+      ScrapeSource.tmdb,
+    ];
+    service.perSourceCandidates[ScrapeSource.bangumi] = const <ScrapeCandidate>[
+      ScrapeCandidate(
+        source: ScrapeSource.bangumi,
+        entryId: '42',
+        title: 'My Anime',
+        posterUrl: 'https://img/b42.png',
+      ),
+    ];
+    service.perSourceErrors[ScrapeSource.tmdb] =
+        const ScrapeNetworkException('tmdb down', statusCode: 503);
 
     await tester.pumpWidget(wrap(CoverMatchDialog(
       service: service,
@@ -366,37 +417,38 @@ void main() {
       onApplied: () {},
     )));
     await tester.pumpAndSettle();
-    expect(service.searchCalls, 1);
 
-    await tester.tap(find.text('TMDB'));
-    await tester.pump();
-    final Finder keyField = find.byWidgetPredicate(
-      (Widget widget) =>
-          widget is TextField &&
-          widget.decoration?.hintText == t.video_scrape_tmdb_key_hint,
-    );
-    await tester.enterText(keyField, 'delayed-tmdb-key');
-
-    final Completer<void> writeGate = Completer<void>();
-    prefs.tmdbKeyWriteGate = writeGate;
-    await tester.tap(find.text(t.video_scrape_tmdb_key_save));
-    await tester.pump();
-
-    // 持久化尚未完成时切回 Bangumi：来源切换必须立即生效且不自动搜索。
-    await tester.tap(find.text('Bangumi'));
-    await tester.pump();
-    expect(service.searchCalls, 1);
-
-    // 放行旧 Save continuation。旧实现会在这里对当前 Bangumi 再调一次 _search()。
-    writeGate.complete();
-    await tester.pumpAndSettle();
-    expect(service.searchCalls, 1);
+    // 活着的源有结果 → 用户看到候选，而不是一句「搜索失败」（BUG-1176 分界的多源推广）。
     expect(
-      find.byKey(
-        const ValueKey<String>('cover_match_candidate_bangumi_42'),
-      ),
-      findsNothing,
+      find.byKey(const ValueKey<String>('cover_match_candidate_bangumi_42')),
+      findsOneWidget,
     );
+    expect(find.text(t.video_scrape_search_failed), findsNothing);
+    expect(find.text(t.video_scrape_no_results), findsNothing);
+  });
+
+  testWidgets('多源聚合：全部源失败才出可见失败行', (WidgetTester tester) async {
+    final VideoBookRow book = await seed();
+    final _StubScraperService service = buildService();
+    service.sourcesOverride = <ScrapeSource>[
+      ScrapeSource.bangumi,
+      ScrapeSource.tmdb,
+    ];
+    service.perSourceErrors
+      ..[ScrapeSource.bangumi] = const ScrapeNetworkException('bangumi down')
+      ..[ScrapeSource.tmdb] = const ScrapeNetworkException('tmdb down');
+
+    await tester.pumpWidget(wrap(CoverMatchDialog(
+      service: service,
+      book: book,
+      collectionMemberUids: const <String>['video/my_anime'],
+      onApplied: () {},
+    )));
+    await tester.pumpAndSettle();
+
+    // 全挂 = 真搜不了：出失败行 + 可行动原因，绝不塌缩成「无匹配」。
+    expect(find.text(t.video_scrape_search_failed), findsOneWidget);
+    expect(find.text(t.video_scrape_no_results), findsNothing);
   });
 
   testWidgets('BUG-1251 手动输入的标准标题作为置信度评分标题', (WidgetTester tester) async {


### PR DESCRIPTION
## 动机

用户反馈：「尽可能支持更多数据源，用户不用关心数据源从哪来」「这里没必要让用户选择」。

封面匹配弹窗此前逼用户先在 Bangumi / TMDB / 离线库之间**选一个**，选 TMDB 还要自己去
themoviedb.org 申请 API key 粘进来。而**自动刮削本来就是多源的**（`cover_scraper_service.dart`
离线库 → Bangumi → TMDB 逐层兜底），只有手动弹窗退化成了单选。

## 改了什么

### 1. 弹窗去掉数据源选择器（消除 5 处特殊情况）

`_source` 这个单选状态是 5 个分支的共同根源：`_searchSource` 按源分叉、切源要清空结果、
`_showTmdbKeyField` 跟着联动、`_buildResults` 为「TMDB 没 key」专门写空态、结果不带来源。
删掉这个状态后 5 个分支一起消失，换成：并发查全部可用源 → 同源内按 entryId 去重
（**跨源不去重**：Bangumi 的中文条目与 AniList 的日文条目是同一部作品的不同表示，合并会
丢掉用户正想要的那一个）→ 按置信度 + 标题相似度**稳定排序**。

排序是「不用关心数据源」的前提：不排的话只是把选源的负担换成了翻列表的负担。

来源仍显示在每条候选上（配错可溯源、也解释了「为什么同一部片出现两条」），只是不再是
一个**必须先做的选择**。

### 2. 新增两个零 key 门槛的数据源

| 源 | 端点 | key |
|---|---|---|
| AniList | `POST graphql.anilist.co` | 不需要 |
| Jikan (MyAnimeList) | `GET api.jikan.moe/v4/anime` | 不需要 |

两者都按**日文原题优先**取主标题（本 app 面向日语学习），其余标题与 synonyms / `titles[]`
全进别名参与打分——文件名里常见的恰恰是 Synonym 而不是任何一个主标题。

AniList 的 `averageScore` 是 0~100，已换算成 0~10 与其余源同量纲；`bannerImage`（超宽横幅）
映射到 `backdropUrl` 供详情页 hero 用。MAL 无横版图，`backdropUrl` 恒 null——不编造一张不
存在的图去填宽槽（BUG-1298 的教训）。

### 3. 内置 TMDB key

沿用仓库既有的 `dandanplay_secret.dart` 约定，**不发明新机制**：

- 入库 `tmdb_default_key.dart` 空占位（fresh clone / fork 直接可编译）
- 本机真值 + `git update-index --skip-worktree`（不显示 dirty、永不提交）
- CI 从 `TMDB_API_KEY` repo secret 注入（6 处 job，`main.yml` ×1 + `build-multiplatform.yml` ×5）
- 注入只 `sed` 替换那一行常量，文件注释 / pref-key 常量 / `resolveTmdbApiKey()` 全部存活

取值链 `用户自填 > 内置`，**两者皆空是正常降级**（TMDB 源不可用，其余源照常）——不是错误。

用户自填 key 的入口从弹窗移到**设置 → 视频 → 媒体库**，作为内置 key 被吊销/限流时的
逃生口保留。

### 4. 失败语义（BUG-1176 在多源下的推广）

- **部分源失败** → 只降级：其余源候选照常展示，失败明细进诊断日志（界面不打扰，但
  「某源结果时有时无」可查）
- **全部源失败** → 才出可见失败行 + 可行动原因，绝不塌缩成「无匹配」

失败用**返回值**而非 throw 传递：各源失败原因是 `Object`，重新抛既触发 `only_throw_errors`，
也让「全失败」这个正常控制流伪装成异常。

### 5. TMDB 署名（合约义务）

Terms of Use 要求显示 TMDB 标识 + 逐字免责声明。已在系统设置加上声明行（该英文原句
**刻意不翻译**，17 种语言同一份）。

⚠️ **官方 logo 图尚缺**——须从 themoviedb.org/about/logos-attribution 取原图（不得改色/
改比例/翻转/旋转），我无法代为生成。补上资源后应把该行换成带图的。

## 两种代价模型，刻意不合并

- **自动刮削**逐层兜底、命中 high 立即停：批量刮 500 本不能每本发 5 个请求
- **手动弹窗**并发全查：用户在等，要一次看全

## 测试

新增 `anilist_jikan_client_test.dart`（解析层纯函数）：
- 日文原题优先 + 别名归集 + 主标题不重复进别名
- `averageScore` 0~100 → 0~10 量纲换算
- **GraphQL 错误是 200 + `body.errors`，必须抛**——只看 statusCode 会把「查询被拒」
  静默变成「这部片不存在」
- HTML 剥离、缺封面/缺 mal_id 跳过、jpg→webp 回落、ONA/MUSIC 归 unknown（错误分类会
  主动扣分，宁可不判）
- TMDB key 取值链（断言规则而非字面量，否则会随构建环境变红）

弹窗侧：三条多源聚合用例（全源被查 / 部分失败降级 / 全失败出错误行 / 选择器不复存在）
**取代**已失效的两条 BUG-1234 来源切换用例——那守的是已不存在的行为，属**契约变更非回归**。

## 验证

- `flutter analyze` 全量（含 test）→ **No issues found**
- `flutter test test/media/video/ test/i18n/` → **2016 passed**
- `flutter test test/settings/` → **317 passed**
- `flutter test test/media/video/scraper/` → **204 passed**
- 两个 workflow YAML 经 `yaml.safe_load` 解析校验，6 个注入步骤均被识别为真实 step

未做真机验证。

## 合并前需要你做一件事

在 GitHub repo → Settings → Secrets and variables → Actions 添加 secret
**`TMDB_API_KEY`**（值即你申请到的那把 v3 key）。不加的话发行版里内置 key 为空，
TMDB 源静默降级为「未配置」，其余源不受影响。

另：主 checkout 合并后需执行一次
`git update-index --skip-worktree hibiki/lib/src/media/video/scraper/tmdb_default_key.dart`
并填入真值，后续新建 worktree 时 `setup_worktree.ps1` 才会自动搬运它。

https://claude.ai/code/session_01Noc7HoCtwF9pSjJksKGYYA
