### PR TITLE
fix(video): 番剧下载自动入库补记 added 活动事件，重放靠真新增判据幂等 (BUG-1417/TODO-2556)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -33,7 +33,7 @@
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
-| [BUG-1416](bugs/BUG-1416-anime-download-added-activity.md) | ✅ | ✅ | 番剧下载自动入库不记 added 活动事件 |
+| [BUG-1417](bugs/BUG-1417-anime-download-added-activity.md) | ✅ | ✅ | 番剧下载自动入库不记 added 活动事件 |
 | [BUG-1414](bugs/BUG-1414-md3-manga-fontsize-guard.md) | ✅ | ✅ | manga.json 回写触发 MD3 fontSize 守卫，develop CI 单测门变红 |
 | [BUG-1413](bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md) | ✅ | ✅ | 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null |
 | [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1319 条。点号进各自文件。
+> 共 1320 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1416](bugs/BUG-1416-anime-download-added-activity.md) | ✅ | ✅ | 番剧下载自动入库不记 added 活动事件 |
 | [BUG-1414](bugs/BUG-1414-md3-manga-fontsize-guard.md) | ✅ | ✅ | manga.json 回写触发 MD3 fontSize 守卫，develop CI 单测门变红 |
 | [BUG-1413](bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md) | ✅ | ✅ | 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null |
 | [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |

--- a/docs/bugs/BUG-1416-anime-download-added-activity.md
+++ b/docs/bugs/BUG-1416-anime-download-added-activity.md
@@ -1,0 +1,17 @@
+## BUG-1416 · 番剧下载自动入库不记 added 活动事件
+- **报告**：2026-08-02（TODO-2556）
+- **真实性**：✅ 真 bug。`hibiki/lib/src/media/torrent/anime_download_importer.dart` 全文 `grep -n "Activity\|recordActivity"` 零命中（129 行，入库主体 :58-127）：番剧下载完成后 `importSplitPlaylist` 返回就直接去绑 AniList / 抽封面，从不记 `added` 活动事件。视频域其它入库路径（对话框 5 处 `video_import_dialog.dart:366/462/481/559/634`、扫描首导 `source_library_scanner.dart:758`）全都经 `VideoBookRepository.recordVideoImportActivity`（`video_book_repository.dart:140`）记账，只有下载这条漏了 → 首页 dashboard / 时间轴看不到番剧入库。引入者 `buildAnimeDownloadImporter`（commit `5dbd4b179`）自始未接活动流。
+- **[x] ① 已修复** — `anime_download_importer.dart:73-87` 在 `importSplitPlaylist` 返回后按既有范式记 1 条（整本 1 条，`title=plan.seriesTitle`、`mediaKey=首集 uid`，与对话框 / 扫描首导同粒度）。
+
+  **重复 emit 的根因处置**：`reuseExistingPaths: true` 存在崩溃重放（DB 已提交、计划 flag 未回写）——旧返回值 `({collectionId, episodeUids})` **区分不了「本次真新建」与「复用既有」**：`episodeUids` 是新旧混合列表，`collectionId` 也可能是 `createMediaCollection` 按自然键复用出来的既有 id。所以修的是**判据的数据结构**，不是在活动流侧兜：`importSplitPlaylist` 事务内本来就知道哪几集是自己插的，只是把这个事实丢掉了 → 现在返回 `SplitPlaylistImportResult`（`video_book_repository.dart:24-45` typedef）多带一个 `createdEpisodeUids`（有序子集），emit 条件 = `createdEpisodeUids.isNotEmpty`。全复用 → 一条不记；同系列后续批次带来新集 → 记 1 条（那是真新增内容）。
+
+  为什么**不**在活动流侧做幂等：`addActivityEvent` 的契约明写「纯追加，不去重、不累加」（`packages/hibiki_core/lib/src/database/database.dart:4111`），`activity_events` 表也无唯一索引；read/watch/game 三类事件依赖这个纯追加语义。为一类事件在共享写入点加去重会破坏其余三类。也**没有**用时间窗 / sleep / 去重表这类掩盖手段。
+
+  为什么**不**在 importer 里于调用外自己重扫一遍路径判新旧：那份判据必须与事务内的 `normalizeVideoPath` 归一规则逐字节一致，一旦漂移就把重放误判成新增——同一判据两处实现正是这个 bug 的复发温床。
+
+- **[x] ② 已加自动化测试** — `hibiki/test/torrent/anime_download_importer_test.dart`（4 条新用例，全部变异实测过）：
+  - `下载入库真新增：整本记 1 条 added（title=系列名、mediaKey=首集 uid）` — 变异 `episodeUids.first` → `.last`，仅此条红。
+  - `崩溃重放（同批路径重跑复用既有条目）：不重复记 added` — 变异守卫 `createdEpisodeUids.isNotEmpty` → `episodeUids.isNotEmpty`（= 本 bug 的天真修法），仅此条红。
+  - `added 事件的 media_type 落 ActivityMediaKind.video，不是裸字符串` — 变异 `kActivityMediaVideo` → `kActivityMediaBook`，仅此条红。
+  - `同系列后续批次带来新集：真新增，再记 1 条（幂等判据不是「合集已存在」）` — 变异守卫为 `createdEpisodeUids.length == episodeUids.length`（过严的「全新才记」），仅此条红。
+- **备注**：`SplitPlaylistImportResult` 是新增 typedef，替换了原先在 4 个 lib 调用点 + 7 个测试断言里手抄的匿名 record 类型；`reuseExistingPaths == false` 的路径（对话框 / 扫描首导）行为一字未变（每集都是新建，`createdEpisodeUids == episodeUids`）。

--- a/docs/bugs/BUG-1417-anime-download-added-activity.md
+++ b/docs/bugs/BUG-1417-anime-download-added-activity.md
@@ -1,4 +1,4 @@
-## BUG-1416 · 番剧下载自动入库不记 added 活动事件
+## BUG-1417 · 番剧下载自动入库不记 added 活动事件
 - **报告**：2026-08-02（TODO-2556）
 - **真实性**：✅ 真 bug。`hibiki/lib/src/media/torrent/anime_download_importer.dart` 全文 `grep -n "Activity\|recordActivity"` 零命中（129 行，入库主体 :58-127）：番剧下载完成后 `importSplitPlaylist` 返回就直接去绑 AniList / 抽封面，从不记 `added` 活动事件。视频域其它入库路径（对话框 5 处 `video_import_dialog.dart:366/462/481/559/634`、扫描首导 `source_library_scanner.dart:758`）全都经 `VideoBookRepository.recordVideoImportActivity`（`video_book_repository.dart:140`）记账，只有下载这条漏了 → 首页 dashboard / 时间轴看不到番剧入库。引入者 `buildAnimeDownloadImporter`（commit `5dbd4b179`）自始未接活动流。
 - **[x] ① 已修复** — `anime_download_importer.dart:73-87` 在 `importSplitPlaylist` 返回后按既有范式记 1 条（整本 1 条，`title=plan.seriesTitle`、`mediaKey=首集 uid`，与对话框 / 扫描首导同粒度）。

--- a/hibiki/lib/src/media/source_library/source_library_scanner.dart
+++ b/hibiki/lib/src/media/source_library/source_library_scanner.dart
@@ -740,7 +740,7 @@ class SourceLibraryScanner {
           continue;
         }
 
-        final ({int collectionId, List<String> episodeUids}) result =
+        final SplitPlaylistImportResult result =
             await _videoRepo.importSplitPlaylist(
           collectionName: collectionName,
           entries: entries,

--- a/hibiki/lib/src/media/torrent/anime_download_importer.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_importer.dart
@@ -70,7 +70,7 @@ Future<AnimeDownloadImportOutcome?> Function(
       ],
     );
 
-    // BUG-1416：番剧下载完成自动入库也是一次真实入库，必须进首页活动时间轴——
+    // BUG-1417：番剧下载完成自动入库也是一次真实入库，必须进首页活动时间轴——
     // 与对话框 / 拖拽 / 扫描首导同粒度：整本 1 条 added（title=系列名、mediaKey=
     // 首集 uid），绝不每集一条。
     //

--- a/hibiki/lib/src/media/torrent/anime_download_importer.dart
+++ b/hibiki/lib/src/media/torrent/anime_download_importer.dart
@@ -29,7 +29,8 @@ List<String> sortVideoPathsByEpisode(List<String> paths) {
 }
 
 /// 组装番剧下载完成后的入库回调：N 集拆行 + playlist 合集（一个事务，复用
-/// [VideoBookRepository.importSplitPlaylist]）→ 绑定 AniList id → 封面。
+/// [VideoBookRepository.importSplitPlaylist]）→ 记 added 活动事件 → 绑定
+/// AniList id → 封面。
 ///
 /// 封面分两层、各自 best-effort（用户 2026-08-02：作品海报只归合集封面，成员条目
 /// 保持抽帧/集级剧照）：
@@ -58,8 +59,7 @@ Future<AnimeDownloadImportOutcome?> Function(
   return (AnimeDownloadPlan plan, List<String> videoAbsolutePaths) async {
     if (videoAbsolutePaths.isEmpty) return null;
     final List<String> sorted = sortVideoPathsByEpisode(videoAbsolutePaths);
-    final ({int collectionId, List<String> episodeUids}) result =
-        await repo.importSplitPlaylist(
+    final SplitPlaylistImportResult result = await repo.importSplitPlaylist(
       collectionName: plan.seriesTitle,
       // plan JSON 与 Drift 无法做同一事务；若进程在 DB 提交后、计划 flag
       // 回写前崩溃，重启会重放 importer。以归一化视频路径作稳定业务键并在
@@ -69,6 +69,23 @@ Future<AnimeDownloadImportOutcome?> Function(
         for (final String path in sorted) PlaylistEntry(title: '', path: path),
       ],
     );
+
+    // BUG-1416：番剧下载完成自动入库也是一次真实入库，必须进首页活动时间轴——
+    // 与对话框 / 拖拽 / 扫描首导同粒度：整本 1 条 added（title=系列名、mediaKey=
+    // 首集 uid），绝不每集一条。
+    //
+    // 幂等**只能**看 createdEpisodeUids：`reuseExistingPaths: true` 让崩溃重放
+    // （DB 已提交、计划 flag 未回写）复用既有条目与既有合集，此时一集都没新建 →
+    // 一条都不记。**不是**靠时间窗/去重表掩盖，而是让判据本身分清「真新增」与
+    // 「复用既有」；活动流表按设计是纯追加（addActivityEvent 不去重），不能也
+    // 不该在那一层兜。同系列后续批次（新集号）确有新建 → 记 1 条，这是真新增内容。
+    // best-effort：recordVideoImportActivity 内部自捕获，失败只 log 不影响入库。
+    if (result.createdEpisodeUids.isNotEmpty && result.episodeUids.isNotEmpty) {
+      await repo.recordVideoImportActivity(
+        bookUid: result.episodeUids.first,
+        title: plan.seriesTitle,
+      );
+    }
 
     // AniList 绑定（后续 Jimaku 批量对话框可直接复用该 id，跳过搜番消歧）。
     if (plan.anilistId != null) {

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -32,7 +32,7 @@ import 'package:hibiki/src/utils/misc/hibiki_time_format.dart';
 /// `importSplitPlaylist` 在事务内按 [normalizeVideoPath] 归一路径判「已在库」，只有
 /// 它知道哪几集是这一次插进去的。调用方**不得**在方法外拿路径自己重扫一遍去猜——
 /// 那份判据必须与事务内的规则逐字节一致，一旦漂移就会把崩溃重放误判成新增
-/// （BUG-1416：番剧下载重放重复记 `added` 活动事件的形状）。
+/// （BUG-1417：番剧下载重放重复记 `added` 活动事件的形状）。
 /// `reuseExistingPaths == false` 时每集都是新建，[createdEpisodeUids] 恒等于
 /// [episodeUids]。
 typedef SplitPlaylistImportResult = ({

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -20,6 +20,27 @@ import 'package:hibiki/src/sync/deletion_propagation.dart';
 import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/utils/misc/hibiki_time_format.dart';
 
+/// [VideoBookRepository.importSplitPlaylist] 的落库结果。
+///
+/// * [collectionId] —— playlist 合集 id；`createMediaCollection` 按自然键
+///   `(name, collectionType)` 查重复用，所以它**可能是既有合集**。
+/// * [episodeUids] —— 各集 uid，有序，长度恒 = 入参 `entries`；复用到的既有 uid 和
+///   本次新建的 uid 混在一起，**无法**从这个列表判断新旧。
+/// * [createdEpisodeUids] —— **本次调用真新建**的那几集（[episodeUids] 的有序子集）。
+///
+/// [createdEpisodeUids] 是 `reuseExistingPaths` 复用判据的**唯一真相源**：
+/// `importSplitPlaylist` 在事务内按 [normalizeVideoPath] 归一路径判「已在库」，只有
+/// 它知道哪几集是这一次插进去的。调用方**不得**在方法外拿路径自己重扫一遍去猜——
+/// 那份判据必须与事务内的规则逐字节一致，一旦漂移就会把崩溃重放误判成新增
+/// （BUG-1416：番剧下载重放重复记 `added` 活动事件的形状）。
+/// `reuseExistingPaths == false` 时每集都是新建，[createdEpisodeUids] 恒等于
+/// [episodeUids]。
+typedef SplitPlaylistImportResult = ({
+  int collectionId,
+  List<String> episodeUids,
+  List<String> createdEpisodeUids,
+});
+
 /// VideoBooks 仓库：视频元数据 + 进度；字幕 cue 复用 audioCues 表。
 class VideoBookRepository {
   const VideoBookRepository(this._db);
@@ -196,14 +217,17 @@ class VideoBookRepository {
   /// currentEpisode 恒 0；completed_at 不设）。整批包一个事务：全成或全回滚。
   ///
   /// 封面不在此处理（ffmpeg 属 app 层，且需先知集 uid 命名封面文件）——调用方在拿到
-  /// [episodeUids] 后自行抽封面并 [updateCover] 到首集。返回合集 id + 各集 uid（有序）。
-  Future<({int collectionId, List<String> episodeUids})> importSplitPlaylist({
+  /// [episodeUids] 后自行抽封面并 [updateCover] 到首集。
+  ///
+  /// 返回 [SplitPlaylistImportResult]：合集 id + 各集 uid（有序）+ 本次真新建的集。
+  Future<SplitPlaylistImportResult> importSplitPlaylist({
     required String collectionName,
     required List<PlaylistEntry> entries,
     int? sourceId,
     bool reuseExistingPaths = false,
   }) async {
     final List<String> epUids = <String>[];
+    final List<String> createdUids = <String>[];
     int collectionId = 0;
     await _db.transaction(() async {
       final List<VideoBookRow> existingBooks = await listAll();
@@ -230,6 +254,7 @@ class VideoBookRepository {
         );
         taken.add(uid);
         epUids.add(uid);
+        createdUids.add(uid);
         await saveVideoBook(
           VideoBooksCompanion(
             bookUid: Value(uid),
@@ -255,7 +280,11 @@ class VideoBookRepository {
         await _db.addToCollection(collectionId, MediaKind.video, uid);
       }
     });
-    return (collectionId: collectionId, episodeUids: epUids);
+    return (
+      collectionId: collectionId,
+      episodeUids: epUids,
+      createdEpisodeUids: createdUids,
+    );
   }
 
   /// 统一合集：把**已存在**的 playlist 合集 [collectionId] 的成员对齐到当前 m3u8 清单

--- a/hibiki/lib/src/media/video/video_import_dialog.dart
+++ b/hibiki/lib/src/media/video/video_import_dialog.dart
@@ -345,7 +345,7 @@ class _VideoImportDialogState extends State<VideoImportDialog>
 
         // 统一合集 Phase 2：多集拆成 N 条独立 VideoBooks 行 + 一个 playlist 合集
         // （单一真相源 importSplitPlaylist，与 v38 迁移落库形状对齐）。
-        final ({int collectionId, List<String> episodeUids}) result =
+        final SplitPlaylistImportResult result =
             await widget.repo.importSplitPlaylist(
           collectionName: p.basenameWithoutExtension(m3u8Path),
           entries: entries,
@@ -444,7 +444,7 @@ class _VideoImportDialogState extends State<VideoImportDialog>
           .toList();
       // 统一合集 Phase 2：拆成 N 条独立 VideoBooks 行 + 一个 playlist 合集
       // （合集名用系列名）。封面给首集承接。
-      final ({int collectionId, List<String> episodeUids}) result =
+      final SplitPlaylistImportResult result =
           await widget.repo.importSplitPlaylist(
         collectionName: group.series,
         entries: entries,

--- a/hibiki/test/media/video/video_import_split_playlist_test.dart
+++ b/hibiki/test/media/video/video_import_split_playlist_test.dart
@@ -28,8 +28,8 @@ void main() {
       const PlaylistEntry(title: '', path: '/v/Show E03.mkv'),
     ];
 
-    final ({int collectionId, List<String> episodeUids}) result = await repo
-        .importSplitPlaylist(collectionName: 'Show', entries: entries);
+    final SplitPlaylistImportResult result = await repo.importSplitPlaylist(
+        collectionName: 'Show', entries: entries);
 
     // 每集 uid = video/<集文件名>，有序返回。
     expect(result.episodeUids, <String>[
@@ -81,14 +81,12 @@ void main() {
       PlaylistEntry(title: 'E2', path: 'D:/Downloads/Show E02.mkv'),
     ];
 
-    final ({int collectionId, List<String> episodeUids}) initial =
-        await repo.importSplitPlaylist(
+    final SplitPlaylistImportResult initial = await repo.importSplitPlaylist(
       collectionName: 'Show',
       entries: first,
       reuseExistingPaths: true,
     );
-    final ({int collectionId, List<String> episodeUids}) restarted =
-        await repo.importSplitPlaylist(
+    final SplitPlaylistImportResult restarted = await repo.importSplitPlaylist(
       collectionName: 'Show',
       entries: replay,
       reuseExistingPaths: true,
@@ -106,8 +104,7 @@ void main() {
     addTearDown(db.close);
     final VideoBookRepository repo = VideoBookRepository(db);
 
-    final ({int collectionId, List<String> episodeUids}) result =
-        await repo.importSplitPlaylist(
+    final SplitPlaylistImportResult result = await repo.importSplitPlaylist(
       collectionName: 'Show',
       entries: const <PlaylistEntry>[
         PlaylistEntry(title: 'E1', path: '/v/a.mkv'),
@@ -155,8 +152,7 @@ void main() {
       addTearDown(db.close);
       final VideoBookRepository repo = VideoBookRepository(db);
 
-      final ({int collectionId, List<String> episodeUids}) result =
-          await repo.importSplitPlaylist(
+      final SplitPlaylistImportResult result = await repo.importSplitPlaylist(
         collectionName: 'Show',
         entries: const <PlaylistEntry>[
           PlaylistEntry(title: 'E1', path: '/v/Show E01.mkv'),
@@ -200,8 +196,8 @@ void main() {
         PlaylistEntry(title: 'E1', path: '/v/a.mkv'),
         PlaylistEntry(title: 'E2', path: '/v/b.mkv'),
       ];
-      final ({int collectionId, List<String> episodeUids}) result = await repo
-          .importSplitPlaylist(collectionName: 'Show', entries: entries);
+      final SplitPlaylistImportResult result = await repo.importSplitPlaylist(
+          collectionName: 'Show', entries: entries);
 
       final ({int added, int removed}) recon =
           await repo.reconcileSplitPlaylist(
@@ -223,8 +219,7 @@ void main() {
       addTearDown(db.close);
       final VideoBookRepository repo = VideoBookRepository(db);
 
-      final ({int collectionId, List<String> episodeUids}) result =
-          await repo.importSplitPlaylist(
+      final SplitPlaylistImportResult result = await repo.importSplitPlaylist(
         collectionName: 'Show',
         entries: const <PlaylistEntry>[
           PlaylistEntry(title: 'E1', path: '/v/a.mkv'),

--- a/hibiki/test/torrent/anime_download_importer_test.dart
+++ b/hibiki/test/torrent/anime_download_importer_test.dart
@@ -1,9 +1,13 @@
-/// 番剧下载入库封面（BUG-1393 / BUG-1394）。
+/// 番剧下载入库封面（BUG-1393 / BUG-1394）+ added 活动事件（BUG-1416）。
 ///
 /// 用户 2026-08-02：作品海报只落合集自有封面，不借道首集条目——多集合集的子篇不得
 /// 顶着作品级竖版海报。同时钉住落盘走统一收口（`MediaCoverService.applyCoverBytes`
 /// 的原子 `.tmp`+rename）：`reuseExistingPaths` 重放会覆盖同名文件，裸 writeAsBytes
 /// 不驱逐解码缓存就是 BUG-1118 的形状。
+///
+/// BUG-1416：下载完成自动入库以前一条 `added` 活动事件都不记，首页时间轴看不到番剧
+/// 入库。补记的同时必须扛住崩溃重放——`reuseExistingPaths` 让重放复用既有条目/合集，
+/// 幂等判据只能是 `createdEpisodeUids`（本次真新建的集），不是时间窗、不是去重表。
 library;
 
 import 'dart:io';
@@ -16,6 +20,8 @@ import 'package:hibiki/src/media/torrent/anime_download_service.dart'
     show AnimeDownloadImportOutcome;
 import 'package:hibiki/src/media/video/video_cover_extractor.dart'
     show videoCoverFileName;
+import 'package:hibiki/src/utils/misc/hibiki_time_format.dart'
+    show HibikiTimeFormat;
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -130,6 +136,84 @@ void main() {
     expect(second!.collectionId, first.collectionId);
     expect(File(dest).readAsBytesSync(), jpeg);
     expect(File('$dest.tmp').existsSync(), isFalse, reason: '收口写不留 .tmp');
+  });
+
+  // ── BUG-1416：added 活动事件 ───────────────────────────────────────────
+  //
+  // 幂等判据钉在「本次真新建了集」上（SplitPlaylistImportResult.createdEpisodeUids），
+  // 不是时间窗、不是合集是否已存在。四条用例分别守：真新增记 1 条 / 崩溃重放不重记 /
+  // 字段值域走 ActivityMediaKind 不是裸字符串 / 同系列后续新集仍算真新增。
+
+  Future<List<ActivityEventRow>> addedEvents() =>
+      db.getRecentActivityEvents(eventTypes: <String>[kActivityAdded]);
+
+  test('下载入库真新增：整本记 1 条 added（title=系列名、mediaKey=首集 uid）', () async {
+    final AnimeDownloadImportOutcome? outcome = await importer()(
+      _plan(),
+      <String>[
+        p.join('D:', 'dl', '某番剧 - 01.mkv'),
+        p.join('D:', 'dl', '某番剧 - 02.mkv'),
+      ],
+    );
+    expect(outcome, isNotNull);
+
+    final List<ActivityEventRow> events = await addedEvents();
+    expect(events, hasLength(1), reason: '多集合集整本 1 条，绝不每集一条');
+    final List<MediaCollectionItemRow> items =
+        await db.getCollectionItems(outcome!.collectionId);
+    expect(events.single.title, '某番剧');
+    expect(events.single.mediaKey, items.first.entryKey,
+        reason: 'mediaKey=首集 uid');
+  });
+
+  test('崩溃重放（同批路径重跑复用既有条目）：不重复记 added', () async {
+    final List<String> paths = <String>[
+      p.join('D:', 'dl', '某番剧 - 01.mkv'),
+      p.join('D:', 'dl', '某番剧 - 02.mkv'),
+    ];
+    await importer()(_plan(), paths);
+    expect(await addedEvents(), hasLength(1));
+
+    // 进程在 DB 提交后、计划 flag 回写前崩溃 → 重启原样重放同一批路径。
+    await importer()(_plan(), paths);
+    expect(
+      await addedEvents(),
+      hasLength(1),
+      reason: '一集都没新建（全部复用既有路径）→ 一条都不该再记',
+    );
+  });
+
+  test('added 事件的 media_type 落 ActivityMediaKind.video，不是裸字符串', () async {
+    await importer()(_plan(), <String>[p.join('D:', 'dl', '某番剧 - 01.mkv')]);
+
+    final ActivityEventRow row = (await addedEvents()).single;
+    expect(row.eventType, kActivityAdded);
+    expect(
+      ActivityMediaKind.tryParse(row.mediaType),
+      ActivityMediaKind.video,
+      reason: 'media_type 必须是活动域枚举的 video 落库值，不得写成 MediaKind 的名字',
+    );
+    expect(row.durationMs, isNull, reason: 'added 无时长');
+    expect(row.charsDelta, isNull, reason: 'added 无字符增量');
+    expect(
+      row.dateKey,
+      HibikiTimeFormat.dayKey(
+        DateTime.fromMillisecondsSinceEpoch(row.timestampMs),
+      ),
+      reason: 'dateKey 必须与 timestampMs 同一时刻派生',
+    );
+  });
+
+  test('同系列后续批次带来新集：真新增，再记 1 条（幂等判据不是「合集已存在」）', () async {
+    await importer()(_plan(), <String>[p.join('D:', 'dl', '某番剧 - 01.mkv')]);
+    expect(await addedEvents(), hasLength(1));
+
+    // 同 seriesTitle → 复用既有合集，但 02 是全新的集。
+    await importer()(_plan(), <String>[
+      p.join('D:', 'dl', '某番剧 - 01.mkv'),
+      p.join('D:', 'dl', '某番剧 - 02.mkv'),
+    ]);
+    expect(await addedEvents(), hasLength(2), reason: '真有新集进来就是真新增');
   });
 
   test('响应不是图片（错误页 HTML）：不落盘、合集 coverPath 保持空', () async {

--- a/hibiki/test/torrent/anime_download_importer_test.dart
+++ b/hibiki/test/torrent/anime_download_importer_test.dart
@@ -1,11 +1,11 @@
-/// 番剧下载入库封面（BUG-1393 / BUG-1394）+ added 活动事件（BUG-1416）。
+/// 番剧下载入库封面（BUG-1393 / BUG-1394）+ added 活动事件（BUG-1417）。
 ///
 /// 用户 2026-08-02：作品海报只落合集自有封面，不借道首集条目——多集合集的子篇不得
 /// 顶着作品级竖版海报。同时钉住落盘走统一收口（`MediaCoverService.applyCoverBytes`
 /// 的原子 `.tmp`+rename）：`reuseExistingPaths` 重放会覆盖同名文件，裸 writeAsBytes
 /// 不驱逐解码缓存就是 BUG-1118 的形状。
 ///
-/// BUG-1416：下载完成自动入库以前一条 `added` 活动事件都不记，首页时间轴看不到番剧
+/// BUG-1417：下载完成自动入库以前一条 `added` 活动事件都不记，首页时间轴看不到番剧
 /// 入库。补记的同时必须扛住崩溃重放——`reuseExistingPaths` 让重放复用既有条目/合集，
 /// 幂等判据只能是 `createdEpisodeUids`（本次真新建的集），不是时间窗、不是去重表。
 library;
@@ -138,7 +138,7 @@ void main() {
     expect(File('$dest.tmp').existsSync(), isFalse, reason: '收口写不留 .tmp');
   });
 
-  // ── BUG-1416：added 活动事件 ───────────────────────────────────────────
+  // ── BUG-1417：added 活动事件 ───────────────────────────────────────────
   //
   // 幂等判据钉在「本次真新建了集」上（SplitPlaylistImportResult.createdEpisodeUids），
   // 不是时间窗、不是合集是否已存在。四条用例分别守：真新增记 1 条 / 崩溃重放不重记 /


### PR DESCRIPTION
## 缺陷（已复核，2026-08-02 origin/develop `605453c4f`）

`hibiki/lib/src/media/torrent/anime_download_importer.dart` 全文 `grep -n "Activity\|recordActivity"` **零命中**（129 行，入库主体 `:58-127`）。番剧下载完成后 `importSplitPlaylist` 一返回就去绑 AniList / 抽封面，从不记 `added` 活动事件 → 首页 dashboard 时间轴看不到番剧入库。

视频域其余 6 条入库路径全都经 `VideoBookRepository.recordVideoImportActivity`（`video_book_repository.dart:140`）记账：对话框 5 处（`video_import_dialog.dart:366/462/481/559/634`）+ 扫描首导（`source_library_scanner.dart:758`，BUG-1351）。只有下载这条漏了。引入者 `buildAnimeDownloadImporter`（`5dbd4b179`）自始未接活动流。

## 修法

按既有范式记：**整本 1 条**，`title=plan.seriesTitle`、`mediaKey=首集 uid`，与对话框多集分组 / 扫描首导同粒度，绝不每集一条。

### 重复 emit 的处置：修判据，不在活动流侧兜

`reuseExistingPaths: true` 存在崩溃重放（DB 已提交、计划 flag 未回写 → 重启重放同一批路径）。旧返回值 `({collectionId, episodeUids})` **区分不了「本次真新建」与「复用既有」**：`episodeUids` 是新旧混合列表，`collectionId` 也可能是 `createMediaCollection` 按自然键复用出来的既有 id。

根因修在**判据的数据结构**上——`importSplitPlaylist` 事务内本来就按 `normalizeVideoPath` 判过「已在库」，它知道哪几集是自己插的，只是把这个事实丢掉了。现在返回 `SplitPlaylistImportResult`（typedef，`video_book_repository.dart:24-45`），多带有序子集 `createdEpisodeUids`；emit 条件 = `createdEpisodeUids.isNotEmpty`：

- 崩溃重放全部复用 → 一集没新建 → **一条不记**；
- 同系列后续批次带来新集号 → 有新建 → 记 1 条（那是真新增内容，不是重复）。

**为什么不在活动流侧做幂等**：`addActivityEvent` 契约明写「纯追加，不去重、不累加」（`packages/hibiki_core/lib/src/database/database.dart:4111`），表也无唯一索引；`read`/`watch`/`game` 三类依赖该语义。为一类事件在共享写入点加去重会破坏其余三类。

**为什么不在 importer 里于调用外重扫路径自己判新旧**：那份判据必须与事务内的 `normalizeVideoPath` 归一规则逐字节一致，一旦漂移就把重放误判成新增——同一判据两处实现正是复发温床。

**没有**用时间窗 / sleep / 重试 / 去重表这类掩盖手段。

### 顺带收口

`SplitPlaylistImportResult` typedef 替换了原先在 4 个 lib 调用点 + 7 处测试断言里手抄的匿名 record 类型。`reuseExistingPaths == false` 的路径（对话框 / 扫描首导）行为**一字未变**（每集都是新建，`createdEpisodeUids == episodeUids`）。

## 测试（`hibiki/test/torrent/anime_download_importer_test.dart`，4 条新用例，逐条变异实测）

| 用例 | 变异 | 结果 |
|---|---|---|
| 真新增：整本记 1 条 added（title=系列名、mediaKey=首集 uid） | `episodeUids.first` → `.last` | 仅此条红 |
| 崩溃重放（同批路径重跑复用既有条目）：不重复记 | 守卫 `createdEpisodeUids.isNotEmpty` → `episodeUids.isNotEmpty`（本 bug 的天真修法） | 仅此条红 |
| media_type 落 `ActivityMediaKind.video`，不是裸字符串 | `kActivityMediaVideo` → `kActivityMediaBook` | 仅此条红 |
| 同系列后续批次带来新集：真新增，再记 1 条 | 守卫 → `createdEpisodeUids.length == episodeUids.length`（过严的「全新才记」） | 仅此条红 |

变异全部为真实行为改动（非注释、非 no-op），还原走反向文本替换，还原后 `git status --short` 干净、`grep` 无残留。

## 门禁

- `flutter analyze`（含 test 目录）：`No issues found!`
- `dart run tool/flutter_test_failures.dart --no-pub`（`test/torrent/` + `test/media/video/` + `test/media/source_library/` + media cover 守卫 + `unified_collections_architecture_guard` + `home_dashboard_page` + `video_library_naming_guard` + `media_domain_kinds` + `source_guard_adoption_test` + `bugs_per_file_guard_test` + `md3_design_system_static_test`）：
  `FLUTTER TEST VERDICT: PASSED - 2631 tests ran, all tests passed`（exit 0）
- `md3_design_system_static_test` 现已**无既有红**（PR#707 已落 develop，`manga_json_writeback.dart` offender 已修）；未新增 offender。
- `dart run tool/bug.dart check`：`check 通过：1320 条，号唯一，索引同步`
- 未 bump `+build`（整合线统一 bump）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
