### PR TITLE
ci(windows): vcpkg 缓存 key 带 runner 镜像版本，消掉桌面发布链取件抖动 (TODO-2668)

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -909,17 +909,53 @@ jobs:
           bash ci/apply-patches.sh
       # 内置 libtorrent 引擎的 Windows DLL：vcpkg 编 libtorrent + bridge，产物落
       # native/hibiki_torrent/prebuilt/windows-x64/，供下面 flutter build windows
-      # 的 copy-if-present 随包（缺则跳，运行期回退 qb）。vcpkg 二进制缓存摊薄首编
-      # ~40min（boost+openssl+libtorrent）到后续秒级。
+      # 的 copy-if-present 随包（缺则跳，运行期回退 qb）。
+      #
+      # TODO-2668｜缓存 key 必须带 runner 镜像版本，两条 Windows workflow 同一处病灶。
+      # 完整实测数据与失败链路见 release-desktop.yml 同名步骤上的长注释；要点：
+      # 常量 key 只装得下一种 runner 镜像的 ABI，而 actions/cache 命中即不回存，于是
+      # 另一种镜像永远冷编（`Restored 0 package(s)` + 22 min + ~110 个 tarball，其中
+      # ~45 个来自 mirror.msys2.org / ftpmirror.gnu.org / www.nasm.us / download.qt.io
+      # 这 4 个不受控主机）。key 带上 ImageVersion 后两种镜像各占一个条目，都走
+      # `Restored 72 package(s)` 的零下载路径（4 min）。二进制缓存故意不留 restore-keys：
+      # 前缀命中回来的是另一镜像的归档，实测一个都用不上。
+      - name: Resolve vcpkg cache identity
+        id: vcpkg_cache_id
+        shell: pwsh
+        run: |
+          # runner 镜像版本决定了镜像内固化的 vcpkg 修订与 MSVC 工具集，也就决定了
+          # 所有 vcpkg 包的 ABI hash。取不到时退回常量，行为等同改动前（冷编但不失败）。
+          $image = $env:ImageVersion
+          if ([string]::IsNullOrWhiteSpace($image)) { $image = 'unknown-image' }
+          $image = ($image -replace '[^0-9A-Za-z._-]', '-')
+          Write-Host "vcpkg cache identity (runner ImageVersion): $image"
+          # 用 pwsh 的 `>>`（GHA 的 shell: pwsh 是 PowerShell 7，写 UTF-8 无 BOM）。
+          # 别换成 `Out-File -Encoding utf8`：那在 Windows PowerShell 5.1 下会写 BOM，
+          # BOM 会跟着糊进第一个 key，GITHUB_OUTPUT 的 key=value 解析当场失效。
+          "image=$image" >> $env:GITHUB_OUTPUT
+      # 第二层，只兜「新镜像上线那一次必然冷编」的残余：缓存 vcpkg 的 distfile 目录，
+      # 等价于官方 asset cache 但不需要额外存储。distfile 全部 SHA512 校验，故前缀
+      # restore-key 拿回上一个镜像的目录是安全的；那 4 个高危非 GitHub 主机上的件跨
+      # vcpkg 修订几乎不变，前缀命中即可把高危取件面清零。排除 downloads\tools（解压
+      # 后的树）以免条目撑到 GB 级；重新解压是纯本地操作，不碰网络。
+      - name: Cache vcpkg source distfiles (libtorrent)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ runner.temp }}\vcpkg-downloads
+            !${{ runner.temp }}\vcpkg-downloads\tools
+          key: ${{ runner.os }}-vcpkg-downloads-libtorrent-v1-${{ steps.vcpkg_cache_id.outputs.image }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-downloads-libtorrent-v1-
       - name: Cache vcpkg binary archives (libtorrent)
         uses: actions/cache@v4
         with:
           path: ~\AppData\Local\vcpkg\archives
-          key: ${{ runner.os }}-vcpkg-libtorrent-x64-windows-v1
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-libtorrent-
+          key: ${{ runner.os }}-vcpkg-libtorrent-x64-windows-v2-${{ steps.vcpkg_cache_id.outputs.image }}
       - name: Build embedded libtorrent DLL (vcpkg)
         shell: pwsh
+        env:
+          VCPKG_DOWNLOADS: ${{ runner.temp }}\vcpkg-downloads
         run: |
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install libtorrent:x64-windows
           if ($LASTEXITCODE -ne 0) { throw "vcpkg install libtorrent failed" }

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -311,16 +311,69 @@ jobs:
           bash ci/apply-patches.sh
       # 内置 libtorrent 引擎 DLL：vcpkg 编 libtorrent + bridge，产物随发布包（下面
       # flutter build 的 copy-if-present 拷到 hibiki.exe 旁）。发布版必须带上，故此步
-      # 失败即让发布失败（不静默出无内置引擎的包）。vcpkg 二进制缓存摊薄首编。
+      # 失败即让发布失败（不静默出无内置引擎的包）。
+      #
+      # TODO-2668｜缓存 key 必须带 runner 镜像版本，否则这条链路每次都在冷编 + 拉网。
+      # 旧 key 是常量 `<os>-vcpkg-libtorrent-x64-windows-v1`，有两个叠加的后果：
+      #   a) GitHub 的 windows-2022 池同时在跑多个镜像版本，不同镜像里固化的 vcpkg
+      #      修订不同，全部包的 ABI hash 就不同，一个常量 key 只装得下其中一种；
+      #   b) actions/cache 只在「主 key 未命中」时才回存，所以另一种镜像的归档
+      #      永远存不进去，一直冷。
+      # 2026-08-02 实测 5 次 desktop run，ImageVersion 与命中率完全对应、无一例外：
+      #   20260728.258.1 -> `Restored 72 package(s)`，vcpkg 步骤 4 min，零下载；
+      #   20260720.249.2 -> 缓存命中、白下载解压 81MB，然后 `Restored 0 package(s)`，
+      #                     22 min 全量重编 72 个包，并拉 ~110 个 tarball。
+      # 那 ~110 个件里有 ~45 个来自 4 个不受我们控制的非 GitHub 主机
+      # （mirror.msys2.org x40 / ftpmirror.gnu.org x2 / www.nasm.us / download.qt.io）。
+      # run 30729229450 就死在其中一个：automake-1.17.tar.gz 三个 GNU 镜像同时
+      # `curl error 35 (SSL connect error)`，而 vcpkg 把 SSL connect error 判成
+      # 「Not a transient network error, won't retry」直接 BUILD_FAILED，桌面发布链整条
+      # 红（publish 那句 `No files matched hibiki-*-windows-setup.exe` 只是级联）。
+      # 所以根因不是「vcpkg 的重试判定写错了」——那是外部缺陷、我们改不了——而是
+      # 这条路径本来就不该下载任何东西：key 带上 ImageVersion 后两种镜像各占一个
+      # 条目，都走 `Restored 72` 的零下载路径，取件抖动面归零、顺带每次省 ~18 min。
+      # 二进制缓存故意不留 restore-keys：前缀命中回来的是另一镜像的归档，实测
+      # `Restored 0`，纯白下 81MB，还会连同新归档一起回存、越滚越大。
+      - name: Resolve vcpkg cache identity
+        id: vcpkg_cache_id
+        shell: pwsh
+        run: |
+          # runner 镜像版本决定了镜像内固化的 vcpkg 修订与 MSVC 工具集，也就决定了
+          # 所有 vcpkg 包的 ABI hash。取不到时退回常量，行为等同改动前（冷编但不失败）。
+          $image = $env:ImageVersion
+          if ([string]::IsNullOrWhiteSpace($image)) { $image = 'unknown-image' }
+          $image = ($image -replace '[^0-9A-Za-z._-]', '-')
+          Write-Host "vcpkg cache identity (runner ImageVersion): $image"
+          # 用 pwsh 的 `>>`（GHA 的 shell: pwsh 是 PowerShell 7，写 UTF-8 无 BOM）。
+          # 别换成 `Out-File -Encoding utf8`：那在 Windows PowerShell 5.1 下会写 BOM，
+          # BOM 会跟着糊进第一个 key，GITHUB_OUTPUT 的 key=value 解析当场失效。
+          "image=$image" >> $env:GITHUB_OUTPUT
+      # 第二层，只兜「新镜像上线那一次必然冷编」的残余：把 vcpkg 的 distfile 目录也
+      # 缓存住，等价于 vcpkg 官方 asset cache 要解决的问题，但不需要额外的 Azure 或
+      # 自建存储。distfile 全部按 SHA512 校验，所以前缀 restore-key 拿回上一个镜像的
+      # 目录是安全的——对不上号的文件 vcpkg 自己会重下。而恰好那 4 个高危非 GitHub
+      # 主机上的件（msys2 工具链 / automake / libiconv / nasm / jom）跨 vcpkg 修订几乎
+      # 不变，前缀命中就能把高危取件面清零。排除 downloads\tools（解压后的树）以免把
+      # 条目撑到 GB 级；重新解压是纯本地操作，不碰网络。该目录长期只增不减，体积不
+      # 合适了就把 key 里的 -v1 递增一次。
+      - name: Cache vcpkg source distfiles (libtorrent)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ runner.temp }}\vcpkg-downloads
+            !${{ runner.temp }}\vcpkg-downloads\tools
+          key: ${{ runner.os }}-vcpkg-downloads-libtorrent-v1-${{ steps.vcpkg_cache_id.outputs.image }}
+          restore-keys: |
+            ${{ runner.os }}-vcpkg-downloads-libtorrent-v1-
       - name: Cache vcpkg binary archives (libtorrent)
         uses: actions/cache@v4
         with:
           path: ~\AppData\Local\vcpkg\archives
-          key: ${{ runner.os }}-vcpkg-libtorrent-x64-windows-v1
-          restore-keys: |
-            ${{ runner.os }}-vcpkg-libtorrent-
+          key: ${{ runner.os }}-vcpkg-libtorrent-x64-windows-v2-${{ steps.vcpkg_cache_id.outputs.image }}
       - name: Build embedded libtorrent DLL (vcpkg)
         shell: pwsh
+        env:
+          VCPKG_DOWNLOADS: ${{ runner.temp }}\vcpkg-downloads
         run: |
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install libtorrent:x64-windows
           if ($LASTEXITCODE -ne 0) { throw "vcpkg install libtorrent failed" }


### PR DESCRIPTION
## 症状与真实根因

失败 run [`30729229450`](https://github.com/hajisensai/hibiki/actions/runs/30729229450)（head `510eb5281`，2026-08-02 03:34）：`Build embedded libtorrent DLL (vcpkg)` 在 `automake-1.17.tar.gz` 上三个 GNU 镜像同时 `curl error 35 (SSL connect error)`，vcpkg 判成 `Not a transient network error, won't retry` → `BUILD_FAILED`。publish 那句 `No files matched hibiki-*-windows-setup.exe` 只是级联。

**但 automake 不是根因，甚至不是「高危包」——它只是当晚掷骰子输的那一个。**

真实根因：**二进制缓存 key 是常量 `<os>-vcpkg-libtorrent-x64-windows-v1`**，两个后果叠加：

1. GitHub 的 windows-2022 池**同时在跑多个镜像版本**，各自固化的 vcpkg 修订不同 → 全部包的 ABI hash 不同 → 一个常量 key 只装得下其中一种；
2. `actions/cache` **只在主 key 未命中时才回存**，所以另一种镜像的归档**永远存不进去**，一直冷编。

### 实测证据（2026-08-02，5 次 desktop run，`ImageVersion` 与命中率完全对应、无一例外）

| run | ImageVersion | vcpkg 结果 | 耗时 |
|---|---|---|---|
| 30733265391 | **20260728.258.1** | `Restored 72 package(s)` | **4 min，零下载** |
| 30729229450 | **20260728.258.1** | 缓存 miss → 冷编 | **红（automake）** |
| 30737389630 | 20260720.249.2 | 缓存命中，`Restored 0 package(s)` | 22 min |
| 30735153142 | 20260720.249.2 | 缓存命中，`Restored 0 package(s)` | 22 min |
| 30734579757 | 20260720.249.2 | 缓存 miss | 25 min |

命中率 **1/5**。冷路径要编 **72 个包**、拉 **~110 个 tarball**，其中 **~45 个来自 4 个不受我们控制的非 GitHub 主机**：

- `mirror.msys2.org` ×40（vcpkg-make 现在要引一整套 MSYS2 工具链）
- `ftpmirror.gnu.org` ×2（automake、libiconv）
- `www.nasm.us` ×1（openssl 要）
- `download.qt.io` ×1（jom）

所以「近 10 次只红 1 次」是**运气**，不是稳态：每次 push 有 ~80% 概率去掷 ~110 次网络骰子。

## 改法

**根因层**：cache key 带上 `ImageVersion` → 两种镜像各占一个条目，都走 `Restored 72` 的零下载路径。**不下载的东西不会抖**，顺带每次省 ~18 min。

二进制缓存**故意去掉 `restore-keys`**：前缀命中回来的是另一镜像的归档，实测 `Restored 0` —— 纯白下 81MB，还会连同新归档一起回存、越滚越大。

**残余兜底层**：新增 vcpkg distfile 目录缓存（`VCPKG_DOWNLOADS` 重定向到 `runner.temp`），兜住「新镜像上线那一次必然冷编」。等价于 vcpkg 官方 asset cache 要解决的问题，但不需要额外的 Azure / 自建存储。distfile 全部按 SHA512 校验，故前缀 `restore-keys` 是安全的（对不上号 vcpkg 自己重下）；而那 4 个高危非 GitHub 主机上的件（msys2 / automake / libiconv / nasm / jom）跨 vcpkg 修订几乎不变，前缀命中即可把高危取件面清零。排除 `downloads\tools`（解压后的树）以免条目撑到 GB 级。

两条 Windows workflow（`release-desktop.yml` / `build-multiplatform.yml`）同一处病灶，一起改。

## 为什么不是别的方案

- **纯 retry**：vcpkg 明确不重试，外面套一层只是把 1 次失败变 3 次；而且它治不了「每次都在冷编」这个真问题。
- **预置 automake 固定件**：只堵 1/45 个高危件，下次红在 msys2 或 nasm.us。
- **独立 asset 存储（Azure/release assets）**：要新增可控存储 + 凭据 + 维护面，而 distfile 缓存用现成的 `actions/cache` 就等价。
- **vendor 预编译 DLL 入库**：要往仓库塞二进制，且 `native/hibiki_torrent/.gitignore` 明确不收。

## 验证

- `flutter analyze` 全量（含 test）：`No issues found!`
- 32 条目录枚举型守卫：`FLUTTER TEST VERDICT: PASSED - 194 tests ran`
- 条件加跑（改 workflow/.ps1）三条：`FLUTTER TEST VERDICT: PASSED - 31 tests ran`
- `tool/check_release_policy.ps1`：`Release policy guard passed.`
- 两个 YAML 均通过 parse，纯 LF、无 BOM/NUL
- 新增 pwsh 片段两个分支（有/无 `ImageVersion`）本机实跑过

**验不到、要靠本 PR 的 CI 实证的部分**：`$env:ImageVersion` 在 runner 上确实存在且就是那个 20260728.258.1。本 PR 触发的 `build-multiplatform.yml`（**artifact-only，无任何 release 面**）的 windows 作业会打出 `vcpkg cache identity (runner ImageVersion): <值>`——若打成 `unknown-image`，说明该变量名不对、需换 signal（这是本改动唯一的静默失效模式）。

## 兼容层的清理条件

distfile 缓存那层是显式兜底，不是根治。可以撤掉的条件：vcpkg 上游把 `curl error 35` 归回 transient 并重试，**或**我们不再在 CI 现编 libtorrent（改成产物随 release asset 分发）。根因层（key 带 ImageVersion）是永久修复，不需要清理。

