### PR TITLE
feat(gal): 「附着到已在运行的游戏」提到工具栏一级入口

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52190 (3070 per locale)
+/// Strings: 52207 (3071 per locale)
 ///
-/// Built on 2026-08-02 at 01:55 UTC
+/// Built on 2026-08-02 at 03:14 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4125,6 +4125,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get stat_hourly_band_unattributed => 'Unsplit history';
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -11169,6 +11170,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -18280,6 +18283,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -25406,6 +25411,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -32544,6 +32551,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -39611,6 +39620,8 @@ class _StringsId extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -46724,6 +46735,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -53654,6 +53667,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -60586,6 +60601,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -67679,6 +67696,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -74785,6 +74804,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -81875,6 +81896,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -88913,6 +88936,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -95983,6 +96008,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -103038,6 +103065,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 // Path: <root>
@@ -109605,6 +109634,8 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       '早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。';
+  @override
+  String get game_attach_and_capture => '附着并捕获';
 }
 
 // Path: <root>
@@ -116456,6 +116487,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get game_attach_and_capture => 'Attach and capture';
 }
 
 /// Flat map(s) containing all translations.
@@ -122755,6 +122788,8 @@ extension on _StringsEn {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -129052,6 +129087,8 @@ extension on _StringsAr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -135371,6 +135408,8 @@ extension on _StringsDe {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -141689,6 +141728,8 @@ extension on _StringsEs {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -148013,6 +148054,8 @@ extension on _StringsFr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -154319,6 +154362,8 @@ extension on _StringsId {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -160639,6 +160684,8 @@ extension on _StringsIt {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -166921,6 +166968,8 @@ extension on _StringsJa {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -173207,6 +173256,8 @@ extension on _StringsKo {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -179521,6 +179572,8 @@ extension on _StringsNl {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -185832,6 +185885,8 @@ extension on _StringsPtBr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -192148,6 +192203,8 @@ extension on _StringsRu {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -198447,6 +198504,8 @@ extension on _StringsTh {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -204755,6 +204814,8 @@ extension on _StringsTr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -211059,6 +211120,8 @@ extension on _StringsVi {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }
@@ -217309,6 +217372,8 @@ extension on _StringsZhCn {
         return '未区分历史';
       case 'stat_hourly_unattributed_note':
         return '早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。';
+      case 'game_attach_and_capture':
+        return '附着并捕获';
       default:
         return null;
     }
@@ -223586,6 +223651,8 @@ extension on _StringsZhHk {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'game_attach_and_capture':
+        return 'Attach and capture';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "漫画",
   "stat_hourly_band_unattributed": "未区分历史",
-  "stat_hourly_unattributed_note": "早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。"
+  "stat_hourly_unattributed_note": "早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。",
+  "game_attach_and_capture": "附着并捕获"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3068,5 +3068,6 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "game_attach_and_capture": "Attach and capture"
 }

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -616,17 +616,32 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
 
   /// 拉起窗口选择器：选择结果只作为 intent 交给 app 级会话控制器。
   Future<void> _pickExternalWindow() async {
+    final ExternalWindowInfo? picked = await _showExternalWindowPicker();
+    // 选回当前已绑定的那个窗口是 no-op，不是「重新绑定」：bindWindow 在捕获模式下会
+    // startAttachedCapture 重启整条会话（launch 会话会因此退化成 attach，正在跑的
+    // engine hook 与已收台词一起丢）。预选中当前游戏后回车确认是最自然的操作，绝不能
+    // 因此把会话打断。
+    if (picked == null || picked.hwnd == _session.state.boundWindow?.hwnd) {
+      return;
+    }
+    await _session.bindWindow(picked);
+  }
+
+  /// 只负责「选」：列出可捕获窗口交给用户挑一个，绑定还是直接起捕获由调用方决定。
+  /// 拆出来是因为「附着并捕获」与「绑定窗口」对同一份列表有两种不同的后续处置，
+  /// 把处置塞进选择器会逼出模式参数。
+  Future<ExternalWindowInfo?> _showExternalWindowPicker() async {
     if (!Platform.isWindows) {
       HibikiToast.show(msg: t.external_window_unsupported);
-      return;
+      return null;
     }
     final List<ExternalWindowInfo> windows =
         await WindowCaptureChannel.listWindows();
     if (windows.isEmpty) {
       HibikiToast.show(msg: t.external_window_no_windows);
-      return;
+      return null;
     }
-    if (!context.mounted) return;
+    if (!context.mounted) return null;
     // BUG-1049：Hibiki 自己启动的游戏必须在这份列表里「已经选好」。会话知道游戏 pid，
     // 却把它和一屏无关窗口平铺在一起，等于让用户替 app 认自己刚拉起的进程。按 pid
     // 把它排到第一条、标注出来并预置焦点：打开即落在正确的窗口上，回车就绑。
@@ -667,12 +682,33 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         ],
       ),
     );
-    // 选回当前已绑定的那个窗口是 no-op，不是「重新绑定」：bindWindow 在捕获模式下会
-    // startAttachedCapture 重启整条会话（launch 会话会因此退化成 attach，正在跑的
-    // engine hook 与已收台词一起丢）。预选中当前游戏后回车确认是最自然的操作，绝不能
-    // 因此把会话打断。
-    if (picked == null || picked.hwnd == boundHwnd) return;
-    await _session.bindWindow(picked);
+    return picked;
+  }
+
+  /// 附着到**已在运行**的游戏：与「启动并捕获」并列的一级入口。
+  ///
+  /// 底层能力一直都在（injector `--pid` attach + [GalHookSessionController.
+  /// startAttachedCapture] 的完整注入编排），但此前唯一入口是「更多」溢出菜单里
+  /// 那个叫「外部窗口挖矿」的模式开关——名字看不出是「附着到已经在跑的游戏」，
+  /// 等于把一条主路径藏进溢出菜单，用户只能每次都让 Hibiki 把游戏拉起来。
+  ///
+  /// 直接调 [GalHookSessionController.startAttachedCapture]，不拼
+  /// 「[GalHookSessionController.bindWindow] + [GalHookSessionController
+  /// .setExternalWindowMode]」两步：那两个方法各自都会在另一半就位时触发
+  /// startAttachedCapture，连着调会起两次会话，第二次把第一次刚装好的 engine hook
+  /// 和已收台词一起丢掉。startAttachedCapture 自己就把 externalWindowMode /
+  /// boundWindow / gamePid 一次设对。
+  Future<void> _attachToRunningGame() async {
+    final ExternalWindowInfo? picked = await _showExternalWindowPicker();
+    if (picked == null) return;
+    final GalHookSessionState state = _session.state;
+    // 已经在捕获这个窗口：重来一遍只会丢掉正在跑的 hook 与已收台词，什么都不做。
+    if (state.isActive &&
+        state.externalWindowMode &&
+        state.boundWindow?.hwnd == picked.hwnd) {
+      return;
+    }
+    await _session.startAttachedCapture(picked);
   }
 
   /// galgame 引擎-hook（launch 模式）：页面只发起会话；位数解析、注入器选择、窗口绑定、
@@ -1036,6 +1072,17 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
           tooltip: t.game_launch_and_capture,
           label: labelOf(t.game_launch_and_capture),
           onTap: _launchGalgameEngineHook,
+        ),
+      // 「游戏已经自己在跑」是和「让 Hibiki 拉起游戏」同等常见的起点（Steam / 启动器 /
+      // 转区工具拉起的进程都属此列），attach 能力也一直都在，只是入口此前藏在「更多」
+      // 菜单的模式开关里。两条起点并列摆出来，用户不必再为了捕获而重启游戏。
+      if (Platform.isWindows)
+        HibikiIconButton(
+          icon: Icons.cable_outlined,
+          tooltip: t.game_attach_and_capture,
+          label: labelOf(t.game_attach_and_capture),
+          focusId: const HibikiFocusId('game-toolbar-attach'),
+          onTap: _attachToRunningGame,
         ),
       if (state.isActive)
         HibikiIconButton(

--- a/hibiki/test/pages/texthooker_attach_running_game_guard_test.dart
+++ b/hibiki/test/pages/texthooker_attach_running_game_guard_test.dart
@@ -1,0 +1,123 @@
+// 「附着到已在运行的游戏」一级入口的源码接线守卫。
+//
+// 背景：injector 的 `--pid` attach 与 GalHookSessionController.startAttachedCapture
+// 的完整注入编排一直都在，但唯一 UI 入口是「更多」溢出菜单里那个叫「外部窗口挖矿」的
+// 模式开关——名字看不出是「附着到已经在跑的游戏」，用户只能每次都让 Hibiki 把游戏拉起来
+// 才能捕获。这里钉住三条：
+//  ① 工具栏一级按钮存在（与「启动并捕获」并列，不再退回溢出菜单）；
+//  ② 附着动作直接走 startAttachedCapture，**不得**改回「bindWindow +
+//     setExternalWindowMode」两步拼装——那两个方法各自都会在另一半就位时触发
+//     startAttachedCapture，连着调会起两次会话，第二次把第一次刚装好的 engine hook
+//     和已收台词一起丢掉；
+//  ③ 已在捕获同一窗口时是 no-op，不重启会话。
+//
+// 守卫读源码字符串而不 import 页面：按钮只在 Platform.isWindows 下构建，而 CI 单测门跑
+// 在 Linux 上，widget 渲染断言在那里恒为空。
+//
+// 注意：② 的断言必须只看**方法体**，不能扫全文件——本文件与页面 dartdoc 里都写着
+// 「setExternalWindowMode」这些词用于解释为什么不能那么写，扫全文件会让守卫恒绿。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 取 [signature]（须一路匹配到方法体的开花括号）对应的方法体，用于把断言限制在实现内，
+/// 避开 dartdoc 里为解释反例而出现的同名符号。
+///
+/// 用花括号配对而不是「找同缩进的 `\n  }`」：带命名参数的签名本身就跨行且含 `{...}`
+/// （如 `_buildToolbarActions(BuildContext context, {required bool embedded})`），
+/// 缩进猜测会把参数列表的闭合当成方法结束，取到空体让所有断言恒绿。
+String _methodBody(String src, RegExp signature) {
+  final Match? match = signature.firstMatch(src);
+  expect(match, isNotNull, reason: '未找到方法签名：${signature.pattern}');
+  final int bodyStart = match!.end;
+  int depth = 1;
+  int i = bodyStart;
+  while (i < src.length && depth > 0) {
+    final String c = src[i];
+    if (c == '{') depth++;
+    if (c == '}') depth--;
+    i++;
+  }
+  expect(depth, 0, reason: '${signature.pattern} 的方法体花括号未闭合');
+  return src.substring(bodyStart, i - 1);
+}
+
+final RegExp _toolbarSig =
+    RegExp(r'List<Widget> _buildToolbarActions\([\s\S]*?\)\s*\{');
+final RegExp _attachSig =
+    RegExp(r'Future<void> _attachToRunningGame\(\)\s*async\s*\{');
+final RegExp _pickSig =
+    RegExp(r'Future<void> _pickExternalWindow\(\)\s*async\s*\{');
+
+void main() {
+  final String pageSrc =
+      File('lib/src/pages/implementations/texthooker_page.dart')
+          .readAsStringSync();
+
+  group('附着到运行中的游戏：一级入口存在', () {
+    test('工具栏有 attach 按钮且接到 _attachToRunningGame', () {
+      final String toolbar = _methodBody(pageSrc, _toolbarSig);
+      expect(toolbar.contains('t.game_attach_and_capture'), isTrue,
+          reason: '附着入口必须是工具栏一级按钮，不能退回「更多」溢出菜单');
+      expect(toolbar.contains('onTap: _attachToRunningGame'), isTrue,
+          reason: 'attach 按钮必须接到附着动作');
+      expect(toolbar.contains('t.game_launch_and_capture'), isTrue,
+          reason: '「启动并捕获」仍须并列存在——两条起点都是主路径');
+    });
+
+    test('附着动作有独立方法', () {
+      expect(
+        RegExp(r'Future<void> _attachToRunningGame\(\) async \{')
+            .hasMatch(pageSrc),
+        isTrue,
+        reason: '附着动作须是独立方法，便于工具栏与后续入口共用',
+      );
+    });
+  });
+
+  group('附着动作不得退回双启动拼装', () {
+    test('方法体直接调 startAttachedCapture', () {
+      final String body = _methodBody(pageSrc, _attachSig);
+      expect(body.contains('startAttachedCapture('), isTrue,
+          reason: '附着必须一步起会话');
+    });
+
+    test('方法体不得出现 bindWindow / setExternalWindowMode', () {
+      final String body = _methodBody(pageSrc, _attachSig);
+      expect(body.contains('setExternalWindowMode'), isFalse,
+          reason: 'bindWindow 与 setExternalWindowMode 各自都会触发 '
+              'startAttachedCapture，拼装会起两次会话并丢掉已装好的 hook');
+      expect(body.contains('bindWindow'), isFalse,
+          reason: '同上：附着路径不经绑定方法，startAttachedCapture 自己会把 '
+              'externalWindowMode / boundWindow / gamePid 一次设对');
+    });
+
+    test('已在捕获同一窗口时不重启会话', () {
+      final String body = _methodBody(pageSrc, _attachSig);
+      expect(body.contains('state.isActive'), isTrue, reason: '须先判当前是否已在捕获');
+      expect(body.contains('boundWindow?.hwnd == picked.hwnd'), isTrue,
+          reason: '选回正在捕获的同一窗口必须 no-op，否则重启会丢已收台词');
+    });
+  });
+
+  group('选择器只负责选，处置交调用方', () {
+    test('存在只返回选中窗口的 picker', () {
+      expect(
+        RegExp(r'Future<ExternalWindowInfo\?> _showExternalWindowPicker\(\)')
+            .hasMatch(pageSrc),
+        isTrue,
+        reason: '「附着并捕获」与「绑定窗口」对同一份列表有两种后续处置，'
+            '把处置塞进选择器会逼出模式参数',
+      );
+    });
+
+    test('_pickExternalWindow 仍走绑定路径（旧入口行为不变）', () {
+      final String body = _methodBody(pageSrc, _pickSig);
+      expect(body.contains('_showExternalWindowPicker()'), isTrue,
+          reason: '旧入口复用同一个选择器');
+      expect(body.contains('_session.bindWindow(picked)'), isTrue,
+          reason: '旧入口语义是「绑定」，不得改成直接起捕获');
+    });
+  });
+}


### PR DESCRIPTION
用户诉求：**不启动游戏也能对指定的、已经在跑的应用开始捕获**，不必每次都让 Hibiki 把游戏拉起来。

## 现状不是「没这能力」，是「入口藏了」

底层一直是全的：

- native injector 支持 `--pid` attach（与 `--launch` 二选一），`injector_main.cpp` 里 attach 与 launch 共用同一套注入编排；
- Dart 侧 `GalHookSessionController.startAttachedCapture` 是完整路径：探目标位数 → 选 injector → 注入 → engine hook。

缺的只是 UI 入口。此前唯一路径是「更多」溢出菜单里那个叫**「外部窗口挖矿」**的模式开关——名字看不出是「附着到已经在跑的游戏」，而且是个模式开关而不是动作按钮，等于把一条主路径藏进了溢出菜单。工具栏一级只有「启动并捕获」（选 exe 由 Hibiki 拉起），用户自然以为必须重启游戏才能捕获。

## 改动

- 工具栏加**「附着并捕获」**一级按钮，与「启动并捕获」并列（Windows）。两条起点都是主路径：Steam / 启动器 / 转区工具拉起的进程都只能走 attach。
- 附着动作**直接调 `startAttachedCapture`**，不拼「`bindWindow` + `setExternalWindowMode`」两步。那两个方法各自都会在另一半就位时触发 `startAttachedCapture`，连着调会起**两次会话**，第二次把第一次刚装好的 engine hook 和已收台词一起丢掉；`startAttachedCapture` 自己就把 `externalWindowMode` / `boundWindow` / `gamePid` 一次设对。
- 选中的窗口**已在捕获中则 no-op**，不重启会话。
- 窗口选择器拆出只负责「选」的 `_showExternalWindowPicker`：附着与绑定对同一份列表有两种后续处置，把处置塞进选择器会逼出模式参数。旧入口 `_pickExternalWindow` 与溢出菜单开关行为均不变。

## 守卫

`hibiki/test/pages/texthooker_attach_running_game_guard_test.dart`，源码扫描（按钮只在 `Platform.isWindows` 下构建，CI 单测门在 Linux，widget 渲染断言在那里恒为空）。

断言**只看方法体**而不扫全文件：页面 dartdoc 与守卫注释里都写着 `setExternalWindowMode` 用于解释反例，扫全文件会让守卫恒绿。第一版 helper 用「找同缩进 `\n  }`」取方法体，被 `_buildToolbarActions` 跨行命名参数的 `}` 提前截断成空体——已改成正则定位方法体开括号 + 花括号配对。

三条变异各自实测变红后还原：

| 变异 | 结果 |
|---|---|
| 改回 `bindWindow` + `setExternalWindowMode` 两步拼装 | 红（2 条断言） |
| 摘掉工具栏按钮 `onTap` | 红 |
| 删掉 no-op 守卫 | 红 |

## 验证

- `flutter analyze` 全量（含 test）：`No issues found!`
- 定向 `flutter_test_failures.dart`：**100 tests passed**，含 i18n 17 语言完整性、`external_window_mining`、`window_capture_channel`、`gal_hook_session_controller`、`texthooker_page` 与既有工具栏守卫。

未做真机验证：attach 到真实游戏进程需要 Windows 真机跑一遍原始路径，本轮只做到自动化层。

未 bump `+build`，按惯例由合并时的 release commit 统一处理。

https://claude.ai/code/session_01VjxJLfVKzfP9JCgnci4E8Z
