### PR TITLE
feat(video): 查词浮层顶栏加「重播本句 / 跳到此句 / 复制」

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 52836 (3108 per locale)
+/// Strings: 52853 (3109 per locale)
 ///
-/// Built on 2026-08-02 at 08:03 UTC
+/// Built on 2026-08-02 at 09:22 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4183,6 +4183,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get mihon_extension_sources_included => 'Included sources';
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -11323,6 +11324,8 @@ class _StringsAr extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -18530,6 +18533,8 @@ class _StringsDe extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -25752,6 +25757,8 @@ class _StringsEs extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -32986,6 +32993,8 @@ class _StringsFr extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -40149,6 +40158,8 @@ class _StringsId extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -47358,6 +47369,8 @@ class _StringsIt extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -54384,6 +54397,8 @@ class _StringsJa extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -61412,6 +61427,8 @@ class _StringsKo extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -68601,6 +68618,8 @@ class _StringsNl extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -75803,6 +75822,8 @@ class _StringsPtBr extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -82989,6 +83010,8 @@ class _StringsRu extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -90123,6 +90146,8 @@ class _StringsTh extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -97289,6 +97314,8 @@ class _StringsTr extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -104440,6 +104467,8 @@ class _StringsVi extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 // Path: <root>
@@ -111091,6 +111120,8 @@ class _StringsZhCn extends _StringsEn {
   String get mihon_extension_sources_included => '包含的源';
   @override
   String get mihon_extension_preview_read_only => '预览是只读的。安装扩展后才能打开阅读。';
+  @override
+  String get video_subtitle_replay => '重播本句';
 }
 
 // Path: <root>
@@ -118038,6 +118069,8 @@ class _StringsZhHk extends _StringsEn {
   @override
   String get mihon_extension_preview_read_only =>
       'Preview is read-only. Install the extension to open and read.';
+  @override
+  String get video_subtitle_replay => 'Replay this line';
 }
 
 /// Flat map(s) containing all translations.
@@ -124414,6 +124447,8 @@ extension on _StringsEn {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -130788,6 +130823,8 @@ extension on _StringsAr {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -137184,6 +137221,8 @@ extension on _StringsDe {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -143579,6 +143618,8 @@ extension on _StringsEs {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -149980,6 +150021,8 @@ extension on _StringsFr {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -156363,6 +156406,8 @@ extension on _StringsId {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -162760,6 +162805,8 @@ extension on _StringsIt {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -169119,6 +169166,8 @@ extension on _StringsJa {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -175482,6 +175531,8 @@ extension on _StringsKo {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -181873,6 +181924,8 @@ extension on _StringsNl {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -188261,6 +188314,8 @@ extension on _StringsPtBr {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -194654,6 +194709,8 @@ extension on _StringsRu {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -201030,6 +201087,8 @@ extension on _StringsTh {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -207415,6 +207474,8 @@ extension on _StringsTr {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -213796,6 +213857,8 @@ extension on _StringsVi {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }
@@ -220123,6 +220186,8 @@ extension on _StringsZhCn {
         return '包含的源';
       case 'mihon_extension_preview_read_only':
         return '预览是只读的。安装扩展后才能打开阅读。';
+      case 'video_subtitle_replay':
+        return '重播本句';
       default:
         return null;
     }
@@ -226477,6 +226542,8 @@ extension on _StringsZhHk {
         return 'Included sources';
       case 'mihon_extension_preview_read_only':
         return 'Preview is read-only. Install the extension to open and read.';
+      case 'video_subtitle_replay':
+        return 'Replay this line';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "放弃",
   "mihon_extension_preview_source_select": "选择要预览的源",
   "mihon_extension_sources_included": "包含的源",
-  "mihon_extension_preview_read_only": "预览是只读的。安装扩展后才能打开阅读。"
+  "mihon_extension_preview_read_only": "预览是只读的。安装扩展后才能打开阅读。",
+  "video_subtitle_replay": "重播本句"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3106,5 +3106,6 @@
   "mihon_extension_preview_discard": "Discard",
   "mihon_extension_preview_source_select": "Pick a source to preview",
   "mihon_extension_sources_included": "Included sources",
-  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read."
+  "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
+  "video_subtitle_replay": "Replay this line"
 }

--- a/hibiki/lib/src/media/video/video_player_controller.dart
+++ b/hibiki/lib/src/media/video/video_player_controller.dart
@@ -327,7 +327,27 @@ class VideoPlayerController extends ChangeNotifier
   Future<void> Function()? _pauseAtSubtitleEndOverride;
   bool Function()? _pauseAtSubtitleEndIsPlayingOverride;
   Future<void> Function(int positionMs)? _pauseAtSubtitleEndSeekOverride;
+
+  /// 测试注入：[replayCue] 的起播出口（生产为 null，走真 [play]）。无 [_player] 的
+  /// 纯单测里 [play] 是 no-op，靠它断言「重播确实起播了」。
+  Future<void> Function()? _replayPlayOverride;
   int? _lastSubtitleEndPauseCueIndex;
+
+  /// 「只播这一句就停」的一次性目标 cue 下标（[replayCue] 置，句尾停下即消耗）；
+  /// null = 无一次性请求。
+  ///
+  /// **与全局偏好 [_pauseAtSubtitleEnd] 正交**，故必须是独立字段而不是「临时把开关
+  /// 打开、停下再关」：后者一旦停不下来（用户中途 seek 走 / 换片）就把用户的真实偏好
+  /// 永久写反了。两者经 [_holdEnabledForCue] 汇成同一个句尾判定，句尾暂停的时序、
+  /// seek 回句尾的落点、防重复停（[_lastSubtitleEndPauseCueIndex]）全部共用一套代码，
+  /// 不产生第二条平行路径。
+  ///
+  /// **生命周期绝不能挂进 [_clearSeekTargetSnap]**（那是「主动跳转快照」的复位点）：
+  /// 该方法在**自然播放越过目标句**时会被 [_applySeekTargetSnap] 自行调用，而那一刻
+  /// 正是重播即将抵达句尾、最需要本字段存活的时刻——挂进去等于每次重播都在停下来
+  /// 之前把自己清掉。因此只在**用户主动改变播放位置**的两个真实出口（[seekMs] /
+  /// [_rawSeekMs]，后者覆盖 [skipToCue] 点别的句子）和换片换字幕（[setCues]）清。
+  int? _oneShotHoldCueIndex;
 
   /// 当前启用的 mpv 着色器绝对路径（[load] 复用 / [applyShaders] 实时切换）。
   List<String> _shaderPaths = <String>[];
@@ -867,6 +887,10 @@ class VideoPlayerController extends ChangeNotifier
     // 换字幕/换片（[load] 经此）复位主动跳转目标快照 + 在途 seek 宽限：旧目标下标对新
     // _cues 已失效，留着会让首个 tick 误 snap（TODO-565）。
     _clearSeekTargetSnap();
+    // 同理复位一次性「只播这一句就停」请求与句尾防重复停记号：两者都是**旧 _cues 的
+    // 下标**，对新列表已无意义，留着会让新片的某句被无缘无故停一次。
+    _oneShotHoldCueIndex = null;
+    _lastSubtitleEndPauseCueIndex = null;
     notifyListeners();
   }
 
@@ -1130,8 +1154,7 @@ class VideoPlayerController extends ChangeNotifier
     final int requestedStartMs = initialPositionMs < 0 ? 0 : initialPositionMs;
     final int preloadStartMs =
         resolveEpisodeStart(startIntent, requestedStartMs, null);
-    final bool startArmed =
-        await applyMpvStartPosition(player, preloadStartMs);
+    final bool startArmed = await applyMpvStartPosition(player, preloadStartMs);
     if (!_isCurrentLoad(player, loadToken)) return; // start 下发后换片/销毁。
 
     await player.open(
@@ -1919,11 +1942,13 @@ class VideoPlayerController extends ChangeNotifier
     bool Function()? isPlaying,
     required Future<void> Function() onPause,
     Future<void> Function(int positionMs)? onSeek,
+    Future<void> Function()? onPlay,
   }) {
     _pauseAtSubtitleEnd = enabled;
     _pauseAtSubtitleEndOverride = onPause;
     _pauseAtSubtitleEndIsPlayingOverride = isPlaying;
     _pauseAtSubtitleEndSeekOverride = onSeek;
+    _replayPlayOverride = onPlay;
     _lastSubtitleEndPauseCueIndex = null;
   }
 
@@ -2169,16 +2194,32 @@ class VideoPlayerController extends ChangeNotifier
     }
   }
 
+  /// 第 [cueIndex] 句是否该在句尾停：全局偏好开着（每句都停）**或**它正是一次性
+  /// [replayCue] 的目标句。两个来源在此汇成单一判定，句尾时序只有一套实现。
+  bool _holdEnabledForCue(int cueIndex) =>
+      _pauseAtSubtitleEnd || _oneShotHoldCueIndex == cueIndex;
+
+  /// 消耗一次性 hold（仅当它正指向 [cueIndex]）。停下即用完，避免用户之后自然播回
+  /// 同一句时被再停一次。
+  void _consumeOneShotHold(int cueIndex) {
+    if (_oneShotHoldCueIndex == cueIndex) _oneShotHoldCueIndex = null;
+  }
+
+  /// 句尾落进 gap（下一拍无 cue）的暂停路径。此刻 [_currentCueIndex] 仍是**刚结束
+  /// 那句**（调用点在把它清成 -1 之前），故一次性 hold 按它判定并消耗。
   void _pauseForSubtitleEnd() {
-    if (!_pauseAtSubtitleEnd) return;
+    final int endedCueIndex = _currentCueIndex;
+    if (!_holdEnabledForCue(endedCueIndex)) return;
+    _consumeOneShotHold(endedCueIndex);
     unawaited((_pauseAtSubtitleEndOverride ?? pause).call());
   }
 
   bool _shouldHoldAtSubtitleEnd(int nextCueIndex, int effectiveMs) {
-    if (!_pauseAtSubtitleEnd || nextCueIndex < 0) return false;
+    if (nextCueIndex < 0) return false;
     if (_currentCueIndex < 0 || _currentCueIndex >= _cues.length) {
       return false;
     }
+    if (!_holdEnabledForCue(_currentCueIndex)) return false;
     if (nextCueIndex == _currentCueIndex) return false;
     final AudioCue cue = _cues[_currentCueIndex];
     if (effectiveMs <= cue.endMs) return false;
@@ -2196,6 +2237,7 @@ class VideoPlayerController extends ChangeNotifier
 
   void _pauseAndSeekForSubtitleEnd(AudioCue cue, int cueIndex) {
     _lastSubtitleEndPauseCueIndex = cueIndex;
+    _consumeOneShotHold(cueIndex);
     unawaited(() async {
       await (_pauseAtSubtitleEndOverride ?? pause).call();
       final Future<void> Function(int positionMs) seekToEnd =
@@ -2242,6 +2284,8 @@ class VideoPlayerController extends ChangeNotifier
   Future<void> seekMs(int positionMs) async {
     final int clampedMs = positionMs.clamp(0, 1 << 30);
     _clearSeekTargetSnap();
+    // 用户主动改变播放位置 = 放弃「只播这一句就停」的意图（[_oneShotHoldCueIndex]）。
+    _oneShotHoldCueIndex = null;
     _beginPlainSeekInFlight(clampedMs);
     // 权威同步：直接按目标位置算一次字幕（不经 tick 的位置调和），gap 则立即清空。
     _syncCueForPosition(clampedMs, persistPosition: false);
@@ -2255,6 +2299,10 @@ class VideoPlayerController extends ChangeNotifier
   /// 快照 snap 回目标，凭空多一次闪烁。
   Future<void> _rawSeekMs(int positionMs) async {
     _clearSeekTargetSnap();
+    // 同 [seekMs]：跳到别的句（[skipToCue]）即放弃上一次「只播这一句就停」。
+    // [replayCue] 是唯一例外——它在本方法**之后**才置自己的一次性 hold，与
+    // [skipToCue] 置 [_seekTargetCueIndex] 的顺序契约完全同构，故不会被自清。
+    _oneShotHoldCueIndex = null;
     await _player?.seek(Duration(milliseconds: positionMs.clamp(0, 1 << 30)));
   }
 
@@ -2376,6 +2424,42 @@ class VideoPlayerController extends ChangeNotifier
     _seekSnapGraceTicksLeft =
         _seekTargetCueIndex == null ? 0 : _seekSnapGraceTicks;
   }
+
+  /// 重播 [cue]：跳回句首并播放，**播到该句结尾自动暂停**（一次性）。
+  ///
+  /// 供查词浮层顶栏「重播本句」使用（听不清就地重听，不必手动倒回再按暂停）。
+  ///
+  /// 与 [skipToCue] 的差别只有两点：本方法会**主动起播**，并给这一句挂一次性
+  /// [_oneShotHoldCueIndex]。句尾停下的判定、落点与防重复停完全复用「字幕结束暂停」
+  /// 那套（[_shouldHoldAtSubtitleEnd] / [_pauseAndSeekForSubtitleEnd]），因此倍速、
+  /// 字幕延迟（[_delayMs]）、关键帧吸附、seek 在途 lag 全部自动吃到同一份处理——
+  /// **不是**在 UI 层按 `endMs - startMs` 起个定时器等句长（那种做法会被倍速、缓冲、
+  /// 用户中途 seek 逐一打穿）。
+  ///
+  /// 一次性 hold 的作废由 [seekMs] / [_rawSeekMs] / [setCues] 负责：用户中途拖进度、
+  /// 跳去别的句或换片，都立刻放弃「停在本句尾」的意图。全局偏好
+  /// `字幕结束暂停`（[setPauseAtSubtitleEnd]）与本方法正交，互不改写。
+  Future<void> replayCue(AudioCue cue) async {
+    // 先 seek（内部 [_rawSeekMs] 会清掉上一次的一次性 hold），再置本次目标——顺序与
+    // [skipToCue] 置 [_seekTargetCueIndex] 同构，故绝不会被自清。
+    await skipToCue(cue);
+    final int? targetIndex = _resolveCueIndex(cue);
+    if (targetIndex != null) {
+      _oneShotHoldCueIndex = targetIndex;
+      // 这一句可能刚被句尾暂停过（全局开关开着时）。不清防重复记号的话，重播到句尾会
+      // 被 [_shouldHoldAtSubtitleEnd] 的「停过就不再停」挡掉、直接播进下一句。
+      _lastSubtitleEndPauseCueIndex = null;
+    }
+    // targetIndex == null（目标不在当前 cue 列表，换轨/换片竞态）：仍已 seek 到位，
+    // 但没有可挂 hold 的下标，退化成「跳过去接着播」，不静默假装能停。
+    // 两条分支共用同一个起播出口——分头调 play 会让退化路径绕开测试注入、也埋下
+    // 「以后只改一处」的隐患。
+    await (_replayPlayOverride ?? play).call();
+  }
+
+  /// 测试可见：当前一次性「只播这一句就停」目标下标（[_oneShotHoldCueIndex]）。
+  @visibleForTesting
+  int? get debugOneShotHoldCueIndex => _oneShotHoldCueIndex;
 
   /// 升序 cue 列表上按 `startMs` 二分求分界下标（要求 [cues] 已按 startMs 升序）：
   /// - [inclusive] 为 false：lower bound——返回首个 `startMs >= value` 的下标；

--- a/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart
@@ -170,6 +170,54 @@ extension _VideoLookupFavorite on _VideoHibikiPageState {
     _showOsd(t.favorite_added, icon: Icons.favorite);
   }
 
+  /// 查词浮层顶栏「重播本句」：跳回当前查词那句的句首、起播，播到句尾自动暂停。
+  ///
+  /// 句尾停在 [VideoPlayerController.replayCue] 里由播放器的句尾判定负责（与「字幕
+  /// 结束暂停」偏好共用一套时序），这里只负责选对句子和反馈。
+  ///
+  /// 不动 [_pausedForLookup]：它记录的是「查词**之前**是否在播」，是关浮层恢复播放
+  /// （BUG-072）的依据；重播是浮层内的临时试听，改写它会让关浮层后的恢复行为跟着
+  /// 用户听没听过一句而漂移。
+  Future<void> _replayLookupCue() async {
+    final AudioCue? cue = _lastLookupCue;
+    final VideoPlayerController? controller = _controller;
+    if (cue == null || controller == null) {
+      _showOsd(t.no_sentence_selected);
+      return;
+    }
+    await controller.replayCue(cue);
+  }
+
+  /// 查词浮层顶栏「跳到此句」：把播放位置移到当前查词那句的句首，**不改播放状态**
+  /// （查词时通常已暂停，跳完仍停在句首）。与字幕跳转列表行的 ▶ / 点行同一入口
+  /// （[VideoPlayerController.skipToCue]），前导余量与 cue-snap 行为完全一致。
+  Future<void> _jumpToLookupCue() async {
+    final AudioCue? cue = _lastLookupCue;
+    final VideoPlayerController? controller = _controller;
+    if (cue == null || controller == null) {
+      _showOsd(t.no_sentence_selected);
+      return;
+    }
+    await controller.skipToCue(cue);
+  }
+
+  /// 查词浮层顶栏「复制」：复制当前查词那句的字幕文本。
+  ///
+  /// 优先复制锚定 cue 的文本（与收藏 / 制卡取的是同一句）；没有 cue 时（无字幕轨、
+  /// 或字幕 gap 中查词）回落到 [_lastLookupSentence]，不至于让按钮变成哑的。
+  void _copyLookupSentence() {
+    final AudioCue? cue = _lastLookupCue;
+    final String text = (cue?.text.trim().isNotEmpty ?? false)
+        ? cue!.text.trim()
+        : _lastLookupSentence.trim();
+    if (text.isEmpty) {
+      _showOsd(t.no_sentence_selected);
+      return;
+    }
+    Clipboard.setData(ClipboardData(text: text));
+    _showOsd(t.copied_to_clipboard, icon: Icons.copy);
+  }
+
   /// 从字幕跳转列表面板行内复制某句文本到剪贴板（TODO-152 子A）。不暂停 / 不查词。
   void _copyCueText(AudioCue cue) {
     final String text = cue.text.trim();

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -3590,14 +3590,23 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
     _thumbnailGrabber = null;
   }
 
-  /// 查词浮层顶部「收藏当前字幕句」星标行（覆写 [DictionaryPageMixin.buildPopupHeaderFor]）。
+  /// 查词浮层顶部「当前字幕句」动作行（覆写 [DictionaryPageMixin.buildPopupHeaderFor]）。
   /// 仅顶层（[index] == 0，真查词那句）显示；嵌套递归查词层（index > 0）不属于某条字幕句，
-  /// 返回 null。星标实心=已收藏，空心=未收藏，点击 toggle。
+  /// 返回 null。
+  ///
+  /// 四个动作都作用于**当前查词那句**（[_lastLookupCue]）：重播本句 / 跳到此句 / 复制 /
+  /// 收藏。前三个与字幕跳转列表行尾的 ▶ ⧉ 同源（[VideoPlayerController.skipToCue] /
+  /// 剪贴板），用户在浮层里不必先关浮层再去字幕列表找回那一行。
+  ///
+  /// 没有锚定 cue（无字幕轨 / gap 中查词）时重播与跳转无处可去，置灰而不是隐藏——
+  /// 按钮位置恒定，不会因句而异地跳来跳去。复制仍可用（回落整句文本）。
+  /// 星标实心=已收藏，空心=未收藏，点击 toggle。
   @override
   Widget? buildPopupHeaderFor(int index) {
     if (index != 0) return null;
     final ThemeData theme =
         appModel.overrideDictionaryTheme ?? Theme.of(context);
+    final bool hasCue = _lastLookupCue != null && _controller != null;
     return Material(
       type: MaterialType.transparency,
       child: Container(
@@ -3607,6 +3616,30 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
         child: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
+            HibikiIconButton(
+              key: const Key('video_popup_replay_cue_button'),
+              tooltip: t.video_subtitle_replay,
+              icon: Icons.replay,
+              size: 20,
+              enabled: hasCue,
+              onTap: _replayLookupCue,
+            ),
+            HibikiIconButton(
+              key: const Key('video_popup_jump_to_cue_button'),
+              // 复用字幕跳转列表行尾 ▶ 的图标与文案：同一动作同一表征，不造第二套说法。
+              tooltip: t.video_subtitle_list_jump,
+              icon: Icons.play_arrow,
+              size: 20,
+              enabled: hasCue,
+              onTap: _jumpToLookupCue,
+            ),
+            HibikiIconButton(
+              key: const Key('video_popup_copy_sentence_button'),
+              tooltip: t.copy,
+              icon: Icons.content_copy_outlined,
+              size: 20,
+              onTap: _copyLookupSentence,
+            ),
             HibikiIconButton(
               key: const Key('video_favorite_sentence_button'),
               // tooltip 用「句子收藏」（已有 i18n），描述按钮职责；不复用 toast 文案
@@ -4148,8 +4181,7 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// （dictionaryPopup scope 的切词条 / 制卡）由 [dictionaryPopupInputSpecFor] 统一减掉，
   /// 不会被抢走，与守卫把制卡键排在守卫之外是同一条边界。
   @override
-  Set<ShortcutAction> get dictionaryPopupForwardedActions =>
-      <ShortcutAction>{
+  Set<ShortcutAction> get dictionaryPopupForwardedActions => <ShortcutAction>{
         ...ShortcutAction.actionsForScope(ShortcutScope.video),
         // 「返回上一级」（默认 Esc / Alt+←）：浮层持焦时按它必须关浮层。它在
         // universal scope，不在 video 组里，漏掉就等于 BUG-1269 那半边重开。

--- a/hibiki/test/media/video/video_player_replay_cue_test.dart
+++ b/hibiki/test/media/video/video_player_replay_cue_test.dart
@@ -1,0 +1,275 @@
+// 查词浮层顶栏「重播本句」的一次性句尾暂停（[VideoPlayerController.replayCue]）。
+//
+// 核心不变量：一次性 hold 与全局偏好「字幕结束暂停」（[setPauseAtSubtitleEnd]）**正交**
+// ——重播不改写偏好，偏好也不改写重播；两者共用同一套句尾判定与落点。
+//
+// 另一条易回归的线是**生命周期**：一次性 hold 绝不能挂进 `_clearSeekTargetSnap`（自然
+// 播放越过目标句时播放器自己会调它，那正是最需要 hold 存活的一刻），只在用户主动改变
+// 播放位置（seekMs / skipToCue）与换片（setCues）时作废。
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_controller.dart';
+import 'package:hibiki_audio/hibiki_audio.dart';
+
+AudioCue _cue(int i, int s, int e) => AudioCue()
+  ..bookKey = 'video/1'
+  ..chapterHref = 'video://default'
+  ..sentenceIndex = i
+  ..textFragmentId = ''
+  ..text = 'line$i'
+  ..startMs = s
+  ..endMs = e
+  ..audioFileIndex = 0;
+
+void main() {
+  group('VideoPlayerController.replayCue 一次性句尾暂停', () {
+    test('全局偏好关着时，重播那一句仍在句尾停一次（直接进下一句路径）', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 1001, 2000)]);
+
+      final List<String> actions = <String>[];
+      c.debugSetPauseAtSubtitleEndForTesting(
+        // 关键：全局偏好**关着**。停下来只能是一次性 hold 的功劳。
+        enabled: false,
+        isPlaying: () => true,
+        onPause: () async => actions.add('pause'),
+        onSeek: (int positionMs) async => actions.add('seek:$positionMs'),
+        onPlay: () async => actions.add('play'),
+      );
+
+      await c.replayCue(c.cues[0]);
+      expect(actions, <String>['play'], reason: '重播必须主动起播');
+      expect(c.debugOneShotHoldCueIndex, 0);
+
+      c.debugUpdateCueForPosition(900);
+      expect(actions, <String>['play'], reason: '句中不停');
+
+      c.debugUpdateCueForPosition(1125);
+      await Future<void>.delayed(Duration.zero);
+      expect(actions, <String>['play', 'pause', 'seek:1000'],
+          reason: '越过句尾：暂停并回到该句的精确结尾');
+      expect(c.debugOneShotHoldCueIndex, isNull, reason: '停下即消耗');
+    });
+
+    test('全局偏好关着时，句尾落进 gap 也停（gap 路径）', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      // cue0 与 cue1 之间是静音 gap，句尾后下一拍无 cue。
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 2000, 3000)]);
+
+      int pauses = 0;
+      c.debugSetPauseAtSubtitleEndForTesting(
+        enabled: false,
+        isPlaying: () => true,
+        onPause: () async => pauses++,
+      );
+
+      await c.replayCue(c.cues[0]);
+      c.debugUpdateCueForPosition(500);
+      expect(pauses, 0);
+
+      c.debugUpdateCueForPosition(1500);
+      expect(pauses, 1, reason: 'gap 路径同样要停');
+      expect(c.debugOneShotHoldCueIndex, isNull);
+
+      // 消耗后继续播，后面的句子不受影响（偏好仍是关着的）。
+      c.debugUpdateCueForPosition(2500);
+      c.debugUpdateCueForPosition(3500);
+      expect(pauses, 1, reason: '一次性 hold 不得升级成全局「每句都停」');
+    });
+
+    test('重播不写全局偏好：别的句子照常播过去', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[
+        _cue(0, 0, 1000),
+        _cue(1, 1001, 2000),
+        _cue(2, 2001, 3000),
+      ]);
+
+      int pauses = 0;
+      c.debugSetPauseAtSubtitleEndForTesting(
+        enabled: false,
+        isPlaying: () => true,
+        onPause: () async => pauses++,
+      );
+
+      // 重播 cue1（不是第一句，验证下标解析而非「恰好是 0」）。
+      await c.replayCue(c.cues[1]);
+      expect(c.debugOneShotHoldCueIndex, 1);
+
+      c.debugUpdateCueForPosition(1500);
+      c.debugUpdateCueForPosition(2100);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 1, reason: '只有被重播的 cue1 在句尾停');
+
+      // cue2 结束时不该再停。
+      c.debugUpdateCueForPosition(2500);
+      c.debugUpdateCueForPosition(3500);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 1);
+    });
+
+    test('自然播回同一句不再停（停下即消耗，不是永久循环）', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 1001, 2000)]);
+
+      int pauses = 0;
+      c.debugSetPauseAtSubtitleEndForTesting(
+        enabled: false,
+        isPlaying: () => true,
+        onPause: () async => pauses++,
+      );
+
+      await c.replayCue(c.cues[0]);
+      c.debugUpdateCueForPosition(900);
+      c.debugUpdateCueForPosition(1125);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 1);
+
+      // 用户按播放继续；再次走过 cue0 的句尾时不该被停第二次。
+      c.debugUpdateCueForPosition(500);
+      c.debugUpdateCueForPosition(1125);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 1, reason: '一次性 hold 已被消耗');
+    });
+
+    test('用户中途拖进度条（seekMs）作废一次性 hold', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 1001, 2000)]);
+
+      int pauses = 0;
+      c.debugSetPauseAtSubtitleEndForTesting(
+        enabled: false,
+        isPlaying: () => true,
+        onPause: () async => pauses++,
+      );
+
+      await c.replayCue(c.cues[0]);
+      expect(c.debugOneShotHoldCueIndex, 0);
+
+      await c.seekMs(300);
+      expect(c.debugOneShotHoldCueIndex, isNull,
+          reason: '主动改变播放位置 = 放弃「停在本句尾」的意图');
+
+      c.debugUpdateCueForPosition(900);
+      c.debugUpdateCueForPosition(1125);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 0);
+    });
+
+    test('跳去别的句（skipToCue）作废一次性 hold', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 1001, 2000)]);
+
+      int pauses = 0;
+      c.debugSetPauseAtSubtitleEndForTesting(
+        enabled: false,
+        isPlaying: () => true,
+        onPause: () async => pauses++,
+      );
+
+      await c.replayCue(c.cues[0]);
+      await c.skipToCue(c.cues[1]);
+      expect(c.debugOneShotHoldCueIndex, isNull);
+
+      c.debugUpdateCueForPosition(900);
+      c.debugUpdateCueForPosition(1125);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 0);
+    });
+
+    test('换字幕/换片（setCues）清掉一次性 hold（旧下标对新列表无意义）', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 1001, 2000)]);
+
+      int pauses = 0;
+      c.debugSetPauseAtSubtitleEndForTesting(
+        enabled: false,
+        isPlaying: () => true,
+        onPause: () async => pauses++,
+      );
+
+      await c.replayCue(c.cues[0]);
+      expect(c.debugOneShotHoldCueIndex, 0);
+
+      c.setCues(<AudioCue>[_cue(0, 0, 5000), _cue(1, 5001, 9000)]);
+      expect(c.debugOneShotHoldCueIndex, isNull);
+
+      c.debugUpdateCueForPosition(2000);
+      c.debugUpdateCueForPosition(5500);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 0, reason: '新片的句子不得被上一片的 hold 停住');
+    });
+
+    test('全局偏好开着时重播同一句仍能停（防重复停记号被重播复位）', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 1001, 2000)]);
+
+      int pauses = 0;
+      c.debugSetPauseAtSubtitleEndForTesting(
+        // 偏好开着：cue0 已经被句尾暂停过一次，记号停在 cue0 上。
+        enabled: true,
+        isPlaying: () => true,
+        onPause: () async => pauses++,
+      );
+
+      c.debugUpdateCueForPosition(900);
+      c.debugUpdateCueForPosition(1125);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 1);
+
+      // 用户在查词浮层里点「重播本句」：必须再停一次，而不是被「这句停过了」挡掉。
+      await c.replayCue(c.cues[0]);
+      c.debugUpdateCueForPosition(900);
+      c.debugUpdateCueForPosition(1125);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 2, reason: '重播复位了防重复停记号');
+    });
+
+    test('暂停态不停：句尾判定只对真正在播的情形生效', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 1001, 2000)]);
+
+      int pauses = 0;
+      c.debugSetPauseAtSubtitleEndForTesting(
+        enabled: false,
+        // 用户重播后立刻手动按了暂停：位置不再前进，任何越界都是别的原因造成的。
+        isPlaying: () => false,
+        onPause: () async => pauses++,
+      );
+
+      await c.replayCue(c.cues[0]);
+      c.debugUpdateCueForPosition(900);
+      c.debugUpdateCueForPosition(1125);
+      await Future<void>.delayed(Duration.zero);
+      expect(pauses, 0);
+    });
+
+    test('cue 不在当前列表时退化为「跳过去接着播」，不假装能停', () async {
+      final VideoPlayerController c = VideoPlayerController();
+      addTearDown(c.dispose);
+      c.setCues(<AudioCue>[_cue(0, 0, 1000), _cue(1, 1001, 2000)]);
+
+      final List<String> actions = <String>[];
+      c.debugSetPauseAtSubtitleEndForTesting(
+        enabled: false,
+        isPlaying: () => true,
+        onPause: () async => actions.add('pause'),
+        onPlay: () async => actions.add('play'),
+      );
+
+      // 换轨/换片竞态：手上的 cue 已不属于当前列表。
+      await c.replayCue(_cue(9, 90000, 91000));
+      expect(actions, <String>['play']);
+      expect(c.debugOneShotHoldCueIndex, isNull);
+    });
+  });
+}

--- a/hibiki/test/pages/video_popup_cue_actions_guard_test.dart
+++ b/hibiki/test/pages/video_popup_cue_actions_guard_test.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫：视频查词浮层顶栏的「当前字幕句」动作行。
+///
+/// 用户诉求：在视频查词浮窗里就能重播/跳转/复制当前那句，不必关掉浮窗再去右侧字幕
+/// 列表把那一行找回来。顶栏原先只有一个收藏 ★。
+///
+/// 这是**接线守卫**：四个按钮的存在、各自接到哪个 handler、handler 又落到播放器的
+/// 哪个 API。真正的时序逻辑（播到句尾一次性暂停）由
+/// `test/media/video/video_player_replay_cue_test.dart` 行为测试覆盖，两层不重复。
+///
+/// 顶栏是纯 Flutter widget（`DictionaryPopupLayer._buildTopBar` 的 headerWidget 注入点），
+/// 但要立起来需要整个视频页 State + media_kit + DB，widget 测试代价远超收益；接线层
+/// 的回归（按钮被误删、handler 接错）源码扫描即可咬死。
+void main() {
+  final File page =
+      File('lib/src/pages/implementations/video_hibiki_page.dart');
+  final File part = File(
+    'lib/src/pages/implementations/video_hibiki/lookup_favorite.part.dart',
+  );
+
+  late String pageSrc;
+  late String partSrc;
+
+  setUpAll(() {
+    expect(page.existsSync(), isTrue);
+    expect(part.existsSync(), isTrue);
+    pageSrc = page.readAsStringSync();
+    partSrc = part.readAsStringSync();
+  });
+
+  /// 取 [src] 中 [startSig] 到 [endSig] 之间的片段。从**方法签名**起截，把方法上方的
+  /// doc 注释排除在外——否则注释里提到的符号会把断言喂绿（假绿）。
+  String region(String src, String startSig, String endSig) {
+    final int start = src.indexOf(startSig);
+    expect(start, isNonNegative, reason: 'missing region start: $startSig');
+    final int end = src.indexOf(endSig, start);
+    expect(end, isNonNegative, reason: 'missing region end: $endSig');
+    return src.substring(start, end);
+  }
+
+  group('查词浮层顶栏：当前字幕句动作行', () {
+    late String header;
+
+    setUpAll(() {
+      header = region(
+        pageSrc,
+        'Widget? buildPopupHeaderFor(int index) {',
+        '/// 关闭查词浮层栈中第',
+      );
+    });
+
+    test('四个动作按钮都在（重播 / 跳转 / 复制 / 收藏）', () {
+      for (final String key in <String>[
+        'video_popup_replay_cue_button',
+        'video_popup_jump_to_cue_button',
+        'video_popup_copy_sentence_button',
+        'video_favorite_sentence_button',
+      ]) {
+        expect(
+          header.contains("Key('$key')"),
+          isTrue,
+          reason: '顶栏缺少动作按钮 $key',
+        );
+      }
+    });
+
+    test('每个按钮接到各自的 handler', () {
+      for (final String handler in <String>[
+        '_replayLookupCue',
+        '_jumpToLookupCue',
+        '_copyLookupSentence',
+        '_toggleFavoriteSentenceForVideo',
+      ]) {
+        expect(
+          header.contains('onTap: $handler'),
+          isTrue,
+          reason: '顶栏按钮未接到 $handler',
+        );
+      }
+    });
+
+    test('无锚定 cue 时重播/跳转置灰，而不是留着点了没反应', () {
+      // 无字幕轨 / gap 中查词时没有可重播可跳转的句子。复制不受此限（回落整句文本）。
+      expect(
+        header.contains('final bool hasCue ='),
+        isTrue,
+        reason: '缺少「是否有锚定 cue」的判定',
+      );
+      expect(
+        'enabled: hasCue'.allMatches(header).length,
+        2,
+        reason: '重播与跳转两个按钮都必须按 hasCue 置灰',
+      );
+    });
+  });
+
+  group('顶栏 handler 落到播放器 API', () {
+    test('_replayLookupCue 走 replayCue（一次性句尾暂停），不是裸 seek', () {
+      final String body = region(
+        partSrc,
+        'Future<void> _replayLookupCue() async {',
+        '\n  }',
+      );
+      expect(
+        body.contains('controller.replayCue('),
+        isTrue,
+        reason: '重播必须走 replayCue —— 句尾暂停的时序在播放器层',
+      );
+    });
+
+    test('_jumpToLookupCue 走 skipToCue（与字幕列表行同一入口）', () {
+      final String body = region(
+        partSrc,
+        'Future<void> _jumpToLookupCue() async {',
+        '\n  }',
+      );
+      expect(
+        body.contains('controller.skipToCue('),
+        isTrue,
+        reason: '跳转必须复用 skipToCue，保持前导余量与 cue-snap 一致',
+      );
+    });
+
+    test('_copyLookupSentence 优先复制锚定 cue 文本，无 cue 时回落整句', () {
+      final String body = region(
+        partSrc,
+        'void _copyLookupSentence() {',
+        '\n  }',
+      );
+      expect(body.contains('Clipboard.setData('), isTrue);
+      expect(
+        body.contains('_lastLookupSentence'),
+        isTrue,
+        reason: '无 cue（无字幕轨 / gap 查词）时必须回落，按钮不能变哑',
+      );
+    });
+
+    test('重播不改写 _pausedForLookup（关浮层恢复播放的依据，BUG-072）', () {
+      final String body = region(
+        partSrc,
+        'Future<void> _replayLookupCue() async {',
+        '\n  }',
+      );
+      expect(
+        body.contains('_pausedForLookup'),
+        isFalse,
+        reason: '浮层内试听不得篡改「查词前是否在播」的记录',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 诉求

视频页查词浮窗顶栏原先只有一个收藏 ★（见用户截图红箭头处）。要重听或跳回当前这句，得先关掉浮窗、再去右侧「字幕列表」把那一行找回来。现在把这三个动作直接放进浮窗顶栏，全部作用于当前查词那句（`_lastLookupCue`）：

| 按钮 | 行为 |
|---|---|
| ⟲ 重播本句 | 跳回句首起播，**播到句尾自动暂停** |
| ▶ 跳到此句 | seek 到句首，不改播放状态（与字幕列表行尾 ▶ 同一入口） |
| ⧉ 复制 | 复制该句字幕文本 |
| ★ 收藏 | 原有，未改动 |

## 为什么动到了播放器层

「播到句尾自动暂停」这个能力仓库里**原本没有**。已有的是全局偏好「字幕结束暂停」（`_pauseAtSubtitleEnd`）——每句都停；需要的是一次性的「只播这一句就停」。

做法是在 `VideoPlayerController` 加一次性 `_oneShotHoldCueIndex`，与全局偏好经 `_holdEnabledForCue` 汇成**同一个句尾判定**：句尾时序、seek 回句尾的落点、防重复停记号全部共用一套代码，不产生第二条平行路径。因此倍速、字幕延迟、关键帧吸附、seek 在途 lag 都自动吃到同一份处理。

**没有**在 UI 层按 `endMs - startMs` 起定时器等句长——那种做法会被倍速、缓冲、用户中途 seek 逐一打穿。

两者严格正交：重播不写偏好，偏好也不写重播。故意用独立字段而不是「临时把开关打开、停下再关」——后者一旦停不下来（用户中途 seek 走 / 换片）就把用户的真实偏好永久写反了。

## 一个易踩的坑（也是守卫重点）

一次性 hold 的生命周期**绝不能挂进 `_clearSeekTargetSnap`**。那是「主动跳转快照」的复位点，而 `_applySeekTargetSnap` 在**自然播放越过目标句**时会自行调用它——那一刻正是重播即将抵达句尾、最需要 hold 存活的时候。挂进去等于每次重播都在停下来之前把自己清掉。

所以只在两类事件作废：用户主动改变播放位置（`seekMs` / `_rawSeekMs`，后者覆盖 `skipToCue` 点别的句子）、换片换字幕（`setCues`）。

## 其它决定

- 跳转复用 `skipToCue`，与字幕列表行尾 ▶ 完全同源（同样的 180ms 前导余量与 cue-snap），不造第二套行为；tooltip 也复用已有的 `video_subtitle_list_jump`。
- 复制优先取锚定 cue 文本，无 cue 时回落整句文本，按钮不会变哑。
- 无锚定 cue（无字幕轨 / gap 中查词）时重播与跳转**置灰而非隐藏**，按钮位置恒定，不会因句而异地跳来跳去。
- 重播不动 `_pausedForLookup`——那是关浮层恢复播放的依据（BUG-072），浮层内的临时试听不该让它跟着用户听没听过一句而漂移。
- 新增 1 个 i18n key（`video_subtitle_replay`），经 `tool/i18n_sync.dart` 同步 17 语言 + `dart run slang` 重新生成。

## 测试

- `test/media/video/video_player_replay_cue_test.dart`（10 例行为测试）：两条句尾路径（直接进下一句 / 落进 gap）、消耗后不重复停、三个作废点、偏好开着时重播同一句仍能停、暂停态不停、cue 不在列表时的退化。
- `test/pages/video_popup_cue_actions_guard_test.dart`（7 例接线守卫）：四个按钮的存在、handler 接线、置灰条件、落到播放器的哪个 API。

## 验证

- `flutter analyze` 全量（含 test）：**No issues found**
- 定向 `test/media/video/ test/pages/ test/i18n/`：**4812 tests 完成**。唯一的红是 `manga_interceptor_test.dart` suite 装载失败（`Invalid WebSocket upgrade request`），与本改动无关，单独重跑 **8/8 绿** → 并发伪红。
- **变异实测**三组，均精确转红、还原后全绿：
  1. 句尾判定忽略一次性 hold → 4 例红
  2. 把 hold 清除挂进 `_clearSeekTargetSnap`（本次要防的那个陷阱）→ 4 例红
  3. 重播按钮接错 handler + 丢掉一个 `enabled: hasCue` → 2 例精确红

未跑真机复测（浮窗顶栏为纯 Flutter widget，接线与时序已由上述两层覆盖）。

https://claude.ai/code/session_018HGCpsPkJiVJECLZ6wYNej
