### PR TITLE
feat(manga): 漫画扩展安装前预览 + 来源/浏览页头去重复标题

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52343 (3079 per locale)
+/// Strings: 52445 (3085 per locale)
 ///
-/// Built on 2026-08-02 at 03:29 UTC
+/// Built on 2026-08-02 at 05:57 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4138,6 +4138,15 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'This manga was imported from images, so there is no original book to convert back to.';
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  String get mihon_extension_preview => 'Preview';
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  String get mihon_extension_preview_discard => 'Discard';
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  String get mihon_extension_sources_included => 'Included sources';
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -11204,6 +11213,21 @@ class _StringsAr extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -18337,6 +18361,21 @@ class _StringsDe extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -25485,6 +25524,21 @@ class _StringsEs extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -32645,6 +32699,21 @@ class _StringsFr extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -39734,6 +39803,21 @@ class _StringsId extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -46869,6 +46953,21 @@ class _StringsIt extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -53821,6 +53920,21 @@ class _StringsJa extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -60775,6 +60889,21 @@ class _StringsKo extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -67890,6 +68019,21 @@ class _StringsNl extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -75018,6 +75162,21 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -82130,6 +82289,21 @@ class _StringsRu extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -89190,6 +89364,21 @@ class _StringsTh extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -96282,6 +96471,21 @@ class _StringsTr extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -103359,6 +103563,21 @@ class _StringsVi extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 // Path: <root>
@@ -109944,6 +110163,19 @@ class _StringsZhCn extends _StringsEn {
   String get book_convert_blocked_no_original => '这本漫画是从图片导入的，没有可还原的原书。';
   @override
   String get book_convert_blocked_source_missing => '源文件已从磁盘上消失。';
+  @override
+  String get mihon_extension_preview => '预览';
+  @override
+  String get mihon_extension_preview_warning =>
+      '预览会在安装前运行该扩展的代码。在你选择安装之前，不会有任何东西写进你的库。';
+  @override
+  String get mihon_extension_preview_discard => '放弃';
+  @override
+  String get mihon_extension_preview_source_select => '选择要预览的源';
+  @override
+  String get mihon_extension_sources_included => '包含的源';
+  @override
+  String get mihon_extension_preview_read_only => '预览是只读的。安装扩展后才能打开阅读。';
 }
 
 // Path: <root>
@@ -116817,6 +117049,21 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get mihon_extension_preview => 'Preview';
+  @override
+  String get mihon_extension_preview_warning =>
+      'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+  @override
+  String get mihon_extension_preview_discard => 'Discard';
+  @override
+  String get mihon_extension_preview_source_select =>
+      'Pick a source to preview';
+  @override
+  String get mihon_extension_sources_included => 'Included sources';
+  @override
+  String get mihon_extension_preview_read_only =>
+      'Preview is read-only. Install the extension to open and read.';
 }
 
 /// Flat map(s) containing all translations.
@@ -123134,6 +123381,18 @@ extension on _StringsEn {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -129449,6 +129708,18 @@ extension on _StringsAr {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -135786,6 +136057,18 @@ extension on _StringsDe {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -142122,6 +142405,18 @@ extension on _StringsEs {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -148464,6 +148759,18 @@ extension on _StringsFr {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -154788,6 +155095,18 @@ extension on _StringsId {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -161126,6 +161445,18 @@ extension on _StringsIt {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -167426,6 +167757,18 @@ extension on _StringsJa {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -173730,6 +174073,18 @@ extension on _StringsKo {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -180062,6 +180417,18 @@ extension on _StringsNl {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -186391,6 +186758,18 @@ extension on _StringsPtBr {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -192725,6 +193104,18 @@ extension on _StringsRu {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -199042,6 +199433,18 @@ extension on _StringsTh {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -205368,6 +205771,18 @@ extension on _StringsTr {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -211690,6 +212105,18 @@ extension on _StringsVi {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }
@@ -217958,6 +218385,18 @@ extension on _StringsZhCn {
         return '这本漫画是从图片导入的，没有可还原的原书。';
       case 'book_convert_blocked_source_missing':
         return '源文件已从磁盘上消失。';
+      case 'mihon_extension_preview':
+        return '预览';
+      case 'mihon_extension_preview_warning':
+        return '预览会在安装前运行该扩展的代码。在你选择安装之前，不会有任何东西写进你的库。';
+      case 'mihon_extension_preview_discard':
+        return '放弃';
+      case 'mihon_extension_preview_source_select':
+        return '选择要预览的源';
+      case 'mihon_extension_sources_included':
+        return '包含的源';
+      case 'mihon_extension_preview_read_only':
+        return '预览是只读的。安装扩展后才能打开阅读。';
       default:
         return null;
     }
@@ -224253,6 +224692,18 @@ extension on _StringsZhHk {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'mihon_extension_preview':
+        return 'Preview';
+      case 'mihon_extension_preview_warning':
+        return 'Previewing runs this extension\'s code before it is installed. Nothing is added to your library until you choose to install.';
+      case 'mihon_extension_preview_discard':
+        return 'Discard';
+      case 'mihon_extension_preview_source_select':
+        return 'Pick a source to preview';
+      case 'mihon_extension_sources_included':
+        return 'Included sources';
+      case 'mihon_extension_preview_read_only':
+        return 'Preview is read-only. Install the extension to open and read.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "这本书已经是该格式了。",
   "book_convert_blocked_text_only": "这是一本没有页图的文字书。只有扫描版图片书才能转成漫画。",
   "book_convert_blocked_no_original": "这本漫画是从图片导入的，没有可还原的原书。",
-  "book_convert_blocked_source_missing": "源文件已从磁盘上消失。"
+  "book_convert_blocked_source_missing": "源文件已从磁盘上消失。",
+  "mihon_extension_preview": "预览",
+  "mihon_extension_preview_warning": "预览会在安装前运行该扩展的代码。在你选择安装之前，不会有任何东西写进你的库。",
+  "mihon_extension_preview_discard": "放弃",
+  "mihon_extension_preview_source_select": "选择要预览的源",
+  "mihon_extension_sources_included": "包含的源",
+  "mihon_extension_preview_read_only": "预览是只读的。安装扩展后才能打开阅读。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3077,5 +3077,11 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "mihon_extension_preview": "Preview",
+  "mihon_extension_preview_warning": "Previewing runs this extension's code before it is installed. Nothing is added to your library until you choose to install.",
+  "mihon_extension_preview_discard": "Discard",
+  "mihon_extension_preview_source_select": "Pick a source to preview",
+  "mihon_extension_sources_included": "Included sources",
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
 }

--- a/hibiki/lib/src/media/manga/manga_browse_page.dart
+++ b/hibiki/lib/src/media/manga/manga_browse_page.dart
@@ -99,6 +99,17 @@ class _MangaBrowsePageState extends ConsumerState<MangaBrowsePage> {
         .toList(growable: false);
   }
 
+  /// 页头。与 `MediaSourcesPage` / `MangaSourcesPage` 同一范式：库页视图导航条
+  /// 存在时它就是页头主位，**不再另渲染一个页面大标题**——导航条自己已经标明了当前
+  /// 在哪个视图。仅在没有导航条（独立 push 进来）时才回退到文字标题。
+  Widget _buildHeader() {
+    final Widget? navigation = widget.navigation;
+    if (navigation != null) {
+      return HibikiPageHeader.customTitle(title: navigation);
+    }
+    return HibikiPageHeader(title: t.library_view_browse);
+  }
+
   @override
   Widget build(BuildContext context) {
     final List<MangaOnlineSourceRow> sources = _enabledSources();
@@ -106,11 +117,7 @@ class _MangaBrowsePageState extends ConsumerState<MangaBrowsePage> {
       kind: DesktopContentKind.readerShelf,
       child: Column(
         children: <Widget>[
-          if (!isCupertinoPlatform(context))
-            HibikiPageHeader(
-              title: t.library_view_browse,
-              bottom: widget.navigation,
-            ),
+          if (!isCupertinoPlatform(context)) _buildHeader(),
           Expanded(
             child: ListView(
               padding: const EdgeInsets.all(16),

--- a/hibiki/lib/src/media/manga/manga_browse_page.dart
+++ b/hibiki/lib/src/media/manga/manga_browse_page.dart
@@ -77,7 +77,7 @@ class _MangaBrowsePageState extends ConsumerState<MangaBrowsePage> {
         context: context,
         builder: (BuildContext context) => MihonSourceBrowsePage(
           manager: _manager!,
-          source: source,
+          target: MihonInstalledTarget(source),
         ),
       ),
     );

--- a/hibiki/lib/src/media/manga/manga_sources_page.dart
+++ b/hibiki/lib/src/media/manga/manga_sources_page.dart
@@ -130,6 +130,31 @@ class _MangaSourcesPageState extends ConsumerState<MangaSourcesPage> {
         style: Theme.of(context).textTheme.titleLarge,
       );
 
+  /// 页头。与 `MediaSourcesPage` 同一范式：库页视图导航条存在时它就是页头主位，
+  /// **不再另渲染一个页面大标题**——导航条自己已经标明了当前在哪个视图，标题只是
+  /// 重复占一行。仅在没有导航条（独立 push 进来）时才回退到文字标题。
+  Widget _buildHeader() {
+    final List<Widget> actions = <Widget>[
+      HibikiIconButton(
+        tooltip: t.media_source_add,
+        label: t.media_source_add,
+        icon: Icons.create_new_folder_outlined,
+        onTap: () => _localSourcesKey.currentState?.addSource(),
+      ),
+    ];
+    final Widget? navigation = widget.navigation;
+    if (navigation != null) {
+      return HibikiPageHeader.customTitle(
+        title: navigation,
+        actions: actions,
+      );
+    }
+    return HibikiPageHeader(
+      title: t.media_source_manage_title,
+      actions: actions,
+    );
+  }
+
   /// 扩展宿主不可用时统一的占位（iOS / Linux）。结构不变，只是这一节没内容。
   Widget _unavailableNote() => Padding(
         padding: const EdgeInsets.all(24),
@@ -146,19 +171,7 @@ class _MangaSourcesPageState extends ConsumerState<MangaSourcesPage> {
       kind: DesktopContentKind.readerShelf,
       child: Column(
         children: <Widget>[
-          if (!isCupertinoPlatform(context))
-            HibikiPageHeader(
-              title: t.media_source_manage_title,
-              actions: <Widget>[
-                HibikiIconButton(
-                  tooltip: t.media_source_add,
-                  label: t.media_source_add,
-                  icon: Icons.create_new_folder_outlined,
-                  onTap: () => _localSourcesKey.currentState?.addSource(),
-                ),
-              ],
-              bottom: widget.navigation,
-            ),
+          if (!isCupertinoPlatform(context)) _buildHeader(),
           Expanded(
             child: ListView(
               padding: const EdgeInsets.all(16),

--- a/hibiki/lib/src/media/manga/mihon/mihon_extensions_page.dart
+++ b/hibiki/lib/src/media/manga/mihon/mihon_extensions_page.dart
@@ -8,6 +8,8 @@ import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/media/media_search_text.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_extension_store_client.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_manager.dart';
+import 'package:hibiki/src/media/manga/mihon/mihon_models.dart';
+import 'package:hibiki/src/media/manga/mihon/mihon_source_browse_page.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/utils.dart';
 
@@ -161,8 +163,115 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
     }
   }
 
-  Future<void> _confirmAndInstall(MihonInstallProposal proposal) async {
-    if (!mounted) return;
+  /// 「装之前先看看这个源有什么漫画」。
+  ///
+  /// 与 [_install] 共用同一个 proposal——下载、校验签名指纹、比对仓库元数据都已经
+  /// 做完了，差别只在拿到 proposal 之后走 [MihonManager.beginPreview] 而不是直接
+  /// commit：扩展代码会真跑起来（它是代码不是配置，不跑就没有任何内容可看），但
+  /// **不写库、不进受信任签名表**。用户看完在预览页底部二选一：放弃（删干净）
+  /// 或安装（走与直接安装完全相同的签名确认框）。
+  Future<void> _preview(MihonAvailableExtension extension) async {
+    MihonPreviewSession? session;
+    try {
+      final MihonInstallProposal proposal =
+          await _manager!.prepareStoreInstall(extension);
+      final MihonPreviewSession started =
+          await _manager!.beginPreview(proposal);
+      session = started;
+      final MihonSource? source = await _pickPreviewSource(started);
+      if (source == null) {
+        session = null;
+        await _manager!.endPreview(started, keep: false);
+        return;
+      }
+      final bool install = await _openPreviewBrowse(started, source);
+      session = null;
+      // keep 时落地的文件留给 commitInstall 复用，只清运行时缓存与崩溃标记。
+      await _manager!.endPreview(started, keep: install);
+      if (install) await _confirmAndInstall(started.proposal);
+    } catch (error) {
+      final MihonPreviewSession? pending = session;
+      if (pending != null) {
+        try {
+          await _manager!.endPreview(pending, keep: false);
+        } on Object {
+          // 清理失败不能掩盖真正的错误，继续把原始错误报给用户。
+        }
+      }
+      if (mounted) HibikiToast.show(msg: '$error');
+    }
+  }
+
+  /// 一个扩展可能提供多个源（不同站点 / 不同语言），得先问预览哪一个。
+  /// 只有一个就别多一次点击。
+  Future<MihonSource?> _pickPreviewSource(MihonPreviewSession session) async {
+    if (session.sources.length == 1) return session.sources.single;
+    if (!mounted) return null;
+    return showAppDialog<MihonSource>(
+      context: context,
+      builder: (BuildContext dialogContext) => AlertDialog(
+        title: Text(t.mihon_extension_preview_source_select),
+        content: SizedBox(
+          width: 420,
+          child: ListView(
+            shrinkWrap: true,
+            children: <Widget>[
+              for (final MihonSource source in session.sources)
+                HibikiListItem(
+                  title: Text(source.name),
+                  subtitle: Text(
+                    source.baseUrl.isEmpty
+                        ? source.language.toUpperCase()
+                        : '${source.language.toUpperCase()} · '
+                            '${source.baseUrl}',
+                  ),
+                  onTap: () => Navigator.pop(dialogContext, source),
+                ),
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          adaptiveDialogAction(
+            context: dialogContext,
+            onPressed: () => Navigator.pop(dialogContext),
+            child: Text(t.dialog_cancel),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 打开只读预览浏览页，返回用户是否选择了安装。
+  /// 系统返回键 / 手势返回 pop 出 null，按「放弃」处理。
+  Future<bool> _openPreviewBrowse(
+    MihonPreviewSession session,
+    MihonSource source,
+  ) async {
+    if (!mounted) return false;
+    final bool? install = await Navigator.of(context).push<bool>(
+      adaptivePageRoute<bool>(
+        context: context,
+        builder: (BuildContext pageContext) => MihonSourceBrowsePage(
+          manager: _manager!,
+          target: MihonPreviewTarget(session: session, source: source),
+          footer: _PreviewFooter(
+            onDiscard: () => Navigator.pop(pageContext, false),
+            onInstall: () => Navigator.pop(pageContext, true),
+          ),
+        ),
+      ),
+    );
+    return install ?? false;
+  }
+
+  /// 签名确认 + 落地安装。返回**是否真的装上了**。
+  ///
+  /// 用户点取消时把已下载的 APK 一并丢掉：走到这一步文件已经在 `tmp/` 里躺着了。
+  Future<bool> _confirmAndInstall(MihonInstallProposal proposal) async {
+    if (!mounted) {
+      await _manager!.discardProposal(proposal);
+      return false;
+    }
     final bool? confirmed = await showAppDialog<bool>(
       context: context,
       builder: (BuildContext dialogContext) => AlertDialog.adaptive(
@@ -193,11 +302,16 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
         ],
       ),
     );
-    if (confirmed != true) return;
+    if (confirmed != true) {
+      await _manager!.discardProposal(proposal);
+      return false;
+    }
     try {
       await _manager!.commitInstall(proposal, trustSigner: true);
+      return true;
     } catch (error) {
       if (mounted) HibikiToast.show(msg: '$error');
+      return false;
     }
   }
 
@@ -419,6 +533,11 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
           extension: extension,
           installed: installed[extension.packageName],
           onInstall: () => unawaited(_install(extension)),
+          // 只对未安装的开放：Android 的 native install 会覆盖 exts/ 里同包名的
+          // 文件，对已装扩展预览等于拿未确认的版本顶掉用户正在用的那份。
+          onPreview: installed[extension.packageName] == null
+              ? () => unawaited(_preview(extension))
+              : null,
           onUninstall: installed[extension.packageName] == null
               ? null
               : () => unawaited(
@@ -526,11 +645,18 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
   }
 }
 
+/// 仓库里一条可用扩展。
+///
+/// 副标题不止版本号：仓库 index 里本来就带着**这个扩展装完会给你哪几个站**
+/// （[MihonAvailableExtension.sources] 的名字 + 域名）和 NSFW 标记，以前这些数据
+/// 只喂给搜索匹配，一个字都没显示，用户只能靠扩展名猜。安装前能看清装的是什么，
+/// 是「预览」的第一层——不需要跑任何代码，也没有任何网络请求。
 class _AvailableExtensionTile extends StatelessWidget {
   const _AvailableExtensionTile({
     required this.extension,
     required this.installed,
     required this.onInstall,
+    required this.onPreview,
     required this.onUninstall,
     required this.onEnabledChanged,
   });
@@ -538,6 +664,9 @@ class _AvailableExtensionTile extends StatelessWidget {
   final MihonAvailableExtension extension;
   final MangaExtensionRow? installed;
   final VoidCallback onInstall;
+
+  /// 未安装时才有：跑一次 staged 试用，看真实内容。
+  final VoidCallback? onPreview;
   final VoidCallback? onUninstall;
   final ValueChanged<bool>? onEnabledChanged;
 
@@ -545,14 +674,44 @@ class _AvailableExtensionTile extends StatelessWidget {
   Widget build(BuildContext context) {
     final bool update =
         installed != null && extension.versionCode > installed!.versionCode;
+    final ThemeData theme = Theme.of(context);
     return HibikiCard(
       padding: EdgeInsets.zero,
       child: HibikiListItem(
-        leading: const Icon(Icons.extension_outlined),
-        title: Text(extension.name),
-        subtitle: Text(
-          '${extension.language} · ${extension.versionName} · '
-          'lib ${extension.libVersion}',
+        leading: _ExtensionIcon(url: extension.iconUrl),
+        title: Row(
+          children: <Widget>[
+            Flexible(child: Text(extension.name)),
+            if (extension.contentWarning >= 3) ...<Widget>[
+              const SizedBox(width: 8),
+              _NsfwBadge(theme: theme),
+            ],
+          ],
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Text(
+              '${extension.language} · ${extension.versionName} · '
+              'lib ${extension.libVersion}',
+            ),
+            if (extension.sources.isNotEmpty) ...<Widget>[
+              const SizedBox(height: 6),
+              Text(
+                t.mihon_extension_sources_included,
+                style: theme.textTheme.labelSmall,
+              ),
+              for (final MihonAvailableSource source in extension.sources)
+                Text(
+                  source.baseUrl.isEmpty
+                      ? '· ${source.name} (${source.language})'
+                      : '· ${source.name} (${source.language}) — '
+                          '${source.baseUrl}',
+                  style: theme.textTheme.bodySmall,
+                ),
+            ],
+          ],
         ),
         trailing: Wrap(
           crossAxisAlignment: WrapCrossAlignment.center,
@@ -561,6 +720,11 @@ class _AvailableExtensionTile extends StatelessWidget {
               Switch.adaptive(
                 value: installed!.enabled,
                 onChanged: onEnabledChanged,
+              ),
+            if (onPreview != null)
+              TextButton(
+                onPressed: onPreview,
+                child: Text(t.mihon_extension_preview),
               ),
             TextButton(
               onPressed: installed == null || update ? onInstall : onUninstall,
@@ -577,6 +741,116 @@ class _AvailableExtensionTile extends StatelessWidget {
       ),
     );
   }
+}
+
+/// 预览页底部的操作条。
+///
+/// 两句说明不是装饰，是这个功能唯一诚实的地方：**预览已经在跑这个扩展的代码了**
+/// （否则不可能有内容），它与安装的差别是「有没有写进你的库」，不是「有没有执行」。
+/// 说清楚，用户才知道自己在同意什么。
+class _PreviewFooter extends StatelessWidget {
+  const _PreviewFooter({
+    required this.onDiscard,
+    required this.onInstall,
+  });
+
+  final VoidCallback onDiscard;
+  final VoidCallback onInstall;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return ColoredBox(
+      color: theme.colorScheme.surfaceContainerHighest,
+      child: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                t.mihon_extension_preview_warning,
+                style: theme.textTheme.bodySmall,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                t.mihon_extension_preview_read_only,
+                style: theme.textTheme.bodySmall,
+              ),
+              const SizedBox(height: 10),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: <Widget>[
+                  TextButton(
+                    onPressed: onDiscard,
+                    child: Text(t.mihon_extension_preview_discard),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: onInstall,
+                    child: Text(t.mihon_extension_install),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// 扩展图标。仓库 index 给的是远程 URL，取不到就退回通用扩展图标——图标加载失败
+/// 不该让整行显示不出来。
+class _ExtensionIcon extends StatelessWidget {
+  const _ExtensionIcon({required this.url});
+
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    if (url.isEmpty) return const Icon(Icons.extension_outlined);
+    return SizedBox(
+      width: 32,
+      height: 32,
+      child: Image.network(
+        url,
+        width: 32,
+        height: 32,
+        errorBuilder: (BuildContext context, Object error, StackTrace? stack) =>
+            const Icon(Icons.extension_outlined),
+        loadingBuilder: (
+          BuildContext context,
+          Widget child,
+          ImageChunkEvent? progress,
+        ) =>
+            progress == null ? child : const Icon(Icons.extension_outlined),
+      ),
+    );
+  }
+}
+
+class _NsfwBadge extends StatelessWidget {
+  const _NsfwBadge({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.errorContainer,
+          borderRadius: BorderRadius.circular(4),
+        ),
+        child: Text(
+          '18+',
+          style: theme.textTheme.labelSmall?.copyWith(
+            color: theme.colorScheme.onErrorContainer,
+          ),
+        ),
+      );
 }
 
 class _InstalledExtensionTile extends StatelessWidget {

--- a/hibiki/lib/src/media/manga/mihon/mihon_manager.dart
+++ b/hibiki/lib/src/media/manga/mihon/mihon_manager.dart
@@ -66,6 +66,9 @@ class MihonManager extends ChangeNotifier {
       await Directory(p.join(rootDirectory.path, 'tmp'))
           .create(recursive: true);
       await reload();
+      // 必须在 reload 之后：判断孤儿要拿 installed 跟标记里的包名比对。
+      await _recoverAbandonedPreview();
+      await _clearStagedApks();
       await _refreshStores();
     } catch (exception) {
       error = '$exception';
@@ -442,6 +445,168 @@ class MihonManager extends ChangeNotifier {
     });
   }
 
+  /// 丢弃一个没有走到 [commitInstall] 的安装提案。
+  ///
+  /// [prepareStoreInstall] / [prepareLocalInstall] 成功后 APK 已经落在 `tmp/`，
+  /// 用户在签名确认框点取消时那份文件就没人认领了（最大 100 MiB）。
+  /// [_clearStagedApks] 会在下次启动兜底，但当场删掉才是对的。
+  Future<void> discardProposal(MihonInstallProposal proposal) async {
+    final File temp = File(proposal.tempPath);
+    if (await temp.exists()) await temp.delete();
+  }
+
+  /// 开一次「装之前先看看这个源有什么漫画」的试用预览。
+  ///
+  /// Mihon 扩展是**代码**不是配置——站点怎么解析、封面在哪、翻页规则全在 APK 里，
+  /// 所以预览内容必然要真跑它的代码。预览与安装的差别因此不在「有没有执行」，
+  /// 而在**有没有在库里留下痕迹**：
+  /// - 不写 `manga_extensions` / `manga_online_sources`，所以它不进已安装列表、
+  ///   不出现在「浏览」视图、不参与任何续读；
+  /// - 不把签名指纹写进受信任表（只有 [commitInstall] 才写）；
+  /// - 放弃时把落地的文件删干净。
+  ///
+  /// 平台差异只在「代码从哪加载」：桌面 sidecar 直接吃任意路径的 APK 字节，
+  /// staged 的临时文件就能跑；Android 的 `invoke` 只认 `filesDir/exts/<pkg>.ext`
+  /// （Dart 传过去的 `apkPath` 在那条路径上是死字段），所以必须先
+  /// [MihonRuntime.installPrivateExtension] 把文件放进私有目录——**那一步只是文件
+  /// 落地，不构成本类意义上的「安装」**。
+  ///
+  /// 只对**未安装**的扩展开放：Android 的 native install 会覆盖 `exts/` 里同包名
+  /// 的文件，对已装扩展做预览等于拿未经确认的版本顶掉用户正在用的那份。已装的
+  /// 扩展本来就能从「浏览」进去看，不需要预览。
+  Future<MihonPreviewSession> beginPreview(
+    MihonInstallProposal proposal,
+  ) async {
+    if (proposal.current != null) {
+      throw const MihonRuntimeException(
+        'PREVIEW_ALREADY_INSTALLED',
+        'Preview is only available for extensions that are not installed',
+      );
+    }
+    final String packageName = proposal.inspection.packageName;
+    late final MihonPreviewSession session;
+    await _guarded(() async {
+      // 标记先于文件落地写：崩溃留下的孤儿只能靠它认出来（见 _recoverAbandonedPreview）。
+      await _writePreviewMarker(packageName);
+      try {
+        final String runtimePath = Platform.isAndroid
+            ? await runtime.installPrivateExtension(proposal.tempPath)
+            : proposal.tempPath;
+        final MihonExtensionRef extension = MihonExtensionRef(
+          packageName: packageName,
+          apkPath: runtimePath,
+        );
+        final List<MihonSource> loaded = await runtime.listSources(extension);
+        if (loaded.isEmpty) {
+          throw const MihonRuntimeException(
+            'NO_SOURCES',
+            'Extension did not expose any manga sources',
+          );
+        }
+        session = MihonPreviewSession(
+          proposal: proposal,
+          extension: extension,
+          sources: loaded,
+        );
+      } catch (_) {
+        await _discardPreview(packageName, tempPath: proposal.tempPath);
+        rethrow;
+      }
+    });
+    return session;
+  }
+
+  /// 结束预览。
+  ///
+  /// [keep] 为 true 表示用户看完决定装：落地的文件留给 [commitInstall] 复用
+  /// （Android 上它已经在 `exts/` 里，桌面上 temp 文件还等着被 rename 过去），
+  /// 这里只清运行时的已加载缓存，让安装后重新加载到同一份文件。
+  /// 为 false 则把预览留下的一切删干净。
+  Future<void> endPreview(
+    MihonPreviewSession session, {
+    required bool keep,
+  }) async {
+    final String packageName = session.proposal.inspection.packageName;
+    if (keep) {
+      await runtime.invalidateExtension(packageName);
+      await _clearPreviewMarker();
+      return;
+    }
+    await _guarded(
+      () => _discardPreview(
+        packageName,
+        tempPath: session.proposal.tempPath,
+      ),
+    );
+  }
+
+  Future<void> _discardPreview(
+    String packageName, {
+    required String tempPath,
+  }) async {
+    await runtime.invalidateExtension(packageName);
+    if (Platform.isAndroid) {
+      await runtime.uninstallPrivateExtension(packageName);
+    }
+    final File temp = File(tempPath);
+    if (await temp.exists()) await temp.delete();
+    await _clearPreviewMarker();
+  }
+
+  File get _previewMarker =>
+      File(p.join(rootDirectory.path, 'tmp', 'preview-pending'));
+
+  Future<void> _writePreviewMarker(String packageName) async {
+    await _previewMarker.parent.create(recursive: true);
+    await _previewMarker.writeAsString(packageName, flush: true);
+  }
+
+  Future<void> _clearPreviewMarker() async {
+    if (await _previewMarker.exists()) await _previewMarker.delete();
+  }
+
+  /// 预览期间进程被杀，会在 Android 私有目录里留下一个没有任何 DB 记录的孤儿
+  /// 扩展文件。它不会出现在任何列表里（列表读 DB），但会占空间，而且下次预览同
+  /// 一个包时 native 的 install 会走「升级」分支去比对签名版本号，行为不可预期。
+  ///
+  /// 桌面端不需要动 runtime：那边预览用的是 `tmp/*.apk.part`，由 [_clearStagedApks]
+  /// 统一清理，没有任何东西被放进常驻目录。
+  Future<void> _recoverAbandonedPreview() async {
+    if (!await _previewMarker.exists()) return;
+    try {
+      final String packageName = (await _previewMarker.readAsString()).trim();
+      final bool reallyInstalled = installed.any(
+        (MangaExtensionRow row) => row.packageName == packageName,
+      );
+      if (Platform.isAndroid && packageName.isNotEmpty && !reallyInstalled) {
+        await runtime.invalidateExtension(packageName);
+        await runtime.uninstallPrivateExtension(packageName);
+      }
+    } on Object {
+      // 清不掉不能挡住整个扩展子系统启动：孤儿文件只占空间，不影响正确性。
+    }
+    await _clearPreviewMarker();
+  }
+
+  /// 清掉上次进程留下的半成品 APK。
+  ///
+  /// `tmp/extension-<sha>.apk.part` 是 [_prepareInstallBytes] 的落脚点，正常路径
+  /// 上一定会被 [commitInstall] rename 掉或被失败分支删掉，只有进程在中途被杀才
+  /// 会留下。它们没有任何长期意义，且每个最大 100 MiB。
+  Future<void> _clearStagedApks() async {
+    final Directory tmp = Directory(p.join(rootDirectory.path, 'tmp'));
+    if (!await tmp.exists()) return;
+    try {
+      await for (final FileSystemEntity entity in tmp.list()) {
+        if (entity is File && entity.path.endsWith('.apk.part')) {
+          await entity.delete();
+        }
+      }
+    } on Object {
+      // 同上：清理是尽力而为，不能让它挡住启动。
+    }
+  }
+
   Future<void> uninstallExtension(
     MangaExtensionRow extension, {
     bool clearData = false,
@@ -684,6 +849,36 @@ class MihonInstallProposal {
   final MihonAvailableExtension? expected;
   final MangaExtensionRow? current;
   final bool signerTrusted;
+}
+
+/// 一次进行中的扩展试用预览。
+///
+/// 持有 staged（已落地但未登记入库）的扩展引用和它暴露出来的源列表。生命周期由
+/// [MihonManager.beginPreview] / [MihonManager.endPreview] 成对管理——**不要**自己
+/// 拿 [extension] 去调 [MihonManager.commitInstall] 之外的写库路径，那会绕过
+/// 「预览不留痕迹」的不变量。
+@immutable
+class MihonPreviewSession {
+  const MihonPreviewSession({
+    required this.proposal,
+    required this.extension,
+    required this.sources,
+  });
+
+  final MihonInstallProposal proposal;
+  final MihonExtensionRef extension;
+  final List<MihonSource> sources;
+
+  /// 把预览里的某个源包装成浏览页能直接吃的上下文。
+  ///
+  /// 偏好恒为空：源偏好落在 `manga_source_preferences` 表且以
+  /// `(extensionPackage, sourceId)` 为键，而预览的扩展根本没进库——读它只会拿到
+  /// 空表，写它则会留下指向不存在扩展的孤儿行。预览就用扩展的内置默认值。
+  MihonSourceContext contextFor(MihonSource source) => MihonSourceContext(
+        extension: extension,
+        source: source,
+        preferences: const <MihonPreference>[],
+      );
 }
 
 @immutable

--- a/hibiki/lib/src/media/manga/mihon/mihon_source_browse_page.dart
+++ b/hibiki/lib/src/media/manga/mihon/mihon_source_browse_page.dart
@@ -13,15 +13,51 @@ import 'package:hibiki/utils.dart';
 
 enum _MihonBrowseMode { popular, latest, search }
 
+/// 浏览页要浏览的那「一个源」从哪来。
+///
+/// 两个变体的差别只在**上下文怎么拿到**和**能不能落库**，网格、搜索、分页、
+/// 封面代理全部同一套代码——所以这里用 sealed 穷尽，而不是给页面塞一堆可空参数
+/// 再靠「恰有一个非空」的隐式约定分流。
+sealed class MihonBrowseTarget {
+  const MihonBrowseTarget();
+}
+
+/// 已安装并登记入库的源：上下文和用户偏好都从库里读，可以进详情、可以入库。
+class MihonInstalledTarget extends MihonBrowseTarget {
+  const MihonInstalledTarget(this.row);
+
+  final MangaOnlineSourceRow row;
+}
+
+/// 试用预览里的源：上下文来自 staged 会话，库里根本没有这个扩展。
+///
+/// 因此**只读**——不能进详情页。详情页会走 `MihonLibraryService.add()` 把书写进
+/// 书架，而那要求扩展和源都已在库里登记；对一个随时可能被放弃的预览来说，那会
+/// 留下指向不存在扩展的孤儿行。预览的目的是「看看这个源有没有我要的漫画」，
+/// 网格 + 搜索 + 封面已经够判断，真要读就先装。
+class MihonPreviewTarget extends MihonBrowseTarget {
+  const MihonPreviewTarget({
+    required this.session,
+    required this.source,
+  });
+
+  final MihonPreviewSession session;
+  final MihonSource source;
+}
+
 class MihonSourceBrowsePage extends StatefulWidget {
   const MihonSourceBrowsePage({
     required this.manager,
-    required this.source,
+    required this.target,
     super.key,
+    this.footer,
   });
 
   final MihonManager manager;
-  final MangaOnlineSourceRow source;
+  final MihonBrowseTarget target;
+
+  /// 钉在正文底部的操作条。预览用它放「放弃 / 信任并安装」。
+  final Widget? footer;
 
   @override
   State<MihonSourceBrowsePage> createState() => _MihonSourceBrowsePageState();
@@ -50,10 +86,20 @@ class _MihonSourceBrowsePageState extends State<MihonSourceBrowsePage> {
     super.dispose();
   }
 
+  /// 预览态只读：封面不可点，也没有详情页可去。
+  bool get _readOnly => widget.target is MihonPreviewTarget;
+
   Future<void> _initialise() async {
     try {
-      final MihonSourceContext context =
-          await widget.manager.contextForSource(widget.source);
+      final MihonSourceContext context = switch (widget.target) {
+        MihonInstalledTarget(:final MangaOnlineSourceRow row) =>
+          await widget.manager.contextForSource(row),
+        MihonPreviewTarget(
+          :final MihonPreviewSession session,
+          :final MihonSource source,
+        ) =>
+          session.contextFor(source),
+      };
       final List<MihonFilter> filters = await widget.manager.runtime.getFilters(
         context.extension,
         context.source,
@@ -155,7 +201,10 @@ class _MihonSourceBrowsePageState extends State<MihonSourceBrowsePage> {
   @override
   Widget build(BuildContext context) {
     return HibikiPageScaffold(
-      title: widget.source.name,
+      title: switch (widget.target) {
+        MihonInstalledTarget(:final MangaOnlineSourceRow row) => row.name,
+        MihonPreviewTarget(:final MihonSource source) => source.name,
+      },
       headerBottom: Padding(
         padding: const EdgeInsets.only(top: 8),
         child: Row(
@@ -212,6 +261,7 @@ class _MihonSourceBrowsePageState extends State<MihonSourceBrowsePage> {
             ),
           ),
           Expanded(child: _buildResults()),
+          if (widget.footer != null) widget.footer!,
         ],
       ),
     );
@@ -258,7 +308,7 @@ class _MihonSourceBrowsePageState extends State<MihonSourceBrowsePage> {
             final MihonManga manga = _items[index];
             return HibikiCard(
               padding: EdgeInsets.zero,
-              onTap: () => _openDetails(manga),
+              onTap: _readOnly ? null : () => _openDetails(manga),
               // HibikiCard 内部已用 Material(clipBehavior: antiAlias) 按同一
               // 圆角 token 裁剪，这里不再多包一层 ClipRRect。
               child: Column(

--- a/hibiki/test/media/manga/mihon_manager_preview_test.dart
+++ b/hibiki/test/media/manga/mihon_manager_preview_test.dart
@@ -1,0 +1,263 @@
+import 'dart:io';
+
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/mihon/mihon_manager.dart';
+import 'package:hibiki/src/media/manga/mihon/mihon_models.dart';
+import 'package:hibiki/src/media/manga/mihon/mihon_runtime.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+
+/// 扩展「装之前先试用」的生命周期不变量。
+///
+/// 这个功能唯一的安全承诺不是「没跑代码」——预览必须真跑扩展代码，否则拿不到
+/// 任何内容（Mihon 扩展是代码不是配置）。承诺是**不留痕迹**：
+/// 预览不写 `manga_extensions` / `manga_online_sources`，不写受信任签名表，
+/// 放弃时把落地的 APK 删干净。本文件守的就是这条线。
+///
+/// Android 特有的那一步（`installPrivateExtension` 把文件放进 `filesDir/exts`，
+/// 放弃时 `uninstallPrivateExtension` 删掉）在宿主平台上跑不到——`Platform.isAndroid`
+/// 恒为 false，也无法在单测里伪造。所以这里守的是**平台无关的那部分**：库里零
+/// 痕迹、temp 文件按 keep 语义处置、拒绝对已安装扩展预览、崩溃标记会被清理。
+void main() {
+  late Directory root;
+  late HibikiDatabase database;
+  late _PreviewRuntime runtime;
+  late MihonManager manager;
+
+  setUp(() async {
+    root = await Directory.systemTemp.createTemp('hibiki-mihon-preview-');
+    database = HibikiDatabase.forTesting(NativeDatabase.memory());
+    runtime = _PreviewRuntime();
+    manager = MihonManager(
+      database: database,
+      rootDirectory: root,
+      runtime: runtime,
+    );
+    await manager.initialise();
+  });
+
+  tearDown(() async {
+    manager.dispose();
+    await database.close();
+    if (await root.exists()) await root.delete(recursive: true);
+  });
+
+  Future<MihonInstallProposal> prepare(List<int> bytes) async {
+    final File apk = File('${root.path}${Platform.pathSeparator}fixture.apk');
+    await apk.writeAsBytes(bytes, flush: true);
+    return manager.prepareLocalInstall(apk.path);
+  }
+
+  test('预览拿得到源，但库里一点痕迹都不留', () async {
+    final MihonPreviewSession session = await manager.beginPreview(
+      await prepare(<int>[1, 2, 3]),
+    );
+
+    expect(session.sources, hasLength(1));
+    expect(session.sources.single.name, 'Fixture source');
+    // 扩展引用指向 staged 的那份文件，不是 extensions/ 下的常驻路径。
+    expect(session.extension.packageName, 'org.example.fixture');
+
+    // 这三张表是「已安装」的唯一真相源：一条都不能多。
+    expect(await database.getMangaExtensions(), isEmpty);
+    expect(await database.getMangaOnlineSources(), isEmpty);
+    expect(await database.isMangaSignerTrusted('aabb'), isFalse);
+    // manager 的内存视图同样不该出现它，否则会渗进「浏览」视图。
+    expect(manager.installed, isEmpty);
+    expect(manager.sources, isEmpty);
+
+    await manager.endPreview(session, keep: false);
+  });
+
+  test('放弃预览会把 staged 的 APK 删干净', () async {
+    final MihonInstallProposal proposal = await prepare(<int>[1, 2, 3]);
+    final MihonPreviewSession session = await manager.beginPreview(proposal);
+    expect(await File(proposal.tempPath).exists(), isTrue);
+
+    await manager.endPreview(session, keep: false);
+
+    expect(
+      await File(proposal.tempPath).exists(),
+      isFalse,
+      reason: '放弃后不该留下最大 100 MiB 的半成品',
+    );
+    expect(await _stagedApks(root), isEmpty);
+  });
+
+  test('接受预览会保留 staged 的 APK 给 commitInstall 复用', () async {
+    final MihonInstallProposal proposal = await prepare(<int>[1, 2, 3]);
+    final MihonPreviewSession session = await manager.beginPreview(proposal);
+
+    await manager.endPreview(session, keep: true);
+
+    expect(
+      await File(proposal.tempPath).exists(),
+      isTrue,
+      reason: 'keep 语义就是「接着要装」，删了 commitInstall 就没东西可搬',
+    );
+    // 但仍然只是 staged：在 commitInstall 之前，库里依旧什么都没有。
+    expect(await database.getMangaExtensions(), isEmpty);
+  });
+
+  test('预览完接着安装，走的是同一份文件且真的落库', () async {
+    final MihonInstallProposal proposal = await prepare(<int>[1, 2, 3]);
+    final MihonPreviewSession session = await manager.beginPreview(proposal);
+    await manager.endPreview(session, keep: true);
+
+    await manager.commitInstall(proposal, trustSigner: true);
+
+    final MangaExtensionRow? row =
+        await database.getMangaExtension('org.example.fixture');
+    expect(row, isNotNull);
+    expect(row!.versionCode, 1);
+    expect(await database.getMangaOnlineSources(), hasLength(1));
+    expect(await database.isMangaSignerTrusted('aabb'), isTrue);
+    expect(
+      await _stagedApks(root),
+      isEmpty,
+      reason: 'commitInstall 应该把 staged 文件搬走或删掉，不留残骸',
+    );
+  });
+
+  test('已安装的扩展不给预览（会顶掉用户正在用的那份）', () async {
+    final MihonInstallProposal first = await prepare(<int>[1, 2, 3]);
+    await manager.commitInstall(first, trustSigner: true);
+
+    runtime.versionCode = 2;
+    final MihonInstallProposal update = await prepare(<int>[4, 5, 6]);
+    await expectLater(
+      manager.beginPreview(update),
+      throwsA(
+        isA<MihonRuntimeException>().having(
+          (MihonRuntimeException error) => error.code,
+          'code',
+          'PREVIEW_ALREADY_INSTALLED',
+        ),
+      ),
+    );
+  });
+
+  test('扩展一个源都不给时预览失败，且不留残骸', () async {
+    runtime.emptySources = true;
+    final MihonInstallProposal proposal = await prepare(<int>[1, 2, 3]);
+
+    await expectLater(
+      manager.beginPreview(proposal),
+      throwsA(
+        isA<MihonRuntimeException>().having(
+          (MihonRuntimeException error) => error.code,
+          'code',
+          'NO_SOURCES',
+        ),
+      ),
+    );
+
+    expect(await File(proposal.tempPath).exists(), isFalse);
+    expect(await _previewMarker(root).exists(), isFalse);
+    expect(await database.getMangaExtensions(), isEmpty);
+  });
+
+  test('取消安装提案会把已下载的 APK 丢掉', () async {
+    final MihonInstallProposal proposal = await prepare(<int>[1, 2, 3]);
+    expect(await File(proposal.tempPath).exists(), isTrue);
+
+    await manager.discardProposal(proposal);
+
+    expect(await File(proposal.tempPath).exists(), isFalse);
+  });
+
+  test('上次进程在预览中途被杀，下次启动清掉标记和半成品', () async {
+    // 直接伪造崩溃现场：标记还在、staged APK 还在、库里没有对应记录。
+    manager.dispose();
+    final File marker = _previewMarker(root);
+    await marker.parent.create(recursive: true);
+    await marker.writeAsString('org.example.orphan', flush: true);
+    final File staged = File(
+      '${root.path}${Platform.pathSeparator}tmp'
+      '${Platform.pathSeparator}extension-deadbeef.apk.part',
+    );
+    await staged.writeAsBytes(<int>[9], flush: true);
+
+    manager = MihonManager(
+      database: database,
+      rootDirectory: root,
+      runtime: runtime,
+    );
+    await manager.initialise();
+
+    expect(
+      await marker.exists(),
+      isFalse,
+      reason: '标记不清掉，下次预览同一个包时判断孤儿的依据就是脏的',
+    );
+    expect(
+      await staged.exists(),
+      isFalse,
+      reason: '半成品 APK 每个最大 100 MiB，崩一次留一个',
+    );
+  });
+}
+
+File _previewMarker(Directory root) => File(
+      '${root.path}${Platform.pathSeparator}tmp'
+      '${Platform.pathSeparator}preview-pending',
+    );
+
+Future<List<FileSystemEntity>> _stagedApks(Directory root) async {
+  final Directory tmp = Directory(
+    '${root.path}${Platform.pathSeparator}tmp',
+  );
+  if (!await tmp.exists()) return const <FileSystemEntity>[];
+  return tmp
+      .list()
+      .where(
+        (FileSystemEntity entity) => entity.path.endsWith('.apk.part'),
+      )
+      .toList();
+}
+
+class _PreviewRuntime extends Fake implements MihonRuntime {
+  int versionCode = 1;
+  bool emptySources = false;
+
+  @override
+  Future<MihonExtensionInspection> inspectExtension(String apkPath) async =>
+      MihonExtensionInspection(
+        packageName: 'org.example.fixture',
+        name: 'Fixture extension',
+        versionCode: versionCode,
+        versionName: '1.6.$versionCode',
+        libVersion: '1.6',
+        signerSha256: 'aabb',
+        sourceClasses: const <String>['FixtureSource'],
+      );
+
+  @override
+  Future<String> installPrivateExtension(String apkPath) async => apkPath;
+
+  @override
+  Future<void> uninstallPrivateExtension(String packageName) async {}
+
+  @override
+  Future<List<MihonSource>> listSources(
+    MihonExtensionRef extension, {
+    List<MihonPreference> preferences = const <MihonPreference>[],
+  }) async {
+    if (emptySources) return const <MihonSource>[];
+    return const <MihonSource>[
+      MihonSource(
+        extensionPackage: 'org.example.fixture',
+        id: '9223372036854775807',
+        name: 'Fixture source',
+        language: 'en',
+        baseUrl: 'https://source.example',
+      ),
+    ];
+  }
+
+  @override
+  Future<void> invalidateExtension(String packageName) async {}
+
+  @override
+  Future<void> dispose() async {}
+}

--- a/hibiki/test/media/manga/mihon_source_browse_page_test.dart
+++ b/hibiki/test/media/manga/mihon_source_browse_page_test.dart
@@ -71,7 +71,7 @@ void main() {
           theme: ThemeData.light(useMaterial3: true),
           home: MihonSourceBrowsePage(
             manager: manager,
-            source: manager.sources.single,
+            target: MihonInstalledTarget(manager.sources.single),
           ),
         ),
       );

--- a/hibiki/test/pages/manga_sources_view_composition_test.dart
+++ b/hibiki/test/pages/manga_sources_view_composition_test.dart
@@ -88,4 +88,39 @@ void main() {
       );
     });
   });
+
+  /// 用户口径：「删掉漫画里面的标题，管理来源、浏览这两个」。
+  ///
+  /// 这两个页面此前用的是 `HibikiPageHeader(title: ..., bottom: navigation)`
+  /// ——页头先渲染一行页面大标题，再把库页视图导航条挂在它下面。可导航条本身就
+  /// 标明了当前在哪个视图，那行标题纯属重复占一行高度。通用媒体来源页
+  /// (`MediaSourcesPage._buildHeader`) 早已迁到 `customTitle` 范式（导航条直接占
+  /// 页头主位），漫画这两个页是漏迁的，所以比别处多出一行。
+  ///
+  /// 守的是**形态**不是文案：只要还有 `bottom: widget.navigation`，就说明又退回
+  /// 了「标题在上、导航条在下」的两行结构。
+  group('漫画来源 / 浏览页头不再渲染重复的页面大标题', () {
+    for (final (String label, String file) in <(String, String)>[
+      ('来源', 'manga_sources_page.dart'),
+      ('浏览', 'manga_browse_page.dart'),
+    ]) {
+      test('$label 页：有导航条时它占页头主位（customTitle）', () {
+        final String source = _read(<String>[file]);
+        expect(
+          source,
+          contains('HibikiPageHeader.customTitle('),
+          reason: '导航条必须直接占页头主位，而不是挂在一行大标题下面',
+        );
+      });
+
+      test('$label 页：不再把导航条挂成页头的 bottom', () {
+        final String source = _read(<String>[file]);
+        expect(
+          source,
+          isNot(contains('bottom: widget.navigation')),
+          reason: 'bottom 形态就意味着上方还留着那行被用户要求删掉的大标题',
+        );
+      });
+    }
+  });
 }


### PR DESCRIPTION
## 起因

用户两个诉求，同一批落地：

1. 「这个漫画的来源，漫画扩展能不能预览。安装之前」→ 原本不能，本 PR 补齐。
2. 「删掉漫画里面的标题。管理来源、浏览这两个」→ 页头去掉重复的大标题。

## 一、页头去重复标题（commit 1）

`MangaSourcesPage` / `MangaBrowsePage` 用的是 `HibikiPageHeader(title: ..., bottom: navigation)`——先渲染一行页面大标题，再把库页视图导航条挂它下面。导航条本身已标明当前在哪个视图，那行标题纯属重复占一行。

通用媒体来源页 `MediaSourcesPage._buildHeader` 早已迁到 `customTitle` 范式（导航条直接占页头主位），漫画这两个页是漏迁的，所以比别处多一行。**补齐漏迁，不是加特例分支。** 没有导航条（独立 push 进来）时仍回退到文字标题，行为不变。

## 二、扩展安装前预览（commit 2）

### 元信息预览（零代码执行、零网络请求）

仓库 index 里本来就解析出了 `sources`（每个源的名字 / 语言 / 站点域名）、`iconUrl`、`contentWarning`，但卡片只渲染「语言 · 版本 · lib 版本」，图标写死 `Icons.extension_outlined`，`sources` 唯一的用途是喂给搜索匹配——所以能搜到某个扩展，却看不出它装完给你哪几个站。现在直接列出来。**数据早就在手里，只是从没显示。**

### 真内容试用（跑代码，但不留痕迹）

Mihon 扩展是**代码**不是配置，站点解析全在 APK 里，所以「看看这个源有什么漫画」必然要真跑它。因此预览与安装的差别不在「有没有执行」，而在**有没有在库里留下痕迹**：

- 不写 `manga_extensions` / `manga_online_sources`
- 不写受信任签名表
- 放弃时把落地的 APK 删干净

UI 上不含糊其辞，footer 明说「预览会在安装前运行该扩展的代码」。

### 平台差异（零 Kotlin 改动）

| 端 | invoke 怎么拿到扩展代码 | 预览做法 |
|---|---|---|
| 桌面 | `desktop_mihon_runtime.dart:94` 把 `apkPath` 读成 base64 喂 sidecar，任意路径都行 | 直接用 staged 临时文件 |
| Android | `MihonChannelHandler.kt:217` **忽略** Dart 传的 `apkPath`，只认 `filesDir/exts/<pkg>.ext` | 先 `installPrivateExtension` 让文件落地——**那一步只是文件落地，不构成安装** |

### 约束与不变量

- **只对未安装的扩展开放**。Android 的 native install 会覆盖 `exts/` 里同包名文件，对已装扩展预览等于拿未确认版本顶掉用户正在用的那份；何况已装的本来就能浏览。
- **预览只读，封面不可点**。详情页会走 `MihonLibraryService.add()` 写书架，那要求扩展和源都已登记入库，对随时可能被放弃的预览会留下孤儿行。
- **崩溃残留**：预览中途进程被杀会留下无 DB 记录的孤儿。`tmp/preview-pending` 标记 + 启动时清理，并顺带清 `tmp/*.apk.part`（每个最大 100 MiB）。

### 顺带修掉的既有泄漏

签名确认框点取消时，已下载的 APK 原本留在 `tmp/` 没人管，现在走 `discardProposal` 当场删（`_clearStagedApks` 仍在启动时兜底）。

### 结构

浏览页原本只能吃 `MangaOnlineSourceRow`（DB 行）。改成 sealed `MihonBrowseTarget` {`MihonInstalledTarget`, `MihonPreviewTarget`} 穷尽分流，而不是加一堆可空参数靠「恰有一个非空」的隐式约定——网格 / 搜索 / 分页 / 封面代理全部复用同一套代码。

## 验证

- `flutter analyze` 全量 **No issues found**
- 定向 `flutter test` **31 项全绿，退出码 0**
- 新增守卫 12 条（4 条页头形态 + 8 条预览生命周期），**全部变异实测过**：
  - 页头改回旧写法 → 2 条真红（`+7 -2`）
  - 去掉删 temp → 2 条真红
  - 去掉已安装拒绝检查 → 1 条真红

## 未验证（明确缺口）

Android 真机上的 staged 加载与放弃清理路径。`installPrivateExtension` / `uninstallPrivateExtension` 那两步在宿主平台单测里跑不到——`Platform.isAndroid` 恒为 false 且无法伪造。桌面路径逻辑已由单测覆盖。

https://claude.ai/code/session_01CLgkAR1onf3ix6RSCUoFiu
