### PR TITLE
fix(test): 修守卫自身剩余六项假绿源（TODO-2715）

### DIFF
--- a/hibiki/test/media/media_cover_write_guard_test.dart
+++ b/hibiki/test/media/media_cover_write_guard_test.dart
@@ -26,6 +26,13 @@
 //    弹窗重取）复用，同路径重下后 UI 命中旧解码缓存 = 显示旧图，守卫全绿。
 //    这条把豁免收成「白名单文件里**哪些函数**可以裸写」的显式清单：新增裸写函数
 //    或把已收口的函数改回裸写都会红。
+//
+// ④（TODO-2715 补的结构洞）**②/③ 都只在「白名单文件」内部收紧，跨文件那条路仍然
+//    敞着**：任意新文件 A 派生封面目的地、交给任意文件 B 裸写，A 没有 rawWrite、
+//    B 没有 destMarker，两边都不命中。静态扫描追不了跨文件的路径变量流，所以改守
+//    **入口**：`kCoverPathDerivers` 是封面目的地派生点的封闭注册表，新增派生点直接
+//    红，评审时必须回答「它把这个路径交给谁写」。每条登记还带一个可证伪的角色断言
+//    （收口本体 / 经服务落盘 / 只派生不落盘），登记与实际不符同样红。
 
 import 'dart:io';
 
@@ -34,6 +41,99 @@ import 'package:path/path.dart' as p;
 
 import '../helpers/source_guard.dart';
 import '../helpers/scan_scale.dart';
+
+/// 封面目的地派生标记：三岛目录/文件名的唯一派生入口。
+final RegExp kCoverDestMarker = RegExp(
+    r'videoCoverFileName\(|videoCoversDirectory\(|gameCoversDirectory\(|VideoStorage\.coversDir\(');
+
+/// 原始写盘调用（对文件的写/拷/换名）。
+final RegExp kRawWrite =
+    RegExp(r'writeAsBytes\(|\.copy\(|\.rename\(|openWrite\(');
+
+/// 一个「封面目的地派生点」文件在收口体系里的角色（TODO-2715 ③）。
+enum CoverDeriverRole {
+  /// 收口本体：`MediaCoverService` 自己，写盘与驱逐在同一函数里。
+  sink,
+
+  /// 派生目的地并**自己写**：必须经 `MediaCoverService.applyCover*`。
+  writesViaService,
+
+  /// 只派生路径不写盘（读取 / 展示 / 删除 / 交给收口去写）：文件内不得出现裸写。
+  derivesPathOnly,
+}
+
+/// **封面目的地派生点的完整注册表**（TODO-2715 ③）。
+///
+/// 为什么需要它 —— 旧判据的结构性洞：②「派生 + 裸写」要求两者**在同一个文件**才算
+/// 违规，于是把派生点和写盘点拆到两个文件，两边都不命中。BUG-1394 已经在**白名单
+/// 文件内部**把豁免收成逐函数，但「任意新文件 A 派生目的地、交给任意文件 B 裸写」
+/// 这条路径当时仍然是敞开的：A 没有 rawWrite，B 没有 destMarker。
+///
+/// 静态扫描追不了跨文件的路径变量流，所以这里改守**入口**：能派生封面目的地的文件
+/// 是一个封闭集合，新增一个就红，评审时必须回答「它把这个路径交给谁写？」。
+/// 每条登记同时是一条可证伪断言（见下面的三条角色断言），不是一句散文。
+const Map<String, (CoverDeriverRole, String)> kCoverPathDerivers =
+    <String, (CoverDeriverRole, String)>{
+  'lib/src/media/media_cover_service.dart': (
+    CoverDeriverRole.sink,
+    '收口本体：写盘 + 驱逐解码缓存在同一函数里。',
+  ),
+  'lib/src/media/torrent/anime_download_importer.dart': (
+    CoverDeriverRole.derivesPathOnly,
+    'BUG-1394 那条跨文件洞的派生半边：它算出目的地后交给 video_cover_extractor '
+        '落盘，自己一个字节都不写。当年正因为「派生在这、裸写在那」，逐文件判据两边'
+        '都不命中；现在这半边由本注册表钉住，写盘那半边由 writesViaService 钉住。',
+  ),
+  'lib/src/media/video/scraper/cover_downloader.dart': (
+    CoverDeriverRole.writesViaService,
+    '刮削封面下载路，字节走 applyCoverBytes。',
+  ),
+  'lib/src/media/video/scraper/cover_scraper_service.dart': (
+    CoverDeriverRole.writesViaService,
+    '刮削换封面，字节走 applyCoverBytes。',
+  ),
+  'lib/src/media/video/scraper/episode_scrape_service.dart': (
+    CoverDeriverRole.derivesPathOnly,
+    '每集刮削只算目的地路径，落盘交给 cover_downloader。',
+  ),
+  'lib/src/media/video/scraper/member_cover_cleanup.dart': (
+    CoverDeriverRole.writesViaService,
+    '成员封面清理/重取，重取那半走 applyCover*。',
+  ),
+  'lib/src/media/video/video_book_repository.dart': (
+    CoverDeriverRole.derivesPathOnly,
+    '仓储层只解析封面路径供读取/展示，不落盘。',
+  ),
+  'lib/src/media/video/video_cover_extractor.dart': (
+    CoverDeriverRole.writesViaService,
+    'ffmpeg 子进程直写目标路径（Dart 侧无字节）；下载路已走 applyCoverBytes。'
+        '本文件的裸写边界由下面第 ③ 条逐函数名单钉死。',
+  ),
+  'lib/src/media/video/video_import_dialog.dart': (
+    CoverDeriverRole.writesViaService,
+    '导入弹窗重取封面，字节走 applyCover*。',
+  ),
+  'lib/src/media/video/video_storage.dart': (
+    CoverDeriverRole.derivesPathOnly,
+    '路径派生的定义处之一，自身不落盘。',
+  ),
+  'lib/src/mining/galgame_cover_resolver.dart': (
+    CoverDeriverRole.writesViaService,
+    'galgame 封面解析/落盘，字节走 applyCover*。',
+  ),
+  'lib/src/pages/implementations/home_video_page.dart': (
+    CoverDeriverRole.derivesPathOnly,
+    '页面只按路径读封面显示，不落盘。',
+  ),
+  'lib/src/pages/implementations/media_collection_detail_page.dart': (
+    CoverDeriverRole.derivesPathOnly,
+    '合集详情页只按路径读封面显示，不落盘。',
+  ),
+  'lib/src/storage/app_paths.dart': (
+    CoverDeriverRole.derivesPathOnly,
+    '目录派生的定义处，自身不落盘。',
+  ),
+};
 
 void main() {
   final Directory libDir = Directory('lib');
@@ -74,13 +174,61 @@ void main() {
             '${offenders.join('\n')}');
   });
 
+  test('封面目的地派生点是封闭集合（跨文件「派生在 A、裸写在 B」的结构洞，TODO-2715）', () {
+    final Map<String, String> actual = <String, String>{};
+    for (final File f in dartFiles()) {
+      final String path = norm(f.path);
+      final String src = maskComments(f.readAsStringSync());
+      if (!kCoverDestMarker.hasMatch(src)) continue;
+      actual[path] = src.contains('MediaCoverService.applyCover')
+          ? 'viaService'
+          : (kRawWrite.hasMatch(src) ? 'rawWrite' : 'pathOnly');
+    }
+
+    final List<String> unregistered = actual.keys
+        .where((String p) => !kCoverPathDerivers.containsKey(p))
+        .toList(growable: false);
+    expect(unregistered, isEmpty,
+        reason: '新的封面目的地派生点未登记。派生点是收口体系的入口：'
+            '「派生在 A、裸写在 B」正是 BUG-1394 那类漏网形态，而逐文件的'
+            '「派生 + 裸写同文件」判据对它零覆盖。请把它加进 kCoverPathDerivers '
+            '并写清它把路径交给谁写：\n${unregistered.join('\n')}');
+
+    final List<String> dead = kCoverPathDerivers.keys
+        .where((String p) => !actual.containsKey(p))
+        .toList(growable: false);
+    expect(dead, isEmpty,
+        reason: '这些登记项已经不再派生封面目的地——理由与代码脱节的登记等于一张'
+            '不会被审的通行证，删掉它：\n${dead.join('\n')}');
+
+    // 角色断言：每条登记都必须是可证伪的，而不是一句散文。
+    final List<String> roleViolations = <String>[];
+    kCoverPathDerivers.forEach((String path, (CoverDeriverRole, String) entry) {
+      final String? state = actual[path];
+      if (state == null) return; // 已由 dead 断言报出。
+      switch (entry.$1) {
+        case CoverDeriverRole.sink:
+          if (state != 'rawWrite') {
+            roleViolations.add('$path: 登记为收口本体，却不再自己写盘（实际 $state）');
+          }
+        case CoverDeriverRole.writesViaService:
+          if (state != 'viaService') {
+            roleViolations.add('$path: 登记为「经 MediaCoverService 落盘」，实际 $state——'
+                '要么它改回裸写了，要么它已经不写盘、该改登记为 derivesPathOnly');
+          }
+        case CoverDeriverRole.derivesPathOnly:
+          if (state != 'pathOnly') {
+            roleViolations.add('$path: 登记为「只派生路径不落盘」，实际 $state——'
+                '它开始写盘了，必须经 MediaCoverService.applyCover*');
+          }
+      }
+    });
+    expect(roleViolations, isEmpty, reason: roleViolations.join('\n'));
+  });
+
   test('封面目的地写盘必须经 MediaCoverService.applyCover*（白名单外禁裸写）', () {
-    // 封面目的地派生标记：三岛目录/文件名的唯一派生入口。
-    final RegExp destMarker = RegExp(
-        r'videoCoverFileName\(|videoCoversDirectory\(|gameCoversDirectory\(|VideoStorage\.coversDir\(');
-    // 原始写盘调用（对文件的写/拷/换名）。
-    final RegExp rawWrite =
-        RegExp(r'writeAsBytes\(|\.copy\(|\.rename\(|openWrite\(');
+    final RegExp destMarker = kCoverDestMarker;
+    final RegExp rawWrite = kRawWrite;
     // 注释（行注释 / doc / 块注释）里的提法不算调用：先做共享词法掩码再匹配，
     // 否则「见 VideoStorage.coversDir()」这类文档引用会误报。TODO-2477：旧写法是
     // 删除式 `replaceAll(RegExp(r'//.*$'), '')`，块注释与串里的 `//` 两个方向都错。

--- a/hibiki/test/models/woff2_decoder_test.dart
+++ b/hibiki/test/models/woff2_decoder_test.dart
@@ -5,9 +5,19 @@ import 'package:flutter/services.dart' show FontLoader;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hibiki/src/models/woff2_decoder.dart';
 
+/// The committed fixture. It is tracked in git (`test/fixtures/fonts/`), so
+/// "not found" means the repo is broken, never "this machine happens to lack
+/// one" — see [_findWoff2] for why that distinction is load-bearing.
+const String kVendoredWoff2Fixture = 'test/fixtures/fonts/Roboto-Regular.woff2';
+
 /// Locates a real `.woff2` fixture. The Flutter SDK ships several (Roboto)
-/// under its bundled DevTools assets; honour an explicit override too. Returns
-/// null when none is found (the test then skips rather than failing on CI).
+/// under its bundled DevTools assets; honour an explicit override too.
+///
+/// TODO-2715: this used to return null and the test then called
+/// `markTestSkipped` — i.e. **deleting the fixture deleted the test**, and the
+/// output said "skipped", not "failed". A guard that can be silently removed by
+/// removing a file it reads is not a guard. The fixture is committed, so a
+/// missing one is a repo defect: [_requireWoff2] fails instead of skipping.
 String _baseName(Directory d) => d.path
     .replaceAll('\\', '/')
     .split('/')
@@ -27,7 +37,7 @@ String? _scanForWoff2(Directory dir) {
 String? _findWoff2() {
   // Committed fixture (CI-stable). Falls back to an override / the SDK's
   // bundled Roboto woff2 when run outside the repo tree.
-  final File vendored = File('test/fixtures/fonts/Roboto-Regular.woff2');
+  final File vendored = File(kVendoredWoff2Fixture);
   if (vendored.existsSync()) return vendored.path;
 
   final String? override = Platform.environment['HIBIKI_WOFF2_FIXTURE'];
@@ -61,6 +71,17 @@ String? _findWoff2() {
   return null;
 }
 
+/// [_findWoff2] or a hard failure. Never a skip.
+String _requireWoff2() {
+  final String? fixture = _findWoff2();
+  if (fixture != null) return fixture;
+  fail('no .woff2 fixture found. The committed one is $kVendoredWoff2Fixture — '
+      'restore it (git checkout) rather than skipping this test. An explicit '
+      'HIBIKI_WOFF2_FIXTURE override is honoured when running outside the repo '
+      'tree. TODO-2715: this used to markTestSkipped, which turned "the '
+      'fixture is gone" into a silently green run.');
+}
+
 ({int flavor, int numTables, Map<String, (int, int)> tables}) _parse(
     Uint8List sfnt) {
   final ByteData bd =
@@ -84,13 +105,26 @@ String? _findWoff2() {
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  // TODO-2715: the fixture is part of the test, not part of the environment.
+  // Asserting its presence separately makes "the fixture vanished" a distinct,
+  // legible failure instead of a decode error further down.
+  test('the committed .woff2 fixture is present and non-trivial', () {
+    final File vendored = File(kVendoredWoff2Fixture);
+    expect(vendored.existsSync(), isTrue,
+        reason: '$kVendoredWoff2Fixture is tracked in git; a missing file is a '
+            'broken checkout, not a reason to skip the decoder test');
+    // A git-lfs pointer / truncated download is ~130 bytes of ASCII; a real
+    // woff2 starts with the `wOF2` signature and is kilobytes long.
+    final Uint8List bytes = vendored.readAsBytesSync();
+    expect(bytes.length, greaterThan(4096),
+        reason: 'fixture is ${bytes.length} bytes — looks truncated');
+    expect(String.fromCharCodes(bytes.sublist(0, 4)), 'wOF2',
+        reason: 'fixture does not carry the woff2 signature');
+  });
+
   test('decodes a real Roboto .woff2 into a loadable, structurally valid sfnt',
       () async {
-    final String? fixture = _findWoff2();
-    if (fixture == null) {
-      markTestSkipped('no .woff2 fixture found (set HIBIKI_WOFF2_FIXTURE)');
-      return;
-    }
+    final String fixture = _requireWoff2();
 
     final Uint8List woff2 = File(fixture).readAsBytesSync();
     final Uint8List? sfnt = Woff2Decoder.toSfnt(woff2);

--- a/hibiki/test/pages/video_hibiki_page_source_corpus.dart
+++ b/hibiki/test/pages/video_hibiki_page_source_corpus.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../helpers/part_corpus.dart';
+import '../helpers/source_guard.dart';
 
 /// TODO-590: `video_hibiki_page.dart` 正被分批拆成主壳 + `video_hibiki/*.part.dart`
 /// 一组 part 文件（零行为重构，照搬 TODO-589 reader_hibiki 范式）。原来逐文件硬编码
@@ -67,14 +68,21 @@ const String kFadingChromeGatePath =
     'lib/src/utils/components/fading_chrome_gate.dart';
 
 /// 共享淡出门控自身仍满足「默认 easeInOut + IgnorePointer + AnimatedOpacity」。
+///
+/// 四条全是**要求型**（isTrue）断言，所以判据必须剥注释：裸 `contains` 下
+/// 「把实现删光、把同样的字面量留在注释里」是完全合法的骗绿写法（TODO-2715）。
+/// 组件构造走 [containsIdentifierCall]（`IgnorePointer(` 的左边界，防
+/// `MyIgnorePointer(` 顶包），字面量走 [containsCodeLine]（只认代码行）。
 void expectFadingChromeGateContract() {
   final String gate = File(kFadingChromeGatePath).readAsStringSync();
-  expect(gate.contains('this.curve = Curves.easeInOut'), isTrue,
-      reason: 'FadingChromeGate 默认曲线必须是 easeInOut（调用点不传即取此值）');
-  expect(gate.contains('IgnorePointer('), isTrue,
-      reason: '淡出后必须 IgnorePointer 不拦点击');
-  expect(gate.contains('AnimatedOpacity('), isTrue,
-      reason: '淡入淡出必须由 AnimatedOpacity 实现');
-  expect(gate.contains('curve: curve'), isTrue,
-      reason: 'AnimatedOpacity 必须真把 curve 透传下去，否则默认值形同虚设');
+  expect(containsCodeLine(gate, 'this.curve = Curves.easeInOut'), isTrue,
+      reason: 'FadingChromeGate 默认曲线必须是 easeInOut（调用点不传即取此值）；'
+          '注释里写着这句不算实现');
+  expect(containsIdentifierCall(gate, 'IgnorePointer'), isTrue,
+      reason: '淡出后必须 IgnorePointer 不拦点击；注释里提到它不算实现');
+  expect(containsIdentifierCall(gate, 'AnimatedOpacity'), isTrue,
+      reason: '淡入淡出必须由 AnimatedOpacity 实现；注释里提到它不算实现');
+  expect(containsCodeLine(gate, 'curve: curve'), isTrue,
+      reason: 'AnimatedOpacity 必须真把 curve 透传下去，否则默认值形同虚设；'
+          '注释里写着这句不算实现');
 }

--- a/hibiki/test/settings/md3_design_system_static_test.dart
+++ b/hibiki/test/settings/md3_design_system_static_test.dart
@@ -1138,11 +1138,287 @@ void main() {
               'data-root migration overlay and the main.dart splash branches.',
     };
 
+    // TODO-2715 ①：豁免的**粒度**从「整份文件」收到「这份文件里被审过的那几个 token」。
+    //
+    // 旧机制的问题不是名单太长，而是**名单项的语义**：文件一旦进 allowedFiles，它里面
+    // 新写的**任何**违规都不会被抓——理由写的是「图表内容的小字号」，实际连 `Card(` /
+    // `ListTile(` / 圆角一起整份免检。BUG-1425 已经用几条手写的可证伪断言堵了其中 5 个
+    // 文件（video_chapter_panel / texthooker_page / video_shader_dialog /
+    // anime_download_dialog / manga_json_writeback），但那是逐文件手写的，覆盖不了另外
+    // 69 个，而且每加一个豁免就要再手写一条。
+    //
+    // 新机制：每条豁免同时登记它**当前实际命中**的 token 集合。
+    // - 命中了名单外的 token ⇒ 违规。旧理由不再捎带免检未来的新违规；
+    // - 名单里的 token 不再命中 ⇒ 过期登记，必须删。这就是 BUG-1425 那条 dead-entry
+    //   断言，粒度从「文件」下沉到「token」。
+    //
+    // 为什么是**两张表**而不是把 token 塞进 allowedFiles 的值：理由是给人读的散文、
+    // token 是给判据用的数据，两者的评审方式和修改节奏不同（改理由不该动判据，反之
+    // 亦然）。下面有一条断言强制两张表键集合完全一致，所以拆表不会漂。
+    //
+    // 这张表是**实测生成**的，不是人拍脑袋写的：写下时逐文件跑 _forbiddenChromeHits
+    // 得到，因此本轮零红。它不是「以后再收窄」的占位——名单里的每个 token 从现在起
+    // 都必须真实存在，删一个就红。
+    const Map<String, Set<String>> allowedTokens = <String, Set<String>>{
+      'lib/src/anki/anki_mined_card_action_sheet.dart': <String>{'ListTile('},
+      'lib/src/creator/fields/image_field.dart': <String>{'fontSize:'},
+      'lib/src/lookup/gal_hook_text_overlay_controller.dart': <String>{
+        'fontSize:'
+      },
+      'lib/src/media/audiobook/audiobook_bridge.dart': <String>{'fontSize:'},
+      'lib/src/media/audiobook/audiobook_clip_text_render.dart': <String>{
+        'BorderRadius.circular(',
+        'fontSize:'
+      },
+      'lib/src/media/audiobook/audiobook_session.dart': <String>{'fontSize:'},
+      'lib/src/media/audiobook/now_listening_mini_bar.dart': <String>{
+        'BorderRadius.circular(',
+        'surfaceContainerHighest'
+      },
+      'lib/src/media/manga/manga_json_writeback.dart': <String>{'fontSize:'},
+      'lib/src/media/manga/mokuro_payload.dart': <String>{'fontSize:'},
+      'lib/src/media/manga/ocr/google_lens_ocr_service.dart': <String>{
+        'fontSize:'
+      },
+      'lib/src/media/video/cover_ui/cover_match_dialog.dart': <String>{
+        'BorderRadius.circular(',
+        'CheckboxListTile('
+      },
+      'lib/src/media/video/danmaku_manual_match_panel.dart': <String>{
+        'ListTile('
+      },
+      'lib/src/media/video/subtitle_waveform_align_panel.dart': <String>{
+        'BorderRadius.circular(',
+        'surfaceContainerHighest'
+      },
+      'lib/src/media/video/video_chapter_panel.dart': <String>{'fontSize:'},
+      'lib/src/media/video/video_control_layout_editor.dart': <String>{
+        'surfaceContainerHigh',
+        'surfaceContainerHighest'
+      },
+      'lib/src/media/video/video_danmaku_text_metrics.dart': <String>{
+        'fontSize:'
+      },
+      'lib/src/media/video/video_episode_panel.dart': <String>{
+        'VisualDensity.compact',
+        'fontSize:'
+      },
+      'lib/src/media/video/video_episode_rail.dart': <String>{
+        'BorderRadius.circular(',
+        'surfaceContainerHighest',
+        'fontSize:'
+      },
+      'lib/src/media/video/video_long_press_speed_badge.dart': <String>{
+        'BorderRadius.circular(',
+        'fontSize:'
+      },
+      'lib/src/media/video/video_settings_actions.dart': <String>{
+        'fontSize:',
+        'ListTile('
+      },
+      'lib/src/media/video/video_subtitle_jump_panel.dart': <String>{
+        'VisualDensity.compact',
+        'fontSize:'
+      },
+      'lib/src/media/video/video_subtitle_overlay.dart': <String>{
+        'BorderRadius.circular(',
+        'fontSize:'
+      },
+      'lib/src/media/video/video_subtitle_style.dart': <String>{'fontSize:'},
+      'lib/src/media/video/video_thumbnail_preview_overlay.dart': <String>{
+        'BorderRadius.circular(',
+        'fontSize:'
+      },
+      'lib/src/media/video/video_volume_overlays.dart': <String>{
+        'BorderRadius.circular(',
+        'surfaceContainerHighest',
+        'fontSize:'
+      },
+      'lib/src/models/app_model.dart': <String>{
+        'surfaceContainerHigh',
+        'fontSize:'
+      },
+      'lib/src/models/theme_notifier.dart': <String>{
+        'surfaceContainerLow',
+        'surfaceContainerLowest',
+        'surfaceContainerHigh',
+        'surfaceContainerHighest'
+      },
+      'lib/src/ocr/manga_ocr_folder_job.dart': <String>{'fontSize:'},
+      'lib/src/pages/implementations/anime_download_dialog.dart': <String>{
+        'BorderRadius.circular(',
+        'VisualDensity.compact',
+        'surfaceContainerHighest',
+        'fontSize:',
+        'Card(',
+        'ListTile('
+      },
+      'lib/src/pages/implementations/custom_theme_page.dart': <String>{
+        'surfaceContainerLow'
+      },
+      'lib/src/pages/implementations/dictionary_popup_native.dart': <String>{
+        'surfaceContainerHighest'
+      },
+      'lib/src/pages/implementations/dictionary_popup_webview.dart': <String>{
+        'surfaceContainerHigh'
+      },
+      'lib/src/pages/implementations/game_diagnostics_page.dart': <String>{
+        'BorderRadius.circular(',
+        'ListTile('
+      },
+      'lib/src/pages/implementations/games_library_page.dart': <String>{
+        'surfaceContainerHighest',
+        'fontSize:'
+      },
+      'lib/src/pages/implementations/history_reader_page.dart': <String>{
+        'surfaceContainerHighest'
+      },
+      'lib/src/pages/implementations/home_video_page.dart': <String>{
+        'BorderRadius.circular(',
+        'fontSize:'
+      },
+      'lib/src/pages/implementations/jimaku_batch_dialog.dart': <String>{
+        'ListTile('
+      },
+      'lib/src/pages/implementations/jimaku_subtitle_dialog.dart': <String>{
+        'BorderRadius.circular(',
+        'VisualDensity.compact',
+        'ListTile('
+      },
+      'lib/src/pages/implementations/media_collection_detail_page.dart':
+          <String>{
+        'BorderRadius.circular(',
+        'surfaceContainerLow',
+        'surfaceContainerHighest',
+        'fontSize:'
+      },
+      'lib/src/pages/implementations/popup_settings_injection.dart': <String>{
+        'surfaceContainerHigh'
+      },
+      'lib/src/pages/implementations/reader_hibiki/chrome.part.dart': <String>{
+        'BorderRadius.circular(',
+        'VisualDensity.compact',
+        'surfaceContainerHigh',
+        'surfaceContainerHighest',
+        'fontSize:'
+      },
+      'lib/src/pages/implementations/reader_hibiki/lyrics.part.dart': <String>{
+        'fontSize:'
+      },
+      'lib/src/pages/implementations/reader_hibiki_history_page.dart': <String>{
+        'surfaceContainerHighest'
+      },
+      'lib/src/pages/implementations/reader_hibiki_page.dart': <String>{
+        'BorderRadius.circular('
+      },
+      'lib/src/pages/implementations/reader_history/card_widgets.part.dart':
+          <String>{'surfaceContainerHighest'},
+      'lib/src/pages/implementations/reader_history/dialogs.part.dart':
+          <String>{'fontSize:'},
+      'lib/src/pages/implementations/reader_history/remote.part.dart': <String>{
+        'VisualDensity.compact',
+        'surfaceContainerHighest'
+      },
+      'lib/src/pages/implementations/reading_statistics_page.dart': <String>{
+        'surfaceContainerHighest'
+      },
+      'lib/src/pages/implementations/sentence_context_dialog.dart': <String>{
+        'VisualDensity.compact'
+      },
+      'lib/src/pages/implementations/series_shelf_card.dart': <String>{
+        'BorderRadius.circular(',
+        'surfaceContainerHighest'
+      },
+      'lib/src/pages/implementations/texthooker_page.dart': <String>{
+        'BorderRadius.circular(',
+        'surfaceContainerHighest'
+      },
+      'lib/src/pages/implementations/video_hibiki/audio_track.part.dart':
+          <String>{'ListTile('},
+      'lib/src/pages/implementations/video_hibiki/controls_popover.part.dart':
+          <String>{'surfaceContainerHighest', 'fontSize:'},
+      'lib/src/pages/implementations/video_hibiki/controls_theme.part.dart':
+          <String>{'BorderRadius.circular(', 'fontSize:'},
+      'lib/src/pages/implementations/video_hibiki/episode.part.dart': <String>{
+        'BorderRadius.circular(',
+        'VisualDensity.compact',
+        'fontSize:'
+      },
+      'lib/src/pages/implementations/video_hibiki/flicker_notice.part.dart':
+          <String>{
+        'BorderRadius.circular(',
+        'VisualDensity.compact',
+        'fontSize:'
+      },
+      'lib/src/pages/implementations/video_hibiki/layout.part.dart': <String>{
+        'fontSize:'
+      },
+      'lib/src/pages/implementations/video_hibiki/quality.part.dart': <String>{
+        'ListTile('
+      },
+      'lib/src/pages/implementations/video_hibiki/subtitle.part.dart': <String>{
+        'BorderRadius.circular(',
+        'fontSize:',
+        'ListTile('
+      },
+      'lib/src/pages/implementations/video_hibiki/volume_osd.part.dart':
+          <String>{'BorderRadius.circular(', 'fontSize:'},
+      'lib/src/pages/implementations/video_hibiki_page.dart': <String>{
+        'fontSize:',
+        'ListTile('
+      },
+      'lib/src/pages/implementations/video_shader_dialog.dart': <String>{
+        'CheckboxListTile('
+      },
+      'lib/src/pages/implementations/video_statistics_page.dart': <String>{
+        'surfaceContainerHighest'
+      },
+      'lib/src/settings/settings_schema_video.dart': <String>{'fontSize:'},
+      'lib/src/startup/loading_watchdog_view.dart': <String>{'fontSize:'},
+      'lib/src/storage/data_root_migration_view.dart': <String>{'fontSize:'},
+      'lib/src/sync/backup_import_overlay_view.dart': <String>{'fontSize:'},
+      'lib/src/utils/components/clipboard_lookup_text_panel.dart': <String>{
+        'fontSize:'
+      },
+      'lib/src/utils/components/cover_badge.dart': <String>{
+        'BorderRadius.circular('
+      },
+      'lib/src/utils/components/hibiki_design_tokens.dart': <String>{
+        'BorderRadius.circular(',
+        'surfaceContainerLow',
+        'surfaceContainerHigh',
+        'surfaceContainerHighest',
+        'fontSize:'
+      },
+      'lib/src/utils/components/hibiki_material_components.dart': <String>{
+        'BorderRadius.circular(',
+        'VisualDensity.compact',
+        'surfaceContainerHigh',
+        'fontSize:'
+      },
+      'lib/src/utils/components/settings_shared.dart': <String>{
+        'VisualDensity.compact',
+        'fontSize:'
+      },
+      'lib/src/utils/components/stat_contribution_heatmap.dart': <String>{
+        'surfaceContainerHighest'
+      },
+      'lib/src/utils/popup_theme_css.dart': <String>{'surfaceContainerHigh'},
+    };
+
+    expect(allowedTokens.keys.toSet(), allowedFiles.keys.toSet(),
+        reason: '两张豁免表的键必须一一对应：allowedFiles 是给人读的理由，'
+            'allowedTokens 是判据真正用的范围。少一边 = 要么有文件整份免检'
+            '（token 表缺项按空集处理会当场红，这条只是把原因说清），'
+            '要么有条理由挂在名单上却不再有对应范围。');
+
     final List<String> violations = <String>[];
     // BUG-1425：真正被用上的豁免键。一条豁免没被用上只有两种情况——文件没了，或者
     // 文件里早就一个禁用 token 都不剩；两种都是**过期豁免**：理由与代码脱节，却仍
     // 挂在名单上给该文件整份免检，等于给未来的违规预留了一张不会被审的通行证。
     final Set<String> liveAllowlistKeys = <String>{};
+    // TODO-2715：逐 token 的实际命中，用来抓「登记了却不再命中」的过期 token。
+    final Map<String, Set<String>> liveTokens = <String, Set<String>>{};
     final List<File> dartFiles = Directory('lib/src')
         .listSync(recursive: true)
         .whereType<File>()
@@ -1154,13 +1430,24 @@ void main() {
     for (final File file in dartFiles) {
       final String path = file.path.replaceAll(r'\', '/');
       final String? reason = allowedFiles[path];
+      // TODO-2715：先剥注释。判据是禁止型（isNot），注释里写着 `fontSize:` 的说明
+      // 文字会被当成命中——既制造假红，又会把一条注释登记进豁免范围。
       final String source = _withoutSharedComponentNames(
-        file.readAsStringSync(),
+        maskComments(file.readAsStringSync()),
       );
       final List<String> hits = _forbiddenChromeHits(source, forbidden);
       if (hits.isEmpty) continue;
       if (reason != null && reason.isNotEmpty) {
         liveAllowlistKeys.add(path);
+        liveTokens[path] = hits.toSet();
+        final Set<String> covered =
+            allowedTokens[path] ?? const <String>{}; // 缺项 = 零豁免范围。
+        final List<String> uncovered = hits
+            .where((String token) => !covered.contains(token))
+            .toList(growable: false);
+        if (uncovered.isEmpty) continue;
+        violations.add('$path: ${uncovered.join(', ')}'
+            '（豁免只覆盖 ${covered.join(', ')}；新 token 不在被审范围内）');
         continue;
       }
       violations.add('$path: ${hits.join(', ')}');
@@ -1183,6 +1470,25 @@ void main() {
           'the file is gone, or it has zero forbidden-chrome hits. A reason '
           'that has drifted away from the code is not a reviewed exception, '
           'it is a standing blanket waiver. Delete the entry.',
+    );
+
+    // TODO-2715：同一条纪律下沉到 token 粒度。登记了却不再命中的 token 会悄悄
+    // 变成「预留通行证」：那一项收口之后，同名 token 再长回来不会红。
+    final List<String> deadTokens = <String>[];
+    allowedTokens.forEach((String path, Set<String> tokens) {
+      final Set<String>? live = liveTokens[path];
+      if (live == null) return; // 整条已由 deadAllowlistEntries 报出。
+      final Iterable<String> gone =
+          tokens.where((String token) => !live.contains(token));
+      if (gone.isNotEmpty) deadTokens.add('$path: ${gone.join(', ')}');
+    });
+    expect(
+      deadTokens,
+      isEmpty,
+      reason: 'TODO-2715: these exempted tokens no longer occur in the file. '
+          'A token that has been routed through the shared MD3 components must '
+          'be removed from allowedTokens, otherwise the exemption silently '
+          'holds the door open for it to come back:\n${deadTokens.join('\n')}',
     );
   });
 

--- a/hibiki/test/storage/data_root_migrator_test.dart
+++ b/hibiki/test/storage/data_root_migrator_test.dart
@@ -8,6 +8,8 @@ import 'package:path/path.dart' as p;
 
 import 'package:hibiki/src/storage/data_root_migrator.dart';
 
+import '../helpers/source_guard.dart';
+
 /// TODO-935 E1 块2 单测：数据根迁移引擎 [DataRootMigrator]。
 ///
 /// 三类用例：
@@ -1059,8 +1061,23 @@ void main() {
           'data_root_migrator.dart',
         ),
       ).readAsStringSync();
-      expect(src.contains('listSync(recursive: true'), isFalse,
+      // TODO-2715：判据不得写成精确字面量 `'listSync(recursive: true'`——
+      // `dart format` 会把它折成 `listSync(\n  recursive: true,\n)`，字面量当场
+      // 失配、守卫静默变绿（这个坑在 docs/agent/fast-workflow.md 里被点名，
+      // 但被守的这一侧一直没改）。同时先剥注释：注释里写着这个调用不算实现。
+      final RegExp syncRecursiveList =
+          RegExp(r'(?<![A-Za-z0-9_$])listSync\s*\(\s*recursive:\s*true');
+      expect(syncRecursiveList.hasMatch(maskComments(src)), isFalse,
           reason: '迁移引擎不得在主 isolate 上同步递归列目录（会冻结 UI）');
+      // 判据自校验：正则本身还认不认得这两种写法（禁止型断言长期零命中，
+      // 扫盘那条路检验不到它）。
+      expect(
+          syncRecursiveList.hasMatch('dir.listSync(recursive: true)'), isTrue);
+      expect(syncRecursiveList.hasMatch('dir.listSync(\n  recursive: true,\n)'),
+          isTrue,
+          reason: 'dart format 折行形态必须同样被抓到');
+      expect(syncRecursiveList.hasMatch('dir.listSync(recursive: false)'),
+          isFalse);
     });
 
     test('幂等/防重入：对已含迁移数据的目标再次迁移 → 拒绝覆盖，源与目标均完整', () async {

--- a/hibiki/test/tools/integration_test_no_tester_tap_guard_test.dart
+++ b/hibiki/test/tools/integration_test_no_tester_tap_guard_test.dart
@@ -2,63 +2,95 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import '../helpers/scan_scale.dart';
+import '../helpers/source_guard.dart';
 
-/// Anti-recurrence guard for the project-wide integration-test discipline:
-/// **integration tests drive the real app by focus + synthetic keys only,
-/// never by coordinate taps.** See CLAUDE.md「集成测试一律焦点驱动」 and
-/// docs/agent/integration-testing.md「焦点驱动操作」.
+// Anti-recurrence guard for the project-wide integration-test discipline:
+// **integration tests drive the real app by focus + synthetic keys only,
+// never by coordinate taps.** See CLAUDE.md「集成测试一律焦点驱动」 and
+// docs/agent/integration-testing.md「焦点驱动操作」.
+//
+// Coordinate taps depend on exact screen position; any layout / scroll /
+// scale / platform change silently misplaces them. Focus + key events are
+// position-independent and behave identically on the emulator, the Windows
+// off-screen runner and the Mac runner. The single legal interaction tool is
+// `integration_test/helpers/focus_driver.dart` (`FocusDriver`: `focusWidget`
+// + `activate()` Enter, `adjust()` arrows, `back()` gameButtonB).
+//
+// What this guard forbids: `tester.tap(` / `tester.tapAt(` /
+// `tester.longPress(` (and the `widgetTester.` aliases). It does **not** match
+// `tester.drag(` / `.fling(` — those are legitimate "scroll a Scrollable into
+// view" operations (FocusDriver has no scroll primitive), and the current
+// tree contains exactly 5 such scroll drags that must stay legal.
+//
+// Exemption channels (kept narrow on purpose):
+//   1. A trailing `// itest-tap-allow: <reason>` comment on the offending
+//      line — for a deliberate, justified coordinate tap that genuinely has
+//      no focus equivalent (e.g. tapping inside a platform WebView to prove
+//      it does not steal keyboard focus). Must carry a reason.
+//   2. A temporary `_legacyAllowlist` of files still pending migration — a
+//      scaffold that only blocks *new* offenders. It must shrink to empty as
+//      files are migrated; the guard fails if a listed file has *more*
+//      offenders than recorded (new offender) AND fails if the allowlist is
+//      stale (a listed file now has *fewer* than recorded — bump it down /
+//      remove the entry). This forces monotonic decrement to zero.
+//
+// TODO-2715 fixed two defects in the guard itself:
+//   * **Basename keys.** The allowlist and the per-file counters were keyed by
+//     `entity.uri.pathSegments.last`, so two same-named files in different
+//     directories (`video/foo_test.dart` + `reader/foo_test.dart`) shared one
+//     budget: one could gain offenders while the other lost them and the
+//     guard stayed green. Keys are now repository-relative paths.
+//   * **No comment stripping.** `forbiddenTap` ran on raw lines, so a
+//     commented-out `// await tester.tap(...)` counted as a violation (false
+//     red) — which is precisely why `focus_driver.dart` needed a blanket
+//     exemption in the first place. The match now runs on lexically masked
+//     lines (the `// itest-tap-allow:` marker is still read off the original
+//     lines, which is legal because the mask is length-preserving), so the
+//     whole-file exemption is gone: a *real* `tester.tap(` inside
+//     `focus_driver.dart` is now a violation like anywhere else.
+// ---------------------------------------------------------------------------
+// Forbidden coordinate-interaction calls. tapAt/longPress included; drag and
+// fling are deliberately excluded (legitimate scrolling).
+// ---------------------------------------------------------------------------
+final RegExp kForbiddenTap =
+    RegExp(r'(?:tester|widgetTester)\.(?:tap|tapAt|longPress)\(');
+
+/// A `// itest-tap-allow: <reason>` marker exempts a deliberate, documented
+/// coordinate tap. A bare marker without a reason after the colon is
+/// rejected. The marker may sit on the matched line OR, because `dart format`
+/// can wrap a long `tester.tap(...)` call across several lines, on any line
+/// up to and including the one that terminates the statement (ends with
+/// `;`). So the guard scans the whole logical statement for the marker.
+final RegExp kAllowMarker = RegExp(r'//\s*itest-tap-allow:\s*\S');
+
+/// 1-based line numbers of unexcused coordinate taps in [content].
 ///
-/// Coordinate taps depend on exact screen position; any layout / scroll /
-/// scale / platform change silently misplaces them. Focus + key events are
-/// position-independent and behave identically on the emulator, the Windows
-/// off-screen runner and the Mac runner. The single legal interaction tool is
-/// `integration_test/helpers/focus_driver.dart` (`FocusDriver`: `focusWidget`
-/// + `activate()` Enter, `adjust()` arrows, `back()` gameButtonB).
-///
-/// What this guard forbids: `tester.tap(` / `tester.tapAt(` /
-/// `tester.longPress(` (and the `widgetTester.` aliases). It does **not** match
-/// `tester.drag(` / `.fling(` — those are legitimate "scroll a Scrollable into
-/// view" operations (FocusDriver has no scroll primitive), and the current
-/// tree contains exactly 5 such scroll drags that must stay legal.
-///
-/// Exemption channels (kept narrow on purpose):
-///   1. `helpers/focus_driver.dart` — the focus-driving helper itself; its
-///      doc-comments mention `tap` while explicitly forbidding it.
-///   2. A trailing `// itest-tap-allow: <reason>` comment on the offending
-///      line — for a deliberate, justified coordinate tap that genuinely has
-///      no focus equivalent (e.g. tapping inside a platform WebView to prove
-///      it does not steal keyboard focus). Must carry a reason.
-///   3. A temporary `_legacyAllowlist` of files still pending migration — a
-///      scaffold that only blocks *new* offenders. It must shrink to empty as
-///      files are migrated; the guard fails if a listed file has *more*
-///      offenders than recorded (new offender) AND fails if the allowlist is
-///      stale (a listed file now has *fewer* than recorded — bump it down /
-///      remove the entry). This forces monotonic decrement to zero.
+/// Violations are matched on comment-masked lines (a commented-out tap is not
+/// a tap); the allow marker is matched on the original lines (it *is* a
+/// comment). Both arrays are index-aligned because the mask is
+/// length-preserving.
+List<int> unexcusedCoordinateTapLines(String content) {
+  final List<String> lines = content.split('\n');
+  final List<String> code = maskComments(content).split('\n');
+  final List<int> hits = <int>[];
+  for (int i = 0; i < lines.length; i++) {
+    if (!kForbiddenTap.hasMatch(code[i])) continue;
+    if (_statementHasAllowMarker(lines, i, kAllowMarker)) continue;
+    hits.add(i + 1);
+  }
+  return hits;
+}
+
 void main() {
-  // -------------------------------------------------------------------------
-  // Forbidden coordinate-interaction calls. tapAt/longPress included; drag and
-  // fling are deliberately excluded (legitimate scrolling).
-  // -------------------------------------------------------------------------
-  final RegExp forbiddenTap =
-      RegExp(r'(?:tester|widgetTester)\.(?:tap|tapAt|longPress)\(');
-
-  /// A `// itest-tap-allow: <reason>` marker exempts a deliberate, documented
-  /// coordinate tap. A bare marker without a reason after the colon is
-  /// rejected. The marker may sit on the matched line OR, because `dart format`
-  /// can wrap a long `tester.tap(...)` call across several lines, on any line
-  /// up to and including the one that terminates the statement (ends with
-  /// `;`). So the guard scans the whole logical statement for the marker.
-  final RegExp allowMarker = RegExp(r'//\s*itest-tap-allow:\s*\S');
-
   /// Files still containing un-migrated coordinate taps, with their current
   /// offender count. TEMPORARY SCAFFOLD — every entry must trend to 0 and be
   /// removed. Do NOT add new entries: new files must be focus-driven from the
   /// start (that is the whole point of this guard).
+  ///
+  /// Keys are **repository-relative paths** (`integration_test/...`), never
+  /// basenames: a basename budget is shared by every same-named file in the
+  /// tree, which lets a new offender hide behind another file's migration.
   const Map<String, int> legacyAllowlist = <String, int>{};
-
-  /// The focus-driving helper itself is always exempt (its doc-comments
-  /// reference `tap` while forbidding it).
-  const Set<String> exemptBasenames = <String>{'focus_driver.dart'};
 
   test('integration_test uses focus driving, never tester.tap/longPress', () {
     final Directory dir = Directory('integration_test');
@@ -71,29 +103,20 @@ void main() {
 
     for (final FileSystemEntity entity in dir.listSync(recursive: true)) {
       if (entity is! File || !entity.path.endsWith('.dart')) continue;
-      final String basename = entity.uri.pathSegments.last;
-      if (exemptBasenames.contains(basename)) continue;
+      final String relative = entity.path.replaceAll(r'\', '/');
       scanned++;
 
-      final String content = entity.readAsStringSync();
-      final List<String> lines = content.split('\n');
-      for (int i = 0; i < lines.length; i++) {
-        final String line = lines[i];
-        if (!forbiddenTap.hasMatch(line)) continue;
-        // A documented exemption removes this hit. The marker can be on the
-        // matched line or on a later line of the same (possibly wrapped)
-        // statement, up to and including the line that ends it with `;`.
-        if (_statementHasAllowMarker(lines, i, allowMarker)) continue;
-
-        perFileCounts[basename] = (perFileCounts[basename] ?? 0) + 1;
-        if (!legacyAllowlist.containsKey(basename)) {
-          hardOffenders.add('${entity.path}:${i + 1}');
+      for (final int line
+          in unexcusedCoordinateTapLines(entity.readAsStringSync())) {
+        perFileCounts[relative] = (perFileCounts[relative] ?? 0) + 1;
+        if (!legacyAllowlist.containsKey(relative)) {
+          hardOffenders.add('${entity.path}:$line');
         }
       }
     }
 
     expectScanScale(scanned,
-        what: 'integration_test/ 下未豁免的 .dart', atLeast: 60, measured: 86);
+        what: 'integration_test/ 下的 .dart', atLeast: 60, measured: 87);
 
     // 1) No coordinate taps in files outside the temporary allowlist.
     expect(
@@ -137,6 +160,65 @@ void main() {
         reason: 'Stale allowlist entries — migration progressed but the '
             'recorded count was not lowered. The scaffold must shrink to '
             'empty:\n${stale.join('\n')}');
+  });
+
+  // TODO-2715: the scan above is a forbid-type assertion that is permanently
+  // empty in a healthy tree, so it never exercises the detector. These feed
+  // hand-written sources through the same function, both directions.
+  group('detector self-check (hand-written sources, no disk involved)', () {
+    test('a bare coordinate tap is a violation', () {
+      expect(
+          unexcusedCoordinateTapLines('await tester.tap(finder);'), <int>[1]);
+      expect(
+          unexcusedCoordinateTapLines('await tester.tapAt(offset);'), <int>[1]);
+      expect(unexcusedCoordinateTapLines('await widgetTester.longPress(f);'),
+          <int>[1]);
+    });
+
+    test('a commented-out tap is not a violation (false-red direction)', () {
+      expect(
+          unexcusedCoordinateTapLines('// await tester.tap(finder);'), isEmpty);
+      expect(unexcusedCoordinateTapLines('/* await tester.tap(finder); */'),
+          isEmpty);
+      expect(
+        unexcusedCoordinateTapLines(
+            '/// Drive by focus; never `await tester.tap(finder)`.'),
+        isEmpty,
+        reason: 'this is exactly why focus_driver.dart used to need a '
+            'whole-file exemption',
+      );
+    });
+
+    test('a marker with a reason excuses the tap, a bare marker does not', () {
+      expect(
+        unexcusedCoordinateTapLines(
+            'await tester.tap(f); // itest-tap-allow: platform WebView'),
+        isEmpty,
+      );
+      expect(
+        unexcusedCoordinateTapLines('await tester.tap(f); // itest-tap-allow:'),
+        <int>[1],
+        reason: 'a marker without a reason is not a reviewed exception',
+      );
+    });
+
+    test('the marker survives dart format wrapping the statement', () {
+      expect(
+        unexcusedCoordinateTapLines('''
+await tester.tap(
+  finder,
+  warnIfMissed: false,
+); // itest-tap-allow: platform WebView
+'''),
+        isEmpty,
+      );
+    });
+
+    test('drag/fling stay legal (scrolling has no focus equivalent)', () {
+      expect(unexcusedCoordinateTapLines('await tester.drag(f, o);'), isEmpty);
+      expect(unexcusedCoordinateTapLines('await tester.fling(f, o, 300);'),
+          isEmpty);
+    });
   });
 }
 

--- a/hibiki/test/tools/safe_file_name_guard_test.dart
+++ b/hibiki/test/tools/safe_file_name_guard_test.dart
@@ -3,15 +3,29 @@
 // 背景：全仓曾有 10+ 份手写 `[\\/:*?"<>|]` 及排列变体，其中 home_video_page 的
 // 一份漏写反斜杠（BUG-1125：云视频 id 含 `\` 时字幕与封面落到不同目录）。收敛到
 // `lib/src/utils/misc/safe_file_name.dart` 后，本测试扫描 lib/ 源码，禁止再手写
-// 该字符类的 RegExp（结构参考 bugs_per_file_guard_test.dart，纯 dart:io）。
+// 该字符类的 RegExp。
+//
+// TODO-2715 修掉判据自身的两个假相源（旧写法是「同一行里既有 `RegExp(` 又有指纹」）：
+//
+// ⑤ **假红**：旧注释自陈「注释/文档里引用历史字符串不算违规」，但代码里**从来没有
+//    剥过注释**——把一段历史写法注释掉当反例，守卫会当场判红。现在先 [maskComments]
+//    再匹配，注释与判据终于一致。
+// ④ **假绿**：`dart format` 会把长构造折成
+//    `RegExp(\n  r'[\\/:*?"<>|]',\n)`，`RegExp(` 与指纹落在两行，逐行判据直接失配。
+//    现在改成「先定位 `RegExp(` 调用，再用括号配对切出整个调用原文」，与换行无关。
+//
+// 判据是**禁止型**（violations isEmpty），所以真实仓库里长期零命中——也就是说
+// 「判据本身还认不认得违规」在扫盘那条路上永远得不到检验。下面的自校验用**手写语料**
+// 独立喂进同一个 [findWindowsFileNameBlacklistRegExps]，正负两向都钉住。
 
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import '../helpers/scan_scale.dart';
+import '../helpers/source_guard.dart';
 
 /// 手写黑名单字符类的指纹子串（覆盖历史上出现过的全部排列变体）。
-const List<String> _fingerprints = <String>[
+const List<String> kBlacklistFingerprints = <String>[
   r':*?"<>|', // [\\/:*?"<>|] / [\/:*?"<>|] / [:*?"<>|] / [...\x00-\x1f]
   r'<>:"/', // [<>:"/\\|?*] / [\x00-\x1F<>:"/\\|?*]
   r':"|?*', // [<>:"|?*\x00-\x1F]
@@ -19,6 +33,34 @@ const List<String> _fingerprints = <String>[
 
 /// 唯一允许持有该字符类的真相源。
 const String _allowedFile = 'lib/src/utils/misc/safe_file_name.dart';
+
+/// 以独立标识符身份出现的 `RegExp(` 构造（`MyRegExp(` 不算）。
+final RegExp _regExpConstruction = RegExp(r'(?<![A-Za-z0-9_$])RegExp\s*\(');
+
+/// [source] 里所有「构造了 Windows 文件名黑名单字符类」的 `RegExp(...)` 调用，
+/// 返回 `行号: 首行原文` 形式的定位串（行号从 1 起）。
+///
+/// 词法纪律：
+/// - 注释（`//`、`/* */`，含跨行）先掩成等长空白 ⇒ 注释里引用历史字符串不算违规；
+/// - 调用范围由 [enclosingCall] 的括号配对给出 ⇒ `dart format` 怎么折行都不影响；
+/// - 调用原文再掩一次注释 ⇒ 调用实参之间夹的注释同样不算数。
+List<String> findWindowsFileNameBlacklistRegExps(String source) {
+  final String code = maskComments(source);
+  // 便宜的前置过滤：整份代码里连指纹都没有就不必做括号配对。
+  if (!kBlacklistFingerprints.any(code.contains)) return const <String>[];
+
+  final List<String> hits = <String>[];
+  for (final RegExpMatch match in _regExpConstruction.allMatches(code)) {
+    // match.end 落在 `(` 之后一位，必然在这次调用的实参区间里。
+    final EnclosingCall call = enclosingCall(source, match.end);
+    final String callCode = maskComments(call.text);
+    if (!kBlacklistFingerprints.any(callCode.contains)) continue;
+    final int line =
+        '\n'.allMatches(source.substring(0, call.start)).length + 1;
+    hits.add('$line: ${call.text.split('\n').first.trim()}');
+  }
+  return hits;
+}
 
 void main() {
   test('lib/ 下除唯一真相源外不得手写 Windows 文件名黑名单 RegExp', () {
@@ -36,17 +78,10 @@ void main() {
     for (final File f in files) {
       final String rel = f.path.replaceAll(r'\', '/');
       if (rel == _allowedFile || rel.endsWith('/$_allowedFile')) continue;
-      final List<String> lines = f.readAsLinesSync();
-      for (int i = 0; i < lines.length; i++) {
-        final String line = lines[i];
-        // 只匹配真正构造 RegExp 的行；注释/文档里引用历史字符串不算违规。
-        if (!line.contains('RegExp(')) continue;
-        for (final String fp in _fingerprints) {
-          if (line.contains(fp)) {
-            violations.add('$rel:${i + 1}: ${line.trim()}');
-            break;
-          }
-        }
+      for (final String hit in findWindowsFileNameBlacklistRegExps(
+        f.readAsStringSync(),
+      )) {
+        violations.add('$rel:$hit');
       }
     }
 
@@ -57,5 +92,90 @@ void main() {
           'safeWindowsFileName / windowsUnsafeFileNameChars——直接复用，'
           '勿再复制字符集（BUG-1125 正是复制时漏了反斜杠）：\n${violations.join('\n')}',
     );
+  });
+
+  // 真相源自己必须还持有那个字符集，否则上面那条「除它以外都不许有」守的是空气。
+  test('唯一真相源仍持有该字符类', () {
+    final File truth = File(_allowedFile);
+    expect(truth.existsSync(), isTrue, reason: '真相源文件不见了：$_allowedFile');
+    expect(findWindowsFileNameBlacklistRegExps(truth.readAsStringSync()),
+        isNotEmpty,
+        reason: '$_allowedFile 里已经找不到黑名单字符类了——要么它被改坏，'
+            '要么指纹表过期；两种都会让主守卫退化成永远绿');
+  });
+
+  group('判据自校验（手写语料，与磁盘扫描互不依赖）', () {
+    test('单行写法命中', () {
+      expect(
+        findWindowsFileNameBlacklistRegExps(
+          "final RegExp bad = RegExp(r'[\\\\/:*?\"<>|]');",
+        ),
+        isNotEmpty,
+      );
+    });
+
+    test('④ dart format 折行后仍命中', () {
+      expect(
+        findWindowsFileNameBlacklistRegExps('''
+final RegExp bad = RegExp(
+  r'[\\\\/:*?"<>|]',
+);
+'''),
+        isNotEmpty,
+        reason: '折行是 dart format 的常规产物，判据不得依赖「同一行」',
+      );
+    });
+
+    test('④ 另外两个历史排列变体折行后同样命中', () {
+      for (final String cls in <String>[r'[<>:"/\|?*]', r'[<>:"|?*]']) {
+        expect(
+          findWindowsFileNameBlacklistRegExps(
+              'final r = RegExp(\n  r\'$cls\',\n);'),
+          isNotEmpty,
+          reason: '排列变体 $cls 折行后漏判',
+        );
+      }
+    });
+
+    test('⑤ 行注释里的历史写法不算违规', () {
+      expect(
+        findWindowsFileNameBlacklistRegExps(
+          "// 旧写法：RegExp(r'[\\\\/:*?\"<>|]')，已收敛到 safe_file_name.dart",
+        ),
+        isEmpty,
+      );
+    });
+
+    test('⑤ 块注释 / 文档注释里的历史写法不算违规', () {
+      expect(
+        findWindowsFileNameBlacklistRegExps('''
+/* 历史写法留档：
+   RegExp(r'[\\\\/:*?"<>|]')
+*/
+/// 参见 RegExp(r'[<>:"/\\\\|?*]') 的收敛过程。
+void f() {}
+'''),
+        isEmpty,
+      );
+    });
+
+    test('不构造 RegExp 的普通串不算违规', () {
+      expect(
+        findWindowsFileNameBlacklistRegExps(
+          "final String note = 'chars are :*?\"<>| on Windows';",
+        ),
+        isEmpty,
+        reason: '本守卫钉的是「别再手写这个 RegExp」，不是禁止提到这些字符',
+      );
+    });
+
+    test('无关的 RegExp 不误伤', () {
+      expect(
+        findWindowsFileNameBlacklistRegExps(
+          "final RegExp ok = RegExp(r'^[a-z0-9_]+\$');",
+        ),
+        isEmpty,
+      );
+    });
   });
 }

--- a/hibiki/test/widgets/horizontal_drag_scroll_guard_test.dart
+++ b/hibiki/test/widgets/horizontal_drag_scroll_guard_test.dart
@@ -2,6 +2,30 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import '../helpers/scan_scale.dart';
+import '../helpers/source_guard.dart';
+
+/// 横向滚动区的判据。
+///
+/// TODO-2715：旧判据是精确字面量 `'scrollDirection: Axis.horizontal'`，
+/// `dart format` 只要把它折成 `scrollDirection:\n    Axis.horizontal`（长实参表里
+/// 常见）就一个也匹配不到——分母归零、守卫全绿。改成允许任意空白/换行。
+final RegExp kHorizontalAxis = RegExp(r'scrollDirection:\s*Axis\.horizontal');
+
+/// 包裹件。用 [identifierCall] 定左边界，`MyHorizontalDragScrollable(` 不算数。
+final RegExp kDragScrollableWrap = identifierCall(
+  'HorizontalDragScrollable',
+  allowNamedConstructor: false,
+);
+
+/// 一个文件里的「横向滚动区数 / 包裹数」。判据先剥注释：注释里的示例代码既不该
+/// 被算成违规（假红），也不该被算成包裹（假绿）。
+({int horizontals, int wrapped}) countHorizontalScrollAreas(String source) {
+  final String code = maskComments(source);
+  return (
+    horizontals: kHorizontalAxis.allMatches(code).length,
+    wrapped: kDragScrollableWrap.allMatches(code).length,
+  );
+}
 
 /// 桌面端 Flutter 的默认 `MaterialScrollBehavior.dragDevices` **不含鼠标**：横向
 /// 滚动区用鼠标左键按住左右拖会毫无反应（用户实报）。仓库早在
@@ -41,14 +65,13 @@ void main() {
     for (final FileSystemEntity entity in libDir.listSync(recursive: true)) {
       if (entity is! File || !entity.path.endsWith('.dart')) continue;
       scanned++;
-      final String source = entity.readAsStringSync();
-      final int horizontals =
-          'scrollDirection: Axis.horizontal'.allMatches(source).length;
+      final counts = countHorizontalScrollAreas(entity.readAsStringSync());
+      final int horizontals = counts.horizontals;
       if (horizontals == 0) continue;
       withHorizontal++;
 
       final String relative = entity.path.replaceAll(r'\', '/');
-      final int wrapped = 'HorizontalDragScrollable('.allMatches(source).length;
+      final int wrapped = counts.wrapped;
       final int exempt = exemptions.keys.any(relative.endsWith) ? 1 : 0;
 
       if (wrapped + exempt < horizontals) {
@@ -76,10 +99,54 @@ void main() {
     );
   });
 
+  // TODO-2715：判据自校验。上面那条是禁止型断言（offenders isEmpty），真实仓库里
+  // 长期零命中，所以「分子/分母还认不认得代码」在扫盘那条路上得不到检验；这里用
+  // 手写语料独立喂进同一个 [countHorizontalScrollAreas]，正负两向都钉住。
+  group('判据自校验（手写语料，与磁盘扫描互不依赖）', () {
+    test('单行写法数得到', () {
+      final c = countHorizontalScrollAreas(
+        'ListView(scrollDirection: Axis.horizontal, children: []);',
+      );
+      expect(c.horizontals, 1);
+      expect(c.wrapped, 0);
+    });
+
+    test('dart format 折行后仍数得到（旧字面量判据在这里归零）', () {
+      final c = countHorizontalScrollAreas('''
+ListView.builder(
+  scrollDirection:
+      Axis.horizontal,
+  itemBuilder: (_, __) => const SizedBox(),
+);
+''');
+      expect(c.horizontals, 1, reason: '折行是 dart format 的常规产物，分母不得依赖「同一行」');
+    });
+
+    test('包裹件计数认左边界，不被同后缀标识符顶包', () {
+      final c = countHorizontalScrollAreas('''
+HorizontalDragScrollable(child: ListView(scrollDirection: Axis.horizontal));
+MyHorizontalDragScrollable(child: SizedBox());
+''');
+      expect(c.horizontals, 1);
+      expect(c.wrapped, 1, reason: 'MyHorizontalDragScrollable( 不是这个共享件');
+    });
+
+    test('注释里的示例既不算横向区也不算包裹', () {
+      final c = countHorizontalScrollAreas('''
+// 示例：ListView(scrollDirection: Axis.horizontal) 要包 HorizontalDragScrollable(
+/* scrollDirection: Axis.horizontal */
+void f() {}
+''');
+      expect(c.horizontals, 0);
+      expect(c.wrapped, 0);
+    });
+  });
+
   test('共享件本体存在且放开了 mouse/trackpad/stylus', () {
     final File file = File('lib/src/utils/misc/platform_utils.dart');
     expect(file.existsSync(), isTrue);
-    final String source = file.readAsStringSync();
+    // 全是要求型断言：注释里写着这些名字不算实现（TODO-2715）。
+    final String source = maskComments(file.readAsStringSync());
     expect(source, contains('class HorizontalDragScrollable'));
     expect(source, contains('PointerDeviceKind.mouse'));
     expect(source, contains('PointerDeviceKind.trackpad'));
@@ -92,7 +159,7 @@ void main() {
     final File main = File('lib/main.dart');
     expect(main.existsSync(), isTrue);
     expect(
-      main.readAsStringSync(),
+      maskComments(main.readAsStringSync()),
       isNot(contains('scrollBehavior:')),
       reason: '全局放开鼠标拖动滚动会让垂直网格与 MediaCardDraggable 的 Draggable '
           '抢手势，把「拖卡进合集」变成「拖动网格滚动」。只包横向区。',


### PR DESCRIPTION
承接 PR#756（扫描规模哨兵 + 三份语料守卫）。#756 按范围纪律留下的六项，本轮全部落地。

## 六项

| # | 问题 | 方向 | 修法 |
|---|---|---|---|
| ① | `md3_design_system_static_test` 74 条豁免是**整文件免检** | 假绿 | 新增 `allowedTokens`：豁免按 token 生效 |
| ② | `woff2_decoder_test` fixture 缺失 `markTestSkipped` | 静默消失 | 改硬失败 + 独立的 fixture 存在性断言 |
| ③ | `media_cover_write_guard`「派生 + 裸写须同文件」 | 假绿（结构洞） | `kCoverPathDerivers` 派生点封闭注册表 + 角色断言 |
| ④ | 三处字面量判据 `dart format` 折行即失效；一处 basename 作键 | 假绿 | 允许折行的正则 / 改仓库相对路径键 |
| ⑤ | `safe_file_name_guard` 完全没剥注释，而注释自陈剥了 | **假红** | `maskComments` + `enclosingCall` 括号配对 |
| ⑥ | `expectFadingChromeGateContract` 裸 `contains` + 未剥注释 | 假绿 | `containsCodeLine` / `containsIdentifierCall` |

④⑤⑥ 的共性是「判据与它自称的契约不一致」，⑤⑥ 尤其是**注释在说谎**——这两处的注释现在与判据一致了。

## 新旧判据 A/B（把 origin/develop 的旧判据复制成临时探针，跑同一份语料）

| 语料 | 旧判据 | 新判据 |
|---|---|---|
| `platform_utils.dart` 里**注释掉**的历史 `RegExp(r'[\/:*?"<>\|]')`（单行） | 🔴 红（假红，⑤ 证实） | 🟢 绿 |
| 同文件里 `dart format` **折行**的真违规 `RegExp(\n  r'[...]',\n)` | 🟢 绿（假绿，④ 证实） | 🔴 红 |
| `cover_badge.dart` 里折行的 `scrollDirection:\n    Axis.horizontal`（无包裹） | 🟢 绿（假绿） | 🔴 红 |
| `fading_chrome_gate.dart` 默认曲线改掉、字面量只留在注释里 | 🟢 绿（假绿，⑥ 证实） | 🔴 红 |

探针跑完即删，不入库。

## 变异实测（每条守卫各自）

全部用**反向替换**还原（`git checkout --` 禁用）。第一轮踩到两次**编译失败变异**（`Card()` / `MutatedOpacity(` 让 lib 编不过，把 `data_root_migrator_test` 与 fading 那条一起变成 suite 装载失败 = 无效变异），已改成能编译的形态重跑。

| 变异 | 结果 |
|---|---|
| ① 往 `mokuro_payload.dart` 塞名单外 token `Card(` | 🔴 |
| ① 往 `allowedTokens` 塞一个不再命中的 token | 🔴（dead token） |
| ② 藏掉 `test/fixtures/fonts/Roboto-Regular.woff2` | 🔴（旧行为是"skipped"） |
| ③ 新建一个未登记的封面目的地派生文件 | 🔴 |
| ③ 角色登记写错（开发中真实发生：`anime_download_importer` 我先标了 `writesViaService`） | 🔴，改回 `derivesPathOnly` |
| ④ safe_file_name 折行真违规 | 🔴 |
| ④ horizontal 折行真违规 | 🔴 |
| ④ `data_root_migrator.dart` 里折行的 `listSync(\n  recursive: true,\n)` | 🔴 |
| ④ integration_test 里裸 `tester.tap(` | 🔴 |
| ⑤ 注释掉的历史写法 | 🟢（正确） |
| ⑥ 默认曲线改掉、字面量留注释 | 🔴 |

另外给这批禁止型守卫补了**判据自校验**（手写语料、与磁盘扫描互不依赖）：禁止型断言在健康仓库里永远零命中，判据本身坏掉时扫盘那条路检验不到——这正是 ④ 那三条能坏那么久没人发现的原因。

## ① 收窄了多少

**不是只做机制**。74 条豁免全部从「对全部 14 个禁用 token 整份免检」收成「只对它当前实测命中的那几个 token 免检」，实测生成、本轮零红。收窄幅度：74 文件 × 14 个禁用 token = **1036** 个 (文件, token) 免检格 → **131** 个（实测命中数）。BUG-1425 此前逐文件手写的 5 条可证伪断言保留不动（它们比 token 粒度更细，钉的是「这个 token 只许出现在哪」）。

主扫描同时补上 `maskComments`——测出来只影响一处（`clipboard_lookup_text_panel.dart` 的 `fontSizeFactor` 只在注释里），零条豁免因此变成 dead entry。

## 验证

- `dart format --set-exit-if-changed`：0 changed
- `flutter analyze` 全量（含 test）：`No issues found! (ran in 43.6s)`
- **35 条整批**：`FLUTTER TEST VERDICT: PASSED - 225 tests ran, all tests passed`（基线 207，**+18**，全部是新增的判据自校验用例；N 变大符合预期）
- 定向：`test/{tools,settings,models,storage,widgets,media,pages}` → `PASSED - 8590 tests ran, all tests passed`
- 未动 `docs/bugs/`，未跑 `bugs_per_file_guard`

## 需要 integration owner / TODO-2720 那条线跟进的文档改动（本 PR 未动 `docs/agent/fast-workflow.md`，那是 2720 的地盘）

1. 「实测 207 tests」→ **225**。
2. 「同一个坑也存在于被守的一侧：`test/storage/data_root_migrator_test.dart` 里 `contains('listSync(recursive: true')` 这条断言就抓不到折行写法」——**本 PR 已修**，这句可以改成已修记录。

## 顺带发现、本轮没改

- `md3_design_system_static_test` 的另一条 `bannedByFile` 测试（约 line 627）仍在**未剥注释**的源码上跑 `isNot(contains(...))`，同 ⑤ 的假红形态。没动是因为它是点名清单型、判据面窄，且改动会牵动 `_functionSource` 切片，留作独立一条。
- `integration_test_no_tester_tap_guard` 原来的 `focus_driver.dart` 整文件豁免其实是**空豁免**：它文里的 `tester.tap` 后面没有 `(`，正则本来就不命中。豁免已随剥注释一起删掉，现在 `focus_driver.dart` 里真写一个 `tester.tap(` 会被抓。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH


