### PR TITLE
test(reader): 新增 balancedBlockFrom —— 解 PR#723 与 PR#719 的 wheel 锚点冲突

### DIFF
--- a/hibiki/test/helpers/source_guard.dart
+++ b/hibiki/test/helpers/source_guard.dart
@@ -658,16 +658,74 @@ String methodBody(
   if (open < 0) {
     fail('方法签名后找不到左花括号：$signature');
   }
+  final int close = _balancedBraceEnd(structural, open);
+  if (close < 0) {
+    fail('方法体花括号不配对：$signature');
+  }
+  return src.substring(start, close + 1);
+}
+
+/// 从 [structural]（已掩码的语料）的左花括号 [open] 起做配对，返回配对上的 `}` 的
+/// 下标；不配对返回 -1。掩码由调用方按语料词法先做好，这里只认结构。
+int _balancedBraceEnd(String structural, int open) {
   int depth = 0;
   for (int i = open; i < structural.length; i++) {
     final String c = structural[i];
     if (c == '{') depth++;
     if (c == '}') {
       depth--;
-      if (depth == 0) return src.substring(start, i + 1);
+      if (depth == 0) return i;
     }
   }
-  fail('方法体花括号不配对：$signature');
+  return -1;
+}
+
+/// 从**调用方给定的起点** [start] 起，用花括号配对切出到右边界的整块。
+///
+/// 与 [methodBody] 的分工 —— 这是本函数存在的全部理由：[methodBody] 把「怎么定
+/// 起点」（按签名文本 `indexOf`）和「怎么定右边界」（花括号配对）焊死在一起，起点
+/// 只能是语料里**第一处**签名文本。合并语料里同一签名出现多次时，第一处未必是要守
+/// 的那处，而且锚错时守卫是**静默锚到别人身上**（窗口里没有被守的符号 ⇒ 要求型断言
+/// 红、禁止型断言假绿），不是报错。
+///
+/// 实例（BUG-1426 之后的 reader 合并语料）：`'wheel', function(e)` 逐字相同的两处 ——
+/// spread 独立文档自带那份在主壳 `reader_hibiki_page.dart:566`，正文引擎那份在
+/// `reader_hibiki/webview.part.dart:1408`，而语料是「主壳在前、part 按路径排序在后」，
+/// 第一处必然是 spread 那份。
+///
+/// **不做「取第 N 处匹配」**：序号是脆的 —— 语料拼接顺序、part 文件改名、再多一份同
+/// 签名监听都会把序号挤歪，而挤歪后守卫照样绿着守错了对象。所以起点必须由调用方用
+/// **语义判据**定（如 [bodyEngineWheelListenerStart] 按块内 `hoshiContinuousMode`
+/// 认正文那份），右边界才由本函数用结构配对定。
+///
+/// 右边界用配对而不是「下一个固定文本」（旧写法 `indexOf('}, {passive:')`）：监听器
+/// 一旦漏写 `passive` 选项，文本右边界就一路吞到下一个监听器，窗口断言凭空变假。
+///
+/// [openSearchFrom] 用来把「返回值起点」和「找左花括号的起点」分开（[methodBody] 要
+/// 先跳过参数表圆括号）；默认与 [start] 相同。
+/// 起点越界 / 找不到左花括号 / 花括号不配对一律 `fail`，绝不返回空串。
+String balancedBlockFrom(
+  String src,
+  int start, {
+  SourceLexicon lexicon = SourceLexicon.dart,
+  int? openSearchFrom,
+  String what = '结构块',
+}) {
+  if (start < 0 || start > src.length) {
+    fail('$what 的起点下标越界：$start（语料长度 ${src.length}）');
+  }
+  final String structural = lexicon == SourceLexicon.js
+      ? maskJsCommentsAndStrings(src)
+      : maskCommentsAndStrings(src);
+  final int open = structural.indexOf('{', openSearchFrom ?? start);
+  if (open < 0) {
+    fail('$what：起点之后找不到左花括号');
+  }
+  final int close = _balancedBraceEnd(structural, open);
+  if (close < 0) {
+    fail('$what：花括号不配对');
+  }
+  return src.substring(start, close + 1);
 }
 
 /// 在 [body] 的**代码行**上查找 [needle]，注释里的同名文本不算数。

--- a/hibiki/test/reader/scroll_cross_chapter_try_scroll_test.dart
+++ b/hibiki/test/reader/scroll_cross_chapter_try_scroll_test.dart
@@ -113,50 +113,76 @@ void main() {
     late String paginationScripts;
     late String corpus;
     setUpAll(() {
-      paginationScripts = File('lib/src/reader/reader_pagination_scripts.dart')
-          .readAsStringSync()
-          .replaceAll('\r\n', '\n');
-      corpus = readReaderPageSource();
+      // TODO-2527: 两份语料都先掩码——`downSPos` / `_wheelBoundaryArmed` 这类符号
+      // 本来就原样写在生产注释里（webview.part.dart 的 TODO-656 说明段就有），裸
+      // contains 会被注释满足：把实现删光只留注释，旧写法照样全绿。
+      paginationScripts = maskCommentsAndScriptLines(
+        File('lib/src/reader/reader_pagination_scripts.dart')
+            .readAsStringSync()
+            .replaceAll('\r\n', '\n'),
+      );
+      corpus = maskCommentsAndScriptLines(readReaderPageSource());
     });
 
     test('_bStart 记手势起点滚动量 downSPos/downSMax', () {
-      expect(paginationScripts, contains('downSPos'),
+      expect(containsCodeLine(paginationScripts, 'downSPos'), isTrue,
           reason: 'touchstart 必须记手势起点沿内容轴的滚动量');
-      expect(paginationScripts, contains('downSMax'),
+      expect(containsCodeLine(paginationScripts, 'downSMax'), isTrue,
           reason: 'touchstart 必须记最大可滚量供边界判定');
     });
     test('_bEnd 用手势起点在边界判据，不再用 touchend 瞬时 atTop', () {
-      expect(paginationScripts, contains('downAtStart'),
+      expect(containsCodeLine(paginationScripts, 'downAtStart'), isTrue,
           reason: '跨章必须看手势起点是否在章首（downSPos<=2）');
-      expect(paginationScripts, contains('downAtEnd'),
+      expect(containsCodeLine(paginationScripts, 'downAtEnd'), isTrue,
           reason: '跨章必须看手势起点是否在章末');
       expect(
-          paginationScripts, isNot(contains('var atTop = root.scrollTop <= 2')),
+          containsCodeLine(
+              paginationScripts, 'var atTop = root.scrollTop <= 2'),
+          isFalse,
           reason: '_bEnd 不得再用 touchend 瞬时 scrollTop<=2 判跨章（提前跨章根因）');
     });
     test('滚轮跨章用真试滚（scrollBy + moved），不再用 stuck 推算/瞬时几何', () {
       final String wheel = _wheelBlock(corpus);
-      expect(wheel, contains('var moved = Math.abs(after - before) > 1'),
+      // 锚点自检：窗口必须落在**正文引擎**那份 wheel 监听上。spread 独立文档那份
+      // 逐字同签名、在语料里更靠前（见 _wheelBlock 注释），锚错时下面的 needle 会
+      // 集体落空 —— 但那时报的是「实现没了」，会把人引向生产代码。这条先红，直接
+      // 说清是守卫自己锚歪了。
+      expect(wheel.contains('hoshiContinuousMode'), isTrue,
+          reason: '窗口锚到了没有连续/分页门控的那份 wheel 监听（spread 独立文档），'
+              '守卫在守错对象');
+      expect(wheel.contains('onSpreadTapEmpty'), isFalse,
+          reason: '窗口吃进了 spread 独立文档的脚本段，右边界塌了');
+      expect(
+          containsCodeLine(wheel, 'var moved = Math.abs(after - before) > 1'),
+          isTrue,
           reason: '滚轮跨章须靠真试滚的实际位移判边界');
-      expect(wheel, contains('window.scrollBy'),
+      expect(containsCodeLine(wheel, 'window.scrollBy'), isTrue,
           reason: '横排/竖排都真的 window.scrollBy 一步再读位移（已验证原语）');
-      expect(wheel, isNot(contains('atStart = root.scrollTop <= 2')),
+      expect(containsCodeLine(wheel, 'atStart = root.scrollTop <= 2'), isFalse,
           reason: '不得再用瞬时 scrollTop<=2 几何');
-      expect(wheel, isNot(contains('_wheelLastScrollPos')),
+      expect(containsCodeLine(wheel, '_wheelLastScrollPos'), isFalse,
           reason: '不得再用相邻拍位置推算（时序坏 → 横排中部误翻）');
       // arm-then-fire 二次确认仍在。
-      expect(wheel, contains('_wheelBoundaryArmed'),
+      expect(containsCodeLine(wheel, '_wheelBoundaryArmed'), isTrue,
           reason: '保留 arm-then-fire 二次确认吸收单帧擦边');
     });
   });
 }
 
+/// 正文引擎那份 wheel 监听的**回调体**窗口。
+///
+/// 两件事必须分开定，合在一起就出错：
+/// - **起点**：BUG-1426 之后语料里有两份 wheel 监听，签名逐字相同
+///   （`'wheel', function(e)`）。spread 独立文档自带那份在主壳
+///   `reader_hibiki_page.dart:566`，正文引擎那份在
+///   `reader_hibiki/webview.part.dart:1408`，而语料是「主壳在前」⇒ 按签名文本
+///   `indexOf`（含 `methodBody` 的内建定位）必然锚到 spread 那份，守错对象。所以起点
+///   走语义判据 [bodyEngineWheelListenerStart]（按块内 `hoshiContinuousMode` 认）。
+/// - **右边界**：旧写法 `indexOf('}, {passive:')` 一旦监听器漏写 passive 选项就一路
+///   吞到下一个监听器，所以改成 [balancedBlockFrom] 的花括号配对。
 String _wheelBlock(String source) {
-  // BUG-1426：spread 独立文档自带的 wheel 监听（无连续/分页门控）在合并语料里排在
-  // 正文引擎那份**前面**，裸 indexOf 会锚错。按块内的 hoshiContinuousMode 挑正文那份。
   final int start = bodyEngineWheelListenerStart(source);
   expect(start, isNonNegative, reason: 'missing body-engine wheel listener');
-  final int end = source.indexOf('}, {passive:', start);
-  expect(end, isNonNegative);
-  return source.substring(start, end);
+  return balancedBlockFrom(source, start,
+      lexicon: SourceLexicon.js, what: '正文引擎 wheel 监听回调体');
 }


### PR DESCRIPTION
**这是 PR#723 的合并阻塞解法。** 整合线请**先合本 PR、再 rebase #723**；届时 #723 的
`test/reader/scroll_cross_chapter_try_scroll_test.dart` 要么无冲突，要么直接取本 PR 的写法
（本 PR 已包含该文件 TODO-2527 的全部收口内容）。#723 其余 5 个文件本 PR 一个字没碰。

## 阻塞的实质

PR#719（`b524563fb`）落地后，reader 合并语料里有**两份逐字同签名**的 wheel 监听：

| 哪一份 | 位置 | 语料里的顺序 |
|---|---|---|
| spread 独立文档自带（BUG-1426，直送 `onWheelPaginate`，无连续/分页门控） | `hibiki/lib/src/pages/implementations/reader_hibiki_page.dart:566` | **在前**（语料是「主壳 + part 按路径排序」） |
| 正文引擎（要守的那份） | `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:1408` | 在后 |

两处都匹配 `'wheel', function(e)`。PR#723 把窗口改成
`methodBody(source, "'wheel', function(e)", lexicon: SourceLexicon.js)` —— `methodBody` 内建的定位是
`indexOf(signature)` 取**第一处**，于是必然锚到 spread 那份，守错对象。

PR#723 的基底 `6078a4379` 上这两样都还不存在（既没有主壳里的 spread wheel 监听，也没有
`bodyEngineWheelListenerStart`），所以它在自己分支上是绿的；rebase 到今天的 develop 才暴露。

正解 = **#719 的锚点定位 + #723 的花括号右边界**，需要一个新原语。

## 新 helper

```dart
String balancedBlockFrom(
  String src,
  int start, {
  SourceLexicon lexicon = SourceLexicon.dart,
  int? openSearchFrom,
  String what = '结构块',
})
```

语义：**起点由调用方给，右边界由配对算**。从 `openSearchFrom ?? start` 起找第一个左花括号
（在按 `lexicon` 掩码后的结构串上），配对到匹配的 `}`，返回 `src.substring(start, close + 1)`。
起点越界 / 找不到左花括号 / 不配对一律 `fail`，绝不返回空串。

`methodBody` 保持行为不变，只是把配对循环抽成共享的私有 `_balancedBraceEnd`，两者同一份实现
（掩码仍各算一次，无额外开销）。

**为什么不做「按签名找第 N 处匹配」**：序号是脆的 —— 语料拼接顺序、part 文件改名、再多一份同
签名监听都会把序号挤歪，而挤歪之后守卫**照样绿着守错对象**（要求型断言红、禁止型断言假绿），
不会报错。起点必须由**语义判据**定：这里是 `bodyEngineWheelListenerStart`（按块内是否含
`hoshiContinuousMode` 认正文那份，PR#719 引入）。

## 消费端

`_wheelBlock` = `bodyEngineWheelListenerStart` 定起点 + `balancedBlockFrom(lexicon: js)` 定右边界。
实测窗口 4058 字节，尾部正好收在回调体的 `}`（`SourceLexicon.dart` 会一路跑到
`_cachedEngineSource`，9212 字节 —— 语料是 Dart 文件装 JS 三引号串，必须用 JS 词法）。

同时补一条**锚点自检**：窗口必须含 `hoshiContinuousMode`、不得含 `onSpreadTapEmpty`。锚歪时
needle 会集体落空，报「实现没了」会把人引向生产代码；这条先红，直接说清是守卫自己锚歪了。

该文件 TODO-2527 的收口（语料先过 `maskCommentsAndScriptLines`、断言改 `containsCodeLine`）
一并带上。

## 变异实测（三向）

变异全部改**真实代码**（不塞注释），还原用反向文本替换，未对未提交文件用 `git checkout --`；
还原后 `git status --short` 只剩本 PR 的两个文件。

| 方向 | 变异 | 结果 |
|---|---|---|
| **正向** | `var moved = Math.abs(after - before) > 1;` -> `var moved = root.scrollTop !== _wheelLastScrollPos;`（退回 TODO-656 之前的相邻拍推算） | **RED** —— `Expected: true / Actual: <false>`，reason「滚轮跨章须靠真试滚的实际位移判边界」；**14 tests completed**，是断言红不是编译红 |
| **锚错对象** | `_wheelBlock` 换回 PR#723 的 `methodBody(source, "'wheel', function(e)", lexicon: js)` | **RED** —— 命中新增的锚点自检，reason「窗口锚到了没有连续/分页门控的那份 wheel 监听（spread 独立文档），守卫在守错对象」。**这一向直接证明 PR#723 现在的写法在今天的 develop 上是坏的** |
| **注释假绿** | 实现改成 `var moved = true;`，needle 只留在 `// var moved = Math.abs(after - before) > 1;` | 新版 **RED**；同一份被改坏的源码上，develop 旧版 `PASSED - 14 tests`（**假绿**） |

## 门禁

- `flutter analyze`（全量含 test）：`No issues found! (ran in 59.6s)`，exit 0
- `dart run tool/flutter_test_failures.dart --no-pub test/tools/source_guard_adoption_test.dart test/settings/md3_design_system_static_test.dart test/reader/scroll_cross_chapter_try_scroll_test.dart test/reader/swipe_page_turn_no_animation_test.dart`
  -> `FLUTTER TEST VERDICT: PASSED - 85 tests ran, all tests passed`，exit 0
- 因为动了 `methodBody` 的内部结构，额外跑了**全部 61 个 `methodBody` 消费方**（分两段）：
  `PASSED - 307 tests ran` / `PASSED - 235 tests ran`，exit 0 —— 配对循环抽取零回归
- `dart format` 已跑

## 明确未做

- 未 bump `+build`（整合线统一 bump）。
- 未建 BUG 文档（TODO-2527 既有收尾）。
- 未碰生产代码（纯测试基础设施），未碰 PR#723 那条分支及其另外 5 个文件。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
