### PR TITLE
fix(md3): 守卫豁免与实际命中脱节三类收口 (BUG-1418 / TODO-2629+2630+2631)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1319 条。点号进各自文件。
+> 共 1320 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1418](bugs/BUG-1418-md3-guard-allowlist-drift.md) | ✅ | ✅ | MD3 守卫豁免与实际命中脱节：四处裸 Material chrome 静默放行 + fontSizeFactor 绕过判据 + 过期豁免 |
 | [BUG-1414](bugs/BUG-1414-md3-manga-fontsize-guard.md) | ✅ | ✅ | manga.json 回写触发 MD3 fontSize 守卫，develop CI 单测门变红 |
 | [BUG-1413](bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md) | ✅ | ✅ | 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null |
 | [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |

--- a/docs/bugs/BUG-1418-md3-guard-allowlist-drift.md
+++ b/docs/bugs/BUG-1418-md3-guard-allowlist-drift.md
@@ -1,0 +1,76 @@
+## BUG-1418 · MD3 守卫豁免与实际命中脱节：四处裸 Material chrome 静默放行 + fontSizeFactor 绕过判据 + 过期豁免
+- **报告**：2026-08-02（TODO-2629 / 2630 / 2631，PR#707 排查时发现，当时有意未动）
+- **真实性**：✅ 真 bug（三类都复核成立）
+
+`hibiki/test/settings/md3_design_system_static_test.dart` 的
+`ordinary page chrome does not reopen local MD3 decisions` 是全 `lib/src` 子串扫描 +
+**整文件**豁免（`allowedFiles`：命中任一禁用 token 时，只要该文件有一条 reason 就整份放行）。
+这个「理由是散文、豁免是整文件」的结构漏了三类东西：
+
+### A 类（TODO-2629）豁免写得比实际命中宽 —— 理由没覆盖到的部分被静默放行
+整文件豁免下，**理由里没提到的那部分违规是看不见的**：主守卫永远不会为这些文件报错，
+光读 allowlist 也看不出理由与代码已经对不上。四处实测成立：
+
+| 位置 | 实际命中 | 豁免理由只覆盖 |
+|---|---|---|
+| `hibiki/lib/src/media/video/video_chapter_panel.dart:114` | 裸 `ListTile(` | 「行字号随 appUiScale 缩放」；且它援引的同类 `video_subtitle_jump_panel.dart` 根本不用 `ListTile`（手搓 `InkWell`+`Container` 行） |
+| `hibiki/lib/src/pages/implementations/texthooker_page.dart:178,647` | 两处裸 `ListTile(`（选轨对话框 / 窗口选择对话框） | 「hook 状态胶囊是实时内容指示器」 |
+| `hibiki/lib/src/pages/implementations/video_shader_dialog.dart:602` | 裸 `ListTile(`（Anime4K 预设选择列表） | 「导入的 shader 文件以勾选行列出」（即 :365 / :505 两处 `CheckboxListTile`） |
+| `hibiki/lib/src/pages/implementations/anime_download_dialog.dart:1837` | `SwitchListTile(`（「一并下载字幕」**设置开关**） | 通篇只讲候选行 / 字幕行 / 任务行等**内容行**，从没提过开关 |
+
+处置：**收口，不是把理由改宽去追认现状**（那等于事后合法化）。四处全部改走共享 MD3 组件
+（`HibikiListItem` / `AdaptiveSettingsSwitchRow`，与 PR#698、`games_library_page` 同款收口）。
+`HibikiListItem` 补了 `autofocus`——`texthooker` 窗口选择器的 BUG-1049 焦点驱动行为
+（「打开即落在正确的窗口上，回车就绑」）靠它，收口时不能悄悄丢掉。
+
+### B 类（TODO-2630）真盲区 —— 换个写法就绕过判据
+根因 `hibiki/lib/src/utils/components/clipboard_lookup_text_panel.dart:111-114`：
+
+```dart
+return base.apply(
+  fontSizeFactor: (_dictionaryHeadwordBaseFontSize / safeBaseSize) * safeScale,
+);
+```
+
+**读一个排版令牌（`tokens.type.pageTitle`）只为把它整除掉**，最终字号恒等于 `26 * scale`。
+两宗罪：① 整个文件一个 `fontSize:` 都不剩（`grep -c "fontSize:"` = 0），子串判据天然扫不到，
+等于给绕过留了正门；② 谁把 `pageTitle` 调大，因子自动补偿回 26，改动零反馈、静默失效。
+
+复核后**这个 26 本身是合理的**：BUG-175 / TODO-222 要求源文本条与查词弹窗 headword 同级，
+而那个 headword 不是 Flutter 排版角色，是 WebView 里 `hibiki/assets/popup/popup.css` 的
+`.expression { font-size: 26px }`。所以它是**跨边界对齐常量**，不是本地重新拍板的 MD3 字号。
+处置：停止伪装——明写 `fontSize: kPopupHeadwordFontSize * safeScale`，常量文档化说明它对齐谁，
+allowlist 记这条 reviewed 理由，并用可证伪断言把它与 popup.css 钉在一起（改哪边都红）。
+判据侧补 `fontSizeFactor` / `fontSizeDelta`（`TextStyle.apply` 的两个字号旋钮）。
+扩判据后全仓重扫：`lib/src` 里 `fontSizeFactor` 只此一处、`fontSizeDelta` 零处，无新增违规。
+
+### C 类（TODO-2631）过期豁免 —— 理由早与代码脱节，却仍给整文件免检
+`hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart` 的豁免理由写的是
+「shellScript 收到 `fontSize: s.fontSize.round()`」，实测该文件**零禁用 token 命中**
+（`shellScript` 这个符号在整个 `lib/src` 里也已不存在）。加上结构性检查后又扫出**同类 14 条**，
+全部经复核零命中：`hibiki_dropdown` / `adaptive_theme` / `global_lookup_render` /
+`media_item_dialog_page` / `reader_quick_settings_sheet` / `video_side_panel` /
+`video_danmaku_overlay` / `dictionary_dialog_import_page` / `dictionary_dialog_delete_page` /
+`cupertino_settings_renderer` / `hibiki_list_tile` / `hibiki_text_selection_controls` /
+`update_checker_ui` / `reader_pagination_scripts`。
+（典型：`hibiki_list_tile.dart` 的理由是「Legacy compatibility adapter wraps framework
+ListTile」，但它早已改成委托 `HibikiListItem`，一个框架 `ListTile` 都不剩。）
+这些不是无害的死条目——它们是**给未来的违规预留的、不会被审的通行证**：哪天有人往
+`hibiki_list_tile.dart` 塞真 chrome，守卫会照旧放行。处置：15 条全删。
+
+- **[x] ① 已修复** — A 类四处收口共享 MD3 组件 + `HibikiListItem.autofocus`；B 类去掉
+  `fontSizeFactor` 洗白改明写对齐常量；C 类删 15 条过期豁免。
+- **[x] ② 已加自动化测试** — `hibiki/test/settings/md3_design_system_static_test.dart`
+  三条新守卫（均已变异实测）：
+  - `reviewed content exemptions do not silently cover bare chrome`：把 A 类四处逐条钉成
+    可证伪断言，判据复用主守卫同一个标识符边界原语 `_containsForbiddenChrome`（不是另写
+    一套宽松子串）。四处各自改回裸 chrome 都能让它红。
+  - `source lookup strip headword size stays pinned to the popup CSS`：把「对齐弹窗
+    headword」从散文钉成断言——Dart 常量必须等于 `popup.css` 里 `.expression` 的真实
+    px 值，且不许退回 `fontSizeFactor` / `fontSizeDelta`。两个方向（改 Dart / 改 CSS）都红。
+  - `ordinary page chrome …` 新增 `deadAllowlistEntries` 断言：任何豁免条目一旦零命中
+    （或文件没了）立刻红，C 类这种「理由漂走、整文件免检」不会再攒下来。
+  - 判据本体新增 `fontSizeFactor` / `fontSizeDelta` 两个禁用 token（B 类绕过口）。
+- **备注**：本次**没有**放宽任何断言、没有 skip、没有把文件移出扫描范围；A 类也没有把豁免
+  理由改宽去追认现状。`video_shader_dialog` 的豁免保留 `CheckboxListTile` 部分，并加了
+  「那两处勾选行必须还在」的正向断言——理由所依附的事实消失时，理由必须重写而不是继承。

--- a/hibiki/lib/src/media/video/video_chapter_panel.dart
+++ b/hibiki/lib/src/media/video/video_chapter_panel.dart
@@ -111,8 +111,12 @@ class _VideoChapterPanelState extends State<VideoChapterPanel> {
       itemBuilder: (BuildContext _, int i) {
         final VideoChapter chapter = chapters[i];
         final bool selected = i == widget.currentIndex;
-        return ListTile(
-          dense: true,
+        // BUG-1418：行骨架走共享 MD3 组件（[HibikiListItem]），不再裸 ListTile。
+        // 本文件的 reviewed 豁免只覆盖「行字号随 appUiScale 缩放」这一条内容理由，
+        // 从不覆盖行骨架；它援引的同类 video_subtitle_jump_panel 也根本不用 ListTile。
+        return HibikiListItem(
+          density: HibikiListDensity.compact,
+          selected: selected,
           leading: Text(
             '${i + 1}',
             style: TextStyle(
@@ -122,6 +126,7 @@ class _VideoChapterPanelState extends State<VideoChapterPanel> {
               fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
             ),
           ),
+          titleMaxLines: 2,
           title: Text(
             _chapterLabel(chapter),
             maxLines: 2,
@@ -140,8 +145,6 @@ class _VideoChapterPanelState extends State<VideoChapterPanel> {
               fontFeatures: const <FontFeature>[FontFeature.tabularFigures()],
             ),
           ),
-          selected: selected,
-          selectedColor: cs.primary,
           trailing: selected ? Icon(Icons.play_arrow, color: cs.primary) : null,
           onTap: () => widget.onTapChapter(chapter),
         );

--- a/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/anime_download_dialog.dart
@@ -1834,10 +1834,11 @@ class _AnimeDownloadDialogState extends ConsumerState<AnimeDownloadDialog>
                 ],
                 const SizedBox(height: 4),
                 if (_chosenSubs.isNotEmpty)
-                  SwitchListTile(
-                    dense: true,
-                    contentPadding: EdgeInsets.zero,
-                    title: Text(t.anime_download_include_subs),
+                  // BUG-1418：这是一个「设置开关」，不是候选行/字幕行/任务行——
+                  // 本文件的 reviewed 豁免通篇只讲内容行，从没覆盖过开关。走共享
+                  // MD3 开关行（与 games_library_page 同款收口）。
+                  AdaptiveSettingsSwitchRow(
+                    title: t.anime_download_include_subs,
                     value: _includeSubs,
                     onChanged: _pushing
                         ? null

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -175,14 +175,24 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                 builder: (BuildContext context) {
                   final bool excluded = _session.state.excludedAudioSourcePtrs
                       .contains(track.sourcePtr);
-                  return ListTile(
+                  // BUG-1418：行骨架走共享 MD3 组件，不再裸 ListTile。本文件的
+                  // reviewed 豁免只覆盖「hook 状态胶囊是实时内容指示器」，从不覆盖
+                  // 对话框行骨架。`ListTile.enabled` 的两个作用分开落地：不可选走
+                  // onTap: null（本来就有），置灰走显式 disabled 前景色。
+                  final Color disabledColor = HibikiDesignTokens.of(context)
+                      .surfaces
+                      .onSurface
+                      .withValues(alpha: 0.38);
+                  return HibikiListItem(
                     leading: Icon(
                       excluded ? Icons.music_off_outlined : Icons.graphic_eq,
+                      color: excluded ? disabledColor : null,
                     ),
                     title: Text(
                       '${t.game_track_voice} ${track.orderIndex + 1} · '
                       '${track.format.sampleRate} Hz · '
                       '${track.format.channels} ch',
+                      style: excluded ? TextStyle(color: disabledColor) : null,
                     ),
                     subtitle: Text(
                       <String>[
@@ -191,6 +201,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                             '${track.avgEnergy.toStringAsFixed(1)}',
                         if (excluded) t.game_track_bgm,
                       ].join(' · '),
+                      style: excluded ? TextStyle(color: disabledColor) : null,
                     ),
                     trailing: Wrap(
                       spacing: 4,
@@ -222,7 +233,6 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                       ],
                     ),
                     // 已明确标为 BGM 的轨不能再被误点成这句语音；仍可试听与恢复。
-                    enabled: !excluded,
                     onTap: excluded
                         ? null
                         : () =>
@@ -644,7 +654,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         title: Text(t.external_window_select),
         children: <Widget>[
           for (final ExternalWindowInfo window in ordered)
-            ListTile(
+            // BUG-1418：行骨架走共享 MD3 组件，不再裸 ListTile（豁免理由只覆盖
+            // hook 状态胶囊）。autofocus 是 BUG-1049 的焦点驱动行为，随之收进
+            // [HibikiListItem]，不能在收口时悄悄丢掉。
+            HibikiListItem(
               // 焦点驱动纪律：这一项拿到初始焦点，Tab/方向键从它开始，Enter 直接确认。
               autofocus: gamePid != null
                   ? window.pid == gamePid

--- a/hibiki/lib/src/pages/implementations/video_shader_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/video_shader_dialog.dart
@@ -609,6 +609,9 @@ class Anime4kPresetPickerDialog extends StatelessWidget {
                               .rowVertical,
                         ),
                         title: Text(preset.name),
+                        // 预设说明是两三句话，裸 ListTile 的 subtitle 不截行；
+                        // 收口后显式放宽到 3 行，别让长语言（英/德）被吃掉半句。
+                        subtitleMaxLines: 3,
                         subtitle: Text(presetDescription(preset.id)),
                         trailing: added
                             ? Icon(Icons.check, color: cs.primary)

--- a/hibiki/lib/src/pages/implementations/video_shader_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/video_shader_dialog.dart
@@ -599,8 +599,15 @@ class Anime4kPresetPickerDialog extends StatelessWidget {
                     () {
                       final bool added =
                           preset.fileNames.every(downloadedFiles.contains);
-                      return ListTile(
-                        contentPadding: EdgeInsets.zero,
+                      // BUG-1418：预设选择行走共享 MD3 组件，不再裸 ListTile。
+                      // 本文件的 reviewed 豁免只写了「导入的 shader 文件以勾选行
+                      // 列出」（即那两处 CheckboxListTile），从不覆盖这个预设列表。
+                      return HibikiListItem(
+                        padding: EdgeInsets.symmetric(
+                          vertical: HibikiDesignTokens.of(context)
+                              .spacing
+                              .rowVertical,
+                        ),
                         title: Text(preset.name),
                         subtitle: Text(presetDescription(preset.id)),
                         trailing: added

--- a/hibiki/lib/src/utils/components/clipboard_lookup_text_panel.dart
+++ b/hibiki/lib/src/utils/components/clipboard_lookup_text_panel.dart
@@ -4,7 +4,20 @@ import 'package:flutter/services.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
 import 'package:hibiki/src/utils/misc/lookup_input_limits.dart';
 
-const double _dictionaryHeadwordBaseFontSize = 26.0;
+/// 查词弹窗 headword 的字号，单位逻辑像素。
+///
+/// BUG-175 / TODO-222 要求源文本条与弹窗 headword **同级**；那个 headword 不是
+/// Flutter 排版角色，而是 WebView 里 `assets/popup/popup.css` 的
+/// `.expression { font-size: 26px }`。所以这个数字是**跨边界对齐常量**，不是本地
+/// 重新拍板的 MD3 字号——守卫用 `md3_design_system_static_test.dart` 的
+/// 「source lookup strip headword size stays pinned to the popup CSS」把它与
+/// popup.css 钉在一起，改哪边都会红。
+///
+/// BUG-1418：这里曾写成 `pageTitle.apply(fontSizeFactor: 26 / pageTitle.fontSize)`
+/// —— 读一个设计令牌只为把它整除掉。那个写法有两宗罪：① 文件里一个 `fontSize:`
+/// 都不剩，MD3 守卫的子串判据天然扫不到，等于绕过门禁；② 谁把 `pageTitle` 调大，
+/// 因子会自动补偿回 26，改动零反馈、静默失效。现在明写字号、明说它对齐谁。
+const double kPopupHeadwordFontSize = 26.0;
 
 class SourceLookupTextPanel extends StatefulWidget {
   const SourceLookupTextPanel({
@@ -99,19 +112,15 @@ class _SourceLookupTextPanelState extends State<SourceLookupTextPanel> {
     );
   }
 
+  /// 字体族 / 字重 / 颜色仍取 MD3 的 [HibikiTypeRoles.pageTitle] 标题角色；
+  /// 只有**字号**按 [kPopupHeadwordFontSize] 与弹窗 headword 对齐，再乘用户的
+  /// 词典字号比例。
   TextStyle _dictionaryHeadwordTextStyle(BuildContext context) {
     final TextStyle base = HibikiDesignTokens.of(context).type.pageTitle;
-    final double baseSize = base.fontSize ?? _dictionaryHeadwordBaseFontSize;
-    final double safeBaseSize = baseSize.isFinite && baseSize > 0
-        ? baseSize
-        : _dictionaryHeadwordBaseFontSize;
     final double requestedScale = widget.dictionaryHeadwordScale;
     final double safeScale =
         requestedScale.isFinite && requestedScale > 0 ? requestedScale : 1.0;
-    return base.apply(
-      fontSizeFactor:
-          (_dictionaryHeadwordBaseFontSize / safeBaseSize) * safeScale,
-    );
+    return base.copyWith(fontSize: kPopupHeadwordFontSize * safeScale);
   }
 
   void _handleShiftHover(

--- a/hibiki/lib/src/utils/components/hibiki_material_components.dart
+++ b/hibiki/lib/src/utils/components/hibiki_material_components.dart
@@ -153,6 +153,7 @@ class HibikiListItem extends StatefulWidget {
     this.titleMaxLines = 1,
     this.subtitleMaxLines = 2,
     this.focusId,
+    this.autofocus = false,
   });
 
   final Widget title;
@@ -177,6 +178,14 @@ class HibikiListItem extends StatefulWidget {
   final int titleMaxLines;
   final int subtitleMaxLines;
   final HibikiFocusId? focusId;
+
+  /// 本行开屏即拿到键盘焦点（等价于框架 `ListTile.autofocus`）。
+  ///
+  /// BUG-1418：把裸 `ListTile` 收口到本组件时，唯一没有对应物的就是 `autofocus`。
+  /// 焦点驱动纪律下它不是装饰——「打开对话框即落在正确的那一行，回车直接确认」
+  /// （texthooker 窗口选择器的 BUG-1049 行为）全靠它。只在 [onTap] 非空、真正建出
+  /// [InkWell] 焦点节点时有意义。
+  final bool autofocus;
 
   @override
   State<HibikiListItem> createState() => _HibikiListItemState();
@@ -302,6 +311,7 @@ class _HibikiListItemState extends State<HibikiListItem> {
             ? content
             : InkWell(
                 onTap: widget.onTap,
+                autofocus: widget.autofocus,
                 borderRadius: highlightRadius,
                 child: content,
               ),

--- a/hibiki/test/media/video/video_chapter_panel_test.dart
+++ b/hibiki/test/media/video/video_chapter_panel_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:hibiki/src/media/video/video_chapter_panel.dart';
 import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
 
 void main() {
   Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
@@ -63,10 +64,12 @@ void main() {
       ),
     ));
 
+    // BUG-1418：行骨架已从裸 ListTile 收口到共享 HibikiListItem，祖先按新组件找。
+    expect(find.byType(ListTile), findsNothing);
     // 仅当前章（Body, index 1）有 play_arrow trailing 标记。
     final Finder bodyTile = find.ancestor(
       of: find.text('Body'),
-      matching: find.byType(ListTile),
+      matching: find.byType(HibikiListItem),
     );
     expect(
       find.descendant(of: bodyTile, matching: find.byIcon(Icons.play_arrow)),
@@ -74,7 +77,7 @@ void main() {
     );
     final Finder introTile = find.ancestor(
       of: find.text('Intro'),
-      matching: find.byType(ListTile),
+      matching: find.byType(HibikiListItem),
     );
     expect(
       find.descendant(of: introTile, matching: find.byIcon(Icons.play_arrow)),

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -662,6 +662,11 @@ void main() {
       'surfaceContainerHigh',
       'surfaceContainerHighest',
       'fontSize:',
+      // BUG-1418：`TextStyle.apply` 的两个字号旋钮。少了它们，「读一个排版令牌
+      // 再用 fontSizeFactor 把它整除掉」就能锁死任意字号而整个文件一个
+      // `fontSize:` 都不剩——判据天然扫不到，等于给绕过留了正门。
+      'fontSizeFactor',
+      'fontSizeDelta',
       'Card(',
       'ListTile(',
       'SwitchListTile(',
@@ -1148,6 +1153,21 @@ void main() {
               'roles, the same reviewed startup-chrome exception class as the '
               'data-root migration / backup import overlays and the main.dart '
               'splash branches.',
+      // BUG-1418：查词源文本条的字号是**跨边界对齐常量**，不是本地 MD3 排版决定：
+      // BUG-175 / TODO-222 要求它与查词弹窗 headword 同级，而那个 headword 是
+      // WebView 里 assets/popup/popup.css 的 `.expression { font-size: 26px }`。
+      // 与 dictionary_popup_native / popup_theme_css 同一 reviewed 豁免类（弹窗查词
+      // 排版是内容，不是页面 chrome）。这条散文由下面
+      // 「source lookup strip headword size stays pinned to the popup CSS」钉成
+      // 可证伪断言：常量必须等于 popup.css 里的真实值，且不得退回 fontSizeFactor。
+      'lib/src/utils/components/clipboard_lookup_text_panel.dart':
+          'The source-text strip must render at the popup dictionary headword '
+              'size (BUG-175/TODO-222). That headword lives in the WebView, not '
+              'in a Flutter type role: assets/popup/popup.css sets '
+              '.expression { font-size: 26px }. kPopupHeadwordFontSize is that '
+              'cross-boundary parity constant (scaled by the user dictionary '
+              'font ratio), the same reviewed exception class as '
+              'dictionary_popup_native / popup_theme_css.',
       'lib/src/sync/backup_import_overlay_view.dart':
           'TODO-1151 backup import/restore overlay is pre-init startup chrome '
               '(rendered while the DB is closed / isInitialised=false during the '
@@ -1228,6 +1248,53 @@ void main() {
     expect(_containsForbiddenChrome(animeDownload, 'SwitchListTile('), isFalse,
         reason: 'anime_download_dialog is allowlisted for content rows; a '
             'settings toggle must go through the shared MD3 switch row');
+  });
+
+  // BUG-1418：查词源文本条的豁免理由说它的字号对齐弹窗 headword，而那个 headword
+  // 是 WebView 里 popup.css 的 `.expression`。散文会漂，这条把两侧钉在一起：常量
+  // 变了、popup.css 变了、或有人把字号重新藏回 TextStyle.apply，都会红。
+  test('source lookup strip headword size stays pinned to the popup CSS', () {
+    final String panel = File(
+      'lib/src/utils/components/clipboard_lookup_text_panel.dart',
+    ).readAsStringSync();
+    final String code = maskComments(panel);
+
+    final RegExp declaration =
+        RegExp(r'const double kPopupHeadwordFontSize = ([0-9.]+);');
+    final RegExpMatch? declared = declaration.firstMatch(code);
+    expect(declared, isNotNull,
+        reason: 'the strip must name its headword size as a documented '
+            'cross-boundary constant, not an inline literal');
+    final double dartSize = double.parse(declared!.group(1)!);
+
+    // popup.css 的 `.expression` 就是弹窗 headword 那一行。
+    final String popupCss = File('assets/popup/popup.css').readAsStringSync();
+    final RegExpMatch? cssRule = RegExp(
+      r'\.expression\s*\{[^}]*?font-size:\s*([0-9.]+)px',
+      dotAll: true,
+    ).firstMatch(popupCss);
+    expect(cssRule, isNotNull,
+        reason: 'popup.css must still size the .expression headword; if that '
+            'rule moved, the Flutter-side parity reason is stale');
+    expect(dartSize, double.parse(cssRule!.group(1)!),
+        reason: 'the source-text strip must render at the popup headword size '
+            '(BUG-175/TODO-222); the two sides have drifted apart');
+
+    // 不许把字号重新藏进 TextStyle.apply（BUG-1418 的原始绕过写法）。
+    expect(code, isNot(contains('fontSizeFactor')));
+    expect(code, isNot(contains('fontSizeDelta')));
+    // 唯一的字号写入就是那条对齐常量。
+    final List<String> fontSizeLines = code
+        .split('\n')
+        .where((String line) => line.contains('fontSize:'))
+        .map((String line) => line.trim())
+        .toList(growable: false);
+    expect(
+        fontSizeLines,
+        <String>[
+          'return base.copyWith(fontSize: kPopupHeadwordFontSize * safeScale);'
+        ],
+        reason: 'the allowlisted hit must stay the single popup-parity size');
   });
 
   // BUG-1414：上面 allowlist 里 manga_json_writeback.dart 的豁免理由是「纯数据层、

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -680,10 +680,6 @@ void main() {
           'Shared MD3 component implementation may map tokens to framework widgets.',
       'lib/src/utils/components/settings_shared.dart':
           'Shared adaptive settings primitives own compact settings controls.',
-      'lib/src/utils/components/hibiki_dropdown.dart':
-          'Shared dropdown owns its menu anchor shape until it is tokenized.',
-      'lib/src/utils/adaptive/adaptive_theme.dart':
-          'Cupertino text-theme bridge defines platform typography roles.',
       'lib/src/models/theme_notifier.dart':
           'Theme preview content intentionally displays generated surface roles.',
       'lib/src/pages/implementations/custom_theme_page.dart':
@@ -719,15 +715,8 @@ void main() {
               'properties for the three popup injectors — same reviewed '
               'exception class as popup_settings_injection / '
               'dictionary_popup_webview.',
-      'lib/src/lookup/global_lookup_render.dart':
-          'Global lookup popup theming injects MD3 ColorScheme surface roles into popup CSS (same as dictionary_popup_webview).',
       'lib/src/pages/implementations/history_reader_page.dart':
           'History preview uses content-derived surface and text metrics.',
-      'lib/src/pages/implementations/media_item_dialog_page.dart':
-          'TODO-293 long-press media dialog redesign: the cover-hero placeholder '
-              '(no-cover case) paints a surfaceContainerHighest->High tonal '
-              'gradient as immersive cover content, not ordinary page chrome. '
-              'Surfaces still flow through HibikiDialogFrame + HibikiDesignTokens.',
       'lib/src/pages/implementations/reader_hibiki_history_page.dart':
           'Book-cover overlays and drag affordances are reader-shelf content.',
       // CoverBadge 是压在封面图上的角标胶囊（字幕/云端/播放列表等），把书架/
@@ -823,19 +812,10 @@ void main() {
               'image context-menu font size are reader content / chrome, '
               'same rationale as the parent reader_hibiki_page.dart allowlist '
               '(extracted verbatim).',
-      // TODO-589 batch8: reader webview 域(EPUB WebView 构建 / hoshi.local 资源拦截
-      // + 净化 / 单 IIFE setup 脚本)拆到 reader_hibiki/webview.part.dart；同一份
-      // 「reader content / WebView 注入」豁免随搬运延伸到该 part（零行为变化，逐字符
-      // 自父文件搬出，含 _buildReaderSetupScript 整段内联 JS 的字节级等价）。
-      'lib/src/pages/implementations/reader_hibiki/webview.part.dart':
-          'Reader pagination shell script receives the content font size '
-              '(fontSize: s.fontSize.round() passed to '
-              'ReaderPaginationScripts.shellScript) and the WebView injects '
-              'reader content styling, not ordinary page chrome — same '
-              'rationale as the parent reader_hibiki_page.dart allowlist '
-              '(extracted verbatim).',
-      'lib/src/media/audiobook/reader_quick_settings_sheet.dart':
-          'Reader quick settings and audiobook chrome migrate under Task 8.',
+      // BUG-1418：reader_hibiki/webview.part.dart 的豁免已删除。它的理由写的是
+      // 「shellScript 收到 fontSize: s.fontSize.round()」，但该文件如今一个禁用
+      // token 都不剩（`shellScript` 这个符号在整个 lib/src 里也已不存在），豁免早与
+      // 代码脱节。下面的「no dead allowlist entries」断言会让同类过期豁免立刻红。
       'lib/src/media/audiobook/audiobook_bridge.dart':
           'Serialized audiobook bridge data includes reader font size.',
       'lib/src/media/audiobook/audiobook_session.dart':
@@ -887,11 +867,6 @@ void main() {
               'and playback state as video-subsystem content in the player overlay '
               'and collection hero; card typography scales with appUiScale in the '
               'player, the same reviewed content exception as video_episode_panel.',
-      'lib/src/media/video/video_side_panel.dart':
-          'Video translucent side-panel scaffold (favorite sentences list etc.) '
-              'renders video-subsystem overlay chrome; lock toggle (TODO-611) '
-              'uses a dense compact icon button consistent with the sibling '
-              'subtitle jump panel, not ordinary page chrome.',
       'lib/src/media/video/video_subtitle_style.dart':
           'Subtitle appearance model holds user-configurable caption font '
               'size (content), defaults mirror the allowlisted overlay caption.',
@@ -905,8 +880,6 @@ void main() {
               '(entry button surface, delay/view controls) routes through '
               'HibikiDesignTokens + shared MD3 components (HibikiIconButton / '
               'adaptiveSlider / AdaptiveSettingsTextField).',
-      'lib/src/media/video/video_danmaku_overlay.dart':
-          'Danmaku overlay renders timed video content text, not app chrome.',
       'lib/src/media/video/video_danmaku_text_metrics.dart':
           'BUG-1297/PR#627 danmaku font-size single source of truth, shared '
               'by rendering (video_danmaku_overlay) and geometry measurement '
@@ -1124,20 +1097,6 @@ void main() {
               'manga.json blocks; pure data layer, no UI typography.',
       'lib/src/creator/fields/image_field.dart':
           'Anki image-field renderer uses OCR/image coordinate typography.',
-      'lib/src/pages/implementations/dictionary_dialog_import_page.dart':
-          'Dictionary import content mirrors text-theme metrics.',
-      'lib/src/pages/implementations/dictionary_dialog_delete_page.dart':
-          'Dictionary delete content mirrors text-theme metrics.',
-      'lib/src/settings/cupertino_settings_renderer.dart':
-          'Cupertino destination list still wraps platform navigation rows.',
-      'lib/src/utils/components/hibiki_list_tile.dart':
-          'Legacy compatibility adapter wraps framework ListTile.',
-      'lib/src/utils/components/hibiki_text_selection_controls.dart':
-          'Shared text-selection toolbar owns its transient surface.',
-      'lib/src/utils/misc/update_checker_ui.dart':
-          'Update checker migrated card shell is already covered by local guard.',
-      'lib/src/reader/reader_pagination_scripts.dart':
-          'Injected reader JavaScript receives content font size.',
       'lib/src/storage/data_root_migration_view.dart':
           'TODO-959 data-root migration overlay is pre-init startup chrome '
               '(rendered while the DB is closed / isInitialised=false during '
@@ -1179,6 +1138,10 @@ void main() {
     };
 
     final List<String> violations = <String>[];
+    // BUG-1418：真正被用上的豁免键。一条豁免没被用上只有两种情况——文件没了，或者
+    // 文件里早就一个禁用 token 都不剩；两种都是**过期豁免**：理由与代码脱节，却仍
+    // 挂在名单上给该文件整份免检，等于给未来的违规预留了一张不会被审的通行证。
+    final Set<String> liveAllowlistKeys = <String>{};
     final List<File> dartFiles = Directory('lib/src')
         .listSync(recursive: true)
         .whereType<File>()
@@ -1193,7 +1156,10 @@ void main() {
       );
       final List<String> hits = _forbiddenChromeHits(source, forbidden);
       if (hits.isEmpty) continue;
-      if (reason != null && reason.isNotEmpty) continue;
+      if (reason != null && reason.isNotEmpty) {
+        liveAllowlistKeys.add(path);
+        continue;
+      }
       violations.add('$path: ${hits.join(', ')}');
     }
 
@@ -1202,6 +1168,18 @@ void main() {
       isEmpty,
       reason: 'Route ordinary visual chrome through shared MD3 components, or '
           'add a reviewed allowlist reason for true content exceptions.',
+    );
+
+    final List<String> deadAllowlistEntries = allowedFiles.keys
+        .where((String path) => !liveAllowlistKeys.contains(path))
+        .toList(growable: false);
+    expect(
+      deadAllowlistEntries,
+      isEmpty,
+      reason: 'BUG-1418: these allowlist entries no longer match anything — '
+          'the file is gone, or it has zero forbidden-chrome hits. A reason '
+          'that has drifted away from the code is not a reviewed exception, '
+          'it is a standing blanket waiver. Delete the entry.',
     );
   });
 

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -1185,6 +1185,51 @@ void main() {
     );
   });
 
+  // BUG-1418：上面四个文件的豁免理由写得比实际命中宽——理由只谈行字号 / 状态胶囊 /
+  // 勾选行 / 内容行，却顺带把行骨架和设置开关一起放了行。整份文件免检时，「理由没
+  // 覆盖到的那部分」是静默通过的，光看 allowlist 根本看不出来。裸 chrome 已收口到
+  // 共享 MD3 组件，这条把「收口后不许长回来」钉成可证伪断言：判据复用主守卫同一个
+  // 标识符边界原语（[_containsForbiddenChrome]），不是另写一套宽松子串。
+  test('reviewed content exemptions do not silently cover bare chrome', () {
+    // 章节面板：行骨架是共享组件，不是裸 ListTile（其豁免只覆盖行字号）。
+    final String chapterPanel =
+        File('lib/src/media/video/video_chapter_panel.dart').readAsStringSync();
+    expect(chapterPanel, contains('HibikiListItem('));
+    expect(_containsForbiddenChrome(chapterPanel, 'ListTile('), isFalse,
+        reason: 'video_chapter_panel is allowlisted for row font size only; '
+            'its row skeleton must stay a shared MD3 component');
+
+    // Hook 控制台：两个选择对话框的行骨架同上（其豁免只覆盖状态胶囊）。
+    final String texthooker =
+        File('lib/src/pages/implementations/texthooker_page.dart')
+            .readAsStringSync();
+    expect(texthooker, contains('HibikiListItem('));
+    expect(_containsForbiddenChrome(texthooker, 'ListTile('), isFalse,
+        reason: 'texthooker_page is allowlisted for hook status pills only; '
+            'its dialog rows must stay shared MD3 components');
+
+    // 着色器对话框：豁免只写了「导入的 shader 文件以勾选行列出」，所以
+    // CheckboxListTile 留着，Anime4K 预设列表的裸 ListTile 不许回来。
+    final String shaderDialog =
+        File('lib/src/pages/implementations/video_shader_dialog.dart')
+            .readAsStringSync();
+    expect(shaderDialog, contains('HibikiListItem('));
+    expect(shaderDialog, contains('CheckboxListTile('),
+        reason: 'the reviewed reason is about the shader-file checkbox rows; '
+            'if they are gone the reason must be rewritten, not inherited');
+    expect(_containsForbiddenChrome(shaderDialog, 'ListTile('), isFalse,
+        reason: 'the Anime4K preset picker must stay a shared MD3 row');
+
+    // 番剧下载对话框：豁免通篇讲内容行，开关不在其中。
+    final String animeDownload =
+        File('lib/src/pages/implementations/anime_download_dialog.dart')
+            .readAsStringSync();
+    expect(animeDownload, contains('AdaptiveSettingsSwitchRow('));
+    expect(_containsForbiddenChrome(animeDownload, 'SwitchListTile('), isFalse,
+        reason: 'anime_download_dialog is allowlisted for content rows; a '
+            'settings toggle must go through the shared MD3 switch row');
+  });
+
   // BUG-1414：上面 allowlist 里 manga_json_writeback.dart 的豁免理由是「纯数据层、
   // 无 Flutter import」。理由只是一句散文，会随代码漂移；这条把它钉成可证伪的
   // 断言——一旦有人往回写层塞 UI，豁免立刻失效，而不是继续静默免检。

--- a/hibiki/test/widgets/hibiki_list_item_focus_test.dart
+++ b/hibiki/test/widgets/hibiki_list_item_focus_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/focus/hibiki_focus_controller.dart';
 import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
@@ -39,6 +40,51 @@ void main() {
       controller.activeContext!,
       const ActivateIntent(),
     );
+    expect(taps, 1);
+  });
+
+  // BUG-1418：把 texthooker 窗口选择器的裸 ListTile 收口到本组件时，唯一没有对应物的
+  // 就是 `autofocus`。它不是装饰——BUG-1049 的「打开对话框即落在正确的那一行，回车直接
+  // 确认」全靠它。这条锁住：带 autofocus 的行开屏就持有键盘焦点，且 Enter 直接触发
+  // onTap（对话框里没有 HibikiFocusRoot，走的是 InkWell 自己的焦点节点）。
+  testWidgets('autofocus HibikiListItem takes keyboard focus on open',
+      (WidgetTester tester) async {
+    int taps = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: <Widget>[
+            HibikiListItem(
+              title: const Text('Other window'),
+              onTap: () => taps += 1,
+            ),
+            HibikiListItem(
+              autofocus: true,
+              title: const Text('The game window'),
+              onTap: () => taps += 1,
+            ),
+          ],
+        ),
+      ),
+    ));
+    await tester.pump();
+
+    final InkWell focused = tester.widget<InkWell>(
+      find
+          .descendant(
+            of: find.ancestor(
+              of: find.text('The game window'),
+              matching: find.byType(HibikiListItem),
+            ),
+            matching: find.byType(InkWell),
+          )
+          .first,
+    );
+    expect(focused.autofocus, isTrue);
+
+    // 焦点真的落在这一行上：Enter 直接确认，不需要先 Tab 过去。
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
     expect(taps, 1);
   });
 


### PR DESCRIPTION
一次收口 md3 守卫 `ordinary page chrome does not reopen local MD3 decisions` 的三类存量问题。
三类各一个 commit，便于单独回滚。**没有**放宽任何断言、没有 skip、没有把文件移出扫描范围。

根因文档：`docs/bugs/BUG-1418-md3-guard-allowlist-drift.md`

## 共同根因
守卫的 `allowedFiles` 是**整文件**豁免 + 散文理由：命中任一禁用 token 时，只要该文件有一条
reason 就整份放行。于是「理由里没提到的那部分」静默通过，而且理由会随代码漂走却没人发现。

## A（TODO-2629）豁免写得比实际命中宽 — commit 1
四处复核成立，全部**收口到共享 MD3 组件**（不是把理由改宽去追认现状）：

| 位置 | 命中 | 理由只覆盖 |
|---|---|---|
| `video_chapter_panel.dart:114` | 裸 `ListTile(` | 「行字号随 appUiScale」；且它援引的同类 `video_subtitle_jump_panel` 根本不用 ListTile |
| `texthooker_page.dart:178,647` | 两处裸 `ListTile(` | 「hook 状态胶囊」 |
| `video_shader_dialog.dart:602` | 裸 `ListTile(` | 「shader 文件勾选行」（即两处 CheckboxListTile） |
| `anime_download_dialog.dart:1837` | `SwitchListTile(`（设置开关） | 通篇只讲内容行 |

`HibikiListItem` 补 `autofocus`——texthooker 窗口选择器的 BUG-1049 焦点驱动行为
（「打开即落在正确的窗口上，回车就绑」）靠它，收口时不能悄悄丢掉。

## B（TODO-2630）真盲区：换个写法绕过判据 — commit 2
`clipboard_lookup_text_panel.dart` 读排版令牌 `pageTitle` 只为用
`apply(fontSizeFactor: 26 / pageTitle.fontSize)` 把它整除掉，字号恒等于 26 —— 整个文件
一个 `fontSize:` 都不剩，子串判据天然扫不到。

复核后 26 本身合理：它对齐的是 WebView 里 `assets/popup/popup.css` 的
`.expression { font-size: 26px }`（BUG-175 / TODO-222），是**跨边界对齐常量**，不是本地
MD3 排版决定。所以修法是停止伪装：明写 `fontSize: kPopupHeadwordFontSize * safeScale`，
allowlist 记 reviewed 理由，并把它与 popup.css 钉成可证伪断言。
判据补 `fontSizeFactor` / `fontSizeDelta`；**扩判据后全仓重扫无新增违规**
（`lib/src` 里 `fontSizeFactor` 只此一处、`fontSizeDelta` 零处）。

## C（TODO-2631）过期豁免 — commit 3
`reader_hibiki/webview.part.dart` 的理由说该文件有 `fontSize: s.fontSize.round()`，实测
零命中（`shellScript` 这个符号在 `lib/src` 里也已不存在）。加上「豁免必须真的对应命中」的
结构性断言后又扫出同类 **14 条**，逐条复核零命中后一并删除（共 15 条）。典型：
`hibiki_list_tile.dart` 的理由是「wraps framework ListTile」，但它早已改成委托
`HibikiListItem`。这些是给未来违规预留的、不会被审的通行证。

## 变异实测（每类都做，均为真行为改动，未写在注释里）
| 变异 | 转红的用例 |
|---|---|
| 四处各自改回裸 `ListTile` / `SwitchListTile` | `reviewed content exemptions do not silently cover bare chrome`（四条断言分别命中） |
| 非豁免文件塞一处真 `apply(fontSizeFactor: 1.35)` | `ordinary page chrome …` → `collections_page.dart: fontSizeFactor` |
| 同一文件改塞经 MD3 令牌的合法用法（负向对照） | 仍绿 ✅ |
| 把 `fontSizeFactor` 洗白写法加回 clipboard 面板 | `source lookup strip headword size stays pinned to the popup CSS` |
| 把 popup.css `.expression` 改成 28px | 同上（Expected 28.0 / Actual 26.0） |
| 删豁免后往 `webview.part.dart` 塞一行真 `fontSize:` | `ordinary page chrome …` 把它列成违规（证明该文件真的在被扫） |
| 把 `webview.part.dart` 豁免加回去 | `dead allowlist entry` 断言 |

还原一律用反向文本替换，未对未提交文件用 `git checkout --`；还原后 `git status --short` 干净。

## 门禁
- `flutter analyze`（含 test）：`No issues found!`
- `md3_design_system_static_test`：`PASSED - 63 tests ran`（基线 61，+2 新守卫）
- `source_guard_adoption_test` 所在 `test/tools`：`PASSED - 186 tests ran`
- 定向批 `test/settings test/widgets test/media/video test/media/torrent test/pages test/mining test/lookup`：`PASSED - 7176 tests ran`
- 全量套件 verdict 见评论

未 bump `+build`（整合线统一 bump）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
