### PR TITLE
fix(tool): renumber 自校验走独立遍历 + 文本判据改黑名单嗅探（BUG-1437 / TODO-2669）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1336 条。点号进各自文件。
+> 共 1337 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1437](bugs/BUG-1437-renumber-selfcheck-blind.md) | ✅ | ✅ | renumber 自校验与替换共用同一扫描器，漏改文件被谎报零残留 |
 | [BUG-1432](bugs/BUG-1432-ime-physical-key-ledger.md) | ✅ | ✅ | TODO-2652「三处快捷键台账仍记裸 logicalKey」经查证伪：`LogicalKeyboardKey.process` 在 5 个出包平台上根本不可达 |
 | [BUG-1430](bugs/BUG-1430-subtitle-obscure-switch-lag.md) | ✅ | ✅ | 切换字幕遮罩模式卡顿：两次事务落盘 + UI 等落盘 + 全局广播重建全 app |
 | [BUG-1429](bugs/BUG-1429-bug-tool-number-pool-misses-uncommitted-worktrees.md) | ✅ | ✅ | bug.dart 取号扫不到并发工作区未提交的 bug 文件，一天连撞六次 |

--- a/docs/bugs/BUG-1437-renumber-selfcheck-blind.md
+++ b/docs/bugs/BUG-1437-renumber-selfcheck-blind.md
@@ -1,0 +1,51 @@
+## BUG-1437 · renumber 自校验与替换共用同一扫描器，漏改文件被谎报零残留
+- **报告**：2026-08-02（用户：）
+- **真实性**：✅ 真 bug。两个根因，第二个才是要害。
+  **根因①（口径太窄）**：`tool/bug.dart:946-950`（改造前的 `looksTextual`）用**白名单**判文本
+  ——「有点号 **且** 扩展名在 `textExtensions` 里」。实测：
+  ```
+  looksTextual(.gitattributes) = false
+  looksTextual(third_party/m_extension_server/UPSTREAM) = false
+  looksTextual(LICENSE) = false
+  looksTextual(Makefile) = false
+  ```
+  文本文件的扩展名是开放集合，枚举不完；而没扩展名的纯文本（`UPSTREAM` / `LICENSE` /
+  `Makefile`）和前导点文件（`.gitattributes`）在本仓真实存在并真的承载 BUG 引用。
+  **根因②（守卫与被守对象同盲）**：`repoScanPaths()`（`:994`，过滤在 `:1014`）套这个判据，
+  而**替换**（`buildRenumberPlan:1216-1217`）与**自校验**（`findResidualRefs:1188-1189`）
+  **吃的是同一个 `repoScanPaths()`**——守卫和被守对象共用同一副瞎眼镜，扫描器漏掉的文件在
+  自校验里同样看不见，于是「零残留」是假的。实测一次改号 9 处引用只落了 7 处，漏掉
+  `.gitattributes` 与 `third_party/m_extension_server/UPSTREAM`，工具仍打印「自校验零残留」。
+  这比取号撞号危险：撞号人能发现，自校验骗人则没人会去复查。
+  **现场 A/B（真 git fixture，`renumber 9246 → 9250`）**：
+  ```
+  改前：[out] renumber 完成：…（2 处引用 / 1 个文件改名，自校验零残留）   ← 退出码 0
+        UPSTREAM       => 🔴 仍是 BUG-9246
+        .gitattributes => 🔴 仍是 BUG-9246
+        notes.bin      => 🔴 仍是 BUG-9246
+  改后：工具结论：报错 -> 改号后仍有 BUG-9246 残留，请人工处理：docs/notes.bin:1
+        UPSTREAM       => ✅ 已改   .gitattributes => ✅ 已改
+  ```
+  次要盲区一处：两侧读文件都用 `readAsStringSync()`，非 UTF-8 文本（GBK 等）抛
+  `FormatException` 后直接 `continue`——里面的 ASCII `BUG-NNN` 同样看不见。
+- **[x] ① 已修复** — `tool/bug.dart`：
+  ① `looksTextual` 判据由白名单改成**黑名单 + NUL 嗅探**（`binaryExtensions` 只是省一次
+  开文件的快路径，真正判据是读头 8KB 看有没有 NUL，`fileLooksBinary` / `bytesLookBinary`；
+  `excludedScanPrefixes` 挡住 `build/`、`.dart_tool/` 等生成物目录；前导点不再当扩展名分隔符）。
+  ② **自校验走独立遍历**：新增 `residualScanPaths()`，自己跑 `git ls-files`（tracked +
+  untracked）、**一个扩展名判据都不用**，二进制在 `findResidualRefs` 里按字节现场判；
+  撞号态下的自校验范围也从 `effectivePaths`（＝ `repoScanPaths ∩ scope`，会继承扫描器盲区）
+  改成直接取 `git diff` 出来的 `scope.paths`。这样 `looksTextual` 再退化一次，自校验仍看得见残留。
+  ③ 残留扫描改用 `utf8.decode(..., allowMalformed: true)`，GBK 等非 UTF-8 文本里的 ASCII
+  引用也算残留。
+- **[x] ② 已加自动化测试** — `hibiki/test/tools/bug_tool_renumber_scope_test.dart`
+  新增 group「BUG-1437：扫描口径 + 自校验独立遍历」共 6 个用例：无扩展名/前导点文件的引用
+  必须被真正改到；**替换扫描器漏掉一类文件时自校验必须报红、不许打印「零残留」**；非撞号态
+  全量口径同样看得见；`findResidualRefs` 的枚举不复用 `repoScanPaths`（直接盯独立性）；
+  真二进制既不被改也不被误报；非 UTF-8 文本里的 ASCII 引用算残留。
+  **反向变异实测**：把撞号态自校验范围改回 `effectivePaths` → 用例 2 转红；把
+  `findResidualRefs` 默认改回 `repoScanPaths()` → 用例 3、4 转红（均为断言失败，非编译失败）。
+- **备注**：性能实测（本仓 11880 个 tracked 文件 / 394MB）：`repoScanPaths` 8370→9706 个文件、
+  1477ms→3077ms；全量 `findResidualRefs` 3461ms→1922ms；真仓库 `renumber --dry-run`
+  端到端 8.3s→7.9s（噪声内，耗时由 1857 个 ref 的跨分支扫描主导，不由文件扫描主导）。
+  没碰 `new` / `check` 的取号逻辑（PR#730 刚改完那块），也没碰 `reindex`。

--- a/hibiki/test/tools/bug_tool_renumber_scope_test.dart
+++ b/hibiki/test/tools/bug_tool_renumber_scope_test.dart
@@ -39,6 +39,12 @@ void writeFile(Directory root, String rel, String content) {
   f.writeAsStringSync(content);
 }
 
+void writeBytes(Directory root, String rel, List<int> bytes) {
+  final f = File('${root.path}/$rel');
+  f.parent.createSync(recursive: true);
+  f.writeAsBytesSync(bytes);
+}
+
 String readFile(Directory root, String rel) => File('${root.path}/$rel').readAsStringSync();
 
 bool exists(Directory root, String rel) => File('${root.path}/$rel').existsSync();
@@ -99,6 +105,7 @@ Directory makeCollisionFixture(
   String baseBranch = 'develop',
   bool commitPrSide = true,
   bool touchBaseBugFile = false,
+  Map<String, String> extraPrFiles = const <String, String>{},
 }) {
   final root = Directory.systemTemp.createTempSync('bug_collide_');
   temps.add(root);
@@ -117,6 +124,7 @@ Directory makeCollisionFixture(
   writeFile(root, 'hibiki/lib/src/reader/restore.dart', prLib);
   writeFile(root, 'hibiki/test/reader/reader_restore_bug_9246_test.dart', prTest);
   writeFile(root, 'hibiki/lib/src/reader/notes.dart', lookalikeCorpus);
+  extraPrFiles.forEach((String rel, String content) => writeFile(root, rel, content));
   if (touchBaseBugFile) {
     writeFile(
         root, 'docs/bugs/BUG-9246-helper-version-drift.md', '$baseBugDoc- **备注**：本 PR 顺手补的一行。\n');
@@ -392,6 +400,134 @@ void main() {
       expect(fp['a.dart'], '2:0');
       expect(fp['bug_9246_test.dart'], '0:1');
       expect(fp.containsKey('clean.dart'), isFalse);
+    });
+  });
+
+  // —— BUG-1437：替换与自校验共用同一副「瞎眼镜」。
+  //    旧 `looksTextual` 要求「有点号 + 扩展名在白名单里」，实测 `.gitattributes` /
+  //    `third_party/m_extension_server/UPSTREAM` / `LICENSE` / `Makefile` 全判成非文本；
+  //    而 `findResidualRefs` 与 `buildRenumberPlan` 吃的是同一个 `repoScanPaths()`，
+  //    于是漏改的文件在自校验里同样看不见——实测 9 处引用只落了 7 处，工具仍打印
+  //    「自校验零残留」。取号撞了人能发现，自校验骗人没人会去复查。
+  group('BUG-1437：扫描口径 + 自校验独立遍历', () {
+    const Map<String, String> oddNameFiles = <String, String>{
+      'third_party/m_extension_server/UPSTREAM': '上游基线。修复记录见 BUG-9246。\n',
+      '.gitattributes': '# 由 BUG-9246 引入的 CRLF 规则\n*.dart text\n',
+      'LICENSE': 'MIT License\n\n历史豁免见 BUG-9246。\n',
+      'Makefile': 'all:\n\t@echo BUG-9246\n',
+    };
+
+    test('无扩展名 / 前导点文件里的引用会被真正改到（白名单判据看不见它们）', () async {
+      final root = makeCollisionFixture(temps, extraPrFiles: oddNameFiles);
+
+      // 前提成立：这四类路径在旧判据下全是「非文本」，现在必须判成文本。
+      for (final rel in oddNameFiles.keys) {
+        expect(bug.looksTextual(rel), isTrue, reason: '$rel 又被判成非文本了');
+      }
+
+      await bug.cmdRenumber(<String>['9246', '9250'], scanner: stubScanner(<int>{9246}));
+
+      for (final rel in oddNameFiles.keys) {
+        expect(readFile(root, rel), contains('BUG-9250'), reason: '$rel 里的引用没改到');
+        expect(readFile(root, rel), isNot(contains('BUG-9246')), reason: '$rel 里还留着旧号');
+      }
+    });
+
+    test('替换扫描器漏掉一类文件时，自校验必须报红——不许打印「零残留」', () async {
+      // 模拟「扩展名判据又退化了一次」：引用落在一个扩展名进了二进制黑名单、
+      // 内容其实是纯文本的文件里。替换侧按黑名单跳过它；自校验走独立遍历 +
+      // 字节嗅探，必须照样看得见。守卫与被守对象共用扫描器时这里是假绿。
+      makeCollisionFixture(temps, extraPrFiles: <String, String>{
+        'docs/notes.bin': '这一行引用 BUG-9246，替换侧看不见它。\n',
+      });
+      expect(bug.looksTextual('docs/notes.bin'), isFalse, reason: '前提：替换侧确实跳过它');
+
+      await expectLater(
+        bug.cmdRenumber(<String>['9246', '9250'], scanner: stubScanner(<int>{9246})),
+        throwsA(isA<bug.BugToolError>()
+            .having((bug.BugToolError e) => e.message, 'message', contains('残留'))
+            .having((bug.BugToolError e) => e.message, 'message', contains('docs/notes.bin'))),
+      );
+      expect(out.join('\n'), isNot(contains('自校验零残留')));
+    });
+
+    test('非撞号态（全量口径）同样看得见漏改', () async {
+      final root = Directory.systemTemp.createTempSync('bug_residual_full_');
+      temps.add(root);
+      git(root, <String>['init', '-q', '-b', 'develop', '.']);
+      git(root, <String>['config', 'user.email', 'fixture@example.com']);
+      git(root, <String>['config', 'user.name', 'fixture']);
+      git(root, <String>['config', 'commit.gpgsign', 'false']);
+      writeFile(root, 'docs/BUGS.md', indexShell);
+      writeFile(root, 'docs/bugs/BUG-9246-reader-restore.md', prBugDoc);
+      writeFile(root, 'docs/notes.bin', '漏网的引用 BUG-9246。\n');
+      git(root, <String>['add', '-A']);
+      git(root, <String>['commit', '-qm', 'single BUG-9246']);
+      Directory.current = root;
+
+      // 前提：这是非撞号态（只有一份同号文件），自校验走全量 residualScanPaths()。
+      expect(bug.locateBugFiles(9246), hasLength(1));
+
+      await expectLater(
+        bug.cmdRenumber(<String>['9246', '9250'], scanner: stubScanner(<int>{9246})),
+        throwsA(isA<bug.BugToolError>()
+            .having((bug.BugToolError e) => e.message, 'message', contains('残留'))),
+      );
+    });
+
+    test('findResidualRefs 的枚举不复用 repoScanPaths（这一条直接盯独立性）', () async {
+      final root = Directory.systemTemp.createTempSync('bug_residual_indep_');
+      temps.add(root);
+      git(root, <String>['init', '-q', '-b', 'develop', '.']);
+      git(root, <String>['config', 'user.email', 'fixture@example.com']);
+      git(root, <String>['config', 'user.name', 'fixture']);
+      git(root, <String>['config', 'commit.gpgsign', 'false']);
+      writeFile(root, 'docs/notes.bin', '引用 BUG-9246 在这里。\n');
+      writeFile(root, 'UPSTREAM', '引用 BUG-9246 也在这里。\n');
+      git(root, <String>['add', '-A']);
+      git(root, <String>['commit', '-qm', 'seed']);
+      Directory.current = root;
+
+      final scan = await bug.repoScanPaths();
+      expect(scan, isNot(contains('docs/notes.bin')), reason: '前提：替换侧按黑名单跳过 .bin');
+      final residual = await bug.findResidualRefs(9246);
+      expect(residual, contains('docs/notes.bin:1'), reason: '自校验复用了 repoScanPaths 就会在这里瞎掉');
+      expect(residual, contains('UPSTREAM:1'));
+    });
+
+    test('真二进制文件既不被改、也不被误报成残留', () async {
+      final root = Directory.systemTemp.createTempSync('bug_residual_bin_');
+      temps.add(root);
+      git(root, <String>['init', '-q', '-b', 'develop', '.']);
+      git(root, <String>['config', 'user.email', 'fixture@example.com']);
+      git(root, <String>['config', 'user.name', 'fixture']);
+      git(root, <String>['config', 'commit.gpgsign', 'false']);
+      // 头部就有 NUL：即使字节里出现 `BUG-9246`，也不是引用载体。
+      writeBytes(root, 'assets/blob', <int>[0x89, 0x50, 0x00, 0x01, ...'BUG-9246'.codeUnits]);
+      git(root, <String>['add', '-A']);
+      git(root, <String>['commit', '-qm', 'binary blob']);
+      Directory.current = root;
+
+      expect(bug.looksTextual('assets/blob'), isFalse);
+      expect(await bug.findResidualRefs(9246), isEmpty);
+    });
+
+    test('非 UTF-8 文本（GBK 等）里的 ASCII 引用也算残留', () async {
+      final root = Directory.systemTemp.createTempSync('bug_residual_gbk_');
+      temps.add(root);
+      git(root, <String>['init', '-q', '-b', 'develop', '.']);
+      git(root, <String>['config', 'user.email', 'fixture@example.com']);
+      git(root, <String>['config', 'user.name', 'fixture']);
+      git(root, <String>['config', 'commit.gpgsign', 'false']);
+      // GBK 的「中文」+ ASCII 引用；readAsStringSync 会抛 FormatException，
+      // 旧实现在那里直接 continue，等于对这类文件也瞎。
+      writeBytes(
+          root, 'legacy.txt', <int>[0xD6, 0xD0, 0xCE, 0xC4, 0x20, ...'BUG-9246'.codeUnits, 0x0A]);
+      git(root, <String>['add', '-A']);
+      git(root, <String>['commit', '-qm', 'gbk']);
+      Directory.current = root;
+
+      expect(await bug.findResidualRefs(9246), contains('legacy.txt:1'));
     });
   });
 }

--- a/tool/bug.dart
+++ b/tool/bug.dart
@@ -897,56 +897,103 @@ String? renameNumberInPath(String path, int oldNumber, int newNumber) {
   return dir + base.replaceAllMapped(re, (Match m) => '${m[1]}${m[2]}$pad');
 }
 
-/// 认得出的纯文本扩展名（二进制不读、不改）。
-const Set<String> textExtensions = <String>{
-  '.dart',
-  '.md',
-  '.yaml',
-  '.yml',
-  '.json',
-  '.txt',
-  '.ps1',
-  '.sh',
-  '.bat',
-  '.cmd',
-  '.js',
-  '.mjs',
-  '.ts',
-  '.html',
-  '.css',
-  '.kt',
-  '.kts',
-  '.java',
-  '.cpp',
-  '.cc',
-  '.h',
-  '.hpp',
-  '.mm',
-  '.m',
-  '.swift',
-  '.gradle',
-  '.xml',
-  '.py',
-  '.rb',
-  '.go',
-  '.rs',
-  '.toml',
-  '.ini',
-  '.cfg',
-  '.properties',
-  '.podspec',
-  '.plist',
-  '.pro',
-  '.patch',
-  '.diff',
-  '.sql',
-  '.csv',
+/// 明确排除的二进制/容器扩展名（**黑名单**，只是省一次开文件的快路径；
+/// 真正的判据是下面的 NUL 嗅探）。
+///
+/// 🔴 判据必须是黑名单，不能是白名单。旧实现要求「有点号 + 扩展名在白名单里」，
+/// 实测把 `.gitattributes` / `third_party/m_extension_server/UPSTREAM` / `LICENSE` /
+/// `Makefile` 这类**没有扩展名或扩展名冷门的纯文本**全判成非文本；它们既不会被
+/// renumber 替换，也不会被自校验看见——一次改号 9 处引用只落了 7 处，工具仍报
+/// 「零残留」（TODO-2669）。文本文件的扩展名是开放集合，枚举不完；二进制格式是
+/// 有限集合，而且漏了一个还有 NUL 嗅探兜底。
+const Set<String> binaryExtensions = <String>{
+  // 图片
+  '.png', '.jpg', '.jpeg', '.gif', '.bmp', '.ico', '.icns', '.webp', '.avif',
+  '.tif', '.tiff', '.psd', '.heic',
+  // 字体
+  '.ttf', '.otf', '.ttc', '.woff', '.woff2', '.eot',
+  // 音视频
+  '.mp3', '.wav', '.flac', '.ogg', '.opus', '.m4a', '.aac', '.mp4', '.m4v',
+  '.mkv', '.mov', '.avi', '.webm', '.wmv', '.flv',
+  // 归档 / 压缩
+  '.zip', '.7z', '.rar', '.tar', '.gz', '.tgz', '.bz2', '.xz', '.zst', '.lz4',
+  '.jar', '.aar', '.apk', '.aab', '.ipa', '.war', '.nupkg',
+  // 可执行 / 库 / 编译中间产物
+  '.exe', '.dll', '.so', '.dylib', '.lib', '.a', '.o', '.obj', '.pdb',
+  '.class', '.dex', '.wasm', '.bin', '.pyc', '.pyd',
+  // 文档 / 数据库 / 密钥容器
+  '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx',
+  '.db', '.sqlite', '.sqlite3', '.jks', '.keystore', '.p12', '.pfx', '.der',
+  // 模型 / 词典二进制
+  '.onnx', '.tflite', '.pt', '.pth', '.safetensors', '.mdx', '.mdd',
 };
 
+/// 无论从哪条枚举路径来的都不扫的目录（生成物 / 缓存 / VCS 内部 / 测试证据）。
+/// `git ls-files` 本来就不吐这些，但兜底遍历 [walkFallback] 与 [extraScanPaths] 会。
+const List<String> excludedScanPrefixes = <String>[
+  '.git/',
+  '.dart_tool/',
+  'build/',
+  'node_modules/',
+  '.gradle/',
+  '.idea/',
+  'Pods/',
+  '.worktrees/',
+  '.claude/',
+  '.codex-test/',
+];
+
+/// 头部多少字节内出现 NUL 就判二进制（git 自己也是这个套路）。
+const int binarySniffBytes = 8192;
+
+/// 纯字节判据：这段头部像不像二进制。不碰路径、不碰扩展名。
+///
+/// 替换侧与自校验侧共用**这一个低层原语**是有意的——「什么算二进制」只该有一个定义。
+/// 二者的独立性在于各自的**枚举与过滤**，见 [residualScanPaths]。
+bool bytesLookBinary(List<int> head) => head.contains(0);
+
+/// 读文件头做 NUL 嗅探。读不出来一律当二进制（扫不了的东西别硬扫）。
+/// 只读前 [binarySniffBytes] 字节——仓里最大的几个无扩展名文件是 18MB 的
+/// `libavcodec`，整读会把 renumber 拖垮。
+bool fileLooksBinary(String path) {
+  RandomAccessFile? raf;
+  try {
+    raf = File(path).openSync();
+    final int len = raf.lengthSync();
+    if (len <= 0) return false; // 空文件当文本，无害
+    final int n = len < binarySniffBytes ? len : binarySniffBytes;
+    return bytesLookBinary(raf.readSync(n));
+  } on FileSystemException {
+    return true;
+  } finally {
+    try {
+      raf?.closeSync();
+    } on FileSystemException {
+      // 关不上不影响判据。
+    }
+  }
+}
+
+/// 路径层面就能否掉的（不碰磁盘）：排除目录 + 二进制扩展名黑名单。
+///
+/// 「扩展名」只认最后一个点**在文件名中间**的那种：`.gitattributes` / `.gitignore`
+/// 的前导点不是扩展名分隔符，旧实现把它当扩展名正是漏扫的原因之一。
+bool isExcludedScanPath(String path) {
+  final String p = normalizeRelPath(path);
+  for (final prefix in excludedScanPrefixes) {
+    if (p.startsWith(prefix) || p == prefix.substring(0, prefix.length - 1)) return true;
+  }
+  final int slash = p.lastIndexOf('/');
+  final int dot = p.lastIndexOf('.');
+  if (dot > slash + 1 && binaryExtensions.contains(p.substring(dot).toLowerCase())) return true;
+  return false;
+}
+
+/// 这个文件值不值得按文本扫描：先路径/扩展名黑名单毙掉（不碰磁盘），
+/// 剩下的读头 [binarySniffBytes] 字节做 NUL 嗅探。
 bool looksTextual(String path) {
-  final dot = path.lastIndexOf('.');
-  if (dot < 0) return false;
-  return textExtensions.contains(path.substring(dot).toLowerCase());
+  if (isExcludedScanPath(path)) return false;
+  return !fileLooksBinary(path);
 }
 
 /// 取路径的文件名部分。
@@ -1011,7 +1058,46 @@ Future<List<String>> repoScanPaths() async {
   for (final extra in extraScanPaths) {
     if (File(extra).existsSync()) paths.add(extra);
   }
-  final list = paths.where(looksTextual).where((String p) => File(p).existsSync()).toList()..sort();
+  // 先 exists 再 looksTextual：后者要开文件做 NUL 嗅探，路径不存在时白扔一个异常。
+  final list = paths.where((String p) => File(p).existsSync()).where(looksTextual).toList()..sort();
+  return list;
+}
+
+/// 自校验专用的**独立**文件枚举。
+///
+/// 🔴 刻意不复用 [repoScanPaths] / [looksTextual]：守卫和被守对象共用同一个扫描器时，
+/// 扫描器漏掉的文件在守卫里同样看不见，「自校验零残留」就是假的。TODO-2669 实测：
+/// 一次改号 9 处引用只落了 7 处，漏掉 `.gitattributes` 与
+/// `third_party/m_extension_server/UPSTREAM`，而 renumber 仍打印「自校验零残留」。
+///
+/// 这里只做两件事：把工作区文件全列出来、逐个确认真实存在。**一个扩展名判据都不用**
+/// ——扩展名/黑名单再退化一次，这条路照样看得见残留。二进制在
+/// [findResidualRefs] 里按字节现场判。
+Future<List<String>> residualScanPaths() async {
+  final paths = <String>{};
+  final tracked = await runGit(<String>['ls-files', '-z'], timeout: const Duration(seconds: 60));
+  final others = await runGit(<String>[
+    'ls-files',
+    '-z',
+    '--others',
+    '--exclude-standard',
+  ], timeout: const Duration(seconds: 60));
+  if (tracked != null && tracked.exitCode == 0) {
+    for (final r in <ProcessResult?>[tracked, others]) {
+      if (r == null || r.exitCode != 0) continue;
+      paths.addAll(splitGitZ(r.stdout as String));
+    }
+  } else {
+    paths.addAll(walkFallback().map(normalizeRelPath));
+  }
+  for (final extra in extraScanPaths) {
+    if (File(extra).existsSync()) paths.add(normalizeRelPath(extra));
+  }
+  final list = paths
+      .where((String p) => !p.startsWith('.git/'))
+      .where((String p) => File(p).existsSync())
+      .toList()
+    ..sort();
   return list;
 }
 
@@ -1183,22 +1269,29 @@ Map<String, String> bugRefFingerprint(int number, Iterable<String> paths) {
 }
 
 /// 扫出所有仍在引用 `number` 的位置（`path:line` 或 `path（文件名）`）。
-/// renumber 的自校验用这个，口径与替换完全一致（同一个 [bugRefPattern]）。
+/// renumber 的自校验用这个，命中判据与替换一致（同一个 [bugRefPattern]），
+/// 但**文件枚举刻意各走各的**：不传 [paths] 时走 [residualScanPaths]，不是
+/// [repoScanPaths]。守卫和被守对象共用扫描器 = 守卫永远和 bug 同盲（TODO-2669）。
 /// 只看工作区文件——git 历史里的旧号是历史，不算残留。
 Future<List<String>> findResidualRefs(int number, {List<String>? paths}) async {
-  final files = paths ?? await repoScanPaths();
+  final files = paths ?? await residualScanPaths();
   final re = bugRefPattern(number);
   final hits = <String>[];
   for (final p in files) {
     final f = File(p);
     if (!f.existsSync()) continue;
+    // 自校验自己判二进制（按字节，不看扩展名）：扩展名判据再退化，这里仍看得见。
+    if (fileLooksBinary(p)) {
+      if (re.hasMatch(baseName(p))) hits.add('$p（文件名）');
+      continue;
+    }
     String content;
     try {
-      content = f.readAsStringSync();
+      // 宽松解码：GBK 等非 UTF-8 文本里的 `BUG-NNN` 是纯 ASCII，照样得算残留。
+      // 旧实现在 FormatException 上直接 `continue`，等于对这类文件也瞎。
+      content = utf8.decode(f.readAsBytesSync(), allowMalformed: true);
     } on FileSystemException {
       continue;
-    } on FormatException {
-      continue; // 非 UTF-8 文本（GBK 等），不可能是我们要改的 BUG 引用载体，跳过
     }
     if (re.hasMatch(content)) {
       final lines = content.split('\n');
@@ -1515,12 +1608,18 @@ Future<void> cmdRenumber(List<String> args, {BranchScanner? scanner}) async {
   //    BUG-<old>，那是合法的，不算残留。
   //    范围里的路径要按改名结果映射一次，否则改完名的文件会因「旧路径已不存在」被跳过、
   //    残留检查形同虚设。
+  //    🔴 范围**必须独立于 repoScanPaths 算**：effectivePaths ＝ repoScanPaths ∩ scope，
+  //    拿它当自校验范围就把扫描器的盲区一并继承过来，守卫又和 bug 同盲。这里直接取
+  //    git diff 出来的 scope.paths，只剔掉索引与别人那条 bug 文件。
   final Map<String, String> renameMap = <String, String>{
-    for (final r in plan.renames) r.from: r.to,
+    for (final r in plan.renames) normalizeRelPath(r.from): r.to,
   };
+  String afterRename(String p) => renameMap[normalizeRelPath(p)] ?? p;
   final residual = await findResidualRefs(
     oldNumber,
-    paths: collided ? effectivePaths.map((String p) => renameMap[p] ?? p).toList() : null,
+    paths: collided
+        ? scope.paths.where((String p) => !isIndex(p) && !isForeign(p)).map(afterRename).toList()
+        : null,
   );
   if (residual.isNotEmpty) {
     throw BugToolError(


### PR DESCRIPTION
## 问题（BUG-1437）

`tool/bug.dart renumber` 的**自校验会骗人**。这比取号盲区危险：取号撞了人能发现；自校验骗人意味着使用者按它的话判定「改号完成」，实际留着旧号，没人会去复查。

两个根因（行号按 `origin/develop@7994789fa`）：

1. **口径太窄** — `tool/bug.dart:946-950` 的 `looksTextual` 用**白名单**：「有点号 **且** 扩展名在 `textExtensions` 里」。实测 `looksTextual('.gitattributes') = false`、`looksTextual('third_party/m_extension_server/UPSTREAM') = false`、`LICENSE = false`、`Makefile = false`。文本扩展名是开放集合，枚举不完。
2. 🔴 **守卫与被守对象同盲**（要害）— `repoScanPaths()`（`:994`，过滤在 `:1014`）套这个判据，而**替换**（`buildRenumberPlan:1216-1217`）与**自校验**（`findResidualRefs:1188-1189`）**吃同一个 `repoScanPaths()`**。扫描器漏掉的文件在自校验里同样看不见 ⇒ 「零残留」是假的。实测一次改号 9 处引用只落了 7 处，工具仍报「自校验零残留」。

## 改前 / 改后对照（真 git fixture，`renumber 9246 → 9250`）

改前（`origin/develop` 的 `tool/bug.dart`）：

```
[out] renumber 完成：BUG-9246 → BUG-9250（2 处引用 / 1 个文件改名，自校验零残留）
工具结论：成功退出（没有抛错）
--- 落盘实况 ---
  third_party/m_extension_server/UPSTREAM  =>  🔴 仍是 BUG-9246
  .gitattributes                           =>  🔴 仍是 BUG-9246
  docs/notes.bin                           =>  🔴 仍是 BUG-9246
  lib/restore.dart                         =>  ✅ 已改
```

改后：

```
工具结论：报错 -> 改号后仍有 BUG-9246 残留，请人工处理：
  docs/notes.bin:1
--- 落盘实况 ---
  third_party/m_extension_server/UPSTREAM  =>  ✅ 已改
  .gitattributes                           =>  ✅ 已改
  docs/notes.bin                           =>  🔴 仍是 BUG-9246   ← 被守卫抓住了
  lib/restore.dart                         =>  ✅ 已改
```

（`docs/notes.bin` 是刻意模拟「扫描器又漏了一类文件」：扩展名进了二进制黑名单、内容其实是文本。替换侧跳过它，自校验独立遍历必须看得见。）

## 改法

- `looksTextual` 判据由白名单改**黑名单 + NUL 嗅探**：`binaryExtensions`（图片/字体/音视频/归档/可执行/文档容器/模型）只是省一次开文件的快路径，真正判据是读头 8KB 找 NUL（`fileLooksBinary` / `bytesLookBinary`）；`excludedScanPrefixes` 挡 `build/`、`.dart_tool/`、`node_modules/` 等生成物目录；前导点不再当扩展名分隔符（`.gitattributes` 不是 `.gitattributes` 扩展名）。
- 🔴 **自校验走独立遍历**：新增 `residualScanPaths()`，自己跑 `git ls-files`（tracked + untracked），**一个扩展名判据都不用**；二进制在 `findResidualRefs` 里按字节现场判。撞号态下的自校验范围也从 `effectivePaths`（＝ `repoScanPaths ∩ scope`，会继承扫描器盲区）改成直接取 `git diff` 的 `scope.paths`。
- 残留扫描改 `utf8.decode(..., allowMalformed: true)`：GBK 等非 UTF-8 文本里的 ASCII `BUG-NNN` 也算残留（旧实现在 `FormatException` 上直接 `continue`）。

## 反向变异实测

| 变异 | 结果 |
|---|---|
| 撞号态自校验范围改回 `effectivePaths` | 工具回到「自校验零残留」假绿；用例「替换扫描器漏掉一类文件时自校验必须报红」转红（断言失败，非编译失败） |
| `findResidualRefs` 默认改回 `repoScanPaths()` | 用例「非撞号态全量口径同样看得见」「`findResidualRefs` 的枚举不复用 `repoScanPaths`」转红（断言失败） |

两次变异均用反向文本替换还原，还原后 `tool/bug.dart` 与变异前 SHA-256 逐字节一致。

## 性能（本仓 11880 个 tracked 文件 / 394MB）

| 指标 | 改前 | 改后 |
|---|---|---|
| `repoScanPaths` 收到的文件数 | 8370 | 9706 |
| `repoScanPaths` 耗时 | 1477ms | 3077ms |
| 全量 `findResidualRefs` | 3461ms | 1922ms |
| 真仓库 `renumber --dry-run` 端到端 | 8.3s | 7.9s（噪声内） |

端到端由 1861 个 ref 的跨分支扫描主导，不由文件扫描主导。最大的几个无扩展名文件是 18MB 的 `libavcodec`，靠 8KB NUL 嗅探早退，不会整读。

## 测试

`hibiki/test/tools/bug_tool_renumber_scope_test.dart` 新增 group「BUG-1437：扫描口径 + 自校验独立遍历」共 6 个用例。

## 影响面

只动 `renumber` 的文件遍历与自校验。**没碰** `new` / `check` 的取号逻辑（PR#730 刚改完那块），**没碰** `reindex`。`looksTextual` / `repoScanPaths` 口径变宽会让 `renumber` 的替换范围与「范围外一字未变」指纹守卫一起变宽 —— 两者是同向的，替换到哪儿守卫就盯到哪儿。

## 门禁

- `flutter analyze`（全量含 test）：`No issues found! (ran in 45.0s)`
- `dart run tool/flutter_test_failures.dart --no-pub test/tools`：`FLUTTER TEST VERDICT: PASSED - 216 tests ran, all tests passed`（含两条 bug.dart 元守卫 + `bugs_per_file_guard_test`）
- 真仓库 `dart run tool/bug.dart check --strict`：退出码 0，`check 通过：1337 条，号唯一，索引同步` / `这些号都没有被别的文件名占用`

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
