### PR TITLE
fix(windows): WebView2 鼠标键状态全量跟随 ev.buttons，止右键后点击查词失效 (BUG-1419)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1323 条。点号进各自文件。
+> 共 1324 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1419](bugs/BUG-1419-webview2-sticky-mouse-buttons-block-lookup.md) | ✅ | ✅ | Windows 阅读器右键后左键点击只出蓝色选区、查词失效（WebView2 鼠标键状态粘滞） |
 | [BUG-1417](bugs/BUG-1417-anime-download-added-activity.md) | ✅ | ✅ | 番剧下载自动入库不记 added 活动事件 |
 | [BUG-1416](bugs/BUG-1416-netflix-still-frame-at-mine-time.md) | ✅ | ✅ | Netflix 沉浸捕获选静态帧时取的是片段首帧，不是制卡那一刻的帧 |
 | [BUG-1415](bugs/BUG-1415-ci-mextension-upstream-404.md) | ✅ | ✅ | CI macos/windows/publish 全红：Mihon 桌面 runtime 构建 git clone 已 404 的 M-Extension-Server |

--- a/docs/bugs/BUG-1419-webview2-sticky-mouse-buttons-block-lookup.md
+++ b/docs/bugs/BUG-1419-webview2-sticky-mouse-buttons-block-lookup.md
@@ -1,0 +1,20 @@
+## BUG-1419 · Windows 阅读器右键后左键点击只出蓝色选区、查词失效（WebView2 鼠标键状态粘滞）
+
+- **报告**：2026-08-02（用户：书籍里面，右键复制以后，点击查词只会出现原生蓝色的高亮，查不了词。平台 Windows 桌面，「点击查词」= 鼠标左键单击一个词）
+- **真实性**：✅ 真 bug（架构缺陷已静态确证；真机复现待用户在 Windows 验证，见备注）。与 BUG-927 同症状不同层：927 修的是阅读器 JS 手势层（早退条件 + 复制后清选区，修复仍在、守卫仍绿），本条在其**下游的平台层**——fork 的 WebView2 鼠标键状态同步。
+  - 根因：`packages/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.h:71` 的 `VirtualKeyState::set()` 是**粘滞增量位集**——只有 `setPointerButton` 的 down/up 会翻转 `MK_*` 位，没有任何自愈路径；而 `custom_platform_view.dart` 旧实现（`onPointerDown`）把 `ev.buttons` **整个位掩码**喂给只接受单个位的 `_getButton`，结果存进 `_downButtons[ev.pointer]` 的是**单值** `PointerButton`。
+  - 触发：`ev.buttons` 在多键并按时是复合值（左|右 = `kPrimaryMouseButton | kSecondaryMouseButton` = 3），`_getButton(3)` 落进 `default → PointerButton.none`，**覆盖掉**该 pointer 已记的按钮；抬起时 `_downButtons.remove` 取回 `none` → 对应的 button-up **永远发不到 WebView2**。同族触发还有：模态路由（阅读器右键走 `_showReaderTextContextMenu` → `showMenu` 的 `PopupRoute`）期间指针序列被打断、指针在 WebView 之外抬起。
+  - 后果：`MK_*` 位永久卡死。此后每个 `SendMouseInput(MOVE, virtualKeys_.state(), ...)`（`in_app_webview.cpp:1893`）都带着「某键仍按住」进 Blink，被判成**拖拽**：鼠标一动就把正文刷成**原生蓝色选区**，而 click 不成立 → 阅读器 `_gestureEnd` 的 tap 分支（`webview.part.dart:1093`）拿不到干净的点击，`selectText` → `onTextSelected` → 查词弹窗整条链永久失效。旧实现按 pointer id 分桶，而 hover 是**另一个 pointer id**，所以残留位连「移动鼠标」都无法自愈，只能重启 app。
+  - 为什么是 Windows 独有：Android/iOS/macOS 的 WebView 是真平台视图，指针由系统直送；只有 Windows 合成模式经 fork 手工转发鼠标状态，才存在这份可漂移的副本。
+- **[x] ① 已修复** — 状态所有权归一：按钮真值唯一来源是 Flutter 每个指针事件自带的 `ev.buttons` 掩码，fork 不再维护可漂移的副本。
+  - `custom_platform_view.dart`：删除 `_downButtons` 单值记账，改为单个全局 `_mouseButtons` 掩码（鼠标是单一设备，状态天然全局——按 pointer id 分桶正是 hover 无法自愈的原因）。
+  - 新增纯函数 `diffMouseButtonMasks(previous, next)`：逐位比对，只对**变化**的位产出一次 down/up 翻转，掩码未变返回空表（按住不动时重发 down 会污染 Blink 拖拽判定）。
+  - `onPointerHover / Down / Up / Cancel / Move` 五个非触摸入口统一调 `_syncMouseButtons(ev.buttons)`。hover 的掩码恒为 0，成为**残留位的自愈点**：任何原因漏发的 up 都会在用户下一次移动鼠标时补上，不再需要重启 app。触摸路径（`_setPointerUpdate`）不受影响。
+  - 提交：（见 PR）
+- **[x] ② 已加自动化测试** — 两层：
+  - 行为层 `packages/flutter_inappwebview_windows/test/mouse_button_mask_diff_test.dart`（7 例）：单键成对、右键不再被当成 none、**多键并按各自成对**（根因用例）、掩码归 0 时补齐所有残留位、未变化不下发。
+  - 结构层 `hibiki/test/reader/webview2_mouse_button_sync_guard_test.dart`（4 例，进 CI 单测门）：钉死 `_downButtons` 不得复活、`_getButton` 不得再吃整个掩码、五个入口都接线、差分必须走纯函数且跳过未变化位。fork 包自己的 test 目录不进 CI（真门只跑 `hibiki/test`），故结构守卫放 hibiki 侧。
+  - 变异实测：删掉一处 `_syncMouseButtons(ev.buttons)` → 守卫报「实际只有 4 处」变红；把 `if (wasDown == isDown) continue;` 改成恒假 → 守卫与行为单测同时变红。两次均反向替换还原并逐字节核对。
+- **备注**：
+  - 与 BUG-927 的关系：927 的三处修复（pointerup 早退只认 `nativeMoved`、两处 copy 后 `_clearReaderAppSelection`、右键 eval try/catch）**全部仍在且守卫全绿**，本条不是它的回退。927 修好了「JS 侧残留选区吞点击」，但当平台层把 MOVE 标成拖拽时，蓝色选区是 Blink **持续重建**的，JS 侧 `clearSelection` 清完立刻又被画回来——所以症状复现而根因在下游。
+  - 真机验证缺口：本机未复现原始失败路径（需 Windows 真实鼠标序列 + WebView2 合成渲染，离屏 itest 的既有冒烟目标长期红、且合成鼠标绕不过 fork 转发层）。架构缺陷本身由源码确证并有行为单测覆盖；**是否根治用户症状需在 Windows 构建后按原路径复测**：拖选 → 右键 → 复制 → 左键单击一个词 → 应正常弹词典。

--- a/hibiki/test/reader/webview2_mouse_button_sync_guard_test.dart
+++ b/hibiki/test/reader/webview2_mouse_button_sync_guard_test.dart
@@ -1,0 +1,63 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// BUG-1419 源码守卫：Windows fork 的鼠标键状态必须全量跟随 Flutter 的 `ev.buttons`
+/// 掩码，不得回到「按 pointer id 记单个 PointerButton」的粘滞增量实现。
+///
+/// 为什么在 hibiki 侧做源码扫描：真值来源 `custom_platform_view.dart` 属 vendored fork
+/// （`packages/flutter_inappwebview_windows`），它自己的 test 目录不进 CI 的 unit test
+/// 门（真门是 Build Release APK 的 Run unit tests，只跑 `hibiki/test`）。行为侧差分逻辑
+/// 已由该包的 `test/mouse_button_mask_diff_test.dart` 覆盖；这里钉死接线结构，防回退。
+///
+/// 回归形态：WebView2 的 `VirtualKeyState`（windows/in_app_webview/in_app_webview.h）是
+/// 纯增量位集，只有 down/up 会翻转、没有自愈。一旦某个 button-up 发不出去（多键并按被
+/// `_getButton` 映射成 none、模态路由夺走 up、指针在 WebView 外抬起），`MK_*` 位就永久
+/// 卡死；此后每个 MOVE 都带着「某键仍按住」进 Blink → 鼠标一动就把正文刷成原生蓝色选区、
+/// click 不成立 → 阅读器点击查词永久失效（用户报「右键复制以后点击查词只出蓝色高亮」）。
+void main() {
+  final File view = File(
+      '../packages/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart');
+
+  late String src;
+
+  setUpAll(() {
+    expect(view.existsSync(), isTrue,
+        reason: 'custom_platform_view.dart 不存在，fork 路径变了须更新守卫');
+    src = view.readAsStringSync().replaceAll('\r\n', '\n');
+  });
+
+  test('按钮状态不得再按 pointer id 记单值 PointerButton', () {
+    expect(src.contains('_downButtons'), isFalse,
+        reason: 'BUG-1419 回退：_downButtons 单值记账无法表达多键并按，'
+            '复合掩码会被映射成 none 并覆盖已记按钮 → button-up 永久丢失');
+  });
+
+  test('掩码不得整体喂给单键映射函数', () {
+    // `_getButton` 只接受单个位（kPrimaryMouseButton 等）；把 ev.buttons 整体传进去，
+    // 左|右 = 3 会落进 default → PointerButton.none，正是 BUG-1419 的根因。
+    expect(src.contains('_getButton(ev.buttons)'), isFalse,
+        reason: 'BUG-1419 回退：ev.buttons 是位掩码，必须逐位差分而非整体映射成单键');
+  });
+
+  test('五个非触摸指针入口都全量同步 ev.buttons', () {
+    expect(src.contains('void _syncMouseButtons(int buttons)'), isTrue,
+        reason: '全量同步入口被改名/删除，守卫须同步更新');
+    // hover / down / up / cancel / move 各一处：hover 的掩码恒 0，是残留位唯一可靠的
+    // 自愈点；缺任何一处都会让某类漏发的 up 无法补上。
+    final int calls = '_syncMouseButtons(ev.buttons)'.allMatches(src).length;
+    expect(calls, greaterThanOrEqualTo(5),
+        reason: 'onPointerHover / Down / Up / Cancel / Move 五个入口都必须调用，'
+            '实际只有 $calls 处');
+  });
+
+  test('同步走纯函数差分，且差分只对变化位产出翻转', () {
+    expect(src.contains('diffMouseButtonMasks(_mouseButtons, buttons)'), isTrue,
+        reason: '_syncMouseButtons 必须复用可单测的纯函数 diffMouseButtonMasks');
+    expect(src.contains('List<MouseButtonTransition> diffMouseButtonMasks('),
+        isTrue,
+        reason: 'diffMouseButtonMasks 是 BUG-1419 的真值来源，不得内联回 State');
+    expect(src.contains('if (wasDown == isDown) continue;'), isTrue,
+        reason: '未变化的位必须跳过：按住不动时重发 down 会污染 Blink 的拖拽判定');
+  });
+}

--- a/packages/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
+++ b/packages/flutter_inappwebview_windows/lib/src/in_app_webview/custom_platform_view.dart
@@ -72,6 +72,35 @@ PointerButton _getButton(int value) {
   }
 }
 
+/// 一次要发给 WebView2 的按钮状态翻转（[button] 在 [isDown] 方向上变化）。
+typedef MouseButtonTransition = ({PointerButton button, bool isDown});
+
+/// 位掩码 → 单键的顺序表，[diffMouseButtonMasks] 逐位比对用。
+const List<int> kMouseButtonMasks = <int>[
+  kPrimaryMouseButton,
+  kSecondaryMouseButton,
+  kTertiaryButton,
+];
+
+/// BUG-1419：算出从按钮掩码 [previous] 到 [next] 需要补发的 down/up 序列。
+///
+/// WebView2 侧的 `VirtualKeyState`（in_app_webview.h）是粘滞增量位集，没有自愈；
+/// 因此按钮真值必须唯一来源于 Flutter 指针事件自带的 `buttons` 掩码，逐位补差。
+/// 只对**变化**的位产出一次翻转：掩码相同则返回空表（不产生冗余 SendMouseInput），
+/// 多键并按各自独立成对，任何一次丢失的 up 都会在下一个掩码为 0 的事件（hover）
+/// 被补上。
+List<MouseButtonTransition> diffMouseButtonMasks(int previous, int next) {
+  if (previous == next) return const <MouseButtonTransition>[];
+  final List<MouseButtonTransition> transitions = <MouseButtonTransition>[];
+  for (final int mask in kMouseButtonMasks) {
+    final bool wasDown = (previous & mask) != 0;
+    final bool isDown = (next & mask) != 0;
+    if (wasDown == isDown) continue;
+    transitions.add((button: _getButton(mask), isDown: isDown));
+  }
+  return transitions;
+}
+
 const MethodChannel _pluginChannel = IN_APP_WEBVIEW_STATIC_CHANNEL;
 
 /// setSize 去抖判定（TODO-428/420）。
@@ -331,7 +360,21 @@ class CustomPlatformView extends StatefulWidget {
 
 class _CustomPlatformViewState extends State<CustomPlatformView> {
   final GlobalKey _key = GlobalKey();
-  final _downButtons = <int, PointerButton>{};
+
+  /// BUG-1419：WebView2 侧的鼠标键状态（`VirtualKeyState`，in_app_webview.h）是
+  /// **粘滞增量**位集——只有 `setPointerButton` 的 down/up 会翻转它，没有任何自愈。
+  /// 旧实现按 pointer id 记一个**单值** `PointerButton`，把整个 `ev.buttons` 掩码喂给
+  /// `_getButton`；而该掩码在同时按住两个键时是复合值（左|右 = 3），
+  /// `_getButton` 落进 `default → none`，覆盖掉已记的按钮 → 抬起时发不出对应的
+  /// button-up → WebView2 的 `MK_*` 位**永久卡死**。此后每个 MOVE 都带着「某键仍按住」
+  /// 送进 Blink，被判成拖拽：鼠标一动就把正文刷成原生蓝色选区，且 click 不成立
+  /// （查词 tap 链因此永久失效，见 docs/bugs/BUG-1419）。
+  ///
+  /// 根因修复：按钮真值唯一来源是 Flutter 每个指针事件自带的 `ev.buttons` 掩码，
+  /// fork 不再维护可漂移的副本。这里只保存「上一次同步给 native 的掩码」用于算差分，
+  /// 逐位补发 down/up。鼠标是单一设备，状态天然全局，故**不按 pointer id 分桶**——
+  /// 那正是旧实现无法用 hover（另一个 pointer id）自愈残留的原因。
+  int _mouseButtons = 0;
 
   PointerDeviceKind _pointerKind = PointerDeviceKind.unknown;
 
@@ -386,6 +429,20 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
     );
   }
 
+  /// 把 [buttons]（Flutter 指针事件的按钮位掩码）全量同步给 WebView2。
+  ///
+  /// 每个非触摸指针事件都调用它：`onPointerHover` 的掩码恒为 0，所以任何原因漏掉的
+  /// button-up（模态路由夺走 up、指针在 WebView 外抬起、多键并按）都会在用户下一次
+  /// 移动鼠标时自愈，不再需要重启 app。差分本身是纯函数
+  /// [diffMouseButtonMasks]（可单测）。
+  void _syncMouseButtons(int buttons) {
+    for (final MouseButtonTransition t
+        in diffMouseButtonMasks(_mouseButtons, buttons)) {
+      _controller._setPointerButtonState(t.button, t.isDown);
+    }
+    _mouseButtons = buttons;
+  }
+
   Widget _buildInner() {
     return NotificationListener<SizeChangedLayoutNotification>(
         onNotification: (notification) {
@@ -404,6 +461,9 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                         return;
                       }
                       _controller._setCursorPos(ev.localPosition);
+                      // BUG-1419：hover 的语义就是「当前没有任何键按下」，是残留
+                      // MK_* 位唯一可靠的自愈点。坐标先同步，补发的 up 才落在实处。
+                      _syncMouseButtons(ev.buttons);
                     },
                     onPointerDown: (ev) {
                       _reportSurfaceSize();
@@ -428,9 +488,7 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                             ev.pressure);
                         return;
                       }
-                      final button = _getButton(ev.buttons);
-                      _downButtons[ev.pointer] = button;
-                      _controller._setPointerButtonState(button, true);
+                      _syncMouseButtons(ev.buttons);
                     },
                     onPointerUp: (ev) {
                       _pointerKind = ev.kind;
@@ -443,10 +501,9 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                             ev.pressure);
                         return;
                       }
-                      final button = _downButtons.remove(ev.pointer);
-                      if (button != null) {
-                        _controller._setPointerButtonState(button, false);
-                      }
+                      // PointerUpEvent.buttons 是**抬起之后**仍按住的键，多键并按时
+                      // 只清掉真正松开的那一位。
+                      _syncMouseButtons(ev.buttons);
                     },
                     onPointerCancel: (ev) {
                       _pointerKind = ev.kind;
@@ -463,10 +520,9 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                             ev.pressure);
                         return;
                       }
-                      final button = _downButtons.remove(ev.pointer);
-                      if (button != null) {
-                        _controller._setPointerButtonState(button, false);
-                      }
+                      // 取消 = 该指针的所有键都不再按住（Flutter 的 cancel 事件
+                      // buttons 已为 0，这里显式走同一条差分路径补发 up）。
+                      _syncMouseButtons(ev.buttons);
                     },
                     onPointerMove: (ev) {
                       _pointerKind = ev.kind;
@@ -479,6 +535,9 @@ class _CustomPlatformViewState extends State<CustomPlatformView> {
                             ev.pressure);
                       } else {
                         _controller._setCursorPos(ev.localPosition);
+                        // 拖动中掩码变化（第二个键按下/松开）也必须逐位补发，
+                        // 否则又会退化成旧的粘滞状态。
+                        _syncMouseButtons(ev.buttons);
                       }
                     },
                     onPointerSignal: (signal) {

--- a/packages/flutter_inappwebview_windows/test/mouse_button_mask_diff_test.dart
+++ b/packages/flutter_inappwebview_windows/test/mouse_button_mask_diff_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_inappwebview_windows/src/in_app_webview/custom_platform_view.dart';
+
+/// BUG-1419：WebView2 鼠标键状态粘滞。
+///
+/// WebView2 侧的 `VirtualKeyState`（windows/in_app_webview/in_app_webview.h）是纯
+/// 增量位集：只有 `setPointerButton` 的 down/up 会翻转它，没有任何自愈。旧实现把
+/// `ev.buttons`（位掩码）用 `_getButton` 映射成**单个** `PointerButton` 存进
+/// `_downButtons[ev.pointer]`，多键并按时掩码是复合值（左|右 = 3）→ 落进 default →
+/// `none`，覆盖掉已记的按钮 → 抬起时发不出 button-up → `MK_*` 位永久卡死。之后每个
+/// MOVE 都带着「某键仍按住」进 Blink，鼠标一动就把正文刷成原生蓝色选区，click 不
+/// 成立、查词 tap 链永久失效。
+///
+/// [diffMouseButtonMasks] 是修复后的真值来源：逐位补差，保证 down/up 严格配对。
+void main() {
+  group('diffMouseButtonMasks', () {
+    test('掩码未变时不产生任何下发', () {
+      expect(diffMouseButtonMasks(0, 0), isEmpty);
+      expect(diffMouseButtonMasks(kPrimaryMouseButton, kPrimaryMouseButton),
+          isEmpty,
+          reason: '按住不动的每一个 move 都重发 down 会污染 Blink 的拖拽判定');
+    });
+
+    test('单键按下与抬起各产生一次配对翻转', () {
+      final down = diffMouseButtonMasks(0, kPrimaryMouseButton);
+      expect(down, hasLength(1));
+      expect(down.single.button, PointerButton.primary);
+      expect(down.single.isDown, isTrue);
+
+      final up = diffMouseButtonMasks(kPrimaryMouseButton, 0);
+      expect(up, hasLength(1));
+      expect(up.single.button, PointerButton.primary);
+      expect(up.single.isDown, isFalse);
+    });
+
+    test('右键同样成对，不会被当成 none 丢掉', () {
+      final down = diffMouseButtonMasks(0, kSecondaryMouseButton);
+      expect(down.single.button, PointerButton.secondary);
+      expect(down.single.isDown, isTrue);
+      final up = diffMouseButtonMasks(kSecondaryMouseButton, 0);
+      expect(up.single.button, PointerButton.secondary);
+      expect(up.single.isDown, isFalse);
+    });
+
+    test('BUG-1419 根因：多键并按不再退化成 none，两个键各自成对', () {
+      // 左键按住时再按右键：ev.buttons = 3。旧实现 _getButton(3) → none，
+      // 覆盖掉已记的 primary，之后无论怎么抬手都发不出 primary 的 up。
+      const int both = kPrimaryMouseButton | kSecondaryMouseButton;
+      final add = diffMouseButtonMasks(kPrimaryMouseButton, both);
+      expect(add, hasLength(1), reason: '只有新增的右键需要下发，左键不重发');
+      expect(add.single.button, PointerButton.secondary);
+      expect(add.single.isDown, isTrue);
+
+      // 先松右键：只清右键，左键仍按住。
+      final releaseRight = diffMouseButtonMasks(both, kPrimaryMouseButton);
+      expect(releaseRight, hasLength(1));
+      expect(releaseRight.single.button, PointerButton.secondary);
+      expect(releaseRight.single.isDown, isFalse);
+
+      // 从两键直接回到 0（例如指针在 WebView 外抬起后收到 hover）：两个键都补 up。
+      final releaseBoth = diffMouseButtonMasks(both, 0);
+      expect(releaseBoth, hasLength(2));
+      expect(releaseBoth.every((t) => !t.isDown), isTrue);
+      expect(
+        releaseBoth.map((t) => t.button).toSet(),
+        <PointerButton>{PointerButton.primary, PointerButton.secondary},
+      );
+    });
+
+    test('掩码为 0 的事件（hover）能自愈任何残留位', () {
+      // hover 的语义就是「没有任何键按下」，是漏掉的 up 唯一可靠的补发点。
+      const int stuck = kPrimaryMouseButton |
+          kSecondaryMouseButton |
+          kTertiaryButton;
+      final healed = diffMouseButtonMasks(stuck, 0);
+      expect(healed, hasLength(3), reason: '三个卡住的键都要补 up');
+      expect(healed.every((t) => !t.isDown), isTrue);
+    });
+
+    test('中键与其它键互不干扰', () {
+      final t = diffMouseButtonMasks(kPrimaryMouseButton,
+          kPrimaryMouseButton | kTertiaryButton);
+      expect(t, hasLength(1));
+      expect(t.single.button, PointerButton.tertiary);
+      expect(t.single.isDown, isTrue);
+    });
+
+    test('掩码表只覆盖三个真实鼠标键，顺序稳定', () {
+      expect(kMouseButtonMasks, <int>[
+        kPrimaryMouseButton,
+        kSecondaryMouseButton,
+        kTertiaryButton,
+      ]);
+    });
+  });
+}


### PR DESCRIPTION
## 用户症状

Windows 桌面，书籍里**右键复制之后，鼠标左键单击一个词只出现原生蓝色高亮，查不了词**（2026-08-02 报）。

## 根因（平台层，不是 BUG-927 的回退）

BUG-927 的三处修复全部仍在、守卫仍绿。它修的是阅读器 **JS 手势层**；本条在其下游的 **Windows 平台层**：

- `packages/flutter_inappwebview_windows/windows/in_app_webview/in_app_webview.h:71` 的 `VirtualKeyState::set()` 是**粘滞增量位集**——只有 `setPointerButton` 的 down/up 翻转 `MK_*` 位，没有任何自愈。
- `custom_platform_view.dart` 旧实现把 `ev.buttons` **整个位掩码**喂给只接受单个位的 `_getButton`。多键并按时掩码是复合值（左|右 = 3）→ 落进 `default → PointerButton.none` → **覆盖掉** `_downButtons[ev.pointer]` 里已记的按钮 → 抬起时取回 `none`，对应的 **button-up 永远发不到 WebView2**。
- 后果：`MK_*` 位永久卡死。此后每个 `SendMouseInput(MOVE, virtualKeys_.state(), ...)` 都带着「某键仍按住」进 Blink，被判成**拖拽** → 鼠标一动就把正文刷成原生蓝色选区，click 不成立 → `_gestureEnd` 的 tap 分支拿不到干净点击，`selectText → onTextSelected →` 查词弹窗整条链失效。
- 旧实现按 pointer id 分桶，而 hover 是**另一个 pointer id**，残留位连移动鼠标都无法自愈，只能重启 app。
- Windows 独有：其它平台 WebView 是真平台视图、指针由系统直送；只有 Windows 合成模式经 fork 手工转发，才有这份可漂移的副本。

## 修复：状态所有权归一

按钮真值唯一来源是 Flutter 每个指针事件自带的 `ev.buttons` 掩码，fork 不再维护可漂移副本。

- 删 `_downButtons` 单值记账 → 单个全局 `_mouseButtons` 掩码（鼠标是单一设备，状态天然全局；按 pointer id 分桶正是 hover 无法自愈的原因）。
- 新增纯函数 `diffMouseButtonMasks(previous, next)`：逐位比对，只对**变化**的位产出一次翻转；掩码未变返回空表（按住不动重发 down 会污染 Blink 拖拽判定）。
- `onPointerHover / Down / Up / Cancel / Move` 五个非触摸入口统一 `_syncMouseButtons(ev.buttons)`。**hover 掩码恒 0，成为残留位的自愈点**：任何原因漏发的 up 都会在下一次移动鼠标时补上。触摸路径（`_setPointerUpdate`）不受影响。

## 测试

- 行为层 `packages/flutter_inappwebview_windows/test/mouse_button_mask_diff_test.dart`（7 例）：单键成对、右键不再被当 none、**多键并按各自成对**（根因用例）、掩码归 0 补齐所有残留位、未变化不下发。
- 结构层 `hibiki/test/reader/webview2_mouse_button_sync_guard_test.dart`（4 例，进 CI 单测门；fork 包自己的 test 不进）：`_downButtons` 不得复活、`_getButton` 不得再吃整个掩码、五个入口都接线、差分走纯函数且跳过未变化位。
- **变异实测**：删一处 `_syncMouseButtons(ev.buttons)` → 守卫报「实际只有 4 处」变红；`if (wasDown == isDown) continue;` 改恒假 → 守卫与行为单测**同时**变红。均反向替换还原并逐字节核对。
- `flutter analyze` 全绿（fork 包 2 个 issue 为改动前既有，位于未触碰文件）；`test/reader` 定向 `FLUTTER TEST VERDICT: PASSED - 1304 tests ran`。

## 待验证（draft 原因）

本机未复现原始失败路径——需 Windows 真实鼠标序列 + WebView2 合成渲染，离屏 itest 的既有冒烟目标长期红且合成鼠标绕不过 fork 转发层。架构缺陷本身由源码确证并有行为单测覆盖，**是否根治用户症状需在 Windows 构建后按原路径复测**：拖选 → 右键 → 复制 → 左键单击一个词 → 应正常弹词典。

档案：`docs/bugs/BUG-1419-webview2-sticky-mouse-buttons-block-lookup.md`

https://claude.ai/code/session_01Ec1mWh1wuVwvwnBGLmdcZH