### PR TITLE
fix(manga): 扩展筛选去掉仓库级可搜字段 + 列表懒建 + mokuro.moe 归「漫画源」(BUG-1430/1431)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1332 条。点号进各自文件。
+> 共 1334 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1431](bugs/BUG-1431-mokuro-source-belongs-with-extensions.md) | ✅ | ✅ | mokuro.moe 挂在本地扫描根下，应与漫画扩展同级 |
+| [BUG-1430](bugs/BUG-1430-manga-extension-filter-and-lag.md) | ✅ | ✅ | 漫画扩展列表筛选不生效 + 语言下拉卡顿 |
 | [BUG-1427](bugs/BUG-1427-mobile-mining-ffmpeg-stuck-6-0.md) | 🚧 | 🚧 | 移动端制卡链 FFmpeg 停在 6.0，上游已迁到 ffmpeg-kit-next (FFmpeg 8.1.2) |
 | [BUG-1426](bugs/BUG-1426-spread-input-bridges.md) | ✅ | ✅ | 双页 spread 页滚轮与左右翻页失效 |
 | [BUG-1425](bugs/BUG-1425-md3-guard-allowlist-drift.md) | ✅ | ✅ | MD3 守卫豁免与实际命中脱节：四处裸 Material chrome 静默放行 + fontSizeFactor 绕过判据 + 过期豁免 |

--- a/docs/bugs/BUG-1430-manga-extension-filter-and-lag.md
+++ b/docs/bugs/BUG-1430-manga-extension-filter-and-lag.md
@@ -1,0 +1,19 @@
+## BUG-1430 · 漫画扩展列表筛选不生效 + 语言下拉卡顿
+- **报告**：2026-08-02（用户：截图，「来源」页装了 keiyoushi 仓库后，语言选 JA、搜索框输入 `raw`，列表纹丝不动；下拉框很卡）
+- **真实性**：✅ 真 bug，三个独立根因叠在一起
+  1. **搜索被仓库级字段打成全命中** —— `hibiki/lib/src/media/manga/mihon/mihon_extensions_page.dart:363`（改前）把 `extension.storeUrl` 塞进可搜字段。同一仓库里每个扩展的 `storeUrl` 完全一样，keiyoushi 的索引地址是
+     `https://github.com/keiyoushi/extensions/raw/repo/index.pb`，经 `normalizeMediaSearchText` 丢掉标点后是
+     `httpsgithubcomkeiyoushiextensionsrawrepoindexpb` —— 含 `raw`、`github`、`repo`、`index`。搜这几个词里的任何一个，该仓库 1900+ 个扩展一个不漏地留下来，用户看到的就是「筛选完全不生效」。同一行还塞了 `extension.language`（低基数共享值，且已有专门的语言下拉）。
+  2. **语言过滤强行放行 `all`** —— 同文件 `:360`（改前）`extension.language.toLowerCase() == 'all'` 是个无条件通行分支：选 JA 时所有多语言扩展照旧全列出来。keiyoushi 的 `all` 大多是聚合站，于是「选了日语，整屏还是 all」。
+  3. **列表非懒建（下拉卡顿的真正来源）** —— `MihonExtensionsPage(embedded: true)` 返回裸 `Column`，宿主 `MangaSourcesPage` 是 `ListView` + 单个巨型 child。`Column` 没有视口裁剪，1900+ 个 `_AvailableExtensionTile` 全部实体化成 RenderObject 并每帧参与布局/绘制；下拉菜单一展开就是连续动画帧，于是卡死。改一次筛选还要连带重建整棵树。
+- **[x] ① 已修复** —
+  - 可搜字段只留**条目自身**标识：扩展名 / 包名 / 其提供的源名与域名；剔除 `storeUrl` 与 `language`。
+  - `all` 降级为语言下拉里的一个普通选项（显示 `ALL`，与条目副标题里的 `all · 1.6.4 · lib 1.6` 同词），消掉无条件通行分支；本地独有扩展也一并跟随语言过滤。
+  - 内嵌形态改为返回 sliver（`SliverMainAxisGroup` + `SliverList.builder`），`MangaSourcesPage` 的滚动容器从 `ListView` 换成 `CustomScrollView`，只建视口内的十几行。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/manga/mihon_extensions_page_test.dart`
+  - 「搜索不吃仓库 URL：搜 raw 只留名字里真有 raw 的扩展」（三个扩展共用 keiyoushi 索引地址）；
+  - 「语言选 JA 不再混进 all 语言的扩展」；
+  - 「内嵌节懒建：视口外的扩展不进 widget 树」（300 条，末条必须 `findsNothing`）；
+  - 既有 embedded 用例改为在 `CustomScrollView` 里 pump，反向锚 `find.byType(ListView) findsNothing`。
+  - 三条守卫均已变异实测：把 `storeUrl` 加回可搜字段 / 把 `== 'all'` 分支加回来 / 把内嵌节换回 `Column`，对应用例分别变红。
+- **备注**：搜索仍是每次按键全量过滤（1900 条 × 数个字段），实测在懒建之后不再是瓶颈，故未加 debounce——加了只是把症状推后。

--- a/docs/bugs/BUG-1431-mokuro-source-belongs-with-extensions.md
+++ b/docs/bugs/BUG-1431-mokuro-source-belongs-with-extensions.md
@@ -1,0 +1,13 @@
+## BUG-1431 · mokuro.moe 挂在本地扫描根下，应与漫画扩展同级
+- **报告**：2026-08-02（用户：「浏览里面，mokuro 不应该单独显示。应该和漫画扩展同一层级」+ 截图，「来源」页「本地扫描根」一节里 Hibiki 互联下面直接跟着 Mokuro.moe）
+- **真实性**：✅ 真 bug（信息架构错位，非崩溃类）
+  - 根因 `hibiki/lib/src/pages/implementations/media_sources_view.dart:169-179`（改前）：共享的扫描根视图里为 `mediaKind == 'manga'` 特判出一行 `Mokuro.moe`。这个视图是书 / 视频 / 漫画三域共用的**本地扫描根**列表，而 mokuro.moe 是个网站，既不是扫描根也不属于三域共用能力。
+  - 连带问题：那个开关的语义与同一页「漫画源」一节里扩展源的开关**不一致**——关掉 mokuro.moe 只让它的目录页显示成禁用态（`mokuro_moe_catalog_view.dart:148` 的 `enabledOverride`），「浏览」里那一行照旧列着（`manga_browse_page.dart` 硬编码首行、根本不读这个偏好）。同一节里两种开关语义，用户无法解释。
+- **[x] ① 已修复** —
+  - 新增 `hibiki/lib/src/media/manga/online/mokuro_moe_source_row.dart`：与 `_buildOnlineSource` 同构的一行（左开关 + 名字 + 站点地址），放进 `MangaSourcesPage` 的「漫画源」一节最前，与扩展提供的在线源同级；
+  - 从 `MediaSourcesView` 摘掉 manga 特判分支与 `_mangaOnlineCatalogEnabled` 状态，该视图恢复成纯扫描根视图；
+  - 「浏览」页改读同一个偏好（`isMokuroMoeSourceEnabled`，`ref.watch(appProvider)` 保证 Offstage 保活的视图也能跟着刷新）：关掉就不列出来，与扩展源同一条可见性规则。默认值仍是 true，既有行为不变。
+- **[x] ② 已加自动化测试** —
+  - `hibiki/test/pages/manga_sources_view_composition_test.dart`：「mokuro.moe 归「漫画源」一节，不再挂在本地扫描根下」——正向锚 `MokuroMoeSourceRow()` 且位置在 `t.mihon_sources_title` 之后，反向锚 `media_sources_view.dart` 里不得再出现 `Mokuro`；「浏览」用例加 `isMokuroMoeSourceEnabled(` 锚。
+  - `hibiki/test/pages/media_sources_dialog_test.dart`：manga 语境下 `find.text('Mokuro.moe')` 改为 `findsNothing`（反向锚，防止被塞回扫描根列表）。
+- **备注**：Hibiki 互联仍留在「本地扫描根」一节——它指向的是局域网里另一台自己设备上的同一批本地文件，与「网站」不是一类。文件头已写死这条边界，防止下次又往里加在线源。

--- a/hibiki/lib/src/media/manga/manga_browse_page.dart
+++ b/hibiki/lib/src/media/manga/manga_browse_page.dart
@@ -6,13 +6,18 @@ import 'package:hibiki/src/media/manga/mihon/mihon_manager.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_runtime_factory.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_source_browse_page.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_catalog_view.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_source_row.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/utils.dart';
 
 /// 漫画库「浏览」视图：可浏览内容的**在线来源清单**。
 ///
-/// 内置的 mokuro.moe 目录恒在第一行；已启用的 Mihon 在线来源与它**并列**排在
+/// 内置的 mokuro.moe 目录在第一行；已启用的 Mihon 在线来源与它**并列**排在
 /// 后面（用户口径：扩展来的在线源不另开 tab，与 mokuro.moe 同处「浏览」）。
+///
+/// mokuro.moe 与扩展源遵守**同一条**可见性规则（BUG-1431）：在「来源」视图里被
+/// 关掉的源不出现在这里。此前 mokuro.moe 那个开关只让它的目录页显示成禁用态，
+/// 行却照旧列着——同一节里两种开关语义，用户没法解释。
 ///
 /// 平台差异只体现在**内容**上，不体现在结构上：iOS / Linux 没有扩展宿主
 /// （[MihonRuntimeFactory.isSupported] 为 false），这一页仍然存在、仍然在同一个
@@ -102,6 +107,9 @@ class _MangaBrowsePageState extends ConsumerState<MangaBrowsePage> {
   @override
   Widget build(BuildContext context) {
     final List<MangaOnlineSourceRow> sources = _enabledSources();
+    // watch（不是 read）：偏好改动经 PreferencesRepository -> AppModel 转发过来，
+    // 本页在库页壳里是 Offstage 保活的，不 watch 就永远停在旧值上。
+    final bool mokuroEnabled = isMokuroMoeSourceEnabled(ref.watch(appProvider));
     return DesktopContentLayout(
       kind: DesktopContentKind.readerShelf,
       child: Column(
@@ -115,16 +123,17 @@ class _MangaBrowsePageState extends ConsumerState<MangaBrowsePage> {
             child: ListView(
               padding: const EdgeInsets.all(16),
               children: <Widget>[
-                HibikiCard(
-                  padding: EdgeInsets.zero,
-                  child: HibikiListItem(
-                    leading: const Icon(Icons.auto_stories_outlined),
-                    title: Text(t.mihon_source_browse_mokuro),
-                    subtitle: const Text('mokuro.moe'),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: _openMokuro,
+                if (mokuroEnabled)
+                  HibikiCard(
+                    padding: EdgeInsets.zero,
+                    child: HibikiListItem(
+                      leading: const Icon(Icons.auto_stories_outlined),
+                      title: Text(t.mihon_source_browse_mokuro),
+                      subtitle: const Text('mokuro.moe'),
+                      trailing: const Icon(Icons.chevron_right),
+                      onTap: _openMokuro,
+                    ),
                   ),
-                ),
                 for (final MangaOnlineSourceRow source in sources)
                   HibikiCard(
                     padding: EdgeInsets.zero,

--- a/hibiki/lib/src/media/manga/manga_sources_page.dart
+++ b/hibiki/lib/src/media/manga/manga_sources_page.dart
@@ -8,6 +8,7 @@ import 'package:hibiki/src/media/manga/mihon/mihon_extensions_page.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_manager.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_models.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_runtime_factory.dart';
+import 'package:hibiki/src/media/manga/online/mokuro_moe_source_row.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/pages/implementations/media_sources_view.dart';
 import 'package:hibiki/utils.dart';
@@ -18,7 +19,17 @@ import 'package:hibiki/utils.dart';
 /// 1. 本地漫画扫描根（与书 / 视频共用的 [MediaSourcesView]）；
 /// 2. 漫画扩展（Mihon 扩展仓库 + 安装 / 启停 / 卸载）——用户口径：「漫画扩展
 ///    不就是来源吗，来源设置里面加上就行了」，因此**不另开顶层 tab**；
-/// 3. 扩展提供的在线来源（启停 / 排序 / 偏好 / 清数据 / 置顶）。
+/// 3. 在线漫画源：内置的 mokuro.moe **与**扩展提供的源并列（启停 / 排序 / 偏好 /
+///    清数据 / 置顶）。
+///
+/// 🔴 mokuro.moe 归第 3 节，不归第 1 节（BUG-1431）：它是个网站，不是本地扫描根。
+/// 之前它和「Hibiki 互联」一起挂在「本地扫描根」下，用户口径「mokuro 不应该单独
+/// 显示，应该和漫画扩展同一层级」。挪进「漫画源」后它与扩展源同构——同一节、同一
+/// 种开关语义（关掉 = 不在「浏览」里出现）。
+///
+/// 🔴 本页的滚动容器必须是 [CustomScrollView]（BUG-1430）：第 2 节要渲染整个扩展
+/// 仓库（keiyoushi 有 1900+ 条），只有 sliver 才能懒建。换回 `ListView` +
+/// 内嵌 `Column` 会立刻把「语言下拉一展开就卡死」带回来。
 ///
 /// 平台差异只在**内容**：iOS / Linux 没有扩展宿主，第 2、3 节渲染成
 /// `mihon_runtime_unavailable` 提示，视图本身与其它平台同构、同位。
@@ -160,42 +171,58 @@ class _MangaSourcesPageState extends ConsumerState<MangaSourcesPage> {
               bottom: widget.navigation,
             ),
           Expanded(
-            child: ListView(
-              padding: const EdgeInsets.all(16),
-              children: <Widget>[
-                _sectionTitle(t.media_source_local_roots),
-                const SizedBox(height: 8),
-                MediaSourcesView(
-                  key: _localSourcesKey,
-                  mediaKind: 'manga',
-                ),
-                const SizedBox(height: 28),
-                _sectionTitle(t.mihon_extensions_title),
-                const SizedBox(height: 8),
-                if (manager == null)
-                  _unavailableNote()
-                else
-                  const MihonExtensionsPage(embedded: true),
-                const SizedBox(height: 28),
-                _sectionTitle(t.mihon_sources_title),
-                const SizedBox(height: 8),
-                if (manager == null)
-                  _unavailableNote()
-                else if (manager.sources.isEmpty)
-                  Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: Text(
-                      t.mihon_source_empty,
-                      textAlign: TextAlign.center,
-                    ),
+            child: CustomScrollView(
+              slivers: <Widget>[
+                SliverPadding(
+                  padding: const EdgeInsets.all(16),
+                  sliver: SliverMainAxisGroup(
+                    slivers: <Widget>[
+                      SliverToBoxAdapter(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: <Widget>[
+                            _sectionTitle(t.media_source_local_roots),
+                            const SizedBox(height: 8),
+                            MediaSourcesView(
+                              key: _localSourcesKey,
+                              mediaKind: 'manga',
+                            ),
+                            const SizedBox(height: 28),
+                            _sectionTitle(t.mihon_extensions_title),
+                            const SizedBox(height: 8),
+                          ],
+                        ),
+                      ),
+                      if (manager == null)
+                        SliverToBoxAdapter(child: _unavailableNote())
+                      else
+                        const MihonExtensionsPage(embedded: true),
+                      SliverToBoxAdapter(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: <Widget>[
+                            const SizedBox(height: 28),
+                            _sectionTitle(t.mihon_sources_title),
+                            const SizedBox(height: 8),
+                            // 内置在线源：与扩展提供的源同节同级（见类文档）。
+                            const MokuroMoeSourceRow(),
+                            if (manager == null) _unavailableNote(),
+                          ],
+                        ),
+                      ),
+                      if (manager != null)
+                        SliverList.builder(
+                          itemCount: manager.sources.length,
+                          itemBuilder: (BuildContext context, int index) =>
+                              _buildOnlineSource(
+                            manager,
+                            manager.sources[index],
+                            index,
+                          ),
+                        ),
+                    ],
                   ),
-                if (manager != null)
-                  for (int index = 0; index < manager.sources.length; index++)
-                    _buildOnlineSource(
-                      manager,
-                      manager.sources[index],
-                      index,
-                    ),
+                ),
               ],
             ),
           ),

--- a/hibiki/lib/src/media/manga/mihon/mihon_extensions_page.dart
+++ b/hibiki/lib/src/media/manga/mihon/mihon_extensions_page.dart
@@ -20,8 +20,14 @@ import 'package:hibiki/utils.dart';
 /// [embedded] 为 true 时：
 /// - 不再包 `DesktopContentLayout` / `HibikiPageHeader`（外层已有一套 chrome），
 ///   页头那三个动作（刷新仓库 / 导入 APK / 添加仓库）降级成本节顶部的按钮行；
-/// - 内容体从 `ListView` 换成 `Column`——它被塞进外层 `ListView` 的无界高度里，
-///   再嵌一个可滚动的 `ListView` 会直接抛约束异常。
+/// - `build` 返回的是**sliver**（[SliverMainAxisGroup]），由外层 `CustomScrollView`
+///   直接消费。
+///
+/// 🔴 内嵌形态必须是 sliver，不能是 `Column`（BUG-1430）：keiyoushi 这类完整仓库
+/// 有 1900+ 个扩展，塞进 `Column` 就是 1900 个 RenderObject 全部实体化——`Column`
+/// 没有视口裁剪，每一帧都要布局并绘制全部条目，于是「语言下拉一展开就卡死」「改一
+/// 次筛选卡几秒」。外层滚动容器换成 `CustomScrollView` 后，这里用 `SliverList`
+/// 只建可见的那十几行。
 class MihonExtensionsPage extends ConsumerStatefulWidget {
   const MihonExtensionsPage({
     super.key,
@@ -255,20 +261,23 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
     final MihonManager manager =
         _manager ?? widget.manager ?? ref.read(appProvider).mihonManager;
     if (widget.embedded) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          Wrap(
-            spacing: 8,
-            runSpacing: 8,
-            children: _actions(manager),
+      return SliverMainAxisGroup(
+        slivers: <Widget>[
+          SliverToBoxAdapter(
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: _actions(manager),
+            ),
           ),
           if (manager.loading)
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 8),
-              child: LinearProgressIndicator(),
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.symmetric(vertical: 8),
+                child: LinearProgressIndicator(),
+              ),
             ),
-          _buildContent(manager),
+          ..._buildContentSlivers(manager),
         ],
       );
     }
@@ -285,7 +294,16 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
           Expanded(
             child: Stack(
               children: <Widget>[
-                _buildContent(manager),
+                CustomScrollView(
+                  slivers: <Widget>[
+                    SliverPadding(
+                      padding: const EdgeInsets.all(16),
+                      sliver: SliverMainAxisGroup(
+                        slivers: _buildContentSlivers(manager),
+                      ),
+                    ),
+                  ],
+                ),
                 if (manager.loading)
                   const Positioned.fill(
                     child: ColoredBox(
@@ -301,53 +319,64 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
     );
   }
 
-  Widget _buildContent(MihonManager manager) {
+  List<Widget> _buildContentSlivers(MihonManager manager) {
     final Map<String, MangaExtensionRow> installed =
         <String, MangaExtensionRow>{
       for (final MangaExtensionRow row in manager.installed)
         row.packageName: row,
     };
     if (manager.stores.isEmpty && manager.installed.isEmpty) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              const Icon(Icons.extension_outlined, size: 48),
-              const SizedBox(height: 12),
-              Text(
-                t.mihon_store_empty,
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 16),
-              Wrap(
-                spacing: 12,
-                children: <Widget>[
-                  FilledButton.icon(
-                    onPressed: _addStore,
-                    icon: const Icon(Icons.add_link),
-                    label: Text(t.mihon_store_add),
-                  ),
-                  OutlinedButton.icon(
-                    onPressed: _importApk,
-                    icon: const Icon(Icons.file_open_outlined),
-                    label: Text(t.mihon_extension_import),
-                  ),
-                ],
-              ),
-            ],
-          ),
+      final Widget empty = Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            const Icon(Icons.extension_outlined, size: 48),
+            const SizedBox(height: 12),
+            Text(
+              t.mihon_store_empty,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 12,
+              children: <Widget>[
+                FilledButton.icon(
+                  onPressed: _addStore,
+                  icon: const Icon(Icons.add_link),
+                  label: Text(t.mihon_store_add),
+                ),
+                OutlinedButton.icon(
+                  onPressed: _importApk,
+                  icon: const Icon(Icons.file_open_outlined),
+                  label: Text(t.mihon_extension_import),
+                ),
+              ],
+            ),
+          ],
         ),
       );
+      return <Widget>[
+        // 独立页把空态撑满视口垂直居中；内嵌时它只是页面中的一节，撑满会把下面的
+        // 「漫画源」一节顶出屏幕。
+        if (widget.embedded)
+          SliverToBoxAdapter(child: empty)
+        else
+          SliverFillRemaining(
+              hasScrollBody: false, child: Center(child: empty)),
+      ];
     }
     final Set<String> availablePackages = manager.available
         .map((MihonAvailableExtension extension) => extension.packageName)
         .toSet();
+    // 语言码一律折成小写做值域：仓库里同一门语言大小写不统一时不会分裂成两项。
+    // `all`（多语言扩展）是**一个普通语言项**，不再被强行混进每一种语言里——
+    // 选 JA 却整屏都是 `all`（而且 keiyoushi 的 `all` 大多是聚合站）正是用户说的
+    // 「筛选不生效」的一半（BUG-1430）。要看它就在下拉里选 ALL。
     final List<String> languages = manager.available
-        .map((MihonAvailableExtension extension) => extension.language)
-        .where((String language) =>
-            language.isNotEmpty && language.toLowerCase() != 'all')
+        .map((MihonAvailableExtension extension) =>
+            extension.language.toLowerCase())
+        .where((String language) => language.isNotEmpty)
         .toSet()
         .toList()
       ..sort();
@@ -355,16 +384,18 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
         filterByMediaSearch<MihonAvailableExtension>(
       manager.available
           .where((MihonAvailableExtension extension) =>
-              _language == '*' ||
-              extension.language == _language ||
-              extension.language.toLowerCase() == 'all')
+              _language == '*' || extension.language.toLowerCase() == _language)
           .toList(growable: false),
       _searchQuery,
+      // 🔴 可搜字段只能是**条目自身**的标识。`storeUrl` 是仓库级字段，同一仓库的
+      // 每个扩展都一样：keiyoushi 的索引地址是
+      // `https://github.com/keiyoushi/extensions/raw/repo/index.pb`，归一化后含
+      // `raw`/`github`/`repo`/`index`，于是搜「raw」整个仓库 1900 个扩展全部命中，
+      // 看起来就是「筛选完全没生效」（BUG-1430）。`language` 同理是低基数共享值，
+      // 且已有专门的语言下拉，留在这里只会把「all」这类查询打成全命中。
       (MihonAvailableExtension extension) => <String>[
         extension.name,
         extension.packageName,
-        extension.storeUrl,
-        extension.language,
         ...extension.sources.expand(
           (MihonAvailableSource source) => <String>[
             source.name,
@@ -375,7 +406,8 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
     );
     final List<MangaExtensionRow> localOnly = manager.installed
         .where((MangaExtensionRow row) =>
-            !availablePackages.contains(row.packageName))
+            !availablePackages.contains(row.packageName) &&
+            (_language == '*' || row.language.toLowerCase() == _language))
         .toList(growable: false);
     final List<MangaExtensionRow> visibleLocalOnly =
         filterByMediaSearch<MangaExtensionRow>(
@@ -384,83 +416,82 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
       (MangaExtensionRow extension) => <String>[
         extension.name,
         extension.packageName,
-        extension.language,
       ],
     );
-    return _contentContainer(<Widget>[
-      for (final MangaExtensionStoreRow store in manager.stores)
-        HibikiCard(
-          padding: EdgeInsets.zero,
-          child: HibikiListItem(
-            leading: const Icon(Icons.hub_outlined),
-            title: Text(store.name),
-            subtitle: Text(
-              store.lastError == null
-                  ? store.indexUrl
-                  : '${store.indexUrl}\n${store.lastError}',
-            ),
-            trailing: IconButton(
-              tooltip: t.dialog_delete,
-              onPressed: () => unawaited(
-                manager.removeStore(store.indexUrl),
+    return <Widget>[
+      SliverList.builder(
+        itemCount: manager.stores.length,
+        itemBuilder: (BuildContext context, int index) {
+          final MangaExtensionStoreRow store = manager.stores[index];
+          return HibikiCard(
+            padding: EdgeInsets.zero,
+            child: HibikiListItem(
+              leading: const Icon(Icons.hub_outlined),
+              title: Text(store.name),
+              subtitle: Text(
+                store.lastError == null
+                    ? store.indexUrl
+                    : '${store.indexUrl}\n${store.lastError}',
               ),
-              icon: const Icon(Icons.delete_outline),
+              trailing: IconButton(
+                tooltip: t.dialog_delete,
+                onPressed: () => unawaited(
+                  manager.removeStore(store.indexUrl),
+                ),
+                icon: const Icon(Icons.delete_outline),
+              ),
             ),
-          ),
-        ),
+          );
+        },
+      ),
       if (manager.available.isNotEmpty || manager.installed.isNotEmpty)
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          child: _buildFilters(languages),
-        ),
-      const SizedBox(height: 8),
-      for (final MihonAvailableExtension extension in visibleAvailable)
-        _AvailableExtensionTile(
-          extension: extension,
-          installed: installed[extension.packageName],
-          onInstall: () => unawaited(_install(extension)),
-          onUninstall: installed[extension.packageName] == null
-              ? null
-              : () => unawaited(
-                    _uninstall(installed[extension.packageName]!),
-                  ),
-          onEnabledChanged: installed[extension.packageName] == null
-              ? null
-              : (bool value) => unawaited(manager.setExtensionEnabled(
-                    installed[extension.packageName]!,
-                    value,
-                  )),
-        ),
-      for (final MangaExtensionRow extension in visibleLocalOnly)
-        _InstalledExtensionTile(
-          extension: extension,
-          onUninstall: () => unawaited(_uninstall(extension)),
-          onEnabledChanged: (bool value) => unawaited(
-            manager.setExtensionEnabled(extension, value),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 8),
+            child: _buildFilters(languages),
           ),
         ),
+      const SliverToBoxAdapter(child: SizedBox(height: 8)),
+      SliverList.builder(
+        itemCount: visibleAvailable.length,
+        itemBuilder: (BuildContext context, int index) {
+          final MihonAvailableExtension extension = visibleAvailable[index];
+          final MangaExtensionRow? row = installed[extension.packageName];
+          return _AvailableExtensionTile(
+            extension: extension,
+            installed: row,
+            onInstall: () => unawaited(_install(extension)),
+            onUninstall: row == null ? null : () => unawaited(_uninstall(row)),
+            onEnabledChanged: row == null
+                ? null
+                : (bool value) =>
+                    unawaited(manager.setExtensionEnabled(row, value)),
+          );
+        },
+      ),
+      SliverList.builder(
+        itemCount: visibleLocalOnly.length,
+        itemBuilder: (BuildContext context, int index) {
+          final MangaExtensionRow extension = visibleLocalOnly[index];
+          return _InstalledExtensionTile(
+            extension: extension,
+            onUninstall: () => unawaited(_uninstall(extension)),
+            onEnabledChanged: (bool value) => unawaited(
+              manager.setExtensionEnabled(extension, value),
+            ),
+          );
+        },
+      ),
       if (_searchQuery.trim().isNotEmpty &&
           visibleAvailable.isEmpty &&
           visibleLocalOnly.isEmpty)
-        Padding(
-          padding: const EdgeInsets.symmetric(vertical: 32),
-          child: Center(child: Text(t.no_search_results)),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 32),
+            child: Center(child: Text(t.no_search_results)),
+          ),
         ),
-    ]);
-  }
-
-  /// 独立页自带滚动；内嵌时外层 `ListView` 已经在滚了，这里必须是裸 `Column`。
-  Widget _contentContainer(List<Widget> children) {
-    if (widget.embedded) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: children,
-      );
-    }
-    return ListView(
-      padding: const EdgeInsets.all(16),
-      children: children,
-    );
+    ];
   }
 
   Widget _buildFilters(List<String> languages) {
@@ -471,11 +502,15 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
       ),
       items: <DropdownMenuItem<String>>[
         DropdownMenuItem<String>(
+          key: const ValueKey<String>('mihon_extension_language_*'),
           value: '*',
           child: Text(t.mihon_extension_language_all),
         ),
+        // `all` 也在这里，作为一个**普通语言项**（显示成 ALL，与条目副标题里的
+        // `all · 1.6.4 · lib 1.6` 同一个词）。见 `_buildContentSlivers` 里的说明。
         for (final String language in languages)
           DropdownMenuItem<String>(
+            key: ValueKey<String>('mihon_extension_language_$language'),
             value: language,
             child: Text(language.toUpperCase()),
           ),

--- a/hibiki/lib/src/media/manga/mihon/mihon_manager.dart
+++ b/hibiki/lib/src/media/manga/mihon/mihon_manager.dart
@@ -27,6 +27,7 @@ class MihonManager extends ChangeNotifier {
     required this.rootDirectory,
     required this.runtime,
     MihonExtensionStoreClient? storeClient,
+    this.seedDefaultStore = false,
   }) : _storeClient = storeClient ?? MihonExtensionStoreClient() {
     if (Platform.isWindows || Platform.isMacOS) {
       _exitShutdown =
@@ -38,6 +39,15 @@ class MihonManager extends ChangeNotifier {
   final Directory rootDirectory;
   final MihonRuntime runtime;
   final MihonExtensionStoreClient _storeClient;
+
+  /// 是否在 [initialise] 里装配默认扩展仓库（见 [kMihonDefaultStoreIndexUrl]）。
+  ///
+  /// 默认 **false**，只有真实 app 启动那一处（`AppModel.mihonManager`）传 true。
+  /// 装默认仓库是**应用启动策略**，不是「构造一个 manager」的语义：挂在
+  /// [initialise] 上无条件执行，会让任何构造 manager 的单测都去真实网络拉
+  /// keiyoushi 索引（1900+ 条），既慢又把测试结果绑在外网上——这正是本轮
+  /// `mihon_manager_install_test` 那条 cold-start 用例变红的原因。
+  final bool seedDefaultStore;
 
   List<MangaExtensionStoreRow> stores = const <MangaExtensionStoreRow>[];
   List<MangaExtensionRow> installed = const <MangaExtensionRow>[];
@@ -92,6 +102,7 @@ class MihonManager extends ChangeNotifier {
   /// 由 [addStore] 单独拉这一个仓库，不会把同一个索引拉两遍。整个过程吞异常——
   /// 断网或仓库临时 502 不该让扩展子系统初始化失败（`_initialise` 会 rethrow）。
   Future<void> _seedDefaultStore() async {
+    if (!seedDefaultStore) return;
     final bool seeded = await database.getPrefTyped<bool>(
       kMihonDefaultStoreSeededPref,
       false,

--- a/hibiki/lib/src/media/manga/mihon/mihon_manager.dart
+++ b/hibiki/lib/src/media/manga/mihon/mihon_manager.dart
@@ -12,6 +12,15 @@ import 'package:hibiki/src/media/manga/mihon/mihon_models.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_runtime.dart';
 import 'package:hibiki/src/startup/exit_flush_registry.dart';
 
+/// 开箱即用的默认扩展仓库（用户指定）。没有它的话「漫画扩展」一节首次打开是空的，
+/// 用户得先自己知道一个仓库地址才能开始——而这个仓库就是社区事实标准。
+const String kMihonDefaultStoreIndexUrl =
+    'https://github.com/keiyoushi/extensions/raw/repo/index.pb';
+
+/// 默认仓库**只自动添加一次**：置位后用户删掉它就不会被下次启动重新塞回来。
+/// 只在添加成功后置位，所以首次启动断网不会永久丢掉默认仓库。
+const String kMihonDefaultStoreSeededPref = 'mihon_default_store_seeded';
+
 class MihonManager extends ChangeNotifier {
   MihonManager({
     required this.database,
@@ -67,12 +76,39 @@ class MihonManager extends ChangeNotifier {
           .create(recursive: true);
       await reload();
       await _refreshStores();
+      await _seedDefaultStore();
     } catch (exception) {
       error = '$exception';
       rethrow;
     } finally {
       loading = false;
       _notify();
+    }
+  }
+
+  /// 首次启动把 [kMihonDefaultStoreIndexUrl] 装进来（见常量文档）。
+  ///
+  /// 放在 [_refreshStores] **之后**：那一步只刷已有仓库，首次启动是空跑，紧接着
+  /// 由 [addStore] 单独拉这一个仓库，不会把同一个索引拉两遍。整个过程吞异常——
+  /// 断网或仓库临时 502 不该让扩展子系统初始化失败（`_initialise` 会 rethrow）。
+  Future<void> _seedDefaultStore() async {
+    final bool seeded = await database.getPrefTyped<bool>(
+      kMihonDefaultStoreSeededPref,
+      false,
+    );
+    if (seeded) return;
+    if (stores.any((MangaExtensionStoreRow row) =>
+        row.indexUrl == kMihonDefaultStoreIndexUrl)) {
+      await database.setPrefTyped<bool>(kMihonDefaultStoreSeededPref, true);
+      return;
+    }
+    try {
+      await addStore(kMihonDefaultStoreIndexUrl);
+      await database.setPrefTyped<bool>(kMihonDefaultStoreSeededPref, true);
+    } catch (_) {
+      // 下次启动再试。`addStore` 的 `_guarded` 已经把失败写进 `error`，但「默认仓库
+      // 这次没拉到」不是用户发起的操作，不该在扩展页挂一条报错。
+      error = null;
     }
   }
 

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_source_row.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_source_row.dart
@@ -1,0 +1,54 @@
+// 内置在线漫画源 mokuro.moe 在「来源」视图里的一行。
+//
+// BUG-1431：它此前挂在「本地扫描根」一节里（和 Hibiki 互联并排），但 mokuro.moe
+// 是个网站、不是扫描根。用户口径：「mokuro 不应该单独显示，应该和漫画扩展同一
+// 层级」。现在它和扩展提供的在线源同处「漫画源」一节，长得也一样（左开关 + 名字 +
+// 地址），开关语义也一样：**关掉就不出现在「浏览」里**。
+//
+// 值走偏好 `manga_online_catalog_enabled`（默认 true，保持既有行为）。
+// `PreferencesRepository` 写完会 notifyListeners，`AppModel` 转发，所以这里
+// `ref.watch(appProvider)` 就能让「来源」与「浏览」两个视图同步——「浏览」在库页壳
+// 里是 Offstage 保活的，不靠 provider 通知它永远不会重建。
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:hibiki/src/models/app_model.dart';
+import 'package:hibiki/utils.dart';
+
+/// 偏好未就绪时的兜底站点（与 `PreferencesRepository` 的默认值一致）。
+const String kMokuroMoeDefaultBaseUrl = 'https://mokuro.moe';
+
+/// mokuro.moe 是否参与漫画浏览。偏好未就绪时按默认值 true 处理——这条路径只在
+/// widget 测试里出现，真实运行时 `AppModel` 早已初始化完毕。
+bool isMokuroMoeSourceEnabled(AppModel appModel) =>
+    !appModel.isPreferencesReady || appModel.mangaOnlineCatalogEnabled;
+
+/// 见文件头：与 `_buildOnlineSource` 同构的一行，放在「漫画源」一节最前。
+class MokuroMoeSourceRow extends ConsumerWidget {
+  const MokuroMoeSourceRow({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AppModel appModel = ref.watch(appProvider);
+    final bool ready = appModel.isPreferencesReady;
+    return HibikiCard(
+      padding: EdgeInsets.zero,
+      child: HibikiListItem(
+        leading: Switch.adaptive(
+          value: isMokuroMoeSourceEnabled(appModel),
+          onChanged: ready
+              ? (bool value) =>
+                  unawaited(appModel.setMangaOnlineCatalogEnabled(value))
+              : null,
+        ),
+        title: const Text('Mokuro.moe'),
+        subtitle: Text(
+          ready ? appModel.mangaOnlineCatalogBaseUrl : kMokuroMoeDefaultBaseUrl,
+        ),
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -3214,6 +3214,10 @@ class AppModel with ChangeNotifier {
       database: database,
       rootDirectory: root,
       runtime: MihonRuntimeFactory.create(root),
+      // 只有真实 app 启动这一处装默认扩展仓库（用户诉求：漫画扩展仓库默认带
+      // keiyoushi）。别把它挪进 MihonManager 的默认值——那会让每个构造 manager
+      // 的单测都去拉真实网络索引，见 MihonManager.seedDefaultStore 的说明。
+      seedDefaultStore: true,
     );
     _mihonManager = manager;
     unawaited(manager.initialise());

--- a/hibiki/lib/src/pages/implementations/media_sources_view.dart
+++ b/hibiki/lib/src/pages/implementations/media_sources_view.dart
@@ -64,11 +64,13 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
   /// null = 仍在加载；非 null = 已加载（可能为空列表）。
   List<SourceLibraryRow>? _rows;
 
-  /// Virtual sources are not `media_sources` scan roots. They are composed into
-  /// this view so "Sources" describes every origin that can supply the media
-  /// experience instead of only local folders.
+  /// Hibiki 互联不是 `media_sources` 扫描根，但它确实是**本机之外的同一批本地
+  /// 文件**（局域网里另一台自己的设备），所以与扫描根同列。
+  ///
+  /// 🔴 别再往这里加「网站」型来源（BUG-1431）：mokuro.moe 曾挂在这一节，用户口径
+  /// 是它不该跟扫描根混在一起。在线漫画源统一归 `MangaSourcesPage` 的「漫画源」
+  /// 一节（`MokuroMoeSourceRow`），与扩展提供的源同级。
   bool? _interconnectEnabled;
-  bool? _mangaOnlineCatalogEnabled;
 
   /// 每个来源 id → 当前**累计拥有**的媒体条目数（TODO-1036）。
   /// 与列表一起加载，避免逐行 FutureBuilder 抖动。来源不在 map 里时回退 0。
@@ -106,16 +108,11 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
         await _db.getMediaSourcesByKind(widget.mediaKind);
     final bool interconnectEnabled =
         await SyncRepository(_db).isInterconnectEnabled();
-    final bool mangaOnlineCatalogEnabled = await _db.getPrefTyped<bool>(
-      'manga_online_catalog_enabled',
-      true,
-    );
     final Map<int, int> counts = await _loadCumulativeCounts(rows);
     if (!mounted) return;
     setState(() {
       _rows = rows;
       _interconnectEnabled = interconnectEnabled;
-      _mangaOnlineCatalogEnabled = mangaOnlineCatalogEnabled;
       _cumulativeCount
         ..clear()
         ..addAll(counts);
@@ -151,10 +148,7 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
   Widget _buildBody(HibikiDesignTokens tokens) {
     final List<SourceLibraryRow>? rows = _rows;
     final bool? interconnectEnabled = _interconnectEnabled;
-    final bool? mangaOnlineCatalogEnabled = _mangaOnlineCatalogEnabled;
-    if (rows == null ||
-        interconnectEnabled == null ||
-        mangaOnlineCatalogEnabled == null) {
+    if (rows == null || interconnectEnabled == null) {
       return buildLoading(padding: const EdgeInsets.all(24));
     }
     final List<Widget> sourceRows = <Widget>[
@@ -166,17 +160,6 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
         value: interconnectEnabled,
         onChanged: _setInterconnectEnabled,
       ),
-      if (widget.mediaKind == 'manga')
-        _buildVirtualSourceRow(
-          tokens,
-          icon: Icons.public_outlined,
-          title: 'Mokuro.moe',
-          subtitle: _appModel.isPreferencesReady
-              ? _appModel.mangaOnlineCatalogBaseUrl
-              : 'https://mokuro.moe',
-          value: mangaOnlineCatalogEnabled,
-          onChanged: _setMangaOnlineCatalogEnabled,
-        ),
       if (rows.isNotEmpty) ...<Widget>[
         Padding(
           padding: EdgeInsets.symmetric(vertical: tokens.spacing.gap / 2),
@@ -261,20 +244,6 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
     } catch (_) {
       if (!mounted) return;
       setState(() => _interconnectEnabled = !value);
-    }
-  }
-
-  Future<void> _setMangaOnlineCatalogEnabled(bool value) async {
-    setState(() => _mangaOnlineCatalogEnabled = value);
-    try {
-      if (_appModel.isPreferencesReady) {
-        await _appModel.setMangaOnlineCatalogEnabled(value);
-      } else {
-        await _db.setPrefTyped<bool>('manga_online_catalog_enabled', value);
-      }
-    } catch (_) {
-      if (!mounted) return;
-      setState(() => _mangaOnlineCatalogEnabled = !value);
     }
   }
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1161
+version: 1.3.1+1162
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/manga/mihon_default_store_seed_test.dart
+++ b/hibiki/test/media/manga/mihon_default_store_seed_test.dart
@@ -1,0 +1,171 @@
+// 默认扩展仓库自动装配（用户诉求：「漫画扩展仓库默认添加 keiyoushi」）。
+//
+// 守两条不变量：
+// 1. 首次初始化把 [kMihonDefaultStoreIndexUrl] 装进来——不装的话「漫画扩展」一节
+//    开箱是空的，用户得先自己知道一个仓库地址；
+// 2. **只装一次**——用户删掉它之后重启不会被塞回来（置位 pref
+//    [kMihonDefaultStoreSeededPref]）。这条比第 1 条更容易写坏：任何「没有仓库就
+//    补一个」的写法都会把用户的删除操作每次启动撤销掉。
+//
+// 另外守「装不上不致命」：首次启动断网时初始化不得抛，且 pref 不置位（下次再试）。
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/mihon/mihon_extension_store_client.dart';
+import 'package:hibiki/src/media/manga/mihon/mihon_manager.dart';
+import 'package:hibiki/src/media/manga/mihon/mihon_runtime.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+void main() {
+  late Directory root;
+  late HibikiDatabase database;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('hibiki-mihon-seed-');
+    database = HibikiDatabase.forTesting(NativeDatabase.memory());
+  });
+
+  tearDown(() async {
+    await database.close();
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  MihonManager build(MihonExtensionStoreClient client) => MihonManager(
+        database: database,
+        rootDirectory: root,
+        runtime: _SeedRuntime(),
+        storeClient: client,
+      );
+
+  test('首次初始化自动装上 keiyoushi 仓库，且只拉这一个索引', () async {
+    final _FakeStoreClient client = _FakeStoreClient();
+    final MihonManager manager = build(client);
+    addTearDown(manager.dispose);
+
+    await manager.initialise();
+
+    expect(
+      manager.stores.map((MangaExtensionStoreRow row) => row.indexUrl),
+      contains(kMihonDefaultStoreIndexUrl),
+    );
+    expect(client.fetchedStoreUrls, <String>[kMihonDefaultStoreIndexUrl]);
+    expect(
+      await database.getPrefTyped<bool>(kMihonDefaultStoreSeededPref, false),
+      isTrue,
+    );
+  });
+
+  test('用户删掉默认仓库后重启不会被重新塞回来', () async {
+    final MihonManager first = build(_FakeStoreClient());
+    await first.initialise();
+    await first.removeStore(kMihonDefaultStoreIndexUrl);
+    expect(first.stores, isEmpty);
+    first.dispose();
+
+    final _FakeStoreClient second = _FakeStoreClient();
+    final MihonManager manager = build(second);
+    addTearDown(manager.dispose);
+    await manager.initialise();
+
+    expect(manager.stores, isEmpty);
+    expect(second.fetchedStoreUrls, isEmpty);
+  });
+
+  test('首次启动拉不到仓库不致命：初始化不抛，pref 不置位，下次还会再试', () async {
+    final MihonManager offline = build(_FailingStoreClient());
+    await offline.initialise();
+    expect(offline.stores, isEmpty);
+    expect(
+      offline.error,
+      isNull,
+      reason: '默认仓库不是用户发起的操作，拉不到不该在扩展页挂一条报错',
+    );
+    expect(
+      await database.getPrefTyped<bool>(kMihonDefaultStoreSeededPref, false),
+      isFalse,
+    );
+    offline.dispose();
+
+    final MihonManager online = build(_FakeStoreClient());
+    addTearDown(online.dispose);
+    await online.initialise();
+    expect(
+      online.stores.map((MangaExtensionStoreRow row) => row.indexUrl),
+      contains(kMihonDefaultStoreIndexUrl),
+    );
+  });
+}
+
+MihonStore _store(String indexUrl) => MihonStore(
+      indexUrl: indexUrl,
+      name: 'Keiyoushi',
+      badgeLabel: '',
+      signingKey: 'aabb',
+      contact: const <String, String?>{},
+      format: MihonStoreFormat.currentJson,
+      extensionListUrl: null,
+      embeddedExtensions: <MihonAvailableExtension>[
+        MihonAvailableExtension(
+          storeUrl: indexUrl,
+          name: 'RawKuma',
+          packageName: 'org.example.rawkuma',
+          apkUrl: '$indexUrl/rawkuma.apk',
+          iconUrl: '',
+          libVersion: '1.6',
+          versionCode: 1,
+          versionName: '1.6.1',
+          language: 'ja',
+          contentWarning: 0,
+          sources: const <MihonAvailableSource>[],
+        ),
+      ],
+    );
+
+class _FakeStoreClient extends Fake implements MihonExtensionStoreClient {
+  final List<String> fetchedStoreUrls = <String>[];
+
+  @override
+  Future<MihonStoreFetchResult> fetchStore(
+    String rawUrl, {
+    String? etag,
+    String? lastModified,
+    bool allowInsecure = false,
+  }) async {
+    fetchedStoreUrls.add(rawUrl);
+    return MihonStoreFetchResult(
+      store: _store(rawUrl),
+      etag: null,
+      lastModified: null,
+    );
+  }
+
+  @override
+  Future<List<MihonAvailableExtension>> fetchExtensions(
+    MihonStore store, {
+    bool allowInsecure = false,
+  }) async =>
+      store.embeddedExtensions;
+
+  @override
+  void close() {}
+}
+
+class _FailingStoreClient extends Fake implements MihonExtensionStoreClient {
+  @override
+  Future<MihonStoreFetchResult> fetchStore(
+    String rawUrl, {
+    String? etag,
+    String? lastModified,
+    bool allowInsecure = false,
+  }) async =>
+      throw const SocketException('offline');
+
+  @override
+  void close() {}
+}
+
+class _SeedRuntime extends Fake implements MihonRuntime {
+  @override
+  Future<void> dispose() async {}
+}

--- a/hibiki/test/media/manga/mihon_default_store_seed_test.dart
+++ b/hibiki/test/media/manga/mihon_default_store_seed_test.dart
@@ -16,6 +16,9 @@ import 'package:hibiki/src/media/manga/mihon/mihon_extension_store_client.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_manager.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_runtime.dart';
 import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+import '../../helpers/source_guard.dart';
 
 void main() {
   late Directory root;
@@ -36,6 +39,7 @@ void main() {
         rootDirectory: root,
         runtime: _SeedRuntime(),
         storeClient: client,
+        seedDefaultStore: true,
       );
 
   test('首次初始化自动装上 keiyoushi 仓库，且只拉这一个索引', () async {
@@ -93,6 +97,31 @@ void main() {
     expect(
       online.stores.map((MangaExtensionStoreRow row) => row.indexUrl),
       contains(kMihonDefaultStoreIndexUrl),
+    );
+  });
+
+  // 装默认仓库是**应用启动策略**，不是「构造一个 manager」的语义。挂成 manager
+  // 的默认行为，等于让每个构造 manager 的单测都去拉 keiyoushi 的真实索引
+  // （1900+ 条）——本轮就是这样把 `mihon_manager_install_test` 那条 cold-start
+  // 用例打红的：setUp 里种进来的默认仓库让后续 refresh 多刷了一个仓库。
+  test('默认仓库装配默认关闭，只有真实 app 启动那一处打开', () {
+    final String managerSource = maskComments(
+      File(p.join(
+              'lib', 'src', 'media', 'manga', 'mihon', 'mihon_manager.dart'))
+          .readAsStringSync(),
+    );
+    expect(
+      managerSource,
+      contains('this.seedDefaultStore = false'),
+      reason: '构造 manager 不得默认触发网络装配',
+    );
+    final String appModelSource = maskComments(
+      File(p.join('lib', 'src', 'models', 'app_model.dart')).readAsStringSync(),
+    );
+    expect(
+      appModelSource,
+      contains('seedDefaultStore: true'),
+      reason: '真实 app 启动必须开，否则用户拿不到默认仓库',
     );
   });
 }

--- a/hibiki/test/media/manga/mihon_extensions_page_test.dart
+++ b/hibiki/test/media/manga/mihon_extensions_page_test.dart
@@ -12,6 +12,11 @@ import 'package:hibiki/src/media/manga/mihon/mihon_runtime.dart';
 import 'package:hibiki/utils.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
+/// keiyoushi 这类真实仓库的索引地址：注意路径里带 `raw`（GitHub 原始文件直链）。
+/// BUG-1430 的一半根因就长在这个字符串上——它曾经是可搜字段。
+const String _kRepoIndexUrl =
+    'https://github.com/keiyoushi/extensions/raw/repo/index.pb';
+
 void main() {
   late Directory root;
   late HibikiDatabase database;
@@ -55,8 +60,7 @@ void main() {
     if (await root.exists()) await root.delete(recursive: true);
   });
 
-  testWidgets('search filters extensions by normalized name and package',
-      (WidgetTester tester) async {
+  Future<void> pumpStandalone(WidgetTester tester) async {
     await tester.binding.setSurfaceSize(const Size(1400, 900));
     addTearDown(() => tester.binding.setSurfaceSize(null));
     await tester.pumpWidget(
@@ -70,6 +74,11 @@ void main() {
       ),
     );
     await tester.pump();
+  }
+
+  testWidgets('search filters extensions by normalized name and package',
+      (WidgetTester tester) async {
+    await pumpStandalone(tester);
 
     expect(find.text('フェイト Extension'), findsOneWidget);
     expect(find.text('Unrelated extension'), findsOneWidget);
@@ -89,11 +98,96 @@ void main() {
     expect(find.text('Unrelated extension'), findsOneWidget);
   });
 
+  // BUG-1430（其一）：可搜字段里混进了**仓库级**的 `storeUrl`。同一个仓库的每个
+  // 扩展 storeUrl 完全一样，于是任何命中该 URL 的查询都会「命中全部」——用户搜
+  // 「raw」（想找 RawKuma 这类生肉源），keiyoushi 索引地址里的斜杠 raw 斜杠让 1900
+  // 个扩展一个不少地留下来，看上去就是「筛选完全不生效」。
+  testWidgets('搜索不吃仓库 URL：搜 raw 只留名字里真有 raw 的扩展', (WidgetTester tester) async {
+    manager.available = <MihonAvailableExtension>[
+      _extension(
+        name: 'RawKuma',
+        packageName: 'org.example.rawkuma',
+        sourceName: 'RawKuma',
+        storeUrl: _kRepoIndexUrl,
+      ),
+      _extension(
+        name: 'AHottie',
+        packageName: 'org.example.ahottie',
+        sourceName: 'AHottie',
+        storeUrl: _kRepoIndexUrl,
+      ),
+      _extension(
+        name: 'Akuma',
+        packageName: 'org.example.akuma',
+        sourceName: 'Akuma',
+        storeUrl: _kRepoIndexUrl,
+      ),
+    ];
+    await pumpStandalone(tester);
+    expect(find.text('AHottie'), findsWidgets);
+
+    await tester.enterText(
+      find.byKey(const ValueKey<String>('mihon_extension_search_field')),
+      'raw',
+    );
+    await tester.pump();
+
+    expect(find.text('RawKuma'), findsWidgets);
+    expect(
+      find.text('AHottie'),
+      findsNothing,
+      reason: '仓库索引地址里的 raw 不该把整个仓库都算作命中',
+    );
+    expect(find.text('Akuma'), findsNothing);
+  });
+
+  // BUG-1430（其二）：语言下拉选 JA 时，实现额外放行 language 为 all 的扩展。
+  // keiyoushi 的 all 多是多语言聚合站，于是选了日语整屏还是 all——用户口径同样
+  // 是「筛选不生效」。all 现在是下拉里的一个普通选项，选 JA 就只有 JA。
+  testWidgets('语言选 JA 不再混进 all 语言的扩展', (WidgetTester tester) async {
+    manager.available = <MihonAvailableExtension>[
+      _extension(
+        name: 'Japanese only',
+        packageName: 'org.example.ja',
+        sourceName: 'JA source',
+        language: 'ja',
+      ),
+      _extension(
+        name: 'Multi language',
+        packageName: 'org.example.all',
+        sourceName: 'ALL source',
+        language: 'all',
+      ),
+    ];
+    await pumpStandalone(tester);
+    expect(find.text('Japanese only'), findsOneWidget);
+    expect(find.text('Multi language'), findsOneWidget);
+
+    await tester.tap(find.byType(DropdownButtonFormField<String>));
+    await tester.pumpAndSettle();
+    // 展开后的菜单项挂在 Overlay 里（树序在后），关闭态那份在 DropdownButton 自己的
+    // IndexedStack 里；`.last` 取的是菜单那份。先 ensureVisible 再点，免得菜单
+    // 正好把它排在需要滚动的位置。
+    final Finder languageItem =
+        find.byKey(const ValueKey<String>('mihon_extension_language_ja')).last;
+    await tester.ensureVisible(languageItem);
+    await tester.pumpAndSettle();
+    // warnIfMissed: false —— 命中的是菜单项外面那层 `_DropdownMenuItemButton`
+    // 的 InkWell（真实用户点击也是它接手），DropdownMenuItem 自己不是 hit target。
+    await tester.tap(languageItem, warnIfMissed: false);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Japanese only'), findsOneWidget);
+    expect(find.text('Multi language'), findsNothing);
+  });
+
   // 用户口径：漫画扩展不另开顶层 tab，收进「来源」视图当一节。那一节的宿主是
-  // 「来源」视图自己的 ListView，所以这一页必须能在**无界高度 + 外层已在滚动**
-  // 的语境里渲染：既不能自带第二层可滚动列表（嵌套滚动 = 约束异常），也不能再
-  // 摆一套页面 chrome（外层已有页头）。同时三个页头动作一个都不能丢。
-  testWidgets('embedded 模式可直接塞进「来源」视图的 ListView：无 chrome、无自带滚动、动作齐全',
+  // 「来源」视图自己的滚动容器，所以这一页必须能在**外层已在滚动**的语境里渲染：
+  // 既不能自带第二层可滚动列表，也不能再摆一套页面 chrome。同时三个页头动作
+  // 一个都不能丢。
+  //
+  // BUG-1430：宿主现在是 CustomScrollView，内嵌节返回 sliver。
+  testWidgets('embedded 模式可直接塞进「来源」视图的 CustomScrollView：无 chrome、无自带滚动、动作齐全',
       (WidgetTester tester) async {
     await tester.binding.setSurfaceSize(const Size(1400, 900));
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -102,11 +196,11 @@ void main() {
         child: MaterialApp(
           theme: ThemeData.light(useMaterial3: true),
           home: Scaffold(
-            body: ListView(
-              children: <Widget>[
-                const Text('outer-section-above'),
+            body: CustomScrollView(
+              slivers: <Widget>[
+                const SliverToBoxAdapter(child: Text('outer-section-above')),
                 MihonExtensionsPage(manager: manager, embedded: true),
-                const Text('outer-section-below'),
+                const SliverToBoxAdapter(child: Text('outer-section-below')),
               ],
             ),
           ),
@@ -117,12 +211,12 @@ void main() {
 
     // 真渲染出扩展条目，不是空壳。
     expect(find.text('フェイト Extension'), findsOneWidget);
-    // 上下两节都在——说明它没有把外层 ListView 撑爆或吞掉兄弟节点。
+    // 上下两节都在——说明它没有把外层滚动容器撑爆或吞掉兄弟节点。
     expect(find.text('outer-section-above'), findsOneWidget);
     expect(find.text('outer-section-below'), findsOneWidget);
-    // 整棵树只有外层那一个纵向滚动列表：内嵌节不得再嵌一层
-    // （搜索框内部的横向 editable Scrollable 不算，所以判据锚在 ListView 上）。
-    expect(find.byType(ListView), findsOneWidget);
+    // 整棵树只有外层那一个纵向滚动容器：内嵌节不得再嵌一层。
+    expect(find.byType(CustomScrollView), findsOneWidget);
+    expect(find.byType(ListView), findsNothing);
     // 页头三动作降级成本节顶部按钮行，能力不减。
     expect(find.text(t.mihon_store_refresh), findsWidgets);
     expect(find.text(t.mihon_extension_import), findsWidgets);
@@ -132,15 +226,56 @@ void main() {
     expect(find.byType(DesktopContentLayout), findsNothing);
     expect(tester.takeException(), null);
   });
+
+  // BUG-1430（其三，也是「下拉框很卡」的真正来源）：内嵌节以前是裸 Column，
+  // keiyoushi 的 1900+ 个扩展会全部实体化成 RenderObject —— Column 没有视口
+  // 裁剪，每帧都要布局并绘制全部条目。这条守卫锚在「视口外的条目根本没被建出来」
+  // 上：改回 Column（或任何非 sliver 容器）都会让它变红。
+  testWidgets('内嵌节懒建：视口外的扩展不进 widget 树', (WidgetTester tester) async {
+    manager.available = <MihonAvailableExtension>[
+      for (int i = 0; i < 300; i++)
+        _extension(
+          name: 'Extension $i',
+          packageName: 'org.example.e$i',
+          sourceName: 'Source $i',
+        ),
+    ];
+    await tester.binding.setSurfaceSize(const Size(1400, 900));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          theme: ThemeData.light(useMaterial3: true),
+          home: Scaffold(
+            body: CustomScrollView(
+              slivers: <Widget>[
+                MihonExtensionsPage(manager: manager, embedded: true),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.text('Extension 0'), findsOneWidget);
+    expect(
+      find.text('Extension 299'),
+      findsNothing,
+      reason: '末尾条目远在视口之外，懒建的话根本不该存在于 widget 树里',
+    );
+  });
 }
 
 MihonAvailableExtension _extension({
   required String name,
   required String packageName,
   required String sourceName,
+  String storeUrl = 'https://repo.example/index.json',
+  String language = 'ja',
 }) =>
     MihonAvailableExtension(
-      storeUrl: 'https://repo.example/index.json',
+      storeUrl: storeUrl,
       name: name,
       packageName: packageName,
       apkUrl: 'https://repo.example/$packageName.apk',
@@ -148,13 +283,13 @@ MihonAvailableExtension _extension({
       libVersion: '1.6',
       versionCode: 1,
       versionName: '1.6.1',
-      language: 'ja',
+      language: language,
       contentWarning: 0,
       sources: <MihonAvailableSource>[
         MihonAvailableSource(
           id: packageName,
           name: sourceName,
-          language: 'ja',
+          language: language,
           baseUrl: 'https://source.example/$packageName',
         ),
       ],

--- a/hibiki/test/pages/manga_sources_view_composition_test.dart
+++ b/hibiki/test/pages/manga_sources_view_composition_test.dart
@@ -51,6 +51,27 @@ void main() {
       expect(sources, contains('_buildOnlineSource('));
       expect(sources, contains('t.mihon_sources_title'));
     });
+
+    // BUG-1431，用户口径：「mokuro 不应该单独显示，应该和漫画扩展同一层级」。
+    // 它此前是「本地扫描根」一节里的一行（和 Hibiki 互联并排），但它是个网站。
+    test('mokuro.moe 归「漫画源」一节，不再挂在本地扫描根下', () {
+      expect(sources, contains('MokuroMoeSourceRow()'));
+      expect(
+        sources.indexOf('MokuroMoeSourceRow()'),
+        greaterThan(sources.indexOf('t.mihon_sources_title')),
+        reason: '它必须排在「漫画源」小标题之后，与扩展提供的在线源同节',
+      );
+      final String localRoots = maskComments(
+        File(p.join('lib', 'src', 'pages', 'implementations',
+                'media_sources_view.dart'))
+            .readAsStringSync(),
+      );
+      expect(
+        localRoots,
+        isNot(contains('Mokuro')),
+        reason: '共享的扫描根视图（书/视频/漫画三域共用）里不得再出现在线站点',
+      );
+    });
   });
 
   group('iOS / Linux 导航结构与其它平台相同', () {
@@ -85,6 +106,13 @@ void main() {
         browse,
         contains('MihonSourceBrowsePage('),
         reason: '已启用的 Mihon 在线源要能从「浏览」直接进内容，不是只在设置里躺着',
+      );
+      // BUG-1431：mokuro.moe 与扩展源遵守同一条可见性规则——「来源」里关掉的源
+      // 不出现在「浏览」里。以前它那个开关只让目录页显示成禁用态，行照旧列着。
+      expect(
+        browse,
+        contains('isMokuroMoeSourceEnabled('),
+        reason: '「浏览」必须尊重「来源」里的 mokuro.moe 开关，否则同一节两种开关语义',
       );
     });
   });

--- a/hibiki/test/pages/media_sources_dialog_test.dart
+++ b/hibiki/test/pages/media_sources_dialog_test.dart
@@ -1,5 +1,5 @@
 // TODO-817 M1c MediaSourcesDialog widget 行为 + 源码守卫测试：
-//  (1) 空扫描根仍显示 Hibiki 互联；漫画还显示独立可开关的 Mokuro.moe。
+//  (1) 空扫描根仍显示 Hibiki 互联；漫画**不再**在这里显示 Mokuro.moe（BUG-1431）。
 //  (2) 预置 video 来源 -> 按 sortOrder 渲染 label/rootPath/统计文案。
 //  (3) lastScanError != null -> 显示 media_source_scan_error。
 //  (4) 移除来源 -> 确认对话框含 media_source_remove_keeps_media；确认后该来源消失，
@@ -122,7 +122,7 @@ void main() {
     expect(find.text('No sources yet'), findsNothing);
   });
 
-  testWidgets('manga sources compose interconnect, internet and every folder',
+  testWidgets('manga sources compose interconnect and every folder — 但不含在线站点',
       (tester) async {
     final HibikiDatabase db = _memDb();
     addTearDown(db.close);
@@ -143,7 +143,10 @@ void main() {
     await _pumpDialog(tester, db, 'manga');
 
     expect(find.text('Hibiki Interconnect'), findsOneWidget);
-    expect(find.text('Mokuro.moe'), findsOneWidget);
+    // BUG-1431：mokuro.moe 是个网站，不是扫描根，已挪到「来源」视图的「漫画源」
+    // 一节（`MokuroMoeSourceRow`），与扩展提供的在线源同级。这条反向锚防止它被
+    // 重新塞回本地扫描根列表。
+    expect(find.text('Mokuro.moe'), findsNothing);
     expect(find.text('Manga A'), findsOneWidget);
     expect(find.text(r'D:\manga\a'), findsOneWidget);
     expect(find.text('Manga B'), findsOneWidget);


### PR DESCRIPTION
用户报告三件事，都已根因修复。

## BUG-1430 · 筛选不生效 + 语言下拉很卡

三个独立根因叠在一起：

1. **搜索被仓库级字段打成全命中**。可搜字段里混进了 `extension.storeUrl`——它是**仓库级**的，同一仓库里每个扩展完全一样。keiyoushi 的索引地址是 `https://github.com/keiyoushi/extensions/raw/repo/index.pb`，经 `normalizeMediaSearchText` 丢掉标点后含 `raw` / `github` / `repo` / `index`，所以搜 `raw` 时该仓库 1900+ 个扩展一个不漏地全部命中，看起来就是「筛选完全不生效」。可搜字段收敛为**条目自身**的标识：扩展名 / 包名 / 它提供的源名与域名。低基数的 `language` 也一并剔除（已有专门的语言下拉）。
2. **语言过滤有无条件通行分支**。`extension.language.toLowerCase() == 'all'` 让所有多语言扩展在选任何语言时都放行；keiyoushi 的 `all` 大多是聚合站，于是「选了 JA，整屏还是 all」。`all` 降级为语言下拉里的一个普通选项（显示 `ALL`，与条目副标题里的 `all · 1.6.4 · lib 1.6` 同词），消掉特例分支；本地独有扩展也跟随语言过滤。
3. **列表非懒建 —— 这才是「卡」的真正来源**。`MihonExtensionsPage(embedded: true)` 返回裸 `Column`，宿主是 `ListView` + 单个巨型 child。`Column` 没有视口裁剪，1900+ 个条目全部实体化成 RenderObject 并每帧参与布局/绘制；下拉一展开就是连续动画帧，于是卡死。内嵌形态改为返回 sliver（`SliverMainAxisGroup` + `SliverList.builder`），`MangaSourcesPage` 的滚动容器换成 `CustomScrollView`，只建视口内那十几行。

## BUG-1431 · mokuro.moe 应与漫画扩展同级

它此前被特判进了书 / 视频 / 漫画三域**共用**的「本地扫描根」一节（和 Hibiki 互联并排），但它是个网站。新增 `MokuroMoeSourceRow`，放进「漫画源」一节最前，与扩展提供的在线源同构同级；`MediaSourcesView` 摘掉 manga 特判，恢复成纯扫描根视图。

顺带修掉一个开关语义不一致：以前关掉 mokuro.moe 只让它的目录页显示成禁用态，「浏览」里那一行照旧列着（该页硬编码首行、根本不读这个偏好）。现在两者遵守同一条规则——关掉的源不出现在「浏览」里。默认值仍是 true，既有行为不变。

## 另：默认扩展仓库

首次启动自动装配 keiyoushi 的 `index.pb`（用户诉求），只装一次——删掉后重启不会被塞回来；拉不到不致命，下次启动重试，且不在扩展页挂报错。

装配是**应用启动策略**而非 manager 构造语义：`MihonManager.seedDefaultStore` 默认 `false`，只有 `AppModel.mihonManager` 那一处传 `true`。挂成默认行为会让每个构造 manager 的单测都去拉真实网络索引——本轮确实把 `mihon_manager_install_test` 的 cold-start 用例打红过（setUp 里种进来的仓库让后续 refresh 多刷一个，`available` 变成 2 条），已补源码守卫钉住两端。

## 验证

- `flutter analyze`（含 test 目录）：**No issues found**。
- 新增/改动的守卫**全部做过变异实测**：把 `storeUrl` 加回可搜字段 / 把 `== 'all'` 分支加回来 / 把内嵌节换回 `Column` / 拿掉默认仓库装配 —— 对应用例分别变红，还原后全绿。
- 爆炸半径定向扫（`test/media/manga` + `test/pages` + `test/models` + `test/tools`）：3610 项，唯一失败是 `local_audio_manager_test` 的 Windows `%TEMP%` 删除锁（`errno = 32`），隔离重跑 `VERDICT: PASSED - 18 tests ran`。
- 全量套件跑过两次完整（17159 / 17160 项）。出现过的失败全部在本轮 diff 之外的文件，逐个隔离重跑均通过：`update_manifest_publish_race_test`（PowerShell 环境缺 `bash`）、`image_chapter_pause_cancel_test`、`hibiki_library_host_service_books_test`、`local_audio_manager_test`（均为 `%TEMP%` / 时序竞态）。
- ⚠️ 未能拿到一条「全量套件一次全绿」的 VERDICT 行：本机同时有 **7~8 个其它会话的全量套件在跑**，共用 `%TEMP%` 与 native assets，必然互相踩出无关文件的文件锁失败。按仓库既有分级判据（并发 ≥3 时判绿门下调为「analyze 全量绿 + 定向绿」）收口。合入前建议在低并发时机补跑一次全量。
- 本分支上只触发了 SonarCloud（pass）；真正的单测门 `Build Release APK / Run unit tests` 未在此 draft 分支触发，不能当兜底。

## 尚未覆盖

用户同一条消息里还提到「书架 / 视频 / 游戏也加在线来源」「TMW 有声书 nyaa 源 + 配套 srt」——那是独立的大工程（其余三域连「浏览」视图都还没有），不在本 PR 范围。

https://claude.ai/code/session_01BtrWLsRcTG3TAPnZVp8Cn5
