### PR TITLE
fix(video): \pos 字幕与锚点字幕共用同一条控制条避让契约（BUG-1330）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1277 条。点号进各自文件。
+> 共 1278 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1330](bugs/BUG-1330-video-pos-subtitle-no-controls-dodge.md) | ✅ | ✅ | 带 \pos 的字幕不避让控制条、盖住暂停键 |
 | [BUG-1328](bugs/BUG-1328-ui-font-chain-collapsed-to-single-family.md) | ✅ | ✅ | 界面字体回退链被压成单值：中文默认字形难看、日文缺字逐字乱回退、用户第2条字体永不生效 |
 | [BUG-1327](bugs/BUG-1327-video-context-dialog-barrier.md) | ✅ | ✅ | 视频页制卡上下文对话框被查词浮层 barrier 吃掉点击 |
 | [BUG-1326](bugs/BUG-1326-popup-ctx-modal-args-stringified.md) | ✅ | ✅ | 调整上下文回点制卡永远点第一个词条 |

--- a/docs/bugs/BUG-1330-video-pos-subtitle-no-controls-dodge.md
+++ b/docs/bugs/BUG-1330-video-pos-subtitle-no-controls-dodge.md
@@ -37,7 +37,7 @@ Dialogue: 0,0:00:41.35,0:00:44.48,OP_JP,,0,0,0,,{\an7\pos(461,672)\fad(250,250)\
 
 ### 修复
 
-- **[x] ① 已修复** — commit `（见下方补记）`
+- **[x] ① 已修复** — commit `75e9ad012`
   - 几何真相源抽成纯函数 `resolveAbsoluteCueOffset()`（`video_subtitle_overlay.dart`），
     与 `_paddingFor` **严格同构**：取下限、不是加法、只单向移动。
     - 盒底越过 `height - bottomReserve` 才上抬（`math.min`，高位盒不被拽下）；

--- a/docs/bugs/BUG-1330-video-pos-subtitle-no-controls-dodge.md
+++ b/docs/bugs/BUG-1330-video-pos-subtitle-no-controls-dodge.md
@@ -1,0 +1,73 @@
+## BUG-1330 · 带 \pos 的字幕不避让控制条、盖住暂停键
+
+- **报告**：2026-08-01（用户：底栏出现时字幕不跟着移动；字幕层级比暂停键还高）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:1335`（旧 `\pos` 分支直接 `return Stack(Positioned(...))`）
+
+### 复现片源真值
+
+`[Nekomoe kissaten&VCB-Studio] Tensei Oujo to Tensai Reijou no Mahou Kakumei`，
+`PlayResX 1280 / PlayResY 720`，OP 卡拉OK 每字一条独立事件（每集 175 条）：
+
+```
+Dialogue: 0,0:00:41.35,0:00:44.48,OP_JP,,0,0,0,,{\an7\pos(461,672)\fad(250,250)\blur2}手
+```
+
+`y=672/720 = 93.3%`，正是桌面进度条 + 按钮行那一条。控制条一出现就把整句 OP 歌词压在
+底下；而字幕层在 Stack 里挂在 media_kit 控制条之上，于是歌词反过来盖住暂停/播放键。
+
+### 根因
+
+字幕层有两条互斥的定位分支：
+
+- 锚点分支 → `_anchoredPadded` → `_paddingFor`：实现了「控制条可见时对 reserve 取下限」
+  的避让契约（TODO-129/161、BUG-180/226/228/238/1069，产品语义是 **UI 赢重叠**）。
+- `\pos` / `\move` 绝对定位分支 → 裸 `Positioned` + `FractionalTranslation`：
+  `controlsVisible` / `controlsBottomReserve` / `controlsTopReserve` **一个都不参与**。
+
+即避让契约被挂在了「定位分支」上，而不是「字幕层」上。定位方式是实现细节，避让是产品
+契约，契约不该随分支消失——这是特殊情况分裂，不是缺功能。
+
+`\pos` 的坐标映射本身没问题（按 PlayResX/Y 归一 + fit:contain letterbox 映射，已核）。
+
+### 为什么不能用 `Positioned` 修
+
+判断「盒底是否探进控制条带」需要**子盒真实尺寸**，而 `Positioned` 与
+`FractionalTranslation` 都在布局前定位、拿不到尺寸。故改用 `CustomSingleChildLayout` +
+`SingleChildLayoutDelegate`，在 `getPositionForChild(size, childSize)` 里定位与钳制一次算完。
+
+### 修复
+
+- **[x] ① 已修复** — commit `（见下方补记）`
+  - 几何真相源抽成纯函数 `resolveAbsoluteCueOffset()`（`video_subtitle_overlay.dart`），
+    与 `_paddingFor` **严格同构**：取下限、不是加法、只单向移动。
+    - 盒底越过 `height - bottomReserve` 才上抬（`math.min`，高位盒不被拽下）；
+    - 盒顶越过 `topReserve` 才下压（`math.max`，低位盒不被顶上）；
+    - 都不成立时坐标逐像素等于作者 `\pos`（招牌 / 画面中部特效外观不变）。
+  - 控制条显隐用 `TweenAnimationBuilder` 在「作者位 ↔ 避让位」间插值，时长/曲线与锚点
+    分支的 `AnimatedPadding` 同源（200ms / easeOut），两条分支跟手感一致。
+  - `controlsVisible == null`（测试 / 有声书 / 无控制条）时避让进度恒 0，历史像素级不变。
+  - **水平方向不做任何钳制**：横向出屏是另一个根因（`\fn@…` 竖排字体前缀未支持，见备注），
+    钳到屏内只会把那个 bug 盖住。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_pos_dodge_test.dart`
+  - 9 条行为测试用**片源真值**（`\an7\pos(461,672)`、1280×720 → 1080p）算，覆盖：隐藏时
+    逐像素不变、可见时恰骑进度条上缘、取下限不加法、只上抬不下拽、顶栏对称、淡入淡出插值、
+    x 不钳制、带高不足时顶部优先、`\an` 锚点换算。
+  - 2 条源码守卫：`\pos` 分支不得退回裸 `Positioned` / `FractionalTranslation`；避让必须
+    是 `math.min`/`math.max` 而非 reserve 加法。
+  - 守卫已做**变异实测**（纪律要求）：① 去掉插值 → 插值那条真红；② 把分支退回旧的裸
+    `Positioned` → 源码守卫真红。两次均反向替换还原，未用 `git checkout --`。
+  - 回归：`test/media/video` 1993 条、`test/pages` 2484 条全绿。
+
+### 备注
+
+同一批用户报告里另外两条，已定性但**不在本次修复范围**：
+
+1. **字幕列表全是单字**（图1）：不是 bug，片源就是每字一条 `\pos` 事件，列表 1:1 列事件。
+   若要改善需在列表层把「同一行的逐字事件」合并回一句（新功能，非修 bug）。
+2. **竖排歌词跑到屏幕左边外**（图3）：真 bug，独立根因——
+   `{\fad(250,250)\blur2\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}雨上がり…`
+   里的 `\fn@` **`@` 前缀**是 ASS/GDI 的「竖排字体」约定（字形在字体内已预旋转 90°，配合
+   `\frz270` 才得到「字正着、行竖排」）。`_resolveAssFontFamily`
+   （`video_subtitle_overlay.dart:2244`）把 `@` 直接剥掉当普通字体名，竖排语义丢失，而
+   `\frz270` 照转 → 整行躺倒、盒子几何错位到左边缘外。需单独立项支持竖排书写模式。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -1337,21 +1337,7 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       // \pos 绝对定位：把字幕盒的 \an 锚点精确落到映射坐标（\pos 覆盖 MarginV）。
       final SubtitleAnchor anchor = posMarkup!.anchor ??
           const SubtitleAnchor(SubtitleVAlign.bottom, SubtitleHAlign.center);
-      return Stack(
-        children: <Widget>[
-          Positioned(
-            left: posScreen.dx,
-            top: posScreen.dy,
-            child: FractionalTranslation(
-              translation: Offset(
-                -_hFrac(anchor.horizontal),
-                -_vFrac(anchor.vertical),
-              ),
-              child: content,
-            ),
-          ),
-        ],
-      );
+      return _absolutePositioned(posScreen, anchor, content);
     }
     // 无 \pos：纯 SRT 副字幕强制顶部锚点；否则按 markup 锚点（null → 历史底居中）。
     final SubtitleAnchor? anchor = forceTop
@@ -2500,6 +2486,57 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     );
   }
 
+  /// `\pos` / `\move` 绝对定位盒：把字幕盒的 `\an` 锚点落到 [posScreen]，并与锚点分支
+  /// （[_anchoredPadded] → [_paddingFor]）**共用同一条 chrome 避让契约**。
+  ///
+  /// BUG-1330 根因：避让原先挂在「锚点定位分支」上而不是「字幕层」上——带 `\pos` 的 cue
+  /// 直接走裸 [Positioned] 返回，[controlsVisible] / reserve 一概不参与，于是 OP 卡拉OK 那种
+  /// `{\an7\pos(461,672)}`（672/720 = 画面 93.3%，正是进度条那一条）的逐字歌词恒被控制条
+  /// 压住、且画在 chrome 之上盖掉暂停键。定位方式是**实现细节**，「UI 赢重叠」是产品契约，
+  /// 契约不该随分支消失。
+  ///
+  /// 语义与 [_paddingFor] 严格同构——**取下限、不是加法、只单向移动**：
+  /// - 盒底探进底部 chrome 带才上抬到恰骑其上缘（`min`，绝不把高位盒往下拽）；
+  /// - 盒顶探进顶部 chrome 带才下压到其下缘（`max`，绝不把低位盒往上顶）；
+  /// - 两者都不成立时坐标逐像素等于作者 `\pos`（招牌 / 画面中部特效外观不变）。
+  ///
+  /// 水平方向**不做任何钳制**：`\pos` 的 x 是作者语义，横向出屏另有根因（`\fn@…` 竖排
+  /// 字体前缀未支持），钳到屏内只会把那个 bug 盖住。
+  ///
+  /// 无 [VideoSubtitleOverlay.controlsVisible]（测试 / 有声书 / 无控制条）时避让进度恒 0，
+  /// 与历史像素级一致。控制条显隐用 [TweenAnimationBuilder] 在「作者位」与「避让位」之间
+  /// 插值，时长/曲线与锚点分支的 [AnimatedPadding] 同源，两条分支跟手感一致。
+  Widget _absolutePositioned(
+      Offset posScreen, SubtitleAnchor anchor, Widget content) {
+    final double anchorFx = _hFrac(anchor.horizontal);
+    final double anchorFy = _vFrac(anchor.vertical);
+    Widget layout(double dodgeProgress) => CustomSingleChildLayout(
+          delegate: _AbsoluteCueLayoutDelegate(
+            pos: posScreen,
+            anchorFx: anchorFx,
+            anchorFy: anchorFy,
+            topReserve: widget.controlsTopReserve,
+            bottomReserve: widget.controlsBottomReserve,
+            dodgeProgress: dodgeProgress,
+          ),
+          child: content,
+        );
+
+    final ValueListenable<bool>? visible = widget.controlsVisible;
+    if (visible == null) return layout(0);
+    return ValueListenableBuilder<bool>(
+      valueListenable: visible,
+      builder: (BuildContext _, bool controlsVisible, Widget? child) {
+        return TweenAnimationBuilder<double>(
+          tween: Tween<double>(end: controlsVisible ? 1.0 : 0.0),
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+          builder: (BuildContext _, double t, Widget? __) => layout(t),
+        );
+      },
+    );
+  }
+
   /// 把 [charContext] 对应字符的局部布局矩形转成全局屏幕矩形（弹窗定位用）。
   /// 无 RenderBox 时退化成 [Rect.zero]，调用方有 fallback。
   static Rect _globalRectOf(BuildContext charContext) {
@@ -2508,6 +2545,91 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     final Offset topLeft = ro.localToGlobal(Offset.zero);
     return topLeft & ro.size;
   }
+}
+
+/// `\pos` / `\move` 绝对定位盒的最终左上角（容器局部坐标）。纯函数，几何真相源。
+///
+/// [pos] 是 `\pos` 映射到容器的锚点；[anchorFx]/[anchorFy] 是 `\an` 锚点在盒内的比例
+/// （左/上=0、中=0.5、右/下=1），故作者位 = `pos - (anchorFx*w, anchorFy*h)`。
+///
+/// [dodgeProgress] ∈ [0,1] 是控制条可见度（0=隐藏，1=完全可见）：在作者位与避让位之间
+/// 线性插值，供淡入淡出期跟随。避让语义与 [VideoSubtitleOverlayState._paddingFor] 同构
+/// ——对 chrome 带**取下限、单向移动**，不是加法：
+/// - 盒底越过 `height - bottomReserve` 才上抬（`math.min`，高位盒不被拽下）；
+/// - 盒顶越过 `topReserve` 才下压（`math.max`，低位盒不被顶上）；
+/// - 带高不足以容纳字幕盒时顶部优先（结果确定，不来回抖）。
+///
+/// 水平坐标恒为作者位（`\pos` 的 x 是作者语义，不钳制）。
+@visibleForTesting
+Offset resolveAbsoluteCueOffset({
+  required Offset pos,
+  required Size container,
+  required Size child,
+  required double anchorFx,
+  required double anchorFy,
+  required double topReserve,
+  required double bottomReserve,
+  required double dodgeProgress,
+}) {
+  final double rawX = pos.dx - anchorFx * child.width;
+  final double rawY = pos.dy - anchorFy * child.height;
+  if (dodgeProgress <= 0) return Offset(rawX, rawY);
+  double dodgedY = rawY;
+  // 底部 chrome（进度条 + 按钮行）：只上抬，抬到盒底恰骑其上缘。
+  final double bandBottom = container.height - bottomReserve;
+  dodgedY = math.min(dodgedY, bandBottom - child.height);
+  // 顶部 chrome（标题栏 + 右上角菜单，BUG-1069 同契约）：只下压，压到其下缘。
+  dodgedY = math.max(dodgedY, topReserve);
+  final double t = dodgeProgress.clamp(0.0, 1.0).toDouble();
+  return Offset(rawX, rawY + (dodgedY - rawY) * t);
+}
+
+/// [resolveAbsoluteCueOffset] 的布局壳：`\pos` 盒需要**子盒真实尺寸**才能判断「盒底是否
+/// 探进控制条」，故不能用 [Positioned] + [FractionalTranslation]（两者都在布局前定位）。
+class _AbsoluteCueLayoutDelegate extends SingleChildLayoutDelegate {
+  const _AbsoluteCueLayoutDelegate({
+    required this.pos,
+    required this.anchorFx,
+    required this.anchorFy,
+    required this.topReserve,
+    required this.bottomReserve,
+    required this.dodgeProgress,
+  });
+
+  final Offset pos;
+  final double anchorFx;
+  final double anchorFy;
+  final double topReserve;
+  final double bottomReserve;
+  final double dodgeProgress;
+
+  // 字幕盒按内容自然尺寸排版（与旧 Positioned(child:) 的无界宽同义）：不被层尺寸拉伸，
+  // 也不因避让而换行重排——避让只挪位置，不改变盒的排版结果。
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) =>
+      const BoxConstraints();
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) =>
+      resolveAbsoluteCueOffset(
+        pos: pos,
+        container: size,
+        child: childSize,
+        anchorFx: anchorFx,
+        anchorFy: anchorFy,
+        topReserve: topReserve,
+        bottomReserve: bottomReserve,
+        dodgeProgress: dodgeProgress,
+      );
+
+  @override
+  bool shouldRelayout(_AbsoluteCueLayoutDelegate old) =>
+      pos != old.pos ||
+      anchorFx != old.anchorFx ||
+      anchorFy != old.anchorFy ||
+      topReserve != old.topReserve ||
+      bottomReserve != old.bottomReserve ||
+      dodgeProgress != old.dodgeProgress;
 }
 
 /// GDI 全名尾部**字重后缀** → [FontWeight]；不是字重后缀返回 null。纯函数可单测。

--- a/hibiki/test/media/video/video_subtitle_pos_dodge_test.dart
+++ b/hibiki/test/media/video/video_subtitle_pos_dodge_test.dart
@@ -1,0 +1,162 @@
+// BUG-1330：带 `\pos` 的字幕不避让控制条、画在暂停键之上。
+//
+// 用户片源真值（[Nekomoe kissaten&VCB-Studio] Tensei Oujo to Tensai Reijou no Mahou
+// Kakumei，PlayResX 1280 / PlayResY 720）：
+//
+//   Dialogue: 0,0:00:41.35,0:00:44.48,OP_JP,,0,0,0,,{\an7\pos(461,672)\fad(250,250)\blur2}手
+//
+// y=672/720 = 93.3%，正是进度条那一条。旧实现里 `\pos` 分支直接走裸 Positioned 返回，
+// controlsVisible / reserve 一概不参与——避让契约被挂在「定位分支」而不是「字幕层」上。
+// 本组测试钉死：绝对定位分支与锚点分支（_paddingFor）共用同一条取下限避让语义。
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki/src/media/video/video_subtitle_style.dart';
+
+void main() {
+  // 1080p 显示区 + 桌面控制条几何。
+  const Size container = Size(1920, 1080);
+  const double bottomReserve = kVideoControlsBottomReserve; // 56
+  const double topReserve = 60;
+  // 片源真值：\pos(461,672) 在 1280x720 画布 → 归一后落到 1080p 显示区。
+  const Offset opCharPos =
+      Offset(461 / 1280 * 1920, 672 / 720 * 1080); // dy=1008
+  // OP_JP Fontsize 38（720 画布）→ 1080p 上约 57px 高的单字盒。
+  const Size charBox = Size(57, 57);
+  // \an7 = 左上锚点。
+  const double an7Fx = 0;
+  const double an7Fy = 0;
+
+  Offset resolve({
+    Offset pos = opCharPos,
+    Size child = charBox,
+    double anchorFx = an7Fx,
+    double anchorFy = an7Fy,
+    double dodgeProgress = 1,
+    double top = topReserve,
+    double bottom = bottomReserve,
+  }) =>
+      resolveAbsoluteCueOffset(
+        pos: pos,
+        container: container,
+        child: child,
+        anchorFx: anchorFx,
+        anchorFy: anchorFy,
+        topReserve: top,
+        bottomReserve: bottom,
+        dodgeProgress: dodgeProgress,
+      );
+
+  group('\\pos 绝对定位盒的 chrome 避让（BUG-1330）', () {
+    test('控制条隐藏时逐像素等于作者 \\pos（不改变既有外观）', () {
+      final Offset o = resolve(dodgeProgress: 0);
+      expect(o.dy, closeTo(1008, 0.01), reason: '\\an7 顶锚：盒顶就落在 \\pos 的 y 上');
+      expect(o.dx, closeTo(461 / 1280 * 1920, 0.01));
+    });
+
+    test('控制条可见时 OP 逐字歌词被抬到恰骑进度条上缘（用户报的原始失败路径）', () {
+      final Offset o = resolve();
+      // 作者位盒底 1008+57=1065 > 可用带底 1080-56=1024 → 上抬 41px。
+      expect(o.dy + charBox.height,
+          closeTo(container.height - bottomReserve, 0.01),
+          reason: '盒底应恰骑控制条上缘，既不被压住也不飞');
+      expect(o.dy, lessThan(1008), reason: '必须是上抬');
+    });
+
+    test('取下限而非加法：盒底没探进控制条带的 \\pos 字幕坐标一动不动', () {
+      // 画面中部的招牌/特效：盒底 600+57 远在 1024 之上。
+      final Offset o = resolve(pos: const Offset(300, 600));
+      expect(o.dy, closeTo(600, 0.01),
+          reason: '加法叠加会把它凭空多抬一个 reserve（TODO-161 顶飞回归）');
+    });
+
+    test('避让只上抬、绝不把字幕往下拽', () {
+      // 一个已经很高的 \pos：避让后不得变大（变大=下移）。
+      final Offset lifted = resolve(pos: const Offset(300, 100));
+      expect(lifted.dy, lessThanOrEqualTo(100 + 0.01));
+    });
+
+    test('顶部 chrome 同契约：只下压到顶栏下缘，且不把低位盒往上顶', () {
+      final Offset o = resolve(pos: const Offset(300, 5));
+      expect(o.dy, closeTo(topReserve, 0.01),
+          reason: '盒顶探进顶栏 → 压到其下缘（BUG-1069 同契约）');
+      final Offset low = resolve(pos: const Offset(300, 500));
+      expect(low.dy, closeTo(500, 0.01), reason: '顶栏避让不得把画面中部的盒往上顶');
+    });
+
+    test('控制条淡入淡出期在作者位与避让位之间插值（与 AnimatedPadding 同手感）', () {
+      final Offset at0 = resolve(dodgeProgress: 0);
+      final Offset at1 = resolve(dodgeProgress: 1);
+      final Offset half = resolve(dodgeProgress: 0.5);
+      expect(half.dy, closeTo((at0.dy + at1.dy) / 2, 0.01));
+    });
+
+    test('水平坐标恒为作者位——横向出屏另有根因（\\fn@ 竖排字体），不得用钳制掩盖', () {
+      // 片源真值：{\an2\frz270\pos(10,360)} 竖排歌词，x 极小。
+      final Offset o = resolve(
+        pos: const Offset(10 / 1280 * 1920, 360 / 720 * 1080),
+        anchorFx: 0.5,
+        anchorFy: 1,
+        child: const Size(700, 57),
+      );
+      expect(o.dx, closeTo(10 / 1280 * 1920 - 350, 0.01),
+          reason: 'x 必须原样透传（含负值）；钳到屏内会把竖排字体未支持这个真 bug 盖住');
+    });
+
+    test('可用带比字幕盒还矮时顶部优先，结果确定不抖', () {
+      final Offset o = resolve(
+        pos: const Offset(300, 900),
+        child: const Size(57, 1200),
+        dodgeProgress: 1,
+      );
+      expect(o.dy, closeTo(topReserve, 0.01));
+    });
+
+    test('\\an 锚点比例参与作者位换算（\\an2 底居中）', () {
+      final Offset o = resolve(
+        pos: const Offset(960, 500),
+        anchorFx: 0.5,
+        anchorFy: 1,
+        child: const Size(400, 60),
+        dodgeProgress: 0,
+      );
+      expect(o.dx, closeTo(960 - 200, 0.01));
+      expect(o.dy, closeTo(500 - 60, 0.01));
+    });
+  });
+
+  group('源码守卫：避让契约不得随定位分支消失', () {
+    final String src = File('lib/src/media/video/video_subtitle_overlay.dart')
+        .readAsStringSync();
+
+    test('\\pos 分支不得退回裸 Positioned（那正是 BUG-1330 的形状）', () {
+      final int branch = src.indexOf('final Offset? posScreen = _posScreen(');
+      expect(branch, greaterThanOrEqualTo(0), reason: '\\pos 定位分支应存在');
+      final int branchEnd = src.indexOf('    // 无 \\pos：', branch);
+      expect(branchEnd, greaterThan(branch));
+      final String body = src.substring(branch, branchEnd);
+      expect(body, contains('_absolutePositioned('),
+          reason: '\\pos 分支必须走带避让的定位盒');
+      expect(body, isNot(contains('FractionalTranslation')),
+          reason: 'FractionalTranslation 在布局前定位、拿不到子盒尺寸，无法判断是否探进控制条');
+    });
+
+    test('绝对定位避让必须取下限（min/max），不得写成 reserve 加法', () {
+      final int fn = src.indexOf('Offset resolveAbsoluteCueOffset(');
+      expect(fn, greaterThanOrEqualTo(0));
+      // 切到下一个顶层声明为止。不能用 '\n}' 找函数尾——具名参数列表的 '}) {' 也以 '}'
+      // 开行，会把函数体整段切掉，守卫就永远只看参数签名（本测试首版即栽在这里）。
+      final int fnEnd = src.indexOf('class _AbsoluteCueLayoutDelegate', fn);
+      expect(fnEnd, greaterThan(fn));
+      final String body = src.substring(fn, fnEnd);
+      expect(body, contains('math.min(dodgedY, bandBottom - child.height)'),
+          reason: '底部避让取下限：盒底骑控制条上缘');
+      expect(body, contains('math.max(dodgedY, topReserve)'),
+          reason: '顶部避让取下限（对称）');
+      expect(body, isNot(contains('+ bottomReserve')),
+          reason: '避让不能写成加法叠加（TODO-161 顶飞回归）');
+    });
+  });
+}


### PR DESCRIPTION
## 用户报告

- 「他不会随底栏出现，移动。这个要修复」
- 「层级比暂停还高」

## 根因

字幕层有两条互斥的定位分支：

- 锚点分支 → `_anchoredPadded` → `_paddingFor`：实现了「控制条可见时对 reserve 取下限」的避让契约（TODO-129/161、BUG-180/226/228/238/1069，产品语义是 **UI 赢重叠**）。
- `\pos` / `\move` 绝对定位分支 → 裸 `Positioned` + `FractionalTranslation`：`controlsVisible` / `controlsBottomReserve` / `controlsTopReserve` **一个都不参与**。

避让契约被挂在「定位分支」上而不是「字幕层」上。定位方式是实现细节，避让是产品契约，契约不该随分支消失。

`\pos` 的坐标映射本身没问题（按 PlayResX/Y 归一 + fit:contain letterbox 映射，已核）。

## 复现片源真值

`[Nekomoe kissaten&VCB-Studio] Tensei Oujo to Tensai Reijou no Mahou Kakumei`，`PlayResX 1280 / PlayResY 720`，OP 卡拉OK 每字一条独立事件（每集 175 条）：

```
Dialogue: 0,0:00:41.35,0:00:44.48,OP_JP,,0,0,0,,{\an7\pos(461,672)\fad(250,250)\blur2}手
```

`y=672/720 = 93.3%`，正是桌面进度条 + 按钮行那一条。

## 为什么不能用 Positioned 修

判断「盒底是否探进控制条带」需要**子盒真实尺寸**，而 `Positioned` 与 `FractionalTranslation` 都在布局前定位、拿不到尺寸。改用 `CustomSingleChildLayout` + `SingleChildLayoutDelegate`，在 `getPositionForChild(size, childSize)` 里定位与钳制一次算完。

## 修复

- 几何真相源抽成纯函数 `resolveAbsoluteCueOffset()`，与 `_paddingFor` **严格同构**：取下限、不是加法、只单向移动。盒底越过 `height - bottomReserve` 才上抬（`math.min`）；盒顶越过 `topReserve` 才下压（`math.max`）；都不成立时逐像素等于作者 `\pos`（招牌 / 画面中部特效外观不变）。
- 控制条显隐用 `TweenAnimationBuilder` 在「作者位 ↔ 避让位」间插值，200ms / easeOut，与锚点分支 `AnimatedPadding` 同源。
- `controlsVisible == null`（测试 / 有声书 / 无控制条）时避让进度恒 0，历史像素级不变。
- **水平方向不做任何钳制**：横向出屏是另一个根因（见下），钳到屏内只会把那个 bug 盖住。

## 验证

- 新增 `hibiki/test/media/video/video_subtitle_pos_dodge_test.dart`：9 条行为测试（用片源真值 `\an7\pos(461,672)`、1280×720 → 1080p 算）+ 2 条源码守卫。
- 守卫做了**变异实测**：① 去掉插值 → 插值那条真红；② 把分支退回旧的裸 `Positioned` → 源码守卫真红。两次均反向替换还原。
- 回归：`test/media/video` **1993 条**全绿、`test/pages` **2484 条**全绿；全量 `flutter analyze` No issues found。

## 同批报告里未纳入本 PR 的两条（已定性）

1. **字幕列表全是单字**：不是 bug——片源就是每字一条 `\pos` 事件，列表 1:1 列事件；libass 靠 `\pos` 把它们摆成一行才看着像一句。要改善需在列表层把「同一行的逐字事件」合并回一句，属新功能。
2. **竖排歌词跑到屏幕左边外**：真 bug，独立根因。`{\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}` 里的 `\fn@` **`@` 前缀**是 ASS/GDI 的「竖排字体」约定（字形在字体内已预旋转 90°，配合 `\frz270` 才得到「字正着、行竖排」）。`_resolveAssFontFamily`（`video_subtitle_overlay.dart:2244`）把 `@` 直接剥掉当普通字体名，竖排语义丢失而 `\frz270` 照转 → 整行躺倒、盒子几何错位到左边缘外。需单独立项支持竖排书写模式。

https://claude.ai/code/session_01NsfYwDbaihWsR71mBQ1MWZ