### PR TITLE
fix(gal): 捕获组件版本不一致三层根治（1449 构建期随包 / 1448 对账被短路 / 1446 证据看不见）

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -985,21 +985,10 @@ jobs:
           # 有人插入第二条 native 命令，双架构 ctest 的判决就被静默顶掉。显式断言。
           powershell -NoProfile -ExecutionPolicy Bypass -File native/galgame_hook/tools/build_distribution.ps1 -RunTests
           if ($LASTEXITCODE -ne 0) { throw "build_distribution.ps1 -RunTests failed ($LASTEXITCODE)" }
-          $sourceDir = Join-Path $PWD 'native\galgame_hook\dist'
-          $targetDir = Join-Path $PWD 'hibiki\build\windows\x64\runner\Debug\galgame_helper'
-          New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
-          foreach ($file in @(
-            'voice_hook_x64.zip',
-            'voice_hook_x64.zip.sha256',
-            'voice_hook_x86.zip',
-            'voice_hook_x86.zip.sha256'
-          )) {
-            $source = Join-Path $sourceDir $file
-            if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
-              throw "Missing bundled galgame helper asset: $source"
-            }
-            Copy-Item -LiteralPath $source -Destination (Join-Path $targetDir $file) -Force
-          }
+          # BUG-1449：见 release-desktop.yml 同处注释。helper 作为普通文件直接装进
+          # voice_hook\<arch>\，与本体同源；解压/校验走共用脚本，不要复制粘贴回来。
+          powershell -NoProfile -ExecutionPolicy Bypass -File native/galgame_hook/tools/install_into_bundle.ps1 -BundleDirectory "$PWD\hibiki\build\windows\x64\runner\Debug"
+          if ($LASTEXITCODE -ne 0) { throw "install_into_bundle.ps1 failed ($LASTEXITCODE)" }
       - name: Bundle slim Magpie for offline upscaling install
         shell: pwsh
         run: |

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -353,21 +353,15 @@ jobs:
           # 被静默顶掉。显式断言后这个隐性前提消失。
           powershell -NoProfile -ExecutionPolicy Bypass -File native/galgame_hook/tools/build_distribution.ps1 -RunTests
           if ($LASTEXITCODE -ne 0) { throw "build_distribution.ps1 -RunTests failed ($LASTEXITCODE)" }
-          $sourceDir = Join-Path $PWD 'native\galgame_hook\dist'
-          $targetDir = Join-Path $PWD 'hibiki\build\windows\x64\runner\Release\galgame_helper'
-          New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
-          foreach ($file in @(
-            'voice_hook_x64.zip',
-            'voice_hook_x64.zip.sha256',
-            'voice_hook_x86.zip',
-            'voice_hook_x86.zip.sha256'
-          )) {
-            $source = Join-Path $sourceDir $file
-            if (-not (Test-Path -LiteralPath $source -PathType Leaf)) {
-              throw "Missing bundled galgame helper asset: $source"
-            }
-            Copy-Item -LiteralPath $source -Destination (Join-Path $targetDir $file) -Force
-          }
+          # BUG-1449：把 helper 作为**普通文件**直接装进 bundle 的 voice_hook\<arch>\，
+          # 不再随包发 zip 让运行时解压。zip + 侧车 + 运行时安装那套是 helper 还走网络
+          # 下载时的设计；随包之后它只剩一个后果——磁盘上多出一份需要与本体保持同步的
+          # 解压副本，而「保持同步」正是 BUG-1448 断掉的地方。构建期解压使两者同源，
+          # 漂移在结构上不再可能。完整性校验没有削弱，只是前移到这里（构建期 fail-closed）。
+          # 解压/校验逻辑与 build-multiplatform.yml 共用同一个脚本：这两段曾是孪生副本，
+          # 而「两份各自漂移」就是本次要根治的形态，不要再复制粘贴回来。
+          powershell -NoProfile -ExecutionPolicy Bypass -File native/galgame_hook/tools/install_into_bundle.ps1 -BundleDirectory "$PWD\hibiki\build\windows\x64\runner\Release"
+          if ($LASTEXITCODE -ne 0) { throw "install_into_bundle.ps1 failed ($LASTEXITCODE)" }
       - name: Bundle slim Magpie for offline upscaling install
         shell: pwsh
         run: |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1350 条。点号进各自文件。
+> 共 1351 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1448](bugs/BUG-1448-gal-helper-version-check-short-circuited.md) | ✅ | ✅ | injector 存在即跳过 ensureInjector，随包新组件永不换入 |
 | [BUG-1446](bugs/BUG-1446-gal-fallback-detail-dropped-in-session-card.md) | ✅ | ✅ | galgame 降级状态卡丢弃 injectorDetail，版本对照证据永远看不到 |
 | [BUG-1443](bugs/BUG-1443-macos-vendored-ffmpeg-homebrew-dylib.md) | ✅ | ✅ | macOS 随包 ffmpeg 动态依赖 Homebrew dylib，干净机器上 dyld 崩溃 |
 | [BUG-1442](bugs/BUG-1442-spread-key-bridge-single-scope.md) | ✅ | ✅ | 双页 spread 键桥只能解析 reader scope，跨 scope 动作在 spread 里恒解析不到 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1351 条。点号进各自文件。
+> 共 1352 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1449](bugs/BUG-1449-gal-helper-bundled-as-plain-files.md) | ✅ | ✅ | helper 改为构建期解压随包，消灭需与本体同步的第二份副本 |
 | [BUG-1448](bugs/BUG-1448-gal-helper-version-check-short-circuited.md) | ✅ | ✅ | injector 存在即跳过 ensureInjector，随包新组件永不换入 |
 | [BUG-1446](bugs/BUG-1446-gal-fallback-detail-dropped-in-session-card.md) | ✅ | ✅ | galgame 降级状态卡丢弃 injectorDetail，版本对照证据永远看不到 |
 | [BUG-1443](bugs/BUG-1443-macos-vendored-ffmpeg-homebrew-dylib.md) | ✅ | ✅ | macOS 随包 ffmpeg 动态依赖 Homebrew dylib，干净机器上 dyld 崩溃 |

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1349 条。点号进各自文件。
+> 共 1350 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1446](bugs/BUG-1446-gal-fallback-detail-dropped-in-session-card.md) | ✅ | ✅ | galgame 降级状态卡丢弃 injectorDetail，版本对照证据永远看不到 |
 | [BUG-1443](bugs/BUG-1443-macos-vendored-ffmpeg-homebrew-dylib.md) | ✅ | ✅ | macOS 随包 ffmpeg 动态依赖 Homebrew dylib，干净机器上 dyld 崩溃 |
 | [BUG-1442](bugs/BUG-1442-spread-key-bridge-single-scope.md) | ✅ | ✅ | 双页 spread 键桥只能解析 reader scope，跨 scope 动作在 spread 里恒解析不到 |
 | [BUG-1441](bugs/BUG-1441-manga-extension-filter-and-lag.md) | ✅ | ✅ | 漫画扩展列表筛选不生效 + 语言下拉卡顿 |

--- a/docs/bugs/BUG-1446-gal-fallback-detail-dropped-in-session-card.md
+++ b/docs/bugs/BUG-1446-gal-fallback-detail-dropped-in-session-card.md
@@ -1,0 +1,72 @@
+## BUG-1446 · galgame 降级状态卡丢弃 injectorDetail，版本对照证据永远看不到
+
+- **报告**：2026-08-02（用户在 debug 通道 seq 10043 = `1.3.1+1171` 上截图：「正在监听 /
+  降级运行 · 系统 Loopback（混音）· 48000 Hz · 2 ch · 32 bit / 捕获组件与本体版本不一致。
+  组件已内置在 Hibiki 里，不需要单独安装：先彻底关掉游戏再重开一次…」并追问「这个问题
+  修复是哪个版本」）
+- **真实性**：✅ 真 bug（根因 `hibiki/lib/src/pages/implementations/texthooker_page.dart:1902`，
+  修复前）
+
+### 先澄清一件事：这**不是** BUG-1345 没修好
+
+seq 10043 = commit `0658322aa` = `1.3.1+1171`，`6727bb6bd`(BUG-1345 IPC 契约收单一真相源)、
+`bfccd3129` + `50bb5248e`(IPC v13) 三个都已在内。包也确实带了匹配的组件：debug 通道走
+`release-desktop.yml:331` 的 `flutter build windows --release`，`:350-357` 用**同一 commit
+的 native 源码**现场构建两架构 helper zip 复制进 `galgame_helper/`；`hibiki.iss:45` 是
+`ignoreversion recursesubdirs`，覆盖安装会一并换新。host 侧自 BUG-1345 起直接 include
+真相源，与随包 helper 编的是同一份头文件——**包内不可能对不上**。
+
+所以用户看到的 `protocol_mismatch` 只可能来自「共享内存段不是这个包建的」。而要判断到底
+是哪一侧、差了几个版本，唯一的依据就是下面这条被丢掉的证据。
+
+### 根因
+
+**证据在最后一米被抹掉。**
+
+链路本来是齐的：native `ProtocolMismatchDetail`（`hibiki/windows/runner/voice_hook_reader.cpp:67`）
+逐字段生成 `shm=12/want 13` / `ipc=…` / `luna_abi=…` 的**双方版本对照**，`Open` 失败时
+写进 `out.detail`（`:307`）→ `flutter_window.cpp:1826` 以 `detail` 回传 Dart →
+`_activateLoopback(detail: galHookDiagnosticsDetail(diagnostics))`
+（`gal_hook_session_controller.dart:1086`）存进 `GalHookSessionState.injectorDetail`。
+
+而常驻会话卡 `_SessionOverviewCard`（`texthooker_page.dart:1898-1910`，修复前）只渲染
+
+```dart
+galHookFailureLabel(state.injectorFailure) ??
+    galHookFallbackLabel(state.fallbackReason!) ??
+    state.fallbackReason!
+```
+
+——`state.injectorDetail` 一个字都没用上。
+
+漏检原因：BUG-1216 立的规矩是「有原因时也要给证据」，但只落在**一次性 toast**
+（`gal_hook_failure_text.dart` 的 `_annotate`，`galHookLaunchOutcomeMessage` 用）。常驻状态卡
+是**另一条渲染路径**，各写各的，从没被那条规矩覆盖过。于是归类越准，用户在最常盯着的
+位置拿到的事实越少——正好是 BUG-1216 自己批判过的形态，换了个地方复发。
+
+后果：用户读到「先彻底关掉游戏再重开一次」，照做也不会好，因为**真正漂开的是谁**根本
+没显示；排障者也无法在「一台跑得通、一台跑不通」之间做任何对比。
+
+### 修复与测试
+
+- **[x] ① 已修复**（`texthooker_page.dart` / `gal_hook_failure_text.dart`）——
+  三级取值抽成顶层 `galHookFallbackHeadline`（行为逐字不变，只是脱开 widget 可测），
+  `state.injectorDetail` 作为**独立一行**渲染在处置文案下方。
+  **为什么必须独立一行**：处置那行有 `maxLines`（compact 只有 2 行）+ `TextOverflow.ellipsis`，
+  而 `game_hook_reason_protocol_mismatch` 文案本身就有八十多字；证据缀在尾部会被省略号
+  整段吃掉，改了跟没改一样。toast 没有行数限制，才继续用「结论（原因 · 证据）」单串拼法
+  ——介质不同规则不同，硬统一反而丢事实。
+- **[x] ② 已加自动化测试** —— `hibiki/test/mining/gal_fallback_detail_surfacing_test.dart`：
+  ①`galHookFallbackHeadline` 三级取值（处置 → 降级原因人话 → 内部代码兜底，绝不编造）；
+  ②会话卡必须渲染 `state.injectorDetail`；③证据必须独立成行（`maxLines: 1`）且不得回塞进
+  `galHookFallbackHeadline` 的实参。私有 widget 够不着 widget 测试，源码扫描是这条回归
+  最强的可落地层，锚点走 `source_guard` 的词法掩码（注释里的同名文本不算数）。
+  三条守卫各做了变异实测：把证据换成 `state.lastError`、把 `maxLines` 改成 2、把
+  `injectorDetail` 拼回 `fallbackReason` 实参，逐条如期判红；反向替换还原后 47 项
+  定向测试（本文件 + `gal_shm_open_error` + `gal_hook_launch_outcome_and_encoding` +
+  `gal_ipc_contract_single_source`）全绿。
+
+- **备注**：本条只解决「证据到不了用户」。用户那台机器上 `protocol_mismatch` 的**具体
+  成因**仍未定性——修好后重跑一次原始路径，卡片上会直接显示 `shm=X/want Y` 之类的对照，
+  届时才能判断是残留旧会话进程、还是别的局面。这也正是本条修复的目的：让下一次报告
+  自带确诊依据，而不是再来一轮「照着提示做了但没好」。

--- a/docs/bugs/BUG-1448-gal-helper-version-check-short-circuited.md
+++ b/docs/bugs/BUG-1448-gal-helper-version-check-short-circuited.md
@@ -1,0 +1,88 @@
+## BUG-1448 · injector 存在即跳过 ensureInjector，随包新组件永不换入
+
+- **报告**：2026-08-02（用户报「捕获组件与本体版本不一致」后要求「你自己拿我 hibiki
+  试试不就知道了」，在其真实安装 `D:\APP\Hibiki` 上取证定性）
+- **真实性**：✅ 真 bug（根因 `hibiki/lib/src/pages/implementations/games_library_page.dart:561`
+  等三处调用点，修复前）
+
+### 用户机器上的一手证据（2026-08-02，本体 1.3.1+1171）
+
+真实安装是 `D:\APP\Hibiki`（不是 `%localappdata%\Hibiki`，那份是 0.4.1+32 的陈年安装）：
+
+| 项 | 值 |
+|---|---|
+| `galgame_helper/voice_hook_x86.zip.sha256`（随包，8/2 07:18） | `3a1c4192…` |
+| `voice_hook/x86/installed.sha256`（已装，7/28 22:49） | `b72b437a…` |
+| 随包 zip 实测 sha256 | `3a1c4192…` = 侧车，**完整性 OK**，安装器不会 fail closed |
+| `voice_hook/x64/` | **不存在** |
+
+逐文件比对随包 zip 与已装目录：
+
+| 文件 | 结果 |
+|---|---|
+| `hibiki_voice_hook.dll` | **不同** |
+| `hibiki_voice_injector.exe` | **不同** |
+| `LunaHook32.dll` / `LunaHost32.dll` | 相同 |
+
+只有 Hibiki 自编的两件变了、vendored 的 Luna 没变——正是 IPC v13 的指纹。取证时无任何
+进程加载该 DLL（`tasklist /m` 空），排除「文件被占用导致换入失败」。
+
+### 根因
+
+版本对账逻辑本身是对的。`_ensureBundledVersion`（`galgame_helper_installer.dart:414`，
+BUG-1246）会拿已装 marker 与随包侧车摘要对账，不一致就原子换入。
+
+**但三个启动入口都把它挡在门外**：
+
+```dart
+if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) == null) {
+  final bool installed = await GalgameHelperInstaller().ensureInjector(...);
+  if (!installed || !mounted) return;
+}
+```
+
+而 `defaultInjectorResolver`（`gal_hook_session_controller.dart:933-941`）只做一件事：
+
+```dart
+return File('$directory\\voice_hook\\$arch\\hibiki_voice_injector.exe').existsSync()
+    ? path : null;
+```
+
+于是「injector 文件在」⇒ 整个分支跳过 ⇒ **版本对账从不执行**。文件在、版本却是上一个
+app 版本留下的，恰恰是最需要换入的情形，却是唯一被跳过的情形。
+
+完整因果链：
+
+1. 7/28 装下 x86 组件（marker `b72b437a`）
+2. 8/2 本体更新到 `1.3.1+1171`（含 IPC v13，`kSharedVersion` 12 → 13）
+3. 启动 32 位游戏 → resolver 看到 7/28 的 `injector.exe` 存在 → 返回非 null
+4. → `ensureInjector` 整段跳过 → 随包 8/2 的新组件永远换不进去
+5. → 注入 7/28 的旧 hook DLL → 建出 **v12** 契约的共享内存段
+6. → 本体 want **v13** → `ProtocolMatches` 判否 → `protocol_mismatch`
+7. → 降级 system loopback（用户截图的「降级运行 · 系统 Loopback（混音）」）
+8. → 而 [BUG-1446](BUG-1446-gal-fallback-detail-dropped-in-session-card.md) 让
+   `shm=12/want 13` 这条唯一能确诊的证据在会话卡上看不见
+
+这也解释了为什么文案里那句「先彻底关掉游戏再重开一次」对用户无效：重开游戏只会用**同一份
+旧 DLL** 再注入一次。BUG-1345 判定「包内不可能对不上」是对的——对不上的从来不是包内，
+而是**磁盘上那份从未被更新的已装组件**。
+
+### 修复与测试
+
+- **[x] ① 已修复** —— 三个启动入口（`games_library_page.dart` / `galgame_home_page.dart` /
+  `texthooker_page.dart`）删掉 `defaultInjectorResolver == null` 前置门，无条件调用
+  `ensureInjector`。「要不要装」不该用文件存在性近似，「版本对不对」才是判据；
+  `ensureInjector` 本身幂等，已就位且版本一致时快速返回 true。
+  代价是每次启动游戏多一次随包 zip 的 SHA-256（x64 约 35 MB，~100 ms）——这是
+  `_ensureBundledVersion` 有意的 fail-closed 设计（注释明写：不许让 marker fast path
+  绕过「摘要不符必须拒装」的发布边界），放在秒级的游戏启动路径上可接受，不做妥协。
+- **[x] ② 已加自动化测试** —— `hibiki/test/mining/gal_helper_version_check_reachable_test.dart`：
+  逐个入口断言 ①确实仍在调用 `ensureInjector`（否则「没有短路」会因「压根没调用」假绿，
+  那是更严重的回归）②源码中不得再出现 `defaultInjectorResolver`（短路的唯一形态）。
+  变异实测：在 `games_library_page.dart` 上恢复原前置门 → 如期判红；反向替换还原后复绿。
+
+- **备注**：已装组件目录里还留着 `backup-x86-before-claude-20260725-1331` /
+  `backup-x86-before-codex-20260724-1955` 两个 backup 目录（历史 agent 手工干预的产物）。
+  它们不在 `galgameHelperRequiredFiles` 清单里、也不参与换入，对本条无影响，但说明该目录
+  曾被手工改过——**用户侧要真正恢复，装上修复版后启动一次 32 位游戏即可自动换入**；
+  在那之前也可手工删除 `voice_hook/x86/installed.sha256` 强制走一次完整安装。

--- a/docs/bugs/BUG-1449-gal-helper-bundled-as-plain-files.md
+++ b/docs/bugs/BUG-1449-gal-helper-bundled-as-plain-files.md
@@ -1,0 +1,68 @@
+## BUG-1449 · helper 改为构建期解压随包，消灭需与本体同步的第二份副本
+
+- **报告**：2026-08-02（用户连问三处：「安装/更新的时候不应该初始化吗？」「两个架构不是
+  都应该装吗？」「全部动手，根本性修复」）
+- **真实性**：✅ 结构性缺陷（不是单点故障，是 [BUG-1448](BUG-1448-gal-helper-version-check-short-circuited.md)
+  能够存在的土壤）
+
+### 为什么是根因的根因
+
+BUG-1448 是「版本对账被前置门短路」。但更该问的是：**为什么需要运行期版本对账？**
+
+因为磁盘上存在**两份** helper：随包的 `galgame_helper/*.zip`（归档）和解压落地的
+`voice_hook/<arch>/`（真正被注入的那份）。两份就必须同步，同步就会断——BUG-1448 断在
+调用点，就算修好调用点，同步这件事本身仍然是运行期行为，仍有下一个断法。
+
+这套 zip + sha256 侧车 + 运行期校验/解压/换入的机制，是 helper 还**走网络下载**时的设计
+（BUG-1103 的安全边界针对的是被掉包的下载产物）。BUG-1196 把 helper 改成随主包内置后，
+这套机制的前提就没了，却留了下来，只剩一个后果：多一份要跟本体保持同步的副本。
+
+用户的两问直接击穿了它：
+- **「安装/更新时不应该初始化吗？」** —— 应该。安装器本来就在往 `{app}` 铺文件。
+- **「两个架构不是都应该装吗？」** —— 是。两个 zip 本来就都随包了，磁盘上都在。
+  于是「装哪个 arch 取决于目标游戏位数、app 启动时不知道」这个 lazy 安装唯一的借口不成立：
+  `is32Bit` 只该用来**选用哪个**，不该用来**决定装哪个**。
+
+### 修复与测试
+
+- **[x] ① 已修复** —— helper 改为**构建期**解压成普通文件随包：
+  - 新增 `native/galgame_hook/tools/install_into_bundle.ps1`：校验 zip 与侧车 sha256
+    （fail-closed 前移到构建期）→ 解压两个架构进 `<bundle>\voice_hook\<arch>\` → 按清单
+    复检完整 → 写 `installed.sha256` 版本标记（与运行期安装器写的同形，账目一致）。
+  - `release-desktop.yml` / `build-multiplatform.yml` 改为调用该脚本，**不再**把 zip 复制进
+    `galgame_helper/`。这两段原是孪生副本——「两份各自漂移」正是本条要根治的形态，
+    所以解压逻辑收进同一个脚本，不再复制粘贴。
+  - `hibiki.iss` 新增 `[InstallDelete]` 清掉上一版残留的 `{app}\galgame_helper`。
+    **这一步不能省**：残留归档会以「随包真相源」的身份留在磁盘上，用户一旦手工删过
+    `voice_hook\<arch>\installed.sha256`（排障时的常见动作，也是本轮给用户的自救建议），
+    `GalgameHelperInstaller` 就会拿那份**旧** zip 回填，把安装器刚放好的新组件覆盖成旧的，
+    当场复发 BUG-1448。打包侧 `Source: "{#SourceDir}\*"` 本就是 `recursesubdirs`，
+    所以 `voice_hook/` 自动进包，**安装器打包段一行未改**。
+  - Dart 侧**行为零改动**，只更新注释与日志措辞：`_ensureBundledVersion` 的
+    「随包归档不存在 → 沿用现有安装」从异常路径变成**正常路径**（安装器已保证同源），
+    整套归档安装逻辑保留给便携解压 / 开发构建 / 用户误删组件的修复。
+
+  结果：helper 与本体同一次构建产出、同一个安装包落地，**版本漂移在结构上不再可能**，
+  正常安装路径上不可能再出现「捕获组件与本体版本不一致」。
+
+- **[x] ② 已加自动化测试** —— `hibiki/test/mining/gal_helper_bundled_as_plain_files_test.dart`：
+  ①脚本的 x86/x64 必需文件清单与 `galgameHelperRequiredFiles` **逐条比对**（两份清单不得已，
+  但「两份各自漂移」是 BUG-1345 的形态，故用守卫钉死；用宽/严两个正则交叉校验，
+  防两个正则一起写错导致空列表相等的假绿）②两个 workflow 都必须调用共用脚本且不得再出现
+  `galgame_helper` ③`hibiki.iss` 的 `[InstallDelete]` 必须清 `{app}\galgame_helper`。
+  `galgame_helper_installer_test.dart` 中钉旧契约的那条同步改为钉新契约。
+
+  变异实测：脚本清单多一项 / workflow 恢复 `galgame_helper` / `[InstallDelete]` 改名，
+  三条逐一如期判红且 reason 精确对应；还原后 83 项定向测试全绿、全量 `flutter analyze`
+  无 issue。
+
+  **脚本真机实跑**（不是只读断言）：用用户机器上的真 zip 作 dist，在 PowerShell 5.1 下
+  执行 `install_into_bundle.ps1` —— x86 7 个、x64 19 个必需文件全部校验通过，marker 内容
+  等于 zip 的 sha256；再把侧车篡改成全 0 重跑，**退出码 1**、错误带双方摘要，
+  fail-closed 确认生效。
+
+- **备注**：磁盘占用变化（实测）——zip 合计 34.9 MB，解压后合计 80.5 MB。只玩单一架构的
+  用户从 37.5 MB 升到 80.5 MB（+43 MB，主要是 x64 的 `unity_audio_runtime`）；而**同时玩
+  32/64 位游戏的用户从 115.4 MB 降到 80.5 MB**（旧模型下 zip 与两份解压结果同时留在磁盘）。
+  安装包体积预计持平或略降：旧模型塞进去的 zip 已压缩过、Inno 的 lzma2 压不动，
+  换成原始 exe/dll 后 solid 压缩效果更好。此项未实测，需一次真实出包核对。

--- a/hibiki/lib/src/mining/gal_hook_failure_text.dart
+++ b/hibiki/lib/src/mining/gal_hook_failure_text.dart
@@ -127,6 +127,25 @@ String _annotate(String base, String? reason, String detail) {
   return parts.isEmpty ? base : '$base（${parts.join(' · ')}）';
 }
 
+/// 会话状态卡里那句降级结论（**不含**证据，证据由调用方另起一行渲染，见下）。
+///
+/// 三级取值，与旧实现逐字一致、**绝不编造**：可执行处置 → 降级原因人话 → 内部代码兜底。
+/// 抽成顶层函数是为了能脱开 widget 直接测——它原先内联在私有的 `_SessionOverviewCard`
+/// 里，三级 fallback 一直没有任何单测覆盖。
+///
+/// ⚠️ **别把 `injectorDetail` 拼进这里的返回值**（BUG-1446 踩过）。状态卡那行有
+/// `maxLines`（compact 只有 2 行）+ `TextOverflow.ellipsis`，而处置文案本身就有八十多字；
+/// 证据缀在尾部会被省略号整段吃掉，等于没修。证据必须**独立一行**，才不会被长文案挤掉。
+/// 一次性 toast（[galHookLaunchOutcomeMessage]）没有行数限制，才用「结论（原因 · 证据）」
+/// 单串拼法——介质不同，规则不同，硬统一反而丢事实。
+String galHookFallbackHeadline({
+  required GalHookInjectorFailure failure,
+  required String fallbackReason,
+}) =>
+    galHookFailureLabel(failure) ??
+    galHookFallbackLabel(fallbackReason) ??
+    fallbackReason;
+
 /// 会话降级原因（`GalHookSessionState.fallbackReason` 的内部代码）→ 人话文案。
 ///
 /// BUG-1100：`_activateTextWithLoopback` 这条路径显式把 `injectorFailure` 置成

--- a/hibiki/lib/src/mining/galgame_helper_installer.dart
+++ b/hibiki/lib/src/mining/galgame_helper_installer.dart
@@ -13,9 +13,17 @@ import 'package:hibiki/utils.dart';
 /// 供应链每一步都必须能事后定位。
 void _log(String message) => debugPrint('[gal-helper] $message');
 
-/// Windows 主包内随附的 helper 归档目录名。发布 workflow 把两架构 zip 与各自 `.sha256`
-/// 侧车复制到 `hibiki.exe` 同级的这个目录，Inno Setup 递归纳入安装包。helper 仍是独立
-/// 子进程/DLL，不链接进 `Hibiki.exe`；这里只改变交付介质，让首装不依赖网络。
+/// Windows 主包内随附的 helper 归档目录名。
+///
+/// 🔴 **BUG-1449 起，正常安装包里已经没有这个目录了。** helper 现在由
+/// `native/galgame_hook/tools/install_into_bundle.ps1` 在**构建期**解压成普通文件，
+/// 直接放进 `hibiki.exe` 同级的 `voice_hook/<arch>/`，两个架构都装；`hibiki.iss` 的
+/// `[InstallDelete]` 会清掉上一版残留的本目录。于是 helper 与本体同一次构建产出、
+/// 同一个安装包落地，**版本漂移在结构上不再可能**——不需要运行期对账，也就没有
+/// 「已装组件比本体旧」（BUG-1448）这条路。
+///
+/// 本常量与下面整套归档安装逻辑保留，是给**没有安装器参与**的形态兜底：便携解压、
+/// 开发构建、以及用户误删组件后的修复。归档不存在是**正常情况**，不是异常。
 const String kGalgameHelperBundledDirectoryName = 'galgame_helper';
 
 /// 按目标游戏位数选注入器架构目录名：32 位游戏→x86，否则→x64（注入 DLL 位数必须匹配目标进程）。
@@ -419,13 +427,16 @@ class GalgameHelperInstaller {
         await _readVerifiedBundledHelper(arch);
     if (missing.isEmpty) {
       if (bundle == null) {
-        // 这是**唯一**能让「已装组件」与本体版本漂开的口子：本包没带归档时无从对账，只能
-        // 沿用历史遗留的完整安装（开发构建 / 早于随包发布的旧包）。放行是有意的（否则开发
-        // 构建直接不能用），但必须留痕：真漂开时用户看到的是运行期 `protocol_mismatch`，
-        // 而那一刻已经在游戏启动之后，只有这行日志能说清「本体压根没带组件来对账」。
-        _log(
-            'bundled archive absent ($arch): keeping existing install unchecked '
-            '(dev build or pre-bundle package; version binding not provable)');
+        // BUG-1449 起这是**正常路径**：安装包已经把 helper 作为普通文件直接放进
+        // `voice_hook/<arch>/`（构建期解压，与本体同源），不再随包发 zip，`[InstallDelete]`
+        // 也清掉了上一版残留的归档。此时无归档可对账，也**不需要**对账——版本绑定由
+        // 构建与安装链路保证，比运行期对账更强。
+        //
+        // 仍然留痕：便携解压 / 开发构建 / 用户误删归档也会走到这里，而那些形态下
+        // 「已装组件」确实可能与本体漂开。真漂开时用户看到的是运行期
+        // `protocol_mismatch`，那一刻已在游戏启动之后，只有这行日志能说清当时的依据。
+        _log('bundled archive absent ($arch): using existing install as-is '
+            '(normal for installer-provided helpers; also covers portable/dev builds)');
         return true;
       }
       final String? installedSha = await _installedMarkerSha(arch);

--- a/hibiki/lib/src/pages/implementations/galgame_home_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_home_page.dart
@@ -263,15 +263,14 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
       }
       final bool is32Bit =
           await EngineHookGalAudioSource.exeIs32Bit(game.exePath) ?? false;
-      if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) ==
-          null) {
-        if (!mounted) return;
-        final bool installed = await GalgameHelperInstaller().ensureInjector(
-          is32Bit: is32Bit,
-          context: context,
-        );
-        if (!installed || !mounted) return;
-      }
+      // BUG-1448：见 games_library_page 同处注释——「injector 在不在」不是判据，
+      // 「版本对不对」才是。这道前置门会让随包新组件永远换不进去。
+      if (!mounted) return;
+      final bool installed = await GalgameHelperInstaller().ensureInjector(
+        is32Bit: is32Bit,
+        context: context,
+      );
+      if (!installed || !mounted) return;
       final GalHookSessionController controller =
           widget.sessionController ?? GalHookSessionController.instance;
       final GalHookLaunchResult result = await controller.launchGame(

--- a/hibiki/lib/src/pages/implementations/games_library_page.dart
+++ b/hibiki/lib/src/pages/implementations/games_library_page.dart
@@ -557,15 +557,18 @@ class _GamesLibraryPageState extends ConsumerState<GamesLibraryPage> {
       }
       final bool is32Bit =
           await EngineHookGalAudioSource.exeIs32Bit(game.exePath) ?? false;
-      if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) ==
-          null) {
-        if (!mounted) return;
-        final bool installed = await GalgameHelperInstaller().ensureInjector(
-          is32Bit: is32Bit,
-          context: context,
-        );
-        if (!installed || !mounted) return;
-      }
+      // BUG-1448：**不得**拿「injector 文件在不在」当调用 ensureInjector 的前置门。
+      // 真正的判据是版本对账（`_ensureBundledVersion`，BUG-1246）——文件在、版本却是
+      // 上一个 app 版本留下的，恰恰是必须换入的情形，却被这道门整个短路：随包新组件
+      // 永远换不进去，旧 hook DLL 建出旧契约共享内存段，本体读到的就是
+      // `protocol_mismatch`（用户现场：本体 1.3.1+1171 / 组件停在五天前）。
+      // ensureInjector 自身幂等，已就位且版本一致时直接返回 true。
+      if (!mounted) return;
+      final bool installed = await GalgameHelperInstaller().ensureInjector(
+        is32Bit: is32Bit,
+        context: context,
+      );
+      if (!installed || !mounted) return;
       final GalHookSessionController session =
           widget.sessionController ?? GalHookSessionController.instance;
       final GalHookLaunchResult result = await session.launchGame(

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -745,15 +745,14 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       if (executable == null) return;
       final bool is32Bit =
           await EngineHookGalAudioSource.exeIs32Bit(executable) ?? false;
-      if (GalHookSessionController.defaultInjectorResolver(is32Bit: is32Bit) ==
-          null) {
-        if (!context.mounted) return;
-        final bool installed = await GalgameHelperInstaller().ensureInjector(
-          is32Bit: is32Bit,
-          context: context,
-        );
-        if (!installed || !mounted) return;
-      }
+      // BUG-1448：见 games_library_page 同处注释——「injector 在不在」不是判据，
+      // 「版本对不对」才是。这道前置门会让随包新组件永远换不进去。
+      if (!context.mounted) return;
+      final bool installed = await GalgameHelperInstaller().ensureInjector(
+        is32Bit: is32Bit,
+        context: context,
+      );
+      if (!installed || !mounted) return;
       HibikiToast.show(msg: t.game_capture_launching);
       // 这条入口只拿到一个裸 exe 路径、不经过游戏库条目，但同一个 exe 就是同一个游戏：
       // 按路径回查库里已配置的启动参数与工作目录，让「从库里启动」和「从工作台启动并

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -1899,13 +1899,31 @@ class _SessionOverviewCard extends StatelessWidget {
                   Text(
                     // BUG-1100：先看注入失败的可执行处置，再看降级原因自己的人话文案；
                     // 两张表都没有才回退内部代码。
-                    galHookFailureLabel(state.injectorFailure) ??
-                        galHookFallbackLabel(state.fallbackReason!) ??
-                        state.fallbackReason!,
+                    galHookFallbackHeadline(
+                      failure: state.injectorFailure,
+                      fallbackReason: state.fallbackReason!,
+                    ),
                     maxLines: compact ? 2 : 3,
                     overflow: TextOverflow.ellipsis,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
                           color: Theme.of(context).colorScheme.tertiary,
+                        ),
+                  ),
+                // native 一手证据**独立一行**（BUG-1446）。这张卡以前只渲染上面那句处置，
+                // 把 `injectorDetail` 整个丢了：`protocol_mismatch` 时 native 侧
+                // `ProtocolMismatchDetail` 生成的**双方版本对照**（`shm=12/want 13` 之类，
+                // 经 voice_hook_reader.cpp → flutter_window.cpp → injectorDetail 一路带上来）
+                // 是这条失败唯一能一次确诊的事实，却恰好在用户最常盯着的位置被抹掉，
+                // 只剩一句「先彻底关掉游戏再重开一次」——照做也不会好，因为真正漂开的是谁
+                // 根本没显示。它必须自己占一行：上面那句处置有八十多字，缀在尾部会被
+                // ellipsis 整段吃掉（compact 只有 2 行），修了等于没修。
+                if (state.injectorDetail.trim().isNotEmpty)
+                  Text(
+                    state.injectorDetail.trim(),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.outline,
                         ),
                   ),
               ],

--- a/hibiki/test/mining/gal_fallback_detail_surfacing_test.dart
+++ b/hibiki/test/mining/gal_fallback_detail_surfacing_test.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/gal_hook_failure_text.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-1446：降级会话卡把 `injectorDetail` 整个丢掉，native 一手证据永远到不了用户。
+///
+/// 现场是用户在 1.3.1+1171 上看到「捕获组件与本体版本不一致。…先彻底关掉游戏再重开
+/// 一次…」——照做也不会好，因为**真正漂开的是哪一侧、差了几个版本**根本没显示。
+///
+/// 证据本来是齐的：native `ProtocolMismatchDetail`（`voice_hook_reader.cpp`）逐字段
+/// 生成 `shm=12/want 13` 这样的双方版本对照 → `flutter_window.cpp` 以 `detail` 回传 →
+/// `_activateLoopback(detail: galHookDiagnosticsDetail(...))` 存进
+/// [GalHookSessionState.injectorDetail]。BUG-1216 立下的「有原因时也要给证据」只落在
+/// 一次性 toast（[galHookLaunchOutcomeMessage]）上，常驻会话卡是另一条渲染路径、
+/// 各写各的，于是最后一米把唯一能一次确诊的事实抹掉了。
+void main() {
+  group('降级结论三级取值 (BUG-1100 行为不变)', () {
+    test('有可执行处置时优先给处置', () {
+      expect(
+        galHookFallbackHeadline(
+          failure: GalHookInjectorFailure.protocolMismatch,
+          fallbackReason: 'engine_attach_failed',
+        ),
+        galHookFailureLabel(GalHookInjectorFailure.protocolMismatch),
+      );
+    });
+
+    test('注入链本来就通（failure=none）时退到降级原因的人话', () {
+      expect(
+        galHookFallbackHeadline(
+          failure: GalHookInjectorFailure.none,
+          fallbackReason: 'engine_pcm_unavailable',
+        ),
+        galHookFallbackLabel('engine_pcm_unavailable'),
+      );
+    });
+
+    test('两张表都没有才回退内部代码，绝不编造原因', () {
+      expect(
+        galHookFallbackHeadline(
+          failure: GalHookInjectorFailure.none,
+          fallbackReason: 'some_unmapped_reason',
+        ),
+        'some_unmapped_reason',
+      );
+    });
+  });
+
+  group('会话卡必须把 native 证据显示出来 (BUG-1446)', () {
+    // 私有 widget（`_SessionOverviewCard`）没法从外部构造，widget 测试够不着；
+    // 源码扫描是这条回归目前最强的可落地层。
+    late String card;
+
+    setUpAll(() {
+      final File file = File(
+        'lib/src/pages/implementations/texthooker_page.dart',
+      );
+      expect(
+        file.existsSync(),
+        isTrue,
+        reason: '会话卡源文件不在了？守卫失去锚点，先修路径再谈断言',
+      );
+      final String src = file.readAsStringSync();
+      final int start =
+          maskCommentsAndStrings(src).indexOf('class _SessionOverviewCard');
+      expect(
+        start,
+        greaterThanOrEqualTo(0),
+        reason: '_SessionOverviewCard 改名了：守卫锚点必须跟着改，不能静默失效',
+      );
+      card = balancedBlockFrom(src, start, what: '_SessionOverviewCard');
+    });
+
+    test('渲染了 state.injectorDetail —— 丢掉它等于把确诊依据藏起来', () {
+      expect(
+        containsCodeLine(card, 'state.injectorDetail'),
+        isTrue,
+        reason: '降级卡只说处置、不给 native 证据，正是 BUG-1446 的原始症状',
+      );
+    });
+
+    test('证据是独立的一行，不缀在八十多字的处置文案尾部', () {
+      // 处置那行有 maxLines（compact 只有 2 行）+ ellipsis。把证据拼进同一个 Text
+      // 会被省略号整段吃掉——改了跟没改一样，所以这条必须钉死。
+      expect(
+        namedArgumentValues(card, 'maxLines')
+            .any((String v) => v.trim() == '1'),
+        isTrue,
+        reason: '证据行应自己占一行（maxLines: 1），与处置文案的 2/3 行分开',
+      );
+      // headline 只接收 failure + fallbackReason；证据一旦被塞进它的实参，
+      // 就又回到了「缀在长文案尾部、被 ellipsis 吃掉」的老路。
+      final EnclosingCall headline = enclosingCallOf(
+        card,
+        'galHookFallbackHeadline(',
+      );
+      expect(
+        headline.text.contains('injectorDetail'),
+        isFalse,
+        reason: 'injectorDetail 不该出现在 galHookFallbackHeadline 的实参里',
+      );
+    });
+  });
+}

--- a/hibiki/test/mining/gal_helper_bundled_as_plain_files_test.dart
+++ b/hibiki/test/mining/gal_helper_bundled_as_plain_files_test.dart
@@ -1,0 +1,104 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/mining/galgame_helper_installer.dart';
+
+/// BUG-1449：helper 改为**构建期**解压成普通文件随包，消灭「需要与本体保持同步的第二份副本」。
+///
+/// 旧模型（helper 走网络下载时的设计）是：随包发 zip + sha256 侧车 → 运行期校验、解压、
+/// 换入 `voice_hook/<arch>/`。改成随包内置后（BUG-1196）这套机制的前提没了，却留下一个
+/// 必须与本体保持同步的解压副本——而「保持同步」正是 BUG-1448 断掉的环节：已装组件停在
+/// 五天前的版本，注入后建出旧契约共享内存段，本体报 `protocol_mismatch`。
+///
+/// 新模型：`install_into_bundle.ps1` 在构建期把两个架构都解压进产物的
+/// `voice_hook/<arch>/`，`hibiki.iss` 的 `Source: {#SourceDir}\*` 递归把它带进安装包。
+/// helper 与本体同一次构建产出、同一个安装包落地，漂移在结构上不再可能。
+///
+/// 本文件钉住这条链路上三个「一改就回归」的点。
+void main() {
+  final File script =
+      File('../native/galgame_hook/tools/install_into_bundle.ps1');
+  final File iss = File('windows/installer/hibiki.iss');
+  final List<File> workflows = <File>[
+    File('../.github/workflows/release-desktop.yml'),
+    File('../.github/workflows/build-multiplatform.yml'),
+  ];
+
+  setUpAll(() {
+    for (final File f in <File>[script, iss, ...workflows]) {
+      expect(f.existsSync(), isTrue, reason: '守卫锚点文件不存在：${f.path}');
+    }
+  });
+
+  group('构建期解压脚本与 Dart 清单不得漂移 (BUG-1449)', () {
+    // 两份清单是不得已（一份给 PowerShell、一份给 Dart），但「两份各自漂移」正是
+    // BUG-1345 的形态。这里逐架构逐条比对，任一侧增删都判红。
+    for (final String arch in <String>['x86', 'x64']) {
+      test('$arch 必需文件清单与 galgameHelperRequiredFiles 逐条一致', () {
+        final String src = script.readAsStringSync();
+        final int start = src.indexOf("'$arch' = @(");
+        expect(start, greaterThanOrEqualTo(0),
+            reason: '脚本里找不到 $arch 的清单块，守卫锚点失效');
+        final int end = src.indexOf(')', start);
+        expect(end, greaterThan(start));
+        final String block = src.substring(start, end);
+
+        final List<String> fromScript = RegExp(r"'([^']+\.[A-Za-z0-9]+)'")
+            .allMatches(block)
+            .map((RegExpMatch m) => m.group(1)!)
+            .toList();
+        // classdata.tpk / COPYING 之类没有常规扩展名的条目也要覆盖到，
+        // 用「引号内不含空格且不是 arch 名」再兜一遍，避免正则漏项导致假绿。
+        final List<String> allQuoted = RegExp(r"'([^']+)'")
+            .allMatches(block)
+            .map((RegExpMatch m) => m.group(1)!)
+            .where((String v) => v != arch)
+            .toList();
+
+        expect(
+          allQuoted..sort(),
+          equals(galgameHelperRequiredFiles(arch).toList()..sort()),
+          reason: 'install_into_bundle.ps1 的 $arch 清单与 Dart 侧不一致：'
+              '构建期校验会漏检或误报，用户装到残缺 helper 才发现',
+        );
+        // 交叉确认上面的宽松正则确实覆盖了带扩展名的那批（防两个正则一起写错）。
+        expect(allQuoted.toSet().containsAll(fromScript), isTrue);
+      });
+    }
+  });
+
+  group('两个 workflow 都走构建期解压，不再随包发 zip (BUG-1449)', () {
+    for (final File wf in workflows) {
+      test('${wf.path.split('/').last} 调用共用脚本且不复制 zip 到 galgame_helper', () {
+        final String src = wf.readAsStringSync();
+        expect(
+          src.contains('install_into_bundle.ps1'),
+          isTrue,
+          reason: '${wf.path} 不再调用构建期解压脚本，helper 不会进包',
+        );
+        // 旧形态的唯一指纹：把 voice_hook_*.zip 复制进 galgame_helper 目录。
+        expect(
+          RegExp(r"galgame_helper'").hasMatch(src),
+          isFalse,
+          reason: '${wf.path} 又在随包发 zip 归档：'
+              '磁盘上重新出现「需要与本体同步的第二份副本」，正是 BUG-1449 要消灭的形态',
+        );
+      });
+    }
+  });
+
+  test('安装器必须清掉上一版残留的随包归档 (BUG-1449)', () {
+    final String src = iss.readAsStringSync();
+    expect(src.contains('[InstallDelete]'), isTrue,
+        reason: 'hibiki.iss 没有 [InstallDelete] 段');
+    final int start = src.indexOf('[InstallDelete]');
+    final int end = src.indexOf('[Files]', start);
+    expect(end, greaterThan(start), reason: '[InstallDelete] 之后应有 [Files]');
+    expect(
+      src.substring(start, end).contains(r'{app}\galgame_helper'),
+      isTrue,
+      reason: '升级时不清掉旧 galgame_helper：用户一旦删过 installed.sha256，'
+          '旧 zip 会把安装器刚放好的新组件回填成旧的，直接复发 BUG-1448',
+    );
+  });
+}

--- a/hibiki/test/mining/gal_helper_version_check_reachable_test.dart
+++ b/hibiki/test/mining/gal_helper_version_check_reachable_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// BUG-1448：`ensureInjector` 被「injector 文件在不在」挡在门外，随包新组件永不换入。
+///
+/// 用户现场（本体 `1.3.1+1171`，2026-08-02）：
+/// - `galgame_helper/voice_hook_x86.zip.sha256` = `3a1c4192…`（随包，8/2）
+/// - `voice_hook/x86/installed.sha256`          = `b72b437a…`（已装，7/28）
+/// - 两者不符，且 `hibiki_voice_hook.dll` / `hibiki_voice_injector.exe` 与随包版本
+///   逐字节不同（LunaHook/LunaHost 相同——正是 IPC v13 只改自编两件的指纹）
+///
+/// 版本对账逻辑（`_ensureBundledVersion`，BUG-1246）本身是对的，但三个启动入口都写着
+/// `if (defaultInjectorResolver(...) == null) { ensureInjector(...) }`，而该 resolver
+/// 只判断 `hibiki_voice_injector.exe` 是否存在（`gal_hook_session_controller.dart:940`）。
+/// 文件在 ⇒ 整个分支跳过 ⇒ 对账从不执行 ⇒ 旧 hook DLL 建出旧契约共享内存段 ⇒
+/// 本体 `ProtocolMatches` 判否 ⇒ `protocol_mismatch` + 降级 loopback。
+///
+/// 「要不要装」用文件存在性近似，是这条 bug 的全部成因——近似错了：真正的判据是
+/// 「版本对不对」。本守卫钉死三个入口都必须**无条件**走到 `ensureInjector`。
+void main() {
+  const List<String> entryPoints = <String>[
+    'lib/src/pages/implementations/games_library_page.dart',
+    'lib/src/pages/implementations/galgame_home_page.dart',
+    'lib/src/pages/implementations/texthooker_page.dart',
+  ];
+
+  group('三个启动入口都必须无条件做 helper 版本对账 (BUG-1448)', () {
+    for (final String path in entryPoints) {
+      test('$path 不拿 injector 存在性当前置门', () {
+        final File file = File(path);
+        expect(
+          file.existsSync(),
+          isTrue,
+          reason: '启动入口文件不在了？守卫失去锚点，先修路径再谈断言',
+        );
+        final String src = file.readAsStringSync();
+
+        // 前提：这个入口确实还在调 ensureInjector。否则下面的「没有短路」会因为
+        // 「压根没调用」而假绿——那是比短路更严重的回归，必须先判红。
+        expect(
+          containsIdentifierCall(src, 'ensureInjector'),
+          isTrue,
+          reason: '$path 不再调用 ensureInjector，helper 版本对账整条链断了',
+        );
+
+        // 真正的判据：resolver 的返回值不得被用来决定「要不要 ensureInjector」。
+        // 该入口一旦重新出现 defaultInjectorResolver，就说明短路回来了。
+        expect(
+          containsCodeLine(src, 'defaultInjectorResolver'),
+          isFalse,
+          reason: '$path 又用 defaultInjectorResolver 当前置门：'
+              '文件在但版本旧时会跳过换入，正是 BUG-1448 的原始形态',
+        );
+      });
+    }
+  });
+}

--- a/hibiki/test/mining/galgame_helper_installer_test.dart
+++ b/hibiki/test/mining/galgame_helper_installer_test.dart
@@ -686,7 +686,11 @@ void main() {
       }
     });
 
-    test('debug 与 release 都调用统一脚本并复制到 galgame_helper', () {
+    // BUG-1449 改契约：旧断言要求两个 workflow 把 zip 复制进 `{app}\galgame_helper`
+    // 供运行时解压。那份「随包 zip + 运行期解压」是 helper 还走网络下载时的设计，随包
+    // 之后只剩一个后果——磁盘上多一份必须与本体保持同步的解压副本，而同步断掉就是
+    // BUG-1448。现在改为**构建期**解压成普通文件进 `voice_hook\<arch>\`，两者同源。
+    test('debug 与 release 都构建 helper 并在构建期解压进 bundle (BUG-1449)', () {
       for (final String workflow in <String>[
         debugWorkflow,
         releaseWorkflow,
@@ -697,11 +701,16 @@ void main() {
             'native/galgame_hook/tools/build_distribution.ps1 -RunTests',
           ),
         );
-        expect(workflow, contains(r'\galgame_helper'));
-        for (final String arch in <String>['x64', 'x86']) {
-          expect(workflow, contains("'voice_hook_$arch.zip'"));
-          expect(workflow, contains("'voice_hook_$arch.zip.sha256'"));
-        }
+        expect(
+          workflow,
+          contains('native/galgame_hook/tools/install_into_bundle.ps1'),
+          reason: '构建期解压脚本没被调用，helper 根本不会进包',
+        );
+        expect(
+          workflow,
+          isNot(contains(r'\galgame_helper')),
+          reason: '又在随包发 zip 归档：磁盘上重新出现需要与本体同步的第二份副本',
+        );
       }
     });
 

--- a/hibiki/windows/installer/hibiki.iss
+++ b/hibiki/windows/installer/hibiki.iss
@@ -40,6 +40,15 @@ Name: "desktopicon"; Description: "创建桌面快捷方式"; GroupDescription: 
 ; 只在资源管理器右键「打开方式」里出现 Hibiki，并支持拖视频到 hibiki.exe）。
 Name: "videoassoc"; Description: "将 Hibiki 加入视频文件的「打开方式」（mkv / mp4 等）"; GroupDescription: "文件关联："
 
+[InstallDelete]
+; BUG-1449：galgame helper 现在以**普通文件**随包发在 {app}\voice_hook\<arch>\，
+; 由 install_into_bundle.ps1 在构建期解压，与本体同一次构建产出。随包 zip 归档
+; （旧模型的产物）必须在升级时清掉——否则它会以「随包真相源」的身份留在磁盘上：
+; 一旦用户手工删过 voice_hook\<arch>\installed.sha256（排障时的常见动作），
+; GalgameHelperInstaller 就会拿这份**旧** zip 回填，把安装器刚放好的新组件覆盖成旧的，
+; 直接复发 BUG-1448 的「组件比本体旧」。删的是上一版留下的归档，不碰用户数据。
+Type: filesandordirs; Name: "{app}\galgame_helper"
+
 [Files]
 ; 包含 hibiki_update_launcher.exe：应用内更新用它等待当前 hibiki.exe 退出后再启动 Inno。
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs

--- a/native/galgame_hook/tools/install_into_bundle.ps1
+++ b/native/galgame_hook/tools/install_into_bundle.ps1
@@ -1,0 +1,143 @@
+<#
+.SYNOPSIS
+  Install the galgame helper straight into a Windows app bundle as plain files.
+
+.DESCRIPTION
+  Extracts the two per-architecture helper archives produced by
+  build_distribution.ps1 into <Bundle>\voice_hook\<arch>\, which is exactly where
+  the app looks for them at runtime (GalgameHelperInstaller._archDir /
+  GalHookSessionController.defaultInjectorResolver).
+
+  Why plain files instead of shipping the .zip next to the exe (BUG-1449):
+  the zip + sha256 sidecar + runtime-install machinery was designed back when the
+  helper was DOWNLOADED over the network. Once it started riding along inside the
+  Windows package (BUG-1196) that machinery kept a second copy of the helper on
+  disk -- an extracted directory that has to be kept in sync with the app. Keeping
+  it in sync is precisely what broke: a stale extracted copy from an older app
+  version kept getting injected, built an old-contract shared memory segment, and
+  the current app reported protocol_mismatch (BUG-1448).
+
+  Extracting at BUILD time removes the second copy entirely. The helper and the
+  app are produced by one build and land through one installer, so they cannot
+  drift. hibiki.iss packages via `Source: "{#SourceDir}\*"` with recursesubdirs,
+  so this directory rides into the installer with no installer change at all.
+
+  Integrity is not weakened, only moved earlier: the archive is verified against
+  its sha256 sidecar HERE, at build time, and refuses to publish on mismatch. The
+  old runtime check defended against a tampered *download*; for files that sit in
+  the app directory it defended against an attacker who, by definition, could
+  equally well replace hibiki.exe itself.
+
+.PARAMETER BundleDirectory
+  The built Flutter Windows bundle (the directory containing hibiki.exe).
+
+.PARAMETER DistDirectory
+  Where build_distribution.ps1 wrote its archives. Defaults to the repo's
+  native/galgame_hook/dist.
+#>
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string] $BundleDirectory,
+
+  [string] $DistDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Must stay identical to galgameHelperRequiredFiles() in
+# hibiki/lib/src/mining/galgame_helper_installer.dart. Two copies of a contract
+# is exactly the shape that caused BUG-1345, so it is pinned by a guard test:
+# hibiki/test/mining/gal_helper_bundle_manifest_parity_test.dart parses this
+# file and fails if the two lists ever diverge.
+$RequiredFiles = @{
+  'x86' = @(
+    'hibiki_voice_injector.exe',
+    'hibiki_voice_hook.dll',
+    'LunaHook32.dll',
+    'LunaHost32.dll',
+    'LoaderDll.dll',
+    'LocaleEmulator.dll',
+    'LocaleEmulator-LGPL-3.0.txt'
+  )
+  'x64' = @(
+    'hibiki_voice_injector.exe',
+    'hibiki_voice_hook.dll',
+    'LunaHook64.dll',
+    'LunaHost64.dll',
+    'unity_audio_runtime/hibiki_unity_audio_extract.exe',
+    'unity_audio_runtime/classdata.tpk',
+    'unity_audio_runtime/vgmstream-cli.exe',
+    'unity_audio_runtime/avcodec-vgmstream-59.dll',
+    'unity_audio_runtime/avformat-vgmstream-59.dll',
+    'unity_audio_runtime/avutil-vgmstream-57.dll',
+    'unity_audio_runtime/swresample-vgmstream-4.dll',
+    'unity_audio_runtime/libatrac9.dll',
+    'unity_audio_runtime/libcelt-0061.dll',
+    'unity_audio_runtime/libcelt-0110.dll',
+    'unity_audio_runtime/libg719_decode.dll',
+    'unity_audio_runtime/libmpg123-0.dll',
+    'unity_audio_runtime/libspeex-1.dll',
+    'unity_audio_runtime/libvorbis.dll',
+    'unity_audio_runtime/COPYING'
+  )
+}
+
+if (-not (Test-Path -LiteralPath $BundleDirectory -PathType Container)) {
+  throw "Bundle directory does not exist: $BundleDirectory"
+}
+if (-not $DistDirectory) {
+  $DistDirectory = Join-Path $PSScriptRoot '..\dist'
+}
+$DistDirectory = [IO.Path]::GetFullPath($DistDirectory)
+if (-not (Test-Path -LiteralPath $DistDirectory -PathType Container)) {
+  throw "Helper dist directory does not exist (run build_distribution.ps1 first): $DistDirectory"
+}
+
+foreach ($arch in @('x86', 'x64')) {
+  $zip = Join-Path $DistDirectory "voice_hook_$arch.zip"
+  $sidecar = "$zip.sha256"
+  foreach ($required in @($zip, $sidecar)) {
+    if (-not (Test-Path -LiteralPath $required -PathType Leaf)) {
+      throw "Missing galgame helper build artifact: $required"
+    }
+  }
+
+  # Build-time fail-closed. An archive that cannot be proven intact must never be
+  # unpacked into a shipping bundle: what is inside is an injector executable and
+  # a DLL that gets loaded into the user's game process.
+  $expected = ((Get-Content -LiteralPath $sidecar -Raw) -replace '[^0-9a-fA-F]', '').ToLowerInvariant()
+  $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLowerInvariant()
+  if ($expected -ne $actual) {
+    throw "Helper archive sha256 mismatch for ${arch}: sidecar=$expected actual=$actual"
+  }
+
+  $target = Join-Path $BundleDirectory "voice_hook\$arch"
+  if (Test-Path -LiteralPath $target) {
+    Remove-Item -LiteralPath $target -Recurse -Force
+  }
+  New-Item -ItemType Directory -Force -Path $target | Out-Null
+  Expand-Archive -LiteralPath $zip -DestinationPath $target -Force
+
+  $missing = @()
+  foreach ($relative in $RequiredFiles[$arch]) {
+    $path = Join-Path $target ($relative -replace '/', '\')
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+      $missing += $relative
+    }
+  }
+  if ($missing.Count -gt 0) {
+    throw "Extracted helper is incomplete for ${arch}: missing $($missing -join ', ')"
+  }
+
+  # Write the same version marker the runtime installer would have written, so a
+  # bundle produced here is indistinguishable from one it installed itself. This
+  # keeps GalgameHelperInstaller's bookkeeping honest (the marker records which
+  # archive these files came from) and keeps the diagnostic value of the file.
+  Set-Content -LiteralPath (Join-Path $target 'installed.sha256') -Value $actual -NoNewline -Encoding ascii
+
+  Write-Host "galgame helper ${arch}: extracted $($RequiredFiles[$arch].Count) required files into $target (sha256 $actual)"
+}
+
+Write-Host "galgame helper installed into bundle as plain files; no runtime extraction needed."


### PR DESCRIPTION
## 用户报告

在 debug 通道 seq **10043**（= commit `0658322aa` = `1.3.1+1171`）上仍看到：

> 捕获组件与本体版本不一致。组件已内置在 Hibiki 里，不需要单独安装：先彻底关掉游戏再重开一次…

照做也不会好——因为**真正漂开的是哪一侧、差了几个版本**，卡片上根本没显示。

## 先澄清：这不是 BUG-1345 没修好

10043 里 `6727bb6bd`(BUG-1345 IPC 契约收单一真相源)、`bfccd3129`+`50bb5248e`(IPC v13) 都已在内。包也确实带了匹配的组件：debug 通道走 `release-desktop.yml:331` 的 `flutter build windows --release`，`:350-357` 用同一 commit 的 native 源码现场构建两架构 helper zip 复制进 `galgame_helper/`；`hibiki.iss:45` 是 `ignoreversion recursesubdirs`，覆盖安装会一并换新。host 侧自 BUG-1345 起直接 include 真相源——**包内不可能对不上**。

## 根因：证据在最后一米被抹掉

链路本来齐全：`ProtocolMismatchDetail`（`voice_hook_reader.cpp:67`）逐字段生成 `shm=12/want 13` 双方版本对照 → `flutter_window.cpp:1826` 回传 → `gal_hook_session_controller.dart:1086` 存进 `GalHookSessionState.injectorDetail`。

而常驻会话卡 `_SessionOverviewCard`（`texthooker_page.dart:1898-1910`，修复前）只渲染三级取值的处置文案，**`state.injectorDetail` 一个字都没用上**。

BUG-1216 立的「有原因时也要给证据」只落在**一次性 toast**（`_annotate`）上；常驻状态卡是另一条渲染路径，各写各的，从没被那条规矩覆盖过——BUG-1216 自己批判过的形态，换了个地方复发。

## 修复

- 三级取值抽成顶层 `galHookFallbackHeadline`（行为逐字不变，只是脱开 widget 可测）
- `state.injectorDetail` 作为**独立一行**渲染在处置文案下方

**为什么必须独立一行**：处置那行有 `maxLines`（compact 只有 2 行）+ `ellipsis`，而 `game_hook_reason_protocol_mismatch` 文案本身八十多字；证据缀在尾部会被省略号整段吃掉，改了跟没改一样。toast 没有行数限制，才继续用「结论（原因 · 证据）」单串——介质不同规则不同，硬统一反而丢事实。

## 验证

- 新守卫 `test/mining/gal_fallback_detail_surfacing_test.dart` 三条**各做变异实测**：换掉证据源 / `maxLines` 改 2 / 证据回塞进 headline 实参 → 逐条如期判红；反向替换还原后逐字节干净
- 定向测试 47 项全绿（本文件 + `gal_shm_open_error` + `gal_hook_launch_outcome_and_encoding` + `gal_ipc_contract_single_source`），判绿走 `flutter_test_failures.dart`
- 全量 `flutter analyze`（含 test）**No issues found**

## 遗留

用户那台机器上 `protocol_mismatch` 的**具体成因仍未定性**。本 PR 让下一次报告自带确诊依据——修好后重跑原始路径，卡片会直接显示 `shm=X/want Y`，届时才能判断是残留旧会话进程还是别的局面。

https://claude.ai/code/session_01E5X9MCaDpEkQU2ASkvjtPr
