### PR TITLE
test(lookup): 钉住「浮层子项必须接对话框隐藏计数」+ 补安卓独立查词窗第五处 (TODO-2584)

### DIFF
--- a/hibiki/lib/src/media/audiobook/floating_lyric_lookup_host.dart
+++ b/hibiki/lib/src/media/audiobook/floating_lyric_lookup_host.dart
@@ -72,6 +72,17 @@ class FloatingLyricLookupHost extends ConsumerStatefulWidget {
   /// 不能再用 `entries.isNotEmpty` 当判据——那会让隐藏热槽把整层 [IgnorePointer]
   /// 永久翻成可命中，吃掉底下所有点击。判据 = 搜索期占位在显示，或存在**可见**
   /// 弹窗层；隐身热槽（visible=false，停屏外预热）不算。
+  ///
+  /// **有意不接** [DictionaryPageMixin.lookupPopupHiddenByDialog]（BUG-797/1040/1327/1364
+  /// 同族收口时逐条复核过）：本判据与那四处**极性相反**。那四处（弹窗层 `visible`、
+  /// 整屏 dismiss barrier、搜索期占位卡）都是「往树里放一个会画、会吃点击的东西」，漏接
+  /// 计数 = 对话框被盖住/点不着；而这里 `true` 只是把外层 [IgnorePointer] 的 `ignoring`
+  /// 翻成 **false**，即「不强制忽略」——它本身不拦截任何东西，拦截与否完全由子项决定。
+  /// 对话框期间本层的两个子项都已让位：弹窗层经 [parkedPopupLayer] 停到屏外
+  /// （`screen.width + 8`，连安卓原生平台视图也够不着），占位卡经 [Visibility] 收成零尺寸，
+  /// Stack 自身 `hitTestSelf` 恒假 ⇒ 点击照常穿到底下页面。给这里再与一次计数是纯粹的
+  /// 对称性改动，不产生任何可观测差异，故不改（行为证据见
+  /// `test/media/audiobook/floating_lyric_lookup_host_test.dart` 的「对话框期间点击穿透」）。
   static bool shouldBlockHitTest(DictionaryPopupController popup) =>
       popup.isSearchingUi || popup.hasVisiblePopup;
 

--- a/hibiki/lib/src/pages/implementations/popup_dictionary_page.dart
+++ b/hibiki/lib/src/pages/implementations/popup_dictionary_page.dart
@@ -506,7 +506,15 @@ class _PopupDictionaryPageState extends ConsumerState<PopupDictionaryPage>
       // 以 entry 身份钉住整层。
       key: ObjectKey(entry),
       pos: Rect.fromLTWH(0, 0, cardSize.width, cardSize.height),
-      visible: entry.visible,
+      // BUG-797/1040/1327/1364 同族收口：查词浮层的**每个**子项都必须与
+      // [DictionaryPageMixin.lookupPopupHiddenByDialog] 相与。本表面（安卓独立查词窗）
+      // 今天恰好接不出对话框——`_buildLayer` 没传 `onMinedCardAction` / `onOpenInAnki` /
+      // `onOpenSentenceContextModal`，唯三会调 `runWithLookupPopupHidden` 的入口都不在，
+      // 于是计数恒 0、本条件恒真。但「安全」来自这个**非局部**的接线巧合，而不是本层
+      // 自身：哪天给这里补上制卡动作对话框，安卓原生 WebView 平台视图会立刻按 airspace
+      // 盖住它（BUG-797 的原始症状，且这窗就是安卓专用）。故在此显式接线，让不变量由
+      // 本层自己持有（守卫 test/pages/lookup_overlay_dialog_gate_guard_test.dart）。
+      visible: entry.visible && !lookupPopupHiddenByDialog,
       screen: MediaQuery.sizeOf(context),
       child: layer,
     );

--- a/hibiki/test/media/audiobook/floating_lyric_lookup_host_test.dart
+++ b/hibiki/test/media/audiobook/floating_lyric_lookup_host_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/audiobook/floating_lyric_lookup_host.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_controller.dart';
+import 'package:hibiki/src/pages/implementations/dictionary_popup_layer.dart';
 
 /// TODO-354 ① 行为守卫：书架/首页（无 reader）开的悬浮字幕点词必须路由进常驻主窗口
 /// 查词宿主，而不再被 app 级 no-op handler 吞掉。
@@ -125,6 +126,117 @@ void main() {
       expect(src, contains('reuseWarmSlot: true'), reason: '顶层查词必须原地复用热槽');
       expect(src, contains('clipBehavior: Clip.none'),
           reason: '停屏外的隐藏热槽会被默认 hardEdge 裁掉而失温');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // TODO-2584：`shouldBlockHitTest` 为什么**有意**不接对话框隐藏计数
+  // ---------------------------------------------------------------------------
+  //
+  // BUG-797/1040（弹窗层 visible）、BUG-1327（barrier）、BUG-1364（搜索期占位卡）三处
+  // 都必须与 `_popupHidingDialogDepth` 相与，于是本判据看上去像"第四处漏网"。逐条复核
+  // 后结论是**不改**：它与那三处极性相反。那三处是「往树里放一个会画、会吃点击的东西」，
+  // 漏接计数 = 对话框被盖住 / 点不着；这里 `true` 只是把外层 `IgnorePointer` 的
+  // `ignoring` 翻成 **false**（"不强制忽略"），本身不拦截任何东西——拦不拦由子项决定，
+  // 而两个子项在对话框期间都已让位。
+  //
+  // 下面两条用**真的** `parkedPopupLayer` 复刻本 host 的图层形态直接观测点击落到谁身上：
+  // 第一条是负向控制（子项在场时确实吃得掉点击，证明 harness 不是空跑），第二条钉死
+  // 「子项让位后即便 `ignoring == false`，点击照常穿到底下」。
+  group('对话框期间点击穿透（shouldBlockHitTest 有意不接对话框计数）', () {
+    const Size screen = Size(800, 600); // = flutter_test 默认视口，停屏外才真在屏外。
+
+    Widget harness({
+      required DictionaryPopupController popup,
+      required bool childrenYielded,
+      required VoidCallback onUnderTap,
+    }) {
+      Widget opaqueBlock(Color color) => GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {},
+            child: ColoredBox(color: color),
+          );
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Stack(
+          children: <Widget>[
+            // 底下的页面 / 对话框。
+            Positioned.fill(
+              child: GestureDetector(
+                behavior: HitTestBehavior.opaque,
+                onTap: onUnderTap,
+                child: const SizedBox.expand(),
+              ),
+            ),
+            IgnorePointer(
+              // 真实接线：本 host 的 build 就是这一句。
+              ignoring: !FloatingLyricLookupHost.shouldBlockHitTest(popup),
+              child: Stack(
+                clipBehavior: Clip.none,
+                children: <Widget>[
+                  // 搜索期占位卡的让位形态（BUG-1364 后：Visibility 收成零尺寸）。
+                  Positioned(
+                    left: 0,
+                    top: 0,
+                    width: 200,
+                    height: 200,
+                    child: Visibility(
+                      visible: !childrenYielded,
+                      child: opaqueBlock(const Color(0xFF00FF00)),
+                    ),
+                  ),
+                  // 弹窗层的让位形态（BUG-797 后：真 parkedPopupLayer 停到屏外）。
+                  parkedPopupLayer(
+                    pos: const Rect.fromLTWH(0, 0, 200, 200),
+                    visible: !childrenYielded,
+                    screen: screen,
+                    child: opaqueBlock(const Color(0xFF0000FF)),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    testWidgets('负向控制：子项在场时确实吃掉点击', (WidgetTester tester) async {
+      final DictionaryPopupController popup =
+          DictionaryPopupController(lowMemory: false)
+            ..beginSearchUi(const Rect.fromLTWH(10, 10, 1, 1));
+      addTearDown(popup.dispose);
+      int underTaps = 0;
+      await tester.pumpWidget(harness(
+        popup: popup,
+        childrenYielded: false,
+        onUnderTap: () => underTaps++,
+      ));
+      await tester.pump();
+      await tester.tapAt(const Offset(50, 50));
+      await tester.pump();
+      expect(underTaps, 0, reason: 'harness 若连"子项吃点击"都复现不了，下一条的穿透就证明不了任何东西');
+    });
+
+    testWidgets('对话框期间：ignoring 仍为 false，但点击照常穿到底下',
+        (WidgetTester tester) async {
+      final DictionaryPopupController popup =
+          DictionaryPopupController(lowMemory: false)
+            ..beginSearchUi(const Rect.fromLTWH(10, 10, 1, 1));
+      addTearDown(popup.dispose);
+      expect(FloatingLyricLookupHost.shouldBlockHitTest(popup), isTrue,
+          reason: '前置：对话框不改变搜索状态，本判据仍为真 ⇒ ignoring == false');
+      int underTaps = 0;
+      await tester.pumpWidget(harness(
+        popup: popup,
+        childrenYielded: true,
+        onUnderTap: () => underTaps++,
+      ));
+      await tester.pump();
+      await tester.tapAt(const Offset(50, 50));
+      await tester.pump();
+      expect(underTaps, 1,
+          reason: '子项都已让位（占位卡零尺寸 / 弹窗层停屏外），Stack 自身 hitTestSelf '
+              '恒假 ⇒ `ignoring: false` 不拦截任何东西，给它再与一次计数是纯对称性改动');
     });
   });
 }

--- a/hibiki/test/pages/lookup_overlay_dialog_gate_guard_test.dart
+++ b/hibiki/test/pages/lookup_overlay_dialog_gate_guard_test.dart
@@ -1,0 +1,401 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// TODO-2584：「查词浮层子项必须接对话框隐藏计数」这条缝的**收口守卫**。
+///
+/// 历史上同一条缝被分三次发现、每次只补一处，因为每次都拿「当次症状的判据」划范围：
+/// - BUG-797 / BUG-1040 修弹窗层（`parkedPopupLayer` 的 `visible`），判据是「**平台视图
+///   airspace**」；
+/// - BUG-1327 修整屏 dismiss barrier（`shouldShowLookupDismissBarrier`），判据是
+///   「**命中测试**」；
+/// - BUG-1364 修搜索期占位卡——它既不是平台视图也不是 barrier，前两次的视野都不覆盖它。
+///
+/// 三个判据互不包含，中间必然漏缝。本守卫改用一个**与症状无关**的判据：
+///
+///   查词浮层 `Stack` 的**每一个直接子项**，都必须能顺着调用链走到对话框隐藏计数
+///   （`_popupHidingDialogDepth` / `lookupPopupHiddenByDialog`）。
+///
+/// 「能走到」是真的顺着源码求出来的（下面的不动点），不是白名单：
+/// 1. 宿主集合由**正向规则**发现——`lib/` 下所有 `with DictionaryPageMixin` 的文件。
+///    新加宿主自动进范围，且与「被守的子项集合」无关（不是取反算出来的，不会因为被测
+///    范围放宽就缩成空集）。
+/// 2. 每个宿主里，浮层 children 列表用**结构锚点**定位：包含 `…entries.length; i++)`
+///    这个弹窗层循环的那个列表字面量（每个浮层的存在理由就是画弹窗层）。
+/// 3. 列表按括号配对切成顶层元素，逐个判定：要么它的 `if` 条件引用了计数，要么它调用的
+///    构造/方法在不动点里被判为「可达计数」。都不是就红。
+///
+/// 不用编译期约束（例如让子项走一个必须传入计数的公共基类）的理由：这些子项**必须**用
+/// 两套互斥的让位机制——原生平台视图（弹窗层 WebView）无视 `Opacity`/`IgnorePointer`，
+/// 只能靠 [parkedPopupLayer] 停到屏外；纯 Flutter 子项（占位卡 / barrier）反过来不能停
+/// 屏外（会改变布局槽位），只能 `Visibility` / 不挂。一个"必传计数"的公共基类没法同时
+/// 承载这两种让位语义，硬合会退化成"基类只存字段、让位仍靠各子类自觉"，守不住任何东西。
+/// 真正的单一入口已经在 `DictionaryPageMixin` 里（PR#688 的占位卡改一处覆盖四宿主），
+/// 本守卫钉的是**入口外面**那一层：宿主自己往 Stack 里塞的东西。
+///
+/// 反例（本守卫必须红）：往任一宿主的浮层 Stack 里加一个不接计数的新子项。
+/// 变异实测记录见 PR 描述。
+// ---------------------------------------------------------------------------
+// 判据里唯一的"魔法字符串"：对话框隐藏计数自身的两个名字。
+// ---------------------------------------------------------------------------
+
+/// 计数的私有字段名（`DictionaryPageMixin` 内部）与它的 `@protected` 读取器。
+/// 子项的让位条件必须最终引用其中之一。
+const List<String> _kGateTokens = <String>[
+  '_popupHidingDialogDepth',
+  'lookupPopupHiddenByDialog',
+];
+
+/// 必须被发现到的已知宿主（防守卫塌成空集 / 静默漏扫）。
+/// 只作**下界**：新宿主自动进范围，不需要往这里加。
+const List<String> _kKnownHosts = <String>[
+  'lib/src/media/audiobook/floating_lyric_lookup_host.dart',
+  'lib/src/pages/implementations/home_dictionary_page.dart',
+  'lib/src/pages/implementations/popup_dictionary_page.dart',
+  'lib/src/pages/implementations/texthooker_page.dart',
+  'lib/src/pages/implementations/video_hibiki_page.dart',
+];
+
+const String _kMixinPath =
+    'lib/src/pages/implementations/dictionary_page_mixin.dart';
+const String _kPopupLayerPath =
+    'lib/src/pages/implementations/dictionary_popup_layer.dart';
+
+/// `with … DictionaryPageMixin …`（注释里的同名文本不算数——先掩码再匹配）。
+final RegExp _kWithMixin = RegExp(
+  r'(?<![A-Za-z0-9_$])with(?![A-Za-z0-9_$])[^{;]*(?<![A-Za-z0-9_$])'
+  r'DictionaryPageMixin(?![A-Za-z0-9_$])',
+);
+
+/// 弹窗层循环 `for (int i = 0; i < <ctrl>.entries.length; i++)` 的结构锚点。
+final RegExp _kEntriesLoop = RegExp(r'\.entries\.length\s*;\s*i\s*\+\+\s*\)');
+
+/// `Widget foo(` / `List<Widget> foo(` 声明。
+final RegExp _kWidgetMethodDecl = RegExp(
+  r'(?<![A-Za-z0-9_$])(?:Widget|List<Widget>)\s+(_?[A-Za-z][A-Za-z0-9_]*)\s*\(',
+);
+
+/// 直接调用（排除 `x.foo(`，那是别的对象的方法，不在本文件的方法表里）。
+final RegExp _kDirectCall =
+    RegExp(r'(?<![A-Za-z0-9_$.])(_?[A-Za-z][A-Za-z0-9_]*)\s*\(');
+
+String _read(String path) => File(path).readAsStringSync();
+
+/// `lib/` 下所有 `with DictionaryPageMixin` 的文件（正斜杠相对路径，已排序）。
+List<String> _discoverHosts() {
+  final List<String> hits = <String>[];
+  for (final FileSystemEntity e in Directory('lib').listSync(recursive: true)) {
+    if (e is! File || !e.path.endsWith('.dart')) continue;
+    final String raw = e.readAsStringSync();
+    // 先做廉价子串预筛（lib/ 上千个文件，逐个词法掩码太慢），命中再掩码复核。
+    if (!raw.contains('DictionaryPageMixin')) continue;
+    if (!_kWithMixin.hasMatch(maskComments(raw))) continue;
+    hits.add(e.path.replaceAll(r'\', '/'));
+  }
+  hits.sort();
+  return hits;
+}
+
+/// 名字 → 方法体（原文切片）。同名取首个声明。
+///
+/// 不用 `methodBody`：那个 helper 每次调用都要把整份源码重新词法掩码一遍，而
+/// `video_hibiki_page.dart` 一个文件就有几十个 `Widget` 方法（250KB × 几十次）。
+/// 这里把掩码结果复用，配对逻辑与 `methodBody` 一致（先配平参数表圆括号，再配花括号），
+/// 另外多认一种 `methodBody` 不支持的形态：箭头体 `=> …;`。
+Map<String, String> _widgetMethodBodies(String src, String structural) {
+  final Map<String, String> bodies = <String, String>{};
+  for (final RegExpMatch m in _kWidgetMethodDecl.allMatches(structural)) {
+    final String name = m.group(1)!;
+    if (bodies.containsKey(name)) continue;
+    // m.end 落在参数表左括号之后，深度已为 1。
+    int depth = 1;
+    int afterParams = -1;
+    for (int i = m.end; i < structural.length; i++) {
+      if (structural[i] == '(') depth++;
+      if (structural[i] == ')') {
+        depth--;
+        if (depth == 0) {
+          afterParams = i + 1;
+          break;
+        }
+      }
+    }
+    if (afterParams < 0) continue;
+    int j = afterParams;
+    while (j < structural.length && structural[j].trim().isEmpty) {
+      j++;
+    }
+    if (j >= structural.length) continue;
+    if (structural.startsWith('=>', j)) {
+      final int semi = structural.indexOf(';', j);
+      if (semi < 0) continue;
+      bodies[name] = src.substring(m.start, semi + 1);
+      continue;
+    }
+    if (structural[j] != '{') continue; // 抽象声明 `Widget foo();` 等，无体。
+    int braces = 0;
+    for (int i = j; i < structural.length; i++) {
+      if (structural[i] == '{') braces++;
+      if (structural[i] == '}') {
+        braces--;
+        if (braces == 0) {
+          bodies[name] = src.substring(m.start, i + 1);
+          break;
+        }
+      }
+    }
+  }
+  return bodies;
+}
+
+/// 不动点：方法体里直接出现计数 ⇒ 可达；调用了另一个可达的方法 ⇒ 也可达。
+///
+/// 这一步是本守卫**不是白名单**的关键：`_buildNestedPopupLayer` 这类宿主薄转发器之所以
+/// 算过，是因为它真的调到了带计数的 `buildNestedPopupLayer`，而不是因为名字被登记过。
+Set<String> _gateReachable(Map<String, String> bodies) {
+  // 注释里写着 `_popupHidingDialogDepth` 不算数（本仓守卫的老坑）：先掩码再判。
+  final Map<String, String> masked = <String, String>{
+    for (final MapEntry<String, String> e in bodies.entries)
+      e.key: maskComments(e.value),
+  };
+  final Set<String> reachable = <String>{};
+  for (final MapEntry<String, String> e in masked.entries) {
+    if (_kGateTokens.any(e.value.contains)) reachable.add(e.key);
+  }
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    for (final MapEntry<String, String> e in masked.entries) {
+      if (reachable.contains(e.key)) continue;
+      for (final RegExpMatch m in _kDirectCall.allMatches(e.value)) {
+        final String callee = m.group(1)!;
+        if (callee == e.key || !reachable.contains(callee)) continue;
+        reachable.add(e.key);
+        changed = true;
+        break;
+      }
+    }
+  }
+  return reachable;
+}
+
+/// 从 [index] 往回找**未配对的左方括号**（即包住它的那个列表字面量的开头）。
+int _enclosingListOpen(String structural, int index, String label) {
+  int depth = 0;
+  for (int i = index - 1; i >= 0; i--) {
+    final String c = structural[i];
+    if (c == ']') {
+      depth++;
+    } else if (c == '[') {
+      if (depth == 0) return i;
+      depth--;
+    }
+  }
+  fail('$label：弹窗层循环不在任何列表字面量里（找不到未配对的 `[`）');
+}
+
+int _matchingListClose(String structural, int open, String label) {
+  int depth = 0;
+  for (int i = open; i < structural.length; i++) {
+    if (structural[i] == '[') depth++;
+    if (structural[i] == ']') {
+      depth--;
+      if (depth == 0) return i;
+    }
+  }
+  fail('$label：浮层 children 列表的方括号不配对');
+}
+
+/// 定位宿主的浮层 children 列表：包含弹窗层循环、且写成 `<Widget>[` 的列表字面量。
+///
+/// 只认显式 `<Widget>[`（五个宿主今天全是这个写法）。这既排掉了非 widget 列表里同名的
+/// `.entries.length` 循环，也让"漏认"变成**红**而不是静默跳过：宿主一个都没匹配上会
+/// 直接 fail，不会悄悄扫了 0 个子项还全绿。
+List<int> _overlayListOpens(String structural, String label) {
+  final Set<int> opens = <int>{};
+  bool sawLoop = false;
+  for (final RegExpMatch loop in _kEntriesLoop.allMatches(structural)) {
+    sawLoop = true;
+    final int open = _enclosingListOpen(structural, loop.start, label);
+    int i = open - 1;
+    while (i >= 0 && structural[i].trim().isEmpty) {
+      i--;
+    }
+    if (i >= 7 && structural.substring(i - 7, i + 1) == '<Widget>') {
+      opens.add(open);
+    }
+  }
+  if (opens.isEmpty) {
+    fail('$label：找不到浮层 children 列表（包含 `…entries.length; i++)` 的 '
+        '`<Widget>[` 字面量${sawLoop ? "；有循环但外层列表不是 `<Widget>[`" : ""}）。'
+        '查词浮层的存在理由就是画弹窗层，找不到说明宿主结构变了——必须调整本守卫的锚点，'
+        '而不是让它静默跳过这个宿主');
+  }
+  return opens.toList()..sort();
+}
+
+/// 按括号配对把列表字面量切成**顶层元素**（原文切片）。
+List<String> _topLevelElements(
+    String src, String structural, int open, String label) {
+  final int close = _matchingListClose(structural, open, label);
+  final List<String> parts = <String>[];
+  int depth = 0;
+  int start = open + 1;
+  for (int i = start; i < close; i++) {
+    final String c = structural[i];
+    if (c == '(' || c == '[' || c == '{') {
+      depth++;
+    } else if (c == ')' || c == ']' || c == '}') {
+      depth--;
+    } else if (c == ',' && depth == 0) {
+      parts.add(src.substring(start, i));
+      start = i + 1;
+    }
+  }
+  parts.add(src.substring(start, close));
+  return parts
+      .map((String p) => p.trim())
+      .where((String p) => maskComments(p).trim().isNotEmpty)
+      .toList();
+}
+
+/// 一个顶层元素的判定结果。
+class _ChildVerdict {
+  const _ChildVerdict({required this.ok, required this.why});
+
+  final bool ok;
+  final String why;
+}
+
+/// 剥掉 `if (...)` / `for (...)` 头部，收集 `if` 条件，返回剩下的 widget 表达式。
+_ChildVerdict _judgeChild(String element, Set<String> reachable) {
+  String rest = maskComments(element).trim();
+  final List<String> conditions = <String>[];
+  while (true) {
+    final RegExpMatch? head = RegExp(r'^(if|for)\s*\(').firstMatch(rest);
+    if (head == null) break;
+    final int openP = rest.indexOf('(');
+    int depth = 0;
+    int closeP = -1;
+    for (int i = openP; i < rest.length; i++) {
+      if (rest[i] == '(') depth++;
+      if (rest[i] == ')') {
+        depth--;
+        if (depth == 0) {
+          closeP = i;
+          break;
+        }
+      }
+    }
+    if (closeP < 0) {
+      return const _ChildVerdict(ok: false, why: '`if`/`for` 头部圆括号不配对');
+    }
+    if (head.group(1) == 'if') {
+      conditions.add(rest.substring(openP + 1, closeP));
+    }
+    rest = rest.substring(closeP + 1).trim();
+  }
+  for (final String cond in conditions) {
+    if (_kGateTokens.any(cond.contains)) {
+      return const _ChildVerdict(ok: true, why: '显示条件引用了对话框隐藏计数');
+    }
+  }
+  final RegExpMatch? callee =
+      RegExp(r'^(_?[A-Za-z][A-Za-z0-9_]*)').firstMatch(rest);
+  final String name = callee?.group(1) ?? '<非标识符表达式>';
+  if (reachable.contains(name)) {
+    return _ChildVerdict(ok: true, why: '`$name` 顺调用链接到对话框隐藏计数');
+  }
+  return _ChildVerdict(
+    ok: false,
+    why: '`$name` 既没在显示条件里引用对话框隐藏计数，'
+        '其调用链也走不到 ${_kGateTokens.join(" / ")}',
+  );
+}
+
+void main() {
+  final String mixinSrc = _read(_kMixinPath);
+  final Map<String, String> mixinBodies =
+      _widgetMethodBodies(mixinSrc, maskCommentsAndStrings(mixinSrc));
+
+  group('查词浮层子项 × 对话框隐藏计数（TODO-2584 收口守卫）', () {
+    final List<String> hosts = _discoverHosts();
+
+    test('宿主发现规则不得塌成空集', () {
+      for (final String known in _kKnownHosts) {
+        expect(hosts, contains(known),
+            reason: '正向发现规则（`with DictionaryPageMixin`）漏掉了已知宿主 $known；'
+                '守卫范围一旦缩水，后面每条断言都会静默变成"没什么可查"');
+      }
+    });
+
+    test('每个宿主的浮层 children 逐项都能走到对话框隐藏计数', () {
+      int totalChildren = 0;
+      final List<String> failures = <String>[];
+      for (final String host in hosts) {
+        final String src = _read(host);
+        final String structural = maskCommentsAndStrings(src);
+        final Map<String, String> bodies = <String, String>{
+          ...mixinBodies,
+          // 宿主自身的方法优先（薄转发器 `_buildNestedPopupLayer` 等同名覆盖）。
+          ..._widgetMethodBodies(src, structural),
+        };
+        final Set<String> reachable = _gateReachable(bodies);
+        for (final int open in _overlayListOpens(structural, host)) {
+          final List<String> children =
+              _topLevelElements(src, structural, open, host);
+          expect(children, isNotEmpty, reason: '$host：浮层 children 列表被切成空');
+          totalChildren += children.length;
+          for (final String child in children) {
+            final _ChildVerdict verdict = _judgeChild(child, reachable);
+            if (verdict.ok) continue;
+            final String head = maskComments(child)
+                .split('\n')
+                .map((String l) => l.trim())
+                .firstWhere((String l) => l.isNotEmpty, orElse: () => child);
+            failures.add('$host\n    子项: $head\n    原因: ${verdict.why}');
+          }
+        }
+      }
+      expect(
+        failures,
+        isEmpty,
+        reason: '查词浮层子树整体排在 `showAppDialog` 推的路由之上（根 Overlay / 根 '
+            'builder），对话框打开期间**每个**子项都必须让位——漏一个就是 BUG-797 / '
+            '1040 / 1327 / 1364 再来一次。修法二选一：\n'
+            '  ① 把子项收进 `DictionaryPageMixin` 的构建方法，在那里与 '
+            '`_popupHidingDialogDepth == 0` 相与（占位卡 / 弹窗层的做法）；\n'
+            '  ② 子项的显示条件里显式与 `!lookupPopupHiddenByDialog` 相与'
+            '（barrier 的做法）。\n未通过项：\n${failures.join("\n")}',
+      );
+      expect(totalChildren, greaterThanOrEqualTo(10),
+          reason: '五个宿主今天共 12 个浮层子项；切出的子项数骤降说明列表锚点漂了，'
+              '守卫在对着空气跑');
+    });
+
+    test('不动点真的解析出了两个共享构建方法（否则"可达"是假的）', () {
+      final Set<String> reachable = _gateReachable(mixinBodies);
+      expect(reachable, contains('buildNestedPopupLayer'),
+          reason: '弹窗层构建方法必须自带 `_popupHidingDialogDepth` 判据');
+      expect(reachable, contains('buildPopupLoadingPlaceholder'),
+          reason: '搜索期占位卡构建方法必须自带 `_popupHidingDialogDepth` 判据'
+              '（BUG-1364）');
+    });
+
+    test('barrier 判据函数真的用了传进去的 hiddenByDialog', () {
+      // 宿主侧只证明"计数被传进去了"，用没用得看被调函数自己——不补这条，
+      // 把 `shouldShowLookupDismissBarrier` 的实现改成忽略该参数，上面全绿。
+      final String src = _read(_kPopupLayerPath);
+      final String masked = maskComments(src);
+      final int start = masked.indexOf('bool shouldShowLookupDismissBarrier(');
+      expect(start, greaterThanOrEqualTo(0),
+          reason: '找不到 barrier 判据函数（注释里的同名文本不算）');
+      final int end = masked.indexOf(';', start);
+      expect(end, greaterThan(start));
+      expect(src.substring(start, end), contains('!hiddenByDialog'),
+          reason: 'BUG-1327：对话框打开时一律不挂 barrier');
+    });
+  });
+}


### PR DESCRIPTION
## 背景：同一条缝被分三次发现

查词浮层子树整体排在 `showAppDialog` 推的路由**之上**（根 Overlay / 根 builder），对话框打开期间每个子项都必须让位。这条不变量从来没被任何东西保证过，于是分三次被发现、每次只补一处，因为每次都拿「当次症状的判据」划范围：

| 次 | 修的东西 | 当次判据 |
|---|---|---|
| BUG-797 / 1040 | 弹窗层 `parkedPopupLayer` 的 `visible` | 平台视图 airspace |
| BUG-1327 | 整屏 dismiss barrier | 命中测试 |
| BUG-1364（PR#688） | 搜索期占位卡 | 既不是平台视图也不是 barrier，前两次视野都不覆盖 |

三个判据互不包含 ⇒ 中间必然漏缝。

## ① `floating_lyric_lookup_host.shouldBlockHitTest`：复核后判定**不改**

它看上去是"第四处漏网"，但与那三处**极性相反**：那三处是「往树里放一个会画、会吃点击的东西」，漏接计数 = 对话框被盖住 / 点不着；这里 `true` 只是把外层 `IgnorePointer` 的 `ignoring` 翻成 **false**（"不强制忽略"），本身不拦截任何东西——拦不拦完全由子项决定。而对话框期间本 host 的两个子项都已让位：弹窗层经 `parkedPopupLayer` 停到 `screen.width + 8`（连安卓原生平台视图也够不着），占位卡经 `Visibility` 收成零尺寸，`Stack.hitTestSelf` 恒假。

给它再与一次计数是纯粹的对称性改动，**不产生任何可观测差异**，故不改，只在源码里记下这条判断。

行为证据（`test/media/audiobook/floating_lyric_lookup_host_test.dart` 新增 group，用**真的** `parkedPopupLayer`）：
- 负向控制：子项在场时点击确实被吃掉（证明 harness 不是空跑）；
- 让位后即便 `shouldBlockHitTest == true`（`ignoring == false`），点击照常穿到底下页面。

## ② 守卫：`test/pages/lookup_overlay_dialog_gate_guard_test.dart`

判据换成与症状无关的一条：

> 查词浮层 `Stack` 的**每一个直接子项**，都必须能顺着调用链走到 `_popupHidingDialogDepth` / `lookupPopupHiddenByDialog`。

- **源码扫描而非编译期约束**，理由写在文件头：这些子项**必须**用两套互斥的让位机制——原生平台视图（弹窗层 WebView）无视 `Opacity`/`IgnorePointer`，只能停屏外；纯 Flutter 子项不能停屏外（会改布局槽位），只能 `Visibility` / 不挂。一个"必传计数"的公共基类没法同时承载两种让位语义，硬合会退化成"基类只存字段、让位仍靠各子类自觉"。真正的单一入口已经在 `DictionaryPageMixin` 里（PR#688 改一处覆盖四宿主），本守卫钉的是**入口外面**那一层：宿主自己往 Stack 里塞的东西。
- **不是白名单**：「可达」由方法体**不动点**求出（体内直接出现计数 ⇒ 可达；调用了可达方法 ⇒ 也可达）。`_buildNestedPopupLayer` 这类薄转发器算过，是因为它真的调到了带计数的 `buildNestedPopupLayer`，不是因为名字被登记过。
- **范围不由被守集合取反算出**：宿主集合是**正向发现**的（`lib/` 下所有 `with DictionaryPageMixin`，掩码后匹配），新宿主自动进范围；另有已知五宿主的**下界**断言防止发现规则塌成空集。
- **锚点结构化**：浮层 children 列表 = 包含 `…entries.length; i++)` 且写成 `<Widget>[` 的列表字面量；子项按括号配对切出，与缩进/换行/参数顺序无关。锚不上直接 `fail`，不会静默跳过某个宿主。
- **无子串包含陷阱**：判定跑在**切出来的标识符上做等值比较**，不是裸 `contains('X(')`；注释一律先经 `test/helpers/source_guard.dart` 的词法掩码。
- **防空跑**：子项总数下界 + 「不动点必须解析出 `buildNestedPopupLayer` / `buildPopupLoadingPlaceholder`」+ 「`shouldShowLookupDismissBarrier` 自己真的用了 `hiddenByDialog`」（宿主侧只证明计数被**传进去**，用没用得看被调函数）。

### 守卫独立查出的第五处：`popup_dictionary_page`（安卓独立查词窗）

`_buildLayer` 的 `parkedPopupLayer(visible: entry.visible)` 没接计数。今天恒安全只是因为该表面没传 `onMinedCardAction` / `onOpenInAnki` / `onOpenSentenceContextModal`——唯三会调 `runWithLookupPopupHidden` 的入口都不在，计数恒 0。**安全来自非局部的接线巧合而不是本层自身**；哪天给这里补上制卡动作对话框，安卓原生 WebView 会立刻按 airspace 盖住它（BUG-797 原始症状，而这窗本就是安卓专用）。故显式接线，不留潜伏点。

无用户可见症状 ⇒ 不建 BUG 档。

## 变异实测

| 变异 | 结果 |
|---|---|
| A. 往 `floating_lyric_lookup_host` 的浮层 Stack 加一个新子项 `_buildMutationBadge()`（不接计数，代码可编译） | **红**，报「\`_buildMutationBadge\` 既没在显示条件里引用对话框隐藏计数，其调用链也走不到 …」 |
| B. 同一子项体内改成 `Visibility(visible: !lookupPopupHiddenByDialog, …)` | **绿** |
| C. 把 `popup_dictionary_page` 的修复回退成 `visible: entry.visible` | **红**，精确指到 `_buildLayer` |
| D. 把 `shouldShowLookupDismissBarrier` 的 `&& !hiddenByDialog` 去掉 | **红**（第 4 条断言） |

变异均用反向替换还原，未对未提交文件用 `git checkout --`；还原后 `git status --short` 只剩本轮 4 个文件。

## 误伤评估

- 合法新增子项的两条路都放行：收进 mixin 构建方法（占位卡/弹窗层的做法）、或显示条件里显式与 `!lookupPopupHiddenByDialog` 相与（barrier 的做法）——变异 B 实测。
- 判据只跑在**顶层子项**上（子项内部随便写），且与格式无关。
- 未提供 allowlist / 豁免口子（防止养成加白名单的习惯）；锚不上宿主是 `fail` 而不是跳过。

## 门禁

- `flutter analyze`（含 test）：`No issues found! (ran in 33.3s)`
- 定向 `dart run tool/flutter_test_failures.dart --no-pub test/pages test/lookup test/media/audiobook`：
  `FLUTTER TEST VERDICT: FAILED - … (tests completed: 4031, flutter exit code: 1)`
  唯一失败是**既有红** `test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart`（另有线程在修，本 PR 未触碰）；本 PR 相关的 `test/pages/lookup_overlay_dialog_gate_guard_test.dart`、`test/pages/lookup_search_placeholder_dialog_test.dart`、`test/pages/lookup_dismiss_barrier_dialog_test.dart`、`test/pages/sentence_context_dialog_zorder_guard_test.dart`、`test/media/audiobook/floating_lyric_lookup_host_test.dart` 全绿。

未 bump `+build`（草稿分支，未发布）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
