### PR TITLE
fix(home): 游戏活动身份两道闸——同名条目不再取第一个 / 脏 key 不再误绑封面 (BUG-1412)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1316 条。点号进各自文件。
+> 共 1317 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |
 | [BUG-1406](bugs/BUG-1406-libmpv-ffmpeg-version-guard-first-match.md) | ✅ | ✅ | libmpv FFmpeg 版本守卫只校验第一个匹配，单 ABI 静默降级不报红 |
 | [BUG-1400](bugs/BUG-1400-appaths-prefs-channel-fakeasync-deadlock.md) | ✅ | ✅ | AppPaths 解析穿真实 prefs 通道，fake async 相位一次调用钉死整个 isolate（互联下载登记测试 flaky） |
 | [BUG-1394](bugs/BUG-1394-cover-write-guard-cross-file.md) | ✅ | ✅ | 封面写盘守卫的跨文件派生覆盖洞：番剧下载封面绕过 BUG-1118 收口 |

--- a/docs/bugs/BUG-1412-activity-identity-gates.md
+++ b/docs/bugs/BUG-1412-activity-identity-gates.md
@@ -1,0 +1,26 @@
+## BUG-1412 · 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面
+- **报告**：2026-08-02（BUG-1284 修复后的复核发现；移植自抢救分支 `codex/fix-pr578-identity-gates`）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/mining/galgame_library.dart:341` 的
+  `findGalgameForActivity` 在 BUG-1284 引入三层兼容后缺两道闸：
+  1. **脏 key 无闸** —— `mediaKey` 非空但既不等于任何 `galgames.id`、也不是 exe 路径时
+     （游戏被删后残留的稳定 id、或历史脏值），代码继续下坠到标题快照层，把活动绑到
+     **另一个**同名游戏的封面上；
+  2. **标题层取首项** —— 标题匹配循环命中即 `return game`，库里存在同名条目时结果由
+     `games` 的列表顺序决定，等于随机挑一只游戏顶包。
+  两道都会让首页 Activity / 游戏首页时间线显示**错误游戏的封面**，比原本的占位图标更糟。
+- **[x] ① 根因修复** — 在 `galgame_library.dart` 补两道闸：新增
+  `bool _looksLikeLegacyExePath(String)`，只有带路径分隔符且以 `.exe` 结尾的 key 才具备
+  旧路径身份，其余非空 key 未命中 id 即安全返回 `null`；标题层抽出
+  `GalgameEntry? _findUniqueGalgameByActivityTitle(List<GalgameEntry>, String)`，
+  候选必须**唯一**，零个或多个一律返回 `null`，不再依赖库顺序取首项。
+  稳定 id 精确命中与旧 exePath 精确命中的既有行为不变（BUG-1284 不回归）。
+- **[x] ② 自动化测试** —
+  `hibiki/test/mining/galgame_launch_args_test.dart` 新增 4 个纯函数用例：重复标题下
+  stable id / 旧 exePath 仍精确命中、路径迁移失效只接受唯一标题、无 key 重复标题返回
+  null、deleted id 与脏非路径 key 不得回落同名游戏；
+  `hibiki/test/pages/home_dashboard_page_test.dart` 新增 widget 用例，播三条历史活动
+  （无 key 重复标题 / deleted stable id / 脏 key）并断言活动区**没有**任何
+  `ResizeImage(FileImage)` 封面，即真回退成类型图标。
+- **备注**：移植自抢救分支 `codex/fix-pr578-identity-gates`（`ae4239919`），该分支基底旧，
+  按 hunk 在当前 `origin/develop` 上重做而非 cherry-pick。分支前置提交 `9d6243bd0`
+  （BUG-1284）已在 develop，本条只补其上的两道闸。

--- a/hibiki/lib/src/mining/galgame_library.dart
+++ b/hibiki/lib/src/mining/galgame_library.dart
@@ -309,6 +309,19 @@ String galgameNameFromExe(String exePath) {
 /// 路径归一成大小写无关的比较键（Windows 路径大小写不敏感、分隔符 `\\`/`/` 等价）。
 String _exePathKey(String path) => path.replaceAll('/', '\\').toLowerCase();
 
+/// 是否像历史活动曾写入 [mediaKey] 的 Windows exe 路径。
+///
+/// 稳定 id 与脏 key 都不能凭标题继续猜游戏；只有带路径分隔符且以 `.exe` 结尾的值
+/// 才具有旧路径身份。这里也接受测试/迁移数据里的根相对形式（如 `\ABS\GAME.EXE`），
+/// 但拒绝裸文件名和任意非路径字符串。
+bool _looksLikeLegacyExePath(String value) {
+  final String normalized = value.trim().replaceAll('/', '\\');
+  final int separator = normalized.lastIndexOf('\\');
+  if (separator < 0) return false;
+  final String fileName = normalized.substring(separator + 1);
+  return fileName.length > 4 && fileName.toLowerCase().endsWith('.exe');
+}
+
 /// 按 exe 路径在库里找条目；找不到返回 null。路径比较走与去重同一套归一
 /// （[_exePathKey]），所以 `D:/Games/a.exe` 与 `D:\games\A.EXE` 认作同一个游戏。
 ///
@@ -327,14 +340,45 @@ GalgameEntry? findGalgameByExePath(
   return null;
 }
 
+/// 按活动落库时的标题快照找唯一游戏；零个或多个候选都返回 null。
+GalgameEntry? _findUniqueGalgameByActivityTitle(
+  List<GalgameEntry> games,
+  String title,
+) {
+  final String snapshot = title.trim();
+  if (snapshot.isEmpty) return null;
+
+  GalgameEntry? candidate;
+  for (final GalgameEntry game in games) {
+    final Iterable<String?> knownTitles = <String?>[
+      game.displayName,
+      game.name,
+      game.metadata.name,
+      game.metadata.nameCn,
+      ...game.metadata.aliases,
+      galgameNameFromExe(game.exePath),
+    ];
+    if (!knownTitles.any((String? value) => value?.trim() == snapshot)) {
+      continue;
+    }
+    if (candidate != null) return null;
+    candidate = game;
+  }
+  return candidate;
+}
+
 /// 把一条游戏活动反查回游戏库条目。
 ///
 /// 新活动的 [mediaKey] 统一写 `galgames.id`；历史版本曾把 exe 绝对路径写进同一字段，
 /// attach 模式则可能完全没有 key。因此读取顺序固定为：
 ///
 /// 1. `galgames.id`；
-/// 2. 旧 exe 路径（复用 [findGalgameByExePath] 的 Windows 路径归一）；
-/// 3. 活动落库时的标题快照（本地名 / 当前显示名 / 元数据名与别名 / exe 文件名）。
+/// 2. 只有 key 可识别为旧 exe 路径时，才按 Windows 路径归一精确匹配；
+/// 3. 旧路径因迁移失效时，允许按标题快照恢复，但候选必须唯一；
+/// 4. 完全无 key 的更老事件也只接受唯一标题候选。
+///
+/// 非空的稳定 id / 脏非路径 key 一旦未命中就安全返回 null，绝不借同标题绑定到另一
+/// 游戏；重复标题同样返回 null，而不是依赖库顺序取首项。
 ///
 /// 这层兼容必须集中在领域模型旁边，首页 Activity 与游戏首页时间线共用；否则一个页面
 /// 能显示历史活动封面、另一个页面仍只剩占位图标。
@@ -348,26 +392,13 @@ GalgameEntry? findGalgameForActivity(
     for (final GalgameEntry game in games) {
       if (game.id == key) return game;
     }
+    if (!_looksLikeLegacyExePath(key)) return null;
     final GalgameEntry? byExePath = findGalgameByExePath(games, key);
     if (byExePath != null) return byExePath;
+    return _findUniqueGalgameByActivityTitle(games, title);
   }
 
-  final String snapshot = title.trim();
-  if (snapshot.isEmpty) return null;
-  for (final GalgameEntry game in games) {
-    final Iterable<String?> knownTitles = <String?>[
-      game.displayName,
-      game.name,
-      game.metadata.name,
-      game.metadata.nameCn,
-      ...game.metadata.aliases,
-      galgameNameFromExe(game.exePath),
-    ];
-    if (knownTitles.any((String? value) => value?.trim() == snapshot)) {
-      return game;
-    }
-  }
-  return null;
+  return _findUniqueGalgameByActivityTitle(games, title);
 }
 
 /// 把用户输入的一整行启动参数拆成 argv token，规则与 Windows `CommandLineToArgvW`

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1141
+version: 1.3.1+1142
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/mining/galgame_launch_args_test.dart
+++ b/hibiki/test/mining/galgame_launch_args_test.dart
@@ -100,9 +100,15 @@ void main() {
   });
 
   group('findGalgameByExePath', () {
-    GalgameEntry entry(String id, String exe, String args) => GalgameEntry(
+    GalgameEntry entry(
+      String id,
+      String exe,
+      String args, {
+      String? name,
+    }) =>
+        GalgameEntry(
           id: id,
-          name: id,
+          name: name ?? id,
           exePath: exe,
           workdir: '',
           launchArgs: args,
@@ -128,7 +134,7 @@ void main() {
       expect(findGalgameByExePath(<GalgameEntry>[], r'D:\a.exe'), isNull);
     });
 
-    test('活动身份统一兼容新 id、旧 exePath 与无 key 标题快照', () {
+    test('活动身份统一兼容新 id、旧 exePath 与无 key 唯一标题快照', () {
       expect(
         findGalgameForActivity(games, mediaKey: 'a', title: '旧标题')?.id,
         'a',
@@ -147,6 +153,156 @@ void main() {
       );
       expect(
         findGalgameForActivity(games, mediaKey: 'missing', title: 'missing'),
+        isNull,
+      );
+    });
+
+    test('exact stable id 在重复标题中仍精确命中，不能退化成标题首项', () {
+      final List<GalgameEntry> sameTitle = <GalgameEntry>[
+        entry(
+          'stable-a',
+          r'D:\Games\A\a.exe',
+          '-a',
+          name: '共同标题',
+        ),
+        entry(
+          'stable-b',
+          r'D:\Games\B\b.exe',
+          '-b',
+          name: '共同标题',
+        ),
+      ];
+
+      expect(
+        findGalgameForActivity(
+          sameTitle,
+          mediaKey: 'stable-b',
+          title: '共同标题',
+        )?.id,
+        'stable-b',
+      );
+    });
+
+    test('旧 exePath 精确命中优先于重复标题，路径迁移只接受唯一标题', () {
+      final List<GalgameEntry> sameTitle = <GalgameEntry>[
+        entry(
+          'path-a',
+          r'D:\Games\A\a.exe',
+          '-a',
+          name: '共同标题',
+        ),
+        entry(
+          'path-b',
+          r'D:\Games\B\b.exe',
+          '-b',
+          name: '共同标题',
+        ),
+      ];
+      expect(
+        findGalgameForActivity(
+          sameTitle,
+          mediaKey: r'd:/games/b/B.EXE',
+          title: '共同标题',
+        )?.id,
+        'path-b',
+      );
+      expect(
+        findGalgameForActivity(
+          sameTitle,
+          mediaKey: r'D:\Games\Moved\old.exe',
+          title: '共同标题',
+        ),
+        isNull,
+      );
+
+      final List<GalgameEntry> uniqueTitle = <GalgameEntry>[
+        entry(
+          'moved',
+          r'D:\Games\New\game.exe',
+          '',
+          name: '唯一旧标题',
+        ),
+        entry(
+          'other',
+          r'D:\Games\Other\other.exe',
+          '',
+          name: '其他游戏',
+        ),
+      ];
+      expect(
+        findGalgameForActivity(
+          uniqueTitle,
+          mediaKey: r'D:\Games\Old\game.exe',
+          title: '唯一旧标题',
+        )?.id,
+        'moved',
+      );
+    });
+
+    test('无 key 的 legacy 标题只有唯一候选时命中，重复标题安全返回 null', () {
+      final List<GalgameEntry> uniqueTitle = <GalgameEntry>[
+        entry(
+          'unique',
+          r'D:\Games\Unique\game.exe',
+          '',
+          name: '唯一标题',
+        ),
+        entry(
+          'other',
+          r'D:\Games\Other\other.exe',
+          '',
+          name: '其他标题',
+        ),
+      ];
+      expect(
+        findGalgameForActivity(uniqueTitle, title: '唯一标题')?.id,
+        'unique',
+      );
+
+      final List<GalgameEntry> sameTitle = <GalgameEntry>[
+        entry(
+          'duplicate-a',
+          r'D:\Games\A\a.exe',
+          '',
+          name: '重复标题',
+        ),
+        entry(
+          'duplicate-b',
+          r'D:\Games\B\b.exe',
+          '',
+          name: '重复标题',
+        ),
+      ];
+      expect(
+        findGalgameForActivity(sameTitle, title: '重复标题'),
+        isNull,
+      );
+    });
+
+    test('deleted stable id 与脏非路径 key 不得回落到另一个同标题游戏', () {
+      final List<GalgameEntry> currentGames = <GalgameEntry>[
+        entry(
+          'replacement',
+          r'D:\Games\Replacement\game.exe',
+          '',
+          name: '已删除游戏的标题',
+        ),
+      ];
+
+      expect(
+        findGalgameForActivity(
+          currentGames,
+          mediaKey: 'deleted-stable-id',
+          title: '已删除游戏的标题',
+        ),
+        isNull,
+      );
+      expect(
+        findGalgameForActivity(
+          currentGames,
+          mediaKey: 'dirty-key',
+          title: '已删除游戏的标题',
+        ),
         isNull,
       );
     });

--- a/hibiki/test/pages/home_dashboard_page_test.dart
+++ b/hibiki/test/pages/home_dashboard_page_test.dart
@@ -743,6 +743,88 @@ void main() {
         reason: '游戏活动条应兼容旧 exePath 并渲染 galgames.coverPath 封面（BUG-1284）');
   });
 
+  testWidgets('BUG-1412：活动身份门禁——不因重复标题、deleted id 或脏 key 误绑现存游戏封面',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final File cover = File('${storeDir.path}/identity_guard_cover.png')
+      ..writeAsBytesSync(_kOnePixelPng);
+    final DateTime now = DateTime.now();
+    await seedGame(
+      id: 'duplicate-a',
+      name: '重复标题',
+      addedAt: now,
+      coverPath: cover.path,
+    );
+    await seedGame(
+      id: 'duplicate-b',
+      name: '重复标题',
+      addedAt: now,
+      coverPath: cover.path,
+    );
+    await seedGame(
+      id: 'replacement',
+      name: '已删除游戏的标题',
+      addedAt: now,
+      coverPath: cover.path,
+    );
+    await seedGame(
+      id: 'dirty-current',
+      name: '脏键标题',
+      addedAt: now,
+      coverPath: cover.path,
+    );
+
+    Future<void> addLegacyActivity({
+      required String title,
+      String? mediaKey,
+      required int offsetMs,
+    }) =>
+        db.addActivityEvent(
+          eventType: kActivityGame,
+          mediaType: kActivityMediaGame,
+          title: title,
+          dateKey: HibikiTimeFormat.dayKey(now),
+          timestampMs: now.millisecondsSinceEpoch - offsetMs,
+          mediaKey: mediaKey,
+          durationMs: 60000,
+        );
+
+    await addLegacyActivity(title: '重复标题', offsetMs: 1000);
+    await addLegacyActivity(
+      title: '已删除游戏的标题',
+      mediaKey: 'deleted-stable-id',
+      offsetMs: 2000,
+    );
+    await addLegacyActivity(
+      title: '脏键标题',
+      mediaKey: 'dirty-key',
+      offsetMs: 3000,
+    );
+
+    await tester.pumpWidget(buildApp());
+    await pumpDashboard(tester);
+
+    expect(tester.takeException(), isNull);
+    final Finder fileImages = inSection(
+      t.home_activity,
+      find.byWidgetPredicate(
+        (Widget w) =>
+            w is Image &&
+            w.image is ResizeImage &&
+            (w.image as ResizeImage).imageProvider is FileImage,
+      ),
+    );
+    expect(
+      fileImages,
+      findsNothing,
+      reason: '身份不唯一或 key 不可信时必须回退类型图标，不能借标题取任意现存封面',
+    );
+  });
+
   testWidgets('BUG-1112：点活动时间轴的游戏条切到「游戏」tab，不再落到视频 tab',
       (WidgetTester tester) async {
     tester.view.physicalSize = const Size(1280, 900);


### PR DESCRIPTION
## 来源

**移植自抢救分支 `codex/fix-pr578-identity-gates`（远端 `ae4239919`）。**
该分支基底陈旧，**未 cherry-pick / 未 merge**，按 hunk 在当前 `origin/develop`（`4de73c62b`）上重做。

分支的前置提交 `9d6243bd0`（活动身份统一，BUG-1284）**已在 develop**，本 PR 只补它上面缺的两道闸。

## 问题在今天的 develop 上仍然存在

`hibiki/lib/src/mining/galgame_library.dart` 的 `findGalgameForActivity` 与分支的 "before" 状态**逐字节一致**（该文件与分支父提交仅差一处无关重命名 `filterDroppedGameExes` → `filterOutDuplicateGameExes`）。两个缺陷都还在：

1. **脏 key 无闸** —— `mediaKey` 非空但既不等于任何 `galgames.id`、也不是 exe 路径时（游戏被删后残留的稳定 id，或历史脏值），代码继续下坠到标题快照层，把活动绑到**另一个**同名游戏的封面。
2. **标题层取首项** —— 标题匹配循环命中即 `return game`，库里存在同名条目时结果由 `games` 的列表顺序决定，等于随机挑一只游戏顶包。

两者都会让首页 Activity / 游戏首页时间线显示**错误游戏的封面**，比原本的占位图标更糟。

## 改动

新增两个纯函数（均带完整类型签名）：

- `bool _looksLikeLegacyExePath(String value)` —— 只有带路径分隔符且以 `.exe` 结尾的 key 才具备旧路径身份；其余非空 key 未命中 id 即安全返回 `null`。
- `GalgameEntry? _findUniqueGalgameByActivityTitle(List<GalgameEntry> games, String title)` —— 候选必须**唯一**，零个或多个一律返回 `null`，不再依赖库顺序取首项。

稳定 id 精确命中与旧 exePath 精确命中的既有行为不变（BUG-1284 不回归）。两个消费方（`home_dashboard_page.dart` 两处、`galgame_home_page.dart` 一处）在 `null` 时都已优雅回退成类型图标 / 原始标题，无破坏性。

## 验证

- `flutter analyze --no-pub`（含 test）：`No issues found!`，exit 0。
- 定向测试 10 个文件（改动覆盖 + 两个源码扫描守卫 + 相邻 galgame/dashboard 域）：
  `FLUTTER TEST VERDICT: PASSED - 146 tests ran, all tests passed`，exit 0。
- **变异实测**（随分支救回的测试不假定有效，逐条实测）：
  - 变异 1（摘掉 gate 1 的 `_looksLikeLegacyExePath` 判断）→ 单测 `deleted stable id 与脏非路径 key 不得回落到另一个同标题游戏` **红** + widget 测试 **红**。
  - 变异 2（gate 2 改回命中即 `return game`，即修复前的「取第一个」）→ 单测 `无 key 的 legacy 标题只有唯一候选时命中，重复标题安全返回 null` **红** + widget 测试 **红**。
  - 两次均反向替换还原，`grep MUTATION` 零残留，还原后重跑仍 146 绿。

## BUG 号

分支自身不带 bug 文档，故无撞号。新建 `BUG-1412`（`bug.dart new` 跨 1721 个分支取到 1407，按并发纪律 `bug.dart renumber` 让到 1412 留余量）。
注：分支前置提交的 `BUG-1237-activity-game-cover` 在主线已被 renumber 成 **BUG-1284**（1237 现归 popup-touch-copy），本 PR 正文引用已对齐 1284。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
