### PR TITLE
漫画设置独立成大类 + 缩放/翻页/音量键 + 互联 OCR + 通知统一配色

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52870 (3110 per locale)
+/// Strings: 53091 (3123 per locale)
 ///
-/// Built on 2026-08-02 at 12:49 UTC
+/// Built on 2026-08-02 at 16:17 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4185,6 +4185,22 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
       'Preview is read-only. Install the extension to open and read.';
   String get selection_copy_empty => 'No text selected.';
   String get video_subtitle_replay => 'Replay this line';
+  String get manga_ocr_done => 'OCR complete';
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  String get manga_page_animation => 'Page turn animation';
+  String get manga_page_animation_none => 'None';
+  String get manga_page_animation_slide => 'Slide';
+  String get manga_page_animation_fade => 'Fade';
+  String get manga_default_zoom => 'Default zoom';
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -11329,6 +11345,35 @@ class _StringsAr extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -18540,6 +18585,35 @@ class _StringsDe extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -25766,6 +25840,35 @@ class _StringsEs extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -33004,6 +33107,35 @@ class _StringsFr extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -40171,6 +40303,35 @@ class _StringsId extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -47384,6 +47545,35 @@ class _StringsIt extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -54414,6 +54604,35 @@ class _StringsJa extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -61446,6 +61665,35 @@ class _StringsKo extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -68639,6 +68887,35 @@ class _StringsNl extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -75845,6 +76122,35 @@ class _StringsPtBr extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -83035,6 +83341,35 @@ class _StringsRu extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -90173,6 +90508,35 @@ class _StringsTh extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -97343,6 +97707,35 @@ class _StringsTr extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -104498,6 +104891,35 @@ class _StringsVi extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 // Path: <root>
@@ -111153,6 +111575,32 @@ class _StringsZhCn extends _StringsEn {
   String get selection_copy_empty => '未选中文本。';
   @override
   String get video_subtitle_replay => '重播本句';
+  @override
+  String get manga_ocr_done => 'OCR 已完成';
+  @override
+  String get settings_destination_manga_summary => '阅读器、OCR 与在线目录';
+  @override
+  String get manga_page_animation => '翻页动画';
+  @override
+  String get manga_page_animation_none => '无';
+  @override
+  String get manga_page_animation_slide => '滑动';
+  @override
+  String get manga_page_animation_fade => '淡入淡出';
+  @override
+  String get manga_default_zoom => '默认缩放';
+  @override
+  String get manga_zoom_sensitivity => '缩放灵敏度';
+  @override
+  String get manga_volume_key_paging => '音量键翻页';
+  @override
+  String get manga_volume_key_paging_subtitle => '在漫画阅读器中用音量加减键翻页';
+  @override
+  String get manga_tap_zone_paging => '点击边缘翻页';
+  @override
+  String get manga_tap_zone_paging_subtitle => '点击页面左右边缘翻页';
+  @override
+  String get manga_section_viewing => '浏览与翻页';
 }
 
 // Path: <root>
@@ -118104,6 +118552,35 @@ class _StringsZhHk extends _StringsEn {
   String get selection_copy_empty => 'No text selected.';
   @override
   String get video_subtitle_replay => 'Replay this line';
+  @override
+  String get manga_ocr_done => 'OCR complete';
+  @override
+  String get settings_destination_manga_summary =>
+      'Reader, OCR and online catalog';
+  @override
+  String get manga_page_animation => 'Page turn animation';
+  @override
+  String get manga_page_animation_none => 'None';
+  @override
+  String get manga_page_animation_slide => 'Slide';
+  @override
+  String get manga_page_animation_fade => 'Fade';
+  @override
+  String get manga_default_zoom => 'Default zoom';
+  @override
+  String get manga_zoom_sensitivity => 'Zoom sensitivity';
+  @override
+  String get manga_volume_key_paging => 'Volume keys turn pages';
+  @override
+  String get manga_volume_key_paging_subtitle =>
+      'Use volume up and down to turn pages in the manga reader';
+  @override
+  String get manga_tap_zone_paging => 'Tap edges to turn pages';
+  @override
+  String get manga_tap_zone_paging_subtitle =>
+      'Tap the left or right edge of the page to turn';
+  @override
+  String get manga_section_viewing => 'Viewing and page turning';
 }
 
 /// Flat map(s) containing all translations.
@@ -124484,6 +124961,32 @@ extension on _StringsEn {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -130862,6 +131365,32 @@ extension on _StringsAr {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -137262,6 +137791,32 @@ extension on _StringsDe {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -143661,6 +144216,32 @@ extension on _StringsEs {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -150066,6 +150647,32 @@ extension on _StringsFr {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -156453,6 +157060,32 @@ extension on _StringsId {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -162854,6 +163487,32 @@ extension on _StringsIt {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -169217,6 +169876,32 @@ extension on _StringsJa {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -175584,6 +176269,32 @@ extension on _StringsKo {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -181979,6 +182690,32 @@ extension on _StringsNl {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -188371,6 +189108,32 @@ extension on _StringsPtBr {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -194768,6 +195531,32 @@ extension on _StringsRu {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -201148,6 +201937,32 @@ extension on _StringsTh {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -207537,6 +208352,32 @@ extension on _StringsTr {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -213922,6 +214763,32 @@ extension on _StringsVi {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }
@@ -220253,6 +221120,32 @@ extension on _StringsZhCn {
         return '未选中文本。';
       case 'video_subtitle_replay':
         return '重播本句';
+      case 'manga_ocr_done':
+        return 'OCR 已完成';
+      case 'settings_destination_manga_summary':
+        return '阅读器、OCR 与在线目录';
+      case 'manga_page_animation':
+        return '翻页动画';
+      case 'manga_page_animation_none':
+        return '无';
+      case 'manga_page_animation_slide':
+        return '滑动';
+      case 'manga_page_animation_fade':
+        return '淡入淡出';
+      case 'manga_default_zoom':
+        return '默认缩放';
+      case 'manga_zoom_sensitivity':
+        return '缩放灵敏度';
+      case 'manga_volume_key_paging':
+        return '音量键翻页';
+      case 'manga_volume_key_paging_subtitle':
+        return '在漫画阅读器中用音量加减键翻页';
+      case 'manga_tap_zone_paging':
+        return '点击边缘翻页';
+      case 'manga_tap_zone_paging_subtitle':
+        return '点击页面左右边缘翻页';
+      case 'manga_section_viewing':
+        return '浏览与翻页';
       default:
         return null;
     }
@@ -226611,6 +227504,32 @@ extension on _StringsZhHk {
         return 'No text selected.';
       case 'video_subtitle_replay':
         return 'Replay this line';
+      case 'manga_ocr_done':
+        return 'OCR complete';
+      case 'settings_destination_manga_summary':
+        return 'Reader, OCR and online catalog';
+      case 'manga_page_animation':
+        return 'Page turn animation';
+      case 'manga_page_animation_none':
+        return 'None';
+      case 'manga_page_animation_slide':
+        return 'Slide';
+      case 'manga_page_animation_fade':
+        return 'Fade';
+      case 'manga_default_zoom':
+        return 'Default zoom';
+      case 'manga_zoom_sensitivity':
+        return 'Zoom sensitivity';
+      case 'manga_volume_key_paging':
+        return 'Volume keys turn pages';
+      case 'manga_volume_key_paging_subtitle':
+        return 'Use volume up and down to turn pages in the manga reader';
+      case 'manga_tap_zone_paging':
+        return 'Tap edges to turn pages';
+      case 'manga_tap_zone_paging_subtitle':
+        return 'Tap the left or right edge of the page to turn';
+      case 'manga_section_viewing':
+        return 'Viewing and page turning';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "预览是只读的。安装扩展后才能打开阅读。",
   "selection_copy_empty": "未选中文本。",
   "video_subtitle_replay": "重播本句"
+,
+  "manga_ocr_done": "OCR 已完成",
+  "settings_destination_manga_summary": "阅读器、OCR 与在线目录",
+  "manga_page_animation": "翻页动画",
+  "manga_page_animation_none": "无",
+  "manga_page_animation_slide": "滑动",
+  "manga_page_animation_fade": "淡入淡出",
+  "manga_default_zoom": "默认缩放",
+  "manga_zoom_sensitivity": "缩放灵敏度",
+  "manga_volume_key_paging": "音量键翻页",
+  "manga_volume_key_paging_subtitle": "在漫画阅读器中用音量加减键翻页",
+  "manga_tap_zone_paging": "点击边缘翻页",
+  "manga_tap_zone_paging_subtitle": "点击页面左右边缘翻页",
+  "manga_section_viewing": "浏览与翻页"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3109,4 +3109,18 @@
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
   "video_subtitle_replay": "Replay this line"
+,
+  "manga_ocr_done": "OCR complete",
+  "settings_destination_manga_summary": "Reader, OCR and online catalog",
+  "manga_page_animation": "Page turn animation",
+  "manga_page_animation_none": "None",
+  "manga_page_animation_slide": "Slide",
+  "manga_page_animation_fade": "Fade",
+  "manga_default_zoom": "Default zoom",
+  "manga_zoom_sensitivity": "Zoom sensitivity",
+  "manga_volume_key_paging": "Volume keys turn pages",
+  "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
+  "manga_tap_zone_paging": "Tap edges to turn pages",
+  "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
+  "manga_section_viewing": "Viewing and page turning"
 }

--- a/hibiki/lib/main.dart
+++ b/hibiki/lib/main.dart
@@ -883,10 +883,14 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
     switch (result) {
       case AnkiFetchSuccess():
         await ref.read(ankiViewModelProvider.notifier).reloadSettings();
-        HibikiToast.show(msg: 'AnkiMobile configuration imported.');
+        HibikiToast.show(
+          msg: 'AnkiMobile configuration imported.',
+          severity: ToastSeverity.success,
+        );
       case AnkiFetchError(:final message, :final code):
         HibikiToast.show(
           msg: AnkiViewModel.localizeAnkiFetchError(message, code),
+          severity: ToastSeverity.error,
         );
     }
   }
@@ -903,7 +907,9 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
     final String? error = uri.queryParameters['error'];
     if (code == null) {
       HibikiToast.show(
-          msg: t.sync_auth_error(message: error ?? 'missing code'));
+        msg: t.sync_auth_error(message: error ?? 'missing code'),
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -916,12 +922,20 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
         default:
           return;
       }
-      HibikiToast.show(msg: t.sync_signed_in);
+      HibikiToast.show(
+        msg: t.sync_signed_in,
+        severity: ToastSeverity.success,
+      );
     } on SyncAuthError catch (e) {
       HibikiToast.show(
-          msg: t.sync_auth_error(message: friendlySyncErrorDetail(e)));
+        msg: t.sync_auth_error(message: friendlySyncErrorDetail(e)),
+        severity: ToastSeverity.error,
+      );
     } catch (e) {
-      HibikiToast.show(msg: friendlySyncError(e));
+      HibikiToast.show(
+        msg: friendlySyncError(e),
+        severity: ToastSeverity.error,
+      );
     }
   }
 
@@ -986,7 +1000,10 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
     // 此处首帧入库之间文件可能被移动/删除（或检查与使用间的竞态），故再校验一次；
     // 文件不存在则不入库、不静默吞，给与既有失败路径一致的 toast 反馈（TODO-903）。
     if (!await File(videoPath).exists()) {
-      HibikiToast.show(msg: t.video_file_not_found);
+      HibikiToast.show(
+        msg: t.video_file_not_found,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -1387,7 +1404,10 @@ class _HoshiReaderAppState extends ConsumerState<HoshiReaderApp>
                             Clipboard.setData(
                               ClipboardData(text: appModel.initError!),
                             );
-                            HibikiToast.show(msg: t.error_copied);
+                            HibikiToast.show(
+                              msg: t.error_copied,
+                              severity: ToastSeverity.success,
+                            );
                           },
                         ),
                       ],

--- a/hibiki/lib/src/anki/anki_mined_card_action_sheet.dart
+++ b/hibiki/lib/src/anki/anki_mined_card_action_sheet.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hibiki_anki/hibiki_anki.dart';
 
 import 'package:hibiki/src/utils/misc/show_app_dialog.dart';
-import 'package:hibiki/utils.dart' show t, HibikiToast;
+import 'package:hibiki/utils.dart' show t, HibikiToast, ToastSeverity;
 
 /// BUG-1040：把「一段期间内让查词弹窗让位」的执行权交回宿主页面的钩子。
 ///
@@ -105,7 +105,10 @@ class _MinedCardActionDialogState extends State<_MinedCardActionDialog> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _busy = false);
-      HibikiToast.show(msg: t.anki_card_action_failed);
+      HibikiToast.show(
+        msg: t.anki_card_action_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     if (!mounted) return;
@@ -126,7 +129,10 @@ class _MinedCardActionDialogState extends State<_MinedCardActionDialog> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _busy = false);
-      HibikiToast.show(msg: t.anki_card_action_failed);
+      HibikiToast.show(
+        msg: t.anki_card_action_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     if (!mounted) return;
@@ -291,7 +297,10 @@ class _AnkiNoteViewerDialogState extends State<_AnkiNoteViewerDialog> {
     if (!mounted) return;
     setState(() => _busy = false);
     if (!ok) {
-      HibikiToast.show(msg: t.anki_note_open_failed);
+      HibikiToast.show(
+        msg: t.anki_note_open_failed,
+        severity: ToastSeverity.error,
+      );
     }
   }
 
@@ -305,7 +314,10 @@ class _AnkiNoteViewerDialogState extends State<_AnkiNoteViewerDialog> {
     } catch (e) {
       if (!mounted) return;
       setState(() => _busy = false);
-      HibikiToast.show(msg: t.anki_card_action_failed);
+      HibikiToast.show(
+        msg: t.anki_card_action_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     if (!mounted) return;
@@ -435,13 +447,19 @@ Future<void> openMinedCardInAnki({
 }) async {
   final matches = await repo.findMatchingNotes(expression, reading);
   if (matches.isEmpty) {
-    HibikiToast.show(msg: t.anki_open_no_card);
+    HibikiToast.show(
+      msg: t.anki_open_no_card,
+      severity: ToastSeverity.error,
+    );
     return;
   }
   if (matches.length == 1) {
     final ok = await repo.openNoteInAnki(matches.first.noteId);
     if (!ok) {
-      HibikiToast.show(msg: t.anki_note_open_failed);
+      HibikiToast.show(
+        msg: t.anki_note_open_failed,
+        severity: ToastSeverity.error,
+      );
     }
     return;
   }
@@ -490,7 +508,10 @@ class _OpenNotePickerState extends State<_OpenNotePicker> {
     if (!mounted) return;
     if (!ok) {
       setState(() => _busy = false);
-      HibikiToast.show(msg: t.anki_note_open_failed);
+      HibikiToast.show(
+        msg: t.anki_note_open_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     Navigator.of(context).pop();

--- a/hibiki/lib/src/creator/actions/play_audio_action.dart
+++ b/hibiki/lib/src/creator/actions/play_audio_action.dart
@@ -101,6 +101,7 @@ class PlayAudioAction extends QuickAction {
       msg: t.audio_unavailable,
       toastLength: Toast.LENGTH_SHORT,
       gravity: ToastGravity.BOTTOM,
+      severity: ToastSeverity.error,
     );
   }
 }

--- a/hibiki/lib/src/creator/audio_export_field.dart
+++ b/hibiki/lib/src/creator/audio_export_field.dart
@@ -108,6 +108,7 @@ abstract class AudioExportField extends Field with ExportFieldSearch {
             msg: t.audio_unavailable,
             toastLength: Toast.LENGTH_SHORT,
             gravity: ToastGravity.BOTTOM,
+            severity: ToastSeverity.error,
           );
         }
       }

--- a/hibiki/lib/src/creator/enhancements/pop_from_stash_enhancement.dart
+++ b/hibiki/lib/src/creator/enhancements/pop_from_stash_enhancement.dart
@@ -37,6 +37,7 @@ class PopFromStashEnhancement extends Enhancement {
         msg: t.stash_nothing_to_pop,
         toastLength: Toast.LENGTH_SHORT,
         gravity: ToastGravity.BOTTOM,
+        severity: ToastSeverity.error,
       );
     } else {
       String lastStashItem = stashContents.last;

--- a/hibiki/lib/src/creator/enhancements/save_tags_enhancement.dart
+++ b/hibiki/lib/src/creator/enhancements/save_tags_enhancement.dart
@@ -40,6 +40,7 @@ class SaveTagsEnhancement extends Enhancement {
       msg: t.saved_tags,
       toastLength: Toast.LENGTH_SHORT,
       gravity: ToastGravity.BOTTOM,
+      severity: ToastSeverity.success,
     );
   }
 }

--- a/hibiki/lib/src/creator/enhancements/search_dictionary_enhancement.dart
+++ b/hibiki/lib/src/creator/enhancements/search_dictionary_enhancement.dart
@@ -43,6 +43,7 @@ class SearchDictionaryEnhancement extends Enhancement {
           msg: t.no_text_to_search,
           toastLength: Toast.LENGTH_SHORT,
           gravity: ToastGravity.BOTTOM,
+          severity: ToastSeverity.error,
         );
         return;
       } else {
@@ -53,6 +54,7 @@ class SearchDictionaryEnhancement extends Enhancement {
           ),
           toastLength: Toast.LENGTH_SHORT,
           gravity: ToastGravity.BOTTOM,
+          severity: ToastSeverity.warning,
         );
       }
     }

--- a/hibiki/lib/src/creator/enhancements/sentence_picker_enhancement.dart
+++ b/hibiki/lib/src/creator/enhancements/sentence_picker_enhancement.dart
@@ -39,6 +39,7 @@ class SentencePickerEnhancement extends Enhancement {
         msg: t.no_text,
         toastLength: Toast.LENGTH_SHORT,
         gravity: ToastGravity.BOTTOM,
+        severity: ToastSeverity.error,
       );
       return;
     }

--- a/hibiki/lib/src/creator/enhancements/text_segmentation_enhancement.dart
+++ b/hibiki/lib/src/creator/enhancements/text_segmentation_enhancement.dart
@@ -38,6 +38,7 @@ class TextSegmentationEnhancement extends Enhancement {
         msg: t.no_text,
         toastLength: Toast.LENGTH_SHORT,
         gravity: ToastGravity.BOTTOM,
+        severity: ToastSeverity.error,
       );
       return;
     }

--- a/hibiki/lib/src/creator/export_field_search.dart
+++ b/hibiki/lib/src/creator/export_field_search.dart
@@ -60,6 +60,7 @@ mixin ExportFieldSearch on Field {
             ),
             toastLength: Toast.LENGTH_SHORT,
             gravity: ToastGravity.BOTTOM,
+            severity: ToastSeverity.warning,
           );
 
           return fallbackTerm;
@@ -71,6 +72,7 @@ mixin ExportFieldSearch on Field {
       msg: t.no_text_to_search,
       toastLength: Toast.LENGTH_SHORT,
       gravity: ToastGravity.BOTTOM,
+      severity: ToastSeverity.error,
     );
 
     return null;

--- a/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
+++ b/hibiki/lib/src/lookup/gal_hook_text_overlay_controller.dart
@@ -511,17 +511,26 @@ class GalHookTextOverlayController extends ChangeNotifier {
     }
     final String? lineId = _displayedLineId;
     if (lineId == null) {
-      HibikiToast.show(msg: t.game_hook_line_unavailable);
+      HibikiToast.show(
+        msg: t.game_hook_line_unavailable,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final GalTrackPreview? preview =
         await _session.exportLineAudioPreview(lineId);
     if (preview == null) {
-      HibikiToast.show(msg: t.game_line_preview_failed);
+      HibikiToast.show(
+        msg: t.game_line_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     if (!await DesktopAudioPlayback.playFile(preview.filePath)) {
-      HibikiToast.show(msg: t.game_line_preview_failed);
+      HibikiToast.show(
+        msg: t.game_line_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     _replaying = true;
@@ -559,6 +568,8 @@ class GalHookTextOverlayController extends ChangeNotifier {
       final bool saved = await _session.finishLineRecapture();
       HibikiToast.show(
         msg: saved ? t.game_hook_recapture_saved : t.game_hook_recapture_empty,
+        // 补录窗口空手而归不是崩溃，是「这次没录到」——warning 而非 error。
+        severity: saved ? ToastSeverity.success : ToastSeverity.warning,
       );
       await _syncVoiceState();
       notifyListeners();
@@ -566,7 +577,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
     }
     final String? lineId = _displayedLineId;
     if (lineId == null) {
-      HibikiToast.show(msg: t.game_hook_line_unavailable);
+      HibikiToast.show(
+        msg: t.game_hook_line_unavailable,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final bool started = await _session.startLineRecapture(lineId);
@@ -574,6 +588,8 @@ class GalHookTextOverlayController extends ChangeNotifier {
       msg: started
           ? t.game_hook_recapture_started
           : t.game_hook_recapture_unavailable,
+      // 开录是「去游戏里重播这句」的操作指示（info）；开不起来是能力缺失（error）。
+      severity: started ? ToastSeverity.info : ToastSeverity.error,
     );
     await _syncVoiceState();
     notifyListeners();
@@ -613,7 +629,10 @@ class GalHookTextOverlayController extends ChangeNotifier {
         entry == null ||
         entry.text != text ||
         !_session.isLineInCurrentSession(entry)) {
-      HibikiToast.show(msg: t.game_hook_line_unavailable);
+      HibikiToast.show(
+        msg: t.game_hook_line_unavailable,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final String term = JapaneseLanguage.instance
@@ -693,12 +712,17 @@ class GalHookTextOverlayController extends ChangeNotifier {
     );
     HibikiToast.showMine(msg: described.message, status: described.status);
     if (result.sentenceAudioMissing) {
-      HibikiToast.show(msg: t.game_card_sentence_audio_missing);
+      // 卡片建成了、只是缺句子音频 = 部分成功。
+      HibikiToast.show(
+        msg: t.game_card_sentence_audio_missing,
+        severity: ToastSeverity.warning,
+      );
     }
     if (result.unmappedTokens.isNotEmpty) {
       HibikiToast.show(
         msg: '${t.game_card_mapping_missing}: '
             '${result.unmappedTokens.join(', ')}',
+        severity: ToastSeverity.warning,
       );
     }
     return result.toPopupReply();

--- a/hibiki/lib/src/media/audiobook/audiobook_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/audiobook_import_dialog.dart
@@ -519,7 +519,10 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
       if (path == null || !mounted) return;
       final String ext = p.extension(path).toLowerCase().replaceFirst('.', '');
       if (!_alignmentExtensions.contains(ext)) {
-        HibikiToast.show(msg: t.import_unsupported_file_format(ext: '.$ext'));
+        HibikiToast.show(
+          msg: t.import_unsupported_file_format(ext: '.$ext'),
+          severity: ToastSeverity.error,
+        );
         return;
       }
       setState(() {
@@ -594,7 +597,10 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
 
   Future<void> _doImport() async {
     if (!_hasAudioSource || (!widget.audioOnly && _alignmentPath == null)) {
-      HibikiToast.show(msg: t.audiobook_import_error);
+      HibikiToast.show(
+        msg: t.audiobook_import_error,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -623,6 +629,7 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
           if (mounted) {
             HibikiToast.show(
               msg: t.import_unsupported_file_format(ext: '.$ext'),
+              severity: ToastSeverity.error,
             );
           }
           return;
@@ -785,7 +792,7 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
         final String msg = tail == null
             ? t.audiobook_import_success
             : '${t.audiobook_import_success} · $tail';
-        HibikiToast.show(msg: msg);
+        HibikiToast.show(msg: msg, severity: ToastSeverity.success);
         Navigator.pop(context, true); // true = reload player
       }
     } on FileSystemException catch (e, stack) {
@@ -800,12 +807,14 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
               size: _formatBytes(grandTotal),
             ),
             toastLength: Toast.LENGTH_LONG,
+            severity: ToastSeverity.error,
           );
         } else {
           HibikiToast.show(
             msg: t.audiobook_import_error_copy_failed(
               name: e.path ?? '',
             ),
+            severity: ToastSeverity.error,
           );
         }
       }
@@ -813,7 +822,10 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
       ErrorLogService.instance.log('AudiobookImport.doImport', e, stack);
       debugPrint('AudiobookImportDialog import error: $e');
       if (mounted) {
-        HibikiToast.show(msg: t.audiobook_import_error);
+        HibikiToast.show(
+          msg: t.audiobook_import_error,
+          severity: ToastSeverity.error,
+        );
       }
     } finally {
       if (mounted) {
@@ -827,7 +839,10 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
   /// 字节写坏）。
   Future<void> _openReMatchSheet(Audiobook ab) async {
     if (!_hasEpub) {
-      HibikiToast.show(msg: t.ttu_not_bound_cannot_rematch);
+      HibikiToast.show(
+        msg: t.ttu_not_bound_cannot_rematch,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     await SasayakiRematch.promptAndRun(
@@ -1015,7 +1030,10 @@ class _AudiobookImportDialogState extends State<AudiobookImportDialog>
       ErrorLogService.instance.log('AudiobookImport.deleteAudiobook', e, st);
       debugPrint('AudiobookImportDialog: deleteAudiobook failed: $e\n$st');
       if (mounted) {
-        HibikiToast.show(msg: t.audiobook_import_error);
+        HibikiToast.show(
+          msg: t.audiobook_import_error,
+          severity: ToastSeverity.error,
+        );
       }
       return;
     }

--- a/hibiki/lib/src/media/audiobook/book_import_dialog.dart
+++ b/hibiki/lib/src/media/audiobook/book_import_dialog.dart
@@ -544,7 +544,10 @@ class _BookImportDialogState extends State<BookImportDialog>
       if (attachedAudio) t.import_sidecar_audio(count: _audioPaths.length),
     ];
     if (parts.isNotEmpty && mounted) {
-      HibikiToast.show(msg: parts.join(' · '));
+      HibikiToast.show(
+        msg: parts.join(' · '),
+        severity: ToastSeverity.info,
+      );
     }
   }
 
@@ -569,7 +572,10 @@ class _BookImportDialogState extends State<BookImportDialog>
       if (path == null || !mounted) return;
       final String ext = p.extension(path).toLowerCase().replaceFirst('.', '');
       if (!_subtitleExtensions.contains(ext)) {
-        HibikiToast.show(msg: t.import_unsupported_file_format(ext: '.$ext'));
+        HibikiToast.show(
+          msg: t.import_unsupported_file_format(ext: '.$ext'),
+          severity: ToastSeverity.error,
+        );
         return;
       }
 
@@ -796,7 +802,10 @@ class _BookImportDialogState extends State<BookImportDialog>
 
   Future<void> _doImport() async {
     if (_epubPath == null && !_hasSubtitles) {
-      HibikiToast.show(msg: t.srt_import_missing_input);
+      HibikiToast.show(
+        msg: t.srt_import_missing_input,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     // 兜底闸门：选/拖两条入口在收下路径时就已过 [_handoffIfManga]，但 initialEpubPath
@@ -806,12 +815,18 @@ class _BookImportDialogState extends State<BookImportDialog>
     if (epubPath != null && await _handoffIfManga(epubPath)) return;
     if (!mounted) return;
     if (_epubPath != null && !_hasSubtitles && _audioPaths.isNotEmpty) {
-      HibikiToast.show(msg: t.srt_import_audio_needs_subtitle);
+      HibikiToast.show(
+        msg: t.srt_import_audio_needs_subtitle,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final String title = _titleCtrl.text.trim();
     if (title.isEmpty) {
-      HibikiToast.show(msg: t.srt_import_missing_title);
+      HibikiToast.show(
+        msg: t.srt_import_missing_title,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -823,7 +838,10 @@ class _BookImportDialogState extends State<BookImportDialog>
       isCancelled: (Object e) => e is DuplicateImportCancelledException,
       onCancelled: () {
         if (mounted) {
-          HibikiToast.show(msg: t.book_import_duplicate_cancelled);
+          HibikiToast.show(
+            msg: t.book_import_duplicate_cancelled,
+            severity: ToastSeverity.info,
+          );
           Navigator.pop(context, false);
         }
       },
@@ -850,7 +868,7 @@ class _BookImportDialogState extends State<BookImportDialog>
           final String msg = tail == null
               ? t.srt_import_success
               : '${t.srt_import_success} · $tail';
-          HibikiToast.show(msg: msg);
+          HibikiToast.show(msg: msg, severity: ToastSeverity.success);
           Navigator.pop(context, true);
         }
       },

--- a/hibiki/lib/src/media/audiobook/reader_quick_settings_sheet.dart
+++ b/hibiki/lib/src/media/audiobook/reader_quick_settings_sheet.dart
@@ -1534,7 +1534,7 @@ class _ReaderQuickSettingsSheetState extends State<ReaderQuickSettingsSheet>
                       },
             onCopy: () {
               Clipboard.setData(ClipboardData(text: favorite.text));
-              HibikiToast.show(msg: t.copy);
+              HibikiToast.show(msg: t.copy, severity: ToastSeverity.success);
             },
             onDelete: () async {
               await widget.onDeleteFavorite?.call(favorite);

--- a/hibiki/lib/src/media/audiobook/sasayaki_rematch.dart
+++ b/hibiki/lib/src/media/audiobook/sasayaki_rematch.dart
@@ -52,7 +52,10 @@ class SasayakiRematch {
     void Function(bool running)? onRunningChanged,
   }) async {
     if (extractDir.isEmpty) {
-      HibikiToast.show(msg: t.ttu_not_bound_cannot_rematch);
+      HibikiToast.show(
+        msg: t.ttu_not_bound_cannot_rematch,
+        severity: ToastSeverity.error,
+      );
       return null;
     }
     final AudiobookHealth? overlay = await repo.readHealthOverlay(ab.bookKey);
@@ -205,11 +208,17 @@ class SasayakiRematch {
     List<int> windows = EpubCueMatcher.defaultProbeWindows,
   }) async {
     if (sections.isEmpty) {
-      HibikiToast.show(msg: t.sasayaki_no_sections);
+      HibikiToast.show(
+        msg: t.sasayaki_no_sections,
+        severity: ToastSeverity.error,
+      );
       return null;
     }
     if (cues.isEmpty) {
-      HibikiToast.show(msg: t.sasayaki_no_cues_to_match);
+      HibikiToast.show(
+        msg: t.sasayaki_no_cues_to_match,
+        severity: ToastSeverity.error,
+      );
       return null;
     }
     try {
@@ -220,16 +229,24 @@ class SasayakiRematch {
       );
       final MapEntry<int, double>? best = r.best;
       if (best == null || best.value <= 0) {
-        HibikiToast.show(msg: t.sasayaki_all_zero);
+        HibikiToast.show(
+          msg: t.sasayaki_all_zero,
+          severity: ToastSeverity.warning,
+        );
         return null;
       }
       final String pctStr = (best.value * 100).toStringAsFixed(2);
       HibikiToast.show(
-          msg: t.sasayaki_auto_picked(window: best.key, pct: pctStr));
+        msg: t.sasayaki_auto_picked(window: best.key, pct: pctStr),
+        severity: ToastSeverity.success,
+      );
       return best.key;
     } catch (e, st) {
       debugPrint('[hibiki-audiobook] autoProbe failed: $e\n$st');
-      HibikiToast.show(msg: t.sasayaki_auto_failed(error: e));
+      HibikiToast.show(
+        msg: t.sasayaki_auto_failed(error: e),
+        severity: ToastSeverity.error,
+      );
       return null;
     }
   }
@@ -256,12 +273,18 @@ class SasayakiRematch {
     try {
       final List<AudioCue> cues = await repo.cuesForBook(ab.bookKey);
       if (cues.isEmpty) {
-        HibikiToast.show(msg: t.sasayaki_no_stored_cues);
+        HibikiToast.show(
+          msg: t.sasayaki_no_stored_cues,
+          severity: ToastSeverity.error,
+        );
         return;
       }
       final List<EpubSection> sections = epubSectionsFromExtractDir(extractDir);
       if (sections.isEmpty) {
-        HibikiToast.show(msg: t.sasayaki_no_chapters);
+        HibikiToast.show(
+          msg: t.sasayaki_no_chapters,
+          severity: ToastSeverity.error,
+        );
         return;
       }
       final MatchResult result = await EpubCueMatcher.matchInIsolate(
@@ -285,10 +308,14 @@ class SasayakiRematch {
       await repo.updateHealthOverlay(bookKey: ab.bookKey, health: health);
       HibikiToast.show(
         msg: t.sasayaki_rematch_result(pct: pctStr, window: searchWindow),
+        severity: ToastSeverity.success,
       );
     } catch (e, st) {
       debugPrint('[hibiki-audiobook] SasayakiRematch failed: $e\n$st');
-      HibikiToast.show(msg: t.sasayaki_rematch_failed(error: e));
+      HibikiToast.show(
+        msg: t.sasayaki_rematch_failed(error: e),
+        severity: ToastSeverity.error,
+      );
     }
   }
 }

--- a/hibiki/lib/src/media/collections/add_to_collection_dialog.dart
+++ b/hibiki/lib/src/media/collections/add_to_collection_dialog.dart
@@ -63,7 +63,10 @@ Future<bool> showAddToCollectionDialog({
     collectionId = picked;
   }
   await database.addToCollection(collectionId, mediaType, entryKey);
-  HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
+  HibikiToast.show(
+    msg: t.batch_add_to_collection_success(n: 1),
+    severity: ToastSeverity.success,
+  );
   return true;
 }
 

--- a/hibiki/lib/src/media/collections/collection_drag.dart
+++ b/hibiki/lib/src/media/collections/collection_drag.dart
@@ -31,6 +31,11 @@ enum CollectionAddOutcome {
 }
 
 /// 提示通道。默认 [HibikiToast.show]；测试注入自己的收集器。
+///
+/// 刻意**不带** `ToastSeverity`：这一个通道要送两种语义（已存在=warning、落库
+/// 失败=error），要着色就得把语义塞进 typedef，而 typedef 一改，注入自己收集器的
+/// 测试（`test/media/collection_add_failure_test.dart`）全部失配。语义着色留到
+/// 通道本身重构时一起做，这里维持旧的中性外观。
 typedef CollectionAddNotifier = void Function(String message);
 
 /// 「把一个 [MediaRef] 加进合集」的共享落库编排（书架 / 视频库 / 游戏库三处同一份）。

--- a/hibiki/lib/src/media/import/import_flow_mixin.dart
+++ b/hibiki/lib/src/media/import/import_flow_mixin.dart
@@ -68,7 +68,10 @@ mixin ImportFlowMixin<T extends StatefulWidget> on State<T> {
           debugMessage != null ? debugMessage(e) : '$logTag failed: $e',
         );
         if (mounted) {
-          HibikiToast.show(msg: '${t.srt_import_error}: $e');
+          HibikiToast.show(
+            msg: '${t.srt_import_error}: $e',
+            severity: ToastSeverity.error,
+          );
         }
       }
     } finally {

--- a/hibiki/lib/src/media/import/real_path_directory_picker.dart
+++ b/hibiki/lib/src/media/import/real_path_directory_picker.dart
@@ -259,6 +259,7 @@ List<String> _filterPickedFilesByExtension({
       msg: t.import_unsupported_file_format(
         ext: ext.isEmpty ? p.basename(rejected.first) : ext,
       ),
+      severity: ToastSeverity.error,
     );
   }
   return accepted;

--- a/hibiki/lib/src/media/manga/manga_import_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_import_dialog.dart
@@ -231,6 +231,7 @@ class _MangaImportDialogState extends State<MangaImportDialog>
       final String ext = p.extension(path).toLowerCase();
       HibikiToast.show(
         msg: t.import_unsupported_file_format(ext: ext.isEmpty ? path : ext),
+        severity: ToastSeverity.error,
       );
       return;
     }
@@ -259,6 +260,7 @@ class _MangaImportDialogState extends State<MangaImportDialog>
         msg: t.import_unsupported_file_format(
           ext: ext.isEmpty ? paths.first : ext,
         ),
+        severity: ToastSeverity.error,
       );
     }
   }
@@ -318,12 +320,18 @@ class _MangaImportDialogState extends State<MangaImportDialog>
     final String? path = _path;
     final ImportCarrier? carrier = _carrier;
     if (path == null || carrier == null) {
-      HibikiToast.show(msg: t.manga_import_missing_input);
+      HibikiToast.show(
+        msg: t.manga_import_missing_input,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final String title = _titleCtrl.text.trim();
     if (title.isEmpty) {
-      HibikiToast.show(msg: t.srt_import_missing_title);
+      HibikiToast.show(
+        msg: t.srt_import_missing_title,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -333,7 +341,10 @@ class _MangaImportDialogState extends State<MangaImportDialog>
       isCancelled: (Object e) => e is DuplicateImportCancelledException,
       onCancelled: () {
         if (mounted) {
-          HibikiToast.show(msg: t.book_import_duplicate_cancelled);
+          HibikiToast.show(
+            msg: t.book_import_duplicate_cancelled,
+            severity: ToastSeverity.info,
+          );
           Navigator.pop(context, false);
         }
       },
@@ -378,7 +389,10 @@ class _MangaImportDialogState extends State<MangaImportDialog>
 
         reportProgress(1, t.import_step_done);
         if (mounted) {
-          HibikiToast.show(msg: t.srt_import_success);
+          HibikiToast.show(
+            msg: t.srt_import_success,
+            severity: ToastSeverity.success,
+          );
           Navigator.pop(context, true);
         }
       },

--- a/hibiki/lib/src/media/manga/manga_ocr_settings_section.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_settings_section.dart
@@ -161,13 +161,19 @@ class _MangaOcrSettingsSectionState
           _downloading = false;
           _downloadSub = null;
         });
-        HibikiToast.show(msg: t.manga_ocr_download_failed);
+        HibikiToast.show(
+          msg: t.manga_ocr_download_failed,
+          severity: ToastSeverity.error,
+        );
       },
       onDone: () async {
         _downloadSub = null;
         if (!mounted) return;
         setState(() => _downloading = false);
-        HibikiToast.show(msg: t.manga_ocr_download_done);
+        HibikiToast.show(
+          msg: t.manga_ocr_download_done,
+          severity: ToastSeverity.success,
+        );
         await _loadStatus();
       },
     );
@@ -206,7 +212,10 @@ class _MangaOcrSettingsSectionState
       if (mounted) setState(() => _deleting = false);
     }
     if (!mounted) return;
-    HibikiToast.show(msg: t.manga_ocr_delete_done);
+    HibikiToast.show(
+      msg: t.manga_ocr_delete_done,
+      severity: ToastSeverity.success,
+    );
     await _loadStatus();
   }
 

--- a/hibiki/lib/src/media/manga/manga_ocr_settings_section.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_settings_section.dart
@@ -9,7 +9,7 @@ import 'package:hibiki/src/models/app_model.dart';
 import 'package:hibiki/src/ocr/manga_ocr_service.dart';
 import 'package:hibiki/utils.dart';
 
-/// 设置区「漫画 OCR」组的正文（内联进阅读设置分类）。
+/// 设置区「漫画 OCR」组的正文（隶属**漫画**设置分类）。
 ///
 /// 内容：默认引擎下拉、内置 OCR 模型状态行（已下载/未下载 + 体积）、下载按钮
 /// （进度条 + 可取消）、删除按钮（二次确认）。本地模型只在支持整卷 ONNX 的平台
@@ -250,31 +250,50 @@ class _MangaOcrSettingsSectionState
     );
   }
 
+  /// 补齐标准设置行的水平内边距。
+  ///
+  /// [SettingsCustomItem] 是 `settings_schema_widgets.dart` 的 switch 里**唯一**
+  /// 不经过 `AdaptiveSettingsRow*` 的分支，而那 16px 横向 padding 正是由行控件自带
+  /// 的。于是本组件的裸内容贴在卡片边（x=0），同一张卡片里的模型状态行与「在线目录
+  /// 地址」行却在 x=16——用户看到的「漫画设置左右间距和其他设置不一样」就是这 16px。
+  /// 这里由组件自己补上，与制卡/媒体记录/配置方案那几个 body 逃生口的做法一致
+  /// （它们靠 `AdaptiveSettingsSection` + `AdaptiveSettingsRow` 天然拿到 16）。
+  Widget _inset(Widget child) {
+    return Padding(
+      padding: EdgeInsets.symmetric(
+        horizontal: HibikiDesignTokens.of(context).spacing.rowHorizontal,
+      ),
+      child: child,
+    );
+  }
+
   Widget _buildBody(ThemeData theme) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
-        _sectionLabel(theme, t.manga_ocr_section),
+        _inset(_sectionLabel(theme, t.manga_ocr_section)),
         // 引擎下拉全平台显示：出厂默认已是 Google Lens（会上传页面），把开关关在
         // 桌面里等于让移动端用户无法持久地退回离线引擎。外部 mokuro 是桌面工具，
         // 由下拉项自身 disable，不再靠整块 gating。
-        _buildEnginePreference(theme),
+        _inset(_buildEnginePreference(theme)),
         const SizedBox(height: 12),
         if (widget.service.isSupportedPlatform)
           _buildModelBlock(theme)
         else
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: Text(
-              t.manga_ocr_unsupported,
-              style: theme.textTheme.bodySmall
-                  ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          _inset(
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              child: Text(
+                t.manga_ocr_unsupported,
+                style: theme.textTheme.bodySmall
+                    ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+              ),
             ),
           ),
         // 外部 mokuro CLI 是桌面工具，仅桌面显示。
         if (isDesktopPlatform) ...<Widget>[
           const SizedBox(height: 16),
-          _buildExternalBlock(theme),
+          _inset(_buildExternalBlock(theme)),
         ],
       ],
     );
@@ -310,6 +329,13 @@ class _MangaOcrSettingsSectionState
           enabled: isDesktopPlatform,
           child: Text(t.manga_ocr_engine_external),
         ),
+        // 互联「配对主机代跑」：服务端/客户端链路早已完整（/api/ocr/job*），此前
+        // 只是没进偏好枚举，导致它永远只能被 auto 兜底顺序选中、无法显式指定。
+        // 移动端没有本地 ONNX 时这是唯一可用的整卷引擎。
+        DropdownMenuItem<MangaOcrEnginePreference>(
+          value: MangaOcrEnginePreference.pairedHost,
+          child: Text(t.manga_remote_ocr_engine),
+        ),
       ],
       onChanged: (MangaOcrEnginePreference? value) {
         if (value == null) return;
@@ -321,9 +347,11 @@ class _MangaOcrSettingsSectionState
 
   Widget _buildModelBlock(ThemeData theme) {
     if (_loadingStatus) {
-      return const Padding(
-        padding: EdgeInsets.symmetric(vertical: 8),
-        child: LinearProgressIndicator(),
+      return _inset(
+        const Padding(
+          padding: EdgeInsets.symmetric(vertical: 8),
+          child: LinearProgressIndicator(),
+        ),
       );
     }
     final MangaOcrModelStatus? status = _status;
@@ -345,41 +373,47 @@ class _MangaOcrSettingsSectionState
         ),
         if (_downloading) ...<Widget>[
           const SizedBox(height: 8),
-          LinearProgressIndicator(value: _downloadProgress),
+          _inset(LinearProgressIndicator(value: _downloadProgress)),
           const SizedBox(height: 4),
           if (_downloadingFile != null)
-            Text(
-              t.manga_ocr_downloading_file(file: _downloadingFile!),
-              style: theme.textTheme.bodySmall,
+            _inset(
+              Text(
+                t.manga_ocr_downloading_file(file: _downloadingFile!),
+                style: theme.textTheme.bodySmall,
+              ),
             ),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: TextButton(
-              onPressed: _cancelDownload,
-              child: Text(t.dialog_cancel),
+          _inset(
+            Align(
+              alignment: Alignment.centerLeft,
+              child: TextButton(
+                onPressed: _cancelDownload,
+                child: Text(t.dialog_cancel),
+              ),
             ),
           ),
         ] else ...<Widget>[
           const SizedBox(height: 8),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: ready
-                ? OutlinedButton.icon(
-                    onPressed: _deleting ? null : _confirmDelete,
-                    icon: _deleting
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.delete_outline, size: 18),
-                    label: Text(t.manga_ocr_delete),
-                  )
-                : FilledButton.icon(
-                    onPressed: _startDownload,
-                    icon: const Icon(Icons.download_outlined, size: 18),
-                    label: Text(t.manga_ocr_download),
-                  ),
+          _inset(
+            Align(
+              alignment: Alignment.centerLeft,
+              child: ready
+                  ? OutlinedButton.icon(
+                      onPressed: _deleting ? null : _confirmDelete,
+                      icon: _deleting
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : const Icon(Icons.delete_outline, size: 18),
+                      label: Text(t.manga_ocr_delete),
+                    )
+                  : FilledButton.icon(
+                      onPressed: _startDownload,
+                      icon: const Icon(Icons.download_outlined, size: 18),
+                      label: Text(t.manga_ocr_download),
+                    ),
+            ),
           ),
         ],
       ],

--- a/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
@@ -770,7 +770,8 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       if (createdBookKey != null) {
         await _applyOcrToManagedBook(path, external: external);
         if (!mounted) return;
-        HibikiToast.show(msg: t.manga_ocr_wizard_done);
+        // 书已在库，这条路径只把 OCR 结果贴回去，没有导入动作 —— 用 OCR 文案。
+        HibikiToast.show(msg: t.manga_ocr_done);
         Navigator.pop(context, createdBookKey);
         return;
       }

--- a/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
@@ -1007,14 +1007,13 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
         enabled: _externalAvailable,
         label: Text(t.manga_ocr_engine_external),
       ),
-      // 与另外三个引擎同构：探到主机就保留 segment，不可用时置灰而非隐藏；
-      // 一台主机都没探到（无配对 / 老 host / 不支持）才整段消失。
-      if (_remoteAvailable || _remoteModelsMissing)
-        ButtonSegment<MangaOcrEngineId>(
-          value: MangaOcrEngineId.pairedHost,
-          enabled: _remoteAvailable,
-          label: Text(t.manga_remote_ocr_engine),
-        ),
+      // 与另外三个引擎同构：始终保留 segment，不可用时置灰而非隐藏。否则持久化的
+      // pairedHost 偏好在主机暂时离线时会变成「selected 不在 segments 里」的死状态。
+      ButtonSegment<MangaOcrEngineId>(
+        value: MangaOcrEngineId.pairedHost,
+        enabled: _remoteAvailable,
+        label: Text(t.manga_remote_ocr_engine),
+      ),
     ];
     // 只有一个可用引擎时无需选择器，直接省略（仍已在 _refreshEngines 选好）。
     if (segments.length < 2) return remoteReason ?? const SizedBox.shrink();

--- a/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
+++ b/hibiki/lib/src/media/manga/manga_ocr_wizard_dialog.dart
@@ -771,7 +771,10 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
         await _applyOcrToManagedBook(path, external: external);
         if (!mounted) return;
         // 书已在库，这条路径只把 OCR 结果贴回去，没有导入动作 —— 用 OCR 文案。
-        HibikiToast.show(msg: t.manga_ocr_done);
+        HibikiToast.show(
+          msg: t.manga_ocr_done,
+          severity: ToastSeverity.success,
+        );
         Navigator.pop(context, createdBookKey);
         return;
       }
@@ -780,7 +783,10 @@ class _MangaOcrWizardDialogState extends ConsumerState<MangaOcrWizardDialog> {
       final String bookKey =
           await runner(path: path, external: external, title: _title);
       if (!mounted) return;
-      HibikiToast.show(msg: t.manga_ocr_wizard_done);
+      HibikiToast.show(
+        msg: t.manga_ocr_wizard_done,
+        severity: ToastSeverity.success,
+      );
       Navigator.pop(context, bookKey);
     } catch (e) {
       if (!mounted) return;

--- a/hibiki/lib/src/media/manga/manga_overlay_html.dart
+++ b/hibiki/lib/src/media/manga/manga_overlay_html.dart
@@ -716,7 +716,7 @@ String mangaWindowDocument(
 /// 按 data-spread 测量。
 /// `#manga-root` 的过渡声明，由翻页动画偏好决定。
 ///
-/// `slide` = 旧行为（transform 过渡，只是时长改由偏好给）；`none` = 不声明过渡
+/// `slide` = 旧行为（transform 过渡，时长由动画样式的统一值域给出）；`none` = 不声明过渡
 /// （瞬时翻页，给要极限响应的用户）；`fade` = 只过渡 opacity，位移由 JS 在淡出后
 /// 瞬时完成（见 `__mangaApplyTranslate`）。
 String _rootTransitionCss(MangaPageAnimation animation) {
@@ -1059,7 +1059,7 @@ String _mangaGestureJs({
     _selectOcrChar(e.clientX, e.clientY, true);
   }, {passive:true});
   // 点击边缘翻页（仅 spread）。此前漫画**没有任何点击翻页手段**：_onTap 命中不到
-  // OCR 就只报 onTapEmpty（Dart 侧是 no-op），触屏用户只能靠 swipe。
+  // OCR 就只报 onTapEmpty（Dart 侧只回收焦点），触屏用户只能靠 swipe。
   // 左右各占 TAP_ZONE 宽度；中间留白仍走 onTapEmpty，避免抢走查词/呼出 chrome。
   // 方向按阅读方向镜像：LTR 右边缘前进，RTL 左边缘前进。
   var TAP_ZONE_PAGING = $tapZonePaging;
@@ -1132,7 +1132,11 @@ String _mangaGestureJs({
     var g = _pinchGeom();
     if (!g || g.dist <= 0) return;
     e.preventDefault();
-    _zoomAbout(pinch.zoom * (g.dist / pinch.dist), g.cx, g.cy);
+    _zoomAbout(
+      pinch.zoom * Math.pow(g.dist / pinch.dist, ZOOM_SENS),
+      g.cx,
+      g.cy
+    );
   }, {passive: false});
   document.addEventListener('pointerup', function(e){
     if (e.pointerType === 'touch') {

--- a/hibiki/lib/src/media/manga/manga_overlay_html.dart
+++ b/hibiki/lib/src/media/manga/manga_overlay_html.dart
@@ -5,6 +5,7 @@ import 'package:characters/characters.dart';
 import 'package:flutter/foundation.dart' show visibleForTesting;
 
 import 'package:hibiki/src/media/manga/manga_reading_mode.dart';
+import 'package:hibiki/src/media/manga/manga_view_prefs.dart';
 import 'package:hibiki/src/media/manga/mokuro_payload.dart';
 
 /// 把一页所有 mokuro block 渲染成绝对定位的透明 `<p class="ocr-box">` 层。
@@ -560,6 +561,11 @@ String mangaWindowDocument(
   int zoomPercent = 100,
   int documentGeneration = 0,
   Set<int>? ocrPageIndices,
+  int zoomMinPercent = kMangaZoomMinPercent,
+  int zoomMaxPercent = kMangaZoomMaxPercent,
+  int zoomSensitivity = kMangaZoomSensitivityDefault,
+  MangaPageAnimation pageAnimation = MangaPageAnimation.slide,
+  bool tapZonePaging = true,
 }) {
   final bool isWebtoon = mode == MangaReadingMode.webtoon;
   // spread 容器本身始终按 LTR 的几何顺序排列，保证 offsetLeft 是稳定的
@@ -638,7 +644,7 @@ String mangaWindowDocument(
       : '#manga-viewport{overflow:hidden;width:100vw;height:100vh;}'
           '#manga-root{display:flex;flex-direction:row;direction:ltr;'
           'height:100vh;align-items:center;'
-          'transition:transform 0.14s ease-out;will-change:transform;}'
+          '${_rootTransitionCss(pageAnimation)}will-change:transform;}'
           '.manga-spread{display:flex;flex:0 0 100vw;'
           'width:100vw;height:100vh;align-items:center;'
           'justify-content:center;$pageDirectionCss}';
@@ -688,6 +694,11 @@ String mangaWindowDocument(
     currentSpread: currentSpread,
     restoreFraction: restoreFraction,
     zoomPercent: zoomPercent,
+    zoomMinPercent: zoomMinPercent,
+    zoomMaxPercent: zoomMaxPercent,
+    zoomSensitivity: zoomSensitivity,
+    pageAnimation: pageAnimation,
+    tapZonePaging: tapZonePaging,
   )}'
       '</script>'
       '</body></html>';
@@ -703,20 +714,45 @@ String mangaWindowDocument(
 /// 禁用，消除桌面拖动时的原生图片/选区残影（「秃瓢」）。手势阈值镜像 reader
 /// （absDx>absDy 判 swipe，小位移判 tap）。spread translateX 在 [_mangaApplyTranslate]
 /// 按 data-spread 测量。
+/// `#manga-root` 的过渡声明，由翻页动画偏好决定。
+///
+/// `slide` = 旧行为（transform 过渡，只是时长改由偏好给）；`none` = 不声明过渡
+/// （瞬时翻页，给要极限响应的用户）；`fade` = 只过渡 opacity，位移由 JS 在淡出后
+/// 瞬时完成（见 `__mangaApplyTranslate`）。
+String _rootTransitionCss(MangaPageAnimation animation) {
+  switch (animation) {
+    case MangaPageAnimation.none:
+      return '';
+    case MangaPageAnimation.slide:
+      return 'transition:transform ${animation.durationMs}ms ease-out;';
+    case MangaPageAnimation.fade:
+      return 'transition:opacity ${animation.durationMs}ms ease-out;';
+  }
+}
+
 String _mangaGestureJs({
   required bool isWebtoon,
   required bool rtl,
   required int currentSpread,
   required double restoreFraction,
   required int zoomPercent,
+  required int zoomMinPercent,
+  required int zoomMaxPercent,
+  required int zoomSensitivity,
+  required MangaPageAnimation pageAnimation,
+  required bool tapZonePaging,
 }) {
   // RTL：strip 视觉镜像，但 DOM offsetLeft 仍是几何坐标；translateX 统一把目标跨页
   // 首页 offsetLeft 平移到视口左边缘（width=100vw 的视口里目标跨页正好填满）。
   return '''
 (function(){
   function _bridge(){ return window.flutter_inappwebview; }
-  // ── desktop canvas zoom/pan ──
-  var ZOOM = ${zoomPercent.clamp(50, 200) / 100.0};
+  // ── canvas zoom/pan ──
+  var ZOOM_MIN = ${zoomMinPercent / 100.0};
+  var ZOOM_MAX = ${zoomMaxPercent / 100.0};
+  // 灵敏度倍率（设置项，100% = 基准）。
+  var ZOOM_SENS = ${zoomSensitivity / 100.0};
+  var ZOOM = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, ${zoomPercent / 100.0}));
   var PAN_X = window.innerWidth * (1 - ZOOM) / 2;
   var PAN_Y = window.innerHeight * (1 - ZOOM) / 2;
   var rightDrag = null;
@@ -725,20 +761,57 @@ String _mangaGestureJs({
     if (canvas) canvas.style.transform =
       'translate(' + PAN_X + 'px,' + PAN_Y + 'px) scale(' + ZOOM + ')';
   }
+  function _clampZoom(z){
+    return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, z));
+  }
+  // 以 (ax, ay) 屏幕点为锚缩放到 next：锚点下的图像内容保持不动。缩到 <=1 时回中，
+  // 因为此时整页已完全放得下，任何残留平移都只是把页面推出视口。
+  function _zoomAbout(next, ax, ay){
+    next = _clampZoom(next);
+    if (Math.abs(next - ZOOM) < 0.0005) return false;
+    var localX = (ax - PAN_X) / ZOOM;
+    var localY = (ay - PAN_Y) / ZOOM;
+    ZOOM = next;
+    PAN_X = ax - localX * ZOOM;
+    PAN_Y = ay - localY * ZOOM;
+    if (ZOOM <= 1) {
+      PAN_X = window.innerWidth * (1 - ZOOM) / 2;
+      PAN_Y = window.innerHeight * (1 - ZOOM) / 2;
+    }
+    _applyCanvas();
+    var b = _bridge();
+    if (b) b.callHandler('onMangaZoomChanged', Math.round(ZOOM * 100));
+    return true;
+  }
   window.__mangaSetZoom = function(percent){
-    ZOOM = Math.min(2, Math.max(0.5, percent / 100));
+    ZOOM = _clampZoom(percent / 100);
     PAN_X = window.innerWidth * (1 - ZOOM) / 2;
     PAN_Y = window.innerHeight * (1 - ZOOM) / 2;
     _applyCanvas();
   };
   _applyCanvas();
   // ── spread translateX：把固定 100vw 的 spread 容器平移到视口左边缘 ──
+  // 动画样式由设置决定：slide/none 直接改 transform（过渡与否交给 CSS）；fade 先
+  // 淡出、位移完成后再淡入（位移本身不过渡，否则会同时看到滑动与淡入淡出）。
+  var PAGE_ANIM = '${pageAnimation.key}';
+  var PAGE_ANIM_MS = ${pageAnimation.durationMs};
+  var _fadeTimer = null;
   window.__mangaApplyTranslate = function(target){
     var root = document.getElementById('manga-root');
     if (!root) return;
     var spread = root.querySelector('.manga-spread[data-spread="'+target+'"]');
-    if (!spread) { root.style.transform = 'translateX(0px)'; return; }
-    root.style.transform = 'translateX(' + (-spread.offsetLeft) + 'px)';
+    var offset = spread ? -spread.offsetLeft : 0;
+    if (PAGE_ANIM !== 'fade') {
+      root.style.transform = 'translateX(' + offset + 'px)';
+      return;
+    }
+    if (_fadeTimer) clearTimeout(_fadeTimer);
+    root.style.opacity = '0';
+    _fadeTimer = setTimeout(function(){
+      _fadeTimer = null;
+      root.style.transform = 'translateX(' + offset + 'px)';
+      root.style.opacity = '1';
+    }, PAGE_ANIM_MS);
   };
   // ── webtoon scrollTo：恢复时把 data-spread==target 的页顶滚进视口，再按**页内**
   //    fraction 微调（HIGH-1：fraction 是 (scrollY-page.offsetTop)/page.offsetHeight
@@ -900,6 +973,28 @@ String _mangaGestureJs({
   // ── 手势消歧（pointer，覆盖触摸/鼠标）──
   var sx = 0, sy = 0, st = 0, has = false;
   function _start(x, y){ has = true; sx = x; sy = y; st = Date.now(); }
+  // ── 触屏双指捏合缩放 ──
+  // 此前触屏**完全无法缩放**：viewport 声明了 user-scalable=no（必须的：浏览器原生
+  // 缩放会和 #manga-canvas 的 transform 打架），而 JS 侧没有任何 touch/多指处理。
+  // 于是移动端漫画只能看 100%，这也是「缩放极其不灵敏」的一部分。
+  // 这里自己实现：记录活跃触点，两指时按距离比例缩放并以两指中点为锚。
+  var touchPts = {};
+  var pinch = null;
+  // 捏合结束后要吞掉配对的松手事件，否则手指抬起会被 _end 判成 swipe 翻页。
+  // （注意：本注释随文档注入 WebView，不得出现松手事件的字面名——
+  // manga_overlay_html_test 的 C1 不变式按该字面量计数，全文档恰好允许一个。）
+  var pinchGuard = false;
+  function _pinchGeom(){
+    var ids = Object.keys(touchPts);
+    if (ids.length < 2) return null;
+    var a = touchPts[ids[0]], b = touchPts[ids[1]];
+    var dx = a.x - b.x, dy = a.y - b.y;
+    return {
+      dist: Math.sqrt(dx * dx + dy * dy),
+      cx: (a.x + b.x) / 2,
+      cy: (a.y + b.y) / 2
+    };
+  }
   // Niratan-style hit testing: regions are explicit character rectangles.
   // Use a constant 4 screen-pixel slop at every zoom and choose the smallest
   // overlapping region, instead of asking browser caret geometry to guess.
@@ -963,10 +1058,26 @@ String _mangaGestureJs({
     shiftHoverX = e.clientX; shiftHoverY = e.clientY;
     _selectOcrChar(e.clientX, e.clientY, true);
   }, {passive:true});
+  // 点击边缘翻页（仅 spread）。此前漫画**没有任何点击翻页手段**：_onTap 命中不到
+  // OCR 就只报 onTapEmpty（Dart 侧是 no-op），触屏用户只能靠 swipe。
+  // 左右各占 TAP_ZONE 宽度；中间留白仍走 onTapEmpty，避免抢走查词/呼出 chrome。
+  // 方向按阅读方向镜像：LTR 右边缘前进，RTL 左边缘前进。
+  var TAP_ZONE_PAGING = $tapZonePaging;
+  var IS_RTL = $rtl;
+  var TAP_ZONE = 0.25;
+  function _tapZoneTurn(x){
+    if (!TAP_ZONE_PAGING || IS_WEBTOON) return null;
+    var w = window.innerWidth || 1;
+    if (x <= w * TAP_ZONE) return IS_RTL ? 'next' : 'prev';
+    if (x >= w * (1 - TAP_ZONE)) return IS_RTL ? 'prev' : 'next';
+    return null;
+  }
   function _onTap(x, y){
     var b = _bridge();
     if (!b) return;
     if (_selectOcrChar(x, y, false)) return;
+    var zone = _tapZoneTurn(x);
+    if (zone) { b.callHandler('onMangaTurn', zone); return; }
     // 裸图 / 尚未完成 OCR 的区域不打开大图，继续留在阅读器。
     b.callHandler('onTapEmpty');
   }
@@ -990,6 +1101,17 @@ String _mangaGestureJs({
     }
   }
   document.addEventListener('pointerdown', function(e){
+    if (e.pointerType === 'touch') {
+      touchPts[e.pointerId] = {x: e.clientX, y: e.clientY};
+      var g = _pinchGeom();
+      if (g && g.dist > 0) {
+        // 第二指落下：进入捏合，取消已经开始的单指 swipe 计时。
+        pinch = {dist: g.dist, zoom: ZOOM};
+        pinchGuard = true;
+        has = false;
+        return;
+      }
+    }
     if (RESCAN) { rescanStart = {x: e.clientX, y: e.clientY}; return; }
     if (e.button === 2) {
       rightDrag = {
@@ -1002,7 +1124,29 @@ String _mangaGestureJs({
     if (e.button !== 0) return;
     _start(e.clientX, e.clientY);
   }, {passive: true});
+  document.addEventListener('pointermove', function(e){
+    if (e.pointerType !== 'touch') return;
+    if (!touchPts[e.pointerId]) return;
+    touchPts[e.pointerId] = {x: e.clientX, y: e.clientY};
+    if (!pinch) return;
+    var g = _pinchGeom();
+    if (!g || g.dist <= 0) return;
+    e.preventDefault();
+    _zoomAbout(pinch.zoom * (g.dist / pinch.dist), g.cx, g.cy);
+  }, {passive: false});
   document.addEventListener('pointerup', function(e){
+    if (e.pointerType === 'touch') {
+      delete touchPts[e.pointerId];
+      if (pinch) {
+        // 还剩一指时仍不恢复 swipe：等全部手指抬起，避免捏合尾巴被判成翻页。
+        if (Object.keys(touchPts).length < 2) pinch = null;
+        return;
+      }
+      if (pinchGuard) {
+        if (Object.keys(touchPts).length === 0) pinchGuard = false;
+        return;
+      }
+    }
     // 必须排在 _end 的 tap/swipe 消歧之前：框选松手不得被判成 tap 查词或 swipe 翻页。
     if (RESCAN) { _rescanFinish(e.clientX, e.clientY); return; }
     if (e.button === 2) {
@@ -1025,32 +1169,40 @@ String _mangaGestureJs({
   // 注意：本注释随文档注入 WebView，不能出现松手事件的字面名——
   // manga_overlay_html_test 的 C1 不变式按该字面量计数，恰好允许一个。
   document.addEventListener('pointercancel', function(e){
+    if (e.pointerType === 'touch') {
+      delete touchPts[e.pointerId];
+      if (Object.keys(touchPts).length < 2) pinch = null;
+      if (Object.keys(touchPts).length === 0) pinchGuard = false;
+    }
     if (RESCAN) _rescanClear();
   }, {passive: true});
   document.addEventListener('contextmenu', function(e){
     e.preventDefault();
   }, {passive:false});
 
-  // Ctrl/Command + wheel: 50%..200%, 10% steps, anchored at the pointer.
+  // Ctrl/Command + wheel：以指针为锚的**比例**缩放。
+  //
+  // 旧实现把 e.deltaY 只当符号用（恒 ±0.1 的加法步长），于是：① 触控板的高频小
+  // delta 与鼠标的一格大 delta 被同等对待；② 加法步长在高倍率下相对变化越来越小
+  // （1.9→2.0 只有 5.3%）。两者叠加就是用户说的「缩放极其不灵敏」。
+  // 现在按 delta 幅值走乘法缩放：一格标准滚轮（deltaY=100）≈ 22%，触控板的小 delta
+  // 按比例给小步长，任何倍率下手感一致。deltaMode 归一化后再算，否则「行/页」模式
+  // 的浏览器会得到完全不同的步长。
+  function _wheelSteps(e){
+    var dy = e.deltaY || 0;
+    if (e.deltaMode === 1) dy *= 16;
+    else if (e.deltaMode === 2) dy *= window.innerHeight;
+    // 单次事件封顶 4 格，防惯性滚动一帧糊上天。
+    return Math.max(-4, Math.min(4, -dy / 100));
+  }
   document.addEventListener('wheel', function(e){
     if (RESCAN) return;
     if (!(e.ctrlKey || e.metaKey)) return;
     e.preventDefault();
     e.stopImmediatePropagation();
-    var next = Math.min(2, Math.max(0.5, ZOOM + (e.deltaY < 0 ? 0.1 : -0.1)));
-    if (Math.abs(next - ZOOM) < 0.001) return;
-    var localX = (e.clientX - PAN_X) / ZOOM;
-    var localY = (e.clientY - PAN_Y) / ZOOM;
-    ZOOM = next;
-    PAN_X = e.clientX - localX * ZOOM;
-    PAN_Y = e.clientY - localY * ZOOM;
-    if (ZOOM <= 1) {
-      PAN_X = window.innerWidth * (1 - ZOOM) / 2;
-      PAN_Y = window.innerHeight * (1 - ZOOM) / 2;
-    }
-    _applyCanvas();
-    var b = _bridge();
-    if (b) b.callHandler('onMangaZoomChanged', Math.round(ZOOM * 100));
+    var steps = _wheelSteps(e);
+    if (steps === 0) return;
+    _zoomAbout(ZOOM * Math.exp(steps * 0.2 * ZOOM_SENS), e.clientX, e.clientY);
   }, {passive:false});
 
   // ── 桌面鼠标滚轮翻页（仅 spread，BUG-051）──
@@ -1061,20 +1213,33 @@ String _mangaGestureJs({
   // 避免一格滚动翻一叠页。
   if (!IS_WEBTOON) {
     var _wheelLock = false;
+    var _wheelAccum = 0;
+    var _wheelDir = 0;
     document.addEventListener('wheel', function(e){
       if (RESCAN) return;
       if (e.ctrlKey || e.metaKey) return;
       e.preventDefault();
-      if (_wheelLock) return;
       var d = e.deltaY || e.deltaX || 0;
-      if (Math.abs(d) < 2) return;
+      if (e.deltaMode === 1) d *= 16;
+      else if (e.deltaMode === 2) d *= window.innerHeight;
+      if (d === 0) return;
+      var dir = d > 0 ? 1 : -1;
+      // 反向立刻清账：来回滚不该被上一方向的余量吃掉。
+      if (dir !== _wheelDir) { _wheelAccum = 0; _wheelDir = dir; }
+      if (_wheelLock) return;
+      // 按累计位移而非「一个事件 = 一页」触发：鼠标一格（deltaY≈100）立刻翻一页，
+      // 触控板的碎 delta 攒够一格才翻。旧实现是「首个事件就翻 + 320ms 全禁」，
+      // 于是滚轮翻页上限约 3 页/秒，且触控板轻扫也会误翻——用户说的「翻页逻辑难受」。
+      _wheelAccum += Math.abs(d);
+      if (_wheelAccum < 40) return;
+      _wheelAccum = 0;
       var b = _bridge();
       if (!b) return;
       _wheelLock = true;
-      setTimeout(function(){ _wheelLock = false; }, 320);
+      setTimeout(function(){ _wheelLock = false; }, 110);
       // 向下/向右滚 = 页序前进（next），向上/向左 = 后退（prev）；Dart 端按阅读
       // 方向已统一 clamp（与 swipe 同口径）。
-      b.callHandler('onMangaTurn', d > 0 ? 'next' : 'prev');
+      b.callHandler('onMangaTurn', dir > 0 ? 'next' : 'prev');
     }, {passive: false});
   }
   // ── 抑制原生拖拽残影（BUG-051「秃瓢」）──

--- a/hibiki/lib/src/media/manga/manga_sources_page.dart
+++ b/hibiki/lib/src/media/manga/manga_sources_page.dart
@@ -98,7 +98,9 @@ class _MangaSourcesPageState extends ConsumerState<MangaSourcesPage> {
     try {
       await _manager!.clearSourceData(source);
     } on Object catch (error) {
-      if (mounted) HibikiToast.show(msg: '$error');
+      if (mounted) {
+        HibikiToast.show(msg: '$error', severity: ToastSeverity.error);
+      }
     }
   }
 

--- a/hibiki/lib/src/media/manga/manga_view_prefs.dart
+++ b/hibiki/lib/src/media/manga/manga_view_prefs.dart
@@ -1,0 +1,62 @@
+/// 漫画阅读器「观看偏好」的值域与枚举（缩放范围、灵敏度、翻页动画）。
+///
+/// 刻意做成**无依赖的叶子文件**：偏好仓库（`preferences_repository.dart`）、设置
+/// schema、阅读器页面与 WebView 文档生成器四处都要用同一组边界值，此前这些数字
+/// 被各自硬编码（`clamp(50, 200)` 在 Dart 侧 4 处 + JS 侧 2 处各写一遍），改一次
+/// 范围要同步 6 个地方，漏一个就表现为「设置里能调到 400% 但阅读器里被打回 200%」。
+library;
+
+/// 漫画缩放百分比下限 / 上限（单一真相源）。
+///
+/// 上限从旧的 200% 提到 400%：200% 对高分屏上的小开本单页漫画根本不够（用户反馈
+/// 「缩放极其不灵敏」的一半是这个天花板，而不是步长）。下限保持 50%。
+const int kMangaZoomMinPercent = 50;
+const int kMangaZoomMaxPercent = 400;
+
+/// 缩放灵敏度倍率（百分比）。100 = 基准手感，越大滚轮/捏合每一步缩放越多。
+const int kMangaZoomSensitivityMin = 25;
+const int kMangaZoomSensitivityMax = 400;
+const int kMangaZoomSensitivityDefault = 100;
+
+/// 翻页动画样式。
+///
+/// 存字符串键而非 enum index：重排枚举不得破坏已落盘的偏好。
+enum MangaPageAnimation { none, slide, fade }
+
+extension MangaPageAnimationKey on MangaPageAnimation {
+  String get key {
+    switch (this) {
+      case MangaPageAnimation.none:
+        return 'none';
+      case MangaPageAnimation.slide:
+        return 'slide';
+      case MangaPageAnimation.fade:
+        return 'fade';
+    }
+  }
+
+  /// 动画时长（毫秒）。`none` 恒 0，供 CSS `transition-duration` 直接使用。
+  int get durationMs {
+    switch (this) {
+      case MangaPageAnimation.none:
+        return 0;
+      case MangaPageAnimation.slide:
+        return 180;
+      case MangaPageAnimation.fade:
+        return 160;
+    }
+  }
+
+  /// 未知值一律回落 [MangaPageAnimation.slide]（旧版本行为 = 有滑动过渡）。
+  static MangaPageAnimation fromKey(String raw) {
+    switch (raw) {
+      case 'none':
+        return MangaPageAnimation.none;
+      case 'fade':
+        return MangaPageAnimation.fade;
+      case 'slide':
+      default:
+        return MangaPageAnimation.slide;
+    }
+  }
+}

--- a/hibiki/lib/src/media/manga/mihon/mihon_extensions_page.dart
+++ b/hibiki/lib/src/media/manga/mihon/mihon_extensions_page.dart
@@ -114,7 +114,9 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
     try {
       await _manager!.addStore(url, allowInsecure: allowInsecure);
     } catch (error) {
-      if (mounted) HibikiToast.show(msg: '$error');
+      if (mounted) {
+        HibikiToast.show(msg: '$error', severity: ToastSeverity.error);
+      }
     }
   }
 
@@ -155,7 +157,9 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
           await _manager!.prepareLocalInstall(path);
       await _confirmAndInstall(proposal);
     } catch (error) {
-      if (mounted) HibikiToast.show(msg: '$error');
+      if (mounted) {
+        HibikiToast.show(msg: '$error', severity: ToastSeverity.error);
+      }
     }
   }
 
@@ -165,7 +169,9 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
           await _manager!.prepareStoreInstall(extension);
       await _confirmAndInstall(proposal);
     } catch (error) {
-      if (mounted) HibikiToast.show(msg: '$error');
+      if (mounted) {
+        HibikiToast.show(msg: '$error', severity: ToastSeverity.error);
+      }
     }
   }
 
@@ -316,7 +322,9 @@ class _MihonExtensionsPageState extends ConsumerState<MihonExtensionsPage> {
       await _manager!.commitInstall(proposal, trustSigner: true);
       return true;
     } catch (error) {
-      if (mounted) HibikiToast.show(msg: '$error');
+      if (mounted) {
+        HibikiToast.show(msg: '$error', severity: ToastSeverity.error);
+      }
       return false;
     }
   }

--- a/hibiki/lib/src/media/manga/mihon/mihon_source_browse_page.dart
+++ b/hibiki/lib/src/media/manga/mihon/mihon_source_browse_page.dart
@@ -429,7 +429,9 @@ class _MihonMangaDetailPageState extends State<MihonMangaDetailPage> {
       ErrorLogService.instance
           .log('MihonMangaDetailPage.addToBookshelf', error, stack);
       debugPrint('[Mihon] add to bookshelf failed: $error');
-      if (mounted) HibikiToast.show(msg: '$error');
+      if (mounted) {
+        HibikiToast.show(msg: '$error', severity: ToastSeverity.error);
+      }
     } finally {
       if (mounted) setState(() => _libraryBusy = false);
     }

--- a/hibiki/lib/src/media/manga/ocr/manga_ocr_engine.dart
+++ b/hibiki/lib/src/media/manga/ocr/manga_ocr_engine.dart
@@ -12,6 +12,7 @@ enum MangaOcrEnginePreference {
   localOnnx,
   googleLens,
   externalMokuro,
+  pairedHost,
 }
 
 extension MangaOcrEnginePreferenceKey on MangaOcrEnginePreference {
@@ -25,6 +26,8 @@ extension MangaOcrEnginePreferenceKey on MangaOcrEnginePreference {
         return 'google_lens';
       case MangaOcrEnginePreference.externalMokuro:
         return 'external_mokuro';
+      case MangaOcrEnginePreference.pairedHost:
+        return 'paired_host';
     }
   }
 
@@ -38,6 +41,8 @@ extension MangaOcrEnginePreferenceKey on MangaOcrEnginePreference {
         return MangaOcrEngineId.googleLens;
       case MangaOcrEnginePreference.externalMokuro:
         return MangaOcrEngineId.externalMokuro;
+      case MangaOcrEnginePreference.pairedHost:
+        return MangaOcrEngineId.pairedHost;
     }
   }
 
@@ -49,6 +54,8 @@ extension MangaOcrEnginePreferenceKey on MangaOcrEnginePreference {
         return MangaOcrEnginePreference.googleLens;
       case 'external_mokuro':
         return MangaOcrEnginePreference.externalMokuro;
+      case 'paired_host':
+        return MangaOcrEnginePreference.pairedHost;
       case 'auto':
       default:
         return MangaOcrEnginePreference.auto;

--- a/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
+++ b/hibiki/lib/src/media/manga/online/mokuro_moe_catalog_view.dart
@@ -226,7 +226,10 @@ class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
     }
     setState(() {});
     if (completed) {
-      HibikiToast.show(msg: t.manga_ocr_wizard_done);
+      HibikiToast.show(
+        msg: t.manga_ocr_wizard_done,
+        severity: ToastSeverity.success,
+      );
     }
   }
 
@@ -303,7 +306,10 @@ class MokuroMoeCatalogViewState extends ConsumerState<MokuroMoeCatalogView> {
         .toList();
     _queue.enqueue(seriesName: series.name, volumeNames: volumes);
     setState(() => _selectedVolumes.clear());
-    HibikiToast.show(msg: t.manga_online_queue_added);
+    HibikiToast.show(
+      msg: t.manga_online_queue_added,
+      severity: ToastSeverity.info,
+    );
   }
 
   // ── UI ───────────────────────────────────────────────────────────────

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -2196,7 +2196,10 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
           );
           if (!mounted) return;
           setState(() => _wholeVolumeOcrRunning = false);
-          HibikiToast.show(msg: '${t.manga_ocr_wizard_failed}: $error');
+          HibikiToast.show(
+            msg: '${t.manga_ocr_wizard_failed}: $error',
+            severity: ToastSeverity.error,
+          );
         },
         onDone: () {
           _wholeVolumeOcrSubscription = null;
@@ -2212,7 +2215,10 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         stack,
       );
       if (mounted) {
-        HibikiToast.show(msg: '${t.manga_ocr_wizard_failed}: $error');
+        HibikiToast.show(
+          msg: '${t.manga_ocr_wizard_failed}: $error',
+          severity: ToastSeverity.error,
+        );
       }
     } finally {
       if (mounted) setState(() => _wholeVolumeOcrOpen = false);
@@ -2267,6 +2273,7 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         engine: acceleration.label,
         reason: acceleration.degradeReasons.join('; '),
       ),
+      severity: ToastSeverity.warning,
     );
   }
 
@@ -2320,7 +2327,7 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     // 整卷 OCR 只是就地重写已入库书的 manga.json，没有发生任何导入：这里必须用
     // OCR 语义的文案，不能复用向导的「漫画已导入」（用户在阅读器里跑完 OCR 却看到
     // 「导入已完成」）。
-    HibikiToast.show(msg: t.manga_ocr_done);
+    HibikiToast.show(msg: t.manga_ocr_done, severity: ToastSeverity.success);
   }
 
   void _cancelWholeVolumeOcr() {
@@ -2366,14 +2373,20 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     final MangaBoxRescanService service =
         _rescanService ??= MangaBoxRescanService();
     if (!service.isLocalRescanSupported) {
-      HibikiToast.show(msg: t.manga_ocr_unsupported);
+      HibikiToast.show(
+        msg: t.manga_ocr_unsupported,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     if (!_rescanModelReady) {
       await _refreshRescanModelReady();
       if (!mounted) return;
       if (!_rescanModelReady) {
-        HibikiToast.show(msg: t.manga_rescan_model_missing);
+        HibikiToast.show(
+          msg: t.manga_rescan_model_missing,
+          severity: ToastSeverity.error,
+        );
         return;
       }
     }
@@ -2388,7 +2401,12 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       source: 'window.__mangaSetRescanMode && '
           'window.__mangaSetRescanMode(${on ? 'true' : 'false'});',
     );
-    if (on) HibikiToast.show(msg: t.manga_rescan_hint);
+    if (on) {
+      HibikiToast.show(
+        msg: t.manga_rescan_hint,
+        severity: ToastSeverity.info,
+      );
+    }
   }
 
   /// JS 框选回传（`onMangaBoxSelected`）：payload 是
@@ -2419,11 +2437,17 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       MangaHibikiPage.mangaImageRelativePath(payload.images[pageIndex].url),
     );
     if (imagePath == null) {
-      HibikiToast.show(msg: t.manga_rescan_failed);
+      HibikiToast.show(
+        msg: t.manga_rescan_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     _rescanBusy = true;
-    HibikiToast.show(msg: t.manga_rescan_running);
+    HibikiToast.show(
+      msg: t.manga_rescan_running,
+      severity: ToastSeverity.info,
+    );
     try {
       final MangaBoxRescanService service =
           _rescanService ??= MangaBoxRescanService();
@@ -2438,7 +2462,12 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       );
     } on Object catch (error, stack) {
       ErrorLogService.instance.log('MangaHibikiPage.rescan', error, stack);
-      if (mounted) HibikiToast.show(msg: t.manga_rescan_failed);
+      if (mounted) {
+        HibikiToast.show(
+          msg: t.manga_rescan_failed,
+          severity: ToastSeverity.error,
+        );
+      }
     } finally {
       _rescanBusy = false;
     }
@@ -2528,10 +2557,18 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       if (!mounted) return;
       setState(() => _payload = payload);
       await _loadInitialWindow();
-      HibikiToast.show(msg: t.manga_rescan_writeback_done);
+      HibikiToast.show(
+        msg: t.manga_rescan_writeback_done,
+        severity: ToastSeverity.success,
+      );
     } on Object catch (error, stack) {
       ErrorLogService.instance.log('MangaHibikiPage.rescanWrite', error, stack);
-      if (mounted) HibikiToast.show(msg: t.manga_rescan_writeback_failed);
+      if (mounted) {
+        HibikiToast.show(
+          msg: t.manga_rescan_writeback_failed,
+          severity: ToastSeverity.error,
+        );
+      }
     }
   }
 

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -2258,7 +2258,10 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         await _replacePageOcrOverlay(pageIndex, payload.images[pageIndex]);
       }
     }
-    HibikiToast.show(msg: t.manga_ocr_wizard_done);
+    // 整卷 OCR 只是就地重写已入库书的 manga.json，没有发生任何导入：这里必须用
+    // OCR 语义的文案，不能复用向导的「漫画已导入」（用户在阅读器里跑完 OCR 却看到
+    // 「导入已完成」）。
+    HibikiToast.show(msg: t.manga_ocr_done);
   }
 
   void _cancelWholeVolumeOcr() {

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -41,6 +41,8 @@ import 'package:hibiki/src/media/manga/ocr/manga_box_rescan.dart';
 import 'package:hibiki/src/media/manga/ocr/manga_ocr_engine.dart';
 import 'package:hibiki/src/media/manga/ocr/manga_ocr_cache_recovery.dart';
 import 'package:hibiki/src/media/manga/reader/manga_rescan_result_sheet.dart';
+import 'package:hibiki/src/media/manga/reader/manga_volume_key_paging_controller.dart';
+import 'package:hibiki/src/media/manga/reader/manga_zoom_preference_debouncer.dart';
 import 'package:hibiki/src/focus/page_focus_ownership.dart';
 import 'package:hibiki/src/shortcuts/input_binding.dart'
     show InputBinding, ModifierKey, MouseBinding, activeModifierKeys;
@@ -613,6 +615,7 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   double _currentFraction = 0;
   Timer? _progressDebounce;
   Timer? _onlineGeometryPersistDebounce;
+  MangaZoomPreferenceDebouncer? _zoomPreferenceDebouncer;
   int _lastSavedPage = -1;
   double _lastSavedFraction = -1;
 
@@ -765,6 +768,16 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   @override
   void initState() {
     super.initState();
+    _volumeKeyPagingController = MangaVolumeKeyPagingController(
+      onPrevious: () => _executeReaderInputAction(
+        MangaReaderInputAction.previous,
+        source: _MangaReaderInputSource.volumeKey,
+      ),
+      onNext: () => _executeReaderInputAction(
+        MangaReaderInputAction.next,
+        source: _MangaReaderInputSource.volumeKey,
+      ),
+    );
     WidgetsBinding.instance.addObserver(this);
     // 进程退出兜底：把未落盘的页码 flush 掉（与 EPUB/PDF 阅读器同纪律）。
     ExitFlushRegistry.instance.register(_flushPosition);
@@ -774,8 +787,8 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
 
   @override
   void dispose() {
-    // 交还音量键所有权（见 _volumeKeysOwned）：必须早于其它拆栈，且无条件执行。
-    _applyVolumeKeyPaging(false);
+    // 交还音量键所有权：必须早于其它拆栈，且无条件执行。
+    _volumeKeyPagingController.dispose();
     ExitFlushRegistry.instance.unregister(_flushPosition);
     final MangaBoxRescanService? rescanService = _rescanService;
     _rescanService = null;
@@ -788,6 +801,10 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
     _windowGate.abandon();
     _progressDebounce?.cancel();
     _onlineGeometryPersistDebounce?.cancel();
+    final MangaZoomPreferenceDebouncer? zoomDebouncer =
+        _zoomPreferenceDebouncer;
+    _zoomPreferenceDebouncer = null;
+    if (zoomDebouncer != null) unawaited(zoomDebouncer.dispose());
     _dictionaryTurnDismissTimer?.cancel();
     unawaited(_wholeVolumeOcrSubscription?.cancel());
     _wholeVolumeOcrSubscription = null;
@@ -1868,32 +1885,13 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   /// （`audiobook.part.dart` 的 `_setupVolumeKeyHandlers` 无条件覆盖）。漫画页接管后
   /// 必须在 dispose 里交还——清 handler 并关掉原生拦截，否则退出漫画后音量键继续被
   /// `MainActivity.dispatchKeyEvent` 吞掉，用户调不动系统音量（BUG-196 的老坑）。
-  bool _volumeKeysOwned = false;
+  late final MangaVolumeKeyPagingController _volumeKeyPagingController;
 
   void _applyVolumeKeyPaging(bool enabled) {
     // 只有 Android 侧 dispatchKeyEvent 会转发音量键；其它平台连通道都没有。
-    final bool want = enabled && isMobilePlatform;
-    if (want == _volumeKeysOwned) return;
-    _volumeKeysOwned = want;
-    if (want) {
-      VolumeKeyChannel.instance.setHandlers(
-        onVolumeUp: () => _onVolumeKeyTurn(isUp: true),
-        onVolumeDown: () => _onVolumeKeyTurn(isUp: false),
-      );
-      unawaited(VolumeKeyChannel.instance.setInterceptEnabled(true));
-    } else {
-      VolumeKeyChannel.instance.setHandlers();
-      unawaited(VolumeKeyChannel.instance.setInterceptEnabled(false));
-    }
-  }
-
-  /// 音量减 = 页序前进（与 EPUB 阅读器同口径）。方向的 RTL 校正统一在
-  /// [_onMangaTurn] 一侧做，这里只报页序语义。
-  void _onVolumeKeyTurn({required bool isUp}) {
-    if (!mounted) return;
-    _executeReaderInputAction(
-      isUp ? MangaReaderInputAction.previous : MangaReaderInputAction.next,
-      source: _MangaReaderInputSource.volumeKey,
+    _volumeKeyPagingController.apply(
+      enabled: enabled,
+      platformSupported: Platform.isAndroid,
     );
   }
 
@@ -2941,11 +2939,18 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         value.clamp(kMangaZoomMinPercent, kMangaZoomMaxPercent);
     if (_zoomPercent == normalized) return;
     setState(() => _zoomPercent = normalized);
+    _zoomPreferenceDebouncer?.discard();
     await appModel.setMangaZoomPercent(normalized);
     await _controller?.evaluateJavascript(
       source: 'window.__mangaSetZoom && '
           'window.__mangaSetZoom($normalized);',
     );
+  }
+
+  void _queueZoomPreferencePersist(int value) {
+    (_zoomPreferenceDebouncer ??= MangaZoomPreferenceDebouncer(
+      persist: appModel.setMangaZoomPercent,
+    )).queue(value);
   }
 
   Future<void> _jumpToPage(int oneBasedPage) async {
@@ -3438,7 +3443,7 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
             } else {
               _zoomPercent = normalized;
             }
-            unawaited(appModel.setMangaZoomPercent(normalized));
+            _queueZoomPreferencePersist(normalized);
           },
         );
         // webtoon 滚动报告：更新 fraction/页码（绝不重载）。

--- a/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_hibiki_page.dart
@@ -27,6 +27,7 @@ import 'package:hibiki/src/ocr/ocr_types.dart' show OcrRect;
 import 'package:hibiki/src/media/manga/manga_overlay_html.dart';
 import 'package:hibiki/src/media/manga/manga_reading_mode.dart';
 import 'package:hibiki/src/media/manga/manga_reading_stats.dart';
+import 'package:hibiki/src/media/manga/manga_view_prefs.dart';
 import 'package:hibiki/src/media/manga/manga_spread_model.dart';
 import 'package:hibiki/src/media/manga/mihon/manga_page_provider.dart';
 import 'package:hibiki/src/media/manga/mihon/mihon_library.dart';
@@ -97,7 +98,7 @@ enum MangaReaderInputAction {
   backOrExit,
 }
 
-enum _MangaReaderInputSource { flutter, nativeWebView }
+enum _MangaReaderInputSource { flutter, nativeWebView, volumeKey }
 
 /// Serializes burst page-turn input across asynchronous WebView window loads.
 ///
@@ -597,6 +598,12 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   String _spreadDirection = 'rtl';
   int _zoomPercent = 100;
 
+  /// 观看偏好快照（打开书时从 [AppModel] 读一次，随文档注入 WebView）。
+  /// 与 [_zoomPercent] 不同，这三项没有页内切换入口，只在设置里改。
+  int _zoomSensitivity = kMangaZoomSensitivityDefault;
+  MangaPageAnimation _pageAnimation = MangaPageAnimation.slide;
+  bool _tapZonePaging = true;
+
   /// 最近一次实际生效的布局（由 [_buildSpreadsFor] 记账），didChangeMetrics
   /// 只在解析结果真变时才重建 spread 序列，避免键盘弹出等无关 metrics 抖动。
   MangaPageLayout _pageLayout = MangaPageLayout.single;
@@ -767,6 +774,8 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
 
   @override
   void dispose() {
+    // 交还音量键所有权（见 _volumeKeysOwned）：必须早于其它拆栈，且无条件执行。
+    _applyVolumeKeyPaging(false);
     ExitFlushRegistry.instance.unregister(_flushPosition);
     final MangaBoxRescanService? rescanService = _rescanService;
     _rescanService = null;
@@ -920,7 +929,13 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       appModel.mangaSpreadPreference,
     );
     _spreadDirection = appModel.mangaReadingDirection == 'ltr' ? 'ltr' : 'rtl';
-    _zoomPercent = appModel.mangaZoomPercent.clamp(50, 200);
+    _zoomPercent = appModel.mangaZoomPercent
+        .clamp(kMangaZoomMinPercent, kMangaZoomMaxPercent);
+    _zoomSensitivity = appModel.mangaZoomSensitivity
+        .clamp(kMangaZoomSensitivityMin, kMangaZoomSensitivityMax);
+    _pageAnimation = MangaPageAnimationKey.fromKey(appModel.mangaPageAnimation);
+    _tapZonePaging = appModel.mangaTapZonePaging;
+    _applyVolumeKeyPaging(appModel.mangaVolumeKeyPaging);
 
     // 阅读模式：用户覆盖优先，null 走自动判定（页图长宽比中位数）。
     final MangaReadingMode mode =
@@ -1153,7 +1168,13 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       appModel.mangaSpreadPreference,
     );
     _spreadDirection = appModel.mangaReadingDirection == 'ltr' ? 'ltr' : 'rtl';
-    _zoomPercent = appModel.mangaZoomPercent.clamp(50, 200);
+    _zoomPercent = appModel.mangaZoomPercent
+        .clamp(kMangaZoomMinPercent, kMangaZoomMaxPercent);
+    _zoomSensitivity = appModel.mangaZoomSensitivity
+        .clamp(kMangaZoomSensitivityMin, kMangaZoomSensitivityMax);
+    _pageAnimation = MangaPageAnimationKey.fromKey(appModel.mangaPageAnimation);
+    _tapZonePaging = appModel.mangaTapZonePaging;
+    _applyVolumeKeyPaging(appModel.mangaVolumeKeyPaging);
     final EpubBookRow row = persistedRow != null
         ? persistedRow.copyWith(
             epubPath: p.basename(mangaJson.path),
@@ -1652,6 +1673,9 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
       restoreFraction: isWebtoon ? _currentFraction : 0,
       documentGeneration: documentGeneration,
       ocrPageIndices: keptPages,
+      zoomSensitivity: _zoomSensitivity,
+      pageAnimation: _pageAnimation,
+      tapZonePaging: _tapZonePaging,
     );
   }
 
@@ -1837,6 +1861,41 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   _MangaReaderInputSource? _lastReaderInputSource;
   DateTime? _lastReaderInputAt;
   Timer? _dictionaryTurnDismissTimer;
+
+  /// 是否已接管音量键。
+  ///
+  /// [VolumeKeyChannel] 是**进程级单例**，EPUB 阅读器也会往同一个 handler 槽里写
+  /// （`audiobook.part.dart` 的 `_setupVolumeKeyHandlers` 无条件覆盖）。漫画页接管后
+  /// 必须在 dispose 里交还——清 handler 并关掉原生拦截，否则退出漫画后音量键继续被
+  /// `MainActivity.dispatchKeyEvent` 吞掉，用户调不动系统音量（BUG-196 的老坑）。
+  bool _volumeKeysOwned = false;
+
+  void _applyVolumeKeyPaging(bool enabled) {
+    // 只有 Android 侧 dispatchKeyEvent 会转发音量键；其它平台连通道都没有。
+    final bool want = enabled && isMobilePlatform;
+    if (want == _volumeKeysOwned) return;
+    _volumeKeysOwned = want;
+    if (want) {
+      VolumeKeyChannel.instance.setHandlers(
+        onVolumeUp: () => _onVolumeKeyTurn(isUp: true),
+        onVolumeDown: () => _onVolumeKeyTurn(isUp: false),
+      );
+      unawaited(VolumeKeyChannel.instance.setInterceptEnabled(true));
+    } else {
+      VolumeKeyChannel.instance.setHandlers();
+      unawaited(VolumeKeyChannel.instance.setInterceptEnabled(false));
+    }
+  }
+
+  /// 音量减 = 页序前进（与 EPUB 阅读器同口径）。方向的 RTL 校正统一在
+  /// [_onMangaTurn] 一侧做，这里只报页序语义。
+  void _onVolumeKeyTurn({required bool isUp}) {
+    if (!mounted) return;
+    _executeReaderInputAction(
+      isUp ? MangaReaderInputAction.previous : MangaReaderInputAction.next,
+      source: _MangaReaderInputSource.volumeKey,
+    );
+  }
 
   void _executeReaderInputAction(
     MangaReaderInputAction action, {
@@ -2841,7 +2900,8 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
   }
 
   Future<void> _setZoomPercent(int value) async {
-    final int normalized = value.clamp(50, 200);
+    final int normalized =
+        value.clamp(kMangaZoomMinPercent, kMangaZoomMaxPercent);
     if (_zoomPercent == normalized) return;
     setState(() => _zoomPercent = normalized);
     await appModel.setMangaZoomPercent(normalized);
@@ -2946,12 +3006,12 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
         ),
         PopupMenuItem<_MangaContextAction>(
           value: _MangaContextAction.zoomIn,
-          enabled: _zoomPercent < 200,
+          enabled: _zoomPercent < kMangaZoomMaxPercent,
           child: Text('${t.manga_zoom} + ($_zoomPercent%)'),
         ),
         PopupMenuItem<_MangaContextAction>(
           value: _MangaContextAction.zoomOut,
-          enabled: _zoomPercent > 50,
+          enabled: _zoomPercent > kMangaZoomMinPercent,
           child: Text('${t.manga_zoom} − ($_zoomPercent%)'),
         ),
       ],
@@ -3333,7 +3393,8 @@ class _MangaHibikiPageState extends BaseSourcePageState<MangaHibikiPage>
               _ => null,
             };
             if (value == null) return;
-            final int normalized = value.clamp(50, 200);
+            final int normalized =
+                value.clamp(kMangaZoomMinPercent, kMangaZoomMaxPercent);
             if (_zoomPercent == normalized) return;
             if (mounted) {
               setState(() => _zoomPercent = normalized);

--- a/hibiki/lib/src/media/manga/reader/manga_volume_key_paging_controller.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_volume_key_paging_controller.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:hibiki/src/utils/misc/volume_key_channel.dart';
+
+/// Owns the process-wide Android volume-key bridge while a manga page is active.
+///
+/// Android forwards repeated ACTION_DOWN events while a key is held. The
+/// controller accepts the first event immediately and rate-limits the repeat
+/// stream so a long press cannot queue turns all the way to the end of a book.
+class MangaVolumeKeyPagingController {
+  MangaVolumeKeyPagingController({
+    required this.onPrevious,
+    required this.onNext,
+    this.throttle = const Duration(milliseconds: 180),
+    DateTime Function()? now,
+    VolumeKeyChannel? channel,
+  })  : _now = now ?? DateTime.now,
+        _channel = channel ?? VolumeKeyChannel.instance;
+
+  final void Function() onPrevious;
+  final void Function() onNext;
+  final Duration throttle;
+  final DateTime Function() _now;
+  final VolumeKeyChannel _channel;
+
+  bool _owned = false;
+  DateTime? _lastAcceptedAt;
+
+  bool get owned => _owned;
+
+  void apply({required bool enabled, required bool platformSupported}) {
+    final bool want = enabled && platformSupported;
+    if (want == _owned) return;
+    _owned = want;
+    if (want) {
+      _channel.setHandlers(
+        onVolumeUp: () => _accept(onPrevious),
+        onVolumeDown: () => _accept(onNext),
+      );
+      unawaited(_channel.setInterceptEnabled(true));
+    } else {
+      _channel.setHandlers();
+      _lastAcceptedAt = null;
+      unawaited(_channel.setInterceptEnabled(false));
+    }
+  }
+
+  void dispose() => apply(enabled: false, platformSupported: true);
+
+  void _accept(void Function() action) {
+    final DateTime now = _now();
+    final DateTime? previous = _lastAcceptedAt;
+    if (previous != null && now.difference(previous) < throttle) return;
+    _lastAcceptedAt = now;
+    action();
+  }
+}

--- a/hibiki/lib/src/media/manga/reader/manga_zoom_preference_debouncer.dart
+++ b/hibiki/lib/src/media/manga/reader/manga_zoom_preference_debouncer.dart
@@ -1,0 +1,38 @@
+import 'dart:async';
+
+/// Coalesces high-frequency WebView pinch/wheel zoom callbacks into one
+/// trailing preference write while keeping the in-page zoom UI immediate.
+class MangaZoomPreferenceDebouncer {
+  MangaZoomPreferenceDebouncer({
+    required this.persist,
+    this.delay = const Duration(milliseconds: 250),
+  });
+
+  final Future<void> Function(int value) persist;
+  final Duration delay;
+
+  Timer? _timer;
+  int? _pending;
+
+  void queue(int value) {
+    _pending = value;
+    _timer?.cancel();
+    _timer = Timer(delay, () => unawaited(flush()));
+  }
+
+  void discard() {
+    _timer?.cancel();
+    _timer = null;
+    _pending = null;
+  }
+
+  Future<void> flush() async {
+    _timer?.cancel();
+    _timer = null;
+    final int? pending = _pending;
+    _pending = null;
+    if (pending != null) await persist(pending);
+  }
+
+  Future<void> dispose() => flush();
+}

--- a/hibiki/lib/src/media/metadata/book_cover_scrape_dialog.dart
+++ b/hibiki/lib/src/media/metadata/book_cover_scrape_dialog.dart
@@ -170,6 +170,7 @@ class _BookCoverScrapeDialogState extends State<BookCoverScrapeDialog> {
         msg: failure == null
             ? t.book_scrape_failed
             : '${t.book_scrape_failed}\n${_failureReason(failure)}',
+        severity: ToastSeverity.error,
       );
       return;
     }

--- a/hibiki/lib/src/media/metadata/scrape_failure_view.dart
+++ b/hibiki/lib/src/media/metadata/scrape_failure_view.dart
@@ -112,7 +112,10 @@ class _ScrapeFailureViewState extends State<ScrapeFailureView> {
                 label: Text(t.copy_error),
                 onPressed: () {
                   Clipboard.setData(ClipboardData(text: widget.detail));
-                  HibikiToast.show(msg: t.error_copied);
+                  HibikiToast.show(
+                    msg: t.error_copied,
+                    severity: ToastSeverity.success,
+                  );
                 },
               ),
             ],

--- a/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
+++ b/hibiki/lib/src/media/video/cover_ui/cover_match_dialog.dart
@@ -466,7 +466,10 @@ class _CoverMatchDialogState extends ConsumerState<CoverMatchDialog> {
     }
     if (!mounted) return;
     Navigator.of(context).pop();
-    HibikiToast.show(msg: t.video_scrape_applied);
+    HibikiToast.show(
+      msg: t.video_scrape_applied,
+      severity: ToastSeverity.success,
+    );
   }
 
   @override

--- a/hibiki/lib/src/media/video/cover_ui/scrape_info_dialog.dart
+++ b/hibiki/lib/src/media/video/cover_ui/scrape_info_dialog.dart
@@ -227,7 +227,10 @@ class ScrapeInfoDialog extends StatelessWidget {
     try {
       await launchUrl(Uri.parse(url), mode: LaunchMode.externalApplication);
     } catch (_) {
-      HibikiToast.show(msg: t.video_scrape_apply_failed);
+      HibikiToast.show(
+        msg: t.video_scrape_apply_failed,
+        severity: ToastSeverity.error,
+      );
     }
   }
 }

--- a/hibiki/lib/src/media/video/video_import_dialog.dart
+++ b/hibiki/lib/src/media/video/video_import_dialog.dart
@@ -288,6 +288,7 @@ class _VideoImportDialogState extends State<VideoImportDialog>
     setState(() => _subtitlePath = m.subtitlePath);
     HibikiToast.show(
       msg: t.import_sidecar_subtitle(name: p.basename(m.subtitlePath!)),
+      severity: ToastSeverity.info,
     );
   }
 

--- a/hibiki/lib/src/mining/galgame_helper_installer.dart
+++ b/hibiki/lib/src/mining/galgame_helper_installer.dart
@@ -491,6 +491,7 @@ class GalgameHelperInstaller {
     if (ensured) return true;
     HibikiToast.show(
       msg: t.game_helper_bundle_missing,
+      severity: ToastSeverity.error,
     );
     return false;
   }

--- a/hibiki/lib/src/mining/galgame_scrape_dialog.dart
+++ b/hibiki/lib/src/mining/galgame_scrape_dialog.dart
@@ -309,11 +309,17 @@ class _GalgameScrapeDialogState extends State<GalgameScrapeDialog> {
     if (!applied) {
       // 失败：复位转圈（否则按钮永久禁用），弹窗保留让用户改选/重试。
       setState(() => _applyingCandidate = null);
-      HibikiToast.show(msg: failureMessage ?? t.game_scrape_no_result);
+      HibikiToast.show(
+        msg: failureMessage ?? t.game_scrape_no_result,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     Navigator.of(context).pop(true);
-    HibikiToast.show(msg: t.game_scrape_applied);
+    HibikiToast.show(
+      msg: t.game_scrape_applied,
+      severity: ToastSeverity.success,
+    );
   }
 
   @override

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -3865,7 +3865,10 @@ class AppModel with ChangeNotifier {
       _rebuildDictPathsCache();
     } catch (e, stack) {
       ErrorLogService.instance.log('deleteDictionaries', e, stack);
-      HibikiToast.show(msg: t.dictionaries_delete_failed);
+      HibikiToast.show(
+        msg: t.dictionaries_delete_failed,
+        severity: ToastSeverity.error,
+      );
     } finally {
       dictionarySearchAgainNotifier.notifyListeners();
     }
@@ -3893,7 +3896,10 @@ class AppModel with ChangeNotifier {
       unawaited(_propagateDictionaryDeleteToRemote(dictionary.name));
     } catch (e, stack) {
       ErrorLogService.instance.log('deleteDictionary', e, stack);
-      HibikiToast.show(msg: t.dictionary_delete_failed);
+      HibikiToast.show(
+        msg: t.dictionary_delete_failed,
+        severity: ToastSeverity.error,
+      );
     } finally {
       dictionarySearchAgainNotifier.notifyListeners();
     }
@@ -4191,6 +4197,7 @@ class AppModel with ChangeNotifier {
         msg: t.storage_permissions,
         toastLength: Toast.LENGTH_SHORT,
         gravity: ToastGravity.BOTTOM,
+        severity: ToastSeverity.info,
       );
     }
 
@@ -4495,12 +4502,14 @@ class AppModel with ChangeNotifier {
         msg: t.stash_added_single(term: terms.first),
         toastLength: Toast.LENGTH_SHORT,
         gravity: ToastGravity.BOTTOM,
+        severity: ToastSeverity.success,
       );
     } else {
       HibikiToast.show(
         msg: t.stash_added_multiple,
         toastLength: Toast.LENGTH_SHORT,
         gravity: ToastGravity.BOTTOM,
+        severity: ToastSeverity.success,
       );
     }
   }
@@ -4511,6 +4520,7 @@ class AppModel with ChangeNotifier {
       msg: t.stash_clear_single(term: term),
       toastLength: Toast.LENGTH_SHORT,
       gravity: ToastGravity.BOTTOM,
+      severity: ToastSeverity.success,
     );
   }
 
@@ -4526,6 +4536,7 @@ class AppModel with ChangeNotifier {
       msg: t.failed_online_service,
       toastLength: Toast.LENGTH_SHORT,
       gravity: ToastGravity.BOTTOM,
+      severity: ToastSeverity.error,
     );
   }
 
@@ -4568,6 +4579,7 @@ class AppModel with ChangeNotifier {
         msg: t.copied_to_clipboard,
         toastLength: Toast.LENGTH_SHORT,
         gravity: ToastGravity.BOTTOM,
+        severity: ToastSeverity.success,
       );
     }
   }
@@ -5807,12 +5819,22 @@ class AppModel with ChangeNotifier {
           final String deckName = outcome.result == MineResult.success
               ? (await repo.loadSettings()).selectedDeckName ?? ''
               : '';
+          final ({
+            String message,
+            bool success,
+            bool record,
+            MineToastStatus status
+          }) described = describeMineOutcome(outcome, deckName: deckName);
           HibikiToast.show(
-            msg: describeMineOutcome(outcome, deckName: deckName).message,
+            msg: described.message,
+            severity: mineToastSeverity(described.status),
           );
         } catch (e, stack) {
           ErrorLogService.instance.log('FloatingDict.ankiExport', e, stack);
-          HibikiToast.show(msg: t.card_export_failed);
+          HibikiToast.show(
+            msg: t.card_export_failed,
+            severity: ToastSeverity.error,
+          );
         }
       },
     );

--- a/hibiki/lib/src/models/app_model.dart
+++ b/hibiki/lib/src/models/app_model.dart
@@ -5861,6 +5861,22 @@ class AppModel with ChangeNotifier {
   Future<void> setMangaZoomPercent(int value) =>
       prefsRepo.setMangaZoomPercent(value);
 
+  int get mangaZoomSensitivity => prefsRepo.mangaZoomSensitivity;
+  Future<void> setMangaZoomSensitivity(int value) =>
+      prefsRepo.setMangaZoomSensitivity(value);
+
+  String get mangaPageAnimation => prefsRepo.mangaPageAnimation;
+  Future<void> setMangaPageAnimation(String value) =>
+      prefsRepo.setMangaPageAnimation(value);
+
+  bool get mangaVolumeKeyPaging => prefsRepo.mangaVolumeKeyPaging;
+  Future<void> setMangaVolumeKeyPaging(bool value) =>
+      prefsRepo.setMangaVolumeKeyPaging(value);
+
+  bool get mangaTapZonePaging => prefsRepo.mangaTapZonePaging;
+  Future<void> setMangaTapZonePaging(bool value) =>
+      prefsRepo.setMangaTapZonePaging(value);
+
   /// 漫画「在线目录」站点根 URL（O1 mokuro.moe 目录源；空值由 client 归一回默认）。
   String get mangaOnlineCatalogBaseUrl => prefsRepo.mangaOnlineCatalogBaseUrl;
   Future<void> setMangaOnlineCatalogBaseUrl(String value) =>

--- a/hibiki/lib/src/models/dictionary_import_manager.dart
+++ b/hibiki/lib/src/models/dictionary_import_manager.dart
@@ -163,14 +163,19 @@ class DictionaryImportManager {
       }
       if (failedNames.isNotEmpty) {
         HibikiToast.show(
-            msg: formatImportFailureSummary(failedNames),
-            toastLength: Toast.LENGTH_LONG);
+          msg: formatImportFailureSummary(failedNames),
+          toastLength: Toast.LENGTH_LONG,
+          severity: ToastSeverity.error,
+        );
       }
       // TODO-082：成功导入数 = 总数 - 失败数；> 0 给一条明确成功提示，与失败汇总
       // 可同时出现（部分成功部分失败）。
       final int succeeded = zipFiles.length - failedNames.length;
       if (succeeded > 0) {
-        HibikiToast.show(msg: t.dict_import_success_summary(n: succeeded));
+        HibikiToast.show(
+          msg: t.dict_import_success_summary(n: succeeded),
+          severity: ToastSeverity.success,
+        );
       }
       return;
     }
@@ -294,7 +299,10 @@ class DictionaryImportManager {
         progressNotifier.value = t.import_complete;
         onImportSuccess();
         // TODO-082：单目录导入成功，给一条明确成功提示（与文件/批量路径一致）。
-        HibikiToast.show(msg: t.dict_import_success_summary(n: 1));
+        HibikiToast.show(
+          msg: t.dict_import_success_summary(n: 1),
+          severity: ToastSeverity.success,
+        );
       } finally {
         if (tempZip.existsSync()) tempZip.deleteSync();
       }

--- a/hibiki/lib/src/models/preferences_repository.dart
+++ b/hibiki/lib/src/models/preferences_repository.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 
+import 'package:hibiki/src/media/manga/manga_view_prefs.dart';
 import 'package:hibiki/src/media/torrent/anime_download_config.dart';
 import 'package:hibiki/src/media/video/dandanplay_client.dart';
 import 'package:hibiki/src/media/video/video_danmaku_model.dart';
@@ -1883,7 +1884,49 @@ class PreferencesRepository extends ChangeNotifier {
       getPref('manga_zoom_percent', defaultValue: 100) as int;
 
   Future<void> setMangaZoomPercent(int value) async {
-    await setPref('manga_zoom_percent', value.clamp(50, 200));
+    await setPref(
+      'manga_zoom_percent',
+      value.clamp(kMangaZoomMinPercent, kMangaZoomMaxPercent),
+    );
+    notifyListeners();
+  }
+
+  /// 滚轮/捏合缩放灵敏度倍率（百分比，100 = 基准）。
+  int get mangaZoomSensitivity => getPref('manga_zoom_sensitivity',
+      defaultValue: kMangaZoomSensitivityDefault) as int;
+
+  Future<void> setMangaZoomSensitivity(int value) async {
+    await setPref(
+      'manga_zoom_sensitivity',
+      value.clamp(kMangaZoomSensitivityMin, kMangaZoomSensitivityMax),
+    );
+    notifyListeners();
+  }
+
+  /// 翻页动画样式（`none` / `slide` / `fade`）。
+  String get mangaPageAnimation => getPref('manga_page_animation',
+      defaultValue: MangaPageAnimation.slide.key) as String;
+
+  Future<void> setMangaPageAnimation(String value) async {
+    await setPref('manga_page_animation', value);
+    notifyListeners();
+  }
+
+  /// 音量键翻页（漫画阅读器）。默认开：与 EPUB 阅读器的音量键翻页一致。
+  bool get mangaVolumeKeyPaging =>
+      getPref('manga_volume_key_paging', defaultValue: true) as bool;
+
+  Future<void> setMangaVolumeKeyPaging(bool value) async {
+    await setPref('manga_volume_key_paging', value);
+    notifyListeners();
+  }
+
+  /// 点击页面左右边缘翻页。默认开：触屏此前完全没有点击翻页手段。
+  bool get mangaTapZonePaging =>
+      getPref('manga_tap_zone_paging', defaultValue: true) as bool;
+
+  Future<void> setMangaTapZonePaging(bool value) async {
+    await setPref('manga_tap_zone_paging', value);
     notifyListeners();
   }
 

--- a/hibiki/lib/src/pages/base_source_page.dart
+++ b/hibiki/lib/src/pages/base_source_page.dart
@@ -1288,7 +1288,10 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       // favoriteEntry），桌面可能收不到 → 星标不变色 → 用户判定「点了没用」（DB 其实
       // 已写）。DB 写成功后**与 callHandler 返回值解耦**直接弹 toast，保证两宿主都有
       // 确定反馈，不依赖也不改动返回值通道。
-      HibikiToast.show(msg: t.word_favorite_removed);
+      HibikiToast.show(
+        msg: t.word_favorite_removed,
+        severity: ToastSeverity.success,
+      );
       return false;
     }
     // TODO-1252：把当前书身份（阅读器 / 有声书覆写 lookupBookIdentity）随收藏落库，
@@ -1303,7 +1306,10 @@ abstract class BaseSourcePageState<T extends BaseSourcePage>
       bookKey: favIdentity?.bookKey,
       title: favIdentity?.title ?? '',
     );
-    HibikiToast.show(msg: t.word_favorite_added);
+    HibikiToast.show(
+      msg: t.word_favorite_added,
+      severity: ToastSeverity.success,
+    );
     return true;
   }
 

--- a/hibiki/lib/src/pages/implementations/audio_recorder_page.dart
+++ b/hibiki/lib/src/pages/implementations/audio_recorder_page.dart
@@ -406,7 +406,10 @@ class _AudioRecorderDialogPageState
       onPressed: () async {
         await _audioPlayer.stop();
         if (!await _recorder.hasPermission()) {
-          HibikiToast.show(msg: t.microphone_permission_denied);
+          HibikiToast.show(
+            msg: t.microphone_permission_denied,
+            severity: ToastSeverity.error,
+          );
           return;
         }
         if (!mounted) return;
@@ -438,7 +441,10 @@ class _AudioRecorderDialogPageState
 
   void executeSave() {
     if (_audioFile == null) {
-      HibikiToast.show(msg: t.no_audio_file);
+      HibikiToast.show(
+        msg: t.no_audio_file,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 

--- a/hibiki/lib/src/pages/implementations/collection_relations_section.dart
+++ b/hibiki/lib/src/pages/implementations/collection_relations_section.dart
@@ -150,7 +150,10 @@ class _CollectionRelationsSectionState
     if (chosen == null || !mounted) return;
     await widget.database.bindCollectionRelationTarget(relation.id, chosen.id);
     if (!mounted) return;
-    HibikiToast.show(msg: t.collection_relation_bound(name: chosen.name));
+    HibikiToast.show(
+      msg: t.collection_relation_bound(name: chosen.name),
+      severity: ToastSeverity.success,
+    );
     setState(() => _refresh++);
   }
 

--- a/hibiki/lib/src/pages/implementations/collections_page.dart
+++ b/hibiki/lib/src/pages/implementations/collections_page.dart
@@ -597,7 +597,10 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
   Future<void> _playItemAudio(_CollectionItem item) async {
     final String? bookKey = item.bookKey;
     if (bookKey == null || bookKey.isEmpty) {
-      HibikiToast.show(msg: t.srt_audio_unresolved);
+      HibikiToast.show(
+        msg: t.srt_audio_unresolved,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -616,13 +619,19 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
 
     final List<File>? audioFiles = _audioFileMap[bookKey];
     if (audioFiles == null || audioFiles.isEmpty) {
-      HibikiToast.show(msg: t.srt_audio_unresolved);
+      HibikiToast.show(
+        msg: t.srt_audio_unresolved,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
     final List<AudioCue>? cues = _cueMap[bookKey];
     if (cues == null || cues.isEmpty) {
-      HibikiToast.show(msg: t.srt_audio_unresolved);
+      HibikiToast.show(
+        msg: t.srt_audio_unresolved,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -634,11 +643,17 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
       text: item.text,
     );
     if (range == null) {
-      HibikiToast.show(msg: t.srt_audio_unresolved);
+      HibikiToast.show(
+        msg: t.srt_audio_unresolved,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     if (range.audioFileIndex < 0 || range.audioFileIndex >= audioFiles.length) {
-      HibikiToast.show(msg: t.srt_audio_unresolved);
+      HibikiToast.show(
+        msg: t.srt_audio_unresolved,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -659,7 +674,10 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
   ) async {
     final VideoBookRow? row = _videoRowMap[bookUid];
     if (row == null) {
-      HibikiToast.show(msg: t.srt_audio_unresolved);
+      HibikiToast.show(
+        msg: t.srt_audio_unresolved,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final ({String filePath, int startMs, int endMs})? clip =
@@ -670,7 +688,10 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
       favoriteDurationMs: item.normCharLength,
     );
     if (clip == null) {
-      HibikiToast.show(msg: t.srt_audio_unresolved);
+      HibikiToast.show(
+        msg: t.srt_audio_unresolved,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     await _extractAndPlay(
@@ -709,7 +730,10 @@ class _CollectionsPageState extends BasePageState<CollectionsPage> {
       if (result != null) {
         await TtsChannel.instance.playFile(result);
       } else {
-        HibikiToast.show(msg: t.audio_clip_failed);
+        HibikiToast.show(
+          msg: t.audio_clip_failed,
+          severity: ToastSeverity.error,
+        );
       }
     } finally {
       // 只清自己那一次的进行中标记：期间用户已点了别的行（先停旧后播新）时，

--- a/hibiki/lib/src/pages/implementations/custom_fonts_page.dart
+++ b/hibiki/lib/src/pages/implementations/custom_fonts_page.dart
@@ -698,7 +698,10 @@ class _CustomFontsPageState extends BasePageState {
 
     if (count > 0) {
       await _save();
-      HibikiToast.show(msg: t.custom_fonts_imported_count(count: count));
+      HibikiToast.show(
+        msg: t.custom_fonts_imported_count(count: count),
+        severity: ToastSeverity.success,
+      );
     }
   }
 
@@ -863,7 +866,10 @@ class _CustomFontsPageState extends BasePageState {
     } catch (e, stack) {
       ErrorLogService.instance.log('CustomFontsPage.extractArchive', e, stack);
       debugPrint('[hibiki-fonts] archive extract failed: $e');
-      HibikiToast.show(msg: t.custom_fonts_archive_error);
+      HibikiToast.show(
+        msg: t.custom_fonts_archive_error,
+        severity: ToastSeverity.error,
+      );
       return 0;
     }
   }
@@ -984,9 +990,15 @@ class _CustomFontsPageState extends BasePageState {
 
       if (count > 0) {
         await _save();
-        HibikiToast.show(msg: t.custom_fonts_imported_count(count: count));
+        HibikiToast.show(
+          msg: t.custom_fonts_imported_count(count: count),
+          severity: ToastSeverity.success,
+        );
       } else {
-        HibikiToast.show(msg: t.custom_fonts_no_fonts_in_archive);
+        HibikiToast.show(
+          msg: t.custom_fonts_no_fonts_in_archive,
+          severity: ToastSeverity.error,
+        );
       }
     } on DioError catch (e, stack) {
       if (mounted) Navigator.pop(context);
@@ -997,6 +1009,7 @@ class _CustomFontsPageState extends BasePageState {
         HibikiToast.show(
           msg: '${t.custom_fonts_download_failed}: ${e.type.name}',
           toastLength: Toast.LENGTH_LONG,
+          severity: ToastSeverity.error,
         );
       }
       final f = File(tempPath);
@@ -1008,6 +1021,7 @@ class _CustomFontsPageState extends BasePageState {
       HibikiToast.show(
         msg: '${t.custom_fonts_download_failed}: $e',
         toastLength: Toast.LENGTH_LONG,
+        severity: ToastSeverity.error,
       );
       final f = File(tempPath);
       if (await f.exists()) await f.delete();
@@ -1102,7 +1116,10 @@ class _CustomFontsPageState extends BasePageState {
         debugPrint('[Hibiki] failed to delete font file $filePath: $e');
       }
     }
-    HibikiToast.show(msg: t.custom_fonts_removed);
+    HibikiToast.show(
+      msg: t.custom_fonts_removed,
+      severity: ToastSeverity.success,
+    );
   }
 
   /// [newIndex] 是**最终下标**（HibikiReorderableColumn 语义），不是 SDK

--- a/hibiki/lib/src/pages/implementations/custom_theme_page.dart
+++ b/hibiki/lib/src/pages/implementations/custom_theme_page.dart
@@ -325,7 +325,10 @@ class _CustomThemePageState extends BasePageState<CustomThemePage> {
   void _shareTheme() {
     final code = _encodeTheme();
     Clipboard.setData(ClipboardData(text: code));
-    HibikiToast.show(msg: t.theme_code_copied);
+    HibikiToast.show(
+      msg: t.theme_code_copied,
+      severity: ToastSeverity.success,
+    );
   }
 
   void _applyImportedTheme(
@@ -429,12 +432,18 @@ class _CustomThemePageState extends BasePageState<CustomThemePage> {
                     onPressed: () {
                       final result = _decodeTheme(controller.text);
                       if (result == null) {
-                        HibikiToast.show(msg: t.import_theme_invalid);
+                        HibikiToast.show(
+                          msg: t.import_theme_invalid,
+                          severity: ToastSeverity.error,
+                        );
                         return;
                       }
                       Navigator.pop(ctx);
                       _applyImportedTheme(result);
-                      HibikiToast.show(msg: t.import_theme_success);
+                      HibikiToast.show(
+                        msg: t.import_theme_success,
+                        severity: ToastSeverity.success,
+                      );
                     },
                     child: Text(t.dialog_import),
                   ),

--- a/hibiki/lib/src/pages/implementations/dictionary_dialog_page.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_dialog_page.dart
@@ -450,7 +450,10 @@ class _DictionaryDialogPageState extends BasePageState {
     );
     // TODO-082：导入一开始就给用户一个明确反馈（开始后台导入），不只让用户盯着
     // 模态进度框猜测进度。
-    HibikiToast.show(msg: t.dict_import_started);
+    HibikiToast.show(
+      msg: t.dict_import_started,
+      severity: ToastSeverity.info,
+    );
 
     bool hadMemoryError = false;
     final List<String> failedNames = [];
@@ -491,6 +494,7 @@ class _DictionaryDialogPageState extends BasePageState {
       HibikiToast.show(
         msg: DictionaryImportManager.formatImportFailureSummary(failedNames),
         toastLength: Toast.LENGTH_LONG,
+        severity: ToastSeverity.error,
       );
     }
 
@@ -498,7 +502,10 @@ class _DictionaryDialogPageState extends BasePageState {
     // （失败的另由上面的失败汇总文案告知，两者可同时出现：部分成功部分失败）。
     final int successCount = dictFiles.length - failedNames.length;
     if (successCount > 0) {
-      HibikiToast.show(msg: t.dict_import_success_summary(n: successCount));
+      HibikiToast.show(
+        msg: t.dict_import_success_summary(n: successCount),
+        severity: ToastSeverity.success,
+      );
     }
 
     if (hadMemoryError && mounted) {
@@ -524,7 +531,10 @@ class _DictionaryDialogPageState extends BasePageState {
     );
     if (importPaths.isEmpty) {
       debugPrint('[hibiki-drop] [dictionary-dialog] intent=unsupportedSurface');
-      HibikiToast.show(msg: t.drag_drop_unsupported_on_dictionary);
+      HibikiToast.show(
+        msg: t.drag_drop_unsupported_on_dictionary,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     _importDictionaryPaths(importPaths);
@@ -942,6 +952,7 @@ class _DictionaryDialogPageState extends BasePageState {
       HibikiToast.show(
         msg: DictionaryImportManager.formatImportFailureSummary(failedNames),
         toastLength: Toast.LENGTH_LONG,
+        severity: ToastSeverity.error,
       );
     }
   }
@@ -1035,7 +1046,10 @@ class _DictionaryDialogPageState extends BasePageState {
       );
       // TODO-082：目录导入也在开始时给明确反馈（成功/失败提示由
       // DictionaryImportManager.importFromDirectory 在完成时弹出）。
-      HibikiToast.show(msg: t.dict_import_started);
+      HibikiToast.show(
+        msg: t.dict_import_started,
+        severity: ToastSeverity.info,
+      );
     }
 
     bool hadMemoryError = false;
@@ -1077,6 +1091,7 @@ class _DictionaryDialogPageState extends BasePageState {
       HibikiToast.show(
         msg: folderImportError,
         toastLength: Toast.LENGTH_LONG,
+        severity: ToastSeverity.error,
       );
     }
 
@@ -1603,6 +1618,9 @@ class _DictionaryDialogPageState extends BasePageState {
     if (!dictionary.isUpdatable) return;
 
     String resultMsg = t.dict_update_latest;
+    // 三种结局（已最新 / 已更新 / 更新失败）共用一条 toast，配色跟着文案一起定，
+    // 否则失败也是一条无色提示、与「已是最新」长得一模一样。
+    ToastSeverity resultSeverity = ToastSeverity.info;
     await _runWithDownloadProgressDialog(
       initialMessage: t.dict_update_checking,
       body: (
@@ -1616,6 +1634,7 @@ class _DictionaryDialogPageState extends BasePageState {
           if (!DictionaryUpdateService.needsUpdate(
               dictionary.revision, remoteRevision)) {
             resultMsg = t.dict_update_latest;
+            resultSeverity = ToastSeverity.info;
           } else {
             await _redownloadAndReimport(
               name: dictionary.name,
@@ -1631,15 +1650,17 @@ class _DictionaryDialogPageState extends BasePageState {
               },
             );
             resultMsg = t.dict_update_done(name: dictionary.name);
+            resultSeverity = ToastSeverity.success;
           }
         } catch (e, stack) {
           ErrorLogService.instance
               .log('DictionaryDialog.updateSingle', e, stack);
           resultMsg = t.dict_update_failed(error: '$e');
+          resultSeverity = ToastSeverity.error;
         }
       },
     );
-    HibikiToast.show(msg: resultMsg);
+    HibikiToast.show(msg: resultMsg, severity: resultSeverity);
   }
 
   /// TODO-839：本地导入 / 旧词典（isUpdatable=false，无在线来源）的「从文件重选覆盖
@@ -1691,6 +1712,8 @@ class _DictionaryDialogPageState extends BasePageState {
     if (!mounted) return;
 
     String resultMsg = t.dict_update_done(name: dictionary.name);
+    // 覆盖导入没抛异常即成功；catch 里连同文案一起翻成 error 配色。
+    ToastSeverity resultSeverity = ToastSeverity.success;
     await _runWithDownloadProgressDialog(
       initialMessage: t.dict_update_updating(name: dictionary.name),
       body: (
@@ -1708,13 +1731,14 @@ class _DictionaryDialogPageState extends BasePageState {
           ErrorLogService.instance
               .log('DictionaryDialog.updateFromFile', e, stack);
           resultMsg = t.dict_update_failed(error: '$e');
+          resultSeverity = ToastSeverity.error;
         }
       },
     );
     if (Platform.isAndroid || Platform.isIOS) {
       await FilePicker.platform.clearTemporaryFiles();
     }
-    HibikiToast.show(msg: resultMsg);
+    HibikiToast.show(msg: resultMsg, severity: resultSeverity);
   }
 
   /// 异名覆盖确认对话框：所选文件包名 [incoming] 与被更新词典 [existing] 不同时弹出，
@@ -1757,7 +1781,10 @@ class _DictionaryDialogPageState extends BasePageState {
     final List<Dictionary> updatable =
         appModel.dictionaries.where((Dictionary d) => d.isUpdatable).toList();
     if (updatable.isEmpty) {
-      HibikiToast.show(msg: t.dict_update_none);
+      HibikiToast.show(
+        msg: t.dict_update_none,
+        severity: ToastSeverity.info,
+      );
       return;
     }
 
@@ -1810,6 +1837,8 @@ class _DictionaryDialogPageState extends BasePageState {
         failed: failed.toString(),
       ),
       toastLength: Toast.LENGTH_LONG,
+      // 有失败即「部分成功」→ warning；全成或全已最新才算 success。
+      severity: failed > 0 ? ToastSeverity.warning : ToastSeverity.success,
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_page_mixin.dart
@@ -606,7 +606,10 @@ mixin DictionaryPageMixin {
       // TODO-956 A：与 [base_source_page] 同因——桌面 callHandler 返回值不一定回传
       // JS，弹窗 ☆→★ 变色不可靠。视频弹窗走本 mixin，DB 写成功后同样解耦弹 toast，
       // 保证 reader / 有声书 / 视频三宿主收藏反馈一致。
-      HibikiToast.show(msg: t.word_favorite_removed);
+      HibikiToast.show(
+        msg: t.word_favorite_removed,
+        severity: ToastSeverity.success,
+      );
       return false;
     }
     // TODO-1252：把当前书 / 视频身份（视频页覆写 lookupBookIdentity）随收藏落库，供
@@ -621,7 +624,10 @@ mixin DictionaryPageMixin {
       bookKey: favIdentity?.bookKey,
       title: favIdentity?.title ?? '',
     );
-    HibikiToast.show(msg: t.word_favorite_added);
+    HibikiToast.show(
+      msg: t.word_favorite_added,
+      severity: ToastSeverity.success,
+    );
     return true;
   }
 

--- a/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
+++ b/hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart
@@ -1346,7 +1346,10 @@ JSON.stringify((function(){
                 final bool shared =
                     await SelectionExternalActions.instance.shareText(text);
                 if (!shared) {
-                  HibikiToast.show(msg: t.selection_share_failed);
+                  HibikiToast.show(
+                    msg: t.selection_share_failed,
+                    severity: ToastSeverity.error,
+                  );
                 }
                 await _clearSelectedTextAcrossFrames();
               },
@@ -1361,7 +1364,10 @@ JSON.stringify((function(){
                 final bool opened =
                     await SelectionExternalActions.instance.searchWeb(text);
                 if (!opened) {
-                  HibikiToast.show(msg: t.selection_web_search_unavailable);
+                  HibikiToast.show(
+                    msg: t.selection_web_search_unavailable,
+                    severity: ToastSeverity.error,
+                  );
                 }
                 await _clearSelectedTextAcrossFrames();
               },

--- a/hibiki/lib/src/pages/implementations/floating_dict_page.dart
+++ b/hibiki/lib/src/pages/implementations/floating_dict_page.dart
@@ -99,8 +99,12 @@ class _FloatingDictPageState extends ConsumerState<FloatingDictPage> {
     final String deckName = outcome.result == MineResult.success
         ? (await repo.loadSettings()).selectedDeckName ?? ''
         : '';
+    final described = describeMineOutcome(outcome, deckName: deckName);
     HibikiToast.show(
-      msg: describeMineOutcome(outcome, deckName: deckName).message,
+      msg: described.message,
+      // 制卡结果的语义已由 describeMineOutcome 算出（added/duplicate/failed），
+      // 这里只把它翻译成 toast 配色，不再另判一次。
+      severity: mineToastSeverity(described.status),
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_detail_page.dart
@@ -868,7 +868,10 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
     final String rawDate = _releaseDate.text.trim();
     final String? date = rawDate.isEmpty ? null : draftDate(rawDate);
     if (rawDate.isNotEmpty && date == null) {
-      HibikiToast.show(msg: t.game_edit_invalid_date);
+      HibikiToast.show(
+        msg: t.game_edit_invalid_date,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final GalgameEntry game = widget.game;
@@ -906,7 +909,7 @@ class _GalgameEditTabState extends State<_GalgameEditTab> {
     await widget.repo.updateEntry(next);
     await widget.onSaved();
     if (!mounted) return;
-    HibikiToast.show(msg: t.game_edit_saved);
+    HibikiToast.show(msg: t.game_edit_saved, severity: ToastSeverity.success);
   }
 
   /// 刮削：打开统一刮削弹窗（与库页卡菜单「刮削元数据」同一个入口，

--- a/hibiki/lib/src/pages/implementations/galgame_home_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_home_page.dart
@@ -254,11 +254,17 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
     _launching = true;
     try {
       if (!Platform.isWindows) {
-        HibikiToast.show(msg: t.game_launch_unsupported);
+        HibikiToast.show(
+          msg: t.game_launch_unsupported,
+          severity: ToastSeverity.error,
+        );
         return;
       }
       if (!File(game.exePath).existsSync()) {
-        HibikiToast.show(msg: t.game_exe_missing);
+        HibikiToast.show(
+          msg: t.game_exe_missing,
+          severity: ToastSeverity.error,
+        );
         return;
       }
       final bool is32Bit =
@@ -298,7 +304,22 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
         lastError: state.lastError,
         injectorDetail: state.injectorDetail,
       );
-      if (message != null) HibikiToast.show(msg: message);
+      // BUG-1089 的着色面：outcome 已经把「跑起来了 / 只剩整机混音兜底 / 根本没起来」
+      // 分好了，toast 的颜色跟着同一份判定走，别再让三种结局长成同一条无色提示。
+      if (message != null) {
+        HibikiToast.show(
+          msg: message,
+          severity: switch (outcome) {
+            GalHookLaunchOutcome.running => ToastSeverity.success,
+            GalHookLaunchOutcome.degradedLoopback => ToastSeverity.warning,
+            GalHookLaunchOutcome.failed ||
+            GalHookLaunchOutcome.windowMissing =>
+              ToastSeverity.error,
+            // message 为 null 时根本不播报，这里走不到。
+            GalHookLaunchOutcome.superseded => ToastSeverity.neutral,
+          },
+        );
+      }
       if (!result.launched) return;
       widget.onLaunched?.call();
     } finally {

--- a/hibiki/lib/src/pages/implementations/game_diagnostics_page.dart
+++ b/hibiki/lib/src/pages/implementations/game_diagnostics_page.dart
@@ -65,11 +65,17 @@ class _GameDiagnosticsPageState extends State<GameDiagnosticsPage> {
   /// 有别的入口绕过禁用又变回静默无反应。
   void _handleSelectVoice(int sourcePtr) {
     if (!_controller.hasEngineSource) {
-      HibikiToast.show(msg: t.game_track_select_requires_engine);
+      HibikiToast.show(
+        msg: t.game_track_select_requires_engine,
+        severity: ToastSeverity.error,
+      );
     } else if (!galTrackSelectionAffectsCapture(
       _controller.state.audioBackend,
     )) {
-      HibikiToast.show(msg: t.game_tracks_pcm_only_hint);
+      HibikiToast.show(
+        msg: t.game_tracks_pcm_only_hint,
+        severity: ToastSeverity.warning,
+      );
       return;
     }
     _controller.selectVoiceTrack(sourcePtr);
@@ -88,13 +94,19 @@ class _GameDiagnosticsPageState extends State<GameDiagnosticsPage> {
         await _controller.exportTrackPreview(track.sourcePtr);
     if (!mounted) return;
     if (preview == null) {
-      HibikiToast.show(msg: t.game_track_preview_failed);
+      HibikiToast.show(
+        msg: t.game_track_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final bool started = await DesktopAudioPlayback.playFile(preview.filePath);
     if (!mounted) return;
     if (!started) {
-      HibikiToast.show(msg: t.game_track_preview_failed);
+      HibikiToast.show(
+        msg: t.game_track_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     _previewResetTimer?.cancel();

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -173,7 +173,10 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       return; // 用户取消
     }
     if (filterOutDuplicateGameExes(_games, <String>[exe]).isEmpty) {
-      HibikiToast.show(msg: t.game_already_added);
+      HibikiToast.show(
+        msg: t.game_already_added,
+        severity: ToastSeverity.warning,
+      );
       return; // 已在库里：不重复添加
     }
     final GalgameEntry entry = newGalgameEntryFromExe(exe);
@@ -187,7 +190,10 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   Future<void> _handleDrop(List<String> paths, Offset _) async {
     final List<String> exes = filterOutDuplicateGameExes(_games, paths);
     if (exes.isEmpty) {
-      HibikiToast.show(msg: t.game_drop_no_exe);
+      HibikiToast.show(
+        msg: t.game_drop_no_exe,
+        severity: ToastSeverity.warning,
+      );
       return;
     }
     // 批内 id 用「基准时刻 + 序号微秒」错开，避免同微秒撞 id。
@@ -199,7 +205,10 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     ];
     await _repo.addAll(added);
     _refresh();
-    HibikiToast.show(msg: t.game_drop_imported(count: added.length));
+    HibikiToast.show(
+      msg: t.game_drop_imported(count: added.length),
+      severity: ToastSeverity.success,
+    );
     for (final GalgameEntry entry in added) {
       unawaited(_autoCover(entry, silent: true));
     }
@@ -210,7 +219,12 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
   /// [silent] = 添加游戏后的后台补齐（成功静默、失败不打扰）；用户从菜单主动触发时
   /// 为 false，两种结局都给 toast，否则「点了没反应」无从判断。
   Future<void> _autoCover(GalgameEntry game, {bool silent = false}) async {
-    if (!silent) HibikiToast.show(msg: t.game_cover_searching);
+    if (!silent) {
+      HibikiToast.show(
+        msg: t.game_cover_searching,
+        severity: ToastSeverity.info,
+      );
+    }
     final ResolvedGameCover? resolved = await autoResolveGameCover(
       gameId: game.id,
       gameName: game.displayName,
@@ -218,11 +232,21 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       workdir: game.workdir,
     );
     if (resolved == null) {
-      if (!silent) HibikiToast.show(msg: t.game_cover_not_found);
+      if (!silent) {
+        HibikiToast.show(
+          msg: t.game_cover_not_found,
+          severity: ToastSeverity.error,
+        );
+      }
       return;
     }
     await _applyCover(game, resolved.path);
-    if (!silent) HibikiToast.show(msg: t.game_cover_updated);
+    if (!silent) {
+      HibikiToast.show(
+        msg: t.game_cover_updated,
+        severity: ToastSeverity.success,
+      );
+    }
   }
 
   /// 手动设置封面：统一封面服务（P3）——[MediaCoverService.pickCoverImage] 平台
@@ -241,11 +265,17 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       sourcePath: picked.path,
     );
     if (saved == null) {
-      HibikiToast.show(msg: t.game_cover_not_found);
+      HibikiToast.show(
+        msg: t.game_cover_not_found,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     await _applyCover(game, saved);
-    HibikiToast.show(msg: t.game_cover_updated);
+    HibikiToast.show(
+      msg: t.game_cover_updated,
+      severity: ToastSeverity.success,
+    );
   }
 
   /// 把新封面路径写回条目并刷新。
@@ -473,7 +503,10 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     if (outcome != CollectionAddOutcome.added || !mounted) return;
     await _loadCollectionMaps();
     _refresh();
-    HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
+    HibikiToast.show(
+      msg: t.batch_add_to_collection_success(n: 1),
+      severity: ToastSeverity.success,
+    );
   }
 
   /// 合集横排行折叠开关（游戏库独立偏好命名空间，见
@@ -548,11 +581,17 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
     _launching = true;
     try {
       if (!Platform.isWindows) {
-        HibikiToast.show(msg: t.game_launch_unsupported);
+        HibikiToast.show(
+          msg: t.game_launch_unsupported,
+          severity: ToastSeverity.error,
+        );
         return;
       }
       if (!File(game.exePath).existsSync()) {
-        HibikiToast.show(msg: t.game_exe_missing);
+        HibikiToast.show(
+          msg: t.game_exe_missing,
+          severity: ToastSeverity.error,
+        );
         return;
       }
       final bool is32Bit =
@@ -596,7 +635,22 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
         lastError: state.lastError,
         injectorDetail: state.injectorDetail,
       );
-      if (message != null) HibikiToast.show(msg: message);
+      // BUG-1089 的着色面：outcome 已经把「跑起来了 / 只剩整机混音兜底 / 根本没起来」
+      // 分好了，toast 的颜色跟着同一份判定走，别再让三种结局长成同一条无色提示。
+      if (message != null) {
+        HibikiToast.show(
+          msg: message,
+          severity: switch (outcome) {
+            GalHookLaunchOutcome.running => ToastSeverity.success,
+            GalHookLaunchOutcome.degradedLoopback => ToastSeverity.warning,
+            GalHookLaunchOutcome.failed ||
+            GalHookLaunchOutcome.windowMissing =>
+              ToastSeverity.error,
+            // message 为 null 时根本不播报，这里走不到。
+            GalHookLaunchOutcome.superseded => ToastSeverity.neutral,
+          },
+        );
+      }
       if (!result.launched) return;
       widget.onLaunched?.call();
     } finally {

--- a/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_dictionary_page.dart
@@ -407,7 +407,10 @@ class _HomeDictionaryPageState extends BaseTabPageState<HomeDictionaryPage>
     );
     if (importPaths.isEmpty) {
       debugPrint('[hibiki-drop] [home-dictionary] intent=unsupportedSurface');
-      HibikiToast.show(msg: t.drag_drop_unsupported_on_dictionary);
+      HibikiToast.show(
+        msg: t.drag_drop_unsupported_on_dictionary,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     unawaited(appModel.showDictionaryMenu(initialImportPaths: importPaths));

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -920,7 +920,12 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             : collectionCount == 0
                 ? t.batch_delete_success_video(n: deleted)
                 : t.batch_dissolve_success(m: dissolved);
-    HibikiToast.show(msg: successMsg, severity: ToastSeverity.success);
+    HibikiToast.show(
+      msg: successMsg,
+      severity: deleted > 0 || dissolved > 0
+          ? ToastSeverity.success
+          : ToastSeverity.warning,
+    );
   }
 
   Future<void> _waitForVideoCardsToUnmount() async {

--- a/hibiki/lib/src/pages/implementations/home_video_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_video_page.dart
@@ -818,6 +818,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
         n: dropped + _selection.length,
         m: dropped,
       ),
+      severity: ToastSeverity.warning,
     );
     return _selection.isNotEmpty;
   }
@@ -919,7 +920,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
             : collectionCount == 0
                 ? t.batch_delete_success_video(n: deleted)
                 : t.batch_dissolve_success(m: dissolved);
-    HibikiToast.show(msg: successMsg);
+    HibikiToast.show(msg: successMsg, severity: ToastSeverity.success);
   }
 
   Future<void> _waitForVideoCardsToUnmount() async {
@@ -947,7 +948,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (_selectedUids.isEmpty) return;
     final List<BookTagRow>? allTags = ref.read(allTagsProvider).valueOrNull;
     if (allTags == null || allTags.isEmpty) {
-      HibikiToast.show(msg: t.tag_no_tags_hint);
+      HibikiToast.show(msg: t.tag_no_tags_hint, severity: ToastSeverity.info);
       return;
     }
     await showAppDialog<void>(
@@ -1239,7 +1240,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (!mounted) return;
     _exitSelectionMode();
     await _loadLibraryMaps();
-    HibikiToast.show(msg: t.series_created);
+    HibikiToast.show(msg: t.series_created, severity: ToastSeverity.success);
   }
 
   /// 档2：恰 1 合集 + 若干散卡 → 散卡并入该合集（不弹命名）。
@@ -1254,7 +1255,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (!mounted) return;
     _exitSelectionMode();
     await _loadLibraryMaps();
-    HibikiToast.show(msg: t.batch_add_to_collection_success(n: refs.length));
+    HibikiToast.show(
+      msg: t.batch_add_to_collection_success(n: refs.length),
+      severity: ToastSeverity.success,
+    );
   }
 
   /// 档3：≥2 合集（可带散卡）→ 合并成一个。目标 = 成员最多合集（其名作默认名，
@@ -1309,7 +1313,7 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     if (!mounted) return;
     _exitSelectionMode();
     await _loadLibraryMaps();
-    HibikiToast.show(msg: t.collection_merged);
+    HibikiToast.show(msg: t.collection_merged, severity: ToastSeverity.success);
   }
 
   /// 打开收藏夹页（书签 + 收藏句子，含视频来源的收藏句子，TODO-047 ③a）。与书架页头
@@ -1824,7 +1828,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     );
     if (outcome != CollectionAddOutcome.added || !mounted) return;
     await _loadLibraryMaps();
-    HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
+    HibikiToast.show(
+      msg: t.batch_add_to_collection_success(n: 1),
+      severity: ToastSeverity.success,
+    );
   }
 
   Future<void> _editTags(VideoBookRow book) async {
@@ -1846,7 +1853,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final bool alreadyHas =
         existing?[bookUid]?.any((BookTagRow t) => t.id == tag.id) ?? false;
     if (alreadyHas) {
-      HibikiToast.show(msg: t.tag_already_on_book(name: tag.name));
+      HibikiToast.show(
+        msg: t.tag_already_on_book(name: tag.name),
+        severity: ToastSeverity.warning,
+      );
       return;
     }
 
@@ -1854,7 +1864,10 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     ref.invalidate(videoBookTagMapProvider);
     ref.invalidate(filteredVideoBookUidsProvider);
     if (mounted) {
-      HibikiToast.show(msg: t.tag_added_to_video(name: tag.name));
+      HibikiToast.show(
+        msg: t.tag_added_to_video(name: tag.name),
+        severity: ToastSeverity.success,
+      );
     }
   }
 
@@ -1869,14 +1882,20 @@ class _HomeVideoPageState extends BaseModuleTabPageState<HomeVideoPage> {
     final List<BookTagRow> existing =
         await db.getTagsForCollection(collectionId);
     if (existing.any((BookTagRow t) => t.id == tag.id)) {
-      HibikiToast.show(msg: t.tag_already_on_collection(name: tag.name));
+      HibikiToast.show(
+        msg: t.tag_already_on_collection(name: tag.name),
+        severity: ToastSeverity.warning,
+      );
       return;
     }
     await db.addTagToCollection(collectionId, tag.id);
     ref.invalidate(collectionTagMapProvider);
     ref.invalidate(filteredCollectionIdsProvider);
     if (mounted) {
-      HibikiToast.show(msg: t.tag_added_to_collection(name: tag.name));
+      HibikiToast.show(
+        msg: t.tag_added_to_collection(name: tag.name),
+        severity: ToastSeverity.success,
+      );
     }
   }
 
@@ -5116,6 +5135,7 @@ class _VideoBatchTagPickerDialogState
           name: tag.name,
           n: widget.selectedUids.length,
         ),
+        severity: ToastSeverity.success,
       );
     }
     for (final int tagId in _removeTagIds) {
@@ -5126,6 +5146,7 @@ class _VideoBatchTagPickerDialogState
           name: tag.name,
           n: widget.selectedUids.length,
         ),
+        severity: ToastSeverity.success,
       );
     }
     Navigator.pop(context);

--- a/hibiki/lib/src/pages/implementations/illustrations_viewer_page.dart
+++ b/hibiki/lib/src/pages/implementations/illustrations_viewer_page.dart
@@ -406,7 +406,10 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
   Future<void> _shareCurrentImage() async {
     final File file = _currentFile();
     if (!file.existsSync()) {
-      HibikiToast.show(msg: t.reader_image_file_unavailable);
+      HibikiToast.show(
+        msg: t.reader_image_file_unavailable,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     try {
@@ -415,7 +418,10 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
         subject: p.basename(file.path),
       );
     } catch (e) {
-      HibikiToast.show(msg: t.reader_image_share_failed(error: e));
+      HibikiToast.show(
+        msg: t.reader_image_share_failed(error: e),
+        severity: ToastSeverity.error,
+      );
     }
   }
 
@@ -423,7 +429,10 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
   Future<void> _copyCurrentImageToClipboard() async {
     final File file = _currentFile();
     if (!file.existsSync()) {
-      HibikiToast.show(msg: t.reader_image_file_unavailable);
+      HibikiToast.show(
+        msg: t.reader_image_file_unavailable,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     try {
@@ -431,9 +440,15 @@ class _FullScreenGalleryState extends State<_FullScreenGallery> {
         'copyImageFile',
         <String, String>{'path': file.path},
       );
-      HibikiToast.show(msg: t.copied_to_clipboard);
+      HibikiToast.show(
+        msg: t.copied_to_clipboard,
+        severity: ToastSeverity.success,
+      );
     } catch (e) {
-      HibikiToast.show(msg: t.reader_image_copy_failed(error: e));
+      HibikiToast.show(
+        msg: t.reader_image_copy_failed(error: e),
+        severity: ToastSeverity.error,
+      );
     }
   }
 

--- a/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
+++ b/hibiki/lib/src/pages/implementations/media_collection_detail_page.dart
@@ -550,7 +550,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         await widget.database.getCollectionScrapeMeta(widget.collection.id);
     if (!mounted) return;
     if (meta == null) {
-      HibikiToast.show(msg: t.collection_episode_scrape_unbound);
+      HibikiToast.show(
+        msg: t.collection_episode_scrape_unbound,
+        severity: ToastSeverity.info,
+      );
       return;
     }
     final String tmdbKey = resolveTmdbApiKey(
@@ -576,6 +579,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           msg: t.collection_episode_scrape_failed(
             error: outcome.errors.values.first,
           ),
+          severity: ToastSeverity.error,
         );
         return;
       }
@@ -584,6 +588,7 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           updated: outcome.updated,
           skipped: outcome.unmatched,
         ),
+        severity: ToastSeverity.success,
       );
       await _reload();
       widget.onChanged();
@@ -605,7 +610,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     );
     if (!mounted) return;
     if (proposals.isEmpty) {
-      HibikiToast.show(msg: t.collection_episode_rename_empty);
+      HibikiToast.show(
+        msg: t.collection_episode_rename_empty,
+        severity: ToastSeverity.info,
+      );
       return;
     }
     final List<EpisodeRenameProposal>? chosen =
@@ -634,9 +642,13 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           n: renamed,
           m: chosen.length - renamed,
         ),
+        severity: ToastSeverity.warning,
       );
     } else {
-      HibikiToast.show(msg: t.collection_episode_rename_apply(n: renamed));
+      HibikiToast.show(
+        msg: t.collection_episode_rename_apply(n: renamed),
+        severity: ToastSeverity.success,
+      );
     }
     await _reload();
     widget.onChanged();
@@ -746,16 +758,23 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
           }
         }
         if (episodeId == null) {
-          HibikiToast.show(msg: t.collection_episode_bangumi_not_found);
+          HibikiToast.show(
+            msg: t.collection_episode_bangumi_not_found,
+            severity: ToastSeverity.warning,
+          );
         }
       } else {
         // 集号都解析不出（文件名无集号且无集级刮削）：同样明示降级去向，
         // 不静默换成条目页（复核意见）。
-        HibikiToast.show(msg: t.collection_episode_bangumi_not_found);
+        HibikiToast.show(
+          msg: t.collection_episode_bangumi_not_found,
+          severity: ToastSeverity.warning,
+        );
       }
     } on ScrapeNetworkException catch (e) {
       HibikiToast.show(
         msg: t.collection_episode_bangumi_open_failed(error: e.toString()),
+        severity: ToastSeverity.error,
       );
     } finally {
       bangumi.close();
@@ -790,7 +809,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
       }
     }
     if (firstMissing == null) {
-      HibikiToast.show(msg: t.collection_episode_no_missing);
+      HibikiToast.show(
+        msg: t.collection_episode_no_missing,
+        severity: ToastSeverity.info,
+      );
       return;
     }
     _openDownloadDialog(episodeNumber: firstMissing);
@@ -806,7 +828,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
         widget.collection.id, MediaKind.video, ep.bookUid);
     if (!mounted) return;
     widget.onChanged();
-    HibikiToast.show(msg: t.collection_member_removed);
+    HibikiToast.show(
+      msg: t.collection_member_removed,
+      severity: ToastSeverity.success,
+    );
     final bool emptied =
         await widget.database.getMediaCollectionById(widget.collection.id) ==
             null;
@@ -899,7 +924,10 @@ class _MediaCollectionDetailPageState extends State<MediaCollectionDetailPage>
     }
     if (!mounted) return;
     widget.onChanged();
-    HibikiToast.show(msg: t.collection_split_done(n: newIds.length));
+    HibikiToast.show(
+      msg: t.collection_split_done(n: newIds.length),
+      severity: ToastSeverity.success,
+    );
     if (!choice.keepOriginal) {
       Navigator.of(context).maybePop();
       return;

--- a/hibiki/lib/src/pages/implementations/media_sources_view.dart
+++ b/hibiki/lib/src/pages/implementations/media_sources_view.dart
@@ -468,7 +468,7 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
     final bool dup = existing.any(
         (SourceLibraryRow r) => r.transport == 'local' && r.rootPath == norm);
     if (dup) {
-      HibikiToast.show(msg: norm);
+      HibikiToast.show(msg: norm, severity: ToastSeverity.warning);
       return;
     }
 
@@ -508,7 +508,7 @@ class MediaSourcesViewState extends ConsumerState<MediaSourcesView>
       return (cfg['host'] as String?) == result.host;
     });
     if (dup) {
-      HibikiToast.show(msg: norm);
+      HibikiToast.show(msg: norm, severity: ToastSeverity.warning);
       return;
     }
 
@@ -734,7 +734,7 @@ class _NetworkSourceFormDialogState extends State<_NetworkSourceFormDialog> {
   Future<void> _testConnection() async {
     final String? error = _validate();
     if (error != null) {
-      HibikiToast.show(msg: error);
+      HibikiToast.show(msg: error, severity: ToastSeverity.error);
       return;
     }
     setState(() => _testing = true);
@@ -767,10 +767,18 @@ class _NetworkSourceFormDialogState extends State<_NetworkSourceFormDialog> {
           useTls: _useTls,
         );
       }
-      if (mounted) HibikiToast.show(msg: t.sync_connection_success);
+      if (mounted) {
+        HibikiToast.show(
+          msg: t.sync_connection_success,
+          severity: ToastSeverity.success,
+        );
+      }
     } catch (e) {
       if (mounted) {
-        HibikiToast.show(msg: '${t.sync_connection_failed}: $e');
+        HibikiToast.show(
+          msg: '${t.sync_connection_failed}: $e',
+          severity: ToastSeverity.error,
+        );
       }
     } finally {
       if (mounted) setState(() => _testing = false);
@@ -780,7 +788,7 @@ class _NetworkSourceFormDialogState extends State<_NetworkSourceFormDialog> {
   void _submit() {
     final String? error = _validate();
     if (error != null) {
-      HibikiToast.show(msg: error);
+      HibikiToast.show(msg: error, severity: ToastSeverity.error);
       return;
     }
     final String pass = _passwordController.text;

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/audiobook.part.dart
@@ -324,7 +324,10 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
     } catch (e, stack) {
       ErrorLogService.instance.log('ReaderHibiki.startSession', e, stack);
       debugPrint('[ReaderHibiki] audiobook session start failed: $e');
-      if (mounted) HibikiToast.show(msg: t.audiobook_load_error);
+      if (mounted) {
+        HibikiToast.show(
+            msg: t.audiobook_load_error, severity: ToastSeverity.error);
+      }
       return;
     }
     if (controller == null) return;
@@ -1086,7 +1089,9 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
               'audioFileCount=$audioFileCount',
           StackTrace.current,
         );
-        HibikiToast.show(msg: t.audiobook_export_clip_no_text);
+        HibikiToast.show(
+            msg: t.audiobook_export_clip_no_text,
+            severity: ToastSeverity.error);
         return;
       case AudiobookClipBoundaryKind.noAudio:
         debugPrint(
@@ -1100,7 +1105,9 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
               'selectedText="${selectedText.trim()}"',
           StackTrace.current,
         );
-        HibikiToast.show(msg: t.audiobook_export_clip_no_selection);
+        HibikiToast.show(
+            msg: t.audiobook_export_clip_no_selection,
+            severity: ToastSeverity.error);
         return;
       case AudiobookClipBoundaryKind.unsupportedRange:
         debugPrint(
@@ -1115,7 +1122,9 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
           'selection has no single-file cue range (cross-chapter/cross-file)',
           StackTrace.current,
         );
-        HibikiToast.show(msg: t.audiobook_export_clip_unsupported_range);
+        HibikiToast.show(
+            msg: t.audiobook_export_clip_unsupported_range,
+            severity: ToastSeverity.error);
         return;
       case AudiobookClipBoundaryKind.tooLong:
         // BUG-1320：超时长上限此前并进 unsupportedRange，同章长选区被误报「跨章或
@@ -1133,7 +1142,9 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
               'text="${selectedText.trim()}")',
           StackTrace.current,
         );
-        HibikiToast.show(msg: t.audiobook_export_clip_too_long);
+        HibikiToast.show(
+            msg: t.audiobook_export_clip_too_long,
+            severity: ToastSeverity.error);
         return;
       case AudiobookClipBoundaryKind.exportable:
         final AudioPlaybackRange range = result.range!;
@@ -1155,7 +1166,9 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
                 'text="${selectedText.trim()}")',
             StackTrace.current,
           );
-          HibikiToast.show(msg: t.audiobook_export_clip_unsupported_range);
+          HibikiToast.show(
+              msg: t.audiobook_export_clip_unsupported_range,
+              severity: ToastSeverity.error);
           return;
         }
         // D4 时长上限已收进 classifyAudiobookClipSelection（BUG-1320，tooLong 分支
@@ -1345,7 +1358,8 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
     _AudiobookClipDynamicPlan? dynamicPlan,
   }) async {
     _audiobookClipExporting = true;
-    HibikiToast.show(msg: t.audiobook_export_clip_in_progress);
+    HibikiToast.show(
+        msg: t.audiobook_export_clip_in_progress, severity: ToastSeverity.info);
 
     // 渲图前先抓阅读主题色 + 写排方向 + 字号（在 await 前读，避免跨 await 用 context）。
     final ReaderThemeColors themeColors = _readerThemeColors;
@@ -1403,7 +1417,9 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
           StackTrace.current,
         );
         if (mounted) {
-          HibikiToast.show(msg: t.audiobook_export_clip_failed);
+          HibikiToast.show(
+              msg: t.audiobook_export_clip_failed,
+              severity: ToastSeverity.error);
         }
         return;
       }
@@ -1418,7 +1434,11 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
               '(text="$text")',
           StackTrace.current,
         );
-        if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_failed);
+        if (mounted) {
+          HibikiToast.show(
+              msg: t.audiobook_export_clip_failed,
+              severity: ToastSeverity.error);
+        }
         return;
       }
       final AudiobookClipTextLayout layout = computeClipTextLayout(
@@ -1488,7 +1508,11 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
             'renderAudiobookClipTextToPng returned null (text="$text")',
             StackTrace.current,
           );
-          if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_failed);
+          if (mounted) {
+            HibikiToast.show(
+                msg: t.audiobook_export_clip_failed,
+                severity: ToastSeverity.error);
+          }
           return;
         }
         // BUG-543：移动端 ffmpeg-kit min 变体无 png decoder（有 mjpeg decoder），
@@ -1505,7 +1529,11 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
                 '(pngLen=${pngBytes.length}, text="$text")',
             StackTrace.current,
           );
-          if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_failed);
+          if (mounted) {
+            HibikiToast.show(
+                msg: t.audiobook_export_clip_failed,
+                severity: ToastSeverity.error);
+          }
           return;
         }
         imageFile = File('$base.jpg');
@@ -1534,7 +1562,11 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
             'video synth failed: ${synth.failure} ${synth.detail ?? ''}',
             StackTrace.current,
           );
-          if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_failed);
+          if (mounted) {
+            HibikiToast.show(
+                msg: t.audiobook_export_clip_failed,
+                severity: ToastSeverity.error);
+          }
           return;
         }
       }
@@ -1551,7 +1583,11 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
         );
         if (savePath != null) {
           await File(outPath).copy(savePath);
-          if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_saved);
+          if (mounted) {
+            HibikiToast.show(
+                msg: t.audiobook_export_clip_saved,
+                severity: ToastSeverity.success);
+          }
         }
       } else {
         final List<XFile> sharedFiles = audiobookClipMobileShareAttachments(
@@ -1568,13 +1604,20 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
         // 旧兼容兜底又把临时 .aac 当第二个附件分享，系统分享面板把它显示成一个多余
         // “字幕/音频文件”。产物契约收敛为单个带声视频，不再泄漏中间文件。
         await HibikiShare.shareFiles(sharedFiles, subject: text);
-        if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_saved);
+        if (mounted) {
+          HibikiToast.show(
+              msg: t.audiobook_export_clip_saved,
+              severity: ToastSeverity.success);
+        }
       }
     } catch (e, stack) {
       ErrorLogService.instance
           .log('ReaderHibiki.exportClip.pipeline', e, stack);
       debugPrint('[ReaderHibiki] export-clip pipeline error: $e');
-      if (mounted) HibikiToast.show(msg: t.audiobook_export_clip_failed);
+      if (mounted) {
+        HibikiToast.show(
+            msg: t.audiobook_export_clip_failed, severity: ToastSeverity.error);
+      }
     } finally {
       _audiobookClipExporting = false;
       // 清理临时中间文件。桌面端最终视频已 copy 到用户选定路径，可一并清理；移动端
@@ -1814,7 +1857,7 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
 
     if (newPaths == null || newPaths.isEmpty || !mounted) return;
 
-    HibikiToast.show(msg: t.dialog_importing);
+    HibikiToast.show(msg: t.dialog_importing, severity: ToastSeverity.info);
 
     try {
       // TODO-1032：复制导入 + 改写 SrtBook.audioPaths（清 audioRoot）的核心写入逻辑
@@ -1826,12 +1869,16 @@ extension _ReaderAudiobook on _ReaderHibikiPageState {
       await _resolveAudioSlot(forceReload: true);
       if (mounted) {
         _rebuild(() {});
-        HibikiToast.show(msg: t.audiobook_import_success);
+        HibikiToast.show(
+            msg: t.audiobook_import_success, severity: ToastSeverity.success);
       }
     } catch (e, stack) {
       ErrorLogService.instance.log('ReaderHibiki.srtBookAudioPicker', e, stack);
       debugPrint('[ReaderHibiki] srtBookAudioPicker failed: $e');
-      if (mounted) HibikiToast.show(msg: t.audiobook_import_error);
+      if (mounted) {
+        HibikiToast.show(
+            msg: t.audiobook_import_error, severity: ToastSeverity.error);
+      }
     }
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/chrome.part.dart
@@ -396,7 +396,8 @@ extension _ReaderChrome on _ReaderHibikiPageState {
           return;
         case 'copy':
           await Clipboard.setData(ClipboardData(text: selectedText));
-          HibikiToast.show(msg: t.copied_to_clipboard);
+          HibikiToast.show(
+              msg: t.copied_to_clipboard, severity: ToastSeverity.success);
           // 复制是终结动作：清掉刻意保留的原生选区，和移动端拖选菜单的 'copy'
           // （_clearReaderAppSelection）对齐。否则残留的原生蓝色选区会一直卡住后续
           // 查词（见 webview.part.dart pointerup 里对 nativeMoved 的处理）。BUG-927。
@@ -594,14 +595,16 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         return;
       case 'copy':
         await Clipboard.setData(ClipboardData(text: data.text));
-        HibikiToast.show(msg: t.copied_to_clipboard);
+        HibikiToast.show(
+            msg: t.copied_to_clipboard, severity: ToastSeverity.success);
         await _clearReaderAppSelection();
         return;
       case 'share':
         final bool shared =
             await SelectionExternalActions.instance.shareText(data.text);
         if (mounted && !shared) {
-          HibikiToast.show(msg: t.selection_share_failed);
+          HibikiToast.show(
+              msg: t.selection_share_failed, severity: ToastSeverity.error);
         }
         await _clearReaderAppSelection();
         return;
@@ -609,7 +612,9 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         final bool opened =
             await SelectionExternalActions.instance.searchWeb(data.text);
         if (mounted && !opened) {
-          HibikiToast.show(msg: t.selection_web_search_unavailable);
+          HibikiToast.show(
+              msg: t.selection_web_search_unavailable,
+              severity: ToastSeverity.error);
         }
         await _clearReaderAppSelection();
         return;
@@ -762,7 +767,8 @@ extension _ReaderChrome on _ReaderHibikiPageState {
   Future<void> _exportAudiobookClipFromSelectionData(
       ReaderSelectionData data) async {
     if (data.text.isEmpty) {
-      HibikiToast.show(msg: t.audiobook_export_clip_no_text);
+      HibikiToast.show(
+          msg: t.audiobook_export_clip_no_text, severity: ToastSeverity.error);
       return;
     }
     await _fillLookupStateFromSelectionData(data, extractNativeImages: false);
@@ -854,7 +860,8 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     if (!mounted) return;
     if (data == null) {
       // 无选区 / 解析失败：走与 _exportAudiobookClip 空选区分支一致的兜底文案。
-      HibikiToast.show(msg: t.audiobook_export_clip_no_text);
+      HibikiToast.show(
+          msg: t.audiobook_export_clip_no_text, severity: ToastSeverity.error);
       return;
     }
     _exportAudiobookClip();
@@ -863,7 +870,8 @@ extension _ReaderChrome on _ReaderHibikiPageState {
   Future<void> _shareReaderImage(String imgUrl) async {
     final File? file = _readerImageFileForUrl(imgUrl);
     if (file == null) {
-      HibikiToast.show(msg: t.reader_image_file_unavailable);
+      HibikiToast.show(
+          msg: t.reader_image_file_unavailable, severity: ToastSeverity.error);
       return;
     }
     try {
@@ -872,14 +880,17 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         subject: p.basename(file.path),
       );
     } catch (e) {
-      HibikiToast.show(msg: t.reader_image_share_failed(error: e));
+      HibikiToast.show(
+          msg: t.reader_image_share_failed(error: e),
+          severity: ToastSeverity.error);
     }
   }
 
   Future<void> _copyReaderImageToClipboard(String imgUrl) async {
     final File? file = _readerImageFileForUrl(imgUrl);
     if (file == null) {
-      HibikiToast.show(msg: t.reader_image_file_unavailable);
+      HibikiToast.show(
+          msg: t.reader_image_file_unavailable, severity: ToastSeverity.error);
       return;
     }
     try {
@@ -887,9 +898,12 @@ extension _ReaderChrome on _ReaderHibikiPageState {
         'copyImageFile',
         <String, String>{'path': file.path},
       );
-      HibikiToast.show(msg: t.copied_to_clipboard);
+      HibikiToast.show(
+          msg: t.copied_to_clipboard, severity: ToastSeverity.success);
     } catch (e) {
-      HibikiToast.show(msg: t.reader_image_copy_failed(error: e));
+      HibikiToast.show(
+          msg: t.reader_image_copy_failed(error: e),
+          severity: ToastSeverity.error);
     }
   }
 
@@ -2107,7 +2121,8 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     final String sentence =
         appModel.currentMediaSource?.currentSentence.text ?? '';
     if (sentence.isEmpty) {
-      HibikiToast.show(msg: t.no_sentence_selected);
+      HibikiToast.show(
+          msg: t.no_sentence_selected, severity: ToastSeverity.error);
       return;
     }
 
@@ -2146,7 +2161,8 @@ extension _ReaderChrome on _ReaderHibikiPageState {
       if (sentenceRange != null || _lyricsMode) {
         await _refreshSectionHighlights(section);
       }
-      HibikiToast.show(msg: t.favorite_removed);
+      HibikiToast.show(
+          msg: t.favorite_removed, severity: ToastSeverity.success);
       return;
     }
 
@@ -2171,7 +2187,7 @@ extension _ReaderChrome on _ReaderHibikiPageState {
     if (sentenceRange != null || _lyricsMode) {
       await _refreshSectionHighlights(section);
     }
-    HibikiToast.show(msg: t.favorite_added);
+    HibikiToast.show(msg: t.favorite_added, severity: ToastSeverity.success);
   }
 
   /// TODO-1308 问题②（BUG-696 根因①）：书内收藏面板跳转的唯一真实路径——quick

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/mining.part.dart
@@ -130,7 +130,9 @@ extension _ReaderMining on _ReaderHibikiPageState {
           '(lookupCue=null, sentenceRange=${_cachedSentenceRange != null}, '
           'draftSentences=${_miningDraft.length}).',
         );
-        HibikiToast.show(msg: t.card_mined_without_sentence_audio);
+        HibikiToast.show(
+            msg: t.card_mined_without_sentence_audio,
+            severity: ToastSeverity.warning);
       }
     }
 
@@ -149,6 +151,7 @@ extension _ReaderMining on _ReaderHibikiPageState {
               ? 'sentence audio export failed'
               : 'sentence audio export failed: $sentenceAudioFailure',
         ),
+        severity: ToastSeverity.error,
       );
       return (context: null, cleanup: cleanupSasayakiTempDir);
     }
@@ -256,7 +259,8 @@ extension _ReaderMining on _ReaderHibikiPageState {
     if (described.record) {
       unawaited(_recordMinedSentence(fields, miningContext, outcome.noteId));
     }
-    HibikiToast.show(msg: described.message);
+    HibikiToast.show(
+        msg: described.message, severity: mineToastSeverity(described.status));
     if (described.success) {
       // TODO-270 F/G：合并卡已落地 → 清空多句草稿（popup.js 同事件把角标清零，
       // 两端在同一事件归零、不漂移）。下一次查词从空草稿重新累积。
@@ -299,7 +303,8 @@ extension _ReaderMining on _ReaderHibikiPageState {
         : '';
     final described =
         describeMineOutcome(outcome, deckName: deckName, overwrite: true);
-    HibikiToast.show(msg: described.message);
+    HibikiToast.show(
+        msg: described.message, severity: mineToastSeverity(described.status));
     if (described.success) {
       return MinePopupResult(ankiConnect: true, noteId: outcome.noteId);
     }
@@ -328,7 +333,9 @@ extension _ReaderMining on _ReaderHibikiPageState {
     if (context.sentence.trim().isEmpty) {
       debugPrint('[mine-diag] empty sentence: no sentence captured for this '
           'selection (JS sentence extraction returned empty or no selection).');
-      HibikiToast.show(msg: t.card_mined_no_sentence_captured);
+      HibikiToast.show(
+          msg: t.card_mined_no_sentence_captured,
+          severity: ToastSeverity.warning);
       return;
     }
 
@@ -348,7 +355,9 @@ extension _ReaderMining on _ReaderHibikiPageState {
     if (!AnkiHandlebarOptions.anyFieldConsumesSentence(fieldMappings)) {
       debugPrint('[mine-diag] sentence non-empty but no field maps {sentence}/'
           '{cue-sentence}; card will have an empty sentence field.');
-      HibikiToast.show(msg: t.card_mined_unmapped_sentence_field);
+      HibikiToast.show(
+          msg: t.card_mined_unmapped_sentence_field,
+          severity: ToastSeverity.warning);
       return;
     }
 
@@ -357,7 +366,9 @@ extension _ReaderMining on _ReaderHibikiPageState {
         !AnkiHandlebarOptions.anyFieldConsumesSentenceAudio(fieldMappings)) {
       debugPrint('[mine-diag] sentence audio attached but no field maps '
           '{sentence-audio}; the audio will not land on the card.');
-      HibikiToast.show(msg: t.card_mined_unmapped_sentence_audio_field);
+      HibikiToast.show(
+          msg: t.card_mined_unmapped_sentence_audio_field,
+          severity: ToastSeverity.warning);
     }
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -65,7 +65,8 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
         // 里建/启，而这条路径正是「JS 迟迟不回 onRestoreComplete」——遮罩已摘、书能
         // 读，却一秒都不记时长（字数照常累计 ⇒ 速度又爆表）。
         _ensureReadingTimeTracker();
-        HibikiToast.show(msg: t.reader_content_timeout);
+        HibikiToast.show(
+            msg: t.reader_content_timeout, severity: ToastSeverity.warning);
       },
     );
   }

--- a/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/webview.part.dart
@@ -1729,7 +1729,9 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
                     final text = await _controller?.getSelectedText();
                     if (text == null || text.isEmpty) return;
                     await Clipboard.setData(ClipboardData(text: text));
-                    HibikiToast.show(msg: t.copied_to_clipboard);
+                    HibikiToast.show(
+                        msg: t.copied_to_clipboard,
+                        severity: ToastSeverity.success);
                     // 复制后清掉 ActionMode 残留的原生选区，和桌面右键 'copy' 对齐，
                     // 避免残留选区卡住后续查词。BUG-927。
                     await _clearReaderAppSelection();
@@ -1746,7 +1748,9 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
                           .instance
                           .shareText(text);
                       if (mounted && !shared) {
-                        HibikiToast.show(msg: t.selection_share_failed);
+                        HibikiToast.show(
+                            msg: t.selection_share_failed,
+                            severity: ToastSeverity.error);
                       }
                       await _clearReaderAppSelection();
                     },
@@ -1763,7 +1767,8 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
                           .searchWeb(text);
                       if (mounted && !opened) {
                         HibikiToast.show(
-                            msg: t.selection_web_search_unavailable);
+                            msg: t.selection_web_search_unavailable,
+                            severity: ToastSeverity.error);
                       }
                       await _clearReaderAppSelection();
                     },
@@ -2475,7 +2480,8 @@ ${webViewKeyBridgeScript(handlerName: 'onSpaceKey', keys: const <String>[' '])}
           ErrorLogService.instance.log(
               'ReaderHibiki.onWebViewCreationFailed', error.description, null);
           if (!mounted) return;
-          HibikiToast.show(msg: t.reader_open_failed);
+          HibikiToast.show(
+              msg: t.reader_open_failed, severity: ToastSeverity.error);
           Navigator.of(context).pop();
           return;
         }

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_history_page.dart
@@ -953,7 +953,9 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     required String successMsg,
   }) async {
     if (alreadyHas) {
-      HibikiToast.show(msg: t.tag_already_on_book(name: tag.name));
+      HibikiToast.show(
+          msg: t.tag_already_on_book(name: tag.name),
+          severity: ToastSeverity.warning);
       return;
     }
     await addToDb();
@@ -961,7 +963,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       ref.invalidate(p);
     }
     if (mounted) {
-      HibikiToast.show(msg: successMsg);
+      HibikiToast.show(msg: successMsg, severity: ToastSeverity.success);
     }
   }
 
@@ -1004,14 +1006,18 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     final List<BookTagRow> existing =
         await db.getTagsForCollection(collectionId);
     if (existing.any((BookTagRow t) => t.id == tag.id)) {
-      HibikiToast.show(msg: t.tag_already_on_collection(name: tag.name));
+      HibikiToast.show(
+          msg: t.tag_already_on_collection(name: tag.name),
+          severity: ToastSeverity.warning);
       return;
     }
     await db.addTagToCollection(collectionId, tag.id);
     ref.invalidate(collectionTagMapProvider);
     ref.invalidate(filteredCollectionIdsProvider);
     if (mounted) {
-      HibikiToast.show(msg: t.tag_added_to_collection(name: tag.name));
+      HibikiToast.show(
+          msg: t.tag_added_to_collection(name: tag.name),
+          severity: ToastSeverity.success);
     }
   }
 
@@ -1033,7 +1039,9 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     if (outcome != CollectionAddOutcome.added || !mounted) return;
     _shelfMapsFuture = _loadShelfMaps();
     _rebuild(() {});
-    HibikiToast.show(msg: t.batch_add_to_collection_success(n: 1));
+    HibikiToast.show(
+        msg: t.batch_add_to_collection_success(n: 1),
+        severity: ToastSeverity.success);
   }
 
   /// 某媒体卡上挂的标签列：标签 map 为空 / 该 key 无标签都返回 null，否则渲染
@@ -2329,6 +2337,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     _rebuild(() {});
     HibikiToast.show(
       msg: wasCompleted ? t.book_marked_uncompleted : t.book_marked_completed,
+      severity: ToastSeverity.success,
     );
   }
 
@@ -2358,10 +2367,12 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
         BookFormatRebuild.resolveVerdict(row: row, target: target);
     final BookConvertBlocker? blocker = verdict.blocker;
     if (blocker != null) {
-      HibikiToast.show(msg: _bookConvertBlockerMessage(blocker));
+      HibikiToast.show(
+          msg: _bookConvertBlockerMessage(blocker),
+          severity: ToastSeverity.error);
       return;
     }
-    HibikiToast.show(msg: t.book_convert_running);
+    HibikiToast.show(msg: t.book_convert_running, severity: ToastSeverity.info);
     try {
       await BookFormatRebuild.convert(
         db: appModel.database,
@@ -2370,7 +2381,10 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
       );
     } catch (e, stack) {
       ErrorLogService.instance.log('ReaderHistory.convertBookFormat', e, stack);
-      if (mounted) HibikiToast.show(msg: t.book_convert_failed);
+      if (mounted) {
+        HibikiToast.show(
+            msg: t.book_convert_failed, severity: ToastSeverity.error);
+      }
       return;
     }
     if (!mounted) return;
@@ -2378,7 +2392,7 @@ class _ReaderHibikiHistoryPageState<T extends HistoryReaderPage>
     // 集合去重 —— 不显式 invalidate，书架会一直画着旧格式的卡。
     ref.invalidate(hibikiBooksProvider(JapaneseLanguage.instance));
     _rebuild(() {});
-    HibikiToast.show(msg: t.book_convert_done);
+    HibikiToast.show(msg: t.book_convert_done, severity: ToastSeverity.success);
   }
 
   /// 把「为什么不能转」翻译成一句给用户看的话。每一条都说清具体原因，不是笼统

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -1929,7 +1929,8 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
       debugPrint('[ReaderHibiki] _initBook failed: $e\n$stack');
       ErrorLogService.instance.log('ReaderHibiki._initBook', e, stack);
       if (!mounted) return;
-      HibikiToast.show(msg: t.reader_open_failed);
+      HibikiToast.show(
+          msg: t.reader_open_failed, severity: ToastSeverity.error);
       // BUG-782 同款并发退出合流：init 失败自动退与用户手动退（PopScope 的
       // onPopInvokedWithResult）可能同窗竞发，两条各自 pop 会连退两级把书架也
       // 弹掉。共用同一把 _popInProgress 锁：用户已在退出就让用户路径收尾，这里
@@ -1978,7 +1979,8 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
     if (!mounted) return;
     if (!located.exists) {
       debugPrint('[ReaderHibiki] book ${widget.bookKey} not found on disk');
-      HibikiToast.show(msg: t.book_file_not_found);
+      HibikiToast.show(
+          msg: t.book_file_not_found, severity: ToastSeverity.error);
       // 与 _initBook catch 同款 _popInProgress 合流（防与用户手动退出竞发连退两级）。
       if (_popInProgress) return;
       _popInProgress = true;
@@ -2011,7 +2013,8 @@ class _ReaderHibikiPageState extends BaseSourcePageState<ReaderHibikiPage>
             bookRow.chaptersJson, _book!.chapters.length);
       }
       if (!mounted) return;
-      HibikiToast.show(msg: t.epub_parse_fallback);
+      HibikiToast.show(
+          msg: t.epub_parse_fallback, severity: ToastSeverity.warning);
     }
 
     final List<String> hrefs = _book!.chapters.map((ch) => ch.href).toList();

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -605,7 +605,12 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
             : collectionCount == 0
                 ? t.batch_delete_success(n: deleted)
                 : t.batch_dissolve_success(m: dissolved);
-    HibikiToast.show(msg: successMsg, severity: ToastSeverity.success);
+    HibikiToast.show(
+      msg: successMsg,
+      severity: deleted > 0 || dissolved > 0
+          ? ToastSeverity.success
+          : ToastSeverity.warning,
+    );
   }
 
   /// 批量操作前把选中集收敛到真实存在的条目上，真剔掉了就明说。

--- a/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/books.part.dart
@@ -190,7 +190,8 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
 
   Future<void> _openSrtBook(SrtBook book) async {
     if (book.bookKey.isEmpty) {
-      HibikiToast.show(msg: t.srt_epub_not_ready);
+      HibikiToast.show(
+          msg: t.srt_epub_not_ready, severity: ToastSeverity.error);
       return;
     }
     // BUG-456: SRT books must use the normal media entry so AppModel registers
@@ -373,7 +374,8 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     if (mounted) {
       _refreshSrtBooks();
       _rebuild(() {});
-      HibikiToast.show(msg: t.audiobook_relocate_done);
+      HibikiToast.show(
+          msg: t.audiobook_relocate_done, severity: ToastSeverity.success);
     }
   }
 
@@ -603,7 +605,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
             : collectionCount == 0
                 ? t.batch_delete_success(n: deleted)
                 : t.batch_dissolve_success(m: dissolved);
-    HibikiToast.show(msg: successMsg);
+    HibikiToast.show(msg: successMsg, severity: ToastSeverity.success);
   }
 
   /// 批量操作前把选中集收敛到真实存在的条目上，真剔掉了就明说。
@@ -644,6 +646,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
         n: dropped + _selection.length,
         m: dropped,
       ),
+      severity: ToastSeverity.warning,
     );
     return _selection.isNotEmpty;
   }
@@ -654,7 +657,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     if (!await _pruneStaleSelection() || !mounted) return;
     final allTags = ref.read(allTagsProvider).valueOrNull;
     if (allTags == null || allTags.isEmpty) {
-      HibikiToast.show(msg: t.tag_no_tags_hint);
+      HibikiToast.show(msg: t.tag_no_tags_hint, severity: ToastSeverity.info);
       return;
     }
     await showAppDialog<void>(
@@ -776,7 +779,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     _exitSelectionMode();
     _shelfMapsFuture = _loadShelfMaps();
     _rebuild(() {});
-    HibikiToast.show(msg: t.series_created);
+    HibikiToast.show(msg: t.series_created, severity: ToastSeverity.success);
   }
 
   /// 档2：恰 1 合集 + 若干散卡 → 散卡并入该合集（不弹命名）。
@@ -792,7 +795,9 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     _exitSelectionMode();
     _shelfMapsFuture = _loadShelfMaps();
     _rebuild(() {});
-    HibikiToast.show(msg: t.batch_add_to_collection_success(n: refs.length));
+    HibikiToast.show(
+        msg: t.batch_add_to_collection_success(n: refs.length),
+        severity: ToastSeverity.success);
   }
 
   /// 档3：≥2 合集（可带散卡）→ 合并成一个。目标 = 成员最多合集（其名作默认名，
@@ -848,7 +853,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     _exitSelectionMode();
     _shelfMapsFuture = _loadShelfMaps();
     _rebuild(() {});
-    HibikiToast.show(msg: t.collection_merged);
+    HibikiToast.show(msg: t.collection_merged, severity: ToastSeverity.success);
   }
 
   Future<void> _confirmDeleteSrtBook(SrtBook book) async {
@@ -904,10 +909,12 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
       case BackgroundListenResult.started:
         break;
       case BackgroundListenResult.noAudio:
-        HibikiToast.show(msg: t.floating_lyric_no_audio);
+        HibikiToast.show(
+            msg: t.floating_lyric_no_audio, severity: ToastSeverity.error);
         break;
       case BackgroundListenResult.loadFailed:
-        HibikiToast.show(msg: t.audiobook_load_error);
+        HibikiToast.show(
+            msg: t.audiobook_load_error, severity: ToastSeverity.error);
         break;
     }
     _rebuild(() {});
@@ -942,6 +949,7 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
         msg: reason.isEmpty
             ? t.epub_delete_error
             : '${t.epub_delete_error}: $reason',
+        severity: ToastSeverity.error,
       );
       return;
     }
@@ -977,19 +985,23 @@ extension _ReaderHistoryBooks on _ReaderHibikiHistoryPageState {
     final List<String> picked = await _pickSrtAudioFiles();
     if (picked.isEmpty || !mounted) return;
 
-    HibikiToast.show(msg: t.dialog_importing);
+    HibikiToast.show(msg: t.dialog_importing, severity: ToastSeverity.info);
     try {
       await SrtBookRepository(appModel.database)
           .replaceAudio(uid: book.uid, pickedPaths: picked);
       if (mounted) {
         _refreshSrtBooks();
         _rebuild(() {});
-        HibikiToast.show(msg: t.audiobook_import_success);
+        HibikiToast.show(
+            msg: t.audiobook_import_success, severity: ToastSeverity.success);
       }
     } catch (e, stack) {
       ErrorLogService.instance.log('ReaderHistory.openAudioImport', e, stack);
       debugPrint('[ReaderHistory] openAudioImport failed: $e');
-      if (mounted) HibikiToast.show(msg: t.audiobook_import_error);
+      if (mounted) {
+        HibikiToast.show(
+            msg: t.audiobook_import_error, severity: ToastSeverity.error);
+      }
     }
   }
 

--- a/hibiki/lib/src/pages/implementations/reader_history/dialogs.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_history/dialogs.part.dart
@@ -413,6 +413,7 @@ class _BatchTagPickerDialogState extends State<_BatchTagPickerDialog> {
           name: tag.name,
           n: widget.selectedKeys.length,
         ),
+        severity: ToastSeverity.success,
       );
     }
     for (final tagId in _removeTagIds) {
@@ -422,6 +423,7 @@ class _BatchTagPickerDialogState extends State<_BatchTagPickerDialog> {
           name: tag.name,
           n: widget.selectedKeys.length,
         ),
+        severity: ToastSeverity.success,
       );
     }
     Navigator.pop(context);

--- a/hibiki/lib/src/pages/implementations/reader_pdf_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_pdf_page.dart
@@ -437,7 +437,7 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
   void _notifyNoTextLayer() {
     if (_noTextLayerNotified) return;
     _noTextLayerNotified = true;
-    HibikiToast.show(msg: t.pdf_no_text_layer);
+    HibikiToast.show(msg: t.pdf_no_text_layer, severity: ToastSeverity.error);
   }
 
   // ── Phase 5：书签（复用 EPUB 的 Bookmarks 表）───────────────────────
@@ -462,7 +462,8 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
         ),
       );
       if (!mounted) return;
-      HibikiToast.show(msg: t.pdf_bookmark_added);
+      HibikiToast.show(
+          msg: t.pdf_bookmark_added, severity: ToastSeverity.success);
     } catch (e, stack) {
       ErrorLogService.instance.log('ReaderPdfPage.addBookmark', e, stack);
     }
@@ -479,7 +480,8 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
     }
     if (!mounted) return;
     if (bookmarks.isEmpty) {
-      HibikiToast.show(msg: t.pdf_bookmarks_empty);
+      HibikiToast.show(
+          msg: t.pdf_bookmarks_empty, severity: ToastSeverity.info);
       return;
     }
     await showAppDialog<void>(
@@ -524,7 +526,7 @@ class _ReaderPdfPageState extends BaseSourcePageState<ReaderPdfPage>
     }
     if (!mounted) return;
     if (outline.isEmpty) {
-      HibikiToast.show(msg: t.pdf_outline_empty);
+      HibikiToast.show(msg: t.pdf_outline_empty, severity: ToastSeverity.info);
       return;
     }
     await showAppDialog<void>(

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -130,13 +130,19 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         await _session.exportLineAudioPreview(line.id);
     if (!mounted) return;
     if (preview == null) {
-      HibikiToast.show(msg: t.game_line_preview_failed);
+      HibikiToast.show(
+        msg: t.game_line_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final bool started = await DesktopAudioPlayback.playFile(preview.filePath);
     if (!mounted) return;
     if (!started) {
-      HibikiToast.show(msg: t.game_line_preview_failed);
+      HibikiToast.show(
+        msg: t.game_line_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     _linePreviewResetTimer?.cancel();
@@ -160,7 +166,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   Future<void> _pickLineTrack(TexthookerLineEntry line) async {
     final List<GalAudioTrack> tracks = _session.state.audioTracks;
     if (tracks.isEmpty) {
-      HibikiToast.show(msg: t.game_no_tracks);
+      HibikiToast.show(
+        msg: t.game_no_tracks,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final int? picked = await showAppDialog<int>(
@@ -249,6 +258,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     if (!mounted) return;
     HibikiToast.show(
       msg: applied ? t.game_line_track_applied : t.game_line_track_failed,
+      severity: applied ? ToastSeverity.success : ToastSeverity.error,
     );
   }
 
@@ -257,11 +267,17 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     final GalTrackPreview? preview =
         await _session.exportLineTrackPreview(lineId, sourcePtr);
     if (preview == null) {
-      HibikiToast.show(msg: t.game_track_preview_failed);
+      HibikiToast.show(
+        msg: t.game_track_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     if (!await DesktopAudioPlayback.playFile(preview.filePath)) {
-      HibikiToast.show(msg: t.game_track_preview_failed);
+      HibikiToast.show(
+        msg: t.game_track_preview_failed,
+        severity: ToastSeverity.error,
+      );
     }
   }
 
@@ -288,14 +304,20 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                   await _session.exportTrackPreview(track.sourcePtr);
               if (!dialogContext.mounted) return;
               if (preview == null) {
-                HibikiToast.show(msg: t.game_track_preview_failed);
+                HibikiToast.show(
+                  msg: t.game_track_preview_failed,
+                  severity: ToastSeverity.error,
+                );
                 return;
               }
               final bool started =
                   await DesktopAudioPlayback.playFile(preview.filePath);
               if (!dialogContext.mounted) return;
               if (!started) {
-                HibikiToast.show(msg: t.game_track_preview_failed);
+                HibikiToast.show(
+                  msg: t.game_track_preview_failed,
+                  severity: ToastSeverity.error,
+                );
                 return;
               }
               previewReset?.cancel();
@@ -353,6 +375,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       final bool ok = await _session.finishLineRecapture();
       HibikiToast.show(
         msg: ok ? t.game_hook_recapture_saved : t.game_hook_recapture_empty,
+        // 补录窗口空手而归不是崩溃，是「这次没录到」——warning 而非 error。
+        severity: ok ? ToastSeverity.success : ToastSeverity.warning,
       );
       return;
     }
@@ -361,6 +385,8 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       msg: started
           ? t.game_hook_recapture_started
           : t.game_hook_recapture_unavailable,
+      // 开录是「去游戏里重播这句」的操作指示（info）；开不起来是能力缺失（error）。
+      severity: started ? ToastSeverity.info : ToastSeverity.error,
     );
   }
 
@@ -599,13 +625,18 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     }
     HibikiToast.showMine(msg: described.message, status: described.status);
     if (result.sentenceAudioMissing) {
-      HibikiToast.show(msg: t.game_card_sentence_audio_missing);
+      // 卡片建成了、只是缺句子音频 = 部分成功。
+      HibikiToast.show(
+        msg: t.game_card_sentence_audio_missing,
+        severity: ToastSeverity.warning,
+      );
     }
     if (result.unmappedTokens.isNotEmpty) {
       // 冒号统一全角（与上方 external_window_capture_failed toast 一致）。
       HibikiToast.show(
         msg: '${t.game_card_mapping_missing}：'
             '${result.unmappedTokens.join(', ')}',
+        severity: ToastSeverity.warning,
       );
     }
     if (described.success) {
@@ -642,13 +673,19 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   /// 把处置塞进选择器会逼出模式参数。
   Future<ExternalWindowInfo?> _showExternalWindowPicker() async {
     if (!Platform.isWindows) {
-      HibikiToast.show(msg: t.external_window_unsupported);
+      HibikiToast.show(
+        msg: t.external_window_unsupported,
+        severity: ToastSeverity.error,
+      );
       return null;
     }
     final List<ExternalWindowInfo> windows =
         await WindowCaptureChannel.listWindows();
     if (windows.isEmpty) {
-      HibikiToast.show(msg: t.external_window_no_windows);
+      HibikiToast.show(
+        msg: t.external_window_no_windows,
+        severity: ToastSeverity.error,
+      );
       return null;
     }
     if (!context.mounted) return null;
@@ -732,7 +769,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     _launchingGalHook = true;
     try {
       if (!Platform.isWindows) {
-        HibikiToast.show(msg: t.external_window_unsupported);
+        HibikiToast.show(
+          msg: t.external_window_unsupported,
+          severity: ToastSeverity.error,
+        );
         return;
       }
       final FilePickerResult? picked = await FilePicker.platform.pickFiles(
@@ -753,7 +793,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         context: context,
       );
       if (!installed || !mounted) return;
-      HibikiToast.show(msg: t.game_capture_launching);
+      HibikiToast.show(
+        msg: t.game_capture_launching,
+        severity: ToastSeverity.info,
+      );
       // 这条入口只拿到一个裸 exe 路径、不经过游戏库条目，但同一个 exe 就是同一个游戏：
       // 按路径回查库里已配置的启动参数与工作目录，让「从库里启动」和「从工作台启动并
       // 捕获」用同一份配置。库里没有这个 exe（临时选的文件）→ 空配置 = 旧行为。
@@ -786,7 +829,22 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         lastError: state.lastError,
         injectorDetail: state.injectorDetail,
       );
-      if (message != null) HibikiToast.show(msg: message);
+      // BUG-1089 的着色面：outcome 已经把「跑起来了 / 只剩整机混音兜底 / 根本没起来」
+      // 分好了，toast 的颜色跟着同一份判定走，别再让三种结局长成同一条无色提示。
+      if (message != null) {
+        HibikiToast.show(
+          msg: message,
+          severity: switch (outcome) {
+            GalHookLaunchOutcome.running => ToastSeverity.success,
+            GalHookLaunchOutcome.degradedLoopback => ToastSeverity.warning,
+            GalHookLaunchOutcome.failed ||
+            GalHookLaunchOutcome.windowMissing =>
+              ToastSeverity.error,
+            // message 为 null 时根本不播报，这里走不到。
+            GalHookLaunchOutcome.superseded => ToastSeverity.neutral,
+          },
+        );
+      }
     } finally {
       _launchingGalHook = false;
     }
@@ -805,11 +863,20 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       final LunaHookCodeProfileStore store =
           await LunaHookCodeProfileStore.openDefault();
       await store.replaceFrom(File(path));
-      HibikiToast.show(msg: 'Hook Code · ${t.dialog_import}');
+      HibikiToast.show(
+        msg: 'Hook Code · ${t.dialog_import}',
+        severity: ToastSeverity.success,
+      );
     } on FormatException {
-      HibikiToast.show(msg: t.audiobook_import_error);
+      HibikiToast.show(
+        msg: t.audiobook_import_error,
+        severity: ToastSeverity.error,
+      );
     } catch (_) {
-      HibikiToast.show(msg: t.audiobook_import_error);
+      HibikiToast.show(
+        msg: t.audiobook_import_error,
+        severity: ToastSeverity.error,
+      );
     }
   }
 
@@ -824,9 +891,15 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       final LunaHookCodeProfileStore store =
           await LunaHookCodeProfileStore.openDefault();
       await store.exportTo(File(path));
-      HibikiToast.show(msg: 'Hook Code · ${t.dialog_export}');
+      HibikiToast.show(
+        msg: 'Hook Code · ${t.dialog_export}',
+        severity: ToastSeverity.success,
+      );
     } catch (_) {
-      HibikiToast.show(msg: t.audiobook_import_error);
+      HibikiToast.show(
+        msg: t.audiobook_import_error,
+        severity: ToastSeverity.error,
+      );
     }
   }
 
@@ -835,7 +908,11 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     final TexthookerTextThread? thread = _session.selectedTextThread;
     final String? hookCode = thread?.hookCode;
     if (executable == null || hookCode == null || hookCode.trim().isEmpty) {
-      HibikiToast.show(msg: t.game_text_thread_hint);
+      // 没选文本线程就点保存＝前置条件不满足、什么都没存下，必须让用户看出这次没成。
+      HibikiToast.show(
+        msg: t.game_text_thread_hint,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     try {
@@ -854,9 +931,15 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
           label: label,
         ),
       );
-      HibikiToast.show(msg: 'Hook Code · ${t.dialog_save}');
+      HibikiToast.show(
+        msg: 'Hook Code · ${t.dialog_save}',
+        severity: ToastSeverity.success,
+      );
     } catch (_) {
-      HibikiToast.show(msg: t.audiobook_import_error);
+      HibikiToast.show(
+        msg: t.audiobook_import_error,
+        severity: ToastSeverity.error,
+      );
     }
   }
 
@@ -2022,13 +2105,19 @@ class _LineTracksCardState extends State<_LineTracksCard> {
         await widget.session.exportLineTrackPreview(lineId, track.sourcePtr);
     if (!mounted) return;
     if (preview == null) {
-      HibikiToast.show(msg: t.game_track_preview_failed);
+      HibikiToast.show(
+        msg: t.game_track_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final bool started = await DesktopAudioPlayback.playFile(preview.filePath);
     if (!mounted) return;
     if (!started) {
-      HibikiToast.show(msg: t.game_track_preview_failed);
+      HibikiToast.show(
+        msg: t.game_track_preview_failed,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     _previewResetTimer?.cancel();
@@ -2049,6 +2138,7 @@ class _LineTracksCardState extends State<_LineTracksCard> {
     if (!mounted) return;
     HibikiToast.show(
       msg: applied ? t.game_line_track_applied : t.game_line_track_failed,
+      severity: applied ? ToastSeverity.success : ToastSeverity.error,
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
@@ -22,7 +22,20 @@ const double kTorrentSettingsContentMaxWidth = 560;
 /// 从「设置→视频」搬到「下载」页——下载既已独立成页，配置就该在页内，不再埋进
 /// 视频设置。所有字段写 `QbConnectionConfig`（即时生效到内置引擎）。
 class TorrentSettingsSection extends ConsumerStatefulWidget {
-  const TorrentSettingsSection({super.key, this.desktopOverride});
+  const TorrentSettingsSection({
+    super.key,
+    this.desktopOverride,
+    this.constrainWidth = true,
+  });
+
+  /// 是否把正文收进 [kTorrentSettingsContentMaxWidth]（560）并水平居中。
+  ///
+  /// true（默认）= 下载页语境：整页只有这一组表单，居中限宽是为了让左侧文案与最右
+  /// 侧控件不至于隔着整块 4K 面板。
+  /// false = 嵌进「下载」设置分类的详情 pane：那里同屏还有别的设置卡片，居中限宽会
+  /// 让本组左边缘变成 `(paneWidth - 560) / 2`，与其它分类的行完全对不齐（用户反馈的
+  /// 「下载设置左右间距和其他设置不一样」）。此时改为与普通设置行同一条 16px 基线。
+  final bool constrainWidth;
 
   /// 仅测试注入：覆盖「本平台是否有内置引擎」的判据（BUG-1207 的平台门控）。
   /// null = 用真实 `dart:io` 平台判断。照搬 `book_import_dialog.dart` 的
@@ -163,6 +176,9 @@ class _TorrentSettingsSectionState
         icon: Icons.folder_open_outlined,
         showIcon: true,
         controlBelow: true,
+        // 嵌入设置详情时外层已经统一缩进 16，这里不能再叠一层（否则本行 32、
+        // 同卡片其它内容 16）。
+        horizontalPadding: widget.constrainWidth ? null : 0,
         onTap: _pickingFolder ? null : _changeDownloadFolder,
         trailing: Wrap(
           spacing: 8,
@@ -651,6 +667,19 @@ class _TorrentSettingsSectionState
         ],
       ],
     );
+    if (!widget.constrainWidth) {
+      // 设置详情 pane 语境：不居中限宽，改用与普通设置行同一条 16px 左右基线。
+      return Padding(
+        padding: EdgeInsets.symmetric(
+          horizontal: HibikiDesignTokens.of(context).spacing.rowHorizontal,
+        ),
+        child: SizedBox(
+          key: const ValueKey<String>('torrent-settings-content'),
+          width: double.infinity,
+          child: content,
+        ),
+      );
+    }
     return Align(
       alignment: Alignment.topCenter,
       child: ConstrainedBox(

--- a/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
+++ b/hibiki/lib/src/pages/implementations/torrent_settings_section.dart
@@ -303,6 +303,7 @@ class _TorrentSettingsSectionState
       subtitle: subtitle,
       value: value,
       onChanged: onChanged,
+      horizontalPadding: widget.constrainWidth ? null : 0,
     );
   }
 
@@ -495,6 +496,7 @@ class _TorrentSettingsSectionState
             title: t.video_setting_torrent_limit_lan,
             subtitle: t.video_setting_torrent_limit_lan_hint,
             value: c.limitLocalPeers,
+            horizontalPadding: widget.constrainWidth ? null : 0,
             onChanged: (bool v) => _commit(
                 (QbConnectionConfig c) => c.copyWith(limitLocalPeers: v)),
           ),
@@ -502,6 +504,7 @@ class _TorrentSettingsSectionState
             title: t.video_setting_torrent_upload_enabled,
             subtitle: t.video_setting_torrent_upload_enabled_hint,
             value: c.uploadEnabled,
+            horizontalPadding: widget.constrainWidth ? null : 0,
             onChanged: (bool v) =>
                 _commit((QbConnectionConfig c) => c.copyWith(uploadEnabled: v)),
           ),

--- a/hibiki/lib/src/pages/implementations/video_hibiki/clip_export.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/clip_export.part.dart
@@ -9,21 +9,27 @@ part of '../video_hibiki_page.dart';
 extension _VideoClipExport on _VideoHibikiPageState {
   Future<void> _toggleClipExport() async {
     if (_clipExporting) {
-      _showOsd(t.video_clip_exporting);
+      _showOsd(t.video_clip_exporting, severity: ToastSeverity.info);
       return;
     }
 
     final VideoPlayerController? controller = _controller;
     if (controller == null) return;
     if (_isRemote || _currentVideoPath == null) {
-      _showOsd(t.video_clip_export_remote_download_required);
+      _showOsd(
+        t.video_clip_export_remote_download_required,
+        severity: ToastSeverity.warning,
+      );
       return;
     }
 
     if (!_clipExportMarking) {
       final int? positionMs = controller.positionMs;
       if (positionMs == null) {
-        _showOsd(t.video_clip_export_invalid_range);
+        _showOsd(
+          t.video_clip_export_invalid_range,
+          severity: ToastSeverity.error,
+        );
         return;
       }
       _rebuild(() {
@@ -34,7 +40,7 @@ extension _VideoClipExport on _VideoHibikiPageState {
         _clipExportStartAudioStreamIndex = controller.currentAudioStreamIndex;
         _clipExportStartAudioStreamCount = controller.realAudioStreamCount;
       });
-      _showOsd(t.video_clip_export_start);
+      _showOsd(t.video_clip_export_start, severity: ToastSeverity.info);
       return;
     }
 
@@ -46,12 +52,18 @@ extension _VideoClipExport on _VideoHibikiPageState {
         endMs == null ||
         startPath != _currentVideoPath) {
       _rebuild(_clearClipExportState);
-      _showOsd(t.video_clip_export_source_changed);
+      _showOsd(
+        t.video_clip_export_source_changed,
+        severity: ToastSeverity.warning,
+      );
       return;
     }
     if (endMs <= startMs) {
       _rebuild(_clearClipExportState);
-      _showOsd(t.video_clip_export_invalid_range);
+      _showOsd(
+        t.video_clip_export_invalid_range,
+        severity: ToastSeverity.error,
+      );
       return;
     }
 
@@ -76,17 +88,20 @@ extension _VideoClipExport on _VideoHibikiPageState {
     if (outputPath == null) {
       // 桌面用户取消了「另存为」——此刻尚未产出任何文件，直接清状态收场。
       _rebuild(_clearClipExportState);
-      _showOsd(t.video_clip_export_cancelled);
+      _showOsd(t.video_clip_export_cancelled, severity: ToastSeverity.info);
       _focusOwnership.reclaim(FocusReclaimCause.overlayClosed);
       return;
     }
     if (generation != _clipExportGeneration || _currentVideoPath != startPath) {
       _rebuild(_clearClipExportState);
-      _showOsd(t.video_clip_export_source_changed);
+      _showOsd(
+        t.video_clip_export_source_changed,
+        severity: ToastSeverity.warning,
+      );
       return;
     }
     _rebuild(() => _clipExporting = true);
-    _showOsd(t.video_clip_exporting);
+    _showOsd(t.video_clip_exporting, severity: ToastSeverity.info);
 
     final VideoClipExportResult result = await exportVideoClipViaFfmpeg(
       inputPath: startPath,
@@ -110,7 +125,10 @@ extension _VideoClipExport on _VideoHibikiPageState {
       await _deleteClipOutput(result.outputPath ?? outputPath);
       if (mounted) {
         _rebuild(_clearClipExportState);
-        _showOsd(t.video_clip_export_source_changed);
+        _showOsd(
+          t.video_clip_export_source_changed,
+          severity: ToastSeverity.warning,
+        );
       }
       return;
     }
@@ -121,9 +139,12 @@ extension _VideoClipExport on _VideoHibikiPageState {
       // 区分带没带字幕：字幕封装可能被静默降级（容器封不下、旧的桌面精简 ffmpeg 没有
       // movtext 编码器），不告诉用户的话，他只会看到一个「导出成功却没字幕」的片段，
       // 无从判断是自己没选字幕还是导出丢了。
-      _showOsd(result.subtitleTrackCount > 0
-          ? t.video_clip_exported_with_subtitles(path: exported)
-          : t.video_clip_exported(path: exported));
+      _showOsd(
+        result.subtitleTrackCount > 0
+            ? t.video_clip_exported_with_subtitles(path: exported)
+            : t.video_clip_exported(path: exported),
+        severity: ToastSeverity.success,
+      );
       if (!(Platform.isWindows || Platform.isMacOS || Platform.isLinux)) {
         await HibikiShare.shareFiles(<XFile>[
           XFile(exported),
@@ -140,7 +161,10 @@ extension _VideoClipExport on _VideoHibikiPageState {
       final String reason = (detail == null || detail.isEmpty)
           ? readable
           : '$readable — ${detail.length > 200 ? '${detail.substring(detail.length - 200)}…' : detail}';
-      _showOsd(t.video_clip_export_failed(reason: reason));
+      _showOsd(
+        t.video_clip_export_failed(reason: reason),
+        severity: ToastSeverity.error,
+      );
     }
     _focusOwnership.reclaim(FocusReclaimCause.overlayClosed);
   }
@@ -302,13 +326,19 @@ extension _VideoClipExport on _VideoHibikiPageState {
         if (savePath != null) {
           final String finalPath = _uniqueScreenshotSavePath(savePath);
           await tmp.copy(finalPath);
-          _showOsd(t.video_screenshot_saved_to(path: finalPath));
+          _showOsd(
+            t.video_screenshot_saved_to(path: finalPath),
+            severity: ToastSeverity.success,
+          );
         }
       } else {
         await HibikiShare.shareFiles(<XFile>[
           XFile(tmp.path, mimeType: 'image/jpeg'),
         ], subject: screenshotName);
-        _showOsd(t.video_screenshot_ready(file: screenshotName));
+        _showOsd(
+          t.video_screenshot_ready(file: screenshotName),
+          severity: ToastSeverity.success,
+        );
       }
     } catch (e, stack) {
       debugPrint('[VideoHibikiPage] screenshot save failed: $e\n$stack');
@@ -349,6 +379,7 @@ extension _VideoClipExport on _VideoHibikiPageState {
       t.video_screenshot_failed_reason(
         reason: text.isEmpty ? 'unknown error' : text,
       ),
+      severity: ToastSeverity.error,
     );
   }
 }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/danmaku.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/danmaku.part.dart
@@ -188,6 +188,7 @@ extension _VideoDanmaku on _VideoHibikiPageState {
               ? t.video_danmaku_manual_network_error
               : t.video_danmaku_manual_bind_server_error,
           icon: Icons.error_outline,
+          severity: ToastSeverity.error,
         );
         return;
       }
@@ -204,7 +205,12 @@ extension _VideoDanmaku on _VideoHibikiPageState {
       // 该集有效但暂无弹幕：绑定照样生效（之后有人发就会出现），但要说清楚，
       // 否则用户只看到「面板关了、什么都没有」。
       if (result.items.isEmpty) {
-        _showOsd(t.video_danmaku_manual_bind_empty, icon: Icons.info_outline);
+        // 绑定本身成功（episodeId 已落库），只是这集暂无弹幕——状态告知而非失败。
+        _showOsd(
+          t.video_danmaku_manual_bind_empty,
+          icon: Icons.info_outline,
+          severity: ToastSeverity.info,
+        );
       }
       debugPrint(
         '[VideoDanmaku] manual bind episode=${episode.episodeId} '
@@ -214,7 +220,11 @@ extension _VideoDanmaku on _VideoHibikiPageState {
       debugPrint('[VideoDanmaku] manual bind failed: $e');
       // UI 巡检 PR-4：失败给可见反馈（此前只 debugPrint，用户选完集面板不关、
       // 弹幕不出现、零提示）。原始异常只留日志，不进 UI。
-      _showOsd(t.video_danmaku_manual_bind_failed, icon: Icons.error_outline);
+      _showOsd(
+        t.video_danmaku_manual_bind_failed,
+        icon: Icons.error_outline,
+        severity: ToastSeverity.error,
+      );
     } finally {
       client.close();
     }

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
@@ -108,7 +108,7 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
   Future<void> _toggleFavoriteSentenceForVideo() async {
     final String sentence = _lastLookupSentence;
     if (sentence.isEmpty) {
-      _showOsd(t.no_sentence_selected);
+      _showOsd(t.no_sentence_selected, severity: ToastSeverity.error);
       return;
     }
     final AudioCue? cue = _lastLookupCue;
@@ -137,7 +137,13 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
           );
         });
       }
-      _showOsd(t.favorite_removed, icon: Icons.favorite_border);
+      // 加入收藏＝success（绿），移出＝info（蓝）：都执行成功了，但只有「加进去了」
+      // 值得一枚对勾；取消收藏染绿会让人以为又收藏了一次。
+      _showOsd(
+        t.favorite_removed,
+        icon: Icons.favorite_border,
+        severity: ToastSeverity.info,
+      );
       return;
     }
     await repo.add(
@@ -167,7 +173,11 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
         ));
       });
     }
-    _showOsd(t.favorite_added, icon: Icons.favorite);
+    _showOsd(
+      t.favorite_added,
+      icon: Icons.favorite,
+      severity: ToastSeverity.success,
+    );
   }
 
   /// 查词浮层顶栏「重播本句」：跳回当前查词那句的句首、起播，播到句尾自动暂停。
@@ -223,7 +233,11 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
     final String text = cue.text.trim();
     if (text.isEmpty) return;
     Clipboard.setData(ClipboardData(text: text));
-    _showOsd(t.copied_to_clipboard, icon: Icons.copy);
+    _showOsd(
+      t.copied_to_clipboard,
+      icon: Icons.copy,
+      severity: ToastSeverity.success,
+    );
   }
 
   /// 字幕跳转列表面板某句是否已收藏（同步，读缓存 [_favoritedVideoSentences]）。
@@ -296,6 +310,8 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
     _showOsd(
       wasFavorited ? t.favorite_removed : t.favorite_added,
       icon: wasFavorited ? Icons.favorite_border : Icons.favorite,
+      // 与 [_toggleFavoriteSentenceForVideo] 同口径：加入 success、移出 info。
+      severity: wasFavorited ? ToastSeverity.info : ToastSeverity.success,
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_mining.part.dart
@@ -443,19 +443,25 @@ extension _VideoLookupMining on _VideoHibikiPageState {
     // BUG-296 / TODO-390：应带句子音频却抽取失败 → 显式 OSD + 中止，不建无音频卡。
     if (res.aborted) {
       if (mounted) {
-        _showOsd(t.card_export_failed_detail(
-          reason: audioFailure == null
-              ? 'sentence audio export failed'
-              : 'sentence audio export failed: $audioFailure',
-        ));
+        _showOsd(
+          t.card_export_failed_detail(
+            reason: audioFailure == null
+                ? 'sentence audio export failed'
+                : 'sentence audio export failed: $audioFailure',
+          ),
+          severity: ToastSeverity.error,
+        );
       }
       return const MinePopupResult();
     }
     // W2a：动图降级为静态帧时可感知 OSD（原因取 GIF 失败摘要，最贴近根因）。
     if (res.degradedToStill && mounted) {
-      _showOsd(t.card_cover_degraded_to_static(
-        reason: coverFailure ?? 'animated clip unavailable',
-      ));
+      _showOsd(
+        t.card_cover_degraded_to_static(
+          reason: coverFailure ?? 'animated clip unavailable',
+        ),
+        severity: ToastSeverity.warning,
+      );
     }
     final MineOutcome outcome = res.outcome! as MineOutcome;
     final MinePopupResult result = outcome.result == MineResult.success
@@ -478,7 +484,13 @@ extension _VideoLookupMining on _VideoHibikiPageState {
     if (described.record) unawaited(_recordMinedForVideo());
     // TODO-971：制卡成功（card_exported / card_overwritten，含牌组名）走突出 OSD——
     // 居中、更大、停留更久，区别于音量/亮度小角标，避免用户「制卡了没反馈」。
-    _showOsd(described.message, prominent: true);
+    // describeMineOutcome 早就算出了 status，此前只被拿去选 prominent 布尔、颜色
+    // 整个丢掉，于是视频页制卡成功与失败长得一模一样。透传语义即可对齐其它入口。
+    _showOsd(
+      described.message,
+      prominent: true,
+      severity: mineToastSeverity(described.status),
+    );
     return result;
   }
 

--- a/hibiki/lib/src/pages/implementations/video_hibiki/quality.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/quality.part.dart
@@ -140,11 +140,13 @@ extension _VideoQuality on _VideoHibikiPageState {
         _youtubeVariantsLoading = false;
         _youtubeVariantsResolved = true; // 已解析（含空档）——不再重复 getManifest。
       });
-      if (set.variants.isEmpty) _showOsd(t.video_quality_load_failed);
+      if (set.variants.isEmpty) {
+        _showOsd(t.video_quality_load_failed, severity: ToastSeverity.error);
+      }
     } catch (_) {
       if (!mounted || seq != _episodeLoadSeq) return;
       _rebuild(() => _youtubeVariantsLoading = false);
-      _showOsd(t.video_quality_load_failed);
+      _showOsd(t.video_quality_load_failed, severity: ToastSeverity.error);
     }
   }
 

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle.part.dart
@@ -468,7 +468,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     }
     if (!mounted) return false;
     if (cues.isEmpty) {
-      _showOsd(t.video_subtitle_load_failed(label: source.label));
+      _showOsd(
+        t.video_subtitle_load_failed(label: source.label),
+        severity: ToastSeverity.error,
+      );
       return false;
     }
     controller.setSecondaryCues(cues);
@@ -637,7 +640,7 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     // 仅在字幕真被应用（解析出 cue）时报「已下载并应用」；cue 为空时
     // _selectSubtitleSource 已弹失败提示，不再叠加误导性的成功提示。
     if (applied && mounted) {
-      _showOsd(t.video_jimaku_downloaded);
+      _showOsd(t.video_jimaku_downloaded, severity: ToastSeverity.success);
     }
   }
 
@@ -668,7 +671,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     final String? path = result?.files.single.path;
     if (path == null) return;
     if (subtitleFormatForPath(path) == null) {
-      _showOsd(t.video_subtitle_import_unsupported);
+      _showOsd(
+        t.video_subtitle_import_unsupported,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     // 复制到 video_subtitles/ 持久目录再应用：远端选择按文件路径持久化（见
@@ -707,7 +713,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     }
     if (!mounted) return;
     if (cues.isEmpty) {
-      _showOsd(t.video_subtitle_load_failed(label: displayLabel));
+      _showOsd(
+        t.video_subtitle_load_failed(label: displayLabel),
+        severity: ToastSeverity.error,
+      );
       return;
     }
     controller.setCues(cues);
@@ -747,7 +756,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     RemoteVideoEmbeddedSubtitleTrack track,
   ) async {
     if (!track.isText) {
-      _showOsd(t.video_subtitle_import_unsupported);
+      _showOsd(
+        t.video_subtitle_import_unsupported,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     final RemoteVideoClient? client = widget.remoteClient;
@@ -860,7 +872,12 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     }
     if (cues.isEmpty) {
       // 手选到空轨（机翻失败 / 该轨无文字）：提示；自动应用（loadSeq!=null）静默不打扰。
-      if (loadSeq == null) _showOsd(t.video_subtitle_youtube_empty);
+      if (loadSeq == null) {
+        _showOsd(
+          t.video_subtitle_youtube_empty,
+          severity: ToastSeverity.error,
+        );
+      }
       return;
     }
     controller.setCues(cues);
@@ -894,7 +911,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     String srcPath,
   ) async {
     if (subtitleFormatForPath(srcPath) == null) {
-      _showOsd(t.video_subtitle_import_unsupported);
+      _showOsd(
+        t.video_subtitle_import_unsupported,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     // TODO-1236：经 AppPaths 解析（跟随桌面自定义数据根），与迁移白名单 `video_subtitles`
@@ -907,7 +927,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
         await File(srcPath).copy(dest);
       } catch (_) {
         if (!mounted) return;
-        _showOsd(t.video_subtitle_import_failed);
+        _showOsd(
+          t.video_subtitle_import_failed,
+          severity: ToastSeverity.error,
+        );
         return;
       }
     }
@@ -964,7 +987,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
       );
       if (!mounted) return false;
       if (!shown) {
-        _showOsd(t.video_subtitle_load_failed(label: source.label));
+        _showOsd(
+          t.video_subtitle_load_failed(label: source.label),
+          severity: ToastSeverity.error,
+        );
         return false;
       }
       final String persisted = source.toPersistedValue();
@@ -981,7 +1007,11 @@ extension _VideoSubtitle on _VideoHibikiPageState {
       }
       if (!mounted) return false;
       _rebuild(() => _currentSubtitleSource = persisted);
-      _showOsd(t.video_subtitle_graphic_shown(label: source.label));
+      // 图形轨只能当画面渲染、逐字查词失效——是降级而非成功，配色要说清。
+      _showOsd(
+        t.video_subtitle_graphic_shown(label: source.label),
+        severity: ToastSeverity.warning,
+      );
       return true;
     }
 
@@ -1000,7 +1030,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     // **不切换、不持久化**——避免谎报「已切换」却空屏，也避免用一个坏内封轨覆盖掉
     // 当前正常工作的字幕源（下次进来还是空）。
     if (cues.isEmpty) {
-      _showOsd(t.video_subtitle_load_failed(label: source.label));
+      _showOsd(
+        t.video_subtitle_load_failed(label: source.label),
+        severity: ToastSeverity.error,
+      );
       return false;
     }
     controller.setCues(cues);
@@ -1266,7 +1299,10 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     final String? videoPath = controller.videoPath;
     final int? durationMs = controller.durationMs;
     if (cues.isEmpty || videoPath == null || videoPath.isEmpty) {
-      _showOsd(t.video_subtitle_auto_align_low_confidence);
+      _showOsd(
+        t.video_subtitle_auto_align_low_confidence,
+        severity: ToastSeverity.warning,
+      );
       return null;
     }
     // 时长缺失时用最后一条 cue 的结束时间兜底（cue 升序由 setCues 保证），仍能栅格化。
@@ -1281,6 +1317,7 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     _showOsd(
       t.video_subtitle_auto_align_running,
       icon: Icons.auto_fix_high,
+      severity: ToastSeverity.info,
     );
 
     final List<double> rawRms = await extractAudioEnergyEnvelope(
@@ -1312,12 +1349,16 @@ extension _VideoSubtitle on _VideoHibikiPageState {
         _showOsd(
           t.video_subtitle_auto_align_done(ms: result.offsetMs),
           icon: Icons.auto_fix_high,
+          severity: ToastSeverity.success,
         );
         // TODO-1206：回传实际平移量，让面板把滑条/数值/波形同步到新延迟。
         return result.offsetMs;
       case SubtitleAutoAlignStatus.lowConfidence:
       case SubtitleAutoAlignStatus.noData:
-        _showOsd(t.video_subtitle_auto_align_low_confidence);
+        _showOsd(
+          t.video_subtitle_auto_align_low_confidence,
+          severity: ToastSeverity.warning,
+        );
         return null;
     }
   }
@@ -1366,13 +1407,19 @@ extension _VideoSubtitle on _VideoHibikiPageState {
     final List<AudioCue> cues = controller.cues;
     final String? videoPath = controller.videoPath;
     if (cues.isEmpty || videoPath == null || videoPath.isEmpty) {
-      _showOsd(t.video_subtitle_waveform_unavailable);
+      _showOsd(
+        t.video_subtitle_waveform_unavailable,
+        severity: ToastSeverity.warning,
+      );
       return;
     }
     final List<double> env = await _loadSubtitleWaveformEnvelope();
     if (!mounted) return;
     if (env.isEmpty) {
-      _showOsd(t.video_subtitle_waveform_unavailable);
+      _showOsd(
+        t.video_subtitle_waveform_unavailable,
+        severity: ToastSeverity.warning,
+      );
       return;
     }
     // 波形时间窗上界：与 extractAudioEnergyEnvelope 探测上界同源（前 N 分钟截断），

--- a/hibiki/lib/src/pages/implementations/video_hibiki/subtitle_caret.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/subtitle_caret.part.dart
@@ -49,7 +49,7 @@ extension _VideoSubtitleCaret on _VideoHibikiPageState {
     if (!_immersiveAllowsLookup) return;
     final int anchor = _subtitleHitTester.caretAnchorEntry();
     if (anchor < 0) {
-      _showOsd(t.no_sentence_selected);
+      _showOsd(t.no_sentence_selected, severity: ToastSeverity.error);
       return;
     }
     // 与 _lookupAt 同款暂停语义：仅在播时置位标记，fire-and-forget 暂停。

--- a/hibiki/lib/src/pages/implementations/video_hibiki/volume_osd.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/volume_osd.part.dart
@@ -28,6 +28,7 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
     IconData? icon,
     double? progress,
     bool prominent = false,
+    ToastSeverity severity = ToastSeverity.neutral,
   }) {
     if (!mounted) return;
     _osdNotifier.value = _VideoOsdMessage(
@@ -35,6 +36,7 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
       icon: icon,
       progress: progress?.clamp(0.0, 1.0).toDouble(),
       prominent: prominent,
+      severity: severity,
     );
     _osdTimer?.cancel();
     // TODO-971：突出 OSD（制卡成功）停留更久（3.6s），普通通知仍 2.6s。
@@ -331,6 +333,15 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
   Widget _buildOsdCard(_VideoOsdMessage osd) {
     final ColorScheme cs = _videoChromeColorScheme(context);
     final bool prominent = osd.prominent;
+    // 语义配色：null（neutral）＝旧的半透明 inverseSurface。着色时保留同样的半透明
+    // 观感，OSD 压在画面上，实心色块会挡视线。
+    final ({Color background, Color foreground, IconData icon})? palette =
+        toastSeverityPalette(osd.severity);
+    final Color surfaceColor = palette == null
+        ? _osdSurfaceColor(cs)
+        : palette.background.withValues(alpha: 0.88);
+    final Color textColor =
+        palette == null ? _osdTextColor(cs) : palette.foreground;
     final double fontSize = prominent ? 18 : 14;
     final double iconSize = prominent ? 24 : 18;
     final EdgeInsets cardPadding = prominent
@@ -356,7 +367,7 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
           ),
           child: DecoratedBox(
             decoration: BoxDecoration(
-              color: _osdSurfaceColor(cs),
+              color: surfaceColor,
               borderRadius: radius,
               boxShadow: prominent
                   ? <BoxShadow>[
@@ -374,13 +385,17 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   if (osd.icon != null) ...<Widget>[
-                    Icon(osd.icon, size: iconSize, color: _osdTextColor(cs)),
+                    Icon(osd.icon, size: iconSize, color: textColor),
+                    SizedBox(width: prominent ? 12 : 8),
+                  ] else if (palette != null) ...<Widget>[
+                    // 语义图标：e-ink / 灰阶下颜色会塌掉，形状是唯一区分手段。
+                    Icon(palette.icon, size: iconSize, color: textColor),
                     SizedBox(width: prominent ? 12 : 8),
                   ] else if (prominent) ...<Widget>[
                     Icon(
                       Icons.check_circle,
                       size: iconSize,
-                      color: _osdTextColor(cs),
+                      color: textColor,
                     ),
                     const SizedBox(width: 12),
                   ],
@@ -392,7 +407,7 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
                         Text(
                           osd.message,
                           style: TextStyle(
-                            color: _osdTextColor(cs),
+                            color: textColor,
                             fontSize: fontSize,
                             fontWeight:
                                 prominent ? FontWeight.w600 : FontWeight.normal,
@@ -407,10 +422,9 @@ extension _VideoVolumeOsd on _VideoHibikiPageState {
                               value: osd.progress,
                               minHeight: 3,
                               backgroundColor:
-                                  _osdTextColor(cs).withValues(alpha: 0.25),
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                _osdTextColor(cs),
-                              ),
+                                  textColor.withValues(alpha: 0.25),
+                              valueColor:
+                                  AlwaysStoppedAnimation<Color>(textColor),
                             ),
                           ),
                         ],

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -27,6 +27,9 @@ import 'package:hibiki/src/media/audiobook/mining_sentence_draft.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/pages/implementations/video_loading_overlay.dart';
 import 'package:hibiki/src/utils/misc/swipe_dismiss_wrapper.dart';
+// 只取语义枚举与调色板：视频页的通知一律走左上角 _showOsd，不得用 HibikiToast
+// （BUG-931 有守卫），故刻意不 import 整套 toast API。
+import 'package:hibiki/src/utils/misc/toast_severity.dart';
 import 'package:hibiki/src/media/drag_drop/drop_classification.dart';
 import 'package:hibiki/src/media/drag_drop/hibiki_file_drop_target.dart';
 import 'package:hibiki/src/media/import/real_path_directory_picker.dart';
@@ -590,11 +593,18 @@ class _VideoOsdMessage {
     this.icon,
     this.progress,
     this.prominent = false,
+    this.severity = ToastSeverity.neutral,
   });
 
   final String message;
   final IconData? icon;
   final double? progress;
+
+  /// 语义配色。左上角 OSD 此前**没有任何颜色参数**（70 处调用全恒灰），成功与失败
+  /// 长得一模一样——包括视频页制卡：`describeMineOutcome` 早就算出了状态，却只被
+  /// 拿去选 `prominent` 布尔，颜色信息整个丢掉。与底部 toast 共用同一套语义
+  /// （[ToastSeverity]），保持两套通知系统同一门语言。
+  final ToastSeverity severity;
 
   /// TODO-971：突出变体（制卡成功用）。普通 OSD 沿用音量/亮度同款左上角小角标，
   /// 太轻易被忽略；制卡成功这类用户主动操作的确认改成居中、更大字号、停留更久的

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -3205,7 +3205,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
       _failed = false;
       _failReason = null;
     });
-    _showOsd(t.video_resource_relink_success);
+    _showOsd(t.video_resource_relink_success, severity: ToastSeverity.success);
     await _loadSingle(updated);
   }
 
@@ -3262,7 +3262,10 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     }
     if (!result.shouldNotifyFailure) return;
     final String label = result.source?.label ?? t.video_menu_subtitle_track;
-    _showOsd(t.video_subtitle_load_failed(label: label));
+    _showOsd(
+      t.video_subtitle_load_failed(label: label),
+      severity: ToastSeverity.error,
+    );
   }
 
   /// 位置持久化（controller 每秒至多一次回调）。
@@ -6040,7 +6043,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   Future<void> _toggleFavoriteCurrentCue() async {
     final AudioCue? cue = _currentCueForAction();
     if (cue == null || cue.text.trim().isEmpty) {
-      _showOsd(t.no_sentence_selected);
+      _showOsd(t.no_sentence_selected, severity: ToastSeverity.error);
       return;
     }
     // BUG-931：收藏不再唤起 media_kit 控制条——原先那句 poke 会派发合成 hover 把底栏
@@ -6295,7 +6298,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
         await RenderBackendService.instance.setImpellerDisabled(true);
     if (!ok || !appModel.platformServices.lifecycle.supportsRestart) {
       // pref 未写成（非 Android）或平台不支持自动重启：降级提示手动重开。
-      if (mounted) _showOsd(t.render_restart_required);
+      if (mounted) {
+        _showOsd(t.render_restart_required, severity: ToastSeverity.warning);
+      }
       return;
     }
     try {
@@ -6303,7 +6308,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     } catch (e) {
       // 起新进程失败（Process.start 抛错等）→ 降级提示手动重开。
       debugPrint('[render] switch to Skia restart failed: $e');
-      if (mounted) _showOsd(t.render_restart_required);
+      if (mounted) {
+        _showOsd(t.render_restart_required, severity: ToastSeverity.warning);
+      }
     }
   }
 
@@ -6355,17 +6362,20 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     }
     if (files.subtitles.isNotEmpty) {
       debugPrint('[hibiki-drop] [video-playback] intent=unsupportedSubtitle');
-      _showOsd(t.video_subtitle_import_unsupported);
+      _showOsd(
+        t.video_subtitle_import_unsupported,
+        severity: ToastSeverity.error,
+      );
       return;
     }
     if (files.audios.isNotEmpty && files.videos.isEmpty) {
       debugPrint('[hibiki-drop] [video-playback] intent=unsupportedAudio');
-      _showOsd(t.video_drop_audio_unsupported);
+      _showOsd(t.video_drop_audio_unsupported, severity: ToastSeverity.error);
       return;
     }
     if (files.hasAny) {
       debugPrint('[hibiki-drop] [video-playback] intent=unsupportedSurface');
-      _showOsd(t.video_drop_subtitle_only);
+      _showOsd(t.video_drop_subtitle_only, severity: ToastSeverity.error);
     }
   }
 

--- a/hibiki/lib/src/settings/settings_destination.dart
+++ b/hibiki/lib/src/settings/settings_destination.dart
@@ -7,6 +7,10 @@ enum SettingsDestinationId {
   appearance,
   profiles,
   reading,
+  // 「漫画」一级分类：漫画阅读器的观看偏好（方向/缩放/翻页）+ 漫画 OCR。原先
+  // OCR 组寄生在 reading 末尾、观看偏好则完全不在设置里；漫画与 EPUB 阅读没有
+  // 任何共享设置项，故拆成独立大类（见 settings_schema_manga.dart）。
+  manga,
   lookup,
   cardCreation,
   video,

--- a/hibiki/lib/src/settings/settings_schema.dart
+++ b/hibiki/lib/src/settings/settings_schema.dart
@@ -8,6 +8,7 @@ import 'package:hibiki/src/settings/settings_schema_downloads.dart';
 import 'package:hibiki/src/settings/settings_schema_game.dart';
 import 'package:hibiki/src/settings/settings_schema_listening.dart';
 import 'package:hibiki/src/settings/settings_schema_lookup.dart';
+import 'package:hibiki/src/settings/settings_schema_manga.dart';
 import 'package:hibiki/src/settings/settings_schema_tracking.dart';
 import 'package:hibiki/src/settings/settings_schema_profiles.dart';
 import 'package:hibiki/src/settings/settings_schema_reading.dart';
@@ -87,6 +88,8 @@ List<SettingsDestination> _buildDestinations() {
   return List<SettingsDestination>.unmodifiable(<SettingsDestination>[
     buildAppearanceDestination(),
     buildReadingDestination(),
+    // 「漫画」大类：从阅读分类拆出（观看偏好 + OCR，详见 buildMangaDestination）。
+    buildMangaDestination(),
     buildListeningDestination(),
     buildVideoDestination(),
     buildMediaTrackingDestination(),

--- a/hibiki/lib/src/settings/settings_schema_downloads.dart
+++ b/hibiki/lib/src/settings/settings_schema_downloads.dart
@@ -48,8 +48,10 @@ SettingsDestination buildDownloadsDestination() {
     ],
     // 内联既有 torrent 设置组件（不改写）。包一层 AdaptiveSettingsSection 让它拿到
     // 与其它 section 一致的卡片表面（body 契约：自带 section 布局、不自带脚手架/滚动）。
+    // constrainWidth:false —— 下载页那套「560 居中限宽」在设置详情 pane 里会让本组
+    // 左边缘变成 (paneWidth-560)/2，与其它 12 个分类的设置行完全对不齐。
     body: (SettingsContext context) => const AdaptiveSettingsSection(
-      children: <Widget>[TorrentSettingsSection()],
+      children: <Widget>[TorrentSettingsSection(constrainWidth: false)],
     ),
   );
 }

--- a/hibiki/lib/src/settings/settings_schema_manga.dart
+++ b/hibiki/lib/src/settings/settings_schema_manga.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:hibiki/src/media/manga/manga_view_prefs.dart';
@@ -117,13 +119,13 @@ SettingsDestination buildMangaDestination() {
                 c.appModel.setMangaTapZonePaging(value),
           ),
           // 音量键只有 Android 侧 `MainActivity.dispatchKeyEvent` 会拦截并转发
-          // （见 VolumeKeyChannel），其它平台没有可拦截的音量键，故只在移动端显示。
+          // （见 VolumeKeyChannel），iOS 与桌面端均没有实现，故只在 Android 显示。
           SettingsSwitchItem(
             id: 'manga.volume_key_paging',
             title: t.manga_volume_key_paging,
             subtitle: t.manga_volume_key_paging_subtitle,
             icon: Icons.volume_up_outlined,
-            visible: (SettingsContext c) => isMobilePlatform,
+            visible: (_) => Platform.isAndroid,
             value: (SettingsContext c) => c.appModel.mangaVolumeKeyPaging,
             onChanged: (SettingsContext c, bool value) =>
                 c.appModel.setMangaVolumeKeyPaging(value),

--- a/hibiki/lib/src/settings/settings_schema_manga.dart
+++ b/hibiki/lib/src/settings/settings_schema_manga.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+
+import 'package:hibiki/src/media/manga/manga_view_prefs.dart';
+import 'package:hibiki/src/settings/settings_context.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
+import 'package:hibiki/src/settings/settings_schema_manga_ocr.dart';
+import 'package:hibiki/utils.dart';
+
+/// 「漫画」一级设置分类。
+///
+/// 此前漫画在设置页只有一个折叠的「漫画 OCR」组，寄生在**阅读**分类末尾
+/// （`settings_schema_reading.dart` 内联 [buildMangaOcrSection]），而真正影响日常
+/// 观看的三项（阅读方向 / 缩放 / 翻页）根本不在设置里，只能在漫画阅读器的右键菜单
+/// 里改，重装或换设备后无从预设。漫画与 EPUB 阅读共用「阅读」分类本身就是错的：
+/// 两者没有一个设置项是共享的（漫画没有字体/行距/排版方向，EPUB 没有跨页/缩放）。
+///
+/// 故拆成独立一级分类，并把漫画阅读器的观看偏好一并抬进来。OCR 组原样复用
+/// （[buildMangaOcrSection]），只是换了归属。
+SettingsDestination buildMangaDestination() {
+  return SettingsDestination(
+    id: SettingsDestinationId.manga,
+    title: t.manga_library,
+    summary: t.settings_destination_manga_summary,
+    icon: Icons.auto_stories_outlined,
+    sections: <SettingsSection>[
+      SettingsSection(
+        title: t.manga_section_viewing,
+        items: <SettingsItem>[
+          // 阅读方向：偏好是新书的默认值，已打开的书仍按自身状态走。
+          SettingsSegmentedItem<String>(
+            id: 'manga.reading_direction',
+            title: t.manga_reading_direction,
+            icon: Icons.swap_horiz_outlined,
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: 'rtl',
+                label: t.manga_direction_rtl,
+              ),
+              SettingsSegmentOption<String>(
+                value: 'ltr',
+                label: t.manga_direction_ltr,
+              ),
+            ],
+            selected: (SettingsContext c) => c.appModel.mangaReadingDirection,
+            onChanged: (SettingsContext c, String value) =>
+                c.appModel.setMangaReadingDirection(value),
+          ),
+          SettingsSliderItem(
+            id: 'manga.default_zoom',
+            title: t.manga_default_zoom,
+            icon: Icons.zoom_in_outlined,
+            min: kMangaZoomMinPercent.toDouble(),
+            max: kMangaZoomMaxPercent.toDouble(),
+            divisions: (kMangaZoomMaxPercent - kMangaZoomMinPercent) ~/ 10,
+            step: 10,
+            titleReadout: true,
+            commitOnRelease: true,
+            label: (double v) => '${v.round()}%',
+            value: (SettingsContext c) => c.appModel.mangaZoomPercent
+                .clamp(kMangaZoomMinPercent, kMangaZoomMaxPercent)
+                .toDouble(),
+            onChanged: (SettingsContext c, double value) =>
+                c.appModel.setMangaZoomPercent(value.round()),
+          ),
+          // 灵敏度：滚轮/捏合每一步缩放多少的倍率。旧实现丢弃滚轮 delta 幅值、
+          // 恒定 ±10 个百分点，触控板与鼠标同等对待，是「缩放极其不灵敏」的主因；
+          // 算法已改成按 delta 比例的乘法缩放，这里让用户再微调总倍率。
+          SettingsSliderItem(
+            id: 'manga.zoom_sensitivity',
+            title: t.manga_zoom_sensitivity,
+            icon: Icons.tune_outlined,
+            min: kMangaZoomSensitivityMin.toDouble(),
+            max: kMangaZoomSensitivityMax.toDouble(),
+            divisions:
+                (kMangaZoomSensitivityMax - kMangaZoomSensitivityMin) ~/ 25,
+            step: 25,
+            titleReadout: true,
+            commitOnRelease: true,
+            label: (double v) => '${v.round()}%',
+            value: (SettingsContext c) => c.appModel.mangaZoomSensitivity
+                .clamp(kMangaZoomSensitivityMin, kMangaZoomSensitivityMax)
+                .toDouble(),
+            onChanged: (SettingsContext c, double value) =>
+                c.appModel.setMangaZoomSensitivity(value.round()),
+          ),
+          SettingsSegmentedItem<String>(
+            id: 'manga.page_animation',
+            title: t.manga_page_animation,
+            icon: Icons.animation_outlined,
+            options: <SettingsSegmentOption<String>>[
+              SettingsSegmentOption<String>(
+                value: MangaPageAnimation.none.key,
+                label: t.manga_page_animation_none,
+              ),
+              SettingsSegmentOption<String>(
+                value: MangaPageAnimation.slide.key,
+                label: t.manga_page_animation_slide,
+              ),
+              SettingsSegmentOption<String>(
+                value: MangaPageAnimation.fade.key,
+                label: t.manga_page_animation_fade,
+              ),
+            ],
+            selected: (SettingsContext c) =>
+                MangaPageAnimationKey.fromKey(c.appModel.mangaPageAnimation)
+                    .key,
+            onChanged: (SettingsContext c, String value) =>
+                c.appModel.setMangaPageAnimation(value),
+          ),
+          SettingsSwitchItem(
+            id: 'manga.tap_zone_paging',
+            title: t.manga_tap_zone_paging,
+            subtitle: t.manga_tap_zone_paging_subtitle,
+            icon: Icons.touch_app_outlined,
+            value: (SettingsContext c) => c.appModel.mangaTapZonePaging,
+            onChanged: (SettingsContext c, bool value) =>
+                c.appModel.setMangaTapZonePaging(value),
+          ),
+          // 音量键只有 Android 侧 `MainActivity.dispatchKeyEvent` 会拦截并转发
+          // （见 VolumeKeyChannel），其它平台没有可拦截的音量键，故只在移动端显示。
+          SettingsSwitchItem(
+            id: 'manga.volume_key_paging',
+            title: t.manga_volume_key_paging,
+            subtitle: t.manga_volume_key_paging_subtitle,
+            icon: Icons.volume_up_outlined,
+            visible: (SettingsContext c) => isMobilePlatform,
+            value: (SettingsContext c) => c.appModel.mangaVolumeKeyPaging,
+            onChanged: (SettingsContext c, bool value) =>
+                c.appModel.setMangaVolumeKeyPaging(value),
+          ),
+        ],
+      ),
+      buildMangaOcrSection(),
+    ],
+  );
+}

--- a/hibiki/lib/src/settings/settings_schema_manga_ocr.dart
+++ b/hibiki/lib/src/settings/settings_schema_manga_ocr.dart
@@ -7,7 +7,7 @@ import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/utils.dart';
 
-/// 「漫画 OCR」设置组（内联进阅读设置分类，默认折叠）。
+/// 「漫画 OCR」设置组（隶属**漫画**设置分类，默认折叠）。
 ///
 /// 全平台显示（P4）：模型下载/状态行移动端也需要（单框补扫用识别三件套）；
 /// 整卷 OCR 向导仍桌面/远程，外部 mokuro CLI 块在 section 正文内自行按桌面
@@ -21,7 +21,7 @@ SettingsSection buildMangaOcrSection() {
     collapsedByDefault: true,
     items: <SettingsItem>[
       SettingsCustomItem(
-        id: 'reading.manga_ocr',
+        id: 'manga.ocr',
         searchTitle: t.manga_ocr_section,
         builder: (SettingsContext c) => MangaOcrSettingsSection(
           service: c.ref.read(mangaOcrServiceProvider),
@@ -33,7 +33,7 @@ SettingsSection buildMangaOcrSection() {
       // MokuroMoeClient 的 normalizeMokuroMoeBaseUrl 归一回默认站点，故这里
       // 只 trim 存原值、不做格式校验。
       SettingsTextItem(
-        id: 'reading.manga_online_catalog_base_url',
+        id: 'manga.online_catalog_base_url',
         title: t.manga_online_base_url_label,
         icon: Icons.cloud_outlined,
         keyboardType: TextInputType.url,

--- a/hibiki/lib/src/settings/settings_schema_reading.dart
+++ b/hibiki/lib/src/settings/settings_schema_reading.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:hibiki/src/settings/settings_actions.dart';
 import 'package:hibiki/src/settings/settings_context.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
-import 'package:hibiki/src/settings/settings_schema_manga_ocr.dart';
 import 'package:hibiki/utils.dart';
 
 SettingsDestination buildReadingDestination() {
@@ -841,10 +840,6 @@ SettingsDestination buildReadingDestination() {
           ),
         ],
       ),
-      // 「漫画 OCR」组（内置模型下载/删除 + 外部 mokuro CLI）——仅桌面显示，
-      // 默认折叠。见 settings_schema_manga_ocr.dart（经 provider 触达并行编写的
-      // MangaOcrServiceImpl，impl 落地前 analyze 会报缺文件）。
-      buildMangaOcrSection(),
     ],
   );
 }

--- a/hibiki/lib/src/settings/settings_schema_system.dart
+++ b/hibiki/lib/src/settings/settings_schema_system.dart
@@ -350,9 +350,13 @@ Future<void> _checkUpdateNow(SettingsContext settingsContext) async {
       msg: newer
           ? t.update_cached_newer(version: cached.latestTag)
           : t.update_cached_up_to_date(version: cached.latestTag),
+      severity: ToastSeverity.info,
     );
   } else {
-    HibikiToast.show(msg: t.update_checking_now);
+    HibikiToast.show(
+      msg: t.update_checking_now,
+      severity: ToastSeverity.info,
+    );
   }
   try {
     await UpdateChecker.scheduleCheck(
@@ -366,8 +370,14 @@ Future<void> _checkUpdateNow(SettingsContext settingsContext) async {
       customProxy: settingsContext.appModel.updateCustomProxy,
       // 网络刷新跑完写回缓存，下次手动检查直接乐观显示（恒快）。
       cacheWriter: settingsContext.appModel.setUpdateCheckCache,
-      onUpToDate: () => HibikiToast.show(msg: t.update_already_latest),
-      onError: (Object _) => HibikiToast.show(msg: t.update_check_failed),
+      onUpToDate: () => HibikiToast.show(
+        msg: t.update_already_latest,
+        severity: ToastSeverity.info,
+      ),
+      onError: (Object _) => HibikiToast.show(
+        msg: t.update_check_failed,
+        severity: ToastSeverity.error,
+      ),
     );
   } finally {
     _manualCheckInFlight = false;

--- a/hibiki/lib/src/utils/components/settings_shared.dart
+++ b/hibiki/lib/src/utils/components/settings_shared.dart
@@ -422,7 +422,17 @@ class AdaptiveSettingsRow extends StatelessWidget {
     this.trailingFlexible = false,
     this.titleMaxLines,
     this.subtitleMaxLines,
+    this.horizontalPadding,
   });
+
+  /// 覆盖本行的水平内边距；null = 用标准 `tokens.spacing.rowHorizontal`（16）。
+  ///
+  /// 存在的理由：这 16px 此前是硬编码、无逃生口的，而它同时是「设置行左边缘」的
+  /// 事实标准。于是任何**自带内边距**的嵌入式正文（`SettingsCustomItem` 的 builder、
+  /// `SettingsDestination.body` 逃生口）一旦把自己整体缩进 16，里面夹杂的
+  /// [AdaptiveSettingsRow] 就变成 32，与同卡片其它行错开——「下载设置左右间距和其他
+  /// 设置不一样」正是这一类。给出显式 0 让调用方声明「外层已经缩进过了」。
+  final double? horizontalPadding;
 
   final String title;
   final String? subtitle;
@@ -507,7 +517,8 @@ class AdaptiveSettingsRow extends StatelessWidget {
                 constraints.maxWidth < stackThreshold + iconExtra);
         return Padding(
           padding: EdgeInsets.symmetric(
-            horizontal: cupertino ? 16 : tokens.spacing.rowHorizontal,
+            horizontal: horizontalPadding ??
+                (cupertino ? 16 : tokens.spacing.rowHorizontal),
             vertical:
                 stackControls ? tokens.spacing.rowVertical : tokens.spacing.gap,
           ),

--- a/hibiki/lib/src/utils/components/settings_shared.dart
+++ b/hibiki/lib/src/utils/components/settings_shared.dart
@@ -713,6 +713,7 @@ class AdaptiveSettingsSwitchRow extends StatelessWidget {
     this.subtitle,
     this.icon,
     this.showIcon = false,
+    this.horizontalPadding,
   });
 
   final String title;
@@ -723,6 +724,7 @@ class AdaptiveSettingsSwitchRow extends StatelessWidget {
   /// 才渲染左栏图标徽章。schema 层的 `showIcons` 经此透传（此前只转发 icon 不
   /// 转发 showIcon，值控件行声明的图标从不渲染，同卡片左栏对不齐）。
   final bool showIcon;
+  final double? horizontalPadding;
   final bool value;
   final ValueChanged<bool>? onChanged;
 
@@ -733,6 +735,7 @@ class AdaptiveSettingsSwitchRow extends StatelessWidget {
       subtitle: subtitle,
       icon: icon,
       showIcon: showIcon,
+      horizontalPadding: horizontalPadding,
       trailing: adaptiveSwitch(
         context: context,
         value: value,

--- a/hibiki/lib/src/utils/misc/hibiki_toast.dart
+++ b/hibiki/lib/src/utils/misc/hibiki_toast.dart
@@ -4,46 +4,12 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:hibiki/src/utils/components/hibiki_design_tokens.dart';
+import 'package:hibiki/src/utils/misc/toast_severity.dart';
 
 export 'package:fluttertoast/fluttertoast.dart' show Toast, ToastGravity;
-
-/// TODO-1325 #6: 制卡结果 toast 的语义状态。决定 MD3 toast 的着色与 Material 图标，
-/// 让「加入了 / 已存在 / 失败 / 制卡中」一眼可辨，而不再只靠弹窗里 mine 按钮的图标变化。
-enum MineToastStatus { added, duplicate, failed, pending }
-
-/// 把 [MineToastStatus] 映射成 toast 的 (背景色, 前景色, 图标)。用固定 Material 色阶
-/// （绿/橙/红/蓝）而非主题取色，保证四态在任意主题下都语义清晰、对比达标；也让无
-/// BuildContext 的降级路径（独立弹窗 Activity）能直接复用同一配色。
-({Color background, Color foreground, IconData icon}) mineToastPalette(
-  MineToastStatus status,
-) {
-  switch (status) {
-    case MineToastStatus.added:
-      return (
-        background: const Color(0xFF2E7D32), // green 800
-        foreground: Colors.white,
-        icon: Icons.check_circle_rounded,
-      );
-    case MineToastStatus.duplicate:
-      return (
-        background: const Color(0xFFEF6C00), // orange 800
-        foreground: Colors.white,
-        icon: Icons.library_add_check_rounded,
-      );
-    case MineToastStatus.failed:
-      return (
-        background: const Color(0xFFC62828), // red 800
-        foreground: Colors.white,
-        icon: Icons.error_rounded,
-      );
-    case MineToastStatus.pending:
-      return (
-        background: const Color(0xFF1565C0), // blue 800
-        foreground: Colors.white,
-        icon: Icons.sync_rounded,
-      );
-  }
-}
+// 语义与调色板住在 toast_severity.dart（视频页 OSD 也用，见该文件头注释），
+// 这里再导出一次，让既有 `import hibiki_toast.dart` 的调用点无需改 import。
+export 'package:hibiki/src/utils/misc/toast_severity.dart';
 
 /// Global navigator key used by the desktop toast overlay.
 /// Must be assigned to the MaterialApp's navigatorKey.
@@ -56,28 +22,42 @@ abstract final class HibikiToast {
   static set navigatorKey(GlobalKey<NavigatorState> key) =>
       _toastNavigatorKey = key;
 
+  /// [severity] 决定配色与图标（见 [ToastSeverity]）。显式传 [backgroundColor] /
+  /// [textColor] 仍然优先——少数调用点（如 tag chip 透传自身颜色）不是语义着色。
   static void show({
     required String msg,
     Toast toastLength = Toast.LENGTH_SHORT,
     ToastGravity gravity = ToastGravity.BOTTOM,
     Color? backgroundColor,
     Color? textColor,
+    ToastSeverity severity = ToastSeverity.neutral,
   }) {
+    final ({Color background, Color foreground, IconData icon})? palette =
+        toastSeverityPalette(severity);
+    final Color? bg = backgroundColor ?? palette?.background;
+    final Color? fg = textColor ?? palette?.foreground;
     if (Platform.isAndroid || Platform.isIOS) {
+      // 原生 toast 画不了图标，只能着色；桌面自绘 overlay 图标齐全。
       Fluttertoast.showToast(
         msg: msg,
         toastLength: toastLength,
         gravity: gravity,
-        backgroundColor: backgroundColor,
-        textColor: textColor,
+        backgroundColor: bg,
+        textColor: fg,
       );
+      return;
+    }
+    final int durationMs = toastLength == Toast.LENGTH_LONG ? 3500 : 2000;
+    // 有语义调色板且调用点没自带颜色时，走带图标的着色渲染器（与制卡 toast 同一个）。
+    if (palette != null && backgroundColor == null && textColor == null) {
+      _showPaletteToast(msg: msg, palette: palette, durationMs: durationMs);
       return;
     }
     _showDesktopToast(
       msg: msg,
-      durationMs: toastLength == Toast.LENGTH_LONG ? 3500 : 2000,
-      backgroundColor: backgroundColor,
-      textColor: textColor,
+      durationMs: durationMs,
+      backgroundColor: bg,
+      textColor: fg,
     );
   }
 
@@ -111,18 +91,47 @@ abstract final class HibikiToast {
     required String msg,
     required MineToastStatus status,
   }) {
+    // pending 停留更久（等制卡结果覆盖它），结果 toast 用短时长。
+    _insertToastEntry(
+      overlay: overlay,
+      durationMs: status == MineToastStatus.pending ? 4000 : 2400,
+      builder: (BuildContext context) => _SeverityToastWidget(
+        msg: msg,
+        palette: mineToastPalette(status),
+      ),
+    );
+  }
+
+  /// 语义着色 toast（桌面自绘路径）。与制卡 toast 共用同一个渲染器，避免出现
+  /// 「制卡的有图标有颜色、别的没有」这种同类通知两副长相。
+  static void _showPaletteToast({
+    required String msg,
+    required ({Color background, Color foreground, IconData icon}) palette,
+    required int durationMs,
+  }) {
+    final overlay = _toastNavigatorKey?.currentState?.overlay;
+    if (overlay == null) return;
+    _insertToastEntry(
+      overlay: overlay,
+      durationMs: durationMs,
+      builder: (BuildContext context) =>
+          _SeverityToastWidget(msg: msg, palette: palette),
+    );
+  }
+
+  static void _insertToastEntry({
+    required OverlayState overlay,
+    required int durationMs,
+    required WidgetBuilder builder,
+  }) {
     _dismissTimer?.cancel();
     _currentEntry?.remove();
     _currentEntry = null;
 
-    final entry = OverlayEntry(
-      builder: (context) => _MineToastWidget(msg: msg, status: status),
-    );
+    final entry = OverlayEntry(builder: builder);
     _currentEntry = entry;
     overlay.insert(entry);
 
-    // pending 停留更久（等制卡结果覆盖它），结果 toast 用短时长。
-    final int durationMs = status == MineToastStatus.pending ? 4000 : 2400;
     _dismissTimer = Timer(Duration(milliseconds: durationMs), () {
       entry.remove();
       if (_currentEntry == entry) _currentEntry = null;
@@ -233,20 +242,23 @@ class _DesktopToastWidgetState extends State<_DesktopToastWidget>
   }
 }
 
-/// TODO-1325 #6: 制卡结果 toast 的自绘 MD3 组件——一张圆角卡片，左侧状态图标 + 文案，
-/// 整体用状态色填充、白色前景，淡入呈现。与 [_DesktopToastWidget] 同一定位/动画骨架，
-/// 但多了图标与语义色（added/duplicate/failed/pending）。
-class _MineToastWidget extends StatefulWidget {
-  const _MineToastWidget({required this.msg, required this.status});
+/// 语义 toast 的自绘 MD3 组件——一张圆角卡片，左侧状态图标 + 文案，整体用状态色
+/// 填充、白色前景，淡入呈现。与 [_DesktopToastWidget] 同一定位/动画骨架，但多了图标
+/// 与语义色。
+///
+/// 制卡结果（[mineToastPalette]）与通用语义（[toastSeverityPalette]）共用本组件：
+/// 两者都只是一组 (背景, 前景, 图标)，没有理由各写一个渲染器。
+class _SeverityToastWidget extends StatefulWidget {
+  const _SeverityToastWidget({required this.msg, required this.palette});
 
   final String msg;
-  final MineToastStatus status;
+  final ({Color background, Color foreground, IconData icon}) palette;
 
   @override
-  State<_MineToastWidget> createState() => _MineToastWidgetState();
+  State<_SeverityToastWidget> createState() => _SeverityToastWidgetState();
 }
 
-class _MineToastWidgetState extends State<_MineToastWidget>
+class _SeverityToastWidgetState extends State<_SeverityToastWidget>
     with SingleTickerProviderStateMixin {
   late final AnimationController _controller;
   late final Animation<double> _opacity;
@@ -272,7 +284,7 @@ class _MineToastWidgetState extends State<_MineToastWidget>
   Widget build(BuildContext context) {
     final tokens = HibikiDesignTokens.of(context);
     final ({Color background, Color foreground, IconData icon}) palette =
-        mineToastPalette(widget.status);
+        widget.palette;
     return Positioned(
       bottom: 50,
       left: 0,

--- a/hibiki/lib/src/utils/misc/toast_severity.dart
+++ b/hibiki/lib/src/utils/misc/toast_severity.dart
@@ -40,7 +40,8 @@ enum ToastSeverity { neutral, info, success, warning, error }
     case ToastSeverity.warning:
       return (
         background: const Color(0xFFEF6C00), // orange 800
-        foreground: Colors.white,
+        // orange 800 配白字仅约 3.08:1；黑字约 6.81:1，满足普通正文 4.5:1。
+        foreground: Colors.black,
         icon: Icons.warning_amber_rounded,
       );
     case ToastSeverity.error:
@@ -78,7 +79,7 @@ enum MineToastStatus { added, duplicate, failed, pending }
     case MineToastStatus.duplicate:
       return (
         background: const Color(0xFFEF6C00), // orange 800
-        foreground: Colors.white,
+        foreground: Colors.black,
         icon: Icons.library_add_check_rounded,
       );
     case MineToastStatus.failed:

--- a/hibiki/lib/src/utils/misc/toast_severity.dart
+++ b/hibiki/lib/src/utils/misc/toast_severity.dart
@@ -1,0 +1,112 @@
+/// 应用内短时通知的**语义**与配色，供两套互不相干的通知系统共用：
+/// 底部 [HibikiToast]（`hibiki_toast.dart`）与视频页左上角 OSD
+/// （`video_hibiki/volume_osd.part.dart`）。
+///
+/// 独立成文件而不是塞进 `hibiki_toast.dart`：视频页有一条守卫测试禁止它出现
+/// `HibikiToast.show`（BUG-931，两套通知必须各归各位），若语义枚举住在 toast 文件
+/// 里，视频页就得为了一个枚举 import 整套 toast API——那正是守卫想避免的耦合。
+///
+/// 背景：改这套之前，326 个 `HibikiToast.show` 里 325 个走默认无色（其中 170 余条
+/// 是失败、70 余条是成功），70 个 `_showOsd` 100% 无色，只有 18 个制卡 toast 有颜色。
+/// 用户只能靠读文字分辨「成了还是崩了」。
+library;
+
+import 'package:flutter/material.dart';
+
+/// 通知语义。
+///
+/// [neutral] 保留旧观感（主题 inverseSurface / OSD 灰，无图标），用于纯信息提示。
+enum ToastSeverity { neutral, info, success, warning, error }
+
+/// 把 [ToastSeverity] 映射成 (背景色, 前景色, 图标)。[ToastSeverity.neutral] 返回
+/// null＝不着色，交回各系统的主题默认（旧行为）。
+///
+/// 用固定 Material 800 色阶而非主题取色：保证四态在任意主题下语义清晰、对比达标，
+/// 也让无 BuildContext 的降级路径（独立弹窗 Activity 的原生 toast）能复用同一配色。
+/// **每态都带图标**——e-ink（灰阶）与色觉障碍下颜色会塌掉，图标形状是那时唯一的
+/// 区分手段（与 `game_diagnostics_page` 的 e-ink 降级同口径）。
+({Color background, Color foreground, IconData icon})? toastSeverityPalette(
+  ToastSeverity severity,
+) {
+  switch (severity) {
+    case ToastSeverity.neutral:
+      return null;
+    case ToastSeverity.success:
+      return (
+        background: const Color(0xFF2E7D32), // green 800
+        foreground: Colors.white,
+        icon: Icons.check_circle_rounded,
+      );
+    case ToastSeverity.warning:
+      return (
+        background: const Color(0xFFEF6C00), // orange 800
+        foreground: Colors.white,
+        icon: Icons.warning_amber_rounded,
+      );
+    case ToastSeverity.error:
+      return (
+        background: const Color(0xFFC62828), // red 800
+        foreground: Colors.white,
+        icon: Icons.error_rounded,
+      );
+    case ToastSeverity.info:
+      return (
+        background: const Color(0xFF1565C0), // blue 800
+        foreground: Colors.white,
+        icon: Icons.info_rounded,
+      );
+  }
+}
+
+/// TODO-1325 #6: 制卡结果 toast 的语义状态。决定 MD3 toast 的着色与 Material 图标，
+/// 让「加入了 / 已存在 / 失败 / 制卡中」一眼可辨，而不再只靠弹窗里 mine 按钮的图标变化。
+enum MineToastStatus { added, duplicate, failed, pending }
+
+/// 把 [MineToastStatus] 映射成 toast 的 (背景色, 前景色, 图标)。用固定 Material 色阶
+/// （绿/橙/红/蓝）而非主题取色，保证四态在任意主题下都语义清晰、对比达标；也让无
+/// BuildContext 的降级路径（独立弹窗 Activity）能直接复用同一配色。
+({Color background, Color foreground, IconData icon}) mineToastPalette(
+  MineToastStatus status,
+) {
+  switch (status) {
+    case MineToastStatus.added:
+      return (
+        background: const Color(0xFF2E7D32), // green 800
+        foreground: Colors.white,
+        icon: Icons.check_circle_rounded,
+      );
+    case MineToastStatus.duplicate:
+      return (
+        background: const Color(0xFFEF6C00), // orange 800
+        foreground: Colors.white,
+        icon: Icons.library_add_check_rounded,
+      );
+    case MineToastStatus.failed:
+      return (
+        background: const Color(0xFFC62828), // red 800
+        foreground: Colors.white,
+        icon: Icons.error_rounded,
+      );
+    case MineToastStatus.pending:
+      return (
+        background: const Color(0xFF1565C0), // blue 800
+        foreground: Colors.white,
+        icon: Icons.sync_rounded,
+      );
+  }
+}
+
+/// 制卡状态 → 通用语义。让视频页左上角 OSD 与底部制卡 toast 说同一门颜色语言
+/// （`duplicate` 是「已存在」而非失败，落在 warning 而不是 error）。
+ToastSeverity mineToastSeverity(MineToastStatus status) {
+  switch (status) {
+    case MineToastStatus.added:
+      return ToastSeverity.success;
+    case MineToastStatus.duplicate:
+      return ToastSeverity.warning;
+    case MineToastStatus.failed:
+      return ToastSeverity.error;
+    case MineToastStatus.pending:
+      return ToastSeverity.info;
+  }
+}

--- a/hibiki/test/helpers/source_guard.dart
+++ b/hibiki/test/helpers/source_guard.dart
@@ -192,6 +192,13 @@ String maskComments(String source) => _mask(
       maskStringContent: false,
     );
 
+/// 把注释掩掉后折叠全部空白，供必须跨 `dart format` 换行匹配的源码守卫使用。
+///
+/// 不能让消费端直接对原源码 `replaceAll(RegExp(r'\s+'), '')`：那会把注释里的
+/// needle 一并折进语料，删掉真实实现、只留同文字注释时仍然假绿。
+String compactCode(String source) =>
+    maskComments(source).replaceAll(RegExp(r'\s+'), '');
+
 /// 同 [maskComments]，并把字符串字面量的内容也换成空白。
 ///
 /// 用于花括号 / 圆括号配对这类**结构**扫描：串里的花括号（尤其是三引号里注入的

--- a/hibiki/test/helpers/source_guard_lexer_test.dart
+++ b/hibiki/test/helpers/source_guard_lexer_test.dart
@@ -66,6 +66,37 @@ final b = \'\'\'{ js }\'\'\';
     });
   });
 
+  group('compactCode', () {
+    const String needle = 'HibikiToast.show(msg: t.failed,';
+
+    test('跨 dart format 换行仍命中真实调用', () {
+      const String src = '''
+HibikiToast.show(
+  msg: t.failed,
+  severity: ToastSeverity.error,
+);
+''';
+      expect(compactCode(src), contains(compactCode(needle)));
+    });
+
+    test('整行、行尾与块注释里的调用均不命中', () {
+      for (final String src in <String>[
+        '// HibikiToast.show(msg: t.failed, severity: ToastSeverity.error);',
+        'final ok = true; // HibikiToast.show(msg: t.failed,',
+        '/*\nHibikiToast.show(msg: t.failed, severity: x);\n*/',
+      ]) {
+        expect(compactCode(src), isNot(contains(compactCode(needle))),
+            reason: src);
+      }
+    });
+
+    test('needle 的右边界标点防止 i18n key 前缀假绿', () {
+      const String renamed =
+          'HibikiToast.show(msg: t.failed_v2, severity: ToastSeverity.error);';
+      expect(compactCode(renamed), isNot(contains(compactCode(needle))));
+    });
+  });
+
   group('③ 块注释', () {
     test('单行块注释里的字面量不算命中', () {
       expect(containsCodeLine('/* needleToken */\n', 'needleToken'), isFalse);

--- a/hibiki/test/media/import/import_flow_mixin_test.dart
+++ b/hibiki/test/media/import/import_flow_mixin_test.dart
@@ -189,10 +189,20 @@ void main() {
         reason: 'runImport 的 catch 必须以 logTag 落 ErrorLogService',
       );
       expect(
-        source.contains(r"HibikiToast.show(msg: '${t.srt_import_error}: $e')"),
+        _squashWs(source).contains(
+          _squashWs(r"HibikiToast.show(msg: '${t.srt_import_error}: $e'"),
+        ),
         isTrue,
         reason: 'runImport 的 catch 必须给用户失败提示（toast）',
       );
     });
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
+/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
+/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/media/import/import_flow_mixin_test.dart
+++ b/hibiki/test/media/import/import_flow_mixin_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/import/import_flow_mixin.dart';
 import 'package:hibiki/utils.dart';
 
+import '../../helpers/source_guard.dart';
+
 /// 最小宿主：把 [ImportFlowMixin] 接进来，按 `importing` 渲染进度块，
 /// 用以验证 mixin 的写入器 + 渲染契约（书/有声书/视频导入对话框共享的真行为），
 /// 以及 [ImportFlowMixin.runImport] 模板的错误处理契约（审计 §1-K / BUG-1117：
@@ -189,8 +191,8 @@ void main() {
         reason: 'runImport 的 catch 必须以 logTag 落 ErrorLogService',
       );
       expect(
-        _squashWs(source).contains(
-          _squashWs(r"HibikiToast.show(msg: '${t.srt_import_error}: $e'"),
+        compactCode(source).contains(
+          compactCode(r"HibikiToast.show(msg: '${t.srt_import_error}: $e',"),
         ),
         isTrue,
         reason: 'runImport 的 catch 必须给用户失败提示（toast）',
@@ -198,11 +200,3 @@ void main() {
     });
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
-/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
-/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/media/manga/manga_ocr_wizard_remote_test.dart
+++ b/hibiki/test/media/manga/manga_ocr_wizard_remote_test.dart
@@ -133,6 +133,7 @@ void main() {
     required _FakeRemoteRunner remote,
     MangaOcrImportRunner? importOverride,
     GoogleLensMangaOcrRunner? lensRunner,
+    String? initialEnginePreference,
   }) async {
     String? popped;
     final Widget app = ProviderScope(
@@ -149,6 +150,7 @@ void main() {
                         service: _UnsupportedOcrService(),
                         remoteRunner: remote,
                         lensRunner: lensRunner,
+                        initialEnginePreference: initialEnginePreference,
                       ),
                       db: db,
                       initialImageDir: imageDir.path,
@@ -304,6 +306,34 @@ void main() {
 
     expect(find.text(t.manga_remote_ocr_engine), findsNothing);
     expect(find.text(t.manga_ocr_engine_none), findsOneWidget);
+    final Finder runBtn =
+        find.widgetWithText(FilledButton, t.manga_ocr_wizard_run);
+    expect(tester.widget<FilledButton>(runBtn).onPressed, isNull);
+  });
+
+  testWidgets(
+      'explicit pairedHost stays represented and disabled while host is offline',
+      (WidgetTester tester) async {
+    final _FakeRemoteRunner remote = _FakeRemoteRunner(target: null);
+    await pumpWizard(
+      tester,
+      remote: remote,
+      lensRunner: _NoopLensRunner(),
+      initialEnginePreference: MangaOcrEnginePreference.pairedHost.key,
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+
+    final SegmentedButton<MangaOcrEngineId> selector =
+        tester.widget<SegmentedButton<MangaOcrEngineId>>(
+            find.byType(SegmentedButton<MangaOcrEngineId>));
+    final ButtonSegment<MangaOcrEngineId> paired = selector.segments.firstWhere(
+      (ButtonSegment<MangaOcrEngineId> segment) =>
+          segment.value == MangaOcrEngineId.pairedHost,
+    );
+    expect(paired.enabled, isFalse);
+    expect(selector.selected, <MangaOcrEngineId>{MangaOcrEngineId.pairedHost});
     final Finder runBtn =
         find.widgetWithText(FilledButton, t.manga_ocr_wizard_run);
     expect(tester.widget<FilledButton>(runBtn).onPressed, isNull);

--- a/hibiki/test/media/manga/manga_overlay_html_test.dart
+++ b/hibiki/test/media/manga/manga_overlay_html_test.dart
@@ -801,6 +801,9 @@ void main() {
       expect(doc.contains("e.pointerType === 'touch'"), isTrue,
           reason: '必须自己处理触点，浏览器原生缩放被 user-scalable=no 禁掉了');
       expect(doc.contains('_pinchGeom'), isTrue, reason: '必须有双指捏合几何');
+      expect(
+          doc.contains('Math.pow(g.dist / pinch.dist, ZOOM_SENS)'), isTrue,
+          reason: '灵敏度设置声明覆盖滚轮与捏合，pinch 比率也必须应用 ZOOM_SENS');
       expect(doc.contains("addEventListener('pointermove'"), isTrue,
           reason: '捏合需要 pointermove 才能跟手');
     });

--- a/hibiki/test/media/manga/manga_overlay_html_test.dart
+++ b/hibiki/test/media/manga/manga_overlay_html_test.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/media/manga/manga_overlay_html.dart';
 import 'package:hibiki/src/media/manga/manga_reading_mode.dart';
+import 'package:hibiki/src/media/manga/manga_view_prefs.dart';
 import 'package:hibiki/src/media/manga/mokuro_payload.dart';
 import 'package:hibiki/src/reader/reader_selection_scripts.dart';
 
@@ -618,8 +619,14 @@ void main() {
       // wheel 回调必须 preventDefault（overflow:hidden 视口下消除无操作反馈）并按
       // deltaY 符号报 next/prev。
       expect(doc.contains('e.preventDefault()'), isTrue);
-      expect(doc.contains("d > 0 ? 'next' : 'prev'"), isTrue,
+      expect(doc.contains("dir > 0 ? 'next' : 'prev'"), isTrue,
           reason: 'wheel 必须按滚动方向报 next/prev');
+      // 翻页触发按**累计位移**而非「一个事件 = 一页」：鼠标一格立即翻，触控板碎
+      // delta 攒够才翻。旧实现首个事件就翻 + 320ms 全禁，滚轮上限约 3 页/秒。
+      expect(doc.contains('_wheelAccum'), isTrue,
+          reason: '滚轮翻页必须按累计 delta 触发，不能一个事件翻一页');
+      expect(doc.contains('_wheelLock = false; }, 110)'), isTrue,
+          reason: '滚轮合并窗口 110ms（旧 320ms 把翻页上限压到约 3 页/秒）');
     });
 
     test('webtoon IS_WEBTOON=true 运行时跳过 wheel→翻页（保留原生竖滚，BUG-051）', () {
@@ -761,11 +768,83 @@ void main() {
         inlineSelectionJs: '',
         zoomPercent: 100,
       );
-      expect(doc.contains('Math.min(2, Math.max(0.5'), isTrue);
+      // 缩放边界由参数注入（默认 50%..400%），不再是写死的 0.5/2。
+      expect(doc.contains('var ZOOM_MIN = 0.5;'), isTrue);
+      expect(doc.contains('var ZOOM_MAX = 4.0;'), isTrue);
       expect(doc.contains('rightDrag.startX) > 4'), isTrue);
       expect(doc.contains("callHandler('onMangaContextMenu'"), isTrue);
       expect(doc.contains("callHandler('onMangaZoomChanged'"), isTrue);
       expect(doc.contains('e.ctrlKey || e.metaKey'), isTrue);
+      // 滚轮缩放必须按 deltaY **幅值**做乘法缩放。旧实现只取符号、恒 ±0.1 加法步长
+      // （触控板与鼠标同等对待 + 高倍率下相对变化越来越小）＝「缩放极其不灵敏」。
+      expect(doc.contains('Math.exp(steps * 0.2 * ZOOM_SENS)'), isTrue,
+          reason: '滚轮缩放必须是按 delta 幅值的乘法缩放，不能是定长加法');
+      expect(doc.contains('e.deltaMode === 1'), isTrue,
+          reason: 'deltaMode 必须归一化，否则行/页模式步长完全不同');
+    });
+
+    test('缩放范围与灵敏度随参数注入，触屏有捏合缩放', () {
+      final String doc = mangaWindowDocument(
+        <MokuroImage>[_pageWithTwoBlocks()],
+        <String>['p.jpg'],
+        mode: MangaReadingMode.spread,
+        spreadDirection: 'rtl',
+        inlineSelectionJs: '',
+        zoomPercent: 100,
+        zoomMaxPercent: 300,
+        zoomSensitivity: 200,
+      );
+      expect(doc.contains('var ZOOM_MAX = 3.0;'), isTrue);
+      expect(doc.contains('var ZOOM_SENS = 2.0;'), isTrue);
+      // 触屏此前完全无法缩放：viewport 是 user-scalable=no（必须，否则浏览器原生
+      // 缩放与 #manga-canvas 的 transform 打架），而 JS 侧没有任何多指处理。
+      expect(doc.contains("e.pointerType === 'touch'"), isTrue,
+          reason: '必须自己处理触点，浏览器原生缩放被 user-scalable=no 禁掉了');
+      expect(doc.contains('_pinchGeom'), isTrue, reason: '必须有双指捏合几何');
+      expect(doc.contains("addEventListener('pointermove'"), isTrue,
+          reason: '捏合需要 pointermove 才能跟手');
+    });
+
+    test('点击边缘翻页可关，且方向随 RTL 镜像', () {
+      String docFor({required bool tapZonePaging, required String direction}) =>
+          mangaWindowDocument(
+            <MokuroImage>[_pageWithTwoBlocks()],
+            <String>['p.jpg'],
+            mode: MangaReadingMode.spread,
+            spreadDirection: direction,
+            inlineSelectionJs: '',
+            tapZonePaging: tapZonePaging,
+          );
+      final String on = docFor(tapZonePaging: true, direction: 'rtl');
+      expect(on.contains('var TAP_ZONE_PAGING = true;'), isTrue);
+      expect(on.contains('var IS_RTL = true;'), isTrue);
+      // RTL 下左边缘前进（LTR 相反）——同一份 JS 靠 IS_RTL 分流。
+      expect(on.contains("IS_RTL ? 'next' : 'prev'"), isTrue);
+      final String off = docFor(tapZonePaging: false, direction: 'ltr');
+      expect(off.contains('var TAP_ZONE_PAGING = false;'), isTrue);
+      expect(off.contains('var IS_RTL = false;'), isTrue);
+    });
+
+    test('翻页动画偏好决定 #manga-root 过渡声明', () {
+      String docFor(MangaPageAnimation animation) => mangaWindowDocument(
+            <MokuroImage>[_pageWithTwoBlocks()],
+            <String>['p.jpg'],
+            mode: MangaReadingMode.spread,
+            spreadDirection: 'rtl',
+            inlineSelectionJs: '',
+            pageAnimation: animation,
+          );
+      expect(docFor(MangaPageAnimation.slide).contains('transition:transform '),
+          isTrue);
+      // none = 完全不声明过渡（要极限响应的用户）。
+      final String none = docFor(MangaPageAnimation.none);
+      expect(none.contains('transition:transform '), isFalse);
+      expect(none.contains('transition:opacity '), isFalse);
+      // fade 只过渡 opacity，位移在淡出后瞬时完成，否则会同时看到滑动与淡入淡出。
+      final String fade = docFor(MangaPageAnimation.fade);
+      expect(fade.contains('transition:opacity '), isTrue);
+      expect(fade.contains('transition:transform '), isFalse);
+      expect(fade.contains("PAGE_ANIM !== 'fade'"), isTrue);
     });
 
     test('window document exposes its navigation generation', () {

--- a/hibiki/test/media/manga/manga_volume_key_paging_controller_test.dart
+++ b/hibiki/test/media/manga/manga_volume_key_paging_controller_test.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/reader/manga_volume_key_paging_controller.dart';
+import 'package:hibiki/src/utils/misc/channel_constants.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final TestDefaultBinaryMessenger messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  const StandardMethodCodec codec = StandardMethodCodec();
+
+  Future<void> sendNative(String method) async {
+    final Completer<void> replied = Completer<void>();
+    messenger.handlePlatformMessage(
+      HibikiChannels.volumeKeys.name,
+      codec.encodeMethodCall(MethodCall(method)),
+      (_) => replied.complete(),
+    );
+    await replied.future;
+  }
+
+  test('Android ownership, repeat throttling and release use the real channel',
+      () async {
+    final List<MethodCall> outbound = <MethodCall>[];
+    messenger.setMockMethodCallHandler(HibikiChannels.volumeKeys, (call) async {
+      outbound.add(call);
+      return null;
+    });
+    addTearDown(() {
+      messenger.setMockMethodCallHandler(HibikiChannels.volumeKeys, null);
+    });
+
+    DateTime now = DateTime(2026);
+    final List<String> turns = <String>[];
+    final MangaVolumeKeyPagingController controller =
+        MangaVolumeKeyPagingController(
+      onPrevious: () => turns.add('previous'),
+      onNext: () => turns.add('next'),
+      now: () => now,
+    );
+
+    controller.apply(enabled: true, platformSupported: true);
+    await Future<void>.delayed(Duration.zero);
+    expect(outbound, <MethodCall>[
+      const MethodCall('setInterceptEnabled', true),
+    ]);
+
+    await sendNative('onVolumeDown');
+    await sendNative('onVolumeDown');
+    expect(turns, <String>['next'], reason: '同一 ACTION_DOWN repeat 不得堆满队列');
+
+    now = now.add(const Duration(milliseconds: 180));
+    await sendNative('onVolumeUp');
+    expect(turns, <String>['next', 'previous']);
+
+    controller.dispose();
+    await Future<void>.delayed(Duration.zero);
+    expect(outbound.last, const MethodCall('setInterceptEnabled', false));
+    await sendNative('onVolumeDown');
+    expect(turns, <String>['next', 'previous'], reason: '销毁后 handler 必须已清空');
+  });
+
+  test('unsupported platform never takes native ownership', () async {
+    final List<MethodCall> outbound = <MethodCall>[];
+    messenger.setMockMethodCallHandler(HibikiChannels.volumeKeys, (call) async {
+      outbound.add(call);
+      return null;
+    });
+    addTearDown(() {
+      messenger.setMockMethodCallHandler(HibikiChannels.volumeKeys, null);
+    });
+    final MangaVolumeKeyPagingController controller =
+        MangaVolumeKeyPagingController(onPrevious: () {}, onNext: () {});
+    controller.apply(enabled: true, platformSupported: false);
+    await Future<void>.delayed(Duration.zero);
+    expect(outbound, isEmpty);
+  });
+}

--- a/hibiki/test/media/manga/manga_zoom_preference_debouncer_test.dart
+++ b/hibiki/test/media/manga/manga_zoom_preference_debouncer_test.dart
@@ -1,0 +1,40 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/manga/reader/manga_zoom_preference_debouncer.dart';
+
+void main() {
+  test('high-frequency zoom callbacks persist only the trailing value', () {
+    fakeAsync((FakeAsync async) {
+      final List<int> writes = <int>[];
+      final MangaZoomPreferenceDebouncer debouncer =
+          MangaZoomPreferenceDebouncer(
+        persist: (int value) async => writes.add(value),
+      );
+
+      for (int value = 101; value <= 350; value++) {
+        debouncer.queue(value);
+      }
+      async.elapse(const Duration(milliseconds: 249));
+      expect(writes, isEmpty);
+      async.elapse(const Duration(milliseconds: 1));
+      async.flushMicrotasks();
+      expect(writes, <int>[350]);
+    });
+  });
+
+  test('dispose flushes the final pending zoom instead of losing it', () {
+    fakeAsync((FakeAsync async) {
+      final List<int> writes = <int>[];
+      final MangaZoomPreferenceDebouncer debouncer =
+          MangaZoomPreferenceDebouncer(
+        persist: (int value) async => writes.add(value),
+      );
+      debouncer.queue(275);
+      debouncer.dispose();
+      async.flushMicrotasks();
+      expect(writes, <int>[275]);
+      async.elapse(const Duration(seconds: 1));
+      expect(writes, <int>[275]);
+    });
+  });
+}

--- a/hibiki/test/pages/anki_mined_card_action_wiring_static_test.dart
+++ b/hibiki/test/pages/anki_mined_card_action_wiring_static_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// TODO-1007/1008：「点 ✓ 弹操作选择（覆写/新增重复卡/查看·在 Anki 中打开）」可达性
 /// 链路的源码守卫。锁住 minedCardAction 在 popup.js → webview → layer → 两条宿主车道
 /// （mixin / base_source_page）全程接线，避免任一层漏接导致点 ✓ 又回到「静默无反应」。
@@ -169,10 +171,10 @@ void main() {
       reason: '三处宿主回调 await 必须各有 try',
     );
     // catch 块固定形态：复位 _busy（避免卡死）+ 弹失败反馈。三处都必须出现这条收口。
-    final String catchReset = _squashWs('setState(() => _busy = false); '
-        'HibikiToast.show(msg: t.anki_card_action_failed');
+    final String catchReset = compactCode('setState(() => _busy = false); '
+        'HibikiToast.show(msg: t.anki_card_action_failed,');
     expect(
-      catchReset.allMatches(_squashWs(src)).length,
+      catchReset.allMatches(compactCode(src)).length,
       3,
       reason: '三处 catch 必须复位 _busy 并弹 anki_card_action_failed 反馈',
     );
@@ -180,11 +182,3 @@ void main() {
     expect(src.contains('} catch (e) {'), isTrue);
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
-/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
-/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/anki_mined_card_action_wiring_static_test.dart
+++ b/hibiki/test/pages/anki_mined_card_action_wiring_static_test.dart
@@ -169,10 +169,10 @@ void main() {
       reason: '三处宿主回调 await 必须各有 try',
     );
     // catch 块固定形态：复位 _busy（避免卡死）+ 弹失败反馈。三处都必须出现这条收口。
-    const String catchReset =
-        'setState(() => _busy = false);\n      HibikiToast.show(msg: t.anki_card_action_failed);';
+    final String catchReset = _squashWs('setState(() => _busy = false); '
+        'HibikiToast.show(msg: t.anki_card_action_failed');
     expect(
-      catchReset.allMatches(src).length,
+      catchReset.allMatches(_squashWs(src)).length,
       3,
       reason: '三处 catch 必须复位 _busy 并弹 anki_card_action_failed 反馈',
     );
@@ -180,3 +180,11 @@ void main() {
     expect(src.contains('} catch (e) {'), isTrue);
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
+/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
+/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/favorite_word_toast_test.dart
+++ b/hibiki/test/pages/favorite_word_toast_test.dart
@@ -71,14 +71,17 @@ void main() {
           File('lib/src/pages/base_source_page.dart').readAsStringSync();
       final int handlerStart = src.indexOf('Future<bool> onFavoriteFromPopup(');
       expect(handlerStart, greaterThan(0));
-      final String body = src.substring(handlerStart);
-      expect(body, contains('HibikiToast.show(msg: t.word_favorite_added)'),
+      final String body = _squashWs(src.substring(handlerStart));
+      expect(body,
+          contains(_squashWs('HibikiToast.show(msg: t.word_favorite_added')),
           reason: '收藏成功后必须弹「已收藏」toast');
-      expect(body, contains('HibikiToast.show(msg: t.word_favorite_removed)'),
+      expect(body,
+          contains(_squashWs('HibikiToast.show(msg: t.word_favorite_removed')),
           reason: '取消收藏后必须弹「已取消收藏」toast');
       expect(
         body.indexOf('addFavoriteWord(') <
-            body.indexOf('HibikiToast.show(msg: t.word_favorite_added)'),
+            body.indexOf(
+                _squashWs('HibikiToast.show(msg: t.word_favorite_added')),
         isTrue,
         reason: 'add 的 toast 必须在 addFavoriteWord 写库之后（解耦于返回值通道）',
       );
@@ -90,14 +93,25 @@ void main() {
               .readAsStringSync();
       final int handlerStart = src.indexOf('Future<bool> onFavoriteEntry(');
       expect(handlerStart, greaterThan(0));
-      final String body = src.substring(handlerStart);
-      expect(body, contains('HibikiToast.show(msg: t.word_favorite_added)'));
-      expect(body, contains('HibikiToast.show(msg: t.word_favorite_removed)'));
+      final String body = _squashWs(src.substring(handlerStart));
+      expect(body,
+          contains(_squashWs('HibikiToast.show(msg: t.word_favorite_added')));
+      expect(body,
+          contains(_squashWs('HibikiToast.show(msg: t.word_favorite_removed')));
       expect(
         body.indexOf('addFavoriteWord(') <
-            body.indexOf('HibikiToast.show(msg: t.word_favorite_added)'),
+            body.indexOf(
+                _squashWs('HibikiToast.show(msg: t.word_favorite_added')),
         isTrue,
       );
     });
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行调用换成
+/// 多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然要求同一
+/// 函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/favorite_word_toast_test.dart
+++ b/hibiki/test/pages/favorite_word_toast_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/src/utils/misc/hibiki_toast.dart';
 
+import '../helpers/source_guard.dart';
+
 // TODO-956 A：右部词条收藏「点了没用」的真因 = 唯一反馈是 popup.css 的 ☆→★ 变色，
 // 而该变色依赖 popup.js `nowFav = await callHandler('favoriteEntry')` 的返回值往返；
 // 桌面 flutter_inappwebview_windows fork 的 callHandler 返回值 marshalling 与移动端
@@ -71,17 +73,17 @@ void main() {
           File('lib/src/pages/base_source_page.dart').readAsStringSync();
       final int handlerStart = src.indexOf('Future<bool> onFavoriteFromPopup(');
       expect(handlerStart, greaterThan(0));
-      final String body = _squashWs(src.substring(handlerStart));
+      final String body = compactCode(src.substring(handlerStart));
       expect(body,
-          contains(_squashWs('HibikiToast.show(msg: t.word_favorite_added')),
+          contains(compactCode('HibikiToast.show(msg: t.word_favorite_added,')),
           reason: '收藏成功后必须弹「已收藏」toast');
       expect(body,
-          contains(_squashWs('HibikiToast.show(msg: t.word_favorite_removed')),
+          contains(compactCode('HibikiToast.show(msg: t.word_favorite_removed,')),
           reason: '取消收藏后必须弹「已取消收藏」toast');
       expect(
         body.indexOf('addFavoriteWord(') <
             body.indexOf(
-                _squashWs('HibikiToast.show(msg: t.word_favorite_added')),
+                compactCode('HibikiToast.show(msg: t.word_favorite_added,')),
         isTrue,
         reason: 'add 的 toast 必须在 addFavoriteWord 写库之后（解耦于返回值通道）',
       );
@@ -93,25 +95,17 @@ void main() {
               .readAsStringSync();
       final int handlerStart = src.indexOf('Future<bool> onFavoriteEntry(');
       expect(handlerStart, greaterThan(0));
-      final String body = _squashWs(src.substring(handlerStart));
+      final String body = compactCode(src.substring(handlerStart));
       expect(body,
-          contains(_squashWs('HibikiToast.show(msg: t.word_favorite_added')));
+          contains(compactCode('HibikiToast.show(msg: t.word_favorite_added,')));
       expect(body,
-          contains(_squashWs('HibikiToast.show(msg: t.word_favorite_removed')));
+          contains(compactCode('HibikiToast.show(msg: t.word_favorite_removed,')));
       expect(
         body.indexOf('addFavoriteWord(') <
             body.indexOf(
-                _squashWs('HibikiToast.show(msg: t.word_favorite_added')),
+                compactCode('HibikiToast.show(msg: t.word_favorite_added,')),
         isTrue,
       );
     });
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行调用换成
-/// 多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然要求同一
-/// 函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/manga_hibiki_page_test.dart
+++ b/hibiki/test/pages/manga_hibiki_page_test.dart
@@ -13,6 +13,7 @@ import 'package:hibiki/models.dart';
 import 'package:hibiki/src/media/manga/manga_ocr_provider.dart';
 import 'package:hibiki/src/media/manga/manga_overlay_html.dart';
 import 'package:hibiki/src/media/manga/manga_reading_mode.dart';
+import 'package:hibiki/src/media/manga/manga_view_prefs.dart';
 import 'package:hibiki/src/media/manga/mokuro_payload.dart';
 import 'package:hibiki/src/media/media_item.dart';
 import 'package:hibiki/src/ocr/manga_ocr_service.dart';
@@ -56,6 +57,21 @@ class _MangaTestAppModel extends AppModel {
 
   @override
   int get mangaZoomPercent => 100;
+
+  // 观看偏好同样必须在 fake 上给出真值：AppModel 的这些 getter 都走 prefsRepo，
+  // 而测试里 _prefsRepo 是 null（`prefsRepo` 是 `_prefsRepo!`）。漏一个就在
+  // _loadBook 里抛 _TypeError，表现为页面永远不 ready。
+  @override
+  int get mangaZoomSensitivity => kMangaZoomSensitivityDefault;
+
+  @override
+  String get mangaPageAnimation => MangaPageAnimation.slide.key;
+
+  @override
+  bool get mangaTapZonePaging => true;
+
+  @override
+  bool get mangaVolumeKeyPaging => false;
 }
 
 /// 整卷 OCR 入口测试用 fake 服务（只有 modelStatus 有意义）。

--- a/hibiki/test/pages/manga_spread_double_page_test.dart
+++ b/hibiki/test/pages/manga_spread_double_page_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/i18n/strings.g.dart';
 import 'package:hibiki/models.dart';
 import 'package:hibiki/src/media/manga/manga_spread_model.dart';
+import 'package:hibiki/src/media/manga/manga_view_prefs.dart';
 import 'package:hibiki/src/media/media_item.dart';
 import 'package:hibiki/src/pages/implementations/manga_hibiki_page.dart';
 import 'package:hibiki_audio/hibiki_audio.dart';
@@ -54,6 +55,21 @@ class _MangaTestAppModel extends AppModel {
 
   @override
   int get mangaZoomPercent => 100;
+
+  // 观看偏好同样必须在 fake 上给出真值：AppModel 这些 getter 都走 prefsRepo，
+  // 而测试里 _prefsRepo 是 null（`prefsRepo` 是 `_prefsRepo!`）。漏一个就在
+  // _loadBook 里抛 _TypeError，表现为页面永远不 ready。
+  @override
+  int get mangaZoomSensitivity => kMangaZoomSensitivityDefault;
+
+  @override
+  String get mangaPageAnimation => MangaPageAnimation.slide.key;
+
+  @override
+  bool get mangaTapZonePaging => true;
+
+  @override
+  bool get mangaVolumeKeyPaging => false;
 }
 
 Widget _harness(AppModel appModel, String bookKey) {

--- a/hibiki/test/pages/mine_toast_test.dart
+++ b/hibiki/test/pages/mine_toast_test.dart
@@ -46,8 +46,15 @@ void main() {
     expect(mineToastPalette(MineToastStatus.failed).icon, Icons.error_rounded);
     expect(mineToastPalette(MineToastStatus.pending).background,
         const Color(0xFF1565C0));
-    // 前景统一白色（保证四种状态色上的对比）。
-    for (final MineToastStatus s in MineToastStatus.values) {
+    // orange 800 配白字只有 3.08:1；duplicate/warning 用黑字达到 6.81:1。
+    expect(mineToastPalette(MineToastStatus.duplicate).foreground, Colors.black);
+    expect(toastSeverityPalette(ToastSeverity.warning)?.foreground,
+        Colors.black);
+    for (final MineToastStatus s in <MineToastStatus>[
+      MineToastStatus.added,
+      MineToastStatus.failed,
+      MineToastStatus.pending,
+    ]) {
       expect(mineToastPalette(s).foreground, Colors.white);
     }
   });

--- a/hibiki/test/pages/reader_webview_creation_recovery_guard_static_test.dart
+++ b/hibiki/test/pages/reader_webview_creation_recovery_guard_static_test.dart
@@ -79,7 +79,9 @@ void main() {
     expect(block.contains('kReaderWebViewCreationFailedSentinel'), isTrue,
         reason: 'onReceivedError 必须先判 sentinel 区分创建失败');
     expect(
-        block.contains('HibikiToast.show(msg: t.reader_open_failed)'), isTrue,
+        _squashWs(block)
+            .contains(_squashWs('HibikiToast.show(msg: t.reader_open_failed')),
+        isTrue,
         reason: '命中创建失败必须提示用户打开失败');
     expect(block.contains('Navigator.of(context).pop()'), isTrue,
         reason: '命中创建失败必须退回书架，不让 spinner 永挂');
@@ -87,3 +89,11 @@ void main() {
         reason: 'setState/Navigator 前必须 mounted 守卫');
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
+/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
+/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/reader_webview_creation_recovery_guard_static_test.dart
+++ b/hibiki/test/pages/reader_webview_creation_recovery_guard_static_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// TODO-904 源码守卫：阅读器正文 WebView native 实例创建失败时可见恢复，不再永久 spinner。
 ///
 /// 根因：Windows 反复开关书后 native WebView2 实例创建失败抛
@@ -79,8 +81,8 @@ void main() {
     expect(block.contains('kReaderWebViewCreationFailedSentinel'), isTrue,
         reason: 'onReceivedError 必须先判 sentinel 区分创建失败');
     expect(
-        _squashWs(block)
-            .contains(_squashWs('HibikiToast.show(msg: t.reader_open_failed')),
+        compactCode(block)
+            .contains(compactCode('HibikiToast.show(msg: t.reader_open_failed,')),
         isTrue,
         reason: '命中创建失败必须提示用户打开失败');
     expect(block.contains('Navigator.of(context).pop()'), isTrue,
@@ -89,11 +91,3 @@ void main() {
         reason: 'setState/Navigator 前必须 mounted 守卫');
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
-/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
-/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/sentence_favorites_todo047_guard_test.dart
+++ b/hibiki/test/pages/sentence_favorites_todo047_guard_test.dart
@@ -186,8 +186,8 @@ void main() {
     test('① 抽音失败(result==null)弹 audio_clip_failed 提示，不再静默(BUG-252)', () {
       // 修前 _playItemAudio 在 result!=null 时才 playFile，else 什么都不做。
       expect(
-        _squashWs(src),
-        contains(_squashWs('HibikiToast.show(msg: t.audio_clip_failed')),
+        compactCode(src),
+        contains(compactCode('HibikiToast.show(msg: t.audio_clip_failed,')),
         reason: 'ffmpeg 抽音失败必须给用户可见反馈，否则点了像没反应',
       );
       // 失败提示必须挂在 extractAudioSegment 返回 null 的 else 分支上。
@@ -259,11 +259,3 @@ void main() {
     });
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
-/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
-/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/sentence_favorites_todo047_guard_test.dart
+++ b/hibiki/test/pages/sentence_favorites_todo047_guard_test.dart
@@ -186,8 +186,8 @@ void main() {
     test('① 抽音失败(result==null)弹 audio_clip_failed 提示，不再静默(BUG-252)', () {
       // 修前 _playItemAudio 在 result!=null 时才 playFile，else 什么都不做。
       expect(
-        src,
-        contains('HibikiToast.show(msg: t.audio_clip_failed)'),
+        _squashWs(src),
+        contains(_squashWs('HibikiToast.show(msg: t.audio_clip_failed')),
         reason: 'ffmpeg 抽音失败必须给用户可见反馈，否则点了像没反应',
       );
       // 失败提示必须挂在 extractAudioSegment 返回 null 的 else 分支上。
@@ -259,3 +259,11 @@ void main() {
     });
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
+/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
+/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/video_favorite_osd_guard_test.dart
+++ b/hibiki/test/pages/video_favorite_osd_guard_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'video_hibiki_page_source_corpus.dart';
+import '../helpers/source_guard.dart';
 
 /// BUG-931：视频播放器里的两个 UX 契约，用源码扫描守卫锁死，防未来重构悄悄回退。
 ///
@@ -45,7 +46,7 @@ void main() {
       );
       // 正向证据：收藏路径确实改走了左上角 OSD。
       expect(
-        _squashWs(body).contains(_squashWs('_showOsd(t.no_sentence_selected')),
+        compactCode(body).contains(compactCode('_showOsd(t.no_sentence_selected,')),
         isTrue,
         reason: '收藏无句可选时应走左上角 `_showOsd`，不是底部 toast。',
       );
@@ -60,20 +61,12 @@ void main() {
             '`HibikiToast.show` 说明有提示回退到了屏幕底部。',
       );
       // 收藏加/移除确实用 OSD（防止有人把提示整个删掉来「绕过」守卫）。
-      expect(_squashWs(src).contains(_squashWs('_showOsd(t.favorite_added')),
+      expect(compactCode(src).contains(compactCode('_showOsd(t.favorite_added,')),
           isTrue,
           reason: '收藏成功应走左上角 `_showOsd(t.favorite_added ...)`。');
-      expect(_squashWs(src).contains(_squashWs('_showOsd(t.favorite_removed')),
+      expect(compactCode(src).contains(compactCode('_showOsd(t.favorite_removed,')),
           isTrue,
           reason: '取消收藏应走左上角 `_showOsd(t.favorite_removed ...)`。');
     });
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
-/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
-/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/video_favorite_osd_guard_test.dart
+++ b/hibiki/test/pages/video_favorite_osd_guard_test.dart
@@ -45,7 +45,7 @@ void main() {
       );
       // 正向证据：收藏路径确实改走了左上角 OSD。
       expect(
-        body.contains('_showOsd(t.no_sentence_selected)'),
+        _squashWs(body).contains(_squashWs('_showOsd(t.no_sentence_selected')),
         isTrue,
         reason: '收藏无句可选时应走左上角 `_showOsd`，不是底部 toast。',
       );
@@ -60,10 +60,20 @@ void main() {
             '`HibikiToast.show` 说明有提示回退到了屏幕底部。',
       );
       // 收藏加/移除确实用 OSD（防止有人把提示整个删掉来「绕过」守卫）。
-      expect(src.contains('_showOsd(t.favorite_added'), isTrue,
+      expect(_squashWs(src).contains(_squashWs('_showOsd(t.favorite_added')),
+          isTrue,
           reason: '收藏成功应走左上角 `_showOsd(t.favorite_added ...)`。');
-      expect(src.contains('_showOsd(t.favorite_removed'), isTrue,
+      expect(_squashWs(src).contains(_squashWs('_showOsd(t.favorite_removed')),
+          isTrue,
           reason: '取消收藏应走左上角 `_showOsd(t.favorite_removed ...)`。');
     });
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
+/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
+/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/video_mining_context_guard_test.dart
+++ b/hibiki/test/pages/video_mining_context_guard_test.dart
@@ -343,9 +343,18 @@ void main() {
         reason: '制卡成功/覆盖消息须由 describeMineOutcome 统一产出（含 deck 名）。');
     // 成功分支发出突出 OSD。
     expect(
-      mineImpl.contains('_showOsd(described.message, prominent: true)'),
+      _squashWs(mineImpl)
+          .contains(_squashWs('_showOsd(described.message, prominent: true')),
       isTrue,
       reason: 'TODO-971：制卡成功须走突出 OSD（prominent: true），不再是易忽略的小角标。',
     );
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
+/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
+/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/video_mining_context_guard_test.dart
+++ b/hibiki/test/pages/video_mining_context_guard_test.dart
@@ -343,18 +343,10 @@ void main() {
         reason: '制卡成功/覆盖消息须由 describeMineOutcome 统一产出（含 deck 名）。');
     // 成功分支发出突出 OSD。
     expect(
-      _squashWs(mineImpl)
-          .contains(_squashWs('_showOsd(described.message, prominent: true')),
+      compactCode(mineImpl)
+          .contains(compactCode('_showOsd(described.message, prominent: true,')),
       isTrue,
       reason: 'TODO-971：制卡成功须走突出 OSD（prominent: true），不再是易忽略的小角标。',
     );
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
-/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
-/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/video_osd_card_created_alignment_guard_test.dart
+++ b/hibiki/test/pages/video_osd_card_created_alignment_guard_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import 'video_hibiki_page_source_corpus.dart';
+import '../helpers/source_guard.dart';
 
 /// TODO-1254：视频制卡成功提示（`card_exported` / `card_overwritten`，走
 /// `_showOsd(..., prominent: true)`）的定位守卫。
@@ -31,8 +32,8 @@ void main() {
   test('制卡成功 OSD 触发保留：_showOsd(described.message, prominent: true)', () {
     // 只改定位、不动内容 / 触发：突出制卡提示仍走 prominent 变体。
     expect(
-      _squashWs(src)
-          .contains(_squashWs('_showOsd(described.message, prominent: true')),
+      compactCode(src)
+          .contains(compactCode('_showOsd(described.message, prominent: true,')),
       isTrue,
       reason: '制卡成功提示必须仍走 prominent OSD（内容 / 触发不得改）',
     );
@@ -62,11 +63,3 @@ void main() {
     );
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
-/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
-/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/pages/video_osd_card_created_alignment_guard_test.dart
+++ b/hibiki/test/pages/video_osd_card_created_alignment_guard_test.dart
@@ -31,7 +31,8 @@ void main() {
   test('制卡成功 OSD 触发保留：_showOsd(described.message, prominent: true)', () {
     // 只改定位、不动内容 / 触发：突出制卡提示仍走 prominent 变体。
     expect(
-      src.contains('_showOsd(described.message, prominent: true);'),
+      _squashWs(src)
+          .contains(_squashWs('_showOsd(described.message, prominent: true')),
       isTrue,
       reason: '制卡成功提示必须仍走 prominent OSD（内容 / 触发不得改）',
     );
@@ -61,3 +62,11 @@ void main() {
     );
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
+/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
+/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/reader/reader_mining_audio_guard_test.dart
+++ b/hibiki/test/reader/reader_mining_audio_guard_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import '../pages/reader_hibiki_page_source_corpus.dart';
+import '../helpers/source_guard.dart';
 
 void main() {
   group('reader mining context guard', () {
@@ -208,10 +209,10 @@ void main() {
       final String source = readReaderPageSource();
 
       expect(
-        _squashWs(source),
+        compactCode(source),
         contains(
-          _squashWs(
-              'HibikiToast.show(msg: t.card_mined_without_sentence_audio'),
+          compactCode(
+              'HibikiToast.show(msg: t.card_mined_without_sentence_audio,'),
         ),
         reason:
             'A card created with audio files present but no resolvable sentence '
@@ -227,11 +228,3 @@ void main() {
     });
   });
 }
-
-/// 折叠全部空白后再比对调用文本。
-///
-/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
-/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
-/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
-/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
-String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/reader/reader_mining_audio_guard_test.dart
+++ b/hibiki/test/reader/reader_mining_audio_guard_test.dart
@@ -208,8 +208,11 @@ void main() {
       final String source = readReaderPageSource();
 
       expect(
-        source,
-        contains('HibikiToast.show(msg: t.card_mined_without_sentence_audio)'),
+        _squashWs(source),
+        contains(
+          _squashWs(
+              'HibikiToast.show(msg: t.card_mined_without_sentence_audio'),
+        ),
         reason:
             'A card created with audio files present but no resolvable sentence '
             'range must visibly tell the user no sentence audio was attached, '
@@ -224,3 +227,11 @@ void main() {
     });
   });
 }
+
+/// 折叠全部空白后再比对调用文本。
+///
+/// 守卫要钉的是「这条代码路径确实弹了带该文案的提示」，而不是它在源码里排成几行。
+/// 给 toast / OSD 增补实参（如统一语义配色的 `severity:`）会让 dart format 把单行
+/// 调用换成多行，逐字匹配单行调用就会假红——红的是格式，不是行为。折叠空白后仍然
+/// 要求同一函数名 + 同一具名实参 + 同一 i18n key 连续出现，守卫强度不变。
+String _squashWs(String s) => s.replaceAll(RegExp(r'\s+'), '');

--- a/hibiki/test/settings/settings_destination_order_guard_test.dart
+++ b/hibiki/test/settings/settings_destination_order_guard_test.dart
@@ -30,6 +30,7 @@ void main() {
     const List<String> expectedOrder = <String>[
       'buildAppearanceDestination()',
       'buildReadingDestination()',
+      'buildMangaDestination()',
       'buildListeningDestination()',
       'buildVideoDestination()',
       'buildDownloadsDestination()',

--- a/hibiki/test/settings/settings_schema_coverage_test.dart
+++ b/hibiki/test/settings/settings_schema_coverage_test.dart
@@ -35,6 +35,18 @@ import '../helpers/test_platform_services.dart';
 /// 让覆盖测试不对「别处已覆盖」的项裸喊 UNVERIFIED/FAIL，且强制每个 changed
 /// 但未 effect-verified 的设置都必须有去处（no silent caps）。
 const Map<String, String> kCoveredElsewhere = <String, String>{
+  // 漫画观看偏好五项。写 prefsRepo（changed=true），生效点全部在**漫画阅读器的
+  // WebView 文档**里——这些值被注入成 CSS 过渡声明 / JS 常量（ZOOM_SENS、
+  // TAP_ZONE_PAGING、IS_RTL、PAGE_ANIM），widget harness 里没有 WebView，也就没有
+  // 可探的渲染输入。由 manga_overlay_html_test 逐项咬住：同一份生成器在不同参数下
+  // 必须产出不同的文档（缩放上下限/灵敏度、点击翻页开关与 RTL 镜像、三种翻页动画
+  // 各自的过渡声明），阅读方向另有既有的 RTL 几何用例。
+  'manga/Reading direction': 'test/media/manga/manga_overlay_html_test.dart',
+  'manga/Default zoom': 'test/media/manga/manga_overlay_html_test.dart',
+  'manga/Zoom sensitivity': 'test/media/manga/manga_overlay_html_test.dart',
+  'manga/Page turn animation': 'test/media/manga/manga_overlay_html_test.dart',
+  'manga/Tap edges to turn pages':
+      'test/media/manga/manga_overlay_html_test.dart',
   // galgame 窗口超分三态开关（PR#430）。写 prefsRepo（changed=true），生效点整条在
   // 本进程之外 —— 改写 Magpie 自己的 config.json、拉起 / 收掉一个独立的 Magpie 进程、
   // 由它去做全屏缩放，widget harness 里没有任何可探的渲染输入；而且它 Windows-only，

--- a/hibiki/test/settings/volume_key_desktop_gate_test.dart
+++ b/hibiki/test/settings/volume_key_desktop_gate_test.dart
@@ -9,6 +9,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/src/settings/settings_schema_listening.dart';
+import 'package:hibiki/src/settings/settings_schema_manga.dart';
 import 'package:hibiki/src/settings/settings_schema_reading.dart';
 
 void main() {
@@ -37,6 +38,15 @@ void main() {
         itemById(listening, 'listening.volume_key_sentence_nav').visible,
         isNotNull,
         reason: '音量键句子导航必须平台门控，桌面不显示',
+      );
+    });
+
+    test('manga：音量键翻页项带 visible 门控（非总是显示）', () {
+      final SettingsDestination manga = buildMangaDestination();
+      expect(
+        itemById(manga, 'manga.volume_key_paging').visible,
+        isNotNull,
+        reason: '漫画音量键翻页开关必须平台门控，iOS/桌面不显示',
       );
     });
   });
@@ -76,6 +86,14 @@ void main() {
           readSource('lib/src/settings/settings_schema_listening.dart')
               .readAsStringSync();
       expectAndroidGate(src, 'listening.volume_key_sentence_nav');
+    });
+
+    test('manga schema：翻页开关门控为 Platform.isAndroid', () {
+      final String src =
+          readSource('lib/src/settings/settings_schema_manga.dart')
+              .readAsStringSync();
+      expect(src.contains("import 'dart:io'"), isTrue);
+      expectAndroidGate(src, 'manga.volume_key_paging');
     });
   });
 }


### PR DESCRIPTION
用户报的 7 件事，逐条根因修复。

## 1. 漫画设置从「阅读」里拿出来

漫画此前在设置页只有一个折叠的「漫画 OCR」组，寄生在**阅读**分类末尾；真正影响
日常观看的方向/缩放/翻页根本不在设置里，只能在阅读器右键菜单改，换设备无从预设。
漫画与 EPUB 没有任何共享设置项（漫画没有字体/行距/排版方向，EPUB 没有跨页/缩放），
故拆成独立一级分类 `settings_schema_manga.dart`，并把观看偏好一并抬进来。

## 2. 漫画设置、下载设置左右间距和别处不一样

两个独立根因：

- `SettingsCustomItem` 是 `settings_schema_widgets.dart` 那个 switch 里**唯一**不经过
  `AdaptiveSettingsRow` 的分支，而那 16px 横向 padding 正是行控件自带的 —— 漫画 OCR
  正文因此贴在 x=0，同一张卡片里的其它行在 x=16。
- `TorrentSettingsSection` 把自己收进 560 居中限宽（下载页语境正确），嵌进设置详情
  pane 后左边缘变成 `(paneWidth-560)/2`，与其它 12 个分类完全对不齐。

顺带给 `AdaptiveSettingsRow` 补 `horizontalPadding` 逃生口：这 16px 此前硬编码无从
覆盖，正是任何「自带缩进的嵌入式正文」一缩进就双重 padding 的根源。

## 3. 缩放极其不灵敏

根因在 `manga_overlay_html.dart` 的滚轮处理：它把 `e.deltaY` **只当符号用**，恒 ±0.1 的
**加法**步长。于是 ① 触控板的高频小 delta 与鼠标一格大 delta 被同等对待；② 加法步长
在高倍率下相对变化越来越小（1.9→2.0 只有 5.3%）；③ 上限死钳 200%。

改成按 delta 幅值的**乘法**缩放（`deltaMode` 先归一化），范围 50%~400%，另给一条灵敏度
倍率设置。另外触屏此前**完全无法缩放**（viewport 是 `user-scalable=no`，JS 侧没有任何
多指处理），补了自实现的双指捏合。

## 4. 翻页逻辑难受 / 翻页动画不对

- 此前**没有任何点击翻页手段**：`_onTap` 命中不到 OCR 就只报 `onTapEmpty`（Dart 侧是
  no-op），触屏只能靠 swipe。补左右边缘点击翻页，方向随 RTL 镜像，可关。
- 滚轮翻页原是「首个事件就翻 + 320ms 全禁」，上限约 3 页/秒且触控板轻扫误翻。改成按
  累计 delta 触发 + 110ms 合并窗口。
- 翻页动画原是写死的 `transform 0.14s`，只在已加载窗口内生效。改为可配 none/slide/fade。

## 5. 缺少音量键翻页

`VolumeKeyChannel` 基础设施早就有（Android `MainActivity.dispatchKeyEvent` 拦截转发），
只有 EPUB 阅读器在用，漫画从未接线。补上，并在 dispose 交还所有权——通道是进程级单例，
不交还会让退出漫画后系统音量调不动（BUG-196 老坑）。

## 6. 支持 hibiki 互联的 OCR 模型

**这条基本已经存在**：`/api/ocr/job*` 的 host/client 全链路、串行队列、断点续传都在。
真正的缺口是 `pairedHost` 不在 `MangaOcrEnginePreference` 里，只能被 auto 兜底顺序选中、
无法显式指定；而且引擎选择器整体按桌面 gating，移动端（最依赖远程引擎的平台）根本看不到。
两处都放开。

## 7. 漫画 OCR 完毕显示「导入已完成」

根因是 `manga_ocr_wizard_done` = "Manga imported" 被复用在**没有发生导入**的两条路径：
阅读器整卷 OCR（书早已在库，只是就地重写 manga.json）与向导的「贴回已入库书」。新增
语义中立的 `manga_ocr_done`；真正走 `MangaImporter` 的那条保持原 key。
（mokuro.moe 下载队列那两处确实会导入，故**未**改动。）

## 8. 气泡通知统一加颜色

改之前：底部 `HibikiToast.show` 326 个调用点里 325 个无色（其中 170 余条是失败、70 余条
是成功）；视频左上角 OSD 的 70 个调用点 100% 无色，API 里压根没有颜色参数；只有 18 个
制卡 toast 有颜色。用户只能靠读文字判断成败。

新增 `ToastSeverity{neutral,info,success,warning,error}` + 调色板，两套通知系统共用；
`_MineToastWidget` 泛化成 `_SeverityToastWidget`，不再「制卡的有图标有颜色、别的没有」。
**375 个调用点**按各自消息的 i18n 真值逐条判定。

刻意保持无色：视频播放态角标 15 处（倍速/画质/音轨/字幕轨/沉浸开关/±10s/字幕延迟）——
它们随每次按键触发，上色会让画面持续闪色块。

制卡类不写死语义：`describeMineOutcome` 已是三态真相，四处入口统一走
`mineToastSeverity(described.status)`，避免把「已存在」漆成 error。

## 验证

- `flutter analyze --no-pub`（含 test 目录）：No issues found。
- 全量 `dart run tool/flutter_test_failures.dart --no-pub`：**17255 tests，全绿**。
  （一次运行里 `update_manifest_publish_race_test` 报 5 个 `bash 找不到`，是我用
  PowerShell 起进程、PATH 里没有 bash 的启动方式问题；在有 bash 的 shell 里复跑该 suite
  与 `anime_download_service_test` 全通过。）
- 新增/调整的守卫已**变异实测**：把 `card_mined_without_sentence_audio` 换成别的 key，
  守卫如期变红，改回即绿。

### 需要 reviewer 留意

- 9 个源码扫描守卫原先逐字匹配**单行**调用文本，给 toast 增补实参后 `dart format` 换行
  即假红。已改为折叠空白后再匹配，仍要求同一函数 + 同一具名实参 + 同一 i18n key 连续
  出现，强度不变（不是放宽成「只要出现 HibikiToast 就算过」）。
- 5 个新漫画设置项已登记进 `settings_schema_coverage_test` 的 `kCoveredElsewhere`：
  它们的生效点在 WebView 文档里（注入成 CSS 过渡声明 / JS 常量），widget harness 探不到，
  改由 `manga_overlay_html_test` 断言「同一生成器在不同参数下产出不同文档」。
- 未 bump `hibiki/pubspec.yaml` 的 `+build`，留给合并/发版时按仓库惯例统一处理。
- 覆盖测试日志里有一条**既有**的 `reading/Invert volume buttons` FAIL（changed=false），
  不是本 PR 引入，也不触发任何断言。

https://claude.ai/code/session_01Kw3NWYPEVgiN8yUXqdyGYC
