### PR TITLE
fix(test): 歌词/独立文档留白守卫锚点抬到纯函数契约，修 develop 单测红 (BUG-1372, TODO-2585)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1304 条。点号进各自文件。
+> 共 1305 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1372](bugs/BUG-1372-lyrics-bottom-reserve-guard.md) | ✅ | ✅ | 歌词底栏预留守卫锚在实现写法上，PR#670 合并 Padding 后 develop 单测红 |
 | [BUG-1365](bugs/BUG-1365-local-audio-query-races-binding-index-build.md) | ✅ | ✅ | 桌面本地音频查询与绑定期建索引竞态：撞锁被吞成 null＝「暂无发音」（CI flaky） |
 | [BUG-1358](bugs/BUG-1358-schema-guard-handwritten-comment-strip.md) | ✅ | ✅ | PR#679 新守卫手写 startsWith('//') 剥注释，违反 source_guard 纪律，develop 单测门红 |
 | [BUG-1353](bugs/BUG-1353-ci-macos-bsd-sed-inplace.md) | ✅ | ✅ | CI macos/ios 作业固定红：TMDB key 注入用了 GNU-only 的裸 sed -i |

--- a/docs/bugs/BUG-1372-lyrics-bottom-reserve-guard.md
+++ b/docs/bugs/BUG-1372-lyrics-bottom-reserve-guard.md
@@ -44,11 +44,27 @@ final double lyricsBottomInset =
     `_buildBody` 必须调 `independentDocumentInsets` 且包 `Padding`，且**不得**就地出现
     `EdgeInsets` 构造。
 
+  - **同一方法体里的第二处同类锚点一并抬高**：
+    `test/macos/macos_shell_fullscreen_sidebar_test.dart:107/109`（PR#670 自己加的）钉的是
+    `'_lyricsMode || _spreadDocumentLoaded'` 与**局部变量名** `'top:
+    independentDocumentTopInset'`，同属 B 类要求型锚点。改为在 `methodBody(_buildBody)` 上
+    断言「调了 `independentDocumentInsets` + 喂了 `titlebarInset:
+    _macosWindowTitlebarInset`」；数值契约交给上面的行为层。
+
 - **变异实测**：
   - 生产纯函数 `bottom:` 改成常量 `0` ⇒ 行为层 2 条红（`FAILED … 2 error events`）。
   - `_buildBody` 绕开纯函数、就地拼 `EdgeInsets.only(top: …, bottom: 0)` ⇒ 接线层 2 条红。
-  - 两次均反向替换还原，`git status --short` 干净。
+  - `_buildBody` 的 `titlebarInset:` 实参改常量 `0` ⇒ macOS 守卫红。
+  - 三次均反向替换还原，`git status --short` 干净。
 
 - **备注**：本会话第二次「刚合的 PR 带进一条红」。共同点是复核跑的定向测试没覆盖到扫描本
   PR 改动文件的守卫——`reader_hibiki_page.dart` 被 **155** 个测试文件扫描（`grep -l`），
-  改这个文件必须至少跑 `test/pages` + `test/reader`。
+  改这个文件必须至少跑 `test/pages` + `test/reader`——本轮正是这个全量反查在
+  `test/macos/` 下逮到第二条同类锚点，只跑 `test/pages` 会漏。
+
+  本轮全量反查另外暴露两条**与本 BUG 无关**的 develop 现状（未在本 PR 处理）：
+  - `test/pages/home_video_remote_download_register_test.dart`「host 有外挂字幕时连带下载
+    并解析成 cue 写入」**flaky**：同一份代码 2 红 3 绿，改动前后表现一致。
+  - `test/settings/md3_design_system_static_test.dart:1164` 红，命中
+    `collection_split_dialog.dart` / `collection_relations_section.dart` /
+    `episode_rename_confirm_dialog.dart`，来自 `a328828ed` / `eaa2d4303` 两个合集 PR。

--- a/docs/bugs/BUG-1372-lyrics-bottom-reserve-guard.md
+++ b/docs/bugs/BUG-1372-lyrics-bottom-reserve-guard.md
@@ -1,0 +1,54 @@
+## BUG-1372 · 歌词底栏预留守卫锚在实现写法上，PR#670 合并 Padding 后 develop 单测红
+
+- **报告**：2026-08-02（用户：巡检发现 develop 单测红，TODO-2585）
+- **真实性**：✅ 真 bug（**守卫自身的 bug，不是功能回归**）
+
+### 判据坏，不是功能坏
+
+`test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart:38` 断言
+`body.contains('EdgeInsets.only(bottom: _readerBottomReserve)')`。PR#670（`df5745832`，
+BUG-1343 macOS 独立文档顶部缩进）把 `_buildBody` 里顶/底两笔留白合成同一个
+`EdgeInsets.only(top: …, bottom: lyricsBottomInset)`：
+
+```dart
+final double lyricsBottomInset =
+    _lyricsMode && _hasEverLoaded && _showChrome ? _readerBottomReserve : 0;
+```
+
+**底部预留分毫未变**（同门控、同数值、同样包 `Padding`），只有拼写变了。判别依据：
+只改生产代码不碰测试时，同一文件里另两条断言
+（`'_lyricsMode && _hasEverLoaded && _showChrome'`、`'Padding('`）**照常通过**，只有那条
+字面量断言红——红的是「怎么写」，不是「留没留」。
+
+根因是本仓已定案的 B 类「要求型」锚点失效模式：把契约写成实现拼写，下一次重构必再断。
+换个匹配器只是把红往后推一次。
+
+- **根因**：`hibiki/test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart:38`
+  （被守对象：`hibiki/lib/src/pages/implementations/reader_hibiki_page.dart:2637` `_buildBody`）
+
+### 修复
+
+- **[x] ① 已修复** — 把契约从「实现写法」抬到纯函数：新增
+  `hibiki/lib/src/reader/reader_chrome_floating.dart` 的
+  `independentDocumentInsets({lyricsMode, spreadDocumentLoaded, chromeOccupiesLayout,
+  bottomReserve, titlebarInset}) -> EdgeInsets`，与既有 `bottomChromeReserve` /
+  `topProgressReserve` 同一真相源文件；`_buildBody` 只负责喂状态 + 按结果包 `Padding`。
+  零行为变更（顶/底两笔取值与 PR#670 后完全一致）。
+- **[x] ② 已加自动化测试** — 同名测试文件重写成两层：
+  - **行为层**（6 条）直接钉 `independentDocumentInsets` 的数值契约：歌词 + 底栏占位 ⇒
+    `bottom == bottomReserve`；预留高变了留白跟着变（禁硬编码）；底栏未占位 / 正文模式 /
+    spread ⇒ `bottom == 0`；BUG-1343 顶部缩进；两笔都 0 ⇒ `EdgeInsets.zero`。
+    与写法、参数顺序、包几层 widget 无关。
+  - **接线层**（2 条）改用共享 `test/helpers/source_guard.dart` 的 `methodBody` +
+    `containsIdentifierCall`（替掉原来 `indexOf(start)`/`indexOf(end,…)` 的字面量切片）：
+    `_buildBody` 必须调 `independentDocumentInsets` 且包 `Padding`，且**不得**就地出现
+    `EdgeInsets` 构造。
+
+- **变异实测**：
+  - 生产纯函数 `bottom:` 改成常量 `0` ⇒ 行为层 2 条红（`FAILED … 2 error events`）。
+  - `_buildBody` 绕开纯函数、就地拼 `EdgeInsets.only(top: …, bottom: 0)` ⇒ 接线层 2 条红。
+  - 两次均反向替换还原，`git status --short` 干净。
+
+- **备注**：本会话第二次「刚合的 PR 带进一条红」。共同点是复核跑的定向测试没覆盖到扫描本
+  PR 改动文件的守卫——`reader_hibiki_page.dart` 被 **155** 个测试文件扫描（`grep -l`），
+  改这个文件必须至少跑 `test/pages` + `test/reader`。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -2639,34 +2639,25 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       return Center(child: adaptiveIndicator(context: context));
     }
     final Widget webView = _buildWebView();
-    // BUG-379: 歌词模式（LyricsModeHtml）是独立 HTML，没有 window.hoshiReader，
-    // _applyChromeInsets 对它整体 early-return，正文那套「告诉 WebView 底栏预留高度」
-    // 的机制对歌词页完全失效。于是歌词 WebView 仍 Positioned.fill 铺满全屏，底栏
-    // （_buildAudiobookBar，bottom:0）盖在其上，歌词文档级 CSS 滚动条（主题化的细条）
-    // 沿整屏高度绘制，底部一段被绘制进底栏区域，看上去像「进度条跑进底栏里」。
-    //
-    // 正文模式滚动条被原生关闭（verticalScrollBarEnabled:false）且 body 经 setChromeInsets
-    // 推离底栏，所以不暴露此问题；唯独歌词页两条都不成立。这里在 Flutter 侧把歌词 WebView
-    // 收缩到底栏之上（底栏可见时留 _readerBottomReserve），视口本身不再与底栏重叠，
-    // CSS 滚动条自然只画在歌词区域内。底栏可见条件与 _buildBottomChrome / popupBottomReserve
-    // 保持一致（_hasEverLoaded && _showChrome），_showChrome 切换会触发 _rebuild 重建本树。
-    // BUG-1343：歌词 / spread 都是独立 HTML，不读取正文引擎的 chromeTopInset。
-    // macOS 顶部 DragToMoveArea 叠在 WebView 之上时，独立文档必须由 Flutter 侧缩进，
-    // 否则首行歌词或整页图会落到拖拽区下面且无法交互。
-    final double independentDocumentTopInset =
-        (_lyricsMode || _spreadDocumentLoaded) ? _macosWindowTitlebarInset : 0;
-    final double lyricsBottomInset =
-        _lyricsMode && _hasEverLoaded && _showChrome ? _readerBottomReserve : 0;
-    if (independentDocumentTopInset > 0 || lyricsBottomInset > 0) {
-      return Padding(
-        padding: EdgeInsets.only(
-          top: independentDocumentTopInset,
-          bottom: lyricsBottomInset,
-        ),
-        child: webView,
-      );
-    }
-    return webView;
+    // BUG-379 / BUG-1343：歌词模式（LyricsModeHtml）与 spread 整页图都是独立 HTML，
+    // 没有 window.hoshiReader，_applyChromeInsets 对它们整体 early-return，正文那套
+    // 「告诉 WebView 预留多少」的机制对它们失效，只能由 Flutter 侧收缩视口本身。
+    // 留多少是 [independentDocumentInsets] 说了算（单一真相源，行为单测直接钉它）；
+    // 这里只负责喂当前状态并按结果包 Padding。
+    // BUG-1372：底部预留曾以 `EdgeInsets.only(bottom: _readerBottomReserve)` 这个**写法**
+    // 被静态守卫钉住，PR#670 把顶/底两笔留白合成一个 Padding 后写法变了、行为没变，
+    // 守卫却红了。改由纯函数承载契约后，守卫钉的是「预留来自它」而非某种拼写。
+    // _showChrome / _hasEverLoaded 切换会触发 _rebuild 重建本树。
+    final EdgeInsets independentDocumentPadding = independentDocumentInsets(
+      lyricsMode: _lyricsMode,
+      spreadDocumentLoaded: _spreadDocumentLoaded,
+      // 底栏占位条件与 _buildBottomChrome / popupBottomReserve 一致。
+      chromeOccupiesLayout: _hasEverLoaded && _showChrome,
+      bottomReserve: _readerBottomReserve,
+      titlebarInset: _macosWindowTitlebarInset,
+    );
+    if (independentDocumentPadding == EdgeInsets.zero) return webView;
+    return Padding(padding: independentDocumentPadding, child: webView);
   }
 
   String _buildStyleTag() {

--- a/hibiki/lib/src/reader/reader_chrome_floating.dart
+++ b/hibiki/lib/src/reader/reader_chrome_floating.dart
@@ -18,6 +18,8 @@
 /// reused by the reader chrome + its guards.
 library;
 
+import 'package:flutter/painting.dart';
+
 /// Clamps a stored auto-hide duration (milliseconds) into a sane range. `0` is
 /// not allowed (the surface would vanish instantly on reveal); the slider min is
 /// 1s and max 10s. Non-finite / out-of-range values degrade to the 3s default.
@@ -86,6 +88,38 @@ double bottomChromeReserve({
 }) {
   if (!barOccupiesLayout || floating) return 0;
   return chromeHeight;
+}
+
+/// BUG-379 / BUG-1343 / BUG-1372：**独立 HTML 文档**（歌词模式 [LyricsModeHtml]、
+/// spread 整页图）的 WebView 四周留白，是「阅读器页给独立文档留多少空间」的唯一真相源。
+///
+/// 为什么独立文档要 Flutter 侧留白、正文不用：正文经 `_applyChromeInsets` 把预留高
+/// 下发给 `window.hoshiReader`，由页内 CSS 收缩 body；独立 HTML 没有这个桥，
+/// `_applyChromeInsets` 对它整体 early-return，于是只能由 Flutter 侧收缩视口本身。
+///
+///  * **底部**（BUG-379）：歌词 WebView 原本 `Positioned.fill` 铺满全屏，底栏
+///    （`_buildAudiobookBar`，bottom:0）盖在其上，歌词文档级 CSS 滚动条沿整屏高度绘制，
+///    底部一段被画进底栏区域 → 看上去像「进度条跑进底栏」。留 [bottomReserve] 后视口
+///    不再与底栏重叠。[chromeOccupiesLayout] 就是底栏的占位条件
+///    （`_hasEverLoaded && _showChrome`，与 [bottomChromeReserve] 同一门控），
+///    [bottomReserve] 已含悬浮态恒 0 的语义（悬浮不占正文位置）。
+///    spread 不需要底部留白：它没有文档级滚动条，底栏叠在整页图上是既有可接受形态。
+///  * **顶部**（BUG-1343）：macOS 顶部 DragToMoveArea 叠在 WebView 之上，独立文档若不
+///    缩进，首行歌词 / 整页图会落到拖拽区下面且无法交互。[titlebarInset] 在非 macOS 恒 0。
+///
+/// 返回 [EdgeInsets.zero] 表示「无需任何留白」，调用方据此跳过 `Padding` 包装。
+EdgeInsets independentDocumentInsets({
+  required bool lyricsMode,
+  required bool spreadDocumentLoaded,
+  required bool chromeOccupiesLayout,
+  required double bottomReserve,
+  required double titlebarInset,
+}) {
+  final bool independentDocument = lyricsMode || spreadDocumentLoaded;
+  return EdgeInsets.only(
+    top: independentDocument ? titlebarInset : 0,
+    bottom: lyricsMode && chromeOccupiesLayout ? bottomReserve : 0,
+  );
 }
 
 /// Whether the top progress strip should be painted right now.

--- a/hibiki/test/macos/macos_shell_fullscreen_sidebar_test.dart
+++ b/hibiki/test/macos/macos_shell_fullscreen_sidebar_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// TODO-1375 源码守卫：macOS 原生壳三症状根因修复不变式。
 ///
 /// ① 小说全屏退出后 sidebar 消失、退出阅读界面跳设置页且无边栏可退（困死）；
@@ -104,10 +106,25 @@ void main() {
     expect(reader, contains('kMacTitleBarHeight'));
     expect(reader, contains('_macosWindowTitlebarInset'));
     expect(reader, contains('_readerTopOffset =>'));
-    expect(reader, contains('_lyricsMode || _spreadDocumentLoaded'),
-        reason: '不注入正文引擎的歌词/spread 文档也必须避开顶部拖拽区');
-    expect(reader, contains('top: independentDocumentTopInset'),
-        reason: '独立文档由 Flutter 侧真实缩进，不能只改正文 CSS inset');
+    // BUG-1372：这两条原本钉的是 `_lyricsMode || _spreadDocumentLoaded` 和局部变量名
+    // `top: independentDocumentTopInset` 两个**实现拼写**——与它们同一方法体里那条
+    // `EdgeInsets.only(bottom: _readerBottomReserve)` 守卫同属 B 类「要求型」锚点，
+    // `_buildBody` 一重构就凭空变红（行为分毫未变）。独立文档缩进多少现由纯函数
+    // `independentDocumentInsets` 承载，「歌词/spread 缩进标题栏高、正文不缩进」的数值
+    // 契约由 test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart 的行为
+    // 断言钉死；这里只钉一件本文件该管的事：reader 页确实把标题栏高喂进了那个真相源。
+    final String buildBody = methodBody(reader, '  Widget _buildBody()');
+    expect(
+      containsIdentifierCall(buildBody, 'independentDocumentInsets'),
+      isTrue,
+      reason: '不注入正文引擎的歌词/spread 文档也必须避开顶部拖拽区，'
+          '缩进量走单一真相源 independentDocumentInsets',
+    );
+    expect(
+      containsCodeLine(buildBody, 'titlebarInset: _macosWindowTitlebarInset'),
+      isTrue,
+      reason: '独立文档由 Flutter 侧真实缩进标题栏高，不能只改正文 CSS inset',
+    );
     expect(
       readerChrome,
       contains('_stableTopInset + _macosWindowTitlebarInset'),

--- a/hibiki/test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart
+++ b/hibiki/test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart
@@ -1,5 +1,8 @@
+import 'package:flutter/painting.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_chrome_floating.dart';
 
+import '../helpers/source_guard.dart';
 import 'reader_hibiki_page_source_corpus.dart';
 
 /// BUG-379：歌词模式（LyricsModeHtml）进度条跑进底栏。
@@ -8,52 +11,147 @@ import 'reader_hibiki_page_source_corpus.dart';
 /// early-return，正文那套「告诉 WebView 底栏预留高度」的机制对歌词页失效。歌词 WebView
 /// 仍 `Positioned.fill` 铺满全屏，底栏（`_buildAudiobookBar`，bottom:0）盖在其上，歌词
 /// 文档级 CSS 滚动条（主题化的细条）沿整屏高度绘制，底部一段被绘制进底栏区域 → 看上去
-/// 像「进度条跑进底栏」。
+/// 像「进度条跑进底栏」。修复：底栏可见时把歌词 WebView 收缩 `_readerBottomReserve`。
 ///
-/// 修复：`_buildBody` 在歌词模式且底栏可见时给 WebView 套底部 padding
-/// `_readerBottomReserve`，把视口收缩到底栏之上，CSS 滚动条只画在歌词区域内。
+/// BUG-1372：**这个守卫本身**曾把契约写成实现拼写
+/// `body.contains('EdgeInsets.only(bottom: _readerBottomReserve)')`。PR#670（BUG-1343）
+/// 给独立文档补顶部 macOS 标题栏缩进，把顶/底两笔留白合成同一个 `EdgeInsets.only(top:…,
+/// bottom:…)`——底部预留分毫未变，守卫却在 develop 上红了。这是本仓已定案的 B 类
+/// 「要求型」锚点失效模式：换个匹配器只是把下一次重构的红往后推。
 ///
-/// reader 页含真实 `InAppWebView` 平台视图，widget 测试无法挂载整页观测 CSS 滚动条几何，
-/// 故以源码扫描守卫钉死「歌词模式 _buildBody 留底栏空间」不变式（撤销修复 → 断言红）。
+/// 所以契约被抬到纯函数 [independentDocumentInsets]：
+///  * **行为层**（下面第一组测试）直接钉数值——歌词 + 底栏占位 ⇒ 底部 == 预留高。
+///    与写法、参数顺序、包几层 Padding 全部无关，是真正不怕重构的判据。
+///  * **接线层**（第二组）只钉一件源码事实：`_buildBody` 的留白必须来自那个纯函数，
+///    不得就地拼 `EdgeInsets`。reader 页含真实 `InAppWebView` 平台视图，widget 测试挂
+///    不起整页，这一层只能靠源码扫描；但它钉的是「谁负责算」，不是「怎么写」。
 void main() {
-  final String src = readReaderPageSource();
+  group('independentDocumentInsets（独立 HTML 文档留白契约）', () {
+    const double reserve = 72;
+    const double titlebar = 28;
 
-  test('lyrics-mode _buildBody reserves bottom space for the chrome bar', () {
-    final String body = _functionSource(
-      src,
-      '  Widget _buildBody()',
-      // BUG-396：原结束标记 `_isCustomTheme` getter 已随判据归一删除，改用紧随其后的
-      // `_buildStyleTag`（仍在 `_buildBody` 之后）作为切片终点。
-      '  String _buildStyleTag()',
-    );
-    // 歌词模式 + 底栏可见时必须给 WebView 套底部预留，否则全屏歌词 WebView 的 CSS
-    // 滚动条会延伸进底栏区域。底栏可见条件与 _buildBottomChrome / popupBottomReserve
-    // 一致（_hasEverLoaded && _showChrome）。
-    expect(
-      body.contains('_lyricsMode && _hasEverLoaded && _showChrome'),
-      isTrue,
-      reason: '歌词模式且底栏可见时 _buildBody 必须给 WebView 留底栏空间（BUG-379）',
-    );
-    expect(
-      body.contains('EdgeInsets.only(bottom: _readerBottomReserve)'),
-      isTrue,
-      reason: '歌词 WebView 必须收缩 _readerBottomReserve，使 CSS 滚动条不进底栏',
-    );
-    // 防回归：底部预留高度必须复用 _readerBottomReserve（= chrome 高 + 底部安全区），
-    // 不得硬编码一个不跟底栏实际高度走的常量。
-    expect(
-      body.contains('Padding('),
-      isTrue,
-      reason: '歌词模式分支必须用 Padding 收缩 WebView',
-    );
+    EdgeInsets insets({
+      required bool lyricsMode,
+      bool spreadDocumentLoaded = false,
+      required bool chromeOccupiesLayout,
+      double bottomReserve = reserve,
+      double titlebarInset = 0,
+    }) {
+      return independentDocumentInsets(
+        lyricsMode: lyricsMode,
+        spreadDocumentLoaded: spreadDocumentLoaded,
+        chromeOccupiesLayout: chromeOccupiesLayout,
+        bottomReserve: bottomReserve,
+        titlebarInset: titlebarInset,
+      );
+    }
+
+    test('歌词模式 + 底栏占位：底部预留 == 底栏预留高（BUG-379 本体）', () {
+      expect(
+        insets(lyricsMode: true, chromeOccupiesLayout: true).bottom,
+        reserve,
+        reason: '底部预留必须等于 _readerBottomReserve，否则 CSS 滚动条画进底栏',
+      );
+    });
+
+    test('底栏预留高变了，留白跟着变（不得硬编码常量）', () {
+      expect(
+        insets(
+          lyricsMode: true,
+          chromeOccupiesLayout: true,
+          bottomReserve: 123.5,
+        ).bottom,
+        123.5,
+      );
+      // 悬浮底栏不占正文位置 ⇒ bottomChromeReserve 已为 0，留白也必须为 0。
+      expect(
+        insets(lyricsMode: true, chromeOccupiesLayout: true, bottomReserve: 0)
+            .bottom,
+        0,
+      );
+    });
+
+    test('底栏未占位（_hasEverLoaded && _showChrome 为假）：不留底部', () {
+      expect(insets(lyricsMode: true, chromeOccupiesLayout: false).bottom, 0);
+    });
+
+    test('正文模式不留底部（正文走 setChromeInsets，重复留白会挖掉一条空白）', () {
+      expect(insets(lyricsMode: false, chromeOccupiesLayout: true).bottom, 0);
+      expect(
+        insets(
+          lyricsMode: false,
+          spreadDocumentLoaded: true,
+          chromeOccupiesLayout: true,
+        ).bottom,
+        0,
+        reason: 'spread 没有文档级滚动条，不需要也不应吃底栏预留',
+      );
+    });
+
+    test('BUG-1343：歌词 / spread 顶部缩进标题栏高，正文不缩进', () {
+      expect(
+        insets(
+          lyricsMode: true,
+          chromeOccupiesLayout: true,
+          titlebarInset: titlebar,
+        ).top,
+        titlebar,
+      );
+      expect(
+        insets(
+          lyricsMode: false,
+          spreadDocumentLoaded: true,
+          chromeOccupiesLayout: false,
+          titlebarInset: titlebar,
+        ).top,
+        titlebar,
+      );
+      expect(
+        insets(
+          lyricsMode: false,
+          chromeOccupiesLayout: true,
+          titlebarInset: titlebar,
+        ).top,
+        0,
+      );
+    });
+
+    test('两笔留白都为 0 时返回 EdgeInsets.zero（调用方据此跳过 Padding）', () {
+      expect(
+        insets(lyricsMode: false, chromeOccupiesLayout: true),
+        EdgeInsets.zero,
+      );
+      expect(
+        insets(lyricsMode: true, chromeOccupiesLayout: true, bottomReserve: 0),
+        EdgeInsets.zero,
+      );
+    });
   });
-}
 
-/// 截取 [source] 中从 [start] 标记到下一个 [end] 标记之间的片段（含函数体）。
-String _functionSource(String source, String start, String end) {
-  final int startIndex = source.indexOf(start);
-  expect(startIndex, isNonNegative, reason: 'Missing start marker: $start');
-  final int endIndex = source.indexOf(end, startIndex + start.length);
-  expect(endIndex, isNonNegative, reason: 'Missing end marker: $end');
-  return source.substring(startIndex, endIndex);
+  group('_buildBody 接线', () {
+    final String body =
+        methodBody(readReaderPageSource(), '  Widget _buildBody()');
+
+    test('留白只能来自 independentDocumentInsets（单一真相源）', () {
+      expect(
+        containsIdentifierCall(body, 'independentDocumentInsets'),
+        isTrue,
+        reason: '_buildBody 必须把独立文档留白委托给纯函数，行为契约才有单测钉得住',
+      );
+      expect(
+        containsIdentifierCall(body, 'Padding'),
+        isTrue,
+        reason: '算出来的留白必须真包成 Padding 作用到 WebView 上',
+      );
+    });
+
+    test('不得就地拼 EdgeInsets（绕开纯函数 = 绕开上面那组行为断言）', () {
+      expect(
+        containsIdentifierCall(body, 'EdgeInsets'),
+        isFalse,
+        reason: '_buildBody 里出现 EdgeInsets 构造（如 EdgeInsets.only(bottom: …)）'
+            '意味着留白重新长回页面里，纯函数单测再绿也不代表真实渲染留了空间',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## 结论：判据坏，不是功能坏

`test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart:38` 断言字面量
`'EdgeInsets.only(bottom: _readerBottomReserve)'`。PR#670（`df5745832`，BUG-1343 macOS
独立文档顶部缩进）把 `_buildBody` 的顶/底两笔留白合成同一个 `EdgeInsets.only(top:…,
bottom: lyricsBottomInset)`，**底部预留分毫未变**（同门控 `_lyricsMode && _hasEverLoaded
&& _showChrome`、同数值 `_readerBottomReserve`、同样包 `Padding`），只有拼写变了。

判别方式（只改生产代码、完全不碰测试）：同一文件另两条断言
（`'_lyricsMode && _hasEverLoaded && _showChrome'`、`'Padding('`）**照常通过**，只有那条
字面量断言红 —— 红的是「怎么写」，不是「留没留」。

## 修法：锚点从实现写法抬到契约

不换匹配器（B 类要求型锚点换匹配器只是把下次重构的红往后推）：

- 新增 `independentDocumentInsets(...)` 到 `lib/src/reader/reader_chrome_floating.dart`
  （与既有 `bottomChromeReserve` / `topProgressReserve` 同一真相源文件），承载
  「独立 HTML 文档（歌词 / spread）留多少白」。`_buildBody` 只喂状态 + 按结果包
  `Padding`。**零行为变更**。
- 守卫重写成两层：
  - **行为层 6 条**直接钉纯函数数值：歌词+底栏占位 ⇒ `bottom == bottomReserve`；预留高
    变了留白跟着变（禁硬编码）；底栏未占位 / 正文 / spread ⇒ `bottom == 0`；BUG-1343
    顶部缩进；两笔都 0 ⇒ `EdgeInsets.zero`。与写法、参数顺序、包几层 widget 无关。
  - **接线层 2 条**改用共享 `test/helpers/source_guard.dart` 的 `methodBody` +
    `containsIdentifierCall`（替掉原来 `indexOf(start)`/`indexOf(end,…)` 的字面量切片）：
    `_buildBody` 必须调纯函数且包 `Padding`，**不得**就地拼 `EdgeInsets`。

## 顺带：全量反查逮到第二条同类锚点

`grep -l 'reader_hibiki_page' hibiki/test/` ⇒ **155** 个测试文件在扫这个文件。全跑之后
`test/macos/macos_shell_fullscreen_sidebar_test.dart:107/109`（PR#670 自己加的）也红：
它钉的是 `'_lyricsMode || _spreadDocumentLoaded'` 和**局部变量名**
`'top: independentDocumentTopInset'`，同属 B 类锚点。一并抬到
`methodBody(_buildBody)` 上的委托断言。**只跑 `test/pages` 会漏掉它** —— 这正是本会话
两次「刚合的 PR 带进一条红」的共同成因。

## 变异实测（三次，均反向替换还原）

| 变异 | 预期 | 实测 |
|---|---|---|
| 纯函数 `bottom:` 改常量 `0` | 行为层红 | FAILED，2 error events |
| `_buildBody` 绕开纯函数、就地拼 `EdgeInsets.only(top:…, bottom: 0)` | 接线层红 | FAILED，2 error events |
| `_buildBody` 的 `titlebarInset:` 改常量 `0` | macOS 守卫红 | FAILED，1 error event |

## 门禁

- `flutter analyze`（含 test）：`No issues found!`
- 定向测试（155 个扫描守卫全覆盖：`test/pages` + `test/reader` + 另 25 个文件）：
  `FLUTTER TEST VERDICT: PASSED - 4861 tests ran, all tests passed`

## 未在本 PR 处理的两条 develop 现状（与本 BUG 无关）

- `test/pages/home_video_remote_download_register_test.dart`「host 有外挂字幕时连带下载
  并解析成 cue 写入」**flaky**：同一份代码 2 红 3 绿，改动前后表现一致。
- `test/settings/md3_design_system_static_test.dart:1164` 红，命中
  `collection_split_dialog.dart` / `collection_relations_section.dart` /
  `episode_rename_confirm_dialog.dart`，来自 `a328828ed` / `eaa2d4303` 两个合集 PR。

BUG 档：`docs/bugs/BUG-1372-lyrics-bottom-reserve-guard.md`

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
