### PR TITLE
feat(manga): 整卷 OCR 出厂默认引擎改成 Google Lens

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 52343 (3079 per locale)
 ///
-/// Built on 2026-08-02 at 03:29 UTC
+/// Built on 2026-08-02 at 05:19 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3530,7 +3530,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_ocr_engine_google_lens => 'Google Lens';
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   String get manga_google_lens_disclosure_body =>
@@ -10156,7 +10156,7 @@ class _StringsAr extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -17289,7 +17289,7 @@ class _StringsDe extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -24437,7 +24437,7 @@ class _StringsEs extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -31597,7 +31597,7 @@ class _StringsFr extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -38686,7 +38686,7 @@ class _StringsId extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -45821,7 +45821,7 @@ class _StringsIt extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -52773,7 +52773,7 @@ class _StringsJa extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -59727,7 +59727,7 @@ class _StringsKo extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -66842,7 +66842,7 @@ class _StringsNl extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -73970,7 +73970,7 @@ class _StringsPtBr extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -81082,7 +81082,7 @@ class _StringsRu extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -88142,7 +88142,7 @@ class _StringsTh extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -95234,7 +95234,7 @@ class _StringsTr extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -102311,7 +102311,7 @@ class _StringsVi extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -108971,7 +108971,7 @@ class _StringsZhCn extends _StringsEn {
   String get manga_google_lens_section => '整页识别（Google Lens）';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens 使用 Chromium 的非公开接口。仅在你明确选择 Lens 时上传页面；自动模式绝不会上传。';
+      'Google Lens 使用 Chromium 的非公开接口。Lens 是默认引擎，但只有你在本设备同意一次性提示后才会上传页面；自动模式绝不会上传。';
   @override
   String get manga_google_lens_disclosure_title => '将漫画页面发送到 Google Lens？';
   @override
@@ -115769,7 +115769,7 @@ class _StringsZhHk extends _StringsEn {
   String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
   @override
   String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -122222,7 +122222,7 @@ extension on _StringsEn {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -128537,7 +128537,7 @@ extension on _StringsAr {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -134874,7 +134874,7 @@ extension on _StringsDe {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -141210,7 +141210,7 @@ extension on _StringsEs {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -147552,7 +147552,7 @@ extension on _StringsFr {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -153876,7 +153876,7 @@ extension on _StringsId {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -160214,7 +160214,7 @@ extension on _StringsIt {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -166514,7 +166514,7 @@ extension on _StringsJa {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -172818,7 +172818,7 @@ extension on _StringsKo {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -179150,7 +179150,7 @@ extension on _StringsNl {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -185479,7 +185479,7 @@ extension on _StringsPtBr {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -191813,7 +191813,7 @@ extension on _StringsRu {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -198130,7 +198130,7 @@ extension on _StringsTh {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -204456,7 +204456,7 @@ extension on _StringsTr {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -210778,7 +210778,7 @@ extension on _StringsVi {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -217053,7 +217053,7 @@ extension on _StringsZhCn {
       case 'manga_google_lens_section':
         return '整页识别（Google Lens）';
       case 'manga_google_lens_privacy':
-        return 'Google Lens 使用 Chromium 的非公开接口。仅在你明确选择 Lens 时上传页面；自动模式绝不会上传。';
+        return 'Google Lens 使用 Chromium 的非公开接口。Lens 是默认引擎，但只有你在本设备同意一次性提示后才会上传页面；自动模式绝不会上传。';
       case 'manga_google_lens_disclosure_title':
         return '将漫画页面发送到 Google Lens？';
       case 'manga_google_lens_disclosure_body':
@@ -223341,7 +223341,7 @@ extension on _StringsZhHk {
       case 'manga_google_lens_section':
         return 'Full-page OCR (Google Lens)';
       case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.';
+        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52343 (3079 per locale)
+/// Strings: 52309 (3077 per locale)
 ///
-/// Built on 2026-08-02 at 05:19 UTC
+/// Built on 2026-08-02 at 05:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -3528,9 +3528,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_ocr_engine_auto => 'Automatic (never uploads to Lens)';
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   String get manga_google_lens_disclosure_body =>
@@ -10152,11 +10149,6 @@ class _StringsAr extends _StringsEn {
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -17285,11 +17277,6 @@ class _StringsDe extends _StringsEn {
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -24433,11 +24420,6 @@ class _StringsEs extends _StringsEn {
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -31594,11 +31576,6 @@ class _StringsFr extends _StringsEn {
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
   @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
-  @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   @override
@@ -38682,11 +38659,6 @@ class _StringsId extends _StringsEn {
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -45818,11 +45790,6 @@ class _StringsIt extends _StringsEn {
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
   @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
-  @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   @override
@@ -52769,11 +52736,6 @@ class _StringsJa extends _StringsEn {
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -59723,11 +59685,6 @@ class _StringsKo extends _StringsEn {
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -66838,11 +66795,6 @@ class _StringsNl extends _StringsEn {
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -73967,11 +73919,6 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
   @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
-  @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   @override
@@ -81079,11 +81026,6 @@ class _StringsRu extends _StringsEn {
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
   @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
-  @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   @override
@@ -88138,11 +88080,6 @@ class _StringsTh extends _StringsEn {
   String get manga_ocr_engine_local_onnx => 'Local ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
   @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
@@ -95231,11 +95168,6 @@ class _StringsTr extends _StringsEn {
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
   @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
-  @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   @override
@@ -102308,11 +102240,6 @@ class _StringsVi extends _StringsEn {
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
   @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
-  @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   @override
@@ -108967,11 +108894,6 @@ class _StringsZhCn extends _StringsEn {
   String get manga_ocr_engine_local_onnx => '本地 ONNX';
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
-  @override
-  String get manga_google_lens_section => '整页识别（Google Lens）';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens 使用 Chromium 的非公开接口。Lens 是默认引擎，但只有你在本设备同意一次性提示后才会上传页面；自动模式绝不会上传。';
   @override
   String get manga_google_lens_disclosure_title => '将漫画页面发送到 Google Lens？';
   @override
@@ -115766,11 +115688,6 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get manga_ocr_engine_google_lens => 'Google Lens';
   @override
-  String get manga_google_lens_section => 'Full-page OCR (Google Lens)';
-  @override
-  String get manga_google_lens_privacy =>
-      'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
-  @override
   String get manga_google_lens_disclosure_title =>
       'Send manga pages to Google Lens?';
   @override
@@ -122219,10 +122136,6 @@ extension on _StringsEn {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -128534,10 +128447,6 @@ extension on _StringsAr {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -134871,10 +134780,6 @@ extension on _StringsDe {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -141207,10 +141112,6 @@ extension on _StringsEs {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -147549,10 +147450,6 @@ extension on _StringsFr {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -153873,10 +153770,6 @@ extension on _StringsId {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -160211,10 +160104,6 @@ extension on _StringsIt {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -166511,10 +166400,6 @@ extension on _StringsJa {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -172815,10 +172700,6 @@ extension on _StringsKo {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -179147,10 +179028,6 @@ extension on _StringsNl {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -185476,10 +185353,6 @@ extension on _StringsPtBr {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -191810,10 +191683,6 @@ extension on _StringsRu {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -198127,10 +197996,6 @@ extension on _StringsTh {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -204453,10 +204318,6 @@ extension on _StringsTr {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -210775,10 +210636,6 @@ extension on _StringsVi {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':
@@ -217050,10 +216907,6 @@ extension on _StringsZhCn {
         return '本地 ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return '整页识别（Google Lens）';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens 使用 Chromium 的非公开接口。Lens 是默认引擎，但只有你在本设备同意一次性提示后才会上传页面；自动模式绝不会上传。';
       case 'manga_google_lens_disclosure_title':
         return '将漫画页面发送到 Google Lens？';
       case 'manga_google_lens_disclosure_body':
@@ -223338,10 +223191,6 @@ extension on _StringsZhHk {
         return 'Local ONNX';
       case 'manga_ocr_engine_google_lens':
         return 'Google Lens';
-      case 'manga_google_lens_section':
-        return 'Full-page OCR (Google Lens)';
-      case 'manga_google_lens_privacy':
-        return 'Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.';
       case 'manga_google_lens_disclosure_title':
         return 'Send manga pages to Google Lens?';
       case 'manga_google_lens_disclosure_body':

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "本地 ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "整页识别（Google Lens）",
-  "manga_google_lens_privacy": "Google Lens 使用 Chromium 的非公开接口。仅在你明确选择 Lens 时上传页面；自动模式绝不会上传。",
+  "manga_google_lens_privacy": "Google Lens 使用 Chromium 的非公开接口。Lens 是默认引擎，但只有你在本设备同意一次性提示后才会上传页面；自动模式绝不会上传。",
   "manga_google_lens_disclosure_title": "将漫画页面发送到 Google Lens？",
   "manga_google_lens_disclosure_body": "识别本漫画会把尚无 OCR 文本的页面缩小为 JPEG 后发送给 Google，结果缓存在本设备。该接口并非官方公开 API，可能随时失效。只有同意后才会上传。",
   "manga_google_lens_disclosure_accept": "同意并开始识别",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "自动（不会上传到 Lens）",
   "manga_ocr_engine_local_onnx": "本地 ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "整页识别（Google Lens）",
-  "manga_google_lens_privacy": "Google Lens 使用 Chromium 的非公开接口。Lens 是默认引擎，但只有你在本设备同意一次性提示后才会上传页面；自动模式绝不会上传。",
   "manga_google_lens_disclosure_title": "将漫画页面发送到 Google Lens？",
   "manga_google_lens_disclosure_body": "识别本漫画会把尚无 OCR 文本的页面缩小为 JPEG 后发送给 Google，结果缓存在本设备。该接口并非官方公开 API，可能随时失效。只有同意后才会上传。",
   "manga_google_lens_disclosure_accept": "同意并开始识别",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2637,7 +2637,7 @@
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
   "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Pages are uploaded only when you explicitly select Lens; Automatic mode never uploads them.",
+  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -2636,8 +2636,6 @@
   "manga_ocr_engine_auto": "Automatic (never uploads to Lens)",
   "manga_ocr_engine_local_onnx": "Local ONNX",
   "manga_ocr_engine_google_lens": "Google Lens",
-  "manga_google_lens_section": "Full-page OCR (Google Lens)",
-  "manga_google_lens_privacy": "Google Lens uses an unofficial Chromium endpoint. Lens is the default engine, but no page is uploaded until you accept the one-time consent prompt on this device; Automatic mode never uploads pages at all.",
   "manga_google_lens_disclosure_title": "Send manga pages to Google Lens?",
   "manga_google_lens_disclosure_body": "Recognizing this manga sends a reduced JPEG copy of each page without OCR text to Google. Results are cached on this device. The endpoint is unofficial and may stop working. Nothing is uploaded unless you agree.",
   "manga_google_lens_disclosure_accept": "Agree and start OCR",

--- a/hibiki/lib/src/media/manga/manga_ocr_settings_section.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_settings_section.dart
@@ -11,10 +11,11 @@ import 'package:hibiki/utils.dart';
 
 /// 设置区「漫画 OCR」组的正文（内联进阅读设置分类）。
 ///
-/// 内容：内置 OCR 模型状态行（已下载/未下载 + 体积）、下载按钮（进度条 + 可取消）、
-/// 删除按钮（二次确认）。本地模型只在支持整卷 ONNX 的平台显示；下方是外部
-/// mokuro CLI 路径设置（仅桌面）和 Google Lens 整页上传说明。旧的单框 Gemini
-/// 配置不再渲染。
+/// 内容：默认引擎下拉、内置 OCR 模型状态行（已下载/未下载 + 体积）、下载按钮
+/// （进度条 + 可取消）、删除按钮（二次确认）。本地模型只在支持整卷 ONNX 的平台
+/// 显示；下方是外部 mokuro CLI 路径设置（仅桌面）。旧的单框 Gemini 配置和 Google
+/// Lens 说明段落均不再渲染——Lens 的上传告知由首次使用时的
+/// `ensureGoogleLensDisclosure` 同意弹窗承担，设置页不再重复一遍。
 ///
 /// 服务经构造参数注入（不 `ref.read` provider），偏好与外部探测提供可注入默认实现，
 /// 故最小 widget 测试注 fake 即可独立编译/通过；真实接线由 `settings_schema_manga_ocr.dart`
@@ -275,8 +276,6 @@ class _MangaOcrSettingsSectionState
           const SizedBox(height: 16),
           _buildExternalBlock(theme),
         ],
-        const SizedBox(height: 16),
-        _buildLensBlock(theme),
       ],
     );
   }
@@ -317,20 +316,6 @@ class _MangaOcrSettingsSectionState
         setState(() => _enginePreference = value);
         unawaited(_writeEnginePreference(value));
       },
-    );
-  }
-
-  Widget _buildLensBlock(ThemeData theme) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: <Widget>[
-        _sectionLabel(theme, t.manga_google_lens_section),
-        Text(
-          t.manga_google_lens_privacy,
-          style: theme.textTheme.bodySmall
-              ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
-        ),
-      ],
     );
   }
 

--- a/hibiki/lib/src/media/manga/manga_ocr_settings_section.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_settings_section.dart
@@ -254,10 +254,11 @@ class _MangaOcrSettingsSectionState
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
         _sectionLabel(theme, t.manga_ocr_section),
-        if (isDesktopPlatform) ...<Widget>[
-          _buildEnginePreference(theme),
-          const SizedBox(height: 12),
-        ],
+        // 引擎下拉全平台显示：出厂默认已是 Google Lens（会上传页面），把开关关在
+        // 桌面里等于让移动端用户无法持久地退回离线引擎。外部 mokuro 是桌面工具，
+        // 由下拉项自身 disable，不再靠整块 gating。
+        _buildEnginePreference(theme),
+        const SizedBox(height: 12),
         if (widget.service.isSupportedPlatform)
           _buildModelBlock(theme)
         else
@@ -303,8 +304,11 @@ class _MangaOcrSettingsSectionState
           value: MangaOcrEnginePreference.googleLens,
           child: Text(t.manga_ocr_engine_google_lens),
         ),
+        // 仍然出现在列表里（而不是按平台裁项）：裁项会让「已存 external_mokuro
+        // 的偏好」在移动端找不到匹配 value 而触发 Dropdown 断言。
         DropdownMenuItem<MangaOcrEnginePreference>(
           value: MangaOcrEnginePreference.externalMokuro,
+          enabled: isDesktopPlatform,
           child: Text(t.manga_ocr_engine_external),
         ),
       ],

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -1817,8 +1817,15 @@ class PreferencesRepository extends ChangeNotifier {
 
   /// PC 漫画整卷 OCR 默认引擎。稳定字符串而非 enum index，避免重排枚举破坏偏好。
   /// `auto` 的解析顺序由漫画模块统一控制，且永不自动跨到 Google Lens。
+  ///
+  /// 出厂默认是 `google_lens`：整页识别的版面/竖排质量明显优于本地 ONNX，且不
+  /// 依赖 1GB 级模型下载或桌面 mokuro CLI，是唯一「装完就能用」的引擎。这**不**
+  /// 削弱隐私边界——真正的上传闸门是 [ensureGoogleLensDisclosure] 的逐设备一次性
+  /// 同意弹窗，用户拒绝即不发任何字节；想彻底离线的用户把本偏好改回 `auto`，
+  /// `auto` 的解析链依旧永不跨到 Lens。
   String get mangaOcrEnginePreference =>
-      getPref('manga_ocr_engine_preference', defaultValue: 'auto') as String;
+      getPref('manga_ocr_engine_preference', defaultValue: 'google_lens')
+          as String;
 
   Future<void> setMangaOcrEnginePreference(String value) async {
     await setPref('manga_ocr_engine_preference', value);

--- a/hibiki/test/media/manga/ocr/manga_ocr_default_engine_test.dart
+++ b/hibiki/test/media/manga/ocr/manga_ocr_default_engine_test.dart
@@ -1,0 +1,103 @@
+/// 漫画整卷 OCR 的**出厂默认引擎** = Google Lens。
+///
+/// 默认值是纯数据、编译期无痕：写错成 `auto` 只表现为「用户不改设置就永远跑不出
+/// 满意的识别结果」，没有任何编译/运行期信号。这里把三件事一起钉死：
+/// - ① 未写过偏好的新装机读到 `google_lens`（默认值本身）；
+/// - ② 该字符串能被 [MangaOcrEnginePreferenceKey.fromKey] 认出——`fromKey` 的
+///   `default:` 分支会把任何拼错的键静默吞成 `auto`，只测 ① 抓不到这类错字；
+/// - ③ 显式偏好优先于能力探测：即使本地 ONNX 已就绪，解析结果仍是 Lens。
+///
+/// 隐私边界不变式（`auto` 永不跨到 Lens）由 `manga_ocr_engine_test.dart` 守；
+/// 默认改成 Lens 后真正的上传闸门是 `ensureGoogleLensDisclosure` 的逐设备同意弹窗。
+library;
+
+import 'package:drift/drift.dart' hide isNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/ocr/manga_ocr_engine.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+HibikiDatabase _testDb() {
+  return HibikiDatabase.forTesting(
+    DatabaseConnection(NativeDatabase.memory()),
+  );
+}
+
+void main() {
+  group('漫画 OCR 默认引擎', () {
+    late HibikiDatabase db;
+    late PreferencesRepository repo;
+
+    setUp(() async {
+      db = _testDb();
+      repo = PreferencesRepository(db);
+      await repo.loadFromDb();
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('新装机默认 = google_lens', () {
+      expect(repo.mangaOcrEnginePreference, 'google_lens');
+    });
+
+    test('默认字符串能被 fromKey 认出（不落到 auto 的兜底分支）', () {
+      expect(
+        MangaOcrEnginePreferenceKey.fromKey(repo.mangaOcrEnginePreference),
+        MangaOcrEnginePreference.googleLens,
+      );
+    });
+
+    test('用户改回 auto 后跨 reload 持久化（离线用户能彻底退出 Lens）', () async {
+      await repo.setMangaOcrEnginePreference(
+        MangaOcrEnginePreference.auto.key,
+      );
+      final PreferencesRepository reloaded = PreferencesRepository(db);
+      await reloaded.loadFromDb();
+      expect(reloaded.mangaOcrEnginePreference, 'auto');
+    });
+
+    test('默认偏好即使本地 ONNX 就绪也解析成 Lens（显式优先于探测）', () {
+      final MangaOcrEngineId? engine = resolveMangaOcrEngine(
+        preference: MangaOcrEnginePreferenceKey.fromKey(
+          repo.mangaOcrEnginePreference,
+        ),
+        hasExistingMetadata: false,
+        capabilities: const <MangaOcrEngineCapability>[
+          MangaOcrEngineCapability(
+            id: MangaOcrEngineId.localOnnx,
+            supported: true,
+            ready: true,
+            requiresNetwork: false,
+            uploadsImages: false,
+            supportsIncremental: true,
+          ),
+          MangaOcrEngineCapability(
+            id: MangaOcrEngineId.googleLens,
+            supported: true,
+            ready: true,
+            requiresNetwork: true,
+            uploadsImages: true,
+            supportsIncremental: true,
+          ),
+        ],
+      );
+      expect(engine, MangaOcrEngineId.googleLens);
+    });
+
+    test('已有 mokuro 元数据时默认引擎不触发任何 OCR', () {
+      expect(
+        resolveMangaOcrEngine(
+          preference: MangaOcrEnginePreferenceKey.fromKey(
+            repo.mangaOcrEnginePreference,
+          ),
+          hasExistingMetadata: true,
+          capabilities: const <MangaOcrEngineCapability>[],
+        ),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 为什么

默认 `auto` 的解析链是 本地 ONNX → 外部 mokuro → 配对主机，且**刻意永不跨到 Lens**（隐私边界）。后果是新装机在没下 1GB 级 ONNX 模型、也没配桌面 mokuro CLI 之前，`auto` 解析不出任何可用引擎；移动端更只剩「配对主机」这一条要求局域网另有一台 PC 的路。真正开箱即用、整页版面/竖排质量最好的引擎反而要用户自己去设置里翻出来选。

## 改了什么

- `PreferencesRepository.mangaOcrEnginePreference` 默认值 `auto` → `google_lens`。
- 引擎下拉从「仅桌面」放开到全平台：默认已是会上传的引擎，把开关关在桌面里等于让移动端用户无法持久地退回离线引擎。外部 mokuro 项保留在列表里但按平台 `enabled` ——按平台裁项会让已存 `external_mokuro` 的偏好在移动端找不到匹配 value 触发 Dropdown 断言。
- **删掉设置页底部的 Google Lens 说明段落**：「整页识别（Google Lens）」小标题 + 「Google Lens 使用 Chromium 的非公开接口……」一行整块移除，两个 i18n key（`manga_google_lens_section` / `manga_google_lens_privacy`）经 `i18n_sync --remove` 从 17 个 locale 一并摘掉。它是纯静态文字、无任何可操作控件，标题还容易被误读成第四个独立引擎。

## 隐私边界没有被削弱

上传闸门一直是 `ensureGoogleLensDisclosure` 的**逐设备一次性同意弹窗**（拒绝就不发任何字节），不是这条偏好、也不是被删掉的那段说明文字。`resolveMangaOcrEngine` 的 `auto` 解析链一字未动，仍永不跨到 Lens；想彻底离线的用户把偏好改回 `auto` 即可，且现在移动端也能改。

## 守卫

新增 `hibiki/test/media/manga/ocr/manga_ocr_default_engine_test.dart`：默认值本身、`fromKey` 不落兜底分支（防拼错键被静默吞成 auto）、显式偏好优先于能力探测、改回 `auto` 可跨 reload 持久化、已有 mokuro 元数据时不触发 OCR。

**变异实测**：把默认改回 `'auto'` → 5 例中 3 例红（`FLUTTER TEST VERDICT: FAILED`）；还原后全绿。

## 验证

- `flutter analyze`（含 test 目录）：`No issues found!`（默认值改动后、说明段落删除后各跑一次）
- `dart run tool/flutter_test_failures.dart --no-pub` 定向：manga OCR 引擎/向导/入口 5 个文件 → `PASSED - 18 tests ran`
- 同上，设置 section UI + settings schema coverage + `test/i18n` + OCR 引擎守卫 → `PASSED - 39 tests ran`
- 未做真机验证（本 PR 只改默认值、下拉可见性、删静态文案，无渲染或平台边界改动）。

https://claude.ai/code/session_01Scb6tzq5MDDkHJJnxjn9KK
