### PR TITLE
ci(cache): 收敛 Actions 缓存到 10 GB 配额内 (TODO-2721)

### DIFF
--- a/.github/workflows/build-multiplatform.yml
+++ b/.github/workflows/build-multiplatform.yml
@@ -161,24 +161,22 @@ jobs:
             sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
             rm -f "$dst.bak"
           fi
-      # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
-      # is idempotent so a warm cache is safe).
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pubcache-
+      # TODO-2721: 只缓存 Gradle 的下载物（modules-2 / wrapper dists），不缓存
+      # <ver>/transforms 这类可从 modules-2 重算的派生产物。三个 workflow
+      # （main / release / build-multiplatform）的 path + key 必须逐字相同，且此步
+      # 之前不得 sed 改 build.gradle / settings.gradle —— 否则同一份内容会被存成
+      # 两条各 2.7 GB 的缓存。理由见 docs/agent/build.md 的「CI 缓存配额」，守卫见
+      # hibiki/test/build/workflow_cache_quota_guard_test.dart。
       - name: Cache Gradle caches
         uses: actions/cache@v4
         with:
           path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('hibiki/android/**/*.gradle*', 'hibiki/android/gradle/wrapper/gradle-wrapper.properties') }}
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/journal-1
+            ~/.gradle/wrapper/dists
+          key: ${{ runner.os }}-gradle-v2-${{ hashFiles('hibiki/android/**/*.gradle*', 'hibiki/android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            ${{ runner.os }}-gradle-v2-
       - name: Flutter pub get
         working-directory: hibiki
         run: flutter pub get
@@ -376,15 +374,6 @@ jobs:
             sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
             rm -f "$dst.bak"
           fi
-      # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
-      # is idempotent so a warm cache is safe).
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pubcache-
       - name: Flutter pub get
         working-directory: hibiki
         run: flutter pub get
@@ -564,15 +553,6 @@ jobs:
             sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
             rm -f "$dst.bak"
           fi
-      # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
-      # is idempotent so a warm cache is safe).
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pubcache-
       # TODO-1208: cache CocoaPods spec repos, downloaded pod source and generated
       # Pods dirs. Keyed on Podfile.lock/pubspec.lock; CocoaPods re-installs on a
       # mismatch and a miss just re-downloads.
@@ -736,15 +716,6 @@ jobs:
             sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
             rm -f "$dst.bak"
           fi
-      # TODO-1208: cache resolved pub packages (miss auto-rebuilds; apply-patches
-      # is idempotent so a warm cache is safe).
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pubcache-
       # TODO-1208: cache CocoaPods spec repos, downloaded pod source and generated
       # Pods dirs. Keyed on Podfile.lock/pubspec.lock; CocoaPods re-installs on a
       # mismatch and a miss just re-downloads.
@@ -880,14 +851,6 @@ jobs:
             sed -i.bak "s|^const String kBuiltinTmdbApiKey = '';|const String kBuiltinTmdbApiKey = '$TMDB_API_KEY';|" "$dst"
             rm -f "$dst.bak"
           fi
-      # TODO-1208: Windows Dart pub cache defaults to %LOCALAPPDATA%\Pub\Cache.
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~\AppData\Local\Pub\Cache
-          key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pubcache-
       # TODO-1208: cache media_kit's libmpv + ANGLE .7z archives it downloads into
       # the CMake binary dir (hibiki/build/windows/x64). media_kit skips the
       # download when the .7z exists with a matching MD5, so caching just the

--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,79 @@
+# TODO-2721：PR 关闭后删掉只属于该 PR 的 Actions 缓存。
+#
+# GitHub 的缓存是**按 ref 分桶**的：`refs/pull/<N>/merge` 上存的缓存和
+# `refs/heads/develop` 上同 key 的缓存是两条独立记录，一起算进仓库那 10 GB 配额。
+# 正常情况下 PR run 会命中 base 分支的缓存、不新存；但仓库一旦超配额、develop 那条
+# 被 LRU 驱逐，下一个 PR run 就会 miss 并在**自己的 PR 桶**里存一份 —— 于是出现
+# 「同一个 key 两条 1.8 GB 记录」，配额越紧越容易复制，是个正反馈。
+#
+# PR 合并/关闭后那些桶永远不会再被读到，但 GitHub 只在「7 天无访问」后才回收。
+# 这一步把它们立刻删掉，把配额还给 develop。
+#
+# 本 workflow **不发布任何东西**：无 checkout、无构建、无 release，只调
+# `DELETE /repos/{owner}/{repo}/actions/caches?key=...&ref=...`。
+name: Cleanup PR caches
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: cache-cleanup-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    # fork PR 的 GITHUB_TOKEN 是只读的，`actions: write` 拿不到，跑了必红。
+    # 本仓的开发模式是同仓分支 PR，fork 直接跳过即可。
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete caches scoped to this PR ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_REF: refs/pull/${{ github.event.pull_request.number }}/merge
+        run: |
+          set -euo pipefail
+          freed=0
+          count=0
+          # 分页取完这个 ref 下的全部缓存再删（边列边删会跳页）。
+          keys="$(gh api --paginate \
+            "repos/$REPO/actions/caches?per_page=100&ref=$PR_REF" \
+            --jq '.actions_caches[] | "\(.id)\t\(.size_in_bytes)\t\(.key)"')"
+          if [ -z "$keys" ]; then
+            echo "No caches scoped to $PR_REF."
+            exit 0
+          fi
+          while IFS=$'\t' read -r id size key; do
+            [ -n "${id:-}" ] || continue
+            echo "Deleting $key ($((size / 1024 / 1024)) MB, id=$id)"
+            # 按 id 删是精确的；失败不让整条 workflow 红（缓存可能刚被 LRU 驱逐）。
+            gh api -X DELETE "repos/$REPO/actions/caches/$id" || \
+              echo "::warning title=Cache delete failed::$key"
+            freed=$((freed + size))
+            count=$((count + 1))
+          done <<< "$keys"
+          echo "Deleted $count cache(s), freed $((freed / 1024 / 1024)) MB from $PR_REF." \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report repository cache usage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          usage="$(gh api "repos/$REPO/actions/cache/usage")"
+          bytes="$(echo "$usage" | jq -r '.active_caches_size_in_bytes')"
+          entries="$(echo "$usage" | jq -r '.active_caches_count')"
+          mb=$((bytes / 1024 / 1024))
+          echo "Repository cache usage: ${mb} MB in ${entries} entries (limit 10240 MB)." \
+            >> "$GITHUB_STEP_SUMMARY"
+          # 超配额只警告不失败：这条 workflow 的职责是回收，不是守门。
+          if [ "$mb" -gt 10240 ]; then
+            echo "::warning title=Actions cache over quota::${mb} MB > 10240 MB; GitHub is LRU-evicting."
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,12 +78,6 @@ jobs:
         sed -i '/systemProp\.https\.proxyPort/d' gradle.properties
         sed -i '/systemProp\.http\.nonProxyHosts/d' gradle.properties
 
-    - name: Remove aliyun mirrors from gradle files
-      working-directory: hibiki/android
-      run: |
-        sed -i "/maven.*aliyun/d" build.gradle
-        sed -i "/maven.*aliyun/d" settings.gradle
-
     # google_oauth_secret.dart is gitignored (the real client secret lives only
     # on dev hosts); CI lacks it, so google_drive_auth.dart's import fails
     # `flutter analyze`. When the GOOGLE_OAUTH_CLIENT_SECRET repo secret is set,
@@ -148,29 +142,28 @@ jobs:
           rm -f "$dst.bak"
         fi
 
-    # TODO-1208: cache the resolved pub packages so pub get is near-instant on a
-    # warm runner. apply-patches.sh is idempotent (cp -r overwrite), so a restored
-    # already-patched cache re-patches to the same bytes. Cache miss auto-rebuilds.
-    - name: Cache pub packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.pub-cache
-        key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-pubcache-
-
-    # TODO-1208: cache Gradle's dependency + wrapper caches for the PR-only
-    # release-verify APK build. Keyed on the gradle build/wrapper files so a
-    # toolchain bump invalidates it; a miss just re-downloads.
+    # TODO-2721: 只缓存 Gradle 的下载物（modules-2 / wrapper dists），不缓存
+    # <ver>/transforms 这类可从 modules-2 重算的派生产物。三个 workflow
+    # （main / release / build-multiplatform）的 path + key 必须逐字相同，且此步
+    # 之前不得 sed 改 build.gradle / settings.gradle —— 否则同一份内容会被存成
+    # 两条各 2.7 GB 的缓存。理由见 docs/agent/build.md 的「CI 缓存配额」，守卫见
+    # hibiki/test/build/workflow_cache_quota_guard_test.dart。
     - name: Cache Gradle caches
       uses: actions/cache@v4
       with:
         path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('hibiki/android/**/*.gradle*', 'hibiki/android/gradle/wrapper/gradle-wrapper.properties') }}
+          ~/.gradle/caches/modules-2
+          ~/.gradle/caches/journal-1
+          ~/.gradle/wrapper/dists
+        key: ${{ runner.os }}-gradle-v2-${{ hashFiles('hibiki/android/**/*.gradle*', 'hibiki/android/gradle/wrapper/gradle-wrapper.properties') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-
+          ${{ runner.os }}-gradle-v2-
+
+    - name: Remove aliyun mirrors from gradle files
+      working-directory: hibiki/android
+      run: |
+        sed -i "/maven.*aliyun/d" build.gradle
+        sed -i "/maven.*aliyun/d" settings.gradle
 
     - name: Flutter pub get
       working-directory: hibiki

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -279,15 +279,6 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
-      # TODO-1208: cache resolved pub packages. Windows Dart pub cache defaults to
-      # %LOCALAPPDATA%\Pub\Cache (apply-patches.sh resolves the same path).
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~\AppData\Local\Pub\Cache
-          key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pubcache-
       # TODO-1208: cache media_kit's pre-built libmpv + ANGLE .7z archives it
       # downloads from GitHub into the CMake binary dir (hibiki/build/windows/x64).
       # media_kit's download_and_verify skips the download when the archive exists
@@ -894,14 +885,6 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
-      # TODO-1208: cache resolved pub packages (macOS/iOS default ~/.pub-cache).
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pubcache-
       # TODO-1208: cache CocoaPods spec repos + downloaded pod source and the
       # generated Pods dirs. Keyed on the Podfile.lock/pubspec.lock so a pod bump
       # invalidates it; CocoaPods re-installs on a mismatch, and a miss just
@@ -1225,14 +1208,6 @@ jobs:
           elif [ ! -f "$dst" ]; then
             cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
           fi
-      # TODO-1208: cache resolved pub packages (macOS/iOS default ~/.pub-cache).
-      - name: Cache pub packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pubcache-
       # TODO-1208: cache CocoaPods spec repos + downloaded pod source and the
       # generated Pods dirs. Keyed on the Podfile.lock/pubspec.lock so a pod bump
       # invalidates it; CocoaPods re-installs on a mismatch, and a miss just

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,12 +300,6 @@ jobs:
         sed -i '/systemProp\.https\.proxyPort/d' gradle.properties
         sed -i '/systemProp\.http\.nonProxyHosts/d' gradle.properties
 
-    - name: Remove aliyun mirrors from gradle files
-      working-directory: hibiki/android
-      run: |
-        sed -i "/maven.*aliyun/d" build.gradle
-        sed -i "/maven.*aliyun/d" settings.gradle
-
     # google_oauth_secret.dart is gitignored (the real client secret lives only
     # on dev hosts); CI lacks it, so google_drive_auth.dart's import fails
     # `flutter analyze`. When the GOOGLE_OAUTH_CLIENT_SECRET repo secret is set,
@@ -373,26 +367,28 @@ jobs:
           cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
         fi
 
-    # TODO-1208: cache resolved pub packages + Gradle caches to shave minutes off
-    # every push/release build. apply-patches.sh is idempotent so a warm cache is
-    # safe; a miss auto-rebuilds. Keyed on lockfiles/gradle files.
-    - name: Cache pub packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.pub-cache
-        key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-pubcache-
-
+    # TODO-2721: 只缓存 Gradle 的下载物（modules-2 / wrapper dists），不缓存
+    # <ver>/transforms 这类可从 modules-2 重算的派生产物。三个 workflow
+    # （main / release / build-multiplatform）的 path + key 必须逐字相同，且此步
+    # 之前不得 sed 改 build.gradle / settings.gradle —— 否则同一份内容会被存成
+    # 两条各 2.7 GB 的缓存。理由见 docs/agent/build.md 的「CI 缓存配额」，守卫见
+    # hibiki/test/build/workflow_cache_quota_guard_test.dart。
     - name: Cache Gradle caches
       uses: actions/cache@v4
       with:
         path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('hibiki/android/**/*.gradle*', 'hibiki/android/gradle/wrapper/gradle-wrapper.properties') }}
+          ~/.gradle/caches/modules-2
+          ~/.gradle/caches/journal-1
+          ~/.gradle/wrapper/dists
+        key: ${{ runner.os }}-gradle-v2-${{ hashFiles('hibiki/android/**/*.gradle*', 'hibiki/android/gradle/wrapper/gradle-wrapper.properties') }}
         restore-keys: |
-          ${{ runner.os }}-gradle-
+          ${{ runner.os }}-gradle-v2-
+
+    - name: Remove aliyun mirrors from gradle files
+      working-directory: hibiki/android
+      run: |
+        sed -i "/maven.*aliyun/d" build.gradle
+        sed -i "/maven.*aliyun/d" settings.gradle
 
     - name: Flutter pub get
       working-directory: hibiki
@@ -848,14 +844,6 @@ jobs:
         elif [ ! -f "$dst" ]; then
           cp hibiki/lib/src/media/video/dandanplay_secret.example.dart "$dst"
         fi
-
-    - name: Cache pub packages
-      uses: actions/cache@v4
-      with:
-        path: ~/.pub-cache
-        key: ${{ runner.os }}-pubcache-${{ hashFiles('**/pubspec.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-pubcache-
 
     - name: Flutter pub get
       working-directory: hibiki

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -63,6 +63,52 @@ Flutter 版本号以 `hibiki/pubspec.yaml` 的 `version: X.Y.Z+build` 为准。�
 - 纯文档、PM 元数据、不影响分发行为的 CI 维护不强制 bump；发布、安装包或运行行为变化应 bump。
 - 发布 workflow 修改后必须运行 `tool/check_release_policy.ps1`（Windows：`powershell -NoProfile -ExecutionPolicy Bypass -File tool/check_release_policy.ps1`；GitHub Actions 用 `pwsh`）。该守卫会拒绝重新引入 workflow-local run number、缺失完整历史 checkout、缺失同 tag/commit 发布并发锁，或文档缺少 cross-workflow release sequence / single GitHub Release 规则。
 
+## CI 缓存配额（TODO-2721）
+
+GitHub Actions 给每个仓库的缓存配额是**硬上限 10 GB**，超了就按 LRU 静默驱逐。
+驱逐不是洁癖问题：桌面发布 run `30729229450` 变红的最后一环就是 vcpkg 缓存被驱逐
+后冷编 + 拉外部镜像失败。2026-08-02 实测 `gh api
+repos/hajisensai/hibiki/actions/cache/usage` = **10.65 GB / 14 条**，长期在驱逐。
+
+三条铁律（守卫 `hibiki/test/build/workflow_cache_quota_guard_test.dart`）：
+
+1. **pub cache 只准存一份，由 `subosito/flutter-action@v2` 存。**
+   它的 `cache: true` 不只缓存 Flutter SDK，还会额外挂一个
+   `Cache pub dependencies` 步骤把 `~/.pub-cache`（Windows 是
+   `%LOCALAPPDATA%\Pub\Cache`）存成
+   `flutter-pub-<os>-<channel>-<ver>-<arch>-<pubspec.lock hash>`。
+   workflow 里再挂 `actions/cache` 存同一个目录只是换个 key 名存第二遍：实测
+   `flutter-pub-linux-…-3fa29c49` = 149,357,387 B 与
+   `Linux-pubcache-3fa29c49` = 149,365,205 B，同一批字节，三平台白占 447 MB，
+   每个作业还要多解压一次（6~32 s）。**不要再加 `Cache pub packages` 步骤。**
+2. **Gradle 缓存三处必须逐字相同，且缓存步骤排在改 `*.gradle` 的 sed 前面。**
+   `hashFiles()` 算的是**当时磁盘上**的内容。`main.yml` / `release.yml` 原先在缓存
+   步骤之前就 `sed -i` 删掉了 `build.gradle` / `settings.gradle` 里的 aliyun 镜像行，
+   而 `build-multiplatform.yml` 的同名 sed 在缓存步骤之后 —— 于是同一份内容被存成
+   两条 key：`Linux-gradle-6facc6ed…`(2,901,298,096 B) 与
+   `Linux-gradle-5709404c…`(2,901,388,049 B)，差 89,953 B，白占 2.7 GB。
+3. **Gradle 只缓存下载物，不缓存派生产物。**
+   `~/.gradle/caches` 全量含 `<ver>/transforms`（解包 AAR / jetify / desugar 输出），
+   本机实测 5,073.7 MB，是 `modules-2`(1,937.2 MB) 的 2.6 倍，而它能从 modules-2
+   重算。只列 `~/.gradle/caches/modules-2` + `~/.gradle/caches/journal-1` +
+   `~/.gradle/wrapper/dists`。key 前缀带 `-v2-` 是为了让 `restore-keys` 够不到旧的
+   胖缓存（否则每次先白拉 2.7 GB）。
+
+另外：GitHub 缓存**按 ref 分桶**，`refs/pull/<N>/merge` 与 `refs/heads/develop` 上
+同 key 是两条独立记录。正常 PR run 会命中 base 分支的缓存不新存，但仓库一旦超配额、
+develop 那条被驱逐，下一个 PR run 就 miss 并在自己的 PR 桶里存一份 —— 越紧越复制，
+是正反馈。`.github/workflows/cache-cleanup.yml` 在 PR 关闭时立刻删掉该 PR 桶
+（GitHub 自己要等 7 天无访问才回收），并把当前用量写进 step summary。
+
+查用量与逐条明细：
+
+```bash
+gh api repos/hajisensai/hibiki/actions/cache/usage
+gh api "repos/hajisensai/hibiki/actions/caches?per_page=100"   --jq '.actions_caches[] | "\(.size_in_bytes) \(.ref) \(.key)"' | sort -rn
+```
+
+删存量缓存前先确认没有 in-flight 的 run 在用它（`gh run list --status in_progress`）。
+
 ## 依赖补丁
 
 Flutter 3.44.0 下部分上游依赖未适配，两种补法并存（对个别包**有重叠**）：

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -81,6 +81,11 @@ repos/hajisensai/hibiki/actions/cache/usage` = **10.65 GB / 14 条**，长期在
    `flutter-pub-linux-…-3fa29c49` = 149,357,387 B 与
    `Linux-pubcache-3fa29c49` = 149,365,205 B，同一批字节，三平台白占 447 MB，
    每个作业还要多解压一次（6~32 s）。**不要再加 `Cache pub packages` 步骤。**
+   代价说清楚：flutter-action 那条 pub 缓存**没有 `restore-keys`**（实测其
+   `actions/cache@v5` 输入里只有 `key`），所以 `pubspec.lock` 一变就是全冷，
+   `flutter pub get` 要重下约 150 MB；旧的 `<OS>-pubcache-` 前缀能给个部分命中。
+   这是有意取舍：换来的是 447 MB 永久配额 + 每作业少一次解压，而 lockfile 变更
+   本来就不频繁，且那时重新解析依赖并不亏。
 2. **Gradle 缓存三处必须逐字相同，且缓存步骤排在改 `*.gradle` 的 sed 前面。**
    `hashFiles()` 算的是**当时磁盘上**的内容。`main.yml` / `release.yml` 原先在缓存
    步骤之前就 `sed -i` 删掉了 `build.gradle` / `settings.gradle` 里的 aliyun 镜像行，

--- a/hibiki/test/build/workflow_cache_quota_guard_test.dart
+++ b/hibiki/test/build/workflow_cache_quota_guard_test.dart
@@ -1,0 +1,308 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+/// TODO-2721 守卫：GitHub Actions 缓存必须留在 10 GB 配额里。
+///
+/// 2026-08-02 实测 `gh api repos/hajisensai/hibiki/actions/cache/usage` =
+/// 10.65 GB / 14 条，超配额，GitHub 一直在 LRU 驱逐。驱逐不是「洁癖问题」：
+/// 桌面发布 run 30729229450 变红的最后一环就是 vcpkg 缓存被驱逐后冷编 + 拉网失败。
+///
+/// 超配额是三条规则叠出来的，本守卫逐条钉死：
+///
+/// 1. **同一份 pub cache 被存了两遍。** `subosito/flutter-action@v2` 的
+///    `cache: true` 自己就会把 `~/.pub-cache` 存成
+///    `flutter-pub-<os>-<channel>-<ver>-<arch>-<pubspec.lock hash>`；workflow 里
+///    再挂一个 `actions/cache` 存同一个目录，只是换了个 key 名。实测
+///    `flutter-pub-linux-...-3fa29c49` = 149,357,387 B 与
+///    `Linux-pubcache-3fa29c49` = 149,365,205 B——同一批字节，两条记录，
+///    三平台合计白占 447 MB，且每个作业还要多花 6~32 s 重复解压一次。
+///    ⇒ 任何 workflow 都不许再为 pub cache 目录挂 `actions/cache`。
+///
+/// 2. **同一份 Gradle 缓存被存了两遍。** `main.yml` / `release.yml` 在缓存步骤
+///    **之前**用 `sed -i` 删掉了 `build.gradle` / `settings.gradle` 里的 aliyun
+///    镜像行，而 `build-multiplatform.yml` 的同名 sed 在缓存步骤**之后**。
+///    两边 `hashFiles('hibiki/android/**/*.gradle*')` 因此算在不同内容上，
+///    产出两条 key：`Linux-gradle-6facc6ed…`（2,901,298,096 B）与
+///    `Linux-gradle-5709404c…`（2,901,388,049 B）——差 89,953 B，实质同一份，
+///    白占 2.7 GB。⇒ 三个 workflow 的 Gradle 缓存 path + key 必须逐字相同，
+///    且缓存步骤必须排在那些 sed **前面**。
+///
+/// 3. **Gradle 缓存里塞了派生产物。** `~/.gradle/caches` 全量含
+///    `<ver>/transforms`（解包 AAR / jetify / desugar 的输出）。本机实测
+///    `~/.gradle/caches/8.14.2/transforms` = 5,073.7 MB，是
+///    `~/.gradle/caches/modules-2`（1,937.2 MB）的 2.6 倍，而它完全可以从
+///    modules-2 重算。⇒ 只缓存下载物（`modules-2` / `wrapper/dists`）
+///    加一个记账用的 `journal-1`，不缓存整个 `~/.gradle/caches`。
+void main() {
+  final Directory workflowsDir = Directory('../.github/workflows');
+
+  test('workflows 目录存在', () {
+    expect(workflowsDir.existsSync(), isTrue,
+        reason: 'expected ${workflowsDir.absolute.path}');
+  });
+
+  final List<File> workflows = workflowsDir.existsSync()
+      ? (workflowsDir
+          .listSync()
+          .whereType<File>()
+          .where(
+              (File f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
+          .toList()
+        ..sort((File a, File b) => a.path.compareTo(b.path)))
+      : <File>[];
+
+  /// 一个 workflow 步骤块：`- name:` / `- uses:` 起头，延伸到下一个同缩进
+  /// （或更浅）的列表项。行号是 0 基，指向原文。
+  final List<_CacheStep> allCacheSteps = <_CacheStep>[];
+
+  /// 每个 workflow 里「用 sed 改 build.gradle / settings.gradle」的最早行号。
+  final Map<String, int> earliestGradleSed = <String, int>{};
+
+  final RegExp stepHeader = RegExp(r'^(\s*)-\s+(name|uses):');
+  final RegExp pathKey = RegExp(r'^(\s*)path:\s*(.*)$');
+  final RegExp keyLine = RegExp(r'^\s*key:\s*(.*)$');
+  final RegExp restoreKeysLine = RegExp(r'^\s*restore-keys:\s*(.*)$');
+  // `sed ... build.gradle` / `sed ... settings.gradle`（就地编辑与否都算：任何
+  // 对这两个文件的 sed 改写都会污染 hashFiles）。
+  final RegExp gradleSed = RegExp(r'\bsed\b[^\n]*\b(build|settings)\.gradle\b');
+
+  for (final File workflow in workflows) {
+    final String name = workflow.uri.pathSegments.last;
+    final String source = workflow.readAsStringSync();
+    final List<String> raw = source.split('\n');
+    // 注释不是配置：整块扫描前先掩成等长空白，免得注释里写的
+    // `~/.gradle/caches` / `path: ~/.pub-cache` 把守卫骗绿或骗红。
+    final List<String> masked = maskHashComments(source).split('\n');
+
+    for (int i = 0; i < masked.length; i++) {
+      if (gradleSed.hasMatch(masked[i])) {
+        earliestGradleSed[name] = earliestGradleSed[name] == null
+            ? i
+            : (earliestGradleSed[name]! < i ? earliestGradleSed[name]! : i);
+      }
+
+      final RegExpMatch? header = stepHeader.firstMatch(masked[i]);
+      if (header == null) continue;
+      final int indent = header.group(1)!.length;
+
+      // 步骤块 = 从本行到下一个缩进 <= indent 的列表项 / 更浅的 key 行。
+      int end = masked.length;
+      for (int j = i + 1; j < masked.length; j++) {
+        final String line = masked[j];
+        if (line.trim().isEmpty) continue;
+        final int lead = line.length - line.trimLeft().length;
+        if (lead <= indent) {
+          end = j;
+          break;
+        }
+      }
+      final List<String> block = masked.sublist(i, end);
+      if (!block.any((String l) => l.contains('uses: actions/cache@'))) {
+        continue;
+      }
+
+      // path: 可能是标量，也可能是 `|` 块。
+      final List<String> paths = <String>[];
+      for (int j = 0; j < block.length; j++) {
+        final RegExpMatch? pm = pathKey.firstMatch(block[j]);
+        if (pm == null) continue;
+        final String inline = pm.group(2)!.trim();
+        if (inline.isNotEmpty && inline != '|' && inline != '|-') {
+          paths.add(inline);
+          continue;
+        }
+        final int pathIndent = pm.group(1)!.length;
+        for (int k = j + 1; k < block.length; k++) {
+          final String line = block[k];
+          if (line.trim().isEmpty) continue;
+          final int lead = line.length - line.trimLeft().length;
+          if (lead <= pathIndent) break;
+          paths.add(line.trim());
+        }
+      }
+
+      String keyText = '';
+      for (final String line in block) {
+        final RegExpMatch? km = keyLine.firstMatch(line);
+        if (km != null) {
+          keyText = km.group(1)!.trim();
+          break;
+        }
+      }
+      final List<String> restoreKeys = <String>[];
+      for (int j = 0; j < block.length; j++) {
+        if (!restoreKeysLine.hasMatch(block[j])) continue;
+        final int rkIndent = block[j].length - block[j].trimLeft().length;
+        for (int k = j + 1; k < block.length; k++) {
+          final String line = block[k];
+          if (line.trim().isEmpty) continue;
+          final int lead = line.length - line.trimLeft().length;
+          if (lead <= rkIndent) break;
+          restoreKeys.add(line.trim());
+        }
+        break;
+      }
+
+      allCacheSteps.add(_CacheStep(
+        workflow: name,
+        line: i + 1,
+        header: raw[i].trim(),
+        paths: paths,
+        key: keyText,
+        restoreKeys: restoreKeys,
+      ));
+    }
+  }
+
+  test('扫描到了 actions/cache 步骤（守卫没跑空）', () {
+    expect(allCacheSteps, isNotEmpty,
+        reason: '一个 actions/cache 步骤都没扫到，说明块切分坏了或 workflow 改版了；'
+            '本守卫的其余断言此时全部无意义。');
+  });
+
+  test('没有 workflow 再为 pub cache 目录挂第二个 actions/cache', () {
+    // flutter-action 的 `cache: true` 已经存过这两个目录（Linux/macOS 是
+    // ~/.pub-cache，Windows 是 %LOCALAPPDATA%\Pub\Cache）。
+    bool isPubCachePath(String p) {
+      final String v = p.toLowerCase().replaceAll(r'\', '/');
+      return v.contains('.pub-cache') ||
+          (v.contains('appdata/local/pub/cache'));
+    }
+
+    final List<String> offenders = allCacheSteps
+        .where((_CacheStep s) => s.paths.any(isPubCachePath))
+        .map((_CacheStep s) => '${s.workflow}:${s.line} ${s.header} '
+            '(path: ${s.paths.join(", ")})')
+        .toList();
+
+    expect(offenders, isEmpty,
+        reason: 'subosito/flutter-action@v2 的 `cache: true` 已经把 pub cache 存成 '
+            '`flutter-pub-<os>-...-<pubspec.lock hash>` 了；再挂一个 actions/cache 只是'
+            '把同一批字节换个 key 名存第二遍，白占 GitHub 那 10 GB 配额（三平台 447 MB）'
+            '并让每个作业多解压一次。删掉这些步骤：\n${offenders.join("\n")}');
+  });
+
+  group('Gradle 缓存', () {
+    final List<_CacheStep> gradleSteps = allCacheSteps
+        .where((_CacheStep s) => s.key.contains('-gradle-'))
+        .toList();
+
+    test('三个 Android workflow 各有且仅有一个 Gradle 缓存步骤', () {
+      final List<String> owners =
+          gradleSteps.map((_CacheStep s) => s.workflow).toList()..sort();
+      expect(
+          owners,
+          equals(<String>[
+            'build-multiplatform.yml',
+            'main.yml',
+            'release.yml',
+          ]),
+          reason: 'Gradle 缓存步骤的归属变了。多一个 workflow 存 Gradle 缓存就多一条 '
+              '2.7 GB 级记录，改动前先算配额；少一个则说明本守卫已失去锚点。'
+              '实际扫到：$owners');
+    });
+
+    test('三处的 path + key + restore-keys 逐字相同', () {
+      final Set<String> shapes = gradleSteps
+          .map((_CacheStep s) => 'path=${s.paths.join("|")} key=${s.key} '
+              'restore=${s.restoreKeys.join("|")}')
+          .toSet();
+      expect(shapes.length, 1,
+          reason: 'Gradle 缓存 key 只要有一处不同，同一份 2.7 GB 内容就会被存成两条。'
+              'develop 上真发生过：`Linux-gradle-6facc6ed…` 与 '
+              '`Linux-gradle-5709404c…` 只差 89,953 B。当前形状：\n'
+              '${gradleSteps.map((_CacheStep s) => "${s.workflow}:${s.line} "
+                  "path=${s.paths} key=${s.key}").join("\n")}');
+    });
+
+    test('只缓存下载物，不缓存 transforms 之类的派生产物', () {
+      final List<String> offenders = <String>[];
+      for (final _CacheStep step in gradleSteps) {
+        for (final String p in step.paths) {
+          final String v = p.trim();
+          // 整个 ~/.gradle/caches（或 ~/.gradle）会把 <ver>/transforms 一起吞进来。
+          if (v == '~/.gradle' ||
+              v == '~/.gradle/' ||
+              v == '~/.gradle/caches' ||
+              v == '~/.gradle/caches/') {
+            offenders.add('${step.workflow}:${step.line} path 含 "$v"');
+          }
+        }
+      }
+      expect(offenders, isEmpty,
+          reason: '`~/.gradle/caches` 全量里 `<ver>/transforms` 是可从 modules-2 '
+              '重算的构建产物（本机实测 5,073.7 MB vs modules-2 的 1,937.2 MB）。'
+              '缓存它是拿配额换 CPU，而配额才是本仓的瓶颈。只列 '
+              '`~/.gradle/caches/modules-2` / `~/.gradle/caches/journal-1` / '
+              '`~/.gradle/wrapper/dists`：\n${offenders.join("\n")}');
+    });
+
+    test('Gradle 缓存步骤必须排在改写 build.gradle/settings.gradle 的 sed 前面', () {
+      // 反向锚：那些 sed 还在，才说明这条排序断言仍有对象可查。
+      expect(
+          earliestGradleSed.keys.toSet(),
+          containsAll(
+              <String>['build-multiplatform.yml', 'main.yml', 'release.yml']),
+          reason: '三个 workflow 里删 aliyun 镜像的 sed 消失了？若注入方式改版请同步'
+              '更新本守卫，别让它空转。实际：${earliestGradleSed.keys.toList()..sort()}');
+
+      final List<String> offenders = <String>[];
+      for (final _CacheStep step in gradleSteps) {
+        final int? sedLine = earliestGradleSed[step.workflow];
+        if (sedLine == null) continue;
+        if (sedLine + 1 < step.line) {
+          offenders.add('${step.workflow}: sed 在第 ${sedLine + 1} 行，'
+              'Gradle 缓存步骤在第 ${step.line} 行');
+        }
+      }
+      expect(offenders, isEmpty,
+          reason: 'hashFiles() 算的是**当时磁盘上**的内容。sed 改过 build.gradle / '
+              'settings.gradle 之后再算 key，得到的哈希与「没改过」的 workflow 不同，'
+              '同一份 Gradle 缓存就被存成两条 2.7 GB 记录。把 sed 步骤挪到缓存步骤'
+              '之后（gradle 真正跑起来之前即可）：\n${offenders.join("\n")}');
+    });
+  });
+
+  test('PR 关闭后回收 PR 作用域缓存的 workflow 还在，且不碰发布', () {
+    final File cleanup = File('../.github/workflows/cache-cleanup.yml');
+    expect(cleanup.existsSync(), isTrue,
+        reason: 'cache-cleanup.yml 是把 refs/pull/<N>/merge 桶还给配额的唯一入口；'
+            'GitHub 自己要等 7 天无访问才回收。');
+    final String masked = maskHashComments(cleanup.readAsStringSync());
+    expect(masked, contains('actions/caches'),
+        reason: '清理步骤必须真的调 DELETE /actions/caches');
+    // 这条 workflow 只做回收，绝不能长出发布动作（CLAUDE.md 发布通道硬规则）。
+    for (final String forbidden in <String>[
+      'softprops/action-gh-release',
+      'gh release create',
+      'make_latest',
+    ]) {
+      expect(masked.contains(forbidden), isFalse,
+          reason: 'cache-cleanup.yml 不得触碰发布链路，发现：$forbidden');
+    }
+  });
+}
+
+/// 一个 `actions/cache` 步骤的规范化形状。
+class _CacheStep {
+  const _CacheStep({
+    required this.workflow,
+    required this.line,
+    required this.header,
+    required this.paths,
+    required this.key,
+    required this.restoreKeys,
+  });
+
+  final String workflow;
+
+  /// 1 基行号（指向 `- name:` / `- uses:` 那行）。
+  final int line;
+  final String header;
+  final List<String> paths;
+  final String key;
+  final List<String> restoreKeys;
+}


### PR DESCRIPTION
## 问题

`gh api repos/hajisensai/hibiki/actions/cache/usage` = **10.65 GB / 14 条**，GitHub 每仓上限 10 GB，一直在 LRU 驱逐。

驱逐有实际后果：桌面发布 run `30729229450` 变红的根因链最后一环就是 vcpkg 缓存被驱逐后冷编 + 拉外部镜像失败。PR#757 修好 key 常量问题后**还会再加约 916 MB**，压力只会更大。

## 根因（三条产生规则，不是「删几条了事」）

### 1. 同一份 pub cache 存了两遍 — 447 MB

`subosito/flutter-action@v2` 的 `cache: true` 不只缓存 Flutter SDK：它自带一个 `Cache pub dependencies` 步骤，把 `~/.pub-cache`（Windows 是 `%LOCALAPPDATA%\Pub\Cache`）存成 `flutter-pub-<os>-<channel>-<ver>-<arch>-<pubspec.lock hash>`。日志实证（run 30740890240 / android job）：

```
Cache hit for: flutter-pub-linux-stable-3.44.0-x64-559ffa3f…-3fa29c49…
Cache Size: ~142 MB (149,357,387 B)
...紧接着...
Cache hit for: Linux-pubcache-3fa29c49…
Cache Size: ~142 MB (149,365,205 B)
```

同一批字节、同一个 `pubspec.lock` 哈希后缀，两条记录差 7,818 B。11 个 workflow 作业全都这么干，三平台合计白占 **447 MB**，每个作业还要多解压一次（实测 6~32 s）。

⇒ 删掉全部 11 个 `Cache pub packages` 步骤。

### 2. 同一份 Gradle 缓存存了两遍 — 2,767 MB

`main.yml` / `release.yml` 在缓存步骤**之前**就 `sed -i` 删掉了 `build.gradle`(7 行) / `settings.gradle`(3 行) 里的 aliyun 镜像行；`build-multiplatform.yml` 的同名 sed 在缓存步骤**之后**。`hashFiles('hibiki/android/**/*.gradle*')` 算的是**当时磁盘上**的内容，于是两边得到不同哈希：

| workflow | 日志实证 | key | size |
|---|---|---|---|
| `release.yml` build job | job 91478006244 | `Linux-gradle-6facc6ed…` | 2,901,298,096 B |
| `build-multiplatform.yml` android job | job 91478006350 | `Linux-gradle-5709404c…` | 2,901,388,049 B |

差 **89,953 B** — 实质同一份内容，存了两条 2.7 GB。

⇒ 把两处 sed 挪到缓存步骤之后（gradle 真正跑起来之前即可，中间只有 `flutter pub get` / `apply-patches`），三处 key 归一。

### 3. Gradle 缓存里装的是派生产物 — 主项 5 GB 级

`~/.gradle/caches` 全量的构成（本机 `C:\Users\wrds\.gradle`，同一个项目、同一 Gradle 8.14.2）：

| 目录 | 大小 |
|---|---|
| `caches/8.14.2/transforms` | **5,073.7 MB** |
| `caches/modules-2` | 1,937.2 MB |
| `caches/8.14.2/generated-gradle-jars` | 176.7 MB |
| `caches/8.14.2/javaCompile` + `kotlin-dsl` + `fileHashes` + `groovy-dsl` | 57.9 MB |
| `caches/jars-9` + `journal-1` | 7.6 MB |

`transforms` 是解包 AAR / jetify / desugar 的**输出**，可以从 `modules-2` 重算 —— 缓存它是拿配额换 CPU，而配额才是本仓的瓶颈。

⇒ 改成只列 `~/.gradle/caches/modules-2` + `~/.gradle/caches/journal-1` + `~/.gradle/wrapper/dists`；key 前缀带 `-v2-`，让 `restore-keys` 够不到旧胖缓存（否则每次先白拉 2.7 GB）。

### 附带：为什么会出现「两条同前缀 flutter-windows」

GitHub 缓存**按 ref 分桶**：`refs/pull/<N>/merge` 与 `refs/heads/develop` 上同 key 是两条独立记录（本仓当下就能看到 `refs/pull/757/merge` 上有两条 vcpkg 缓存）。flutter-action 的 key 模板尾部没有可变分量，所以同前缀只可能是不同 ref。正常 PR run 会命中 base 分支不新存；但仓库超配额 → develop 那条被驱逐 → 下个 PR run miss 并在自己桶里存一份 —— **越紧越复制，是正反馈**。

⇒ 新增 `.github/workflows/cache-cleanup.yml`：PR 关闭时立刻删掉该 PR 桶（GitHub 自己要等 7 天无访问才回收），并把当前用量写进 step summary。无 checkout、无构建、无 release。

## 配额算式

PR#757 落地后的稳态（develop 桶，全部 key 命中）：

```
2767 gradle(pristine hash)  + 2767 gradle(sed hash)
2078 flutter-macos SDK      + 1804 flutter-windows SDK + 1609 flutter-linux SDK
 835 vcpkg-downloads        +   81 vcpkg-bin-v2        +   81 vcpkg-bin-v1(废弃)
 164 flutter-pub-macos      +  164 macOS-pubcache
 147 flutter-pub-windows    +  147 Windows-pubcache
 142 flutter-pub-linux      +  142 Linux-pubcache
   8 macOS-pods
= 12,936 MB (126% 配额)
```

改后：

```
12,936 − 2,767 (重复 gradle) − 453 (重复 pubcache) − 81 (废弃 vcpkg v1)
      = 9,635 MB  ← 只靠「删除项」，不依赖任何估算，已 < 10,240 MB
```

再叠第 3 条（gradle 那条从 2,767 MB 降到 X）：`6,868 + X`。X 的量级只能由 CI 实测，本 PR 的 build-multiplatform run 会给出真值。

## 验证：验到哪一层

| 层 | 结论 |
|---|---|
| **实证（GitHub API + CI 日志）** | 两条 gradle key 的成因与字节数、pub cache 双存的字节数、ref 分桶存在性 — 全部来自 `gh api` 与 job 91478006244 / 91478006350 / 91477942000 的原始日志 |
| **本地实测** | Gradle 缓存构成（transforms 5,073.7 MB vs modules-2 1,937.2 MB）来自本机 `~/.gradle` 实测；YAML 全部 `yaml.safe_load` 通过；守卫 5 处变异全部报红 |
| **CI 实证（本 PR 跑完才有）** | 改后 gradle 缓存的真实压缩体积 X、pub cache 删除后 `flutter pub get` 是否仍走缓存。触发的 `build-multiplatform.yml` / `main.yml` 已确认零 `softprops` / 零 `gh release` / 零 `make_latest`，是纯 artifact workflow |
| **推断（未验证）** | ①「两条同前缀 flutter-windows = 不同 ref」是从「key 模板无可变尾缀 + 本仓确实存在 PR 桶 + 驱逐确实在发生」推出的，没有留存那条已被驱逐记录的直接证据；② 排除 transforms 后 Android 构建会多花多少 artifact-transform 时间，未量化 |

## 白占的缓存（实测依据）

- **`<OS>-pubcache-*`（447 MB）**：与 flutter-action 的 `flutter-pub-*` 逐字节等价，纯重复。已删。
- **废弃的 `Windows-vcpkg-libtorrent-x64-windows-v1`（81 MB）**：PR#757 已把 key 换成带镜像版本的 v2，v1 再也不会被主 key 命中。
- **`Windows-mediakit7z-*`（0 B）**：三次 run 日志里全是 `Cache not found for input keys: Windows-mediakit7z-…, Windows-mediakit7z-`，连 restore-key 前缀都没有 —— 说明它从来没存进去过（`hibiki/build/windows/x64/*.7z` 在保存时不存在）。**本 PR 未动它**：它占 0 配额，删它属于另一个问题（要么修好路径要么删步骤），不该混进配额 PR。

## 本地门禁

- `flutter analyze`（含 test）→ `No issues found! (ran in 53.5s)`
- 35 条整批 → `FLUTTER TEST VERDICT: PASSED - 207 tests ran, all tests passed`（N 基线 207；结构判据：jsonl 里 suites loaded = 35/35，无缺失/空 suite）
- workflow/.ps1 条件加跑（`workflow_sed_inplace_portability_guard` + `powershell_51_compat_guard` + `magpie_bundled_install` + 本 PR 新守卫）→ `FLUTTER TEST VERDICT: PASSED - 40 tests ran`
- `tool/check_release_policy.ps1` → `Release policy guard passed.`

## 合并后的收尾（不在本 PR 做）

存量缓存现在**还不能删**：develop 上跑的仍是旧 key，PR#757 也还开着。合入 develop 后再跑一次（先 `gh run list --status in_progress` 确认没有 run 在用）：

```bash
gh api "repos/hajisensai/hibiki/actions/caches?per_page=100" \
  --jq '.actions_caches[] | select(.key | test("-pubcache-|^Linux-gradle-(?!v2)|vcpkg-libtorrent-x64-windows-v1$")) | "\(.id) \(.key)"'
# 逐条 gh api -X DELETE repos/hajisensai/hibiki/actions/caches/<id>
```

不删也行：7 天无访问后 GitHub 自己会回收，只是这 7 天里配额仍紧。
