### PR TITLE
perf(sync): 清掉同步链路两处纯浪费——封面惰性读 + folder 缓存脏判定 (TODO-2657)

### DIFF
--- a/hibiki/lib/src/sync/dropbox_sync_backend.dart
+++ b/hibiki/lib/src/sync/dropbox_sync_backend.dart
@@ -300,7 +300,7 @@ class DropboxSyncBackend extends SyncBackend
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async {
     final sanitized = requireBookFolderName(bookTitle);
 
@@ -322,6 +322,7 @@ class DropboxSyncBackend extends SyncBackend
 
     folderIdCache[sanitized] = folderPath;
 
+    final Uint8List? coverData = await readCoverData?.call();
     if (coverData != null) {
       try {
         final format = detectCoverFormat(coverData);

--- a/hibiki/lib/src/sync/ftp_sync_backend.dart
+++ b/hibiki/lib/src/sync/ftp_sync_backend.dart
@@ -218,7 +218,7 @@ class FtpSyncBackend extends SyncBackend
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) =>
       _opLock.withLock(() async {
         final sanitized = requireBookFolderName(bookTitle);
@@ -242,6 +242,7 @@ class FtpSyncBackend extends SyncBackend
           await _client!.changeDirectory(_homeDir);
           folderIdCache[sanitized] = folderPath;
 
+          final Uint8List? coverData = await readCoverData?.call();
           if (coverData != null) {
             try {
               final format = detectCoverFormat(coverData);

--- a/hibiki/lib/src/sync/google_drive_handler.dart
+++ b/hibiki/lib/src/sync/google_drive_handler.dart
@@ -268,7 +268,7 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolder,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async {
     final sanitized = requireBookFolderName(bookTitle);
 
@@ -311,6 +311,7 @@ class GoogleDriveHandler with SyncFolderCache, SyncBackendFileTrioMixin {
       final folderId = created.id!;
       folderIdCache[sanitized] = folderId;
 
+      final Uint8List? coverData = await readCoverData?.call();
       if (coverData != null) {
         try {
           await _uploadCover(api, folderId: folderId, coverData: coverData);

--- a/hibiki/lib/src/sync/google_drive_sync_backend.dart
+++ b/hibiki/lib/src/sync/google_drive_sync_backend.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart' show visibleForTesting;
 
@@ -122,12 +121,12 @@ class GoogleDriveSyncBackend extends SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) =>
       _wrapErrors(() => _drive.ensureBookFolder(
             bookTitle: bookTitle,
             rootFolder: rootFolderId,
-            coverData: coverData,
+            readCoverData: readCoverData,
           ));
 
   // ── Metadata sync ─────────────────────────────────────────────────

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -372,7 +372,7 @@ class InterconnectSyncBackend extends SyncBackend
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async {
     final sanitized = requireBookFolderName(bookTitle);
 
@@ -385,6 +385,7 @@ class InterconnectSyncBackend extends SyncBackend
     await _ops!.ensureCollection(path);
     folderIdCache[sanitized] = path;
 
+    final Uint8List? coverData = await readCoverData?.call();
     if (coverData != null) {
       try {
         final format = detectCoverFormat(coverData);

--- a/hibiki/lib/src/sync/obfuscating_sync_backend.dart
+++ b/hibiki/lib/src/sync/obfuscating_sync_backend.dart
@@ -113,15 +113,23 @@ class ObfuscatingSyncBackend extends SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) =>
       _inner.ensureBookFolder(
         bookTitle: bookTitle,
         rootFolderId: rootFolderId,
-        // 封面是小数据，整块混淆。null 原样透传。
-        coverData:
-            coverData == null ? null : SyncObfuscator.obfuscateBytes(coverData),
+        // 封面是小数据，整块混淆。null 原样透传。混淆包在惰性回调「里面」，
+        // 所以内层后端缓存命中不调用回调时，既不读磁盘也不做混淆（TODO-2657）。
+        readCoverData:
+            readCoverData == null ? null : _obfuscateCover(readCoverData),
       );
+
+  /// 把惰性封面来源 [inner] 包一层混淆，保持惰性（只在被调用时才读+混淆）。
+  static SyncCoverDataProvider _obfuscateCover(SyncCoverDataProvider inner) =>
+      () async {
+        final Uint8List? data = await inner();
+        return data == null ? null : SyncObfuscator.obfuscateBytes(data);
+      };
 
   // ── Metadata sync (JSON, 纯委托 — A2 follow-up) ───────────────────
 

--- a/hibiki/lib/src/sync/onedrive_sync_backend.dart
+++ b/hibiki/lib/src/sync/onedrive_sync_backend.dart
@@ -314,7 +314,7 @@ class OneDriveSyncBackend extends SyncBackend
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async {
     final sanitized = requireBookFolderName(bookTitle);
 
@@ -346,6 +346,7 @@ class OneDriveSyncBackend extends SyncBackend
     }
     folderIdCache[sanitized] = folderId;
 
+    final Uint8List? coverData = await readCoverData?.call();
     if (coverData != null) {
       try {
         final format = detectCoverFormat(coverData);

--- a/hibiki/lib/src/sync/sftp_sync_backend.dart
+++ b/hibiki/lib/src/sync/sftp_sync_backend.dart
@@ -142,7 +142,7 @@ class SftpSyncBackend extends SyncBackend
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) =>
       _guarded(() async {
         final sanitized = requireBookFolderName(bookTitle);
@@ -156,6 +156,7 @@ class SftpSyncBackend extends SyncBackend
         await _mkdirIfAbsent(sftp, path);
         folderIdCache[sanitized] = path;
 
+        final Uint8List? coverData = await readCoverData?.call();
         if (coverData != null) {
           try {
             final format = detectCoverFormat(coverData);

--- a/hibiki/lib/src/sync/sync_backend.dart
+++ b/hibiki/lib/src/sync/sync_backend.dart
@@ -132,6 +132,18 @@ String requireBookFolderName(String bookTitle) {
 String ensureFolderIdTrailingSlash(String folderId) =>
     folderId.endsWith('/') ? folderId : '$folderId/';
 
+/// 惰性封面字节来源，交给 [SyncBackend.ensureBookFolder]。
+///
+/// TODO-2657: 每个后端的 `ensureBookFolder` 在书名→folderId 缓存命中时**直接
+/// return**，封面字节根本没被看一眼。此前调用方（`SyncManager._syncBookOnce`）
+/// 却在调用前就 `readAsBytesSync()` 读完整张封面图，于是稳态下每本书每轮都白读
+/// 一整张图再丢弃。改成惰性回调后，只有真正走到「新建/确认文件夹 + 上传封面」
+/// 分支的后端才会去读磁盘——cache-miss 分支的行为一字不变。
+///
+/// 返回 `null` 表示这本书没有可用封面（路径缺失/读失败），与旧的
+/// `coverData == null` 完全同义。
+typedef SyncCoverDataProvider = Future<Uint8List?> Function();
+
 abstract class SyncBackend implements SyncAssetStore {
   // ── Auth ──────────────────────────────────────────────────────────
 
@@ -146,10 +158,13 @@ abstract class SyncBackend implements SyncAssetStore {
 
   Future<String> findOrCreateRootFolder();
   Future<List<SyncFileRef>> listBooks(String rootFolderId);
+
+  /// [readCoverData] 只在实现真的要上传封面时才调用（见 [SyncCoverDataProvider]）；
+  /// 缓存命中的快路径必须**不**调用它。
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   });
 
   // ── Metadata sync (JSON) ──────────────────────────────────────────

--- a/hibiki/lib/src/sync/sync_manager.dart
+++ b/hibiki/lib/src/sync/sync_manager.dart
@@ -267,20 +267,16 @@ class SyncManager {
 
     final rootId = await _backend.findOrCreateRootFolder();
 
-    Uint8List? coverData;
-    if (book.coverPath != null) {
-      try {
-        final file = File(book.coverPath!);
-        if (file.existsSync()) coverData = file.readAsBytesSync();
-      } catch (e) {
-        debugPrint('[sync] cover image read failed: $e');
-      }
-    }
-
+    // TODO-2657: 封面字节惰性提供，不再在调用前预读。`ensureBookFolder` 在书名→
+    // folderId 缓存命中时直接 return、封面根本用不上；旧代码却每本书每轮都
+    // `readAsBytesSync()` 读完整张图再丢弃。回调只在后端真的要上传封面（新建/首次
+    // 确认文件夹）时才被调用，cache-miss 分支拿到的字节与从前逐字节相同。
+    final String? coverPath = book.coverPath;
     final folderId = await _backend.ensureBookFolder(
       bookTitle: book.title,
       rootFolderId: rootId,
-      coverData: coverData,
+      readCoverData:
+          coverPath == null ? null : () => _readCoverBytes(coverPath),
     );
 
     final syncFiles = await _backend.listSyncFiles(folderId);
@@ -879,6 +875,20 @@ class SyncManager {
         readingTimeMs: Value((stat.readingTimeSec * 1000).round()),
         lastStatisticModified: Value(stat.lastStatisticModified),
       ));
+    }
+  }
+
+  /// 读一本书的封面字节；路径不存在或读失败一律返回 `null`（与旧的
+  /// `coverData == null` 同义，后端据此跳过封面上传）。只被
+  /// [SyncCoverDataProvider] 回调调用，即只在后端真要上传封面时才执行。
+  static Future<Uint8List?> _readCoverBytes(String coverPath) async {
+    try {
+      final File file = File(coverPath);
+      if (!await file.exists()) return null;
+      return await file.readAsBytes();
+    } catch (e) {
+      debugPrint('[sync] cover image read failed: $e');
+      return null;
     }
   }
 

--- a/hibiki/lib/src/sync/sync_manager.dart
+++ b/hibiki/lib/src/sync/sync_manager.dart
@@ -894,18 +894,51 @@ class SyncManager {
 
   // ── Drive cache persistence ───────────────────────────────────────
 
+  /// 上次真正落盘的根 folderId / 书名→folderId 映射（TODO-2657 脏判定基线）。
+  ///
+  /// [_persistDriveCache] 每本书都被调一次。稳态（所有书都缓存命中）下这张映射表
+  /// 一字不变，旧实现却每本书都 `jsonEncode` 整表 + upsert 一次外加一次
+  /// `setRootFolderId`，N 本书写出 O(N²) 字节的纯重复。只在内容真变时写。
+  ///
+  /// **崩溃安全语义逐字不变**：这不是「攒到整轮结束再落盘」。任何新学到的
+  /// folderId 都让映射表相对基线变脏，因而仍在该书 `syncBook` 返回前落盘；中途
+  /// 崩溃时已同步书的 folderId 一个都不会丢。被跳过的只有「内容与磁盘完全相同」
+  /// 的重写，跳过它按定义不可能丢信息。
+  String? _persistedRootFolderId;
+  Map<String, String> _persistedFolderCache = const <String, String>{};
+
   Future<void> _restoreDriveCache() async {
     if (_backend.cachedRootFolderId != null) return;
     final rootId = await _repo.getRootFolderId();
     final folderCache = await _repo.getFolderCache();
     _backend.restoreCache(rootFolderId: rootId, titleToFolderId: folderCache);
+    // 刚读出来的就是磁盘现值，直接当脏判定基线，省掉「恢复后第一次落盘」的无谓
+    // 整表重写。刻意用**未经 normalizeFolderId 归一化**的原值：这样 restoreCache
+    // 的尾斜杠自愈（BUG-845）仍会被判为「变脏」并写回磁盘，被污染的持久化缓存照旧
+    // 在下一次落盘时清干净。
+    _persistedRootFolderId = rootId;
+    _persistedFolderCache = Map<String, String>.unmodifiable(folderCache);
   }
 
   Future<void> _persistDriveCache() async {
     final rootId = _backend.cachedRootFolderId;
-    if (rootId != null) await _repo.setRootFolderId(rootId);
+    if (rootId != null && rootId != _persistedRootFolderId) {
+      await _repo.setRootFolderId(rootId);
+      _persistedRootFolderId = rootId;
+    }
     final cache = _backend.cachedFolderIds;
-    if (cache.isNotEmpty) await _repo.setFolderCache(cache);
+    if (cache.isNotEmpty && !_sameFolderCache(cache, _persistedFolderCache)) {
+      await _repo.setFolderCache(cache);
+      _persistedFolderCache = Map<String, String>.unmodifiable(cache);
+    }
+  }
+
+  static bool _sameFolderCache(Map<String, String> a, Map<String, String> b) {
+    if (a.length != b.length) return false;
+    for (final MapEntry<String, String> entry in a.entries) {
+      if (b[entry.key] != entry.value) return false;
+    }
+    return true;
   }
 }
 

--- a/hibiki/lib/src/sync/webdav_sync_backend.dart
+++ b/hibiki/lib/src/sync/webdav_sync_backend.dart
@@ -103,7 +103,7 @@ class WebDavSyncBackend extends SyncBackend
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async {
     final sanitized = requireBookFolderName(bookTitle);
 
@@ -119,6 +119,7 @@ class WebDavSyncBackend extends SyncBackend
     await _ops!.ensureCollection(path);
     folderIdCache[sanitized] = path;
 
+    final Uint8List? coverData = await readCoverData?.call();
     if (coverData != null) {
       try {
         final format = detectCoverFormat(coverData);

--- a/hibiki/test/sync/cloud_book_folder_tags_test.dart
+++ b/hibiki/test/sync/cloud_book_folder_tags_test.dart
@@ -162,7 +162,7 @@ class _FakeBookFolderBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       throw UnimplementedError();
   @override

--- a/hibiki/test/sync/cloud_remote_book_client_test.dart
+++ b/hibiki/test/sync/cloud_remote_book_client_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/sync/cloud_remote_book_client.dart';
@@ -103,7 +102,7 @@ class _ControllableSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       throw UnimplementedError();
   @override

--- a/hibiki/test/sync/obfuscating_sync_backend_test.dart
+++ b/hibiki/test/sync/obfuscating_sync_backend_test.dart
@@ -16,8 +16,15 @@ class _RecordingBackend implements SyncBackend {
   /// assetId -> 预置的「云端字节」，下载时写入目标文件。
   final Map<String, Uint8List> remoteBytes = <String, Uint8List>{};
 
-  /// 最近一次 ensureBookFolder 收到的 coverData（已是装饰器处理后的）。
+  /// 最近一次 ensureBookFolder 从惰性回调取到的封面字节（已是装饰器处理后的）。
   Uint8List? lastCoverData;
+
+  /// ensureBookFolder 里惰性封面回调被调用的次数（验证装饰器保持惰性）。
+  int coverProviderCalls = 0;
+
+  /// true 时 ensureBookFolder 模拟「书名→folderId 缓存命中」：直接早退，
+  /// 一次都不碰封面回调。
+  bool simulateCacheHit = false;
 
   /// 记录 JSON 方法被调用（验证纯委托不混淆）。
   TtuProgress? lastProgress;
@@ -68,9 +75,14 @@ class _RecordingBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async {
-    lastCoverData = coverData;
+    if (simulateCacheHit) return 'folder-$bookTitle';
+    // 模拟 cache-miss 分支：真的去取封面字节（缓存命中的后端不会调用回调）。
+    if (readCoverData != null) {
+      coverProviderCalls++;
+      lastCoverData = await readCoverData();
+    }
     return 'folder-$bookTitle';
   }
 
@@ -170,7 +182,7 @@ void main() {
   });
 
   group('ObfuscatingSyncBackend cover obfuscation', () {
-    test('ensureBookFolder obfuscates coverData', () async {
+    test('ensureBookFolder obfuscates lazily-read cover bytes', () async {
       final inner = _RecordingBackend();
       final backend = ObfuscatingSyncBackend(inner);
       final cover =
@@ -179,7 +191,7 @@ void main() {
       await backend.ensureBookFolder(
         bookTitle: 'Book',
         rootFolderId: 'root',
-        coverData: cover,
+        readCoverData: () async => cover,
       );
 
       final stored = inner.lastCoverData!;
@@ -187,10 +199,32 @@ void main() {
       expect(SyncObfuscator.deobfuscateBytes(stored), cover);
     });
 
-    test('ensureBookFolder forwards null coverData untouched', () async {
+    test('ensureBookFolder forwards a null cover provider untouched', () async {
       final inner = _RecordingBackend();
       final backend = ObfuscatingSyncBackend(inner);
       await backend.ensureBookFolder(bookTitle: 'B', rootFolderId: 'r');
+      expect(inner.lastCoverData, isNull);
+      expect(inner.coverProviderCalls, 0);
+    });
+
+    // TODO-2657: 装饰器必须把混淆包在惰性回调「里面」。若它先 await 取字节、混淆
+    // 完再把常量透传下去（eager 形态），内层后端即使缓存命中根本不要封面，也已经
+    // 付掉了整张图的磁盘读 + 混淆代价——正是这轮要消掉的浪费。
+    test('ObfuscatingSyncBackend does not read the cover eagerly', () async {
+      final inner = _RecordingBackend()..simulateCacheHit = true;
+      final backend = ObfuscatingSyncBackend(inner);
+      int reads = 0;
+
+      await backend.ensureBookFolder(
+        bookTitle: 'Book',
+        rootFolderId: 'root',
+        readCoverData: () async {
+          reads++;
+          return Uint8List.fromList(<int>[1, 2, 3, 4]);
+        },
+      );
+
+      expect(reads, 0, reason: '内层后端缓存命中不取封面时，装饰器也不许自己先读一遍');
       expect(inner.lastCoverData, isNull);
     });
   });

--- a/hibiki/test/sync/sync_compare_conflict_test.dart
+++ b/hibiki/test/sync/sync_compare_conflict_test.dart
@@ -79,7 +79,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       remoteBooks[bookTitle]?.folderId ?? 'folder-$bookTitle';
 

--- a/hibiki/test/sync/sync_compare_delete_test.dart
+++ b/hibiki/test/sync/sync_compare_delete_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
@@ -110,7 +109,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       throw UnimplementedError();
   @override

--- a/hibiki/test/sync/sync_compare_dialog_labels_test.dart
+++ b/hibiki/test/sync/sync_compare_dialog_labels_test.dart
@@ -78,7 +78,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       remoteBooks[bookTitle]?.folderId ?? 'folder-$bookTitle';
 

--- a/hibiki/test/sync/sync_compare_download_test.dart
+++ b/hibiki/test/sync/sync_compare_download_test.dart
@@ -138,7 +138,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       throw UnimplementedError();
   @override

--- a/hibiki/test/sync/sync_compare_orphan_test.dart
+++ b/hibiki/test/sync/sync_compare_orphan_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -92,7 +91,7 @@ class _OrphanFakeBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       throw UnimplementedError();
   @override

--- a/hibiki/test/sync/sync_conflict_present_test.dart
+++ b/hibiki/test/sync/sync_conflict_present_test.dart
@@ -74,7 +74,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       remoteBooks[bookTitle]?.folderId ?? 'folder-$bookTitle';
 

--- a/hibiki/test/sync/sync_cover_lazy_read_test.dart
+++ b/hibiki/test/sync/sync_cover_lazy_read_test.dart
@@ -1,0 +1,250 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/hibiki_sync_server.dart';
+import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_file_ref.dart';
+import 'package:hibiki/src/sync/sync_manager.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// TODO-2657 ①：封面字节必须惰性读。
+///
+/// 每个后端的 `ensureBookFolder` 在书名→folderId 缓存命中时**直接 return**，封面
+/// 根本用不上；旧实现却在调用前 `readAsBytesSync()` 读完整张封面图再丢弃，于是
+/// 稳态下每本书每轮都白读一整张图。
+///
+/// 这里从两端钉死：
+///  - `SyncManager` 侧：调用 `ensureBookFolder` **之前**不许碰磁盘（用「回调被调用
+///    时封面文件才刚被创建」做判别器 —— eager 版只能读到 null）；
+///  - 真后端侧（`InterconnectSyncBackend` 打真 `HibikiSyncServer`）：cache-miss 那
+///    轮的行为一字不变（封面照旧上传、字节逐字节一致），cache-hit 那轮回调一次都
+///    不许被调用。
+
+/// PNG magic header + 一点载荷，`detectCoverFormat` 会判成 `image/png` / `.png`。
+final Uint8List _kCoverBytes = Uint8List.fromList(<int>[
+  0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, //
+  0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+]);
+
+/// 模拟真后端形状的 fake：书名→folderId 缓存命中就早退（不碰封面回调），
+/// 未命中才「新建文件夹 + 取封面上传」。
+class _LazyCoverBackend implements SyncBackend {
+  _LazyCoverBackend({this.onCacheMiss});
+
+  /// cache-miss 分支在调用封面回调**之前**执行的副作用。
+  final Future<void> Function()? onCacheMiss;
+
+  final Map<String, String> _folders = <String, String>{};
+  String? _root;
+
+  /// 封面回调被调用的次数——稳态（缓存命中）必须保持不增。
+  int coverProviderCalls = 0;
+
+  /// 最近一次从回调取到的封面字节。
+  Uint8List? lastCoverData;
+
+  @override
+  Future<String> findOrCreateRootFolder() async => _root ??= 'root';
+
+  @override
+  Future<String> ensureBookFolder({
+    required String bookTitle,
+    required String rootFolderId,
+    SyncCoverDataProvider? readCoverData,
+  }) async {
+    final String? cached = _folders[bookTitle];
+    if (cached != null) return cached; // 缓存命中：封面回调一次都不碰。
+
+    await onCacheMiss?.call();
+    final String id = 'folder-$bookTitle';
+    _folders[bookTitle] = id;
+    if (readCoverData != null) {
+      coverProviderCalls++;
+      lastCoverData = await readCoverData();
+    }
+    return id;
+  }
+
+  @override
+  Future<SyncFileTrio> listSyncFiles(String folderId) async =>
+      const SyncFileTrio();
+
+  @override
+  void clearCache() {
+    _root = null;
+    _folders.clear();
+  }
+
+  @override
+  void restoreCache({
+    String? rootFolderId,
+    Map<String, String>? titleToFolderId,
+  }) {
+    _root = rootFolderId;
+    if (titleToFolderId != null) _folders.addAll(titleToFolderId);
+  }
+
+  @override
+  String? get cachedRootFolderId => _root;
+
+  @override
+  Map<String, String> get cachedFolderIds =>
+      Map<String, String>.unmodifiable(_folders);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<EpubBookRow> _insertBook(
+  HibikiDatabase db, {
+  required String title,
+  required String coverPath,
+}) async {
+  await db.insertEpubBook(EpubBooksCompanion.insert(
+    bookKey: title,
+    title: title,
+    epubPath: '/fake/$title.epub',
+    extractDir: '/fake/$title',
+    chapterCount: 1,
+    chaptersJson: '[]',
+    importedAt: DateTime.now().millisecondsSinceEpoch,
+    coverPath: Value<String?>(coverPath),
+  ));
+  return (await db.getAllEpubBooks()).firstWhere((r) => r.title == title);
+}
+
+void main() {
+  test('SyncManager reads the cover only when the backend asks for it',
+      () async {
+    final Directory tempDir =
+        await Directory.systemTemp.createTemp('hibiki_cover_lazy_');
+    addTearDown(() => tempDir.delete(recursive: true));
+    final File coverFile = File('${tempDir.path}/cover.png');
+
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final EpubBookRow book =
+        await _insertBook(db, title: 'Book', coverPath: coverFile.path);
+
+    // 判别器：封面文件在 syncBook 调用时**还不存在**，只有在后端进到 cache-miss
+    // 分支、正要取封面的那一刻才被写出来。旧的 eager 版在 ensureBookFolder 之前
+    // 就 readAsBytesSync 了，那时文件不存在 → 只能拿到 null。
+    final backend = _LazyCoverBackend(
+      onCacheMiss: () => coverFile.writeAsBytes(_kCoverBytes),
+    );
+    final SyncManager manager = SyncManager(db: db, backend: backend);
+
+    expect(coverFile.existsSync(), isFalse);
+    await manager.syncBook(
+      book: book,
+      syncStats: false,
+      statsSyncMode: StatisticsSyncMode.merge,
+      syncAudioBook: false,
+    );
+
+    expect(backend.coverProviderCalls, 1, reason: 'cache-miss 分支必须照旧拿到封面');
+    expect(backend.lastCoverData, _kCoverBytes,
+        reason: '惰性读必须读到回调触发时刻的真实文件内容；'
+            '预读实现只会读到 null（那时文件还没被创建）');
+  });
+
+  test('a cached book folder triggers no cover read at all', () async {
+    final Directory tempDir =
+        await Directory.systemTemp.createTemp('hibiki_cover_lazy_hit_');
+    addTearDown(() => tempDir.delete(recursive: true));
+    final File coverFile = File('${tempDir.path}/cover.png');
+    await coverFile.writeAsBytes(_kCoverBytes);
+
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final EpubBookRow book =
+        await _insertBook(db, title: 'Book', coverPath: coverFile.path);
+
+    final backend = _LazyCoverBackend();
+    final SyncManager manager = SyncManager(db: db, backend: backend);
+
+    for (int round = 0; round < 3; round++) {
+      await manager.syncBook(
+        book: book,
+        syncStats: false,
+        statsSyncMode: StatisticsSyncMode.merge,
+        syncAudioBook: false,
+      );
+    }
+
+    // 第 1 轮 cache-miss 读一次，第 2/3 轮缓存命中一次都不读。
+    expect(backend.coverProviderCalls, 1, reason: '缓存命中的书不许再读封面图');
+  });
+
+  test(
+      'InterconnectSyncBackend: cache miss still uploads the cover, '
+      'cache hit never reads it', () async {
+    final Directory tempDir =
+        await Directory.systemTemp.createTemp('hibiki_cover_p2p_');
+    addTearDown(() => tempDir.delete(recursive: true));
+    await Directory('${tempDir.path}/sync-data').create(recursive: true);
+
+    final String token = HibikiSyncServer.generateToken();
+    final HibikiSyncServer server = HibikiSyncServer(
+      syncDataDir: tempDir.path,
+      port: 0,
+      token: token,
+      allowLan: false,
+    );
+    await server.start();
+    addTearDown(server.stop);
+
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final SyncRepository repo = SyncRepository(db);
+    await repo.setHibikiClientUrls(<HibikiClientUrl>[
+      HibikiClientUrl(url: 'http://127.0.0.1:${server.port}'),
+    ]);
+    await repo.setHibikiClientToken(token);
+
+    final InterconnectSyncBackend backend = InterconnectSyncBackend.instance;
+    backend.clearCache();
+    addTearDown(backend.clearCache);
+    expect(await backend.restoreAuth(repo), isTrue);
+
+    final String root = await backend.findOrCreateRootFolder();
+    int reads = 0;
+    Future<Uint8List?> readCover() async {
+      reads++;
+      return _kCoverBytes;
+    }
+
+    // ── cache miss：行为一字不变，封面照旧真上传 ──
+    final String folder = await backend.ensureBookFolder(
+      bookTitle: 'CoverBook',
+      rootFolderId: root,
+      readCoverData: readCover,
+    );
+    expect(reads, 1);
+
+    final SyncFileRef? uploaded =
+        await backend.findContentFile(folder, 'cover_1_6.png');
+    expect(uploaded, isNotNull, reason: 'cache-miss 分支必须仍然上传封面');
+    final File dest = File('${tempDir.path}/downloaded.png');
+    await backend.downloadContentFile(fileId: uploaded!.id, destination: dest);
+    expect(await dest.readAsBytes(), _kCoverBytes,
+        reason: '上传的封面字节必须与回调返回的逐字节一致');
+
+    // ── cache hit：回调一次都不许被调用 ──
+    final String folder2 = await backend.ensureBookFolder(
+      bookTitle: 'CoverBook',
+      rootFolderId: root,
+      readCoverData: readCover,
+    );
+    expect(folder2, folder);
+    expect(reads, 1, reason: '缓存命中的快路径不许触碰封面回调');
+  });
+}

--- a/hibiki/test/sync/sync_delete_evicts_folder_cache_test.dart
+++ b/hibiki/test/sync/sync_delete_evicts_folder_cache_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:drift/native.dart';
 import 'package:flutter/material.dart';
@@ -96,7 +95,7 @@ class _CacheTrackingBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       throw UnimplementedError();
   @override

--- a/hibiki/test/sync/sync_empty_title_folder_spill_test.dart
+++ b/hibiki/test/sync/sync_empty_title_folder_spill_test.dart
@@ -42,7 +42,7 @@ class _RecordingBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async {
     ensureBookFolderTitles.add(bookTitle);
     return '$rootFolderId${sanitizeTtuFilename(bookTitle)}/';

--- a/hibiki/test/sync/sync_folder_cache_persist_test.dart
+++ b/hibiki/test/sync/sync_folder_cache_persist_test.dart
@@ -1,0 +1,194 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_file_ref.dart';
+import 'package:hibiki/src/sync/sync_manager.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// TODO-2657 ②：`_persistDriveCache` 每本书都被调一次，旧实现每次都
+/// `jsonEncode` 整张书名→folderId 映射表 + upsert，外加一次 `setRootFolderId`。
+/// 稳态（所有书都缓存命中）下这张表一字不变，N 本书就白写 O(N²) 字节。
+///
+/// 修法是脏判定，**不是**批量落盘：内容真变就照旧立刻写（崩溃安全语义不变），
+/// 内容没变才跳过。三条用例分别钉住：没变不写 / 变了立刻写 / 尾斜杠自愈仍会写。
+class _StableFolderBackend implements SyncBackend {
+  _StableFolderBackend({this.normalizeTrailingSlash = false});
+
+  /// 模拟路径式后端（WebDAV / 互联）在 `restoreCache` 里的尾斜杠归一化（BUG-845）。
+  final bool normalizeTrailingSlash;
+
+  final Map<String, String> _folders = <String, String>{};
+  String? _root;
+
+  String _normalize(String id) =>
+      normalizeTrailingSlash && !id.endsWith('/') ? '$id/' : id;
+
+  @override
+  Future<String> findOrCreateRootFolder() async => _root ??= _normalize('root');
+
+  @override
+  Future<String> ensureBookFolder({
+    required String bookTitle,
+    required String rootFolderId,
+    SyncCoverDataProvider? readCoverData,
+  }) async =>
+      _folders[bookTitle] ??= _normalize('folder-$bookTitle');
+
+  @override
+  Future<SyncFileTrio> listSyncFiles(String folderId) async =>
+      const SyncFileTrio();
+
+  @override
+  void clearCache() {
+    _root = null;
+    _folders.clear();
+  }
+
+  @override
+  void restoreCache({
+    String? rootFolderId,
+    Map<String, String>? titleToFolderId,
+  }) {
+    _root = rootFolderId == null ? null : _normalize(rootFolderId);
+    titleToFolderId?.forEach((String title, String id) {
+      _folders[title] = _normalize(id);
+    });
+  }
+
+  @override
+  String? get cachedRootFolderId => _root;
+
+  @override
+  Map<String, String> get cachedFolderIds =>
+      Map<String, String>.unmodifiable(_folders);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<EpubBookRow> _insertBook(HibikiDatabase db, String title) async {
+  await db.insertEpubBook(EpubBooksCompanion.insert(
+    bookKey: title,
+    title: title,
+    epubPath: '/fake/$title.epub',
+    extractDir: '/fake/$title',
+    chapterCount: 1,
+    chaptersJson: '[]',
+    importedAt: DateTime.now().millisecondsSinceEpoch,
+  ));
+  return (await db.getAllEpubBooks()).firstWhere((r) => r.title == title);
+}
+
+void main() {
+  test('an unchanged folder cache is not rewritten for every book', () async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final SyncRepository repo = SyncRepository(db);
+
+    await repo.setRootFolderId('root');
+    await repo.setFolderCache(<String, String>{
+      'Book1': 'folder-Book1',
+      'Book2': 'folder-Book2',
+    });
+    final EpubBookRow book1 = await _insertBook(db, 'Book1');
+    final EpubBookRow book2 = await _insertBook(db, 'Book2');
+
+    final backend = _StableFolderBackend();
+    final SyncManager manager = SyncManager(db: db, backend: backend);
+
+    await manager.syncBook(
+      book: book1,
+      syncStats: false,
+      statsSyncMode: StatisticsSyncMode.merge,
+      syncAudioBook: false,
+    );
+
+    // 从这一刻起磁盘上放的是哨兵值。缓存内容没有任何变化，后续同步不许再碰这两行。
+    // 无条件重写的旧实现会把哨兵冲掉。
+    await repo.setRootFolderId('sentinel-root');
+    await repo.setFolderCache(<String, String>{'SENTINEL': 'untouched'});
+
+    await manager.syncBook(
+      book: book2,
+      syncStats: false,
+      statsSyncMode: StatisticsSyncMode.merge,
+      syncAudioBook: false,
+    );
+
+    expect(
+        await repo.getFolderCache(), <String, String>{'SENTINEL': 'untouched'},
+        reason: '映射表一字未变时不许重写整表');
+    expect(await repo.getRootFolderId(), 'sentinel-root',
+        reason: '根 folderId 未变时不许重写');
+  });
+
+  test('a newly learned folder id is persisted before that book returns',
+      () async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final SyncRepository repo = SyncRepository(db);
+
+    final EpubBookRow book1 = await _insertBook(db, 'Book1');
+    final EpubBookRow book2 = await _insertBook(db, 'Book2');
+
+    final backend = _StableFolderBackend();
+    final SyncManager manager = SyncManager(db: db, backend: backend);
+
+    await manager.syncBook(
+      book: book1,
+      syncStats: false,
+      statsSyncMode: StatisticsSyncMode.merge,
+      syncAudioBook: false,
+    );
+
+    // 崩溃安全：脏判定不得退化成「攒到整轮结束再落盘」。第一本书返回时，它的
+    // folderId 必须已经在磁盘上——此刻进程被杀也不会丢。
+    expect(await repo.getRootFolderId(), 'root');
+    expect(
+        await repo.getFolderCache(), <String, String>{'Book1': 'folder-Book1'});
+
+    await manager.syncBook(
+      book: book2,
+      syncStats: false,
+      statsSyncMode: StatisticsSyncMode.merge,
+      syncAudioBook: false,
+    );
+
+    expect(await repo.getFolderCache(), <String, String>{
+      'Book1': 'folder-Book1',
+      'Book2': 'folder-Book2',
+    });
+  });
+
+  test('a slash-less persisted folder id still self-heals on the next persist',
+      () async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(NativeDatabase.memory());
+    addTearDown(db.close);
+    final SyncRepository repo = SyncRepository(db);
+
+    // 被污染的持久化缓存（某些 WebDAV 服务器的 PROPFIND href 没有尾斜杠，BUG-845）。
+    await repo.setRootFolderId('root');
+    await repo.setFolderCache(<String, String>{'Book1': 'folder-Book1'});
+    final EpubBookRow book1 = await _insertBook(db, 'Book1');
+
+    final backend = _StableFolderBackend(normalizeTrailingSlash: true);
+    final SyncManager manager = SyncManager(db: db, backend: backend);
+
+    await manager.syncBook(
+      book: book1,
+      syncStats: false,
+      statsSyncMode: StatisticsSyncMode.merge,
+      syncAudioBook: false,
+    );
+
+    // 脏判定基线必须取**磁盘原值**而不是 restoreCache 归一化后的值，否则自愈写回
+    // 被判成「没变」而永远不落盘，磁盘上的污染值就再也清不掉。
+    expect(await repo.getFolderCache(),
+        <String, String>{'Book1': 'folder-Book1/'});
+    expect(await repo.getRootFolderId(), 'root/');
+  });
+}

--- a/hibiki/test/sync/sync_gating_test.dart
+++ b/hibiki/test/sync/sync_gating_test.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:drift/drift.dart' show Value;
@@ -39,7 +38,7 @@ class _RecordingExportBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       'folder';
 

--- a/hibiki/test/sync/sync_manager_conflict_test.dart
+++ b/hibiki/test/sync/sync_manager_conflict_test.dart
@@ -52,7 +52,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       'folder';
 

--- a/hibiki/test/sync/sync_manager_folder_cache_test.dart
+++ b/hibiki/test/sync/sync_manager_folder_cache_test.dart
@@ -59,7 +59,7 @@ class _AlwaysRetryableBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       throw UnimplementedError();
   @override

--- a/hibiki/test/sync/sync_orchestrator_conflict_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_conflict_test.dart
@@ -37,7 +37,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) async =>
       'folder';
 

--- a/hibiki/test/sync/sync_orchestrator_live_audio_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_live_audio_test.dart
@@ -188,7 +188,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) =>
       _store.ensureFolder(rootFolderId, bookTitle);
   @override

--- a/hibiki/test/sync/sync_orchestrator_live_book_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_live_book_test.dart
@@ -157,7 +157,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) {
     ensureBookFolderCalled = true;
     return _store.ensureFolder(rootFolderId, bookTitle);

--- a/hibiki/test/sync/sync_orchestrator_live_dict_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_live_dict_test.dart
@@ -134,7 +134,7 @@ class _FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) =>
       _store.ensureFolder(rootFolderId, bookTitle);
 

--- a/hibiki/test/sync/sync_orchestrator_test.dart
+++ b/hibiki/test/sync/sync_orchestrator_test.dart
@@ -64,7 +64,7 @@ class FakeSyncBackend implements SyncBackend {
   Future<String> ensureBookFolder({
     required String bookTitle,
     required String rootFolderId,
-    Uint8List? coverData,
+    SyncCoverDataProvider? readCoverData,
   }) =>
       _store.ensureFolder(rootFolderId, bookTitle);
 


### PR DESCRIPTION
清掉同步链路上两处**纯浪费**，零协议改动、零 schema 改动、零 wire 风险。两处各一个 commit，便于单独回滚。

## ① 每本书每轮白读一张整图（commit 9d9c869a0）

`SyncManager._syncBookOnce` 在调用 `ensureBookFolder` **之前**无条件 `readAsBytesSync()` 读完整张封面图，而**七个后端**（WebDAV / Dropbox / OneDrive / 互联 / FTP / SFTP / Google Drive）在「书名→folderId」缓存命中时都是**直接 return**，`coverData` 整个被丢弃。

**cache-miss 分支到底要不要 coverData？要。** 七个后端逐一确认：cache-miss 时都会用它上传 `cover_1_6.<ext>`（Google Drive 只在新建文件夹分支上传）。所以**不能删参数**，改成惰性：

- 新增 `typedef SyncCoverDataProvider = Future<Uint8List?> Function();`
- `ensureBookFolder` 的 `Uint8List? coverData` → `SyncCoverDataProvider? readCoverData`
- 每个后端在原来 `if (coverData != null)` 的位置加一行 `final Uint8List? coverData = await readCoverData?.call();`，**下面的上传块一字未动**
- `ObfuscatingSyncBackend` 把混淆包在回调**内部**，内层缓存命中时既不读盘也不混淆
- 顺带 `readAsBytesSync` → 异步 `readAsBytes`，不再阻塞 UI isolate

## ② 每本书每轮重写整张缓存表（commit 9e5e85880）

`_persistDriveCache()` 每本书调一次，无条件 `jsonEncode(整张 folderId 映射表)` + upsert，外加一次 `setRootFolderId`。稳态下这张表一字不变 → N 本书 O(N²) 字节 + 2N 次 DB 写。

**改批量落盘的崩溃后果？——没改成批量落盘。** 改成**脏判定**：只在根 folderId 或映射表内容相对上次落盘真变了才写。任何新学到的 folderId 都让表变脏，因而**仍在该书 `syncBook` 返回前落盘**，崩溃安全语义逐字不变、没有引入任何丢失窗口。被跳过的只有「内容与磁盘完全相同」的重写，跳过它按定义不可能丢信息。

一个坑已收口：脏判定基线取 `_restoreDriveCache` 读到的**磁盘原值**而非 `restoreCache` 归一化后的值，否则尾斜杠自愈（BUG-845）会被判成「没变」而永远写不回磁盘。

## 与 PR#725（TODO-2656 增量索引）的关系

PR#725 也改 `sync_manager.dart`。已读其 diff，结论：

- **git 层面不冲突**：#725 在 `sync_manager.dart` 的 hunk 落在 `syncAllBooks` / `_syncBookOnce` 的 `assetKey` 之后 / `_handleExport`；本 PR 的 hunk 在 `_syncBookOnce` 的封面块（更靠前 15 行以上）和文件末尾的 `_restoreDriveCache` / `_persistDriveCache`。两者互不相交。本 PR **不动** `sync_repository.dart`（#725 动）。
- **本 PR 仍然有效，不是死代码优化**：#725 的 `_trySkipViaIndex` 只在 `syncAllBooks` 里对「索引判定为已一致」的书早退。仍走全路径的有：索引不可用/首轮、索引里没有的书（新导入 / 上轮失败被剔除）、**以及每一本真有变化要同步的书**。这些书照旧每本白读一张封面图 + 重写整表。另外 `syncBook` 的两个公开调用点 `sync_auto_trigger.dart:694` 与 `sync_compare_dialog.dart:691` **完全不经过索引**，两处浪费在那里 100% 存在。
- **一处 git 不报、合完编译红的语义冲突**（交整合线，本 PR 不自行 rebase 到未合分支）：#725 新增的 `hibiki/test/sync/sync_index_book_skip_test.dart` 里 `_CountingBackend implements SyncBackend` 仍按旧签名声明 `Uint8List? coverData`（diff 第 1886 行）。两者都合入后需把该行改成 `SyncCoverDataProvider? readCoverData,`（一行）。
- **合并顺序建议**：先合本 PR（面窄、无新概念），#725 再 rebase 时只需改上面那一行；反过来也行，改动量相同。

## 测试（每条都做过变异实测）

新增 `test/sync/sync_cover_lazy_read_test.dart`（3 条）+ `test/sync/sync_folder_cache_persist_test.dart`（3 条），并加固 `obfuscating_sync_backend_test.dart` 一条。

| 变异 | 转红的用例 |
|---|---|
| `sync_manager` 改回 eager 预读 | `SyncManager reads the cover only when the backend asks for it`（拿到 null） |
| `interconnect_sync_backend` 缓存命中前也调回调 | `InterconnectSyncBackend: cache miss still uploads the cover, cache hit never reads it`（reads 2≠1） |
| 混淆装饰器改成先取字节再包常量回调 | `ObfuscatingSyncBackend does not read the cover eagerly`（reads 1≠0） |
| `_persistDriveCache` 去掉脏判定 | `an unchanged folder cache is not rewritten for every book`（磁盘哨兵被冲掉） |
| 删掉 `syncBook` 里的 per-book 落盘（=批量落盘） | `a newly learned folder id is persisted before that book returns` |
| 脏判定基线改取归一化后的值 | `a slash-less persisted folder id still self-heals on the next persist` |

## 门禁

- `flutter analyze`（含 test）：`No issues found!`
- `test/sync` 全目录：`FLUTTER TEST VERDICT: PASSED - 1908 tests ran, all tests passed`
- `source_guard_adoption_test` + `md3_design_system_static_test` + 新增 ② 测试：`FLUTTER TEST VERDICT: PASSED - 67 tests ran, all tests passed`
- 未 bump `+build`（整合线统一 bump）。未建 BUG 文档（性能浪费不是功能 bug）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
