### PR TITLE
test(reader): TODO-2527 第一批 —— reader 合并语料高危守卫窗口收成词法原语

### DIFF
--- a/hibiki/test/pages/reader_chapter_html_cache_test.dart
+++ b/hibiki/test/pages/reader_chapter_html_cache_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
 import 'reader_hibiki_page_source_corpus.dart';
 
 /// BUG-270 (TODO-296 B) 守卫：锁定跨章 sanitize-HTML LRU 缓存 + 下一章预取的接线。
@@ -19,103 +20,105 @@ void main() {
       // _putChapterHtml / _buildSanitizedChapterHtmlBytes /
       // _prefetchAdjacentChapter / _onChapterLoadComplete 已搬到
       // reader_hibiki/webview.part.dart，故改读「主壳 + 全部 part」合并语料。
-      src = readReaderPageSource();
+      // TODO-2527: 语料先掩码 + 窗口改花括号配对。旧写法七个窗口全是「本方法名 →
+      // **下一个**方法名」的文本切片（其中两个直接切到语料尾部），窗口里夹着别的方法
+      // 体和大段注释；`_kChapterHtmlCacheLimit` / `_prefetchingHtmlPath` /
+      // `scheduleMicrotask` 这些串本来就写在生产注释里，要求型断言可被注释单独满足、
+      // 禁止型断言可被注释误判红。
+      src = maskCommentsAndScriptLines(readReaderPageSource());
     });
 
     test('HTML 缓存是有界 LRU（LinkedHashMap + 容量上限）', () {
       expect(
-          src.contains('LinkedHashMap<String, Uint8List> _sanitizedHtmlCache'),
+          containsCodeLine(
+              src, 'LinkedHashMap<String, Uint8List> _sanitizedHtmlCache'),
           isTrue,
           reason: '跨章 HTML 缓存必须用 LinkedHashMap 维护 LRU 顺序');
-      expect(src.contains('static const int _kChapterHtmlCacheLimit'), isTrue,
+      expect(containsCodeLine(src, 'static const int _kChapterHtmlCacheLimit'),
+          isTrue,
           reason: '缓存必须有界，防无限增长');
     });
 
     test('HTML 资源分支经缓存提供，而非每次原地重建', () {
-      final int payloadIdx = src
-          .indexOf('Future<_ReaderResourceResponse> _readerResourcePayload(');
-      final int interceptIdx =
-          src.indexOf('Future<WebResourceResponse?> _interceptRequest(');
-      expect(payloadIdx, greaterThan(0));
-      expect(interceptIdx, greaterThan(payloadIdx));
-      final String payloadBody = src.substring(payloadIdx, interceptIdx);
-      expect(payloadBody.contains('_chapterHtmlBytes(filePath, data)'), isTrue,
+      final String payloadBody = methodBody(
+          src, 'Future<_ReaderResourceResponse> _readerResourcePayload(');
+      expect(containsCodeLine(payloadBody, '_chapterHtmlBytes(filePath, data)'),
+          isTrue,
           reason: 'HTML 分支必须走 _chapterHtmlBytes（命中缓存/失效重建），'
               '不能在资源分支里内联 sanitize+inject');
 
-      final int chapterIdx = src.indexOf('Uint8List _chapterHtmlBytes(');
-      expect(chapterIdx, greaterThan(interceptIdx));
-      final String interceptBody = src.substring(interceptIdx, chapterIdx);
-      expect(interceptBody.contains('_readerResourcePayload(url)'), isTrue,
+      final String interceptBody =
+          methodBody(src, 'Future<WebResourceResponse?> _interceptRequest(');
+      expect(containsCodeLine(interceptBody, '_readerResourcePayload(url)'),
+          isTrue,
           reason: '_interceptRequest 必须复用共享资源分支，避免 https/custom-scheme '
               '两套路径绕过 HTML 缓存');
     });
 
     test('_chapterHtmlBytes 命中即把条目顶到 MRU', () {
-      final int idx = src.indexOf('Uint8List _chapterHtmlBytes(');
-      expect(idx, greaterThan(0));
-      final int end = src.indexOf('void _putChapterHtml(');
-      final String body = src.substring(idx, end);
-      expect(body.contains('_sanitizedHtmlCache.remove(filePath)'), isTrue);
-      expect(body.contains('_sanitizedHtmlCache[filePath] = cached'), isTrue,
+      final String body = methodBody(src, 'Uint8List _chapterHtmlBytes(');
+      expect(containsCodeLine(body, '_sanitizedHtmlCache.remove(filePath)'),
+          isTrue);
+      expect(containsCodeLine(body, '_sanitizedHtmlCache[filePath] = cached'),
+          isTrue,
           reason: '命中时移除再插入 = 顶到最近使用');
     });
 
     test('_putChapterHtml 超限淘汰最旧条目', () {
-      final int idx = src.indexOf('void _putChapterHtml(');
-      expect(idx, greaterThan(0));
-      final int end = src.indexOf('Uint8List _buildSanitizedChapterHtmlBytes(');
-      final String body = src.substring(idx, end);
-      expect(body.contains('_kChapterHtmlCacheLimit'), isTrue);
+      final String body = methodBody(src, 'void _putChapterHtml(');
+      expect(containsCodeLine(body, '_kChapterHtmlCacheLimit'), isTrue);
       expect(
-          body.contains(
+          containsCodeLine(body,
               '_sanitizedHtmlCache.remove(_sanitizedHtmlCache.keys.first)'),
           isTrue,
           reason: '超限时淘汰 keys.first（最旧/最久未用）');
+      // 旧写法拿 `_buildSanitizedChapterHtmlBytes` 当右边界，顺带证明了它存在。
+      // 换成花括号配对后不再需要它定边界，存在性单独锁住。
+      expect(
+          containsCodeLine(src, 'Uint8List _buildSanitizedChapterHtmlBytes('),
+          isTrue,
+          reason: 'sanitize+inject 构建入口必须还在');
     });
 
     test('样式失效必须清空 HTML 缓存（styleTag 烘进缓存条目）', () {
-      final int idx = src.indexOf('void _invalidateStyleCache()');
-      expect(idx, greaterThan(0));
-      final int end = src.indexOf('Future<void> _applyStylesLive()');
-      final String body = src.substring(idx, end);
-      expect(body.contains('_cachedStyleTag = null'), isTrue);
-      expect(body.contains('_sanitizedHtmlCache.clear()'), isTrue,
+      final String body = methodBody(src, 'void _invalidateStyleCache()');
+      expect(containsCodeLine(body, '_cachedStyleTag = null'), isTrue);
+      expect(containsCodeLine(body, '_sanitizedHtmlCache.clear()'), isTrue,
           reason: '改字号/字体/主题后，缓存里旧 styleTag 的 HTML 必须丢弃');
     });
 
     test('翻章后预取下一章并去重在途读取', () {
-      expect(src.contains('void _prefetchAdjacentChapter('), isTrue);
-      // 预取必须挂在章节加载完成之后
-      final int loadIdx = src.indexOf('Future<void> _onChapterLoadComplete(');
-      expect(loadIdx, greaterThan(0));
-      // _onChapterLoadComplete 是 webview part 的最后一个方法（合并语料末尾），
-      // _invalidateFavoriteSentenceCache 仍在主壳（更早），故切到语料尾部。
-      final String loadBody = src.substring(loadIdx);
-      expect(loadBody.contains('_prefetchAdjacentChapter(chapterSnapshot + 1)'),
+      expect(containsCodeLine(src, 'void _prefetchAdjacentChapter('), isTrue);
+      // 预取必须挂在章节加载完成之后。旧写法把窗口切到**语料尾部**（因为
+      // _onChapterLoadComplete 恰好是 webview part 最后一个方法），一旦后面再加方法，
+      // 窗口就把新方法体也算进来。
+      final String loadBody =
+          methodBody(src, 'Future<void> _onChapterLoadComplete(');
+      expect(
+          containsCodeLine(
+              loadBody, '_prefetchAdjacentChapter(chapterSnapshot + 1)'),
           isTrue,
           reason: '加载完一章后预取下一章（前进翻章方向）');
 
-      final int prefIdx = src.indexOf('void _prefetchAdjacentChapter(');
-      // _prefetchAdjacentChapter 之后在 part 内紧跟 static _isValidFontData。
-      final int prefEnd = src.indexOf('static bool _isValidFontData(', prefIdx);
-      expect(prefEnd, greaterThan(prefIdx));
-      final String prefBody = src.substring(prefIdx, prefEnd);
-      expect(prefBody.contains('_prefetchingHtmlPath'), isTrue,
+      final String prefBody = methodBody(src, 'void _prefetchAdjacentChapter(');
+      expect(containsCodeLine(prefBody, '_prefetchingHtmlPath'), isTrue,
           reason: '在途预取要去重，避免与落地导航重复读盘');
-      expect(prefBody.contains('_sanitizedHtmlCache.containsKey(filePath)'),
+      expect(
+          containsCodeLine(
+              prefBody, '_sanitizedHtmlCache.containsKey(filePath)'),
           isTrue,
           reason: '已缓存就跳过预取');
       // 渐进重建 phase2：旧断言钉的 scheduleMicrotask 恰是问题本身——microtask
       // 在当前任务展开后立刻同步执行，读盘+净化全落在同一帧内（假「后台」）。
       // 现钉事件队列任务 + 异步 IO + style epoch 过期丢弃三件套。
-      expect(prefBody.contains('scheduleMicrotask'), isFalse,
+      expect(containsCodeLine(prefBody, 'scheduleMicrotask'), isFalse,
           reason: 'microtask 同帧同步执行会阻塞 UI，预取必须走事件队列任务');
-      expect(prefBody.contains('unawaited(Future<void>(()'), isTrue,
+      expect(containsCodeLine(prefBody, 'unawaited(Future<void>(()'), isTrue,
           reason: '预取走事件队列任务（当前帧先收尾）+ 异步读盘');
-      expect(prefBody.contains('await file.readAsBytes()'), isTrue,
+      expect(containsCodeLine(prefBody, 'await file.readAsBytes()'), isTrue,
           reason: 'IO 必须异步，让出主 isolate');
-      expect(prefBody.contains('_styleEpoch != styleEpochAtStart'), isTrue,
+      expect(containsCodeLine(prefBody, '_styleEpoch != styleEpochAtStart'),
+          isTrue,
           reason: '真异步后必须按 style epoch 丢弃跨样式失效的过期结果'
               '（styleTag 烤进缓存条目，旧代际入缓存=脏样式）');
     });

--- a/hibiki/test/reader/book_open_perf_wiring_guard_test.dart
+++ b/hibiki/test/reader/book_open_perf_wiring_guard_test.dart
@@ -1,16 +1,23 @@
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 
 /// TODO-131 守卫：锁定「打开书籍白屏优化」的开书路径接线，防回归。
 /// reader_hibiki_page.dart 太重（WebView + DB + profile providers）不便在 host
 /// widget 测试里整页 mount，纯函数等价性由 book_open_char_counts_test.dart 覆盖；
 /// 这里用源码扫描守住 _initBook 的关键时序/数据流不变量。
+///
+/// TODO-2527：语料先过 [maskCommentsAndScriptLines]，方法体窗口改由 [methodBody]
+/// 的花括号配对给出。旧写法两处都能假绿：
+/// - 窗口是「本方法签名 → **下一个**方法签名」的文本切片，中间夹的方法体也算进窗口；
+/// - 窗口不掩码，`_recomputeCharCountsInBackground` / `_chapterCumulativeChars`
+///   这些符号本来就写在本页的说明注释里，实现删光只留注释照样绿。
 void main() {
   late String src;
 
   setUpAll(() {
-    src = readReaderPageSource();
+    src = maskCommentsAndScriptLines(readReaderPageSource());
   });
 
   test('_initBook 并行起跑 profile/settings 链与书本定位/解析链', () {
@@ -29,91 +36,89 @@ void main() {
   });
 
   test('开书优先复用 DB 已存的 per-chapter 字符数（跳过整本 html_parser 计数）', () {
-    expect(src.contains('parseBookOnly'), isTrue,
+    expect(containsCodeLine(src, 'parseBookOnly'), isTrue,
         reason: '冷开首屏走 parseBookOnly（不在 isolate 里整本计数）');
-    expect(src.contains('charCountsFromChaptersJson('), isTrue,
+    expect(containsCodeLine(src, 'charCountsFromChaptersJson('), isTrue,
         reason: '必须从 chaptersJson 复用 DB 计数');
     // 整本「解析+计数」入口 parseAndCountChapters 不应再出现在开书路径
     // （只保留给等价性测试/旧路径），否则等于没省下计数。
-    expect(src.contains('compute(parseAndCountChapters'), isFalse,
+    expect(containsCodeLine(src, 'compute(parseAndCountChapters'), isFalse,
         reason: '_initBook 不应再 compute(parseAndCountChapters)——那会整本计数');
   });
 
   test('DB 计数缺失时后台补算并重置统计基准（避免 charDiff 幻象 spike）', () {
-    expect(src.contains('_recomputeCharCountsInBackground'), isTrue);
+    expect(containsCodeLine(src, '_recomputeCharCountsInBackground'), isTrue);
     // 后台补算落定后必须重置统计水位 _sessionMaxAbsoluteChars（TODO-147 改名前
     // 为 _lastAbsoluteCount），否则零计数期间它停在 0，计数落定后首个进度回调会把
     // 整段前缀误当本次新读字数累进统计。
-    final int recomputeIdx =
-        src.indexOf('void _recomputeCharCountsInBackground()');
-    expect(recomputeIdx, greaterThan(0));
-    final int nextMethodIdx =
-        src.indexOf('Future<EpubBook?> _buildBookFromDb(');
-    final String body = src.substring(recomputeIdx, nextMethodIdx);
-    expect(body.contains('_sessionMaxAbsoluteChars = _absoluteCharPosition('),
+    final String body =
+        methodBody(src, 'void _recomputeCharCountsInBackground()');
+    expect(
+        containsCodeLine(
+            body, '_sessionMaxAbsoluteChars = _absoluteCharPosition('),
         isTrue,
         reason: '补算落定后必须把统计水位校到当前位置，杜绝统计 spike');
-    expect(body.contains('identical(_book, book)'), isTrue,
+    expect(containsCodeLine(body, 'identical(_book, book)'), isTrue,
         reason: '只在仍是同一本书时采用补算结果（防换书竞态）');
   });
 
   test('_applyCharCounts 重建累计前缀并刷新进度总字数', () {
-    final int idx = src.indexOf('void _applyCharCounts(List<int> counts)');
-    expect(idx, greaterThan(0));
-    final int end = src.indexOf('void _recomputeCharCountsInBackground()');
-    final String body = src.substring(idx, end);
-    expect(body.contains('_chapterCumulativeChars'), isTrue);
-    expect(body.contains('_progressTotalChars'), isTrue);
+    final String body =
+        methodBody(src, 'void _applyCharCounts(List<int> counts)');
+    expect(containsCodeLine(body, '_chapterCumulativeChars'), isTrue);
+    expect(containsCodeLine(body, '_progressTotalChars'), isTrue);
   });
 
   test('跨章收藏高亮复用书内缓存并按 section 过滤', () {
-    expect(src, contains('_favoriteSentencesForBookCache'),
+    expect(containsCodeLine(src, '_favoriteSentencesForBookCache'), isTrue,
         reason: 'reader 应缓存当前书收藏，跨章只做内存过滤，避免每章全量 getAll/decode/sort');
-    expect(src, contains('_favoriteSentencesForSection'));
+    expect(containsCodeLine(src, '_favoriteSentencesForSection'), isTrue);
 
-    final int helperIdx = src.indexOf('_favoriteSentencesForSection');
-    final int applyIdx = src.indexOf('Future<void> _applyChapterHighlights()');
-    final int lyricsIdx = src.indexOf('Future<void> _applyLyricsFavorites()');
-    final int refreshIdx =
-        src.indexOf('Future<void> _refreshSectionHighlights(int section)');
-    final int toggleIdx = src.indexOf('Future<void> _toggleFavoriteSentence()');
-    expect(helperIdx, greaterThan(0));
-    expect(applyIdx, greaterThan(0));
-    expect(lyricsIdx, greaterThan(applyIdx));
-    expect(refreshIdx, greaterThan(lyricsIdx));
-    expect(toggleIdx, greaterThan(refreshIdx));
-
-    final String helperBody = src.substring(helperIdx, applyIdx);
-    expect(helperBody, contains('s.bookKey == widget.bookKey'));
-    expect(helperBody, contains('s.sectionIndex == section'),
+    final String helperBody = methodBody(
+        src, 'Future<List<FavoriteSentence>> _favoriteSentencesForSection(');
+    expect(containsCodeLine(helperBody, 's.bookKey == widget.bookKey'), isTrue);
+    expect(containsCodeLine(helperBody, 's.sectionIndex == section'), isTrue,
         reason: '章节高亮必须只取当前 section，不能把整本收藏都交给高亮桥');
 
-    final String applyBody = src.substring(applyIdx, lyricsIdx);
-    final String refreshBody = src.substring(refreshIdx, toggleIdx);
+    // 旧写法拿 `_applyLyricsFavorites` 当 `_applyChapterHighlights` 的右边界，
+    // 顺带证明了它存在。换成花括号配对后不再需要它定边界，存在性单独锁住，
+    // 避免这次迁移悄悄少守一个符号。
     expect(
-        applyBody, contains('_favoriteSentencesForSection(_currentChapter)'));
-    expect(refreshBody, contains('_favoriteSentencesForSection(section)'));
-    expect(applyBody, isNot(contains('getAll()')),
+        containsCodeLine(src, 'Future<void> _applyLyricsFavorites()'), isTrue,
+        reason: '歌词模式收藏高亮入口必须还在');
+    final String applyBody =
+        methodBody(src, 'Future<void> _applyChapterHighlights()');
+    final String refreshBody =
+        methodBody(src, 'Future<void> _refreshSectionHighlights(int section)');
+    expect(
+        containsCodeLine(
+            applyBody, '_favoriteSentencesForSection(_currentChapter)'),
+        isTrue);
+    expect(
+        containsCodeLine(refreshBody, '_favoriteSentencesForSection(section)'),
+        isTrue);
+    expect(containsCodeLine(applyBody, 'getAll()'), isFalse,
         reason: '_applyChapterHighlights 跑在每章加载路径，不能每章全量解码收藏');
-    expect(refreshBody, isNot(contains('getAll()')),
+    expect(containsCodeLine(refreshBody, 'getAll()'), isFalse,
         reason: '_refreshSectionHighlights 也应复用缓存并只按 section 筛');
   });
 
   test('收藏新增删除会失效缓存再刷新高亮', () {
-    expect(src, contains('void _invalidateFavoriteSentenceCache()'));
+    expect(containsCodeLine(src, 'void _invalidateFavoriteSentenceCache()'),
+        isTrue);
 
-    final int settingsIdx = src.indexOf('Future<void> _showAppearanceSheet(');
-    final int progressIdx = src.indexOf('Widget _buildTopProgressBar()');
-    final int toggleIdx = src.indexOf('Future<void> _toggleFavoriteSentence()');
-    expect(settingsIdx, greaterThan(0));
-    expect(progressIdx, greaterThan(settingsIdx));
-    expect(toggleIdx, greaterThan(progressIdx));
-    // TODO-589 batch7: these methods moved into reader_hibiki/chrome.part.dart
-    // (last in the merged corpus); `buildPopupAudioControls` is an @override that
-    // stays in the shell (earlier in the corpus), so it is no longer a valid end
-    // marker — `_toggleFavoriteSentence` is the final member, slice to EOF.
-    final String settingsBody = src.substring(settingsIdx, progressIdx);
-    final String toggleBody = src.substring(toggleIdx);
+    // TODO-589 batch7: 这些方法搬进了 reader_hibiki/chrome.part.dart（合并语料末尾）。
+    // 旧写法用「下一个方法名」当右边界，方法一被搬走/改名窗口就整段错位；改成花括号
+    // 配对后窗口与成员顺序、文件归属无关。旧右边界 `_buildTopProgressBar` 的存在性
+    // 单独锁住，不因这次迁移丢覆盖。
+    expect(containsCodeLine(src, 'Widget _buildTopProgressBar()'), isTrue,
+        reason: '顶栏进度条构建入口必须还在');
+    final String settingsBody = methodBody(
+        src, 'Future<void> _showAppearanceSheet({String? initialSubPage})');
+    final String toggleBody =
+        methodBody(src, 'Future<void> _toggleFavoriteSentence()');
+    // 这两条锚点是**跨行**的相邻语句对（「删完紧接着失效缓存」），containsCodeLine 逐行
+    // 匹配表达不了，故保留整段 contains——窗口已掩码，注释满足不了它。
     expect(
         settingsBody,
         contains(
@@ -124,7 +129,8 @@ void main() {
     // 缩进）。守卫更新到当前缩进，不变量强度不变：内容键删除仍走 removeByContent 单条删。
     expect(toggleBody,
         contains('await repo.removeByContent(\n          text: sentence,'));
-    expect(toggleBody, contains('_invalidateFavoriteSentenceCache();'));
+    expect(containsCodeLine(toggleBody, '_invalidateFavoriteSentenceCache();'),
+        isTrue);
     // 删除路径（内容键回退分支）删后必失效缓存。
     final int removeIdx = toggleBody.indexOf('await repo.removeByContent(');
     final int removeInvalidateIdx =
@@ -142,9 +148,10 @@ void main() {
     expect(rebuildAfterAddIdx, greaterThan(addIdx),
         reason: '新增收藏后必须 rebuild 星标态');
     final String addBody = toggleBody.substring(addIdx, rebuildAfterAddIdx);
-    expect(addBody, contains('_currentFavoriteId = fav.id;'),
+    expect(containsCodeLine(addBody, '_currentFavoriteId = fav.id;'), isTrue,
         reason: 'BUG-494：新增后记住精确 id，供随后 removeById 精确删单条');
-    expect(addBody, contains('_invalidateFavoriteSentenceCache();'),
+    expect(containsCodeLine(addBody, '_invalidateFavoriteSentenceCache();'),
+        isTrue,
         reason: '新增收藏后必须失效缓存重新拉取/过滤，保证高亮和星标状态准确');
   });
 }

--- a/hibiki/test/reader/reader_inchapter_progress_scroll_test.dart
+++ b/hibiki/test/reader/reader_inchapter_progress_scroll_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_page.dart'
     show parseReaderStableProgressDetails, readerScrollProgressRefreshAllowed;
 
+import '../helpers/source_guard.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 
 /// BUG-213：章内原生滚动进度不更新（用户：「章内滚动进度不会动，只有到下一章了
@@ -127,114 +128,135 @@ void main() {
     });
   });
 
+  // TODO-2527：本组四个窗口原来全是**定长字符窗口**（`idx + 700` / `+2700` / `+1400`
+  // / `+3200`），注释里已经写着「窗口放宽到 2700 / 1400」——那正是定长窗口塌掉时的
+  // 典型补丁史：函数体一长，被守的那一项就漂出窗口，守卫凭空变假。而且窗口从**原始**
+  // 语料切，`requestAnimationFrame` / `_refreshProgress()` / `throttleMs` 这些串本来
+  // 就写在生产注释里（reader 合并语料 37% 是注释），把实现删光只留注释照样绿。
+  // 现在：语料先掩码，窗口由花括号配对给出（Dart 侧 methodBody，JS 侧 JS 词法）。
   group('源码守卫：章内滚动进度回传通道存在（防回归）', () {
     late String src;
+    late String engineJs;
 
     setUpAll(() {
-      src = readReaderPageSource();
+      src = maskCommentsAndScriptLines(readReaderPageSource());
+      engineJs = _engineJs(src);
     });
 
     test('setup 脚本注册 window+document scroll 监听并回传 onReaderScroll', () {
       // 通道必须挂在两模式共享的 setup 脚本里（_buildReaderSetupScript），且对 window
       // 与 document 都监听（覆盖连续模式 window 滚动 + 分页模式 body 内部滚动）。
       // TODO-718：第二参传 isUserDriven（最近真实用户输入驱动），故匹配前缀不含闭括号。
-      expect(src.contains("callHandler('onReaderScroll'"), isTrue,
+      expect(containsCodeLine(src, "callHandler('onReaderScroll'"), isTrue,
           reason: 'scroll reporter 必须经 callHandler 把进度回传 Dart');
       expect(
-        src.contains("window.addEventListener('scroll', _onReaderScrollEvent"),
+        containsCodeLine(
+            src, "window.addEventListener('scroll', _onReaderScrollEvent"),
         isTrue,
         reason: '必须监听 window scroll（连续模式 window 原生滚动）',
       );
       expect(
-        src.contains(
-            "document.addEventListener('scroll', _onReaderScrollEvent"),
+        containsCodeLine(
+            src, "document.addEventListener('scroll', _onReaderScrollEvent"),
         isTrue,
         reason: '必须监听 document scroll capture（分页模式 body 内部滚动）',
       );
     });
 
     test('BUG-380：回传通道是 rAF 节流（边滑边回传）+ 尾沿补一发，且抑制重锚瞬态', () {
-      expect(src.contains('requestAnimationFrame'), isTrue);
+      expect(containsCodeLine(src, 'requestAnimationFrame'), isTrue);
       // rAF 节流：滑动中每个动画帧最多回传一次（合并同帧多次 scroll 事件），进度边滑
       // 边实时跟随。锁住「rAF 在飞时不再排新 rAF」这个节流不变量——若回退成纯尾沿
       // 去抖（每次都 clearTimeout 推后定时器、滑动期间不回传），下面的断言会转红。
-      final int idx = src.indexOf('function _onReaderScrollEvent()');
-      expect(idx, greaterThan(0), reason: '_onReaderScrollEvent 必须存在');
-      final String handler = src.substring(idx, idx + 700);
-      expect(handler.contains('if (!_progressScrollRaf) {'), isTrue,
+      final String handler = methodBody(
+          engineJs, 'function _onReaderScrollEvent()',
+          lexicon: SourceLexicon.js);
+      expect(containsCodeLine(handler, 'if (!_progressScrollRaf) {'), isTrue,
           reason: 'rAF 节流：在飞期不再排新 rAF，滑动中按帧回传（不是纯尾沿去抖）');
-      expect(handler.contains('_reportReaderScroll();'), isTrue,
+      expect(containsCodeLine(handler, '_reportReaderScroll();'), isTrue,
           reason: 'rAF 回调里必须直接回传，让进度边滑边更新');
       // 尾沿补一发：滑停后短延时再回传一次最终位置（rAF 节流不保证捕捉到静止帧）。
-      expect(handler.contains('_progressScrollTimer'), isTrue,
+      expect(containsCodeLine(handler, '_progressScrollTimer'), isTrue,
           reason: '尾沿补发必须有 timer 变量');
-      expect(handler.contains('}, 120);'), isTrue,
+      expect(containsCodeLine(handler, '}, 120);'), isTrue,
           reason: '尾沿补发延时（120ms）回传最终静止位置');
-      expect(handler.contains('clearTimeout(_progressScrollTimer)'), isTrue,
+      expect(containsCodeLine(handler, 'clearTimeout(_progressScrollTimer)'),
+          isTrue,
           reason: '新滚动须重置尾沿补发 timer');
       // 防回归：滑动期间不得只靠尾沿（旧 bug 是 rAF 内再套 setTimeout 200ms 纯去抖）。
-      expect(handler.contains('}, 200);'), isFalse,
+      expect(containsCodeLine(handler, '}, 200);'), isFalse,
           reason: 'BUG-380：不得回退成「rAF 内套 200ms 纯尾沿去抖」(滑动中不回传)');
-      expect(src.contains('r._reanchorPending === true) return'), isTrue,
+      expect(
+          containsCodeLine(src, 'r._reanchorPending === true) return'), isTrue,
           reason: '程序化重锚期（_reanchorPending）必须跳过回传，避免恢复/重排瞬态误触发');
     });
 
     test('Dart 注册 onReaderScroll handler 并走纯函数门控后 coalesce 刷新', () {
-      expect(src.contains("handlerName: 'onReaderScroll'"), isTrue,
+      expect(containsCodeLine(src, "handlerName: 'onReaderScroll'"), isTrue,
           reason: '必须注册 onReaderScroll JS handler');
       // TODO-718：callback 现按 isUserDriven 传 _handleReaderScroll(bool)，签名加参。
-      expect(src.contains('_handleReaderScroll('), isTrue);
-      final int idx = src.indexOf('void _handleReaderScroll()');
-      expect(idx, greaterThan(0), reason: '_handleReaderScroll 必须存在');
-      // 窗口放宽到 2700：TODO-151/164(BUG-225) 诊断块 + TODO-736 B-3 settle 块 + TODO-718
-      // 顶部解武装块，函数体持续加长（旧窗口会切断在分发前漏掉末尾误转红）。
-      final String body = src.substring(idx, idx + 2700);
-      expect(body.contains('readerScrollProgressRefreshAllowed('), isTrue,
+      expect(containsCodeLine(src, '_handleReaderScroll('), isTrue);
+      final String body = methodBody(src, 'void _handleReaderScroll()');
+      expect(
+          containsCodeLine(body, 'readerScrollProgressRefreshAllowed('), isTrue,
           reason: '门控必须走纯函数 readerScrollProgressRefreshAllowed');
       // BUG-380：门控通过后走 coalesce 守卫（高频滚动不堆积 evaluateJavascript），
       // 而不是裸调 _refreshProgress()。
-      expect(body.contains('_refreshProgressFromScroll();'), isTrue,
+      expect(containsCodeLine(body, '_refreshProgressFromScroll();'), isTrue,
           reason: '滚动路径门控通过后必须走 _refreshProgressFromScroll coalesce 守卫');
     });
 
     test('BUG-380/卡死：_refreshProgressFromScroll 是 coalesce 守卫 + 50ms 节流', () {
-      final int idx = src.indexOf('void _refreshProgressFromScroll()');
-      expect(idx, greaterThan(0), reason: '_refreshProgressFromScroll 必须存在');
-      // 窗口放宽到 1400：卡死修复在此函数内插入了时间节流块，函数体加长。
-      final String body = src.substring(idx, idx + 1400);
+      final String body = methodBody(src, 'void _refreshProgressFromScroll()');
       // 在飞时再来的滚动只置 pending，不并发跑第二次 evaluateJavascript。
-      expect(body.contains('if (_scrollProgressInFlight) {'), isTrue,
+      expect(containsCodeLine(body, 'if (_scrollProgressInFlight) {'), isTrue,
           reason: '在飞期必须只置 pending，避免 hoshiProgressDetails 调用堆积');
-      expect(body.contains('_scrollProgressPending = true;'), isTrue);
+      expect(containsCodeLine(body, '_scrollProgressPending = true;'), isTrue);
       // 飞完后若有 pending 补跑一次，保证最终静止位置一定被刷到。
-      expect(body.contains('whenComplete('), isTrue,
+      expect(containsCodeLine(body, 'whenComplete('), isTrue,
           reason: '必须在刷新完成后清在飞标记并按 pending 补跑（coalesce）');
-      expect(body.contains('_refreshProgress()'), isTrue,
+      expect(containsCodeLine(body, '_refreshProgress()'), isTrue,
           reason: 'coalesce 守卫最终仍调既有 _refreshProgress 重算进度');
       // 卡死修复：时间节流（对齐 hoshi 安卓 CONTINUOUS_PROGRESS_THROTTLE_MS=50ms）。原本只有
       // coalesce、一完成就背靠背补跑 calculateProgress 全文重算 → 鼠标拖动/连续滚动把 WebView
       // JS 线程占满卡死。节流后滑动中最多每 50ms 一次 + 尾沿补发最终位置。
-      expect(body.contains('throttleMs'), isTrue,
+      expect(containsCodeLine(body, 'throttleMs'), isTrue,
           reason: '滚动进度重算必须时间节流，否则背靠背全文重算 → JS 卡死（对齐 hoshi 安卓 50ms）');
-      expect(body.contains('_scrollProgressThrottleTimer'), isTrue,
+      expect(containsCodeLine(body, '_scrollProgressThrottleTimer'), isTrue,
           reason: '节流尾沿 timer 必须存在（保证停止后最终位置被刷到）');
     });
 
     test('刷新进度必须走 stableProgressInvocation，避免恢复/重锚瞬态 0 落库', () {
-      final int idx = src.indexOf('Future<void> _refreshProgress() async');
-      expect(idx, greaterThan(0), reason: '_refreshProgress 必须存在');
-      final String body = src.substring(idx, idx + 3200);
+      final String body =
+          methodBody(src, 'Future<void> _refreshProgress() async');
       expect(
-        body.contains('ReaderPaginationScripts.stableProgressInvocation()'),
+        containsCodeLine(
+            body, 'ReaderPaginationScripts.stableProgressInvocation()'),
         isTrue,
         reason: '恢复完成和滚动回传复用 _refreshProgress；这里必须走 stable '
             'gate，_reanchorPending 时返回 null，不能直接读瞬态 progress=0',
       );
       expect(
-        body.contains("source: 'window.hoshiProgressDetails()'"),
+        containsCodeLine(body, "source: 'window.hoshiProgressDetails()'"),
         isFalse,
         reason: '裸 hoshiProgressDetails 会绕过 _reanchorPending/settled gate',
       );
     });
   });
+}
+
+/// 从**掩码后**的合并语料里切出注入 WebView 的引擎脚本（三引号 JS 语料）。
+///
+/// 需要单独切一刀是因为 [methodBody] 的 [SourceLexicon.js] 只能扫纯 JS：直接对整份
+/// Dart 语料用 JS 词法，会把 `'''` 读成「空串 + 新串」，三引号里的花括号被当成串内容
+/// 抹掉，配对当场跑偏。先按 Dart 侧的稳定标记把 JS blob 切出来，再在里面用 JS 词法
+/// 配对函数体。两个标记都是代码本体，掩码后仍在。
+String _engineJs(String maskedSource) {
+  const String start = 'window.__hoshiEngine = {';
+  const String end = r'$longPressDragJs';
+  final int startIndex = maskedSource.indexOf(start);
+  expect(startIndex, isNonNegative, reason: '找不到注入引擎脚本起点：$start');
+  final int endIndex = maskedSource.indexOf(end, startIndex + start.length);
+  expect(endIndex, greaterThan(startIndex), reason: '找不到注入引擎脚本终点：$end');
+  return maskedSource.substring(startIndex, endIndex);
 }

--- a/hibiki/test/reader/reader_mouse_drag_scroll_guard_static_test.dart
+++ b/hibiki/test/reader/reader_mouse_drag_scroll_guard_static_test.dart
@@ -1,16 +1,28 @@
 import 'package:flutter_test/flutter_test.dart';
+import '../helpers/source_guard.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 
+/// TODO-2527：本文件所有窗口从**掩码语料**上切、断言一律 [containsCodeLine]。
+///
+/// 旧写法有两个洞，reader 合并语料里注释占 37%，两个洞都是现成的假绿机会：
+/// - 窗口从**原始**语料切 ⇒ 窗口里的 JS 注释参与 `contains`，把实现删光、注释里留下
+///   同名字面量（`_wheelBoundaryArmed`、`window.getSelection` 这类符号本来就写在生产
+///   注释里）照样绿；
+/// - 窗口右边界是 `indexOf('}, {passive:')` / 「下一个函数签名」这种**文本**标记，
+///   窗口会横跨到别的监听器 / 别的函数里，断言命中的可能根本不是被守的那一段。
+///
+/// 现在：语料先过 [maskCommentsAndScriptLines]（Dart 注释 + 三引号里的 JS 注释一起换
+/// 等长空白），窗口由 [methodBody] 的花括号配对给出（JS 词法），断言走 [containsCodeLine]。
 void main() {
-  late String source;
   late String setupScript;
 
   setUpAll(() {
     // TODO-589 batch8: setup 脚本(鼠标拖动状态机)已搬到
     // reader_hibiki/webview.part.dart，改读「主壳 + 全部 part」合并语料。
-    source = readReaderPageSource();
+    // TODO-2527: 语料先掩码——三引号里的 JS 注释与 Dart 注释一起变等长空白，
+    // 下标与原文逐字节对齐，切片位置不变、注释不再能满足任何断言。
     setupScript = _between(
-      source,
+      maskCommentsAndScriptLines(readReaderPageSource()),
       r'var hoshiContinuousMode = C.continuousMode;',
       'window.hoshiProgressDetails = function()',
     );
@@ -18,30 +30,32 @@ void main() {
 
   test('continuous pointer drag captures reader body text; paged protects it',
       () {
-    final String guard = _functionSource(
+    final String guard = _jsFunction(
       setupScript,
       'function _hoshiReaderMouseDragStartAllowed(e)',
-      'function _hoshiReaderMouseDragScrollBy(dx, dy)',
     );
 
-    expect(guard, contains('_hoshiReaderPointerPrimaryButton(e)'));
-    expect(guard, isNot(contains("e.pointerType !== 'mouse'")),
+    expect(
+        containsCodeLine(guard, '_hoshiReaderPointerPrimaryButton(e)'), isTrue);
+    expect(containsCodeLine(guard, "e.pointerType !== 'mouse'"), isFalse,
         reason: 'touch and mouse must share the same drag state machine');
-    expect(guard, contains("closest('a[href], ruby, rt, rp')"),
+    expect(containsCodeLine(guard, "closest('a[href], ruby, rt, rp')"), isTrue,
         reason:
             'links and ruby text must keep native selection/click behavior');
-    expect(guard, contains('input, textarea, select, button'),
+    expect(containsCodeLine(guard, 'input, textarea, select, button'), isTrue,
         reason: 'form controls must keep native editing and selection');
-    expect(guard, contains('[contenteditable="true"]'),
+    expect(containsCodeLine(guard, '[contenteditable="true"]'), isTrue,
         reason: 'editable islands must not be grabbed for reader scrolling');
-    expect(guard, contains('window.getSelection'),
+    expect(containsCodeLine(guard, 'window.getSelection'), isTrue,
         reason: 'an existing text selection must not be grabbed for dragging');
     // 砍掉 PC 鼠标左键拖动平移：连续模式 _hoshiReaderMouseDragStartAllowed 返 false，
     // 鼠标左键回归原生选字/划词；不再捕获正文做 JS scrollBy 平移（卡顿 + 鼠标拖动提前
     // 跨章的来源）。分页模式仍走下方 caret 命中逻辑（拖动转翻页 BUG-368 不受影响）。
-    expect(guard, contains('if (hoshiContinuousMode) return false;'),
+    expect(containsCodeLine(guard, 'if (hoshiContinuousMode) return false;'),
+        isTrue,
         reason: '连续模式鼠标左键回归原生选字/划词，不再捕获正文拖动平移（已砍）');
-    expect(guard, isNot(contains('if (hoshiContinuousMode) return true;')),
+    expect(containsCodeLine(guard, 'if (hoshiContinuousMode) return true;'),
+        isFalse,
         reason: '旧的「连续模式捕获正文拖动平移」已砍，防回归');
     final int continuousModeIndex =
         guard.indexOf('if (hoshiContinuousMode) return false;');
@@ -54,8 +68,9 @@ void main() {
     expect(caretHitIndex, greaterThan(continuousModeIndex),
         reason: 'caret-range text hits must only protect paged mode');
 
-    final String pointerDown = _listenerBlock(setupScript, 'pointerdown');
-    expect(pointerDown, isNot(contains("e.pointerType === 'touch' ||")),
+    final String pointerDown = _jsListener(setupScript, 'pointerdown');
+    expect(
+        containsCodeLine(pointerDown, "e.pointerType === 'touch' ||"), isFalse,
         reason: 'touch must not be filtered out of pointer drag startup');
     final int guardIndex =
         pointerDown.indexOf('_hoshiReaderMouseDragStartAllowed(e)');
@@ -69,46 +84,52 @@ void main() {
   test(
       'text caret range helper uses browser hit testing without preventDefault',
       () {
-    final String helper = _functionSource(
+    final String helper = _jsFunction(
       setupScript,
       'function _hoshiReaderCaretRangeAtPoint(x, y)',
-      'function _hoshiReaderMouseDragStartAllowed(e)',
     );
 
-    expect(helper, contains('document.caretPositionFromPoint'));
-    expect(helper, contains('document.caretRangeFromPoint'));
-    expect(helper, contains('Node.TEXT_NODE'));
-    expect(helper, isNot(contains('preventDefault')),
+    expect(containsCodeLine(helper, 'document.caretPositionFromPoint'), isTrue);
+    expect(containsCodeLine(helper, 'document.caretRangeFromPoint'), isTrue);
+    expect(containsCodeLine(helper, 'Node.TEXT_NODE'), isTrue);
+    expect(containsCodeLine(helper, 'preventDefault'), isFalse,
         reason: 'text hit testing must not cancel native drag selection');
   });
 
   test(
       'claimed pointer drag suppresses pointerup/touchend tap or swipe fallback',
       () {
-    final String pointerMove = _listenerBlock(setupScript, 'pointermove');
-    expect(pointerMove, isNot(contains("e.pointerType === 'touch') return")),
+    final String pointerMove = _jsListener(setupScript, 'pointermove');
+    expect(containsCodeLine(pointerMove, "e.pointerType === 'touch') return"),
+        isFalse,
         reason: 'touch moves must be able to claim reader scrolling');
-    expect(pointerMove, contains('_hoshiReaderPointerStillDown(e)'));
-    expect(pointerMove, contains('_hoshiReaderMouseDragClaimed = true'));
-    expect(pointerMove, contains('_hoshiReaderMouseDragIgnoreTouchEnd = true'),
+    expect(containsCodeLine(pointerMove, '_hoshiReaderPointerStillDown(e)'),
+        isTrue);
+    expect(containsCodeLine(pointerMove, '_hoshiReaderMouseDragClaimed = true'),
+        isTrue);
+    expect(
+        containsCodeLine(
+            pointerMove, '_hoshiReaderMouseDragIgnoreTouchEnd = true'),
+        isTrue,
         reason:
             'claimed touch drags must suppress the following legacy touchend');
-    expect(pointerMove, contains('e.preventDefault()'));
-    expect(pointerMove, contains('_hoshiReaderClearMouseSelection()'),
+    expect(containsCodeLine(pointerMove, 'e.preventDefault()'), isTrue);
+    expect(containsCodeLine(pointerMove, '_hoshiReaderClearMouseSelection()'),
+        isTrue,
         reason: 'claimed text drags must clear browser native selection');
-    expect(pointerMove, contains('_hoshiReaderPointerNoSelect(true)'),
+    expect(containsCodeLine(pointerMove, '_hoshiReaderPointerNoSelect(true)'),
+        isTrue,
         reason:
             'claimed drags temporarily disable native selection only while active');
-    final String clearSelection = _functionSource(
+    final String clearSelection = _jsFunction(
       setupScript,
       'function _hoshiReaderClearMouseSelection()',
-      'function _hoshiReaderPointerPrimaryButton(e)',
     );
-    expect(clearSelection, contains('window.getSelection'));
-    expect(clearSelection, contains('removeAllRanges'));
+    expect(containsCodeLine(clearSelection, 'window.getSelection'), isTrue);
+    expect(containsCodeLine(clearSelection, 'removeAllRanges'), isTrue);
 
-    final String pointerUp = _listenerBlock(setupScript, 'pointerup');
-    expect(pointerUp, isNot(contains("e.pointerType === 'touch' ||")),
+    final String pointerUp = _jsListener(setupScript, 'pointerup');
+    expect(containsCodeLine(pointerUp, "e.pointerType === 'touch' ||"), isFalse,
         reason: 'touch pointerup must finish the same claimed-drag path');
     final int finishIndex = pointerUp.indexOf('_finishHoshiReaderMouseDrag(e)');
     final int gestureEndIndex = pointerUp.indexOf('_gestureEnd');
@@ -116,10 +137,12 @@ void main() {
     expect(gestureEndIndex, isNonNegative);
     expect(finishIndex, lessThan(gestureEndIndex),
         reason: 'claimed drags must finish before the legacy _gestureEnd path');
-    expect(pointerUp, contains('if (_hoshiReaderMouseDragClaimed)'));
-    expect(pointerUp, contains('_hoshiReaderPointerNoSelect(false)'));
+    expect(containsCodeLine(pointerUp, 'if (_hoshiReaderMouseDragClaimed)'),
+        isTrue);
+    expect(containsCodeLine(pointerUp, '_hoshiReaderPointerNoSelect(false)'),
+        isTrue);
 
-    final String touchEnd = _listenerBlock(setupScript, 'touchend');
+    final String touchEnd = _jsListener(setupScript, 'touchend');
     final int ignoreIndex =
         touchEnd.indexOf('_hoshiReaderMouseDragIgnoreTouchEnd');
     final int legacyEndIndex = touchEnd.indexOf('_gestureEnd');
@@ -128,24 +151,24 @@ void main() {
     expect(ignoreIndex, lessThan(legacyEndIndex),
         reason:
             'claimed touch drags must not replay tap/selection on touchend');
-    expect(touchEnd, contains('e.preventDefault()'));
+    expect(containsCodeLine(touchEnd, 'e.preventDefault()'), isTrue);
   });
 
   test('continuous pointer drag scrolls along horizontal and vertical axes',
       () {
-    final String scrollFn = _functionSource(
+    final String scrollFn = _jsFunction(
       setupScript,
       'function _hoshiReaderMouseDragScrollBy(dx, dy)',
-      'function _finishHoshiReaderMouseDrag(e)',
     );
 
-    expect(scrollFn, contains('r.isVertical'));
-    expect(scrollFn, contains('window.scrollBy({left:'));
-    expect(scrollFn, contains('window.scrollBy({left: 0, top:'));
+    expect(containsCodeLine(scrollFn, 'r.isVertical'), isTrue);
+    expect(containsCodeLine(scrollFn, 'window.scrollBy({left:'), isTrue);
+    expect(
+        containsCodeLine(scrollFn, 'window.scrollBy({left: 0, top:'), isTrue);
 
-    final String pointerMove = _listenerBlock(setupScript, 'pointermove');
-    expect(pointerMove, contains('if (hoshiContinuousMode)'));
-    expect(pointerMove, isNot(contains("callHandler('onSwipe'")),
+    final String pointerMove = _jsListener(setupScript, 'pointermove');
+    expect(containsCodeLine(pointerMove, 'if (hoshiContinuousMode)'), isTrue);
+    expect(containsCodeLine(pointerMove, "callHandler('onSwipe'"), isFalse,
         reason: 'continuous pointer drag should scroll, not page-turn');
   });
 
@@ -156,41 +179,45 @@ void main() {
   // scrollBy({left: dx}) and reversed the drag direction. Removing the sign
   // is the fix; this guard turns red if the writing-mode sign flip returns.
   test('continuous vertical drag follows the pointer without a sign flip', () {
-    final String scrollFn = _functionSource(
+    final String scrollFn = _jsFunction(
       setupScript,
       'function _hoshiReaderMouseDragScrollBy(dx, dy)',
-      'function _finishHoshiReaderMouseDrag(e)',
     );
 
     // Vertical axis: content follows the pointer with plain `-dx` (no sign).
-    expect(scrollFn, contains('window.scrollBy({left: -dx, top: 0'),
+    expect(containsCodeLine(scrollFn, 'window.scrollBy({left: -dx, top: 0'),
+        isTrue,
         reason: 'vertical drag must pan with scrollBy({left: -dx}) so the '
             'content follows the pointer (mouse-right → content-right)');
     // Horizontal axis stays finger-following on the vertical pointer axis.
-    expect(scrollFn, contains('window.scrollBy({left: 0, top: -dy'),
+    expect(containsCodeLine(scrollFn, 'window.scrollBy({left: 0, top: -dy'),
+        isTrue,
         reason: 'horizontal-writing drag must pan with scrollBy({top: -dy})');
     // The writing-mode-dependent sign flip that reversed vertical-rl is gone.
-    expect(scrollFn, isNot(contains('-dx * sign')),
+    expect(containsCodeLine(scrollFn, '-dx * sign'), isFalse,
         reason:
             'BUG-338: the writing-mode sign flip reversed vertical-rl drag');
-    expect(scrollFn, isNot(contains("=== 'vertical-rl') ? -1")),
+    expect(containsCodeLine(scrollFn, "=== 'vertical-rl') ? -1"), isFalse,
         reason: 'BUG-338: drag pan direction must not depend on writing-mode');
   });
 
   test('paged desktop mouse drag emits at most one onSwipe on release', () {
-    final String finishFn = _functionSource(
+    final String finishFn = _jsFunction(
       setupScript,
       'function _finishHoshiReaderMouseDrag(e)',
-      "document.addEventListener('touchstart'",
     );
 
-    expect(finishFn, contains('_hoshiReaderMouseDragSwipeSent'));
-    expect(finishFn, contains('_hoshiReaderMouseDragSwipeSent = true'));
-    expect(finishFn, contains("callHandler('onSwipe'"));
-    expect(finishFn, contains('_hoshiReaderMouseDragPageDirection = null'));
+    expect(
+        containsCodeLine(finishFn, '_hoshiReaderMouseDragSwipeSent'), isTrue);
+    expect(containsCodeLine(finishFn, '_hoshiReaderMouseDragSwipeSent = true'),
+        isTrue);
+    expect(containsCodeLine(finishFn, "callHandler('onSwipe'"), isTrue);
+    expect(
+        containsCodeLine(finishFn, '_hoshiReaderMouseDragPageDirection = null'),
+        isTrue);
 
-    final String pointerMove = _listenerBlock(setupScript, 'pointermove');
-    expect(pointerMove, isNot(contains("callHandler('onSwipe'")),
+    final String pointerMove = _jsListener(setupScript, 'pointermove');
+    expect(containsCodeLine(pointerMove, "callHandler('onSwipe'"), isFalse,
         reason: 'paged mouse drag decides direction during move but sends once '
             'from pointerup');
   });
@@ -198,14 +225,18 @@ void main() {
   test(
       'link image context menu and non-left pointer seek wiring stays separate',
       () {
-    expect(setupScript, contains("closest('a[href]')"));
-    expect(setupScript, contains("document.addEventListener('contextmenu'"));
-    expect(setupScript, contains("'onImageContextMenu'"));
+    expect(containsCodeLine(setupScript, "closest('a[href]')"), isTrue);
+    expect(
+        containsCodeLine(
+            setupScript, "document.addEventListener('contextmenu'"),
+        isTrue);
+    expect(containsCodeLine(setupScript, "'onImageContextMenu'"), isTrue);
 
-    final String mouseDown = _listenerBlock(setupScript, 'mousedown');
-    expect(mouseDown, contains('if (e.button === 0) return;'));
-    expect(mouseDown, contains('e.button === 2 && _hoshiBlockImageUrl'));
-    expect(mouseDown, contains("callHandler('onPointerSeek'"));
+    final String mouseDown = _jsListener(setupScript, 'mousedown');
+    expect(containsCodeLine(mouseDown, 'if (e.button === 0) return;'), isTrue);
+    expect(containsCodeLine(mouseDown, 'e.button === 2 && _hoshiBlockImageUrl'),
+        isTrue);
+    expect(containsCodeLine(mouseDown, "callHandler('onPointerSeek'"), isTrue);
   });
 
   // TODO-553: paged-mode touch must fall back to the touchstart/touchend swipe
@@ -213,38 +244,46 @@ void main() {
   // executable proof lives in reader_paged_touch_swipe_behavior_test.{js,dart};
   // this is the node-less static tripwire for the gates.
   test('touch only engages the pointer drag machine in continuous mode', () {
-    final String engages = _functionSource(
+    final String engages = _jsFunction(
       setupScript,
       'function _hoshiReaderPointerEngages(e)',
-      'function _hoshiReaderPointerNoSelect(enabled)',
     );
-    expect(engages, contains('_hoshiReaderPointerPrimaryButton(e)'));
-    expect(engages, contains("e.pointerType === 'touch'"));
-    expect(engages, contains('return hoshiContinuousMode'),
+    expect(containsCodeLine(engages, '_hoshiReaderPointerPrimaryButton(e)'),
+        isTrue);
+    expect(containsCodeLine(engages, "e.pointerType === 'touch'"), isTrue);
+    expect(containsCodeLine(engages, 'return hoshiContinuousMode'), isTrue,
         reason: 'paged-mode touch must not enter the pointer drag machine');
 
-    final String pointerDown = _listenerBlock(setupScript, 'pointerdown');
-    expect(pointerDown, contains('_hoshiReaderPointerEngages(e)'),
+    final String pointerDown = _jsListener(setupScript, 'pointerdown');
+    expect(
+        containsCodeLine(pointerDown, '_hoshiReaderPointerEngages(e)'), isTrue,
         reason: 'pointerdown must gate touch through the engage predicate');
 
-    final String pointerMove = _listenerBlock(setupScript, 'pointermove');
-    expect(pointerMove,
-        contains("e.pointerType === 'touch' && !hoshiContinuousMode"),
+    final String pointerMove = _jsListener(setupScript, 'pointermove');
+    expect(
+        containsCodeLine(
+            pointerMove, "e.pointerType === 'touch' && !hoshiContinuousMode"),
+        isTrue,
         reason: 'paged-mode touch moves must return before claiming a drag, '
             'leaving touchend -> _gestureEnd -> onSwipe to turn the page');
 
-    final String pointerUp = _listenerBlock(setupScript, 'pointerup');
-    expect(pointerUp, contains('_hoshiReaderPointerEngages(e)'),
+    final String pointerUp = _jsListener(setupScript, 'pointerup');
+    expect(containsCodeLine(pointerUp, '_hoshiReaderPointerEngages(e)'), isTrue,
         reason: 'paged-mode touch pointerup must not run the native-text path');
 
-    final String pointerCancel = _listenerBlock(setupScript, 'pointercancel');
-    expect(pointerCancel,
-        contains("e.pointerType === 'touch' && !hoshiContinuousMode"),
+    final String pointerCancel = _jsListener(setupScript, 'pointercancel');
+    expect(
+        containsCodeLine(
+            pointerCancel, "e.pointerType === 'touch' && !hoshiContinuousMode"),
+        isTrue,
         reason: 'paged-mode touch pointercancel must bail before resetting the '
             'drag machine, mirroring the pointermove exclusion');
   });
 }
 
+/// 从**掩码后**的合并语料里切出 setup 脚本这一段。
+///
+/// 两个标记都是 JS 语句本体，掩码后仍在；注释里写着同样的文字也不会再把边界锚歪。
 String _between(String source, String start, String end) {
   final int startIndex = source.indexOf(start);
   expect(startIndex, isNonNegative, reason: 'missing start marker: $start');
@@ -253,20 +292,20 @@ String _between(String source, String start, String end) {
   return source.substring(startIndex, endIndex);
 }
 
-String _functionSource(String source, String start, String end) {
-  final int startIndex = source.indexOf(start);
-  expect(startIndex, isNonNegative, reason: 'missing function marker: $start');
-  final int endIndex = source.indexOf(end, startIndex + start.length);
-  expect(endIndex, isNonNegative, reason: 'missing next marker: $end');
-  return source.substring(startIndex, endIndex);
-}
+/// JS 函数体窗口（花括号配对，JS 词法）。
+///
+/// 替掉旧的「从本函数签名找到**下一个**函数签名」文本窗口：那种窗口把两者之间的
+/// 所有内容（别的函数、别的监听器）都算进来，断言命中的可能根本不是被守的函数。
+String _jsFunction(String source, String signature) =>
+    methodBody(source, signature, lexicon: SourceLexicon.js);
 
-String _listenerBlock(String source, String eventName) {
-  final String marker = "addEventListener('$eventName'";
-  final int startIndex = source.indexOf(marker);
-  expect(startIndex, isNonNegative, reason: 'missing listener: $eventName');
-  final int endIndex = source.indexOf('}, {passive:', startIndex);
-  expect(endIndex, isNonNegative,
-      reason: 'listener must end with a passive option: $eventName');
-  return source.substring(startIndex, endIndex);
-}
+/// `document.addEventListener('<event>', function(e) {...})` 的**回调体**窗口。
+///
+/// 锚点取 `'<event>', function(e)`，[methodBody] 从这里配对回调的花括号，窗口就是
+/// 这一个监听器的函数体。旧写法右边界是 `indexOf('}, {passive:')`——一旦某个监听器
+/// 漏写 passive 选项，窗口会一路吞到下一个监听器里去。
+String _jsListener(String source, String eventName) => methodBody(
+      source,
+      "'$eventName', function(e)",
+      lexicon: SourceLexicon.js,
+    );

--- a/hibiki/test/reader/scroll_cross_chapter_try_scroll_test.dart
+++ b/hibiki/test/reader/scroll_cross_chapter_try_scroll_test.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 
+import '../helpers/source_guard.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 
 /// TODO-656「试滚范式」根治：跨章不再用瞬时坐标阈值 `scrollTop<=2`，而是「内容真的
@@ -112,48 +113,57 @@ void main() {
     late String paginationScripts;
     late String corpus;
     setUpAll(() {
-      paginationScripts = File('lib/src/reader/reader_pagination_scripts.dart')
-          .readAsStringSync()
-          .replaceAll('\r\n', '\n');
-      corpus = readReaderPageSource();
+      // TODO-2527: 两份语料都先掩码——`downSPos` / `_wheelBoundaryArmed` 这类符号
+      // 本来就原样写在生产注释里（webview.part.dart:1466 就有一处），裸 contains
+      // 会被注释满足：把实现删光只留注释，旧写法照样全绿。
+      paginationScripts = maskCommentsAndScriptLines(
+        File('lib/src/reader/reader_pagination_scripts.dart')
+            .readAsStringSync()
+            .replaceAll('\r\n', '\n'),
+      );
+      corpus = maskCommentsAndScriptLines(readReaderPageSource());
     });
 
     test('_bStart 记手势起点滚动量 downSPos/downSMax', () {
-      expect(paginationScripts, contains('downSPos'),
+      expect(containsCodeLine(paginationScripts, 'downSPos'), isTrue,
           reason: 'touchstart 必须记手势起点沿内容轴的滚动量');
-      expect(paginationScripts, contains('downSMax'),
+      expect(containsCodeLine(paginationScripts, 'downSMax'), isTrue,
           reason: 'touchstart 必须记最大可滚量供边界判定');
     });
     test('_bEnd 用手势起点在边界判据，不再用 touchend 瞬时 atTop', () {
-      expect(paginationScripts, contains('downAtStart'),
+      expect(containsCodeLine(paginationScripts, 'downAtStart'), isTrue,
           reason: '跨章必须看手势起点是否在章首（downSPos<=2）');
-      expect(paginationScripts, contains('downAtEnd'),
+      expect(containsCodeLine(paginationScripts, 'downAtEnd'), isTrue,
           reason: '跨章必须看手势起点是否在章末');
       expect(
-          paginationScripts, isNot(contains('var atTop = root.scrollTop <= 2')),
+          containsCodeLine(
+              paginationScripts, 'var atTop = root.scrollTop <= 2'),
+          isFalse,
           reason: '_bEnd 不得再用 touchend 瞬时 scrollTop<=2 判跨章（提前跨章根因）');
     });
     test('滚轮跨章用真试滚（scrollBy + moved），不再用 stuck 推算/瞬时几何', () {
       final String wheel = _wheelBlock(corpus);
-      expect(wheel, contains('var moved = Math.abs(after - before) > 1'),
+      expect(
+          containsCodeLine(wheel, 'var moved = Math.abs(after - before) > 1'),
+          isTrue,
           reason: '滚轮跨章须靠真试滚的实际位移判边界');
-      expect(wheel, contains('window.scrollBy'),
+      expect(containsCodeLine(wheel, 'window.scrollBy'), isTrue,
           reason: '横排/竖排都真的 window.scrollBy 一步再读位移（已验证原语）');
-      expect(wheel, isNot(contains('atStart = root.scrollTop <= 2')),
+      expect(containsCodeLine(wheel, 'atStart = root.scrollTop <= 2'), isFalse,
           reason: '不得再用瞬时 scrollTop<=2 几何');
-      expect(wheel, isNot(contains('_wheelLastScrollPos')),
+      expect(containsCodeLine(wheel, '_wheelLastScrollPos'), isFalse,
           reason: '不得再用相邻拍位置推算（时序坏 → 横排中部误翻）');
       // arm-then-fire 二次确认仍在。
-      expect(wheel, contains('_wheelBoundaryArmed'),
+      expect(containsCodeLine(wheel, '_wheelBoundaryArmed'), isTrue,
           reason: '保留 arm-then-fire 二次确认吸收单帧擦边');
     });
   });
 }
 
-String _wheelBlock(String source) {
-  final int start = source.indexOf("addEventListener('wheel'");
-  expect(start, isNonNegative, reason: 'missing wheel listener');
-  final int end = source.indexOf('}, {passive:', start);
-  expect(end, isNonNegative);
-  return source.substring(start, end);
-}
+/// wheel 监听器的**回调体**窗口（花括号配对，JS 词法）。
+///
+/// 旧写法右边界是 `indexOf('}, {passive:')`：监听器一旦漏写 passive 选项，窗口就
+/// 一路吞到下一个监听器；而 `_wheelBoundaryArmed` 恰好原样写在本块的注释里
+/// （webview.part.dart:1466），窗口不掩码时那条要求型断言可被注释单独满足。
+String _wheelBlock(String source) =>
+    methodBody(source, "'wheel', function(e)", lexicon: SourceLexicon.js);

--- a/hibiki/test/reader/ui_scale_reanchor_continuous_test.dart
+++ b/hibiki/test/reader/ui_scale_reanchor_continuous_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_page.dart'
     show readerUiScaleReanchorAllowed, readerRestoreReanchorAllowed;
 
+import '../helpers/source_guard.dart';
 import '../pages/reader_hibiki_page_source_corpus.dart';
 
 /// TODO-693：改 appUiScale（整体界面缩放）时，**连续/滚动模式**阅读位置被弹回章节开头。
@@ -123,50 +124,53 @@ void main() {
     });
   });
 
+  // TODO-2527：JS 侧两个窗口原来用 `indexOf('\n  },')` / `indexOf('\n  }')` 当右边界
+  // ——那是「首个缩进两格的右花括号」，函数体里嵌一层同缩进的块就当场截断；而且窗口从
+  // 未掩码的源码切，`getFirstVisibleCharOffset()` / `finally` 这类串在生产注释里到处
+  // 都是，实现删光只留注释照样绿。现在窗口由 JS 花括号配对给出，语料先掩码。
   group('JS 守卫：连续模式两阶段重锚原语 + _reanchorPending 串行契约', () {
     late String js;
+    late String continuousShell;
 
     setUpAll(() {
-      js = File('lib/src/reader/reader_pagination_scripts.dart')
-          .readAsStringSync()
-          .replaceAll('\r\n', '\n');
+      js = maskCommentsAndScriptLines(
+        File('lib/src/reader/reader_pagination_scripts.dart')
+            .readAsStringSync()
+            .replaceAll('\r\n', '\n'),
+      );
+      continuousShell = _continuousShellJs(js);
     });
 
     /// 切出 `beginUiScaleReanchor: function() { ... }` 函数体，避免误命中别处。
-    String beginBody() {
-      const String marker = 'beginUiScaleReanchor: function()';
-      final int start = js.indexOf(marker);
-      expect(start, greaterThanOrEqualTo(0),
-          reason: '找不到 beginUiScaleReanchor 定义（连续模式重锚阶段1）');
-      final int end = js.indexOf('\n  },', start);
-      expect(end, greaterThan(start), reason: '找不到 beginUiScaleReanchor 体结尾');
-      return js.substring(start, end);
-    }
+    String beginBody() => methodBody(
+          continuousShell,
+          'beginUiScaleReanchor: function()',
+          lexicon: SourceLexicon.js,
+        );
 
-    String commitBody() {
-      const String marker = 'commitUiScaleReanchor: function()';
-      final int start = js.indexOf(marker);
-      expect(start, greaterThanOrEqualTo(0),
-          reason: '找不到 commitUiScaleReanchor 定义（连续模式重锚阶段2）');
-      final int end = js.indexOf('\n  }', start);
-      expect(end, greaterThan(start), reason: '找不到 commitUiScaleReanchor 体结尾');
-      return js.substring(start, end);
-    }
+    String commitBody() => methodBody(
+          continuousShell,
+          'commitUiScaleReanchor: function()',
+          lexicon: SourceLexicon.js,
+        );
 
     test('阶段1 beginUiScaleReanchor 先置 _reanchorPending 再暂存锚', () {
       final String body = beginBody();
       // 已有重锚在飞则让既有序列接管，不重复采样。
-      expect(body.contains('this._reanchorPending === true) return -1'), isTrue,
+      expect(
+          containsCodeLine(body, 'this._reanchorPending === true) return -1'),
+          isTrue,
           reason: 'begin 必须在已有重锚在飞时返回 -1（让 setChromeInsets/updatePageSize '
               '等既有序列接管，不重复采样/不抢旗）');
       // 关键时序：采样首个可见字符 → 置旗 → 暂存锚。置旗必须发生（挡住 reflow 归零 scroll）。
-      expect(body.contains('getFirstVisibleCharOffset()'), isTrue,
+      expect(containsCodeLine(body, 'getFirstVisibleCharOffset()'), isTrue,
           reason: 'begin 必须用 getFirstVisibleCharOffset 采样精确锚');
       // BUG-493：置旗改走清旗单点 setter（_setReanchorPending，语义不变）。
-      expect(body.contains('this._setReanchorPending(true)'), isTrue,
+      expect(containsCodeLine(body, 'this._setReanchorPending(true)'), isTrue,
           reason: 'begin 必须置 _reanchorPending=true，否则 reflow 归零 scroll 会经 '
               'onReaderScroll 落库 progress≈0 弹回章首（TODO-693 根因）');
-      expect(body.contains('this._uiScaleReanchorOffset = charOffset'), isTrue,
+      expect(containsCodeLine(body, 'this._uiScaleReanchorOffset = charOffset'),
+          isTrue,
           reason: 'begin 必须暂存锚供 commit 阶段提交');
       // 时序：置旗在暂存之前/同段，且无可用锚时早返回不置旗。
       final int idxOffsetInvalid = body.indexOf('charOffset < 0) return -1');
@@ -181,23 +185,26 @@ void main() {
       final String body = commitBody();
       // 仅当 begin 成功暂存了有效锚才提交，否则 no-op（绝不误清别处的 _reanchorPending）。
       expect(
-          body.contains('off === undefined || off < 0) return false'), isTrue,
+          containsCodeLine(body, 'off === undefined || off < 0) return false'),
+          isTrue,
           reason: 'commit 必须在无有效暂存锚时整体 no-op，绝不误清别处重锚旗');
       // TODO-1229：commit 透传 begin 暂存的滚动位（<=0 章首区保位 hint，不弹回前导）。
       expect(
-          body.contains(
+          containsCodeLine(body,
               'this.scrollToCharOffset(off, undefined, this._uiScaleReanchorScroll)'),
           isTrue,
           reason: 'commit 必须把锚滚回视口首边并透传采到的滚动位（settle 后的真实位置）');
       // finally 清旗 + 清暂存，保证异常路径也不卡死 _reanchorPending（HBK-REG-004 同形）。
-      expect(body.contains('finally'), isTrue,
+      expect(containsCodeLine(body, 'finally'), isTrue,
           reason: 'commit 必须在 finally 清旗，异常路径也不能卡死 _reanchorPending');
       // BUG-493：清旗改走单点 setter（true→false 转换经 onReanchorSettled 通知 Dart 补刷进度）。
-      expect(body.contains('this._setReanchorPending(false)'), isTrue,
+      expect(containsCodeLine(body, 'this._setReanchorPending(false)'), isTrue,
           reason: 'commit 必须清 _reanchorPending，否则后续滚动回传被永久挡住');
-      expect(body.contains('this._uiScaleReanchorOffset = undefined'), isTrue,
+      expect(containsCodeLine(body, 'this._uiScaleReanchorOffset = undefined'),
+          isTrue,
           reason: 'commit 必须清暂存锚，避免下次缩放误用旧锚');
-      expect(body.contains('this._uiScaleReanchorScroll = undefined'), isTrue,
+      expect(containsCodeLine(body, 'this._uiScaleReanchorScroll = undefined'),
+          isTrue,
           reason: 'commit 必须清暂存滚动位，避免下次缩放误用旧 hint');
     });
 
@@ -210,14 +217,14 @@ void main() {
 
     test('invocation builder 用 typeof 守卫使分页模式整体 no-op', () {
       expect(
-        js.contains(
+        containsCodeLine(js,
             "typeof window.hoshiReader.beginUiScaleReanchor === 'function'"),
         isTrue,
         reason: 'beginUiScaleReanchorInvocation 必须 typeof 守卫——分页 shell 缺此函数，'
             '误调时整体 no-op 返回 -1',
       );
       expect(
-        js.contains(
+        containsCodeLine(js,
             "typeof window.hoshiReader.commitUiScaleReanchor === 'function'"),
         isTrue,
         reason: 'commitUiScaleReanchorInvocation 必须 typeof 守卫',
@@ -229,17 +236,18 @@ void main() {
     late String src;
 
     setUpAll(() {
-      src = readReaderPageSource();
+      src = maskCommentsAndScriptLines(readReaderPageSource());
     });
 
     test('build 用 ref.listen 监听 appUiScale 变化并调连续重锚', () {
       // 用 select 只监听 appUiScale 标量，避免 AppModel 任意字段变更都触发。
       expect(
-        src.contains('appProvider.select((AppModel m) => m.appUiScale)'),
+        containsCodeLine(
+            src, 'appProvider.select((AppModel m) => m.appUiScale)'),
         isTrue,
         reason: '必须用 ref.listen + select 只监听 appUiScale 标量变化（TODO-693）',
       );
-      expect(src.contains('_reanchorContinuousForUiScale()'), isTrue,
+      expect(containsCodeLine(src, '_reanchorContinuousForUiScale()'), isTrue,
           reason: 'appUiScale 变化必须触发 _reanchorContinuousForUiScale 重锚');
     });
 
@@ -247,28 +255,33 @@ void main() {
       // TODO-697：两阶段编排（门控→begin→intResult→postFrame→commit）已抽到 top-level
       // runUiScaleReanchorOrchestration（运行时序列由 *_runtime_test.dart 真执行锁定）。
       // 这里只静态守卫「方法把本 State 实例字段正确绑进编排回调」这层接线。
-      final int idx =
-          src.indexOf('Future<void> _reanchorContinuousForUiScale()');
-      expect(idx, greaterThan(0), reason: '_reanchorContinuousForUiScale 必须存在');
-      final String body = src.substring(idx, idx + 2000);
-      expect(body.contains('runUiScaleReanchorOrchestration('), isTrue,
+      // TODO-2527: `idx + 2000` 定长窗口换成花括号配对——方法体再长也不会漂出窗口，
+      // 再短也不会把下一个方法的属性读进来。
+      final String body =
+          methodBody(src, 'Future<void> _reanchorContinuousForUiScale()');
+      expect(containsCodeLine(body, 'runUiScaleReanchorOrchestration('), isTrue,
           reason: '方法必须委托给 top-level runUiScaleReanchorOrchestration（编排核心，'
               '运行时序列由 runtime 测试锁定）');
       // TODO-718：编排核心改由调用方注入门控结果（gateAllowed）。693 缩放重锚路径必须绑
       // readerUiScaleReanchorAllowed（含 !restoreInFlight 早返回）。
       expect(
-          body.contains('gateAllowed: readerUiScaleReanchorAllowed('), isTrue,
+          containsCodeLine(body, 'gateAllowed: readerUiScaleReanchorAllowed('),
+          isTrue,
           reason: '缩放重锚必须把 readerUiScaleReanchorAllowed 结果绑进 gateAllowed');
       // 门控的五个实例字段必须绑进 readerUiScaleReanchorAllowed（撤任一 → 对应抑制不再受控）。
-      expect(body.contains('controllerAvailable: _controller != null'), isTrue,
+      expect(containsCodeLine(body, 'controllerAvailable: _controller != null'),
+          isTrue,
           reason: '必须把控制器存活绑进门控');
       expect(
-          body.contains('continuousMode: _settings?.isContinuousMode == true'),
+          containsCodeLine(
+              body, 'continuousMode: _settings?.isContinuousMode == true'),
           isTrue,
           reason: '必须把连续模式绑进门控（分页模式抑制的来源）');
-      expect(body.contains('readerContentReady: _readerContentReady'), isTrue);
-      expect(body.contains('lyricsMode: _lyricsMode'), isTrue);
-      expect(body.contains('restoreInFlight: _restoreInFlight'), isTrue);
+      expect(containsCodeLine(body, 'readerContentReady: _readerContentReady'),
+          isTrue);
+      expect(containsCodeLine(body, 'lyricsMode: _lyricsMode'), isTrue);
+      expect(
+          containsCodeLine(body, 'restoreInFlight: _restoreInFlight'), isTrue);
       // begin / commit 回调必须绑各自的 invocation；postFrame 必须经 addPostFrameCallback。
       final int idxBegin = body
           .indexOf('ReaderPaginationScripts.beginUiScaleReanchorInvocation()');
@@ -279,7 +292,7 @@ void main() {
       expect(idxCommit, greaterThan(0),
           reason:
               'evalCommit 回调必须绑 commitUiScaleReanchorInvocation（settle 后滚回清旗）');
-      expect(body.contains('addPostFrameCallback'), isTrue,
+      expect(containsCodeLine(body, 'addPostFrameCallback'), isTrue,
           reason:
               'schedulePostFrame 必须经 WidgetsBinding.addPostFrameCallback 等过渡帧 '
               'settle（box.size 是 FittedBox 逐帧过渡，沿用 _syncPageSize 的 settle 时机）');
@@ -289,12 +302,9 @@ void main() {
         () {
       // 编排核心的源码切片守卫：运行时序列已由 runtime 测试锁定，这里再静态确认
       // 「门控 → begin → intResult → charOffset<0 早返回 → postFrame → commit」骨架在源码里。
-      final int idx =
-          src.indexOf('Future<void> runUiScaleReanchorOrchestration(');
-      expect(idx, greaterThan(0),
-          reason: 'runUiScaleReanchorOrchestration top-level 编排核心必须存在');
-      final String body = src.substring(idx, idx + 1600);
-      expect(body.contains('if (!gateAllowed)'), isTrue,
+      final String body =
+          methodBody(src, 'Future<void> runUiScaleReanchorOrchestration(');
+      expect(containsCodeLine(body, 'if (!gateAllowed)'), isTrue,
           reason: '编排核心必须先过调用方注入的门控结果 gateAllowed（TODO-718：不再硬编码'
               '单一门控函数，缩放/恢复两路径各传自己的门控真值表）');
       final int idxBegin = body.indexOf('await evalBegin()');
@@ -401,7 +411,7 @@ void main() {
     late String src;
 
     setUpAll(() {
-      src = readReaderPageSource();
+      src = maskCommentsAndScriptLines(readReaderPageSource());
     });
 
     test(
@@ -424,28 +434,26 @@ void main() {
               '否则归零会先污染落库（要求①③：采锚在归零前）');
       // 同段内 _refreshProgress() 必须出现在采锚之后。
       final String afterReanchor = src.substring(idxReanchor, idxStartPoll);
-      expect(afterReanchor.contains('_refreshProgress();'), isTrue,
+      expect(containsCodeLine(afterReanchor, '_refreshProgress();'), isTrue,
           reason: '采锚之后才轮到 _refreshProgress()（置旗已挡住归零，读到正确位置）');
     });
 
     test('_reanchorContinuousAfterRestore 委托编排核心并绑恢复完成门控', () {
-      final int idx =
-          src.indexOf('Future<void> _reanchorContinuousAfterRestore()');
-      expect(idx, greaterThan(0),
-          reason: '_reanchorContinuousAfterRestore 必须存在（TODO-718）');
-      final String body = src.substring(idx, idx + 2000);
-      expect(body.contains('runUiScaleReanchorOrchestration('), isTrue,
+      final String body =
+          methodBody(src, 'Future<void> _reanchorContinuousAfterRestore()');
+      expect(containsCodeLine(body, 'runUiScaleReanchorOrchestration('), isTrue,
           reason: '恢复重锚必须复用 top-level 编排核心（同 693 两阶段序列）');
       // 要求②：必须绑恢复完成专用门控 readerRestoreReanchorAllowed（不含 restoreInFlight 早返回），
       // 绝不复用 readerUiScaleReanchorAllowed。
       expect(
-          body.contains('gateAllowed: readerRestoreReanchorAllowed('), isTrue,
+          containsCodeLine(body, 'gateAllowed: readerRestoreReanchorAllowed('),
+          isTrue,
           reason: '恢复重锚必须绑 readerRestoreReanchorAllowed（避开会早返回的门控，要求②）');
-      expect(body.contains('readerUiScaleReanchorAllowed('), isFalse,
+      expect(containsCodeLine(body, 'readerUiScaleReanchorAllowed('), isFalse,
           reason:
               '恢复重锚不得复用含 !restoreInFlight 早返回的 readerUiScaleReanchorAllowed');
       // 门控不绑 restoreInFlight（恢复完成路径下必为 false）。
-      expect(body.contains('restoreInFlight:'), isFalse,
+      expect(containsCodeLine(body, 'restoreInFlight:'), isFalse,
           reason: '恢复重锚门控不应再绑 restoreInFlight');
       // 复用同一两阶段 begin/commit invocation（与 _reanchorPending 串行旗一致）。
       final int idxBegin = body
@@ -457,12 +465,28 @@ void main() {
       expect(idxCommit, greaterThan(0),
           reason:
               'evalCommit 必须绑 commitUiScaleReanchorInvocation（settle 后滚回清旗）');
-      expect(body.contains('addPostFrameCallback'), isTrue,
+      expect(containsCodeLine(body, 'addPostFrameCallback'), isTrue,
           reason: 'schedulePostFrame 必须经 addPostFrameCallback 等 settle 时机');
       expect(
-          body.contains('continuousMode: _settings?.isContinuousMode == true'),
+          containsCodeLine(
+              body, 'continuousMode: _settings?.isContinuousMode == true'),
           isTrue,
           reason: '必须把连续模式绑进门控（分页抑制来源）');
     });
   });
+}
+
+/// 从**掩码后**的 `reader_pagination_scripts.dart` 里切出连续模式 shell 的 JS 语料。
+///
+/// [methodBody] 的 [SourceLexicon.js] 只能扫纯 JS：直接对 Dart 文件用 JS 词法，
+/// `'''` 会被读成「空串 + 新串」，三引号里的花括号被当成串内容抹掉、配对跑偏。
+/// 先按 Dart 侧稳定标记切出 JS blob，再在里面用 JS 词法配对函数体。
+String _continuousShellJs(String maskedSource) {
+  const String start = 'window.__hoshiShells.continuous = function(C) {';
+  const String end = '</script>';
+  final int startIndex = maskedSource.indexOf(start);
+  expect(startIndex, isNonNegative, reason: '找不到连续模式 shell 起点：$start');
+  final int endIndex = maskedSource.indexOf(end, startIndex + start.length);
+  expect(endIndex, greaterThan(startIndex), reason: '找不到连续模式 shell 终点：$end');
+  return maskedSource.substring(startIndex, endIndex);
 }


### PR DESCRIPTION
TODO-2527 **第一批**：把 `reader_hibiki` 合并语料上高危的裸 `substring` 守卫窗口收成词法原语。

reader 合并语料 583,582 字节里注释占 **188,385 字节 = 32%**（本分支实测），裸窗口里三分之一是注释，`contains` 有大量机会被注释满足。本 PR 复用 PR#715 跑通的范式：

1. 语料先过 `maskCommentsAndScriptLines`（Dart 注释 + 三引号里的 JS 注释一起换**等长**空白），**所有**窗口从掩码语料上切；
2. 窗口边界由**结构**给出：JS 侧 `methodBody(..., lexicon: SourceLexicon.js)`（先按 Dart 稳定标记切出 JS blob，再在里面配对），Dart 侧 `methodBody(...)` 花括号配对；
3. 断言全改 `containsCodeLine`（少数**跨行**相邻语句对锚点保留整段 `contains`，窗口已掩码）。

## 覆盖（6 commit / 6 文件，一文件一 commit）

| 文件 | 旧窗口形态 | 改法 |
|---|---|---|
| `test/reader/reader_mouse_drag_scroll_guard_static_test.dart` | 3 处 `indexOf('}, {passive:')` / 「下一个函数签名」文本窗口 | 12 个 JS 函数体 / 监听器回调体窗口改 `methodBody(js)` |
| `test/reader/scroll_cross_chapter_try_scroll_test.dart` | wheel 块 `indexOf('}, {passive:')` | `methodBody(js)`；`reader_pagination_scripts` 侧断言一并收口 |
| `test/reader/book_open_perf_wiring_guard_test.dart` | 8 处「本方法名 → 下一个方法名」窗口（2 处切到语料尾） | 6 个 `methodBody`；旧右边界符号（`_applyLyricsFavorites` / `_buildTopProgressBar`）存在性单独锁住，迁移不丢覆盖 |
| `test/reader/ui_scale_reanchor_continuous_test.dart` | JS 侧 `indexOf('\n  },')` / `indexOf('\n  }')`；Dart 侧 `idx+2000` / `idx+1600` 定长窗口 | `methodBody(js)` + `methodBody` |
| `test/reader/reader_inchapter_progress_scroll_test.dart` | 4 个**定长**窗口 `idx+700 / +2700 / +1400 / +3200`（注释里已写着「窗口放宽到 2700 / 1400」= 定长窗口塌掉的补丁史） | Dart `methodBody` + JS `methodBody(js)` |
| `test/pages/reader_chapter_html_cache_test.dart` | 7 处文本窗口（2 处切到语料尾） | 7 个 `methodBody`；旧右边界 `_buildSanitizedChapterHtmlBytes` 存在性单独锁住 |

## 变异实测：改前假绿 / 改后转红（21 组，42 次真跑）

每条被改断言两个状态，**同一份被改坏的生产源码同时跑新旧两个版本的守卫**（旧版本按 base `6078a4379` 取出为临时同名 sibling，跑完删除）：

- **F（正向）**：真实现改坏，needle 不出现在任何地方；
- **R（反向·关键）**：真实现改坏，needle **只留在注释里**。

期望：要求型（isTrue）R -> 新红 / **旧绿（假绿）**；禁止型（isFalse）R -> 新绿 / **旧红（假红）**。

| # | 断言 | 类型 | F: 新/旧 | R: 新/旧 |
|---|---|---|---|---|
| M1 | `window.getSelection` @ `_hoshiReaderMouseDragStartAllowed` | isTrue | RED / RED | **RED / GREEN** |
| M2 | `preventDefault` @ `_hoshiReaderCaretRangeAtPoint` | isFalse | RED / RED | **GREEN / RED** |
| M3 | `removeAllRanges` @ `_hoshiReaderClearMouseSelection` | isTrue | RED / RED | **RED / GREEN** |
| S1 | `_wheelBoundaryArmed` @ wheel 回调体 | isTrue | RED / RED | **RED / GREEN** |
| S2 | `window.scrollBy` @ wheel 回调体 | isTrue | RED / RED | **RED / GREEN** |
| S3 | `atStart = root.scrollTop <= 2` @ wheel 回调体 | isFalse | RED / RED | **GREEN / RED** |
| B1 | `parseBookOnly` @ 全语料 | isTrue | RED / RED | **RED / GREEN** |
| B2 | `_recomputeCharCountsInBackground` @ 全语料 | isTrue | RED / RED | RED / RED* |
| B3 | `_chapterCumulativeChars` @ `_applyCharCounts` | isTrue | RED / RED | **RED / GREEN** |
| B4 | `compute(parseAndCountChapters` @ 全语料 | isFalse | RED / RED | **GREEN / RED** |
| H1 | `_prefetchingHtmlPath` @ `_prefetchAdjacentChapter` | isTrue | RED / RED | **RED / GREEN** |
| H2 | `scheduleMicrotask` @ `_prefetchAdjacentChapter` | isFalse | RED / RED | **GREEN / RED** |
| H3 | `_sanitizedHtmlCache.clear()` @ `_invalidateStyleCache` | isTrue | RED / RED | **RED / GREEN** |
| I1 | `requestAnimationFrame` @ 全语料 | isTrue | RED / RED | **RED / GREEN** |
| I2 | `}, 120);` @ `_onReaderScrollEvent` | isTrue | RED / RED | **RED / GREEN** |
| I3 | `_refreshProgressFromScroll();` @ `_handleReaderScroll` | isTrue | **RED / GREEN** | **RED / GREEN** |
| I4 | `}, 200);` @ `_onReaderScrollEvent` | isFalse | RED / RED | **GREEN / RED** |
| U1 | `getFirstVisibleCharOffset()` @ `beginUiScaleReanchor` | isTrue | RED / RED | **RED / GREEN** |
| U2 | `finally` @ `commitUiScaleReanchor` | isTrue | RED / **GREEN**+ | **RED / GREEN** |
| U2b | 同上，连生产注释一起抹 | isTrue | RED / RED | **RED / GREEN** |
| U3 | `gateAllowed: readerRestoreReanchorAllowed(` @ `_reanchorContinuousAfterRestore` | isTrue | RED / RED | **RED / GREEN** |

**\* B2 的精确归因**：旧文件确实红了，但失败的是**相邻**那条窗口锚点断言
（`expect(recomputeIdx, greaterThan(0))` -> `Actual: <-1>`），被测的
`src.contains('_recomputeCharCountsInBackground')` 本身仍被 `reader_hibiki_page.dart:1863`
的注释满足 = 假绿；新文件红在 `containsCodeLine` 本身（`Expected: true / Actual: <false>`）。

**+ U2 的 F 态其实等价于 R 态**：`reader_pagination_scripts.dart:3226` 的生产注释
「（finally 只在本入口确实拥有旗时执行）」本来就含 `finally`，只抹代码抹不干净。
这正说明这条断言**今天就是假绿可达**。U2b 连注释一起抹后旧文件才红。

### 两条与注释无关的**纯窗口塌陷**假绿（本批新发现）

- **I3**：旧窗口 `src.substring(idx, idx + 2700)` 从 `void _handleReaderScroll()`（navigation.part.dart:299）
  一路切到**第 369 行**，而该方法只到 337 行 —— 窗口整个吞掉了隔壁的 `_refreshProgressFromScroll()`
  方法体，里面第 356 行有一处**自递归**调用。于是把 331 行真正的分发调用改坏，旧守卫仍绿
  （命中的是隔壁方法里那处）。这条与注释无关，是定长窗口自身的洞。
- **U2**：旧 `commitBody()` 右边界 `indexOf('\n  }')` 把注释一起圈进来（见上）。

## 存量真违规

**未发现**。六个文件换成词法原语后一次全绿（无需放宽任何断言）。

## 门禁

- `flutter analyze`（含 test 目录）：`No issues found! (ran in 61.1s)`，exit 0
- `dart run tool/flutter_test_failures.dart --no-pub test/reader test/pages test/tools/source_guard_adoption_test.dart test/settings/md3_design_system_static_test.dart`
  -> `FLUTTER TEST VERDICT: PASSED - 3956 tests ran, all tests passed`，exit 0
- `dart format` 已跑；`git status --short` 干净（变异全部反向文本替换还原，未用 `git checkout --`）

## 明确未做

- **`test/reader/reader_mouse_paging_boundary_guard_static_test.dart` 一个字没碰**（PR#715 已改完并在合并队列里）。
- 本批只做点名的 6 个文件。全量三角扫描显示 reader 语料还有 **~24 个**同型文件（needle 在生产注释里可满足），留给第二批。中危 / 其余语料的 90 高危 / 61 中危 / 57 待判**全部未动**。
- 未 bump `+build`（整合线统一 bump）。未建 BUG 文档（既有 TODO 收尾）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
