### PR TITLE
fix(audio): 本地音频库 SQLITE_BUSY 不再被吞成与「真没这词」同形的 null (BUG-1413)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1317 条。点号进各自文件。
+> 共 1318 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1413](bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md) | ✅ | ✅ | 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null |
 | [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |
 | [BUG-1406](bugs/BUG-1406-libmpv-ffmpeg-version-guard-first-match.md) | ✅ | ✅ | libmpv FFmpeg 版本守卫只校验第一个匹配，单 ABI 静默降级不报红 |
 | [BUG-1400](bugs/BUG-1400-appaths-prefs-channel-fakeasync-deadlock.md) | ✅ | ✅ | AppPaths 解析穿真实 prefs 通道，fake async 相位一次调用钉死整个 isolate（互联下载登记测试 flaky） |

--- a/docs/bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md
+++ b/docs/bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md
@@ -1,0 +1,108 @@
+## BUG-1413 · 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null
+- **报告**：2026-08-02（用户：看板 TODO-2580，BUG-1365 备注里点名的残留边界）
+- **真实性**：✅ 真 bug（用户可见失败形态真实存在，且**一条日志都不记**）。
+
+  **与 BUG-1365 的关系**：同族，后者只修了「绑定期」那半。BUG-1365 把读端用
+  `LocalAudioDb.waitForPendingIndexing` 确定性地排在**自家** in-flight 写端之后，
+  消除了绑定期的读写无序。它没有、也修不了另一半——`local_audio_db.dart` 那个
+  `catch → return null` 依然把 `SQLITE_BUSY` 压成与「库里真没这个词」**完全同形**
+  的 `null`。BUG-1365 的备注原话：「跨 isolate 的『A isolate 建索引 / B isolate 查询』
+  仍只有 `busy_timeout` 兜底……要根治需把在途登记提升到跨 isolate 共享」。
+
+  **先摸清：那条跨 isolate 竞态今天不可达**（证据在下，故本条**不**去造跨 isolate
+  在途登记——那是在解决一个不存在的问题）：
+
+  - 桌面（Windows/macOS/Linux）**没有**第二个跑 `popupMain` 的 isolate。`popupMain`
+    只被 Android 的 `PopupEngineHolder.kt:27/116` 在 `:popup` **独立进程**里当第二个
+    FlutterEngine 入口拉起；桌面 runner 全都只有一个 engine
+    （`hibiki/windows/runner/main.cpp:168`、`macos/Runner/MainFlutterWindow.swift:23`、
+    `linux/runner/my_application.cc:58`）。桌面「弹窗词典」是主 isolate 里的一个 Dialog
+    （`app_model.dart:4357-4378`），Windows 全局查词浮窗是原生 WebView2，桥消息也回主
+    isolate 处理（`overlay_bridge_handlers.dart:62-66`）。
+  - Android 那边确实有第二进程，但 `TtsChannel._isSupported == Platform.isAndroid`
+    （`tts_channel.dart:44`）为真 → 两侧都走 native `TtsChannelHandler`，**Dart 的
+    `LocalAudioDb.ensureIndexes` 根本不执行**。
+  - 结论：「桌面跑 Dart 建索引」与「存在第二 isolate」两个条件从不同时成立，
+    `_pendingIndexing`（`local_audio_db.dart:152`，isolate-local 静态）在桌面只有一份，
+    BUG-1365 的防护在桌面**真的**成立。跨 isolate 拿不到完成信号是**结构事实**
+    （静态字段不跨 isolate 共享，`TtsChannel.instance` 也是 isolate-local 单例），
+    但今天没有代码路径能走到。
+
+  **真正可达、且今天就在坑用户的是同一个「同形 null」，走的是另一条边**：
+
+  1. `hibiki/lib/src/utils/misc/local_audio_db.dart:229`（修前）——`queryMeta` 的
+     `catch (e, stack) { log; return null; }`：`SQLITE_BUSY` 与上面三处真·未命中的
+     `null` 逐字节同形，调用方无从区分。`extractBlob` 同（`:288`）。
+  2. `hibiki/lib/src/utils/misc/lookup_audio_playback.dart:51-53 / 60-62`（修前）——
+     查词发音链对 `queryLocalAudio` 套 `.timeout(500ms)`，`on TimeoutException { return null; }`。
+     **500ms 比只读连接自己的 `PRAGMA busy_timeout = 3000` 更短**，所以库一旦真被占用，
+     永远是这里先到点：sqlite 的 `SqliteException` **压根没机会抛出来**，第 1 条的分类
+     再准也打不中，而且这条路径**连一条日志都不记**（`ErrorLogService` 完全空白）。
+     这是整条链上最静默的 fail-open 出口。
+  3. `hibiki/lib/src/creator/enhancements/local_audio_enhancement.dart:150-152`（修前）——
+     制卡链同款 `on TimeoutException { // Fall through }`，用户侧＝卡片音频字段空、零提示。
+  4. 终点：`word_audio_resolver.dart:130-138` 的 `localAudio` 分支把 `null` 一视同仁当
+     「这个库没有」跳过 → `popup.js:2439-2444` 只判 falsy → 弹「暂无发音」
+     （i18n `popup_no_audio_available`）。用户无从知道其实是**数据库正忙**。
+
+  可达窗口（桌面，同 isolate，与竞态无关）：`AppModel.initialise()` 在 `app_model.dart:2225`
+  发起 `bindForNativeHandler()`，`tts_channel.dart:88` `unawaited(ensureIndexes)` 不阻塞
+  init → `isInitialised` 随即置真、可以查词；而首次在大库上建索引「可达数秒」
+  （BUG-1365 实测 3153ms）。**即 app 启动后头几秒的查词发音会静默落空**；设置页每次
+  增删/开关本地音频库（`local_audio_manager.dart:166`）再触发一轮同样窗口。
+
+  本地确定性实测（Windows，`flutter test`，不靠时间赛跑）：另一个 isolate 持
+  `BEGIN EXCLUSIVE` 时，`LocalAudioDb.queryMeta(dbPath, '勉強', 'べんきょう')`
+  （库里**确实有**这个词）在 **3157ms** 后返回 `null`——与同一时刻查一个库里
+  **确实没有**的词返回的 `null` 逐字节同形。这正是用户看到的「暂无发音」。
+
+- **[x] ① 已修复** —— 把「没有答案」从一个**值**改成一个**类型**，与远端音源既有的
+  `RemoteLookupUnreachableError` 同一套分工（「不可达/没答上」抛异常、「可达但确实
+  没有」返回 null），不新造第二种概念：
+
+  - `hibiki/lib/src/utils/misc/local_audio_db.dart`：新增 `LocalAudioUnavailableError`
+    + `LocalAudioUnavailableReason{busy,timedOut}`；`queryMeta` / `extractBlob` 改
+    `on SqliteException` 分类，`SQLITE_BUSY(5)`/`SQLITE_LOCKED(6)` 抛可区分类型。
+    其余 sqlite 错误（缺表/损坏/无权限）是**稳定**故障、且导入期已被
+    `isUsableAudioSource` 拦，保持既有 log + null 不动。
+  - `hibiki/lib/src/utils/misc/tts_channel.dart`：`queryLocalAudio` / `extractLocalAudio`
+    的 catch-all 前加 `on LocalAudioUnavailableError { rethrow; }`，让它穿透
+    `Isolate.run` 边界（自定义异常可原样跨 `Isolate.run` 回传，已实测）。
+  - `hibiki/lib/src/utils/misc/lookup_audio_playback.dart`：500ms 预算提为共享常量
+    `kLocalAudioQueryBudget`；两处 `on TimeoutException` 不再 `return null`，改抛
+    `LocalAudioUnavailableError(timedOut)`。**预算值本身不动**（保持既有手感）——
+    改的是「预算耗尽」的含义：它是「没查出来」，不是「查出来没有」。
+  - `hibiki/lib/src/utils/misc/word_audio_resolver.dart`：`_resolveLocal` / `_resolveLocalAt`
+    接住该类型 → 记一条**用户可见**的错误日志（设置 → 诊断 → 错误日志，
+    `settings_schema_system.dart:254-264`）后继续下一音源。刻意**不**做重试、
+    **不**计入远端那套失败冷却：本地库忙是瞬态（建索引完就好），冷却会把一个
+    马上就能用的库额外禁用 45s，把小问题放大成「这段时间该库全哑」。
+  - `hibiki/lib/src/creator/enhancements/local_audio_enhancement.dart`：制卡链同样接住
+    并记日志，行为仍是落远端/TTS 兜底（不崩制卡）。
+
+  **没有加延迟、重试、sleep，也没有调大 `busy_timeout`**——调大超时是典型假修复：
+  它只让撞上的概率变小，同形 null 一点没变（守卫测试钉死两条查询路径的
+  `busy_timeout = 3000` 不得被调大）。
+
+- **[x] ② 已加自动化测试** —— `hibiki/test/utils/misc/local_audio_busy_vs_miss_test.dart`（9 例）：
+  - 行为级**确定性**复现：另一个 isolate 持 `BEGIN EXCLUSIVE` 造 BUSY（非时间赛跑），
+    断言 `queryMeta` / `extractBlob` 撞锁抛 `busy`、而「库里真没这个词」仍是 `null`，
+    放锁后立刻恢复；另一例断言该类型能穿透 `TtsChannel.queryLocalAudio` 的 `Isolate.run`。
+  - `WordAudioResolver` 三例：没答上 → 记错误日志 + 继续下一源；真·未命中 → **不**污染
+    错误日志；blob 提取阶段没答上同样分开处置。
+  - 源码守卫：两处 `on TimeoutException` 必须抛 unavailable 且不得 `return null`；
+    预算是共享常量且制卡链同用；`busy_timeout = 3000` 恰好两处不得被调大。
+
+  变异实测（4 次，每次只改语义关键的一小处、均能编译）：① `_isBusy` 的 5/6 改 55/66
+  → 3 条行为用例红、源码守卫仍绿（证明行为守卫不与字符串守卫重复）；② 删 `TtsChannel`
+  的 `rethrow` → 只有「穿透 Isolate.run」红；③ 把 resolver 的日志调用短路 → 只有
+  「记用户可见错误日志」+「blob 提取阶段」两例红；④ 把 `on TimeoutException` 改回
+  `return null` → 只有对应源码守卫红。四次均反向替换还原，`git status --short` 干净。
+
+- **备注**：仍未收口的同形出口（**知情留下**，非本条范围）：`queryMeta` / `extractBlob`
+  对**非** BUSY 的 sqlite 错误（缺表/损坏）仍是 log + null；`popup.js:2439` 只判 falsy，
+  要给用户区分文案（如「音频库忙，稍后重试」）需三份 popup.js 镜像 + 三处 bridge handler
+  契约 + 17 语言 i18n 一起升级，代价远大于本条。跨 isolate 在途登记**刻意未做**——
+  桌面无第二 isolate、Android 不走 Dart 路径（见上），今天不可达；一旦将来真在桌面引入
+  第二个调 `queryLocalAudio` 的 isolate，它的 `TtsChannel._desktopDbConfigs` 会是空列表
+  （恒返回 null）且 `_pendingIndexing` 各自一份，届时要一并处理。

--- a/hibiki/lib/src/creator/enhancements/local_audio_enhancement.dart
+++ b/hibiki/lib/src/creator/enhancements/local_audio_enhancement.dart
@@ -7,8 +7,10 @@ import 'package:http/http.dart' as http;
 import 'package:path_provider/path_provider.dart';
 import 'package:hibiki/creator.dart';
 import 'package:hibiki/models.dart';
+import 'package:hibiki/src/utils/misc/local_audio_db.dart'
+    show LocalAudioUnavailableError;
 import 'package:hibiki/src/utils/misc/lookup_audio_playback.dart'
-    show resolveLookupAudioUrl;
+    show kLocalAudioQueryBudget, resolveLookupAudioUrl;
 import 'package:hibiki/utils.dart';
 
 /// BUG-1005：把 [resolveLookupAudioUrl] 解析出的单词音频 ref 物化成本地 [File] 供 Anki 落
@@ -125,6 +127,21 @@ class LocalAudioEnhancement extends AudioEnhancement {
     );
   }
 
+  /// 本地音频库这次没应答（撞锁 / 查询预算耗尽）时记一条用户可见的错误日志
+  /// （设置 → 诊断 → 错误日志），而不是静默把它当成「这个词没有发音」。
+  static void _logLocalAudioSkipped(
+    String term,
+    Object error,
+    StackTrace stack,
+  ) {
+    ErrorLogService.instance.log(
+      'LocalAudioEnhancement 本地音频库未能应答（$term）：'
+      '本次落远端音源 / TTS 兜底，这不代表库里没有这个词的发音',
+      error,
+      stack,
+    );
+  }
+
   Future<File?> _generateAudio(
       AppModel appModel, String term, String reading) async {
     // 1. Local audio database (Yomitan SQLite): query metadata, then extract
@@ -135,7 +152,7 @@ class LocalAudioEnhancement extends AudioEnhancement {
     try {
       final info = await TtsChannel.instance
           .queryLocalAudio(term, reading)
-          .timeout(const Duration(milliseconds: 500));
+          .timeout(kLocalAudioQueryBudget);
       if (info != null) {
         final int dbIndex = (info['dbIndex'] as int?) ?? 0;
         final path = await TtsChannel.instance.extractLocalAudio(
@@ -148,8 +165,14 @@ class LocalAudioEnhancement extends AudioEnhancement {
           if (file.existsSync()) return file;
         }
       }
-    } on TimeoutException {
-      // Fall through
+    } on TimeoutException catch (e, stack) {
+      // BUG-1413：预算耗尽＝本地库**没答上**，不是「这个词没有发音」。仍旧落到
+      // step 2 / step 3 兜底（行为不变），但必须留痕：旧实现这里是整条制卡链上
+      // 最静默的一处——音频字段空且无任何提示，用户与开发者都看不出库当时在忙。
+      _logLocalAudioSkipped(term, e, stack);
+    } on LocalAudioUnavailableError catch (e, stack) {
+      // 库明确报了撞锁（BUG-1413）：同样只是这次没取到，继续兜底而不是崩制卡。
+      _logLocalAudioSkipped(term, e, stack);
     }
 
     // 2. BUG-1005：配置的音频源（含**远程发音源** forvo/jpod101/hibikiRemote）——与查词

--- a/hibiki/lib/src/utils/misc/local_audio_db.dart
+++ b/hibiki/lib/src/utils/misc/local_audio_db.dart
@@ -9,6 +9,60 @@ import 'package:sqlite3/sqlite3.dart';
 
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 
+/// 本地音频库这次**没能给出答案**的原因。共同点：库里到底有没有这个词，
+/// 这次**根本没查出来**——与「库读到了、里面确实没有」是两件事。
+enum LocalAudioUnavailableReason {
+  /// 库文件被并发写者独占（`SQLITE_BUSY` / `SQLITE_LOCKED`），等满
+  /// `busy_timeout` 仍没拿到共享锁。最典型的写者就是我们自己绑定期的
+  /// [LocalAudioDb.ensureIndexes]（大库建索引可达数秒）。
+  busy,
+
+  /// 调用方的查询预算先于库自己的 `busy_timeout` 到点——库还在忙，
+  /// 只是我们不等了。**预算耗尽不是「这个词没有发音」的判据。**
+  timedOut,
+}
+
+/// 一次本地音频库读操作没能给出答案：忙 / 预算耗尽。
+///
+/// 根因修复（BUG-1413）：[LocalAudioDb.queryMeta] / [LocalAudioDb.extractBlob]
+/// 旧实现把 `SQLITE_BUSY` 和「查不到行」都压成同一个 `null`，调用方无从区分，
+/// 用户只看到「暂无发音」，无从知道其实是数据库正忙。把「没有答案」从一个
+/// **值**改成一个**类型**后，它与「没有这个词」在编译期就分开了，
+/// 调用方不可能再无意中把两者当成一回事。
+///
+/// 与远端音源的 `RemoteLookupUnreachableError` 是同一套分工：
+/// 「不可达 / 没答上」抛异常，「可达但确实没有音频」返回 null。
+class LocalAudioUnavailableError implements Exception {
+  const LocalAudioUnavailableError({
+    required this.reason,
+    this.dbPath = '',
+    this.detail = '',
+  });
+
+  final LocalAudioUnavailableReason reason;
+
+  /// 出问题的库路径；预算耗尽（[LocalAudioUnavailableReason.timedOut]）时调用方
+  /// 通常只知道 dbIndex 拿不到路径，留空。
+  final String dbPath;
+
+  /// 底层错误的可读描述（如 sqlite 的 `SqliteException` 文本），供错误日志排查。
+  final String detail;
+
+  @override
+  String toString() {
+    final String where = dbPath.isEmpty ? '' : ' db=$dbPath';
+    final String why = detail.isEmpty ? '' : ' ($detail)';
+    return 'LocalAudioUnavailableError(${reason.name})$where$why';
+  }
+}
+
+/// `SQLITE_BUSY` / `SQLITE_LOCKED`：库被别的连接占着，这次没读成。
+/// `resultCode` 是主结果码（`extendedResultCode & 0xFF`），故 `BUSY_SNAPSHOT`
+/// 之类的扩展码也一并归入。
+bool _isBusy(SqliteException e) =>
+    e.resultCode == 5 /* SQLITE_BUSY */ ||
+    e.resultCode == 6 /* SQLITE_LOCKED */;
+
 /// Pure-Dart reader for the Yomitan "Local Audio Server" SQLite databases used
 /// for term-pronunciation audio.
 ///
@@ -226,6 +280,22 @@ class LocalAudioDb {
         }
       }
       return best; // 全被过滤 → null（该库无启用源命中）
+    } on SqliteException catch (e, stack) {
+      // BUG-1413：撞锁**不是**「库里没这个词」。旧实现在这里 `return null`，与上面
+      // 三处真·未命中的 null 完全同形，调用方（WordAudioResolver）只能当 miss 处理
+      // → 用户看到「暂无发音」，无从知道数据库正忙。抛可区分的类型，让「没有答案」
+      // 走独立路径；只读连接的 busy_timeout 已经等过了，这里不再重试、不加延迟。
+      if (_isBusy(e)) {
+        throw LocalAudioUnavailableError(
+          reason: LocalAudioUnavailableReason.busy,
+          dbPath: dbPath,
+          detail: '$e',
+        );
+      }
+      // 其余 sqlite 错误（缺表 / 损坏 / 无权限）是**稳定**故障，不是瞬态：库要么
+      // 一直答不了要么导入时就被 [isUsableAudioSource] 拦下。保持既有 log + null。
+      ErrorLogService.instance.log('LocalAudioDb.queryMeta', e, stack);
+      return null;
     } catch (e, stack) {
       ErrorLogService.instance.log('LocalAudioDb.queryMeta', e, stack);
       return null;
@@ -285,6 +355,19 @@ class LocalAudioDb {
       out.parent.createSync(recursive: true);
       out.writeAsBytesSync(data);
       return out.path;
+    } on SqliteException catch (e, stack) {
+      // 同 [queryMeta]（BUG-1413）：撞锁是「这次没取成」，不是「这个词条没有音频」。
+      // 旧实现的 null 会让 WordAudioResolver 跳过该库继续下一源，最终同样落到
+      // 「暂无发音」且用户完全无从分辨。
+      if (_isBusy(e)) {
+        throw LocalAudioUnavailableError(
+          reason: LocalAudioUnavailableReason.busy,
+          dbPath: dbPath,
+          detail: '$e',
+        );
+      }
+      ErrorLogService.instance.log('LocalAudioDb.extractBlob', e, stack);
+      return null;
     } catch (e, stack) {
       ErrorLogService.instance.log('LocalAudioDb.extractBlob', e, stack);
       return null;

--- a/hibiki/lib/src/utils/misc/lookup_audio_playback.dart
+++ b/hibiki/lib/src/utils/misc/lookup_audio_playback.dart
@@ -7,8 +7,23 @@ import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/utils/misc/audio_mime.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:hibiki/src/utils/misc/local_audio_db.dart'
+    show LocalAudioUnavailableError, LocalAudioUnavailableReason;
 import 'package:hibiki/src/utils/misc/tts_channel.dart';
 import 'package:hibiki/src/utils/misc/word_audio_resolver.dart';
+
+/// 单次本地音频库查询的**预算**上限：超过就不再等，把控制权还给 UI
+/// （自动发音不能为了一个库把查词卡住）。
+///
+/// ⚠️ 这个值比 [LocalAudioDb] 只读连接自己的 `busy_timeout = 3000` **短**，
+/// 所以库一旦真被占用，永远是这里先到点——[LocalAudioDb] 的 BUSY 分类根本
+/// 来不及触发。因此预算耗尽必须**也**归成 [LocalAudioUnavailableError]
+/// （BUG-1413）：旧实现 `return null` 与「库里真没这个词」同形，而且连一条
+/// 日志都没有，是整条链上最静默的一个 fail-open 出口。
+///
+/// 预算本身不改（保持既有 500ms 手感）——改的是「预算耗尽」的**含义**：
+/// 它是「没查出来」，不是「查出来没有」。
+const Duration kLocalAudioQueryBudget = Duration(milliseconds: 500);
 
 /// Resolves and plays the audio for [expression] / [reading] exactly like Hoshi:
 /// enabled sources only, no TTS fallback.
@@ -47,18 +62,22 @@ Future<String?> resolveLookupAudioUrl(
       try {
         return await TtsChannel.instance
             .queryLocalAudio(expression, reading)
-            .timeout(const Duration(milliseconds: 500));
+            .timeout(kLocalAudioQueryBudget);
       } on TimeoutException {
-        return null;
+        throw const LocalAudioUnavailableError(
+          reason: LocalAudioUnavailableReason.timedOut,
+        );
       }
     },
     queryLocalAudioByDbIndex: (expression, reading, dbIndex) async {
       try {
         return await TtsChannel.instance
             .queryLocalAudio(expression, reading, dbIndex: dbIndex)
-            .timeout(const Duration(milliseconds: 500));
+            .timeout(kLocalAudioQueryBudget);
       } on TimeoutException {
-        return null;
+        throw const LocalAudioUnavailableError(
+          reason: LocalAudioUnavailableReason.timedOut,
+        );
       }
     },
     extractLocalAudio: TtsChannel.instance.extractLocalAudio,

--- a/hibiki/lib/src/utils/misc/tts_channel.dart
+++ b/hibiki/lib/src/utils/misc/tts_channel.dart
@@ -177,6 +177,11 @@ class TtsChannel {
           }
           return null;
         });
+      } on LocalAudioUnavailableError {
+        // BUG-1413：库这次没答上（撞锁）必须穿透到 WordAudioResolver。在这里吞成
+        // null 就又与「库里真没这个词」同形了——那正是本条要消除的东西。
+        // 自定义异常可原样跨 Isolate.run 边界回到本 isolate（已实测）。
+        rethrow;
       } catch (e, stack) {
         ErrorLogService.instance.log('TtsChannel.queryLocalAudio', e, stack);
         return null;
@@ -217,6 +222,8 @@ class TtsChannel {
               source: source,
               cacheDir: Directory(cacheDirPath),
             ));
+      } on LocalAudioUnavailableError {
+        rethrow; // 同 [queryLocalAudio]（BUG-1413）：没答上 ≠ 没有音频。
       } catch (e, stack) {
         ErrorLogService.instance.log('TtsChannel.extractLocalAudio', e, stack);
         return null;

--- a/hibiki/lib/src/utils/misc/word_audio_resolver.dart
+++ b/hibiki/lib/src/utils/misc/word_audio_resolver.dart
@@ -8,6 +8,8 @@ import 'package:hibiki/src/models/audio_source_config.dart';
 import 'package:hibiki/src/sync/hibiki_remote_lookup_client.dart'
     show RemoteLookupUnreachableError;
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:hibiki/src/utils/misc/local_audio_db.dart'
+    show LocalAudioUnavailableError;
 
 /// 弱网下的连接超时上限：从 5s 放宽到 8s，减少慢握手被误判为失败（TODO-1057）。
 const Duration kRemoteAudioConnectTimeout = Duration(seconds: 8);
@@ -178,9 +180,14 @@ class WordAudioResolver {
   }
 
   Future<String?> _resolveLocal(String expression, String reading) async {
-    final Map<String, dynamic>? info =
-        await queryLocalAudio(expression, reading);
-    return _extractLocal(info);
+    try {
+      final Map<String, dynamic>? info =
+          await queryLocalAudio(expression, reading);
+      return await _extractLocal(info);
+    } on LocalAudioUnavailableError catch (e, stack) {
+      _logLocalAudioUnavailable(e, stack, expression);
+      return null;
+    }
   }
 
   Future<String?> _resolveLocalAt(
@@ -188,9 +195,38 @@ class WordAudioResolver {
     String reading,
     int dbIndex,
   ) async {
-    final Map<String, dynamic>? info =
-        await queryLocalAudioByDbIndex(expression, reading, dbIndex);
-    return _extractLocal(info, fallbackDbIndex: dbIndex);
+    try {
+      final Map<String, dynamic>? info =
+          await queryLocalAudioByDbIndex(expression, reading, dbIndex);
+      return await _extractLocal(info, fallbackDbIndex: dbIndex);
+    } on LocalAudioUnavailableError catch (e, stack) {
+      _logLocalAudioUnavailable(e, stack, expression);
+      return null;
+    }
+  }
+
+  /// 本地库这次**没答上**（撞锁 / 查询预算耗尽）：与「库里真没这个词」是两回事。
+  ///
+  /// BUG-1413：旧实现下这两件事都是一个裸 `null`，`resolveConfigured` 只能一视同仁
+  /// 跳到下一源，最终用户看到「暂无发音」，且**整条链一条日志都没有**（500ms 预算
+  /// 先于库自己的 3s `busy_timeout` 到点，sqlite 的异常压根没机会抛出来）。现在记一条
+  /// 用户可见的错误日志（设置 → 诊断 → 错误日志），再跳下一源。
+  ///
+  /// 刻意**不**做重试、**不**计入 [_markRemoteSourceFailed] 那套失败冷却：冷却是给
+  /// 「连不上的死源」设计的，而本地库忙是瞬态的（绑定期建索引结束就恢复）——把一个
+  /// 马上就能用的库额外禁用 45s，等于把小问题放大成「这段时间该库全哑」。
+  static void _logLocalAudioUnavailable(
+    LocalAudioUnavailableError e,
+    StackTrace stack,
+    String expression,
+  ) {
+    ErrorLogService.instance.log(
+      'WordAudioResolver.localAudio 本地音频库未能应答'
+      '（$expression / ${e.reason.name}）：本次跳过该库，'
+      '这不代表库里没有这个词的发音',
+      e,
+      stack,
+    );
   }
 
   Future<String?> _extractLocal(

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1142
+version: 1.3.1+1143
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/utils/misc/local_audio_busy_vs_miss_test.dart
+++ b/hibiki/test/utils/misc/local_audio_busy_vs_miss_test.dart
@@ -1,0 +1,315 @@
+import 'dart:io';
+import 'dart:isolate';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/models/audio_source_config.dart';
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:hibiki/src/utils/misc/local_audio_db.dart';
+import 'package:hibiki/src/utils/misc/tts_channel.dart';
+import 'package:hibiki/src/utils/misc/word_audio_resolver.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+/// BUG-1413（BUG-1365 同族的残留边界）：本地音频库「这次没答上」曾与「库里真没
+/// 这个词」压成同一个 `null`。
+///
+/// BUG-1365 只修了**绑定期**那半——同 isolate 内用 `waitForPendingIndexing` 把读
+/// 排在自家写之后。它没有、也修不了另一半：`local_audio_db.dart` 的
+/// `catch → return null` 依然把 `SQLITE_BUSY` 压成与真·未命中同形的 null，而查词
+/// 侧 500ms 的查询预算比库自己的 `busy_timeout = 3000` 更短，超时也 `return null`
+/// 且**一条日志都不记**。两条路的终点都是用户看到「暂无发音」，无从知道库在忙。
+///
+/// 这里用「另一个 isolate 持 `BEGIN EXCLUSIVE`」制造**确定性** BUSY（不靠时间赛跑）。
+void _holdExclusiveLock(List<Object?> args) {
+  final String dbPath = args[0] as String;
+  final SendPort ready = args[1] as SendPort;
+  final Database db = sqlite3.open(dbPath, mode: OpenMode.readWrite);
+  db.execute('PRAGMA busy_timeout = 30000');
+  // EXCLUSIVE 立刻拿独占锁：其它连接连读都拿不到 shared 锁 → 必 SQLITE_BUSY。
+  db.execute('BEGIN EXCLUSIVE');
+  final ReceivePort release = ReceivePort();
+  ready.send(release.sendPort);
+  release.listen((Object? msg) {
+    db.execute('ROLLBACK');
+    db.dispose();
+    release.close();
+    if (msg is SendPort) msg.send('released');
+  });
+}
+
+/// 在另一个 isolate 上持有 [dbPath] 的独占锁，直到调用返回的释放回调。
+Future<Future<void> Function()> _lockExclusively(String dbPath) async {
+  final ReceivePort ready = ReceivePort();
+  final Isolate isolate = await Isolate.spawn(
+      _holdExclusiveLock, <Object?>[dbPath, ready.sendPort]);
+  final SendPort release = await ready.first as SendPort;
+  ready.close();
+  return () async {
+    final ReceivePort done = ReceivePort();
+    release.send(done.sendPort);
+    await done.first; // 等锁真的放掉再往下（Windows 上占用中的文件删不掉）
+    done.close();
+    isolate.kill(priority: Isolate.immediate);
+  };
+}
+
+void _seedDb(String path) {
+  final Database db = sqlite3.open(path);
+  db.execute('CREATE TABLE entries '
+      '(expression TEXT, reading TEXT, file TEXT, source TEXT)');
+  db.execute('CREATE TABLE android (file TEXT, source TEXT, data BLOB)');
+  db.execute("INSERT INTO entries VALUES ('勉強','べんきょう','a.mp3','src1')");
+  final PreparedStatement stmt =
+      db.prepare('INSERT INTO android (file, source, data) VALUES (?,?,?)');
+  stmt.execute(<Object?>[
+    'a.mp3',
+    'src1',
+    Uint8List.fromList(<int>[1, 2])
+  ]);
+  stmt.dispose();
+  db.dispose();
+}
+
+void main() {
+  group('BUG-1413: 库忙 vs 库里真没这个词（LocalAudioDb 层）', () {
+    late Directory tmp;
+    late String dbPath;
+
+    setUp(() {
+      tmp = Directory.systemTemp.createTempSync('hibiki_busy_vs_miss');
+      dbPath = '${tmp.path}/audio.db';
+      _seedDb(dbPath);
+    });
+
+    tearDown(() async {
+      await LocalAudioDb.waitForPendingIndexing();
+      if (tmp.existsSync()) tmp.deleteSync(recursive: true);
+    });
+
+    test('queryMeta：真·未命中仍是 null，撞锁改抛 busy（两者不再同形）', () async {
+      // 无锁基线：命中 = 记录，未命中 = null。
+      expect(LocalAudioDb.queryMeta(dbPath, '勉強', 'べんきょう')?.file, 'a.mp3');
+      expect(LocalAudioDb.queryMeta(dbPath, 'ないよ', ''), isNull,
+          reason: '库读得好好的、里面确实没有 → 权威 miss，保持 null');
+
+      final Future<void> Function() unlock = await _lockExclusively(dbPath);
+      try {
+        // 修复前：这里返回 null —— 与上面那个「真没这个词」的 null **完全同形**，
+        // 调用方无从区分，用户只看到「暂无发音」。
+        expect(
+          () => LocalAudioDb.queryMeta(dbPath, '勉強', 'べんきょう'),
+          throwsA(isA<LocalAudioUnavailableError>().having(
+            (LocalAudioUnavailableError e) => e.reason,
+            'reason',
+            LocalAudioUnavailableReason.busy,
+          )),
+          reason: '库被独占＝这次没查出来，不等于库里没有这个词',
+        );
+      } finally {
+        await unlock();
+      }
+
+      // 放锁后立刻恢复正常，证明这是瞬态、不该被当成「没有」。
+      expect(LocalAudioDb.queryMeta(dbPath, '勉強', 'べんきょう')?.file, 'a.mp3');
+    }, timeout: const Timeout(Duration(seconds: 120)));
+
+    test('extractBlob：撞锁改抛 busy，不再吞成「这个词条没有音频」', () async {
+      final Directory cache = Directory('${tmp.path}/cache')
+        ..createSync(recursive: true);
+      final Future<void> Function() unlock = await _lockExclusively(dbPath);
+      try {
+        expect(
+          () => LocalAudioDb.extractBlob(
+            dbPath: dbPath,
+            file: 'a.mp3',
+            source: 'src1',
+            cacheDir: cache,
+          ),
+          throwsA(isA<LocalAudioUnavailableError>().having(
+            (LocalAudioUnavailableError e) => e.reason,
+            'reason',
+            LocalAudioUnavailableReason.busy,
+          )),
+        );
+      } finally {
+        await unlock();
+      }
+      expect(
+        LocalAudioDb.extractBlob(
+          dbPath: dbPath,
+          file: 'a.mp3',
+          source: 'src1',
+          cacheDir: cache,
+        ),
+        isNotNull,
+        reason: '放锁后照常取得到 blob',
+      );
+    }, timeout: const Timeout(Duration(seconds: 120)));
+
+    test('TtsChannel.queryLocalAudio 把 busy 穿透 Isolate.run 边界', () async {
+      await TtsChannel.instance.setLocalAudioDbs(
+          <LocalAudioDbConfig>[LocalAudioDbConfig(path: dbPath)]);
+      // 先让绑定期的建索引跑完，再上锁：这样测的是**查询**撞锁，而不是建索引撞锁。
+      await LocalAudioDb.waitForPendingIndexing();
+      expect(
+          await TtsChannel.instance.queryLocalAudio('勉強', 'べんきょう'), isNotNull);
+      expect(await TtsChannel.instance.queryLocalAudio('ないよ', ''), isNull,
+          reason: '真·未命中仍是 null');
+
+      final Future<void> Function() unlock = await _lockExclusively(dbPath);
+      try {
+        // 修复前：TtsChannel 的 catch-all 会把它记一条日志后 `return null`，
+        // 与上一行的真·未命中同形。
+        await expectLater(
+          TtsChannel.instance.queryLocalAudio('勉強', 'べんきょう'),
+          throwsA(isA<LocalAudioUnavailableError>()),
+        );
+      } finally {
+        await unlock();
+        await TtsChannel.instance
+            .setLocalAudioDbs(const <LocalAudioDbConfig>[]);
+      }
+    }, timeout: const Timeout(Duration(seconds: 120)));
+  });
+
+  group('BUG-1413: WordAudioResolver 分开处置「没答上」与「没有这个词」', () {
+    tearDown(() {
+      WordAudioResolver.debugResetRemoteFailureCooldown();
+      WordAudioResolver.debugSetNowProvider(null);
+    });
+
+    List<AudioSourceConfig> sourcesLocalThenRemote() => <AudioSourceConfig>[
+          AudioSourceConfig.localAudio(
+            label: 'local',
+            path: '/db/first.db',
+            enabled: true,
+          ),
+          AudioSourceConfig.remoteAudio(
+              url: 'https://remote.test/?term={term}'),
+        ];
+
+    test('本地库没答上：记一条用户可见错误日志，并继续下一源（不当成 miss）', () async {
+      final int before = ErrorLogService.instance.entries.length;
+      final resolver = WordAudioResolver(
+        queryLocalAudio: (_, __) async => null,
+        queryLocalAudioByDbIndex: (_, __, ___) async =>
+            throw const LocalAudioUnavailableError(
+          reason: LocalAudioUnavailableReason.busy,
+          dbPath: '/db/first.db',
+        ),
+        extractLocalAudio: (_, __, {dbIndex = 0}) async => null,
+        fetchAudioSourceList: (_) async =>
+            const <String>['https://cdn.test/remote.mp3'],
+      );
+
+      final String? result = await resolver.resolveConfigured(
+        expression: '勉強',
+        reading: 'べんきょう',
+        sources: sourcesLocalThenRemote(),
+      );
+
+      expect(result, 'https://cdn.test/remote.mp3',
+          reason: '本地库没答上不得中断解析，要继续走下一个音源');
+      final List<ErrorLogEntry> added =
+          ErrorLogService.instance.entries.skip(before).toList();
+      expect(added, isNotEmpty,
+          reason: 'BUG-1413：库在忙必须留下用户可见的痕迹，'
+              '否则用户看到「暂无发音」永远不知道是数据库忙');
+      expect(added.map((ErrorLogEntry e) => e.source).join('\n'),
+          contains('WordAudioResolver.localAudio'));
+    });
+
+    test('本地库真·未命中：安静跳到下一源，不污染错误日志', () async {
+      final int before = ErrorLogService.instance.entries.length;
+      final resolver = WordAudioResolver(
+        queryLocalAudio: (_, __) async => null,
+        queryLocalAudioByDbIndex: (_, __, ___) async => null,
+        extractLocalAudio: (_, __, {dbIndex = 0}) async => null,
+        fetchAudioSourceList: (_) async =>
+            const <String>['https://cdn.test/remote.mp3'],
+      );
+
+      final String? result = await resolver.resolveConfigured(
+        expression: '勉強',
+        reading: 'べんきょう',
+        sources: sourcesLocalThenRemote(),
+      );
+
+      expect(result, 'https://cdn.test/remote.mp3');
+      expect(ErrorLogService.instance.entries.length, before,
+          reason: '「库里真没这个词」是正常结果，不是错误，不该进错误日志');
+    });
+
+    test('blob 提取阶段没答上同样被分开处置', () async {
+      final int before = ErrorLogService.instance.entries.length;
+      final resolver = WordAudioResolver(
+        queryLocalAudio: (_, __) async => null,
+        queryLocalAudioByDbIndex: (_, __, dbIndex) async => <String, dynamic>{
+          'file': 'a.mp3',
+          'source': 'src1',
+          'dbIndex': dbIndex,
+        },
+        extractLocalAudio: (_, __, {dbIndex = 0}) async =>
+            throw const LocalAudioUnavailableError(
+          reason: LocalAudioUnavailableReason.busy,
+        ),
+        fetchAudioSourceList: (_) async =>
+            const <String>['https://cdn.test/remote.mp3'],
+      );
+
+      final String? result = await resolver.resolveConfigured(
+        expression: '勉強',
+        reading: 'べんきょう',
+        sources: sourcesLocalThenRemote(),
+      );
+
+      expect(result, 'https://cdn.test/remote.mp3');
+      expect(ErrorLogService.instance.entries.length, greaterThan(before));
+    });
+  });
+
+  group('BUG-1413 源码守卫：查询预算耗尽不得再被吞成同形 null', () {
+    final String playbackSrc =
+        File('lib/src/utils/misc/lookup_audio_playback.dart')
+            .readAsStringSync();
+    final String dbSrc =
+        File('lib/src/utils/misc/local_audio_db.dart').readAsStringSync();
+
+    test(
+        'lookup_audio_playback 的 TimeoutException 分支抛 unavailable 而非 return null',
+        () {
+      // 500ms 预算比库自己的 busy_timeout=3000 更短，所以库一忙**永远**是这里
+      // 先到点；这里 return null 就等于把「没查出来」写成「没有这个词」。
+      expect(playbackSrc, contains('on TimeoutException {'));
+      final int firstTimeout = playbackSrc.indexOf('on TimeoutException {');
+      expect(firstTimeout, greaterThanOrEqualTo(0));
+      for (final Match m in 'on TimeoutException {'.allMatches(playbackSrc)) {
+        final String block = playbackSrc.substring(m.start, m.start + 200);
+        expect(block, contains('throw const LocalAudioUnavailableError('),
+            reason: 'BUG-1413：预算耗尽必须归成可区分的 unavailable');
+        expect(block.contains('return null;'), isFalse,
+            reason: 'BUG-1413：不得再返回与真·未命中同形的 null');
+      }
+    });
+
+    test('查询预算是共享常量，不再各处手写 500ms 魔数', () {
+      expect(playbackSrc, contains('const Duration kLocalAudioQueryBudget'));
+      final String enhancement =
+          File('lib/src/creator/enhancements/local_audio_enhancement.dart')
+              .readAsStringSync();
+      expect(enhancement, contains('kLocalAudioQueryBudget'),
+          reason: '制卡链与查词链必须用同一个预算，否则两边行为会漂开');
+      expect(enhancement, contains('LocalAudioUnavailableError'),
+          reason: '制卡链也要接住 unavailable，否则新抛的异常会崩制卡');
+    });
+
+    test('local_audio_db 对 BUSY 分类，且不靠调大 busy_timeout 掩盖', () {
+      expect(dbSrc, contains('bool _isBusy(SqliteException e)'));
+      expect(dbSrc, contains('LocalAudioUnavailableReason.busy'));
+      // 查询路径的 busy_timeout 保持 3000：本条修的是「BUSY 被吞成同形 null」，
+      // 调大超时只会让撞上的概率变小，同形问题一点没变（典型假修复）。
+      expect('PRAGMA busy_timeout = 3000'.allMatches(dbSrc).length, 2,
+          reason: 'queryMeta / extractBlob 两条只读查询路径的 busy_timeout 不得被调大');
+    });
+  });
+}


### PR DESCRIPTION
BUG-1365（PR#687）同族的残留边界，看板 TODO-2580。文档：`docs/bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md`

## 先摸清：那条跨 isolate 竞态今天**不可达**

TODO-2580 描述的「弹窗独立 isolate 跨不过 `waitForPendingIndexing`」是**结构事实**（静态字段不跨 isolate 共享，`TtsChannel.instance` 也是 isolate-local 单例），但今天没有代码路径能走到：

- 桌面（Win/mac/Linux）**没有**第二个跑 `popupMain` 的 isolate——runner 全都只有一个 engine（`windows/runner/main.cpp:168` 等）；桌面「弹窗词典」是主 isolate 里的 Dialog（`app_model.dart:4357`），Windows 全局查词浮窗是原生 WebView2、桥消息回主 isolate。
- Android 确实有 `:popup` 独立进程，但 `_isSupported == Platform.isAndroid` 为真 → 走 native `TtsChannelHandler`，**Dart 的 `ensureIndexes` 根本不执行**。
- 「桌面跑 Dart 建索引」与「存在第二 isolate」两个条件从不同时成立。

所以本 PR **刻意不造**跨 isolate 在途登记——那是在解决一个不存在的问题。价值按任务预期从「修竞态」转为「修那个吞异常的 catch」。

## 真正可达的是同一个「同形 null」的另一条边

1. `local_audio_db.dart` 的 `catch → return null` 把 `SQLITE_BUSY` 压成与真·未命中**逐字节同形**的 null。
2. 更要命：查词/制卡链对 `queryLocalAudio` 套 `.timeout(500ms)`，**比只读连接自己的 `busy_timeout = 3000` 更短**——库一忙永远是它先到点，sqlite 异常压根抛不出来，而 `on TimeoutException { return null; }` **连一条日志都不记**。
3. 可达窗口：`initialise()` 里 `unawaited(ensureIndexes)` 不阻塞 init，而首次大库建索引可达数秒 → **app 启动后头几秒的查词发音静默落空**，用户只看到「暂无发音」。

确定性实测：另一 isolate 持 `BEGIN EXCLUSIVE` 时，查一个库里**确实有**的词，`queryMeta` 在 **3157ms** 后返回 `null`——与查一个库里**确实没有**的词返回的 `null` 完全同形。

## 修法：把「没有答案」从一个**值**改成一个**类型**

沿用远端音源既有的 `RemoteLookupUnreachableError` 同款分工（不可达/没答上抛异常、可达但确实没有返回 null），不新造第二种概念：

| 文件 | 改动 |
|---|---|
| `local_audio_db.dart` | 新增 `LocalAudioUnavailableError` + `Reason{busy,timedOut}`；`queryMeta`/`extractBlob` 对 `SQLITE_BUSY(5)`/`LOCKED(6)` 抛可区分类型；非 BUSY 的**稳定**故障（缺表/损坏）保持既有 log + null |
| `tts_channel.dart` | catch-all 前 `rethrow`，穿透 `Isolate.run` 边界（已实测自定义异常可原样回传） |
| `lookup_audio_playback.dart` | 500ms 提为共享常量 `kLocalAudioQueryBudget`；超时改抛 unavailable。**预算值本身不动**，改的是它的含义：「没查出来」≠「查出来没有」 |
| `word_audio_resolver.dart` | 接住后记一条**用户可见**错误日志（设置 → 诊断 → 错误日志）再走下一源 |
| `local_audio_enhancement.dart` | 制卡链同样接住并留痕，不崩制卡 |

**没有加延迟/重试/sleep，也没有调大 `busy_timeout`**——调大是典型假修复，只让撞上的概率变小、同形问题一点没变（守卫钉死两处 `busy_timeout = 3000` 不得被调大）。

`word_audio_resolver` 刻意**不**给本地库套远端那套失败冷却：本地忙是瞬态（建索引完就好），冷却 45s 会把小问题放大成「这段时间该库全哑」。

## 测试

`hibiki/test/utils/misc/local_audio_busy_vs_miss_test.dart`（9 例）：另一个 isolate 持 `BEGIN EXCLUSIVE` 造**确定性** BUSY（非时间赛跑）→ 断言 `queryMeta`/`extractBlob` 撞锁抛 busy、真·未命中仍 null、放锁后立刻恢复；断言该类型能穿透 `Isolate.run`；resolver 三例区分「没答上」（记日志）与「没有这个词」（不污染日志）；源码守卫钉死超时分支与 `busy_timeout`。

**变异实测 4 次**（每次只改语义关键的一小处、均能编译，反向替换还原）：
1. `_isBusy` 的 5/6 → 55/66 ⇒ 3 条行为用例红、源码守卫仍绿（证明行为守卫不与字符串守卫重复）
2. 删 `TtsChannel` 的 `rethrow` ⇒ 只有「穿透 Isolate.run」红
3. 短路 resolver 的日志调用 ⇒ 只有「记用户可见错误日志」+「blob 提取阶段」红
4. `on TimeoutException` 改回 `return null` ⇒ 只有对应源码守卫红

## 门禁

- `flutter analyze`（含 test）：`No issues found!`
- 定向：`PASSED - 741 tests ran`（`test/utils/misc` + 本地音频/查词/制卡相邻）、`PASSED - 42 tests ran`（`grep -l` 反查出的 20 个守卫文件中余下 4 个）、`PASSED - 3 tests ran`（bug 文档 per-file 守卫）
- ⚠️ 扩到 `test/tools` 时有 1 条红：`test/build/libmpv_truehd_guard_test.dart:62` 的手写注释剥离。**不是本 PR 引入**——该文件我未触碰，且当前 `origin/develop` 上该模式已被另一线程修掉（`startsWith('//')` 计数为 0），rebase 后自然消失。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH

