### PR TITLE
feat(video): 合集相关作品数据层(schema v65) + 集级刮削资料/重命名服务 (TODO-2484/2491 A线)

### DIFF
--- a/hibiki/lib/src/media/metadata/bangumi_api_client.dart
+++ b/hibiki/lib/src/media/metadata/bangumi_api_client.dart
@@ -190,6 +190,36 @@ class BangumiApiClient {
     );
   }
 
+  /// `GET /subjects/{id}/subjects`：拉条目的关联条目列表（前传/续集/番外/剧场版
+  /// 等，`relation` 字段为源侧中文关系词）。TODO-2484 合集「相关作品」用。
+  Future<BangumiRawResponse> fetchSubjectRelations(String subjectId) {
+    final Uri uri = Uri.parse('$baseUrl/subjects/$subjectId/subjects');
+    return _run(
+      () => _client.get(uri, headers: _headers()).timeout(timeout),
+    );
+  }
+
+  /// `GET /episodes?subject_id={id}&type=0`：拉条目的**正篇**分集列表（分页）。
+  /// TODO-2491 集级刮削用。`type=0` = 本篇（滤掉 SP/OP/ED），与追番模块的
+  /// `getMainEpisodes` 同口径；分页由调用方按响应 `total`/`offset` 驱动。
+  Future<BangumiRawResponse> fetchSubjectEpisodes(
+    String subjectId, {
+    int limit = 200,
+    int offset = 0,
+  }) {
+    final Uri uri = Uri.parse('$baseUrl/episodes').replace(
+      queryParameters: <String, String>{
+        'subject_id': subjectId,
+        'type': '0',
+        'limit': '${limit.clamp(1, 200)}',
+        'offset': '$offset',
+      },
+    );
+    return _run(
+      () => _client.get(uri, headers: _headers()).timeout(timeout),
+    );
+  }
+
   Future<BangumiRawResponse> _run(
     Future<http.Response> Function() send,
   ) async {

--- a/hibiki/lib/src/media/tracking/media_tracking_repository.dart
+++ b/hibiki/lib/src/media/tracking/media_tracking_repository.dart
@@ -548,12 +548,29 @@ class MediaTrackingRepository {
     final VideoScrapeMetaRow? scrape = await _db.getVideoScrapeMeta(bookUid);
     final bool isBangumi = scrape?.source == kTrackingProviderBangumi;
     final String collectionTitle = collection?.name.trim() ?? '';
+    // 条目名只能取**作品级**资料：v65 起集级刮削（TODO-2491）会把
+    // video_scrape_meta.title 覆盖成集名（episodeNumber 非空即集级行），
+    // 直接取会让追番映射顶着「第 3 话 某某」当条目名。集级行回退所属合集的
+    // 刮削资料（同 subject 的作品名）；无合集资料则不给名（subjectId 仍在，
+    // 映射功能不受影响，只是少个显示名）。
+    String? bangumiSubjectName;
+    if (isBangumi) {
+      if (scrape!.episodeNumber == null) {
+        bangumiSubjectName = scrape.title;
+      } else if (collection != null) {
+        final CollectionScrapeMetaRow? collectionScrape =
+            await _db.getCollectionScrapeMeta(collection.id);
+        if (collectionScrape?.source == kTrackingProviderBangumi) {
+          bangumiSubjectName = collectionScrape!.title;
+        }
+      }
+    }
     return (
       mediaTitle: collectionTitle.isEmpty ? video.title : collectionTitle,
       videoTitle: video.title,
       bangumiSubjectId:
           isBangumi ? int.tryParse(scrape!.subjectId.trim()) : null,
-      bangumiSubjectName: isBangumi ? scrape!.title : null,
+      bangumiSubjectName: bangumiSubjectName,
       bangumiEpisodeCount: isBangumi ? scrape!.episodeCount : null,
     );
   }

--- a/hibiki/lib/src/media/video/scraper/bangumi_client.dart
+++ b/hibiki/lib/src/media/video/scraper/bangumi_client.dart
@@ -124,8 +124,194 @@ class BangumiClient {
     return parseBangumiSubjectDetailAsCandidate(response.body);
   }
 
+  /// 拉取条目的关联条目列表 `GET /v0/subjects/{id}/subjects`（TODO-2484 合集
+  /// 「相关作品」）。只保留动画（type 2）与三次元（type 6）条目——关联列表里的
+  /// 原声集/广播剧/书籍对视频合集无用，在解析层滤掉。
+  ///
+  /// 网络失败 / 非 2xx / JSON 异常 → 抛 [ScrapeNetworkException]。
+  Future<List<BangumiRelatedSubject>> fetchSubjectRelations(
+    String subjectId,
+  ) async {
+    final BangumiRawResponse response;
+    try {
+      response = await _api.fetchSubjectRelations(subjectId);
+    } on BangumiTransportException catch (e) {
+      throw ScrapeNetworkException('Bangumi relations ${e.message}');
+    }
+    if (!response.isOk) {
+      throw ScrapeNetworkException(
+        'Bangumi relations HTTP ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+    return parseBangumiRelatedSubjects(response.body);
+  }
+
+  /// 拉取条目的**正篇**分集列表 `GET /v0/episodes?subject_id=&type=0`（TODO-2491
+  /// 集级刮削），内部按响应 `total` 分页拉全。
+  ///
+  /// 网络失败 / 非 2xx / JSON 异常 → 抛 [ScrapeNetworkException]。
+  Future<List<BangumiEpisodeInfo>> fetchSubjectEpisodes(
+    String subjectId,
+  ) async {
+    final List<BangumiEpisodeInfo> all = <BangumiEpisodeInfo>[];
+    int offset = 0;
+    while (true) {
+      final BangumiRawResponse response;
+      try {
+        response = await _api.fetchSubjectEpisodes(subjectId, offset: offset);
+      } on BangumiTransportException catch (e) {
+        throw ScrapeNetworkException('Bangumi episodes ${e.message}');
+      }
+      if (!response.isOk) {
+        throw ScrapeNetworkException(
+          'Bangumi episodes HTTP ${response.statusCode}',
+          statusCode: response.statusCode,
+        );
+      }
+      final ({List<BangumiEpisodeInfo> episodes, int total}) page =
+          parseBangumiEpisodesResponse(response.body);
+      all.addAll(page.episodes);
+      offset += page.episodes.length;
+      // 空页兜底：错误负载/total 虚高时防死循环。
+      if (page.episodes.isEmpty || offset >= page.total) break;
+    }
+    return all;
+  }
+
   /// 关闭内部 client（若为默认自建）。测试注入的 mock client 由调用方自行管理。
   void close() => _api.close();
+}
+
+/// Bangumi 关联条目（`/v0/subjects/{id}/subjects` 单项的领域投影）。
+class BangumiRelatedSubject {
+  const BangumiRelatedSubject({
+    required this.subjectId,
+    required this.subjectType,
+    required this.relation,
+    required this.title,
+    this.coverUrl,
+  });
+
+  /// 关联条目的 subject id（字符串化）。
+  final String subjectId;
+
+  /// Bangumi 条目类型（2=动画 / 6=三次元；解析层已滤掉其余类型）。
+  final int subjectType;
+
+  /// 源侧关系词原文（`续集` / `前传` / `番外篇` …），映射到落库枚举由
+  /// `collection_relations_scrape.dart` 的 `mapBangumiRelation` 负责。
+  final String relation;
+
+  /// 标题（`name_cn` 非空优先，否则 `name`）。
+  final String title;
+
+  /// 封面 URL（`images.large` → `common` 逐级回退），可缺失。
+  final String? coverUrl;
+}
+
+/// Bangumi 分集（`/v0/episodes` 单项的领域投影，只收正篇 type=0）。
+class BangumiEpisodeInfo {
+  const BangumiEpisodeInfo({
+    required this.episodeNumber,
+    this.title,
+    this.airDate,
+    this.summary,
+  });
+
+  /// 正篇集号（源侧 `sort`；非整数的特殊话数在解析层跳过）。
+  final int episodeNumber;
+
+  /// 集名（`name_cn` 非空优先，否则 `name`）；两者皆空为 null。
+  final String? title;
+
+  /// 放送日期 `YYYY-MM-DD` 原文。
+  final String? airDate;
+
+  /// 集简介（`desc`）。
+  final String? summary;
+}
+
+/// 纯函数：解析 `/v0/subjects/{id}/subjects` 响应（顶层 JSON 数组）。
+///
+/// 只保留动画（type 2）/三次元（type 6）条目；缺 id/标题/relation 的项跳过。
+/// JSON 结构异常 → 抛 [ScrapeNetworkException]。
+List<BangumiRelatedSubject> parseBangumiRelatedSubjects(String body) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(body);
+  } catch (e) {
+    throw ScrapeNetworkException('Bangumi relations JSON decode failed: $e');
+  }
+  if (decoded is! List<Object?>) {
+    throw const ScrapeNetworkException('Bangumi relations not a JSON array');
+  }
+  final List<BangumiRelatedSubject> related = <BangumiRelatedSubject>[];
+  for (final Object? item in decoded) {
+    if (item is! Map<String, Object?>) continue;
+    final int? type = _asInt(item['type']);
+    // 原声集/书籍等对视频合集无用，只留动画(2)/三次元(6)。
+    if (type == null || (type != 2 && type != 6)) continue;
+    final Object? id = item['id'];
+    if (id is! int) continue;
+    final String? relation = _nonEmptyString(item['relation']);
+    if (relation == null) continue;
+    final String? title =
+        _nonEmptyString(item['name_cn']) ?? _nonEmptyString(item['name']);
+    if (title == null) continue;
+    String? coverUrl;
+    final Object? images = item['images'];
+    if (images is Map<String, Object?>) {
+      coverUrl =
+          _nonEmptyString(images['large']) ?? _nonEmptyString(images['common']);
+    }
+    related.add(BangumiRelatedSubject(
+      subjectId: '$id',
+      subjectType: type,
+      relation: relation,
+      title: title,
+      coverUrl: coverUrl,
+    ));
+  }
+  return related;
+}
+
+/// 纯函数：解析 `/v0/episodes` 分页响应，返回本页分集 + 源侧 total。
+///
+/// `sort` 非整数（25.5 之类的番外话数混进正篇的历史脏数据）跳过；缺 sort 跳过。
+/// JSON 结构异常 → 抛 [ScrapeNetworkException]。
+({List<BangumiEpisodeInfo> episodes, int total}) parseBangumiEpisodesResponse(
+  String body,
+) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(body);
+  } catch (e) {
+    throw ScrapeNetworkException('Bangumi episodes JSON decode failed: $e');
+  }
+  if (decoded is! Map<String, Object?>) {
+    throw const ScrapeNetworkException('Bangumi episodes not a JSON object');
+  }
+  final int total = _asInt(decoded['total']) ?? 0;
+  final Object? items = decoded['data'];
+  final List<BangumiEpisodeInfo> episodes = <BangumiEpisodeInfo>[];
+  if (items is List<Object?>) {
+    for (final Object? item in items) {
+      if (item is! Map<String, Object?>) continue;
+      final double? sort = _asDouble(item['sort']);
+      if (sort == null) continue;
+      final int episodeNumber = sort.toInt();
+      if (episodeNumber.toDouble() != sort || episodeNumber <= 0) continue;
+      episodes.add(BangumiEpisodeInfo(
+        episodeNumber: episodeNumber,
+        title:
+            _nonEmptyString(item['name_cn']) ?? _nonEmptyString(item['name']),
+        airDate: _nonEmptyString(item['airdate']),
+        summary: _nonEmptyString(item['desc']),
+      ));
+    }
+  }
+  return (episodes: episodes, total: total);
 }
 
 /// 纯函数：把 Bangumi `/v0/subjects/{id}` **详情**响应体解析为 [ScrapeCandidate]

--- a/hibiki/lib/src/media/video/scraper/bangumi_client.dart
+++ b/hibiki/lib/src/media/video/scraper/bangumi_client.dart
@@ -169,12 +169,18 @@ class BangumiClient {
           statusCode: response.statusCode,
         );
       }
-      final ({List<BangumiEpisodeInfo> episodes, int total}) page =
-          parseBangumiEpisodesResponse(response.body);
+      final ({
+        List<BangumiEpisodeInfo> episodes,
+        int rawCount,
+        int total
+      }) page = parseBangumiEpisodesResponse(response.body);
       all.addAll(page.episodes);
-      offset += page.episodes.length;
+      // offset 必须按**源返回的原始条数**推进，不能按过滤后的 episodes 长度：
+      // 一页若全被过滤（非整数 sort 的脏数据页），按过滤后长度推进会原地踏步
+      // 或提前 break，把后面还没拉的正常页整段丢掉。
+      offset += page.rawCount;
       // 空页兜底：错误负载/total 虚高时防死循环。
-      if (page.episodes.isEmpty || offset >= page.total) break;
+      if (page.rawCount == 0 || offset >= page.total) break;
     }
     return all;
   }
@@ -276,11 +282,14 @@ List<BangumiRelatedSubject> parseBangumiRelatedSubjects(String body) {
   return related;
 }
 
-/// 纯函数：解析 `/v0/episodes` 分页响应，返回本页分集 + 源侧 total。
+/// 纯函数：解析 `/v0/episodes` 分页响应，返回本页分集 + 源侧 total +
+/// **原始条数** [rawCount]（分页 offset 必须按它推进——过滤后的 episodes
+/// 长度会在脏数据页上把 offset 卡住）。
 ///
 /// `sort` 非整数（25.5 之类的番外话数混进正篇的历史脏数据）跳过；缺 sort 跳过。
 /// JSON 结构异常 → 抛 [ScrapeNetworkException]。
-({List<BangumiEpisodeInfo> episodes, int total}) parseBangumiEpisodesResponse(
+({List<BangumiEpisodeInfo> episodes, int rawCount, int total})
+    parseBangumiEpisodesResponse(
   String body,
 ) {
   final Object? decoded;
@@ -294,6 +303,7 @@ List<BangumiRelatedSubject> parseBangumiRelatedSubjects(String body) {
   }
   final int total = _asInt(decoded['total']) ?? 0;
   final Object? items = decoded['data'];
+  final int rawCount = items is List<Object?> ? items.length : 0;
   final List<BangumiEpisodeInfo> episodes = <BangumiEpisodeInfo>[];
   if (items is List<Object?>) {
     for (final Object? item in items) {
@@ -311,7 +321,7 @@ List<BangumiRelatedSubject> parseBangumiRelatedSubjects(String body) {
       ));
     }
   }
-  return (episodes: episodes, total: total);
+  return (episodes: episodes, rawCount: rawCount, total: total);
 }
 
 /// 纯函数：把 Bangumi `/v0/subjects/{id}` **详情**响应体解析为 [ScrapeCandidate]

--- a/hibiki/lib/src/media/video/scraper/collection_relations_scrape.dart
+++ b/hibiki/lib/src/media/video/scraper/collection_relations_scrape.dart
@@ -86,6 +86,7 @@ class _PendingRelation {
     required this.subjectId,
     required this.title,
     this.coverUrl,
+    this.bindBySubject = true,
   });
 
   final CollectionRelationType type;
@@ -93,6 +94,12 @@ class _PendingRelation {
   final String subjectId;
   final String title;
   final String? coverUrl;
+
+  /// 是否允许按 (source, subjectId) 反查本地合集绑定。TMDB 季边必须关掉：
+  /// 季边的 subjectId 是**季自身 id**（保证同 tv 多季不撞唯一键），而
+  /// collection_scrape_meta 存的是搜索候选的 **tv/movie id**——两个 id 空间
+  /// 互相独立且会撞号，按号反查等于随机乱绑。季边只走标题精确匹配兜底。
+  final bool bindBySubject;
 }
 
 /// 抓取并落库合集 [collectionId] 的相关作品。
@@ -176,15 +183,21 @@ Future<CollectionRelationsScrapeReport> scrapeCollectionRelations({
   int bound = 0;
   final List<CollectionRelationsCompanion> companions =
       <CollectionRelationsCompanion>[];
-  for (int i = 0; i < pending.length; i++) {
-    final _PendingRelation p = pending[i];
+  // (source, subjectId) 去重、首见保留：源侧偶见同一条目以不同关系词重复出现
+  // （Bangumi 脏数据），不去重会撞表唯一键、把 replaceCollectionRelations 的
+  // 事务整批回滚成「一条都写不进」。
+  final Set<String> seenSubjects = <String>{};
+  for (final _PendingRelation p in pending) {
+    if (!seenSubjects.add('${p.source.name}|${p.subjectId}')) continue;
     int? target;
-    final List<int> bySubject =
-        await db.collectionIdsByScrapeSubject(p.source.name, p.subjectId);
-    for (final int id in bySubject) {
-      if (id != collectionId) {
-        target = id;
-        break;
+    if (p.bindBySubject) {
+      final List<int> bySubject =
+          await db.collectionIdsByScrapeSubject(p.source.name, p.subjectId);
+      for (final int id in bySubject) {
+        if (id != collectionId) {
+          target = id;
+          break;
+        }
       }
     }
     target ??= titleToCollectionId[p.title];
@@ -192,7 +205,7 @@ Future<CollectionRelationsScrapeReport> scrapeCollectionRelations({
     companions.add(CollectionRelationsCompanion.insert(
       collectionId: collectionId,
       relationType: p.type.wire,
-      sortIndex: Value<int>(i),
+      sortIndex: Value<int>(companions.length),
       targetCollectionId: Value<int?>(target),
       source: p.source.name,
       subjectId: p.subjectId,
@@ -238,6 +251,9 @@ Future<List<_PendingRelation>> _fetchTmdbRelations(
             coverUrl: season.posterPath == null
                 ? null
                 : '${TmdbClient.posterBase}${season.posterPath}',
+            // 季 id 与 collection_scrape_meta 的 tv/movie id 不同空间，
+            // 按号反查会乱绑（见 _PendingRelation.bindBySubject）。
+            bindBySubject: false,
           ),
       ];
     }

--- a/hibiki/lib/src/media/video/scraper/collection_relations_scrape.dart
+++ b/hibiki/lib/src/media/video/scraper/collection_relations_scrape.dart
@@ -1,0 +1,275 @@
+/// 合集「相关作品」抓取与落库（TODO-2484 数据层）。
+///
+/// 数据流：合集已有刮削绑定（`collection_scrape_meta` 的 `(source, subjectId)`）
+/// → 按源拉关联条目（Bangumi `/v0/subjects/{id}/subjects`；TMDB tv 的季列表 /
+/// movie 的 `belongs_to_collection` 成员）→ 映射成 [CollectionRelationType]
+/// → 已在本地库的目标（按 `(source, subjectId)` 反查已刮削合集，标题精确匹配
+/// 兜底）自动填 `targetCollectionId` → `replaceCollectionRelations` 整体替换。
+///
+/// 失败纪律（对齐 `ScrapeNetworkException` 风格）：源失败不吞——记入
+/// [CollectionRelationsScrapeReport.sourceErrors] 由调用方展示/记日志；且**源
+/// 失败时不动库**（不能把上次刮到的关系清成空表）。
+///
+/// 本文件不持有 UI；详情页展示由后续线程消费 `watchCollectionRelations`。
+library;
+
+import 'package:drift/drift.dart' show Value;
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 相关作品关系类型（落库 wire 值见 [wire]，与 `collection_relations.relation_type`
+/// 列一一对应；UI 层按枚举渲染，不解析源词）。
+enum CollectionRelationType {
+  prequel('prequel'),
+  sequel('sequel'),
+  sideStory('side_story'),
+  movie('movie'),
+  spinOff('spin_off'),
+  other('other');
+
+  const CollectionRelationType(this.wire);
+
+  /// 落库字符串（固定小写下划线，冻结不改）。
+  final String wire;
+
+  /// 从落库字符串还原；未知值（前向兼容）归 [other]。
+  static CollectionRelationType fromWire(String wire) {
+    for (final CollectionRelationType type in values) {
+      if (type.wire == wire) return type;
+    }
+    return CollectionRelationType.other;
+  }
+}
+
+/// 纯函数：Bangumi `relation` 中文关系词 → [CollectionRelationType]。
+///
+/// 值域来自 Bangumi 关联条目页的实际用词（前传/续集/番外篇/剧场版/衍生…）；
+/// 未收录的词（总集篇/主线故事/不同演绎…）一律 [CollectionRelationType.other]，
+/// 不猜。
+CollectionRelationType mapBangumiRelation(String relation) {
+  final String r = relation.trim();
+  if (r == '前传' || r == '前傳') return CollectionRelationType.prequel;
+  if (r == '续集' || r == '續集') return CollectionRelationType.sequel;
+  if (r == '番外篇' || r == '番外' || r == '外传' || r == '外傳') {
+    return CollectionRelationType.sideStory;
+  }
+  if (r == '剧场版' || r == '劇場版') return CollectionRelationType.movie;
+  if (r == '衍生' || r == '衍生作品') return CollectionRelationType.spinOff;
+  return CollectionRelationType.other;
+}
+
+/// 一次相关作品刮削的结果摘要。
+class CollectionRelationsScrapeReport {
+  const CollectionRelationsScrapeReport({
+    required this.written,
+    required this.boundLocal,
+    required this.sourceErrors,
+  });
+
+  /// 本次写入的关系边数（源成功但确实没有关联条目时为 0，且库被替换为空）。
+  final int written;
+
+  /// 其中自动绑定到本地合集的边数。
+  final int boundLocal;
+
+  /// 逐源错误（key = 源名，value = 技术描述）。非空时**库未被改动**。
+  final Map<String, String> sourceErrors;
+}
+
+/// 抓取层中间产物：一条待落库的关系边（尚未做本地绑定）。
+class _PendingRelation {
+  const _PendingRelation({
+    required this.type,
+    required this.source,
+    required this.subjectId,
+    required this.title,
+    this.coverUrl,
+  });
+
+  final CollectionRelationType type;
+  final ScrapeSource source;
+  final String subjectId;
+  final String title;
+  final String? coverUrl;
+}
+
+/// 抓取并落库合集 [collectionId] 的相关作品。
+///
+/// 前置：合集必须已有刮削绑定（`collection_scrape_meta` 有行），否则抛
+/// [StateError]——调用方要么刚跑完 `applyCollectionScrape`（绑定必在），要么
+/// 在 UI 上只对已刮削合集暴露该动作。
+///
+/// [bangumi] / [tmdb] 与绑定源对应者为 null 时按「源不可用」记入
+/// [CollectionRelationsScrapeReport.sourceErrors]（如用户未配 TMDB key）。
+/// 网络/解析失败同样记入 sourceErrors，**不抛出也不吞**；出错时不改动库。
+Future<CollectionRelationsScrapeReport> scrapeCollectionRelations({
+  required HibikiDatabase db,
+  required int collectionId,
+  BangumiClient? bangumi,
+  TmdbClient? tmdb,
+}) async {
+  final CollectionScrapeMetaRow? meta =
+      await db.getCollectionScrapeMeta(collectionId);
+  if (meta == null) {
+    throw StateError(
+      'collection $collectionId has no scrape binding; scrape it first',
+    );
+  }
+
+  final List<_PendingRelation> pending = <_PendingRelation>[];
+  final Map<String, String> errors = <String, String>{};
+
+  if (meta.source == ScrapeSource.bangumi.name) {
+    if (bangumi == null) {
+      errors[meta.source] = 'Bangumi client unavailable';
+    } else {
+      try {
+        final List<BangumiRelatedSubject> related =
+            await bangumi.fetchSubjectRelations(meta.subjectId);
+        for (final BangumiRelatedSubject r in related) {
+          pending.add(_PendingRelation(
+            type: mapBangumiRelation(r.relation),
+            source: ScrapeSource.bangumi,
+            subjectId: r.subjectId,
+            title: r.title,
+            coverUrl: r.coverUrl,
+          ));
+        }
+      } on ScrapeNetworkException catch (e) {
+        errors[meta.source] = e.toString();
+      }
+    }
+  } else if (meta.source == ScrapeSource.tmdb.name) {
+    if (tmdb == null) {
+      errors[meta.source] = 'TMDB client unavailable (no API key)';
+    } else {
+      try {
+        pending.addAll(await _fetchTmdbRelations(tmdb, meta));
+      } on ScrapeNetworkException catch (e) {
+        errors[meta.source] = e.toString();
+      }
+    }
+  } else {
+    // offlineDb / manualUrl：没有关系端点，明说而不是装作「无关联」。
+    errors[meta.source] = 'source has no relations endpoint';
+  }
+
+  if (errors.isNotEmpty) {
+    return CollectionRelationsScrapeReport(
+      written: 0,
+      boundLocal: 0,
+      sourceErrors: errors,
+    );
+  }
+
+  // 本地绑定：(source, subjectId) 反查已刮削合集优先，标题精确匹配兜底；
+  // 永不绑回自身（Bangumi 偶见自引用脏数据）。
+  final List<MediaCollectionRow> allCollections =
+      await db.getAllMediaCollections();
+  final Map<String, int> titleToCollectionId = <String, int>{
+    for (final MediaCollectionRow c in allCollections.reversed)
+      if (c.id != collectionId) c.name: c.id,
+  };
+
+  int bound = 0;
+  final List<CollectionRelationsCompanion> companions =
+      <CollectionRelationsCompanion>[];
+  for (int i = 0; i < pending.length; i++) {
+    final _PendingRelation p = pending[i];
+    int? target;
+    final List<int> bySubject =
+        await db.collectionIdsByScrapeSubject(p.source.name, p.subjectId);
+    for (final int id in bySubject) {
+      if (id != collectionId) {
+        target = id;
+        break;
+      }
+    }
+    target ??= titleToCollectionId[p.title];
+    if (target != null) bound++;
+    companions.add(CollectionRelationsCompanion.insert(
+      collectionId: collectionId,
+      relationType: p.type.wire,
+      sortIndex: Value<int>(i),
+      targetCollectionId: Value<int?>(target),
+      source: p.source.name,
+      subjectId: p.subjectId,
+      title: p.title,
+      coverUrl: Value<String?>(p.coverUrl),
+    ));
+  }
+
+  await db.replaceCollectionRelations(collectionId, companions);
+  return CollectionRelationsScrapeReport(
+    written: companions.length,
+    boundLocal: bound,
+    sourceErrors: const <String, String>{},
+  );
+}
+
+/// TMDB 侧关联条目：tv → 季列表（特别篇季 = side_story，其余季 = other，季与
+/// 季之间没有可靠的先后语义，不硬编 prequel/sequel）；movie →
+/// `belongs_to_collection` 成员（按上映日期相对本条目分 prequel/sequel，无日期
+/// 归 other），排除自身。
+///
+/// tv/movie 判定优先走 detailUrl（`themoviedb.org/tv|movie/<id>`）；旧数据缺
+/// detailUrl 时先按 tv 试、404 再按 movie 试（两个 id 空间独立且会撞号，因此
+/// 只在无法判定时才这样探测）。
+Future<List<_PendingRelation>> _fetchTmdbRelations(
+  TmdbClient tmdb,
+  CollectionScrapeMetaRow meta,
+) async {
+  final TmdbSubjectKind? kind = tmdbKindFromDetailUrl(meta.detailUrl);
+
+  if (kind == TmdbSubjectKind.tv || kind == null) {
+    final TmdbTvDetail? detail = await tmdb.fetchTvDetail(meta.subjectId);
+    if (detail != null) {
+      return <_PendingRelation>[
+        for (final TmdbSeasonRef season in detail.seasons)
+          _PendingRelation(
+            type: season.seasonNumber == 0
+                ? CollectionRelationType.sideStory
+                : CollectionRelationType.other,
+            source: ScrapeSource.tmdb,
+            subjectId: season.seasonId,
+            title: season.name,
+            coverUrl: season.posterPath == null
+                ? null
+                : '${TmdbClient.posterBase}${season.posterPath}',
+          ),
+      ];
+    }
+    if (kind == TmdbSubjectKind.tv) return const <_PendingRelation>[];
+  }
+
+  final TmdbMovieCollectionRef? ref =
+      await tmdb.fetchMovieCollectionRef(meta.subjectId);
+  if (ref == null) return const <_PendingRelation>[];
+  final List<TmdbCollectionPart> parts =
+      await tmdb.fetchCollectionParts(ref.collectionId);
+
+  final List<_PendingRelation> pending = <_PendingRelation>[];
+  for (final TmdbCollectionPart part in parts) {
+    if (part.movieId == meta.subjectId) continue; // 排除自身。
+    CollectionRelationType type = CollectionRelationType.other;
+    final String? selfDate = meta.airDate;
+    final String? partDate = part.releaseDate;
+    if (selfDate != null && partDate != null) {
+      final int cmp = partDate.compareTo(selfDate);
+      if (cmp < 0) type = CollectionRelationType.prequel;
+      if (cmp > 0) type = CollectionRelationType.sequel;
+    }
+    pending.add(_PendingRelation(
+      type: type,
+      source: ScrapeSource.tmdb,
+      subjectId: part.movieId,
+      title: part.title,
+      coverUrl: part.posterPath == null
+          ? null
+          : '${TmdbClient.posterBase}${part.posterPath}',
+    ));
+  }
+  return pending;
+}

--- a/hibiki/lib/src/media/video/scraper/episode_rename.dart
+++ b/hibiki/lib/src/media/video/scraper/episode_rename.dart
@@ -1,0 +1,114 @@
+/// 集显示名提案与批量改名（TODO-2491 数据层）。
+///
+/// 与集级刮削（`episode_scrape_service.dart`）刻意分离：**自动刮削路径永不改
+/// 名**（对齐 BUG-1310 用户拍板——改名必须经用户确认）。本文件提供：
+///  - [proposeEpisodeDisplayName]：纯函数，集号 + 集名 → 展示名；
+///  - [renameCollectionEpisodes]：批量改名服务，`dryRun: true` 只产出
+///    旧名/新名对照表（供 UI 确认弹窗渲染），`dryRun: false` 逐条写穿
+///    `video_books.title`（走 `updateVideoBookTitle`，与库页手动重命名同一
+///    落库口）。
+///
+/// 改名依据是集级刮削已落库的 `video_scrape_meta`（`episode_number` 非空的
+/// 行）；未刮或作品级旧行不产生提案——先刮再改名。
+library;
+
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 纯函数：集号 + 集名 → 展示名。
+///
+/// 格式 `E<零填充集号> <集名>`（如 `E01 出会い`；无集名时只有 `E01`）。
+/// [padWidth] 是集号最小宽度（默认 2；三位数集号的长番由调用方按最大集号传
+/// 3），语言中立、可被文件名排序。
+String proposeEpisodeDisplayName({
+  required int episodeNumber,
+  String? episodeTitle,
+  int padWidth = 2,
+}) {
+  final String number = episodeNumber.toString().padLeft(padWidth, '0');
+  final String? title = episodeTitle?.trim();
+  return (title == null || title.isEmpty) ? 'E$number' : 'E$number $title';
+}
+
+/// 一条改名提案：旧名 → 新名（`newTitle != oldTitle` 才产出）。
+class EpisodeRenameProposal {
+  const EpisodeRenameProposal({
+    required this.bookUid,
+    required this.oldTitle,
+    required this.newTitle,
+  });
+
+  final String bookUid;
+  final String oldTitle;
+  final String newTitle;
+}
+
+/// 对合集 [collectionId] 的视频成员按集级刮削资料生成改名提案。
+///
+/// [dryRun] = true 只返回对照表；false 时对每条提案写穿
+/// `video_books.title` 后返回同一份对照表（供调用方汇报）。
+///
+/// 提案规则：
+///  - 只处理 `video_scrape_meta.episode_number` 非空的成员（集级已刮）；
+///  - 集名 = 该行 `title`；若与合集作品名相同（集名缺失时集级刮削的回退值），
+///    不当集名用——提案退化为纯 `E01` 式；
+///  - 零填充宽度取合集内最大集号的十进制宽度（至少 2）；
+///  - 新旧同名不产出提案。
+Future<List<EpisodeRenameProposal>> renameCollectionEpisodes({
+  required HibikiDatabase db,
+  required int collectionId,
+  required bool dryRun,
+}) async {
+  final CollectionScrapeMetaRow? collectionMeta =
+      await db.getCollectionScrapeMeta(collectionId);
+
+  final List<MediaCollectionItemRow> items =
+      await db.getCollectionItems(collectionId);
+  final List<({VideoBookRow book, VideoScrapeMetaRow meta, int episode})>
+      scraped = <({VideoBookRow book, VideoScrapeMetaRow meta, int episode})>[];
+  for (final MediaCollectionItemRow item in items) {
+    if (item.mediaType != 'video') continue;
+    final VideoBookRow? book = await db.getVideoBookByBookUid(item.entryKey);
+    if (book == null) continue;
+    final VideoScrapeMetaRow? meta = await db.getVideoScrapeMeta(book.bookUid);
+    final int? episode = meta?.episodeNumber;
+    if (meta == null || episode == null) continue;
+    scraped.add((book: book, meta: meta, episode: episode));
+  }
+  if (scraped.isEmpty) return const <EpisodeRenameProposal>[];
+
+  int maxEpisode = 0;
+  for (final ({VideoBookRow book, VideoScrapeMetaRow meta, int episode}) s
+      in scraped) {
+    if (s.episode > maxEpisode) maxEpisode = s.episode;
+  }
+  final int padWidth =
+      maxEpisode.toString().length < 2 ? 2 : maxEpisode.toString().length;
+
+  final List<EpisodeRenameProposal> proposals = <EpisodeRenameProposal>[];
+  for (final ({VideoBookRow book, VideoScrapeMetaRow meta, int episode}) s
+      in scraped) {
+    // 集名缺失时集级刮削回退写了作品名——那不是集名，别拼成「E01 作品名」。
+    final String? episodeTitle =
+        (collectionMeta != null && s.meta.title == collectionMeta.title)
+            ? null
+            : s.meta.title;
+    final String newTitle = proposeEpisodeDisplayName(
+      episodeNumber: s.episode,
+      episodeTitle: episodeTitle,
+      padWidth: padWidth,
+    );
+    if (newTitle == s.book.title) continue;
+    proposals.add(EpisodeRenameProposal(
+      bookUid: s.book.bookUid,
+      oldTitle: s.book.title,
+      newTitle: newTitle,
+    ));
+  }
+
+  if (!dryRun) {
+    for (final EpisodeRenameProposal proposal in proposals) {
+      await db.updateVideoBookTitle(proposal.bookUid, proposal.newTitle);
+    }
+  }
+  return proposals;
+}

--- a/hibiki/lib/src/media/video/scraper/episode_scrape_service.dart
+++ b/hibiki/lib/src/media/video/scraper/episode_scrape_service.dart
@@ -1,0 +1,295 @@
+/// 集级刮削服务（TODO-2491 数据层）：给定已绑定刮削源的合集，把**每一集**的
+/// 集名/简介/放送日期（和 TMDB 剧照）落到条目级 `video_scrape_meta`（主键
+/// bookUid，一集一行，v65 起带 `episode_number`）。
+///
+/// 对齐方式：成员文件名经 [parseVideoFilename]（G10 单规则引擎）解出集号，与源
+/// 分集列表（TMDB `/tv/{id}/season/{n}`；Bangumi `/v0/episodes?type=0`）按集号
+/// 对齐；解不出集号或源无该集 → 跳过并计数（[EpisodeScrapeOutcome.unmatched]）。
+/// TMDB 的季号取合集成员解析季号的众数，无季默认 1；Bangumi 无季概念（多季是
+/// 独立 subject），直接按正篇集号对齐。
+///
+/// 剧照（仅 TMDB 提供）落为该集封面：走 [CoverDownloader] 的既有
+/// `video_covers/<uid>.jpg` 约定 + `cover_meta.json` 标记
+/// [CoverOrigin.autoScraped]；封面来源是用户亲选（[CoverOrigin.isUserChosen]）
+/// 时**绝不覆盖**，计入 [EpisodeScrapeOutcome.stillsSkippedUserCover]。刻意不
+/// 另存剧照文件/路径列：剧照就是集封面，另存会造第二真相并被
+/// `gcOrphanCovers`（保留集 = `video_books.cover_path`）当孤儿回收。
+///
+/// 本服务**永不改条目标题**——改名是独立的用户确认动作（`episode_rename.dart`，
+/// 对齐 BUG-1310 的用户拍板：自动刮削路径不改名）。
+library;
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
+import 'package:hibiki/src/media/video/scraper/cover_downloader.dart';
+import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
+import 'package:hibiki/src/media/video/video_filename_parser.dart';
+import 'package:hibiki/src/media/video/video_storage.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+/// 一次集级刮削的结果摘要。
+class EpisodeScrapeOutcome {
+  const EpisodeScrapeOutcome({
+    required this.updated,
+    required this.unmatched,
+    required this.stillsApplied,
+    required this.stillsSkippedUserCover,
+    required this.errors,
+  });
+
+  /// 写入 `video_scrape_meta` 的集数。
+  final int updated;
+
+  /// 未匹配集数（文件名解不出集号 / 源分集列表无该集号）。
+  final int unmatched;
+
+  /// 剧照成功落为集封面的数量。
+  final int stillsApplied;
+
+  /// 因用户亲选封面而跳过剧照的数量（[CoverOrigin.isUserChosen] 防线）。
+  final int stillsSkippedUserCover;
+
+  /// 错误集合（key = 源名或 `still_E<集号>`）。源级失败时资料零写入；剧照级
+  /// 失败只影响该集封面，资料照常写入。
+  final Map<String, String> errors;
+}
+
+/// 单集的源侧资料（对齐后待落库）。
+class _SourceEpisode {
+  const _SourceEpisode({
+    required this.episodeNumber,
+    this.title,
+    this.summary,
+    this.airDate,
+    this.stillPath,
+  });
+
+  final int episodeNumber;
+  final String? title;
+  final String? summary;
+  final String? airDate;
+
+  /// TMDB 剧照相对路径；Bangumi 恒 null。
+  final String? stillPath;
+}
+
+/// 集级刮削服务。构造注入网络客户端与封面设施（测试注入 mock / 临时目录）。
+class EpisodeScrapeService {
+  EpisodeScrapeService({
+    required HibikiDatabase db,
+    BangumiClient? bangumiClient,
+    TmdbClient? tmdbClient,
+    CoverDownloader? coverDownloader,
+    CoverMetaStore? coverMetaStore,
+    Directory? coversDirectory,
+  })  : _db = db,
+        _bangumi = bangumiClient,
+        _tmdb = tmdbClient,
+        _coverDownloader = coverDownloader,
+        _coverMetaStore = coverMetaStore,
+        _coversDirectory = coversDirectory;
+
+  final HibikiDatabase _db;
+  final BangumiClient? _bangumi;
+  final TmdbClient? _tmdb;
+
+  /// 三者 null 时跳过剧照（只写文字资料）：调用方不关心封面就不必搭封面设施。
+  final CoverDownloader? _coverDownloader;
+  final CoverMetaStore? _coverMetaStore;
+  final Directory? _coversDirectory;
+
+  /// 对合集 [collectionId] 的全部视频成员做集级刮削。
+  ///
+  /// 前置：合集必须已有刮削绑定（`collection_scrape_meta` 有行），否则抛
+  /// [StateError]。源级网络失败记入 [EpisodeScrapeOutcome.errors] 且资料零写入
+  /// （不吞也不抛，调用方决定展示方式）。
+  Future<EpisodeScrapeOutcome> scrapeCollectionEpisodes(
+      int collectionId) async {
+    final CollectionScrapeMetaRow? meta =
+        await _db.getCollectionScrapeMeta(collectionId);
+    if (meta == null) {
+      throw StateError(
+        'collection $collectionId has no scrape binding; scrape it first',
+      );
+    }
+
+    // 成员 → (book, 文件名解析)。非 video 成员（书/游戏混编合集）不参与。
+    final List<MediaCollectionItemRow> items =
+        await _db.getCollectionItems(collectionId);
+    final List<({VideoBookRow book, VideoNameInfo parsed})> members =
+        <({VideoBookRow book, VideoNameInfo parsed})>[];
+    for (final MediaCollectionItemRow item in items) {
+      if (item.mediaType != 'video') continue;
+      final VideoBookRow? book = await _db.getVideoBookByBookUid(item.entryKey);
+      if (book == null) continue;
+      members.add((
+        book: book,
+        parsed: parseVideoFilename(p.basename(book.videoPath)),
+      ));
+    }
+
+    // 源分集列表。
+    final Map<String, String> errors = <String, String>{};
+    final Map<int, _SourceEpisode> byNumber = <int, _SourceEpisode>{};
+    if (meta.source == ScrapeSource.bangumi.name) {
+      final BangumiClient? bangumi = _bangumi;
+      if (bangumi == null) {
+        errors[meta.source] = 'Bangumi client unavailable';
+      } else {
+        try {
+          for (final BangumiEpisodeInfo e
+              in await bangumi.fetchSubjectEpisodes(meta.subjectId)) {
+            byNumber.putIfAbsent(
+              e.episodeNumber,
+              () => _SourceEpisode(
+                episodeNumber: e.episodeNumber,
+                title: e.title,
+                summary: e.summary,
+                airDate: e.airDate,
+              ),
+            );
+          }
+        } on ScrapeNetworkException catch (e) {
+          errors[meta.source] = e.toString();
+        }
+      }
+    } else if (meta.source == ScrapeSource.tmdb.name) {
+      final TmdbClient? tmdb = _tmdb;
+      if (tmdb == null) {
+        errors[meta.source] = 'TMDB client unavailable (no API key)';
+      } else if (tmdbKindFromDetailUrl(meta.detailUrl) ==
+          TmdbSubjectKind.movie) {
+        errors[meta.source] = 'movie subject has no episodes';
+      } else {
+        try {
+          for (final TmdbEpisodeInfo e in await tmdb.fetchSeasonEpisodes(
+            meta.subjectId,
+            _dominantSeason(members),
+          )) {
+            byNumber.putIfAbsent(
+              e.episodeNumber,
+              () => _SourceEpisode(
+                episodeNumber: e.episodeNumber,
+                title: e.title,
+                summary: e.summary,
+                airDate: e.airDate,
+                stillPath: e.stillPath,
+              ),
+            );
+          }
+        } on ScrapeNetworkException catch (e) {
+          errors[meta.source] = e.toString();
+        }
+      }
+    } else {
+      errors[meta.source] = 'source has no episodes endpoint';
+    }
+
+    if (errors.isNotEmpty) {
+      return EpisodeScrapeOutcome(
+        updated: 0,
+        unmatched: 0,
+        stillsApplied: 0,
+        stillsSkippedUserCover: 0,
+        errors: errors,
+      );
+    }
+
+    // 对齐 + 落库。重复集号（v1/v2 双版本文件）各写各的、资料相同——重复不算
+    // 未匹配；未匹配 = 解不出集号或源无该集（缺集/特典超范围）。
+    int updated = 0;
+    int unmatched = 0;
+    int stillsApplied = 0;
+    int stillsSkippedUserCover = 0;
+    for (final ({VideoBookRow book, VideoNameInfo parsed}) member in members) {
+      final int? episodeNumber = member.parsed.episode;
+      final _SourceEpisode? source =
+          episodeNumber == null ? null : byNumber[episodeNumber];
+      if (source == null) {
+        unmatched++;
+        continue;
+      }
+      await _db.upsertVideoScrapeMeta(VideoScrapeMetaCompanion.insert(
+        bookUid: member.book.bookUid,
+        source: meta.source,
+        subjectId: meta.subjectId,
+        // 集名缺失时回退作品名：title 列非空约束，且带 episodeNumber 的行语义
+        // 上仍是「这一集」，回退值只影响展示兜底。
+        title: source.title ?? meta.title,
+        summary: Value<String?>(source.summary),
+        airDate: Value<String?>(source.airDate),
+        episodeNumber: Value<int?>(source.episodeNumber),
+        scrapedAt: DateTime.now(),
+      ));
+      updated++;
+
+      // 剧照 → 集封面（TMDB only；封面设施未注入则跳过）。
+      final CoverDownloader? downloader = _coverDownloader;
+      final CoverMetaStore? metaStore = _coverMetaStore;
+      final String? stillPath = source.stillPath;
+      if (downloader == null || metaStore == null || stillPath == null) {
+        continue;
+      }
+      final CoverMeta? coverMeta = await metaStore.get(member.book.bookUid);
+      if (coverMeta != null && coverMeta.origin.isUserChosen) {
+        stillsSkippedUserCover++;
+        continue;
+      }
+      try {
+        final String coverPath = await downloader.downloadCover(
+          url: '${TmdbClient.posterBase}$stillPath',
+          bookUid: member.book.bookUid,
+          coversDirectory: _coversDirectory ?? await VideoStorage.coversDir(),
+        );
+        await _db.updateVideoBookCover(member.book.bookUid, coverPath);
+        await metaStore.set(
+          member.book.bookUid,
+          CoverMeta(
+            origin: CoverOrigin.autoScraped,
+            source: ScrapeSource.tmdb,
+            entryId: meta.subjectId,
+          ),
+        );
+        stillsApplied++;
+      } on ScrapeNetworkException catch (e) {
+        // 剧照失败只影响该集封面，资料已写入；逐集记错不打断批次。
+        errors['still_E${source.episodeNumber}'] = e.toString();
+      }
+    }
+
+    return EpisodeScrapeOutcome(
+      updated: updated,
+      unmatched: unmatched,
+      stillsApplied: stillsApplied,
+      stillsSkippedUserCover: stillsSkippedUserCover,
+      errors: errors,
+    );
+  }
+
+  /// 合集成员解析季号的众数；全员无季 → 1（单季剧集文件名普遍不带季号）。
+  static int _dominantSeason(
+    List<({VideoBookRow book, VideoNameInfo parsed})> members,
+  ) {
+    final Map<int, int> counts = <int, int>{};
+    for (final ({VideoBookRow book, VideoNameInfo parsed}) m in members) {
+      final int? season = m.parsed.season;
+      if (season != null) {
+        counts[season] = (counts[season] ?? 0) + 1;
+      }
+    }
+    int best = 1;
+    int bestCount = 0;
+    for (final MapEntry<int, int> entry in counts.entries) {
+      if (entry.value > bestCount) {
+        best = entry.key;
+        bestCount = entry.value;
+      }
+    }
+    return best;
+  }
+}

--- a/hibiki/lib/src/media/video/scraper/episode_scrape_service.dart
+++ b/hibiki/lib/src/media/video/scraper/episode_scrape_service.dart
@@ -5,7 +5,8 @@
 /// 对齐方式：成员文件名经 [parseVideoFilename]（G10 单规则引擎）解出集号，与源
 /// 分集列表（TMDB `/tv/{id}/season/{n}`；Bangumi `/v0/episodes?type=0`）按集号
 /// 对齐；解不出集号或源无该集 → 跳过并计数（[EpisodeScrapeOutcome.unmatched]）。
-/// TMDB 的季号取合集成员解析季号的众数，无季默认 1；Bangumi 无季概念（多季是
+/// TMDB 按成员实际出现的**每个季**各拉一次分集表、成员按自己的季对齐（混季
+/// 合集里少数季成员不被多数季错配），无季默认 1；Bangumi 无季概念（多季是
 /// 独立 subject），直接按正篇集号对齐。
 ///
 /// 剧照（仅 TMDB 提供）落为该集封面：走 [CoverDownloader] 的既有
@@ -133,15 +134,21 @@ class EpisodeScrapeService {
       ));
     }
 
-    // 源分集列表。
+    // 源分集索引：季号 -> (集号 -> 资料)。Bangumi 无季概念（多季是独立
+    // subject），全部进 [_kAnySeason] 桶、对齐时忽略成员季号；TMDB 按成员出现
+    // 的**每个季**各拉一次——混季合集（S1+S2 文件混放）里少数季成员绝不能被
+    // 多数季的分集表错配资料。
     final Map<String, String> errors = <String, String>{};
-    final Map<int, _SourceEpisode> byNumber = <int, _SourceEpisode>{};
+    final Map<int, Map<int, _SourceEpisode>> bySeason =
+        <int, Map<int, _SourceEpisode>>{};
     if (meta.source == ScrapeSource.bangumi.name) {
       final BangumiClient? bangumi = _bangumi;
       if (bangumi == null) {
         errors[meta.source] = 'Bangumi client unavailable';
       } else {
         try {
+          final Map<int, _SourceEpisode> byNumber =
+              bySeason.putIfAbsent(_kAnySeason, () => <int, _SourceEpisode>{});
           for (final BangumiEpisodeInfo e
               in await bangumi.fetchSubjectEpisodes(meta.subjectId)) {
             byNumber.putIfAbsent(
@@ -166,21 +173,28 @@ class EpisodeScrapeService {
           TmdbSubjectKind.movie) {
         errors[meta.source] = 'movie subject has no episodes';
       } else {
+        // 成员实际出现的季集合（文件名无季 → 默认 1：单季剧集文件名普遍不带季号）。
+        final Set<int> seasons = <int>{
+          for (final ({VideoBookRow book, VideoNameInfo parsed}) m in members)
+            m.parsed.season ?? 1,
+        };
         try {
-          for (final TmdbEpisodeInfo e in await tmdb.fetchSeasonEpisodes(
-            meta.subjectId,
-            _dominantSeason(members),
-          )) {
-            byNumber.putIfAbsent(
-              e.episodeNumber,
-              () => _SourceEpisode(
-                episodeNumber: e.episodeNumber,
-                title: e.title,
-                summary: e.summary,
-                airDate: e.airDate,
-                stillPath: e.stillPath,
-              ),
-            );
+          for (final int season in seasons) {
+            final Map<int, _SourceEpisode> byNumber =
+                bySeason.putIfAbsent(season, () => <int, _SourceEpisode>{});
+            for (final TmdbEpisodeInfo e
+                in await tmdb.fetchSeasonEpisodes(meta.subjectId, season)) {
+              byNumber.putIfAbsent(
+                e.episodeNumber,
+                () => _SourceEpisode(
+                  episodeNumber: e.episodeNumber,
+                  title: e.title,
+                  summary: e.summary,
+                  airDate: e.airDate,
+                  stillPath: e.stillPath,
+                ),
+              );
+            }
           }
         } on ScrapeNetworkException catch (e) {
           errors[meta.source] = e.toString();
@@ -208,8 +222,10 @@ class EpisodeScrapeService {
     int stillsSkippedUserCover = 0;
     for (final ({VideoBookRow book, VideoNameInfo parsed}) member in members) {
       final int? episodeNumber = member.parsed.episode;
-      final _SourceEpisode? source =
-          episodeNumber == null ? null : byNumber[episodeNumber];
+      final _SourceEpisode? source = episodeNumber == null
+          ? null
+          : (bySeason[_kAnySeason]?[episodeNumber] ??
+              bySeason[member.parsed.season ?? 1]?[episodeNumber]);
       if (source == null) {
         unmatched++;
         continue;
@@ -271,25 +287,6 @@ class EpisodeScrapeService {
     );
   }
 
-  /// 合集成员解析季号的众数；全员无季 → 1（单季剧集文件名普遍不带季号）。
-  static int _dominantSeason(
-    List<({VideoBookRow book, VideoNameInfo parsed})> members,
-  ) {
-    final Map<int, int> counts = <int, int>{};
-    for (final ({VideoBookRow book, VideoNameInfo parsed}) m in members) {
-      final int? season = m.parsed.season;
-      if (season != null) {
-        counts[season] = (counts[season] ?? 0) + 1;
-      }
-    }
-    int best = 1;
-    int bestCount = 0;
-    for (final MapEntry<int, int> entry in counts.entries) {
-      if (entry.value > bestCount) {
-        best = entry.key;
-        bestCount = entry.value;
-      }
-    }
-    return best;
-  }
+  /// Bangumi 分集的季桶哨兵：Bangumi 无季概念，对齐时忽略成员季号。
+  static const int _kAnySeason = -1;
 }

--- a/hibiki/lib/src/media/video/scraper/tmdb_client.dart
+++ b/hibiki/lib/src/media/video/scraper/tmdb_client.dart
@@ -83,8 +83,278 @@ class TmdbClient {
     return parseTmdbMultiResponse(utf8.decode(response.bodyBytes));
   }
 
+  /// 拉取 tv 条目详情 `GET /3/tv/{id}`（TODO-2484：季列表作合集「相关作品」；
+  /// TODO-2491：确认条目是 tv）。404（条目不存在）→ null。
+  ///
+  /// 其余网络失败 / 非 2xx / JSON 异常 → 抛 [ScrapeNetworkException]。
+  Future<TmdbTvDetail?> fetchTvDetail(String tvId) async {
+    final String? body = await _getJsonOrNullOn404('/tv/$tvId', 'TMDB tv');
+    return body == null ? null : parseTmdbTvDetail(body);
+  }
+
+  /// 拉取 tv 某一季的分集列表 `GET /3/tv/{id}/season/{n}`（TODO-2491 集级
+  /// 刮削）。404（该季不存在）→ 空列表（调用方按「源无此季」计未匹配）。
+  Future<List<TmdbEpisodeInfo>> fetchSeasonEpisodes(
+    String tvId,
+    int seasonNumber,
+  ) async {
+    final String? body = await _getJsonOrNullOn404(
+        '/tv/$tvId/season/$seasonNumber', 'TMDB season');
+    return body == null
+        ? const <TmdbEpisodeInfo>[]
+        : parseTmdbSeasonEpisodes(body);
+  }
+
+  /// 拉取 movie 条目的所属系列引用 `GET /3/movie/{id}` 的
+  /// `belongs_to_collection`（TODO-2484）。条目 404 或不属于任何系列 → null。
+  Future<TmdbMovieCollectionRef?> fetchMovieCollectionRef(
+    String movieId,
+  ) async {
+    final String? body =
+        await _getJsonOrNullOn404('/movie/$movieId', 'TMDB movie');
+    return body == null ? null : parseTmdbMovieCollectionRef(body);
+  }
+
+  /// 拉取 TMDB 系列（collection）的成员列表 `GET /3/collection/{id}`
+  /// （TODO-2484：movie 合集的「相关作品」）。404 → 空列表。
+  Future<List<TmdbCollectionPart>> fetchCollectionParts(
+    String tmdbCollectionId,
+  ) async {
+    final String? body = await _getJsonOrNullOn404(
+        '/collection/$tmdbCollectionId', 'TMDB collection');
+    return body == null
+        ? const <TmdbCollectionPart>[]
+        : parseTmdbCollectionParts(body);
+  }
+
+  /// 共享 GET：`https://api.themoviedb.org/3<path>?language=zh-CN&api_key=…`。
+  /// 404 返回 null（各端点自定语义）；其余非 2xx / 网络失败抛
+  /// [ScrapeNetworkException]。异常 message 统一 [redactCredentialsInText]
+  /// 脱敏——TMDB 是 key-in-query，`http.ClientException.toString()` 会带完整
+  /// URL（BUG-1219 红线，与 [search] 同源收口）。
+  Future<String?> _getJsonOrNullOn404(String path, String what) async {
+    final Uri uri = Uri.parse('https://api.themoviedb.org/3$path')
+        .replace(queryParameters: <String, String>{
+      'language': 'zh-CN',
+      'api_key': _apiKey,
+    });
+    final http.Response response;
+    try {
+      response = await _client.get(
+        uri,
+        headers: const <String, String>{'Accept': 'application/json'},
+      ).timeout(_timeout);
+    } on TimeoutException {
+      throw ScrapeNetworkException('$what timed out');
+    } catch (e) {
+      throw ScrapeNetworkException(
+        redactCredentialsInText('$what request failed: $e'),
+      );
+    }
+    if (response.statusCode == 404) return null;
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ScrapeNetworkException(
+        '$what HTTP ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+    return utf8.decode(response.bodyBytes);
+  }
+
   /// 关闭内部 client（若为默认自建）。
   void close() => _client.close();
+}
+
+/// TMDB 条目种类（tv / movie）。合集绑定的 subjectId 是纯数字，两个 id 空间
+/// 独立且会撞号，必须由 [tmdbKindFromDetailUrl]（detailUrl 里带 `/tv/` 或
+/// `/movie/`）或调用方上下文判定，不能按 id 猜。
+enum TmdbSubjectKind { tv, movie }
+
+/// 纯函数：从 TMDB detailUrl（`https://www.themoviedb.org/tv/123` 式）解析
+/// 条目种类；不是 TMDB 详情 URL → null。
+TmdbSubjectKind? tmdbKindFromDetailUrl(String? detailUrl) {
+  if (detailUrl == null) return null;
+  final Uri? uri = Uri.tryParse(detailUrl.trim());
+  if (uri == null || !uri.host.endsWith('themoviedb.org')) return null;
+  final List<String> segments = uri.pathSegments;
+  if (segments.isEmpty) return null;
+  return switch (segments.first) {
+    'tv' => TmdbSubjectKind.tv,
+    'movie' => TmdbSubjectKind.movie,
+    _ => null,
+  };
+}
+
+/// TMDB tv 详情投影：季列表（TODO-2484 相关作品用）。
+class TmdbTvDetail {
+  const TmdbTvDetail({required this.name, required this.seasons});
+
+  final String? name;
+  final List<TmdbSeasonRef> seasons;
+}
+
+/// TMDB tv 的一季。
+class TmdbSeasonRef {
+  const TmdbSeasonRef({
+    required this.seasonId,
+    required this.seasonNumber,
+    required this.name,
+    this.airDate,
+    this.posterPath,
+  });
+
+  /// 季自身的 TMDB id（全局唯一，与 tv id 不同空间），字符串化。
+  final String seasonId;
+
+  /// 季号（0 = 特别篇）。
+  final int seasonNumber;
+
+  final String name;
+  final String? airDate;
+  final String? posterPath;
+}
+
+/// TMDB 分集（`/3/tv/{id}/season/{n}` 的 `episodes[]` 投影）。
+class TmdbEpisodeInfo {
+  const TmdbEpisodeInfo({
+    required this.episodeNumber,
+    this.title,
+    this.summary,
+    this.airDate,
+    this.stillPath,
+  });
+
+  final int episodeNumber;
+  final String? title;
+  final String? summary;
+  final String? airDate;
+
+  /// 剧照相对路径（`/xxx.jpg`），完整 URL = [TmdbClient.posterBase] + 本值。
+  final String? stillPath;
+}
+
+/// TMDB movie 的所属系列引用（`belongs_to_collection`）。
+class TmdbMovieCollectionRef {
+  const TmdbMovieCollectionRef({required this.collectionId, this.name});
+
+  /// TMDB collection id，字符串化。
+  final String collectionId;
+  final String? name;
+}
+
+/// TMDB 系列成员（`/3/collection/{id}` 的 `parts[]` 投影）。
+class TmdbCollectionPart {
+  const TmdbCollectionPart({
+    required this.movieId,
+    required this.title,
+    this.releaseDate,
+    this.posterPath,
+  });
+
+  /// 成员 movie id，字符串化。
+  final String movieId;
+  final String title;
+  final String? releaseDate;
+  final String? posterPath;
+}
+
+/// 纯函数：解析 `/3/tv/{id}` 响应为 [TmdbTvDetail]。JSON 结构异常 → 抛
+/// [ScrapeNetworkException]。
+TmdbTvDetail parseTmdbTvDetail(String body) {
+  final Map<String, Object?> decoded = _decodeObject(body, 'TMDB tv');
+  final List<TmdbSeasonRef> seasons = <TmdbSeasonRef>[];
+  final Object? seasonsNode = decoded['seasons'];
+  if (seasonsNode is List<Object?>) {
+    for (final Object? item in seasonsNode) {
+      if (item is! Map<String, Object?>) continue;
+      final Object? id = item['id'];
+      final Object? number = item['season_number'];
+      final String? name = _nonEmptyString(item['name']);
+      if (id is! int || number is! int || name == null) continue;
+      seasons.add(TmdbSeasonRef(
+        seasonId: '$id',
+        seasonNumber: number,
+        name: name,
+        airDate: _nonEmptyString(item['air_date']),
+        posterPath: _nonEmptyString(item['poster_path']),
+      ));
+    }
+  }
+  return TmdbTvDetail(name: _nonEmptyString(decoded['name']), seasons: seasons);
+}
+
+/// 纯函数：解析 `/3/tv/{id}/season/{n}` 响应的分集列表。缺 `episode_number`
+/// 的项跳过。JSON 结构异常 → 抛 [ScrapeNetworkException]。
+List<TmdbEpisodeInfo> parseTmdbSeasonEpisodes(String body) {
+  final Map<String, Object?> decoded = _decodeObject(body, 'TMDB season');
+  final Object? episodesNode = decoded['episodes'];
+  final List<TmdbEpisodeInfo> episodes = <TmdbEpisodeInfo>[];
+  if (episodesNode is List<Object?>) {
+    for (final Object? item in episodesNode) {
+      if (item is! Map<String, Object?>) continue;
+      final Object? number = item['episode_number'];
+      if (number is! int || number <= 0) continue;
+      episodes.add(TmdbEpisodeInfo(
+        episodeNumber: number,
+        title: _nonEmptyString(item['name']),
+        summary: _nonEmptyString(item['overview']),
+        airDate: _nonEmptyString(item['air_date']),
+        stillPath: _nonEmptyString(item['still_path']),
+      ));
+    }
+  }
+  return episodes;
+}
+
+/// 纯函数：从 `/3/movie/{id}` 响应取 `belongs_to_collection`；不属于任何系列
+/// → null。JSON 结构异常 → 抛 [ScrapeNetworkException]。
+TmdbMovieCollectionRef? parseTmdbMovieCollectionRef(String body) {
+  final Map<String, Object?> decoded = _decodeObject(body, 'TMDB movie');
+  final Object? node = decoded['belongs_to_collection'];
+  if (node is! Map<String, Object?>) return null;
+  final Object? id = node['id'];
+  if (id is! int) return null;
+  return TmdbMovieCollectionRef(
+    collectionId: '$id',
+    name: _nonEmptyString(node['name']),
+  );
+}
+
+/// 纯函数：解析 `/3/collection/{id}` 响应的成员电影列表。缺 id/标题的项跳过。
+/// JSON 结构异常 → 抛 [ScrapeNetworkException]。
+List<TmdbCollectionPart> parseTmdbCollectionParts(String body) {
+  final Map<String, Object?> decoded = _decodeObject(body, 'TMDB collection');
+  final Object? partsNode = decoded['parts'];
+  final List<TmdbCollectionPart> parts = <TmdbCollectionPart>[];
+  if (partsNode is List<Object?>) {
+    for (final Object? item in partsNode) {
+      if (item is! Map<String, Object?>) continue;
+      final Object? id = item['id'];
+      final String? title = _nonEmptyString(item['title']);
+      if (id is! int || title == null) continue;
+      parts.add(TmdbCollectionPart(
+        movieId: '$id',
+        title: title,
+        releaseDate: _nonEmptyString(item['release_date']),
+        posterPath: _nonEmptyString(item['poster_path']),
+      ));
+    }
+  }
+  return parts;
+}
+
+/// 解 JSON 顶层对象；非对象/解码失败 → 抛 [ScrapeNetworkException]。
+Map<String, Object?> _decodeObject(String body, String what) {
+  final Object? decoded;
+  try {
+    decoded = jsonDecode(body);
+  } catch (e) {
+    throw ScrapeNetworkException('$what JSON decode failed: $e');
+  }
+  if (decoded is! Map<String, Object?>) {
+    throw ScrapeNetworkException('$what response not a JSON object');
+  }
+  return decoded;
 }
 
 /// 纯函数：解析 TMDB `/search/multi` 响应，滤掉非 tv/movie，缺 poster_path 跳过。

--- a/hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+++ b/hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
@@ -1,0 +1,35 @@
+// 入库默认值（空占位，保证任何 clone/worktree 都能直接编译）。模板见
+// tmdb_default_key.example.dart。
+//
+// 内置 TMDB API key（v3 auth）——让封面/元数据刮削开箱即用，用户不必自己去
+// themoviedb.org 申请再粘贴。key 会编译进二进制（客户端密钥本质会随包分发），故
+// **不入库真值**，以免被密钥扫描器反复告警、也避免轮换后的新值随每次 commit 重新公开。
+// 同 google_oauth_secret.dart / dandanplay_secret.dart 的既有约定。
+//
+// 本机要启用内置 key 时：把真值填到本文件，再执行一次——
+//   git update-index --skip-worktree hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+// 真值只留本地、不显示 dirty、永不提交。CI 发布构建从 GitHub Actions secret
+// TMDB_API_KEY 注入（见 main.yml / build-multiplatform.yml）。
+//
+// 留空时 TMDB 源自动降级为「未配置」：不构造 client、UI 不出 TMDB 候选，其余数据源
+// （Bangumi / AniList / Jikan / 离线库）照常工作。fork 构建请填自己申请的 key。
+//
+// ⚠️ 使用本 key 附带合约义务（TMDB Terms of Use）：应用内须展示 TMDB logo 与
+// "This product uses the TMDB API but is not endorsed or certified by TMDB."
+// ——见「关于」页署名区。删 key 前不要先删署名，反之亦然。
+const String kBuiltinTmdbApiKey = '';
+
+/// 用户自定义 TMDB API key 的偏好键（存 Drift `preferences` 表，不改 schema）。
+///
+/// 与 [kBuiltinTmdbApiKey] 同住一个文件是有意的：「这次请求用哪把 key」的全部输入
+/// 就是这两者，分散在 UI 文件里会让人以为改弹窗就能改取值规则。
+const String kVideoScraperTmdbApiKeyPref = 'video_scraper_tmdb_api_key';
+
+/// 解析实际生效的 TMDB key：**用户自填优先，其次内置**。
+///
+/// 两者皆空 → 返回空串，调用方据此判定「TMDB 未配置」并跳过该源。返回空串是**正常
+/// 降级路径不是错误**：fresh clone / fork 构建本就没有内置 key。
+String resolveTmdbApiKey(String userKey) {
+  final String trimmed = userKey.trim();
+  return trimmed.isEmpty ? kBuiltinTmdbApiKey.trim() : trimmed;
+}

--- a/hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart
+++ b/hibiki/lib/src/media/video/scraper/tmdb_default_key.example.dart
@@ -1,0 +1,21 @@
+// 模板（入库）。把真值填进同目录的 `tmdb_default_key.dart`，再执行一次：
+//   git update-index --skip-worktree hibiki/lib/src/media/video/scraper/tmdb_default_key.dart
+// 真值只留本地、不显示 dirty、永不提交。
+//
+// 真值来源：https://www.themoviedb.org/settings/api → Developer Plan（免费，非商业）
+//   - 应用名称：Hibiki
+//   - 应用网址：https://github.com/hajisensai/hibiki
+//   - 使用类型：按实际分发面选 Desktop / Mobile Application（**不要选 Personal**，
+//     本项目是公开分发的应用，不是个人自用）
+//   - 拿「API 密钥」那一串 32 位十六进制（v3 auth），不是 v4 读访问令牌
+//
+// CI 发布构建从 GitHub Actions secret TMDB_API_KEY 注入，无需改本文件。
+//
+// 留空时 TMDB 源自动降级为「未配置」，其余数据源照常工作。
+const String kBuiltinTmdbApiKey = '';
+
+/// 解析实际生效的 TMDB key：用户自填优先，其次内置。两者皆空 = TMDB 未配置。
+String resolveTmdbApiKey(String userKey) {
+  final String trimmed = userKey.trim();
+  return trimmed.isEmpty ? kBuiltinTmdbApiKey.trim() : trimmed;
+}

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -28,6 +28,7 @@ import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
 import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
 import 'package:hibiki/src/media/video/scraper/offline_index.dart';
 import 'package:hibiki/src/media/video/scraper/cover_downloader.dart';
+import 'package:hibiki/src/media/video/scraper/collection_relations_scrape.dart';
 import 'package:hibiki/src/media/video/scraper/collection_scrape_apply.dart';
 import 'package:hibiki/src/media/video/scraper/cover_scraper_service.dart';
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
@@ -3507,15 +3508,56 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         applyScrape: (
           CollectionScrapeResult result, {
           required String? confirmedTitle,
-        }) =>
-            applyCollectionScrape(
-          db,
-          collection.id,
-          result,
-          confirmedTitle: confirmedTitle,
-        ),
+        }) async {
+          await applyCollectionScrape(
+            db,
+            collection.id,
+            result,
+            confirmedTitle: confirmedTitle,
+          );
+          // TODO-2484：同一次刮削顺带拉「相关作品」。fire-and-forget——弹窗
+          // 主流程（封面+资料）已落库成功，关系区块是增量数据，拉取失败只记
+          // 日志、下次重刮补齐，不把弹窗关闭卡在第二轮网络请求上。
+          unawaited(_scrapeCollectionRelations(db, collection.id));
+        },
       ),
     );
+  }
+
+  /// 合集刮削后的「相关作品」拉取（TODO-2484）。独立函数：applyScrape 闭包只管
+  /// 触发；失败（含逐源错误）统一进 ErrorLogService，不上 UI。
+  Future<void> _scrapeCollectionRelations(
+    HibikiDatabase db,
+    int collectionId,
+  ) async {
+    final String tmdbKey = ref
+        .read(appProvider)
+        .prefsRepo
+        .getPref(kVideoScraperTmdbApiKeyPref, defaultValue: '') as String;
+    final BangumiClient bangumi = BangumiClient();
+    final TmdbClient? tmdb =
+        tmdbKey.isEmpty ? null : TmdbClient(apiKey: tmdbKey);
+    try {
+      final CollectionRelationsScrapeReport report =
+          await scrapeCollectionRelations(
+        db: db,
+        collectionId: collectionId,
+        bangumi: bangumi,
+        tmdb: tmdb,
+      );
+      for (final MapEntry<String, String> entry
+          in report.sourceErrors.entries) {
+        ErrorLogService.instance.log(
+          'CollectionRelations.${entry.key}',
+          entry.value,
+        );
+      }
+    } catch (e, stack) {
+      ErrorLogService.instance.log('CollectionRelations', e, stack);
+    } finally {
+      bangumi.close();
+      tmdb?.close();
+    }
   }
 
   /// 合集右键「为合集获取字幕」：与合集详情页 AppBar 同一 [JimakuBatchDialog]

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -33,6 +33,8 @@ import 'package:hibiki/src/media/video/scraper/collection_scrape_apply.dart';
 import 'package:hibiki/src/media/video/scraper/cover_scraper_service.dart';
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
 import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_default_key.dart'
+    show resolveTmdbApiKey;
 import 'package:hibiki/src/media/media_cover_service.dart';
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
@@ -3530,10 +3532,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     HibikiDatabase db,
     int collectionId,
   ) async {
-    final String tmdbKey = ref
+    // 用户自填 key 优先，其次内置 key（resolveTmdbApiKey）——与封面刮削同一
+    // 取值规则；读裸偏好会让只靠内置 key 的用户 TMDB 关系路静默失效。
+    final String tmdbKey = resolveTmdbApiKey(ref
         .read(appProvider)
         .prefsRepo
-        .getPref(kVideoScraperTmdbApiKeyPref, defaultValue: '') as String;
+        .getPref(kVideoScraperTmdbApiKeyPref, defaultValue: '') as String);
     final BangumiClient bangumi = BangumiClient();
     final TmdbClient? tmdb =
         tmdbKey.isEmpty ? null : TmdbClient(apiKey: tmdbKey);

--- a/hibiki/test/database/collection_relations_test.dart
+++ b/hibiki/test/database/collection_relations_test.dart
@@ -1,0 +1,305 @@
+import 'package:drift/drift.dart' show QueryRow, Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:sqlite3/common.dart' show CommonDatabase;
+
+/// TODO-2484 守卫：合集「相关作品」边表（schema v65）。
+///
+/// 覆盖：迁移（fresh v65 / 真 v64→v65）、CRUD（整体替换 + 排序 + 升级绑定 +
+/// 按 subject 反查）、FK 行为（删合集 cascade 清边 / 删目标合集 setNull 退回
+/// 纯刮削态）、同合集同源同条目唯一键。
+void main() {
+  /// 必须显式开 `foreign_keys`：`NativeDatabase.memory()` 默认关闭外键，而生产
+  /// 路径在 `applyPragmas` 里开。不开的话 cascade / setNull 用例会「通过得毫无
+  /// 意义」——它们测的正是 FK 行为本身。
+  Future<HibikiDatabase> openDb() async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (CommonDatabase rawDb) =>
+            rawDb.execute('PRAGMA foreign_keys = ON'),
+      ),
+    );
+    addTearDown(db.close);
+    return db;
+  }
+
+  CollectionRelationsCompanion relation(
+    int collectionId, {
+    String relationType = 'sequel',
+    int sortIndex = 0,
+    int? targetCollectionId,
+    String source = 'bangumi',
+    String subjectId = '200',
+    String title = '続・作品',
+    String? coverUrl,
+  }) =>
+      CollectionRelationsCompanion.insert(
+        collectionId: collectionId,
+        relationType: relationType,
+        sortIndex: Value<int>(sortIndex),
+        targetCollectionId: Value<int?>(targetCollectionId),
+        source: source,
+        subjectId: subjectId,
+        title: title,
+        coverUrl: Value<String?>(coverUrl),
+      );
+
+  group('schema v65 migration', () {
+    test(
+        'fresh DB (v65) has collection_relations table and '
+        'video_scrape_meta.episode_number column', () async {
+      final HibikiDatabase db = await openDb();
+      expect(db.schemaVersion, 65);
+      final List<QueryRow> tables = await db
+          .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")
+          .get();
+      expect(tables, hasLength(1),
+          reason: 'fresh createAll must include v65 collection_relations');
+      final List<QueryRow> columns =
+          await db.customSelect('PRAGMA table_info(video_scrape_meta)').get();
+      expect(
+        columns.map((QueryRow r) => r.read<String>('name')),
+        contains('episode_number'),
+        reason: 'fresh createAll must include v65 episode_number column',
+      );
+    });
+
+    test(
+        'real v64->v65 creates collection_relations, adds episode_number, '
+        'preserves rows, bumps user_version', () async {
+      final HibikiDatabase db = await _openV64Db();
+
+      final List<QueryRow> tables = await db
+          .customSelect(
+              "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")
+          .get();
+      expect(tables, hasLength(1), reason: 'from<65 分支必须建出新表');
+
+      // 既有行原样保留；episode_number 回填 NULL = 旧作品级资料。
+      final MediaCollectionRow? collection = await db.getMediaCollectionById(1);
+      expect(collection, isNotNull);
+      expect(collection!.name, 'Bocchi the Rock!');
+      final VideoScrapeMetaRow? meta = await db.getVideoScrapeMeta('uid-old');
+      expect(meta, isNotNull);
+      expect(meta!.title, '孤独摇滚！');
+      expect(meta.episodeNumber, isNull,
+          reason: 'ADD COLUMN 后旧行必须回填 NULL（作品级旧资料语义）');
+
+      // 新表真的可用（不只是建了个壳）。
+      await db.replaceCollectionRelations(
+          1, <CollectionRelationsCompanion>[relation(1)]);
+      expect(await db.getCollectionRelations(1), hasLength(1));
+
+      final QueryRow version =
+          await db.customSelect('PRAGMA user_version').getSingle();
+      expect(version.read<int>('user_version'), db.schemaVersion);
+    });
+  });
+
+  group('CRUD', () {
+    test(
+        'replaceCollectionRelations swaps whole edge set and orders by '
+        'sortIndex', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await db.createMediaCollection('本篇');
+      await db.replaceCollectionRelations(id, <CollectionRelationsCompanion>[
+        relation(id, subjectId: '2', title: 'B', sortIndex: 1),
+        relation(id,
+            subjectId: '1', title: 'A', sortIndex: 0, relationType: 'prequel'),
+      ]);
+      final List<CollectionRelationRow> first =
+          await db.getCollectionRelations(id);
+      expect(first.map((CollectionRelationRow r) => r.title).toList(),
+          <String>['A', 'B'],
+          reason: '读取按 sortIndex 升序');
+
+      // 第二轮替换：上一轮的边必须整体消失（源撤销的关联不能残留）。
+      await db.replaceCollectionRelations(id, <CollectionRelationsCompanion>[
+        relation(id, subjectId: '3', title: 'C'),
+      ]);
+      final List<CollectionRelationRow> second =
+          await db.getCollectionRelations(id);
+      expect(second, hasLength(1));
+      expect(second.single.title, 'C');
+      expect(second.single.relationType, 'sequel');
+    });
+
+    test(
+        'bindCollectionRelationTarget upgrades scrape-only edge to local '
+        'binding and back', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await db.createMediaCollection('本篇');
+      final int target = await db.createMediaCollection('续篇');
+      await db.replaceCollectionRelations(
+          id, <CollectionRelationsCompanion>[relation(id)]);
+      final CollectionRelationRow edge =
+          (await db.getCollectionRelations(id)).single;
+      expect(edge.targetCollectionId, isNull, reason: '初始为纯刮削态');
+
+      await db.bindCollectionRelationTarget(edge.id, target);
+      expect((await db.getCollectionRelations(id)).single.targetCollectionId,
+          target);
+
+      await db.bindCollectionRelationTarget(edge.id, null);
+      expect((await db.getCollectionRelations(id)).single.targetCollectionId,
+          isNull,
+          reason: '传 null 解绑退回纯刮削态');
+    });
+
+    test(
+        'collectionIdsByScrapeSubject finds collections scraped from the '
+        'same subject', () async {
+      final HibikiDatabase db = await openDb();
+      final int a = await db.createMediaCollection('A');
+      final int b = await db.createMediaCollection('B');
+      await db.upsertCollectionScrapeMeta(CollectionScrapeMetaCompanion.insert(
+        collectionId: Value<int>(a),
+        source: 'bangumi',
+        subjectId: '900',
+        title: 'A 作品',
+        scrapedAt: DateTime(2026),
+      ));
+      expect(await db.collectionIdsByScrapeSubject('bangumi', '900'), <int>[a]);
+      expect(await db.collectionIdsByScrapeSubject('tmdb', '900'), isEmpty,
+          reason: '不同源不算同条目');
+      expect(await db.collectionIdsByScrapeSubject('bangumi', '901'), isEmpty);
+      expect(b, isNot(a));
+    });
+
+    test(
+        'unique key (collectionId, source, subjectId) rejects duplicate '
+        'edges', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await db.createMediaCollection('本篇');
+      await db.replaceCollectionRelations(
+          id, <CollectionRelationsCompanion>[relation(id)]);
+      await expectLater(
+        db.replaceCollectionRelations(id, <CollectionRelationsCompanion>[
+          relation(id, title: '第一条'),
+          relation(id, title: '重复 subject'),
+        ]),
+        throwsA(anything),
+        reason: '同合集同源同 subjectId 第二条必须被唯一键拒绝',
+      );
+    });
+  });
+
+  group('foreign keys', () {
+    test('deleting the collection cascades its relation edges', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await db.createMediaCollection('本篇');
+      await db.replaceCollectionRelations(
+          id, <CollectionRelationsCompanion>[relation(id)]);
+      expect(await db.getCollectionRelations(id), hasLength(1));
+
+      await db.deleteMediaCollectionRaw(id);
+      final QueryRow count = await db
+          .customSelect('SELECT COUNT(*) AS c FROM collection_relations')
+          .getSingle();
+      expect(count.read<int>('c'), 0, reason: '删合集必须 cascade 清掉它的全部关系边');
+    });
+
+    test(
+        'deleting the bound target collection nulls targetCollectionId '
+        '(back to scrape-only)', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await db.createMediaCollection('本篇');
+      final int target = await db.createMediaCollection('续篇');
+      await db.replaceCollectionRelations(id, <CollectionRelationsCompanion>[
+        relation(id, targetCollectionId: target),
+      ]);
+      expect((await db.getCollectionRelations(id)).single.targetCollectionId,
+          target);
+
+      await db.deleteMediaCollectionRaw(target);
+      final CollectionRelationRow edge =
+          (await db.getCollectionRelations(id)).single;
+      expect(edge.targetCollectionId, isNull,
+          reason: '删目标合集必须 setNull 退回纯刮削态，而不是连边一起删');
+      expect(edge.title, '続・作品', reason: '刮削事实（标题等）保留');
+    });
+  });
+}
+
+/// 打开一个 `user_version = 64` 的库：有 media_collections /
+/// collection_scrape_meta / video_scrape_meta（v64 shape，无 episode_number）
+/// 及其数据，但**没有** collection_relations，强制 HibikiDatabase 打开时跑真实
+/// 的 `if (from < 65)` 分支。
+///
+/// from=64 时迁移阶梯上只有 `from < 65` 这一个条件成立，因此这里只需备齐该分支
+/// 触碰到的表，不必重建整个 v64 schema。
+Future<HibikiDatabase> _openV64Db() async {
+  final HibikiDatabase db = HibikiDatabase.forTesting(
+    NativeDatabase.memory(
+      setup: (CommonDatabase rawDb) {
+        rawDb.execute('''
+CREATE TABLE media_collections (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  collection_type TEXT NOT NULL DEFAULT 'collection',
+  cover_source TEXT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  order_updated_at INTEGER NOT NULL DEFAULT 0,
+  anilist_id INTEGER NULL,
+  audio_track_id TEXT NULL,
+  subtitle_delay_ms INTEGER NULL,
+  cover_path TEXT NULL
+);
+''');
+        rawDb.execute('''
+CREATE TABLE collection_scrape_meta (
+  collection_id INTEGER NOT NULL PRIMARY KEY REFERENCES media_collections (id) ON DELETE CASCADE,
+  source TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  original_title TEXT NULL,
+  summary TEXT NULL,
+  air_date TEXT NULL,
+  rating REAL NULL,
+  rating_count INTEGER NULL,
+  episode_count INTEGER NULL,
+  tags_json TEXT NULL,
+  infobox_json TEXT NULL,
+  backdrop_path TEXT NULL,
+  detail_url TEXT NULL,
+  scraped_at INTEGER NOT NULL
+);
+''');
+        rawDb.execute('''
+CREATE TABLE video_scrape_meta (
+  book_uid TEXT NOT NULL PRIMARY KEY,
+  source TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  original_title TEXT NULL,
+  summary TEXT NULL,
+  air_date TEXT NULL,
+  rating REAL NULL,
+  rating_count INTEGER NULL,
+  episode_count INTEGER NULL,
+  tags_json TEXT NULL,
+  infobox_json TEXT NULL,
+  detail_url TEXT NULL,
+  scraped_at INTEGER NOT NULL
+);
+''');
+        rawDb.execute(
+          'INSERT INTO media_collections (id, name, collection_type, '
+          'sort_order, created_at, order_updated_at) '
+          "VALUES (1, 'Bocchi the Rock!', 'playlist', 0, 0, 0)",
+        );
+        rawDb.execute(
+          'INSERT INTO video_scrape_meta (book_uid, source, subject_id, '
+          "title, scraped_at) VALUES ('uid-old', 'bangumi', '100', "
+          "'孤独摇滚！', 0)",
+        );
+        rawDb.execute('PRAGMA user_version = 64');
+      },
+    ),
+  );
+  addTearDown(db.close);
+  return db;
+}

--- a/hibiki/test/database/migration_test.dart
+++ b/hibiki/test/database/migration_test.dart
@@ -1079,7 +1079,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 hibiki_paired_peers). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 64,
+      expect(db.schemaVersion, 65,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1156,7 +1156,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 64,
+      expect(db.schemaVersion, 65,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1316,7 +1316,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 64,
+      expect(db.schemaVersion, 65,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1367,7 +1367,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 64);
+      expect(db.schemaVersion, 65);
     });
 
     test(
@@ -1376,7 +1376,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 64,
+      expect(db.schemaVersion, 65,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1410,7 +1410,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 64,
+      expect(db.schemaVersion, 65,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1450,7 +1450,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 64);
+      expect(db.schemaVersion, 65);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1481,7 +1481,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 64);
+      expect(db.schemaVersion, 65);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1515,7 +1515,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 64);
+      expect(db.schemaVersion, 65);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1527,7 +1527,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 64);
+      expect(db.schemaVersion, 65);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1563,7 +1563,7 @@ void main() {
     // 且既有合集行**一行不少、一列不改**（升级绝不能碰用户数据）。
     test('fresh DB (v64) has collection_scrape_meta table', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 64);
+      expect(db.schemaVersion, 65);
       final rows = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_scrape_meta'")

--- a/hibiki/test/database/migration_v40_collections_test.dart
+++ b/hibiki/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64);
+    expect(db.schemaVersion, 65);
   });
 }

--- a/hibiki/test/database/migration_v51_pdf_format_test.dart
+++ b/hibiki/test/database/migration_v51_pdf_format_test.dart
@@ -110,6 +110,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64);
+    expect(db.schemaVersion, 65);
   });
 }

--- a/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
@@ -117,6 +117,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64);
+    expect(db.schemaVersion, 65);
   });
 }

--- a/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64);
+    expect(db.schemaVersion, 65);
   });
 }

--- a/hibiki/test/database/migration_v55_galgame_library_test.dart
+++ b/hibiki/test/database/migration_v55_galgame_library_test.dart
@@ -122,7 +122,7 @@ CREATE TABLE preferences (
     final String? pref = await db.getPref('galgame_library');
     expect(pref, isNotNull);
 
-    expect(await userVersionOf(db), 64);
+    expect(await userVersionOf(db), 65);
   });
 
   test('脏数据被逐条跳过，不让整个迁移失败', () async {
@@ -158,7 +158,7 @@ CREATE TABLE preferences (
 
     final List<GalgameRow> rows = await db.getAllGalgames();
     expect(rows.map((GalgameRow r) => r.id), <String>['ok-1', 'ok-2']);
-    expect(await userVersionOf(db), 64);
+    expect(await userVersionOf(db), 65);
   });
 
   test('整串 JSON 损坏 / 非数组 / 空串时迁移仍然成功，只是回填为空', () async {
@@ -169,7 +169,7 @@ CREATE TABLE preferences (
     ]) {
       final HibikiDatabase db = await openV53Db(raw);
       expect(await db.getAllGalgames(), isEmpty, reason: 'raw=$raw');
-      expect(await userVersionOf(db), 64, reason: 'raw=$raw');
+      expect(await userVersionOf(db), 65, reason: 'raw=$raw');
       await db.close();
     }
   });
@@ -177,7 +177,7 @@ CREATE TABLE preferences (
   test('偏好里根本没有 galgame_library 时迁移正常，表为空', () async {
     final HibikiDatabase db = await openV53Db(null);
     expect(await db.getAllGalgames(), isEmpty);
-    expect(await userVersionOf(db), 64);
+    expect(await userVersionOf(db), 65);
   });
 
   test('回填幂等：表里已有行就不再重复回填', () async {
@@ -227,7 +227,7 @@ CREATE TABLE preferences (
       ),
     );
     expect(await db.getAllGalgames(), hasLength(1));
-    expect(await userVersionOf(db), 64);
+    expect(await userVersionOf(db), 65);
   });
 
   test('删游戏经 FK cascade 连带清掉 sources 与 sessions', () async {

--- a/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64,
+    expect(db.schemaVersion, 65,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v57_naming_unification_test.dart
+++ b/hibiki/test/database/migration_v57_naming_unification_test.dart
@@ -154,7 +154,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64,
+    expect(db.schemaVersion, 65,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
             'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
             'v63 = 清理旧全局超分 pref');

--- a/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64,
+    expect(db.schemaVersion, 65,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v60_reading_pages_test.dart
+++ b/hibiki/test/database/migration_v60_reading_pages_test.dart
@@ -59,7 +59,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 65, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/hibiki/test/database/migration_v61_collection_cover_path_test.dart
+++ b/hibiki/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64,
+    expect(db.schemaVersion, 65,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/hibiki/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/hibiki/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 64,
+    expect(db.schemaVersion, 65,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/hibiki/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/hibiki/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -126,8 +126,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 64);
-    expect(db.schemaVersion, 64);
+    expect(version.read<int>('user_version'), 65);
+    expect(db.schemaVersion, 65);
 
     final List<QueryRow> preferences = await db
         .customSelect(
@@ -196,8 +196,9 @@ void main() {
     }
     expect(
       schemaAfter.keys.toSet().difference(schemaBefore.keys.toSet()),
-      <String>{'collection_scrape_meta'},
-      reason: '除 v64 的 collection_scrape_meta 外，升级不得新增任何表',
+      <String>{'collection_scrape_meta', 'collection_relations'},
+      reason: '除 v64 的 collection_scrape_meta 与 v65 的 collection_relations '
+          '外，升级不得新增任何表',
     );
   });
 
@@ -215,7 +216,7 @@ void main() {
     expect(await db.getPref('theme'), 's:dark');
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 64);
+    expect(version.read<int>('user_version'), 65);
   });
 
   test(
@@ -247,7 +248,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 64);
+      expect(probe.select('PRAGMA user_version').first.values.first, 65);
       expect(
         probe.select(
           'SELECT 1 FROM profile_settings '

--- a/hibiki/test/media/video/scraper/collection_relations_scrape_test.dart
+++ b/hibiki/test/media/video/scraper/collection_relations_scrape_test.dart
@@ -1,0 +1,292 @@
+import 'dart:convert';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
+import 'package:hibiki/src/media/video/scraper/collection_relations_scrape.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:sqlite3/common.dart' show CommonDatabase;
+import 'package:drift/drift.dart' show Value;
+
+/// TODO-2484：合集「相关作品」抓取层守卫。全部走内存 DB + MockClient，无真实网络。
+void main() {
+  Future<HibikiDatabase> openDb() async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (CommonDatabase rawDb) =>
+            rawDb.execute('PRAGMA foreign_keys = ON'),
+      ),
+    );
+    addTearDown(db.close);
+    return db;
+  }
+
+  Future<int> boundCollection(
+    HibikiDatabase db, {
+    String name = '本篇',
+    String source = 'bangumi',
+    String subjectId = '100',
+    String? detailUrl,
+    String? airDate,
+  }) async {
+    final int id = await db.createMediaCollection(name);
+    await db.upsertCollectionScrapeMeta(CollectionScrapeMetaCompanion.insert(
+      collectionId: Value<int>(id),
+      source: source,
+      subjectId: subjectId,
+      title: name,
+      airDate: Value<String?>(airDate),
+      detailUrl: Value<String?>(detailUrl),
+      scrapedAt: DateTime(2026),
+    ));
+    return id;
+  }
+
+  group('mapBangumiRelation', () {
+    test('maps the six known relation words and defaults to other', () {
+      expect(mapBangumiRelation('前传'), CollectionRelationType.prequel);
+      expect(mapBangumiRelation('续集'), CollectionRelationType.sequel);
+      expect(mapBangumiRelation('番外篇'), CollectionRelationType.sideStory);
+      expect(mapBangumiRelation('外传'), CollectionRelationType.sideStory);
+      expect(mapBangumiRelation('剧场版'), CollectionRelationType.movie);
+      expect(mapBangumiRelation('衍生'), CollectionRelationType.spinOff);
+      expect(mapBangumiRelation('总集篇'), CollectionRelationType.other);
+      expect(mapBangumiRelation('主线故事'), CollectionRelationType.other);
+    });
+
+    test('wire round-trip is stable and unknown wire falls back to other', () {
+      for (final CollectionRelationType type in CollectionRelationType.values) {
+        expect(CollectionRelationType.fromWire(type.wire), type);
+      }
+      expect(CollectionRelationType.sideStory.wire, 'side_story');
+      expect(CollectionRelationType.fromWire('future_kind'),
+          CollectionRelationType.other);
+    });
+  });
+
+  group('parseBangumiRelatedSubjects', () {
+    test('keeps anime/real, drops music and relation-less items', () {
+      final String body = jsonEncode(<Object?>[
+        <String, Object?>{
+          'id': 201,
+          'type': 2,
+          'name': 'Sequel',
+          'name_cn': '续作',
+          'relation': '续集',
+          'images': <String, Object?>{'large': 'https://img/l.jpg'},
+        },
+        <String, Object?>{
+          'id': 202,
+          'type': 3, // 音乐（OST）→ 滤掉
+          'name': 'OST',
+          'relation': '原声集',
+        },
+        <String, Object?>{
+          'id': 203,
+          'type': 2,
+          'name': 'NoRelation', // 缺 relation → 滤掉
+        },
+      ]);
+      final List<BangumiRelatedSubject> related =
+          parseBangumiRelatedSubjects(body);
+      expect(related, hasLength(1));
+      expect(related.single.subjectId, '201');
+      expect(related.single.title, '续作');
+      expect(related.single.relation, '续集');
+      expect(related.single.coverUrl, 'https://img/l.jpg');
+    });
+
+    test('non-array payload throws ScrapeNetworkException', () {
+      expect(() => parseBangumiRelatedSubjects('{"error":"x"}'),
+          throwsA(isA<ScrapeNetworkException>()));
+    });
+  });
+
+  group('tmdb parsers', () {
+    test('tmdbKindFromDetailUrl distinguishes tv and movie', () {
+      expect(tmdbKindFromDetailUrl('https://www.themoviedb.org/tv/100'),
+          TmdbSubjectKind.tv);
+      expect(tmdbKindFromDetailUrl('https://www.themoviedb.org/movie/7'),
+          TmdbSubjectKind.movie);
+      expect(tmdbKindFromDetailUrl('https://bgm.tv/subject/1'), isNull);
+      expect(tmdbKindFromDetailUrl(null), isNull);
+    });
+
+    test('parseTmdbTvDetail extracts seasons', () {
+      final String body = jsonEncode(<String, Object?>{
+        'name': '某剧',
+        'seasons': <Object?>[
+          <String, Object?>{
+            'id': 900,
+            'season_number': 0,
+            'name': '特别篇',
+            'poster_path': '/sp.jpg',
+          },
+          <String, Object?>{
+            'id': 901,
+            'season_number': 1,
+            'name': '第 1 季',
+            'air_date': '2023-01-04',
+          },
+        ],
+      });
+      final TmdbTvDetail detail = parseTmdbTvDetail(body);
+      expect(detail.seasons, hasLength(2));
+      expect(detail.seasons.first.seasonNumber, 0);
+      expect(detail.seasons.last.seasonId, '901');
+    });
+
+    test('parseTmdbMovieCollectionRef reads belongs_to_collection or null', () {
+      expect(
+        parseTmdbMovieCollectionRef(jsonEncode(<String, Object?>{
+          'belongs_to_collection': <String, Object?>{'id': 55, 'name': '系列'},
+        }))!
+            .collectionId,
+        '55',
+      );
+      expect(
+        parseTmdbMovieCollectionRef(
+            jsonEncode(<String, Object?>{'belongs_to_collection': null})),
+        isNull,
+      );
+    });
+
+    test('parseTmdbCollectionParts extracts member movies', () {
+      final List<TmdbCollectionPart> parts =
+          parseTmdbCollectionParts(jsonEncode(<String, Object?>{
+        'parts': <Object?>[
+          <String, Object?>{
+            'id': 7,
+            'title': '第一部',
+            'release_date': '2001-01-01',
+            'poster_path': '/p1.jpg',
+          },
+          <String, Object?>{'id': 8, 'title': '第二部'},
+          <String, Object?>{'title': '缺 id 丢弃'},
+        ],
+      }));
+      expect(parts, hasLength(2));
+      expect(parts.first.movieId, '7');
+    });
+  });
+
+  group('scrapeCollectionRelations (bangumi)', () {
+    MockClient bangumiRelationsClient(List<Object?> payload) =>
+        MockClient((http.Request req) async {
+          if (req.url.path.endsWith('/subjects/100/subjects')) {
+            return http.Response.bytes(utf8.encode(jsonEncode(payload)), 200,
+                headers: <String, String>{
+                  'content-type': 'application/json; charset=utf-8',
+                });
+          }
+          return http.Response('not found', 404);
+        });
+
+    test('writes edges, auto-binds local collections by subject and by title',
+        () async {
+      final HibikiDatabase db = await openDb();
+      final int self = await boundCollection(db);
+      // 目标 A：另一合集已刮过 subject 201 → 按 (source, subjectId) 绑定。
+      final int targetA =
+          await boundCollection(db, name: '续篇合集', subjectId: '201');
+      // 目标 B：无刮削绑定，但合集名与关联条目标题精确相同 → 标题兜底绑定。
+      final int targetB = await db.createMediaCollection('剧场版之名');
+
+      final BangumiClient bangumi = BangumiClient(
+        client: bangumiRelationsClient(<Object?>[
+          <String, Object?>{
+            'id': 201,
+            'type': 2,
+            'name_cn': '续作',
+            'name': 'Sequel',
+            'relation': '续集',
+          },
+          <String, Object?>{
+            'id': 202,
+            'type': 2,
+            'name_cn': '剧场版之名',
+            'name': 'Movie',
+            'relation': '剧场版',
+          },
+          <String, Object?>{
+            'id': 100, // 自引用脏数据：subject 与自身相同 → 不得绑回自己。
+            'type': 2,
+            'name_cn': '本篇',
+            'name': 'Self',
+            'relation': '其他',
+          },
+        ]),
+      );
+      addTearDown(bangumi.close);
+
+      final CollectionRelationsScrapeReport report =
+          await scrapeCollectionRelations(
+        db: db,
+        collectionId: self,
+        bangumi: bangumi,
+      );
+      expect(report.sourceErrors, isEmpty);
+      expect(report.written, 3);
+      expect(report.boundLocal, 2);
+
+      final List<CollectionRelationRow> edges =
+          await db.getCollectionRelations(self);
+      expect(edges, hasLength(3));
+      expect(edges[0].relationType, 'sequel');
+      expect(edges[0].targetCollectionId, targetA);
+      expect(edges[1].relationType, 'movie');
+      expect(edges[1].targetCollectionId, targetB,
+          reason: '无 subject 绑定时按标题精确匹配兜底');
+      expect(edges[2].targetCollectionId, isNull,
+          reason: '自引用条目绝不绑回自身（标题匹配也排除自身）');
+      expect(edges.map((CollectionRelationRow e) => e.sortIndex).toList(),
+          <int>[0, 1, 2]);
+    });
+
+    test('source failure keeps previous edges and reports the error', () async {
+      final HibikiDatabase db = await openDb();
+      final int self = await boundCollection(db);
+      final BangumiClient good = BangumiClient(
+        client: bangumiRelationsClient(<Object?>[
+          <String, Object?>{
+            'id': 201,
+            'type': 2,
+            'name': 'Sequel',
+            'relation': '续集',
+          },
+        ]),
+      );
+      addTearDown(good.close);
+      await scrapeCollectionRelations(
+          db: db, collectionId: self, bangumi: good);
+      expect(await db.getCollectionRelations(self), hasLength(1));
+
+      final BangumiClient bad = BangumiClient(
+        client:
+            MockClient((http.Request req) async => http.Response('boom', 500)),
+      );
+      addTearDown(bad.close);
+      final CollectionRelationsScrapeReport report =
+          await scrapeCollectionRelations(
+        db: db,
+        collectionId: self,
+        bangumi: bad,
+      );
+      expect(report.sourceErrors, isNotEmpty, reason: '源失败必须上报不吞');
+      expect(await db.getCollectionRelations(self), hasLength(1),
+          reason: '源失败时不得把上次刮到的关系清空');
+    });
+
+    test('missing scrape binding throws StateError', () async {
+      final HibikiDatabase db = await openDb();
+      final int bare = await db.createMediaCollection('未刮削');
+      expect(
+        () => scrapeCollectionRelations(db: db, collectionId: bare),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/hibiki/test/media/video/scraper/collection_relations_scrape_test.dart
+++ b/hibiki/test/media/video/scraper/collection_relations_scrape_test.dart
@@ -288,5 +288,240 @@ void main() {
         throwsStateError,
       );
     });
+
+    test(
+        'duplicate subjects from source are deduped first-wins '
+        '(no unique-key rollback)', () async {
+      final HibikiDatabase db = await openDb();
+      final int self = await boundCollection(db);
+      final BangumiClient bangumi = BangumiClient(
+        client: bangumiRelationsClient(<Object?>[
+          <String, Object?>{
+            'id': 201,
+            'type': 2,
+            'name': 'Dup',
+            'relation': '续集',
+          },
+          <String, Object?>{
+            'id': 201,
+            'type': 2,
+            'name': 'Dup again',
+            'relation': '其他',
+          },
+        ]),
+      );
+      addTearDown(bangumi.close);
+      final CollectionRelationsScrapeReport report =
+          await scrapeCollectionRelations(
+        db: db,
+        collectionId: self,
+        bangumi: bangumi,
+      );
+      expect(report.sourceErrors, isEmpty);
+      expect(report.written, 1,
+          reason: '同 (source, subjectId) 重复条目首见保留——不去重会撞唯一键'
+              '把整批替换回滚成零写入');
+      final CollectionRelationRow edge =
+          (await db.getCollectionRelations(self)).single;
+      expect(edge.relationType, 'sequel', reason: '首见（续集）保留');
+    });
+  });
+
+  group('scrapeCollectionRelations (tmdb)', () {
+    MockClient tmdbApiClient(Map<String, String> pathToBody) =>
+        MockClient((http.Request req) async {
+          final String? body = pathToBody[req.url.path];
+          if (body == null) return http.Response('not found', 404);
+          return http.Response.bytes(utf8.encode(body), 200,
+              headers: <String, String>{
+                'content-type': 'application/json; charset=utf-8',
+              });
+        });
+
+    test(
+        'tv seasons become edges (specials=side_story) and season edges '
+        'never bind by subject id', () async {
+      final HibikiDatabase db = await openDb();
+      final int self = await boundCollection(
+        db,
+        source: 'tmdb',
+        subjectId: '77',
+        detailUrl: 'https://www.themoviedb.org/tv/77',
+      );
+      // 撞号干扰：另一合集的刮削绑定 subjectId 恰好等于季 id 901（tv/movie id
+      // 与季 id 空间独立、必然撞号）。季边若按 subject 反查会错绑到它。
+      final int decoy = await boundCollection(
+        db,
+        name: '撞号合集',
+        source: 'tmdb',
+        subjectId: '901',
+      );
+      // 标题精确匹配兜底对季边仍然生效。
+      final int titleTarget = await db.createMediaCollection('第 2 季');
+
+      final TmdbClient tmdb = TmdbClient(
+        apiKey: 'k',
+        client: tmdbApiClient(<String, String>{
+          '/3/tv/77': jsonEncode(<String, Object?>{
+            'name': 'Show',
+            'seasons': <Object?>[
+              <String, Object?>{
+                'id': 900,
+                'season_number': 0,
+                'name': '特别篇',
+              },
+              <String, Object?>{
+                'id': 901,
+                'season_number': 1,
+                'name': '第 1 季',
+                'poster_path': '/s1.jpg',
+              },
+              <String, Object?>{
+                'id': 902,
+                'season_number': 2,
+                'name': '第 2 季',
+              },
+            ],
+          }),
+        }),
+      );
+      addTearDown(tmdb.close);
+
+      final CollectionRelationsScrapeReport report =
+          await scrapeCollectionRelations(
+        db: db,
+        collectionId: self,
+        tmdb: tmdb,
+      );
+      expect(report.sourceErrors, isEmpty);
+      expect(report.written, 3);
+      expect(report.boundLocal, 1);
+
+      final List<CollectionRelationRow> edges =
+          await db.getCollectionRelations(self);
+      expect(edges[0].relationType, 'side_story',
+          reason: 'season 0（特别篇）归 side_story');
+      expect(edges[0].title, '特别篇');
+      expect(edges[1].relationType, 'other');
+      expect(edges[1].targetCollectionId, isNull,
+          reason: '季边绝不按 subject 反查——季 id 901 撞上 decoy 合集的 '
+              'tv id 901 也不能绑');
+      expect(edges[1].coverUrl, '${TmdbClient.posterBase}/s1.jpg');
+      expect(edges[2].targetCollectionId, titleTarget, reason: '季边仍走标题精确匹配兜底');
+      expect(decoy, isNot(titleTarget));
+    });
+
+    test('movie parts typed by release date relative to self, self excluded',
+        () async {
+      final HibikiDatabase db = await openDb();
+      final int self = await boundCollection(
+        db,
+        source: 'tmdb',
+        subjectId: '55',
+        detailUrl: 'https://www.themoviedb.org/movie/55',
+        airDate: '2005-06-01',
+      );
+      final TmdbClient tmdb = TmdbClient(
+        apiKey: 'k',
+        client: tmdbApiClient(<String, String>{
+          '/3/movie/55': jsonEncode(<String, Object?>{
+            'belongs_to_collection': <String, Object?>{'id': 5, 'name': '系列'},
+          }),
+          '/3/collection/5': jsonEncode(<String, Object?>{
+            'parts': <Object?>[
+              <String, Object?>{
+                'id': 55,
+                'title': '本体',
+                'release_date': '2005-06-01',
+              },
+              <String, Object?>{
+                'id': 54,
+                'title': '前作',
+                'release_date': '2001-01-01',
+              },
+              <String, Object?>{
+                'id': 56,
+                'title': '续作',
+                'release_date': '2010-01-01',
+              },
+              <String, Object?>{'id': 57, 'title': '未定档'},
+            ],
+          }),
+        }),
+      );
+      addTearDown(tmdb.close);
+
+      final CollectionRelationsScrapeReport report =
+          await scrapeCollectionRelations(
+        db: db,
+        collectionId: self,
+        tmdb: tmdb,
+      );
+      expect(report.sourceErrors, isEmpty);
+      final List<CollectionRelationRow> edges =
+          await db.getCollectionRelations(self);
+      expect(edges, hasLength(3), reason: '排除自身（id 55）');
+      expect(
+        <String, String>{
+          for (final CollectionRelationRow e in edges) e.title: e.relationType,
+        },
+        <String, String>{
+          '前作': 'prequel',
+          '续作': 'sequel',
+          '未定档': 'other',
+        },
+        reason: '按上映日期相对本条目分型，无日期归 other',
+      );
+    });
+
+    test('detailUrl-less subject probes tv first, falls back to movie on 404',
+        () async {
+      final HibikiDatabase db = await openDb();
+      final int self = await boundCollection(
+        db,
+        source: 'tmdb',
+        subjectId: '55',
+        airDate: '2005-06-01',
+      );
+      final List<String> requested = <String>[];
+      final TmdbClient tmdb = TmdbClient(
+        apiKey: 'k',
+        client: MockClient((http.Request req) async {
+          requested.add(req.url.path);
+          final Map<String, String> routes = <String, String>{
+            // '/3/tv/55' 不注册 → 404 → 回退 movie 探测。
+            '/3/movie/55': jsonEncode(<String, Object?>{
+              'belongs_to_collection': <String, Object?>{'id': 5},
+            }),
+            '/3/collection/5': jsonEncode(<String, Object?>{
+              'parts': <Object?>[
+                <String, Object?>{
+                  'id': 54,
+                  'title': '前作',
+                  'release_date': '2001-01-01',
+                },
+              ],
+            }),
+          };
+          final String? body = routes[req.url.path];
+          if (body == null) return http.Response('not found', 404);
+          return http.Response.bytes(utf8.encode(body), 200);
+        }),
+      );
+      addTearDown(tmdb.close);
+
+      final CollectionRelationsScrapeReport report =
+          await scrapeCollectionRelations(
+        db: db,
+        collectionId: self,
+        tmdb: tmdb,
+      );
+      expect(report.sourceErrors, isEmpty);
+      expect(requested.first, '/3/tv/55', reason: '缺 detailUrl 先按 tv 探测');
+      final List<CollectionRelationRow> edges =
+          await db.getCollectionRelations(self);
+      expect(edges.single.relationType, 'prequel',
+          reason: 'tv 404 后回退 movie 路径产出系列成员边');
+    });
   });
 }

--- a/hibiki/test/media/video/scraper/episode_rename_test.dart
+++ b/hibiki/test/media/video/scraper/episode_rename_test.dart
@@ -1,0 +1,164 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/episode_rename.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:sqlite3/common.dart' show CommonDatabase;
+
+/// TODO-2491：集显示名提案与批量改名守卫。
+///
+/// 关键契约：dryRun 只出对照表**零写库**；执行态写穿 `video_books.title`；
+/// 集名缺失（集级刮削回退写了作品名）时提案退化为纯 `E01` 式；未刮成员零提案
+/// （自动刮削路径永不改名——改名只能从这里、经用户确认走）。
+void main() {
+  Future<HibikiDatabase> openDb() async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (CommonDatabase rawDb) =>
+            rawDb.execute('PRAGMA foreign_keys = ON'),
+      ),
+    );
+    addTearDown(db.close);
+    return db;
+  }
+
+  Future<int> boundCollection(HibikiDatabase db, {String name = '作品名'}) async {
+    final int id = await db.createMediaCollection(name);
+    await db.upsertCollectionScrapeMeta(CollectionScrapeMetaCompanion.insert(
+      collectionId: Value<int>(id),
+      source: 'bangumi',
+      subjectId: '100',
+      title: name,
+      scrapedAt: DateTime(2026),
+    ));
+    return id;
+  }
+
+  Future<void> addScrapedEpisode(
+    HibikiDatabase db,
+    int collectionId,
+    String uid, {
+    required String title,
+    int? episodeNumber,
+    String? episodeTitle,
+  }) async {
+    await db.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: uid,
+      title: title,
+      videoPath: '/videos/$uid.mkv',
+    ));
+    await db.addToCollectionRaw(collectionId, 'video', uid);
+    if (episodeNumber != null) {
+      await db.upsertVideoScrapeMeta(VideoScrapeMetaCompanion.insert(
+        bookUid: uid,
+        source: 'bangumi',
+        subjectId: '100',
+        title: episodeTitle ?? '作品名',
+        episodeNumber: Value<int?>(episodeNumber),
+        scrapedAt: DateTime(2026),
+      ));
+    }
+  }
+
+  group('proposeEpisodeDisplayName', () {
+    test('formats E<padded> <title>, pure E<padded> without title', () {
+      expect(
+        proposeEpisodeDisplayName(episodeNumber: 1, episodeTitle: '出会い'),
+        'E01 出会い',
+      );
+      expect(proposeEpisodeDisplayName(episodeNumber: 7), 'E07');
+      expect(proposeEpisodeDisplayName(episodeNumber: 7, episodeTitle: '  '),
+          'E07',
+          reason: '空白集名等同无集名');
+      expect(
+        proposeEpisodeDisplayName(
+            episodeNumber: 7, episodeTitle: 'x', padWidth: 3),
+        'E007 x',
+      );
+      expect(proposeEpisodeDisplayName(episodeNumber: 123), 'E123',
+          reason: '集号宽于 padWidth 时不截断');
+    });
+  });
+
+  group('renameCollectionEpisodes', () {
+    test('dryRun returns old->new table without writing', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(db);
+      await addScrapedEpisode(db, id, 'u1',
+          title: 'Show - 01', episodeNumber: 1, episodeTitle: '出会い');
+      await addScrapedEpisode(db, id, 'u2',
+          title: 'Show - 02', episodeNumber: 2, episodeTitle: '別れ');
+      await addScrapedEpisode(db, id, 'raw', title: '未刮的成员');
+
+      final List<EpisodeRenameProposal> proposals =
+          await renameCollectionEpisodes(
+        db: db,
+        collectionId: id,
+        dryRun: true,
+      );
+      expect(proposals, hasLength(2), reason: '未刮成员不产生提案');
+      expect(proposals.first.oldTitle, 'Show - 01');
+      expect(proposals.first.newTitle, 'E01 出会い');
+      expect(proposals.last.newTitle, 'E02 別れ');
+
+      expect((await db.getVideoBookByBookUid('u1'))!.title, 'Show - 01',
+          reason: 'dryRun 绝不写库');
+      expect((await db.getVideoBookByBookUid('raw'))!.title, '未刮的成员');
+    });
+
+    test('execute writes titles through video_books and skips already-equal',
+        () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(db);
+      await addScrapedEpisode(db, id, 'u1',
+          title: 'Show - 01', episodeNumber: 1, episodeTitle: '出会い');
+      await addScrapedEpisode(db, id, 'u2',
+          title: 'E02 別れ', episodeNumber: 2, episodeTitle: '別れ');
+
+      final List<EpisodeRenameProposal> proposals =
+          await renameCollectionEpisodes(
+        db: db,
+        collectionId: id,
+        dryRun: false,
+      );
+      expect(proposals, hasLength(1), reason: '新旧同名不产出提案');
+      expect((await db.getVideoBookByBookUid('u1'))!.title, 'E01 出会い');
+      expect((await db.getVideoBookByBookUid('u2'))!.title, 'E02 別れ');
+    });
+
+    test('episode title equal to work title degrades to bare E<n>', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(db, name: '孤独摇滚！');
+      // 集级刮削在集名缺失时回退写了作品名——提案不能拼成「E01 孤独摇滚！」。
+      await addScrapedEpisode(db, id, 'u1',
+          title: 'Show - 01', episodeNumber: 1, episodeTitle: '孤独摇滚！');
+
+      final List<EpisodeRenameProposal> proposals =
+          await renameCollectionEpisodes(
+        db: db,
+        collectionId: id,
+        dryRun: true,
+      );
+      expect(proposals.single.newTitle, 'E01');
+    });
+
+    test('pad width follows max episode number (three digits)', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(db);
+      await addScrapedEpisode(db, id, 'u1',
+          title: 'a', episodeNumber: 1, episodeTitle: '一');
+      await addScrapedEpisode(db, id, 'u100',
+          title: 'b', episodeNumber: 100, episodeTitle: '百');
+
+      final List<EpisodeRenameProposal> proposals =
+          await renameCollectionEpisodes(
+        db: db,
+        collectionId: id,
+        dryRun: true,
+      );
+      expect(proposals.map((EpisodeRenameProposal p) => p.newTitle).toList(),
+          <String>['E001 一', 'E100 百'],
+          reason: '零填充宽度取合集内最大集号宽度');
+    });
+  });
+}

--- a/hibiki/test/media/video/scraper/episode_scrape_service_test.dart
+++ b/hibiki/test/media/video/scraper/episode_scrape_service_test.dart
@@ -86,8 +86,11 @@ void main() {
 
   group('parseBangumiEpisodesResponse', () {
     test('keeps integer main-episode sorts, drops fractional or zero', () {
-      final ({List<BangumiEpisodeInfo> episodes, int total}) page =
-          parseBangumiEpisodesResponse(jsonEncode(<String, Object?>{
+      final ({
+        List<BangumiEpisodeInfo> episodes,
+        int rawCount,
+        int total
+      }) page = parseBangumiEpisodesResponse(jsonEncode(<String, Object?>{
         'total': 4,
         'data': <Object?>[
           <String, Object?>{
@@ -101,6 +104,7 @@ void main() {
         ],
       }));
       expect(page.total, 4);
+      expect(page.rawCount, 4, reason: '分页 offset 按原始条数推进，不受过滤影响');
       expect(page.episodes.map((BangumiEpisodeInfo e) => e.episodeNumber),
           <int>[1, 2]);
       expect(page.episodes.first.title, '第一话');
@@ -281,7 +285,7 @@ void main() {
       expect(outcome.errors, isEmpty);
       expect(outcome.updated, 2);
       expect(seasonRequests.single, '/3/tv/77/season/2',
-          reason: '季号取成员文件名解析的众数（S02 → season 2）');
+          reason: '成员均为 S02 → 只拉 season 2');
 
       // u1：资料写入但封面纹丝不动。
       expect((await db.getVideoScrapeMeta('u1'))!.title, '一话');
@@ -322,6 +326,97 @@ void main() {
       expect(outcome.errors['tmdb'], contains('movie'),
           reason: 'movie 条目无分集：显式报错而不是装作零匹配');
       expect(outcome.updated, 0);
+    });
+  });
+
+  group('mixed seasons and pagination', () {
+    test('mixed-season members each align against their own season table',
+        () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(
+        db,
+        source: 'tmdb',
+        subjectId: '77',
+        detailUrl: 'https://www.themoviedb.org/tv/77',
+      );
+      await addVideoMember(db, id, 'u1', 'Show S01E01.mkv');
+      await addVideoMember(db, id, 'u2', 'Show S02E01.mkv');
+
+      final List<String> seasonRequests = <String>[];
+      final TmdbClient tmdb = TmdbClient(
+        apiKey: 'k',
+        client: MockClient((http.Request req) async {
+          seasonRequests.add(req.url.path);
+          final Map<String, List<Map<String, Object?>>> episodesBySeason =
+              <String, List<Map<String, Object?>>>{
+            '/3/tv/77/season/1': <Map<String, Object?>>[
+              <String, Object?>{'episode_number': 1, 'name': '一季一话'},
+            ],
+            '/3/tv/77/season/2': <Map<String, Object?>>[
+              <String, Object?>{'episode_number': 1, 'name': '二季一话'},
+            ],
+          };
+          final List<Map<String, Object?>>? episodes =
+              episodesBySeason[req.url.path];
+          if (episodes == null) return http.Response('not found', 404);
+          return http.Response.bytes(
+            utf8.encode(jsonEncode(<String, Object?>{'episodes': episodes})),
+            200,
+          );
+        }),
+      );
+      addTearDown(tmdb.close);
+
+      final EpisodeScrapeOutcome outcome =
+          await EpisodeScrapeService(db: db, tmdbClient: tmdb)
+              .scrapeCollectionEpisodes(id);
+      expect(outcome.errors, isEmpty);
+      expect(outcome.updated, 2);
+      expect(seasonRequests.toSet(),
+          <String>{'/3/tv/77/season/1', '/3/tv/77/season/2'},
+          reason: '按成员出现的每个季各拉一次');
+      expect((await db.getVideoScrapeMeta('u1'))!.title, '一季一话',
+          reason: 'S01 成员对齐第 1 季分集表');
+      expect((await db.getVideoScrapeMeta('u2'))!.title, '二季一话',
+          reason: 'S02 成员对齐第 2 季分集表，不被另一季错配');
+    });
+
+    test(
+        'bangumi pagination advances by raw count across fully-filtered '
+        'pages', () async {
+      final List<int> offsets = <int>[];
+      final BangumiClient bangumi = BangumiClient(
+        client: MockClient((http.Request req) async {
+          if (!req.url.path.endsWith('/episodes')) {
+            return http.Response('not found', 404);
+          }
+          final int offset =
+              int.parse(req.url.queryParameters['offset'] ?? '0');
+          offsets.add(offset);
+          // 第一页两条全是非整数 sort（过滤后为空），第二页才是正篇第 3 话。
+          final List<Map<String, Object?>> page = offset == 0
+              ? <Map<String, Object?>>[
+                  <String, Object?>{'sort': 0.5, 'name': 'SP1'},
+                  <String, Object?>{'sort': 1.5, 'name': 'SP2'},
+                ]
+              : <Map<String, Object?>>[
+                  <String, Object?>{'sort': 3, 'name': '第三话'},
+                ];
+          return http.Response.bytes(
+            utf8.encode(
+                jsonEncode(<String, Object?>{'data': page, 'total': 3})),
+            200,
+          );
+        }),
+      );
+      addTearDown(bangumi.close);
+
+      final List<BangumiEpisodeInfo> episodes =
+          await bangumi.fetchSubjectEpisodes('100');
+      expect(offsets, <int>[0, 2],
+          reason: 'offset 按原始返回条数推进——按过滤后长度推进会在全滤页上'
+              '提前终止，丢掉后面的正常页');
+      expect(episodes.single.episodeNumber, 3);
     });
   });
 }

--- a/hibiki/test/media/video/scraper/episode_scrape_service_test.dart
+++ b/hibiki/test/media/video/scraper/episode_scrape_service_test.dart
@@ -1,0 +1,327 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
+import 'package:hibiki/src/media/video/scraper/cover_downloader.dart';
+import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
+import 'package:hibiki/src/media/video/scraper/episode_scrape_service.dart';
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:sqlite3/common.dart' show CommonDatabase;
+
+/// TODO-2491：集级刮削服务守卫。全部走内存 DB + MockClient + 临时目录，无真实
+/// 网络。覆盖：集号对齐（缺集/无集号/重复集号）、Bangumi/TMDB 两源解析、剧照
+/// 落集封面且**绝不覆盖用户手选封面**、movie 条目无分集的显式报错。
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<HibikiDatabase> openDb() async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (CommonDatabase rawDb) =>
+            rawDb.execute('PRAGMA foreign_keys = ON'),
+      ),
+    );
+    addTearDown(db.close);
+    return db;
+  }
+
+  Future<int> boundCollection(
+    HibikiDatabase db, {
+    String name = '本篇',
+    String source = 'bangumi',
+    String subjectId = '100',
+    String? detailUrl,
+  }) async {
+    final int id = await db.createMediaCollection(name);
+    await db.upsertCollectionScrapeMeta(CollectionScrapeMetaCompanion.insert(
+      collectionId: Value<int>(id),
+      source: source,
+      subjectId: subjectId,
+      title: name,
+      detailUrl: Value<String?>(detailUrl),
+      scrapedAt: DateTime(2026),
+    ));
+    return id;
+  }
+
+  Future<void> addVideoMember(
+    HibikiDatabase db,
+    int collectionId,
+    String uid,
+    String fileName, {
+    String? coverPath,
+  }) async {
+    await db.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: uid,
+      title: uid,
+      videoPath: '/videos/$fileName',
+      coverPath: Value<String?>(coverPath),
+    ));
+    await db.addToCollectionRaw(collectionId, 'video', uid);
+  }
+
+  MockClient bangumiEpisodesClient(List<Map<String, Object?>> episodes) =>
+      MockClient((http.Request req) async {
+        if (req.url.path.endsWith('/episodes')) {
+          return http.Response.bytes(
+            utf8.encode(jsonEncode(<String, Object?>{
+              'data': episodes,
+              'total': episodes.length,
+            })),
+            200,
+            headers: <String, String>{
+              'content-type': 'application/json; charset=utf-8',
+            },
+          );
+        }
+        return http.Response('not found', 404);
+      });
+
+  group('parseBangumiEpisodesResponse', () {
+    test('keeps integer main-episode sorts, drops fractional or zero', () {
+      final ({List<BangumiEpisodeInfo> episodes, int total}) page =
+          parseBangumiEpisodesResponse(jsonEncode(<String, Object?>{
+        'total': 4,
+        'data': <Object?>[
+          <String, Object?>{
+            'sort': 1,
+            'name_cn': '第一话',
+            'airdate': '2023-01-04'
+          },
+          <String, Object?>{'sort': 2.0, 'name': 'Ep2'},
+          <String, Object?>{'sort': 2.5, 'name': '番外混入'},
+          <String, Object?>{'sort': 0, 'name': '零号'},
+        ],
+      }));
+      expect(page.total, 4);
+      expect(page.episodes.map((BangumiEpisodeInfo e) => e.episodeNumber),
+          <int>[1, 2]);
+      expect(page.episodes.first.title, '第一话');
+    });
+  });
+
+  group('bangumi episode alignment', () {
+    test(
+        'writes per-episode meta, counts unmatched (no episode number / '
+        'missing on source), duplicates both written', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(db);
+      await addVideoMember(db, id, 'u1', '[Grp] Show - 01.mkv');
+      await addVideoMember(db, id, 'u1b', '[Grp] Show - 01v2.mkv');
+      await addVideoMember(db, id, 'u2', '[Grp] Show - 02.mkv');
+      await addVideoMember(db, id, 'u3', '[Grp] Show - 03.mkv'); // 源缺第 3 集
+      await addVideoMember(db, id, 'um', 'Show Movie SP.mkv'); // 解不出集号
+
+      final BangumiClient bangumi = BangumiClient(
+        client: bangumiEpisodesClient(<Map<String, Object?>>[
+          <String, Object?>{
+            'sort': 1,
+            'name_cn': '出会い',
+            'airdate': '2023-01-04',
+            'desc': '第一话简介',
+          },
+          <String, Object?>{'sort': 2, 'name': '第二话'},
+        ]),
+      );
+      addTearDown(bangumi.close);
+
+      final EpisodeScrapeService service =
+          EpisodeScrapeService(db: db, bangumiClient: bangumi);
+      final EpisodeScrapeOutcome outcome =
+          await service.scrapeCollectionEpisodes(id);
+
+      expect(outcome.errors, isEmpty);
+      expect(outcome.updated, 3, reason: 'u1 + u1b（重复集号双版本）+ u2');
+      expect(outcome.unmatched, 2, reason: 'u3 源缺集 + um 解不出集号');
+
+      final VideoScrapeMetaRow? u1 = await db.getVideoScrapeMeta('u1');
+      expect(u1, isNotNull);
+      expect(u1!.episodeNumber, 1);
+      expect(u1.title, '出会い');
+      expect(u1.airDate, '2023-01-04');
+      expect(u1.summary, '第一话简介');
+      expect(u1.source, 'bangumi');
+      expect((await db.getVideoScrapeMeta('u1b'))!.episodeNumber, 1,
+          reason: '重复集号（v2 版本文件）同资料各写各的');
+      expect((await db.getVideoScrapeMeta('u2'))!.title, '第二话');
+      expect(await db.getVideoScrapeMeta('u3'), isNull);
+      expect(await db.getVideoScrapeMeta('um'), isNull);
+    });
+
+    test('episode title falls back to work title when source omits it',
+        () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(db, name: '作品名');
+      await addVideoMember(db, id, 'u1', 'Show - 01.mkv');
+      final BangumiClient bangumi = BangumiClient(
+        client: bangumiEpisodesClient(<Map<String, Object?>>[
+          <String, Object?>{'sort': 1},
+        ]),
+      );
+      addTearDown(bangumi.close);
+      await EpisodeScrapeService(db: db, bangumiClient: bangumi)
+          .scrapeCollectionEpisodes(id);
+      expect((await db.getVideoScrapeMeta('u1'))!.title, '作品名');
+    });
+
+    test('source failure reports error and writes nothing', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(db);
+      await addVideoMember(db, id, 'u1', 'Show - 01.mkv');
+      final BangumiClient bangumi = BangumiClient(
+        client:
+            MockClient((http.Request req) async => http.Response('boom', 500)),
+      );
+      addTearDown(bangumi.close);
+      final EpisodeScrapeOutcome outcome =
+          await EpisodeScrapeService(db: db, bangumiClient: bangumi)
+              .scrapeCollectionEpisodes(id);
+      expect(outcome.errors, isNotEmpty, reason: '源失败必须上报不吞');
+      expect(outcome.updated, 0);
+      expect(await db.getVideoScrapeMeta('u1'), isNull);
+    });
+
+    test('missing scrape binding throws StateError', () async {
+      final HibikiDatabase db = await openDb();
+      final int bare = await db.createMediaCollection('未刮削');
+      expect(
+        () => EpisodeScrapeService(db: db).scrapeCollectionEpisodes(bare),
+        throwsStateError,
+      );
+    });
+  });
+
+  group('tmdb stills', () {
+    // 最小合法 JPEG 头（魔数 FF D8 FF），CoverDownloader 的图片嗅探要求。
+    final List<int> jpegBytes = <int>[
+      0xFF,
+      0xD8,
+      0xFF,
+      0xE0,
+      0x00,
+      0x10,
+      0x4A,
+      0x46,
+      0x49,
+      0x46,
+    ];
+
+    test(
+        'applies stills as episode covers, never overwrites user-chosen '
+        'cover, season from filename majority', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(
+        db,
+        source: 'tmdb',
+        subjectId: '77',
+        detailUrl: 'https://www.themoviedb.org/tv/77',
+      );
+      await addVideoMember(db, id, 'u1', 'Show S02E01.mkv',
+          coverPath: '/covers/manual-u1.jpg');
+      await addVideoMember(db, id, 'u2', 'Show S02E02.mkv');
+
+      final List<String> seasonRequests = <String>[];
+      final TmdbClient tmdb = TmdbClient(
+        apiKey: 'k',
+        client: MockClient((http.Request req) async {
+          seasonRequests.add(req.url.path);
+          return http.Response.bytes(
+            utf8.encode(jsonEncode(<String, Object?>{
+              'episodes': <Object?>[
+                <String, Object?>{
+                  'episode_number': 1,
+                  'name': '一话',
+                  'overview': '概要一',
+                  'air_date': '2024-04-01',
+                  'still_path': '/still1.jpg',
+                },
+                <String, Object?>{
+                  'episode_number': 2,
+                  'name': '二话',
+                  'still_path': '/still2.jpg',
+                },
+              ],
+            })),
+            200,
+          );
+        }),
+      );
+      addTearDown(tmdb.close);
+
+      final Directory coversDir =
+          await Directory.systemTemp.createTemp('ep_stills_');
+      addTearDown(() => coversDir.delete(recursive: true));
+      final CoverMetaStore metaStore = CoverMetaStore(coversDir);
+      // u1 的封面是用户手选：绝不覆盖（TODO-2491 防线）。
+      await metaStore.set('u1', const CoverMeta(origin: CoverOrigin.manual));
+
+      final CoverDownloader downloader = CoverDownloader(
+        client: MockClient((http.Request req) async => http.Response.bytes(
+            jpegBytes, 200,
+            headers: <String, String>{'content-type': 'image/jpeg'})),
+      );
+
+      final EpisodeScrapeService service = EpisodeScrapeService(
+        db: db,
+        tmdbClient: tmdb,
+        coverDownloader: downloader,
+        coverMetaStore: metaStore,
+        coversDirectory: coversDir,
+      );
+      final EpisodeScrapeOutcome outcome =
+          await service.scrapeCollectionEpisodes(id);
+
+      expect(outcome.errors, isEmpty);
+      expect(outcome.updated, 2);
+      expect(seasonRequests.single, '/3/tv/77/season/2',
+          reason: '季号取成员文件名解析的众数（S02 → season 2）');
+
+      // u1：资料写入但封面纹丝不动。
+      expect((await db.getVideoScrapeMeta('u1'))!.title, '一话');
+      final VideoBookRow u1 = (await db.getVideoBookByBookUid('u1'))!;
+      expect(u1.coverPath, '/covers/manual-u1.jpg', reason: '用户手选封面绝不被剧照覆盖');
+      expect(outcome.stillsSkippedUserCover, 1);
+      expect((await metaStore.get('u1'))!.origin, CoverOrigin.manual);
+
+      // u2：剧照落为封面 + cover_meta 标 autoScraped。
+      expect(outcome.stillsApplied, 1);
+      final VideoBookRow u2 = (await db.getVideoBookByBookUid('u2'))!;
+      expect(u2.coverPath, isNotNull);
+      expect(File(u2.coverPath!).existsSync(), isTrue,
+          reason: '剧照必须真实落盘到 covers 目录');
+      final CoverMeta? u2Meta = await metaStore.get('u2');
+      expect(u2Meta!.origin, CoverOrigin.autoScraped);
+      expect(u2Meta.source, ScrapeSource.tmdb);
+    });
+
+    test('movie subject has no episodes and says so', () async {
+      final HibikiDatabase db = await openDb();
+      final int id = await boundCollection(
+        db,
+        source: 'tmdb',
+        subjectId: '55',
+        detailUrl: 'https://www.themoviedb.org/movie/55',
+      );
+      await addVideoMember(db, id, 'u1', 'Movie.mkv');
+      final TmdbClient tmdb = TmdbClient(
+        apiKey: 'k',
+        client: MockClient(
+            (http.Request req) async => http.Response('unexpected', 500)),
+      );
+      addTearDown(tmdb.close);
+      final EpisodeScrapeOutcome outcome =
+          await EpisodeScrapeService(db: db, tmdbClient: tmdb)
+              .scrapeCollectionEpisodes(id);
+      expect(outcome.errors['tmdb'], contains('movie'),
+          reason: 'movie 条目无分集：显式报错而不是装作零匹配');
+      expect(outcome.updated, 0);
+    });
+  });
+}

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -399,6 +399,7 @@ _MergedTagState _mergeTagClocks(
   GalgameSources,
   GalgameSessions,
   GalgameTagMappings,
+  CollectionRelations,
 ])
 class HibikiDatabase extends _$HibikiDatabase {
   /// [isMainProcess] gates the TODO-905 sidecar rebuild: the main app passes
@@ -417,7 +418,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   HibikiDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 64;
+  int get schemaVersion => 65;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1302,6 +1303,26 @@ class HibikiDatabase extends _$HibikiDatabase {
             // _tableExists 短路 no-op。
             if (!await _tableExists('collection_scrape_meta')) {
               await m.createTable(collectionScrapeMeta);
+            }
+          }
+          if (from < 65) {
+            // v65（TODO-2484/2491）：
+            // ① 新增 collection_relations —— 合集「相关作品」边表（Bangumi
+            //    subject relations / TMDB tv seasons 与 movie
+            //    belongs_to_collection 的落地宿主）。纯新增表：旧库升级后本表
+            //    为空 = 全部合集无相关作品数据，UI 不渲染该区块，逐像素不变；
+            //    重刮一次即回填（Never break userspace）。
+            // ② video_scrape_meta 加 episode_number 列 —— 集级刮削对齐后的
+            //    源侧集号。纯 ADD COLUMN，列 nullable 且无 DEFAULT → 既有全部
+            //    行回填 NULL = 旧的作品级资料，消费方按 NULL 走旧行为。
+            // 幂等：fresh DB 已由 onCreate 的 createAll 建好，重复升级时
+            // _tableExists / _columnExists 短路 no-op。
+            if (!await _tableExists('collection_relations')) {
+              await m.createTable(collectionRelations);
+            }
+            if (await _tableExists('video_scrape_meta') &&
+                !await _columnExists('video_scrape_meta', 'episode_number')) {
+              await m.addColumn(videoScrapeMeta, videoScrapeMeta.episodeNumber);
             }
           }
         },
@@ -2576,7 +2597,8 @@ class HibikiDatabase extends _$HibikiDatabase {
 
   /// 监听单个合集的刮削资料。详情页据此在刮削落库后自动重建 hero，无需手动刷新
   /// （与合集封面同一次写入事务，用户点「使用」后资料与背景图一起出现）。
-  Stream<CollectionScrapeMetaRow?> watchCollectionScrapeMeta(int collectionId) =>
+  Stream<CollectionScrapeMetaRow?> watchCollectionScrapeMeta(
+          int collectionId) =>
       (select(collectionScrapeMeta)
             ..where(($CollectionScrapeMetaTable t) =>
                 t.collectionId.equals(collectionId)))
@@ -2588,6 +2610,87 @@ class HibikiDatabase extends _$HibikiDatabase {
             ..where(($CollectionScrapeMetaTable t) =>
                 t.collectionId.equals(collectionId)))
           .go();
+
+  // ── collection_relations（合集相关作品，schema v65 / TODO-2484）──────
+
+  /// 整体替换某合集的相关作品边（重刮即替换）。
+  ///
+  /// 事务内 delete + insert 而非逐条 upsert：关系列表来自源的一次完整响应，
+  /// 逐条 upsert 会留下上次刮削已不存在的残边（源侧撤销的关联永远删不掉）。
+  Future<void> replaceCollectionRelations(
+    int collectionId,
+    List<CollectionRelationsCompanion> relations,
+  ) =>
+      transaction(() async {
+        await (delete(collectionRelations)
+              ..where(($CollectionRelationsTable t) =>
+                  t.collectionId.equals(collectionId)))
+            .go();
+        for (final CollectionRelationsCompanion c in relations) {
+          await into(collectionRelations).insert(c);
+        }
+      });
+
+  /// 按展示顺序（sortIndex → id）列出某合集的相关作品。
+  Future<List<CollectionRelationRow>> getCollectionRelations(
+    int collectionId,
+  ) =>
+      (select(collectionRelations)
+            ..where(($CollectionRelationsTable t) =>
+                t.collectionId.equals(collectionId))
+            ..orderBy([
+              ($CollectionRelationsTable t) =>
+                  OrderingTerm(expression: t.sortIndex),
+              ($CollectionRelationsTable t) => OrderingTerm(expression: t.id),
+            ]))
+          .get();
+
+  /// 监听某合集的相关作品（详情页据此在刮削落库后自动出现该区块）。
+  Stream<List<CollectionRelationRow>> watchCollectionRelations(
+    int collectionId,
+  ) =>
+      (select(collectionRelations)
+            ..where(($CollectionRelationsTable t) =>
+                t.collectionId.equals(collectionId))
+            ..orderBy([
+              ($CollectionRelationsTable t) =>
+                  OrderingTerm(expression: t.sortIndex),
+              ($CollectionRelationsTable t) => OrderingTerm(expression: t.id),
+            ]))
+          .watch();
+
+  /// 删除某合集的全部相关作品边（「重新刮削」前先清，或纠错后作废）。
+  Future<void> deleteCollectionRelations(int collectionId) =>
+      (delete(collectionRelations)
+            ..where(($CollectionRelationsTable t) =>
+                t.collectionId.equals(collectionId)))
+          .go();
+
+  /// 升级绑定：把一条纯刮削目标边绑定为本地合集（[targetCollectionId] 传 null
+  /// 即解绑退回纯刮削态）。
+  Future<void> bindCollectionRelationTarget(
+    int relationId,
+    int? targetCollectionId,
+  ) =>
+      (update(collectionRelations)
+            ..where(($CollectionRelationsTable t) => t.id.equals(relationId)))
+          .write(CollectionRelationsCompanion(
+        targetCollectionId: Value<int?>(targetCollectionId),
+      ));
+
+  /// 反查：已把 (source, subjectId) 刮成资料的本地合集 id 列表（抓取层用它把
+  /// 「纯刮削目标」自动升级绑定为本地合集）。
+  Future<List<int>> collectionIdsByScrapeSubject(
+    String source,
+    String subjectId,
+  ) async {
+    final List<CollectionScrapeMetaRow> rows =
+        await (select(collectionScrapeMeta)
+              ..where(($CollectionScrapeMetaTable t) =>
+                  t.source.equals(source) & t.subjectId.equals(subjectId)))
+            .get();
+    return <int>[for (final CollectionScrapeMetaRow r in rows) r.collectionId];
+  }
 
   /// 监听视频库 uid 集合。插入/删除行时发出更新后的 uid 列表；库页据此在任意
   /// 导入路径（页内 / 拖拽 / 外部「用 Hibiki 打开」/ 远端下载）落库后自动重查，

--- a/packages/hibiki_core/lib/src/database/database.g.dart
+++ b/packages/hibiki_core/lib/src/database/database.g.dart
@@ -17651,6 +17651,12 @@ class $VideoScrapeMetaTable extends VideoScrapeMeta
   late final GeneratedColumn<String> detailUrl = GeneratedColumn<String>(
       'detail_url', aliasedName, true,
       type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _episodeNumberMeta =
+      const VerificationMeta('episodeNumber');
+  @override
+  late final GeneratedColumn<int> episodeNumber = GeneratedColumn<int>(
+      'episode_number', aliasedName, true,
+      type: DriftSqlType.int, requiredDuringInsert: false);
   static const VerificationMeta _scrapedAtMeta =
       const VerificationMeta('scrapedAt');
   @override
@@ -17672,6 +17678,7 @@ class $VideoScrapeMetaTable extends VideoScrapeMeta
         tagsJson,
         infoboxJson,
         detailUrl,
+        episodeNumber,
         scrapedAt
       ];
   @override
@@ -17752,6 +17759,12 @@ class $VideoScrapeMetaTable extends VideoScrapeMeta
       context.handle(_detailUrlMeta,
           detailUrl.isAcceptableOrUnknown(data['detail_url']!, _detailUrlMeta));
     }
+    if (data.containsKey('episode_number')) {
+      context.handle(
+          _episodeNumberMeta,
+          episodeNumber.isAcceptableOrUnknown(
+              data['episode_number']!, _episodeNumberMeta));
+    }
     if (data.containsKey('scraped_at')) {
       context.handle(_scrapedAtMeta,
           scrapedAt.isAcceptableOrUnknown(data['scraped_at']!, _scrapedAtMeta));
@@ -17793,6 +17806,8 @@ class $VideoScrapeMetaTable extends VideoScrapeMeta
           .read(DriftSqlType.string, data['${effectivePrefix}infobox_json']),
       detailUrl: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}detail_url']),
+      episodeNumber: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}episode_number']),
       scrapedAt: attachedDatabase.typeMapping
           .read(DriftSqlType.dateTime, data['${effectivePrefix}scraped_at'])!,
     );
@@ -17847,6 +17862,12 @@ class VideoScrapeMetaRow extends DataClass
   /// 条目详情页 URL（`https://bgm.tv/subject/<id>`），供「查看条目」跳转。
   final String? detailUrl;
 
+  /// 集号（v65 / TODO-2491）：集级刮削按文件名解析的集号与源的分集列表对齐后写入
+  /// （TMDB `episode_number` / Bangumi `sort`）。NULL = 本行是旧的**作品级**资料
+  /// （v54~v64 的自动刮削把整部作品的简介写进每个文件），或集级刮削未能从文件名
+  /// 解出集号。存对齐后的**源侧集号**而非文件名原文，便于重刮时按号更新。
+  final int? episodeNumber;
+
   /// 本行写入时间（重刮判据 / 展示「资料更新于」）。
   final DateTime scrapedAt;
   const VideoScrapeMetaRow(
@@ -17863,6 +17884,7 @@ class VideoScrapeMetaRow extends DataClass
       this.tagsJson,
       this.infoboxJson,
       this.detailUrl,
+      this.episodeNumber,
       required this.scrapedAt});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
@@ -17897,6 +17919,9 @@ class VideoScrapeMetaRow extends DataClass
     }
     if (!nullToAbsent || detailUrl != null) {
       map['detail_url'] = Variable<String>(detailUrl);
+    }
+    if (!nullToAbsent || episodeNumber != null) {
+      map['episode_number'] = Variable<int>(episodeNumber);
     }
     map['scraped_at'] = Variable<DateTime>(scrapedAt);
     return map;
@@ -17934,6 +17959,9 @@ class VideoScrapeMetaRow extends DataClass
       detailUrl: detailUrl == null && nullToAbsent
           ? const Value.absent()
           : Value(detailUrl),
+      episodeNumber: episodeNumber == null && nullToAbsent
+          ? const Value.absent()
+          : Value(episodeNumber),
       scrapedAt: Value(scrapedAt),
     );
   }
@@ -17955,6 +17983,7 @@ class VideoScrapeMetaRow extends DataClass
       tagsJson: serializer.fromJson<String?>(json['tagsJson']),
       infoboxJson: serializer.fromJson<String?>(json['infoboxJson']),
       detailUrl: serializer.fromJson<String?>(json['detailUrl']),
+      episodeNumber: serializer.fromJson<int?>(json['episodeNumber']),
       scrapedAt: serializer.fromJson<DateTime>(json['scrapedAt']),
     );
   }
@@ -17975,6 +18004,7 @@ class VideoScrapeMetaRow extends DataClass
       'tagsJson': serializer.toJson<String?>(tagsJson),
       'infoboxJson': serializer.toJson<String?>(infoboxJson),
       'detailUrl': serializer.toJson<String?>(detailUrl),
+      'episodeNumber': serializer.toJson<int?>(episodeNumber),
       'scrapedAt': serializer.toJson<DateTime>(scrapedAt),
     };
   }
@@ -17993,6 +18023,7 @@ class VideoScrapeMetaRow extends DataClass
           Value<String?> tagsJson = const Value.absent(),
           Value<String?> infoboxJson = const Value.absent(),
           Value<String?> detailUrl = const Value.absent(),
+          Value<int?> episodeNumber = const Value.absent(),
           DateTime? scrapedAt}) =>
       VideoScrapeMetaRow(
         bookUid: bookUid ?? this.bookUid,
@@ -18010,6 +18041,8 @@ class VideoScrapeMetaRow extends DataClass
         tagsJson: tagsJson.present ? tagsJson.value : this.tagsJson,
         infoboxJson: infoboxJson.present ? infoboxJson.value : this.infoboxJson,
         detailUrl: detailUrl.present ? detailUrl.value : this.detailUrl,
+        episodeNumber:
+            episodeNumber.present ? episodeNumber.value : this.episodeNumber,
         scrapedAt: scrapedAt ?? this.scrapedAt,
       );
   VideoScrapeMetaRow copyWithCompanion(VideoScrapeMetaCompanion data) {
@@ -18033,6 +18066,9 @@ class VideoScrapeMetaRow extends DataClass
       infoboxJson:
           data.infoboxJson.present ? data.infoboxJson.value : this.infoboxJson,
       detailUrl: data.detailUrl.present ? data.detailUrl.value : this.detailUrl,
+      episodeNumber: data.episodeNumber.present
+          ? data.episodeNumber.value
+          : this.episodeNumber,
       scrapedAt: data.scrapedAt.present ? data.scrapedAt.value : this.scrapedAt,
     );
   }
@@ -18053,6 +18089,7 @@ class VideoScrapeMetaRow extends DataClass
           ..write('tagsJson: $tagsJson, ')
           ..write('infoboxJson: $infoboxJson, ')
           ..write('detailUrl: $detailUrl, ')
+          ..write('episodeNumber: $episodeNumber, ')
           ..write('scrapedAt: $scrapedAt')
           ..write(')'))
         .toString();
@@ -18073,6 +18110,7 @@ class VideoScrapeMetaRow extends DataClass
       tagsJson,
       infoboxJson,
       detailUrl,
+      episodeNumber,
       scrapedAt);
   @override
   bool operator ==(Object other) =>
@@ -18091,6 +18129,7 @@ class VideoScrapeMetaRow extends DataClass
           other.tagsJson == this.tagsJson &&
           other.infoboxJson == this.infoboxJson &&
           other.detailUrl == this.detailUrl &&
+          other.episodeNumber == this.episodeNumber &&
           other.scrapedAt == this.scrapedAt);
 }
 
@@ -18108,6 +18147,7 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
   final Value<String?> tagsJson;
   final Value<String?> infoboxJson;
   final Value<String?> detailUrl;
+  final Value<int?> episodeNumber;
   final Value<DateTime> scrapedAt;
   final Value<int> rowid;
   const VideoScrapeMetaCompanion({
@@ -18124,6 +18164,7 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
     this.tagsJson = const Value.absent(),
     this.infoboxJson = const Value.absent(),
     this.detailUrl = const Value.absent(),
+    this.episodeNumber = const Value.absent(),
     this.scrapedAt = const Value.absent(),
     this.rowid = const Value.absent(),
   });
@@ -18141,6 +18182,7 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
     this.tagsJson = const Value.absent(),
     this.infoboxJson = const Value.absent(),
     this.detailUrl = const Value.absent(),
+    this.episodeNumber = const Value.absent(),
     required DateTime scrapedAt,
     this.rowid = const Value.absent(),
   })  : bookUid = Value(bookUid),
@@ -18162,6 +18204,7 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
     Expression<String>? tagsJson,
     Expression<String>? infoboxJson,
     Expression<String>? detailUrl,
+    Expression<int>? episodeNumber,
     Expression<DateTime>? scrapedAt,
     Expression<int>? rowid,
   }) {
@@ -18179,6 +18222,7 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
       if (tagsJson != null) 'tags_json': tagsJson,
       if (infoboxJson != null) 'infobox_json': infoboxJson,
       if (detailUrl != null) 'detail_url': detailUrl,
+      if (episodeNumber != null) 'episode_number': episodeNumber,
       if (scrapedAt != null) 'scraped_at': scrapedAt,
       if (rowid != null) 'rowid': rowid,
     });
@@ -18198,6 +18242,7 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
       Value<String?>? tagsJson,
       Value<String?>? infoboxJson,
       Value<String?>? detailUrl,
+      Value<int?>? episodeNumber,
       Value<DateTime>? scrapedAt,
       Value<int>? rowid}) {
     return VideoScrapeMetaCompanion(
@@ -18214,6 +18259,7 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
       tagsJson: tagsJson ?? this.tagsJson,
       infoboxJson: infoboxJson ?? this.infoboxJson,
       detailUrl: detailUrl ?? this.detailUrl,
+      episodeNumber: episodeNumber ?? this.episodeNumber,
       scrapedAt: scrapedAt ?? this.scrapedAt,
       rowid: rowid ?? this.rowid,
     );
@@ -18261,6 +18307,9 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
     if (detailUrl.present) {
       map['detail_url'] = Variable<String>(detailUrl.value);
     }
+    if (episodeNumber.present) {
+      map['episode_number'] = Variable<int>(episodeNumber.value);
+    }
     if (scrapedAt.present) {
       map['scraped_at'] = Variable<DateTime>(scrapedAt.value);
     }
@@ -18286,6 +18335,7 @@ class VideoScrapeMetaCompanion extends UpdateCompanion<VideoScrapeMetaRow> {
           ..write('tagsJson: $tagsJson, ')
           ..write('infoboxJson: $infoboxJson, ')
           ..write('detailUrl: $detailUrl, ')
+          ..write('episodeNumber: $episodeNumber, ')
           ..write('scrapedAt: $scrapedAt, ')
           ..write('rowid: $rowid')
           ..write(')'))
@@ -21784,6 +21834,550 @@ class GalgameTagMappingsCompanion
   }
 }
 
+class $CollectionRelationsTable extends CollectionRelations
+    with TableInfo<$CollectionRelationsTable, CollectionRelationRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CollectionRelationsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _collectionIdMeta =
+      const VerificationMeta('collectionId');
+  @override
+  late final GeneratedColumn<int> collectionId = GeneratedColumn<int>(
+      'collection_id', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES media_collections (id) ON DELETE CASCADE'));
+  static const VerificationMeta _relationTypeMeta =
+      const VerificationMeta('relationType');
+  @override
+  late final GeneratedColumn<String> relationType = GeneratedColumn<String>(
+      'relation_type', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _sortIndexMeta =
+      const VerificationMeta('sortIndex');
+  @override
+  late final GeneratedColumn<int> sortIndex = GeneratedColumn<int>(
+      'sort_index', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _targetCollectionIdMeta =
+      const VerificationMeta('targetCollectionId');
+  @override
+  late final GeneratedColumn<int> targetCollectionId = GeneratedColumn<int>(
+      'target_collection_id', aliasedName, true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES media_collections (id) ON DELETE SET NULL'));
+  static const VerificationMeta _sourceMeta = const VerificationMeta('source');
+  @override
+  late final GeneratedColumn<String> source = GeneratedColumn<String>(
+      'source', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _subjectIdMeta =
+      const VerificationMeta('subjectId');
+  @override
+  late final GeneratedColumn<String> subjectId = GeneratedColumn<String>(
+      'subject_id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _titleMeta = const VerificationMeta('title');
+  @override
+  late final GeneratedColumn<String> title = GeneratedColumn<String>(
+      'title', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _coverUrlMeta =
+      const VerificationMeta('coverUrl');
+  @override
+  late final GeneratedColumn<String> coverUrl = GeneratedColumn<String>(
+      'cover_url', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  static const VerificationMeta _coverPathMeta =
+      const VerificationMeta('coverPath');
+  @override
+  late final GeneratedColumn<String> coverPath = GeneratedColumn<String>(
+      'cover_path', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns => [
+        id,
+        collectionId,
+        relationType,
+        sortIndex,
+        targetCollectionId,
+        source,
+        subjectId,
+        title,
+        coverUrl,
+        coverPath
+      ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'collection_relations';
+  @override
+  VerificationContext validateIntegrity(
+      Insertable<CollectionRelationRow> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('collection_id')) {
+      context.handle(
+          _collectionIdMeta,
+          collectionId.isAcceptableOrUnknown(
+              data['collection_id']!, _collectionIdMeta));
+    } else if (isInserting) {
+      context.missing(_collectionIdMeta);
+    }
+    if (data.containsKey('relation_type')) {
+      context.handle(
+          _relationTypeMeta,
+          relationType.isAcceptableOrUnknown(
+              data['relation_type']!, _relationTypeMeta));
+    } else if (isInserting) {
+      context.missing(_relationTypeMeta);
+    }
+    if (data.containsKey('sort_index')) {
+      context.handle(_sortIndexMeta,
+          sortIndex.isAcceptableOrUnknown(data['sort_index']!, _sortIndexMeta));
+    }
+    if (data.containsKey('target_collection_id')) {
+      context.handle(
+          _targetCollectionIdMeta,
+          targetCollectionId.isAcceptableOrUnknown(
+              data['target_collection_id']!, _targetCollectionIdMeta));
+    }
+    if (data.containsKey('source')) {
+      context.handle(_sourceMeta,
+          source.isAcceptableOrUnknown(data['source']!, _sourceMeta));
+    } else if (isInserting) {
+      context.missing(_sourceMeta);
+    }
+    if (data.containsKey('subject_id')) {
+      context.handle(_subjectIdMeta,
+          subjectId.isAcceptableOrUnknown(data['subject_id']!, _subjectIdMeta));
+    } else if (isInserting) {
+      context.missing(_subjectIdMeta);
+    }
+    if (data.containsKey('title')) {
+      context.handle(
+          _titleMeta, title.isAcceptableOrUnknown(data['title']!, _titleMeta));
+    } else if (isInserting) {
+      context.missing(_titleMeta);
+    }
+    if (data.containsKey('cover_url')) {
+      context.handle(_coverUrlMeta,
+          coverUrl.isAcceptableOrUnknown(data['cover_url']!, _coverUrlMeta));
+    }
+    if (data.containsKey('cover_path')) {
+      context.handle(_coverPathMeta,
+          coverPath.isAcceptableOrUnknown(data['cover_path']!, _coverPathMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+        {collectionId, source, subjectId},
+      ];
+  @override
+  CollectionRelationRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CollectionRelationRow(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      collectionId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}collection_id'])!,
+      relationType: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}relation_type'])!,
+      sortIndex: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}sort_index'])!,
+      targetCollectionId: attachedDatabase.typeMapping.read(
+          DriftSqlType.int, data['${effectivePrefix}target_collection_id']),
+      source: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}source'])!,
+      subjectId: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}subject_id'])!,
+      title: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}title'])!,
+      coverUrl: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}cover_url']),
+      coverPath: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}cover_path']),
+    );
+  }
+
+  @override
+  $CollectionRelationsTable createAlias(String alias) {
+    return $CollectionRelationsTable(attachedDatabase, alias);
+  }
+}
+
+class CollectionRelationRow extends DataClass
+    implements Insertable<CollectionRelationRow> {
+  final int id;
+
+  /// 边的起点：本地合集。删合集 cascade 清边。
+  final int collectionId;
+
+  /// 关系类型，wire 值固定小写下划线：`prequel`（前传）/ `sequel`（续集）/
+  /// `side_story`（番外/外传）/ `movie`（剧场版）/ `spin_off`（衍生）/ `other`。
+  /// 源侧的中文/自由文本关系词在抓取层映射成这六个值再落库，UI 不解析源词。
+  final String relationType;
+
+  /// 同一合集内的展示顺序（抓取层按源返回顺序编号，0-based 致密）。
+  final int sortIndex;
+
+  /// 已绑定态：目标在本地库中的合集 id。纯刮削态为 NULL；目标合集被删自动
+  /// setNull 退回纯刮削态。
+  final int? targetCollectionId;
+
+  /// 目标条目来源（`ScrapeSource.name`：bangumi / tmdb）。
+  final String source;
+
+  /// 目标条目在源内的 id（Bangumi subject id / TMDB id 或季 id），字符串化。
+  final String subjectId;
+
+  /// 目标条目标题（源侧中文优先）。
+  final String title;
+
+  /// 目标封面远程 URL（未下载时 UI 可按需拉取）。
+  final String? coverUrl;
+
+  /// 目标封面本地路径（抓取层下载落地后回填）。
+  final String? coverPath;
+  const CollectionRelationRow(
+      {required this.id,
+      required this.collectionId,
+      required this.relationType,
+      required this.sortIndex,
+      this.targetCollectionId,
+      required this.source,
+      required this.subjectId,
+      required this.title,
+      this.coverUrl,
+      this.coverPath});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['collection_id'] = Variable<int>(collectionId);
+    map['relation_type'] = Variable<String>(relationType);
+    map['sort_index'] = Variable<int>(sortIndex);
+    if (!nullToAbsent || targetCollectionId != null) {
+      map['target_collection_id'] = Variable<int>(targetCollectionId);
+    }
+    map['source'] = Variable<String>(source);
+    map['subject_id'] = Variable<String>(subjectId);
+    map['title'] = Variable<String>(title);
+    if (!nullToAbsent || coverUrl != null) {
+      map['cover_url'] = Variable<String>(coverUrl);
+    }
+    if (!nullToAbsent || coverPath != null) {
+      map['cover_path'] = Variable<String>(coverPath);
+    }
+    return map;
+  }
+
+  CollectionRelationsCompanion toCompanion(bool nullToAbsent) {
+    return CollectionRelationsCompanion(
+      id: Value(id),
+      collectionId: Value(collectionId),
+      relationType: Value(relationType),
+      sortIndex: Value(sortIndex),
+      targetCollectionId: targetCollectionId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(targetCollectionId),
+      source: Value(source),
+      subjectId: Value(subjectId),
+      title: Value(title),
+      coverUrl: coverUrl == null && nullToAbsent
+          ? const Value.absent()
+          : Value(coverUrl),
+      coverPath: coverPath == null && nullToAbsent
+          ? const Value.absent()
+          : Value(coverPath),
+    );
+  }
+
+  factory CollectionRelationRow.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CollectionRelationRow(
+      id: serializer.fromJson<int>(json['id']),
+      collectionId: serializer.fromJson<int>(json['collectionId']),
+      relationType: serializer.fromJson<String>(json['relationType']),
+      sortIndex: serializer.fromJson<int>(json['sortIndex']),
+      targetCollectionId: serializer.fromJson<int?>(json['targetCollectionId']),
+      source: serializer.fromJson<String>(json['source']),
+      subjectId: serializer.fromJson<String>(json['subjectId']),
+      title: serializer.fromJson<String>(json['title']),
+      coverUrl: serializer.fromJson<String?>(json['coverUrl']),
+      coverPath: serializer.fromJson<String?>(json['coverPath']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'collectionId': serializer.toJson<int>(collectionId),
+      'relationType': serializer.toJson<String>(relationType),
+      'sortIndex': serializer.toJson<int>(sortIndex),
+      'targetCollectionId': serializer.toJson<int?>(targetCollectionId),
+      'source': serializer.toJson<String>(source),
+      'subjectId': serializer.toJson<String>(subjectId),
+      'title': serializer.toJson<String>(title),
+      'coverUrl': serializer.toJson<String?>(coverUrl),
+      'coverPath': serializer.toJson<String?>(coverPath),
+    };
+  }
+
+  CollectionRelationRow copyWith(
+          {int? id,
+          int? collectionId,
+          String? relationType,
+          int? sortIndex,
+          Value<int?> targetCollectionId = const Value.absent(),
+          String? source,
+          String? subjectId,
+          String? title,
+          Value<String?> coverUrl = const Value.absent(),
+          Value<String?> coverPath = const Value.absent()}) =>
+      CollectionRelationRow(
+        id: id ?? this.id,
+        collectionId: collectionId ?? this.collectionId,
+        relationType: relationType ?? this.relationType,
+        sortIndex: sortIndex ?? this.sortIndex,
+        targetCollectionId: targetCollectionId.present
+            ? targetCollectionId.value
+            : this.targetCollectionId,
+        source: source ?? this.source,
+        subjectId: subjectId ?? this.subjectId,
+        title: title ?? this.title,
+        coverUrl: coverUrl.present ? coverUrl.value : this.coverUrl,
+        coverPath: coverPath.present ? coverPath.value : this.coverPath,
+      );
+  CollectionRelationRow copyWithCompanion(CollectionRelationsCompanion data) {
+    return CollectionRelationRow(
+      id: data.id.present ? data.id.value : this.id,
+      collectionId: data.collectionId.present
+          ? data.collectionId.value
+          : this.collectionId,
+      relationType: data.relationType.present
+          ? data.relationType.value
+          : this.relationType,
+      sortIndex: data.sortIndex.present ? data.sortIndex.value : this.sortIndex,
+      targetCollectionId: data.targetCollectionId.present
+          ? data.targetCollectionId.value
+          : this.targetCollectionId,
+      source: data.source.present ? data.source.value : this.source,
+      subjectId: data.subjectId.present ? data.subjectId.value : this.subjectId,
+      title: data.title.present ? data.title.value : this.title,
+      coverUrl: data.coverUrl.present ? data.coverUrl.value : this.coverUrl,
+      coverPath: data.coverPath.present ? data.coverPath.value : this.coverPath,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CollectionRelationRow(')
+          ..write('id: $id, ')
+          ..write('collectionId: $collectionId, ')
+          ..write('relationType: $relationType, ')
+          ..write('sortIndex: $sortIndex, ')
+          ..write('targetCollectionId: $targetCollectionId, ')
+          ..write('source: $source, ')
+          ..write('subjectId: $subjectId, ')
+          ..write('title: $title, ')
+          ..write('coverUrl: $coverUrl, ')
+          ..write('coverPath: $coverPath')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, collectionId, relationType, sortIndex,
+      targetCollectionId, source, subjectId, title, coverUrl, coverPath);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CollectionRelationRow &&
+          other.id == this.id &&
+          other.collectionId == this.collectionId &&
+          other.relationType == this.relationType &&
+          other.sortIndex == this.sortIndex &&
+          other.targetCollectionId == this.targetCollectionId &&
+          other.source == this.source &&
+          other.subjectId == this.subjectId &&
+          other.title == this.title &&
+          other.coverUrl == this.coverUrl &&
+          other.coverPath == this.coverPath);
+}
+
+class CollectionRelationsCompanion
+    extends UpdateCompanion<CollectionRelationRow> {
+  final Value<int> id;
+  final Value<int> collectionId;
+  final Value<String> relationType;
+  final Value<int> sortIndex;
+  final Value<int?> targetCollectionId;
+  final Value<String> source;
+  final Value<String> subjectId;
+  final Value<String> title;
+  final Value<String?> coverUrl;
+  final Value<String?> coverPath;
+  const CollectionRelationsCompanion({
+    this.id = const Value.absent(),
+    this.collectionId = const Value.absent(),
+    this.relationType = const Value.absent(),
+    this.sortIndex = const Value.absent(),
+    this.targetCollectionId = const Value.absent(),
+    this.source = const Value.absent(),
+    this.subjectId = const Value.absent(),
+    this.title = const Value.absent(),
+    this.coverUrl = const Value.absent(),
+    this.coverPath = const Value.absent(),
+  });
+  CollectionRelationsCompanion.insert({
+    this.id = const Value.absent(),
+    required int collectionId,
+    required String relationType,
+    this.sortIndex = const Value.absent(),
+    this.targetCollectionId = const Value.absent(),
+    required String source,
+    required String subjectId,
+    required String title,
+    this.coverUrl = const Value.absent(),
+    this.coverPath = const Value.absent(),
+  })  : collectionId = Value(collectionId),
+        relationType = Value(relationType),
+        source = Value(source),
+        subjectId = Value(subjectId),
+        title = Value(title);
+  static Insertable<CollectionRelationRow> custom({
+    Expression<int>? id,
+    Expression<int>? collectionId,
+    Expression<String>? relationType,
+    Expression<int>? sortIndex,
+    Expression<int>? targetCollectionId,
+    Expression<String>? source,
+    Expression<String>? subjectId,
+    Expression<String>? title,
+    Expression<String>? coverUrl,
+    Expression<String>? coverPath,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (collectionId != null) 'collection_id': collectionId,
+      if (relationType != null) 'relation_type': relationType,
+      if (sortIndex != null) 'sort_index': sortIndex,
+      if (targetCollectionId != null)
+        'target_collection_id': targetCollectionId,
+      if (source != null) 'source': source,
+      if (subjectId != null) 'subject_id': subjectId,
+      if (title != null) 'title': title,
+      if (coverUrl != null) 'cover_url': coverUrl,
+      if (coverPath != null) 'cover_path': coverPath,
+    });
+  }
+
+  CollectionRelationsCompanion copyWith(
+      {Value<int>? id,
+      Value<int>? collectionId,
+      Value<String>? relationType,
+      Value<int>? sortIndex,
+      Value<int?>? targetCollectionId,
+      Value<String>? source,
+      Value<String>? subjectId,
+      Value<String>? title,
+      Value<String?>? coverUrl,
+      Value<String?>? coverPath}) {
+    return CollectionRelationsCompanion(
+      id: id ?? this.id,
+      collectionId: collectionId ?? this.collectionId,
+      relationType: relationType ?? this.relationType,
+      sortIndex: sortIndex ?? this.sortIndex,
+      targetCollectionId: targetCollectionId ?? this.targetCollectionId,
+      source: source ?? this.source,
+      subjectId: subjectId ?? this.subjectId,
+      title: title ?? this.title,
+      coverUrl: coverUrl ?? this.coverUrl,
+      coverPath: coverPath ?? this.coverPath,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (collectionId.present) {
+      map['collection_id'] = Variable<int>(collectionId.value);
+    }
+    if (relationType.present) {
+      map['relation_type'] = Variable<String>(relationType.value);
+    }
+    if (sortIndex.present) {
+      map['sort_index'] = Variable<int>(sortIndex.value);
+    }
+    if (targetCollectionId.present) {
+      map['target_collection_id'] = Variable<int>(targetCollectionId.value);
+    }
+    if (source.present) {
+      map['source'] = Variable<String>(source.value);
+    }
+    if (subjectId.present) {
+      map['subject_id'] = Variable<String>(subjectId.value);
+    }
+    if (title.present) {
+      map['title'] = Variable<String>(title.value);
+    }
+    if (coverUrl.present) {
+      map['cover_url'] = Variable<String>(coverUrl.value);
+    }
+    if (coverPath.present) {
+      map['cover_path'] = Variable<String>(coverPath.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CollectionRelationsCompanion(')
+          ..write('id: $id, ')
+          ..write('collectionId: $collectionId, ')
+          ..write('relationType: $relationType, ')
+          ..write('sortIndex: $sortIndex, ')
+          ..write('targetCollectionId: $targetCollectionId, ')
+          ..write('source: $source, ')
+          ..write('subjectId: $subjectId, ')
+          ..write('title: $title, ')
+          ..write('coverUrl: $coverUrl, ')
+          ..write('coverPath: $coverPath')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$HibikiDatabase extends GeneratedDatabase {
   _$HibikiDatabase(QueryExecutor e) : super(e);
   $HibikiDatabaseManager get managers => $HibikiDatabaseManager(this);
@@ -21871,6 +22465,8 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
       $GalgameSessionsTable(this);
   late final $GalgameTagMappingsTable galgameTagMappings =
       $GalgameTagMappingsTable(this);
+  late final $CollectionRelationsTable collectionRelations =
+      $CollectionRelationsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -21929,7 +22525,8 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
         galgames,
         galgameSources,
         galgameSessions,
-        galgameTagMappings
+        galgameTagMappings,
+        collectionRelations
       ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules(
@@ -22100,6 +22697,20 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
                 limitUpdateKind: UpdateKind.delete),
             result: [
               TableUpdate('galgame_tag_mappings', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('media_collections',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('collection_relations', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('media_collections',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('collection_relations', kind: UpdateKind.update),
             ],
           ),
         ],
@@ -34334,6 +34945,7 @@ typedef $$VideoScrapeMetaTableCreateCompanionBuilder = VideoScrapeMetaCompanion
   Value<String?> tagsJson,
   Value<String?> infoboxJson,
   Value<String?> detailUrl,
+  Value<int?> episodeNumber,
   required DateTime scrapedAt,
   Value<int> rowid,
 });
@@ -34352,6 +34964,7 @@ typedef $$VideoScrapeMetaTableUpdateCompanionBuilder = VideoScrapeMetaCompanion
   Value<String?> tagsJson,
   Value<String?> infoboxJson,
   Value<String?> detailUrl,
+  Value<int?> episodeNumber,
   Value<DateTime> scrapedAt,
   Value<int> rowid,
 });
@@ -34420,6 +35033,9 @@ class $$VideoScrapeMetaTableFilterComposer
 
   ColumnFilters<String> get detailUrl => $composableBuilder(
       column: $table.detailUrl, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get episodeNumber => $composableBuilder(
+      column: $table.episodeNumber, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<DateTime> get scrapedAt => $composableBuilder(
       column: $table.scrapedAt, builder: (column) => ColumnFilters(column));
@@ -34492,6 +35108,10 @@ class $$VideoScrapeMetaTableOrderingComposer
   ColumnOrderings<String> get detailUrl => $composableBuilder(
       column: $table.detailUrl, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<int> get episodeNumber => $composableBuilder(
+      column: $table.episodeNumber,
+      builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<DateTime> get scrapedAt => $composableBuilder(
       column: $table.scrapedAt, builder: (column) => ColumnOrderings(column));
 
@@ -34561,6 +35181,9 @@ class $$VideoScrapeMetaTableAnnotationComposer
   GeneratedColumn<String> get detailUrl =>
       $composableBuilder(column: $table.detailUrl, builder: (column) => column);
 
+  GeneratedColumn<int> get episodeNumber => $composableBuilder(
+      column: $table.episodeNumber, builder: (column) => column);
+
   GeneratedColumn<DateTime> get scrapedAt =>
       $composableBuilder(column: $table.scrapedAt, builder: (column) => column);
 
@@ -34622,6 +35245,7 @@ class $$VideoScrapeMetaTableTableManager extends RootTableManager<
             Value<String?> tagsJson = const Value.absent(),
             Value<String?> infoboxJson = const Value.absent(),
             Value<String?> detailUrl = const Value.absent(),
+            Value<int?> episodeNumber = const Value.absent(),
             Value<DateTime> scrapedAt = const Value.absent(),
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -34639,6 +35263,7 @@ class $$VideoScrapeMetaTableTableManager extends RootTableManager<
             tagsJson: tagsJson,
             infoboxJson: infoboxJson,
             detailUrl: detailUrl,
+            episodeNumber: episodeNumber,
             scrapedAt: scrapedAt,
             rowid: rowid,
           ),
@@ -34656,6 +35281,7 @@ class $$VideoScrapeMetaTableTableManager extends RootTableManager<
             Value<String?> tagsJson = const Value.absent(),
             Value<String?> infoboxJson = const Value.absent(),
             Value<String?> detailUrl = const Value.absent(),
+            Value<int?> episodeNumber = const Value.absent(),
             required DateTime scrapedAt,
             Value<int> rowid = const Value.absent(),
           }) =>
@@ -34673,6 +35299,7 @@ class $$VideoScrapeMetaTableTableManager extends RootTableManager<
             tagsJson: tagsJson,
             infoboxJson: infoboxJson,
             detailUrl: detailUrl,
+            episodeNumber: episodeNumber,
             scrapedAt: scrapedAt,
             rowid: rowid,
           ),
@@ -37300,6 +37927,436 @@ typedef $$GalgameTagMappingsTableProcessedTableManager = ProcessedTableManager<
     (GalgameTagMappingRow, $$GalgameTagMappingsTableReferences),
     GalgameTagMappingRow,
     PrefetchHooks Function({bool gameId, bool tagId})>;
+typedef $$CollectionRelationsTableCreateCompanionBuilder
+    = CollectionRelationsCompanion Function({
+  Value<int> id,
+  required int collectionId,
+  required String relationType,
+  Value<int> sortIndex,
+  Value<int?> targetCollectionId,
+  required String source,
+  required String subjectId,
+  required String title,
+  Value<String?> coverUrl,
+  Value<String?> coverPath,
+});
+typedef $$CollectionRelationsTableUpdateCompanionBuilder
+    = CollectionRelationsCompanion Function({
+  Value<int> id,
+  Value<int> collectionId,
+  Value<String> relationType,
+  Value<int> sortIndex,
+  Value<int?> targetCollectionId,
+  Value<String> source,
+  Value<String> subjectId,
+  Value<String> title,
+  Value<String?> coverUrl,
+  Value<String?> coverPath,
+});
+
+final class $$CollectionRelationsTableReferences extends BaseReferences<
+    _$HibikiDatabase, $CollectionRelationsTable, CollectionRelationRow> {
+  $$CollectionRelationsTableReferences(
+      super.$_db, super.$_table, super.$_typedResult);
+
+  static $MediaCollectionsTable _collectionIdTable(_$HibikiDatabase db) =>
+      db.mediaCollections.createAlias(
+          'collection_relations__collection_id__media_collections__id');
+
+  $$MediaCollectionsTableProcessedTableManager get collectionId {
+    final $_column = $_itemColumn<int>('collection_id')!;
+
+    final manager =
+        $$MediaCollectionsTableTableManager($_db, $_db.mediaCollections)
+            .filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_collectionIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+
+  static $MediaCollectionsTable _targetCollectionIdTable(_$HibikiDatabase db) =>
+      db.mediaCollections.createAlias(
+          'collection_relations__target_collection_id__media_collections__id');
+
+  $$MediaCollectionsTableProcessedTableManager? get targetCollectionId {
+    final $_column = $_itemColumn<int>('target_collection_id');
+    if ($_column == null) return null;
+    final manager =
+        $$MediaCollectionsTableTableManager($_db, $_db.mediaCollections)
+            .filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_targetCollectionIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+}
+
+class $$CollectionRelationsTableFilterComposer
+    extends Composer<_$HibikiDatabase, $CollectionRelationsTable> {
+  $$CollectionRelationsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get relationType => $composableBuilder(
+      column: $table.relationType, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get sortIndex => $composableBuilder(
+      column: $table.sortIndex, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get source => $composableBuilder(
+      column: $table.source, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get subjectId => $composableBuilder(
+      column: $table.subjectId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get title => $composableBuilder(
+      column: $table.title, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get coverUrl => $composableBuilder(
+      column: $table.coverUrl, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get coverPath => $composableBuilder(
+      column: $table.coverPath, builder: (column) => ColumnFilters(column));
+
+  $$MediaCollectionsTableFilterComposer get collectionId {
+    final $$MediaCollectionsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.collectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableFilterComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$MediaCollectionsTableFilterComposer get targetCollectionId {
+    final $$MediaCollectionsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.targetCollectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableFilterComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$CollectionRelationsTableOrderingComposer
+    extends Composer<_$HibikiDatabase, $CollectionRelationsTable> {
+  $$CollectionRelationsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get relationType => $composableBuilder(
+      column: $table.relationType,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get sortIndex => $composableBuilder(
+      column: $table.sortIndex, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get source => $composableBuilder(
+      column: $table.source, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get subjectId => $composableBuilder(
+      column: $table.subjectId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get title => $composableBuilder(
+      column: $table.title, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get coverUrl => $composableBuilder(
+      column: $table.coverUrl, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get coverPath => $composableBuilder(
+      column: $table.coverPath, builder: (column) => ColumnOrderings(column));
+
+  $$MediaCollectionsTableOrderingComposer get collectionId {
+    final $$MediaCollectionsTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.collectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableOrderingComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$MediaCollectionsTableOrderingComposer get targetCollectionId {
+    final $$MediaCollectionsTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.targetCollectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableOrderingComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$CollectionRelationsTableAnnotationComposer
+    extends Composer<_$HibikiDatabase, $CollectionRelationsTable> {
+  $$CollectionRelationsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get relationType => $composableBuilder(
+      column: $table.relationType, builder: (column) => column);
+
+  GeneratedColumn<int> get sortIndex =>
+      $composableBuilder(column: $table.sortIndex, builder: (column) => column);
+
+  GeneratedColumn<String> get source =>
+      $composableBuilder(column: $table.source, builder: (column) => column);
+
+  GeneratedColumn<String> get subjectId =>
+      $composableBuilder(column: $table.subjectId, builder: (column) => column);
+
+  GeneratedColumn<String> get title =>
+      $composableBuilder(column: $table.title, builder: (column) => column);
+
+  GeneratedColumn<String> get coverUrl =>
+      $composableBuilder(column: $table.coverUrl, builder: (column) => column);
+
+  GeneratedColumn<String> get coverPath =>
+      $composableBuilder(column: $table.coverPath, builder: (column) => column);
+
+  $$MediaCollectionsTableAnnotationComposer get collectionId {
+    final $$MediaCollectionsTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.collectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableAnnotationComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$MediaCollectionsTableAnnotationComposer get targetCollectionId {
+    final $$MediaCollectionsTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.targetCollectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableAnnotationComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$CollectionRelationsTableTableManager extends RootTableManager<
+    _$HibikiDatabase,
+    $CollectionRelationsTable,
+    CollectionRelationRow,
+    $$CollectionRelationsTableFilterComposer,
+    $$CollectionRelationsTableOrderingComposer,
+    $$CollectionRelationsTableAnnotationComposer,
+    $$CollectionRelationsTableCreateCompanionBuilder,
+    $$CollectionRelationsTableUpdateCompanionBuilder,
+    (CollectionRelationRow, $$CollectionRelationsTableReferences),
+    CollectionRelationRow,
+    PrefetchHooks Function({bool collectionId, bool targetCollectionId})> {
+  $$CollectionRelationsTableTableManager(
+      _$HibikiDatabase db, $CollectionRelationsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$CollectionRelationsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$CollectionRelationsTableOrderingComposer(
+                  $db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$CollectionRelationsTableAnnotationComposer(
+                  $db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int> collectionId = const Value.absent(),
+            Value<String> relationType = const Value.absent(),
+            Value<int> sortIndex = const Value.absent(),
+            Value<int?> targetCollectionId = const Value.absent(),
+            Value<String> source = const Value.absent(),
+            Value<String> subjectId = const Value.absent(),
+            Value<String> title = const Value.absent(),
+            Value<String?> coverUrl = const Value.absent(),
+            Value<String?> coverPath = const Value.absent(),
+          }) =>
+              CollectionRelationsCompanion(
+            id: id,
+            collectionId: collectionId,
+            relationType: relationType,
+            sortIndex: sortIndex,
+            targetCollectionId: targetCollectionId,
+            source: source,
+            subjectId: subjectId,
+            title: title,
+            coverUrl: coverUrl,
+            coverPath: coverPath,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required int collectionId,
+            required String relationType,
+            Value<int> sortIndex = const Value.absent(),
+            Value<int?> targetCollectionId = const Value.absent(),
+            required String source,
+            required String subjectId,
+            required String title,
+            Value<String?> coverUrl = const Value.absent(),
+            Value<String?> coverPath = const Value.absent(),
+          }) =>
+              CollectionRelationsCompanion.insert(
+            id: id,
+            collectionId: collectionId,
+            relationType: relationType,
+            sortIndex: sortIndex,
+            targetCollectionId: targetCollectionId,
+            source: source,
+            subjectId: subjectId,
+            title: title,
+            coverUrl: coverUrl,
+            coverPath: coverPath,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$CollectionRelationsTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: (
+              {collectionId = false, targetCollectionId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (collectionId) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.collectionId,
+                    referencedTable: $$CollectionRelationsTableReferences
+                        ._collectionIdTable(db),
+                    referencedColumn: $$CollectionRelationsTableReferences
+                        ._collectionIdTable(db)
+                        .id,
+                  ) as T;
+                }
+                if (targetCollectionId) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.targetCollectionId,
+                    referencedTable: $$CollectionRelationsTableReferences
+                        ._targetCollectionIdTable(db),
+                    referencedColumn: $$CollectionRelationsTableReferences
+                        ._targetCollectionIdTable(db)
+                        .id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ));
+}
+
+typedef $$CollectionRelationsTableProcessedTableManager = ProcessedTableManager<
+    _$HibikiDatabase,
+    $CollectionRelationsTable,
+    CollectionRelationRow,
+    $$CollectionRelationsTableFilterComposer,
+    $$CollectionRelationsTableOrderingComposer,
+    $$CollectionRelationsTableAnnotationComposer,
+    $$CollectionRelationsTableCreateCompanionBuilder,
+    $$CollectionRelationsTableUpdateCompanionBuilder,
+    (CollectionRelationRow, $$CollectionRelationsTableReferences),
+    CollectionRelationRow,
+    PrefetchHooks Function({bool collectionId, bool targetCollectionId})>;
 
 class $HibikiDatabaseManager {
   final _$HibikiDatabase _db;
@@ -37417,4 +38474,6 @@ class $HibikiDatabaseManager {
       $$GalgameSessionsTableTableManager(_db, _db.galgameSessions);
   $$GalgameTagMappingsTableTableManager get galgameTagMappings =>
       $$GalgameTagMappingsTableTableManager(_db, _db.galgameTagMappings);
+  $$CollectionRelationsTableTableManager get collectionRelations =>
+      $$CollectionRelationsTableTableManager(_db, _db.collectionRelations);
 }

--- a/packages/hibiki_core/lib/src/database/tables.dart
+++ b/packages/hibiki_core/lib/src/database/tables.dart
@@ -1142,8 +1142,8 @@ class RevealedImages extends Table {
 @DataClassName('CollectionScrapeMetaRow')
 class CollectionScrapeMeta extends Table {
   /// 合集身份（= MediaCollections.id）。删合集 cascade 清本表。
-  IntColumn get collectionId =>
-      integer().references(MediaCollections, #id, onDelete: KeyAction.cascade)();
+  IntColumn get collectionId => integer()
+      .references(MediaCollections, #id, onDelete: KeyAction.cascade)();
 
   /// 来源（`ScrapeSource.name`：bangumi / tmdb / offlineDb / manualUrl）。
   TextColumn get source => text()();
@@ -1256,11 +1256,74 @@ class VideoScrapeMeta extends Table {
   /// 条目详情页 URL（`https://bgm.tv/subject/<id>`），供「查看条目」跳转。
   TextColumn get detailUrl => text().nullable()();
 
+  /// 集号（v65 / TODO-2491）：集级刮削按文件名解析的集号与源的分集列表对齐后写入
+  /// （TMDB `episode_number` / Bangumi `sort`）。NULL = 本行是旧的**作品级**资料
+  /// （v54~v64 的自动刮削把整部作品的简介写进每个文件），或集级刮削未能从文件名
+  /// 解出集号。存对齐后的**源侧集号**而非文件名原文，便于重刮时按号更新。
+  IntColumn get episodeNumber => integer().nullable()();
+
   /// 本行写入时间（重刮判据 / 展示「资料更新于」）。
   DateTimeColumn get scrapedAt => dateTime()();
 
   @override
   Set<Column> get primaryKey => {bookUid};
+}
+
+// ── collection_relations ────────────────────────────────────────────
+// 合集相关作品（v65 / TODO-2484）：一行 = 「某合集 → 一部相关作品」的有向边，
+// 来自刮削源的关联数据（Bangumi subject relations / TMDB tv seasons 与
+// movie belongs_to_collection）。目标两态：
+//   - 纯刮削：只有 (source, subjectId, title, coverUrl/coverPath)，本地库里还没有
+//     对应合集，UI 只能展示 + 跳源详情页；
+//   - 已绑定：targetCollectionId 非空，点击可直接跳本地合集。
+// 两态不是两张表：绑定只是在纯刮削行上补一个本地 id（「升级绑定」），身份仍由
+// (collectionId, source, subjectId) 决定。
+//
+// 与 [CollectionScrapeMeta] 同族：可重建的刮削缓存（删了重刮即回填），删除合集
+// FK cascade 连带清边；目标合集被删则 setNull 退回纯刮削态（刮削事实还在，只是
+// 本地绑定失效——这正是「目标两态」的语义，不需要墓碑）。
+@DataClassName('CollectionRelationRow')
+class CollectionRelations extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  /// 边的起点：本地合集。删合集 cascade 清边。
+  IntColumn get collectionId => integer()
+      .references(MediaCollections, #id, onDelete: KeyAction.cascade)();
+
+  /// 关系类型，wire 值固定小写下划线：`prequel`（前传）/ `sequel`（续集）/
+  /// `side_story`（番外/外传）/ `movie`（剧场版）/ `spin_off`（衍生）/ `other`。
+  /// 源侧的中文/自由文本关系词在抓取层映射成这六个值再落库，UI 不解析源词。
+  TextColumn get relationType => text()();
+
+  /// 同一合集内的展示顺序（抓取层按源返回顺序编号，0-based 致密）。
+  IntColumn get sortIndex => integer().withDefault(const Constant(0))();
+
+  /// 已绑定态：目标在本地库中的合集 id。纯刮削态为 NULL；目标合集被删自动
+  /// setNull 退回纯刮削态。
+  IntColumn get targetCollectionId => integer()
+      .nullable()
+      .references(MediaCollections, #id, onDelete: KeyAction.setNull)();
+
+  /// 目标条目来源（`ScrapeSource.name`：bangumi / tmdb）。
+  TextColumn get source => text()();
+
+  /// 目标条目在源内的 id（Bangumi subject id / TMDB id 或季 id），字符串化。
+  TextColumn get subjectId => text()();
+
+  /// 目标条目标题（源侧中文优先）。
+  TextColumn get title => text()();
+
+  /// 目标封面远程 URL（未下载时 UI 可按需拉取）。
+  TextColumn get coverUrl => text().nullable()();
+
+  /// 目标封面本地路径（抓取层下载落地后回填）。
+  TextColumn get coverPath => text().nullable()();
+
+  /// 同一合集下同一源内条目只此一边（重复刮削按此去重）。
+  @override
+  List<Set<Column>> get uniqueKeys => [
+        {collectionId, source, subjectId},
+      ];
 }
 
 // ── galgames ────────────────────────────────────────────────────────


### PR DESCRIPTION
## TODO-2484 + TODO-2491 数据层：合集相关作品(Relations) + 集级刮削资料/重命名服务

**本批只做数据层**（schema / 抓取服务 / 应用服务 / 纯函数 / 测试）；UI 展示由后续线程接力。硬边界遵守：未改 `media_collection_detail_page.dart` / `video_episode_rail.dart`（PR#608 独占中）。

### Schema v64 → v65（packages/hibiki_core）
- 新表 `collection_relations`：合集「相关作品」有向边。列：`id`(自增) / `collection_id`(FK→media_collections, **cascade**) / `relation_type`(枚举字符串 prequel|sequel|side_story|movie|spin_off|other) / `sort_index` / `target_collection_id`(FK→media_collections, **setNull**，可空=纯刮削态) / `source` / `subject_id` / `title` / `cover_url` / `cover_path`；唯一键 `(collection_id, source, subject_id)`。目标两态（纯刮削 vs 已绑定本地）是同一行的可空列，不是两张表。
- `video_scrape_meta` 加 `episode_number`(int, 可空)：集级刮削对齐后的源侧集号；NULL=旧作品级资料。**刻意不加剧照路径列**：剧照直接落成员封面文件（`video_covers/<uid>.jpg` + cover_meta），独立路径列会造第二真相并被 `gcOrphanCovers` 当孤儿回收。
- 迁移 `if (from < 65)`：createTable + addColumn，`_tableExists`/`_columnExists` 幂等守卫；纯新增零破坏。
- DAO（HibikiDatabase 实例方法）：`replaceCollectionRelations`（事务 delete+insert 整体替换，防源撤销的残边）/ `getCollectionRelations` / `watchCollectionRelations` / `deleteCollectionRelations` / `bindCollectionRelationTarget`（升级绑定/解绑）/ `collectionIdsByScrapeSubject`（(source,subjectId) 反查本地合集）。

### 相关作品抓取（TODO-2484）
- 传输层：`BangumiApiClient.fetchSubjectRelations`（GET /v0/subjects/{id}/subjects）、`fetchSubjectEpisodes`（GET /v0/episodes?type=0 分页）。
- 域层：`BangumiClient.fetchSubjectRelations/fetchSubjectEpisodes` + 纯函数解析器（只留动画/三次元条目）；`TmdbClient` 新增 `fetchTvDetail` / `fetchSeasonEpisodes` / `fetchMovieCollectionRef` / `fetchCollectionParts` + 共享 `_getJsonOrNullOn404`（照抄 BUG-1219 的 `redactCredentialsInText` key 脱敏红线）。
- 服务：`collection_relations_scrape.dart` —— `CollectionRelationType` 枚举(wire 值冻结) + `mapBangumiRelation`(中文关系词映射，未知归 other) + `scrapeCollectionRelations(db, collectionId, bangumi?, tmdb?)`。本地绑定：(source,subjectId) 反查优先、标题精确匹配兜底、永不绑回自身。**逐源报错不吞：源失败记 `sourceErrors` 且不改动库**（不清掉上次刮到的关系）。TMDB tv→季列表(特别篇=side_story，其余=other)；movie→belongs_to_collection 成员(按上映日期分 prequel/sequel)。tv/movie 判定走 detailUrl，缺失时 tv→404→movie 探测。
- 挂接：`home_video_page._openCollectionCoverMatch` 的 applyScrape 闭包在 `applyCollectionScrape` 落库后 fire-and-forget 调 `_scrapeCollectionRelations`（失败进 ErrorLogService，不卡弹窗主流程）；也可独立调用供 UI 后续复用。

### 集级刮削 + 重命名（TODO-2491）
- `episode_scrape_service.dart`：`EpisodeScrapeService.scrapeCollectionEpisodes(collectionId)` —— 成员文件名经 `parseVideoFilename`（G10 单引擎）解集号，与源分集按集号对齐（TMDB 季号=成员解析季号众数，无季默认 1；Bangumi type=0 正篇 sort）；未匹配（无集号/源缺集）跳过计数，重复集号（v1/v2 双版本）各写各的；落 `video_scrape_meta`（title/summary/airDate/episodeNumber）。TMDB 剧照落为集封面（CoverDownloader 既有约定 + cover_meta 标 `autoScraped`），**用户手选封面（isUserChosen）绝不覆盖**。movie 条目显式报 `movie subject has no episodes`。**本服务永不改标题**。
- `episode_rename.dart`：纯函数 `proposeEpisodeDisplayName`（`E01 集名` 式，零填充宽度=最大集号宽度，语言中立）+ `renameCollectionEpisodes(db, collectionId, dryRun)` —— dryRun 返回旧名/新名对照表（供确认弹窗），执行态经 `updateVideoBookTitle` 写穿；集名==作品名（集级刮削的回退值）时退化为纯 `E01`。**自动刮削路径永不调用改名**（对齐 #635 用户拍板）。

### 测试
- `test/database/collection_relations_test.dart`（8 用例）：fresh v65 / 真 v64→v65 迁移（手建 v64 shape）/ CRUD / cascade / setNull / 唯一键——全部 `PRAGMA foreign_keys=ON`（内存库默认关外键，不开 cascade 用例假绿）。
- `test/media/video/scraper/collection_relations_scrape_test.dart`：关系词映射、fixture 解析（滤音乐/缺 relation）、TMDB 四解析器、端到端（MockClient）写库+绑定（subject/标题/自引用排除）、**源失败保留旧边**。
- `episode_scrape_service_test.dart`：Bangumi 对齐（缺集/无集号/重复集号）、集名回退、源失败零写入、TMDB 剧照（手选封面跳过 + autoScraped 落盘 + 季号众数断言请求路径 /season/2）、movie 显式报错。
- `episode_rename_test.dart`：格式纯函数、dryRun 零写库、执行写穿、同名跳过、三位数零填充。
- 既有 15 个迁移测试的 `schemaVersion/user_version == 64` 断言随版本 bump 到 65；`migration_v63` 的「升级新增表集合」断言加入 `collection_relations`。

### 验证
- 全量 `flutter analyze`：No issues（见下）。
- 定向门 `dart run tool/flutter_test_failures.dart --no-pub test/database test/media/video/scraper`：`FLUTTER TEST VERDICT: PASSED - 723 tests ran, all tests passed`。

### 供 UI 线程接力的接口清单
```dart
// hibiki_core (HibikiDatabase)
Future<void> replaceCollectionRelations(int collectionId, List<CollectionRelationsCompanion> relations);
Future<List<CollectionRelationRow>> getCollectionRelations(int collectionId);
Stream<List<CollectionRelationRow>> watchCollectionRelations(int collectionId);
Future<void> deleteCollectionRelations(int collectionId);
Future<void> bindCollectionRelationTarget(int relationId, int? targetCollectionId);
Future<List<int>> collectionIdsByScrapeSubject(String source, String subjectId);

// collection_relations_scrape.dart
enum CollectionRelationType { prequel, sequel, sideStory, movie, spinOff, other } // .wire / .fromWire
CollectionRelationType mapBangumiRelation(String relation);
Future<CollectionRelationsScrapeReport> scrapeCollectionRelations({required HibikiDatabase db, required int collectionId, BangumiClient? bangumi, TmdbClient? tmdb});

// episode_scrape_service.dart
class EpisodeScrapeService { EpisodeScrapeService({required HibikiDatabase db, BangumiClient? bangumiClient, TmdbClient? tmdbClient, CoverDownloader? coverDownloader, CoverMetaStore? coverMetaStore, Directory? coversDirectory});
  Future<EpisodeScrapeOutcome> scrapeCollectionEpisodes(int collectionId); }

// episode_rename.dart
String proposeEpisodeDisplayName({required int episodeNumber, String? episodeTitle, int padWidth = 2});
Future<List<EpisodeRenameProposal>> renameCollectionEpisodes({required HibikiDatabase db, required int collectionId, required bool dryRun});
```

### 遗留（后续线程）
- UI 展示：详情页「相关作品」区块（watchCollectionRelations）、集级资料/改名确认弹窗、集封面 rail —— 本批不触碰两个独占文件。
- relations 边的封面只存 `coverUrl` 未下载（`coverPath` 列已备好，UI 需要缩略图时再决定下载策略）。
- anilistId 匹配未做：Bangumi/TMDB relations 响应里没有 AniList id 可比对，只按 (source,subjectId)+标题绑定。
- `packages/hibiki_core/CLAUDE.md` 的表数/schemaVersion 描述早已落后（写着 53 表/v63），未随手改，留给文档线程统一刷新。
- `database.g.dart` diff 偏大：新表对 media_collections 的 FK 使 drift manager API 生成反向引用并整段位移，内容为纯生成物；合并冲突时在 packages/hibiki_core 重跑 `dart run build_runner build --delete-conflicting-outputs` 即可。

https://claude.ai/code/session_017ZUDdFKDGNxpH4r5UcdWj4
