### PR TITLE
feat(manga): 书↔漫画转化接进界面 + 历史分裂不变量守卫 (TODO-2150 阶段二 PR-A)

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52190 (3070 per locale)
+/// Strings: 52343 (3079 per locale)
 ///
-/// Built on 2026-08-02 at 01:55 UTC
+/// Built on 2026-08-02 at 03:29 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4125,6 +4125,19 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get stat_hourly_band_unattributed => 'Unsplit history';
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  String get book_convert_to_manga_action => 'Convert to manga';
+  String get book_convert_to_book_action => 'Convert back to book';
+  String get book_convert_running => 'Converting…';
+  String get book_convert_done => 'Conversion finished';
+  String get book_convert_failed => 'Conversion failed';
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -11169,6 +11182,28 @@ class _StringsAr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -18280,6 +18315,28 @@ class _StringsDe extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -25406,6 +25463,28 @@ class _StringsEs extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -32544,6 +32623,28 @@ class _StringsFr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -39611,6 +39712,28 @@ class _StringsId extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -46724,6 +46847,28 @@ class _StringsIt extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -53654,6 +53799,28 @@ class _StringsJa extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -60586,6 +60753,28 @@ class _StringsKo extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -67679,6 +67868,28 @@ class _StringsNl extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -74785,6 +74996,28 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -81875,6 +82108,28 @@ class _StringsRu extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -88913,6 +89168,28 @@ class _StringsTh extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -95983,6 +96260,28 @@ class _StringsTr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -103038,6 +103337,28 @@ class _StringsVi extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 // Path: <root>
@@ -109605,6 +109926,24 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       '早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。';
+  @override
+  String get book_convert_to_manga_action => '转换为漫画';
+  @override
+  String get book_convert_to_book_action => '转换回书';
+  @override
+  String get book_convert_running => '转换中…';
+  @override
+  String get book_convert_done => '转换完成';
+  @override
+  String get book_convert_failed => '转换失败';
+  @override
+  String get book_convert_blocked_already => '这本书已经是该格式了。';
+  @override
+  String get book_convert_blocked_text_only => '这是一本没有页图的文字书。只有扫描版图片书才能转成漫画。';
+  @override
+  String get book_convert_blocked_no_original => '这本漫画是从图片导入的，没有可还原的原书。';
+  @override
+  String get book_convert_blocked_source_missing => '源文件已从磁盘上消失。';
 }
 
 // Path: <root>
@@ -116456,6 +116795,28 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String get book_convert_to_manga_action => 'Convert to manga';
+  @override
+  String get book_convert_to_book_action => 'Convert back to book';
+  @override
+  String get book_convert_running => 'Converting…';
+  @override
+  String get book_convert_done => 'Conversion finished';
+  @override
+  String get book_convert_failed => 'Conversion failed';
+  @override
+  String get book_convert_blocked_already =>
+      'This book is already in that format.';
+  @override
+  String get book_convert_blocked_text_only =>
+      'This is a text book with no page images. Only scanned image books can become manga.';
+  @override
+  String get book_convert_blocked_no_original =>
+      'This manga was imported from images, so there is no original book to convert back to.';
+  @override
+  String get book_convert_blocked_source_missing =>
+      'The source files are gone from disk.';
 }
 
 /// Flat map(s) containing all translations.
@@ -122755,6 +123116,24 @@ extension on _StringsEn {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -129052,6 +129431,24 @@ extension on _StringsAr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -135371,6 +135768,24 @@ extension on _StringsDe {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -141689,6 +142104,24 @@ extension on _StringsEs {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -148013,6 +148446,24 @@ extension on _StringsFr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -154319,6 +154770,24 @@ extension on _StringsId {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -160639,6 +161108,24 @@ extension on _StringsIt {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -166921,6 +167408,24 @@ extension on _StringsJa {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -173207,6 +173712,24 @@ extension on _StringsKo {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -179521,6 +180044,24 @@ extension on _StringsNl {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -185832,6 +186373,24 @@ extension on _StringsPtBr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -192148,6 +192707,24 @@ extension on _StringsRu {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -198447,6 +199024,24 @@ extension on _StringsTh {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -204755,6 +205350,24 @@ extension on _StringsTr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -211059,6 +211672,24 @@ extension on _StringsVi {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }
@@ -217309,6 +217940,24 @@ extension on _StringsZhCn {
         return '未区分历史';
       case 'stat_hourly_unattributed_note':
         return '早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。';
+      case 'book_convert_to_manga_action':
+        return '转换为漫画';
+      case 'book_convert_to_book_action':
+        return '转换回书';
+      case 'book_convert_running':
+        return '转换中…';
+      case 'book_convert_done':
+        return '转换完成';
+      case 'book_convert_failed':
+        return '转换失败';
+      case 'book_convert_blocked_already':
+        return '这本书已经是该格式了。';
+      case 'book_convert_blocked_text_only':
+        return '这是一本没有页图的文字书。只有扫描版图片书才能转成漫画。';
+      case 'book_convert_blocked_no_original':
+        return '这本漫画是从图片导入的，没有可还原的原书。';
+      case 'book_convert_blocked_source_missing':
+        return '源文件已从磁盘上消失。';
       default:
         return null;
     }
@@ -223586,6 +224235,24 @@ extension on _StringsZhHk {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'book_convert_to_manga_action':
+        return 'Convert to manga';
+      case 'book_convert_to_book_action':
+        return 'Convert back to book';
+      case 'book_convert_running':
+        return 'Converting…';
+      case 'book_convert_done':
+        return 'Conversion finished';
+      case 'book_convert_failed':
+        return 'Conversion failed';
+      case 'book_convert_blocked_already':
+        return 'This book is already in that format.';
+      case 'book_convert_blocked_text_only':
+        return 'This is a text book with no page images. Only scanned image books can become manga.';
+      case 'book_convert_blocked_no_original':
+        return 'This manga was imported from images, so there is no original book to convert back to.';
+      case 'book_convert_blocked_source_missing':
+        return 'The source files are gone from disk.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "漫画",
   "stat_hourly_band_unattributed": "未区分历史",
-  "stat_hourly_unattributed_note": "早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。"
+  "stat_hourly_unattributed_note": "早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。",
+  "book_convert_to_manga_action": "转换为漫画",
+  "book_convert_to_book_action": "转换回书",
+  "book_convert_running": "转换中…",
+  "book_convert_done": "转换完成",
+  "book_convert_failed": "转换失败",
+  "book_convert_blocked_already": "这本书已经是该格式了。",
+  "book_convert_blocked_text_only": "这是一本没有页图的文字书。只有扫描版图片书才能转成漫画。",
+  "book_convert_blocked_no_original": "这本漫画是从图片导入的，没有可还原的原书。",
+  "book_convert_blocked_source_missing": "源文件已从磁盘上消失。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3068,5 +3068,14 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "book_convert_to_manga_action": "Convert to manga",
+  "book_convert_to_book_action": "Convert back to book",
+  "book_convert_running": "Converting…",
+  "book_convert_done": "Conversion finished",
+  "book_convert_failed": "Conversion failed",
+  "book_convert_blocked_already": "This book is already in that format.",
+  "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
+  "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
+  "book_convert_blocked_source_missing": "The source files are gone from disk."
 }

--- a/hibiki/lib/src/epub/epub_importer.dart
+++ b/hibiki/lib/src/epub/epub_importer.dart
@@ -110,22 +110,7 @@ class EpubImporter {
       final EpubBook book = result.book;
       final List<int> characterCounts = result.characterCounts;
 
-      final String chaptersJson = jsonEncode(
-        book.chapters
-            .asMap()
-            .entries
-            .map((entry) => <String, Object>{
-                  'id': entry.value.id,
-                  'href': entry.value.href,
-                  'mediaType': entry.value.mediaType,
-                  'characters': characterCounts[entry.key],
-                  // TODO-1192: 标记该 characters 计数的口径版本，供开书判定是否需
-                  // 要按新口径（[japaneseCharCount]）后台重算并回写（见
-                  // [kChapterCharCountCaliber] / charCountsFromChaptersJson）。
-                  'charCaliber': kChapterCharCountCaliber,
-                })
-            .toList(),
-      );
+      final String chaptersJson = buildChaptersJson(book, characterCounts);
 
       final String? tocJson = book.toc.isNotEmpty
           ? jsonEncode(
@@ -239,6 +224,48 @@ class EpubImporter {
       _tryDeleteDir(tempDir);
       rethrow;
     }
+  }
+
+  /// `EpubBooks.chaptersJson` 的**唯一**序列化口径：每章 `id`/`href`/`mediaType`/
+  /// `characters` + 计数口径版本 [kChapterCharCountCaliber]。
+  ///
+  /// 公开是给「漫画 → 书」转化用的（`book_format_rebuild.dart`）：转成漫画时这一列
+  /// 被写成 `'[]'`，转回来只能由重新解析解压树重建。两处各写一份 JSON 结构，字段名
+  /// 或 charCaliber 漂一个字，书架字数与 TODO-1192 的口径重算就同时坏掉。
+  static String buildChaptersJson(EpubBook book, List<int> characterCounts) {
+    return jsonEncode(
+      book.chapters
+          .asMap()
+          .entries
+          .map((entry) => <String, Object>{
+                'id': entry.value.id,
+                'href': entry.value.href,
+                'mediaType': entry.value.mediaType,
+                'characters': characterCounts[entry.key],
+                // TODO-1192: 标记该 characters 计数的口径版本，供开书判定是否需
+                // 要按新口径（[japaneseCharCount]）后台重算并回写（见
+                // [kChapterCharCountCaliber] / charCountsFromChaptersJson）。
+                'charCaliber': kChapterCharCountCaliber,
+              })
+          .toList(),
+    );
+  }
+
+  /// 重新解析**已解压**的书目录 [extractDir]，返回 `(chapterCount, chaptersJson,
+  /// coverPath)` 三件套。
+  ///
+  /// 用于「漫画 → 书」转回：本仓的 EPUB 在盘上只有解压树、没有独立 `.epub`
+  /// （BUG-088），所以「撤销」不存在——只能拿解压树重新算一遍。DOM 解析与字数统计
+  /// 放 isolate（与导入同款 [compute]），不卡 UI。
+  static Future<({int chapterCount, String chaptersJson, String? coverPath})>
+      reparseExtractedBook(String extractDir) async {
+    final _ParseResult result =
+        await compute(_reparseExtractedInIsolate, extractDir);
+    return (
+      chapterCount: result.book.chapters.length,
+      chaptersJson: buildChaptersJson(result.book, result.characterCounts),
+      coverPath: result.book.coverHref,
+    );
   }
 
   /// Move the freshly-extracted [srcDir] to [targetDir]; returns the
@@ -414,6 +441,16 @@ List<int> _computeCharacterCounts(EpubBook book) {
     book.chapters.length,
     (int index) => book.chapterCharacterCount(index),
     growable: false,
+  );
+}
+
+/// 解析一个**已经解压好**的书目录（不解压、不写盘），供「漫画 → 书」转回重算
+/// 章节与字数。
+_ParseResult _reparseExtractedInIsolate(String extractDir) {
+  final EpubBook book = EpubParser.parseFromExtracted(extractDir);
+  return _ParseResult(
+    book: book,
+    characterCounts: _computeCharacterCounts(book),
   );
 }
 

--- a/hibiki/lib/src/media/manga/book_format_convert.dart
+++ b/hibiki/lib/src/media/manga/book_format_convert.dart
@@ -12,9 +12,9 @@
 ///
 /// **转化即重建**：不是翻一个字段就完事——`format='manga'` 的阅读器硬要求
 /// `extractDir/manga.json` + `images/` 存在（缺了直接 `_loadFailed`），所以转过去
-/// 必须真的产出页图与 `manga.json`。反向（漫画 → 书）则要求原始 `.epub`/`.pdf` 仍在
-/// 书目录里；从 `.mokuro`/裸图片目录导入的漫画压根没有那个原始文件，只能明确说不支持
-/// ——而不是造一本假书糊弄过去。
+/// 必须真的产出页图与 `manga.json`。反向（漫画 → 书）则要求书目录里仍有可还原的
+/// **书侧源产物**；从 `.mokuro`/裸图片目录导入的漫画压根没有过那样的产物，只能明确
+/// 说不支持——而不是造一本假书糊弄过去。
 ///
 /// 本文件只做**判定**（纯函数，便于单测）；磁盘探测由调用方完成后把事实传进来，
 /// 与 `drop_classification.dart` 的 `isDirectory` / `isImageArchive` 注入同一范式。
@@ -41,16 +41,16 @@ enum BookConvertBlocker {
   /// 文字书（普通 EPUB）没有可用作页图的内容。转成漫画后阅读器只会打开一本空书。
   textOnlyBook,
 
-  /// 这本漫画是从 `.mokuro` / 裸图片目录导入的，书目录里没有可还原的原始
-  /// `.epub`/`.pdf`。只能保持漫画身份。
+  /// 这本漫画是从 `.mokuro` / 裸图片目录导入的，书目录里没有可还原的书侧源产物
+  /// （EPUB 解压树 / `document.pdf`）。只能保持漫画身份。
   noOriginalFile,
 
-  /// 记录在案的源文件在磁盘上找不到了（被手工删了 / 外部存储掉盘）。
+  /// 记录在案的源产物在磁盘上找不到了（被手工删了 / 外部存储掉盘）。
   sourceMissing,
 }
 
-/// 判定结果。[blocker] 为 null 即可转化，[sourcePath] 是重建要读的源文件
-/// （转漫画时 = 原 `.epub`/`.pdf`；转回书时 = 要指回去的那个原始文件）。
+/// 判定结果。[blocker] 为 null 即可转化，[sourcePath] 是重建要读的**源产物**
+/// （转漫画时 = 页图来源；转回书时 = 要重新解析的那份书侧产物）。
 class BookConvertVerdict {
   const BookConvertVerdict.supported(this.sourcePath) : blocker = null;
 
@@ -66,13 +66,16 @@ class BookConvertVerdict {
   bool get supported => blocker == null;
 }
 
-/// 书目录里那份原始文件的既有形态（调用方探测后传入）。
+/// 书目录里那份**源产物**的既有形态（调用方探测后传入）。
 ///
-/// 三种 format 的 `epubPath` 语义各不相同，故这里只描述**事实**、不描述格式：
-/// - EPUB 行：`epubPath` = 原 `.epub` 文件名（导入时拷进书目录，仍在）；
-/// - PDF 行：`epubPath` = `hibiki.pdf`（PDF 拷进书目录，仍在）；
-/// - 漫画行：`epubPath` = `manga.json`（**不是**原始文件；原始文件可能存在也可能
-///   压根没有过——`.mokuro`/裸目录导入的漫画就没有）。
+/// 三种 format 的源产物形态各不相同，故这里只描述**事实**、不描述格式。
+/// 各自的源产物是什么，由 `book_format_rebuild.dart` 的探测器负责认定：
+/// - EPUB 行：源产物 = **解压书目录本身**。本仓的 EPUB 从不在书目录里留一份独立
+///   `.epub`（导入即解压，BUG-088 已确认 `epubPath` 只是导入时的原始文件名、
+///   **永远解析不到真实文件**），所以「转成漫画要读的东西」只能是解压树；
+/// - PDF 行：源产物 = `extractDir/document.pdf`（导入时真的拷进了书目录，仍在）；
+/// - 漫画行：`epubPath` = `manga.json`（**不是**书侧源产物；书侧源产物可能仍在，
+///   也可能压根没有过——`.mokuro`/裸目录导入的漫画就没有）。
 class BookSourceProbe {
   const BookSourceProbe({
     required this.sourceExists,
@@ -80,21 +83,22 @@ class BookSourceProbe {
     this.recoverableOriginalPath,
   });
 
-  /// `extractDir/epubPath` 指向的文件当前是否存在。
+  /// 源产物当前是否存在（EPUB 行 = 解压树解析得通；PDF 行 = 那个文件在）。
   final bool sourceExists;
 
-  /// 该文件是不是「一包页图」（`MangaArchiveImporter.looksLikeImageArchive`，
-  /// 对 `.epub` 有专门的图片型判定分支）。PDF 恒可渲染成页图，不看这一位。
+  /// 源产物是不是「一叠页图」：EPUB 行走 `MangaArchiveImporter.isPureImageEpub`
+  /// （每章都只有图片）。PDF 恒可渲染成页图，不看这一位。
   final bool sourceIsImageArchive;
 
-  /// 漫画行专用：书目录里仍在的原始 `.epub`/`.pdf` 绝对路径（没有则 null）。
+  /// 漫画行专用：书目录里仍可还原的书侧源产物绝对路径——`document.pdf` 文件，
+  /// 或仍在的 EPUB 解压书目录（都没有则 null）。
   final String? recoverableOriginalPath;
 }
 
 /// 判定一本书能否转成漫画。纯函数。
 ///
-/// [format] / [sourceAbsolutePath] 来自 `EpubBooks` 行（后者 =
-/// `p.join(extractDir, epubPath)`），[probe] 是调用方的磁盘探测结果。
+/// [format] 来自 `EpubBooks` 行，[sourceAbsolutePath] 是该行的源产物绝对路径
+/// （见 [BookSourceProbe]），[probe] 是调用方的磁盘探测结果。
 BookConvertVerdict verdictToManga({
   required BookFormat format,
   required String sourceAbsolutePath,
@@ -121,8 +125,9 @@ BookConvertVerdict verdictToManga({
 
 /// 判定一本漫画能否转回书。纯函数。
 ///
-/// 「转回」是把 `epubPath` 指回书目录里**仍在的**原始 `.epub`/`.pdf`——那才是真书。
-/// 从 `.mokuro`/裸图片目录导入的漫画没有这样的原始文件，不支持（不造假书）。
+/// 「转回」是拿书目录里**仍在的**书侧源产物（`document.pdf` / EPUB 解压树）重新
+/// 算出章节与封面——那才是真书。从 `.mokuro`/裸图片目录导入的漫画没有这样的产物，
+/// 不支持（不造假书）。
 BookConvertVerdict verdictToBook({
   required BookFormat format,
   required BookSourceProbe probe,

--- a/hibiki/lib/src/media/manga/book_format_rebuild.dart
+++ b/hibiki/lib/src/media/manga/book_format_rebuild.dart
@@ -1,0 +1,444 @@
+/// 「书 ↔ 漫画」转化的**产物重建 + 落库**（`book_format_convert.dart` 只做判定）。
+///
+/// ## 一句话
+///
+/// 转化不是翻一个字段，是**让目标格式的磁盘产物存在，然后把行指过去**。身份
+/// （`EpubBooks.bookKey` = 主键 = 合集/标签/进度/统计/Profile 的 entryKey）与书目录
+/// （`extractDir`，三种格式共用同一个）全程不动，所以转化天然零悬挂引用。
+///
+/// ## 「源产物」是什么（这是本文件最容易踩错的一条）
+///
+/// 三种 format 的书侧源产物形态不同，且**都不是 `extractDir/epubPath`**：
+/// - `format='epub'`：源产物 = **解压书目录本身**。本仓的 EPUB 导入即解压、
+///   从不在书目录里留一份独立 `.epub`；`epubPath` 只是导入时的原始文件名，
+///   `p.join(extractDir, epubPath)` **永远指不到真实文件**（BUG-088 已就此坏过一次：
+///   同步的 `File(book.epubPath).existsSync()` 守卫因此静默跳过了每一次上传）。
+///   照着「原始 `.epub` 仍在书目录里」去探测，每一本 EPUB 都会被判成
+///   [BookConvertBlocker.sourceMissing]，转化对文字书/图片书**全线不可用**。
+/// - `format='pdf'`：源产物 = `extractDir/document.pdf`（导入时真的拷进去了）。
+/// - `format='manga'`：`epubPath` = `manga.json`，是漫画侧产物；书侧源产物要么是
+///   仍在的 `document.pdf`，要么是仍在的 EPUB 解压树，要么压根没有过
+///   （`.mokuro`/裸图片目录导入的漫画）。
+///
+/// ## 往返不掉东西
+///
+/// 转回书**不删**漫画产物（`manga.json` + `images/`），转成漫画时若 `manga.json`
+/// 仍然完好就直接复用。于是「书 → 漫画 → 书 → 漫画」的往返不会把整卷 OCR 结果
+/// 冲掉——OCR 是用户花小时级时间跑出来的，重建一次就没了才是真的丢数据。
+library;
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:pdfrx/pdfrx.dart';
+
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:hibiki/src/epub/epub_book.dart';
+import 'package:hibiki/src/epub/epub_importer.dart';
+import 'package:hibiki/src/epub/epub_parser.dart';
+import 'package:hibiki/src/media/manga/book_format_convert.dart';
+import 'package:hibiki/src/media/manga/import/manga_archive_importer.dart';
+import 'package:hibiki/src/media/manga/manga_importer.dart';
+import 'package:hibiki/src/media/manga/manga_storage.dart';
+import 'package:hibiki/src/media/manga/mokuro_payload.dart';
+import 'package:hibiki/src/pdf/pdf_engine.dart';
+import 'package:hibiki/src/pdf/pdf_importer.dart';
+import 'package:hibiki/src/sync/ttu_filename.dart';
+
+/// PDF 逐页导出页图时的目标宽度（px）。比封面的 600 大得多：页图是**要拿去 OCR 再
+/// 查词**的，600px 的扫描页在识别端就是一团糊。
+const double kPdfPageRasterWidth = 1600;
+
+/// 把 [pdfPath] 的每一页栅格化成 PNG 落进 [staging]，返回页数。
+///
+/// 注入点：PDFium 是平台原生库，`flutter test` 里拉不起来（native assets 不布置、
+/// worker isolate 直接 open 失败）。把这一处原生依赖收成可替换函数，转化的编排、
+/// 产物布局与落库就都能被真单测覆盖，而不是只能靠真机跑一遍。
+typedef PdfPageStager = Future<int> Function(
+  String pdfPath,
+  Directory staging,
+  void Function(int done, int total)? onProgress,
+);
+
+/// 读 [pdfPath] 的页数（「漫画 → PDF」转回时算 `chapterCount`）。同上，可注入。
+typedef PdfPageCounter = Future<int> Function(String pdfPath);
+
+/// 一本书的源产物探测结果：喂给 `book_format_convert.dart` 纯判定的**事实**。
+class BookConvertProbe {
+  const BookConvertProbe({required this.probe, required this.sourcePath});
+
+  /// 判定所需的磁盘事实。
+  final BookSourceProbe probe;
+
+  /// 转成漫画时要读的源产物绝对路径（EPUB 行 = 解压书目录；PDF 行 = 那个 PDF）。
+  final String sourcePath;
+}
+
+/// 转化引擎。静态入口 + 两个可注入的原生依赖。
+abstract final class BookFormatRebuild {
+  /// 单测注入点（见 [PdfPageStager]）。null = 用真实的 PDFium 实现。
+  @visibleForTesting
+  static PdfPageStager? debugPdfPageStager;
+
+  /// 单测注入点（见 [PdfPageCounter]）。null = 用真实的 PDFium 实现。
+  @visibleForTesting
+  static PdfPageCounter? debugPdfPageCounter;
+
+  /// 探测 [row] 的书目录，产出判定所需的事实。
+  ///
+  /// 纯 IO，不做任何判断——「能不能转」全部交给 `book_format_convert.dart` 的纯
+  /// 函数，这样判据只有一份、且能不碰磁盘地单测。
+  static BookConvertProbe probeSource(EpubBookRow row) {
+    final BookFormat format = BookFormat.parseOrEpub(row.format);
+    final String extractDir = row.extractDir;
+    switch (format) {
+      case BookFormat.pdf:
+        final String pdf = p.join(extractDir, row.epubPath);
+        return BookConvertProbe(
+          probe: BookSourceProbe(
+            sourceExists: File(pdf).existsSync(),
+            // PDF 恒可栅格化成页图，这一位对 PDF 无意义。
+            sourceIsImageArchive: false,
+          ),
+          sourcePath: pdf,
+        );
+      case BookFormat.epub:
+        final EpubBook? book = tryParseExtractedBook(extractDir);
+        return BookConvertProbe(
+          probe: BookSourceProbe(
+            sourceExists: book != null,
+            sourceIsImageArchive:
+                book != null && MangaArchiveImporter.isPureImageEpub(book),
+          ),
+          sourcePath: extractDir,
+        );
+      case BookFormat.manga:
+        return BookConvertProbe(
+          probe: BookSourceProbe(
+            sourceExists: File(p.join(extractDir, row.epubPath)).existsSync(),
+            sourceIsImageArchive: false,
+            recoverableOriginalPath: recoverableBookSource(extractDir),
+          ),
+          sourcePath: p.join(extractDir, row.epubPath),
+        );
+    }
+  }
+
+  /// 磁盘探测 + 纯判定的合成：这本书能不能转成 [target]？
+  ///
+  /// UI 在**点击时**调它（而不是在建菜单时）：探测要解析 OPF，放进 build 会把
+  /// 书架每次重绘都拖进磁盘 IO；而且被挡住时给一句具体原因，比灰掉一个按钮有用。
+  static BookConvertVerdict resolveVerdict({
+    required EpubBookRow row,
+    required BookFormatTarget target,
+  }) {
+    final BookConvertProbe probed = probeSource(row);
+    final BookFormat format = BookFormat.parseOrEpub(row.format);
+    switch (target) {
+      case BookFormatTarget.manga:
+        return verdictToManga(
+          format: format,
+          sourceAbsolutePath: probed.sourcePath,
+          probe: probed.probe,
+        );
+      case BookFormatTarget.book:
+        return verdictToBook(format: format, probe: probed.probe);
+    }
+  }
+
+  /// 执行转化：重建目标格式的磁盘产物，再在**单事务**里把行指过去。
+  ///
+  /// 判定不通过时抛 [BookConvertBlockedException]（调用方据 [BookConvertBlocker]
+  /// 给出具体说明），重建失败时抛 [MangaImportException] 或底层 IO 异常。
+  /// [onProgress] 回报 `(done, total)`：转漫画时是页，转回书时不回报（一次解析）。
+  ///
+  /// **失败不改行**：产物重建整段跑完才写库。半途失败只可能在书目录里留下多余的
+  /// 页图，行仍指向原格式，书照旧能打开——这比「行已改、产物没建完」安全得多。
+  static Future<void> convert({
+    required HibikiDatabase db,
+    required EpubBookRow row,
+    required BookFormatTarget target,
+    void Function(int done, int total)? onProgress,
+  }) async {
+    final BookConvertVerdict verdict = resolveVerdict(row: row, target: target);
+    final BookConvertBlocker? blocker = verdict.blocker;
+    if (blocker != null) throw BookConvertBlockedException(blocker);
+    final String source = verdict.sourcePath!;
+    switch (target) {
+      case BookFormatTarget.manga:
+        await _rebuildToManga(
+          db: db,
+          row: row,
+          sourcePath: source,
+          sourceFormat: BookFormat.parseOrEpub(row.format),
+          onProgress: onProgress,
+        );
+      case BookFormatTarget.book:
+        await _rebuildToBook(db: db, row: row, sourcePath: source);
+    }
+  }
+
+  // ── 转成漫画 ────────────────────────────────────────────────────────
+
+  static Future<void> _rebuildToManga({
+    required HibikiDatabase db,
+    required EpubBookRow row,
+    required String sourcePath,
+    required BookFormat sourceFormat,
+    void Function(int done, int total)? onProgress,
+  }) async {
+    final String bookDir = row.extractDir;
+    final ({int pageCount, String coverRel})? reused =
+        _reusableMangaArtifacts(bookDir);
+    final ({int pageCount, String coverRel}) artifacts = reused ??
+        await _buildMangaArtifacts(
+          bookDir: bookDir,
+          sourcePath: sourcePath,
+          sourceFormat: sourceFormat,
+          onProgress: onProgress,
+        );
+
+    await db.transaction(() async {
+      // 单条 UPDATE 本就原子；包事务是为了让「转化落库是一个不可分单位」这条不变量
+      // 在有人往里加第二条语句时**继续**成立，而不是那时才发现它从来没被保证过。
+      await db.updateEpubBookFormat(
+        row.bookKey,
+        format: BookFormat.manga,
+        epubPath: MangaStorage.kMangaJsonFileName,
+        chapterCount: artifacts.pageCount,
+        chaptersJson: '[]',
+        coverPath: artifacts.coverRel,
+        // 无条件清成 null = 跟随页图长宽比自动判定。复用旧产物时也照清：上一轮的
+        // 手动覆盖未必还配得上这一批页图。
+        mangaReadingMode: null,
+      );
+    });
+  }
+
+  /// 书目录里已有的漫画产物还能不能直接用：`manga.json` 解析得通、有页、且它引用的
+  /// 每一张页图都还在。能用就返回页数与封面相对路径，否则 null（要重建）。
+  static ({int pageCount, String coverRel})? _reusableMangaArtifacts(
+    String bookDir,
+  ) {
+    final File json = File(p.join(bookDir, MangaStorage.kMangaJsonFileName));
+    if (!json.existsSync()) return null;
+    final MokuroPayload payload;
+    try {
+      payload = parseMangaJson(json.readAsStringSync());
+    } catch (_) {
+      return null;
+    }
+    if (payload.images.isEmpty) return null;
+    for (final MokuroImage image in payload.images) {
+      if (!MangaStorage.destFile(bookDir, image.url).existsSync()) return null;
+    }
+    return (
+      pageCount: payload.images.length,
+      coverRel: payload.images.first.url,
+    );
+  }
+
+  static Future<({int pageCount, String coverRel})> _buildMangaArtifacts({
+    required String bookDir,
+    required String sourcePath,
+    required BookFormat sourceFormat,
+    void Function(int done, int total)? onProgress,
+  }) async {
+    final Directory staging =
+        await Directory.systemTemp.createTemp('hibiki_book_convert_');
+    try {
+      switch (sourceFormat) {
+        case BookFormat.pdf:
+          final PdfPageStager stager = debugPdfPageStager ?? _rasterizePdfPages;
+          await stager(sourcePath, staging, onProgress);
+        case BookFormat.epub:
+          // 解压树就是页图来源；沿 spine 顺序铺成 `page_%06d.<ext>`，与压缩包导入
+          // 走的是同一个函数（页序必须同口径）。
+          final EpubBook? book = tryParseExtractedBook(sourcePath);
+          if (book == null) {
+            throw const MangaImportException(
+              'Extracted EPUB could not be parsed',
+            );
+          }
+          await MangaArchiveImporter.copyEpubPages(book, staging);
+        case BookFormat.manga:
+          throw const MangaImportException('Already a manga');
+      }
+
+      final MokuroPayload payload =
+          await MangaImporter.payloadFromImageFolder(staging);
+      final List<String> destRels = MangaImporter.planMangaDestRels(
+        srcDir: staging,
+        payload: payload,
+      );
+      _refuseIfWouldClobberBookFiles(bookDir: bookDir, destRels: destRels);
+      // `return await`（不是 `return`）：在 async 函数里裸 `return future` 会让
+      // finally 在 future 完成**之前**就跑，暂存目录被删在拷图中途，第二页起
+      // PathNotFoundException。
+      return await MangaImporter.copyMangaArtifacts(
+        srcDir: staging,
+        payload: payload,
+        destRels: destRels,
+        bookDir: bookDir,
+        onProgress: onProgress,
+      );
+    } finally {
+      if (staging.existsSync()) {
+        await staging.delete(recursive: true);
+      }
+    }
+  }
+
+  /// 漫画产物落在 `<bookDir>/images/`，而 EPUB 的解压树也住在同一个书目录里。若某本
+  /// EPUB 恰好自带顶层 `images/`，铺页图就会**覆盖掉书自己的资源**——转回书时那本书
+  /// 少了几张图，且没有任何报错。
+  ///
+  /// 判据只有一条：目标路径已存在，而书目录里**没有** `manga.json`。没有 manga.json
+  /// 就说明 `images/` 不是我们铺的，那是书自己的东西，宁可硬失败也不覆盖。反过来
+  /// manga.json 在场时（重建 / 往返）覆盖的是我们自己的上一批产物，本来就该覆盖。
+  static void _refuseIfWouldClobberBookFiles({
+    required String bookDir,
+    required List<String> destRels,
+  }) {
+    if (File(p.join(bookDir, MangaStorage.kMangaJsonFileName)).existsSync()) {
+      return;
+    }
+    for (final String destRel in destRels) {
+      final File dest = MangaStorage.destFile(bookDir, destRel);
+      if (dest.existsSync()) {
+        throw MangaImportException(
+          'Refusing to overwrite an existing book file: $destRel',
+        );
+      }
+    }
+  }
+
+  static Future<int> _rasterizePdfPages(
+    String pdfPath,
+    Directory staging,
+    void Function(int done, int total)? onProgress,
+  ) async {
+    await PdfEngine.ensureInitialized();
+    final PdfDocument document = await PdfDocument.openFile(pdfPath);
+    try {
+      final int total = document.pages.length;
+      if (total <= 0) {
+        throw const MangaImportException('PDF has no pages');
+      }
+      for (int i = 0; i < total; i++) {
+        final Uint8List? png = await PdfEngine.renderPagePng(
+          document.pages[i],
+          targetWidth: kPdfPageRasterWidth,
+        );
+        if (png == null) {
+          throw MangaImportException('Could not rasterise PDF page ${i + 1}');
+        }
+        final String name = 'page_${i.toString().padLeft(6, '0')}.png';
+        await File(p.join(staging.path, name)).writeAsBytes(png, flush: true);
+        onProgress?.call(i + 1, total);
+      }
+      return total;
+    } finally {
+      await document.dispose();
+    }
+  }
+
+  // ── 转回书 ──────────────────────────────────────────────────────────
+
+  static Future<void> _rebuildToBook({
+    required HibikiDatabase db,
+    required EpubBookRow row,
+    required String sourcePath,
+  }) async {
+    final bool isPdf = FileSystemEntity.isFileSync(sourcePath);
+    final BookFormat target = isPdf ? BookFormat.pdf : BookFormat.epub;
+
+    final int chapterCount;
+    final String chaptersJson;
+    final String? coverPath;
+    final String epubPath;
+    if (isPdf) {
+      final PdfPageCounter counter = debugPdfPageCounter ?? _countPdfPages;
+      chapterCount = await counter(sourcePath);
+      // PDF 无章字数，进度按页（与 PdfImporter 落库口径一致）。
+      chaptersJson = '[]';
+      epubPath = p.basename(sourcePath);
+      final File cover =
+          File(p.join(row.extractDir, PdfImporter.kCoverFileName));
+      coverPath = cover.existsSync() ? PdfImporter.kCoverFileName : null;
+    } else {
+      final ({
+        int chapterCount,
+        String chaptersJson,
+        String? coverPath
+      }) parsed = await EpubImporter.reparseExtractedBook(sourcePath);
+      chapterCount = parsed.chapterCount;
+      chaptersJson = parsed.chaptersJson;
+      coverPath = parsed.coverPath;
+      // 转成漫画时 `epubPath` 被写成 `manga.json`，原始文件名无处可存也无处可用
+      // （EPUB 行的 epubPath 从不解析成真实文件）。这里合成的是同步侧
+      // (`sync_manager._exportContentIfMissing`) 打包上传时用的同一个名字，
+      // 全仓只有这一种「这本书的 epub 文件名」口径。
+      epubPath = '${sanitizeTtuFilename(row.title)}.epub';
+    }
+
+    await db.transaction(() async {
+      await db.updateEpubBookFormat(
+        row.bookKey,
+        format: target,
+        epubPath: epubPath,
+        chapterCount: chapterCount,
+        chaptersJson: chaptersJson,
+        // null = 保持原封面不变。转回书时若算不出封面（EPUB 无 cover-image、
+        // PDF 的 cover.png 被删），保留漫画首页当封面也比把书架变成空白格好。
+        coverPath: coverPath,
+        // 表约定：非漫画行恒 null。
+        mangaReadingMode: null,
+      );
+    });
+  }
+
+  static Future<int> _countPdfPages(String pdfPath) async {
+    await PdfEngine.ensureInitialized();
+    final PdfDocument document = await PdfDocument.openFile(pdfPath);
+    try {
+      return document.pages.length;
+    } finally {
+      await document.dispose();
+    }
+  }
+
+  // ── 共享探测原语 ────────────────────────────────────────────────────
+
+  /// 解析一个**可能是** EPUB 解压树的目录；不是（缺 `META-INF/container.xml`、
+  /// OPF 坏了、spine 空）就返回 null。
+  static EpubBook? tryParseExtractedBook(String extractDir) {
+    if (!Directory(extractDir).existsSync()) return null;
+    try {
+      return EpubParser.parseFromExtracted(extractDir);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// 书目录里还能不能还原出**书侧**源产物：优先 `document.pdf`（PDF 导入拷进来的
+  /// 那份），否则看解压树是不是仍解析得通。都没有 → null（`.mokuro`/裸图片目录
+  /// 导入的漫画就是这一类，转回书对它没有意义）。
+  static String? recoverableBookSource(String extractDir) {
+    final String pdf = p.join(extractDir, PdfImporter.kPdfFileName);
+    if (File(pdf).existsSync()) return pdf;
+    if (tryParseExtractedBook(extractDir) != null) return extractDir;
+    return null;
+  }
+}
+
+/// 判定不通过时抛出，带上具体的 [blocker] 供调用方翻译成一句给用户看的原因。
+class BookConvertBlockedException implements Exception {
+  const BookConvertBlockedException(this.blocker);
+
+  final BookConvertBlocker blocker;
+
+  @override
+  String toString() => 'BookConvertBlockedException: $blocker';
+}

--- a/hibiki/lib/src/media/manga/book_format_rebuild.dart
+++ b/hibiki/lib/src/media/manga/book_format_rebuild.dart
@@ -351,6 +351,9 @@ abstract final class BookFormatRebuild {
     required EpubBookRow row,
     required String sourcePath,
   }) async {
+    // [recoverableBookSource] 只会回两种东西：`document.pdf` 这个**文件**，或仍解析
+    // 得通的 EPUB **解压目录**。所以「是不是文件」就是「转回 PDF 还是转回 EPUB」，
+    // 不需要再看扩展名（扩展名判据会在无扩展名的目录上悄悄退化）。
     final bool isPdf = FileSystemEntity.isFileSync(sourcePath);
     final BookFormat target = isPdf ? BookFormat.pdf : BookFormat.epub;
 

--- a/hibiki/lib/src/media/manga/import/manga_archive_importer.dart
+++ b/hibiki/lib/src/media/manga/import/manga_archive_importer.dart
@@ -32,6 +32,22 @@ const List<String> _kYomitanBankPrefixes = <String>[
 const String _kYomitanIndexEntry = 'index.json';
 
 abstract final class MangaArchiveImporter {
+  /// [book]（已解压的 EPUB）是不是「纯图漫画」：每个 `linear && !isNav` 章节都只有
+  /// 图片、且图片扩展名都在 [kMangaImageExtensions] 内。
+  ///
+  /// 公开是因为「一本已在库的 EPUB 能不能转成漫画」问的是同一个问题，而那本书在
+  /// 盘上**只有解压树、没有独立 `.epub`**（BUG-088），走不了 [looksLikeImageArchive]
+  /// 的压缩包入口。判据只能有一份，否则「导入时算漫画、转化时不算」这种自相矛盾
+  /// 迟早出现。
+  static bool isPureImageEpub(EpubBook book) => _isPureImageEpub(book);
+
+  /// 按 spine 顺序把 [book] 的页图铺进 [staging]（`page_%06d.<ext>` 自然序）。
+  ///
+  /// 与 [isPureImageEpub] 同理公开：导入压缩包与「就地把书转成漫画」必须产出同一
+  /// 批页、同一种排序，否则同一本书从两条路进来页序不同。
+  static Future<void> copyEpubPages(EpubBook book, Directory staging) =>
+      _copyEpubPages(book, staging);
+
   static bool looksLikeImageArchive(String archivePath) {
     final String extension = p.extension(archivePath).toLowerCase();
     if (extension == '.epub') {

--- a/hibiki/lib/src/media/manga/manga_importer.dart
+++ b/hibiki/lib/src/media/manga/manga_importer.dart
@@ -79,8 +79,30 @@ class MangaImporter {
     void Function(int done, int total)? onProgress,
   }) async {
     final Directory root = Directory(imageDirPath);
+    final MokuroPayload payload = await payloadFromImageFolder(root);
+    final String proposedTitle = title?.trim().isNotEmpty == true
+        ? title!.trim()
+        : (p.basename(root.path).isEmpty ? 'manga' : p.basename(root.path));
+    return _copyAndInsert(
+      db: db,
+      srcDir: root,
+      payload: payload,
+      proposedTitle: proposedTitle,
+      policy: policy,
+      onProgress: onProgress,
+    );
+  }
+
+  /// 「一个装着页图的文件夹」→ [MokuroPayload] 的**唯一**枚举/解码口径：自然序枚举
+  /// [root] 下的页图，逐张解码取真实宽高（`bakeOrientation` 后，EXIF 旋转过的页不会
+  /// 把宽高读反），OCR 框留空。
+  ///
+  /// 抽成公开函数是因为「导入一本新漫画」与「把已在库的书就地转成漫画」
+  /// （`book_format_rebuild.dart`）用的是同一批页图事实：两处各写一遍枚举/解码，
+  /// 排序或宽高口径一旦漂开，转化产出的 `manga.json` 就与导入产出的不是同一种东西。
+  static Future<MokuroPayload> payloadFromImageFolder(Directory root) async {
     if (!root.existsSync()) {
-      throw MangaImportException('Manga image folder not found: $imageDirPath');
+      throw MangaImportException('Manga image folder not found: ${root.path}');
     }
     final List<MangaOcrPageFile> files = enumerateMangaPages(root);
     if (files.isEmpty) {
@@ -103,17 +125,70 @@ class MangaImporter {
         ),
       );
     }
-    final String proposedTitle = title?.trim().isNotEmpty == true
-        ? title!.trim()
-        : (p.basename(root.path).isEmpty ? 'manga' : p.basename(root.path));
-    return _copyAndInsert(
-      db: db,
-      srcDir: root,
-      payload: MokuroPayload(images: pages),
-      proposedTitle: proposedTitle,
-      policy: policy,
-      onProgress: onProgress,
-    );
+    return MokuroPayload(images: pages);
+  }
+
+  /// 第一遍（纯校验，零副作用）：为 [payload] 的每页规划书目录内的 destRel
+  /// （`images/...`，sanitize + 保留子目录 + 去重 + 防穿越），并校验源图在 [srcDir]
+  /// 里确实存在。返回值与 `payload.images` 一一对应、同序。
+  ///
+  /// 与 [copyMangaArtifacts] 拆成两步不是为了好看：调用方（导入器）必须在**建书目录
+  /// 与问用户同名冲突之前**跑完校验，否则一次注定失败的导入会先弹一个同名弹窗、
+  /// 再留下一个空书目录。
+  static List<String> planMangaDestRels({
+    required Directory srcDir,
+    required MokuroPayload payload,
+  }) {
+    final List<String> destRels = <String>[];
+    final Set<String> usedDestRels = <String>{};
+    for (final MokuroImage page in payload.images) {
+      // sanitizeRelSegments 对含 `..` 的 img_path 抛 MangaImportException（防穿越红线）。
+      final List<String> segments = MangaStorage.sanitizeRelSegments(page.url);
+      destRels.add(MangaStorage.uniqueDestRel(segments, usedDestRels));
+      final File src = _sourceFile(srcDir.path, page.url);
+      if (!src.existsSync()) {
+        throw MangaImportException('Missing manga page image: ${page.url}');
+      }
+    }
+    return destRels;
+  }
+
+  /// 第二遍（落盘）：把页图从 [srcDir] 拷进 `<bookDir>/images/<destRel>`，再写
+  /// `<bookDir>/manga.json`（`url` 已改写成 destRel）。返回页数与封面相对路径
+  /// （= 第一页页图，书架封面解析器 `p.join(extractDir, coverPath)` 直接可用）。
+  ///
+  /// **不碰数据库**：导入走 `insertEpubBook`、转化走 `updateEpubBookFormat`，
+  /// 但两者产出的磁盘产物必须逐字节同构，故这一段只有一份实现。
+  static Future<({int pageCount, String coverRel})> copyMangaArtifacts({
+    required Directory srcDir,
+    required MokuroPayload payload,
+    required List<String> destRels,
+    required String bookDir,
+    void Function(int done, int total)? onProgress,
+  }) async {
+    // 逐页 await 让主 isolate 有机会喂进度不卡 UI。
+    final int total = payload.images.length;
+    final List<MokuroImage> rewritten = <MokuroImage>[];
+    for (int i = 0; i < total; i++) {
+      final MokuroImage page = payload.images[i];
+      final String destRel = destRels[i];
+      final File src = _sourceFile(srcDir.path, page.url);
+      final File dest = MangaStorage.destFile(bookDir, destRel);
+      dest.parent.createSync(recursive: true);
+      await src.copy(dest.path);
+      rewritten.add(
+        MokuroImage(url: destRel, size: page.size, blocks: page.blocks),
+      );
+      onProgress?.call(i + 1, total);
+    }
+
+    // 写序列化页/框结构（url 已改写为 destRel；mangaPayloadToJson 保留 lines_coords）。
+    final Map<String, Object?> serialized =
+        mangaPayloadToJson(MokuroPayload(images: rewritten, ocr: payload.ocr));
+    await File(p.join(bookDir, MangaStorage.kMangaJsonFileName))
+        .writeAsString(jsonEncode(serialized), flush: true);
+
+    return (pageCount: total, coverRel: destRels.first);
   }
 
   /// 从 [mokuroPath] 指向的 `.mokuro` 文件导入一本漫画，返回新建的 `bookKey`。
@@ -235,17 +310,8 @@ class MangaImporter {
   }) async {
     // 第一遍：规划每页 destRel（sanitize + 保留子目录 + 去重）并校验源图存在 + 防路径穿越。
     // 全部在任何落盘/落库之前完成——校验失败零副作用，无需回滚。
-    final List<String> destRels = <String>[];
-    final Set<String> usedDestRels = <String>{};
-    for (final MokuroImage page in payload.images) {
-      // sanitizeRelSegments 对含 `..` 的 img_path 抛 MangaImportException（防穿越红线）。
-      final List<String> segments = MangaStorage.sanitizeRelSegments(page.url);
-      destRels.add(MangaStorage.uniqueDestRel(segments, usedDestRels));
-      final File src = _sourceFile(srcDir.path, page.url);
-      if (!src.existsSync()) {
-        throw MangaImportException('Missing manga page image: ${page.url}');
-      }
-    }
+    final List<String> destRels =
+        planMangaDestRels(srcDir: srcDir, payload: payload);
 
     final List<EpubBookRow> existingBooks = await db.getAllEpubBooks();
     final String storedTitle = await resolveDuplicateTitle(
@@ -258,31 +324,18 @@ class MangaImporter {
 
     String? insertedKey;
     try {
-      // 第二遍：逐页拷贝到 `<bookDir>/images/<destRel>`（保留子目录结构），并构造改写后的
-      // payload（url = destRel）供写 manga.json。逐页 await 让主 isolate 有机会喂进度不卡 UI。
-      final int total = payload.images.length;
-      final List<MokuroImage> rewritten = <MokuroImage>[];
-      for (int i = 0; i < total; i++) {
-        final MokuroImage page = payload.images[i];
-        final String destRel = destRels[i];
-        final File src = _sourceFile(srcDir.path, page.url);
-        final File dest = MangaStorage.destFile(bookDir, destRel);
-        dest.parent.createSync(recursive: true);
-        await src.copy(dest.path);
-        rewritten.add(
-          MokuroImage(url: destRel, size: page.size, blocks: page.blocks),
-        );
-        onProgress?.call(i + 1, total);
-      }
-
-      // 封面 = 第一页页图的相对路径（书架封面解析器 `p.join(extractDir, coverPath)`）。
-      final String coverRel = destRels.first;
-
-      // 写序列化页/框结构（url 已改写为 destRel；mangaPayloadToJson 保留 lines_coords）。
-      final Map<String, Object?> serialized = mangaPayloadToJson(
-          MokuroPayload(images: rewritten, ocr: payload.ocr));
-      await File(p.join(bookDir, MangaStorage.kMangaJsonFileName))
-          .writeAsString(jsonEncode(serialized), flush: true);
+      // 第二遍：拷图 + 写 manga.json。封面 = 第一页页图的相对路径（书架封面解析器
+      // `p.join(extractDir, coverPath)`）。
+      final ({int pageCount, String coverRel}) artifacts =
+          await copyMangaArtifacts(
+        srcDir: srcDir,
+        payload: payload,
+        destRels: destRels,
+        bookDir: bookDir,
+        onProgress: onProgress,
+      );
+      final int total = artifacts.pageCount;
+      final String coverRel = artifacts.coverRel;
 
       final int importedAtMs = DateTime.now().millisecondsSinceEpoch;
       insertedKey = await db.insertEpubBook(

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -20,6 +20,8 @@ import 'package:hibiki/src/media/drag_drop/drop_decision.dart';
 import 'package:hibiki/src/media/display_title.dart';
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
+import 'package:hibiki/src/media/manga/book_format_convert.dart';
+import 'package:hibiki/src/media/manga/book_format_rebuild.dart';
 import 'package:hibiki/src/media/manga/manga_import_dialog.dart';
 import 'package:hibiki/src/media/manga/manga_module.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_download_queue.dart';
@@ -2119,6 +2121,24 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
         icon: Icons.code_outlined,
         onPressed: () => _openCssEditor(bookKey),
       ),
+      // 「书 ↔ 漫画」转化。放这张卡菜单里，因为漫画库与书架本就是同一个页面
+      // （`manga_library_page` 只是 `mangaOnly: true` 的壳）、同一张卡、同一份
+      // 菜单——转化恰好是「这本书用哪个阅读器打开」的开关，与「标记已读完」
+      // 「换封面」同一层级。方向由当前卡自己的源标识决定，不额外读库：
+      // `mediaSourceIdentifier` 就是 `EpubBooks.format` 派生出来的
+      // （`ReaderHibikiSource.mediaSourceKeyFor`），与书架的漫画/书分流同一判据。
+      DialogListAction(
+        label: _isMangaItem(item)
+            ? t.book_convert_to_book_action
+            : t.book_convert_to_manga_action,
+        icon: _isMangaItem(item)
+            ? Icons.menu_book_outlined
+            : Icons.auto_stories_outlined,
+        onPressed: () => _convertBookFormat(
+          bookKey,
+          _isMangaItem(item) ? BookFormatTarget.book : BookFormatTarget.manga,
+        ),
+      ),
       // TODO-291 阶段2：书架长按「悬浮字幕」= 启动该书的后台听书会话（无正在播则用该书
       // 启动 + 拉起悬浮窗），不再只翻 bool。该书已是活动会话则改为「停止后台听书」。
       if (Platform.isAndroid || Platform.isWindows)
@@ -2308,6 +2328,70 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     HibikiToast.show(
       msg: wasCompleted ? t.book_marked_uncompleted : t.book_marked_completed,
     );
+  }
+
+  /// 这张卡是不是漫画。判据与书架的漫画/书分流
+  /// （[filterShelfEntriesByMangaSplit]）逐字相同：`mediaSourceIdentifier` 由
+  /// `EpubBooks.format` 经 `ReaderHibikiSource.mediaSourceKeyFor` 派生，卡上已有，
+  /// 不必为了画一行菜单再去读一次库。
+  bool _isMangaItem(MediaItem item) =>
+      item.mediaSourceIdentifier == MangaHibikiSource.kUniqueKey;
+
+  /// 单卡「书 ↔ 漫画」转化：重建目标格式的磁盘产物，再把 `EpubBooks` 行指过去。
+  ///
+  /// `bookKey` 与 `mediaIdentifier` 全程不变，所以合集/标签/进度/统计/Profile 一条
+  /// 不断，书架与首页「继续」上仍然是同一条目——转化不会把一本书变成两本。
+  ///
+  /// 判定放在**点击后**：探测要解析 OPF/磁盘，塞进菜单 build 会让书架每次重绘都吃
+  /// 一遍 IO；而且转不了的时候给一句具体原因，远比灰掉一个按钮有用（用户报过
+  /// 「拖进去一点反应都没有」）。
+  Future<void> _convertBookFormat(
+    String bookKey,
+    BookFormatTarget target,
+  ) async {
+    Navigator.pop(context);
+    final EpubBookRow? row = await appModel.database.getEpubBook(bookKey);
+    if (row == null || !mounted) return;
+    final BookConvertVerdict verdict =
+        BookFormatRebuild.resolveVerdict(row: row, target: target);
+    final BookConvertBlocker? blocker = verdict.blocker;
+    if (blocker != null) {
+      HibikiToast.show(msg: _bookConvertBlockerMessage(blocker));
+      return;
+    }
+    HibikiToast.show(msg: t.book_convert_running);
+    try {
+      await BookFormatRebuild.convert(
+        db: appModel.database,
+        row: row,
+        target: target,
+      );
+    } catch (e, stack) {
+      ErrorLogService.instance.log('ReaderHistory.convertBookFormat', e, stack);
+      if (mounted) HibikiToast.show(msg: t.book_convert_failed);
+      return;
+    }
+    if (!mounted) return;
+    // 转化只改列、不改 bookKey 集合，而 `hibikiBooksProvider` 的响应源按 bookKey
+    // 集合去重 —— 不显式 invalidate，书架会一直画着旧格式的卡。
+    ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
+    _rebuild(() {});
+    HibikiToast.show(msg: t.book_convert_done);
+  }
+
+  /// 把「为什么不能转」翻译成一句给用户看的话。每一条都说清具体原因，不是笼统
+  /// 一句「不支持」。
+  String _bookConvertBlockerMessage(BookConvertBlocker blocker) {
+    switch (blocker) {
+      case BookConvertBlocker.alreadyTarget:
+        return t.book_convert_blocked_already;
+      case BookConvertBlocker.textOnlyBook:
+        return t.book_convert_blocked_text_only;
+      case BookConvertBlocker.noOriginalFile:
+        return t.book_convert_blocked_no_original;
+      case BookConvertBlocker.sourceMissing:
+        return t.book_convert_blocked_source_missing;
+    }
   }
 
   String? _parseBookKey(String mediaIdentifier) =>

--- a/hibiki/lib/src/pdf/pdf_engine.dart
+++ b/hibiki/lib/src/pdf/pdf_engine.dart
@@ -1,6 +1,10 @@
 import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:pdfrx/pdfrx.dart';
+
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
 
 /// PDF 阅读器（Phase 1）的 pdfrx/PDFium 引擎初始化单一入口。
 ///
@@ -46,6 +50,62 @@ class PdfEngine {
         Pdfrx.pdfiumModulePath = candidate;
         return;
       }
+    }
+  }
+
+  /// 把 [page] 栅格化成 PNG 字节（等比缩到宽 [targetWidth]，白底）。失败返回 null。
+  ///
+  /// 导入器取封面与「PDF → 漫画」逐页导出页图用的是同一段 PDFium 调用，差别只有
+  /// 目标宽度，故收在引擎入口一处：两边各写一份，背景色/缩放/dispose 时机随时能漂。
+  static Future<Uint8List?> renderPagePng(
+    PdfPage page, {
+    required double targetWidth,
+  }) async {
+    try {
+      final double scale = page.width > 0 ? targetWidth / page.width : 1.0;
+      final PdfImage? rendered = await page.render(
+        fullWidth: page.width * scale,
+        fullHeight: page.height * scale,
+        backgroundColor: 0xFFFFFFFF,
+      );
+      if (rendered == null) return null;
+      try {
+        return await bgraToPng(
+            rendered.pixels, rendered.width, rendered.height);
+      } finally {
+        rendered.dispose();
+      }
+    } catch (e, stack) {
+      ErrorLogService.instance.log('PdfEngine.renderPagePng', e, stack);
+      return null;
+    }
+  }
+
+  /// 把 PDFium 输出的 BGRA8888 位图编码成 PNG 字节（纯 CPU codec，无 GPU 回读，
+  /// 离屏可靠）。
+  static Future<Uint8List?> bgraToPng(
+    Uint8List bgra,
+    int width,
+    int height,
+  ) async {
+    final ui.ImmutableBuffer buffer =
+        await ui.ImmutableBuffer.fromUint8List(bgra);
+    final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
+      buffer,
+      width: width,
+      height: height,
+      pixelFormat: ui.PixelFormat.bgra8888,
+    );
+    final ui.Codec codec = await descriptor.instantiateCodec();
+    final ui.FrameInfo frame = await codec.getNextFrame();
+    final ui.Image image = frame.image;
+    try {
+      final ByteData? png =
+          await image.toByteData(format: ui.ImageByteFormat.png);
+      return png?.buffer.asUint8List();
+    } finally {
+      image.dispose();
+      codec.dispose();
     }
   }
 }

--- a/hibiki/lib/src/pdf/pdf_importer.dart
+++ b/hibiki/lib/src/pdf/pdf_importer.dart
@@ -1,6 +1,4 @@
 import 'dart:io';
-import 'dart:typed_data';
-import 'dart:ui' as ui;
 
 import 'package:drift/drift.dart';
 import 'package:path/path.dart' as p;
@@ -146,58 +144,9 @@ class PdfImporter {
 
   /// 把 PDF 首页栅格化成封面 PNG 字节（失败返回 null，不阻断导入——书仍可无封面入架）。
   /// 目标宽度约 600px 以保证书架封面清晰；高度按页面纵横比等比。
-  static Future<Uint8List?> _renderCoverPng(PdfPage page) async {
-    try {
-      const double targetWidth = 600;
-      final double scale = page.width > 0 ? targetWidth / page.width : 1.0;
-      final double fullWidth = page.width * scale;
-      final double fullHeight = page.height * scale;
-      final PdfImage? rendered = await page.render(
-        fullWidth: fullWidth,
-        fullHeight: fullHeight,
-        backgroundColor: 0xFFFFFFFF,
-      );
-      if (rendered == null) return null;
-      try {
-        return await _bgraToPng(
-          rendered.pixels,
-          rendered.width,
-          rendered.height,
-        );
-      } finally {
-        rendered.dispose();
-      }
-    } catch (e, stack) {
-      ErrorLogService.instance.log('PdfImporter.renderCover', e, stack);
-      return null;
-    }
-  }
-
-  /// 把 PDFium 输出的 BGRA8888 位图编码成 PNG 字节（纯 CPU codec，无 GPU 回读，
-  /// 与 Phase 0 spike 同路径，离屏可靠）。
-  static Future<Uint8List?> _bgraToPng(
-    Uint8List bgra,
-    int width,
-    int height,
-  ) async {
-    final ui.ImmutableBuffer buffer =
-        await ui.ImmutableBuffer.fromUint8List(bgra);
-    final ui.ImageDescriptor descriptor = ui.ImageDescriptor.raw(
-      buffer,
-      width: width,
-      height: height,
-      pixelFormat: ui.PixelFormat.bgra8888,
-    );
-    final ui.Codec codec = await descriptor.instantiateCodec();
-    final ui.FrameInfo frame = await codec.getNextFrame();
-    final ui.Image image = frame.image;
-    try {
-      final ByteData? png =
-          await image.toByteData(format: ui.ImageByteFormat.png);
-      return png?.buffer.asUint8List();
-    } finally {
-      image.dispose();
-      codec.dispose();
-    }
-  }
+  ///
+  /// 栅格化与 PNG 编码本体在 [PdfEngine]：「PDF → 漫画」转化要逐页导出同款页图，
+  /// 两处各写一份的话背景色/缩放/dispose 时机随时能漂。
+  static Future<Uint8List?> _renderCoverPng(PdfPage page) =>
+      PdfEngine.renderPagePng(page, targetWidth: 600);
 }

--- a/hibiki/test/media/manga/book_format_rebuild_test.dart
+++ b/hibiki/test/media/manga/book_format_rebuild_test.dart
@@ -1,0 +1,565 @@
+/// 「书 ↔ 漫画」转化的**产物重建 + 落库**端到端（真磁盘 + 真 SQLite）。
+///
+/// `book_format_convert_test.dart` 只覆盖纯判定，`epub_book_format_convert_test.dart`
+/// 只覆盖单条 DAO。本文件把两端接起来跑真流程：解压树/PDF → 页图 + `manga.json`
+/// → 单事务改行 → 再转回来。四条验收口径（身份逐字节不变、书架恰好一条、进度与
+/// 最后阅读时刻不丢、跳回原文进正确阅读器）都在这里落地。
+///
+/// PDFium 是平台原生库、`flutter test` 里拉不起来，故 PDF 两处原生依赖走
+/// [BookFormatRebuild.debugPdfPageStager] / [BookFormatRebuild.debugPdfPageCounter]
+/// 注入——被测的是转化的**编排、产物布局与落库**，不是 PDFium 本身。
+library;
+
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:drift/drift.dart' show Value;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/media.dart';
+import 'package:hibiki/src/media/manga/book_format_convert.dart';
+import 'package:hibiki/src/media/manga/book_format_rebuild.dart';
+import 'package:hibiki/src/media/manga/manga_storage.dart';
+import 'package:hibiki/src/media/manga/mokuro_payload.dart';
+import 'package:hibiki/src/pdf/pdf_importer.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const String bookKey = 'Scanned Volume 01';
+  late Directory root;
+  late String bookDir;
+  late HibikiDatabase db;
+
+  setUp(() {
+    root = Directory.systemTemp.createTempSync('book_convert_');
+    bookDir = p.join(root.path, bookKey);
+    Directory(bookDir).createSync(recursive: true);
+    db = HibikiDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await db.close();
+    BookFormatRebuild.debugPdfPageStager = null;
+    BookFormatRebuild.debugPdfPageCounter = null;
+    if (root.existsSync()) root.deleteSync(recursive: true);
+  });
+
+  Future<void> seedRow({
+    required BookFormat format,
+    required String epubPath,
+    required int chapterCount,
+    required String chaptersJson,
+    String? coverPath,
+  }) async {
+    await db.insertEpubBook(
+      EpubBooksCompanion.insert(
+        bookKey: bookKey,
+        title: bookKey,
+        epubPath: epubPath,
+        extractDir: bookDir,
+        chapterCount: chapterCount,
+        chaptersJson: chaptersJson,
+        importedAt: 1700000000000,
+        format: Value<String>(format.dbValue),
+        coverPath:
+            coverPath == null ? const Value.absent() : Value<String>(coverPath),
+        author: const Value<String>('作者'),
+      ),
+    );
+  }
+
+  Future<EpubBookRow> row() async => (await db.getEpubBook(bookKey))!;
+
+  // ── 图片型 EPUB → 漫画 ───────────────────────────────────────────────
+
+  test('图片型 EPUB 转成漫画：页图 + manga.json 落进书目录，行一次写穿', () async {
+    writeExtractedImageEpub(bookDir);
+    await seedRow(
+      format: BookFormat.epub,
+      epubPath: 'scan.epub',
+      chapterCount: 2,
+      chaptersJson: '[{"id":"page1","characters":0}]',
+      coverPath: 'OEBPS/images/1.png',
+    );
+
+    await BookFormatRebuild.convert(
+      db: db,
+      row: await row(),
+      target: BookFormatTarget.manga,
+    );
+
+    // 磁盘产物：漫画阅读器硬要求 extractDir/manga.json + 同目录 images/。
+    final File json = File(p.join(bookDir, MangaStorage.kMangaJsonFileName));
+    expect(json.existsSync(), isTrue);
+    final MokuroPayload payload = parseMangaJson(json.readAsStringSync());
+    expect(payload.images, hasLength(2));
+    for (final MokuroImage image in payload.images) {
+      expect(MangaStorage.destFile(bookDir, image.url).existsSync(), isTrue);
+    }
+    // spine 顺序：fixture 的 spine 是 page2 → page1，故第一页是 30px 宽那张。
+    expect(payload.images.first.size.width, 30);
+
+    final EpubBookRow after = await row();
+    expect(after.format, BookFormat.manga.dbValue);
+    expect(after.epubPath, MangaStorage.kMangaJsonFileName);
+    expect(after.chapterCount, 2, reason: '漫画的 chapterCount 是页数');
+    expect(after.chaptersJson, '[]');
+    expect(after.coverPath, payload.images.first.url);
+    expect(after.mangaReadingMode, isNull, reason: 'null = 跟随页图比例自动判定');
+    expect(after.extractDir, bookDir, reason: '三种格式共用同一个书目录');
+    expect(after.author, '作者');
+  });
+
+  test('文字 EPUB 被挡住并给出具体原因，磁盘与行都不动', () async {
+    writeExtractedImageEpub(bookDir, firstPageBody: '<p>これは本文です。</p>');
+    await seedRow(
+      format: BookFormat.epub,
+      epubPath: 'novel.epub',
+      chapterCount: 2,
+      chaptersJson: '[{"id":"page1","characters":9}]',
+    );
+
+    expect(
+      BookFormatRebuild.resolveVerdict(
+        row: await row(),
+        target: BookFormatTarget.manga,
+      ).blocker,
+      BookConvertBlocker.textOnlyBook,
+    );
+    await expectLater(
+      BookFormatRebuild.convert(
+        db: db,
+        row: await row(),
+        target: BookFormatTarget.manga,
+      ),
+      throwsA(isA<BookConvertBlockedException>()),
+    );
+    expect(
+      File(p.join(bookDir, MangaStorage.kMangaJsonFileName)).existsSync(),
+      isFalse,
+    );
+    expect((await row()).format, BookFormat.epub.dbValue);
+  });
+
+  test('EPUB 解压树没了 → sourceMissing（不是当成文字书含糊拒绝）', () async {
+    await seedRow(
+      format: BookFormat.epub,
+      epubPath: 'gone.epub',
+      chapterCount: 1,
+      chaptersJson: '[]',
+    );
+    expect(
+      BookFormatRebuild.resolveVerdict(
+        row: await row(),
+        target: BookFormatTarget.manga,
+      ).blocker,
+      BookConvertBlocker.sourceMissing,
+    );
+  });
+
+  // ── 验收口径 ────────────────────────────────────────────────────────
+
+  test(
+      '验收①②③④：双向转化后身份逐字节不变、书架恰好一条、进度与最后阅读时刻不丢、'
+      '阅读器路由跟着 format 走', () async {
+    writeExtractedImageEpub(bookDir);
+    await seedRow(
+      format: BookFormat.epub,
+      epubPath: 'scan.epub',
+      chapterCount: 2,
+      chaptersJson: '[{"id":"page1","href":"text/1.xhtml","characters":0}]',
+      coverPath: 'OEBPS/images/1.png',
+    );
+    // 「最后阅读时刻」的真值载体：ReaderPositions.updatedAt（书架「最近阅读」按它排）。
+    await db.upsertReaderPosition(
+      ReaderPositionsCompanion.insert(
+        bookKey: bookKey,
+        sectionIndex: 3,
+        normCharOffset: 4200,
+        charOffset: const Value<int>(777),
+        updatedAt: 1712345678901,
+      ),
+    );
+    final int collectionId = await db.createMediaCollection('扫描本');
+    await db.addToCollection(collectionId, MediaKind.epub, bookKey);
+
+    final String identifierBefore =
+        ReaderHibikiSource.mediaIdentifierFor(bookKey);
+
+    await BookFormatRebuild.convert(
+      db: db,
+      row: await row(),
+      target: BookFormatTarget.manga,
+    );
+    final EpubBookRow asManga = await row();
+
+    // ① 身份逐字节不变。
+    expect(asManga.bookKey, bookKey);
+    expect(ReaderHibikiSource.mediaIdentifierFor(asManga.bookKey),
+        identifierBefore);
+    // ② 书架恰好一条（书架列的就是 EpubBooks 行）。
+    expect(await db.getAllEpubBooks(), hasLength(1));
+    // ③ 进度与最后阅读时刻不丢。
+    final ReaderPositionRow posAsManga = (await db.getReaderPosition(bookKey))!;
+    expect(posAsManga.sectionIndex, 3);
+    expect(posAsManga.normCharOffset, 4200);
+    expect(posAsManga.charOffset, 777);
+    expect(posAsManga.updatedAt, 1712345678901);
+    // ④ 跳回原文进正确阅读器。
+    expect(
+      ReaderHibikiSource.mediaSourceKeyFor(
+          BookFormat.parseOrEpub(asManga.format)),
+      MangaHibikiSource.kUniqueKey,
+    );
+    // 合集成员没断。
+    expect(
+        (await db.getCollectionItems(collectionId)).single.entryKey, bookKey);
+
+    // ── 转回书 ──
+    await BookFormatRebuild.convert(
+      db: db,
+      row: asManga,
+      target: BookFormatTarget.book,
+    );
+    final EpubBookRow asBook = await row();
+
+    expect(asBook.bookKey, bookKey, reason: '①往返后主键仍逐字节不变');
+    expect(ReaderHibikiSource.mediaIdentifierFor(asBook.bookKey),
+        identifierBefore);
+    expect(await db.getAllEpubBooks(), hasLength(1), reason: '②往返后仍恰好一条');
+    final ReaderPositionRow posAsBook = (await db.getReaderPosition(bookKey))!;
+    expect(posAsBook.sectionIndex, 3);
+    expect(posAsBook.charOffset, 777);
+    expect(posAsBook.updatedAt, 1712345678901, reason: '③最后阅读时刻不丢');
+    expect(
+      ReaderHibikiSource.mediaSourceKeyFor(
+          BookFormat.parseOrEpub(asBook.format)),
+      ReaderHibikiSource.instance.uniqueKey,
+      reason: '④转回书后必须回到 EPUB 阅读器',
+    );
+    expect(
+        (await db.getCollectionItems(collectionId)).single.entryKey, bookKey);
+
+    // 转回书是**重建**：chaptersJson 由重新解析解压树得到，不是留着漫画的 '[]'。
+    expect(asBook.format, BookFormat.epub.dbValue);
+    expect(asBook.chaptersJson, isNot('[]'));
+    expect(jsonDecode(asBook.chaptersJson), hasLength(2));
+    expect(asBook.chapterCount, 2);
+    expect(asBook.mangaReadingMode, isNull, reason: '表约定：非漫画行恒 null');
+  });
+
+  test('往返不冲掉整卷 OCR：manga.json 仍完好时直接复用，不重建页图', () async {
+    writeExtractedImageEpub(bookDir);
+    await seedRow(
+      format: BookFormat.epub,
+      epubPath: 'scan.epub',
+      chapterCount: 2,
+      chaptersJson: '[{"id":"page1","characters":0}]',
+    );
+    await BookFormatRebuild.convert(
+      db: db,
+      row: await row(),
+      target: BookFormatTarget.manga,
+    );
+
+    // 模拟整卷 OCR 跑完：往 manga.json 里塞识别结果。
+    final File json = File(p.join(bookDir, MangaStorage.kMangaJsonFileName));
+    final Map<String, Object?> decoded =
+        jsonDecode(json.readAsStringSync()) as Map<String, Object?>;
+    final List<Object?> pages = decoded['pages']! as List<Object?>;
+    (pages.first! as Map<String, Object?>)['blocks'] = <Object?>[
+      <String, Object?>{
+        'box': <double>[1, 2, 3, 4],
+        'vertical': true,
+        'font_size': 12.0,
+        'z_index': 0,
+        'lines': <String>['小時間跑出來的識別結果'],
+      },
+    ];
+    json.writeAsStringSync(jsonEncode(decoded));
+
+    await BookFormatRebuild.convert(
+      db: db,
+      row: await row(),
+      target: BookFormatTarget.book,
+    );
+    await BookFormatRebuild.convert(
+      db: db,
+      row: await row(),
+      target: BookFormatTarget.manga,
+    );
+
+    final MokuroPayload after = parseMangaJson(json.readAsStringSync());
+    expect(after.images.first.blocks, hasLength(1),
+        reason: '转回书从不删漫画产物、转回漫画复用完好的 manga.json——'
+            '否则一次往返就把用户跑了几小时的整卷 OCR 冲干净了');
+    expect(after.images.first.blocks.single.lines.single, '小時間跑出來的識別結果');
+  });
+
+  test('绝不覆盖书自己的文件：书目录已有同名页图且无 manga.json 时硬失败', () async {
+    writeExtractedImageEpub(bookDir);
+    // 这本 EPUB 恰好自带顶层 images/page_000000.png（页图落点与它撞名）。
+    final File owned =
+        File(p.join(bookDir, MangaStorage.kImagesDirName, 'page_000000.png'));
+    owned.parent.createSync(recursive: true);
+    owned.writeAsBytesSync(const <int>[1, 2, 3]);
+    await seedRow(
+      format: BookFormat.epub,
+      epubPath: 'scan.epub',
+      chapterCount: 2,
+      chaptersJson: '[]',
+    );
+
+    await expectLater(
+      BookFormatRebuild.convert(
+        db: db,
+        row: await row(),
+        target: BookFormatTarget.manga,
+      ),
+      throwsA(isA<MangaImportException>()),
+    );
+    expect(owned.readAsBytesSync(), <int>[1, 2, 3],
+        reason: '宁可硬失败也不静默覆盖书自己的资源');
+    expect((await row()).format, BookFormat.epub.dbValue);
+  });
+
+  // ── PDF ↔ 漫画（原生依赖注入） ──────────────────────────────────────
+
+  test('PDF 转成漫画：逐页栅格化的页图落进书目录，行按页数写穿', () async {
+    File(p.join(bookDir, PdfImporter.kPdfFileName))
+        .writeAsBytesSync(const <int>[0x25, 0x50, 0x44, 0x46]);
+    File(p.join(bookDir, PdfImporter.kCoverFileName))
+        .writeAsBytesSync(pngBytes(20, 40));
+    await seedRow(
+      format: BookFormat.pdf,
+      epubPath: PdfImporter.kPdfFileName,
+      chapterCount: 3,
+      chaptersJson: '[]',
+      coverPath: PdfImporter.kCoverFileName,
+    );
+    BookFormatRebuild.debugPdfPageStager = (
+      String pdfPath,
+      Directory staging,
+      void Function(int, int)? onProgress,
+    ) async {
+      for (int i = 0; i < 3; i++) {
+        File(p.join(staging.path, 'page_${i.toString().padLeft(6, '0')}.png'))
+            .writeAsBytesSync(pngBytes(50 + i, 100));
+        onProgress?.call(i + 1, 3);
+      }
+      return 3;
+    };
+
+    final List<int> reported = <int>[];
+    await BookFormatRebuild.convert(
+      db: db,
+      row: await row(),
+      target: BookFormatTarget.manga,
+      onProgress: (int done, int total) => reported.add(done),
+    );
+
+    final EpubBookRow after = await row();
+    expect(after.format, BookFormat.manga.dbValue);
+    expect(after.chapterCount, 3);
+    expect(after.coverPath, 'images/page_000000.png');
+    expect(reported, isNotEmpty, reason: '逐页进度要真的回报，否则长任务像卡死');
+    final MokuroPayload payload = parseMangaJson(
+      File(p.join(bookDir, MangaStorage.kMangaJsonFileName)).readAsStringSync(),
+    );
+    expect(payload.images.map((MokuroImage e) => e.size.width).toList(),
+        <double>[50, 51, 52]);
+  });
+
+  test('漫画转回 PDF：指回 document.pdf、页数由 PDF 现算、封面回到 cover.png', () async {
+    File(p.join(bookDir, PdfImporter.kPdfFileName))
+        .writeAsBytesSync(const <int>[0x25, 0x50, 0x44, 0x46]);
+    File(p.join(bookDir, PdfImporter.kCoverFileName))
+        .writeAsBytesSync(pngBytes(20, 40));
+    writeMangaArtifacts(bookDir, pageCount: 2);
+    await seedRow(
+      format: BookFormat.manga,
+      epubPath: MangaStorage.kMangaJsonFileName,
+      chapterCount: 2,
+      chaptersJson: '[]',
+      coverPath: 'images/page_000000.png',
+    );
+    BookFormatRebuild.debugPdfPageCounter = (String pdfPath) async => 42;
+
+    await BookFormatRebuild.convert(
+      db: db,
+      row: await row(),
+      target: BookFormatTarget.book,
+    );
+
+    final EpubBookRow after = await row();
+    expect(after.format, BookFormat.pdf.dbValue);
+    expect(after.epubPath, PdfImporter.kPdfFileName);
+    expect(after.chapterCount, 42);
+    expect(after.chaptersJson, '[]');
+    expect(after.coverPath, PdfImporter.kCoverFileName);
+    expect(after.mangaReadingMode, isNull);
+    expect(
+      ReaderHibikiSource.mediaSourceKeyFor(
+          BookFormat.parseOrEpub(after.format)),
+      ReaderPdfSource.kUniqueKey,
+      reason: '转回 PDF 后必须进 PDF 阅读器，不是 EPUB 阅读器',
+    );
+  });
+
+  test('从图片导入的漫画转不回书：没有书侧源产物就明说，不造假书', () async {
+    writeMangaArtifacts(bookDir, pageCount: 2);
+    await seedRow(
+      format: BookFormat.manga,
+      epubPath: MangaStorage.kMangaJsonFileName,
+      chapterCount: 2,
+      chaptersJson: '[]',
+      coverPath: 'images/page_000000.png',
+    );
+    expect(
+      BookFormatRebuild.resolveVerdict(
+        row: await row(),
+        target: BookFormatTarget.book,
+      ).blocker,
+      BookConvertBlocker.noOriginalFile,
+    );
+    await expectLater(
+      BookFormatRebuild.convert(
+        db: db,
+        row: await row(),
+        target: BookFormatTarget.book,
+      ),
+      throwsA(isA<BookConvertBlockedException>()),
+    );
+    expect((await row()).format, BookFormat.manga.dbValue);
+  });
+
+  test('已经是目标格式 → alreadyTarget（两个方向都挡）', () async {
+    writeMangaArtifacts(bookDir, pageCount: 1);
+    await seedRow(
+      format: BookFormat.manga,
+      epubPath: MangaStorage.kMangaJsonFileName,
+      chapterCount: 1,
+      chaptersJson: '[]',
+    );
+    expect(
+      BookFormatRebuild.resolveVerdict(
+        row: await row(),
+        target: BookFormatTarget.manga,
+      ).blocker,
+      BookConvertBlocker.alreadyTarget,
+    );
+  });
+
+  // ── 源产物探测：本文件真正的地雷区 ──────────────────────────────────
+
+  test('EPUB 行的源产物是解压书目录，不是 extractDir/epubPath（那永远不存在）', () async {
+    writeExtractedImageEpub(bookDir);
+    await seedRow(
+      format: BookFormat.epub,
+      epubPath: 'scan.epub',
+      chapterCount: 2,
+      chaptersJson: '[]',
+    );
+    final BookConvertProbe probed = BookFormatRebuild.probeSource(await row());
+    expect(File(p.join(bookDir, 'scan.epub')).existsSync(), isFalse,
+        reason: '本仓的 EPUB 导入即解压，书目录里从来没有一份独立 .epub（BUG-088）');
+    expect(probed.sourcePath, bookDir);
+    expect(probed.probe.sourceExists, isTrue,
+        reason: '照 extractDir/epubPath 探测的话这里会是 false，'
+            '于是每一本 EPUB 都被判成 sourceMissing、转化全线不可用');
+    expect(probed.probe.sourceIsImageArchive, isTrue);
+  });
+
+  test('漫画行的可还原书侧产物：优先 document.pdf，否则仍解析得通的解压树', () async {
+    writeMangaArtifacts(bookDir, pageCount: 1);
+    expect(BookFormatRebuild.recoverableBookSource(bookDir), isNull);
+
+    writeExtractedImageEpub(bookDir);
+    expect(BookFormatRebuild.recoverableBookSource(bookDir), bookDir);
+
+    File(p.join(bookDir, PdfImporter.kPdfFileName)).writeAsBytesSync(<int>[1]);
+    expect(BookFormatRebuild.recoverableBookSource(bookDir),
+        p.join(bookDir, PdfImporter.kPdfFileName));
+  });
+}
+
+/// 一张 [width]x[height] 的合法 PNG（页图解码要拿真实宽高）。
+Uint8List pngBytes(int width, int height) => Uint8List.fromList(
+      img.encodePng(img.Image(width: width, height: height)),
+    );
+
+/// 直接往 [dir] 铺一棵**已解压**的纯图 EPUB 树（container.xml + OPF + 两个只含
+/// `<img>` 的 spine 页 + 两张图）。spine 顺序是 page2 → page1，好让「按 spine 铺页」
+/// 与「按文件名排序」区分得开。
+void writeExtractedImageEpub(
+  String dir, {
+  String firstPageBody = '<img src="../images/1.png"/>',
+}) {
+  void write(String relative, List<int> bytes) {
+    final File file = File(p.join(dir, p.joinAll(relative.split('/'))));
+    file.parent.createSync(recursive: true);
+    file.writeAsBytesSync(bytes);
+  }
+
+  write('META-INF/container.xml', utf8.encode('''
+<?xml version="1.0"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles><rootfile full-path="OEBPS/content.opf"/></rootfiles>
+</container>'''));
+  write('OEBPS/content.opf', utf8.encode('''
+<?xml version="1.0"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Scanned Volume 01</dc:title>
+  </metadata>
+  <manifest>
+    <item id="page1" href="text/1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="page2" href="text/2.xhtml" media-type="application/xhtml+xml"/>
+    <item id="image1" href="images/1.png" media-type="image/png"/>
+    <item id="image2" href="images/2.png" media-type="image/png"/>
+  </manifest>
+  <spine>
+    <itemref idref="page2"/>
+    <itemref idref="page1"/>
+  </spine>
+</package>'''));
+  write(
+    'OEBPS/text/1.xhtml',
+    utf8.encode(
+      '<html xmlns="http://www.w3.org/1999/xhtml"><body>$firstPageBody</body>'
+      '</html>',
+    ),
+  );
+  write(
+    'OEBPS/text/2.xhtml',
+    utf8.encode('<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+        '<img src="../images/2.png"/></body></html>'),
+  );
+  write('OEBPS/images/1.png', pngBytes(20, 40));
+  write('OEBPS/images/2.png', pngBytes(30, 40));
+}
+
+/// 往 [dir] 铺一份最小可用的漫画产物（`manga.json` + `images/`），模拟
+/// `.mokuro`/裸图片目录导入的漫画。
+void writeMangaArtifacts(String dir, {required int pageCount}) {
+  final List<Map<String, Object?>> pages = <Map<String, Object?>>[];
+  for (int i = 0; i < pageCount; i++) {
+    final String rel = 'images/page_${i.toString().padLeft(6, '0')}.png';
+    final File file = File(p.join(dir, p.joinAll(rel.split('/'))));
+    file.parent.createSync(recursive: true);
+    file.writeAsBytesSync(pngBytes(60, 90));
+    pages.add(<String, Object?>{
+      'url': rel,
+      'width': 60,
+      'height': 90,
+      'blocks': <Object?>[],
+    });
+  }
+  File(p.join(dir, MangaStorage.kMangaJsonFileName))
+      .writeAsStringSync(jsonEncode(<String, Object?>{'pages': pages}));
+}

--- a/hibiki/test/media/sources/book_history_split_guard_test.dart
+++ b/hibiki/test/media/sources/book_history_split_guard_test.dart
@@ -1,0 +1,114 @@
+/// 守卫：三个书族媒体源必须保持 `implementsHistory: false`。
+///
+/// ## 守什么，为什么这条不变量比一次修复值钱
+///
+/// 「书 ↔ 漫画」转化（`book_format_rebuild.dart`）改的是 `EpubBooks.format`，
+/// **不改** `bookKey`。书架、合集、标签、进度、统计、Profile 全都按 `bookKey` 关联，
+/// 所以转化天然零悬挂引用、书架前后恰好一条。
+///
+/// 但 `MediaItem.uniqueKey` 不是 `mediaIdentifier`，而是
+/// `'$mediaSourceIdentifier/$mediaIdentifier'`（`media_item.dart`），
+/// 而 `mediaSourceIdentifier` 由 `ReaderHibikiSource.mediaSourceKeyFor(format)`
+/// **按当前 format 现算** —— 转化必然把它从 `reader_ttu` 换成 `reader_manga`
+/// （或反过来）。`MediaItems.uniqueKey` 又是 UNIQUE 列。于是：
+///
+/// > 只要有任何一个书族源把 `implementsHistory` 置成 true，
+/// > `AppModel.openMedia` 就会在开书时 `addMediaItem`，
+/// > 同一本书转化前后会插进**两条** `media_items` 行，
+/// > 最近打开流里一本书裂成两条。
+///
+/// 今天这件事**不会发生**：三个书族源全是 false，且全仓没有任何
+/// `implementsHistory: true`（书架的「最近阅读」根本不走 `media_items`，
+/// 它从 `ReaderPositions` 现算——见 `MediaSource.implementsHistory` 的文档）。
+///
+/// 所以这条守卫不是在修一个 bug，而是**用不变量替代修复机械**：与其等有人把它翻成
+/// true、再写几百行去合并被劈成两半的历史，不如在这里钉死「别翻」。翻了这条测试
+/// 立刻红，理由就写在断言的 reason 里，读到的人不需要重新推导一遍。
+///
+/// ## 变异实测打在哪
+///
+/// 把三个源里任意一个的 `implementsHistory: false` 改成 `true` ⇒ 第一条 test 必红。
+/// 新增第四个 `ReaderMediaSource` 子类而不登记 ⇒ 第三条 test 必红。
+library;
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/media.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../../helpers/source_guard.dart';
+
+void main() {
+  test('三个书族源恒 implementsHistory:false（翻了就把一本书的历史劈成两条）', () {
+    // 行为断言，不是语料断言：语料能被等价改写绕过，构造出来的实例不能。
+    const String why = '书族源必须保持 implementsHistory:false。'
+        'MediaItem.uniqueKey = 源标识 + "/" + 媒体标识，'
+        '而源标识由 EpubBooks.format 现算——「书 ↔ 漫画」转化'
+        '必然改它。置 true 会让 openMedia 在转化前后各插一条 media_items，'
+        '同一本书在最近打开流里裂成两条，且 UNIQUE 列救不了（键本来就不同）。'
+        '书的「最近阅读」现算自 ReaderPositions，从不需要 media_items。';
+    expect(ReaderHibikiSource.instance.implementsHistory, isFalse, reason: why);
+    expect(ReaderPdfSource.instance.implementsHistory, isFalse, reason: why);
+    expect(MangaHibikiSource.instance.implementsHistory, isFalse, reason: why);
+  });
+
+  test('分裂机制是真的：同一本书三种 format 派生出三个互异的 MediaItem.uniqueKey', () {
+    // 这条把上面那段理由从注释变成可执行的事实。它**恒真**（三个源键本就互异，
+    // 见 manga_routing_guard_test），存在的意义是：谁想把上面那条 false 改成
+    // true 之前，先在这里看见「改了会发生什么」。
+    const String bookKey = 'Scanned Volume 01';
+    final String mediaIdentifier =
+        ReaderHibikiSource.mediaIdentifierFor(bookKey);
+    final Set<String> uniqueKeys = <String>{
+      for (final BookFormat format in BookFormat.values)
+        MediaItem(
+          mediaIdentifier: mediaIdentifier,
+          title: bookKey,
+          mediaTypeIdentifier: ReaderMediaType.instance.uniqueKey,
+          mediaSourceIdentifier: ReaderHibikiSource.mediaSourceKeyFor(format),
+          position: 0,
+          duration: 1,
+          canDelete: false,
+          canEdit: true,
+        ).uniqueKey,
+    };
+    expect(uniqueKeys, hasLength(BookFormat.values.length),
+        reason: 'mediaIdentifier 三种 format 完全相同（转化不改 bookKey），'
+            'uniqueKey 却互异——差的正是 mediaSourceIdentifier。'
+            '这就是 implementsHistory 一旦为 true 就会分裂历史的机制。');
+    // 反面：身份本身没变，变的只有源标识。
+    expect(mediaIdentifier, ReaderHibikiSource.mediaIdentifierFor(bookKey),
+        reason: 'mediaIdentifier 只由 bookKey 决定，与 format 无关——'
+            '转化不改 bookKey ⇒ 它逐字节不变');
+  });
+
+  test('书族源就这三个——新增第四个必须来这里登记并守住 false', () {
+    // 正向枚举：扫 lib/ 找出全部 ReaderMediaSource 子类，与上面断言过的三个比对。
+    // 反过来「用已断言的集合去取反」会让新增的源天生落在集合外、零覆盖。
+    final RegExp declaration =
+        RegExp(r'class\s+(\w+)\s+extends\s+ReaderMediaSource');
+    final Set<String> found = <String>{};
+    for (final FileSystemEntity entity
+        in Directory('lib').listSync(recursive: true)) {
+      if (entity is! File || !entity.path.endsWith('.dart')) continue;
+      // 走共享掩码：注释里写「EPUB / 漫画 / PDF 都 extends ReaderMediaSource」这类
+      // 说明是资产，不该被当成一个真的声明（`media_item_edit_dialog_page.dart`
+      // 里就有一句）。掩码与原文等长，正则窗口语义不变。
+      for (final RegExpMatch match
+          in declaration.allMatches(maskComments(entity.readAsStringSync()))) {
+        found.add(match.group(1)!);
+      }
+    }
+    expect(
+      found,
+      <String>{'ReaderHibikiSource', 'ReaderPdfSource', 'MangaHibikiSource'},
+      reason: '发现了未登记的书族媒体源：${found.toList()..sort()}。'
+          '书族源共用同一个 EpubBooks 身份、且会被「书 ↔ 漫画」转化在它们之间'
+          '切换，所以每一个都必须 implementsHistory:false 并在本文件第一条断言里'
+          '登记。删了源也要来改这里。',
+    );
+    // 扫描本身失效（目录改名 / listSync 拿不到东西）必须红，不能静默变成摆设。
+    expect(found, isNotEmpty, reason: '一个 ReaderMediaSource 子类都没扫到——扫描逻辑失效了');
+  });
+}


### PR DESCRIPTION
## 做了什么

把已有的「书 ↔ 漫画」**判定层**（`book_format_convert.dart`，此前在 `lib/` 里一个生产调用方都没有）接上真正的产物重建与 UI 入口，并用一条不变量守卫替代「事后修复被劈开的历史」。

### 1. 产物重建（新增 `hibiki/lib/src/media/manga/book_format_rebuild.dart`）

`book_format_convert.dart:21` 注释一直引用的这个文件此前**不存在**。现在它是：

- **书 → 漫画**：图片型 EPUB 按 spine 铺页图 / PDF 逐页栅格化 → 拷进 `<extractDir>/images/` + 写 `manga.json` → **单事务**改写 `format`/`epubPath`/`chapterCount`/`chaptersJson`/`coverPath`/`mangaReadingMode`。
- **漫画 → 书**：重新解析书目录里仍在的书侧源产物（`document.pdf` / EPUB 解压树）算回章节、字数与封面。
- `bookKey`（= 主键 = 合集/标签/进度/统计/Profile 的 entryKey）与 `extractDir` 全程不动 ⇒ 零悬挂引用。
- **失败不改行**：重建整段跑完才写库。
- **往返不掉 OCR**：转回书不删漫画产物；转成漫画时 `manga.json` 仍完好就直接复用，`书→漫画→书→漫画` 不会冲掉用户跑了几小时的整卷 OCR。
- **绝不覆盖书自己的文件**：页图落点已存在且书目录里没有 `manga.json` ⇒ 硬失败（那是 EPUB 自己的资源）。

### 2. 修掉判定层的一条错误前提（这条是阻断性的）

`book_format_convert.dart` 原注释写「EPUB 行：`epubPath` = 原 `.epub` 文件名（导入时拷进书目录，仍在）」。**事实相反**：本仓 EPUB 导入即解压，书目录里从来没有独立 `.epub`，`p.join(extractDir, epubPath)` 永远指不到真实文件（`sync_manager.dart:706-709` 的 BUG-088 注释已就此坏过一次）。照旧注释探测，**每一本 EPUB 都会被判成 `sourceMissing`**、转化对文字书/图片书全线不可用。现在源产物认定改为：EPUB = 解压书目录本身，PDF = `extractDir/document.pdf`。

### 3. UI 入口

挂在书架/漫画库**共用**的卡片长按（桌面右键）菜单 `_epubExtraActions`。理由：`manga_library_page` 只是 `ReaderHibikiHistoryPage(mangaOnly: true)` 的壳，两边同一张卡、同一份菜单；转化恰好是「这本书用哪个阅读器打开」的开关，与「标记已读完」「换封面」同一层级。方向由卡自己的 `mediaSourceIdentifier` 决定（不额外读库）；被挡住时给一句具体原因而非灰按钮。

### 4. 守卫：三个书族源恒 `implementsHistory: false`

`hibiki/test/media/sources/book_history_split_guard_test.dart`。`MediaItem.uniqueKey = 源标识/媒体标识`，而源标识由 `EpubBooks.format` 现算 —— 转化必然改它。一旦有书族源置 `true`，`openMedia` 就会在转化前后各插一条 `media_items`，同一本书在最近打开流里裂成两条。今天三个源全是 `false`、全仓零 `implementsHistory: true`，所以这条守卫不是修 bug，是**用不变量替代修复机械**：与其等有人翻成 true 再写几百行去合并被劈开的历史，不如钉死「别翻」。第三条断言正向枚举 `lib/` 下全部 `ReaderMediaSource` 子类，新增第四个不登记即红。

### 5. 顺带去重（无行为变化）

- PDF 页栅格化 + BGRA→PNG 收进 `PdfEngine.renderPagePng` / `bgraToPng`（`PdfImporter` 改为委托）。
- 漫画产物生成的两遍式内核从 `MangaImporter._copyAndInsert` 抽成公开 `payloadFromImageFolder` / `planMangaDestRels` / `copyMangaArtifacts`，导入与转化共用一份（页序、宽高、destRel 口径不许漂）。
- `chaptersJson` 序列化抽成 `EpubImporter.buildChaptersJson`（含 `charCaliber`）。

## 明确不做

不加 `format` 的 CHECK 约束、不动 schema、不做数据迁移、不碰 `media_items`。加 CHECK 要重建 `epub_books` 核心书表，是本轮唯一能毁用户库的动作，而写入侧已被 `BookFormat` 枚举在编译期封死（理由已成文于 `book_format.dart:14-21`）。也不做 PR-B（转化后重建 Bangumi 映射）。

## 验收口径 → 测试

| 口径 | 测试 |
|---|---|
| 双向转化后 `bookKey` / `mediaIdentifier` 逐字节不变 | `book_format_rebuild_test.dart` 「验收①②③④」 |
| 书架前后恰好一条 | 同上（`getAllEpubBooks()` 恒 `hasLength(1)`）+ 守卫测试（`media_items` 侧） |
| 阅读位置与最后阅读时刻不丢 | 同上（`ReaderPositions` 四列逐字节比对） |
| 跳回原文进正确阅读器 | 同上（`mediaSourceKeyFor`）+ 既有 `manga_routing_guard_test` / `reader_pdf_routing_guard_test` 继续绿 |

## 变异实测

8 次，逐条确认被守的行为反向改坏后**该条**转红（详见 commit 讨论）。其中 M6（把 EPUB 源产物改回 `extractDir/epubPath` 这条错误前提）一次打红 6 条用例。

## 门禁

- `flutter analyze`（含 test）：`No issues found!`
- `test/media/manga` + `test/media/sources` + 两个 routing guard + `test/database/epub_book_format_convert_test.dart` + `test/epub` + `test/ocr` + `test/i18n`：**748 passed**
- `test/pages` + `test/reader` + `test/tools`：**4093 passed**
- `md3_design_system_static_test` + `source_guard_adoption_test`：**64 passed**

未 bump `+build`（整合线统一 bump）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
