### PR TITLE
fix(mining): Netflix 静态帧按制卡那一刻取帧，不再取录制片段首帧 (BUG-1416/TODO-2521)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1318 条。点号进各自文件。
+> 共 1319 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1416](bugs/BUG-1416-netflix-still-frame-at-mine-time.md) | ✅ | ✅ | Netflix 沉浸捕获选静态帧时取的是片段首帧，不是制卡那一刻的帧 |
 | [BUG-1413](bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md) | ✅ | ✅ | 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null |
 | [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |
 | [BUG-1406](bugs/BUG-1406-libmpv-ffmpeg-version-guard-first-match.md) | ✅ | ✅ | libmpv FFmpeg 版本守卫只校验第一个匹配，单 ABI 静默降级不报红 |

--- a/docs/bugs/BUG-1416-netflix-still-frame-at-mine-time.md
+++ b/docs/bugs/BUG-1416-netflix-still-frame-at-mine-time.md
@@ -1,0 +1,43 @@
+## BUG-1416 · Netflix 沉浸捕获选静态帧时取的是片段首帧，不是制卡那一刻的帧
+
+- **报告**：2026-08-02（用户：TODO-2521 后半，用户拍板「肯定是按制卡时候的时间来，不要后续点击再回来制卡」）
+- **真实性**：✅ 真 bug（两层根因）
+  - 根因 A（偏好被结构性吞掉）：`hibiki/lib/src/models/app_model.dart:6172-6207` 的 Netflix 段恒经
+    `buildImmersionRequest` 下发 `providedCoverBytes`，而引擎的 `imageMode` 阶梯在
+    `hibiki/lib/src/mining/immersion_mining_engine.dart:296-320` 藏在 `if (coverPath == null)` 里
+    —— 有 provided 字节时那个 switch **根本不会被求值**。所以「动图 / 制卡时截图 / 字幕开头截图」
+    这个偏好在 Netflix 这条链路上恒被吞成动图（TODO-2519 只接了 YouTube 那一半，Netflix 半边留到本条）。
+  - 根因 B（时刻信息压根没传下来）：浏览器扩展 `tools/browser-extension/content.js` 的
+    `hibikiEnqueue` 只把字幕 cue 窗 `startV/endV`（±200ms 录制边距）存进队列，**不记录用户按下
+    制卡键那一刻的 `video.currentTime`**；`background.js` 的 `mineClip` 也只发
+    `clipBase64/clipDurationMs/documentTitle`。因此即使修好 A，也只能取到片段首帧（= 句首 −200ms
+    −起播推进量），而不是制卡那一刻的帧。这不是「加个参数」能了的，必须把那一刻沿链路传下来。
+- **[x] ① 已修复** — 三段一起改（同一 PR，wire 两侧同时落地）：
+  - 扩展：入队时就地采样制卡时刻视频时间（只在它落在本句 cue 窗内时才记，面板行查词停在别句的
+    情况不记）；批量录制在 `beginClip` **前后各采一次** `v.currentTime` 取中点，实测下发片段的
+    时间基锚点 + 其误差上界；`mineClip` 新增 `clipAnchorMs` / `clipAnchorUncertaintyMs` /
+    `cueStartMs` / `mineAtMs` 四个可选字段（老版扩展不发 → 全 null，向后兼容）。
+  - Dart：`ImmersionMinePayload` 解析四字段；新纯函数 `resolveClipStillTarget` 把「视频时间」
+    换算成片段内偏移；`transcodeClipToCapture` 在静态帧模式下不编动图、改抽单帧；
+    `ImmersionCaptureResult.coverIsStill` 让封面名走 `netflix_frame.jpg`（Anki 按扩展名判 MIME）。
+  - ffmpeg：`buildFfmpegFrameArgs` 新增 `decodeFromStart` —— 录制片段是 `MediaRecorder` 产出的
+    **无 Cues 索引** webm，`-ss` 放 `-i` 前的输入定位会落到最近关键帧（正是本条明令禁止的糊弄）；
+    静态帧走输出定位（`-ss` 在 `-i` 后，从 0 解码丢弃到目标时刻）。长视频/书架封面保持默认输入定位。
+  - 误差账（正面回答，不含糊）：锚点误差 = 扩展实测的 `clipAnchorUncertaintyMs`（`recorder.start()`
+    必落在两次采样之间，故真值必在 `锚点 ± 该值` 内），随请求下发并写进诊断日志；不可约项是
+    **采集帧率量化** —— `offscreen.js` 的 `maxFrameRate: 12` 决定片段里最多每 83ms 才有一帧，
+    ffmpeg 取「pts ≥ 目标」的第一帧，故 **做不到一帧（源 ~42ms）以内**，总偏差约
+    `实测锚点不确定度 + ≤83ms(采集帧量化) + ≤42ms(源帧采样)`。相对现状（首帧 = 句首，可差数秒）
+    是数量级改善，但「一帧内」做不到，如实记在此。
+- **[x] ② 已加自动化测试** — `hibiki/test/mining/netflix_still_frame_mine_time_test.dart`（19 用例）：
+  静态帧只出单帧不进动图链 / 取的是制卡时刻而非首帧 / 锚点与句首有偏移时仍取对 / 动图偏好零回归 /
+  `decodeFromStart` / wire 解析与向后兼容 / ffmpeg 定位方式 / 两条源码扫描守卫（app_model 的 Netflix
+  段必须真解析并下发 stillTarget；扩展两侧必须采样并转发）。11 处变异实测逐条转红。
+- **备注**：本条只做「clipBytes（扩展录制片段）」这条**真实可达**的路径。同文件里
+  `ImmersionCaptureChannel.capture`（native 后台软解实例）分支要求 `netflixVideoId + clipStartMs
+  + clipEndMs`，而扩展的 `mineClip` 从不发 `netflixVideoId` → 那条分支从扩展侧不可达（TODO-2521
+  前半，用户未表态，本轮按建议保留不删）。`screenshotBase64`/`timestampMs` 在本仓无任何生产者，
+  `buildImmersionRequest` 里的 2A 截图降级同样只在测试里被触达。
+  用户要真正用上本条修复需**更新浏览器扩展**（app 启动会把内置副本刷到 `<appSupport>` 并自更新，
+  见 `background.js` 的 `maybeSelfReload`）；只更新 app 不更新扩展时，静态帧仍出片段首帧并在诊断
+  日志里标 `exact=false`。

--- a/hibiki/assets/browser_extension/background.js
+++ b/hibiki/assets/browser_extension/background.js
@@ -485,6 +485,14 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           body: JSON.stringify({
             fields: msg.fields, sentence: msg.sentence || '',
             clipBase64: msg.clipBase64, clipDurationMs: msg.clipDurationMs,
+            // BUG-1416：片段时间基锚点 + 句首 + 制卡那一刻（都是**视频时间**），服务端在静态帧
+            // 模式下据此在片段里定位取帧。null（老队列项/采样失败）就不发 → 服务端退片段起点。
+
+            ...(typeof msg.clipAnchorMs === 'number' ? { clipAnchorMs: msg.clipAnchorMs } : {}),
+            ...(typeof msg.clipAnchorUncertaintyMs === 'number'
+              ? { clipAnchorUncertaintyMs: msg.clipAnchorUncertaintyMs } : {}),
+            ...(typeof msg.cueStartMs === 'number' ? { cueStartMs: msg.cueStartMs } : {}),
+            ...(typeof msg.mineAtMs === 'number' ? { mineAtMs: msg.mineAtMs } : {}),
             ...(msg.documentTitle ? { documentTitle: msg.documentTitle } : {}),
           }),
         });

--- a/hibiki/assets/browser_extension/content.js
+++ b/hibiki/assets/browser_extension/content.js
@@ -698,6 +698,12 @@ window.hibikiEnqueue = function (fields, sentence) {
   const cw = hibikiPendingCueWindow;
   const w = cw ? { text: cw.text || '', startV: cw.startMs, endV: cw.endMs } : hibikiCurrentCueWindowV();
   if (!w) return { ok: false, reason: 'no-cue' };
+  // BUG-1416：**制卡那一刻**的视频时间就地采样并随队列项持久化。用户拍板「按制卡时候的时间来」，
+  // 而这是唯一还知道那一刻的地方——之后的回放录制只知道句首，再也拿不回这个时刻。
+  // 只在它确实落在本句 cue 窗内才记：面板行查词（hibikiPendingCueWindow）可能停在别的句上，
+  // 那种时刻不在将要录的片段里，记下来只会让下游取到夹取后的边界帧。null → 下游退句首。
+  const nowV = hibikiVideoTimeMs();
+  const mineAtV = (nowV !== null && nowV >= w.startV && nowV <= w.endV) ? nowV : null;
   const site = hibikiSite();
   const youtubeId = site === 'youtube' ? hibikiYoutubeId() : null;
   const netflixId = site === 'netflix' ? hibikiNetflixId() : null;
@@ -711,6 +717,9 @@ window.hibikiEnqueue = function (fields, sentence) {
     id: Date.now() + '-' + Math.random().toString(36).slice(2),
     fields: fields, sentence: sentence || w.text || '',
     startV: Math.max(0, w.startV - 200), endV: w.endV + 200,
+    // BUG-1416：startV 带了 200ms 录制头部提前量，不是真句首；静态帧「字幕开头」要的是真句首。
+    cueStartV: w.startV,
+    mineAtV: mineAtV,
     site: site,
     youtubeId: youtubeId,
     netflixId: netflixId,
@@ -871,9 +880,22 @@ async function hibikiRunNetflixBatch() {
         // 不变），不再因 seek→播放时序把本可录的句误跳。
         const advancing = await hibikiWaitForPlaying(v, 4000);
         if (!advancing) { fail++; window.hibikiToast('生成中… ' + (done + fail) + '/' + items.length, true); continue; }
+        // BUG-1416：实测片段的**时间基锚点**（clip t=0 对应的视频时间）。绝不能假设它等于
+        // 本句 seek 目标——上面的 waitForSeekSettled/waitForBuffered/waitForPlaying（40ms 轮询、
+        // 要求 currentTime 真前进 20ms 以上）加这一次 IPC 往返，都在推进视频时间。
+        // recorder.start() 必落在「发消息」与「收到 ack」之间，故真锚点必在 [before, after] 内：
+        // 取中点，误差上界 = 半个区间，随请求下发供服务端写进诊断日志（可观测，不靠猜）。
+        const anchorBeforeV = hibikiVideoTimeMs(v);
         const beginResp = await chrome.runtime.sendMessage({ target: 'offscreen', type: 'beginClip' });
+        const anchorAfterV = hibikiVideoTimeMs(v);
         began = !!(beginResp && beginResp.ok);
         if (!began) { fail++; window.hibikiToast('生成中… ' + (done + fail) + '/' + items.length, true); continue; }
+        const anchorV = (anchorBeforeV === null || anchorAfterV === null)
+          ? null
+          : Math.round((anchorBeforeV + anchorAfterV) / 2);
+        const anchorUncertaintyMs = (anchorBeforeV === null || anchorAfterV === null)
+          ? null
+          : Math.round(Math.abs(anchorAfterV - anchorBeforeV) / 2);
         // 本句结束判据：字幕文本变成别的/清空（≠ 这一句），且已过句首 0.4s。refText 用入队时存的整句
         // 文本，比「播放时现采样」稳（避免字幕还没渲染时采到空 → 判据失效整段录到超时）。
         // seek 后字幕要零点几秒才重新渲染：**先等本句字幕真正出现**（过句首 0.3s 后第一段非空字幕
@@ -912,6 +934,10 @@ async function hibikiRunNetflixBatch() {
             chrome.runtime.sendMessage(
               // BUG-676（TODO-1361 ③）：带上入队时抓的剧名；旧队列项无则录制时现抓（此刻正在目标集页）。
               { type: 'mineClip', fields: q.fields, sentence: q.sentence, clipBase64: clip.clipBase64, clipDurationMs: clip.clipDurationMs,
+                // BUG-1416：静态帧模式要「制卡那一刻」的帧，服务端据这三个视频时间换算片段内偏移。
+                clipAnchorMs: anchorV, clipAnchorUncertaintyMs: anchorUncertaintyMs,
+                cueStartMs: (typeof q.cueStartV === 'number' ? q.cueStartV : null),
+                mineAtMs: (typeof q.mineAtV === 'number' ? q.mineAtV : null),
                 documentTitle: q.documentTitle || (typeof netflixDocumentTitle === 'function' ? netflixDocumentTitle() : '') },
               (resp) => {
                 try { if (chrome.runtime.lastError) return resolve('retry'); } catch (_) { return resolve('retry'); }

--- a/hibiki/lib/src/mining/immersion_capture_channel.dart
+++ b/hibiki/lib/src/mining/immersion_capture_channel.dart
@@ -48,12 +48,65 @@ abstract final class ImmersionCaptureChannel {
   }
 }
 
+/// BUG-1416：静态帧模式下「取片段里的哪一刻」。[offsetMs] 是**片段内偏移**（毫秒，t=0 起）。
+///
+/// [exact] = 这个偏移是由真实时间信息换算出来的（制卡时刻 / 句首的视频时间 − 片段时间基锚点）。
+/// false = 换算所需的时间信息没随请求传下来（老版扩展），只能退到片段起点 —— 仍是静态帧（用户
+/// 选的就是静态帧），但**不是**制卡那一刻的帧。调用方据此写诊断日志，不静默糊弄过去。
+typedef ClipStillTarget = ({int offsetMs, bool exact});
+
+/// 抽单帧的注入点（默认 [extractVideoFrameViaFfmpeg] 真身，测试注入假件）。逐参对齐真身。
+///
+/// 与 `immersion_mining_engine.dart` 的 `FrameExtractor` 分开声明，因为这条路必须显式下发
+/// [decodeFromStart]：录制片段是无 Cues 索引的 MediaRecorder webm，输入定位取不准帧。
+typedef ClipFrameExtractor = Future<String?> Function({
+  required String inputPath,
+  required String outputPath,
+  double atSeconds,
+  bool decodeFromStart,
+  FfmpegFailureReporter? onFailure,
+  String? tlsPinSha256,
+});
+
+/// 纯函数：把用户的图片模式偏好 + 请求里的三个**视频时间**换算成片段内偏移。可单测。
+///
+/// 返回 null = 不取静态帧（用户选动图）→ 调用方走既有动图链，行为逐字不变。
+///
+/// 三个时间同处「视频时间」基（`video.currentTime`），故减法直接成立；[clipAnchorMs] 是片段
+/// t=0 对应的视频时间，由扩展实测下发（见 [ImmersionMinePayload.clipAnchorMs] —— 绝不能假设
+/// 它等于句首，seek 落定/缓冲/起播推进量都在里面）。
+///
+/// 结果夹到 `[0, durationMs]`：durationMs 是墙钟时长，本就是真实时长的**上界**，夹取只挡住
+/// 明显越界的脏输入，不引入偏移。
+ClipStillTarget? resolveClipStillTarget({
+  required VideoMiningImageMode imageMode,
+  required int? clipAnchorMs,
+  required int? cueStartMs,
+  required int? mineAtMs,
+  required int durationMs,
+}) {
+  if (!imageMode.isStill) return null;
+  final int? targetVideoMs = switch (imageMode) {
+    // 用户拍板：「按制卡时候的时间来」——制卡那一刻的视频时间，不是句首、更不是片段首帧。
+    VideoMiningImageMode.currentFrame => mineAtMs,
+    VideoMiningImageMode.subtitleStart => cueStartMs,
+    VideoMiningImageMode.gif => null,
+  };
+  if (clipAnchorMs == null || targetVideoMs == null) {
+    return (offsetMs: 0, exact: false);
+  }
+  final int raw = targetVideoMs - clipAnchorMs;
+  final int upper = durationMs > 0 ? durationMs : 0;
+  return (offsetMs: raw.clamp(0, upper), exact: true);
+}
+
 class ImmersionCaptureResult {
   const ImmersionCaptureResult({
     this.gifBytes,
     this.audioBytes,
     this.error,
     this.animatedFormat = MiningAnimatedFormat.gif,
+    this.coverIsStill = false,
   });
 
   /// 动图封面字节。字段名与 MethodChannel 的 wire key `gifBytes` 一样是历史名，**不代表
@@ -71,6 +124,14 @@ class ImmersionCaptureResult {
   /// 默认 [MiningAnimatedFormat.gif]：截图降级（无动图）与 native 后台实例路径都只可能
   /// 是 GIF，此时该字段不参与文件名（见 [buildImmersionRequest] 的 `coverIsAnimated`）。
   final MiningAnimatedFormat animatedFormat;
+
+  /// BUG-1416：[gifBytes] 里装的是**单帧 JPEG**（用户选了静态帧），不是动图。
+  ///
+  /// 为什么不新开一个 `stillBytes` 字段：[gifBytes] 就是这条链路的「封面字节」通道，
+  /// 分成两个字段会让每个下游都长出一对 if。字节走原通道，用这个布尔说明它是什么——
+  /// 与 [animatedFormat] 同样是「实际产出物的自描述」。
+  /// [animatedFormat] 在本值为 true 时不参与文件名（封面是 `.jpg`）。
+  final bool coverIsStill;
 
   bool get ok => error == null;
 
@@ -104,7 +165,15 @@ ImmersionMiningRequest buildImmersionRequest(
   final bool useCapture = cap.ok;
   final Uint8List? cover =
       useCapture ? (cap.gifBytes ?? p.screenshotBytes) : p.screenshotBytes;
-  final bool coverIsAnimated = useCapture && cap.gifBytes != null;
+  final bool coverFromCapture = useCapture && cap.gifBytes != null;
+  final bool coverIsAnimated = coverFromCapture && !cap.coverIsStill;
+  // BUG-1416：三种封面各自的名字（Anki 按扩展名判 MIME）。片段里抽的静态帧与 2A 截图都是
+  // JPEG，但分开命名——媒体库里一眼看得出这张卡的封面是哪条路产出的。
+  final String coverName = coverIsAnimated
+      ? 'netflix_clip.${cap.animatedFormat.fileExtension}'
+      : coverFromCapture
+          ? 'netflix_frame.jpg'
+          : 'netflix_shot.jpg';
   final Uint8List? audio = useCapture ? cap.audioBytes : null;
   return ImmersionMiningRequest(
     fields: p.fields,
@@ -118,9 +187,7 @@ ImmersionMiningRequest buildImmersionRequest(
     providedCoverBytes: cover,
     // 扩展名跟随**实际产出格式**，不是用户所选：编码器缺失时捕获内部已降级 GIF，按所选
     // 格式拼名会写出 `.avif` 里装 GIF 字节的卡（Anki 按扩展名判 MIME → 封面不显示）。
-    providedCoverName: coverIsAnimated
-        ? 'netflix_clip.${cap.animatedFormat.fileExtension}'
-        : 'netflix_shot.jpg',
+    providedCoverName: coverName,
     providedAudioBytes: audio,
     providedAudioName: audio == null
         ? null
@@ -147,15 +214,23 @@ ImmersionMiningRequest buildImmersionRequest(
 /// 缺失（移动端 ffmpeg-kit 无 libsvtav1/libwebp）时自动降级 GIF 并**同时换回 GIF 的封顶
 /// 参数**，产出格式经 [ImmersionCaptureResult.animatedFormat] 带回给文件名。
 ///
-/// [gifExtractor] / [audioExtractor] 供测试注入，默认指向 ffmpeg 真身。
+/// BUG-1416：[stillTarget] 非 null（用户选了静态帧）时**不编动图**，改在片段内
+/// [ClipStillTarget.offsetMs] 处抽一帧 JPEG 当封面（音频照抽，两种模式一致）。用户拍板
+/// 「肯定是按制卡时候的时间来」——所以取的不是片段首帧，而是制卡那一刻在片段里的位置。
+/// 偏移换算见 [resolveClipStillTarget]；取帧走 `decodeFromStart`（录制片段无 Cues 索引，
+/// 输入定位会落到最近关键帧）。
+///
+/// [gifExtractor] / [audioExtractor] / [frameExtractor] 供测试注入，默认指向 ffmpeg 真身。
 Future<ImmersionCaptureResult> transcodeClipToCapture(
   Uint8List clipBytes, {
   required int durationMs,
   required MiningMediaCompression compression,
   required String tempDir,
   MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+  ClipStillTarget? stillTarget,
   GifExtractor gifExtractor = extractClipGifViaFfmpeg,
   AudioExtractor audioExtractor = extractAudioSegmentViaFfmpeg,
+  ClipFrameExtractor frameExtractor = extractVideoFrameViaFfmpeg,
 }) async {
   final Directory dir = Directory('$tempDir/nf_clip_${clipBytes.length}');
   await dir.create(recursive: true);
@@ -163,17 +238,28 @@ Future<ImmersionCaptureResult> transcodeClipToCapture(
     final File clip = File('${dir.path}/clip.webm');
     await clip.writeAsBytes(clipBytes, flush: true);
     final int endMs = durationMs > 0 ? durationMs : 6000;
+    // 静态帧模式：片段内定点抽一帧，**不进** extractAnimatedClipWithFallback（既是行为正确
+    // 性，也避免顶格档动图编码那种大体积开销 —— 静态帧不吃 gifFps/gifWidth）。
+    final String? framePath = stillTarget == null
+        ? null
+        : await frameExtractor(
+            inputPath: clip.path,
+            outputPath: '${dir.path}/clip_frame.jpg',
+            atSeconds: stillTarget.offsetMs / 1000.0,
+            decodeFromStart: true,
+          );
     // 输出扩展名由每次尝试的格式补（ffmpeg 按扩展名选 muxer），故这里只给不含扩展名的前缀。
-    final AnimatedClipExtraction? animated =
-        await extractAnimatedClipWithFallback(
-      format: format,
-      inputPath: clip.path,
-      startMs: 0,
-      endMs: endMs,
-      outputPathStem: '${dir.path}/clip',
-      compression: compression,
-      extractor: gifExtractor,
-    );
+    final AnimatedClipExtraction? animated = stillTarget != null
+        ? null
+        : await extractAnimatedClipWithFallback(
+            format: format,
+            inputPath: clip.path,
+            startMs: 0,
+            endMs: endMs,
+            outputPathStem: '${dir.path}/clip',
+            compression: compression,
+            extractor: gifExtractor,
+          );
     final String? audioPath = await audioExtractor(
       inputPath: clip.path,
       startMs: 0,
@@ -182,19 +268,23 @@ Future<ImmersionCaptureResult> transcodeClipToCapture(
       audioChannels: compression.audioChannels,
       audioBitrate: compression.audioBitrate,
     );
-    final Uint8List? gif =
-        animated != null ? await File(animated.path).readAsBytes() : null;
+    // 封面字节走同一个通道（[ImmersionCaptureResult.gifBytes]），是不是静态帧由
+    // coverIsStill 说明——不为静态帧另开一条并行字段/分支。
+    final String? coverPath = framePath ?? animated?.path;
+    final Uint8List? cover =
+        coverPath != null ? await File(coverPath).readAsBytes() : null;
     final Uint8List? audio =
         audioPath != null ? await File(audioPath).readAsBytes() : null;
-    if (gif == null && audio == null) {
+    if (cover == null && audio == null) {
       return const ImmersionCaptureResult(
           error: 'clip transcode produced nothing');
     }
     return ImmersionCaptureResult(
-      gifBytes: gif,
+      gifBytes: cover,
       audioBytes: audio,
-      // 实际产出格式（可能已降级），不是用户所选。gif==null 时不参与文件名。
+      // 实际产出格式（可能已降级），不是用户所选。cover==null / 静态帧时不参与文件名。
       animatedFormat: animated?.format ?? MiningAnimatedFormat.gif,
+      coverIsStill: framePath != null,
     );
   } catch (e) {
     return ImmersionCaptureResult(error: 'clip transcode failed: $e');

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -6173,14 +6173,37 @@ class _AppModelRemoteLookupService
     if (payload.clipBytes != null) {
       // Netflix 批量录制的片段边界即句子边界（seek 到句首 → 录到字幕变化停），整段转码 [0,时长]。
       // 扩展 mineClip 不发段内窗/gifEnd（批量回放全自动、无查词交互、无鼠标/弹窗）→ 无从也无须裁段内窗（V16#4）。
+      final int clipDurationMs = payload.clipDurationMs ?? 6000;
+      // BUG-1416：动图 vs 静态帧偏好在 Netflix 这条路上过去被结构性吞掉——buildImmersionRequest
+      // 恒给 providedCoverBytes，引擎的 imageMode 阶梯（immersion_mining_engine.dart 的
+      // `if (coverPath == null)`）根本不会被求值。故必须在**产字节这一层**就按偏好分流。
+      final ClipStillTarget? stillTarget = resolveClipStillTarget(
+        imageMode: _appModel.videoMiningImageMode,
+        clipAnchorMs: payload.clipAnchorMs,
+        cueStartMs: payload.cueStartMs,
+        mineAtMs: payload.mineAtMs,
+        durationMs: clipDurationMs,
+      );
+      if (stillTarget != null) {
+        // 偏移误差在真机上可观测，而不是靠猜：锚点不确定度由扩展在 beginClip 前后实测下发。
+        ErrorLogService.instance.logDiagnostic(
+          'Anki.mineImmersion.netflix.still',
+          'imageMode=${_appModel.videoMiningImageMode.wireName} '
+              'offsetMs=${stillTarget.offsetMs} exact=${stillTarget.exact} '
+              'anchorMs=${payload.clipAnchorMs} '
+              'anchorUncertaintyMs=${payload.clipAnchorUncertaintyMs} '
+              'mineAtMs=${payload.mineAtMs} cueStartMs=${payload.cueStartMs}',
+        );
+      }
       cap = await transcodeClipToCapture(
         payload.clipBytes!,
-        durationMs: payload.clipDurationMs ?? 6000,
+        durationMs: clipDurationMs,
         compression: compression,
         tempDir: Directory.systemTemp.path,
         // 与上面 resolve 的 format 同值：转码按它选编码器 + 输出扩展名 + 降级链，
         // 实际产出格式经 ImmersionCaptureResult.animatedFormat 回传给封面文件名。
         format: animatedFormat,
+        stillTarget: stillTarget,
       );
     } else if (payload.netflixVideoId != null &&
         payload.clipStartMs != null &&

--- a/hibiki/lib/src/sync/immersion_mine_payload.dart
+++ b/hibiki/lib/src/sync/immersion_mine_payload.dart
@@ -17,6 +17,10 @@ class ImmersionMinePayload {
     this.screenshotBytes,
     this.clipBytes,
     this.clipDurationMs,
+    this.clipAnchorMs,
+    this.clipAnchorUncertaintyMs,
+    this.cueStartMs,
+    this.mineAtMs,
   });
 
   final Map<String, String> fields;
@@ -40,6 +44,30 @@ class ImmersionMinePayload {
 
   /// [clipBytes] 的时长（毫秒），供 ffmpeg 截取上界；null 时用默认上限。
   final int? clipDurationMs;
+
+  /// BUG-1416 —— 片段的**时间基锚点**：[clipBytes] 的 t=0 对应的**视频时间**（毫秒）。
+  ///
+  /// 录制不是从字幕句首开整的：扩展 seek 到 `cueStart-200` 后要等 seek 落定、等缓冲、
+  /// 等 `currentTime` 真前进（`content.js` 的 `hibikiWaitForPlaying`，40ms 轮询）才发
+  /// `beginClip`，再经一次 IPC 往返才真正 `recorder.start()`。这段推进量既非零也不固定，
+  /// **不能假设 t=0 == cueStart-200**。故由扩展在 `beginClip` 前后各采一次 `v.currentTime`、
+  /// 取中点实测下发。null = 老版扩展没发（此时无法把任何视频时间换算成片段内偏移）。
+  final int? clipAnchorMs;
+
+  /// [clipAnchorMs] 的**实测**误差上界（毫秒）= `beginClip` 前后两次采样之差的一半。
+  /// `recorder.start()` 必发生在这两次采样之间，故真值必落在 `锚点 ± 本值` 内。
+  /// 只进诊断日志（让偏移误差在真机上可观测，而不是靠猜），不参与取帧运算。
+  final int? clipAnchorUncertaintyMs;
+
+  /// BUG-1416 —— 本句字幕**句首**的视频时间（毫秒）。静态帧模式 `subtitleStart` 用它。
+  final int? cueStartMs;
+
+  /// BUG-1416 —— **制卡那一刻**的视频时间（毫秒）：用户在播放中按下制卡时的
+  /// `video.currentTime`，入队时就地采样并随队列项持久化（不是回放录制时的时间）。
+  /// 静态帧模式 `currentFrame` 用它 —— 用户拍板「按制卡时候的时间来」。
+  /// 扩展只在它确实落在本句 cue 窗内时才发（面板行查词可能停在别的句上），故非 null
+  /// 即保证该时刻被录进了片段。
+  final int? mineAtMs;
 
   /// true = 带了媒体/时间戳，走沉浸引擎路径；false = 纯文本挖词，走现有 mineEntry 回落。
   bool get isImmersion =>
@@ -81,6 +109,11 @@ class ImmersionMinePayload {
       screenshotBytes: _tryDecodeBase64(json['screenshotBase64']),
       clipBytes: _tryDecodeBase64(json['clipBase64']),
       clipDurationMs: (json['clipDurationMs'] as num?)?.round(),
+      clipAnchorMs: (json['clipAnchorMs'] as num?)?.round(),
+      clipAnchorUncertaintyMs:
+          (json['clipAnchorUncertaintyMs'] as num?)?.round(),
+      cueStartMs: (json['cueStartMs'] as num?)?.round(),
+      mineAtMs: (json['mineAtMs'] as num?)?.round(),
     );
   }
 

--- a/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
+++ b/hibiki/lib/src/utils/misc/desktop_audio_clipper.dart
@@ -664,10 +664,19 @@ Future<AudioMetadata?> extractAudioMetadataViaFfprobe({
 /// not decoded from 0). [atSeconds] is clamped to >= 0 so a tiny/short video
 /// never seeks negative; seeking past the end yields no frame (the extractor
 /// then reports null). A non-zero default (e.g. 10s) avoids a black intro frame.
+///
+/// BUG-1416：[decodeFromStart] 把 `-ss` 挪到 `-i` **之后**（输出定位：从 0 解码、丢弃到
+/// 目标时间点再取第一帧）。输入定位依赖容器的索引，而 `MediaRecorder` 产出的 webm
+/// **没有 Cues 索引**（浏览器扩展 Netflix 录制片段就是这种），对它做输入定位会落到
+/// 最近的关键帧甚至整段失败 —— 那正是「按制卡时刻取帧」不能接受的糊弄。短片段
+/// （≤12s）从头解码是毫秒级代价，换来的是「取到的就是那一刻的帧」。
+///
+/// **长视频（书架封面、本地剧集）绝不能开**：那会从 0 解码整个文件。
 List<String> buildFfmpegFrameArgs({
   required String inputPath,
   required String outputPath,
   double atSeconds = 0.0,
+  bool decodeFromStart = false,
   // BUG-891：远端自签主机的 TLS 证书 SHA-256 钉扎指纹（透传给 ffmpeg），非远端/公网源为 null。
   String? tlsPinSha256,
 }) {
@@ -675,10 +684,10 @@ List<String> buildFfmpegFrameArgs({
   return <String>[
     '-y',
     ...buildFfmpegRemoteInputArgs(inputPath, tlsPinSha256: tlsPinSha256),
-    '-ss',
-    seek.toStringAsFixed(3),
+    if (!decodeFromStart) ...<String>['-ss', seek.toStringAsFixed(3)],
     '-i',
     inputPath,
+    if (decodeFromStart) ...<String>['-ss', seek.toStringAsFixed(3)],
     '-an',
     '-frames:v',
     '1',
@@ -700,6 +709,9 @@ Future<String?> extractVideoFrameViaFfmpeg({
   required String inputPath,
   required String outputPath,
   double atSeconds = 10.0,
+  // BUG-1416：无 Cues 索引的短片段（MediaRecorder webm）用输出定位取准帧，见
+  // [buildFfmpegFrameArgs]。长视频保持默认 false（输入定位，快）。
+  bool decodeFromStart = false,
   FfmpegFailureReporter? onFailure,
   // BUG-891：远端自签主机的 TLS 证书 SHA-256 钉扎指纹（透传给 ffmpeg），非远端/公网源为 null。
   String? tlsPinSha256,
@@ -715,6 +727,7 @@ Future<String?> extractVideoFrameViaFfmpeg({
         inputPath: inputPath,
         outputPath: outputPath,
         atSeconds: atSeconds,
+        decodeFromStart: decodeFromStart,
         tlsPinSha256: tlsPinSha256,
       ),
       const Duration(seconds: 30),

--- a/hibiki/test/mining/netflix_still_frame_mine_time_test.dart
+++ b/hibiki/test/mining/netflix_still_frame_mine_time_test.dart
@@ -1,0 +1,414 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/immersion_capture_channel.dart';
+import 'package:hibiki/src/mining/immersion_mining_request.dart';
+import 'package:hibiki/src/sync/immersion_mine_payload.dart';
+import 'package:hibiki/src/utils/misc/desktop_audio_clipper.dart';
+
+/// BUG-1416：Netflix（沉浸捕获）选「静态帧」时，取的必须是**制卡那一刻**对应时间点的帧。
+///
+/// 用户拍板：「肯定是按制卡时候的时间来，不要后续点击再回来制卡」。这否掉了「取录制片段
+/// 首帧」这个看着合理的做法 —— 片段是回放录制的，t=0 是句首（还带 200ms 提前量 + 起播推进
+/// 量），离用户按下制卡键那一刻可以差好几秒。
+///
+/// 本文件钉死五件事：
+/// 1. 静态帧偏好下产出的是**单帧**，根本不进动图编码链；
+/// 2. 取的帧按**制卡时刻**定位，不是片段首帧；
+/// 3. 片段时间基锚点与句首**有偏移**时仍取对（锚点是实测下发的，不是假设等于句首）；
+/// 4. 动图偏好（默认档）逐字节不受影响；
+/// 5. 取帧走 `decodeFromStart`（录制片段是无 Cues 索引的 MediaRecorder webm，输入定位会
+///    落到最近关键帧 —— 那正是「不许默默拿最近的关键帧糊弄」禁止的做法）。
+
+/// 记录一次单帧抽取调用的实参。
+typedef _FrameCall = ({
+  String inputPath,
+  String outputPath,
+  double atSeconds,
+  bool decodeFromStart,
+});
+
+class _FakeFrameExtractor {
+  _FakeFrameExtractor({this.succeed = true});
+
+  final bool succeed;
+  final List<_FrameCall> calls = <_FrameCall>[];
+
+  Future<String?> call({
+    required String inputPath,
+    required String outputPath,
+    double atSeconds = 10.0,
+    bool decodeFromStart = false,
+    FfmpegFailureReporter? onFailure,
+    String? tlsPinSha256,
+  }) async {
+    calls.add((
+      inputPath: inputPath,
+      outputPath: outputPath,
+      atSeconds: atSeconds,
+      decodeFromStart: decodeFromStart,
+    ));
+    if (!succeed) return null;
+    final File out = File(outputPath);
+    out.parent.createSync(recursive: true);
+    out.writeAsBytesSync(<int>[0xFF, 0xD8, 0xFF, 0xE0]);
+    return outputPath;
+  }
+}
+
+class _FakeGifExtractor {
+  final List<String> outputs = <String>[];
+
+  Future<String?> call({
+    required String inputPath,
+    required int startMs,
+    required int endMs,
+    required String outputPath,
+    int fps = 8,
+    int width = 320,
+    MiningAnimatedFormat format = MiningAnimatedFormat.gif,
+    bool diagnosticOnly = false,
+    FfmpegFailureReporter? onFailure,
+    String? tlsPinSha256,
+  }) async {
+    outputs.add(outputPath);
+    final File out = File(outputPath);
+    out.parent.createSync(recursive: true);
+    out.writeAsBytesSync(<int>[1, 2, 3, 4, 5, 6]);
+    return outputPath;
+  }
+}
+
+/// 音频侧不参与取帧断言，但必须照抽（静态帧模式不该把音频一起砍掉）。
+class _FakeAudioExtractor {
+  int calls = 0;
+
+  Future<String?> call({
+    required String inputPath,
+    required int startMs,
+    required int endMs,
+    required String outputPath,
+    int? audioStreamIndex,
+    int? audioStreamCount,
+    FfmpegFailureReporter? onFailure,
+    int audioChannels = 1,
+    String audioBitrate = '64k',
+    String? tlsPinSha256,
+  }) async {
+    calls++;
+    final File out = File(outputPath);
+    out.parent.createSync(recursive: true);
+    out.writeAsBytesSync(<int>[9, 9, 9]);
+    return outputPath;
+  }
+}
+
+void main() {
+  group('resolveClipStillTarget（纯函数：视频时间 → 片段内偏移）', () {
+    test('currentFrame：按制卡那一刻定位，不是片段起点', () {
+      final ClipStillTarget? t = resolveClipStillTarget(
+        imageMode: VideoMiningImageMode.currentFrame,
+        clipAnchorMs: 10000,
+        cueStartMs: 10200,
+        mineAtMs: 12500,
+        durationMs: 6000,
+      );
+      expect(t, isNotNull);
+      expect(t!.offsetMs, 2500,
+          reason: '制卡时刻 12500 − 片段锚点 10000 = 2500ms。取 0（首帧）就是用户否掉的做法。');
+      expect(t.exact, isTrue);
+    });
+
+    test('subtitleStart：按真句首定位（句首≠片段起点，录制带 200ms 提前量）', () {
+      final ClipStillTarget? t = resolveClipStillTarget(
+        imageMode: VideoMiningImageMode.subtitleStart,
+        clipAnchorMs: 10000,
+        cueStartMs: 10200,
+        mineAtMs: 12500,
+        durationMs: 6000,
+      );
+      expect(t!.offsetMs, 200);
+      expect(t.exact, isTrue);
+    });
+
+    test('gif（默认档）→ null，调用方走既有动图链', () {
+      expect(
+        resolveClipStillTarget(
+          imageMode: VideoMiningImageMode.gif,
+          clipAnchorMs: 10000,
+          cueStartMs: 10200,
+          mineAtMs: 12500,
+          durationMs: 6000,
+        ),
+        isNull,
+      );
+    });
+
+    test('老版扩展没发时间信息 → 仍出静态帧（用户选的就是静态帧），但标记 exact=false', () {
+      final ClipStillTarget? t = resolveClipStillTarget(
+        imageMode: VideoMiningImageMode.currentFrame,
+        clipAnchorMs: null,
+        cueStartMs: null,
+        mineAtMs: null,
+        durationMs: 6000,
+      );
+      expect(t, isNotNull);
+      expect(t!.offsetMs, 0);
+      expect(t.exact, isFalse,
+          reason: '拿不到时刻就退片段起点，但必须标出来 —— 调用方据此写诊断日志，不静默糊弄。');
+    });
+
+    test('脏输入夹到 [0, durationMs]，不产生负偏移/越界偏移', () {
+      expect(
+        resolveClipStillTarget(
+          imageMode: VideoMiningImageMode.currentFrame,
+          clipAnchorMs: 10000,
+          cueStartMs: 10200,
+          mineAtMs: 9000,
+          durationMs: 6000,
+        )!
+            .offsetMs,
+        0,
+      );
+      expect(
+        resolveClipStillTarget(
+          imageMode: VideoMiningImageMode.currentFrame,
+          clipAnchorMs: 10000,
+          cueStartMs: 10200,
+          mineAtMs: 99000,
+          durationMs: 6000,
+        )!
+            .offsetMs,
+        6000,
+      );
+    });
+  });
+
+  group('transcodeClipToCapture：静态帧模式', () {
+    late Directory tempRoot;
+    late _FakeFrameExtractor frame;
+    late _FakeGifExtractor gif;
+    late _FakeAudioExtractor audio;
+
+    setUp(() async {
+      tempRoot = await Directory.systemTemp.createTemp('bug1415_');
+      frame = _FakeFrameExtractor();
+      gif = _FakeGifExtractor();
+      audio = _FakeAudioExtractor();
+    });
+
+    tearDown(() async {
+      if (tempRoot.existsSync()) await tempRoot.delete(recursive: true);
+    });
+
+    Future<ImmersionCaptureResult> run(ClipStillTarget? target) =>
+        transcodeClipToCapture(
+          Uint8List.fromList(<int>[1, 2, 3, 4]),
+          durationMs: 6000,
+          compression:
+              MiningMediaCompression.resolve(imageTier: 1, audioTier: 0),
+          tempDir: tempRoot.path,
+          format: MiningAnimatedFormat.avif,
+          stillTarget: target,
+          gifExtractor: gif.call,
+          audioExtractor: audio.call,
+          frameExtractor: frame.call,
+        );
+
+    test('① 选静态帧 → 产出单帧，完全不进动图编码链', () async {
+      final ImmersionCaptureResult cap =
+          await run((offsetMs: 2500, exact: true));
+
+      expect(cap.ok, isTrue);
+      expect(cap.coverIsStill, isTrue);
+      expect(cap.gifBytes, isNotNull);
+      expect(gif.outputs, isEmpty,
+          reason: '静态帧不该编动图 —— 既是行为正确性，也是不触发顶格档大体积编码的原因。');
+      expect(frame.calls, hasLength(1));
+      expect(frame.calls.single.outputPath, endsWith('.jpg'));
+      expect(audio.calls, 1, reason: '静态帧模式不该把音频一起砍掉。');
+    });
+
+    test('② 取的帧对应制卡时刻，不是片段首帧', () async {
+      await run((offsetMs: 2500, exact: true));
+      expect(frame.calls.single.atSeconds, closeTo(2.5, 1e-9));
+      expect(frame.calls.single.atSeconds, isNot(0.0),
+          reason: '取首帧正是用户否掉的做法：片段 t=0 是句首，离制卡那一刻可以差好几秒。');
+    });
+
+    test('③ 片段起点与句首有偏移时仍取对（锚点实测，不假设等于句首）', () async {
+      // 扩展 seek 到 cueStart-200=10000，但等 seek 落定/缓冲/起播推进后才真正开录：
+      // 实测锚点 10480。制卡时刻 12500 → 片段内 2020ms。
+      final ClipStillTarget? t = resolveClipStillTarget(
+        imageMode: VideoMiningImageMode.currentFrame,
+        clipAnchorMs: 10480,
+        cueStartMs: 10200,
+        mineAtMs: 12500,
+        durationMs: 6000,
+      );
+      await run(t);
+      expect(frame.calls.single.atSeconds, closeTo(2.02, 1e-9),
+          reason: '若把锚点当成 seek 目标 10000，这里会算成 2.5s —— 差 480ms、约 6 个采集帧。');
+    });
+
+    test('④ 动图偏好（stillTarget=null）逐字节不受影响', () async {
+      final ImmersionCaptureResult cap = await run(null);
+
+      expect(cap.coverIsStill, isFalse);
+      expect(frame.calls, isEmpty, reason: '动图档不该去抽单帧。');
+      expect(gif.outputs, hasLength(1));
+      expect(gif.outputs.single, endsWith('.avif'));
+      expect(cap.animatedFormat, MiningAnimatedFormat.avif);
+    });
+
+    test('⑤ 取帧走 decodeFromStart（录制片段无 Cues 索引，输入定位会落到最近关键帧）', () async {
+      await run((offsetMs: 2500, exact: true));
+      expect(frame.calls.single.decodeFromStart, isTrue,
+          reason: 'MediaRecorder webm 没有 Cues；输入定位取到的是最近关键帧而不是那一刻的帧。');
+    });
+
+    test('抽帧失败但有音频 → 与动图失败同形降级（无封面有音频），不整卡失败', () async {
+      frame = _FakeFrameExtractor(succeed: false);
+      final ImmersionCaptureResult cap =
+          await run((offsetMs: 2500, exact: true));
+      expect(cap.ok, isTrue);
+      expect(cap.gifBytes, isNull);
+      expect(cap.coverIsStill, isFalse);
+      expect(cap.audioBytes, isNotNull);
+    });
+  });
+
+  group('buildImmersionRequest：静态帧封面的文件名', () {
+    ImmersionMinePayload payload() => ImmersionMinePayload(
+          fields: const <String, String>{'word': 'x'},
+          sentence: 's',
+          clipBytes: Uint8List.fromList(<int>[1]),
+        );
+
+    test('静态帧 → .jpg（Anki 按扩展名判 MIME；给 .avif 会显示不出封面）', () {
+      final ImmersionMiningRequest req = buildImmersionRequest(
+        payload(),
+        ImmersionCaptureResult(
+          gifBytes: Uint8List.fromList(<int>[0xFF, 0xD8]),
+          audioBytes: Uint8List.fromList(<int>[1]),
+          animatedFormat: MiningAnimatedFormat.avif,
+          coverIsStill: true,
+        ),
+        audioExpected: true,
+      );
+      expect(req.providedCoverName, 'netflix_frame.jpg');
+    });
+
+    test('动图 → 跟随实际产出格式（老行为不变）', () {
+      final ImmersionMiningRequest req = buildImmersionRequest(
+        payload(),
+        ImmersionCaptureResult(
+          gifBytes: Uint8List.fromList(<int>[1, 2]),
+          audioBytes: Uint8List.fromList(<int>[1]),
+          animatedFormat: MiningAnimatedFormat.avif,
+        ),
+        audioExpected: true,
+      );
+      expect(req.providedCoverName, 'netflix_clip.avif');
+    });
+  });
+
+  group('wire：扩展下发的三个视频时间被解析', () {
+    test('ImmersionMinePayload 解析 clipAnchorMs / cueStartMs / mineAtMs', () {
+      final ImmersionMinePayload p =
+          ImmersionMinePayload.fromJson(<String, dynamic>{
+        'fields': <String, dynamic>{'word': 'x'},
+        'sentence': 's',
+        'clipDurationMs': 6000,
+        'clipAnchorMs': 10480,
+        'clipAnchorUncertaintyMs': 12,
+        'cueStartMs': 10200,
+        'mineAtMs': 12500,
+      });
+      expect(p.clipAnchorMs, 10480);
+      expect(p.clipAnchorUncertaintyMs, 12);
+      expect(p.cueStartMs, 10200);
+      expect(p.mineAtMs, 12500);
+    });
+
+    test('老版扩展不发这些字段 → 全 null，不报错（向后兼容）', () {
+      final ImmersionMinePayload p =
+          ImmersionMinePayload.fromJson(<String, dynamic>{
+        'fields': <String, dynamic>{'word': 'x'},
+        'sentence': 's',
+      });
+      expect(p.clipAnchorMs, isNull);
+      expect(p.cueStartMs, isNull);
+      expect(p.mineAtMs, isNull);
+    });
+  });
+
+  group('buildFfmpegFrameArgs：定位方式', () {
+    test('decodeFromStart=true → -ss 在 -i 之后（输出定位，逐帧解码到目标时刻）', () {
+      final List<String> args = buildFfmpegFrameArgs(
+        inputPath: '/tmp/clip.webm',
+        outputPath: '/tmp/f.jpg',
+        atSeconds: 2.5,
+        decodeFromStart: true,
+      );
+      expect(args.indexOf('-ss'), greaterThan(args.indexOf('-i')));
+      expect(args[args.indexOf('-ss') + 1], '2.500');
+    });
+
+    test('默认（长视频/书架封面）仍是输入定位 —— 绝不能从 0 解码多 GB 剧集', () {
+      final List<String> args = buildFfmpegFrameArgs(
+        inputPath: '/tmp/ep.mkv',
+        outputPath: '/tmp/f.jpg',
+        atSeconds: 10,
+      );
+      expect(args.indexOf('-ss'), lessThan(args.indexOf('-i')));
+    });
+  });
+
+  group('源码扫描守卫：这条路不能再被结构性吞掉', () {
+    /// 剥掉注释再扫：散文里为解释这条断链必然写出同样的符号名，让文档喂绿守卫是假阳性。
+    String codeOnly(String src) => src.split('\n').map((String line) {
+          final int i = line.indexOf('//');
+          return i < 0 ? line : line.substring(0, i);
+        }).join('\n');
+
+    test('mineImmersion 的 Netflix 段必须把静态帧目标下发给 transcodeClipToCapture', () {
+      final String src =
+          File('lib/src/models/app_model.dart').readAsStringSync();
+      final int start = src.indexOf('Future<RemoteMineResult> mineImmersion(');
+      expect(start, greaterThan(0), reason: 'mineImmersion 改名了？守卫锚点失效，请同步更新。');
+      final int end = src.indexOf('void recordHistory(', start);
+      expect(end, greaterThan(start));
+      final String body = codeOnly(src.substring(start, end));
+      final int netflix = body.indexOf('ImmersionCaptureResult cap =');
+      expect(netflix, greaterThan(0),
+          reason: 'YouTube/Netflix 分界锚点失效，请同步更新守卫。');
+      final String nf = body.substring(netflix);
+
+      expect(nf, contains('resolveClipStillTarget('),
+          reason: 'Netflix 段必须按 videoMiningImageMode 解析静态帧目标；'
+              '不解析就等于用户选的「制卡时截图」在这条链路上恒被吞成动图（BUG-1416）。');
+      expect(nf, contains('imageMode: _appModel.videoMiningImageMode'),
+          reason: '偏好必须真读 AppModel，不能写死。');
+      expect(nf, contains('stillTarget: stillTarget'),
+          reason: '解析出来还得真传给 transcodeClipToCapture，否则解析了也白解析。');
+    });
+
+    test('浏览器扩展在制卡入口就地采样制卡时刻，并随 mineClip 发出', () {
+      final String content = codeOnly(
+          File('../tools/browser-extension/content.js').readAsStringSync());
+      expect(content, contains('mineAtV'),
+          reason: '入队时不采样「制卡那一刻」的视频时间，之后的回放录制就永远拿不回它。');
+      expect(content, contains('mineAtMs:'), reason: 'mineClip 必须把制卡时刻发给服务端。');
+      expect(content, contains('clipAnchorMs:'),
+          reason: '片段时间基锚点必须实测下发 —— 假设它等于 seek 目标就是几百毫秒的系统性偏差。');
+
+      final String background = codeOnly(
+          File('../tools/browser-extension/background.js').readAsStringSync());
+      expect(background, contains('clipAnchorMs'),
+          reason: 'background 的 mineClip 转发漏掉字段 = content 采了也白采。');
+      expect(background, contains('mineAtMs'));
+    });
+  });
+}

--- a/tools/browser-extension/background.js
+++ b/tools/browser-extension/background.js
@@ -485,6 +485,14 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
           body: JSON.stringify({
             fields: msg.fields, sentence: msg.sentence || '',
             clipBase64: msg.clipBase64, clipDurationMs: msg.clipDurationMs,
+            // BUG-1416：片段时间基锚点 + 句首 + 制卡那一刻（都是**视频时间**），服务端在静态帧
+            // 模式下据此在片段里定位取帧。null（老队列项/采样失败）就不发 → 服务端退片段起点。
+
+            ...(typeof msg.clipAnchorMs === 'number' ? { clipAnchorMs: msg.clipAnchorMs } : {}),
+            ...(typeof msg.clipAnchorUncertaintyMs === 'number'
+              ? { clipAnchorUncertaintyMs: msg.clipAnchorUncertaintyMs } : {}),
+            ...(typeof msg.cueStartMs === 'number' ? { cueStartMs: msg.cueStartMs } : {}),
+            ...(typeof msg.mineAtMs === 'number' ? { mineAtMs: msg.mineAtMs } : {}),
             ...(msg.documentTitle ? { documentTitle: msg.documentTitle } : {}),
           }),
         });

--- a/tools/browser-extension/content.js
+++ b/tools/browser-extension/content.js
@@ -698,6 +698,12 @@ window.hibikiEnqueue = function (fields, sentence) {
   const cw = hibikiPendingCueWindow;
   const w = cw ? { text: cw.text || '', startV: cw.startMs, endV: cw.endMs } : hibikiCurrentCueWindowV();
   if (!w) return { ok: false, reason: 'no-cue' };
+  // BUG-1416：**制卡那一刻**的视频时间就地采样并随队列项持久化。用户拍板「按制卡时候的时间来」，
+  // 而这是唯一还知道那一刻的地方——之后的回放录制只知道句首，再也拿不回这个时刻。
+  // 只在它确实落在本句 cue 窗内才记：面板行查词（hibikiPendingCueWindow）可能停在别的句上，
+  // 那种时刻不在将要录的片段里，记下来只会让下游取到夹取后的边界帧。null → 下游退句首。
+  const nowV = hibikiVideoTimeMs();
+  const mineAtV = (nowV !== null && nowV >= w.startV && nowV <= w.endV) ? nowV : null;
   const site = hibikiSite();
   const youtubeId = site === 'youtube' ? hibikiYoutubeId() : null;
   const netflixId = site === 'netflix' ? hibikiNetflixId() : null;
@@ -711,6 +717,9 @@ window.hibikiEnqueue = function (fields, sentence) {
     id: Date.now() + '-' + Math.random().toString(36).slice(2),
     fields: fields, sentence: sentence || w.text || '',
     startV: Math.max(0, w.startV - 200), endV: w.endV + 200,
+    // BUG-1416：startV 带了 200ms 录制头部提前量，不是真句首；静态帧「字幕开头」要的是真句首。
+    cueStartV: w.startV,
+    mineAtV: mineAtV,
     site: site,
     youtubeId: youtubeId,
     netflixId: netflixId,
@@ -871,9 +880,22 @@ async function hibikiRunNetflixBatch() {
         // 不变），不再因 seek→播放时序把本可录的句误跳。
         const advancing = await hibikiWaitForPlaying(v, 4000);
         if (!advancing) { fail++; window.hibikiToast('生成中… ' + (done + fail) + '/' + items.length, true); continue; }
+        // BUG-1416：实测片段的**时间基锚点**（clip t=0 对应的视频时间）。绝不能假设它等于
+        // 本句 seek 目标——上面的 waitForSeekSettled/waitForBuffered/waitForPlaying（40ms 轮询、
+        // 要求 currentTime 真前进 20ms 以上）加这一次 IPC 往返，都在推进视频时间。
+        // recorder.start() 必落在「发消息」与「收到 ack」之间，故真锚点必在 [before, after] 内：
+        // 取中点，误差上界 = 半个区间，随请求下发供服务端写进诊断日志（可观测，不靠猜）。
+        const anchorBeforeV = hibikiVideoTimeMs(v);
         const beginResp = await chrome.runtime.sendMessage({ target: 'offscreen', type: 'beginClip' });
+        const anchorAfterV = hibikiVideoTimeMs(v);
         began = !!(beginResp && beginResp.ok);
         if (!began) { fail++; window.hibikiToast('生成中… ' + (done + fail) + '/' + items.length, true); continue; }
+        const anchorV = (anchorBeforeV === null || anchorAfterV === null)
+          ? null
+          : Math.round((anchorBeforeV + anchorAfterV) / 2);
+        const anchorUncertaintyMs = (anchorBeforeV === null || anchorAfterV === null)
+          ? null
+          : Math.round(Math.abs(anchorAfterV - anchorBeforeV) / 2);
         // 本句结束判据：字幕文本变成别的/清空（≠ 这一句），且已过句首 0.4s。refText 用入队时存的整句
         // 文本，比「播放时现采样」稳（避免字幕还没渲染时采到空 → 判据失效整段录到超时）。
         // seek 后字幕要零点几秒才重新渲染：**先等本句字幕真正出现**（过句首 0.3s 后第一段非空字幕
@@ -912,6 +934,10 @@ async function hibikiRunNetflixBatch() {
             chrome.runtime.sendMessage(
               // BUG-676（TODO-1361 ③）：带上入队时抓的剧名；旧队列项无则录制时现抓（此刻正在目标集页）。
               { type: 'mineClip', fields: q.fields, sentence: q.sentence, clipBase64: clip.clipBase64, clipDurationMs: clip.clipDurationMs,
+                // BUG-1416：静态帧模式要「制卡那一刻」的帧，服务端据这三个视频时间换算片段内偏移。
+                clipAnchorMs: anchorV, clipAnchorUncertaintyMs: anchorUncertaintyMs,
+                cueStartMs: (typeof q.cueStartV === 'number' ? q.cueStartV : null),
+                mineAtMs: (typeof q.mineAtV === 'number' ? q.mineAtV : null),
                 documentTitle: q.documentTitle || (typeof netflixDocumentTitle === 'function' ? netflixDocumentTitle() : '') },
               (resp) => {
                 try { if (chrome.runtime.lastError) return resolve('retry'); } catch (_) { return resolve('retry'); }


### PR DESCRIPTION
TODO-2521 后半 / BUG-1416。用户拍板：**「肯定是按制卡时候的时间来，不要后续点击再回来制卡」**。

## 这条路今天实际怎么走

Netflix 沉浸捕获是**回放批量录制**，不是实时捕获：

1. 用户在播放中查词制卡 → `tools/browser-extension/content.js:694` `hibikiEnqueue` 只把字幕 cue 的
   `[startV, endV]`（±200ms 录制边距）存进队列（`content.js:713`）。**按下制卡键那一刻的
   `video.currentTime` 既没被采样也没被存**。
2. 之后批量生成：`hibikiRunNetflixBatch` seek 到 `q.startV`（`content.js:855`）→ 等 seek 落定 →
   等缓冲 → `hibikiWaitForPlaying`（`content.js:994-1008`，40ms 轮询，要求 currentTime 真前进
   20ms 以上）→ 发 `beginClip` → `offscreen.js:69` `recorder.start()`。
3. `endClip`（`offscreen.js:78-96`）回 `clipBase64` + **墙钟** `clipDurationMs`。
4. `background.js:478` `mineClip` 只 POST `{fields, sentence, clipBase64, clipDurationMs,
   documentTitle}` —— **没有任何时间戳**。
5. `app_model.dart:6172-6207` → `transcodeClipToCapture` 整段转动图 → `buildImmersionRequest`
   给 `providedCoverBytes`。

**为什么偏好被吞**：引擎的 `imageMode` 阶梯在 `immersion_mining_engine.dart:296-320`，整段藏在
`if (coverPath == null)` 里；Netflix 恒有 `providedCoverBytes`（`:214-218` 已把 coverPath 填上）
→ 那个 switch **根本不会被求值**。这不是漏传参数，是结构性短路。TODO-2519 只接了 YouTube 半边，
`remote_mining_image_mode_test.dart:193-197` 的注释明确把 Netflix 半边排除在守卫外。

## 可达性结论（如实）

- ✅ **`clipBytes` 这条路真实可达**，是扩展 Netflix 制卡今天唯一走的路。本 PR 改的就是它。
- ❌ **`ImmersionCaptureChannel.capture`（native 后台软解）这条分支从扩展侧不可达**：它要求
  `netflixVideoId + clipStartMs + clipEndMs`，而 `background.js` 的 `mineClip` 从不发
  `netflixVideoId`。这就是 TODO-2521 前半那段 native 死代码，用户未表态，本轮**按建议保留不删**。
- ❌ `screenshotBase64` / `timestampMs` 在本仓**没有任何生产者**（全仓 grep 只有消费端），
  `buildImmersionRequest` 里的「2A 截图卡」降级只在测试里被触达。
- ⚠️ **用户要真正用上本修复必须更新浏览器扩展**（wire 两侧同一 PR 落地）。app 启动会把内置副本刷到
  `<appSupport>` 并由 `background.js` 的 `maybeSelfReload` 自更新；只更新 app 不更新扩展时，
  静态帧仍出片段首帧，并在诊断日志里标 `exact=false`（不静默糊弄）。

## 改了什么

**扩展（`tools/browser-extension/`，含 `assets/` 镜像）**
- `content.js` `hibikiEnqueue`：就地采样**制卡那一刻**的 `video.currentTime` 存进队列项（`mineAtV`），
  外加真句首 `cueStartV`（`startV` 带了 200ms 提前量，不是句首）。只在该时刻确实落在本句 cue 窗内
  才记 —— 面板行查词可能停在别的句上，那种时刻不在将要录的片段里。
- `content.js` 批量循环：在 `beginClip` **前后各采一次** `v.currentTime`，取中点作片段时间基锚点，
  半个区间作误差上界。
- `background.js` `mineClip`：转发 `clipAnchorMs` / `clipAnchorUncertaintyMs` / `cueStartMs` /
  `mineAtMs`（值缺失就不发 → 服务端 null → 向后兼容）。

**Dart**
- `ImmersionMinePayload`：解析上述四字段。
- `resolveClipStillTarget()`（新纯函数）：图片模式偏好 + 三个视频时间 → 片段内偏移 `(offsetMs, exact)`。
  `currentFrame` 取制卡时刻、`subtitleStart` 取真句首、`gif` 返回 null（走既有动图链）。
- `transcodeClipToCapture`：静态帧模式下**不进** `extractAnimatedClipWithFallback`，改抽单帧；音频照抽。
- `ImmersionCaptureResult.coverIsStill`：让 `buildImmersionRequest` 把封面命名成 `netflix_frame.jpg`
  （Anki 按扩展名判 MIME，给 `.avif` 会显示不出封面）。`gifBytes` **wire key 未改**（TODO-2520 另行处理）。
- `app_model.dart`：解析目标 + 写诊断日志（含实测不确定度）+ 下发。

**ffmpeg 定位方式**
- `buildFfmpegFrameArgs` 新增 `decodeFromStart`：把 `-ss` 挪到 `-i` **之后**。录制片段是
  `MediaRecorder` 产出的**无 Cues 索引** webm，`-ss` 放前面的输入定位会落到最近关键帧 ——
  那正是本条明令禁止的糊弄。≤12s 短片段从头解码是毫秒级代价。
  **长视频（书架封面 / 本地剧集）保持默认输入定位**，绝不从 0 解码多 GB 文件。

## 偏移与误差上界（正面回答）

**片段起点与制卡时刻的偏移怎么算**：三个量同处「视频时间」基（`video.currentTime`），
`offsetMs = mineAtMs − clipAnchorMs`，夹到 `[0, clipDurationMs]`。

**锚点为什么必须实测、不能假设**：`clip t=0 ≠ seek 目标`。seek 落定、缓冲门、
`hibikiWaitForPlaying`（40ms 轮询 + 要求前进 >20ms）、`beginClip` 的 IPC 往返、
`MediaRecorder.start()` 延迟，全都在推进视频时间，且量不固定。把锚点当成 `cueStart-200`
会引入几百毫秒的**系统性**偏差（测试 ③ 用 480ms 的例子把这条钉住）。

**锚点误差上界（可证明）**：`recorder.start()` 必发生在「发消息」与「收到 ack」之间，
而 `currentTime` 在播放中单调递增 → 真锚点必落在两次采样之间。取中点，误差 ≤ 半个区间 =
下发的 `clipAnchorUncertaintyMs`。这是**每条片段实测**的值，写进诊断日志，不是估计。

**做不到一帧内 —— 如实说明差多少**：
| 误差项 | 上界 | 来源 |
|---|---|---|
| 锚点不确定度 | 实测下发（IPC 往返量级） | `beginClip` 前后采样差的一半 |
| **采集帧率量化** | **≤ 83ms** | `offscreen.js:44` `maxFrameRate: 12` —— 片段里最多每 83ms 才有一帧，这是 tabCapture 的硬限制，不可约 |
| 源帧采样 | ≤ ~42ms | `v.currentTime` 的分辨率约 1 个源帧（~24fps） |

合计约 `实测不确定度 + ≤83ms + ≤42ms`。**结论：证明不了「偏差在一帧内」**，因为片段本身只有
12fps。相对现状（首帧 = 句首，离制卡时刻可差**数秒**）是数量级改善，但不吹成「精确到一帧」。
要再压只能提高 `maxFrameRate`（录制成本上升），不在本 PR 范围。

## 测试与变异实测

`hibiki/test/mining/netflix_still_frame_mine_time_test.dart`，19 用例。11 处变异逐条实测转红：

| # | 变异（改坏被断言的行为） | 转红的用例 |
|---|---|---|
| 1 | 静态帧模式下仍编动图 | ① 选静态帧 → 产出单帧，完全不进动图编码链 |
| 2 | `atSeconds` 写死 0（取首帧） | ② 取的帧对应制卡时刻 / ③ 起点有偏移时仍取对 |
| 3 | 用 `cueStartMs` 代替实测锚点做减法 | currentFrame / subtitleStart 两条纯函数用例 + ③ |
| 4 | `decodeFromStart: false` | ⑤ 取帧走 decodeFromStart |
| 5 | 无视 `stillTarget`，恒抽单帧 | ④ 动图偏好逐字节不受影响 |
| 6 | 静态帧封面名退回 `netflix_shot.jpg` | 静态帧 → .jpg |
| 7 | `mineAtMs` 解析写死 null | wire 解析 |
| 8 | `-ss` 恒放 `-i` 前 | buildFfmpegFrameArgs 定位方式 |
| 9 | app_model 去掉 `stillTarget:` 下发 | 源码守卫（Netflix 段） |
| 10 | `background.js` 不转发 `clipAnchorMs` | 源码守卫（扩展） |
| 11 | `content.js` 不发 `clipAnchorMs` | 源码守卫（扩展） |

变异内容一律落在**真实代码**上（不塞注释——两条源码守卫都先 `codeOnly()` 剥注释，塞注释等于没做）；
还原走反向文本替换，未对任何未提交文件用 `git checkout --`；还原后 `grep MUTATION` 零残留。

## 门禁

- `flutter analyze`（含 test）：**No issues found**
- `flutter_test_failures.dart` 批 A（`test/mining test/sync test/build test/lookup test/utils` +
  `source_guard_adoption_test` + `md3_design_system_static_test`）：`FAILED` —— **唯一失败是
  develop 上的既有红** `lib/src/media/manga/manga_json_writeback.dart: fontSize:`（PR#692 于 08-01
  带入，另一条线在修）。**无新增 offender**（列表只有这一条）。
- `flutter_test_failures.dart` 批 B（`test/media/video test/dictionary test/shortcuts test/reader
  test/anki test/storage test/pages`）：`PASSED - 7112 tests ran`
- 改号后复验（新测试 + 扩展镜像守卫 + bug 工具三件套）：`PASSED - 51 tests ran`

`grep -l` 反查：改到的文件被 33（Dart 侧）+ 53（扩展镜像侧）个既有守卫扫到，已全部纳入上面两批。
其中扩展镜像 `browser_extension_mirror_full_guard_test.dart` 要求 `tools/` 与 `assets/` 整目录字节
一致，已跑 `dart run hibiki/tool/sync_browser_extension.dart` 同步并验绿。

## BUG 号

`dart run tool/bug.dart new` 首次取到 1415；**开 PR 前重扫全 ref 发现撞号**
（`fix/vendor-m-extension-server-todo2559` 的 `BUG-1415-ci-mextension-upstream-404.md`）。
已用 `dart run tool/bug.dart renumber 1415 1416`（文件名 / 正文 H2 / 代码引用 / 测试注释四处同改
+ reindex + 自校验零残留）改到 **BUG-1416**，改后 `check 通过：1319 条，号唯一，索引同步`。

未 bump `+build`（整合线统一 bump）。未删 TODO-2521 前半的 native 死代码。未改 `gifBytes` 字段名。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
