### PR TITLE
fix(shortcuts): 无文本焦点时解除 Windows IME 关联，修中文输入法吞掉全部快捷键 (BUG-1450)

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,7 +29,7 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1359 条。点号进各自文件。
+> 共 1360 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
@@ -37,6 +37,7 @@
 | [BUG-1453](bugs/BUG-1453-video-gamepad-synthetic-right-click.md) | ✅ | ✅ | 手柄按键同时触发视频动作与右键菜单 |
 | [BUG-1452](bugs/BUG-1452-gal-unselected-thread-implies-audio.md) | ✅ | ✅ | 未选择台词线程时仍显示正在监听与句级音频 |
 | [BUG-1451](bugs/BUG-1451-popup-copy-shortcut-and-context-menu.md) | ✅ | ✅ | 查词弹窗无法复制（Ctrl+C 与右键「复制」都无效） |
+| [BUG-1450](bugs/BUG-1450-windows-ime-swallows-shortcuts.md) | ✅ | ✅ | 中文输入法激活时全表面快捷键失效（IME 吞键） |
 | [BUG-1449](bugs/BUG-1449-gal-helper-bundled-as-plain-files.md) | ✅ | ✅ | helper 改为构建期解压随包，消灭需与本体同步的第二份副本 |
 | [BUG-1448](bugs/BUG-1448-gal-helper-version-check-short-circuited.md) | ✅ | ✅ | injector 存在即跳过 ensureInjector，随包新组件永不换入 |
 | [BUG-1447](bugs/BUG-1447-manga-remote-ocr-probe-ignores-models-ready.md) | ✅ | ✅ | 远端 OCR probe 只校验 supported 不校验 modelsReady，模型未下载的主机照样可选，白传一整卷才报错 |

--- a/docs/bugs/BUG-1450-windows-ime-swallows-shortcuts.md
+++ b/docs/bugs/BUG-1450-windows-ime-swallows-shortcuts.md
@@ -4,10 +4,10 @@
   - **本机实测取证**（Win32 消息探针，微软拼音中文态）：字母键到达窗口的确实是 `WM_KEYDOWN wParam=0x00E5`（`VK_PROCESSKEY`），lParam 保留真实 scancode（0x15=Y / 0x2C=Z / 0x24=J / 0x32=M / 0x02=数字1）。即消息通道没变，变的是键的身份被输入法接管。
   - **「日语能用」不是反例**：日语输入法常驻半角英数态时根本不吃字母，只有空格被吃；那一个键恰好被 BUG-1239 的 native 单键转发救回（`hibiki/windows/runner/ime_space_dispatch.cpp`，仅识别 scancode `0x39` 且仅接在视频页）。中文拼音没有等价的英数态（切英文即切走输入法），所以空格 + 全部字母快捷键一起废——BUG-1239 那条单键补丁在结构上救不了其余键。
 - **[x] ① 已修复** — 不再逐键补转发（那等于在 app 内重建键盘管线，且必然与真实文本输入打架），而是消除特殊情况本身：**没有可编辑焦点时解除窗口 IME 关联，文本框拿焦时立刻恢复**。Dart 侧持有焦点真相、native 侧持有 HWND，经 `app.hibiki/windows_ime_guard` 通道对接。
-  - Dart：`hibiki/lib/src/platform/windows_ime_guard.dart`（纯谓词 `imeShouldBeEnabled` + `FocusManager` 驱动，判据复用既有 `focusedEditableText()`，不另造第二套真相），在 `runApp` 前 `install()`（`hibiki/lib/main.dart`），冷启动第一帧即生效。
+  - Dart：`hibiki/lib/src/platform/windows_ime_guard.dart`（纯谓词 `imeShouldBeEnabled` + `FocusManager` 驱动，定位焦点复用既有 `focusedEditableText()`，再按 `EditableText.readOnly` 区分真实输入与 `SelectableText` 的只读选择焦点），在 `runApp` 前 `install()`（`hibiki/lib/main.dart`），冷启动第一帧即生效。
   - native：`hibiki/windows/runner/ime_association_guard.{h,cpp}` 状态机 + `FlutterWindow::RegisterImeGuardChannel`（`hibiki/windows/runner/flutter_window.cpp`）。实际调用 `ImmAssociateContextEx(hwnd, nullptr, IACE_DEFAULT / 0)`（与 Chromium `InputMethodWinImm32` 同契约），作用于**持焦的 Flutter view HWND**而非顶层框架窗口——IME context 是 per-HWND 的，只改顶层无效。
   - 兼容性：仅 Windows 生效（`defaultTargetPlatform` 判定），其余平台空转；旧 runner 缺通道时吞 `MissingPluginException` 回到修复前行为；BUG-1239 的空格通道原样保留不动（Never break userspace），只是修复后它基本不再触发。
 - **[x] ② 已加自动化测试** — 两侧各自可执行，且**均已变异实测**（变异内容不写进注释）：
-  - Dart：`hibiki/test/platform/windows_ime_guard_test.dart`（6 条）——冷启动即解除、文本框拿焦必须恢复（否则中日文全打不了，比原 bug 更糟）、失焦再解除、同状态焦点churn 不重复打通道、非 Windows 空转。变异 3 处全部转红：谓词取反 / 去掉去重 / 去掉 install 首次同步。
+  - Dart：`hibiki/test/platform/windows_ime_guard_test.dart`——冷启动即解除、点击 `SelectableText` 不得恢复、`SelectableText ↔ TextField` 切焦只按真实输入能力翻转、文本框拿焦必须恢复（否则中日文全打不了，比原 bug 更糟）、失焦再解除、同状态焦点 churn 不重复打通道、非 Windows 空转。
   - native：`hibiki/windows/runner/tests/ime_association_guard_test.cpp`，由 `CMakeLists.txt` 的 `hibiki_windows_ime_association_gate` 在每次 Windows runner 构建时编译执行（沿用 BUG-1239 的构建门模式）——首次 disable 必须落地、重复请求合并、re-enable 必须落地、首次 enable 也要落地（热重启后窗口可能已解除）、平台调用失败不得记账。变异「去掉去重」实测转红。以项目真实编译选项 `/W4 /WX` 零警告通过。
-- **备注**：真机验收由用户执行（用户已确认）。需覆盖：① 中文拼音激活时视频页/阅读器的空格与字母快捷键；② 点进搜索框/笔记框/Anki 字段后能否立刻输入中文与日文；③ 输入完离开文本框后快捷键是否恢复。
+- **备注**：真 Windows IME / 设备验收尚未执行。需覆盖：① 中文拼音激活时视频页/阅读器的空格与字母快捷键；② 点击可选文本后快捷键仍可用；③ 点进搜索框/笔记框/Anki 字段后能否立刻输入中文与日文；④ 输入完离开文本框后快捷键是否恢复。

--- a/docs/bugs/BUG-1450-windows-ime-swallows-shortcuts.md
+++ b/docs/bugs/BUG-1450-windows-ime-swallows-shortcuts.md
@@ -1,0 +1,13 @@
+## BUG-1450 · 中文输入法激活时全表面快捷键失效（IME 吞键）
+- **报告**：2026-08-02（用户：日语输入法能用空格快捷键了，中文输入法不行，快捷键之类的用不了）
+- **真实性**：✅ 真 bug —— 根因是平台层而非快捷键解析层。Flutter 的 Windows 窗口**终生**保留 IME context：`Win32Window::SetChildContent` 把焦点交给 Flutter view 子窗口（`hibiki/windows/runner/win32_window.cpp:353`），而引擎从不在「无文本输入客户端」时解除该窗口的 IME 关联。于是只要输入法处于吞键模式，每次按键都被输入法拿走，以 `WM_KEYDOWN / wParam=VK_PROCESSKEY` 到达，引擎再按 BUG-1427 钉死的平台事实把它报成 `physical=0 / logical=0` 的 KeyEvent，`HibikiShortcutRegistry.resolveKeyboard` 的精确相等与物理键回退**同时**落空（`hibiki/lib/src/shortcuts/shortcut_registry.dart:322-352`），整张快捷键表静默失效。
+  - **本机实测取证**（Win32 消息探针，微软拼音中文态）：字母键到达窗口的确实是 `WM_KEYDOWN wParam=0x00E5`（`VK_PROCESSKEY`），lParam 保留真实 scancode（0x15=Y / 0x2C=Z / 0x24=J / 0x32=M / 0x02=数字1）。即消息通道没变，变的是键的身份被输入法接管。
+  - **「日语能用」不是反例**：日语输入法常驻半角英数态时根本不吃字母，只有空格被吃；那一个键恰好被 BUG-1239 的 native 单键转发救回（`hibiki/windows/runner/ime_space_dispatch.cpp`，仅识别 scancode `0x39` 且仅接在视频页）。中文拼音没有等价的英数态（切英文即切走输入法），所以空格 + 全部字母快捷键一起废——BUG-1239 那条单键补丁在结构上救不了其余键。
+- **[x] ① 已修复** — 不再逐键补转发（那等于在 app 内重建键盘管线，且必然与真实文本输入打架），而是消除特殊情况本身：**没有可编辑焦点时解除窗口 IME 关联，文本框拿焦时立刻恢复**。Dart 侧持有焦点真相、native 侧持有 HWND，经 `app.hibiki/windows_ime_guard` 通道对接。
+  - Dart：`hibiki/lib/src/platform/windows_ime_guard.dart`（纯谓词 `imeShouldBeEnabled` + `FocusManager` 驱动，判据复用既有 `focusedEditableText()`，不另造第二套真相），在 `runApp` 前 `install()`（`hibiki/lib/main.dart`），冷启动第一帧即生效。
+  - native：`hibiki/windows/runner/ime_association_guard.{h,cpp}` 状态机 + `FlutterWindow::RegisterImeGuardChannel`（`hibiki/windows/runner/flutter_window.cpp`）。实际调用 `ImmAssociateContextEx(hwnd, nullptr, IACE_DEFAULT / 0)`（与 Chromium `InputMethodWinImm32` 同契约），作用于**持焦的 Flutter view HWND**而非顶层框架窗口——IME context 是 per-HWND 的，只改顶层无效。
+  - 兼容性：仅 Windows 生效（`defaultTargetPlatform` 判定），其余平台空转；旧 runner 缺通道时吞 `MissingPluginException` 回到修复前行为；BUG-1239 的空格通道原样保留不动（Never break userspace），只是修复后它基本不再触发。
+- **[x] ② 已加自动化测试** — 两侧各自可执行，且**均已变异实测**（变异内容不写进注释）：
+  - Dart：`hibiki/test/platform/windows_ime_guard_test.dart`（6 条）——冷启动即解除、文本框拿焦必须恢复（否则中日文全打不了，比原 bug 更糟）、失焦再解除、同状态焦点churn 不重复打通道、非 Windows 空转。变异 3 处全部转红：谓词取反 / 去掉去重 / 去掉 install 首次同步。
+  - native：`hibiki/windows/runner/tests/ime_association_guard_test.cpp`，由 `CMakeLists.txt` 的 `hibiki_windows_ime_association_gate` 在每次 Windows runner 构建时编译执行（沿用 BUG-1239 的构建门模式）——首次 disable 必须落地、重复请求合并、re-enable 必须落地、首次 enable 也要落地（热重启后窗口可能已解除）、平台调用失败不得记账。变异「去掉去重」实测转红。以项目真实编译选项 `/W4 /WX` 零警告通过。
+- **备注**：真机验收由用户执行（用户已确认）。需覆盖：① 中文拼音激活时视频页/阅读器的空格与字母快捷键；② 点进搜索框/笔记框/Anki 字段后能否立刻输入中文与日文；③ 输入完离开文本框后快捷键是否恢复。

--- a/hibiki/lib/main.dart
+++ b/hibiki/lib/main.dart
@@ -56,6 +56,7 @@ import 'package:hibiki/src/sync/book_exit_sync_scope.dart';
 import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/anki/ankimobile_repository.dart';
 import 'package:hibiki/src/platform/platform_services.dart';
+import 'package:hibiki/src/platform/windows_ime_guard.dart';
 import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/platform/desktop/desktop_lifecycle_service.dart';
 import 'package:hibiki/src/platform/ios/ios_url_event_channel.dart';
@@ -308,6 +309,11 @@ void main([List<String> args = const <String>[]]) {
         platformServicesProvider.overrideWithValue(platformServices),
       ],
     );
+
+    /// BUG-1450：Windows 上没有文本框持焦时解除窗口的 IME 关联，否则中文输入法
+    /// 会吞掉每一个按键（引擎把它们报成 physical=0/logical=0），整张快捷键表失效。
+    /// 必须在 runApp 之前挂上：install 会立刻同步一次，冷启动第一帧起就生效。
+    WindowsImeGuard.install();
 
     /// Start the application immediately so the user sees the loading page
     /// rather than a blank white screen while initialisation is in progress.

--- a/hibiki/lib/src/platform/windows_ime_guard.dart
+++ b/hibiki/lib/src/platform/windows_ime_guard.dart
@@ -65,8 +65,10 @@ abstract final class WindowsImeGuard {
   static void _onFocusChanged() => _syncNow();
 
   static void _syncNow() {
+    final EditableText? editable = focusedEditableText();
     final bool enable = imeShouldBeEnabled(
-      hasEditableFocus: focusedEditableText() != null,
+      hasEditableFocus: editable != null,
+      focusedEditableIsReadOnly: editable?.readOnly ?? true,
     );
     // 焦点变化一帧内会触发多次通知；只有状态真正翻转才打通道。
     if (_lastSent == enable) return;
@@ -89,7 +91,13 @@ abstract final class WindowsImeGuard {
 
 /// 是否应当让输入法接管按键。
 ///
-/// 唯一判据是「有没有真正在编辑的文本框」：有就必须开（否则用户打不了中日文），
-/// 没有就必须关（否则输入法吞掉全部快捷键）。抽成纯函数以便直接单测，不必起
-/// 平台通道。
-bool imeShouldBeEnabled({required bool hasEditableFocus}) => hasEditableFocus;
+/// 唯一判据是「有没有真正在接收输入的文本框」：有就必须开（否则用户打不了中日文），
+/// 没有就必须关（否则输入法吞掉全部快捷键）。不能只判断 [EditableText] 是否存在：
+/// [SelectableText] 内部同样用一个 `readOnly` 的 [EditableText] 承载选择焦点，点击它
+/// 不代表用户要输入文字。这里按输入能力判定，而不是对白名单里的 widget 类型特判。
+/// 抽成纯函数以便直接单测，不必起平台通道。
+bool imeShouldBeEnabled({
+  required bool hasEditableFocus,
+  required bool focusedEditableIsReadOnly,
+}) =>
+    hasEditableFocus && !focusedEditableIsReadOnly;

--- a/hibiki/lib/src/platform/windows_ime_guard.dart
+++ b/hibiki/lib/src/platform/windows_ime_guard.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+import 'package:hibiki/src/shortcuts/gamepad_service.dart'
+    show focusedEditableText;
+
+/// BUG-1450：Windows 上中文输入法激活时全表面快捷键失效的根治开关。
+///
+/// 根因不在快捷键解析层。Flutter 的 Windows 窗口**终生**保留 IME context——引擎
+/// 不会在「没有文本框聚焦」时解除关联。于是只要输入法处于吞键模式（微软拼音的中文
+/// 态、MS-IME 的假名态），每一次按键都被输入法拿走，以
+/// `WM_KEYDOWN / wParam=VK_PROCESSKEY` 到达，引擎再把它报成
+/// `physical=0 / logical=0` 的 KeyEvent（BUG-1427 已把这条平台事实钉成守卫），
+/// 于是整张快捷键表静默失效。
+///
+/// 日语输入法「看起来正常」只是因为它常驻半角英数态、根本不吃字母；被吃掉的空格那
+/// 一个键恰好被 BUG-1239 的 native 单键转发救了回来。中文拼音没有等价的英数态
+/// （切英文就等于切走输入法），所以空格 + 全部字母快捷键一起废。
+///
+/// 修法是消除这个特殊情况而不是逐键补转发：**没有文本输入焦点时解除窗口的 IME
+/// 关联**，按键根本不进输入法，走正常 KeyEvent 管线；文本框一拿到焦点立刻恢复，
+/// 中日文输入照常。native 侧见 `windows/runner/ime_association_guard.h`。
+///
+/// 只作用于 Windows。其它平台不存在这条平台缺陷，`install` 直接空转。
+abstract final class WindowsImeGuard {
+  static const MethodChannel _channel =
+      MethodChannel('app.hibiki/windows_ime_guard');
+
+  static bool _installed = false;
+  static bool? _lastSent;
+
+  /// 仅供测试覆盖平台判定与通道，避免真机 channel 依赖。
+  @visibleForTesting
+  static bool debugForceEnabled = false;
+
+  /// 仅供测试观察最近一次真正发出的请求（null = 还没发过）。
+  @visibleForTesting
+  static bool? get debugLastSent => _lastSent;
+
+  @visibleForTesting
+  static void debugReset() {
+    FocusManager.instance.removeListener(_onFocusChanged);
+    _installed = false;
+    _lastSent = null;
+  }
+
+  static bool get _active =>
+      debugForceEnabled ||
+      (!kIsWeb && defaultTargetPlatform == TargetPlatform.windows);
+
+  /// 挂上焦点监听。幂等；非 Windows 平台空转。
+  ///
+  /// 启动时没有任何文本框持焦，所以首次同步会立刻解除关联——快捷键从冷启动第一帧
+  /// 起就不受输入法影响。
+  static void install() {
+    if (_installed || !_active) return;
+    _installed = true;
+    FocusManager.instance.addListener(_onFocusChanged);
+    _syncNow();
+  }
+
+  static void _onFocusChanged() => _syncNow();
+
+  static void _syncNow() {
+    final bool enable = imeShouldBeEnabled(
+      hasEditableFocus: focusedEditableText() != null,
+    );
+    // 焦点变化一帧内会触发多次通知；只有状态真正翻转才打通道。
+    if (_lastSent == enable) return;
+    _lastSent = enable;
+    unawaited(_send(enable));
+  }
+
+  static Future<void> _send(bool enable) async {
+    try {
+      await _channel.invokeMethod<void>('setImeEnabled', enable);
+    } on MissingPluginException {
+      // 旧 runner（未含 BUG-1450 的 native 侧）：保持现状，不让缺通道把 app 打挂。
+    } on PlatformException {
+      // 关联失败不致命——最坏是回到修复前的行为。下次焦点翻转会重试，因为失败的
+      // 状态没有在 native 侧落账（见 ImeAssociationGuard::SetEnabled）。
+      _lastSent = null;
+    }
+  }
+}
+
+/// 是否应当让输入法接管按键。
+///
+/// 唯一判据是「有没有真正在编辑的文本框」：有就必须开（否则用户打不了中日文），
+/// 没有就必须关（否则输入法吞掉全部快捷键）。抽成纯函数以便直接单测，不必起
+/// 平台通道。
+bool imeShouldBeEnabled({required bool hasEditableFocus}) => hasEditableFocus;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1199
+version: 1.3.1+1200
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/platform/windows_ime_guard_test.dart
+++ b/hibiki/test/platform/windows_ime_guard_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/platform/windows_ime_guard.dart';
+
+/// BUG-1450：中文输入法激活时全表面快捷键失效。根因是 Flutter 的 Windows 窗口终生
+/// 保留 IME context，输入法吞掉所有按键（引擎报成 physical=0/logical=0）。修法是
+/// 无文本框焦点时解除关联、文本框拿焦时恢复。
+///
+/// 这里锁死两条不变式：
+/// 1. 没有可编辑焦点 → 关（否则快捷键继续被吞）。
+/// 2. 有可编辑焦点 → 开（否则用户在 app 里根本打不了中日文——比原 bug 更糟）。
+void main() {
+  group('imeShouldBeEnabled', () {
+    test('无文本框焦点时关闭输入法接管，快捷键才能到达', () {
+      expect(imeShouldBeEnabled(hasEditableFocus: false), isFalse);
+    });
+
+    test('文本框持焦时必须开启，否则中日文输入全废', () {
+      expect(imeShouldBeEnabled(hasEditableFocus: true), isTrue);
+    });
+  });
+
+  group('WindowsImeGuard 焦点驱动', () {
+    final List<bool> calls = <bool>[];
+
+    setUp(() {
+      calls.clear();
+      WindowsImeGuard.debugReset();
+      WindowsImeGuard.debugForceEnabled = true;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('app.hibiki/windows_ime_guard'),
+        (MethodCall call) async {
+          if (call.method == 'setImeEnabled') {
+            calls.add(call.arguments as bool);
+          }
+          return null;
+        },
+      );
+    });
+
+    tearDown(() {
+      WindowsImeGuard.debugForceEnabled = false;
+      WindowsImeGuard.debugReset();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel('app.hibiki/windows_ime_guard'),
+        null,
+      );
+    });
+
+    testWidgets('冷启动无文本框焦点：立刻解除关联', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: Text('no text field'))),
+      );
+      WindowsImeGuard.install();
+      await tester.pump();
+
+      expect(calls, <bool>[false]);
+      expect(WindowsImeGuard.debugLastSent, isFalse);
+    });
+
+    testWidgets('文本框拿到焦点 → 恢复；失焦 → 再次解除', (WidgetTester tester) async {
+      final FocusNode node = FocusNode();
+      addTearDown(node.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: <Widget>[
+                TextField(focusNode: node),
+                const Text('elsewhere'),
+              ],
+            ),
+          ),
+        ),
+      );
+      WindowsImeGuard.install();
+      await tester.pump();
+      expect(calls, <bool>[false], reason: '启动时没有编辑焦点');
+
+      node.requestFocus();
+      await tester.pump();
+      expect(calls, <bool>[false, true],
+          reason: '文本框持焦必须恢复输入法，否则打不了中文');
+
+      node.unfocus();
+      await tester.pump();
+      expect(calls, <bool>[false, true, false],
+          reason: '离开文本框应重新让快捷键可用');
+    });
+
+    testWidgets('同一状态的重复焦点通知不重复打通道', (WidgetTester tester) async {
+      final FocusNode a = FocusNode();
+      final FocusNode b = FocusNode();
+      addTearDown(a.dispose);
+      addTearDown(b.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: <Widget>[
+                Focus(focusNode: a, child: const Text('a')),
+                Focus(focusNode: b, child: const Text('b')),
+              ],
+            ),
+          ),
+        ),
+      );
+      WindowsImeGuard.install();
+      await tester.pump();
+
+      a.requestFocus();
+      await tester.pump();
+      b.requestFocus();
+      await tester.pump();
+
+      expect(calls, <bool>[false],
+          reason: '两个都不是文本框，状态没翻转就不该再发');
+    });
+
+    testWidgets('非 Windows 平台完全空转', (WidgetTester tester) async {
+      WindowsImeGuard.debugReset();
+      WindowsImeGuard.debugForceEnabled = false;
+
+      await tester.pumpWidget(
+        const MaterialApp(home: Scaffold(body: Text('x'))),
+      );
+      WindowsImeGuard.install();
+      await tester.pump();
+
+      expect(calls, isEmpty);
+    });
+  });
+}

--- a/hibiki/test/platform/windows_ime_guard_test.dart
+++ b/hibiki/test/platform/windows_ime_guard_test.dart
@@ -14,11 +14,33 @@ import 'package:hibiki/src/platform/windows_ime_guard.dart';
 void main() {
   group('imeShouldBeEnabled', () {
     test('无文本框焦点时关闭输入法接管，快捷键才能到达', () {
-      expect(imeShouldBeEnabled(hasEditableFocus: false), isFalse);
+      expect(
+        imeShouldBeEnabled(
+          hasEditableFocus: false,
+          focusedEditableIsReadOnly: false,
+        ),
+        isFalse,
+      );
     });
 
     test('文本框持焦时必须开启，否则中日文输入全废', () {
-      expect(imeShouldBeEnabled(hasEditableFocus: true), isTrue);
+      expect(
+        imeShouldBeEnabled(
+          hasEditableFocus: true,
+          focusedEditableIsReadOnly: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('只读 EditableText 持焦不等于文本输入，保持 IME 解除', () {
+      expect(
+        imeShouldBeEnabled(
+          hasEditableFocus: true,
+          focusedEditableIsReadOnly: true,
+        ),
+        isFalse,
+      );
     });
   });
 
@@ -84,13 +106,66 @@ void main() {
 
       node.requestFocus();
       await tester.pump();
-      expect(calls, <bool>[false, true],
-          reason: '文本框持焦必须恢复输入法，否则打不了中文');
+      expect(calls, <bool>[false, true], reason: '文本框持焦必须恢复输入法，否则打不了中文');
 
       node.unfocus();
       await tester.pump();
-      expect(calls, <bool>[false, true, false],
-          reason: '离开文本框应重新让快捷键可用');
+      expect(calls, <bool>[false, true, false], reason: '离开文本框应重新让快捷键可用');
+    });
+
+    testWidgets('点击 SelectableText 不会重新关联 IME，快捷键保持可用',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: SelectableText('click to select')),
+        ),
+      );
+      WindowsImeGuard.install();
+      await tester.pump();
+      expect(calls, <bool>[false]);
+
+      await tester.tap(find.byType(SelectableText));
+      await tester.pump();
+
+      expect(
+        calls,
+        <bool>[false],
+        reason: 'SelectableText 的只读 EditableText 焦点不能冒充输入焦点',
+      );
+      expect(WindowsImeGuard.debugLastSent, isFalse);
+    });
+
+    testWidgets('SelectableText 与真文本框来回切焦只在输入能力变化时切换',
+        (WidgetTester tester) async {
+      final FocusNode editableNode = FocusNode();
+      addTearDown(editableNode.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: <Widget>[
+                const SelectableText('selectable'),
+                TextField(focusNode: editableNode),
+              ],
+            ),
+          ),
+        ),
+      );
+      WindowsImeGuard.install();
+      await tester.pump();
+
+      await tester.tap(find.byType(SelectableText));
+      await tester.pump();
+      expect(calls, <bool>[false]);
+
+      editableNode.requestFocus();
+      await tester.pump();
+      expect(calls, <bool>[false, true]);
+
+      await tester.tap(find.byType(SelectableText));
+      await tester.pump();
+      expect(calls, <bool>[false, true, false]);
     });
 
     testWidgets('同一状态的重复焦点通知不重复打通道', (WidgetTester tester) async {
@@ -119,8 +194,7 @@ void main() {
       b.requestFocus();
       await tester.pump();
 
-      expect(calls, <bool>[false],
-          reason: '两个都不是文本框，状态没翻转就不该再发');
+      expect(calls, <bool>[false], reason: '两个都不是文本框，状态没翻转就不该再发');
     });
 
     testWidgets('非 Windows 平台完全空转', (WidgetTester tester) async {

--- a/hibiki/windows/runner/CMakeLists.txt
+++ b/hibiki/windows/runner/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(${BINARY_NAME} WIN32
   "foreground_selection.cpp"
   "global_lookup_window.cpp"
   "hook_toolbar_window.cpp"
+  "ime_association_guard.cpp"
   "ime_space_dispatch.cpp"
   "low_level_mouse_hook.cpp"
   "main.cpp"
@@ -83,6 +84,9 @@ target_link_libraries(${BINARY_NAME} PRIVATE avrt)
 # 剪切板面板背景逐像素透明（global_lookup_window composition 模式）：DirectComposition
 # 视觉树承载 WebView2 composition controller 的透明像素，dxguid 提供 DComp/DXGI IID。
 target_link_libraries(${BINARY_NAME} PRIVATE dcomp dxguid)
+# BUG-1450: ImmAssociateContextEx — detach the IME from the window while no text
+# field has focus so CJK IMEs stop swallowing every shortcut key.
+target_link_libraries(${BINARY_NAME} PRIVATE imm32)
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 add_dependencies(${BINARY_NAME} flutter_assemble)
 
@@ -101,6 +105,24 @@ add_custom_target(hibiki_windows_ime_space_gate
   VERBATIM
 )
 add_dependencies(${BINARY_NAME} hibiki_windows_ime_space_gate)
+
+# BUG-1450: same treatment for the IME association state machine. Getting the
+# coalescing or the failure path wrong either strands the window with the IME
+# detached (no Chinese/Japanese input anywhere in the app) or re-attached (the
+# whole shortcut table dies again), so it runs on every Windows runner build.
+add_executable(hibiki_windows_ime_association_test
+  "ime_association_guard.cpp"
+  "tests/ime_association_guard_test.cpp"
+)
+apply_standard_settings(hibiki_windows_ime_association_test)
+target_compile_definitions(hibiki_windows_ime_association_test PRIVATE "NOMINMAX")
+target_link_libraries(hibiki_windows_ime_association_test PRIVATE imm32)
+add_custom_target(hibiki_windows_ime_association_gate
+  COMMAND "$<TARGET_FILE:hibiki_windows_ime_association_test>"
+  DEPENDS hibiki_windows_ime_association_test
+  VERBATIM
+)
+add_dependencies(${BINARY_NAME} hibiki_windows_ime_association_gate)
 
 add_executable(hibiki_update_launcher WIN32
   "update_launcher.cpp"

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -542,6 +542,7 @@ bool FlutterWindow::OnCreate() {
           "app.hibiki/windows_ime_space",
           &flutter::StandardMethodCodec::GetInstance());
 
+  RegisterImeGuardChannel();
   RegisterFloatingLyricChannel();
   RegisterClipboardTextChannel();
   RegisterGalHookTextChannel();
@@ -850,6 +851,51 @@ void FlutterWindow::RegisterFloatingLyricChannel() {
         } else {
           result->NotImplemented();
         }
+      });
+}
+
+void FlutterWindow::RegisterImeGuardChannel() {
+  // BUG-1450: Dart owns focus knowledge, the runner owns the HWND. Dart calls
+  // setImeEnabled(false) while nothing editable holds focus so a CJK IME stops
+  // consuming shortcut keys, and setImeEnabled(true) the moment a text field
+  // takes focus so Chinese/Japanese input keeps working everywhere.
+  ime_association_guard_ = ImeAssociationGuard(
+      [](HWND hwnd, bool enable, void*) {
+        return ApplyImeAssociation(hwnd, enable);
+      },
+      nullptr);
+
+  windows_ime_guard_channel_ =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          flutter_controller_->engine()->messenger(),
+          "app.hibiki/windows_ime_guard",
+          &flutter::StandardMethodCodec::GetInstance());
+
+  windows_ime_guard_channel_->SetMethodCallHandler(
+      [this](const flutter::MethodCall<flutter::EncodableValue>& call,
+             std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>>
+                 result) {
+        if (call.method_name() != "setImeEnabled") {
+          result->NotImplemented();
+          return;
+        }
+        const auto* enable = std::get_if<bool>(call.arguments());
+        if (enable == nullptr) {
+          result->Error("bad_args", "setImeEnabled expects a bool");
+          return;
+        }
+        // The IME context is per-HWND and applies to whichever window holds
+        // focus. Win32Window::SetChildContent does SetFocus(child), so the
+        // Flutter view — not the top-level frame — is the window the IME talks
+        // to. Fall back to the frame only if the view is gone (teardown).
+        HWND target = flutter_controller_ && flutter_controller_->view()
+                          ? flutter_controller_->view()->GetNativeWindow()
+                          : nullptr;
+        if (target == nullptr) {
+          target = GetHandle();
+        }
+        ime_association_guard_.SetEnabled(target, *enable);
+        result->Success();
       });
 }
 

--- a/hibiki/windows/runner/flutter_window.cpp
+++ b/hibiki/windows/runner/flutter_window.cpp
@@ -894,7 +894,16 @@ void FlutterWindow::RegisterImeGuardChannel() {
         if (target == nullptr) {
           target = GetHandle();
         }
-        ime_association_guard_.SetEnabled(target, *enable);
+        const ImeAssociationUpdate update =
+            ime_association_guard_.SetEnabled(target, *enable);
+        if (update == ImeAssociationUpdate::kFailed) {
+          // Let Dart clear its optimistic cache so the same desired state can
+          // be retried. Reporting Success here would strand a recreated view
+          // with the wrong association until some unrelated focus transition.
+          result->Error("ime_association_failed",
+                        "ImmAssociateContextEx failed for the Flutter view");
+          return;
+        }
         result->Success();
       });
 }

--- a/hibiki/windows/runner/flutter_window.h
+++ b/hibiki/windows/runner/flutter_window.h
@@ -10,6 +10,7 @@
 
 #include "floating_lyric_window.h"
 #include "global_lookup_window.h"
+#include "ime_association_guard.h"
 #include "win32_window.h"
 
 // A window that does nothing but host a Flutter view.
@@ -60,6 +61,16 @@ class FlutterWindow : public Win32Window {
   // Flutter turns VK_PROCESSKEY into a KeyEvent with physical/logical key 0.
   std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
       windows_ime_space_channel_;
+
+  // BUG-1450: Dart tells us whether anything editable holds focus; while
+  // nothing does we detach the window's IME context so a CJK IME stops eating
+  // every shortcut key. See ime_association_guard.h.
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>>
+      windows_ime_guard_channel_;
+  ImeAssociationGuard ime_association_guard_;
+
+  // Wires the ime_guard MethodChannel to ime_association_guard_.
+  void RegisterImeGuardChannel();
 
   // Drives the standalone always-on-top desktop lyric strip (the Windows
   // counterpart of Android's FloatingLyricService). See floating_lyric_window.h.

--- a/hibiki/windows/runner/ime_association_guard.cpp
+++ b/hibiki/windows/runner/ime_association_guard.cpp
@@ -1,0 +1,29 @@
+#include "ime_association_guard.h"
+
+#include <imm.h>
+
+bool ApplyImeAssociation(HWND hwnd, bool enable) {
+  if (hwnd == nullptr) {
+    return false;
+  }
+  // Passing a null HIMC with IACE_DEFAULT restores the thread's default input
+  // context; with flags 0 it detaches the window from any input context, which
+  // is what stops the IME from consuming keystrokes for this window.
+  return ImmAssociateContextEx(hwnd, nullptr,
+                               enable ? IACE_DEFAULT : 0) != FALSE;
+}
+
+bool ImeAssociationGuard::SetEnabled(HWND hwnd, bool enable) {
+  if (associate_ == nullptr) {
+    return false;
+  }
+  if (initialised_ && enabled_ == enable) {
+    return false;
+  }
+  if (!associate_(hwnd, enable, context_)) {
+    return false;
+  }
+  enabled_ = enable;
+  initialised_ = true;
+  return true;
+}

--- a/hibiki/windows/runner/ime_association_guard.cpp
+++ b/hibiki/windows/runner/ime_association_guard.cpp
@@ -13,17 +13,18 @@ bool ApplyImeAssociation(HWND hwnd, bool enable) {
                                enable ? IACE_DEFAULT : 0) != FALSE;
 }
 
-bool ImeAssociationGuard::SetEnabled(HWND hwnd, bool enable) {
+ImeAssociationUpdate ImeAssociationGuard::SetEnabled(HWND hwnd, bool enable) {
   if (associate_ == nullptr) {
-    return false;
+    return ImeAssociationUpdate::kFailed;
   }
-  if (initialised_ && enabled_ == enable) {
-    return false;
+  if (initialised_ && hwnd_ == hwnd && enabled_ == enable) {
+    return ImeAssociationUpdate::kUnchanged;
   }
   if (!associate_(hwnd, enable, context_)) {
-    return false;
+    return ImeAssociationUpdate::kFailed;
   }
+  hwnd_ = hwnd;
   enabled_ = enable;
   initialised_ = true;
-  return true;
+  return ImeAssociationUpdate::kApplied;
 }

--- a/hibiki/windows/runner/ime_association_guard.h
+++ b/hibiki/windows/runner/ime_association_guard.h
@@ -1,0 +1,56 @@
+#ifndef RUNNER_IME_ASSOCIATION_GUARD_H_
+#define RUNNER_IME_ASSOCIATION_GUARD_H_
+
+#include <windows.h>
+
+// BUG-1450: Flutter's Windows HWND keeps a live IME context for the whole
+// lifetime of the window -- the engine never dissociates it when no text field
+// holds focus. While a CJK IME is in a swallowing mode (Microsoft Pinyin in
+// Chinese mode, MS-IME in kana mode) every keystroke is consumed by the IME and
+// arrives as WM_KEYDOWN/wParam=VK_PROCESSKEY. The engine then reports it as a
+// KeyEvent with physical/logical key 0 (see BUG-1427), so the whole shortcut
+// table silently dies -- not just Space (BUG-1239 only patched that one key).
+//
+// The fix is to remove the special case instead of forwarding keys one by one:
+// dissociate the IME context while nothing editable has focus, and associate it
+// back the moment a text field takes focus. Dart owns focus knowledge and drives
+// this through the app.hibiki/windows_ime_guard channel.
+//
+// Win32 contract (same one Chromium's InputMethodWinImm32 uses):
+//   disable -> ImmAssociateContextEx(hwnd, nullptr, 0)
+//   enable  -> ImmAssociateContextEx(hwnd, nullptr, IACE_DEFAULT)
+
+// Performs the real Win32 association change. Returns false when the platform
+// call fails; separated from the state machine so tests can drive the latter
+// without a live HWND.
+bool ApplyImeAssociation(HWND hwnd, bool enable);
+
+using ImeAssociateFn = bool (*)(HWND hwnd, bool enable, void* context);
+
+// Tracks the association state so repeated identical requests (focus churn
+// emits many notifications per frame) do not hammer Win32.
+class ImeAssociationGuard {
+ public:
+  ImeAssociationGuard() = default;
+  explicit ImeAssociationGuard(ImeAssociateFn fn, void* context = nullptr)
+      : associate_(fn), context_(context) {}
+
+  // Requests the IME association state. Returns true when the request reached
+  // the platform (state actually changed, or this is the first request -- the
+  // window starts out associated by the engine, but we must not assume the
+  // first "enable" is a no-op after a hot restart).
+  bool SetEnabled(HWND hwnd, bool enable);
+
+  bool enabled() const { return enabled_; }
+  bool initialised() const { return initialised_; }
+
+ private:
+  ImeAssociateFn associate_ = nullptr;
+  void* context_ = nullptr;
+  // Flutter creates the window with the IME associated, so that is the state we
+  // start from; `initialised_` forces the first request through regardless.
+  bool enabled_ = true;
+  bool initialised_ = false;
+};
+
+#endif  // RUNNER_IME_ASSOCIATION_GUARD_H_

--- a/hibiki/windows/runner/ime_association_guard.h
+++ b/hibiki/windows/runner/ime_association_guard.h
@@ -27,6 +27,12 @@ bool ApplyImeAssociation(HWND hwnd, bool enable);
 
 using ImeAssociateFn = bool (*)(HWND hwnd, bool enable, void* context);
 
+enum class ImeAssociationUpdate {
+  kUnchanged,
+  kApplied,
+  kFailed,
+};
+
 // Tracks the association state so repeated identical requests (focus churn
 // emits many notifications per frame) do not hammer Win32.
 class ImeAssociationGuard {
@@ -35,11 +41,11 @@ class ImeAssociationGuard {
   explicit ImeAssociationGuard(ImeAssociateFn fn, void* context = nullptr)
       : associate_(fn), context_(context) {}
 
-  // Requests the IME association state. Returns true when the request reached
-  // the platform (state actually changed, or this is the first request -- the
-  // window starts out associated by the engine, but we must not assume the
-  // first "enable" is a no-op after a hot restart).
-  bool SetEnabled(HWND hwnd, bool enable);
+  // Requests the IME association state. The HWND is part of the cached identity:
+  // a recreated Flutter view must receive the current state even when `enable`
+  // did not change. The first request is always applied too (after a Dart hot
+  // restart the native window may already be dissociated).
+  ImeAssociationUpdate SetEnabled(HWND hwnd, bool enable);
 
   bool enabled() const { return enabled_; }
   bool initialised() const { return initialised_; }
@@ -51,6 +57,7 @@ class ImeAssociationGuard {
   // start from; `initialised_` forces the first request through regardless.
   bool enabled_ = true;
   bool initialised_ = false;
+  HWND hwnd_ = nullptr;
 };
 
 #endif  // RUNNER_IME_ASSOCIATION_GUARD_H_

--- a/hibiki/windows/runner/tests/ime_association_guard_test.cpp
+++ b/hibiki/windows/runner/tests/ime_association_guard_test.cpp
@@ -1,0 +1,118 @@
+#include "../ime_association_guard.h"
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Recorder {
+  std::vector<bool> requests;
+  bool fail_next = false;
+};
+
+bool Record(HWND hwnd, bool enable, void* context) {
+  auto* rec = static_cast<Recorder*>(context);
+  if (rec->fail_next) {
+    rec->fail_next = false;
+    return false;
+  }
+  rec->requests.push_back(enable);
+  return true;
+}
+
+bool Expect(bool condition, const std::string& message) {
+  if (condition) {
+    return true;
+  }
+  std::cerr << "FAIL: " << message << '\n';
+  return false;
+}
+
+HWND FakeHwnd() {
+  return reinterpret_cast<HWND>(static_cast<UINT_PTR>(0x1234));
+}
+
+}  // namespace
+
+int main() {
+  bool passed = true;
+
+  // The engine leaves the window associated, but the first request must still
+  // reach the platform: a shortcut-only surface has to be dissociated once.
+  {
+    Recorder rec;
+    ImeAssociationGuard guard(Record, &rec);
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), false),
+                     "first disable must reach the platform");
+    passed &= Expect(rec.requests.size() == 1 && rec.requests[0] == false,
+                     "first disable records exactly one disable");
+    passed &= Expect(!guard.enabled(), "guard reports disabled");
+  }
+
+  // Focus churn emits many identical notifications per frame; only transitions
+  // may hit Win32.
+  {
+    Recorder rec;
+    ImeAssociationGuard guard(Record, &rec);
+    guard.SetEnabled(FakeHwnd(), false);
+    passed &= Expect(!guard.SetEnabled(FakeHwnd(), false),
+                     "repeated disable is coalesced");
+    passed &= Expect(rec.requests.size() == 1,
+                     "repeated disable makes no second platform call");
+  }
+
+  // Re-enabling on text-field focus is the path that must never be swallowed --
+  // if it is, the user cannot type Chinese/Japanese at all.
+  {
+    Recorder rec;
+    ImeAssociationGuard guard(Record, &rec);
+    guard.SetEnabled(FakeHwnd(), false);
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), true),
+                     "re-enable on editable focus must reach the platform");
+    passed &= Expect(rec.requests.size() == 2 && rec.requests[1] == true,
+                     "re-enable records an enable request");
+    passed &= Expect(guard.enabled(), "guard reports enabled");
+  }
+
+  // Even the very first request being "enable" must be forwarded: after a hot
+  // restart the guard object is fresh but the window may be dissociated.
+  {
+    Recorder rec;
+    ImeAssociationGuard guard(Record, &rec);
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), true),
+                     "first enable must reach the platform too");
+    passed &= Expect(rec.requests.size() == 1 && rec.requests[0] == true,
+                     "first enable records one enable");
+  }
+
+  // A failed platform call must not be remembered as applied, otherwise the
+  // coalescing above would strand the window in the wrong state forever.
+  {
+    Recorder rec;
+    ImeAssociationGuard guard(Record, &rec);
+    rec.fail_next = true;
+    passed &= Expect(!guard.SetEnabled(FakeHwnd(), false),
+                     "failed platform call reports failure");
+    passed &= Expect(!guard.initialised(),
+                     "failed platform call does not latch state");
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), false),
+                     "retry after failure reaches the platform again");
+    passed &= Expect(rec.requests.size() == 1 && rec.requests[0] == false,
+                     "retry records the disable");
+  }
+
+  // A guard without a platform hook must be inert rather than claim success.
+  {
+    ImeAssociationGuard guard;
+    passed &= Expect(!guard.SetEnabled(FakeHwnd(), false),
+                     "guard without an associate fn does nothing");
+  }
+
+  if (!passed) {
+    std::cerr << "ime_association_guard_test FAILED\n";
+    return 1;
+  }
+  std::cout << "ime_association_guard_test passed\n";
+  return 0;
+}

--- a/hibiki/windows/runner/tests/ime_association_guard_test.cpp
+++ b/hibiki/windows/runner/tests/ime_association_guard_test.cpp
@@ -12,6 +12,7 @@ struct Recorder {
 };
 
 bool Record(HWND hwnd, bool enable, void* context) {
+  (void)hwnd;
   auto* rec = static_cast<Recorder*>(context);
   if (rec->fail_next) {
     rec->fail_next = false;
@@ -33,6 +34,10 @@ HWND FakeHwnd() {
   return reinterpret_cast<HWND>(static_cast<UINT_PTR>(0x1234));
 }
 
+HWND SecondFakeHwnd() {
+  return reinterpret_cast<HWND>(static_cast<UINT_PTR>(0x5678));
+}
+
 }  // namespace
 
 int main() {
@@ -43,7 +48,8 @@ int main() {
   {
     Recorder rec;
     ImeAssociationGuard guard(Record, &rec);
-    passed &= Expect(guard.SetEnabled(FakeHwnd(), false),
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), false) ==
+                         ImeAssociationUpdate::kApplied,
                      "first disable must reach the platform");
     passed &= Expect(rec.requests.size() == 1 && rec.requests[0] == false,
                      "first disable records exactly one disable");
@@ -56,7 +62,8 @@ int main() {
     Recorder rec;
     ImeAssociationGuard guard(Record, &rec);
     guard.SetEnabled(FakeHwnd(), false);
-    passed &= Expect(!guard.SetEnabled(FakeHwnd(), false),
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), false) ==
+                         ImeAssociationUpdate::kUnchanged,
                      "repeated disable is coalesced");
     passed &= Expect(rec.requests.size() == 1,
                      "repeated disable makes no second platform call");
@@ -68,7 +75,8 @@ int main() {
     Recorder rec;
     ImeAssociationGuard guard(Record, &rec);
     guard.SetEnabled(FakeHwnd(), false);
-    passed &= Expect(guard.SetEnabled(FakeHwnd(), true),
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), true) ==
+                         ImeAssociationUpdate::kApplied,
                      "re-enable on editable focus must reach the platform");
     passed &= Expect(rec.requests.size() == 2 && rec.requests[1] == true,
                      "re-enable records an enable request");
@@ -80,7 +88,8 @@ int main() {
   {
     Recorder rec;
     ImeAssociationGuard guard(Record, &rec);
-    passed &= Expect(guard.SetEnabled(FakeHwnd(), true),
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), true) ==
+                         ImeAssociationUpdate::kApplied,
                      "first enable must reach the platform too");
     passed &= Expect(rec.requests.size() == 1 && rec.requests[0] == true,
                      "first enable records one enable");
@@ -92,20 +101,37 @@ int main() {
     Recorder rec;
     ImeAssociationGuard guard(Record, &rec);
     rec.fail_next = true;
-    passed &= Expect(!guard.SetEnabled(FakeHwnd(), false),
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), false) ==
+                         ImeAssociationUpdate::kFailed,
                      "failed platform call reports failure");
     passed &= Expect(!guard.initialised(),
                      "failed platform call does not latch state");
-    passed &= Expect(guard.SetEnabled(FakeHwnd(), false),
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), false) ==
+                         ImeAssociationUpdate::kApplied,
                      "retry after failure reaches the platform again");
     passed &= Expect(rec.requests.size() == 1 && rec.requests[0] == false,
                      "retry records the disable");
   }
 
+  // A Flutter view HWND can be recreated while the Dart-side desired state is
+  // unchanged. Coalescing by bool alone would skip the new window and leave it
+  // with the engine's default associated IME context.
+  {
+    Recorder rec;
+    ImeAssociationGuard guard(Record, &rec);
+    guard.SetEnabled(FakeHwnd(), false);
+    passed &= Expect(guard.SetEnabled(SecondFakeHwnd(), false) ==
+                         ImeAssociationUpdate::kApplied,
+                     "same state on a new HWND must be applied");
+    passed &= Expect(rec.requests.size() == 2 && !rec.requests[1],
+                     "new HWND receives the current disabled state");
+  }
+
   // A guard without a platform hook must be inert rather than claim success.
   {
     ImeAssociationGuard guard;
-    passed &= Expect(!guard.SetEnabled(FakeHwnd(), false),
+    passed &= Expect(guard.SetEnabled(FakeHwnd(), false) ==
+                         ImeAssociationUpdate::kFailed,
                      "guard without an associate fn does nothing");
   }
 


### PR DESCRIPTION
用户报：日语输入法能用空格快捷键了，中文输入法不行，快捷键之类的用不了。

## 根因（在平台层，不在快捷键解析层）

Flutter 的 Windows 窗口**终生**保留 IME context——`Win32Window::SetChildContent` 把焦点交给 Flutter view 子窗口，而引擎从不在「无文本输入客户端」时解除该窗口的 IME 关联。于是只要输入法处于吞键模式，每次按键都被输入法拿走，以 `WM_KEYDOWN / wParam=VK_PROCESSKEY` 到达，引擎再按 BUG-1427 钉死的平台事实报成 `physical=0 / logical=0`，`resolveKeyboard` 的精确相等与物理键回退**同时**落空，整张快捷键表静默失效。

本机 Win32 消息探针实测（微软拼音中文态）：字母键到达窗口的确实是 `wParam=0x00E5`，lParam 保留真实 scancode（Y/Z/J/M/数字1）。消息通道没变，变的是键的身份被输入法接管。

「日语能用」不是反例：日语输入法常驻半角英数态时根本不吃字母，只有空格被吃，而那一个键恰好被 BUG-1239 的 native 单键转发（仅 scancode `0x39`、仅接视频页）救回。中文拼音没有等价英数态（切英文即切走输入法），所以空格 + 全部字母快捷键一起废——BUG-1239 那条单键补丁在结构上救不了其余键。

## 修法

消除特殊情况本身，而不是逐键补转发（后者等于在 app 内重建键盘管线，且必然与真实文本输入打架）：**无可编辑焦点时解除 IME 关联，文本框拿焦时立刻恢复**。

- Dart：`windows_ime_guard.dart`，纯谓词 + `FocusManager` 驱动，判据复用既有 `focusedEditableText()`（不另造第二套真相），`runApp` 前 install，冷启动第一帧生效。
- native：`ime_association_guard.{h,cpp}` 状态机 + `app.hibiki/windows_ime_guard` 通道；`ImmAssociateContextEx(hwnd, nullptr, IACE_DEFAULT / 0)`（与 Chromium `InputMethodWinImm32` 同契约），作用于**持焦的 Flutter view HWND** 而非顶层框架窗口——IME context 是 per-HWND 的，只改顶层无效。
- 仅 Windows 生效，其余平台空转；旧 runner 缺通道时吞 `MissingPluginException` 回到修复前行为；BUG-1239 的空格通道原样保留（Never break userspace）。

## 验证

- Dart `test/platform/windows_ime_guard_test.dart` 6 条；**变异实测 3 处全部转红**（谓词取反 / 去掉去重 / 去掉 install 首次同步）。
- native `tests/ime_association_guard_test.cpp` 进 Windows 构建门 `hibiki_windows_ime_association_gate`（沿用 BUG-1239 模式）；**变异「去掉去重」实测转红**；以项目真实 `/W4 /WX` 零警告通过。
- `flutter analyze --no-pub` 全量 No issues；定向 651 条（platform + video IME space + shortcuts）全绿；`flutter build windows --release` 成功，构建门随之执行通过。

## 待真机验收（用户已认领）

1. 中文拼音激活时，视频页/阅读器的空格与字母快捷键是否恢复；
2. 点进搜索框 / 笔记框 / Anki 字段后能否**立刻**输入中文与日文；
3. 输入完离开文本框后快捷键是否恢复。

BUG-1450

https://claude.ai/code/session_01VZT4UvzbR4T9RWFxE4gBJC