### PR TITLE
feat(downloads): 放送日历页（AniList airing schedule 周历，TODO-2487）

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 49504 (2912 per locale)
+/// Strings: 49674 (2922 per locale)
 ///
-/// Built on 2026-08-01 at 05:47 UTC
+/// Built on 2026-08-01 at 06:18 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3937,6 +3937,19 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get download_task_status_error => 'Error';
   String get download_task_pause => 'Pause';
   String get download_task_resume => 'Resume';
+  String get download_airing_calendar_title => 'Airing calendar';
+  String get download_airing_calendar_show_all => 'Show all this season';
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  String get download_airing_calendar_in_library => 'In library';
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  String get download_airing_calendar_week_prev => 'Previous week';
+  String get download_airing_calendar_week_next => 'Next week';
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -10635,6 +10648,29 @@ class _StringsAr extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -17400,6 +17436,29 @@ class _StringsDe extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -24181,6 +24240,29 @@ class _StringsEs extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -30973,6 +31055,29 @@ class _StringsFr extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -37694,6 +37799,29 @@ class _StringsId extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -44461,6 +44589,29 @@ class _StringsIt extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -51045,6 +51196,29 @@ class _StringsJa extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -57631,6 +57805,29 @@ class _StringsKo extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -64378,6 +64575,29 @@ class _StringsNl extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -71138,6 +71358,29 @@ class _StringsPtBr extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -77882,6 +78125,29 @@ class _StringsRu extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -84574,6 +84840,29 @@ class _StringsTh extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -91298,6 +91587,29 @@ class _StringsTr extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -98007,6 +98319,29 @@ class _StringsVi extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 // Path: <root>
@@ -104242,6 +104577,28 @@ class _StringsZhCn extends _StringsEn {
   String get download_task_pause => '暂停';
   @override
   String get download_task_resume => '恢复';
+  @override
+  String get download_airing_calendar_title => '放送日历';
+  @override
+  String get download_airing_calendar_show_all => '显示本季全部';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      '暂无可显示的放送信息：给合集绑定 AniList 或添加下载订阅后，这里会显示对应的放送时间。';
+  @override
+  String get download_airing_calendar_error => '放送时间表加载失败';
+  @override
+  String get download_airing_calendar_in_library => '已入库';
+  @override
+  String get download_airing_calendar_subscribed => '订阅中';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      '第 ${episode} 集';
+  @override
+  String get download_airing_calendar_week_prev => '上一周';
+  @override
+  String get download_airing_calendar_week_next => '下一周';
+  @override
+  String get download_airing_calendar_week_empty => '本周没有相关放送';
 }
 
 // Path: <root>
@@ -110747,6 +111104,29 @@ class _StringsZhHk extends _StringsEn {
   String get download_task_pause => 'Pause';
   @override
   String get download_task_resume => 'Resume';
+  @override
+  String get download_airing_calendar_title => 'Airing calendar';
+  @override
+  String get download_airing_calendar_show_all => 'Show all this season';
+  @override
+  String get download_airing_calendar_empty_guidance =>
+      'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+  @override
+  String get download_airing_calendar_error =>
+      'Failed to load the airing schedule';
+  @override
+  String get download_airing_calendar_in_library => 'In library';
+  @override
+  String get download_airing_calendar_subscribed => 'Subscribed';
+  @override
+  String download_airing_calendar_episode_label({required Object episode}) =>
+      'Ep ${episode}';
+  @override
+  String get download_airing_calendar_week_prev => 'Previous week';
+  @override
+  String get download_airing_calendar_week_next => 'Next week';
+  @override
+  String get download_airing_calendar_week_empty => 'Nothing airing this week';
 }
 
 /// Flat map(s) containing all translations.
@@ -116727,6 +117107,26 @@ extension on _StringsEn {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -122705,6 +123105,26 @@ extension on _StringsAr {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -128705,6 +129125,26 @@ extension on _StringsDe {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -134704,6 +135144,26 @@ extension on _StringsEs {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -140709,6 +141169,26 @@ extension on _StringsFr {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -146696,6 +147176,26 @@ extension on _StringsId {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -152697,6 +153197,26 @@ extension on _StringsIt {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -158660,6 +159180,26 @@ extension on _StringsJa {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -164627,6 +165167,26 @@ extension on _StringsKo {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -170622,6 +171182,26 @@ extension on _StringsNl {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -176614,6 +177194,26 @@ extension on _StringsPtBr {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -182611,6 +183211,26 @@ extension on _StringsRu {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -188591,6 +189211,26 @@ extension on _StringsTh {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -194580,6 +195220,26 @@ extension on _StringsTr {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -200565,6 +201225,26 @@ extension on _StringsVi {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }
@@ -206497,6 +207177,26 @@ extension on _StringsZhCn {
         return '暂停';
       case 'download_task_resume':
         return '恢复';
+      case 'download_airing_calendar_title':
+        return '放送日历';
+      case 'download_airing_calendar_show_all':
+        return '显示本季全部';
+      case 'download_airing_calendar_empty_guidance':
+        return '暂无可显示的放送信息：给合集绑定 AniList 或添加下载订阅后，这里会显示对应的放送时间。';
+      case 'download_airing_calendar_error':
+        return '放送时间表加载失败';
+      case 'download_airing_calendar_in_library':
+        return '已入库';
+      case 'download_airing_calendar_subscribed':
+        return '订阅中';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => '第 ${episode} 集';
+      case 'download_airing_calendar_week_prev':
+        return '上一周';
+      case 'download_airing_calendar_week_next':
+        return '下一周';
+      case 'download_airing_calendar_week_empty':
+        return '本周没有相关放送';
       default:
         return null;
     }
@@ -212455,6 +213155,26 @@ extension on _StringsZhHk {
         return 'Pause';
       case 'download_task_resume':
         return 'Resume';
+      case 'download_airing_calendar_title':
+        return 'Airing calendar';
+      case 'download_airing_calendar_show_all':
+        return 'Show all this season';
+      case 'download_airing_calendar_empty_guidance':
+        return 'Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.';
+      case 'download_airing_calendar_error':
+        return 'Failed to load the airing schedule';
+      case 'download_airing_calendar_in_library':
+        return 'In library';
+      case 'download_airing_calendar_subscribed':
+        return 'Subscribed';
+      case 'download_airing_calendar_episode_label':
+        return ({required Object episode}) => 'Ep ${episode}';
+      case 'download_airing_calendar_week_prev':
+        return 'Previous week';
+      case 'download_airing_calendar_week_next':
+        return 'Next week';
+      case 'download_airing_calendar_week_empty':
+        return 'Nothing airing this week';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "移动中",
   "download_task_status_error": "出错",
   "download_task_pause": "暂停",
-  "download_task_resume": "恢复"
+  "download_task_resume": "恢复",
+  "download_airing_calendar_title": "放送日历",
+  "download_airing_calendar_show_all": "显示本季全部",
+  "download_airing_calendar_empty_guidance": "暂无可显示的放送信息：给合集绑定 AniList 或添加下载订阅后，这里会显示对应的放送时间。",
+  "download_airing_calendar_error": "放送时间表加载失败",
+  "download_airing_calendar_in_library": "已入库",
+  "download_airing_calendar_subscribed": "订阅中",
+  "download_airing_calendar_episode_label": "第 ${episode} 集",
+  "download_airing_calendar_week_prev": "上一周",
+  "download_airing_calendar_week_next": "下一周",
+  "download_airing_calendar_week_empty": "本周没有相关放送"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2910,5 +2910,15 @@
   "download_task_status_moving": "Moving",
   "download_task_status_error": "Error",
   "download_task_pause": "Pause",
-  "download_task_resume": "Resume"
+  "download_task_resume": "Resume",
+  "download_airing_calendar_title": "Airing calendar",
+  "download_airing_calendar_show_all": "Show all this season",
+  "download_airing_calendar_empty_guidance": "Nothing to show yet: bind a collection to AniList or add a download subscription, and their airing times will appear here.",
+  "download_airing_calendar_error": "Failed to load the airing schedule",
+  "download_airing_calendar_in_library": "In library",
+  "download_airing_calendar_subscribed": "Subscribed",
+  "download_airing_calendar_episode_label": "Ep ${episode}",
+  "download_airing_calendar_week_prev": "Previous week",
+  "download_airing_calendar_week_next": "Next week",
+  "download_airing_calendar_week_empty": "Nothing airing this week"
 }

--- a/hibiki/lib/pages.dart
+++ b/hibiki/lib/pages.dart
@@ -13,6 +13,7 @@ export 'src/pages/implementations/history_reader_page.dart';
 export 'src/pages/implementations/home_reader_page.dart';
 export 'src/pages/implementations/home_video_page.dart';
 export 'src/pages/implementations/home_game_page.dart';
+export 'src/pages/implementations/airing_calendar_page.dart';
 export 'src/pages/implementations/downloads_page.dart';
 export 'src/pages/implementations/browser_extension_page.dart';
 export 'src/pages/implementations/home_page.dart';

--- a/hibiki/lib/src/media/video/airing_calendar_cache.dart
+++ b/hibiki/lib/src/media/video/airing_calendar_cache.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+
+import 'package:hibiki/src/media/video/anilist_client.dart';
+
+/// 放送日历缓存（TODO-2487）：内存 + 偏好 JSON 两层，TTL 数小时。**不建
+/// Drift 表**（v65 被并行线程占用），偏好键 `airing_calendar_cache` 已在
+/// profile_keys.dart 按前缀排除出 Profile 快照（设备缓存，不随 Profile 走）。
+
+/// 偏好键（单键存最近一次成功拉取；签名不匹配视为未命中）。
+const String kAiringCalendarCachePrefKey = 'airing_calendar_cache';
+
+/// 缓存有效期。放送表一天内基本不变，几小时足够新鲜且远离 AniList rate limit。
+const Duration kAiringCalendarCacheTtl = Duration(hours: 3);
+
+/// 一次成功拉取的完整周窗口结果。
+class AiringScheduleCache {
+  const AiringScheduleCache({
+    required this.fetchedAtMs,
+    required this.signature,
+    required this.episodes,
+  });
+
+  /// 拉取完成时刻（epoch 毫秒），TTL 判定用。
+  final int fetchedAtMs;
+
+  /// 缓存身份，见 [airingCacheSignature]。
+  final String signature;
+
+  final List<AniListAiringEpisode> episodes;
+}
+
+/// 组缓存签名（纯函数）：`<weekStart epoch 秒>|all` 或
+/// `<weekStart>|ids:<升序逗号 id>`。绑定集/订阅集变化 → 签名变化 → 未命中。
+String airingCacheSignature({
+  required int weekStartEpochSeconds,
+  required List<int>? mediaIds,
+}) {
+  if (mediaIds == null) return '$weekStartEpochSeconds|all';
+  final List<int> sorted = List<int>.of(mediaIds)..sort();
+  return '$weekStartEpochSeconds|ids:${sorted.join(',')}';
+}
+
+/// 编码成偏好 JSON 字符串（与 [decodeAiringScheduleCache] 往返，纯函数）。
+String encodeAiringScheduleCache(AiringScheduleCache cache) {
+  return jsonEncode(<String, dynamic>{
+    'fetchedAtMs': cache.fetchedAtMs,
+    'signature': cache.signature,
+    'episodes': <Map<String, dynamic>>[
+      for (final AniListAiringEpisode e in cache.episodes)
+        <String, dynamic>{
+          'mediaId': e.mediaId,
+          'episode': e.episode,
+          'airingAt': e.airingAtSeconds,
+          if (e.media.romaji != null) 'romaji': e.media.romaji,
+          if (e.media.english != null) 'english': e.media.english,
+          if (e.media.native != null) 'native': e.media.native,
+          if (e.media.coverUrl != null) 'cover': e.media.coverUrl,
+        },
+    ],
+  });
+}
+
+/// 解码偏好 JSON。结构不符 / 签名不匹配 / 超 TTL → null（当无缓存）。纯函数，
+/// [nowMs] 由调用方注入便于单测。
+AiringScheduleCache? decodeAiringScheduleCache(
+  String raw, {
+  required String signature,
+  required int nowMs,
+  Duration ttl = kAiringCalendarCacheTtl,
+}) {
+  if (raw.isEmpty) return null;
+  try {
+    final dynamic json = jsonDecode(raw);
+    if (json is! Map) return null;
+    final dynamic fetchedAtMs = json['fetchedAtMs'];
+    if (fetchedAtMs is! int) return null;
+    if (json['signature'] != signature) return null;
+    if (nowMs - fetchedAtMs > ttl.inMilliseconds) return null;
+    final dynamic episodes = json['episodes'];
+    if (episodes is! List) return null;
+    final List<AniListAiringEpisode> out = <AniListAiringEpisode>[];
+    for (final dynamic e in episodes) {
+      if (e is! Map) continue;
+      final dynamic mediaId = e['mediaId'];
+      final dynamic episode = e['episode'];
+      final dynamic airingAt = e['airingAt'];
+      if (mediaId is! int || episode is! int || airingAt is! int) continue;
+      out.add(AniListAiringEpisode(
+        mediaId: mediaId,
+        episode: episode,
+        airingAtSeconds: airingAt,
+        media: AniListMedia(
+          id: mediaId,
+          romaji: e['romaji'] as String?,
+          english: e['english'] as String?,
+          native: e['native'] as String?,
+          coverUrl: e['cover'] as String?,
+        ),
+      ));
+    }
+    return AiringScheduleCache(
+      fetchedAtMs: fetchedAtMs,
+      signature: signature,
+      episodes: out,
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+/// 进程内内存缓存（跨页面开关存活；app 重启后由偏好层兜底）。
+class AiringMemoryCache {
+  AiringMemoryCache._();
+
+  static AiringScheduleCache? _latest;
+
+  /// 命中条件与偏好层同口径：签名一致且未过 TTL。
+  static AiringScheduleCache? get(
+    String signature, {
+    required int nowMs,
+    Duration ttl = kAiringCalendarCacheTtl,
+  }) {
+    final AiringScheduleCache? cache = _latest;
+    if (cache == null) return null;
+    if (cache.signature != signature) return null;
+    if (nowMs - cache.fetchedAtMs > ttl.inMilliseconds) return null;
+    return cache;
+  }
+
+  static void put(AiringScheduleCache cache) => _latest = cache;
+
+  /// 测试隔离用。
+  static void reset() => _latest = null;
+}

--- a/hibiki/lib/src/media/video/airing_week.dart
+++ b/hibiki/lib/src/media/video/airing_week.dart
@@ -1,0 +1,46 @@
+import 'package:hibiki/src/media/video/anilist_client.dart';
+
+/// 放送日历的周窗口/时区纯函数（TODO-2487）。全部无 IO、无状态，单测在
+/// `test/media/video/airing_week_test.dart`。
+
+/// AniList airingAt（Unix epoch 秒）→ 本地时刻。
+DateTime airingAtToLocal(int airingAtSeconds) =>
+    DateTime.fromMillisecondsSinceEpoch(airingAtSeconds * 1000).toLocal();
+
+/// [local] 所在自然周的周一 00:00（本地时区）。日减法走 DateTime 构造器的
+/// 组件归一化而不是 `subtract(Duration)`——跨 DST 边界减 Duration 会把
+/// 00:00 漂成 23:00/01:00。
+DateTime localWeekStart(DateTime local) =>
+    DateTime(local.year, local.month, local.day - (local.weekday - 1));
+
+/// 本地日期差（b - a，忽略时分秒）。DST 安全：把两端日期组件搬到 UTC 再取
+/// 整天差，避免本地 Duration 差在 23/25 小时的日子上取整错位。
+int daysBetweenLocalDates(DateTime a, DateTime b) =>
+    DateTime.utc(b.year, b.month, b.day)
+        .difference(DateTime.utc(a.year, a.month, a.day))
+        .inDays;
+
+/// 把一批放送条目按**本地**星期几分进 7 个桶（0=周一 … 6=周日），桶内按放送
+/// 时刻升序；落在 [weekStartLocal] 起 7 天窗口外的条目丢弃（服务端窗口按 UTC
+/// 秒裁过，本地换算后仍可能溢出到相邻周）。
+List<List<AniListAiringEpisode>> groupEpisodesByLocalWeekday({
+  required List<AniListAiringEpisode> episodes,
+  required DateTime weekStartLocal,
+}) {
+  final List<List<AniListAiringEpisode>> buckets =
+      List<List<AniListAiringEpisode>>.generate(
+    7,
+    (_) => <AniListAiringEpisode>[],
+  );
+  for (final AniListAiringEpisode episode in episodes) {
+    final DateTime local = airingAtToLocal(episode.airingAtSeconds);
+    final int index = daysBetweenLocalDates(weekStartLocal, local);
+    if (index < 0 || index > 6) continue;
+    buckets[index].add(episode);
+  }
+  for (final List<AniListAiringEpisode> bucket in buckets) {
+    bucket.sort((AniListAiringEpisode a, AniListAiringEpisode b) =>
+        a.airingAtSeconds.compareTo(b.airingAtSeconds));
+  }
+  return buckets;
+}

--- a/hibiki/lib/src/media/video/anilist_client.dart
+++ b/hibiki/lib/src/media/video/anilist_client.dart
@@ -139,6 +139,101 @@ List<AniListMedia> parseAniListSearchResponse(String body) {
   }
 }
 
+/// AniList 放送时间表条目：某番剧某一集的放送时刻（epoch 秒，UTC 基准）。
+class AniListAiringEpisode {
+  const AniListAiringEpisode({
+    required this.mediaId,
+    required this.episode,
+    required this.airingAtSeconds,
+    required this.media,
+  });
+
+  /// AniList 媒体 id（与合集 anilistId / 下载订阅 anilistId 同一 id 空间）。
+  final int mediaId;
+
+  /// 集号（AniList 从 1 起）。
+  final int episode;
+
+  /// 放送时刻（Unix epoch 秒）；本地展示用 `airingAtToLocal`（airing_week.dart）。
+  final int airingAtSeconds;
+
+  /// 该集所属番剧的标题/封面等元数据（airingSchedules.media 内联对象）。
+  final AniListMedia media;
+}
+
+/// airingSchedules 的一页结果（Page.pageInfo.hasNextPage 决定是否继续翻页）。
+class AniListAiringPage {
+  const AniListAiringPage({required this.episodes, required this.hasNextPage});
+
+  final List<AniListAiringEpisode> episodes;
+  final bool hasNextPage;
+}
+
+/// AniList HTTP 层失败（非 200，含 429 rate limit）。放送日历要求错误如实
+/// 上抛展示（与 [AniListClient.searchAnime] 的吞错语义**有意不同**：搜索是
+/// 尽力而为的辅助路径，日历页必须让用户看到失败原因并可重试）。
+class AniListRequestException implements Exception {
+  const AniListRequestException(this.statusCode, this.message);
+
+  final int statusCode;
+  final String message;
+
+  @override
+  String toString() => 'AniList HTTP $statusCode: $message';
+}
+
+/// 解析 airingSchedules GraphQL 响应。纯函数，结构不符 → 空页（HTTP 层错误
+/// 由 [AniListClient.fetchAiringSchedulePage] 以 [AniListRequestException] 上抛）。
+AniListAiringPage parseAniListAiringResponse(String body) {
+  const AniListAiringPage empty = AniListAiringPage(
+    episodes: <AniListAiringEpisode>[],
+    hasNextPage: false,
+  );
+  try {
+    final dynamic json = jsonDecode(body);
+    if (json is! Map) return empty;
+    final dynamic data = json['data'];
+    if (data is! Map) return empty;
+    final dynamic page = data['Page'];
+    if (page is! Map) return empty;
+    final dynamic pageInfo = page['pageInfo'];
+    final bool hasNextPage = pageInfo is Map && pageInfo['hasNextPage'] == true;
+    final dynamic schedules = page['airingSchedules'];
+    if (schedules is! List) return empty;
+    final List<AniListAiringEpisode> out = <AniListAiringEpisode>[];
+    for (final dynamic s in schedules) {
+      if (s is! Map) continue;
+      final dynamic mediaId = s['mediaId'];
+      final dynamic episode = s['episode'];
+      final dynamic airingAt = s['airingAt'];
+      if (mediaId is! int || episode is! int || airingAt is! int) continue;
+      final dynamic m = s['media'];
+      final dynamic title = m is Map ? m['title'] : null;
+      final dynamic cover = m is Map ? m['coverImage'] : null;
+      out.add(AniListAiringEpisode(
+        mediaId: mediaId,
+        episode: episode,
+        airingAtSeconds: airingAt,
+        media: AniListMedia(
+          id: mediaId,
+          romaji: title is Map ? title['romaji'] as String? : null,
+          english: title is Map ? title['english'] as String? : null,
+          native: title is Map ? title['native'] as String? : null,
+          coverUrl: cover is Map ? cover['large'] as String? : null,
+          episodes:
+              m is Map && m['episodes'] is int ? m['episodes'] as int : null,
+          seasonYear: m is Map && m['seasonYear'] is int
+              ? m['seasonYear'] as int
+              : null,
+        ),
+      ));
+    }
+    return AniListAiringPage(episodes: out, hasNextPage: hasNextPage);
+  } catch (_) {
+    return empty;
+  }
+}
+
 /// AniList GraphQL 客户端：按标题搜番拿 anilist id（Jimaku 按 anilist_id 查字幕的前置）。
 class AniListClient {
   AniListClient({http.Client? client}) : _client = client ?? http.Client();
@@ -188,6 +283,65 @@ query ($search: String) {
       }
     }
     return const <AniListMedia>[];
+  }
+
+  static const String _airingQuery = r'''
+query ($from: Int, $to: Int, $ids: [Int], $page: Int) {
+  Page(page: $page, perPage: 50) {
+    pageInfo { hasNextPage }
+    airingSchedules(airingAt_greater: $from, airingAt_lesser: $to, mediaId_in: $ids, sort: TIME) {
+      mediaId
+      episode
+      airingAt
+      media {
+        title { romaji english native }
+        coverImage { large }
+        episodes
+        seasonYear
+      }
+    }
+  }
+}''';
+
+  /// 拉取 ([airingAtGreater], [airingAtLesser]) 开区间（epoch 秒）窗口内的
+  /// 放送时间表一页。[mediaIds] 非空时只查这些番剧（合集绑定 + 订阅）；null =
+  /// 不过滤（「显示本季全部」）。**变量缺省 ≠ null**：GraphQL 规范里未提供的
+  /// 变量使对应实参视同未写，故 [mediaIds] 为 null 时直接不放进 variables，
+  /// AniList 才不会按「mediaId_in: null」过滤出 0 结果。
+  ///
+  /// 与 [searchAnime] 不同，本方法**不吞错**：非 200（含 429 rate limit）抛
+  /// [AniListRequestException]，网络异常原样上抛，调用方如实展示并提供重试。
+  Future<AniListAiringPage> fetchAiringSchedulePage({
+    required int airingAtGreater,
+    required int airingAtLesser,
+    List<int>? mediaIds,
+    int page = 1,
+  }) async {
+    final http.Response res = await _client.post(
+      Uri.parse(_endpoint),
+      headers: const <String, String>{
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: jsonEncode(<String, dynamic>{
+        'query': _airingQuery,
+        'variables': <String, dynamic>{
+          'from': airingAtGreater,
+          'to': airingAtLesser,
+          'page': page,
+          if (mediaIds != null) 'ids': mediaIds,
+        },
+      }),
+    );
+    if (res.statusCode != 200) {
+      final String body = utf8.decode(res.bodyBytes, allowMalformed: true);
+      final String snippet =
+          body.length > 200 ? '${body.substring(0, 200)}…' : body;
+      throw AniListRequestException(res.statusCode, snippet);
+    }
+    return parseAniListAiringResponse(
+      utf8.decode(res.bodyBytes, allowMalformed: true),
+    );
   }
 
   void close() => _client.close();

--- a/hibiki/lib/src/pages/implementations/airing_calendar_page.dart
+++ b/hibiki/lib/src/pages/implementations/airing_calendar_page.dart
@@ -1,0 +1,560 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:http/http.dart' as http;
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
+
+import 'package:hibiki/src/media/torrent/anime_download_subscription.dart';
+import 'package:hibiki/src/media/torrent/download_network_proxy.dart';
+import 'package:hibiki/src/media/video/airing_calendar_cache.dart';
+import 'package:hibiki/src/media/video/airing_week.dart';
+import 'package:hibiki/src/media/video/anilist_client.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/pages/implementations/media_collection_detail_page.dart';
+import 'package:hibiki/src/pages/implementations/video_hibiki_page.dart';
+import 'package:hibiki/utils.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 放送日历页（TODO-2487，hayase Schedule 式周历）：周一到周日七列（窄屏切
+/// 按天分组列表），默认只显示与本地相关的番剧——合集绑定的 anilistId + 下载
+/// 订阅的 anilistId；「显示本季全部」开关拉当季全量 airing。数据走 AniList
+/// airingSchedules（[AniListClient.fetchAiringSchedulePage]，HTTP 客户端经
+/// [AppModel.createDownloadHttpClient] 走既有下载代理配置）；缓存内存 + 偏好
+/// 两层（airing_calendar_cache.dart），**无 Drift schema 改动**。
+class AiringCalendarPage extends ConsumerStatefulWidget {
+  const AiringCalendarPage({super.key, this.onOpenSubscriptions});
+
+  /// 点「订阅中」条目：本页先 pop，再由 DownloadsPage 把自己的 TabController
+  /// 切到订阅 tab（本页不持有下载页内部状态）。null = 订阅条目不可点。
+  final VoidCallback? onOpenSubscriptions;
+
+  @override
+  ConsumerState<AiringCalendarPage> createState() => _AiringCalendarPageState();
+}
+
+class _AiringCalendarPageState extends ConsumerState<AiringCalendarPage> {
+  /// 「显示本季全部」分页上限：AniList perPage=50，一周全量 airing 实测数百条，
+  /// 12 页（600 条）够覆盖；防御性上限避免异常响应导致无限翻页打爆 rate limit。
+  static const int _maxPages = 12;
+
+  /// 翻页间隔：AniList 约 90 req/min，700ms 一页远低于限额，避免 429。
+  static const Duration _pageInterval = Duration(milliseconds: 700);
+
+  /// 七列布局的最小宽度；再窄切按天分组列表。
+  static const double _wideLayoutMinWidth = 900;
+
+  late DateTime _weekStart = localWeekStart(DateTime.now());
+  bool _showAll = false;
+  bool _loading = true;
+  String? _errorDetail;
+  List<AniListAiringEpisode> _episodes = const <AniListAiringEpisode>[];
+  Map<int, MediaCollectionRow> _collectionsByAnilistId =
+      <int, MediaCollectionRow>{};
+  Map<int, AnimeDownloadSubscription> _subscriptionsByAnilistId =
+      <int, AnimeDownloadSubscription>{};
+
+  /// intl 星期名数据是否就绪（与 collections_page 同范式：未就绪先渲染 ISO
+  /// 日期，数据到位后 setState 换本地化星期名）。
+  bool _dateSymbolsReady = false;
+
+  AppModel get _appModel => ref.read(appProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(initializeDateFormatting().then((_) {
+      if (mounted) setState(() => _dateSymbolsReady = true);
+    }));
+    unawaited(_load());
+  }
+
+  /// 重载整页：本地映射（合集/订阅）恒重建，放送表按缓存口径取。
+  /// [force] = 用户点刷新，绕过两层缓存。
+  Future<void> _load({bool force = false}) async {
+    setState(() {
+      _loading = true;
+      _errorDetail = null;
+    });
+    try {
+      final List<MediaCollectionRow> collections =
+          await _appModel.database.getAllMediaCollections();
+      final AnimeDownloadSubscriptionStore? store =
+          _appModel.animeDownloadSubscriptionStore;
+      final List<AnimeDownloadSubscription> subscriptions = store == null
+          ? const <AnimeDownloadSubscription>[]
+          : await store.loadAll();
+      final Map<int, MediaCollectionRow> collectionsById =
+          <int, MediaCollectionRow>{
+        for (final MediaCollectionRow c in collections)
+          if (c.anilistId != null) c.anilistId!: c,
+      };
+      final Map<int, AnimeDownloadSubscription> subscriptionsById =
+          <int, AnimeDownloadSubscription>{
+        for (final AnimeDownloadSubscription s in subscriptions) s.anilistId: s,
+      };
+      final List<int> boundIds = <int>{
+        ...collectionsById.keys,
+        ...subscriptionsById.keys,
+      }.toList()
+        ..sort();
+      final List<int>? filterIds = _showAll ? null : boundIds;
+      List<AniListAiringEpisode> episodes = const <AniListAiringEpisode>[];
+      // 相关模式且零绑定：不发网络请求，直接进引导空态。
+      if (filterIds == null || filterIds.isNotEmpty) {
+        episodes = await _fetchEpisodes(filterIds: filterIds, force: force);
+      }
+      if (!mounted) return;
+      setState(() {
+        _collectionsByAnilistId = collectionsById;
+        _subscriptionsByAnilistId = subscriptionsById;
+        _episodes = episodes;
+        _loading = false;
+      });
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _errorDetail = error.toString();
+      });
+    }
+  }
+
+  /// 取本周窗口的放送条目：内存缓存 → 偏好缓存 → AniList 分页拉取。
+  Future<List<AniListAiringEpisode>> _fetchEpisodes({
+    required List<int>? filterIds,
+    required bool force,
+  }) async {
+    final int weekStartSeconds = _weekStart.millisecondsSinceEpoch ~/ 1000;
+    final int weekEndSeconds = DateTime(
+          _weekStart.year,
+          _weekStart.month,
+          _weekStart.day + 7,
+        ).millisecondsSinceEpoch ~/
+        1000;
+    final String signature = airingCacheSignature(
+      weekStartEpochSeconds: weekStartSeconds,
+      mediaIds: filterIds,
+    );
+    final int nowMs = DateTime.now().millisecondsSinceEpoch;
+    if (!force) {
+      final AiringScheduleCache? memory =
+          AiringMemoryCache.get(signature, nowMs: nowMs);
+      if (memory != null) return memory.episodes;
+      final String raw = _appModel.prefsRepo
+          .getPref(kAiringCalendarCachePrefKey, defaultValue: '') as String;
+      final AiringScheduleCache? persisted = decodeAiringScheduleCache(
+        raw,
+        signature: signature,
+        nowMs: nowMs,
+      );
+      if (persisted != null) {
+        AiringMemoryCache.put(persisted);
+        return persisted.episodes;
+      }
+    }
+    final http.Client httpClient = await _appModel.createDownloadHttpClient();
+    final AniListClient client = AniListClient(client: httpClient);
+    try {
+      final List<AniListAiringEpisode> all = <AniListAiringEpisode>[];
+      int page = 1;
+      while (true) {
+        // airingAt_greater 是严格大于：-1 让周一 00:00 整点的条目也进窗口。
+        final AniListAiringPage result = await client
+            .fetchAiringSchedulePage(
+              airingAtGreater: weekStartSeconds - 1,
+              airingAtLesser: weekEndSeconds,
+              mediaIds: filterIds,
+              page: page,
+            )
+            .timeout(kDownloadDiscoveryTimeout);
+        all.addAll(result.episodes);
+        if (!result.hasNextPage || page >= _maxPages) break;
+        page += 1;
+        await Future<void>.delayed(_pageInterval);
+      }
+      final AiringScheduleCache cache = AiringScheduleCache(
+        fetchedAtMs: nowMs,
+        signature: signature,
+        episodes: all,
+      );
+      AiringMemoryCache.put(cache);
+      await _appModel.prefsRepo.setPref(
+        kAiringCalendarCachePrefKey,
+        encodeAiringScheduleCache(cache),
+      );
+      return all;
+    } finally {
+      client.close();
+    }
+  }
+
+  void _shiftWeek(int days) {
+    setState(() {
+      _weekStart = DateTime(
+        _weekStart.year,
+        _weekStart.month,
+        _weekStart.day + days,
+      );
+    });
+    unawaited(_load());
+  }
+
+  /// 打开合集详情（与 collections_page/home_video_page 同范式：loadMembers 解析
+  /// 有序视频成员，点集经 playlistCollectionId 进播放器）。日历页背后没有库页
+  /// 要刷新，onChanged 仅重载本页映射。
+  void _openCollectionDetail(MediaCollectionRow collection) {
+    final HibikiDatabase db = _appModel.database;
+    final VideoBookRepository repo = VideoBookRepository(db);
+    Navigator.push<void>(
+      context,
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (_) => MediaCollectionDetailPage(
+          database: db,
+          collection: collection,
+          loadMembers: () async {
+            final List<MediaCollectionItemRow> members =
+                await db.getCollectionItems(collection.id);
+            final List<VideoBookRow> rows = <VideoBookRow>[];
+            for (final MediaCollectionItemRow m in members) {
+              if (m.mediaType != MediaKind.video.dbValue) continue;
+              final VideoBookRow? row = await repo.getByBookUid(m.entryKey);
+              if (row != null) rows.add(row);
+            }
+            return rows;
+          },
+          onOpenEpisode: (VideoBookRow episode) {
+            Navigator.push<void>(
+              context,
+              adaptivePageRoute<void>(
+                context: context,
+                builder: (_) => VideoHibikiPage.neutralized(
+                  bookUid: episode.bookUid,
+                  repo: repo,
+                  playlistCollectionId: collection.id,
+                ),
+              ),
+            );
+          },
+          onChanged: () => unawaited(_load()),
+        ),
+      ),
+    );
+  }
+
+  void _openSubscriptions() {
+    final VoidCallback? callback = widget.onOpenSubscriptions;
+    if (callback == null) return;
+    Navigator.of(context).pop();
+    callback();
+  }
+
+  String _weekdayName(DateTime day) {
+    if (!_dateSymbolsReady) return HibikiTimeFormat.dayKey(day);
+    final String locale = LocaleSettings.currentLocale.languageTag;
+    DateFormat format;
+    try {
+      format = DateFormat.E(locale);
+    } on ArgumentError {
+      format = DateFormat.E();
+    }
+    return format.format(day);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(t.download_airing_calendar_title),
+        actions: <Widget>[
+          IconButton(
+            tooltip: t.refresh,
+            icon: const Icon(Icons.refresh),
+            onPressed: _loading ? null : () => unawaited(_load(force: true)),
+          ),
+        ],
+      ),
+      body: Column(
+        children: <Widget>[
+          _buildToolbar(theme),
+          Expanded(child: _buildBody(theme)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildToolbar(ThemeData theme) {
+    final DateTime weekEnd = DateTime(
+      _weekStart.year,
+      _weekStart.month,
+      _weekStart.day + 6,
+    );
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      child: Row(
+        children: <Widget>[
+          IconButton(
+            tooltip: t.download_airing_calendar_week_prev,
+            icon: const Icon(Icons.chevron_left),
+            onPressed: _loading ? null : () => _shiftWeek(-7),
+          ),
+          Text(
+            '${HibikiTimeFormat.dayKey(_weekStart)} ~ '
+            '${HibikiTimeFormat.dayKey(weekEnd)}',
+            style: theme.textTheme.titleSmall,
+          ),
+          IconButton(
+            tooltip: t.download_airing_calendar_week_next,
+            icon: const Icon(Icons.chevron_right),
+            onPressed: _loading ? null : () => _shiftWeek(7),
+          ),
+          const Spacer(),
+          FilterChip(
+            label: Text(t.download_airing_calendar_show_all),
+            selected: _showAll,
+            onSelected: _loading
+                ? null
+                : (bool value) {
+                    setState(() => _showAll = value);
+                    unawaited(_load());
+                  },
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody(ThemeData theme) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final String? errorDetail = _errorDetail;
+    if (errorDetail != null) {
+      return _buildError(theme, errorDetail);
+    }
+    if (!_showAll &&
+        _collectionsByAnilistId.isEmpty &&
+        _subscriptionsByAnilistId.isEmpty) {
+      return _buildCenteredNote(
+        theme,
+        icon: Icons.event_note_outlined,
+        message: t.download_airing_calendar_empty_guidance,
+      );
+    }
+    if (_episodes.isEmpty) {
+      return _buildCenteredNote(
+        theme,
+        icon: Icons.event_available_outlined,
+        message: t.download_airing_calendar_week_empty,
+      );
+    }
+    final List<List<AniListAiringEpisode>> buckets =
+        groupEpisodesByLocalWeekday(
+      episodes: _episodes,
+      weekStartLocal: _weekStart,
+    );
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final bool wide = constraints.maxWidth >= _wideLayoutMinWidth;
+        return wide
+            ? _buildWeekColumns(theme, buckets)
+            : _buildDayList(theme, buckets);
+      },
+    );
+  }
+
+  /// 网络失败：如实展示错误详情 + 重试按钮（不吞、不静默降级）。
+  Widget _buildError(ThemeData theme, String detail) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(Icons.cloud_off, size: 40, color: theme.colorScheme.error),
+              const SizedBox(height: 12),
+              Text(
+                t.download_airing_calendar_error,
+                style: theme.textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                detail,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+                maxLines: 4,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 16),
+              FilledButton.tonalIcon(
+                icon: const Icon(Icons.refresh),
+                label: Text(t.anime_download_retry),
+                onPressed: () => unawaited(_load(force: true)),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCenteredNote(
+    ThemeData theme, {
+    required IconData icon,
+    required String message,
+  }) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 480),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(icon, size: 40, color: theme.colorScheme.onSurfaceVariant),
+              const SizedBox(height: 12),
+              Text(
+                message,
+                style: theme.textTheme.bodyMedium,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 宽屏：周一到周日七列。
+  Widget _buildWeekColumns(
+    ThemeData theme,
+    List<List<AniListAiringEpisode>> buckets,
+  ) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        for (int i = 0; i < 7; i++)
+          Expanded(
+            child: Column(
+              children: <Widget>[
+                _buildDayHeader(theme, i),
+                Expanded(
+                  child: ListView(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    children: <Widget>[
+                      for (final AniListAiringEpisode episode in buckets[i])
+                        _buildEpisodeTile(theme, episode),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+      ],
+    );
+  }
+
+  /// 窄屏：按天分组的列表（只列有条目的天）。
+  Widget _buildDayList(
+    ThemeData theme,
+    List<List<AniListAiringEpisode>> buckets,
+  ) {
+    return ListView(
+      padding: const EdgeInsets.only(bottom: 12),
+      children: <Widget>[
+        for (int i = 0; i < 7; i++)
+          if (buckets[i].isNotEmpty) ...<Widget>[
+            _buildDayHeader(theme, i),
+            for (final AniListAiringEpisode episode in buckets[i])
+              _buildEpisodeTile(theme, episode),
+          ],
+      ],
+    );
+  }
+
+  Widget _buildDayHeader(ThemeData theme, int weekdayIndex) {
+    final DateTime day = DateTime(
+      _weekStart.year,
+      _weekStart.month,
+      _weekStart.day + weekdayIndex,
+    );
+    final bool isToday = daysBetweenLocalDates(day, DateTime.now()) == 0;
+    final String date = HibikiTimeFormat.dayKey(day).substring(5);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Text(
+        '${_weekdayName(day)} $date',
+        style: theme.textTheme.titleSmall?.copyWith(
+          color: isToday ? theme.colorScheme.primary : null,
+          fontWeight: isToday ? FontWeight.bold : null,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEpisodeTile(ThemeData theme, AniListAiringEpisode episode) {
+    final MediaCollectionRow? collection =
+        _collectionsByAnilistId[episode.mediaId];
+    final AnimeDownloadSubscription? subscription =
+        _subscriptionsByAnilistId[episode.mediaId];
+    final DateTime local = airingAtToLocal(episode.airingAtSeconds);
+    final VoidCallback? onTap = collection != null
+        ? () => _openCollectionDetail(collection)
+        : subscription != null && widget.onOpenSubscriptions != null
+            ? _openSubscriptions
+            : null;
+    final String episodeLabel =
+        t.download_airing_calendar_episode_label(episode: episode.episode);
+    return ListTile(
+      dense: true,
+      onTap: onTap,
+      title: Text(
+        episode.media.displayTitle,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Wrap(
+        spacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: <Widget>[
+          Text('${HibikiTimeFormat.hourMinute(local)} $episodeLabel'),
+          if (collection != null)
+            _buildBadge(
+              theme,
+              t.download_airing_calendar_in_library,
+              theme.colorScheme.primary,
+            ),
+          if (subscription != null)
+            _buildBadge(
+              theme,
+              t.download_airing_calendar_subscribed,
+              theme.colorScheme.tertiary,
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBadge(ThemeData theme, String label, Color color) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 1),
+      decoration: BoxDecoration(
+        border: Border.all(color: color),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(color: color),
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/pages/implementations/downloads_page.dart
+++ b/hibiki/lib/src/pages/implementations/downloads_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_tasks_section.dart';
 import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/pages/implementations/airing_calendar_page.dart';
 import 'package:hibiki/src/pages/implementations/anime_download_dialog.dart';
 import 'package:hibiki/src/pages/implementations/download_subscriptions_panel.dart';
 import 'package:hibiki/src/pages/implementations/torrent_settings_section.dart';
@@ -41,6 +42,25 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
     );
   }
 
+  /// 放送日历整页入口（TODO-2487）。[tabContext] 必须来自 DefaultTabController
+  /// 之下（AppBar actions 里的 Builder），日历页点「订阅中」条目 pop 回来后
+  /// 用它把本页 tab 切到订阅。
+  void _openAiringCalendar(BuildContext tabContext) {
+    final TabController tabController = DefaultTabController.of(tabContext);
+    Navigator.push<void>(
+      context,
+      adaptivePageRoute<void>(
+        context: context,
+        builder: (_) => AiringCalendarPage(
+          onOpenSubscriptions: () {
+            if (!mounted) return;
+            tabController.animateTo(2);
+          },
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
@@ -69,6 +89,16 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                     ],
                   ),
             actions: <Widget>[
+              if (!_showSettings)
+                Builder(
+                  // Builder：拿 DefaultTabController 之下的 context，日历页
+                  // 「订阅中」条目点击回跳时能切回订阅 tab（TODO-2487）。
+                  builder: (BuildContext tabContext) => IconButton(
+                    tooltip: t.download_airing_calendar_title,
+                    icon: const Icon(Icons.calendar_month_outlined),
+                    onPressed: () => _openAiringCalendar(tabContext),
+                  ),
+                ),
               if (!_showSettings)
                 IconButton(
                   tooltip: t.manga_online_catalog_title,

--- a/hibiki/lib/src/profile/profile_keys.dart
+++ b/hibiki/lib/src/profile/profile_keys.dart
@@ -91,6 +91,10 @@ class ProfileKeys {
     'audiobook_volume_',
     'audiobook_image_pause_',
     'audiobook_health_overlay_',
+    // TODO-2487: airing calendar fetch cache is device-local network cache,
+    // not a reading preference. Snapshotting it per profile would restore
+    // stale schedules on profile switch for zero benefit.
+    'airing_calendar_',
   ];
 
   /// BUG-1018 (A4): per-item display-name overrides are CONTENT tied to a

--- a/hibiki/test/media/video/airing_calendar_cache_test.dart
+++ b/hibiki/test/media/video/airing_calendar_cache_test.dart
@@ -1,0 +1,130 @@
+// TODO-2487 放送日历：缓存签名/编解码纯函数 + 进程内缓存命中口径。缓存身份 =
+// 周窗口 + 过滤集（绑定合集/订阅的 id 升序），任一变化即未命中；TTL 判定的
+// now 由调用方注入，测试不依赖真实时钟。
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/video/airing_calendar_cache.dart';
+import 'package:hibiki/src/media/video/anilist_client.dart';
+
+AiringScheduleCache _cache({
+  int fetchedAtMs = 1000,
+  String signature = 'sig',
+  List<AniListAiringEpisode> episodes = const <AniListAiringEpisode>[],
+}) =>
+    AiringScheduleCache(
+      fetchedAtMs: fetchedAtMs,
+      signature: signature,
+      episodes: episodes,
+    );
+
+void main() {
+  setUp(AiringMemoryCache.reset);
+
+  group('airingCacheSignature', () {
+    test('distinguishes all-mode from ids-mode and sorts ids', () {
+      const int week = 1770000000;
+      expect(
+        airingCacheSignature(weekStartEpochSeconds: week, mediaIds: null),
+        '$week|all',
+      );
+      expect(
+        airingCacheSignature(
+          weekStartEpochSeconds: week,
+          mediaIds: <int>[9, 5, 7],
+        ),
+        '$week|ids:5,7,9',
+      );
+      expect(
+        airingCacheSignature(weekStartEpochSeconds: week, mediaIds: <int>[]),
+        '$week|ids:',
+      );
+    });
+  });
+
+  group('encode/decode round-trip', () {
+    test('round-trips episodes with titles', () {
+      final AiringScheduleCache cache = _cache(
+        episodes: <AniListAiringEpisode>[
+          const AniListAiringEpisode(
+            mediaId: 42,
+            episode: 7,
+            airingAtSeconds: 1770000000,
+            media: AniListMedia(
+              id: 42,
+              romaji: 'Frieren',
+              native: '葬送のフリーレン',
+              coverUrl: 'https://x/c.png',
+            ),
+          ),
+        ],
+      );
+      final AiringScheduleCache? decoded = decodeAiringScheduleCache(
+        encodeAiringScheduleCache(cache),
+        signature: 'sig',
+        nowMs: 2000,
+      );
+      expect(decoded, isNotNull);
+      final AniListAiringEpisode episode = decoded!.episodes.single;
+      expect(episode.mediaId, 42);
+      expect(episode.episode, 7);
+      expect(episode.airingAtSeconds, 1770000000);
+      expect(episode.media.displayTitle, 'Frieren');
+      expect(episode.media.native, '葬送のフリーレン');
+      expect(episode.media.coverUrl, 'https://x/c.png');
+    });
+
+    test('misses on mismatched signature', () {
+      final String raw = encodeAiringScheduleCache(_cache());
+      expect(
+        decodeAiringScheduleCache(raw, signature: 'other', nowMs: 2000),
+        isNull,
+      );
+    });
+
+    test('misses past TTL but hits inside it', () {
+      final String raw = encodeAiringScheduleCache(_cache(fetchedAtMs: 1000));
+      const Duration ttl = Duration(hours: 3);
+      final int justInside = 1000 + ttl.inMilliseconds;
+      final int justPast = 1000 + ttl.inMilliseconds + 1;
+      expect(
+        decodeAiringScheduleCache(raw, signature: 'sig', nowMs: justInside),
+        isNotNull,
+      );
+      expect(
+        decodeAiringScheduleCache(raw, signature: 'sig', nowMs: justPast),
+        isNull,
+      );
+    });
+
+    test('rejects malformed payloads without throwing', () {
+      expect(
+        decodeAiringScheduleCache('', signature: 'sig', nowMs: 0),
+        isNull,
+      );
+      expect(
+        decodeAiringScheduleCache('not json', signature: 'sig', nowMs: 0),
+        isNull,
+      );
+      expect(
+        decodeAiringScheduleCache('[]', signature: 'sig', nowMs: 0),
+        isNull,
+      );
+    });
+  });
+
+  group('AiringMemoryCache', () {
+    test('hits on same signature inside TTL, misses otherwise', () {
+      AiringMemoryCache.put(_cache(fetchedAtMs: 1000));
+      expect(AiringMemoryCache.get('sig', nowMs: 2000), isNotNull);
+      expect(AiringMemoryCache.get('other', nowMs: 2000), isNull);
+      final int past = 1000 + kAiringCalendarCacheTtl.inMilliseconds + 1;
+      expect(AiringMemoryCache.get('sig', nowMs: past), isNull);
+    });
+
+    test('reset clears the cache', () {
+      AiringMemoryCache.put(_cache());
+      AiringMemoryCache.reset();
+      expect(AiringMemoryCache.get('sig', nowMs: 1001), isNull);
+    });
+  });
+}

--- a/hibiki/test/media/video/airing_week_test.dart
+++ b/hibiki/test/media/video/airing_week_test.dart
@@ -1,0 +1,106 @@
+// TODO-2487 放送日历：周窗口/时区纯函数单测。放送时刻是 AniList 的 epoch 秒，
+// 展示按设备本地时区——测试用「本地时间 → epoch 秒」构造输入，不依赖测试机
+// 所在时区，三端 CI 均可跑。
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/media/video/airing_week.dart';
+import 'package:hibiki/src/media/video/anilist_client.dart';
+
+AniListAiringEpisode _episode(int mediaId, DateTime local, {int episode = 1}) =>
+    AniListAiringEpisode(
+      mediaId: mediaId,
+      episode: episode,
+      airingAtSeconds: local.millisecondsSinceEpoch ~/ 1000,
+      media: AniListMedia(id: mediaId),
+    );
+
+void main() {
+  group('airingAtToLocal', () {
+    test('round-trips a local wall-clock time through epoch seconds', () {
+      final DateTime local = DateTime(2026, 8, 5, 21, 30);
+      final int seconds = local.millisecondsSinceEpoch ~/ 1000;
+      expect(airingAtToLocal(seconds), local);
+    });
+  });
+
+  group('localWeekStart', () {
+    test('maps every weekday of one week to the same Monday midnight', () {
+      final DateTime monday = DateTime(2026, 8, 3);
+      expect(monday.weekday, DateTime.monday);
+      for (int offset = 0; offset < 7; offset++) {
+        final DateTime day = DateTime(2026, 8, 3 + offset, 15, 42);
+        expect(localWeekStart(day), monday, reason: 'offset $offset');
+      }
+    });
+
+    test('normalizes across a month boundary', () {
+      // 2026-08-01 是周六 → 所在周的周一是 2026-07-27。
+      expect(localWeekStart(DateTime(2026, 8, 1, 9)), DateTime(2026, 7, 27));
+    });
+
+    test('returns local midnight Monday, with zero time components', () {
+      final DateTime start = localWeekStart(DateTime(2026, 8, 6, 23, 59));
+      expect(start.weekday, DateTime.monday);
+      expect(start.hour, 0);
+      expect(start.minute, 0);
+      expect(start.second, 0);
+    });
+  });
+
+  group('daysBetweenLocalDates', () {
+    test('ignores time-of-day components', () {
+      expect(
+        daysBetweenLocalDates(
+          DateTime(2026, 8, 3, 23),
+          DateTime(2026, 8, 4, 0, 1),
+        ),
+        1,
+      );
+    });
+
+    test('is negative when b precedes a', () {
+      expect(
+        daysBetweenLocalDates(DateTime(2026, 8, 3), DateTime(2026, 8, 1)),
+        -2,
+      );
+    });
+  });
+
+  group('groupEpisodesByLocalWeekday', () {
+    test('buckets by local weekday and sorts within a day', () {
+      final DateTime monday = DateTime(2026, 8, 3);
+      final AniListAiringEpisode late1 = _episode(1, DateTime(2026, 8, 3, 22));
+      final AniListAiringEpisode early = _episode(2, DateTime(2026, 8, 3, 9));
+      final AniListAiringEpisode sunday =
+          _episode(3, DateTime(2026, 8, 9, 23, 30));
+      final List<List<AniListAiringEpisode>> buckets =
+          groupEpisodesByLocalWeekday(
+        episodes: <AniListAiringEpisode>[late1, early, sunday],
+        weekStartLocal: monday,
+      );
+      expect(buckets, hasLength(7));
+      expect(
+        buckets[0].map((AniListAiringEpisode e) => e.mediaId).toList(),
+        <int>[2, 1],
+      );
+      expect(buckets[6].single.mediaId, 3);
+      for (int i = 1; i < 6; i++) {
+        expect(buckets[i], isEmpty, reason: 'day $i');
+      }
+    });
+
+    test('drops entries outside the 7-day window', () {
+      final DateTime monday = DateTime(2026, 8, 3);
+      final AniListAiringEpisode before =
+          _episode(1, DateTime(2026, 8, 2, 23, 59));
+      final AniListAiringEpisode after =
+          _episode(2, DateTime(2026, 8, 10, 0, 1));
+      final List<List<AniListAiringEpisode>> buckets =
+          groupEpisodesByLocalWeekday(
+        episodes: <AniListAiringEpisode>[before, after],
+        weekStartLocal: monday,
+      );
+      expect(buckets.expand((List<AniListAiringEpisode> b) => b), isEmpty);
+    });
+  });
+}

--- a/hibiki/test/media/video/anilist_airing_schedule_test.dart
+++ b/hibiki/test/media/video/anilist_airing_schedule_test.dart
@@ -1,0 +1,159 @@
+// TODO-2487 放送日历：AniList airingSchedules 查询的解析纯函数 + 客户端契约。
+// 关键契约：① mediaIds 为 null 时变量表**不含** ids 键（GraphQL 规范里缺省的
+// 变量使实参视同未写；显式 null 会被当作「mediaId_in: null」过滤出 0 结果）；
+// ② 非 200（含 429 rate limit）抛 AniListRequestException 如实上抛，不吞错。
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:hibiki/src/media/video/anilist_client.dart';
+
+String _pageBody({
+  List<Map<String, dynamic>> schedules = const <Map<String, dynamic>>[],
+  bool hasNextPage = false,
+}) =>
+    jsonEncode(<String, dynamic>{
+      'data': <String, dynamic>{
+        'Page': <String, dynamic>{
+          'pageInfo': <String, dynamic>{'hasNextPage': hasNextPage},
+          'airingSchedules': schedules,
+        },
+      },
+    });
+
+void main() {
+  group('parseAniListAiringResponse', () {
+    test('parses schedules with media titles and hasNextPage', () {
+      final AniListAiringPage page = parseAniListAiringResponse(_pageBody(
+        hasNextPage: true,
+        schedules: <Map<String, dynamic>>[
+          <String, dynamic>{
+            'mediaId': 42,
+            'episode': 7,
+            'airingAt': 1770000000,
+            'media': <String, dynamic>{
+              'title': <String, dynamic>{'romaji': 'Sousou no Frieren'},
+              'coverImage': <String, dynamic>{'large': 'https://x/c.png'},
+              'episodes': 28,
+              'seasonYear': 2026,
+            },
+          },
+        ],
+      ));
+      expect(page.hasNextPage, isTrue);
+      final AniListAiringEpisode episode = page.episodes.single;
+      expect(episode.mediaId, 42);
+      expect(episode.episode, 7);
+      expect(episode.airingAtSeconds, 1770000000);
+      expect(episode.media.displayTitle, 'Sousou no Frieren');
+      expect(episode.media.coverUrl, 'https://x/c.png');
+    });
+
+    test('returns empty page on malformed body', () {
+      expect(parseAniListAiringResponse('not json').episodes, isEmpty);
+      expect(parseAniListAiringResponse('{}').episodes, isEmpty);
+      expect(parseAniListAiringResponse('{}').hasNextPage, isFalse);
+    });
+
+    test('skips entries missing required int fields', () {
+      final AniListAiringPage page = parseAniListAiringResponse(_pageBody(
+        schedules: <Map<String, dynamic>>[
+          <String, dynamic>{'mediaId': 'bad', 'episode': 1, 'airingAt': 2},
+          <String, dynamic>{'mediaId': 3, 'episode': 1, 'airingAt': 2},
+        ],
+      ));
+      expect(page.episodes.single.mediaId, 3);
+    });
+  });
+
+  group('AniListClient.fetchAiringSchedulePage', () {
+    test('sends window variables and omits ids when mediaIds is null',
+        () async {
+      late Map<String, dynamic> captured;
+      final AniListClient client = AniListClient(
+        client: MockClient((http.Request request) async {
+          captured = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(_pageBody(), 200);
+        }),
+      );
+      await client.fetchAiringSchedulePage(
+        airingAtGreater: 100,
+        airingAtLesser: 200,
+      );
+      client.close();
+      final Map<String, dynamic> variables =
+          captured['variables'] as Map<String, dynamic>;
+      expect(variables['from'], 100);
+      expect(variables['to'], 200);
+      expect(variables['page'], 1);
+      expect(variables.containsKey('ids'), isFalse);
+    });
+
+    test('passes mediaIds and page when provided', () async {
+      late Map<String, dynamic> captured;
+      final AniListClient client = AniListClient(
+        client: MockClient((http.Request request) async {
+          captured = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(_pageBody(), 200);
+        }),
+      );
+      await client.fetchAiringSchedulePage(
+        airingAtGreater: 100,
+        airingAtLesser: 200,
+        mediaIds: <int>[9, 5],
+        page: 3,
+      );
+      client.close();
+      final Map<String, dynamic> variables =
+          captured['variables'] as Map<String, dynamic>;
+      expect(variables['ids'], <int>[9, 5]);
+      expect(variables['page'], 3);
+    });
+
+    test('throws AniListRequestException with status on non-200', () async {
+      final AniListClient client = AniListClient(
+        client: MockClient(
+          (http.Request request) async => http.Response('rate limited', 429),
+        ),
+      );
+      await expectLater(
+        client.fetchAiringSchedulePage(airingAtGreater: 0, airingAtLesser: 1),
+        throwsA(
+          isA<AniListRequestException>()
+              .having((AniListRequestException e) => e.statusCode, 'statusCode',
+                  429)
+              .having(
+                (AniListRequestException e) => e.message,
+                'message',
+                contains('rate limited'),
+              ),
+        ),
+      );
+      client.close();
+    });
+
+    test('parses a 200 response into episodes', () async {
+      final AniListClient client = AniListClient(
+        client: MockClient(
+          (http.Request request) async => http.Response(
+            _pageBody(
+              schedules: <Map<String, dynamic>>[
+                <String, dynamic>{'mediaId': 1, 'episode': 2, 'airingAt': 3},
+              ],
+            ),
+            200,
+          ),
+        ),
+      );
+      final AniListAiringPage page = await client.fetchAiringSchedulePage(
+        airingAtGreater: 0,
+        airingAtLesser: 10,
+      );
+      client.close();
+      expect(page.episodes.single.episode, 2);
+      expect(page.hasNextPage, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

hayase Schedule 式放送日历整页：下载页 AppBar 日历图标进入，周一~周日七列（<900px 窄屏切按天分组列表）。默认只显示与本地相关的番剧（合集绑定 anilistId + 下载订阅 anilistId），「显示本季全部」开关拉当季全量 airing。

## AniList 查询设计

- `AniListClient.fetchAiringSchedulePage`：`Page(page,perPage:50){ pageInfo{hasNextPage} airingSchedules(airingAt_greater,airingAt_lesser,mediaId_in,sort:TIME){...} }`，窗口=本地周一 00:00 起 7 天的 epoch 秒（greater 严格大于故 -1 含整点）。
- **变量缺省≠null**：mediaIds 为 null 时不放进 variables（GraphQL 规范缺省变量使实参视同未写），否则 AniList 按 `mediaId_in:null` 过滤出 0 结果——有契约测试钉住。
- 与既有 searchAnime 吞错语义**有意不同**：非 200（含 429）抛 `AniListRequestException` 如实展示 + 重试按钮。
- HTTP 客户端经 `AppModel.createDownloadHttpClient()` 走既有下载代理配置；全量模式分页 700ms 间隔 + 12 页上限防 rate limit。
- 缓存：内存 + 偏好 `airing_calendar_cache` 两层（TTL 3h，签名=周窗口+过滤集），**无 Drift schema 改动**（v65 被并行占用）；偏好键按前缀排除出 Profile 快照。

## 页面结构

- `airing_calendar_page.dart`：工具栏（上/下周 + 周区间 + 本季全部 FilterChip）+ 三态 body（loading / 错误详情+重试 / 七列或按天列表）；零绑定引导空态、本周无放送空态分开。
- 条目：标题 + 当地 HH:mm + 集号 + 「已入库/订阅中」徽标；已入库点进 `MediaCollectionDetailPage`（collections_page 同范式，点集经 playlistCollectionId 进播放器），订阅中 pop 回下载页并切到订阅 tab（Builder 捕获 DefaultTabController，downloads_page 只动 AppBar actions 一处）。
- 纯函数：`airing_week.dart`（时区换算/周一起点/DST 安全日差/七桶分组）+ `airing_calendar_cache.dart`（签名/编解码），各配单测。

## 验证

- `flutter analyze`：No issues found
- `dart run tool/flutter_test_failures.dart --no-pub <3 新测试 + anilist_client/下载页相邻/profile_keys>`：**FLUTTER TEST VERDICT: PASSED - 54 tests ran, all tests passed**
- i18n：10 key 经 i18n_sync 全 17 语言 + dart run slang 重生成

## 遗留

- 未真机验证（合并门=analyze+VERDICT）；「本季全部」的实际 AniList 响应量级未实测，页数上限 12 为防御值。

TODO-2487

https://claude.ai/code/session_017ZUDdFKDGNxpH4r5UcdWj4