### PR TITLE
feat(sync): 远端数据删除 —— 远端条目长按删除 + 「从所有设备删除」推到互联对端

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52343 (3079 per locale)
+/// Strings: 52377 (3081 per locale)
 ///
-/// Built on 2026-08-02 at 03:29 UTC
+/// Built on 2026-08-02 at 05:58 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4138,6 +4138,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'This manga was imported from images, so there is no original book to convert back to.';
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -11204,6 +11207,11 @@ class _StringsAr extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -18337,6 +18345,11 @@ class _StringsDe extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -25485,6 +25498,11 @@ class _StringsEs extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -32645,6 +32663,11 @@ class _StringsFr extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -39734,6 +39757,11 @@ class _StringsId extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -46869,6 +46897,11 @@ class _StringsIt extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -53821,6 +53854,11 @@ class _StringsJa extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -60775,6 +60813,11 @@ class _StringsKo extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -67890,6 +67933,11 @@ class _StringsNl extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -75018,6 +75066,11 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -82130,6 +82183,11 @@ class _StringsRu extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -89190,6 +89248,11 @@ class _StringsTh extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -96282,6 +96345,11 @@ class _StringsTr extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -103359,6 +103427,11 @@ class _StringsVi extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 // Path: <root>
@@ -109944,6 +110017,10 @@ class _StringsZhCn extends _StringsEn {
   String get book_convert_blocked_no_original => '这本漫画是从图片导入的，没有可还原的原书。';
   @override
   String get book_convert_blocked_source_missing => '源文件已从磁盘上消失。';
+  @override
+  String get remote_delete_failed => '无法在对端设备上删除';
+  @override
+  String get remote_delete_unsupported => '对端设备版本过旧，不支持远端删除，请先升级对端 Hibiki';
 }
 
 // Path: <root>
@@ -116817,6 +116894,11 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get book_convert_blocked_source_missing =>
       'The source files are gone from disk.';
+  @override
+  String get remote_delete_failed => 'Could not delete it on the paired device';
+  @override
+  String get remote_delete_unsupported =>
+      'The paired device is too old to support remote deletion. Update Hibiki there first.';
 }
 
 /// Flat map(s) containing all translations.
@@ -123134,6 +123216,10 @@ extension on _StringsEn {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -129449,6 +129535,10 @@ extension on _StringsAr {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -135786,6 +135876,10 @@ extension on _StringsDe {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -142122,6 +142216,10 @@ extension on _StringsEs {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -148464,6 +148562,10 @@ extension on _StringsFr {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -154788,6 +154890,10 @@ extension on _StringsId {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -161126,6 +161232,10 @@ extension on _StringsIt {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -167426,6 +167536,10 @@ extension on _StringsJa {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -173730,6 +173844,10 @@ extension on _StringsKo {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -180062,6 +180180,10 @@ extension on _StringsNl {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -186391,6 +186513,10 @@ extension on _StringsPtBr {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -192725,6 +192851,10 @@ extension on _StringsRu {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -199042,6 +199172,10 @@ extension on _StringsTh {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -205368,6 +205502,10 @@ extension on _StringsTr {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -211690,6 +211828,10 @@ extension on _StringsVi {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }
@@ -217958,6 +218100,10 @@ extension on _StringsZhCn {
         return '这本漫画是从图片导入的，没有可还原的原书。';
       case 'book_convert_blocked_source_missing':
         return '源文件已从磁盘上消失。';
+      case 'remote_delete_failed':
+        return '无法在对端设备上删除';
+      case 'remote_delete_unsupported':
+        return '对端设备版本过旧，不支持远端删除，请先升级对端 Hibiki';
       default:
         return null;
     }
@@ -224253,6 +224399,10 @@ extension on _StringsZhHk {
         return 'This manga was imported from images, so there is no original book to convert back to.';
       case 'book_convert_blocked_source_missing':
         return 'The source files are gone from disk.';
+      case 'remote_delete_failed':
+        return 'Could not delete it on the paired device';
+      case 'remote_delete_unsupported':
+        return 'The paired device is too old to support remote deletion. Update Hibiki there first.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "这本书已经是该格式了。",
   "book_convert_blocked_text_only": "这是一本没有页图的文字书。只有扫描版图片书才能转成漫画。",
   "book_convert_blocked_no_original": "这本漫画是从图片导入的，没有可还原的原书。",
-  "book_convert_blocked_source_missing": "源文件已从磁盘上消失。"
+  "book_convert_blocked_source_missing": "源文件已从磁盘上消失。",
+  "remote_delete_failed": "无法在对端设备上删除",
+  "remote_delete_unsupported": "对端设备版本过旧，不支持远端删除，请先升级对端 Hibiki"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3077,5 +3077,7 @@
   "book_convert_blocked_already": "This book is already in that format.",
   "book_convert_blocked_text_only": "This is a text book with no page images. Only scanned image books can become manga.",
   "book_convert_blocked_no_original": "This manga was imported from images, so there is no original book to convert back to.",
-  "book_convert_blocked_source_missing": "The source files are gone from disk."
+  "book_convert_blocked_source_missing": "The source files are gone from disk.",
+  "remote_delete_failed": "Could not delete it on the paired device",
+  "remote_delete_unsupported": "The paired device is too old to support remote deletion. Update Hibiki there first."
 }

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -498,6 +498,17 @@ class AppModel with ChangeNotifier {
       extractVideoCover: (
               {required String videoPath, required String bookUid}) =>
           extractVideoCover(videoPath: videoPath, bookUid: bookUid),
+      // host 收到 DELETE /api/library/videos/<id> 时的磁盘回收（VideoDeletionHost）：
+      // 复用本机长按删除的同一函数，按「仍在 app 资产目录内 + 无其它条目引用」回收
+      // 封面 / 字幕缓存。**不碰用户自己导入的原始视频文件**——远端删除与本地删除
+      // 在「删掉哪些字节」上必须完全同语义，否则同一动作在两端后果不同。
+      cleanupVideoOnDisk: (VideoBookRow row) =>
+          VideoBookRepository(database).reclaimDeletedVideoBookAssets(
+        deletedBookUid: row.bookUid,
+        deletedCoverPath: row.coverPath,
+        deletedSubtitlePath: row.subtitleSource,
+        deletedVideoPath: row.videoPath,
+      ),
       removeLocalAudioEntry: (String displayName) async {
         // 按 displayName 在 LocalAudioManager 中找到对应 index 并删除。
         // LocalAudioManager.remove(int) 删除 DB 文件 + 从 prefs 移出 + 推 native。

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -3859,11 +3859,15 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
   /// 动作：
   /// * 「下载」→ 复用 [_downloadRemote]（与封面下载按钮同一入口，内部已去重）。
   /// * 「信息」→ 弹基本元数据（标题 + 是否含字幕）。
+  /// * 「删除」→ 仅互联后端（[InterconnectSyncBackend]，有 deleteRemoteVideo）才显示；
+  ///   云盘后端（[CloudRemoteVideoClient]）无此能力，按类型门控隐藏，与远端书卡
+  ///   [_showRemoteBookDialog] 同一纪律。
   ///
-  /// 删除：远端视频是 host/client 模型（client 不存视频，只从 host 流式播放），
-  /// [RemoteVideoClient] / [InterconnectSyncBackend] 均无 deleteRemoteVideo 能力，
-  /// 故不提供删除动作（真实能力边界，非掩盖）。
+  /// 注：此处曾注明「均无 deleteRemoteVideo 能力，故不提供删除动作」——该能力现已补齐
+  /// （host `VideoDeletionHost` + `DELETE /api/library/videos/<id>` + client 方法四层）。
   void _showRemoteVideoDialog(RemoteVideoInfo video) {
+    final RemoteVideoClient? client = _remoteVideoClient;
+    final bool canDelete = client is InterconnectSyncBackend;
     showAppDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => MediaItemDialogFrame(
@@ -3888,8 +3892,76 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             },
           ),
         ],
+        dangerActions: <DialogDangerAction>[
+          if (canDelete)
+            DialogDangerAction(
+              label: t.dialog_delete,
+              onPressed: () {
+                Navigator.pop(dialogContext);
+                _confirmDeleteRemoteVideo(video, client);
+              },
+            ),
+        ],
       ),
     );
+  }
+
+  /// 删除互联对端 host 上的远端视频，删完强制刷新远端列表。
+  ///
+  /// 删的是 host 库里的条目 + host app 自己拥有的封面/字幕缓存与上传副本；host 用户
+  /// **自己导入的原始视频文件不删**（见 `AppModelLibraryHostService.deleteVideo`）。
+  ///
+  /// 三种结果各有可见反馈——静默失败正是远端书删除的老毛病（只写日志、用户以为删了）：
+  /// * 成功 → 列表里消失（强制刷新绕过 [RemoteLibraryCache] TTL）；
+  /// * host 版本过旧不支持（404/405）→ 提示升级对端；
+  /// * 其它失败（网络 / host 500）→ 提示失败。
+  Future<void> _confirmDeleteRemoteVideo(
+    RemoteVideoInfo video,
+    InterconnectSyncBackend backend,
+  ) async {
+    final bool? confirmed = await showAppDialog<bool>(
+      context: context,
+      builder: (BuildContext dialogContext) => AlertDialog(
+        title: Text(video.title),
+        content: Text(t.sync_compare_delete_confirm(name: video.title)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: Text(t.dialog_cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: Text(t.dialog_delete),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    bool supported = true;
+    bool failed = false;
+    try {
+      supported = await backend.deleteRemoteVideo(video.id);
+    } catch (e, stack) {
+      failed = true;
+      ErrorLogService.instance.log('HomeVideoPage.deleteRemoteVideo', e, stack);
+    }
+    if (!mounted) return;
+    if (failed) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.remote_delete_failed)),
+      );
+    } else if (!supported) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.remote_delete_unsupported)),
+      );
+    }
+    // 删成功才需要重取清单；失败时列表本就没变。forceRefresh 绕过远端库缓存 TTL，
+    // 否则刚删掉的视频会在 TTL 内继续显示成幽灵卡片。
+    if (!failed && supported) {
+      setState(() {
+        _remoteFuture = _loadRemoteVideos(forceRefresh: true);
+      });
+    }
   }
 
   /// 展示远端视频的基本元数据（标题 + 大小 + 字幕有无）。纯信息弹窗。

--- a/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/remote.part.dart
@@ -267,41 +267,38 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
     );
   }
 
-  /// 删除互联后端上的远端书（含其有声书），删完刷新远端列表。仅互联后端可达
+  /// 删除互联后端上的远端书（含其有声书），删完强制刷新远端列表。仅互联后端可达
   /// （[InterconnectSyncBackend.deleteRemoteBook] / [deleteRemoteAudiobook]）。
+  ///
+  /// 身份键统一用 [RemoteBookInfo.downloadId]（= `bookKey ?? title`），与下载 / 有声书
+  /// 删除同键（BUG-414 定下的纪律）。host 端 `_findBookByTitleOrKey` 两种键都能命中，
+  /// 故对老 host 也安全；此前这里单独传 `book.title` 属遗漏。
   Future<void> _confirmDeleteRemoteBook(
     RemoteBookInfo book,
     InterconnectSyncBackend backend,
   ) async {
-    final bool? confirmed = await showAppDialog<bool>(
-      context: context,
-      builder: (BuildContext dialogContext) => AlertDialog(
-        title: Text(book.title),
-        content: Text(t.sync_compare_delete_confirm(name: book.title)),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, false),
-            child: Text(t.dialog_cancel),
-          ),
-          TextButton(
-            onPressed: () => Navigator.pop(dialogContext, true),
-            child: Text(t.dialog_delete),
-          ),
-        ],
-      ),
-    );
+    final bool? confirmed = await _confirmRemoteDelete(book.title);
     if (confirmed != true) return;
+    bool failed = false;
     try {
-      await backend.deleteRemoteBook(book.title);
+      await backend.deleteRemoteBook(book.downloadId);
       if (book.hasAudiobook) {
         await backend.deleteRemoteAudiobook(book.downloadId);
       }
     } catch (e, stack) {
+      failed = true;
       ErrorLogService.instance
           .log('ReaderHibikiHistoryPage.deleteRemoteBook', e, stack);
     }
     if (!mounted) return;
-    _refreshRemoteBooks();
+    // 失败必须给可见提示：原实现只写日志就刷新列表，书还在原处、用户以为自己看错了。
+    if (failed) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.remote_delete_failed)),
+      );
+      return;
+    }
+    _forceRefreshRemoteBooks();
   }
 
   /// 远端书卡左上角类型徽章：有有声书 → 耳机徽章（与本地 _audiobookBadge 同色，
@@ -739,10 +736,16 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
   }
 
   /// 长按 / 桌面右键纯 SRT 远端占位卡：弹与远端 EPUB 卡一致的动作面板
-  /// （[MediaItemDialogFrame] 复用）。唯一动作是「下载」（远端占位无本地副本；
-  /// 互联删除 API 面向 EPUB 关联包，standalone SRT 不接删除，真实能力边界）。
+  /// （[MediaItemDialogFrame] 复用）。
+  ///
+  /// 动作：「下载」+「删除」。此处曾注明「互联删除 API 面向 EPUB 关联包，standalone
+  /// SRT 不接删除，真实能力边界」——那条描述偏保守：`DELETE /api/library/audiobooks/
+  /// <identity>` 的 host 端 identity 解析同时查 `Audiobooks(bookKey)` 与 `SrtBooks(uid)`，
+  /// 传 uid 本就能命中，缺的只是这个 UI 入口。
   void _showRemoteSrtDialog(RemoteAudiobookInfo book) {
     final String title = book.title ?? book.identity;
+    final RemoteBookClient? client = _remoteBookClient;
+    final bool canDelete = client is InterconnectSyncBackend;
     showAppDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) => MediaItemDialogFrame(
@@ -759,8 +762,75 @@ extension _ReaderHistoryRemote on _ReaderHibikiHistoryPageState {
             },
           ),
         ],
+        dangerActions: <DialogDangerAction>[
+          if (canDelete)
+            DialogDangerAction(
+              label: t.dialog_delete,
+              onPressed: () {
+                Navigator.pop(dialogContext);
+                _confirmDeleteRemoteSrt(book, client);
+              },
+            ),
+        ],
       ),
     );
+  }
+
+  /// 删除互联对端 host 上的纯 SRT 有声书（身份键 = uid），删完强制刷新远端列表。
+  /// 反馈与 [_confirmDeleteRemoteBook] 同款：失败必给可见提示，不静默。
+  Future<void> _confirmDeleteRemoteSrt(
+    RemoteAudiobookInfo book,
+    InterconnectSyncBackend backend,
+  ) async {
+    final String title = book.title ?? book.identity;
+    final bool? confirmed = await _confirmRemoteDelete(title);
+    if (confirmed != true) return;
+    bool failed = false;
+    try {
+      await backend.deleteRemoteAudiobook(book.identity);
+    } catch (e, stack) {
+      failed = true;
+      ErrorLogService.instance
+          .log('ReaderHibikiHistoryPage.deleteRemoteSrt', e, stack);
+    }
+    if (!mounted) return;
+    if (failed) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.remote_delete_failed)),
+      );
+      return;
+    }
+    _forceRefreshRemoteBooks();
+  }
+
+  /// 远端删除的统一二次确认框（文案明说「从远端删除、本地保留、不可撤销」）。
+  Future<bool?> _confirmRemoteDelete(String name) {
+    return showAppDialog<bool>(
+      context: context,
+      builder: (BuildContext dialogContext) => AlertDialog(
+        title: Text(name),
+        content: Text(t.sync_compare_delete_confirm(name: name)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, false),
+            child: Text(t.dialog_cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext, true),
+            child: Text(t.dialog_delete),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 远端删除后的列表重取：**必须** forceRefresh 穿透 [RemoteLibraryCache] 的 TTL。
+  /// 非强制的 [_refreshRemoteBooks] 会命中缓存，让刚删掉的条目在 TTL 内继续显示成
+  /// 幽灵卡片（远端书删除的既有毛病）。
+  void _forceRefreshRemoteBooks() {
+    _rebuild(() {
+      _remoteBooksFuture = _loadRemoteBooks(forceRefresh: true);
+    });
   }
 
   /// 下载纯 SRT 远端有声书：`getRemoteAudiobook(identity=uid)` 拉 `.hibikiaudio` 包 →

--- a/hibiki/lib/src/sync/app_model_library_host_service.dart
+++ b/hibiki/lib/src/sync/app_model_library_host_service.dart
@@ -50,6 +50,7 @@ class AppModelLibraryHostService
     implements
         HibikiLibraryHostService,
         DeletionTombstoneHost,
+        VideoDeletionHost,
         InterconnectServiceConfigHost {
   AppModelLibraryHostService({
     required HibikiDatabase db,
@@ -59,6 +60,7 @@ class AppModelLibraryHostService
     required Future<void> Function(Future<void> Function() body) runExclusive,
     Future<void> Function(File epubFile)? importBookFromFile,
     Future<void> Function(EpubBookRow row)? cleanupBookOnDisk,
+    Future<void> Function(VideoBookRow row)? cleanupVideoOnDisk,
     List<LocalAudioDbEntry> localAudioEntries = const <LocalAudioDbEntry>[],
     Directory? localAudioStagingDir,
     Future<void> Function(LocalAudioPackageContents)? onLocalAudioImported,
@@ -76,6 +78,7 @@ class AppModelLibraryHostService
         _runExclusive = runExclusive,
         _importBookFromFile = importBookFromFile,
         _cleanupBookOnDisk = cleanupBookOnDisk,
+        _cleanupVideoOnDisk = cleanupVideoOnDisk,
         _localAudioEntries = localAudioEntries,
         _localAudioStagingDir = localAudioStagingDir,
         _onLocalAudioImported = onLocalAudioImported,
@@ -106,6 +109,11 @@ class AppModelLibraryHostService
   /// 书籍磁盘清理回调（可选；null 时只执行 DB 删除，跳过 AudiobookStorage/SrtBook 清理）。
   /// 生产传 ReaderHibikiSource 实例的磁盘清理部分。
   final Future<void> Function(EpubBookRow row)? _cleanupBookOnDisk;
+
+  /// 视频磁盘清理回调（可选；null 时只执行 DB 删除 + 上传副本目录回收）。
+  /// 生产传 `VideoBookRepository.reclaimDeletedVideoBookAssets` 的等价闭包——它按
+  /// 「仍在 app 资产目录内 + 无其它条目引用」回收封面 / 字幕缓存，**不碰原始视频文件**。
+  final Future<void> Function(VideoBookRow row)? _cleanupVideoOnDisk;
 
   // ── 本地音频（T3.1）──────────────────────────────────────────────────────
 
@@ -1265,6 +1273,68 @@ class AppModelLibraryHostService
   Future<bool> videoExists(String id) async {
     _assertSafeVideoId(id);
     return (await _db.getVideoBookByBookUid(id)) != null;
+  }
+
+  /// 从 host 视频库删除 bookUid 为 [id] 的视频（[VideoDeletionHost]）。
+  ///
+  /// 与 host 用户在自己视频库长按删除同语义（镜像 `VideoBookRepository.deleteVideoBook`
+  /// + `reclaimDeletedVideoBookAssets`）：DB 行 + 字幕 cue + 合集引用 + 删除墓碑，磁盘侧
+  /// **只回收 app 自己拥有的字节**。用户自己导入的原始视频文件绝不删除。
+  @override
+  Future<void> deleteVideo(String id) async {
+    _assertSafeVideoId(id);
+    await _runExclusive(() async {
+      final VideoBookRow? row = await _db.getVideoBookByBookUid(id);
+      if (row == null) return; // 幂等：不存在则静默跳过
+
+      // DB 事务：删 VideoBooks 行 + 本视频的 audio_cues（标签映射经 FK cascade）。
+      await _db.deleteVideoBook(id);
+      // 统一合集：删条目时清其全部合集引用（逻辑外键无 DB cascade），镜像本地
+      // 删除路径，避免留孤儿成员 / 合集卡数量虚高。
+      await _db.removeEntryFromAllCollections(MediaKind.video, id);
+      // 记删除墓碑：host 的其它已配对设备下次同步会拉到并逐条确认删除，使
+      // 「从所有设备删除」在 client→host→其它 client 链路上闭合。best-effort。
+      try {
+        await _db.writeSyncDeletionTombstone(
+          SyncTombstoneKind.video.dbValue,
+          id,
+          DateTime.now().millisecondsSinceEpoch,
+        );
+      } catch (_) {
+        // best-effort：记账失败不影响视频已删。
+      }
+
+      // 磁盘回收，两条都只碰「能证明是 app 自己写进来的」字节：
+      // ① client 上传副本目录（本 host 自己按 uid 建的，见 importVideo）。
+      await _deleteUploadedVideoCopy(row);
+      // ② 封面 / 字幕缓存交注入回调（与 deleteBook 的 cleanupBookOnDisk 同构，生产接
+      //    VideoBookRepository.reclaimDeletedVideoBookAssets，其内部有「仍在 app 资产
+      //    目录内 + 无其它条目引用」双重判据）。
+      try {
+        await _cleanupVideoOnDisk?.call(row);
+      } catch (_) {
+        // best-effort：磁盘回收失败不影响 DB 已删。
+      }
+    });
+  }
+
+  /// 删除 client 上传副本目录——当且仅当该行的 `videoPath` 确实落在本 host 的
+  /// `<uploadedVideoRoot>/<safeUid>/` 之内。
+  ///
+  /// host 用户自己导入的原片不在这个目录下，所以这条 [p.isWithin] 判据就是
+  /// 「这些字节是 app 自己搬进来的」的证明；判据不成立时一个字节都不动。
+  Future<void> _deleteUploadedVideoCopy(VideoBookRow row) async {
+    final Directory? root = _uploadedVideoRoot;
+    if (root == null) return;
+    final Directory owned =
+        Directory(p.join(root.path, _sanitizeVideoIdForPath(row.bookUid)));
+    if (!owned.existsSync()) return;
+    if (!p.isWithin(owned.path, row.videoPath)) return;
+    try {
+      await owned.delete(recursive: true);
+    } catch (_) {
+      // best-effort：目录被占用等失败不影响 DB 已删。
+    }
   }
 
   /// 接收 client 上传的单文件视频并注册进 host 视频库（client→host live push）。

--- a/hibiki/lib/src/sync/hibiki_library_host_service.dart
+++ b/hibiki/lib/src/sync/hibiki_library_host_service.dart
@@ -1457,3 +1457,26 @@ abstract interface class DeletionTombstoneHost {
   Future<List<({String mediaType, String itemKey, int deletedAt})>>
       listDeletionTombstones();
 }
+
+/// host 端「删除视频」的**可选**能力（client→host 删除方向）。
+///
+/// 与 [HibikiLibraryHostService] 分开的理由同 [DeletionTombstoneHost]：主接口有十余个
+/// 测试 fake 用 `implements` 全量实现，往主接口加方法会强制它们全部补桩（Never break
+/// userspace）。书 / 有声书 / 本地音频 / 词典的 delete 是主接口的历史既成事实，新增的
+/// 视频删除不再扩大那个面。
+///
+/// server 用 `is` 探测——host 不实现就让 `DELETE /api/library/videos/<id>` 落 404，
+/// client 侧 [RemoteVideoDeletionClient.deleteRemoteVideo] 已按 404/405 优雅降级
+/// （旧版本 host 天然如此）。
+abstract interface class VideoDeletionHost {
+  /// 从 host 视频库删除 bookUid 为 [id] 的视频。
+  ///
+  /// 语义与 host 用户在自己视频库里长按删除**完全一致**：删 `VideoBooks` 行 + 其字幕
+  /// cue、清合集引用、记删除墓碑（供 host 的其它已配对设备继续传播），磁盘侧**只回收
+  /// app 自己拥有的文件**——client 上传副本目录、封面 / 字幕缓存。
+  /// **用户自己导入的原始视频文件绝不删除**（本地删除路径同此约束，见
+  /// `VideoBookRepository.reclaimDeletedVideoBookAssets`）。
+  ///
+  /// 幂等：[id] 不存在时静默返回。[id] 含路径穿越字符时抛 [ArgumentError]。
+  Future<void> deleteVideo(String id);
+}

--- a/hibiki/lib/src/sync/hibiki_sync_server.dart
+++ b/hibiki/lib/src/sync/hibiki_sync_server.dart
@@ -1615,6 +1615,26 @@ class HibikiSyncServer {
     return id;
   }
 
+  /// 裸视频 id（`/api/library/videos/<id>`，**无** suffix）的提取 + 穿越校验。
+  ///
+  /// PUT（client→host 上传）与 DELETE（client→host 删除）共用这一处：两者都只接
+  /// 「裸 id」，带 suffix 的子路由（cover / streamurl / stream / subtitle / position /
+  /// clipaudio）在上方已被 [_extractVideoId] 消化掉。
+  ///
+  /// 收敛成函数而不是在每个端点里手抄穿越判断——安全闸门靠复制粘贴维持，抄漏一处
+  /// 就是真漏洞（同 [_rejectUnsafeAssetId] 的教训，守卫见
+  /// `test/sync/hibiki_sync_server_asset_gate_test.dart`，它按纯文本计数穿越判断的
+  /// 出现次数，所以正文注释里也不要写那个字面量）。视频域不能用那道资产闸门是因为
+  /// 它禁 `/`，而视频 bookUid 合法含 `/`。
+  static String? _extractBareVideoId(String reqPath) {
+    const String prefix = '/api/library/videos/';
+    if (!reqPath.startsWith(prefix)) return null;
+    final String id = reqPath.substring(prefix.length);
+    if (id.isEmpty) return null;
+    if (id.contains('..') || id.contains('\\')) return null;
+    return id;
+  }
+
   /// GET /api/library/activity — host 最近活动事件（新首页 Activity 面板的互联
   /// 数据源；display-only，client 不落库）。limit 参数钳制 1..500。老 client 不知
   /// 道此端点、老 host 对此路径 404（client 侧优雅降级为空列表）。
@@ -1909,9 +1929,8 @@ class HibikiSyncServer {
     // （bookUid 形如 video/xxx），但拒 `..` / `\`（路径穿越）。title / 原始文件名经
     // URL-encode 走 header（HTTP header 只收 ASCII，日文标题必须编码）。
     if (method == 'PUT' && reqPath.startsWith('/api/library/videos/')) {
-      const String prefix = '/api/library/videos/';
-      final String id = reqPath.substring(prefix.length);
-      if (id.isEmpty || id.contains('..') || id.contains('\\')) {
+      final String? id = _extractBareVideoId(reqPath);
+      if (id == null) {
         return shelf.Response(400, body: 'Invalid video id');
       }
       final String title =
@@ -1941,6 +1960,33 @@ class HibikiSyncServer {
         } catch (_) {
           // best-effort
         }
+      }
+    }
+
+    // DELETE /api/library/videos/<id> — client→host 删除远端视频。两个来源：远端视频卡
+    // 长按「删除」，以及本机删除时选了「从所有设备删除」后同步把墓碑推给 host。
+    // 与 PUT 同样只接「裸 id 无 suffix」（带 suffix 的端点已在上方消化）。
+    //
+    // host 未实现 [VideoDeletionHost]（旧版本 app / 测试 fake）时**不接管**，落到下方
+    // 404 —— 这正是 client 侧的能力探测信号，[InterconnectSyncBackend.deleteRemoteVideo]
+    // 按 404/405 判「该 host 不支持」并优雅降级，不报错给用户。
+    // 204 与其它资产链的 DELETE（[_serveAssetPackage]）保持同一成功码。
+    if (method == 'DELETE' && reqPath.startsWith('/api/library/videos/')) {
+      final String? id = _extractBareVideoId(reqPath);
+      if (id == null) {
+        return shelf.Response(400, body: 'Invalid video id');
+      }
+      // 显式 `as` 而不是靠类型提升：[VideoDeletionHost] 不是 [HibikiLibraryHostService]
+      // 的子类型，Dart 不做交集提升（写 `svc.deleteVideo` 会报未定义）。与
+      // [DeletionTombstoneHost] 的探测写法一致。
+      if (svc is! VideoDeletionHost) {
+        return shelf.Response.notFound('Video deletion not supported');
+      }
+      try {
+        await (svc as VideoDeletionHost).deleteVideo(id);
+        return shelf.Response(204);
+      } catch (e) {
+        return shelf.Response(500, body: 'Video delete failed: $e');
       }
     }
 

--- a/hibiki/lib/src/sync/interconnect_sync_backend.dart
+++ b/hibiki/lib/src/sync/interconnect_sync_backend.dart
@@ -1313,6 +1313,27 @@ class InterconnectSyncBackend extends SyncBackend
     _ops!.checkStatus(res.statusCode, 'PUT /api/library/videos/$id');
   }
 
+  /// 通知对端 host 删除 bookUid 为 [id] 的视频（远端视频卡长按删除 / 「从所有设备
+  /// 删除」的墓碑推送）。
+  ///
+  /// 返回 true = host 已删除；false = 该 host 不支持视频删除（旧版本 app 无此端点，
+  /// 或 host 库服务未实现 `VideoDeletionHost`，两者都表现为 404/405）。调用方据此
+  /// 区分「删成了」与「对端不支持」——后者不该报错给用户、也不该标记墓碑已发布，
+  /// 留待 host 升级后下次同步重试。其余失败照常抛（[WebDavOps.checkStatus]），
+  /// 与 [putRemoteVideoSubtitle] 的旧 host 降级同款。
+  Future<bool> deleteRemoteVideo(String id) async {
+    await _ensureResolved();
+    final HttpClientRequest req = await _ops!.buildRequest(
+      'DELETE',
+      '$_apiBase/api/library/videos/${_encodeVideoId(id)}',
+    );
+    final HttpClientResponse res = await req.close();
+    await res.drain<void>();
+    if (res.statusCode == 404 || res.statusCode == 405) return false;
+    _ops!.checkStatus(res.statusCode, 'DELETE /api/library/videos/$id');
+    return true;
+  }
+
   /// 把视频 [id] 的一个外挂字幕 sidecar [file] 推给 host（BUG-964，随
   /// [putRemoteVideo] 的 live push 一起走）。[suffix] 是相对视频 stem 的字幕后缀
   /// （`.srt` / `.ja.srt` …，host 端按自己的视频文件名 stem + suffix 落盘）。

--- a/hibiki/lib/src/sync/sync_orchestrator.dart
+++ b/hibiki/lib/src/sync/sync_orchestrator.dart
@@ -1293,16 +1293,30 @@ class SyncOrchestrator {
     }
   }
 
-  /// 删除墓碑同步（互联 host API 通道）。GET host 墓碑（老 host 404 → null 优雅跳过）→
-  /// 与本地在库键求交 deleteLocal 候选 → 过基线守卫 → 塞 report。与云
-  /// [syncDeletionTombstones] 同消费语义；互联为 GET-only（host→client 方向），client
-  /// 自身删除不经此推给 host（各端自行确认删除，见蓝图）。
+  /// 删除墓碑同步（互联 host API 通道），**双向**：
+  ///
+  /// 1. 推送（client→host，[_pushDeletionTombstonesLive]）：把本机「从所有设备删除」
+  ///    产生的墓碑真的删到对端 host 上。host 自己的 delete 会写它自己的墓碑，于是
+  ///    第三台设备下轮照常收到确认提示——链路闭合。
+  /// 2. 消费（host→client）：GET host 墓碑（老 host 404 → null 优雅跳过）→ 与本地在库键
+  ///    求交 deleteLocal 候选 → 过基线守卫 → 塞 report，UI 弹逐条确认。
+  ///
+  /// 此处曾是 GET-only（注释原文「client 自身删除不经此推给 host，各端自行确认删除」），
+  /// 后果是勾了「从所有设备删除」对互联对端完全无效——墓碑只留在本地表里没人发布。
+  /// 消费语义仍与云 [syncDeletionTombstones] 一致；推送是互联独有（云通道的对应动作是
+  /// 往 `__tombstones__` 写标记，两者各记各的基线，见
+  /// [SyncRepository.getDeletionTombstonesPushBaselineMs]）。
   Future<void> _syncDeletionTombstonesLive(
     SyncRunReport report,
     InterconnectSyncBackend backend,
   ) async {
     try {
       final int nextBaseline = DateTime.now().millisecondsSinceEpoch;
+      // 先推后拉：本机的删除意图先发出去，再看对端有什么要删的。两步共用同一个
+      // nextBaseline（预取，防 IO 期间时钟漂移造成窗口空洞）。推送整段自带 try，
+      // 失败不挡消费。
+      await _pushDeletionTombstonesLive(report, backend, nextBaseline);
+
       final List<({String mediaType, String itemKey, int deletedAt})>? remote =
           await backend.getRemoteDeletionTombstones();
       if (remote == null) return; // 老 host 无 /api/tombstones 端点，优雅跳过。
@@ -1343,6 +1357,121 @@ class SyncOrchestrator {
       }
     } catch (e) {
       report.noteError('deletion tombstones live sync', e);
+    }
+  }
+
+  /// 把本机未推送的删除墓碑推给对端 host（client→host，「从所有设备删除」的落地端）。
+  ///
+  /// 墓碑只在用户显式选 [DeleteScope.syncEverywhere] 时才写（各实体删除路径的门控），
+  /// 所以走到这里的每一条都是用户明确要求「所有设备都删」的条目——推送不需要再问一次。
+  ///
+  /// 因果轴用 [SyncRepository.getDeletionTombstonesPushBaselineMs]：只推
+  /// `baseline < deletedAt <= nextBaseline` 的墓碑，整批成功才推进基线。**不碰墓碑行上的
+  /// `remotePublishedAt`**——那是云通道 `__tombstones__` 的账，互联去标它会让同时配了云
+  /// 备份的设备永远跳过这条、只连云的第三台设备再也收不到这次删除。
+  ///
+  /// 两类失败区别对待：
+  /// * **异常**（网络 / host 5xx）→ 不推进基线，下轮整批重试。这类失败通常是整体性的
+  ///   （断网），整批重试正是想要的；DELETE 端点幂等，重推已成功的无害。
+  /// * **host 不支持**（视频 DELETE 端点 404/405 = 对端版本过旧）→ 记 `report.errors`
+  ///   但**不**阻塞基线。能力缺失不是暂时性故障，为它永久卡住基线会让书 / 有声书的
+  ///   删除每轮无谓重推。代价是对端升级前的这条视频删除会漏掉——UI 侧长按删除路径会
+  ///   直接提示「对端版本过旧」，同步路径则留在日志里。
+  Future<void> _pushDeletionTombstonesLive(
+    SyncRunReport report,
+    InterconnectSyncBackend backend,
+    int nextBaseline,
+  ) async {
+    try {
+      final SyncRepository repo = SyncRepository(_db);
+      int baseline = await repo.getDeletionTombstonesPushBaselineMs();
+      // 时钟回拨钳制：基线晚于本轮取的 now 时按 now 算，否则一次回拨会把窗口永久关死。
+      if (baseline > nextBaseline) baseline = nextBaseline;
+
+      final List<SyncDeletionTombstoneRow> rows =
+          await _db.getSyncDeletionTombstones();
+      bool retryable = false;
+      for (final SyncDeletionTombstoneRow row in rows) {
+        // 窗口两端都要卡：晚于 nextBaseline 的（本地时钟超前写出的未来戳）留到下轮，
+        // 否则推进基线会把它一并盖掉、这条删除就此蒸发。
+        if (row.deletedAt <= baseline || row.deletedAt > nextBaseline) continue;
+        final SyncTombstoneKind? kind =
+            SyncTombstoneKind.tryParse(row.mediaType);
+        // 未知 kind = 比本端新的版本写的墓碑，本端不认识就别猜着删（前向兼容）。
+        if (kind == null) continue;
+        if (!_hasInterconnectDeletionChannel(kind)) continue;
+        try {
+          final bool supported =
+              await _pushOneDeletionLive(backend, kind, row.itemKey);
+          if (!supported) {
+            report.errors.add(
+              'host does not support deleting ${row.mediaType} '
+              '"${row.itemKey}" (peer app too old); skipped',
+            );
+          }
+        } catch (e) {
+          retryable = true;
+          report.noteError(
+            'deletion push ${row.mediaType}/${row.itemKey}',
+            e,
+          );
+        }
+      }
+      if (!retryable) {
+        await repo.setDeletionTombstonesPushBaselineMs(nextBaseline);
+      }
+    } catch (e) {
+      report.noteError('deletion tombstones live push', e);
+    }
+  }
+
+  /// 该 kind 在互联 live 通道上有没有删除端点。
+  ///
+  /// 收藏词 / 收藏句没有：它们经聚合快照通道同步，而 `applyAggregateSnapshot` 按设计
+  /// 只做 MAX / 并集（删除不跨端传播）。这里如实跳过——不假装推过（那会静默丢删除），
+  /// 也不算作失败（那会为一件永远做不成的事永久卡住基线）。
+  static bool _hasInterconnectDeletionChannel(SyncTombstoneKind kind) {
+    switch (kind) {
+      case SyncTombstoneKind.book:
+      case SyncTombstoneKind.audiobook:
+      case SyncTombstoneKind.srtbook:
+      case SyncTombstoneKind.localaudio:
+      case SyncTombstoneKind.video:
+        return true;
+      case SyncTombstoneKind.favoriteword:
+      case SyncTombstoneKind.favoritesentence:
+        return false;
+    }
+  }
+
+  /// 按 kind 分派到对应的 host 删除端点。返回 host 是否支持该删除（false = 对端版本
+  /// 过旧，端点 404/405）；其余失败照常抛给调用方计入 retryable。
+  ///
+  /// 纯字幕书（srtbook）与有声书共用 `DELETE /api/library/audiobooks/<identity>`：host
+  /// 端 identity 解析同时查 `Audiobooks(bookKey)` 与 `SrtBooks(uid)`，两种键都能命中。
+  Future<bool> _pushOneDeletionLive(
+    InterconnectSyncBackend backend,
+    SyncTombstoneKind kind,
+    String itemKey,
+  ) async {
+    switch (kind) {
+      case SyncTombstoneKind.book:
+        await backend.deleteRemoteBook(itemKey);
+        return true;
+      case SyncTombstoneKind.audiobook:
+      case SyncTombstoneKind.srtbook:
+        await backend.deleteRemoteAudiobook(itemKey);
+        return true;
+      case SyncTombstoneKind.localaudio:
+        await backend.deleteRemoteLocalAudio(itemKey);
+        return true;
+      case SyncTombstoneKind.video:
+        // 唯一会如实报「不支持」的一条：视频删除端点是本次新增的，旧 host 没有。
+        return backend.deleteRemoteVideo(itemKey);
+      case SyncTombstoneKind.favoriteword:
+      case SyncTombstoneKind.favoritesentence:
+        // [_hasInterconnectDeletionChannel] 已挡在前面，走不到这里。
+        return true;
     }
   }
 

--- a/hibiki/lib/src/sync/sync_repository.dart
+++ b/hibiki/lib/src/sync/sync_repository.dart
@@ -100,6 +100,18 @@ class SyncRepository {
   // 设备本地（[deviceLocalPrefKeys]）：随备份跨设备会让新设备把老墓碑误判为新闻反复弹。
   static const _keyDeletionTombstonesBaselineMs =
       'sync_deletion_tombstones_baseline_ms';
+  // 删除墓碑**推送**的因果基线（互联通道专用，与上面的消费基线镜像对称）：描述
+  // 「本设备已把删除推给对端 host 到什么时刻」。deletedAt 晚于它的墓碑才需要推。
+  //
+  // 为什么不复用墓碑行上的 `remotePublishedAt`：那个字段的语义是「已写进云端
+  // `__tombstones__` 资产」。互联推送去标它，会让同时配了云备份的设备在云通道
+  // `syncDeletionTombstones` 的 `remotePublishedAt == 0` 过滤里永远跳过这条——只连
+  // 云的第三台设备就再也收不到这次删除了。两个通道各记各的账。
+  //
+  // 设备本地（[deviceLocalPrefKeys]）：随备份跨设备会让新设备以为自己已经推过一批
+  // 它从没连过的 host。
+  static const _keyDeletionTombstonesPushBaselineMs =
+      'sync_deletion_tombstones_push_baseline_ms';
   static const _keyDesktopCredentials = 'sync_desktop_credentials';
   static const _keyBackendType = 'sync_backend_type';
   // 「与 Hoshi/ッツ 共享」开关：开启后 Google Drive 后端改用可见 My Drive /
@@ -246,6 +258,22 @@ class SyncRepository {
 
   Future<void> setDeletionTombstonesBaselineMs(int ms) =>
       _setString(_keyDeletionTombstonesBaselineMs, ms.toString());
+
+  /// 删除墓碑**推送**的因果基线（毫秒，互联通道专用）。本地墓碑 deletedAt 晚于它才
+  /// 推给对端 host；早于它视为本设备已推过、不再重复请求。0 = 从未推送过。
+  ///
+  /// 单一全局键（不按 host 分）：互联是 host/client 模型且 client 侧后端是单例
+  /// [InterconnectSyncBackend.instance]，实际只对一个 host 推送；消费侧基线
+  /// （[getDeletionTombstonesBaselineMs]）也是同样的全局口径，两侧保持一致。
+  /// 设备本地（[deviceLocalPrefKeys]），理由见键定义处注释。
+  Future<int> getDeletionTombstonesPushBaselineMs() async {
+    final String? s =
+        await _getStringOrNull(_keyDeletionTombstonesPushBaselineMs);
+    return s == null ? 0 : int.tryParse(s) ?? 0;
+  }
+
+  Future<void> setDeletionTombstonesPushBaselineMs(int ms) =>
+      _setString(_keyDeletionTombstonesPushBaselineMs, ms.toString());
 
   // ── 增量同步索引（`__index__`，TODO-2656） ─────────────────────────
   //
@@ -965,6 +993,9 @@ class SyncRepository {
     _keyCollectionsBaselineMs,
     // 删除墓碑消费基线：同理设备本地，跨设备携带会让新设备反复弹老墓碑确认框。
     _keyDeletionTombstonesBaselineMs,
+    // 删除墓碑推送基线：同理设备本地，跨设备携带会让新设备以为自己已经把一批删除
+    // 推给过一个它从没连过的 host（漏推 = 对端该删的没删）。
+    _keyDeletionTombstonesPushBaselineMs,
     // 增量同步索引缓存：本端对**某一个特定远端**的观测。跨设备携带会让新设备
     // 以为自己已经看过一个它从没连过的远端，据此跳过真正该拉的书（漏同步）。
     'sync_index_manifest_cache_cloud',

--- a/hibiki/test/sync/interconnect_delete_push_test.dart
+++ b/hibiki/test/sync/interconnect_delete_push_test.dart
@@ -1,0 +1,317 @@
+/// 「从所有设备删除」在互联通道上的 **client→host 推送**端到端测试。
+///
+/// 覆盖 [SyncOrchestrator]._pushDeletionTombstonesLive + 新增的视频删除四层
+/// （[VideoDeletionHost] / `DELETE /api/library/videos/<id>` /
+/// [InterconnectSyncBackend.deleteRemoteVideo]）。
+///
+/// 此前互联通道是 GET-only：client 勾了「从所有设备删除」只在本地写一条墓碑，没有任何
+/// 人发布，对端 host 完全不受影响。这些用例钉住修复后的行为，以及三条不能被后续改动
+/// 破坏的不变量：
+/// 1. host 用户**自己导入的原始视频文件不删**（只回收 app 自己拥有的字节）；
+/// 2. 互联推送**不碰墓碑行的 `remotePublishedAt`**（那是云通道的账，污染它会让只连云的
+///    第三台设备永远收不到这次删除）；
+/// 3. host 删除后写自己的墓碑，链路能继续传播到第三台设备。
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:drift/drift.dart' hide isNull, isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/sync/app_model_library_host_service.dart';
+import 'package:hibiki/src/sync/hibiki_library_host_service.dart';
+import 'package:hibiki/src/sync/hibiki_sync_server.dart';
+import 'package:hibiki/src/sync/interconnect_sync_backend.dart';
+import 'package:hibiki/src/sync/sync_asset_package_service.dart';
+import 'package:hibiki/src/sync/sync_backend.dart';
+import 'package:hibiki/src/sync/sync_orchestrator.dart';
+import 'package:hibiki/src/sync/sync_repository.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:path/path.dart' as p;
+
+HibikiDatabase _memDb() =>
+    HibikiDatabase.forTesting(DatabaseConnection(NativeDatabase.memory()));
+
+/// 旧版本 host：实现主接口但**不**实现 [VideoDeletionHost]，用来钉能力探测降级。
+/// DELETE 路由在调 deleteVideo 之前就 `is!` 判掉并返 404，故这里一个方法都不用真写。
+class _LegacyHostWithoutVideoDelete implements HibikiLibraryHostService {
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName} not needed here');
+}
+
+Future<InterconnectSyncBackend> _buildClientBackend({
+  required String base,
+  required String token,
+}) async {
+  final HibikiDatabase db = _memDb();
+  addTearDown(db.close);
+  final SyncRepository repo = SyncRepository(db);
+  await repo.setHibikiClientUrls(<HibikiClientUrl>[
+    HibikiClientUrl(url: base, enabled: true),
+  ]);
+  await repo.setHibikiClientToken(token);
+  final InterconnectSyncBackend backend =
+      InterconnectSyncBackend.withProbe((String u, String t) async => true);
+  await backend.restoreAuth(repo);
+  await backend.authenticate(repo: repo);
+  return backend;
+}
+
+SyncOrchestrator _orchestrator({
+  required HibikiDatabase db,
+  required SyncBackend backend,
+  required Directory tmp,
+}) =>
+    SyncOrchestrator(
+      db: db,
+      backend: backend,
+      dictionaryResourceRoot: tmp,
+      audioDatabaseRoot: tmp,
+      tempDir: tmp,
+      syncStats: false,
+      syncAudioBookPosition: false,
+      syncContent: false,
+      syncAudioBookFiles: false,
+      syncVideoFiles: false,
+      syncDictionary: false,
+      syncLocalAudio: false,
+    );
+
+void main() {
+  late Directory work;
+  late HibikiSyncServer server;
+  late HibikiDatabase hostDb;
+  late Directory hostUploads;
+  late String base;
+  const String token = 'delete-push-token';
+
+  /// host 用户自己导入的原片（**不在** uploadedVideoRoot 下）。
+  late File hostOwnVideo;
+
+  setUp(() async {
+    work = await Directory.systemTemp.createTemp('delete_push_');
+    hostDb = _memDb();
+    hostUploads = Directory(p.join(work.path, 'host_uploads'))
+      ..createSync(recursive: true);
+    hostOwnVideo = File(p.join(work.path, 'my_own_movie.mp4'))
+      ..writeAsBytesSync(<int>[9, 9, 9, 9]);
+    final AppModelLibraryHostService libSvc = AppModelLibraryHostService(
+      db: hostDb,
+      dictionaryResourceRoot: Directory(work.path),
+      packages: SyncAssetPackageService(db: hostDb),
+      refreshDictionaryCache: () async {},
+      runExclusive: (Future<void> Function() body) => body(),
+      uploadedVideoRoot: hostUploads,
+    );
+    server = HibikiSyncServer(
+      syncDataDir: p.join(work.path, 'server_data'),
+      port: 0,
+      token: token,
+      allowLan: false,
+      libraryService: libSvc,
+    );
+    await server.start();
+    base = 'http://127.0.0.1:${server.port}';
+  });
+
+  tearDown(() async {
+    await server.stop();
+    await hostDb.close();
+    if (work.existsSync()) await work.delete(recursive: true);
+  });
+
+  test('client 删视频（syncEverywhere）推送到 host：库里没了，原始视频文件保留', () async {
+    // host 库里有这个视频，videoPath 指向 host 用户自己的原片。
+    await hostDb.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: 'video/mine',
+      title: 'Mine',
+      videoPath: hostOwnVideo.path,
+    ));
+
+    final HibikiDatabase localDb = _memDb();
+    addTearDown(localDb.close);
+    // 用户在 client 上选「从所有设备删除」→ 各删除路径写下这条墓碑。
+    final int deletedAt = DateTime.now().millisecondsSinceEpoch - 1000;
+    await localDb.writeSyncDeletionTombstone(
+      SyncTombstoneKind.video.dbValue,
+      'video/mine',
+      deletedAt,
+    );
+
+    final InterconnectSyncBackend backend =
+        await _buildClientBackend(base: base, token: token);
+    final SyncRunReport report = SyncRunReport();
+    await _orchestrator(db: localDb, backend: backend, tmp: work)
+        .syncDeletionTombstonesLiveForTest(report, backend);
+
+    // host 库里这条真的没了。
+    expect(await hostDb.allVideoBooks(), isEmpty);
+    // 不变量 ①：host 用户自己的原片一个字节都没动。删的是库条目，不是用户的媒体文件。
+    expect(hostOwnVideo.existsSync(), isTrue,
+        reason: '远端删除绝不能删掉 host 用户自己导入的原始视频文件');
+    expect(hostOwnVideo.readAsBytesSync(), <int>[9, 9, 9, 9]);
+    // 不变量 ③：host 写了自己的墓碑，第三台设备下轮同步照常收到确认提示。
+    final List<SyncDeletionTombstoneRow> hostTombs =
+        await hostDb.getSyncDeletionTombstones();
+    expect(
+      hostTombs
+          .where((SyncDeletionTombstoneRow r) =>
+              r.mediaType == SyncTombstoneKind.video.dbValue &&
+              r.itemKey == 'video/mine')
+          .length,
+      1,
+      reason: 'host 删除后必须记墓碑，否则删除传播在 host 这里断链',
+    );
+  });
+
+  test('推送不碰 remotePublishedAt：云通道的账不被互联污染', () async {
+    await hostDb.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: 'video/mine',
+      title: 'Mine',
+      videoPath: hostOwnVideo.path,
+    ));
+
+    final HibikiDatabase localDb = _memDb();
+    addTearDown(localDb.close);
+    await localDb.writeSyncDeletionTombstone(
+      SyncTombstoneKind.video.dbValue,
+      'video/mine',
+      DateTime.now().millisecondsSinceEpoch - 1000,
+    );
+
+    final InterconnectSyncBackend backend =
+        await _buildClientBackend(base: base, token: token);
+    await _orchestrator(db: localDb, backend: backend, tmp: work)
+        .syncDeletionTombstonesLiveForTest(SyncRunReport(), backend);
+
+    // 不变量 ②：互联推送成功后，墓碑行的 remotePublishedAt 必须仍是 0。
+    // 它一旦被标非 0，云通道 syncDeletionTombstones 的 `remotePublishedAt == 0` 过滤
+    // 就会永远跳过这条 —— 只连云备份的第三台设备再也收不到这次删除。
+    final List<SyncDeletionTombstoneRow> local =
+        await localDb.getSyncDeletionTombstones();
+    expect(local.single.remotePublishedAt, 0,
+        reason: '互联推送与云发布必须各记各的账（推送基线走 preferences）');
+    // 互联自己的账：推送基线已推进（下轮不再重推这条）。
+    expect(
+      await SyncRepository(localDb).getDeletionTombstonesPushBaselineMs(),
+      greaterThan(0),
+    );
+  });
+
+  test('推送后基线推进：第二轮不再重复删（host 已空也不报错）', () async {
+    await hostDb.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: 'video/mine',
+      title: 'Mine',
+      videoPath: hostOwnVideo.path,
+    ));
+    final HibikiDatabase localDb = _memDb();
+    addTearDown(localDb.close);
+    await localDb.writeSyncDeletionTombstone(
+      SyncTombstoneKind.video.dbValue,
+      'video/mine',
+      DateTime.now().millisecondsSinceEpoch - 1000,
+    );
+    final InterconnectSyncBackend backend =
+        await _buildClientBackend(base: base, token: token);
+    final SyncOrchestrator orch =
+        _orchestrator(db: localDb, backend: backend, tmp: work);
+
+    await orch.syncDeletionTombstonesLiveForTest(SyncRunReport(), backend);
+    final int firstBaseline =
+        await SyncRepository(localDb).getDeletionTombstonesPushBaselineMs();
+    expect(firstBaseline, greaterThan(0));
+
+    // host 这时又自己导入了同 uid 的视频（模拟「删后重加」）。第二轮推送必须**不**再删它
+    // ——那条墓碑的 deletedAt 已在基线之下，不再是新闻。
+    await hostDb.upsertVideoBook(VideoBooksCompanion.insert(
+      bookUid: 'video/mine',
+      title: 'Mine Again',
+      videoPath: hostOwnVideo.path,
+    ));
+    final SyncRunReport second = SyncRunReport();
+    await orch.syncDeletionTombstonesLiveForTest(second, backend);
+    expect((await hostDb.allVideoBooks()).length, 1,
+        reason: '基线之下的旧墓碑不该反复删掉 host 上重新加回来的条目');
+  });
+
+  test('收藏词/收藏句墓碑无互联删除通道：跳过且不阻塞基线推进', () async {
+    final HibikiDatabase localDb = _memDb();
+    addTearDown(localDb.close);
+    await localDb.writeSyncDeletionTombstone(
+      SyncTombstoneKind.favoriteword.dbValue,
+      'ねこ',
+      DateTime.now().millisecondsSinceEpoch - 1000,
+    );
+
+    final InterconnectSyncBackend backend =
+        await _buildClientBackend(base: base, token: token);
+    final SyncRunReport report = SyncRunReport();
+    await _orchestrator(db: localDb, backend: backend, tmp: work)
+        .syncDeletionTombstonesLiveForTest(report, backend);
+
+    // 聚合通道按设计不传播删除，这里如实跳过：不报错，也不为一件永远做不成的事
+    // 把基线永久卡住（那会让书/视频的删除每轮无谓重推）。
+    expect(report.errors, isEmpty);
+    expect(
+      await SyncRepository(localDb).getDeletionTombstonesPushBaselineMs(),
+      greaterThan(0),
+    );
+  });
+
+  test('旧 host 不支持视频删除：DELETE 返 404，client 判 false，基线仍推进', () async {
+    // 换一台「旧版本」host（不实现 VideoDeletionHost）。
+    final HibikiSyncServer legacy = HibikiSyncServer(
+      syncDataDir: p.join(work.path, 'legacy_data'),
+      port: 0,
+      token: token,
+      allowLan: false,
+      libraryService: _LegacyHostWithoutVideoDelete(),
+    );
+    await legacy.start();
+    addTearDown(legacy.stop);
+    final String legacyBase = 'http://127.0.0.1:${legacy.port}';
+
+    final InterconnectSyncBackend backend =
+        await _buildClientBackend(base: legacyBase, token: token);
+
+    // client 侧能力探测：404 → false（而不是抛异常）。
+    expect(await backend.deleteRemoteVideo('video/whatever'), isFalse);
+
+    final HibikiDatabase localDb = _memDb();
+    addTearDown(localDb.close);
+    await localDb.writeSyncDeletionTombstone(
+      SyncTombstoneKind.video.dbValue,
+      'video/mine',
+      DateTime.now().millisecondsSinceEpoch - 1000,
+    );
+    final SyncRunReport report = SyncRunReport();
+    await _orchestrator(db: localDb, backend: backend, tmp: work)
+        .syncDeletionTombstonesLiveForTest(report, backend);
+
+    // 能力缺失如实记进 report（用户/日志可见），但不是暂时性故障，故不阻塞基线：
+    // 否则书/有声书的删除会被一条永远推不成的视频删除拖着每轮重推。
+    expect(report.errors.any((String e) => e.contains('too old')), isTrue,
+        reason: '对端不支持必须留下可见记录，不能静默吞掉');
+    expect(
+      await SyncRepository(localDb).getDeletionTombstonesPushBaselineMs(),
+      greaterThan(0),
+    );
+  });
+
+  test('DELETE /api/library/videos/<id> 路径穿越拒绝', () async {
+    final HttpClient client = HttpClient();
+    addTearDown(client.close);
+    final HttpClientRequest req = await client.deleteUrl(
+      Uri.parse('$base/api/library/videos/..%2Fetc%2Fpasswd'),
+    );
+    req.headers.set(
+      HttpHeaders.authorizationHeader,
+      'Basic ${base64Encode(utf8.encode('hibiki:$token'))}',
+    );
+    final HttpClientResponse res = await req.close();
+    await res.drain<void>();
+    expect(res.statusCode, 400);
+  });
+}


### PR DESCRIPTION
## 解决什么

两个真实缺口，对应「长按远端书籍/视频等能删远端数据」与「从所有设备删除时远端也要删」：

1. **远端视频没有删除入口**，而且不是 UI 漏了——从 `HibikiLibraryHostService` 接口、host 实现、server 路由到 client 方法**四层全缺**（其它四条资产链词典/书/本地音频/有声书都有 DELETE）。
2. **「从所有设备删除」对互联对端完全无效**：`_syncDeletionTombstonesLive` 是 GET-only，client 勾选后只在本地写一条墓碑，没有任何人发布，host 永远收不到。

## 做了什么

**Phase 1 · 远端条目删除**
- 新增可选能力接口 `VideoDeletionHost` + `DELETE /api/library/videos/<id>` + `InterconnectSyncBackend.deleteRemoteVideo`。选可选接口而非往主接口加方法，是因为主接口有十余个测试 fake 用 `implements` 全量实现（`DeletionTombstoneHost` 当初分离同理）。
- 远端视频卡、远端纯字幕书占位卡长按菜单加「删除」。
- 顺带修远端书删除三处既有毛病：失败静默、删完不 `forceRefresh` 导致 TTL 内幽灵卡片、身份键 title/downloadId 不一致。

**Phase 2 · 删除推送**
- `_syncDeletionTombstonesLive` 改双向：先推本机墓碑给 host，再消费 host 墓碑。host 删除时写自己的墓碑，第三台设备照常收到确认提示，链路闭合。
- 顺带消掉一个既有死角：只配互联且本机是 client 角色时，勾选框会亮但静默无效（与已修的 BUG-1338 死角②同型）。

## 两个值得单独看的决策

**不复用 `remotePublishedAt`。** 它的语义是「已写进云端 `__tombstones__`」。互联推送若去标它，同时配了云备份的设备在云通道的 `remotePublishedAt == 0` 过滤里会永远跳过这条——只连云的第三台设备再也收不到这次删除。改用独立的推送基线（preferences KV，无 schema 迁移）。已有变异测试钉住。

**host 删视频不碰用户原片。** 只回收 app 自己拥有的字节：client 上传副本目录（`p.isWithin` 判据证明是 app 搬进来的）+ 封面/字幕缓存（复用本机删除的 `reclaimDeletedVideoBookAssets`，它有「仍在 app 资产目录内 + 无其它条目引用」双重判据）。远端删除与本地删除在「删掉哪些字节」上必须完全同语义。已有变异测试钉住。

## 兼容性

老版本 host 没有视频 DELETE 端点 → 404 → client 判「对端不支持」：UI 路径提示升级对端，同步路径记 `report.errors` 但**不阻塞推送基线**（能力缺失不是暂时性故障，为它永久卡住会让书/有声书的删除每轮无谓重推）。网络/5xx 这类真·暂时失败才阻塞基线、下轮整批重试（DELETE 幂等）。

## 验证

- `flutter analyze` 全量（含 test）：No issues found.
- `flutter test test/sync test/i18n test/pages --no-pub`：**4570 passed**, exit 0.
- 新增 `test/sync/interconnect_delete_push_test.dart`（6 例，真 server + 真 host + 真 client 端到端）。
- **变异实测**两条关键守卫：注入「误删原片」→「原始视频文件保留」用例变红；注入 `markSyncDeletionPublished` →「不碰 remotePublishedAt」用例变红。还原后复绿。

未做真机验证——链路是纯网络+DB，端到端测试已覆盖真实 server/host/client；跨设备真机复测留给合入前的人工确认。

https://claude.ai/code/session_01Jz8AxDDxD9Ja8XogVyD9Wd
