### PR TITLE
docs(agent): 沉淀三类并发伪红判别纪律 (TODO-2658/2670)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@
 ## 验证
 
 - 文档改动：至少 `git diff --cached --check`，不必跑 Flutter 测试。
-- Dart/Flutter 改动（在 `hibiki/` 下）：`dart format` 改动文件 + push 前全量 `flutter analyze`（含 test 目录，CI 把 warning 当致命）+ **按爆炸半径分级的测试**——分支上跑改动覆盖 + 相邻功能的定向 `flutter test <目标> --no-pub`，全量套件由 PR CI 兜底（真单测门是 Build Release APK 的 Run unit tests）；**合入 `develop` 前仍必须本地全量测试，且必须走 `dart run tool/flutter_test_failures.dart --no-pub`**——它是唯一会把「一个测试都没跑成」判为失败的入口（native asset 下载失败、编译失败、tag 过滤把测试全滤掉都算失败），并在 stdout 末行打 `FLUTTER TEST VERDICT: PASSED - N tests ran` / `FAILED - <原因>`。**判绿只认这行 + 退出码**：裸 `flutter test ... | tail -N` 的退出码是 `tail` 的、恒为 0，构建失败时零测试执行会被伪装成通过（BUG-1157）。分级判据见 [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md)。（工具链钉定：本地 `.fvmrc` 3.41.6，CI 3.44.0；本机 flutter 不在 PATH 就把完整路径写进 `CLAUDE.local.md`。）
+- Dart/Flutter 改动（在 `hibiki/` 下）：`dart format` 改动文件 + push 前全量 `flutter analyze`（含 test 目录，CI 把 warning 当致命）+ **按爆炸半径分级的测试**——分支上跑改动覆盖 + 相邻功能的定向 `flutter test <目标> --no-pub`，全量套件由 PR CI 兜底（真单测门是 Build Release APK 的 Run unit tests）；**合入 `develop` 前仍必须本地全量测试，且必须走 `dart run tool/flutter_test_failures.dart --no-pub`**——它是唯一会把「一个测试都没跑成」判为失败的入口（native asset 下载失败、编译失败、tag 过滤把测试全滤掉都算失败），并在 stdout 末行打 `FLUTTER TEST VERDICT: PASSED - N tests ran` / `FAILED - <原因>`。**判绿只认这行 + 退出码**：裸 `flutter test ... | tail -N` 的退出码是 `tail` 的、恒为 0，构建失败时零测试执行会被伪装成通过（BUG-1157）。分级判据见 [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md)。**测试红了不等于代码坏了**：本机 5~10 个 agent 并发，实测有三类并发伪红（互抢 `sqlite3.dll` / 宿主 IPC 崩溃致 suite 装载失败 / 结果文件被抢致零输出），**遇红先分型再动手**，且**不许拿「可能是伪红」当借口跳过真红**、**零测试执行的红也不算红**——症状、定性办法和三条判别纪律见 [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md) 的「并发伪红判别」。（工具链钉定：本地 `.fvmrc` 3.41.6，CI 3.44.0；本机 flutter 不在 PATH 就把完整路径写进 `CLAUDE.local.md`。）
 - Android 资源/manifest/Gradle/权限/通知/前台服务/打包改动：再加 `gradlew :app:assembleRelease`（在 `hibiki/android/`；Windows 用 `.\gradlew.bat`）。
 - 阅读器/导入/播放/布局问题，声明「修好了」前必须用真实模拟器或用户指定设备复测原始失败路径并留证据（见 [docs/agent/integration-testing.md](docs/agent/integration-testing.md)）。
 - 集成测试操作真 app **一律焦点驱动（`FocusDriver` / `tester.sendKeyEvent`，禁止 `tester.tap` 或坐标点击）**：`Tab` 遍历→检测控件类型→Switch/按钮确认用 `Enter`（**不要用空格**——App 已把裸空格中和为 `DoNothingIntent`，焦点确认统一走 Enter / 手柄 A，见 `hibiki/lib/src/shortcuts/global_navigation.dart`）、Slider/Stepper/Segmented 用方向键→断言真写穿 DB/真生效→还原。同一份测试三端可跑（模拟器 `-d emulator-<port>` / Windows 离屏 `hibiki/tool/run_windows_itest.ps1` / Mac 跨机 `tool/run_mac_itest.ps1`），完整流程见 [docs/agent/integration-testing.md](docs/agent/integration-testing.md) 的「焦点驱动操作」。
@@ -113,7 +113,7 @@
 
 | 要做的事 | 看这里 |
 |---|---|
-| 加功能/修 bug/合并的分级快车道：难度分级、子代理分工、并行时间线、验证分级 | [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md) |
+| 加功能/修 bug/合并的分级快车道：难度分级、子代理分工、并行时间线、验证分级、**并发伪红判别** | [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md) |
 | 5 平台构建 / Melos / bootstrap + 依赖补丁机制 / 发布通道与版本号规则 / galgame helper Windows 随包与在线更新 | [docs/agent/build.md](docs/agent/build.md) |
 | 模拟器集成测试三层架构 / 焦点驱动（禁坐标点击）/ AnkiDroid provisioning / ADB 降级 / DB 查询 / 测试素材 | [docs/agent/integration-testing.md](docs/agent/integration-testing.md) |
 | 持续审查模式 / docs/reviews 报告格式 / 回归记录 | [docs/agent/review-process.md](docs/agent/review-process.md) |

--- a/docs/agent/fast-workflow.md
+++ b/docs/agent/fast-workflow.md
@@ -49,7 +49,27 @@ S/A 级同理裁剪：S 级连 worktree bootstrap 都可 `-SkipBootstrap` 到底
 - **定向测试** = 改动直接覆盖的 test 文件 + 相邻功能的 test 文件，`flutter test test/<路径> --no-pub`。
 - **`flutter analyze` 全量在 push 前必跑**（含 test 目录）——它本身只要秒级~1 分钟，而 CI 把 warning 当致命，省这一步只会在 CI 上浪费一轮。
 - **分支 draft PR**：定向测试绿 + 全量 analyze 绿即可 push；全量 test 由 CI 兜底（真单测门是 **Build Release APK 的 Run unit tests**，不是 Build and Test）。声明「修好了」的真机复测门槛**不变**（[integration-testing.md](integration-testing.md)）。
-- **合入 `develop`**：integration owner 本地全量 analyze + 全量 test **不变**（bash 环境跑；别 `| tail` 吞退出码；别重叠跑锁 sqlite3.dll）。
+- **合入 `develop`**：integration owner 本地全量 analyze + 全量 test **不变**（bash 环境跑；别 `| tail` 吞退出码；重叠跑会互抢 `sqlite3.dll`，见下节）。
+
+## 并发伪红判别
+
+本机常态是 5~10 个 agent 同时跑测试，**测试红有相当比例不是被测代码坏了**。下面三类都是实测形态，各有独立的定性办法。
+
+**遇红先分型，再动手**——断言失败 / suite 装载失败 / 零输出，三者的处置完全不同，串了型就是白追一轮。
+
+| 形态 | 症状 | 定性办法 | 处置 |
+|---|---|---|---|
+| ① 互抢 `sqlite3.dll` | 多个 `flutter_tester` 争用同一份 native 库；无关文件莫名失败，或进程不报错只静停 | 数一下本机在跑的并发测试进程（`dart` / `flutter_tester`） | 别重叠跑；错开或串行化后单独重跑该目标确认 |
+| ② 宿主 IPC 崩溃 | VERDICT `FAILED - ...(N 个 error event(s), M 个 tests completed)`，但**零断言失败**；日志里 `Bad state: Cannot close sink while adding stream.` @ `flutter_tools/flutter_platform.dart:766` → `Connection closed before test suite loaded` | 本质是 suite **装载**失败，不是断言失败。**分片重跑并对账**：各分片完成数之和 ≈ 原批完成数 + 没装载上的数量 | 账对得上 → 伪红，按分片结果判绿，并在回报里写清对账数字 |
+| ③ 结果文件被抢 | 跑很久**零输出、像卡死**；既没断言失败也没装载失败 | 看有没有并发进程在写同一份 `.codex-test/flutter-test/flutter_test.jsonl`（`flutter_test_failures.dart` 的默认输出目录就是 `../.codex-test/flutter-test`，所有 agent 共用） | **规避优先于诊断**：每次跑都显式给独立输出，`--output-dir=../.codex-test/flutter-test-<任务名>` |
+
+出处：② PR#716 实测（7 路并发 / 27 个 dart+flutter_tester 进程；分片对账 325 + 2602 = 2927 ≈ 2923 完成 + 4 个没装载上）；③ PR#728 实测。
+
+### 判别纪律（三条，不可打折）
+
+1. **先分型再动手**：先看是断言失败、suite 装载失败还是零输出。只有断言失败才是「被测代码可能坏了」，另两类先按并发伪红查。
+2. 🔴 **不许拿「可能是并发伪红」当借口跳过真红**。伪红是要**证明**出来的（进程数、分片对账、并发结果文件），不是默认假设。判不明就如实写一句「这条红我没判明，交给 CI」并继续推进——**不要反复重跑碰运气，也不要默认它是假的**。
+3. 🔴 **零测试执行的红也不算红**。变异测试里删掉整行造成编译失败、`0 tests ran` 的，那不是行为红，是**无效变异**，必须把变异改成能编译的形态再跑。这与「零测试执行的绿是假绿」（BUG-1157）是同一枚硬币的两面：**`N tests ran` 的 N 本身就是判据的一部分**，N=0 时 PASSED 和 FAILED 都不成立。
 
 ## 合并流水线（integration owner）
 


### PR DESCRIPTION
## 为什么

本机常态 5~10 个 agent 并发跑测试。本会话已**三次**有 agent 把并发导致的假失败当成真红去追（或反过来差点拿它当借口跳过真红）。这三类此前**只活在看板里，新 agent 看不到**。

## 写到哪

`docs/agent/fast-workflow.md` 新增「并发伪红判别」一节（紧接既有「验证分级细则」），+ `CLAUDE.md` 验证章节一行指针 + 索引表补词。

选它的理由：`CLAUDE.md` 明确说「详细操作流程拆到 `docs/agent/`」；`fast-workflow.md` 就是「验证按爆炸半径分级」的归宿，而且**唯一一处 `sqlite3.dll` 提法本来就在它第 52 行**（半句话）。`integration-testing.md` 讲的是真机/模拟器集成测试，不是单测判绿。没有新建文件。

## 三类形态（表格：症状 / 定性办法 / 处置）

| 形态 | 关键点 |
|---|---|
| ① 互抢 `sqlite3.dll` | 原来只有半句「别重叠跑锁 sqlite3.dll」，补齐成完整条目 |
| ② 宿主 IPC 崩溃（PR#716 实测） | VERDICT `FAILED - (N 个 error event(s), M 个 tests completed)` 但**零断言失败**；`Bad state: Cannot close sink while adding stream.` @ `flutter_platform.dart:766` → `Connection closed before test suite loaded`。本质是 suite **装载**失败。定性 = **分片重跑并对账**（实测 325+2602=2927 ≈ 2923 完成 + 4 个没装载上） |
| ③ 结果文件被抢（PR#728 实测） | 跑很久**零输出像卡死**；并发撞同一份 `.codex-test/flutter-test/flutter_test.jsonl`（`flutter_test_failures.dart` 默认输出目录所有 agent 共用）。规避 = `--output-dir=../.codex-test/flutter-test-<任务名>` |

## 判别纪律（重点）

1. **遇红先分型再动手** —— 断言失败 / suite 装载失败 / 零输出，处置完全不同。
2. 🔴 **不许拿「可能是伪红」当借口跳过真红**：伪红要**证明**（进程数 / 分片对账 / 并发结果文件），不是默认假设；判不明就如实写「这条红我没判明，交给 CI」并继续，不反复重跑碰运气。
3. 🔴 **零测试执行的红也不算红**：编译失败致 `0 tests ran` 的变异是**无效变异**，不是行为红。与既有「零测试执行的绿是假绿」(BUG-1157) 并列写在一起 —— `N tests ran` 的 N 本身就是判据的一部分。

## 既有矛盾说法

扫了 `CLAUDE.md` / `hibiki/CLAUDE.md` / `AGENTS.md` / `docs/agent/*` / `docs/BUGS.md`，**没有找到「测试红了就是坏了」这类绝对化表述需要订正**。唯一相关的 `CLAUDE.md` 根因修复条款说的是「先复现或沿真实代码路径定位」，与「先分型」相容，未改动。

## 范围

纯文档，2 文件 +23/-3。**未碰任何生产代码或测试代码**，未 bump `+build`。

## 门禁

- `git diff --cached --check` 干净
- `flutter analyze`（全量含 test）：`No issues found! (ran in 76.5s)`，EXIT=0
- 两条元守卫（`source_guard_adoption_test` + `md3_design_system_static_test`），经 `hibiki/tool/flutter_test_failures.dart`（输出重定向到文件，未接管道，独立 `--output-dir`）：
  `FLUTTER TEST VERDICT: PASSED - 66 tests ran, all tests passed`，EXIT=0

按用户提速指令，本轮未跑其它套件。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
