### PR TITLE
fix(video): 支持 ASS \fn@ 竖排字体的字形预旋转（BUG-1331）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1278 条。点号进各自文件。
+> 共 1279 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1331](bugs/BUG-1331-video-ass-vertical-font-not-supported.md) | ✅ | ✅ | \fn@ 竖排字体未支持导致整行躺倒出屏 |
 | [BUG-1330](bugs/BUG-1330-video-pos-subtitle-no-controls-dodge.md) | ✅ | ✅ | 带 \pos 的字幕不避让控制条、盖住暂停键 |
 | [BUG-1328](bugs/BUG-1328-ui-font-chain-collapsed-to-single-family.md) | ✅ | ✅ | 界面字体回退链被压成单值：中文默认字形难看、日文缺字逐字乱回退、用户第2条字体永不生效 |
 | [BUG-1327](bugs/BUG-1327-video-context-dialog-barrier.md) | ✅ | ✅ | 视频页制卡上下文对话框被查词浮层 barrier 吃掉点击 |

--- a/docs/bugs/BUG-1331-video-ass-vertical-font-not-supported.md
+++ b/docs/bugs/BUG-1331-video-ass-vertical-font-not-supported.md
@@ -29,7 +29,7 @@ GDI/VSFilter 约定：字体名以 `@` 开头 = **竖排字体**，其字形逆�
 
 ### 修复
 
-- **[x] ① 已修复** — commit `（见下方补记）`
+- **[x] ① 已修复** — commit `feb566548`
   - 新增判据纯函数 `isAssVerticalFontName()` 与渲染侧 `_applyVerticalGlyphRotation()`：
     对 `@` 字体的**每个字形**绕自身中心逆时针转 90°（`Transform.rotate(-π/2)`；Flutter Z 轴
     视觉正方向为顺时针，取负与 `_applyAssTransform` 里 `\frz` 的取负同源）。

--- a/docs/bugs/BUG-1331-video-ass-vertical-font-not-supported.md
+++ b/docs/bugs/BUG-1331-video-ass-vertical-font-not-supported.md
@@ -1,0 +1,63 @@
+## BUG-1331 · \fn@ 竖排字体未支持导致整行躺倒出屏
+
+- **报告**：2026-08-01（用户：「这左边的字都出去了」）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/src/media/video/video_subtitle_overlay.dart:2244`
+  （`_resolveAssFontFamily` 把 `@` 前缀当噪声剥掉，无人承接竖排语义）
+
+### 复现片源真值
+
+`[Nekomoe kissaten&VCB-Studio] Tensei Oujo to Tensai Reijou no Mahou Kakumei`，
+`PlayResX 1280 / PlayResY 720`（每集 OP 各一条）：
+
+```
+Dialogue: 0,0:02:00.02,0:02:09.36,OP_JP,,0,0,0,,{\fad(250,250)\blur2\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}雨上がり　君は　君の目で答えを探してほしい
+```
+
+### 根因
+
+GDI/VSFilter 约定：字体名以 `@` 开头 = **竖排字体**，其字形逆时针预旋转 90°（字顶朝左）
+存储，而文本**仍按水平方向排版**。字幕组据此写出竖排的标准组合：
+
+- `\fn@…` → 字形躺倒（逆时针 90°）
+- `\frz270` → 整行顺时针 90°：行方向由水平变竖直（自上而下），字形同时被转回正立
+
+两次旋转互相抵消，才得到「字正着、行竖排」。
+
+`_resolveAssFontFamily` 剥掉 `@` 这一步**本身是对的**（DirectWrite 家族名确实不含 `@`，
+不剥就查不到字体），但剥掉之后没有任何地方承接竖排语义；而 `\frz270` 照转不误 —— 于是
+只剩下单向的 90° 旋转：整行躺倒，盒几何随之错位到画面左缘外。
+
+### 修复
+
+- **[x] ① 已修复** — commit `（见下方补记）`
+  - 新增判据纯函数 `isAssVerticalFontName()` 与渲染侧 `_applyVerticalGlyphRotation()`：
+    对 `@` 字体的**每个字形**绕自身中心逆时针转 90°（`Transform.rotate(-π/2)`；Flutter Z 轴
+    视觉正方向为顺时针，取负与 `_applyAssTransform` 里 `\frz` 的取负同源）。
+  - 关键取舍：**忠实建模「字形预旋转」本身，而不是新造一套竖排排版分支**。这样
+    `\pos` / `\an` / `\frz` / `\fad` / 分组 / 逐字命中登记**全部照旧生效**，零特例分支——
+    竖排是「字形属性」而非「布局模式」，按 ASS 原语义它本就该落在这一层。
+  - 行内 `\fn` 优先于样式表 `Fontname`，与 `_styleForGrapheme` 的字体优先级同源。
+  - 纯字幕模式（`respectAssStyle` 关）位置/样式语义整体归零，竖排一并不生效。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_subtitle_vertical_font_test.dart`
+  - 3 条纯函数判据 + 5 条渲染行为 + 2 条源码守卫，共 10 条。
+  - 行为测试用**片源真值**（`\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)`）逐层
+    累乘祖先 `Transform` 矩阵，断言字形轴向：`@`+`\frz270` → 净 0（正立）；只有 `@` →
+    逆时针 90°；**无 `@` 的普通字体 + `\frz270` → 仍单向躺倒**（招牌类字幕既有语义不被改）。
+  - 守卫已做**变异实测**：把方向写反成 `+π/2` → 3 条测试同时红（2 条行为 + 1 条守卫）；
+    反向替换还原，未用 `git checkout --`。
+  - 回归：`test/media/video` 2003 条全绿。
+
+### 已知近似
+
+`Transform.rotate` 不改变布局尺寸，而 GDI 竖排字形的 advance 是宽高互换的。CJK 全角字
+（含全角空格）宽≈高，逐字盒几何几乎不变；`@` 字体本就是 CJK 竖排专用，混排窄拉丁字符时
+会有半字宽级别的偏差，接受。
+
+另：`\frz` 目前绕**盒中心**旋转（`_applyAssTransform` 的 `Alignment.center`），libass 绕
+**对齐点/`\org`** 旋转。本条不改（既有招牌字幕依赖当前行为，且与本 bug 的躺倒无关），
+差异体现为长文本旋转后有半个行高级别的位移。若日后发现旋转招牌位置偏移，从这里查。
+
+### 相关
+
+- BUG-1330：同批用户报告的另一条（带 `\pos` 的字幕不避让控制条），根因不同、已单独修复。

--- a/hibiki/lib/src/media/video/video_subtitle_overlay.dart
+++ b/hibiki/lib/src/media/video/video_subtitle_overlay.dart
@@ -1510,7 +1510,8 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
               isSecondary: isSecondary,
             ));
           }
-          final Widget ch = _buildSubtitleChar(chars[i], i, markup, cue);
+          final Widget ch = _applyVerticalGlyphRotation(
+              _buildSubtitleChar(chars[i], i, markup, cue), i, markup);
           // 选词光标环（手柄查词）：光标停在本字符时外画一圈主题色圆角框。
           // foregroundDecoration 画在字形之上、不改变布局几何（字幕排版零位移）。
           // 登记与画环同帧同源（entryIndex 即登记序），不存在几何滞后。
@@ -1799,6 +1800,46 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
       );
     }
     return _applySpanScale(glyph, char, i, markup, fillStyle);
+  }
+
+  /// GDI/ASS「`@` 前缀 = 竖排字体」约定的字形预旋转（BUG-1331）。
+  ///
+  /// 语义（VSFilter/libass 与 GDI 一致）：`@` 开头的字体，其**字形本身**逆时针预旋转
+  /// 90°（字顶朝左）存储，而文本**仍按水平方向排版**。字幕组据此写出竖排的标准组合
+  ///
+  /// ```
+  /// {\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}雨上がり　君は…
+  /// ```
+  ///
+  /// ——`\frz270`（ASS 逆时针为正，270° 即顺时针 90°）把整行顺时针转 90°：行方向由水平
+  /// 变竖直（自上而下），字形由躺倒转回正立。两次旋转互相抵消才得到「字正着、行竖排」。
+  ///
+  /// 旧实现只在 [_resolveAssFontFamily] 里把 `@` 当噪声剥掉（DirectWrite 家族名确实不含
+  /// `@`，那一步是对的），却没有任何地方承接被剥掉的**竖排语义**；而 `\frz270` 照转不误
+  /// ——于是只剩下单向的 90° 旋转，整行躺倒、盒几何随之错位到画面左缘外（用户报「左边的
+  /// 字都出去了」）。
+  ///
+  /// 修法是忠实建模「字形预旋转」本身，而不是新造一套竖排排版分支：每个字形绕自身中心
+  /// 逆时针转 90°（Flutter 的 Z 轴视觉正方向为顺时针，故取 `-π/2`；与 [_applyAssTransform]
+  /// 里 `\frz` 的取负同源）。`\pos` / `\an` / `\frz` / `\fad` / 分组 / 命中登记**全部照旧
+  /// 生效**，零特例分支。
+  ///
+  /// 近似说明：[Transform.rotate] 不改变布局尺寸，而 GDI 竖排字形的 advance 是宽高互换的。
+  /// CJK 全角字（含全角空格）宽≈高，故逐字盒几何几乎不变；`@` 字体本就是 CJK 竖排专用，
+  /// 混排窄拉丁字符时会有半字宽级别的偏差，接受。
+  ///
+  /// 纯字幕模式（respectAssStyle 关）位置/样式语义整体归零，竖排一并不生效。
+  Widget _applyVerticalGlyphRotation(
+      Widget glyph, int i, SubtitleMarkup? markup) {
+    if (!widget.respectAssStyle || markup == null) return glyph;
+    // 行内 \fn 优先于样式表 Fontname（与 [_styleForGrapheme] 的字体优先级同源）。
+    final SubtitleSpan? span = _spanAt(i, markup);
+    final String? spanFont = span?.fontName;
+    final String? name = (spanFont != null && spanFont.isNotEmpty)
+        ? spanFont
+        : markup.cueStyle?.fontName;
+    if (!isAssVerticalFontName(name)) return glyph;
+    return Transform.rotate(angle: -math.pi / 2, child: glyph);
   }
 
   /// span 级静态 `\fscx`/`\fscy` 缩放（ASS：标签处生效到下一次覆盖——说话人前缀
@@ -2546,6 +2587,14 @@ class _VideoSubtitleOverlayState extends State<VideoSubtitleOverlay>
     return topLeft & ro.size;
   }
 }
+
+/// ASS/GDI 字体名是否声明了**竖排书写**（`@` 前缀约定，BUG-1331）。
+///
+/// `@` 只是「字形已预旋转 90°」的标记，不属于家族名——故 [_resolveAssFontFamily] 按家族名
+/// 解析时剥掉它是对的，本判据负责把被剥掉的那半语义接住（见 `_applyVerticalGlyphRotation`）。
+@visibleForTesting
+bool isAssVerticalFontName(String? name) =>
+    name != null && name.startsWith('@');
 
 /// `\pos` / `\move` 绝对定位盒的最终左上角（容器局部坐标）。纯函数，几何真相源。
 ///

--- a/hibiki/test/media/video/video_subtitle_vertical_font_test.dart
+++ b/hibiki/test/media/video/video_subtitle_vertical_font_test.dart
@@ -1,0 +1,158 @@
+// BUG-1331：`\fn@…` 竖排字体未支持 → 整行躺倒、跑出画面左缘。
+//
+// 用户片源真值（[Nekomoe kissaten&VCB-Studio] Tensei Oujo to Tensai Reijou no Mahou
+// Kakumei，PlayResX 1280 / PlayResY 720）：
+//
+//   Dialogue: 0,...,OP_JP,,0,0,0,,{\fad(250,250)\blur2\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}雨上がり…
+//
+// GDI/VSFilter 约定：`@` 前缀字体的**字形**逆时针预旋转 90°（字顶朝左），文本仍水平排版；
+// 作者叠 `\frz270`（顺时针 90°）把行转竖、字形转正。两次旋转抵消才是「字正着、行竖排」。
+// 旧实现把 `@` 当噪声剥掉却没人承接竖排语义，`\frz270` 照转 → 只剩单向 90°，整行躺倒。
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/media/video/video_subtitle_overlay.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+AudioCue _cueOf(String raw) {
+  final SubtitleMarkup m =
+      parseSubtitleMarkup(raw, playResX: 1280, playResY: 720);
+  return AudioCue()
+    ..bookKey = 'b'
+    ..chapterHref = 'c'
+    ..sentenceIndex = 0
+    ..textFragmentId = ''
+    ..text = m.plainText
+    ..markup = m
+    ..startMs = 0
+    ..endMs = 5000;
+}
+
+Future<void> _pump(WidgetTester tester, AudioCue cue,
+    {bool respect = true}) async {
+  tester.view.physicalSize = const Size(1280, 720);
+  tester.view.devicePixelRatio = 1.0;
+  addTearDown(tester.view.reset);
+  final VideoPlayerController c = VideoPlayerController();
+  addTearDown(c.dispose);
+  c.setCues(<AudioCue>[cue]);
+  c.debugUpdateCueForPosition(1000);
+  await tester.pumpWidget(MaterialApp(
+    // 关调试横幅：它本身是个 45° 旋转 Transform，会污染旋转扫描。
+    debugShowCheckedModeBanner: false,
+    home: Scaffold(
+      body: SizedBox(
+        width: 1280,
+        height: 720,
+        child: VideoSubtitleOverlay(controller: c, respectAssStyle: respect),
+      ),
+    ),
+  ));
+  await tester.pump();
+}
+
+/// 该字形从「屏幕 x 轴正方向」被转到了哪个方向。y 向下坐标系里 (0,-1) = 视觉逆时针 90°。
+Offset _glyphAxis(WidgetTester tester, String glyph) {
+  final Iterable<Transform> ts = tester.widgetList<Transform>(
+    find.ancestor(of: find.text(glyph).first, matching: find.byType(Transform)),
+  );
+  Offset axis = const Offset(1, 0);
+  for (final Transform t in ts) {
+    // 取两点之差消掉平移分量，只留旋转/缩放对**方向**的作用。
+    axis = MatrixUtils.transformPoint(t.transform, axis) -
+        MatrixUtils.transformPoint(t.transform, Offset.zero);
+  }
+  final double len = axis.distance;
+  return len == 0 ? axis : Offset(axis.dx / len, axis.dy / len);
+}
+
+void main() {
+  group('isAssVerticalFontName（@ 前缀判据）', () {
+    test('@ 开头 = 竖排字体', () {
+      expect(isAssVerticalFontName('@A-OTF Kaimin Tsuki Std H'), isTrue);
+    });
+    test('普通字体名 / 空 / null 都不是竖排', () {
+      expect(isAssVerticalFontName('A-OTF Kaimin Tsuki Std H'), isFalse);
+      expect(isAssVerticalFontName(''), isFalse);
+      expect(isAssVerticalFontName(null), isFalse);
+    });
+    test('@ 只能在开头（家族名内部含 @ 不算）', () {
+      expect(isAssVerticalFontName('Foo@Bar'), isFalse);
+    });
+  });
+
+  group('渲染：@ 字体的字形预旋转（BUG-1331）', () {
+    testWidgets('片源真值组合 \\fn@…+\\frz270 → 字形正立（两次旋转抵消）', (tester) async {
+      await _pump(
+        tester,
+        _cueOf(r'{\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}雨上がり'),
+      );
+      final Offset axis = _glyphAxis(tester, '雨');
+      // 字形逆时针 90°（@）+ 整行顺时针 90°（\frz270）= 净 0：x 轴仍指向 x 轴。
+      expect(axis.dx, closeTo(1, 0.02),
+          reason: '@ 与 \\frz270 必须抵消成正立字形；只剩单向 90° 就是用户报的「整行躺倒」');
+      expect(axis.dy, closeTo(0, 0.02));
+    });
+
+    testWidgets('只有 @ 没有 \\frz：字形逆时针 90°（忠实复现 GDI 预旋转）', (tester) async {
+      await _pump(tester, _cueOf(r'{\fn@A-OTF Kaimin Tsuki Std H}雨'));
+      final Offset axis = _glyphAxis(tester, '雨');
+      expect(axis.dx, closeTo(0, 0.02));
+      expect(axis.dy, closeTo(-1, 0.02), reason: 'y 向下坐标系里 (0,-1) = 视觉逆时针 90°');
+    });
+
+    testWidgets('无 @ 的普通字体 + \\frz270：字形躺倒（既有行为不变，非竖排）', (tester) async {
+      await _pump(
+          tester, _cueOf(r'{\fnA-OTF Kaimin Tsuki Std H\frz270\pos(10,360)}雨'));
+      final Offset axis = _glyphAxis(tester, '雨');
+      expect(axis.dy, closeTo(1, 0.02),
+          reason: '没有 @ 就没有预旋转，\\frz270 单向生效——招牌类字幕的既有语义不能被改');
+    });
+
+    testWidgets('纯字幕模式（respectAssStyle 关）竖排一并不生效', (tester) async {
+      await _pump(
+        tester,
+        _cueOf(r'{\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}雨'),
+        respect: false,
+      );
+      final Offset axis = _glyphAxis(tester, '雨');
+      expect(axis.dx, closeTo(1, 0.02), reason: '纯字幕模式位置/样式语义整体归零');
+    });
+
+    testWidgets('竖排不改变逐字命中登记（查词照常）', (tester) async {
+      await _pump(
+        tester,
+        _cueOf(r'{\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}雨上がり'),
+      );
+      for (final String ch in <String>['雨', '上', 'が', 'り']) {
+        expect(find.text(ch), findsWidgets, reason: '每个 grapheme 仍各自成 widget');
+      }
+    });
+  });
+
+  group('源码守卫', () {
+    final String src = File('lib/src/media/video/video_subtitle_overlay.dart')
+        .readAsStringSync();
+
+    test('@ 前缀剥离处必须仍有竖排语义的承接方（不得只剥不接）', () {
+      expect(src, contains("name.startsWith('@') ? name.substring(1) : name"),
+          reason: '家族名解析仍应剥 @（DirectWrite 家族名不含 @）');
+      expect(src, contains('isAssVerticalFontName('),
+          reason: '剥掉的竖排语义必须有人承接，否则回到 BUG-1331');
+      expect(src, contains('_applyVerticalGlyphRotation('),
+          reason: '字形预旋转必须真的作用到字符渲染上');
+    });
+
+    test('预旋转方向锁死为逆时针 90°（-π/2）', () {
+      final int fn = src.indexOf('Widget _applyVerticalGlyphRotation(');
+      expect(fn, greaterThanOrEqualTo(0));
+      final int fnEnd = src.indexOf('\n  /// span 级静态', fn);
+      expect(fnEnd, greaterThan(fn));
+      final String body = src.substring(fn, fnEnd);
+      expect(body, contains('Transform.rotate(angle: -math.pi / 2'),
+          reason: '方向写反（+π/2）会让字形与 \\frz270 叠成 180°，字倒立');
+    });
+  });
+}


### PR DESCRIPTION
> **Stacked on #660**（base 指向该 PR 的分支）。#660 合并后本 PR 的 base 会自动回落到 `develop`。

## 用户报告

「这左边的字都出去了」——OP 竖排歌词整行躺倒、跑出画面左缘。

## 复现片源真值

`[Nekomoe kissaten&VCB-Studio] Tensei Oujo to Tensai Reijou no Mahou Kakumei`，`PlayResX 1280 / PlayResY 720`（每集 OP 各一条）：

```
Dialogue: 0,0:02:00.02,0:02:09.36,OP_JP,,0,0,0,,{\fad(250,250)\blur2\fn@A-OTF Kaimin Tsuki Std H\an2\frz270\pos(10,360)}雨上がり　君は　君の目で答えを探してほしい
```

## 根因

GDI/VSFilter 约定：字体名以 `@` 开头 = **竖排字体**，其字形逆时针预旋转 90°（字顶朝左）存储，而文本**仍按水平方向排版**。字幕组据此写出竖排的标准组合：

- `\fn@…` → 字形躺倒（逆时针 90°）
- `\frz270` → 整行顺时针 90°：行方向由水平变竖直，字形同时被转回正立

两次旋转互相抵消，才得到「字正着、行竖排」。

`_resolveAssFontFamily` 剥掉 `@` 这一步**本身是对的**（DirectWrite 家族名确实不含 `@`，不剥就查不到字体），但剥掉之后没有任何地方承接竖排语义；而 `\frz270` 照转不误 —— 于是只剩下单向的 90° 旋转：整行躺倒，盒几何随之错位到画面左缘外。

## 修复

忠实建模「**字形**预旋转」本身，而不是新造一套竖排排版分支：新增判据纯函数 `isAssVerticalFontName()` + 渲染侧 `_applyVerticalGlyphRotation()`，对 `@` 字体的每个字形绕自身中心逆时针转 90°（`Transform.rotate(-π/2)`，取负与 `_applyAssTransform` 里 `\frz` 同源）。

这样 `\pos` / `\an` / `\frz` / `\fad` / 分组 / 逐字命中登记**全部照旧生效**，零特例分支——竖排是「字形属性」而非「布局模式」，按 ASS 原语义本就该落在这一层。行内 `\fn` 优先于样式表 `Fontname`；纯字幕模式（`respectAssStyle` 关）不生效。

## 验证

- 新增 `hibiki/test/media/video/video_subtitle_vertical_font_test.dart`：3 条判据 + 5 条渲染行为 + 2 条源码守卫。
- 行为测试用片源真值逐层累乘祖先 `Transform` 矩阵断言字形轴向：`@`+`\frz270` → 净 0（正立）；只有 `@` → 逆时针 90°；**无 `@` 的普通字体 + `\frz270` → 仍单向躺倒**（招牌类字幕既有语义受保护）。
- **变异实测**：方向写反成 `+π/2` → 3 条测试同时红（2 行为 + 1 守卫），反向替换还原。
- 回归 `test/media/video` **2003 条**全绿；全量 `flutter analyze` No issues found。

## 已知近似（已写进 BUG-1331 文档）

- `Transform.rotate` 不改变布局尺寸，而 GDI 竖排字形 advance 是宽高互换的。CJK 全角字宽≈高，逐字盒几何几乎不变；混排窄拉丁字符会有半字宽级别偏差。
- `\frz` 目前绕**盒中心**旋转，libass 绕**对齐点/`\org`**。本条不改（既有招牌字幕依赖当前行为，与本 bug 的躺倒无关），差异是半个行高级别的位移。

## 位置说明

修复后字形正立、成一竖列贴画面左缘（上下略微超出画面）——这是作者 `\pos(10,360)` + `\an2` 的原意图，与 libass 一致，不是残留 bug。

https://claude.ai/code/session_01NsfYwDbaihWsR71mBQ1MWZ