### PR TITLE
fix(home): 活动时间轴按稳定媒体身份聚合 + 扫描首导 playlist 记 added 事件 (BUG-1350/1351)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1293 条。点号进各自文件。
+> 共 1295 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1351](bugs/BUG-1351-scan-playlist-import-no-added-activity.md) | ✅ | ✅ | 扫描导入新播放列表合集不落 added 活动事件 |
+| [BUG-1350](bugs/BUG-1350-dashboard-activity-cross-series-merge.md) | ✅ | ✅ | 首页活动时间轴同日同集号跨作品被合并吞掉观看记录 |
 | [BUG-1345](bugs/BUG-1345-gal-ipc-contract-host-copy-drift.md) | ✅ | ✅ | galgame 捕获报「捕获组件版本与 Hibiki 不一致」：IPC 契约在 host 侧有手抄副本，且处置指向已不存在的动作 |
 | [BUG-1341](bugs/BUG-1341-mihon-detail-layout.md) | ✅ | ✅ | Mihon 漫画详情页路由触发布局断言 |
 | [BUG-1340](bugs/BUG-1340-mihon-extension-catalog-restart.md) | ✅ | ✅ | 漫画扩展重启后可下载目录消失且无法安装新扩展 |

--- a/docs/bugs/BUG-1350-dashboard-activity-cross-series-merge.md
+++ b/docs/bugs/BUG-1350-dashboard-activity-cross-series-merge.md
@@ -1,0 +1,6 @@
+## BUG-1350 · 首页活动时间轴同日同集号跨作品被合并吞掉观看记录
+- **报告**：2026-08-02（用户：首页的活动没有跟进——当天实机看过的合集（已看 1 集）在活动时间轴上不出现）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/activity_feed.dart:121-122`（修前行号）：`aggregateActivityEvents` 的分组键是 `(设备, dateKey, eventType, title)`，其中 title 是落库时的**显示快照**。统一合集 Phase 2 拆集后，每集 VideoBook 的 title 是裸集号（`S01E01`），同一天看两部不同作品的同集号会被合并成一条；条目 `mediaKey` 取组内最晚事件 → 先看那部的观看在时间轴上整条消失。生产库实锤 3 次（2026-07-23 / 07-28 / 07-31）：07-31 用户先看 Seven Mortal Sins S01E01（3 个 session，共约 3.5 分钟）再看 Tensei Oujo S01E01（3 个 session），6 行合成一条、身份被 Tensei 占据，Seven Mortal Sins（用户截图里「已看 1 集」的那部）在活动流上不可见。写入端（`VideoWatchTracker.stop` → `addActivityEvent`）经生产库核对**完好**：活动行与 `video_watch_statistics` 逐日吻合。
+- **[x] ① 已修复** — 分组身份改为 `(设备, dateKey, eventType, mediaType, mediaKey??title)`：mediaKey（书=bookKey / 视频=bookUid / 游戏=id）是稳定媒体身份，优先于 title 快照；无 mediaKey 的老行 / 旧 host 远端行回退 title（生产库核对：无「同组混 null 与非 null mediaKey」的数据）。附带收益：同媒体改名后 title 快照不同的多 session 现在正确合并；同名跨 mediaType 不再互并。提交：见本分支。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/activity_feed_test.dart`：①复刻 07-31 真实数据形状（同日同 `S01E01` 两 mediaKey → 两条、各自身份/时长不互吞）；②同 mediaKey 改名快照仍合并（sessionCount=2）；③无 mediaKey 回退 title 合并；④同名同类型跨 mediaType 不合并。
+- **备注**：并发根因 BUG-1351（扫描导入不落 added 事件）同轮修复；番剧下载导入不落 added 事件在并行线文件域内，另行移交（见回报）。

--- a/docs/bugs/BUG-1351-scan-playlist-import-no-added-activity.md
+++ b/docs/bugs/BUG-1351-scan-playlist-import-no-added-activity.md
@@ -1,0 +1,6 @@
+## BUG-1351 · 扫描导入新播放列表合集不落 added 活动事件
+- **真实性**：✅ 真 bug（对「以 m3u8 清单库扫描为主导入路径」的用户，入库在首页活动时间轴上完全不可见）。根因 `hibiki/lib/src/media/source_library/source_library_scanner.dart:743-748`（修前行号）：`_importPlaylists` 首导新 playlist 合集走 `importSplitPlaylist` 后不调 `VideoBookRepository.recordVideoImportActivity`——该方法按 `video_book_repository.dart:129-135` 的旧契约只由 `VideoImportDialog` 调用，「自动库扫描批量、避免刷屏」被一刀切成全静默。生产库证据：2026-07-31 用户把新 m3u8 放进扫描根导入 Seven Mortal Sins 52 集（合集 75，命名=清单 basename，与 `_importPlaylists` 的命名唯一吻合；该目录不是任何登记扫描根之外的对话框导入，且对话框各路径均有 emit），activity_events 里视频 added 事件全库为 0 条。
+- **报告**：2026-08-02（用户：首页的活动没有跟进——含最近入库不出现）
+- **[x] ① 已修复** — `_importPlaylists` 首导分支（`existingPlaylistIds` 记账后）补调 `recordVideoImportActivity(bookUid=首集 uid, title=合集名)`，与对话框/拖拽导入同粒度（整本 1 条）；重扫走 reconcile 分支天然不 emit；散装单视频扫描保持静默（首扫可达数百文件，逐条 emit 才是原契约担心的刷屏）。同步更新 `video_book_repository.dart` 的方法契约注释。提交：见本分支。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/source_library/source_library_scanner_test.dart`（TODO-1237 组）：①首导 1 个 playlist 合集断言恰 1 条 added 事件（title=合集名、mediaKey=首集 uid）；②重扫 reconcile 不重复 emit（仍 1 条）；③散装单视频扫描零事件（守住不刷屏边界）。
+- **备注**：姊妹缺口——番剧下载完成自动入库（`anime_download_importer.dart:41-96`）同样不 emit（07-29 入库 13 集零事件），该文件被并行线独占，停在诊断移交（见回报）。显示层同轮修 BUG-1350。

--- a/hibiki/lib/src/media/source_library/source_library_scanner.dart
+++ b/hibiki/lib/src/media/source_library/source_library_scanner.dart
@@ -749,6 +749,17 @@ class SourceLibraryScanner {
         // 记入 map：同一次扫描里遇到第二个同名清单时走 reconcile，不再重导致重复。
         existingPlaylistIds[collectionName] = result.collectionId;
 
+        // BUG-1351：扫描首导的新 playlist 合集也是用户入库（用户把新清单放进扫描根
+        // 再扫描——对常用 m3u8 清单库的用户这就是主导入路径），整本记 1 条 added
+        // 活动事件（title=合集名、mediaKey=首集 uid，与对话框 / 拖拽导入同粒度）。
+        // 重扫走上面的 reconcile 分支天然不 emit；散装单视频扫描仍保持静默（首扫可
+        // 达数百文件，逐条 emit 才是刷屏）。best-effort：方法内自捕获异常，只 log
+        // 不影响导入。
+        await _videoRepo.recordVideoImportActivity(
+          bookUid: result.episodeUids.first,
+          title: collectionName,
+        );
+
         // TODO-1237 ①: cover from the first USABLE episode (local ffmpeg only),
         // applied to the first episode row; mobile / any failure -> null cover,
         // never aborts the scan.

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -126,14 +126,15 @@ class VideoBookRepository {
     return out;
   }
 
-  /// v49：记录一条「added」活动事件，喂首页 Activity 时间轴。**只在用户明示导入
-  /// 视频成功后**由 [VideoImportDialog] 显式调用（单文件 / 文件夹单集 / 播放列表首集 /
-  /// 流媒体各调一次；播放列表整本只调一次，title=合集名、mediaKey=首集 uid）——刻意
-  /// **不放进 [saveVideoBook]**，让自动库扫描（source_library_scanner，批量）、远端打开
-  /// （home_video_page，打开≠导入）、云同步（app_model_library_host_service）等非明示
-  /// 导入路径天然不 emit，避免刷屏或语义错误（对齐 EpubImporter 只在用户导入管线
-  /// emit 的做法）。timestamp/dateKey 用调用时刻。best-effort：记账失败只 log，不影响
-  /// 视频已导入。
+  /// v49：记录一条「added」活动事件，喂首页 Activity 时间轴。**只在用户导入视频
+  /// 成功后**调用：[VideoImportDialog] 各路径（单文件 / 文件夹单集 / 播放列表首集 /
+  /// 流媒体各调一次；播放列表整本只调一次，title=合集名、mediaKey=首集 uid），以及
+  /// 扫描首导的新 playlist 合集（source_library_scanner，BUG-1351：用户把新清单放进
+  /// 扫描根就是入库动作，整本 1 条；重扫 reconcile 不 emit）——刻意**不放进
+  /// [saveVideoBook]**，让散装文件批量扫描、远端打开（home_video_page，打开≠导入）、
+  /// 云同步（app_model_library_host_service）等路径天然不 emit，避免刷屏或语义错误
+  /// （对齐 EpubImporter 只在用户导入管线 emit 的做法）。timestamp/dateKey 用调用
+  /// 时刻。best-effort：记账失败只 log，不影响视频已导入。
   Future<void> recordVideoImportActivity({
     required String bookUid,
     required String title,

--- a/hibiki/lib/src/pages/implementations/activity_feed.dart
+++ b/hibiki/lib/src/pages/implementations/activity_feed.dart
@@ -102,9 +102,15 @@ class ActivityDateGroup {
 
 /// 纯函数：把事件流聚合成「按日期倒序分组、每组内条目按最近时刻倒序」的时间线。
 ///
-/// 分组键 = (dateKey, title, eventType)。同键事件合并：时长/字数求和；session 数按
-/// [sessionGap] 归并；latestTimestampMs 取最大。added 事件无时长，session 数按同样
-/// 归并（通常 1）。输入不要求有序。
+/// 分组键 = (设备, dateKey, eventType, mediaType, mediaKey??title)。同键事件合并：
+/// 时长/字数求和；session 数按 [sessionGap] 归并；latestTimestampMs 取最大。added
+/// 事件无时长，session 数按同样归并（通常 1）。输入不要求有序。
+///
+/// BUG-1350：合并身份必须优先 mediaKey（书=bookKey / 视频=bookUid / 游戏=id）——
+/// title 只是落库时的显示快照，拆集后的视频行标题是裸集号（`S01E01`），同日看两部
+/// 不同作品的第一集会被 title 键错误合并成一条、mediaKey 取最晚事件，先看的那部在
+/// 时间轴上整条消失。老行 / 远端旧 host 行无 mediaKey 时回退 title（真实数据里同组
+/// 不混 null 与非 null——同一媒体同一天的行来自同一写入端）。
 List<ActivityDateGroup> aggregateActivityEvents(
   List<ActivityEventRow> events, {
   Duration sessionGap = kActivitySessionGap,
@@ -118,8 +124,8 @@ List<ActivityDateGroup> aggregateActivityEvents(
     // 设备来源进分组键：互联对端事件与本机事件**不合并**（provenance 优先——
     // 标明设备来源后混并无法归属），各自成条各带标签。分隔符沿用 NUL（标题可含任意可见字符）。
     final String? device = sourceDeviceOf?.call(e);
-    final String key =
-        '${device ?? ''}\u0000${e.dateKey}\u0000${e.eventType}\u0000${e.title}';
+    final String key = '${device ?? ''}\u0000${e.dateKey}\u0000${e.eventType}'
+        '\u0000${e.mediaType}\u0000${e.mediaKey ?? e.title}';
     (byKey[key] ??= <ActivityEventRow>[]).add(e);
     deviceByKey[key] = device;
   }

--- a/hibiki/test/media/source_library/source_library_scanner_test.dart
+++ b/hibiki/test/media/source_library/source_library_scanner_test.dart
@@ -626,6 +626,16 @@ ep2.mp4
       final SourceLibraryRow after = (await db.getMediaSourceById(sid))!;
       expect(after.mediaCount, 1, reason: '1 个 playlist 合集导入');
       expect(after.lastScanError, isNull);
+
+      // BUG-1351：扫描首导的新 playlist 合集要落 1 条 added 活动事件（整本一条，
+      // title=合集名、mediaKey=首集 uid），喂首页 Activity 时间轴。
+      final List<ActivityEventRow> events =
+          await db.getRecentActivityEvents(limit: 10);
+      expect(events, hasLength(1), reason: '首导 1 个 playlist 合集 = 1 条 added 事件');
+      expect(events.single.eventType, 'added');
+      expect(events.single.mediaType, 'video');
+      expect(events.single.title, 'series');
+      expect(events.single.mediaKey, 'video/ep1');
     });
 
     test('empty / comment-only m3u8 imports nothing (skipped, no error)',
@@ -691,6 +701,11 @@ ep2.mp4
       final SourceLibraryRow afterSrc = (await db.getMediaSourceById(sid))!;
       expect(afterSrc.mediaCount, 0,
           reason: 'second scan reports 0 newly-imported media');
+
+      // BUG-1351 边界：散装单视频扫描保持静默（首扫可达数百文件，逐条 emit 才是
+      // 刷屏）——added 活动事件只给 playlist 合集首导。
+      expect(await db.getRecentActivityEvents(limit: 10), isEmpty,
+          reason: '散装文件扫描不 emit added 事件');
     });
 
     // TODO-1237 ②: re-scanning a folder whose only manifest is a playlist must
@@ -731,6 +746,10 @@ ep2.mp4
       final SourceLibraryRow afterSrc = (await db.getMediaSourceById(sid))!;
       expect(afterSrc.mediaCount, 0,
           reason: 'second scan reports 0 newly-imported playlists');
+
+      // BUG-1351：重扫走 reconcile 分支，不重复 emit added 事件——仍只有首导那 1 条。
+      expect(await db.getRecentActivityEvents(limit: 10), hasLength(1),
+          reason: '重扫不重复记 added 活动事件');
     });
 
     // TODO-1237 ②: the user's real bug — a manifest whose EPISODE PATHS change

--- a/hibiki/test/pages/activity_feed_test.dart
+++ b/hibiki/test/pages/activity_feed_test.dart
@@ -160,6 +160,113 @@ void main() {
           <String>['C', 'B']);
     });
 
+    // BUG-1350：拆集后视频行的 title 是裸集号（S01E01），同日看两部不同作品的
+    // 同集号必须按 mediaKey 分开成两条——旧实现按 title 合并，先看的那部整条消失
+    // （复刻 2026-07-31 真实数据：Seven Mortal Sins S01E01 + Tensei Oujo S01E01）。
+    test('BUG-1350：同日同集号跨作品按 mediaKey 分开，不互吞', () {
+      final int base = DateTime(2026, 7, 31, 21).millisecondsSinceEpoch;
+      final List<ActivityDateGroup> groups =
+          aggregateActivityEvents(<ActivityEventRow>[
+        _ev(
+            eventType: kActivityWatch,
+            mediaType: 'video',
+            title: 'S01E01',
+            mediaKey: 'video/Seven Mortal Sins - S01E01',
+            dateKey: '2026-07-31',
+            timestampMs: base,
+            durationMs: 18718),
+        _ev(
+            eventType: kActivityWatch,
+            mediaType: 'video',
+            title: 'S01E01',
+            mediaKey: 'video/Tensei Oujo - S01E01',
+            dateKey: '2026-07-31',
+            timestampMs: base + const Duration(hours: 2).inMilliseconds,
+            durationMs: 1019979),
+      ]);
+      expect(groups, hasLength(1));
+      final List<ActivityEntry> entries = groups.first.entries;
+      expect(entries, hasLength(2),
+          reason: '不同 mediaKey 不得因 title 同为 S01E01 被合并');
+      // 组内按最近时刻倒序：Tensei（更晚）在前，各自保留自己的身份与时长。
+      expect(entries[0].mediaKey, 'video/Tensei Oujo - S01E01');
+      expect(entries[0].totalDurationMs, 1019979);
+      expect(entries[1].mediaKey, 'video/Seven Mortal Sins - S01E01');
+      expect(entries[1].totalDurationMs, 18718);
+    });
+
+    test('BUG-1350：同 mediaKey 多 session 仍合并（title 快照变化也不拆开）', () {
+      final int base = DateTime(2026, 7, 31, 9).millisecondsSinceEpoch;
+      final List<ActivityDateGroup> groups =
+          aggregateActivityEvents(<ActivityEventRow>[
+        _ev(
+            eventType: kActivityWatch,
+            mediaType: 'video',
+            title: 'S01E01',
+            mediaKey: 'video/X - S01E01',
+            dateKey: '2026-07-31',
+            timestampMs: base,
+            durationMs: 100),
+        _ev(
+            eventType: kActivityWatch,
+            mediaType: 'video',
+            title: 'X 第一集', // 改名后的快照：身份仍是同一 mediaKey
+            mediaKey: 'video/X - S01E01',
+            dateKey: '2026-07-31',
+            timestampMs: base + const Duration(hours: 2).inMilliseconds,
+            durationMs: 200),
+      ]);
+      final List<ActivityEntry> entries = groups.single.entries;
+      expect(entries, hasLength(1), reason: '同一媒体同日合并成一条');
+      expect(entries.single.totalDurationMs, 300);
+      expect(entries.single.sessionCount, 2);
+    });
+
+    test('BUG-1350：无 mediaKey 的老行回退 title 合并（兼容不回退）', () {
+      final int base = DateTime(2026, 7, 18, 9).millisecondsSinceEpoch;
+      final List<ActivityDateGroup> groups =
+          aggregateActivityEvents(<ActivityEventRow>[
+        _ev(
+            eventType: kActivityGame,
+            mediaType: 'game',
+            title: 'G',
+            dateKey: '2026-07-18',
+            timestampMs: base,
+            charsDelta: 10),
+        _ev(
+            eventType: kActivityGame,
+            mediaType: 'game',
+            title: 'G',
+            dateKey: '2026-07-18',
+            timestampMs: base + 60000,
+            charsDelta: 20),
+      ]);
+      expect(groups.single.entries, hasLength(1));
+      expect(groups.single.entries.single.totalChars, 30);
+    });
+
+    test('BUG-1350：同 title 同类型跨 mediaType 不合并', () {
+      final int base = DateTime(2026, 7, 18, 9).millisecondsSinceEpoch;
+      final List<ActivityDateGroup> groups =
+          aggregateActivityEvents(<ActivityEventRow>[
+        _ev(
+            eventType: kActivityAdded,
+            mediaType: 'book',
+            title: 'Same',
+            mediaKey: 'Same',
+            dateKey: '2026-07-18',
+            timestampMs: base),
+        _ev(
+            eventType: kActivityAdded,
+            mediaType: 'video',
+            title: 'Same',
+            mediaKey: 'Same',
+            dateKey: '2026-07-18',
+            timestampMs: base + 1000),
+      ]);
+      expect(groups.single.entries, hasLength(2), reason: '书与视频即使同名同键也各自成条');
+    });
+
     test('空输入返回空列表', () {
       expect(aggregateActivityEvents(const <ActivityEventRow>[]), isEmpty);
     });


### PR DESCRIPTION
## 用户症状
「首页的活动没有跟进」——当天实机看过的合集（已看 1 集）在 dashboard 活动时间轴上不出现；最近入库也不出现。

## 验真伪（生产库只读取证）
写入端**健康**：`VideoWatchTracker.stop → addActivityEvent` 的 watch 行与 `video_watch_statistics` 逐日吻合（8-01 活动 18 行 / 统计 9436s 级对齐）。症状全部在读取/写入覆盖两处结构缺陷：

## 根因与修复
### BUG-1350（读取端聚合身份，已修）
`activity_feed.dart` `aggregateActivityEvents` 分组键 `(设备, dateKey, eventType, title)` 用 title **显示快照**做身份。拆集后视频行 title 是裸集号（`S01E01`）：同日看两部不同作品的第一集被合并成一条、`mediaKey` 取最晚事件——先看那部整条消失。生产库实锤 3 次（7-23/7-28/7-31）；7-31 正是用户截图那部 Seven Mortal Sins S01E01 被 Tensei Oujo S01E01 吞掉。
修复：分组身份 → `(设备, dateKey, eventType, mediaType, mediaKey??title)`。

### BUG-1351（写入端覆盖缺口，已修）
`source_library_scanner._importPlaylists` 首导新 playlist 合集不调 `recordVideoImportActivity`（旧契约只挂 VideoImportDialog）。该用户主导入路径是 m3u8 清单库扫描：7-31 入库 52 集零 added 事件（视频 added 全库 0 条）。
修复：首导分支补记整本 1 条（title=合集名、mediaKey=首集 uid）；重扫 reconcile 与散装单视频扫描保持静默（防刷屏边界不动）。

### 姊妹缺口（禁碰域，停诊断移交）
`anime_download_importer.dart:41-96`（`buildAnimeDownloadImporter`）番剧下载完成自动入库同样不 emit（7-29 入库 13 集零事件）。该文件被并行线独占——建议在 `importSplitPlaylist` 返回后补 `repo.recordVideoImportActivity(bookUid: result.episodeUids.first, title: plan.seriesTitle)`，注意崩溃重放（`reuseExistingPaths: true`）路径需防重复 emit（可用「合集是否新建」判据）。

## 测试
- `test/pages/activity_feed_test.dart`：+4 例（复刻 7-31 真实数据形状 / 同 mediaKey 改名快照合并 / 无 key 回退 / 跨 mediaType 不合并）
- `test/media/source_library/source_library_scanner_test.dart`：+3 断言（首导 1 条 / 重扫不重复 / 散装零事件）
- 变异实测：两处修复分别回退后对应测试红（2 fail / 2 fail），恢复后绿。

## 验证
- `flutter analyze`：No issues found
- `dart run tool/flutter_test_failures.dart --no-pub`（activity_feed / scanner / home_dashboard_page / activity_events DAO / interconnect_dashboard_feed）：`FLUTTER TEST VERDICT: PASSED - 101 tests ran, all tests passed`
- `dart run tool/bug.dart check`：1295 条，号唯一，索引同步