### PR TITLE
fix(db): PR#712 的 v68 迁移修复——外键父表缺席不再打断 onUpgrade (BUG-1444)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1318 条。点号进各自文件。
+> 共 1319 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1444](bugs/BUG-1444-v68-media-images-fk-parent-missing.md) | ✅ | ✅ | v68 迁移 INSERT media_images 在外键开启时因 FK 父表缺席抛 no such table，整条 onUpgrade 中断 |
 | [BUG-1413](bugs/BUG-1413-local-audio-busy-swallowed-as-miss.md) | ✅ | ✅ | 本地音频库 SQLITE_BUSY 被吞成与「真没这词」同形的 null |
 | [BUG-1412](bugs/BUG-1412-activity-identity-gates.md) | ✅ | ✅ | 游戏活动身份回退过宽：同名条目取第一个 / 脏 key 误绑封面 |
 | [BUG-1406](bugs/BUG-1406-libmpv-ffmpeg-version-guard-first-match.md) | ✅ | ✅ | libmpv FFmpeg 版本守卫只校验第一个匹配，单 ABI 静默降级不报红 |

--- a/docs/bugs/BUG-1444-v68-media-images-fk-parent-missing.md
+++ b/docs/bugs/BUG-1444-v68-media-images-fk-parent-missing.md
@@ -1,0 +1,37 @@
+## BUG-1444 · v68 迁移 INSERT media_images 在外键开启时因 FK 父表缺席抛 no such table，整条 onUpgrade 中断
+- **报告**：2026-08-02（用户：PR#712 集成线硬停，`hibiki/test/database` 65 个 error / 18 个文件）
+- **真实性**：✅ 真 bug。根因 `packages/hibiki_core/lib/src/database/database.dart:1379`（`if (from < 68)` 步里那条 `INSERT INTO media_images ... SELECT ... FROM collection_scrape_meta`）。
+
+  `media_images` 带两条外键（`collection_id` → `media_collections`、`book_uid` → `video_books`，
+  `packages/hibiki_core/lib/src/database/tables.dart:1355`）。SQLite 解析外键父表的时机是**执行 DML 时**、
+  不是建表时：只要 `PRAGMA foreign_keys = ON`，这条 INSERT 就会去找两张父表，缺任何一张直接抛
+  `SqliteException(1): no such table: main.<父表>`，把整条 `onUpgrade` 打断——库升不上去、app 打不开。
+  抛不抛与本条 INSERT 搬几行、`book_uid` 是否恒为 NULL 全都无关。
+
+  两张父表都不是「从来就有」：`video_books` 只在 `from<17` / `from<20` 建、`media_collections` 只在
+  `from<38` 建（`database.dart:628` / `:660` / `:875`）。而真实 app 恒以 `PRAGMA foreign_keys = ON`
+  打开库（`database.dart:156` `_openWithRecovery` 的 `applyPragmas`），所以「外键开着」不是测试专属条件。
+
+  实测 65 个 error 里 44 个是这条（33 个 `video_books` + 11 个 `media_collections`），其余 20 个是
+  schema bump 后没跟着改的 `expect(..., 67)` 字面量、1 个是前面抛错后的文件锁连带。
+
+  **爆炸半径的如实边界**：真实用户库走到 v68 时两张父表恒在（v38+ 的库必有 `media_collections`，
+  v20+ 的库必有 `video_books`），所以这条**不会**让正常升级路径的老用户打不开 app。硬红的是
+  部分迁移库 / 阶梯测试的最小种子库，以及由此而来的 CI 单测门。另有一条外溢：升级完成后
+  `media_images` 在这类库里成了一张「碰不得」的表——`DELETE FROM video_books` 触发 cascade 时
+  SQLite 要解析 `media_images` 自己的 FK，同样抛（`migration_v57_naming_unification_test` 实测）。
+- **[x] ① 已修复** — `b821cfe51`：搬运期间 `PRAGMA foreign_keys = OFF`，收尾**按进入时的取值恢复**
+  （新增 `_foreignKeysEnabled()`；不像 v57 无条件置 ON，那会把调用方显式关掉的外键悄悄打开）。
+  沿用 v16/v57 的既有先例：搬运的引用完整性由源表 `collection_scrape_meta` 自己的外键继承；
+  刻意不加 `foreign_key_check` 门——真库若存过孤儿刮削行，抛错等于把用户锁死在「app 打不开」，
+  代价远大于一行永不渲染的残图。
+- **[x] ② 已加自动化测试** — `hibiki/test/database/migration_v68_media_images_test.dart`（4 例，全部
+  **显式指定**外键状态）：父表缺席 + 外键开着不抛；父表齐全时搬运正确且外键仍是**真强制**（删合集
+  cascade 清图组，只断言 PRAGMA 值会被「写回去但没生效」骗过）；进来时外键关着则升完仍关着；
+  `media_images` 已在场时重复升级不重插。变异实测：还原 FK-off 后第 1 例红在原始报错
+  `no such table: main.video_books`；把恢复改成无条件 ON 后第 3 例红。
+- **备注**：同域既有的 `media_images_test.dart` 覆盖不到这条——它的 v67 种子用 `NativeDatabase.memory()`
+  默认关外键，父表缺不缺都不报，正是本仓反复记过的「memory DB 默认关外键 = FK/cascade 用例假绿」同一个坑。
+  同轮连带修正：`migration_v57_naming_unification_test` 种子补 `media_collections`（真实 v56 库恒有该表，
+  种子缺它是 fixture 不真实）、`migration_v63` 新增表白名单补 `media_images`、14 个文件 37 处
+  `expect(..., 67)` → `68`。纯 DB 迁移层，无需设备复测。

--- a/hibiki/test/database/collection_relations_test.dart
+++ b/hibiki/test/database/collection_relations_test.dart
@@ -50,7 +50,7 @@ void main() {
         'fresh DB (v66) has collection_relations table and '
         'video_scrape_meta.episode_number column', () async {
       final HibikiDatabase db = await openDb();
-      expect(db.schemaVersion, 67);
+      expect(db.schemaVersion, 68);
       final List<QueryRow> tables = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_relations'")

--- a/hibiki/test/database/migration_test.dart
+++ b/hibiki/test/database/migration_test.dart
@@ -1079,7 +1079,7 @@ void main() {
       // now 31 (v30 series/shelf_entries + v31 hibiki_paired_peers). This v28 DB
       // upgrades all the way to current; TODO-894's backfill still ran (asserted
       // below). The literal had to track the bump.
-      expect(db.schemaVersion, 67,
+      expect(db.schemaVersion, 68,
           reason: 'global schemaVersion is now 38 (TODO-616 v30 + TODO-1017 '
               'v31 + TODO-1195 v32 + TODO-1204 v33 + v34 statistics_tombstones + '
               'TODO-1157 v35 stream_spec_json + TODO-1252 v36 favorite_words '
@@ -1156,7 +1156,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 67,
+      expect(db.schemaVersion, 68,
           reason:
               'TODO-1288 bumps schema to v37 (audiobook srt_books self-heal)');
 
@@ -1316,7 +1316,7 @@ void main() {
 
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 67,
+      expect(db.schemaVersion, 68,
           reason: 'global schemaVersion is now 38 (…v35 + TODO-1252 v36 + '
               'TODO-1288 v37 audiobook srt_books self-heal + v38 unified '
               'media_collections); v29->v30 '
@@ -1367,7 +1367,7 @@ void main() {
           .map((r) => r.data['name'] as String)
           .toSet();
       expect(tableNames, containsAll(['series', 'shelf_entries']));
-      expect(db.schemaVersion, 67);
+      expect(db.schemaVersion, 68);
     });
 
     test(
@@ -1376,7 +1376,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 67,
+      expect(db.schemaVersion, 68,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1410,7 +1410,7 @@ void main() {
       final db = await _openDb();
       final version = await db.customSelect('PRAGMA user_version').getSingle();
       expect(version.read<int>('user_version'), db.schemaVersion);
-      expect(db.schemaVersion, 67,
+      expect(db.schemaVersion, 68,
           reason:
               'TODO-1288 v37 audiobook srt_books self-heal; v38 unified media_collections (series→collection + playlist split)');
 
@@ -1450,7 +1450,7 @@ void main() {
     test('fresh DB (v35) has video_books.stream_spec_json column (TODO-1157)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 67);
+      expect(db.schemaVersion, 68);
       final cols =
           await db.customSelect("PRAGMA table_info('video_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1481,7 +1481,7 @@ void main() {
 
     test('fresh DB (v45) has media_collections.anilist_id column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 67);
+      expect(db.schemaVersion, 68);
       final cols =
           await db.customSelect("PRAGMA table_info('media_collections')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1515,7 +1515,7 @@ void main() {
 
     test('fresh DB (v46) has epub_books.completed_at column', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 67);
+      expect(db.schemaVersion, 68);
       final cols =
           await db.customSelect("PRAGMA table_info('epub_books')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1527,7 +1527,7 @@ void main() {
         'fresh DB (v36) has favorite_words.book_key + title columns (TODO-1252)',
         () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 67);
+      expect(db.schemaVersion, 68);
       final cols =
           await db.customSelect("PRAGMA table_info('favorite_words')").get();
       final colNames = cols.map((r) => r.data['name'] as String).toSet();
@@ -1563,7 +1563,7 @@ void main() {
     // 且既有合集行**一行不少、一列不改**（升级绝不能碰用户数据）。
     test('fresh DB (v64) has collection_scrape_meta table', () async {
       final db = await _openDb();
-      expect(db.schemaVersion, 67);
+      expect(db.schemaVersion, 68);
       final rows = await db
           .customSelect(
               "SELECT name FROM sqlite_master WHERE type='table' AND name='collection_scrape_meta'")

--- a/hibiki/test/database/migration_v40_collections_test.dart
+++ b/hibiki/test/database/migration_v40_collections_test.dart
@@ -116,6 +116,6 @@ CREATE TABLE media_collection_items (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67);
+    expect(db.schemaVersion, 68);
   });
 }

--- a/hibiki/test/database/migration_v51_pdf_format_test.dart
+++ b/hibiki/test/database/migration_v51_pdf_format_test.dart
@@ -110,6 +110,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67);
+    expect(db.schemaVersion, 68);
   });
 }

--- a/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
+++ b/hibiki/test/database/migration_v53_manga_reading_mode_test.dart
@@ -117,6 +117,6 @@ CREATE TABLE epub_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67);
+    expect(db.schemaVersion, 68);
   });
 }

--- a/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
+++ b/hibiki/test/database/migration_v54_video_scrape_meta_test.dart
@@ -154,6 +154,6 @@ CREATE TABLE video_books (
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67);
+    expect(db.schemaVersion, 68);
   });
 }

--- a/hibiki/test/database/migration_v55_galgame_library_test.dart
+++ b/hibiki/test/database/migration_v55_galgame_library_test.dart
@@ -122,7 +122,7 @@ CREATE TABLE preferences (
     final String? pref = await db.getPref('galgame_library');
     expect(pref, isNotNull);
 
-    expect(await userVersionOf(db), 67);
+    expect(await userVersionOf(db), 68);
   });
 
   test('脏数据被逐条跳过，不让整个迁移失败', () async {
@@ -158,7 +158,7 @@ CREATE TABLE preferences (
 
     final List<GalgameRow> rows = await db.getAllGalgames();
     expect(rows.map((GalgameRow r) => r.id), <String>['ok-1', 'ok-2']);
-    expect(await userVersionOf(db), 67);
+    expect(await userVersionOf(db), 68);
   });
 
   test('整串 JSON 损坏 / 非数组 / 空串时迁移仍然成功，只是回填为空', () async {
@@ -169,7 +169,7 @@ CREATE TABLE preferences (
     ]) {
       final HibikiDatabase db = await openV53Db(raw);
       expect(await db.getAllGalgames(), isEmpty, reason: 'raw=$raw');
-      expect(await userVersionOf(db), 67, reason: 'raw=$raw');
+      expect(await userVersionOf(db), 68, reason: 'raw=$raw');
       await db.close();
     }
   });
@@ -177,7 +177,7 @@ CREATE TABLE preferences (
   test('偏好里根本没有 galgame_library 时迁移正常，表为空', () async {
     final HibikiDatabase db = await openV53Db(null);
     expect(await db.getAllGalgames(), isEmpty);
-    expect(await userVersionOf(db), 67);
+    expect(await userVersionOf(db), 68);
   });
 
   test('回填幂等：表里已有行就不再重复回填', () async {
@@ -227,7 +227,7 @@ CREATE TABLE preferences (
       ),
     );
     expect(await db.getAllGalgames(), hasLength(1));
-    expect(await userVersionOf(db), 67);
+    expect(await userVersionOf(db), 68);
   });
 
   test('删游戏经 FK cascade 连带清掉 sources 与 sessions', () async {

--- a/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
+++ b/hibiki/test/database/migration_v56_galgame_launch_args_test.dart
@@ -73,7 +73,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67,
+    expect(db.schemaVersion, 68,
         reason: 'v56 给 galgames 加 launch_args（可配置游戏启动参数）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v57_naming_unification_test.dart
+++ b/hibiki/test/database/migration_v57_naming_unification_test.dart
@@ -22,7 +22,11 @@ void main() {
           rawDb.execute('PRAGMA foreign_keys = OFF');
           // v56 shape：video_books 全列在场，imported_at/completed_at 是 drift
           // DateTime（Unix 秒整数）。media_sources 只作 source_id 的 FK 目标
-          // （foreign_key_check 需要父表在场）。
+          // （foreign_key_check 需要父表在场）；media_collections 同理，是 v68
+          // media_images 的 FK 目标 —— media_images 既是 video_books 的 cascade
+          // 子表、又自己 FK 到 media_collections，删 video_books 行时 SQLite 要
+          // 连着解析这条 FK，父表缺席就抛 no such table。真实 v56 库恒有该表
+          // （v38 就建了），种子缺它是本 fixture 的不真实处，不是被测行为。
           rawDb.execute('''
 CREATE TABLE media_sources (
   id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -37,6 +41,17 @@ CREATE TABLE media_sources (
   recursive INTEGER NOT NULL DEFAULT 1,
   sort_order INTEGER NOT NULL DEFAULT 0,
   created_at INTEGER NOT NULL
+)
+''');
+          rawDb.execute('''
+CREATE TABLE media_collections (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  collection_type TEXT NOT NULL DEFAULT 'collection',
+  cover_source TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT 0,
+  order_updated_at INTEGER NOT NULL DEFAULT 0
 )
 ''');
           rawDb.execute('''
@@ -154,7 +169,7 @@ CREATE TABLE book_tag_membership_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67,
+    expect(db.schemaVersion, 68,
         reason: 'v57 = 命名统一；v58 = 外部媒体自动记录；v59 = 游戏标签；'
             'v60 = 阅读页数；v61 = 合集自有封面；v62 = 每游戏窗口超分档位；'
             'v63 = 清理旧全局超分 pref');

--- a/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
+++ b/hibiki/test/database/migration_v59_galgame_tag_mappings_test.dart
@@ -85,7 +85,7 @@ CREATE TABLE galgame_sessions (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67,
+    expect(db.schemaVersion, 68,
         reason: 'v59 新建 galgame_tag_mappings（BUG-1113 游戏接入共享标签池）');
 
     final GalgameRow? legacy = await db.getGalgame('legacy_game');

--- a/hibiki/test/database/migration_v60_reading_pages_test.dart
+++ b/hibiki/test/database/migration_v60_reading_pages_test.dart
@@ -59,7 +59,7 @@ CREATE TABLE statistics_tombstones (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67, reason: 'v60 = reading_statistics.pages_read');
+    expect(db.schemaVersion, 68, reason: 'v60 = reading_statistics.pages_read');
 
     final List<ReadingStatisticRow> rows = await db.getAllReadingStatistics();
     expect(rows, hasLength(1));

--- a/hibiki/test/database/migration_v61_collection_cover_path_test.dart
+++ b/hibiki/test/database/migration_v61_collection_cover_path_test.dart
@@ -68,7 +68,7 @@ CREATE TABLE media_collection_items (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67,
+    expect(db.schemaVersion, 68,
         reason: 'v61 给 media_collections 加合集自有封面列（BUG-1211）');
 
     final MediaCollectionRow? legacy = await db.getMediaCollectionById(7);

--- a/hibiki/test/database/migration_v62_galgame_upscaling_mode_test.dart
+++ b/hibiki/test/database/migration_v62_galgame_upscaling_mode_test.dart
@@ -102,7 +102,7 @@ CREATE TABLE galgame_tag_mappings (
 
     final version = await db.customSelect('PRAGMA user_version').getSingle();
     expect(version.read<int>('user_version'), db.schemaVersion);
-    expect(db.schemaVersion, 67,
+    expect(db.schemaVersion, 68,
         reason: 'v62 给 galgames 加 upscaling_mode（每游戏窗口超分档位）');
 
     // 列真的建出来了（不只是 Dart 侧读到默认值）。

--- a/hibiki/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
+++ b/hibiki/test/database/migration_v63_legacy_galgame_upscaling_pref_test.dart
@@ -126,8 +126,8 @@ void main() {
 
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 67);
-    expect(db.schemaVersion, 67);
+    expect(version.read<int>('user_version'), 68);
+    expect(db.schemaVersion, 68);
 
     final List<QueryRow> preferences = await db
         .customSelect(
@@ -186,10 +186,11 @@ void main() {
       'untouched',
     );
     // 本用例 seed 的是 v62 库，因此这一次打开会连跑 v63、v64（collection_scrape_meta，
-    // BUG-1310）、v65（Mihon 五表）**和** v66（collection_relations）。断言据此拆成
-    // 两半，原意图一分不弱化：
+    // BUG-1310）、v65（Mihon 五表）、v66（collection_relations）**和** v68
+    // （media_images）。断言据此拆成两半，原意图一分不弱化：
     //  ① 既有表逐张全文比对 —— v63 只能删行，不得 ALTER/DROP/rebuild 或留影子表；
-    //  ② 新增表必须**恰好**是 v64 一张 + v65 五张 + v66 一张 —— v63 自己仍然一张表都不许建。
+    //  ② 新增表必须**恰好**是 v64 一张 + v65 五张 + v66 一张 + v68 一张 —— v63
+    //     自己仍然一张表都不许建。
     final Map<String, String> schemaAfter = await _tableSqlFromDrift(db);
     for (final MapEntry<String, String> entry in schemaBefore.entries) {
       expect(schemaAfter[entry.key], entry.value,
@@ -205,9 +206,10 @@ void main() {
         'manga_source_preferences',
         'manga_trusted_signers',
         'collection_relations',
+        'media_images',
       },
-      reason: '除 v64 的 collection_scrape_meta、v65 的 Mihon 五表与 v66 的 '
-          'collection_relations 外，升级不得新增任何表',
+      reason: '除 v64 的 collection_scrape_meta、v65 的 Mihon 五表、v66 的 '
+          'collection_relations 与 v68 的 media_images 外，升级不得新增任何表',
     );
   });
 
@@ -225,7 +227,7 @@ void main() {
     expect(await db.getPref('theme'), 's:dark');
     final QueryRow version =
         await db.customSelect('PRAGMA user_version').getSingle();
-    expect(version.read<int>('user_version'), 67);
+    expect(version.read<int>('user_version'), 68);
   });
 
   test(
@@ -257,7 +259,7 @@ void main() {
     final sqlite3.Database probe =
         sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
     try {
-      expect(probe.select('PRAGMA user_version').first.values.first, 67);
+      expect(probe.select('PRAGMA user_version').first.values.first, 68);
       expect(
         probe.select(
           'SELECT 1 FROM profile_settings '

--- a/hibiki/test/database/migration_v65_mihon_manga_tables_test.dart
+++ b/hibiki/test/database/migration_v65_mihon_manga_tables_test.dart
@@ -105,8 +105,8 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(db.schemaVersion, 67);
-    expect(await _userVersion(db), 67);
+    expect(db.schemaVersion, 68);
+    expect(await _userVersion(db), 68);
 
     // v63 真跑了：两处废弃偏好都没了。
     expect(
@@ -168,7 +168,7 @@ void main() {
     );
     addTearDown(db.close);
 
-    expect(await _userVersion(db), 67);
+    expect(await _userVersion(db), 68);
     final Set<String> tables = await _tableNames(db);
     for (final String table in _mangaTables) {
       expect(tables, contains(table), reason: 'from=63 时 v65 必须仍然建表：缺 $table');
@@ -185,7 +185,7 @@ void main() {
     addTearDown(db.close);
 
     // 表已存在不能让 onUpgrade 抛异常——抛了 v63 的删除也会一起回滚。
-    expect(await _userVersion(db), 67);
+    expect(await _userVersion(db), 68);
     expect(
       await _countRows(
         db,
@@ -204,7 +204,7 @@ void main() {
     final HibikiDatabase first = HibikiDatabase.forTesting(
       NativeDatabase.memory(setup: _seedV62),
     );
-    expect(await _userVersion(first), 67);
+    expect(await _userVersion(first), 68);
     await first.close();
 
     // 同一份内存库不能跨实例复用，这里改用「第二次打开已是 v65 的形状」：
@@ -220,7 +220,7 @@ void main() {
       ),
     );
     addTearDown(second.close);
-    expect(await _userVersion(second), 67);
+    expect(await _userVersion(second), 68);
     expect(
       await _countRows(second, "SELECT 1 FROM preferences WHERE key = 'theme'"),
       1,

--- a/hibiki/test/database/migration_v68_media_images_test.dart
+++ b/hibiki/test/database/migration_v68_media_images_test.dart
@@ -1,0 +1,215 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_core/hibiki_core.dart';
+import 'package:sqlite3/common.dart' show CommonDatabase;
+
+/// v68 迁移专项守卫：`media_images` 建表 + 搬 `collection_scrape_meta
+/// .backdrop_path` 这一步，在**外键强制打开**的连接上必须走得通。
+///
+/// ## 这条测试防的是什么
+///
+/// `media_images` 带两条外键（`collection_id` → `media_collections`、
+/// `book_uid` → `video_books`）。SQLite 解析外键父表的时机是**执行 DML 时**，
+/// 不是建表时：只要 `PRAGMA foreign_keys = ON`，一条 INSERT 就会去找两张父表，
+/// 缺任何一张都直接抛 `no such table: main.<父表>`，把整条 `onUpgrade` 打断
+/// ——库升不上去、app 打不开。抛不抛与本条 INSERT 搬几行、`book_uid` 是否恒为
+/// NULL 全都无关。
+///
+/// 两张父表都不是「从来就有」：`video_books` 只在 `from<17` / `from<20` 建、
+/// `media_collections` 只在 `from<38` 建。任何没走到那一级的库（部分迁移的旧库、
+/// 阶梯测试的最小种子库）到 v68 这一步就是父表缺席。而**真实 app 恒以
+/// `PRAGMA foreign_keys = ON` 打开库**（`_openWithRecovery` 的 `applyPragmas`），
+/// 所以「外键开着」不是测试专属条件。
+///
+/// 同域的 `media_images_test.dart` 覆盖不到这条：它的 v67 种子用
+/// `NativeDatabase.memory()` 默认关外键，父表缺不缺都不会报——那正是本仓反复记过
+/// 的「memory DB 默认关外键 = cascade/FK 用例假绿」同一个坑。本文件所有用例一律
+/// **显式指定**外键状态。
+///
+/// ## 锁四件事
+///  1. 父表缺席 + 外键开着，v67→v68 不抛，背景图照样搬进 `media_images`；
+///  2. 父表齐全（真实旧库形态）搬运结果正确，且升级完外键仍是真强制；
+///  3. 调用方进来时外键是关的，升级完仍是关的（v68 只按原值恢复，不无条件置 ON）；
+///  4. `media_images` 已存在的库重复升级不重插。
+void main() {
+  /// v67 时代 `collection_scrape_meta` 的形状。刻意**不带** REFERENCES——与当前
+  /// Dart 表定义一致（该表本来就没有 FK 到 media_collections），种子行才能在外键
+  /// 开着时插进一个没有 media_collections 的库。
+  const String scrapeMetaDdl = '''
+CREATE TABLE collection_scrape_meta (
+  collection_id INTEGER NOT NULL PRIMARY KEY,
+  source TEXT NOT NULL,
+  subject_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  original_title TEXT,
+  summary TEXT,
+  air_date TEXT,
+  rating REAL,
+  rating_count INTEGER,
+  episode_count INTEGER,
+  tags_json TEXT,
+  infobox_json TEXT,
+  backdrop_path TEXT,
+  detail_url TEXT,
+  scraped_at INTEGER NOT NULL
+)
+''';
+
+  const String mediaCollectionsDdl = '''
+CREATE TABLE media_collections (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  collection_type TEXT NOT NULL DEFAULT 'collection',
+  cover_source TEXT,
+  cover_path TEXT,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL DEFAULT 0,
+  order_updated_at INTEGER NOT NULL DEFAULT 0
+)
+''';
+
+  const String videoBooksDdl = '''
+CREATE TABLE video_books (
+  book_uid TEXT NOT NULL PRIMARY KEY,
+  title TEXT NOT NULL,
+  video_path TEXT NOT NULL
+)
+''';
+
+  const String legacyMediaImagesDdl = '''
+CREATE TABLE media_images (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  collection_id INTEGER,
+  book_uid TEXT,
+  kind TEXT NOT NULL,
+  position INTEGER NOT NULL DEFAULT 0,
+  path TEXT NOT NULL,
+  source_url TEXT
+)
+''';
+
+  /// 打开一个 `user_version = 67` 的种子库。[withParentTables] 控制两张外键父表
+  /// 在不在场，[foreignKeys] 控制连接进入迁移时的外键强制状态。
+  Future<HibikiDatabase> openV67Db({
+    required bool withParentTables,
+    required bool foreignKeys,
+    bool withMediaImages = false,
+  }) async {
+    final HibikiDatabase db = HibikiDatabase.forTesting(
+      NativeDatabase.memory(
+        setup: (CommonDatabase rawDb) {
+          // 建表/塞种子期间先关外键：这一步模拟的是「库已经长成这样」，不是测约束。
+          rawDb.execute('PRAGMA foreign_keys = OFF');
+          if (withParentTables) {
+            rawDb.execute(mediaCollectionsDdl);
+            rawDb.execute(videoBooksDdl);
+            rawDb.execute(
+                "INSERT INTO media_collections (id, name) VALUES (5, 'c5')");
+            rawDb.execute(
+                "INSERT INTO media_collections (id, name) VALUES (6, 'c6')");
+          }
+          rawDb.execute(scrapeMetaDdl);
+          rawDb.execute(
+            'INSERT INTO collection_scrape_meta '
+            '(collection_id, source, subject_id, title, backdrop_path, '
+            ' scraped_at) '
+            "VALUES (5, 'tmdb', '100', 't5', "
+            "'/covers/collections/5_backdrop.jpg', 0)",
+          );
+          // 无背景行：不得被搬成 path='' 的垃圾行。
+          rawDb.execute(
+            'INSERT INTO collection_scrape_meta '
+            '(collection_id, source, subject_id, title, scraped_at) '
+            "VALUES (6, 'bangumi', '200', 't6', 0)",
+          );
+          if (withMediaImages) {
+            // 「表已经建出来但 user_version 还停在 67」的形态（升级中途断电 /
+            // 手工修过的库）：重复升级必须靠 _tableExists 短路，不得再搬一遍。
+            rawDb.execute(legacyMediaImagesDdl);
+            rawDb.execute(
+              'INSERT INTO media_images (collection_id, kind, position, path) '
+              "VALUES (5, 'backdrop', 0, '/covers/collections/5_backdrop.jpg')",
+            );
+          }
+          rawDb.execute('PRAGMA user_version = 67');
+          // 真实 app 恒以外键强制打开库（_openWithRecovery 的 applyPragmas），
+          // 迁移就是在这个状态下跑的。
+          rawDb.execute(foreignKeys
+              ? 'PRAGMA foreign_keys = ON'
+              : 'PRAGMA foreign_keys = OFF');
+        },
+      ),
+    );
+    addTearDown(db.close);
+    return db;
+  }
+
+  Future<int> userVersionOf(HibikiDatabase db) async =>
+      (await db.customSelect('PRAGMA user_version').getSingle())
+          .read<int>('user_version');
+
+  Future<bool> foreignKeysOf(HibikiDatabase db) async =>
+      (await db.customSelect('PRAGMA foreign_keys').getSingle())
+          .read<int>('foreign_keys') ==
+      1;
+
+  test('外键开着 + 两张父表都缺席：v67 升 v68 不抛，背景图照搬', () async {
+    // 修复前这里抛 SqliteException(1): no such table: main.media_collections，
+    // 整条 onUpgrade 中断——用户侧就是 app 打不开。
+    final HibikiDatabase db =
+        await openV67Db(withParentTables: false, foreignKeys: true);
+
+    expect(await userVersionOf(db), 68, reason: '迁移必须跑完并落 user_version');
+
+    final List<MediaImageRow> rows = await db.getAllMediaImages();
+    expect(rows, hasLength(1), reason: 'NULL backdrop_path 不得搬出垃圾行');
+    expect(rows.single.collectionId, 5);
+    expect(rows.single.kind, MediaImageKind.backdrop.dbValue);
+    expect(rows.single.position, 0);
+    expect(rows.single.path, '/covers/collections/5_backdrop.jpg');
+    expect(rows.single.bookUid, isNull);
+
+    expect(await foreignKeysOf(db), isTrue, reason: '进来时外键是开的，迁移收尾必须恢复回开');
+  });
+
+  test('外键开着 + 父表齐全（真实旧库形态）：搬运正确且外键仍是真强制', () async {
+    final HibikiDatabase db =
+        await openV67Db(withParentTables: true, foreignKeys: true);
+
+    expect(await userVersionOf(db), 68);
+
+    final List<MediaImageRow> rows = await db.getAllMediaImages();
+    expect(rows, hasLength(1));
+    expect(rows.single.collectionId, 5);
+    expect(rows.single.path, '/covers/collections/5_backdrop.jpg');
+
+    expect(await foreignKeysOf(db), isTrue);
+
+    // 外键真的在生效：删掉合集，cascade 清掉它的图组行。只断言 PRAGMA 值会被
+    // 「写回去但没生效」骗过。
+    await db.customStatement('DELETE FROM media_collections WHERE id = 5');
+    expect(await db.getAllMediaImages(), isEmpty, reason: '恢复后的外键必须是真强制');
+  });
+
+  test('进来时外键是关的：v68 按原值恢复，不无条件置 ON', () async {
+    final HibikiDatabase db =
+        await openV67Db(withParentTables: true, foreignKeys: false);
+
+    expect(await userVersionOf(db), 68);
+    expect(await db.getAllMediaImages(), hasLength(1));
+    expect(await foreignKeysOf(db), isFalse, reason: 'v68 不得把调用方显式关掉的外键悄悄打开');
+  });
+
+  test('media_images 已在场：重复升级不重插', () async {
+    final HibikiDatabase db = await openV67Db(
+      withParentTables: true,
+      foreignKeys: true,
+      withMediaImages: true,
+    );
+
+    expect(await userVersionOf(db), 68);
+    final List<MediaImageRow> rows = await db.getAllMediaImages();
+    expect(rows, hasLength(1), reason: '_tableExists 短路，绝不重插');
+    expect(rows.single.path, '/covers/collections/5_backdrop.jpg');
+  });
+}

--- a/packages/hibiki_core/lib/src/database/database.dart
+++ b/packages/hibiki_core/lib/src/database/database.dart
@@ -1390,13 +1390,34 @@ class HibikiDatabase extends _$HibikiDatabase {
               if (await _tableExists('collection_scrape_meta') &&
                   await _columnExists(
                       'collection_scrape_meta', 'backdrop_path')) {
-                await customStatement(
-                  'INSERT INTO media_images '
-                  '(collection_id, kind, position, path) '
-                  "SELECT collection_id, 'backdrop', 0, backdrop_path "
-                  'FROM collection_scrape_meta '
-                  "WHERE backdrop_path IS NOT NULL AND backdrop_path != ''",
-                );
+                // 搬运期间必须关 FK 强制。media_images 带两条外键
+                // （collection_id -> media_collections、book_uid -> video_books），
+                // 而 SQLite 是在**执行 DML 时**才去解析父表的：父表不在场就直接抛
+                // `no such table: main.<父表>` 中断整条 onUpgrade（= 库打不开），
+                // 且与本条 INSERT 搬几行、book_uid 是否恒为 NULL 全都无关。两张父表
+                // 各自只在自己那一级阶梯里建（video_books 在 from<17 / from<20，
+                // media_collections 在 from<38），没走到那一级的库到这里就是缺席。
+                // 关 FK 是 v16/v57 的既有先例：搬运的引用完整性由源表
+                // collection_scrape_meta 自己的外键继承，不需要在这里再验一遍；也
+                // 刻意不加 foreign_key_check 门 —— 真库若存过孤儿刮削行，抛错就等于
+                // 把用户锁死在「app 打不开」，代价远大于一行永不渲染的残图。
+                // 收尾**恢复进入本步时的取值**，不像 v57 那样无条件置 ON：那会把
+                // 调用方（含迁移测试）显式关掉的 FK 悄悄打开，改变后续步骤的行为。
+                final bool foreignKeysWereOn = await _foreignKeysEnabled();
+                await customStatement('PRAGMA foreign_keys = OFF');
+                try {
+                  await customStatement(
+                    'INSERT INTO media_images '
+                    '(collection_id, kind, position, path) '
+                    "SELECT collection_id, 'backdrop', 0, backdrop_path "
+                    'FROM collection_scrape_meta '
+                    "WHERE backdrop_path IS NOT NULL AND backdrop_path != ''",
+                  );
+                } finally {
+                  if (foreignKeysWereOn) {
+                    await customStatement('PRAGMA foreign_keys = ON');
+                  }
+                }
               }
             }
           }
@@ -1663,6 +1684,13 @@ class HibikiDatabase extends _$HibikiDatabase {
     }
     final rows = await customSelect('PRAGMA table_info($tableName)').get();
     return rows.any((row) => row.read<String>('name') == columnName);
+  }
+
+  /// 当前连接上 `PRAGMA foreign_keys` 的取值。迁移里要临时关外键时用它记住进入
+  /// 时的状态，收尾按原值恢复 —— 无条件置 ON 会把调用方显式关掉的外键悄悄打开。
+  Future<bool> _foreignKeysEnabled() async {
+    final QueryRow row = await customSelect('PRAGMA foreign_keys').getSingle();
+    return row.read<int>('foreign_keys') == 1;
   }
 
   Future<bool> _tableExists(String tableName) async {


### PR DESCRIPTION
**这是 PR#712（`feature/jellyfin-artwork-parity`）的迁移修复线，base 指向 #712 的分支而不是 develop**——
#712 是你自己的线，不动它的历史、不 force-push；这条合进 #712 即可，#712 再照常走它自己的合并。

## 根因

`media_images` 带两条外键（`collection_id` → `media_collections`、`book_uid` → `video_books`）。
SQLite 解析外键父表是在**执行 DML 时**、不是建表时：只要 `PRAGMA foreign_keys = ON`，v68 那条把
`collection_scrape_meta.backdrop_path` 搬进 `media_images` 的 INSERT 就会去找两张父表，缺任何一张
直接抛 `SqliteException(1): no such table: main.<父表>`，整条 `onUpgrade` 中断、库升不上去。
抛不抛与搬几行、`book_uid` 是否恒为 NULL 全都无关。

两张父表都不是「从来就有」：`video_books` 只在 `from<17` / `from<20` 建、`media_collections` 只在
`from<38` 建；真实 app 又恒以 `foreign_keys=ON` 打开库（`_openWithRecovery` 的 `applyPragmas`），
所以「外键开着」不是测试专属条件。

`hibiki/test/database` 实测 **65 个 error / 18 个文件**，其中 44 个是这条（33 个 `video_books`
+ 11 个 `media_collections`），20 个是 schema bump 后没跟着改的 `expect(..., 67)`，1 个是抛错后的文件锁连带。

**爆炸半径的如实边界**：真实用户库走到 v68 时两张父表恒在（v38+ 必有 `media_collections`，v20+ 必有
`video_books`），所以这条**不会**让正常升级路径的老用户打不开 app。硬红的是部分迁移库 / 阶梯测试的
最小种子库，以及由此而来的 CI 单测门。另有一条外溢：升级完成后 `media_images` 在这类库里成了一张
「碰不得」的表——`DELETE FROM video_books` 触发 cascade 时 SQLite 要解析 `media_images` 自己的 FK，同样抛。

## 改法

- `database.dart` v68 步：搬运期间 `PRAGMA foreign_keys = OFF`，收尾**按进入时的取值恢复**
  （新增 `_foreignKeysEnabled()`；不像 v57 无条件置 ON——那会把调用方显式关掉的外键悄悄打开）。
  沿用 v16/v57 的既有先例：搬运的引用完整性由源表 `collection_scrape_meta` 自己的外键继承。
  **刻意不加 `foreign_key_check` 门**——真库若存过孤儿刮削行，抛错等于把用户锁死在「app 打不开」，
  代价远大于一行永不渲染的残图。
- 未改任何 ≤67 的已落地迁移语句；未重建表、未加 CHECK；未碰 `ttu_*` / `reader_ttu` 持久化键。
- 未改动 PR#712 的任何功能语义（`media_images` 表定义、DAO、UI 一律没动）。

## 连带（schema bump 的必然churn）

- 14 个文件 37 处 `expect(schemaVersion / user_version, 67)` → `68`；
- `migration_v57_naming_unification_test` 种子补 `media_collections`：`media_images` 既是 `video_books`
  的 cascade 子表、又自己 FK 到 `media_collections`，删 `video_books` 行时 SQLite 要连着解析这条 FK。
  真实 v56 库恒有该表（v38 就建了），种子缺它是 fixture 不真实，不是被测行为；
- `migration_v63` 新增表白名单补 `media_images`。

## 新守卫

`hibiki/test/database/migration_v68_media_images_test.dart`（4 例，**全部显式指定外键状态**——同域既有的
`media_images_test.dart` 的 v67 种子用 `NativeDatabase.memory()` 默认关外键，父表缺不缺都不报，正是本仓
反复记过的「memory DB 默认关外键 = FK/cascade 用例假绿」同一个坑）：

1. 父表缺席 + 外键开着，v67→v68 不抛，背景图照搬；
2. 父表齐全（真实旧库形态）搬运正确，且升完外键仍是**真强制**（删合集 cascade 清图组——只断言 PRAGMA
   值会被「写回去但没生效」骗过）；
3. 进来时外键关着，升完仍关着；
4. `media_images` 已在场时重复升级不重插。

**变异实测**：还原 FK-off 后第 1 例红在原始报错 `no such table: main.video_books`（4 tests ran / 1 error）；
把恢复改成无条件 `ON` 后第 3 例红（4 tests ran / 1 error）。

## 验证

- `dart format` 改动文件；
- `flutter analyze`（含 test）：`No issues found! (ran in 43.4s)`；
- `hibiki/test/database` 全目录：`FLUTTER TEST VERDICT: PASSED - 534 tests ran, all tests passed`
  （修前 `FAILED - 65 error event(s), 530 test(s) completed`）；
- 32 条全仓元守卫 + `bugs_per_file_guard`：31 条可加载的全绿
  （`PASSED - 135 tests ran`）。两条例外均与本 PR 无关：
  `md3_design_system_static_test` 红在 `lib/src/media/manga/manga_json_writeback.dart: fontSize:` ——
  该文件与该守卫在 #712 自身 diff 里**一行未碰**，是分支基底陈旧继承来的，develop 已由
  `03aec7eab` / `6611be78f`（BUG-1418）修掉，#712 rebase 到 develop 后自动消失；
  `test/media/sources/book_history_split_guard_test.dart` 在本分支基底上还不存在（develop 后加的）。

BUG 记录：`docs/bugs/BUG-1444-v68-media-images-fk-parent-missing.md`。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
