### PR TITLE
fix(audio): 桌面本地音频查询排在自家绑定期建索引之后 (BUG-1365 / TODO-2514)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1303 条。点号进各自文件。
+> 共 1304 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1365](bugs/BUG-1365-local-audio-query-races-binding-index-build.md) | ✅ | ✅ | 桌面本地音频查询与绑定期建索引竞态：撞锁被吞成 null＝「暂无发音」（CI flaky） |
 | [BUG-1358](bugs/BUG-1358-schema-guard-handwritten-comment-strip.md) | ✅ | ✅ | PR#679 新守卫手写 startsWith('//') 剥注释，违反 source_guard 纪律，develop 单测门红 |
 | [BUG-1353](bugs/BUG-1353-ci-macos-bsd-sed-inplace.md) | ✅ | ✅ | CI macos/ios 作业固定红：TMDB key 注入用了 GNU-only 的裸 sed -i |
 | [BUG-1352](bugs/BUG-1352-ci-package-tests-schema-literal.md) | ✅ | ✅ | CI Run package tests 红：packages 侧 schemaVersion 等值断言漏跟 v66 |

--- a/docs/bugs/BUG-1365-local-audio-query-races-binding-index-build.md
+++ b/docs/bugs/BUG-1365-local-audio-query-races-binding-index-build.md
@@ -1,0 +1,57 @@
+## BUG-1365 · 桌面本地音频查询与绑定期建索引竞态：撞锁被吞成 null＝「暂无发音」（CI flaky）
+- **报告**：2026-08-02（用户：看板 TODO-2514，APK 门偶发红）
+- **真实性**：✅ 真 bug（功能真坏，不是判据坏；只改生产代码即可稳定绿，测试断言一个字没动）。
+
+  CI 现场（run `30686295664`，headSha `2703ef22eb`，Build Release APK / Run unit tests，16382 tests completed）：
+
+  ```
+  desktop TtsChannel local-audio behavior (real sqlite via Isolate.run) queryLocalAudio honors dbIndex bounds
+    Expected: not null
+      Actual: <null>
+    test/utils/misc/local_audio_query_offload_test.dart 191:7
+  ```
+
+  根因链（全在生产代码里）：
+
+  1. `hibiki/lib/src/utils/misc/tts_channel.dart:88` —— `setLocalAudioDbs` 对每个库
+     `unawaited(LocalAudioDb.ensureIndexes(cfg.path))`。那是**我们自己**对同一个库文件开的
+     `OpenMode.readWrite` 连接（`hibiki/lib/src/utils/misc/local_audio_db.dart:146`），跑两条 `CREATE INDEX`。
+  2. `hibiki/lib/src/utils/misc/tts_channel.dart:129` —— `queryLocalAudio` 与那个写连接**完全无序**：
+     绑定一返回就能发查询，两条连接在同一 inode 上抢锁。
+  3. `hibiki/lib/src/utils/misc/local_audio_db.dart:193` —— 只读连接只有
+     `PRAGMA busy_timeout = 3000` 这一道赌注；`CREATE INDEX` 提交阶段持独占锁，赌输就 `SQLITE_BUSY`。
+  4. `hibiki/lib/src/utils/misc/local_audio_db.dart:229` —— `queryMeta` 的
+     `catch (e, stack) { ...; return null; }` 把 BUSY 吞成 `null`，与「库里真没这个词」完全同形。
+     用户侧＝查词「暂无发音」；CI 侧＝上面那条 `Expected not null`。
+
+  两条本地实测证据（Windows，`flutter test`）：
+
+  - **无序窗口 100% 存在**：20 万行库，绑定后立刻查询，查询返回时 `idx_entries_expr_read`
+    尚未建出 —— 修前 **6/6 轮**命中该窗口。
+  - **撞上就必吐 null**：让一个写者持有 EXCLUSIVE 5s（＝真实十万行库上 `CREATE INDEX` 提交的量级），
+    生产 `TtsChannel.queryLocalAudio` 在 3153ms 后返回 `null`，报错形态与 CI 逐字一致
+    （`Expected: not null / Actual: <null>`）。
+
+  注：CI 那次红是 1 行 tiny DB 上的偶发，需要写者在提交窗口被调度器拖住；本机 Windows
+  20 次顺序跑 + 320 轮争用跑都没自然撞出（负载敏感，且 Linux POSIX 锁语义与 Windows 不同）。
+  因此本条按「无序契约」定性与修复，而不是按时间赛跑修。
+
+- **[x] ① 已修复** —— `hibiki/lib/src/utils/misc/tts_channel.dart`：`queryLocalAudio` /
+  `extractLocalAudio` 在把查询交给 `Isolate.run` **之前**，先
+  `await LocalAudioDb.waitForPendingIndexing(<该库路径>)`，把读端确定性地排在自家 in-flight 写端之后。
+  用的是 `ensureIndexes` 早就发布的 per-path 完成信号（`local_audio_manager.dart:286` 删库前已在用同一个原语），
+  **没有加延迟、重试、sleep 或特例分支**；无在途任务时是一次立即完成的 Future，零额外成本。
+  `setLocalAudioDbs` 仍保持 `unawaited`（绑定不阻塞）。
+
+- **[x] ② 已加自动化测试** —— `hibiki/test/utils/misc/local_audio_query_offload_test.dart`：
+  - 行为守卫 `BUG-1365: queries are ordered after our own index build` →
+    `queryLocalAudio does not return while indexing is still in flight`：20 万行库绑定后立刻查询，
+    断言查询返回时索引**已经**建好。变异实测：把 `await Future.wait([... waitForPendingIndexing ...])`
+    换成 `await Future<void>.value()` 后，该用例是**唯一**变红的（`Expected: true / Actual: <false>`），
+    源码守卫仍绿 —— 说明行为守卫不与字符串守卫重复。
+  - 源码守卫 `desktop queryLocalAudio / extractLocalAudio waits out the binding-time index build`：
+    两处方法体必须含 `LocalAudioDb.waitForPendingIndexing(`，且其位置必须早于 `Isolate.run(`（等在后面等于没等）。
+
+- **备注**：残留边界 —— 弹窗词典跑在**独立 isolate**，`_pendingIndexing` 是 per-isolate 静态，
+  跨 isolate 的「A isolate 建索引 / B isolate 查询」仍只有 `busy_timeout` 兜底。这是本次修复之前
+  就存在的行为，未扩大；要根治需把在途登记提升到跨 isolate 共享（或让绑定只发生在主 isolate），另开条目。

--- a/hibiki/lib/src/utils/misc/tts_channel.dart
+++ b/hibiki/lib/src/utils/misc/tts_channel.dart
@@ -144,6 +144,18 @@ class TtsChannel {
         for (final LocalAudioDbConfig c in _desktopDbConfigs)
           (path: c.path, order: List<String>.of(c.sourceOrder)),
       ];
+      // 绑定期 [setLocalAudioDbs] 对同一批库文件 unawaited 派出了
+      // [LocalAudioDb.ensureIndexes]——那是**我们自己**开的 readWrite 连接。
+      // 在它收尾前发查询，两条连接就在同一个 inode 上抢锁：CREATE INDEX 提交
+      // 阶段持独占锁，只读连接的 busy_timeout 一到点就 SQLITE_BUSY，被
+      // [LocalAudioDb.queryMeta] 的 catch 吞成 null——与「库里真没这个词」
+      // 完全同形，用户看到「暂无发音」（BUG-1365）。in-flight 写有现成的
+      // per-path 完成信号，读端排在它后面即可，不靠 busy_timeout 赌赢。
+      // 无在途任务时是一次立即完成的 Future，零额外成本。
+      await Future.wait(<Future<void>>[
+        for (int i = start; i < end && i < configs.length; i++)
+          if (i >= 0) LocalAudioDb.waitForPendingIndexing(configs[i].path),
+      ]);
       try {
         return await Isolate.run(() {
           for (int i = start; i < end && i < configs.length; i++) {
@@ -194,6 +206,10 @@ class TtsChannel {
       // 字符串，Directory 在 worker isolate 内重建）。
       final Directory dir = await getTemporaryDirectory();
       final String cacheDirPath = dir.path;
+      // 同 [queryLocalAudio]：blob 读取也必须排在自家绑定期建索引之后，否则
+      // 撞上 CREATE INDEX 的独占锁 → busy 超时 → extractBlob catch 吞成 null
+      // ＝已查到词条却「音频提取失败」（BUG-1365）。
+      await LocalAudioDb.waitForPendingIndexing(dbPath);
       try {
         return await Isolate.run(() => LocalAudioDb.extractBlob(
               dbPath: dbPath,

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1124
+version: 1.3.1+1125
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/utils/misc/local_audio_query_offload_test.dart
+++ b/hibiki/test/utils/misc/local_audio_query_offload_test.dart
@@ -107,6 +107,29 @@ void main() {
       expect(body, contains('LocalAudioDb.extractBlob('));
     });
 
+    test('desktop queryLocalAudio waits out the binding-time index build', () {
+      final String body = _slice(
+          ttsSrc,
+          'Future<Map<String, dynamic>?> queryLocalAudio(',
+          'Future<String?> extractLocalAudio(');
+      expect(body, contains('LocalAudioDb.waitForPendingIndexing('),
+          reason: 'BUG-1365：查询不排在自家 ensureIndexes 写连接之后，'
+              '就会撞 CREATE INDEX 的独占锁 → busy 超时 → 吞成 null＝「暂无发音」');
+      expect(body.indexOf('LocalAudioDb.waitForPendingIndexing('),
+          lessThan(body.indexOf('Isolate.run(')),
+          reason: '等必须发生在把查询交给 Isolate.run 之前，等在后面等于没等');
+    });
+
+    test('desktop extractLocalAudio waits out the binding-time index build',
+        () {
+      final String body = _slice(ttsSrc, 'Future<String?> extractLocalAudio(',
+          'Future<bool> playFile(');
+      expect(body, contains('LocalAudioDb.waitForPendingIndexing('),
+          reason: 'BUG-1365：blob 提取同样会撞建索引的写锁');
+      expect(body.indexOf('LocalAudioDb.waitForPendingIndexing('),
+          lessThan(body.indexOf('Isolate.run(')));
+    });
+
     test('dead code speak stays deleted (zero callers repo-wide)', () {
       expect(ttsSrc.contains('Future<void> speak('), isFalse,
           reason: 'TtsChannel.speak 全仓零调用者，已删除，不得复活');
@@ -203,6 +226,81 @@ void main() {
       await LocalAudioDb.waitForPendingIndexing(dbPath);
       expect(hasIndex(dbPath, 'idx_entries_expr_read'), isTrue);
       expect(hasIndex(dbPath, 'idx_android_file_source'), isTrue);
+    });
+  });
+
+  /// BUG-1365 的行为守卫：绑定期 `ensureIndexes` 是**我们自己**对同一库文件开的
+  /// readWrite 连接。旧实现里查询与它完全无序，只靠只读连接 3s 的 busy_timeout
+  /// 赌能拿到 shared 锁；赌输就 SQLITE_BUSY → `queryMeta` 的 catch 吞成 null，
+  /// 与「库里真没这个词」同形（用户＝「暂无发音」，CI＝本文件
+  /// `queryLocalAudio honors dbIndex bounds` 偶发 `Expected not null`）。
+  ///
+  /// 这里不测时序快慢（那会造出第二个 flaky），只测**顺序契约**：一个大到建索引
+  /// 明显耗时的库，绑定后立刻查询，查询返回时索引必须已经建好——即读端确实排在
+  /// 自家写端之后。旧实现下查询会在建索引还在途时就返回（实测 6/6 轮）。
+  group('BUG-1365: queries are ordered after our own index build', () {
+    late Directory tmp;
+    late String dbPath;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('hibiki_tts_order');
+      dbPath = '${tmp.path}/audio.db';
+      final Database db = sqlite3.open(dbPath);
+      db.execute('CREATE TABLE entries '
+          '(expression TEXT, reading TEXT, file TEXT, source TEXT)');
+      db.execute('CREATE TABLE android (file TEXT, source TEXT, data BLOB)');
+      // 索引要建得「够慢」才能暴露无序窗口：真实 Yomitan 本地音频库是十万行级。
+      db.execute('BEGIN');
+      final PreparedStatement ins =
+          db.prepare('INSERT INTO entries (expression, reading, file, source) '
+              'VALUES (?,?,?,?)');
+      for (int i = 0; i < 200000; i++) {
+        ins.execute(<Object?>['w$i', 'r$i', 'f$i.mp3', 'src1']);
+      }
+      ins.execute(<Object?>['勉強', 'べんきょう', 'a.mp3', 'src1']);
+      ins.dispose();
+      db.execute('COMMIT');
+      final PreparedStatement stmt =
+          db.prepare('INSERT INTO android (file, source, data) VALUES (?,?,?)');
+      stmt.execute(<Object?>[
+        'a.mp3',
+        'src1',
+        Uint8List.fromList(<int>[1, 2])
+      ]);
+      stmt.dispose();
+      db.dispose();
+    });
+
+    tearDown(() async {
+      await TtsChannel.instance.setLocalAudioDbs(const <LocalAudioDbConfig>[]);
+      await LocalAudioDb.waitForPendingIndexing();
+      if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    });
+
+    bool indexBuilt(String path) {
+      final Database probe = sqlite3.open(path, mode: OpenMode.readOnly);
+      try {
+        probe.execute('PRAGMA busy_timeout = 10000');
+        return probe.select(
+          "SELECT name FROM sqlite_master WHERE type='index' AND name=?",
+          <Object?>['idx_entries_expr_read'],
+        ).isNotEmpty;
+      } finally {
+        probe.dispose();
+      }
+    }
+
+    test('queryLocalAudio does not return while indexing is still in flight',
+        () async {
+      expect(indexBuilt(dbPath), isFalse, reason: '导入的库本无索引');
+      await TtsChannel.instance.setLocalAudioDbs(
+          <LocalAudioDbConfig>[LocalAudioDbConfig(path: dbPath)]);
+      final Map<String, dynamic>? hit =
+          await TtsChannel.instance.queryLocalAudio('勉強', 'べんきょう', dbIndex: 0);
+      expect(indexBuilt(dbPath), isTrue,
+          reason: '查询返回时自家建索引还在途 → 读写无序，撞锁只是时间问题（BUG-1365）');
+      expect(hit, isNotNull);
+      expect(hit!['file'], 'a.mp3');
     });
   });
 }


### PR DESCRIPTION
## 结论：功能真坏，不是判据坏

只改生产代码、测试断言一个字没动，原用例即稳定绿。

## 根因

`local_audio_query_offload_test`「queryLocalAudio honors dbIndex bounds」在 APK 门偶发红
（`Expected: not null / Actual: <null>`，run `30686295664`，headSha `2703ef22eb`，16382 tests completed）。

1. `hibiki/lib/src/utils/misc/tts_channel.dart:88` — `setLocalAudioDbs` 对每个库
   `unawaited(LocalAudioDb.ensureIndexes(cfg.path))`，那是**我们自己**对同一库文件开的
   `readWrite` 连接（`local_audio_db.dart:146`），跑两条 `CREATE INDEX`。
2. `tts_channel.dart:129` — `queryLocalAudio` 与那个写连接**完全无序**，绑定一返回就能发查询。
3. `local_audio_db.dart:193` — 只读连接只有 `busy_timeout = 3000` 一道赌注；`CREATE INDEX`
   提交阶段持独占锁，赌输就 `SQLITE_BUSY`。
4. `local_audio_db.dart:229` — `queryMeta` 的 `catch → return null` 把 BUSY 吞成 `null`，
   与「库里真没这个词」完全同形。用户侧就是查词「暂无发音」。

即：这不只是 CI flaky，是真实用户路径上的缺陷（导入大库后立刻查词会静默失败）。

## 修法（无延迟、无重试、无吞异常）

把查询交给 `Isolate.run` **之前**，先 `await LocalAudioDb.waitForPendingIndexing(<该库路径>)`
——用的是 `ensureIndexes` 早就发布的 per-path 完成信号（`local_audio_manager.dart:286`
删库前已在用同一原语）。补的是缺失的**顺序契约**，不是给测试加 `await` 迁就 bug。
无在途任务时是一次立即完成的 Future，零额外成本；`setLocalAudioDbs` 仍 `unawaited`，绑定不阻塞。
`extractLocalAudio` 同样处理（blob 提取撞同一把锁）。

## 证据

| 项 | 结果 |
|---|---|
| 无序窗口（20 万行库，绑定后立刻查询，返回时索引是否已建好） | **修前 6/6 轮命中窗口**；修后 0（由构造保证） |
| 写者持锁 5s 时生产 `queryLocalAudio` 的返回 | 3153ms 后 `null`，与 CI 报错逐字同形 |
| 原用例重复跑（修后） | **0 / 20 红** |
| 变异测试（`await Future.wait([...waitForPendingIndexing...])` → `await Future<void>.value()`） | 新行为守卫是**唯一**变红用例（`Expected: true / Actual: <false>`），源码守卫仍绿 |
| `flutter analyze`（含 test） | `No issues found! (ran in 31.7s)` |
| 定向测试 | `FLUTTER TEST VERDICT: PASSED - 47 tests ran`（改动直接消费方 + bug 守卫）<br>`FLUTTER TEST VERDICT: PASSED - 672 tests ran`（`test/utils/misc` 全目录） |

诚实说明：本机 Windows 未能自然撞出 CI 那次偶发（20 次顺序 + 320 轮争用 + 16 路并发均绿；
并发跑出的红全是 `flutter test` 进程互抢 `sqlite3.dll` 的基础设施伪红）。CI 那次是 1 行 tiny DB
上写者被调度器拖住，负载敏感且 Linux POSIX 锁语义与 Windows 不同。因此本 PR 按**无序契约**
定性与修复，并用上表两条确定性实测（窗口存在性 + 撞上必吐 null）替代时间赛跑式复现。

## 守卫

- 行为守卫 `BUG-1365: queries are ordered after our own index build`。
- 源码守卫：`queryLocalAudio` / `extractLocalAudio` 方法体须含 `LocalAudioDb.waitForPendingIndexing(`，
  且位置早于 `Isolate.run(`（等在后面等于没等）。

## 残留边界（未扩大，另开条目）

弹窗词典跑在独立 isolate，`_pendingIndexing` 是 per-isolate 静态，跨 isolate 的
「A 建索引 / B 查询」仍只有 `busy_timeout` 兜底 —— 本次修复之前就是如此。

BUG 建档：`docs/bugs/BUG-1365-local-audio-query-races-binding-index-build.md`

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
