### PR TITLE
fix(test): PR#460 反定时器判据从禁 token 抬到禁行为，修 develop 上 4 条既有红

### DIFF
--- a/docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md
+++ b/docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md
@@ -14,12 +14,18 @@
   - 非 hook 实例（有声书歌词条 / 剪贴板文本窗）完全不进这条分支，窗口样式与渲染逐像素不变。
 - **[ ] ② 只有源码扫描守卫，缺运行时验证** — `hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart`（新增，源码扫描守卫）：
   - `WS_EX_TRANSPARENT` 只允许在 `SetBodyExTransparent` 内被应用，且必须配 `SWP_FRAMECHANGED`；`SetBodyExTransparent` 只允许被 `ApplyPassThroughExStyle` 调用；
-  - `return HTTRANSPARENT;` 在两个文件中都不得出现；`SetTimer(` / `KillTimer(` / 轮询符号在两个文件中都不得出现（PR#460 回归门）；
+  - `return HTTRANSPARENT;` 在两个文件中都不得出现；**定时器不得翻转可交互性**（PR#460 回归门，判据见下方「PR#460 回归门的判据修正」）；
   - **顺序不变量**：`pass_through_toolbar_.Show(` 必须出现在 `SetBodyExTransparent(true)` 之前，且失败路径必须把 `pass_through_` 摁回 false；
   - 工具条窗建窗 flags 不含 `WS_EX_TRANSPARENT`、含 `WS_EX_NOACTIVATE` / `WS_EX_TOPMOST`，且全文件没有 `GWL_EXSTYLE` 改写；
   - 两窗共表（8 个 action 顺序逐个比对）、共字形、共派发、几何由正文窗单向下发；
   - `CMakeLists.txt` 真的编了新 TU。
-  - 同时把 `hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart` 里那条「禁止一切 `WS_EX_TRANSPARENT` 改写」的旧断言换成新契约：**保留**反定时器四条（那才是 PR#460 的真教训），把「禁用该位」换成「必须走唯一 applier + 必须有逃生工具条」。旧断言正是浮窗长期带着一个跨进程无效的穿透模式的原因，如实记录在测试注释里。
+  - 同时把 `hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart` 里那条「禁止一切 `WS_EX_TRANSPARENT` 改写」的旧断言换成新契约：**保留**反定时器判据（那才是 PR#460 的真教训），把「禁用该位」换成「必须走唯一 applier + 必须有逃生工具条」。旧断言正是浮窗长期带着一个跨进程无效的穿透模式的原因，如实记录在测试注释里。
+- **PR#460 回归门的判据修正（2026-08-02）** — 上面两条守卫里的反定时器判据原本写成四个 token 禁令（`PollCursorInteractivity` / `ApplyInteractive` / `SetTimer(` / `KillTimer(`，双窗守卫里还有 `Timer(` / `WM_TIMER`）。**禁的是关键字，不是行为**，两个方向都错：
+  - **漏真阳**：`SetCoalescableTimer`、给 `SetTimer` 传一个自己的 `TIMERPROC`、`SetWindowsHookEx` 都能原样重建 PR#460，却绕开 `SetTimer(` 这个字面量；
+  - **报假阳**：PR#749 给台词浮窗加「按住 Shift 悬停查词」的 60ms 轮询时被误伤——那个定时器只读光标位置派发查词，全程碰不到任何可交互性状态，还专门写了 `if (pass_through_) { StopHoverLookupPolling(); return; }` 主动让位（`floating_lyric_window.cpp` `MaybeHoverLookup`），却让两条守卫同时转红并把红带进 develop。
+  - 判据改为不变式本身，收进 `hibiki/test/helpers/win32_interactivity_guard.dart` 的 `expectTimerCannotFlipInteractivity()`：① 每次装表必须把 TIMERPROC 传 `nullptr`，保证 `case WM_TIMER:` 是唯一定时器回调入口（否则后面的分析不完整）；② 禁 `SetWindowsHookEx`（离线程轮询光标，源码扫描分析不了它的回调）；③ 从每个 `case WM_TIMER:` 出发沿真实调用图做**可达性闭包**，闭包里出现任何可交互性写操作（`GWL_EXSTYLE` / `WS_EX_TRANSPARENT` / `SWP_FRAMECHANGED` / `HTTRANSPARENT` / `EnableWindow(` / `SetBodyExTransparent(` / `ApplyPassThroughExStyle(` / `pass_through_ =`）即红。
+  - 一句话语义：信息只许**单向**流动——穿透态 → 定时器（定时器可以读到 `pass_through_` 并把自己停掉），反向一律禁止。
+  - 变异实测（8 次，每次改完跑守卫、再按反向替换还原并逐字节比对）：PR#460 换成无辜命名、两跳之外重建 → 红；给 `SetTimer` 传自己的 `TIMERPROC` 绕开分析 → 红；在 `case WM_TIMER:` 里直接翻位 → 红；在 `case WM_TIMER:` 里加一句与可交互性无关的 `RequestRender()` → **绿**（判据不误伤）。
   - **局限（如实说明）**：源码扫描锁的是接线，不是运行时行为。跨进程点击真的落到游戏、以及工具条在任意时刻都可点，仍需下面的 Windows 真机验收。C++ 进不了 Dart 单测；更强的 Windows itest 层因本机冒烟门长期红而受阻，属成本取舍，不是跳过。
 - 🔴 **还差什么（这条 bug 未完成的全部原因）**：Windows 真机四条验收**一条都没做**。跨进程点击是否真的落到游戏、工具条是否在任意时刻都可点，源码扫描一个字也证明不了。四条如下，全部通过前本条保持未完成：
   1. 开穿透 → 点浮窗覆盖的游戏正文区 → **游戏推进台词**（这条是 BUG-951 本身，其余三条都是它的配套）；

--- a/hibiki/test/helpers/win32_interactivity_guard.dart
+++ b/hibiki/test/helpers/win32_interactivity_guard.dart
@@ -1,0 +1,261 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'source_guard.dart';
+
+// ---------------------------------------------------------------------------
+// PR#460 / BUG-951 不变式的**行为级**判据
+// ---------------------------------------------------------------------------
+//
+// 不变式的真实语义（见 docs/bugs/BUG-951-gal-overlay-click-through-cross-process.md）：
+// **定时器 / 离线程光标轮询永远不得改写浮窗的鼠标可交互性**
+// （WS_EX_TRANSPARENT / pass_through_ / HTTRANSPARENT / EnableWindow）。
+// PR#460 按 16ms 定时器读光标位置来回翻这个位，定时器一被饿死，用户已经把光标甩到
+// 工具条上点下去时位还没清掉——点击穿进游戏推台词 / 选分支，存档被破坏。
+//
+// 信息只允许**单向**流动：穿透态 -> 定时器（定时器可以读到 pass_through_ 并把自己
+// 停掉），反向一律禁止。
+//
+// 为什么不能继续用 token 判据（这个文件存在的原因）：
+// 旧守卫写的是 expect(cpp.contains('SetTimer('), isFalse)——它禁的是**关键字**，
+// 不是**行为**。于是 PR#749 给台词浮窗加「按住 Shift 悬停查词」的 60ms 轮询时被误伤：
+// 那个定时器只读光标位置派发查词，全程碰不到任何可交互性状态（还专门写了
+// if (pass_through_) { StopHoverLookupPolling(); return; } 主动让位），却让两条守卫
+// 同时转红。token 判据**两个方向都错**：
+// - 漏真阳：SetCoalescableTimer / TIMERPROC 回调 / SetWindowsHookEx 都能原样重建
+//   PR#460，却绕开 SetTimer( 这个字面量；
+// - 报假阳：任何与可交互性无关的定时器都被判红。
+//
+// 这里改成沿真实调用图判定：从每个定时器回调入口出发做**可达性闭包**，闭包里出现任何
+// 可交互性写操作即红。同时把「定时器回调入口可枚举」本身也钉死（TIMERPROC 必须是
+// nullptr，否则闭包分析就不完整），不然判据自己会被绕过去。
+
+/// 会改写「这个窗口收不收鼠标」的写操作。命中其一即视为翻转了可交互性。
+///
+/// 判据故意覆盖 Win32 里**所有**能做到这件事的装置，而不只是 PR#460 用过的那个：
+/// - `GWL_EXSTYLE` / `WS_EX_TRANSPARENT` / `SWP_FRAMECHANGED`：PR#460 的原装置；
+/// - `HTTRANSPARENT`：BUG-951 本体那个跨进程无效的装置；
+/// - `EnableWindow(`：另一条让整窗不吃鼠标的路；
+/// - `SetBodyExTransparent(` / `ApplyPassThroughExStyle(`：本仓的唯一 applier 与其漏斗。
+///   从定时器调到它们，等于绕过「只有三条生命周期边可以重放穿透」的结构不变式；
+/// - `pass_through_ =`：状态本身的写（`pass_through_ ==` 的读不算，`(?!=)` 排掉）。
+final List<RegExp> _interactivityWrites = <RegExp>[
+  RegExp(r'(?<![A-Za-z0-9_])GWL_EXSTYLE(?![A-Za-z0-9_])'),
+  RegExp(r'(?<![A-Za-z0-9_])WS_EX_TRANSPARENT(?![A-Za-z0-9_])'),
+  RegExp(r'(?<![A-Za-z0-9_])SWP_FRAMECHANGED(?![A-Za-z0-9_])'),
+  RegExp(r'(?<![A-Za-z0-9_])HTTRANSPARENT(?![A-Za-z0-9_])'),
+  RegExp(r'(?<![A-Za-z0-9_])EnableWindow\s*\('),
+  RegExp(r'(?<![A-Za-z0-9_])SetBodyExTransparent\s*\('),
+  RegExp(r'(?<![A-Za-z0-9_])ApplyPassThroughExStyle\s*\('),
+  RegExp(r'(?<![A-Za-z0-9_])pass_through_\s*=(?!=)'),
+];
+
+/// 装表的 Win32 入口。两个都认：只禁 `SetTimer` 会让 `SetCoalescableTimer` 原样
+/// 重建 PR#460 还判绿。
+const List<String> _timerInstallers = <String>[
+  'SetTimer',
+  'SetCoalescableTimer',
+];
+
+/// 从已掩码语料 [structural] 的下标 [openParen]（指向 `(`）起做圆括号配对，
+/// 返回配对上的 `)` 的下标；不配对返回 -1。
+int _matchingParen(String structural, int openParen) {
+  int depth = 0;
+  for (int i = openParen; i < structural.length; i++) {
+    final String c = structural[i];
+    if (c == '(') depth++;
+    if (c == ')') {
+      depth--;
+      if (depth == 0) return i;
+    }
+  }
+  return -1;
+}
+
+/// 把 `(a, b, c)` 的实参按**顶层**逗号切开（嵌套括号内的逗号不切）。
+List<String> _topLevelArgs(String call) {
+  final String inner = call.substring(1, call.length - 1);
+  final String structural = maskCommentsAndStrings(inner);
+  final List<String> out = <String>[];
+  int depth = 0;
+  int start = 0;
+  for (int i = 0; i < structural.length; i++) {
+    final String c = structural[i];
+    if (c == '(' || c == '[' || c == '{') depth++;
+    if (c == ')' || c == ']' || c == '}') depth--;
+    if (c == ',' && depth == 0) {
+      out.add(inner.substring(start, i).trim());
+      start = i + 1;
+    }
+  }
+  out.add(inner.substring(start).trim());
+  return out;
+}
+
+/// 取 [source] 里 [name] 每一次调用的完整实参表原文（含首尾圆括号）。
+List<String> _callArgumentLists(String source, String name) {
+  final String searchable = maskComments(source);
+  final String structural = maskCommentsAndStrings(source);
+  final RegExp call =
+      RegExp(r'(?<![A-Za-z0-9_])' + RegExp.escape(name) + r'\s*\(');
+  final List<String> out = <String>[];
+  for (final RegExpMatch m in call.allMatches(searchable)) {
+    final int open = m.end - 1;
+    final int close = _matchingParen(structural, open);
+    if (close < 0) {
+      fail('$name 的实参表圆括号不配对（下标 $open）');
+    }
+    out.add(source.substring(open, close + 1));
+  }
+  return out;
+}
+
+/// 取出 [source] 里每一个 `case WM_TIMER:` 分支体（花括号配对）。
+///
+/// 分支体必须是带花括号的形式；裸 `case WM_TIMER: Foo(); break;` 直接 `fail`——
+/// 没有花括号就没有可靠的右边界，闭包会一路吞到下一个 case，判据会静默变宽。
+List<String> _timerHandlerBodies(String source) {
+  const String label = 'case WM_TIMER:';
+  final String searchable = maskComments(source);
+  final String structural = maskCommentsAndStrings(source);
+  final List<String> out = <String>[];
+  int from = 0;
+  while (true) {
+    final int idx = searchable.indexOf(label, from);
+    if (idx < 0) break;
+    int probe = idx + label.length;
+    while (probe < structural.length &&
+        (structural[probe] == ' ' ||
+            structural[probe] == '\n' ||
+            structural[probe] == '\r' ||
+            structural[probe] == '\t')) {
+      probe++;
+    }
+    if (probe >= structural.length || structural[probe] != '{') {
+      fail('case WM_TIMER 分支体必须用花括号包起来，否则闭包分析取不到右边界');
+    }
+    out.add(balancedBlockFrom(source, idx,
+        openSearchFrom: probe, what: 'case WM_TIMER 分支体'));
+    from = idx + label.length;
+  }
+  return out;
+}
+
+/// 找 `[className]::[name]` 的**定义**体；只有声明或根本没有时返回 null。
+String? _memberDefinitionBody(String source, String className, String name) {
+  final String searchable = maskComments(source);
+  final String structural = maskCommentsAndStrings(source);
+  final RegExp def = RegExp(r'(?<![A-Za-z0-9_])' +
+      RegExp.escape(className) +
+      r'::' +
+      RegExp.escape(name) +
+      r'\s*\(');
+  for (final RegExpMatch m in def.allMatches(searchable)) {
+    final int open = m.end - 1;
+    final int close = _matchingParen(structural, open);
+    if (close < 0) continue;
+    int probe = close + 1;
+    // 跳过 const / noexcept / 空白，落到定义体的左花括号上。
+    while (probe < structural.length) {
+      final String c = structural[probe];
+      if (c == ' ' || c == '\n' || c == '\r' || c == '\t') {
+        probe++;
+        continue;
+      }
+      final RegExpMatch? word = RegExp(r'^[A-Za-z_][A-Za-z0-9_]*')
+          .firstMatch(structural.substring(probe));
+      if (word != null) {
+        probe += word.group(0)!.length;
+        continue;
+      }
+      break;
+    }
+    if (probe < structural.length && structural[probe] == '{') {
+      return balancedBlockFrom(source, m.start,
+          openSearchFrom: probe, what: '$className::$name 定义体');
+    }
+  }
+  return null;
+}
+
+/// [body] 的代码里以标识符身份被调用的所有名字。
+Set<String> _calledIdentifiers(String body) {
+  final RegExp call = RegExp(r'([A-Za-z_][A-Za-z0-9_]*)\s*\(');
+  return call
+      .allMatches(maskCommentsAndStrings(body))
+      .map((RegExpMatch m) => m.group(1)!)
+      .toSet();
+}
+
+/// 从 [seed] 出发、在 [source] 里可达的 [className] 成员函数体的并集（含 [seed]）。
+///
+/// 判据必须是**可达性**而不是「WM_TIMER 分支体这一屏里有没有」：PR#460 正是
+/// `case WM_TIMER:` 里只写一行 `UpdatePassThroughFromCursor();`，真正翻位的
+/// `SetWindowLongPtr(hwnd_, GWL_EXSTYLE, ...)` 在两跳之外。
+String reachableFromTimerCallback(
+  String source,
+  String className,
+  String seed,
+) {
+  final StringBuffer closure = StringBuffer(seed);
+  final Set<String> seen = <String>{};
+  final List<String> queue = _calledIdentifiers(seed).toList();
+  while (queue.isNotEmpty) {
+    final String name = queue.removeLast();
+    if (!seen.add(name)) continue;
+    final String? body = _memberDefinitionBody(source, className, name);
+    if (body == null) continue;
+    closure.writeln(body);
+    queue.addAll(_calledIdentifiers(body));
+  }
+  return closure.toString();
+}
+
+/// 断言 [source] 里**没有任何定时器回调**能改写窗口的鼠标可交互性（PR#460 不变式）。
+///
+/// [className] 是被扫文件里那个窗口类的名字（成员函数定义写作 `类名::方法`）。
+/// [label] 只进失败原因，方便一眼看出是哪份语料红的。
+///
+/// 三条一起才成立，缺一条判据就有洞：
+/// 1. 定时器回调入口**可枚举**——每次装表都必须把 TIMERPROC 传 `nullptr`，
+///    这样 `case WM_TIMER:` 就是唯一入口，第 3 条的闭包才是完整的；
+/// 2. 没有 `SetWindowsHookEx`——离线程钩子是另一条轮询光标的路，源码扫描分析不了
+///    它的回调，所以整个禁掉；
+/// 3. 每个 `case WM_TIMER:` 分支体的**可达性闭包**里不得出现任何可交互性写操作。
+void expectTimerCannotFlipInteractivity(
+  String source, {
+  required String className,
+  required String label,
+}) {
+  // 1) 入口可枚举。
+  for (final String installer in _timerInstallers) {
+    for (final String args in _callArgumentLists(source, installer)) {
+      final List<String> parts = _topLevelArgs(args);
+      expect(parts.length, greaterThanOrEqualTo(4),
+          reason: '$label：$installer$args 参数个数不对，判据读不到 TIMERPROC');
+      expect(parts[3], 'nullptr',
+          reason: '$label：$installer 必须把 TIMERPROC 传 nullptr，'
+              '否则定时器回调不止 case WM_TIMER 一处，'
+              '「定时器不翻转可交互性」这条判据就分析不完整了（PR#460 不变式）。');
+    }
+  }
+
+  // 2) 离线程光标钩子整个禁掉。
+  expect(maskComments(source).contains('SetWindowsHookEx'), isFalse,
+      reason: '$label：低级鼠标钩子是绕开消息循环轮询光标的另一条路，'
+          '源码扫描分析不了它的回调，因此不许出现在这份语料里（PR#460 不变式）。');
+
+  // 3) 每个定时器回调的可达闭包里不得有可交互性写操作。
+  for (final String handler in _timerHandlerBodies(source)) {
+    final String closure =
+        reachableFromTimerCallback(source, className, handler);
+    final String structural = maskCommentsAndStrings(closure);
+    for (final RegExp write in _interactivityWrites) {
+      expect(write.hasMatch(structural), isFalse,
+          reason: '$label：从 case WM_TIMER 可达的代码里出现了 '
+              '${write.pattern} —— 定时器又在翻转窗口的鼠标可交互性了。'
+              '这正是 PR#460 被 revert 的原因：表被饿死时，用户已经把光标甩到'
+              '工具条上点下去，位还没清掉，点击穿进游戏推台词 / 选分支。'
+              '定时器只许**读**穿透态（读到就把自己停掉），不许写。');
+    }
+  }
+}

--- a/hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart
+++ b/hibiki/test/media/audiobook/floating_lyric_click_through_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../helpers/win32_interactivity_guard.dart';
+
 /// Source-scan guards for the desktop floating-subtitle strip's click-through
 /// contract (TODO-038). The native Win32 window cannot run on the host, so
 /// these guards pin the load-bearing wiring that makes the strip both
@@ -42,21 +44,37 @@ void main() {
       expect(createFlags.contains('WS_EX_TOPMOST'), isTrue);
     });
 
-    test('interactivity is not driven by a hover timer', () {
+    test('no timer can flip interactivity (PR#460 invariant)', () {
       // A timer-driven transparent/interactive flip is inherently racy: a fast
       // mouse-enter + click can arrive while WS_EX_TRANSPARENT is still set.
       // This is the invariant that killed PR#460 and it still holds.
-      expect(cpp.contains('PollCursorInteractivity'), isFalse);
-      expect(cpp.contains('ApplyInteractive'), isFalse);
-      expect(cpp.contains('SetTimer('), isFalse);
-      expect(cpp.contains('KillTimer('), isFalse);
+      //
+      // PR#749 UPDATE — this used to be four token bans
+      // (`PollCursorInteractivity` / `ApplyInteractive` / `SetTimer(` /
+      // `KillTimer(`). Banning the KEYWORD instead of the BEHAVIOUR was wrong
+      // in both directions: `SetCoalescableTimer` / a `TIMERPROC` callback /
+      // `SetWindowsHookEx` all rebuild PR#460 verbatim while dodging the
+      // literal `SetTimer(`, and any timer unrelated to interactivity was
+      // failed on sight — which is what happened when the hook overlay grew a
+      // 60ms Shift-hover lookup poll that only reads the cursor and dispatches
+      // a word lookup (and explicitly stands down under `pass_through_`).
+      //
+      // The predicate is now the invariant itself: walk the real call graph out
+      // of every timer callback and fail if anything reachable WRITES the
+      // window's mouse interactivity. Information may flow pass-through ->
+      // timer (a timer may read the state and stop itself), never the reverse.
+      expectTimerCannotFlipInteractivity(
+        cpp,
+        className: 'FloatingLyricWindow',
+        label: 'floating_lyric_window.cpp',
+      );
 
       // BUG-951 UPDATE — this test used to also forbid touching
       // WS_EX_TRANSPARENT at all. That blanket ban was the reason the overlay
       // shipped a pass-through mode that did nothing across processes: the bit
       // is the ONLY cross-process click-through mechanism Win32 has. What was
       // actually unsafe was flipping it by cursor position on a timer, which
-      // the four assertions above already forbid.
+      // the reachability predicate above already forbids.
       //
       // The bit is now applied statically for as long as the user keeps
       // pass-through on, with the toolbar moved into its own always-clickable

--- a/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
+++ b/hibiki/test/tools/gal_overlay_passthrough_dual_window_guard_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import '../helpers/source_guard.dart';
+import '../helpers/win32_interactivity_guard.dart';
 
 /// BUG-951 — source-scan guards for the galgame hook overlay's pass-through
 /// design.
@@ -34,8 +35,11 @@ void main() {
   late String bodyHeader;
   late String cmake;
   late String host;
+  late String dartChannel;
 
   setUpAll(() {
+    dartChannel = File('lib/src/platform/gal_hook_text_overlay_channel.dart')
+        .readAsStringSync();
     body = File('windows/runner/floating_lyric_window.cpp').readAsStringSync();
     bodyHeader =
         File('windows/runner/floating_lyric_window.h').readAsStringSync();
@@ -120,17 +124,37 @@ void main() {
     });
 
     test('pass-through is not driven by a timer (PR#460 regression)', () {
+      // PR#749 UPDATE — this used to ban the token `Timer(` outright. That
+      // judged the KEYWORD, not the BEHAVIOUR, and it was wrong in both
+      // directions: a `TIMERPROC` callback rebuilds PR#460 verbatim without the
+      // body ever containing `WM_TIMER`, while a timer that merely reads the
+      // cursor to dispatch a word lookup — which is what the Shift-hover lookup
+      // poll does, and it explicitly stands down under `pass_through_` — was
+      // failed on sight.
+      //
+      // The predicate is now the invariant itself: from every timer callback,
+      // walk the real call graph and fail if anything reachable WRITES the
+      // window's mouse interactivity. It also pins that the callbacks are
+      // enumerable at all (TIMERPROC must be nullptr), so the reachability
+      // analysis cannot be dodged by installing a timer with its own callback.
+      expectTimerCannotFlipInteractivity(body,
+          className: 'FloatingLyricWindow', label: 'floating_lyric_window.cpp');
+      expectTimerCannotFlipInteractivity(toolbar,
+          className: 'HookToolbarWindow', label: 'hook_toolbar_window.cpp');
+      // The toolbar is the escape hatch; it has no pass-through state to flip
+      // and no reason to own a timer at all, so the stricter ban still applies
+      // there. Losing this would mean the one always-clickable window grew a
+      // way to stop being clickable.
+      expect(stripLineComments(toolbar).contains('Timer('), isFalse,
+          reason: 'The escape-hatch toolbar has no legitimate timer.');
+      // Symbol-level tombstones for PR#460's own helpers, in either file. Cheap
+      // belt-and-braces on top of the behavioural predicate: a resurrection by
+      // copy-paste is caught by name even before the call graph is walked.
       for (final String source in <String>[body, toolbar]) {
-        // Any Win32 timer entry point at all, not just SetTimer/KillTimer:
-        // SetCoalescableTimer would otherwise re-create PR#460 verbatim while
-        // passing a SetTimer-only ban. Neither file has a legitimate timer.
-        expect(source.contains('Timer('), isFalse,
-            reason: 'No timer of any kind may drive pass-through.');
-        expect(source.contains('WM_TIMER'), isFalse);
-        // Nor a mouse hook, the other way to poll the cursor off-thread.
-        expect(source.contains('SetWindowsHookEx'), isFalse);
-        expect(source.contains('PollCursorInteractivity'), isFalse);
-        expect(source.contains('ApplyPassThroughHitTest'), isFalse);
+        final String code = stripLineComments(source);
+        expect(code.contains('PollCursorInteractivity'), isFalse);
+        expect(code.contains('ApplyPassThroughHitTest'), isFalse);
+        expect(code.contains('UpdatePassThroughFromCursor'), isFalse);
       }
     });
 
@@ -237,6 +261,10 @@ void main() {
       final String table = toolbarHeader.substring(
           toolbarHeader.indexOf('kSlotActions'),
           toolbarHeader.indexOf('};', toolbarHeader.indexOf('kSlotActions')));
+      // Spelled out on purpose: the row's left-to-right order is muscle memory
+      // (rightmost is always 关闭), so a reorder must be a deliberate edit here
+      // and not something a refactor can do quietly. `topmost` joined at slot 7
+      // in PR#749 — ahead of close, so slots 0..6 kept their index.
       const List<String> expected = <String>[
         'replayVoice',
         'recaptureVoice',
@@ -245,6 +273,7 @@ void main() {
         'toggleTransparency',
         'lock',
         'openWorkbench',
+        'topmost',
         'close',
       ];
       final List<String> found = RegExp('"([a-zA-Z]+)"')
@@ -253,11 +282,33 @@ void main() {
           .toList();
       expect(found, expected,
           reason: 'Slot order is the wire contract with the Dart controller.');
-      expect(toolbarHeader.contains('constexpr int kSlotCount = 8'), isTrue);
+      // Derived, not a second literal to keep in sync: a table that grows while
+      // kSlotCount does not is an out-of-bounds read in both windows.
+      expect(
+          toolbarHeader
+              .contains('constexpr int kSlotCount = ${expected.length}'),
+          isTrue,
+          reason: 'kSlotCount must equal the shared table length.');
       expect(
           body.contains('kHookTextControlSlotCount = hook_toolbar::kSlotCount'),
           isTrue,
           reason: 'The body must derive its slot count from the shared table.');
+
+      // No dead buttons. Every slot must actually be executed somewhere: either
+      // natively in DispatchControlAction (`lock` / `topmost` deliberately skip
+      // the Dart round-trip) or by the Dart controller's action switch. Without
+      // this, adding a slot to the table draws a button that does nothing —
+      // and the hardcoded list above would happily bless it.
+      final String dispatcher = functionBody(body,
+          'void FloatingLyricWindow::DispatchControlAction(const std::string& action)');
+      for (final String action in expected) {
+        final bool nativelyHandled = dispatcher.contains('== "$action"');
+        final bool dartHandled = dartChannel.contains("case '$action':");
+        expect(nativelyHandled || dartHandled, isTrue,
+            reason: 'Slot "$action" is drawn and hit-tested but nothing runs '
+                'it — neither DispatchControlAction nor the Dart controller '
+                'handles it.');
+      }
     });
 
     test('glyph + active tint are shared too', () {
@@ -279,7 +330,24 @@ void main() {
       final String dispatcher = functionBody(body,
           'void FloatingLyricWindow::DispatchControlAction(const std::string& action)');
       expect(dispatcher.contains('on_lock_'), isTrue);
-      expect(dispatcher.contains('topmost_ = !topmost_'), isTrue);
+      // PR#749 UPDATE — this used to be `contains('topmost_ = !topmost_')`,
+      // an inline write that PR#749 correctly extracted into SetTopmost() so
+      // the pin button and Dart's session reset drive the same code. Pinning
+      // the literal would have punished the better structure, so pin the
+      // structure instead: the dispatcher toggles through the single applier,
+      // and the applier is the ONLY writer of topmost_. Every window-Z
+      // SetWindowPos reads that member, so a second writer is how the pin ends
+      // up lit while the window is no longer topmost.
+      expect(dispatcher.contains('SetTopmost(!topmost_)'), isTrue,
+          reason: 'The pin button must toggle through the single applier.');
+      expect(countOf(stripLineComments(body), 'topmost_ ='), 1,
+          reason: 'SetTopmost() must be the only writer of topmost_.');
+      expect(
+          functionBody(
+                  body, 'void FloatingLyricWindow::SetTopmost(bool enabled)')
+              .contains('topmost_ = enabled'),
+          isTrue,
+          reason: 'That one writer must be SetTopmost().');
     });
 
     test('geometry is pushed from the body, not recomputed in the toolbar', () {


### PR DESCRIPTION
修掉 develop 上 **4 条既有真红**（不是本 PR 引入），并把 PR#460 的反定时器判据从「禁 token」抬到「禁行为」。

## 判定：(A) 守卫判据过宽 — 不是 PR#749 引入回归

4 条红全部由 `6d93671c7`（PR#749「台词浮窗 Shift 悬停查词 + 置顶按钮」）引入，合并时未跟着更新守卫：

| 文件 | 断言 | 性质 |
|---|---|---|
| `test/media/audiobook/floating_lyric_click_through_guard_test.dart:51` | `SetTimer(` token 禁令 | 判据过宽 |
| `test/tools/gal_overlay_passthrough_dual_window_guard_test.dart:127` | `Timer(` token 禁令 | 判据过宽（同根因） |
| 同上 `:254` | 槽位表硬编码 8 项 | 字面量过期 |
| 同上 `:282` | `topmost_ = !topmost_` 字面量 | 字面量过期 |

> 属主更正：协调线把槽位表那条归给 `27975f7b5`。实测 `kSlotActions` 里的 `"topmost"` 与 `kSlotCount 8 -> 9` 是 `6d93671c7` 加的（`git show 6d93671c7 -- hibiki/windows/runner/hook_toolbar_window.h`）；`27975f7b5` / `0e9a1f5a1` 只给**剪贴板文本窗**加了图钉，没碰 gal hook 工具条的槽位表。4 条红同源。

## PR#460 那条不变式的真实语义

查 `1b64393d9`（PR#460 合并）→ `99a964749`（revert）→ `docs/bugs/BUG-951-*.md`：

PR#460 为了让穿透态下顶部恢复带还能点，**按 16ms 定时器读光标位置来回翻整窗 `WS_EX_TRANSPARENT`**。被 revert 的理由是本质竞态：定时器可被饿死，期间用户快速甩到工具条点一下会穿过去点进游戏，推进台词或选中分支破坏存档。

所以不变式是「**定时器 / 离线程光标轮询不得改写窗口的鼠标可交互性**」——一个**行为**。守卫却把它写成四个 **token** 禁令。

## PR#749 的定时器碰不到这条不变式

`floating_lyric_window.cpp` 的 60ms 表只做 Shift 悬停查词：

- `case WM_TIMER:` → `MaybeHoverLookup()` → `CharIndexAt()` / `DispatchLookupAt()` / `ResetHoverLookupAnchor()` / `StopHoverLookupPolling()`，闭包里**没有任何**可交互性写操作；
- 唯一的 ex-style 写者 `SetBodyExTransparent()` 只被 `ApplyPassThroughExStyle()` 调用，后者只有 Show / Hide / SetPassThrough 三个调用点——定时器不在其中；
- `MaybeHoverLookup()` 开头还专门写了 `if (pass_through_) { StopHoverLookupPolling(); ResetHoverLookupAnchor(); return; }`，主动向 BUG-951 的契约让位。

信息是**单向**的：穿透态 → 定时器（定时器读到就把自己停掉），从不反向。

## 新判据（`test/helpers/win32_interactivity_guard.dart`）

`expectTimerCannotFlipInteractivity()` 三条一起才成立：

1. **入口可枚举** — 每次 `SetTimer` / `SetCoalescableTimer` 都必须把 TIMERPROC 传 `nullptr`，保证 `case WM_TIMER:` 是唯一定时器回调入口（否则第 3 条的分析不完整）；
2. **禁 `SetWindowsHookEx`** — 离线程钩子是另一条轮询光标的路，源码扫描分析不了它的回调；
3. **可达性闭包** — 从每个 `case WM_TIMER:` 沿真实调用图展开成员函数体，闭包里出现任何可交互性写操作即红：`GWL_EXSTYLE` / `WS_EX_TRANSPARENT` / `SWP_FRAMECHANGED` / `HTTRANSPARENT` / `EnableWindow(` / `SetBodyExTransparent(` / `ApplyPassThroughExStyle(` / `pass_through_ =`。

覆盖面比旧 token 判据**更严**：旧判据放行 `SetCoalescableTimer`、自带 TIMERPROC、`SetWindowsHookEx`；新判据都堵上了。

## 变异实测（8 次，全部反向替换还原 + sha256 逐字节比对 = REVERT-EXACT）

| # | 变异 | 期望 | 实测 |
|---|---|---|---|
| M2 | PR#460 换无辜命名（`RefreshOverlayHitState` → `CommitHitStyle`），两跳之外翻位 | 红 | **红**（3 failures / 26 ran）— 证明闭包分析生效，不是符号名匹配 |
| M3 | `SetTimer(..., &HoverProc)` 自带 TIMERPROC 绕开分析 | 红 | **红**（2 / 26） |
| M4 | 在 `case WM_TIMER:` 里直接 `SetWindowLongPtr(GWL_EXSTYLE, \| WS_EX_TRANSPARENT)` | 红 | **红**（3 / 26） |
| M5 | 在 `case WM_TIMER:` 里加无关的 `RequestRender()` | **绿** | **绿**（26 ran, passed）— 判据不误伤 |
| M6 | 加第 10 个槽位 + `kSlotCount = 10` | 红 | **红**（1 / 16） |
| M7 | 表长增加但 `kSlotCount` 不动 | 红 | **红**（1 / 16） |
| M8 | 给 `topmost_` 加第二个写者 | 红 | **红**（1 / 16） |
| M9 | 加一个**已登记进 expected 列表**但无人执行的槽位 | 红 | **红**，原因串正是 `Slot "screenshot" is drawn and hit-tested but nothing runs it` — 隔离出新增的「没有死按钮」断言确实活着（M6 只命中列表字面量，那条没跑到） |

每轮 `N tests ran` 均 > 0，无零测试执行。

## 另两条：钉结构，不钉字面量

- 槽位表 8 → 9（`topmost` 插在 `close` 前，0..6 索引不变）。`kSlotCount` 改为由 `expected.length` **推导**，不再是第二个要手工同步的字面量；**新增「没有死按钮」断言**：每个槽位必须真被 `DispatchControlAction`（`lock` / `topmost` 走 native）或 Dart 控制器 switch（其余 7 个）执行。
- `topmost_ = !topmost_` → PR#749 把它提成了 `SetTopmost()`（图钉按钮与 Dart 会话复位共用一条路）。钉字面量等于惩罚更好的结构。改钉：派发器经唯一 applier 翻转，且 `SetTopmost()` 是 `topmost_` 的**唯一写者**——每处 window-Z `SetWindowPos` 都读这个成员，第二个写者就是「图钉亮着而窗口已经不置顶」的来源。

净效果是**加严**，不是放宽。

## 验证

| 门 | 结果 |
|---|---|
| `flutter analyze`（全量含 test） | `No issues found! (ran in 51.6s)` |
| 32 条元守卫整批 | `PASSED - 194 tests ran`（与基线 194 一致） |
| `test/media/audiobook` 全目录（主判据） | `PASSED - 882 tests ran` |
| `test/tools` 全目录 + `test/mining/gal_ipc_contract_single_source_test.dart` | `PASSED - 242 tests ran` |
| `test/tools/bugs_per_file_guard_test.dart`（改了 docs/bugs 后重跑） | `PASSED - 3 tests ran` |

未改任何 `hibiki/windows/` native 源码（变异全部逐字节还原，`git status` 干净）。Galgame 只动 Windows 端。

## 没做的事 + 理由

**没有改 `docs/agent/fast-workflow.md` 的条件加跑清单。** 那段在未合并的 PR#752（`docs/merge-scan-guard-checklist-2705` @ `9b4c1946f`）上，develop 侧根本没有这一节；在我的分支上另起一份 = 保证冲突，而且「+2 个测试名」是治标。反向枚举的结果见 PR 讨论 / 交付报告：条件清单列了 **9 个**测试，实际读 native / 非 Dart 树的守卫约 **150 个**，且 android / ios / macos / linux / `packages/*/windows` 五棵树**一条触发规则都没有**。建议 #752 的属主把「点名测试」换成「按树给 glob」。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
