### PR TITLE
fix(scraper): 合集子篇不再被自动刮成作品级海报

### DIFF
--- a/hibiki/lib/src/media/torrent/anime_download_importer.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_importer.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
@@ -8,7 +9,7 @@ import 'package:hibiki/src/media/torrent/anime_download_service.dart';
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/media/video/video_filename_parser.dart';
-import 'package:hibiki/src/storage/app_paths.dart';
+import 'package:hibiki/src/media/video/video_storage.dart';
 import 'package:hibiki/src/media/video/video_cover_extractor.dart'
     show downloadVideoCoverToPath, extractVideoCover, videoCoverFileName;
 
@@ -28,15 +29,30 @@ List<String> sortVideoPathsByEpisode(List<String> paths) {
 }
 
 /// 组装番剧下载完成后的入库回调：N 集拆行 + playlist 合集（一个事务，复用
-/// [VideoBookRepository.importSplitPlaylist]）→ 绑定 AniList id → 封面（优先
-/// AniList 封面 URL，失败退 ffmpeg 抽帧）落到首集并让合集封面指向它。
+/// [VideoBookRepository.importSplitPlaylist]）→ 绑定 AniList id → 封面。
+///
+/// 封面分两层、各自 best-effort（用户 2026-08-02：子篇不得被赋予作品级竖版海报）：
+/// * **作品海报（AniList 封面 URL）→ 合集自有封面**（`MediaCollections.coverPath`，
+///   落 `video_covers/collections/<collectionId>.jpg`），**不再借道首集条目封面**
+///   ——旧路径把海报写进首集 `VideoBooks.coverPath` 再让合集 coverSource 指过去，
+///   结果是成员条目顶着一张作品级竖版海报；
+/// * **首集抽帧缩略图 → 首集条目封面**，并保留 coverSource 借用链指向首集：
+///   海报下载失败/无 URL 时，合集卡回落链（coverPath 优先 → coverSource 借成员）
+///   仍能显示首集抽帧，与旧行为对齐。
 ///
 /// 封面/绑定失败不影响入库结果（best-effort），入库本体失败返回 null（由
 /// [AnimeDownloadService] 把计划标 failed）。
+///
+/// [httpClient] / [collectionCoversDirectory] 仅供测试注入（默认自建 client /
+/// 生产 [VideoStorage.collectionCoversDir]）。
 Future<AnimeDownloadImportOutcome?> Function(
   AnimeDownloadPlan plan,
   List<String> videoAbsolutePaths,
-) buildAnimeDownloadImporter(HibikiDatabase db) {
+) buildAnimeDownloadImporter(
+  HibikiDatabase db, {
+  http.Client? httpClient,
+  Directory? collectionCoversDirectory,
+}) {
   final VideoBookRepository repo = VideoBookRepository(db);
   return (AnimeDownloadPlan plan, List<String> videoAbsolutePaths) async {
     if (videoAbsolutePaths.isEmpty) return null;
@@ -63,25 +79,40 @@ Future<AnimeDownloadImportOutcome?> Function(
       } catch (_) {}
     }
 
-    // 封面：下载 AniList 封面 → 退 ffmpeg 抽帧；设到首集并让合集封面指向首集。
     if (result.episodeUids.isNotEmpty) {
+      // ① 作品海报 → 合集自有封面（见函数注释；文件名/目录与
+      //    applyCandidateToCollection 同约定，gcOrphanCovers 非递归天然免疫）。
+      final String? coverUrl = plan.coverUrl;
+      if (coverUrl != null && coverUrl.isNotEmpty) {
+        try {
+          final Directory covers = collectionCoversDirectory ??
+              await VideoStorage.collectionCoversDir();
+          final String? collectionCoverPath = await downloadVideoCoverToPath(
+            coverUrl: coverUrl,
+            outputPath: p.join(
+              covers.path,
+              videoCoverFileName('${result.collectionId}'),
+            ),
+            httpClient: httpClient,
+          );
+          if (collectionCoverPath != null) {
+            await db.updateMediaCollectionCoverPath(
+              result.collectionId,
+              collectionCoverPath,
+            );
+          }
+        } catch (_) {}
+      }
+
+      // ② 首集抽帧缩略图 → 首集条目封面 + coverSource 借用链兜底。
       try {
         final String firstUid = result.episodeUids.first;
-        String? coverPath;
-        final String? coverUrl = plan.coverUrl;
-        if (coverUrl != null && coverUrl.isNotEmpty) {
-          final Directory covers = await AppPaths.videoCoversDirectory();
-          coverPath = await downloadVideoCoverToPath(
-            coverUrl: coverUrl,
-            outputPath: p.join(covers.path, videoCoverFileName(firstUid)),
-          );
-        }
-        coverPath ??= await extractVideoCover(
+        final String? framePath = await extractVideoCover(
           videoPath: sorted.first,
           bookUid: firstUid,
         );
-        if (coverPath != null) {
-          await repo.updateCover(firstUid, coverPath);
+        if (framePath != null) {
+          await repo.updateCover(firstUid, framePath);
           // ⚠️ 唯一落库点：MediaCollections.coverSource 持久化 'video|<uid>'，
           // compositeKey 生成串与历史手写插值逐字节一致。
           await db.updateMediaCollectionCover(

--- a/hibiki/lib/src/media/video/scraper/collection_member_policy.dart
+++ b/hibiki/lib/src/media/video/scraper/collection_member_policy.dart
@@ -1,0 +1,34 @@
+/// 合集子篇判据（用户 2026-08-02：「刮削的时候，子篇会刮削成和合集封面一样竖的
+/// 那种。取消这个设定」）。
+///
+/// 作品级竖版海报只属于**合集自有封面**（`MediaCollections.coverPath`）；成员数
+/// ≥2 的合集里的每一集（子篇）在任何**自动**路径下都不落作品海报——封面保持抽帧
+/// 缩略图或集级剧照（`EpisodeScrapeService` 的 TMDB 剧照），两者都没有就保持无
+/// 封面，不拿作品海报凑数。单片（独立条目或单成员合集）不受影响。用户在弹窗里
+/// 亲手匹配（`applyCandidateToBooks` → userScraped）永远放行，不经此判据。
+library;
+
+import 'package:hibiki_core/hibiki_core.dart'
+    show MediaCollectionItemRow, MediaKind;
+
+/// 从全库合集成员表算出「合集子篇」视频 uid 集合：条目属于任一**成员数 ≥2** 的
+/// 合集即视为子篇。成员数按合集全部成员计、不分媒体种类——混编合集（视频 + 书）
+/// 里的视频集同样是某个多成员容器的一员，作品海报同样该落容器不落成员。
+///
+/// 纯函数、无 IO、输入序无关；输入取 `HibikiDatabase.getAllCollectionItems()`
+/// 一次全量（消 N+1，与该查询的注释口径一致）。
+Set<String> videoUidsInMultiMemberCollections(
+  List<MediaCollectionItemRow> items,
+) {
+  final Map<int, int> memberCountByCollection = <int, int>{};
+  for (final MediaCollectionItemRow item in items) {
+    memberCountByCollection[item.collectionId] =
+        (memberCountByCollection[item.collectionId] ?? 0) + 1;
+  }
+  return <String>{
+    for (final MediaCollectionItemRow item in items)
+      if (item.mediaType == MediaKind.video.dbValue &&
+          memberCountByCollection[item.collectionId]! >= 2)
+        item.entryKey,
+  };
+}

--- a/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
@@ -326,12 +326,24 @@ class CoverScraperService {
   /// [rescrapeScraped] 只解锁「要不要覆盖**自动**刮来的旧结果」，它**不是**
   /// 「覆盖一切」——用户亲手选定的封面（[CoverOrigin.userScraped]，见
   /// [applyCandidateToBooks]）在任何开关下都不会被动（BUG-1325）。
+  ///
+  /// 合集子篇（成员数 ≥2 的合集成员，判据 `videoUidsInMultiMemberCollections`）
+  /// 在本层**一律不落封面**、任何开关都解不开——作品级竖版海报只属于合集自有
+  /// 封面（[applyCandidateToCollection]），子篇封面保持抽帧缩略图或集级剧照
+  /// （EpisodeScrapeService），两者都没有就保持无封面（用户 2026-08-02）。子篇
+  /// 与受保护封面走同一条「只刮资料不碰封面」路径、不改既有 cover_meta；用户在
+  /// 弹窗亲手匹配（[applyCandidateToBooks]）与集级剧照不经此闸。
   Stream<BatchScrapeProgress> scrapeLibrary(
     List<VideoBookRow> books, {
     bool rescrapeScraped = false,
   }) async* {
     final Map<String, _ResolvedMatch> decisionCache =
         <String, _ResolvedMatch>{};
+    // 合集子篇集合每批取一次（全量单查询，消 N+1）；含 sidecar 在内的整条
+    // scrapeOne 封面流水线对子篇都不放行——目录级 poster.jpg 刷满整季与在线
+    // 海报同症（Kodi/Jellyfin 生态单集图约定是 -thumb 而非 -poster，此处
+    // 整体跳过实际不损失单集 sidecar）。
+    final Set<String> collectionEpisodes = await _repo.collectionEpisodeUids();
     for (int i = 0; i < books.length; i++) {
       final VideoBookRow book = books[i];
       ScrapeOutcome outcome;
@@ -342,13 +354,14 @@ class CoverScraperService {
           final CoverMeta? meta = await _coverMeta.get(book.bookUid);
           final CoverOrigin origin = meta?.origin ?? CoverOrigin.autoFrame;
           final CoverOverwritePolicy policy = origin.batchOverwritePolicy;
-          final bool allowed = switch (policy) {
-            CoverOverwritePolicy.free => true,
-            CoverOverwritePolicy.rescrapeOnly ||
-            CoverOverwritePolicy.legacyStrict =>
-              rescrapeScraped,
-            CoverOverwritePolicy.never => false,
-          };
+          final bool allowed = !collectionEpisodes.contains(book.bookUid) &&
+              switch (policy) {
+                CoverOverwritePolicy.free => true,
+                CoverOverwritePolicy.rescrapeOnly ||
+                CoverOverwritePolicy.legacyStrict =>
+                  rescrapeScraped,
+                CoverOverwritePolicy.never => false,
+              };
           if (!allowed) {
             outcome = ScrapeSkippedProtected(origin);
             // 封面受保护 ≠ 条目资料也不要。手动设过封面、或目录里有 poster.jpg

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -10,6 +10,8 @@ import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/media/video/external_video.dart'
     show normalizeVideoPath;
 import 'package:hibiki/src/media/video/m3u8_playlist.dart' show PlaylistEntry;
+import 'package:hibiki/src/media/video/scraper/collection_member_policy.dart'
+    show videoUidsInMultiMemberCollections;
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart'
     show ScrapeInfoboxEntry, ScrapeMetadata, ScrapeSource, ScrapeTag;
 import 'package:hibiki/src/media/video/video_path_migration.dart';
@@ -338,6 +340,11 @@ class VideoBookRepository {
   /// 统一合集：某合集的成员引用行（按 sortIndex 有序）。播放器据此建播放列表兄弟集。
   Future<List<MediaCollectionItemRow>> getCollectionItems(int collectionId) =>
       _db.getCollectionItems(collectionId);
+
+  /// 合集子篇 uid 集合：属于任一**成员数 ≥2** 合集的视频条目。自动刮削据此对
+  /// 子篇**不落作品级海报**（判据与理由见 [videoUidsInMultiMemberCollections]）。
+  Future<Set<String>> collectionEpisodeUids() async =>
+      videoUidsInMultiMemberCollections(await _db.getAllCollectionItems());
 
   /// 统一合集：按 id 取合集（播放器取 playlist 合集名做制卡 documentTitle 系列名）。
   Future<MediaCollectionRow?> getMediaCollectionById(int id) =>

--- a/hibiki/test/media/video/scraper/collection_member_cover_gate_test.dart
+++ b/hibiki/test/media/video/scraper/collection_member_cover_gate_test.dart
@@ -1,0 +1,198 @@
+/// 合集子篇封面闸测试（用户 2026-08-02：多集合集成员不得被自动刮成作品级海报）。
+///
+/// 覆盖四条：① 多集合集成员批量自动刮削不落海报（资料照刮、cover_meta 不动）；
+/// ② 单片（无合集）照旧自动落海报；③ 单成员合集照旧；④ 用户手动匹配
+/// （applyCandidateToBooks）对子篇永远放行。
+library;
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/alias_cache.dart';
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
+import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
+import 'package:hibiki/src/media/video/scraper/offline_index.dart';
+import 'package:hibiki/src/media/video/scraper/cover_downloader.dart';
+import 'package:hibiki/src/media/video/scraper/cover_scraper_service.dart';
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:path/path.dart' as p;
+
+/// 最小合法 PNG 魔数字节。
+final List<int> _fakePng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x01, 0x02, 0x03,
+];
+
+MockClient _pngClient() => MockClient((http.Request req) async {
+      return http.Response.bytes(
+        _fakePng,
+        200,
+        headers: const <String, String>{'content-type': 'image/png'},
+      );
+    });
+
+void main() {
+  // 刮削落盘点走 evictLocalCoverCache（需要 PaintingBinding）。
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late HibikiDatabase db;
+  late VideoBookRepository repo;
+  late Directory tmp;
+  late CoverMetaStore coverMeta;
+  late AliasCache aliasCache;
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    repo = VideoBookRepository(db);
+    tmp = await Directory.systemTemp.createTemp('member_cover_gate_');
+    coverMeta = CoverMetaStore(tmp);
+    aliasCache = AliasCache(tmp);
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  Future<VideoBookRow> seed({
+    required String bookUid,
+    required String videoPath,
+  }) async {
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: Value(bookUid),
+      title: Value(bookUid),
+      videoPath: Value(videoPath),
+    ));
+    return (await db.getVideoBookByBookUid(bookUid))!;
+  }
+
+  /// 「进击的巨人」离线库唯一精确命中记录（打分恒 high）。
+  OfflineIndex offline() => OfflineIndex(const <OfflineAnimeRecord>[
+        OfflineAnimeRecord(
+          title: '进击的巨人',
+          synonyms: <String>['Attack on Titan'],
+          type: ScrapeEntryType.tv,
+          episodes: 25,
+          year: 2013,
+          picture: 'https://img/aot.png',
+          sourceId: 'myanimelist.net/anime/16498',
+        ),
+      ]);
+
+  CoverScraperService build() => CoverScraperService(
+        repository: repo,
+        coverMetaStore: coverMeta,
+        aliasCache: aliasCache,
+        bangumiClient: BangumiClient(
+          client: MockClient(
+            (http.Request req) async => http.Response(
+              '{"data":[]}',
+              200,
+              headers: const <String, String>{
+                'content-type': 'application/json',
+              },
+            ),
+          ),
+        ),
+        coverDownloader: CoverDownloader(client: _pngClient()),
+        offlineIndex: offline(),
+        enableSidecar: false,
+        coversDirectory: tmp,
+      );
+
+  test('多集合集成员批量自动刮削：不落海报、不写 cover_meta、资料照刮', () async {
+    final VideoBookRow ep1 = await seed(
+      bookUid: 'video/ep1',
+      videoPath: p.join('anime', '进击的巨人', '进击的巨人 - 01.mkv'),
+    );
+    final VideoBookRow ep2 = await seed(
+      bookUid: 'video/ep2',
+      videoPath: p.join('anime', '进击的巨人', '进击的巨人 - 02.mkv'),
+    );
+    final int cid =
+        await db.createMediaCollection('进击的巨人', collectionType: 'playlist');
+    await db.addToCollection(cid, MediaKind.video, 'video/ep1');
+    await db.addToCollection(cid, MediaKind.video, 'video/ep2');
+
+    final List<BatchScrapeProgress> progress =
+        await build().scrapeLibrary(<VideoBookRow>[ep1, ep2]).toList();
+
+    for (final BatchScrapeProgress pr in progress) {
+      expect(pr.outcome, isA<ScrapeSkippedProtected>(),
+          reason: '子篇封面被闸住，走「只刮资料」路径');
+    }
+    for (final String uid in <String>['video/ep1', 'video/ep2']) {
+      final VideoBookRow row = (await db.getVideoBookByBookUid(uid))!;
+      expect(row.coverPath, isNull, reason: '子篇条目不落作品海报');
+      expect(await coverMeta.get(uid), isNull,
+          reason: '自动路径跳过时不得篡改/新增 cover_meta');
+      expect(await repo.scrapeMetadata(uid), isNotNull,
+          reason: '条目资料（简介/评分等）照刮不受影响');
+    }
+  });
+
+  test('单片（无合集）照旧自动落海报', () async {
+    final VideoBookRow solo = await seed(
+      bookUid: 'video/solo',
+      videoPath: p.join('anime', '进击的巨人', '进击的巨人 - 04.mkv'),
+    );
+    final List<BatchScrapeProgress> progress =
+        await build().scrapeLibrary(<VideoBookRow>[solo]).toList();
+    expect(progress.single.outcome, isA<ScrapeApplied>());
+    final VideoBookRow row = (await db.getVideoBookByBookUid('video/solo'))!;
+    expect(row.coverPath, isNotNull);
+    expect(File(row.coverPath!).existsSync(), isTrue);
+  });
+
+  test('单成员合集视为单片：照旧自动落海报', () async {
+    final VideoBookRow single = await seed(
+      bookUid: 'video/single',
+      videoPath: p.join('anime', '进击的巨人', '进击的巨人 - 05.mkv'),
+    );
+    final int cid =
+        await db.createMediaCollection('单成员', collectionType: 'collection');
+    await db.addToCollection(cid, MediaKind.video, 'video/single');
+
+    final List<BatchScrapeProgress> progress =
+        await build().scrapeLibrary(<VideoBookRow>[single]).toList();
+    expect(progress.single.outcome, isA<ScrapeApplied>());
+    expect(
+        (await db.getVideoBookByBookUid('video/single'))!.coverPath, isNotNull);
+  });
+
+  test('用户手动匹配（applyCandidateToBooks）对子篇永远放行', () async {
+    await seed(
+      bookUid: 'video/ep1',
+      videoPath: p.join('anime', '进击的巨人', '进击的巨人 - 01.mkv'),
+    );
+    await seed(
+      bookUid: 'video/ep2',
+      videoPath: p.join('anime', '进击的巨人', '进击的巨人 - 02.mkv'),
+    );
+    final int cid =
+        await db.createMediaCollection('进击的巨人', collectionType: 'playlist');
+    await db.addToCollection(cid, MediaKind.video, 'video/ep1');
+    await db.addToCollection(cid, MediaKind.video, 'video/ep2');
+
+    await build().applyCandidateToBooks(
+      bookUids: <String>['video/ep1'],
+      candidate: const ScrapeCandidate(
+        source: ScrapeSource.offlineDb,
+        entryId: 'myanimelist.net/anime/16498',
+        title: '进击的巨人',
+        posterUrl: 'https://img/aot.png',
+      ),
+    );
+
+    final VideoBookRow row = (await db.getVideoBookByBookUid('video/ep1'))!;
+    expect(row.coverPath, isNotNull, reason: '用户亲手拍板不经子篇闸');
+    final CoverMeta? meta = await coverMeta.get('video/ep1');
+    expect(meta!.origin, CoverOrigin.userScraped);
+  });
+}

--- a/hibiki/test/media/video/scraper/collection_member_policy_test.dart
+++ b/hibiki/test/media/video/scraper/collection_member_policy_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/collection_member_policy.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+MediaCollectionItemRow _item(int collectionId, String mediaType, String key) =>
+    MediaCollectionItemRow(
+      collectionId: collectionId,
+      mediaType: mediaType,
+      entryKey: key,
+      sortIndex: 0,
+    );
+
+void main() {
+  group('videoUidsInMultiMemberCollections（合集子篇判据）', () {
+    test('成员数 ≥2 合集的视频成员判为子篇；单成员合集不判', () {
+      final Set<String> uids = videoUidsInMultiMemberCollections(
+        <MediaCollectionItemRow>[
+          // 双成员 playlist：两集都是子篇。
+          _item(1, 'video', 'video/ep1'),
+          _item(1, 'video', 'video/ep2'),
+          // 单成员合集：单片，可照旧刮海报。
+          _item(2, 'video', 'video/solo'),
+        ],
+      );
+      expect(uids, <String>{'video/ep1', 'video/ep2'});
+    });
+
+    test('混编合集按全部成员计数，非 video 成员不进结果', () {
+      final Set<String> uids = videoUidsInMultiMemberCollections(
+        <MediaCollectionItemRow>[
+          // 视频 + 书混编：合集有 2 个成员，视频成员是子篇；书成员不属视频域。
+          _item(3, 'video', 'video/mixed'),
+          _item(3, 'epub', 'book/one'),
+        ],
+      );
+      expect(uids, <String>{'video/mixed'});
+    });
+
+    test('空输入 → 空集合', () {
+      expect(
+        videoUidsInMultiMemberCollections(const <MediaCollectionItemRow>[]),
+        isEmpty,
+      );
+    });
+
+    test('同条目跨多个合集：任一合集成员数 ≥2 即判子篇', () {
+      final Set<String> uids = videoUidsInMultiMemberCollections(
+        <MediaCollectionItemRow>[
+          _item(4, 'video', 'video/both'), // 单成员合集
+          _item(5, 'video', 'video/both'), // 双成员合集
+          _item(5, 'video', 'video/other'),
+        ],
+      );
+      expect(uids, contains('video/both'));
+    });
+  });
+}

--- a/hibiki/test/torrent/anime_download_importer_test.dart
+++ b/hibiki/test/torrent/anime_download_importer_test.dart
@@ -1,0 +1,118 @@
+/// 番剧下载入库封面测试（用户 2026-08-02：作品海报只落合集自有封面，不借道
+/// 首集条目——多集合集的子篇不得顶着作品级竖版海报）。
+library;
+
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/torrent/anime_download_importer.dart';
+import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
+import 'package:hibiki/src/media/torrent/anime_download_service.dart'
+    show AnimeDownloadImportOutcome;
+import 'package:hibiki/src/media/video/video_cover_extractor.dart'
+    show videoCoverFileName;
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:path/path.dart' as p;
+
+/// 最小合法 PNG 魔数字节。
+final List<int> _fakePng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x01, 0x02, 0x03,
+];
+
+AnimeDownloadPlan _plan({String? coverUrl}) => AnimeDownloadPlan(
+      id: 'plan-1',
+      createdAtMs: 0,
+      seriesTitle: '某番剧',
+      torrentTitle: '[组] 某番剧 01-02',
+      magnet: 'magnet:?xt=urn:btih:deadbeef',
+      qbCategory: 'hibiki',
+      anilistId: 42,
+      coverUrl: coverUrl,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late HibikiDatabase db;
+  late Directory tmp;
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    tmp = await Directory.systemTemp.createTemp('anime_dl_importer_');
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  test('作品海报落合集自有封面 coverPath，成员条目一张海报都不沾', () async {
+    final Future<AnimeDownloadImportOutcome?> Function(
+      AnimeDownloadPlan,
+      List<String>,
+    ) importer = buildAnimeDownloadImporter(
+      db,
+      httpClient: MockClient(
+        (http.Request req) async => http.Response.bytes(_fakePng, 200),
+      ),
+      collectionCoversDirectory: tmp,
+    );
+
+    final AnimeDownloadImportOutcome? outcome = await importer(
+      _plan(coverUrl: 'https://img.anili.st/poster.jpg'),
+      <String>[
+        p.join('D:', 'dl', '某番剧 - 01.mkv'),
+        p.join('D:', 'dl', '某番剧 - 02.mkv'),
+      ],
+    );
+
+    expect(outcome, isNotNull);
+    final MediaCollectionRow col =
+        (await db.getMediaCollectionById(outcome!.collectionId))!;
+    final String expectedCover =
+        p.join(tmp.path, videoCoverFileName('${outcome.collectionId}'));
+    expect(col.coverPath, expectedCover, reason: '海报直落合集自有封面列');
+    expect(File(expectedCover).existsSync(), isTrue);
+
+    // 成员条目（含首集）不落作品海报——测试环境抽帧不可用，封面应保持 null，
+    // 而绝不是那张下载成功了的海报。
+    final List<MediaCollectionItemRow> items =
+        await db.getCollectionItems(outcome.collectionId);
+    expect(items, hasLength(2));
+    for (final MediaCollectionItemRow item in items) {
+      final VideoBookRow book =
+          (await db.getVideoBookByBookUid(item.entryKey))!;
+      expect(book.coverPath, isNull, reason: '子篇条目封面只能是抽帧/剧照，绝不是作品海报');
+    }
+
+    // AniList 绑定照旧。
+    expect(col.anilistId, 42);
+  });
+
+  test('无海报 URL：合集 coverPath 保持空，不误写', () async {
+    final Future<AnimeDownloadImportOutcome?> Function(
+      AnimeDownloadPlan,
+      List<String>,
+    ) importer = buildAnimeDownloadImporter(
+      db,
+      httpClient: MockClient(
+        (http.Request req) async => http.Response.bytes(_fakePng, 200),
+      ),
+      collectionCoversDirectory: tmp,
+    );
+
+    final AnimeDownloadImportOutcome? outcome = await importer(
+      _plan(),
+      <String>[p.join('D:', 'dl', '某番剧 - 01.mkv')],
+    );
+
+    expect(outcome, isNotNull);
+    final MediaCollectionRow col =
+        (await db.getMediaCollectionById(outcome!.collectionId))!;
+    expect(col.coverPath, isNull);
+  });
+}


### PR DESCRIPTION
## 背景（用户 2026-08-02 反馈）

「刮削的时候，子篇会刮削成和合集封面一样竖的那种。取消这个设定。要是这样的话，不如不刮削封面。」——多集合集的每一集被自动刮上与合集封面相同的作品级竖版海报。期望：作品海报只属于合集封面；成员条目保持抽帧缩略图或集级剧照（EpisodeScrapeService 剧照路径不受影响）；两者都没有就保持无封面。

## 海报写入成员封面的全部入口盘点与处置

| 入口 | 现状 | 处置 |
|---|---|---|
| `CoverScraperService.scrapeLibrary`（后台自动刮 `VideoScrapeAutoService` + 页头「全部刮削」共用收口） | 高置信自动落海报到每个成员；sidecar 目录级 `poster.jpg` 同症 | **加闸**：子篇一律不落封面，复用既有受保护封面的「只刮资料不碰封面」路径（outcome 复用 `ScrapeSkippedProtected`，不新增 sealed 子类、不破坏消费方 switch）；不改既有 cover_meta；`rescrapeScraped` 开关也解不开 |
| `scrapeOne` 直接调用 | lib 内无 `scrapeLibrary` 以外调用方（已核） | 不需单独处理 |
| `anime_download_importer`（AniList 海报） | 海报落**首集条目封面**，合集 coverSource 借道指向首集 | **根因改法**：海报直落合集自有封面 `MediaCollections.coverPath`（`video_covers/collections/<id>.jpg`，与 `applyCandidateToCollection` 同约定，gcOrphanCovers 非递归天然免疫）；首集只抽帧 + 保留 coverSource 借用链兜底（海报下载失败回落首集抽帧，展示链 coverPath 优先 → coverSource 已核 `home_video_page` 合集卡） |
| `applyCandidateToBooks`（弹窗手动匹配） | 用户亲手拍板（userScraped） | **保留放行**（加测试钉住） |
| `EpisodeScrapeService`（TMDB 集级剧照） | 集级图 | 不动 |
| `applyCandidateToCollection` / `collection_scrape_apply` | 已只写合集自己（BUG-1211/1310） | 不动 |
| 抽帧路径（import dialog / source_library_scanner / extractPlaylistCover） | 抽帧非海报 | 不动 |

## 判据

纯函数 `videoUidsInMultiMemberCollections(List<MediaCollectionItemRow>)`（`collection_member_policy.dart`）：条目属于任一**成员数 ≥2** 的合集即视为子篇；成员数按合集全部成员计（混编合集同判）。单片（独立条目或单成员合集）不受影响照旧刮海报。仓库层 `VideoBookRepository.collectionEpisodeUids()` 每批一次全量查询（`getAllCollectionItems`，消 N+1）。

注：判据按任务书口径不区分 collectionType（playlist / 手动收藏合集同判）——手动把多部独立电影收进一个合集的场景也会被闸，此时单条目手动匹配仍可用。

## 测试（VERDICT 判绿）

- `collection_member_policy_test.dart`：判据纯函数 4 条（≥2 判子篇 / 单成员不判 / 混编计数 / 跨合集任一命中）
- `collection_member_cover_gate_test.dart`：①多集成员批量自动刮不落海报、不写 cover_meta、资料照刮 ②单片照旧 ③单成员合集照旧 ④手动匹配对子篇放行（userScraped）
- `anime_download_importer_test.dart`：海报落合集 coverPath 而非首集条目（成员封面 null）；无 URL 不误写
- **变异实测**：临时移除 `!collectionEpisodes.contains(...)` 闸 → 闸门测试红（1 error）→ 反向还原复绿

```
flutter analyze: No issues found! (ran in 37.7s)
FLUTTER TEST VERDICT: PASSED - 512 tests ran, all tests passed   (test/media/video/scraper + test/torrent)
```

## 存量现状与恢复途径（不做自动迁移）

已被历史行为刮成海报的子篇封面**保持原样**（用户未要求迁移，不扩大范围）。手动恢复：单条目长按/右键菜单的「重新抽帧」入口重抽缩略图，或删除条目封面后重导；合集封面本身不受影响。

## 范围说明

任务书写的 `media/video/anime_download_importer.dart` 实际位于 `media/torrent/`；它是本任务点名的指定修改对象，故「torrent 域禁碰」按 torrent 引擎/后端/对话框（backend、nyaa、qb、anime_download_dialog 等）理解，均未触碰。禁碰四页面文件（home_video_page / media_collection_detail_page / video_episode_rail / anime_download_dialog）零改动——闸门放在 service 层，页头「全部刮削」挂点自然生效。