### PR TITLE
fix(webview): 五处 InAppWebView 接管 renderer 死亡，止 Android 连坐杀 app (BUG-1386)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1307 条。点号进各自文件。
+> 共 1308 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1386](bugs/BUG-1386-webview-renderer-gone-kills-app.md) | ✅ | ✅ | Android renderer 被回收时未接管 onRenderProcessGone，整个 app 被系统杀掉 |
 | [BUG-1373](bugs/BUG-1373-ios-pod-install-license-file-type.md) | ✅ | ✅ | iOS pod install 断在 license 校验：LICENSE.GPLv3 扩展名不被 CocoaPods 接受 |
 | [BUG-1372](bugs/BUG-1372-android-appsmoke-prewarm-webview-renderer-kills-app.md) | ✅ | ✅ | Android appSmoke：预热 headless WebView 永不销毁，renderer 被 OOM kill 后连坐杀整个 app 进程 |
 | [BUG-1365](bugs/BUG-1365-local-audio-query-races-binding-index-build.md) | ✅ | ✅ | 桌面本地音频查询与绑定期建索引竞态：撞锁被吞成 null＝「暂无发音」（CI flaky） |

--- a/docs/bugs/BUG-1386-webview-renderer-gone-kills-app.md
+++ b/docs/bugs/BUG-1386-webview-renderer-gone-kills-app.md
@@ -1,0 +1,82 @@
+## BUG-1386 · Android renderer 被回收时未接管 onRenderProcessGone，整个 app 被系统杀掉
+
+- **报告**：2026-08-02（看板 TODO-2589 收口，源自 PR#690 修启动预热时暴露的同类缺口）
+- **真实性**：✅ 真 bug（真机崩溃风险，非只影响 CI）
+
+### 根因
+
+Android 上一个 WebView 的 HTML 渲染跑在独立的 chromium renderer 子进程里。系统内存紧张时会回收
+它（`didCrash=false`）。此时后果由 `WebViewClient.onRenderProcessGone` 的返回值决定 ——
+本仓 vendored 的
+`third_party/flutter_inappwebview_android/android/src/main/java/com/pichillilorenzo/flutter_inappwebview_android/webview/in_app_webview/InAppWebViewClientCompat.java:811-822`：
+
+```java
+if (webView.customSettings.useOnRenderProcessGone && webView.channelDelegate != null) {
+  webView.channelDelegate.onRenderProcessGone(didCrash, rendererPriorityAtExit);
+  return true;                                    // 自报接管，只有那一个 WebView 白屏
+}
+return super.onRenderProcessGone(view, detail);   // 没接管 → AwBrowserTerminator 杀掉整个 app 进程
+```
+
+注意 Java 侧是**发完事件立刻 `return true`**，而 Dart 回调签名是 `void`，返回值回不到 Java。
+所以**救 app 的唯一动作就是「传了非 null 的 `onRenderProcessGone`」**：
+`third_party/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview.dart:444-445`
+（headless 侧 `headless_in_app_webview.dart:380-381`）在
+`params.onRenderProcessGone != null && settings.useOnRenderProcessGone == null` 时把
+`useOnRenderProcessGone` 自动推成 `true`，从而走进上面那个 `return true` 分支。回调体里写什么
+只影响「死后能恢复多少」，不影响「app 是否被杀」。
+
+PR#690（BUG-1372）只修了 `main.dart` 的启动预热那一处。`lib/` 下**另外 5 处**构造全部没传这个
+回调，五处同构地暴露在同一颗地雷上：
+
+| 站点 | file:line |
+|---|---|
+| 漫画阅读器 | `hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart:2899` |
+| EPUB 阅读器 | `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:1654` |
+| 词典弹窗 | `hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart:1249` |
+| Lapis 样式编辑器预览 | `hibiki/lib/src/anki/lapis_style_editor_page.dart:379` |
+| 有声书剪辑离屏渲染（headless） | `hibiki/lib/src/media/audiobook/audiobook_clip_webview_render.dart:173` |
+
+（iOS/macOS 上游已实现且 WKWebView 终止不杀 app，只白屏；Windows fork 原生从不 raise
+`ProcessFailed`；Linux 无实现。本条只做 Android 侧崩溃止血。）
+
+### 修复
+
+- **[x] ① 已修复** — 新增单一入口 `hibiki/lib/src/webview/webview_death_guard.dart`
+  的 `WebViewDeathGuard`（epoch key + `flushBeforeRebuild` / `afterRebuild` 两个钩子 +
+  重建预算），五处各自只声明「抢救什么 / 重建后调哪个已有 restore」：
+
+  | 站点 | flushBeforeRebuild | afterRebuild |
+  |---|---|---|
+  | 漫画 | `_windowGate.abandon()` + 丢 controller + `_flushPosition()` | `setState` 换 epoch key（恢复锚 `_currentSpread`/`_currentFraction` 实时更新，重建安全） |
+  | EPUB 阅读器 | 取消 `_progressPollTimer` + 丢 controller + `_flushPosition()` | **null（只救命不重建）** |
+  | 词典弹窗 | 清 `_ready`/controller/推送去重基线 + 置 `_refreshWhenReady` | `setState` 换 key，新 `onLoadStop` 全量重推 |
+  | Lapis 预览 | 丢 controller | `setState` 换 key，`onLoadStop → _refreshPreview` 自愈 |
+  | 有声书剪辑（headless） | 置 `rendererDead` + 解开 8s load 等待 | null（一次性离屏管线不重建，发 null 帧让调用方回退单句静态） |
+
+  阅读器刻意不重建：恢复锚 `_initialProgress`/`_initialCharOffset`
+  （`reader_hibiki_page.dart:1208/1211`）记的是**进入本章那一刻的快照**，章内滚动只更新
+  `_lastProgress*`；跨章翻进本章时 `_beginNavigation`（`navigation.part.dart:428-429`）常把它们
+  写成 `0.0 / -1`。换 key 强制重建后 restore 会回到章首，紧接着
+  `_onRestoreComplete → _refreshProgress → _debouncedSavePosition` 把回退位置如实落库，把 DB 里
+  更靠后的真实进度覆盖掉。另有两处硬阻塞：`webview.part.dart:1809-1821` 的
+  `debugEvaluateJavascript == null` 断言只在 dispose 清（State 不重建 ⇒ 第二次
+  `onWebViewCreated` 必炸），`navigation.part.dart:903-907` 的 `_refreshProgress` 无 try/catch。
+  白屏可退出重进，进度写回退不可逆 —— 两害相权本轮只救命。
+
+- **[x] ② 已加自动化测试** —
+  - 源码扫描守卫 `hibiki/test/webview/webview_render_process_gone_guard_test.dart`：正向规则扫全
+    `lib/`（词法掩码后找以独立标识符身份出现的 `InAppWebView(` / `HeadlessInAppWebView(` 构造，
+    窗口由 `enclosingCall` 括号配对给出），断言**每一处**都传了非 null 的
+    `onRenderProcessGone`，且没有哪处把 `useOnRenderProcessGone` 显式写成 `false`
+    （唯一一种「回调传了、Java 侧仍回落 super」的假绿写法）。发现数为 0 或少于当前已知 6 处
+    一律 fail，防重构后守卫静默空跑。
+  - 行为测试 `hibiki/test/webview/webview_death_guard_test.dart`：flush 先于 rebuild、epoch 换
+    key、flush 抛错不挡重建、重建预算封顶、`afterRebuild == null` 只救命、同一次死亡重入丢弃。
+  - 变异实测：摘掉 Lapis 那处的 `onRenderProcessGone` → 守卫红并精确报出
+    `lib/src/anki/lapis_style_editor_page.dart:402 InAppWebView —— 没有 onRenderProcessGone 参数`；
+    给该处加 `useOnRenderProcessGone: false` → 第三条断言红；把该处换成不走
+    `WebViewDeathGuard` 的内联闭包 → 守卫仍绿（验不误伤）。
+
+- **备注**：Windows fork（`packages/flutter_inappwebview_windows`）原生侧从不 raise
+  `ProcessFailed`，那边注册 `onRenderProcessGone` 是死代码，要改 C++，属独立工作量，本条不含。

--- a/hibiki/lib/src/anki/lapis_style_editor_page.dart
+++ b/hibiki/lib/src/anki/lapis_style_editor_page.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:hibiki/src/webview/webview_death_guard.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 
@@ -87,6 +88,21 @@ class _LapisStyleEditorPageState extends State<LapisStyleEditorPage> {
   bool _showBack = true;
   bool _allowPop = false;
   InAppWebViewController? _previewController;
+
+  /// renderer 死亡处置（救命动作 = 下面 [InAppWebView.onRenderProcessGone] 传了
+  /// 非 null 回调，否则 Android 会连坐杀掉整个 app）。
+  ///
+  /// 这块预览是**纯只读渲染**：用户编辑的规则/布局/自由 CSS 全在本 State 的
+  /// `_rules` / `_layout` / `_advancedCssController` 里，`_save()` 一个字节都不
+  /// 从 WebView 取。所以重建零损失，flush 只需丢掉报废的 controller，
+  /// `onLoadStop → _refreshPreview()` 会把预览自愈回来。
+  late final WebViewDeathGuard _previewDeathGuard = WebViewDeathGuard(
+    surface: 'lapis_style_preview',
+    flushBeforeRebuild: () async => _previewController = null,
+    afterRebuild: () {
+      if (mounted) setState(() {});
+    },
+  );
 
   static const List<String> _colorChoices = <String>[
     '#2F6B5F',
@@ -376,6 +392,13 @@ class _LapisStyleEditorPageState extends State<LapisStyleEditorPage> {
       fontScalePercent: widget.fontScalePercent,
       customCss: _composeCustomCss(),
     );
+    return KeyedSubtree(
+      key: _previewDeathGuard.rebuildKey,
+      child: _buildWebPreviewSurface(css),
+    );
+  }
+
+  Widget _buildWebPreviewSurface(String css) {
     return InAppWebView(
       initialData: InAppWebViewInitialData(
         data: buildLapisStylePreviewHtml(
@@ -408,6 +431,13 @@ class _LapisStyleEditorPageState extends State<LapisStyleEditorPage> {
         );
       },
       onLoadStop: (_, __) => _refreshPreview(),
+      // 非 null 本身就是救命动作：Java 侧据此 `return true`，不再连坐杀 app。
+      onRenderProcessGone:
+          (InAppWebViewController _, RenderProcessGoneDetail detail) =>
+              unawaited(_previewDeathGuard.handleDeath(
+        didCrash: detail.didCrash,
+        rendererPriorityAtExit: detail.rendererPriorityAtExit,
+      )),
     );
   }
 

--- a/hibiki/lib/src/media/audiobook/audiobook_clip_webview_render.dart
+++ b/hibiki/lib/src/media/audiobook/audiobook_clip_webview_render.dart
@@ -7,6 +7,7 @@ import 'package:flutter/painting.dart' show Color;
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:hibiki/src/media/audiobook/audiobook_clip_text_render.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:hibiki/src/webview/webview_death_guard.dart';
 
 /// TODO-1167：单帧 takeScreenshot 的超时上限，对齐 load 的 8s 语义（截图原来无超时，
 /// 卡死会永久挂住整条导出管线 → 表现为卡死/ANR）。
@@ -168,6 +169,20 @@ Future<void> renderAudiobookClipFramesViaWebView({
   final Size size = Size(layout.width.toDouble(), layout.height.toDouble());
   final Completer<void> loaded = Completer<void>();
   HeadlessInAppWebView? headless;
+  // renderer 子进程死了：这条导出管线**不能重建**（一次性离屏渲染，重开一遍
+  // 也只会在同样的内存压力下再死一次），只能立刻收尾让调用方回退单句静态。
+  // 但 `onRenderProcessGone` 这个回调**必须传**——Java 侧
+  // (`InAppWebViewClientCompat.onRenderProcessGone`) 只有拿到非 null 回调才
+  // `return true`，否则默认动作是杀掉整个 app 进程。
+  bool rendererDead = false;
+  final WebViewDeathGuard deathGuard = WebViewDeathGuard(
+    surface: 'audiobook_clip_offscreen',
+    flushBeforeRebuild: () async {
+      rendererDead = true;
+      // 解开 8s 等待：renderer 已死，onLoadStop 永远不会来了。
+      if (!loaded.isCompleted) loaded.complete();
+    },
+  );
 
   try {
     headless = HeadlessInAppWebView(
@@ -188,6 +203,12 @@ Future<void> renderAudiobookClipFramesViaWebView({
       onLoadStop: (InAppWebViewController controller, WebUri? url) {
         if (!loaded.isCompleted) loaded.complete();
       },
+      onRenderProcessGone:
+          (InAppWebViewController _, RenderProcessGoneDetail detail) =>
+              unawaited(deathGuard.handleDeath(
+        didCrash: detail.didCrash,
+        rendererPriorityAtExit: detail.rendererPriorityAtExit,
+      )),
     );
     await headless.run();
 
@@ -204,6 +225,17 @@ Future<void> renderAudiobookClipFramesViaWebView({
         'offscreen vertical clip WebView never reported onLoadStop within 8s (segments=${segments.length})',
         StackTrace.current,
       );
+    }
+    if (rendererDead) {
+      ErrorLogService.instance.log(
+        'AudiobookClipWebViewRender.rendererGone',
+        'offscreen vertical clip renderer died before layout '
+            '(segments=${segments.length}); falling back to static',
+        StackTrace.current,
+      );
+      // 发一帧 null 让调用方回退单句静态（与 noController 分支同一契约）。
+      await onFrame(indices.first, null);
+      return;
     }
 
     try {
@@ -231,6 +263,18 @@ Future<void> renderAudiobookClipFramesViaWebView({
     await Future<void>.delayed(const Duration(milliseconds: 32));
 
     for (final int idx in indices) {
+      if (rendererDead) {
+        // renderer 死在逐帧循环中途：剩下的 evaluateJavascript/takeScreenshot
+        // 只会抛或挂满超时，直接以 null 帧收尾让调用方回退。
+        ErrorLogService.instance.log(
+          'AudiobookClipWebViewRender.rendererGone',
+          'offscreen vertical clip renderer died mid-loop (frame=$idx, '
+              'segments=${segments.length}); falling back to static',
+          StackTrace.current,
+        );
+        await onFrame(idx, null);
+        return;
+      }
       await controller.evaluateJavascript(
         source: 'window.__clipSetActive && window.__clipSetActive($idx);',
       );

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -49,6 +49,7 @@ import 'package:hibiki/src/pages/implementations/stat_activity.dart';
 import 'package:hibiki/src/reader/reader_selection_data.dart';
 import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 import 'package:hibiki/src/startup/exit_flush_registry.dart';
+import 'package:hibiki/src/webview/webview_death_guard.dart';
 import 'package:hibiki/utils.dart';
 
 /// Manga reader implementation owned by the standalone manga module.
@@ -599,6 +600,33 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   /// 窗口文档加载的所有权闸门：generation 与 ready 锁只能经它读写，迟到的旧回调
   /// 不能解开新窗口的锁（BUG-1170），页面销毁时在飞加载被显式放弃（BUG-1171）。
   final MangaWindowLoadGate _windowGate = MangaWindowLoadGate();
+
+  /// renderer 死亡处置（救命动作 = 下面 [InAppWebView.onRenderProcessGone] 传了
+  /// 非 null 回调，否则 Android 会连坐杀掉整个 app）。
+  ///
+  /// 抢救三件事，缺一都会在重建后出错：
+  /// - `_flushPosition()`：600ms debounce（[_recordProgress]）里还没落盘的页码；
+  /// - `_windowGate.abandon()`：renderer 死时若有 `loadData` 在飞，它的 ready 锁
+  ///   永远等不到 `onLoadStop`，会挂满 10s 超时再从 `unawaited` 调用点抛未捕获
+  ///   异步异常（BUG-1171 同源），并且 `_navigating` 会卡 true 让重建后的
+  ///   `_loadInitialWindow()` 直接早退成白屏；
+  /// - `_controller = null`：报废的 controller 上 `evaluateJavascript` 只会抛。
+  ///
+  /// 重建安全性：恢复锚是 `_currentSpread` / `_currentFraction`，它们由 JS 的
+  /// `onMangaScroll` / `onMangaTurn` 实时更新，永远是**当前真实位置**，不是进入
+  /// 本章时的快照 —— 所以重建后 `onWebViewCreated → _loadInitialWindow() →
+  /// _markWindowReady()` 把同一个 spread 重新应用回去，不会写回退的进度。
+  late final WebViewDeathGuard _webViewDeathGuard = WebViewDeathGuard(
+    surface: 'manga_reader',
+    flushBeforeRebuild: () async {
+      _windowGate.abandon();
+      _controller = null;
+      await _flushPosition();
+    },
+    afterRebuild: () {
+      if (mounted) setState(() {});
+    },
+  );
 
   /// 旧选区 payload 的制卡卡图回退：当前 spread 首页图的绝对文件路径。新 payload
   /// 会以 [_miningPageIndex] 精确定位 OCR 命中的页，不能用此值覆盖。
@@ -2896,6 +2924,15 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         ),
       );
     }
+    // 重建 key 挂在 WebView **之上**：`manga_webview` 这个 ValueKey 是集成测试
+    // finder 的锚点，不能随代次变化。
+    return KeyedSubtree(
+      key: _webViewDeathGuard.rebuildKey,
+      child: _buildWebViewSurface(),
+    );
+  }
+
+  Widget _buildWebViewSurface() {
     return InAppWebView(
       key: const ValueKey<String>('manga_webview'),
       initialSettings: InAppWebViewSettings(
@@ -3008,6 +3045,13 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       onLoadStop: (InAppWebViewController controller, WebUri? url) async {
         await _markWindowReady(controller);
       },
+      // 非 null 本身就是救命动作：Java 侧据此 `return true`，不再连坐杀 app。
+      onRenderProcessGone:
+          (InAppWebViewController _, RenderProcessGoneDetail detail) =>
+              unawaited(_webViewDeathGuard.handleDeath(
+        didCrash: detail.didCrash,
+        rendererPriorityAtExit: detail.rendererPriorityAtExit,
+      )),
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -17,6 +17,7 @@ import 'package:hibiki/src/platform/selection_external_actions.dart';
 import 'package:hibiki/src/reader/popup_swipe_close_script.dart';
 import 'package:hibiki/src/reader/reader_caret_scripts.dart';
 import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart';
+import 'package:hibiki/src/webview/webview_death_guard.dart';
 import 'package:hibiki/utils.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -241,6 +242,32 @@ class DictionaryPopupWebViewState
       _controller?.evaluateJavascript(source: source);
   bool _ready = false;
   bool _refreshWhenReady = false;
+
+  /// renderer 死亡处置（救命动作 = 下面 [InAppWebView.onRenderProcessGone] 传了
+  /// 非 null 回调，否则 Android 会连坐杀掉整个 app）。
+  ///
+  /// 这块表面**几乎零损失**：查询词、结果、嵌套层级栈全在 Dart
+  /// （`widget.result` / 宿主的 popup 栈），WebView 只是渲染面。死掉丢的是滚动
+  /// 位置和 popup.js 的角标态；重建后 [refreshCurrentResult] 会把当前结果全量
+  /// 重推。flush 要做的就是把「已推过 / 已渲染过」的去重基线清空 —— 否则
+  /// [refreshCurrentResult] 会认为「这个结果已经推过了」而直接早退，新 WebView
+  /// 永远拿不到内容。
+  late final WebViewDeathGuard _deathGuard = WebViewDeathGuard(
+    surface: 'dictionary_popup',
+    flushBeforeRebuild: () async {
+      _controller = null;
+      _ready = false;
+      _lastPushedResult = null;
+      _lastRenderedResult = null;
+      _lastSentStaticRevision = null;
+      _lastSentInAppExtrasKey = null;
+      // 新 WebView 的 onLoadStop 据此立刻补推当前结果。
+      _refreshWhenReady = true;
+    },
+    afterRebuild: () {
+      if (mounted) setState(() {});
+    },
+  );
   String? _lastSearchTerm;
   int _lastEntryCount = 0;
   int _renderToken = 0;
@@ -2062,6 +2089,13 @@ JSON.stringify((function(){
       onLoadResourceWithCustomScheme: (controller, request) async {
         return dictionaryMediaCustomSchemeResponse(request.url);
       },
+      // 非 null 本身就是救命动作：Java 侧据此 `return true`，不再连坐杀 app。
+      onRenderProcessGone:
+          (InAppWebViewController _, RenderProcessGoneDetail detail) =>
+              unawaited(_deathGuard.handleDeath(
+        didCrash: detail.didCrash,
+        rendererPriorityAtExit: detail.rendererPriorityAtExit,
+      )),
     );
 
     // TODO-896 症状②：Windows 上原生 WebView2 菜单已禁（hideDefaultSystemContextMenuItems
@@ -2070,14 +2104,17 @@ JSON.stringify((function(){
     // [HitTestBehavior.translucent] 让右键之外的所有指针事件照常落到 WebView（不抢左键
     // 框选 / 滚动 / 点击）。
     if (isWindowsPlatform) {
-      return GestureDetector(
-        behavior: HitTestBehavior.translucent,
-        onSecondaryTapDown: (TapDownDetails details) =>
-            _showWindowsContextMenu(context, details.globalPosition),
-        child: webView,
+      return KeyedSubtree(
+        key: _deathGuard.rebuildKey,
+        child: GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onSecondaryTapDown: (TapDownDetails details) =>
+              _showWindowsContextMenu(context, details.globalPosition),
+          child: webView,
+        ),
       );
     }
-    return webView;
+    return KeyedSubtree(key: _deathGuard.rebuildKey, child: webView);
   }
 
   /// TODO-896 症状②：Windows 桌面右键弹 Flutter [showMenu]（替代偏移的 WebView2 原生

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -2455,6 +2455,16 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
       onConsoleMessage: (controller, msg) {
         debugPrint('[WebView] ${msg.message}');
       },
+      // 非 null 本身就是救命动作：Android 上 renderer 被 OOM 回收时，
+      // `InAppWebViewClientCompat.onRenderProcessGone` 只有拿到非 null 回调才
+      // `return true`；否则默认动作是把整个 app 进程一起杀掉。这里的处置刻意
+      // **不重建**（见 [_webViewDeathGuard] 的注释：恢复锚陈旧会把进度写回退）。
+      onRenderProcessGone:
+          (InAppWebViewController _, RenderProcessGoneDetail detail) =>
+              unawaited(_webViewDeathGuard.handleDeath(
+        didCrash: detail.didCrash,
+        rendererPriorityAtExit: detail.rendererPriorityAtExit,
+      )),
     );
     // KeyedSubtree carries [_webViewKey] (a GlobalKey) on the InAppWebView's own
     // render subtree so [onDismissBarrierHover] can read the WebView's RenderBox

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -69,6 +69,7 @@ import 'package:hibiki/src/reader/reader_settings.dart';
 import 'package:hibiki/src/reader/reader_top_progress.dart';
 import 'package:hibiki/src/reader/ttu_toc_flatten.dart';
 import 'package:hibiki/src/startup/exit_flush_registry.dart';
+import 'package:hibiki/src/webview/webview_death_guard.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
 import 'package:hibiki/src/media/audiobook/floating_lyric_channel.dart';
 import 'package:hibiki/src/media/audiobook/pointer_seek.dart';
@@ -1323,6 +1324,40 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   /// 的阅读位置/统计在 exit(0) 前落库。
   ExitFlushCallback? _exitFlushCallback;
   Timer? _progressPollTimer;
+
+  /// renderer 死亡处置（救命动作 = [_buildWebView] 里给 `InAppWebView` 传了非
+  /// null 的 `onRenderProcessGone`，否则 Android 会连坐杀掉整个 app）。
+  ///
+  /// **这里刻意不重建**（`afterRebuild` 为 null），与漫画/词典弹窗/Lapis 三处
+  /// 不同。原因是阅读器的恢复锚 `_initialProgress` / `_initialCharOffset`
+  /// （[_initBook] / `_beginNavigation` / reload 三处写）记的是**进入本章那一刻
+  /// 的快照**，章内滚动只更新 `_lastProgress*`、不回写它俩。跨章翻进本章时
+  /// `_beginNavigation` 常把它们写成 `0.0 / -1`，于是换 key 强制重建后
+  /// `onWebViewCreated → 重新 restore` 会回到**章首**，紧接着
+  /// `_onRestoreComplete → _refreshProgress → _debouncedSavePosition` 把这个回退
+  /// 位置如实落库，把 DB 里更靠后的真实进度覆盖掉。白屏可以退出重进，进度被写
+  /// 回退不可逆 —— 两害相权，本轮只救命不重建。
+  ///
+  /// 要把重建做对，得先补齐这些前置条件（不在本轮止血范围内）：
+  /// ① 崩溃回调里用 `_lastProgressValue` / `_lastProgressCharOffset` 补齐
+  ///    `_initialProgress` / `_initialCharOffset`（照 reload 路径的范式）；
+  /// ② `webview.part.dart` 里 `onWebViewCreated` 的
+  ///    `debugEvaluateJavascript == null` 断言改成幂等 —— State 不重建，第二次
+  ///    `onWebViewCreated` 必炸 assert；
+  /// ③ `navigation.part.dart` 的 `_refreshProgress` 给 `evaluateJavascript`
+  ///    补 try/catch。
+  ///
+  /// flush 侧仍要做满：取消轮询与 debounce（报废 controller 上的
+  /// `evaluateJavascript` 会抛成未捕获异步错误）、落盘当前位置、丢掉 controller。
+  late final WebViewDeathGuard _webViewDeathGuard = WebViewDeathGuard(
+    surface: 'reader_hibiki',
+    flushBeforeRebuild: () async {
+      _progressPollTimer?.cancel();
+      _progressPollTimer = null;
+      _controller = null;
+      await _flushPosition();
+    },
+  );
   // BUG-380: 滚动进度刷新的「在飞 + 待重跑」守卫。rAF 节流后滚动回传可能高频到来，
   // 每次 _refreshProgress 都 evaluateJavascript 跑较重的 hoshiProgressDetails（遍历全章
   // TextNode + caretRangeFromPoint），未加守卫会让多次调用堆积。_scrollProgressInFlight

--- a/hibiki/lib/src/webview/webview_death_guard.dart
+++ b/hibiki/lib/src/webview/webview_death_guard.dart
@@ -1,0 +1,154 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// WebView renderer 子进程死亡的**统一处置**。
+///
+/// ## 为什么必须有这个东西：救命动作是「传了回调」，不是「回调里做了什么」
+///
+/// Android 上一个 WebView 的 HTML 渲染跑在**独立的 chromium renderer 子进程**里。
+/// 系统内存紧张时会把这个子进程回收掉（`didCrash=false`），或者它自己崩溃
+/// （`didCrash=true`）。此时 `WebViewClient.onRenderProcessGone` 的返回值决定
+/// 后果：返回 `true` = 「宿主已接管」，只有那一个 WebView 变白；返回 `false`
+/// （`super` 的默认实现）= 「没人接管」，`AwBrowserTerminator` 直接 **SIGTRAP
+/// 杀掉整个 app 进程**。
+///
+/// 本仓 vendored 的
+/// `third_party/flutter_inappwebview_android/.../InAppWebViewClientCompat.java`
+/// 那段是：
+///
+/// ```java
+/// if (webView.customSettings.useOnRenderProcessGone && webView.channelDelegate != null) {
+///   webView.channelDelegate.onRenderProcessGone(didCrash, rendererPriorityAtExit);
+///   return true;                      // fire-and-forget，随即自报接管
+/// }
+/// return super.onRenderProcessGone(view, detail);   // 没接管 → 连坐杀 app
+/// ```
+///
+/// 注意 Java 侧是**发完事件立刻 `return true`**，而 Dart 侧的回调签名是 `void`：
+/// 返回值根本回不到 Java。所以 —— **救 app 的唯一动作，就是在构造
+/// `InAppWebView` / `HeadlessInAppWebView` 时传了一个非 null 的
+/// `onRenderProcessGone`**（它会让
+/// `flutter_inappwebview_android/.../in_app_webview.dart:444` 把
+/// `useOnRenderProcessGone` 自动推成 `true`，从而走进上面那个 `return true`
+/// 分支）。回调体里写什么、写多少，都只影响「死后能恢复多少」，不影响「app
+/// 是否被杀」。
+///
+/// 正因为救命动作在所有站点**完全同构**，处置就必须收在这一个类里，各站点只剩
+/// 「重建后调哪个已有 restore」这一个差异（[flushBeforeRebuild] /
+/// [afterRebuild] 两个钩子）。分散到 N 处各写各的，只要第 N+1 处忘了传，那处就
+/// 是一颗真机崩溃地雷 —— 守卫
+/// `test/webview/webview_render_process_gone_guard_test.dart` 断言 `lib/` 下每一
+/// 处构造都传了这个回调。
+///
+/// ## 恢复策略
+///
+/// renderer 死后那个 WebView 的 native 视图已经报废，`evaluateJavascript` 只会
+/// 抛或永久挂起；Flutter 侧不会自动知道。要复活只能把 widget 整个换掉，让
+/// framework 重建一个新的平台视图 —— 这就是 [rebuildKey]：把它挂在 WebView
+/// **之上**（`KeyedSubtree`），epoch 一变整棵子树重建，而 WebView 自己的
+/// `ValueKey`（集成测试的 finder 锚点）保持不变。
+///
+/// 重建**不是**免费的：宿主 State 不会重建，字段全部原样保留，所以
+/// - 易失状态（还在 debounce 窗口里没落盘的进度）必须在 [flushBeforeRebuild]
+///   里抢救；
+/// - 陈旧的 controller / ready 标志也必须在同一个钩子里清掉，否则新 WebView
+///   起来之前的那段时间里，旧引用仍会被当成活的。
+///
+/// 有的宿主重建反而会写坏数据（恢复锚是「进入本章时的快照」而不是「当前实际
+/// 位置」，重建后 restore 会把更靠后的真实进度覆盖回退），那种站点就把
+/// [afterRebuild] 传 null：**只救命、不重建**。这不是偷懒，是两害相权 ——
+/// 白屏可以退出重进，进度被写回退不可逆。
+class WebViewDeathGuard {
+  WebViewDeathGuard({
+    required this.surface,
+    Future<void> Function()? flushBeforeRebuild,
+    VoidCallback? afterRebuild,
+    int maxRebuilds = kDefaultMaxRebuilds,
+    void Function(String surface, String message)? reporter,
+  })  : _flushBeforeRebuild = flushBeforeRebuild,
+        _afterRebuild = afterRebuild,
+        _maxRebuilds = maxRebuilds,
+        _reporter = reporter ?? _debugPrintReport;
+
+  /// 重建预算。renderer 被 OOM kill 往往不是一次性事件：内存压力还在，重建出来
+  /// 的新 renderer 会立刻再死。无上限重建 = 无限重建风暴，比白屏更糟。用完预算
+  /// 就停在「死着」的状态，等用户退出重进。
+  static const int kDefaultMaxRebuilds = 3;
+
+  /// 诊断用的站点名，也是 [rebuildKey] 的前缀。
+  final String surface;
+
+  final Future<void> Function()? _flushBeforeRebuild;
+  final VoidCallback? _afterRebuild;
+  final int _maxRebuilds;
+  final void Function(String surface, String message) _reporter;
+
+  int _epoch = 0;
+  int _deathCount = 0;
+  bool _handling = false;
+
+  /// 当前这块表面的第几代 WebView（从 0 起）。
+  int get epoch => _epoch;
+
+  /// 累计观测到的 renderer 死亡次数（含预算用尽后不再重建的那些）。
+  int get deathCount => _deathCount;
+
+  /// 重建预算是否已用尽：此后只抢救数据、不再重建。
+  bool get isRebuildBudgetExhausted => _deathCount > _maxRebuilds;
+
+  /// 挂在 WebView **之上**（而不是 WebView 自己）的重建 key。
+  ///
+  /// 挂在上面而非 WebView 自己身上，是为了不动 `ValueKey('hoshi_webview')` /
+  /// `ValueKey('manga_webview')` 这类被大量集成测试 finder 依赖的锚点。
+  Key get rebuildKey => ValueKey<String>('${surface}_webview_gen_$_epoch');
+
+  /// renderer 死了。接到 `onRenderProcessGone` 就调这个。
+  ///
+  /// 顺序是硬的：**先抢救数据、再决定是否重建**。预算用尽时前半段照做，只是不
+  /// 递增 epoch、不通知宿主重建。
+  ///
+  /// 参数取平台 `RenderProcessGoneDetail` 的两个原始值，本类刻意不 import
+  /// flutter_inappwebview —— 处置策略是纯逻辑，要能脱离平台通道单测。
+  Future<void> handleDeath({
+    bool didCrash = false,
+    Object? rendererPriorityAtExit,
+  }) async {
+    // 同一次死亡可能由多路回调进来（例如宿主自己也挂了监听）；重入直接丢弃，
+    // 否则 epoch 会一次死亡跳两代、预算被虚耗。
+    if (_handling) return;
+    _handling = true;
+    _deathCount += 1;
+    _reporter(
+      surface,
+      'renderer gone (didCrash=$didCrash, '
+      'priorityAtExit=$rendererPriorityAtExit, death#$_deathCount)',
+    );
+    try {
+      // 抢救永远先做，且抛错也不能挡住后面的重建：宿主 flush 失败最多丢这次
+      // 增量，而不重建就是永久白屏。
+      await _flushBeforeRebuild?.call();
+    } catch (e, stack) {
+      _reporter(surface, 'flushBeforeRebuild failed: $e\n$stack');
+    }
+    if (isRebuildBudgetExhausted) {
+      _reporter(
+        surface,
+        'rebuild budget exhausted (max=$_maxRebuilds); surface stays dead',
+      );
+      _handling = false;
+      return;
+    }
+    _epoch += 1;
+    try {
+      _afterRebuild?.call();
+    } catch (e, stack) {
+      _reporter(surface, 'afterRebuild failed: $e\n$stack');
+    }
+    _handling = false;
+  }
+
+  static void _debugPrintReport(String surface, String message) {
+    debugPrint('[WebViewDeathGuard] $surface: $message');
+  }
+}

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1135
+version: 1.3.1+1136
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/webview/webview_death_guard_test.dart
+++ b/hibiki/test/webview/webview_death_guard_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/webview/webview_death_guard.dart';
+
+/// [WebViewDeathGuard] 的处置策略行为测试。
+///
+/// 救命动作（「传了非 null 回调」）由源码守卫
+/// `webview_render_process_gone_guard_test.dart` 钉住；这里钉的是死亡之后那套
+/// 顺序：先抢救数据、再重建、重建有预算。
+void main() {
+  test('先 flush 再重建：顺序不能反（否则重建把易失增量丢掉）', () async {
+    final List<String> order = <String>[];
+    final WebViewDeathGuard guard = WebViewDeathGuard(
+      surface: 'test',
+      flushBeforeRebuild: () async => order.add('flush'),
+      afterRebuild: () => order.add('rebuild'),
+      reporter: (_, __) {},
+    );
+    await guard.handleDeath(didCrash: true);
+    expect(order, <String>['flush', 'rebuild']);
+  });
+
+  test('epoch 递增换出新 rebuildKey（同一 key 不会重建平台视图）', () async {
+    final WebViewDeathGuard guard = WebViewDeathGuard(
+      surface: 'reader',
+      reporter: (_, __) {},
+    );
+    final Key first = guard.rebuildKey;
+    expect(guard.epoch, 0);
+    await guard.handleDeath();
+    expect(guard.epoch, 1);
+    expect(guard.rebuildKey, isNot(first));
+  });
+
+  test('flush 抛错不挡重建（丢一次增量好过永久白屏）', () async {
+    bool rebuilt = false;
+    final WebViewDeathGuard guard = WebViewDeathGuard(
+      surface: 'test',
+      flushBeforeRebuild: () async => throw StateError('db closed'),
+      afterRebuild: () => rebuilt = true,
+      reporter: (_, __) {},
+    );
+    await guard.handleDeath();
+    expect(rebuilt, isTrue);
+    expect(guard.epoch, 1);
+  });
+
+  test('重建预算用尽后只抢救不重建（内存压力下的重建风暴止损）', () async {
+    int flushes = 0;
+    int rebuilds = 0;
+    final WebViewDeathGuard guard = WebViewDeathGuard(
+      surface: 'test',
+      maxRebuilds: 2,
+      flushBeforeRebuild: () async => flushes++,
+      afterRebuild: () => rebuilds++,
+      reporter: (_, __) {},
+    );
+    for (int i = 0; i < 5; i++) {
+      await guard.handleDeath();
+    }
+    expect(flushes, 5, reason: '每次死亡都要抢救数据，预算与它无关');
+    expect(rebuilds, 2, reason: '重建次数封顶在 maxRebuilds');
+    expect(guard.epoch, 2);
+    expect(guard.isRebuildBudgetExhausted, isTrue);
+    expect(guard.deathCount, 5);
+  });
+
+  test('afterRebuild 为 null = 只救命不重建（阅读器那种恢复锚会写回退的宿主）', () async {
+    int flushes = 0;
+    final WebViewDeathGuard guard = WebViewDeathGuard(
+      surface: 'reader_hibiki',
+      flushBeforeRebuild: () async => flushes++,
+      reporter: (_, __) {},
+    );
+    await guard.handleDeath();
+    expect(flushes, 1);
+    expect(guard.deathCount, 1);
+  });
+
+  test('同一次死亡的重入回调被丢弃（epoch 不会一次跳两代）', () async {
+    late final WebViewDeathGuard guard;
+    int rebuilds = 0;
+    guard = WebViewDeathGuard(
+      surface: 'test',
+      flushBeforeRebuild: () async {
+        // 抢救途中再进来一次（宿主自己也挂了监听 / 平台重复发事件）。
+        await guard.handleDeath();
+      },
+      afterRebuild: () => rebuilds++,
+      reporter: (_, __) {},
+    );
+    await guard.handleDeath();
+    expect(guard.epoch, 1);
+    expect(guard.deathCount, 1);
+    expect(rebuilds, 1);
+  });
+}

--- a/hibiki/test/webview/webview_render_process_gone_guard_test.dart
+++ b/hibiki/test/webview/webview_render_process_gone_guard_test.dart
@@ -1,0 +1,222 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// 源码守卫：`lib/` 下**每一处** WebView 构造都必须传非 null 的
+/// `onRenderProcessGone`。
+///
+/// ## 为什么「传了这个参数」本身就是被守的语义（不是摆设式字面量断言）
+///
+/// Android 上一个 WebView 的 HTML 渲染跑在独立的 chromium renderer 子进程里。系统
+/// 内存紧张时会把它回收掉。此时
+/// `third_party/flutter_inappwebview_android/.../InAppWebViewClientCompat.java`
+/// 的 `onRenderProcessGone` 决定后果：
+///
+/// ```java
+/// if (webView.customSettings.useOnRenderProcessGone && webView.channelDelegate != null) {
+///   webView.channelDelegate.onRenderProcessGone(didCrash, rendererPriorityAtExit);
+///   return true;                                     // 自报接管，只白屏
+/// }
+/// return super.onRenderProcessGone(view, detail);    // 默认动作：杀掉整个 app 进程
+/// ```
+///
+/// Java 侧是**发完事件立刻 `return true`**，而 Dart 回调签名是 `void` —— 返回值
+/// 回不到 Java。所以回调体里写什么完全不影响存活，唯一决定「app 是否被系统连坐
+/// 杀掉」的就是**这个参数是不是 null**：
+/// `third_party/flutter_inappwebview_android/lib/src/in_app_webview/in_app_webview.dart:444`
+/// （headless 侧 `headless_in_app_webview.dart:380`）在
+/// `params.onRenderProcessGone != null && settings.useOnRenderProcessGone == null`
+/// 时把 `useOnRenderProcessGone` 自动推成 true，从而走进上面那个 `return true`。
+///
+/// 于是本守卫的两条断言都是**真语义**而非拼写：
+/// 1. 每处构造都有非 null 的 `onRenderProcessGone`；
+/// 2. 没有哪一处把 `useOnRenderProcessGone` 显式写成 `false` —— 那是唯一一种
+///    「回调传了、Java 侧依然回落 `super`」的写法，会让第 1 条变成假绿。
+///
+/// ## 判据不从被守对象推导
+///
+/// 宿主集合由**正向规则**发现（扫全 `lib/`，找以独立标识符身份出现的
+/// `InAppWebView(` / `HeadlessInAppWebView(` 构造），不是照抄一份已知文件清单；
+/// 新增第 N+1 处会被自动纳入。窗口由括号配对给出（[enclosingCall]），与缩进、
+/// 参数顺序、参数多少无关。发现数为 0 或少于当前已知的 6 处一律 fail —— 重构把
+/// 构造点搬走时守卫要红，而不是静默空跑。
+void main() {
+  const List<String> constructorNames = <String>[
+    'InAppWebView',
+    'HeadlessInAppWebView',
+  ];
+
+  // 当前 lib/ 下的实际构造点数（main.dart 预热 + 阅读器 + 漫画 + 词典弹窗 +
+  // Lapis 预览 + 有声书剪辑离屏）。少于这个数说明发现规则锚不上目标了。
+  const int knownHostCount = 6;
+
+  final List<String> anchorErrors = <String>[];
+  final List<_WebViewHost> hosts =
+      _discoverHosts(constructorNames, anchorErrors);
+
+  test('lib/ 下能发现 WebView 构造点（发现规则本身不许空跑）', () {
+    expect(
+      anchorErrors,
+      isEmpty,
+      reason: '括号配对回溯没落在被找的构造器上，窗口锚歪了，'
+          '后面的参数断言不可信：\n${anchorErrors.join('\n')}',
+    );
+    expect(
+      hosts,
+      isNotEmpty,
+      reason: '一处 InAppWebView 构造都没扫到，说明发现规则失效（包名/构造器改了？），'
+          '此时后面的逐处断言会全部空转成假绿',
+    );
+    expect(
+      hosts.length,
+      greaterThanOrEqualTo(knownHostCount),
+      reason: '已知 $knownHostCount 处 WebView 构造点，现在只发现 ${hosts.length} 处：'
+          '要么构造点被搬走/改名（发现规则要跟着更新），要么真的被删了。'
+          '发现到的：${hosts.map((_WebViewHost h) => h.where).join(', ')}',
+    );
+  });
+
+  test('每一处 WebView 构造都传了非 null 的 onRenderProcessGone', () {
+    final List<String> offenders = <String>[];
+    for (final _WebViewHost host in hosts) {
+      final String? value =
+          _topLevelNamedArgument(host.call.text, 'onRenderProcessGone');
+      if (value == null) {
+        offenders.add('${host.where} —— 没有 onRenderProcessGone 参数');
+        continue;
+      }
+      if (value.isEmpty || value == 'null') {
+        offenders.add('${host.where} —— onRenderProcessGone 传了 `$value`');
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason: 'Android 上没接管 renderer 死亡 = 系统把整个 app 进程一起杀掉'
+          '（InAppWebViewClientCompat.onRenderProcessGone 回落 super）。'
+          '救命动作就是传一个非 null 回调，处置逻辑收在 '
+          'lib/src/webview/webview_death_guard.dart 的 WebViewDeathGuard。'
+          '未接管的构造点：\n${offenders.join('\n')}',
+    );
+  });
+
+  test('没有哪一处把 useOnRenderProcessGone 显式关成 false', () {
+    final List<String> offenders = <String>[];
+    for (final _WebViewHost host in hosts) {
+      final String masked = maskCommentsAndStrings(host.call.text);
+      final RegExp disabled = RegExp(
+        r'(?<![A-Za-z0-9_$])useOnRenderProcessGone\s*:\s*false',
+      );
+      if (disabled.hasMatch(masked)) {
+        offenders.add(host.where);
+      }
+    }
+    expect(
+      offenders,
+      isEmpty,
+      reason: '把 useOnRenderProcessGone 写成 false 会让 Java 侧无视已传的回调、'
+          '回落 super（= 杀 app），上一条断言随即变成假绿。'
+          '默认不写即可：in_app_webview.dart:444 会在回调非 null 时自动推成 true。'
+          '违规处：${offenders.join(', ')}',
+    );
+  });
+}
+
+class _WebViewHost {
+  _WebViewHost({required this.where, required this.call});
+
+  /// `路径:行号 构造器名` —— 断言失败时直接指出是哪一处。
+  final String where;
+  final EnclosingCall call;
+}
+
+/// 发现规则跑在 `main()` 体内（测试注册前），所以这里**不能**调 [expect]
+/// （会抛 `OutsideTestException`）；锚歪的情况收进 [anchorErrors]，由第一个测试断言。
+List<_WebViewHost> _discoverHosts(
+  List<String> constructorNames,
+  List<String> anchorErrors,
+) {
+  final List<_WebViewHost> hosts = <_WebViewHost>[];
+  final List<File> files = Directory('lib')
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((File f) => f.path.endsWith('.dart'))
+      .toList()
+    ..sort((File a, File b) => a.path.compareTo(b.path));
+  for (final File file in files) {
+    final String source = file.readAsStringSync();
+    // 先做词法掩码再找：注释里写着 `InAppWebView(` 不算构造点。掩码等长，
+    // 下标可直接回原串取切片。
+    final String masked = maskCommentsAndStrings(source);
+    for (final String name in constructorNames) {
+      // allowNamedConstructor: false —— 只认裸构造。负向后顾保证
+      // `HeadlessInAppWebView(` 不会被 `InAppWebView` 这条规则重复命中。
+      final RegExp pattern = identifierCall(name, allowNamedConstructor: false);
+      for (final RegExpMatch match in pattern.allMatches(masked)) {
+        final EnclosingCall call = enclosingCall(source, match.end);
+        // 防锚歪：括号回溯拿到的必须就是这个构造器本身。
+        if (call.name != name) {
+          anchorErrors.add(
+            '${file.path} 里 $name 的括号配对回溯拿到了 `${call.name}`',
+          );
+          continue;
+        }
+        final int line =
+            '\n'.allMatches(source.substring(0, call.start)).length + 1;
+        hosts.add(_WebViewHost(
+          where: '${file.path.replaceAll(r'\', '/')}:$line $name',
+          call: call,
+        ));
+      }
+    }
+  }
+  return hosts;
+}
+
+/// 取 [callText] 这次调用**自身实参表**（深度 1）上名为 [label] 的命名参数值。
+///
+/// 深度用 `(` `[` `{` 三种括号计数（泛型 `<>` 不影响括号深度，所以不用管），
+/// 因此嵌套 widget 里同名的参数不会被误当成本次调用的参数。找不到返回 null。
+String? _topLevelNamedArgument(String callText, String label) {
+  final String masked = maskCommentsAndStrings(callText);
+  final int open = masked.indexOf('(');
+  if (open < 0) return null;
+  final RegExp pattern = RegExp(
+    r'(?<![A-Za-z0-9_$])' + RegExp.escape(label) + r'\s*:',
+  );
+  for (final RegExpMatch match in pattern.allMatches(masked)) {
+    if (match.start < open) continue;
+    if (_bracketDepth(masked, open, match.start) != 1) continue;
+    int i = match.end;
+    int depth = 0;
+    while (i < masked.length) {
+      final String c = masked[i];
+      if (c == '(' || c == '[' || c == '{') {
+        depth++;
+      } else if (c == ')' || c == ']' || c == '}') {
+        if (depth == 0) break;
+        depth--;
+      } else if (c == ',' && depth == 0) {
+        break;
+      }
+      i++;
+    }
+    return callText.substring(match.end, i).trim();
+  }
+  return null;
+}
+
+int _bracketDepth(String masked, int from, int to) {
+  int depth = 0;
+  for (int i = from; i < to; i++) {
+    final String c = masked[i];
+    if (c == '(' || c == '[' || c == '{') {
+      depth++;
+    } else if (c == ')' || c == ']' || c == '}') {
+      depth--;
+    }
+  }
+  return depth;
+}


### PR DESCRIPTION
## 问题（BUG-1386，看板 TODO-2589）

Android 上 WebView 的 HTML 渲染跑在独立 chromium renderer 子进程里。内存紧张被系统回收时，
`third_party/flutter_inappwebview_android/.../InAppWebViewClientCompat.java:811-822` 若没拿到
`onRenderProcessGone` 回调就回落 `super`（false）= `AwBrowserTerminator` **杀掉整个 app 进程**。
PR#690（BUG-1372）只修了 `main.dart` 的启动预热，`lib/` 下另外 **5 处**构造全部裸奔。真机同样中招。

关键机制：Java 侧是 **fire-and-forget 后自己 `return true`**，而 Dart 回调是 `void`、返回值回不去。
⇒ **救 app 的唯一动作就是「传了非 null 的 `onRenderProcessGone`」**（它让
`in_app_webview.dart:444-445` 把 `useOnRenderProcessGone` 自动推成 true）。五处完全同构，
差异只剩「重建后调哪个已有 restore」。

## 做法：收成单一入口

新增 `hibiki/lib/src/webview/webview_death_guard.dart` 的 `WebViewDeathGuard`
（epoch key + `flushBeforeRebuild` / `afterRebuild` 钩子 + 重建预算，与 `WebViewPrewarmSession` 同风格）。
各站点只声明「抢救什么 / 重建后调哪个已有 restore」：

| 站点 | flushBeforeRebuild | afterRebuild |
|---|---|---|
| 漫画 `manga_hibiki_page.dart` | `_windowGate.abandon()` + 丢 controller + `_flushPosition()` | `setState` 换 epoch key |
| EPUB 阅读器 `reader_hibiki/webview.part.dart` | 取消 `_progressPollTimer` + 丢 controller + `_flushPosition()` | **null（只救命不重建）** |
| 词典弹窗 `dictionary_popup_webview.dart` | 清 `_ready`/controller/推送去重基线 + 置 `_refreshWhenReady` | `setState` 换 key，新 `onLoadStop` 全量重推 |
| Lapis 预览 `lapis_style_editor_page.dart` | 丢 controller | `setState` 换 key，`onLoadStop → _refreshPreview` 自愈 |
| 有声书剪辑 `audiobook_clip_webview_render.dart`（headless） | 置 `rendererDead` + 解开 8s load 等待 | null（一次性管线，发 null 帧让调用方回退单句静态） |

重建 key 一律挂在 WebView **之上**（`KeyedSubtree`），`hoshi_webview` / `manga_webview` 这些
集成测试 finder 锚点保持不变。

## 阅读器为什么不重建（本轮验证结论）

`_restoreInFlight` / `_suppressPositionPersist` **不是竞态源**：前者失败路径也清（`webview.part.dart:2448`、
`navigation.part.dart:458`）且有 8s 兜底 `_failNavigation`，后者只在 `_initBook` 一次性置位。
真正的竞态在**恢复锚陈旧**：`_initialProgress`/`_initialCharOffset`（`reader_hibiki_page.dart:1208/1211`）
记的是「进入本章那一刻的快照」，章内滚动只写 `_lastProgress*`；跨章翻进本章时 `_beginNavigation`
（`navigation.part.dart:428-429`）常把它们写成 `0.0 / -1`。换 key 强制重建 → restore 回章首 →
`_onRestoreComplete → _refreshProgress → _debouncedSavePosition` 把回退位置**如实落库**，覆盖 DB 里
更靠后的真实进度。另有两处硬阻塞：`webview.part.dart:1809-1821` 的 `debugEvaluateJavascript == null`
断言只在 dispose 清（State 不重建 ⇒ 第二次 `onWebViewCreated` 必炸），`navigation.part.dart:903-907`
的 `_refreshProgress` 无 try/catch。白屏可退出重进，进度写回退不可逆 —— 本轮只救命，前置条件写进代码注释与 BUG 文档。

## 守卫

`hibiki/test/webview/webview_render_process_gone_guard_test.dart`：
- **正向规则发现宿主** —— 扫全 `lib/`，词法掩码后找以独立标识符身份出现的
  `InAppWebView(` / `HeadlessInAppWebView(` 构造，窗口由 `enclosingCall` 括号配对给出（不是定长字符窗口，
  也不是照抄一份已知文件清单）；
- **判据不从被守对象推导** —— 断言 ① 每处都有非 null `onRenderProcessGone`（这一条**就是**语义：
  Java 侧只看回调是否非 null），② 没有哪处把 `useOnRenderProcessGone` 显式写成 `false`
  （唯一一种「回调传了、Java 侧仍回落 super」的假绿写法）；
- **锚不上要 fail** —— 发现数为 0 或少于当前已知 6 处即红，防重构后守卫静默空跑；括号回溯锚歪也单独报。

行为测试 `hibiki/test/webview/webview_death_guard_test.dart`：flush 先于 rebuild、epoch 换 key、
flush 抛错不挡重建、重建预算封顶、`afterRebuild == null` 只救命、同一次死亡重入丢弃。

### 变异实测（两个方向）
- **反向**：摘掉 Lapis 那处的 `onRenderProcessGone` → 守卫红并精确报出
  `lib/src/anki/lapis_style_editor_page.dart:402 InAppWebView —— 没有 onRenderProcessGone 参数`；
  另加 `useOnRenderProcessGone: false` → 第三条断言红。
- **正向**：把该处换成**不走** `WebViewDeathGuard` 的内联闭包 → 守卫**仍绿**（验不误伤）。
- 还原走反向替换，`git status --short` 干净（diff 纯新增，零删除）。

## 范围外
不碰 iOS/macOS（上游已实现且 WKWebView 终止不杀 app）、Windows fork（原生从不 raise `ProcessFailed`，
注册即死代码，要改 C++）、Linux（无实现）。不合并 develop、不 bump `+build`。

## 验证
- `flutter analyze --no-pub`（含 test）：**No issues found!**
- `dart run tool/flutter_test_failures.dart --no-pub test/pages test/reader test/dictionary test/lookup test/anki test/focus test/webview test/startup test/native test/widgets test/shortcuts test/media/audiobook`
  → `FAILED - ... (tests completed: 6905)`，**唯一失败**是既有红
  `reader_lyrics_progress_bottom_reserve_static_test`（PR#693 在修；断言的
  `EdgeInsets.only(bottom: _readerBottomReserve)` 在 HEAD 与工作树里都不存在，与本 PR 无关）。
- `grep -l` 反查所有扫改动生产文件的守卫（约 230 个测试文件），全部落在上述目录内并已一并跑过。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
