### PR TITLE
fix(video): 字幕轨列表下载后当场刷新 + Jimaku 类型筛选 + 入口改名（BUG-1329）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1277 条。点号进各自文件。
+> 共 1278 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1329](bugs/BUG-1329-video-subtitle-menu-not-refreshed-after-download.md) | ✅ | ✅ | 下载/导入字幕后字幕轨列表不刷新，且重新枚举时长时间挂加载条 |
 | [BUG-1328](bugs/BUG-1328-ui-font-chain-collapsed-to-single-family.md) | ✅ | ✅ | 界面字体回退链被压成单值：中文默认字形难看、日文缺字逐字乱回退、用户第2条字体永不生效 |
 | [BUG-1327](bugs/BUG-1327-video-context-dialog-barrier.md) | ✅ | ✅ | 视频页制卡上下文对话框被查词浮层 barrier 吃掉点击 |
 | [BUG-1326](bugs/BUG-1326-popup-ctx-modal-args-stringified.md) | ✅ | ✅ | 调整上下文回点制卡永远点第一个词条 |

--- a/docs/bugs/BUG-1329-video-subtitle-menu-not-refreshed-after-download.md
+++ b/docs/bugs/BUG-1329-video-subtitle-menu-not-refreshed-after-download.md
@@ -1,0 +1,42 @@
+## BUG-1329 · 下载/导入字幕后字幕轨列表不刷新，且重新枚举时长时间挂加载条
+- **报告**：2026-08-01（用户：视频页「字幕」分类截图 —— 「我手动下载完以后，这里没有下载的字幕，而且一直在加载」）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart`（修复前的 `_invalidateSubtitleMenuSourcesCache` 及其两个调用点：`_openJimakuDialog` / `_importExternalSubtitleInner`）。
+
+  字幕轨列表 `_subtitleMenuSources` 的**唯一**重建驱动事件是「进入字幕分类」
+  （`VideoQuickSettingsSheet.onSubtitleCategoryShown` → `_ensureSubtitleMenuSourcesLoaded`，
+  见 `video_quick_settings_sheet.dart:70/86/104`）。而 Jimaku 下载 / 外挂导入完成后，代码
+  只做了 `_subtitleMenuSourcesPath = null`（作废缓存 key），**指望「下次进入字幕分类」再重
+  枚举**。两个后果：
+
+  1. **列表不刷新**：下载几乎总是**从已经打开的「字幕」分类里**发起的（用户就是点那一行
+     「获取字幕」进去的）。面板不关、分类不切 → `onSubtitleCategoryShown` 不会再触发 →
+     列表原样停在旧枚举结果，刚下载的字幕根本不出现。另外
+     `listAllSubtitleSources` 按设计只看内嵌轨 + 视频同目录 sidecar，落在
+     `<dataRoot>/documents/video_subtitles/` 的下载档只能靠
+     `includeCurrentPersistedSubtitleForMenu` 作为「当前项」被注入 —— 而那一步同样只在重枚举
+     时才跑。
+  2. **长时间加载条**：真去重枚举时又要对整个容器重跑一遍 `ffmpeg -i`（超时预算按文件体积
+     放大，见 `subtitleExtractTimeoutForBytes`），期间 `_subtitleMenuLoading=true`，字幕轨区
+     顶部挂 `LinearProgressIndicator`，旧行还在、新行没有 —— 正是截图里的样子。而这趟重探
+     带来的唯一新信息，就是我们手里那个已知路径的外挂文件。
+
+  同一批还修掉一个能让加载条**永久**转下去的真实泄漏：`_applyYoutubeCaptionTrack` 里
+  `_subtitleMenuLoading = true` 之后靠三条各自复位的 return 路径收尾，`resolveYoutubeCaptionCues`
+  抛错那条谁也走不到，标志永久留在 true，且再无入口能关掉它。
+
+- **[x] ① 已修复** — `_registerImportedSubtitleSource(path)` 取代缓存作废式刷新：新档是 app 自己
+  刚写下的外挂文件，路径与标签都在手里，直接插进 `_subtitleMenuSources` 首位（与
+  `includeCurrentPersistedSubtitleForMenu` 的「当前导入排最前」约定一致），枚举缓存 key 保持
+  有效、不重探容器。两个落盘点（Jimaku 下载 / 外挂导入）统一走它。另外
+  `_ensureSubtitleMenuSourcesLoaded` 的加载态收敛成单出口（枚举失败用 `null` 表达，不再有
+  「某条 return 忘了复位」的分支），`_applyYoutubeCaptionTrack` 的 cue 解析包进 try/finally。
+  提交：见本分支 `fix(video): ...` commit。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/video_subtitle_menu_refresh_guard_test.dart`
+  （静态守卫：两个落盘点都调 `_registerImportedSubtitleSource`；并入路径不重置缓存 key、不点亮
+  加载态、按 `sameExternalSubtitlePathForMenu` 去重；旧的缓存作废 helper 零残留；YouTube cue
+  解析必须 try/finally 收敛加载态；枚举加载态置真后只有唯一复位点）。media_kit 跑不了 headless、
+  ffmpeg 枚举也不能在单测里真跑，故锁调用点契约。
+- **备注**：同批用户诉求还有两项（非 bug，属改进）：①「自动获取字幕」改名为「获取字幕」
+  （i18n key `video_jimaku_fetch` 值改，17 语言同步）；② Jimaku 对话框支持按字幕**类型**筛选
+  （ass/srt/ssa/vtt chip，纯函数 `filterCandidatesByFormat` / `availableFormats`，测试见
+  `hibiki/test/pages/jimaku_filter_test.dart` 与 `jimaku_format_filter_widget_test.dart`）。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 49504 (2912 per locale)
+/// Strings: 49538 (2914 per locale)
 ///
-/// Built on 2026-08-01 at 05:47 UTC
+/// Built on 2026-08-01 at 05:59 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -2995,7 +2995,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get video_jimaku_downloaded => 'Subtitle downloaded and applied';
   String get video_jimaku_episode => 'Episode (optional)';
   String get video_jimaku_episode_hint => 'Leave empty to list all';
-  String get video_jimaku_fetch => 'Auto-fetch subtitles (Jimaku)';
+  String get video_jimaku_fetch => 'Fetch subtitles (Jimaku)';
   String get video_jimaku_filter => 'Filter results (e.g. WEBRip, BD)';
   String get video_jimaku_find_sources => 'Find subtitles';
   String get video_jimaku_language => 'Language';
@@ -3937,6 +3937,8 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_task_status_error => 'Error';
   String get download_task_pause => 'Pause';
   String get download_task_resume => 'Resume';
+  String get video_jimaku_format => 'Format';
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -9013,7 +9015,7 @@ class _StringsAr extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'جلب الترجمات تلقائيًا (Jimaku)';
+  String get video_jimaku_fetch => 'جلب الترجمات (Jimaku)';
   @override
   String get video_jimaku_filter => 'تصفية النتائج (مثل WEBRip وBD)';
   @override
@@ -10635,6 +10637,10 @@ class _StringsAr extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -15768,7 +15774,7 @@ class _StringsDe extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Untertitel automatisch holen (Jimaku)';
+  String get video_jimaku_fetch => 'Untertitel holen (Jimaku)';
   @override
   String get video_jimaku_filter => 'Ergebnisse filtern (z. B. WEBRip, BD)';
   @override
@@ -17400,6 +17406,10 @@ class _StringsDe extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -22547,8 +22557,7 @@ class _StringsEs extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch =>
-      'Obtener subtítulos automáticamente (Jimaku)';
+  String get video_jimaku_fetch => 'Obtener subtítulos (Jimaku)';
   @override
   String get video_jimaku_filter => 'Filtrar resultados (p. ej. WEBRip, BD)';
   @override
@@ -24181,6 +24190,10 @@ class _StringsEs extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -29340,7 +29353,7 @@ class _StringsFr extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Récupération auto des sous-titres (Jimaku)';
+  String get video_jimaku_fetch => 'Récupérer les sous-titres (Jimaku)';
   @override
   String get video_jimaku_filter => 'Filtrer les résultats (ex. WEBRip, BD)';
   @override
@@ -30973,6 +30986,10 @@ class _StringsFr extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -36070,7 +36087,7 @@ class _StringsId extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Ambil subtitle otomatis (Jimaku)';
+  String get video_jimaku_fetch => 'Ambil subtitle (Jimaku)';
   @override
   String get video_jimaku_filter => 'Saring hasil (mis. WEBRip, BD)';
   @override
@@ -37694,6 +37711,10 @@ class _StringsId extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -42830,7 +42851,7 @@ class _StringsIt extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Recupero automatico sottotitoli (Jimaku)';
+  String get video_jimaku_fetch => 'Recupera sottotitoli (Jimaku)';
   @override
   String get video_jimaku_filter => 'Filtra risultati (es. WEBRip, BD)';
   @override
@@ -44461,6 +44482,10 @@ class _StringsIt extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -49442,7 +49467,7 @@ class _StringsJa extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => '字幕を自動取得（Jimaku）';
+  String get video_jimaku_fetch => '字幕を取得（Jimaku）';
   @override
   String get video_jimaku_filter => '結果を絞り込み（WEBRip、BD など）';
   @override
@@ -51045,6 +51070,10 @@ class _StringsJa extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -56025,7 +56054,7 @@ class _StringsKo extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => '자막 자동 가져오기(Jimaku)';
+  String get video_jimaku_fetch => '자막 가져오기(Jimaku)';
   @override
   String get video_jimaku_filter => '결과 필터(예: WEBRip, BD)';
   @override
@@ -57631,6 +57660,10 @@ class _StringsKo extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -62751,7 +62784,7 @@ class _StringsNl extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Ondertitels automatisch ophalen (Jimaku)';
+  String get video_jimaku_fetch => 'Ondertitels ophalen (Jimaku)';
   @override
   String get video_jimaku_filter => 'Resultaten filteren (bijv. WEBRip, BD)';
   @override
@@ -64378,6 +64411,10 @@ class _StringsNl extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -69508,7 +69545,7 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Buscar legendas automaticamente (Jimaku)';
+  String get video_jimaku_fetch => 'Buscar legendas (Jimaku)';
   @override
   String get video_jimaku_filter => 'Filtrar resultados (ex.: WEBRip, BD)';
   @override
@@ -71138,6 +71175,10 @@ class _StringsPtBr extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -76256,7 +76297,7 @@ class _StringsRu extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Авто-загрузка субтитров (Jimaku)';
+  String get video_jimaku_fetch => 'Загрузить субтитры (Jimaku)';
   @override
   String get video_jimaku_filter => 'Фильтр результатов (например, WEBRip, BD)';
   @override
@@ -77882,6 +77923,10 @@ class _StringsRu extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -82954,7 +82999,7 @@ class _StringsTh extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'ดึงคำบรรยายอัตโนมัติ (Jimaku)';
+  String get video_jimaku_fetch => 'ดึงคำบรรยาย (Jimaku)';
   @override
   String get video_jimaku_filter => 'กรองผลลัพธ์ (เช่น WEBRip, BD)';
   @override
@@ -84574,6 +84619,10 @@ class _StringsTh extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -89674,7 +89723,7 @@ class _StringsTr extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Altyazıları otomatik getir (Jimaku)';
+  String get video_jimaku_fetch => 'Altyazıları getir (Jimaku)';
   @override
   String get video_jimaku_filter => 'Sonuçları filtrele (ör. WEBRip, BD)';
   @override
@@ -91298,6 +91347,10 @@ class _StringsTr extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -96387,7 +96440,7 @@ class _StringsVi extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => 'Tự lấy phụ đề (Jimaku)';
+  String get video_jimaku_fetch => 'Lấy phụ đề (Jimaku)';
   @override
   String get video_jimaku_filter => 'Lọc kết quả (vd WEBRip, BD)';
   @override
@@ -98007,6 +98060,10 @@ class _StringsVi extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 // Path: <root>
@@ -102750,7 +102807,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => '留空列出全部';
   @override
-  String get video_jimaku_fetch => '自动获取字幕（Jimaku）';
+  String get video_jimaku_fetch => '获取字幕（Jimaku）';
   @override
   String get video_jimaku_filter => '筛选结果（如 WEBRip、BD）';
   @override
@@ -104242,6 +104299,10 @@ class _StringsZhCn extends _StringsEn {
   String get download_task_pause => '暂停';
   @override
   String get download_task_resume => '恢复';
+  @override
+  String get video_jimaku_format => '类型';
+  @override
+  String get video_jimaku_format_all => '全部';
 }
 
 // Path: <root>
@@ -109153,7 +109214,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get video_jimaku_episode_hint => 'Leave empty to list all';
   @override
-  String get video_jimaku_fetch => '自動取得字幕（Jimaku）';
+  String get video_jimaku_fetch => '取得字幕（Jimaku）';
   @override
   String get video_jimaku_filter => '篩選結果（如 WEBRip、BD）';
   @override
@@ -110747,6 +110808,10 @@ class _StringsZhHk extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get video_jimaku_format => 'Format';
+  @override
+  String get video_jimaku_format_all => 'All';
 }
 
 /// Flat map(s) containing all translations.
@@ -115320,7 +115385,7 @@ extension on _StringsEn {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Auto-fetch subtitles (Jimaku)';
+        return 'Fetch subtitles (Jimaku)';
       case 'video_jimaku_filter':
         return 'Filter results (e.g. WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -116727,6 +116792,10 @@ extension on _StringsEn {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -121297,7 +121366,7 @@ extension on _StringsAr {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'جلب الترجمات تلقائيًا (Jimaku)';
+        return 'جلب الترجمات (Jimaku)';
       case 'video_jimaku_filter':
         return 'تصفية النتائج (مثل WEBRip وBD)';
       case 'video_jimaku_find_sources':
@@ -122705,6 +122774,10 @@ extension on _StringsAr {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -127296,7 +127369,7 @@ extension on _StringsDe {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Untertitel automatisch holen (Jimaku)';
+        return 'Untertitel holen (Jimaku)';
       case 'video_jimaku_filter':
         return 'Ergebnisse filtern (z. B. WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -128705,6 +128778,10 @@ extension on _StringsDe {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -133296,7 +133373,7 @@ extension on _StringsEs {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Obtener subtítulos automáticamente (Jimaku)';
+        return 'Obtener subtítulos (Jimaku)';
       case 'video_jimaku_filter':
         return 'Filtrar resultados (p. ej. WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -134704,6 +134781,10 @@ extension on _StringsEs {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -139300,7 +139381,7 @@ extension on _StringsFr {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Récupération auto des sous-titres (Jimaku)';
+        return 'Récupérer les sous-titres (Jimaku)';
       case 'video_jimaku_filter':
         return 'Filtrer les résultats (ex. WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -140709,6 +140790,10 @@ extension on _StringsFr {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -145288,7 +145373,7 @@ extension on _StringsId {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Ambil subtitle otomatis (Jimaku)';
+        return 'Ambil subtitle (Jimaku)';
       case 'video_jimaku_filter':
         return 'Saring hasil (mis. WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -146696,6 +146781,10 @@ extension on _StringsId {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -151288,7 +151377,7 @@ extension on _StringsIt {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Recupero automatico sottotitoli (Jimaku)';
+        return 'Recupera sottotitoli (Jimaku)';
       case 'video_jimaku_filter':
         return 'Filtra risultati (es. WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -152697,6 +152786,10 @@ extension on _StringsIt {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -157254,7 +157347,7 @@ extension on _StringsJa {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return '字幕を自動取得（Jimaku）';
+        return '字幕を取得（Jimaku）';
       case 'video_jimaku_filter':
         return '結果を絞り込み（WEBRip、BD など）';
       case 'video_jimaku_find_sources':
@@ -158660,6 +158753,10 @@ extension on _StringsJa {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -163220,7 +163317,7 @@ extension on _StringsKo {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return '자막 자동 가져오기(Jimaku)';
+        return '자막 가져오기(Jimaku)';
       case 'video_jimaku_filter':
         return '결과 필터(예: WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -164627,6 +164724,10 @@ extension on _StringsKo {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -169212,7 +169313,7 @@ extension on _StringsNl {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Ondertitels automatisch ophalen (Jimaku)';
+        return 'Ondertitels ophalen (Jimaku)';
       case 'video_jimaku_filter':
         return 'Resultaten filteren (bijv. WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -170622,6 +170723,10 @@ extension on _StringsNl {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -175206,7 +175311,7 @@ extension on _StringsPtBr {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Buscar legendas automaticamente (Jimaku)';
+        return 'Buscar legendas (Jimaku)';
       case 'video_jimaku_filter':
         return 'Filtrar resultados (ex.: WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -176614,6 +176719,10 @@ extension on _StringsPtBr {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -181203,7 +181312,7 @@ extension on _StringsRu {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Авто-загрузка субтитров (Jimaku)';
+        return 'Загрузить субтитры (Jimaku)';
       case 'video_jimaku_filter':
         return 'Фильтр результатов (например, WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -182611,6 +182720,10 @@ extension on _StringsRu {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -187183,7 +187296,7 @@ extension on _StringsTh {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'ดึงคำบรรยายอัตโนมัติ (Jimaku)';
+        return 'ดึงคำบรรยาย (Jimaku)';
       case 'video_jimaku_filter':
         return 'กรองผลลัพธ์ (เช่น WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -188591,6 +188704,10 @@ extension on _StringsTh {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -193171,7 +193288,7 @@ extension on _StringsTr {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Altyazıları otomatik getir (Jimaku)';
+        return 'Altyazıları getir (Jimaku)';
       case 'video_jimaku_filter':
         return 'Sonuçları filtrele (ör. WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -194580,6 +194697,10 @@ extension on _StringsTr {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -199157,7 +199278,7 @@ extension on _StringsVi {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return 'Tự lấy phụ đề (Jimaku)';
+        return 'Lấy phụ đề (Jimaku)';
       case 'video_jimaku_filter':
         return 'Lọc kết quả (vd WEBRip, BD)';
       case 'video_jimaku_find_sources':
@@ -200565,6 +200686,10 @@ extension on _StringsVi {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }
@@ -205102,7 +205227,7 @@ extension on _StringsZhCn {
       case 'video_jimaku_episode_hint':
         return '留空列出全部';
       case 'video_jimaku_fetch':
-        return '自动获取字幕（Jimaku）';
+        return '获取字幕（Jimaku）';
       case 'video_jimaku_filter':
         return '筛选结果（如 WEBRip、BD）';
       case 'video_jimaku_find_sources':
@@ -206497,6 +206622,10 @@ extension on _StringsZhCn {
         return '暂停';
       case 'download_task_resume':
         return '恢复';
+      case 'video_jimaku_format':
+        return '类型';
+      case 'video_jimaku_format_all':
+        return '全部';
       default:
         return null;
     }
@@ -211050,7 +211179,7 @@ extension on _StringsZhHk {
       case 'video_jimaku_episode_hint':
         return 'Leave empty to list all';
       case 'video_jimaku_fetch':
-        return '自動取得字幕（Jimaku）';
+        return '取得字幕（Jimaku）';
       case 'video_jimaku_filter':
         return '篩選結果（如 WEBRip、BD）';
       case 'video_jimaku_find_sources':
@@ -212455,6 +212584,10 @@ extension on _StringsZhHk {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'video_jimaku_format':
+        return 'Format';
+      case 'video_jimaku_format_all':
+        return 'All';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Subtitle downloaded and applied",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Auto-fetch subtitles (Jimaku)",
+  "video_jimaku_fetch": "Fetch subtitles (Jimaku)",
   "video_jimaku_filter": "Filter results (e.g. WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "تم تنزيل الترجمة وتطبيقها",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "جلب الترجمات تلقائيًا (Jimaku)",
+  "video_jimaku_fetch": "جلب الترجمات (Jimaku)",
   "video_jimaku_filter": "تصفية النتائج (مثل WEBRip وBD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Untertitel heruntergeladen und angewendet",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Untertitel automatisch holen (Jimaku)",
+  "video_jimaku_fetch": "Untertitel holen (Jimaku)",
   "video_jimaku_filter": "Ergebnisse filtern (z. B. WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Subtítulo descargado y aplicado",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Obtener subtítulos automáticamente (Jimaku)",
+  "video_jimaku_fetch": "Obtener subtítulos (Jimaku)",
   "video_jimaku_filter": "Filtrar resultados (p. ej. WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Sous-titre téléchargé et appliqué",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Récupération auto des sous-titres (Jimaku)",
+  "video_jimaku_fetch": "Récupérer les sous-titres (Jimaku)",
   "video_jimaku_filter": "Filtrer les résultats (ex. WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Subtitle diunduh dan diterapkan",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Ambil subtitle otomatis (Jimaku)",
+  "video_jimaku_fetch": "Ambil subtitle (Jimaku)",
   "video_jimaku_filter": "Saring hasil (mis. WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Sottotitoli scaricati e applicati",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Recupero automatico sottotitoli (Jimaku)",
+  "video_jimaku_fetch": "Recupera sottotitoli (Jimaku)",
   "video_jimaku_filter": "Filtra risultati (es. WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "字幕をダウンロードして適用しました",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "字幕を自動取得（Jimaku）",
+  "video_jimaku_fetch": "字幕を取得（Jimaku）",
   "video_jimaku_filter": "結果を絞り込み（WEBRip、BD など）",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "자막을 다운로드해 적용했습니다",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "자막 자동 가져오기(Jimaku)",
+  "video_jimaku_fetch": "자막 가져오기(Jimaku)",
   "video_jimaku_filter": "결과 필터(예: WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Ondertitel gedownload en toegepast",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Ondertitels automatisch ophalen (Jimaku)",
+  "video_jimaku_fetch": "Ondertitels ophalen (Jimaku)",
   "video_jimaku_filter": "Resultaten filteren (bijv. WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Legenda baixada e aplicada",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Buscar legendas automaticamente (Jimaku)",
+  "video_jimaku_fetch": "Buscar legendas (Jimaku)",
   "video_jimaku_filter": "Filtrar resultados (ex.: WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Субтитры загружены и применены",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Авто-загрузка субтитров (Jimaku)",
+  "video_jimaku_fetch": "Загрузить субтитры (Jimaku)",
   "video_jimaku_filter": "Фильтр результатов (например, WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "ดาวน์โหลดและใช้คำบรรยายแล้ว",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "ดึงคำบรรยายอัตโนมัติ (Jimaku)",
+  "video_jimaku_fetch": "ดึงคำบรรยาย (Jimaku)",
   "video_jimaku_filter": "กรองผลลัพธ์ (เช่น WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Altyazı indirildi ve uygulandı",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Altyazıları otomatik getir (Jimaku)",
+  "video_jimaku_fetch": "Altyazıları getir (Jimaku)",
   "video_jimaku_filter": "Sonuçları filtrele (ör. WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "Đã tải và áp dụng phụ đề",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "Tự lấy phụ đề (Jimaku)",
+  "video_jimaku_fetch": "Lấy phụ đề (Jimaku)",
   "video_jimaku_filter": "Lọc kết quả (vd WEBRip, BD)",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "字幕已下载并应用",
   "video_jimaku_episode": "集数（可选）",
   "video_jimaku_episode_hint": "留空列出全部",
-  "video_jimaku_fetch": "自动获取字幕（Jimaku）",
+  "video_jimaku_fetch": "获取字幕（Jimaku）",
   "video_jimaku_filter": "筛选结果（如 WEBRip、BD）",
   "video_jimaku_find_sources": "查找字幕",
   "video_jimaku_language": "语言",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "移动中",
   "download_task_status_error": "出错",
   "download_task_pause": "暂停",
-  "download_task_resume": "恢复"
+  "download_task_resume": "恢复",
+  "video_jimaku_format": "类型",
+  "video_jimaku_format_all": "全部"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2232,7 +2232,7 @@
   "video_jimaku_downloaded": "字幕已下載並套用",
   "video_jimaku_episode": "Episode (optional)",
   "video_jimaku_episode_hint": "Leave empty to list all",
-  "video_jimaku_fetch": "自動取得字幕（Jimaku）",
+  "video_jimaku_fetch": "取得字幕（Jimaku）",
   "video_jimaku_filter": "篩選結果（如 WEBRip、BD）",
   "video_jimaku_find_sources": "Find subtitles",
   "video_jimaku_language": "Language",
@@ -2910,5 +2910,7 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "video_jimaku_format": "Format",
+  "video_jimaku_format_all": "All"
 }

--- a/hibiki/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/jimaku_subtitle_dialog.dart
@@ -23,6 +23,10 @@ class JimakuCandidate {
 
   /// 从文件名解析出的集号（认不出为 null），用于按集升序排列。
   int? get episode => file.episode;
+
+  /// 字幕文件类型（扩展名小写不含点，如 `ass`/`srt`）。候选在入列前已过
+  /// [JimakuFile.isTextSubtitle]，故这里恒是四种可解析文本格式之一。
+  String get format => file.extension;
 }
 
 /// 给候选排序，消除 Jimaku 返回的乱序（用户报「集数是乱的」的根因是全程无排序）。
@@ -78,6 +82,35 @@ List<String> availableLanguages(List<JimakuCandidate> candidates) {
     if (present.remove(lang)) out.add(lang);
   }
   out.addAll(present);
+  return out;
+}
+
+/// 按字幕类型（扩展名）筛选候选。[format] 为 null（= 全部）时原样返回；非 null 时只留
+/// 该类型的候选（如 `ass` 只留 ASS/字幕特效轨）。纯函数，便于单测。
+///
+/// 与 [filterCandidatesByLanguage] 同构：两个维度各自独立，调用方按「语言 → 类型」串联。
+List<JimakuCandidate> filterCandidatesByFormat(
+    List<JimakuCandidate> candidates, String? format) {
+  if (format == null) return candidates;
+  return candidates
+      .where((JimakuCandidate c) => c.format == format)
+      .toList(growable: false);
+}
+
+/// 候选里出现过的字幕类型集合（去重，稳定顺序 ass/srt/ssa/vtt 优先，未知格式按字典序
+/// 追在后面）。用于渲染类型筛选 chip；只出现一种类型时调用方不必渲染该区。纯函数。
+List<String> availableFormats(List<JimakuCandidate> candidates) {
+  const List<String> order = <String>['ass', 'srt', 'ssa', 'vtt'];
+  final Set<String> present = <String>{};
+  for (final JimakuCandidate c in candidates) {
+    if (c.format.isNotEmpty) present.add(c.format);
+  }
+  final List<String> out = <String>[];
+  for (final String format in order) {
+    if (present.remove(format)) out.add(format);
+  }
+  final List<String> rest = present.toList()..sort();
+  out.addAll(rest);
   return out;
 }
 
@@ -159,6 +192,11 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
   /// 当前选中的语言筛选；null = 「全部」（不过滤）。
   String? _selectedLanguage;
 
+  /// 当前选中的字幕类型筛选（扩展名，如 `ass`）；null = 「全部」（不过滤）。
+  /// 与语言不同，**不做跨会话记忆**：同一番不同来源的可用类型差别很大，记住一个类型
+  /// 反而常让下次搜索空屏。
+  String? _selectedFormat;
+
   /// 上次搜索是否带了集数（用于「该集无结果」时显示「显示全部集」出口）。
   bool _searchedWithEpisode = false;
 
@@ -180,7 +218,7 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
       _candidates = List<JimakuCandidate>.unmodifiable(seed);
       _searched = true;
       _apiKeyCollapsed = widget.initialApiKey.trim().isNotEmpty;
-      _reconcileSelectedLanguage();
+      _reconcileSelectedFilters();
     }
     final List<AniListMedia>? seedSeries = widget.debugInitialSeriesMatches;
     if (seedSeries != null && seedSeries.isNotEmpty) {
@@ -189,12 +227,16 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     }
   }
 
-  /// 把记忆/选中的语言与当前候选对齐：记忆语言本次结果里没出现 → 退回「全部」
-  /// （保底：绝不因记忆语言无候选而空屏）。
-  void _reconcileSelectedLanguage() {
+  /// 把记忆/选中的筛选（语言 + 类型）与当前候选对齐：本次结果里没出现的值 → 退回
+  /// 「全部」（保底：绝不因上一轮的筛选值在新结果里无候选而空屏）。
+  void _reconcileSelectedFilters() {
     final String? lang = _selectedLanguage;
     if (lang != null && !availableLanguages(_candidates).contains(lang)) {
       _selectedLanguage = null;
+    }
+    final String? format = _selectedFormat;
+    if (format != null && !availableFormats(_candidates).contains(format)) {
+      _selectedFormat = null;
     }
   }
 
@@ -311,8 +353,8 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         _searched = true;
         _searchedWithEpisode = episode != null;
         _selectedSeriesId = anilistId;
-        // 记忆语言本次无候选 → 退回「全部」，不空屏（保底）。
-        _reconcileSelectedLanguage();
+        // 记忆语言 / 上轮类型本次无候选 → 退回「全部」，不空屏（保底）。
+        _reconcileSelectedFilters();
         // 配好 key 且搜出结果后，默认收起 API key 输入区腾出列表空间
         // （用户：「apikey 配完是不是可以缩小显示」）。用户仍可点「修改」展开。
         _apiKeyCollapsed = sorted.isNotEmpty;
@@ -393,6 +435,11 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     if (lang != null) {
       await widget.onPreferredLanguageChanged?.call(lang);
     }
+  }
+
+  /// 选某字幕类型（[format]=null 即「全部」）：只更新筛选，不持久化（见 [_selectedFormat]）。
+  void _selectFormat(String? format) {
+    setState(() => _selectedFormat = format);
   }
 
   /// 「显示全部集」：清空集数框并重搜（不带 episode），从 Jimaku 启发式误伤里逃生。
@@ -480,6 +527,27 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
     ]);
   }
 
+  /// 字幕类型筛选分区（含「全部」）：用户按 ass / srt 挑格式（ASS 带样式特效、
+  /// srt 纯文本）。只有一种类型时整区不渲染——单选项的筛选器是纯噪声。
+  Widget _buildFormatChips() {
+    final List<String> formats = availableFormats(_candidates);
+    if (formats.length < 2) return const SizedBox.shrink();
+    return _chipSection(t.video_jimaku_format, <Widget>[
+      ChoiceChip(
+        label: Text(t.video_jimaku_format_all),
+        selected: _selectedFormat == null,
+        onSelected: (_) => _selectFormat(null),
+      ),
+      for (final String format in formats)
+        ChoiceChip(
+          // 类型名是文件扩展名本身（ASS / SRT），不进 i18n：它是格式标识不是可译词。
+          label: Text(format.toUpperCase()),
+          selected: _selectedFormat == format,
+          onSelected: (_) => _selectFormat(format),
+        ),
+    ]);
+  }
+
   /// 宽屏两栏的最小内容宽（dp）：≥ 此宽度筛选面板与结果列表左右并排，否则退化为
   /// 上下两段（手机竖屏）。720 顶宽减 48 padding 后 672 必两栏；360dp 手机竖屏内容
   /// 宽 ~296 必单栏；横屏手机（640+）正好用两栏吃掉「矮而宽」。
@@ -532,6 +600,7 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
           if (_candidates.isNotEmpty) ...<Widget>[
             const SizedBox(height: 12),
             _buildLanguageChips(),
+            _buildFormatChips(),
             TextField(
               decoration: InputDecoration(
                 labelText: t.video_jimaku_filter,
@@ -583,9 +652,13 @@ class _JimakuSubtitleDialogState extends State<JimakuSubtitleDialog>
         ),
       );
     }
-    // 先按语言筛选（_selectedLanguage），再交给列表做关键词二次筛选。
+    // 先按语言筛选（_selectedLanguage）、再按类型筛选（_selectedFormat），最后交给
+    // 列表做关键词二次筛选。三层各自独立、顺序不影响结果集。
     return JimakuCandidateList(
-      candidates: filterCandidatesByLanguage(_candidates, _selectedLanguage),
+      candidates: filterCandidatesByFormat(
+        filterCandidatesByLanguage(_candidates, _selectedLanguage),
+        _selectedFormat,
+      ),
       filter: _filter,
       busyName: _busyName,
       onDownload: _busyName == null ? _download : null,

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -383,37 +383,69 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     }
     // BUG-939：已为当前视频枚举过就直接用缓存，不再重跑 ffprobe、不再显加载条。
     // 修「每次进字幕分类都要加载、明明没可加载的地方」——无内嵌轨/外挂的视频枚举结果
-    // 恒空，但只跑一次；有轨的视频重开时也不再把已枚举的字幕轨先清空重来。缓存在换视频
-    // （路径变）与导入新字幕档（[_invalidateSubtitleMenuSourcesCache]）时失效。
+    // 恒空，但只跑一次；有轨的视频重开时也不再把已枚举的字幕轨先清空重来。缓存只在换视频
+    // （路径变）时失效；导入/下载新字幕档不再作废整份缓存，而是就地并入
+    // （BUG-1329 [_registerImportedSubtitleSource]），省掉一整趟无谓的容器重探。
     if (_subtitleMenuSourcesPath == videoPath) return;
     if (_subtitleMenuLoading) return;
     _rebuild(() => _subtitleMenuLoading = true);
-    final List<SubtitleSource> sources;
+    // 枚举失败（ffmpeg 偶发失败 / 缺失）用 null 表达，与「枚举出空列表」区分：前者不写
+    // 缓存 key（下次打开重试，不被缓存成「已加载空」），后者是有效结果。单出口收敛加载
+    // 态，[_subtitleMenuLoading] 不存在任何提前 return 把它留在 true 的分支。
+    List<SubtitleSource>? enumerated;
     try {
-      sources = await _subtitleSourcesForMenu(
+      enumerated = await _subtitleSourcesForMenu(
         videoPath: videoPath,
         currentSubtitleSource: _currentSubtitleSource,
         currentCues: controller.cues,
       );
     } catch (_) {
-      // 枚举失败不写缓存 key，下次打开重试（ffprobe 偶发失败不该被缓存成「已加载空」）。
-      if (!mounted) return;
-      _rebuild(() => _subtitleMenuLoading = false);
-      return;
+      enumerated = null;
     }
     if (!mounted) return;
+    final List<SubtitleSource>? sources = enumerated;
     _rebuild(() {
-      _subtitleMenuSources = sources;
       _subtitleMenuLoading = false;
-      _subtitleMenuSourcesPath = videoPath;
+      if (sources != null) {
+        _subtitleMenuSources = sources;
+        _subtitleMenuSourcesPath = videoPath;
+      }
     });
   }
 
-  /// BUG-939：让字幕轨枚举缓存失效（下次打开「字幕」分类重新 ffprobe 枚举）。导入新字幕
-  /// 档（[_importExternalSubtitleInner] / Jimaku 下载）后调用——新档不在旧枚举结果里，
-  /// 靠这条让它下次出现在字幕轨列表。换视频不需调它（缓存 key 是视频路径，路径变自然失效）。
-  void _invalidateSubtitleMenuSourcesCache() {
-    _subtitleMenuSourcesPath = null;
+  /// BUG-1329：把刚落盘的外挂字幕档（[_importExternalSubtitleInner] 导入 / Jimaku 下载）
+  /// **当场**并入字幕轨枚举结果，让它立刻出现在「字幕」分类的字幕轨列表里。
+  ///
+  /// 取代旧的「清掉 [_subtitleMenuSourcesPath]、等下次进入字幕分类重新枚举」（BUG-939
+  /// 留下的缓存作废式刷新）。旧做法有两个真实症状：
+  ///  1. **列表不刷新**：下载/导入几乎总是**从已经打开的「字幕」分类里发起**的，而重新
+  ///     枚举的唯一驱动事件是「进入字幕分类」
+  ///     （[VideoQuickSettingsSheet.onSubtitleCategoryShown]）——面板不关、分类不切，它
+  ///     永远不会再触发，列表就停在旧结果，用户看不到自己刚下载的字幕。
+  ///  2. **长时间加载条**：真去重新枚举时又要对整个容器重跑一遍 `ffmpeg -i`（超时预算按
+  ///     文件体积放大），字幕轨区顶部的 [LinearProgressIndicator] 一直转——而这趟探测
+  ///     带来的唯一新信息，就是我们手里这个已知路径的外挂文件。
+  ///
+  /// 新档是本 app 刚写下的外挂文件，路径与标签都在手里，没有任何需要向 ffmpeg 求证的
+  /// 东西：直接插到列表首位（与 [includeCurrentPersistedSubtitleForMenu] 的「当前导入排
+  /// 最前」约定一致），内嵌轨枚举缓存保持有效、不重探。尚未为当前视频枚举过（缓存 key
+  /// 不匹配）时什么都不做——首次枚举本就会经 [includeCurrentPersistedSubtitleForMenu]
+  /// 把它带上。远端视频没有本地枚举列表（走 host / YouTube 轨），直接跳过。
+  void _registerImportedSubtitleSource(String path) {
+    if (_isRemote) return;
+    final String? videoPath = _currentVideoPath;
+    if (videoPath == null || _subtitleMenuSourcesPath != videoPath) return;
+    final bool alreadyListed = _subtitleMenuSources.any(
+      (SubtitleSource source) => sameExternalSubtitlePathForMenu(source, path),
+    );
+    if (alreadyListed) return;
+    final SubtitleSource added = SubtitleSource.external(
+      externalPath: path,
+      label: p.basename(path),
+    );
+    _rebuild(() {
+      _subtitleMenuSources = <SubtitleSource>[added, ..._subtitleMenuSources];
+    });
   }
 
   /// 选中某副字幕源（TODO-857 / TODO-1312）：抽 cue → [VideoPlayerController.setSecondaryCues]
@@ -598,10 +630,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
       label: p.basename(downloaded),
     );
     final bool applied = await _selectSubtitleSource(controller, source);
-    // BUG-939：Jimaku 下载的新字幕档不在旧枚举结果里 → 失效缓存，下次打开字幕分类重枚举。
-    if (applied) {
-      _invalidateSubtitleMenuSourcesCache();
-    }
+    // BUG-1329：下载的新档当场并入字幕轨列表（用户就站在「字幕」分类里看着它）。**不**按
+    // applied 门控：文件已经在盘上了，即使这次解析不出 cue（坏档/编码问题）也该列出来，
+    // 否则用户下载完看不到任何东西、只能猜自己有没有下成功。
+    _registerImportedSubtitleSource(downloaded);
     // 仅在字幕真被应用（解析出 cue）时报「已下载并应用」；cue 为空时
     // _selectSubtitleSource 已弹失败提示，不再叠加误导性的成功提示。
     if (applied && mounted) {
@@ -813,15 +845,18 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     List<AudioCue> cues = client.cachedCaptionCues(track.trackKey);
     if (cues.isEmpty) {
       if (mounted) _rebuild(() => _subtitleMenuLoading = true);
-      cues = await resolveYoutubeCaptionCues(track,
-          bookKey: 'yt:${widget.bookUid}');
-      if (!mounted) return;
-      if (loadSeq != null && loadSeq != _episodeLoadSeq) {
-        _rebuild(() => _subtitleMenuLoading = false);
-        return;
+      try {
+        cues = await resolveYoutubeCaptionCues(track,
+            bookKey: 'yt:${widget.bookUid}');
+      } finally {
+        // BUG-1329：cue 解析抛错（网络/解析异常）时也必须收掉加载态。原来靠三条各自
+        // 复位的 return 路径，抛错那条谁也没走到，[_subtitleMenuLoading] 就永久留在
+        // true——字幕轨区顶部的进度条从此一直转，且再没有任何入口能把它关掉。
+        if (mounted) _rebuild(() => _subtitleMenuLoading = false);
       }
+      if (!mounted) return;
+      if (loadSeq != null && loadSeq != _episodeLoadSeq) return;
       if (cues.isNotEmpty) client.cacheCaptionCues(track.trackKey, cues);
-      _rebuild(() => _subtitleMenuLoading = false);
     }
     if (cues.isEmpty) {
       // 手选到空轨（机翻失败 / 该轨无文字）：提示；自动应用（loadSeq!=null）静默不打扰。
@@ -882,9 +917,8 @@ extension _VideoSubtitle on _VideoHibikiPageState {
       label: p.basename(dest),
     );
     await _selectSubtitleSource(controller, source);
-    // BUG-939：导入了新外挂字幕档，它不在旧枚举结果里 → 失效缓存，下次打开「字幕」分类
-    // 重新枚举把它列进字幕轨列表。
-    _invalidateSubtitleMenuSourcesCache();
+    // BUG-1329：导入的新外挂字幕档当场并入字幕轨列表（不再等「下次进入字幕分类」重枚举）。
+    _registerImportedSubtitleSource(dest);
     debugPrint(
       '[hibiki-drop] [video-playback] externalSubtitle imported '
       'path=$dest',

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -1118,7 +1118,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// （ffprobe 探测内嵌轨 + 同目录外挂）按此 key 记忆：同一视频重开「字幕」分类直接
   /// 用缓存渲染，不再每次重跑 ffprobe 显加载条、也不再把已枚举出的字幕轨先清空重来
   /// （用户报「字幕轨每次都要加载、明明没可加载的地方；之前有的字幕还会消失要等」）。
-  /// null=尚未为当前视频枚举 / 已失效（换视频、导入新字幕档）→ 下次打开重新枚举。
+  /// null=尚未为当前视频枚举 / 已失效（换视频）→ 下次打开重新枚举。BUG-1329：导入或
+  /// 下载新字幕档**不**作废这个 key（那会换来一整趟无谓的容器重探 + 长时间加载条），
+  /// 新档由 `_registerImportedSubtitleSource` 就地并入 `_subtitleMenuSources`。
   String? _subtitleMenuSourcesPath;
 
   /// 当前视频是否有内封章节（TODO-424）：控制条章节入口按钮的显隐门控。章节列表是

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1090
+version: 1.3.1+1091
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/jimaku_filter_test.dart
+++ b/hibiki/test/pages/jimaku_filter_test.dart
@@ -81,6 +81,67 @@ void main() {
     });
   });
 
+  group('format filter（按字幕类型筛选，用户要「只看 ass 的」）', () {
+    final List<JimakuCandidate> candidates = <JimakuCandidate>[
+      _cand('ep01.ja.srt'),
+      _cand('ep01.ja.ass'),
+      _cand('ep02.zh.ASS'), // 大写扩展名也要归到 ass
+      _cand('ep03.ja.vtt'),
+    ];
+
+    test('null（全部）不过滤', () {
+      expect(filterCandidatesByFormat(candidates, null), candidates);
+    });
+
+    test('选 ass 只留 ass 候选（含大写扩展名）', () {
+      final List<JimakuCandidate> out =
+          filterCandidatesByFormat(candidates, 'ass');
+      expect(out.map((JimakuCandidate c) => c.file.name),
+          <String>['ep01.ja.ass', 'ep02.zh.ASS']);
+    });
+
+    test('选 srt 不会漏进 ass', () {
+      final List<JimakuCandidate> out =
+          filterCandidatesByFormat(candidates, 'srt');
+      expect(
+          out.map((JimakuCandidate c) => c.file.name), <String>['ep01.ja.srt']);
+    });
+
+    test('availableFormats 去重 + ass/srt/ssa/vtt 稳定顺序', () {
+      expect(availableFormats(candidates), <String>['ass', 'srt', 'vtt']);
+      expect(
+        availableFormats(<JimakuCandidate>[
+          _cand('a.vtt'),
+          _cand('b.ssa'),
+          _cand('c.srt'),
+          _cand('d.ass'),
+        ]),
+        <String>['ass', 'srt', 'ssa', 'vtt'],
+      );
+    });
+
+    test('只有一种类型时 availableFormats 仍返回它（由 UI 决定不渲染单选项筛选区）', () {
+      expect(
+          availableFormats(<JimakuCandidate>[_cand('a.srt'), _cand('b.srt')]),
+          <String>['srt']);
+    });
+
+    test('语言 + 类型两层筛选可叠加，且顺序无关', () {
+      final List<JimakuCandidate> langThenFormat = filterCandidatesByFormat(
+        filterCandidatesByLanguage(candidates, 'ja'),
+        'ass',
+      );
+      final List<JimakuCandidate> formatThenLang = filterCandidatesByLanguage(
+        filterCandidatesByFormat(candidates, 'ass'),
+        'ja',
+      );
+      expect(langThenFormat.map((JimakuCandidate c) => c.file.name),
+          <String>['ep01.ja.ass']);
+      expect(formatThenLang.map((JimakuCandidate c) => c.file.name),
+          langThenFormat.map((JimakuCandidate c) => c.file.name));
+    });
+  });
+
   group('sortJimakuCandidates（消除集数乱序）', () {
     test('同语言按集号升序，认不出集号排末尾', () {
       final List<JimakuCandidate> sorted =

--- a/hibiki/test/pages/jimaku_format_filter_widget_test.dart
+++ b/hibiki/test/pages/jimaku_format_filter_widget_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/video/jimaku_client.dart';
+import 'package:hibiki/src/pages/implementations/jimaku_subtitle_dialog.dart';
+import 'package:hibiki/utils.dart';
+
+/// 「获取字幕（Jimaku）」对话框的**类型筛选**（用户：「支持筛选类型，也就是 ass 的」）。
+///
+/// 纯函数层（[filterCandidatesByFormat] / [availableFormats]）在 `jimaku_filter_test.dart`
+/// 里断言；这里驱动真对话框，锁住三条 UI 契约：类型 chip 真渲染、点它真过滤列表、
+/// 只有一种类型时整区不出现（单选项筛选器是纯噪声）。
+void main() {
+  JimakuCandidate cand(String name) => JimakuCandidate(
+        entryName: 'Some Anime Series',
+        file: JimakuFile(name: name, url: 'https://x/$name'),
+      );
+
+  Future<void> pumpDialog(
+    WidgetTester tester,
+    List<JimakuCandidate> candidates,
+  ) async {
+    // 宽屏两栏：筛选面板与结果列表同屏可见，chip 与候选行不用滚动即可命中。
+    tester.view.physicalSize = const Size(1200, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Builder(builder: (BuildContext ctx) {
+            return ElevatedButton(
+              onPressed: () => showDialog<String>(
+                context: ctx,
+                builder: (_) => JimakuSubtitleDialog(
+                  initialQuery: 'Some Anime',
+                  initialApiKey: 'TEST_KEY',
+                  onApiKeyChanged: (_) async {},
+                  saveDirectory: '/tmp/jimaku',
+                  debugInitialCandidates: candidates,
+                ),
+              ),
+              child: const Text('open'),
+            );
+          }),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'), warnIfMissed: false);
+    await tester.pumpAndSettle();
+  }
+
+  /// 类型分区（`_chipSection` 的 Column）：最近的那个 Column 祖先就是它。
+  /// 必须限定在这个分区里找 chip——「全部」在语言区也有一个同名 chip。
+  Finder formatSection() => find
+      .ancestor(
+        of: find.text(t.video_jimaku_format),
+        matching: find.byType(Column),
+      )
+      .first;
+
+  Finder formatChip(String label) => find.descendant(
+        of: formatSection(),
+        matching: find.widgetWithText(ChoiceChip, label),
+      );
+
+  final List<JimakuCandidate> mixed = <JimakuCandidate>[
+    cand('Show - 01.ja.srt'),
+    cand('Show - 01.ja.ass'),
+    cand('Show - 02.ja.ass'),
+  ];
+
+  testWidgets('混合类型时渲染 ASS / SRT 类型 chip', (WidgetTester tester) async {
+    await pumpDialog(tester, mixed);
+    expect(find.text(t.video_jimaku_format), findsOneWidget);
+    expect(formatChip('ASS'), findsOneWidget);
+    expect(formatChip('SRT'), findsOneWidget);
+    expect(formatChip(t.video_jimaku_format_all), findsOneWidget);
+    // 未选类型时三条候选都在。
+    expect(find.text('Show - 01.ja.srt'), findsOneWidget);
+    expect(find.text('Show - 01.ja.ass'), findsOneWidget);
+    expect(find.text('Show - 02.ja.ass'), findsOneWidget);
+  });
+
+  testWidgets('点 ASS 只剩 ass 候选，点「全部」还原', (WidgetTester tester) async {
+    await pumpDialog(tester, mixed);
+
+    await tester.tap(formatChip('ASS'));
+    await tester.pumpAndSettle();
+    expect(find.text('Show - 01.ja.srt'), findsNothing,
+        reason: '选了 ass 之后 srt 候选必须从列表里消失');
+    expect(find.text('Show - 01.ja.ass'), findsOneWidget);
+    expect(find.text('Show - 02.ja.ass'), findsOneWidget);
+
+    await tester.tap(formatChip(t.video_jimaku_format_all));
+    await tester.pumpAndSettle();
+    expect(find.text('Show - 01.ja.srt'), findsOneWidget,
+        reason: '「全部」必须把被筛掉的候选放回来');
+  });
+
+  testWidgets('只有一种类型时不渲染类型筛选区', (WidgetTester tester) async {
+    await pumpDialog(tester, <JimakuCandidate>[
+      cand('Show - 01.ja.srt'),
+      cand('Show - 02.ja.srt'),
+    ]);
+    expect(find.text(t.video_jimaku_format), findsNothing,
+        reason: '所有候选都是同一种类型时，类型筛选器无从筛起，不该占版面');
+  });
+}

--- a/hibiki/test/pages/video_subtitle_menu_refresh_guard_test.dart
+++ b/hibiki/test/pages/video_subtitle_menu_refresh_guard_test.dart
@@ -12,12 +12,19 @@ import 'video_hibiki_page_source_corpus.dart';
 void main() {
   final String src = readVideoHibikiSource();
 
+  /// 剥掉整行注释。源码扫描守卫若把注释也算数，「把调用点注释掉」这种改动就能原样
+  /// 骗过它（本仓已被这类假绿咬过多次）；所以下面所有 contains 断言都跑在纯代码上。
+  String codeOnly(String source) => source
+      .split('\n')
+      .where((String line) => !line.trimLeft().startsWith('//'))
+      .join('\n');
+
   String region(String startSig, String endSig) {
     final int start = src.indexOf(startSig);
     expect(start, greaterThanOrEqualTo(0), reason: 'missing $startSig');
     final int end = src.indexOf(endSig, start + startSig.length);
     expect(end, greaterThan(start), reason: 'missing $endSig after $startSig');
-    return src.substring(start, end);
+    return codeOnly(src.substring(start, end));
   }
 
   test('BUG-1329: Jimaku 下载完把新档就地并入字幕轨列表', () {

--- a/hibiki/test/pages/video_subtitle_menu_refresh_guard_test.dart
+++ b/hibiki/test/pages/video_subtitle_menu_refresh_guard_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'video_hibiki_page_source_corpus.dart';
+
+/// BUG-1329 的静态守卫：下载 / 导入字幕后，字幕轨列表必须**当场**多出那一条，而不是
+/// 作废整份枚举缓存、等一个在面板已经开着时永远不会再来的「进入字幕分类」事件。
+///
+/// media_kit 跑不了 headless、ffmpeg 枚举也不能在单测里真跑，所以这里锁调用点契约：
+///  - 两个落盘点（Jimaku 下载 / 外挂导入）都调 `_registerImportedSubtitleSource`；
+///  - 旧的 `_invalidateSubtitleMenuSourcesCache`（清缓存 key 等下次重探）彻底消失；
+///  - `_subtitleMenuLoading` 的每一个置真点都有配对的收敛路径，不存在「抛错就永远转圈」。
+void main() {
+  final String src = readVideoHibikiSource();
+
+  String region(String startSig, String endSig) {
+    final int start = src.indexOf(startSig);
+    expect(start, greaterThanOrEqualTo(0), reason: 'missing $startSig');
+    final int end = src.indexOf(endSig, start + startSig.length);
+    expect(end, greaterThan(start), reason: 'missing $endSig after $startSig');
+    return src.substring(start, end);
+  }
+
+  test('BUG-1329: Jimaku 下载完把新档就地并入字幕轨列表', () {
+    final String body = region(
+      'Future<void> _openJimakuDialog(VideoPlayerController controller) async {',
+      'Future<void> _pickAndImportSubtitle(',
+    );
+    expect(body.contains('_registerImportedSubtitleSource(downloaded)'), isTrue,
+        reason: '下载几乎总是从已经打开的「字幕」分类里发起的，只清缓存 key 不会有任何'
+            '事件把它重新枚举出来 → 用户看不到自己刚下载的字幕（BUG-1329）');
+  });
+
+  test('BUG-1329: 导入外挂字幕后把新档就地并入字幕轨列表', () {
+    final String body = region(
+      'Future<void> _importExternalSubtitleInner(',
+      'void _showSubtitleLoadingOverlay() {',
+    );
+    expect(body.contains('_registerImportedSubtitleSource(dest)'), isTrue,
+        reason: '导入落盘后同样要当场进列表，与 Jimaku 下载走同一条并入路径（BUG-1329）');
+  });
+
+  test('BUG-1329: 并入不重探容器、不重置枚举缓存 key', () {
+    final String body = region(
+      'void _registerImportedSubtitleSource(String path) {',
+      '/// 选中某副字幕源',
+    );
+    expect(body.contains('_subtitleMenuSourcesPath != videoPath'), isTrue,
+        reason: '尚未为当前视频枚举过时不该硬塞（首次枚举本就会带上它）');
+    expect(body.contains('sameExternalSubtitlePathForMenu('), isTrue,
+        reason: '已在列表里的同一路径不能再插一条重复行');
+    expect(body.contains('_subtitleMenuSourcesPath = null'), isFalse,
+        reason: '并入新档不得作废枚举缓存——那正是「重新 ffmpeg 探整个容器 + 长时间'
+            '挂加载条」的来源（BUG-1329 第二个症状）');
+    expect(body.contains('_subtitleMenuLoading'), isFalse,
+        reason: '就地并入是纯内存操作，不该点亮任何加载态');
+  });
+
+  test('BUG-1329: 旧的「清缓存等下次重探」路径已彻底移除', () {
+    // 连注释一起断言为零：留着这个名字就意味着还有别的调用点在走旧语义。
+    expect(src.contains('_invalidateSubtitleMenuSourcesCache'), isFalse,
+        reason: '缓存作废式刷新已被就地并入取代，不得残留（BUG-1329）');
+  });
+
+  test('BUG-1329: YouTube 字幕轨 cue 解析抛错也要收掉加载条', () {
+    final String body = region(
+      'Future<void> _applyYoutubeCaptionTrack(',
+      'Future<void> _importExternalSubtitle(',
+    );
+    final int resolve = body.indexOf('resolveYoutubeCaptionCues(');
+    expect(resolve, greaterThanOrEqualTo(0),
+        reason: 'missing cue resolve call');
+    final int tryIdx = body.lastIndexOf('try {', resolve);
+    expect(tryIdx, greaterThanOrEqualTo(0),
+        reason: 'cue 解析必须包在 try 里，否则抛错时下面的复位语句谁也走不到');
+    final String afterResolve = body.substring(resolve);
+    final int finallyIdx = afterResolve.indexOf('} finally {');
+    expect(finallyIdx, greaterThanOrEqualTo(0),
+        reason: '必须有 finally 收敛加载态（BUG-1329）');
+    expect(
+      afterResolve
+          .substring(finallyIdx)
+          .contains('_rebuild(() => _subtitleMenuLoading = false)'),
+      isTrue,
+      reason: 'finally 里必须真把 _subtitleMenuLoading 复位；否则解析异常后字幕轨区'
+          '顶部的进度条永远转下去，且再没有入口能关掉它（BUG-1329）',
+    );
+  });
+
+  test('BUG-1329: 字幕轨枚举单出口收敛加载态', () {
+    final String body = region(
+      'Future<void> _ensureSubtitleMenuSourcesLoaded() async {',
+      'void _registerImportedSubtitleSource(',
+    );
+    // 置真恰好一次；置真之后的复位也恰好一次（函数开头远端/无路径分支里的那次
+    // `= false` 是清空态复位，不在这条加载链路上，不该被算进来）。
+    expect('_subtitleMenuLoading = true'.allMatches(body).length, 1,
+        reason: '加载态只应有一个置真点');
+    final int truePoint = body.indexOf('_subtitleMenuLoading = true');
+    final String afterTrue = body.substring(truePoint);
+    expect('_subtitleMenuLoading = false'.allMatches(afterTrue).length, 1,
+        reason: '置真之后有多个复位点，正是「某条 return 忘了复位、加载条永远转」的'
+            '温床（BUG-1329）；收敛成唯一出口');
+  });
+}


### PR DESCRIPTION
用户反馈（视频页「字幕」分类截图）三条，一并处理。

## 1. 「自动获取字幕（Jimaku）」→「获取字幕（Jimaku）」
i18n key `video_jimaku_fetch` 的**值**改名，17 语言同步（key 不动，无迁移风险）。对话框标题读同一 key，一并跟着改。

## 2. Jimaku 对话框支持按字幕类型筛选（用户要「只看 ass 的」）
- 新增纯函数 `filterCandidatesByFormat` / `availableFormats`（`jimaku_subtitle_dialog.dart`），与既有语言筛选同构、可叠加、顺序无关。
- UI：语言 chip 下面加一排类型 chip（全部 / ASS / SRT / SSA / VTT）。只出现一种类型时整区不渲染——单选项的筛选器是纯噪声。
- 类型**不做跨会话记忆**（语言是记的）：同一番不同来源可用类型差别很大，记住一个类型反而常让下次搜索空屏。
- 新 i18n key `video_jimaku_format` / `video_jimaku_format_all`（走 `i18n_sync --add`，17 语言）。

## 3. BUG-1329：下载完字幕轨列表里没有它，而且一直在加载
**根因**：字幕轨列表 `_subtitleMenuSources` 的唯一重建驱动是「进入字幕分类」事件（`onSubtitleCategoryShown`）。而下载/导入完成后代码只做 `_subtitleMenuSourcesPath = null`（作废缓存 key），**指望「下次进入字幕分类」再重枚举**——可下载几乎总是**从已经打开的那个字幕分类里**发起的，面板不关、分类不切，那个事件永远不会再来。

两个症状同源：
1. 列表原样停在旧结果，刚下载的字幕不出现（落在 `video_subtitles/` 的下载档本来也只能靠 `includeCurrentPersistedSubtitleForMenu` 在重枚举时被注入）；
2. 真去重枚举时又要对整个容器重跑 `ffmpeg -i`（超时预算按体积放大），期间字幕轨区顶部一直挂 `LinearProgressIndicator`，旧行还在、新行没有——正是截图里的样子。

**修法**：`_registerImportedSubtitleSource(path)` 取代缓存作废式刷新。新档是 app 自己刚写下的外挂文件，路径与标签都在手里，没有任何需要向 ffmpeg 求证的东西 → 直接插进列表首位（与「当前导入排最前」约定一致），枚举缓存保持有效、不重探容器。Jimaku 下载与外挂导入两个落盘点统一走它；且**不按 applied 门控**——文件已经在盘上，即使这次解析不出 cue 也该列出来，否则用户下载完看不到任何东西、只能猜自己有没有下成功。

顺带修掉同一标志上两处会让加载条转不停的结构问题：
- `_ensureSubtitleMenuSourcesLoaded` 的加载态收敛成单出口（枚举失败用 `null` 表达，不再有「某条 return 忘了复位」的分支）；
- `_applyYoutubeCaptionTrack` 的 cue 解析补上 try/finally —— 原来靠三条各自复位的 return 收尾，`resolveYoutubeCaptionCues` 抛错那条谁也走不到，`_subtitleMenuLoading` 会**永久**留在 true，且再无入口能关掉它。

## 验证
- `flutter analyze`（含 test）：No issues found。
- 定向测试 `FLUTTER TEST VERDICT: PASSED - 395 tests ran`（jimaku 筛选/对话框/entry picker/batch、视频字幕守卫、i18n、settings schema）。
- 新增源码扫描守卫 `video_subtitle_menu_refresh_guard_test.dart` 做了**变异实测**：6 条断言逐条改坏都真红（注释掉两个并入调用 / 并入时顺手作废缓存 / 旧 helper 名残留 / finally 退化成 catch / 枚举加载态多一个复位点）。守卫本身会先剥掉整行注释再断言，避免「注释掉调用点」骗过扫描。
- 未做真机复测（`_registerImportedSubtitleSource` 走的是内存列表，无法在 headless 下驱动 media_kit）。

https://claude.ai/code/session_01RUzAnwsDm69iM2aX8KQ2aj
