### PR TITLE
fix(scraper): 子篇作品海报改投合集封面 + 存量清理 + 封面写盘守卫覆盖洞（接管 PR#677 三条必改）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1309 条。点号进各自文件。
+> 共 1311 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1394](bugs/BUG-1394-cover-write-guard-cross-file.md) | ✅ | ✅ | 封面写盘守卫的跨文件派生覆盖洞：番剧下载封面绕过 BUG-1118 收口 |
+| [BUG-1393](bugs/BUG-1393-collection-member-poster.md) | ✅ | ✅ | 合集子篇被自动刮成作品级竖版海报，且作品海报被整个丢弃 |
 | [BUG-1381](bugs/BUG-1381-lyrics-bottom-reserve-guard.md) | ✅ | ✅ | 歌词底栏预留守卫锚在实现写法上，PR#670 合并 Padding 后 develop 单测红 |
 | [BUG-1380](bugs/BUG-1380-wheel-gate-token-consumed-before-paginate.md) | ✅ | ✅ | 分页滚轮闸门在换章加载期消费手势 token，整段横向惯性被吞 |
 | [BUG-1373](bugs/BUG-1373-ios-pod-install-license-file-type.md) | ✅ | ✅ | iOS pod install 断在 license 校验：LICENSE.GPLv3 扩展名不被 CocoaPods 接受 |

--- a/docs/bugs/BUG-1393-collection-member-poster.md
+++ b/docs/bugs/BUG-1393-collection-member-poster.md
@@ -1,0 +1,19 @@
+## BUG-1393 · 合集子篇被自动刮成作品级竖版海报，且作品海报被整个丢弃
+- **报告**：2026-08-02（用户：「子篇封面禁用作品级竖版海报：**作品海报只归合集封面**，成员条目保持抽帧/集级剧照，宁可无封面不凑数（含下载导入海报改落合集 coverPath）」）
+- **真实性**：✅ 真 bug。两半根因：
+  - **闸门缺失**：`hibiki/lib/src/media/video/scraper/cover_scraper_service.dart:329` `scrapeLibrary` 逐本只按 `CoverOrigin.batchOverwritePolicy` 判覆盖许可，完全不知道这本属不属于合集（`VideoBookRow` 无 collection 字段），于是 26 集番的每一集都被 `_applyCandidate`（同文件 `:890`）刷上同一张作品级竖版海报。
+  - **改投缺失（第一版修复的回退）**：只加闸不改投的话，`updateMediaCollectionCoverPath` 全仓只剩两个调用方（`collection_scrape_apply.dart:43` 手动弹窗、番剧下载导入），**扫描/自动刮削的多集合集海报既不落成员也不落合集** → 合集卡从「显示海报」退化成「显示首集抽帧」（渲染回退链 `home_video_page.dart:3487` 的 `coverPath` 优先 → 借成员）。这与用户口径「作品海报**只归合集封面**」直接相悖：用户要的是海报**改投**，不是海报**消失**。
+  - **存量不回退**：`_maybeBackfillCovers`（`home_video_page.dart:521`）只补空封面，`VideoScrapeAutoService._pending`（`auto_scrape_service.dart:129`）只喂「还没有资料行」的书——而被刷上海报的子篇**恰恰都有资料行**，永远不会被重新访问。不做存量清理，用户开 app 看到的还是坏的。
+- **[x] ① 已修复** — 三处：
+  1. `collection_member_policy.dart`（新）`multiMemberCollectionIdByVideoUid` 纯函数：全库合集成员表 → `子篇 uid → 最小多成员 collectionId`。返回 **Map 而不是 Set/bool**——闸住只做对一半，海报还得有地方去。
+  2. `cover_scraper_service.dart` `scrapeLibrary`：子篇一律不落成员封面（任何开关解不开），并复用同一次匹配的决策调 `_promoteCollectionCover` 把海报下到 `collections/<id>.jpg` + 写 `MediaCollections.coverPath`；一合集一次、不覆盖已有合集封面、失败只记日志不翻 outcome。`_scrapeMetadataOnly` 改为返回 `MatchDecision?` 以复用匹配结果，不重发搜索。
+  3. `member_cover_cleanup.dart`（新）存量清理：纯判据 `planMemberCoverCleanup` + 落地 `runMemberCoverCleanup`，由 `VideoScrapeAutoService.sweep` 在**刮削之前**每进程跑一次。把成员身上的作品海报**升格**成合集自有封面后清成员那一列。
+  4. `anime_download_importer.dart`：AniList 作品海报直落合集 `coverPath`，首集只留抽帧 + `coverSource` 借用链兜底。
+  - **误删方向的收口**（存量清理是清空类改动）：只认 `CoverOrigin.autoScraped`（`manual`/`userScraped`/`sidecar` 是用户拍板、`scraped` 是来源不明的存量、`autoFrame`/无记录本就是想保留的）；路径**只来自被清那一行自己的 `coverPath` 字段**（不枚举目录不猜文件名）；规范化后必须 `p.isWithin` 自有封面目录**且直接父目录相等**（目录外 = 用户自己的图，`collections/` 子目录 = 合集封面，都在射程外）；**一个文件都不删**——孤儿由既有 `VideoStorage.gcOrphanCovers` 回收（它非递归，`collections/` 天然免疫）。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/media/video/scraper/collection_member_policy_test.dart`（6）判据纯函数。
+  - `hibiki/test/media/video/scraper/collection_member_cover_gate_test.dart`（5）闸 + **海报真落到合集 coverPath**、一合集只下一次、已有合集封面不覆盖不出网、单片/单成员合集照旧、用户手动匹配放行。
+  - `hibiki/test/media/video/scraper/member_cover_cleanup_test.dart`（14）判据层 **误删方向逐条穷举**（用户手选/legacy scraped/抽帧/非子篇/空路径/目录外/路径遍历/`collections/` 子目录）+ 落地层真 DB 真文件（升格、非目标行逐字节不变、不覆盖已有合集封面、幂等、升格后的合集封面扛得住 `gcOrphanCovers`）。
+  - `hibiki/test/torrent/anime_download_importer_test.dart`（4）海报落合集列、成员不沾、无 URL 不误写、非图片响应不落盘。
+  - **变异实测**：摘掉 `_promoteCollectionCover` 调用 → gate 测试红；把清理判据从 `!= autoScraped` 放宽成 `== autoFrame` → 7 条红（含全部误删方向用例）；拆掉 `p.isWithin` + 父目录围栏 → 2 条误删方向用例红。
+- **备注**：接管 PR#677 复核退回的三条必改（看板 TODO-2554，源需求 TODO-2549）。守卫覆盖洞另记 BUG-1394。

--- a/docs/bugs/BUG-1394-cover-write-guard-cross-file.md
+++ b/docs/bugs/BUG-1394-cover-write-guard-cross-file.md
@@ -1,0 +1,13 @@
+## BUG-1394 · 封面写盘守卫的跨文件派生覆盖洞：番剧下载封面绕过 BUG-1118 收口
+- **报告**：2026-08-02（PR#677 复核）
+- **真实性**：✅ 真 bug（守卫假绿 + 真实的旧图回归面）。
+  - **绕过点**：`hibiki/lib/src/media/video/video_cover_extractor.dart:157` 的 `downloadVideoCoverToPath` 是**裸 `writeAsBytes`**——不 evict 双键解码缓存、不原子 `.tmp`+rename、不校验图片魔数。它被三个**覆盖写**场景复用：番剧下载重放（`anime_download_importer.dart`，`reuseExistingPaths:true` 会覆盖同名文件）、流媒体换封面（`url_stream_video.dart:196`）、导入弹窗重取缩略图（`video_import_dialog.dart:664`）。同路径重下后 UI 重建命中旧解码缓存 = **用户看到旧图**，正是 BUG-1118 的形状。
+  - **守卫为什么不报**：`hibiki/test/media/media_cover_write_guard_test.dart:59-91` 是**单文件内 AND 判定**（destMarker && rawWrite && !applyCover）。派生点与写盘点跨文件时两边都逃：调用方（如 `anime_download_importer.dart`）有 destMarker（`videoCoverFileName(` / `videoCoversDirectory(`）但没有 rawWrite → 第 83 行直接 `continue`；真正的裸写在 `video_cover_extractor.dart`，而它整个文件在白名单里 → 第 78 行直接 `continue`。给「导入期首写（ffmpeg 子进程直写目标路径，此前无解码缓存）」开的豁免，被整文件放行的粒度扩大成了「这个文件里干什么都行」。
+- **[x] ① 已修复** —
+  - `video_cover_extractor.dart` `downloadVideoCoverToPath` 改走统一收口 `MediaCoverService.applyCoverBytes`（原子 `.tmp`+rename、失败不动旧封面、成功后 `evictLocalCoverCache` 双键驱逐），并在落盘前过 `looksLikeImageBytes`（`media/metadata/image_download.dart:180`，与 `CoverDownloader` 同一个判据，不再各写一份魔数嗅探）。**三个调用点一次修完**，不是只补番剧下载那一处。
+  - 库注释同步收紧豁免边界：ffmpeg 两条路（子进程写盘、Dart 侧无字节）仍是豁免；Dart 侧有字节的路不在豁免内。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/media/media_cover_write_guard_test.dart` 新增第 4 条守卫「白名单文件的裸写豁免逐函数登记」：把整文件白名单降级成 `{文件 → 允许裸写的函数名集合}` 显式清单（`media_cover_service.dart` → `{applyCoverFile, applyCoverBytes}`；`video_cover_extractor.dart` → `{}` 空集）。新增裸写函数、或把已收口的函数改回裸写，都会红。
+  - 行为侧：`hibiki/test/media/video/youtube_import_cover_test.dart` 补「覆盖写同名文件内容真被换掉 + 不留 `.tmp`」「非图片响应（HTML 错误页）不落盘」「`content-type: image/*` 权威放行」；`hibiki/test/torrent/anime_download_importer_test.dart` 补重放覆盖同名合集封面用例。
+  - **变异实测**：把 `downloadVideoCoverToPath` 改回裸 `writeAsBytes` → 新守卫红（**行为测试全绿**——`.tmp` 断言对裸写同样成立，这正是必须有源码扫描守卫的理由）。
+- **备注**：与 BUG-1393 同一 PR 落地（接管 PR#677 的三条必改，看板 TODO-2554）。

--- a/hibiki/lib/src/media/torrent/anime_download_importer.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_importer.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
 import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
@@ -8,7 +9,7 @@ import 'package:hibiki/src/media/torrent/anime_download_service.dart';
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/media/video/video_filename_parser.dart';
-import 'package:hibiki/src/storage/app_paths.dart';
+import 'package:hibiki/src/media/video/video_storage.dart';
 import 'package:hibiki/src/media/video/video_cover_extractor.dart'
     show downloadVideoCoverToPath, extractVideoCover, videoCoverFileName;
 
@@ -28,15 +29,31 @@ List<String> sortVideoPathsByEpisode(List<String> paths) {
 }
 
 /// 组装番剧下载完成后的入库回调：N 集拆行 + playlist 合集（一个事务，复用
-/// [VideoBookRepository.importSplitPlaylist]）→ 绑定 AniList id → 封面（优先
-/// AniList 封面 URL，失败退 ffmpeg 抽帧）落到首集并让合集封面指向它。
+/// [VideoBookRepository.importSplitPlaylist]）→ 绑定 AniList id → 封面。
+///
+/// 封面分两层、各自 best-effort（用户 2026-08-02：作品海报只归合集封面，成员条目
+/// 保持抽帧/集级剧照）：
+/// * **作品海报（AniList 封面 URL）→ 合集自有封面**（`MediaCollections.coverPath`，
+///   落 `video_covers/collections/<collectionId>.jpg`），**不再借道首集条目封面**
+///   ——旧路径把海报写进首集 `VideoBooks.coverPath` 再让合集 coverSource 指过去，
+///   结果是成员条目顶着一张作品级竖版海报；
+/// * **首集抽帧缩略图 → 首集条目封面**，并保留 coverSource 借用链指向首集：海报
+///   下载失败/无 URL 时，合集卡回落链（coverPath 优先 → 借成员）仍能显示首集抽帧，
+///   与旧行为对齐。
 ///
 /// 封面/绑定失败不影响入库结果（best-effort），入库本体失败返回 null（由
 /// [AnimeDownloadService] 把计划标 failed）。
+///
+/// [httpClient] / [collectionCoversDirectory] 仅供测试注入（默认自建 client /
+/// 生产 [VideoStorage.collectionCoversDir]）。
 Future<AnimeDownloadImportOutcome?> Function(
   AnimeDownloadPlan plan,
   List<String> videoAbsolutePaths,
-) buildAnimeDownloadImporter(HibikiDatabase db) {
+) buildAnimeDownloadImporter(
+  HibikiDatabase db, {
+  http.Client? httpClient,
+  Directory? collectionCoversDirectory,
+}) {
   final VideoBookRepository repo = VideoBookRepository(db);
   return (AnimeDownloadPlan plan, List<String> videoAbsolutePaths) async {
     if (videoAbsolutePaths.isEmpty) return null;
@@ -63,25 +80,40 @@ Future<AnimeDownloadImportOutcome?> Function(
       } catch (_) {}
     }
 
-    // 封面：下载 AniList 封面 → 退 ffmpeg 抽帧；设到首集并让合集封面指向首集。
     if (result.episodeUids.isNotEmpty) {
+      // ① 作品海报 → 合集自有封面（见函数注释）。文件名/目录与
+      //    applyCandidateToCollection 同约定；gcOrphanCovers 非递归，天然免疫。
+      final String? coverUrl = plan.coverUrl;
+      if (coverUrl != null && coverUrl.isNotEmpty) {
+        try {
+          final Directory covers = collectionCoversDirectory ??
+              await VideoStorage.collectionCoversDir();
+          final String? collectionCoverPath = await downloadVideoCoverToPath(
+            coverUrl: coverUrl,
+            outputPath: p.join(
+              covers.path,
+              videoCoverFileName('${result.collectionId}'),
+            ),
+            httpClient: httpClient,
+          );
+          if (collectionCoverPath != null) {
+            await db.updateMediaCollectionCoverPath(
+              result.collectionId,
+              collectionCoverPath,
+            );
+          }
+        } catch (_) {}
+      }
+
+      // ② 首集抽帧缩略图 → 首集条目封面 + coverSource 借用链兜底。
       try {
         final String firstUid = result.episodeUids.first;
-        String? coverPath;
-        final String? coverUrl = plan.coverUrl;
-        if (coverUrl != null && coverUrl.isNotEmpty) {
-          final Directory covers = await AppPaths.videoCoversDirectory();
-          coverPath = await downloadVideoCoverToPath(
-            coverUrl: coverUrl,
-            outputPath: p.join(covers.path, videoCoverFileName(firstUid)),
-          );
-        }
-        coverPath ??= await extractVideoCover(
+        final String? framePath = await extractVideoCover(
           videoPath: sorted.first,
           bookUid: firstUid,
         );
-        if (coverPath != null) {
-          await repo.updateCover(firstUid, coverPath);
+        if (framePath != null) {
+          await repo.updateCover(firstUid, framePath);
           // ⚠️ 唯一落库点：MediaCollections.coverSource 持久化 'video|<uid>'，
           // compositeKey 生成串与历史手写插值逐字节一致。
           await db.updateMediaCollectionCover(

--- a/hibiki/lib/src/media/video/scraper/auto_scrape_service.dart
+++ b/hibiki/lib/src/media/video/scraper/auto_scrape_service.dart
@@ -19,6 +19,8 @@ library;
 import 'dart:async';
 
 import 'package:hibiki/src/media/video/scraper/cover_scraper_service.dart';
+import 'package:hibiki/src/media/video/scraper/member_cover_cleanup.dart'
+    show runMemberCoverCleanup;
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki_core/hibiki_core.dart' show VideoBookRow;
 
@@ -55,6 +57,10 @@ class VideoScrapeAutoService {
   /// 当前是否有一轮在跑（串行保证：第二次 [sweep] 直接返回，不并发开第二条流水线）。
   bool _running = false;
 
+  /// 本进程是否已跑过存量子篇海报清理（[CoverScraperService.reclaimMemberScrapedCovers]）。
+  /// 判据幂等，跑一次就够；失败也记，不在同一进程里反复重扫全库。
+  bool _reclaimedMemberCovers = false;
+
   /// dispose 后置位，让跑到一半的循环在下一本之前收手。
   bool _disposed = false;
 
@@ -88,6 +94,19 @@ class VideoScrapeAutoService {
     if (_isEnabled != null && !_isEnabled()) return;
     _running = true;
     try {
+      // 存量清理先于本轮刮削：被刷上作品海报的子篇**恰恰是已经有资料行的书**，
+      // 永远进不了 [_pending]，挂在刮削后面就等于永远不跑（用户开 app 看不到修复）。
+      // 判据幂等且不需要 CoverScraperService（不加载离线索引），本进程只跑一次。
+      if (!_reclaimedMemberCovers) {
+        _reclaimedMemberCovers = true;
+        try {
+          await runMemberCoverCleanup(repo: _repo);
+        } catch (_) {
+          // 后台静默清理：失败不拖累刮削，下次启动重来。
+        }
+        if (_disposed) return;
+      }
+
       final List<VideoBookRow> pending = await _pending(books);
       if (pending.isEmpty || _disposed) return;
 

--- a/hibiki/lib/src/media/video/scraper/collection_member_policy.dart
+++ b/hibiki/lib/src/media/video/scraper/collection_member_policy.dart
@@ -1,0 +1,48 @@
+/// 合集子篇判据（BUG-1393；用户 2026-08-02：「作品海报只归合集封面，成员条目保持
+/// 抽帧/集级剧照，宁可无封面不凑数」）。
+///
+/// 作品级竖版海报只属于**合集自有封面**（`MediaCollections.coverPath`）；成员数
+/// ≥2 的合集里的每一集（子篇）在任何**自动**路径下都不落作品海报——封面保持抽帧
+/// 缩略图或集级剧照（`EpisodeScrapeService` 的 TMDB 剧照），两者都没有就保持无
+/// 封面，不拿作品海报凑数。单片（独立条目或单成员合集）不受影响。用户在弹窗里
+/// 亲手匹配（`applyCandidateToBooks` → userScraped）永远放行，不经此判据。
+///
+/// ⚠️ 判据返回的不是「要不要跳过」的 bool，而是**归属 collectionId**：闸住子篇
+/// 封面只做对了一半，那张海报还得有地方去（用户口径是「归合集封面」而不是「消
+/// 失」）。把 collectionId 一并算出来，自动刮削才能把海报改落到容器上；bool 会
+/// 把这条信息扔掉，逼调用方再查一次库。
+library;
+
+import 'package:hibiki_core/hibiki_core.dart'
+    show MediaCollectionItemRow, MediaKind;
+
+/// 从全库合集成员表算出「合集子篇 → 所属多成员合集 id」的映射：条目属于任一
+/// **成员数 ≥2** 的合集即视为子篇。成员数按合集全部成员计、不分媒体种类——混编
+/// 合集（视频 + 书）里的视频集同样是某个多成员容器的一员，作品海报同样该落容器
+/// 不落成员。
+///
+/// 一条目跨多个多成员合集时取**最小 collectionId**（与
+/// `HibikiDatabase.getPrimaryCollectionIdByEntry` 的折叠归属同口径：库网格里该
+/// 条目折进 id 最小的合集卡，海报也该落到用户看得见的那张卡上）。
+///
+/// 纯函数、无 IO、输入序无关；输入取 `HibikiDatabase.getAllCollectionItems()`
+/// 一次全量（消 N+1，与该查询的注释口径一致）。
+Map<String, int> multiMemberCollectionIdByVideoUid(
+  List<MediaCollectionItemRow> items,
+) {
+  final Map<int, int> memberCountByCollection = <int, int>{};
+  for (final MediaCollectionItemRow item in items) {
+    memberCountByCollection[item.collectionId] =
+        (memberCountByCollection[item.collectionId] ?? 0) + 1;
+  }
+  final Map<String, int> result = <String, int>{};
+  for (final MediaCollectionItemRow item in items) {
+    if (item.mediaType != MediaKind.video.dbValue) continue;
+    if (memberCountByCollection[item.collectionId]! < 2) continue;
+    final int? existing = result[item.entryKey];
+    if (existing == null || item.collectionId < existing) {
+      result[item.entryKey] = item.collectionId;
+    }
+  }
+  return result;
+}

--- a/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
@@ -20,6 +20,8 @@ import 'package:hibiki/src/media/video/scraper/alias_cache.dart';
 import 'package:hibiki/src/media/video/scraper/anilist_client.dart';
 import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
 import 'package:hibiki/src/media/video/scraper/jikan_client.dart';
+import 'package:hibiki/src/media/video/scraper/collection_member_policy.dart'
+    show multiMemberCollectionIdByVideoUid;
 import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
 import 'package:hibiki/src/media/video/scraper/filename_parser.dart';
 import 'package:hibiki/src/media/video/scraper/match_scorer.dart';
@@ -36,7 +38,8 @@ import 'package:hibiki/src/media/video/video_storage.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/media/video/video_cover_extractor.dart'
     show videoCoverFileName;
-import 'package:hibiki_core/hibiki_core.dart' show VideoBookRow;
+import 'package:hibiki_core/hibiki_core.dart'
+    show MediaCollectionRow, VideoBookRow;
 import 'package:path/path.dart' as p;
 
 /// slim 缓存落盘文件名（与原始库同目录）。
@@ -199,6 +202,10 @@ class CoverScraperService {
   final Map<String, ScrapeMetadata> _metadataCache = <String, ScrapeMetadata>{};
   final Set<String> _metadataFailed = <String>{};
 
+  /// 本实例内已尝试过「子篇海报改投合集封面」的 collectionId（成功或失败都记）。
+  /// 26 集番只该发一次海报下载，也不该整季逐集重试同一个打不通的 CDN。
+  final Set<int> _collectionCoverAttempted = <int>{};
+
   /// 是否已装载离线库（供 UI 决定是否显示「离线」来源徽标 / 下载入口）。
   bool get hasOfflineIndex => _offline != null;
 
@@ -326,12 +333,26 @@ class CoverScraperService {
   /// [rescrapeScraped] 只解锁「要不要覆盖**自动**刮来的旧结果」，它**不是**
   /// 「覆盖一切」——用户亲手选定的封面（[CoverOrigin.userScraped]，见
   /// [applyCandidateToBooks]）在任何开关下都不会被动（BUG-1325）。
+  ///
+  /// 合集子篇（成员数 ≥2 的合集成员，判据 [multiMemberCollectionIdByVideoUid]）
+  /// 在本层**一律不落成员封面**、任何开关都解不开——但那张作品海报**不被丢弃**，
+  /// 而是改落到它所属合集的自有封面（[_promoteCollectionCover] →
+  /// `MediaCollections.coverPath`）。用户 2026-08-02 的口径是「作品海报只归合集
+  /// 封面」，不是「作品海报消失」：只闸不改投会让多集合集卡从显示海报退化成显示
+  /// 首集抽帧。子篇成员封面保持抽帧缩略图或集级剧照（EpisodeScrapeService），两
+  /// 者都没有就保持无封面。用户在弹窗亲手匹配（[applyCandidateToBooks]）不经此闸。
   Stream<BatchScrapeProgress> scrapeLibrary(
     List<VideoBookRow> books, {
     bool rescrapeScraped = false,
   }) async* {
     final Map<String, _ResolvedMatch> decisionCache =
         <String, _ResolvedMatch>{};
+    // 子篇归属每批取一次（全量单查询，消 N+1）；含 sidecar 在内的整条 scrapeOne
+    // 封面流水线对子篇都不放行——目录级 poster.jpg 刷满整季与在线海报同症
+    // （Kodi/Jellyfin 生态单集图约定是 -thumb 而非 -poster，此处整体跳过实际不
+    // 损失单集 sidecar）。
+    final Map<String, int> memberCollectionIds =
+        await _repo.multiMemberCollectionIds();
     for (int i = 0; i < books.length; i++) {
       final VideoBookRow book = books[i];
       ScrapeOutcome outcome;
@@ -342,20 +363,30 @@ class CoverScraperService {
           final CoverMeta? meta = await _coverMeta.get(book.bookUid);
           final CoverOrigin origin = meta?.origin ?? CoverOrigin.autoFrame;
           final CoverOverwritePolicy policy = origin.batchOverwritePolicy;
-          final bool allowed = switch (policy) {
-            CoverOverwritePolicy.free => true,
-            CoverOverwritePolicy.rescrapeOnly ||
-            CoverOverwritePolicy.legacyStrict =>
-              rescrapeScraped,
-            CoverOverwritePolicy.never => false,
-          };
+          final int? memberCollectionId = memberCollectionIds[book.bookUid];
+          final bool allowed = memberCollectionId == null &&
+              switch (policy) {
+                CoverOverwritePolicy.free => true,
+                CoverOverwritePolicy.rescrapeOnly ||
+                CoverOverwritePolicy.legacyStrict =>
+                  rescrapeScraped,
+                CoverOverwritePolicy.never => false,
+              };
           if (!allowed) {
             outcome = ScrapeSkippedProtected(origin);
             // 封面受保护 ≠ 条目资料也不要。手动设过封面、或目录里有 poster.jpg
             // 的库（整理过的库很常见）此前会被整本跳过、永远刮不到简介/评分；
             // 这里补一次**只刮资料不碰封面**的匹配。outcome 仍报
             // ScrapeSkippedProtected（说的是封面），既有语义不变。
-            await _scrapeMetadataOnly(book, decisionCache);
+            final MatchDecision? decision =
+                await _scrapeMetadataOnly(book, decisionCache);
+            // 子篇：同一次匹配得到的作品海报改投合集自有封面（不重下、不碰成员）。
+            if (memberCollectionId != null && decision != null) {
+              await _promoteCollectionCover(
+                memberCollectionId,
+                decision.candidate,
+              );
+            }
           } else {
             outcome = await scrapeOne(
               book,
@@ -378,15 +409,18 @@ class CoverScraperService {
   }
 
   /// 只刮**条目资料**、绝不碰封面：给封面来源受保护（manual / sidecar / 已刮）的
-  /// 书补资料用。走与封面刮削同一套解析 + 匹配 + 打分，但只在 high 置信度落资料
-  /// ——medium 在封面侧要人工确认，资料侧同理不能自作主张（配错条目 = 一整篇别人
-  /// 的简介，比配错封面更难被一眼发现）。
-  Future<void> _scrapeMetadataOnly(
+  /// 书、以及合集子篇补资料用。走与封面刮削同一套解析 + 匹配 + 打分，但只在 high
+  /// 置信度落资料——medium 在封面侧要人工确认，资料侧同理不能自作主张（配错条目
+  /// = 一整篇别人的简介，比配错封面更难被一眼发现）。
+  ///
+  /// 返回本次采信的 high 决策（无匹配 / 置信度不足返回 null），供调用方复用同一
+  /// 次匹配的海报改投合集封面——不返回就得为同一本再解析+搜索一遍。
+  Future<MatchDecision?> _scrapeMetadataOnly(
     VideoBookRow book,
     Map<String, _ResolvedMatch> decisionCache,
   ) async {
     final ParsedMediaName? parsed = _mergedParse(book.videoPath);
-    if (parsed == null || parsed.title.isEmpty) return;
+    if (parsed == null || parsed.title.isEmpty) return null;
     final String cacheKey = parsed.title;
 
     final _ResolvedMatch resolved;
@@ -398,12 +432,46 @@ class CoverScraperService {
     }
     final MatchDecision? decision = resolved.decision;
     if (decision == null || decision.confidence != MatchConfidence.high) {
-      return;
+      return null;
     }
     await _persistMetadata(
       bookUids: <String>[book.bookUid],
       candidate: decision.candidate,
     );
+    return decision;
+  }
+
+  /// 子篇的作品海报改投**所属合集的自有封面**（用户 2026-08-02：作品海报只归合集
+  /// 封面）。整条流水线里唯一会因为「这本是子篇」而发生的写入，且只写合集那一行。
+  ///
+  /// 三条不变量：
+  /// * **不覆盖已有合集封面**——用户手动刮过的合集（`applyCollectionScrape`）或
+  ///   上一集已改投过的，自动路径一律让路；
+  /// * **一合集一次**（[_collectionCoverAttempted]）——26 集番不该发 26 次海报下
+  ///   载；失败也记，避免整季逐集重试同一个打不通的 CDN；
+  /// * **失败不升级**——本轮 outcome 已是 `ScrapeSkippedProtected`（说的是成员封
+  ///   面），合集封面下载失败不该把它翻成 `ScrapeFailed` 误导 UI，只记日志。
+  Future<void> _promoteCollectionCover(
+    int collectionId,
+    ScrapeCandidate candidate,
+  ) async {
+    if (candidate.posterUrl.isEmpty) return;
+    if (!_collectionCoverAttempted.add(collectionId)) return;
+    try {
+      final MediaCollectionRow? row =
+          await _repo.getMediaCollectionById(collectionId);
+      if (row == null) return;
+      final String? existing = row.coverPath;
+      if (existing != null && existing.isNotEmpty) return;
+      final String coverPath = await downloadCollectionCover(
+        collectionId: collectionId,
+        candidate: candidate,
+      );
+      await _repo.updateMediaCollectionCoverPath(collectionId, coverPath);
+    } catch (e, stack) {
+      ErrorLogService.instance
+          .log('CoverScraperService.promoteCollectionCover', e, stack);
+    }
   }
 
   // ── 公开：手动匹配（UI 弹窗用）─────────────────────────────────

--- a/hibiki/lib/src/media/video/scraper/member_cover_cleanup.dart
+++ b/hibiki/lib/src/media/video/scraper/member_cover_cleanup.dart
@@ -1,0 +1,191 @@
+/// 存量子篇作品海报清理（BUG-1393 ③；用户 2026-08-02 的第三段：闸住新的还不够，
+/// 已经被刷上竖版海报的子篇不回退，用户开 app 看到的还是坏的）。
+///
+/// 判据（[planMemberCoverCleanup]）是**无 IO 的纯函数**，落地（[runMemberCoverCleanup]）
+/// 与它分开：这样**误删方向**（多清了别人的）可以被穷举断言——非子篇、单成员合集、用户
+/// 手选/sidecar/来源不明的存量封面、抽帧封面、指向自有目录之外的封面，全部必须
+/// 不出现在计划里。
+///
+/// 安全边界（每一条都是「不该动的绝不动」）：
+/// * **只认 [CoverOrigin.autoScraped]**——它是当前代码里**唯一**由自动刮削写下
+///   作品海报时打的标记。`manual` / `userScraped` / `sidecar` 是用户亲自定的
+///   （BUG-1325 的红线），`scraped` 是来源不明的存量（分不清是自动刮的还是用户
+///   在旧版本弹窗里选的，按 [CoverOverwritePolicy.legacyStrict] 同样保守放过），
+///   `autoFrame` / 无记录本来就是我们想保留的抽帧缩略图。
+/// * **路径只来自被清那一行自己的 `coverPath` 字段**：不枚举目录、不按 uid 猜
+///   文件名——猜出来的路径可能是别人的封面。
+/// * **必须严格落在自有封面目录的第一层**（`p.isWithin` + 直接父目录相等）：目录
+///   外 = 用户自己放的图，`collections/` 子目录 = 合集自有封面，两者都在射程外。
+/// * **不删文件**：只清 DB 列 + `cover_meta.json` 记录，孤儿文件由既有
+///   `VideoStorage.gcOrphanCovers` 回收（它保留全库 `video_books.cover_path`、且
+///   非递归所以 `collections/` 天然免疫）。少一个删除动作就少一整类误删。
+library;
+
+import 'dart:io';
+
+import 'package:hibiki/src/media/media_cover_service.dart';
+import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart'
+    show CoverMeta, CoverOrigin;
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/media/video/video_cover_extractor.dart'
+    show videoCoverFileName;
+import 'package:hibiki/src/media/video/video_storage.dart';
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:hibiki_core/hibiki_core.dart'
+    show MediaCollectionRow, VideoBookRow;
+import 'package:path/path.dart' as p;
+
+/// 一条存量清理动作：把 [bookUid] 这个子篇身上的作品海报摘掉。
+class MemberCoverCleanup {
+  const MemberCoverCleanup({
+    required this.bookUid,
+    required this.collectionId,
+    required this.coverPath,
+    required this.promoteToCollection,
+  });
+
+  /// 要摘掉封面的子篇条目。
+  final String bookUid;
+
+  /// 它所属的多成员合集（海报的正确归宿）。
+  final int collectionId;
+
+  /// 该子篇当前的封面绝对路径（**规范化后**，取自它自己的 `coverPath` 列）。
+  final String coverPath;
+
+  /// 是否把这张海报升格成 [collectionId] 的自有封面。
+  ///
+  /// 合集还没有自有封面时为 true（每个合集只有第一顺位成员升格，其余成员只清
+  /// 自己那一列）——用户要的是「海报归合集」，不是「海报消失」。合集已有自有
+  /// 封面（用户设的或刮过的）时为 false：绝不覆盖。
+  final bool promoteToCollection;
+
+  @override
+  String toString() => 'MemberCoverCleanup($bookUid → collection $collectionId,'
+      ' promote=$promoteToCollection)';
+}
+
+/// 算出存量清理计划。全部入参都是快照，函数本身无 IO、可穷举断言。
+///
+/// * [multiMemberCollectionIdByVideoUid]：子篇 → 所属多成员合集 id
+///   （`multiMemberCollectionIdByVideoUid` 的结果）。
+/// * [coverMetaByUid]：`cover_meta.json` 全量快照（`CoverMetaStore.all()`）。
+/// * [coverPathByUid]：全库视频条目的当前 `coverPath`。
+/// * [collectionsWithOwnCover]：已经有自有封面（`coverPath` 非空）的合集 id。
+/// * [coversDirectoryPath]：成员封面目录（`VideoStorage.coversDir()`）。
+///
+/// 返回按 bookUid 升序的稳定计划（同一合集只有排序最前的成员会 promote）。
+List<MemberCoverCleanup> planMemberCoverCleanup({
+  required Map<String, int> multiMemberCollectionIdByVideoUid,
+  required Map<String, CoverMeta> coverMetaByUid,
+  required Map<String, String?> coverPathByUid,
+  required Set<int> collectionsWithOwnCover,
+  required String coversDirectoryPath,
+}) {
+  final String coversDir = p.normalize(coversDirectoryPath);
+  final Set<int> promoted = <int>{...collectionsWithOwnCover};
+  final List<String> uids = multiMemberCollectionIdByVideoUid.keys.toList()
+    ..sort();
+
+  final List<MemberCoverCleanup> plan = <MemberCoverCleanup>[];
+  for (final String uid in uids) {
+    // ① 只清自动刮削打下的作品海报标记；其余来源（用户的 / 来源不明的存量 /
+    //    抽帧）一律放过。无记录 = 视同 autoFrame，同样放过。
+    if (coverMetaByUid[uid]?.origin != CoverOrigin.autoScraped) continue;
+
+    // ② 路径只来自这一行自己的字段。
+    final String? raw = coverPathByUid[uid];
+    if (raw == null || raw.isEmpty) continue;
+    final String normalized = p.normalize(raw);
+
+    // ③ 必须是自有封面目录**第一层**里的文件：目录外是用户自己的图，
+    //    `collections/` 子目录是合集自有封面，两者都不许碰。
+    if (!p.isWithin(coversDir, normalized)) continue;
+    if (!p.equals(p.dirname(normalized), coversDir)) continue;
+
+    final int collectionId = multiMemberCollectionIdByVideoUid[uid]!;
+    plan.add(MemberCoverCleanup(
+      bookUid: uid,
+      collectionId: collectionId,
+      coverPath: normalized,
+      promoteToCollection: promoted.add(collectionId),
+    ));
+  }
+  return plan;
+}
+
+/// 跑一遍存量清理并落地（判据见 [planMemberCoverCleanup]）。返回清理条数。
+///
+/// 逐条两步：
+/// 1. `promoteToCollection` 的那一条把海报**升格**成合集自有封面（走统一收口
+///    [MediaCoverService.applyCoverFile]：原子 `.tmp`+rename + 双键驱逐）——用户
+///    要的是「作品海报归合集封面」，不是「作品海报消失」；
+/// 2. 清成员 `cover_path` 列 + 删它的 `cover_meta.json` 记录（回落到「无记录 =
+///    autoFrame」，视频页的 `_maybeBackfillCovers` 下一轮会补一张真正的抽帧图）。
+///
+/// 单条失败只记日志继续：判据幂等，下次进页面重跑。
+///
+/// [coversDirectory] / [collectionCoversDirectory] 是测试接缝，默认生产目录。
+Future<int> runMemberCoverCleanup({
+  required VideoBookRepository repo,
+  CoverMetaStore? coverMetaStore,
+  Directory? coversDirectory,
+  Directory? collectionCoversDirectory,
+}) async {
+  final Map<String, int> memberCollectionIds =
+      await repo.multiMemberCollectionIds();
+  if (memberCollectionIds.isEmpty) return 0;
+
+  final Directory covers = coversDirectory ?? await VideoStorage.coversDir();
+  final CoverMetaStore coverMeta = coverMetaStore ?? CoverMetaStore(covers);
+  final List<VideoBookRow> books = await repo.listAll();
+  final List<MediaCollectionRow> collections =
+      await repo.getAllMediaCollections();
+
+  final List<MemberCoverCleanup> plan = planMemberCoverCleanup(
+    multiMemberCollectionIdByVideoUid: memberCollectionIds,
+    coverMetaByUid: await coverMeta.all(),
+    coverPathByUid: <String, String?>{
+      for (final VideoBookRow b in books) b.bookUid: b.coverPath,
+    },
+    collectionsWithOwnCover: <int>{
+      for (final MediaCollectionRow c in collections)
+        if ((c.coverPath ?? '').isNotEmpty) c.id,
+    },
+    coversDirectoryPath: covers.path,
+  );
+  if (plan.isEmpty) return 0;
+
+  final Directory collectionCovers =
+      collectionCoversDirectory ?? await VideoStorage.collectionCoversDir();
+  int cleaned = 0;
+  for (final MemberCoverCleanup action in plan) {
+    try {
+      if (action.promoteToCollection) {
+        final File source = File(action.coverPath);
+        if (await source.exists()) {
+          await collectionCovers.create(recursive: true);
+          final String destPath = p.join(
+            collectionCovers.path,
+            videoCoverFileName('${action.collectionId}'),
+          );
+          await MediaCoverService.applyCoverFile(
+            source: source,
+            destPath: destPath,
+          );
+          await repo.updateMediaCollectionCoverPath(
+            action.collectionId,
+            destPath,
+          );
+        }
+      }
+      await repo.clearCover(action.bookUid);
+      await coverMeta.remove(action.bookUid);
+      cleaned++;
+    } catch (e, stack) {
+      ErrorLogService.instance.log('runMemberCoverCleanup', e, stack);
+    }
+  }
+  return cleaned;
+}

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -10,6 +10,8 @@ import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/media/video/external_video.dart'
     show normalizeVideoPath;
 import 'package:hibiki/src/media/video/m3u8_playlist.dart' show PlaylistEntry;
+import 'package:hibiki/src/media/video/scraper/collection_member_policy.dart'
+    show multiMemberCollectionIdByVideoUid;
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart'
     show ScrapeInfoboxEntry, ScrapeMetadata, ScrapeSource, ScrapeTag;
 import 'package:hibiki/src/media/video/video_path_migration.dart';
@@ -344,6 +346,21 @@ class VideoBookRepository {
   Future<MediaCollectionRow?> getMediaCollectionById(int id) =>
       _db.getMediaCollectionById(id);
 
+  /// 统一合集：全部合集（存量子篇海报清理判「哪些合集已有自有封面」用）。
+  Future<List<MediaCollectionRow>> getAllMediaCollections() =>
+      _db.getAllMediaCollections();
+
+  /// 合集子篇 → 所属多成员合集 id：属于任一**成员数 ≥2** 合集的视频条目。自动
+  /// 刮削据此对子篇**不落作品级海报**、并把海报改落到这个 collectionId 上（判据
+  /// 与理由见 [multiMemberCollectionIdByVideoUid]）。
+  Future<Map<String, int>> multiMemberCollectionIds() async =>
+      multiMemberCollectionIdByVideoUid(await _db.getAllCollectionItems());
+
+  /// 统一合集：写合集**自有**封面绝对路径（`MediaCollections.coverPath`）。
+  /// 作品级竖版海报的唯一归宿（用户 2026-08-02）。
+  Future<void> updateMediaCollectionCoverPath(int id, String? coverPath) =>
+      _db.updateMediaCollectionCoverPath(id, coverPath);
+
   Future<List<VideoBookRow>> listAll() => _db.allVideoBooks();
 
   /// 监听视频库行集合（uid）变化，供库页在任意导入路径（页内 / 拖拽 / 外部
@@ -527,6 +544,9 @@ class VideoBookRepository {
   /// 更新视频封面图绝对路径（书架/视频库长按菜单手动设置封面）。
   Future<void> updateCover(String bookUid, String coverPath) =>
       _db.updateVideoBookCover(bookUid, coverPath);
+
+  /// 清空视频封面图路径（存量子篇作品海报摘除，见 `member_cover_cleanup.dart`）。
+  Future<void> clearCover(String bookUid) => _db.clearVideoBookCover(bookUid);
 
   /// 更新视频/播放列表标题（视频库长按菜单「重命名」）。
   Future<void> updateTitle(String bookUid, String title) =>

--- a/hibiki/lib/src/media/video/video_cover_extractor.dart
+++ b/hibiki/lib/src/media/video/video_cover_extractor.dart
@@ -15,15 +15,20 @@
 ///   2. ffmpeg 抽帧（默认 10s 避开黑场片头；播放列表遍历到首个可用集）；
 ///   3. 远端缩略图 URL 下载（流媒体书，如 YouTube hqdefault）。
 ///
-/// 与 `MediaCoverService` 的分工：本文件是**导入期首写**（目标路径通常尚无
-/// 解码缓存，且 ffmpeg 直接以目标路径为输出，写盘方是子进程），属于
-/// `media_cover_write_guard_test.dart` 的记录在案豁免；导入后的**换图/覆盖写**
-/// （手动设封面、刮削、sidecar）一律走 `MediaCoverService.applyCoverFile` /
-/// `applyCoverBytes` 收口（内含双键驱逐）。
+/// 与 `MediaCoverService` 的分工：本文件的 **ffmpeg 两条路**（内嵌封面 / 抽帧）
+/// 是导入期首写——写盘方是 ffmpeg 子进程、直接以目标路径为输出，Dart 侧无字节可
+/// 交给收口，属于 `media_cover_write_guard_test.dart` 的记录在案豁免。**Dart 侧
+/// 有字节的路（[downloadVideoCoverToPath]）不在豁免内**，一律走
+/// `MediaCoverService.applyCoverBytes` 收口（原子落盘 + 双键驱逐）：它被番剧下载
+/// 重放、流媒体换封面、导入弹窗重取三处**覆盖写**复用，按首写豁免裸写就是
+/// BUG-1118。该豁免的边界由守卫**逐函数**钉死，不再是整文件放行（BUG-1394）。
 library;
 
 import 'dart:io';
 
+import 'package:hibiki/src/media/media_cover_service.dart';
+import 'package:hibiki/src/media/metadata/image_download.dart'
+    show looksLikeImageBytes;
 import 'package:hibiki/src/media/video/ffmpeg_backend.dart';
 import 'package:hibiki/src/storage/app_paths.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart'
@@ -136,8 +141,16 @@ String videoCoverFileName(String bookUid) {
 /// TODO-1281：把**远端封面 URL**（YouTube 缩略图 `youtubeThumbnailUrl` 等）下载到
 /// [outputPath]（调用方用 [videoCoverFileName] + [AppPaths.videoCoversDirectory] 拼出
 /// 与 [extractVideoCover] 同目录同命名，书架显示逻辑复用），成功返回 [outputPath]，否则
-/// 返回 null（下载失败 / 非 2xx / 空体 / 非法 URL）——**best-effort**，绝不抛：导入仍成功，
-/// 书架显示占位。流媒体书 videoPath 是 URL、ffmpeg 抽帧不适用，故封面走缩略图 URL 下载。
+/// 返回 null（下载失败 / 非 2xx / 空体 / 非图片 / 非法 URL）——**best-effort**，绝不抛：
+/// 导入仍成功，书架显示占位。流媒体书 videoPath 是 URL、ffmpeg 抽帧不适用，故封面走
+/// 缩略图 URL 下载。
+///
+/// **落盘走统一收口 [MediaCoverService.applyCoverBytes]**（原子 `.tmp`+rename、失败
+/// 不动旧封面、成功后双键驱逐解码缓存），响应体先过 [looksLikeImageBytes] 魔数/
+/// Content-Type 校验。本函数虽然住在「导入期首写产线」文件里，实际是被**三个覆盖写
+/// 场景**复用的通用下载器（番剧下载重放 `reuseExistingPaths` 覆盖同名文件、流媒体
+/// 换封面、导入弹窗重取缩略图）；旧实现的裸 `writeAsBytes` 继承了首写豁免却跑在覆盖
+/// 路径上，同路径重下后 UI 命中旧解码缓存 = 显示旧图，正是 BUG-1118 的形状。
 ///
 /// [httpClient] 仅供测试注入（默认自建、用完关闭）；把「下载 IO」与「目录解析」分离，让
 /// 本函数无需 path_provider 即可单测（调用方负责解析 [outputPath]）。
@@ -153,9 +166,16 @@ Future<String?> downloadVideoCoverToPath({
     final http.Response res = await client.get(uri);
     if (res.statusCode < 200 || res.statusCode >= 300) return null;
     if (res.bodyBytes.isEmpty) return null;
-    final File output = File(outputPath);
-    await output.parent.create(recursive: true);
-    await output.writeAsBytes(res.bodyBytes, flush: true);
+    // 非图片（错误页 HTML / 占位文本）不落盘：零字节封面与「一张 404 页面」在书架
+    // 上同样是坏图，但后者还会顶掉本来能抽出来的帧。
+    if (!looksLikeImageBytes(res.bodyBytes, res.headers['content-type'])) {
+      return null;
+    }
+    await File(outputPath).parent.create(recursive: true);
+    await MediaCoverService.applyCoverBytes(
+      bytes: res.bodyBytes,
+      destPath: outputPath,
+    );
     return outputPath;
   } catch (_) {
     return null;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1132
+version: 1.3.1+1133
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/media_cover_write_guard_test.dart
+++ b/hibiki/test/media/media_cover_write_guard_test.dart
@@ -13,9 +13,19 @@
 // 豁免（记录在案）：
 // - media_cover_service.dart：收口自身。
 // - media/video/video_cover_extractor.dart：导入期首写产线（ffmpeg 子进程直写
-//   目标路径 / 流媒体缩略图下载），目标路径此前无解码缓存，见其库注释。
+//   目标路径），Dart 侧无字节可交给收口，见其库注释。
 // - lib/src/sync/**：互联层远端封面（remote_cover_image / remote_cover_cache，
 //   协议字段 coverUrl 冻结）是网络缓存，本轮不收编（见 MediaCoverService 类注释）。
+//
+// ③（BUG-1394 补的覆盖洞）**豁免是逐函数的，不是整文件的**。②/① 都是「同一个
+//    文件里同时出现派生 + 裸写」才报，于是「派生点与写盘点跨文件」两边都逃：
+//    anime_download_importer.dart 派生了 videoCoverFileName 目的地但自己不写盘
+//    （→ ② 的 rawWrite 不命中直接放行），真正的裸 writeAsBytes 在被整文件豁免的
+//    video_cover_extractor.dart 里（→ ② 的白名单直接 continue）。结果是给「导入
+//    期首写」开的豁免被三个**覆盖写**调用点（番剧下载重放、流媒体换封面、导入
+//    弹窗重取）复用，同路径重下后 UI 命中旧解码缓存 = 显示旧图，守卫全绿。
+//    这条把豁免收成「白名单文件里**哪些函数**可以裸写」的显式清单：新增裸写函数
+//    或把已收口的函数改回裸写都会红。
 
 import 'dart:io';
 
@@ -69,7 +79,8 @@ void main() {
     const Set<String> allowed = <String>{
       // 收口自身。
       'lib/src/media/media_cover_service.dart',
-      // 导入期首写产线（ffmpeg 直写 / 缩略图下载），见其库注释。
+      // 导入期首写产线（ffmpeg 子进程直写目标路径），见其库注释。缩略图下载路
+      // 已收口，本条豁免的实际边界由下面第 ③ 条逐函数钉死（BUG-1394）。
       'lib/src/media/video/video_cover_extractor.dart',
     };
     final List<String> offenders = <String>[];
@@ -88,6 +99,49 @@ void main() {
         reason: '这些文件推导了封面目的地路径且有原始写盘调用，但没有经 '
             'MediaCoverService.applyCoverFile/applyCoverBytes 收口（BUG-1118 '
             '的「落盘后忘 evict」正是这么回归的）：\n${offenders.join('\n')}');
+  });
+
+  test('白名单文件的裸写豁免逐函数登记（跨文件派生+写盘的覆盖洞，BUG-1394）', () {
+    // 白名单文件里**允许**裸写封面的函数全名单。空 = 该文件已无裸写。
+    // 新增裸写函数、或把已收口的函数改回裸 writeAsBytes，都会让本用例红。
+    const Map<String, Set<String>> allowedRawWriters = <String, Set<String>>{
+      // 收口自身：两个入口的 .tmp 写 + rename 就是收口实现本体。
+      'lib/src/media/media_cover_service.dart': <String>{
+        'applyCoverFile',
+        'applyCoverBytes',
+      },
+      // ffmpeg 两条路由子进程写盘，Dart 侧无字节；下载路已改走
+      // MediaCoverService.applyCoverBytes，故本文件不该再有任何裸写。
+      'lib/src/media/video/video_cover_extractor.dart': <String>{},
+    };
+    final RegExp rawWrite =
+        RegExp(r'writeAsBytes\(|\.copy\(|\.rename\(|openWrite\(');
+    final RegExp lineComment = RegExp(r'//.*$');
+    // 顶层声明 / 类成员声明的行首标识（`static Future<void> applyCoverBytes({`、
+    // `Future<String?> downloadVideoCoverToPath({` 等）：缩进 ≤2 且缩进之后**立刻**
+    // 是标识符，取 `(` / `{` 前的最后一个标识符为函数名。缩进阈值把函数体里的
+    // `if (...) {` / `} catch (_) {` 这类控制流挡在外面（它们缩进 ≥4，且行首不是
+    // 「类型 空格 名字」的形状）。
+    final RegExp declaration =
+        RegExp(r'^ {0,2}(?:static )?(?:[\w<>?,]+ )+(\w+)\s*[({]');
+
+    allowedRawWriters.forEach((String path, Set<String> allowed) {
+      final List<String> lines = File(path).readAsLinesSync();
+      final Set<String> found = <String>{};
+      String current = '<file-scope>';
+      for (final String line in lines) {
+        final RegExpMatch? decl = declaration.firstMatch(line);
+        if (decl != null) current = decl.group(1)!;
+        if (rawWrite.hasMatch(line.replaceAll(lineComment, ''))) {
+          found.add(current);
+        }
+      }
+      expect(found, allowed,
+          reason: '$path 里的裸写封面函数与登记名单不符。豁免是逐函数的：'
+              '「导入期首写」的理由只对 ffmpeg 子进程写盘成立，Dart 侧有字节的路'
+              '（被覆盖写场景跨文件复用）必须走 MediaCoverService.applyCoverBytes。\n'
+              '实际=$found 登记=$allowed');
+    });
   });
 
   test('收口方法本体存在且包含「写盘→驱逐」结构', () {

--- a/hibiki/test/media/video/scraper/collection_member_cover_gate_test.dart
+++ b/hibiki/test/media/video/scraper/collection_member_cover_gate_test.dart
@@ -1,0 +1,234 @@
+/// 合集子篇封面闸 + 海报改投合集（BUG-1393 ①）。
+///
+/// 用户 2026-08-02：「子篇封面禁用作品级竖版海报：**作品海报只归合集封面**，成员
+/// 条目保持抽帧/集级剧照，宁可无封面不凑数」。关键在「归合集封面」——只闸不改投
+/// 会让多集合集卡从显示海报退化成显示首集抽帧，与用户口径相悖。
+///
+/// 覆盖：① 子篇不落成员封面**且**海报落到合集 coverPath；② 一合集只下一次海报；
+/// ③ 合集已有自有封面时不覆盖；④ 单片 / 单成员合集照旧落成员海报；⑤ 用户手动
+/// 匹配对子篇永远放行。
+library;
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/alias_cache.dart';
+import 'package:hibiki/src/media/video/scraper/bangumi_client.dart';
+import 'package:hibiki/src/media/video/scraper/cover_downloader.dart';
+import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
+import 'package:hibiki/src/media/video/scraper/cover_scraper_service.dart';
+import 'package:hibiki/src/media/video/scraper/offline_index.dart';
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/media/video/video_cover_extractor.dart'
+    show videoCoverFileName;
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:path/path.dart' as p;
+
+/// 最小合法 PNG 魔数字节。
+const List<int> _fakePng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x01, 0x02, 0x03,
+];
+
+void main() {
+  // 刮削落盘点走 evictLocalCoverCache（需要 PaintingBinding）。
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late HibikiDatabase db;
+  late VideoBookRepository repo;
+  late Directory tmp;
+  late Directory collectionCovers;
+  late CoverMetaStore coverMeta;
+  late AliasCache aliasCache;
+  late int posterDownloads;
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    repo = VideoBookRepository(db);
+    tmp = await Directory.systemTemp.createTemp('member_cover_gate_');
+    collectionCovers = Directory(p.join(tmp.path, 'collections'));
+    await collectionCovers.create(recursive: true);
+    coverMeta = CoverMetaStore(tmp);
+    aliasCache = AliasCache(tmp);
+    posterDownloads = 0;
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  Future<VideoBookRow> seed({
+    required String bookUid,
+    required String videoPath,
+  }) async {
+    await db.upsertVideoBook(VideoBooksCompanion(
+      bookUid: Value(bookUid),
+      title: Value(bookUid),
+      videoPath: Value(videoPath),
+    ));
+    return (await db.getVideoBookByBookUid(bookUid))!;
+  }
+
+  /// 「进击的巨人」离线库唯一精确命中记录（打分恒 high）。
+  OfflineIndex offline() => OfflineIndex(const <OfflineAnimeRecord>[
+        OfflineAnimeRecord(
+          title: '进击的巨人',
+          synonyms: <String>['Attack on Titan'],
+          type: ScrapeEntryType.tv,
+          episodes: 25,
+          year: 2013,
+          picture: 'https://img/aot.png',
+          sourceId: 'myanimelist.net/anime/16498',
+        ),
+      ]);
+
+  CoverScraperService build() => CoverScraperService(
+        repository: repo,
+        coverMetaStore: coverMeta,
+        aliasCache: aliasCache,
+        bangumiClient: BangumiClient(
+          client: MockClient(
+            (http.Request req) async => http.Response(
+              '{"data":[]}',
+              200,
+              headers: const <String, String>{
+                'content-type': 'application/json',
+              },
+            ),
+          ),
+        ),
+        coverDownloader: CoverDownloader(
+          client: MockClient((http.Request req) async {
+            posterDownloads++;
+            return http.Response.bytes(
+              _fakePng,
+              200,
+              headers: const <String, String>{'content-type': 'image/png'},
+            );
+          }),
+        ),
+        offlineIndex: offline(),
+        enableSidecar: false,
+        coversDirectory: tmp,
+        collectionCoversDirectory: collectionCovers,
+      );
+
+  Future<int> seedSeries(String name) async {
+    await seed(
+      bookUid: 'video/ep1',
+      videoPath: p.join('anime', name, '$name - 01.mkv'),
+    );
+    await seed(
+      bookUid: 'video/ep2',
+      videoPath: p.join('anime', name, '$name - 02.mkv'),
+    );
+    final int cid =
+        await db.createMediaCollection(name, collectionType: 'playlist');
+    await db.addToCollection(cid, MediaKind.video, 'video/ep1');
+    await db.addToCollection(cid, MediaKind.video, 'video/ep2');
+    return cid;
+  }
+
+  Future<List<VideoBookRow>> rows(List<String> uids) async => <VideoBookRow>[
+        for (final String uid in uids) (await db.getVideoBookByBookUid(uid))!,
+      ];
+
+  test('多集合集：成员不落海报，海报改落合集 coverPath；一合集只下一次', () async {
+    final int cid = await seedSeries('进击的巨人');
+
+    final List<BatchScrapeProgress> progress = await build()
+        .scrapeLibrary(await rows(<String>['video/ep1', 'video/ep2']))
+        .toList();
+
+    for (final BatchScrapeProgress pr in progress) {
+      expect(pr.outcome, isA<ScrapeSkippedProtected>(),
+          reason: '子篇成员封面被闸住，走「只刮资料」路径');
+    }
+    for (final String uid in <String>['video/ep1', 'video/ep2']) {
+      final VideoBookRow row = (await db.getVideoBookByBookUid(uid))!;
+      expect(row.coverPath, isNull, reason: '子篇条目不落作品海报');
+      expect(await coverMeta.get(uid), isNull,
+          reason: '自动路径跳过时不得篡改/新增 cover_meta');
+      expect(await repo.scrapeMetadata(uid), isNotNull,
+          reason: '条目资料（简介/评分等）照刮不受影响');
+    }
+
+    // ⚠️ 本轮的核心断言：海报**没有被丢弃**，而是落到了合集自有封面。
+    final String expected =
+        p.join(collectionCovers.path, videoCoverFileName('$cid'));
+    expect((await db.getMediaCollectionById(cid))!.coverPath, expected,
+        reason: '用户口径是「作品海报只归合集封面」，不是「作品海报消失」');
+    expect(File(expected).existsSync(), isTrue);
+    expect(posterDownloads, 1, reason: '26 集番不该发 26 次海报下载');
+  });
+
+  test('合集已有自有封面：自动路径不覆盖它，也不重下', () async {
+    final int cid = await seedSeries('进击的巨人');
+    final File own = File(p.join(collectionCovers.path, 'user_picked.jpg'));
+    await own.writeAsBytes(<int>[0xFF, 0xD8, 0xFF, 0x42]);
+    await db.updateMediaCollectionCoverPath(cid, own.path);
+
+    await build()
+        .scrapeLibrary(await rows(<String>['video/ep1', 'video/ep2']))
+        .toList();
+
+    expect((await db.getMediaCollectionById(cid))!.coverPath, own.path);
+    expect(own.readAsBytesSync(), <int>[0xFF, 0xD8, 0xFF, 0x42]);
+    expect(posterDownloads, 0, reason: '已有封面就不该出网');
+  });
+
+  test('单片（无合集）照旧自动落成员海报', () async {
+    final VideoBookRow solo = await seed(
+      bookUid: 'video/solo',
+      videoPath: p.join('anime', '进击的巨人', '进击的巨人 - 04.mkv'),
+    );
+    final List<BatchScrapeProgress> progress =
+        await build().scrapeLibrary(<VideoBookRow>[solo]).toList();
+    expect(progress.single.outcome, isA<ScrapeApplied>());
+    final VideoBookRow row = (await db.getVideoBookByBookUid('video/solo'))!;
+    expect(row.coverPath, isNotNull);
+    expect(File(row.coverPath!).existsSync(), isTrue);
+  });
+
+  test('单成员合集视为单片：照旧自动落成员海报，不写合集 coverPath', () async {
+    final VideoBookRow single = await seed(
+      bookUid: 'video/single',
+      videoPath: p.join('anime', '进击的巨人', '进击的巨人 - 05.mkv'),
+    );
+    final int cid =
+        await db.createMediaCollection('单成员', collectionType: 'collection');
+    await db.addToCollection(cid, MediaKind.video, 'video/single');
+
+    final List<BatchScrapeProgress> progress =
+        await build().scrapeLibrary(<VideoBookRow>[single]).toList();
+    expect(progress.single.outcome, isA<ScrapeApplied>());
+    expect(
+        (await db.getVideoBookByBookUid('video/single'))!.coverPath, isNotNull);
+    expect((await db.getMediaCollectionById(cid))!.coverPath, isNull);
+  });
+
+  test('用户手动匹配（applyCandidateToBooks）对子篇永远放行', () async {
+    await seedSeries('进击的巨人');
+
+    await build().applyCandidateToBooks(
+      bookUids: <String>['video/ep1'],
+      candidate: const ScrapeCandidate(
+        source: ScrapeSource.offlineDb,
+        entryId: 'myanimelist.net/anime/16498',
+        title: '进击的巨人',
+        posterUrl: 'https://img/aot.png',
+      ),
+    );
+
+    final VideoBookRow row = (await db.getVideoBookByBookUid('video/ep1'))!;
+    expect(row.coverPath, isNotNull, reason: '用户亲手拍板不经子篇闸');
+    final CoverMeta? meta = await coverMeta.get('video/ep1');
+    expect(meta!.origin, CoverOrigin.userScraped);
+  });
+}

--- a/hibiki/test/media/video/scraper/collection_member_policy_test.dart
+++ b/hibiki/test/media/video/scraper/collection_member_policy_test.dart
@@ -1,0 +1,86 @@
+/// 合集子篇判据（BUG-1393）：谁是子篇、它的作品海报该落到哪个合集。
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/collection_member_policy.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+MediaCollectionItemRow _item(int collectionId, String mediaType, String key) =>
+    MediaCollectionItemRow(
+      collectionId: collectionId,
+      mediaType: mediaType,
+      entryKey: key,
+      sortIndex: 0,
+    );
+
+void main() {
+  group('multiMemberCollectionIdByVideoUid', () {
+    test('成员数 ≥2 合集的视频成员判为子篇并带出 collectionId；单成员合集不判', () {
+      final Map<String, int> uids = multiMemberCollectionIdByVideoUid(
+        <MediaCollectionItemRow>[
+          // 双成员 playlist：两集都是子篇，海报归 collection 1。
+          _item(1, 'video', 'video/ep1'),
+          _item(1, 'video', 'video/ep2'),
+          // 单成员合集：单片，可照旧刮成员海报。
+          _item(2, 'video', 'video/solo'),
+        ],
+      );
+      expect(uids, <String, int>{'video/ep1': 1, 'video/ep2': 1});
+      expect(uids.containsKey('video/solo'), isFalse);
+    });
+
+    test('混编合集按全部成员计数，非 video 成员不进结果', () {
+      final Map<String, int> uids = multiMemberCollectionIdByVideoUid(
+        <MediaCollectionItemRow>[
+          // 视频 + 书混编：合集有 2 个成员，视频成员是子篇；书成员不属视频域。
+          _item(3, 'video', 'video/mixed'),
+          _item(3, 'epub', 'book/one'),
+        ],
+      );
+      expect(uids, <String, int>{'video/mixed': 3});
+    });
+
+    test('空输入 → 空映射', () {
+      expect(
+        multiMemberCollectionIdByVideoUid(const <MediaCollectionItemRow>[]),
+        isEmpty,
+      );
+    });
+
+    test('同条目跨多个多成员合集：取最小 collectionId（与折叠归属同口径）', () {
+      final Map<String, int> uids = multiMemberCollectionIdByVideoUid(
+        <MediaCollectionItemRow>[
+          _item(9, 'video', 'video/both'),
+          _item(9, 'video', 'video/nine'),
+          _item(5, 'video', 'video/both'),
+          _item(5, 'video', 'video/five'),
+        ],
+      );
+      expect(uids['video/both'], 5, reason: '海报该落到库网格里折叠进的那张卡');
+    });
+
+    test('单成员合集不参与取最小：只在多成员合集里挑', () {
+      final Map<String, int> uids = multiMemberCollectionIdByVideoUid(
+        <MediaCollectionItemRow>[
+          _item(4, 'video', 'video/both'), // 单成员合集，id 更小
+          _item(5, 'video', 'video/both'),
+          _item(5, 'video', 'video/other'),
+        ],
+      );
+      expect(uids['video/both'], 5, reason: 'id 4 是单成员合集，不该被选成子篇归属');
+    });
+
+    test('输入序无关', () {
+      final List<MediaCollectionItemRow> items = <MediaCollectionItemRow>[
+        _item(7, 'video', 'video/a'),
+        _item(7, 'video', 'video/b'),
+        _item(8, 'video', 'video/a'),
+        _item(8, 'video', 'video/c'),
+      ];
+      expect(
+        multiMemberCollectionIdByVideoUid(items),
+        multiMemberCollectionIdByVideoUid(items.reversed.toList()),
+      );
+    });
+  });
+}

--- a/hibiki/test/media/video/scraper/member_cover_cleanup_test.dart
+++ b/hibiki/test/media/video/scraper/member_cover_cleanup_test.dart
@@ -1,0 +1,332 @@
+/// 存量子篇作品海报清理（BUG-1393 ③）。
+///
+/// 分两层：
+/// * **判据层**（纯函数 [planMemberCoverCleanup]）——重点是**误删方向**：把「不该
+///   动的」逐条穷举，断言它们一条都不进计划。只验「该清的清了」对「多清了别人的」
+///   完全无感；
+/// * **落地层**（[runMemberCoverCleanup]）——真 DB + 真文件，断言海报升格到合集、
+///   成员那一列被清、非目标行逐字节不变、幂等，以及升格后的合集封面**不会**被既有
+///   `gcOrphanCovers` 当孤儿删掉。
+library;
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/cover_meta_store.dart';
+import 'package:hibiki/src/media/video/scraper/member_cover_cleanup.dart';
+import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:hibiki/src/media/video/video_book_repository.dart';
+import 'package:hibiki/src/media/video/video_cover_extractor.dart'
+    show videoCoverFileName;
+import 'package:hibiki/src/media/video/video_storage.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+const List<int> _jpegBytes = <int>[0xFF, 0xD8, 0xFF, 0x01, 0x02, 0x03];
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // ── 判据层：误删方向穷举 ────────────────────────────────────────
+  group('planMemberCoverCleanup 判据', () {
+    const String covers = r'/data/video_covers';
+
+    List<MemberCoverCleanup> plan({
+      required CoverOrigin? origin,
+      String? coverPath = '$covers/video_ep1.jpg',
+      Map<String, int>? members,
+      Set<int> withOwnCover = const <int>{},
+    }) =>
+        planMemberCoverCleanup(
+          multiMemberCollectionIdByVideoUid:
+              members ?? <String, int>{'video/ep1': 1},
+          coverMetaByUid: <String, CoverMeta>{
+            if (origin != null) 'video/ep1': CoverMeta(origin: origin),
+          },
+          coverPathByUid: <String, String?>{'video/ep1': coverPath},
+          collectionsWithOwnCover: withOwnCover,
+          coversDirectoryPath: covers,
+        );
+
+    test('目标：多成员合集成员 + autoScraped + 封面在自有目录 → 进计划并升格', () {
+      final List<MemberCoverCleanup> result =
+          plan(origin: CoverOrigin.autoScraped);
+      expect(result, hasLength(1));
+      expect(result.single.bookUid, 'video/ep1');
+      expect(result.single.collectionId, 1);
+      expect(result.single.promoteToCollection, isTrue);
+    });
+
+    // ⚠️ 误删方向：以下每一条都是「不该动的」。任何一条漏进计划都意味着用户的
+    //    封面被平白清掉。
+    test('误删方向 · 用户亲自定的封面（manual / userScraped / sidecar）一条都不进计划', () {
+      for (final CoverOrigin origin in <CoverOrigin>[
+        CoverOrigin.manual,
+        CoverOrigin.userScraped,
+        CoverOrigin.sidecar,
+      ]) {
+        expect(plan(origin: origin), isEmpty, reason: '$origin 是用户拍板的，不许碰');
+      }
+    });
+
+    test('误删方向 · 来源不明的存量 scraped 保守放过（分不清是自动刮的还是用户选的）', () {
+      expect(plan(origin: CoverOrigin.scraped), isEmpty);
+    });
+
+    test('误删方向 · 抽帧封面 / 无 cover_meta 记录不进计划（这本来就是想保留的状态）', () {
+      expect(plan(origin: CoverOrigin.autoFrame), isEmpty);
+      expect(plan(origin: null), isEmpty);
+    });
+
+    test('误删方向 · 非子篇（不在多成员合集里）即便 autoScraped 也不进计划', () {
+      expect(
+        plan(origin: CoverOrigin.autoScraped, members: <String, int>{}),
+        isEmpty,
+      );
+    });
+
+    test('误删方向 · 封面路径为空 / null 不进计划', () {
+      expect(plan(origin: CoverOrigin.autoScraped, coverPath: null), isEmpty);
+      expect(plan(origin: CoverOrigin.autoScraped, coverPath: ''), isEmpty);
+    });
+
+    test('误删方向 · 封面在自有目录之外（用户自己放的图）不进计划', () {
+      expect(
+        plan(
+          origin: CoverOrigin.autoScraped,
+          coverPath: r'/home/me/pictures/my_own.jpg',
+        ),
+        isEmpty,
+      );
+      // 路径遍历也必须挡住：规范化后逃出自有目录。
+      expect(
+        plan(
+          origin: CoverOrigin.autoScraped,
+          coverPath: '$covers/../elsewhere/x.jpg',
+        ),
+        isEmpty,
+      );
+    });
+
+    test('误删方向 · collections/ 子目录（合集自有封面）不在射程内', () {
+      expect(
+        plan(
+          origin: CoverOrigin.autoScraped,
+          coverPath: '$covers/collections/1.jpg',
+        ),
+        isEmpty,
+        reason: '合集自有封面正是海报该待的地方，绝不能被当成成员海报摘掉',
+      );
+    });
+
+    test('合集已有自有封面：成员仍清，但不覆盖合集那张（promote=false）', () {
+      final List<MemberCoverCleanup> result = plan(
+        origin: CoverOrigin.autoScraped,
+        withOwnCover: <int>{1},
+      );
+      expect(result, hasLength(1));
+      expect(result.single.promoteToCollection, isFalse);
+    });
+
+    test('同一合集多成员：只有排序最前的一个升格，其余只清列', () {
+      final List<MemberCoverCleanup> result = planMemberCoverCleanup(
+        multiMemberCollectionIdByVideoUid: <String, int>{
+          'video/ep2': 1,
+          'video/ep1': 1,
+        },
+        coverMetaByUid: <String, CoverMeta>{
+          'video/ep1': const CoverMeta(origin: CoverOrigin.autoScraped),
+          'video/ep2': const CoverMeta(origin: CoverOrigin.autoScraped),
+        },
+        coverPathByUid: <String, String?>{
+          'video/ep1': '$covers/video_ep1.jpg',
+          'video/ep2': '$covers/video_ep2.jpg',
+        },
+        collectionsWithOwnCover: const <int>{},
+        coversDirectoryPath: covers,
+      );
+      expect(result.map((MemberCoverCleanup a) => a.bookUid).toList(),
+          <String>['video/ep1', 'video/ep2']);
+      expect(result.first.promoteToCollection, isTrue);
+      expect(result.last.promoteToCollection, isFalse);
+    });
+  });
+
+  // ── 落地层：真 DB + 真文件 ──────────────────────────────────────
+  group('runMemberCoverCleanup 落地', () {
+    late HibikiDatabase db;
+    late VideoBookRepository repo;
+    late Directory covers;
+    late Directory collectionCovers;
+    late CoverMetaStore coverMeta;
+
+    Future<void> seedBook(String uid, {String? coverFile}) async {
+      String? coverPath;
+      if (coverFile != null) {
+        final File f = File(p.join(covers.path, coverFile));
+        await f.writeAsBytes(_jpegBytes);
+        coverPath = f.path;
+      }
+      await db.upsertVideoBook(VideoBooksCompanion(
+        bookUid: Value(uid),
+        title: Value(uid),
+        videoPath: Value('D:/v/$uid.mkv'),
+        coverPath: Value(coverPath),
+      ));
+    }
+
+    setUp(() async {
+      db = HibikiDatabase.forTesting(NativeDatabase.memory());
+      repo = VideoBookRepository(db);
+      covers = await Directory.systemTemp.createTemp('member_cleanup_');
+      collectionCovers = Directory(p.join(covers.path, 'collections'));
+      await collectionCovers.create(recursive: true);
+      coverMeta = CoverMetaStore(covers);
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (await covers.exists()) await covers.delete(recursive: true);
+    });
+
+    Future<int> run() => runMemberCoverCleanup(
+          repo: repo,
+          coverMetaStore: coverMeta,
+          coversDirectory: covers,
+          collectionCoversDirectory: collectionCovers,
+        );
+
+    test('海报升格成合集封面、成员那一列被清；非目标行逐字节不变', () async {
+      // A：双成员合集，ep1 顶着自动刮来的作品海报，ep2 是抽帧。
+      await seedBook('video/ep1', coverFile: 'ep1.jpg');
+      await seedBook('video/ep2', coverFile: 'ep2.jpg');
+      await coverMeta.set(
+          'video/ep1', const CoverMeta(origin: CoverOrigin.autoScraped));
+      await coverMeta.set(
+          'video/ep2', const CoverMeta(origin: CoverOrigin.autoFrame));
+      final int a = await db.createMediaCollection('A');
+      await db.addToCollection(a, MediaKind.video, 'video/ep1');
+      await db.addToCollection(a, MediaKind.video, 'video/ep2');
+
+      // B：单成员合集 —— 单片，海报本来就该留在成员上。
+      await seedBook('video/solo', coverFile: 'solo.jpg');
+      await coverMeta.set(
+          'video/solo', const CoverMeta(origin: CoverOrigin.autoScraped));
+      final int b = await db.createMediaCollection('B');
+      await db.addToCollection(b, MediaKind.video, 'video/solo');
+
+      // C：不属任何合集的独立条目。
+      await seedBook('video/free', coverFile: 'free.jpg');
+      await coverMeta.set(
+          'video/free', const CoverMeta(origin: CoverOrigin.autoScraped));
+
+      // D：双成员合集，但用户手选过成员封面（userScraped）——永不覆盖。
+      await seedBook('video/mine', coverFile: 'mine.jpg');
+      await seedBook('video/mine2', coverFile: 'mine2.jpg');
+      await coverMeta.set(
+          'video/mine', const CoverMeta(origin: CoverOrigin.userScraped));
+      final int d = await db.createMediaCollection('D');
+      await db.addToCollection(d, MediaKind.video, 'video/mine');
+      await db.addToCollection(d, MediaKind.video, 'video/mine2');
+
+      expect(await run(), 1, reason: '只有 A 的 ep1 该被清');
+
+      // 目标：ep1 摘干净、海报升格到合集 A。
+      final VideoBookRow ep1 = (await db.getVideoBookByBookUid('video/ep1'))!;
+      expect(ep1.coverPath, isNull);
+      expect(await coverMeta.get('video/ep1'), isNull);
+      final String promoted =
+          p.join(collectionCovers.path, videoCoverFileName('$a'));
+      expect((await db.getMediaCollectionById(a))!.coverPath, promoted);
+      expect(File(promoted).readAsBytesSync(), _jpegBytes);
+
+      // 误删方向：其余四本全部原封不动。
+      for (final String uid in <String>[
+        'video/ep2',
+        'video/solo',
+        'video/free',
+        'video/mine',
+        'video/mine2',
+      ]) {
+        final VideoBookRow row = (await db.getVideoBookByBookUid(uid))!;
+        expect(row.coverPath, isNotNull, reason: '$uid 的封面被误清了');
+        expect(File(row.coverPath!).existsSync(), isTrue);
+      }
+      expect((await coverMeta.get('video/ep2'))!.origin, CoverOrigin.autoFrame);
+      expect(
+          (await coverMeta.get('video/solo'))!.origin, CoverOrigin.autoScraped);
+      expect(
+          (await coverMeta.get('video/mine'))!.origin, CoverOrigin.userScraped);
+      expect((await db.getMediaCollectionById(b))!.coverPath, isNull);
+      expect((await db.getMediaCollectionById(d))!.coverPath, isNull);
+    });
+
+    test('合集已有自有封面：不覆盖它，但成员海报照样摘掉', () async {
+      await seedBook('video/e1', coverFile: 'e1.jpg');
+      await seedBook('video/e2', coverFile: 'e2.jpg');
+      await coverMeta.set(
+          'video/e1', const CoverMeta(origin: CoverOrigin.autoScraped));
+      final int cid = await db.createMediaCollection('已刮过');
+      await db.addToCollection(cid, MediaKind.video, 'video/e1');
+      await db.addToCollection(cid, MediaKind.video, 'video/e2');
+      final File own = File(p.join(collectionCovers.path, 'own.jpg'));
+      await own.writeAsBytes(<int>[0x89, 0x50, 0x4E, 0x47]);
+      await db.updateMediaCollectionCoverPath(cid, own.path);
+
+      expect(await run(), 1);
+      expect((await db.getMediaCollectionById(cid))!.coverPath, own.path,
+          reason: '合集已有的自有封面（用户刮的）不许被存量清理顶掉');
+      expect(own.readAsBytesSync(), <int>[0x89, 0x50, 0x4E, 0x47]);
+      expect((await db.getVideoBookByBookUid('video/e1'))!.coverPath, isNull);
+    });
+
+    test('幂等：第二轮 0 条，且不再改动任何行', () async {
+      await seedBook('video/a1', coverFile: 'a1.jpg');
+      await seedBook('video/a2', coverFile: 'a2.jpg');
+      await coverMeta.set(
+          'video/a1', const CoverMeta(origin: CoverOrigin.autoScraped));
+      final int cid = await db.createMediaCollection('A');
+      await db.addToCollection(cid, MediaKind.video, 'video/a1');
+      await db.addToCollection(cid, MediaKind.video, 'video/a2');
+
+      expect(await run(), 1);
+      final String? after = (await db.getMediaCollectionById(cid))!.coverPath;
+      expect(await run(), 0);
+      expect((await db.getMediaCollectionById(cid))!.coverPath, after);
+      expect(
+          (await db.getVideoBookByBookUid('video/a2'))!.coverPath, isNotNull);
+    });
+
+    test('误删方向 · 升格后的合集封面不会被既有 gcOrphanCovers 当孤儿删掉', () async {
+      await seedBook('video/g1', coverFile: 'g1.jpg');
+      await seedBook('video/g2', coverFile: 'g2.jpg');
+      await coverMeta.set(
+          'video/g1', const CoverMeta(origin: CoverOrigin.autoScraped));
+      final int cid = await db.createMediaCollection('G');
+      await db.addToCollection(cid, MediaKind.video, 'video/g1');
+      await db.addToCollection(cid, MediaKind.video, 'video/g2');
+      await run();
+
+      final String promoted =
+          (await db.getMediaCollectionById(cid))!.coverPath!;
+      // GC 的保留集只含全库 video_books.cover_path（清完 g1 后就剩 g2）。
+      await VideoStorage.gcOrphanCovers(
+        referencedCoverPaths: <String>[
+          for (final VideoBookRow r in await db.allVideoBooks())
+            if (r.coverPath != null) r.coverPath!,
+        ],
+        coversDirectory: covers,
+      );
+      expect(File(promoted).existsSync(), isTrue,
+          reason: 'gcOrphanCovers 非递归，collections/ 子目录必须免疫');
+      expect(
+        File((await db.getVideoBookByBookUid('video/g2'))!.coverPath!)
+            .existsSync(),
+        isTrue,
+        reason: '仍被引用的成员封面不许被 GC 删',
+      );
+    });
+  });
+}

--- a/hibiki/test/media/video/youtube_import_cover_test.dart
+++ b/hibiki/test/media/video/youtube_import_cover_test.dart
@@ -13,11 +13,15 @@ import 'package:path/path.dart' as p;
 /// 覆盖两块可离线单测的纯逻辑 / IO 分支：
 /// - [youtubeThumbnailUrl]：由 videoId 拼 hqdefault 缩略图 URL（导入封面源）；
 /// - [downloadVideoCoverToPath]：把缩略图 URL 下载到指定路径（注入 MockClient，
-///   不碰真网络 / path_provider），断言 2xx 写文件、非 2xx / 空体 / 非法 URL 返回 null。
+///   不碰真网络 / path_provider），断言 2xx 写文件、非 2xx / 空体 / 非图片 / 非法 URL
+///   返回 null，以及**覆盖写走统一收口**（原子 `.tmp`+rename，BUG-1394）。
 ///
 /// 真实标题抓取（[resolveYoutubeMetadata]）依赖 youtube_explode + 真网络，属外部系统
 /// 契约（守卫见 youtube_resolver_impl_symbols_test.dart），此处不联网测。
 void main() {
+  // 落盘走 MediaCoverService.applyCoverBytes → evictLocalCoverCache（需 PaintingBinding）。
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   group('youtubeThumbnailUrl', () {
     test('builds hqdefault url from video id', () {
       expect(
@@ -44,7 +48,8 @@ void main() {
     });
 
     test('2xx with bytes writes the file and returns the path', () async {
-      final Uint8List bytes = Uint8List.fromList(<int>[1, 2, 3, 4, 5]);
+      // JPEG 魔数：收口前先过 looksLikeImageBytes（错误页 HTML 不许当封面落盘）。
+      final Uint8List bytes = Uint8List.fromList(<int>[0xFF, 0xD8, 0xFF, 4, 5]);
       final MockClient client = MockClient((http.Request req) async {
         expect(req.url.host, 'i.ytimg.com');
         return http.Response.bytes(bytes, 200);
@@ -58,6 +63,68 @@ void main() {
       expect(result, outputPath);
       expect(File(outputPath).existsSync(), isTrue);
       expect(File(outputPath).readAsBytesSync(), bytes);
+      expect(File('$outputPath.tmp').existsSync(), isFalse,
+          reason: '收口的原子写不该留 .tmp');
+    });
+
+    test('content-type image/* 即便字节非图片魔数也放行（服务端权威）', () async {
+      final Uint8List bytes = Uint8List.fromList(<int>[1, 2, 3, 4, 5]);
+      final MockClient client = MockClient(
+        (http.Request req) async => http.Response.bytes(
+          bytes,
+          200,
+          headers: const <String, String>{'content-type': 'image/jpeg'},
+        ),
+      );
+      final String outputPath = p.join(tmp.path, 'cover.jpg');
+      expect(
+        await downloadVideoCoverToPath(
+          coverUrl: youtubeThumbnailUrl('vid123'),
+          outputPath: outputPath,
+          httpClient: client,
+        ),
+        outputPath,
+      );
+    });
+
+    test('非图片响应（错误页 HTML）返回 null 且不落盘', () async {
+      final MockClient client = MockClient(
+        (http.Request req) async => http.Response(
+          '<html>404 not found</html>',
+          200,
+          headers: const <String, String>{'content-type': 'text/html'},
+        ),
+      );
+      final String outputPath = p.join(tmp.path, 'cover.jpg');
+      expect(
+        await downloadVideoCoverToPath(
+          coverUrl: youtubeThumbnailUrl('vid123'),
+          outputPath: outputPath,
+          httpClient: client,
+        ),
+        isNull,
+      );
+      expect(File(outputPath).existsSync(), isFalse);
+    });
+
+    test('覆盖写同名文件：内容真被换掉、不留 .tmp（BUG-1118 形状）', () async {
+      final String outputPath = p.join(tmp.path, 'cover.jpg');
+      await File(outputPath).writeAsBytes(<int>[0x89, 0x50, 0x4E, 0x47, 0xAA]);
+      final Uint8List fresh =
+          Uint8List.fromList(<int>[0xFF, 0xD8, 0xFF, 0xBE, 0xEF]);
+      final MockClient client = MockClient(
+        (http.Request req) async => http.Response.bytes(fresh, 200),
+      );
+      expect(
+        await downloadVideoCoverToPath(
+          coverUrl: youtubeThumbnailUrl('vid123'),
+          outputPath: outputPath,
+          httpClient: client,
+        ),
+        outputPath,
+      );
+      expect(File(outputPath).readAsBytesSync(), fresh);
+      expect(File('$outputPath.tmp').existsSync(), isFalse);
     });
 
     test('non-2xx returns null and writes nothing', () async {

--- a/hibiki/test/torrent/anime_download_importer_test.dart
+++ b/hibiki/test/torrent/anime_download_importer_test.dart
@@ -1,0 +1,161 @@
+/// 番剧下载入库封面（BUG-1393 / BUG-1394）。
+///
+/// 用户 2026-08-02：作品海报只落合集自有封面，不借道首集条目——多集合集的子篇不得
+/// 顶着作品级竖版海报。同时钉住落盘走统一收口（`MediaCoverService.applyCoverBytes`
+/// 的原子 `.tmp`+rename）：`reuseExistingPaths` 重放会覆盖同名文件，裸 writeAsBytes
+/// 不驱逐解码缓存就是 BUG-1118 的形状。
+library;
+
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/torrent/anime_download_importer.dart';
+import 'package:hibiki/src/media/torrent/anime_download_plan.dart';
+import 'package:hibiki/src/media/torrent/anime_download_service.dart'
+    show AnimeDownloadImportOutcome;
+import 'package:hibiki/src/media/video/video_cover_extractor.dart'
+    show videoCoverFileName;
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:path/path.dart' as p;
+
+/// 最小合法 PNG 魔数字节。
+const List<int> _fakePng = <int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x00, 0x01, 0x02, 0x03,
+];
+
+AnimeDownloadPlan _plan({String? coverUrl}) => AnimeDownloadPlan(
+      id: 'plan-1',
+      createdAtMs: 0,
+      seriesTitle: '某番剧',
+      torrentTitle: '[组] 某番剧 01-02',
+      magnet: 'magnet:?xt=urn:btih:deadbeef',
+      qbCategory: 'hibiki',
+      anilistId: 42,
+      coverUrl: coverUrl,
+    );
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late HibikiDatabase db;
+  late Directory tmp;
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    tmp = await Directory.systemTemp.createTemp('anime_dl_importer_');
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (await tmp.exists()) await tmp.delete(recursive: true);
+  });
+
+  Future<AnimeDownloadImportOutcome?> Function(
+    AnimeDownloadPlan,
+    List<String>,
+  ) importer({List<int> bytes = _fakePng}) => buildAnimeDownloadImporter(
+        db,
+        httpClient: MockClient(
+          (http.Request req) async => http.Response.bytes(
+            bytes,
+            200,
+            headers: const <String, String>{'content-type': 'image/png'},
+          ),
+        ),
+        collectionCoversDirectory: tmp,
+      );
+
+  test('作品海报落合集自有封面 coverPath，成员条目一张海报都不沾', () async {
+    final AnimeDownloadImportOutcome? outcome = await importer()(
+      _plan(coverUrl: 'https://img.anili.st/poster.jpg'),
+      <String>[
+        p.join('D:', 'dl', '某番剧 - 01.mkv'),
+        p.join('D:', 'dl', '某番剧 - 02.mkv'),
+      ],
+    );
+
+    expect(outcome, isNotNull);
+    final MediaCollectionRow col =
+        (await db.getMediaCollectionById(outcome!.collectionId))!;
+    final String expectedCover =
+        p.join(tmp.path, videoCoverFileName('${outcome.collectionId}'));
+    expect(col.coverPath, expectedCover, reason: '海报直落合集自有封面列');
+    expect(File(expectedCover).readAsBytesSync(), _fakePng);
+
+    // 成员条目（含首集）不落作品海报——测试环境抽帧不可用，封面应保持 null，
+    // 而绝不是那张下载成功了的海报。
+    final List<MediaCollectionItemRow> items =
+        await db.getCollectionItems(outcome.collectionId);
+    expect(items, hasLength(2));
+    for (final MediaCollectionItemRow item in items) {
+      final VideoBookRow book =
+          (await db.getVideoBookByBookUid(item.entryKey))!;
+      expect(book.coverPath, isNull, reason: '子篇条目封面只能是抽帧/剧照，绝不是作品海报');
+    }
+
+    // AniList 绑定照旧。
+    expect(col.anilistId, 42);
+  });
+
+  test('无海报 URL：合集 coverPath 保持空，不误写', () async {
+    final AnimeDownloadImportOutcome? outcome = await importer()(
+      _plan(),
+      <String>[p.join('D:', 'dl', '某番剧 - 01.mkv')],
+    );
+
+    expect(outcome, isNotNull);
+    expect((await db.getMediaCollectionById(outcome!.collectionId))!.coverPath,
+        isNull);
+  });
+
+  test('重放导入覆盖同名合集封面：内容真被换掉（收口的原子写，非裸 writeAsBytes）', () async {
+    const List<int> jpeg = <int>[0xFF, 0xD8, 0xFF, 0xAA, 0xBB];
+    final AnimeDownloadImportOutcome? first = await importer()(
+      _plan(coverUrl: 'https://img.anili.st/poster.jpg'),
+      <String>[p.join('D:', 'dl', '某番剧 - 01.mkv')],
+    );
+    final String dest =
+        p.join(tmp.path, videoCoverFileName('${first!.collectionId}'));
+    expect(File(dest).readAsBytesSync(), _fakePng);
+
+    // reuseExistingPaths 让重放复用同一合集 → 同一目标文件名。
+    final AnimeDownloadImportOutcome? second = await importer(bytes: jpeg)(
+      _plan(coverUrl: 'https://img.anili.st/poster.jpg'),
+      <String>[p.join('D:', 'dl', '某番剧 - 01.mkv')],
+    );
+    expect(second!.collectionId, first.collectionId);
+    expect(File(dest).readAsBytesSync(), jpeg);
+    expect(File('$dest.tmp').existsSync(), isFalse, reason: '收口写不留 .tmp');
+  });
+
+  test('响应不是图片（错误页 HTML）：不落盘、合集 coverPath 保持空', () async {
+    final AnimeDownloadImportOutcome? outcome =
+        await buildAnimeDownloadImporter(
+      db,
+      httpClient: MockClient(
+        (http.Request req) async => http.Response(
+          '<html>404</html>',
+          200,
+          headers: const <String, String>{'content-type': 'text/html'},
+        ),
+      ),
+      collectionCoversDirectory: tmp,
+    )(
+      _plan(coverUrl: 'https://img.anili.st/poster.jpg'),
+      <String>[p.join('D:', 'dl', '某番剧 - 01.mkv')],
+    );
+
+    expect(outcome, isNotNull);
+    expect((await db.getMediaCollectionById(outcome!.collectionId))!.coverPath,
+        isNull);
+    expect(
+      File(p.join(tmp.path, videoCoverFileName('${outcome.collectionId}')))
+          .existsSync(),
+      isFalse,
+    );
+  });
+}

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -2839,6 +2839,15 @@ class HibikiDatabase extends _$HibikiDatabase {
       (update(videoBooks)..where((t) => t.bookUid.equals(bookUid)))
           .write(VideoBooksCompanion(coverPath: Value(coverPath)));
 
+  /// 清空视频封面图路径（回落到「无封面」占位）。
+  ///
+  /// 与 [updateVideoBookCover] 分开而不是给它塞 null：清空是**独立动作**（存量
+  /// 子篇作品海报摘除，见 `member_cover_cleanup.dart`），可空参数会让「忘了传」
+  /// 和「有意清空」在类型上无法区分。
+  Future<void> clearVideoBookCover(String bookUid) =>
+      (update(videoBooks)..where((t) => t.bookUid.equals(bookUid)))
+          .write(const VideoBooksCompanion(coverPath: Value<String?>(null)));
+
   /// 更新视频/播放列表标题（用户在视频库长按菜单「重命名」）。title 列已存在，
   /// 无 schema 变更。
   Future<void> updateVideoBookTitle(String bookUid, String title) =>


### PR DESCRIPTION
**接管 PR#677 复核退回的三条必改**（看板 TODO-2554，源需求 TODO-2549）。
原 PR#677 的 job 停摆无人认领，本 PR 基于**当前 `origin/develop`**（`0bb1647ef`）重做，
不在 `todo-member-cover-fix` 分支上追加任何 commit。**PR#677 仍 OPEN，由原作者决定合并或放弃**
（若本 PR 先合，#677 会全量冲突，建议届时由原作者关闭）。

## 用户验收口径（逐字）
> 子篇封面禁用作品级竖版海报：**作品海报只归合集封面**，成员条目保持抽帧/集级剧照，
> 宁可无封面不凑数（含下载导入海报改落合集 coverPath）

关键在「**作品海报只归合集封面**」——海报要**改投**，不是**消失**。

## 三条必改怎么修的

### ① 自动刮削路径上作品海报被整个丢弃（用户可见回退）· BUG-1393
只加闸不改投的话，`updateMediaCollectionCoverPath` 全仓只剩两个调用方（手动弹窗、番剧下载导入），
**扫描/自动刮削的多集合集海报既不落成员也不落合集** → 合集卡从「显示海报」退化成「显示首集抽帧」
（渲染回退链 `home_video_page.dart:3487` 的 `coverPath` 优先 → 借成员）。这与用户口径直接相悖。

- `collection_member_policy.dart`（新）判据返回 **`子篇 uid → 最小多成员 collectionId` 的 Map**，
  而不是 Set/bool——闸住成员封面只做对一半，海报还得有地方去；bool 会把归属信息扔掉，逼调用方再查一次库。
- `scrapeLibrary`：子篇一律不落成员封面（任何开关解不开），并**复用同一次匹配的决策**调
  `_promoteCollectionCover` 把海报下到 `collections/<id>.jpg` + 写 `MediaCollections.coverPath`。
  一合集一次（26 集番不发 26 次下载）、不覆盖已有合集封面、失败只记日志不把 outcome 翻成 `ScrapeFailed`。
  `_scrapeMetadataOnly` 改为返回 `MatchDecision?`，不重发搜索。
- `anime_download_importer`：AniList 作品海报直落合集 `coverPath`，首集只留抽帧 + `coverSource` 借用链兜底。

`CoverScraperService` 仍**不持有 `HibikiDatabase`**（类顶注的约束）：新查询/写入都经 `VideoBookRepository` 门面。

### ② 新落盘绕过 BUG-1118 收口 + 守卫覆盖洞 · BUG-1394
`downloadVideoCoverToPath` 是**裸 `writeAsBytes`**（不 evict 双键解码缓存、不原子写、不校验魔数），
却被**三个覆盖写场景**复用：番剧下载重放（`reuseExistingPaths:true` 覆盖同名文件）、流媒体换封面、
导入弹窗重取。同路径重下后 UI 命中旧解码缓存 = 用户看到旧图。

- 改走 `MediaCoverService.applyCoverBytes`（原子 `.tmp`+rename + 双键驱逐）+ 落盘前过 `looksLikeImageBytes`
  （复用 `image_download.dart` 里已有的公共判据，不再各写一份魔数嗅探）。**三个调用点一次修完**。
- **守卫覆盖洞**：`media_cover_write_guard_test.dart` 原判定是「**同一文件内**派生 && 裸写 && 无 applyCover」，
  派生点与写盘点跨文件时两边都逃——调用方有 destMarker 但没 rawWrite（第 83 行放行），
  真正的裸写在整文件白名单里的 `video_cover_extractor.dart`（第 78 行放行）。
  新增第 ④ 条守卫把**整文件白名单降级成「文件 → 允许裸写的函数名集合」显式清单**
  （`media_cover_service.dart` → `{applyCoverFile, applyCoverBytes}`；`video_cover_extractor.dart` → 空集）。

### ③ 存量无清理 · BUG-1393 ③
被刷上海报的子篇**恰恰都有资料行**，`VideoScrapeAutoService._pending` 只喂「还没有资料行」的书，
`_maybeBackfillCovers` 只补空封面 → 永远不会被重新访问，用户开 app 看不到修复。

- `member_cover_cleanup.dart`（新）：纯判据 `planMemberCoverCleanup` + 落地 `runMemberCoverCleanup`，
  由 `VideoScrapeAutoService.sweep` 在**刮削之前**每进程跑一次（不需要 `CoverScraperService`，不加载离线索引）。
- 把成员身上的海报**升格**成合集自有封面后清成员那一列——用户要的是「海报归合集」，不是「海报消失」。

**误删方向的收口**（这是清空类改动）：
1. **只认 `CoverOrigin.autoScraped`**（当前代码里唯一由自动刮削写作品海报时打的标记）。
   `manual`/`userScraped`/`sidecar` 是用户拍板（BUG-1325 红线）、`scraped` 是来源不明的存量（保守放过）、
   `autoFrame`/无记录本就是想保留的抽帧。
2. **路径只来自被清那一行自己的 `coverPath` 字段**——不枚举目录、不按 uid 猜文件名。
3. 规范化后必须 `p.isWithin` 自有封面目录**且直接父目录相等**：目录外 = 用户自己的图，
   `collections/` 子目录 = 合集自有封面，两者都在射程外（路径遍历 `../` 也被挡）。
4. **一个文件都不删**：孤儿由既有 `VideoStorage.gcOrphanCovers` 回收（它非递归 → `collections/` 天然免疫，
   保留集 = 全库 `video_books.cover_path`）。少一个删除动作就少一整类误删。

## 变异实测
| 变异 | 结果 |
|---|---|
| 摘掉 `_promoteCollectionCover` 调用（只闸不改投） | `collection_member_cover_gate_test` 红 ✅ |
| `downloadVideoCoverToPath` 改回裸 `writeAsBytes` | 新守卫红 ✅（**行为测试全绿**——`.tmp` 断言对裸写同样成立，这正是必须有源码扫描守卫的理由） |
| 清理判据从 `!= autoScraped` 放宽成 `== autoFrame` | 7 条红 ✅（含全部误删方向用例） |
| 拆掉 `p.isWithin` + 父目录围栏 | 2 条误删方向用例红 ✅ |

## 验证
- `flutter analyze --no-pub`（含 test）：`No issues found!`
- `FLUTTER TEST VERDICT: PASSED - 3557 tests ran, all tests passed`
  （`test/media/video` + `media/collections` + `media/metadata` + `media/source_library` + `media/drag_drop`
   + 封面服务/写盘守卫 + `test/storage` + `test/torrent` + `test/database` + `test/tools` + `test/helpers`）
- `FLUTTER TEST VERDICT: PASSED - 80 tests ran`（`test/pages` 视频页相关 + `settings_schema_coverage`）
- 覆盖集来自 `grep -rl` 反查所有扫本轮改动生产文件的守卫/测试。
- 未跑全量套件、未跑 Windows itest、未合并 develop（按任务约束）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
