### PR TITLE
test(guard): TODO-2477 消掉 15 处手写注释剥离，统一走 source_guard 词法原语

### DIFF
--- a/hibiki/test/build/windows_vendored_mpv_angle_guard_test.dart
+++ b/hibiki/test/build/windows_vendored_mpv_angle_guard_test.dart
@@ -1,8 +1,9 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
 
 /// TODO-1172 source-scan guard: the Windows media_kit video libraries (libmpv +
 /// ANGLE) are vendored into the repo so a clean Windows build is fully
@@ -37,12 +38,11 @@ void main() {
     return m!.group(1)!;
   }
 
-  // CMake source with comment lines stripped, so the download regression guards
-  // match real commands and never a mention of file(DOWNLOAD) in a comment.
-  String codeOnly(String text) => const LineSplitter()
-      .convert(text)
-      .where((String line) => !line.trimLeft().startsWith('#'))
-      .join('\n');
+  // CMake source with comments masked, so the download regression guards match
+  // real commands and never a mention of file(DOWNLOAD) in a comment.
+  // TODO-2477: shared maskHashComments — equal-length masking that also strips
+  // trailing `# ...` comments, which the old whole-line filter let through.
+  String codeOnly(String text) => maskHashComments(text);
 
   void expectRealSevenZip(File archive) {
     expect(archive.existsSync(), isTrue,

--- a/hibiki/test/build/workflow_sed_inplace_portability_guard_test.dart
+++ b/hibiki/test/build/workflow_sed_inplace_portability_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1353 守卫：跑在 macOS runner 上的 workflow 作业不得使用裸 `sed -i`。
 ///
 /// BSD/macOS 的 sed 与 GNU sed 在 `-i` 上语义不同：BSD 的 `-i` **必须**带备份
@@ -25,6 +27,9 @@ void main() {
   /// `log_upload_workflow_injection_guard_test.dart`）都是纯文本扫描，保持一致。
   List<MapEntry<String, String>> splitJobs(String source) {
     final List<String> lines = source.split('\n');
+    // 注释判定走共享等长掩码（行号/列宽与原文一一对应）；正文仍写入**原文**行，
+    // 报错信息要显示真实内容。
+    final List<String> masked = maskHashComments(source).split('\n');
     final int jobsAt = lines.indexWhere((String l) => l.trimRight() == 'jobs:');
     if (jobsAt < 0) return const <MapEntry<String, String>>[];
 
@@ -48,8 +53,9 @@ void main() {
         currentName = header.group(1);
         continue;
       }
-      // 顶层 key（零缩进非空行）代表 jobs: 段结束。
-      if (line.isNotEmpty && !line.startsWith(' ') && !line.startsWith('#')) {
+      // 顶层 key（零缩进非空行）代表 jobs: 段结束。整行注释在掩码后只剩空白，
+      // 于是天然不会被当成顶层 key（旧写法靠手判 `startsWith('#')`）。
+      if (masked[i].trim().isNotEmpty && !masked[i].startsWith(' ')) {
         flush();
         currentName = null;
         break;
@@ -99,9 +105,11 @@ void main() {
 
       for (final MapEntry<String, String> job in splitJobs(source)) {
         if (!mayRunOnMacos(job.value)) continue;
-        for (final String line in job.value.split('\n')) {
-          // 注释行不算实际命令。
-          if (line.trimLeft().startsWith('#')) continue;
+        // 注释行不算实际命令：走共享等长掩码，顺带掩掉行尾 `# ...`（旧写法只跳
+        // 整行注释），且引号内的 `#`（`sed 's/#x/y/'`）不会被误当注释抹半条命令。
+        // 注意只掩**命令扫描**这一侧：mayRunOnMacos 仍看原文，保持「宁可严、
+        // 不可漏」——被注释掉的 runs-on: macos 依旧让该作业纳入检查范围。
+        for (final String line in maskHashComments(job.value).split('\n')) {
           if (bareInPlace.hasMatch(line)) {
             offenders.add('${job.key}: ${line.trim()}');
           }
@@ -121,9 +129,10 @@ void main() {
     final List<String> offenders = <String>[];
 
     for (final File workflow in workflows) {
-      for (final String line in workflow.readAsStringSync().split('\n')) {
+      for (final String line in maskHashComments(
+        workflow.readAsStringSync(),
+      ).split('\n')) {
         if (!line.contains(marker)) continue;
-        if (line.trimLeft().startsWith('#')) continue;
         injectionSites++;
         if (!line.contains('sed -i.bak ')) {
           offenders.add('${workflow.uri.pathSegments.last}: ${line.trim()}');

--- a/hibiki/test/focus/media_page_focus_ownership_guard_test.dart
+++ b/hibiki/test/focus/media_page_focus_ownership_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 架构守卫：媒体页（视频 / 阅读器）把键盘焦点的回收**全部**交给
 /// `PageFocusOwnership`，不得再各自裸调 `requestFocus`。
 ///
@@ -44,13 +46,10 @@ void main() {
         .where((File f) => f.path.endsWith('.dart'));
   }
 
-  /// 剥掉 `//` 注释（整行与行尾）——注释里合法地讲解 `requestFocus`，扫的是代码。
-  /// 唯一已知误差：字符串里的 `//`（如 URL）会把该行剩余截掉；`requestFocus`
-  /// 不会出现在 URL 之后，故不影响本守卫。
-  String codeOnly(String source) => source.split('\n').map((String line) {
-        final int at = line.indexOf('//');
-        return at < 0 ? line : line.substring(0, at);
-      }).join('\n');
+  /// 剥掉注释——注释里合法地讲解 `requestFocus`，扫的是代码。
+  /// TODO-2477：走共享词法掩码，串里的 `//`（URL）不再把该行剩余截掉，
+  /// 块注释也一并掩掉（旧写法对 `/* requestFocus() */` 零覆盖）。
+  String codeOnly(String source) => maskComments(source);
 
   test('媒体页不得绕过 PageFocusOwnership 裸调 requestFocus', () {
     final List<String> violations = <String>[];

--- a/hibiki/test/helpers/source_guard_lexer_test.dart
+++ b/hibiki/test/helpers/source_guard_lexer_test.dart
@@ -438,6 +438,28 @@ final String js = \'\'\'
       expect(maskJsComments(js).contains('keepMe'), isTrue);
     });
 
+    test('已知边界：`)` 之后的正则被当成除号（TODO-2477 复核结论）', () {
+      // `/` 是正则还是除号，只能靠前一个有意义 token 判。`)` 有意**不在**
+      // _kJsRegexAllowedAfter 里，因为 `(a+b)/2` 是除法，而「if 条件收口后紧跟
+      // 正则」在真实代码里罕见。代价是下面这种写法会被读成「除号 + 行注释」，
+      // 从 `//` 起到行尾整段被掩掉。
+      //
+      // 全仓 66 个真实 .js 资产扫下来没有一处命中（TODO-2477 实测），所以保持
+      // 现状；真要修得引入表达式上下文/ASI 跟踪，代价远大于收益。这条用例把
+      // 边界钉住：谁哪天真去修了，它会红，提醒同步更新这段说明。
+      const String js = 'if (a) /x://y/.test(b); keepMe;';
+      expect(maskJsComments(js).contains('keepMe'), isFalse,
+          reason: '这是已知且有意的取舍，不是回归；改动前先读上面的说明');
+      // 反过来：`(`、`=`、`[`、`return` 之后的正则都判得对，含 `\/` 转义斜杠。
+      for (final String ok in <String>[
+        r't(/x:\/\/y/); keepMe;',
+        r'var re = /a:\/\/b/; keepMe;',
+        r'return /a:\/\/b/.test(s); keepMe;',
+      ]) {
+        expect(maskJsComments(ok).contains('keepMe'), isTrue, reason: ok);
+      }
+    });
+
     test('maskJsCommentsAndStrings 掩掉串内容但保留结构括号', () {
       const String js = "function f() { const s = '}{'; return 1; }";
       final String structural = maskJsCommentsAndStrings(js);

--- a/hibiki/test/lookup/global_lookup_inapp_isolation_guard_test.dart
+++ b/hibiki/test/lookup/global_lookup_inapp_isolation_guard_test.dart
@@ -1,7 +1,8 @@
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
 
 /// TODO-867 P3b/P3c — guards isolating the app-OUTSIDE nested-stack host
 /// (global_lookup_host.js + buildStackRenderScript) from the in-app popup.
@@ -562,15 +563,12 @@ void main() {
       // The layout math is CSS / logical px throughout; the only dpr boundary is
       // C++ window geometry / the WH_MOUSE_LL hook. So neither host.js nor the
       // pure layout function may multiply/divide by a device pixel ratio.
-      // Strip // line comments first (the Chinese docs legitimately mention
-      // "dpr" to EXPLAIN the rule); the CODE must carry no dpr arithmetic.
+      // Strip comments first (the Chinese docs legitimately mention "dpr" to
+      // EXPLAIN the rule); the CODE must carry no dpr arithmetic. TODO-2477:
+      // shared lexical mask — block comments and `//` inside string literals
+      // are both handled, which the old per-line indexOf('//') got wrong.
       final String layoutRaw = read('lib/src/lookup/global_lookup_layout.dart');
-      final StringBuffer codeOnly = StringBuffer();
-      for (final String line in const LineSplitter().convert(layoutRaw)) {
-        final int c = line.indexOf('//');
-        codeOnly.writeln(c >= 0 ? line.substring(0, c) : line);
-      }
-      final String layoutCode = codeOnly.toString();
+      final String layoutCode = maskComments(layoutRaw);
       for (final String token in <String>[
         'dpr',
         'devicePixelRatio',

--- a/hibiki/test/media/media_cover_write_guard_test.dart
+++ b/hibiki/test/media/media_cover_write_guard_test.dart
@@ -32,6 +32,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 
+import '../helpers/source_guard.dart';
+
 void main() {
   final Directory libDir = Directory('lib');
 
@@ -73,9 +75,9 @@ void main() {
     // 原始写盘调用（对文件的写/拷/换名）。
     final RegExp rawWrite =
         RegExp(r'writeAsBytes\(|\.copy\(|\.rename\(|openWrite\(');
-    // 行注释（含 doc 注释）里的提法不算调用：逐行剥掉 `//` 之后再匹配，
-    // 否则「见 VideoStorage.coversDir()」这类文档引用会误报。
-    final RegExp lineComment = RegExp(r'//.*$', multiLine: true);
+    // 注释（行注释 / doc / 块注释）里的提法不算调用：先做共享词法掩码再匹配，
+    // 否则「见 VideoStorage.coversDir()」这类文档引用会误报。TODO-2477：旧写法是
+    // 删除式 `replaceAll(RegExp(r'//.*$'), '')`，块注释与串里的 `//` 两个方向都错。
     const Set<String> allowed = <String>{
       // 收口自身。
       'lib/src/media/media_cover_service.dart',
@@ -89,7 +91,7 @@ void main() {
       if (allowed.contains(path)) continue;
       // 互联层远端封面本轮不收编（协议 coverUrl 冻结，W 系列另册处理）。
       if (path.startsWith('lib/src/sync/')) continue;
-      final String src = f.readAsStringSync().replaceAll(lineComment, '');
+      final String src = maskComments(f.readAsStringSync());
       if (!destMarker.hasMatch(src)) continue;
       if (!rawWrite.hasMatch(src)) continue;
       if (src.contains('MediaCoverService.applyCover')) continue;
@@ -116,7 +118,6 @@ void main() {
     };
     final RegExp rawWrite =
         RegExp(r'writeAsBytes\(|\.copy\(|\.rename\(|openWrite\(');
-    final RegExp lineComment = RegExp(r'//.*$');
     // 顶层声明 / 类成员声明的行首标识（`static Future<void> applyCoverBytes({`、
     // `Future<String?> downloadVideoCoverToPath({` 等）：缩进 ≤2 且缩进之后**立刻**
     // 是标识符，取 `(` / `{` 前的最后一个标识符为函数名。缩进阈值把函数体里的
@@ -126,13 +127,16 @@ void main() {
         RegExp(r'^ {0,2}(?:static )?(?:[\w<>?,]+ )+(\w+)\s*[({]');
 
     allowedRawWriters.forEach((String path, Set<String> allowed) {
-      final List<String> lines = File(path).readAsLinesSync();
+      // 先等长掩码再按行切：块注释与串里的 `//` 都掩得掉，且列宽与原文一致，
+      // 所以 declaration 正则仍能在掩码行上正确匹配（代码本身原样保留）。
+      final List<String> lines =
+          maskComments(File(path).readAsStringSync()).split('\n');
       final Set<String> found = <String>{};
       String current = '<file-scope>';
       for (final String line in lines) {
         final RegExpMatch? decl = declaration.firstMatch(line);
         if (decl != null) current = decl.group(1)!;
-        if (rawWrite.hasMatch(line.replaceAll(lineComment, ''))) {
+        if (rawWrite.hasMatch(line)) {
           found.add(current);
         }
       }

--- a/hibiki/test/mining/magpie_bundled_install_test.dart
+++ b/hibiki/test/mining/magpie_bundled_install_test.dart
@@ -15,6 +15,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/mining/magpie_installer.dart';
 import 'package:path/path.dart' as p;
 
+import '../helpers/source_guard.dart';
+
 /// 造一个内容合法的最小 Magpie 包：三个必需根文件 + effects 目录。
 List<int> _buildFakeMagpieZip() {
   final Archive archive = Archive();
@@ -228,7 +230,10 @@ void main() {
       final List<String> callers = <String>[];
 
       for (final File file in _workflowFiles()) {
-        final List<String> lines = file.readAsLinesSync();
+        // 注释判定走共享等长掩码（YAML / PowerShell 的 `#`）：行号与列宽同原文
+        // 一一对应，下面按行号定位 step 边界的逻辑不受影响。
+        final List<String> lines =
+            maskHashComments(file.readAsStringSync()).split('\n');
         for (int index = 0; index < lines.length; index++) {
           final String line = lines[index];
           if (!line.contains(scriptPath)) continue;
@@ -262,7 +267,8 @@ void main() {
           int nextCommand = index + 1;
           while (nextCommand < stepEnd) {
             final String candidate = lines[nextCommand].trim();
-            if (candidate.isNotEmpty && !candidate.startsWith('#')) break;
+            // 掩码后整行注释只剩空白，故「非空」即「是真命令行」。
+            if (candidate.isNotEmpty) break;
             nextCommand++;
           }
           expect(nextCommand, lessThan(stepEnd),

--- a/hibiki/test/mining/remote_mining_animated_format_test.dart
+++ b/hibiki/test/mining/remote_mining_animated_format_test.dart
@@ -7,6 +7,8 @@ import 'package:hibiki/src/mining/immersion_mining_engine.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1330：浏览器扩展的远端制卡（YouTube / Netflix）过去完全不读动图格式偏好，恒出 GIF。
 ///
 /// 本文件钉死三件事：
@@ -300,10 +302,7 @@ void main() {
 
     /// 剥掉注释再扫「不得出现」的字面量。散文里为解释 bug 必然会写出 `clip.gif` 这类
     /// 触发词，让文档把守卫扫红是假阳性；判据只应落在真实代码上。
-    String codeOnly(String src) => src.split('\n').map((String line) {
-          final int i = line.indexOf('//');
-          return i < 0 ? line : line.substring(0, i);
-        }).join('\n');
+    String codeOnly(String src) => maskComments(src);
 
     test('mineImmersion 读 videoMiningAnimatedFormat 并成对下发', () {
       final String src = libFile('lib/src/models/app_model.dart');

--- a/hibiki/test/mining/remote_mining_image_mode_test.dart
+++ b/hibiki/test/mining/remote_mining_image_mode_test.dart
@@ -7,6 +7,8 @@ import 'package:hibiki/src/mining/immersion_mining_request.dart';
 import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart'
     show MiningMediaCompression, FfmpegFailureReporter;
 
+import '../helpers/source_guard.dart';
+
 /// TODO-2519(2a)：远端制卡的 **YouTube** 路径过去只透传了动图**格式**偏好
 /// （`videoMiningAnimatedFormat`，BUG-1330），却没透传「动图 vs 静态帧」偏好
 /// （`videoMiningImageMode`）——用户在 Anki 设置里选「字幕开头截图 / 制卡时截图」，
@@ -176,10 +178,7 @@ void main() {
   group('源码扫描守卫：mineImmersion 的 YouTube 段必须下发 imageMode', () {
     /// 剥掉注释再扫。散文里为解释这条断链必然写出同样的符号名，让文档把守卫喂绿是
     /// 假阳性；判据只应落在真实代码上。
-    String codeOnly(String src) => src.split('\n').map((String line) {
-          final int i = line.indexOf('//');
-          return i < 0 ? line : line.substring(0, i);
-        }).join('\n');
+    String codeOnly(String src) => maskComments(src);
 
     test('ImmersionMiningRequest 收 _appModel.videoMiningImageMode', () {
       final String src =

--- a/hibiki/test/reader/reader_content_styles_test.dart
+++ b/hibiki/test/reader/reader_content_styles_test.dart
@@ -8,6 +8,8 @@ import 'package:hibiki/src/reader/reader_content_styles.dart';
 import 'package:hibiki/src/reader/reader_settings.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 
+import '../helpers/source_guard.dart';
+
 Future<ReaderSettings> _defaultSettings() async {
   final HibikiDatabase db = HibikiDatabase.forTesting(NativeDatabase.memory());
   addTearDown(db.close);
@@ -447,7 +449,10 @@ void main() {
       for (final String mode in <String>['vertical-rl', 'horizontal-tb']) {
         final ReaderSettings settings = await _defaultSettings();
         await settings.setWritingMode(mode);
-        final String css = ReaderContentStyles.css(settings: settings);
+        // TODO-2477：先做共享 CSS 词法掩码，块注释（含跨行、含花括号的）不再
+        // 参与 blockPattern 配对，也不必在逐行处手判 `/*` 开头。
+        final String css =
+            maskCssComments(ReaderContentStyles.css(settings: settings));
 
         int enforcedBlocks = 0;
         for (final RegExpMatch block in blockPattern.allMatches(css)) {
@@ -459,7 +464,7 @@ void main() {
           enforcedBlocks++;
           for (final String line in block.group(2)!.split('\n')) {
             final String trimmed = line.trim();
-            if (trimmed.isEmpty || trimmed.startsWith('/*')) continue;
+            if (trimmed.isEmpty) continue;
             if (trimmed.startsWith('--')) continue; // 自定义变量本身不参与布局。
             final RegExpMatch? decl = declPattern.firstMatch(trimmed);
             if (decl == null) continue;

--- a/hibiki/test/reader/reader_selection_action_bar_nonmodal_guard_test.dart
+++ b/hibiki/test/reader/reader_selection_action_bar_nonmodal_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 String _between(String source, String start, String end) {
   final int startAt = source.indexOf(start);
   final int endAt = source.indexOf(end, startAt + start.length);
@@ -11,11 +13,7 @@ String _between(String source, String start, String end) {
   return source.substring(startAt, endAt);
 }
 
-String _withoutLineComments(String source) =>
-    source.split('\n').map((String line) {
-      final int at = line.indexOf('//');
-      return at < 0 ? line : line.substring(0, at);
-    }).join('\n');
+String _withoutLineComments(String source) => maskComments(source);
 
 void main() {
   final String chrome =

--- a/hibiki/test/reader/vn_blank_tap_chrome_reveal_bug1195_test.dart
+++ b/hibiki/test/reader/vn_blank_tap_chrome_reveal_bug1195_test.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_chrome_floating.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1195：视觉小说（VN）模式点屏幕只会翻页，控制栏（菜单）永远唤不出来。
 ///
 /// 根因：VN 是唯一把「点空白」绑成翻页的 view-mode，旧实现在 JS 的 `_gestureEnd`
@@ -321,9 +323,4 @@ String _vnBlankTapBody(String chrome) {
 
 /// 去掉行注释（Dart 与注入 JS 同用 `//`），使守卫只看真代码——注释里正当地引用了
 /// 被修掉的旧写法。
-String _stripLineComments(String source) {
-  return source.split('\n').map((String line) {
-    final int idx = line.indexOf('//');
-    return idx >= 0 ? line.substring(0, idx) : line;
-  }).join('\n');
-}
+String _stripLineComments(String source) => maskCommentsAndScriptLines(source);

--- a/hibiki/test/settings/settings_redesign_static_test.dart
+++ b/hibiki/test/settings/settings_redesign_static_test.dart
@@ -690,12 +690,12 @@ String _statementAround(String code, String needle) {
 }
 
 /// YAML 里是否有一条**未被注释掉**的行含 [key]。
+///
+/// TODO-2477：注释判定走共享 [maskHashComments]（等长掩码，且认引号状态，
+/// `sed 's/#x/y/'` 这类引号内的 `#` 不会被当注释把半条命令抹掉）。
 bool _yamlDeclares(String yaml, String key) {
-  for (final String line in yaml.split('\n')) {
-    if (line.trimLeft().startsWith('#')) continue;
-    final int hash = line.indexOf('#');
-    final String code = hash >= 0 ? line.substring(0, hash) : line;
-    if (code.contains(key)) return true;
+  for (final String line in maskHashComments(yaml).split('\n')) {
+    if (line.contains(key)) return true;
   }
   return false;
 }

--- a/hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart
+++ b/hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart
@@ -2,66 +2,17 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 剥除 Dart 源码里的注释，只保留真实代码，避免静态守卫把文档注释（`///`）/行注释
 /// （`//`）/块注释（`/* */`）里出现的示例文字（如反引号包裹的 `windowManager.show()`）
 /// 误判为真实调用（TODO-972：CI 静态守卫误报）。
 ///
-/// 实现是一个字符级状态机，能识别字符串字面量（`'...'` / `"..."`，含 `r''` 原始串与
-/// `\` 转义），不会把字符串里出现的 `//` 误删，从而保留对真实调用的检测能力。
-/// 注释字符用空格替换（保留长度/换行的相对结构对本守卫无关紧要，但避免把相邻 token
-/// 粘连）。
-String stripDartComments(String src) {
-  final StringBuffer out = StringBuffer();
-  final int n = src.length;
-  int i = 0;
-  while (i < n) {
-    final String c = src[i];
-    final String next = i + 1 < n ? src[i + 1] : '';
-
-    // 行注释 // 或 /// —— 跳到行尾（保留换行）。
-    if (c == '/' && next == '/') {
-      while (i < n && src[i] != '\n') {
-        i++;
-      }
-      continue;
-    }
-
-    // 块注释 /* ... */（含 /** 文档块）—— 跳到 */，保留其中换行以维持行结构。
-    if (c == '/' && next == '*') {
-      i += 2;
-      while (i < n && !(src[i] == '*' && i + 1 < n && src[i + 1] == '/')) {
-        if (src[i] == '\n') out.write('\n');
-        i++;
-      }
-      i += 2; // 跳过结尾 */
-      continue;
-    }
-
-    // 字符串字面量 '...' 或 "..." —— 整段原样保留，串内 // 不算注释。
-    if (c == '\'' || c == '"') {
-      final String quote = c;
-      out.write(c);
-      i++;
-      while (i < n) {
-        final String s = src[i];
-        out.write(s);
-        if (s == '\\' && i + 1 < n) {
-          // 转义序列：连同被转义字符一起原样写出，防止 \' / \" 提前终止。
-          out.write(src[i + 1]);
-          i += 2;
-          continue;
-        }
-        i++;
-        if (s == quote) break;
-      }
-      continue;
-    }
-
-    out.write(c);
-    i++;
-  }
-  return out.toString();
-}
+/// 实现委托给共享词法掩码 [maskComments]（TODO-2477）：原先这里手写了一份字符级
+/// 状态机，行为与共享版一致但各自维护——本仓已因「每个守卫各写一份剥离逻辑」
+/// 反复出过假绿。共享版额外保证**等长掩码**（注释换成等量空白而非删除），
+/// 下标可直接回原串切片。
+String stripDartComments(String src) => maskComments(src);
 
 void main() {
   String read(String path) => File(path).readAsStringSync();

--- a/hibiki/test/sync/tls/hibiki_pinning_guard_test.dart
+++ b/hibiki/test/sync/tls/hibiki_pinning_guard_test.dart
@@ -2,55 +2,20 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/source_guard.dart';
+
 /// TODO-961 M0 设计稿 2.7 源码守卫：lib/src/sync/ 下禁止出现无条件放行证书
 /// 的 badCertificateCallback / onBadCertificate（写松 = 自以为加密、实则比
 /// 明文更危险）。pinned client 的回调只能做指纹相等才 true。
 
-/// 字符级剥除 Dart 注释，避免把文档/行/块注释里的示例文字误判为违规。
-String stripDartComments(String src) {
-  final StringBuffer out = StringBuffer();
-  final int n = src.length;
-  int i = 0;
-  while (i < n) {
-    final String c = src[i];
-    final String next = i + 1 < n ? src[i + 1] : '';
-    if (c == '/' && next == '/') {
-      while (i < n && src[i] != '\n') {
-        i++;
-      }
-      continue;
-    }
-    if (c == '/' && next == '*') {
-      i += 2;
-      while (i < n && !(src[i] == '*' && i + 1 < n && src[i + 1] == '/')) {
-        if (src[i] == '\n') out.write('\n');
-        i++;
-      }
-      i += 2;
-      continue;
-    }
-    if (c == '\\' || c == '"') {
-      final String quote = c;
-      out.write(c);
-      i++;
-      while (i < n) {
-        final String s = src[i];
-        out.write(s);
-        if (s == '\\' && i + 1 < n) {
-          out.write(src[i + 1]);
-          i += 2;
-          continue;
-        }
-        i++;
-        if (s == quote) break;
-      }
-      continue;
-    }
-    out.write(c);
-    i++;
-  }
-  return out.toString();
-}
+/// 剥除 Dart 注释，避免把文档/行/块注释里的示例文字误判为违规。
+///
+/// TODO-2477：改为委托共享词法掩码 [maskComments]。原先这里手写的字符级状态机
+/// 有一处真实缺陷——判串起点写成 `c == '\' || c == '"'`，把**反斜杠**当成了
+/// 单引号，于是单引号串（Dart 源码里的绝大多数串）根本没被保护，串里的 `//`
+/// 会把该行剩余部分连同真实代码一起抹掉。共享版按 Dart 词法正确识别单/双引号、
+/// 三引号、`r` 原始串与转义。
+String stripDartComments(String src) => maskComments(src);
 
 void main() {
   test('stripDartComments 保留真实代码、剥除注释', () {

--- a/hibiki/test/widgets/dcomp_compositor_shutdown_guard_test.dart
+++ b/hibiki/test/widgets/dcomp_compositor_shutdown_guard_test.dart
@@ -2,17 +2,15 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// 剥掉 Dart 源码里的行注释（`//` 到行尾，含 `///` 文档注释），用于「先于 exit(0)
 /// 调用 native pre-exit hook」这类**代码顺序**断言：源文件的文档注释里常出现
 /// `` `exit(0)` `` 字面（如 desktop_lifecycle_service.dart 的方法说明），裸
 /// `indexOf('exit(0)')` 会命中注释而非真实代码调用，造成顺序误判（TODO-950）。
-/// 这些被守卫的源文件不含「字符串字面量里嵌 `//`」的情况，按行去尾注释即可。
-String _stripDartLineComments(String src) {
-  return src.split('\n').map((String line) {
-    final int idx = line.indexOf('//');
-    return idx >= 0 ? line.substring(0, idx) : line;
-  }).join('\n');
-}
+/// TODO-2477：改走共享词法掩码 [maskComments]——原先按行 `indexOf('//')` 截断，
+/// 块注释与串里的 `//`（URL）两个方向都判错；共享版等长掩码，下标仍可回原串。
+String _stripDartLineComments(String src) => maskComments(src);
 
 /// BUG-255 / TODO-313 Family B 源码守卫：vendored fork flutter_inappwebview_windows
 /// 的进程级 DirectComposition Compositor 单例必须在**受控退出时机**释放，绝不能


### PR DESCRIPTION
## 为什么（止血，不是清洁）

本会话四次「刚合的 PR 带进 develop 一条红」，其中两次是新 PR 手搓
`startsWith('//')` 之类的注释剥离被元守卫抓到。**只要仓库里还留着手搓样板，
新代码就会继续照抄它们。** 本轮把存量样板全部消干净，断掉复发源。

## 改了什么

自己扫的真实清单（判据：该文件是否**自己实现了**注释剥离，而不是调用 helper；
不止 `startsWith('//')`，还含字符级状态机、`indexOf('//')` 逐行截断、
`replaceAll(RegExp(r'//.*$'), '')` 删除式、`startsWith('#')` / `startsWith('/*')`）。

| 原形态 | 换成 | 文件 |
|---|---|---|
| 字符级状态机 ×2 | `maskComments` | `desktop_lookup_foreground_guard_static` / `hibiki_pinning_guard` |
| `indexOf('//')` 逐行截断 ×5 | `maskComments` | `dcomp_compositor_shutdown` / `media_page_focus_ownership` / `reader_selection_action_bar_nonmodal` / `global_lookup_inapp_isolation` / `remote_mining_animated_format` + `remote_mining_image_mode` |
| `RegExp(r'//.*$')` 删除式 ×2 | `maskComments` | `media_cover_write_guard` |
| `indexOf('//')`（Dart + 三引号 JS） | `maskCommentsAndScriptLines` | `vn_blank_tap_chrome_reveal_bug1195` |
| `startsWith('#')` ×5 | `maskHashComments` | `windows_vendored_mpv_angle` / `workflow_sed_inplace_portability`（3 处）/ `settings_redesign`（`_yamlDeclares`）/ `magpie_bundled_install` |
| `startsWith('/*')` | `maskCssComments` | `reader_content_styles` |

### 顺带修掉一个真缺陷

`hibiki_pinning_guard` 的手写状态机把串起点写成
`if (c == '\' || c == '"')` —— 用**反斜杠**冒充单引号。于是单引号串（Dart 里
绝大多数串）从未进入串状态，串里的 `//` 会把该行剩余的真代码一起抹掉。
这正是 TODO-2477 记的那类洞：「URL 之后的真违规静默消失 ⇒ 守卫假绿」。

### 两处刻意保守，避免把守卫改松

- `workflow_sed`：`mayRunOnMacos` 仍读**原文**（保持文档写明的「宁可严、不可漏」——
  被注释掉的 `runs-on: macos` 依旧让该作业进检查范围），只对命令扫描侧掩码。
- `splitJobs`：用等长掩码**判定**注释，正文仍写入原文行，报错信息不失真。

## 变异实测：32 例，全部符合预期

每例都改**真代码**（不塞注释里）、跑守卫、反向替换还原并校验字节 SHA-256 一致。

- **B 类**（破坏被守的真行为 → 必红）：15 例全红 ⇒ 迁移后守卫非空转、没变永真。
- **A 类**（把断言字面量塞进块注释 / 跨行块注释 / 行尾 `#` 注释 → 必绿）：12 例全绿。
  这些正是旧逐行写法会**误判为违规**的形态（旧 RED = 假阳性）。
- **A2 类**（`'https://x'` 之后紧跟真违规 → 必红）：2 例全红。
  旧写法在这里会被 URL 里的 `//` 骗成 **GREEN（假绿）**，正是 PR#651 坐实的那种洞。
- **假绿反向**（把要求的字面量只留在注释里 → 必须仍红）：2 例（`remote_mining` 两条）全红。

## 元守卫

`source_guard_adoption_test` **没有**靠白名单放行这 15 个文件（白名单一直只有 3 条，
且都是有具体理由的：helper 本体 / 模式表本体 / 被测对象自身契约断言）。变异实测：
新造一个第 16 个手搓文件 → 守卫报红并精确指出
`test/reader/mutation_probe_2477_16th_test.dart:5 用了 startsWith('//')`；删掉即回绿。
所以**无需清空白名单**，且守卫对新增文件的覆盖仍然有效。

## maskJsComments「能力缺口」结论

TODO-2477 记的这条**已经被现有实现闭合**：`_JsMasker` 已处理正则字面量、模板串、
`${}` 插值递归，并有 8 条专门词法用例。本轮做了实证复核：

- 全仓 **66 个真实 `.js` 资产**逐个跑 `maskJsComments`，三条不变量全部成立：
  等长 / 只把字符置为空白（绝不替换成别的字符）/ 幂等。
- 定向探针覆盖 `(`、`=`、`[`、`return` 之后的正则（含 `\/` 转义斜杠）——均判对。
- 仅存一处**有意**取舍：`)` 之后的正则被当成除号（因为 `(a+b)/2` 是除法）。
  仓内 66 个 JS 文件**零命中**；真要修需引入表达式上下文 / ASI 跟踪，代价远大于收益。
  已补一条用例把该边界钉死，将来谁修了它会红并提示同步更新说明。

## 范围与门禁

- **不改生产代码**（纯测试基础设施）；**未 bump `+build`**（整合线统一 bump）；**未合 develop**。
- 跳过清单见下方。
- `flutter analyze`（含 test 目录）：`No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub <16 个改动文件 + 元守卫 + 词法用例>`：
  `FLUTTER TEST VERDICT: PASSED - 274 tests ran, all tests passed`

## 按所有权跳过的文件

- `hibiki/test/pages/**`（另一施工线独占）——其中 `test/pages/popup_image_lightbox_close_guard_test.dart:38`
  **确有一处手搓 `indexOf('//')` 未迁**，留给该线或后续。
- PR#693 / #694 / #695 涉及文件（复核线在看）：经 `gh pr diff --name-only` 逐个比对，
  与本轮清单**无交集**，无需额外跳过。

## 不在本轮

TODO-2527 的定长字符窗口（86 处 / 57 文件）与 TODO-2477 记的「覆盖率洞」
（`gal_overlay` / `global_lookup_hotkey` / `reader_mining_race` 同一文件里部分断言无防护）
本轮未动。
