### PR TITLE
docs(comments): 修两类与事实不符的注释——ffmpeg-min 编码器现状 + schema 版本号 (TODO-2569)

### DIFF
--- a/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -796,10 +796,13 @@ List<String> buildFfmpegClipGifArgs({
 ///   本负载是 16–48 帧的短片，延迟比压缩率重要，且静态链接体积约 3–5MB 对 5–9MB）。
 ///
 /// 三条分支的参数形态已在带 libsvtav1/libwebp 的真实 ffmpeg 上跑通（1080p30 源 4 秒窗，
-/// 480px·8fps：AVIF 36 KB / WebP 163 KB / GIF 471 KB）。**但入库的 `ffmpeg-min` 尚未含
-/// 这两个编码器**（见 `tool/ffmpeg-min/build-ffmpeg-min.sh`）——须重跑
-/// `.github/workflows/ffmpeg-min.yml` 并重新 vendor exe。在那之前调用点的 fail-open
-/// 会把 AVIF/WebP 降级回 GIF，卡照样制得出来，只是用户选的格式暂不生效。
+/// 480px·8fps：AVIF 36 KB / WebP 163 KB / GIF 471 KB）。**入库的 `ffmpeg-min` 已含这两个
+/// 编码器**（配方 `tool/ffmpeg-min/build-ffmpeg-min.sh` 的 `--enable-libsvtav1
+/// --enable-libwebp` + `ENCODERS` 含 `libsvtav1,libwebp_anim`；exe 由 `fdd5001ff` 重新
+/// vendor，`third_party/ffmpeg-min/windows/ffmpeg.exe -encoders` 可复核）——桌面端不会
+/// 产生注定失败的编码调用，**别为此再跑一次 `.github/workflows/ffmpeg-min.yml`**。
+/// 调用点按 [MiningAnimatedFormat.encodeAttempts] 降级回 GIF 的链路保留为兜底（用户
+/// 自带的外部 ffmpeg 可能缺编码器），不是当前入库 exe 的常态路径。
 ///
 /// `-2` 让高度按宽度等比且取偶（三种编码器都要求偶数维度）。`-ss`/`-t` 置于 `-i` 前做
 /// 快速输入定位（多 GB 剧集不从 0 解码）。时长 clamp 到 `(0, maxDurationMs]`。

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -2671,7 +2671,7 @@ class HibikiDatabase extends _$HibikiDatabase {
                 t.collectionId.equals(collectionId)))
           .go();
 
-  // ── collection_relations（合集相关作品，schema v65 / TODO-2484）──────
+  // ── collection_relations（合集相关作品，schema v66 / TODO-2484）──────
 
   /// 整体替换某合集的相关作品边（重刮即替换）。
   ///

--- a/packages/hibiki_core/lib/src/database/database.g.dart
+++ b/packages/hibiki_core/lib/src/database/database.g.dart
@@ -6172,10 +6172,10 @@ class ReadingHourlyLogRow extends DataClass
   final int hour;
   final int readingTimeMs;
 
-  /// v65：写入面身份（`BookFormat.dbValue`：'epub' / 'pdf' / 'manga'）。此前没有
+  /// v67：写入面身份（`BookFormat.dbValue`：'epub' / 'pdf' / 'manga'）。此前没有
   /// 任何身份列，EPUB / PDF / 漫画同一小时的时长在写入时就被加成一行，永久分不开；
   /// 日级 `reading_statistics` 靠 title→format 反查能拆，时段表拆不开只因缺这列。
-  /// `''` = v65 前的历史行（写入时信息已丢，如实标未区分）以及云同步里旧端贡献的
+  /// `''` = v67 前的历史行（写入时信息已丢，如实标未区分）以及云同步里旧端贡献的
   /// 无法归因差额（见 aggregate_sync_service 的 deficit-lift）。
   final String format;
   const ReadingHourlyLogRow(
@@ -17907,7 +17907,7 @@ class VideoScrapeMetaRow extends DataClass
   /// 条目详情页 URL（`https://bgm.tv/subject/<id>`），供「查看条目」跳转。
   final String? detailUrl;
 
-  /// 集号（v65 / TODO-2491）：集级刮削按文件名解析的集号与源的分集列表对齐后写入
+  /// 集号（v66 / TODO-2491）：集级刮削按文件名解析的集号与源的分集列表对齐后写入
   /// （TMDB `episode_number` / Bangumi `sort`）。NULL = 本行是旧的**作品级**资料
   /// （v54~v64 的自动刮削把整部作品的简介写进每个文件），或集级刮削未能从文件名
   /// 解出集号。存对齐后的**源侧集号**而非文件名原文，便于重刮时按号更新。

--- a/packages/hibiki_core/lib/src/database/tables.dart
+++ b/packages/hibiki_core/lib/src/database/tables.dart
@@ -160,10 +160,10 @@ class ReadingHourlyLogs extends Table {
   IntColumn get hour => integer()();
   IntColumn get readingTimeMs => integer()();
 
-  /// v65：写入面身份（`BookFormat.dbValue`：'epub' / 'pdf' / 'manga'）。此前没有
+  /// v67：写入面身份（`BookFormat.dbValue`：'epub' / 'pdf' / 'manga'）。此前没有
   /// 任何身份列，EPUB / PDF / 漫画同一小时的时长在写入时就被加成一行，永久分不开；
   /// 日级 `reading_statistics` 靠 title→format 反查能拆，时段表拆不开只因缺这列。
-  /// `''` = v65 前的历史行（写入时信息已丢，如实标未区分）以及云同步里旧端贡献的
+  /// `''` = v67 前的历史行（写入时信息已丢，如实标未区分）以及云同步里旧端贡献的
   /// 无法归因差额（见 aggregate_sync_service 的 deficit-lift）。
   TextColumn get format => text().withDefault(const Constant(''))();
 
@@ -1263,7 +1263,7 @@ class VideoScrapeMeta extends Table {
   /// 条目详情页 URL（`https://bgm.tv/subject/<id>`），供「查看条目」跳转。
   TextColumn get detailUrl => text().nullable()();
 
-  /// 集号（v65 / TODO-2491）：集级刮削按文件名解析的集号与源的分集列表对齐后写入
+  /// 集号（v66 / TODO-2491）：集级刮削按文件名解析的集号与源的分集列表对齐后写入
   /// （TMDB `episode_number` / Bangumi `sort`）。NULL = 本行是旧的**作品级**资料
   /// （v54~v64 的自动刮削把整部作品的简介写进每个文件），或集级刮削未能从文件名
   /// 解出集号。存对齐后的**源侧集号**而非文件名原文，便于重刮时按号更新。
@@ -1277,7 +1277,7 @@ class VideoScrapeMeta extends Table {
 }
 
 // ── collection_relations ────────────────────────────────────────────
-// 合集相关作品（v65 / TODO-2484）：一行 = 「某合集 → 一部相关作品」的有向边，
+// 合集相关作品（v66 / TODO-2484）：一行 = 「某合集 → 一部相关作品」的有向边，
 // 来自刮削源的关联数据（Bangumi subject relations / TMDB tv seasons 与
 // movie belongs_to_collection）。目标两态：
 //   - 纯刮削：只有 (source, subjectId, title, coverUrl/coverPath)，本地库里还没有


### PR DESCRIPTION
两处（实际 4 处）注释描述的事实已经变了、注释没跟上，且都会让后来者**做出错误动作**。只改注释，零行为改动。

## ① `hibiki/lib/src/utils/misc/desktop_audio_clipper.dart`

旧注释：「**但入库的 `ffmpeg-min` 尚未含这两个编码器**……须重跑 `.github/workflows/ffmpeg-min.yml` 并重新 vendor exe」。

实测（本 worktree 直接跑入库二进制）：

```
$ third_party/ffmpeg-min/windows/ffmpeg.exe -hide_banner -encoders | grep -Ei 'svtav1|webp|gif'
 V.....  libsvtav1             (codec av1)
 V....D  gif
 V....D  libwebp_anim          (codec webp)
 V....D  libwebp               (codec webp)
```

`-version` 的 configuration 也含 `--enable-libsvtav1 --enable-libwebp`，且 `--enable-encoder=` 白名单里已列 `libsvtav1,libwebp_anim`；配方 `tool/ffmpeg-min/build-ffmpeg-min.sh` 同样已经打开（commit `cee33889b`），exe 由 `fdd5001ff` 重新 vendor。

⇒ 桌面端根本不产生注定失败的编码调用。照旧注释做会**白跑一次 vendor workflow**。

新注释改写为现状 + 可复核方法（`ffmpeg.exe -encoders`），并把 `MiningAnimatedFormat.encodeAttempts` 的降级链如实标为**兜底**（用户自带的外部 ffmpeg 可能缺编码器），而不是当前入库 exe 的常态路径。

## ② schema 版本号（3 处，全是「这列是哪个迁移加的」）

| 位置 | 旧 | 实际 | 依据 |
|---|---|---|---|
| `tables.dart` `ReadingHourlyLogs.format` doc（2 处提及） | v65 | **v67** | `database.dart` 的 `if (from < 67)` 块：`reading_hourly_logs` 加 `format` 列 |
| `tables.dart` `VideoScrapeMeta.episodeNumber` doc | v65 | **v66** | `if (from < 66)` 块 |
| `tables.dart` `collection_relations` 段头 + `database.dart` DAO 段头 | v65 | **v66** | 同上 |

后两条的根因在 `if (from < 66)` 块自己的注释里已经写明了：「原写作 v65，集成时与 develop 已落地的 Mihon 漫画扩展生态 v65 撞号，**顺延到 v66**」——迁移侧改了号，表定义侧的 doc 没跟上。v65 现在真正的归属是 Mihon 五表（`migration_v65_mihon_manga_tables_test.dart` 守着）。

后两条超出原始工单范围，是我核实 `format` 版本号时在同一文件里发现的**同一类缺陷**，一并修掉。schema 注释是后人查「这列什么时候加的」的唯一去处，错版本号会让人去查错迁移。

### `database.g.dart` 是**重新生成**的

`cd packages/hibiki_core && dart run build_runner build`，本次生成只产出这 3 行 doc 镜像（`:6175` / `:6178` / `:17910`），无其它漂移。**未手改生成文件**。

## 验证

- `dart format`：4 files, 0 changed
- `flutter analyze`（`hibiki/`）：`No issues found! (ran in 34.0s)` / exit 0
- `flutter analyze`（`packages/hibiki_core/`）：`No issues found! (ran in 4.3s)` / exit 0
- 包测试（照抄 `.github/workflows/main.yml` 的 `Run package tests` 命令，`cd packages/hibiki_core && dart ../../hibiki/tool/flutter_test_failures.dart`）：`FLUTTER TEST VERDICT: PASSED - 40 tests ran, all tests passed` / exit 0
- 定向 app 测试 `test/database test/build test/tools test/mining`：`FLUTTER TEST VERDICT: PASSED - 1844 tests ran, all tests passed` / exit 0

未跑全量套件 / Windows itest（注释改动，爆炸半径为零）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
