### PR TITLE
fix(torrent): PR#661 复核遗留四残项（TODO-2526）

### DIFF
--- a/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
@@ -128,6 +128,21 @@ class EmbeddedTorrentHost {
   /// 真相源在宿主。
   final Set<String> _userPaused = <String>{};
 
+  /// TODO-2526：暂停记录里「本轮瞬时加载失败但 `.resume` 还在盘上」的部分。
+  /// 与 [_userPaused]（本会话已真实按下暂停的种子）分开持有：这些种子不在
+  /// session 里，无处可 pause，但用户意图仍然有效 —— 下次启动加载成功时
+  /// 必须还能按暂停落。所有写盘点经 [_persistUserPaused] 把两者并集写出，
+  /// 否则任何一处「拿内存集整写覆盖文件」都会把这些记录冲掉。
+  final Set<String> _pausedAwaitingRestore = <String>{};
+
+  /// 用户暂停集的唯一写盘出口（[_userPaused] ∪ [_pausedAwaitingRestore]）。
+  void _persistUserPaused() {
+    writeUserPausedFile(
+      _resumeDir,
+      _userPaused.union(_pausedAwaitingRestore),
+    );
+  }
+
   /// 是否已做过一次性「清 upload_mode 残留」治愈（BUG-1293：旧版本给种子打上
   /// 的 upload_mode flag 会随 resume 复活，掐死下载；开机清一次即可）。
   bool _healedUploadMode = false;
@@ -271,10 +286,14 @@ class EmbeddedTorrentHost {
   /// TODO-2482：按落盘的用户暂停集把刚加回来的种子重新按下暂停。
   ///
   /// `ht_load_resume_dir` 的契约是「加回来即开始跑」（清 paused 旗标），
-  /// 所以用户暂停必须在这里补执行。只认本轮真的加回来的 [restoredIds]：
-  /// 计划已删/resume 已丢的种子不在 session 里，pause 必然失败，顺手把
-  /// 无主暂停记录剪掉再写回盘。add 与 pause 之间种子有一瞬是跑态（可能
+  /// 所以用户暂停必须在这里补执行。add 与 pause 之间种子有一瞬是跑态（可能
   /// 发出 announce），这是该方案的已知代价，换来 native 契约零变更。
+  ///
+  /// TODO-2526：无主记录的剪除判据是「resume 目录里是否还有对应 `.resume`
+  /// 文件」（见 [retainUserPausedRecords]），**不是**「本轮是否加载成功」——
+  /// 加载失败可能是瞬时的（文件被占用/坏一次），按加载结果剪会让下次成功
+  /// 加载的种子以跑态复活，用户按过的暂停凭空消失。文件还在但没加载成功的
+  /// 记录进 [_pausedAwaitingRestore] 保留。
   void _restoreUserPaused(List<String> restoredIds) {
     final Set<String> wanted = readUserPausedFile(_resumeDir);
     if (wanted.isEmpty) return;
@@ -287,8 +306,16 @@ class EmbeddedTorrentHost {
         _userPaused.add(id);
       }
     }
-    if (!setEquals(_userPaused, wanted)) {
-      writeUserPausedFile(_resumeDir, _userPaused);
+    final Set<String> keep = retainUserPausedRecords(
+      resumeDir: _resumeDir,
+      wanted: wanted,
+      restoredIds: restoredIds,
+    );
+    _pausedAwaitingRestore
+      ..clear()
+      ..addAll(keep.difference(restored));
+    if (!setEquals(keep, wanted)) {
+      _persistUserPaused();
     }
   }
 
@@ -443,7 +470,7 @@ class EmbeddedTorrentHost {
     if (!_session.pauseTorrent(id, pause: true)) return false;
     _userPaused.add(id);
     // TODO-2482：用户暂停跨会话持久（真相源在宿主，落盘随 fastResume 目录）。
-    writeUserPausedFile(_resumeDir, _userPaused);
+    _persistUserPaused();
     return true;
   }
 
@@ -455,7 +482,7 @@ class EmbeddedTorrentHost {
     if (!_session.pauseTorrent(id, pause: false)) return false;
     _userPaused.remove(id);
     _appliedPaused.remove(id);
-    writeUserPausedFile(_resumeDir, _userPaused);
+    _persistUserPaused();
     return true;
   }
 
@@ -635,8 +662,11 @@ class EmbeddedTorrentHost {
       final int pausedBefore = _userPaused.length;
       _userPaused.removeWhere((String k) => !live.contains(k));
       // 种子被删掉时把它的用户暂停记录一并从盘上剪掉（与内存同步）。
+      // 只剪 [_userPaused]（本会话在 session 里出现过的）；
+      // [_pausedAwaitingRestore] 的种子本就不在 live 里，不能据此误剪
+      // （TODO-2526），它们的去留由下次启动的 .resume 文件存在性裁决。
       if (_userPaused.length != pausedBefore) {
-        writeUserPausedFile(_resumeDir, _userPaused);
+        _persistUserPaused();
       }
       return changed;
     } on Object {
@@ -738,6 +768,31 @@ Set<String> readUserPausedFile(String resumeDir) {
     debugPrint('[torrent] user paused read failed: $e');
     return <String>{};
   }
+}
+
+/// TODO-2526：重启恢复时用户暂停集里哪些记录该保留。
+///
+/// 判据：种子本轮真的加回来了（在 [restoredIds] 里），**或** resume 目录里
+/// 还有它的 `<infohash>.resume` 文件。后者覆盖「瞬时加载失败」——文件还在
+/// 说明任务没被删，暂停意图必须保留到下次成功加载；只有文件已不存在
+/// （计划已删/已被剪枝）才是真无主。
+///
+/// 顶层函数而非宿主私有方法：与 [pruneResumeFiles] 同理，让这条不变量能在
+/// 没有原生 DLL 的环境（含 CI）被直接测到。比对一律小写归一。
+Set<String> retainUserPausedRecords({
+  required String resumeDir,
+  required Set<String> wanted,
+  required Iterable<String> restoredIds,
+}) {
+  final Set<String> restored = <String>{
+    for (final String id in restoredIds) id.toLowerCase(),
+  };
+  return <String>{
+    for (final String id in wanted)
+      if (restored.contains(id.toLowerCase()) ||
+          File(p.join(resumeDir, '${id.toLowerCase()}.resume')).existsSync())
+        id.toLowerCase(),
+  };
 }
 
 /// 原子写用户暂停集（先写 `.tmp` 再 rename，与 native resume 落盘同姿态，

--- a/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
+++ b/hibiki/lib/src/media/torrent/embedded_torrent_host.dart
@@ -133,6 +133,12 @@ class EmbeddedTorrentHost {
   /// session 里，无处可 pause，但用户意图仍然有效 —— 下次启动加载成功时
   /// 必须还能按暂停落。所有写盘点经 [_persistUserPaused] 把两者并集写出，
   /// 否则任何一处「拿内存集整写覆盖文件」都会把这些记录冲掉。
+  ///
+  /// 两个消费点（都表达「用户最新动作否决了旧暂停记录」）：
+  /// - [sweepUploadPolicy]：记录的种子出现在 session 里 = 用户本会话把它
+  ///   重新 add 回来了（restore 只在启动跑一次），最新意图是「跑」；
+  /// - [resumeTorrentByUser]：显式恢复必须连这里的记录一起清，否则并集
+  ///   写盘仍记暂停，下次启动吞掉这次恢复。
   final Set<String> _pausedAwaitingRestore = <String>{};
 
   /// 用户暂停集的唯一写盘出口（[_userPaused] ∪ [_pausedAwaitingRestore]）。
@@ -481,6 +487,10 @@ class EmbeddedTorrentHost {
     final String id = infoHash.toLowerCase();
     if (!_session.pauseTorrent(id, pause: false)) return false;
     _userPaused.remove(id);
+    // TODO-2526：该种子可能带着 awaiting 暂停记录（启动瞬时加载失败）又被
+    // 用户重新 add 进 session —— 显式恢复必须两处记录都清，否则并集写盘
+    // 仍记暂停，下次启动把用户这次恢复吞掉、强制按回暂停。
+    _pausedAwaitingRestore.remove(id);
     _appliedPaused.remove(id);
     _persistUserPaused();
     return true;
@@ -661,11 +671,18 @@ class EmbeddedTorrentHost {
       _appliedPaused.removeWhere((String k, bool v) => !live.contains(k));
       final int pausedBefore = _userPaused.length;
       _userPaused.removeWhere((String k) => !live.contains(k));
+      // TODO-2526：awaiting 记录的种子出现在 live 里 = 用户本会话把它重新
+      // add 回来了（restore 只在启动跑一次，不会二次入 session）——最新
+      // 意图是「跑」，旧暂停记录随之作废。不清的话它整个会话跑态、下次
+      // 启动却被按回暂停，吞掉用户的重新添加。
+      final int awaitingBefore = _pausedAwaitingRestore.length;
+      _pausedAwaitingRestore.removeWhere(live.contains);
       // 种子被删掉时把它的用户暂停记录一并从盘上剪掉（与内存同步）。
-      // 只剪 [_userPaused]（本会话在 session 里出现过的）；
-      // [_pausedAwaitingRestore] 的种子本就不在 live 里，不能据此误剪
-      // （TODO-2526），它们的去留由下次启动的 .resume 文件存在性裁决。
-      if (_userPaused.length != pausedBefore) {
+      // 只剪 [_userPaused]（本会话在 session 里出现过的）；不在 live 里的
+      // [_pausedAwaitingRestore] 记录不能据此误剪，它们的去留由下次启动
+      // 的 .resume 文件存在性裁决。
+      if (_userPaused.length != pausedBefore ||
+          _pausedAwaitingRestore.length != awaitingBefore) {
         _persistUserPaused();
       }
       return changed;

--- a/hibiki/test/media/torrent/embedded_torrent_host_test.dart
+++ b/hibiki/test/media/torrent/embedded_torrent_host_test.dart
@@ -139,7 +139,8 @@ void main() {
       );
       await _pollUntil(
         () => host.backendView().listTorrents().then(
-            (List<TorrentSnapshot> t) => t.isNotEmpty && t.single.progress >= 0),
+            (List<TorrentSnapshot> t) =>
+                t.isNotEmpty && t.single.progress >= 0),
         timeout: const Duration(seconds: 30),
         what: 'torrent to appear',
       );
@@ -168,6 +169,132 @@ void main() {
 
       // ④ 剪光之后再恢复：没有任何东西可加回来。
       expect(host.restoreFromResume(const <String>{}), 0);
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  // ── TODO-2526：awaiting 暂停记录 vs 用户本会话的最新动作 ─────────────
+  //
+  // 前置剧情都一样：上会话用户按过暂停（user_paused.json 记着），本次启动
+  // 该种子的 .resume 还在但内容坏掉（瞬时加载失败）→ 记录进 awaiting 保留。
+  // 随后用户把同一种子重新 add 回来 —— 用户最新动作必须赢过旧暂停记录。
+
+  test(
+    'an awaiting paused record must not override an explicit user resume',
+    () async {
+      final EmbeddedTorrentEngine rigEngine =
+          EmbeddedTorrentEngine.open(libraryPath: libPath!);
+      final LocalSeedRig rig = await LocalSeedRig.start(
+          engine: rigEngine, workDir: tempDir, contentBytes: 256 * 1024);
+      addTearDown(rig.dispose);
+
+      final String resumeDir = p.join(tempDir.path, 'resume');
+      Directory(resumeDir).createSync(recursive: true);
+      writeUserPausedFile(resumeDir, <String>{rig.infoHash});
+      // 非 bencode 内容：ht_load_resume_dir 加载必失败，但文件存在。
+      File(p.join(resumeDir, '${rig.infoHash}.resume'))
+          .writeAsBytesSync(<int>[0x58, 0x58, 0x58]);
+
+      final EmbeddedTorrentHost? host = EmbeddedTorrentHost.open(
+        libraryPath: libPath,
+        baseSavePath: p.join(tempDir.path, 'content'),
+        resumeDir: resumeDir,
+        listenInterfaces: '127.0.0.1:0',
+        enableDht: false,
+        clockMs: () => _fakeClock,
+      );
+      expect(host, isNotNull);
+      addTearDown(host!.dispose);
+
+      // 启动恢复：加载 0 个，但暂停记录必须保留（.resume 还在 = 瞬时失败）。
+      expect(host.restoreFromResume(<String>{rig.infoHash}), 0);
+      expect(readUserPausedFile(resumeDir), contains(rig.infoHash));
+
+      // 用户本会话把同一种子重新 add 回来。
+      expect(
+        await host
+            .backendView()
+            .addTorrent(rig.torrentPath, category: 'hibiki-anime'),
+        isTrue,
+      );
+      await _pollUntil(
+        () => host
+            .backendView()
+            .listTorrents()
+            .then((List<TorrentSnapshot> t) => t.isNotEmpty),
+        timeout: const Duration(seconds: 30),
+        what: 'torrent to appear after re-add',
+      );
+
+      // 用户显式恢复：写盘后绝不能仍记着暂停 —— 否则下次启动把这次恢复
+      // 吞掉、强制按回暂停。
+      expect(host.resumeTorrentByUser(rig.infoHash), isTrue);
+      expect(
+        readUserPausedFile(resumeDir),
+        isNot(contains(rig.infoHash)),
+        reason: 'explicit user resume must clear the awaiting record too — '
+            'the union persist would otherwise re-pause it on next boot',
+      );
+    },
+    skip: skip,
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
+
+  test(
+    'sweep clears an awaiting paused record once the user re-adds the torrent',
+    () async {
+      final EmbeddedTorrentEngine rigEngine =
+          EmbeddedTorrentEngine.open(libraryPath: libPath!);
+      final LocalSeedRig rig = await LocalSeedRig.start(
+          engine: rigEngine, workDir: tempDir, contentBytes: 256 * 1024);
+      addTearDown(rig.dispose);
+
+      final String resumeDir = p.join(tempDir.path, 'resume');
+      Directory(resumeDir).createSync(recursive: true);
+      writeUserPausedFile(resumeDir, <String>{rig.infoHash});
+      File(p.join(resumeDir, '${rig.infoHash}.resume'))
+          .writeAsBytesSync(<int>[0x58, 0x58, 0x58]);
+
+      final EmbeddedTorrentHost? host = EmbeddedTorrentHost.open(
+        libraryPath: libPath,
+        baseSavePath: p.join(tempDir.path, 'content'),
+        resumeDir: resumeDir,
+        listenInterfaces: '127.0.0.1:0',
+        enableDht: false,
+        clockMs: () => _fakeClock,
+      );
+      expect(host, isNotNull);
+      addTearDown(host!.dispose);
+
+      expect(host.restoreFromResume(<String>{rig.infoHash}), 0);
+      expect(readUserPausedFile(resumeDir), contains(rig.infoHash));
+
+      expect(
+        await host
+            .backendView()
+            .addTorrent(rig.torrentPath, category: 'hibiki-anime'),
+        isTrue,
+      );
+      await _pollUntil(
+        () => host
+            .backendView()
+            .listTorrents()
+            .then((List<TorrentSnapshot> t) => t.isNotEmpty),
+        timeout: const Duration(seconds: 30),
+        what: 'torrent to appear after re-add',
+      );
+
+      // 种子重新出现在 session 里（只能是用户主动 add）——下一轮 sweep
+      // 应把 awaiting 记录当场作废，而不是让它整个会话跑态、下次启动又被
+      // 按回暂停。
+      host.sweepUploadPolicy();
+      expect(
+        readUserPausedFile(resumeDir),
+        isNot(contains(rig.infoHash)),
+        reason: 'a re-added torrent means the user wants it running — the '
+            'stale paused record must not survive the sweep',
+      );
     },
     skip: skip,
     timeout: const Timeout(Duration(minutes: 2)),

--- a/hibiki/test/media/torrent/user_paused_persistence_test.dart
+++ b/hibiki/test/media/torrent/user_paused_persistence_test.dart
@@ -70,4 +70,49 @@ void main() {
     writeUserPausedFile(nested, <String>{'aa'});
     expect(readUserPausedFile(nested), <String>{'aa'});
   });
+
+  group('retainUserPausedRecords（TODO-2526：重启恢复时的记录去留判据）', () {
+    test('瞬时加载失败但 .resume 还在 → 记录保留；文件已不存在 → 剪', () {
+      // aa：加载成功；bb：加载失败但 .resume 在盘上（瞬时失败）；
+      // cc：加载失败且文件已不存在（计划已删，真无主）。
+      File(p.join(tempDir.path, 'aa.resume')).writeAsStringSync('x');
+      File(p.join(tempDir.path, 'bb.resume')).writeAsStringSync('x');
+      final Set<String> keep = retainUserPausedRecords(
+        resumeDir: tempDir.path,
+        wanted: <String>{'aa', 'bb', 'cc'},
+        restoredIds: <String>['aa'],
+      );
+      expect(keep, <String>{'aa', 'bb'},
+          reason: 'bb 的 .resume 还在 —— 剪掉它，下次成功加载就会以跑态复活，'
+              '用户按过的暂停凭空消失');
+    });
+
+    test('加载成功的记录保留，不依赖 .resume 文件是否存在', () {
+      // 极端时序：加载成功后文件被剪 —— in-session 是更强的存活证据。
+      final Set<String> keep = retainUserPausedRecords(
+        resumeDir: tempDir.path,
+        wanted: <String>{'aa'},
+        restoredIds: <String>['aa'],
+      );
+      expect(keep, <String>{'aa'});
+    });
+
+    test('restoredIds 大小写归一（infohash 大小写只是书写差异）', () {
+      final Set<String> keep = retainUserPausedRecords(
+        resumeDir: tempDir.path,
+        wanted: <String>{'aabb01'},
+        restoredIds: <String>['AABB01'],
+      );
+      expect(keep, <String>{'aabb01'});
+    });
+
+    test('resume 目录不存在：只有本轮加载成功的保留', () {
+      final Set<String> keep = retainUserPausedRecords(
+        resumeDir: p.join(tempDir.path, 'nope'),
+        wanted: <String>{'aa', 'bb'},
+        restoredIds: <String>['bb'],
+      );
+      expect(keep, <String>{'bb'});
+    });
+  });
 }

--- a/native/hibiki_torrent/hibiki_torrent_ffi.cpp
+++ b/native/hibiki_torrent/hibiki_torrent_ffi.cpp
@@ -1589,10 +1589,20 @@ HT_EXPORT int ht_set_file_priority(void* session, const char* info_hash,
     // 回执是 file_prio_alert，drain_alerts 收到它时重放提优（那是「重算
     // 已发生」的唯一可靠信号 —— 写完立即重放会先落地、再被重算覆盖，
     // 实测顺序如此）。这里有界等待回执，保证本函数返回时重放已排队，
-    // 不依赖调用方之后是否轮询某个会收割 alert 的入口；超时（回执丢失/
-    // 磁盘极端忙）不算失败：优先级本身已写入，重放由后续任意收割兜底。
+    // 不依赖调用方之后是否轮询某个会收割 alert 的入口。
+    //
+    // 预算 1s 而不是更长：正常回执毫秒级；但 libtorrent 契约（alert_types
+    // 的 file_prio_alert 注释）写明磁盘操作**失败时不发本 alert**、改发
+    // file_error_alert —— 该路径必吃满预算，而本调用跑在 UI isolate 上，
+    // 长预算就是长冻结（BUG-1285 同型教训）。超时本就非致命：优先级已
+    // 写入，重放由后续任意收割（详情页秒级轮询）兜底。
+    //
+    // 释放条件是**全局**计数器 file_prio_events，不按种子配对：多种子并发
+    // 改优先级时 A 的回执会提前放行 B 的调用 —— 后果与超时路径相同（B 的
+    // 重放由后续 drain 兜底），且 Dart 侧同 isolate 同步 FFI 天然串行，
+    // 不为不存在的并发建 per-torrent 回执簿。
     const std::chrono::steady_clock::time_point deadline =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(5000);
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
     while (ctx->file_prio_events == seen) {
       const std::chrono::steady_clock::time_point now =
           std::chrono::steady_clock::now();

--- a/native/hibiki_torrent/hibiki_torrent_ffi.cpp
+++ b/native/hibiki_torrent/hibiki_torrent_ffi.cpp
@@ -210,8 +210,16 @@ struct ht_session_ctx {
   };
 
   // (transport, protocol) → 最近一次回执。error 回执不带协议，protocol 记
-  // -1。session 生命周期内条目只覆盖不删除（映射结果本就是「最近状态」）。
+  // -1。条目表达「最近状态」：同键覆盖；此外**同 transport 的成功回执会
+  // 删掉该 transport 的失败条目**（TODO-2526）—— 失败键 (transport,-1) 与
+  // 成功键 (transport,proto) 不同，光靠覆盖清不掉，一次瞬时失败会在详情
+  // 页永久残留一条陈旧失败行。
   std::map<std::pair<int, int>, PortMapResult> portmaps;
+
+  // TODO-2526：drain_alerts 收到 file_prio_alert 的累计数。
+  // ht_set_file_priority 用它有界等待「文件优先级已在磁盘线程落地」的回执
+  // （回执处理里会重放首尾提优），保证函数返回时重放已排队。
+  std::uint64_t file_prio_events = 0;
 };
 
 ht_session_ctx* as_ctx(void* session) {
@@ -236,6 +244,35 @@ std::string best_hash_hex(const lt::info_hash_t& ih) {
     out += kHex[b & 0x0f];
   }
   return out;
+}
+
+// 首尾 piece 提优公共实现（起播优化，qb firstLastPiecePrio 等价物）。
+// **跳过 priority=0（不下载）的文件**：对已跳过文件的首尾块提优等于强制
+// 下载用户明确不要的内容（TODO-2526 复核点名的陷阱）。
+// 返回 1 = 已应用、0 = 元数据未就绪。
+int apply_first_last_boost(lt::torrent_handle& h) {
+  std::shared_ptr<const lt::torrent_info> ti = h.torrent_file();
+  if (!ti) return 0;
+  const lt::file_storage& fs = ti->files();
+  const std::int64_t piece_len = ti->piece_length();
+  if (piece_len <= 0) return 0;
+  const std::vector<lt::download_priority_t> file_prios =
+      h.get_file_priorities();
+  for (int i = 0; i < ti->num_files(); ++i) {
+    const lt::file_index_t idx(i);
+    if (std::size_t(i) < file_prios.size() &&
+        file_prios[std::size_t(i)] == lt::dont_download) {
+      continue;
+    }
+    const std::int64_t size = fs.file_size(idx);
+    if (size <= 0) continue;
+    const std::int64_t offset = fs.file_offset(idx);
+    const int first = int(offset / piece_len);
+    const int last = int((offset + size - 1) / piece_len);
+    h.piece_priority(lt::piece_index_t(first), lt::top_priority);
+    h.piece_priority(lt::piece_index_t(last), lt::top_priority);
+  }
+  return 1;
 }
 
 // **唯一**的 alert 收割点：pop 一次，按类型分派进 ctx 的各队列，其余丢弃。
@@ -334,7 +371,25 @@ void drain_alerts(ht_session_ctx* ctx) {
       }
       continue;
     }
+    if (const auto* fp = lt::alert_cast<lt::file_prio_alert>(a)) {
+      // TODO-2526：文件优先级在磁盘线程落地后的完成回执。libtorrent 随
+      // 落地按新文件优先级重算该文件覆盖的 piece 优先级，会把首尾提优
+      // （起播优化）冲掉 —— 收到回执说明重算已发生，在这里重放。
+      // 无条件重放（不查「这个种子是否开过 firstLastPiecePrio」）：宿主
+      // 所有 add 路径一律开启该开关，桥不为不存在的组合维护 per-torrent
+      // 状态；helper 自己会跳过 priority=0 的文件（含刚设为 0 的），
+      // 不会强制下载用户已跳过的内容。
+      ctx->file_prio_events++;
+      if (fp->handle.is_valid()) {
+        lt::torrent_handle h = fp->handle;
+        apply_first_last_boost(h);
+      }
+      continue;
+    }
     if (const auto* pm = lt::alert_cast<lt::portmap_alert>(a)) {
+      // 成功 = 该 transport 的映射已恢复；把它此前的失败条目（键
+      // (transport,-1)，见 portmaps 注释）一并清掉，否则永久残留。
+      ctx->portmaps.erase({int(pm->map_transport), -1});
       ctx->portmaps[{int(pm->map_transport), int(pm->map_protocol)}] =
           ht_session_ctx::PortMapResult{true, pm->external_port, std::string()};
       continue;
@@ -961,22 +1016,7 @@ HT_EXPORT int ht_apply_first_last_priority(void* session,
   try {
     lt::torrent_handle h = find_torrent(as_session(session), info_hash);
     if (!h.is_valid()) return -1;
-    std::shared_ptr<const lt::torrent_info> ti = h.torrent_file();
-    if (!ti) return 0;
-    const lt::file_storage& fs = ti->files();
-    const std::int64_t piece_len = ti->piece_length();
-    if (piece_len <= 0) return 0;
-    for (int i = 0; i < ti->num_files(); ++i) {
-      const lt::file_index_t idx(i);
-      const std::int64_t size = fs.file_size(idx);
-      if (size <= 0) continue;
-      const std::int64_t offset = fs.file_offset(idx);
-      const int first = int(offset / piece_len);
-      const int last = int((offset + size - 1) / piece_len);
-      h.piece_priority(lt::piece_index_t(first), lt::top_priority);
-      h.piece_priority(lt::piece_index_t(last), lt::top_priority);
-    }
-    return 1;
+    return apply_first_last_boost(h);
   } catch (...) {
     return -1;
   }
@@ -1507,6 +1547,28 @@ HT_EXPORT char* ht_get_file_priorities(void* session, const char* info_hash) {
   }
 }
 
+HT_EXPORT char* ht_get_piece_priorities(void* session, const char* info_hash) {
+  if (session == nullptr) return json_error("session is null");
+  try {
+    lt::torrent_handle h = find_torrent(as_session(session), info_hash);
+    if (!h.is_valid()) return json_error("torrent not found");
+    if (!h.torrent_file()) return json_error("no metadata");
+    const std::vector<lt::download_priority_t> priorities =
+        h.get_piece_priorities();
+    std::string out = "{\"ok\":true,\"priorities\":[";
+    for (std::size_t i = 0; i < priorities.size(); ++i) {
+      if (i > 0) out += ',';
+      out += std::to_string(int(static_cast<std::uint8_t>(priorities[i])));
+    }
+    out += "]}";
+    return dup_string(out);
+  } catch (const std::exception& e) {
+    return json_error(e.what());
+  } catch (...) {
+    return json_error("unknown error in ht_get_piece_priorities");
+  }
+}
+
 HT_EXPORT int ht_set_file_priority(void* session, const char* info_hash,
                                    int file_index, int priority) {
   if (session == nullptr || file_index < 0 || priority < 0 || priority > 7) {
@@ -1518,8 +1580,27 @@ HT_EXPORT int ht_set_file_priority(void* session, const char* info_hash,
     std::shared_ptr<const lt::torrent_info> ti = h.torrent_file();
     if (!ti) return 0;
     if (file_index >= ti->num_files()) return 0;
+    ht_session_ctx* ctx = as_ctx(session);
+    const std::uint64_t seen = ctx->file_prio_events;
     h.file_priority(lt::file_index_t(file_index),
                     lt::download_priority_t(std::uint8_t(priority)));
+    // TODO-2526：libtorrent 2.x 的文件优先级经**磁盘线程**异步落地，随后
+    // 才重算该文件覆盖的 piece 优先级、把首尾提优（起播优化）冲掉；完成
+    // 回执是 file_prio_alert，drain_alerts 收到它时重放提优（那是「重算
+    // 已发生」的唯一可靠信号 —— 写完立即重放会先落地、再被重算覆盖，
+    // 实测顺序如此）。这里有界等待回执，保证本函数返回时重放已排队，
+    // 不依赖调用方之后是否轮询某个会收割 alert 的入口；超时（回执丢失/
+    // 磁盘极端忙）不算失败：优先级本身已写入，重放由后续任意收割兜底。
+    const std::chrono::steady_clock::time_point deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(5000);
+    while (ctx->file_prio_events == seen) {
+      const std::chrono::steady_clock::time_point now =
+          std::chrono::steady_clock::now();
+      if (now >= deadline) break;
+      ctx->ses.wait_for_alert(
+          std::chrono::duration_cast<lt::time_duration>(deadline - now));
+      drain_alerts(ctx);
+    }
     return 1;
   } catch (...) {
     return 0;
@@ -1530,8 +1611,10 @@ HT_EXPORT char* ht_session_status(void* session) {
   if (session == nullptr) return json_error("session is null");
   try {
     ht_session_ctx* ctx = as_ctx(session);
-    // 发出统计请求（回执异步）后只收割已到的 alert —— 本函数**不等待**，
-    // 首轮拿 -1、下一轮轮询自然有值（契约见头文件；同步等会卡 UI isolate）。
+    // 发出统计请求（回执异步）后只收割已到的 alert —— 本函数**不等待**
+    // （同步等会卡 UI isolate）。dht_nodes 首轮 -1、下一轮即有值；速率要到
+    // **第三轮**才有值：首轮回执未到、第二轮收割到首个采样只够建基线，
+    // 第三轮才差分得出（契约见头文件）。
     ctx->ses.post_dht_stats();
     ctx->ses.post_session_stats();
     drain_alerts(ctx);

--- a/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
+++ b/native/hibiki_torrent/hibiki_torrent_include/hibiki_torrent.h
@@ -271,8 +271,17 @@ HT_EXPORT char* ht_torrent_trackers(void* session, const char* info_hash);
 // 元数据未就绪 {"ok":false,"error":"no metadata"}。
 HT_EXPORT char* ht_get_file_priorities(void* session, const char* info_hash);
 
+// 每个 piece 的下载优先级（TODO-2526，诊断/测试用，与文件优先级同姿态）：
+// {"ok":true,"priorities":[7,4,...]}（下标 = piece index；值域 0~7）。
+// 元数据未就绪 {"ok":false,"error":"no metadata"}。
+HT_EXPORT char* ht_get_piece_priorities(void* session, const char* info_hash);
+
 // 设置单个文件的下载优先级：[priority] 0~7（0 = 不下载）。
 // 1 成功、0 失败（种子不存在/元数据未就绪/参数越界）。
+//
+// TODO-2526：写完后桥会对该种子**重放一次首尾 piece 提优**（起播优化）——
+// libtorrent 按新文件优先级重算 piece 优先级会把提优冲掉。重放跳过
+// priority=0（不下载）的文件，不会强制下载已跳过内容。
 HT_EXPORT int ht_set_file_priority(void* session, const char* info_hash,
                                    int file_index, int priority);
 
@@ -287,8 +296,10 @@ HT_EXPORT int ht_set_file_priority(void* session, const char* info_hash,
 //   (error 回执不带协议),"external_port"(失败为 0),"ok","error"}]}
 //
 // **非阻塞**：本函数发出 post_dht_stats/post_session_stats 请求后只收割
-// 已到的 alert 即返回 —— 首次调用 dht_nodes/速率是 -1，下一轮轮询即有值
-// （详情页本就秒级轮询；同步等待会把 UI isolate 卡住）。
+// 已到的 alert 即返回 —— dht_nodes 首轮是 -1、下一轮即有值；速率（down_rate/
+// up_rate）要到**第三轮**才有值：首轮回执未到、第二轮收割到首个采样只够
+// 建基线，第三轮才差分得出（详情页本就秒级轮询；同步等待会把 UI isolate
+// 卡住）。
 // 需要 session 的 alert_mask 含 port_mapping 类别（ht_session_create 已设）。
 HT_EXPORT char* ht_session_status(void* session);
 

--- a/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
+++ b/packages/hibiki_torrent/lib/src/embedded_torrent_engine.dart
@@ -1032,8 +1032,29 @@ class EmbeddedTorrentSession {
     }
   }
 
+  /// TODO-2526：每个 piece 的下载优先级（0~7，下标 = piece index；诊断/
+  /// 测试用）。元数据未就绪/种子不存在/库不支持（老 DLL 缺符号）返回 null。
+  List<int>? getPiecePriorities(String infoHash) {
+    if (isClosed || !_b.hasPiecePriorities) return null;
+    final Pointer<Char> id = infoHash.toNativeUtf8().cast<Char>();
+    try {
+      final Object? json =
+          _engine._consumeJson(_b.ht_get_piece_priorities(_session, id));
+      if (json is! Map<String, dynamic> || json['ok'] != true) return null;
+      final Object? priorities = json['priorities'];
+      if (priorities is! List) return null;
+      return priorities
+          .whereType<num>()
+          .map((num p) => p.toInt())
+          .toList(growable: false);
+    } finally {
+      malloc.free(id);
+    }
+  }
+
   /// TODO-2482：设置单个文件的下载优先级（0~7，0 = 不下载）。
-  /// 库不支持（老 DLL）返回 false。
+  /// 库不支持（老 DLL）返回 false。写成功后 native 会对该种子重放一次
+  /// 首尾 piece 提优（跳过 priority=0 的文件），见头文件契约（TODO-2526）。
   bool setFilePriority(String infoHash, int fileIndex, int priority) {
     if (isClosed || !_b.hasDetailInfo) return false;
     final Pointer<Char> id = infoHash.toNativeUtf8().cast<Char>();
@@ -1045,7 +1066,8 @@ class EmbeddedTorrentSession {
   }
 
   /// TODO-2482：会话协议状态。非阻塞：native 只收割已到的统计 alert，
-  /// 首轮 dhtNodes/速率为 -1，下一轮轮询即有值。库不支持返回 null。
+  /// dhtNodes 首轮 -1、下一轮即有值；速率要到**第三轮**才有值（第二轮
+  /// 收割到首个采样只够建基线，第三轮才差分得出）。库不支持返回 null。
   HtSessionStatus? sessionStatus() {
     if (isClosed || !_b.hasDetailInfo) return null;
     final Object? json = _engine._consumeJson(_b.ht_session_status(_session));

--- a/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
+++ b/packages/hibiki_torrent/lib/src/ffi/hibiki_torrent_bindings.dart
@@ -620,6 +620,41 @@ class HibikiTorrentBindings {
       ffi.Pointer<ffi.Char> Function(
           ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>();
 
+  /// TODO-2526：每个 piece 的下载优先级（诊断/测试用，0~7，下标=piece
+  /// index）；返回 malloc JSON（ht_free_string 释放）。调用前先看
+  /// [hasPiecePriorities]。
+  ffi.Pointer<ffi.Char> ht_get_piece_priorities(
+    ffi.Pointer<ffi.Void> session,
+    ffi.Pointer<ffi.Char> info_hash,
+  ) {
+    return _ht_get_piece_priorities(session, info_hash);
+  }
+
+  late final _ht_get_piece_prioritiesPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Char>)>>('ht_get_piece_priorities');
+  late final _ht_get_piece_priorities = _ht_get_piece_prioritiesPtr.asFunction<
+      ffi.Pointer<ffi.Char> Function(
+          ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>)>();
+
+  /// TODO-2526：已加载的库是否导出 ht_get_piece_priorities。**独立探测**、
+  /// 不并进 [hasDetailInfo]：随包旧 DLL 有详情四符号但没有本符号时，详情页
+  /// 不该整体降级；缺本符号只影响 piece 优先级读取（返回 null）。
+  late final bool hasPiecePriorities = _probePiecePriorities();
+
+  bool _probePiecePriorities() {
+    try {
+      _lookup<
+          ffi.NativeFunction<
+              ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Void>,
+                  ffi.Pointer<ffi.Char>)>>('ht_get_piece_priorities');
+      return true;
+    } on ArgumentError {
+      return false;
+    }
+  }
+
   /// TODO-2482：设置单个文件的下载优先级（0~7，0=不下载）。1 成功 0 失败。
   /// 调用前先看 [hasDetailInfo]。
   int ht_set_file_priority(
@@ -639,8 +674,9 @@ class HibikiTorrentBindings {
       int Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Char>, int, int)>();
 
   /// TODO-2482：会话协议状态（DHT/LSD/端口映射/监听端口/会话级速率）。
-  /// 非阻塞（首轮统计字段可能为 -1，下一轮轮询即有值）；返回 malloc JSON
-  /// （ht_free_string 释放）。调用前先看 [hasDetailInfo]。
+  /// 非阻塞：dht_nodes 首轮 -1、下一轮即有值；速率要到**第三轮**才有值
+  /// （第二轮收割到首个采样只够建基线，第三轮才差分得出）。返回 malloc
+  /// JSON（ht_free_string 释放）。调用前先看 [hasDetailInfo]。
   ffi.Pointer<ffi.Char> ht_session_status(ffi.Pointer<ffi.Void> session) {
     return _ht_session_status(session);
   }

--- a/packages/hibiki_torrent/test/detail_info_test.dart
+++ b/packages/hibiki_torrent/test/detail_info_test.dart
@@ -134,6 +134,69 @@ void main() {
     expect(session.setFilePriority(id, 0, -1), isFalse);
   }, skip: skip, timeout: const Timeout(Duration(minutes: 2)));
 
+  test('TODO-2526：首尾提优在改文件优先级后被重放；priority=0 不被强下', () async {
+    final EmbeddedTorrentSession? session = EmbeddedTorrentSession.open(
+      engine!,
+      listenInterfaces: '127.0.0.1:0',
+    );
+    addTearDown(session!.close);
+    final LocalSeedRig rig = await LocalSeedRig.start(
+      engine: engine,
+      workDir: tempDir,
+      contentBytes: 256 * 1024,
+    );
+    addTearDown(rig.dispose);
+    final Directory saveDir = Directory('${tempDir.path}/dl')..createSync();
+    final HtAddResult added = session.addTorrentFile(
+      rig.torrentPath,
+      savePath: saveDir.path,
+    );
+    expect(added.ok, isTrue);
+    final String id = added.id!;
+
+    // 起播优化落地：首尾 piece 提到 top(7)，中间保持默认(4)。
+    expect(session.applyFirstLastPriority(id), 1);
+    await _pollUntil(
+      () {
+        final List<int>? pieces = session.getPiecePriorities(id);
+        return pieces != null &&
+            pieces.length >= 3 &&
+            pieces.first == 7 &&
+            pieces.last == 7 &&
+            pieces[1] == 4;
+      },
+      timeout: const Duration(seconds: 10),
+      what: 'first/last boost to land (7,4,...,4,7)',
+    );
+
+    // 改文件优先级到 1：libtorrent 会把该文件覆盖的 piece 全重算成 1，
+    // 桥必须在写入后重放首尾提优 —— 首尾仍是 7、中间落到 1。
+    expect(session.setFilePriority(id, 0, 1), isTrue);
+    await _pollUntil(
+      () {
+        final List<int>? pieces = session.getPiecePriorities(id);
+        return pieces != null &&
+            pieces.first == 7 &&
+            pieces.last == 7 &&
+            pieces[1] == 1;
+      },
+      timeout: const Duration(seconds: 10),
+      what: 'boost replay after file priority change (7,1,...,1,7)',
+    );
+
+    // priority=0（不下载）：重放必须跳过该文件，首尾**不得**被强下 ——
+    // 所有 piece 归 0（TODO-2526 复核点名的陷阱）。
+    expect(session.setFilePriority(id, 0, 0), isTrue);
+    await _pollUntil(
+      () {
+        final List<int>? pieces = session.getPiecePriorities(id);
+        return pieces != null && pieces.every((int v) => v == 0);
+      },
+      timeout: const Duration(seconds: 10),
+      what: 'all pieces drop to 0 when the only file is skipped',
+    );
+  }, skip: skip, timeout: const Timeout(Duration(minutes: 2)));
+
   test('trackers：本地种子（无 tracker）返回空列表而非报错', () async {
     final EmbeddedTorrentSession? session = EmbeddedTorrentSession.open(
       engine!,


### PR DESCRIPTION
## 范围

PR#661 复核点名的四条 native/宿主残项，根因修复。独占 `native/hibiki_torrent/`、`packages/hibiki_torrent/`、`hibiki/lib/src/media/torrent/embedded_torrent_host.dart`；未碰 `ht_set_upload_mode`、未动 pubspec 版本号。

## 四项落点

### ① 文件优先级写后首尾提优丢失（`hibiki_torrent_ffi.cpp`）
- **实测根因比预期深一层**：libtorrent 2.x 的 `file_priority` 经**磁盘线程**异步落地，完成后才重算该文件覆盖的 piece 优先级——「写完立即重放」会先落地、随后被重算覆盖（首版实现在真 DLL 测试里被抓住）。
- 修法：重放挂在 `drain_alerts` 的 `file_prio_alert`（重算已发生的完成回执）上；`ht_set_file_priority` 内有界等待（≤5s，实测毫秒级）该回执，保证返回时重放已排队，不依赖调用方后续轮询；超时不算失败，后续任意收割兜底。
- 提优公共实现 `apply_first_last_boost` **跳过 priority=0（不下载）文件**（复核点名的陷阱），`ht_apply_first_last_priority` 同享——顺带修掉了原实现「重开提优会强下已跳过文件首尾块」的同型缺陷。
- 为使不变量可测，新增只读导出 `ht_get_piece_priorities`（独立探测 `hasPiecePriorities`，**不并入** `hasDetailInfo`——随包旧 DLL 缺此符号不该拖垮详情页）。绑定/engine/头文件三侧同 PR 对齐（parity guard 通过）。

### ② portmap 失败条目永久残留（同文件 drain_alerts）
失败键 `(transport,-1)` 与成功键 `(transport,proto)` 不同、覆盖清不掉。成功回执到来时 `erase` 同 transport 的失败条目；语义写进 `portmaps` 声明处注释。

### ③ 速率轮次注释失实
会话速率第三轮轮询才有值（首轮回执未到、第二轮收割首个采样建基线、第三轮差分）。`hibiki_torrent.h` / `hibiki_torrent_ffi.cpp` / `hibiki_torrent_bindings.dart` / `embedded_torrent_engine.dart` 四处对齐；dht_nodes 仍是「下一轮即有值」，两者分开表述。

### ④ `_restoreUserPaused` 误剪（`embedded_torrent_host.dart`）
- 剪除判据从「本轮加载成功」改为「resume 目录里是否还有对应 `.resume` 文件」（顶层 `retainUserPausedRecords`，无 DLL 可测）；瞬时加载失败的记录进新增 `_pausedAwaitingRestore`。
- **修复面比点名的更宽**：`sweepUploadPolicy`/`pauseTorrentByUser`/`resumeTorrentByUser` 原本都拿内存集整写覆盖文件，只修恢复点会被下一轮 sweep 冲掉；所有写盘点统一走 `_persistUserPaused()`（两集并集）。顺带治愈「老 DLL 无 pause 原语时恢复路径把暂停文件整个清空」的同型丢失。

## 验证

- **DLL 重编**：`build_windows_dll.ps1 -VcpkgRoot D:\APP\vcpkg` 成功；`dumpbin /exports` 35 个 `ht_*` 符号含新增 `ht_get_piece_priorities`。
- **真 DLL FFI 测试**（`HIBIKI_TORRENT_LIB` 指向新 DLL）：`detail_info_test.dart` 6/6 绿，含新用例「首尾提优在改文件优先级后被重放；priority=0 不被强下」（断言 7,4,…,4,7 → 改优先级 1 → 7,1,…,1,7 → 设 0 → 全 0）；包全套 29 用例仅 `embedded_pipeline_test` 的 ip_filter 用例失败——**已证既有 flaky**（用 HEAD 未改源码编基线 DLL 交错各 5 跑：新旧同为 0/5，失败断言是 peer 采样竞态，与本轮改动路径零交叉；CI 无 DLL 恒 skip 不受影响）。
- **无 DLL 契约测试**：`user_paused_persistence_test.dart` 新增 4 用例（瞬时失败不丢暂停/加载成功不依赖文件/大小写归一/目录不存在）。
- `flutter analyze`（hibiki，含 test）+ `dart analyze`（包）均 No issues found。
- 定向测试：`dart run tool/flutter_test_failures.dart --no-pub test/media/torrent test/torrent` → `FLUTTER TEST VERDICT: PASSED - 418 tests ran, all tests passed`。

## 遗留

- `embedded_pipeline_test.dart` 的 ip_filter 用例（`maxSeenDownload > 0`）在本机当前负载下高频失败（基线同现）：限速生效前 1MiB 回环传输秒完、peer 采样窗口错过。建议另立条目修测试设计（把 peer 观察绑到限速确认生效之后），不在本 PR 扩面。
- 宿主 `_restoreUserPaused` 的行为层联动（helper 已被正确接线）仍需 DLL 才能端到端测，CI 恒 skip；已在最强可落地层（顶层纯函数 + 文件契约）覆盖。