### PR TITLE
fix(sync): 补上书架批删这个漏接的入口（BUG-1338 死角② 残留）

### DIFF
--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -512,6 +512,13 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
         : mediaCount == 0
             ? t.batch_dissolve_confirm(m: collectionCount)
             : t.batch_delete_mixed_confirm(n: mediaCount, m: collectionCount);
+    // TODO-2470 死角②：勾选框只在它真能兑现时才摆出来，两个条件缺一不可——
+    //   ① 本轮真会删媒体本体（纯解散合集 mediaCount==0 只解除分组，scope 无处可用，
+    //      合集自身的删除传播走 collection_sync_engine；与视频页同一判断）；
+    //   ② 本机存在删除传播通道（纯本地零网络判据）。
+    final bool canSyncEverywhere = mediaCount > 0 &&
+        await hasDeletionPropagationChannel(SyncRepository(appModel.database));
+    if (!mounted) return;
     final DeleteScope? scope = await showAppDialog<DeleteScope>(
       context: context,
       builder: (ctx) => ReaderHistoryDeleteDialog(
@@ -524,6 +531,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
             : buildDeletionDisclosure(
                 target: DeletionDisclosureTarget.shelfBook,
               ),
+        showSyncScope: canSyncEverywhere,
         onConfirm: (DeleteScope s) => Navigator.pop(ctx, s),
       ),
     );

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1106
+version: 1.3.1+1107
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/sync/delete_scope_no_channel_widget_test.dart
+++ b/hibiki/test/sync/delete_scope_no_channel_widget_test.dart
@@ -14,6 +14,8 @@ import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart
 import 'package:hibiki/src/sync/deletion_disclosure.dart';
 import 'package:hibiki/src/sync/deletion_prompt.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
+
+import '../pages/reader_history_source_corpus.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 void main() {
@@ -61,6 +63,43 @@ void main() {
       await tester.pump();
 
       expect(got, DeleteScope.keepLocalOnly);
+    });
+  });
+
+  /// 源码守卫：每一个会摆出「从所有设备删除」勾选框的入口，都必须先问过通道判据。
+  ///
+  /// 这条守卫是**被真实疏漏催生的**：初版修复只接了 `_confirmMediaDelete` 与三个
+  /// `showDeleteScopeConfirm` 调用点，漏掉了书架批删 `_batchDeleteConfirm` 里第二个
+  /// `ReaderHistoryDeleteDialog` 构造点——它继续无条件显示那个兑现不了的勾选框。
+  /// 死角②的复发方式就是「又冒出一个没接线的入口」，所以按入口数量而非行为来钉。
+  group('入口覆盖源码守卫（TODO-2470 死角②）', () {
+    test('每个 ReaderHistoryDeleteDialog 构造点都显式传 showSyncScope', () {
+      final String source = readReaderHistorySource();
+      // 语料含 dialogs.part.dart 里的类声明本身（`const ReaderHistoryDeleteDialog({`），
+      // 它不是调用点，要从计数里剔掉。
+      final int ctorCount =
+          'ReaderHistoryDeleteDialog('.allMatches(source).length -
+              'const ReaderHistoryDeleteDialog('.allMatches(source).length;
+      final int gatedCount = 'showSyncScope:'.allMatches(source).length;
+
+      expect(ctorCount, greaterThan(0), reason: '书架页必须存在删除确认框构造点');
+      expect(
+        gatedCount,
+        ctorCount,
+        reason: '有 $ctorCount 个构造点但只有 $gatedCount 处传了 showSyncScope——'
+            '漏接的那个入口会在没有任何同步通道时继续显示「从所有设备删除」，'
+            '正是 TODO-2470 死角②的复发形态',
+      );
+    });
+
+    test('每个 showDeleteScopeConfirm 调用点都显式传 db', () {
+      final String source = readReaderHistorySource();
+      // 书架页自身不用通用弹窗；断言写成「有调用就必须带 db」，防止将来
+      // 有人在此页新引入一个不查判据的调用点。
+      final int calls = 'showDeleteScopeConfirm('.allMatches(source).length;
+      if (calls == 0) return;
+      expect('db:'.allMatches(source).length, greaterThanOrEqualTo(calls),
+          reason: '通用删除弹窗必须传 db，否则它无从得知本机有没有传播通道');
     });
   });
 


### PR DESCRIPTION
接 PR #666（内容已 squash 进 develop）。**#666 关闭后我又 push 了一个补漏 commit，它永远进不了 develop**，所以这部分改动在 develop 上是缺的——本 PR 补齐。

## develop 上残留的缺口（已核实）

`ReaderHistoryDeleteDialog` 有**两个**构造点，#666 只接了一个：

```
origin/develop:.../reader_hibiki_history_page.dart:1886  → 有 showSyncScope ✅
origin/develop:.../reader_history/books.part.dart:517    → 没有            ❌
```

`books.part.dart:517` 是**书架批量删除**（`_batchDeleteConfirm`）。它照样删媒体本体、照样透传 `DeleteScope`，但那个「从所有设备删除」勾选框在本机一个同步通道都没有时**仍然无条件显示** —— 用户报的死角②在这条路径上原样存在。

## 本 PR 做两件事

1. **接上判据**：`showSyncScope: canSyncEverywhere`，其中
   `canSyncEverywhere = mediaCount > 0 && await hasDeletionPropagationChannel(...)`。
   多出的 `mediaCount > 0` 是对齐视频页早已存在的判断——纯解散合集不删媒体本体，`scope` 无处可用，合集自身的删除传播走 `collection_sync_engine`。

2. **补一条按「入口数量」钉的源码守卫**：每个 `ReaderHistoryDeleteDialog` 构造点都必须显式传 `showSyncScope`。

   为什么按数量而不是按行为钉：死角②的复发形态就是「又冒出一个没接线的入口」，而行为测试只能覆盖已知入口、盯不住新增的。**这条守卫正是被这次真实疏漏催生的** —— 我自己就是漏了第二个构造点才发现需要它。

## 验证

- `flutter analyze`（含 test）**No issues found**（基于当前 develop）。
- `delete_scope_no_channel_widget_test` + `reader_history_batch_delete_count_guard_test` + `reader_shelf_batch_collection_ops_test` 共 **12 条全绿**。
- **变异实测**：把 `showSyncScope` 拿掉（即回到 develop 当前的漏接状态）→ 守卫报「有 2 个构造点但只有 1 处传了 showSyncScope」精确变红，反向替换还原。守卫不是摆设。

未做真机验证。

https://claude.ai/code/session_012syhu25RSx7mzveQSRZWsm
