### PR TITLE
fix(test): manga.json 回写的 mokuro font_size 不再被 MD3 chrome 守卫误伤（修 develop CI 红, BUG-1414）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1318 条。点号进各自文件。
+> 共 1319 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1414](bugs/BUG-1414-md3-manga-fontsize-guard.md) | ✅ | ✅ | manga.json 回写触发 MD3 fontSize 守卫，develop CI 单测门变红 |
 | [BUG-1413](bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md) | ✅ | ✅ | 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null |
 | [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |
 | [BUG-1406](bugs/BUG-1406-libmpv-ffmpeg-version-guard-first-match.md) | ✅ | ✅ | libmpv FFmpeg 版本守卫只校验第一个匹配，单 ABI 静默降级不报红 |

--- a/docs/bugs/BUG-1414-md3-manga-fontsize-guard.md
+++ b/docs/bugs/BUG-1414-md3-manga-fontsize-guard.md
@@ -1,0 +1,11 @@
+## BUG-1414 · manga.json 回写触发 MD3 fontSize 守卫，develop CI 单测门变红
+- **报告**：2026-08-02（用户：项目负责人）
+- **真实性**：✅ 真 bug（CI 真红）。`Build Release APK` 的 `Run unit tests (main app)` 失败（run 30722983628，head a237e0551），verdict：`FAILED - flutter test exited with 1 ... Actual: ['lib/src/media/manga/manga_json_writeback.dart: fontSize:']`。本地在 origin/develop（ac1574b46）已复现。
+  - 守卫：`hibiki/test/settings/md3_design_system_static_test.dart` 的 `ordinary page chrome does not reopen local MD3 decisions`（禁用串表 `:664` 含 `fontSize:`，全 `lib/src` 子串扫描）。
+  - 命中行：`hibiki/lib/src/media/manga/manga_json_writeback.dart:142` 的 `fontSize: estimateMangaBlockFontSize(`（PR#692 引入）。
+  - **定性：守卫误伤，不是功能坏**。这个 `fontSize:` 是 mokuro 数据模型构造器 `MokuroBlock(...)` 的名参（`hibiki/lib/src/media/manga/mokuro_payload.dart:81/96`），落盘成 manga.json 的 `font_size` 字段（`mokuro_payload.dart:290`），唯一消费方是 `hibiki/lib/src/media/manga/manga_overlay_html.dart:46`：`(block.fontSize / pageWidth) * 100` 折算成 WebView 覆盖层的 CSS `cqi` 命中框字号。全文件零 `package:flutter/` import（`manga_json_writeback.dart:29-37`），不可能是页面 chrome。
+- **[x] ① 已修复** — 按守卫自己在失败信息里写明的机制（“add a reviewed allowlist reason for true content exceptions”）给 `manga_json_writeback.dart` 加一条写明理由的豁免，与已有三个同字段生产者（`mokuro_payload.dart` / `ocr/manga_ocr_folder_job.dart` / `media/manga/ocr/google_lens_ocr_service.dart`）同一 reviewed 豁免类。**生产代码零改动**（`git diff origin/develop -- hibiki/lib` 为空）。
+  - 为什么不改判据：`fontSize:` 与 `TextStyle(fontSize:)` 逐字符同形，要分辨只能知道外层构造器是谁，即把这个子串扫描器换成 Dart 语法分析——那是它有意不做的事。“没有 Flutter import 就跳过扫描”也不行：那是把扫描范围改小（把门禁变松），不是把判据改准。
+- **[x] ② 已加自动化测试** — 新增 `manga.json writeback stays a pure data layer`（同文件）：把豁免理由里“纯数据层、无 UI 代码”钉成可证伪断言（无 `package:flutter/` import、`fontSize:` 只允许是 `estimateMangaBlockFontSize(` 那一行、无 `TextStyle(`/`Card(`/`ListTile(`/`BorderRadius.circular(`/`surfaceContainer*`/`Widget build(`），防止整文件豁免退化成永久免检。
+  - 变异实测三个方向均已跑真：M1 在未豁免的 UI 文件（`media/metadata/scrape_failure_view.dart`）塞 `TextStyle(fontSize: 14)` → 扫描守卫转红；M2 往回写层塞 `package:flutter/material.dart` + `Card(` → 新守卫转红；M3 把回写层那行改成硬编码 `fontSize: 14` → 新守卫转红。三个变异均用反向文本替换还原，`git status` 零残留。
+- **备注**：存量三条同类豁免（mokuro_payload / manga_ocr_folder_job / google_lens_ocr_service）仍是整文件免检，没有本条这种可证伪钉子；另外 `manga_ocr_folder_job.dart:264` 的 `estimateMangaFontSize` 与本文件 `estimateMangaBlockFontSize` 是两份各自实现的同字段估算。两件都超出本次修红范围，未动。

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -786,6 +786,21 @@ void main() {
           'Estimates the MokuroBlock.fontSize data field (sqrt(area/chars)) '
               'for OCR-produced manga.json blocks; pure data layer, no UI '
               'code.',
+      // BUG-1414：PR#692 的框选回写是 manga.json 的**第四个生产者**，与上面三条
+      // 豁免的是同一个数据字段——`MokuroBlock(fontSize: …)` 落盘成 `font_size`，
+      // 由 manga_overlay_html.dart:46 折算成 WebView 覆盖层的 CSS `cqi` 命中框字号，
+      // 从不进任何 Flutter `TextStyle`。判据本身表达不了这个区分：那串禁用子串
+      // 与 `TextStyle(...)` 里的同名实参逐字符同形，要分辨只能知道外层构造器
+      // 是谁，也就是把这个子串扫描器换成 Dart 语法分析——那是它有意不做的事。
+      // 所以走守卫自己在失败信息里写明的机制（reviewed allowlist reason），
+      // 并由下面「manga.json 回写层保持纯数据层」把「无 UI 代码」这句话钉成可证伪
+      // 的断言，防止这条豁免退化成整文件免检。
+      'lib/src/media/manga/manga_json_writeback.dart':
+          'Writes the MokuroBlock.fontSize data field when appending a '
+              'user-drawn block to manga.json (estimate + serialize); pure '
+              'data layer with no Flutter import, same reviewed exception '
+              'class as mokuro_payload / manga_ocr_folder_job / '
+              'google_lens_ocr_service.',
       'lib/src/pages/implementations/reader_hibiki_page.dart':
           'Hoshi reader content and reader chrome have separate migration rules.',
       // TODO-589 batch1: reader_hibiki_page.dart 拆成主壳 + reader_hibiki/*.part.dart；
@@ -1168,6 +1183,45 @@ void main() {
       reason: 'Route ordinary visual chrome through shared MD3 components, or '
           'add a reviewed allowlist reason for true content exceptions.',
     );
+  });
+
+  // BUG-1414：上面 allowlist 里 manga_json_writeback.dart 的豁免理由是「纯数据层、
+  // 无 Flutter import」。理由只是一句散文，会随代码漂移；这条把它钉成可证伪的
+  // 断言——一旦有人往回写层塞 UI，豁免立刻失效，而不是继续静默免检。
+  test('manga.json writeback stays a pure data layer', () {
+    final String source = File(
+      'lib/src/media/manga/manga_json_writeback.dart',
+    ).readAsStringSync();
+    final String code = maskComments(source);
+
+    // 无 Flutter import ⇒ 这个文件里不可能存在页面 chrome。
+    expect(code, isNot(contains('package:flutter/')),
+        reason: 'manga_json_writeback.dart is allowlisted as a pure data '
+            'layer; a Flutter import invalidates that reason');
+
+    // 唯一的那个名参必须是 MokuroBlock 数据字段的估算写入，不是排版。
+    final List<String> dataFieldLines = code
+        .split('\n')
+        .where((String line) => line.contains('fontSize:'))
+        .map((String line) => line.trim())
+        .toList(growable: false);
+    expect(dataFieldLines, <String>['fontSize: estimateMangaBlockFontSize('],
+        reason: 'the allowlisted hit must stay the MokuroBlock data-field '
+            'write, not page typography');
+
+    for (final String chrome in const <String>[
+      'TextStyle(',
+      'Card(',
+      'ListTile(',
+      'BorderRadius.circular(',
+      'surfaceContainer',
+      'VisualDensity',
+      'PopupMenuButton(',
+      'Widget build(',
+    ]) {
+      expect(code, isNot(contains(chrome)),
+          reason: 'manga.json writeback must stay UI-free, found $chrome');
+    }
   });
 
   test('scrape failure detail uses the shared MD3 card and design tokens', () {


### PR DESCRIPTION
## 为什么

develop 的真单测门（`Build Release APK` → `tests` job → `Run unit tests (main app)`，run `30722983628`，head `a237e0551`）红：

```
FLUTTER TEST VERDICT: FAILED - flutter test exited with 1. ... (1 error event(s), 16982 test(s) completed).
  Expected: empty
    Actual: ['lib/src/media/manga/manga_json_writeback.dart: fontSize:']
```

守卫：`hibiki/test/settings/md3_design_system_static_test.dart` 的 `ordinary page chrome does not reopen local MD3 decisions`（禁用串表含 `fontSize:`，全 `lib/src` 子串扫描）。
offender：`hibiki/lib/src/media/manga/manga_json_writeback.dart:142`，PR#692 合入。

## 定性：守卫误伤，不是功能坏

- 那个 `fontSize:` 是 mokuro 数据模型构造器 `MokuroBlock(...)` 的名参（`mokuro_payload.dart:81/96`）；
- 落盘成 manga.json 的 `font_size` 字段（`mokuro_payload.dart:290`）；
- 唯一消费方 `manga_overlay_html.dart:46`：`(block.fontSize / pageWidth) * 100` → WebView 覆盖层的 CSS `cqi` 命中框字号，**从不进任何 Flutter `TextStyle`**；
- 该文件零 `package:flutter/` import（`manga_json_writeback.dart:29-37`）。

**生产代码零改动**（`git diff origin/develop -- hibiki/lib` 为空）。

## 为什么不是「改判据」而是 allowlist

`fontSize:` 与 `TextStyle(fontSize:)` 逐字符同形，要分辨只能知道外层构造器是谁，也就是把这个子串扫描器换成 Dart 语法分析——那是它有意不做的事。
「文件没有 Flutter import 就跳过扫描」也不行：那是把扫描范围改小（门禁变松），不是把判据改准。
所以走守卫**自己在失败信息里写明**的机制（`add a reviewed allowlist reason for true content exceptions`），与已有三个同字段生产者（`mokuro_payload.dart` / `ocr/manga_ocr_folder_job.dart` / `media/manga/ocr/google_lens_ocr_service.dart`）同一 reviewed 豁免类。

## 豁免不是白给：新增可证伪钉子

新增 `manga.json writeback stays a pure data layer`，把豁免理由里「纯数据层、无 UI 代码」变成断言：无 `package:flutter/` import、`fontSize:` 只允许是 `estimateMangaBlockFontSize(` 那一行、无 `TextStyle(` / `Card(` / `ListTile(` / `BorderRadius.circular(` / `surfaceContainer*` / `Widget build(`。整文件豁免因此不会退化成永久免检。

## 变异实测（三个方向都跑真）

| 变异 | 期望 | 实测 |
|---|---|---|
| M1：未豁免 UI 文件 `media/metadata/scrape_failure_view.dart` 塞 `TextStyle(fontSize: 14)` | 扫描守卫红 | ✅ 红：`Actual: ['lib/src/media/metadata/scrape_failure_view.dart: fontSize:']` |
| M2：回写层塞 `package:flutter/material.dart` + `Card(` | 新守卫红 | ✅ 红：`Expected: not contains 'package:flutter/'` |
| M3：回写层那行改成硬编码 `fontSize: 14` | 新守卫红 | ✅ 红：`Expected: ['fontSize: estimateMangaBlockFontSize('] / Actual: ['fontSize: 14,']` |

三个变异均以反向文本替换还原，`git status` 零残留（未对未提交文件用 `git checkout --`）。

## 门禁

- `flutter analyze`（含 test）：`No issues found! (ran in 38.0s)`，EXIT=0
- `flutter test test/tools/source_guard_adoption_test.dart test/media/manga/manga_json_writeback_test.dart test/settings/md3_design_system_static_test.dart --no-pub`：`+81: All tests passed!`，EXIT=0
- `dart format`：0 changed
- `dart run tool/bug.dart check`：`通过：1319 条，号唯一，索引同步`（push 前对 664 个远端 ref 重扫 `BUG-1414` 无撞号）

BUG-1414

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH