### PR TITLE
test(infra): 「按触发条件加跑」从手写名字表换成按树推导 (TODO-2720)

### DIFF
--- a/docs/agent/fast-workflow.md
+++ b/docs/agent/fast-workflow.md
@@ -138,7 +138,16 @@ S/A 级同理裁剪：S 级连 worktree bootstrap 都可 `-SkipBootstrap` 到底
 | `test/pages/video_hibiki_page_source_corpus_test.dart` | `video_hibiki/` part 目录枚举 | 同上，视频页语料 |
 | `test/sync/sync_settings_schema_source_corpus_test.dart` | `sync_settings_schema/` part 目录枚举 | 同上，同步设置 schema 语料 |
 
-一条命令跑完，**实测 207 tests**（2026-08-02，`origin/develop@c05a91edc` + PR#756；补入三条语料守卫前是 32 条 / 194 tests / 34 秒）——比争论「这条该不该跑」便宜得多，所以**不要挑，整批跑**：
+一条命令跑完，**实测 207 tests**（2026-08-02，`origin/develop@c05a91edc` + PR#756）——比争论「这条该不该跑」便宜得多，所以**不要挑，整批跑**：
+
+**N 的演进链要留着，别只写当前值**——「N 应该是多少」本身就是判空转的信号，只写当前值就丢掉了「它为什么变」：
+
+| N | 条数 | 变化来源 |
+|---|---|---|
+| 194 | 32 | 初版（34 秒） |
+| **207** | **35** | PR#756 补入三条合并语料守卫 |
+| 225 | 35 | PR#760 给禁止型判据补 18 条自校验（**尚未合入**，合入后以此为准） |
+
 
 ```bash
 cd hibiki && dart run tool/flutter_test_failures.dart --no-pub \
@@ -166,8 +175,6 @@ cd hibiki && dart run tool/flutter_test_failures.dart --no-pub \
   test/sync/sync_settings_schema_source_corpus_test.dart
 ```
 
-**另有一批「枚举非源码树」的，按触发条件加跑**（不进默认清单是因为它们只在碰对应资产时才可能红）：改 `.github/workflows` 或 `.ps1` → `test/build/workflow_sed_inplace_portability_guard_test.dart` + `test/tools/powershell_51_compat_guard_test.dart` + `test/mining/magpie_bundled_install_test.dart`；改 `tools/browser-extension/` → `test/build/browser_extension_mirror_full_guard_test.dart` + `test/lookup/browser_extension_installer_test.dart`；动 `docs/bugs/` → `test/tools/bugs_per_file_guard_test.dart`；动 vendored 二进制 / podspec → `test/tools/ffmpeg_min_vendored_self_contained_guard_test.dart` + `test/tools/ffmpeg_kit_podspec_license_guard_test.dart`；动 `hibiki/windows/` native → `test/mining/gal_ipc_contract_single_source_test.dart`。
-
 ### 清单会过期——怎么重新推导
 
 **按行为反向枚举，不按名字猜**。名字里带 `guard` / `static` / `adoption` 的既不充分也不必要：`i18n_completeness_test.dart` 不带 guard 却必须进，`resume_prune_guard_test.dart` 带 guard 却是定点。
@@ -182,7 +189,7 @@ comm -12 /tmp/a /tmp/b   # 候选集，再逐个读代码定性
 
 🔴 **两个已被实测踩到的坑**：
 
-1. **`listSync(` 会被 `dart format` 折行**成 `listSync(\n  recursive: true,\n)`。单行正则 `listSync\(recursive: true\)` 漏掉 `source_guard_adoption_test.dart` 本身——本清单第一版就是这么漏的。要么用多行匹配，要么只 grep `listSync` 裸词再逐个看。（同一个坑也存在于被守的一侧：`test/storage/data_root_migrator_test.dart` 里 `contains('listSync(recursive: true')` 这条断言就抓不到折行写法。）
+1. **`listSync(` 会被 `dart format` 折行**成 `listSync(\n  recursive: true,\n)`。单行正则 `listSync\(recursive: true\)` 漏掉 `source_guard_adoption_test.dart` 本身——本清单第一版就是这么漏的。要么用多行匹配，要么只 grep `listSync` 裸词再逐个看。（同一个坑也存在于被守的一侧：`test/storage/data_root_migrator_test.dart` 里 `contains('listSync(recursive: true')` 这条断言就抓不到折行写法——**PR#760 已改成折行容忍正则**；例子留在这里不是因为它还没修，而是因为「精确字面量断言被 `dart format` 折行打断」这个形态还会再出现。）
 2. **grep 只能定位不能定性**。命中后必须**读代码**确认扫描根是仓库源码树而不是 `Directory.systemTemp` 临时目录——63 个候选里超过一半是「在临时目录造文件再遍历」的行为测试。
 
 ### 扫描规模哨兵（TODO-2707 已补完）
@@ -193,7 +200,78 @@ TODO-2707（PR#756）已把这条补完：**35 条现在条条有扫描规模哨
 
 🔴 **这件事真正的收获不是「修好了什么」，而是「以前无法证明什么」。**变异实测的做法是把 3 条守卫的扫描后缀改成永不匹配：**原判据在零文件扫描下全部保持绿色，只有哨兵响了**。也就是说此前那些「全绿」是真的绿，但**此前没有任何办法把它与「瞎着绿」区分开**。这也正是每次判绿都要自查 `N tests ran` 的 N 有没有偏小的理由——在哨兵补全之前，N 是唯一的空转信号。
 
+### 禁止型断言的盲区：全绿 ≠ 在工作
+
+🔴 PR#760 挖出来的结构性问题，和上面的空转是同一族：
+
+> **禁止型断言（「不得出现 X」）在健康仓库里本来就永远零命中。于是判据本身坏掉时，扫盘那条路根本检验不到它。**
+
+「精确字面量被 `dart format` 折行打断」这类判据缺陷能坏很久没人发现，根子就在这儿：守卫每天都绿，而绿正是它坏掉时的预期表现。**扫描规模哨兵管的是「扫到东西了没」，管不到「判得准不准」。**
+
+应对：给禁止型守卫补**判据自校验**——手写一小段必然违规的语料，喂给判据，要求它必须报出来。自校验语料必须与磁盘扫描**互不依赖、独立枚举**，否则同一个缺陷让两边一起失明。PR#760 做了新旧判据 A/B 实测：一条真假红（旧红新绿）、两条真假绿（旧绿新红）。
+
+配套关系：**「合并后必跑清单」管的是「该跑的守卫有没有跑到」，判据自校验管的是「跑到的守卫判得准不准」**——两层都塌过，缺一层就是另一种形式的假绿。
+
 **新写目录枚举型守卫时，扫描规模下界断言是必需项，不是加分项**；语料型守卫的「磁盘再枚举一遍」必须与生产侧用**不同**实现，否则枚举器自身的缺陷会让守卫与被守方在同一处同时失明。
+
+## 另一半：按触发条件加跑——**不点名，按树推导**
+
+上面那 35 条扫的是 Dart 源码树。另一半守卫读的是 **native / 资产 / 配置树**：`hibiki/windows`、`hibiki/android`、`hibiki/{ios,macos,linux}`、`packages/*/windows`、`native/`、`tools/browser-extension`、`.github/workflows`、`third_party/`。整批清单抓不到它们，因为它们只在碰对应资产时才可能红。
+
+### 这里曾经挂着一份手写的 9 个测试名，它烂了——而且是必然烂的
+
+结构性成因一句话：
+
+> **清单的分类维度是「资产种类」（workflow / 扩展 / 二进制 / native），而真实触发面的维度是「哪棵源码树」。**
+
+两者不对齐，于是五棵最大的 native 树里只有一棵被点了一个名：
+
+| 树 | 引用它的守卫数（实测） | 旧手写清单覆盖 |
+|---|---|---|
+| `hibiki/windows` | 75 | **只点了 `gal_ipc_contract_single_source` 1 个** |
+| `hibiki/android` | 38 | **0，无任何触发规则** |
+| `tools/browser-extension` | 49 | 2 |
+| `packages/flutter_inappwebview_windows` | 20 | **0** |
+| `.github/workflows` | 20 | 3 |
+| `native/hoshidicts` / `native/galgame_hook` | 12 / 9 | 1（半覆盖） |
+| `hibiki/macos` / `hibiki/ios` / `hibiki/linux` | 9 / 7 / 2 | **0** |
+| `packages/gamepads_windows` / `third_party/desktop_drop` | 4 / 3 | **0** |
+
+改一行 `hibiki/windows/runner/flutter_window.cpp` 会牵动 **72 条**守卫，旧清单一条都没提。这是「合入的 PR 把红带进 develop」已发生 3 次的共同根因之一（TODO-2720）。
+
+### 现在：从仓库现状推导
+
+```bash
+cd hibiki
+dart run tool/tests_for_changes.dart --base=origin/develop            # 该加跑哪些
+dart run tool/tests_for_changes.dart --base=origin/develop --explain  # 顺带说明被哪条路径命中
+dart run tool/tests_for_changes.dart hibiki/windows/runner/x.cpp      # 也可以直接给文件
+
+# 直接串给测试入口：
+dart run tool/flutter_test_failures.dart --no-pub \
+  --output-dir=../.codex-test/flutter-test-trigger \
+  $(dart run tool/tests_for_changes.dart --base=origin/develop)
+```
+
+判据一句话：
+
+> **改动文件 F 触发测试 T ⟺ T 的源码里引用了某个仓库路径 P，且 F 落在 P 底下。**
+
+**为什么这条不会像名字表那样烂**：被提取的字符串和被守卫断言存在的路径，是同一个文件里的**同一个字面量**。树改名时守卫必须改那个字面量（不然它自己就红），索引自动跟着走。名字表没有这种耦合，只能靠人记得去改——这次就是没人记得。
+
+规则本身由 `test/tools/tests_for_changes_guard_test.dart` 守着，三层判据：① 被替掉的那 9 条手写规则必须仍能被推导出来（**超集，不是近似**）；② 原先零覆盖的树现在每棵都推得出测试；③ 逐树规模下界，且下界由一份**与提取器毫无共享代码**的朴素 `contains` 扫描独立算出（共用同一个枚举函数会让守卫与被守方在同一处同时失明，`tool/bug.dart` 的 `buildRenumberPlan` / `findResidualRefs` 踩过）。
+
+**有意的偏置：过度触发，不漏触发。** 漏一条 ⇒ 红带进 develop；多跑一条 ⇒ 多几秒。所以不剥注释（注释里点名一棵树本身就是证据）、路径解析退到最近存在的祖先（构建产物 / `.../` 省略写法 / 被删的叶子都还算数）。
+
+**不需要分层**。实测 `hibiki/windows/runner/flutter_window.cpp` 推出的 61 条跑完 **46 秒 / 503 tests**（`origin/develop@f0a00f410`）——比争论「该不该跑」便宜得多，整批跑。
+
+**唯一的例外：扫描面运行时才算得出来的守卫。** 典型是 `powershell_51_compat_guard_test.dart`——它从 `.github/workflows/*.yml` 里解析 `powershell -File <脚本>`，被守的 `.ps1` 清单是 yml 内容决定的，源码里没有那些路径的字面量。这类守卫在**自己文件里**写一行声明：
+
+```dart
+// tests-for-changes: **/*.ps1
+```
+
+规则住在拥有它的那个文件里，改守卫的人一眼看得见；守卫断言每条声明至少匹配到一个真实文件，所以声明烂掉是**响的**不是哑的。
 
 ## 输出可信 ≠ 结论可信
 
@@ -213,8 +291,19 @@ git rev-parse <你以为推上去的那个东西>
 |---|---|---|---|
 | 假失败 | push 报 non-FF 错误 | 并发竞态，commit 其实已经进去了 | `gh api` 查远端 sha |
 | **假成功** | push 报 `[new branch]` / `Everything up-to-date` | 推的 ref 不是工作所在位置（detached HEAD / 推错分支） | `git ls-remote` 查远端 sha |
+| **单端点滞后** | 刚 push 成功，`gh api` 却仍返回旧 sha | 两个端点同一时刻不同值——`gh api` 有传播延迟 | `git ls-remote origin refs/heads/<branch>` 当场就是新值；判 `develop` head 一律以它为准 |
 
-**通则：凡「远端 / 外部系统的状态」，一律以向它查询到的状态为准，不以本地命令的输出叙述为准。** 本地输出只能证明「这条命令做了它说的事」，证明不了「这件事就是我要的事」。同族实例还有：`flutter test | tail` 的退出码是 `tail` 的（恒 0）、构建失败时零测试执行会被伪装成通过（BUG-1157）。
+**通则：凡「远端 / 外部系统的状态」，一律以向它查询到的状态为准，不以本地命令的输出叙述为准；而「向它查询」不等于「问某一个端点」——同一份远端状态在 `gh api` 和 `git ls-remote` 上可以同时是两个值。** 本地输出只能证明「这条命令做了它说的事」，证明不了「这件事就是我要的事」。同族实例还有：`flutter test | tail` 的退出码是 `tail` 的（恒 0）、构建失败时零测试执行会被伪装成通过（BUG-1157）。
+
+### 判「测试跑全了没」是结构问题，不是算术问题
+
+🔴 **别去数 `test(`。** 实测：整合线想核 `test/sync` 的 `N=1937` 对不对，用 grep 数出 9 个 `test(`，算 `1933 + 9 = 1942 ≠ 1937`，差 5，于是怀疑漏跑。**这条路本身就是错的**——源码里的 `test(` 数**从来不等于**运行时用例数：`testWidgets`、参数化循环、`group` 内动态生成的用例，全都对不上。
+
+决定性的是 **suite 层的结构对账**：`test/sync` 磁盘 **237 个 suite、装载 237、0 缺失、0 空 suite** ⇒ 运行是完整的，N 的差额来自用例本身而不是漏跑。
+
+**`N tests ran` 的 N 仍是判据的一部分**（N=0 时 PASSED 和 FAILED 都不成立），但它是**次级信号**：N 能证伪「跑了」，证明不了「跑全了」。清单 / 推导规则要回答的问题是「**该跑的 suite 有没有都跑到**」，那是结构问题，不是算术问题。
+
+这和既有的「grep 只能定位不能定性」是同一个坑的两个面：那条讲**查代码**，这条讲**判测试覆盖**。
 
 ## 合并流水线（integration owner）
 

--- a/docs/agent/fast-workflow.md
+++ b/docs/agent/fast-workflow.md
@@ -263,7 +263,7 @@ dart run tool/flutter_test_failures.dart --no-pub \
 
 **有意的偏置：过度触发，不漏触发。** 漏一条 ⇒ 红带进 develop；多跑一条 ⇒ 多几秒。所以不剥注释（注释里点名一棵树本身就是证据）、路径解析退到最近存在的祖先（构建产物 / `.../` 省略写法 / 被删的叶子都还算数）。
 
-**不需要分层**。实测 `hibiki/windows/runner/flutter_window.cpp` 推出的 61 条跑完 **46 秒 / 503 tests**（`origin/develop@f0a00f410`）——比争论「该不该跑」便宜得多，整批跑。
+**不需要分层**。实测 `hibiki/windows/runner/flutter_window.cpp` 推出的 **72 条**跑完 **53 秒 / 594 tests**（`origin/develop@f0a00f410`）——比争论「该不该跑」便宜得多，整批跑。
 
 **唯一的例外：扫描面运行时才算得出来的守卫。** 典型是 `powershell_51_compat_guard_test.dart`——它从 `.github/workflows/*.yml` 里解析 `powershell -File <脚本>`，被守的 `.ps1` 清单是 yml 内容决定的，源码里没有那些路径的字面量。这类守卫在**自己文件里**写一行声明：
 

--- a/hibiki/test/tools/powershell_51_compat_guard_test.dart
+++ b/hibiki/test/tools/powershell_51_compat_guard_test.dart
@@ -15,6 +15,10 @@
 // `powershell -File` 调用，对应脚本自动进入守卫范围。
 //
 // 纯 dart:io，不依赖 Flutter 运行时；cwd 是 hibiki/，所以跨出仓库根用 '../'。
+//
+// 受约束脚本集合是运行时从 yml 里解析出来的，源码里没有那些 .ps1 的路径字面量，
+// 所以 `tool/tests_for_changes.dart` 的静态提取看不见它们 —— 这里显式声明触发面。
+// tests-for-changes: **/*.ps1
 
 import 'dart:io';
 

--- a/hibiki/test/tools/tests_for_changes_guard_test.dart
+++ b/hibiki/test/tools/tests_for_changes_guard_test.dart
@@ -330,6 +330,40 @@ void main() {
           isFalse);
     });
 
+    test('两处硬编码目录名必须仍对得上仓库布局', () {
+      // 工具里只有这两组硬编码名字。硬编码本身不是问题，**哑掉**才是：
+      // 仓库改了布局而常量没跟上，路径解析会静默退化——容器目录不再被拒，
+      // 一次对 `hibiki` 的引用就把整棵树拉进触发面，推导结果从「精准」变成「全跑」。
+      for (final RepoPath container in kContainerDirs) {
+        final Directory dir = Directory('${fs.root.path}/$container');
+        expect(dir.existsSync(), isTrue, reason: '容器目录 $container 不在了');
+        final int subDirs =
+            dir.listSync(followLinks: false).whereType<Directory>().length;
+        expect(subDirs, greaterThanOrEqualTo(5),
+            reason: '$container 只剩 $subDirs 个子目录，'
+                '它可能已经不再是「装着互不相干多个域」的容器目录');
+      }
+    });
+
+    test('索引里不得混进构建产物路径（否则索引因机器而异）', () {
+      // 本机有 `hibiki/build/windows/x64/...`、CI 的干净 checkout 没有。
+      // 一旦这类路径进了索引，本机推导出的测试集就和 CI 的不一样——
+      // 这是「本机全绿 CI 红」最难查的一种。
+      //
+      // 注意这条在**没有构建产物的干净环境**上是平凡通过的（那里本来就没东西可混
+      // 进来）；它要抓的正是「在有产物的开发机上」跑出来的那份被污染的索引。
+      final List<String> polluted = <String>[];
+      index.forEach((RepoPath test, TestTriggerFace face) {
+        for (final RepoPath ref in face.referencedPaths) {
+          if (ref.split('/').any(kNonSourceDirs.contains)) {
+            polluted.add('$test → $ref');
+          }
+        }
+      });
+      expect(polluted, isEmpty,
+          reason: '这些引用落在构建产物 / 机器本地目录里：\n${polluted.join('\n')}');
+    });
+
     test('存在性判定必须逐段精确大小写（Windows NTFS 大小写不敏感）', () {
       // 直接用 existsSync 时，注释里的「Android/iOS/macOS/Windows/Linux」会让
       // `hibiki/Linux` 在 Windows 上判为存在、在 Linux CI 上判为不存在——

--- a/hibiki/test/tools/tests_for_changes_guard_test.dart
+++ b/hibiki/test/tools/tests_for_changes_guard_test.dart
@@ -1,0 +1,358 @@
+// 守卫：`tool/tests_for_changes.dart` 这条**推导规则**本身。
+//
+// ## 它替掉了什么
+//
+// `docs/agent/fast-workflow.md` 里原来挂着一份手写的「按触发条件加跑」清单，
+// 一共点名 9 个测试。那份表的分类维度是「资产种类」（workflow / 扩展 / 二进制 /
+// native），而真实触发面的维度是「哪棵源码树」。两者不对齐的后果是：
+// `hibiki/android/` 30+ 条守卫**一条触发规则都没有**、`packages/*/windows` 同样
+// 零覆盖、`hibiki/windows/` 60+ 条守卫只被点了 1 个名。改一行
+// `hibiki/windows/runner/flutter_window.cpp` 会牵动几十条守卫，清单一条都没提。
+// 这是「合入的 PR 把红带进 develop」已发生 3 次的共同根因之一（TODO-2720）。
+//
+// ## 为什么守卫必须存在
+//
+// 换成推导规则之后，规则本身成了**代码**，于是它会以代码的方式烂：提取器少认一种
+// 写法，输出就静默变少，而少输出的表现形式恰恰是「测试更快跑完了」——没有任何人
+// 会去质疑它。所以这条守卫的每一项都是在回答同一个问题：**推导出来的东西还够多吗**。
+//
+// ## 三层判据，缺一不可
+//
+// 1. **行为对账**：被替掉的那 9 条手写规则，必须能被推导出来（超集，不是近似）。
+// 2. **盲区断言**：原先零覆盖的五棵 native 树，现在每棵都推得出测试。
+// 3. **规模哨兵 + 独立枚举**：逐树下界，且下界由一份**与提取器毫无共享代码**的
+//    朴素文本扫描独立算出。共用同一个有缺陷的枚举函数会让守卫与被守方在同一处
+//    同时失明（`tool/bug.dart` 的 buildRenumberPlan / findResidualRefs 共用
+//    repoScanPaths 就是这么瞎的），所以这里的朴素侧只用 `String.contains`，
+//    一行都不碰 normalizeRepoPath / extractRepoPathReferences。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../tool/tests_for_changes.dart';
+
+void main() {
+  final RepoFs fs = RepoFs(locateRepoRoot(Directory.current));
+  late final Map<RepoPath, TestTriggerFace> index;
+
+  setUpAll(() {
+    index = buildReferenceIndex(fs);
+  });
+
+  /// 推导：改了 [changed] 该跑哪些测试（仓库根相对的测试路径）。
+  Set<RepoPath> derive(String changed) => selectTestsForChanges(
+        changedFiles: <RepoPath>[normalizeChangedPath(changed, fs)],
+        index: index,
+        fs: fs,
+      ).keys.toSet();
+
+  /// 朴素侧：**独立枚举** hibiki/test 下的测试文件，与 listAppTestFiles 无共享代码。
+  ///
+  /// 故意写成最笨的形态（手写递归 + `String.contains`），这样它不可能和结构化
+  /// 提取器在同一个地方出错。它算出来的是下界，结构化侧只能比它多不能比它少。
+  List<File> naiveTestFiles() {
+    final List<File> out = <File>[];
+    void walk(Directory dir) {
+      for (final FileSystemEntity e in dir.listSync(followLinks: false)) {
+        if (e is Directory) {
+          walk(e);
+        } else if (e is File && e.path.endsWith('_test.dart')) {
+          out.add(e);
+        }
+      }
+    }
+
+    walk(Directory('test'));
+    return out;
+  }
+
+  /// 朴素侧：源码里逐字出现 `<tree>` 且后面不接标识符字符的测试文件数。
+  int naiveTreeMentions(String tree) {
+    final RegExp needle = RegExp('${RegExp.escape(tree)}(?![A-Za-z0-9_])');
+    int n = 0;
+    for (final File f in naiveTestFiles()) {
+      if (needle.hasMatch(f.readAsStringSync())) n++;
+    }
+    return n;
+  }
+
+  /// 结构化侧：索引里引用到 [tree] 下任意路径的测试文件数。
+  int indexedTreeMentions(String tree) => index.entries
+      .where((MapEntry<RepoPath, TestTriggerFace> e) => e.value.referencedPaths
+          .any((RepoPath ref) => ref == tree || ref.startsWith('$tree/')))
+      .length;
+
+  group('tests_for_changes 推导规则', () {
+    test('索引规模哨兵：扫描面不得塌掉', () {
+      expect(index.length, greaterThanOrEqualTo(1700),
+          reason: 'hibiki/test 下应有 2100+ 个 *_test.dart（实测 2180）；'
+              '数量塌掉说明 listAppTestFiles 的枚举坏了，'
+              '而坏掉的表现是「推导结果变少」——不会有人自己发现');
+      final int withFace =
+          index.values.where((TestTriggerFace f) => !f.isEmpty).length;
+      expect(withFace, greaterThanOrEqualTo(780),
+          reason: '实测 970 个测试文件有可提取的触发面；'
+              '掉到 780 以下说明路径提取器少认了一大类写法');
+    });
+
+    test('三遍提取各自都必须活着（合成语料逐遍点名）', () {
+      // 为什么不能指望全量下界替这条把关：本仓注释极其详尽，一个用 `p.join`
+      // 写路径的守卫，注释里往往**同时**写着含斜杠的那条路径。变异实测里把
+      // join 那一遍整个关掉，全量下界与「结构化 ≥ 朴素」两条**全绿**——因为
+      // 注释里的斜杠写法把它兜住了。逐遍的存活断言只能用合成语料点名。
+      expect(
+        extractRepoPathReferences(
+          'final File f = '
+          "File('../native/galgame_hook/include/voice_hook_ipc.h');",
+          fs,
+        ),
+        contains('native/galgame_hook/include/voice_hook_ipc.h'),
+        reason: '含斜杠字面量那一遍死了',
+      );
+      expect(
+        extractRepoPathReferences(
+          'final Directory d = '
+          "Directory(p.join(root.path, 'hibiki', 'windows', 'runner'));",
+          fs,
+        ),
+        contains('hibiki/windows/runner'),
+        reason: 'p.join 段链那一遍死了——这段语料里一个斜杠都没有，'
+            '只有这一遍认得，而本仓大量 native 守卫正是这么写路径的',
+      );
+      expect(
+        extractRepoPathReferences(
+          '// 见 packages/flutter_inappwebview_windows/.../in_app_webview.cpp',
+          fs,
+        ),
+        contains('packages/flutter_inappwebview_windows'),
+        reason: '最近祖先回退死了：注释里的 `.../` 省略写法退不到那棵树',
+      );
+      expect(
+        extractRepoPathReferences(
+          "expect(cmake.contains(r'native/galgame_hook/dist'), isTrue);",
+          fs,
+        ),
+        contains('native/galgame_hook'),
+        reason: '最近祖先回退死了：指向构建产物（磁盘上不存在）的路径整条被丢掉',
+      );
+    });
+
+    test('被替掉的 9 条手写规则，必须全部能被推导出来', () {
+      // 这张表是**被替掉的那份文档清单的原文**，一条不改地抄在这里。
+      // 推导规则可以比它多，绝不许比它少——少一条就是回到「名字表腐烂」的老路。
+      const Map<String, List<String>> replacedHandWrittenRules =
+          <String, List<String>>{
+        '.github/workflows/build-multiplatform.yml': <String>[
+          'hibiki/test/build/workflow_sed_inplace_portability_guard_test.dart',
+          'hibiki/test/tools/powershell_51_compat_guard_test.dart',
+          'hibiki/test/mining/magpie_bundled_install_test.dart',
+        ],
+        'tool/setup_worktree.ps1': <String>[
+          'hibiki/test/tools/powershell_51_compat_guard_test.dart',
+        ],
+        'tools/browser-extension/manifest.json': <String>[
+          'hibiki/test/build/browser_extension_mirror_full_guard_test.dart',
+          'hibiki/test/lookup/browser_extension_installer_test.dart',
+        ],
+        'docs/bugs/BUG-9999-x.md': <String>[
+          'hibiki/test/tools/bugs_per_file_guard_test.dart',
+        ],
+        'third_party/ffmpeg-min/recipe.md': <String>[
+          'hibiki/test/tools/ffmpeg_min_vendored_self_contained_guard_test.dart',
+        ],
+        'third_party/ffmpeg_kit_flutter/ios/x.podspec': <String>[
+          'hibiki/test/tools/ffmpeg_kit_podspec_license_guard_test.dart',
+        ],
+        'hibiki/windows/runner/flutter_window.cpp': <String>[
+          'hibiki/test/mining/gal_ipc_contract_single_source_test.dart',
+        ],
+      };
+
+      final List<String> missing = <String>[];
+      replacedHandWrittenRules.forEach((String changed, List<String> expected) {
+        final Set<RepoPath> got = derive(changed);
+        for (final String want in expected) {
+          if (!got.contains(want)) missing.add('$changed → $want');
+        }
+      });
+      expect(missing, isEmpty,
+          reason: '推导规则漏掉了原手写清单里的条目：\n${missing.join('\n')}\n'
+              '推导规则必须是那份清单的超集，否则这次替换是净损失');
+    });
+
+    test('原先零触发规则的 native 树，现在每棵都推得出测试', () {
+      // 表里每一项在替换前的手写清单里都是**零覆盖**（`hibiki/windows` 只有 1 条）。
+      // 下界取实测值的约 80%，只在量级塌掉时才响。
+      const Map<String, int> blindSpots = <String, int>{
+        'hibiki/android/app/src/main/AndroidManifest.xml': 10,
+        'hibiki/android/app/build.gradle': 6,
+        'packages/gamepads_windows/windows/gamepad.cpp': 3,
+        'packages/flutter_inappwebview_windows/windows/CMakeLists.txt': 4,
+        'hibiki/ios/Runner/Info.plist': 5,
+        'hibiki/macos/Runner/MainFlutterWindow.swift': 6,
+        'hibiki/linux/CMakeLists.txt': 2,
+        'native/hoshidicts/CMakeLists.txt': 9,
+        'native/galgame_hook/include/voice_hook_ipc.h': 8,
+        'third_party/desktop_drop/windows/desktop_drop_plugin.cpp': 4,
+        'hibiki/windows/runner/flutter_window.cpp': 55,
+      };
+      final List<String> tooThin = <String>[];
+      blindSpots.forEach((String changed, int floor) {
+        final int got = derive(changed).length;
+        if (got < floor) tooThin.add('$changed → $got 个（下界 $floor）');
+      });
+      expect(tooThin, isEmpty,
+          reason: '这些树曾经完全没有触发规则，PR 改到它们时一条守卫都不会被跑到。'
+              '推导结果掉到下界以下说明提取器又瞎了：\n${tooThin.join('\n')}');
+    });
+
+    test('逐树规模哨兵：结构化提取不得少于独立朴素扫描', () {
+      // 朴素侧只认 `hibiki/android` 这种含斜杠的逐字写法；结构化侧还认
+      // `p.join(root, 'hibiki', 'android')`。所以结构化 ≥ 朴素是**恒等式级**的期望，
+      // 一旦反过来，就是结构化侧的某一遍扫描坏了。
+      const List<String> trees = <String>[
+        'hibiki/windows',
+        'hibiki/android',
+        'hibiki/ios',
+        'hibiki/macos',
+        'hibiki/linux',
+        'tools/browser-extension',
+        '.github/workflows',
+        'native/hoshidicts',
+        'native/galgame_hook',
+        'packages/flutter_inappwebview_windows',
+      ];
+      final List<String> regressions = <String>[];
+      for (final String tree in trees) {
+        final int naive = naiveTreeMentions(tree);
+        final int indexed = indexedTreeMentions(tree);
+        if (indexed < naive) {
+          regressions.add('$tree：结构化 $indexed < 朴素 $naive');
+        }
+      }
+      expect(regressions, isEmpty,
+          reason: '结构化提取比「逐字 contains」还少，说明含斜杠字面量那一遍漏了：\n'
+              '${regressions.join('\n')}');
+    });
+
+    test('逐树规模哨兵：绝对下界（实测值的约 80%）', () {
+      const Map<String, int> floors = <String, int>{
+        'hibiki/windows': 58,
+        'hibiki/android': 29,
+        'tools/browser-extension': 38,
+        '.github/workflows': 15,
+        'packages/flutter_inappwebview_windows': 15,
+        'native/hoshidicts': 9,
+        'native/galgame_hook': 7,
+        'hibiki/ios': 5,
+        'hibiki/macos': 6,
+        'hibiki/linux': 2,
+      };
+      final List<String> thin = <String>[];
+      floors.forEach((String tree, int floor) {
+        final int got = indexedTreeMentions(tree);
+        if (got < floor) thin.add('$tree：$got < $floor');
+      });
+      expect(thin, isEmpty, reason: '逐树引用数塌到下界以下：\n${thin.join('\n')}');
+    });
+
+    test('声明的 tests-for-changes glob 必须匹配到真实文件', () {
+      // 声明是唯一「人写」的部分，所以它是唯一会哑掉的部分。
+      // 这条把它的腐烂变成响的：glob 匹配不到任何文件就当场红。
+      final String rootPath = fs.root.path.replaceAll('\\', '/');
+      const Set<String> skip = <String>{
+        '.git',
+        '.dart_tool',
+        '.worktrees',
+        '.codex-test',
+        'build',
+        'node_modules',
+        'Pods',
+      };
+      final List<String> repoFiles = <String>[];
+      void walk(Directory dir) {
+        late final List<FileSystemEntity> entries;
+        try {
+          entries = dir.listSync(followLinks: false);
+        } on FileSystemException {
+          return;
+        }
+        for (final FileSystemEntity e in entries) {
+          final String name = e.path.replaceAll('\\', '/').split('/').last;
+          if (skip.contains(name)) continue;
+          if (e is Directory) {
+            walk(e);
+          } else if (e is File) {
+            repoFiles.add(
+                e.path.replaceAll('\\', '/').replaceFirst('$rootPath/', ''));
+          }
+        }
+      }
+
+      walk(fs.root);
+      expect(repoFiles.length, greaterThanOrEqualTo(5000),
+          reason: '仓库文件枚举塌了（实测上万），下面的 glob 校验会假绿');
+
+      final List<String> declared = <String>[];
+      final List<String> dead = <String>[];
+      index.forEach((RepoPath test, TestTriggerFace face) {
+        for (final String glob in face.declaredGlobs) {
+          declared.add('$test: $glob');
+          final RegExp re = globToRegExp(glob);
+          if (!repoFiles.any(re.hasMatch)) dead.add('$test: $glob');
+        }
+      });
+      expect(declared, isNotEmpty,
+          reason: '一条 `// tests-for-changes:` 声明都没有——'
+              '要么机制被删了，要么正则不认了；无论哪种，'
+              'powershell_51_compat_guard 这类运行时算扫描面的守卫就又没触发规则了');
+      expect(dead, isEmpty,
+          reason: '这些声明的 glob 在仓库里匹配不到任何文件，已经是死规则：\n'
+              '${dead.join('\n')}');
+    });
+
+    test('Dart 源码树的改动不由本工具输出（默认整批 35 条兜底）', () {
+      expect(
+          isDefaultBatchCoveredChange('hibiki/lib/src/models/app_model.dart'),
+          isTrue);
+      expect(
+          isDefaultBatchCoveredChange('hibiki/test/tools/x_test.dart'), isTrue);
+      expect(
+          isDefaultBatchCoveredChange('packages/hibiki_core/lib/src/db.dart'),
+          isTrue);
+      expect(
+          isDefaultBatchCoveredChange('hibiki/windows/runner/x.cpp'), isFalse,
+          reason: 'native 树绝不能被当成「已被整批覆盖」而吞掉');
+      expect(
+          isDefaultBatchCoveredChange(
+              'packages/gamepads_windows/windows/x.cpp'),
+          isFalse);
+    });
+
+    test('存在性判定必须逐段精确大小写（Windows NTFS 大小写不敏感）', () {
+      // 直接用 existsSync 时，注释里的「Android/iOS/macOS/Windows/Linux」会让
+      // `hibiki/Linux` 在 Windows 上判为存在、在 Linux CI 上判为不存在——
+      // 同一份索引两个平台两个样，本机全绿 CI 红。
+      expect(fs.exists('hibiki/linux'), isTrue,
+          reason: '真实目录必须判存在，否则这条测试在守一个空契约');
+      expect(fs.exists('hibiki/Linux'), isFalse, reason: '大小写不匹配必须判不存在');
+      expect(fs.exists('hibiki/windows'), isTrue);
+      expect(fs.exists('hibiki/Windows'), isFalse);
+    });
+
+    test('fast-workflow.md 的「按触发条件加跑」必须指向本工具而不是名字表', () {
+      final File doc = File('${fs.root.path}/docs/agent/fast-workflow.md');
+      expect(doc.existsSync(), isTrue, reason: '文档没了，规则就没有入口');
+      final String text = doc.readAsStringSync();
+      expect(text.contains('tool/tests_for_changes.dart'), isTrue,
+          reason: 'fast-workflow.md 必须给出推导命令，否则规则再对也没人执行');
+      final int anchor = text.indexOf('按触发条件加跑');
+      expect(anchor, greaterThanOrEqualTo(0),
+          reason: '「按触发条件加跑」这一节的锚点不见了，本断言在守空气');
+      expect(text.substring(anchor).contains('tests_for_changes.dart'), isTrue,
+          reason: '「按触发条件加跑」一节里必须是推导命令，'
+              '不许退回手写测试名清单——名字表必然腐烂，这次就是');
+    });
+  });
+}

--- a/hibiki/tool/tests_for_changes.dart
+++ b/hibiki/tool/tests_for_changes.dart
@@ -1,0 +1,587 @@
+// 由改动文件推导「必须加跑哪些测试」。
+//
+// ## 为什么要有这个工具
+//
+// `docs/agent/fast-workflow.md` 里的默认整批 35 条守卫，扫的是 Dart 源码树，
+// 目录枚举、自动纳入新文件，所以「整批跑」就够了。真正会漏的是另一半：
+// **读 native / 非 Dart 树的守卫**（`hibiki/windows`、`hibiki/android`、
+// `packages/*/windows`、`native/`、`tools/browser-extension`、`.github/workflows`、
+// `third_party/` …）。它们的触发面不在 Dart 树里，整批清单抓不到，于是文档里
+// 长期挂着一份**手写的 9 个测试名**当「按触发条件加跑」清单。
+//
+// 那份名字表的分类维度是「资产种类」（workflow / 扩展 / 二进制 / native），
+// 而真实触发面的维度是「哪棵源码树」。两者不对齐，结果是五棵最大的 native 树里
+// 只有一棵被点了一个名——改一行 `hibiki/windows/runner/*.cpp` 会牵动十几条守卫，
+// 清单一条都没提。**这是「合入的 PR 把红带进 develop」的共同根因之一。**
+//
+// ## 判据：不再点名，改为从仓库现状推导
+//
+// 每条这类守卫都必须在源码里写出它要读的路径（否则它读不到东西）。所以
+// **测试文件自己的路径字面量就是触发面的真相源**：
+//
+//   改动文件 F 触发测试 T  ⟺  T 的源码里引用了某个仓库路径 P，且 F 落在 P 底下。
+//
+// 这个判据比手写名字表稳，关键在于**耦合**：被提取的字符串和被守卫断言存在的
+// 路径是同一个文件里的同一个字面量。树改名时，守卫必须改那个字面量（不然它自己
+// 就红了），于是索引自动跟着走。名字表没有这种耦合，只会烂。
+//
+// ## 有意的偏置：过度触发，不漏触发
+//
+// 漏一条 ⇒ 红带进 develop（本仓已发生 3 次）；多跑一条 ⇒ 多花几秒。两者代价不
+// 对称，所以所有取舍一律偏向多输出：
+//
+// - **不剥注释**。注释里点名一棵树，本身就是「这个测试和那棵树有关」的证据；
+//   而且 `tool/` 下没法 import `test/helpers/source_guard.dart`（它依赖
+//   `package:flutter_test`），自己再写一遍词法器只会多一处会烂的实现。
+// - 路径候选取**后缀最长匹配**，并且允许补 `hibiki/` 前缀（测试的 cwd 是
+//   `hibiki/`，`'windows/runner/x.cpp'` 这种写法指的是 `hibiki/windows/...`）。
+// - 引用到**文件**时，同目录的其它文件也算触发（新增文件才不会被漏掉）。
+//
+// 唯一的收敛手段是**磁盘存在性**：候选路径必须真的在仓库里存在。这既滤掉了 URL、
+// 正则、临时目录，也让规则跟着仓库自动更新。
+//
+// ## 用法
+//
+//   cd hibiki
+//   dart run tool/tests_for_changes.dart --base=origin/develop
+//   dart run tool/tests_for_changes.dart hibiki/windows/runner/flutter_window.cpp
+//   dart run tool/tests_for_changes.dart --base=origin/develop --explain
+//   dart run tool/tests_for_changes.dart --stats
+//
+// 输出是可直接喂给 `flutter test` 的、相对 `hibiki/` 的测试路径，每行一个：
+//
+//   cd hibiki && dart run tool/flutter_test_failures.dart --no-pub \
+//     --output-dir=../.codex-test/flutter-test-trigger \
+//     $(dart run tool/tests_for_changes.dart --base=origin/develop)
+//
+// ignore_for_file: avoid_print
+
+import 'dart:io';
+
+/// 仓库根相对路径，一律 POSIX 分隔符、无前导 `./`。
+typedef RepoPath = String;
+
+/// 「容器目录」：底下装的是互不相干的多个域，整棵树当一个触发单元没有意义。
+///
+/// 只有这两个是硬编码的名字，而且它们的腐烂是**响的**不是**哑的**——
+/// `tests_for_changes_guard_test.dart` 断言两者都存在且各含 ≥5 个子目录，
+/// 仓库真改了布局会当场红。
+const Set<RepoPath> kContainerDirs = <RepoPath>{'hibiki', 'packages'};
+
+/// 非源码、且**各机器有无不一致**的目录名。
+///
+/// 它们必须被排除，理由不是「没用」而是「会让索引因机器而异」：本机有
+/// `hibiki/build/windows/x64/...`、CI 的干净 checkout 没有，同一条路径字面量
+/// 在两处解析成不同深度，于是本机推导出的测试集和 CI 的不一样。索引必须只由
+/// **入库内容**决定。
+const Set<String> kNonSourceDirs = <String>{
+  'build',
+  '.dart_tool',
+  '.gradle',
+  '.codex-test',
+  '.worktrees',
+  'node_modules',
+  'Pods',
+};
+
+/// 默认整批 35 条 + 定向测试已经覆盖的 Dart 源码树。
+///
+/// 落在这些树里的改动**不由本工具输出**：它们的守卫是目录枚举型的，
+/// 「整批跑」本来就抓得到，再输出一遍只会把结果淹掉、让人不看。
+/// `--include-dart` 可关掉这层过滤。
+const List<String> kDefaultBatchCoveredGlobs = <String>[
+  'hibiki/lib/',
+  'hibiki/test/',
+  'hibiki/integration_test/',
+];
+
+/// 仓库磁盘视图。抽成对象是为了让守卫测试能对着真仓库跑同一份逻辑，
+/// 而不必把 `Directory` 到处传。
+class RepoFs {
+  RepoFs(this.root);
+
+  /// 仓库根目录（含 `hibiki/pubspec.yaml` 与 `native/`）。
+  final Directory root;
+
+  final Map<RepoPath, bool> _existsCache = <RepoPath, bool>{};
+  final Map<RepoPath, bool> _isDirCache = <RepoPath, bool>{};
+  final Map<RepoPath, Set<String>> _entriesCache = <RepoPath, Set<String>>{};
+  Set<RepoPath>? _topLevelCache;
+
+  String _abs(RepoPath repoPath) =>
+      repoPath.isEmpty ? root.path : '${root.path}/$repoPath';
+
+  /// 某个目录下的直接子项名。**大小写按磁盘原样**。
+  Set<String> _entriesOf(RepoPath dirRepoPath) =>
+      _entriesCache.putIfAbsent(dirRepoPath, () {
+        final Directory dir = Directory(_abs(dirRepoPath));
+        if (!dir.existsSync()) return const <String>{};
+        try {
+          return dir
+              .listSync(followLinks: false)
+              .map((FileSystemEntity e) =>
+                  e.path.replaceAll('\\', '/').split('/').last)
+              .toSet();
+        } on FileSystemException {
+          return const <String>{};
+        }
+      });
+
+  /// 仓库里是否真有这个路径（文件或目录），**逐段精确大小写比对**。
+  ///
+  /// 不能直接用 `existsSync`：Windows 的 NTFS 大小写不敏感，且会静默吃掉路径段
+  /// 末尾的空格与点。于是注释里的「Android/iOS/macOS/Windows/Linux」会被判成
+  /// `hibiki/Linux` 存在——**在 Linux CI 上却不存在**，同一份索引两个平台两个样。
+  /// 逐段比对目录列表把这两类幽灵一次性掐掉。
+  bool exists(RepoPath repoPath) => _existsCache.putIfAbsent(repoPath, () {
+        final List<String> segments = repoPath.split('/');
+        RepoPath cursor = '';
+        for (final String seg in segments) {
+          if (seg.isEmpty) return false;
+          if (!_entriesOf(cursor).contains(seg)) return false;
+          cursor = cursor.isEmpty ? seg : '$cursor/$seg';
+        }
+        return true;
+      });
+
+  /// 这个路径是不是目录。
+  bool isDirectory(RepoPath repoPath) => _isDirCache.putIfAbsent(repoPath,
+      () => exists(repoPath) && Directory(_abs(repoPath)).existsSync());
+
+  /// 仓库根下的一级目录名（含 `.github`）。**运行时枚举，不硬编码。**
+  Set<RepoPath> topLevelDirs() => _topLevelCache ??= root
+      .listSync(followLinks: false)
+      .whereType<Directory>()
+      .map((Directory d) => d.path.replaceAll('\\', '/').split('/').last)
+      .where((String name) => name != '.git')
+      .toSet();
+}
+
+/// 从 [start] 起向上找仓库根：以 `hibiki/pubspec.yaml` + `native/` 同时存在为准。
+Directory locateRepoRoot(Directory start) {
+  Directory dir = start.absolute;
+  for (int depth = 0; depth < 12; depth++) {
+    final bool hasApp = File('${dir.path}/hibiki/pubspec.yaml').existsSync();
+    final bool hasNative = Directory('${dir.path}/native').existsSync();
+    if (hasApp && hasNative) return dir;
+    final Directory parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  throw StateError('定位不到仓库根（找不到 hibiki/pubspec.yaml + native/）：'
+      '${start.absolute.path}');
+}
+
+/// 把任意写法的路径候选归一成仓库根相对路径；无法归一则返回 `null`。
+///
+/// 归一规则（按顺序试，取第一个在磁盘上存在的）：
+/// 1. 丢掉 `.` / `..` / 空段；
+/// 2. 从最长后缀往最短试，要求首段是仓库一级目录；
+/// 3. 同一后缀内，**从最长前缀往最短退**，落到最近的一个真实存在的祖先；
+/// 4. 都不成时，给各级后缀补 `hibiki/` 前缀再走一遍（测试 cwd 是 `hibiki/`）。
+///
+/// 第 3 步不是可有可无的收尾，它兜住三类实测漏网：
+/// - 指向**构建产物**的路径（`native/galgame_hook/dist` 磁盘上不存在）；
+/// - 注释里的**省略写法**（`packages/flutter_inappwebview_windows/.../x.cpp`）；
+/// - 被删/被改名的叶子文件。
+/// 三类都属于「这个测试确实关心那棵树」，退到最近祖先是正确的过度触发。
+///
+/// 最后拒绝 [kContainerDirs]——它们太宽，等于「整个仓库」。
+RepoPath? normalizeRepoPath(String candidate, RepoFs fs) {
+  // `C:/x`、`a*b` 之类不可能是仓库路径，而且在 Windows 上 existsSync 会直接抛。
+  if (_illegalPathChar.hasMatch(candidate)) return null;
+  final List<String> segments = candidate
+      .replaceAll('\\', '/')
+      .split('/')
+      .where((String s) => s.isNotEmpty && s != '.' && s != '..')
+      .toList();
+  if (segments.isEmpty) return null;
+
+  final Set<RepoPath> topLevel = fs.topLevelDirs();
+  RepoPath? best;
+  int bestDepth = 0;
+
+  void consider(RepoPath joined) {
+    if (kContainerDirs.contains(joined)) return;
+    final List<String> parts = joined.split('/');
+    if (parts.any(kNonSourceDirs.contains)) return;
+    if (!fs.exists(joined)) return;
+    if (parts.length <= bestDepth) return;
+    best = joined;
+    bestDepth = parts.length;
+  }
+
+  for (int start = 0; start < segments.length; start++) {
+    for (int end = segments.length; end > start; end--) {
+      final String tail = segments.sublist(start, end).join('/');
+      if (topLevel.contains(segments[start])) consider(tail);
+      // 首段不是一级目录时，可能是相对 `hibiki/` 写的（`windows/runner/x.cpp`）。
+      consider('hibiki/$tail');
+    }
+  }
+  return best;
+}
+
+/// Windows / POSIX 都不可能出现在仓库路径里的字符。
+final RegExp _illegalPathChar = RegExp(r'[:*?<>|"]');
+
+/// 任意含 `/` 的路径形 token。故意不认 `$`/`{`，插值前缀会在后缀匹配里被丢掉。
+final RegExp _slashPathToken =
+    RegExp(r'[A-Za-z0-9_.\-]+(?:/[A-Za-z0-9_.\-]+)+');
+
+/// `join(` / `p.join(` / `path.join(` 调用起点。
+final RegExp _joinCall = RegExp(r'\b(?:p|path)?\.?join\s*\(');
+
+/// 单/双引号里的简单字面量（不含转义与插值，够用了：路径段本来就不该有）。
+final RegExp _simpleQuoted =
+    RegExp("'([^'\\\\\\\$\\n]*)'|\"([^\"\\\\\\\$\\n]*)\"");
+
+/// 从一段 Dart 源码里提取它引用到的仓库路径。
+///
+/// 两遍扫描取并集：
+/// - **含斜杠字面量**：`'../packages/gamepads_windows/windows'`、
+///   `'\${root.path}/hibiki/windows/runner'`（插值前缀靠后缀匹配丢掉）。
+/// - **join 段链**：`p.join(root.path, 'hibiki', 'windows')` 这种一个斜杠都没有的
+///   写法，只靠第一遍会全漏——本仓大多数 native 守卫正是这么写路径的。
+Set<RepoPath> extractRepoPathReferences(String source, RepoFs fs) {
+  final Set<RepoPath> refs = <RepoPath>{};
+
+  for (final RegExpMatch m in _slashPathToken.allMatches(source)) {
+    final RepoPath? p = normalizeRepoPath(m.group(0)!, fs);
+    if (p != null) refs.add(p);
+  }
+
+  for (final RegExpMatch call in _joinCall.allMatches(source)) {
+    final int open = call.end - 1;
+    final int close = _matchingParen(source, open);
+    if (close < 0) continue;
+    final String args = source.substring(open + 1, close);
+    final List<String> segments = <String>[];
+    for (final RegExpMatch lit in _simpleQuoted.allMatches(args)) {
+      final String text = lit.group(1) ?? lit.group(2) ?? '';
+      if (text.isEmpty) continue;
+      segments.add(text);
+    }
+    if (segments.isEmpty) continue;
+    for (int start = 0; start < segments.length; start++) {
+      final RepoPath? p =
+          normalizeRepoPath(segments.sublist(start).join('/'), fs);
+      if (p != null) {
+        refs.add(p);
+        break;
+      }
+    }
+  }
+
+  return refs;
+}
+
+/// 从 [open]（`(` 的下标）找配对的 `)`；找不到返回 -1。
+int _matchingParen(String source, int open) {
+  int depth = 0;
+  for (int i = open; i < source.length; i++) {
+    final String c = source[i];
+    if (c == '(') {
+      depth++;
+    } else if (c == ')') {
+      depth--;
+      if (depth == 0) return i;
+    } else if (c == '\n' && depth > 0 && i - open > 4000) {
+      return -1;
+    }
+  }
+  return -1;
+}
+
+/// 显式声明的触发 glob：`// tests-for-changes: **/*.ps1`。
+///
+/// 少数守卫的扫描面是**运行时算出来**的，源码里根本没有那些路径的字面量，
+/// 静态提取必然看不见。典型是 `powershell_51_compat_guard_test.dart`：它从
+/// `.github/workflows/*.yml` 里解析 `powershell -File <脚本>`，被守的 `.ps1`
+/// 清单是 yml 的内容决定的。
+///
+/// 这类守卫在自己文件里写一行声明。**规则住在拥有它的那个文件里**，改守卫的人
+/// 一眼看得见；而 `tests_for_changes_guard_test.dart` 断言每条声明至少匹配到一个
+/// 真实文件，所以声明烂掉是**响的**不是哑的——这正是它比文档里一行名字表强的地方。
+/// **必须行首锚定**：不锚定的话，任何在句子中间提到这个标记的散文（包括本工具的
+/// 守卫自己的注释与断言文案）都会被当成一条真声明，凭空造出一堆匹配不到文件的
+/// 「死规则」。这不是假想——`tests_for_changes_guard_test.dart` 第一版就是被自己
+/// 的 reason 文案匹配到而红的。
+final RegExp _declaredTrigger = RegExp(
+  r'^\s*//\s*tests-for-changes:\s*(\S[^\n]*)',
+  multiLine: true,
+);
+
+/// 提取一个测试文件里声明的触发 glob。
+List<String> extractDeclaredTriggerGlobs(String source) {
+  final List<String> globs = <String>[];
+  for (final RegExpMatch m in _declaredTrigger.allMatches(source)) {
+    for (final String g in m.group(1)!.trim().split(RegExp(r'\s+'))) {
+      if (g.isNotEmpty) globs.add(g);
+    }
+  }
+  return globs;
+}
+
+/// 最小 glob：`**` 跨目录、`*` 单层、`?` 单字符，其余按字面量转义。
+RegExp globToRegExp(String glob) {
+  final StringBuffer out = StringBuffer('^');
+  for (int i = 0; i < glob.length; i++) {
+    final String c = glob[i];
+    if (c == '*') {
+      if (i + 1 < glob.length && glob[i + 1] == '*') {
+        out.write('.*');
+        i++;
+      } else {
+        out.write('[^/]*');
+      }
+    } else if (c == '?') {
+      out.write('[^/]');
+    } else {
+      out.write(RegExp.escape(c));
+    }
+  }
+  out.write(r'$');
+  return RegExp(out.toString());
+}
+
+/// 一个测试文件的触发面：源码里提取到的路径引用 + 显式声明的 glob。
+class TestTriggerFace {
+  const TestTriggerFace({
+    required this.referencedPaths,
+    required this.declaredGlobs,
+  });
+
+  /// 从源码里静态提取到的仓库路径引用。
+  final Set<RepoPath> referencedPaths;
+
+  /// `// tests-for-changes:` 声明的 glob（扫描面运行时才算得出来的守卫用）。
+  final List<String> declaredGlobs;
+
+  bool get isEmpty => referencedPaths.isEmpty && declaredGlobs.isEmpty;
+}
+
+/// 枚举 `hibiki/test/` 下全部 `*_test.dart`，返回仓库根相对路径。
+List<RepoPath> listAppTestFiles(RepoFs fs) {
+  final Directory testDir = Directory('${fs.root.path}/hibiki/test');
+  if (!testDir.existsSync()) {
+    throw StateError('hibiki/test 不存在，扫描面是空的');
+  }
+  final List<RepoPath> out = <RepoPath>[];
+  for (final FileSystemEntity e
+      in testDir.listSync(recursive: true, followLinks: false)) {
+    if (e is! File) continue;
+    final String rel = e.path
+        .replaceAll('\\', '/')
+        .replaceFirst('${fs.root.path.replaceAll('\\', '/')}/', '');
+    if (!rel.endsWith('_test.dart')) continue;
+    out.add(rel);
+  }
+  out.sort();
+  return out;
+}
+
+/// 测试文件 → 它的触发面。
+Map<RepoPath, TestTriggerFace> buildReferenceIndex(RepoFs fs) {
+  final Map<RepoPath, TestTriggerFace> index = <RepoPath, TestTriggerFace>{};
+  for (final RepoPath test in listAppTestFiles(fs)) {
+    final String source = File('${fs.root.path}/$test').readAsStringSync();
+    index[test] = TestTriggerFace(
+      referencedPaths: extractRepoPathReferences(source, fs),
+      declaredGlobs: extractDeclaredTriggerGlobs(source),
+    );
+  }
+  return index;
+}
+
+/// 这条改动是不是「默认整批 35 条 + 定向测试」已经覆盖的 Dart 源码树。
+bool isDefaultBatchCoveredChange(RepoPath changed) {
+  for (final String prefix in kDefaultBatchCoveredGlobs) {
+    if (changed.startsWith(prefix)) return true;
+  }
+  final List<String> segments = changed.split('/');
+  if (segments.length > 3 && segments.first == 'packages') {
+    if (segments[2] == 'lib' || segments[2] == 'test') return true;
+  }
+  return false;
+}
+
+/// [changed] 是否落在引用路径 [ref] 的触发面里。
+///
+/// - `ref` 是目录 ⇒ 目录下全部文件都算；
+/// - `ref` 是文件 ⇒ 该文件本身，外加**同目录**的其它文件（新增文件不能被漏掉），
+///   但同目录必须有 ≥2 层深度，免得 `hibiki/pubspec.yaml` 把整个 `hibiki/` 拉进来。
+bool changeTriggersReference(RepoPath changed, RepoPath ref, RepoFs fs) {
+  if (changed == ref) return true;
+  if (fs.isDirectory(ref)) return changed.startsWith('$ref/');
+  final int slash = ref.lastIndexOf('/');
+  if (slash < 0) return false;
+  final RepoPath parent = ref.substring(0, slash);
+  if (parent.split('/').length < 2) return false;
+  if (kContainerDirs.contains(parent)) return false;
+  return changed.startsWith('$parent/');
+}
+
+/// 推导结果：该跑的测试 → 是被哪几条引用路径 / 声明 glob 命中的。
+Map<RepoPath, Set<String>> selectTestsForChanges({
+  required Iterable<RepoPath> changedFiles,
+  required Map<RepoPath, TestTriggerFace> index,
+  required RepoFs fs,
+  bool includeDartTrees = false,
+}) {
+  final List<RepoPath> effective = changedFiles
+      .map((RepoPath c) => c.replaceAll('\\', '/'))
+      .where(
+          (RepoPath c) => includeDartTrees || !isDefaultBatchCoveredChange(c))
+      .toList();
+  final Map<RepoPath, Set<String>> hits = <RepoPath, Set<String>>{};
+  for (final MapEntry<RepoPath, TestTriggerFace> entry in index.entries) {
+    for (final RepoPath changed in effective) {
+      for (final RepoPath ref in entry.value.referencedPaths) {
+        if (!changeTriggersReference(changed, ref, fs)) continue;
+        hits.putIfAbsent(entry.key, () => <String>{}).add(ref);
+      }
+      for (final String glob in entry.value.declaredGlobs) {
+        if (!globToRegExp(glob).hasMatch(changed)) continue;
+        hits.putIfAbsent(entry.key, () => <String>{}).add('glob:$glob');
+      }
+    }
+  }
+  return hits;
+}
+
+/// 把命令行给的改动路径归一成仓库根相对。
+///
+/// 和 [normalizeRepoPath] 的区别：**不要求存在**。改动可以是删除或新增的文件，
+/// 拿存在性当门会把「新加了一个 native 文件」这种最需要推导的场景整个吞掉。
+RepoPath normalizeChangedPath(String raw, RepoFs fs) {
+  final List<String> segments = raw
+      .replaceAll('\\', '/')
+      .split('/')
+      .where((String s) => s.isNotEmpty && s != '.' && s != '..')
+      .toList();
+  if (segments.isEmpty) return raw;
+  final Set<RepoPath> topLevel = fs.topLevelDirs();
+  for (int start = 0; start < segments.length; start++) {
+    if (topLevel.contains(segments[start])) {
+      return segments.sublist(start).join('/');
+    }
+  }
+  return 'hibiki/${segments.join('/')}';
+}
+
+/// 把仓库路径归到「树」（前两段）——统计与哨兵的粒度。
+RepoPath treeOf(RepoPath repoPath) {
+  final List<String> seg = repoPath.split('/');
+  return seg.length >= 2 ? '${seg[0]}/${seg[1]}' : seg.first;
+}
+
+/// 把仓库根相对的测试路径转成 `flutter test` 在 `hibiki/` 下能直接吃的相对路径。
+RepoPath toFlutterTestArg(RepoPath repoPath) => repoPath.startsWith('hibiki/')
+    ? repoPath.substring('hibiki/'.length)
+    : repoPath;
+
+Iterable<String> _lines(String input) =>
+    input.split(RegExp(r'\r?\n')).map((String s) => s.trim());
+
+/// 从 [base] 求出**分叉点**再 diff。
+///
+/// 直接 `git diff --name-only origin/develop` 是错的：本机常有 5~10 个 agent 并发，
+/// `origin/develop` 一直在动，那条 diff 会把**别人刚落地的东西**也算成「我改了什么」。
+/// 实测本 PR 自举时就被污染成 43 个测试，里面全是 `.github/workflows` / `docs/bugs`
+/// 这些我根本没碰的树。基准必须是 `git merge-base HEAD <base>`。
+List<RepoPath> _changedFromGit(Directory root, String base) {
+  final List<RepoPath> out = <RepoPath>[];
+  final ProcessResult mergeBase = Process.runSync(
+      'git', <String>['merge-base', 'HEAD', base],
+      workingDirectory: root.path);
+  final String diffBase =
+      mergeBase.exitCode == 0 ? (mergeBase.stdout as String).trim() : base;
+  final ProcessResult diff = Process.runSync(
+      'git', <String>['diff', '--name-only', diffBase],
+      workingDirectory: root.path);
+  if (diff.exitCode != 0) {
+    throw StateError('git diff --name-only $diffBase 失败：${diff.stderr}');
+  }
+  out.addAll(_lines(diff.stdout as String));
+  final ProcessResult untracked = Process.runSync(
+      'git', <String>['ls-files', '--others', '--exclude-standard'],
+      workingDirectory: root.path);
+  if (untracked.exitCode == 0) {
+    out.addAll(_lines(untracked.stdout as String));
+  }
+  return out.where((String s) => s.trim().isNotEmpty).toList();
+}
+
+void main(List<String> args) {
+  final RepoFs fs = RepoFs(locateRepoRoot(Directory.current));
+  final bool explain = args.contains('--explain');
+  final bool stats = args.contains('--stats');
+  final bool includeDart = args.contains('--include-dart');
+
+  final Map<RepoPath, TestTriggerFace> index = buildReferenceIndex(fs);
+
+  if (stats) {
+    final Map<RepoPath, Set<RepoPath>> perTree = <RepoPath, Set<RepoPath>>{};
+    for (final MapEntry<RepoPath, TestTriggerFace> e in index.entries) {
+      for (final RepoPath ref in e.value.referencedPaths) {
+        perTree.putIfAbsent(treeOf(ref), () => <RepoPath>{}).add(e.key);
+      }
+    }
+    final List<MapEntry<RepoPath, Set<RepoPath>>> sorted = perTree.entries
+        .toList()
+      ..sort((MapEntry<RepoPath, Set<RepoPath>> a,
+              MapEntry<RepoPath, Set<RepoPath>> b) =>
+          b.value.length.compareTo(a.value.length));
+    print('索引：${index.length} 个测试文件，'
+        '${index.values.where((TestTriggerFace f) => !f.isEmpty).length} 个有触发面');
+    print('（下表是**引用该树的测试文件数**，不是实际触发数——'
+        '实际触发要看改的是树里哪个文件）');
+    for (final MapEntry<RepoPath, Set<RepoPath>> e in sorted) {
+      if (e.value.length < 2) continue;
+      print('${e.value.length.toString().padLeft(4)}  ${e.key}');
+    }
+    return;
+  }
+
+  String? base;
+  final List<RepoPath> literal = <RepoPath>[];
+  for (final String a in args) {
+    if (a.startsWith('--base=')) {
+      base = a.substring('--base='.length);
+    } else if (!a.startsWith('--')) {
+      literal.add(a.replaceAll('\\', '/'));
+    }
+  }
+
+  final List<RepoPath> changed =
+      (base != null ? _changedFromGit(fs.root, base) : literal)
+          .map((String raw) => normalizeChangedPath(raw, fs))
+          .toList();
+  if (changed.isEmpty) {
+    stderr.writeln('没有改动文件输入；用 --base=<ref> 或直接给路径。');
+    return;
+  }
+
+  final Map<RepoPath, Set<String>> hits = selectTestsForChanges(
+    changedFiles: changed,
+    index: index,
+    fs: fs,
+    includeDartTrees: includeDart,
+  );
+  final List<RepoPath> selected = hits.keys.toList()..sort();
+
+  if (explain) {
+    final int filtered = changed.where(isDefaultBatchCoveredChange).length;
+    stderr.writeln('改动 ${changed.length} 个文件，其中 $filtered 个落在默认整批'
+        '已覆盖的 Dart 树（不再重复输出，用 --include-dart 关掉）。');
+    stderr.writeln('推导出 ${selected.length} 个必须加跑的测试：');
+    for (final RepoPath t in selected) {
+      stderr
+          .writeln('  ${toFlutterTestArg(t)}  ← ${hits[t]!.toList()..sort()}');
+    }
+  }
+  for (final RepoPath t in selected) {
+    print(toFlutterTestArg(t));
+  }
+}


### PR DESCRIPTION
## 问题

`docs/agent/fast-workflow.md` 里两份清单，**默认整批 35 条是好的**（本 PR 未动），坏的是另一份：「按触发条件加跑」只手写了 **9 个测试名**，而真正读 native / 非 Dart 树的守卫有 150+ 个。

**结构性成因**（不是谁不小心）：

> 清单的分类维度是**「资产种类」**（workflow / 扩展 / 二进制 / native），真实触发面的维度是**「哪棵源码树」**。两者不对齐。

实测逐树覆盖（本 PR 工具 `--stats` 得出，`origin/develop@f0a00f410`）：

| 树 | 引用它的守卫数 | 旧清单覆盖 |
|---|---|---|
| `hibiki/windows` | **75** | 只点了 `gal_ipc_contract_single_source` **1 个** |
| `hibiki/android` | **38** | **0** |
| `tools/browser-extension` | 49 | 2 |
| `packages/flutter_inappwebview_windows` | 20 | **0** |
| `.github/workflows` | 20 | 3 |
| `native/hoshidicts` / `native/galgame_hook` | 12 / 9 | 1（半覆盖） |
| `hibiki/macos` / `ios` / `linux` | 9 / 7 / 2 | **0** |
| `packages/gamepads_windows` / `third_party/desktop_drop` | 4 / 3 | **0** |

改一行 `hibiki/windows/runner/flutter_window.cpp` 牵动 **72 条**守卫，旧清单一条都没提。

## 方案：不点名，按树推导

新增 `hibiki/tool/tests_for_changes.dart`。判据一句话：

> **改动文件 F 触发测试 T ⟺ T 的源码里引用了某个仓库路径 P，且 F 落在 P 底下。**

**为什么这条不会像名字表那样烂**：被提取的字符串和被守卫断言存在的路径，是同一个文件里的**同一个字面量**。树改名时守卫必须改它（不然它自己就红），索引自动跟着走。名字表没有这种耦合。

三遍提取取并集（含斜杠字面量 / `p.join` 段链 / 退到最近存在的祖先），收敛只靠**磁盘存在性**。

## 实测踩到并修掉的四个坑

1. **Windows NTFS 大小写不敏感**：注释里的「Android/iOS/macOS/Windows/Linux」会让 `hibiki/Linux` 在本机判存在、Linux CI 判不存在 ⇒ **同一份索引两个平台两个样**。改成逐段精确大小写比对。
2. **构建产物目录进索引**：`hibiki/build/...` 本机有、CI 干净 checkout 没有，同样让索引因机器而异。加 `kNonSourceDirs` 排除。
3. **`--base=origin/develop` 直接 diff 是错的**：并发下 `origin/develop` 一直在动，本 PR 自举时被污染成 43 个测试（里面全是我没碰的树）。改走 `git merge-base`，降到 12 个。
4. **最近祖先回退**：`native/galgame_hook/dist`（构建产物）、`packages/flutter_inappwebview_windows/.../x.cpp`（注释省略写法）原本被存在性检查整条丢掉。

## 例外：运行时才算得出扫描面的守卫

`powershell_51_compat_guard_test.dart` 从 workflow yml 里解析 `powershell -File <脚本>`，源码里没有那些 `.ps1` 的字面量。它在**自己文件里**声明一行：

```dart
// tests-for-changes: **/*.ps1
```

守卫断言每条声明至少匹配到一个真实文件 ⇒ 声明烂掉是**响的**不是哑的。

## 守卫（`test/tools/tests_for_changes_guard_test.dart`，10 tests）

1. **行为对账**：被替掉的 9 条手写规则必须仍能被推导出来（**超集**，不是近似）。
2. **盲区断言**：原先零覆盖的树逐棵有下界。
3. **规模哨兵 + 独立枚举**：逐树下界，且下界由一份**与提取器无任何共享代码**的朴素 `contains` 扫描独立算出（避免 `tool/bug.dart` 那种「守卫与被守方共用同一个有缺陷的枚举函数、同处失明」）。
4. **逐遍存活断言**（合成语料）。

## 变异实测：6 次，其中一次抓到守卫自己的真空档

| 变异 | 结果 |
|---|---|
| M1 关掉 `p.join` 段链那一遍 | **🔴 第一轮假绿** → 补合成语料逐遍断言后变红 |
| M2 关掉含斜杠字面量那一遍 | 红（5 error events / 10 completed） |
| M3 删掉 `.ps1` 的 `tests-for-changes` 声明 | 红 |
| M4 `exists()` 退回大小写不敏感 | 红 |
| M5 文档里去掉工具引用 | 红 |
| M6 关掉最近祖先回退 | 红 |

M1 假绿的原因值得记下：**本仓注释极其详尽**，一个用 `p.join` 写路径的守卫，注释里往往同时写着含斜杠的那条路径，于是全量下界和「结构化 ≥ 朴素」两条都被注释兜住了。**逐遍存活只能用合成语料点名，指望全量下界替它把关是假的。**

全部变异用**反向替换**还原（未用 `git checkout --`），还原后 `grep` 复核零残留。所有红都是 10 tests completed 的行为红，非编译失败的 `0 tests ran`。

## 性能：不用分层

`hibiki/windows/runner/flutter_window.cpp` 推出的 61 条实测 **46 秒 / 503 tests / PASSED**。整批跑就行。

## 验证

- `dart format`：4 个改动文件
- `flutter analyze` 全量（含 test）：**`No issues found! (ran in 44.4s)`**
- **35 条整批**（命令块从 `docs/agent/fast-workflow.md` 逐字抽出执行）：**`FLUTTER TEST VERDICT: PASSED - 207 tests ran, all tests passed`**（N 基线 207 ✓）
- 本 PR 自举推导出的 12 条：**`PASSED - 68 tests ran`**
- 新守卫单跑：**`PASSED - 10 tests ran`**

## 顺带并入文档的三条（整合线 + PR#760 提供）

1. `gh api` 在 push 后会短暂滞后，`git ls-remote` 才权威 —— 与既有「假失败/假成功」并成三行表。
2. **判「测试跑全了没」是结构问题不是算术问题**：数 `test(` 得出的差额没有意义（`testWidgets` / 参数化 / `group` 动态生成都对不上），决定性的是 suite 层对账（磁盘 237 / 装载 237 / 0 缺失 / 0 空 suite）。
3. PR#760 的**禁止型断言盲区**：健康仓库里永远零命中 ⇒ 判据坏掉时扫盘检验不到。并写清两层关系：**本清单管「该跑的守卫有没有跑到」，判据自校验管「跑到的守卫判得准不准」**。
4. N 演进链保留为 `194(32条) → 207(35条,PR#756) → 225(PR#760,尚未合入)`。

## 未改、交给别的线

- **未动 35 条默认清单**（PR#756 刚校准，N=207）。
- 新守卫**未加进 35 条整批**（硬约束）。它本身是目录枚举型（枚举 `hibiki/test` 全树），下次校准可考虑；但它已被推导规则自我覆盖——任何碰 native 树的 PR 都会推到它。
- 未发现其它守卫的判据缺陷需要交给 TODO-2715；M2/M6 暴露的都是本 PR 自己新代码的问题。

## 已知取舍

- **不剥注释**：`tool/` 下没法 import `test/helpers/source_guard.dart`（依赖 `package:flutter_test`），自己再写一遍词法器只会多一处会烂的实现；而注释里点名一棵树本身就是证据。代价是过度触发（`docs/bugs` 改动会推出 11 条而非 1 条），方向是安全的那侧。
- **Dart 源码树的改动不由本工具输出**（`hibiki/{lib,test,integration_test}`、`packages/*/{lib,test}`），它们由 35 条整批 + 定向测试覆盖；`--include-dart` 可关掉。
- `kContainerDirs = {hibiki, packages}` 是仅有的两个硬编码名字，守卫断言它们存在。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
