### PR TITLE
fix(build): 补丁漂移不再无声——零上下文补丁换成带上下文 (TODO-2636 / BUG-1428)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,12 @@
 *.cmd  text eol=crlf
 *.ps1  text eol=crlf
 
+# 补丁里的空上下文行就是「一个空格」，那是 unified diff 的行首标记，不是可清理
+# 的行尾空白。剥掉它补丁就打不上（BUG-1428）。关掉 whitespace 检查，免得
+# `git diff --check` 每次都报一片假阳、并诱使后人真去「修」它。
+*.patch -whitespace
+*.diff  -whitespace
+
 # 二进制文件不做行尾转换
 *.png   binary
 *.jpg   binary

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1326 条。点号进各自文件。
+> 共 1327 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1428](bugs/BUG-1428-zero-context-patch-drift-silent.md) | ✅ | ✅ | 零上下文补丁漂移无声：git apply --unidiff-zero 对上游漂移 exit 0 后盲插 |
 | [BUG-1425](bugs/BUG-1425-md3-guard-allowlist-drift.md) | ✅ | ✅ | MD3 守卫豁免与实际命中脱节：四处裸 Material chrome 静默放行 + fontSizeFactor 绕过判据 + 过期豁免 |
 | [BUG-1419](bugs/BUG-1419-webview2-sticky-mouse-buttons-block-lookup.md) | ✅ | ✅ | Windows 阅读器右键后左键点击只出蓝色选区、查词失效（WebView2 鼠标键状态粘滞） |
 | [BUG-1418](bugs/BUG-1418-manga-reader-ocr-paired-host-missing.md) | ✅ | ✅ | 阅读器整卷 OCR 看不到「配对主机」选项：openBookOcr 漏传 remoteRunner |

--- a/docs/bugs/BUG-1428-zero-context-patch-drift-silent.md
+++ b/docs/bugs/BUG-1428-zero-context-patch-drift-silent.md
@@ -1,0 +1,83 @@
+## BUG-1428 · 零上下文补丁漂移无声：git apply --unidiff-zero 对上游漂移 exit 0 后盲插
+- **报告**：2026-08-02（用户：TODO-2636，来自 PR#709 写守卫时的实测发现）
+- **真实性**：✅ 真 bug（两个独立根因）
+  - 根因 A：`tool/mihon/build_desktop_runtime.sh:45` / `tool/mihon/build_desktop_runtime.ps1:82`
+    用 `git apply --unidiff-zero` 应用零上下文补丁 `third_party/m_extension_server/server-build.gradle.patch`。
+    零上下文补丁里**纯插入的 hunk**（`@@ -69,0 +70 @@`）没有任何可校验内容，
+    upstream_src 漂移后 `git apply --check --unidiff-zero` 仍 exit 0，真 apply 时
+    按行号盲插到错误位置。构建脚本对补丁漂移完全无声。
+  - 根因 B：`hibiki/test/build/mihon_vendored_server_guard_test.dart:171`（PR#709 原始版本）
+    那条 `git apply --check` 守卫**从落地起就是空转的**。它 `cd` 进 `upstream_src` 跑
+    `git apply --check ../server-build.gradle.patch`；`git apply` 在仓库内把补丁路径
+    解释成**相对仓库根**，`gradle/...` / `server/...` 全部落在 cwd 之外，git 打印 7 行
+    `Skipped patch` 然后 exit 0 —— 把 upstream_src 改坏它照样绿。
+
+### 复现（实测）
+零上下文补丁的盲区分两种形态，`-` 删除行那种其实**挡得住**（`git apply` 即使带
+`--unidiff-zero` 也校验 `-` 行内容），真正无声的是**纯插入 hunk**：
+
+```
+# 拷一份 pristine upstream_src 到仓库外临时目录，模拟上游在 JGroupFilter 前面加了 3 行
+$ git -C /tmp/mut apply --check --unidiff-zero old-zerocontext.patch
+exit=0                                     # ← 盲区：漂移了但 --check 说没事
+$ git -C /tmp/mut apply --unidiff-zero old-zerocontext.patch
+$ sed -n '65,74p' .../model/DataBody.kt
+data class JGroupFilter(
+    val name: String?,
+    val stateString: String? = null,        # ← 盲插到了错误位置
+    val type: String?,
+    val stateBoolean: Boolean?,
+    val stateInt: Int?,
+)
+```
+Kotlin data class 的字段顺序是**位置语义**（主构造器实参顺序、`componentN` 解构），
+编译照过、行为已错。
+
+根因 B 的复现更直接：
+```
+$ cd third_party/m_extension_server/upstream_src
+$ git apply --check --verbose ../server-build.gradle.patch
+Skipped patch 'gradle/libs.versions.toml'.
+Skipped patch 'server/build.gradle.kts'.
+... （7 行全部 Skipped）
+exit=0
+```
+
+### 修复
+把零上下文补丁换成带默认 3 行上下文的补丁，应用处一律不带 `--unidiff-zero`；
+守卫改从**仓库根** + `--directory=` 调用，并加反空转断言。
+
+- **[x] ① 已修复** — `third_party/m_extension_server/server-build.gradle.patch`
+  用 `git diff`（默认 3 行上下文）重新生成；`tool/mihon/build_desktop_runtime.sh` /
+  `.ps1` 去掉 `--unidiff-zero`；`third_party/m_extension_server/UPSTREAM` 记下
+  「必须带上下文、重生成不许用 `-U0`」。
+  **等价性证据**：新旧补丁应用到同一棵 pristine upstream_src 上（同一 `core.autocrlf`
+  设置），435 个文件逐 sha256 比对 **BYTE-IDENTICAL**；补丁作用不变，只变得更严。
+  （附带发现：旧补丁两条 `index` 后像哈希 `adc2815` / `b0e4c9e` 是错的，实际产出是
+  `6b07a8a` / `89c2d7a` —— 旧补丁生成后被手改过。新补丁的 index 行是真的。）
+- **[x] ② 已加自动化测试** — `hibiki/test/build/mihon_vendored_server_guard_test.dart`
+  （18 个用例，本条新增/改造 4 条）：
+  1. `server-build.gradle.patch 仍能干净地打在 vendored 树上` —— 改成仓库根 +
+     `--directory=` + `--verbose`，并断言日志里**没有** `Skipped patch`、
+     `Checking patch` 条数等于补丁里的文件数（反空转，修根因 B）。
+  2. `server-build.gradle.patch 必须带上下文（零上下文=漂移无声）` —— 扫 hunk 头，
+     禁止 `@@ -N +M @@` / `,0` 形态，并要求真的存在 ` ` 上下文行。
+  3. `<脚本> 应用补丁时不带 --unidiff-zero` —— 两份构建脚本各一条（注释走
+     `maskHashComments` 掩码，解释性注释里写 `--unidiff-zero` 不会假红）。
+  4. 原自解析守卫扩成 `删除行与上下文行都对得上 vendored 树的实际内容` —— `-` 行
+     和 ` ` 上下文行都核到 upstream_src 实际行号上（`git apply` 允许 offset 重定位，
+     所以「行号仍对齐」这件事需要单独守）。
+- **备注**：变异实测四轮，每轮改完跑守卫、跑完用反向文本替换还原（未提交文件禁用
+  `git checkout --`），`upstream_src` 435 文件 sha256 快照比对确认零字节改动：
+  - M1 改坏 upstream_src 被补丁触及的上下文行（`JGroupFilter.stateInt` → `stateIntValue`）：
+    **修前** `git apply --check --unidiff-zero` exit 0（无声）；**修后**
+    `git apply --check` exit 1（`patch does not apply`），守卫 2 条红。
+  - M2 把 `--unidiff-zero` 加回 `build_desktop_runtime.sh` 代码：只有 sh 那条守卫红，
+    ps1 那条保持绿（证明是逐脚本判定、且注释掩码没把解释吃成假红）。
+  - M3 换回零上下文补丁：3 条守卫红。
+  - M4 把守卫改回旧的（空转的）调用形态：反空转断言红，报「这条守卫在空转」。
+  另：`git apply` 在**非仓库**目录下（构建脚本的真实场景）不做前缀过滤，路径按 cwd
+  解释，所以构建脚本本身没有根因 B；只有守卫踩到了。
+- **未做**：CI 侧没跑。M-Extension-Server 的真实 gradle 构建（`:server:test`
+  `:server:shadowJar`，macOS/Windows job）本机没跑，需要 CI 实证；本机做到的是离线
+  复现「vendored → 补丁 → overlay」整条流水线并逐文件核对产物。

--- a/hibiki/test/build/mihon_vendored_server_guard_test.dart
+++ b/hibiki/test/build/mihon_vendored_server_guard_test.dart
@@ -46,6 +46,11 @@ const List<String> _overlayNewFiles = <String>[
 
 String _read(String path) => File(path).readAsStringSync();
 
+/// 补丁里出现的文件数（`+++ b/<path>` 的条数）——用来反空转，不硬编码。
+int _patchedFileCount() => RegExp(r'^\+\+\+ b/', multiLine: true)
+    .allMatches(_read('$_vendorRoot/server-build.gradle.patch'))
+    .length;
+
 /// 掩掉 `#` 行注释（sh 与 ps1 同一种注释符），走共享的等长掩码原语。
 ///
 /// 为什么必须剥：两份脚本的注释里**必须**能写出 "git clone" 这类字样来解释为什么
@@ -143,6 +148,18 @@ void main() {
             reason: '$name 必须仍然应用 server-build.gradle.patch');
       });
 
+      test('$name 应用补丁时不带 --unidiff-zero（零上下文=漂移无声）', () {
+        // 掩掉注释：两份脚本的注释里**必须**能写出 `--unidiff-zero` 来解释为什么
+        // 不再用它，否则这条守卫会被自己的解释性注释判成假红。
+        expect(
+          _maskedCode(body),
+          isNot(contains('--unidiff-zero')),
+          reason: '$name 又给 git apply 加回了 --unidiff-zero —— 零上下文补丁的'
+              '纯插入 hunk 无内容可校验，`git apply --check` 对上游漂移 exit 0，'
+              '真 apply 时按行号盲插到错误位置（BUG-1428）',
+        );
+      });
+
       test('$name 里 overlay 在补丁之后应用（覆盖顺序即安全边界的胜负手）', () {
         final String code = _maskedCode(body);
         final int patchAt = code.indexOf('server-build.gradle.patch');
@@ -169,31 +186,99 @@ void main() {
   });
 
   test('server-build.gradle.patch 仍能干净地打在 vendored 树上', () {
+    // 两处刻意的调用形态，少一个这条守卫就变成空转（BUG-1428）：
+    //
+    // ① **不带** `--unidiff-zero` —— 见下面「补丁必须带上下文」那条。
+    // ② 从**仓库根** + `--directory=`，而不是 cd 进 upstream_src 直接跑。
+    //    `git apply` 在仓库内把补丁路径解释成**相对仓库根**，再丢掉落在当前
+    //    目录之外的条目。在 upstream_src 里跑时，补丁里的 `gradle/...` /
+    //    `server/...` 被当成 `<repo>/gradle/...`，全部落在 cwd 之外 ——
+    //    git 打印 7 行 "Skipped patch" 然后 exit 0。实测：upstream_src 被改坏
+    //    也照样绿。构建脚本没这个问题（它在仓库外的临时目录里跑）。
     final ProcessResult result = Process.runSync(
       'git',
       <String>[
         'apply',
         '--check',
-        '--unidiff-zero',
-        '../server-build.gradle.patch',
+        '--verbose',
+        '--directory=third_party/m_extension_server/upstream_src',
+        'third_party/m_extension_server/server-build.gradle.patch',
       ],
-      workingDirectory: _upstreamSource,
+      workingDirectory: _repositoryRoot,
       stdoutEncoding: utf8,
       stderrEncoding: utf8,
     );
+    final String log = '${result.stdout}\n${result.stderr}';
+
+    // 反空转：git 必须真的逐个检查了补丁里的每个文件。
+    expect(
+      log,
+      isNot(contains('Skipped patch')),
+      reason: 'git apply 跳过了补丁条目 —— 这条守卫在空转，改坏 upstream_src 也会绿；'
+          '路径解释方式又错了：\n$log',
+    );
+    final int checkedFiles = 'Checking patch'.allMatches(log).length;
+    final int expectedFiles = _patchedFileCount();
+    expect(
+      checkedFiles,
+      expectedFiles,
+      reason: 'git apply 只检查了 $checkedFiles 个文件，补丁里有 $expectedFiles 个'
+          ' —— 守卫覆盖不全：\n$log',
+    );
+
     expect(
       result.exitCode,
       0,
       reason: 'git apply --check 失败，upstream_src 与 server-build.gradle.patch '
-          '已经漂开，CI 上构建会挂：\n${result.stderr}',
+          '已经漂开，CI 上构建会挂：\n$log',
     );
   });
 
-  // `git apply --unidiff-zero`（构建脚本和上面那条守卫都用它）会**关掉**上下文
-  // 校验：源文件第 N 行内容变了它照样 exit 0，然后按行号把内容盲替换掉 —— 补丁
-  // 静默打歪，产物错得无声无息。所以必须自己逐条核对补丁的 `-` 行确实落在
-  // upstream_src 对应行上。这才是真正能挡住漂移的那一条。
-  test('server-build.gradle.patch 的每条删除行都对得上 vendored 树的实际内容', () {
+  // 这条是本文件里唯一能让 `git apply --check` **真的**挡住上游漂移的前提
+  // （BUG-1428）。
+  //
+  // 实测：零上下文补丁里纯插入的 hunk（`@@ -69,0 +70 @@`）没有任何可校验内容，
+  // 在 upstream_src 已漂移的树上 `git apply --check --unidiff-zero` 仍 exit 0，
+  // 真 apply 时按行号把新代码盲插到错误位置 —— JGroupFilter 的 `stateString`
+  // 落在 `name` 与 `type` 之间，Kotlin data class 的字段顺序是位置语义，编译照
+  // 过、行为已错。带上下文之后，上游整体位移由 git 自动重定位，内容真变了硬失败。
+  //
+  // 所以补丁必须保持默认 3 行上下文：重新生成用 `git diff`，**不能**用
+  // `git diff -U0`；应用它的地方（两份构建脚本 + 上面那条守卫）都不能带
+  // `--unidiff-zero`。
+  test('server-build.gradle.patch 必须带上下文（零上下文=漂移无声）', () {
+    final List<String> patch =
+        File('$_vendorRoot/server-build.gradle.patch').readAsLinesSync();
+    final RegExp hunkHeader = RegExp(r'^@@ -\S+ \+\S+ @@');
+    final List<String> headers =
+        patch.where(hunkHeader.hasMatch).toList(growable: false);
+    expect(headers, isNotEmpty, reason: '补丁里一个 hunk 都没有 —— 解析失效');
+
+    // 零上下文 hunk 的形态：单行 `@@ -N +M @@`，或 `,0`（纯插入的旧侧长度 0）。
+    final RegExp zeroContext = RegExp(r'^@@ -\d+(?: |,0 )\+|\+\d+(?: |,0) @@');
+    final List<String> offenders =
+        headers.where(zeroContext.hasMatch).toList(growable: false);
+    expect(
+      offenders,
+      isEmpty,
+      reason: '这些 hunk 是零上下文形态，补丁又被 `git diff -U0` 重新生成了：\n'
+          '${offenders.join('\n')}\n'
+          '零上下文的纯插入 hunk 无内容可校验，`git apply --check` 对上游漂移'
+          ' exit 0，然后按行号盲插到错误位置（BUG-1428）',
+    );
+
+    // 正向证据：确实存在 ` ` 开头的上下文行（只看 hunk 头会被空补丁骗过）。
+    final int contextLines =
+        patch.where((String l) => l.startsWith(' ')).length;
+    expect(contextLines, greaterThan(20),
+        reason: '只有 $contextLines 行上下文 —— 补丁实际上仍是零上下文的');
+  });
+
+  // `git apply` 允许 hunk 带 offset 重定位：上游整体位移时它 exit 0 并打在正确
+  // 位置。那对构建是好事，但意味着「补丁的行号仍与 upstream_src 对齐」这件事
+  // 本身不再被 `--check` 保证。vendored 树是钉死的，补丁与它必须逐行对齐，所以
+  // 这里自解析补丁，把 `-` 行**和** ` ` 上下文行都核到 upstream_src 的实际行上。
+  test('server-build.gradle.patch 的删除行与上下文行都对得上 vendored 树的实际内容', () {
     final List<String> patch =
         File('$_vendorRoot/server-build.gradle.patch').readAsLinesSync();
     final RegExp fileHeader = RegExp(r'^\+\+\+ b/(.+)$');
@@ -203,7 +288,21 @@ void main() {
     String? currentPath;
     List<String>? currentLines;
     int sourceLine = 0;
-    int checked = 0;
+    int deletionsChecked = 0;
+    int contextChecked = 0;
+
+    /// 把补丁里一条旧侧的行（`-` 删除行或 ` ` 上下文行）核到 upstream_src 的实
+    /// 际内容上。[lines] 是当前文件的全部行，[kind] 只进错误信息，用来区分是哪
+    /// 一类行对不上。
+    void verifyOldSideLine(List<String> lines, String expected, String kind) {
+      expect(
+        sourceLine <= lines.length ? lines[sourceLine - 1] : null,
+        expected,
+        reason: 'upstream_src/$currentPath 第 $sourceLine 行与补丁的$kind不一致 —— '
+            'upstream_src 与 server-build.gradle.patch 必须同步更新'
+            '（补丁重新生成用 `git diff`，不要用 `-U0`）',
+      );
+    }
 
     for (final String line in patch) {
       final RegExpMatch? header = fileHeader.firstMatch(line);
@@ -222,30 +321,28 @@ void main() {
       }
       if (currentLines == null || sourceLine == 0) continue;
       if (line.startsWith('---') || line.startsWith('+++')) continue;
+      // `\ No newline at end of file` 不占旧侧行号。
+      if (line.startsWith(r'\')) continue;
       if (line.startsWith('+')) continue;
       if (line.startsWith('-')) {
-        final String expected = line.substring(1);
-        expect(
-          sourceLine <= currentLines.length
-              ? currentLines[sourceLine - 1]
-              : null,
-          expected,
-          reason: 'upstream_src/$currentPath 第 $sourceLine 行与补丁的删除行不一致；'
-              '`git apply --unidiff-zero` 不会报错，只会把内容盲替换掉 —— '
-              'upstream_src 与 server-build.gradle.patch 必须同步更新',
-        );
-        checked++;
+        verifyOldSideLine(currentLines, line.substring(1), '删除行');
+        deletionsChecked++;
         sourceLine++;
         continue;
       }
       if (line.startsWith(' ')) {
+        verifyOldSideLine(currentLines, line.substring(1), '上下文行');
+        contextChecked++;
         sourceLine++;
       }
     }
 
     // 自校验：解析器失效（补丁格式变了 / 路径错了）必须红，不能静默扫空。
-    expect(checked, greaterThan(10),
-        reason: '只核对到 $checked 条删除行 —— 补丁解析很可能已经失效');
+    expect(deletionsChecked, greaterThan(10),
+        reason: '只核对到 $deletionsChecked 条删除行 —— 补丁解析很可能已经失效');
+    expect(contextChecked, greaterThan(50),
+        reason: '只核对到 $contextChecked 条上下文行 —— 补丁很可能又变回零上下文，'
+            '或补丁解析已经失效');
   });
 
   test('overlay 覆盖的上游文件路径仍然存在（覆盖没有打空）', () {

--- a/third_party/m_extension_server/UPSTREAM
+++ b/third_party/m_extension_server/UPSTREAM
@@ -39,11 +39,21 @@ Build
 tool/mihon/build_desktop_runtime.sh (macOS) and
 tool/mihon/build_desktop_runtime.ps1 (Windows) do, in this order:
   1. copy upstream_src/ into a temporary directory;
-  2. `git apply --unidiff-zero server-build.gradle.patch` (git apply works
-     outside a git repository);
+  2. `git apply server-build.gradle.patch` (git apply works outside a git
+     repository);
   3. copy overlay/ over the result, overwriting same-named files;
   4. run `:server:test :server:shadowJar` with the pinned Temurin JDK.
 The overlay is applied last, so the security boundary below always wins.
+
+server-build.gradle.patch MUST keep its default 3 lines of context and MUST
+NOT be applied with `--unidiff-zero` (BUG-1428). A zero-context patch has
+nothing to verify in an insertion-only hunk: `git apply --check` returns 0
+even after upstream_src has drifted, and the real apply then blind-inserts by
+line number (measured: the JGroupFilter `stateString` field landed between
+`name` and `type` — a Kotlin data class's field order is positional, so it
+still compiles while already behaving wrong). With context, a pure line shift
+is relocated automatically and a real content change fails loudly.
+Regenerate the patch with `git diff` (never `git diff -U0`).
 
 upstream server/build.gradle.kts derives its revision string from
 `git rev-list HEAD --count`, which yields nothing in a .git-less vendored

--- a/third_party/m_extension_server/server-build.gradle.patch
+++ b/third_party/m_extension_server/server-build.gradle.patch
@@ -2,27 +2,58 @@ diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
 index a61155b..027527d 100644
 --- a/gradle/libs.versions.toml
 +++ b/gradle/libs.versions.toml
-@@ -4 +4 @@ coroutines = "1.10.2"
+@@ -1,7 +1,7 @@
+ [versions]
+ kotlin = "2.2.21"
+ coroutines = "1.10.2"
 -serialization = "1.9.0"
 +serialization = "1.11.0"
+ okhttp = "5.3.2" # Major version is locked by Tachiyomi extensions
+ jackson = "2.18.3" # jackson version locked by javalin, ref: `io.javalin.core.util.OptionalDependency`
+ dex2jar = "2.4.33"
 diff --git a/server/build.gradle.kts b/server/build.gradle.kts
 index e105c56..9fe540c 100644
 --- a/server/build.gradle.kts
 +++ b/server/build.gradle.kts
-@@ -17,0 +18 @@ dependencies {
+@@ -15,6 +15,7 @@ plugins {
+ 
+ dependencies {
+     implementation(libs.bundles.okhttp)
 +    implementation(libs.apksig)
-@@ -42 +43 @@ sourceSets {
+     implementation(libs.icu4j.charset)
+     testImplementation(kotlin("test"))
+ 
+@@ -39,7 +40,7 @@ sourceSets {
+ }
+ 
+ // should be bumped with each stable release
 -val m_extension_serverVersion = "v1.0.4.10"
 +val m_extension_serverVersion = "v1.0.5.0"
+ 
+ // counts commit count on master
+ val m_extension_serverRevision = runCatching {
 diff --git a/server/src/main/kotlin/mextensionserver/impl/MihonInvoker.kt b/server/src/main/kotlin/mextensionserver/impl/MihonInvoker.kt
-index f77332c..adc2815 100644
+index f77332c..6b07a8a 100644
 --- a/server/src/main/kotlin/mextensionserver/impl/MihonInvoker.kt
 +++ b/server/src/main/kotlin/mextensionserver/impl/MihonInvoker.kt
-@@ -32,0 +33 @@ import mextensionserver.model.JAnime
+@@ -30,12 +30,14 @@ import mextensionserver.model.ChapterData
+ import mextensionserver.model.DataBody
+ import mextensionserver.model.EpisodeData
+ import mextensionserver.model.JAnime
 +import mextensionserver.model.JChapter
-@@ -38,0 +40 @@ import mextensionserver.model.toJAnime
+ import mextensionserver.model.JFilterList
+ import mextensionserver.model.JManga
+ import mextensionserver.model.JPage
+ import mextensionserver.model.MangaData
+ import mextensionserver.model.MangaResponse
+ import mextensionserver.model.toJAnime
 +import mextensionserver.model.toJChapter
-@@ -241,10 +243,30 @@ object MihonInvoker {
+ import mextensionserver.model.toJManga
+ import uy.kohesive.injekt.Injekt
+ import uy.kohesive.injekt.api.get
+@@ -239,14 +241,34 @@ object MihonInvoker {
+         }
+ 
          return runBlocking {
 +            val originalManga = mangaData.toSManga(source)
              val detailedManga =
@@ -54,25 +85,54 @@ index f77332c..adc2815 100644
 +                detailedManga.thumbnail_url = originalManga.thumbnail_url
 +            }
              MihonMetadataCache.remember(source, detailedManga)
-@@ -271 +293 @@ object MihonInvoker {
+             detailedManga.toJManga()
+         }
+@@ -268,7 +290,7 @@ object MihonInvoker {
+     private fun invokeGetChapterList(
+         source: Source,
+         mangaData: MangaData?,
 -    ): List<SChapter> {
 +    ): List<JChapter> {
-@@ -285,0 +308 @@ object MihonInvoker {
+         if (mangaData == null) {
+             throw IllegalArgumentException("mangaData is required for getChapterList")
+         }
+@@ -283,6 +305,7 @@ object MihonInvoker {
+                         fetchChapters = true,
+                     ).chapters
+             chapters.onEach { chapter -> MihonMetadataCache.remember(source, chapter) }
 +                .map(SChapter::toJChapter)
-@@ -854 +877 @@ object MihonInvoker {
+         }
+     }
+ 
+@@ -851,7 +874,7 @@ object MihonInvoker {
+                                 }
+                                 if (state is Filter.Text) {
+                                     val text = state
 -                                    text.state = dataGroup.name ?: ""
 +                                    text.state = dataGroup.stateString ?: ""
+                                 }
+                             }
+                         }
 diff --git a/server/src/main/kotlin/mextensionserver/model/DataBody.kt b/server/src/main/kotlin/mextensionserver/model/DataBody.kt
 index f3ec3c1..da50e07 100644
 --- a/server/src/main/kotlin/mextensionserver/model/DataBody.kt
 +++ b/server/src/main/kotlin/mextensionserver/model/DataBody.kt
-@@ -69,0 +70 @@ data class JGroupFilter(
+@@ -67,6 +67,7 @@ data class JGroupFilter(
+     val type: String?,
+     val stateBoolean: Boolean?,
+     val stateInt: Int?,
 +    val stateString: String? = null,
+ )
+ 
+ data class JSortFilter(
 diff --git a/server/src/main/kotlin/mextensionserver/util/BytecodeEditor.kt b/server/src/main/kotlin/mextensionserver/util/BytecodeEditor.kt
 index 0a6fd9f..2a5adfe 100644
 --- a/server/src/main/kotlin/mextensionserver/util/BytecodeEditor.kt
 +++ b/server/src/main/kotlin/mextensionserver/util/BytecodeEditor.kt
-@@ -291,0 +292,8 @@ object BytecodeEditor {
+@@ -289,15 +289,23 @@ object BytecodeEditor {
+                                     pendingConstructions.removeLast()
+                                 }
+                             }
 +                            val replacementIsInterface =
 +                                replacementOwner?.let(hierarchy::isInterface) ?: itf
 +                            val replacementOpcode =
@@ -81,44 +141,98 @@ index 0a6fd9f..2a5adfe 100644
 +                                } else {
 +                                    opcode
 +                                }
-@@ -293 +301 @@ object BytecodeEditor {
+                             logger.trace {
 -                                "Method" to "$opcode: $replacementOwner: $name: ${desc.replaceIndirectly()}"
 +                                "Method" to "$replacementOpcode: $replacementOwner: $name: ${desc.replaceIndirectly()}"
-@@ -296 +304 @@ object BytecodeEditor {
+                             }
+                             super.visitMethodInsn(
 -                                opcode,
 +                                replacementOpcode,
-@@ -300 +308 @@ object BytecodeEditor {
+                                 replacementOwner,
+                                 name,
+                                 desc.replaceIndirectly(),
 -                                itf,
 +                                replacementIsInterface,
-@@ -436,0 +445,2 @@ object BytecodeEditor {
+                             )
+                         }
+ 
+@@ -434,6 +442,8 @@ object BytecodeEditor {
+ 
+         fun superName(name: String): String? = classInfo(name)?.superName
+ 
 +        fun isInterface(name: String): Boolean = classInfo(name)?.isInterface == true
 +
+         fun syntheticConstructors(name: String): Set<String> = syntheticConstructors[name].orEmpty()
+ 
+         fun needsConstructorRedirect(
 diff --git a/server/src/test/kotlin/mextensionserver/impl/TachiyomiXCompatibilityTest.kt b/server/src/test/kotlin/mextensionserver/impl/TachiyomiXCompatibilityTest.kt
-index d00206f..b0e4c9e 100644
+index d00206f..89c2d7a 100644
 --- a/server/src/test/kotlin/mextensionserver/impl/TachiyomiXCompatibilityTest.kt
 +++ b/server/src/test/kotlin/mextensionserver/impl/TachiyomiXCompatibilityTest.kt
-@@ -10,0 +11 @@ import kotlinx.serialization.json.buildJsonObject
+@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.source.model.SMangaUpdate
+ import kotlinx.coroutines.runBlocking
+ import kotlinx.serialization.json.JsonPrimitive
+ import kotlinx.serialization.json.buildJsonObject
 +import mextensionserver.model.JChapter
-@@ -31,0 +33 @@ class TachiyomiXCompatibilityTest {
+ import mextensionserver.model.JManga
+ import mextensionserver.model.MangaData
+ import rx.Observable
+@@ -29,6 +30,7 @@ class TachiyomiXCompatibilityTest {
+         val result = invokeDetails(source)
+ 
+         assertEquals("Updated title", result.title)
 +        assertEquals("/manga", result.url)
-@@ -41 +43 @@ class TachiyomiXCompatibilityTest {
+         assertEquals(listOf(UpdateRequest(fetchDetails = true, fetchChapters = false)), source.requests)
+     }
+ 
+@@ -38,7 +40,7 @@ class TachiyomiXCompatibilityTest {
+ 
+         val result = invokeChapters(source)
+ 
 -        assertEquals(listOf("Chapter 1"), result.map(SChapter::name))
 +        assertEquals(listOf("Chapter 1"), result.map(JChapter::name))
-@@ -115 +117 @@ class TachiyomiXCompatibilityTest {
+         assertEquals(listOf(UpdateRequest(fetchDetails = false, fetchChapters = true)), source.requests)
+     }
+ 
+@@ -112,7 +114,7 @@ class TachiyomiXCompatibilityTest {
+     }
+ 
+     @Suppress("UNCHECKED_CAST")
 -    private fun invokeChapters(source: Source): List<SChapter> {
 +    private fun invokeChapters(source: Source): List<JChapter> {
-@@ -123 +125 @@ class TachiyomiXCompatibilityTest {
+         val method =
+             MihonInvoker::class.java.getDeclaredMethod(
+                 "invokeGetChapterList",
+@@ -120,7 +122,7 @@ class TachiyomiXCompatibilityTest {
+                 MangaData::class.java,
+             )
+         method.isAccessible = true
 -        return method.invoke(MihonInvoker, source, mangaData()) as List<SChapter>
 +        return method.invoke(MihonInvoker, source, mangaData()) as List<JChapter>
-@@ -144 +146 @@ class TachiyomiXCompatibilityTest {
+     }
+ 
+     private data class UpdateRequest(
+@@ -141,7 +143,7 @@ class TachiyomiXCompatibilityTest {
+         ): SMangaUpdate {
+             requests += UpdateRequest(fetchDetails, fetchChapters)
+             return SMangaUpdate(
 -                manga = if (fetchDetails) newManga("Updated title") else manga,
 +                manga = if (fetchDetails) newManga("Updated title").apply { url = "" } else manga,
+                 chapters = if (fetchChapters) listOf(newChapter("Chapter 1")) else chapters,
+             )
+         }
 diff --git a/server/src/test/kotlin/mextensionserver/util/BytecodeEditorTest.kt b/server/src/test/kotlin/mextensionserver/util/BytecodeEditorTest.kt
 index 1635772..63987f5 100644
 --- a/server/src/test/kotlin/mextensionserver/util/BytecodeEditorTest.kt
 +++ b/server/src/test/kotlin/mextensionserver/util/BytecodeEditorTest.kt
-@@ -329 +329,3 @@ class BytecodeEditorTest {
+@@ -326,7 +326,9 @@ class BytecodeEditorTest {
+                     "kotlin/jvm/functions/Function1",
+                     "invoke",
+                     "(Ljava/lang/Object;)Ljava/lang/Object;",
 -                    true,
 +                    // dex2jar can preserve INVOKEINTERFACE while writing a
 +                    // Methodref instead of the required InterfaceMethodref.
 +                    false,
+                 )
+                 visitInsn(Opcodes.ARETURN)
+                 visitMaxs(2, 0)

--- a/tool/mihon/build_desktop_runtime.ps1
+++ b/tool/mihon/build_desktop_runtime.ps1
@@ -75,11 +75,17 @@ try {
     # `git apply` 在非 git 目录下同样可用（实测 exit 0），补丁与 overlay 的应用
     # 顺序和语义与 clone 时代完全一致：先打 build/上游逻辑补丁，再用 Hibiki 的
     # 安全 overlay 覆盖同名文件。
+    #
+    # 补丁必须带上下文，这里也**绝不能**加回 `--unidiff-zero`（BUG-1428）：零上下文
+    # 补丁里纯插入的 hunk 没有任何可校验的内容，`git apply --check` 对上游漂移
+    # exit 0，真 apply 时按行号把新代码盲插到错误位置（实测 JGroupFilter 的
+    # `stateString` 字段被插到 `name` 与 `type` 之间——data class 的字段顺序是位置
+    # 语义，编译照过、行为已错）。带上下文之后，上游只是整体位移则 git 自动重定位，
+    # 内容真变了就硬失败。
     Invoke-Checked -Executable git -Arguments @(
         "-C",
         $sourceRoot,
         "apply",
-        "--unidiff-zero",
         (Join-Path $overlayRoot "server-build.gradle.patch")
     )
     Copy-Tree (Join-Path $overlayRoot "overlay") $sourceRoot

--- a/tool/mihon/build_desktop_runtime.sh
+++ b/tool/mihon/build_desktop_runtime.sh
@@ -42,7 +42,14 @@ cp -R "$vendored_source_root/." "$source_root/"
 # `git apply` 在非 git 目录下同样可用（实测 exit 0），补丁与 overlay 的应用顺序
 # 和语义与 clone 时代完全一致：先打 build/上游逻辑补丁，再用 Hibiki 的安全
 # overlay 覆盖同名文件。
-git -C "$source_root" apply --unidiff-zero "$overlay_root/server-build.gradle.patch"
+#
+# 补丁必须带上下文，这里也**绝不能**加回 `--unidiff-zero`（BUG-1428）：零上下文
+# 补丁里纯插入的 hunk 没有任何可校验的内容，`git apply --check` 对上游漂移
+# exit 0，真 apply 时按行号把新代码盲插到错误位置（实测 JGroupFilter 的
+# `stateString` 字段被插到 `name` 与 `type` 之间——data class 的字段顺序是位置
+# 语义，编译照过、行为已错）。带上下文之后，上游只是整体位移则 git 自动重定位，
+# 内容真变了就硬失败。
+git -C "$source_root" apply "$overlay_root/server-build.gradle.patch"
 cp -R "$overlay_root/overlay/." "$source_root/"
 
 prepare_jdk() {


### PR DESCRIPTION
## 问题（两个独立根因，都是实测出来的）

**根因 A —— 构建脚本对补丁漂移无声。**
`tool/mihon/build_desktop_runtime.{sh,ps1}` 用 `git apply --unidiff-zero` 打零上下文补丁 `third_party/m_extension_server/server-build.gradle.patch`。

需要澄清一点：`--unidiff-zero` **不是**全盘关掉校验 —— 带 `-` 删除行的 hunk 它照样校验（实测改坏 `serialization = "1.9.0"` 会 exit 1）。真正无声的是**纯插入 hunk**（`@@ -69,0 +70 @@`）：旧侧长度为 0，没有任何可校验内容。

```
# 模拟上游在 JGroupFilter 前面加了 3 行注释
$ git -C /tmp/mut apply --check --unidiff-zero old-zerocontext.patch
exit=0                                    # ← 漂移了，--check 说没事
$ git -C /tmp/mut apply --unidiff-zero old-zerocontext.patch
$ sed -n '65,74p' .../model/DataBody.kt
data class JGroupFilter(
    val name: String?,
    val stateString: String? = null,      # ← 盲插到了错误位置
    val type: String?,
    val stateBoolean: Boolean?,
    val stateInt: Int?,
)
```
Kotlin data class 的字段顺序是**位置语义**（主构造器实参顺序、`componentN` 解构），编译照过、行为已错。

**根因 B —— PR#709 那条 `git apply --check` 守卫从落地起就是空转的。**
它 `cd` 进 `upstream_src` 跑 `git apply --check ../server-build.gradle.patch`。`git apply` 在仓库内把补丁路径解释成**相对仓库根**，`gradle/...` / `server/...` 全部落在 cwd 之外：

```
$ cd third_party/m_extension_server/upstream_src
$ git apply --check --verbose ../server-build.gradle.patch
Skipped patch 'gradle/libs.versions.toml'.
... （7 行全部 Skipped）
exit=0
```
把 upstream_src 改坏它照样绿。构建脚本没这个问题（它在仓库外的临时目录里跑，`git apply` 按 cwd 解释路径）。

## 修法

- `server-build.gradle.patch` 用 `git diff`（默认 3 行上下文）重新生成，22 个零上下文 hunk → 19 个带上下文 hunk。
- 两份构建脚本去掉 `--unidiff-zero`。
- 守卫的 `git apply --check` 改从**仓库根** + `--directory=` + `--verbose`，并加**反空转**断言：日志里不许有 `Skipped patch`、`Checking patch` 条数必须等于补丁里的文件数（不硬编码，从 `+++ b/` 数出来）。
- 新增守卫：补丁必须带上下文（禁 `@@ -N +M @@` / `,0` 形态 + 要求真有 ` ` 上下文行）；两份脚本各一条禁 `--unidiff-zero`（走 `maskHashComments`，解释性注释里写 `--unidiff-zero` 不会假红）。
- 原自解析守卫从只核 `-` 行扩到 **`-` 行 + ` ` 上下文行**（`git apply` 允许 offset 重定位，所以「行号仍对齐」需要单独守）。
- `.gitattributes` 给 `*.patch` / `*.diff` 关 whitespace 检查：补丁的空上下文行就是**一个空格**，是 unified diff 的行首标记，剥掉补丁就打不上。

## 「补丁作用不变」的硬证据

新旧补丁应用到同一棵 pristine `upstream_src`（同一 `core.autocrlf` 设置），逐文件 sha256：

```
files old-result: 435 files new-result: 435
only in old-result: []   only in new-result: []   content differs: []
VERDICT: BYTE-IDENTICAL
```

离线复现整条 `vendored → 补丁 → overlay` 流水线（即构建脚本的前三步），含 overlay 后 438 个文件：

```
[old] git apply --unidiff-zero exit=0
[new] git apply exit=0
files old-pipeline: 438  new-pipeline: 438
content differs: []
overlay 生效（产物里有 loopback 绑定）: True
overlay 生效（产物里有 Bearer token）: True
补丁生效（stateString 已加入 JGroupFilter）: True
PIPELINE VERDICT: BYTE-IDENTICAL
```

附带发现：旧补丁两条 `index` 后像哈希（`adc2815` / `b0e4c9e`）**是错的**，实际产出是 `6b07a8a` / `89c2d7a` —— 说明旧的零上下文补丁生成后被手改过。新补丁的 index 行是真的。

## 变异实测（核心验收点）

四轮，每轮改完跑守卫、跑完用反向文本替换还原（未提交文件禁用 `git checkout --`）：

| # | 变异 | 结果 |
|---|---|---|
| M1 | 改坏 upstream_src 被补丁触及的上下文行（`JGroupFilter.stateInt` → `stateIntValue`） | **修前** `git apply --check --unidiff-zero` **exit 0**（无声）；**修后** `git apply --check` **exit 1**（`patch does not apply`），守卫 2 条红 |
| M2 | 把 `--unidiff-zero` 加回 `build_desktop_runtime.sh` 代码 | 只有 sh 那条守卫红，ps1 那条保持绿（逐脚本判定 + 注释掩码没吃成假红） |
| M3 | 换回零上下文补丁 | 3 条守卫红 |
| M4 | 把守卫改回旧的（空转的）调用形态 | 反空转断言红，报「这条守卫在空转」 |

## 全仓零上下文补丁清单

| 位置 | 判定 |
|---|---|
| `third_party/m_extension_server/server-build.gradle.patch` + `tool/mihon/build_desktop_runtime.{sh,ps1}` | ✅ 唯一一处零上下文 diff 补丁打进 vendored 源码 —— **本 PR 修的就是它** |
| `third_party/ffmpeg_kit_flutter/patches/ffmpeg-tls-pin-sha256.patch` | ❌ 不在范围：8 个 hunk **全部带上下文**（`@@ -36,6 +36,12 @@`），且是在独立 ffmpeg 构建环境里手工 `patch -p1`，本仓无脚本应用它 |
| `ci/apply-patches.sh` + `ci/patches/` | ❌ 不在范围：是 `cp -r` **整文件覆盖**，没有 diff、没有行号，不存在「按行号盲插」这一类漂移 |
| 全仓 `-U0` / `--unified=0` 生成点 | ❌ 无（grep 零命中） |

## 不许动的东西（已核）

- `upstream_src/` **435 文件 sha256 快照零字节改动**（变异前后各核一次）
- 5 个 `100755` 可执行位保留（`git ls-files -s` 核过）
- 目录名 `upstream_src` 未改；行尾空格未剥（反而加了 `.gitattributes` 保护）

## 门禁

- `flutter analyze`（含 test）：`No issues found!` exit 0
- `dart run tool/flutter_test_failures.dart --no-pub test/build test/tools/source_guard_adoption_test.dart test/settings/md3_design_system_static_test.dart`
  → `FLUTTER TEST VERDICT: PASSED - 308 tests ran, all tests passed` exit 0
- `dart format`：0 改动
- `git diff --cached --check`：exit 0
- `dart run tool/bug.dart check`：1327 条，号唯一，索引同步

## 没做 / 需要 CI 实证

- **M-Extension-Server 的真实 gradle 构建（`:server:test` `:server:shadowJar`，macOS/Windows job）本机没跑，需要 CI 实证。** 本机做到的是离线复现「vendored → 补丁 → overlay」整条流水线并逐文件核对产物（见上）。
- 未 bump `+build`（整合线统一 bump）。

## 顺带记录的两个工具缺陷（本 PR 未修，属独立条目）

1. `tool/bug.dart renumber` **漏改无扩展名文件和点开头文件**：本次 9 处引用它只改了 7 处，漏掉 `.gitattributes` 和 `third_party/m_extension_server/UPSTREAM`，且自校验报「零残留」。已手工补齐并复核。
2. 取号仍会撞：`bug.dart new` 给的 1427 在我干活期间被 PR#721 renumber 占走，开 PR 前重扫才发现，已改到 1428。

不在范围：TODO-2637（M-Extension-Server 五条既有残余安全风险）没碰。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
