### PR TITLE
fix(reader): spread 键桥的解析 scope 从动作集导出，不再硬编码 reader (BUG-1442) —— PR#722 合并阻塞解法

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1336 条。点号进各自文件。
+> 共 1337 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1442](bugs/BUG-1442-spread-key-bridge-single-scope.md) | ✅ | ✅ | 双页 spread 键桥只能解析 reader scope，跨 scope 动作在 spread 里恒解析不到 |
 | [BUG-1432](bugs/BUG-1432-ime-physical-key-ledger.md) | ✅ | ✅ | TODO-2652「三处快捷键台账仍记裸 logicalKey」经查证伪：`LogicalKeyboardKey.process` 在 5 个出包平台上根本不可达 |
 | [BUG-1430](bugs/BUG-1430-subtitle-obscure-switch-lag.md) | ✅ | ✅ | 切换字幕遮罩模式卡顿：两次事务落盘 + UI 等落盘 + 全局广播重建全 app |
 | [BUG-1429](bugs/BUG-1429-bug-tool-number-pool-misses-uncommitted-worktrees.md) | ✅ | ✅ | bug.dart 取号扫不到并发工作区未提交的 bug 文件，一天连撞六次 |

--- a/docs/bugs/BUG-1442-spread-key-bridge-single-scope.md
+++ b/docs/bugs/BUG-1442-spread-key-bridge-single-scope.md
@@ -1,0 +1,52 @@
+## BUG-1442 · 双页 spread 键桥只能解析 reader scope，跨 scope 动作在 spread 里恒解析不到
+
+- **报告**：2026-08-02（整合线：PR#722 合并阻塞排查）
+- **真实性**：✅ 真 bug（设计缺陷型，非用户可见症状）。根因是键桥把「导出哪些动作」与
+  「解析哪个 scope」写成**两处真值**：
+  - `hibiki/lib/src/pages/implementations/reader_hibiki_page.dart:680`
+    `kSpreadBridgedActions` —— 数据侧，4 个动作恰好全是 reader scope；
+  - `hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart:2113`（修复前）
+    `onSpreadKey` 的 `resolveKeyboard(..., scope: ShortcutScope.reader)` —— 硬编码单 scope。
+
+  两者不联动，于是往 `kSpreadBridgedActions` 里加**任何非 reader scope 的动作**都会
+  **静默失效**：`spreadKeyBridgeTokens` 照样把它的键导进 JS token 表、用户按下也照样
+  `callHandler('onSpreadKey', token)` 回传 Dart，但 `resolveKeyboard` 在 reader scope
+  里找不到它 → `action == null` → handler 早退。键桥对该动作形同虚设，且**没有任何
+  报错**，只有「按了没反应」。
+
+  这条缺陷是 PR#722（「返回上一级」全 app 统一成一个可改键动作）的**合并阻塞**：
+  #722 删掉 `ShortcutAction.readerExitBook`、把退出语义并进新的 `universal` scope 下的
+  `globalBack`；把 `kSpreadBridgedActions:684` 那行机械换成 `globalBack` 后
+  `flutter analyze` 绿，但 `test/reader/spread_page_turn_input_test.dart` 红，报文
+  「Escape 解析成 null，不在 spread 声明的动作集里」——正是本缺陷。
+
+- **[x] ① 已修复** —— 解析侧的 scope 列表改为**从动作集自身按出现序去重导出**，动作集成为
+  唯一真值：新增 `spreadKeyBridgeScopes()` / `resolveSpreadKeyBridgeAction()`
+  （`reader_hibiki_page.dart`），`onSpreadKey` 改调后者、handler 体内不再出现任何
+  `ShortcutScope.xxx` 字面量。scope 顺序 = 动作集里各 scope 首次出现的顺序，所以页面专属
+  scope 排在兜底 scope 之前 → **页面专属键永远优先于兜底**，与 Flutter 焦点路径的
+  「reader → audiobook 逐级回退」同构。
+  `kSpreadBridgedActions` 内容**本次不动**（仍全是 reader scope），故 develop 上零行为变化；
+  `spreadKeyBridgeScopes()` 今天返回 `[reader]`。
+
+- **[x] ② 已加自动化测试** —— `hibiki/test/reader/spread_page_turn_input_test.dart`
+  新增 group「键桥跨 scope 解析 (BUG-1442)」6 条 + 改写既有 2 条断言。逐条变异实测：
+  | 变异（生产代码反向改坏） | 转红的用例 |
+  |---|---|
+  | `spreadKeyBridgeScopes` 返回固定 `[reader]` 不再导出 | 「scope 列表按动作集出现序去重导出」+「动作集里混入别的 scope 时，那个 scope 的键真能解析到」 |
+  | 导出顺序反转（`scopes.insert(0, …)`） | 「scope 列表按动作集出现序去重导出」+「同键被页面 scope 与兜底 scope 都绑时，页面专属胜出」 |
+  | `onSpreadKey` 恢复硬编码 `scope: ShortcutScope.reader` | 「注册了 onSpreadKey 处理器，走注册表解析并 reclaim 焦点」 |
+  | 删掉 `spreadKeyBridgeTokens` 里裸 Space 的 `continue` | 「…且恒排除裸 Space」+「裸 Space 的排除与 scope 无关」 |
+  | `resolveSpreadKeyBridgeAction` 循环里把 scope 钉死成 reader | 「动作集里混入别的 scope 时，那个 scope 的键真能解析到」 |
+
+  五次变异均为 17 tests completed 的**断言失败**（非编译失败/零测试执行）。
+
+- **备注**：
+  - **裸空格中和不受影响**：`spreadKeyBridgeTokens` 的裸 Space 排除判据只看**单条绑定
+    本身**（`key == space && modifiers.isEmpty`），与动作属于哪个 scope 无关。所以将来往
+    动作集里加的跨 scope 兜底动作即便被用户绑成裸 Space 也进不了 token 表，不会在 spread
+    页复活「裸 Space 双触发」，`global_navigation.dart` 把裸空格中和为 `DoNothingIntent`
+    的纪律也不受影响。已由「裸 Space 的排除与 scope 无关」用例钉死（同时断言 `Ctrl+Space`
+    仍能正常进表，排除的只是「裸」的那一条）。
+  - 本条**不改 develop 的运行时行为**，是给 PR#722 让路的使能修复。#722 rebase 后只需把
+    `kSpreadBridgedActions` 里的 `readerExitBook` 换成 `globalBack`，解析侧零改动。

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -2099,6 +2099,12 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
         // Flutter 焦点路径**同一个** resolveKeyboard——改键对两条路一起生效。
         // 收尾 reclaim：这一次按键说明 OS 焦点在 WebView2 手里，不夺回来后续按键
         // 还是只到 DOM（与 onSpaceKey / onSwipe 的 BUG-136 修复同款）。
+        //
+        // BUG-1442：反解析的 scope **不在这里硬编码**，而是由
+        // [resolveSpreadKeyBridgeAction] 从 [kSpreadBridgedActions] 自身导出并逐个
+        // 试（页面专属 scope 在前、兜底 scope 在后）。硬编码单 scope 时，往动作集
+        // 里加任何非 reader scope 的动作都会静默失效：token 进了 JS 表、按下也回传
+        // 到这里，但解析不到动作就早退，桥形同虚设。
         controller.addJavaScriptHandler(
           handlerName: 'onSpreadKey',
           callback: (List<dynamic> args) {
@@ -2106,11 +2112,9 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
             final InputBinding? binding =
                 InputBinding.deserialize(args[0] as String);
             if (binding == null) return;
-            final ShortcutAction? action =
-                appModel.shortcutRegistry.resolveKeyboard(
-              binding.key,
-              modifiers: binding.modifiers,
-              scope: ShortcutScope.reader,
+            final ShortcutAction? action = resolveSpreadKeyBridgeAction(
+              appModel.shortcutRegistry,
+              binding,
             );
             if (action == null) return;
             _executeShortcutAction(action);

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -659,12 +659,18 @@ $keyBridgeScript
 /// **裸 Space 恒排除**：它归正文同款的 `onSpaceKey` 桥（那条经
 /// `resolveReaderSpaceOverride` 解析，有声书激活时是播放/暂停而不是翻页）。两座桥
 /// 都是本 document 上的独立 `keydown` 监听，同一次按下各命中一次就会翻两页。
-List<String> spreadKeyBridgeTokens(HibikiShortcutRegistry registry) {
+List<String> spreadKeyBridgeTokens(
+  HibikiShortcutRegistry registry, {
+  List<ShortcutAction> actions = kSpreadBridgedActions,
+}) {
   if (!registry.isLoaded) return const <String>[];
   final List<String> tokens = <String>[];
-  for (final ShortcutAction action in kSpreadBridgedActions) {
+  for (final ShortcutAction action in actions) {
     for (final InputBinding binding
         in registry.bindingsFor(action).keyboardBindings) {
+      // 裸 Space 的排除**与动作属于哪个 scope 无关**：判据只看这一条绑定本身，所以
+      // 后来往 [kSpreadBridgedActions] 里加的跨 scope 兜底动作即便被用户绑成裸
+      // Space，也一样进不了本表、复活不了双触发。
       if (binding.key == LogicalKeyboardKey.space &&
           binding.modifiers.isEmpty) {
         continue;
@@ -677,12 +683,58 @@ List<String> spreadKeyBridgeTokens(HibikiShortcutRegistry registry) {
 }
 
 /// [spreadKeyBridgeTokens] 导出的动作集（顺序即 token 表顺序，稳定可比较）。
+///
+/// **允许混入非 reader scope 的动作**：桥的解析侧（[spreadKeyBridgeScopes] /
+/// [resolveSpreadKeyBridgeAction]）从本表自身导出要试的 scope，所以往这里加一个
+/// 兜底动作（如把「返回上一级」统一成一个跨表面动作后的那个动作）不需要再改任何
+/// 解析代码。排在前面的动作所属的 scope 先解析 → **页面专属键永远优先于兜底**。
 const List<ShortcutAction> kSpreadBridgedActions = <ShortcutAction>[
   ShortcutAction.readerPageForward,
   ShortcutAction.readerPageBackward,
   ShortcutAction.readerToggleChrome,
   ShortcutAction.readerExitBook,
 ];
+
+/// `onSpreadKey` 反解析 token 时要依次尝试的 scope，**从 [actions] 自身按出现序
+/// 去重导出**，不是另立一份清单。
+///
+/// BUG-1442：桥此前把「导出哪些动作」（数据）和「解析哪个 scope」（硬编码
+/// `ShortcutScope.reader`）分成两处真值，于是往动作集里加任何非 reader scope 的
+/// 动作都会**静默失效**——token 进了 JS 表、按下也回传了 Dart，但 `resolveKeyboard`
+/// 在 reader scope 里找不到它，`onSpreadKey` 直接早退。两处合成一处后，动作集是
+/// 唯一真值，二者不可能漂开。
+List<ShortcutScope> spreadKeyBridgeScopes({
+  List<ShortcutAction> actions = kSpreadBridgedActions,
+}) {
+  final List<ShortcutScope> scopes = <ShortcutScope>[];
+  for (final ShortcutAction action in actions) {
+    if (!scopes.contains(action.scope)) scopes.add(action.scope);
+  }
+  return scopes;
+}
+
+/// 把 `onSpreadKey` 回传的 [binding] 解析成动作：按 [spreadKeyBridgeScopes] 的顺序
+/// 逐个 scope 试 [HibikiShortcutRegistry.resolveKeyboard]，首个命中即用。
+///
+/// 顺序即 [actions] 里各 scope 首次出现的顺序，所以页面专属 scope（reader）排在
+/// 兜底 scope 之前 → 同一个键被两边都绑时页面专属胜出，与 Flutter 焦点路径的
+/// 「reader → audiobook 逐级回退」同构。解析走的仍是与焦点路径**同一个**
+/// `resolveKeyboard`，改键对两条路一起生效。
+ShortcutAction? resolveSpreadKeyBridgeAction(
+  HibikiShortcutRegistry registry,
+  InputBinding binding, {
+  List<ShortcutAction> actions = kSpreadBridgedActions,
+}) {
+  for (final ShortcutScope scope in spreadKeyBridgeScopes(actions: actions)) {
+    final ShortcutAction? action = registry.resolveKeyboard(
+      binding.key,
+      modifiers: binding.modifiers,
+      scope: scope,
+    );
+    if (action != null) return action;
+  }
+  return null;
+}
 
 /// BUG-213：章内原生滚动回传（`onReaderScroll`）到来时，是否应刷新章内进度。
 ///

--- a/hibiki/test/reader/spread_page_turn_input_test.dart
+++ b/hibiki/test/reader/spread_page_turn_input_test.dart
@@ -5,7 +5,12 @@ import 'package:flutter/foundation.dart' show TargetPlatform;
 import 'package:flutter/services.dart' show LogicalKeyboardKey;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_page.dart'
-    show buildSpreadPageHtml, kSpreadBridgedActions, spreadKeyBridgeTokens;
+    show
+        buildSpreadPageHtml,
+        kSpreadBridgedActions,
+        resolveSpreadKeyBridgeAction,
+        spreadKeyBridgeScopes,
+        spreadKeyBridgeTokens;
 import 'package:hibiki/src/reader/reader_settings.dart';
 import 'package:hibiki/src/shortcuts/input_binding.dart';
 import 'package:hibiki/src/shortcuts/shortcut_action.dart';
@@ -121,11 +126,8 @@ void main() {
       for (final String token in tokens) {
         final InputBinding? binding = InputBinding.deserialize(token);
         expect(binding, isNotNull, reason: '$token 不是合法 InputBinding token');
-        final ShortcutAction? action = registry.resolveKeyboard(
-          binding!.key,
-          modifiers: binding.modifiers,
-          scope: ShortcutScope.reader,
-        );
+        final ShortcutAction? action =
+            resolveSpreadKeyBridgeAction(registry, binding!);
         expect(kSpreadBridgedActions.contains(action), isTrue,
             reason: '$token 解析成 $action，不在 spread 声明的动作集里');
       }
@@ -134,8 +136,7 @@ void main() {
       final Set<ShortcutAction> covered = tokens
           .map(InputBinding.deserialize)
           .whereType<InputBinding>()
-          .map((InputBinding b) => registry.resolveKeyboard(b.key,
-              modifiers: b.modifiers, scope: ShortcutScope.reader))
+          .map((InputBinding b) => resolveSpreadKeyBridgeAction(registry, b))
           .whereType<ShortcutAction>()
           .toSet();
       expect(covered, contains(ShortcutAction.readerPageForward));
@@ -158,6 +159,161 @@ void main() {
     });
   });
 
+  /// BUG-1442：键桥的「导出哪些动作」与「解析哪个 scope」此前是两份真值——动作集
+  /// 是数据、scope 是 onSpreadKey 里硬编码的 `ShortcutScope.reader`。往动作集里加
+  /// 任何非 reader scope 的动作都会**静默失效**：token 进了 JS 表、按下也回传了
+  /// Dart，但 resolveKeyboard 在 reader scope 里找不到它，handler 直接早退。
+  ///
+  /// 修法：scope 列表从动作集自身导出（[spreadKeyBridgeScopes]），解析按该顺序逐
+  /// 个试（[resolveSpreadKeyBridgeAction]）。本组锁定这条能力，并钉住两条不得回归
+  /// 的既有性质：页面专属 scope 优先于兜底 scope、裸 Space 恒不进表。
+  group('键桥跨 scope 解析 (BUG-1442)', () {
+    /// 一个确定不在任何 reader 默认绑定里的键，用来当「兜底 scope 专属键」。
+    const InputBinding fallbackOnly =
+        InputBinding(key: LogicalKeyboardKey.keyJ);
+
+    /// reader 与兜底 scope **同时**绑上的键，用来验优先级。
+    const InputBinding shared = InputBinding(key: LogicalKeyboardKey.keyK);
+
+    HibikiShortcutRegistry loadedRegistry() =>
+        HibikiShortcutRegistry()..loadDefaults(TargetPlatform.windows);
+
+    test('生产动作集今天只导出 reader 一个 scope（本次零行为变化）', () {
+      expect(spreadKeyBridgeScopes(), <ShortcutScope>[ShortcutScope.reader],
+          reason: 'kSpreadBridgedActions 现在全是 reader scope，导出的 scope 列表就该'
+              '只有 reader——多一个都说明导出逻辑没在读动作集');
+    });
+
+    test('scope 列表按动作集出现序去重导出，不是硬编码', () {
+      expect(
+        spreadKeyBridgeScopes(actions: const <ShortcutAction>[
+          ShortcutAction.readerPageForward,
+          ShortcutAction.globalBack,
+          ShortcutAction.readerToggleChrome,
+          ShortcutAction.globalToggleFullscreen,
+        ]),
+        <ShortcutScope>[ShortcutScope.reader, ShortcutScope.global],
+        reason: '两个 reader + 两个 global 必须去重成 [reader, global]，且 reader 在前'
+            '（它在动作集里先出现）',
+      );
+      expect(
+        spreadKeyBridgeScopes(actions: const <ShortcutAction>[
+          ShortcutAction.globalBack,
+          ShortcutAction.readerPageForward,
+        ]),
+        <ShortcutScope>[ShortcutScope.global, ShortcutScope.reader],
+        reason: '顺序必须真的跟着动作集走，不能返回固定列表',
+      );
+    });
+
+    test('动作集里混入别的 scope 时，那个 scope 的键真能解析到', () {
+      final HibikiShortcutRegistry registry = loadedRegistry()
+        ..updateBinding(
+          ShortcutAction.globalBack,
+          const ShortcutBindingSet(
+            keyboardBindings: <InputBinding>[fallbackOnly],
+          ),
+        );
+
+      // 生产动作集（纯 reader）解析不到它——这正是 PR#722 撞上的那堵墙。
+      expect(resolveSpreadKeyBridgeAction(registry, fallbackOnly), isNull,
+          reason: '兜底动作没进动作集时本来就不该被解析到（今天的行为，勿变）');
+
+      // 把它加进动作集，解析侧无需任何改动就跟着生效。
+      expect(
+        resolveSpreadKeyBridgeAction(
+          registry,
+          fallbackOnly,
+          actions: const <ShortcutAction>[
+            ShortcutAction.readerPageForward,
+            ShortcutAction.globalBack,
+          ],
+        ),
+        ShortcutAction.globalBack,
+        reason: '解析侧若还硬编码 reader scope，加进动作集的兜底动作永远解析成 null，'
+            '键桥对它形同虚设',
+      );
+    });
+
+    test('同键被页面 scope 与兜底 scope 都绑时，页面专属胜出', () {
+      final HibikiShortcutRegistry registry = loadedRegistry()
+        ..updateBinding(
+          ShortcutAction.readerPageForward,
+          const ShortcutBindingSet(keyboardBindings: <InputBinding>[shared]),
+        )
+        ..updateBinding(
+          ShortcutAction.globalBack,
+          const ShortcutBindingSet(keyboardBindings: <InputBinding>[shared]),
+        );
+
+      expect(
+        resolveSpreadKeyBridgeAction(
+          registry,
+          shared,
+          actions: const <ShortcutAction>[
+            ShortcutAction.readerPageForward,
+            ShortcutAction.globalBack,
+          ],
+        ),
+        ShortcutAction.readerPageForward,
+        reason: '兜底 scope 排在动作集后面 = 解析时也排在后面；反过来会让翻页被'
+            '「返回」夺舍，spread 页直接退书',
+      );
+    });
+
+    test('裸 Space 的排除与 scope 无关：兜底 scope 的动作绑裸 Space 也进不了表', () {
+      final HibikiShortcutRegistry registry = loadedRegistry()
+        ..updateBinding(
+          ShortcutAction.globalBack,
+          const ShortcutBindingSet(
+            keyboardBindings: <InputBinding>[
+              InputBinding(key: LogicalKeyboardKey.space),
+              InputBinding(
+                key: LogicalKeyboardKey.space,
+                modifiers: <ModifierKey>{ModifierKey.ctrl},
+              ),
+            ],
+          ),
+        );
+
+      final List<String> tokens = spreadKeyBridgeTokens(
+        registry,
+        actions: const <ShortcutAction>[
+          ShortcutAction.readerPageForward,
+          ShortcutAction.globalBack,
+        ],
+      );
+
+      // App 已把裸空格中和为 DoNothingIntent、焦点确认统一走 Enter/手柄 A；spread
+      // 页的裸 Space 又归 onSpaceKey 那座桥。两座桥都装 keydown，裸 Space 一旦进本
+      // 表就是同一次按下触发两次。
+      expect(tokens, isNot(contains('Space')),
+          reason: '裸 Space 必须恒排除，跨 scope 动作也不例外——否则空格在 spread 里'
+              '复活成双触发');
+      expect(tokens, contains('Ctrl+Space'),
+          reason: '排除的判据只是「裸」Space，带修饰键的 Space 仍是正常绑定，不该被'
+              '一起误杀');
+    });
+
+    test('spread 专属键（翻页/唤栏/退书）解析结果一字不变', () {
+      final HibikiShortcutRegistry registry = loadedRegistry();
+      // 默认绑定下逐个动作的每条键盘绑定都必须解析回它自己（裸 Space 那条走
+      // onSpaceKey 桥，不在本表，故按同一规则跳过）。
+      for (final ShortcutAction action in kSpreadBridgedActions) {
+        for (final InputBinding binding
+            in registry.bindingsFor(action).keyboardBindings) {
+          if (binding.key == LogicalKeyboardKey.space &&
+              binding.modifiers.isEmpty) {
+            continue;
+          }
+          expect(resolveSpreadKeyBridgeAction(registry, binding), action,
+              reason: '${binding.serialize()} 本该解析成 $action；spread 专属键的行为'
+                  '不允许因为解析改成多 scope 而漂动');
+        }
+      }
+    });
+  });
+
   group('Dart 侧接线 (BUG-1426)', () {
     final String source = readReaderPageSource();
 
@@ -175,9 +331,14 @@ void main() {
 
       expect(body, contains('InputBinding.deserialize'),
           reason: 'token 必须反解析，不能按字面量比键名');
-      expect(body, contains('resolveKeyboard'),
-          reason: '必须走与 Flutter 焦点路径同一个解析，改键才会对两条路一起生效');
-      expect(body, contains('ShortcutScope.reader'));
+      expect(body, contains('resolveSpreadKeyBridgeAction('),
+          reason: '必须走与 Flutter 焦点路径同一个解析（该 helper 内部就是 '
+              'resolveKeyboard），改键才会对两条路一起生效');
+      // BUG-1442：handler 体内**不许**再出现任何 `ShortcutScope.xxx` 字面量——
+      // 硬编码单 scope 正是「动作集里加了跨 scope 动作却静默解析不到」的根因。
+      // 要试哪些 scope 由 spreadKeyBridgeScopes 从动作集导出。
+      expect(body, isNot(contains('ShortcutScope.')),
+          reason: 'onSpreadKey 里硬编码 scope = 动作集与解析侧两份真值，必然漂开');
       expect(body, contains('_executeShortcutAction('),
           reason: '解析出动作却不执行 = 按键仍然没反应');
       expect(body, contains('FocusReclaimCause.gesture'),


### PR DESCRIPTION
## 这个 PR 是干什么的

**它是 PR#722 的合并阻塞解法。整合线应先合本 PR、再 rebase #722。**

#722（「返回上一级」全 app 统一成一个可改键动作）删掉 `ShortcutAction.readerExitBook`，
而 develop 上 `reader_hibiki_page.dart:684`（PR#719 新加的 `kSpreadBridgedActions`）引用它。
整合线的证据探针：机械改成 `globalBack` 后 `flutter analyze` 绿，但
`spread_page_turn_input_test` 红，报文「Escape 解析成 null，不在 spread 声明的动作集里」。

## 根因（技术缺陷，不是产品取舍）

双页 spread 键桥把两件事写成**两处真值**：

| | 位置 | 内容 |
|---|---|---|
| 数据侧 | `reader_hibiki_page.dart:680` `kSpreadBridgedActions` | 4 个动作，恰好全是 reader scope |
| 解析侧 | `reader_hibiki/webview.part.dart:2113`（修复前）`onSpreadKey` | 硬编码 `resolveKeyboard(scope: ShortcutScope.reader)` |

两者不联动 ⇒ 往动作集里加**任何非 reader scope 的动作**都会**静默失效**：
`spreadKeyBridgeTokens` 照样把它的键导进 JS token 表、按下也照样 `callHandler` 回传 Dart，
但 `resolveKeyboard` 在 reader scope 里找不到它 → `action == null` → handler 早退。
没有任何报错，只有「按了没反应」。

**为什么判定是技术问题而不是产品取舍**（逐条排掉了任务里点名的两种产品风险）：

1. **spread 里 Esc 当前没有别的语义**——`readerDismissDict`（默认 Esc）根本不在
   `kSpreadBridgedActions` 里，`readerExitBook` 默认是 Ctrl+W。spread 页今天压根不桥 Esc，
   放开兜底 scope 不会夺走任何现存语义。
2. **不会让 spread 专属键失效**——解析按动作集里各 scope 的**首次出现顺序**逐个试，
   reader 排在兜底之前，页面专属键永远先命中。已由「同键被页面 scope 与兜底 scope 都绑时，
   页面专属胜出」用例钉死。

## 改了什么

- 新增 `spreadKeyBridgeScopes({actions})`：scope 列表**从动作集自身按出现序去重导出**，
  动作集成为唯一真值。
- 新增 `resolveSpreadKeyBridgeAction(registry, binding, {actions})`：按上述顺序逐个 scope 试
  `resolveKeyboard`，首个命中即用。走的仍是与 Flutter 焦点路径**同一个** `resolveKeyboard`，
  改键对两条路一起生效。
- `onSpreadKey` 改调后者，handler 体内**不再出现任何 `ShortcutScope.xxx` 字面量**（守卫钉死）。
- `spreadKeyBridgeTokens` 加 `actions` 参数（默认 `kSpreadBridgedActions`），与解析侧同形。

⚠️ **`kSpreadBridgedActions` 内容本次不动**（仍全是 reader 动作）⇒ **develop 上零行为变化**，
`spreadKeyBridgeScopes()` 今天返回 `[reader]`。这是纯使能修复，产品语义留给 #722。

## #722 rebase 后要做什么

只需把 `kSpreadBridgedActions` 里的 `ShortcutAction.readerExitBook` 换成
`ShortcutAction.globalBack`（`universal` scope）。解析侧**零改动**——`spreadKeyBridgeScopes()`
自动变成 `[reader, universal]`，Esc 走 universal 命中，reader 专属键仍先命中。

## 裸空格中和仍然成立

`spreadKeyBridgeTokens` 的裸 Space 排除判据只看**单条绑定本身**（`key == space &&
modifiers.isEmpty`），**与动作属于哪个 scope 无关**。所以将来加进动作集的跨 scope 兜底动作
即便被用户绑成裸 Space 也进不了 token 表，不会在 spread 页复活「裸 Space 双触发」，
`global_navigation.dart` 把裸空格中和为 `DoNothingIntent` 的纪律不受影响。
用例同时断言 `Ctrl+Space` 仍能正常进表——排除的只是「裸」的那一条，不是误杀所有 Space。

（另：本 PR 没有、也不需要新增任何 `LogicalKeyboardKey.process` 相关兜底。）

## 测试与变异实测

`hibiki/test/reader/spread_page_turn_input_test.dart` 新增 group「键桥跨 scope 解析 (BUG-1442)」
6 条 + 改写既有 2 条断言。**逐条变异实测**（生产代码反向改坏 ⇒ 该条转红）：

| 变异 | 转红的用例 |
|---|---|
| `spreadKeyBridgeScopes` 返回固定 `[reader]` | 「scope 列表按动作集出现序去重导出」+「动作集里混入别的 scope 时，那个 scope 的键真能解析到」 |
| 导出顺序反转（`scopes.insert(0, …)`） | 「scope 列表按动作集出现序去重导出」+「同键被页面 scope 与兜底 scope 都绑时，页面专属胜出」 |
| `onSpreadKey` 恢复硬编码 `scope: ShortcutScope.reader` | 「注册了 onSpreadKey 处理器，走注册表解析并 reclaim 焦点」 |
| 删掉 `spreadKeyBridgeTokens` 里裸 Space 的 `continue` | 「…且恒排除裸 Space」+「裸 Space 的排除与 scope 无关」 |
| `resolveSpreadKeyBridgeAction` 循环里把 scope 钉死成 reader | 「动作集里混入别的 scope 时，那个 scope 的键真能解析到」 |

五次变异均为 **17 tests completed 的断言失败**（不是编译失败/零测试执行）；变异全部用反向文本
替换还原，还原后 `git status --short` 只剩本 PR 的 5 个文件。

「spread 专属键（翻页/唤栏/退书）解析结果一字不变」用例遍历默认绑定下每个 bridged 动作的每条
键盘绑定，断言解析回它自己。

## 门禁 verdict

- `flutter analyze`（全量含 test）：`No issues found!`（exit 0）
- `dart run tool/flutter_test_failures.dart --no-pub`（元守卫 `source_guard_adoption_test` +
  `md3_design_system_static_test` + `test/shortcuts` + `test/focus` + 改动覆盖）：
  `FLUTTER TEST VERDICT: PASSED - 652 tests ran, all tests passed`
- `test/tools/bugs_per_file_guard_test.dart`：`PASSED - 3 tests ran`
- 未跑其它覆盖面套件（按提速指令砍到最小集），全量由 PR CI 兜底。
- 未 bump `+build`（整合线统一 bump）。
- **未做真机验证**：本轮只有单元 / 源码守卫层证据。本 PR 零运行时行为变化，真机门留给 #722。

BUG 档：`docs/bugs/BUG-1442-spread-key-bridge-single-scope.md`（`bug.dart check --strict` 复核
通过：1337 条号唯一，跨 1871 refs + 724 工作区复核 1442 未被别的文件名占用）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
