### PR TITLE
fix(manga): mokuro.moe 下载失败可重试 + 已入库漫画 OCR 按 manga.json 判定 (BUG-1433, BUG-1434)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1335 条。点号进各自文件。
+> 共 1337 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1434](bugs/BUG-1434-mokuro-book-ocr-no-images.md) | ✅ | ✅ | 已导入的 mokuro 漫画在 OCR 向导被误判为没有找到图片 |
+| [BUG-1433](bugs/BUG-1433-mokuro-download-no-retry.md) | ✅ | ✅ | mokuro.moe 卷下载失败后既无自动重试也无手动重试入口 |
 | [BUG-1432](bugs/BUG-1432-ime-physical-key-ledger.md) | ✅ | ✅ | TODO-2652「三处快捷键台账仍记裸 logicalKey」经查证伪：`LogicalKeyboardKey.process` 在 5 个出包平台上根本不可达 |
 | [BUG-1429](bugs/BUG-1429-bug-tool-number-pool-misses-uncommitted-worktrees.md) | ✅ | ✅ | bug.dart 取号扫不到并发工作区未提交的 bug 文件，一天连撞六次 |
 | [BUG-1428](bugs/BUG-1428-zero-context-patch-drift-silent.md) | ✅ | ✅ | 零上下文补丁漂移无声：git apply --unidiff-zero 对上游漂移 exit 0 后盲插 |

--- a/docs/bugs/BUG-1433-mokuro-download-no-retry.md
+++ b/docs/bugs/BUG-1433-mokuro-download-no-retry.md
@@ -1,0 +1,12 @@
+## BUG-1433 · mokuro.moe 卷下载失败后既无自动重试也无手动重试入口
+- **报告**：2026-08-02（用户：截图「下载 → 任务」页，`下载失败: SocketException: 信号灯超时时间已到 (OS Error: 信号灯超时时间已到, errno = 121), address = mokuro.moe, port = 9253`）
+- **真实性**：✅ 真 bug（两条都缺）
+  - 无自动重试：`hibiki/lib/src/media/manga/online/mokuro_moe_download_queue.dart:215`（旧行号）——`_finish` 里只要 error 不是 `MokuroMoeDownloadCancelled` 就直接 `status = failed` 终结。全链唯一的重试是 `mokuro_moe_volume_downloader.dart` 的 416 分支（针对坏 `.part`），与网络瞬断无关。mokuro.moe 是社区托管小站，连接超时是常态。
+  - 无手动重试：`hibiki/lib/src/media/manga/online/mokuro_moe_tasks_section.dart:147`（旧行号）——`trailing: task.isFinished ? null : 取消按钮`，失败行右侧是空的。用户只能回「在线目录」对话框重新找那一卷；重新入队会**新建一条任务**，失败那条僵在列表里（用户第二张截图：同名两行，`(1/2)`）。
+- **[x] ① 已修复** — 就地复活同一个任务对象（不新建行），`.part` 续传不重下已到字节：
+  - 新增非终态 `MokuroMoeTaskStatus.waitingRetry`：网络类瞬时失败按 `kMokuroMoeRetryBackoff`（2s/8s/20s）退避重排；退避**不占执行位**，队列继续跑后面的卷，到期回 `queued` 参与正常调度。
+  - 可重试判据 = 「再来一次可能就好了」：`SocketException` / `TimeoutException` / `TlsException` / 裸 `HttpException`；HTTP 只认 5xx/408/429。为此给 client 加了带状态码的 `MokuroMoeHttpException`（implements `HttpException`，旧类型判断不受影响）——否则 404 的卷会白白重试三轮几十秒。坏 zip 等本地数据错误不自动重试（重跑同一份坏数据不会变好）。
+  - `MokuroMoeDownloadQueue.retry(task)` / `retryAllFailed()`：failed/cancelled 就地回 `queued` 并清零自动重试计数；下载页失败行给「重试」按钮，区段头给「重试」批量按钮。
+  - 提交：见本分支 `fix(manga): mokuro.moe 下载失败自动重试 + 手动重试`
+- **[x] ② 已加自动化测试** — `hibiki/test/media/manga/online/mokuro_moe_download_queue_test.dart`（新增 11 例）：SocketException 退避后自动重跑同一对象、连续失败到上限落 failed、退避期间不占执行位、退避中取消掐掉定时器、404 不重试 / 503 重试、坏 zip 不重试、用户取消不重试、手动 retry 就地复活不新建行、done/进行中 no-op、`retryAllFailed` 条数与不动已成功项。
+- **备注**：断点续传语义本来就是好的（用户截图里重下从 30.0/36.8 MB 接上），缺的只是「回到那一卷」的路径。相关：[BUG-1434](BUG-1434-mokuro-book-ocr-no-images.md)（同一批 mokuro.moe 下载链路）。

--- a/docs/bugs/BUG-1434-mokuro-book-ocr-no-images.md
+++ b/docs/bugs/BUG-1434-mokuro-book-ocr-no-images.md
@@ -1,0 +1,14 @@
+## BUG-1434 · 已导入的 mokuro 漫画在 OCR 向导被误判为没有找到图片
+- **报告**：2026-08-02（用户：截图「OCR 导入漫画」对话框对已导入的 `Atsumare!Fushigi Kenkyubu 第01巻` 报「此文件夹中没有找到图片。」且「开始 OCR」禁用；用户同时指出「这个 mokuro 下载的应该不用 ocr 才对」——正确）
+- **真实性**：✅ 真 bug，两层根因都在「页图深度被当成常数」：
+  - `hibiki/lib/src/ocr/manga_ocr_folder_job.dart:110` `enumerateMangaPages` 只枚举「顶层文件 + **一层**子目录内的文件」。已入库书目录布局是 `manga.json` + `images/<destRel>`，而 destRel **保留源子目录结构**（`manga_importer.dart:242` `sanitizeRelSegments`）：mokuro.moe 的卷 CBZ 顶层带一个 `<卷名>/` 目录，页图因此落在 `images/<卷名>/001.jpg`（第 2 层子目录）→ 一页都枚举不到。裸图片导入的书是扁平的 `images/001.jpg`，所以只有 mokuro.moe 下载的卷中招。
+  - `hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart:1057` `checkOcrFolder` 对**已入库书目录**也按「裸图片文件夹」判定：同样的浅扫够不着深层页图，且「有没有 OCR」只认顶层 `.mokuro` 文件——而书里的 OCR 数据在 `manga.json` 里，不叫 `.mokuro`。于是一本能正常阅读、站点已附带完整 OCR 的书被判成 `noImages`。
+  - 附带确认：`openBookOcr` 的 `onlyMissing` 读的是 OCR 引擎自己的输出缓存（`google_lens_ocr_service.dart:203` `_readExistingPages(output)`），**不是**书里的 `manga.json`。所以真跑起来不会「只补缺失页」，而是把 mokuro.moe 的原生 OCR 全量重跑覆盖——这正是「不该对已有 OCR 的书跑 OCR」的理由。
+- **[x] ① 已修复** —
+  - `enumerateMangaPages` 改为递归下钻，上限 `kMangaPageScanMaxDepth = 6`（防误选磁盘根走穿目录树），每层都排除 `kMangaOcrOutDirName` 产物目录；无权限/瞬时 IO 的子目录跳过而非整卷失败。
+  - `checkOcrFolder` 分两种输入：**已入库书目录**（含 `manga.json`）以页表为准——每页都有 OCR 块 → 新增 `MangaOcrFolderStatus.alreadyOcred`（向导显示「本卷每一页都已有 OCR 数据，无需再跑（重跑会覆盖现有数据）」并禁用运行），有页缺块 → `valid`（可补齐），页表为空 → `noImages`，`manga.json` 读不动 → 退回文件扫描（「元数据坏了」不等于「没有图片」）；**裸图片文件夹**仍按文件判，但改用与 OCR 引擎同一个枚举器 `enumerateMangaPages`，消除「向导说有图、引擎说没页」的两套规则漂移。
+- **[x] ② 已加自动化测试** —
+  - 新增 `hibiki/test/media/manga/manga_ocr_folder_check_test.dart`（9 例，此前 `checkOcrFolder` 无测试）：mokuro.moe 卷（`images/<卷名>/*.jpg` + 每页有块）→ `alreadyOcred` 且显式断言 `isNot(noImages)`（用户症状）；部分页缺块 → `valid`；页表空 → `noImages`；`manga.json` 损坏退回扫描；裸文件夹 `.mokuro` → `hasMokuro`；深层图 → `valid`；无图 → `noImages`；不存在 → `notFound`。
+  - `hibiki/test/ocr/manga_ocr_folder_job_test.dart`：原断言「二层子目录：不收」是这条 bug 的行为快照，已连同理由改为「要收」，并新增深度封顶用例（恰好 6 层收、第 7 层不收）+ 嵌套产物目录仍排除。
+  - **变异实测**（两个修复各自独立生效）：临时关掉 `manga.json` 分支 → `alreadyOcred` 用例报 `valid` 失败；临时把 `kMangaPageScanMaxDepth` 改回 1 → 3 个深层扫描用例失败。
+- **备注**：`onlyMissing` 与书内 `manga.json` 不同源这件事本次未改（超出本轮范围），但已被 `alreadyOcred` 挡在入口外——全页有 OCR 的书不会再进入运行路径。相关：[BUG-1433](BUG-1433-mokuro-download-no-retry.md)。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52190 (3070 per locale)
+/// Strings: 52224 (3072 per locale)
 ///
-/// Built on 2026-08-02 at 01:55 UTC
+/// Built on 2026-08-02 at 05:22 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4125,6 +4125,11 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get stat_hourly_band_unattributed => 'Unsplit history';
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -11169,6 +11174,13 @@ class _StringsAr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -18280,6 +18292,13 @@ class _StringsDe extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -25406,6 +25425,13 @@ class _StringsEs extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -32544,6 +32570,13 @@ class _StringsFr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -39611,6 +39644,13 @@ class _StringsId extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -46724,6 +46764,13 @@ class _StringsIt extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -53654,6 +53701,13 @@ class _StringsJa extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -60586,6 +60640,13 @@ class _StringsKo extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -67679,6 +67740,13 @@ class _StringsNl extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -74785,6 +74853,13 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -81875,6 +81950,13 @@ class _StringsRu extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -88913,6 +88995,13 @@ class _StringsTh extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -95983,6 +96072,13 @@ class _StringsTr extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -103038,6 +103134,13 @@ class _StringsVi extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 // Path: <root>
@@ -109605,6 +109708,13 @@ class _StringsZhCn extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       '早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      '即将自动重试 (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      '本卷每一页都已有 OCR 数据，无需再跑（重跑会覆盖现有数据）。';
 }
 
 // Path: <root>
@@ -116456,6 +116566,13 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get stat_hourly_unattributed_note =>
       'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+  @override
+  String manga_online_retry_waiting(
+          {required Object attempt, required Object total}) =>
+      'Retrying automatically (${attempt}/${total})';
+  @override
+  String get manga_ocr_wizard_already_ocred =>
+      'This volume already has OCR data on every page. Running OCR again would overwrite it.';
 }
 
 /// Flat map(s) containing all translations.
@@ -122755,6 +122872,11 @@ extension on _StringsEn {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -129052,6 +129174,11 @@ extension on _StringsAr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -135371,6 +135498,11 @@ extension on _StringsDe {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -141689,6 +141821,11 @@ extension on _StringsEs {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -148013,6 +148150,11 @@ extension on _StringsFr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -154319,6 +154461,11 @@ extension on _StringsId {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -160639,6 +160786,11 @@ extension on _StringsIt {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -166921,6 +167073,11 @@ extension on _StringsJa {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -173207,6 +173364,11 @@ extension on _StringsKo {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -179521,6 +179683,11 @@ extension on _StringsNl {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -185832,6 +185999,11 @@ extension on _StringsPtBr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -192148,6 +192320,11 @@ extension on _StringsRu {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -198447,6 +198624,11 @@ extension on _StringsTh {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -204755,6 +204937,11 @@ extension on _StringsTr {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -211059,6 +211246,11 @@ extension on _StringsVi {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }
@@ -217309,6 +217501,11 @@ extension on _StringsZhCn {
         return '未区分历史';
       case 'stat_hourly_unattributed_note':
         return '早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            '即将自动重试 (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return '本卷每一页都已有 OCR 数据，无需再跑（重跑会覆盖现有数据）。';
       default:
         return null;
     }
@@ -223586,6 +223783,11 @@ extension on _StringsZhHk {
         return 'Unsplit history';
       case 'stat_hourly_unattributed_note':
         return 'Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.';
+      case 'manga_online_retry_waiting':
+        return ({required Object attempt, required Object total}) =>
+            'Retrying automatically (${attempt}/${total})';
+      case 'manga_ocr_wizard_already_ocred':
+        return 'This volume already has OCR data on every page. Running OCR again would overwrite it.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "漫画",
   "stat_hourly_band_unattributed": "未区分历史",
-  "stat_hourly_unattributed_note": "早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。"
+  "stat_hourly_unattributed_note": "早期记录的时段数据没有存类型，无法拆分；这里按合计如实显示，不归入任何一类。",
+  "manga_online_retry_waiting": "即将自动重试 ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "本卷每一页都已有 OCR 数据，无需再跑（重跑会覆盖现有数据）。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3068,5 +3068,7 @@
   "stat_hourly_band_pdf": "PDF",
   "stat_hourly_band_manga": "Manga",
   "stat_hourly_band_unattributed": "Unsplit history",
-  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type."
+  "stat_hourly_unattributed_note": "Hours recorded before per-format tracking existed have no type stored, so they cannot be split. They are shown as a combined total and are not assigned to any type.",
+  "manga_online_retry_waiting": "Retrying automatically ($attempt/$total)",
+  "manga_ocr_wizard_already_ocred": "This volume already has OCR data on every page. Running OCR again would overwrite it."
 }

--- a/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
@@ -891,6 +891,10 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
               _errorText(theme, t.manga_ocr_wizard_no_images),
             if (_folderStatus == MangaOcrFolderStatus.hasMokuro)
               _errorText(theme, t.manga_ocr_wizard_has_mokuro),
+            // 已入库且每页都有 OCR（mokuro.moe 下载的卷天生如此）：说清「不需要」，
+            // 而不是让用户对着一个禁用的按钮猜。
+            if (_folderStatus == MangaOcrFolderStatus.alreadyOcred)
+              _errorText(theme, t.manga_ocr_wizard_already_ocred),
             if (_folderStatus == MangaOcrFolderStatus.valid) ...<Widget>[
               const SizedBox(height: 12),
               _engineSelector(busy),
@@ -1037,9 +1041,9 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
   }
 }
 
-/// 裸图片文件夹校验结果。
+/// 图片文件夹 / 已入库书目录的校验结果。
 enum MangaOcrFolderStatus {
-  /// 有图、无 `.mokuro`——可 OCR。
+  /// 有图、无 `.mokuro`——可 OCR。已入库的书则是「至少一页还没有 OCR 块」。
   valid,
 
   /// 无任何图片。
@@ -1048,16 +1052,33 @@ enum MangaOcrFolderStatus {
   /// 已有 `.mokuro`——应走普通导入而非 OCR。
   hasMokuro,
 
+  /// 已入库的书每一页都已有 OCR 块——没有可补的页，再跑只会用较差的引擎结果
+  /// 覆盖掉现成数据（mokuro.moe 下载的卷天生如此：站点已给 `.mokuro`）。
+  alreadyOcred,
+
   /// 目录不存在。
   notFound,
 }
 
-/// 纯校验：目录须存在、含图片（一层深）、且**不含** `.mokuro`（有则提示直接普通导入）。
+/// 纯校验：目录须存在、含图片、且**不含** `.mokuro`（有则提示直接普通导入）。
 /// 无平台通道、无 async，便于单测与即时禁用 Run 按钮。
+///
+/// 两种输入分开判：
+/// - **已入库书目录**（含 `manga.json`，即 `EpubBooks.extractDir`）：真相是
+///   `manga.json` 的页表，不是目录里躺着什么文件。页图落在 `images/<destRel>`，
+///   而 destRel 保留源子目录结构，深度不固定；按文件扫描去猜「有没有图 / 有没有
+///   OCR」既够不着深层页图，也认不出已存在的 OCR（书里的 OCR 数据在 manga.json
+///   里，不叫 `.mokuro`）。mokuro.moe 下载的卷正是两条都踩：能正常阅读的书被判成
+///   「此文件夹中没有找到图片」。
+/// - **裸图片文件夹**（用户自选）：仍按文件扫描，只是改用与 OCR 引擎同一个枚举器
+///   [enumerateMangaPages]，避免「向导说有图、引擎说没页」这类两套规则漂移。
 MangaOcrFolderStatus checkOcrFolder(String dirPath) {
   final Directory dir = Directory(dirPath);
   if (!dir.existsSync()) return MangaOcrFolderStatus.notFound;
-  bool hasImage = false;
+
+  final File mangaJson = File(p.join(dirPath, MangaStorage.kMangaJsonFileName));
+  if (mangaJson.existsSync()) return _checkImportedBookDir(mangaJson);
+
   List<FileSystemEntity> entries;
   try {
     entries = dir.listSync();
@@ -1065,24 +1086,33 @@ MangaOcrFolderStatus checkOcrFolder(String dirPath) {
     return MangaOcrFolderStatus.notFound;
   }
   for (final FileSystemEntity entity in entries) {
-    if (entity is File) {
-      final String ext = p.extension(entity.path).toLowerCase();
-      if (ext == '.mokuro') return MangaOcrFolderStatus.hasMokuro;
-      if (kMangaImageExtensions.contains(ext)) hasImage = true;
-    } else if (entity is Directory) {
-      try {
-        for (final FileSystemEntity sub in entity.listSync()) {
-          if (sub is File &&
-              kMangaImageExtensions
-                  .contains(p.extension(sub.path).toLowerCase())) {
-            hasImage = true;
-            break;
-          }
-        }
-      } catch (_) {
-        // 无权限/瞬时 IO：跳过该子目录。
-      }
+    if (entity is File && p.extension(entity.path).toLowerCase() == '.mokuro') {
+      return MangaOcrFolderStatus.hasMokuro;
     }
   }
-  return hasImage ? MangaOcrFolderStatus.valid : MangaOcrFolderStatus.noImages;
+  return enumerateMangaPages(dir).isEmpty
+      ? MangaOcrFolderStatus.noImages
+      : MangaOcrFolderStatus.valid;
+}
+
+/// 已入库书目录的判定：页数与 OCR 完成度都以 `manga.json` 为准。
+///
+/// 每页都有 OCR 块 → [MangaOcrFolderStatus.alreadyOcred]（无可补的页）；有页缺块
+/// → [MangaOcrFolderStatus.valid]（可补齐）。manga.json 读不动时退回文件扫描——
+/// 「元数据坏了」不等于「没有图片」。
+MangaOcrFolderStatus _checkImportedBookDir(File mangaJson) {
+  final MokuroPayload payload;
+  try {
+    payload = parseMangaJson(mangaJson.readAsStringSync());
+  } catch (_) {
+    return enumerateMangaPages(mangaJson.parent).isEmpty
+        ? MangaOcrFolderStatus.noImages
+        : MangaOcrFolderStatus.valid;
+  }
+  if (payload.images.isEmpty) return MangaOcrFolderStatus.noImages;
+  final bool everyPageOcred =
+      payload.images.every((MokuroImage page) => page.blocks.isNotEmpty);
+  return everyPageOcred
+      ? MangaOcrFolderStatus.alreadyOcred
+      : MangaOcrFolderStatus.valid;
 }

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
@@ -503,6 +503,11 @@ class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
             MokuroMoeTaskStatus.running =>
               mokuroMoeStageLabel(pending!.lastEvent),
             MokuroMoeTaskStatus.queued => t.download_status_queued,
+            // 退避重试中也是「未完成任务」，行仍不可再选，得说清它在等什么。
+            MokuroMoeTaskStatus.waitingRetry => t.manga_online_retry_waiting(
+                attempt: pending!.autoRetries,
+                total: _queue.maxAutoRetries,
+              ),
             _ => null,
           };
     final Widget? subtitle = subtitleText == null

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_client.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_client.dart
@@ -19,6 +19,30 @@ import 'dart:io';
 /// 默认目录站点（偏好 `manga_online_catalog_base_url` 空值时的回退）。
 const String kMokuroMoeDefaultBaseUrl = 'https://mokuro.moe';
 
+/// 带状态码的 HTTP 失败。实现 [HttpException] 的隐式接口，`is HttpException`
+/// 仍为真（旧调用点/测试的类型判断不受影响），额外暴露 [statusCode] 供下载
+/// 队列区分「服务端瞬时故障（值得自动重试）」与「该资源就是没有（重试无用）」
+/// ——404 的卷重试三轮只是白等几十秒。
+class MokuroMoeHttpException implements HttpException {
+  const MokuroMoeHttpException(this.statusCode, {this.uri});
+
+  final int statusCode;
+
+  @override
+  final Uri? uri;
+
+  @override
+  String get message => 'mokuro.moe request failed: HTTP $statusCode';
+
+  /// 服务端侧瞬时故障：5xx 网关/过载、408 请求超时、429 限流。
+  /// 4xx 其余（404 缺卷、403 防盗链）是稳定结论，重试没有意义。
+  bool get isTransient =>
+      statusCode >= 500 || statusCode == 408 || statusCode == 429;
+
+  @override
+  String toString() => 'HttpException: $message, uri = $uri';
+}
+
 /// 归一 base URL：trim + 去尾斜杠；空串回退默认站点。
 String normalizeMokuroMoeBaseUrl(String raw) {
   String s = raw.trim();
@@ -153,8 +177,8 @@ class MokuroMoeClient {
       final HttpClientResponse response = await request.close();
       if (response.statusCode != HttpStatus.ok) {
         await response.drain<void>();
-        throw HttpException(
-          'mokuro.moe request failed: HTTP ${response.statusCode}',
+        throw MokuroMoeHttpException(
+          response.statusCode,
           uri: Uri.parse(url),
         );
       }

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_download_queue.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_download_queue.dart
@@ -6,15 +6,36 @@
 /// 不做并发）；区别于旧「失败即停整队」，后台队列语义是单卷失败/取消只标记
 /// 该任务、继续下一卷。下载编排复用 [MokuroMoeVolumeDownloader]，断点续传
 /// 语义不变：失败/取消保留 `.part`，同卷重新入队即续传。
+///
+/// 重试语义（自动 + 手动）都是**就地复活同一个任务对象**，不新建行：任务在列表
+/// 里的位置、身份不变，失败行不会变成一条僵尸残留 + 一条新任务。续传由
+/// downloader 的 `.part` 保证，重试不重下已到的字节。
+/// - 自动：网络类瞬时失败（连接超时/连接重置/TLS/5xx/429）按 [kMokuroMoeRetryBackoff]
+///   退避重排，退避期间状态是 [MokuroMoeTaskStatus.waitingRetry]，**不占执行位**
+///   ——队列继续跑后面的卷，到期再回 queued 参与调度。
+/// - 手动：[MokuroMoeDownloadQueue.retry] 让 failed/cancelled 任务回 queued，
+///   并把自动重试计数清零（用户的一次点击 = 一轮新的自动重试预算）。
 library;
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_client.dart';
 import 'package:hibiki/src/media/manga/online/mokuro_moe_volume_downloader.dart';
+
+/// 自动重试的退避梯度；**长度即最大自动重试次数**。
+///
+/// 首次退避短（2s：抖动/瞬断，站点多半马上就回来），后面拉长（8s/20s：站点
+/// 过载或本机网络出问题，密集重试只会加重）。总计约 30s，超过还失败就交给
+/// 用户手动重试——继续机械重试对社区小站没有礼貌，也帮不上忙。
+const List<Duration> kMokuroMoeRetryBackoff = <Duration>[
+  Duration(seconds: 2),
+  Duration(seconds: 8),
+  Duration(seconds: 20),
+];
 
 /// 测试注入口：替换真实 [MokuroMoeVolumeDownloader.run]（测试绕网络/DB）。
 typedef MokuroMoeVolumeRunner = Stream<MokuroMoeVolumeDownloadEvent> Function({
@@ -23,7 +44,17 @@ typedef MokuroMoeVolumeRunner = Stream<MokuroMoeVolumeDownloadEvent> Function({
 });
 
 /// 单个卷任务的生命周期状态。
-enum MokuroMoeTaskStatus { queued, running, done, failed, cancelled }
+///
+/// [waitingRetry] 是「失败了但还会自己回来」——不是终态（[MokuroMoeDownloadTask.isFinished]
+/// 为 false，不会被「清除已完成」扫掉），也不被 `_pump` 选中执行。
+enum MokuroMoeTaskStatus {
+  queued,
+  running,
+  waitingRetry,
+  done,
+  failed,
+  cancelled
+}
 
 /// 队列中的一个卷下载任务（可变快照；变更经队列 [MokuroMoeDownloadQueue]
 /// 的 notifyListeners 广播）。
@@ -38,8 +69,12 @@ class MokuroMoeDownloadTask {
   /// 最近一次下载事件（阶段/字节/页进度），UI 据此渲染进度。
   MokuroMoeVolumeDownloadEvent? lastEvent;
 
-  /// 失败原因（status == failed 时非空）。
+  /// 失败原因（status == failed / waitingRetry 时非空）。
   String? error;
+
+  /// 已消耗的自动重试次数（0 = 还没自动重试过）。手动 [MokuroMoeDownloadQueue.retry]
+  /// 归零，所以用户点一次重试就重新拿到完整的自动重试预算。
+  int autoRetries = 0;
 
   /// 入库 bookKey（status == done 且真的新建行时非空）。
   String? bookKey;
@@ -63,20 +98,30 @@ class MokuroMoeDownloadQueue extends ChangeNotifier {
     required HibikiDatabase db,
     required MokuroMoeClient Function() clientFactory,
     @visibleForTesting MokuroMoeVolumeRunner? runnerOverride,
+    @visibleForTesting List<Duration>? retryBackoffOverride,
   })  : _db = db,
         _clientFactory = clientFactory,
-        _runnerOverride = runnerOverride;
+        _runnerOverride = runnerOverride,
+        _retryBackoff = retryBackoffOverride ?? kMokuroMoeRetryBackoff;
 
   final HibikiDatabase _db;
   final MokuroMoeClient Function() _clientFactory;
   final MokuroMoeVolumeRunner? _runnerOverride;
+  final List<Duration> _retryBackoff;
 
   final List<MokuroMoeDownloadTask> _tasks = <MokuroMoeDownloadTask>[];
+
+  /// 退避中的重试定时器（任务可并存多个：A 在退避时队列继续跑 B，B 也可能失败）。
+  final Map<MokuroMoeDownloadTask, Timer> _retryTimers =
+      <MokuroMoeDownloadTask, Timer>{};
 
   MokuroMoeDownloadTask? _running;
   MokuroMoeVolumeDownloader? _activeDownloader;
   StreamSubscription<MokuroMoeVolumeDownloadEvent>? _sub;
   bool _disposed = false;
+
+  /// 单个任务最多自动重试几次（超过就落 failed，等用户手动重试）。
+  int get maxAutoRetries => _retryBackoff.length;
 
   /// 累计成功新建行的卷数（书架刷新信号：监听方比对增量后失效书架 provider）。
   int _importedCount = 0;
@@ -134,10 +179,12 @@ class MokuroMoeDownloadQueue extends ChangeNotifier {
     return added;
   }
 
-  /// 取消一个任务：排队中→直接移除；执行中→请求下载器中止（`.part` 保留，
-  /// 供下次同卷续传）。已结束的任务是 no-op。
+  /// 取消一个任务：排队中/退避重试中→直接移除；执行中→请求下载器中止（`.part`
+  /// 保留，供下次同卷续传）。已结束的任务是 no-op。
   void cancel(MokuroMoeDownloadTask task) {
     if (task.isFinished) return;
+    // 退避中的任务先掐掉定时器，否则到期回调还会把它推回 queued。
+    _retryTimers.remove(task)?.cancel();
     if (identical(task, _running)) {
       final MokuroMoeVolumeDownloader? downloader = _activeDownloader;
       if (downloader != null) {
@@ -151,6 +198,51 @@ class MokuroMoeDownloadQueue extends ChangeNotifier {
     }
     _tasks.remove(task);
     notifyListeners();
+  }
+
+  /// 手动重试一个失败/已取消的任务：**就地**把它复活成排队态（不新建任务行，
+  /// 列表位置与身份不变——否则失败行会作为僵尸残留，同名任务重复占位）。
+  ///
+  /// 自动重试计数清零：用户的显式点击重新给满预算。`.part` 仍在，实际是续传，
+  /// 不重下已到的字节。已成功/仍在进行中的任务是 no-op。
+  void retry(MokuroMoeDownloadTask task) {
+    if (task.status != MokuroMoeTaskStatus.failed &&
+        task.status != MokuroMoeTaskStatus.cancelled) {
+      return;
+    }
+    _resetForRetry(task);
+    task.status = MokuroMoeTaskStatus.queued;
+    task.autoRetries = 0;
+    notifyListeners();
+    _pump();
+  }
+
+  /// 重试一切失败/取消的任务（下载页批量入口）。返回真正复活的任务数。
+  int retryAllFailed() {
+    int revived = 0;
+    for (final MokuroMoeDownloadTask task in _tasks) {
+      if (task.status != MokuroMoeTaskStatus.failed &&
+          task.status != MokuroMoeTaskStatus.cancelled) {
+        continue;
+      }
+      _resetForRetry(task);
+      task.status = MokuroMoeTaskStatus.queued;
+      task.autoRetries = 0;
+      revived++;
+    }
+    if (revived > 0) {
+      notifyListeners();
+      _pump();
+    }
+    return revived;
+  }
+
+  /// 清空上一轮的失败/进度残留（状态由调用方置），保证重跑的 UI 从干净起点开始。
+  void _resetForRetry(MokuroMoeDownloadTask task) {
+    task.error = null;
+    task.lastEvent = null;
+    task.bookKey = null;
+    task.skippedExisting = false;
   }
 
   /// 清掉所有已结束任务（下载页「清除已完成」）。
@@ -213,8 +305,12 @@ class MokuroMoeDownloadQueue extends ChangeNotifier {
     if (error is MokuroMoeDownloadCancelled) {
       task.status = MokuroMoeTaskStatus.cancelled;
     } else if (error != null) {
-      task.status = MokuroMoeTaskStatus.failed;
       task.error = '$error';
+      // 网络瞬断（mokuro.moe 是社区小站，连接超时是常态）自己退避重来；
+      // 排不上自动重试的才落终态 failed，等用户手动重试。
+      task.status = _scheduleAutoRetry(task, error)
+          ? MokuroMoeTaskStatus.waitingRetry
+          : MokuroMoeTaskStatus.failed;
     } else if (task.lastEvent?.stage == MokuroMoeDownloadStage.done) {
       task.status = MokuroMoeTaskStatus.done;
       if (!task.skippedExisting && task.bookKey != null) _importedCount++;
@@ -227,9 +323,52 @@ class MokuroMoeDownloadQueue extends ChangeNotifier {
     _pump();
   }
 
+  /// 安排一次自动重试；返回 false 表示这个错误/这个任务不该再自动重试。
+  ///
+  /// 退避期间任务是 [MokuroMoeTaskStatus.waitingRetry]：不占执行位，队列立刻
+  /// 去跑下一卷；到期后回 queued 参与正常调度（而不是插队抢跑）。
+  bool _scheduleAutoRetry(MokuroMoeDownloadTask task, Object error) {
+    if (_disposed) return false;
+    if (task.autoRetries >= _retryBackoff.length) return false;
+    if (!_isTransientError(error)) return false;
+
+    final Duration delay = _retryBackoff[task.autoRetries];
+    task.autoRetries++;
+    // 进度归零：重跑会从 `.part` 续传点重新报字节，留着旧事件会让 UI 停在
+    // 一个不再对应任何下载的进度上。
+    task.lastEvent = null;
+    _retryTimers[task] = Timer(delay, () {
+      _retryTimers.remove(task);
+      // 期间被取消/清掉/手动重试过就不要再插手。
+      if (_disposed || task.status != MokuroMoeTaskStatus.waitingRetry) return;
+      task.status = MokuroMoeTaskStatus.queued;
+      notifyListeners();
+      _pump();
+    });
+    return true;
+  }
+
+  /// 值得自动重试的错误 = 「再来一次可能就好了」的瞬时故障。
+  ///
+  /// 网络/传输层（连接超时、连接重置、DNS 抖动、TLS 握手失败）一律算；HTTP 只认
+  /// 5xx/408/429（[MokuroMoeHttpException.isTransient]），404/403 这类稳定结论
+  /// 重试纯属白等。zip 校验失败、解包失败、路径穿越等本地/数据错误不自动重试
+  /// ——重跑同一份坏数据不会变好，交给用户手动决定。
+  static bool _isTransientError(Object error) {
+    if (error is MokuroMoeHttpException) return error.isTransient;
+    return error is SocketException ||
+        error is TimeoutException ||
+        error is TlsException ||
+        error is HttpException;
+  }
+
   @override
   void dispose() {
     _disposed = true;
+    for (final Timer timer in _retryTimers.values) {
+      timer.cancel();
+    }
+    _retryTimers.clear();
     _activeDownloader?.cancel();
     unawaited(_sub?.cancel());
     super.dispose();

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_tasks_section.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_tasks_section.dart
@@ -36,6 +36,8 @@ class MokuroMoeTasksSection extends ConsumerWidget {
         final ThemeData theme = Theme.of(context);
         final bool hasFinished =
             tasks.any((MokuroMoeDownloadTask t) => t.isFinished);
+        final bool hasRetryable =
+            tasks.any((MokuroMoeDownloadTask t) => _canRetry(t));
         return Column(
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: <Widget>[
@@ -50,6 +52,11 @@ class MokuroMoeTasksSection extends ConsumerWidget {
                       style: theme.textTheme.titleSmall,
                     ),
                   ),
+                  if (hasRetryable)
+                    TextButton(
+                      onPressed: queue.retryAllFailed,
+                      child: Text(t.retry),
+                    ),
                   if (hasFinished)
                     TextButton(
                       onPressed: queue.clearFinished,
@@ -102,6 +109,9 @@ class MokuroMoeTasksSection extends ConsumerWidget {
         Icon(Icons.check_circle_outline, size: 20, color: scheme.primary),
       MokuroMoeTaskStatus.failed =>
         Icon(Icons.error_outline, size: 20, color: scheme.error),
+      // 退避等待中：失败了但队列会自己回来重来（区别于终态 failed 的红叉）。
+      MokuroMoeTaskStatus.waitingRetry =>
+        Icon(Icons.autorenew, size: 20, color: scheme.error),
       MokuroMoeTaskStatus.cancelled =>
         Icon(Icons.block_outlined, size: 20, color: scheme.outline),
       MokuroMoeTaskStatus.running => eink
@@ -125,7 +135,13 @@ class MokuroMoeTasksSection extends ConsumerWidget {
       MokuroMoeTaskStatus.cancelled => t.download_status_cancelled,
       MokuroMoeTaskStatus.failed =>
         '${t.manga_online_failed}: ${task.error ?? ''}',
+      MokuroMoeTaskStatus.waitingRetry => '${t.manga_online_retry_waiting(
+          attempt: task.autoRetries,
+          total: queue.maxAutoRetries,
+        )}: ${task.error ?? ''}',
     };
+    final bool errorTone = task.status == MokuroMoeTaskStatus.failed ||
+        task.status == MokuroMoeTaskStatus.waitingRetry;
     return HibikiListItem(
       density: HibikiListDensity.compact,
       padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
@@ -140,18 +156,37 @@ class MokuroMoeTasksSection extends ConsumerWidget {
         maxLines: 2,
         overflow: TextOverflow.ellipsis,
         style: theme.textTheme.bodySmall?.copyWith(
-          color:
-              task.status == MokuroMoeTaskStatus.failed ? scheme.error : null,
+          color: errorTone ? scheme.error : null,
         ),
       ),
-      trailing: task.isFinished
-          ? null
-          : HibikiIconButton(
-              tooltip: t.dialog_cancel,
-              icon: Icons.close,
-              size: 20,
-              onTap: () => queue.cancel(task),
-            ),
+      // 失败/取消 → 手动重试（就地复活该任务，`.part` 续传）；未结束 → 取消；
+      // 成功 → 无操作。旧实现在失败行给 null，用户只能回「在线目录」重找那一卷，
+      // 重新入队还会多出一条同名任务、失败那条僵在列表里。
+      trailing: switch (task.status) {
+        MokuroMoeTaskStatus.failed ||
+        MokuroMoeTaskStatus.cancelled =>
+          HibikiIconButton(
+            tooltip: t.retry,
+            icon: Icons.refresh,
+            size: 20,
+            onTap: () => queue.retry(task),
+          ),
+        MokuroMoeTaskStatus.done => null,
+        MokuroMoeTaskStatus.queued ||
+        MokuroMoeTaskStatus.running ||
+        MokuroMoeTaskStatus.waitingRetry =>
+          HibikiIconButton(
+            tooltip: t.dialog_cancel,
+            icon: Icons.close,
+            size: 20,
+            onTap: () => queue.cancel(task),
+          ),
+      },
     );
   }
+
+  /// 手动重试可用的任务（与 [MokuroMoeDownloadQueue.retry] 的受理条件同口径）。
+  static bool _canRetry(MokuroMoeDownloadTask task) =>
+      task.status == MokuroMoeTaskStatus.failed ||
+      task.status == MokuroMoeTaskStatus.cancelled;
 }

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_volume_downloader.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_volume_downloader.dart
@@ -254,8 +254,8 @@ class MokuroMoeVolumeDownloader {
       final HttpClientResponse response = await request.close();
       if (response.statusCode != HttpStatus.ok) {
         await response.drain<void>();
-        throw HttpException(
-          'download failed: HTTP ${response.statusCode}',
+        throw MokuroMoeHttpException(
+          response.statusCode,
           uri: Uri.parse(url),
         );
       }
@@ -329,8 +329,8 @@ class MokuroMoeVolumeDownloader {
         sink = part.openWrite();
       } else {
         await response.drain<void>();
-        throw HttpException(
-          'download failed: HTTP ${response.statusCode}',
+        throw MokuroMoeHttpException(
+          response.statusCode,
           uri: Uri.parse(url),
         );
       }

--- a/hibiki/lib/src/ocr/manga_ocr_folder_job.dart
+++ b/hibiki/lib/src/ocr/manga_ocr_folder_job.dart
@@ -105,8 +105,20 @@ int naturalCompare(String a, String b) {
 
 bool _isDigit(int codeUnit) => codeUnit >= 0x30 && codeUnit <= 0x39;
 
-/// 枚举 [root] 下的页图：顶层文件 + **一层**子目录内的文件（更深不递归），
-/// 排除 [kMangaOcrOutDirName] 产物目录，按相对路径自然序排序。
+/// 页图目录树的最大下钻层数（root 自身算第 0 层）。够覆盖真实布局
+/// （书目录 `images/<源子目录>/页.jpg` 已经是第 2 层），又不至于在用户误选
+/// 整个磁盘根时把目录树走穿。
+const int kMangaPageScanMaxDepth = 6;
+
+/// 枚举 [root] 下的页图：递归下钻到 [kMangaPageScanMaxDepth] 层，排除
+/// [kMangaOcrOutDirName] 产物目录，按相对路径自然序排序。
+///
+/// 旧实现只认「顶层文件 + 一层子目录内的文件」。已入库漫画的书目录是
+/// `manga.json` + `images/<destRel>`，而 destRel **保留源子目录结构**：
+/// mokuro.moe 的卷 CBZ 顶层带一个 `<卷名>/` 目录，页图因此落在
+/// `images/<卷名>/001.jpg`（第 2 层子目录），旧枚举一页也扫不到——OCR 向导
+/// 报「此文件夹中没有找到图片」，引擎跑起来也是 no pages。页图深度取决于源
+/// 压缩包怎么打的，不是常数，扫描就不该把它当常数。
 List<MangaOcrPageFile> enumerateMangaPages(Directory root) {
   final List<MangaOcrPageFile> pages = <MangaOcrPageFile>[];
   void addFile(File file) {
@@ -120,21 +132,27 @@ List<MangaOcrPageFile> enumerateMangaPages(Directory root) {
     );
   }
 
-  for (final FileSystemEntity entity in root.listSync(followLinks: false)) {
-    if (entity is File) {
-      addFile(entity);
-    } else if (entity is Directory) {
-      if (p.basename(entity.path) == kMangaOcrOutDirName) {
-        continue;
-      }
-      for (final FileSystemEntity child
-          in entity.listSync(followLinks: false)) {
-        if (child is File) {
-          addFile(child);
+  void walk(Directory dir, int depth) {
+    final List<FileSystemEntity> entries;
+    try {
+      entries = dir.listSync(followLinks: false);
+    } catch (_) {
+      // 无权限/瞬时 IO：跳过该目录，不让整卷枚举失败。
+      return;
+    }
+    for (final FileSystemEntity entity in entries) {
+      if (entity is File) {
+        addFile(entity);
+      } else if (entity is Directory && depth < kMangaPageScanMaxDepth) {
+        if (p.basename(entity.path) == kMangaOcrOutDirName) {
+          continue;
         }
+        walk(entity, depth + 1);
       }
     }
   }
+
+  walk(root, 0);
   pages.sort((MangaOcrPageFile a, MangaOcrPageFile b) =>
       naturalCompare(a.relativeUrl, b.relativeUrl));
   return pages;

--- a/hibiki/test/media/manga/manga_ocr_folder_check_test.dart
+++ b/hibiki/test/media/manga/manga_ocr_folder_check_test.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/manga_ocr_wizard_dialog.dart';
+import 'package:hibiki/src/media/manga/manga_storage.dart';
+import 'package:hibiki/src/media/manga/mokuro_payload.dart';
+import 'package:path/path.dart' as p;
+
+/// [checkOcrFolder] 的判定口径：**已入库书目录**（含 manga.json）看页表，
+/// **裸图片文件夹**看文件。
+///
+/// BUG-1434：mokuro.moe 下载的卷导入后页图落在 `images/<卷名>/001.jpg`
+/// （destRel 保留了 CBZ 顶层的 `<卷名>/` 目录），而旧判定只扫「目录直属文件 +
+/// 一层子目录」，第三层的页图看不见 → 一本能正常阅读、且站点已附带完整 OCR
+/// 的书，被 OCR 向导判成「此文件夹中没有找到图片」并禁用运行。
+void main() {
+  const MokuroBlock block = MokuroBlock(
+    rectangle: Rect.fromLTRB(0, 0, 10, 10),
+    isVertical: true,
+    fontSize: 12,
+    zIndex: 0,
+    lines: <String>['テスト'],
+  );
+
+  MokuroImage page(String url,
+          {List<MokuroBlock> blocks = const <MokuroBlock>[]}) =>
+      MokuroImage(url: url, size: const Size(100, 140), blocks: blocks);
+
+  /// 造一个已入库书目录：`manga.json` + 按每页 destRel 落的空页图文件
+  /// （判定只看路径/扩展名，不解码像素）。
+  Directory bookDir(String prefix, List<MokuroImage> pages, {String? rawJson}) {
+    final Directory dir = Directory.systemTemp.createTempSync(prefix);
+    addTearDown(() {
+      if (dir.existsSync()) dir.deleteSync(recursive: true);
+    });
+    File(p.join(dir.path, MangaStorage.kMangaJsonFileName)).writeAsStringSync(
+      rawJson ?? jsonEncode(mangaPayloadToJson(MokuroPayload(images: pages))),
+    );
+    for (final MokuroImage image in pages) {
+      File(p.joinAll(<String>[dir.path, ...image.url.split('/')]))
+          .createSync(recursive: true);
+    }
+    return dir;
+  }
+
+  Directory plainDir(String prefix) {
+    final Directory dir = Directory.systemTemp.createTempSync(prefix);
+    addTearDown(() {
+      if (dir.existsSync()) dir.deleteSync(recursive: true);
+    });
+    return dir;
+  }
+
+  group('已入库书目录（manga.json 为准）', () {
+    test('mokuro.moe 卷：页图在 images/<卷名>/ 且每页有 OCR → alreadyOcred', () {
+      final Directory dir = bookDir('manga_check_mokuro_', <MokuroImage>[
+        page('images/あつまれ！ふしぎ研究部 第01巻/001.jpg', blocks: <MokuroBlock>[block]),
+        page('images/あつまれ！ふしぎ研究部 第01巻/002.jpg', blocks: <MokuroBlock>[block]),
+      ]);
+
+      final MangaOcrFolderStatus status = checkOcrFolder(dir.path);
+      expect(status, MangaOcrFolderStatus.alreadyOcred);
+      expect(status, isNot(MangaOcrFolderStatus.noImages),
+          reason: 'BUG-1434：用户看到的正是「此文件夹中没有找到图片」');
+    });
+
+    test('有页缺 OCR 块 → valid（可补齐）', () {
+      final Directory dir = bookDir('manga_check_partial_', <MokuroImage>[
+        page('images/vol1/001.jpg', blocks: <MokuroBlock>[block]),
+        page('images/vol1/002.jpg'),
+      ]);
+      expect(checkOcrFolder(dir.path), MangaOcrFolderStatus.valid);
+    });
+
+    test('一页都没 OCR → valid', () {
+      final Directory dir = bookDir('manga_check_none_', <MokuroImage>[
+        page('images/001.jpg'),
+      ]);
+      expect(checkOcrFolder(dir.path), MangaOcrFolderStatus.valid);
+    });
+
+    test('页表为空 → noImages', () {
+      final Directory dir = bookDir('manga_check_empty_', <MokuroImage>[]);
+      expect(checkOcrFolder(dir.path), MangaOcrFolderStatus.noImages);
+    });
+
+    test('manga.json 损坏 → 退回文件扫描，深层页图仍算 valid', () {
+      final Directory dir = bookDir(
+        'manga_check_broken_',
+        const <MokuroImage>[],
+        rawJson: '{ this is not json',
+      );
+      File(p.join(dir.path, 'images', 'vol1', '001.jpg'))
+          .createSync(recursive: true);
+      expect(checkOcrFolder(dir.path), MangaOcrFolderStatus.valid,
+          reason: '「元数据坏了」不等于「没有图片」');
+    });
+  });
+
+  group('裸图片文件夹', () {
+    test('含 .mokuro → hasMokuro（应走普通导入）', () {
+      final Directory dir = plainDir('manga_check_hasmokuro_');
+      File(p.join(dir.path, 'vol.mokuro')).writeAsStringSync('{}');
+      File(p.join(dir.path, '001.jpg')).createSync();
+      expect(checkOcrFolder(dir.path), MangaOcrFolderStatus.hasMokuro);
+    });
+
+    test('只有深层子目录里有图 → valid（与 OCR 引擎枚举同口径）', () {
+      final Directory dir = plainDir('manga_check_deep_');
+      File(p.join(dir.path, 'vol1', 'ch1', '001.jpg'))
+          .createSync(recursive: true);
+      expect(checkOcrFolder(dir.path), MangaOcrFolderStatus.valid);
+    });
+
+    test('只有非图片文件 → noImages', () {
+      final Directory dir = plainDir('manga_check_noimg_');
+      File(p.join(dir.path, 'readme.txt')).writeAsStringSync('x');
+      expect(checkOcrFolder(dir.path), MangaOcrFolderStatus.noImages);
+    });
+
+    test('目录不存在 → notFound', () {
+      expect(
+        checkOcrFolder(p.join(Directory.systemTemp.path, 'no_such_dir_zzz')),
+        MangaOcrFolderStatus.notFound,
+      );
+    });
+  });
+}

--- a/hibiki/test/media/manga/online/mokuro_moe_download_queue_test.dart
+++ b/hibiki/test/media/manga/online/mokuro_moe_download_queue_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:drift/native.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -30,7 +31,7 @@ void main() {
     MokuroMoeDownloadQueue queue,
     List<({String series, String volume})> calls,
     List<StreamController<MokuroMoeVolumeDownloadEvent>> ctrls,
-  }) makeQueue() {
+  }) makeQueue({List<Duration>? backoff}) {
     final List<({String series, String volume})> calls =
         <({String series, String volume})>[];
     final List<StreamController<MokuroMoeVolumeDownloadEvent>> ctrls =
@@ -46,9 +47,19 @@ void main() {
         ctrls.add(c);
         return c.stream;
       },
+      retryBackoffOverride: backoff,
     );
     return (queue: queue, calls: calls, ctrls: ctrls);
   }
+
+  /// 用户实际撞到的失败：mokuro.moe 连接超时（截图里的
+  /// `SocketException: 信号灯超时已到 ... mokuro.moe:9253`）。
+  const SocketException timeout =
+      SocketException('信号灯超时时间已到', osError: OSError('timeout', 121));
+
+  /// 退避全零的队列：Timer(Duration.zero) 在下一轮事件循环触发，pumpEventQueue 可等到。
+  List<Duration> instantBackoff(int times) =>
+      List<Duration>.filled(times, Duration.zero);
 
   test('顺序执行：一次一卷，前一卷收尾后才起下一卷；done 计入 importedCount', () async {
     final r = makeQueue();
@@ -161,5 +172,208 @@ void main() {
     expect(r.queue.tasks.map((MokuroMoeDownloadTask t) => t.volumeName),
         <String>['v2']);
     r.queue.dispose();
+  });
+
+  group('自动重试（网络瞬断自己回来）', () {
+    test('SocketException → waitingRetry，退避到期后自动重跑同一个任务', () async {
+      final r = makeQueue(backoff: instantBackoff(3));
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+      final MokuroMoeDownloadTask task = r.queue.tasks.single;
+
+      r.ctrls[0].addError(timeout);
+      await r.ctrls[0].close();
+      await pumpEventQueue();
+
+      // 不是终态：不能被「清除已完成」扫掉，也不算 finished。
+      expect(task.autoRetries, 1);
+      expect(task.isFinished, isFalse);
+      r.queue.clearFinished();
+      expect(r.queue.tasks, hasLength(1));
+      // 退避到期后重跑，且仍是**同一个任务对象**（不新建行）。
+      expect(r.calls, hasLength(2));
+      expect(r.queue.tasks.single, same(task));
+      expect(task.status, MokuroMoeTaskStatus.running);
+
+      r.ctrls[1].add(doneEvent);
+      await r.ctrls[1].close();
+      await pumpEventQueue();
+      expect(task.status, MokuroMoeTaskStatus.done);
+      expect(r.queue.importedCount, 1);
+      r.queue.dispose();
+    });
+
+    test('连续失败到上限后落 failed，不再无限重试', () async {
+      final r = makeQueue(backoff: instantBackoff(2));
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+      final MokuroMoeDownloadTask task = r.queue.tasks.single;
+
+      for (int attempt = 0; attempt < 3; attempt++) {
+        r.ctrls[attempt].addError(timeout);
+        await r.ctrls[attempt].close();
+        await pumpEventQueue();
+      }
+
+      expect(r.calls, hasLength(3), reason: '首跑 + 2 次自动重试');
+      expect(task.status, MokuroMoeTaskStatus.failed);
+      expect(task.autoRetries, 2);
+      expect(task.error, contains('信号灯超时'));
+      r.queue.dispose();
+    });
+
+    test('退避期间不占执行位：队列立刻去跑下一卷', () async {
+      // 退避足够长，确保观察窗口内不会到期。
+      final r = makeQueue(backoff: const <Duration>[Duration(minutes: 5)]);
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1', 'v2']);
+
+      r.ctrls[0].addError(timeout);
+      await r.ctrls[0].close();
+      await pumpEventQueue();
+
+      expect(r.queue.tasks[0].status, MokuroMoeTaskStatus.waitingRetry);
+      expect(r.calls, hasLength(2));
+      expect(r.queue.runningTask?.volumeName, 'v2');
+      r.queue.dispose();
+    });
+
+    test('退避中取消：移出队列，且到期后不会被偷偷重排', () async {
+      // 退避设短但非零：cancel 掐掉定时器后，即使等过这个时长也不该再起下载。
+      final r =
+          makeQueue(backoff: const <Duration>[Duration(milliseconds: 10)]);
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+      final MokuroMoeDownloadTask task = r.queue.tasks.single;
+
+      r.ctrls[0].addError(timeout);
+      await r.ctrls[0].close();
+      await pumpEventQueue();
+      expect(task.status, MokuroMoeTaskStatus.waitingRetry);
+
+      r.queue.cancel(task);
+      expect(r.queue.tasks, isEmpty);
+
+      await Future<void>.delayed(const Duration(milliseconds: 40));
+      await pumpEventQueue();
+      expect(r.calls, hasLength(1), reason: '取消后定时器必须已被掐掉');
+      r.queue.dispose();
+    });
+
+    test('404 不自动重试（该卷就是没有，重试只是白等）；503 才重试', () async {
+      final r = makeQueue(backoff: instantBackoff(3));
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+      r.ctrls[0].addError(const MokuroMoeHttpException(404));
+      await r.ctrls[0].close();
+      await pumpEventQueue();
+      expect(r.queue.tasks.single.status, MokuroMoeTaskStatus.failed);
+      expect(r.calls, hasLength(1));
+      r.queue.dispose();
+
+      final r2 = makeQueue(backoff: instantBackoff(3));
+      r2.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+      r2.ctrls[0].addError(const MokuroMoeHttpException(503));
+      await r2.ctrls[0].close();
+      await pumpEventQueue();
+      expect(r2.calls, hasLength(2), reason: '服务端瞬时故障值得重试');
+      r2.queue.dispose();
+    });
+
+    test('本地数据错误（坏 zip）不自动重试：重跑同一份坏数据不会变好', () async {
+      final r = makeQueue(backoff: instantBackoff(3));
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+      r.ctrls[0].addError(StateError('mokuro.moe CBZ is not a valid zip'));
+      await r.ctrls[0].close();
+      await pumpEventQueue();
+      expect(r.queue.tasks.single.status, MokuroMoeTaskStatus.failed);
+      expect(r.calls, hasLength(1));
+      r.queue.dispose();
+    });
+
+    test('用户取消不触发自动重试', () async {
+      final r = makeQueue(backoff: instantBackoff(3));
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+      r.queue.cancel(r.queue.tasks.single);
+      await pumpEventQueue();
+      expect(r.queue.tasks.single.status, MokuroMoeTaskStatus.cancelled);
+      expect(r.calls, hasLength(1));
+      r.queue.dispose();
+    });
+  });
+
+  group('手动重试（下载页的重试按钮）', () {
+    test('failed 任务就地复活成排队态，不新建第二条同名行', () async {
+      final r = makeQueue(backoff: const <Duration>[]);
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1']);
+      final MokuroMoeDownloadTask task = r.queue.tasks.single;
+      r.ctrls[0].addError(timeout);
+      await r.ctrls[0].close();
+      await pumpEventQueue();
+      expect(task.status, MokuroMoeTaskStatus.failed);
+
+      r.queue.retry(task);
+      await pumpEventQueue();
+
+      expect(r.queue.tasks, hasLength(1), reason: '失败行不该僵在列表里 + 多出一条新任务');
+      expect(r.queue.tasks.single, same(task));
+      expect(task.status, MokuroMoeTaskStatus.running);
+      expect(task.error, isNull);
+      expect(task.autoRetries, 0, reason: '用户点一次 = 重新拿满自动重试预算');
+      expect(r.calls, hasLength(2));
+      r.queue.dispose();
+    });
+
+    test('已取消的任务也能手动重试；done / 进行中是 no-op', () async {
+      final r = makeQueue(backoff: const <Duration>[]);
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1', 'v2']);
+      final MokuroMoeDownloadTask v1 = r.queue.tasks[0];
+      final MokuroMoeDownloadTask v2 = r.queue.tasks[1];
+
+      r.queue.cancel(v1);
+      await pumpEventQueue();
+      expect(v1.status, MokuroMoeTaskStatus.cancelled);
+      expect(r.queue.runningTask, same(v2));
+
+      // 进行中的任务：no-op（不打断当前下载）。
+      r.queue.retry(v2);
+      expect(v2.status, MokuroMoeTaskStatus.running);
+      expect(r.calls, hasLength(2));
+
+      r.queue.retry(v1);
+      expect(v1.status, MokuroMoeTaskStatus.queued, reason: 'v2 还占着执行位，v1 排队等');
+
+      r.ctrls[1].add(doneEvent);
+      await r.ctrls[1].close();
+      await pumpEventQueue();
+      expect(r.calls, hasLength(3));
+      expect(v1.status, MokuroMoeTaskStatus.running);
+
+      // 已成功的任务：no-op。
+      r.queue.retry(v2);
+      expect(v2.status, MokuroMoeTaskStatus.done);
+      expect(r.calls, hasLength(3));
+      r.queue.dispose();
+    });
+
+    test('retryAllFailed 一次复活所有失败/取消任务并返回条数', () async {
+      final r = makeQueue(backoff: const <Duration>[]);
+      r.queue.enqueue(seriesName: 'S', volumeNames: <String>['v1', 'v2', 'v3']);
+      // v1 失败、v2 取消、v3 成功。
+      r.ctrls[0].addError(timeout);
+      await r.ctrls[0].close();
+      await pumpEventQueue();
+      r.queue.cancel(r.queue.tasks[1]);
+      await pumpEventQueue();
+      r.ctrls[2].add(doneEvent);
+      await r.ctrls[2].close();
+      await pumpEventQueue();
+
+      expect(r.queue.tasks[0].status, MokuroMoeTaskStatus.failed);
+      expect(r.queue.tasks[1].status, MokuroMoeTaskStatus.cancelled);
+      expect(r.queue.tasks[2].status, MokuroMoeTaskStatus.done);
+
+      expect(r.queue.retryAllFailed(), 2);
+      await pumpEventQueue();
+      expect(r.queue.tasks[2].status, MokuroMoeTaskStatus.done,
+          reason: '成功的不动');
+      expect(r.queue.tasks, hasLength(3), reason: '仍是原来那三行');
+      r.queue.dispose();
+    });
   });
 }

--- a/hibiki/test/ocr/manga_ocr_folder_job_test.dart
+++ b/hibiki/test/ocr/manga_ocr_folder_job_test.dart
@@ -130,7 +130,7 @@ void main() {
   });
 
   group('enumerateMangaPages', () {
-    test('顶层 + 一层子目录、白名单扩展名、排除产物目录、自然序', () {
+    test('递归下钻、白名单扩展名、排除产物目录、自然序', () {
       final Directory root = Directory.systemTemp.createTempSync('manga_enum_');
       addTearDown(() => root.deleteSync(recursive: true));
       _writePng(p.join(root.path, 'p10.png'), 10, 10);
@@ -138,19 +138,56 @@ void main() {
       _writePng(p.join(root.path, 'extra', 'p1.png'), 10, 10);
       // bmp 页：导入白名单认它，OCR 枚举也必须收（BUG-1121）。
       _writeBmp(p.join(root.path, 'p3.bmp'), 10, 10);
-      // 二层子目录：不收。
+      // 二层子目录：**要收**。已入库书的页图在 `images/<源子目录>/页`，
+      // mokuro.moe 的卷 CBZ 顶层带 `<卷名>/`，页图正落在这一层；旧实现只扫一层
+      // 子目录，整本书一页都枚举不到（BUG-1434）。
       _writePng(p.join(root.path, 'extra', 'deep', 'x.png'), 10, 10);
       // 产物目录里的图：不收。
       _writePng(p.join(root.path, kMangaOcrOutDirName, 'y.png'), 10, 10);
+      // 嵌套在子目录里的产物目录：同样不收。
+      _writePng(
+          p.join(root.path, 'extra', kMangaOcrOutDirName, 'z.png'), 10, 10);
       // 非图片：不收。
       File(p.join(root.path, 'note.txt')).writeAsStringSync('x');
 
       final List<MangaOcrPageFile> pages = enumerateMangaPages(root);
       expect(
         pages.map((MangaOcrPageFile page) => page.relativeUrl).toList(),
-        <String>['extra/p1.png', 'p2.png', 'p3.bmp', 'p10.png'],
+        <String>[
+          'extra/deep/x.png',
+          'extra/p1.png',
+          'p2.png',
+          'p3.bmp',
+          'p10.png',
+        ],
         reason: '正斜杠相对 url + 自然序（p2 < p3 < p10）',
       );
+    });
+
+    test('下钻深度封顶 kMangaPageScanMaxDepth，更深的不收', () {
+      final Directory root =
+          Directory.systemTemp.createTempSync('manga_enum_deep_');
+      addTearDown(() => root.deleteSync(recursive: true));
+      // 恰好在上限层：收。
+      final List<String> atLimit = <String>[
+        root.path,
+        for (int i = 0; i < kMangaPageScanMaxDepth; i++) 'd$i',
+        'ok.png',
+      ];
+      _writePng(p.joinAll(atLimit), 10, 10);
+      // 再深一层：不收（防误选磁盘根时走穿整棵树）。
+      final List<String> tooDeep = <String>[
+        root.path,
+        for (int i = 0; i < kMangaPageScanMaxDepth + 1; i++) 'e$i',
+        'nope.png',
+      ];
+      _writePng(p.joinAll(tooDeep), 10, 10);
+
+      final List<String> urls = enumerateMangaPages(root)
+          .map((MangaOcrPageFile page) => page.relativeUrl)
+          .toList();
+      expect(urls, hasLength(1));
+      expect(urls.single, endsWith('ok.png'));
     });
   });
 


### PR DESCRIPTION
用户报告两条，都在 mokuro.moe 下载链路上。

## BUG-1433 · 下载失败后无路可退

用户截图：`下载失败: SocketException: 信号灯超时时间已到 ... mokuro.moe:9253`，失败行右侧空空如也。

**根因**：`_finish` 里只要 error 不是取消就直接 `status = failed` 终结（全链唯一的重试是 downloader 的 416 分支，针对坏 `.part`，与网络瞬断无关）；任务行 `trailing: task.isFinished ? null : 取消按钮`，失败行没有任何操作。用户只能回「在线目录」对话框重找那一卷 —— 而重新入队会**新建一条任务**，失败那条僵在列表里（用户第二张截图：同名两行、`(1/2)`）。mokuro.moe 是社区托管小站，连接超时是常态。

**修复**
- 新增非终态 `waitingRetry`：网络类瞬时失败按 2s/8s/20s 退避重排；退避**不占执行位**，队列继续跑后面的卷，到期回 `queued` 参与正常调度。
- 可重试判据只认「再来一次可能就好了」：`SocketException` / `TimeoutException` / `TlsException` / 裸 `HttpException`，HTTP 只认 5xx/408/429。为此给 client 加了带状态码的 `MokuroMoeHttpException`（`implements HttpException`，旧类型判断不受影响）—— 否则 404 的卷会白白重试三轮几十秒。坏 zip 等本地数据错误不自动重试（重跑同一份坏数据不会变好）。
- `retry(task)` / `retryAllFailed()`：**就地复活同一个任务对象**，不新建行；`.part` 保留即续传，不重下已到的字节（用户截图里续传本来就是好的，从 30.0/36.8 MB 接上）。失败/取消行给重试按钮，区段头给批量重试。

## BUG-1434 · 已导入的 mokuro 卷点 OCR 报「此文件夹中没有找到图片」

用户同时指出「这个 mokuro 下载的应该不用 ocr 才对」—— 对，而且报错本身也是错的。

**根因**（两层，都在「页图深度被当成常数」）
1. `enumerateMangaPages` 只枚举「顶层文件 + 一层子目录内的文件」。已入库书目录是 `manga.json` + `images/<destRel>`，而 destRel **保留源子目录结构**：mokuro.moe 的卷 CBZ 顶层带一个 `<卷名>/`，页图落在 `images/<卷名>/001.jpg`（第 2 层子目录）→ 一页都枚举不到。裸图片导入的书是扁平的 `images/001.jpg`，所以只有 mokuro.moe 下载的卷中招。
2. `checkOcrFolder` 对已入库书目录也按「裸图片文件夹」判：同样够不着深层页图，且「有没有 OCR」只认顶层 `.mokuro` 文件 —— 而书里的 OCR 数据在 `manga.json` 里，不叫 `.mokuro`。于是一本能正常阅读、站点已附带完整 OCR 的书被判成 `noImages`。

顺带确认：`openBookOcr` 的 `onlyMissing` 读的是 OCR 引擎自己的输出缓存，不是书里的 `manga.json`，所以真跑起来会把 mokuro.moe 的原生 OCR 全量重跑覆盖 —— 这正是「不该对已有 OCR 的书跑 OCR」的理由。

**修复**
- `enumerateMangaPages` 改递归下钻，上限 `kMangaPageScanMaxDepth = 6`（防误选磁盘根走穿目录树），每层都排除产物目录，无权限子目录跳过而非整卷失败。
- `checkOcrFolder` 分两种输入：**已入库书目录**以 `manga.json` 页表为准 —— 每页都有 OCR 块 → 新状态 `alreadyOcred`（提示「本卷每一页都已有 OCR 数据，无需再跑（重跑会覆盖现有数据）」并禁用运行），有页缺块 → `valid`（可补齐），页表空 → `noImages`，`manga.json` 读不动 → 退回文件扫描（「元数据坏了」不等于「没有图片」）；**裸图片文件夹**仍按文件判，但改用与 OCR 引擎同一个枚举器，消除「向导说有图、引擎说没页」的两套规则漂移。

## 验证

- `flutter analyze`（含 test）全绿。
- `flutter_test_failures.dart` 定向：`test/media/manga` + `test/ocr` **397 例通过**；`test/i18n` + sync-ocr + layout + settings + `test/tools` **281 例通过**。
- 新增测试：队列 11 例、`checkOcrFolder` 9 例（此前**无**测试）、枚举深度 2 例。`manga_ocr_folder_job_test` 里「二层子目录：不收」这条旧断言正是本 bug 的行为快照，已连同理由改正。
- **变异实测**（确认测试不是恒绿）：临时关掉 `manga.json` 分支 → `alreadyOcred` 用例报 `valid` 变红；临时把 `kMangaPageScanMaxDepth` 改回 1 → 3 个深层扫描用例变红。

## 未做 / 留给后续

- `+build` 号未 bump（从近期提交看由 integration owner 合并时统一 +1）。
- `onlyMissing` 与书内 `manga.json` 不同源这件事本轮未改（超出范围），但全页有 OCR 的书已被 `alreadyOcred` 挡在入口外，不会再进入运行路径。
- 未做真机复测（改动为纯逻辑 + 判定层，已由单测覆盖原始失败路径）。

https://claude.ai/code/session_01EsVs5nmbLVprZFsaGzhbqb
