### PR TITLE
fix(reader): 双页 spread 页补自带滚轮/横扫/键桥，翻页不再失效 (BUG-1419)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1323 条。点号进各自文件。
+> 共 1324 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1419](bugs/BUG-1419-spread-input-bridges.md) | ✅ | ✅ | 双页 spread 页滚轮与左右翻页失效 |
 | [BUG-1417](bugs/BUG-1417-anime-download-added-activity.md) | ✅ | ✅ | 番剧下载自动入库不记 added 活动事件 |
 | [BUG-1416](bugs/BUG-1416-netflix-still-frame-at-mine-time.md) | ✅ | ✅ | Netflix 沉浸捕获选静态帧时取的是片段首帧，不是制卡那一刻的帧 |
 | [BUG-1415](bugs/BUG-1415-ci-mextension-upstream-404.md) | ✅ | ✅ | CI macos/windows/publish 全红：Mihon 桌面 runtime 构建 git clone 已 404 的 M-Extension-Server |

--- a/docs/bugs/BUG-1419-spread-input-bridges.md
+++ b/docs/bugs/BUG-1419-spread-input-bridges.md
@@ -1,0 +1,71 @@
+## BUG-1419 · 双页 spread 页滚轮与左右翻页失效
+- **报告**：2026-08-02（用户截图：EPUB 轻小说彩插被自动配成双页展开，"进入这个界面以后，滚轮和左右翻页失效"）
+- **真实性**：✅ 真 bug。根因是 **BUG-1280 ③ 的守卫留下的账**，不是新回归：
+  - spread 页是 `buildSpreadPageHtml`（`hibiki/lib/src/pages/implementations/reader_hibiki_page.dart:497`）
+    生成的**独立文档**（第四种，继歌词 BUG-756 / VN BUG-1195 / spread BUG-1280）。它原本
+    自带的桥只有三条：`onImageTap`（点图片看原图）、`onSpreadTapEmpty`（点留白唤底栏）、
+    `spreadReady`（就绪信号）。**一条翻页输入都没有。**
+  - 而滚轮（`wheel` → `onWheelPaginate`）、横扫（`touchend` → `onSwipe`）、键桥
+    （`webViewKeyBridgeScript`）**全长在正文引擎里**，由
+    `_onChapterLoadComplete`（`reader_hibiki/webview.part.dart:2528`）注入——那里第一句就是
+    BUG-1280 ③ 的守卫：`if (_spreadDocumentLoaded) return;`。于是 spread 文档一条都拿不到。
+  - 两个平台的到达路径不同，结果相同：
+    - **Windows**：`loadData` 的原生实现是 `NavigateToString`（丢 baseUrl），`onLoadStop`
+      的陈旧判据只比 `Uri.path` → 判 stale → 正文引擎**从来**没注入过 spread 文档。
+      所以 Windows 上双页页面**自始至终**没有滚轮翻页，不是本次才坏的。
+    - **Android**：`loadDataWithBaseURL` 保留 baseUrl → 判据放行 → BUG-1280 修复**之前**
+      顺带白捡过正文引擎的滚轮/横扫/键桥；守卫落地后一并消失。BUG-1280 备注里已明确记账
+      （"Android 用户在双页页面上会失去滑动翻页…不得淡化"）并留了 TODO：**"给 spread
+      独立文档补它自己的 onSwipe 脚本 + 键桥"**。本条就是那笔账。
+  - 键盘那一半还叠了 TODO-1078 / BUG-136 同源的焦点问题：Windows 的 WebView2 一旦持有 OS
+    焦点，按键只存在于 DOM 里，Flutter 的 `Focus.onKeyEvent` 收不到——正文靠注入的键桥回传，
+    spread 文档没有键桥，所以方向键也一起没反应。
+  - **用户为什么会进到这个界面**：生产库 `src:reader_ttu:ttu_spread_mode = 'auto'`（**显式存值**，
+    BUG-1280 把默认改成 `off` 只对没设置过的用户生效），且该书的边缘匹配缓存
+    `spread_match:安達としまむら = {"0":true,...,"7":true}` 有成对页 → 自动配成双页。
+    截图那本是 `epub_books.format='epub'` 的轻小说（安達としまむら系列），走 reader 路径，
+    与 BUG-1280 里"轻小说彩插 + rendition:spread"是同一类。
+- **[x] ① 已修复** — 让 spread 独立文档**自带**三条输入通道，且**全部直连既有 Dart handler**，
+  Dart 侧不新增任何翻页语义（节流 / 跨章冷却 / 虚拟页翻页仍是 `_paginate` →
+  `_handlePageTurnLimit` 那一份）：
+  - **滚轮**：`buildSpreadPageHtml` 加文档级 `wheel` 监听 → `onWheelPaginate(dir, axis)`，
+    与正文 `_handlePagedWheelTick` 逐字同款语义（主轴取绝对值更大的那个，`delta > 0` =
+    forward，`preventDefault`）。Dart 侧 handler 未改。
+  - **横扫**：`touchstart`/`touchend` → `onSwipe('left'|'right')`，判据与阈值同正文 `touchend`
+    分支（横向分量占优 + `dist` 或 `fastDist`+900px/s 二选一，`dx < 0` = `'left'`）。阈值由
+    `_loadSpreadPage` 从 `ReaderSettings.swipePageTurnDistThresholds`（随灵敏度设置缩放的
+    **同一真值**）取，spread 侧不另立默认。
+  - **键盘**：新 `onSpreadKey` 桥。token 表由 `spreadKeyBridgeTokens` 按注册表**当前**绑定
+    实时导出（翻页 / 唤收底栏 / 退出书四个动作），改键即时跟随——不重蹈漫画页旧桥写死
+    `ArrowLeft/ArrowRight` 的覆辙（BUG-1347）。Dart 侧 `InputBinding.deserialize` →
+    与 Flutter 焦点路径**同一个** `resolveKeyboard` → `_executeShortcutAction` → reclaim 焦点。
+    **裸 Space 恒排除**：它归与正文逐字同款的 `onSpaceKey` 桥（经 `resolveReaderSpaceOverride`
+    分流"有声书激活 → 播放/暂停"），两座桥都在本 document 装 `keydown`，不排除就翻两页。
+  - **合成 click 抑制**：横扫后浏览器仍会合成一次 `click`，不拦就会同时命中 `onImageTap`
+    （弹图片查看器）。capture 阶段单点吞掉（700ms 一次性窗口，不粘住后续真实点击）。
+  - 顺带把 `swipe_page_turn_sensitivity` 的兜底默认提成
+    `ReaderSettings.defaultSwipePageTurnSensitivity`——它现在有了第二个读取方（settings 未
+    就绪时的 spread 装载），两处各写字面量 `1.0` 会让改默认手感只改到一半。
+- **[x] ② 已加自动化测试** — `hibiki/test/reader/spread_page_turn_input_test.dart`（10 条）：
+  - **行为级**（把生产 `buildSpreadPageHtml` 的 `<script>` 原样丢进 node 真跑，最小假 DOM +
+    capture/bubble 分桶）：滚轮下滚=forward / 上滚=backward / 主轴取绝对值更大者 / 零位移不翻页；
+    横扫过阈值才翻且方向正确、纵向拖动与亚阈值抖动不翻页；横扫后的合成 click 在 capture 被
+    吞掉且不到达任何桥，而**之后**的真实点击照常开图片查看器。
+  - **token 表真行为**：未装载注册表给空表；导出的每个 token 都能反解析回声明的动作集；
+    裸 Space 恒不在表内；改键后表跟着变（`KeyN`）。
+  - **源码守卫**：`onSpreadKey` handler 走 `InputBinding.deserialize` + `resolveKeyboard` +
+    `_executeShortcutAction` + reclaim；`_loadSpreadPage` 真的把阈值/键桥/Space 桥都传进去；
+    spread 复用的既有 handler（`onWheelPaginate` / `onSwipe`）仍在。
+  - 既有 `spread_chrome_escape_guard_test.dart` 的 node runner 同步升级成按 (type, capture)
+    分桶 + capture 先跑可 `stopPropagation`，原断言强度不变（文档级 click 桥仍恰好一个）。
+  - `reader_spread_image_ready_gate_test.dart` 的 `buildSpreadPageHtml(leftUrl:` 连写断言放宽为
+    「调用 builder + 传 leftUrl」——加参数后调用点被 format 折行，那条是拼写脆弱不是契约破裂。
+  - **变异实测 5 次**（见下方备注，结果附在 PR 里）。
+- **备注**：
+  - 🔴 **本次没做鼠标拖动翻页**。正文在桌面有 pointer-drag 翻页（`_finishHoshiReaderMouseDrag`
+    → `onSwipe`），spread 只补了 touch 横扫。理由是它与图片查看器的 click 语义纠缠更深
+    （在图上按下拖动 = 选择/拖图），而桌面的主诉滚轮已经修好。**这是已知缺口，不是遗漏。**
+  - 键桥 token 表在**装载 spread 文档那一刻**求值，用户改键后需重新进一次双页页面才生效
+    （每次进 spread 都重新生成 HTML）。可接受，且与"每章重注入"的正文行为同构。
+  - 未做真机复测：Windows 原始路径（书架 → 打开彩插书 → spreadMode=auto 自动进双页 → 滚轮/
+    方向键翻页）与 Android 横扫都只有静态证据链 + node 行为级测试，没在真机上观测过。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -815,8 +815,32 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
     final String leftUrl = rtl ? urlB : urlA;
     final String rightUrl = rtl ? urlA : urlB;
 
-    final String html =
-        buildSpreadPageHtml(leftUrl: leftUrl, rightUrl: rightUrl);
+    // BUG-1419：spread 独立文档自带翻页输入。阈值取与正文引擎**同一个**真值来源
+    // （`ReaderSettings.swipePageTurnDistThresholds`，随灵敏度设置缩放），不在
+    // spread 侧另立一套默认值——否则调灵敏度只对正文生效，双页页面手感恒定。
+    final ({int dist, int fastDist}) swipeThresholds =
+        ReaderSettings.swipePageTurnDistThresholds(
+      _settings?.swipePageTurnSensitivity ??
+          ReaderSettings.defaultSwipePageTurnSensitivity,
+    );
+    // 键桥：按注册表当前绑定导出（改键即时跟随），外加与正文逐字同款的裸 Space 桥
+    // （`onSpaceKey`，经 resolveReaderSpaceOverride 分流有声书播放/暂停 vs 翻页）。
+    // 两座桥各自裹 IIFE + 幂等安装守卫，同一 document 共存互不覆盖。
+    final String keyBridgeScript = '${webViewKeyBridgeScript(
+      handlerName: 'onSpreadKey',
+      keys: spreadKeyBridgeTokens(appModel.shortcutRegistry),
+    )}\n${webViewKeyBridgeScript(
+      handlerName: 'onSpaceKey',
+      keys: const <String>[' '],
+    )}';
+
+    final String html = buildSpreadPageHtml(
+      leftUrl: leftUrl,
+      rightUrl: rightUrl,
+      swipeDistThreshold: swipeThresholds.dist,
+      swipeFastDistThreshold: swipeThresholds.fastDist,
+      keyBridgeScript: keyBridgeScript,
+    );
 
     // BUG-1280：置位必须在 loadData 之前——`onLoadStop` 可能在 await 返回前就
     // 派发，晚置位等于守卫对这一次加载失效。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -2086,6 +2086,31 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
           },
         );
 
+        // BUG-1419：spread 独立文档的键桥落地点。JS 侧的表由
+        // [spreadKeyBridgeTokens] 按注册表当前绑定导出（裸 Space 除外，那条归上面
+        // 的 onSpaceKey 桥），所以这里只做「token → 动作」的反解析，解析走的是与
+        // Flutter 焦点路径**同一个** resolveKeyboard——改键对两条路一起生效。
+        // 收尾 reclaim：这一次按键说明 OS 焦点在 WebView2 手里，不夺回来后续按键
+        // 还是只到 DOM（与 onSpaceKey / onSwipe 的 BUG-136 修复同款）。
+        controller.addJavaScriptHandler(
+          handlerName: 'onSpreadKey',
+          callback: (List<dynamic> args) {
+            if (args.isEmpty || _lyricsMode) return;
+            final InputBinding? binding =
+                InputBinding.deserialize(args[0] as String);
+            if (binding == null) return;
+            final ShortcutAction? action =
+                appModel.shortcutRegistry.resolveKeyboard(
+              binding.key,
+              modifiers: binding.modifiers,
+              scope: ShortcutScope.reader,
+            );
+            if (action == null) return;
+            _executeShortcutAction(action);
+            _focusOwnership.reclaim(FocusReclaimCause.gesture);
+          },
+        );
+
         controller.addJavaScriptHandler(
           handlerName: 'onSwipe',
           callback: (List<dynamic> args) {

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -97,7 +97,9 @@ import 'package:hibiki/src/utils/components/hibiki_icon_button.dart';
 import 'package:hibiki/src/utils/components/hibiki_material_components.dart';
 import 'package:hibiki/src/utils/misc/show_app_dialog.dart';
 import 'package:hibiki/src/shortcuts/input_binding.dart'
-    show GamepadButton, ModifierKey, activeModifierKeys;
+    show GamepadButton, InputBinding, ModifierKey, activeModifierKeys;
+import 'package:hibiki/src/shortcuts/shortcut_registry.dart'
+    show HibikiShortcutRegistry;
 import 'package:hibiki/src/shortcuts/gamepad_service.dart'
     show GamepadButtonIntent, GamepadLongPressIntent, focusedEditableText;
 import 'package:hibiki/src/shortcuts/shortcut_action.dart';
@@ -494,9 +496,25 @@ bool chapterTurnCoolingDown({
 ///
 /// [leftUrl] / [rightUrl] 是已解析的整页图 URL（调用方已按 RTL/LTR 排好左右）。纯字符串
 /// 生成、无副作用，供单测锁定「spreadReady 被图片 load 门控」（撤回同步触发 → 守卫转红）。
+///
+/// BUG-1419：本文档还必须自带**翻页输入**。spread 是第四种独立文档，
+/// `_onChapterLoadComplete` 的 spread 守卫（BUG-1280 ③）把整份正文引擎挡在门外，
+/// 而滚轮 / 横扫 / 键桥全在那份引擎里 ⇒ 进了双页页面滚轮和翻页键一起失效。三条通道
+/// 都直连**既有** Dart handler，Dart 侧不新增翻页语义：
+/// * `wheel` → `onWheelPaginate`（与正文 `_handlePagedWheelTick` 逐字同款：主轴取
+///   绝对值更大的那个，`delta > 0` = forward）；
+/// * 单指横扫 → `onSwipe`（与正文 `touchend` 分支同款判据：横向分量占优，且位移过
+///   [swipeDistThreshold] 或「过 [swipeFastDistThreshold] + 速度 ≥ 900px/s」，`dx < 0`
+///   = `'left'`）。阈值由调用方从 [ReaderSettings] 取同一真值传入，不在此另立默认；
+/// * 键盘 → [keyBridgeScript]（调用方用 `webViewKeyBridgeScript` 按注册表**当前**绑定
+///   生成）。Windows 的 WebView2 一旦持有 OS 焦点，按键只存在于 DOM 里，Flutter 的
+///   `Focus.onKeyEvent` 收不到（TODO-1078 / BUG-136 同源）。空串 = 不装键桥。
 String buildSpreadPageHtml({
   required String leftUrl,
   required String rightUrl,
+  required int swipeDistThreshold,
+  required int swipeFastDistThreshold,
+  String keyBridgeScript = '',
 }) {
   return '''
 <!DOCTYPE html>
@@ -539,6 +557,58 @@ html,body{width:100vw;height:100vh;overflow:hidden;background:#000}
     if (e && e.target && e.target.tagName === 'IMG') return;
     window.flutter_inappwebview.callHandler('onSpreadTapEmpty');
   });
+  // BUG-1419：翻页输入。正文引擎（滚轮 / 横扫 / 键桥都在里面）对 spread 文档是
+  // 被守卫挡住的，本文档必须自带，否则进了双页页面滚轮和翻页键一起没反应。
+  // 滚轮：与正文 _handlePagedWheelTick 逐字同款语义（主轴取绝对值更大的那个，
+  // delta > 0 = forward），直送既有 onWheelPaginate handler——节流 / 跨章冷却 /
+  // 虚拟页翻页全在 Dart 侧那一份，这里不重复实现。
+  document.addEventListener('wheel', function(e){
+    var horizontal = Math.abs(e.deltaX) > Math.abs(e.deltaY);
+    var delta = horizontal ? e.deltaX : e.deltaY;
+    if (delta === 0) return;
+    e.preventDefault();
+    window.flutter_inappwebview.callHandler('onWheelPaginate',
+      delta > 0 ? 'forward' : 'backward',
+      horizontal ? 'horizontal' : 'vertical');
+  }, {passive: false});
+  // 单指横扫：判据与阈值同正文 touchend 分支（横向分量占优 + 距离/速度二选一），
+  // 方向约定同样是 dx < 0 → 'left'，直送既有 onSwipe handler（那里按书写方向和
+  // invertSwipeDirection 把 left/right 折成 forward/backward）。
+  var _swipeStartX = 0, _swipeStartY = 0, _swipeStartAt = 0, _swipeTracking = false;
+  var _swipeDoneAt = 0;
+  document.addEventListener('touchstart', function(e){
+    if (!e.touches || e.touches.length !== 1) { _swipeTracking = false; return; }
+    _swipeStartX = e.touches[0].clientX;
+    _swipeStartY = e.touches[0].clientY;
+    _swipeStartAt = Date.now();
+    _swipeTracking = true;
+  }, {passive: true});
+  document.addEventListener('touchend', function(e){
+    if (!_swipeTracking) return;
+    _swipeTracking = false;
+    var t = e.changedTouches && e.changedTouches[0];
+    if (!t) return;
+    var dx = t.clientX - _swipeStartX;
+    var dy = t.clientY - _swipeStartY;
+    var absDx = Math.abs(dx), absDy = Math.abs(dy);
+    if (absDx <= absDy) return;
+    var velocity = absDx / Math.max(1, Date.now() - _swipeStartAt) * 1000;
+    if (absDx < $swipeDistThreshold &&
+        !(absDx >= $swipeFastDistThreshold && velocity >= 900)) return;
+    if (e.preventDefault) e.preventDefault();
+    _swipeDoneAt = Date.now();
+    window.flutter_inappwebview.callHandler('onSwipe', dx < 0 ? 'left' : 'right');
+  }, {passive: false});
+  // 横扫之后浏览器仍可能合成一次 click；不拦就会同时命中 onImageTap（弹图片查看器）
+  // 或 onSpreadTapEmpty（翻底栏）。capture 阶段单点吞掉，两个消费者都碰不到它。
+  // 用时间窗而非裸标志：preventDefault 已压掉合成 click 时标志不会残留到下一次
+  // 真实点击（那会表现成「翻页后第一下点击无效」）。
+  document.addEventListener('click', function(e){
+    if (!_swipeDoneAt || (Date.now() - _swipeDoneAt) > 700) return;
+    _swipeDoneAt = 0;
+    e.stopPropagation();
+    if (e.preventDefault) e.preventDefault();
+  }, true);
   var signaled = false;
   function signalReady(){
     if (signaled) return;
@@ -568,10 +638,50 @@ html,body{width:100vw;height:100vh;overflow:hidden;background:#000}
     });
   }
 })();
+$keyBridgeScript
 </script>
 </body></html>
 ''';
 }
+
+/// BUG-1419：spread 独立文档要交回 Dart 的键盘 token 表（[InputBinding.serialize]
+/// 原样，如 `ArrowLeft` / `Ctrl+KeyD`）。
+///
+/// 只导出在双页页面上**真正有意义**的动作：翻页、唤/收底栏、退出书。spread 页没有
+/// 正文，查词 / caret / 振假名那些动作在这里无处可施，桥进来只会白白吞掉按键。
+///
+/// 表由注册表**当前**绑定实时导出而不是硬编码键名（漫画页旧桥写死
+/// `ArrowLeft/ArrowRight/Escape` 的教训，BUG-1347）：用户改键后 spread 页跟着变。
+/// 注册表未装载时 `bindingsFor` 对每个动作都返回空集，与「用户清空了绑定」在数据上
+/// 不可区分，返回空表即可（下一次进 spread 页会拿到真表）。
+///
+/// **裸 Space 恒排除**：它归正文同款的 `onSpaceKey` 桥（那条经
+/// `resolveReaderSpaceOverride` 解析，有声书激活时是播放/暂停而不是翻页）。两座桥
+/// 都是本 document 上的独立 `keydown` 监听，同一次按下各命中一次就会翻两页。
+List<String> spreadKeyBridgeTokens(HibikiShortcutRegistry registry) {
+  if (!registry.isLoaded) return const <String>[];
+  final List<String> tokens = <String>[];
+  for (final ShortcutAction action in kSpreadBridgedActions) {
+    for (final InputBinding binding
+        in registry.bindingsFor(action).keyboardBindings) {
+      if (binding.key == LogicalKeyboardKey.space &&
+          binding.modifiers.isEmpty) {
+        continue;
+      }
+      final String token = binding.serialize();
+      if (!tokens.contains(token)) tokens.add(token);
+    }
+  }
+  return tokens;
+}
+
+/// [spreadKeyBridgeTokens] 导出的动作集（顺序即 token 表顺序，稳定可比较）。
+const List<ShortcutAction> kSpreadBridgedActions = <ShortcutAction>[
+  ShortcutAction.readerPageForward,
+  ShortcutAction.readerPageBackward,
+  ShortcutAction.readerToggleChrome,
+  ShortcutAction.readerExitBook,
+];
 
 /// BUG-213：章内原生滚动回传（`onReaderScroll`）到来时，是否应刷新章内进度。
 ///

--- a/hibiki/lib/src/reader/reader_settings.dart
+++ b/hibiki/lib/src/reader/reader_settings.dart
@@ -404,8 +404,16 @@ class ReaderSettings {
   static double normalizeSwipePageTurnSensitivity(num value) =>
       value.toDouble().clamp(0.3, 2.0).toDouble();
 
+  /// 灵敏度系数的默认值（1.0 = 默认「轻快」手感）。提成常量是因为 BUG-1419 之后
+  /// 它有了**第二个**读取方：spread 独立文档在 settings 尚未就绪时也要算滑动阈值，
+  /// 那里若各写一个字面量 1.0，改默认手感只会改到其中一半。
+  static const double defaultSwipePageTurnSensitivity = 1.0;
+
   double get swipePageTurnSensitivity => normalizeSwipePageTurnSensitivity(
-        _get<double>('swipe_page_turn_sensitivity', 1.0),
+        _get<double>(
+          'swipe_page_turn_sensitivity',
+          defaultSwipePageTurnSensitivity,
+        ),
       );
   Future<void> setSwipePageTurnSensitivity(double v) => _set<double>(
         'swipe_page_turn_sensitivity',

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1152
+version: 1.3.1+1153
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/helpers/source_guard.dart
+++ b/hibiki/test/helpers/source_guard.dart
@@ -925,3 +925,28 @@ String switchCaseBody(
   }
   return src.substring(start, end);
 }
+
+/// 在合并语料里定位**正文引擎那份** `wheel` 监听的起始下标。
+///
+/// BUG-1419 之后语料里有**两份** wheel 监听：spread 独立文档自带的那份
+/// （`buildSpreadPageHtml`，直送 `onWheelPaginate`，没有连续/分页轴向门控）在
+/// 主壳里、位置更靠前；正文引擎那份在 `reader_hibiki/webview.part.dart`。
+/// 裸 `indexOf("addEventListener('wheel'")` 会锚到前者，让所有钉正文轴向门控的
+/// 守卫在「实现完全正确」时转红（本函数就是被这条实测打出来的）。
+///
+/// 判据用**块内是否含 `hoshiContinuousMode`**：连续/分页分流是正文那份独有的语义，
+/// 比「取第几个」稳——将来再多一份独立文档的 wheel 监听也不会把锚点挤歪。
+/// 找不到返回 -1，由调用方断言。
+int bodyEngineWheelListenerStart(String source) {
+  const String needle = "addEventListener('wheel'";
+  int idx = source.indexOf(needle);
+  while (idx >= 0) {
+    final int end = source.indexOf('}, {passive:', idx);
+    if (end > idx &&
+        source.substring(idx, end).contains('hoshiContinuousMode')) {
+      return idx;
+    }
+    idx = source.indexOf(needle, idx + needle.length);
+  }
+  return -1;
+}

--- a/hibiki/test/reader/reader_spread_image_ready_gate_test.dart
+++ b/hibiki/test/reader/reader_spread_image_ready_gate_test.dart
@@ -24,8 +24,12 @@ void main() {
   group('buildSpreadPageHtml gates spreadReady on image load (TODO-1229)', () {
     const String leftUrl = 'hoshi.local/OEBPS/img/left.png';
     const String rightUrl = 'hoshi.local/OEBPS/img/right.png';
-    final String html =
-        buildSpreadPageHtml(leftUrl: leftUrl, rightUrl: rightUrl);
+    final String html = buildSpreadPageHtml(
+      leftUrl: leftUrl,
+      rightUrl: rightUrl,
+      swipeDistThreshold: 44,
+      swipeFastDistThreshold: 22,
+    );
 
     test('两张整页图 URL 与 spreadReady 信号都在', () {
       expect(html, contains('src="$leftUrl"'));
@@ -79,8 +83,13 @@ void main() {
           source.indexOf('String _resolveSpreadImageUrl(', loadSpreadIdx);
       expect(nextIdx, greaterThan(loadSpreadIdx));
       final String body = source.substring(loadSpreadIdx, nextIdx);
-      expect(body, contains('buildSpreadPageHtml(leftUrl:'),
+      // 钉的是「委托给 builder」，不是调用点的换行方式——BUG-1419 给 builder 加了
+      // 阈值/键桥参数后调用点被 dart format 折成多行，旧的 `buildSpreadPageHtml(leftUrl:`
+      // 连写断言当场转红，那是拼写脆弱而不是契约破裂。
+      expect(body, contains('buildSpreadPageHtml('),
           reason: '_loadSpreadPage 必须走 buildSpreadPageHtml 生成 spread HTML');
+      expect(body, contains('leftUrl:'),
+          reason: 'builder 的左右图入参必须由 _loadSpreadPage 解析后传入');
       expect(body.contains("callHandler('spreadReady')"), isFalse,
           reason: '_loadSpreadPage 函数体内不得再内联 spreadReady（已下沉到 builder）');
     });

--- a/hibiki/test/reader/scroll_cross_chapter_try_scroll_test.dart
+++ b/hibiki/test/reader/scroll_cross_chapter_try_scroll_test.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 
+import '../helpers/source_guard.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 
 /// TODO-656「试滚范式」根治：跨章不再用瞬时坐标阈值 `scrollTop<=2`，而是「内容真的
@@ -151,8 +152,10 @@ void main() {
 }
 
 String _wheelBlock(String source) {
-  final int start = source.indexOf("addEventListener('wheel'");
-  expect(start, isNonNegative, reason: 'missing wheel listener');
+  // BUG-1419：spread 独立文档自带的 wheel 监听（无连续/分页门控）在合并语料里排在
+  // 正文引擎那份**前面**，裸 indexOf 会锚错。按块内的 hoshiContinuousMode 挑正文那份。
+  final int start = bodyEngineWheelListenerStart(source);
+  expect(start, isNonNegative, reason: 'missing body-engine wheel listener');
   final int end = source.indexOf('}, {passive:', start);
   expect(end, isNonNegative);
   return source.substring(start, end);

--- a/hibiki/test/reader/spread_chrome_escape_guard_test.dart
+++ b/hibiki/test/reader/spread_chrome_escape_guard_test.dart
@@ -37,8 +37,12 @@ void main() {
   group('spread 文档有唤出底栏的通道 (BUG-1280)', () {
     const String leftUrl = 'hoshi.local/OEBPS/img/left.png';
     const String rightUrl = 'hoshi.local/OEBPS/img/right.png';
-    final String html =
-        buildSpreadPageHtml(leftUrl: leftUrl, rightUrl: rightUrl);
+    final String html = buildSpreadPageHtml(
+      leftUrl: leftUrl,
+      rightUrl: rightUrl,
+      swipeDistThreshold: 44,
+      swipeFastDistThreshold: 22,
+    );
 
     test('图片以外的点击有专桥回传 Dart', () {
       expect(html, contains("callHandler('$kEmptyTapBridge')"),
@@ -266,14 +270,22 @@ function node(tagName, src) {
 }
 
 const imgs = [node('IMG', 'L'), node('IMG', 'R')];
+// BUG-1419 起本文档还挂了 wheel / touch / capture 阶段的 click 监听，故假 DOM 要
+// 按 (type, capture) 分桶——否则「文档级 click 桥只有一个」这条断言会被 capture 阶段
+// 那个吞噬监听凑数放过去。
 const docListeners = {};
+function bucket(type, capture) {
+  const key = type + (capture ? ':capture' : '');
+  return (docListeners[key] = docListeners[key] || []);
+}
 const document = {
   querySelectorAll(selector) {
     assert(selector === 'img', 'unexpected selector ' + selector);
     return imgs;
   },
-  addEventListener(type, fn) {
-    (docListeners[type] = docListeners[type] || []).push(fn);
+  addEventListener(type, fn, options) {
+    const capture = options === true || (options && options.capture === true);
+    bucket(type, capture).push(fn);
   }
 };
 const calls = [];
@@ -288,9 +300,17 @@ assert(calls.length === 1 && calls[0][0] === 'spreadReady',
 assert((docListeners['click'] || []).length === 1,
   'spread document-level click listener missing');
 
-// 真浏览器语义：先跑目标自己的监听，再冒泡到文档级监听，同一个 event 对象。
+// 真浏览器语义：capture 阶段的文档级监听最先跑（可 stopPropagation 掐断后续），
+// 再跑目标自己的监听，最后冒泡回文档级监听——三段共用同一个 event 对象。
 function clickOn(target) {
-  const ev = {target: target};
+  let stopped = false;
+  const ev = {
+    target: target,
+    stopPropagation() { stopped = true; },
+    preventDefault() {}
+  };
+  (docListeners['click:capture'] || []).slice().forEach(fn => fn(ev));
+  if (stopped) return;
   (target.listeners['click'] || []).slice().forEach(fn => fn(ev));
   (docListeners['click'] || []).slice().forEach(fn => fn(ev));
 }

--- a/hibiki/test/reader/spread_page_turn_input_test.dart
+++ b/hibiki/test/reader/spread_page_turn_input_test.dart
@@ -1,0 +1,388 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart' show TargetPlatform;
+import 'package:flutter/services.dart' show LogicalKeyboardKey;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/pages/implementations/reader_hibiki_page.dart'
+    show buildSpreadPageHtml, kSpreadBridgedActions, spreadKeyBridgeTokens;
+import 'package:hibiki/src/reader/reader_settings.dart';
+import 'package:hibiki/src/shortcuts/input_binding.dart';
+import 'package:hibiki/src/shortcuts/shortcut_action.dart';
+import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
+
+import '../helpers/source_guard.dart';
+import '../pages/reader_hibiki_page_source_corpus.dart';
+
+/// BUG-1419 守卫：进了双页 spread 页面，滚轮和左右翻页一起失效。
+///
+/// 根因是 BUG-1280 ③ 的守卫留下的账：spread 是第四种独立文档，
+/// `_onChapterLoadComplete` 判到 `_spreadDocumentLoaded` 就早退、绝不注入正文引擎，
+/// 而**滚轮 / 横扫 / 键桥全长在那份引擎里**。Windows 侧从来就没被注入过（`loadData`
+/// 丢 baseUrl → onLoadStop 判 stale），所以那边的 spread 页自始至终没有滚轮翻页；
+/// Android 侧是 BUG-1280 修复时连同误注入一起失去的（该 BUG 备注已明确记账并留
+/// TODO：「给 spread 独立文档补它自己的 onSwipe + 键桥」）。本次把这笔账还上。
+///
+/// 修法：三条通道都由 spread 文档**自带**，且都直连**既有** Dart handler
+/// （`onWheelPaginate` / `onSwipe` / 新的 `onSpreadKey`），Dart 侧不新增翻页语义——
+/// 节流、跨章冷却、虚拟页翻页仍是 `_paginate` → `_handlePageTurnLimit` 那一份。
+void main() {
+  const String leftUrl = 'hoshi.local/OEBPS/img/left.png';
+  const String rightUrl = 'hoshi.local/OEBPS/img/right.png';
+
+  String htmlWith({String keyBridgeScript = ''}) => buildSpreadPageHtml(
+        leftUrl: leftUrl,
+        rightUrl: rightUrl,
+        swipeDistThreshold: 44,
+        swipeFastDistThreshold: 22,
+        keyBridgeScript: keyBridgeScript,
+      );
+
+  group('spread 文档自带翻页输入 (BUG-1419)', () {
+    test('滚轮桥直连既有 onWheelPaginate，且带主轴参数', () {
+      final String html = htmlWith();
+      expect(html, contains("callHandler('onWheelPaginate'"),
+          reason: 'spread 页没有 wheel 桥 = 滚轮完全无反应（用户报的第一个症状）');
+      expect(html, contains("document.addEventListener('wheel'"),
+          reason: 'wheel 必须挂文档级，两张整页图铺满视口时滚轮落在哪都要算数');
+      expect(html, contains('horizontal'),
+          reason: 'Dart 侧 onWheelPaginate 要 (dir, axis) 两个参数，少一个直接早退');
+    });
+
+    test('横扫桥直连既有 onSwipe，阈值来自入参而非另立默认', () {
+      final String html = buildSpreadPageHtml(
+        leftUrl: leftUrl,
+        rightUrl: rightUrl,
+        swipeDistThreshold: 77,
+        swipeFastDistThreshold: 33,
+      );
+      expect(html, contains("callHandler('onSwipe'"));
+      expect(html, contains('77'), reason: '阈值必须从调用方（随灵敏度设置缩放的真值）插进来');
+      expect(html, contains('33'));
+    });
+
+    test('键桥脚本原样嵌入，空串则不装键桥', () {
+      const String marker = '/*__SPREAD_KEY_BRIDGE_MARKER__*/';
+      expect(htmlWith(keyBridgeScript: marker), contains(marker),
+          reason: '调用方生成的键桥必须真的进文档，否则 WebView2 持焦时按键全丢');
+      expect(htmlWith(), isNot(contains(marker)));
+    });
+
+    // 上面三条只断言字面量在不在。把生产 HTML 里的脚本原样丢进 node 真跑，断言的是
+    // **行为**：滚轮方向映射、横扫阈值判定、横扫后合成 click 不再误触发图片查看器。
+    test('spread 脚本真跑：滚轮方向 / 横扫阈值 / 合成 click 抑制（行为级）', () {
+      final String payload = jsonEncode(<String, String>{'html': htmlWith()});
+      final Directory temp =
+          Directory.systemTemp.createTempSync('hibiki-spread-input-js-');
+      final File payloadFile = File('${temp.path}/payload.json')
+        ..writeAsStringSync(payload);
+      late final ProcessResult result;
+      try {
+        result = Process.runSync(
+          'node',
+          <String>['-e', _spreadInputRunner, payloadFile.path],
+          stdoutEncoding: utf8,
+          stderrEncoding: utf8,
+        );
+      } finally {
+        temp.deleteSync(recursive: true);
+      }
+      expect(
+        result.exitCode,
+        0,
+        reason: 'spread input runner failed:\n'
+            'stdout=${result.stdout}\nstderr=${result.stderr}',
+      );
+      expect(result.stdout.toString().trim(), 'OK');
+    });
+  });
+
+  group('键桥 token 表按注册表当前绑定导出 (BUG-1419)', () {
+    test('未装载的注册表给空表（与「用户清空绑定」同等对待）', () {
+      expect(spreadKeyBridgeTokens(HibikiShortcutRegistry()), isEmpty);
+    });
+
+    test('导出翻页/唤栏/退出的当前绑定，且恒排除裸 Space', () {
+      final HibikiShortcutRegistry registry = HibikiShortcutRegistry()
+        ..loadDefaults(TargetPlatform.windows);
+
+      final List<String> tokens = spreadKeyBridgeTokens(registry);
+      expect(tokens, isNotEmpty, reason: '装载后应导出默认绑定，空表 = 键桥是死的');
+
+      // 裸 Space 归 onSpaceKey 桥（有声书激活时它解析成播放/暂停）。两座桥都在本
+      // document 上装 keydown，同一次按下各命中一次就会翻两页——这条是真实的双触发
+      // 风险，不是洁癖。
+      const String bareSpace = 'Space';
+      expect(tokens.contains(bareSpace), isFalse,
+          reason: '裸 Space 必须留给 onSpaceKey 桥，否则空格翻两页');
+
+      // 表里的每个 token 都必须能反解析回本表声明的动作之一——否则 Dart 侧
+      // onSpreadKey 收到后 resolveKeyboard 得到别的动作（或 null），键桥形同虚设。
+      for (final String token in tokens) {
+        final InputBinding? binding = InputBinding.deserialize(token);
+        expect(binding, isNotNull, reason: '$token 不是合法 InputBinding token');
+        final ShortcutAction? action = registry.resolveKeyboard(
+          binding!.key,
+          modifiers: binding.modifiers,
+          scope: ShortcutScope.reader,
+        );
+        expect(kSpreadBridgedActions.contains(action), isTrue,
+            reason: '$token 解析成 $action，不在 spread 声明的动作集里');
+      }
+
+      // 翻页是本 bug 的主诉，必须真的在表里（默认绑定含方向键）。
+      final Set<ShortcutAction> covered = tokens
+          .map(InputBinding.deserialize)
+          .whereType<InputBinding>()
+          .map((InputBinding b) => registry.resolveKeyboard(b.key,
+              modifiers: b.modifiers, scope: ShortcutScope.reader))
+          .whereType<ShortcutAction>()
+          .toSet();
+      expect(covered, contains(ShortcutAction.readerPageForward));
+      expect(covered, contains(ShortcutAction.readerPageBackward));
+    });
+
+    test('改键后 token 表跟着变（不是硬编码键名）', () {
+      final HibikiShortcutRegistry registry = HibikiShortcutRegistry()
+        ..loadDefaults(TargetPlatform.windows)
+        ..updateBinding(
+          ShortcutAction.readerPageForward,
+          const ShortcutBindingSet(
+            keyboardBindings: <InputBinding>[
+              InputBinding(key: LogicalKeyboardKey.keyN),
+            ],
+          ),
+        );
+      expect(spreadKeyBridgeTokens(registry), contains('KeyN'),
+          reason: '漫画页旧桥写死 ArrowLeft/ArrowRight 的教训（BUG-1347）不得重演');
+    });
+  });
+
+  group('Dart 侧接线 (BUG-1419)', () {
+    final String source = readReaderPageSource();
+
+    test('注册了 onSpreadKey 处理器，走注册表解析并 reclaim 焦点', () {
+      // `handlerName: 'onSpreadKey'` 在合并语料里出现两次——一次是 _loadSpreadPage
+      // 生成桥脚本时的入参，一次才是 handler 注册。裸 indexOf 会切到前者（那段只有
+      // 一行，任何断言都红），所以锚点必须连着 addJavaScriptHandler 一起匹配。
+      final int idx = source.indexOf(
+        RegExp(r"addJavaScriptHandler\(\s*handlerName: 'onSpreadKey'"),
+      );
+      expect(idx, greaterThan(0), reason: 'JS 发了键桥而 Dart 不接 = 桥是死的');
+      final int end = source.indexOf('addJavaScriptHandler', idx + 1);
+      expect(end, greaterThan(idx));
+      final String body = source.substring(idx, end);
+
+      expect(body, contains('InputBinding.deserialize'),
+          reason: 'token 必须反解析，不能按字面量比键名');
+      expect(body, contains('resolveKeyboard'),
+          reason: '必须走与 Flutter 焦点路径同一个解析，改键才会对两条路一起生效');
+      expect(body, contains('ShortcutScope.reader'));
+      expect(body, contains('_executeShortcutAction('),
+          reason: '解析出动作却不执行 = 按键仍然没反应');
+      expect(body, contains('FocusReclaimCause.gesture'),
+          reason: '不夺回 Flutter 焦点，后续按键还是只到 DOM（BUG-136 同族）');
+    });
+
+    test('_loadSpreadPage 真的把三样都传进 HTML', () {
+      final String body =
+          methodBody(source, 'Future<void> _loadSpreadPage(SpreadEntry entry)');
+      expect(containsCodeLine(body, 'swipeDistThreshold:'), isTrue,
+          reason: '不传阈值，横扫判据就退回不到正文那套手感');
+      expect(containsCodeLine(body, 'swipePageTurnDistThresholds('), isTrue,
+          reason: '阈值必须来自 ReaderSettings 的同一真值（随灵敏度设置缩放）');
+      expect(containsCodeLine(body, 'keyBridgeScript:'), isTrue);
+      expect(body, contains("handlerName: 'onSpreadKey'"),
+          reason: '键桥脚本必须在装载 spread 时生成，改键下次进页即生效');
+      expect(body, contains("handlerName: 'onSpaceKey'"),
+          reason: '裸 Space 桥与正文逐字同款，spread 页的空格翻页靠它');
+    });
+
+    // 滚轮/横扫桥只有在 Dart 侧 handler 仍然存在时才有意义。它们是**既有** handler，
+    // 本次没动；这条钉住「以后谁把它们改名/删掉，spread 的滚轮会静默失效」。
+    test('spread 复用的既有 handler 仍在', () {
+      expect(source, contains("handlerName: 'onWheelPaginate'"));
+      expect(source, contains("handlerName: 'onSwipe'"));
+    });
+  });
+
+  group('滑动灵敏度默认值单一真值 (BUG-1419)', () {
+    test('getter 的兜底默认就是 defaultSwipePageTurnSensitivity', () {
+      const String kSettingsFile = 'lib/src/reader/reader_settings.dart';
+      final String settingsSrc = File(kSettingsFile).readAsStringSync();
+      expect(
+        settingsSrc,
+        contains("'swipe_page_turn_sensitivity',\n"
+            '          defaultSwipePageTurnSensitivity,'),
+        reason: 'getter 里写回字面量 1.0 = 又有两处默认，改手感只会改到一半',
+      );
+      expect(ReaderSettings.defaultSwipePageTurnSensitivity, 1.0);
+    });
+  });
+}
+
+/// 把生产 spread HTML 里的 `<script>` 原样丢进 node 跑，用最小假 DOM 复现三条真实
+/// 路径：滚轮 tick、单指横扫、横扫之后浏览器合成的那次 click。
+const String _spreadInputRunner = r"""
+const fs = require('fs');
+const data = JSON.parse(fs.readFileSync(process.argv[1], 'utf8'));
+function assert(value, message) {
+  if (!value) throw new Error(message);
+}
+const html = data.html;
+const open = html.indexOf('<script>');
+const close = html.indexOf('</script>', open);
+assert(open >= 0 && close > open, 'spread script block missing');
+const script = html.slice(open + '<script>'.length, close);
+
+function node(tagName, src) {
+  return {
+    tagName: tagName,
+    src: src,
+    listeners: {},
+    complete: true,
+    naturalWidth: 100,
+    addEventListener(type, fn) {
+      (this.listeners[type] = this.listeners[type] || []).push(fn);
+    },
+    removeEventListener(type, fn) {
+      const list = this.listeners[type] || [];
+      this.listeners[type] = list.filter(f => f !== fn);
+    }
+  };
+}
+
+const imgs = [node('IMG', 'L'), node('IMG', 'R')];
+const docListeners = {};
+function bucket(type, capture) {
+  const key = type + (capture ? ':capture' : '');
+  return (docListeners[key] = docListeners[key] || []);
+}
+const document = {
+  querySelectorAll() { return imgs; },
+  addEventListener(type, fn, options) {
+    const capture = options === true || (options && options.capture === true);
+    bucket(type, capture).push(fn);
+  }
+};
+const calls = [];
+const window = {
+  flutter_inappwebview: {callHandler: (...args) => calls.push(args)}
+};
+new Function('window', 'document', script)(window, document);
+calls.length = 0;
+
+function fire(type, event, capture) {
+  (docListeners[type + (capture ? ':capture' : '')] || [])
+    .slice().forEach(fn => fn(event));
+}
+function wheelEvent(deltaX, deltaY) {
+  let prevented = false;
+  return {
+    deltaX: deltaX,
+    deltaY: deltaY,
+    preventDefault() { prevented = true; },
+    get prevented() { return prevented; }
+  };
+}
+
+// ── 滚轮：纵向鼠标滚轮 ────────────────────────────────────────────────
+assert((docListeners['wheel'] || []).length === 1, 'wheel listener missing');
+const down = wheelEvent(0, 120);
+fire('wheel', down);
+assert(calls.length === 1, 'one wheel tick must emit exactly one bridge call');
+assert(calls[0][0] === 'onWheelPaginate' && calls[0][1] === 'forward' &&
+  calls[0][2] === 'vertical',
+  'scrolling down must page forward on the vertical axis, got ' +
+  JSON.stringify(calls));
+assert(down.prevented, 'wheel must preventDefault, else the doc scrolls instead');
+
+calls.length = 0;
+fire('wheel', wheelEvent(0, -120));
+assert(calls[0][1] === 'backward', 'scrolling up must page backward');
+
+// 主轴取绝对值更大的那个（横向触控板惯性走 horizontal，Dart 侧另有手势闸门）。
+calls.length = 0;
+fire('wheel', wheelEvent(-200, 10));
+assert(calls[0][1] === 'backward' && calls[0][2] === 'horizontal',
+  'dominant horizontal delta must report the horizontal axis, got ' +
+  JSON.stringify(calls));
+
+// 零位移不应产生翻页（触控板惯性收尾会连发 0）。
+calls.length = 0;
+fire('wheel', wheelEvent(0, 0));
+assert(calls.length === 0, 'zero delta must not turn a page');
+
+// ── 横扫：阈值 44px / 快速短滑 22px + 900px/s ────────────────────────
+function touchStart(x, y) {
+  fire('touchstart', {touches: [{clientX: x, clientY: y}]});
+}
+function touchEnd(x, y) {
+  fire('touchend', {
+    changedTouches: [{clientX: x, clientY: y}],
+    preventDefault() {}
+  });
+}
+
+calls.length = 0;
+touchStart(300, 200);
+touchEnd(200, 205);            // dx=-100 横向占优，过 44px
+assert(calls.length === 1 && calls[0][0] === 'onSwipe' && calls[0][1] === 'left',
+  'a leftward swipe must report left, got ' + JSON.stringify(calls));
+
+calls.length = 0;
+touchStart(200, 200);
+touchEnd(300, 205);            // dx=+100
+assert(calls[0][1] === 'right', 'a rightward swipe must report right');
+
+// 纵向为主的滑动不是翻页（图片页竖着划拉不该翻页）。
+calls.length = 0;
+touchStart(200, 200);
+touchEnd(210, 400);
+assert(calls.length === 0, 'a vertical drag must not turn a page');
+
+// 短于阈值且不够快 = 点击抖动，不翻页。
+calls.length = 0;
+touchStart(200, 200);
+touchEnd(215, 202);
+assert(calls.length === 0, 'a sub-threshold nudge must not turn a page');
+
+// ── 横扫之后的合成 click 必须被吞掉 ──────────────────────────────────
+calls.length = 0;
+touchStart(300, 200);
+touchEnd(200, 205);
+assert(calls.length === 1 && calls[0][0] === 'onSwipe', 'swipe precondition');
+calls.length = 0;
+let stopped = false;
+const synthetic = {
+  target: imgs[0],
+  stopPropagation() { stopped = true; },
+  preventDefault() {}
+};
+fire('click', synthetic, true);
+assert(stopped,
+  'the click synthesised right after a swipe must be stopped in capture, ' +
+  'otherwise a page turn also pops the image viewer');
+if (!stopped) {
+  (imgs[0].listeners['click'] || []).slice().forEach(fn => fn(synthetic));
+}
+assert(calls.length === 0, 'swallowed click must not reach any bridge, got ' +
+  JSON.stringify(calls));
+
+// 而**不是**横扫之后的普通点击照常工作（吞噬是一次性 + 700ms 窗口，不许粘住）。
+calls.length = 0;
+let stopped2 = false;
+const realTap = {
+  target: imgs[1],
+  stopPropagation() { stopped2 = true; },
+  preventDefault() {}
+};
+fire('click', realTap, true);
+assert(!stopped2, 'a later real tap must not be swallowed');
+(imgs[1].listeners['click'] || []).slice().forEach(fn => fn(realTap));
+assert(calls.length === 1 && calls[0][0] === 'onImageTap',
+  'tapping an image after a swipe must still open the viewer, got ' +
+  JSON.stringify(calls));
+
+process.stdout.write('OK');
+""";

--- a/hibiki/test/reader/swipe_page_turn_no_animation_test.dart
+++ b/hibiki/test/reader/swipe_page_turn_no_animation_test.dart
@@ -1,5 +1,6 @@
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/reader/reader_content_styles.dart';
@@ -107,7 +108,9 @@ void main() {
     final String src = readReaderPageSource();
 
     // 定位 wheel 监听块（从 addEventListener('wheel' 到其闭合 `}, {passive`)。
-    final int wheelStart = src.indexOf("addEventListener('wheel'");
+    // BUG-1419：语料里现在有两份 wheel 监听（spread 独立文档自带一份，位置更靠前），
+    // 裸 indexOf 会锚到 spread 那份 → 本守卫在实现正确时转红。按连续模式门控挑正文那份。
+    final int wheelStart = bodyEngineWheelListenerStart(src);
     expect(wheelStart, greaterThanOrEqualTo(0),
         reason: 'wheel listener must exist in the reader setup script');
     final int wheelEnd = src.indexOf('{passive: false});', wheelStart);


### PR DESCRIPTION
## 用户报的问题

截图里那本轻小说（安達としまむら，`format='epub'`）被**自动**配成双页展开，进到那个界面后**滚轮和左右翻页全都没反应**。

生产库核实：`src:reader_ttu:ttu_spread_mode = 'auto'`（显式存值，BUG-1280 把默认改成 `off` 只对没设置过的用户生效），且该书边缘匹配缓存 `spread_match:安達としまむら = {"0":true,…,"7":true}` 有成对页 → 自动进 spread。

## 根因（是 BUG-1280 留下的账，不是新回归）

spread 页是 `buildSpreadPageHtml` 生成的**独立文档**（第四种，继歌词/VN/spread 之后），自带的桥只有 `onImageTap` / `onSpreadTapEmpty` / `spreadReady`——**一条翻页输入都没有**。

而滚轮（`wheel` → `onWheelPaginate`）、横扫（`touchend` → `onSwipe`）、键桥全长在**正文引擎**里，由 `_onChapterLoadComplete` 注入；那里第一句就是 BUG-1280 ③ 的守卫 `if (_spreadDocumentLoaded) return;`。

- **Windows**：`loadData` → `NavigateToString` 丢 baseUrl → `onLoadStop` 判 stale → 正文引擎**从来**没进过 spread 文档，所以双页页面自始至终没有滚轮翻页。
- **Android**：BUG-1280 修复前因 baseUrl 被保留而白捡过这些手势，守卫落地后一并消失——BUG-1280 备注已明确记账并留了 TODO：「给 spread 独立文档补它自己的 onSwipe + 键桥」。

键盘那一半还叠了 TODO-1078 / BUG-136：Windows 的 WebView2 一持有 OS 焦点，按键只存在于 DOM 里，Flutter 的 `Focus.onKeyEvent` 收不到——正文靠注入的键桥回传，spread 没有键桥。

## 修法

三条通道都由 spread 文档**自带**，且**全部直连既有 Dart handler**，Dart 侧不新增任何翻页语义（节流 / 跨章冷却 / 虚拟页翻页仍是 `_paginate` → `_handlePageTurnLimit` 那一份）：

| 通道 | 做法 |
|---|---|
| 滚轮 | 文档级 `wheel` → `onWheelPaginate(dir, axis)`，与正文 `_handlePagedWheelTick` 逐字同款语义 |
| 横扫 | `touchstart`/`touchend` → `onSwipe`，判据同正文 `touchend` 分支；阈值从 `ReaderSettings.swipePageTurnDistThresholds` 这一真值取（随灵敏度设置缩放），spread 侧不另立默认 |
| 键盘 | 新 `onSpreadKey` 桥，token 表由 `spreadKeyBridgeTokens` 按注册表**当前**绑定实时导出（翻页/唤收底栏/退出书），改键即时跟随；Dart 侧走与 Flutter 焦点路径**同一个** `resolveKeyboard` |

- **裸 Space 恒排除**：归与正文逐字同款的 `onSpaceKey` 桥（经 `resolveReaderSpaceOverride` 分流「有声书激活 → 播放/暂停」）。两座桥都在本 document 装 `keydown`，不排除就翻两页。
- **合成 click 抑制**：横扫后浏览器仍会合成一次 `click`，不拦就会同时弹图片查看器。capture 阶段单点吞掉（700ms 一次性窗口，不粘住后续真实点击）。
- 顺带把 `swipe_page_turn_sensitivity` 的兜底默认提成 `ReaderSettings.defaultSwipePageTurnSensitivity`——它现在有了第二个读取方，两处字面量 `1.0` 会让改默认手感只改到一半。

## 测试

新增 `hibiki/test/reader/spread_page_turn_input_test.dart`（10 条）：
- **行为级**（生产 HTML 的 `<script>` 原样丢进 node 真跑，最小假 DOM + capture/bubble 分桶）：滚轮下滚=forward/上滚=backward/主轴取绝对值更大者/零位移不翻页；横扫过阈值才翻且方向正确，纵向拖动与亚阈值抖动不翻页；横扫后的合成 click 在 capture 被吞掉且不到达任何桥，而**之后**的真实点击照常开图片查看器。
- **token 表真行为**：未装载给空表；每个 token 都能反解析回声明的动作集；裸 Space 恒不在表内；改键后表跟着变。
- **源码守卫**：`onSpreadKey` handler 的解析/执行/reclaim 链；`_loadSpreadPage` 真的把阈值/键桥/Space 桥都传进去。

**变异实测 5 次，全部转红**：① 拆掉 wheel 桥的 handler 名 ② 滚轮方向反转 ③ 删掉合成 click 的 capture 吞噬 ④ 键桥解析出动作却不执行 ⑤ 不再把裸 Space 让给 onSpaceKey 桥。

既有两处 wheel 守卫（`swipe_page_turn_no_animation_test` / `scroll_cross_chapter_try_scroll_test`）的锚点收紧到正文引擎那份（新增 `bodyEngineWheelListenerStart`）——它们用裸 `indexOf("addEventListener('wheel'")`，会锚到位置更靠前的 spread wheel 监听上，在实现正确时转红。这是实测打出来的。

验证：`flutter analyze`（含 test）无 issue；`test/reader` + `test/pages` 经 `flutter_test_failures.dart` 全绿（**3892 tests ran, all tests passed**）。

## 已知缺口（不淡化）

- **没做鼠标拖动翻页**。正文桌面端有 pointer-drag → `onSwipe`，spread 只补了 touch 横扫；它与图片查看器的 click 语义纠缠更深，而桌面主诉（滚轮）已修好。
- 键桥 token 表在**装载 spread 文档那一刻**求值，改键后需重新进一次双页页面才生效（与正文「每章重注入」同构）。
- **未做真机复测**：Windows 原始路径与 Android 横扫都只有静态证据链 + node 行为级测试。

https://claude.ai/code/session_013jGkJMnizk7khprD1dNfhS
