### PR TITLE
feat(stats): reading_hourly_logs 加 format 维度，时段数据按书/漫画/PDF 可拆（schema v67）

### DIFF
--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -893,7 +893,8 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       }
     }
 
-    _readingTimeTracker ??= ReadingTimeTracker(db)..start();
+    _readingTimeTracker ??= ReadingTimeTracker(db, format: BookFormat.manga)
+      ..start();
     _sessionStartTime = DateTime.now();
 
     final int restoredSpread =
@@ -1130,7 +1131,9 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     restoredPage =
         restoredPage.clamp(0, math.max(0, payload.images.length - 1));
 
-    _readingTimeTracker ??= ReadingTimeTracker(appModel.database)..start();
+    _readingTimeTracker ??=
+        ReadingTimeTracker(appModel.database, format: BookFormat.manga)
+          ..start();
     _sessionStartTime = DateTime.now();
     final MangaReaderSession? previousSession = _pageSession;
     _pageSession = pageSession;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -1291,6 +1291,7 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
   void _ensureReadingTimeTracker() {
     _readingTimeTracker ??= ReadingTimeTracker(
       appModel.database,
+      format: BookFormat.epub,
       onDelta: (int deltaMs) => _sessionReadingMs += deltaMs,
     );
     _readingTimeTracker!.start();

--- a/hibiki/lib/src/pages/implementations/reader_pdf_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_pdf_page.dart
@@ -160,6 +160,7 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
     // BUG-1052：小时桶与每书/每日时长共用这一个带 gap 守卫的时钟（同 EPUB 侧）。
     _readingTimeTracker ??= ReadingTimeTracker(
       db,
+      format: BookFormat.pdf,
       onDelta: (int deltaMs) => _sessionReadingMs += deltaMs,
     )..start();
     return _PdfBookLoad(path: path, row: row);

--- a/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
@@ -203,7 +203,9 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     _hourlyMs = List.filled(24, 0);
     for (final row in rows) {
       if (row.hour >= 0 && row.hour < 24) {
-        _hourlyMs[row.hour] = row.readingTimeMs;
+        // v67 起同一小时按写入面（format）分多行，图表口径是全部阅读面合计，
+        // 必须累加——赋值会只剩最后一行（单一 format 的值）。
+        _hourlyMs[row.hour] += row.readingTimeMs;
       }
     }
   }

--- a/hibiki/lib/src/sync/aggregate_snapshot.dart
+++ b/hibiki/lib/src/sync/aggregate_snapshot.dart
@@ -19,6 +19,7 @@ class AggregateSnapshot {
     this.readingStats = const <ReadingStatRecord>[],
     this.videoStats = const <VideoStatRecord>[],
     this.readingHourly = const <HourlyRecord>[],
+    this.readingHourlyByFormat = const <HourlyFormatRecord>[],
     this.videoHourly = const <HourlyRecord>[],
     this.miningStats = const <MiningRecord>[],
     this.lookupMiningCounters = const <LookupMiningRecord>[],
@@ -44,7 +45,17 @@ class AggregateSnapshot {
 
   final List<ReadingStatRecord> readingStats;
   final List<VideoStatRecord> videoStats;
+
+  /// 阅读逐时**总量**（{dateKey, hour} 每桶一行 = 该小时全部阅读面之和）。
+  /// 旧 wire 形状原样保留：不带 format 的旧端只认识这个 key，合并语义逐字节
+  /// 不变（Never break userspace）。新端把它当「旧世界视角的小时总量」，应用
+  /// 时只用来做差额归因（见 AggregateSyncService.applySnapshotToLocal）。
   final List<HourlyRecord> readingHourly;
+
+  /// 阅读逐时**按写入面拆分**（{dateKey, hour, format} 每桶一行，v67）。加字段
+  /// 走 additive-field 兼容不变量（见 [currentVersion] 注释）：旧端忽略本 key
+  /// 且其上传不携带 → 新端把缺失当空列表，靠 [readingHourly] 差额归因兜底。
+  final List<HourlyFormatRecord> readingHourlyByFormat;
   final List<HourlyRecord> videoHourly;
   final List<MiningRecord> miningStats;
 
@@ -61,6 +72,7 @@ class AggregateSnapshot {
       readingStats.isEmpty &&
       videoStats.isEmpty &&
       readingHourly.isEmpty &&
+      readingHourlyByFormat.isEmpty &&
       videoHourly.isEmpty &&
       miningStats.isEmpty &&
       lookupMiningCounters.isEmpty &&
@@ -75,6 +87,9 @@ class AggregateSnapshot {
             videoStats.map((VideoStatRecord r) => r.toJson()).toList(),
         'readingHourly':
             readingHourly.map((HourlyRecord r) => r.toJson()).toList(),
+        'readingHourlyByFormat': readingHourlyByFormat
+            .map((HourlyFormatRecord r) => r.toJson())
+            .toList(),
         'videoHourly': videoHourly.map((HourlyRecord r) => r.toJson()).toList(),
         'miningStats': miningStats.map((MiningRecord r) => r.toJson()).toList(),
         'lookupMiningCounters': lookupMiningCounters
@@ -106,6 +121,8 @@ class AggregateSnapshot {
           _decodeList(json['readingStats'], ReadingStatRecord.fromJson),
       videoStats: _decodeList(json['videoStats'], VideoStatRecord.fromJson),
       readingHourly: _decodeList(json['readingHourly'], HourlyRecord.fromJson),
+      readingHourlyByFormat: _decodeList(
+          json['readingHourlyByFormat'], HourlyFormatRecord.fromJson),
       videoHourly: _decodeList(json['videoHourly'], HourlyRecord.fromJson),
       miningStats: _decodeList(json['miningStats'], MiningRecord.fromJson),
       lookupMiningCounters: _decodeList(
@@ -256,6 +273,45 @@ class HourlyRecord {
     return HourlyRecord(
       dateKey: dateKey,
       hour: _asInt(json['hour']),
+      durationMs: _asInt(json['durationMs']),
+    );
+  }
+}
+
+/// One reading hourly-log bucket keyed by {dateKey, hour, format} (v67 拆分维度
+/// 的 wire 形状)。[format] 是写入面身份（`BookFormat.dbValue`；`''` = 历史未区分
+/// 桶），逐字节透传——未来新增格式值在旧端也原样保留、不折叠。
+class HourlyFormatRecord {
+  const HourlyFormatRecord({
+    required this.dateKey,
+    required this.hour,
+    required this.format,
+    required this.durationMs,
+  });
+
+  final String dateKey;
+  final int hour;
+  final String format;
+  final int durationMs;
+
+  /// 长度前缀防歧义（风格同 [MiningRecord.key]）：format 是自由串。
+  String get key => '${format.length}:$format|$dateKey|$hour';
+
+  Map<String, Object?> toJson() => <String, Object?>{
+        'dateKey': dateKey,
+        'hour': hour,
+        'format': format,
+        'durationMs': durationMs,
+      };
+
+  static HourlyFormatRecord? fromJson(Map<String, Object?> json) {
+    final Object? dateKey = json['dateKey'];
+    final Object? format = json['format'];
+    if (dateKey is! String || format is! String) return null;
+    return HourlyFormatRecord(
+      dateKey: dateKey,
+      hour: _asInt(json['hour']),
+      format: format,
       durationMs: _asInt(json['durationMs']),
     );
   }

--- a/hibiki/lib/src/sync/aggregate_sync_service.dart
+++ b/hibiki/lib/src/sync/aggregate_sync_service.dart
@@ -171,6 +171,10 @@ class AggregateSyncService {
       readingStats: _mergeReadingStats(local.readingStats, remote.readingStats),
       videoStats: _mergeVideoStats(local.videoStats, remote.videoStats),
       readingHourly: _mergeHourly(local.readingHourly, remote.readingHourly),
+      readingHourlyByFormat: _mergeHourlyFormats(
+        local.readingHourlyByFormat,
+        remote.readingHourlyByFormat,
+      ),
       videoHourly: _mergeHourly(local.videoHourly, remote.videoHourly),
       miningStats: _mergeMining(local.miningStats, remote.miningStats),
       lookupMiningCounters: _mergeLookupMining(
@@ -286,6 +290,55 @@ class AggregateSyncService {
         HourlyRecord(
           dateKey: idById[e.key]!.dateKey,
           hour: idById[e.key]!.hour,
+          durationMs: e.value,
+        ),
+    ];
+  }
+
+  /// 把按 format 分桶的本地行折叠成 {dateKey, hour} 逐时总量（旧 wire 形状，
+  /// 见 materializeLocalSnapshot 的 readingHourly 注释）。
+  static List<HourlyRecord> _foldHourlyTotals(List<ReadingHourlyLogRow> rows) {
+    final Map<String, int> sums = <String, int>{};
+    final Map<String, (String, int)> hourByKey = <String, (String, int)>{};
+    for (final ReadingHourlyLogRow r in rows) {
+      final String key = '${r.dateKey}|${r.hour}';
+      sums[key] = (sums[key] ?? 0) + r.readingTimeMs;
+      hourByKey[key] = (r.dateKey, r.hour);
+    }
+    return <HourlyRecord>[
+      for (final MapEntry<String, int> e in sums.entries)
+        HourlyRecord(
+          dateKey: hourByKey[e.key]!.$1,
+          hour: hourByKey[e.key]!.$2,
+          durationMs: e.value,
+        ),
+    ];
+  }
+
+  /// 按写入面拆分的逐时桶（{dateKey, hour, format}，v67）：与 [_mergeHourly]
+  /// 同款 MAX 折叠，只是 key 多了 format 一维。
+  static List<HourlyFormatRecord> _mergeHourlyFormats(
+    List<HourlyFormatRecord> local,
+    List<HourlyFormatRecord> remote,
+  ) {
+    final Map<String, int> localMap = <String, int>{
+      for (final HourlyFormatRecord r in local) r.key: r.durationMs,
+    };
+    final Map<String, int> remoteMap = <String, int>{
+      for (final HourlyFormatRecord r in remote) r.key: r.durationMs,
+    };
+    final Map<String, HourlyFormatRecord> idById = <String, HourlyFormatRecord>{
+      for (final HourlyFormatRecord r in local) r.key: r,
+      for (final HourlyFormatRecord r in remote) r.key: r,
+    };
+    final Map<String, int> mergedMap =
+        AggregateMergeService.mergeMaxCounters(localMap, remoteMap);
+    return <HourlyFormatRecord>[
+      for (final MapEntry<String, int> e in mergedMap.entries)
+        HourlyFormatRecord(
+          dateKey: idById[e.key]!.dateKey,
+          hour: idById[e.key]!.hour,
+          format: idById[e.key]!.format,
           durationMs: e.value,
         ),
     ];
@@ -410,11 +463,16 @@ class AggregateSyncService {
             lastModified: r.lastModified,
           ),
       ],
-      readingHourly: <HourlyRecord>[
+      // 旧 wire 形状 = 逐时总量：v67 起本地行按 format 分桶，这里先按
+      // {dateKey, hour} 折叠回「该小时全部阅读面之和」，旧端看到的字节语义与
+      // 拆分前完全一致；拆分数据走下面的 readingHourlyByFormat。
+      readingHourly: _foldHourlyTotals(readingHourly),
+      readingHourlyByFormat: <HourlyFormatRecord>[
         for (final ReadingHourlyLogRow r in readingHourly)
-          HourlyRecord(
+          HourlyFormatRecord(
             dateKey: r.dateKey,
             hour: r.hour,
+            format: r.format,
             durationMs: r.readingTimeMs,
           ),
       ],
@@ -498,12 +556,40 @@ class AggregateSyncService {
         lastModified: Value(r.lastModified),
       ));
     }
-    for (final HourlyRecord r in snapshot.readingHourly) {
+    // v67 两步落库，顺序有意：
+    // ① 先落按写入面拆分的桶（新端互相之间的完整拆分数据；OVERWRITE 落
+    //    Dart 侧已折好的 MAX 绝对值，format 裸串逐字节透传）。
+    for (final HourlyFormatRecord r in snapshot.readingHourlyByFormat) {
       await _db.setReadingHourlyLog(
         dateKey: r.dateKey,
         hour: r.hour,
         readingTimeMs: r.durationMs,
+        format: r.format,
       );
+    }
+    // ② 再做逐时总量的差额归因：旧端上传只有总量（不带 format），其中超出
+    //    本地该小时全部 format 桶之和的部分无法归因到任何写入面，累加进 ''
+    //    （未区分）桶。数学上 sum_f MAX_d ≥ MAX_d sum_f，全新端环境差额恒
+    //    ≤ 0（绝不虚增）；重复应用同一快照差额为 0（幂等，与本方法其余
+    //    family 的 MAX/union 保证一致）。
+    if (snapshot.readingHourly.isNotEmpty) {
+      final Map<String, int> localSums = <String, int>{};
+      for (final ReadingHourlyLogRow row
+          in await _db.getAllReadingHourlyLogs()) {
+        final String key = '${row.dateKey}|${row.hour}';
+        localSums[key] = (localSums[key] ?? 0) + row.readingTimeMs;
+      }
+      for (final HourlyRecord r in snapshot.readingHourly) {
+        final int deficit =
+            r.durationMs - (localSums['${r.dateKey}|${r.hour}'] ?? 0);
+        if (deficit > 0) {
+          await _db.addUnattributedHourlyReadingTime(
+            dateKey: r.dateKey,
+            hour: r.hour,
+            deltaMs: deficit,
+          );
+        }
+      }
     }
     for (final HourlyRecord r in snapshot.videoHourly) {
       await _db.setVideoHourlyLog(

--- a/hibiki/lib/src/sync/backup_merge_engine.dart
+++ b/hibiki/lib/src/sync/backup_merge_engine.dart
@@ -142,8 +142,12 @@ class BackupMergeEngine {
       if (_wants('statistics')) {
         await _mergeReadingStatistics();
         await _mergeVideoWatchStatistics();
-        await _mergeHourlyLogs('reading_hourly_logs', 'reading_time_ms');
-        await _mergeHourlyLogs('video_hourly_logs', 'watch_time_ms');
+        // 阅读时段表 v67 起多一维 format（备份 DB 在 ATTACH 前已迁到当前
+        // schema，两侧必有此列）；视频时段表仍是 {dateKey, hour} 两维。
+        await _mergeHourlyLogs('reading_hourly_logs', 'reading_time_ms',
+            keyColumns: const <String>['date_key', 'hour', 'format']);
+        await _mergeHourlyLogs('video_hourly_logs', 'watch_time_ms',
+            keyColumns: const <String>['date_key', 'hour']);
         await _mergeMiningStatistics();
         await _mergeLookupMiningCounters();
         await _mergeFavoriteWords();
@@ -600,22 +604,32 @@ class BackupMergeEngine {
     );
   }
 
-  /// Hourly logs MAX-union per {dateKey, hour}. [valueColumn] is the single
-  /// duration column (reading_time_ms / watch_time_ms).
-  Future<void> _mergeHourlyLogs(String table, String valueColumn) async {
+  /// Hourly logs MAX-union per [keyColumns]（阅读表 {date_key, hour, format}，
+  /// 视频表 {date_key, hour}）。[valueColumn] is the single duration column
+  /// (reading_time_ms / watch_time_ms).
+  Future<void> _mergeHourlyLogs(
+    String table,
+    String valueColumn, {
+    required List<String> keyColumns,
+  }) async {
+    final String keyList = keyColumns.join(', ');
+    final String tEqS =
+        keyColumns.map((String c) => 't.$c = s.$c').join(' AND ');
+    final String sEqTable =
+        keyColumns.map((String c) => 's.$c = $table.$c').join(' AND ');
     await _db.customStatement(
-      'INSERT INTO $table (date_key, hour, $valueColumn) '
-      'SELECT date_key, hour, $valueColumn FROM $_srcAlias.$table AS s '
+      'INSERT INTO $table ($keyList, $valueColumn) '
+      'SELECT $keyList, $valueColumn FROM $_srcAlias.$table AS s '
       'WHERE NOT EXISTS (SELECT 1 FROM $table AS t '
-      'WHERE t.date_key = s.date_key AND t.hour = s.hour)',
+      'WHERE $tEqS)',
     );
     await _db.customStatement(
       'UPDATE $table SET '
       '$valueColumn = MAX($valueColumn, ('
       'SELECT s.$valueColumn FROM $_srcAlias.$table AS s '
-      'WHERE s.date_key = $table.date_key AND s.hour = $table.hour)) '
+      'WHERE $sEqTable)) '
       'WHERE EXISTS (SELECT 1 FROM $_srcAlias.$table AS s '
-      'WHERE s.date_key = $table.date_key AND s.hour = $table.hour)',
+      'WHERE $sEqTable)',
     );
   }
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1120
+version: 1.3.1+1121
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/database/collection_relations_test.dart
+++ b/hibiki/test/database/collection_relations_test.dart
@@ -50,7 +50,7 @@ void main() {
         'fresh DB (v66) has collection_relations table and '
         'video_scrape_meta.episode_number column', () async {
       final HibikiDatabase db = await openDb();
-      expect(db.schemaVersion, 66);
+      expect(db.schemaVersion, 67);
       final List<QueryRow> tables = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")

--- a/hibiki/test/database/concurrent_writes_test.dart
+++ b/hibiki/test/database/concurrent_writes_test.dart
@@ -83,6 +83,7 @@ void main() {
             dateKey: '2026-05-17',
             hour: 14,
             deltaMs: msPerCall,
+            format: BookFormat.epub,
           ),
         ),
       );
@@ -102,12 +103,14 @@ void main() {
             dateKey: '2026-05-17',
             hour: 10,
             deltaMs: 100,
+            format: BookFormat.epub,
           ),
         for (int i = 0; i < n; i++)
           db.addHourlyReadingTime(
             dateKey: '2026-05-17',
             hour: 11,
             deltaMs: 200,
+            format: BookFormat.epub,
           ),
       ]);
 

--- a/hibiki/test/database/migration_test.dart
+++ b/hibiki/test/database/migration_test.dart
@@ -1079,7 +1079,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 hibiki_paired_peers). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 66,
+      expect(db.schemaVersion, 67,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1156,7 +1156,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 66,
+      expect(db.schemaVersion, 67,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1316,7 +1316,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 66,
+      expect(db.schemaVersion, 67,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1367,7 +1367,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 66);
+      expect(db.schemaVersion, 67);
     });
 
     test(
@@ -1376,7 +1376,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 66,
+      expect(db.schemaVersion, 67,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1410,7 +1410,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 66,
+      expect(db.schemaVersion, 67,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1450,7 +1450,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 66);
+      expect(db.schemaVersion, 67);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1481,7 +1481,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 66);
+      expect(db.schemaVersion, 67);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1515,7 +1515,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 66);
+      expect(db.schemaVersion, 67);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1527,7 +1527,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 66);
+      expect(db.schemaVersion, 67);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1563,7 +1563,7 @@ void main() {
     // 且既有合集行**一行不少、一列不改**（升级绝不能碰用户数据）。
     test('fresh DB (v64) has collection_scrape_meta table', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 66);
+      expect(db.schemaVersion, 67);
       final rows = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_scrape_meta'")
@@ -1605,6 +1605,43 @@ void main() {
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
     });
+
+    test('v66 -> v67 rebuilds reading_hourly_logs with format dimension',
+        () async {
+      final db = await _openV66DbWithLegacyReadingHourlyLogs();
+
+      // 既有行零丢失，format 落 ''（历史未区分——写入时信息已丢，不猜身份）。
+      final legacy = await db.getHourlyLogsForDate('2026-07-01');
+      expect(legacy, hasLength(2));
+      expect(legacy.map((l) => l.format).toSet(), {''});
+      expect(legacy.singleWhere((l) => l.hour == 9).readingTimeMs, 1800000);
+      expect(legacy.singleWhere((l) => l.hour == 10).readingTimeMs, 600000);
+
+      // 新唯一键 {dateKey, hour, format}：同一小时不同写入面各自成行，与
+      // 历史 '' 行共存互不冲突。
+      await db.addHourlyReadingTime(
+        dateKey: '2026-07-01',
+        hour: 9,
+        deltaMs: 300000,
+        format: BookFormat.manga,
+      );
+      final after = await db.getHourlyLogsForDate('2026-07-01');
+      expect(after, hasLength(3));
+      expect(
+          after
+              .singleWhere((l) => l.format.isEmpty && l.hour == 9)
+              .readingTimeMs,
+          1800000);
+      expect(
+        after
+            .singleWhere((l) => l.format == BookFormat.manga.dbValue)
+            .readingTimeMs,
+        300000,
+      );
+
+      final version = await db.customSelect('PRAGMA user_version').getSingle();
+      expect(version.read<int>('user_version'), db.schemaVersion);
+    });
   });
 }
 
@@ -1640,6 +1677,37 @@ CREATE TABLE media_collections (
           "'/old/cover.jpg')",
         );
         rawDb.execute('PRAGMA user_version = 63');
+      },
+    ),
+  );
+  addTearDown(db.close);
+  return db;
+}
+
+/// 打开一个 `user_version = 66` 的库：reading_hourly_logs 还是旧形状（无 format
+/// 列、唯一键 {date_key, hour}）且已有跨面加总过的历史行，强制 HibikiDatabase
+/// 打开时跑真实的 `if (from < 67) alterTable(readingHourlyLogs)` 重建分支。
+///
+/// from=66 时迁移阶梯上只有 `from < 67` 这一个条件成立，因此只备齐该分支触碰
+/// 的表（风格同 [_openV63DbWithoutCollectionScrapeMeta]）。
+Future<HibikiDatabase> _openV66DbWithLegacyReadingHourlyLogs() async {
+  final db = HibikiDatabase.forTesting(
+    NativeDatabase.memory(
+      setup: (rawDb) {
+        rawDb.execute('''
+CREATE TABLE reading_hourly_logs (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  date_key TEXT NOT NULL,
+  hour INTEGER NOT NULL,
+  reading_time_ms INTEGER NOT NULL,
+  UNIQUE (date_key, hour)
+);
+''');
+        rawDb.execute(
+          'INSERT INTO reading_hourly_logs (date_key, hour, reading_time_ms) '
+          "VALUES ('2026-07-01', 9, 1800000), ('2026-07-01', 10, 600000)",
+        );
+        rawDb.execute('PRAGMA user_version = 66');
       },
     ),
   );

--- a/hibiki/test/database/migration_v40_collections_test.dart
+++ b/hibiki/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66);
+    expect(db.schemaVersion, 67);
   });
 }

--- a/hibiki/test/database/migration_v51_pdf_format_test.dart
+++ b/hibiki/test/database/migration_v51_pdf_format_test.dart
@@ -110,6 +110,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66);
+    expect(db.schemaVersion, 67);
   });
 }

--- a/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
@@ -117,6 +117,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66);
+    expect(db.schemaVersion, 67);
   });
 }

--- a/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66);
+    expect(db.schemaVersion, 67);
   });
 }

--- a/hibiki/test/database/migration_v55_galgame_library_test.dart
+++ b/hibiki/test/database/migration_v55_galgame_library_test.dart
@@ -122,7 +122,7 @@ CREATE TABLE preferences (
     final String? pref = await db.getPref('galgame_library');
     expect(pref, isNotNull);
 
-    expect(await userVersionOf(db), 66);
+    expect(await userVersionOf(db), 67);
   });
 
   test('脏数据被逐条跳过，不让整个迁移失败', () async {
@@ -158,7 +158,7 @@ CREATE TABLE preferences (
 
     final List<GalgameRow> rows = await db.getAllGalgames();
     expect(rows.map((GalgameRow r) => r.id), <String>['ok-1', 'ok-2']);
-    expect(await userVersionOf(db), 66);
+    expect(await userVersionOf(db), 67);
   });
 
   test('整串 JSON 损坏 / 非数组 / 空串时迁移仍然成功，只是回填为空', () async {
@@ -169,7 +169,7 @@ CREATE TABLE preferences (
     ]) {
       final HibikiDatabase db = await openV53Db(raw);
       expect(await db.getAllGalgames(), isEmpty, reason: 'raw=$raw');
-      expect(await userVersionOf(db), 66, reason: 'raw=$raw');
+      expect(await userVersionOf(db), 67, reason: 'raw=$raw');
       await db.close();
     }
   });
@@ -177,7 +177,7 @@ CREATE TABLE preferences (
   test('偏好里根本没有 galgame_library 时迁移正常，表为空', () async {
     final HibikiDatabase db = await openV53Db(null);
     expect(await db.getAllGalgames(), isEmpty);
-    expect(await userVersionOf(db), 66);
+    expect(await userVersionOf(db), 67);
   });
 
   test('回填幂等：表里已有行就不再重复回填', () async {
@@ -227,7 +227,7 @@ CREATE TABLE preferences (
       ),
     );
     expect(await db.getAllGalgames(), hasLength(1));
-    expect(await userVersionOf(db), 66);
+    expect(await userVersionOf(db), 67);
   });
 
   test('删游戏经 FK cascade 连带清掉 sources 与 sessions', () async {

--- a/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66,
+    expect(db.schemaVersion, 67,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v57_naming_unification_test.dart
+++ b/hibiki/test/database/migration_v57_naming_unification_test.dart
@@ -154,7 +154,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66,
+    expect(db.schemaVersion, 67,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
             'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
             'v63 = 清理旧全局超分 pref');

--- a/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66,
+    expect(db.schemaVersion, 67,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v60_reading_pages_test.dart
+++ b/hibiki/test/database/migration_v60_reading_pages_test.dart
@@ -59,7 +59,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 67, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/hibiki/test/database/migration_v61_collection_cover_path_test.dart
+++ b/hibiki/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66,
+    expect(db.schemaVersion, 67,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/hibiki/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/hibiki/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 66,
+    expect(db.schemaVersion, 67,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/hibiki/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/hibiki/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -126,8 +126,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 66);
-    expect(db.schemaVersion, 66);
+    expect(version.read<int>('user_version'), 67);
+    expect(db.schemaVersion, 67);
 
     final List<QueryRow> preferences = await db
         .customSelect(
@@ -225,7 +225,7 @@ void main() {
     expect(await db.getPref('theme'), 's:dark');
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 66);
+    expect(version.read<int>('user_version'), 67);
   });
 
   test(
@@ -257,7 +257,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 66);
+      expect(probe.select('PRAGMA user_version').first.values.first, 67);
       expect(
         probe.select(
           'SELECT 1 FROM profile_settings '

--- a/hibiki/test/database/migration_v65_mihon_manga_tables_test.dart
+++ b/hibiki/test/database/migration_v65_mihon_manga_tables_test.dart
@@ -105,8 +105,8 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(db.schemaVersion, 66);
-    expect(await _userVersion(db), 66);
+    expect(db.schemaVersion, 67);
+    expect(await _userVersion(db), 67);
 
     // v63 真跑了：两处废弃偏好都没了。
     expect(
@@ -168,7 +168,7 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(await _userVersion(db), 66);
+    expect(await _userVersion(db), 67);
     final Set<String> tables = await _tableNames(db);
     for (final String table in _mangaTables) {
       expect(tables, contains(table), reason: 'from=63 时 v65 必须仍然建表：缺 $table');
@@ -185,7 +185,7 @@ void main() {
     addTearDown(db.close);
 
     // 表已存在不能让 onUpgrade 抛异常——抛了 v63 的删除也会一起回滚。
-    expect(await _userVersion(db), 66);
+    expect(await _userVersion(db), 67);
     expect(
       await _countRows(
         db,
@@ -204,7 +204,7 @@ void main() {
     final HibikiDatabase first = HibikiDatabase.forTesting(
       NativeDatabase.memory(setup: _seedV62),
     );
-    expect(await _userVersion(first), 66);
+    expect(await _userVersion(first), 67);
     await first.close();
 
     // 同一份内存库不能跨实例复用，这里改用「第二次打开已是 v65 的形状」：
@@ -213,14 +213,14 @@ void main() {
       NativeDatabase.memory(
         setup: (sqlite3.Database raw) => _seedV62(
           raw,
-          userVersion: 66,
+          userVersion: 67,
           includeObsoleteRows: false,
           preCreateMangaTables: true,
         ),
       ),
     );
     addTearDown(second.close);
-    expect(await _userVersion(second), 66);
+    expect(await _userVersion(second), 67);
     expect(
       await _countRows(second, "SELECT 1 FROM preferences WHERE key = 'theme'"),
       1,

--- a/hibiki/test/database/reading_statistics_test.dart
+++ b/hibiki/test/database/reading_statistics_test.dart
@@ -1,4 +1,4 @@
-﻿import 'package:drift/native.dart';
+import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -131,6 +131,7 @@ void main() {
         dateKey: '2026-05-16',
         hour: 14,
         deltaMs: 30000,
+        format: BookFormat.epub,
       );
 
       final logs = await db.getHourlyLogsForDate('2026-05-16');
@@ -145,17 +146,99 @@ void main() {
         dateKey: '2026-05-16',
         hour: 14,
         deltaMs: 10000,
+        format: BookFormat.epub,
       );
 
       await db.addHourlyReadingTime(
         dateKey: '2026-05-16',
         hour: 14,
         deltaMs: 5000,
+        format: BookFormat.epub,
       );
 
       final logs = await db.getHourlyLogsForDate('2026-05-16');
       expect(logs, hasLength(1));
       expect(logs.single.readingTimeMs, 15000);
+    });
+
+    test('same hour different formats stay separate rows (v67)', () async {
+      final db = await _openDb();
+      await db.addHourlyReadingTime(
+        dateKey: '2026-05-16',
+        hour: 15,
+        deltaMs: 1200000,
+        format: BookFormat.epub,
+      );
+      await db.addHourlyReadingTime(
+        dateKey: '2026-05-16',
+        hour: 15,
+        deltaMs: 600000,
+        format: BookFormat.manga,
+      );
+
+      final logs = await db.getHourlyLogsForDate('2026-05-16');
+      expect(logs, hasLength(2));
+      final epub = logs.singleWhere((l) => l.format == BookFormat.epub.dbValue);
+      final manga =
+          logs.singleWhere((l) => l.format == BookFormat.manga.dbValue);
+      expect(epub.readingTimeMs, 1200000);
+      expect(manga.readingTimeMs, 600000);
+    });
+
+    test('unattributed bucket accumulates under empty format', () async {
+      final db = await _openDb();
+      await db.addUnattributedHourlyReadingTime(
+        dateKey: '2026-05-16',
+        hour: 16,
+        deltaMs: 4000,
+      );
+      await db.addUnattributedHourlyReadingTime(
+        dateKey: '2026-05-16',
+        hour: 16,
+        deltaMs: 2000,
+      );
+
+      final logs = await db.getHourlyLogsForDate('2026-05-16');
+      expect(logs, hasLength(1));
+      expect(logs.single.format, '');
+      expect(logs.single.readingTimeMs, 6000);
+    });
+
+    test('setReadingHourlyLog overwrites per (dateKey, hour, format)',
+        () async {
+      final db = await _openDb();
+      // 模拟未来版本 wire 里的新格式值：必须逐字节透传，不折叠进已知枚举。
+      const String futureFormat = 'future_format';
+      await db.setReadingHourlyLog(
+        dateKey: '2026-05-16',
+        hour: 17,
+        readingTimeMs: 9000,
+        format: 'epub',
+      );
+      await db.setReadingHourlyLog(
+        dateKey: '2026-05-16',
+        hour: 17,
+        readingTimeMs: 7000,
+        format: futureFormat,
+      );
+      await db.setReadingHourlyLog(
+        dateKey: '2026-05-16',
+        hour: 17,
+        readingTimeMs: 9500,
+        format: 'epub',
+      );
+
+      final logs = await db.getHourlyLogsForDate('2026-05-16');
+      expect(logs, hasLength(2));
+      expect(
+          logs
+              .singleWhere((l) => l.format == BookFormat.epub.dbValue)
+              .readingTimeMs,
+          9500);
+      expect(
+        logs.singleWhere((l) => l.format == futureFormat).readingTimeMs,
+        7000,
+      );
     });
 
     test('different hours create separate logs', () async {
@@ -164,11 +247,13 @@ void main() {
         dateKey: '2026-05-16',
         hour: 10,
         deltaMs: 5000,
+        format: BookFormat.epub,
       );
       await db.addHourlyReadingTime(
         dateKey: '2026-05-16',
         hour: 11,
         deltaMs: 3000,
+        format: BookFormat.epub,
       );
 
       final logs = await db.getHourlyLogsForDate('2026-05-16');

--- a/hibiki/test/database/statistics_clear_all_test.dart
+++ b/hibiki/test/database/statistics_clear_all_test.dart
@@ -17,7 +17,8 @@ Future<void> _seedReadingStats(HibikiDatabase db) async {
       title: 'A', dateKey: '2026-07-05', charsRead: 100, timeMs: 6000);
   await db.addReadingStatistic(
       title: 'B', dateKey: '2026-07-06', charsRead: 50, timeMs: 3000);
-  await db.addHourlyReadingTime(dateKey: '2026-07-05', hour: 10, deltaMs: 6000);
+  await db.addHourlyReadingTime(
+      dateKey: '2026-07-05', hour: 10, deltaMs: 6000, format: BookFormat.epub);
   await db.addLookupCount(
       bookKey: 'book/A', title: 'A', sourceType: 'book', dateKey: '2026-07-05');
   await db.addMineCountPerBook(

--- a/hibiki/test/media/audiobook/reading_time_tracker_delta_test.dart
+++ b/hibiki/test/media/audiobook/reading_time_tracker_delta_test.dart
@@ -33,7 +33,8 @@ ReadingTimeTracker _makeTracker(
   HibikiDatabase db, {
   ReadingTimeDelta? onDelta,
 }) {
-  final ReadingTimeTracker tracker = ReadingTimeTracker(db, onDelta: onDelta);
+  final ReadingTimeTracker tracker =
+      ReadingTimeTracker(db, format: BookFormat.epub, onDelta: onDelta);
   addTearDown(() async {
     tracker.dispose();
     await Future<void>.delayed(const Duration(milliseconds: 120));

--- a/hibiki/test/sync/aggregate_snapshot_test.dart
+++ b/hibiki/test/sync/aggregate_snapshot_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/sync/aggregate_snapshot.dart';
 import 'package:hibiki/src/sync/aggregate_sync_service.dart';
 import 'package:hibiki_audio/hibiki_audio.dart' show FavoriteSentence;
+import 'package:hibiki_core/hibiki_core.dart' show BookFormat;
 
 AggregateSnapshot _sample() => AggregateSnapshot(
       readingStats: const <ReadingStatRecord>[
@@ -26,6 +27,12 @@ AggregateSnapshot _sample() => AggregateSnapshot(
       ],
       readingHourly: const <HourlyRecord>[
         HourlyRecord(dateKey: '2026-06-01', hour: 9, durationMs: 60000),
+      ],
+      readingHourlyByFormat: const <HourlyFormatRecord>[
+        HourlyFormatRecord(
+            dateKey: '2026-06-01', hour: 9, format: 'epub', durationMs: 40000),
+        HourlyFormatRecord(
+            dateKey: '2026-06-01', hour: 9, format: 'manga', durationMs: 20000),
       ],
       videoHourly: const <HourlyRecord>[
         HourlyRecord(dateKey: '2026-06-01', hour: 20, durationMs: 30000),
@@ -80,6 +87,21 @@ void main() {
       expect(back.videoStats.single.watchTimeMs, 30000);
       expect(back.readingHourly.single.durationMs, 60000);
       expect(back.readingHourly.single.hour, 9);
+      expect(back.readingHourlyByFormat, hasLength(2));
+      expect(
+        back.readingHourlyByFormat
+            .singleWhere(
+                (HourlyFormatRecord r) => r.format == BookFormat.epub.dbValue)
+            .durationMs,
+        40000,
+      );
+      expect(
+        back.readingHourlyByFormat
+            .singleWhere(
+                (HourlyFormatRecord r) => r.format == BookFormat.manga.dbValue)
+            .durationMs,
+        20000,
+      );
       expect(back.videoHourly.single.durationMs, 30000);
       expect(back.miningStats.single.count, 3);
       expect(back.miningStats.single.sourceType, 'book');
@@ -256,6 +278,72 @@ void main() {
           ba.readingStats.single.readingTimeMs);
       expect(ab.readingStats.single.charactersRead, 250);
       expect(ab.readingStats.single.readingTimeMs, 60000);
+    });
+
+    test('hourly-by-format MAX per {dateKey, hour, format}; totals untouched',
+        () {
+      // 同一 {dateKey, hour} 下不同 format 是不同桶：各自 MAX，不互相折叠；
+      // 逐时总量字段 readingHourly 保持旧 wire 语义（{dateKey, hour} MAX）。
+      const AggregateSnapshot a = AggregateSnapshot(
+        readingHourly: <HourlyRecord>[
+          HourlyRecord(dateKey: 'd', hour: 9, durationMs: 30000),
+        ],
+        readingHourlyByFormat: <HourlyFormatRecord>[
+          HourlyFormatRecord(
+              dateKey: 'd', hour: 9, format: 'epub', durationMs: 20000),
+          HourlyFormatRecord(
+              dateKey: 'd', hour: 9, format: 'manga', durationMs: 10000),
+        ],
+      );
+      const AggregateSnapshot b = AggregateSnapshot(
+        readingHourly: <HourlyRecord>[
+          HourlyRecord(dateKey: 'd', hour: 9, durationMs: 25000),
+        ],
+        readingHourlyByFormat: <HourlyFormatRecord>[
+          HourlyFormatRecord(
+              dateKey: 'd', hour: 9, format: 'epub', durationMs: 25000),
+        ],
+      );
+      final AggregateSnapshot ab = AggregateSyncService.mergeSnapshots(a, b);
+      final AggregateSnapshot ba = AggregateSyncService.mergeSnapshots(b, a);
+      expect(ab.readingHourly.single.durationMs, 30000);
+      expect(ab.readingHourlyByFormat, hasLength(2));
+      expect(
+        ab.readingHourlyByFormat
+            .singleWhere(
+                (HourlyFormatRecord r) => r.format == BookFormat.epub.dbValue)
+            .durationMs,
+        25000, // MAX(20000, 25000)
+      );
+      expect(
+        ab.readingHourlyByFormat
+            .singleWhere(
+                (HourlyFormatRecord r) => r.format == BookFormat.manga.dbValue)
+            .durationMs,
+        10000, // 只有 a 携带，原样并入
+      );
+      // 可交换性。
+      expect(
+        ba.readingHourlyByFormat
+            .singleWhere(
+                (HourlyFormatRecord r) => r.format == BookFormat.epub.dbValue)
+            .durationMs,
+        25000,
+      );
+    });
+
+    test('an OLD payload missing readingHourlyByFormat defaults it to empty',
+        () {
+      // 旧端上传只有逐时总量：byFormat 缺失 → 空列表，其余 family 照常折叠。
+      final AggregateSnapshot snap =
+          AggregateSnapshot.fromJson(<String, Object?>{
+        'version': AggregateSnapshot.currentVersion,
+        'readingHourly': <Object?>[
+          <String, Object?>{'dateKey': 'd', 'hour': 9, 'durationMs': 1000},
+        ],
+      });
+      expect(snap.readingHourly.single.durationMs, 1000);
+      expect(snap.readingHourlyByFormat, isEmpty);
     });
 
     test('lookup/mine counters MAX both columns; bookKey prefers non-null', () {

--- a/hibiki/test/sync/aggregate_sync_service_cloud_test.dart
+++ b/hibiki/test/sync/aggregate_sync_service_cloud_test.dart
@@ -59,6 +59,65 @@ void main() {
     expect((await db.getAllFavoriteWords()).length, 1);
   });
 
+  test('hourly formats: materialize splits, old-peer totals lift unattributed',
+      () async {
+    // v67：本地按写入面分桶（epub 20s + manga 10s，同一小时）。
+    final HibikiDatabase db = await _freshDb('agg_hourly_fmt_');
+    addTearDown(db.close);
+    await db.addHourlyReadingTime(
+        dateKey: '2026-06-01',
+        hour: 9,
+        deltaMs: 20000,
+        format: BookFormat.epub);
+    await db.addHourlyReadingTime(
+        dateKey: '2026-06-01',
+        hour: 9,
+        deltaMs: 10000,
+        format: BookFormat.manga);
+
+    final AggregateSyncService svc = AggregateSyncService(db);
+    final AggregateSnapshot snap = await svc.materializeLocalSnapshot();
+    // 旧 wire 字段 = 该小时全部阅读面之和（旧端看到的语义与拆分前一致）；
+    // 拆分数据走 readingHourlyByFormat。
+    expect(snap.readingHourly.single.durationMs, 30000);
+    expect(snap.readingHourlyByFormat, hasLength(2));
+
+    // 自我重放幂等：不产生未区分桶、不改变任何行。
+    await svc.applySnapshotToLocal(snap);
+    expect(await db.getHourlyLogsForDate('2026-06-01'), hasLength(2));
+
+    // 旧端 peer 只带逐时总量 45s（不带 format）：与本地 30s 之差 15s 无法归因
+    // 到任何写入面 → 落 ''（未区分）桶；已归因的 epub/manga 桶原样不动。
+    const AggregateSnapshot oldPeer = AggregateSnapshot(
+      readingHourly: <HourlyRecord>[
+        HourlyRecord(dateKey: '2026-06-01', hour: 9, durationMs: 45000),
+      ],
+    );
+    final AggregateSnapshot merged =
+        AggregateSyncService.mergeSnapshots(snap, oldPeer);
+    await svc.applySnapshotToLocal(merged);
+    List<ReadingHourlyLogRow> logs =
+        await db.getHourlyLogsForDate('2026-06-01');
+    expect(logs, hasLength(3));
+    expect(
+        logs
+            .singleWhere((l) => l.format == BookFormat.epub.dbValue)
+            .readingTimeMs,
+        20000);
+    expect(
+        logs
+            .singleWhere((l) => l.format == BookFormat.manga.dbValue)
+            .readingTimeMs,
+        10000);
+    expect(logs.singleWhere((l) => l.format.isEmpty).readingTimeMs, 15000);
+
+    // 重复应用同一 merged 快照：差额为 0，幂等（不虚增未区分桶）。
+    await svc.applySnapshotToLocal(merged);
+    logs = await db.getHourlyLogsForDate('2026-06-01');
+    expect(logs, hasLength(3));
+    expect(logs.singleWhere((l) => l.format.isEmpty).readingTimeMs, 15000);
+  });
+
   test('first sync with empty namespace uploads own snapshot, no crash',
       () async {
     final HibikiDatabase db = await _freshDb('agg_first_');

--- a/hibiki/test/sync/backup_merge_import_test.dart
+++ b/hibiki/test/sync/backup_merge_import_test.dart
@@ -130,6 +130,76 @@ void main() {
     expect(rows.single.readingTimeMs, 9000); // max(6000, 9000)
   });
 
+  test('hourly logs MAX-union per {dateKey, hour, format}; video stays 2-key',
+      () async {
+    final curDir = await _tempDir('mg_cur_');
+    addTearDown(() => cleanupTempDir(curDir));
+    final cur = HibikiDatabase(curDir.path);
+    await cur.addHourlyReadingTime(
+        dateKey: '2026-01-01',
+        hour: 9,
+        deltaMs: 20000,
+        format: BookFormat.epub);
+    await cur.addHourlyReadingTime(
+        dateKey: '2026-01-01',
+        hour: 9,
+        deltaMs: 10000,
+        format: BookFormat.manga);
+    await cur.addVideoHourlyWatchTime(
+        dateKey: '2026-01-01', hour: 21, deltaMs: 1000);
+    await cur.close();
+
+    final srcDir = await _tempDir('mg_src_');
+    addTearDown(() => cleanupTempDir(srcDir));
+    final src = HibikiDatabase(srcDir.path);
+    await src.addHourlyReadingTime(
+        dateKey: '2026-01-01',
+        hour: 9,
+        deltaMs: 30000,
+        format: BookFormat.epub);
+    // 迁移自旧库的未区分行（format=''）也是普通一桶，照常并入。
+    await src.addUnattributedHourlyReadingTime(
+        dateKey: '2026-01-01', hour: 10, deltaMs: 5000);
+    await src.addVideoHourlyWatchTime(
+        dateKey: '2026-01-01', hour: 21, deltaMs: 4000);
+    final zipDir = await _tempDir('mg_zip_');
+    addTearDown(() => cleanupTempDir(zipDir));
+    final zip = p.join(zipDir.path, 'b.zip');
+    await _exportZip(src, srcDir.path, zip);
+    await src.close();
+
+    await BackupService.mergeRestoreBackup(
+        dbDirectory: curDir.path, zipPath: zip);
+    // Re-import the SAME backup again — must stay idempotent.
+    await BackupService.mergeRestoreBackup(
+        dbDirectory: curDir.path, zipPath: zip);
+
+    final after = HibikiDatabase(curDir.path);
+    addTearDown(after.close);
+    final rows = await after.getAllReadingHourlyLogs();
+    expect(rows, hasLength(3));
+    expect(
+      rows
+          .singleWhere(
+              (r) => r.hour == 9 && r.format == BookFormat.epub.dbValue)
+          .readingTimeMs,
+      30000, // MAX(20000, 30000)，不 SUM
+    );
+    expect(
+      rows
+          .singleWhere(
+              (r) => r.hour == 9 && r.format == BookFormat.manga.dbValue)
+          .readingTimeMs,
+      10000, // 仅本机持有，原样保留
+    );
+    expect(
+      rows.singleWhere((r) => r.hour == 10 && r.format.isEmpty).readingTimeMs,
+      5000, // 仅备份持有，原样并入
+    );
+    final videoRows = await after.getAllVideoHourlyLogs();
+    expect(videoRows.single.watchTimeMs, 4000); // MAX(1000, 4000)
+  });
+
   test('reading statistics: many titles under one dateKey are NOT folded',
       () async {
     final curDir = await _tempDir('mg_cur_');

--- a/packages/hibiki_audio/lib/src/audiobook/reading_time_tracker.dart
+++ b/packages/hibiki_audio/lib/src/audiobook/reading_time_tracker.dart
@@ -55,10 +55,18 @@ class ReadingTimeTracker {
   /// 被生命周期 resumed / 章节恢复完成等多处无条件重置，重置前那段前台阅读时长直接蒸发。
   /// 现在两条账目共用**同一个**带 [isContinuousReadingGap] 守卫的时钟：本 tracker 记小时
   /// 桶，[onDelta] 把同一增量喂给会话累计器，任何重置都不再能吃掉时长。
-  ReadingTimeTracker(this._database, {ReadingTimeDelta? onDelta})
-      : _onDelta = onDelta;
+  ReadingTimeTracker(
+    this._database, {
+    required BookFormat format,
+    ReadingTimeDelta? onDelta,
+  })  : _format = format,
+        _onDelta = onDelta;
 
   final HibikiDatabase _database;
+
+  /// 写入面身份（EPUB / PDF / 漫画阅读器各自固定一种），随每个小时桶落库——
+  /// 缺了它时段数据在写入时就被跨面加总、永久分不开（v67 修复的根因）。
+  final BookFormat _format;
   final ReadingTimeDelta? _onDelta;
   Timer? _timer;
   DateTime? _tickStart;
@@ -112,7 +120,8 @@ class ReadingTimeTracker {
 
   void _write(String dateKey, int hour, int deltaMs) {
     _database
-        .addHourlyReadingTime(dateKey: dateKey, hour: hour, deltaMs: deltaMs)
+        .addHourlyReadingTime(
+            dateKey: dateKey, hour: hour, deltaMs: deltaMs, format: _format)
         .catchError((Object e, StackTrace stack) {
       debugPrint('ReadingTimeTracker.write: $e\n$stack');
       debugPrint('[reading-time-tracker] write error: $e');

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -423,7 +423,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   HibikiDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 66;
+  int get schemaVersion => 67;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1355,6 +1355,24 @@ class HibikiDatabase extends _$HibikiDatabase {
             if (await _tableExists('video_scrape_meta') &&
                 !await _columnExists('video_scrape_meta', 'episode_number')) {
               await m.addColumn(videoScrapeMeta, videoScrapeMeta.episodeNumber);
+            }
+          }
+          if (from < 67) {
+            // v67：reading_hourly_logs 加 format 列（写入面身份，
+            // `BookFormat.dbValue`），唯一键 {dateKey,hour} → {dateKey,hour,format}。
+            // 此前时段表没有任何身份列，EPUB / PDF / 漫画同一小时的时长写入时就被
+            // 加成一行、永久分不开（日级 reading_statistics 靠 title→format 能拆，
+            // 只有时段表拆不开）。唯一键变更须重建表，走 alterTable 按当前 Dart
+            // 定义重建 + 按列名拷贝，既有行 format 落列默认 ''（= 历史未区分——
+            // 信息在写入时已丢，如实标注，不猜身份）；全部旧行 format 同为 ''，
+            // 新唯一键下仍互不冲突，零丢行。_columnExists 双守卫：从 v1 起的完整
+            // 阶梯里本表以最新定义建出（已含此列），重复升级短路 no-op（风格同 v39）。
+            if (await _tableExists('reading_hourly_logs') &&
+                !await _columnExists('reading_hourly_logs', 'format')) {
+              await m.alterTable(TableMigration(
+                readingHourlyLogs,
+                newColumns: [readingHourlyLogs.format],
+              ));
             }
           }
         },
@@ -3935,14 +3953,48 @@ class HibikiDatabase extends _$HibikiDatabase {
       select(readingStatistics).get();
 
   // ── reading hourly logs ─────────────────────────────────────────
+  /// ACCUMULATE：把 [deltaMs] 累加进 (dateKey, hour, format) 桶。[format] 是写入
+  /// 面身份（EPUB / PDF / 漫画阅读器各报各的），v67 起时段数据按它可拆。
   Future<void> addHourlyReadingTime({
     required String dateKey,
     required int hour,
     required int deltaMs,
+    required BookFormat format,
+  }) =>
+      _addHourlyReadingTimeRaw(
+        dateKey: dateKey,
+        hour: hour,
+        deltaMs: deltaMs,
+        format: format.dbValue,
+      );
+
+  /// 云聚合同步专用：把旧端（不带 format 的 wire 快照）贡献的、无法归因到任何
+  /// 写入面的逐时差额累加进 `''`（未区分）桶。普通写入面一律走带 [BookFormat]
+  /// 的 [addHourlyReadingTime]，不得用本方法制造新的未区分数据。
+  Future<void> addUnattributedHourlyReadingTime({
+    required String dateKey,
+    required int hour,
+    required int deltaMs,
+  }) =>
+      _addHourlyReadingTimeRaw(
+        dateKey: dateKey,
+        hour: hour,
+        deltaMs: deltaMs,
+        format: '',
+      );
+
+  Future<void> _addHourlyReadingTimeRaw({
+    required String dateKey,
+    required int hour,
+    required int deltaMs,
+    required String format,
   }) =>
       transaction(() async {
         final existing = await (select(readingHourlyLogs)
-              ..where((t) => t.dateKey.equals(dateKey) & t.hour.equals(hour)))
+              ..where((t) =>
+                  t.dateKey.equals(dateKey) &
+                  t.hour.equals(hour) &
+                  t.format.equals(format)))
             .getSingleOrNull();
         if (existing != null) {
           await (update(readingHourlyLogs)
@@ -3956,6 +4008,7 @@ class HibikiDatabase extends _$HibikiDatabase {
               dateKey: dateKey,
               hour: hour,
               readingTimeMs: deltaMs,
+              format: Value(format),
             ),
           );
         }
@@ -3969,23 +4022,31 @@ class HibikiDatabase extends _$HibikiDatabase {
   Future<List<ReadingHourlyLogRow>> getAllReadingHourlyLogs() =>
       select(readingHourlyLogs).get();
 
-  /// OVERWRITE 语义：把 (dateKey, hour) 桶设为绝对值 [readingTimeMs]。云聚合合并
-  /// 已在 Dart 侧算好 MAX，这里直接落绝对值（对照 [addHourlyReadingTime] 的累加）。
+  /// OVERWRITE 语义：把 (dateKey, hour, format) 桶设为绝对值 [readingTimeMs]。
+  /// 云聚合合并已在 Dart 侧算好 MAX，这里直接落绝对值（对照
+  /// [addHourlyReadingTime] 的累加）。[format] 收裸串而非 [BookFormat]：wire 快照
+  /// 可能来自带未来新格式值的新版本端，本方法逐字节保存、不得折叠成已知枚举。
   Future<void> setReadingHourlyLog({
     required String dateKey,
     required int hour,
     required int readingTimeMs,
+    required String format,
   }) =>
       into(readingHourlyLogs).insert(
         ReadingHourlyLogsCompanion.insert(
           dateKey: dateKey,
           hour: hour,
           readingTimeMs: readingTimeMs,
+          format: Value(format),
         ),
         onConflict: DoUpdate(
           (_) =>
               ReadingHourlyLogsCompanion(readingTimeMs: Value(readingTimeMs)),
-          target: [readingHourlyLogs.dateKey, readingHourlyLogs.hour],
+          target: [
+            readingHourlyLogs.dateKey,
+            readingHourlyLogs.hour,
+            readingHourlyLogs.format,
+          ],
         ),
       );
 

--- a/packages/hibiki_core/lib/src/database/database.g.dart
+++ b/packages/hibiki_core/lib/src/database/database.g.dart
@@ -6085,8 +6085,16 @@ class $ReadingHourlyLogsTable extends ReadingHourlyLogs
   late final GeneratedColumn<int> readingTimeMs = GeneratedColumn<int>(
       'reading_time_ms', aliasedName, false,
       type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _formatMeta = const VerificationMeta('format');
   @override
-  List<GeneratedColumn> get $columns => [id, dateKey, hour, readingTimeMs];
+  late final GeneratedColumn<String> format = GeneratedColumn<String>(
+      'format', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(''));
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, dateKey, hour, readingTimeMs, format];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -6121,6 +6129,10 @@ class $ReadingHourlyLogsTable extends ReadingHourlyLogs
     } else if (isInserting) {
       context.missing(_readingTimeMsMeta);
     }
+    if (data.containsKey('format')) {
+      context.handle(_formatMeta,
+          format.isAcceptableOrUnknown(data['format']!, _formatMeta));
+    }
     return context;
   }
 
@@ -6128,7 +6140,7 @@ class $ReadingHourlyLogsTable extends ReadingHourlyLogs
   Set<GeneratedColumn> get $primaryKey => {id};
   @override
   List<Set<GeneratedColumn>> get uniqueKeys => [
-        {dateKey, hour},
+        {dateKey, hour, format},
       ];
   @override
   ReadingHourlyLogRow map(Map<String, dynamic> data, {String? tablePrefix}) {
@@ -6142,6 +6154,8 @@ class $ReadingHourlyLogsTable extends ReadingHourlyLogs
           .read(DriftSqlType.int, data['${effectivePrefix}hour'])!,
       readingTimeMs: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}reading_time_ms'])!,
+      format: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}format'])!,
     );
   }
 
@@ -6157,11 +6171,19 @@ class ReadingHourlyLogRow extends DataClass
   final String dateKey;
   final int hour;
   final int readingTimeMs;
+
+  /// v65：写入面身份（`BookFormat.dbValue`：'epub' / 'pdf' / 'manga'）。此前没有
+  /// 任何身份列，EPUB / PDF / 漫画同一小时的时长在写入时就被加成一行，永久分不开；
+  /// 日级 `reading_statistics` 靠 title→format 反查能拆，时段表拆不开只因缺这列。
+  /// `''` = v65 前的历史行（写入时信息已丢，如实标未区分）以及云同步里旧端贡献的
+  /// 无法归因差额（见 aggregate_sync_service 的 deficit-lift）。
+  final String format;
   const ReadingHourlyLogRow(
       {required this.id,
       required this.dateKey,
       required this.hour,
-      required this.readingTimeMs});
+      required this.readingTimeMs,
+      required this.format});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
@@ -6169,6 +6191,7 @@ class ReadingHourlyLogRow extends DataClass
     map['date_key'] = Variable<String>(dateKey);
     map['hour'] = Variable<int>(hour);
     map['reading_time_ms'] = Variable<int>(readingTimeMs);
+    map['format'] = Variable<String>(format);
     return map;
   }
 
@@ -6178,6 +6201,7 @@ class ReadingHourlyLogRow extends DataClass
       dateKey: Value(dateKey),
       hour: Value(hour),
       readingTimeMs: Value(readingTimeMs),
+      format: Value(format),
     );
   }
 
@@ -6189,6 +6213,7 @@ class ReadingHourlyLogRow extends DataClass
       dateKey: serializer.fromJson<String>(json['dateKey']),
       hour: serializer.fromJson<int>(json['hour']),
       readingTimeMs: serializer.fromJson<int>(json['readingTimeMs']),
+      format: serializer.fromJson<String>(json['format']),
     );
   }
   @override
@@ -6199,16 +6224,22 @@ class ReadingHourlyLogRow extends DataClass
       'dateKey': serializer.toJson<String>(dateKey),
       'hour': serializer.toJson<int>(hour),
       'readingTimeMs': serializer.toJson<int>(readingTimeMs),
+      'format': serializer.toJson<String>(format),
     };
   }
 
   ReadingHourlyLogRow copyWith(
-          {int? id, String? dateKey, int? hour, int? readingTimeMs}) =>
+          {int? id,
+          String? dateKey,
+          int? hour,
+          int? readingTimeMs,
+          String? format}) =>
       ReadingHourlyLogRow(
         id: id ?? this.id,
         dateKey: dateKey ?? this.dateKey,
         hour: hour ?? this.hour,
         readingTimeMs: readingTimeMs ?? this.readingTimeMs,
+        format: format ?? this.format,
       );
   ReadingHourlyLogRow copyWithCompanion(ReadingHourlyLogsCompanion data) {
     return ReadingHourlyLogRow(
@@ -6218,6 +6249,7 @@ class ReadingHourlyLogRow extends DataClass
       readingTimeMs: data.readingTimeMs.present
           ? data.readingTimeMs.value
           : this.readingTimeMs,
+      format: data.format.present ? data.format.value : this.format,
     );
   }
 
@@ -6227,13 +6259,14 @@ class ReadingHourlyLogRow extends DataClass
           ..write('id: $id, ')
           ..write('dateKey: $dateKey, ')
           ..write('hour: $hour, ')
-          ..write('readingTimeMs: $readingTimeMs')
+          ..write('readingTimeMs: $readingTimeMs, ')
+          ..write('format: $format')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, dateKey, hour, readingTimeMs);
+  int get hashCode => Object.hash(id, dateKey, hour, readingTimeMs, format);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -6241,7 +6274,8 @@ class ReadingHourlyLogRow extends DataClass
           other.id == this.id &&
           other.dateKey == this.dateKey &&
           other.hour == this.hour &&
-          other.readingTimeMs == this.readingTimeMs);
+          other.readingTimeMs == this.readingTimeMs &&
+          other.format == this.format);
 }
 
 class ReadingHourlyLogsCompanion extends UpdateCompanion<ReadingHourlyLogRow> {
@@ -6249,17 +6283,20 @@ class ReadingHourlyLogsCompanion extends UpdateCompanion<ReadingHourlyLogRow> {
   final Value<String> dateKey;
   final Value<int> hour;
   final Value<int> readingTimeMs;
+  final Value<String> format;
   const ReadingHourlyLogsCompanion({
     this.id = const Value.absent(),
     this.dateKey = const Value.absent(),
     this.hour = const Value.absent(),
     this.readingTimeMs = const Value.absent(),
+    this.format = const Value.absent(),
   });
   ReadingHourlyLogsCompanion.insert({
     this.id = const Value.absent(),
     required String dateKey,
     required int hour,
     required int readingTimeMs,
+    this.format = const Value.absent(),
   })  : dateKey = Value(dateKey),
         hour = Value(hour),
         readingTimeMs = Value(readingTimeMs);
@@ -6268,12 +6305,14 @@ class ReadingHourlyLogsCompanion extends UpdateCompanion<ReadingHourlyLogRow> {
     Expression<String>? dateKey,
     Expression<int>? hour,
     Expression<int>? readingTimeMs,
+    Expression<String>? format,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (dateKey != null) 'date_key': dateKey,
       if (hour != null) 'hour': hour,
       if (readingTimeMs != null) 'reading_time_ms': readingTimeMs,
+      if (format != null) 'format': format,
     });
   }
 
@@ -6281,12 +6320,14 @@ class ReadingHourlyLogsCompanion extends UpdateCompanion<ReadingHourlyLogRow> {
       {Value<int>? id,
       Value<String>? dateKey,
       Value<int>? hour,
-      Value<int>? readingTimeMs}) {
+      Value<int>? readingTimeMs,
+      Value<String>? format}) {
     return ReadingHourlyLogsCompanion(
       id: id ?? this.id,
       dateKey: dateKey ?? this.dateKey,
       hour: hour ?? this.hour,
       readingTimeMs: readingTimeMs ?? this.readingTimeMs,
+      format: format ?? this.format,
     );
   }
 
@@ -6305,6 +6346,9 @@ class ReadingHourlyLogsCompanion extends UpdateCompanion<ReadingHourlyLogRow> {
     if (readingTimeMs.present) {
       map['reading_time_ms'] = Variable<int>(readingTimeMs.value);
     }
+    if (format.present) {
+      map['format'] = Variable<String>(format.value);
+    }
     return map;
   }
 
@@ -6314,7 +6358,8 @@ class ReadingHourlyLogsCompanion extends UpdateCompanion<ReadingHourlyLogRow> {
           ..write('id: $id, ')
           ..write('dateKey: $dateKey, ')
           ..write('hour: $hour, ')
-          ..write('readingTimeMs: $readingTimeMs')
+          ..write('readingTimeMs: $readingTimeMs, ')
+          ..write('format: $format')
           ..write(')'))
         .toString();
   }
@@ -28619,6 +28664,7 @@ typedef $$ReadingHourlyLogsTableCreateCompanionBuilder
   required String dateKey,
   required int hour,
   required int readingTimeMs,
+  Value<String> format,
 });
 typedef $$ReadingHourlyLogsTableUpdateCompanionBuilder
     = ReadingHourlyLogsCompanion Function({
@@ -28626,6 +28672,7 @@ typedef $$ReadingHourlyLogsTableUpdateCompanionBuilder
   Value<String> dateKey,
   Value<int> hour,
   Value<int> readingTimeMs,
+  Value<String> format,
 });
 
 class $$ReadingHourlyLogsTableFilterComposer
@@ -28648,6 +28695,9 @@ class $$ReadingHourlyLogsTableFilterComposer
 
   ColumnFilters<int> get readingTimeMs => $composableBuilder(
       column: $table.readingTimeMs, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get format => $composableBuilder(
+      column: $table.format, builder: (column) => ColumnFilters(column));
 }
 
 class $$ReadingHourlyLogsTableOrderingComposer
@@ -28671,6 +28721,9 @@ class $$ReadingHourlyLogsTableOrderingComposer
   ColumnOrderings<int> get readingTimeMs => $composableBuilder(
       column: $table.readingTimeMs,
       builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get format => $composableBuilder(
+      column: $table.format, builder: (column) => ColumnOrderings(column));
 }
 
 class $$ReadingHourlyLogsTableAnnotationComposer
@@ -28693,6 +28746,9 @@ class $$ReadingHourlyLogsTableAnnotationComposer
 
   GeneratedColumn<int> get readingTimeMs => $composableBuilder(
       column: $table.readingTimeMs, builder: (column) => column);
+
+  GeneratedColumn<String> get format =>
+      $composableBuilder(column: $table.format, builder: (column) => column);
 }
 
 class $$ReadingHourlyLogsTableTableManager extends RootTableManager<
@@ -28728,24 +28784,28 @@ class $$ReadingHourlyLogsTableTableManager extends RootTableManager<
             Value<String> dateKey = const Value.absent(),
             Value<int> hour = const Value.absent(),
             Value<int> readingTimeMs = const Value.absent(),
+            Value<String> format = const Value.absent(),
           }) =>
               ReadingHourlyLogsCompanion(
             id: id,
             dateKey: dateKey,
             hour: hour,
             readingTimeMs: readingTimeMs,
+            format: format,
           ),
           createCompanionCallback: ({
             Value<int> id = const Value.absent(),
             required String dateKey,
             required int hour,
             required int readingTimeMs,
+            Value<String> format = const Value.absent(),
           }) =>
               ReadingHourlyLogsCompanion.insert(
             id: id,
             dateKey: dateKey,
             hour: hour,
             readingTimeMs: readingTimeMs,
+            format: format,
           ),
           withReferenceMapper: (p0) => p0
               .map((e) => (e.readTable(table), BaseReferences(db, table, e)))

--- a/packages/hibiki_core/lib/src/database/tables.dart
+++ b/packages/hibiki_core/lib/src/database/tables.dart
@@ -160,9 +160,16 @@ class ReadingHourlyLogs extends Table {
   IntColumn get hour => integer()();
   IntColumn get readingTimeMs => integer()();
 
+  /// v65：写入面身份（`BookFormat.dbValue`：'epub' / 'pdf' / 'manga'）。此前没有
+  /// 任何身份列，EPUB / PDF / 漫画同一小时的时长在写入时就被加成一行，永久分不开；
+  /// 日级 `reading_statistics` 靠 title→format 反查能拆，时段表拆不开只因缺这列。
+  /// `''` = v65 前的历史行（写入时信息已丢，如实标未区分）以及云同步里旧端贡献的
+  /// 无法归因差额（见 aggregate_sync_service 的 deficit-lift）。
+  TextColumn get format => text().withDefault(const Constant(''))();
+
   @override
   List<Set<Column>> get uniqueKeys => [
-        {dateKey, hour},
+        {dateKey, hour, format},
       ];
 }
 


### PR DESCRIPTION
## 问题

时段表 `reading_hourly_logs` 唯一键只有 `{dateKey, hour}`、无任何身份列——EPUB/PDF/漫画同一小时的阅读时长在**写入时**就被加成一行，永久分不开。日级 `reading_statistics` 靠 title→format 反查能拆出书/漫画，只有时段表拆不开；已累加的历史行信息已丢，只能修「往后」。

## 方案

**维度复用 `BookFormat`**（epub/pdf/manga，冻结值域、正是阅读器路由与日级拆分的口径），不造新枚举：

1. **schema v66→v67**：`reading_hourly_logs` 加 `format` 列，唯一键改 `{dateKey, hour, format}`；唯一键变更走 `TableMigration` 重建（先例 v39），旧行零丢失、format 落 `''`（历史未区分，如实标注不猜身份）。
2. **写入面各报身份**：`ReadingTimeTracker` 构造收 `required BookFormat format`；EPUB 阅读器→epub、PDF→pdf、漫画（本地/在线两处）→manga。
3. **云聚合同步**（照 additive-field 兼容先例）：`readingHourly` 保持逐时**总量**（旧端 wire 字节语义不变，Never break userspace）；新增 `readingHourlyByFormat` 按 `{dateKey,hour,format}` MAX 折叠。应用端先落拆分桶，再把旧端总量超出本地小时和的**差额**归因进 `''` 桶——数学上 sum_f MAX_d ≥ MAX_d sum_f，全新端环境差额恒 ≤0（绝不虚增），重复应用差额为 0（幂等）。`setReadingHourlyLog` 的 format 收裸串逐字节透传，未来新格式值不折叠。
4. **备份合并**：hourly MAX-union 键泛化为 `keyColumns`（阅读表三维、视频表两维；备份库 ATTACH 前已迁到当前 schema）。
5. **统计页时段图**改累加（原按行赋值，多 format 行只会显示最后一行）。图表 UI 仍显示合计；按面拆分的堆叠图可作后续 UI 迭代。

## 验证

- `flutter analyze`：hibiki / hibiki_core / hibiki_audio 三处 No issues
- `flutter test test/tools test/database test/sync` + tracker + stat 页纯函数：**2666 全绿**，含：
  - v66→v67 迁移 fixture（旧行保留为 `''`、新唯一键异 format 分行共存）
  - 同 format 累加 / 异 format 分行 / 未区分桶累加 / set 按三元键 OVERWRITE 且未知 format 透传
  - 快照 round-trip、byFormat MAX 合并可交换、旧 payload（无 byFormat）兼容
  - 真库：materialize 拆分 + 旧端总量差额归因 + 重复应用幂等
  - 备份合并 MAX-union 幂等（阅读三维 + 视频两维）
  - `book_format_discipline_guard`（新代码全走枚举 dbValue）
- schemaVersion 钉定断言批量 66→67（24+ 处，全部迁移测试绿）

⚠️ 集成注意：**迁移号 v67** 若与并发任务撞车需顺延（先例见 v65/v66 注释）。

https://claude.ai/code/session_01TSQeGgGjpCsf7xSpih9vgN