### PR TITLE
test(gal): 窗口选择器守卫改语义锚点（解 PR#724 合并阻塞）

### DIFF
--- a/hibiki/test/pages/texthooker_window_picker_guard_test.dart
+++ b/hibiki/test/pages/texthooker_window_picker_guard_test.dart
@@ -2,8 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-import '../sync/desktop_lookup_foreground_guard_static_test.dart'
-    show stripDartComments;
+import '../helpers/source_guard.dart';
 
 /// BUG-1049 的静态守卫：捕获目标的窗口选择器必须把 **Hibiki 自己启动的游戏**当成
 /// 已选中的那一项。
@@ -11,65 +10,129 @@ import '../sync/desktop_lookup_foreground_guard_static_test.dart'
 /// 用户实测：从 Hibiki 启动游戏后点「捕获目标」条，弹出的窗口列表把游戏和一屏无关
 /// 窗口平铺在一起、没有任何预选，等于让用户替 app 认它刚拉起来的进程。
 ///
-/// 这条路径没法用 widget 测试可移植地覆盖：`_pickExternalWindow` 首行就是
-/// `Platform.isWindows` 门（非 Windows CI 直接短路），窗口列表来自静态
-/// `WindowCaptureChannel`，会话又是单例。故在源码层锁住修复结构。
+/// 这条路径没法用 widget 测试可移植地覆盖：选择器首行就是 `Platform.isWindows` 门
+/// （非 Windows CI 直接短路），窗口列表来自静态 `WindowCaptureChannel`，会话又是
+/// 单例。故在源码层锁住修复结构。
+///
+/// **锚点为什么不写死方法名**：「列窗口给用户挑」与「挑完之后怎么处置」一度挤在
+/// `_pickExternalWindow` 一个方法里；「附着到已在运行的游戏」（PR#724）要用同一份
+/// 列表配另一种处置，选择器 UI 因此被提到独立的 `_showExternalWindowPicker`。守卫
+/// 原先焊在 `_pickExternalWindow` 的方法体上，这次拆分一落地三条断言就整体飘进只剩
+/// 处置逻辑的旧方法里，全部转红——看起来像功能坏了，实际是守卫塌了。所以两处窗口
+/// 都改用**语义判据**认，拆分前后两种结构都守得住：
+/// - 选择器 = 真的建了 `showAppDialog<ExternalWindowInfo>` 的那个方法；
+/// - 处置 = 真的调 `_session.bindWindow(` 的那个方法。
+/// 认不出来一律 `fail`，绝不静默锚到别处。
 void main() {
-  /// 截取方法体（含花括号）：先越过参数列表，再从其后第一个 `{` 起做花括号计数。
-  String methodBody(String source, String signatureNeedle) {
-    final int sigIdx = source.indexOf(signatureNeedle);
-    if (sigIdx < 0) throw StateError('找不到方法签名：$signatureNeedle');
-    final int parenOpen = source.indexOf('(', sigIdx);
-    int parenDepth = 0;
-    int parenClose = -1;
-    for (int i = parenOpen; i < source.length; i++) {
-      if (source[i] == '(') parenDepth++;
-      if (source[i] == ')') {
-        parenDepth--;
-        if (parenDepth == 0) {
-          parenClose = i;
-          break;
-        }
+  final String source = File(
+    'lib/src/pages/implementations/texthooker_page.dart',
+  ).readAsStringSync();
+
+  /// 候选签名按「拆分后 → 拆分前」排，命中后还要用语义判据复核，序号本身不作数。
+  const List<String> pickerCandidates = <String>[
+    'Future<ExternalWindowInfo?> _showExternalWindowPicker()',
+    'Future<void> _pickExternalWindow()',
+  ];
+
+  /// 窗口选择器 UI 所在方法的方法体（惰性求值：`expect` / `fail` 只能在 test 里调）。
+  String pickerBody() {
+    for (final String signature in pickerCandidates) {
+      if (!containsCodeLine(source, signature)) continue;
+      final String body = methodBody(source, signature);
+      if (containsCodeLine(body, 'showAppDialog<ExternalWindowInfo>')) {
+        return body;
       }
     }
-    if (parenClose <= 0) throw StateError('参数列表没有闭合：$signatureNeedle');
-    final int bodyOpen = source.indexOf('{', parenClose);
-    if (bodyOpen <= 0) throw StateError('找不到方法体：$signatureNeedle');
-    int depth = 0;
-    for (int i = bodyOpen; i < source.length; i++) {
-      if (source[i] == '{') depth++;
-      if (source[i] == '}') {
-        depth--;
-        if (depth == 0) return source.substring(bodyOpen, i + 1);
-      }
-    }
-    throw StateError('方法体没有闭合：$signatureNeedle');
+    fail('找不到承载窗口选择器对话框（showAppDialog<ExternalWindowInfo>）的方法。'
+        '候选签名：${pickerCandidates.join(' / ')}。'
+        '选择器又被挪走了就把新签名加进候选表，别删断言。');
   }
 
-  // 惰性读取：test 外不能调 expect，故文件解析放在这里、由各用例按需取。
-  String pickerBody() => methodBody(
-        stripDartComments(
-          File('lib/src/pages/implementations/texthooker_page.dart')
-              .readAsStringSync(),
-        ),
-        'Future<void> _pickExternalWindow()',
-      );
+  /// 截出「把窗口列表排好序」那条语句的原文：从声明锚点起，按括号配对找到语句
+  /// 结尾的 `;`。用**语句边界**而不是定长字符窗口——多写一行属性就漂出窗口、
+  /// 或反过来把下一条语句读进来，两个方向都会让断言指向错误的对象。
+  ///
+  /// 断言必须关在这条语句里：`w.pid == gamePid` 这种短锚点在整个方法体上做子串
+  /// 匹配会被同一方法里 `trailing: ... window.pid == gamePid` 的**更长标识符**
+  /// 喂成假绿（`window.pid` 的尾巴就是 `w.pid`）——排序真被改坏了守卫照样绿，
+  /// 本次变异实测抓到的就是这一条。
+  String orderingStatement(String body) {
+    const String anchor = 'final List<ExternalWindowInfo> ordered =';
+    final String structural = maskCommentsAndStrings(body);
+    final int start = structural.indexOf(anchor);
+    if (start < 0) {
+      fail('选择器里找不到窗口排序语句的锚点：$anchor。'
+          '排序被挪走或改名了就更新锚点，别删断言。');
+    }
+    int depth = 0;
+    for (int i = start; i < structural.length; i++) {
+      final String c = structural[i];
+      if (c == '(' || c == '[' || c == '{') depth++;
+      if (c == ')' || c == ']' || c == '}') depth--;
+      if (c == ';' && depth == 0) return body.substring(start, i + 1);
+    }
+    fail('窗口排序语句没有以 `;` 收口（括号不配对）：$anchor');
+  }
+
+  /// 「挑完窗口之后怎么处置」所在方法的方法体：绑定意图那一路。
+  String bindIntentBody() {
+    const String signature = 'Future<void> _pickExternalWindow()';
+    expect(containsCodeLine(source, signature), isTrue,
+        reason: '绑定意图入口 $signature 不见了，选回已绑定窗口的 no-op 守卫无处可锚');
+    final String body = methodBody(source, signature);
+    expect(containsCodeLine(body, '_session.bindWindow('), isTrue,
+        reason: '$signature 必须是把选择结果交给 bindWindow 的那一路，'
+            '否则下面的 no-op 判据锚错了对象');
+    return body;
+  }
 
   test('窗口列表按会话 gamePid 把当前游戏排到最前', () {
     final String body = pickerBody();
-    expect(body.contains('_session.state.gamePid'), isTrue,
+    expect(containsCodeLine(body, '_session.state.gamePid'), isTrue,
         reason: '会话已经知道自己启动的游戏 pid，选择器必须用上它');
-    expect(body.contains('w.pid == gamePid'), isTrue,
-        reason: 'Hibiki 启动的游戏窗口应排在列表最前');
+    // 列表是「命中 gamePid 的一段」+「其余」两段拼起来的，且命中的那段必须在前。
+    final String ordering = maskComments(orderingStatement(body));
+    final int matching = ordering.indexOf('pid == gamePid');
+    final int rest = ordering.indexOf('pid != gamePid');
+    expect(matching, isNonNegative,
+        reason: '排序语句里必须有一段按 `pid == gamePid` 挑出当前游戏的窗口');
+    expect(rest, isNonNegative,
+        reason: '排序语句里必须有互补的一段按 `pid != gamePid` 收尾其余窗口');
+    expect(matching, lessThan(rest),
+        reason: 'Hibiki 启动的游戏窗口应排在列表最前，命中段必须拼在其余段之前');
   });
 
   test('当前游戏那一项预置焦点（打开即选中、回车即绑）', () {
-    expect(pickerBody().contains('autofocus:'), isTrue);
+    // 只断言「出现过 autofocus:」不够：把它写成常量 false 或挂到无关那一行，
+    // 焦点驱动照样丢。这里取实参表达式本身，要求它由会话认定的游戏 pid 决定。
+    final List<String> values = namedArgumentValues(pickerBody(), 'autofocus');
+    expect(values, isNotEmpty,
+        reason: 'BUG-1049：列表项必须有 autofocus，打开即落在正确窗口上、回车就绑');
+    expect(values.any((String v) => v.contains('gamePid')), isTrue,
+        reason: '预置焦点必须落在会话认定的游戏窗口那一行，'
+            '而不是列表第一项或某个常量；实参现在是：${values.join(' | ')}');
   });
 
   test('选回已绑定的窗口是 no-op，不重启会话', () {
     // bindWindow 在捕获模式下会 startAttachedCapture 重启整条会话（launch 会话
     // 会退化成 attach，正在跑的 engine hook 与已收台词一起丢）。
-    expect(pickerBody().contains('picked.hwnd == boundHwnd'), isTrue);
+    final String body = bindIntentBody();
+    final String masked = maskComments(body);
+    // 判据是「和当前已绑定窗口的 hwnd 比中了就直接 return」，与写成局部变量还是
+    // 直接读会话无关：`) return;` 与 `) { return; }` 两种落地形态都认。
+    final RegExpMatch? guard = RegExp(
+      r'picked\.hwnd\s*==\s*([\w.?]+)\s*\)\s*\{?\s*return\s*;',
+    ).firstMatch(masked);
+    expect(guard, isNotNull,
+        reason: '选回已绑定窗口必须立刻 return，不能落到 _session.bindWindow(');
+    final String boundExpr = guard!.group(1)!;
+    final bool readsSessionBound =
+        boundExpr.contains('_session.state.boundWindow?.hwnd') ||
+            RegExp('${RegExp.escape(boundExpr)}\\s*=\\s*'
+                    r'_session\.state\.boundWindow\?\.hwnd')
+                .hasMatch(masked);
+    expect(readsSessionBound, isTrue,
+        reason: '比较的右侧必须真的是会话当前已绑定窗口的 hwnd，'
+            '现在比的是 `$boundExpr`');
   });
 }


### PR DESCRIPTION
## 这是 PR#724 的合并阻塞解法

**整合线建议顺序：先合本 PR，再 rebase / 合 #724。**

本 PR 只改守卫测试一个文件，**对 develop 当前结构与 PR#724 拆分后的结构都绿**，所以先后顺序其实都安全；但先合本 PR 能让 #724 rebase 后直接绿，不必在别人的分支上动守卫。

## 判断题：守卫塌了，不是行为丢了

PR#724（`919b35caa`）把 `_pickExternalWindow` 拆成 `_pickExternalWindow`（处置）+ `_showExternalWindowPicker`（选择器 UI）。守卫 `hibiki/test/pages/texthooker_window_picker_guard_test.dart` 仍从 `_pickExternalWindow` 的方法体取窗口，三条断言整体飘进只剩处置逻辑的旧方法里，全红。

逐条核对被守的三条行为，**没有一条丢**：

| 行为 | develop `45c5f0777` | PR#724 `919b35caa` | 结论 |
|---|---|---|---|
| 按 `gamePid` 把游戏窗口排最前 | `texthooker_page.dart:643-650` | `texthooker_page.dart:658-665`（逐字搬进 `_showExternalWindowPicker`） | 未变 |
| `autofocus` 预置焦点（BUG-1049 焦点驱动） | `texthooker_page.dart:660-664` | `texthooker_page.dart:675-679`（逐字搬） | 未变 |
| 选回已绑定窗口 = no-op | `texthooker_page.dart:687` `if (picked == null \|\| picked.hwnd == boundHwnd) return;` | `texthooker_page.dart:634-636` `if (picked == null \|\| picked.hwnd == _session.state.boundWindow?.hwnd) { return; }` | 语义未变 |

第三条是唯一改了写法的：develop 在弹对话框**之前**把 `_session.state.boundWindow?.hwnd` 存进局部 `boundHwnd`，#724 在对话框**关闭之后**直接读会话。两者都是「和当前已绑定窗口比」；对话框开着期间会话若换了绑定窗口，读后者反而更准。不是行为丢失。

所以 **不建 BUG**。

## 改了什么

两处窗口都改用**语义判据**认，而不是焊死方法名：
- 选择器 = 真的建了 `showAppDialog<ExternalWindowInfo>` 的那个方法（候选签名命中后仍要语义复核，序号不作数）；
- 处置 = 真的调 `_session.bindWindow(` 的那个方法。

认不出来一律 `fail`，绝不静默锚到别处。手写注释剥离全部走 `test/helpers/source_guard.dart`（`methodBody` / `containsCodeLine` / `maskComments` / `namedArgumentValues`）。

### 顺带修掉一条既有假绿（变异实测抓出来的）

原断言 `body.contains('w.pid == gamePid')` 在整个方法体上做子串匹配，会被同一方法里 `trailing: gamePid != null && window.pid == gamePid` 喂成命中——`window.pid` 的尾巴就是 `w.pid`。**把排序谓词从 `==` 改成 `!=`（游戏窗口不再排前），旧断言仍然绿**，实测确认。

现在断言关在 `final List<ExternalWindowInfo> ordered =` 那条语句里（按括号配对切到语句结尾 `;`，语句边界而非定长窗口），并额外钉住「命中段拼在其余段之前」。

`autofocus` 那条也从「出现过 `autofocus:`」抬成「实参表达式必须由 `gamePid` 决定」——写成常量 `false` 即红。**这条断言没有被删弱，只被加强。**

## 变异实测（每条都是断言红，`N tests completed`，不是编译红）

| 变异 | 结果 |
|---|---|
| 排序谓词 `w.pid == gamePid` → `!=` | 🔴 `排序语句里必须有一段按 pid == gamePid 挑出当前游戏的窗口` |
| 两段 spread 对调（游戏排最后） | 🔴 `Hibiki 启动的游戏窗口应排在列表最前` |
| `autofocus:` 值 → `false` | 🔴 `预置焦点必须落在会话认定的游戏窗口那一行…实参现在是：false` |
| `autofocus:` 整行删除 | 🔴 `列表项必须有 autofocus` |
| no-op 判据删除（develop 写法） | 🔴 `选回已绑定窗口必须立刻 return` |
| no-op 判据删除（#724 写法，验新结构） | 🔴 同上 |
| no-op 右侧换成 `gamePid` | 🔴 `比较的右侧必须真的是会话当前已绑定窗口的 hwnd，现在比的是 gamePid` |

还原一律用反向文本替换，还原后 `git status --short` 只剩本 PR 的测试文件。

## 复核证据

```
# 守卫（旧）× develop 45c5f0777
FLUTTER TEST VERDICT: PASSED - 3 tests ran, all tests passed

# 守卫（旧）× PR#724 919b35caa 的 texthooker_page.dart
FLUTTER TEST VERDICT: FAILED - flutter test exited with 1.
  The Flutter test harness reported failures (3 error event(s), 3 test(s) completed).

# 守卫（本 PR）× develop  ->  PASSED - 3 tests
# 守卫（本 PR）× PR#724   ->  PASSED - 3 tests
```

## 门禁

- `flutter analyze`（全量含 test）：`No issues found! (ran in 48.6s)`
- `test/pages` + `test/tools/source_guard_adoption_test.dart` + `test/helpers/source_guard_lexer_test.dart`：`FLUTTER TEST VERDICT: PASSED - 2646 tests ran, all tests passed`

不含 `+build` bump（纯测试改动）。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
