### PR TITLE
feat(video): Jellyfin 图组对齐——media_images 表 + 多 backdrop 轮换 + logo 叠加 + 续播卡视频横版

### DIFF
--- a/hibiki/lib/src/media/collections/collection_asset_reclaim.dart
+++ b/hibiki/lib/src/media/collections/collection_asset_reclaim.dart
@@ -38,11 +38,25 @@ import 'package:hibiki_core/hibiki_core.dart';
 
 /// 一行合集快照里「该合集自有、随合集删除一起回收」的磁盘资产路径。
 ///
-/// 目前只有封面一项。将来给 `media_collections` 加横版 backdrop 之类的自有图片
-/// 列时，**在这里加一行**就能让全部六条删除路径同时生效——这正是把回收收成单一
-/// 入口的收益（否则新列会原样重演同一个泄漏）。
+/// 封面一项 + v68 附加图组（media_images，须在删行**前**由调用方快照——行随删
+/// 合集 FK cascade 消失，见 [collectionOwnedImagePaths]）。新增自有图片资产时
+/// **在这两处加**就能让全部删除路径同时生效——这正是把回收收成单一入口的收益
+/// （否则新资产会原样重演同一个泄漏）。
 List<String?> collectionOwnedAssetPaths(MediaCollectionRow collection) {
   return <String?>[collection.coverPath];
+}
+
+/// 某合集当前的附加图文件路径（v68）。**必须在删行前调用**：`media_images` 行
+/// 随删合集 cascade 消失，删后再查恒为空、文件永久泄漏。
+Future<List<String>> collectionOwnedImagePaths(
+  HibikiDatabase db,
+  int collectionId,
+) async {
+  return <String>[
+    for (final MediaImageRow row
+        in await db.getMediaImagesForCollection(collectionId))
+      row.path,
+  ];
 }
 
 /// 删除合集的**唯一入口**：删 DB 行（[HibikiDatabase.deleteMediaCollection]，
@@ -57,13 +71,16 @@ Future<int> deleteMediaCollectionWithAssets(
   int collectionId, {
   Directory? collectionCoversDirectory,
 }) async {
-  // 快照必须在删行**之前**取：行一删，coverPath 就再也推导不出来。
+  // 快照必须在删行**之前**取：行一删，coverPath / 附加图行就再也推导不出来。
   final MediaCollectionRow? snapshot =
       await db.getMediaCollectionById(collectionId);
+  final List<String> imagePaths =
+      await collectionOwnedImagePaths(db, collectionId);
   final int removed = await db.deleteMediaCollection(collectionId);
   await reclaimDeletedCollectionAssets(
     db,
     <MediaCollectionRow>[if (snapshot != null) snapshot],
+    ownedImagePaths: imagePaths,
     collectionCoversDirectory: collectionCoversDirectory,
   );
   return removed;
@@ -79,12 +96,17 @@ Future<int> deleteMediaCollectionWithAssets(
 Future<int> reclaimDeletedCollectionAssets(
   HibikiDatabase db,
   Iterable<MediaCollectionRow> deletedCollections, {
+  List<String> ownedImagePaths = const <String>[],
   Directory? collectionCoversDirectory,
 }) async {
   final List<String> candidates = <String>[
     for (final MediaCollectionRow collection in deletedCollections)
       for (final String? path in collectionOwnedAssetPaths(collection))
         if (path != null && path.isNotEmpty) path,
+    // v68 附加图：行已随删行 cascade 消失，路径由调用方删行前快照
+    // （[collectionOwnedImagePaths]）。文件与合集封面同目录，共用同一护栏。
+    for (final String path in ownedImagePaths)
+      if (path.isNotEmpty) path,
   ];
   // 没有任何自有资产就彻底不碰文件系统（无封面的同步 / 单测路径零 IO）。
   if (candidates.isEmpty) return 0;
@@ -96,6 +118,7 @@ Future<int> reclaimDeletedCollectionAssets(
       for (final MediaCollectionRow collection in survivors)
         for (final String? path in collectionOwnedAssetPaths(collection))
           if (path != null && path.isNotEmpty) path,
+      for (final MediaImageRow row in await db.getAllMediaImages()) row.path,
     ];
     for (final String candidate in candidates) {
       if (await VideoStorage.deleteCollectionCover(

--- a/hibiki/lib/src/media/video/scraper/collection_scrape_apply.dart
+++ b/hibiki/lib/src/media/video/scraper/collection_scrape_apply.dart
@@ -6,9 +6,11 @@
 library;
 
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:drift/drift.dart' show Value;
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart';
+import 'package:hibiki/src/media/video/video_storage.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
 /// 把一次合集刮削的产物写进库。
@@ -36,10 +38,15 @@ Future<void> applyCollectionScrape(
   int collectionId,
   CollectionScrapeResult result, {
   required String? confirmedTitle,
-}) {
+  Directory? collectionCoversDirectory,
+}) async {
   final ScrapeMetadata meta = result.metadata;
   final String scrapedTitle = (confirmedTitle ?? '').trim();
-  return db.transaction(() async {
+  // 旧图行快照必须在整组替换**前**取：替换后行没了，旧文件路径再也推导不出来
+  // （与 collection_asset_reclaim 同一顺序约束）。
+  final List<MediaImageRow> replacedImages =
+      await db.getMediaImagesForCollection(collectionId);
+  await db.transaction(() async {
     await db.updateMediaCollectionCoverPath(collectionId, result.coverPath);
     await db.upsertCollectionScrapeMeta(
       CollectionScrapeMetaCompanion.insert(
@@ -55,15 +62,69 @@ Future<void> applyCollectionScrape(
         episodeCount: Value<int?>(meta.episodeCount),
         tagsJson: Value<String?>(encodeScrapeTags(meta.tags)),
         infoboxJson: Value<String?>(encodeScrapeInfobox(meta.infobox)),
-        backdropPath: Value<String?>(result.backdropPath),
+        // v68 起横版图唯一真相源是 media_images；本列冻结为遗留残留（迁移已把
+        // 存量搬走），新写入恒 NULL，防止两处真相漂开。
+        backdropPath: const Value<String?>(null),
         detailUrl: Value<String?>(meta.detailUrl),
         scrapedAt: DateTime.now(),
       ),
     );
+    await db
+        .replaceMediaImagesForCollection(collectionId, <MediaImagesCompanion>[
+      for (final ScrapedMediaImage image in result.images)
+        MediaImagesCompanion.insert(
+          collectionId: Value<int?>(collectionId),
+          kind: image.kind.dbValue,
+          position: Value<int>(image.position),
+          path: image.path,
+          sourceUrl: Value<String?>(image.sourceUrl),
+        ),
+    ]);
     if (scrapedTitle.isNotEmpty) {
       await db.renameMediaCollection(collectionId, scrapedTitle);
     }
   });
+  // 事务外（文件 IO 不进事务）：整组替换后失去引用的旧图文件回收——v64 遗留的
+  // `<id>_backdrop.jpg` 在首次重刮后正是经这条路清掉，不留确定性泄漏。
+  await _reclaimReplacedCollectionImages(
+    db,
+    replacedImages,
+    result.images,
+    collectionCoversDirectory: collectionCoversDirectory,
+  );
+}
+
+/// 删掉整组替换后失去引用的旧附加图文件。
+///
+/// 护栏与 collection_asset_reclaim 同纪律：只删**落在合集封面目录内 + 替换后全库
+/// 无任何行引用**的文件；失败静默（合集刮削已成功是既成事实）。
+Future<void> _reclaimReplacedCollectionImages(
+  HibikiDatabase db,
+  List<MediaImageRow> before,
+  List<ScrapedMediaImage> after, {
+  Directory? collectionCoversDirectory,
+}) async {
+  final Set<String> kept = <String>{
+    for (final ScrapedMediaImage image in after) image.path,
+  };
+  final List<String> stale = <String>[
+    for (final MediaImageRow row in before)
+      if (!kept.contains(row.path)) row.path,
+  ];
+  if (stale.isEmpty) return;
+  try {
+    final Set<String> stillReferenced = <String>{
+      for (final MediaImageRow row in await db.getAllMediaImages()) row.path,
+    };
+    await VideoStorage.deleteOwnedImageFiles(
+      deletedPaths: stale,
+      stillReferencedPaths: stillReferenced,
+      ownedDir:
+          collectionCoversDirectory ?? await VideoStorage.collectionCoversDir(),
+    );
+  } catch (_) {
+    // 一张残留旧图不该让已成功的刮削流程报错；下次重刮还有机会清。
+  }
 }
 
 /// 这次刮削**该不该**征询用户改名：返回要提议的新名，返回 null = 无需询问。
@@ -99,34 +160,31 @@ String? encodeScrapeInfobox(List<ScrapeInfoboxEntry> infobox) => infobox.isEmpty
         for (final ScrapeInfoboxEntry e in infobox) e.toJson(),
       ]);
 
-/// 读回合集刮削资料为领域对象 + 横版背景路径；未刮过返回 null。
+/// 读回合集刮削资料为领域对象；未刮过返回 null。
+///
+/// v68 起横版图不再从本行读（`backdropPath` 列已冻结为遗留残留），附加图组一律
+/// 走 `getMediaImagesForCollection`。
 ///
 /// JSON 列损坏时该列降级为空列表（其余字段照常返回），不因一列坏掉丢整条资料——
 /// 与 `VideoBookRepository.scrapeMetadata` 同一容错规矩。
-({ScrapeMetadata metadata, String? backdropPath})? decodeCollectionScrapeMeta(
-  CollectionScrapeMetaRow? row,
-) {
+ScrapeMetadata? decodeCollectionScrapeMeta(CollectionScrapeMetaRow? row) {
   if (row == null) return null;
-  return (
-    metadata: ScrapeMetadata(
-      source:
-          ScrapeSource.values.asNameMap()[row.source] ?? ScrapeSource.bangumi,
-      subjectId: row.subjectId,
-      title: row.title,
-      originalTitle: row.originalTitle,
-      summary: row.summary,
-      airDate: row.airDate,
-      rating: row.rating,
-      ratingCount: row.ratingCount,
-      episodeCount: row.episodeCount,
-      tags: _decodeJsonList<ScrapeTag>(row.tagsJson, ScrapeTag.fromJson),
-      infobox: _decodeJsonList<ScrapeInfoboxEntry>(
-        row.infoboxJson,
-        ScrapeInfoboxEntry.fromJson,
-      ),
-      detailUrl: row.detailUrl,
+  return ScrapeMetadata(
+    source: ScrapeSource.values.asNameMap()[row.source] ?? ScrapeSource.bangumi,
+    subjectId: row.subjectId,
+    title: row.title,
+    originalTitle: row.originalTitle,
+    summary: row.summary,
+    airDate: row.airDate,
+    rating: row.rating,
+    ratingCount: row.ratingCount,
+    episodeCount: row.episodeCount,
+    tags: _decodeJsonList<ScrapeTag>(row.tagsJson, ScrapeTag.fromJson),
+    infobox: _decodeJsonList<ScrapeInfoboxEntry>(
+      row.infoboxJson,
+      ScrapeInfoboxEntry.fromJson,
     ),
-    backdropPath: row.backdropPath,
+    detailUrl: row.detailUrl,
   );
 }
 

--- a/hibiki/lib/src/media/video/scraper/cover_downloader.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_downloader.dart
@@ -71,9 +71,24 @@ class CoverDownloader {
   }) async {
     final Directory coversDir =
         coversDirectory ?? await VideoStorage.coversDir();
-    await coversDir.create(recursive: true);
-    final String finalPath =
-        p.join(coversDir.path, videoCoverFileName(bookUid));
+    return downloadImageFile(
+      url: url,
+      fileName: videoCoverFileName(bookUid),
+      directory: coversDir,
+    );
+  }
+
+  /// 下载 [url] 落地为 [directory]/[fileName]，返回绝对路径（v68 附加图组用：
+  /// backdrop/logo/titleCard 的文件名不是 bookUid 1:1 派生，须显式给名）。
+  ///
+  /// 与 [downloadCover] 同一套截止/重试/魔数校验/原子落盘——那是收口，不是两份。
+  Future<String> downloadImageFile({
+    required String url,
+    required String fileName,
+    required Directory directory,
+  }) async {
+    await directory.create(recursive: true);
+    final String finalPath = p.join(directory.path, fileName);
 
     // 整轮下载（含全部重试与退避）只有这一个截止：所有尝试共用同一个 abort trigger，
     // 到点时**在飞的那一次传输也被真正中止**（BUG-1248 的核心性质），并置位

--- a/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
+++ b/hibiki/lib/src/media/video/scraper/cover_scraper_service.dart
@@ -39,7 +39,7 @@ import 'package:hibiki/src/utils/misc/error_log_service.dart';
 import 'package:hibiki/src/media/video/video_cover_extractor.dart'
     show videoCoverFileName;
 import 'package:hibiki_core/hibiki_core.dart'
-    show MediaCollectionRow, VideoBookRow;
+    show MediaCollectionRow, MediaImageKind, VideoBookRow;
 import 'package:path/path.dart' as p;
 
 /// slim 缓存落盘文件名（与原始库同目录）。
@@ -167,7 +167,9 @@ class CoverScraperService {
     bool enableSidecar = true,
     Directory? coversDirectory,
     Directory? collectionCoversDirectory,
+    Directory? imagesDirectory,
   })  : _collectionCoversDirectory = collectionCoversDirectory,
+        _imagesDirectory = imagesDirectory,
         _repo = repository,
         _coverMeta = coverMetaStore,
         _aliasCache = aliasCache,
@@ -197,6 +199,9 @@ class CoverScraperService {
   /// 合集自有封面目录（测试注入临时目录；null = 取生产
   /// [VideoStorage.collectionCoversDir]）。
   final Directory? _collectionCoversDirectory;
+
+  /// 单视频附加图目录（测试注入临时目录；null = 取生产 [VideoStorage.imagesDir]）。
+  final Directory? _imagesDirectory;
 
   /// 条目详情缓存 / 失败记忆，key = `<source>:<entryId>`。见 [_persistMetadata]。
   final Map<String, ScrapeMetadata> _metadataCache = <String, ScrapeMetadata>{};
@@ -728,24 +733,11 @@ class CoverScraperService {
       coversDirectory: covers,
     );
 
-    String? backdropPath;
-    final String? backdropUrl = candidate.backdropUrl;
-    if (backdropUrl != null && backdropUrl.isNotEmpty) {
-      try {
-        // 文件名后缀 `_backdrop` 与海报同目录不同名：collections/<id>.jpg 是竖版，
-        // collections/<id>_backdrop.jpg 是横版，各自独立可重下。
-        backdropPath = await _downloader.downloadCover(
-          url: backdropUrl,
-          bookUid: '${collectionId}_backdrop',
-          coversDirectory: covers,
-        );
-      } catch (e, stack) {
-        // 见上：背景失败不升级为整体失败，但必须留日志——否则「有的合集有背景有的
-        // 没有」永远查不出是源没图还是下载挂了。
-        ErrorLogService.instance
-            .log('CoverScraperService.collectionBackdrop', e, stack);
-      }
-    }
+    final List<ScrapedMediaImage> images = await _downloadImages(
+      candidate: candidate,
+      directory: covers,
+      filePrefix: '$collectionId',
+    );
 
     ScrapeMetadata metadata;
     if (candidate.source == ScrapeSource.bangumi) {
@@ -760,9 +752,122 @@ class CoverScraperService {
 
     return CollectionScrapeResult(
       coverPath: coverPath,
-      backdropPath: backdropPath,
+      images: images,
       metadata: metadata,
     );
+  }
+
+  /// 下载附加图组（v68，Jellyfin 图组对齐；合集与散装电影共用）。
+  ///
+  /// TMDB 源走 `/images` 端点拿完整图组（多张无字 backdrop + 带字横图 + logo）；
+  /// 其余源退化为候选自带的单张 backdropUrl（AniList banner）。失败语义延续
+  /// BUG-1310 的分级：附加图是锦上添花，**任何一张失败都不升级为整体失败**——
+  /// 咽掉留日志，hero 自会回落到海报 + 模糊垫底。
+  ///
+  /// 文件名 = `<filePrefix>_backdrop<n>.jpg` / `<filePrefix>_titlecard.jpg` /
+  /// `<filePrefix>_logo.png`（logo 是透明底 PNG，扩展名如实），与海报不同名、
+  /// 各自独立可重下。v64 遗留的 `<id>_backdrop.jpg`（无序号）只存在于迁移数据里，
+  /// 新刮削不再产生。
+  Future<List<ScrapedMediaImage>> _downloadImages({
+    required ScrapeCandidate candidate,
+    required Directory directory,
+    required String filePrefix,
+  }) async {
+    // 1) 汇集远程 URL 图组。
+    TmdbImageSet set = const TmdbImageSet();
+    if (candidate.source == ScrapeSource.tmdb && _tmdb != null) {
+      try {
+        set = await _tmdb.fetchImageSet(
+          entryId: candidate.entryId,
+          isTv: candidate.type != ScrapeEntryType.movie,
+        );
+      } on ScrapeNetworkException catch (e, stack) {
+        ErrorLogService.instance
+            .log('CoverScraperService.collectionImageSet', e, stack);
+      }
+    }
+    if (set.backdropUrls.isEmpty && candidate.backdropUrl != null) {
+      // 非 TMDB 源（AniList banner）或 /images 拉挂了：候选自带的单张背景兜底，
+      // 与 v64 行为等价。
+      set = TmdbImageSet(
+        backdropUrls: <String>[candidate.backdropUrl!],
+        titleCardUrl: set.titleCardUrl,
+        logoUrl: set.logoUrl,
+      );
+    }
+    if (set.isEmpty) return const <ScrapedMediaImage>[];
+
+    // 2) 逐张落盘（单张失败跳过该张，不拖垮其余）。
+    final List<ScrapedMediaImage> images = <ScrapedMediaImage>[];
+    Future<void> fetch({
+      required MediaImageKind kind,
+      required int position,
+      required String url,
+      required String fileName,
+    }) async {
+      try {
+        final String path = await _downloader.downloadImageFile(
+          url: url,
+          fileName: fileName,
+          directory: directory,
+        );
+        images.add(ScrapedMediaImage(
+          kind: kind,
+          position: position,
+          path: path,
+          sourceUrl: url,
+        ));
+      } catch (e, stack) {
+        ErrorLogService.instance.log(
+            'CoverScraperService.collectionImage.${kind.dbValue}', e, stack);
+      }
+    }
+
+    for (int i = 0; i < set.backdropUrls.length; i++) {
+      await fetch(
+        kind: MediaImageKind.backdrop,
+        position: i,
+        url: set.backdropUrls[i],
+        fileName: '${filePrefix}_backdrop$i.jpg',
+      );
+    }
+    if (set.titleCardUrl != null) {
+      await fetch(
+        kind: MediaImageKind.titleCard,
+        position: 0,
+        url: set.titleCardUrl!,
+        fileName: '${filePrefix}_titlecard.jpg',
+      );
+    }
+    if (set.logoUrl != null) {
+      await fetch(
+        kind: MediaImageKind.logo,
+        position: 0,
+        url: set.logoUrl!,
+        fileName: '${filePrefix}_logo.png',
+      );
+    }
+    return images;
+  }
+
+  /// 散装电影的附加图组落地 + 落库（v68）。
+  ///
+  /// 只在 **movie 型候选**时调用（见 [_applyCandidate]）：剧集（tv 型）的横版图
+  /// 属于合集容器（[applyCandidateToCollection]），逐集各存一份是 N 倍冗余，且
+  /// UI 没有消费单集 backdrop 的槽位。文件落 `video_covers/images/`（GC 免疫子
+  /// 目录），行走 `media_images.bookUid` 归属。图组失败不升级为整体失败。
+  Future<void> _applyBookImages({
+    required String bookUid,
+    required ScrapeCandidate candidate,
+  }) async {
+    final Directory dir = _imagesDirectory ?? await VideoStorage.imagesDir();
+    final List<ScrapedMediaImage> images = await _downloadImages(
+      candidate: candidate,
+      directory: dir,
+      filePrefix: p.basenameWithoutExtension(videoCoverFileName(bookUid)),
+    );
+    if (images.isEmpty) return;
+    await _repo.replaceMediaImages(bookUid, images);
   }
 
   /// 对某路径推导批量/别名缓存 key（= 目录+文件合并解析后的主标题，可空）。UI 弹窗
@@ -979,6 +1084,11 @@ class CoverScraperService {
       bookUids: <String>[bookUid],
       candidate: candidate,
     );
+    // v68：电影候选顺带拉附加图组（backdrop/logo/titleCard，横版续播卡用）。
+    // tv 型跳过——那些图属于合集容器，见 [_applyBookImages]。
+    if (candidate.type == ScrapeEntryType.movie) {
+      await _applyBookImages(bookUid: bookUid, candidate: candidate);
+    }
     if (aliasKey != null && aliasKey.trim().isNotEmpty) {
       await _aliasCache.put(aliasKey, candidate.source, candidate.entryId);
     }

--- a/hibiki/lib/src/media/video/scraper/scraper_types.dart
+++ b/hibiki/lib/src/media/video/scraper/scraper_types.dart
@@ -20,6 +20,8 @@
 /// `sidecar_scanner.dart` / `cover_scraper_service.dart`。
 library;
 
+import 'package:hibiki_core/hibiki_core.dart' show MediaImageKind;
+
 /// 从文件名/目录名解析出的结构化信息（解析层输出）。
 class ParsedMediaName {
   const ParsedMediaName({
@@ -250,25 +252,48 @@ class ScrapeMetadata {
   final String? detailUrl;
 }
 
-/// 合集刮削一次落地的全部产物（BUG-1310）。
+/// 一张已落盘的附加图（刮削产物 → `media_images` 行的领域对象，v68）。
+class ScrapedMediaImage {
+  const ScrapedMediaImage({
+    required this.kind,
+    this.position = 0,
+    required this.path,
+    this.sourceUrl,
+  });
+
+  final MediaImageKind kind;
+
+  /// 同种类内排序位（仅 backdrop 允许 >0，见 `MediaImages.position`）。
+  final int position;
+
+  /// 本地文件绝对路径。
+  final String path;
+
+  /// 来源远程 URL（重下/诊断用）。
+  final String? sourceUrl;
+}
+
+/// 合集刮削一次落地的全部产物（BUG-1310；v68 起横版背景并入 [images] 图组）。
 ///
 /// 合集刮削此前只产出一张海报路径（`downloadCollectionCover` 返回 String），资料与
-/// 横版背景无处安放。本类型把三样东西一次带回给调用方写库：封面、横版背景、条目资料。
+/// 附加图无处安放。本类型把三样东西一次带回给调用方写库：封面、附加图组、条目资料。
 ///
 /// 为什么由调用方写库而不是本层直接写：刮削 service 刻意不持有 [HibikiDatabase]
 /// （见 `cover_scraper_service.dart` 顶注），不该为几列写入把整个数据库拖进它的依赖面。
 class CollectionScrapeResult {
   const CollectionScrapeResult({
     required this.coverPath,
-    this.backdropPath,
+    this.images = const <ScrapedMediaImage>[],
     required this.metadata,
   });
 
   /// 竖版海报本地路径（必有——没有海报的候选在匹配层就被滤掉了）。
   final String coverPath;
 
-  /// 横版背景本地路径；源没有横版图（Bangumi / 离线库）或下载失败时为 null。
-  final String? backdropPath;
+  /// 已落盘的附加图组（backdrop 0..n / logo / titleCard）。源没有横版图
+  /// （Bangumi / 离线库）或全部下载失败时为空列表——hero 自会回落到海报 +
+  /// 模糊垫底，那是这些源的常态路径，不是错误。
+  final List<ScrapedMediaImage> images;
 
   /// 条目资料（Bangumi 走详情端点取全量；其余源由候选自身降级拼出）。
   final ScrapeMetadata metadata;

--- a/hibiki/lib/src/media/video/scraper/tmdb_client.dart
+++ b/hibiki/lib/src/media/video/scraper/tmdb_client.dart
@@ -127,6 +127,45 @@ class TmdbClient {
         : parseTmdbCollectionParts(body);
   }
 
+  /// 拉取条目图组 `GET /3/{tv|movie}/{id}/images`（Jellyfin 图组对齐）：多张
+  /// 无字 backdrop + 带字横图（titleCard）+ 标题 logo。404 / 全空 → 空图组。
+  ///
+  /// `include_image_language` 必须显式给：`/images` 端点不受 `language` 参数的
+  /// 兜底逻辑保护，只传 `language=zh-CN` 会把无语言字段的无字横图全部滤掉。
+  Future<TmdbImageSet> fetchImageSet({
+    required String entryId,
+    required bool isTv,
+  }) async {
+    final String kind = isTv ? 'tv' : 'movie';
+    final Uri uri =
+        Uri.parse('https://api.themoviedb.org/3/$kind/$entryId/images')
+            .replace(queryParameters: <String, String>{
+      'include_image_language': 'zh,ja,en,null',
+      'api_key': _apiKey,
+    });
+    final http.Response response;
+    try {
+      response = await _client.get(
+        uri,
+        headers: const <String, String>{'Accept': 'application/json'},
+      ).timeout(_timeout);
+    } on TimeoutException {
+      throw const ScrapeNetworkException('TMDB images timed out');
+    } catch (e) {
+      throw ScrapeNetworkException(
+        redactCredentialsInText('TMDB images request failed: $e'),
+      );
+    }
+    if (response.statusCode == 404) return const TmdbImageSet();
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw ScrapeNetworkException(
+        'TMDB images HTTP ${response.statusCode}',
+        statusCode: response.statusCode,
+      );
+    }
+    return parseTmdbImageSet(utf8.decode(response.bodyBytes));
+  }
+
   /// 共享 GET：`https://api.themoviedb.org/3<path>?language=zh-CN&api_key=…`。
   /// 404 返回 null（各端点自定语义）；其余非 2xx / 网络失败抛
   /// [ScrapeNetworkException]。异常 message 统一 [redactCredentialsInText]
@@ -341,6 +380,96 @@ List<TmdbCollectionPart> parseTmdbCollectionParts(String body) {
     }
   }
   return parts;
+}
+
+/// TMDB `/images` 端点的分类产物（完整 URL）。
+///
+/// 分类规则抄 Jellyfin（`TmdbClientManager.ConvertToRemoteImageInfo`）：
+/// * `backdrops[]` 里 **`iso_639_1` 为空**的 → 无字横版背景 [backdropUrls]
+///   （全屏背景/轮换槽，永远不该有烧死的片名文字）；
+/// * `backdrops[]` 里 **带语言**的 → 带字横图 [titleCardUrl]（Jellyfin 把它降级
+///   归类为 Thumb——横版卡片槽用它，与全屏背景分开）；
+/// * `logos[]` → [logoUrl]，跳过 SVG（Flutter Image 不解码矢量）。
+class TmdbImageSet {
+  const TmdbImageSet({
+    this.backdropUrls = const <String>[],
+    this.titleCardUrl,
+    this.logoUrl,
+  });
+
+  final List<String> backdropUrls;
+  final String? titleCardUrl;
+  final String? logoUrl;
+
+  bool get isEmpty =>
+      backdropUrls.isEmpty && titleCardUrl == null && logoUrl == null;
+}
+
+/// 无字 backdrop 最多取几张（详情页 10 秒轮换用；TMDB 响应按 vote 降序，取前 N
+/// 即最受认可的 N 张。上限防冷门条目也把几十张全下到用户磁盘上）。
+const int kTmdbMaxBackdrops = 3;
+
+/// 语言偏好序（logo / 带字横图挑选用）：中文界面标题优先，其次日文原题、英文。
+const List<String> _kTmdbImageLanguagePreference = <String>['zh', 'ja', 'en'];
+
+/// 纯函数：解析 `/3/{tv|movie}/{id}/images` 响应并按 Jellyfin 规则分类。
+/// JSON 结构异常 → 抛 [ScrapeNetworkException]。
+TmdbImageSet parseTmdbImageSet(String body) {
+  final Map<String, Object?> decoded = _decodeObject(body, 'TMDB images');
+
+  List<Map<String, Object?>> itemsOf(String key) {
+    final Object? node = decoded[key];
+    if (node is! List<Object?>) return const <Map<String, Object?>>[];
+    return <Map<String, Object?>>[
+      for (final Object? item in node)
+        if (item is Map<String, Object?> &&
+            _nonEmptyString(item['file_path']) != null)
+          item,
+    ];
+  }
+
+  // 带语言序号的挑选：偏好序里最靠前的语言组第一张（组内沿用响应的 vote 降序）。
+  String? pickByLanguage(List<Map<String, Object?>> items) {
+    for (final String lang in _kTmdbImageLanguagePreference) {
+      for (final Map<String, Object?> item in items) {
+        if (_nonEmptyString(item['iso_639_1']) == lang) {
+          return _nonEmptyString(item['file_path']);
+        }
+      }
+    }
+    return items.isEmpty ? null : _nonEmptyString(items.first['file_path']);
+  }
+
+  final List<String> backdrops = <String>[];
+  final List<Map<String, Object?>> titled = <Map<String, Object?>>[];
+  for (final Map<String, Object?> item in itemsOf('backdrops')) {
+    if (_nonEmptyString(item['iso_639_1']) == null) {
+      if (backdrops.length < kTmdbMaxBackdrops) {
+        backdrops.add('${TmdbClient.backdropBase}${item['file_path']}');
+      }
+    } else {
+      titled.add(item);
+    }
+  }
+  final String? titleCardPath = pickByLanguage(titled);
+
+  final List<Map<String, Object?>> logos = <Map<String, Object?>>[
+    for (final Map<String, Object?> item in itemsOf('logos'))
+      // SVG 跳过：Flutter Image 不解码矢量；TMDB logo 常见 png/svg 混排。
+      if (!(_nonEmptyString(item['file_path']) ?? '')
+          .toLowerCase()
+          .endsWith('.svg'))
+        item,
+  ];
+  final String? logoPath = pickByLanguage(logos);
+
+  return TmdbImageSet(
+    backdropUrls: backdrops,
+    titleCardUrl: titleCardPath == null
+        ? null
+        : '${TmdbClient.backdropBase}$titleCardPath',
+    logoUrl: logoPath == null ? null : '${TmdbClient.posterBase}$logoPath',
+  );
 }
 
 /// 解 JSON 顶层对象；非对象/解码失败 → 抛 [ScrapeNetworkException]。

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -13,7 +13,12 @@ import 'package:hibiki/src/media/video/m3u8_playlist.dart' show PlaylistEntry;
 import 'package:hibiki/src/media/video/scraper/collection_member_policy.dart'
     show multiMemberCollectionIdByVideoUid;
 import 'package:hibiki/src/media/video/scraper/scraper_types.dart'
-    show ScrapeInfoboxEntry, ScrapeMetadata, ScrapeSource, ScrapeTag;
+    show
+        ScrapeInfoboxEntry,
+        ScrapeMetadata,
+        ScrapeSource,
+        ScrapeTag,
+        ScrapedMediaImage;
 import 'package:hibiki/src/media/video/video_path_migration.dart';
 import 'package:hibiki/src/media/video/video_storage.dart';
 import 'package:hibiki/src/sync/deletion_propagation.dart';
@@ -102,6 +107,23 @@ class VideoBookRepository {
 
   /// 已刮出资料的 bookUid 集合（自动刮削一次性排除已刮的，避免逐本 N+1 查询）。
   Future<Set<String>> scrapedBookUids() => _db.scrapedVideoBookUids();
+
+  /// v68：整体替换一本视频的附加图组行（散装电影 backdrop/logo/titleCard，
+  /// 重刮即替换）。文件已由刮削层落 `video_covers/images/`，本层只写行。
+  Future<void> replaceMediaImages(
+    String bookUid,
+    List<ScrapedMediaImage> images,
+  ) =>
+      _db.replaceMediaImagesForBook(bookUid, <MediaImagesCompanion>[
+        for (final ScrapedMediaImage image in images)
+          MediaImagesCompanion.insert(
+            bookUid: Value<String?>(bookUid),
+            kind: image.kind.dbValue,
+            position: Value<int>(image.position),
+            path: image.path,
+            sourceUrl: Value<String?>(image.sourceUrl),
+          ),
+      ]);
 
   /// 删一本的条目资料（「重新刮削」前先清）。
   Future<void> deleteScrapeMetadata(String bookUid) =>
@@ -597,12 +619,19 @@ class VideoBookRepository {
     final String? deletedCoverPath = book.coverPath;
     final String? deletedSubtitlePath = book.subtitleSource;
     final String deletedVideoPath = book.videoPath;
+    // v68：附加图行随删行 FK cascade 消失，路径必须删行**前**快照（与 coverPath
+    // 同一顺序约束——行一删就再也推导不出来，见 collection_asset_reclaim）。
+    final List<String> deletedImagePaths = <String>[
+      for (final MediaImageRow row in await _db.getMediaImagesForBook(bookUid))
+        row.path,
+    ];
     await deleteVideoBook(bookUid);
     await reclaimDeletedVideoBookAssets(
       deletedBookUid: bookUid,
       deletedCoverPath: deletedCoverPath,
       deletedSubtitlePath: deletedSubtitlePath,
       deletedVideoPath: deletedVideoPath,
+      deletedImagePaths: deletedImagePaths,
     );
     if (compactDatabase) {
       await compactAfterVideoDeleteBestEffort();
@@ -622,6 +651,7 @@ class VideoBookRepository {
     required String? deletedCoverPath,
     required String? deletedSubtitlePath,
     required String deletedVideoPath,
+    List<String> deletedImagePaths = const <String>[],
   }) async {
     try {
       final ({Set<String> covers, Set<String> subtitles}) refs =
@@ -632,6 +662,20 @@ class VideoBookRepository {
         stillReferencedCoverPaths: refs.covers,
         stillReferencedSubtitlePaths: refs.subtitles,
       );
+      // v68：附加图文件（video_covers/images/，行已 cascade 删除）。护栏：仍被
+      // 幸存行引用的路径保留（同名共享理论上不存在——文件名按 bookUid 派生——
+      // 但护栏与封面/字幕同纪律，宁可漏删）。
+      if (deletedImagePaths.isNotEmpty) {
+        final Set<String> survivingImagePaths = <String>{
+          for (final MediaImageRow row in await _db.getAllMediaImages())
+            row.path,
+        };
+        await VideoStorage.deleteOwnedImageFiles(
+          deletedPaths: deletedImagePaths,
+          stillReferencedPaths: survivingImagePaths,
+          ownedDir: await VideoStorage.imagesDir(),
+        );
+      }
       await VideoStorage.gcOrphanCovers(referencedCoverPaths: refs.covers);
       if (!await isDuplicateVideoPath(
         deletedVideoPath,

--- a/hibiki/lib/src/media/video/video_book_repository.dart
+++ b/hibiki/lib/src/media/video/video_book_repository.dart
@@ -108,6 +108,21 @@ class VideoBookRepository {
   /// 已刮出资料的 bookUid 集合（自动刮削一次性排除已刮的，避免逐本 N+1 查询）。
   Future<Set<String>> scrapedBookUids() => _db.scrapedVideoBookUids();
 
+  /// 一本视频的刮削资料**原始行**（播放器剧集面板判「真·集级集名」要
+  /// `episodeNumber` 列，领域对象 [ScrapeMetadata] 没带它——与合集详情页
+  /// `_episodeMetaByUid` 同一判据同一取数口）。
+  Future<VideoScrapeMetaRow?> episodeScrapeMeta(String bookUid) =>
+      _db.getVideoScrapeMeta(bookUid);
+
+  /// 合集级刮削资料行（播放器剧集面板拿作品名作集名判据）。
+  Future<CollectionScrapeMetaRow?> collectionScrapeMeta(int collectionId) =>
+      _db.getCollectionScrapeMeta(collectionId);
+
+  /// 合集附加图组（v68：播放器剧集面板的封面回退链——本集无图回落合集
+  /// titleCard/backdrop，Jellyfin Episode Primary → Series Thumb 的本仓版）。
+  Future<List<MediaImageRow>> collectionMediaImages(int collectionId) =>
+      _db.getMediaImagesForCollection(collectionId);
+
   /// v68：整体替换一本视频的附加图组行（散装电影 backdrop/logo/titleCard，
   /// 重刮即替换）。文件已由刮削层落 `video_covers/images/`，本层只写行。
   Future<void> replaceMediaImages(

--- a/hibiki/lib/src/media/video/video_episode_rail.dart
+++ b/hibiki/lib/src/media/video/video_episode_rail.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hibiki/src/media/video/cover_ui/portrait_cover_image.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 import 'package:hibiki/src/utils/misc/platform_utils.dart';
 
@@ -281,10 +282,13 @@ class _EpisodeCover extends StatelessWidget {
   Widget build(BuildContext context) {
     final ImageProvider? cover = entry.cover;
     if (cover == null) return _placeholder();
-    return Image(
+    // 16:9 横槽走朝向自适应（v68 收口）：刮到的剧照天然合槽直接铺满；没刮过的集
+    // （2:3 刮削海报 / 方图）模糊垫底 + contain 完整显示。此前这里是全域唯一还在
+    // 裸 `BoxFit.cover` 硬裁的封面消费点——竖版海报被裁成中间一条（BUG-1299 同病）。
+    return PortraitCoverImage(
       image: cover,
-      fit: BoxFit.cover,
-      errorBuilder: (_, __, ___) => _placeholder(),
+      landscapeSlot: true,
+      errorBuilder: (BuildContext _) => _placeholder(),
     );
   }
 

--- a/hibiki/lib/src/media/video/video_home_layout.dart
+++ b/hibiki/lib/src/media/video/video_home_layout.dart
@@ -149,44 +149,49 @@ bool isVideoRecentlyAdded({required int? importedAt, required DateTime now}) {
   return !at.isAfter(now) && now.difference(at) <= kVideoRecentlyAddedWindow;
 }
 
-/// hero 轮播候选（合集粒度）的选取输入。
-class VideoHeroCandidate {
+/// hero 轮播候选单元的选取输入。
+///
+/// [unit] 是调用方的单元载荷——合集**或**散装单视频（v68 起：hero 不再是
+/// 合集专属粒度。用户最后看的是散装条目时，合集门槛会让置顶不是它，见
+/// PR#712 跟进）。本函数只看三个排序事实，对单元种类无感知。
+class VideoHeroCandidate<T> {
   const VideoHeroCandidate({
-    required this.collectionId,
+    required this.unit,
     this.lastWatchedAt,
     this.latestImportedAt = 0,
     this.hasUnfinishedTrace = false,
   });
 
-  final int collectionId;
+  final T unit;
 
-  /// 成员最近观看时刻（无痕迹 = null）。
+  /// 单元最近观看时刻（合集取成员 max；无痕迹 = null）。
   final DateTime? lastWatchedAt;
 
-  /// 成员最近入库时刻毫秒 max（回落排序用）。
+  /// 单元最近入库时刻毫秒（合集取成员 max；回落排序用）。
   final int latestImportedAt;
 
-  /// 有观看痕迹且未整套看完（=「在看」）。
+  /// 有观看痕迹且未看完（=「在看」；合集 = 有痕迹且未整套看完）。
   final bool hasUnfinishedTrace;
 }
 
-/// hero 轮播内容选取：最近在看的前 [limit] 个合集；一个在看的都没有时回落
-/// 「最近添加」（按成员最近入库时刻倒序）。返回合集 id 有序列表。
-List<int> selectVideoHeroCollections(
-  List<VideoHeroCandidate> candidates, {
+/// hero 轮播内容选取：最近在看的前 [limit] 个单元（合集与散装混排，同一
+/// 「最近观看倒序」——置顶恒为用户最后在看的那个东西）；一个在看的都没有时
+/// 回落「最近添加」（按最近入库时刻倒序）。返回单元有序列表。
+List<T> selectVideoHeroUnits<T>(
+  List<VideoHeroCandidate<T>> candidates, {
   int limit = 5,
 }) {
-  final List<VideoHeroCandidate> watching = <VideoHeroCandidate>[
-    for (final VideoHeroCandidate c in candidates)
+  final List<VideoHeroCandidate<T>> watching = <VideoHeroCandidate<T>>[
+    for (final VideoHeroCandidate<T> c in candidates)
       if (c.hasUnfinishedTrace && c.lastWatchedAt != null) c,
-  ]..sort((VideoHeroCandidate a, VideoHeroCandidate b) =>
+  ]..sort((VideoHeroCandidate<T> a, VideoHeroCandidate<T> b) =>
       b.lastWatchedAt!.compareTo(a.lastWatchedAt!));
-  final List<VideoHeroCandidate> pool = watching.isNotEmpty
+  final List<VideoHeroCandidate<T>> pool = watching.isNotEmpty
       ? watching
-      : (List<VideoHeroCandidate>.of(candidates)
-        ..sort((VideoHeroCandidate a, VideoHeroCandidate b) =>
+      : (List<VideoHeroCandidate<T>>.of(candidates)
+        ..sort((VideoHeroCandidate<T> a, VideoHeroCandidate<T> b) =>
             b.latestImportedAt.compareTo(a.latestImportedAt)));
-  return <int>[
-    for (final VideoHeroCandidate c in pool.take(limit)) c.collectionId,
+  return <T>[
+    for (final VideoHeroCandidate<T> c in pool.take(limit)) c.unit,
   ];
 }

--- a/hibiki/lib/src/media/video/video_storage.dart
+++ b/hibiki/lib/src/media/video/video_storage.dart
@@ -61,6 +61,39 @@ class VideoStorage {
   static Future<Directory> collectionCoversDir() async =>
       Directory(p.join((await coversDir()).path, collectionCoversDirName));
 
+  /// **单视频**附加图（media_images，v68：散装电影 backdrop/logo/titleCard）
+  /// 子目录名。与 [collectionCoversDirName] 同理由放子目录：文件名含 kind 后缀、
+  /// 不与成员封面派生名撞车，且 [gcOrphanCovers] 非递归、子目录整体免疫（这些
+  /// 路径不在它的保留集里，同级扁平会被当孤儿删掉）。合集的附加图直接落
+  /// `collections/`（与合集封面同目录，共用删除护栏）。
+  static const String imagesDirName = 'images';
+
+  /// 单视频附加图目录绝对路径（不创建）。见 [imagesDirName]。
+  static Future<Directory> imagesDir() async =>
+      Directory(p.join((await coversDir()).path, imagesDirName));
+
+  /// 回收一批附加图文件（media_images 行已随归属 cascade 删除后调用）。
+  ///
+  /// 纪律与 [deleteBookAssets] 逐字一致：只删**非空 + 落在 [ownedDir] 内 + 不在
+  /// [stillReferencedPaths]（其余归属仍引用）**的文件；目录外一律不碰。返回实删数。
+  static Future<int> deleteOwnedImageFiles({
+    required Iterable<String> deletedPaths,
+    required Iterable<String> stillReferencedPaths,
+    required Directory ownedDir,
+  }) async {
+    int removed = 0;
+    for (final String path in deletedPaths) {
+      if (await _deleteOwnedAsset(
+        candidate: path,
+        ownedDir: ownedDir,
+        stillReferenced: stillReferencedPaths,
+      )) {
+        removed++;
+      }
+    }
+    return removed;
+  }
+
   /// 删掉被删合集自己那张封面（`MediaCollections.coverPath`）。
   ///
   /// 纪律与 [deleteBookAssets] 逐字一致：只删**非空 + 落在合集封面目录内 + 不被其余

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -19,7 +19,10 @@ import 'package:hibiki/src/media/tracking/media_tracking_repository.dart';
 import 'package:hibiki/src/media/tracking/media_tracking_service.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/galgame_repository.dart';
+import 'package:hibiki/src/media/video/cover_ui/cover_orientation_builder.dart';
 import 'package:hibiki/src/media/video/cover_ui/portrait_cover_image.dart';
+import 'package:hibiki/src/media/video/video_home_layout.dart'
+    show VideoCardOrientation;
 import 'package:hibiki/src/media/video/m3u8_playlist.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/pages/base_module_tab_page.dart';
@@ -1305,10 +1308,52 @@ class _HomeDashboardPageState
     _ContinueEntry entry, {
     bool videoLandscape = false,
   }) {
-    // 槽向：书/游戏恒竖版（BUG-1299 口径不变）；续播区的视频卡改 16:9 横版
-    // （用户拍板 + Jellyfin Continue Watching 口径）。横槽装竖图由
-    // [PortraitCoverImage] 模糊垫底承接，不会重演 BUG-1299 的硬裁。
-    final bool landscape = videoLandscape && entry.isVideo;
+    // 续播区视频卡：单行允许横竖混排（用户拍板「继续观看只有一行，混排不破
+    // 排版；书架里不可以」）——朝向随**选图链选中的那张图**探测：titleCard /
+    // backdrop（天然 16:9）→ 横卡；只有竖版海报 → 自然竖卡，不强制模糊垫底成
+    // 16:9。书 / 游戏 /「最近添加」行恒竖版（BUG-1299 口径不变）。探测与卡内
+    // 渲染共用同一 provider 键，零额外解码（CoverOrientationBuilder 契约）。
+    if (videoLandscape && entry.isVideo) {
+      final ImageProvider? probe =
+          _continueArtworkProvider(entry) ?? _continueVideoCoverProvider(entry);
+      return CoverOrientationBuilder(
+        image: probe,
+        builder: (BuildContext context, VideoCardOrientation orientation) =>
+            _buildContinueCardBody(
+          tokens,
+          appModel,
+          entry,
+          landscape: orientation == VideoCardOrientation.landscape,
+        ),
+      );
+    }
+    return _buildContinueCardBody(tokens, appModel, entry, landscape: false);
+  }
+
+  /// 续播视频卡的朝向探测 provider（与 [_continueCover] 渲染路共用键）：远端走
+  /// 互联封面，本地走条目封面；取不到 → null（探测默认竖卡）。
+  ImageProvider? _continueVideoCoverProvider(_ContinueEntry entry) {
+    final RemoteContinueCandidate? remote = entry.remote;
+    if (remote != null) {
+      final RemoteCoverFetcher? fetcher = _remoteCoverFetcher;
+      final String? url = remote.coverUrl;
+      if (url == null || url.isEmpty || fetcher == null) return null;
+      return RemoteCoverImage(url, fetcher, cacheKey: remote.id);
+    }
+    final VideoBookRow? video = entry.video;
+    if (video == null) return null;
+    return resolveMediaCoverImage(
+      kind: MediaKind.video,
+      localPath: video.coverPath,
+    );
+  }
+
+  Widget _buildContinueCardBody(
+    HibikiDesignTokens tokens,
+    AppModel appModel,
+    _ContinueEntry entry, {
+    required bool landscape,
+  }) {
     final double coverWidth =
         landscape ? _kContinueCoverHeight * 16 / 9 : _kContinueCoverWidth;
     // BUG-1111：游戏没有阅读百分比（无完成度概念），状态段只标类型，不能套用

--- a/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dashboard_page.dart
@@ -95,12 +95,16 @@ class _ContinueEntry {
     this.percent = 0,
     this.progress,
     this.collectionName,
+    this.collectionId,
     this.subtitleOverride,
     this.book,
     this.video,
     this.game,
     this.remote,
   });
+
+  /// 所属主合集 id（v68 横版选图链按它取合集附加图组）；null = 散卡。
+  final int? collectionId;
 
   /// 本条的媒体种类。书按真实身份区分 [MediaKind.epub] / [MediaKind.srt]
   /// （两者在本区块行为一致，经 [isBook] 归并），不再用一个 bool 硬编码二元。
@@ -408,6 +412,13 @@ class _HomeDashboardPageState
   /// [initState] 异步载入的视频库（继续观看 + 视频计数）。
   List<VideoBookRow> _videos = const <VideoBookRow>[];
 
+  /// v68 附加图组（media_images）按归属分桶：续播区视频横卡的选图链
+  /// （合集带字横图 → 无字背景 → 目标集封面）。与视频库同批预取。
+  Map<int, List<MediaImageRow>> _mediaImagesByCollection =
+      const <int, List<MediaImageRow>>{};
+  Map<String, List<MediaImageRow>> _mediaImagesByBookUid =
+      const <String, List<MediaImageRow>>{};
+
   /// [_loadDashboardDataUnsafe] 载入的游戏库整表缓存（P4：日明细「游戏」节 +
   /// 活动时间轴游戏行的显示名反查用；空表 = 库为空或尚未载入）。
   List<GalgameEntry> _games = const <GalgameEntry>[];
@@ -575,6 +586,19 @@ class _HomeDashboardPageState
     };
     final Map<String, int> primaryByEntry =
         await db.getPrimaryCollectionIdByEntry();
+    // v68 附加图组：一次全表查询按归属分桶（续播区视频横卡选图链）。
+    final Map<int, List<MediaImageRow>> imagesByCollection =
+        <int, List<MediaImageRow>>{};
+    final Map<String, List<MediaImageRow>> imagesByBookUid =
+        <String, List<MediaImageRow>>{};
+    for (final MediaImageRow imageRow in await db.getAllMediaImages()) {
+      final int? cid = imageRow.collectionId;
+      if (cid != null) {
+        (imagesByCollection[cid] ??= <MediaImageRow>[]).add(imageRow);
+      } else if (imageRow.bookUid case final String uid) {
+        (imagesByBookUid[uid] ??= <MediaImageRow>[]).add(imageRow);
+      }
+    }
     // 组内序：条目在其主折叠合集里的 sortIndex（视频页/书架 _loadShelfMaps 同
     // 口径——一次 getAllCollectionItems 内存分组，只记归属主合集的行）。
     final Map<String, int> memberSortIndex = <String, int>{};
@@ -674,6 +698,8 @@ class _HomeDashboardPageState
       _watchRows = watch;
       _collectionNamesById = collectionNamesById;
       _primaryCollectionByEntry = primaryByEntry;
+      _mediaImagesByCollection = imagesByCollection;
+      _mediaImagesByBookUid = imagesByBookUid;
       _bookKeyByTitle = bookKeyByTitle;
       _epubImportedAtByKey = epubImportedAtByKey;
       _memberSortIndex = memberSortIndex;
@@ -966,6 +992,7 @@ class _HomeDashboardPageState
       entries.add(_videoContinueEntry(
         resume,
         collectionName: _collectionNamesById[ce.key],
+        collectionId: ce.key,
         recentMs: recent,
       ));
     }
@@ -1053,16 +1080,22 @@ class _HomeDashboardPageState
       ),
       child: filtered.isEmpty
           ? Text(t.home_activity_empty, style: tokens.type.metadata)
-          : _continueCardsRow(tokens, appModel, filtered),
+          : _continueCardsRow(tokens, appModel, filtered, videoLandscape: true),
     );
   }
 
   /// 横滑卡片行本体（「继续」与「最近添加」共用）：定高横向 ListView。
+  ///
+  /// [videoLandscape]：续播区传 true——视频卡 16:9 横槽（用户拍板「续播行只对
+  /// 视频改横版，书/游戏维持竖版」，Jellyfin Continue Watching 口径）；「最近
+  /// 添加」传 false 维持全竖版现状。行高不变：两种卡封面同高、宽度不同，底边
+  /// 天然对齐（video_home_layout 同款几何）。
   Widget _continueCardsRow(
     HibikiDesignTokens tokens,
     AppModel appModel,
-    List<_ContinueEntry> entries,
-  ) {
+    List<_ContinueEntry> entries, {
+    bool videoLandscape = false,
+  }) {
     return SizedBox(
       height: _continueRowHeight(context, tokens),
       // 桌面默认 MaterialScrollBehavior 的 dragDevices 不含鼠标——横排行
@@ -1075,8 +1108,12 @@ class _HomeDashboardPageState
           itemCount: entries.length,
           separatorBuilder: (BuildContext _, int __) =>
               SizedBox(width: tokens.spacing.gap),
-          itemBuilder: (BuildContext context, int i) =>
-              _buildContinueCard(tokens, appModel, entries[i]),
+          itemBuilder: (BuildContext context, int i) => _buildContinueCard(
+            tokens,
+            appModel,
+            entries[i],
+            videoLandscape: videoLandscape,
+          ),
         ),
       ),
     );
@@ -1192,6 +1229,7 @@ class _HomeDashboardPageState
   _ContinueEntry _videoContinueEntry(
     VideoBookRow v, {
     required String? collectionName,
+    int? collectionId,
     required int recentMs,
   }) {
     return _ContinueEntry(
@@ -1204,6 +1242,7 @@ class _HomeDashboardPageState
         episodeCount: playlistEpisodeCount(v.playlistJson),
       ),
       collectionName: collectionName,
+      collectionId: collectionId,
       video: v,
     );
   }
@@ -1263,10 +1302,15 @@ class _HomeDashboardPageState
   Widget _buildContinueCard(
     HibikiDesignTokens tokens,
     AppModel appModel,
-    _ContinueEntry entry,
-  ) {
-    // BUG-1299：三类条目统一竖版槽（见 [_kContinueCoverWidth] 注释）。
-    const double coverWidth = _kContinueCoverWidth;
+    _ContinueEntry entry, {
+    bool videoLandscape = false,
+  }) {
+    // 槽向：书/游戏恒竖版（BUG-1299 口径不变）；续播区的视频卡改 16:9 横版
+    // （用户拍板 + Jellyfin Continue Watching 口径）。横槽装竖图由
+    // [PortraitCoverImage] 模糊垫底承接，不会重演 BUG-1299 的硬裁。
+    final bool landscape = videoLandscape && entry.isVideo;
+    final double coverWidth =
+        landscape ? _kContinueCoverHeight * 16 / 9 : _kContinueCoverWidth;
     // BUG-1111：游戏没有阅读百分比（无完成度概念），状态段只标类型，不能套用
     // 书的「阅读 · x%」——否则一律显示「阅读 · 0%」。
     String status = switch (entry.kind) {
@@ -1303,7 +1347,8 @@ class _HomeDashboardPageState
                 child: Stack(
                   fit: StackFit.expand,
                   children: <Widget>[
-                    _continueCover(tokens, appModel, entry),
+                    _continueCover(tokens, appModel, entry,
+                        landscapeSlot: landscape),
                     // 进度条贴封面底部（home_video_page 视频卡同款范式）；算不出
                     // 进度（progress==null）时不画。
                     if (entry.progress case final double progress)
@@ -1351,10 +1396,27 @@ class _HomeDashboardPageState
   Widget _continueCover(
     HibikiDesignTokens tokens,
     AppModel appModel,
-    _ContinueEntry entry,
-  ) {
-    if (entry.remote != null) return _remoteCover(tokens, entry);
-    if (entry.isVideo) return _videoCover(tokens, entry.video!);
+    _ContinueEntry entry, {
+    bool landscapeSlot = false,
+  }) {
+    if (entry.remote != null) {
+      return _remoteCover(tokens, entry, landscapeSlot: landscapeSlot);
+    }
+    if (entry.isVideo) {
+      // v68 横版选图链（Jellyfin preferThumb 口径）：合集/散装的带字横图 →
+      // 无字背景 → 目标集封面（剧照天然合槽；竖版海报模糊垫底）。
+      final ImageProvider? artwork =
+          landscapeSlot ? _continueArtworkProvider(entry) : null;
+      if (artwork != null) {
+        return PortraitCoverImage(
+          image: artwork,
+          landscapeSlot: true,
+          errorBuilder: (BuildContext _) => _coverPlaceholder(
+              tokens, mediaCoverFallbackIcon(MediaKind.video)),
+        );
+      }
+      return _videoCover(tokens, entry.video!, landscapeSlot: landscapeSlot);
+    }
     if (entry.isGame) return _gameCover(tokens, entry.game!);
     return FadeInImage(
       placeholder: MemoryImage(kTransparentImage),
@@ -1370,7 +1432,11 @@ class _HomeDashboardPageState
 
   /// 远端条目封面：互联 coverUrl + 取图器可用则 [RemoteCoverImage]（按稳定 id
   /// 磁盘缓存），否则占位图标。
-  Widget _remoteCover(HibikiDesignTokens tokens, _ContinueEntry entry) {
+  Widget _remoteCover(
+    HibikiDesignTokens tokens,
+    _ContinueEntry entry, {
+    bool landscapeSlot = false,
+  }) {
     final RemoteContinueCandidate remote = entry.remote!;
     final String? coverUrl = remote.coverUrl;
     final RemoteCoverFetcher? fetcher = _remoteCoverFetcher;
@@ -1382,8 +1448,32 @@ class _HomeDashboardPageState
     // BUG-1299：远端封面横竖不可知（host 侧可能是截帧也可能是海报），槽向自适应。
     return PortraitCoverImage(
       image: RemoteCoverImage(coverUrl, fetcher, cacheKey: remote.id),
+      landscapeSlot: landscapeSlot,
       errorBuilder: (BuildContext _) => _coverPlaceholder(tokens, icon),
     );
+  }
+
+  /// v68：续播视频卡的附加图 provider（合集归属查合集图组，散卡查视频图组；
+  /// titleCard 优先于 backdrop）。null = 无附加图，回落条目封面。
+  ImageProvider? _continueArtworkProvider(_ContinueEntry entry) {
+    final List<MediaImageRow>? rows = entry.collectionId != null
+        ? _mediaImagesByCollection[entry.collectionId]
+        : _mediaImagesByBookUid[entry.video?.bookUid];
+    if (rows == null) return null;
+    for (final MediaImageKind kind in const <MediaImageKind>[
+      MediaImageKind.titleCard,
+      MediaImageKind.backdrop,
+    ]) {
+      for (final MediaImageRow row in rows) {
+        if (row.kind == kind.dbValue && row.path.isNotEmpty) {
+          return resolveMediaCoverImage(
+            kind: MediaKind.video,
+            localPath: row.path,
+          );
+        }
+      }
+    }
+    return null;
   }
 
   /// 视频封面：来源解析与游戏/剧集列表共用 [resolveMediaCoverImage]。

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -281,6 +281,11 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 刮削资料（hero 轮播的 backdrop / 简介 / airDate），与 [_loadLibraryMaps]
   /// 同批预取（批量 DAO，无 N+1）。
   Map<String, int> _airYearByUid = const <String, int>{};
+
+  /// 条目刮削资料整行（uid → 行）：散装单元上 hero 时的简介/放送日期数据源
+  /// （v68 hero 收散装）。与 [_airYearByUid] 同一次全表查询派生。
+  Map<String, VideoScrapeMetaRow> _videoScrapeMetaByUid =
+      const <String, VideoScrapeMetaRow>{};
   Map<int, CollectionScrapeMetaRow> _collectionScrapeMetaById =
       const <int, CollectionScrapeMetaRow>{};
 
@@ -485,6 +490,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       for (final VideoScrapeMetaRow r in scrapeRows)
         if (videoAirYear(r.airDate) case final int year) r.bookUid: year,
     };
+    final Map<String, VideoScrapeMetaRow> scrapeMetaByUid =
+        <String, VideoScrapeMetaRow>{
+      for (final VideoScrapeMetaRow r in scrapeRows) r.bookUid: r,
+    };
     final Map<int, CollectionScrapeMetaRow> collectionMetaById =
         <int, CollectionScrapeMetaRow>{
       for (final CollectionScrapeMetaRow r
@@ -515,6 +524,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         _watchAtByUid = watchByUid;
         _legacyWatchAtByTitle = legacyByTitle;
         _airYearByUid = airYearByUid;
+        _videoScrapeMetaByUid = scrapeMetaByUid;
         _collectionScrapeMetaById = collectionMetaById;
         _mediaImagesByCollection = imagesByCollection;
         _mediaImagesByBookUid = imagesByBookUid;
@@ -2355,19 +2365,41 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
   }
 
-  /// hero 轮播数据：按主折叠归属聚合本地成员 → 候选（在看优先、回落最近添加，
-  /// [selectVideoHeroCollections] 纯函数，测试同源）→ 前 5 个合集。远端合集本地
-  /// 无 id 不进 hero（hero 是合集粒度；远端进度条目走「继续观看」行）。
+  /// hero 轮播数据：本地条目按主折叠归属聚成**合集单元**，无归属且**在看**的
+  /// 成为**散装单元**（v68：此前散装被整体排除，用户最后看的是散装时置顶就不是
+  /// 「上一个观看的」），两类同池按最近观看倒序选前 5（[selectVideoHeroUnits]
+  /// 纯函数，测试同源）。「最近添加」回落池维持合集粒度——散装不占回落位，零
+  /// 观看库的 hero 形态与从前完全一致。远端条目本地无行不进 hero（远端进度条目
+  /// 走「继续观看」行）。
   List<_VideoHeroItem> _heroItems(List<VideoBookRow> all) {
     final Map<int, List<VideoBookRow>> membersByCollection =
         <int, List<VideoBookRow>>{};
+    final List<VideoBookRow> standaloneBooks = <VideoBookRow>[];
     for (final VideoBookRow book in all) {
       final int? cid =
           _primaryCollectionByEntry[MediaKind.video.compositeKey(book.bookUid)];
-      if (cid == null || !_collectionsById.containsKey(cid)) continue;
+      if (cid == null || !_collectionsById.containsKey(cid)) {
+        standaloneBooks.add(book);
+        continue;
+      }
       membersByCollection.putIfAbsent(cid, () => <VideoBookRow>[]).add(book);
     }
-    final List<VideoHeroCandidate> candidates = <VideoHeroCandidate>[];
+    final List<VideoHeroCandidate<_VideoHeroItem>> candidates =
+        <VideoHeroCandidate<_VideoHeroItem>>[];
+    for (final VideoBookRow book in standaloneBooks) {
+      // 散装只在「在看」（有断点且未看完）时进候选：用户诉求是「置顶 = 上一个
+      // 观看的」，进在看池混排即可满足；**不进**「最近添加」回落池——否则单
+      // 文件库刚导入一个视频顶上就平白多一块大图，且与下方墙卡同屏重复。
+      if (book.lastPositionMs <= 0 || book.completedAt != null) continue;
+      final DateTime? at =
+          _watchAtByUid[book.bookUid] ?? _legacyWatchAtByTitle[book.title];
+      candidates.add(VideoHeroCandidate<_VideoHeroItem>(
+        unit: _VideoHeroItem.standalone(book),
+        lastWatchedAt: at,
+        latestImportedAt: 0,
+        hasUnfinishedTrace: true,
+      ));
+    }
     membersByCollection.forEach((int cid, List<VideoBookRow> members) {
       // 组内序与合集详情/播放器同源（memberSortIndex）。
       members.sort((VideoBookRow a, VideoBookRow b) {
@@ -2394,22 +2426,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         if (m.completedAt != null) completed++;
         if (m.completedAt != null || m.lastPositionMs > 0) hasTrace = true;
       }
-      candidates.add(VideoHeroCandidate(
-        collectionId: cid,
+      candidates.add(VideoHeroCandidate<_VideoHeroItem>(
+        unit: _VideoHeroItem.collection(
+          collection: _collectionsById[cid]!,
+          members: members,
+          meta: _collectionScrapeMetaById[cid],
+        ),
         lastWatchedAt: lastWatched,
         latestImportedAt: latestImported,
         hasUnfinishedTrace: hasTrace && completed < members.length,
       ));
     });
-    final List<int> picked = selectVideoHeroCollections(candidates);
-    return <_VideoHeroItem>[
-      for (final int cid in picked)
-        _VideoHeroItem(
-          collection: _collectionsById[cid]!,
-          members: membersByCollection[cid]!,
-          meta: _collectionScrapeMetaById[cid],
-        ),
-    ];
+    return selectVideoHeroUnits<_VideoHeroItem>(candidates);
   }
 
   /// 全宽 backdrop hero 轮播。手动切换（滑动 + 右下指示条点击），**禁自动轮播**
@@ -2479,27 +2507,34 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
   }
 
-  /// hero 单页：backdrop（合集刮削 backdropPath 优先 → 成员封面回落，
+  /// hero 单页：backdrop（media_images 横图优先 → 封面回落，
   /// [LandscapeCoverImage] 朝向分流：竖版海报模糊垫底 + contain 前景）+ 左下
-  /// 资料列（季节/年份 · 标题 · 已看 N 集 · 简介两行）+「继续看·第 N 集」
-  /// FilledButton /「详情」按钮分工。背景整面点击 = 进合集详情（与「详情」同
-  /// 路），续播只走 FilledButton。渐变 scrim 走 overlays 注入（层序由组件保证：
-  /// 盖模糊垫底、不压清晰海报前景，BUG-1298 血缘）。
+  /// 资料列（季节/年份 · 标题/logo · 已看 N 集 · 简介两行）+ 续播
+  /// FilledButton /「详情」按钮分工。合集页背景整面点击 = 进合集详情（与
+  /// 「详情」同路）；散装页（v68 起可进 hero）背景点击 = 直接续播（散装没有
+  /// 详情页，「详情」按钮也不出现）。渐变 scrim 走 overlays 注入（层序由组件
+  /// 保证：盖模糊垫底、不压清晰海报前景，BUG-1298 血缘）。
   Widget _buildHeroPage(_VideoHeroItem item) {
     final ThemeData theme = Theme.of(context);
-    // v68：横版背景/logo 走 media_images（v64 的 backdropPath 列已由迁移搬入，
-    // 读它就覆盖了存量数据）。背景无横图回落成员封面（LandscapeCoverImage 垫底）。
-    final List<MediaImageRow>? images =
-        _mediaImagesByCollection[item.collection.id];
+    final MediaCollectionRow? collection = item.collection;
+    final VideoBookRow? standalone = item.standalone;
+    // v68：横版背景/logo 走 media_images（合集归属 / 散装电影的 bookUid 归属）。
+    // 背景无横图回落封面（成员借用链 / 散装自身封面），LandscapeCoverImage 垫底。
+    final List<MediaImageRow>? images = collection != null
+        ? _mediaImagesByCollection[collection.id]
+        : _mediaImagesByBookUid[standalone!.bookUid];
     final ImageProvider? background = _mediaImageProvider(
           images,
           const <MediaImageKind>[MediaImageKind.backdrop],
         ) ??
-        _collectionMembersCoverProvider(item.members);
+        (collection != null
+            ? _collectionMembersCoverProvider(item.members)
+            : _localCoverProvider(standalone!));
     final ImageProvider? logo = _mediaImageProvider(
       images,
       const <MediaImageKind>[MediaImageKind.logo],
     );
+    final String title = collection?.name ?? standalone!.title;
     int completedCount = 0;
     final List<CollectionMemberProgress> progresses =
         <CollectionMemberProgress>[
@@ -2515,8 +2550,20 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final int continueEp = item.members.isEmpty
         ? 1
         : continueMemberIndex(progresses).clamp(0, item.members.length - 1) + 1;
-    final String? airLabel = _heroAirLabel(item.meta);
-    final String? summary = item.meta?.summary?.trim();
+    // 资料：合集读合集刮削行；散装读条目刮削行（电影的作品级资料就在这）。
+    final VideoScrapeMetaRow? standaloneMeta =
+        standalone == null ? null : _videoScrapeMetaByUid[standalone.bookUid];
+    final String? airLabel =
+        _heroAirLabel(item.meta?.airDate ?? standaloneMeta?.airDate);
+    final String? summary =
+        (item.meta?.summary ?? standaloneMeta?.summary)?.trim();
+    // 散装的主按钮语义：有断点 =「继续观看」，全新 =「播放」；合集恒
+    // 「继续看·第 N 集」。背景整面点击与主按钮同路。
+    final VoidCallback? primaryAction = _selectionMode
+        ? null
+        : (collection != null
+            ? () => _openHeroContinue(item)
+            : () => unawaited(_open(standalone!)));
     final TextStyle? titleStyle = theme.textTheme.headlineSmall?.copyWith(
       color: Colors.white,
       fontWeight: FontWeight.w800,
@@ -2546,15 +2593,18 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                 ColoredBox(color: theme.colorScheme.surfaceContainer),
           );
     return Stack(
-      key: ValueKey<String>('home_video_hero_page_${item.collection.id}'),
+      key: ValueKey<String>('home_video_hero_page_${item.pageKey}'),
       fit: StackFit.expand,
       children: <Widget>[
         GestureDetector(
           // 多选纪律（PR#664 复核）：多选态下 hero 不导航（进详情会把批量操作
           // 中途弹走页面）；按钮同门控（onPressed=null 渲染禁用态，见下）。
+          // 合集页背景点击进详情；散装页无详情页，与主按钮同路直接开播。
           onTap: _selectionMode
               ? null
-              : () => _openCollectionDetail(item.collection),
+              : (collection != null
+                  ? () => _openCollectionDetail(collection)
+                  : primaryAction),
           child: backgroundWidget,
         ),
         // 资料列自身不拦背景点击（按钮仍各自可点）。
@@ -2575,22 +2625,22 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                     ),
                   ),
                 ),
-              // v68：有标题 logo 用图（Jellyfin 式），语义/回落仍是合集名文字。
+              // v68：有标题 logo 用图（Jellyfin 式），语义/回落仍是标题文字。
               if (logo != null)
                 Semantics(
-                  label: item.collection.name,
+                  label: title,
                   image: true,
                   child: ConstrainedBox(
                     constraints:
                         const BoxConstraints(maxHeight: 76, maxWidth: 360),
                     child: Image(
                       key: ValueKey<String>(
-                          'home_video_hero_logo_${item.collection.id}'),
+                          'home_video_hero_logo_${item.pageKey}'),
                       image: logo,
                       fit: BoxFit.contain,
                       alignment: AlignmentDirectional.bottomStart,
                       errorBuilder: (_, __, ___) => Text(
-                        item.collection.name,
+                        title,
                         maxLines: 2,
                         overflow: TextOverflow.ellipsis,
                         style: titleStyle,
@@ -2600,23 +2650,26 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                 )
               else
                 ShelfTitleOverflowTooltip(
-                  title: item.collection.name,
+                  title: title,
                   style: titleStyle,
                   maxLines: 2,
                   child: Text(
-                    item.collection.name,
+                    title,
                     maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: titleStyle,
                   ),
                 ),
-              const SizedBox(height: 4),
-              Text(
-                t.video_hero_episodes_watched(n: completedCount),
-                style: theme.textTheme.bodySmall?.copyWith(
-                  color: Colors.white.withValues(alpha: 0.82),
+              // 「已看 N 集」是合集语义；散装单条目不显示（没有集的概念）。
+              if (collection != null) ...<Widget>[
+                const SizedBox(height: 4),
+                Text(
+                  t.video_hero_episodes_watched(n: completedCount),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: Colors.white.withValues(alpha: 0.82),
+                  ),
                 ),
-              ),
+              ],
               if (summary != null && summary.isNotEmpty)
                 Padding(
                   padding: const EdgeInsets.only(top: 6),
@@ -2633,29 +2686,37 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
               Row(
                 children: <Widget>[
                   FilledButton.icon(
-                    key: ValueKey<String>(
-                        'home_video_hero_continue_${item.collection.id}'),
-                    onPressed:
-                        _selectionMode ? null : () => _openHeroContinue(item),
+                    // 合集页 key 沿用 '<id>'（既有 widget 测试锁它）；散装页
+                    // 走 pageKey（'b<uid>'），两个 key 空间不撞。
+                    key: ValueKey<String>(collection != null
+                        ? 'home_video_hero_continue_${collection.id}'
+                        : 'home_video_hero_continue_${item.pageKey}'),
+                    onPressed: primaryAction,
                     icon: const Icon(Icons.play_arrow),
-                    label: Text(t.collection_continue_progress(n: continueEp)),
+                    label: Text(collection != null
+                        ? t.collection_continue_progress(n: continueEp)
+                        : (standalone!.lastPositionMs > 0
+                            ? t.video_continue_watching
+                            : t.collection_play)),
                   ),
-                  const SizedBox(width: 12),
-                  OutlinedButton.icon(
-                    key: ValueKey<String>(
-                        'home_video_hero_detail_${item.collection.id}'),
-                    onPressed: _selectionMode
-                        ? null
-                        : () => _openCollectionDetail(item.collection),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: Colors.white,
-                      side: BorderSide(
-                        color: Colors.white.withValues(alpha: 0.5),
+                  if (collection != null) ...<Widget>[
+                    const SizedBox(width: 12),
+                    OutlinedButton.icon(
+                      key: ValueKey<String>(
+                          'home_video_hero_detail_${collection.id}'),
+                      onPressed: _selectionMode
+                          ? null
+                          : () => _openCollectionDetail(collection),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.white,
+                        side: BorderSide(
+                          color: Colors.white.withValues(alpha: 0.5),
+                        ),
                       ),
+                      icon: const Icon(Icons.info_outline),
+                      label: Text(t.video_hero_detail_view),
                     ),
-                    icon: const Icon(Icons.info_outline),
-                    label: Text(t.video_hero_detail_view),
-                  ),
+                  ],
                 ],
               ),
             ],
@@ -2667,10 +2728,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
 
   /// 季节/年份行：`2024 · 春`；无月份只显年份；无刮削年份返回 null（整行隐藏）。
   /// 季度对齐番剧习惯（1-3 冬 / 4-6 春 / 7-9 夏 / 10-12 秋）。
-  String? _heroAirLabel(CollectionScrapeMetaRow? meta) {
-    final int? year = videoAirYear(meta?.airDate);
+  /// 入参收成裸 airDate 字符串：合集页给合集刮削行的、散装页给条目刮削行的，
+  /// 同一个格式同一个解析。
+  String? _heroAirLabel(String? airDate) {
+    final int? year = videoAirYear(airDate);
     if (year == null) return null;
-    final String? season = switch (videoAirSeasonQuarter(meta?.airDate)) {
+    final String? season = switch (videoAirSeasonQuarter(airDate)) {
       1 => t.video_air_season_winter,
       2 => t.video_air_season_spring,
       3 => t.video_air_season_summer,
@@ -2682,8 +2745,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
 
   /// 「继续看·第 N 集」落地：Next-Up 纯函数选集（[continueMemberIndex]，与合集
   /// 卡进度行同源）→ 共享路由入口带合集上下文开播（剧集面板/上下集/连播）。
+  /// 只服务合集单元；散装单元的主按钮直接 `_open(book)`（见 [_buildHeroPage]）。
   void _openHeroContinue(_VideoHeroItem item) {
-    if (item.members.isEmpty) return;
+    final MediaCollectionRow? collection = item.collection;
+    if (collection == null || item.members.isEmpty) return;
     final List<CollectionMemberProgress> progresses =
         <CollectionMemberProgress>[
       for (final VideoBookRow m in item.members)
@@ -2696,7 +2761,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         continueMemberIndex(progresses).clamp(0, item.members.length - 1);
     unawaited(_open(
       item.members[index],
-      playlistCollectionId: item.collection.id,
+      playlistCollectionId: collection.id,
     ));
   }
 
@@ -5143,16 +5208,33 @@ class _VideoRowItem {
 
 /// hero 轮播一页（TODO-2486）：合集 + 组内有序成员 + 刮削资料（可空 = 无
 /// backdrop/简介，回落成员封面、对应行隐藏）。
+/// hero 轮播单页数据：合集单元（成员 + 合集刮削资料）或散装单视频单元，
+/// 二者恰一非空（v68：散装此前进不了 hero，用户最后看的是散装时置顶就不是
+/// 「上一个观看的」——现在两类同池按最近观看排序）。
 class _VideoHeroItem {
-  const _VideoHeroItem({
-    required this.collection,
+  const _VideoHeroItem.collection({
+    required MediaCollectionRow this.collection,
     required this.members,
     this.meta,
-  });
+  }) : standalone = null;
 
-  final MediaCollectionRow collection;
+  const _VideoHeroItem.standalone(VideoBookRow this.standalone)
+      : collection = null,
+        members = const <VideoBookRow>[],
+        meta = null;
+
+  final MediaCollectionRow? collection;
   final List<VideoBookRow> members;
   final CollectionScrapeMetaRow? meta;
+
+  /// 散装单视频（电影/单集条目）。
+  final VideoBookRow? standalone;
+
+  /// 轮播页稳定 key（合集 `c<id>` / 散装 `b<uid>`，两个 id 空间不撞）。
+  String get pageKey {
+    final MediaCollectionRow? c = collection;
+    return c != null ? 'c${c.id}' : 'b${standalone!.bookUid}';
+  }
 }
 
 /// 视频库分组 union 载荷（多端库联合视图 §2.3 任务10）：本地视频行 [local] 或

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -284,6 +284,13 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   Map<int, CollectionScrapeMetaRow> _collectionScrapeMetaById =
       const <int, CollectionScrapeMetaRow>{};
 
+  /// v68 附加图组（media_images）按归属分桶：合集（hero 背景/logo、续播行横卡）
+  /// 与散装视频（续播行横卡）。与 [_loadLibraryMaps] 同批预取（一次全表查询）。
+  Map<int, List<MediaImageRow>> _mediaImagesByCollection =
+      const <int, List<MediaImageRow>>{};
+  Map<String, List<MediaImageRow>> _mediaImagesByBookUid =
+      const <String, List<MediaImageRow>>{};
+
   /// TODO-2486：年份 / 看完状态下拉筛选（本地即筛，刻意不持久化——与搜索词同
   /// 一决定：下次进库还挂着上次的筛选只会让人以为库空了）。
   VideoYearFilter _yearFilter = const VideoYearFilter.all();
@@ -484,6 +491,19 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
           in await db.getAllCollectionScrapeMeta())
         r.collectionId: r,
     };
+    // v68 附加图组：一次全表查询按归属分桶（hero 背景/logo、续播行横卡）。
+    final Map<int, List<MediaImageRow>> imagesByCollection =
+        <int, List<MediaImageRow>>{};
+    final Map<String, List<MediaImageRow>> imagesByBookUid =
+        <String, List<MediaImageRow>>{};
+    for (final MediaImageRow row in await db.getAllMediaImages()) {
+      final int? cid = row.collectionId;
+      if (cid != null) {
+        (imagesByCollection[cid] ??= <MediaImageRow>[]).add(row);
+      } else if (row.bookUid case final String uid) {
+        (imagesByBookUid[uid] ??= <MediaImageRow>[]).add(row);
+      }
+    }
     if (mounted) {
       setState(() {
         _sortMode = sortMode;
@@ -496,8 +516,27 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         _legacyWatchAtByTitle = legacyByTitle;
         _airYearByUid = airYearByUid;
         _collectionScrapeMetaById = collectionMetaById;
+        _mediaImagesByCollection = imagesByCollection;
+        _mediaImagesByBookUid = imagesByBookUid;
       });
     }
+  }
+
+  /// 附加图组里按种类偏好取首张可用图的 provider（文件悬空 = 视作没有）。
+  /// 探测与渲染共用 [resizedFileImage] 的解码缓存键，零额外解码。
+  ImageProvider? _mediaImageProvider(
+    List<MediaImageRow>? rows,
+    List<MediaImageKind> preference,
+  ) {
+    if (rows == null) return null;
+    for (final MediaImageKind kind in preference) {
+      for (final MediaImageRow row in rows) {
+        if (row.kind != kind.dbValue || row.path.isEmpty) continue;
+        final File file = File(row.path);
+        if (file.existsSync()) return resizedFileImage(file);
+      }
+    }
+    return null;
   }
 
   /// 用户切换排序方式：立即重排 + 偏好持久化（跨启动记住）。
@@ -2448,12 +2487,19 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 盖模糊垫底、不压清晰海报前景，BUG-1298 血缘）。
   Widget _buildHeroPage(_VideoHeroItem item) {
     final ThemeData theme = Theme.of(context);
-    final String? backdropPath = item.meta?.backdropPath;
-    final ImageProvider? background = (backdropPath != null &&
-            backdropPath.isNotEmpty &&
-            File(backdropPath).existsSync())
-        ? FileImage(File(backdropPath))
-        : _collectionMembersCoverProvider(item.members);
+    // v68：横版背景/logo 走 media_images（v64 的 backdropPath 列已由迁移搬入，
+    // 读它就覆盖了存量数据）。背景无横图回落成员封面（LandscapeCoverImage 垫底）。
+    final List<MediaImageRow>? images =
+        _mediaImagesByCollection[item.collection.id];
+    final ImageProvider? background = _mediaImageProvider(
+          images,
+          const <MediaImageKind>[MediaImageKind.backdrop],
+        ) ??
+        _collectionMembersCoverProvider(item.members);
+    final ImageProvider? logo = _mediaImageProvider(
+      images,
+      const <MediaImageKind>[MediaImageKind.logo],
+    );
     int completedCount = 0;
     final List<CollectionMemberProgress> progresses =
         <CollectionMemberProgress>[
@@ -2529,17 +2575,41 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
                     ),
                   ),
                 ),
-              ShelfTitleOverflowTooltip(
-                title: item.collection.name,
-                style: titleStyle,
-                maxLines: 2,
-                child: Text(
-                  item.collection.name,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
+              // v68：有标题 logo 用图（Jellyfin 式），语义/回落仍是合集名文字。
+              if (logo != null)
+                Semantics(
+                  label: item.collection.name,
+                  image: true,
+                  child: ConstrainedBox(
+                    constraints:
+                        const BoxConstraints(maxHeight: 76, maxWidth: 360),
+                    child: Image(
+                      key: ValueKey<String>(
+                          'home_video_hero_logo_${item.collection.id}'),
+                      image: logo,
+                      fit: BoxFit.contain,
+                      alignment: AlignmentDirectional.bottomStart,
+                      errorBuilder: (_, __, ___) => Text(
+                        item.collection.name,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: titleStyle,
+                      ),
+                    ),
+                  ),
+                )
+              else
+                ShelfTitleOverflowTooltip(
+                  title: item.collection.name,
                   style: titleStyle,
+                  maxLines: 2,
+                  child: Text(
+                    item.collection.name,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: titleStyle,
+                  ),
                 ),
-              ),
               const SizedBox(height: 4),
               Text(
                 t.video_hero_episodes_watched(n: completedCount),
@@ -2793,6 +2863,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 横滚行通用卡：高度统一、宽度随封面朝向（竖 2:3 / 横 16:9，
   /// [CoverOrientationBuilder] 探测与卡内封面共用同一 provider 键，零额外解码）。
   /// 底边进度条、集数/「新」/云角标，两行标题 + 溢出 Tooltip（TODO-2490 同款）。
+  ///
+  /// [forceLandscape]：续播行的视频卡恒 16:9 横槽（Jellyfin Continue Watching
+  /// 口径，用户拍板「续播行只对视频改横版」）——不做朝向探测，竖版海报由
+  /// [PortraitCoverImage] 的横槽模糊垫底承接，不会重演 BUG-1299 的硬裁。
   Widget _buildRowMediaCard({
     required Key cardKey,
     required HibikiFocusId focusId,
@@ -2805,130 +2879,144 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     int? episodeCount,
     bool newBadge = false,
     bool cloudBadge = false,
+    bool forceLandscape = false,
   }) {
     final TextStyle? titleStyle = Theme.of(context).textTheme.bodyMedium;
-    return CoverOrientationBuilder(
-      image: cover,
-      builder: (BuildContext context, VideoCardOrientation orientation) {
-        final double width = videoCardWidthForOrientation(
-          orientation: orientation,
-          coverHeight: coverHeight,
-        );
-        return SizedBox(
-          width: width,
-          child: HibikiCard(
-            key: cardKey,
-            focusId: focusId,
-            padding: EdgeInsets.zero,
-            // 多选纪律（PR#664 复核）：横滚行是墙内容的**快捷镜像，不参与勾选**
-            // ——勾选一律走墙卡/合集卡（行卡不在 setVisibleOrder 的可见序里，
-            // 参与勾选会打乱 Shift 区间语义）。进入多选态后行卡点击不得再触发
-            // 播放/流播（误触会把批量操作中途弹进播放器），长按/右键置 null
-            // 让位祖先 SelectionDragArea 扫选，与墙卡同一纪律。
-            onTap: _selectionMode ? null : onTap,
-            onLongPress: _selectionMode ? null : onLongPress,
-            onSecondaryTap: _selectionMode ? null : onLongPress,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
-                SizedBox(
-                  height: coverHeight,
-                  child: Stack(
-                    fit: StackFit.expand,
-                    children: <Widget>[
-                      if (cover == null)
-                        ShelfCoverPlaceholder(
+    Widget buildCard(BuildContext context, VideoCardOrientation orientation) {
+      final double width = videoCardWidthForOrientation(
+        orientation: orientation,
+        coverHeight: coverHeight,
+      );
+      return SizedBox(
+        width: width,
+        child: HibikiCard(
+          key: cardKey,
+          focusId: focusId,
+          padding: EdgeInsets.zero,
+          // 多选纪律（PR#664 复核）：横滚行是墙内容的**快捷镜像，不参与勾选**
+          // ——勾选一律走墙卡/合集卡（行卡不在 setVisibleOrder 的可见序里，
+          // 参与勾选会打乱 Shift 区间语义）。进入多选态后行卡点击不得再触发
+          // 播放/流播（误触会把批量操作中途弹进播放器），长按/右键置 null
+          // 让位祖先 SelectionDragArea 扫选，与墙卡同一纪律。
+          onTap: _selectionMode ? null : onTap,
+          onLongPress: _selectionMode ? null : onLongPress,
+          onSecondaryTap: _selectionMode ? null : onLongPress,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              SizedBox(
+                height: coverHeight,
+                child: Stack(
+                  fit: StackFit.expand,
+                  children: <Widget>[
+                    if (cover == null)
+                      ShelfCoverPlaceholder(
+                        icon: Icons.movie_outlined,
+                        backgroundColor:
+                            Theme.of(context).colorScheme.surfaceContainer,
+                      )
+                    else
+                      PortraitCoverImage(
+                        image: cover,
+                        landscapeSlot:
+                            orientation == VideoCardOrientation.landscape,
+                        errorBuilder: (BuildContext _) => ShelfCoverPlaceholder(
                           icon: Icons.movie_outlined,
                           backgroundColor:
                               Theme.of(context).colorScheme.surfaceContainer,
-                        )
-                      else
-                        PortraitCoverImage(
-                          image: cover,
-                          landscapeSlot:
-                              orientation == VideoCardOrientation.landscape,
-                          errorBuilder: (BuildContext _) =>
-                              ShelfCoverPlaceholder(
-                            icon: Icons.movie_outlined,
+                        ),
+                      ),
+                    if (episodeCount != null && episodeCount >= 2)
+                      Positioned(
+                        top: 6,
+                        right: 6,
+                        child: _buildPlaylistBadge(episodeCount),
+                      ),
+                    if (newBadge)
+                      Positioned(
+                        top: 6,
+                        left: 6,
+                        child: CoverBadge(
+                          icon: Icons.fiber_new_outlined,
+                          label: t.video_recently_added_badge,
+                        ),
+                      ),
+                    if (cloudBadge)
+                      const Positioned(
+                        bottom: 6,
+                        right: 6,
+                        child: CoverBadge(icon: Icons.cloud_outlined),
+                      ),
+                    // 底边进度条（YouTube 式），与墙卡同款视觉。
+                    if (progressFraction != null)
+                      Positioned(
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        child: IgnorePointer(
+                          child: LinearProgressIndicator(
+                            value: progressFraction,
+                            minHeight: 3,
                             backgroundColor:
-                                Theme.of(context).colorScheme.surfaceContainer,
+                                Colors.black.withValues(alpha: 0.35),
+                            color: Theme.of(context).colorScheme.primary,
                           ),
                         ),
-                      if (episodeCount != null && episodeCount >= 2)
-                        Positioned(
-                          top: 6,
-                          right: 6,
-                          child: _buildPlaylistBadge(episodeCount),
-                        ),
-                      if (newBadge)
-                        Positioned(
-                          top: 6,
-                          left: 6,
-                          child: CoverBadge(
-                            icon: Icons.fiber_new_outlined,
-                            label: t.video_recently_added_badge,
-                          ),
-                        ),
-                      if (cloudBadge)
-                        const Positioned(
-                          bottom: 6,
-                          right: 6,
-                          child: CoverBadge(icon: Icons.cloud_outlined),
-                        ),
-                      // 底边进度条（YouTube 式），与墙卡同款视觉。
-                      if (progressFraction != null)
-                        Positioned(
-                          left: 0,
-                          right: 0,
-                          bottom: 0,
-                          child: IgnorePointer(
-                            child: LinearProgressIndicator(
-                              value: progressFraction,
-                              minHeight: 3,
-                              backgroundColor:
-                                  Colors.black.withValues(alpha: 0.35),
-                              color: Theme.of(context).colorScheme.primary,
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
+                      ),
+                  ],
                 ),
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.fromLTRB(8, 6, 8, 2),
-                    child: Align(
-                      alignment: Alignment.topLeft,
-                      child: ShelfTitleOverflowTooltip(
-                        title: title,
-                        style: titleStyle,
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(8, 6, 8, 2),
+                  child: Align(
+                    alignment: Alignment.topLeft,
+                    child: ShelfTitleOverflowTooltip(
+                      title: title,
+                      style: titleStyle,
+                      maxLines: 2,
+                      child: Text(
+                        title,
                         maxLines: 2,
-                        child: Text(
-                          title,
-                          maxLines: 2,
-                          overflow: TextOverflow.ellipsis,
-                          style: titleStyle,
-                        ),
+                        overflow: TextOverflow.ellipsis,
+                        style: titleStyle,
                       ),
                     ),
                   ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        );
-      },
-    );
+        ),
+      );
+    }
+
+    if (forceLandscape) {
+      return Builder(
+        builder: (BuildContext context) =>
+            buildCard(context, VideoCardOrientation.landscape),
+      );
+    }
+    return CoverOrientationBuilder(image: cover, builder: buildCard);
   }
 
   /// 继续观看行·本地散卡：点击直接续播；多集显集数角标 + 按集进度条（单视频无
   /// 总时长列，不造百分比 → 不画进度条，与墙卡同一诚实口径）。
+  /// v68：恒横版 16:9；选图链 titleCard → backdrop（散装电影刮削图组）→ 自身
+  /// 封面（横图直铺 / 竖版海报模糊垫底）。
   Widget _buildContinueEntryCard(VideoBookRow book, double coverHeight) {
     final int episodeCount = playlistEpisodeCount(book.playlistJson);
     return _buildRowMediaCard(
       cardKey: ValueKey<String>('home_video_continue_${book.bookUid}'),
       focusId: HibikiFocusId('home-video-continue-${book.bookUid}'),
-      cover: _localCoverProvider(book),
+      cover: _mediaImageProvider(
+            _mediaImagesByBookUid[book.bookUid],
+            const <MediaImageKind>[
+              MediaImageKind.titleCard,
+              MediaImageKind.backdrop,
+            ],
+          ) ??
+          _localCoverProvider(book),
       title: book.title,
       coverHeight: coverHeight,
       onTap: () => _open(book),
@@ -2939,6 +3027,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         episodeCount: episodeCount,
       ),
       episodeCount: episodeCount,
+      forceLandscape: true,
     );
   }
 
@@ -2954,7 +3043,16 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       cardKey:
           ValueKey<String>('home_video_continue_collection_${collection.id}'),
       focusId: HibikiFocusId('home-video-continue-collection-${collection.id}'),
-      cover: _collectionRowCoverProvider(collection, members),
+      // v68 横版选图链（Jellyfin preferThumb 口径）：带字横图 → 无字背景 →
+      // 成员封面借用链（剧照/海报，竖图由横槽模糊垫底承接）。
+      cover: _mediaImageProvider(
+            _mediaImagesByCollection[collection.id],
+            const <MediaImageKind>[
+              MediaImageKind.titleCard,
+              MediaImageKind.backdrop,
+            ],
+          ) ??
+          _collectionRowCoverProvider(collection, members),
       title: collection.name,
       coverHeight: coverHeight,
       onTap: () {
@@ -2975,6 +3073,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       progressFraction:
           members.isEmpty ? null : completedCount / members.length,
       episodeCount: members.length,
+      forceLandscape: true,
     );
   }
 
@@ -2992,6 +3091,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       onLongPress: () => _showRemoteVideoDialog(video),
       episodeCount: video.isPlaylist ? video.episodes.length : null,
       cloudBadge: true,
+      forceLandscape: true,
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -2864,9 +2864,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// [CoverOrientationBuilder] 探测与卡内封面共用同一 provider 键，零额外解码）。
   /// 底边进度条、集数/「新」/云角标，两行标题 + 溢出 Tooltip（TODO-2490 同款）。
   ///
-  /// [forceLandscape]：续播行的视频卡恒 16:9 横槽（Jellyfin Continue Watching
-  /// 口径，用户拍板「续播行只对视频改横版」）——不做朝向探测，竖版海报由
-  /// [PortraitCoverImage] 的横槽模糊垫底承接，不会重演 BUG-1299 的硬裁。
   Widget _buildRowMediaCard({
     required Key cardKey,
     required HibikiFocusId focusId,
@@ -2879,7 +2876,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     int? episodeCount,
     bool newBadge = false,
     bool cloudBadge = false,
-    bool forceLandscape = false,
   }) {
     final TextStyle? titleStyle = Theme.of(context).textTheme.bodyMedium;
     Widget buildCard(BuildContext context, VideoCardOrientation orientation) {
@@ -2991,19 +2987,14 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       );
     }
 
-    if (forceLandscape) {
-      return Builder(
-        builder: (BuildContext context) =>
-            buildCard(context, VideoCardOrientation.landscape),
-      );
-    }
     return CoverOrientationBuilder(image: cover, builder: buildCard);
   }
 
   /// 继续观看行·本地散卡：点击直接续播；多集显集数角标 + 按集进度条（单视频无
   /// 总时长列，不造百分比 → 不画进度条，与墙卡同一诚实口径）。
-  /// v68：恒横版 16:9；选图链 titleCard → backdrop（散装电影刮削图组）→ 自身
-  /// 封面（横图直铺 / 竖版海报模糊垫底）。
+  /// v68 选图链 titleCard → backdrop（散装电影刮削图组）→ 自身封面；卡朝向随
+  /// 选中那张图探测（用户拍板：续播行单行、横竖混排无排版问题——有横图出横卡，
+  /// 只有竖版海报就自然出竖卡，不强制垫底成 16:9）。
   Widget _buildContinueEntryCard(VideoBookRow book, double coverHeight) {
     final int episodeCount = playlistEpisodeCount(book.playlistJson);
     return _buildRowMediaCard(
@@ -3027,7 +3018,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         episodeCount: episodeCount,
       ),
       episodeCount: episodeCount,
-      forceLandscape: true,
     );
   }
 
@@ -3043,8 +3033,8 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       cardKey:
           ValueKey<String>('home_video_continue_collection_${collection.id}'),
       focusId: HibikiFocusId('home-video-continue-collection-${collection.id}'),
-      // v68 横版选图链（Jellyfin preferThumb 口径）：带字横图 → 无字背景 →
-      // 成员封面借用链（剧照/海报，竖图由横槽模糊垫底承接）。
+      // v68 选图链（Jellyfin preferThumb 口径）：带字横图 → 无字背景 →
+      // 成员封面借用链；卡朝向随选中那张图探测（混排语义，见散卡注释）。
       cover: _mediaImageProvider(
             _mediaImagesByCollection[collection.id],
             const <MediaImageKind>[
@@ -3073,7 +3063,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       progressFraction:
           members.isEmpty ? null : completedCount / members.length,
       episodeCount: members.length,
-      forceLandscape: true,
     );
   }
 
@@ -3091,7 +3080,6 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
       onLongPress: () => _showRemoteVideoDialog(video),
       episodeCount: video.isPlaylist ? video.episodes.length : null,
       cloudBadge: true,
-      forceLandscape: true,
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async' show Timer;
+
 import 'package:drift/drift.dart' show Value;
 import 'package:flutter/material.dart';
 
@@ -123,8 +125,16 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
   /// 回落到「只有标题 + 进度」的旧形态，与本功能引入前一致（BUG-1310）。
   ScrapeMetadata? _scrapeMeta;
 
-  /// 横版背景本地路径；仅 TMDB 源有，Bangumi / 离线库恒为 null。
-  String? _backdropPath;
+  /// 横版背景本地路径组（v68，media_images 轮换序）；仅 TMDB / AniList 源有，
+  /// Bangumi / 离线库恒为空。多张时 hero 每 10 秒交叉淡入轮换（Jellyfin 式）。
+  List<String> _backdropPaths = const <String>[];
+
+  /// 标题 logo 本地路径（透明底 PNG）；有则 hero 用 logo 图替代纯文字标题。
+  String? _logoPath;
+
+  /// 背景轮换下标与定时器（单张 / 禁用动效时不启）。
+  int _heroBackdropIndex = 0;
+  Timer? _backdropRotationTimer;
 
   /// 集级刮削资料（TODO-2491）：bookUid → `video_scrape_meta` 行，**只含
   /// `episodeNumber` 非空**（真·集级）的行。旧作品级行（v54~v64 把整部简介写进
@@ -152,6 +162,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
 
   @override
   void dispose() {
+    _backdropRotationTimer?.cancel();
     _seasonTabs?.dispose();
     super.dispose();
   }
@@ -163,8 +174,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     // 快照，只认它会让详情页标题停在旧文件夹名。
     final CollectionScrapeMetaRow? metaRow =
         await widget.database.getCollectionScrapeMeta(widget.collection.id);
-    final ({ScrapeMetadata metadata, String? backdropPath})? decoded =
-        decodeCollectionScrapeMeta(metaRow);
+    final ScrapeMetadata? decoded = decodeCollectionScrapeMeta(metaRow);
+    // 附加图组（v68）：横版背景（轮换序）与标题 logo。
+    final List<MediaImageRow> imageRows =
+        await widget.database.getMediaImagesForCollection(widget.collection.id);
     // 集级刮削资料（一集一行、episodeNumber 非空才算集级；见 [_episodeMetaByUid]）。
     final Map<String, VideoScrapeMetaRow> episodeMeta =
         <String, VideoScrapeMetaRow>{};
@@ -186,13 +199,42 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       };
       _rebuildSections();
       _episodeMetaByUid = episodeMeta;
-      _scrapeMeta = decoded?.metadata;
-      _backdropPath = decoded?.backdropPath;
+      _scrapeMeta = decoded;
+      _backdropPaths = <String>[
+        for (final MediaImageRow row in imageRows)
+          if (row.kind == MediaImageKind.backdrop.dbValue) row.path,
+      ];
+      _logoPath = null;
+      for (final MediaImageRow row in imageRows) {
+        if (row.kind == MediaImageKind.logo.dbValue && row.path.isNotEmpty) {
+          _logoPath = row.path;
+          break;
+        }
+      }
+      _heroBackdropIndex = 0;
       if (fresh != null) {
         _collectionRow = fresh;
         _name = fresh.name;
       }
       _loading = false;
+    });
+    _syncBackdropRotation();
+  }
+
+  /// 让背景轮换定时器跟上当前背景张数：≥2 张且未禁用动效才轮（Jellyfin 详情页
+  /// 同款 10 秒节奏）；单张 / 禁动效 / 页面销毁一律停表。setState 由定时器回调
+  /// 自己发（只改下标），不重查任何数据。
+  void _syncBackdropRotation() {
+    _backdropRotationTimer?.cancel();
+    _backdropRotationTimer = null;
+    if (!mounted || _backdropPaths.length < 2) return;
+    if (MediaQuery.maybeDisableAnimationsOf(context) ?? false) return;
+    _backdropRotationTimer =
+        Timer.periodic(const Duration(seconds: 10), (Timer _) {
+      if (!mounted || _backdropPaths.length < 2) return;
+      setState(() {
+        _heroBackdropIndex = (_heroBackdropIndex + 1) % _backdropPaths.length;
+      });
     });
   }
 
@@ -306,17 +348,19 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     return (summary == null || summary.isEmpty) ? null : summary;
   }
 
-  /// hero 背景的**横版**图源（BUG-1298 的数据层根治）。
+  /// hero 背景的**横版**图源（BUG-1298 的数据层根治；v68 支持多张轮换，取当前
+  /// 轮换下标那张）。
   ///
-  /// hero 是约 2.7:1 的宽幅槽，理应喂横图。刮削若拿到了 TMDB 的 `backdrop_path`
-  /// 就落在这里，槽向天然吻合、直接 cover 铺满即可。
+  /// hero 是约 2.7:1 的宽幅槽，理应喂横图。刮削若拿到了 TMDB 的横版图组就落在
+  /// media_images 里，槽向天然吻合、直接 cover 铺满即可。
   ///
-  /// 返回 null = 该源没有横版图（Bangumi / 离线库只有竖版海报，恒为 null），此时
+  /// 返回 null = 该源没有横版图（Bangumi / 离线库只有竖版海报，恒为空），此时
   /// 背景回落到海报 + [LandscapeCoverImage] 的模糊垫底。那不是权宜之计，是这些源
   /// 的常态路径。
   ImageProvider? get _heroBackdrop {
-    final String? path = _backdropPath;
-    if (path == null || path.isEmpty) return null;
+    if (_backdropPaths.isEmpty) return null;
+    final String path =
+        _backdropPaths[_heroBackdropIndex % _backdropPaths.length];
     return resolveMediaCoverImage(
       kind: MediaKind.video,
       localPath: path,
@@ -324,6 +368,13 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       decodeWidth: 2560,
     );
   }
+
+  /// 标题 logo 图源（v68）；null = 无 logo，hero 标题走纯文字。
+  ImageProvider? get _heroLogo => resolveMediaCoverImage(
+        kind: MediaKind.video,
+        localPath: _logoPath,
+        decodeWidth: 800,
+      );
 
   ImageProvider? get _heroCover {
     // 读 DB 快照而非进页副本：刮削刚写进去的新封面必须立刻生效（见 [_collectionRow]）。
@@ -1000,13 +1051,23 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           //    模糊垫底 + 靠右完整显示（BUG-1298）。此时不再另放海报卡，否则同一张
           //    图在同一屏出现两次。
           if (backdrop != null) ...<Widget>[
-            Image(
+            // v68：多张背景 10 秒轮换（Jellyfin 详情页同款）。外层 key 恒定供
+            // 测试定位；内层 key 随轮换下标变化驱动 AnimatedSwitcher 交叉淡入。
+            // gaplessPlayback：新图解码完成前保留旧帧，避免轮换瞬间闪底色。
+            KeyedSubtree(
               key: const ValueKey<String>('collection-hero-backdrop'),
-              image: backdrop,
-              fit: BoxFit.cover,
-              alignment: Alignment.center,
-              errorBuilder: (_, __, ___) =>
-                  ColoredBox(color: cs.surfaceContainerHighest),
+              child: AnimatedSwitcher(
+                duration: const Duration(milliseconds: 700),
+                child: Image(
+                  key: ValueKey<int>(_heroBackdropIndex),
+                  image: backdrop,
+                  fit: BoxFit.cover,
+                  alignment: Alignment.center,
+                  gaplessPlayback: true,
+                  errorBuilder: (_, __, ___) =>
+                      ColoredBox(color: cs.surfaceContainerHighest),
+                ),
+              ),
             ),
             ...overlays,
           ] else if (cover != null)
@@ -1124,16 +1185,26 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           ),
           SizedBox(height: tokens.spacing.gap / 2),
         ],
-        Text(
-          _name,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-          style: text.displaySmall?.copyWith(
-            color: Colors.white,
-            fontWeight: FontWeight.w700,
-            height: 1.08,
-          ),
-        ),
+        // v68：有标题 logo 时替代纯文字大标题（Jellyfin `.detailLogo` 同款）。
+        // Semantics 保留合集名——logo 是图，读屏与测试都还能按名字找到它；
+        // logo 解码失败回落文字标题，绝不留一块空白当标题。
+        if (_heroLogo case final ImageProvider logo)
+          Semantics(
+            label: _name,
+            image: true,
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 110, maxWidth: 460),
+              child: Image(
+                key: const ValueKey<String>('collection-hero-logo'),
+                image: logo,
+                fit: BoxFit.contain,
+                alignment: AlignmentDirectional.bottomStart,
+                errorBuilder: (_, __, ___) => _buildHeroTitleText(text),
+              ),
+            ),
+          )
+        else
+          _buildHeroTitleText(text),
         // 原名与合集名相同就不重复占一行（刮削回写后二者常常一致）。
         if (originalTitle != null &&
             originalTitle.isNotEmpty &&
@@ -1190,6 +1261,20 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           onPressed: () => widget.onOpenEpisode(episode),
         ),
       ],
+    );
+  }
+
+  /// hero 纯文字大标题（无 logo 的常态路径 / logo 解码失败回落共用）。
+  Widget _buildHeroTitleText(TextTheme text) {
+    return Text(
+      _name,
+      maxLines: 2,
+      overflow: TextOverflow.ellipsis,
+      style: text.displaySmall?.copyWith(
+        color: Colors.white,
+        fontWeight: FontWeight.w700,
+        height: 1.08,
+      ),
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/episode.part.dart
@@ -214,24 +214,54 @@ extension _VideoEpisode on _VideoHibikiPageState {
   ///
   /// 封面来源判断**不在这里手写分支**——统一走 [resolveMediaCoverImage]：本地集给
   /// `coverPath`、互联远端集给 `coverUrl` + 稳定缓存键，解析器按固定优先级出图。
-  /// 旧单行 playlist 远端模型（`RemoteVideoEpisode`）不下发封面，两者皆空 →
+  ///
+  /// v68 Jellyfin 对齐三件套：
+  /// * 集名：集级刮削集名优先（[_PlaylistEpisodeRef.displayTitle]），回落文件名；
+  /// * 封面回退链的合集段：本集无图 → 合集 titleCard → backdrop
+  ///   （Episode Primary → Series Thumb → Backdrop 的本仓版），此前直接掉到
+  ///   灰色占位图标；
+  /// * 看完/在看角标（Jellyfin played 勾）：轨道本就支持，把数据喂上。
+  /// 旧单行 playlist 远端模型（`RemoteVideoEpisode`）不下发封面，全部图源皆空 →
   /// 返回 null，面板退回纯序号形态。
   List<VideoEpisodeEntry> _episodePanelEntries() {
     final RemoteCoverFetcher? fetcher =
         remoteCoverFetcherFor(widget.remoteClient ?? _resolvedStreamClient);
+    final ImageProvider? seriesFallback = _playlistSeriesFallbackCover();
     return <VideoEpisodeEntry>[
       for (final _PlaylistEpisodeRef e in _episodes)
         VideoEpisodeEntry(
-          title: e.title,
+          title: e.displayTitle ?? e.title,
           cover: resolveMediaCoverImage(
-            kind: MediaKind.video,
-            localPath: e.coverPath,
-            remoteUrl: e.coverUrl,
-            remoteFetcher: fetcher,
-            remoteCacheKey: e.coverCacheKey,
-          ),
+                kind: MediaKind.video,
+                localPath: e.coverPath,
+                remoteUrl: e.coverUrl,
+                remoteFetcher: fetcher,
+                remoteCacheKey: e.coverCacheKey,
+              ) ??
+              seriesFallback,
+          completed: e.completed,
+          started: e.started,
         ),
     ];
+  }
+
+  /// 剧集卡封面回退链的合集段（v68）：合集带字横图 → 无字背景；全缺 → null
+  /// （面板占位图标）。整组只解析一次，面板 N 张卡共享同一 provider。
+  ImageProvider? _playlistSeriesFallbackCover() {
+    for (final MediaImageKind kind in const <MediaImageKind>[
+      MediaImageKind.titleCard,
+      MediaImageKind.backdrop,
+    ]) {
+      for (final MediaImageRow row in _playlistCollectionImages) {
+        if (row.kind == kind.dbValue && row.path.isNotEmpty) {
+          return resolveMediaCoverImage(
+            kind: MediaKind.video,
+            localPath: row.path,
+          );
+        }
+      }
+    }
+    return null;
   }
 
   /// 剧集列表改为覆盖在**视频底部**的横向轨道：画面继续作为沉浸式背景，不把

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -372,13 +372,22 @@ class _PlaylistEpisodeRef {
   const _PlaylistEpisodeRef({
     this.bookUid,
     required this.title,
+    this.displayTitle,
     this.path = '',
     this.coverPath,
     this.coverUrl,
     this.coverCacheKey,
+    this.completed = false,
+    this.started = false,
   });
   final String? bookUid;
   final String title;
+
+  /// 剧集面板展示名（v68 Jellyfin 对齐：集级刮削集名）。null = 无集级集名，
+  /// 面板回落 [title]。**刻意与 [title] 分开**：title 还流向制卡
+  /// documentTitle（「系列名 - 剧集名」），换成刮削集名会静默改卡片字段。
+  final String? displayTitle;
+
   final String path;
 
   /// 本机封面文件路径（本地集：`video_books.coverPath`）。
@@ -389,6 +398,12 @@ class _PlaylistEpisodeRef {
 
   /// 远端封面的稳定磁盘缓存键（用 `RemoteVideoInfo.id`）。
   final String? coverCacheKey;
+
+  /// 看完 / 在看（本地集：`completedAt` / `lastPositionMs`；远端集无口径恒
+  /// false）。剧集面板右上角标（Jellyfin played 勾）的数据源——轨道组件本就
+  /// 支持，此前面板一直没喂。
+  final bool completed;
+  final bool started;
 }
 
 class VideoHibikiPage extends ConsumerStatefulWidget {
@@ -1554,6 +1569,10 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// 单视频（本地 pushReplacement 换集，widget.bookUid 恒为当前集）。
   List<_PlaylistEpisodeRef> _episodes = const <_PlaylistEpisodeRef>[];
 
+  /// 播放中合集的附加图组（v68）：剧集面板封面回退链的合集段（本集无封面 →
+  /// titleCard → backdrop）。仅本地合集连播路径填充；单视频/远端恒空。
+  List<MediaImageRow> _playlistCollectionImages = const <MediaImageRow>[];
+
   /// 当前集索引（[_episodes] 下标）；单视频恒 0。
   int _currentEpisode = 0;
 
@@ -2045,16 +2064,34 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       _delayMs = effectiveSeriesDelayMs(col?.subtitleDelayMs, row.delayMs);
       final List<MediaCollectionItemRow> members =
           await widget.repo.getCollectionItems(collectionId);
+      // v68 Jellyfin 对齐：剧集面板要 ①集级刮削集名 ②合集横图回退链 ③看完/在看
+      // 角标。作品名作集名判据（集名缺失时集级刮削会把作品名回填进 title，那不是
+      // 集名——与合集详情页 `_scrapedEpisodeTitle` 同判据）。
+      final CollectionScrapeMetaRow? colMeta =
+          await widget.repo.collectionScrapeMeta(collectionId);
+      _playlistCollectionImages =
+          await widget.repo.collectionMediaImages(collectionId);
+      final String? workTitle = colMeta?.title.trim();
       final List<_PlaylistEpisodeRef> refs = <_PlaylistEpisodeRef>[];
       for (final MediaCollectionItemRow m in members) {
         if (m.mediaType != MediaKind.video.dbValue) continue;
         final VideoBookRow? er = await widget.repo.getByBookUid(m.entryKey);
         if (er == null) continue; // 孤儿成员（集行已删）→ 读取期过滤。
+        String? scrapedName;
+        final VideoScrapeMetaRow? em =
+            await widget.repo.episodeScrapeMeta(er.bookUid);
+        if (em != null && em.episodeNumber != null) {
+          final String t = em.title.trim();
+          if (t.isNotEmpty && t != workTitle) scrapedName = t;
+        }
         refs.add(_PlaylistEpisodeRef(
           bookUid: er.bookUid,
           title: er.title,
+          displayTitle: scrapedName,
           path: er.videoPath,
           coverPath: er.coverPath,
+          completed: er.completedAt != null,
+          started: er.lastPositionMs > 0,
         ));
       }
       _episodes = refs;

--- a/hibiki/lib/src/storage/data_root_migrator.dart
+++ b/hibiki/lib/src/storage/data_root_migrator.dart
@@ -948,6 +948,7 @@ class DataRootMigrator {
         await _rebaseMediaCollections(db, docs);
         await _rebaseCollectionScrapeMeta(db, docs);
         await _rebaseCollectionRelations(db, docs);
+        await _rebaseMediaImages(db, docs);
         await _rebaseMediaItems(db, docs);
         await _rebasePreferences(db, docs, newSupportRoot);
         await _rebaseProfileSettings(db, docs, newSupportRoot);
@@ -1105,6 +1106,24 @@ class DataRootMigrator {
         'UPDATE collection_scrape_meta SET backdrop_path = ? '
         'WHERE collection_id = ?',
         <Object?>[newBackdrop, c.id],
+      );
+    }
+  }
+
+  /// media_images：path（v68 附加图组：`<documents>/video_covers/collections/`
+  /// 与 `<documents>/video_covers/images/` 两个目录族，与合集封面同型）。
+  /// 不改写 = 换数据根后 hero 背景/logo、续播横卡全部变死链，静默退回海报模糊
+  /// 垫底。kind / source_url 不是本机路径，绝不改写。
+  static Future<void> _rebaseMediaImages(
+    HibikiDatabase db,
+    DocumentsPathRebaser docs,
+  ) async {
+    for (final MediaImageRow row in await db.getAllMediaImages()) {
+      final String? newPath = docs.rebaseNullable(row.path);
+      if (newPath == null || newPath == row.path) continue;
+      await db.customStatement(
+        'UPDATE media_images SET path = ? WHERE id = ?',
+        <Object?>[newPath, row.id],
       );
     }
   }

--- a/hibiki/lib/src/storage/path_rebase_coverage.dart
+++ b/hibiki/lib/src/storage/path_rebase_coverage.dart
@@ -332,6 +332,22 @@ const List<PathRebaseColumn> kPathRebaseColumns = <PathRebaseColumn>[
           '与 media_collections.cover_path 完全同型 → 不改写 = 换数据根后详情页'
           'hero 背景变死链，静默退回海报模糊垫底，用户看到背景「自己没了」。'),
 
+  // ── media_images（媒体附加图组，schema v68 / Jellyfin 图组对齐）──────
+  PathRebaseColumn('MediaImages', 'bookUid', PathRebaseKind.notAPath,
+      '归属视频的 bookUid 逻辑外键，不是路径。'),
+  PathRebaseColumn('MediaImages', 'kind', PathRebaseKind.notAPath,
+      'MediaImageKind 枚举值（backdrop/logo/title_card），不是路径。'),
+  PathRebaseColumn(
+      'MediaImages',
+      'path',
+      PathRebaseKind.documentsRooted,
+      'v68 附加图组落盘位：<documents>/video_covers/collections/（合集归属）与 '
+          '<documents>/video_covers/images/（视频归属）两个目录族，与合集封面'
+          '完全同型 → 不改写 = 换数据根后 hero 背景/logo、续播横卡全部死链，'
+          '静默退回海报模糊垫底。'),
+  PathRebaseColumn('MediaImages', 'sourceUrl', PathRebaseKind.notAPath,
+      '来源远程 URL（重下/诊断用），不是本机路径。'),
+
   // ── collection_relations（合集相关作品边表，schema v66 / TODO-2484）──
   PathRebaseColumn('CollectionRelations', 'source', PathRebaseKind.notAPath,
       'ScrapeSource 枚举名（bangumi/tmdb/...），不是路径。'),

--- a/hibiki/lib/src/sync/collection_sync_engine.dart
+++ b/hibiki/lib/src/sync/collection_sync_engine.dart
@@ -578,7 +578,9 @@ Future<int> applyCollectionLocalChanges(
   if (changes.isEmpty) return 0;
   // 被本轮解散的合集行快照：删行发生在事务里，而回收自有封面是文件 IO，必须挪到
   // 事务提交之后做（BUG-1319）。路径只能在行还活着时取，故在删之前入列。
+  // v68：附加图行随删行 cascade 消失，同一顺序约束，路径也在删前快照。
   final List<MediaCollectionRow> dissolved = <MediaCollectionRow>[];
+  final List<String> dissolvedImagePaths = <String>[];
   await db.transaction(() async {
     for (final CollectionManifestEntry e in changes.entries) {
       final MediaCollectionRow? row =
@@ -588,6 +590,8 @@ Future<int> applyCollectionLocalChanges(
         // 目标态 = 已删：删本地行（若有），墓碑表只留哨兵（镜像 deletedAt）。
         if (row != null) {
           dissolved.add(row);
+          dissolvedImagePaths
+              .addAll(await collectionOwnedImagePaths(db, row.id));
           await db.deleteMediaCollectionRaw(row.id);
         }
         await db.replaceCollectionTombstonesFor(
@@ -608,6 +612,8 @@ Future<int> applyCollectionLocalChanges(
         // 活壳（全成员被移出）：本地沿用「移空自删」语义，不留 0 成员合集卡。
         if (row != null) {
           dissolved.add(row);
+          dissolvedImagePaths
+              .addAll(await collectionOwnedImagePaths(db, row.id));
           await db.deleteMediaCollectionRaw(row.id);
         }
       } else {
@@ -653,7 +659,11 @@ Future<int> applyCollectionLocalChanges(
   });
   // 事务外回收：护栏（落在合集封面目录内 + 不被任何存活合集引用）在 helper 里，
   // 本轮又新建了合集的话它们的封面自然在存活引用集里，不会被误删。
-  await reclaimDeletedCollectionAssets(db, dissolved);
+  await reclaimDeletedCollectionAssets(
+    db,
+    dissolved,
+    ownedImagePaths: dissolvedImagePaths,
+  );
   return changes.changedCollections;
 }
 

--- a/hibiki/test/database/collection_scrape_meta_test.dart
+++ b/hibiki/test/database/collection_scrape_meta_test.dart
@@ -60,7 +60,7 @@ void main() {
         detailUrl: 'https://www.themoviedb.org/tv/100',
       );
 
-  test('落库 → 读回：全字段往返，含横版背景路径', () async {
+  test('落库 → 读回：全字段往返，附加图组落 media_images（v68）', () async {
     final HibikiDatabase db = await openDb();
     final int id = await newCollection(db);
 
@@ -69,32 +69,94 @@ void main() {
       id,
       CollectionScrapeResult(
         coverPath: '/covers/collections/$id.jpg',
-        backdropPath: '/covers/collections/${id}_backdrop.jpg',
+        images: <ScrapedMediaImage>[
+          ScrapedMediaImage(
+            kind: MediaImageKind.backdrop,
+            path: '/covers/collections/${id}_backdrop0.jpg',
+            sourceUrl: 'https://img/b0.jpg',
+          ),
+          ScrapedMediaImage(
+            kind: MediaImageKind.backdrop,
+            position: 1,
+            path: '/covers/collections/${id}_backdrop1.jpg',
+          ),
+          ScrapedMediaImage(
+            kind: MediaImageKind.logo,
+            path: '/covers/collections/${id}_logo.png',
+          ),
+          ScrapedMediaImage(
+            kind: MediaImageKind.titleCard,
+            path: '/covers/collections/${id}_titlecard.jpg',
+          ),
+        ],
         metadata: meta(),
       ),
       confirmedTitle: null,
     );
 
-    final ({ScrapeMetadata metadata, String? backdropPath})? got =
+    final ScrapeMetadata? got =
         decodeCollectionScrapeMeta(await db.getCollectionScrapeMeta(id));
     expect(got, isNotNull);
-    expect(got!.backdropPath, '/covers/collections/${id}_backdrop.jpg');
-    expect(got.metadata.summary, '一部关于魔法的故事。');
-    expect(got.metadata.rating, 8.2);
-    expect(got.metadata.ratingCount, 1234);
-    expect(got.metadata.episodeCount, 12);
-    expect(got.metadata.airDate, '2023-01-04');
-    expect(got.metadata.originalTitle, '転生王女');
+    expect(got!.summary, '一部关于魔法的故事。');
+    expect(got.rating, 8.2);
+    expect(got.ratingCount, 1234);
+    expect(got.episodeCount, 12);
+    expect(got.airDate, '2023-01-04');
+    expect(got.originalTitle, '転生王女');
     expect(
-      got.metadata.tags.map((ScrapeTag t) => t.name).toList(),
+      got.tags.map((ScrapeTag t) => t.name).toList(),
       <String>['奇幻', '百合'],
       reason: '标签必须保序（源按热度降序），JSON 往返不得打乱',
     );
-    expect(got.metadata.infobox.single.key, '导演');
+    expect(got.infobox.single.key, '导演');
+
+    // v68：附加图组整组落 media_images，遗留 backdrop_path 列恒 NULL
+    // （单一真相源，两处都有值必然漂开）。
+    final CollectionScrapeMetaRow? metaRow =
+        await db.getCollectionScrapeMeta(id);
+    expect(metaRow!.backdropPath, isNull, reason: 'v68 起旧列冻结，新刮削不得再写它');
+    final List<MediaImageRow> images = await db.getMediaImagesForCollection(id);
+    expect(images, hasLength(4));
+    final List<MediaImageRow> backdrops = <MediaImageRow>[
+      for (final MediaImageRow r in images)
+        if (r.kind == MediaImageKind.backdrop.dbValue) r,
+    ];
+    expect(backdrops, hasLength(2), reason: 'backdrop 是唯一允许多张的种类');
+    expect(backdrops.first.position, 0);
+    expect(backdrops.first.sourceUrl, 'https://img/b0.jpg');
+    expect(backdrops.last.position, 1);
 
     // 封面列与合集名同一次写入落地。
     final MediaCollectionRow? row = await db.getMediaCollectionById(id);
     expect(row!.coverPath, '/covers/collections/$id.jpg');
+  });
+
+  test('删合集 → media_images 行 FK cascade 清空（v68）', () async {
+    final HibikiDatabase db = await openDb();
+    final int id = await newCollection(db);
+    await applyCollectionScrape(
+      db,
+      id,
+      CollectionScrapeResult(
+        coverPath: '/c.jpg',
+        images: <ScrapedMediaImage>[
+          ScrapedMediaImage(
+            kind: MediaImageKind.backdrop,
+            path: '/covers/collections/${id}_backdrop0.jpg',
+          ),
+        ],
+        metadata: meta(),
+      ),
+      confirmedTitle: null,
+    );
+    expect(await db.getMediaImagesForCollection(id), hasLength(1));
+
+    await db.deleteMediaCollection(id);
+    expect(
+      await db.getAllMediaImages(),
+      isEmpty,
+      reason: '删合集必须连带清附加图行——否则孤儿行指向已删合集，永远无法回收',
+    );
   });
 
   test('用户确认后才回写合集名：文件夹名 → 条目正名', () async {
@@ -298,9 +360,9 @@ void main() {
       <Object?>['{not-a-list', id],
     );
 
-    final ({ScrapeMetadata metadata, String? backdropPath})? got =
+    final ScrapeMetadata? got =
         decodeCollectionScrapeMeta(await db.getCollectionScrapeMeta(id));
-    expect(got!.metadata.tags, isEmpty);
-    expect(got.metadata.summary, '一部关于魔法的故事。', reason: '一列坏掉不得丢整条资料');
+    expect(got!.tags, isEmpty);
+    expect(got.summary, '一部关于魔法的故事。', reason: '一列坏掉不得丢整条资料');
   });
 }

--- a/hibiki/test/database/media_images_test.dart
+++ b/hibiki/test/database/media_images_test.dart
@@ -1,0 +1,215 @@
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sqlite3/common.dart' show CommonDatabase;
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// v68 守卫：media_images 附加图组表（Jellyfin 图组对齐）。
+///
+/// 锁四件事：
+///  1. 两种归属（合集 / 单视频）的整组替换与读回、组内排序；
+///  2. CHECK 单一归属约束在 DB 层真的锁死（不是靠调用方自觉）；
+///  3. 删归属（合集 / 视频）FK cascade 清行；
+///  4. v67→v68 迁移把遗留 `collection_scrape_meta.backdrop_path` 搬进本表
+///     （kind='backdrop', position=0），旧库升级后 hero 背景零丢失。
+void main() {
+  /// 必须显式开 `foreign_keys`：`NativeDatabase.memory()` 默认关闭外键，cascade
+  /// 用例不开就是假绿（与 collection_scrape_meta_test 同一教训）。
+  Future<HibikiDatabase> openDb() async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (CommonDatabase rawDb) =>
+            rawDb.execute('PRAGMA foreign_keys = ON'),
+      ),
+    );
+    addTearDown(db.close);
+    return db;
+  }
+
+  MediaImagesCompanion collectionImage(
+    int collectionId, {
+    required MediaImageKind kind,
+    int position = 0,
+    required String path,
+    String? sourceUrl,
+  }) =>
+      MediaImagesCompanion.insert(
+        collectionId: Value<int?>(collectionId),
+        kind: kind.dbValue,
+        position: Value<int>(position),
+        path: path,
+        sourceUrl: Value<String?>(sourceUrl),
+      );
+
+  test('合集归属：整组替换幂等 + 读回按 kind/position 排序', () async {
+    final HibikiDatabase db = await openDb();
+    final int id = await db.createMediaCollection('c1');
+
+    await db.replaceMediaImagesForCollection(id, <MediaImagesCompanion>[
+      collectionImage(id,
+          kind: MediaImageKind.backdrop, position: 1, path: '/b1.jpg'),
+      collectionImage(id,
+          kind: MediaImageKind.backdrop, position: 0, path: '/b0.jpg'),
+      collectionImage(id, kind: MediaImageKind.logo, path: '/logo.png'),
+    ]);
+    // 再替换一次（重刮）：不残留上一轮的行。
+    await db.replaceMediaImagesForCollection(id, <MediaImagesCompanion>[
+      collectionImage(id, kind: MediaImageKind.backdrop, path: '/b0v2.jpg'),
+      collectionImage(id,
+          kind: MediaImageKind.titleCard, path: '/titlecard.jpg'),
+    ]);
+
+    final List<MediaImageRow> rows = await db.getMediaImagesForCollection(id);
+    expect(rows, hasLength(2), reason: '整组替换必须删干净旧行，不是逐条 upsert');
+    expect(rows.first.kind, MediaImageKind.backdrop.dbValue);
+    expect(rows.first.path, '/b0v2.jpg');
+    expect(rows.last.kind, MediaImageKind.titleCard.dbValue);
+  });
+
+  test('视频归属：整组替换 + 与合集归属互不串桶', () async {
+    final HibikiDatabase db = await openDb();
+    final int cid = await db.createMediaCollection('c1');
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value<String>('video/movie1'),
+      title: Value<String>('Movie 1'),
+      videoPath: Value<String>('/abs/m1.mkv'),
+    ));
+
+    await db.replaceMediaImagesForCollection(cid, <MediaImagesCompanion>[
+      collectionImage(cid, kind: MediaImageKind.backdrop, path: '/c_b0.jpg'),
+    ]);
+    await db.replaceMediaImagesForBook('video/movie1', <MediaImagesCompanion>[
+      MediaImagesCompanion.insert(
+        bookUid: const Value<String?>('video/movie1'),
+        kind: MediaImageKind.backdrop.dbValue,
+        path: '/v_b0.jpg',
+      ),
+    ]);
+
+    expect(
+        (await db.getMediaImagesForCollection(cid)).single.path, '/c_b0.jpg');
+    expect((await db.getMediaImagesForBook('video/movie1')).single.path,
+        '/v_b0.jpg');
+    expect(await db.getAllMediaImages(), hasLength(2));
+  });
+
+  test('CHECK 单一归属：双归属与零归属都被 DB 拒绝', () async {
+    final HibikiDatabase db = await openDb();
+    final int cid = await db.createMediaCollection('c1');
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value<String>('video/movie1'),
+      title: Value<String>('Movie 1'),
+      videoPath: Value<String>('/abs/m1.mkv'),
+    ));
+
+    // 零归属。
+    await expectLater(
+      db.into(db.mediaImages).insert(MediaImagesCompanion.insert(
+            kind: MediaImageKind.logo.dbValue,
+            path: '/orphan.png',
+          )),
+      throwsA(anything),
+      reason: '归属双空的图行谁都回收不了 = 确定性泄漏，必须在 DB 层拒收',
+    );
+    // 双归属。
+    await expectLater(
+      db.into(db.mediaImages).insert(MediaImagesCompanion.insert(
+            collectionId: Value<int?>(cid),
+            bookUid: const Value<String?>('video/movie1'),
+            kind: MediaImageKind.logo.dbValue,
+            path: '/both.png',
+          )),
+      throwsA(anything),
+      reason: '双归属行删除语义不可判定（跟谁 cascade？），必须在 DB 层拒收',
+    );
+  });
+
+  test('删视频 → 视频归属行 FK cascade 清空', () async {
+    final HibikiDatabase db = await openDb();
+    await db.upsertVideoBook(const VideoBooksCompanion(
+      bookUid: Value<String>('video/movie1'),
+      title: Value<String>('Movie 1'),
+      videoPath: Value<String>('/abs/m1.mkv'),
+    ));
+    await db.replaceMediaImagesForBook('video/movie1', <MediaImagesCompanion>[
+      MediaImagesCompanion.insert(
+        bookUid: const Value<String?>('video/movie1'),
+        kind: MediaImageKind.titleCard.dbValue,
+        path: '/v_tc.jpg',
+      ),
+    ]);
+    expect(await db.getAllMediaImages(), hasLength(1));
+
+    await db.deleteVideoBook('video/movie1');
+    expect(await db.getAllMediaImages(), isEmpty,
+        reason: '删视频必须连带清它的附加图行（FK cascade）');
+  });
+
+  test('v67→v68 迁移：遗留 backdrop_path 搬进 media_images，hero 背景零丢失', () async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (CommonDatabase rawDb) {
+          // v67 时代的最小片段：只建迁移会读写的两张表（onUpgrade 的 from<68
+          // 分支只碰 media_images 与 collection_scrape_meta，其余表不参与）。
+          rawDb.execute('''
+CREATE TABLE media_collections (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  collection_type TEXT NOT NULL DEFAULT 'collection',
+  cover_source TEXT,
+  cover_path TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT 0,
+  order_updated_at INTEGER NOT NULL DEFAULT 0
+)
+''');
+          rawDb.execute('''
+CREATE TABLE collection_scrape_meta (
+  collection_id INTEGER NOT NULL PRIMARY KEY,
+  source TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  original_title TEXT,
+  summary TEXT,
+  air_date TEXT,
+  rating REAL,
+  rating_count INTEGER,
+  episode_count INTEGER,
+  tags_json TEXT,
+  infobox_json TEXT,
+  backdrop_path TEXT,
+  detail_url TEXT,
+  scraped_at INTEGER NOT NULL
+)
+''');
+          rawDb.execute(
+              "INSERT INTO media_collections (id, name) VALUES (5, 'c5')");
+          rawDb.execute(
+            'INSERT INTO collection_scrape_meta '
+            '(collection_id, source, subject_id, title, backdrop_path, '
+            ' scraped_at) '
+            "VALUES (5, 'tmdb', '100', 't', "
+            "'/covers/collections/5_backdrop.jpg', 0)",
+          );
+          // 无背景行：不得被搬成 path='' 的垃圾行。
+          rawDb.execute(
+              "INSERT INTO media_collections (id, name) VALUES (6, 'c6')");
+          rawDb.execute(
+            'INSERT INTO collection_scrape_meta '
+            '(collection_id, source, subject_id, title, scraped_at) '
+            "VALUES (6, 'bangumi', '200', 't2', 0)",
+          );
+          rawDb.execute('PRAGMA user_version = 67');
+        },
+      ),
+    );
+    addTearDown(db.close);
+
+    final List<MediaImageRow> rows = await db.getAllMediaImages();
+    expect(rows, hasLength(1), reason: 'NULL backdrop_path 不得搬出垃圾行');
+    expect(rows.single.collectionId, 5);
+    expect(rows.single.kind, MediaImageKind.backdrop.dbValue);
+    expect(rows.single.position, 0);
+    expect(rows.single.path, '/covers/collections/5_backdrop.jpg');
+  });
+}

--- a/hibiki/test/media/collections/collection_asset_reclaim_test.dart
+++ b/hibiki/test/media/collections/collection_asset_reclaim_test.dart
@@ -233,11 +233,14 @@ void main() {
       );
       expect(containsCodeLine(body, 'dissolved.add(row)'), isTrue,
           reason: '删行前必须入列行快照——行一删 coverPath 就推导不出来了');
-      expect(
-          containsCodeLine(
-              body, 'reclaimDeletedCollectionAssets(db, dissolved)'),
+      expect(containsCodeLine(body, 'collectionOwnedImagePaths(db, row.id)'),
           isTrue,
+          reason: 'v68 附加图行随删行 cascade 消失，路径同样必须删前快照');
+      expect(containsCodeLine(body, 'reclaimDeletedCollectionAssets('), isTrue,
           reason: '同步删除传播同样会解散合集，不回收就同样泄漏');
+      expect(containsCodeLine(body, 'ownedImagePaths: dissolvedImagePaths'),
+          isTrue,
+          reason: 'v68 附加图快照必须真的传给回收入口，光快照不回收等于没做');
       final int txEnd = body.indexOf('});');
       final int reclaimAt = body.indexOf('reclaimDeletedCollectionAssets(');
       expect(txEnd >= 0 && reclaimAt > txEnd, isTrue,

--- a/hibiki/test/media/video/scraper/tmdb_image_set_test.dart
+++ b/hibiki/test/media/video/scraper/tmdb_image_set_test.dart
@@ -1,0 +1,85 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/scraper/tmdb_client.dart';
+
+/// v68 守卫：TMDB `/images` 响应的 Jellyfin 式分类（parseTmdbImageSet 纯函数）。
+///
+/// 分类规则是本功能的语义核心，锁三条：
+///  1. **带语言的横图不得混进无字 backdrop**——backdrop 槽是全屏背景/轮换，烧死
+///     片名文字的图进去就是「背景上永远糊着一行字」（Jellyfin 把它降级为 Thumb，
+///     本仓叫 titleCard）；
+///  2. 无字 backdrop 封顶 [kTmdbMaxBackdrops] 张（响应序即 vote 降序）；
+///  3. logo 跳过 SVG（Flutter Image 不解码矢量）+ 按 zh→ja→en 语言偏好挑选。
+void main() {
+  Map<String, Object?> image(String filePath, {String? lang}) =>
+      <String, Object?>{'file_path': filePath, 'iso_639_1': lang};
+
+  String body({
+    List<Map<String, Object?>> backdrops = const <Map<String, Object?>>[],
+    List<Map<String, Object?>> logos = const <Map<String, Object?>>[],
+  }) =>
+      jsonEncode(<String, Object?>{'backdrops': backdrops, 'logos': logos});
+
+  test('带语言横图分流为 titleCard，不混进无字 backdrop', () {
+    final TmdbImageSet set = parseTmdbImageSet(body(
+      backdrops: <Map<String, Object?>>[
+        image('/clean0.jpg'),
+        image('/titled_en.jpg', lang: 'en'),
+        image('/clean1.jpg'),
+        image('/titled_zh.jpg', lang: 'zh'),
+      ],
+    ));
+
+    expect(
+      set.backdropUrls,
+      <String>[
+        '${TmdbClient.backdropBase}/clean0.jpg',
+        '${TmdbClient.backdropBase}/clean1.jpg',
+      ],
+      reason: '带字横图混进背景槽 = 全屏背景永远糊着一行片名',
+    );
+    expect(
+      set.titleCardUrl,
+      '${TmdbClient.backdropBase}/titled_zh.jpg',
+      reason: '带字横图按 zh→ja→en 偏好挑一张作 titleCard',
+    );
+  });
+
+  test('无字 backdrop 封顶 kTmdbMaxBackdrops 张（响应序 = vote 降序）', () {
+    final TmdbImageSet set = parseTmdbImageSet(body(
+      backdrops: <Map<String, Object?>>[
+        for (int i = 0; i < 10; i++) image('/b$i.jpg'),
+      ],
+    ));
+    expect(set.backdropUrls, hasLength(kTmdbMaxBackdrops));
+    expect(set.backdropUrls.first, '${TmdbClient.backdropBase}/b0.jpg',
+        reason: '截断必须保头部（vote 最高的几张），不是随机取样');
+  });
+
+  test('logo：SVG 跳过 + 语言偏好 zh→ja→en → 首张兜底', () {
+    final TmdbImageSet set = parseTmdbImageSet(body(
+      logos: <Map<String, Object?>>[
+        image('/vector.svg', lang: 'zh'),
+        image('/logo_en.png', lang: 'en'),
+        image('/logo_ja.png', lang: 'ja'),
+      ],
+    ));
+    expect(
+      set.logoUrl,
+      '${TmdbClient.posterBase}/logo_ja.png',
+      reason: 'zh 那张是 SVG（Flutter 解不了）须跳过，落到偏好序次位的 ja',
+    );
+
+    final TmdbImageSet noPref = parseTmdbImageSet(body(
+      logos: <Map<String, Object?>>[image('/logo_fr.png', lang: 'fr')],
+    ));
+    expect(noPref.logoUrl, '${TmdbClient.posterBase}/logo_fr.png',
+        reason: '偏好语言全缺时取首张，不是空手而归');
+  });
+
+  test('空响应 / 全空数组 → isEmpty，调用方回落候选单张背景', () {
+    expect(parseTmdbImageSet('{}').isEmpty, isTrue);
+    expect(parseTmdbImageSet(body()).isEmpty, isTrue);
+  });
+}

--- a/hibiki/test/media/video/video_episode_rail_cover_test.dart
+++ b/hibiki/test/media/video/video_episode_rail_cover_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/cover_ui/portrait_cover_image.dart';
+import 'package:hibiki/src/media/video/video_episode_rail.dart';
+import 'package:transparent_image/transparent_image.dart';
+
+/// v68 守卫：选集轨道（播放器/合集详情页共用）的 16:9 卡走朝向自适应，
+/// 不再裸 `BoxFit.cover` 硬裁。
+///
+/// 这里曾是全域**唯一**残留的硬裁点：没刮过的集封面是 2:3 刮削海报或方图 exe
+/// 抽帧，`cover` 进 16:9 槽会被裁成中间一条（BUG-1299 同病）。锁「封面经
+/// [PortraitCoverImage]（landscapeSlot）渲染」这一结构事实——退回裸 Image.cover
+/// 本测试即红。
+void main() {
+  testWidgets('有封面的集卡经 PortraitCoverImage 渲染（横槽自适应）',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: VideoEpisodeRail(
+          episodes: <VideoEpisodeEntry>[
+            VideoEpisodeEntry(
+              title: '第1话',
+              cover: MemoryImage(kTransparentImage),
+            ),
+            const VideoEpisodeEntry(title: '第2话'),
+          ],
+          currentIndex: 0,
+          onTapEpisode: (int _) {},
+          colorScheme: const ColorScheme.dark(),
+        ),
+      ),
+    ));
+    await tester.pump();
+
+    expect(
+      find.byType(PortraitCoverImage),
+      findsOneWidget,
+      reason: '有封面的集卡必须走朝向自适应组件；裸 BoxFit.cover 会把竖版海报裁成中间一条',
+    );
+    // 无封面的集仍是占位图标，不经自适应组件。
+    expect(find.byIcon(Icons.movie_outlined), findsOneWidget);
+  });
+}

--- a/hibiki/test/media/video/video_home_layout_test.dart
+++ b/hibiki/test/media/video/video_home_layout_test.dart
@@ -199,45 +199,71 @@ void main() {
     });
   });
 
-  group('selectVideoHeroCollections', () {
+  group('selectVideoHeroUnits', () {
     test('在看优先按最近观看倒序取前 5', () {
-      final List<VideoHeroCandidate> candidates = <VideoHeroCandidate>[
+      final List<VideoHeroCandidate<int>> candidates =
+          <VideoHeroCandidate<int>>[
         for (int i = 1; i <= 7; i++)
-          VideoHeroCandidate(
-            collectionId: i,
+          VideoHeroCandidate<int>(
+            unit: i,
             lastWatchedAt: DateTime(2026, 7, i),
             latestImportedAt: 100 - i,
             hasUnfinishedTrace: true,
           ),
       ];
-      expect(selectVideoHeroCollections(candidates), <int>[7, 6, 5, 4, 3]);
+      expect(selectVideoHeroUnits(candidates), <int>[7, 6, 5, 4, 3]);
     });
 
     test('无在看回落最近添加（成员最近入库倒序）', () {
-      final List<VideoHeroCandidate> candidates = <VideoHeroCandidate>[
-        const VideoHeroCandidate(collectionId: 1, latestImportedAt: 10),
-        const VideoHeroCandidate(collectionId: 2, latestImportedAt: 30),
-        const VideoHeroCandidate(collectionId: 3, latestImportedAt: 20),
+      final List<VideoHeroCandidate<int>> candidates =
+          <VideoHeroCandidate<int>>[
+        const VideoHeroCandidate<int>(unit: 1, latestImportedAt: 10),
+        const VideoHeroCandidate<int>(unit: 2, latestImportedAt: 30),
+        const VideoHeroCandidate<int>(unit: 3, latestImportedAt: 20),
       ];
-      expect(selectVideoHeroCollections(candidates), <int>[2, 3, 1]);
+      expect(selectVideoHeroUnits(candidates), <int>[2, 3, 1]);
     });
 
     test('已整套看完的合集不算在看（hasUnfinishedTrace=false 走回落池）', () {
-      final List<VideoHeroCandidate> candidates = <VideoHeroCandidate>[
-        VideoHeroCandidate(
-          collectionId: 1,
+      final List<VideoHeroCandidate<int>> candidates =
+          <VideoHeroCandidate<int>>[
+        VideoHeroCandidate<int>(
+          unit: 1,
           lastWatchedAt: DateTime(2026, 7, 30),
           latestImportedAt: 1,
         ),
-        VideoHeroCandidate(
-          collectionId: 2,
+        VideoHeroCandidate<int>(
+          unit: 2,
           lastWatchedAt: DateTime(2026, 7, 1),
           latestImportedAt: 2,
           hasUnfinishedTrace: true,
         ),
       ];
       // 只有 2 在看 → 在看池非空 → 只出在看的（1 不混入）。
-      expect(selectVideoHeroCollections(candidates), <int>[2]);
+      expect(selectVideoHeroUnits(candidates), <int>[2]);
+    });
+
+    test('散装与合集同池混排：最后看的是散装时置顶就是它（PR#712 跟进）', () {
+      // 单元载荷对函数不透明——用字符串区分两类；散装 'b:*' 最近观看晚于合集
+      // 'c:*'，必须排第一。旧实现把散装整体挡在候选外，置顶永远是合集，用户
+      // 实报「置顶不是上一个观看的」。
+      final List<VideoHeroCandidate<String>> candidates =
+          <VideoHeroCandidate<String>>[
+        VideoHeroCandidate<String>(
+          unit: 'c:maid-dragon',
+          lastWatchedAt: DateTime(2026, 8, 1, 20),
+          hasUnfinishedTrace: true,
+        ),
+        VideoHeroCandidate<String>(
+          unit: 'b:happy-end',
+          lastWatchedAt: DateTime(2026, 8, 1, 23),
+          hasUnfinishedTrace: true,
+        ),
+      ];
+      expect(
+        selectVideoHeroUnits(candidates),
+        <String>['b:happy-end', 'c:maid-dragon'],
+      );
     });
   });
 }

--- a/hibiki/test/pages/collection_hero_scrape_meta_test.dart
+++ b/hibiki/test/pages/collection_hero_scrape_meta_test.dart
@@ -64,7 +64,14 @@ void main() {
         collectionId,
         CollectionScrapeResult(
           coverPath: coverPath,
-          backdropPath: backdropPath,
+          // v68：横版背景改走 media_images 图组（apply 落行，页面读表）。
+          images: <ScrapedMediaImage>[
+            if (backdropPath != null)
+              ScrapedMediaImage(
+                kind: MediaImageKind.backdrop,
+                path: backdropPath,
+              ),
+          ],
           metadata: const ScrapeMetadata(
             source: ScrapeSource.tmdb,
             subjectId: '100',

--- a/hibiki/test/pages/home_video_page_menu_test.dart
+++ b/hibiki/test/pages/home_video_page_menu_test.dart
@@ -62,6 +62,7 @@ class PausingBatchDeleteVideoBookRepository extends VideoBookRepository {
     required String? deletedCoverPath,
     required String? deletedSubtitlePath,
     required String deletedVideoPath,
+    List<String> deletedImagePaths = const <String>[],
   }) async {
     reclaimCalls++;
     await super.reclaimDeletedVideoBookAssets(
@@ -69,6 +70,7 @@ class PausingBatchDeleteVideoBookRepository extends VideoBookRepository {
       deletedCoverPath: deletedCoverPath,
       deletedSubtitlePath: deletedSubtitlePath,
       deletedVideoPath: deletedVideoPath,
+      deletedImagePaths: deletedImagePaths,
     );
   }
 

--- a/hibiki/test/pages/home_video_sort_mode_test.dart
+++ b/hibiki/test/pages/home_video_sort_mode_test.dart
@@ -135,7 +135,10 @@ void main() {
 
   testWidgets('默认最近观看：看过的在前，没看过的按导入时间倒序；切名称/导入时间真重排 + 写穿偏好',
       (WidgetTester tester) async {
-    tester.view.physicalSize = const Size(1280, 800);
+    // v68 起散装也进 hero（本用例三张全是散卡，Beta 在看 → 顶部多出一块全宽
+    // hero），视口抬高让墙卡仍在首屏内被懒构建出来——本用例断言的是墙卡排序，
+    // 不是 hero。
+    tester.view.physicalSize = const Size(1280, 2200);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
@@ -178,7 +181,10 @@ void main() {
 
   testWidgets('偏好持久化：带 video_sort_mode=title 开页直接按名称序渲染',
       (WidgetTester tester) async {
-    tester.view.physicalSize = const Size(1280, 800);
+    // v68 起散装也进 hero（本用例三张全是散卡，Beta 在看 → 顶部多出一块全宽
+    // hero），视口抬高让墙卡仍在首屏内被懒构建出来——本用例断言的是墙卡排序，
+    // 不是 hero。
+    tester.view.physicalSize = const Size(1280, 2200);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);

--- a/packages/hibiki_core/lib/hibiki_core.dart
+++ b/packages/hibiki_core/lib/hibiki_core.dart
@@ -4,6 +4,7 @@ export 'src/database/activity_event_types.dart';
 export 'src/database/book_format.dart';
 export 'src/database/collection_order.dart';
 export 'src/database/database.dart';
+export 'src/database/media_image_kind.dart';
 export 'src/database/media_kind.dart';
 export 'src/database/media_kind_mappings.dart';
 export 'src/database/media_ref.dart';

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -405,6 +405,7 @@ _MergedTagState _mergeTagClocks(
   MangaSourcePreferences,
   MangaTrustedSigners,
   CollectionRelations,
+  MediaImages,
 ])
 class HibikiDatabase extends _$HibikiDatabase {
   /// [isMainProcess] gates the TODO-905 sidecar rebuild: the main app passes
@@ -423,7 +424,7 @@ class HibikiDatabase extends _$HibikiDatabase {
   HibikiDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 67;
+  int get schemaVersion => 68;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -1373,6 +1374,30 @@ class HibikiDatabase extends _$HibikiDatabase {
                 readingHourlyLogs,
                 newColumns: [readingHourlyLogs.format],
               ));
+            }
+          }
+          if (from < 68) {
+            // v68（Jellyfin 图组对齐）：新增 media_images —— 媒体附加图组表
+            // （backdrop 多张 / logo / title_card，归属合集或单视频二选一）。
+            // 建表后一次性把 v64 的 collection_scrape_meta.backdrop_path 搬进来
+            // （kind='backdrop', position=0），旧列自此冻结为遗留残留（Series
+            // 先例）：读写一律走 media_images。搬运只在建表的同一分支里跑——
+            // 重复升级时 _tableExists 短路，绝不重插；fresh DB 走 onCreate
+            // createAll，本就没有旧数据可搬（Never break userspace：旧库升级后
+            // 详情页 hero 读到的背景与升级前同一张文件，逐像素不变）。
+            if (!await _tableExists('media_images')) {
+              await m.createTable(mediaImages);
+              if (await _tableExists('collection_scrape_meta') &&
+                  await _columnExists(
+                      'collection_scrape_meta', 'backdrop_path')) {
+                await customStatement(
+                  'INSERT INTO media_images '
+                  '(collection_id, kind, position, path) '
+                  "SELECT collection_id, 'backdrop', 0, backdrop_path "
+                  'FROM collection_scrape_meta '
+                  "WHERE backdrop_path IS NOT NULL AND backdrop_path != ''",
+                );
+              }
             }
           }
         },
@@ -2751,6 +2776,70 @@ class HibikiDatabase extends _$HibikiDatabase {
             .get();
     return <int>[for (final CollectionScrapeMetaRow r in rows) r.collectionId];
   }
+
+  // ── media_images（媒体附加图组，schema v68 / Jellyfin 图组对齐）──────
+
+  /// 整体替换某合集的附加图组（重刮即替换；空列表 = 清空）。
+  ///
+  /// 事务内 delete + insert（与 [replaceCollectionRelations] 同理由）：图组来自
+  /// 源的一次完整响应，逐条 upsert 会留下上次刮削已不存在的残图行。
+  Future<void> replaceMediaImagesForCollection(
+    int collectionId,
+    List<MediaImagesCompanion> images,
+  ) =>
+      transaction(() async {
+        await (delete(mediaImages)
+              ..where(
+                  ($MediaImagesTable t) => t.collectionId.equals(collectionId)))
+            .go();
+        for (final MediaImagesCompanion c in images) {
+          await into(mediaImages).insert(c);
+        }
+      });
+
+  /// 整体替换某视频的附加图组（散装电影刮削用；空列表 = 清空）。
+  Future<void> replaceMediaImagesForBook(
+    String bookUid,
+    List<MediaImagesCompanion> images,
+  ) =>
+      transaction(() async {
+        await (delete(mediaImages)
+              ..where(($MediaImagesTable t) => t.bookUid.equals(bookUid)))
+            .go();
+        for (final MediaImagesCompanion c in images) {
+          await into(mediaImages).insert(c);
+        }
+      });
+
+  /// 某合集的附加图组（kind 组内按 position 升序，backdrop 轮换序即此序）。
+  Future<List<MediaImageRow>> getMediaImagesForCollection(int collectionId) =>
+      (select(mediaImages)
+            ..where(
+                ($MediaImagesTable t) => t.collectionId.equals(collectionId))
+            ..orderBy([
+              ($MediaImagesTable t) => OrderingTerm(expression: t.kind),
+              ($MediaImagesTable t) => OrderingTerm(expression: t.position),
+            ]))
+          .get();
+
+  /// 某视频的附加图组。
+  Future<List<MediaImageRow>> getMediaImagesForBook(String bookUid) =>
+      (select(mediaImages)
+            ..where(($MediaImagesTable t) => t.bookUid.equals(bookUid))
+            ..orderBy([
+              ($MediaImagesTable t) => OrderingTerm(expression: t.kind),
+              ($MediaImagesTable t) => OrderingTerm(expression: t.position),
+            ]))
+          .get();
+
+  /// 全表附加图组（库页/首页批量预取，替代逐归属查询的 N+1；调用方按
+  /// collectionId / bookUid 内存分组）。
+  Future<List<MediaImageRow>> getAllMediaImages() => (select(mediaImages)
+        ..orderBy([
+          ($MediaImagesTable t) => OrderingTerm(expression: t.kind),
+          ($MediaImagesTable t) => OrderingTerm(expression: t.position),
+        ]))
+      .get();
 
   /// 监听视频库 uid 集合。插入/删除行时发出更新后的 uid 列表；库页据此在任意
   /// 导入路径（页内 / 拖拽 / 外部「用 Hibiki 打开」/ 远端下载）落库后自动重查，

--- a/packages/hibiki_core/lib/src/database/database.g.dart
+++ b/packages/hibiki_core/lib/src/database/database.g.dart
@@ -24831,6 +24831,409 @@ class CollectionRelationsCompanion
   }
 }
 
+class $MediaImagesTable extends MediaImages
+    with TableInfo<$MediaImagesTable, MediaImageRow> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $MediaImagesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _collectionIdMeta =
+      const VerificationMeta('collectionId');
+  @override
+  late final GeneratedColumn<int> collectionId = GeneratedColumn<int>(
+      'collection_id', aliasedName, true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES media_collections (id) ON DELETE CASCADE'));
+  static const VerificationMeta _bookUidMeta =
+      const VerificationMeta('bookUid');
+  @override
+  late final GeneratedColumn<String> bookUid = GeneratedColumn<String>(
+      'book_uid', aliasedName, true,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      defaultConstraints: GeneratedColumn.constraintIsAlways(
+          'REFERENCES video_books (book_uid) ON DELETE CASCADE'));
+  static const VerificationMeta _kindMeta = const VerificationMeta('kind');
+  @override
+  late final GeneratedColumn<String> kind = GeneratedColumn<String>(
+      'kind', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _positionMeta =
+      const VerificationMeta('position');
+  @override
+  late final GeneratedColumn<int> position = GeneratedColumn<int>(
+      'position', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _pathMeta = const VerificationMeta('path');
+  @override
+  late final GeneratedColumn<String> path = GeneratedColumn<String>(
+      'path', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _sourceUrlMeta =
+      const VerificationMeta('sourceUrl');
+  @override
+  late final GeneratedColumn<String> sourceUrl = GeneratedColumn<String>(
+      'source_url', aliasedName, true,
+      type: DriftSqlType.string, requiredDuringInsert: false);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, collectionId, bookUid, kind, position, path, sourceUrl];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'media_images';
+  @override
+  VerificationContext validateIntegrity(Insertable<MediaImageRow> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('collection_id')) {
+      context.handle(
+          _collectionIdMeta,
+          collectionId.isAcceptableOrUnknown(
+              data['collection_id']!, _collectionIdMeta));
+    }
+    if (data.containsKey('book_uid')) {
+      context.handle(_bookUidMeta,
+          bookUid.isAcceptableOrUnknown(data['book_uid']!, _bookUidMeta));
+    }
+    if (data.containsKey('kind')) {
+      context.handle(
+          _kindMeta, kind.isAcceptableOrUnknown(data['kind']!, _kindMeta));
+    } else if (isInserting) {
+      context.missing(_kindMeta);
+    }
+    if (data.containsKey('position')) {
+      context.handle(_positionMeta,
+          position.isAcceptableOrUnknown(data['position']!, _positionMeta));
+    }
+    if (data.containsKey('path')) {
+      context.handle(
+          _pathMeta, path.isAcceptableOrUnknown(data['path']!, _pathMeta));
+    } else if (isInserting) {
+      context.missing(_pathMeta);
+    }
+    if (data.containsKey('source_url')) {
+      context.handle(_sourceUrlMeta,
+          sourceUrl.isAcceptableOrUnknown(data['source_url']!, _sourceUrlMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+        {collectionId, kind, position},
+        {bookUid, kind, position},
+      ];
+  @override
+  MediaImageRow map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return MediaImageRow(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      collectionId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}collection_id']),
+      bookUid: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}book_uid']),
+      kind: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}kind'])!,
+      position: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}position'])!,
+      path: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}path'])!,
+      sourceUrl: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}source_url']),
+    );
+  }
+
+  @override
+  $MediaImagesTable createAlias(String alias) {
+    return $MediaImagesTable(attachedDatabase, alias);
+  }
+}
+
+class MediaImageRow extends DataClass implements Insertable<MediaImageRow> {
+  final int id;
+
+  /// 归属合集（与 [bookUid] 二选一）。删合集 cascade 清行。
+  final int? collectionId;
+
+  /// 归属单视频（与 [collectionId] 二选一；散装电影的图组）。删视频 cascade 清行。
+  final String? bookUid;
+
+  /// 图种类（`MediaImageKind.dbValue`：backdrop / logo / title_card）。
+  final String kind;
+
+  /// 同归属同种类内的排序位（仅 backdrop 允许 >0；其余恒 0）。
+  final int position;
+
+  /// 本地文件绝对路径（合集图落 `video_covers/collections/`，视频图落
+  /// `video_covers/images/`——两个子目录都在 gcOrphanCovers 扫描面外）。
+  final String path;
+
+  /// 来源远程 URL（重下/诊断用；手动设置的图为 null）。
+  final String? sourceUrl;
+  const MediaImageRow(
+      {required this.id,
+      this.collectionId,
+      this.bookUid,
+      required this.kind,
+      required this.position,
+      required this.path,
+      this.sourceUrl});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    if (!nullToAbsent || collectionId != null) {
+      map['collection_id'] = Variable<int>(collectionId);
+    }
+    if (!nullToAbsent || bookUid != null) {
+      map['book_uid'] = Variable<String>(bookUid);
+    }
+    map['kind'] = Variable<String>(kind);
+    map['position'] = Variable<int>(position);
+    map['path'] = Variable<String>(path);
+    if (!nullToAbsent || sourceUrl != null) {
+      map['source_url'] = Variable<String>(sourceUrl);
+    }
+    return map;
+  }
+
+  MediaImagesCompanion toCompanion(bool nullToAbsent) {
+    return MediaImagesCompanion(
+      id: Value(id),
+      collectionId: collectionId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(collectionId),
+      bookUid: bookUid == null && nullToAbsent
+          ? const Value.absent()
+          : Value(bookUid),
+      kind: Value(kind),
+      position: Value(position),
+      path: Value(path),
+      sourceUrl: sourceUrl == null && nullToAbsent
+          ? const Value.absent()
+          : Value(sourceUrl),
+    );
+  }
+
+  factory MediaImageRow.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return MediaImageRow(
+      id: serializer.fromJson<int>(json['id']),
+      collectionId: serializer.fromJson<int?>(json['collectionId']),
+      bookUid: serializer.fromJson<String?>(json['bookUid']),
+      kind: serializer.fromJson<String>(json['kind']),
+      position: serializer.fromJson<int>(json['position']),
+      path: serializer.fromJson<String>(json['path']),
+      sourceUrl: serializer.fromJson<String?>(json['sourceUrl']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'collectionId': serializer.toJson<int?>(collectionId),
+      'bookUid': serializer.toJson<String?>(bookUid),
+      'kind': serializer.toJson<String>(kind),
+      'position': serializer.toJson<int>(position),
+      'path': serializer.toJson<String>(path),
+      'sourceUrl': serializer.toJson<String?>(sourceUrl),
+    };
+  }
+
+  MediaImageRow copyWith(
+          {int? id,
+          Value<int?> collectionId = const Value.absent(),
+          Value<String?> bookUid = const Value.absent(),
+          String? kind,
+          int? position,
+          String? path,
+          Value<String?> sourceUrl = const Value.absent()}) =>
+      MediaImageRow(
+        id: id ?? this.id,
+        collectionId:
+            collectionId.present ? collectionId.value : this.collectionId,
+        bookUid: bookUid.present ? bookUid.value : this.bookUid,
+        kind: kind ?? this.kind,
+        position: position ?? this.position,
+        path: path ?? this.path,
+        sourceUrl: sourceUrl.present ? sourceUrl.value : this.sourceUrl,
+      );
+  MediaImageRow copyWithCompanion(MediaImagesCompanion data) {
+    return MediaImageRow(
+      id: data.id.present ? data.id.value : this.id,
+      collectionId: data.collectionId.present
+          ? data.collectionId.value
+          : this.collectionId,
+      bookUid: data.bookUid.present ? data.bookUid.value : this.bookUid,
+      kind: data.kind.present ? data.kind.value : this.kind,
+      position: data.position.present ? data.position.value : this.position,
+      path: data.path.present ? data.path.value : this.path,
+      sourceUrl: data.sourceUrl.present ? data.sourceUrl.value : this.sourceUrl,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MediaImageRow(')
+          ..write('id: $id, ')
+          ..write('collectionId: $collectionId, ')
+          ..write('bookUid: $bookUid, ')
+          ..write('kind: $kind, ')
+          ..write('position: $position, ')
+          ..write('path: $path, ')
+          ..write('sourceUrl: $sourceUrl')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(id, collectionId, bookUid, kind, position, path, sourceUrl);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is MediaImageRow &&
+          other.id == this.id &&
+          other.collectionId == this.collectionId &&
+          other.bookUid == this.bookUid &&
+          other.kind == this.kind &&
+          other.position == this.position &&
+          other.path == this.path &&
+          other.sourceUrl == this.sourceUrl);
+}
+
+class MediaImagesCompanion extends UpdateCompanion<MediaImageRow> {
+  final Value<int> id;
+  final Value<int?> collectionId;
+  final Value<String?> bookUid;
+  final Value<String> kind;
+  final Value<int> position;
+  final Value<String> path;
+  final Value<String?> sourceUrl;
+  const MediaImagesCompanion({
+    this.id = const Value.absent(),
+    this.collectionId = const Value.absent(),
+    this.bookUid = const Value.absent(),
+    this.kind = const Value.absent(),
+    this.position = const Value.absent(),
+    this.path = const Value.absent(),
+    this.sourceUrl = const Value.absent(),
+  });
+  MediaImagesCompanion.insert({
+    this.id = const Value.absent(),
+    this.collectionId = const Value.absent(),
+    this.bookUid = const Value.absent(),
+    required String kind,
+    this.position = const Value.absent(),
+    required String path,
+    this.sourceUrl = const Value.absent(),
+  })  : kind = Value(kind),
+        path = Value(path);
+  static Insertable<MediaImageRow> custom({
+    Expression<int>? id,
+    Expression<int>? collectionId,
+    Expression<String>? bookUid,
+    Expression<String>? kind,
+    Expression<int>? position,
+    Expression<String>? path,
+    Expression<String>? sourceUrl,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (collectionId != null) 'collection_id': collectionId,
+      if (bookUid != null) 'book_uid': bookUid,
+      if (kind != null) 'kind': kind,
+      if (position != null) 'position': position,
+      if (path != null) 'path': path,
+      if (sourceUrl != null) 'source_url': sourceUrl,
+    });
+  }
+
+  MediaImagesCompanion copyWith(
+      {Value<int>? id,
+      Value<int?>? collectionId,
+      Value<String?>? bookUid,
+      Value<String>? kind,
+      Value<int>? position,
+      Value<String>? path,
+      Value<String?>? sourceUrl}) {
+    return MediaImagesCompanion(
+      id: id ?? this.id,
+      collectionId: collectionId ?? this.collectionId,
+      bookUid: bookUid ?? this.bookUid,
+      kind: kind ?? this.kind,
+      position: position ?? this.position,
+      path: path ?? this.path,
+      sourceUrl: sourceUrl ?? this.sourceUrl,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (collectionId.present) {
+      map['collection_id'] = Variable<int>(collectionId.value);
+    }
+    if (bookUid.present) {
+      map['book_uid'] = Variable<String>(bookUid.value);
+    }
+    if (kind.present) {
+      map['kind'] = Variable<String>(kind.value);
+    }
+    if (position.present) {
+      map['position'] = Variable<int>(position.value);
+    }
+    if (path.present) {
+      map['path'] = Variable<String>(path.value);
+    }
+    if (sourceUrl.present) {
+      map['source_url'] = Variable<String>(sourceUrl.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('MediaImagesCompanion(')
+          ..write('id: $id, ')
+          ..write('collectionId: $collectionId, ')
+          ..write('bookUid: $bookUid, ')
+          ..write('kind: $kind, ')
+          ..write('position: $position, ')
+          ..write('path: $path, ')
+          ..write('sourceUrl: $sourceUrl')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$HibikiDatabase extends GeneratedDatabase {
   _$HibikiDatabase(QueryExecutor e) : super(e);
   $HibikiDatabaseManager get managers => $HibikiDatabaseManager(this);
@@ -24930,6 +25333,7 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
       $MangaTrustedSignersTable(this);
   late final $CollectionRelationsTable collectionRelations =
       $CollectionRelationsTable(this);
+  late final $MediaImagesTable mediaImages = $MediaImagesTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
@@ -24994,7 +25398,8 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
         mangaOnlineSources,
         mangaSourcePreferences,
         mangaTrustedSigners,
-        collectionRelations
+        collectionRelations,
+        mediaImages
       ];
   @override
   StreamQueryUpdateRules get streamUpdateRules => const StreamQueryUpdateRules(
@@ -25179,6 +25584,20 @@ abstract class _$HibikiDatabase extends GeneratedDatabase {
                 limitUpdateKind: UpdateKind.delete),
             result: [
               TableUpdate('collection_relations', kind: UpdateKind.update),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('media_collections',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('media_images', kind: UpdateKind.delete),
+            ],
+          ),
+          WritePropagation(
+            on: TableUpdateQuery.onTableName('video_books',
+                limitUpdateKind: UpdateKind.delete),
+            result: [
+              TableUpdate('media_images', kind: UpdateKind.delete),
             ],
           ),
         ],
@@ -31881,6 +32300,21 @@ final class $$VideoBooksTableReferences
     return ProcessedTableManager(
         manager.$state.copyWith(prefetchedData: cache));
   }
+
+  static MultiTypedResultKey<$MediaImagesTable, List<MediaImageRow>>
+      _mediaImagesRefsTable(_$HibikiDatabase db) =>
+          MultiTypedResultKey.fromTable(db.mediaImages,
+              aliasName: 'video_books__book_uid__media_images__book_uid');
+
+  $$MediaImagesTableProcessedTableManager get mediaImagesRefs {
+    final manager = $$MediaImagesTableTableManager($_db, $_db.mediaImages)
+        .filter((f) =>
+            f.bookUid.bookUid.sqlEquals($_itemColumn<String>('book_uid')!));
+
+    final cache = $_typedResult.readTableOrNull(_mediaImagesRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$VideoBooksTableFilterComposer
@@ -32002,6 +32436,27 @@ class $$VideoBooksTableFilterComposer
             $$VideoScrapeMetaTableFilterComposer(
               $db: $db,
               $table: $db.videoScrapeMeta,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
+
+  Expression<bool> mediaImagesRefs(
+      Expression<bool> Function($$MediaImagesTableFilterComposer f) f) {
+    final $$MediaImagesTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.bookUid,
+        referencedTable: $db.mediaImages,
+        getReferencedColumn: (t) => t.bookUid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaImagesTableFilterComposer(
+              $db: $db,
+              $table: $db.mediaImages,
               $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
               joinBuilder: joinBuilder,
               $removeJoinBuilderFromRootComposer:
@@ -32218,6 +32673,27 @@ class $$VideoBooksTableAnnotationComposer
             ));
     return f(composer);
   }
+
+  Expression<T> mediaImagesRefs<T extends Object>(
+      Expression<T> Function($$MediaImagesTableAnnotationComposer a) f) {
+    final $$MediaImagesTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.bookUid,
+        referencedTable: $db.mediaImages,
+        getReferencedColumn: (t) => t.bookUid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaImagesTableAnnotationComposer(
+              $db: $db,
+              $table: $db.mediaImages,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
 }
 
 class $$VideoBooksTableTableManager extends RootTableManager<
@@ -32234,7 +32710,8 @@ class $$VideoBooksTableTableManager extends RootTableManager<
     PrefetchHooks Function(
         {bool sourceId,
         bool videoBookTagMappingsRefs,
-        bool videoScrapeMetaRefs})> {
+        bool videoScrapeMetaRefs,
+        bool mediaImagesRefs})> {
   $$VideoBooksTableTableManager(_$HibikiDatabase db, $VideoBooksTable table)
       : super(TableManagerState(
           db: db,
@@ -32334,12 +32811,14 @@ class $$VideoBooksTableTableManager extends RootTableManager<
           prefetchHooksCallback: (
               {sourceId = false,
               videoBookTagMappingsRefs = false,
-              videoScrapeMetaRefs = false}) {
+              videoScrapeMetaRefs = false,
+              mediaImagesRefs = false}) {
             return PrefetchHooks(
               db: db,
               explicitlyWatchedTables: [
                 if (videoBookTagMappingsRefs) db.videoBookTagMappings,
-                if (videoScrapeMetaRefs) db.videoScrapeMeta
+                if (videoScrapeMetaRefs) db.videoScrapeMeta,
+                if (mediaImagesRefs) db.mediaImages
               ],
               addJoins: <
                   T extends TableManagerState<
@@ -32394,6 +32873,19 @@ class $$VideoBooksTableTableManager extends RootTableManager<
                         referencedItemsForCurrentItem:
                             (item, referencedItems) => referencedItems
                                 .where((e) => e.bookUid == item.bookUid),
+                        typedResults: items),
+                  if (mediaImagesRefs)
+                    await $_getPrefetchedData<VideoBookRow, $VideoBooksTable,
+                            MediaImageRow>(
+                        currentTable: table,
+                        referencedTable: $$VideoBooksTableReferences
+                            ._mediaImagesRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$VideoBooksTableReferences(db, table, p0)
+                                .mediaImagesRefs,
+                        referencedItemsForCurrentItem:
+                            (item, referencedItems) => referencedItems
+                                .where((e) => e.bookUid == item.bookUid),
                         typedResults: items)
                 ];
               },
@@ -32416,7 +32908,8 @@ typedef $$VideoBooksTableProcessedTableManager = ProcessedTableManager<
     PrefetchHooks Function(
         {bool sourceId,
         bool videoBookTagMappingsRefs,
-        bool videoScrapeMetaRefs})>;
+        bool videoScrapeMetaRefs,
+        bool mediaImagesRefs})>;
 typedef $$VideoBookTagMappingsTableCreateCompanionBuilder
     = VideoBookTagMappingsCompanion Function({
   Value<int> id,
@@ -34411,6 +34904,20 @@ final class $$MediaCollectionsTableReferences extends BaseReferences<
     return ProcessedTableManager(
         manager.$state.copyWith(prefetchedData: cache));
   }
+
+  static MultiTypedResultKey<$MediaImagesTable, List<MediaImageRow>>
+      _mediaImagesRefsTable(_$HibikiDatabase db) =>
+          MultiTypedResultKey.fromTable(db.mediaImages,
+              aliasName: 'media_collections__id__media_images__collection_id');
+
+  $$MediaImagesTableProcessedTableManager get mediaImagesRefs {
+    final manager = $$MediaImagesTableTableManager($_db, $_db.mediaImages)
+        .filter((f) => f.collectionId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_mediaImagesRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
 }
 
 class $$MediaCollectionsTableFilterComposer
@@ -34517,6 +35024,27 @@ class $$MediaCollectionsTableFilterComposer
             $$CollectionScrapeMetaTableFilterComposer(
               $db: $db,
               $table: $db.collectionScrapeMeta,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
+
+  Expression<bool> mediaImagesRefs(
+      Expression<bool> Function($$MediaImagesTableFilterComposer f) f) {
+    final $$MediaImagesTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $db.mediaImages,
+        getReferencedColumn: (t) => t.collectionId,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaImagesTableFilterComposer(
+              $db: $db,
+              $table: $db.mediaImages,
               $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
               joinBuilder: joinBuilder,
               $removeJoinBuilderFromRootComposer:
@@ -34683,6 +35211,27 @@ class $$MediaCollectionsTableAnnotationComposer
                 ));
     return f(composer);
   }
+
+  Expression<T> mediaImagesRefs<T extends Object>(
+      Expression<T> Function($$MediaImagesTableAnnotationComposer a) f) {
+    final $$MediaImagesTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $db.mediaImages,
+        getReferencedColumn: (t) => t.collectionId,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaImagesTableAnnotationComposer(
+              $db: $db,
+              $table: $db.mediaImages,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
 }
 
 class $$MediaCollectionsTableTableManager extends RootTableManager<
@@ -34699,7 +35248,8 @@ class $$MediaCollectionsTableTableManager extends RootTableManager<
     PrefetchHooks Function(
         {bool mediaCollectionItemsRefs,
         bool collectionTagMappingsRefs,
-        bool collectionScrapeMetaRefs})> {
+        bool collectionScrapeMetaRefs,
+        bool mediaImagesRefs})> {
   $$MediaCollectionsTableTableManager(
       _$HibikiDatabase db, $MediaCollectionsTable table)
       : super(TableManagerState(
@@ -34772,13 +35322,15 @@ class $$MediaCollectionsTableTableManager extends RootTableManager<
           prefetchHooksCallback: (
               {mediaCollectionItemsRefs = false,
               collectionTagMappingsRefs = false,
-              collectionScrapeMetaRefs = false}) {
+              collectionScrapeMetaRefs = false,
+              mediaImagesRefs = false}) {
             return PrefetchHooks(
               db: db,
               explicitlyWatchedTables: [
                 if (mediaCollectionItemsRefs) db.mediaCollectionItems,
                 if (collectionTagMappingsRefs) db.collectionTagMappings,
-                if (collectionScrapeMetaRefs) db.collectionScrapeMeta
+                if (collectionScrapeMetaRefs) db.collectionScrapeMeta,
+                if (mediaImagesRefs) db.mediaImages
               ],
               addJoins: null,
               getPrefetchedDataCallback: (items) async {
@@ -34821,6 +35373,19 @@ class $$MediaCollectionsTableTableManager extends RootTableManager<
                         referencedItemsForCurrentItem:
                             (item, referencedItems) => referencedItems
                                 .where((e) => e.collectionId == item.id),
+                        typedResults: items),
+                  if (mediaImagesRefs)
+                    await $_getPrefetchedData<MediaCollectionRow,
+                            $MediaCollectionsTable, MediaImageRow>(
+                        currentTable: table,
+                        referencedTable: $$MediaCollectionsTableReferences
+                            ._mediaImagesRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$MediaCollectionsTableReferences(db, table, p0)
+                                .mediaImagesRefs,
+                        referencedItemsForCurrentItem:
+                            (item, referencedItems) => referencedItems
+                                .where((e) => e.collectionId == item.id),
                         typedResults: items)
                 ];
               },
@@ -34843,7 +35408,8 @@ typedef $$MediaCollectionsTableProcessedTableManager = ProcessedTableManager<
     PrefetchHooks Function(
         {bool mediaCollectionItemsRefs,
         bool collectionTagMappingsRefs,
-        bool collectionScrapeMetaRefs})>;
+        bool collectionScrapeMetaRefs,
+        bool mediaImagesRefs})>;
 typedef $$MediaCollectionItemsTableCreateCompanionBuilder
     = MediaCollectionItemsCompanion Function({
   required int collectionId,
@@ -42026,6 +42592,381 @@ typedef $$CollectionRelationsTableProcessedTableManager = ProcessedTableManager<
     (CollectionRelationRow, $$CollectionRelationsTableReferences),
     CollectionRelationRow,
     PrefetchHooks Function({bool collectionId, bool targetCollectionId})>;
+typedef $$MediaImagesTableCreateCompanionBuilder = MediaImagesCompanion
+    Function({
+  Value<int> id,
+  Value<int?> collectionId,
+  Value<String?> bookUid,
+  required String kind,
+  Value<int> position,
+  required String path,
+  Value<String?> sourceUrl,
+});
+typedef $$MediaImagesTableUpdateCompanionBuilder = MediaImagesCompanion
+    Function({
+  Value<int> id,
+  Value<int?> collectionId,
+  Value<String?> bookUid,
+  Value<String> kind,
+  Value<int> position,
+  Value<String> path,
+  Value<String?> sourceUrl,
+});
+
+final class $$MediaImagesTableReferences
+    extends BaseReferences<_$HibikiDatabase, $MediaImagesTable, MediaImageRow> {
+  $$MediaImagesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static $MediaCollectionsTable _collectionIdTable(_$HibikiDatabase db) =>
+      db.mediaCollections
+          .createAlias('media_images__collection_id__media_collections__id');
+
+  $$MediaCollectionsTableProcessedTableManager? get collectionId {
+    final $_column = $_itemColumn<int>('collection_id');
+    if ($_column == null) return null;
+    final manager =
+        $$MediaCollectionsTableTableManager($_db, $_db.mediaCollections)
+            .filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_collectionIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+
+  static $VideoBooksTable _bookUidTable(_$HibikiDatabase db) => db.videoBooks
+      .createAlias('media_images__book_uid__video_books__book_uid');
+
+  $$VideoBooksTableProcessedTableManager? get bookUid {
+    final $_column = $_itemColumn<String>('book_uid');
+    if ($_column == null) return null;
+    final manager = $$VideoBooksTableTableManager($_db, $_db.videoBooks)
+        .filter((f) => f.bookUid.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_bookUidTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+}
+
+class $$MediaImagesTableFilterComposer
+    extends Composer<_$HibikiDatabase, $MediaImagesTable> {
+  $$MediaImagesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get kind => $composableBuilder(
+      column: $table.kind, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get position => $composableBuilder(
+      column: $table.position, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get path => $composableBuilder(
+      column: $table.path, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get sourceUrl => $composableBuilder(
+      column: $table.sourceUrl, builder: (column) => ColumnFilters(column));
+
+  $$MediaCollectionsTableFilterComposer get collectionId {
+    final $$MediaCollectionsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.collectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableFilterComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$VideoBooksTableFilterComposer get bookUid {
+    final $$VideoBooksTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.bookUid,
+        referencedTable: $db.videoBooks,
+        getReferencedColumn: (t) => t.bookUid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$VideoBooksTableFilterComposer(
+              $db: $db,
+              $table: $db.videoBooks,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$MediaImagesTableOrderingComposer
+    extends Composer<_$HibikiDatabase, $MediaImagesTable> {
+  $$MediaImagesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get kind => $composableBuilder(
+      column: $table.kind, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get position => $composableBuilder(
+      column: $table.position, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get path => $composableBuilder(
+      column: $table.path, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get sourceUrl => $composableBuilder(
+      column: $table.sourceUrl, builder: (column) => ColumnOrderings(column));
+
+  $$MediaCollectionsTableOrderingComposer get collectionId {
+    final $$MediaCollectionsTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.collectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableOrderingComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$VideoBooksTableOrderingComposer get bookUid {
+    final $$VideoBooksTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.bookUid,
+        referencedTable: $db.videoBooks,
+        getReferencedColumn: (t) => t.bookUid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$VideoBooksTableOrderingComposer(
+              $db: $db,
+              $table: $db.videoBooks,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$MediaImagesTableAnnotationComposer
+    extends Composer<_$HibikiDatabase, $MediaImagesTable> {
+  $$MediaImagesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get kind =>
+      $composableBuilder(column: $table.kind, builder: (column) => column);
+
+  GeneratedColumn<int> get position =>
+      $composableBuilder(column: $table.position, builder: (column) => column);
+
+  GeneratedColumn<String> get path =>
+      $composableBuilder(column: $table.path, builder: (column) => column);
+
+  GeneratedColumn<String> get sourceUrl =>
+      $composableBuilder(column: $table.sourceUrl, builder: (column) => column);
+
+  $$MediaCollectionsTableAnnotationComposer get collectionId {
+    final $$MediaCollectionsTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.collectionId,
+        referencedTable: $db.mediaCollections,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$MediaCollectionsTableAnnotationComposer(
+              $db: $db,
+              $table: $db.mediaCollections,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+
+  $$VideoBooksTableAnnotationComposer get bookUid {
+    final $$VideoBooksTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.bookUid,
+        referencedTable: $db.videoBooks,
+        getReferencedColumn: (t) => t.bookUid,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$VideoBooksTableAnnotationComposer(
+              $db: $db,
+              $table: $db.videoBooks,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$MediaImagesTableTableManager extends RootTableManager<
+    _$HibikiDatabase,
+    $MediaImagesTable,
+    MediaImageRow,
+    $$MediaImagesTableFilterComposer,
+    $$MediaImagesTableOrderingComposer,
+    $$MediaImagesTableAnnotationComposer,
+    $$MediaImagesTableCreateCompanionBuilder,
+    $$MediaImagesTableUpdateCompanionBuilder,
+    (MediaImageRow, $$MediaImagesTableReferences),
+    MediaImageRow,
+    PrefetchHooks Function({bool collectionId, bool bookUid})> {
+  $$MediaImagesTableTableManager(_$HibikiDatabase db, $MediaImagesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$MediaImagesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$MediaImagesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$MediaImagesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int?> collectionId = const Value.absent(),
+            Value<String?> bookUid = const Value.absent(),
+            Value<String> kind = const Value.absent(),
+            Value<int> position = const Value.absent(),
+            Value<String> path = const Value.absent(),
+            Value<String?> sourceUrl = const Value.absent(),
+          }) =>
+              MediaImagesCompanion(
+            id: id,
+            collectionId: collectionId,
+            bookUid: bookUid,
+            kind: kind,
+            position: position,
+            path: path,
+            sourceUrl: sourceUrl,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int?> collectionId = const Value.absent(),
+            Value<String?> bookUid = const Value.absent(),
+            required String kind,
+            Value<int> position = const Value.absent(),
+            required String path,
+            Value<String?> sourceUrl = const Value.absent(),
+          }) =>
+              MediaImagesCompanion.insert(
+            id: id,
+            collectionId: collectionId,
+            bookUid: bookUid,
+            kind: kind,
+            position: position,
+            path: path,
+            sourceUrl: sourceUrl,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$MediaImagesTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({collectionId = false, bookUid = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (collectionId) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.collectionId,
+                    referencedTable:
+                        $$MediaImagesTableReferences._collectionIdTable(db),
+                    referencedColumn:
+                        $$MediaImagesTableReferences._collectionIdTable(db).id,
+                  ) as T;
+                }
+                if (bookUid) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.bookUid,
+                    referencedTable:
+                        $$MediaImagesTableReferences._bookUidTable(db),
+                    referencedColumn:
+                        $$MediaImagesTableReferences._bookUidTable(db).bookUid,
+                  ) as T;
+                }
+
+                return state;
+              },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ));
+}
+
+typedef $$MediaImagesTableProcessedTableManager = ProcessedTableManager<
+    _$HibikiDatabase,
+    $MediaImagesTable,
+    MediaImageRow,
+    $$MediaImagesTableFilterComposer,
+    $$MediaImagesTableOrderingComposer,
+    $$MediaImagesTableAnnotationComposer,
+    $$MediaImagesTableCreateCompanionBuilder,
+    $$MediaImagesTableUpdateCompanionBuilder,
+    (MediaImageRow, $$MediaImagesTableReferences),
+    MediaImageRow,
+    PrefetchHooks Function({bool collectionId, bool bookUid})>;
 
 class $HibikiDatabaseManager {
   final _$HibikiDatabase _db;
@@ -42156,4 +43097,6 @@ class $HibikiDatabaseManager {
       $$MangaTrustedSignersTableTableManager(_db, _db.mangaTrustedSigners);
   $$CollectionRelationsTableTableManager get collectionRelations =>
       $$CollectionRelationsTableTableManager(_db, _db.collectionRelations);
+  $$MediaImagesTableTableManager get mediaImages =>
+      $$MediaImagesTableTableManager(_db, _db.mediaImages);
 }

--- a/packages/hibiki_core/lib/src/database/media_image_kind.dart
+++ b/packages/hibiki_core/lib/src/database/media_image_kind.dart
@@ -1,0 +1,42 @@
+/// 媒体附加图种类值域（`MediaImages.kind` 列，Jellyfin 图组对齐）。
+///
+/// 只覆盖 `media_images.kind` 一列；与 media_kind.dart 说明的其余字符串值域
+/// **互不通用**。定义在 hibiki_core 是因为它是 schema 值域的一部分。
+///
+/// 命名纪律（术语表）：主封面统一叫 cover（列仍在 `VideoBooks.coverPath` /
+/// `MediaCollections.coverPath`，不进本表）；带字横图**不叫 thumb/thumbnail**
+/// （淘汰词），按影视行业惯例叫 title card。
+library;
+
+/// 一张附加图的种类。
+///
+/// Drift 列保持 `TEXT`（不引入 TypeConverter）：边界上用 [tryParse] 显式解析、
+/// 用 [dbValue] 显式落库，未知值（未来新增种类的旧版本读新库）返回 null 不抛。
+enum MediaImageKind {
+  /// 无字横版背景图（约 16:9）。**唯一允许多张**的种类（`position` 0..n，
+  /// 对齐 Jellyfin `AllowsMultipleImages` 只放行 Backdrop 的拍板）；详情页
+  /// hero 全屏背景 + 轮换用。
+  backdrop('backdrop'),
+
+  /// 标题 logo 图（透明底 PNG），详情页/hero 叠加替代纯文字标题。
+  logo('logo'),
+
+  /// 带片名文字的横版图（TMDB 里 `iso_639_1` 非空的 backdrop——Jellyfin 把它
+  /// 分流为 Thumb，槽位语义：横版卡片图，与全屏背景分开）。
+  titleCard('title_card');
+
+  const MediaImageKind(this.dbValue);
+
+  /// 落 DB 的字符串。永不改变（Never break userspace）。
+  final String dbValue;
+
+  /// DB 字符串 → 枚举；未知/空返回 null，绝不抛。
+  static MediaImageKind? tryParse(String? raw) {
+    for (final MediaImageKind kind in MediaImageKind.values) {
+      if (kind.dbValue == raw) {
+        return kind;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/hibiki_core/lib/src/database/tables.dart
+++ b/packages/hibiki_core/lib/src/database/tables.dart
@@ -1333,6 +1333,66 @@ class CollectionRelations extends Table {
       ];
 }
 
+// ── media_images ────────────────────────────────────────────────────
+// 媒体附加图组（v68，Jellyfin 图组对齐）：一行 = 一张附加图（横版背景 backdrop /
+// 标题 logo / 带字横图 title_card），归属**二选一**——合集（collectionId）或单视频
+// （bookUid），CHECK 约束在 DB 层锁死单一归属。主封面**不进本表**：仍是
+// `MediaCollections.coverPath` / `VideoBooks.coverPath`（冻结契约，书架/GC/同步
+// 全部围绕它）。
+//
+// 为什么是一张表而不是逐列加（对齐 Jellyfin `ItemImageInfo[]` 扁平数组）：
+// backdrop 允许多张（position 排序，详情页 10 秒轮换），列模型装不下；且合集与
+// 散装电影两个归属方各拷一套列就是四份特例。只有 backdrop 允许 position>0
+// （Jellyfin `AllowsMultipleImages` 同拍板），logo / title_card 每归属一张。
+//
+// 与 [CollectionScrapeMeta] 同族：可重建的刮削缓存（重刮即回填）。v64 的
+// `CollectionScrapeMeta.backdropPath` 由 v68 迁移搬进本表（kind='backdrop',
+// position=0），旧列冻结为遗留残留（Series 先例）——读写一律走本表，勿再碰旧列。
+// 删合集 / 删视频经 FK cascade 清行；磁盘文件回收走 collection_asset_reclaim /
+// VideoBookRepository 的既有单一入口（文件不在 gcOrphanCovers 的扫描面内，见
+// VideoStorage 子目录免疫说明）。
+@DataClassName('MediaImageRow')
+class MediaImages extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  /// 归属合集（与 [bookUid] 二选一）。删合集 cascade 清行。
+  IntColumn get collectionId => integer()
+      .nullable()
+      .references(MediaCollections, #id, onDelete: KeyAction.cascade)();
+
+  /// 归属单视频（与 [collectionId] 二选一；散装电影的图组）。删视频 cascade 清行。
+  TextColumn get bookUid => text()
+      .nullable()
+      .references(VideoBooks, #bookUid, onDelete: KeyAction.cascade)();
+
+  /// 图种类（`MediaImageKind.dbValue`：backdrop / logo / title_card）。
+  TextColumn get kind => text()();
+
+  /// 同归属同种类内的排序位（仅 backdrop 允许 >0；其余恒 0）。
+  IntColumn get position => integer().withDefault(const Constant(0))();
+
+  /// 本地文件绝对路径（合集图落 `video_covers/collections/`，视频图落
+  /// `video_covers/images/`——两个子目录都在 gcOrphanCovers 扫描面外）。
+  TextColumn get path => text()();
+
+  /// 来源远程 URL（重下/诊断用；手动设置的图为 null）。
+  TextColumn get sourceUrl => text().nullable()();
+
+  /// 单一归属：合集与视频二选一，恰好一个非空。
+  @override
+  List<String> get customConstraints => <String>[
+        'CHECK ((collection_id IS NULL) != (book_uid IS NULL))',
+      ];
+
+  /// 同归属同种类同槽位唯一（重复刮削整组替换按此幂等）。两条唯一键分别覆盖两种
+  /// 归属——SQLite 的 UNIQUE 对 NULL 不判等，各自只约束自己那种归属的行。
+  @override
+  List<Set<Column>> get uniqueKeys => [
+        {collectionId, kind, position},
+        {bookUid, kind, position},
+      ];
+}
+
 // ── galgames ────────────────────────────────────────────────────────
 /// v55（游戏库对齐 ReinaManager，见 `docs/design/galgame-library-reina-parity.md`）：
 /// galgame 游戏库的持久真相源，取代旧的偏好表单一 JSON key `galgame_library`


### PR DESCRIPTION
## 背景

用户要求对齐 Jellyfin 的图组体系：不止竖版海报，还要横版图（backdrop/带字横图/剧集截图）、详情页多张背景轮换、标题 logo 叠加，以及「继续观看」横版卡片。设计前先实抓了 Jellyfin/jellyfin-web 源码确认其真实拍板（Primary 不分横竖由实体声明宽高比、只有 Backdrop 允许多张、带语言的横图降级为 Thumb、续播卡 preferThumb 且横槽禁竖图污染）。

## 数据结构（消灭特例的核心一步）

**schema v68 新表 `media_images`**：一行一张附加图，`kind ∈ {backdrop, logo, title_card}`，归属合集（FK cascade）或单视频（FK cascade）二选一（CHECK 锁死），只有 backdrop 允许 position>0——Jellyfin `ItemImageInfo[]` + `AllowsMultipleImages` 同构。主封面仍走既有 `coverPath` 冻结契约。

v64 的 `collection_scrape_meta.backdrop_path` 由迁移一次性搬入（旧库升级 hero 背景零丢失、逐像素不变），旧列冻结为遗留残留（`Series` 先例），新写入恒 NULL 防双真相。

命名纪律：带字横图不叫 thumb/thumbnail（术语表淘汰词），叫 `title_card`；新 Dart 符号避开被 `BackdropFilter`/Win11 亚克力污染的 backdrop 词（持久化值延续既有冻结词）。

## 刮削

- TMDB 走 `/images` 端点（显式 `include_image_language=zh,ja,en,null`）：无字横图→backdrop 取前 3（vote 序），**带语言横图→title_card**（Jellyfin 同款分流，保证全屏背景永远无字），logo 跳过 SVG、按 zh→ja→en 挑选。分类是纯函数 `parseTmdbImageSet` + 单测。
- AniList banner 维持单张 backdrop 兜底；Bangumi/Jikan/离线库无横图（常态路径，非错误）。
- **电影型候选**顺带给散装视频落图组（`video_covers/images/`，`media_images.bookUid` 归属）；tv 型刻意跳过——那些图属于合集容器，逐集存 N 份是纯冗余。
- 附加图失败永不拖垮整次刮削（BUG-1310 失败分级延续）。

## UI

- **合集详情页 hero**：多张 backdrop 每 10 秒交叉淡入轮换（`gaplessPlayback` 防闪底、禁用动效时不轮、单张不启定时器）；有 logo 时替代纯文字大标题（Semantics 保留合集名，解码失败回落文字）。
- **视频首页 hero**：背景 + logo 改读 media_images（迁移保证存量 backdrop 覆盖）。
- **续播卡（首页 dashboard + 视频页续播行）**：视频卡改 16:9 横版（用户拍板：书/游戏维持竖版；行高统一宽度随朝向，底边对齐）。选图链抄 Jellyfin preferThumb：`titleCard → backdrop → 目标集封面/成员借用链`，竖图由 `PortraitCoverImage` 横槽模糊垫底承接——**不回退 BUG-1299 的硬裁**（那个 bug 修的是硬裁不是横版本身）。「最近添加」行维持全竖版。
- **VideoEpisodeRail**（播放器/合集详情共用选集轨道）：修掉全域最后一个裸 `BoxFit.cover` 硬裁点 + 守卫测试。

## 回收/迁移闭环

- 删合集（6 条路径的单一入口）/ 删视频 / 同步解散 / 重刮整组替换，都会回收失去引用的图文件（**删行前快照** + 目录内 + 无幸存引用三护栏；v64 遗留 `_backdrop.jpg` 在首次重刮后经此清掉）。
- 数据根迁移 rebase 覆盖 `media_images.path`（`path_rebase_coverage` 登记齐 4 列，守卫绿）。
- GC：新文件全部落 `collections/` 与 `images/` 子目录，`gcOrphanCovers` 非递归天然免疫。

## 明确不做（已向用户说明）

- 同片多压制版本的 version 模型（Jellyfin Version 下拉）：无真实痛点，动 bookUid 语义半径过大；剧场版/特典已由 extras 季组 + CollectionRelations 覆盖。
- 首页 hero PageView 内再嵌 10 秒轮换：与手动翻页手势冲突，轮换只做在合集详情页（Jellyfin 的轮换本来也在详情页）。

## 验证

- `flutter analyze` 全量：No issues found。
- 定向测试三批全绿（220+ 用例）：新增 media_images DAO/CHECK/cascade/**v67→v68 迁移搬运**、TMDB 分类器、选集轨道守卫；相邻 collection_scrape_meta / hero widget / asset_reclaim / video_storage / path_rebase 守卫 / data_root_migrator / collection_sync_engine / full ladder v1→v68 / cover_match_dialog / 刮削服务 / dashboard 全部通过。
- 真机路径（实刮 TMDB → hero 轮换/logo/续播横卡目测）未跑，合并前建议在 Windows 真机对一个 TMDB 番剧合集重刮一次目测四处显示位。

https://claude.ai/code/session_01D4ceFWQdcDrrM6K8anr61d