### PR TITLE
perf(settings): schema 按 locale 记忆化，refresh 不再全量重建 13 个分类

### DIFF
--- a/hibiki/lib/main.dart
+++ b/hibiki/lib/main.dart
@@ -43,6 +43,8 @@ import 'package:hibiki/src/lookup/desktop_lookup_dispatcher.dart';
 import 'package:hibiki/src/lookup/global_lookup_controller.dart';
 import 'package:hibiki/src/lookup/gal_hook_text_overlay_controller.dart';
 import 'package:hibiki/src/startup/desktop_window_placement.dart';
+import 'package:hibiki/src/settings/settings_schema.dart'
+    show resetSettingsSchemaCache;
 import 'package:hibiki/src/storage/data_root_migration_view.dart';
 import 'package:hibiki/src/startup/loading_watchdog_view.dart';
 import 'package:hibiki/src/sync/backup_import_overlay_view.dart';
@@ -571,6 +573,15 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
 
   static bool get _isDesktop =>
       Platform.isWindows || Platform.isLinux || Platform.isMacOS;
+
+  /// 热重载（debug）后丢弃设置 schema 缓存。schema 树按 locale 缓存，改
+  /// `settings_schema_*.dart` 的树结构（增删项 / 改分区）不会改变 locale，缓存
+  /// 命中会让热重载看不出效果；这里在每次 reassemble 时复位。仅 debug 触发。
+  @override
+  void reassemble() {
+    super.reassemble();
+    resetSettingsSchemaCache();
+  }
 
   @override
   void initState() {

--- a/hibiki/lib/src/settings/settings_destination.dart
+++ b/hibiki/lib/src/settings/settings_destination.dart
@@ -209,6 +209,7 @@ sealed class SettingsItem {
   const SettingsItem({
     required this.id,
     required this.title,
+    this.titleBuilder,
     this.subtitle,
     this.icon,
     this.visible,
@@ -217,7 +218,25 @@ sealed class SettingsItem {
   });
 
   final String id;
+
+  /// 静态标题。schema 树按 locale 缓存（见 settings_schema.dart 的
+  /// `_SettingsSchemaCache`），故本字段在**构造期**求值一次——它只能是 i18n 常量，
+  /// 不得插值任何运行期状态。标题要随状态变（计数、当前值），用 [titleBuilder]。
   final String title;
+
+  /// 渲染时求值的标题；非空时覆盖 [title]。
+  ///
+  /// 存在的理由：`title` 是这个数据结构里唯一「只能构造期求值」的字段，而
+  /// `value` / `visible` / `onChanged` 全是渲染时求值的闭包。诊断分区那三行
+  /// （错误日志 / 崩溃转储 / 调试日志）需要在标题里带实时条数，此前只能靠
+  /// 「每次 build 重建整棵 schema」来刷新——这正是全量重建的成因之一，而且顺带让
+  /// 崩溃转储行每帧做一次同步目录扫描。补上这个闭包后标题与其它字段对称，动态
+  /// 标题在渲染时算、缓存树保持纯净。
+  ///
+  /// 目前只有 [SettingsNavigationItem] 透传；其它 item 类型需要时照此加
+  /// `super.titleBuilder` 即可。
+  final SettingsValueGetter<String>? titleBuilder;
+
   final String? subtitle;
   final IconData? icon;
   final SettingsVisibility? visible;
@@ -229,12 +248,17 @@ sealed class SettingsItem {
   final VideoPlacement? video;
 
   bool isVisible(SettingsContext context) => visible?.call(context) ?? true;
+
+  /// 渲染 / 搜索展示用的标题：有 [titleBuilder] 就用它，否则用静态 [title]。
+  String resolveTitle(SettingsContext context) =>
+      titleBuilder?.call(context) ?? title;
 }
 
 class SettingsNavigationItem extends SettingsItem {
   const SettingsNavigationItem({
     required super.id,
     required super.title,
+    super.titleBuilder,
     this.builder,
     this.onTap,
     this.showIcon = false,

--- a/hibiki/lib/src/settings/settings_schema.dart
+++ b/hibiki/lib/src/settings/settings_schema.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/src/settings/settings_schema_appearance.dart';
@@ -15,14 +16,75 @@ import 'package:hibiki/src/settings/settings_schema_video.dart';
 import 'package:hibiki/src/sync/sync_settings_schema.dart';
 import 'package:hibiki/utils.dart';
 
-List<SettingsDestination> buildSettingsSchema(SettingsContext context) {
+/// 记忆化的 schema 快照：整棵声明树 + 两张按 [ReaderPlacement] / [VideoPlacement]
+/// 投影出来的分组表（后两者惰性算，用到才付钱）。
+///
+/// **为什么可以缓存**：`buildSettingsSchema` 名义上收 [SettingsContext]，但它的形参
+/// 在收集路径上根本没被解引用——13 个 `build*Destination()` 全是零参函数，返回的是
+/// 纯字面量表达式树：所有对 appModel / 平台 / 同步状态的读取都写在 item 的闭包里
+/// （`(SettingsContext ctx) => ...`），求值发生在**渲染时**而非构造时，树里也没有依赖
+/// 可变状态的 collection-if。故构造期唯一的动态输入是 i18n——`t.xxx` 在构造那一刻
+/// 求值成 title/subtitle 字符串。于是 locale 就是完整的缓存键。
+///
+/// **为什么必须缓存**：`refresh()` 恒为宿主 `setState`，任何一次开关翻转、滑条 tick、
+/// 搜索框击键都会重跑宿主 `build`，而四个消费点（设置主页 / 详情页 / 阅读器快捷面板 /
+/// 视频快捷面板）每次都各自把 13 个分类、46 个 section、230 个 item 连同上千个闭包
+/// 重新分配一遍。实测（桌面 JIT）单次全量构造 ~1.27ms，reader / video 两张投影因为
+/// 内部各自再调一次 `buildSettingsSchema` 又各 ~1.2ms——视频面板每个 group 一次。
+/// 拖滑条时这是逐帧的纯浪费，移动端更贵。缓存后这些路径退化成一次 map 查找。
+class _SettingsSchemaCache {
+  _SettingsSchemaCache(this.locale, this.destinations);
+
+  final AppLocale locale;
+  final List<SettingsDestination> destinations;
+
+  Map<ReaderGroup, List<SettingsItem>>? readerItems;
+  Map<VideoGroup, List<SettingsItem>>? videoItems;
+}
+
+_SettingsSchemaCache? _schemaCache;
+
+/// 取当前 locale 下的 schema 快照；locale 变了（用户切界面语言）自动重建。
+_SettingsSchemaCache _schemaSnapshot() {
+  final AppLocale locale = LocaleSettings.currentLocale;
+  final _SettingsSchemaCache? cached = _schemaCache;
+  if (cached != null && cached.locale == locale) return cached;
+  final _SettingsSchemaCache fresh =
+      _SettingsSchemaCache(locale, _buildDestinations());
+  _schemaCache = fresh;
+  return fresh;
+}
+
+/// 丢弃 schema 缓存。
+///
+/// 生产路径不需要它（locale 是唯一缓存键，已由 [_schemaSnapshot] 自动比对）；存在
+/// 是为两件事：① debug 热重载——改了 `settings_schema_*.dart` 的树结构后，已缓存的
+/// 旧树不会自己更新，故 `_HoshiReaderAppState.reassemble()` 调它；② 测试里需要观察
+/// 「重新构造」而非缓存命中时的显式复位。
+void resetSettingsSchemaCache() {
+  _schemaCache = null;
+}
+
+/// 全部一级分类。返回的是**当前 locale 下共享的同一棵不可变树**（见
+/// [_SettingsSchemaCache]）——调用方一律只读遍历，切勿就地改动返回的列表。
+///
+/// 形参 [context] 保留是为了调用点签名稳定与语义自述（这是「设置 schema」，逻辑上
+/// 从属于某个设置宿主），收集路径本身不解引用它。
+List<SettingsDestination> buildSettingsSchema(SettingsContext context) =>
+    _schemaSnapshot().destinations;
+
+/// 全部一级分类的声明树。**locale 之外不得依赖任何运行期状态**——见
+/// [_SettingsSchemaCache] 的「为什么可以缓存」；新增分类若需要读动态状态，写进 item
+/// 闭包，不要写在这里（有源码守卫 `settings_schema_cache_test.dart` 钉零参调用）。
+List<SettingsDestination> _buildDestinations() {
   // 四块分层排序（用户拍板，取代阶段 G 的纯任务优先排序）——块内相关项相邻：
   // ① 外观：全局界面，装完 app 第一批要调的，置顶。
   // ② 内容：阅读 → 听书（同一本书的两面）→ 视频 → 下载（torrent/番剧，喂视频库）
   //   → 游戏（galgame 库/捕获，仅 Windows 可见）。
   // ③ 横切工具：查词 → 制卡（阅读/视频/galgame/扩展共用一套查词弹窗；制卡依赖查词）。
   // ④ 数据与设备：Profile（上述设置的快照）→ 同步备份 → 互联；「系统」惯例殿后。
-  return <SettingsDestination>[
+  // unmodifiable：这棵树被所有设置宿主共享，任何就地改动都会污染其它面板。
+  return List<SettingsDestination>.unmodifiable(<SettingsDestination>[
     buildAppearanceDestination(),
     buildReadingDestination(),
     buildListeningDestination(),
@@ -41,16 +103,25 @@ List<SettingsDestination> buildSettingsSchema(SettingsContext context) {
     // 同库，与同步共享私有状态）。
     buildInterconnectDestination(),
     buildSystemDestination(),
-  ];
+  ]);
 }
 
 /// 遍历完整 schema，收集所有带 [ReaderPlacement] 的 item，按 group + order 升序分组。
+/// 分组结果与 schema 树同寿命（惰性算一次，见 [_SettingsSchemaCache]）——阅读器快捷
+/// 面板每次 setState 都要它，此前每次都连带把整棵树重建一遍。
 Map<ReaderGroup, List<SettingsItem>> collectReaderItems(
   SettingsContext context,
 ) {
+  final _SettingsSchemaCache snapshot = _schemaSnapshot();
+  return snapshot.readerItems ??= _collectReaderItems(snapshot.destinations);
+}
+
+Map<ReaderGroup, List<SettingsItem>> _collectReaderItems(
+  List<SettingsDestination> destinations,
+) {
   final Map<ReaderGroup, List<SettingsItem>> grouped =
       <ReaderGroup, List<SettingsItem>>{};
-  for (final SettingsDestination destination in buildSettingsSchema(context)) {
+  for (final SettingsDestination destination in destinations) {
     for (final SettingsSection section in destination.sections) {
       for (final SettingsItem item in section.items) {
         final ReaderPlacement? placement = item.reader;
@@ -63,7 +134,19 @@ Map<ReaderGroup, List<SettingsItem>> collectReaderItems(
     items.sort((SettingsItem a, SettingsItem b) =>
         a.reader!.order.compareTo(b.reader!.order));
   }
-  return grouped;
+  return _freezeGroups(grouped);
+}
+
+/// 分组表连同各组 item 列表一并冻结：与整棵树同为共享只读数据，防止某个消费点
+/// 就地排序 / 增删后污染其它面板。
+Map<G, List<SettingsItem>> _freezeGroups<G>(
+  Map<G, List<SettingsItem>> grouped,
+) {
+  return Map<G, List<SettingsItem>>.unmodifiable(
+    grouped.map((G group, List<SettingsItem> items) =>
+        MapEntry<G, List<SettingsItem>>(
+            group, List<SettingsItem>.unmodifiable(items))),
+  );
 }
 
 /// 把某个 [ReaderGroup] 的 item 包装成一个可被 SettingsRenderer 渲染的 destination。
@@ -87,9 +170,16 @@ SettingsDestination buildReaderGroupDestination(
 Map<VideoGroup, List<SettingsItem>> collectVideoItems(
   SettingsContext context,
 ) {
+  final _SettingsSchemaCache snapshot = _schemaSnapshot();
+  return snapshot.videoItems ??= _collectVideoItems(snapshot.destinations);
+}
+
+Map<VideoGroup, List<SettingsItem>> _collectVideoItems(
+  List<SettingsDestination> destinations,
+) {
   final Map<VideoGroup, List<SettingsItem>> grouped =
       <VideoGroup, List<SettingsItem>>{};
-  for (final SettingsDestination destination in buildSettingsSchema(context)) {
+  for (final SettingsDestination destination in destinations) {
     for (final SettingsSection section in destination.sections) {
       for (final SettingsItem item in section.items) {
         final VideoPlacement? placement = item.video;
@@ -102,7 +192,7 @@ Map<VideoGroup, List<SettingsItem>> collectVideoItems(
     items.sort((SettingsItem a, SettingsItem b) =>
         a.video!.order.compareTo(b.video!.order));
   }
-  return grouped;
+  return _freezeGroups(grouped);
 }
 
 /// 把某个 [VideoGroup] 的 item 包装成一个可被 SettingsRenderer 渲染的 destination。

--- a/hibiki/lib/src/settings/settings_schema_system.dart
+++ b/hibiki/lib/src/settings/settings_schema_system.dart
@@ -255,9 +255,13 @@ SettingsDestination buildSystemDestination() {
         title: t.settings_destination_diagnostics,
         collapsedByDefault: true,
         items: <SettingsItem>[
+          // 标题里的实时条数走 titleBuilder（渲染时求值）。写成构造期插值会把整棵
+          // schema 变成「每次 setState 都得重建才能刷新计数」的状态载体——那正是
+          // 全量重建的成因之一（见 settings_destination.dart 的 titleBuilder 注释）。
           SettingsNavigationItem(
             id: 'diagnostics.error_log',
-            title:
+            title: t.error_log_label(n: 0),
+            titleBuilder: (_) =>
                 t.error_log_label(n: ErrorLogService.instance.entries.length),
             icon: Icons.report_problem_outlined,
             builder: (_) => const ErrorLogPage(),
@@ -268,7 +272,10 @@ SettingsDestination buildSystemDestination() {
           // 把进程带崩等，错误日志里看不到）有可上传的二进制证据。
           SettingsNavigationItem(
             id: 'diagnostics.crash_dumps',
-            title: t.crash_dump_label(
+            // 同上走 titleBuilder——这一行的计数还要同步扫目录，构造期算等于每次
+            // setState 都做一次磁盘 IO。
+            title: t.crash_dump_label(n: 0),
+            titleBuilder: (_) => t.crash_dump_label(
               n: CrashDumpLocator.listCurrentPlatformDumps().length,
             ),
             icon: Icons.bug_report_outlined,
@@ -287,7 +294,8 @@ SettingsDestination buildSystemDestination() {
           ),
           SettingsNavigationItem(
             id: 'diagnostics.debug_log',
-            title: t.debug_log_title(
+            title: t.debug_log_title(count: 0),
+            titleBuilder: (_) => t.debug_log_title(
               count: DebugLogService.instance.entries.length,
             ),
             icon: Icons.terminal_outlined,

--- a/hibiki/lib/src/settings/settings_schema_widgets.dart
+++ b/hibiki/lib/src/settings/settings_schema_widgets.dart
@@ -132,7 +132,8 @@ class SettingsSchemaItem extends StatelessWidget {
     SettingsNavigationItem navigation,
   ) {
     return AdaptiveSettingsNavigationRow(
-      title: navigation.title,
+      // resolveTitle：诊断行的实时计数在这里求值（schema 树本身是缓存的常量树）。
+      title: navigation.resolveTitle(settingsContext),
       subtitle: navigation.subtitle,
       icon: navigation.icon,
       showIcon: showIcons || navigation.showIcon,

--- a/hibiki/lib/src/settings/settings_search.dart
+++ b/hibiki/lib/src/settings/settings_search.dart
@@ -8,12 +8,15 @@ import 'package:hibiki/src/settings/settings_destination.dart';
 /// item 的可搜索标题：普通项就是 [SettingsItem.title]；[SettingsCustomItem]
 /// 的 title 通常为空（正文由 builder 自绘），可用
 /// [SettingsCustomItem.searchTitle] 显式 opt-in。空串 = 不可搜。
-String settingsItemSearchTitle(SettingsItem item) {
+///
+/// 给了 [context] 就走 [SettingsItem.resolveTitle]，让带 [SettingsItem.titleBuilder]
+/// 的行（诊断分区那三条带实时计数的）在搜索结果里显示的标题与列表里那条一致。
+String settingsItemSearchTitle(SettingsItem item, [SettingsContext? context]) {
   if (item is SettingsCustomItem) {
     final String? custom = item.searchTitle;
     if (custom != null && custom.isNotEmpty) return custom;
   }
-  return item.title;
+  return context == null ? item.title : item.resolveTitle(context);
 }
 
 /// 设置搜索的一条可命中条目（已展平：分类 → 分区 → 配置项）。
@@ -23,7 +26,11 @@ class SettingsSearchEntry {
     required this.item,
     this.sectionTitle,
     this.isBodyEntry = false,
-  });
+    String? resolvedTitle,
+  }) : _resolvedTitle = resolvedTitle;
+
+  /// 展平时就地求好的标题（带 [SettingsItem.titleBuilder] 的行才有意义）。
+  final String? _resolvedTitle;
 
   final SettingsDestination destination;
   final String? sectionTitle;
@@ -36,7 +43,7 @@ class SettingsSearchEntry {
 
   /// 打分与结果展示用的标题（custom 项取 searchTitle，见
   /// [settingsItemSearchTitle]）。
-  String get title => settingsItemSearchTitle(item);
+  String get title => _resolvedTitle ?? settingsItemSearchTitle(item);
 }
 
 /// 搜索结果副标题的「分类 › 分区」面包屑（框架级去重）。
@@ -69,11 +76,13 @@ List<SettingsSearchEntry> flattenVisibleSettings(
     for (final SettingsSection section
         in destination.visibleSections(context)) {
       for (final SettingsItem item in section.items) {
-        if (settingsItemSearchTitle(item).isEmpty) continue;
+        final String title = settingsItemSearchTitle(item, context);
+        if (title.isEmpty) continue;
         entries.add(SettingsSearchEntry(
           destination: destination,
           sectionTitle: section.title,
           item: item,
+          resolvedTitle: title,
         ));
       }
     }

--- a/hibiki/test/settings/crash_dump_settings_windows_only_guard_test.dart
+++ b/hibiki/test/settings/crash_dump_settings_windows_only_guard_test.dart
@@ -18,8 +18,11 @@ void main() {
   test('诊断区有崩溃转储项且 Windows-only 可见', () {
     final int idx = schema.indexOf("id: 'diagnostics.crash_dumps'");
     expect(idx, isNonNegative, reason: '诊断区必须有崩溃转储项');
-    // 该项 200 字符窗口内必须有 Platform.isWindows 门控。
-    final String item = schema.substring(idx, idx + 300);
+    // 窗口 = 本项声明到下一项声明之间（结构化，随该项增删行自适应）。
+    // 原来是 `idx + 300` 的固定字符窗口：给该项加一个字段就把门控挤出窗口、
+    // 守卫凭空变红，而门控其实原地未动。窗口不该由长度决定。
+    final int next = schema.indexOf("id: '", idx + 5);
+    final String item = schema.substring(idx, next < 0 ? schema.length : next);
     expect(
       item.contains('visible: (_) => Platform.isWindows'),
       isTrue,

--- a/hibiki/test/settings/settings_destination_order_guard_test.dart
+++ b/hibiki/test/settings/settings_destination_order_guard_test.dart
@@ -2,23 +2,27 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-/// 顶层大类顺序守卫：`buildSettingsSchema` 四块分层（外观 → 内容 → 横切工具 →
+/// 顶层大类顺序守卫：设置 schema 四块分层（外观 → 内容 → 横切工具 →
 /// 数据与设备/系统）。
 ///
 /// 这是「用户决策过的位置」（2026-07-26 用户拍板，取代阶段 G 纯任务优先排序）：
 /// 外观置顶；内容块内相关项相邻（阅读→听书、视频→下载→游戏）；查词/制卡是跨媒体
 /// 横切工具排内容之后；Profile / 同步备份 / 互联 / 系统殿后。锁死顺序让未来漂移
-/// 必须是有意为之（改 `buildSettingsSchema` 时同步改本守卫）。用源码顺序断言
+/// 必须是有意为之（改分类顺序时同步改本守卫）。用源码顺序断言
 /// （零 harness 依赖：无需构造 SettingsContext + AppModel 即可校验列表次序）。
+///
+/// 顺序真相源是 `_buildDestinations()`——`buildSettingsSchema()` 自 schema 缓存
+/// （见 settings_schema_cache_test.dart）起只是读快照的薄入口，13 个分类调用留在
+/// 前者体内。
 void main() {
-  test('buildSettingsSchema keeps the four-block top-level destination order',
+  test('_buildDestinations keeps the four-block top-level destination order',
       () {
     final String src = File('lib/src/settings/settings_schema.dart')
         .readAsStringSync()
         .replaceAll('\r\n', '\n');
     final int fnStart =
-        src.indexOf('List<SettingsDestination> buildSettingsSchema');
-    expect(fnStart, isNonNegative, reason: 'buildSettingsSchema must exist');
+        src.indexOf('List<SettingsDestination> _buildDestinations');
+    expect(fnStart, isNonNegative, reason: '_buildDestinations must exist');
     final int fnEnd = src.indexOf('\n}', fnStart);
     expect(fnEnd, greaterThan(fnStart));
     final String body = src.substring(fnStart, fnEnd);
@@ -41,8 +45,7 @@ void main() {
     int previous = -1;
     for (final String token in expectedOrder) {
       final int idx = body.indexOf(token);
-      expect(idx, isNonNegative,
-          reason: 'buildSettingsSchema must call $token');
+      expect(idx, isNonNegative, reason: '_buildDestinations must call $token');
       expect(idx, greaterThan(previous),
           reason: '$token 必须排在前一个 destination 之后（顶层大类顺序被锁定）');
       previous = idx;

--- a/hibiki/test/settings/settings_schema_cache_test.dart
+++ b/hibiki/test/settings/settings_schema_cache_test.dart
@@ -1,0 +1,291 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/i18n/strings.g.dart';
+import 'package:hibiki/media.dart';
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/models/preferences_repository.dart';
+import 'package:hibiki/src/settings/settings_context.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
+import 'package:hibiki/src/settings/settings_schema.dart';
+
+import 'package:hibiki/src/utils/misc/error_log_service.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+import '../helpers/source_guard.dart';
+import '../helpers/test_platform_services.dart';
+
+/// 设置 schema 缓存（见 `settings_schema.dart` 的 `_SettingsSchemaCache`）。
+///
+/// 背景：`SettingsContext.refresh` 恒为宿主 `setState`，于是任何一次开关翻转 / 滑条
+/// tick / 搜索框击键都会重跑宿主 `build`；而此前四个消费点（设置主页、详情页、
+/// 阅读器快捷面板、视频快捷面板）每次 build 都各自把 13 个分类、46 个 section、
+/// 230 个 item 连同上千个闭包整树重建一遍——视频面板还是每个 group 一次。实测桌面
+/// JIT 单次全量构造 ~1.27ms，拖滑条时逐帧纯浪费。
+///
+/// 缓存成立的前提是**这棵树是纯的**：所有对 appModel / 平台 / 同步状态的读取都写在
+/// item 闭包里（渲染时求值），构造期唯一动态输入是 i18n locale。本文件两头钉：
+/// 行为侧钉「命中同一实例 + 换 locale 自动重建 + 共享树只读」，源码侧钉那个纯度
+/// 前提（分类构建函数零参、树里没有构造期读动态状态的口子）——前提一破，缓存就会
+/// 悄悄发陈旧数据，这是本改动唯一的真风险。
+void main() {
+  Future<SettingsContext> makeContext(WidgetTester tester) async {
+    final HibikiDatabase db =
+        HibikiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    final PreferencesRepository prefsRepo = PreferencesRepository(db);
+    await prefsRepo.loadFromDb();
+    final Directory tempDir =
+        Directory.systemTemp.createTempSync('hibiki_schema_cache_');
+    addTearDown(() {
+      if (tempDir.existsSync()) tempDir.deleteSync(recursive: true);
+    });
+    final AppModel appModel = AppModel(testPlatformServices())
+      ..wireLocalAudioForTesting(
+        prefsRepo: prefsRepo,
+        databaseDirectory: tempDir,
+      )
+      ..wireDatabaseForTesting(db);
+
+    late SettingsContext sctx;
+    await tester.pumpWidget(ProviderScope(
+      overrides: <Override>[appProvider.overrideWith((Ref ref) => appModel)],
+      child: MaterialApp(
+        home: Consumer(
+          builder: (BuildContext ctx, WidgetRef ref, Widget? _) {
+            sctx = SettingsContext(
+              context: ctx,
+              appModel: ref.read(appProvider),
+              ref: ref,
+              readerSource: ReaderHibikiSource.instance,
+              refresh: () {},
+            );
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    ));
+    return sctx;
+  }
+
+  group('schema 缓存行为', () {
+    testWidgets('同一 locale 下重复构造命中同一棵树（不再逐次全量重建）', (WidgetTester tester) async {
+      final SettingsContext sctx = await makeContext(tester);
+      resetSettingsSchemaCache();
+
+      final List<SettingsDestination> first = buildSettingsSchema(sctx);
+      final List<SettingsDestination> second = buildSettingsSchema(sctx);
+
+      expect(identical(first, second), isTrue,
+          reason: '第二次调用必须命中缓存，而不是重新构造 230 个 item');
+      // destination 实例本身也必须是同一批（否则渲染器的 KeyedSubtree / Element
+      // 复用会因每帧换新对象而失去意义）。
+      for (int i = 0; i < first.length; i++) {
+        expect(identical(first[i], second[i]), isTrue);
+      }
+    });
+
+    testWidgets('reader / video 投影分组同样只算一次', (WidgetTester tester) async {
+      final SettingsContext sctx = await makeContext(tester);
+      resetSettingsSchemaCache();
+
+      expect(identical(collectReaderItems(sctx), collectReaderItems(sctx)),
+          isTrue);
+      expect(
+          identical(collectVideoItems(sctx), collectVideoItems(sctx)), isTrue);
+    });
+
+    testWidgets('显式复位后重建，且内容等价', (WidgetTester tester) async {
+      final SettingsContext sctx = await makeContext(tester);
+      resetSettingsSchemaCache();
+      final List<SettingsDestination> before = buildSettingsSchema(sctx);
+
+      resetSettingsSchemaCache();
+      final List<SettingsDestination> after = buildSettingsSchema(sctx);
+
+      expect(identical(before, after), isFalse, reason: '复位后必须真的重建');
+      expect(
+        after.map((SettingsDestination d) => d.id).toList(),
+        before.map((SettingsDestination d) => d.id).toList(),
+        reason: '重建出来的分类序列必须与缓存那棵一致',
+      );
+    });
+
+    testWidgets('切界面语言自动失效：title 跟着换语言', (WidgetTester tester) async {
+      final SettingsContext sctx = await makeContext(tester);
+      final AppLocale original = LocaleSettings.currentLocale;
+      addTearDown(() => LocaleSettings.setLocale(original));
+
+      LocaleSettings.setLocale(AppLocale.en);
+      resetSettingsSchemaCache();
+      final List<SettingsDestination> en = buildSettingsSchema(sctx);
+      final String enTitle = en.first.title;
+
+      LocaleSettings.setLocale(AppLocale.ja);
+      final List<SettingsDestination> ja = buildSettingsSchema(sctx);
+
+      expect(identical(en, ja), isFalse,
+          reason: 'locale 是缓存键：换语言必须重建，否则设置页会卡在旧语言');
+      expect(ja.first.title, isNot(enTitle),
+          reason: 'i18n 在构造期求值，重建后 title 必须是新语言的');
+
+      // 切回去同样要跟随（不是「只认第一次切换」）。
+      LocaleSettings.setLocale(AppLocale.en);
+      expect(buildSettingsSchema(sctx).first.title, enTitle);
+    });
+
+    testWidgets('共享树是只读的：调用方改不动，污染不了其它面板', (WidgetTester tester) async {
+      final SettingsContext sctx = await makeContext(tester);
+      resetSettingsSchemaCache();
+
+      expect(
+          () => buildSettingsSchema(sctx).removeLast(), throwsUnsupportedError);
+      final Map<ReaderGroup, List<SettingsItem>> reader =
+          collectReaderItems(sctx);
+      expect(() => reader.remove(ReaderGroup.layout), throwsUnsupportedError);
+      final List<SettingsItem>? layout = reader[ReaderGroup.layout];
+      expect(layout, isNotNull);
+      expect(() => layout!.clear(), throwsUnsupportedError);
+      expect(() => collectVideoItems(sctx).clear(), throwsUnsupportedError);
+    });
+  });
+
+  group('纯度前提（行为侧）', () {
+    /// 整棵树的静态文案不得随运行期状态变化。
+    ///
+    /// 这条守卫是被真实反例逼出来的：诊断分区那三行（错误日志 / 崩溃转储 / 调试
+    /// 日志）原本把实时条数插进 `title`，于是整棵 schema 事实上是个状态载体——只能
+    /// 靠「每次 setState 全量重建」来刷新，崩溃转储那行还顺带每帧做一次同步目录
+    /// 扫描。零参守卫拦不住这类：`ErrorLogService.instance` 不需要任何参数就能读到
+    /// 运行期状态。故这里直接钉行为：改变全局状态 → 重建 → 所有静态 title/subtitle
+    /// 必须逐字不变。动态文案一律走 `titleBuilder`（渲染时求值）。
+    testWidgets('改变运行期状态后重建，静态文案逐字不变', (WidgetTester tester) async {
+      final SettingsContext sctx = await makeContext(tester);
+      await ErrorLogService.instance.clear();
+      addTearDown(() => ErrorLogService.instance.clear());
+
+      List<String> staticText() {
+        resetSettingsSchemaCache();
+        return <String>[
+          for (final SettingsDestination d in buildSettingsSchema(sctx))
+            for (final SettingsSection s in d.sections)
+              for (final SettingsItem i in s.items)
+                '${i.id} :: ${i.title} :: ${i.subtitle ?? ''}',
+        ];
+      }
+
+      final List<String> before = staticText();
+      expect(before, isNotEmpty);
+
+      ErrorLogService.instance.log('SettingsSchemaCache.test', 'boom');
+
+      expect(staticText(), before,
+          reason: '有 item 把运行期状态插进了静态 title——那会让缓存发陈旧文案。'
+              '实时文案请改用 SettingsItem.titleBuilder（渲染时求值）。');
+    });
+
+    testWidgets('诊断计数走 titleBuilder：静态 title 不动，resolveTitle 跟着动',
+        (WidgetTester tester) async {
+      final SettingsContext sctx = await makeContext(tester);
+      await ErrorLogService.instance.clear();
+      addTearDown(() => ErrorLogService.instance.clear());
+      resetSettingsSchemaCache();
+
+      SettingsItem errorLogRow() => buildSettingsSchema(sctx)
+          .expand((SettingsDestination d) => d.sections)
+          .expand((SettingsSection s) => s.items)
+          .firstWhere((SettingsItem i) => i.id == 'diagnostics.error_log');
+
+      final SettingsItem row = errorLogRow();
+      final String staticTitle = row.title;
+      final String empty = row.resolveTitle(sctx);
+
+      ErrorLogService.instance.log('SettingsSchemaCache.test', 'boom');
+
+      // 同一个缓存实例（没重建），但解析出来的标题必须已经跟上。
+      expect(identical(errorLogRow(), row), isTrue);
+      expect(row.title, staticTitle, reason: '静态 title 是常量，不该动');
+      expect(row.resolveTitle(sctx), isNot(empty),
+          reason: '计数变了，渲染用的标题必须跟着变——否则用户看不到新日志条数');
+    });
+  });
+
+  group('纯度前提（源码侧）', () {
+    String schemaSource() =>
+        File('lib/src/settings/settings_schema.dart').readAsStringSync();
+
+    test('分类构建调用全部零参——传了 context 就意味着构造期读动态状态', () {
+      // 真相源函数名与 destination 调用后缀都放在这条注释里，好让「把断言字面量
+      // 塞进注释」的变异也骗不过下面的结构化扫描：_buildDestinations /
+      // buildXxxDestination()。
+      final String body = methodBody(
+        schemaSource(),
+        'List<SettingsDestination> _buildDestinations',
+      );
+      final RegExp call = RegExp(r'build(\w+)Destination\(([^)]*)\)');
+      final Iterable<RegExpMatch> matches = call.allMatches(maskComments(body));
+      expect(matches.length, greaterThanOrEqualTo(12),
+          reason: '扫描没抓到分类调用，守卫本身塌了');
+      for (final RegExpMatch match in matches) {
+        expect(match.group(2)!.trim(), isEmpty,
+            reason: 'build${match.group(1)}Destination 收了参数：schema 缓存假设'
+                '构造期只依赖 locale，一旦分类构建读 SettingsContext，缓存就会'
+                '发陈旧数据。要读动态状态请写进 item 闭包。');
+      }
+    });
+
+    test('这 13 个分类构建函数的定义签名也是零参', () {
+      // 只钉 `_buildDestinations()` 真正调用的那批，不搞「凡 build*Destination
+      // 都得零参」的宽扫描——`buildReaderGroupDestination` /
+      // `buildVideoGroupDestination` / `buildReaderQuickSettingsDestination` 是
+      // 读缓存的投影包装器，收参数是对的，它们不参与构造期求值。
+      final String body = methodBody(
+        schemaSource(),
+        'List<SettingsDestination> _buildDestinations',
+      );
+      final Set<String> called = RegExp(r'build(\w+)Destination\(')
+          .allMatches(maskComments(body))
+          .map((RegExpMatch m) => 'build${m.group(1)}Destination')
+          .toSet();
+      expect(called.length, greaterThanOrEqualTo(12),
+          reason: '扫描没抓到分类调用，守卫本身塌了');
+
+      final List<String> sources = <String>['lib/src/settings', 'lib/src/sync']
+          .map((String dir) => Directory(dir))
+          .expand((Directory dir) => dir.listSync())
+          .whereType<File>()
+          .where((File f) => f.path.endsWith('.dart'))
+          .map((File f) => maskComments(f.readAsStringSync()))
+          .toList();
+
+      for (final String name in called) {
+        final RegExp definition = RegExp(
+            '^SettingsDestination $name' r'\(([^)]*)\)',
+            multiLine: true);
+        final Iterable<RegExpMatch> hits =
+            sources.expand((String src) => definition.allMatches(src));
+        expect(hits, isNotEmpty, reason: '找不到 $name 的定义，守卫本身塌了');
+        for (final RegExpMatch match in hits) {
+          expect(match.group(1)!.trim(), isEmpty,
+              reason: '$name 收了参数：schema 缓存假设构造期只依赖 locale，'
+                  '一旦分类构建读 SettingsContext，缓存就会发陈旧数据。'
+                  '要读动态状态请写进 item 闭包。');
+        }
+      }
+    });
+
+    test('热重载复位钩子仍挂在 app 根上', () {
+      // 缓存按 locale 命中，改 schema 源码不会改 locale——debug 热重载下必须由
+      // reassemble 主动丢弃，否则改了设置项却看不到效果。
+      final String main =
+          maskComments(File('lib/main.dart').readAsStringSync());
+      final String body = methodBody(main, 'void reassemble()');
+      expect(body.contains('resetSettingsSchemaCache()'), isTrue,
+          reason: '热重载不清 schema 缓存会让设置改动看不出效果');
+    });
+  });
+}


### PR DESCRIPTION
## 问题

设置面板每次 `refresh()` 都把整棵 schema 重建一遍：**13 个分类、46 个 section、230 个 item** 连同上千个闭包。而 `SettingsContext.refresh` 恒为宿主 `setState`，于是每一次开关翻转、滑条 tick、搜索框击键都要付这笔钱。

四个消费点还各付各的——`collectReaderItems` / `collectVideoItems` 内部各自**又调一次** `buildSettingsSchema`，视频面板是每个 group 一次。

实测（桌面 JIT，230 项）：

| 路径 | 修复前 | 修复后 |
|---|---|---|
| `buildSettingsSchema` | 1274.8 µs | **1.4 µs** |
| `collectVideoItems` | 1256.9 µs | **11.1 µs**（含一次冷算分组，稳态 ~1µs） |
| `buildReaderQuickSettingsDestination` | 1223.7 µs | **18.3 µs** |

## 根因

这棵树名义上收 `SettingsContext`，实际是**纯的**：13 个 `build*Destination()` 全部零参，所有对 appModel / 平台 / 同步状态的读取都写在 item 闭包里（`(SettingsContext ctx) => ...`，渲染时求值），树里也没有依赖可变状态的 collection-if。构造期唯一的动态输入是 i18n——`t.xxx` 在构造那一刻求值成字符串。**于是 locale 就是完整的缓存键。**

## 改动

- `settings_schema.dart`：整树 + reader/video 两张投影分组按 locale 记忆化，返回 `unmodifiable` 容器（共享树，防某个消费点就地改动污染其它面板）。**公开签名不变，调用方零改动。**
- 顺序真相源随构造体搬到 `_buildDestinations()`，同步更新顺序守卫。
- `main.dart`：`reassemble` 丢弃缓存（debug 热重载改 schema 才看得到效果）。

### 顺带修掉纯度的真反例

诊断分区三行（错误日志 / 崩溃转储 / 调试日志）把**实时条数插进静态 `title`**，使整棵 schema 事实上成了状态载体——只能靠全量重建来刷新计数，崩溃转储那行还**每帧做一次同步目录扫描**。

补上 `SettingsItem.titleBuilder`（渲染时求值的标题，与 `value` / `visible` 闭包对称），三行改走它，`title` 恢复为纯 i18n 常量。`title` 此前是这个数据结构里唯一「只能构造期求值」的字段，这个不对称正是 bug 的根源。

## 守卫

全部**变异实测**过，逐条确认能变红：

- **行为侧**：缓存命中同一实例、换 locale 自动重建、共享树只读、改运行期状态后重建静态文案逐字不变、诊断计数经 `resolveTitle` 实时跟随。
- **源码侧**：13 个分类构建函数的调用点与定义签名均零参、热重载复位钩子在位。
- `crash_dump` 守卫的固定 300 字符窗口改为结构化窗口（给该项加个字段就假红，门控其实原地未动）。

## 验证

- `flutter analyze` 全绿（含 test 目录）
- `test/settings` + `test/pages` + `test/widgets`：**3386 通过**
  - 1 例 `reader_neutralizer_wired_test` 失败是代理劫持 flutter_tester localhost 的基础设施噪音，单独重跑 `EXIT=0`

https://claude.ai/code/session_012mKPzR8bugVax4Q4Z7qDHn
