### PR TITLE
feat(gal): 台词浮窗支持按住 Shift 悬停查词 + 置顶按钮

### DIFF
--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -13,6 +13,7 @@ import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/magpie_upscaling.dart';
 import 'package:hibiki/src/mining/magpie_upscaling_service.dart';
+import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/models/preferences_repository.dart';
 import 'package:hibiki/src/pages/implementations/home_game_page.dart';
@@ -32,6 +33,11 @@ typedef GalHookPreferenceWriter = Future<void> Function(
   Object? value,
 );
 
+/// 「悬停即查词」开关的读取口（设置项 `hover_auto_lookup`）。真值在
+/// [ReaderHibikiSource]（media source 偏好store，与本控制器用的 prefsRepo 不是同一
+/// 个存储），所以单独开一条读取口而不是复用 [GalHookPreferenceReader]。
+typedef GalHookHoverAutoLookupReader = bool Function();
+
 /// App 级 Windows Hook 台词浮窗控制器。
 class GalHookTextOverlayController extends ChangeNotifier {
   GalHookTextOverlayController._({
@@ -39,11 +45,13 @@ class GalHookTextOverlayController extends ChangeNotifier {
     GalHookMiningCoordinator? miningCoordinator,
     GalHookPreferenceReader? preferenceReader,
     GalHookPreferenceWriter? preferenceWriter,
+    GalHookHoverAutoLookupReader? hoverAutoLookupReader,
   })  : _session = session ?? GalHookSessionController.instance,
         _miningCoordinator =
             miningCoordinator ?? GalHookMiningCoordinator.instance,
         _preferenceReader = preferenceReader,
-        _preferenceWriter = preferenceWriter;
+        _preferenceWriter = preferenceWriter,
+        _hoverAutoLookupReader = hoverAutoLookupReader;
 
   static final GalHookTextOverlayController instance =
       GalHookTextOverlayController._();
@@ -54,11 +62,13 @@ class GalHookTextOverlayController extends ChangeNotifier {
     GalHookMiningCoordinator? miningCoordinator,
     GalHookPreferenceReader? preferenceReader,
     GalHookPreferenceWriter? preferenceWriter,
+    GalHookHoverAutoLookupReader? hoverAutoLookupReader,
   }) : this._(
           session: session,
           miningCoordinator: miningCoordinator,
           preferenceReader: preferenceReader,
           preferenceWriter: preferenceWriter,
+          hoverAutoLookupReader: hoverAutoLookupReader,
         );
 
   static const String _rectPreferenceKey = 'gal_hook_text_window_rect';
@@ -74,6 +84,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
   final GalHookMiningCoordinator _miningCoordinator;
   final GalHookPreferenceReader? _preferenceReader;
   final GalHookPreferenceWriter? _preferenceWriter;
+  final GalHookHoverAutoLookupReader? _hoverAutoLookupReader;
 
   AppModel? _appModel;
   bool _started = false;
@@ -92,6 +103,9 @@ class GalHookTextOverlayController extends ChangeNotifier {
   /// 已推给 native 的语音控件状态，避免每轮 sync 都发一次 channel 调用。
   bool _pushedReplaying = false;
   bool _pushedRecapturing = false;
+
+  /// 已推给 native 的「悬停即查词」值（show 载荷里带过的也算已推）。
+  bool _pushedHoverAutoLookup = false;
   int? _sessionKey;
   String? _displayedLineId;
   double _opacity = _defaultOpacity;
@@ -328,6 +342,7 @@ class GalHookTextOverlayController extends ChangeNotifier {
         text: latest.text,
         rubySpans: rubySpansToChannel(latest.rubySpans),
       );
+      final bool hoverAutoLookup = _readHoverAutoLookup();
       _visible = await GalHookTextOverlayChannel.show(
         rect: _savedRect,
         fontSize: _fontSize,
@@ -335,7 +350,9 @@ class GalHookTextOverlayController extends ChangeNotifier {
         following: _following,
         passThrough: _passThrough,
         locked: _locked,
+        hoverAutoLookup: hoverAutoLookup,
       );
+      _pushedHoverAutoLookup = hoverAutoLookup;
       // native 在 show 里把语音控件复位（见 flutter_window.cpp），本地镜像跟着复位，
       // 否则下一次 _syncVoiceState 会认为「已经推过了」而不再推。
       _pushedReplaying = false;
@@ -434,6 +451,27 @@ class GalHookTextOverlayController extends ChangeNotifier {
       fontSize: next,
     );
     notifyListeners();
+  }
+
+  /// 「悬停即查词」当前值。默认真值在 [ReaderHibikiSource]（与阅读器 / 视频字幕
+  /// 同一个开关），测试可注入替身。
+  bool _readHoverAutoLookup() {
+    final GalHookHoverAutoLookupReader? reader = _hoverAutoLookupReader;
+    if (reader != null) return reader();
+    return ReaderHibikiSource.instance.hoverAutoLookup;
+  }
+
+  /// BUG-756b 同款纪律：设置页改完「悬停即查词」后调用，把最新值推给已经开着的
+  /// native 浮窗。漏掉这一步，用户得关掉浮窗重开才生效。
+  ///
+  /// Shift-悬停查词不受这个开关控制（它是查词的通用手势，始终可用）；本开关只决定
+  /// 「不按 Shift 也查」。
+  Future<void> applyHoverAutoLookupFromPreferences() async {
+    if (!_started) return;
+    final bool next = _readHoverAutoLookup();
+    if (next == _pushedHoverAutoLookup) return;
+    _pushedHoverAutoLookup = next;
+    await GalHookTextOverlayChannel.setHoverAutoLookup(next);
   }
 
   Future<void> _onLockChanged(bool locked) async {

--- a/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
+++ b/hibiki/lib/src/platform/gal_hook_text_overlay_channel.dart
@@ -209,6 +209,7 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
     bool following = true,
     bool passThrough = false,
     bool locked = false,
+    bool hoverAutoLookup = false,
   }) {
     return _instance.showImpl(<String, Object?>{
       'fontSize': fontSize,
@@ -220,6 +221,12 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
       'windowWidth': 900.0,
       'windowHeight': 140.0,
       'clickLookupEnabled': true,
+      // 置顶（📌 按钮）按会话复位为「开」，与 locked / passThrough / following 同
+      // 规矩：上一局用户关掉置顶，不该让这一局的浮窗藏在全屏游戏后面。
+      'topmost': true,
+      // 「悬停即查词」：true 时浮窗上纯悬停即查词，false 时必须按住 Shift（Shift-悬停
+      // 查词本身始终可用，不受此开关控制）。
+      'hoverAutoLookup': hoverAutoLookup,
       'following': following,
       'passThrough': passThrough,
       'locked': locked,
@@ -291,6 +298,16 @@ class GalHookTextOverlayChannel extends FloatingOverlayChannel {
         'replaying': replaying,
         'recapturing': recapturing,
       },
+    );
+  }
+
+  /// 「悬停即查词」live 下发（设置项 `hover_auto_lookup`）：开着浮窗时改设置立刻生效，
+  /// 不必等下一局游戏。关掉时浮窗退回「按住 Shift 悬停才查词」。
+  static Future<void> setHoverAutoLookup(bool enabled) async {
+    if (!_instance.isSupported) return;
+    await _instance.channel.invokeMethod<void>(
+      'setHoverAutoLookup',
+      <String, Object?>{'enabled': enabled},
     );
   }
 

--- a/hibiki/lib/src/settings/settings_schema_lookup.dart
+++ b/hibiki/lib/src/settings/settings_schema_lookup.dart
@@ -227,6 +227,11 @@ SettingsDestination buildLookupDestination() {
             onChanged: (SettingsContext settingsContext, bool value) async {
               await settingsContext.readerSource
                   .setHoverAutoLookup(value: value);
+              // galgame Hook 台词浮窗是独立 native 窗口，读不到 Dart 侧偏好：不 live
+              // 推一次，用户得关掉浮窗重开才生效（阅读器 / 视频页由
+              // notifyReaderSettingsChanged 覆盖，浮窗不在那条链路上）。
+              await GalHookTextOverlayController.instance
+                  .applyHoverAutoLookupFromPreferences();
               notifyReaderSettingsChanged(settingsContext);
             },
           ),

--- a/hibiki/test/tools/gal_overlay_shift_hover_pin_guard_test.dart
+++ b/hibiki/test/tools/gal_overlay_shift_hover_pin_guard_test.dart
@@ -1,0 +1,325 @@
+// galgame Hook 台词浮窗的两件新交互（源码守卫）：
+//
+//  ① **按住 Shift 悬停查词**——与阅读器 `onShiftHover` / 视频字幕
+//     `_handleShiftHover` 同语义，让「查词快捷键」在 gal 浮窗上也成立；
+//  ② **置顶（📌）按钮**——工具栏槽表里新增一个 always-on-top 开关。
+//
+// 浮窗是 runner 自有的 Win32 分层窗（Direct2D/DirectWrite 直绘，独立于 Flutter
+// 视图树），C++ 无法在 Dart 测试里执行，所以在源码层锁死这两件事的**结构**：
+// 断言全部挑「只可能出现在代码里」的字面量（带类型转换 / 带参数的调用形态），
+// 避免注释里的同名词把守卫变成假绿。
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  final String runner = p.join('windows', 'runner');
+  final String window =
+      File(p.join(runner, 'floating_lyric_window.cpp')).readAsStringSync();
+  final String windowHeader =
+      File(p.join(runner, 'floating_lyric_window.h')).readAsStringSync();
+  final String toolbarHeader =
+      File(p.join(runner, 'hook_toolbar_window.h')).readAsStringSync();
+  final String toolbar =
+      File(p.join(runner, 'hook_toolbar_window.cpp')).readAsStringSync();
+  final String host =
+      File(p.join(runner, 'flutter_window.cpp')).readAsStringSync();
+
+  group('Shift-悬停查词', () {
+    test('点击查词与悬停查词共用同一个派发出口', () {
+      // 两条路径各抄一份「取字 → UTF-8 → 客户区 px 换算成屏幕逻辑 px」，迟早
+      // 会漂成两种锚点行为。出口只能有一个。
+      expect(
+        window.contains('bool FloatingLyricWindow::DispatchLookupAt('),
+        isTrue,
+        reason: '查词派发必须收进 DispatchLookupAt 一个出口',
+      );
+      expect(
+        window.contains(
+            'on_context_lookup_(context_id_, utf8, index, screen_rect)'),
+        isTrue,
+        reason: '查词事件必须带上屏幕逻辑 px 的词矩形（锚定到词而非鼠标）',
+      );
+      expect(
+        'on_context_lookup_(context_id_, utf8, index, screen_rect)'
+            .allMatches(window)
+            .length,
+        1,
+        reason: '派发只能有一处；出现两次说明点击 / 悬停各抄了一份',
+      );
+      // 点击（WM_LBUTTONUP）走的是同一个出口。
+      expect(
+        window.contains('DispatchLookupAt(static_cast<float>(lookup_pt.x),'),
+        isTrue,
+        reason: '单击查词必须走 DispatchLookupAt',
+      );
+    });
+
+    test('鼠标移动与轮询两条触发都汇入 MaybeHoverLookup', () {
+      expect(
+        window.contains('MaybeHoverLookup(static_cast<float>(GET_X_LPARAM('),
+        isTrue,
+        reason: 'WM_MOUSEMOVE 必须驱动悬停查词（按住 Shift 划过即逐字查）',
+      );
+      expect(
+        window.contains('MaybeHoverLookup(static_cast<float>(client.x),'),
+        isTrue,
+        reason: '轮询路径必须用当前光标位置驱动同一个判定函数',
+      );
+    });
+
+    test('Shift 读物理键态（GetAsyncKeyState），不读线程同步键态', () {
+      // 浮窗是 WS_EX_NOACTIVATE 的分层窗，键盘焦点永远在游戏那边：GetKeyState
+      // 读的是本线程消息队列的同步键态，对一个从不收键盘消息的窗口永远不更新，
+      // 用它写出来的 Shift 判据是恒 false。
+      expect(
+        window.contains('GetAsyncKeyState(VK_SHIFT) & 0x8000'),
+        isTrue,
+        reason: 'Shift 必须问全局物理键态',
+      );
+      expect(
+        window.contains('GetKeyState(VK_SHIFT)'),
+        isFalse,
+        reason: 'GetKeyState 在这个永远不获焦的窗口上恒为「未按下」',
+      );
+    });
+
+    test('静止光标也能触发：进窗口挂轮询表，离开 / 隐藏就停表', () {
+      // BUG-880（视频页）同款坑：只绑 hover 事件 = 光标不动时按 Shift 不出词。
+      expect(
+        window.contains('void FloatingLyricWindow::StartHoverLookupPolling()'),
+        isTrue,
+      );
+      expect(
+        window.contains('SetTimer(hwnd_, kHoverLookupTimerId,'),
+        isTrue,
+        reason: '轮询必须真的挂表',
+      );
+      expect(
+        window.contains('KillTimer(hwnd_, kHoverLookupTimerId)'),
+        isTrue,
+        reason: '必须能停表，否则鼠标离开后仍在后台空转',
+      );
+      // 三个停表点：WM_MOUSELEAVE、Hide()、以及轮询自查（光标已在窗外）。
+      expect(
+        'StopHoverLookupPolling();'.allMatches(window).length >= 3,
+        isTrue,
+        reason: '离开 / 隐藏 / 光标已在窗外三处都必须停表',
+      );
+    });
+
+    test('去重锚：同一个字不重复查，换台词 / 移出 / 松 Shift 复位', () {
+      expect(
+        window.contains('if (index == hover_lookup_index_)'),
+        isTrue,
+        reason: '命中同一个字必须直接返回，否则轮询会每 60ms 查一次同一个词',
+      );
+      expect(
+        window.contains('void FloatingLyricWindow::ResetHoverLookupAnchor()'),
+        isTrue,
+      );
+      // UpdateText 里必须复位：换句之后同号下标是另一个字了。
+      final int updateTextAt =
+          window.indexOf('void FloatingLyricWindow::UpdateText(');
+      expect(updateTextAt, greaterThan(0));
+      final String updateTextBody = window.substring(
+          updateTextAt, window.indexOf('void FloatingLyricWindow::Highlight('));
+      expect(
+        updateTextBody.contains('ResetHoverLookupAnchor();'),
+        isTrue,
+        reason: '换台词必须清去重锚，否则新句子里同号的字悬停不查',
+      );
+    });
+
+    test('穿透态不查词：判据写在函数里，不靠「收不到鼠标消息」', () {
+      // 轮询读的是全局光标位置，会绕过 WS_EX_TRANSPARENT 这条天然边界。
+      final int hoverAt =
+          window.indexOf('void FloatingLyricWindow::MaybeHoverLookup(');
+      expect(hoverAt, greaterThan(0));
+      final String hoverBody = window.substring(hoverAt, hoverAt + 1600);
+      expect(
+        hoverBody.contains('if (pass_through_) {'),
+        isTrue,
+        reason: '穿透态「鼠标整个属于游戏」，悬停不得查词',
+      );
+      expect(
+        hoverBody.contains(
+            '!hook_text_mode_ || !click_lookup_enabled_ || pressed_ || dragging_'),
+        isTrue,
+        reason: '悬停查词只属于 gal hook 浮窗，且拖窗 / 按下期间不查；'
+            '歌词条与剪贴板文本窗必须保持「点字才查」',
+      );
+    });
+
+    test('「悬停即查词」开关从 Dart 下发（show 载荷 + live setter）', () {
+      expect(
+        windowHeader.contains('void SetHoverAutoLookup(bool enabled);'),
+        isTrue,
+      );
+      expect(
+        host.contains('SetHoverAutoLookup('),
+        isTrue,
+        reason: 'gal_hook_text channel 必须把偏好接到 native 窗口上',
+      );
+      expect(
+        host.contains('"hoverAutoLookup"'),
+        isTrue,
+        reason: 'show 载荷必须带上开关初值',
+      );
+      expect(
+        host.contains('method == "setHoverAutoLookup"'),
+        isTrue,
+        reason: '设置页改完要能 live 推给开着的浮窗',
+      );
+      final String channel = File(p.join(
+        'lib',
+        'src',
+        'platform',
+        'gal_hook_text_overlay_channel.dart',
+      )).readAsStringSync();
+      expect(channel.contains("'hoverAutoLookup': hoverAutoLookup"), isTrue);
+      expect(
+        channel
+            .contains('static Future<void> setHoverAutoLookup(bool enabled)'),
+        isTrue,
+      );
+      final String controller = File(p.join(
+        'lib',
+        'src',
+        'lookup',
+        'gal_hook_text_overlay_controller.dart',
+      )).readAsStringSync();
+      expect(
+        controller.contains(
+            'Future<void> applyHoverAutoLookupFromPreferences() async'),
+        isTrue,
+      );
+      final String settings = File(p.join(
+        'lib',
+        'src',
+        'settings',
+        'settings_schema_lookup.dart',
+      )).readAsStringSync();
+      expect(
+        settings.contains('applyHoverAutoLookupFromPreferences()'),
+        isTrue,
+        reason: '设置项 onChanged 必须把新值推给浮窗，否则要关掉浮窗重开才生效',
+      );
+    });
+  });
+
+  group('置顶（📌）按钮', () {
+    test('槽表里有 topmost，且排在 close 之前（最右仍是关闭）', () {
+      final int tableStart = toolbarHeader.indexOf('kSlotActions');
+      expect(tableStart, greaterThan(0));
+      final String table = toolbarHeader.substring(
+          tableStart, toolbarHeader.indexOf('};', tableStart));
+      final List<String> actions = RegExp('"([a-zA-Z]+)"')
+          .allMatches(table)
+          .map((RegExpMatch m) => m.group(1)!)
+          .toList();
+      expect(actions.contains('topmost'), isTrue, reason: '缺置顶按钮');
+      expect(actions.last, 'close', reason: '最右按钮必须仍是关闭（肌肉记忆）');
+      expect(
+        actions.indexOf('topmost'),
+        actions.indexOf('close') - 1,
+        reason: '置顶插在关闭之前；插到别处会打乱既有槽位下标',
+      );
+    });
+
+    test('按钮状态：📌 字形 + 真实 topmost 高亮 + 状态参与重绘比对', () {
+      expect(
+        toolbarHeader.contains('bool topmost = true;'),
+        isTrue,
+        reason: 'States 必须带上 topmost，独立工具条窗才画得出高亮',
+      );
+      expect(
+        toolbar.contains(r'return L"\U0001F4CC";'),
+        isTrue,
+        reason: '置顶槽必须有 📌 字形',
+      );
+      expect(
+        toolbar.contains('return states.topmost;'),
+        isTrue,
+        reason: '置顶槽的高亮必须跟随真实 topmost 状态',
+      );
+      expect(
+        toolbar.contains('a.topmost == b.topmost'),
+        isTrue,
+        reason: 'SameStates 漏比 topmost = 点了按钮独立工具条不重绘（看着没反应）',
+      );
+      expect(
+        window.contains('states.topmost = topmost_;'),
+        isTrue,
+        reason: '正文窗必须把自己的 topmost_ 映射进 States',
+      );
+    });
+
+    test('置顶只作用于正文窗：穿透逃生工具条永远保持 topmost', () {
+      // BUG-951：穿透态下那个独立工具条是用户**唯一**能点到的东西，被压到游戏
+      // 底下就等于彻底失联。
+      expect(
+        toolbar.contains('states_.topmost ? HWND_TOPMOST'),
+        isFalse,
+        reason: '逃生工具条的 Z 序不得跟随 pin',
+      );
+      expect(
+        window.contains(
+            'SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,'),
+        isTrue,
+        reason: '正文窗的 pin 必须真的改自己的 Z 序',
+      );
+    });
+
+    test('最小宽度跟着槽数走（9 槽 = 350dip 行宽，下限必须更大）', () {
+      final Match? declared =
+          RegExp(r'kSlotCount\s*=\s*(\d+)\s*;').firstMatch(toolbarHeader);
+      expect(declared, isNotNull);
+      final int slots = int.parse(declared!.group(1)!);
+      final Match? minWidth =
+          RegExp(r'kHookTextMinStripWidthDip = ([\d.]+)f;').firstMatch(window);
+      expect(minWidth, isNotNull);
+      final double floor = double.parse(minWidth!.group(1)!);
+      // 行宽 = N * 按钮 30dip + (N-1) * 间隙 10dip。
+      final double rowWidth = slots * 30.0 + (slots - 1) * 10.0;
+      expect(
+        floor,
+        greaterThanOrEqualTo(rowWidth),
+        reason: '窗口下限比工具栏行还窄 = 用户能把自己的按钮拖没',
+      );
+    });
+
+    test('置顶按会话复位为开（浮窗不会藏在下一局游戏后面）', () {
+      expect(
+        windowHeader.contains('void SetTopmost(bool enabled);'),
+        isTrue,
+        reason: '没有复位入口，native 的 topmost_ 会跨会话粘住',
+      );
+      expect(
+        host.contains('BoolFromValue(args, "topmost", true)'),
+        isTrue,
+        reason: 'show 必须按载荷复位置顶',
+      );
+      final String channel = File(p.join(
+        'lib',
+        'src',
+        'platform',
+        'gal_hook_text_overlay_channel.dart',
+      )).readAsStringSync();
+      expect(
+        channel.contains("'topmost': true"),
+        isTrue,
+        reason: '每次 show 都要把置顶复位成开',
+      );
+    });
+
+    test('恢复出来的旧窗口宽度会被夹到当前下限', () {
+      expect(
+        window.contains('std::max(restored_width, min_width)'),
+        isTrue,
+        reason: '老版本存下的窄窗口恢复后会裁掉首尾按钮',
+      );
+    });
+  });
+}

--- a/hibiki/windows/runner/floating_lyric_window.cpp
+++ b/hibiki/windows/runner/floating_lyric_window.cpp
@@ -31,11 +31,17 @@ constexpr float kControlsTopDip = 8.0f;
 // Bottom-right resize grip and the min / max the user may drag the bar to.
 constexpr float kResizeGripDip = 18.0f;
 constexpr float kMinStripWidthDip = 280.0f;
-// Hook mode draws a centred 8-slot toolbar (8 * 30 + 7 * 10 = 310dip). The
+// Hook mode draws a centred 9-slot toolbar (9 * 30 + 8 * 10 = 350dip). The
 // generic 280dip floor would let the user drag the window narrower than its own
 // controls, clipping the leading voice buttons; hook mode therefore floors at
-// the toolbar width plus a small margin.
-constexpr float kHookTextMinStripWidthDip = 330.0f;
+// the toolbar width plus a small margin. Bump this whenever kSlotCount grows —
+// the floor is derived from the row width, not from a taste-based round number.
+constexpr float kHookTextMinStripWidthDip = 370.0f;
+// Shift-悬停查词的轮询表（只在鼠标停在浮窗里时挂着，见 StartHoverLookupPolling）。
+// 60ms ≈ 一次按键的最短可感知延迟，且远低于用户「按下 Shift 想看词」的心理预期；
+// 只在窗口内轮询，代价是一次 GetAsyncKeyState + 一次 DWrite 命中测试。
+constexpr UINT_PTR kHoverLookupTimerId = 1;
+constexpr UINT kHoverLookupPollMs = 60;
 constexpr float kMinStripHeightDip = 64.0f;
 constexpr float kMaxStripWidthDip = 2400.0f;
 constexpr float kMaxStripHeightDip = 480.0f;
@@ -322,9 +328,13 @@ bool FloatingLyricWindow::Show(HWND owner) {
       const int restored_width = initial_bounds_.right - initial_bounds_.left;
       const int restored_height = initial_bounds_.bottom - initial_bounds_.top;
       if (restored_width > 0 && restored_height > 0) {
+        // 存下来的宽度可能比**今天**的工具栏还窄（老版本槽位少、下限也低）。不夹
+        // 一下，恢复出来的窗口会把首尾按钮裁掉；下限本身就是按当前槽数算的。
+        const int min_width =
+            static_cast<int>(ScaleForDpi(MinStripWidthDip()));
         SetWindowPos(hwnd_, HWND_TOPMOST, initial_bounds_.left,
-                     initial_bounds_.top, restored_width, restored_height,
-                     SWP_NOACTIVATE);
+                     initial_bounds_.top, std::max(restored_width, min_width),
+                     restored_height, SWP_NOACTIVATE);
         SyncStripSizeFromWindow();
         ClampCurrentPositionToWindowMonitor();
       }
@@ -347,6 +357,9 @@ void FloatingLyricWindow::Hide() {
   hovered_ = false;
   tracking_mouse_leave_ = false;
   dragging_ = false;
+  // 隐藏后收不到 WM_MOUSELEAVE：定时器留着就是后台空转。
+  StopHoverLookupPolling();
+  ResetHoverLookupAnchor();
   // BUG-951: hand clicks back unconditionally and take the toolbar down with
   // the body. A hidden window that is still WS_EX_TRANSPARENT would come back
   // click-through even if pass-through was switched off while hidden.
@@ -388,6 +401,9 @@ void FloatingLyricWindow::UpdateText(const std::wstring& text,
   // 的分支——那个分支要成立，前提是新旧文本连续，而 hook 台词从来不是。
   scroll_offset_px_ = 0.0f;
   scroll_max_px_ = 0.0f;
+  // 换了台词，去重锚指的那个下标已经是另一个字了：不清就会出现「新句子里鼠标下
+  // 的字正好同号 → 悬停不查」。
+  ResetHoverLookupAnchor();
   RequestRender();
 }
 
@@ -467,6 +483,29 @@ void FloatingLyricWindow::SetVoiceState(bool replaying, bool recapturing) {
 
 void FloatingLyricWindow::SetClickLookupEnabled(bool enabled) {
   click_lookup_enabled_ = enabled;
+}
+
+void FloatingLyricWindow::SetTopmost(bool enabled) {
+  topmost_ = enabled;
+  if (hwnd_ == nullptr) {
+    // 还没建窗：Show() 自己会按 topmost_ 插入 Z 序。
+    return;
+  }
+  // 不做「值没变就早退」：Dart 每局 show 会再调一次 SetTopmost(true)，同值也把窗口
+  // 重新插到 Z 序顶上——上一局被别的窗口爬到上面时，这一次复位就是把它拉回来。
+  SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
+               SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
+  RequestRender();
+}
+
+void FloatingLyricWindow::SetHoverAutoLookup(bool enabled) {
+  if (hover_auto_lookup_ == enabled) {
+    return;
+  }
+  hover_auto_lookup_ = enabled;
+  // 开关一变，上一次的去重锚就没有意义了（刚关掉时更要清，否则重新按 Shift 停在
+  // 同一个字上会被当成「已经查过」）。
+  ResetHoverLookupAnchor();
 }
 
 bool FloatingLyricWindow::ScrollBy(float delta_px) {
@@ -638,6 +677,7 @@ hook_toolbar::States FloatingLyricWindow::ToolbarStates() const {
   states.playing = playing_;
   states.pass_through = pass_through_;
   states.locked = locked_;
+  states.topmost = topmost_;
   return states;
 }
 
@@ -753,6 +793,9 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
           tracking_mouse_leave_ = true;
         }
       }
+      // 鼠标进了窗口才开轮询表：静止光标上按下 Shift 也要能出词（BUG-880 在视频页
+      // 的同款坑）。离开窗口时 WM_MOUSELEAVE 停表。
+      StartHoverLookupPolling();
       if (dragging_) {
         POINT cursor;
         GetCursorPos(&cursor);
@@ -796,10 +839,39 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
           dragging_ = true;
         }
       }
+      // Shift-悬停查词：按住 Shift 在台词上划过即逐字查词（与阅读器 / 视频字幕的
+      // onShiftHover 同语义）。命中新字才派发一次，见 MaybeHoverLookup。
+      MaybeHoverLookup(static_cast<float>(GET_X_LPARAM(lparam)),
+                       static_cast<float>(GET_Y_LPARAM(lparam)));
+      return 0;
+    }
+    case WM_TIMER: {
+      if (wparam != kHoverLookupTimerId) {
+        return DefWindowProc(hwnd_, message, wparam, lparam);
+      }
+      // 轮询只补一件 WM_MOUSEMOVE 补不了的事：光标不动、用户刚按下 Shift。光标位置
+      // 现问系统（不缓存），落在窗口外就直接停表——WM_MOUSELEAVE 偶尔会因为窗口 Z
+      // 序变化而不来，这是兜底。
+      POINT cursor;
+      if (!GetCursorPos(&cursor)) {
+        return 0;
+      }
+      RECT rc;
+      if (!GetWindowRect(hwnd_, &rc) || !PtInRect(&rc, cursor)) {
+        StopHoverLookupPolling();
+        ResetHoverLookupAnchor();
+        return 0;
+      }
+      POINT client = cursor;
+      ScreenToClient(hwnd_, &client);
+      MaybeHoverLookup(static_cast<float>(client.x),
+                       static_cast<float>(client.y));
       return 0;
     }
     case WM_MOUSELEAVE: {
       tracking_mouse_leave_ = false;
+      StopHoverLookupPolling();
+      ResetHoverLookupAnchor();
       if (hovered_ && !dragging_) {
         hovered_ = false;
         RequestRender();
@@ -854,37 +926,9 @@ LRESULT FloatingLyricWindow::HandleMessage(UINT message, WPARAM wparam,
       }
       // A press that never moved into a drag over the lyric text fires the word
       // lookup now — single-tap lookup preserved.
-      if (!was_dragging && was_pressed && was_text &&
-          (on_lookup_ || on_context_lookup_)) {
-        D2D1_RECT_F char_rect = {};
-        const int index = CharIndexAt(static_cast<float>(lookup_pt.x),
-                                      static_cast<float>(lookup_pt.y),
-                                      &char_rect);
-        if (index >= 0) {
-          int utf8_len = WideCharToMultiByte(CP_UTF8, 0, text_.c_str(),
-                                             static_cast<int>(text_.size()),
-                                             nullptr, 0, nullptr, nullptr);
-          std::string utf8(utf8_len, '\0');
-          WideCharToMultiByte(CP_UTF8, 0, text_.c_str(),
-                              static_cast<int>(text_.size()), utf8.data(),
-                              utf8_len, nullptr, nullptr);
-          if (on_context_lookup_) {
-            // Client-area physical px -> screen logical px: the lookup card
-            // anchors to the tapped word, so it must be in the same unit
-            // system Dart uses for screen rects.
-            const float scale = std::max(0.01f, static_cast<float>(dpi_) / 96.0f);
-            RECT wr = {};
-            GetWindowRect(hwnd_, &wr);
-            const D2D1_RECT_F screen_rect = D2D1::RectF(
-                (wr.left + char_rect.left) / scale,
-                (wr.top + char_rect.top) / scale,
-                (wr.left + char_rect.right) / scale,
-                (wr.top + char_rect.bottom) / scale);
-            on_context_lookup_(context_id_, utf8, index, screen_rect);
-          } else if (on_lookup_) {
-            on_lookup_(utf8, index);
-          }
-        }
+      if (!was_dragging && was_pressed && was_text) {
+        DispatchLookupAt(static_cast<float>(lookup_pt.x),
+                         static_cast<float>(lookup_pt.y));
       }
       if (was_dragging) {
         NotifyBoundsChanged();
@@ -1382,7 +1426,7 @@ void FloatingLyricWindow::Render() {
 
     // Controls appear only on hover. Clipboard mode keeps its historical
     // right-aligned buttons (transparency, pin/topmost, lock); Hook mode uses a
-    // centred six-button core toolbar. Their hit areas in ControlActionAt() are
+    // centred shared-slot core toolbar. Their hit areas in ControlActionAt() are
     // gated on hovered_ too, so a click can never hit an invisible button.
     if (hovered_ && draw_body_toolbar) {
       Microsoft::WRL::ComPtr<ID2D1SolidColorBrush> tb_bg;
@@ -1419,7 +1463,7 @@ void FloatingLyricWindow::Render() {
         const float left = (width - controls_total) / 2.0f;
         // Glyph + active tint come from the shared slot table, so the in-body
         // toolbar and the standalone pass-through toolbar always draw the same
-        // eight buttons in the same order (BUG-951).
+        // buttons in the same order (BUG-951).
         const hook_toolbar::States tb_states = ToolbarStates();
         for (int slot = 0; slot < kHookTextControlSlotCount; ++slot) {
           draw_tbtn(left + slot * (t_btn + t_gap),
@@ -1575,13 +1619,17 @@ void FloatingLyricWindow::DispatchControlAction(const std::string& action) {
     return;
   }
   if (action == "topmost") {
-    // The text-only Luna toolbar pin button: toggle always-on-top locally
-    // (LunaTranslator #36). Handled natively — no Dart round-trip — and every
-    // window-Z SetWindowPos reads topmost_ so the new state sticks.
-    topmost_ = !topmost_;
-    SetWindowPos(hwnd_, topmost_ ? HWND_TOPMOST : HWND_NOTOPMOST, 0, 0, 0, 0,
-                 SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE);
-    RequestRender();
+    // 按钮按下 = 翻转，落地走 SetTopmost（与 Dart 的会话复位同一条路径）。
+    // Pin button (clipboard Luna toolbar + galgame hook toolbar slot 7): toggle
+    // always-on-top locally (LunaTranslator #36). Handled natively — no Dart
+    // round-trip — and every window-Z SetWindowPos reads topmost_ so the new
+    // state sticks. Re-pinning also re-asserts HWND_TOPMOST, which is the way
+    // back up when another window has since climbed over the overlay.
+    //
+    // 只作用于**正文窗**。穿透态下的独立工具条窗（HookToolbarWindow）永远保持
+    // HWND_TOPMOST：它是 BUG-951 的逃生口，被压到游戏底下就等于用户再也回不来，
+    // 所以这里刻意不把 Z 同步给它。
+    SetTopmost(!topmost_);
     return;
   }
   if (on_control_) {
@@ -1698,6 +1746,104 @@ void FloatingLyricWindow::SyncStripSizeFromWindow() {
   }
   strip_width_dip_ = static_cast<float>(rc.right - rc.left) / scale;
   strip_height_dip_ = static_cast<float>(rc.bottom - rc.top) / scale;
+}
+
+bool FloatingLyricWindow::DispatchLookupAt(float x, float y) {
+  if (on_lookup_ == nullptr && on_context_lookup_ == nullptr) {
+    return false;
+  }
+  D2D1_RECT_F char_rect = {};
+  const int index = CharIndexAt(x, y, &char_rect);
+  if (index < 0) {
+    return false;
+  }
+  int utf8_len =
+      WideCharToMultiByte(CP_UTF8, 0, text_.c_str(),
+                          static_cast<int>(text_.size()), nullptr, 0, nullptr,
+                          nullptr);
+  std::string utf8(utf8_len, '\0');
+  WideCharToMultiByte(CP_UTF8, 0, text_.c_str(),
+                      static_cast<int>(text_.size()), utf8.data(), utf8_len,
+                      nullptr, nullptr);
+  if (on_context_lookup_) {
+    // Client-area physical px -> screen logical px: the lookup card
+    // anchors to the tapped word, so it must be in the same unit
+    // system Dart uses for screen rects.
+    const float scale = std::max(0.01f, static_cast<float>(dpi_) / 96.0f);
+    RECT wr = {};
+    GetWindowRect(hwnd_, &wr);
+    const D2D1_RECT_F screen_rect =
+        D2D1::RectF((wr.left + char_rect.left) / scale,
+                    (wr.top + char_rect.top) / scale,
+                    (wr.left + char_rect.right) / scale,
+                    (wr.top + char_rect.bottom) / scale);
+    on_context_lookup_(context_id_, utf8, index, screen_rect);
+    return true;
+  }
+  on_lookup_(utf8, index);
+  return true;
+}
+
+void FloatingLyricWindow::ResetHoverLookupAnchor() { hover_lookup_index_ = -1; }
+
+void FloatingLyricWindow::MaybeHoverLookup(float x, float y) {
+  // 只有 gal hook 浮窗走悬停查词：歌词条 / 剪贴板文本窗保持「点字才查」，一字不改。
+  // 按下左键的那段（pending press / 拖窗 / 拉伸）里也不查——那是另一套手势，用户
+  // 正在移动窗口，不是在读词。
+  if (!hook_text_mode_ || !click_lookup_enabled_ || pressed_ || dragging_) {
+    return;
+  }
+  // 穿透态下「鼠标整个属于游戏」（BUG-951 的契约）：正文窗带 WS_EX_TRANSPARENT，
+  // 系统根本不投鼠标消息给它，但轮询定时器读的是全局光标位置，会绕过这条边界 ——
+  // 所以判据必须写在这里，而不是指望收不到消息。
+  if (pass_through_) {
+    StopHoverLookupPolling();
+    ResetHoverLookupAnchor();
+    return;
+  }
+  if (on_lookup_ == nullptr && on_context_lookup_ == nullptr) {
+    return;
+  }
+  // Shift 只能问**物理**键态：这个窗口是 WS_EX_NOACTIVATE 的分层窗，键盘焦点永远
+  // 在游戏那边，GetKeyState 读的是本线程消息队列的同步键态（对一个从不收键盘消息
+  // 的窗口来说永远不会更新）。GetAsyncKeyState 读的是全局实时键态，才是对的。
+  const bool shift = (GetAsyncKeyState(VK_SHIFT) & 0x8000) != 0;
+  if (!shift && !hover_auto_lookup_) {
+    ResetHoverLookupAnchor();
+    return;
+  }
+  const int index = CharIndexAt(x, y);
+  if (index < 0) {
+    // 移出文本区（空白 / 工具条 / 滚动条）即松锚，回来时同一个字仍会再查一次。
+    ResetHoverLookupAnchor();
+    return;
+  }
+  if (index == hover_lookup_index_) {
+    return;  // 同一个字：抖动、轮询都不重复查词。
+  }
+  hover_lookup_index_ = index;
+  if (!DispatchLookupAt(x, y)) {
+    ResetHoverLookupAnchor();
+  }
+}
+
+void FloatingLyricWindow::StartHoverLookupPolling() {
+  if (hover_poll_active_ || hwnd_ == nullptr || !hook_text_mode_) {
+    return;
+  }
+  if (SetTimer(hwnd_, kHoverLookupTimerId, kHoverLookupPollMs, nullptr) != 0) {
+    hover_poll_active_ = true;
+  }
+}
+
+void FloatingLyricWindow::StopHoverLookupPolling() {
+  if (!hover_poll_active_) {
+    return;
+  }
+  if (hwnd_ != nullptr) {
+    KillTimer(hwnd_, kHoverLookupTimerId);
+  }
+  hover_poll_active_ = false;
 }
 
 int FloatingLyricWindow::CharIndexAt(float x, float y,

--- a/hibiki/windows/runner/floating_lyric_window.h
+++ b/hibiki/windows/runner/floating_lyric_window.h
@@ -149,6 +149,10 @@ class FloatingLyricWindow {
   // window, so this is the only place the user can see either state.
   void SetVoiceState(bool replaying, bool recapturing);
   void SetClickLookupEnabled(bool enabled);
+  // 「悬停即查词」（Dart 偏好 `hover_auto_lookup`，与阅读器 / 视频字幕同一开关）。
+  // 关闭时（默认）hook 浮窗只在**按住 Shift** 悬停时查词；打开时纯悬停即查。
+  // Shift-悬停本身不受此开关控制，它是查词的通用手势。
+  void SetHoverAutoLookup(bool enabled);
   // Text-only mode (the transparent clipboard text window): the strip draws
   // ONLY the draggable, tappable text — no playback / lock / close control
   // buttons and no resize grip. Drag + single-tap word lookup still work exactly
@@ -157,8 +161,9 @@ class FloatingLyricWindow {
   // false so its rendering + hit-testing stay byte-for-byte unchanged.
   void SetTextOnly(bool text_only) { text_only_ = text_only; }
   // Rich text-only mode used by the galgame Hook window. It keeps the text-only
-  // rendering surface but enables wrapping, resizing, the six-button core
-  // toolbar, line-context lookup and body pass-through.
+  // rendering surface but enables wrapping, resizing, the shared-slot
+  // toolbar (hook_toolbar::kSlotActions), line-context lookup and body
+  // pass-through.
   void SetHookTextMode(bool enabled) {
     hook_text_mode_ = enabled;
     if (enabled) text_only_ = true;
@@ -183,6 +188,11 @@ class FloatingLyricWindow {
   // created.
   void SetPassThrough(bool enabled);
   bool IsPassThrough() const { return pass_through_; }
+  // 置顶（📌）。用户按按钮时由 DispatchControlAction 就地翻转；这个入口给 Dart 在
+  // 每次 show 时**按会话复位**用——与 locked / passThrough / following 同规矩，
+  // 不然上一局关掉置顶之后，下一局浮窗会藏在全屏游戏后面，用户只会以为它没出来。
+  void SetTopmost(bool enabled);
+  bool IsTopmost() const { return topmost_; }
   // Restores a physical-pixel window rectangle before the next Show. Invalid
   // rectangles are ignored and Show uses its DPI-aware default.
   void SetInitialBounds(int left, int top, int width, int height);
@@ -217,6 +227,23 @@ class FloatingLyricWindow {
 
   // Returns the control action at the client point, or empty when none.
   std::string ControlActionAt(float x, float y);
+
+  // 把 client 点上的那个字送去查词（回调带屏幕逻辑 px 的词矩形）。点击查词与
+  // Shift-悬停查词共用这一个出口，两条路径的取词、坐标换算、载荷永远同形。
+  // 返回是否真的派发了一次查词。
+  bool DispatchLookupAt(float x, float y);
+
+  // Shift-悬停查词（gal hook 浮窗）。命中新字才派发一次，因此鼠标在同一个字上
+  // 抖动、或定时器每次轮询都不会重复查词。
+  void MaybeHoverLookup(float x, float y);
+  // 复位悬停去重锚（松开 Shift / 移出文本 / 换台词），使下次进入同一个字仍会查。
+  void ResetHoverLookupAnchor();
+  // 只在鼠标停在窗口里时开着的轮询定时器：浮窗是 WS_EX_NOACTIVATE 的分层窗，键盘
+  // 焦点永远在游戏那边，收不到任何 WM_KEYDOWN，所以「光标不动、按下 Shift」只能靠
+  // 轮询物理键态发现（这正是 BUG-880 在视频页踩过的坑：只绑 hover 事件 = 不抖鼠标
+  // 就不出词）。离开窗口即停表，不在后台空转。
+  void StartHoverLookupPolling();
+  void StopHoverLookupPolling();
 
   // Runs a toolbar action. Single dispatcher shared by the in-body toolbar
   // (WM_LBUTTONDOWN) and the standalone pass-through toolbar window, so a
@@ -296,7 +323,7 @@ class FloatingLyricWindow {
   void ClampCurrentPositionToWindowMonitor();
 
   // Narrowest width the strip may be resized / restored to. Hook mode floors at
-  // its own 8-slot toolbar width so the voice buttons can never be clipped.
+  // its own toolbar row width so the voice buttons can never be clipped.
   float MinStripWidthDip() const;
 
   HWND hwnd_ = nullptr;
@@ -307,6 +334,13 @@ class FloatingLyricWindow {
   bool replaying_ = false;
   bool recapturing_ = false;
   bool click_lookup_enabled_ = true;
+  // 「悬停即查词」偏好镜像（见 SetHoverAutoLookup）。false 时悬停查词需按住 Shift。
+  bool hover_auto_lookup_ = false;
+  // Shift-悬停查词去重锚：上一次真正派发查词的字下标（-1 = 无）。命中同一个字不
+  // 重复查词——鼠标横穿一行时按字触发，停住不动时不刷屏。
+  int hover_lookup_index_ = -1;
+  // 悬停轮询定时器是否已挂（只在鼠标在窗口内时挂着）。
+  bool hover_poll_active_ = false;
   // Text-only clipboard window: suppress control buttons + resize grip, use the
   // full window height for text. Never true for the audiobook lyric strip.
   bool text_only_ = false;

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -1020,6 +1020,12 @@ void FlutterWindow::RegisterGalHookTextChannel() {
           gal_hook_text_window_->UpdateStyle(StyleFromArgs(args));
           gal_hook_text_window_->SetClickLookupEnabled(
               BoolFromValue(args, "clickLookupEnabled", true));
+          gal_hook_text_window_->SetHoverAutoLookup(
+              BoolFromValue(args, "hoverAutoLookup", false));
+          // 置顶按会话复位（与 locked / passThrough / following 同规矩）：上一局
+          // 关掉置顶后，这一局的浮窗不该藏在全屏游戏后面让用户以为它没出来。
+          gal_hook_text_window_->SetTopmost(
+              BoolFromValue(args, "topmost", true));
           gal_hook_text_window_->SetLocked(
               BoolFromValue(args, "locked", false));
           gal_hook_text_window_->SetPassThrough(
@@ -1053,6 +1059,12 @@ void FlutterWindow::RegisterGalHookTextChannel() {
         } else if (method == "setClickLookupEnabled") {
           gal_hook_text_window_->SetClickLookupEnabled(
               BoolFromValue(args, "enabled", true));
+          result->Success();
+        } else if (method == "setHoverAutoLookup") {
+          // 「悬停即查词」live 下发：设置页一改，正在开着的浮窗立刻跟上，不必等下
+          // 一局游戏（与字号 applyFontSizeFromPreferences 同款纪律）。
+          gal_hook_text_window_->SetHoverAutoLookup(
+              BoolFromValue(args, "enabled", false));
           result->Success();
         } else if (method == "setLocked") {
           gal_hook_text_window_->SetLocked(

--- a/hibiki/windows/runner/hook_toolbar_window.cpp
+++ b/hibiki/windows/runner/hook_toolbar_window.cpp
@@ -60,7 +60,7 @@ bool SameStyle(const hook_toolbar::Style& a, const hook_toolbar::Style& b) {
 bool SameStates(const hook_toolbar::States& a, const hook_toolbar::States& b) {
   return a.replaying == b.replaying && a.recapturing == b.recapturing &&
          a.playing == b.playing && a.pass_through == b.pass_through &&
-         a.locked == b.locked;
+         a.locked == b.locked && a.topmost == b.topmost;
 }
 
 }  // namespace
@@ -84,6 +84,8 @@ const wchar_t* SlotGlyph(int slot, const States& states) {
     case 6:
       return L"▣";  // ▣ workbench
     case 7:
+      return L"\U0001F4CC";  // 📌 always-on-top pin
+    case 8:
       return L"✕";  // ✕ close
     default:
       return L"";
@@ -102,6 +104,8 @@ bool SlotActive(int slot, const States& states) {
       return states.pass_through;
     case 5:
       return states.locked;
+    case 7:
+      return states.topmost;
     default:
       return false;
   }

--- a/hibiki/windows/runner/hook_toolbar_window.h
+++ b/hibiki/windows/runner/hook_toolbar_window.h
@@ -49,7 +49,7 @@ namespace hook_toolbar {
 // Draw / hit-test order of the galgame hook toolbar. Single source of truth:
 // FloatingLyricWindow::ControlActionAt() indexes the same table, so the body
 // window and the standalone toolbar can never disagree about what a slot does.
-constexpr int kSlotCount = 8;
+constexpr int kSlotCount = 9;
 constexpr const char* kSlotActions[kSlotCount] = {
     "replayVoice",         // 0 replay the line's captured audio
     "recaptureVoice",      // 1 open a recapture window
@@ -58,7 +58,13 @@ constexpr const char* kSlotActions[kSlotCount] = {
     "toggleTransparency",  // 4 one-click background transparency
     "lock",                // 5 position lock
     "openWorkbench",       // 6 capture workbench
-    "close",               // 7 close the overlay
+    // 7 always-on-top pin. Handled natively in DispatchControlAction (no Dart
+    // round-trip), exactly like the clipboard window's 📌 — the overlay is born
+    // topmost, and this is the only way to drop it behind another window
+    // without closing it. Inserted ahead of the close slot so the rightmost
+    // button is still 关闭 (muscle memory) and slots 0..6 keep their index.
+    "topmost",
+    "close",  // 8 close the overlay
 };
 
 // Button states that change a slot's glyph or its active tint.
@@ -68,6 +74,9 @@ struct States {
   bool playing = false;
   bool pass_through = false;
   bool locked = false;
+  // Mirrors FloatingLyricWindow::topmost_ so the pin renders lit while the
+  // overlay really is HWND_TOPMOST. Default true = the overlay's own default.
+  bool topmost = true;
 };
 
 // Colours, mirrored from the body window's Style so both toolbars look alike.


### PR DESCRIPTION
## 起因

用户诉求两条：
1. gal 台词浮窗要支持**按住 Shift（查词快捷键）查词** —— 阅读器 / 视频字幕 / 浏览器扩展早就是 Shift-悬停查词，只有这个浮窗还必须点一下。
2. gal 浮窗要有**「在最上面」（置顶）按钮**。

浮窗是 runner 自有的 Win32 分层窗（`FloatingLyricWindow` hook 模式 + 穿透态的 `HookToolbarWindow`），不是 Flutter widget，所以两件事都落在 C++ 侧。

## Shift-悬停查词

- **一个派发出口**：把 `WM_LBUTTONUP` 里那段「取字 → UTF-8 → 客户区物理 px 换算成屏幕逻辑 px」抽成 `DispatchLookupAt()`，点击与悬停共用，词矩形锚点不会漂成两套。
- **Shift 读物理键态**：浮窗是 `WS_EX_NOACTIVATE` 分层窗，键盘焦点永远在游戏那边，`GetKeyState` 读的是本线程消息队列同步键态，对它恒为「未按下」→ 必须 `GetAsyncKeyState`。
- **静止光标也能触发**：鼠标进窗口挂 60ms 轮询表，离开 / 隐藏 / 光标已在窗外即停表。这正是 BUG-880 在视频页踩过的坑（只绑 hover 事件 = 不抖鼠标就不出词）。
- **去重**：命中同一个字不重复查；松 Shift / 移出文本 / 换台词复位锚。
- **穿透态不查词**：轮询读的是全局光标位置，会绕过 `WS_EX_TRANSPARENT` 这条天然边界，所以判据显式写在 `MaybeHoverLookup()` 里。
- **只属于 gal 浮窗**：歌词条 / 剪贴板文本窗（同一个类的另外两个实例）保持「点字才查」，一字不改。
- 顺带接上「悬停即查词」偏好（`hover_auto_lookup`，与阅读器 / 视频同一开关）：`show` 载荷带初值，设置页改完 live 推给开着的浮窗。Shift-悬停本身不受这个开关控制。

## 置顶（📌）按钮

- `hook_toolbar::kSlotActions` 加 `topmost` 槽，**插在 close 之前**（最右仍是关闭，0..6 槽位下标不变），槽数 8 → 9；`States.topmost` 参与 `SameStates` 比对，否则穿透态的独立工具条点了不重绘。
- **只改正文窗 Z 序**：穿透态那个独立工具条窗永远保持 `HWND_TOPMOST` —— 它是 BUG-951 的逃生口，被压到游戏底下等于用户彻底失联。
- **每次 show 复位为「开」**：与 locked / passThrough / following 同规矩。否则上一局关掉置顶，下一局浮窗藏在全屏游戏后面，用户只会以为它没出来。
- 工具栏行宽 350dip，窗口最小宽度 330 → 370dip；恢复旧版本存下的窄窗口时夹到当前下限，免得首尾按钮被裁掉。

## 验证

- `flutter analyze`（含 test）：No issues found。
- `dart run tool/flutter_test_failures.dart --no-pub test/tools/... test/lookup/`：**611 tests ran, all passed**。
- 新守卫 `hibiki/test/tools/gal_overlay_shift_hover_pin_guard_test.dart` 做过 3 次变异实测，每次都真红：① `GetAsyncKeyState` → `GetKeyState`；② 删掉穿透门；③ 把置顶槽换到 close 之后。
- `flutter build windows --debug`：编译通过（native 改动 Dart 测不到，这是唯一的编译门）。
- ⚠️ **真机 gal 会话未验**：需要在真实游戏里确认「按住 Shift 划过台词逐字出词」「📌 点灭后浮窗能被别的窗口盖住、点亮后回到最上面」。

https://claude.ai/code/session_01MFK3A5CXSBvateNdEW2j1V