### PR TITLE
fix(lookup): 搜索中占位卡纳入对话框隐藏计数，不再盖住对话框 (BUG-1364 / TODO-2510)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1302 条。点号进各自文件。
+> 共 1303 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1364](bugs/BUG-1364-search-placeholder-covers-dialog.md) | ✅ | ✅ | 搜索中占位层未接对话框隐藏计数，可能盖住对话框 |
 | [BUG-1358](bugs/BUG-1358-schema-guard-handwritten-comment-strip.md) | ✅ | ✅ | PR#679 新守卫手写 startsWith('//') 剥注释，违反 source_guard 纪律，develop 单测门红 |
 | [BUG-1353](bugs/BUG-1353-ci-macos-bsd-sed-inplace.md) | ✅ | ✅ | CI macos/ios 作业固定红：TMDB key 注入用了 GNU-only 的裸 sed -i |
 | [BUG-1352](bugs/BUG-1352-ci-package-tests-schema-literal.md) | ✅ | ✅ | CI Run package tests 红：packages 侧 schemaVersion 等值断言漏跟 v66 |

--- a/docs/bugs/BUG-1364-search-placeholder-covers-dialog.md
+++ b/docs/bugs/BUG-1364-search-placeholder-covers-dialog.md
@@ -1,0 +1,46 @@
+## BUG-1364 · 搜索中占位层未接对话框隐藏计数，可能盖住对话框
+- **报告**：2026-08-02（看板 TODO-2510，BUG-797 同族旧遗留复核，非近期 PR 引入）
+- **真实性**：✅ 真 bug（层级契约漏项）。根因
+  `hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart:790-840`
+  的 `buildPopupLoadingPlaceholder`（「搜索→就绪才显示」期间画的加载占位卡）**没接**
+  同文件 `:151` 的 `_popupHidingDialogDepth`。
+  - **层级机理**：三个走**根 Overlay** 的宿主（`video_hibiki_page.dart:3941` /
+    `home_dictionary_page.dart` / `texthooker_page.dart:1743` 各自 `overlay.insert`）
+    与常驻 `main.dart` 根 builder 的 `floating_lyric_lookup_host.dart:183`，整棵浮层
+    子树都排在 `showAppDialog` 推的路由**之上**。浮层子树三个组成部分里，barrier 走
+    `shouldShowLookupDismissBarrier`（BUG-1327 已接）、弹窗层走 `parkedPopupLayer` 的
+    `visible && _popupHidingDialogDepth == 0`（BUG-797/1040 已接），只剩这张占位卡漏了。
+  - **这一层不是平台视图**：占位卡是纯 Flutter（`HibikiPopupSurface` +
+    `LinearProgressIndicator`），不是 WebView。所以它盖住对话框**不是** BUG-797 的
+    airspace 原因，而是根 Overlay 的 Flutter z-order；对应地，让位也不需要
+    `parkedPopupLayer` 的「停靠屏外」补偿，`Visibility` 就真的不画不吃点击。
+  - **为什么当初漏掉**：BUG-797 只盯「原生平台视图盖住对话框」，占位卡不是平台视图；
+    BUG-1327 只盯「barrier 吃掉命中测试」。两次都没把「浮层子树整体让位」当成一条契约，
+    于是这条纯 Flutter 分支两次都不在视野内。
+  - **触发时序真实可达**：对话框打开期间再起一次**顶层**查词时，
+    `DictionaryPopupController.beginTop`（`dictionary_popup_controller.dart:201-237`）
+    把复用热槽 / 新目标一律置 `visible = false` → `hasVisiblePopup` 变假 →
+    `pushNestedPopup` 的 `if (!controller.hasVisiblePopup) controller.beginSearchUi(rect)`
+    成立 → 占位卡出现在对话框上面。这类顶层查词不需要点到 app 本体（对话框模态遮罩
+    挡不住它们）：悬浮歌词是独立系统窗口、texthooker / 全局查词的文本来自 app 外。
+  - **reader 车道不受影响**：`base_source_page.dart:685` 的 `_buildLoadingPlaceholder`
+    画在页面路由内，对话框路由在其之上，天然不遮（同理其 barrier 也没接计数）。
+- **[x] ① 已修复** — 在**单一入口** `buildPopupLoadingPlaceholder` 里把这一层纳入既有的
+  嵌套安全计数：外层 `Positioned` 不动（宿主 Stack 子项数与布局不变），内层包
+  `Visibility(visible: _popupHidingDialogDepth == 0)`。四个宿主全部经此方法构造占位卡，
+  故无需改任何调用点，也不会再出现「某个宿主忘接」的漂移。顺带补上占位卡的稳定 key
+  `kLookupSearchPlaceholderKey`（对齐 reader 车道的
+  `base-source-popup-loading-placeholder`，barrier 插拔时不与弹窗层按位置错配，BUG-941 同族）。
+  提交：见下方备注。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/lookup_search_placeholder_dialog_test.dart`
+  （**行为级**，非源码扫描）：在 mixin 宿主上构造「搜索中 → 此时打开对话框」的真实时序，
+  断言占位卡内容不再渲染、`Positioned` 槽位保留、对话框关闭后复原；第二条覆盖嵌套对话框
+  （内层 `finally` 不得提前放出占位卡）。变异实测：把 `visible:` 改回恒 `true` → 两条全红；
+  反向替换还原后全绿。
+- **备注**：未做真机复验（本轮为契约层修复，无 UI 观感变化）。另发现两处**未纳入本轮范围**
+  的同族疑点，供后续判断：① `floating_lyric_lookup_host.dart:75` 的
+  `shouldBlockHitTest`（= `isSearchingUi || hasVisiblePopup`）同样没接对话框计数，对话框
+  期间该 host 仍参与命中测试（其子层此时都不可命中，故当前无实际症状，但判据与
+  `shouldShowLookupDismissBarrier` 不同源）；② 目前「浮层子树整体让位」这条契约由三处
+  各自表达（barrier 纯函数 / 弹窗层 `parkedPopupLayer` / 占位卡 `Visibility`），没有
+  单一守卫钉住「新加的浮层子项必须接计数」——若再加第四种子项，仍可能重演本条。

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -28,6 +28,12 @@ import 'package:hibiki/utils.dart';
 // 弹窗条目统一为共享的 [DictionaryPopupEntry]（见 dictionary_popup_controller.dart）；
 // 旧的 NestedPopupEntry / _PopupStackItem 两份重复类型已收口为它一个。
 
+/// 搜索期加载占位卡（[DictionaryPageMixin.buildPopupLoadingPlaceholder]）在宿主 Stack
+/// 里的稳定身份 key。与 reader 车道 `base-source-popup-loading-placeholder` 同用途，
+/// 也是 BUG-1364 行为测试定位该层的锚点。
+const ValueKey<String> kLookupSearchPlaceholderKey =
+    ValueKey<String>('mixin-popup-loading-placeholder');
+
 /// Non-generic mixin that consolidates the popup stack management, Anki mining,
 /// and audio auto-read logic shared across PopupDictionaryPage
 /// and HomeDictionaryPage.
@@ -790,6 +796,21 @@ mixin DictionaryPageMixin {
   /// 搜索期加载占位卡（「搜索→就绪才显示」模式）：在选中词 [rect] 处画一张与弹窗
   /// 同色的小卡 + 顶部进度条，全程不露空 WebView（与书内 base_source_page 同观感）。
   /// 宿主在 [DictionaryPopupController.isSearchingUi] 为真时渲染。
+  ///
+  /// BUG-1364（BUG-797/1040/1327 同族遗留）：本层此前**没接** [_popupHidingDialogDepth]。
+  /// 三个走根 Overlay 的宿主（视频页 / 首页词典页 / texthooker）+ 常驻根 builder 的
+  /// 悬浮歌词 host，整棵浮层子树都排在 `showAppDialog` 推的路由**之上**，所以对话框
+  /// 打开期间浮层的三个组成部分必须一起让位：barrier（[shouldShowLookupDismissBarrier]）、
+  /// 弹窗层（[parkedPopupLayer] 的 `visible`）都已接线，只剩这张占位卡漏了 → 对话框
+  /// 期间只要再起一次**顶层**查词（[DictionaryPopupController.beginTop] 会把复用的热槽
+  /// / 新目标置 `visible=false`，于是 `hasVisiblePopup` 变假、[pushNestedPopup] 进搜索
+  /// 占位态），这张不透明小卡就画在对话框上面。异步触发真实存在：悬浮歌词是独立系统
+  /// 窗口、texthooker / 全局查词的文本来自 app 外，都不受对话框模态遮罩约束。
+  ///
+  /// 与弹窗层不同，本层是**纯 Flutter widget**（无原生平台视图），故不需要
+  /// [parkedPopupLayer] 的「停靠屏外」补偿——那套几何只为绕开平台视图无视 `Opacity` /
+  /// `IgnorePointer` 的 airspace 行为。这里 [Visibility] 即可真正让位（不画、不吃点击），
+  /// 且外层 [Positioned] 尺寸不变，宿主 Stack 的子项数与布局都不受影响。
   Widget buildPopupLoadingPlaceholder({
     required Rect rect,
     required Size screen,
@@ -799,21 +820,29 @@ mixin DictionaryPageMixin {
         (mixinAppModel.overrideDictionaryTheme ?? mixinTheme).colorScheme;
     final Color fill = mixinAppModel.overrideDictionaryColor ?? cs.surface;
     return Positioned(
+      // 占位层的稳定 key（与弹窗层的 `ObjectKey(entry)` 配套，对齐 reader 车道的
+      // `base-source-popup-loading-placeholder`）：barrier 插拔时 Stack 里的子项按 key
+      // 匹配，占位层与弹窗层不会被按位置错配成对方（BUG-941 同族）。
+      key: kLookupSearchPlaceholderKey,
       left: pos.left,
       top: pos.top,
       width: pos.width,
       height: pos.height,
-      child: HibikiPopupSurface(
-        color: fill,
-        child: Column(
-          children: <Widget>[
-            LinearProgressIndicator(
-              backgroundColor: Colors.transparent,
-              color: cs.primary,
-              minHeight: 2.75,
-            ),
-            const Expanded(child: SizedBox.shrink()),
-          ],
+      child: Visibility(
+        // BUG-1364：与 [parkedPopupLayer] 的 `visible` 同源，纳入同一个嵌套安全计数。
+        visible: _popupHidingDialogDepth == 0,
+        child: HibikiPopupSurface(
+          color: fill,
+          child: Column(
+            children: <Widget>[
+              LinearProgressIndicator(
+                backgroundColor: Colors.transparent,
+                color: cs.primary,
+                minHeight: 2.75,
+              ),
+              const Expanded(child: SizedBox.shrink()),
+            ],
+          ),
         ),
       ),
     );

--- a/hibiki/test/pages/lookup_search_placeholder_dialog_test.dart
+++ b/hibiki/test/pages/lookup_search_placeholder_dialog_test.dart
@@ -1,0 +1,257 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_page_mixin.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_controller.dart';
+import 'package:hibiki_dictionary/hibiki_dictionary.dart';
+
+import '../helpers/fake_inappwebview_platform.dart';
+import '../helpers/test_platform_services.dart';
+
+/// BUG-1364（BUG-797 / BUG-1040 / BUG-1327 同族遗留）：查词浮层子树里「搜索中」的
+/// 加载占位卡此前没接 `_popupHidingDialogDepth`。
+///
+/// 三个走**根 Overlay** 的宿主（视频页 / 首页词典页 / texthooker）与常驻根 builder 的
+/// 悬浮歌词 host，整棵浮层子树都排在 `showAppDialog` 推的路由之上；对话框打开期间
+/// barrier 与弹窗层都已让位，唯独这张不透明占位卡照画 → 盖住对话框。
+///
+/// 触发时序真实存在：对话框打开期间再起一次**顶层**查词时，
+/// [DictionaryPopupController.beginTop] 会把复用的热槽 / 新目标置 `visible = false`，
+/// 于是 `hasVisiblePopup` 变假、`pushNestedPopup` 进搜索占位态。这类查词不需要点到
+/// app 本体（对话框模态遮罩挡不住它们）：悬浮歌词是独立系统窗口，texthooker /
+/// 全局查词的文本来自 app 外。
+///
+/// 本测试直接构造「搜索中 → 此时打开对话框」的时序，断言占位卡真的让位（不在树里
+/// 渲染），且外层 [Positioned] 槽位仍在（宿主 Stack 子项数与布局不变），对话框关闭
+/// 后复原；并覆盖嵌套对话框（计数）不被内层 `finally` 提前复位。
+class _PlaceholderTestAppModel extends AppModel {
+  _PlaceholderTestAppModel({this.results = const <DictionaryEntry>[]})
+      : super(testPlatformServices());
+
+  final List<DictionaryEntry> results;
+
+  @override
+  int get maximumTerms => 10;
+
+  @override
+  double get popupMaxWidth => 360;
+
+  @override
+  double get popupMaxHeight => 360;
+
+  @override
+  bool get popupBottomDocked => false;
+
+  @override
+  double get appUiScale => 1.0;
+
+  @override
+  List<String> get enabledAudioSources => const <String>[];
+
+  @override
+  void addToDictionaryHistory({required DictionarySearchResult result}) {}
+
+  @override
+  void addToSearchHistory({
+    required String historyKey,
+    required String searchTerm,
+  }) {}
+
+  @override
+  Future<DictionarySearchResult> searchDictionary({
+    required String searchTerm,
+    required bool searchWithWildcards,
+    int? overrideMaximumTerms,
+    bool useCache = true,
+    bool allowRemoteLookup = true,
+  }) async {
+    return DictionarySearchResult(searchTerm: searchTerm, entries: results);
+  }
+}
+
+/// 复刻三个根 Overlay 宿主的浮层 Stack 构成（占位卡 + 弹窗层），不牵扯 media_kit /
+/// 真实页面。
+class _PlaceholderHostPage extends ConsumerStatefulWidget {
+  const _PlaceholderHostPage({super.key});
+
+  @override
+  ConsumerState<_PlaceholderHostPage> createState() =>
+      _PlaceholderHostPageState();
+}
+
+class _PlaceholderHostPageState extends ConsumerState<_PlaceholderHostPage>
+    with DictionaryPageMixin {
+  final DictionaryPopupController controller =
+      DictionaryPopupController(lowMemory: false);
+
+  @override
+  AppModel get mixinAppModel => ref.read(appProvider);
+
+  @override
+  ThemeData get mixinTheme => Theme.of(context);
+
+  /// 收尾：把 [DictionaryPopupController.markPendingReveal] 挂的兜底 Timer 落地，
+  /// 否则 widget 树 dispose 后仍有 pending timer，测试框架直接判红。
+  void settlePendingReveal() {
+    setState(() {
+      for (final DictionaryPopupEntry entry in controller.entries) {
+        controller.revealRendered(entry);
+      }
+      controller.endSearchUi();
+    });
+  }
+
+  Future<int> lookup(String term) => pushNestedPopup(
+        query: term,
+        selectionRect: const Rect.fromLTWH(20, 20, 4, 4),
+        controller: controller,
+        replaceStack: true,
+        autoRead: false,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final Size screen = Size(constraints.maxWidth, constraints.maxHeight);
+        return Stack(
+          clipBehavior: Clip.none,
+          children: <Widget>[
+            if (controller.isSearchingUi && controller.pendingRect != null)
+              buildPopupLoadingPlaceholder(
+                rect: controller.pendingRect!,
+                screen: screen,
+              ),
+            for (int i = 0; i < controller.entries.length; i++)
+              buildNestedPopupLayer(
+                index: i,
+                screen: screen,
+                controller: controller,
+                onPush: (String text, Rect rect) async => 0,
+                onPop: (int index) {},
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+Widget _wrap(AppModel appModel, GlobalKey<_PlaceholderHostPageState> key) {
+  return ProviderScope(
+    overrides: <Override>[appProvider.overrideWith((Ref ref) => appModel)],
+    child: TranslationProvider(
+      child: MaterialApp(
+        builder: (BuildContext context, Widget? child) =>
+            child ?? const SizedBox.shrink(),
+        home: Scaffold(body: _PlaceholderHostPage(key: key)),
+      ),
+    ),
+  );
+}
+
+/// 占位卡「正在画」的判据：外层 [Positioned] 槽位内还有那条进度条。
+Finder get _placeholderProgress => find.descendant(
+      of: find.byKey(kLookupSearchPlaceholderKey),
+      matching: find.byType(LinearProgressIndicator),
+    );
+
+void main() {
+  setUpAll(installFakeInAppWebViewPlatform);
+
+  setUp(() => LocaleSettings.setLocale(AppLocale.en));
+
+  testWidgets('搜索中占位卡在对话框期间让位，对话框关闭后复原', (WidgetTester tester) async {
+    final GlobalKey<_PlaceholderHostPageState> key =
+        GlobalKey<_PlaceholderHostPageState>();
+    await tester.pumpWidget(
+      _wrap(
+        _PlaceholderTestAppModel(
+          results: <DictionaryEntry>[
+            DictionaryEntry(word: '語', reading: 'ご', meaning: 'word'),
+          ],
+        ),
+        key,
+      ),
+    );
+
+    final _PlaceholderHostPageState state = key.currentState!;
+    await state.lookup('語');
+    await tester.pump();
+
+    // 「搜索中」窗口期：结果已到但还在等 WebView render 信号，占位卡在画。
+    expect(state.controller.isSearchingUi, isTrue);
+    expect(find.byKey(kLookupSearchPlaceholderKey), findsOneWidget);
+    expect(_placeholderProgress, findsOneWidget, reason: '搜索中占位卡本该可见');
+
+    // 此刻打开一个「必须盖住查词弹窗」的对话框。
+    final Completer<void> dialog = Completer<void>();
+    final Future<void> hidden =
+        state.runWithLookupPopupHidden<void>(() => dialog.future);
+    await tester.pump();
+
+    expect(state.controller.isSearchingUi, isTrue,
+        reason: '对话框不改变搜索状态，占位卡的显示条件仍成立');
+    expect(_placeholderProgress, findsNothing,
+        reason: 'BUG-1364：浮层子树排在对话框路由之上，占位卡必须与 barrier / 弹窗层'
+            '一起让位，否则这张不透明小卡画在对话框上面');
+    expect(find.byKey(kLookupSearchPlaceholderKey), findsOneWidget,
+        reason: '让位只藏内容：Positioned 槽位保留，宿主 Stack 子项数与布局不变');
+
+    dialog.complete();
+    await hidden;
+    await tester.pump();
+
+    expect(_placeholderProgress, findsOneWidget, reason: '对话框关闭后占位卡复原');
+
+    state.settlePendingReveal();
+    await tester.pump();
+  });
+
+  testWidgets('嵌套对话框：内层关闭不提前放出占位卡', (WidgetTester tester) async {
+    final GlobalKey<_PlaceholderHostPageState> key =
+        GlobalKey<_PlaceholderHostPageState>();
+    await tester.pumpWidget(
+      _wrap(
+        _PlaceholderTestAppModel(
+          results: <DictionaryEntry>[
+            DictionaryEntry(word: '語', reading: 'ご', meaning: 'word'),
+          ],
+        ),
+        key,
+      ),
+    );
+
+    final _PlaceholderHostPageState state = key.currentState!;
+    await state.lookup('語');
+    await tester.pump();
+    expect(_placeholderProgress, findsOneWidget);
+
+    final Completer<void> outer = Completer<void>();
+    final Completer<void> inner = Completer<void>();
+    final Future<void> outerRun =
+        state.runWithLookupPopupHidden<void>(() => outer.future);
+    final Future<void> innerRun =
+        state.runWithLookupPopupHidden<void>(() => inner.future);
+    await tester.pump();
+    expect(_placeholderProgress, findsNothing);
+
+    inner.complete();
+    await innerRun;
+    await tester.pump();
+    expect(_placeholderProgress, findsNothing,
+        reason: '外层对话框还开着，计数未归零，占位卡不得回来');
+
+    outer.complete();
+    await outerRun;
+    await tester.pump();
+    expect(_placeholderProgress, findsOneWidget);
+
+    state.settlePendingReveal();
+    await tester.pump();
+  });
+}


### PR DESCRIPTION
## 问题（BUG-797 / 1040 / 1327 同族遗留，非近期 PR 引入）

`dictionary_page_mixin.dart` 的 `buildPopupLoadingPlaceholder`（「搜索→就绪才显示」期间画的加载占位卡）**没接** `_popupHidingDialogDepth`。

三个走**根 Overlay** 的宿主（视频页 / 首页词典页 / texthooker，各自 `overlay.insert`）与常驻 `main.dart` 根 builder 的悬浮歌词 host，整棵浮层子树都排在 `showAppDialog` 推的路由**之上**。子树三个组成部分里：

| 子项 | 是否接对话框计数 |
|---|---|
| dismiss barrier（`shouldShowLookupDismissBarrier`） | ✅ BUG-1327 |
| 弹窗层（`parkedPopupLayer` 的 `visible`） | ✅ BUG-797 / 1040 |
| **搜索中占位卡** | ❌ 本 PR |

**这一层不是平台视图**：占位卡是纯 Flutter（`HibikiPopupSurface` + `LinearProgressIndicator`）。所以它盖住对话框不是 BUG-797 的 airspace 原因，而是根 Overlay 的 Flutter z-order；对应地让位也不需要「停靠屏外」补偿。

**触发时序真实可达**：对话框打开期间再起一次**顶层**查词时，`DictionaryPopupController.beginTop` 把复用热槽 / 新目标一律置 `visible = false` → `hasVisiblePopup` 变假 → `pushNestedPopup` 进搜索占位态 → 占位卡画在对话框上面。这类查词不需要点到 app 本体（对话框模态遮罩挡不住）：悬浮歌词是独立系统窗口、texthooker / 全局查词的文本来自 app 外。

reader 车道（`base_source_page._buildLoadingPlaceholder`）画在页面路由内，天然不遮，不受影响。

## 修法

纳入既有机制，改在**单一入口**：`buildPopupLoadingPlaceholder` 内层包 `Visibility(visible: _popupHidingDialogDepth == 0)`，外层 `Positioned` 保持不变（宿主 Stack 子项数与布局不变）。四个宿主全部经此方法构造占位卡，无需改任何调用点，也不会再出现「某个宿主忘接」的漂移。

顺带补占位卡稳定 key `kLookupSearchPlaceholderKey`，对齐 reader 车道的 `base-source-popup-loading-placeholder`（BUG-941 同族）。

## 测试

`hibiki/test/pages/lookup_search_placeholder_dialog_test.dart`（**行为级**，非源码扫描）：
- 构造「搜索中 → 此时打开对话框」时序，断言占位卡内容不再渲染、`Positioned` 槽位保留、对话框关闭后复原；
- 嵌套对话框：内层 `finally` 不得提前放出占位卡。

**变异实测**：把 `visible:` 改回恒 `true` → 两条全红（`FLUTTER TEST VERDICT: FAILED - ... 2 error event(s), 2 test(s) completed`）；反向替换还原后全绿。

## 门禁

- `flutter analyze`（含 test）：`No issues found!`（exit 0）
- 定向：`FLUTTER TEST VERDICT: PASSED - 33 tests ran, all tests passed`（新测试 + warm slot + zorder guard + dismiss barrier + home dictionary + bugs per-file guard）
- 全 `test/pages`：2551 tests，1 红 `reader_lyrics_progress_bottom_reserve_static_test.dart`（扫 `reader_hibiki_page.dart`，本 PR 未触碰，**先于本改动存在**）
- 未做真机复验（契约层修复，无 UI 观感变化）

## 未纳入本轮范围的同族疑点

1. `floating_lyric_lookup_host.dart:75` 的 `shouldBlockHitTest`（`isSearchingUi || hasVisiblePopup`）同样没接对话框计数——对话框期间该 host 仍参与命中测试。其子层此时都不可命中，故当前无实际症状，但判据与 `shouldShowLookupDismissBarrier` 不同源。
2. 「浮层子树整体让位」这条契约目前由三处各自表达，没有单一守卫钉住「新加的浮层子项必须接计数」——再加第四种子项仍可能重演本条。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
