### PR TITLE
fix(media): override 书名/封面身份跟着书走，不跟着阅读器走 (BUG-1317)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -83,7 +83,7 @@
 | [BUG-1320](bugs/BUG-1320-clip-export-toolong-crosschapter-toast.md) | ✅ | ✅ | 片段导出超时长上限被误报为跨章且上限过紧 |
 | [BUG-1319](bugs/BUG-1319-collection-delete-cover-leak.md) | ✅ | ✅ | 删合集只有 1/6 入口回收自有封面：其余五条只删 DB 行，路径随行永久丢失、GC 又扫不到该子目录 = 确定性空间泄漏 |
 | [BUG-1318](bugs/BUG-1318-tracking-mapping-stale-after-format-change.md) | 🚧 | 🚧 | 转化后 Bangumi 映射不复核：epub→manga 后进度静默永久停报 |
-| [BUG-1317](bugs/BUG-1317-override-title-key-source-asymmetry.md) | 🚧 | 🚧 | 漫画/PDF 书改名后首页与统计仍显示旧名：override 键读写不同源 |
+| [BUG-1317](bugs/BUG-1317-override-title-key-source-asymmetry.md) | ✅ | ✅ | 漫画/PDF 书改名后首页与统计仍显示旧名：override 键读写不同源 |
 | [BUG-1316](bugs/BUG-1316-reader-route-ignores-live-format.md) | ✅ | ✅ | 跳回原文按写死的 EPUB 源打开：漫画/PDF 书用错阅读器 |
 | [BUG-1315](bugs/BUG-1315-texthooker-threadless-lines-never-published.md) | ✅ | ✅ | 未选线程门控把无线程身份的行（WebSocket/Textractor 端点）永久丢弃 |
 | [BUG-1311](bugs/BUG-1311-interconnect-service-config-403-on-plaintext.md) | ✅ | ✅ | 互联同步每轮都报「认证失败」：明文 host 上无条件请求 service-config |

--- a/docs/bugs/BUG-1317-override-title-key-source-asymmetry.md
+++ b/docs/bugs/BUG-1317-override-title-key-source-asymmetry.md
@@ -33,12 +33,45 @@
   转化新增的触发路径：一本 EPUB 书改过名后转成漫画，键从 `reader_ttu` 变成
   `reader_manga`，**书架侧也读不到了**，用户自定义书名与封面静默丢失。
 
-- **[ ] ① 未修复** — 正确语义是「override 跟着**书**走，不跟着阅读器走」，
-  故键里不该有源键。但 `override_title://...` 与缩略图 hashCode 文件名都是**存量
-  持久化键**，直接改会让所有既有 override 读不回来，需要迁移或读取期回退（读新
-  规范键 → 回退依次尝试三个旧源键）。属独立改动，不并进 BUG-1316。
+- **[x] ① 已修复** — 正确语义是「override 跟着**书**走，不跟着阅读器走」，
+  故键里不该有源键。**取读取期回退、不做迁移**（对象只是 preferences 键与缩略图
+  文件名 hash，读取期回退能完全规避 schema 迁移风险）。
 
-- **[ ] ② 未加自动化测试** —
+  施工时发现规划描述漏了一半：源键不只烧在 key 字符串里，还烧在**存储命名空间**
+  里——偏好落 `src:<sourceId>:<key>`（`media_source.dart` 的 `dbSourcePrefKey` +
+  `MediaSource._dbPrefKey`/`_loadPreferencesFromDb`），每个源一份独立缓存。所以
+  只把源键从 key 字符串里拿掉**并不能**让三源互相读到。
 
-- **备注**：`ReaderHibikiSource` 一侧还有个更小的自洽问题：`_overrideTitleForIdentifier`
-  即使不改键规范，也应按 bookKey 现查 format 后合成正确的源键，而不是恒 `reader_ttu`。
+  落地（`hibiki/lib/src/media/media_source.dart`）：
+  - `overrideStore`（默认 `this`）= override 的存储归属源；`ReaderMediaSource`
+    覆盖为 `ReaderHibikiSource.instance`，书族三源统一存一处。
+  - `legacyOverrideStores`（默认 `[this]`）= 读取期回退位置；`ReaderMediaSource`
+    覆盖为 EPUB / 漫画 / PDF 三源，每个元素同时提供旧命名空间宿主与旧键里的源键。
+  - 规范键 `override_title://<mediaIdentifier>`；规范封面文件名
+    `'<mediaIdentifier>/override_thumbnail'.hashCode`。
+  - 读书名 `getOverrideTitleFromMediaItem` 未命中即 `_adoptLegacyOverrideTitle`
+    回退，命中后就地重写进规范键并删旧键。读封面统一走新入口
+    `resolveOverrideThumbnailFile`，命中旧文件名即 `renameSync` 成规范名。
+  - 写 / 清除侧对称：`setOverrideTitleFromMediaItem` 与 `clearOverrideValues` 走
+    `clearOverrideTitle`（规范 + 全部旧位置），`setOverrideThumbnailFromMediaItem`
+    每次变更都 `_deleteLegacyOverrideThumbnails`——否则「清除」会被回退层复活。
+  - 消费点改走迁移感知入口：`reader_history/books.part.dart`（SRT 卡封面）、
+    `reader_hibiki_history_page.dart`（批量刮削「已有封面则跳过」判据）。
+
+  清理条件：一个版本后（存量已被读取期迁走）删掉 `legacyOverrideStores` 与全部
+  `legacy*` helper。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/media/override_identity_test.dart` 新增
+  两个 group（共 10 例，全部经变异实测确认能转红）：
+  - 书名侧：规范键不含源键 / 新键写入读出三源互见 / 三个旧源键各自回退并就地重写
+    成新键 / epub↔manga 转化后不丢 / 清除后旧位置不复活 /
+    书架·首页·统计·通知栏四个消费面同值。
+  - 封面侧：三源规范文件名同名 / 三个旧文件名各自回退并 rename 成规范名 /
+    转化后不丢 / 清除后旧文件名不复活。
+  另更新既有源码扫描守卫 `test/pages/booklongpress_floating_lyric_toggle_test.dart`
+  的锚点（SRT 卡封面必须走 `resolveOverrideThumbnailFile`）。
+
+- **备注**：`ReaderHibikiSource._overrideTitleForIdentifier` 恒填 `reader_ttu` 的
+  自洽问题一并消解——override 身份不再含源键，`legacyOverrideStores` 取自 `this`
+  （书族三源全在内），所以合成 item 填哪个源键都读到同一个值；已在该方法上加注释
+  说明。`reader_ttu` 等持久化 key 本身未动。

--- a/hibiki/lib/src/media/media_cover_service.dart
+++ b/hibiki/lib/src/media/media_cover_service.dart
@@ -21,7 +21,7 @@ import 'package:hibiki/src/utils/misc/gallery_image_picker.dart';
 ///
 /// | 岛 | 存储位置 | 键 / 文件名 | 覆盖规则 | 来源标记 |
 /// |---|---|---|---|---|
-/// | 书（override 缩略图） | `appModel.thumbnailsDirectory`（`<documents>/thumbnails`） | `'<mediaIdentifier>/<sourceId>/override_thumbnail'.hashCode`（无扩展名，[MediaSource.getOverrideThumbnailFilename]） | override 层：清除即回落源默认封面（EPUB 内嵌图等），不存在「保护」概念 | 无 |
+/// | 书（override 缩略图） | `appModel.thumbnailsDirectory`（`<documents>/thumbnails`） | `'<mediaIdentifier>/override_thumbnail'.hashCode`（无扩展名，[MediaSource.getOverrideThumbnailFilename]；BUG-1317 起**不含源键**，读取走 [MediaSource.resolveOverrideThumbnailFile] 以就地迁移旧的 `'<mediaIdentifier>/<sourceId>/override_thumbnail'` 文件名） | override 层：清除即回落源默认封面（EPUB 内嵌图等），不存在「保护」概念 | 无 |
 /// | 视频 | `<documents>/video_covers`（[VideoStorage.coversDir]） | `<sanitize(bookUid)>.jpg`（`videoCoverFileName`），与导入自动截帧同名同路径 | 手动封面写 [CoverOrigin.manual] 进 `cover_meta.json`，批量在线刮削**永不覆盖** manual | [CoverMeta]（autoFrame / manual / scraped / sidecar） |
 /// | 游戏 | `<documents>/game_covers`（`AppPaths.gameCoversDirectory`） | `<galgames.id>.<ext>`（换扩展名时先删旧文件，无孤儿） | 统一刮削弹窗**显式「使用」候选 = 覆盖下载**（`shouldDownloadExplicitScrapedCover`，与视频/书籍手动刮削同语义，2026-07-28 拍板）；自动/隐式路径只在无可用封面文件时下载（`shouldAutoDownloadScrapedCover`），绝不覆盖 | 无独立元数据（自动路径以「封面文件是否存在」为保护判据） |
 ///

--- a/hibiki/lib/src/media/media_source.dart
+++ b/hibiki/lib/src/media/media_source.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:cached_network_image/cached_network_image.dart';
@@ -370,14 +371,15 @@ abstract class MediaSource {
     String? fallbackUrl,
     bool noOverride = false,
   }) {
-    ImageProvider<Object>? overrideThumbnail =
-        getOverrideThumbnailFromMediaItem(
-      appModel: appModel,
-      item: item,
-    );
-
-    if (!noOverride && overrideThumbnail != null) {
-      return overrideThumbnail;
+    if (!noOverride) {
+      final ImageProvider<Object>? overrideThumbnail =
+          getOverrideThumbnailFromMediaItem(
+        appModel: appModel,
+        item: item,
+      );
+      if (overrideThumbnail != null) {
+        return overrideThumbnail;
+      }
     }
 
     if (item.imageUrl != null) {
@@ -414,14 +416,14 @@ abstract class MediaSource {
     required MediaItem item,
     bool noOverride = false,
   }) {
-    ImageProvider<Object>? overrideThumbnail =
-        getOverrideThumbnailFromMediaItem(
-      appModel: appModel,
-      item: item,
-    );
-
-    if (!noOverride && overrideThumbnail != null) {
-      return getOverrideThumbnailFilename(appModel: appModel, item: item);
+    if (!noOverride) {
+      final File? overrideFile = resolveOverrideThumbnailFile(
+        appModel: appModel,
+        item: item,
+      );
+      if (overrideFile != null) {
+        return overrideFile.path;
+      }
     }
 
     if (item.imageUrl != null) {
@@ -435,23 +437,81 @@ abstract class MediaSource {
     return '';
   }
 
+  // ── override 身份（BUG-1317）─────────────────────────────────────────
+  //
+  // override 书名 / 封面的身份是**条目**（`mediaIdentifier`），不是「用哪个阅读器
+  // 打开」。旧实现把源键烧进了两处：
+  //   1. key 字符串 `override_title://<src>/<src>/<mediaId>`——源键出现两次，因为
+  //      `MediaItem.uniqueKey` 自己就是 `<src>/<mediaId>`；封面同理，文件名是
+  //      `'<mediaId>/<src>/override_thumbnail'.hashCode`；
+  //   2. 存储命名空间——偏好落 `src:<src>:<key>`（[dbSourcePrefKey]），每个源一份
+  //      独立缓存，所以光把源键从 key 字符串里拿掉并不够。
+  //
+  // 而一本书的 `mediaSourceIdentifier` 由 `EpubBooks.format` **现算**
+  // （epub→`reader_ttu` / manga→`reader_manga` / pdf→`reader_pdf`，见
+  // `ReaderHibikiSource._bookToMediaItem`），三者共享同一 `hoshi://book/<bookKey>`
+  // 身份。于是同一本书在「书架用真实源」与「首页 / 统计 / 通知栏用合成的 EPUB 源」
+  // 两条路径上读到不同的键——改名后四处显示不一致；EPUB 转成漫画后连书架侧也读不
+  // 回来，用户自定义书名与封面静默丢失。
+  //
+  // 修法：规范位置 = [overrideStore] 的命名空间 + 只含 `mediaIdentifier` 的键；
+  // 读取期依次回退 [legacyOverrideStores] 里的旧位置，命中后**就地重写**成规范
+  // 位置。零 schema 迁移、零存量丢失。清理条件：一个版本后（存量已被读取期迁走）
+  // 删掉 [legacyOverrideStores] 与全部 legacy helper。
+
+  /// override（书名 / 封面）的**存储归属源**。默认归属自己。
+  ///
+  /// 共享同一 `mediaIdentifier` 命名空间的源族必须统一归一个源存，否则同一条目在
+  /// 不同源实例下落进不同的 `src:<sourceId>:` 偏好命名空间——见
+  /// `ReaderMediaSource.overrideStore`（书族三源全归 EPUB 源）。
+  MediaSource get overrideStore => this;
+
+  /// 读取期回退位置：规范位置未命中时依次尝试的**旧**存储。
+  ///
+  /// 每个元素同时提供两样东西：旧偏好命名空间的宿主实例，以及旧键 / 旧封面文件名
+  /// 里烧进去的那个源键（[uniqueKey]）。默认只有自己。
+  List<MediaSource> get legacyOverrideStores => <MediaSource>[this];
+
   /// The map key used to store the override title of an item.
-  String getOverrideTitleKey(MediaItem item) {
-    return 'override_title://${item.mediaSourceIdentifier}/${item.uniqueKey}';
-  }
+  ///
+  /// BUG-1317：只含 `mediaIdentifier`，不含任何源键——override 跟着**条目**走。
+  String getOverrideTitleKey(MediaItem item) =>
+      'override_title://${item.mediaIdentifier}';
+
+  /// BUG-1317 之前的旧书名键形态（源键出现两次）。只用于读取期回退与清除。
+  static String legacyOverrideTitleKey({
+    required String sourceId,
+    required String mediaIdentifier,
+  }) =>
+      'override_title://$sourceId/$sourceId/$mediaIdentifier';
 
   /// The map value used to store the override thumbnail of an item.
+  ///
+  /// BUG-1317：规范文件名只由 `mediaIdentifier` 派生。**读取请走
+  /// [resolveOverrideThumbnailFile]**——直接调本函数只拿得到规范路径，看不见还没
+  /// 迁移的存量旧文件。
   String getOverrideThumbnailFilename({
     required AppModel appModel,
     required MediaItem item,
-  }) {
-    String key =
-        '${item.mediaIdentifier}/${item.mediaSourceIdentifier}/override_thumbnail';
-    String basename = key.hashCode.toString();
-    String filename = path.join(appModel.thumbnailsDirectory.path, basename);
+  }) =>
+      _overrideThumbnailPath(
+        appModel,
+        '${item.mediaIdentifier}/override_thumbnail',
+      );
 
-    return filename;
-  }
+  /// BUG-1317 之前的旧封面文件名（把源键烧进 hashCode）。只用于读取期回退与清除。
+  String legacyOverrideThumbnailFilename({
+    required AppModel appModel,
+    required MediaItem item,
+    required String sourceId,
+  }) =>
+      _overrideThumbnailPath(
+        appModel,
+        '${item.mediaIdentifier}/$sourceId/override_thumbnail',
+      );
+
+  String _overrideThumbnailPath(AppModel appModel, String key) =>
+      path.join(appModel.thumbnailsDirectory.path, key.hashCode.toString());
 
   /// Given a [MediaItem], return its override display title.
   String? getOverrideTitleFromMediaItem(MediaItem item) {
@@ -459,10 +519,112 @@ abstract class MediaSource {
       return null;
     }
 
-    String key = getOverrideTitleKey(item);
-    String? overrideTitle =
-        getPreference<String?>(key: key, defaultValue: null);
-    return overrideTitle;
+    final String key = getOverrideTitleKey(item);
+    final String? current =
+        overrideStore.getPreference<String?>(key: key, defaultValue: null);
+    if (current != null) {
+      return current;
+    }
+    return _adoptLegacyOverrideTitle(item: item, canonicalKey: key);
+  }
+
+  /// BUG-1317 读取期回退：规范键无值时依次试旧键，命中即就地重写成规范键。
+  ///
+  /// 重写故意不 await：本函数在 `build()` 里被同步调用，而 [setPreference] /
+  /// [deletePreference] 的**内存缓存写发生在第一个 await 之前**，所以「下一次读
+  /// 已命中规范键」是同步可见的；落库是写穿，失败由它们内部记日志。
+  String? _adoptLegacyOverrideTitle({
+    required MediaItem item,
+    required String canonicalKey,
+  }) {
+    for (final MediaSource legacy in legacyOverrideStores) {
+      final String legacyKey = legacyOverrideTitleKey(
+        sourceId: legacy.uniqueKey,
+        mediaIdentifier: item.mediaIdentifier,
+      );
+      final String? value =
+          legacy.getPreference<String?>(key: legacyKey, defaultValue: null);
+      if (value == null) {
+        continue;
+      }
+      unawaited(overrideStore.setPreference<String?>(
+        key: canonicalKey,
+        value: value,
+      ));
+      unawaited(legacy.deletePreference(key: legacyKey));
+      return value;
+    }
+    return null;
+  }
+
+  /// 清除一个条目的 override 书名——规范位置 **与全部旧位置**。
+  ///
+  /// BUG-1317：不清旧位置的话，「清除改名」会被读取期回退当成存量重新读回来
+  /// （用户看到旧名复活），换新名则留下永不再读的孤儿行。
+  Future<void> clearOverrideTitle(MediaItem item) async {
+    await overrideStore.deletePreference(key: getOverrideTitleKey(item));
+    for (final MediaSource legacy in legacyOverrideStores) {
+      await legacy.deletePreference(
+        key: legacyOverrideTitleKey(
+          sourceId: legacy.uniqueKey,
+          mediaIdentifier: item.mediaIdentifier,
+        ),
+      );
+    }
+  }
+
+  /// BUG-1317：返回**实际存在**的 override 封面文件，没有则 null。
+  ///
+  /// 命中旧文件名（源键烧进 hash）时就地 rename 成规范文件名。所有消费点——书架卡 /
+  /// 编辑弹窗 / 刮削跳过判据 / [getThumbnailUri] /
+  /// [getOverrideThumbnailFromMediaItem]——都必须走本入口。
+  File? resolveOverrideThumbnailFile({
+    required AppModel appModel,
+    required MediaItem item,
+  }) {
+    final String canonical =
+        getOverrideThumbnailFilename(appModel: appModel, item: item);
+    final File canonicalFile = File(canonical);
+    if (canonicalFile.existsSync()) {
+      return canonicalFile;
+    }
+    for (final MediaSource legacy in legacyOverrideStores) {
+      final File legacyFile = File(legacyOverrideThumbnailFilename(
+        appModel: appModel,
+        item: item,
+        sourceId: legacy.uniqueKey,
+      ));
+      if (!legacyFile.existsSync()) {
+        continue;
+      }
+      try {
+        canonicalFile.parent.createSync(recursive: true);
+        return legacyFile.renameSync(canonical);
+      } catch (e, stack) {
+        ErrorLogService.instance
+            .log('MediaSource.adoptLegacyOverrideThumbnail', e, stack);
+        // rename 失败不该让封面凭空消失：仍返回旧文件，下次读再试一次。
+        return legacyFile;
+      }
+    }
+    return null;
+  }
+
+  /// 删除一个条目全部旧文件名形态的 override 封面（BUG-1317 清理）。
+  void _deleteLegacyOverrideThumbnails({
+    required AppModel appModel,
+    required MediaItem item,
+  }) {
+    for (final MediaSource legacy in legacyOverrideStores) {
+      final File legacyFile = File(legacyOverrideThumbnailFilename(
+        appModel: appModel,
+        item: item,
+        sourceId: legacy.uniqueKey,
+      ));
+      if (legacyFile.existsSync()) {
+        legacyFile.deleteSync();
+      }
+    }
   }
 
   /// Given a [MediaItem], return its override display thumbnail.
@@ -470,17 +632,13 @@ abstract class MediaSource {
     required AppModel appModel,
     required MediaItem item,
   }) {
-    String filename = getOverrideThumbnailFilename(
-      appModel: appModel,
-      item: item,
-    );
-
-    File file = File(filename);
-    if (!file.existsSync()) {
+    final File? file =
+        resolveOverrideThumbnailFile(appModel: appModel, item: item);
+    if (file == null) {
       return null;
     }
 
-    // BUG-959: 降采样解码；existsSync 保留——它区分「有无 override 封面」（同步 API，
+    // BUG-959: 降采样解码；存在性判据保留——它区分「有无 override 封面」（同步 API，
     // 返回 null 表示无 override 由上层回落正常封面），改异步会牵动所有 build 调用点。
     return resizedFileImage(file);
   }
@@ -491,16 +649,21 @@ abstract class MediaSource {
     required MediaItem item,
     required String? title,
   }) async {
-    String key = getOverrideTitleKey(item);
     String? value;
     if (title != null) {
-      String trimmedTitle = title.trim();
+      final String trimmedTitle = title.trim();
       if (trimmedTitle.isNotEmpty) {
         value = trimmedTitle;
       }
     }
 
-    await setPreference<String?>(key: key, value: value);
+    // BUG-1317: 旧位置无条件清掉再写规范位置——否则「清除改名」会被读取期回退
+    // 复活成旧名，「改成新名」则留下永不再读的孤儿行。
+    await clearOverrideTitle(item);
+    await overrideStore.setPreference<String?>(
+      key: getOverrideTitleKey(item),
+      value: value,
+    );
   }
 
   /// Whether this source lets the user edit a [MediaItem]'s author in the edit
@@ -548,6 +711,11 @@ abstract class MediaSource {
       return;
     }
 
+    // BUG-1317: 无论清除还是换图，旧文件名（源键烧进 hash）都必须一起清掉——
+    // 清除时留着会被 [resolveOverrideThumbnailFile] 的回退「复活」，换图时留着
+    // 只是永不再读的孤儿文件。
+    _deleteLegacyOverrideThumbnails(appModel: appModel, item: item);
+
     // 统一封面服务不变量（P3）：override 缩略图是「同路径覆盖写/删除」——filename
     // 由 hashCode 派生、换图不换路径，而 ImageCache 按 (path, scale) 而非内容缓存
     // 解码。写/删后必须双键驱逐（裸 FileImage + resizedFileImage 的 ResizeImage 键，
@@ -562,7 +730,7 @@ abstract class MediaSource {
     required AppModel appModel,
     required MediaItem item,
   }) async {
-    await deletePreference(key: getOverrideTitleKey(item));
+    await clearOverrideTitle(item);
     await setOverrideThumbnailFromMediaItem(
       appModel: appModel,
       item: item,

--- a/hibiki/lib/src/media/sources/reader_hibiki_source.dart
+++ b/hibiki/lib/src/media/sources/reader_hibiki_source.dart
@@ -302,6 +302,13 @@ class ReaderHibikiSource extends ReaderMediaSource {
     return _overrideTitleForIdentifier(mediaIdentifierForSrtUid(uid));
   }
 
+  /// BUG-1317：这里合成的 `mediaSourceIdentifier` **不再参与 override 身份**。
+  ///
+  /// 它以前是个谎——恒填 EPUB 源，于是一本漫画 / PDF 书的 override 键被按 EPUB 源
+  /// 拼出来，与编辑弹窗按真实 format 写进去的键对不上（首页 / 统计 / 通知栏读不到
+  /// 用户改的名字）。现在 override 键只由 `mediaIdentifier` 派生、统一存进
+  /// [overrideStore]，回退位置取自 `this` 的 [legacyOverrideStores]（书族三源全在
+  /// 内），所以本处填哪个源键都读到同一个值。保留 `uniqueKey` 只因它对本类自洽。
   String? _overrideTitleForIdentifier(String mediaIdentifier) {
     return getOverrideTitleFromMediaItem(MediaItem(
       mediaIdentifier: mediaIdentifier,
@@ -903,7 +910,7 @@ class ReaderHibikiSource extends ReaderMediaSource {
         if (appModel != null) {
           await clearOverrideValues(appModel: appModel, item: item);
         } else {
-          await deletePreference(key: getOverrideTitleKey(item));
+          await clearOverrideTitle(item);
         }
       } catch (e, stack) {
         ErrorLogService.instance

--- a/hibiki/lib/src/media/sources/reader_media_source.dart
+++ b/hibiki/lib/src/media/sources/reader_media_source.dart
@@ -20,6 +20,22 @@ abstract class ReaderMediaSource extends MediaSource {
           mediaType: ReaderMediaType.instance,
         );
 
+  /// BUG-1317：EPUB / 漫画 / PDF 是**同一本书**的三种 `EpubBooks.format`，共享
+  /// `hoshi://book/<bookKey>` 身份，而 `mediaSourceIdentifier` 由**当前** format
+  /// 现算（转化后会变）。override 书名 / 封面必须跟着**书**走，不跟着阅读器走，
+  /// 所以三源统一存进 EPUB 源的偏好命名空间。
+  @override
+  MediaSource get overrideStore => ReaderHibikiSource.instance;
+
+  /// BUG-1317 读取期回退：存量 override 按写入时的 format 散落在三个源各自的
+  /// `src:<sourceId>:` 命名空间里，三个都要试。
+  @override
+  List<MediaSource> get legacyOverrideStores => <MediaSource>[
+        ReaderHibikiSource.instance,
+        MangaHibikiSource.instance,
+        ReaderPdfSource.instance,
+      ];
+
   // TODO-786：阅读类媒体源默认卡槽比例归到书封比例 [kShelfBookCardAspectRatio]
   // （≈160/260），让书架封面 fitHeight 自然铺满、消除两侧白带。（书架视频分区
   // 死路径已删，视频卡槽比例随之移除，视频卡归「视频」tab 自管。）

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -2182,13 +2182,14 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
                 displayTitleForBook(item: item, rawTitle: item.title);
             ScrapeBatchItemResult result;
             try {
-              final File existingOverride = File(
-                source.getOverrideThumbnailFilename(
-                  appModel: appModel,
-                  item: item,
-                ),
+              // BUG-1317：跳过判据要认存量旧文件名，否则改版后批量刮削会把用户
+              // 已设的封面当成「没有」重新刮一遍并覆盖掉。
+              final File? existingOverride =
+                  source.resolveOverrideThumbnailFile(
+                appModel: appModel,
+                item: item,
               );
-              if (await existingOverride.exists()) {
+              if (existingOverride != null) {
                 result = ScrapeBatchItemResult.skipped;
               } else {
                 final List<BookScrapeCandidate> candidates =

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -122,14 +122,16 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     // 以前 SRT 卡只读 book.coverPath（旧外层「选择封面图片」专有写入），忽略
     // override，导致在编辑信息弹窗里选的封面在网格卡上不生效。现在统一到 override，
     // 无 override 再退回 book.coverPath（向后兼容历史外层写入的封面）与关联 EPUB 封面。
-    final String overrideCoverPath =
-        ReaderHibikiSource.instance.getOverrideThumbnailFilename(
+    // BUG-1317：读 override 封面必须走 resolveOverrideThumbnailFile——它才认得
+    // 存量的旧文件名（源键烧进 hash）并就地迁移；裸 getOverrideThumbnailFilename
+    // 只拿得到规范路径，会把还没迁移的封面判成「没有」。
+    final File? overrideCover =
+        ReaderHibikiSource.instance.resolveOverrideThumbnailFile(
       appModel: appModel,
       item: _srtBookMediaItem(book),
     );
-    final String? existingOverride = _existingCoverFilePath(overrideCoverPath);
-    if (existingOverride != null) {
-      return _buildFileCover(existingOverride, fallbackIcon);
+    if (overrideCover != null) {
+      return _buildFileCover(overrideCover.path, fallbackIcon);
     }
     final String? ownCoverPath = _existingCoverFilePath(book.coverPath);
     if (ownCoverPath != null) {

--- a/hibiki/lib/src/profile/profile_keys.dart
+++ b/hibiki/lib/src/profile/profile_keys.dart
@@ -99,10 +99,13 @@ class ProfileKeys {
 
   /// BUG-1018 (A4): per-item display-name overrides are CONTENT tied to a
   /// media item, not reading preferences. Their persisted form is
-  /// `src:<sourceId>:override_title://<sourceId>/<uniqueKey>` (see
+  /// `src:<sourceId>:override_title://<mediaIdentifier>` since BUG-1317
+  /// (previously `src:<sourceId>:override_title://<sourceId>/<uniqueKey>`; both
+  /// shapes coexist until the read-time fallback migrates the legacy rows — see
   /// [MediaSource.getOverrideTitleKey] + `dbSourcePrefKey`), so the marker is
-  /// matched as a substring — excluding them from profile snapshots keeps a
-  /// rename visible across profile switches instead of being pruned/reverted.
+  /// matched as a substring — it covers both shapes, and excluding them from
+  /// profile snapshots keeps a rename visible across profile switches instead
+  /// of being pruned/reverted.
   static const String _overrideTitleMarker = 'override_title://';
 
   static bool isExcludedPref(String key) {

--- a/hibiki/test/media/override_identity_test.dart
+++ b/hibiki/test/media/override_identity_test.dart
@@ -8,6 +8,8 @@ import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
+import 'package:hibiki/src/media/display_title.dart';
+
 import '../helpers/test_platform_services.dart';
 
 /// BUG-1018：override 身份与写穿。
@@ -16,6 +18,11 @@ import '../helpers/test_platform_services.dart';
 ///   `mediaIdentifierFor('')`，override 书名互相踩、作者保存静默 no-op。现在
 ///   身份是 `hoshi://srtbook/<uid>`（每书唯一），作者真实写穿 SrtBooks.author。
 /// - 附带：编辑保存没选新封面时不再落 0 字节 override 封面文件。
+///
+/// BUG-1317：override 书名 / 封面的键与存储命名空间都把**源键**烧了进去，而
+/// 源键随 `EpubBooks.format` 现算（epub / manga / pdf），于是同一本书在不同
+/// 消费面读到不同的键。现在规范位置只由 `mediaIdentifier` 决定，书族三源统一
+/// 归 EPUB 源存，旧位置在读取期回退并就地重写。
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -183,6 +190,369 @@ void main() {
         clearOverrideImage: true,
       );
       expect(File(filename).existsSync(), isFalse);
+    });
+  });
+
+  /// BUG-1317：override 书名 / 封面的身份是**书**，不是「用哪个阅读器打开」。
+  ///
+  /// 旧实现把源键烧进了 key 字符串（出现两次）与偏好命名空间（`src:<src>:`），而
+  /// 一本书的源键由 `EpubBooks.format` 现算（epub→reader_ttu / manga→reader_manga
+  /// / pdf→reader_pdf）。于是漫画 / PDF 书改名后，书架、首页、统计、通知栏读到的
+  /// 键各不相同；EPUB 转漫画后连书架也读不回来。
+  group('override identity is per-book, not per-reader (BUG-1317)', () {
+    const String kBookKey = 'bug1317_book';
+    final String kMediaId = ReaderHibikiSource.mediaIdentifierFor(kBookKey);
+
+    /// 书族三源共用同一 `hoshi://book/<bookKey>` 身份，只有源键不同——这正是
+    /// `_bookToMediaItem` 按 format 现算出来的三种形态。
+    MediaItem bookItem(MediaSource source, {String mediaIdentifier = ''}) {
+      return MediaItem(
+        mediaIdentifier: mediaIdentifier.isEmpty ? kMediaId : mediaIdentifier,
+        title: '原始书名',
+        mediaTypeIdentifier: source.mediaType.uniqueKey,
+        mediaSourceIdentifier: source.uniqueKey,
+        position: 0,
+        duration: 1,
+        canDelete: false,
+        canEdit: true,
+      );
+    }
+
+    List<MediaSource> bookSources() => <MediaSource>[
+          ReaderHibikiSource.instance,
+          MangaHibikiSource.instance,
+          ReaderPdfSource.instance,
+        ];
+
+    /// 把一条 override 书名写进 BUG-1317 之前的**旧位置**：源自己的偏好命名空间
+    /// + 源键出现两次的旧键。这就是旧代码的写入路径。
+    Future<void> writeLegacyTitle(
+        MediaSource source, String mediaIdentifier, String title) async {
+      await source.setPreference<String?>(
+        key: MediaSource.legacyOverrideTitleKey(
+          sourceId: source.uniqueKey,
+          mediaIdentifier: mediaIdentifier,
+        ),
+        value: title,
+      );
+    }
+
+    String? readLegacyTitle(MediaSource source, String mediaIdentifier) {
+      return source.getPreference<String?>(
+        key: MediaSource.legacyOverrideTitleKey(
+          sourceId: source.uniqueKey,
+          mediaIdentifier: mediaIdentifier,
+        ),
+        defaultValue: null,
+      );
+    }
+
+    Future<void> purge(String mediaIdentifier) async {
+      for (final MediaSource source in bookSources()) {
+        await source.clearOverrideTitle(
+            bookItem(source, mediaIdentifier: mediaIdentifier));
+      }
+    }
+
+    setUp(() async {
+      final HibikiDatabase db =
+          HibikiDatabase.forTesting(NativeDatabase.memory());
+      addTearDown(db.close);
+      MediaSource.setDatabase(db);
+    });
+
+    test('规范键只含 mediaIdentifier —— 源键一次都不出现', () async {
+      addTearDown(() => purge(kMediaId));
+      final String epubKey = ReaderHibikiSource.instance
+          .getOverrideTitleKey(bookItem(ReaderHibikiSource.instance));
+      final String mangaKey = MangaHibikiSource.instance
+          .getOverrideTitleKey(bookItem(MangaHibikiSource.instance));
+      final String pdfKey = ReaderPdfSource.instance
+          .getOverrideTitleKey(bookItem(ReaderPdfSource.instance));
+
+      expect(epubKey, 'override_title://$kMediaId');
+      expect(mangaKey, epubKey, reason: '同一本书三种 format 必须解析出同一个键');
+      expect(pdfKey, epubKey);
+      for (final MediaSource source in bookSources()) {
+        expect(epubKey.contains(source.uniqueKey), isFalse,
+            reason: '规范键里绝不能再出现源键 ${source.uniqueKey}');
+      }
+    });
+
+    test('新键写入读出：三种 format 下互相可见', () async {
+      addTearDown(() => purge(kMediaId));
+      // 用户在漫画身份下改名（编辑弹窗按真实 format 解析出 MangaHibikiSource）。
+      await MangaHibikiSource.instance.setOverrideTitleFromMediaItem(
+        item: bookItem(MangaHibikiSource.instance),
+        title: '用户改的名',
+      );
+
+      for (final MediaSource source in bookSources()) {
+        expect(
+          source.getOverrideTitleFromMediaItem(bookItem(source)),
+          '用户改的名',
+          reason: '${source.uniqueKey} 也必须读到同一本书的 override',
+        );
+      }
+    });
+
+    test('旧键回退：三个源各一，都能读到并就地重写成新键', () async {
+      for (final MediaSource legacy in bookSources()) {
+        // 一源一本书，避免互相干扰。
+        final String mediaId =
+            ReaderHibikiSource.mediaIdentifierFor('legacy_${legacy.uniqueKey}');
+        addTearDown(() => purge(mediaId));
+        await writeLegacyTitle(legacy, mediaId, '旧名_${legacy.uniqueKey}');
+
+        // 读侧恒用 EPUB 源（首页 / 统计 / 通知栏走的 _overrideTitleForIdentifier
+        // 就是这条路），必须能穿透到另外两个源的旧命名空间。
+        final MediaItem readItem =
+            bookItem(ReaderHibikiSource.instance, mediaIdentifier: mediaId);
+        expect(
+          ReaderHibikiSource.instance.getOverrideTitleFromMediaItem(readItem),
+          '旧名_${legacy.uniqueKey}',
+          reason: '旧位置（${legacy.uniqueKey} 命名空间 + 旧键形态）必须被回退读到',
+        );
+
+        // 就地重写：旧键已被删，规范键已落值。
+        expect(readLegacyTitle(legacy, mediaId), isNull,
+            reason: '命中后必须删掉旧键，否则回退层永远清不掉');
+        expect(
+          ReaderHibikiSource.instance.overrideStore.getPreference<String?>(
+            key: 'override_title://$mediaId',
+            defaultValue: null,
+          ),
+          '旧名_${legacy.uniqueKey}',
+          reason: '命中后必须把值就地重写进规范键',
+        );
+      }
+    });
+
+    test('转化 epub 到 manga 再转回后 override 书名不丢', () async {
+      final String mediaId =
+          ReaderHibikiSource.mediaIdentifierFor('bug1317_convert');
+      addTearDown(() => purge(mediaId));
+      // 存量：用户在 EPUB 时代改过名（旧位置）。
+      await writeLegacyTitle(ReaderHibikiSource.instance, mediaId, '我的书');
+
+      // 转成漫画：源键变 reader_manga。
+      expect(
+        MangaHibikiSource.instance.getOverrideTitleFromMediaItem(
+          bookItem(MangaHibikiSource.instance, mediaIdentifier: mediaId),
+        ),
+        '我的书',
+      );
+      // 在漫画身份下再改一次名。
+      await MangaHibikiSource.instance.setOverrideTitleFromMediaItem(
+        item: bookItem(MangaHibikiSource.instance, mediaIdentifier: mediaId),
+        title: '我的漫画',
+      );
+      // 转回 EPUB：仍是最新的名字，没有被旧值复活。
+      expect(
+        ReaderHibikiSource.instance.getOverrideTitleFromMediaItem(
+          bookItem(ReaderHibikiSource.instance, mediaIdentifier: mediaId),
+        ),
+        '我的漫画',
+      );
+    });
+
+    test('清除改名后旧位置不会把旧名复活', () async {
+      final String mediaId =
+          ReaderHibikiSource.mediaIdentifierFor('bug1317_clear');
+      addTearDown(() => purge(mediaId));
+      await writeLegacyTitle(ReaderPdfSource.instance, mediaId, '旧名');
+
+      await ReaderPdfSource.instance.setOverrideTitleFromMediaItem(
+        item: bookItem(ReaderPdfSource.instance, mediaIdentifier: mediaId),
+        title: null,
+      );
+
+      expect(
+        ReaderHibikiSource.instance.getOverrideTitleFromMediaItem(
+          bookItem(ReaderHibikiSource.instance, mediaIdentifier: mediaId),
+        ),
+        isNull,
+        reason: '清除后必须真的没有名字，不能被旧位置回退复活',
+      );
+    });
+
+    test('书架 / 首页 / 统计 / 通知栏四个消费面拿到同一个值', () async {
+      const String bookKey = 'bug1317_surfaces';
+      final String mediaId = ReaderHibikiSource.mediaIdentifierFor(bookKey);
+      addTearDown(() => purge(mediaId));
+      // 存量场景：书是漫画，用户在旧版本改过名（写进 reader_manga 命名空间）。
+      await writeLegacyTitle(MangaHibikiSource.instance, mediaId, '四处一致');
+
+      // 书架：卡片持有 _bookToMediaItem 产出的真实源 item，走 item 通道。
+      final String shelf = displayTitleForBook(
+        item: bookItem(MangaHibikiSource.instance, mediaIdentifier: mediaId),
+        rawTitle: '原始书名',
+      );
+      // 首页「继续阅读」/ 活动流：只有 bookKey。
+      final String home =
+          displayTitleForBook(bookKey: bookKey, rawTitle: '原始书名');
+      // 阅读统计明细行（reading_statistics_page）与有声书通知栏元数据
+      // （audiobook_session_launcher）走的是同一个入口。
+      final String? stats =
+          ReaderHibikiSource.instance.overrideTitleForBookKey(bookKey);
+      final String? notification =
+          ReaderHibikiSource.instance.overrideTitleForBookKey(bookKey);
+
+      expect(shelf, '四处一致');
+      expect(home, '四处一致');
+      expect(stats, '四处一致');
+      expect(notification, '四处一致');
+    });
+  });
+
+  /// BUG-1317 封面侧：旧文件名把源键烧进 hashCode，转化 / 改名后读不回来。
+  group('override cover identity is per-book, not per-reader (BUG-1317)', () {
+    late Directory storeDir;
+    late HibikiDatabase db;
+    late AppModel appModel;
+
+    MediaItem coverItem(MediaSource source, String bookKey) {
+      return MediaItem(
+        mediaIdentifier: ReaderHibikiSource.mediaIdentifierFor(bookKey),
+        title: '原始书名',
+        mediaTypeIdentifier: source.mediaType.uniqueKey,
+        mediaSourceIdentifier: source.uniqueKey,
+        position: 0,
+        duration: 1,
+        canDelete: false,
+        canEdit: true,
+      );
+    }
+
+    setUp(() async {
+      db = HibikiDatabase.forTesting(NativeDatabase.memory());
+      final PreferencesRepository prefs = PreferencesRepository(db);
+      await prefs.loadFromDb();
+      storeDir = Directory.systemTemp.createTempSync('hibiki_override_1317');
+      appModel = AppModel(testPlatformServices())
+        ..wireDatabaseForTesting(db)
+        ..wireLocalAudioForTesting(
+          prefsRepo: prefs,
+          databaseDirectory: storeDir,
+        );
+    });
+
+    tearDown(() async {
+      await db.close();
+      if (storeDir.existsSync()) {
+        storeDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('规范封面文件名三种 format 下同名，且不由源键派生', () {
+      const String bookKey = 'cover_same';
+      final Set<String> names = <String>{
+        for (final MediaSource source in <MediaSource>[
+          ReaderHibikiSource.instance,
+          MangaHibikiSource.instance,
+          ReaderPdfSource.instance,
+        ])
+          source.getOverrideThumbnailFilename(
+            appModel: appModel,
+            item: coverItem(source, bookKey),
+          ),
+      };
+      expect(names.length, 1, reason: '同一本书三种 format 必须落到同一个封面文件名');
+      // 旧文件名（源键烧进 hash）必须与规范名不同 —— 否则回退层测的是同一个东西。
+      expect(
+        ReaderHibikiSource.instance.legacyOverrideThumbnailFilename(
+          appModel: appModel,
+          item: coverItem(ReaderHibikiSource.instance, bookKey),
+          sourceId: ReaderHibikiSource.instance.uniqueKey,
+        ),
+        isNot(names.single),
+      );
+    });
+
+    test('旧封面文件名三源各一，都能被回退读到并就地 rename 成规范名', () {
+      for (final MediaSource legacy in <MediaSource>[
+        ReaderHibikiSource.instance,
+        MangaHibikiSource.instance,
+        ReaderPdfSource.instance,
+      ]) {
+        final String bookKey = 'cover_legacy_${legacy.uniqueKey}';
+        final MediaItem item = coverItem(legacy, bookKey);
+        final String legacyPath = legacy.legacyOverrideThumbnailFilename(
+          appModel: appModel,
+          item: item,
+          sourceId: legacy.uniqueKey,
+        );
+        final String canonicalPath = legacy.getOverrideThumbnailFilename(
+          appModel: appModel,
+          item: item,
+        );
+        File(legacyPath).parent.createSync(recursive: true);
+        File(legacyPath).writeAsBytesSync(<int>[9, 9, 9]);
+
+        // 读侧恒用 EPUB 源（首页 / 书架 hero 都合成 EPUB 身份）。
+        final File? resolved =
+            ReaderHibikiSource.instance.resolveOverrideThumbnailFile(
+          appModel: appModel,
+          item: coverItem(ReaderHibikiSource.instance, bookKey),
+        );
+        expect(resolved, isNotNull,
+            reason: '${legacy.uniqueKey} 的旧封面文件名必须被回退读到');
+        expect(resolved!.path, canonicalPath, reason: '命中后必须就地 rename 成规范名');
+        expect(File(canonicalPath).existsSync(), isTrue);
+        expect(File(canonicalPath).lengthSync(), 3, reason: '内容必须原样搬过来');
+        expect(File(legacyPath).existsSync(), isFalse, reason: '旧文件不得留下孤儿');
+      }
+    });
+
+    test('转化 epub 到 manga 后 override 封面不丢', () {
+      const String bookKey = 'cover_convert';
+      // 存量：EPUB 时代写下的旧文件名。
+      final String legacyPath =
+          ReaderHibikiSource.instance.legacyOverrideThumbnailFilename(
+        appModel: appModel,
+        item: coverItem(ReaderHibikiSource.instance, bookKey),
+        sourceId: ReaderHibikiSource.instance.uniqueKey,
+      );
+      File(legacyPath).parent.createSync(recursive: true);
+      File(legacyPath).writeAsBytesSync(<int>[7, 7]);
+
+      // 书转成漫画后由漫画源读。
+      final File? resolved =
+          MangaHibikiSource.instance.resolveOverrideThumbnailFile(
+        appModel: appModel,
+        item: coverItem(MangaHibikiSource.instance, bookKey),
+      );
+      expect(resolved, isNotNull);
+      expect(resolved!.lengthSync(), 2);
+    });
+
+    test('清除封面后旧文件名不会把封面复活', () async {
+      const String bookKey = 'cover_clear';
+      final MediaItem item = coverItem(MangaHibikiSource.instance, bookKey);
+      final String legacyPath =
+          MangaHibikiSource.instance.legacyOverrideThumbnailFilename(
+        appModel: appModel,
+        item: item,
+        sourceId: MangaHibikiSource.instance.uniqueKey,
+      );
+      File(legacyPath).parent.createSync(recursive: true);
+      File(legacyPath).writeAsBytesSync(<int>[5]);
+
+      await MangaHibikiSource.instance.setOverrideThumbnailFromMediaItem(
+        appModel: appModel,
+        item: item,
+        file: null,
+        clearOverrideImage: true,
+      );
+
+      expect(
+        ReaderHibikiSource.instance.resolveOverrideThumbnailFile(
+          appModel: appModel,
+          item: coverItem(ReaderHibikiSource.instance, bookKey),
+        ),
+        isNull,
+        reason: '清除后旧文件名必须一起删掉，否则回退层会把封面复活',
+      );
     });
   });
 }

--- a/hibiki/test/pages/booklongpress_floating_lyric_toggle_test.dart
+++ b/hibiki/test/pages/booklongpress_floating_lyric_toggle_test.dart
@@ -213,10 +213,14 @@ void main() {
       'Widget _buildSrtCover(SrtBook book',
       '  MediaItem _srtBookMediaItem(SrtBook book) {',
     );
+    // BUG-1317 起读取入口改为 resolveOverrideThumbnailFile——它在规范文件名之外
+    // 还认得存量的旧文件名（源键烧进 hash）并就地迁移；裸
+    // getOverrideThumbnailFilename 会把未迁移的封面判成「没有」。
     expect(
       srtCover,
-      contains('getOverrideThumbnailFilename'),
-      reason: 'SRT 卡封面必须优先读编辑信息弹窗写入的 override thumbnail（TODO-1191）。',
+      contains('resolveOverrideThumbnailFile'),
+      reason: 'SRT 卡封面必须优先读编辑信息弹窗写入的 override thumbnail（TODO-1191），'
+          '且必须走迁移感知入口（BUG-1317）。',
     );
     // 仍保留 book.coverPath 回退，向后兼容历史外层「选择封面图片」写入的封面。
     expect(


### PR DESCRIPTION
## 问题（今天就在坏）

override 书名 / 封面的身份被烧成了「用哪个阅读器打开」，而不是「哪本书」。

一本书的 `mediaSourceIdentifier` 由 `EpubBooks.format` **现算**（epub→`reader_ttu` /
manga→`reader_manga` / pdf→`reader_pdf`），三者共享同一 `hoshi://book/<bookKey>` 身份。
于是同一本漫画在书架叫新名、在首页 / 统计 / 通知栏叫旧名；EPUB 转成漫画后连书架也读
不回来，用户自定义书名与封面静默丢失。

## 规划描述漏掉的一半

源键不只烧在 key 字符串里（`override_title://<src>/<src>/<mediaId>`，因为
`MediaItem.uniqueKey` 自己就是 `<src>/<mediaId>`，源键出现两次），**还烧在存储命名
空间里**——偏好落 `src:<sourceId>:<key>`（`dbSourcePrefKey` + `MediaSource._dbPrefKey` /
`_loadPreferencesFromDb`），每个源一份独立缓存。

所以只把源键从 key 字符串里拿掉**并不能**让三源互相读到。

## 方案：读取期回退，零 schema 迁移

- `overrideStore`（默认 `this`）= override 的存储归属源。`ReaderMediaSource` 覆盖为
  `ReaderHibikiSource.instance`，书族三源统一存一处。
- `legacyOverrideStores`（默认 `[this]`）= 读取期回退位置。`ReaderMediaSource` 覆盖为
  EPUB / 漫画 / PDF 三源；每个元素同时提供旧命名空间宿主与旧键里烧着的源键。
- 规范键 `override_title://<mediaIdentifier>`；规范封面名
  `'<mediaIdentifier>/override_thumbnail'.hashCode`。
- 读未命中即回退旧位置，命中后**就地重写**：书名重写 pref 并删旧键，封面 `renameSync`
  成规范名。
- 写 / 清除侧对称清旧位置——否则「清除改名 / 清除封面」会被回退层复活。
- 消费点改走迁移感知入口 `resolveOverrideThumbnailFile`：SRT 卡封面
  (`reader_history/books.part.dart`)、批量刮削「已有封面则跳过」判据
  (`reader_hibiki_history_page.dart`)。

清理条件：一个版本后（存量已被读取期迁走）删掉 `legacyOverrideStores` 与全部
`legacy*` helper。

> 全仓只有 3 个 `MediaSource` 具体实现，全是书源、共用同一 `mediaIdentifier` 命名空间，
> 因此规范键去掉源键不存在跨源撞名风险。

附带：`ReaderHibikiSource._overrideTitleForIdentifier` 恒填 `reader_ttu` 的自洽问题一并
消解（override 身份不再含源键）。**未动任何 `ttu_*` / `reader_ttu` 持久化 key 本身。**

## 测试（10 例新增，全部变异实测转红）

`hibiki/test/media/override_identity_test.dart` 新增两个 group。

| 变异 | 转红用例 |
|---|---|
| M1 书名规范键重新烧进源键 | 规范键只含 mediaIdentifier / 新键写入读出 / 旧键回退 / 转化不丢 / 四个消费面 |
| M2 书族三源不再统一 `overrideStore` | 新键写入读出 / 转化不丢 |
| M3 砍掉书名读取期回退 | 旧键回退 / 转化不丢 / 四个消费面 |
| M4 写入前不清旧位置 | 清除改名后旧位置不会把旧名复活 |
| M5 回退命中后不就地重写 | 旧键回退（就地重写断言） |
| M6 封面规范文件名重新烧进源键 | 三源同名 / 旧封面回退（+ 既有 BUG-1018 用例） |
| M7 砍掉封面读取期回退 | 旧封面回退 / 转化封面不丢 |
| M8 清除封面时不删旧文件名 | 清除封面后旧文件名不会把封面复活 |

每次变异后均以反向文本替换还原，`git status --short` 逐次确认零残留。

既有源码扫描守卫 `test/pages/booklongpress_floating_lyric_toggle_test.dart` 的锚点同步
更新为 `resolveOverrideThumbnailFile`。

## 门禁

- `flutter analyze`（含 test）：`No issues found!`
- `test/media test/pages test/profile test/tools test/storage test/epub`：
  `FLUTTER TEST VERDICT: PASSED - 7332 tests ran, all tests passed`
- `test/tools/source_guard_adoption_test.dart` + 8 个相关守卫：
  `FLUTTER TEST VERDICT: PASSED - 101 tests ran, all tests passed`
- `test/reader test/settings test/sync test/models`：1 例红，
  `md3_design_system_static_test` 命中 `lib/src/media/manga/manga_json_writeback.dart:142`
  的 `fontSize:`。**该文件与该行在本分支 base `ac1574b46` 上已存在，本 PR diff 新增
  `fontSize:` 计数为 0** —— 属 develop 既有红，非本 PR 引入。

未 bump `+build`（整合线统一 bump）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
