### PR TITLE
fix(ui): 右键菜单不吃界面大小——漫画菜单错位 + 阅读器菜单双重缩放 (BUG-1438)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1336 条。点号进各自文件。
+> 共 1337 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1438](bugs/BUG-1438-context-menu-ui-scale.md) | ✅ | ✅ | 右键/上下文菜单不吃界面大小：漫画菜单错位 + 阅读器菜单双重缩放 |
 | [BUG-1432](bugs/BUG-1432-ime-physical-key-ledger.md) | ✅ | ✅ | TODO-2652「三处快捷键台账仍记裸 logicalKey」经查证伪：`LogicalKeyboardKey.process` 在 5 个出包平台上根本不可达 |
 | [BUG-1430](bugs/BUG-1430-subtitle-obscure-switch-lag.md) | ✅ | ✅ | 切换字幕遮罩模式卡顿：两次事务落盘 + UI 等落盘 + 全局广播重建全 app |
 | [BUG-1429](bugs/BUG-1429-bug-tool-number-pool-misses-uncommitted-worktrees.md) | ✅ | ✅ | bug.dart 取号扫不到并发工作区未提交的 bug 文件，一天连撞六次 |

--- a/docs/bugs/BUG-1438-context-menu-ui-scale.md
+++ b/docs/bugs/BUG-1438-context-menu-ui-scale.md
@@ -1,0 +1,77 @@
+## BUG-1438 · 右键/上下文菜单不吃界面大小：漫画菜单错位 + 阅读器菜单双重缩放
+
+- **报告**：2026-08-02（用户：「漫画里面等，好多地方的右键没有吃界面大小」）
+- **真实性**：✅ 真 bug，且是**两个方向相反**的缺陷共用一个根因模型（见下）。
+
+### 根因：中和器两侧的坐标空间被混用
+
+生产拓扑是两层缩放，改这块必须同时理解：
+
+1. 全局 `HibikiAppUiScale` 挂在 `MaterialApp.builder`（`hibiki/lib/main.dart:1630`），
+   用 `FittedBox(BoxFit.fill)` 把整棵子树渲染进一个**缩放画布**（尺寸 = 真实视口 / scale）
+   再拉满屏。**根 Navigator / 根 Overlay 都在它之内**（`app_ui_scale.dart:112-122`）
+   → Overlay 本地坐标 = 画布空间，且画布→屏幕这一跳会把其中一切按 scale 放大一次。
+2. 阅读器 / 漫画 / PDF / 视频页在**路由层**再套 `HibikiAppUiScaleNeutralizer`
+   （`app_ui_scale.dart:139-174`），把页面子树净缩放还原成 1.0（让 WebView / Texture 按
+   原生密度渲染）→ 页面内部的坐标与 `MediaQuery.size` 都是**真实屏幕**空间。
+
+菜单（`showMenu` 的 PopupMenuRoute、根 `OverlayEntry`、SelectionOverlay 的 toolbar）
+挂在根 Overlay，也就是**中和器之外**。`InheritedTheme.capture` 捕获不到中和器
+（它是 LayoutBuilder+FittedBox，不是 InheritedTheme），实测 scale=2 下「页面中和 / 不中和」
+菜单渲染结果逐像素相同。由此两条规则不可互抄：
+
+| 位置 | 是否已跟随界面大小 | 代码该怎么写 |
+|---|---|---|
+| 中和器**内**（页面 chrome / 底栏） | 否（净缩放=1） | 必须手动 `× appUiScale` |
+| 中和器**外**（菜单 / 根 Overlay 浮层） | **是**（画布自带） | 尺寸写常量；坐标须 `Overlay.globalToLocal` |
+
+**缺陷 A — 锚点：真实坐标当画布坐标（菜单跑位）**
+`manga_hibiki_page.dart` `_showReaderContextMenu`：JS 报的 `clientX/clientY` 是真实屏幕坐标，
+被直接当 `RelativeRect` 喂给 `showMenu`；边界还用了 `MediaQuery.of(context).size`（中和层内
+= 真实视口，比 `overlay.size` 大 scale 倍）。菜单实际渲染在「点击点 × scale」——125% 时右键
+点 (800,600) 菜单跑到 (1000,750)，越靠右下偏得越远；50% 则缩向左上。
+同型：`hibiki_material_components.dart` 日志面板 `_buildContextMenu` 的
+`TextSelectionToolbarAnchors.primaryAnchor`。
+
+**缺陷 B — 尺寸：菜单被乘了两次 scale（scale²）**
+`reader_hibiki_page.dart` 的 `_readerImageMenuScale = normalize(_readerChromeScale)` 把
+chrome 的缩放口径套到了菜单上（图片右键 / 文字选区右键 / 移动端选区操作条三处）。该 getter
+自己的注释甚至写着「不在阅读器中和后的 chrome 子树内」——既然不在，就已经吃过一次缩放。
+**实测**：同样写 `fontSize: 14 * menuScale`，scale=2 时 chrome 文字渲染 40px，菜单 80px。
+
+顺带修：选区操作条 `selectionBottom = selectionTop + r['height']` 把 Overlay 画布空间的
+`selectionTop` 和 WebView 真实像素的 `height` 相加（混量纲），改为两角各过一次换算。
+
+- **[x] ① 已修复** — commit 见下。改动：
+  - `hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart` `_showReaderContextMenu`：
+    锚点经 `overlay.globalToLocal`，边界改 `Offset.zero & overlay.size`。
+  - `hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart`：三处菜单/操作条
+    去掉全部 `* menuScale`（尺寸写常量）；选区矩形两角各做一次坐标换算。
+  - `hibiki/lib/src/pages/implementations/reader_hibiki_page.dart`：删除
+    `_readerImageMenuScale` getter（双重缩放根源），原位留反向注释防复发。
+  - `hibiki/lib/src/utils/components/hibiki_material_components.dart`：日志面板 toolbar
+    锚点经 `Overlay.globalToLocal`。
+- **[x] ② 已加自动化测试** — `hibiki/test/pages/context_menu_ui_scale_guard_test.dart`（9 条）：
+  - **不变式 A（真渲染 + 真右键手势）**：scale=0.5/1.0/2.0 下菜单矩形到点击点的间隙
+    < `24 × scale`（实测 4.0 / 8.1 / 16.1，恰为菜单自身 padding × scale）。
+  - **不变式 B（真渲染）**：scale=2 的菜单文字高度恰为 scale=1 的 **2 倍**（线性，非平方）。
+  - **两条变异对照**（防恒真假绿）：不做换算时偏移 >200（实测 302）；手动乘 menuScale 时
+    比值变成 **4 倍**（scale²）。
+  - **三条源码守卫**把生产代码钉在范式上，并已**变异实测**：三处分别改回旧写法后，
+    5 个守卫用例全红，反向还原后复绿。
+  - 既有 `reader_image_actions_guard_static_test.dart` /
+    `reader_text_context_menu_scale_guard_test.dart` 原本断言「必须乘 menuScale」，方向是反的，
+    已随本次修复反转并注明原因。
+- **备注**：
+  - 用户原话「好多地方」已核到 5 处（漫画右键、阅读器图片右键、阅读器文字选区右键、
+    阅读器移动端选区操作条、日志面板选区工具条）。全仓其余 `showMenu` 站点（视频 / 合集网格 /
+    合集详情 / 标签管理 / 插画查看器 / 关系图 / 词典弹窗 WebView）逐个核过，**均已正确**。
+  - `VideoHibikiPage.neutralized` 的 `_videoUiScale` 用于**页内**顶底栏，在中和器内，
+    是正确的，不要顺手删。
+  - **附带发现（未在本轮修，非右键问题）**：`reader_pdf_page.dart` 的 Scaffold 带 AppBar，
+    而 `buildDictionary()` 直接放在 body 的 Stack 里，其坐标空间原点是 body 左上角，但
+    `_screenRectForChar`（`reader_pdf_page.dart:401-416`）报的是全局屏幕矩形 → PDF 查词弹窗
+    恒定偏下约 AppBar+状态栏高度，与界面缩放无关。漫画页对这个契约有明文注释
+    （`manga_hibiki_page.dart` 「buildDictionary() 绝不嵌进有 padding/偏移/滚动的子树」），
+    EPUB 阅读器也是无 AppBar 全出血 Stack，**只有 PDF 违约**。建议另开一条跟进。
+  - 真机复测（Windows 调界面大小后漫画/阅读器右键贴住鼠标、菜单字号与底栏一致）待用户。

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -2858,14 +2858,30 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     if (decoded is! Map || !mounted) return;
     final double x = (decoded['x'] as num?)?.toDouble() ?? 0;
     final double y = (decoded['y'] as num?)?.toDouble() ?? 0;
-    final Size size = MediaQuery.of(context).size;
+    // BUG-1438（与 BUG-129/261/381/781 同族）：JS 报的 clientX/clientY 是 **真实屏幕
+    // 坐标**——漫画页整棵子树被 HibikiAppUiScaleNeutralizer 中和回净缩放=1（见
+    // manga_hibiki_source.dart），WebView 全出血铺满真实视口。但 showMenu 的
+    // RelativeRect 落在根 Navigator 的 Overlay 坐标系，而该 Overlay 在全局
+    // HibikiAppUiScale 的 FittedBox 之内（**缩放画布**空间，尺寸 = 真实视口 / scale）。
+    //
+    // 修复前把真实坐标直接当画布坐标喂进去，菜单实际渲染在「点击点 × scale」：
+    // 界面大小 125% 时右键点在 (800,600) 菜单跑到 (1000,750)，越靠右下偏得越远；
+    // 调小到 50% 则菜单缩向左上角。同理 MediaQuery.of(context).size 在中和层内是
+    // **真实视口**尺寸（比 overlay.size 大 scale 倍），当作 RelativeRect 的 right/bottom
+    // 会让贴边翻转判断一起失准。
+    //
+    // 修法与同族一致：不读 scale 数值逆算（自动模式下生效 scale ≠ appModel.appUiScale），
+    // 而用 Overlay 的 RenderBox 沿真实渲染变换链把锚点映射到 Overlay 本地坐标——中间的
+    // FittedBox 缩放被 render transform 自动吸收，对任意 scale 自洽；scale=1 时变换为
+    // 单位阵，逐像素等价（向后兼容）。边界同步改用 overlay.size。
+    final RenderBox overlay =
+        Overlay.of(context).context.findRenderObject()! as RenderBox;
+    final Offset anchor = overlay.globalToLocal(Offset(x, y));
     final _MangaContextAction? action = await showMenu<_MangaContextAction>(
       context: context,
-      position: RelativeRect.fromLTRB(
-        x,
-        y,
-        math.max(0, size.width - x),
-        math.max(0, size.height - y),
+      position: RelativeRect.fromRect(
+        Rect.fromLTWH(anchor.dx, anchor.dy, 1, 1),
+        Offset.zero & overlay.size,
       ),
       items: <PopupMenuEntry<_MangaContextAction>>[
         PopupMenuItem<_MangaContextAction>(

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -196,7 +196,6 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     final BuildContext effectiveContext = menuContext ?? context;
     final RenderBox overlay =
         Overlay.of(effectiveContext).context.findRenderObject()! as RenderBox;
-    final double menuScale = _readerImageMenuScale;
     // BUG-381: [globalPosition] 是真实屏幕坐标（右键路径来自阅读器 State 的 RenderBox
     // localToGlobal，放大图路径来自 details.globalPosition；两者都在「净缩放=1 的真实
     // 视口空间」——阅读器被 HibikiAppUiScaleNeutralizer 中和回 1.0）。但 showMenu 的
@@ -208,7 +207,15 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     // appModel.appUiScale），而用 Overlay 的 RenderBox 把锚点从真实屏幕坐标沿真实渲染
     // 变换链映射到 Overlay 本地坐标系——其间的 FittedBox 缩放被 render transform 自动
     // 吸收，对任意 scale（含自动模式）自洽无残差；scale=1 时变换为单位阵，逐像素等价
-    // （向后兼容）。菜单内容缩放（menuScale）是另一回事，保持不动。
+    // （向后兼容）。
+    //
+    // BUG-1438：菜单内容**不能**再乘界面缩放。菜单渲染在根 Overlay，也就是全局
+    // HibikiAppUiScale 的缩放画布内，画布→屏幕这一跳已经把它按 scale 放大了一次；
+    // 阅读器 chrome 之所以要手动 ×_readerChromeScale，是因为 chrome 在
+    // HibikiAppUiScaleNeutralizer **之内**（净缩放=1，不跟随），而菜单在**之外**。
+    // 旧代码把 chrome 的规则错套到菜单上 → 视觉尺寸是 scale²：实测同样写
+    // `fontSize: 14 * menuScale`，chrome 渲染成 40 而菜单 80（scale=2）。所以这里
+    // 写常量，让菜单与 app 其它右键菜单（视频 / 合集 / 标签管理）口径一致。
     final Offset anchor = overlay.globalToLocal(globalPosition);
     final String? action = await showMenu<String>(
       context: effectiveContext,
@@ -216,24 +223,21 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         Rect.fromLTWH(anchor.dx, anchor.dy, 1, 1),
         Offset.zero & overlay.size,
       ),
-      constraints: BoxConstraints(
-        minWidth: 112.0 * menuScale,
-        maxWidth: 280.0 * menuScale,
-      ),
-      menuPadding: EdgeInsets.symmetric(vertical: 8.0 * menuScale),
+      constraints: const BoxConstraints(minWidth: 112.0, maxWidth: 280.0),
+      menuPadding: const EdgeInsets.symmetric(vertical: 8.0),
       items: <PopupMenuEntry<String>>[
         PopupMenuItem<String>(
           value: 'copy',
-          height: kMinInteractiveDimension * menuScale,
-          padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
+          height: kMinInteractiveDimension,
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Icon(Icons.copy_outlined, size: 18.0 * menuScale),
-              SizedBox(width: 12.0 * menuScale),
+              const Icon(Icons.copy_outlined, size: 18.0),
+              const SizedBox(width: 12.0),
               Text(
                 t.reader_copy_image,
-                style: TextStyle(fontSize: 14.0 * menuScale),
+                style: const TextStyle(fontSize: 14.0),
               ),
             ],
           ),
@@ -246,9 +250,9 @@ extension _ReaderChrome on _ReaderHibikiPageState {
   }
 
   // TODO-954：阅读器文字选区右键菜单（Windows）。完全复用图片右键的「锚点经 Overlay
-  // RenderBox 映射 + menuScale 只缩放菜单自身」范式（见上方 BUG-381 长注释），让查词/
-  // 复制/导出三项随界面大小缩放，而鼠标锚点与 WebView 命中测试不受影响。导出项仅在本书
-  // 有音频 cue 时出现；其它两项恒在。
+  // RenderBox 映射、菜单尺寸写常量」范式（见上方 BUG-381 / BUG-1438 长注释）：菜单随
+  // 界面大小缩放这件事由它所在的缩放画布负责，代码不再手动乘 scale，而鼠标锚点与
+  // WebView 命中测试不受影响。导出项仅在本书有音频 cue 时出现；其它两项恒在。
   Future<void> _showReaderTextContextMenu(Offset globalPosition) async {
     if (!mounted || !isWindowsPlatform || _readerTextContextMenuActive) {
       return;
@@ -285,7 +289,8 @@ extension _ReaderChrome on _ReaderHibikiPageState {
 
       final RenderBox overlay =
           Overlay.of(context).context.findRenderObject()! as RenderBox;
-      final double menuScale = _readerImageMenuScale;
+      // BUG-1438：与图片右键菜单同因——菜单在根 Overlay（缩放画布）内，不得再手动
+      // 乘界面缩放，否则视觉尺寸是 scale²。详见上方 _showReaderImageContextMenu 注释。
       final Offset anchor = overlay.globalToLocal(globalPosition);
 
       final bool hasAudio = _audiobookController != null &&
@@ -294,27 +299,27 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       final List<PopupMenuEntry<String>> items = <PopupMenuEntry<String>>[
         PopupMenuItem<String>(
           value: 'search',
-          height: kMinInteractiveDimension * menuScale,
-          padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
+          height: kMinInteractiveDimension,
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Icon(Icons.search_outlined, size: 18.0 * menuScale),
-              SizedBox(width: 12.0 * menuScale),
-              Text(t.search, style: TextStyle(fontSize: 14.0 * menuScale)),
+              Icon(Icons.search_outlined, size: 18.0),
+              const SizedBox(width: 12.0),
+              Text(t.search, style: TextStyle(fontSize: 14.0)),
             ],
           ),
         ),
         PopupMenuItem<String>(
           value: 'copy',
-          height: kMinInteractiveDimension * menuScale,
-          padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
+          height: kMinInteractiveDimension,
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Icon(Icons.copy_outlined, size: 18.0 * menuScale),
-              SizedBox(width: 12.0 * menuScale),
-              Text(t.copy, style: TextStyle(fontSize: 14.0 * menuScale)),
+              Icon(Icons.copy_outlined, size: 18.0),
+              const SizedBox(width: 12.0),
+              Text(t.copy, style: TextStyle(fontSize: 14.0)),
             ],
           ),
         ),
@@ -323,30 +328,28 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         // （TODO-1279），旧菜单只有查词 / 复制 / 导出，无从收藏当前句；此项填平缺口。
         PopupMenuItem<String>(
           value: 'favorite',
-          height: kMinInteractiveDimension * menuScale,
-          padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
+          height: kMinInteractiveDimension,
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Icon(Icons.star_border, size: 18.0 * menuScale),
-              SizedBox(width: 12.0 * menuScale),
-              Text(t.action_favorite,
-                  style: TextStyle(fontSize: 14.0 * menuScale)),
+              Icon(Icons.star_border, size: 18.0),
+              const SizedBox(width: 12.0),
+              Text(t.action_favorite, style: TextStyle(fontSize: 14.0)),
             ],
           ),
         ),
         if (hasAudio)
           PopupMenuItem<String>(
             value: 'export',
-            height: kMinInteractiveDimension * menuScale,
-            padding: EdgeInsets.symmetric(horizontal: 16.0 * menuScale),
+            height: kMinInteractiveDimension,
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
-                Icon(Icons.movie_creation_outlined, size: 18.0 * menuScale),
-                SizedBox(width: 12.0 * menuScale),
-                Text(t.audiobook_export_clip,
-                    style: TextStyle(fontSize: 14.0 * menuScale)),
+                Icon(Icons.movie_creation_outlined, size: 18.0),
+                const SizedBox(width: 12.0),
+                Text(t.audiobook_export_clip, style: TextStyle(fontSize: 14.0)),
               ],
             ),
           ),
@@ -358,11 +361,8 @@ extension _ReaderChrome on _ReaderHibikiPageState {
           Rect.fromLTWH(anchor.dx, anchor.dy, 1, 1),
           Offset.zero & overlay.size,
         ),
-        constraints: BoxConstraints(
-          minWidth: 112.0 * menuScale,
-          maxWidth: 280.0 * menuScale,
-        ),
-        menuPadding: EdgeInsets.symmetric(vertical: 8.0 * menuScale),
+        constraints: const BoxConstraints(minWidth: 112.0, maxWidth: 280.0),
+        menuPadding: const EdgeInsets.symmetric(vertical: 8.0),
         items: items,
       );
       if (!mounted) return;
@@ -477,8 +477,10 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       return const SizedBox.shrink();
     }
     final Size overlaySize = overlayBox.size;
-    final double menuScale = _readerImageMenuScale;
-    final double barHeight = kMinInteractiveDimension * menuScale;
+    // BUG-1438：本操作条是插进**根 Overlay** 的 OverlayEntry，落在全局
+    // HibikiAppUiScale 的缩放画布内，已天然跟随界面大小；不得再乘
+    // _readerImageMenuScale（那是给中和层内 chrome 用的），否则视觉尺寸是 scale²。
+    const double barHeight = kMinInteractiveDimension;
     const double gap = 8;
     const double handleReserve = 32 + gap;
 
@@ -488,11 +490,18 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     double selectionTop;
     double selectionBottom;
     if (r != null && webBox != null) {
-      final Offset topGlobal = webBox.localToGlobal(
-        Offset(r['x'] ?? 0, r['y'] ?? 0),
+      // BUG-1438：选区矩形的**两个角**都要过 localToGlobal→globalToLocal，不能只映射
+      // 顶边再加上未换算的 height。`r` 来自 WebView（中和层内的真实像素），而
+      // selectionTop 已在 Overlay 画布空间——两者相加是混量纲，界面大小≠100% 时
+      // 「上方放不下→翻到选区下方」这一分支会偏 (1−1/scale)×选区高。
+      final double rx = r['x'] ?? 0;
+      final double ry = r['y'] ?? 0;
+      final Offset topGlobal = webBox.localToGlobal(Offset(rx, ry));
+      final Offset bottomGlobal = webBox.localToGlobal(
+        Offset(rx, ry + (r['height'] ?? 0)),
       );
       selectionTop = overlayBox.globalToLocal(topGlobal).dy;
-      selectionBottom = selectionTop + (r['height'] ?? 0);
+      selectionBottom = overlayBox.globalToLocal(bottomGlobal).dy;
     } else {
       selectionTop = overlaySize.height / 2;
       selectionBottom = selectionTop;
@@ -515,16 +524,16 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       return InkWell(
         onTap: () => _runSelectionAction(action),
         child: Padding(
-          padding: EdgeInsets.symmetric(
-            horizontal: 12.0 * menuScale,
-            vertical: 10.0 * menuScale,
+          padding: const EdgeInsets.symmetric(
+            horizontal: 12.0,
+            vertical: 10.0,
           ),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Icon(icon, size: 18.0 * menuScale),
-              SizedBox(width: 8.0 * menuScale),
-              Text(label, style: TextStyle(fontSize: 14.0 * menuScale)),
+              Icon(icon, size: 18.0),
+              const SizedBox(width: 8.0),
+              Text(label, style: TextStyle(fontSize: 14.0)),
             ],
           ),
         ),
@@ -543,7 +552,7 @@ extension _ReaderChrome on _ReaderHibikiPageState {
             elevation: 6,
             color: theme.popupMenuTheme.color ??
                 theme.colorScheme.surfaceContainerHigh,
-            borderRadius: BorderRadius.circular(8.0 * menuScale),
+            borderRadius: BorderRadius.circular(8.0),
             clipBehavior: Clip.antiAlias,
             child: Row(
               mainAxisSize: MainAxisSize.min,

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -114,7 +114,6 @@ import 'package:hibiki/src/shortcuts/dictionary_caret_controller.dart';
 export 'package:hibiki/src/shortcuts/dictionary_caret_controller.dart'
     show CaretSurface;
 import 'package:hibiki/src/shortcuts/reader_space_override.dart';
-import 'package:hibiki/src/utils/app_ui_scale.dart';
 
 part 'reader_hibiki/lyrics.part.dart';
 part 'reader_hibiki/mining.part.dart';
@@ -1366,10 +1365,12 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
   /// 1.0，故不能用 HibikiAppUiScale.of）。在 build 里读 appModel 会随缩放变化重建。
   double get _readerChromeScale => appModel.appUiScale;
 
-  /// 图片右键菜单由 Flutter PopupMenuRoute 承载，不在阅读器中和后的 chrome 子树内。
-  /// 所以这里复用 reader chrome 的用户界面缩放口径，且只缩放菜单自身，不改鼠标锚点。
-  double get _readerImageMenuScale =>
-      HibikiAppUiScale.normalize(_readerChromeScale);
+  // BUG-1438：曾有 `_readerImageMenuScale = normalize(_readerChromeScale)`，把 chrome
+  // 的缩放口径套到右键菜单 / 选区操作条上。那是错的——菜单由 PopupMenuRoute / 根
+  // OverlayEntry 承载，**在中和器之外**，落在全局 HibikiAppUiScale 的缩放画布里，
+  // 画布→屏幕这一跳已经按 scale 放大过一次；再乘一次得到 scale²（实测 scale=2 时
+  // chrome 文字 40px 而菜单 80px）。菜单尺寸一律写常量，见 chrome.part.dart 的
+  // _showReaderImageContextMenuAtGlobalPosition 注释。
 
   /// 缩放后底栏在屏高度。所有把底栏高度喂给 WebView/光标/焦点环/正文预留的地方都
   /// 走这个 getter，保证视觉高度与预留高度恒等。

--- a/hibiki/lib/src/utils/components/hibiki_material_components.dart
+++ b/hibiki/lib/src/utils/components/hibiki_material_components.dart
@@ -2584,14 +2584,24 @@ class _HibikiLogPanelState extends State<HibikiLogPanel> {
         },
       ),
     ];
+    // BUG-1438（与 BUG-129/261/381/781 同族）：[_lastPointerDownGlobalPosition] 是
+    // 真实屏幕坐标，而本 toolbar 由 SelectionOverlay 挂进根 Overlay——后者落在全局
+    // HibikiAppUiScale 的 FittedBox 缩放画布内，锚点被当画布坐标解读。界面大小≠100%
+    // 时工具条会偏到「右键点 × scale」处（离屏幕原点越远偏得越多）。经 Overlay 的
+    // RenderBox 沿真实渲染变换链换算，缩放被 render transform 自动吸收；scale=1 时
+    // 为单位阵，逐像素等价。
+    final Offset rawAnchor = _lastPointerDownGlobalPosition ?? Offset.zero;
+    final RenderBox? overlayBox =
+        Overlay.maybeOf(context)?.context.findRenderObject() as RenderBox?;
+    final Offset anchor = overlayBox != null && overlayBox.hasSize
+        ? overlayBox.globalToLocal(rawAnchor)
+        : rawAnchor;
     return AdaptiveTextSelectionToolbar.buttonItems(
       // TODO-1380/BUG-694：锚点自持（[_lastPointerDownGlobalPosition]），不读
       // selectableRegionState.contextMenuAnchors——其 glyph 回退路径对选区端点
       // 空断言，toolbar 重建即崩。null 分支不可达（菜单必由面板内 pointer down
       // 召出），仅作类型收口。
-      anchors: TextSelectionToolbarAnchors(
-        primaryAnchor: _lastPointerDownGlobalPosition ?? Offset.zero,
-      ),
+      anchors: TextSelectionToolbarAnchors(primaryAnchor: anchor),
       buttonItems: items,
     );
   }

--- a/hibiki/test/pages/context_menu_ui_scale_guard_test.dart
+++ b/hibiki/test/pages/context_menu_ui_scale_guard_test.dart
@@ -1,0 +1,289 @@
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/utils/app_ui_scale.dart';
+
+/// BUG-1438（与 BUG-129/261/381/781 同族）守卫：**右键 / 上下文菜单在界面大小≠100%
+/// 时的坐标空间与内容尺寸**。
+///
+/// 生产拓扑（两层，必须同时理解才不会改错）：
+///  1. 全局 [HibikiAppUiScale] 挂在 `MaterialApp.builder`（main.dart），用
+///     `FittedBox(BoxFit.fill)` 把整棵子树渲染进一个「缩放画布」（尺寸 = 真实视口 /
+///     scale）再拉满屏。**根 Navigator / 根 Overlay 都在它之内** → Overlay 本地坐标
+///     是画布空间，且画布→屏幕这一跳会把其中一切按 scale 放大一次。
+///  2. 阅读器 / 漫画 / PDF / 视频页在**路由层**再套 [HibikiAppUiScaleNeutralizer]，
+///     把页面子树净缩放还原成 1.0（让 WebView / Texture 按原生密度渲染）→ 页面内部
+///     拿到的坐标和 `MediaQuery.size` 都是**真实屏幕**空间。
+///
+/// 由此得到两条不变式，本文件各用一个真渲染测试锁定：
+///  A. **锚点**：页面手里的真实屏幕坐标喂给 `showMenu` 前，必须经
+///     `Overlay.globalToLocal` 换算（边界同样用 `overlay.size` 而非
+///     `MediaQuery.of(context).size`）。否则菜单渲染在「点击点 × scale」。
+///  B. **内容尺寸**：菜单在中和器**之外**，已经天然跟随界面大小；代码**不得**再手动
+///     乘 scale。旧阅读器代码复用了 chrome 的 `menuScale`，视觉尺寸变成 scale²。
+void main() {
+  /// 复刻生产拓扑：全局缩放包住 Navigator/Overlay，页面再被中和。
+  Widget wrap({required double scale, required Widget page}) => MaterialApp(
+        builder: (BuildContext context, Widget? child) =>
+            HibikiAppUiScale(scale: scale, child: child!),
+        home: HibikiAppUiScaleNeutralizer(child: page),
+      );
+
+  group('不变式 A：菜单锚点经 Overlay 换算后贴住真实点击点', () {
+    /// 被测页面：整屏右键热区。[mapThroughOverlay] 切换「正确范式 / 修复前写法」，
+    /// 让同一个测试既能证明修复有效，也能证明它抓得住回归（变异对照）。
+    Widget menuPage({required bool mapThroughOverlay}) => Builder(
+          builder: (BuildContext context) => Scaffold(
+            body: GestureDetector(
+              behavior: HitTestBehavior.opaque,
+              onSecondaryTapDown: (TapDownDetails d) {
+                final RenderBox overlay = Overlay.of(context)
+                    .context
+                    .findRenderObject()! as RenderBox;
+                final RelativeRect position;
+                if (mapThroughOverlay) {
+                  final Offset anchor = overlay.globalToLocal(d.globalPosition);
+                  position = RelativeRect.fromRect(
+                    Rect.fromLTWH(anchor.dx, anchor.dy, 1, 1),
+                    Offset.zero & overlay.size,
+                  );
+                } else {
+                  // 修复前：真实屏幕坐标直接当画布坐标，边界取 MediaQuery（中和层内
+                  // 是真实视口，比 overlay.size 大 scale 倍）。
+                  final Size size = MediaQuery.of(context).size;
+                  position = RelativeRect.fromLTRB(
+                    d.globalPosition.dx,
+                    d.globalPosition.dy,
+                    size.width - d.globalPosition.dx,
+                    size.height - d.globalPosition.dy,
+                  );
+                }
+                showMenu<String>(
+                  context: context,
+                  position: position,
+                  items: const <PopupMenuEntry<String>>[
+                    PopupMenuItem<String>(value: 'a', child: Text('ITEM')),
+                  ],
+                );
+              },
+              child: const SizedBox.expand(),
+            ),
+          ),
+        );
+
+    /// 右键点屏幕中心偏右下（离原点足够远，放大缩放偏移），返回菜单项与点击点的距离。
+    Future<double> menuOffsetFromClick(
+      WidgetTester tester, {
+      required double scale,
+      required bool mapThroughOverlay,
+    }) async {
+      tester.view.devicePixelRatio = 1.0;
+      tester.view.physicalSize = const Size(1200, 900);
+      addTearDown(tester.view.reset);
+
+      await tester.pumpWidget(wrap(
+          scale: scale, page: menuPage(mapThroughOverlay: mapThroughOverlay)));
+      await tester.pumpAndSettle();
+
+      const Offset click = Offset(700, 520);
+      final TestGesture gesture = await tester.startGesture(
+        click,
+        kind: PointerDeviceKind.mouse,
+        buttons: kSecondaryButton,
+      );
+      await tester.pump(const Duration(milliseconds: 50));
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(find.text('ITEM'), findsOneWidget, reason: '右键应弹出菜单');
+      final Rect itemRect = tester.getRect(
+        find.byWidgetPredicate((Widget w) => w is PopupMenuItem),
+      );
+      // 「贴住点击点」= 点击点到菜单矩形的距离，不是到 topLeft 的距离：点击点落在
+      // 屏幕右半边时 Flutter 会把菜单**向左展开**（右边缘对齐点击点），那是正确
+      // 行为，用 topLeft 度量会把它误判成偏移。
+      return _distanceToRect(itemRect, click);
+    }
+
+    // 修复后菜单与点击点的间隙恒为「菜单自身垂直 padding × scale」（实测 8×scale：
+    // 0.5→4.0 / 1.0→8.1 / 2.0→16.1）；阈值按 scale 取 3 倍余量，既容得下不同主题的
+    // padding，又远小于修复前的偏移量（scale=0.5 实测 302）。
+    for (final double scale in <double>[0.5, 1.0, 2.0]) {
+      testWidgets('缩放 $scale：换算后菜单贴住点击点', (WidgetTester tester) async {
+        final double dist = await menuOffsetFromClick(tester,
+            scale: scale, mapThroughOverlay: true);
+        expect(dist, lessThan(24.0 * scale),
+            reason: 'overlay.globalToLocal 换算后菜单应贴住右键点，实测间隙=$dist');
+      });
+    }
+
+    // 变异对照：证明上面的阈值真能抓住回归，而不是恒真断言。
+    testWidgets('对照：不换算（修复前写法）在缩放下必然偏离', (WidgetTester tester) async {
+      final double dist = await menuOffsetFromClick(tester,
+          scale: 0.5, mapThroughOverlay: false);
+      expect(dist, greaterThan(200.0),
+          reason: '修复前把真实坐标当画布坐标，菜单应明显偏离点击点，实测间隙=$dist');
+    });
+  });
+
+  group('不变式 B：菜单内容尺寸随界面大小线性缩放，不是平方', () {
+    /// 返回菜单里 `fontSize: 14` 文字的**真实屏幕**渲染高度。
+    Future<double> menuTextHeight(
+      WidgetTester tester, {
+      required double scale,
+      required bool doubleScaleBug,
+    }) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+
+      late BuildContext pageContext;
+      await tester.pumpWidget(wrap(
+        scale: scale,
+        page: Builder(builder: (BuildContext c) {
+          pageContext = c;
+          return const Scaffold(body: SizedBox.expand());
+        }),
+      ));
+      await tester.pumpAndSettle();
+
+      // 修复前：中和层内页面读 appUiScale 当 menuScale 再乘一次。
+      final double menuScale = doubleScaleBug ? scale : 1.0;
+      showMenu<String>(
+        context: pageContext,
+        position: const RelativeRect.fromLTRB(20, 20, 20, 20),
+        items: <PopupMenuEntry<String>>[
+          PopupMenuItem<String>(
+            value: 'a',
+            child: Text('ITEM', style: TextStyle(fontSize: 14.0 * menuScale)),
+          ),
+        ],
+      );
+      await tester.pumpAndSettle();
+      // 同一个 test 内会连测两个 scale；pumpWidget 复用 Element 树，上一轮的
+      // PopupMenuRoute 会留在 Navigator 栈里叠加出第二个 'ITEM'。必须断言唯一并在
+      // measure 后 pop 掉，否则 `.first` 量到的是上一轮的菜单（会把 scale² 回归量成
+      // 正常值，测试假绿）。
+      expect(find.text('ITEM'), findsOneWidget,
+          reason: '菜单应唯一——出现多个说明上一轮 route 未清理');
+      final double h = tester.getRect(find.text('ITEM')).height;
+      Navigator.of(pageContext).pop();
+      await tester.pumpAndSettle();
+      return h;
+    }
+
+    testWidgets('scale=2 时菜单文字恰好是 scale=1 的 2 倍', (WidgetTester tester) async {
+      final double at1 =
+          await menuTextHeight(tester, scale: 1.0, doubleScaleBug: false);
+      final double at2 =
+          await menuTextHeight(tester, scale: 2.0, doubleScaleBug: false);
+      expect(at2 / at1, closeTo(2.0, 0.01),
+          reason: '菜单落在缩放画布内，画布→屏幕已放大一次，比值应恰为 scale；'
+              '实测 $at1 -> $at2');
+    });
+
+    // 变异对照：手动再乘一次 scale 会变成 4 倍（scale²），证明上面的断言抓得住回归。
+    testWidgets('对照：手动乘 menuScale 会变成 4 倍（scale²）',
+        (WidgetTester tester) async {
+      final double at1 =
+          await menuTextHeight(tester, scale: 1.0, doubleScaleBug: true);
+      final double at2 =
+          await menuTextHeight(tester, scale: 2.0, doubleScaleBug: true);
+      expect(at2 / at1, closeTo(4.0, 0.01),
+          reason: '双重缩放应产生 scale² 放大；实测 $at1 -> $at2');
+    });
+  });
+
+  group('源码守卫：生产代码钉在正确范式上', () {
+    String read(String path) =>
+        File(path).readAsStringSync().replaceAll('\r\n', '\n');
+
+    /// 剥掉整行注释：负向断言（`isNot(contains(...))`）必须只看真代码，否则解释
+    /// 这段历史的注释本身会让守卫红——那是假失败，比假绿更容易被人删掉守卫。
+    String stripComments(String s) => s
+        .split('\n')
+        .where((String l) => !l.trimLeft().startsWith('//'))
+        .join('\n');
+
+    String slice(String source, String start, String end) {
+      final int s = source.indexOf(start);
+      expect(s, isNonNegative, reason: '找不到起始标记：$start');
+      final int e = source.indexOf(end, s + start.length);
+      expect(e, isNonNegative, reason: '找不到结束标记：$end');
+      return source.substring(s, e);
+    }
+
+    test('漫画阅读器右键菜单：锚点经 Overlay 换算，边界用 overlay.size', () {
+      final String source =
+          read('lib/src/media/manga/reader/manga_hibiki_page.dart');
+      final String fn = slice(
+        source,
+        'Future<void> _showReaderContextMenu(String payloadJson)',
+        'if (!mounted || action == null) return;',
+      );
+
+      expect(fn, contains('Overlay.of(context).context.findRenderObject()'),
+          reason: '必须拿根 Overlay 的 RenderBox 做坐标换算');
+      expect(fn, contains('overlay.globalToLocal(Offset(x, y))'),
+          reason: 'JS 报的 clientX/clientY 是真实屏幕坐标，必须映射到 Overlay 本地');
+      expect(
+        RegExp(r'Rect\.fromLTWH\(\s*anchor\.dx,\s*anchor\.dy').hasMatch(fn),
+        isTrue,
+        reason: 'RelativeRect 必须锚在换算后的 anchor 上，不能是裸 x/y',
+      );
+      expect(fn, contains('Offset.zero & overlay.size'),
+          reason: '边界必须用 overlay.size（画布空间）');
+      expect(
+        stripComments(fn),
+        isNot(contains('MediaQuery.of(context).size')),
+        reason: '中和层内 MediaQuery.size 是真实视口，不是 Overlay 边界（BUG-1438）',
+      );
+    });
+
+    test('阅读器菜单 / 选区操作条：不得手动乘界面缩放', () {
+      final String chrome =
+          read('lib/src/pages/implementations/reader_hibiki/chrome.part.dart');
+      final String shell =
+          read('lib/src/pages/implementations/reader_hibiki_page.dart');
+
+      // 注释里可以解释这段历史，但代码里不能再出现该 getter 与乘法。
+      expect(
+        stripComments(shell),
+        isNot(contains('_readerImageMenuScale')),
+        reason: '该 getter 是双重缩放根源，已删除（BUG-1438）',
+      );
+      expect(
+        stripComments(chrome),
+        isNot(contains('menuScale')),
+        reason: '菜单在缩放画布内已天然跟随界面大小，再乘一次得 scale²（BUG-1438）',
+      );
+    });
+
+    test('日志面板选区工具条：锚点经 Overlay 换算', () {
+      final String source =
+          read('lib/src/utils/components/hibiki_material_components.dart');
+      final String fn = slice(
+        source,
+        'Widget _buildContextMenu(',
+        'buttonItems: items,',
+      );
+      expect(fn, contains('overlayBox.globalToLocal(rawAnchor)'),
+          reason: 'toolbar 挂根 Overlay（画布空间），锚点须换算（BUG-1438）');
+      expect(
+        fn,
+        isNot(contains(
+            'primaryAnchor: _lastPointerDownGlobalPosition ?? Offset.zero')),
+        reason: '不得把真实屏幕坐标直接当 Overlay 锚点',
+      );
+    });
+  });
+}
+
+/// 点 [p] 到矩形 [r] 的最短距离（点落在矩形内为 0）。
+double _distanceToRect(Rect r, Offset p) {
+  final double dx = math.max(0, math.max(r.left - p.dx, p.dx - r.right));
+  final double dy = math.max(0, math.max(r.top - p.dy, p.dy - r.bottom));
+  return math.sqrt(dx * dx + dy * dy);
+}

--- a/hibiki/test/pages/reader_image_actions_guard_static_test.dart
+++ b/hibiki/test/pages/reader_image_actions_guard_static_test.dart
@@ -70,45 +70,40 @@ void main() {
     // so the old corpus-wide isNot(Clipboard.setData) guard was over-broad and removed.
   });
 
-  test('reader image context menu scales with reader chrome only', () {
+  test('reader image context menu does not double-scale with ui scale', () {
     final String source = readReaderPageSource();
 
-    expect(source, contains('double get _readerImageMenuScale'));
+    // BUG-1438：本用例原先要求菜单尺寸乘 `_readerImageMenuScale`，方向是反的。
+    // 菜单由 PopupMenuRoute 承载，挂在根 Overlay = 全局 HibikiAppUiScale 的缩放画布
+    // 内，画布→屏幕这一跳已按 scale 放大过一次；阅读器 chrome 之所以要手动乘，是因为
+    // chrome 在 HibikiAppUiScaleNeutralizer **之内**（净缩放=1）。把 chrome 的规则套到
+    // 菜单上 → 视觉尺寸 scale²（实测 scale=2 时 chrome 文字 40px、菜单 80px）。
+    // 现在菜单尺寸一律写常量，"随界面大小缩放"由它所在的画布负责。
+    // 真行为断言见 test/pages/context_menu_ui_scale_guard_test.dart。
+    expect(source, isNot(contains('double get _readerImageMenuScale')),
+        reason: '双重缩放根源的 getter 必须保持删除状态');
+
     final String menu = _functionSource(
       source,
       'Future<void> _showReaderImageContextMenuAtGlobalPosition(',
       'Future<void> _shareReaderImage(String imgUrl)',
     );
 
-    expect(menu, contains('final double menuScale = _readerImageMenuScale'));
+    // 尺寸写常量，且不得再出现任何 menuScale 乘法。
+    expect(menu, contains('minWidth: 112.0'));
+    expect(menu, contains('maxWidth: 280.0'));
+    expect(menu, contains('height: kMinInteractiveDimension,'));
+    expect(menu, contains('horizontal: 16.0'));
+    expect(menu, contains('size: 18.0'));
+    expect(menu, contains('width: 12.0'));
+    expect(menu, contains('fontSize: 14.0'));
     expect(
-      RegExp(r'minWidth:\s*112(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'maxWidth:\s*280(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'height:\s*kMinInteractiveDimension\s*\*\s*menuScale')
-          .hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'horizontal:\s*16(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'size:\s*18(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'width:\s*12(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'fontSize:\s*14(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
+      menu
+          .split('\n')
+          .where((String l) => !l.trimLeft().startsWith('//'))
+          .join('\n'),
+      isNot(contains('menuScale')),
+      reason: '菜单在缩放画布内已天然跟随界面大小，再乘一次得 scale²（BUG-1438）',
     );
 
     // The menu anchor must be mapped through the Overlay RenderBox so the global
@@ -125,14 +120,12 @@ void main() {
       isTrue,
       reason: 'menu Rect must anchor on overlay-local coords, not raw global',
     );
-    // The anchor mapping must NOT read/scale by menuScale (content scale only).
-    expect(menu, isNot(contains('anchor.dx * menuScale')));
-    expect(menu, isNot(contains('anchor.dy * menuScale')));
-    expect(menu, isNot(contains('globalPosition.dx * menuScale')));
-    expect(menu, isNot(contains('globalPosition.dy * menuScale')));
+    // 锚点绝不能被任何缩放系数改写——它由 Overlay 的 render transform 负责换算。
+    expect(menu, isNot(contains('anchor.dx *')));
+    expect(menu, isNot(contains('anchor.dy *')));
+    expect(menu, isNot(contains('globalPosition.dx *')));
+    expect(menu, isNot(contains('globalPosition.dy *')));
     expect(menu, isNot(contains('webViewOffset *')));
-    expect(menu, isNot(contains('webViewOffset.dx * menuScale')));
-    expect(menu, isNot(contains('webViewOffset.dy * menuScale')));
   });
 
   test('expanded reader image viewer exposes Windows right-click copy menu',

--- a/hibiki/test/pages/reader_text_context_menu_scale_guard_test.dart
+++ b/hibiki/test/pages/reader_text_context_menu_scale_guard_test.dart
@@ -2,10 +2,18 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'reader_hibiki_page_source_corpus.dart';
 
-/// TODO-954 守卫：阅读器**文字选区右键菜单**（查词 / 复制 / 导出）必须随界面大小缩放
-/// （`menuScale = _readerImageMenuScale`，与图片右键同范式，落在 HibikiAppUiScale 内的
-/// Overlay 渲染链上），且导出入口从查词弹窗 header 迁到选区右键（Windows Flutter 菜单 +
-/// 移动端原生 ContextMenu），防止回退成「右键不吃界面大小」/「弹窗里塞导出按钮」。
+/// TODO-954 守卫：阅读器**文字选区右键菜单**（查词 / 复制 / 收藏 / 导出）随界面大小
+/// 缩放，且导出入口从查词弹窗 header 迁到选区右键（Windows Flutter 菜单 + 移动端原生
+/// ContextMenu），防止回退成「弹窗里塞导出按钮」。
+///
+/// BUG-1438 修正了本守卫原来的方向：它曾要求菜单尺寸乘 `menuScale =
+/// _readerImageMenuScale`。那是**双重缩放**——菜单挂在根 Overlay，即全局
+/// HibikiAppUiScale 的缩放画布内，画布→屏幕这一跳已经按 scale 放大过一次；
+/// 而阅读器 chrome 需要手动乘，是因为它在 HibikiAppUiScaleNeutralizer **之内**
+/// （净缩放=1）。两者在中和器的两侧，规则不能互抄。实测 scale=2 时同样写
+/// `fontSize: 14 * menuScale`，chrome 渲染 40px 而菜单 80px。
+/// 「菜单随界面大小缩放」这个诉求本身没变，只是由画布负责，代码写常量即可。
+/// 真行为断言（线性而非平方）见 test/pages/context_menu_ui_scale_guard_test.dart。
 void main() {
   String functionSource(String source, String start, String end) {
     final int startIndex = source.indexOf(start);
@@ -31,10 +39,6 @@ void main() {
       'Future<void> _exportAudiobookClipFromSelection()',
     );
 
-    // Content scale: the menu must derive from _readerImageMenuScale (same
-    // getter the image menu uses), never from a freshly read HibikiAppUiScale.
-    expect(menu, contains('final double menuScale = _readerImageMenuScale'));
-
     // Anchor mapped through the Overlay RenderBox (FittedBox transform absorbed);
     // the Rect must use the mapped `anchor`, not raw globalPosition.
     expect(menu, contains('overlay.globalToLocal(globalPosition)'));
@@ -43,38 +47,24 @@ void main() {
       isTrue,
       reason: 'menu Rect must anchor on overlay-local coords, not raw global',
     );
-    expect(menu, isNot(contains('anchor.dx * menuScale')));
-    expect(menu, isNot(contains('globalPosition.dx * menuScale')));
+    expect(menu, isNot(contains('anchor.dx *')));
+    expect(menu, isNot(contains('globalPosition.dx *')));
 
-    // Every menu item dimension scales with menuScale.
+    // BUG-1438：尺寸写常量，不得再乘任何界面缩放系数（否则 scale²）。
+    expect(menu, contains('minWidth: 112.0'));
+    expect(menu, contains('maxWidth: 280.0'));
+    expect(menu, contains('height: kMinInteractiveDimension,'));
+    expect(menu, contains('horizontal: 16.0'));
+    expect(menu, contains('size: 18.0'));
+    expect(menu, contains('width: 12.0'));
+    expect(menu, contains('fontSize: 14.0'));
     expect(
-      RegExp(r'minWidth:\s*112(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'maxWidth:\s*280(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'height:\s*kMinInteractiveDimension\s*\*\s*menuScale')
-          .hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'horizontal:\s*16(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'size:\s*18(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'width:\s*12(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
-    );
-    expect(
-      RegExp(r'fontSize:\s*14(?:\.0)?\s*\*\s*menuScale').hasMatch(menu),
-      isTrue,
+      menu
+          .split('\n')
+          .where((String l) => !l.trimLeft().startsWith('//'))
+          .join('\n'),
+      isNot(contains('menuScale')),
+      reason: '菜单在缩放画布内已天然跟随界面大小，再乘一次得 scale²（BUG-1438）',
     );
 
     // Three actions present: search, copy, export.


### PR DESCRIPTION
用户报：「漫画里面等，好多地方的右键没有吃界面大小」。核到 **5 处**，是两个方向相反的缺陷共用一个根因模型。

## 根因：中和器两侧的坐标空间被混用

生产拓扑是两层缩放：

1. 全局 `HibikiAppUiScale` 挂在 `MaterialApp.builder`，用 `FittedBox(BoxFit.fill)` 把整棵子树渲染进**缩放画布**（尺寸 = 真实视口 / scale）再拉满屏。**根 Navigator / 根 Overlay 都在它之内** → Overlay 本地坐标 = 画布空间，画布→屏幕这一跳会把其中一切按 scale 放大一次。
2. 阅读器 / 漫画 / PDF / 视频页在**路由层**再套 `HibikiAppUiScaleNeutralizer`，把页面子树净缩放还原成 1.0（让 WebView / Texture 按原生密度渲染）→ 页面内部的坐标与 `MediaQuery.size` 都是**真实屏幕**空间。

菜单挂在根 Overlay，也就是**中和器之外**（`InheritedTheme.capture` 捕获不到中和器——它是 LayoutBuilder+FittedBox）。实测 scale=2 下「页面中和 / 不中和」菜单渲染逐像素相同。由此两条规则不可互抄：

| 位置 | 是否已跟随界面大小 | 代码该怎么写 |
|---|---|---|
| 中和器**内**（页面 chrome / 底栏） | 否（净缩放=1） | 必须手动 `× appUiScale` |
| 中和器**外**（菜单 / 根 Overlay 浮层） | **是**（画布自带） | 尺寸写常量；坐标须 `Overlay.globalToLocal` |

### 缺陷 A — 锚点：真实坐标当画布坐标（菜单跑位）

`manga_hibiki_page._showReaderContextMenu` 把 JS 报的 `clientX/clientY` 直接当 `RelativeRect` 喂给 `showMenu`，边界还用了中和层内的 `MediaQuery.size`（比 `overlay.size` 大 scale 倍）→ 菜单渲染在「点击点 × scale」：125% 时右键点 (800,600) 菜单跑到 (1000,750)，越靠右下偏得越远；50% 则缩向左上。日志面板 `_buildContextMenu` 的 `TextSelectionToolbarAnchors` 同型。

### 缺陷 B — 尺寸：菜单被乘了两次 scale（scale²）

`_readerImageMenuScale = normalize(_readerChromeScale)` 把 chrome 的缩放口径套到了菜单上（图片右键 / 文字选区右键 / 移动端选区操作条三处）。该 getter 自己的注释甚至写着「不在阅读器中和后的 chrome 子树内」——既然不在，就已经吃过一次缩放。**实测**：同样写 `fontSize: 14 * menuScale`，scale=2 时 chrome 渲染 40px、菜单 80px。

顺带修：选区操作条 `selectionBottom = selectionTop + r['height']` 把 Overlay 画布空间的 top 与 WebView 真实像素的 height 相加（混量纲），改为两角各过一次换算。

## 测试

新增 `hibiki/test/pages/context_menu_ui_scale_guard_test.dart`（9 条）：

- **不变式 A（真渲染 + 真右键手势）**：scale=0.5/1.0/2.0 下菜单矩形到点击点的间隙 < `24 × scale`（实测 4.0 / 8.1 / 16.1，恰为菜单自身 padding × scale）。度量用「点到矩形距离」而非 topLeft——点击点在屏幕右半边时 Flutter 会把菜单向左展开，那是正确行为。
- **不变式 B（真渲染）**：scale=2 的菜单文字高度恰为 scale=1 的 **2 倍**（线性，非平方）。
- **两条变异对照**（防恒真假绿）：不做换算时偏移 >200（实测 302）；手动乘 menuScale 时比值变成 **4 倍**。
- **三条源码守卫**已**变异实测**：三处分别改回旧写法后 5 个守卫用例全红，反向还原后复绿。
- 既有 `reader_image_actions_guard_static_test` / `reader_text_context_menu_scale_guard_test` 原本断言「必须乘 menuScale」，**方向是反的**，已随本次修复反转并注明原因。

验证：全量 `flutter analyze`（含 test）干净；定向测试 1921 条全绿（widgets 目录 459 / 阅读器域 1333 / 菜单与缩放 24 / 漫画与中和器 81）。

## 核过但**没问题**的地方

全仓其余 `showMenu` 站点逐个核过均已正确：视频 / 合集网格 / 合集详情 / 标签管理 / 插画查看器 / 关系图 / 词典弹窗 WebView。`VideoHibikiPage.neutralized` 的 `_videoUiScale` 用于**页内**顶底栏，在中和器内，是正确的，不要顺手删。

## 附带发现（未在本轮修，非右键问题）

`reader_pdf_page.dart` 的 Scaffold 带 AppBar，而 `buildDictionary()` 直接放在 body 的 Stack 里（坐标原点 = body 左上角），但 `_screenRectForChar` 报的是全局屏幕矩形 → **PDF 查词弹窗恒定偏下约 AppBar+状态栏高度，与界面缩放无关**。漫画页对这个契约有明文注释，EPUB 阅读器也是无 AppBar 全出血 Stack，只有 PDF 违约。建议另开一条跟进。

## 待验

真机复测（Windows 调界面大小后漫画/阅读器右键贴住鼠标、菜单字号与底栏一致）待用户。

https://claude.ai/code/session_0175LR6JQBJDobABxjY8q538
