### PR TITLE
fix(home): 首页/书架撤强制左右间距（媒体墙 full-bleed）

### DIFF
--- a/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_page.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_page.dart
@@ -92,11 +92,21 @@ class _MokuroMoeCatalogPageState extends ConsumerState<MokuroMoeCatalogPage> {
               },
             ),
           Expanded(
-            child: MokuroMoeCatalogView(
-              db: widget.db ?? appModel.database,
-              embedded: true,
-              enabledOverride: appModel.mangaOnlineCatalogEnabled,
-              snapshotNotifier: _snapshot,
+            // 正文自带内边距：readerShelf 的 desktopContentPadding 已恒为零
+            // （PR#675 撤强制侧向留白），而 [MokuroMoeCatalogView] 自身零内边距，
+            // 桌面上搜索框与封面网格会直接贴窗口边。留白取 spacing.page，与上方
+            // [HibikiPageHeader] 的横向内边距同源（对话框语境走
+            // [MokuroMoeCatalogDialog]，由 ImportDialogFrame 供内边距，不受影响）。
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: HibikiDesignTokens.of(context).spacing.page,
+              ),
+              child: MokuroMoeCatalogView(
+                db: widget.db ?? appModel.database,
+                embedded: true,
+                enabledOverride: appModel.mangaOnlineCatalogEnabled,
+                snapshotNotifier: _snapshot,
+              ),
             ),
           ),
         ],

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -49,8 +49,9 @@ import 'package:hibiki_core/hibiki_core.dart';
 ///   [aggregateActivityEvents] 聚合成「按日期分组」的时间线，顶部按类别筛选。
 ///
 /// 分栏（BUG-1073 后）：宽屏（`constraints.maxWidth >= 900`）= 主列（flex 3：学习活动
-/// → 继续 → 最近添加）+ 侧列（flex 2：Activity 时间轴），整体限宽
-/// [_kDashboardMaxWidth] 居中；窄屏单列堆叠。书与阅读位置走 Riverpod provider
+/// → 继续 → 最近添加）+ 侧列（flex 2：Activity 时间轴），随窗口铺满（旧 1600px
+/// 限宽居中已撤——用户实报「首页左右强制的间距」）；窄屏单列堆叠。书与阅读位置走
+/// Riverpod provider
 /// （响应式）；视频与活动事件在 [initState] 一次性异步载入到本地状态（视频列表天然是
 /// Future）。
 class HomeDashboardPage extends BaseModuleTabPage {
@@ -359,9 +360,6 @@ class _BangumiWatchedDialogState extends State<_BangumiWatchedDialog> {
     );
   }
 }
-
-/// 仪表盘内容最大宽度（逻辑像素）：超宽屏限宽居中，避免每个区块被拉成大片空白。
-const double _kDashboardMaxWidth = 1600;
 
 /// Bangumi 同步卡最多列出的已关联条目数（超出的去设置页看全量；首页卡片是状态
 /// 概览，不是映射管理器）。有失败的条目由
@@ -882,19 +880,7 @@ class _HomeDashboardPageState
         }
         return ListView(
           padding: EdgeInsets.all(tokens.spacing.card),
-          children: <Widget>[
-            // 超宽屏（4K/带鱼屏）限宽居中：再宽下去只是把每个区块拉稀，不增信息量。
-            // heightFactor: 1 让 Align 在 ListView 的无界高度里收敛到内容高度。
-            Align(
-              alignment: Alignment.topCenter,
-              heightFactor: 1,
-              child: ConstrainedBox(
-                constraints:
-                    const BoxConstraints(maxWidth: _kDashboardMaxWidth),
-                child: body,
-              ),
-            ),
-          ],
+          children: <Widget>[body],
         );
       },
     );

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -1509,7 +1509,7 @@ class _HomeDashboardPageState
   Widget _buildHeatmapCard(HibikiDesignTokens tokens) {
     final Map<String, int> charsByDay = _heatmapCharsByDay();
     final Map<String, int> timeMsByDay = _heatmapTimeMsByDay();
-    return _sectionCard(
+    final Widget card = _sectionCard(
       tokens,
       title: t.reading_activity,
       header: _filterChips<int>(
@@ -1554,6 +1554,23 @@ class _HomeDashboardPageState
           SizedBox(height: tokens.spacing.gap),
           _buildDailyGoalRow(tokens),
         ],
+      ),
+    );
+    // 热力图是全仪表盘唯一有**天然最大宽度**的区块：网格列数封顶「一年」、格子边长
+    // 封顶 maxCell，铺到 [statHeatmapMaxGridWidth]（1110）就到头了。整页 1600 限宽撤
+    // 掉后（PR#675），3840 逻辑宽下这张卡被拉到 2244，而网格仍是 1110——右侧空出
+    // 1134px，正是 BUG-1073 症状 3 在超宽屏复发。修法不是把整页限宽加回来（用户实报
+    // 「首页左右强制的间距」要的就是铺满），而是只给这一块按内容的自然上限封顶，并
+    // 左对齐保持与主列其余区块左边缘对齐。1920 及以下主列本就窄于该上限，此处无效果。
+    return Align(
+      alignment: AlignmentDirectional.centerStart,
+      // ListView 给的高度约束无界，heightFactor: 1 让 Align 收敛到内容高度。
+      heightFactor: 1,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: statHeatmapMaxGridWidth() + 2 * _sectionCardInset(tokens),
+        ),
+        child: card,
       ),
     );
   }
@@ -2638,6 +2655,10 @@ class _HomeDashboardPageState
   // ── 共享外壳 ────────────────────────────────────────────────────────────
 
   /// 统一的分区卡：标题（+ 可选右侧 header 控件）+ 内容，套 group 底色圆角。
+  /// [_sectionCard] 的内边距。单独抽出来是因为 [_buildHeatmapCard] 要按「网格自然
+  /// 最大宽度 + 两侧内边距」给卡片限宽，两处必须用同一个值。
+  double _sectionCardInset(HibikiDesignTokens tokens) => tokens.spacing.gap + 4;
+
   Widget _sectionCard(
     HibikiDesignTokens tokens, {
     required String title,
@@ -2652,7 +2673,7 @@ class _HomeDashboardPageState
         ),
       ),
       child: Padding(
-        padding: EdgeInsets.all(tokens.spacing.gap + 4),
+        padding: EdgeInsets.all(_sectionCardInset(tokens)),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           mainAxisSize: MainAxisSize.min,

--- a/hibiki/lib/src/pages/implementations/media_sources_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_sources_page.dart
@@ -30,6 +30,7 @@ class _MediaSourcesPageState extends State<MediaSourcesPage> {
 
   @override
   Widget build(BuildContext context) {
+    final HibikiDesignTokens tokens = HibikiDesignTokens.of(context);
     // 与书架 / 视频 / 词典三个库页同构：DesktopContentLayout + HibikiPageHeader
     // 大标题 + HibikiIconButton 动作，外层 Scaffold 由 HomePage 提供。
     return DesktopContentLayout(
@@ -38,10 +39,17 @@ class _MediaSourcesPageState extends State<MediaSourcesPage> {
         children: <Widget>[
           if (!isCupertinoPlatform(context)) _buildHeader(),
           Expanded(
-            child: MediaSourcesView(
-              key: _viewKey,
-              mediaKind: widget.mediaKind,
-              scrollable: true,
+            // 正文自带内边距：readerShelf 的 desktopContentPadding 已恒为零
+            // （PR#675 撤强制侧向留白），而 [MediaSourcesView] 自身只有行间的纵向
+            // 间距，桌面上文字与开关会直接贴窗口边。留白取 spacing.page，与上方
+            // [HibikiPageHeader] 的横向内边距同源，标题与正文左边缘对齐；滚动条仍
+            // 贴真实边缘（padding 在 SingleChildScrollView 里，不在它外面）。
+            child: SingleChildScrollView(
+              padding: EdgeInsets.symmetric(horizontal: tokens.spacing.page),
+              child: MediaSourcesView(
+                key: _viewKey,
+                mediaKind: widget.mediaKind,
+              ),
             ),
           ),
         ],

--- a/hibiki/lib/src/utils/components/stat_contribution_heatmap.dart
+++ b/hibiki/lib/src/utils/components/stat_contribution_heatmap.dart
@@ -1,6 +1,39 @@
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/pages/implementations/stat_activity.dart';
 
+/// 每屏**最少**列数（周数）。见 [StatContributionHeatmap.weeks]。
+const int kStatHeatmapMinWeeks = 17;
+
+/// 每屏**最多**列数（周数）= GitHub 式「一年」。见 [StatContributionHeatmap.maxWeeks]。
+const int kStatHeatmapMaxWeeks = 53;
+
+/// 单格自然边长（逻辑像素）。见 [StatContributionHeatmap.cell]。
+const double kStatHeatmapCell = 12;
+
+/// 单格放大上限（逻辑像素）。见 [StatContributionHeatmap.maxCell]。
+const double kStatHeatmapMaxCell = 18;
+
+/// 格间距（逻辑像素）。见 [StatContributionHeatmap.spacing]。
+const double kStatHeatmapSpacing = 3;
+
+/// 网格「铺到头」的自然最大宽度（逻辑像素；默认配置下 = 53×18 + 52×3 = 1110）。
+///
+/// 组件有**两道**天然封顶，宿主再宽也只会在网格右侧空出来：
+/// - 列数封顶 [kStatHeatmapMaxWeeks]（一年）——再加列就是大片空周，正是 BUG-1073
+///   病灶 1「左边一大片死黑」；
+/// - 列数封顶后富余宽度分摊给格子边长，但格子封顶 [kStatHeatmapMaxCell]——再放大
+///   就不是热力图而是一排大方块。
+///
+/// 所以**宿主容器要按本值限宽**，不能让卡片跟着窗口拉满：首页整页 1600 限宽撤掉后，
+/// 3840 逻辑宽下热力图卡宽 2244 而网格仍只有 1110，右侧空出 1134px——BUG-1073
+/// 症状 3（区块宽度用不满）在超宽屏复发。消费者调本函数，不要各自抄常量。
+double statHeatmapMaxGridWidth({
+  int maxWeeks = kStatHeatmapMaxWeeks,
+  double maxCell = kStatHeatmapMaxCell,
+  double spacing = kStatHeatmapSpacing,
+}) =>
+    maxWeeks * maxCell + (maxWeeks - 1) * spacing;
+
 /// GitHub 式「贡献热力图」的一天格子：日期键 + 当日活动值 + 强度等级。
 ///
 /// [dateKey] 为 null 表示占位格（当前周里今天之后的未来日，不落在窗口内），渲染成
@@ -45,7 +78,7 @@ class StatHeatmapModel {
 StatHeatmapModel buildStatHeatmap({
   required Map<String, int> valueByDateKey,
   required DateTime now,
-  int weeks = 17,
+  int weeks = kStatHeatmapMinWeeks,
   int weekOffset = 0,
 }) {
   final DateTime today = DateTime(now.year, now.month, now.day);
@@ -108,7 +141,7 @@ StatHeatmapModel buildStatHeatmap({
 int maxHeatmapPageOffset({
   required Map<String, int> valueByDateKey,
   required DateTime now,
-  int weeks = 17,
+  int weeks = kStatHeatmapMinWeeks,
 }) {
   if (valueByDateKey.isEmpty || weeks <= 0) return 0;
   String? minKey;
@@ -172,11 +205,11 @@ class StatContributionHeatmap extends StatefulWidget {
     super.key,
     this.emptyBorderColor,
     this.onDaySelected,
-    this.weeks = 17,
-    this.maxWeeks = 53,
-    this.cell = 12,
-    this.maxCell = 18,
-    this.spacing = 3,
+    this.weeks = kStatHeatmapMinWeeks,
+    this.maxWeeks = kStatHeatmapMaxWeeks,
+    this.cell = kStatHeatmapCell,
+    this.maxCell = kStatHeatmapMaxCell,
+    this.spacing = kStatHeatmapSpacing,
   });
 
   /// 日期键（`2026-06-07`）→ 当日活动值（视频=观看毫秒 / 阅读=字数）的全量映射。

--- a/hibiki/lib/src/utils/misc/platform_utils.dart
+++ b/hibiki/lib/src/utils/misc/platform_utils.dart
@@ -210,20 +210,29 @@ double? desktopContentMaxWidth(
   return switch (kind) {
     // UI v2：取消书架/视频库在宽屏上的 1280px 内容宽上限（用户实报「莫名的左右
     // 宽度上限」）。合集横排行/卡片网格是媒体墙布局，随窗口放宽天然多排一列，
-    // 居中锁窄反而两侧留白。与查词页 TODO-1352 同款 full-bleed 分支（仍保留
-    // desktopContentPadding 的 16/24px 侧向留白，不贴边）。
+    // 居中锁窄反而两侧留白。侧向留白也为零（见 [desktopContentPadding]），
+    // 卡片自带内边距，真正 full-bleed。
     DesktopContentKind.readerShelf => null,
     // TODO-1352: 取消查词页（nav「查词」）在宽屏上的强制内容宽度上限。此前 1040px 把
     // 查词结果区 WebView 居中锁死在窄栏，宽屏两侧大片留白、用户无法让词典正文占满。
-    // 返回 null 让 [DesktopContentLayout] 走 full-bleed 分支（仍保留 24px 侧向留白，
-    // 不贴边），词典正文随窗口放宽（可容纳更多 --dict-columns 与更长释义）。嵌套查词
-    // 弹窗渲染在根 Overlay、独立走 popupMaxWidth，不受此项影响。
+    // 返回 null 让 [DesktopContentLayout] 走 full-bleed 分支（词典正文是文字流，
+    // 仍保留 16/24px 侧向留白不贴边），词典正文随窗口放宽（可容纳更多
+    // --dict-columns 与更长释义）。嵌套查词弹窗渲染在根 Overlay、独立走
+    // popupMaxWidth，不受此项影响。
     DesktopContentKind.dictionary => null,
     DesktopContentKind.settings => 960,
   };
 }
 
-EdgeInsets desktopContentPadding(WindowSizeClass sizeClass) {
+/// [DesktopContentLayout] 的侧向留白。媒体墙类页面（[DesktopContentKind.readerShelf]：
+/// 书架/视频/游戏/漫画目录/来源页）恒为零——卡片自带内边距，宽屏上再叠 16/24px
+/// 强制侧向留白只是在侧栏与内容间挤出一条空带（用户实报「首页左右强制的间距」）。
+/// 查词/设置是文字流正文，贴边可读性差，宽屏保留 16/24px。
+EdgeInsets desktopContentPadding(
+  WindowSizeClass sizeClass,
+  DesktopContentKind kind,
+) {
+  if (kind == DesktopContentKind.readerShelf) return EdgeInsets.zero;
   return switch (sizeClass) {
     WindowSizeClass.compact => EdgeInsets.zero,
     WindowSizeClass.medium => const EdgeInsets.symmetric(horizontal: 16),
@@ -299,7 +308,7 @@ class DesktopContentLayout extends StatelessWidget {
         );
         final double? maxWidth = desktopContentMaxWidth(sizeClass, kind);
         final Widget padded = Padding(
-          padding: desktopContentPadding(sizeClass),
+          padding: desktopContentPadding(sizeClass, kind),
           child: child,
         );
         if (maxWidth == null) return padded;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1116
+version: 1.3.1+1117
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -992,6 +992,60 @@ void main() {
     );
   });
 
+  /// 撤整页 1600 限宽后的**宽屏兜底**：1920 恰好是「主列 ~1076 < 网格自然上限
+  /// 1110」的临界点，热力图刚好被填满，所以只测 1920 结构上测不到 BUG-1073 症状 3
+  /// 的复发。2560 起主列就宽过 1110，热力图卡再拉满就是右侧死空白（3840 下实测卡内
+  /// 2244 对网格 1110，空 1134px）。这里直接量真实几何：网格必须长到自然上限，且卡
+  /// 内不许剩下富余宽度；同时侧列位置仍随窗口走，证明没有把整页限宽偷偷加回来。
+  for (final double width in <double>[2560, 3840]) {
+    testWidgets('宽屏兜底（$width）：热力图卡按网格自然上限封顶，卡内无右侧死空白',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = Size(width, 1200);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await seedAllSections();
+      await tester.pumpWidget(buildApp());
+      await pumpDashboard(tester);
+
+      expect(tester.takeException(), isNull);
+
+      // 网格 = 热力图内最后一个 GestureDetector（Column 里翻页箭头在前、网格在后）。
+      final Finder heatmapFinder = find.byType(StatContributionHeatmap);
+      final Finder gridFinder = find
+          .descendant(
+            of: heatmapFinder,
+            matching: find.byType(GestureDetector),
+          )
+          .last;
+      // 卡内可用宽（= 卡宽 − 两侧内边距）：热力图在 stretch 的 Column 里，宽度就是它。
+      final double cardInnerWidth = tester.getSize(heatmapFinder).width;
+      final double gridWidth = tester.getSize(gridFinder).width;
+
+      // 网格铺到自身两道封顶（53 列 × 18px 格 + 52 × 3px 间距 = 1110）。
+      expect(gridWidth, statHeatmapMaxGridWidth(), reason: 'width=$width');
+      // 富余宽度必须为零——回归时这里是 2244 − 1110 = 1134px 死空白。
+      expect(
+        cardInnerWidth - gridWidth,
+        lessThanOrEqualTo(1.0),
+        reason: 'width=$width 卡内右侧死空白',
+      );
+      // 只封顶热力图这一块：整页没有重新限宽居中，左缘仍贴页面 padding，
+      // 侧列（活动时间轴）起点仍按窗口宽的 ~60% 走。
+      expect(
+        tester.getTopLeft(find.text(t.reading_activity)).dx,
+        lessThan(100),
+        reason: 'width=$width 左缘',
+      );
+      expect(
+        tester.getTopLeft(find.text(t.home_activity)).dx,
+        greaterThan(width * 0.5),
+        reason: 'width=$width 侧列起点',
+      );
+    });
+  }
+
   testWidgets('BUG-1073 窄屏（420）：四个区块仍单列堆叠、左边缘一致', (WidgetTester tester) async {
     tester.view.physicalSize = const Size(420, 1400);
     tester.view.devicePixelRatio = 1.0;

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -972,7 +972,8 @@ void main() {
     );
   });
 
-  testWidgets('BUG-1073 超宽屏（1920）：内容限宽居中，不再左右拉满', (WidgetTester tester) async {
+  testWidgets('超宽屏（1920）：内容随窗口铺满，不再限宽居中（撤 BUG-1073 的 1600px 上限）',
+      (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1920, 1000);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -983,10 +984,11 @@ void main() {
     await pumpDashboard(tester);
 
     expect(tester.takeException(), isNull);
-    // 可用宽 > 1600 时内容居中：左侧留白远大于页面 padding（20）。
+    // 用户实报「首页左右强制的间距」：旧 1600px 限宽居中在 1920 宽下左侧凭空
+    // 挤出 ~140px 空带。撤限宽后内容左缘只剩页面 padding + 卡片内边距。
     expect(
       tester.getTopLeft(find.text(t.reading_activity)).dx,
-      greaterThan(100),
+      lessThan(100),
     );
   });
 

--- a/hibiki/test/utils/misc/platform_layout_test.dart
+++ b/hibiki/test/utils/misc/platform_layout_test.dart
@@ -1,7 +1,21 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/collections/collection_shelf_row.dart';
 import 'package:hibiki/src/utils/misc/platform_utils.dart';
+
+import '../../sync/desktop_lookup_foreground_guard_static_test.dart'
+    show stripDartComments;
+
+/// 页面壳里「自己补横向内边距」的判据：`padding:` 位置上出现一个横向 EdgeInsets，
+/// 且取自 `spacing.page`（设计 token，不是散落魔数）。
+bool _hasOwnHorizontalInset(String code) {
+  return RegExp(
+    r'padding:\s*EdgeInsets\.symmetric\(\s*horizontal:[^;]{0,120}?spacing\.page',
+    dotAll: true,
+  ).hasMatch(code);
+}
 
 void main() {
   group('windowSizeClassOf', () {
@@ -172,6 +186,46 @@ void main() {
         expect(
           desktopContentPadding(sizeClass, DesktopContentKind.readerShelf),
           EdgeInsets.zero,
+        );
+      }
+    });
+
+    test('readerShelf 零留白后，两个裸内容页必须自带横向内边距', () {
+      // 共享侧向留白归零，是因为媒体墙**卡片自带内边距**。但这两页的内容体
+      // （MediaSourcesView / MokuroMoeCatalogView）是裸的文字行与搜索框 + 封面网格，
+      // 自身零内边距——共享留白一撤就直接贴窗口边 0px。所以它们必须在页面壳里自己
+      // 补，量级与其余媒体墙页一致（这里取 spacing.page，与同页 HibikiPageHeader 的
+      // 横向内边距同源，标题与正文左缘对齐）。注释先剥掉，防止说明文字假绿。
+      for (final ({String path, String label}) page
+          in const <({String path, String label})>[
+        (
+          path: 'lib/src/pages/implementations/media_sources_page.dart',
+          label: '来源页',
+        ),
+        (
+          path: 'lib/src/media/manga/online/mokuro_moe_catalog_page.dart',
+          label: 'mokuro 在线目录页',
+        ),
+      ]) {
+        final String code =
+            stripDartComments(File(page.path).readAsStringSync());
+        expect(
+          code.contains('DesktopContentKind.readerShelf'),
+          isTrue,
+          reason: '${page.label} 不再是 readerShelf 页，本守卫需重新定标',
+        );
+        expect(
+          _hasOwnHorizontalInset(code),
+          isTrue,
+          reason: '${page.label} 自身无横向内边距，桌面上会贴窗口边 0px',
+        );
+        // 变异自检：把内边距摘掉守卫必须转红。
+        expect(
+          _hasOwnHorizontalInset(
+            code.replaceAll('spacing.page', 'spacing.nothing'),
+          ),
+          isFalse,
+          reason: '${page.label} 的守卫必须能被摘掉内边距的 mutation 杀红',
         );
       }
     });

--- a/hibiki/test/utils/misc/platform_layout_test.dart
+++ b/hibiki/test/utils/misc/platform_layout_test.dart
@@ -143,17 +143,37 @@ void main() {
 
     test('adds desktop breathing room without changing compact padding', () {
       expect(
-        desktopContentPadding(WindowSizeClass.compact),
+        desktopContentPadding(
+          WindowSizeClass.compact,
+          DesktopContentKind.dictionary,
+        ),
         EdgeInsets.zero,
       );
       expect(
-        desktopContentPadding(WindowSizeClass.medium),
+        desktopContentPadding(
+          WindowSizeClass.medium,
+          DesktopContentKind.dictionary,
+        ),
         const EdgeInsets.symmetric(horizontal: 16),
       );
       expect(
-        desktopContentPadding(WindowSizeClass.expanded),
+        desktopContentPadding(
+          WindowSizeClass.expanded,
+          DesktopContentKind.settings,
+        ),
         const EdgeInsets.symmetric(horizontal: 24),
       );
+    });
+
+    test('reader shelf (media wall) is full-bleed at every size class', () {
+      // 用户实报「首页左右强制的间距」：媒体墙类页面（书架/视频/游戏/漫画目录/
+      // 来源页）卡片自带内边距，宽屏不再叠 16/24px 强制侧向留白。
+      for (final WindowSizeClass sizeClass in WindowSizeClass.values) {
+        expect(
+          desktopContentPadding(sizeClass, DesktopContentKind.readerShelf),
+          EdgeInsets.zero,
+        );
+      }
     });
 
     test('keeps compact dialog fields usable', () {
@@ -213,6 +233,32 @@ void main() {
       // TODO-1352：dictionary 宽屏改为 full-bleed（null 上限），子内容宽度
       // = 屏幕 1600 - 2×24 侧向留白 = 1552（不再锁 1040→992）。
       expect(tester.getSize(find.byKey(childKey)).width, 1552);
+    });
+
+    testWidgets('reader shelf spans edge-to-edge on wide desktop', (
+      WidgetTester tester,
+    ) async {
+      tester.view.devicePixelRatio = 1;
+      tester.view.physicalSize = const Size(1600, 200);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(
+        const Directionality(
+          textDirection: TextDirection.ltr,
+          child: SizedBox(
+            width: double.infinity,
+            height: double.infinity,
+            child: DesktopContentLayout(
+              kind: DesktopContentKind.readerShelf,
+              child: SizedBox.expand(key: childKey),
+            ),
+          ),
+        ),
+      );
+
+      // 媒体墙类页面零侧向留白（用户实报「首页左右强制的间距」）：宽屏子内容
+      // 宽度 = 整屏 1600，不再扣 2×24。
+      expect(tester.getSize(find.byKey(childKey)).width, 1600);
     });
 
     testWidgets('keeps compact content full width without desktop padding', (


### PR DESCRIPTION
## 症状（用户截图实报）

- **首页 dashboard**：超宽屏下侧栏与「学习活动」之间被强制空出 ~150px 宽的空带（右侧对称）。
- **书架页**：侧栏与内容之间有一条固定空带。

## 根因

1. `home_dashboard_page.dart` 的 `_kDashboardMaxWidth = 1600` 限宽居中：窗口比 1600 宽时两侧凭空留白。
2. `DesktopContentLayout` 的 `desktopContentPadding` 在 medium/expanded 强制 16/24px 水平留白（UI v2 只撤了 1280px 宽上限，留白仍在）。

## 修复

- dashboard 撤限宽居中，内容随窗口铺满（仅保留页面自身 padding）。
- `desktopContentPadding` 按 kind 分流：`readerShelf`（书架/视频/游戏/gal/漫画目录/来源页共用的媒体墙）恒零侧向留白——卡片自带内边距不会真贴边；查词/设置是文字流正文，16/24px 保持不变。

## 验证

- `flutter analyze` 全量无 issue。
- 定向：`platform_layout_test.dart` + `home_dashboard_page_test.dart` 59 项全绿（守卫已同步：新增 readerShelf 全尺寸零留白 + 宽屏 edge-to-edge 断言；反转 dashboard「限宽居中」守卫为「铺满」）。
- 相邻几何断言测试（home_video 排序/分区/菜单/合集封面卡、games 库筛选、书架徽章、settings 左对齐）全绿。

https://claude.ai/code/session_01CEz2A19H44rKeAwCXum3ez