### PR TITLE
fix(test): PR#679 新守卫改用共享 maskComments，修 develop 单测门红 (BUG-1358)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1300 条。点号进各自文件。
+> 共 1301 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1358](bugs/BUG-1358-schema-guard-handwritten-comment-strip.md) | ✅ | ✅ | PR#679 新守卫手写 startsWith('//') 剥注释，违反 source_guard 纪律，develop 单测门红 |
 | [BUG-1353](bugs/BUG-1353-ci-macos-bsd-sed-inplace.md) | ✅ | ✅ | CI macos/ios 作业固定红：TMDB key 注入用了 GNU-only 的裸 sed -i |
 | [BUG-1352](bugs/BUG-1352-ci-package-tests-schema-literal.md) | ✅ | ✅ | CI Run package tests 红：packages 侧 schemaVersion 等值断言漏跟 v66 |
 | [BUG-1351](bugs/BUG-1351-scan-playlist-import-no-added-activity.md) | ✅ | ✅ | 扫描导入新播放列表合集不落 added 活动事件 |

--- a/docs/bugs/BUG-1358-schema-guard-handwritten-comment-strip.md
+++ b/docs/bugs/BUG-1358-schema-guard-handwritten-comment-strip.md
@@ -1,0 +1,53 @@
+## BUG-1358 · PR#679 新守卫手写 startsWith('//') 剥注释，违反 source_guard 纪律，develop 单测门红
+
+- **报告**：2026-08-02（用户：巡检发现 develop 单测门红）
+- **真实性**：✅ 真 bug。根因 `hibiki/test/database/package_schema_version_literal_guard_test.dart:54`（PR#679 正文 commit `e48c82587` 新增），写的是
+
+  ```dart
+  if (lines[i].trimLeft().startsWith('//')) continue;
+  ```
+
+  这是 `hibiki/test/helpers/banned_comment_strip.dart` 明令禁用的第一号手写形态，于是
+  `hibiki/test/tools/source_guard_adoption_test.dart` 的
+  「test/ 下不得再手写注释剥离，一律走 helpers/source_guard.dart」当场判红：
+
+  ```
+  Expected: empty
+    Actual: ['test/database/package_schema_version_literal_guard_test.dart:54  用了 startsWith(\'//\') —— 改用 maskComments / containsCodeLine']
+  ```
+
+  讽刺之处：PR#679 本身就是去修 BUG-1352 那条 CI 红的，它引入的守卫又踩了另一条纪律。
+
+- **为什么这条纪律存在**：手写「整行以 `//` 开头就跳过」三个方向都漏——剥不掉行尾注释、
+  剥不掉 `/* */` 块注释、删行还会让后续 `indexOf`/`substring` 的下标与原文错位。
+  对**禁止型**守卫（本例）表现为块注释里的代码被误判成违规（假阳）；对**要求型**守卫
+  则是「把实现删光、只在块注释里留下断言字面量」即可骗绿（假阴）。TODO-2358 / TODO-2477
+  已把存量 22 处迁到共享 helper，`source_guard_adoption_test` 就是防止第 23 处复活的看门人。
+
+- **[x] ① 已修复** — 把注释剥离换成共享词法掩码 `maskComments`
+  （`hibiki/test/helpers/source_guard.dart`）：先整文件掩码，再逐行跑判据正则。
+  没用 `containsCodeLine` 是因为本守卫的判据是**正则**、且报告要给行号，而它只收字面量
+  needle、只返回 bool；`maskComments` 正是它内部用的同一个原语，且**等长等行**，
+  掩码行下标可以直接回原文取证（报告里引用的仍是原始源码行）。
+  提交：见本文件所在 PR。
+
+- **[x] ② 已加自动化测试** — 本条修的就是守卫自身，覆盖它的是既有的
+  `hibiki/test/tools/source_guard_adoption_test.dart`（修前红、修后绿），
+  加上被改守卫自己 `hibiki/test/database/package_schema_version_literal_guard_test.dart`。
+
+- **变异实测**（证明换 helper 后原守卫仍守得住，且顺带修掉一个假阳）：
+  - 变异 A：把 `packages/hibiki_core/test/mihon_database_test.dart:27` 的
+    `expect(database.schemaVersion, greaterThanOrEqualTo(65), ...)` 改回等值字面量
+    `expect(database.schemaVersion, 65, ...)`。该变异**可编译且真跑**，
+    `flutter test` 报 `Expected: <65> Actual: <66>`——正是 BUG-1352 的 CI 红原貌。
+    守卫**如期转红**，并精确报出
+    `../packages/hibiki_core/test/mihon_database_test.dart:27: expect(database.schemaVersion, 65,`
+    （行号正确即证明等长掩码没让下标漂移）。
+  - 变异 B：把 `expect(database.schemaVersion, 65);` 塞进一段 `/* */` 块注释。
+    新版守卫**如期保持绿**（块注释里的不是代码）；旧的 `startsWith('//')` 写法会把这行
+    误判成违规——这就是换 helper 顺带修掉的假阳。
+  - 两次变异均用**反向 Edit 替换**还原（未对未提交文件用 `git checkout --`），
+    还原后 `git status --short` 只剩本轮唯一目标文件。
+
+- **备注**：同一轮实测里 `hibiki/test/.../update_manifest_publish_race_test` 另有 5 个用例红，
+  是 Windows 上 `/tmp/tmp.*` 路径的环境问题，在裸 `origin/develop` 上同样复现，与本条无关。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1118
+version: 1.3.1+1119
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/database/package_schema_version_literal_guard_test.dart
+++ b/hibiki/test/database/package_schema_version_literal_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1352 守卫：`packages/*/test/` 下不得再出现 schemaVersion 的**等值**断言。
 ///
 /// 背景：`HibikiDatabase.schemaVersion` 每次加迁移都 +1，而「当前恰好是第几版」
@@ -49,12 +51,19 @@ void main() {
           in testDir.listSync(recursive: true, followLinks: false)) {
         if (entity is! File || !entity.path.endsWith('.dart')) continue;
         scannedFiles++;
-        final List<String> lines = entity.readAsStringSync().split('\n');
-        for (int i = 0; i < lines.length; i++) {
-          if (lines[i].trimLeft().startsWith('//')) continue;
-          if (exactEquality.hasMatch(lines[i])) {
+        final String source = entity.readAsStringSync();
+        // 剥注释走共享词法掩码（`test/helpers/source_guard.dart`），不手写
+        // 「整行以 // 开头就跳过」：那个形态剥不掉行尾注释与 `/* */` 块注释，
+        // 把违规写法塞进块注释就能骗绿（`source_guard_adoption_test` 守着这条）。
+        // 这里不用 containsCodeLine 是因为判据是**正则**且报告要给行号，而它只收
+        // 字面量 needle、只返回 bool；maskComments 是它内部用的同一个原语，且**等长
+        // 等行**，掩码行下标可以直接回原文取证。
+        final List<String> maskedLines = maskComments(source).split('\n');
+        final List<String> rawLines = source.split('\n');
+        for (int i = 0; i < maskedLines.length; i++) {
+          if (exactEquality.hasMatch(maskedLines[i])) {
             offenders.add(
-                '${entity.path.replaceAll(r'\', '/')}:${i + 1}: ${lines[i].trim()}');
+                '${entity.path.replaceAll(r'\', '/')}:${i + 1}: ${rawLines[i].trim()}');
           }
         }
       }


### PR DESCRIPTION
## 问题

`origin/develop` 单测门红。PR#679（去修 BUG-1352 那条 CI 红的 PR）正文 commit `e48c82587` 新增的守卫
`hibiki/test/database/package_schema_version_literal_guard_test.dart:54` 手写了

```dart
if (lines[i].trimLeft().startsWith('//')) continue;
```

这是 `hibiki/test/helpers/banned_comment_strip.dart` 禁用形态表的第一号，于是
`hibiki/test/tools/source_guard_adoption_test.dart` 当场判红：

```
Expected: empty
  Actual: ['test/database/package_schema_version_literal_guard_test.dart:54  用了 startsWith(\'//\') —— 改用 maskComments / containsCodeLine']
```

## 修法

换成 `test/helpers/source_guard.dart` 的 **`maskComments`**：先整文件词法掩码，再逐行跑判据正则。

没用 `containsCodeLine`，因为本守卫的判据是**正则**、报告还要给行号，而它只收字面量 needle、只返回 bool。
`maskComments` 正是 `containsCodeLine` 内部用的同一个原语，且**等长等行**，掩码行下标可以直接回原文取证
（offender 报告里引用的仍是原始源码行）。

## 变异实测

对 `packages/hibiki_core/test/mihon_database_test.dart:27` 做了两次变异，均**反向替换**还原（未对未提交文件用 `git checkout --`），还原后工作区干净。

| 变异 | 内容 | 可编译 | 守卫 | 结论 |
|---|---|---|---|---|
| A | `greaterThanOrEqualTo(65)` → 等值字面量 `65` | ✅ 真跑出 `Expected: <65> Actual: <66>`（BUG-1352 原貌） | 🔴 如期转红，报 `...mihon_database_test.dart:27: expect(database.schemaVersion, 65,` | 原守卫**仍守得住**，行号正确证明等长掩码没让下标漂移 |
| B | 把 `expect(database.schemaVersion, 65);` 塞进 `/* */` 块注释 | ✅ | 🟢 如期保持绿 | 旧 `startsWith('//')` 写法会把这行误判成违规——换 helper 顺带修掉一个假阳 |

## 验证

- `flutter analyze`（hibiki/，含 test）：`No issues found!`（exit 0）
- 定向测试 `dart run tool/flutter_test_failures.dart --no-pub test/tools/source_guard_adoption_test.dart test/tools/bugs_per_file_guard_test.dart test/helpers test/database/package_schema_version_literal_guard_test.dart`：
  `FLUTTER TEST VERDICT: PASSED - 52 tests ran, all tests passed`（exit 0）
- `dart run tool/bug.dart check`：`check 通过：1298 条，号唯一，索引同步`

> 注：跑 `test/tools` 全目录时另有 5 条红全部落在 `update_manifest_publish_race_test.dart`（Windows 上 `/tmp/tmp.*` 路径的环境问题），在裸 `origin/develop` 上同样复现，与本 PR 无关，未动。

BUG-1358

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
