### PR TITLE
fix(manga): 两个 OCR 向导入口共用引擎依赖装配（BUG-1418 / TODO-2633）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1319 条。点号进各自文件。
+> 共 1320 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1418](bugs/BUG-1418-manga-reader-ocr-paired-host-missing.md) | ✅ | ✅ | 阅读器整卷 OCR 看不到「配对主机」选项：openBookOcr 漏传 remoteRunner |
 | [BUG-1414](bugs/BUG-1414-md3-manga-fontsize-guard.md) | ✅ | ✅ | manga.json 回写触发 MD3 fontSize 守卫，develop CI 单测门变红 |
 | [BUG-1413](bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md) | ✅ | ✅ | 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null |
 | [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |

--- a/docs/bugs/BUG-1418-manga-reader-ocr-paired-host-missing.md
+++ b/docs/bugs/BUG-1418-manga-reader-ocr-paired-host-missing.md
@@ -1,0 +1,28 @@
+## BUG-1418 · 阅读器整卷 OCR 看不到「配对主机」选项：openBookOcr 漏传 remoteRunner
+- **报告**：2026-08-02（用户：TODO-2633）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/manga/manga_module.dart:108-137`（修复前）——
+  `MangaModule.openBookOcr` 构造 `MangaOcrWizardDialog` 时**漏传 `remoteRunner:`**，
+  而同文件 `:99` 的 `openOcrImportWizard` 传了。唯一调用方是阅读器的整卷 OCR 动作
+  `hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart:2077-2083`。
+  后果：该入口 `widget.remoteRunner == null` ⇒ `manga_ocr_wizard_dialog.dart` 的
+  `MangaOcrEngineCapability(id: pairedHost, supported: widget.remoteRunner != null)` 恒 false，
+  `_remoteAvailable` 恒 false ⇒ 引擎分段里**永远不出现**「配对主机」。全平台都中，
+  **安卓最受伤**：它没有本地 ONNX 引擎（`isSupportedPlatform == false`）、也没有外部
+  mokuro CLI（桌面专属），这条洞让阅读器整卷 OCR 只剩 Google Lens。
+- **[x] ① 已修复** — 不是补一个参数（那样第三个入口还会再漏一次），而是消除
+  「两个入口各自手抄一份依赖表」这个结构：新增
+  `hibiki/lib/src/media/manga/manga_ocr_wizard_engines.dart` 的 `MangaOcrWizardEngines`
+  收下四个引擎 runner + 默认引擎偏好，成为 `MangaOcrWizardDialog` 的**必填**参数
+  （漏传编译不过），生产装配只在 `MangaOcrWizardEngines.resolve` 出现一次，
+  `openOcrImportWizard` / `openBookOcr` 共用。顺带消掉阅读器里手抄的
+  `Platform.isWindows || Platform.isLinux || Platform.isMacOS`（`isDesktopPlatform` 的副本）
+  与导入框里重复的 `InterconnectMangaOcrClient` 构造。
+  提交：见本分支 `fix(manga): 两个 OCR 向导入口共用引擎依赖装配` commit。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/manga/manga_module_ocr_entry_engines_test.dart`
+  （5 例）：① 阅读器入口有可用 host 时「配对主机」选项出现；② 无 host 时不出现且
+  引擎区不退化成「无可用引擎」；③ 导入向导入口依赖集同构不回归；④a/④b
+  `externalRunner` 的 desktop 三元（有意差异）两个方向都钉住。
+  变异实测：`openBookOcr` 不转发 runner → ①② 红；`resolve` 里 `remoteRunner: null`
+  → ①②③ 红；`lensRunner: null` → ②③ 红；desktop 三元取反 → ④a④b 红。
+- **备注**：同批查出的 TODO-2634（`auto` 引擎在安卓落到死默认）、TODO-2635
+  （probe 不校验 `modelsReady`）**本轮不做**，与本条互不重叠。

--- a/hibiki/lib/src/media/manga/manga_import_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_import_dialog.dart
@@ -14,7 +14,6 @@ import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
 import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
-import 'package:hibiki/src/sync/sync_repository.dart';
 import 'package:hibiki/utils.dart';
 
 /// 漫画导入对话框。
@@ -43,8 +42,8 @@ class MangaImportDialog extends StatefulWidget {
   /// 拖放/书籍框转交时预填的漫画路径（目录 / `.cbz` / `.zip` 页图包 / `.mokuro`）。
   final String? initialPath;
 
-  /// 测试缝：注入远程 OCR runner（探测已配对 host 能力 + 代跑）。
-  /// null = 生产路径，按 [db] 惰性构造 [InterconnectMangaOcrClient]。
+  /// 测试缝：注入远程 OCR runner（探测已配对 host 能力 + 代跑）。null = 生产路径，
+  /// 由 [MangaOcrWizardEngines.resolve] 按 [db] 构造 [InterconnectMangaOcrClient]。
   final MangaOcrRemoteRunner? mangaOcrRemoteRunner;
 
   /// 测试缝：覆盖「是否桌面平台」判定。null = 用真实 [isDesktopPlatform]。
@@ -70,13 +69,6 @@ class _MangaImportDialogState extends State<MangaImportDialog>
   bool _titleFromUser = false;
 
   bool _pickerActive = false;
-
-  late final MangaOcrRemoteRunner _mangaOcrRemoteRunner =
-      widget.mangaOcrRemoteRunner ??
-          InterconnectMangaOcrClient(repo: SyncRepository(widget.db));
-
-  bool get _ocrEntryDesktop =>
-      widget.ocrEntryDesktopOverride ?? isDesktopPlatform;
 
   @override
   void initState() {
@@ -279,8 +271,8 @@ class _MangaImportDialogState extends State<MangaImportDialog>
     final String? bookKey = await MangaModule.openOcrImportWizard(
       context: context,
       db: widget.db,
-      remoteRunner: _mangaOcrRemoteRunner,
-      desktop: _ocrEntryDesktop,
+      remoteRunnerOverride: widget.mangaOcrRemoteRunner,
+      desktopOverride: widget.ocrEntryDesktopOverride,
     );
     if (bookKey != null && mounted) {
       Navigator.pop(context, true);

--- a/hibiki/lib/src/media/manga/manga_module.dart
+++ b/hibiki/lib/src/media/manga/manga_module.dart
@@ -1,18 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/epub/book_title_conflict.dart';
-import 'package:hibiki/src/media/manga/external_mokuro_runner.dart';
 import 'package:hibiki/src/media/manga/import/manga_archive_importer.dart';
 import 'package:hibiki/src/media/manga/manga_importer.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_background_job.dart';
-import 'package:hibiki/src/media/manga/manga_ocr_provider.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_wizard_dialog.dart';
-import 'package:hibiki/src/media/manga/ocr/google_lens_ocr_service.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_wizard_engines.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_catalog_dialog.dart';
-import 'package:hibiki/src/models/app_model.dart';
-import 'package:hibiki/src/ocr/manga_ocr_service.dart';
 import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
 import 'package:hibiki/utils.dart';
 
@@ -74,60 +69,53 @@ abstract final class MangaModule {
         onProgress: onProgress,
       );
 
+  /// 未入库的裸图片文件夹 → 选引擎 → 整卷 OCR → 落库，返回新建 bookKey。
+  ///
+  /// [remoteRunnerOverride] / [desktopOverride] 只是测试缝，生产传 null 即可；
+  /// 引擎依赖集由 [MangaOcrWizardEngines.resolve] 统一装配，本入口不再手抄。
   static Future<String?> openOcrImportWizard({
     required BuildContext context,
     required HibikiDatabase db,
-    required MangaOcrRemoteRunner remoteRunner,
-    required bool desktop,
+    MangaOcrRemoteRunner? remoteRunnerOverride,
+    bool? desktopOverride,
   }) {
-    final ProviderContainer container =
-        ProviderScope.containerOf(context, listen: false);
-    final AppModel appModel = container.read(appProvider);
-    final MangaOcrService service = container.read(mangaOcrServiceProvider);
-    final String configured = appModel.mangaExternalMokuroPath.trim();
-    final ExternalMokuroRunner? externalRunner = desktop
-        ? ExternalMokuroRunner(
-            configuredPath: configured.isEmpty ? null : configured,
-          )
-        : null;
+    final MangaOcrWizardEngines engines = MangaOcrWizardEngines.resolve(
+      context: context,
+      db: db,
+      remoteRunnerOverride: remoteRunnerOverride,
+      desktopOverride: desktopOverride,
+    );
     return showAppDialog<String>(
       context: context,
-      builder: (_) => MangaOcrWizardDialog(
-        service: service,
-        db: db,
-        externalRunner: externalRunner,
-        remoteRunner: remoteRunner,
-        lensRunner: GoogleLensMangaOcrService(),
-        initialEnginePreference: appModel.mangaOcrEnginePreference,
-      ),
+      builder: (_) => MangaOcrWizardDialog(engines: engines, db: db),
     );
   }
 
   /// 对已入书架的漫画直接运行整卷 OCR。阅读器从当前页触发时，Lens 会先扫
   /// 当前页到末页，再从首页补齐；完成后原子替换本书的 `manga.json`。
+  ///
+  /// 引擎依赖集与 [openOcrImportWizard] **共用同一个装配点**：两个入口各自手抄
+  /// 参数表时，本入口漏掉了 `remoteRunner`，「配对主机」引擎在阅读器里永久不可见
+  /// （BUG-1418）。
   static Future<MangaOcrBackgroundJob?> openBookOcr({
     required BuildContext context,
     required HibikiDatabase db,
     required EpubBookRow book,
     required int startPage,
-    required bool desktop,
+    MangaOcrRemoteRunner? remoteRunnerOverride,
+    bool? desktopOverride,
   }) {
-    final ProviderContainer container =
-        ProviderScope.containerOf(context, listen: false);
-    final AppModel appModel = container.read(appProvider);
-    final String configured = appModel.mangaExternalMokuroPath.trim();
+    final MangaOcrWizardEngines engines = MangaOcrWizardEngines.resolve(
+      context: context,
+      db: db,
+      remoteRunnerOverride: remoteRunnerOverride,
+      desktopOverride: desktopOverride,
+    );
     return showAppDialog<MangaOcrBackgroundJob>(
       context: context,
       builder: (_) => MangaOcrWizardDialog(
-        service: container.read(mangaOcrServiceProvider),
+        engines: engines,
         db: db,
-        externalRunner: desktop
-            ? ExternalMokuroRunner(
-                configuredPath: configured.isEmpty ? null : configured,
-              )
-            : null,
-        lensRunner: GoogleLensMangaOcrService(),
-        initialEnginePreference: appModel.mangaOcrEnginePreference,
         existingBook: book,
         startPage: startPage,
         onlyMissing: true,

--- a/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
@@ -13,6 +13,7 @@ import 'package:hibiki/src/media/manga/external_mokuro_runner.dart';
 import 'package:hibiki/src/media/manga/manga_importer.dart';
 import 'package:hibiki/src/media/manga/manga_json_writeback.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_background_job.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_wizard_engines.dart';
 import 'package:hibiki/src/media/manga/manga_storage.dart';
 import 'package:hibiki/src/media/manga/mokuro_payload.dart';
 import 'package:hibiki/src/media/manga/ocr/google_lens_disclosure.dart';
@@ -36,13 +37,9 @@ import 'package:hibiki/utils.dart';
 /// `ConsumerStatefulWidget` 仅为在「选文件夹」时读 [appProvider] 走真实路径目录选择器。
 class MangaOcrWizardDialog extends ConsumerStatefulWidget {
   const MangaOcrWizardDialog({
-    required this.service,
+    required this.engines,
     required this.db,
-    this.externalRunner,
-    this.remoteRunner,
-    this.lensRunner,
     this.lensDisclosureGate,
-    this.initialEnginePreference,
     this.importOverride,
     this.initialImageDir,
     this.existingBook,
@@ -52,26 +49,17 @@ class MangaOcrWizardDialog extends ConsumerStatefulWidget {
     super.key,
   });
 
-  /// 内置 OCR 服务（接口；真实现由 provider 注入，测试注 fake）。
-  final MangaOcrService service;
+  /// 四个引擎的 runner + 默认引擎偏好，**整套必填**。
+  ///
+  /// 拆成一个对象而不是四个可选参数，是因为「某个入口漏传某个 runner」编译期
+  /// 无痕、运行期只表现为选项少一个（BUG-1418）。生产装配一律走
+  /// [MangaOcrWizardEngines.resolve]。
+  final MangaOcrWizardEngines engines;
 
   /// 目标数据库（漫画行写入此处；导入器读取须为同一实例）。
   final HibikiDatabase db;
 
-  /// 外部 mokuro CLI 后备；null = 不提供外部引擎选项。
-  final ExternalMokuroRunner? externalRunner;
-
-  /// 漫画 P3：互联「已配对主机代跑 OCR」；null = 不提供远程引擎选项。仅当探测
-  /// （probe）到具备 `mangaOcr.supported` 能力的已配对 host 时选项才显示。
-  final MangaOcrRemoteRunner? remoteRunner;
-
-  /// Google Lens whole-page runner. Null keeps Lens absent in isolated tests.
-  final GoogleLensMangaOcrRunner? lensRunner;
-
   final GoogleLensDisclosureGate? lensDisclosureGate;
-
-  /// Optional stable preference key for tests/callers; production reads AppModel.
-  final String? initialEnginePreference;
 
   /// 落库注入口（测试用）：null = 走真实 [MangaImporter]。
   final MangaOcrImportRunner? importOverride;
@@ -199,18 +187,19 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
     if (!mounted) return;
     setState(() => _checkingEngines = true);
     bool builtin = false;
-    if (widget.service.isSupportedPlatform) {
+    if (widget.engines.service.isSupportedPlatform) {
       try {
-        final MangaOcrModelStatus status = await widget.service.modelStatus();
+        final MangaOcrModelStatus status =
+            await widget.engines.service.modelStatus();
         builtin = status.allReady;
       } catch (_) {
         builtin = false;
       }
     }
     bool external = false;
-    if (widget.externalRunner != null) {
+    if (widget.engines.externalRunner != null) {
       try {
-        external = (await widget.externalRunner!.probe()) != null;
+        external = (await widget.engines.externalRunner!.probe()) != null;
       } catch (_) {
         external = false;
       }
@@ -218,9 +207,9 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
     // 漫画 P3：探测已配对 host 的远程 OCR 能力（老 host 无 capabilities 字段 →
     // probe 回 null → 选项隐藏，零破坏）。
     MangaOcrRemoteTarget? remote;
-    if (widget.remoteRunner != null) {
+    if (widget.engines.remoteRunner != null) {
       try {
-        remote = await widget.remoteRunner!.probe();
+        remote = await widget.engines.remoteRunner!.probe();
       } catch (_) {
         remote = null;
       }
@@ -231,10 +220,10 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       _externalAvailable = external;
       _remoteAvailable = remote != null;
       _remoteTarget = remote;
-      _lensAvailable = widget.lensRunner != null;
+      _lensAvailable = widget.engines.lensRunner != null;
       _checkingEngines = false;
-      final String preferenceKey =
-          widget.initialEnginePreference ?? MangaOcrEnginePreference.auto.key;
+      final String preferenceKey = widget.engines.initialEnginePreference ??
+          MangaOcrEnginePreference.auto.key;
       final MangaOcrEnginePreference preference =
           MangaOcrEnginePreferenceKey.fromKey(preferenceKey);
       _engine = resolveMangaOcrEngine(
@@ -243,7 +232,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
             capabilities: <MangaOcrEngineCapability>[
               MangaOcrEngineCapability(
                 id: MangaOcrEngineId.localOnnx,
-                supported: widget.service.isSupportedPlatform,
+                supported: widget.engines.service.isSupportedPlatform,
                 ready: builtin,
                 requiresNetwork: false,
                 uploadsImages: false,
@@ -251,15 +240,15 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
               ),
               MangaOcrEngineCapability(
                 id: MangaOcrEngineId.googleLens,
-                supported: widget.lensRunner != null,
-                ready: widget.lensRunner != null,
+                supported: widget.engines.lensRunner != null,
+                ready: widget.engines.lensRunner != null,
                 requiresNetwork: true,
                 uploadsImages: true,
                 supportsIncremental: true,
               ),
               MangaOcrEngineCapability(
                 id: MangaOcrEngineId.externalMokuro,
-                supported: widget.externalRunner != null,
+                supported: widget.engines.externalRunner != null,
                 ready: external,
                 requiresNetwork: false,
                 uploadsImages: false,
@@ -267,7 +256,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
               ),
               MangaOcrEngineCapability(
                 id: MangaOcrEngineId.pairedHost,
-                supported: widget.remoteRunner != null,
+                supported: widget.engines.remoteRunner != null,
                 ready: remote != null,
                 requiresNetwork: true,
                 uploadsImages: true,
@@ -347,8 +336,8 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       );
       return;
     }
-    await for (final MangaOcrVolumeEvent event
-        in widget.service.ocrFolder(imageDirPath: dir, volumeTitle: _title)) {
+    await for (final MangaOcrVolumeEvent event in widget.engines.service
+        .ocrFolder(imageDirPath: dir, volumeTitle: _title)) {
       if (event.finished) {
         yield MangaOcrBackgroundEvent.finished(
           pagesTotal: event.pagesTotal,
@@ -430,7 +419,8 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       );
       return;
     }
-    await for (final MangaOcrVolumeEvent event in widget.lensRunner!.ocrFolder(
+    await for (final MangaOcrVolumeEvent event
+        in widget.engines.lensRunner!.ocrFolder(
       imageDirPath: dir,
       volumeTitle: _title,
       startPage: widget.startPage,
@@ -483,7 +473,8 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 
   Stream<MangaOcrBackgroundEvent> _backgroundExternalEvents(String dir) async* {
-    await for (final MokuroRunEvent event in widget.externalRunner!.run(dir)) {
+    await for (final MokuroRunEvent event
+        in widget.engines.externalRunner!.run(dir)) {
       if (event.finished) {
         yield MangaOcrBackgroundEvent.finished(
           pagesTotal: event.total,
@@ -504,7 +495,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
     if (target == null) {
       throw StateError(t.manga_remote_ocr_no_host);
     }
-    await for (final MangaOcrRemoteEvent event in widget.remoteRunner!
+    await for (final MangaOcrRemoteEvent event in widget.engines.remoteRunner!
         .run(target: target, imageDirPath: dir, volumeTitle: _title)) {
       if (event.finished) {
         yield MangaOcrBackgroundEvent.finished(
@@ -642,7 +633,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 
   void _runLens(String dir) {
-    _runSub = widget.lensRunner!
+    _runSub = widget.engines.lensRunner!
         .ocrFolder(
       imageDirPath: dir,
       volumeTitle: _title,
@@ -667,8 +658,9 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 
   void _runBuiltin(String dir) {
-    _runSub =
-        widget.service.ocrFolder(imageDirPath: dir, volumeTitle: _title).listen(
+    _runSub = widget.engines.service
+        .ocrFolder(imageDirPath: dir, volumeTitle: _title)
+        .listen(
       (MangaOcrVolumeEvent event) {
         if (!mounted) return;
         if (event.finished) {
@@ -686,7 +678,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 
   void _runExternal(String dir) {
-    _runSub = widget.externalRunner!.run(dir).listen(
+    _runSub = widget.engines.externalRunner!.run(dir).listen(
       (MokuroRunEvent event) {
         if (!mounted) return;
         if (event.finished) {
@@ -714,7 +706,7 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       _onOcrError(t.manga_remote_ocr_no_host);
       return;
     }
-    _runSub = widget.remoteRunner!
+    _runSub = widget.engines.remoteRunner!
         .run(target: target, imageDirPath: dir, volumeTitle: _title)
         .listen(
       (MangaOcrRemoteEvent event) {

--- a/hibiki/lib/src/media/manga/manga_ocr_wizard_engines.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_wizard_engines.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/media/manga/external_mokuro_runner.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_provider.dart';
+import 'package:hibiki/src/media/manga/ocr/google_lens_ocr_service.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/ocr/manga_ocr_service.dart';
+import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki/src/utils/misc/platform_utils.dart';
+
+/// `MangaOcrWizardDialog` 的**整套引擎依赖**（四个引擎的 runner + 默认引擎偏好）。
+///
+/// 存在的唯一理由是消除一类结构性遗漏：向导有多个入口（导入向导 / 已入库整卷
+/// OCR / 将来第三个），而每个引擎在 UI 上出不出现完全由「有没有传对应 runner」
+/// 决定。此前每个入口各自手抄一份构造参数表，阅读器入口（`openBookOcr`）抄漏了
+/// `remoteRunner`，「配对主机」引擎便在该入口永久不可见（BUG-1418）——这种遗漏
+/// 编译期无痕，运行期只表现为「选项少一个」，最受伤的是没有本地 OCR 引擎兜底的
+/// Android。
+///
+/// 收成一个**必填**对象后：① 向导只收 `engines` 一个必填参数，漏传直接编译不过；
+/// ② 生产依赖集只在 [MangaOcrWizardEngines.resolve] 里出现一次，新增入口无从抄漏，
+/// 新增引擎也只改这一处。
+@immutable
+class MangaOcrWizardEngines {
+  /// 直接装配（widget 测试用：只给需要的引擎，其余 null = 该引擎不出现）。
+  const MangaOcrWizardEngines({
+    required this.service,
+    this.externalRunner,
+    this.remoteRunner,
+    this.lensRunner,
+    this.initialEnginePreference,
+  });
+
+  /// 生产依赖集的**唯一**装配点。所有入口都必须经此，不得再手抄参数表。
+  ///
+  /// [remoteRunnerOverride] / [desktopOverride] 只是测试缝：前者替换互联客户端，
+  /// 后者覆盖「是否桌面平台」（外部 mokuro CLI 只在桌面存在）。
+  factory MangaOcrWizardEngines.resolve({
+    required BuildContext context,
+    required HibikiDatabase db,
+    MangaOcrRemoteRunner? remoteRunnerOverride,
+    bool? desktopOverride,
+  }) {
+    final ProviderContainer container =
+        ProviderScope.containerOf(context, listen: false);
+    final AppModel appModel = container.read(appProvider);
+    final bool desktop = desktopOverride ?? isDesktopPlatform;
+    final String configured = appModel.mangaExternalMokuroPath.trim();
+    return MangaOcrWizardEngines(
+      service: container.read(mangaOcrServiceProvider),
+      externalRunner: desktop
+          ? ExternalMokuroRunner(
+              configuredPath: configured.isEmpty ? null : configured,
+            )
+          : null,
+      remoteRunner: remoteRunnerOverride ??
+          InterconnectMangaOcrClient(repo: SyncRepository(db)),
+      lensRunner: GoogleLensMangaOcrService(),
+      initialEnginePreference: appModel.mangaOcrEnginePreference,
+    );
+  }
+
+  /// 内置 OCR 服务（接口；真实现由 provider 注入，测试注 fake）。
+  final MangaOcrService service;
+
+  /// 外部 mokuro CLI 后备；null = 不提供外部引擎选项（非桌面平台本就没有）。
+  final ExternalMokuroRunner? externalRunner;
+
+  /// 漫画 P3：互联「已配对主机代跑 OCR」；null = 不提供远程引擎选项。仅当探测
+  /// （probe）到具备 `mangaOcr.supported` 能力的已配对 host 时选项才真正显示。
+  final MangaOcrRemoteRunner? remoteRunner;
+
+  /// Google Lens whole-page runner. Null keeps Lens absent in isolated tests.
+  final GoogleLensMangaOcrRunner? lensRunner;
+
+  /// 默认引擎偏好键；null 时向导按 `auto` 解析。
+  final String? initialEnginePreference;
+}

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -2079,7 +2079,6 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
           db: appModel.database,
           book: row,
           startPage: _currentPage,
-          desktop: Platform.isWindows || Platform.isLinux || Platform.isMacOS,
         );
       }
       if (!mounted || job == null) return;

--- a/hibiki/test/media/manga/manga_module_ocr_entry_engines_test.dart
+++ b/hibiki/test/media/manga/manga_module_ocr_entry_engines_test.dart
@@ -1,0 +1,265 @@
+/// BUG-1418：OCR 向导两个入口的**引擎依赖集**必须同构。
+///
+/// 阅读器对已入库漫画跑整卷 OCR 走 [MangaModule.openBookOcr]；它此前自己手抄了
+/// 一份向导构造参数表，抄漏了 `remoteRunner`，于是 `pairedHost` 引擎的 `supported`
+/// 恒 false ——「配对主机」选项在阅读器入口**永不出现**。安卓没有本地 ONNX 引擎、
+/// 也没有外部 mokuro CLI，这条洞让它只剩 Google Lens。
+///
+/// 修复方式不是补一个参数，而是把整套引擎依赖收成 [MangaOcrWizardEngines]（向导
+/// 的必填参数，漏传编译不过）并只在 [MangaOcrWizardEngines.resolve] 装配一次，
+/// 两个入口共用。本测试同时钉死：
+/// - ① 阅读器入口在有可用 host 时「配对主机」选项**出现**；
+/// - ② 无 host 时不出现（probe 决定显隐的既有语义不变）；
+/// - ③ 导入向导入口拿到的依赖集与阅读器入口同构、不回归；
+/// - ④ `externalRunner` 的 desktop 三元是**有意**差异，不许被一并抹平。
+library;
+
+import 'dart:io';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/media/manga/manga_module.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_provider.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_wizard_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_wizard_engines.dart';
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/ocr/manga_ocr_service.dart';
+import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+import '../../helpers/test_platform_services.dart';
+
+/// 移动端形态的内置服务：平台不支持（安卓真相，`pairedHost` 是关键补位引擎）。
+class _UnsupportedOcrService implements MangaOcrService {
+  @override
+  bool get isSupportedPlatform => false;
+
+  @override
+  Future<MangaOcrModelStatus> modelStatus() async => const MangaOcrModelStatus(
+        detectorReady: false,
+        recognizerReady: false,
+        downloadedBytes: 0,
+        totalBytes: 1,
+      );
+
+  @override
+  Stream<MangaOcrDownloadEvent> downloadModels() =>
+      const Stream<MangaOcrDownloadEvent>.empty();
+
+  @override
+  Future<void> deleteModels() async {}
+
+  @override
+  Stream<MangaOcrVolumeEvent> ocrFolder({
+    required String imageDirPath,
+    String? volumeTitle,
+  }) =>
+      const Stream<MangaOcrVolumeEvent>.empty();
+}
+
+class _FakeRemoteRunner implements MangaOcrRemoteRunner {
+  _FakeRemoteRunner({this.target});
+
+  final MangaOcrRemoteTarget? target;
+
+  @override
+  Future<MangaOcrRemoteTarget?> probe() async => target;
+
+  @override
+  Stream<MangaOcrRemoteEvent> run({
+    required MangaOcrRemoteTarget target,
+    required String imageDirPath,
+    String? volumeTitle,
+  }) =>
+      const Stream<MangaOcrRemoteEvent>.empty();
+}
+
+const MangaOcrRemoteTarget _capableTarget = MangaOcrRemoteTarget(
+  baseUrl: 'http://192.168.1.2:1234',
+  capability: MangaOcrRemoteCapability(supported: true, modelsReady: true),
+);
+
+void main() {
+  late HibikiDatabase db;
+  late Directory imageDir;
+  late Directory tmpDir;
+  late AppModel appModel;
+  final _UnsupportedOcrService service = _UnsupportedOcrService();
+
+  setUp(() async {
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+    imageDir = Directory.systemTemp.createTempSync('manga_module_ocr_entry');
+    File(p.join(imageDir.path, 'p001.jpg')).writeAsBytesSync(<int>[1, 2, 3]);
+    tmpDir = Directory.systemTemp.createTempSync('manga_module_ocr_entry_db');
+    final PreferencesRepository prefsRepo = PreferencesRepository(db);
+    await prefsRepo.loadFromDb();
+    appModel = AppModel(testPlatformServices())
+      ..wireDatabaseForTesting(db)
+      ..wireLocalAudioForTesting(
+        prefsRepo: prefsRepo,
+        databaseDirectory: tmpDir,
+      );
+  });
+
+  tearDown(() async {
+    await db.close();
+    if (imageDir.existsSync()) imageDir.deleteSync(recursive: true);
+    if (tmpDir.existsSync()) tmpDir.deleteSync(recursive: true);
+  });
+
+  Future<EpubBookRow> seedMangaBook() async {
+    await db.into(db.epubBooks).insert(
+          EpubBooksCompanion.insert(
+            bookKey: 'manga1',
+            title: '巻一',
+            epubPath: p.join(imageDir.path, 'manga.json'),
+            extractDir: imageDir.path,
+            chapterCount: 1,
+            chaptersJson: '[]',
+            importedAt: 1700000000000,
+            format: const Value<String>('manga'),
+          ),
+        );
+    return (await db.getEpubBook('manga1'))!;
+  }
+
+  /// 挂一个按钮驱动入口，回传「点开入口」的动作。
+  Future<void> pumpHost(
+    WidgetTester tester,
+    Future<void> Function(BuildContext context) open,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          appProvider.overrideWith((Ref ref) => appModel),
+          mangaOcrServiceProvider.overrideWithValue(service),
+        ],
+        child: TranslationProvider(
+          child: MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (BuildContext ctx) => ElevatedButton(
+                  onPressed: () => open(ctx),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  MangaOcrWizardEngines mountedEngines(WidgetTester tester) => tester
+      .widget<MangaOcrWizardDialog>(
+        find.byType(MangaOcrWizardDialog),
+      )
+      .engines;
+
+  testWidgets('① 阅读器入口（openBookOcr）：有可用 host 时「配对主机」选项出现',
+      (WidgetTester tester) async {
+    final EpubBookRow book = await seedMangaBook();
+    final _FakeRemoteRunner remote = _FakeRemoteRunner(target: _capableTarget);
+    await pumpHost(tester, (BuildContext ctx) async {
+      await MangaModule.openBookOcr(
+        context: ctx,
+        db: db,
+        book: book,
+        startPage: 3,
+        remoteRunnerOverride: remote,
+        desktopOverride: false,
+      );
+    });
+
+    // 依赖真的到了向导手上（不是被入口吞掉）。
+    expect(mountedEngines(tester).remoteRunner, same(remote));
+    // 用户可见结果：引擎分段里出现「配对主机」。
+    expect(
+      find.text(t.manga_remote_ocr_engine),
+      findsOneWidget,
+      reason: '阅读器入口漏传 remoteRunner 时这条恒 findsNothing（BUG-1418）',
+    );
+  });
+
+  testWidgets('② 阅读器入口：无可用 host 时「配对主机」不出现', (WidgetTester tester) async {
+    final EpubBookRow book = await seedMangaBook();
+    final _FakeRemoteRunner remote = _FakeRemoteRunner(target: null);
+    await pumpHost(tester, (BuildContext ctx) async {
+      await MangaModule.openBookOcr(
+        context: ctx,
+        db: db,
+        book: book,
+        startPage: 0,
+        remoteRunnerOverride: remote,
+        desktopOverride: false,
+      );
+    });
+
+    expect(find.text(t.manga_remote_ocr_engine), findsNothing);
+    // 显隐由 probe 决定而非「传没传 runner」：runner 仍在，只是探测无 host。
+    expect(mountedEngines(tester).remoteRunner, same(remote));
+    // Lens 全平台可用，引擎区不该退化成「无可用引擎」。
+    expect(find.text(t.manga_ocr_engine_none), findsNothing);
+  });
+
+  testWidgets('③ 导入向导入口（openOcrImportWizard）：依赖集与阅读器入口同构',
+      (WidgetTester tester) async {
+    final _FakeRemoteRunner remote = _FakeRemoteRunner(target: _capableTarget);
+    await pumpHost(tester, (BuildContext ctx) async {
+      await MangaModule.openOcrImportWizard(
+        context: ctx,
+        db: db,
+        remoteRunnerOverride: remote,
+        desktopOverride: false,
+      );
+    });
+
+    final MangaOcrWizardEngines engines = mountedEngines(tester);
+    expect(engines.remoteRunner, same(remote));
+    expect(engines.lensRunner, isNotNull, reason: 'Lens 是移动端唯一本地可用引擎');
+    expect(engines.service, same(service));
+    expect(engines.initialEnginePreference, appModel.mangaOcrEnginePreference);
+  });
+
+  testWidgets('④a externalRunner 的 desktop 三元是有意差异：非桌面无外部 CLI',
+      (WidgetTester tester) async {
+    final EpubBookRow book = await seedMangaBook();
+    final _FakeRemoteRunner remote = _FakeRemoteRunner(target: _capableTarget);
+    await pumpHost(tester, (BuildContext ctx) async {
+      await MangaModule.openBookOcr(
+        context: ctx,
+        db: db,
+        book: book,
+        startPage: 0,
+        remoteRunnerOverride: remote,
+        desktopOverride: false,
+      );
+    });
+    expect(mountedEngines(tester).externalRunner, isNull,
+        reason: '非桌面没有外部 mokuro CLI');
+  });
+
+  testWidgets('④b externalRunner 的 desktop 三元是有意差异：桌面仍提供外部 CLI',
+      (WidgetTester tester) async {
+    final _FakeRemoteRunner remote = _FakeRemoteRunner(target: _capableTarget);
+    await pumpHost(tester, (BuildContext ctx) async {
+      await MangaModule.openOcrImportWizard(
+        context: ctx,
+        db: db,
+        remoteRunnerOverride: remote,
+        desktopOverride: true,
+      );
+    });
+    expect(mountedEngines(tester).externalRunner, isNotNull,
+        reason: '桌面必须仍提供外部 mokuro CLI 后备');
+  });
+}

--- a/hibiki/test/media/manga/manga_ocr_wizard_dialog_test.dart
+++ b/hibiki/test/media/manga/manga_ocr_wizard_dialog_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_wizard_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_wizard_engines.dart';
 import 'package:hibiki/src/ocr/manga_ocr_service.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:path/path.dart' as p;
@@ -85,7 +86,7 @@ void main() {
                     poppedResult = await showDialog<String>(
                       context: ctx,
                       builder: (_) => MangaOcrWizardDialog(
-                        service: service,
+                        engines: MangaOcrWizardEngines(service: service),
                         db: db,
                         initialImageDir: imageDir.path,
                         importOverride: ({
@@ -153,7 +154,7 @@ void main() {
                   onPressed: () => showDialog<String>(
                     context: ctx,
                     builder: (_) => MangaOcrWizardDialog(
-                      service: service,
+                      engines: MangaOcrWizardEngines(service: service),
                       db: db,
                       initialImageDir: imageDir.path,
                       importOverride: ({

--- a/hibiki/test/media/manga/manga_ocr_wizard_lens_test.dart
+++ b/hibiki/test/media/manga/manga_ocr_wizard_lens_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_wizard_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_wizard_engines.dart';
 import 'package:hibiki/src/media/manga/ocr/google_lens_ocr_service.dart';
 import 'package:hibiki/src/ocr/manga_ocr_service.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -84,11 +85,13 @@ void main() {
                   onPressed: () => showDialog<void>(
                     context: context,
                     builder: (_) => MangaOcrWizardDialog(
-                      service: _UnavailableLocalService(),
+                      engines: MangaOcrWizardEngines(
+                        service: _UnavailableLocalService(),
+                        lensRunner: lens,
+                        initialEnginePreference: 'google_lens',
+                      ),
                       db: db,
-                      lensRunner: lens,
                       lensDisclosureGate: (_) async => false,
-                      initialEnginePreference: 'google_lens',
                       initialImageDir: imageDir.path,
                       importOverride: ({
                         required String path,

--- a/hibiki/test/media/manga/manga_ocr_wizard_remote_test.dart
+++ b/hibiki/test/media/manga/manga_ocr_wizard_remote_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_wizard_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_wizard_engines.dart';
 import 'package:hibiki/src/ocr/manga_ocr_service.dart';
 import 'package:hibiki/src/sync/interconnect_manga_ocr_client.dart';
 import 'package:hibiki_core/hibiki_core.dart';
@@ -114,9 +115,11 @@ void main() {
                   popped = await showDialog<String>(
                     context: ctx,
                     builder: (_) => MangaOcrWizardDialog(
-                      service: _UnsupportedOcrService(),
+                      engines: MangaOcrWizardEngines(
+                        service: _UnsupportedOcrService(),
+                        remoteRunner: remote,
+                      ),
                       db: db,
-                      remoteRunner: remote,
                       initialImageDir: imageDir.path,
                       importOverride: importOverride,
                     ),


### PR DESCRIPTION
## 问题（BUG-1418）

阅读器对**已入库**漫画跑整卷 OCR 时，「配对主机」引擎选项**永不出现**。

根因（修复前 `hibiki/lib/src/media/manga/manga_module.dart:108-137`）：`MangaModule.openBookOcr`
构造 `MangaOcrWizardDialog` 时漏传 `remoteRunner:`，而同文件 `:99` 的 `openOcrImportWizard`
传了。向导里 `MangaOcrEngineCapability(id: pairedHost, supported: widget.remoteRunner != null)`
于是恒 false ⇒ `_remoteAvailable` 恒 false ⇒ 分段选择器里不渲染该选项。

唯一调用方：`hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart:2077-2083`。

全平台都中，**安卓最受伤**：它 `isSupportedPlatform == false`（无本地 ONNX）、也没有外部
mokuro CLI（桌面专属），这条洞让阅读器整卷 OCR 只剩 Google Lens。

## 修法：让遗漏结构上不可能，而不是补一个参数

只补 `remoteRunner:` 的话，第三个入口还会再漏一次——**两个入口各自手抄一份依赖表**
本身才是缺陷。所以：

- 新增 `MangaOcrWizardEngines`（`hibiki/lib/src/media/manga/manga_ocr_wizard_engines.dart`）：
  四个引擎 runner + 默认引擎偏好收成一个值对象，成为 `MangaOcrWizardDialog` 的
  **必填**参数 —— 漏传直接编译不过。
- 生产依赖集只在 `MangaOcrWizardEngines.resolve()` 装配**一次**，两个入口共用；
  各入口只再传真正不同的 `existingBook` / `startPage` / `launchInBackground`。
- 顺带消掉两处抄写副本：阅读器里手写的 `Platform.isWindows || isLinux || isMacOS`
  （`isDesktopPlatform` 的复制）、导入框里重复的 `InterconnectMangaOcrClient` 构造。

### 两个入口依赖集差异的逐条判定

| 依赖 | 修复前差异 | 判定 |
|---|---|---|
| `service` | 无（两边同源 provider） | 合并 |
| `externalRunner`（`desktop ? ... : null`） | 无（两边同表达式） | **三元有意，原样保留在 resolve 内** |
| `lensRunner` | 无 | 合并 |
| `initialEnginePreference` | 无 | 合并 |
| `remoteRunner` | **openBookOcr 漏传** | 缺陷，合并 |
| `existingBook`/`startPage`/`onlyMissing`/`launchInBackground` | 仅 openBookOcr 有 | 真差异，保留为 openBookOcr 参数 |

引擎依赖集里**零个**有意差异 —— 正因如此才该收成一个对象。

## 测试

`hibiki/test/media/manga/manga_module_ocr_entry_engines_test.dart`（5 例，驱动真实
`MangaModule` 入口）：

- ① 阅读器入口 + 可用 host → 「配对主机」选项**出现**
- ② 阅读器入口 + 无 host → 不出现，且引擎区不退化成「无可用引擎」（显隐仍由 probe 决定）
- ③ 导入向导入口依赖集同构、不回归
- ④a/④b `externalRunner` 的 desktop 三元两个方向都钉住

变异实测（每轮反向改坏源码，确认对应用例转红，改完反向文本替换还原）：

| 变异 | 转红用例 |
|---|---|
| `openBookOcr` 不转发 runner（复刻原 bug 形态） | ①② |
| `resolve()` 里 `remoteRunner: null` | ①②③ |
| `resolve()` 里 `lensRunner: null` | ②③ |
| desktop 三元取反 | ④a ④b |

## 门禁

- `flutter analyze`（含 test）：`No issues found!`
- `FLUTTER TEST VERDICT: PASSED - 442 tests ran`（`test/media/manga` 全目录 + `source_guard_adoption_test` + `md3_design_system_static_test` + 4 个 `grep -l` 反查到的相关守卫 + `test/media/import` + `test/media/drag_drop` 相关）
- `FLUTTER TEST VERDICT: PASSED - 71 tests ran`（`test/pages/manga_*` + `bugs_per_file_guard_test`）

未 bump `+build`（整合线统一 bump）。同批的 TODO-2634 / TODO-2635 本轮未做。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
