### PR TITLE
fix(test): 互联下载登记 flaky 根因收口——AppPaths 解析穿真实 prefs 通道钉死 isolate (BUG-1400)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1315 条。点号进各自文件。
+> 共 1316 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1406](bugs/BUG-1406-libmpv-ffmpeg-version-guard-first-match.md) | ✅ | ✅ | libmpv FFmpeg 版本守卫只校验第一个匹配，单 ABI 静默降级不报红 |
+| [BUG-1400](bugs/BUG-1400-appaths-prefs-channel-fakeasync-deadlock.md) | ✅ | ✅ | AppPaths 解析穿真实 prefs 通道，fake async 相位一次调用钉死整个 isolate（互联下载登记测试 flaky） |
 | [BUG-1394](bugs/BUG-1394-cover-write-guard-cross-file.md) | ✅ | ✅ | 封面写盘守卫的跨文件派生覆盖洞：番剧下载封面绕过 BUG-1118 收口 |
 | [BUG-1393](bugs/BUG-1393-collection-member-poster.md) | ✅ | ✅ | 合集子篇被自动刮成作品级竖版海报，且作品海报被整个丢弃 |
 | [BUG-1392](bugs/BUG-1392-md3-chrome-guard-collection-prs.md) | ✅ | ✅ | 合集三 PR 绕过 MD3 页面 chrome 守卫：CheckboxListTile / 手抄封面角标 / 硬编码 fontSize 直接把 develop 打红 |

--- a/docs/bugs/BUG-1400-appaths-prefs-channel-fakeasync-deadlock.md
+++ b/docs/bugs/BUG-1400-appaths-prefs-channel-fakeasync-deadlock.md
@@ -1,0 +1,74 @@
+## BUG-1400 · AppPaths 解析穿真实 prefs 通道，fake async 相位一次调用钉死整个 isolate（互联下载登记测试 flaky）
+- **报告**：2026-08-02（看板 TODO-2595，PR#693 施工方顺带发现；非其引入）
+- **真实性**：✅ 真 bug（测试夹具缺口，非生产逻辑缺陷）——根因
+  `hibiki/lib/src/storage/app_paths.dart:173`（`_configuredDataRootPath()` 里的
+  `SharedPreferences.getInstance()`）+ `hibiki/lib/src/storage/app_paths.dart:311`
+  （`_useLegacyFlatDocumentsRoot()` 里的 `_prefsOrNull()`），在
+  `hibiki/test/pages/home_video_remote_download_register_test.dart` 缺
+  `SharedPreferences.setMockInitialValues` 的环境下变成永久挂起。
+
+### 现象
+`test/pages/home_video_remote_download_register_test.dart` 第三个用例
+「host 有外挂字幕时连带下载并解析成 cue 写入」同代码重复跑约 **20%** 概率红在
+`expect(row, isNotNull)`（第 190 行）。本机实测**修前 5/22 红**（基线 2/10 + 带诊断 3/12）。
+正常路径下载登记链 **75~90ms** 走完，失败路径 **30s 后仍停在 `running`** —— 是硬挂起，不是慢。
+
+### 根因
+分阶段埋点定位到挂在 `_registerDownloadedVideo` → `_downloadRemoteSubtitleForBook` →
+`AppPaths.videoSubtitlesDirectory()` → `_resolveDocumentsRoot()` 的
+`_configuredDataRootPath()` 里，即 `SharedPreferences.getInstance()`。
+
+链条：
+
+1. `AppPaths` 的**运行时静态便捷层**（`documentsSubdirectory()` 等）每次解析根都 await
+   `SharedPreferences.getInstance()`（`_configuredDataRootPath()` 一次、
+   `_useLegacyFlatDocumentsRoot()` 一次）。封面抽取、字幕落点、缩略图这些**页面级
+   fire-and-forget 链**全从它派生，所以 widget 测试的 `pump()` 相位会大量调用它。
+2. 该测试只 mock 了 `plugins.flutter.io/path_provider`，**没 mock prefs 通道**。于是
+   `getInstance()` 穿到**真实**平台通道，应答只能由**真实事件循环**投递。
+3. `testWidgets` 的 fake async 相位收不到真实事件循环的投递 ⇒ 这次解析永久挂起。
+4. `SharedPreferences.getInstance()` 把首次调用的 `Completer` 存在**进程级静态字段**
+   （`shared_preferences-2.2.3/lib/shared_preferences.dart:24` `static Completer? _completer`，
+   且 `_completer` 在 await **之前**就赋值）。⇒ 后续**每个**调用者，包括别的用例、包括
+   `runAsync` 里的，都 join 同一条死 future。
+5. `home_video_page` 的 `_refresh()` → `_backfillCovers()` 是 fire-and-forget 链，会在
+   fake async 相位发起解析。它是否抢在别人前面成为「首次调用者」取决于调度时序 ⇒ **flaky**。
+   一旦它抢到，第三个用例 `runAsync` 里的下载登记链就卡死在派生字幕目录处，
+   任务停在 `running`、`VideoBooks` 行永远写不出来。
+
+`AppPaths.resolve()` 的注释（`app_paths.dart:87-91`）早已写明这条路径「会被静态便捷层高频
+调用，其中就包括 widget 测试」，并据此把**文件系统探测**挪出了 `_resolveDocumentsRoot`；
+但**平台通道往返**具有一模一样的「FakeAsync 里永不完成」性质，当时没一起收口。
+
+**为什么是夹具坏而不是功能坏**：生产端没有 FakeAsync，`getInstance()` 正常完成并缓存，
+断言本身也完全正确。纯生产侧改不动它——`_configuredDataRootPath()` 按定义就必须读一次
+pref，而在没有 handler 的环境里这次读**无法完成**（记忆化也救不了：被钉死的正是**第一次**
+调用）。同目录 20+ 个 `home_video_*` / `galgame_*` widget 测试早已按约定装了 prefs mock，
+本文件漏了。
+
+### 修复
+- **[x] ① 已修复** — `hibiki/test/pages/home_video_remote_download_register_test.dart`
+  的 `setUp` 补 `SharedPreferences.setMockInitialValues(<String, Object>{})`，与同目录
+  20+ 个 widget 测试同约定。装上后应答由 mock handler 在**进程内**以 microtask 给出，
+  FakeAsync 会调度 microtask ⇒ 解析在 fake async 相位内就走完，跨相位依赖被**结构性消除**
+  （不是概率降低）。**没有**加延迟 / 重试 / `pumpAndSettle` / 放宽断言。
+  提交：见下方提交哈希。
+- **[x] ② 已加自动化测试** — 新增
+  `hibiki/test/storage/app_paths_fakeasync_prefs_channel_test.dart`：钉住
+  「fake async 相位内发起的 `AppPaths` 解析必须在同一相位内完成」+「前一个用例的解析不得
+  毒化后续 `runAsync` 里的解析」两条不变量。
+
+### 证据
+- 确定性复现（不靠自然 flake）：两个 `testWidgets`，A 在 fake async 相位 fire-and-forget
+  一次 `AppPaths.documentsSubdirectory()`，B 在 `runAsync` 里解析同一路径 ——
+  **无 prefs mock：3/3 红**（B `TimeoutException ... after 5002ms`）；
+  **有 prefs mock：3/3 绿**（A 在 `pump()` 内即解析完，B 耗时 **1ms**）。
+- 原用例：**修前 5/22 红**（20 次基线 2 红 + 12 次带诊断 3 红），**修后 0/20 红**。
+- 新守卫变异实测：注掉 `setMockInitialValues` → 两个用例全红；还原 → 全绿。
+
+### 备注
+同一隐患在 `hibiki/test/pages/` 下还有 **21 个**文件（mock 了 path_provider 但没 mock
+prefs），例如 `home_video_remote_download_dedup_test.dart` /
+`home_video_remote_interconnect_test.dart` / `reader_remote_*` / `collections_*` 系列。
+它们目前未观察到红，但携带同一条永久钉死路径。本轮范围只收口 TODO-2595 这一条，
+批量补齐留作后续（改法机械：`setUp` 补一行）。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1140
+version: 1.3.1+1141
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/pages/home_video_remote_download_register_test.dart
+++ b/hibiki/test/pages/home_video_remote_download_register_test.dart
@@ -16,6 +16,7 @@ import 'package:hibiki/src/sync/interconnect_download_manager.dart';
 import 'package:hibiki/src/sync/remote_library_source.dart';
 import 'package:hibiki/src/sync/remote_video_client.dart';
 import 'package:hibiki_core/hibiki_core.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../helpers/test_platform_services.dart';
 
@@ -53,6 +54,18 @@ void main() {
   late VideoBookRepository repo;
 
   setUp(() async {
+    // BUG-1400（本文件此前 flaky，第三个用例约 20% 概率红在 `expect(row, isNotNull)`）：
+    // 登记链路要经 [AppPaths.videoSubtitlesDirectory] 派生字幕落点，而 `AppPaths` 的每次
+    // 根解析都 await `SharedPreferences.getInstance()`。不装 mock 时该调用落到**真实**
+    // 平台通道，应答只能由真实事件循环投递；`testWidgets` 的 fake async 相位里投递不到，
+    // 而 `SharedPreferences` 把首次调用的 completer 记在**进程级静态字段**上——于是一次
+    // 在 fake async 相位发起的解析会把整个 isolate 的 prefs 永久钉死，后面所有 `AppPaths`
+    // 解析（包括 `runAsync` 里的下载登记链）都 join 这条死 future 而挂住，任务停在
+    // running、行永远写不出来。装上 mock 后应答在**进程内**以 microtask 完成，fake async
+    // 相位内即解析完毕，跨相位依赖被彻底消除（守卫见
+    // `test/storage/app_paths_fakeasync_prefs_channel_test.dart`）。
+    // 同目录 20+ 个 `home_video_*` / `galgame_*` widget 测试早已是这个约定，本文件漏了。
+    SharedPreferences.setMockInitialValues(<String, Object>{});
     LocaleSettings.setLocale(AppLocale.en);
     db = HibikiDatabase.forTesting(NativeDatabase.memory());
     final PreferencesRepository prefs = PreferencesRepository(db);

--- a/hibiki/test/storage/app_paths_fakeasync_prefs_channel_test.dart
+++ b/hibiki/test/storage/app_paths_fakeasync_prefs_channel_test.dart
@@ -1,0 +1,97 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/storage/app_paths.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// BUG-1400 守卫：`AppPaths` 的路径解析在 `testWidgets` 的 **fake async 相位内**必须能
+/// 自行走完，不许把完成时机寄托在真实事件循环上。
+///
+/// **为什么这是一条必须钉住的不变量**——[AppPaths.documentsSubdirectory] 是运行时静态
+/// 便捷层，封面抽取、字幕落点、缩略图等**页面级 fire-and-forget 链**都从它派生，因此它
+/// 会被 widget 测试在 `pump()` 相位大量调用。而它每次解析都要 await
+/// `SharedPreferences.getInstance()`：
+///
+///  * 装了 mock（[SharedPreferences.setMockInitialValues]）→ 应答在**进程内**由 mock
+///    handler 以 microtask 给出，FakeAsync 会调度 microtask，解析在本相位内完成；
+///  * 没装 mock → 调用穿到**真实**平台通道，应答只能由真实事件循环投递。FakeAsync 相位
+///    收不到它，于是这次解析永久挂起——而 `SharedPreferences` 把首次调用的 `Completer`
+///    存在**进程级静态字段**里，后续每个调用者（包括别的用例、包括 `runAsync` 里的）都
+///    join 同一条死 future。**一次**在 fake async 相位发起的解析就能钉死整个 isolate 的
+///    所有 `AppPaths` 解析。
+///
+/// 这正是 `home_video_remote_download_register_test.dart` 那条 flaky 的根因：页面的
+/// 封面回填链在 fake async 相位里发起解析，把 prefs 钉死，随后 `runAsync` 里的下载登记
+/// 链卡在派生字幕目录处，任务永远停在 running、`VideoBooks` 行写不出来。
+///
+/// 变异实测（2026-08-02）：注掉下面 `setUp` 里的
+/// [SharedPreferences.setMockInitialValues] → 两个用例**全红**（第一个 `resolved` 仍是
+/// null，第二个 5s 超时）；还原 → 全绿。
+void main() {
+  final TestWidgetsFlutterBinding binding =
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory documentsDir;
+
+  setUpAll(() {
+    documentsDir =
+        Directory.systemTemp.createTempSync('hibiki_app_paths_fakeasync');
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      (MethodCall call) async => documentsDir.path,
+    );
+  });
+
+  tearDownAll(() {
+    binding.defaultBinaryMessenger.setMockMethodCallHandler(
+      const MethodChannel('plugins.flutter.io/path_provider'),
+      null,
+    );
+    if (documentsDir.existsSync()) {
+      try {
+        documentsDir.deleteSync(recursive: true);
+      } catch (_) {}
+    }
+  });
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('fake async 相位内发起的 AppPaths 解析在同一相位内就完成（不依赖真实事件循环）',
+      (WidgetTester tester) async {
+    Directory? resolved;
+    // 刻意不 await：复刻页面里 fire-and-forget 的封面/字幕路径解析。
+    // ignore: unawaited_futures
+    AppPaths.documentsSubdirectory('bug1400_probe')
+        .then((Directory d) => resolved = d);
+
+    // 只 pump（纯 fake async，绝不进 runAsync）。解析若依赖真实事件循环，这里必然还是 null。
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(
+      resolved,
+      isNotNull,
+      reason: 'AppPaths 解析在 fake async 相位内没走完 —— prefs 通道被穿到真实平台层，'
+          '会把进程级 SharedPreferences completer 永久钉死（BUG-1400）',
+    );
+    expect(resolved!.path, endsWith('bug1400_probe'));
+  });
+
+  testWidgets('前一个用例的解析不会毒化后续 runAsync 里的 AppPaths 解析',
+      (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      final Directory dir =
+          await AppPaths.documentsSubdirectory('bug1400_probe').timeout(
+        const Duration(seconds: 5),
+        onTimeout: () => throw StateError(
+          'AppPaths 在 runAsync 里 5s 没解析出来 —— 进程级 prefs completer 已被'
+          '前一个用例的 fake async 相位钉死（BUG-1400）',
+        ),
+      );
+      expect(dir.path, endsWith('bug1400_probe'));
+    });
+  });
+}


### PR DESCRIPTION
看板 TODO-2595。develop 上最后一条**代码侧**的红。

## 结论：判据没坏、生产逻辑没坏，坏的是测试夹具

断言 `expect(row, isNotNull)` 完全正确；生产端没有 FakeAsync，`getInstance()` 正常完成并缓存。
纯生产侧**改不动**它——`_configuredDataRootPath()` 按定义必须读一次 pref，而在没有 handler
的环境里这次读**无法完成**（记忆化也救不了：被钉死的正是**第一次**调用）。

## 根因

`hibiki/lib/src/storage/app_paths.dart:173`（`_configuredDataRootPath()` 的
`SharedPreferences.getInstance()`）+ `app_paths.dart:311`（`_useLegacyFlatDocumentsRoot()`
的 `_prefsOrNull()`）。

1. `AppPaths` 运行时静态便捷层（`documentsSubdirectory()`）每次解析根都 await prefs。封面抽取 /
   字幕落点 / 缩略图这些**页面级 fire-and-forget 链**全从它派生。
2. `home_video_remote_download_register_test.dart` 只 mock 了 `path_provider`，**没 mock prefs**
   ⇒ 调用穿到**真实**平台通道，应答只能由**真实事件循环**投递。
3. `testWidgets` 的 fake async 相位收不到它 ⇒ 这次解析永久挂起。
4. `SharedPreferences` 把首次调用的 `Completer` 存在**进程级静态字段**上（且赋值在 await
   **之前**）⇒ 后续每个调用者（含别的用例、含 `runAsync` 里的）都 join 同一条死 future。
5. 页面 `_refresh()` → `_backfillCovers()` 是 fire-and-forget，能否抢到「首次调用者」取决于
   调度时序 ⇒ **flaky**。抢到时第三个用例的下载登记链卡在派生字幕目录处，任务永远停在
   `running`、`VideoBooks` 行写不出来。

`AppPaths.resolve()` 的注释（`app_paths.dart:87-91`）早已写明这条路径「会被静态便捷层高频调用，
其中就包括 widget 测试」，并据此把**文件系统探测**挪出了 `_resolveDocumentsRoot`；但**平台通道
往返**具有一模一样的「FakeAsync 里永不完成」性质，当时没一起收口。

## 修法（无任何延迟/重试/掩盖）

`setUp` 补 `SharedPreferences.setMockInitialValues(<String, Object>{})`，与同目录 20+ 个
`home_video_*` / `galgame_*` widget 测试同约定。应答改为在**进程内**以 microtask 给出，
FakeAsync 会调度 microtask ⇒ 解析在 fake async 相位内即完成，**跨相位依赖被结构性消除**
（不是概率降低）。没加 `await` / `pumpAndSettle` / `Future.delayed` / 重试，没放宽任何断言。

新增守卫 `hibiki/test/storage/app_paths_fakeasync_prefs_channel_test.dart` 钉两条不变量：
① fake async 相位内发起的 `AppPaths` 解析必须在同一相位内完成；② 前一个用例的解析不得毒化
后续 `runAsync` 里的解析。

## 证据

| 项 | 结果 |
|---|---|
| 原用例修前 | **5/22 红**（基线 2/10 + 带诊断 3/12） |
| 原用例修后 | **0/20 红** |
| 确定性实验（无 prefs mock） | **3/3 红**，`TimeoutException ... after 5002ms` |
| 确定性实验（有 prefs mock） | **3/3 绿**，A 在 `pump()` 内即解析完、B **1ms** |
| 新守卫变异实测 | 注掉 `setMockInitialValues` → 两个用例全红；还原 → 全绿 |
| `flutter analyze`（含 test） | `No issues found!` |
| 定向 `test/storage` + 38 个守卫 | `PASSED - 297 tests ran` |
| 定向 远端下载相邻 7 个页面测试 | `PASSED - 25 tests ran` |

`test/tools/update_manifest_publish_race_test.dart` 5 红是**本机环境**（bash/git `mktemp -d` 拿不到
`/tmp`：`fatal: cannot change to '/tmp/tmp.XXX'`），单跑同样红，与本 PR 无关，文件本轮未改动。

## 顺带发现（本轮未修）

`hibiki/test/pages/` 下还有 **21 个**文件 mock 了 path_provider 但没 mock prefs，携带同一条
永久钉死路径（`home_video_remote_download_dedup_test.dart` / `home_video_remote_interconnect_test.dart` /
`reader_remote_*` / `collections_*` 等）。目前未观察到红，但是潜在同类 flaky 源。改法机械
（`setUp` 补一行），留作后续。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
