### PR TITLE
fix(video): 按文件夹导入分不到一组 + 手动建合集乱序 (BUG-1435 / BUG-1436)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1336 条。点号进各自文件。
+> 共 1338 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1436](bugs/BUG-1436-collection-combine-uses-selection-order.md) | ✅ | ✅ | 批量组合成合集：成员按点选顺序落 sortIndex，选集列表乱序 |
+| [BUG-1435](bugs/BUG-1435-video-folder-import-episode-title-in-series.md) | ✅ | ✅ | 按文件夹导入：SxxExx 后的分集标题并进系列名，同一部番分不到一组 |
 | [BUG-1432](bugs/BUG-1432-ime-physical-key-ledger.md) | ✅ | ✅ | TODO-2652「三处快捷键台账仍记裸 logicalKey」经查证伪：`LogicalKeyboardKey.process` 在 5 个出包平台上根本不可达 |
 | [BUG-1430](bugs/BUG-1430-subtitle-obscure-switch-lag.md) | ✅ | ✅ | 切换字幕遮罩模式卡顿：两次事务落盘 + UI 等落盘 + 全局广播重建全 app |
 | [BUG-1429](bugs/BUG-1429-bug-tool-number-pool-misses-uncommitted-worktrees.md) | ✅ | ✅ | bug.dart 取号扫不到并发工作区未提交的 bug 文件，一天连撞六次 |

--- a/docs/bugs/BUG-1435-video-folder-import-episode-title-in-series.md
+++ b/docs/bugs/BUG-1435-video-folder-import-episode-title-in-series.md
@@ -1,0 +1,36 @@
+## BUG-1435 · 按文件夹导入：SxxExx 后的分集标题并进系列名，同一部番分不到一组
+
+- **报告**：2026-08-02（用户：按文件夹导入一整季 12 集，库里出现 12 个独立项目，不是一个合集）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/media/video/scraper/filename_parser.dart:565`（原 `_parseTitleText` ① 处只把 `SxxExx` 本身替换成空格，其后的分集标题原样留在标题里）+ `filename_parser.dart:377`（`_normalizeSeparators` 的「点分隔命名」判定被 `_`→空格 提前污染）。
+
+### 复现
+
+`日々は過ぎれど飯うまし.S01EXX.<每集不同的分集标题>.WEBRip.Netflix.ja[cc].mkv` 一整季，走「导入视频 → 选文件夹」。
+
+修复前 `parseVideoFilename` 实测（8 个真实文件名）：
+
+```
+SERIES=[日々は過ぎれど飯うまし お金なくなっちゃった!!] S=1 E=3
+SERIES=[日々は過ぎれど飯うまし 出店してみますか!]       S=1 E=9
+SERIES=[日々は過ぎれど飯うまし .ドライブ行かない .WEBRip.Netflix.ja] S=1 E=5
+...
+GROUPS=8   ← 每集自成一组
+```
+
+季/集号解得对，但 `series` 每集都不同 → `groupVideosIntoPlaylists`
+（`hibiki/lib/src/media/video/video_filename_parser.dart:97`）按 series 分组得到 N 组各 1 集
+→ 每组走单片导入分支（`VideoGroup.isPlaylist == false`），一个 playlist 合集都建不出来。
+
+### 根因
+
+1. **主因**：`SxxExx` 是 Jellyfin / Plex / Netflix 系命名的强边界，其后的内容必是「该集独有的分集标题 + 发布元数据」，不属于系列名。原实现走 `_extractFirst`，只把匹配替换成空格，分集标题继续参与标题拼装；`_cutTrailingNoiseTokens` 只截掉 `WEBRip` 起的尾部噪声，截不掉夹在中间的分集标题。
+2. **次因**：`_normalizeSeparators` 先把 `_` 换成空格、再判断「串里没有空格且点 ≥2 → 点是分隔符」。文件名里只要有一个下划线（`ドライブ行かない_`、`クリスマス空いてますか!_`），判定就失效，`.WEBRip.Netflix.ja` 整串留在系列名里。
+
+### 影响面
+
+「按文件夹导入」的分组、导入后的合集数量、刮削搜索词（系列名带分集标题 → 相似度被拉低）。
+
+- **[x] ① 已修复** — `filename_parser.dart`：① 处改为命中 `_seasonEpisode` 即在匹配位置截断，其后文本经 `_cutTrailingNoiseTokens` 清洗后归 `secondaryTitle`（信息不丢）；集号之前无标题字符时（`S01E04 - Title` 这类集号前置命名）保留原「替换成空格」行为，避免标题被截空。`_normalizeSeparators` 的点分隔判定前移到 `_`→空格 之前。提交见本分支。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_filename_parser_test.dart`：新增 group「SxxExx 后的分集标题不进系列名（BUG-1435）」4 例（Netflix 命名 / 含下划线 / secondaryTitle 承接 / 集号前置不截空）+ `groupVideosIntoPlaylists` 的「整季分集标题各不相同 → 仍归一组，按集号排序」。变异实测：把截断改回 `replaceRange` 旧行为 → 4 个 error event，守卫有效。
+
+- **备注**：修好后同一部番按文件夹导入直接归一组，且组内已由 `_compareEpisodes` 按 季→集 排好序，导入路径不再需要事后手动整理。合集**手动**建时的成员顺序是另一条独立缺陷，见 [[BUG-1436]]。

--- a/docs/bugs/BUG-1436-collection-combine-uses-selection-order.md
+++ b/docs/bugs/BUG-1436-collection-combine-uses-selection-order.md
@@ -1,0 +1,32 @@
+## BUG-1436 · 批量组合成合集：成员按点选顺序落 sortIndex，选集列表乱序
+
+- **报告**：2026-08-02（用户：手动做成合集之后里面的顺序也是乱的）
+- **真实性**：✅ 真 bug。根因 `hibiki/lib/src/pages/implementations/home_video_page.dart:1124`（`_selectedUids` 是 `Set<String>`，迭代序 = 点选/框选顺序，逐条 `addToCollection` 即定死 sortIndex）；书架页 `hibiki/lib/src/pages/implementations/reader_history/books.part.dart:685` 同构。
+
+### 复现
+
+视频库页多选一整季 → 「组合」→ 命名 → 建成合集 → 合集详情页「选集」列表顺序为
+E09、E10、E07、E12、E04、E03、E05、E11（= 用户点选顺序 / 库页当前显示顺序），不是集号序。
+
+### 根因
+
+`addToCollection` 在 DAO 层拿不到标题，无从自然排序；调用方三档（新建 / 并入 / 合并）
+都直接按选择集迭代序逐条落盘。合集详情页已有「一键整理」（`collection_one_key_sort.dart`），
+但那是**事后**的手动补救，默认路径从不排序。
+
+### 影响面
+
+视频库页与书架页的批量「组合成合集」；合集内成员序（库页合集行、播放器换集读同一
+`getCollectionItems`，落盘即同序）。
+
+- **[x] ① 已修复** — 新增共享真相源 `sortNewCollectionMembersNaturally`
+  （`hibiki/lib/src/media/collections/collection_one_key_sort.dart`）：落盘前按显示标题
+  `naturalCompare` 排序（规则与「一键整理·按名称」同源），同名按输入下标兜底（`List.sort`
+  非稳定）。视频页与书架页在 `_batchCombineIntoSeries` 里对 `looseRefs` 一次排好，三档共用。
+  只排**本次批次**——并入既有合集时不动已有成员相对序（可能是用户手动拖拽排好的）。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/collections/collection_combine_member_order_test.dart`
+  5 例（自然序取代点选序 / 卷号数值序 / 同名保持输入序 / 空表单元素 / 不改入参）。
+  变异实测：把 `naturalCompare` 结果压成 0 → 2 个 error event，守卫有效。
+
+- **备注**：与 [[BUG-1435]] 是同一用户报告的两条独立缺陷——1435 让「按文件夹导入」建不出
+  合集（导入路径自带 季→集 排序，修好后无此问题），1436 让**手动**建的合集内部乱序。

--- a/hibiki/lib/src/media/collections/collection_one_key_sort.dart
+++ b/hibiki/lib/src/media/collections/collection_one_key_sort.dart
@@ -36,6 +36,38 @@ int compareCollectionMembers(
   return byName != 0 ? byName : a.key.compareTo(b.key);
 }
 
+/// 批量「组合成合集」落盘前，把**本次待加入**的成员排成自然序
+/// （`卷1 < 卷2 < 卷10`、`S01E02 < S01E10`），而不是用户的点选顺序。
+///
+/// 此前三个库页都直接按选择集（`Set<String>`，迭代序 = 点选/框选顺序）逐条
+/// `addToCollection`，sortIndex 就此定型：用户框选一整季建出来的合集，「选集」
+/// 列表是乱序的（E09、E10、E07、E12…），必须再手动跑一次「一键整理」才正常
+/// （BUG-1436）。规则复用「一键整理·按名称」的 [naturalCompare]，两条路径同序。
+///
+/// 只排**本次批次**——并入既有合集时不动已有成员的相对序（那可能是用户手动拖拽
+/// 排好的，重排即破坏）。标题相同则保持输入序：`List.sort` 非稳定排序，装饰上
+/// 原始下标兜底，同名成员的落盘顺序才是确定的。
+List<T> sortNewCollectionMembersNaturally<T>(
+  List<T> items, {
+  required String Function(T) titleOf,
+}) {
+  final List<({T item, String title, int index})> decorated =
+      <({T item, String title, int index})>[
+    for (int i = 0; i < items.length; i++)
+      (item: items[i], title: titleOf(items[i]), index: i),
+  ];
+  decorated.sort((
+    ({T item, String title, int index}) a,
+    ({T item, String title, int index}) b,
+  ) {
+    final int byName = naturalCompare(a.title, b.title);
+    return byName != 0 ? byName : a.index.compareTo(b.index);
+  });
+  return <T>[
+    for (final ({T item, String title, int index}) d in decorated) d.item
+  ];
+}
+
 /// 合集「一键整理」在**库页右键菜单 / 书架网格详情页**的实现：成员行只有身份键，
 /// 故标题 / 导入时间从 epub / srt / galgames / videoBooks 四表现查；查不到的成员
 /// （孤儿 / 对端未知种类）按 `(entryKey, 0)` 兜底排序，不 throw。游戏标题取用户

--- a/hibiki/lib/src/media/video/scraper/filename_parser.dart
+++ b/hibiki/lib/src/media/video/scraper/filename_parser.dart
@@ -375,13 +375,18 @@ class FilenameParser {
   /// 分隔符归一：全角空格→空格、下划线→空格；
   /// 点分隔西式命名（无空格且 ≥2 个点，如 `Mushoku.Tensei.S03E04`）把点当空格。
   static String _normalizeSeparators(String s) {
-    String out = s
-        .replaceAll('　', ' ')
-        .replaceAll('_', ' ')
-        .replaceAll(RegExp(r'\s+'), ' ')
-        .trim();
-    if (!out.contains(' ') && '.'.allMatches(out).length >= 2) {
-      out = out.replaceAll('.', ' ');
+    // 「点分隔命名」（`Title.S01E09.Sub.WEBRip.ja`）的判定必须在 `_`→空格 **之前**
+    // 做：下划线是标题内的普通字符（`ドライブ行かない_`），先替换会让串里凭空多出
+    // 空格，判定失效、`.` 不再当分隔符，整串 `.WEBRip.Netflix.ja` 留在标题里
+    // （BUG-1435）。
+    final String base =
+        s.replaceAll('　', ' ').replaceAll(RegExp(r'\s+'), ' ').trim();
+    final bool dotSeparated =
+        !base.contains(' ') && '.'.allMatches(base).length >= 2;
+    String out =
+        base.replaceAll('_', ' ').replaceAll(RegExp(r'\s+'), ' ').trim();
+    if (dotSeparated) {
+      out = out.replaceAll('.', ' ').replaceAll(RegExp(r'\s+'), ' ').trim();
     }
     return out;
   }
@@ -561,11 +566,32 @@ class FilenameParser {
     }
     // 纯日期/设备命名：直接判空标题，不再做集数误抽取。
     if (_looksLikeNonTitle(text)) return '';
-    // ① S01E04（一次给出季+集）。
-    text = _extractFirst(text, _seasonEpisode, (RegExpMatch m) {
-      st.season ??= int.parse(m.group(1)!);
-      st.episode ??= int.parse(m.group(2)!);
-    });
+    // ① S01E04（一次给出季+集）。`SxxExx` 是 Jellyfin / Plex / Netflix 系命名的
+    // 强边界：它**之后**的一切都不属于系列名——要么是该集独有的分集标题，要么是
+    // 发布元数据（`.WEBRip.Netflix.ja`）。此前只把 `SxxExx` 本身替换成空格、分集
+    // 标题原样留在标题里，同一部番每集解出不同 series，「按文件夹导入」按 series
+    // 分组时分不到一组，12 集变成 12 个独立条目（BUG-1435）。故命中即截断；分集
+    // 标题不丢，归入 [ParsedMediaName.secondaryTitle]。
+    final RegExpMatch? se = _seasonEpisode.firstMatch(text);
+    if (se != null) {
+      st.season ??= int.parse(se.group(1)!);
+      st.episode ??= int.parse(se.group(2)!);
+      final String head = text.substring(0, se.start);
+      if (_hasTitleChars(head)) {
+        final String tail = _cleanupTitle(
+          _cutTrailingNoiseTokens(
+            _cleanupTitle(text.substring(se.end)),
+            st,
+          ),
+        );
+        if (tail.isNotEmpty) st.secondaryTitle ??= tail;
+        text = head;
+      } else {
+        // 集号前置命名（`S01E04 - Title`）：截断会把标题整个丢空，退回原先的
+        // 「替换成空格」行为，让后续规则照常处理剩余文本。
+        text = text.replaceRange(se.start, se.end, ' ');
+      }
+    }
     // ② 其余集数模式（first-wins，括号块里解析出的集数优先保留）。
     if (st.episode == null) {
       text = _extractFirst(text, _cnEpisode, (RegExpMatch m) {

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -59,6 +59,8 @@ import 'package:hibiki/src/media/collections/batch_combine.dart';
 import 'package:hibiki/src/media/collections/collection_context_dialog.dart';
 import 'package:hibiki/src/media/collections/collection_continue.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
+import 'package:hibiki/src/media/collections/collection_one_key_sort.dart'
+    show sortNewCollectionMembersNaturally;
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
 import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/collections/collection_drag.dart';
@@ -1121,12 +1123,21 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (!await _pruneStaleSelection() || !mounted) return;
     final HibikiDatabase db = ref.read(appProvider).database;
     final List<int> collectionIds = _selectedCollectionIds.toList()..sort();
-    final List<ShelfEntryRef> looseRefs = <ShelfEntryRef>[
-      for (final String uid in _selectedUids)
-        if (shelfSelectionToEntry(uid, ShelfSelectionSurface.video)
-            case final ShelfEntryRef ref)
-          ref,
-    ];
+    // 成员序按标题自然序落盘，不用 `_selectedUids`（LinkedHashSet）的点选顺序：
+    // 框选一整季建出来的合集此前「选集」列表是乱的（BUG-1436）。三档共用同一份
+    // 已排好的 refs。
+    final Map<String, String> titleByUid = <String, String>{
+      for (final VideoBookRow b in _visibleVideos) b.bookUid: b.title,
+    };
+    final List<ShelfEntryRef> looseRefs = sortNewCollectionMembersNaturally(
+      <ShelfEntryRef>[
+        for (final String uid in _selectedUids)
+          if (shelfSelectionToEntry(uid, ShelfSelectionSurface.video)
+              case final ShelfEntryRef ref)
+            ref,
+      ],
+      titleOf: (ShelfEntryRef r) => titleByUid[r.entryKey] ?? r.entryKey,
+    );
     final CombineTier tier = classifyCombine(
       collectionCount: collectionIds.length,
       looseCount: looseRefs.length,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -51,6 +51,8 @@ import 'package:hibiki/src/media/metadata/image_download.dart';
 import 'package:hibiki/src/media/metadata/scrape_batch.dart';
 import 'package:hibiki/src/media/metadata/scrape_title_matcher.dart';
 import 'package:hibiki/src/media/collections/collection_grouping.dart';
+import 'package:hibiki/src/media/collections/collection_one_key_sort.dart'
+    show sortNewCollectionMembersNaturally;
 import 'package:hibiki/src/media/collections/shelf_sort.dart';
 import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/collections/collection_drag.dart';

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -682,12 +682,33 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     // 幽灵键会让 addToCollection 撞外键且无人 catch（用户只看到「点了没反应」）。
     if (!await _pruneStaleSelection() || !mounted) return;
     final List<int> collectionIds = _selectedCollectionIds.toList()..sort();
-    final List<ShelfEntryRef> looseRefs = <ShelfEntryRef>[
-      for (final String key in _selectedKeys)
-        if (shelfSelectionToEntry(key, ShelfSelectionSurface.books)
+    // 成员序按显示标题自然序落盘（`卷1 < 卷2 < 卷10`），不用 `_selectedKeys` 的
+    // 点选顺序——否则框选一套书建出来的合集内部是乱的（BUG-1436）。标题走
+    // display-title 门面，与用户看到的一致。
+    // 键带 mediaType：epub 的 bookKey 与 srt 的 uid 是两个独立值域，裸 entryKey
+    // 做映射键有撞键风险。
+    final Map<String, String> titleByRef = <String, String>{
+      for (final MediaItem item in _visibleEpubBooks)
+        if (shelfSelectionToEntry(
+          item.mediaIdentifier,
+          ShelfSelectionSurface.books,
+        )
             case final ShelfEntryRef ref)
-          ref,
-    ];
+          '${ref.mediaType}|${ref.entryKey}':
+              displayTitleForBook(item: item, rawTitle: item.title),
+      for (final SrtBook book in _visibleSrtBooks)
+        '${MediaKind.srt}|${book.uid}': _srtDisplayTitle(book),
+    };
+    final List<ShelfEntryRef> looseRefs = sortNewCollectionMembersNaturally(
+      <ShelfEntryRef>[
+        for (final String key in _selectedKeys)
+          if (shelfSelectionToEntry(key, ShelfSelectionSurface.books)
+              case final ShelfEntryRef ref)
+            ref,
+      ],
+      titleOf: (ShelfEntryRef r) =>
+          titleByRef['${r.mediaType}|${r.entryKey}'] ?? r.entryKey,
+    );
     final CombineTier tier = classifyCombine(
       collectionCount: collectionIds.length,
       looseCount: looseRefs.length,

--- a/hibiki/test/media/collections/collection_combine_member_order_test.dart
+++ b/hibiki/test/media/collections/collection_combine_member_order_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/collections/collection_one_key_sort.dart';
+
+/// BUG-1436：批量「组合成合集」此前直接按选择集（`Set<String>`，迭代序 = 点选/
+/// 框选顺序）逐条 `addToCollection`，sortIndex 就此定型——用户框选一整季建出来的
+/// 合集，「选集」列表是乱的（E09、E10、E07、E12…），必须再手动跑一次「一键整理」。
+///
+/// [sortNewCollectionMembersNaturally] 是三个库页共用的落盘前排序真相源。
+void main() {
+  group('sortNewCollectionMembersNaturally', () {
+    test('点选顺序被自然序取代（S01E02 < S01E10）', () {
+      const List<String> picked = <String>[
+        'Show.S01E09.出店してみますか!.WEBRip.mkv',
+        'Show.S01E10.ただいま.WEBRip.mkv',
+        'Show.S01E07.ずっと忘れないと思う.WEBRip.mkv',
+        'Show.S01E02.この子は星なな.WEBRip.mkv',
+      ];
+      final List<String> sorted = sortNewCollectionMembersNaturally<String>(
+        picked,
+        titleOf: (String s) => s,
+      );
+      expect(sorted, <String>[
+        'Show.S01E02.この子は星なな.WEBRip.mkv',
+        'Show.S01E07.ずっと忘れないと思う.WEBRip.mkv',
+        'Show.S01E09.出店してみますか!.WEBRip.mkv',
+        'Show.S01E10.ただいま.WEBRip.mkv',
+      ]);
+    });
+
+    test('卷号按数值而非字典序（卷2 < 卷10）', () {
+      final List<String> sorted = sortNewCollectionMembersNaturally<String>(
+        <String>['某系列 第10巻', '某系列 第2巻', '某系列 第1巻'],
+        titleOf: (String s) => s,
+      );
+      expect(sorted, <String>['某系列 第1巻', '某系列 第2巻', '某系列 第10巻']);
+    });
+
+    test('标题相同 → 保持输入序（List.sort 非稳定，需下标兜底）', () {
+      final List<({String id, String title})> items =
+          <({String id, String title})>[
+        (id: 'c', title: '同名'),
+        (id: 'a', title: '同名'),
+        (id: 'b', title: '同名'),
+      ];
+      final List<({String id, String title})> sorted =
+          sortNewCollectionMembersNaturally<({String id, String title})>(
+        items,
+        titleOf: (({String id, String title}) e) => e.title,
+      );
+      expect(
+        sorted.map((({String id, String title}) e) => e.id).toList(),
+        <String>['c', 'a', 'b'],
+      );
+    });
+
+    test('空表与单元素不炸', () {
+      expect(
+        sortNewCollectionMembersNaturally<String>(
+          const <String>[],
+          titleOf: (String s) => s,
+        ),
+        isEmpty,
+      );
+      expect(
+        sortNewCollectionMembersNaturally<String>(
+          const <String>['only'],
+          titleOf: (String s) => s,
+        ),
+        <String>['only'],
+      );
+    });
+
+    test('不改入参列表（调用方仍持原点选序）', () {
+      final List<String> input = <String>['b', 'a'];
+      sortNewCollectionMembersNaturally<String>(input,
+          titleOf: (String s) => s);
+      expect(input, <String>['b', 'a']);
+    });
+  });
+}

--- a/hibiki/test/media/video/video_filename_parser_test.dart
+++ b/hibiki/test/media/video/video_filename_parser_test.dart
@@ -113,7 +113,70 @@ void main() {
     });
   });
 
+  // BUG-1435：Jellyfin / Plex / Netflix 系点分隔命名里，`SxxExx` 之后是**该集独有**
+  // 的分集标题 + 发布元数据。此前分集标题被并进系列名，同一部番每集解出不同
+  // series，「按文件夹导入」按 series 分组时分不到一组，12 集变成 12 个独立条目。
+  group('SxxExx 后的分集标题不进系列名（BUG-1435）', () {
+    test('Netflix 式 标题.S01E09.分集标题.WEBRip.Netflix.ja[cc]', () {
+      final VideoNameInfo info = parseVideoFilename(
+        '日々は過ぎれど飯うまし.S01E09.出店してみますか!.WEBRip.Netflix.ja[cc].mkv',
+      );
+      expect(info.series, '日々は過ぎれど飯うまし');
+      expect(info.season, 1);
+      expect(info.episode, 9);
+    });
+
+    test('分集标题含下划线时噪声一样剥干净', () {
+      // `_`→空格 若发生在「点分隔命名」判定之前，标题里凭空多出空格会让判定失效，
+      // `.WEBRip.Netflix.ja` 整串留在系列名里。
+      final VideoNameInfo info = parseVideoFilename(
+        '日々は過ぎれど飯うまし.S01E05.ドライブ行かない_.WEBRip.Netflix.ja[cc].mkv',
+      );
+      expect(info.series, '日々は過ぎれど飯うまし');
+      expect(info.season, 1);
+      expect(info.episode, 5);
+    });
+
+    test('分集标题归 secondaryTitle，不丢信息', () {
+      final ParsedMediaName parsed = FilenameParser.parse(
+        '日々は過ぎれど飯うまし.S01E10.ただいま.WEBRip.Netflix.ja[cc].mkv',
+      );
+      expect(parsed.title, '日々は過ぎれど飯うまし');
+      expect(parsed.secondaryTitle, 'ただいま');
+    });
+
+    test('集号前置命名不被截空（S01E04 之前无标题字符时不截断）', () {
+      final VideoNameInfo info = parseVideoFilename('S01E04 - Title.mkv');
+      expect(info.series, 'Title');
+      expect(info.season, 1);
+      expect(info.episode, 4);
+    });
+  });
+
   group('groupVideosIntoPlaylists', () {
+    test('整季分集标题各不相同 → 仍归一组，按集号排序（BUG-1435）', () {
+      const String prefix = '/v/日々は過ぎれど飯うまし.S01E';
+      const String suffix = '.WEBRip.Netflix.ja[cc].mkv';
+      final List<VideoGroup> groups = groupVideosIntoPlaylists(<String>[
+        '${prefix}09.出店してみますか!$suffix',
+        '${prefix}10.ただいま$suffix',
+        '${prefix}07.ずっと忘れないと思う$suffix',
+        '${prefix}12.ごちそうさま!!$suffix',
+        '${prefix}04.この子は星なな$suffix',
+        '${prefix}03.お金なくなっちゃった!!$suffix',
+        '${prefix}05.ドライブ行かない_$suffix',
+        '${prefix}11.クリスマス空いてますか!_$suffix',
+      ]);
+      expect(groups, hasLength(1), reason: '同一部番必须归一组');
+      final VideoGroup g = groups.single;
+      expect(g.series, '日々は過ぎれど飯うまし');
+      expect(g.isPlaylist, isTrue);
+      expect(
+        g.episodes.map((VideoEpisode e) => e.episode).toList(),
+        <int>[3, 4, 5, 7, 9, 10, 11, 12],
+      );
+    });
+
     test('同系列多集 → 一组，按集号排序', () {
       final List<VideoGroup> groups = groupVideosIntoPlaylists(<String>[
         '/v/[G] Title - 03 [1080p].mkv',


### PR DESCRIPTION
用户报告：按文件夹导入一整季 12 集，库里变成 12 个独立项目；手动做成合集后里面顺序也是乱的。两条是独立缺陷。

## BUG-1435 · 按文件夹导入分不到一组

`日々は過ぎれど飯うまし.S01E09.出店してみますか!.WEBRip.Netflix.ja[cc].mkv` 这类 Jellyfin / Plex / Netflix 点分隔命名，`SxxExx` **之后**是该集独有的分集标题 + 发布元数据。此前解析器只把 `SxxExx` 本身替换成空格，分集标题继续参与标题拼装：

```
修复前（8 个真实文件名实测）
SERIES=[日々は過ぎれど飯うまし お金なくなっちゃった!!] S=1 E=3
SERIES=[日々は過ぎれど飯うまし 出店してみますか!]     S=1 E=9
SERIES=[日々は過ぎれど飯うまし .ドライブ行かない .WEBRip.Netflix.ja] S=1 E=5
GROUPS=8   ← 每集自成一组，一个 playlist 合集都建不出来

修复后
SERIES=[日々は過ぎれど飯うまし] S=1 E=3 / 4 / 5 / 7 / 9 / 10 / 11 / 12
GROUPS=1（8 集，按集号排好）
```

- `filename_parser.dart` ① 处：命中 `_seasonEpisode` 即在匹配位置截断，其后文本经 `_cutTrailingNoiseTokens` 清洗后归 `secondaryTitle`（信息不丢）。集号之前无标题字符时（`S01E04 - Title` 这类集号前置命名）保留原「替换成空格」行为，避免标题被截空。
- `_normalizeSeparators`：「点分隔命名」判定前移到 `_`→空格 **之前**。此前文件名里只要有一个下划线（`ドライブ行かない_`），判定就失效，`.WEBRip.Netflix.ja` 整串留在系列名里。

## BUG-1436 · 手动建的合集内部乱序

批量「组合成合集」直接按选择集（`Set<String>`，迭代序 = 点选/框选顺序）逐条 `addToCollection`，sortIndex 就此定型（E09、E10、E07、E12…）。合集详情页的「一键整理」是事后手动补救，默认路径从不排序。

新增共享真相源 `sortNewCollectionMembersNaturally`：落盘前按显示标题 `naturalCompare` 排序（规则与「一键整理·按名称」同源），同名按输入下标兜底（`List.sort` 非稳定）。只排**本次批次**——并入既有合集时不动已有成员相对序（可能是用户手动拖拽排好的）。视频页与书架页同修，三档（新建 / 并入 / 合并）共用。

## 验证

- `flutter analyze` 全量（含 test）：No issues found
- 定向 520 测试全绿（`test/media/video/scraper/` + 解析器 + 导入 + `test/media/collections/` + `test/tools/`）
- 两个新守卫各做变异实测：截断改回 `replaceRange` 旧行为 → 4 error event；`naturalCompare` 结果压成 0 → 2 error event

未做真机验证。

https://claude.ai/code/session_01XGdphbxECEd6z89MzsBzPL
