### PR TITLE
fix(reader): 滚轮手势闸门 token 消费晚于「能否翻页」确认（BUG-1380）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1305 条。点号进各自文件。
+> 共 1306 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1380](bugs/BUG-1380-wheel-gate-token-consumed-before-paginate.md) | ✅ | ✅ | 分页滚轮闸门在换章加载期消费手势 token，整段横向惯性被吞 |
 | [BUG-1365](bugs/BUG-1365-local-audio-query-races-binding-index-build.md) | ✅ | ✅ | 桌面本地音频查询与绑定期建索引竞态：撞锁被吞成 null＝「暂无发音」（CI flaky） |
 | [BUG-1364](bugs/BUG-1364-search-placeholder-covers-dialog.md) | ✅ | ✅ | 搜索中占位层未接对话框隐藏计数，可能盖住对话框 |
 | [BUG-1358](bugs/BUG-1358-schema-guard-handwritten-comment-strip.md) | ✅ | ✅ | PR#679 新守卫手写 startsWith('//') 剥注释，违反 source_guard 纪律，develop 单测门红 |

--- a/docs/bugs/BUG-1380-wheel-gate-token-consumed-before-paginate.md
+++ b/docs/bugs/BUG-1380-wheel-gate-token-consumed-before-paginate.md
@@ -1,0 +1,52 @@
+## BUG-1380 · 分页滚轮闸门在换章加载期消费手势 token，整段横向惯性被吞
+
+- **报告**：2026-08-02（用户：TODO-2567 第 ④ 项复核）
+- **真实性**：✅ 真 bug（时序缺陷：**消费 token 早于确认这个动作能否执行**）
+
+### 根因
+
+`ReaderWheelGestureGate.shouldStartNewGesture`（`hibiki/lib/src/reader/reader_pagination_scripts.dart:50`，PR#670 引入）
+**无条件**写 `_lastTickAt = now`；而它的调用点
+`hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:2132`（`onWheelPaginate` handler）
+在 `_paginate` **之前**。`_paginate` 入口的 `_paginationInFlight` 守卫
+（`hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart:91`）会直接 return。
+
+于是：横向触控板一次滑动的首个 wheel tick 若恰好落在换章加载 / restore 在飞的窗口里，
+token 已被这个**翻不动页**的 tick 吃掉；加载落定后，整段惯性的后续 tick 全部
+（`now - _lastTickAt < settleInterval`）在闸门早退 ⇒ **用户这一次滑动完全没有反馈**。
+闸门本身「活在 Dart State 而非 JS document」的设计是对的（翻章会重建 document），
+问题只在 token 的消费时机。
+
+### 修复
+
+把 token 的消费挪到「确认这一 tick 能执行」之后，而不是事后回滚：
+回滚方案要求调用方在 `_paginate` 早退后再回来改闸门状态，而 `_paginate` 是异步的——
+回滚点落在 await 之后就与后续 tick 竞态，正是闸门要防的双翻。
+故 `shouldStartNewGesture` 新增必填 `canTurnPage`（阅读器侧传 `!_paginationInFlight`），
+同步地决定是否认领手势：
+
+- `canTurnPage == false` 且本 tick 会开启新手势 ⇒ **不写 `_lastTickAt`**（不认领 token），
+  返回值仍为 `true` 让 tick 继续送进 `_paginate`——那里的 in-flight 分支要靠这些 tick
+  续跨章冷却窗（TODO-1229 v2）。
+- 已在手势内的 tick（返回 `false`）无条件滑 trailing edge，保持 BUG-1342 的原始不变量。
+
+纵向滚轮主路径（`axis != 'horizontal'`）短路在闸门之前，行为零变化。
+
+- **[x] ① 已修复** — `hibiki/lib/src/reader/reader_pagination_scripts.dart`（闸门契约）
+  + `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart`（传 `canTurnPage`）
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/reader/reader_paged_wheel_gesture_behavior_test.dart`：复刻
+  handler 的真实判定顺序（闸门 → `_paginate` in-flight 丢弃）跑整段惯性时间线，
+  断言「换章加载覆盖惯性开头时仍恰好翻一页」（修复前为 0）与「整段被吞后闸门不留 token」；
+  `hibiki/test/reader/reader_mouse_paging_boundary_guard_static_test.dart`：钉死
+  handler 必须把 `canTurnPage: !_paginationInFlight` 交给闸门。
+  变异实测：把 `_lastTickAt = now` 改回无条件写 ⇒ 两条新用例红；
+  把 `canTurnPage: !_paginationInFlight` 改成 `canTurnPage: true` ⇒ 静态守卫红。
+
+### 备注
+
+- 阅读器页含真实 `InAppWebView` 平台视图，`onWheelPaginate` handler 注册在
+  `onWebViewCreated` 里，widget 测试无法挂载出该回调 ⇒ **未做 widget 行为级复现**，
+  测试落在「闸门 token 语义 + handler 判定顺序复刻」这一最强可落地层。
+- 同一条 TODO 的第 ③ 项（`axis == 'horizontal'` 无 pointer-type 区分 ⇒ 横向滚轮鼠标 /
+  Shift+滚轮只翻 1 页）**本轮未动**：那是产品取舍不是 bug，且与本修复无耦合。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -2129,10 +2129,16 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
             final String axis = args[1] as String;
             final int throttleMs =
                 ReaderHibikiSource.instance.wheelPageTurnInterval;
+            // BUG-1380：闸门的 token 消费必须晚于「这一 tick 能不能翻页」的确认。
+            // 换章加载/restore 在飞时 _paginate 会直接丢弃这一 tick，若此刻仍认领
+            // token，整段惯性的后续 tick 全在闸门早退 → 用户这一次滑动零反馈。
+            // canTurnPage=false 时闸门只查询不认领，且仍放行到 _paginate——那里的
+            // in-flight 分支要靠这些 tick 续跨章冷却窗（TODO-1229 v2）。
             if (axis == 'horizontal' &&
                 !_pagedWheelGestureGate.shouldStartNewGesture(
                   now: DateTime.now(),
                   settleInterval: Duration(milliseconds: throttleMs),
+                  canTurnPage: !_paginationInFlight,
                 )) {
               return;
             }

--- a/hibiki/lib/src/reader/reader_pagination_scripts.dart
+++ b/hibiki/lib/src/reader/reader_pagination_scripts.dart
@@ -35,19 +35,34 @@ class ReaderPageStep {
 ///
 /// The gate belongs to the reader State rather than the WebView document, so a
 /// chapter navigation in the middle of momentum cannot reset it and admit a
-/// second page turn. Every tick moves the trailing edge; only a full quiet
-/// interval starts the next gesture.
+/// second page turn. A tick that belongs to an already-claimed gesture moves the
+/// trailing edge; only a full quiet interval starts the next gesture.
 class ReaderWheelGestureGate {
+  /// 最后一个**属于某个已认领手势**的 tick 时刻。被丢弃、翻不动页的 tick 不属于
+  /// 任何手势，不写这里（见 [shouldStartNewGesture] 的 [canTurnPage]）。
   DateTime? _lastTickAt;
 
+  /// BUG-1380：手势 token 的消费必须晚于「这一 tick 确实能翻页」的确认。
+  ///
+  /// [canTurnPage] 由调用方给出（阅读器侧是 `!_paginationInFlight`）：为 false 时
+  /// 这一 tick 已知落不了地（换章加载 / restore 在飞），于是**不认领新手势**——
+  /// 否则整段惯性的首个 tick 白白吃掉 token，加载落定后的后续 tick 全部在闸门早退，
+  /// 用户这一次滑动零反馈。返回值仍是纯查询「本 tick 不属于已认领的手势」，让调用方
+  /// 把 tick 继续送进下游（跨章冷却窗要靠这些 tick 续窗）。
+  ///
+  /// 已在手势内的 tick（返回 false）无条件滑动 trailing edge：它属于已认领的手势，
+  /// 延长静默窗正是闸门的本意。
   bool shouldStartNewGesture({
     required DateTime now,
     required Duration settleInterval,
+    required bool canTurnPage,
   }) {
     final DateTime? lastTickAt = _lastTickAt;
     final bool startsNewGesture =
         lastTickAt == null || now.difference(lastTickAt) >= settleInterval;
-    _lastTickAt = now;
+    if (!startsNewGesture || canTurnPage) {
+      _lastTickAt = now;
+    }
     return startsNewGesture;
   }
 }

--- a/hibiki/test/reader/reader_mouse_paging_boundary_guard_static_test.dart
+++ b/hibiki/test/reader/reader_mouse_paging_boundary_guard_static_test.dart
@@ -197,6 +197,11 @@ void main() {
           reason: '只有横向触控板手势进入跨章节 burst 闸门');
       expect(body, contains('_pagedWheelGestureGate.shouldStartNewGesture'),
           reason: '手势 session 必须属于 reader State，切章后仍在');
+      // BUG-1380：token 只能在这一 tick 真能落地翻页时消费。handler 必须把
+      // _paginationInFlight 交给闸门，否则换章加载期的首个 tick 白吃 token，
+      // 整段惯性的后续 tick 全在闸门早退 → 用户这一次滑动零反馈。
+      expect(body, contains('canTurnPage: !_paginationInFlight'),
+          reason: 'BUG-1380：闸门必须知道这一 tick 能否翻页，才决定是否消费手势 token');
     });
 
     test(

--- a/hibiki/test/reader/reader_paged_wheel_gesture_behavior_test.dart
+++ b/hibiki/test/reader/reader_paged_wheel_gesture_behavior_test.dart
@@ -1,27 +1,58 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 
+const Duration _kSettle = Duration(milliseconds: 450);
+
+/// 复刻 `onWheelPaginate` handler（webview.part.dart）的真实判定顺序：
+///   ① 横向 tick 先过 [ReaderWheelGestureGate]；闸门判「属于已认领手势」→ 早退。
+///   ② 放行的 tick 进 `_paginate`；`_paginationInFlight` 为真时被直接丢弃
+///      （chrome.part.dart 的入口守卫），不产生任何用户可见反馈。
+/// 返回这一段惯性最终让用户看到的翻页次数。
+int _burstPageTurns({
+  required ReaderWheelGestureGate gate,
+  required int totalMs,
+  required int tickIntervalMs,
+  required bool Function(int elapsedMs) paginationInFlight,
+}) {
+  final DateTime start = DateTime(2026, 8, 2);
+  int pageTurns = 0;
+  for (int elapsed = 0; elapsed <= totalMs; elapsed += tickIntervalMs) {
+    final DateTime now = start.add(Duration(milliseconds: elapsed));
+    final bool inFlight = paginationInFlight(elapsed);
+    if (!gate.shouldStartNewGesture(
+      now: now,
+      settleInterval: _kSettle,
+      canTurnPage: !inFlight,
+    )) {
+      continue;
+    }
+    // _paginate 入口：换章加载 / restore 在飞 → 丢弃，用户看不到任何翻页。
+    if (inFlight) continue;
+    pageTurns += 1;
+  }
+  return pageTurns;
+}
+
 /// BUG-1342：macOS 横向触控板滑动会被拆成持续一秒以上的 wheel 惯性流。
 /// 手势闸门必须活在跨章节持久的 reader Dart State，而不是随 WebView document 重建；
 /// 因此这里真执行生产闸门，模拟惯性跨过一次章节导航后仍只放行一页。
+///
+/// BUG-1380：闸门的 token 消费不得早于「这一 tick 真能翻页」的确认。
 void main() {
   test('1.5s horizontal momentum burst starts exactly one gesture', () {
     final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
-    DateTime now = DateTime(2026, 8, 1);
-    int accepted = 0;
-    for (int elapsed = 0; elapsed <= 1500; elapsed += 60) {
-      if (gate.shouldStartNewGesture(
-        now: now,
-        settleInterval: const Duration(milliseconds: 450),
-      )) {
-        accepted += 1;
-      }
-      // The same gate object intentionally survives the simulated chapter
-      // navigation halfway through the burst; a JS-document-local gate would
-      // reset here and incorrectly accept a second page turn.
-      now = now.add(const Duration(milliseconds: 60));
-    }
-    expect(accepted, 1);
+    // The same gate object intentionally survives the simulated chapter
+    // navigation halfway through the burst; a JS-document-local gate would
+    // reset here and incorrectly accept a second page turn.
+    expect(
+      _burstPageTurns(
+        gate: gate,
+        totalMs: 1500,
+        tickIntervalMs: 60,
+        paginationInFlight: (_) => false,
+      ),
+      1,
+    );
   });
 
   test('only a full quiet interval unlocks the next horizontal gesture', () {
@@ -30,23 +61,98 @@ void main() {
     expect(
       gate.shouldStartNewGesture(
         now: first,
-        settleInterval: const Duration(milliseconds: 450),
+        settleInterval: _kSettle,
+        canTurnPage: true,
       ),
       isTrue,
     );
     expect(
       gate.shouldStartNewGesture(
         now: first.add(const Duration(milliseconds: 449)),
-        settleInterval: const Duration(milliseconds: 450),
+        settleInterval: _kSettle,
+        canTurnPage: true,
       ),
       isFalse,
     );
     expect(
       gate.shouldStartNewGesture(
         now: first.add(const Duration(milliseconds: 899)),
-        settleInterval: const Duration(milliseconds: 450),
+        settleInterval: _kSettle,
+        canTurnPage: true,
       ),
       isTrue,
     );
+  });
+
+  // ── BUG-1380 ───────────────────────────────────────────────────────
+  // 换章加载（_paginationInFlight）覆盖惯性流的开头几百毫秒：首个 tick 落不了地。
+  // 旧实现无条件写 _lastTickAt，token 被这个翻不动的 tick 吃掉 ⇒ 加载落定后的所有
+  // 后续 tick 都在闸门早退 ⇒ 用户这一次滑动**完全没有反馈**。
+  test('burst that opens during chapter loading still turns exactly one page',
+      () {
+    final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+    final int pageTurns = _burstPageTurns(
+      gate: gate,
+      totalMs: 1500,
+      tickIntervalMs: 60,
+      // 前 300ms 换章加载在飞，之后落定。
+      paginationInFlight: (int elapsedMs) => elapsedMs <= 300,
+    );
+    expect(pageTurns, isNonZero,
+        reason: '换章加载期消费掉的 token 会吞掉整段惯性 → 用户零反馈（BUG-1380 根因）');
+    expect(pageTurns, 1, reason: '恢复后只放行一页，不得因补翻而连翻');
+  });
+
+  test('a whole burst swallowed by an in-flight navigation leaves no token',
+      () {
+    final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+    // 整段惯性都撞在换章加载里：一次翻页都不产生。
+    expect(
+      _burstPageTurns(
+        gate: gate,
+        totalMs: 600,
+        tickIntervalMs: 60,
+        paginationInFlight: (_) => true,
+      ),
+      0,
+    );
+    // 闸门必须仍是「未认领」状态——紧接着（远小于 settleInterval）到来的第一个可
+    // 落地 tick 就该翻页，而不是等一个完整静默窗。
+    expect(
+      gate.shouldStartNewGesture(
+        now: DateTime(2026, 8, 2).add(const Duration(milliseconds: 660)),
+        settleInterval: _kSettle,
+        canTurnPage: true,
+      ),
+      isTrue,
+    );
+  });
+
+  test('ticks inside an already-claimed gesture keep sliding the trailing edge',
+      () {
+    final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+    final DateTime start = DateTime(2026, 8, 2);
+    // 认领手势。
+    expect(
+      gate.shouldStartNewGesture(
+        now: start,
+        settleInterval: _kSettle,
+        canTurnPage: true,
+      ),
+      isTrue,
+    );
+    // 手势内的 tick 即使 canTurnPage=false（换章加载在飞）也必须续 trailing edge，
+    // 否则同一段惯性会在加载落定后再翻一页（BUG-1342 的原始症状）。
+    for (int elapsed = 300; elapsed <= 1200; elapsed += 300) {
+      expect(
+        gate.shouldStartNewGesture(
+          now: start.add(Duration(milliseconds: elapsed)),
+          settleInterval: _kSettle,
+          canTurnPage: false,
+        ),
+        isFalse,
+        reason: '$elapsed ms 处仍属同一手势',
+      );
+    }
   });
 }


### PR DESCRIPTION
## 根因（TODO-2567 第 ④ 项）

`ReaderWheelGestureGate.shouldStartNewGesture`（`reader_pagination_scripts.dart:50`，PR#670 引入）**无条件**写 `_lastTickAt = now`，而调用点（`webview.part.dart` 的 `onWheelPaginate`）在 `_paginate` **之前**；`_paginate` 入口的 `_paginationInFlight` 守卫（`chrome.part.dart:91`）会直接 return。

⇒ 横向触控板一次滑动的首个 tick 若撞上换章加载 / restore 在飞，token 已被这个**翻不动页**的 tick 吃掉；加载落定后整段惯性的后续 tick 全部在闸门早退 ⇒ **用户这一次滑动完全没有反馈**。

形态：**消费 token 早于确认这个动作能否执行**。闸门「活在 Dart State 而非 JS document」的设计本身是对的，本 PR 不动它。

## 修法：挪消费点，不做事后回滚

`shouldStartNewGesture` 新增必填 `canTurnPage`（阅读器侧传 `!_paginationInFlight`），**同步**决定是否认领手势：

- `canTurnPage == false` 且本 tick 会开启新手势 ⇒ 不写 `_lastTickAt`（不认领 token），返回值仍为 `true` 让 tick 继续送进 `_paginate`——那里的 in-flight 分支要靠这些 tick 续跨章冷却窗（TODO-1229 v2）。
- 已在手势内的 tick（返回 `false`）无条件滑 trailing edge，保持 BUG-1342 原始不变量。

**不选事后回滚 token**：`_paginate` 是异步的，回滚点落在 `await` 之后会与后续 tick 竞态，正是闸门要防的双翻。

纵向滚轮主路径（`axis != 'horizontal'`）短路在闸门之前，行为零变化。

## 测试

- `test/reader/reader_paged_wheel_gesture_behavior_test.dart`：复刻 handler 的真实判定顺序（闸门 → `_paginate` in-flight 丢弃）跑整段惯性时间线，断言「换章加载覆盖惯性开头时仍恰好翻一页」（修复前 0）与「整段被吞后闸门不留 token」。
- `test/reader/reader_mouse_paging_boundary_guard_static_test.dart`：钉死 handler 必须传 `canTurnPage: !_paginationInFlight`。
- **变异实测**：`_lastTickAt = now` 改回无条件写 ⇒ 两条新用例红；`canTurnPage: !_paginationInFlight` 改成 `canTurnPage: true` ⇒ 静态守卫红。

**未做 widget 行为级复现**：`onWheelPaginate` 注册在 `onWebViewCreated` 里，widget 测试挂不出真实 `InAppWebView` 平台视图，该回调永不触发。测试落在最强可落地层（闸门 token 语义 + handler 判定顺序复刻）。

## 门禁

- `flutter analyze`（含 test）：`No issues found!`，exit 0。
- `test/reader`：`FLUTTER TEST VERDICT: PASSED - 1300 tests ran, all tests passed`。
- 反查所有扫描本 PR 改动文件的守卫（`readReaderPageSource()` 语料消费方，约 200 个文件）并全跑：`test/reader` + `test/pages` = 3851 tests，另一批 16 个目标 = 1076 tests。3 条红全部**先于本 PR 存在**、与改动无关：
  - `test/pages/reader_lyrics_progress_bottom_reserve_static_test.dart`（`origin/develop` 的 shell 文件里已无 `EdgeInsets.only(bottom: _readerBottomReserve)`，守卫过期）
  - `test/pages/home_video_remote_download_register_test.dart`（视频页，不读阅读器语料）
  - `test/settings/md3_design_system_static_test.dart`（点名 video cover_ui / collection 对话框）

## 明确未做

同一条 TODO 的第 ③ 项（`axis == 'horizontal'` 无 pointer-type 区分 ⇒ 横向滚轮鼠标 / Shift+滚轮只翻 1 页）本轮**未动**：产品取舍不是 bug，且与本修复**无耦合**（本 PR 只改 token 消费时机，不碰 axis 判据）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
