### PR TITLE
feat(stat): 统计页时段图按 format 分色堆叠，历史未区分数据单独成带 (TODO-2622)

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52105 (3065 per locale)
+/// Strings: 52190 (3070 per locale)
 ///
-/// Built on 2026-08-02 at 01:33 UTC
+/// Built on 2026-08-02 at 01:55 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4119,6 +4119,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_rescan_writeback => 'Save to page';
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  String get stat_hourly_band_epub => 'Text books';
+  String get stat_hourly_band_pdf => 'PDF';
+  String get stat_hourly_band_manga => 'Manga';
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -11152,6 +11158,17 @@ class _StringsAr extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -18252,6 +18269,17 @@ class _StringsDe extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -25367,6 +25395,17 @@ class _StringsEs extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -32494,6 +32533,17 @@ class _StringsFr extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -39550,6 +39600,17 @@ class _StringsId extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -46652,6 +46713,17 @@ class _StringsIt extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -53571,6 +53643,17 @@ class _StringsJa extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -60492,6 +60575,17 @@ class _StringsKo extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -67574,6 +67668,17 @@ class _StringsNl extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -74669,6 +74774,17 @@ class _StringsPtBr extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -81748,6 +81864,17 @@ class _StringsRu extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -88775,6 +88902,17 @@ class _StringsTh extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -95834,6 +95972,17 @@ class _StringsTr extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -102878,6 +103027,17 @@ class _StringsVi extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 // Path: <root>
@@ -109434,6 +109594,17 @@ class _StringsZhCn extends _StringsEn {
   String get manga_rescan_writeback_done => '已回写 manga.json';
   @override
   String get manga_rescan_writeback_failed => '回写 manga.json 失败';
+  @override
+  String get stat_hourly_band_epub => '文字书';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => '漫画';
+  @override
+  String get stat_hourly_band_unattributed => '未区分历史';
+  @override
+  String get stat_hourly_unattributed_note =>
+      '早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。';
 }
 
 // Path: <root>
@@ -116274,6 +116445,17 @@ class _StringsZhHk extends _StringsEn {
   String get manga_rescan_writeback_done => 'Saved to manga.json';
   @override
   String get manga_rescan_writeback_failed => 'Failed to save to manga.json';
+  @override
+  String get stat_hourly_band_epub => 'Text books';
+  @override
+  String get stat_hourly_band_pdf => 'PDF';
+  @override
+  String get stat_hourly_band_manga => 'Manga';
+  @override
+  String get stat_hourly_band_unattributed => 'Unsplit history';
+  @override
+  String get stat_hourly_unattributed_note =>
+      'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
 }
 
 /// Flat map(s) containing all translations.
@@ -122563,6 +122745,16 @@ extension on _StringsEn {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -128850,6 +129042,16 @@ extension on _StringsAr {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -135159,6 +135361,16 @@ extension on _StringsDe {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -141467,6 +141679,16 @@ extension on _StringsEs {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -147781,6 +148003,16 @@ extension on _StringsFr {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -154077,6 +154309,16 @@ extension on _StringsId {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -160387,6 +160629,16 @@ extension on _StringsIt {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -166659,6 +166911,16 @@ extension on _StringsJa {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -172935,6 +173197,16 @@ extension on _StringsKo {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -179239,6 +179511,16 @@ extension on _StringsNl {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -185540,6 +185822,16 @@ extension on _StringsPtBr {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -191846,6 +192138,16 @@ extension on _StringsRu {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -198135,6 +198437,16 @@ extension on _StringsTh {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -204433,6 +204745,16 @@ extension on _StringsTr {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -210727,6 +211049,16 @@ extension on _StringsVi {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }
@@ -216967,6 +217299,16 @@ extension on _StringsZhCn {
         return '已回写 manga.json';
       case 'manga_rescan_writeback_failed':
         return '回写 manga.json 失败';
+      case 'stat_hourly_band_epub':
+        return '文字书';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return '漫画';
+      case 'stat_hourly_band_unattributed':
+        return '未区分历史';
+      case 'stat_hourly_unattributed_note':
+        return '早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。';
       default:
         return null;
     }
@@ -223234,6 +223576,16 @@ extension on _StringsZhHk {
         return 'Saved to manga.json';
       case 'manga_rescan_writeback_failed':
         return 'Failed to save to manga.json';
+      case 'stat_hourly_band_epub':
+        return 'Text books';
+      case 'stat_hourly_band_pdf':
+        return 'PDF';
+      case 'stat_hourly_band_manga':
+        return 'Manga';
+      case 'stat_hourly_band_unattributed':
+        return 'Unsplit history';
+      case 'stat_hourly_unattributed_note':
+        return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "查词",
   "manga_rescan_writeback": "回写本页",
   "manga_rescan_writeback_done": "已回写 manga.json",
-  "manga_rescan_writeback_failed": "回写 manga.json 失败"
+  "manga_rescan_writeback_failed": "回写 manga.json 失败",
+  "stat_hourly_band_epub": "文字书",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "漫画",
+  "stat_hourly_band_unattributed": "未区分历史",
+  "stat_hourly_unattributed_note": "早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3063,5 +3063,10 @@
   "manga_rescan_lookup": "Look up",
   "manga_rescan_writeback": "Save to page",
   "manga_rescan_writeback_done": "Saved to manga.json",
-  "manga_rescan_writeback_failed": "Failed to save to manga.json"
+  "manga_rescan_writeback_failed": "Failed to save to manga.json",
+  "stat_hourly_band_epub": "Text books",
+  "stat_hourly_band_pdf": "PDF",
+  "stat_hourly_band_manga": "Manga",
+  "stat_hourly_band_unattributed": "Unsplit history",
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
 }

--- a/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
+++ b/hibiki/lib/src/pages/implementations/reading_statistics_page.dart
@@ -3,6 +3,7 @@ import 'package:hibiki/media.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/pages/implementations/stat_activity.dart';
 import 'package:hibiki/src/pages/implementations/stat_charts.dart';
+import 'package:hibiki/src/pages/implementations/stat_hourly_breakdown.dart';
 import 'package:hibiki/src/pages/implementations/stat_delete_confirm_dialog.dart';
 import 'package:hibiki/src/pages/implementations/stat_kpi_strip.dart';
 import 'package:hibiki/src/pages/implementations/stat_ring.dart';
@@ -73,8 +74,9 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
   // 每日数据（最近 30 天）
   List<StatDayData> _dailyData = [];
 
-  // 今日每小时数据（0-23）
-  List<int> _hourlyMs = List.filled(24, 0);
+  // 今日每小时数据（0-23），按写入面（format）分带。v67 前的行没有身份，落在
+  // StatHourlyFormatBand.unattributed，图上单独成带、不归入任何阅读面。
+  StatHourlyBreakdown _hourly = StatHourlyBreakdown();
 
   // 制卡 / 收藏计数（来源 'book'），按今日/本周/本月/全部分桶。
   StatActivityBuckets _mined = StatActivityBuckets();
@@ -200,14 +202,17 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
     final db = appModelNoUpdate.database;
     final todayKey = statTodayKey();
     final rows = await db.getHourlyLogsForDate(todayKey);
-    _hourlyMs = List.filled(24, 0);
+    // v67 起同一小时按写入面（format）分多行。这里不再压成一个合计，而是按带累加：
+    // 图表分色堆叠，`''`（v67 前写入 / 旧端同步差额）如实归 unattributed 带。
+    final StatHourlyBreakdown breakdown = StatHourlyBreakdown();
     for (final row in rows) {
-      if (row.hour >= 0 && row.hour < 24) {
-        // v67 起同一小时按写入面（format）分多行，图表口径是全部阅读面合计，
-        // 必须累加——赋值会只剩最后一行（单一 format 的值）。
-        _hourlyMs[row.hour] += row.readingTimeMs;
-      }
+      breakdown.addMs(
+        band: StatHourlyFormatBand.ofDbValue(row.format),
+        hour: row.hour,
+        ms: row.readingTimeMs,
+      );
     }
+    _hourly = breakdown;
   }
 
   void _computeAggregates() {
@@ -477,7 +482,7 @@ class _ReadingStatisticsPageState extends BasePageState<ReadingStatisticsPage> {
                 SliverToBoxAdapter(child: _buildSourceBreakdown()),
                 SliverToBoxAdapter(child: _buildGoalPanel()),
                 SliverToBoxAdapter(
-                    child: buildStatHourlyChartSection(context, _hourlyMs)),
+                    child: buildStatHourlyFormatChartSection(context, _hourly)),
                 SliverToBoxAdapter(
                   child: Padding(
                     padding: EdgeInsets.fromLTRB(card,

--- a/hibiki/lib/src/pages/implementations/stat_charts.dart
+++ b/hibiki/lib/src/pages/implementations/stat_charts.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:hibiki/src/pages/implementations/stat_hourly_breakdown.dart';
 
 /// 统计图表的每日数据点（阅读统计 / 视频统计共用）。
 class StatDayData {
@@ -62,40 +63,57 @@ String formatStatDurationAxis(int ms) {
   return '0';
 }
 
+/// 今日按小时柱状图的一条**堆叠带**：24 小时的毫秒值 + 填充色。
+///
+/// 单带 = 旧的单色柱（视频统计：观看时长没有阅读面之分）；多带 = 同一根柱子自下
+/// 而上按列表序堆叠（阅读统计按 format 分带）。「一根柱子只有一种颜色」在这里是
+/// 「只有一条带」这个普通情况，不是单独的分支。
+class StatHourlyBand {
+  const StatHourlyBand({required this.values, required this.color});
+
+  /// 0-23 时的毫秒值。长度不足的位置按 0 处理。
+  final List<int> values;
+  final Color color;
+}
+
 /// 今日按小时柱状图画笔（0-23 小时，值为毫秒）。阅读统计与视频统计共用。
 class StatHourlyChartPainter extends CustomPainter {
   StatHourlyChartPainter({
-    required this.hourlyMs,
-    required this.barColor,
+    required this.bands,
     required this.barRadius,
     required this.labelColor,
     required this.labelStyle,
   });
 
-  final List<int> hourlyMs;
-  final Color barColor;
+  final List<StatHourlyBand> bands;
   final Radius barRadius;
   final Color labelColor;
   final TextStyle labelStyle;
 
+  static int _valueAt(StatHourlyBand band, int hour) =>
+      hour < band.values.length ? band.values[hour] : 0;
+
+  /// 某小时所有带的合计（决定柱高与纵轴上限）。
+  int totalAt(int hour) => bands.fold<int>(
+      0, (int sum, StatHourlyBand band) => sum + _valueAt(band, hour));
+
   @override
   void paint(Canvas canvas, Size size) {
-    if (hourlyMs.isEmpty) return;
+    if (bands.isEmpty) return;
 
-    final maxMs = hourlyMs.fold<int>(0, (prev, ms) => ms > prev ? ms : prev);
+    final List<int> totals =
+        List<int>.generate(kStatHourlyBuckets, totalAt, growable: false);
+    final maxMs = totals.fold<int>(0, (prev, ms) => ms > prev ? ms : prev);
     if (maxMs == 0) return;
 
     const bottomPadding = 20.0;
     const leftPadding = 32.0;
     final chartHeight = size.height - bottomPadding;
     final chartWidth = size.width - leftPadding;
-    final step = chartWidth / 24;
+    final step = chartWidth / kStatHourlyBuckets;
     final barWidth = step * 0.7;
     final gap = step * 0.15;
 
-    final paint = Paint()
-      ..color = barColor
-      ..style = PaintingStyle.fill;
     final axisPaint = Paint()
       ..color = labelColor.withValues(alpha: 0.55)
       ..strokeWidth = 1;
@@ -126,16 +144,36 @@ class StatHourlyChartPainter extends CustomPainter {
       tp.paint(canvas, Offset(leftPadding - tp.width - 4, y - tp.height / 2));
     }
 
-    for (int i = 0; i < 24; i++) {
+    for (int i = 0; i < kStatHourlyBuckets; i++) {
       final x = leftPadding + i * step + gap;
-      final barHeight = (hourlyMs[i] / maxMs) * chartHeight;
+      final total = totals[i];
 
-      if (hourlyMs[i] > 0) {
+      if (total > 0) {
+        final barHeight = (total / maxMs) * chartHeight;
         final rect = RRect.fromRectAndRadius(
           Rect.fromLTWH(x, chartHeight - barHeight, barWidth, barHeight),
           barRadius,
         );
-        canvas.drawRRect(rect, paint);
+        // 整根柱子先剪成圆角，各段按普通矩形填进去——圆角只在柱子两端出现，不必
+        // 为「首段 / 末段 / 单段」写三套 RRect 分支。
+        canvas.save();
+        canvas.clipRRect(rect);
+        double segmentBottom = chartHeight;
+        int accumulated = 0;
+        for (final StatHourlyBand band in bands) {
+          final int value = _valueAt(band, i);
+          if (value <= 0) continue;
+          accumulated += value;
+          // 用累计值算上沿而非逐段累加高度：避免每段各取一次舍入后段间出现缝隙。
+          final double segmentTop =
+              chartHeight - (accumulated / maxMs) * chartHeight;
+          canvas.drawRect(
+            Rect.fromLTWH(x, segmentTop, barWidth, segmentBottom - segmentTop),
+            Paint()..color = band.color,
+          );
+          segmentBottom = segmentTop;
+        }
+        canvas.restore();
       }
 
       if (i % 3 == 0) {
@@ -156,11 +194,20 @@ class StatHourlyChartPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant StatHourlyChartPainter oldDelegate) =>
-      !listEquals(hourlyMs, oldDelegate.hourlyMs) ||
-      barColor != oldDelegate.barColor ||
+      !_bandsEqual(bands, oldDelegate.bands) ||
       barRadius != oldDelegate.barRadius ||
       labelColor != oldDelegate.labelColor ||
       labelStyle != oldDelegate.labelStyle;
+
+  static bool _bandsEqual(List<StatHourlyBand> a, List<StatHourlyBand> b) {
+    if (a.length != b.length) return false;
+    for (int i = 0; i < a.length; i++) {
+      if (a[i].color != b[i].color || !listEquals(a[i].values, b[i].values)) {
+        return false;
+      }
+    }
+    return true;
+  }
 }
 
 /// 最近 N 天柱状图画笔。阅读统计默认画字数（[statCharsValue]），视频统计删字数后

--- a/hibiki/lib/src/pages/implementations/stat_hourly_breakdown.dart
+++ b/hibiki/lib/src/pages/implementations/stat_hourly_breakdown.dart
@@ -1,0 +1,88 @@
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 时段图一天的桶数（0-23 时）。
+const int kStatHourlyBuckets = 24;
+
+/// 阅读时段图的**分带身份**：统计 UI 自己的值域，与 [BookFormat] 分开。
+///
+/// 前三带一一对应三个阅读面。[unattributed] 不是第四种书，而是「这段时长在**写入
+/// 那一刻**就没有存身份、现在拆不开」这一事实本身：
+/// - v67 之前 `reading_hourly_logs` 没有 `format` 列，同一小时的 EPUB / PDF / 漫画
+///   时长在写入时就被加成了一行，信息已经丢了，事后没有任何依据能把它分开；
+/// - 云聚合从不带 format 的旧端拿到的逐时差额同样无法归因，落在 `''` 桶
+///   （`addUnattributedHourlyReadingTime`）。
+///
+/// 这些行**不得**被默默归进任何一个阅读面。把它们算进 EPUB 只是让图好看，代价是
+/// 给用户编造一个数据里根本不存在的归属。UI 的义务是把它单独画出来、并写明它是
+/// 未区分的历史合计。
+enum StatHourlyFormatBand {
+  /// 文字书（EPUB / TextToEpub / 有声书配对壳）。
+  epub,
+
+  /// PDF 阅读器。
+  pdf,
+
+  /// 漫画阅读器。
+  manga,
+
+  /// 未区分的历史合计。声明序即堆叠序与图例序，它排在最后 ⇒ 画在柱子**最上层**，
+  /// 紧挨图例，用户一眼能看见「这一截不属于任何一类」。
+  unattributed;
+
+  /// `reading_hourly_logs.format` 列 → 分带身份。
+  ///
+  /// 解析走 [BookFormat.tryParse] 而**不是** [BookFormat.parseOrEpub]：宽松解析把
+  /// 未知串按 EPUB 处理，那条回退对「阅读器路由」是对的（总得打开一个阅读器），
+  /// 对这里是错的——它会把 `''` 的历史行伪装成 EPUB 的真实读书时长。
+  static StatHourlyFormatBand ofDbValue(String raw) {
+    final BookFormat? format = BookFormat.tryParse(raw);
+    if (format == null) return StatHourlyFormatBand.unattributed;
+    return switch (format) {
+      BookFormat.epub => StatHourlyFormatBand.epub,
+      BookFormat.pdf => StatHourlyFormatBand.pdf,
+      BookFormat.manga => StatHourlyFormatBand.manga,
+    };
+  }
+}
+
+/// 今日 0-23 时、按 [StatHourlyFormatBand] 分带的时长（毫秒）。
+///
+/// 只保存**分带**值，不另存一份合计：合计随时可由分带求和得到，多存一份就多一个
+/// 会漂开的真相源。
+class StatHourlyBreakdown {
+  StatHourlyBreakdown();
+
+  final Map<StatHourlyFormatBand, List<int>> _byBand =
+      <StatHourlyFormatBand, List<int>>{};
+
+  /// 累加一行日志。同一 (band, hour) 可能有多行（云同步合并后），故是累加不是赋值。
+  /// 越界 [hour] 直接丢弃（DB 列无 CHECK 约束，脏值不该把图画坏）。
+  void addMs({
+    required StatHourlyFormatBand band,
+    required int hour,
+    required int ms,
+  }) {
+    if (hour < 0 || hour >= kStatHourlyBuckets) return;
+    _byBand.putIfAbsent(
+        band, () => List<int>.filled(kStatHourlyBuckets, 0))[hour] += ms;
+  }
+
+  /// 某一带的 24 小时值；该带无数据时返回全零（调用方不必判空）。
+  List<int> valuesOf(StatHourlyFormatBand band) => List<int>.unmodifiable(
+      _byBand[band] ?? List<int>.filled(kStatHourlyBuckets, 0));
+
+  /// 当日真的有非零时长的带，按枚举声明序。堆叠与图例共用这一个顺序，两边天然一致。
+  List<StatHourlyFormatBand> get activeBands => StatHourlyFormatBand.values
+      .where((StatHourlyFormatBand band) =>
+          (_byBand[band] ?? const <int>[]).any((int ms) => ms > 0))
+      .toList(growable: false);
+
+  /// 当日总时长（毫秒）。
+  int get totalMs => _byBand.values.fold<int>(
+      0,
+      (int sum, List<int> values) =>
+          sum + values.fold<int>(0, (int s, int ms) => s + ms));
+
+  /// 当日无任何时长。
+  bool get isEmpty => activeBands.isEmpty;
+}

--- a/hibiki/lib/src/pages/implementations/stat_shared.dart
+++ b/hibiki/lib/src/pages/implementations/stat_shared.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:hibiki/src/pages/implementations/activity_feed.dart';
 import 'package:hibiki/src/pages/implementations/stat_charts.dart';
+import 'package:hibiki/src/pages/implementations/stat_hourly_breakdown.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
@@ -340,9 +341,85 @@ String formatStatHeatmapDay(String dateKey) {
   return '${d.year}-${d.month}-$dd';
 }
 
-/// 「今日按小时」柱状图区块（标题 + [StatHourlyChartPainter] 画布）。
+/// 「今日按小时」单色柱状图区块（视频统计用：观看时长没有阅读面之分，只有一带）。
 /// [hourlyMs] 为 0-23 每小时的毫秒值。
 Widget buildStatHourlyChartSection(BuildContext context, List<int> hourlyMs) {
+  final colorScheme = Theme.of(context).colorScheme;
+  return _buildStatHourlyChartSection(
+    context,
+    bands: <StatHourlyBand>[
+      StatHourlyBand(values: hourlyMs, color: colorScheme.tertiary),
+    ],
+    legendBands: const <StatHourlyFormatBand>[],
+    showUnattributedNote: false,
+  );
+}
+
+/// 「今日按小时」按阅读面（format）分色堆叠的柱状图区块（阅读统计用）。
+///
+/// [breakdown] 里的 [StatHourlyFormatBand.unattributed] 是 v67 之前写入时就没存
+/// 身份的历史合计，它单独成一带、用中性色、并在图例下附一句说明——**不归入任何一个
+/// 阅读面**。
+Widget buildStatHourlyFormatChartSection(
+  BuildContext context,
+  StatHourlyBreakdown breakdown,
+) {
+  final colorScheme = Theme.of(context).colorScheme;
+  final List<StatHourlyFormatBand> active = breakdown.activeBands;
+  return _buildStatHourlyChartSection(
+    context,
+    bands: <StatHourlyBand>[
+      for (final StatHourlyFormatBand band in active)
+        StatHourlyBand(
+          values: breakdown.valuesOf(band),
+          color: statHourlyBandColor(band, colorScheme),
+        ),
+    ],
+    legendBands: statHourlyLegendBands(active),
+    showUnattributedNote: active.contains(StatHourlyFormatBand.unattributed),
+  );
+}
+
+/// 分带填充色。
+///
+/// 未区分历史刻意用中性的 [ColorScheme.outlineVariant]，而不是第四个品类色：它不是
+/// 一种书，配一个和 EPUB / PDF / 漫画平级的彩色只会让人以为它也是某一类。
+Color statHourlyBandColor(StatHourlyFormatBand band, ColorScheme scheme) =>
+    switch (band) {
+      StatHourlyFormatBand.epub => scheme.tertiary,
+      StatHourlyFormatBand.pdf => scheme.primary,
+      StatHourlyFormatBand.manga => scheme.secondary,
+      StatHourlyFormatBand.unattributed => scheme.outlineVariant,
+    };
+
+/// 分带图例文案。
+String statHourlyBandLabel(StatHourlyFormatBand band) => switch (band) {
+      StatHourlyFormatBand.epub => t.stat_hourly_band_epub,
+      StatHourlyFormatBand.pdf => t.stat_hourly_band_pdf,
+      StatHourlyFormatBand.manga => t.stat_hourly_band_manga,
+      StatHourlyFormatBand.unattributed => t.stat_hourly_band_unattributed,
+    };
+
+/// 该画哪些图例项。
+///
+/// 只有一带、且那一带是真实阅读面时不画图例——「一个条目的图例」不提供任何信息，
+/// 只是噪音。但只要含未区分历史就必须画，哪怕它是唯一一带：没有图例的中性柱子会被
+/// 当成某一类的读书时长，那正是这次要消除的误读。
+List<StatHourlyFormatBand> statHourlyLegendBands(
+    List<StatHourlyFormatBand> activeBands) {
+  if (activeBands.length <= 1 &&
+      !activeBands.contains(StatHourlyFormatBand.unattributed)) {
+    return const <StatHourlyFormatBand>[];
+  }
+  return activeBands;
+}
+
+Widget _buildStatHourlyChartSection(
+  BuildContext context, {
+  required List<StatHourlyBand> bands,
+  required List<StatHourlyFormatBand> legendBands,
+  required bool showUnattributedNote,
+}) {
   final tokens = HibikiDesignTokens.of(context);
   final colorScheme = Theme.of(context).colorScheme;
   return Padding(
@@ -358,8 +435,7 @@ Widget buildStatHourlyChartSection(BuildContext context, List<int> hourlyMs) {
           child: CustomPaint(
             size: Size.infinite,
             painter: StatHourlyChartPainter(
-              hourlyMs: hourlyMs,
-              barColor: colorScheme.tertiary,
+              bands: bands,
               barRadius: tokens.radii.chipCorner,
               labelColor: colorScheme.onSurfaceVariant,
               labelStyle: tokens.type.metadata.copyWith(
@@ -368,8 +444,61 @@ Widget buildStatHourlyChartSection(BuildContext context, List<int> hourlyMs) {
             ),
           ),
         ),
+        if (legendBands.isNotEmpty) ...<Widget>[
+          SizedBox(height: tokens.spacing.gap),
+          Wrap(
+            spacing: tokens.spacing.gap,
+            runSpacing: tokens.spacing.gap / 2,
+            children: <Widget>[
+              for (final StatHourlyFormatBand band in legendBands)
+                _StatHourlyLegendChip(band: band),
+            ],
+          ),
+        ],
+        if (showUnattributedNote) ...<Widget>[
+          SizedBox(height: tokens.spacing.gap),
+          Text(
+            t.stat_hourly_unattributed_note,
+            style: tokens.type.metadata.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
         SizedBox(height: tokens.spacing.card + tokens.spacing.gap),
       ],
     ),
   );
+}
+
+/// 图例一项：与柱子同色的小色块 + 文案。
+class _StatHourlyLegendChip extends StatelessWidget {
+  const _StatHourlyLegendChip({required this.band});
+
+  final StatHourlyFormatBand band;
+
+  @override
+  Widget build(BuildContext context) {
+    final tokens = HibikiDesignTokens.of(context);
+    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Container(
+          width: tokens.spacing.gap,
+          height: tokens.spacing.gap,
+          decoration: BoxDecoration(
+            color: statHourlyBandColor(band, colorScheme),
+            borderRadius: BorderRadius.all(tokens.radii.chipCorner),
+          ),
+        ),
+        SizedBox(width: tokens.spacing.gap / 2),
+        Text(
+          statHourlyBandLabel(band),
+          style: tokens.type.metadata.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/hibiki/test/pages/stat_hourly_format_bands_test.dart
+++ b/hibiki/test/pages/stat_hourly_format_bands_test.dart
@@ -1,0 +1,293 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/src/pages/implementations/stat_charts.dart';
+import 'package:hibiki/src/pages/implementations/stat_hourly_breakdown.dart';
+import 'package:hibiki/src/pages/implementations/stat_shared.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// TODO-2622：统计页时段图按 format 分色堆叠。
+///
+/// 守的核心不是「有几种颜色」，而是**历史数据不得被编造归属**：v67 之前
+/// `reading_hourly_logs` 没有 format 列，那些行在写入时身份就丢了，事后没有任何依据
+/// 能拆开。把它们算进 EPUB 只是让图好看，代价是给用户看一个假的归属。所以它必须
+/// 单独成带、用中性色、并且图例与说明必须显式出现。
+void main() {
+  const ColorScheme scheme = ColorScheme.light();
+  final ThemeData theme = ThemeData(colorScheme: scheme);
+
+  setUp(() => LocaleSettings.setLocale(AppLocale.zhCn));
+
+  Widget wrap(Widget child) => TranslationProvider(
+        child: MaterialApp(
+          theme: theme,
+          home: Scaffold(body: SingleChildScrollView(child: child)),
+        ),
+      );
+
+  /// 从渲染树里取出真正喂给画笔的分带数据。断言「画了什么」而不是「传了什么」。
+  StatHourlyChartPainter painterOf(WidgetTester tester) => tester
+      .widgetList<CustomPaint>(find.byType(CustomPaint))
+      .map((CustomPaint c) => c.painter)
+      .whereType<StatHourlyChartPainter>()
+      .single;
+
+  StatHourlyBreakdown breakdownOf(
+      List<(String format, int hour, int ms)> rows) {
+    final StatHourlyBreakdown b = StatHourlyBreakdown();
+    for (final (String format, int hour, int ms) in rows) {
+      b.addMs(
+        band: StatHourlyFormatBand.ofDbValue(format),
+        hour: hour,
+        ms: ms,
+      );
+    }
+    return b;
+  }
+
+  group('StatHourlyFormatBand.ofDbValue', () {
+    test('三个真实写入面各归各带', () {
+      expect(StatHourlyFormatBand.ofDbValue(BookFormat.epub.dbValue),
+          StatHourlyFormatBand.epub);
+      expect(StatHourlyFormatBand.ofDbValue(BookFormat.pdf.dbValue),
+          StatHourlyFormatBand.pdf);
+      expect(StatHourlyFormatBand.ofDbValue(BookFormat.manga.dbValue),
+          StatHourlyFormatBand.manga);
+    });
+
+    test('空 format（v67 前的历史行 / 旧端同步差额）归未区分带，不归 EPUB', () {
+      expect(StatHourlyFormatBand.ofDbValue(''),
+          StatHourlyFormatBand.unattributed);
+    });
+
+    test('未知 format 串也归未区分带（不走 parseOrEpub 的宽松回退）', () {
+      expect(StatHourlyFormatBand.ofDbValue('srtbook'),
+          StatHourlyFormatBand.unattributed);
+    });
+  });
+
+  group('StatHourlyBreakdown', () {
+    test('同 (带, 小时) 的多行累加，不是覆盖', () {
+      final StatHourlyBreakdown b = breakdownOf(<(String, int, int)>[
+        (BookFormat.epub.dbValue, 9, 1000),
+        (BookFormat.epub.dbValue, 9, 2000),
+      ]);
+      expect(b.valuesOf(StatHourlyFormatBand.epub)[9], 3000);
+      expect(b.totalMs, 3000);
+    });
+
+    test('越界小时被丢弃，不把图画坏', () {
+      final StatHourlyBreakdown b = breakdownOf(<(String, int, int)>[
+        (BookFormat.epub.dbValue, 24, 1000),
+        (BookFormat.epub.dbValue, -1, 1000),
+      ]);
+      expect(b.isEmpty, isTrue);
+      expect(b.totalMs, 0);
+    });
+
+    test('activeBands 只含非零带，按枚举声明序（未区分带排在最后）', () {
+      final StatHourlyBreakdown b = breakdownOf(<(String, int, int)>[
+        ('', 3, 500),
+        (BookFormat.manga.dbValue, 3, 500),
+        (BookFormat.epub.dbValue, 3, 500),
+      ]);
+      expect(b.activeBands, <StatHourlyFormatBand>[
+        StatHourlyFormatBand.epub,
+        StatHourlyFormatBand.manga,
+        StatHourlyFormatBand.unattributed,
+      ]);
+    });
+  });
+
+  group('分色堆叠渲染', () {
+    testWidgets('有 format 的数据按类分带渲染，图例列出每一类', (WidgetTester tester) async {
+      final StatHourlyBreakdown b = breakdownOf(<(String, int, int)>[
+        (BookFormat.epub.dbValue, 9, 600000),
+        (BookFormat.pdf.dbValue, 9, 300000),
+        (BookFormat.manga.dbValue, 20, 120000),
+      ]);
+      await tester.pumpWidget(wrap(Builder(
+        builder: (BuildContext context) =>
+            buildStatHourlyFormatChartSection(context, b),
+      )));
+
+      final StatHourlyChartPainter painter = painterOf(tester);
+      expect(painter.bands.length, 3);
+      expect(painter.bands[0].values[9], 600000);
+      expect(painter.bands[0].color, scheme.tertiary);
+      expect(painter.bands[1].values[9], 300000);
+      expect(painter.bands[1].color, scheme.primary);
+      expect(painter.bands[2].values[20], 120000);
+      expect(painter.bands[2].color, scheme.secondary);
+      // 柱高口径仍是当小时合计，分带没有让总量丢失。
+      expect(painter.totalAt(9), 900000);
+
+      expect(find.text(t.stat_hourly_band_epub), findsOneWidget);
+      expect(find.text(t.stat_hourly_band_pdf), findsOneWidget);
+      expect(find.text(t.stat_hourly_band_manga), findsOneWidget);
+      // 全是有身份的数据，不该冒出「未区分历史」这条。
+      expect(find.text(t.stat_hourly_band_unattributed), findsNothing);
+      expect(find.text(t.stat_hourly_unattributed_note), findsNothing);
+    });
+
+    testWidgets('老数据单独成带：不并进 EPUB，图例与说明都标明它分不开', (WidgetTester tester) async {
+      final StatHourlyBreakdown b = breakdownOf(<(String, int, int)>[
+        (BookFormat.epub.dbValue, 9, 600000),
+        ('', 9, 300000),
+      ]);
+      await tester.pumpWidget(wrap(Builder(
+        builder: (BuildContext context) =>
+            buildStatHourlyFormatChartSection(context, b),
+      )));
+
+      final StatHourlyChartPainter painter = painterOf(tester);
+      expect(painter.bands.length, 2);
+      // 核心：EPUB 带只拿到自己那 600000，历史那 300000 绝不能被加进来。
+      expect(painter.bands[0].values[9], 600000);
+      expect(painter.bands[0].color, scheme.tertiary);
+      // 未区分带用中性描边色，不是第四个品类色。
+      expect(painter.bands[1].values[9], 300000);
+      expect(painter.bands[1].color, scheme.outlineVariant);
+      expect(painter.bands[1].color, isNot(scheme.tertiary));
+      expect(painter.bands[1].color, isNot(scheme.primary));
+      expect(painter.bands[1].color, isNot(scheme.secondary));
+      expect(painter.totalAt(9), 900000);
+
+      expect(find.text(t.stat_hourly_band_unattributed), findsOneWidget);
+      expect(find.text(t.stat_hourly_unattributed_note), findsOneWidget);
+    });
+
+    testWidgets('只有老数据时图例仍然出现——中性柱子不能被当成某一类', (WidgetTester tester) async {
+      final StatHourlyBreakdown b = breakdownOf(<(String, int, int)>[
+        ('', 14, 450000),
+      ]);
+      await tester.pumpWidget(wrap(Builder(
+        builder: (BuildContext context) =>
+            buildStatHourlyFormatChartSection(context, b),
+      )));
+
+      final StatHourlyChartPainter painter = painterOf(tester);
+      expect(painter.bands.length, 1);
+      expect(painter.bands.single.color, scheme.outlineVariant);
+      expect(find.text(t.stat_hourly_band_unattributed), findsOneWidget);
+      expect(find.text(t.stat_hourly_unattributed_note), findsOneWidget);
+      expect(find.text(t.stat_hourly_band_epub), findsNothing);
+    });
+
+    testWidgets('只有一类真实阅读面时不画只有一项的空图例', (WidgetTester tester) async {
+      final StatHourlyBreakdown b = breakdownOf(<(String, int, int)>[
+        (BookFormat.epub.dbValue, 8, 60000),
+        (BookFormat.epub.dbValue, 9, 120000),
+      ]);
+      await tester.pumpWidget(wrap(Builder(
+        builder: (BuildContext context) =>
+            buildStatHourlyFormatChartSection(context, b),
+      )));
+
+      final StatHourlyChartPainter painter = painterOf(tester);
+      expect(painter.bands.length, 1);
+      expect(find.text(t.stat_hourly_band_epub), findsNothing);
+      expect(find.text(t.stat_hourly_band_pdf), findsNothing);
+      expect(find.text(t.stat_hourly_band_manga), findsNothing);
+      expect(find.text(t.stat_hourly_band_unattributed), findsNothing);
+      expect(find.text(t.stat_hourly_unattributed_note), findsNothing);
+    });
+
+    testWidgets('空数据不炸：无带、无图例、无说明', (WidgetTester tester) async {
+      await tester.pumpWidget(wrap(Builder(
+        builder: (BuildContext context) =>
+            buildStatHourlyFormatChartSection(context, StatHourlyBreakdown()),
+      )));
+
+      expect(tester.takeException(), isNull);
+      expect(painterOf(tester).bands, isEmpty);
+      expect(find.text(t.stat_today_hourly), findsOneWidget);
+      expect(find.text(t.stat_hourly_band_epub), findsNothing);
+      expect(find.text(t.stat_hourly_unattributed_note), findsNothing);
+    });
+
+    testWidgets('视频统计的单色入口仍是一带（观看时长没有阅读面之分）', (WidgetTester tester) async {
+      await tester.pumpWidget(wrap(Builder(
+        builder: (BuildContext context) => buildStatHourlyChartSection(
+          context,
+          List<int>.filled(kStatHourlyBuckets, 0)..[5] = 90000,
+        ),
+      )));
+
+      final StatHourlyChartPainter painter = painterOf(tester);
+      expect(painter.bands.length, 1);
+      expect(painter.bands.single.color, scheme.tertiary);
+      expect(painter.totalAt(5), 90000);
+      expect(find.text(t.stat_hourly_band_epub), findsNothing);
+      expect(find.text(t.stat_hourly_unattributed_note), findsNothing);
+    });
+  });
+
+  group('画笔真的堆叠（读回像素）', () {
+    // 画布尺寸与画笔内部常量：bottomPadding=20 / leftPadding=32，chartHeight=120。
+    const double width = 480;
+    const double height = 140;
+    const double chartHeight = height - 20;
+
+    /// 第 [hour] 根柱子的水平中心（对齐画笔的 step / barWidth / gap 计算）。
+    int barCenterX(int hour) {
+      const double step = (width - 32) / kStatHourlyBuckets;
+      const double barWidth = step * 0.7;
+      const double gap = step * 0.15;
+      return (32 + hour * step + gap + barWidth / 2).round();
+    }
+
+    Future<ByteData> renderPixels(StatHourlyChartPainter painter) async {
+      final ui.PictureRecorder recorder = ui.PictureRecorder();
+      painter.paint(Canvas(recorder), const Size(width, height));
+      final ui.Image image =
+          await recorder.endRecording().toImage(width.toInt(), height.toInt());
+      final ByteData? data =
+          await image.toByteData(format: ui.ImageByteFormat.rawRgba);
+      return data!;
+    }
+
+    Color pixelAt(ByteData data, int x, int y) {
+      final int offset = (y * width.toInt() + x) * 4;
+      return Color.fromARGB(
+        data.getUint8(offset + 3),
+        data.getUint8(offset),
+        data.getUint8(offset + 1),
+        data.getUint8(offset + 2),
+      );
+    }
+
+    testWidgets('未区分带画在自己那一截，没有覆盖也没有吞掉真实阅读面那一截', (WidgetTester tester) async {
+      // 9 时：EPUB 600000（下 2/3）+ 未区分 300000（上 1/3），全天最高柱 ⇒ 满高。
+      final StatHourlyChartPainter painter = StatHourlyChartPainter(
+        bands: <StatHourlyBand>[
+          StatHourlyBand(
+            values: List<int>.filled(kStatHourlyBuckets, 0)..[9] = 600000,
+            color: scheme.tertiary,
+          ),
+          StatHourlyBand(
+            values: List<int>.filled(kStatHourlyBuckets, 0)..[9] = 300000,
+            color: scheme.outlineVariant,
+          ),
+        ],
+        barRadius: const Radius.circular(4),
+        labelColor: scheme.onSurfaceVariant,
+        labelStyle: const TextStyle(),
+      );
+      // dart:ui 的 toImage / toByteData 靠真实事件循环推进，testWidgets 默认的
+      // FakeAsync 时钟里它们永远不完成（表现为 10 分钟超时而不是断言失败）。
+      final ByteData pixels =
+          (await tester.runAsync(() => renderPixels(painter)))!;
+      final int x = barCenterX(9);
+
+      // 底部 2/3 是 EPUB 色；顶部 1/3 是未区分的中性色。
+      expect(pixelAt(pixels, x, (chartHeight * 0.85).round()), scheme.tertiary);
+      expect(pixelAt(pixels, x, (chartHeight * 0.5).round()), scheme.tertiary);
+      expect(pixelAt(pixels, x, (chartHeight * 0.15).round()),
+          scheme.outlineVariant);
+    });
+  });
+}


### PR DESCRIPTION
## 为什么

数据层 PR#680（schema v67）已经把 `reading_hourly_logs` 按写入面（`format`）分开存了，但**统计页 UI 一直没做**：`reading_statistics_page.dart` 拿到分带的行之后立刻求和成一根合计柱子（`_hourlyMs[row.hour] += row.readingTimeMs`），`format` 取出来了却被丢掉。用户打开统计页看到的和改造前一模一样。

这个 PR 让那个决策变成用户可见的结果。

## 历史数据怎么表达（本 PR 的核心）

用户当初选 A 的前提是「接受分界线、不伪造、不清除」。v67 之前 `reading_hourly_logs` 没有 `format` 列，EPUB / PDF / 漫画同一小时的时长在**写入那一刻**就被加成了一行——信息已经丢了，事后没有任何依据能把它分开。云聚合从旧端拿到的无法归因差额同理（落 `''` 桶）。

所以：

- 这些行归 `StatHourlyFormatBand.unattributed`，**单独成一带**，绝不并进任何一个阅读面；
- 解析走 `BookFormat.tryParse` 而不是 `parseOrEpub`——后者的宽松回退（未知串按 EPUB）对阅读器路由是对的，对这里是错的，它会把历史行伪装成 EPUB 的真实读书时长；
- 配色用中性的 `ColorScheme.outlineVariant`，**刻意不给它第四个品类色**：它不是一种书，和 EPUB/PDF/漫画平级的彩色只会让人以为它也是某一类；
- 图例**必显示**它，哪怕它是当天唯一一带——没有图例的中性柱子会被当成某一类，那正是要消除的误读；
- 图例下附一句说明：「早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。」

反过来，只有一类**真实阅读面**时不画只有一项的空图例（那不提供信息，只是噪音）。

## 实施

| 文件 | 改动 |
|---|---|
| `stat_hourly_breakdown.dart`（新） | `StatHourlyFormatBand` 独立值域 + `ofDbValue` 边界映射 + `StatHourlyBreakdown` 分带聚合 |
| `stat_charts.dart` | `StatHourlyBand`（值+色）；画笔改收 `List<StatHourlyBand>` 堆叠绘制 |
| `stat_shared.dart` | 新 `buildStatHourlyFormatChartSection` + 图例/说明/配色/文案；旧单色入口保留给视频统计 |
| `reading_statistics_page.dart` | `_hourlyMs` → `_hourly`（分带），不再压成合计 |

绘制上，整根柱子先 `clipRRect` 再把各段按普通矩形填进去，圆角自然只出现在柱子两端——不必为「首段/末段/单段」写三套 `RRect` 分支；段上沿用累计值算而非逐段累加高度，避免舍入后段间出现缝隙。

`video_statistics_page.dart` 未改：观看时长没有阅读面之分，走单带入口，行为完全不变。

## 测试

`test/pages/stat_hourly_format_bands_test.dart`，13 例：值域映射 / 累加与越界 / 有 format 分带渲染 / **老数据单独成带不并进 EPUB** / 只有老数据仍显示图例 / 单一阅读面不出空图例 / 空数据不炸 / 视频单色入口不变 / **读回像素验证真的堆叠**。

7 个变异逐个实测转红（反向文本替换还原，未用 `git checkout`）：

| 变异 | 转红用例 |
|---|---|
| `ofDbValue` 改走 `parseOrEpub` | 5 例（含「老数据单独成带」「只有老数据时图例仍出现」） |
| 图例规则去掉未区分例外 | 「只有老数据时图例仍然出现」 |
| 图例恒显示 | 「只有一类真实阅读面时不画只有一项的空图例」 |
| 未区分说明恒隐藏 | 2 例 |
| 未区分带改用 EPUB 品类色 | 2 例 |
| 画笔堆叠顺序反转 | 像素回读用例 |
| `addMs` 赋值而非累加 | 「同 (带, 小时) 的多行累加」 |

## 门禁

- `flutter analyze`（含 test 目录）：`No issues found!`
- `FLUTTER TEST VERDICT: PASSED - 252 tests ran, all tests passed`（新测试 + `md3_design_system_static_test` + `source_guard_adoption_test` + `book_format_discipline_guard_test` + `test/i18n` 全目录 + 10 个相邻 stat/统计页测试）

未 bump `+build`（整合线统一 bump）；未动 schema、未做迁移。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
