### PR TITLE
fix(reader): 设置侧栏「布局与显示」缩为「布局显示」避免两行换行

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 51391 (3023 per locale)
 ///
-/// Built on 2026-08-01 at 12:08 UTC
+/// Built on 2026-08-01 at 16:22 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -104715,7 +104715,7 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get section_interface => '界面';
   @override
-  String get section_layout => '布局与显示';
+  String get section_layout => '布局显示';
   @override
   String get section_navigation => '导航';
   @override
@@ -111318,7 +111318,7 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get section_interface => '介面';
   @override
-  String get section_layout => '版面與顯示';
+  String get section_layout => '版面顯示';
   @override
   String get section_navigation => '導覽';
   @override
@@ -210910,7 +210910,7 @@ extension on _StringsZhCn {
       case 'section_interface':
         return '界面';
       case 'section_layout':
-        return '布局与显示';
+        return '布局显示';
       case 'section_navigation':
         return '导航';
       case 'section_page_turn_direction':
@@ -217074,7 +217074,7 @@ extension on _StringsZhHk {
       case 'section_interface':
         return '介面';
       case 'section_layout':
-        return '版面與顯示';
+        return '版面顯示';
       case 'section_navigation':
         return '導覽';
       case 'section_page_turn_direction':

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -1522,7 +1522,7 @@
   "section_epub": "EPUB 书架",
   "section_floating_lyric": "悬浮歌词",
   "section_interface": "界面",
-  "section_layout": "布局与显示",
+  "section_layout": "布局显示",
   "section_navigation": "导航",
   "section_page_turn_direction": "翻页方向",
   "section_reader_colors": "阅读器颜色",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -1522,7 +1522,7 @@
   "section_epub": "EPUB 書架",
   "section_floating_lyric": "Floating lyric",
   "section_interface": "介面",
-  "section_layout": "版面與顯示",
+  "section_layout": "版面顯示",
   "section_navigation": "導覽",
   "section_page_turn_direction": "翻頁方向",
   "section_reader_colors": "閱讀器顏色",


### PR DESCRIPTION
## 问题

用户截图：阅读器快捷设置左侧栏（固定 208px）里「布局与显示」5 个字，选中加粗后放不下，折成两行，观感差。TODO-1143 之前只是把 `titleMaxLines` 放宽到 2 兜底允许换行，没治标签本身超长。

## 修复

侧栏标签统一不超过 4 个字（其余项：导航/阅读操作/查词/有声书/歌词模式/退出 本来就 ≤4）：

- zh-CN `section_layout`：「布局与显示」→「布局显示」
- zh-HK `section_layout`：「版面與顯示」→「版面顯示」

不叫「排版」——阅读设置里已有 `section_typography` =「排版」分区，会撞名。其余 15 种语言不动。仅改现有 key 的值（key 集不变，不涉 i18n_sync），`strings.g.dart` 由 `dart run slang` 再生成 + `dart format`。

## 验证

- `flutter analyze --no-pub`：No issues found
- 定向测试 61 个全绿：`test/i18n` 全目录 + `reader_settings_reorg_guard` + `settings_renderer_shrinkwrap_scroll_guard` + `reader_layout_theme_card_width` + `reader_layout_css_editor_row_width` + `reader_wide_pane_nav_label`（该测试用自身 const 长标签测两行换行能力，不读 i18n，继续有效）+ `reader_quick_settings_sheet_static` + `audiobook_play_bar_theme_chip`

https://claude.ai/code/session_0159ufn6orkFQaRoY3H45WXG