### PR TITLE
fix(startup): BUG-1372 预热 WebView 生命周期改多路终点，renderer 死亡不再连坐杀 app

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1302 条。点号进各自文件。
+> 共 1303 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1372](bugs/BUG-1372-android-appsmoke-prewarm-webview-renderer-kills-app.md) | ✅ | ✅ | Android appSmoke：预热 headless WebView 永不销毁，renderer 被 OOM kill 后连坐杀整个 app 进程 |
 | [BUG-1358](bugs/BUG-1358-schema-guard-handwritten-comment-strip.md) | ✅ | ✅ | PR#679 新守卫手写 startsWith('//') 剥注释，违反 source_guard 纪律，develop 单测门红 |
 | [BUG-1353](bugs/BUG-1353-ci-macos-bsd-sed-inplace.md) | ✅ | ✅ | CI macos/ios 作业固定红：TMDB key 注入用了 GNU-only 的裸 sed -i |
 | [BUG-1352](bugs/BUG-1352-ci-package-tests-schema-literal.md) | ✅ | ✅ | CI Run package tests 红：packages 侧 schemaVersion 等值断言漏跟 v66 |

--- a/docs/bugs/BUG-1372-android-appsmoke-prewarm-webview-renderer-kills-app.md
+++ b/docs/bugs/BUG-1372-android-appsmoke-prewarm-webview-renderer-kills-app.md
@@ -1,0 +1,28 @@
+## BUG-1372 · Android appSmoke：预热 headless WebView 永不销毁，renderer 被 OOM kill 后连坐杀整个 app 进程
+- **报告**：2026-08-02（CI：develop `Build and Test Android / macOS / Linux / Windows` 的 android job，TODO-2560）
+- **真实性**：✅ 真 bug，根因 `hibiki/lib/main.dart:376`（旧实现：`HeadlessInAppWebView` 的 `dispose()` 只挂在 `onLoadStop` 这一条成功回调上）
+  - 现象不是断言失败，是 **app 进程被杀**：`flutter drive` 侧 `DriverError: ... ext.flutter.driver: (112) Service has disappeared`；app 侧
+    `W/cr_ChildProcessConn: onServiceDisconnected (crash or killed by oom): pid=4440`
+    → `F/chromium: [FATAL:crashpad_client_linux.cc(745)] Render process (4440)'s crash wasn't handled by all associated webviews, triggering application crash.`
+    → `F/libc: Fatal signal 5 (SIGTRAP) ... pid 3331 (p.hibiki.reader)`。
+  - 4/4 次 CI 复现同一签名（run 30688292397 / 30696409627 / 30708854995 / 30710399089），且 4 次里
+    `[Hibiki] WebView engine pre-warmed` 一次都没打印过 —— 证明 `onLoadStop` 从未到达、`dispose()` 从未执行，
+    那个 headless WebView 和它的 chromium renderer 子进程一直活到进程被杀。
+  - 两层根因：
+    1. **生命周期**：销毁绑死在单一成功回调上。回调不来（低端机 / 软件渲染 / 载入失败）就是**永久泄漏一个 renderer 进程**，没有任何终点。
+    2. **平台契约**：全 app 没有任何 WebView 注册 `onRenderProcessGone`。`third_party/flutter_inappwebview_android/.../InAppWebViewClientCompat.java:811-822`
+       —— 只有 `useOnRenderProcessGone` 为真时才 `return true`，否则走 `super.onRenderProcessGone(...)`（= false），而 Android 对 false 的默认动作就是杀掉整个 app 进程。
+  - 真机影响：不是 CI 专属。任何 Android 设备上 WebView renderer 被系统 OOM kill（后台常见）都会让 Hibiki 直接闪退。
+- **[x] ① 已修复** — `hibiki/lib/src/startup/webview_prewarm.dart` 新增 `WebViewPrewarmSession`：把「什么时候结束」从单一成功回调改成**先到者胜的多路终点**
+  （载入完成 / 载入失败 `onReceivedError` / renderer 死亡 `onRenderProcessGone` / 30s 兜底超时），`finish()` 幂等只 dispose 一次、dispose 抛错不外抛；
+  `hibiki/lib/main.dart:376-412` 按此接线。注册 `onRenderProcessGone` 同时让 Android 侧返回 true，renderer 死亡不再连坐杀进程。
+- **[x] ② 已加自动化测试** — `hibiki/test/startup/webview_prewarm_session_test.dart`：6 条行为单测（幂等、`fakeAsync` 超时兜底、撤表、dispose 抛错吞掉）
+  + 1 条 main.dart 接线守卫（`enclosingCallOf` 括号配对取窗口，`maskComments` 掩注释）。守卫做过变异实测：
+  把 `onRenderProcessGone:` 整段挪进注释 → 红；注释掉 `session.armTimeout()` → 红。
+- **备注**：
+  - CI 侧另有**不由本修复覆盖**的环境限制：hosted runner 的 AVD 跑软件 GL，日志里单帧耗时到 `app_time_stats: avg=213995.03ms`、
+    `Skipped 1402 frames`，整轮 appSmoke 耗时 11-23 分钟。本修复移除了观测到的致死路径，但不保证 appSmoke 从此稳定绿；
+    该 job 已是 `continue-on-error: true`（`.github/workflows/build-multiplatform.yml:56`），不阻塞合并门。
+  - **未收口的同类风险（另开条目再修）**：`lapis_style_editor_page.dart:379`、`manga_hibiki_page.dart:2899`、
+    `dictionary_popup_webview.dart:1249`、`reader_hibiki/webview.part.dart:1654` 四个**用户可见**的 `InAppWebView` 同样没有 `onRenderProcessGone`，
+    renderer 死亡一样会杀进程。这四处需要各自的降级 UX（重载 / 提示 / 退回列表），不是加个回调就完事，不并入本次改动。

--- a/hibiki/lib/main.dart
+++ b/hibiki/lib/main.dart
@@ -374,23 +374,45 @@ void main([List<String> args = const <String>[]]) {
       lowMemory: appModel.lowMemoryMode,
     )) {
       unawaited(Future(() async {
+        // 预热持有的是进程级资源（一个 headless WebView = 一个 chromium
+        // renderer 子进程），销毁必须有确定终点，不能只挂在 onLoadStop 这条
+        // 成功路径上：回调不来就是永久泄漏一个 renderer，而 renderer 被 OOM
+        // kill 且 onRenderProcessGone 无人接管时，Android 默认会连整个 app
+        // 进程一起杀（CI Android appSmoke 连续 4 次死于此）。终点交给
+        // WebViewPrewarmSession 收口：载入完成 / 载入失败 / renderer 死亡 /
+        // 超时兜底，先到者胜、只 dispose 一次。
+        late final HeadlessInAppWebView warmup;
+        final WebViewPrewarmSession session = WebViewPrewarmSession(
+          disposeWebView: () => warmup.dispose(),
+          onFinished: (String reason) =>
+              debugPrint('[Hibiki] WebView engine pre-warm ended: $reason'),
+        );
         try {
           // 桌面端等首帧，保证 Flutter view 已 attach（WebView2 前提）。
           if (isDesktopPlatform) {
             await WidgetsBinding.instance.endOfFrame;
           }
-          late final HeadlessInAppWebView warmup;
           warmup = HeadlessInAppWebView(
             initialUrlRequest: URLRequest(url: WebUri('about:blank')),
             onLoadStop: (controller, url) async {
+              // 100ms 让 onLoadStop 的回调栈先出栈再销毁：这是原实现就有的
+              // 保守做法（桌面 WebView2 上在回调里同步 dispose 曾不稳），
+              // 不是等待载入的重试窗口——真正的终点保证在 session 那边。
               await Future.delayed(const Duration(milliseconds: 100));
-              await warmup.dispose();
-              debugPrint('[Hibiki] WebView engine pre-warmed');
+              await session.finish('loaded');
             },
+            onReceivedError: (controller, request, error) =>
+                session.finish('load error: ${error.type}'),
+            // 接管 renderer 死亡：Android 侧只要注册了这个回调，
+            // InAppWebViewClient 就返回 true，chromium 不再连坐杀 app 进程。
+            onRenderProcessGone: (controller, detail) =>
+                session.finish('renderer gone (didCrash=${detail.didCrash})'),
           );
           await warmup.run();
+          session.armTimeout();
         } catch (e) {
           debugPrint('[Hibiki] WebView warmup failed (non-fatal): $e');
+          await session.finish('run failed: $e');
         }
       }));
     }

--- a/hibiki/lib/src/startup/webview_prewarm.dart
+++ b/hibiki/lib/src/startup/webview_prewarm.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 /// 是否应在启动后预热 WebView 引擎，把冷启动成本提前到用户翻书架时。
 ///
 /// 移动端与桌面端都预热（桌面端调用时机另由调用方保证在首帧后），
@@ -10,4 +12,73 @@ bool shouldPrewarmWebView({
 }) {
   if (lowMemory) return false;
   return isMobile || isDesktop;
+}
+
+/// 预热 WebView 的**生命周期看门人**：保证那个 headless WebView 一定会被销毁。
+///
+/// 为什么需要它——预热是纯优化，但它持有的是**进程级**资源：一个 headless
+/// WebView 会拉起一个独立的 chromium renderer 子进程。旧实现把 `dispose()`
+/// 挂在 `onLoadStop` 这一条**成功路径**上，于是「回调不来」等于「永久泄漏一个
+/// renderer 进程」，而 renderer 一旦被系统 OOM kill，`WebViewClient
+/// .onRenderProcessGone` 没人接管时 Android 的默认动作就是**杀掉整个 app
+/// 进程**（`AwBrowserTerminator` → SIGTRAP）。CI Android appSmoke 连续 4 次
+/// 就死在这条路上：`[Hibiki] WebView engine pre-warm` 一次都没打印过（说明
+/// dispose 从未执行），随后 `Render process crash wasn't handled by all
+/// associated webviews, triggering application crash`。
+///
+/// 修法不是等更久或重试，而是把「什么时候结束」从单一成功回调改成**先到者胜的
+/// 多路终点**：载入完成 / 载入失败 / renderer 进程死亡 / [timeout] 兜底。
+/// [finish] 幂等，重复触发是 no-op，所以四条路可以同时接线而不会二次 dispose。
+class WebViewPrewarmSession {
+  WebViewPrewarmSession({
+    required Future<void> Function() disposeWebView,
+    Duration timeout = kDefaultTimeout,
+    void Function(String reason)? onFinished,
+  })  : _disposeWebView = disposeWebView,
+        _timeout = timeout,
+        _onFinished = onFinished;
+
+  /// 兜底时限：预热收益只有几百毫秒到 1.5 秒，超过这个量级还没回调就已经没有
+  /// 预热价值了，留着只剩泄漏成本。不是「等久一点也许就好了」的重试窗口。
+  static const Duration kDefaultTimeout = Duration(seconds: 30);
+
+  final Future<void> Function() _disposeWebView;
+  final Duration _timeout;
+  final void Function(String reason)? _onFinished;
+
+  Timer? _timer;
+  bool _finished = false;
+
+  /// 预热是否已终结（dispose 已发起）。
+  bool get isFinished => _finished;
+
+  /// 兜底定时器是否在跑。仅供测试与诊断。
+  bool get hasPendingTimeout => _timer != null;
+
+  /// 在 headless WebView 真的 `run()` 起来之后调用：装上兜底终点。
+  ///
+  /// 已终结时不再装（回调可能比 `run()` 返回还快）。
+  void armTimeout() {
+    if (_finished || _timer != null) return;
+    _timer = Timer(_timeout, () {
+      unawaited(finish('timeout'));
+    });
+  }
+
+  /// 终结预热并销毁 WebView。先到者胜，重复调用是 no-op。
+  ///
+  /// dispose 抛错只记原因、不外抛：预热失败不该冒泡进启动链路。
+  Future<void> finish(String reason) async {
+    if (_finished) return;
+    _finished = true;
+    _timer?.cancel();
+    _timer = null;
+    String outcome = reason;
+    try {
+      await _disposeWebView();
+    } catch (e) {
+      outcome = '$reason (dispose failed: $e)';
+    }
+    _onFinished?.call(outcome);
+  }
 }

--- a/hibiki/test/startup/webview_prewarm_session_test.dart
+++ b/hibiki/test/startup/webview_prewarm_session_test.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/startup/webview_prewarm.dart';
+
+import '../helpers/source_guard.dart';
+
+void main() {
+  group('WebViewPrewarmSession', () {
+    test('载入完成即销毁一次', () async {
+      int disposed = 0;
+      final List<String> reasons = <String>[];
+      final WebViewPrewarmSession session = WebViewPrewarmSession(
+        disposeWebView: () async => disposed++,
+        onFinished: reasons.add,
+      );
+
+      await session.finish('loaded');
+
+      expect(disposed, 1);
+      expect(reasons, <String>['loaded']);
+      expect(session.isFinished, isTrue);
+    });
+
+    test('多路终点先到者胜：重复 finish 不会二次 dispose', () async {
+      int disposed = 0;
+      final List<String> reasons = <String>[];
+      final WebViewPrewarmSession session = WebViewPrewarmSession(
+        disposeWebView: () async => disposed++,
+        onFinished: reasons.add,
+      );
+
+      await session.finish('renderer gone');
+      await session.finish('loaded');
+      await session.finish('timeout');
+
+      expect(disposed, 1);
+      expect(reasons, <String>['renderer gone']);
+    });
+
+    test('回调一直不来时由超时兜底销毁（旧实现在这里永久泄漏 renderer）', () {
+      fakeAsync((FakeAsync async) {
+        int disposed = 0;
+        final List<String> reasons = <String>[];
+        final WebViewPrewarmSession session = WebViewPrewarmSession(
+          disposeWebView: () async => disposed++,
+          timeout: const Duration(seconds: 30),
+          onFinished: reasons.add,
+        );
+
+        session.armTimeout();
+        expect(session.hasPendingTimeout, isTrue);
+
+        async.elapse(const Duration(seconds: 29));
+        expect(disposed, 0, reason: '超时未到不该提前销毁');
+
+        async.elapse(const Duration(seconds: 2));
+        expect(disposed, 1);
+        expect(reasons, <String>['timeout']);
+        expect(session.isFinished, isTrue);
+      });
+    });
+
+    test('已终结后 armTimeout 不再挂表，超时也不会二次 dispose', () {
+      fakeAsync((FakeAsync async) {
+        int disposed = 0;
+        final WebViewPrewarmSession session = WebViewPrewarmSession(
+          disposeWebView: () async => disposed++,
+          timeout: const Duration(seconds: 30),
+        );
+
+        session.finish('loaded');
+        async.flushMicrotasks();
+        session.armTimeout();
+
+        expect(session.hasPendingTimeout, isFalse);
+        async.elapse(const Duration(minutes: 5));
+        expect(disposed, 1);
+      });
+    });
+
+    test('已装表后正常终结会撤表，超时不再触发', () {
+      fakeAsync((FakeAsync async) {
+        int disposed = 0;
+        final WebViewPrewarmSession session = WebViewPrewarmSession(
+          disposeWebView: () async => disposed++,
+          timeout: const Duration(seconds: 30),
+        );
+
+        session.armTimeout();
+        session.finish('loaded');
+        async.flushMicrotasks();
+
+        expect(session.hasPendingTimeout, isFalse);
+        async.elapse(const Duration(minutes: 5));
+        expect(disposed, 1);
+      });
+    });
+
+    test('dispose 抛错不外抛，原因里带上失败信息', () async {
+      final List<String> reasons = <String>[];
+      final WebViewPrewarmSession session = WebViewPrewarmSession(
+        disposeWebView: () async => throw StateError('boom'),
+        onFinished: reasons.add,
+      );
+
+      await session.finish('loaded');
+
+      expect(session.isFinished, isTrue);
+      expect(reasons.single, contains('dispose failed'));
+      expect(reasons.single, startsWith('loaded'));
+    });
+  });
+
+  // 上面的单测只证明 session 本身对；session 没被 main.dart 接上四条终点，
+  // 预热照样会泄漏 renderer 并连坐杀进程。这条守卫锚在 warmup 的
+  // HeadlessInAppWebView 构造调用上（括号配对给窗口，与缩进/参数顺序无关），
+  // 注释里写同样的字面量不算命中。
+  group('main.dart 预热接线守卫', () {
+    test('warmup 的 HeadlessInAppWebView 接齐四条终点并装了兜底表', () {
+      final String source = File('lib/main.dart').readAsStringSync();
+      final String code = maskComments(source);
+      final EnclosingCall warmup =
+          enclosingCallOf(source, 'initialUrlRequest:');
+
+      expect(warmup.name, 'HeadlessInAppWebView',
+          reason: 'initialUrlRequest 锚点应落在预热的 HeadlessInAppWebView 构造里');
+
+      final String body = maskComments(warmup.text);
+      for (final String callback in <String>[
+        'onLoadStop:',
+        'onReceivedError:',
+        'onRenderProcessGone:',
+      ]) {
+        expect(body, contains(callback),
+            reason: '预热必须接管 $callback，否则该终点缺席：载入失败或 renderer '
+                '被 OOM kill 时 headless WebView 永不销毁，且 Android 会连坐杀 app');
+      }
+      expect(body.split('session.finish(').length - 1, 3,
+          reason: '三条回调终点都必须落到同一个 session.finish（幂等收口）');
+      expect(code, contains('session.armTimeout()'),
+          reason: 'run() 之后必须装兜底表，否则回调全不来时仍然永久泄漏');
+    });
+  });
+}


### PR DESCRIPTION
## 结论先说

CI android `appSmoke`（TODO-2560）**不是测试断言失败，是 app 进程被杀**。

驱动侧：`DriverError: ... ext.flutter.driver: (112) Service has disappeared`
app 侧（4/4 次同一签名）：

```
W/cr_ChildProcessConn: onServiceDisconnected (crash or killed by oom): pid=4440
F/chromium: [FATAL:crashpad_client_linux.cc(745)] Render process (4440)'s crash
            wasn't handled by all associated webviews, triggering application crash.
F/libc:     Fatal signal 5 (SIGTRAP) ... pid 3331 (p.hibiki.reader)
```

复现 run：30688292397 / 30696409627 / 30708854995 / 30710399089。

## 根因（两层，都在生产代码）

1. **生命周期**：`hibiki/lib/main.dart` 里预热用的 `HeadlessInAppWebView` 把 `dispose()`
   **只挂在 `onLoadStop` 这一条成功回调上**。回调不来 = 永久泄漏一个 chromium renderer 子进程。
   4 次 CI 日志里 `[Hibiki] WebView engine pre-warmed` **一次都没打印过** —— dispose 从未执行。
2. **平台契约**：全 app 没有任何 WebView 注册 `onRenderProcessGone`。
   `third_party/flutter_inappwebview_android/.../InAppWebViewClientCompat.java:811-822`
   只有 `useOnRenderProcessGone` 为真才 `return true`，否则回落 `super`（false），
   而 Android 对 false 的默认动作就是**杀掉整个 app 进程**。

这不是 CI 专属：真机上 WebView renderer 被系统 OOM kill（后台常见）同样会让 Hibiki 直接闪退。

## 改法

新增 `WebViewPrewarmSession`（`hibiki/lib/src/startup/webview_prewarm.dart`）：把「什么时候结束」
从单一成功回调改成**先到者胜的多路终点** —— 载入完成 / `onReceivedError` / `onRenderProcessGone` /
30s 兜底超时。`finish()` 幂等只 dispose 一次，dispose 抛错不外抛。`main.dart` 按此接线。

注册 `onRenderProcessGone` 顺带让 Android 侧返回 true，renderer 死亡不再连坐杀进程。

没有加重试、没有加延迟去等它变好；30s 兜底是这个**纯优化资源的寿命上界**（预热收益只有几百毫秒到
1.5 秒），不是重试窗口。

## 验证

- `flutter analyze lib test` → `No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub test/startup/ test/tools/bugs_per_file_guard_test.dart`
  → `FLUTTER TEST VERDICT: PASSED - 70 tests ran, all tests passed`
- 守卫**变异实测**：把 `onRenderProcessGone:` 整段挪进注释 → 红；注释掉 `session.armTimeout()` → 红。

## 遗留（不在本 PR 内）

- **CI 环境限制**：hosted runner 的 AVD 跑软件 GL，日志里单帧 `app_time_stats: avg=213995.03ms`、
  `Skipped 1402 frames`，整轮 appSmoke 耗时 11-23 分钟。本 PR 移除了观测到的致死路径，
  **但不保证 appSmoke 从此稳定绿**。该 job 已是 `continue-on-error: true`
  （`.github/workflows/build-multiplatform.yml:56`），不阻塞合并门。
  若要继续压稳，CI 侧可考虑给 AVD 加 `ram-size` / `emulator-options`，属产品取舍。
- **同类未收口**：`lapis_style_editor_page.dart:379` / `manga_hibiki_page.dart:2899` /
  `dictionary_popup_webview.dart:1249` / `reader_hibiki/webview.part.dart:1654` 四个**用户可见**的
  `InAppWebView` 同样没有 `onRenderProcessGone`，renderer 死亡一样杀进程。这四处各需降级 UX
  （重载 / 提示 / 退回列表），不是加个回调就完事，另开条目。

BUG-1372

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
