### PR TITLE
fix(mihon): /inspect 不再在用户同意前执行扩展代码；端口改由子进程自报；/source-image 加缓冲上限

### DIFF
--- a/hibiki/lib/src/media/manga/mihon/desktop_mihon_runtime.dart
+++ b/hibiki/lib/src/media/manga/mihon/desktop_mihon_runtime.dart
@@ -301,10 +301,6 @@ class DesktopMihonRuntime extends MihonBridgeRuntime
     final Directory preferences =
         Directory(p.join(dataDirectory.path, 'preferences'));
     await preferences.create(recursive: true);
-    final ServerSocket socket =
-        await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-    final int port = socket.port;
-    await socket.close();
     final Random random = Random.secure();
     final String token = base64UrlEncode(
       List<int>.generate(32, (_) => random.nextInt(256)),
@@ -317,7 +313,13 @@ class DesktopMihonRuntime extends MihonBridgeRuntime
         '-Djava.util.prefs.userRoot=${preferences.path}',
         '-jar',
         server.path,
-        '$port',
+        // 0 = "bind an ephemeral port yourself and tell us which one".
+        // Picking the port here (bind → read → close → hand the number over)
+        // is a TOCTOU: between our close and the child's bind any other local
+        // process can take that port, and we would then hand our per-process
+        // Bearer token to a stranger. It also made a benign port collision
+        // fail the whole start with START_TIMEOUT.
+        '0',
         dataDirectory.path,
       ],
       environment: <String, String>{'HIBIKI_MIHON_TOKEN': token},
@@ -352,11 +354,24 @@ class DesktopMihonRuntime extends MihonBridgeRuntime
       );
     }
     _process = process;
-    _port = port;
     _token = token;
-    process.stdout.listen((List<int> _) {});
+
+    // The child prints its real listening port once NanoHTTPD has bound it.
+    // `null` means "it will never arrive" (the process is gone).
+    final Completer<int?> announced = Completer<int?>();
+    // Never cancelled: stdout has to keep being drained or the pipe fills up
+    // and blocks the JVM.
+    process.stdout
+        .transform(const Utf8Decoder(allowMalformed: true))
+        .transform(const LineSplitter())
+        .listen((String line) {
+      if (announced.isCompleted) return;
+      final int? port = _parseReadyPort(line);
+      if (port != null) announced.complete(port);
+    });
     process.stderr.listen((List<int> _) {});
     unawaited(process.exitCode.then((int _) {
+      if (!announced.isCompleted) announced.complete(null);
       if (identical(_process, process)) {
         _process = null;
         _port = null;
@@ -365,8 +380,29 @@ class DesktopMihonRuntime extends MihonBridgeRuntime
     }));
 
     final DateTime deadline = DateTime.now().add(const Duration(seconds: 20));
+    final int? readyPort = await announced.future.timeout(
+      const Duration(seconds: 20),
+      onTimeout: () => null,
+    );
+    if (readyPort == null || readyPort <= 0) {
+      process.kill();
+      _process = null;
+      _port = null;
+      _token = null;
+      throw const MihonRuntimeException(
+        'START_TIMEOUT',
+        'M-Extension-Server did not report a listening port',
+      );
+    }
+    // Only now is a port known to be held by *this* child, so only now may the
+    // per-process Bearer token leave the app.
+    _port = readyPort;
+
     Object? lastError;
     while (DateTime.now().isBefore(deadline)) {
+      // Liveness is checked before the request, not after it fails: a dead
+      // child must not be sent another authenticated request first.
+      if (await _hasExited(process)) break;
       try {
         final MihonCapabilities capabilities = await _readCapabilities();
         if (!capabilities.isUsable) {
@@ -378,7 +414,6 @@ class DesktopMihonRuntime extends MihonBridgeRuntime
         return;
       } catch (error) {
         lastError = error;
-        if (await _hasExited(process)) break;
         await Future<void>.delayed(const Duration(milliseconds: 200));
       }
     }
@@ -391,6 +426,26 @@ class DesktopMihonRuntime extends MihonBridgeRuntime
       'M-Extension-Server did not become ready',
       cause: lastError,
     );
+  }
+
+  /// Readiness contract with the sidecar; mirrors
+  /// `MExtensionServerController.READY_LINE_PREFIX`.
+  static const String _readyLinePrefix = 'HIBIKI_MIHON_READY port=';
+
+  /// Extracts the announced port from one stdout line, or `null` if the line
+  /// is ordinary log output.
+  ///
+  /// The child shares stdout with logback, so the marker is located rather
+  /// than assumed to start the line.
+  static int? _parseReadyPort(String line) {
+    final int marker = line.indexOf(_readyLinePrefix);
+    if (marker < 0) return null;
+    final String tail = line.substring(marker + _readyLinePrefix.length);
+    final Match? digits = RegExp(r'^\d+').matchAsPrefix(tail);
+    if (digits == null) return null;
+    final int? port = int.tryParse(digits.group(0)!);
+    if (port == null || port <= 0 || port > 65535) return null;
+    return port;
   }
 
   Future<MihonCapabilities> _readCapabilities() async {

--- a/hibiki/test/build/mihon_vendored_server_guard_test.dart
+++ b/hibiki/test/build/mihon_vendored_server_guard_test.dart
@@ -407,4 +407,205 @@ void main() {
     expect(controller, contains('"/stop"'));
     expect(controller, contains('hibikiMihonBridge'));
   });
+
+  // ==========================================================================
+  // /inspect 必须是「只读元数据」路径
+  //
+  // 时序才是要害：宿主在 _prepareInstallBytes 里就调 /inspect，弹「第三方扩展会以
+  // Hibiki 权限执行代码」信任对话框在那之后。所以 /inspect 一旦经过
+  // MExtensionServerLoader（Class.forName + newInstance + createSources），用户
+  // 点“取消”时代码早就跑完了——警告变成过去式。加载是 /dalvik 的职责。
+  //
+  // 断言全部打在**剥掉注释**的源码上：这两个文件的注释里必须能写出
+  // "MExtensionServerLoader" / "Class.forName" 来解释为什么不那么做。
+  // ==========================================================================
+  test('/inspect 不加载扩展代码（元数据闭包里没有任何执行原语）', () {
+    const String inspectPath = '$_vendorRoot/overlay/server/src/main/kotlin/'
+        'mextensionserver/controller/InspectHandler.kt';
+    final String inspectCode = maskComments(_read(inspectPath));
+
+    // ① InspectHandler 自己不碰加载器。
+    for (final String primitive in _codeExecutionPrimitives) {
+      expect(
+        inspectCode,
+        isNot(contains(primitive)),
+        reason: 'InspectHandler 里出现了 $primitive —— /inspect 在信任对话框弹出'
+            '之前就会执行扩展的静态初始化 / 构造器 / createSources()',
+      );
+    }
+    expect(
+      inspectCode,
+      contains('PackageTools.getPackageInfo('),
+      reason: '/inspect 必须只走 apk-parser 的元数据读取；换成别的读法就得重新'
+          '证明那条路径不构造类',
+    );
+
+    // ② 闭包的另一端：getPackageInfo 的函数体本身也不能含执行原语。
+    //    这两步合起来才是「从 /inspect 可达的代码里没有执行原语」的完整证据，
+    //    而不是「我读了 InspectHandler 觉得没问题」。
+    const String packageToolsPath = '$_upstreamSource/server/src/main/kotlin/'
+        'mextensionserver/util/PackageTools.kt';
+    expect(
+      File(packageToolsPath).existsSync(),
+      isTrue,
+      reason: 'PackageTools.kt 不在了 —— overlay 里的 getPackageInfo 调用会悬空',
+    );
+    final String body = _kotlinFunctionBody(
+      _read(packageToolsPath),
+      'fun getPackageInfo(',
+    );
+    // 反空转：函数体解析一旦失效（改名 / 花括号匹配错），下面的 isNot(contains)
+    // 会在空串上全部通过，变成假绿。
+    expect(
+      body.length,
+      greaterThan(200),
+      reason: 'getPackageInfo 函数体只解析到 ${body.length} 字符 —— 花括号匹配'
+          '很可能已经失效，下面的断言会在空串上假绿',
+    );
+    expect(
+      body,
+      contains('ApkParsers.getMetaInfo'),
+      reason: '解析出来的函数体不像 getPackageInfo —— 锚点串对错了位置',
+    );
+    for (final String primitive in _codeExecutionPrimitives) {
+      expect(
+        body,
+        isNot(contains(primitive)),
+        reason: 'PackageTools.getPackageInfo 里出现了 $primitive —— /inspect 的'
+            '“只读元数据”闭包被击穿，上游漂移把执行路径带回来了',
+      );
+    }
+  });
+
+  test('sidecar 端口由子进程自报（token 不会发给陌生进程）', () {
+    final String controller = maskComments(_read(
+      '$_vendorRoot/overlay/server/src/main/kotlin/mextensionserver/'
+      'controller/MExtensionServerController.kt',
+    ));
+    final String runtime = maskComments(_read(
+      '$_repositoryRoot/hibiki/lib/src/media/manga/mihon/'
+      'desktop_mihon_runtime.dart',
+    ));
+
+    // 契约两端必须是同一个字面量，否则宿主永远等不到就绪行。
+    expect(controller, contains(_readyLinePrefix));
+    expect(
+      runtime,
+      contains(_readyLinePrefix),
+      reason: '宿主侧的就绪行前缀与 controller 对不上 —— 启动会退化成 20s 超时',
+    );
+
+    // 子进程必须先 bind 再报端口。
+    final int bind = controller.indexOf('server?.start(');
+    final int announce = controller.indexOf('announceReady(');
+    expect(bind, greaterThan(-1), reason: 'controller 里的 NanoHTTPD 启动不见了');
+    expect(announce, greaterThan(-1), reason: '就绪行播报不见了');
+    expect(
+      bind,
+      lessThan(announce),
+      reason: '端口必须在 NanoHTTPD 已经 bind 之后才播报；提前播报等于又回到'
+          '「报出来的端口未必归自己」',
+    );
+
+    // 宿主不许自己挑端口：bind→close→把号交给子进程之间存在 TOCTOU 窗口，
+    // 期间任何本机进程都能抢走该端口，宿主随后把 Bearer token 发给陌生人。
+    expect(
+      runtime,
+      isNot(contains('ServerSocket.bind')),
+      reason: '宿主又开始自己预选端口了 —— token 可能发给抢占该端口的陌生进程',
+    );
+
+    // token 必须在拿到「子进程自报的端口」之后才可能发出。
+    final int awaitPort = runtime.indexOf('await announced.future');
+    final int assignPort = runtime.indexOf('_port = readyPort;');
+    final int firstRequest = runtime.indexOf('await _readCapabilities()');
+    expect(awaitPort, greaterThan(-1), reason: '等待就绪行的地方不见了');
+    expect(assignPort, greaterThan(-1), reason: '_port 的赋值点不见了');
+    expect(firstRequest, greaterThan(-1), reason: '就绪探测请求不见了');
+    expect(awaitPort, lessThan(assignPort));
+    expect(
+      assignPort,
+      lessThan(firstRequest),
+      reason: '_port 必须在第一次带 token 的请求之前、且只能由子进程自报的值赋出',
+    );
+
+    // 就绪循环：先查子进程死没死，再发认证请求。
+    final int loopExited =
+        runtime.indexOf('await _hasExited(process)', awaitPort);
+    expect(loopExited, greaterThan(-1), reason: '就绪循环里的存活检查不见了');
+    expect(
+      loopExited,
+      lessThan(firstRequest),
+      reason: '存活检查必须在请求之前；放在 catch 里等于每轮都先朝一个可能已经'
+          '不是自家子进程的端口发一次带 token 的请求',
+    );
+  });
+
+  test('/source-image 的响应缓冲有硬上限（敌意源不能 OOM 掉 sidecar）', () {
+    final String handler = maskComments(_read(
+      '$_vendorRoot/overlay/server/src/main/kotlin/mextensionserver/'
+      'controller/SourceImageHandler.kt',
+    ));
+    expect(
+      handler,
+      isNot(contains('body.bytes()')),
+      reason: 'body.bytes() 是无上限全量缓冲，sidecar 只有 -Xmx512m；'
+          '源站点控制的 URL 返回超大响应就能把整个 JVM 打死',
+    );
+    expect(handler, contains('MAX_IMAGE_BYTES'));
+    expect(
+      handler,
+      contains('body.byteStream()'),
+      reason: '必须边读边计数；只看 Content-Length 会被 chunked 响应绕过',
+    );
+  });
+}
+
+/// 会让第三方 APK 里的代码真正跑起来的原语。
+///
+/// 前四个是加载器入口，后四个是「把 APK 里的类变成活对象」本身；`/inspect` 的
+/// 可达闭包里出现任意一个，都意味着「用户点确认之前不执行扩展代码」这条不变式
+/// 已经破了。
+///
+/// 刻意**不**收裸 `newInstance`：`DocumentBuilderFactory.newInstance()` 这类
+/// JAXP 静态工厂同名，收了就是纯子串假阳（实测 getPackageInfo 里就有一处）。
+/// 闭包不因此漏 —— 想拿到扩展类的 `Class` 对象，只能经过 `Class.forName` 或者
+/// 自建 ClassLoader，两条都在下面。
+const List<String> _codeExecutionPrimitives = <String>[
+  'MExtensionServerLoader',
+  'invokeWithExtension',
+  'loadExtensionSources',
+  'dex2jar',
+  'URLClassLoader',
+  'Class.forName',
+  'getDeclaredConstructor',
+  'defineClass',
+  'createSources',
+];
+
+/// 宿主与 sidecar 之间的就绪行契约（两端必须共用同一个字面量）。
+const String _readyLinePrefix = 'HIBIKI_MIHON_READY port=';
+
+/// 取 [source] 里以 [anchor] 开头的 Kotlin 函数体（含外层花括号）。
+///
+/// 花括号配对走 [maskCommentsAndStrings]（注释与字符串里的花括号不参与配对），
+/// 再用同下标切回**只剥注释**的版本 —— 两者等长，所以下标通用；返回值里字符串
+/// 字面量原样保留，调用方的 contains 断言才能看到真实代码。
+String _kotlinFunctionBody(String source, String anchor) {
+  final String structural = maskCommentsAndStrings(source);
+  final String readable = maskComments(source);
+  final int start = structural.indexOf(anchor);
+  if (start < 0) return '';
+  final int open = structural.indexOf('{', start);
+  if (open < 0) return '';
+  int depth = 0;
+  for (int i = open; i < structural.length; i++) {
+    final String c = structural[i];
+    if (c == '{') depth++;
+    if (c == '}') {
+      depth--;
+      if (depth == 0) return readable.substring(open, i + 1);
+    }
+  }
+  return '';
 }

--- a/third_party/m_extension_server/UPSTREAM
+++ b/third_party/m_extension_server/UPSTREAM
@@ -80,15 +80,19 @@ server-build.gradle.patch:
   two upstream tests updated to match
 
 overlay/ (full-file replacements):
-  .../controller/MExtensionServerController.kt  the security boundary below
+  .../controller/MExtensionServerController.kt  the security boundary below;
+                                                also prints the readiness line
+                                                the host waits for
   .../controller/DalvikHandler.kt               explicit wire serialisation for
                                                 filters; fixes an upstream
                                                 index-out-of-bounds on cookies
                                                 without a value
-  .../controller/InspectHandler.kt              new: apksig-verified APK
-                                                inspection
+  .../controller/InspectHandler.kt              new: apksig-verified,
+                                                metadata-only APK inspection
+                                                (loads nothing; see below)
   .../controller/SourceImageHandler.kt          new: fetch a source image with
-                                                the extension's own client
+                                                the extension's own client,
+                                                buffered with a hard ceiling
   .../controller/SourceDataHandler.kt           new: clear per-source
                                                 preferences, cookies and cache
 
@@ -101,10 +105,33 @@ Security boundary (must not be weakened)
   bypass it. The token is 256 bits from Dart's Random.secure(), handed to the
   child only through the HIBIKI_MIHON_TOKEN environment variable, and the
   server refuses to start without it.
+- The child, not the host, chooses the listening port. It is started with port
+  0 and prints "HIBIKI_MIHON_READY port=<n>" on stdout once NanoHTTPD has
+  bound; the host parses that line and only then sends its first authenticated
+  request. Letting the host bind/close/hand over a port number instead is a
+  TOCTOU: any local process can take the port in between, and the host would
+  hand it the Bearer token. Both ends of this contract are guarded by
+  hibiki/test/build/mihon_vendored_server_guard_test.dart.
+- /inspect never loads the APK. It is called *before* Hibiki shows the "third
+  party extensions execute code with Hibiki permissions" trust dialog, so it
+  stays on apksig plus PackageTools.getPackageInfo (zip + binary manifest
+  parsing) and never touches MExtensionServerLoader, whose path runs dex2jar,
+  Class.forName + newInstance on the extension main class and
+  SourceFactory.createSources() — arbitrary code, before consent, and cached
+  with no eviction. Loading is /dalvik's job, which the host only reaches
+  after the user has accepted the dialog or explicitly asked for a preview.
+  The guard test asserts this over the whole closure reachable from /inspect,
+  not just the handler.
 - The complete route table is /dalvik, /inspect, /source-image,
   /source-data/clear, /capabilities, / (banner), /stop and upstream's
   /image/<uuid> proxy prefix. All of them sit behind the token gate; nothing
   else is served.
+- /source-image buffers the fetched body with a hard 32 MiB ceiling instead of
+  OkHttp's unbounded body.bytes(); the sidecar runs with -Xmx512m, so an
+  oversized response would otherwise OOM the whole JVM. Note this bounds only
+  the size, not the destination: the URL is chosen by the source site, exactly
+  as in upstream's own /image/<uuid> page path, which is inherent to Mihon's
+  "the site tells the client where the image is" contract.
 - The upstream process identity is retained: Main.kt, ServerWindow.kt,
   MExtensionServerLoader and MihonImageProxy are untouched, and the Hibiki
   host only ever terminates the Process handle it started (never a port or

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/InspectHandler.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/InspectHandler.kt
@@ -3,11 +3,42 @@ package mextensionserver.controller
 import com.android.apksig.ApkVerifier
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import fi.iki.elonen.NanoHTTPD
-import mextensionserver.impl.MExtensionServerLoader
+import mextensionserver.util.PackageTools
 import java.io.File
 import java.security.MessageDigest
 import java.util.Base64
 
+/**
+ * Reads an APK's identity **without ever running a byte of its code.**
+ *
+ * `/inspect` is what the Hibiki host calls *before* it shows the "third-party
+ * extensions execute code with Hibiki permissions" trust dialog, so anything
+ * this route executes has already happened by the time the user is asked — a
+ * "cancel" would arrive too late. It therefore stays on a strictly declarative
+ * path:
+ *
+ *  - `ApkVerifier` proves the APK is internally consistent and yields the
+ *    signer certificate. That is an integrity check, **not** a trust check —
+ *    anyone can self-sign — which is why the signer fingerprint is handed back
+ *    to the host to be matched against the store key and the trusted-signer
+ *    table.
+ *  - `PackageTools.getPackageInfo` parses the zip entries and the binary
+ *    AndroidManifest with apk-parser plus JAXP. It builds no class loader,
+ *    resolves no class and constructs nothing.
+ *
+ * It deliberately does **not** go through `MExtensionServerLoader`. That path
+ * runs `dex2jar`, then `Class.forName` + `newInstance` on the extension main
+ * class (static initialiser + constructor) and `SourceFactory.createSources()`
+ * — arbitrary code with Hibiki's permissions — and it parks the resulting
+ * instance in a cache with no eviction policy, so a rejected extension would
+ * keep its objects, and any threads its constructor started, alive for the rest
+ * of the sidecar's life. None of that ever bought anything here: every field
+ * below comes from `packageInfo`, and `loaded.sources` was never read.
+ *
+ * Loading is the job of `/dalvik`, which the host only reaches after the user
+ * has accepted the trust dialog or has explicitly asked to preview the
+ * extension.
+ */
 class InspectHandler {
     private val mapper = jacksonObjectMapper()
 
@@ -18,43 +49,17 @@ class InspectHandler {
             session.parseBody(files)
             val request = mapper.readValue(files["postData"], InspectRequest::class.java)
             val bytes = Base64.getDecoder().decode(request.data)
-            apk = kotlin.io.path.createTempFile("hibiki-inspect-", ".apk").toFile()
-            apk.writeBytes(bytes)
-            val verification = ApkVerifier.Builder(apk).build().verify()
+            val apkFile = kotlin.io.path.createTempFile("hibiki-inspect-", ".apk").toFile()
+            apk = apkFile
+            apkFile.writeBytes(bytes)
+            val verification = ApkVerifier.Builder(apkFile).build().verify()
             if (!verification.isVerified || verification.signerCertificates.isEmpty()) {
                 throw IllegalArgumentException("APK signature verification failed")
             }
             val signer = MessageDigest.getInstance("SHA-256")
                 .digest(verification.signerCertificates.last().encoded)
                 .joinToString("") { byte -> "%02x".format(byte) }
-            val result = MExtensionServerLoader.invokeWithExtension(request.data) { loaded ->
-                val info = loaded.packageInfo
-                val metadata = info.applicationInfo.metaData
-                val versionName = info.versionName.orEmpty()
-                val libVersion = metadata.getString("tachiyomix.extensionLib")
-                    ?.toDoubleOrNull()
-                    ?: versionName.substringBeforeLast('.').toDoubleOrNull()
-                if (libVersion != 1.4 && libVersion != 1.6) {
-                    throw IllegalArgumentException("Unsupported extension-lib version")
-                }
-                val classes = metadata.getString("tachiyomi.extension.class")
-                    ?.split(";")
-                    ?.map(String::trim)
-                    .orEmpty()
-                mapOf(
-                    "packageName" to info.packageName,
-                    "name" to (
-                        metadata.getString("tachiyomix.name")
-                            ?: info.applicationInfo.name
-                            ?: info.packageName
-                        ),
-                    "versionCode" to info.versionCode,
-                    "versionName" to versionName,
-                    "libVersion" to if (libVersion == 1.4) "1.4" else "1.6",
-                    "signerSha256" to signer,
-                    "sourceClasses" to classes,
-                )
-            }
+            val result = inspect(apkFile, signer)
             NanoHTTPD.newFixedLengthResponse(
                 NanoHTTPD.Response.Status.OK,
                 "application/json",
@@ -69,6 +74,39 @@ class InspectHandler {
         } finally {
             apk?.delete()
         }
+    }
+
+    /** Metadata-only projection of [apkFile]; executes nothing from the APK. */
+    private fun inspect(
+        apkFile: File,
+        signerSha256: String,
+    ): Map<String, Any> {
+        val info = PackageTools.getPackageInfo(apkFile.absolutePath)
+        val metadata = info.applicationInfo.metaData
+        val versionName: String = info.versionName.orEmpty()
+        val libVersion: Double? = metadata.getString("tachiyomix.extensionLib")
+            ?.toDoubleOrNull()
+            ?: versionName.substringBeforeLast('.').toDoubleOrNull()
+        if (libVersion != 1.4 && libVersion != 1.6) {
+            throw IllegalArgumentException("Unsupported extension-lib version")
+        }
+        val classes: List<String> = metadata.getString("tachiyomi.extension.class")
+            ?.split(";")
+            ?.map(String::trim)
+            .orEmpty()
+        return mapOf(
+            "packageName" to info.packageName,
+            "name" to (
+                metadata.getString("tachiyomix.name")
+                    ?: info.applicationInfo.name
+                    ?: info.packageName
+                ),
+            "versionCode" to info.versionCode,
+            "versionName" to versionName,
+            "libVersion" to if (libVersion == 1.4) "1.4" else "1.6",
+            "signerSha256" to signerSha256,
+            "sourceClasses" to classes,
+        )
     }
 
     private data class InspectRequest(val data: String)

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/MExtensionServerController.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/MExtensionServerController.kt
@@ -18,10 +18,30 @@ class MExtensionServerController {
             val actualPort = server?.listeningPort ?: 0
             MihonImageProxy.configure(actualPort)
             logger.info { "Hibiki M-Extension-Server started on loopback port $actualPort" }
+            announceReady(actualPort)
         } catch (error: IOException) {
             logger.error(error) { "Failed to start M-Extension-Server" }
             throw error
         }
+    }
+
+    /**
+     * Tells the host, on stdout, which port this process actually holds.
+     *
+     * The host starts us with port `0` and waits for this line instead of
+     * picking a port itself. A host-side "bind, read the port, close, hand the
+     * number to the child" dance is a TOCTOU: between the close and the child's
+     * bind anything else on the machine can take the port, and the host would
+     * then send its per-process Bearer token to a stranger. Here the port is
+     * printed *after* [NanoHTTPD.start] has bound it, so the number is one this
+     * process demonstrably owns at the moment it is reported.
+     *
+     * The line is deliberately machine-readable and prefix-anchored so it stays
+     * separable from logback output on the same stream.
+     */
+    private fun announceReady(actualPort: Int) {
+        println("$READY_LINE_PREFIX$actualPort")
+        System.out.flush()
     }
 
     fun stop() {
@@ -33,6 +53,11 @@ class MExtensionServerController {
     fun isRunning(): Boolean = server?.isAlive == true
 
     fun getPort(): Int = server?.listeningPort ?: 0
+
+    companion object {
+        /** Host-facing readiness contract; see [announceReady]. */
+        const val READY_LINE_PREFIX = "HIBIKI_MIHON_READY port="
+    }
 
     private inner class WebServer(port: Int) : NanoHTTPD("127.0.0.1", port) {
         private val bearer = System.getenv("HIBIKI_MIHON_TOKEN")

--- a/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/SourceImageHandler.kt
+++ b/third_party/m_extension_server/overlay/server/src/main/kotlin/mextensionserver/controller/SourceImageHandler.kt
@@ -7,7 +7,9 @@ import mextensionserver.impl.MExtensionServerLoader
 import mextensionserver.impl.MihonInvoker
 import mextensionserver.model.DataBody
 import okhttp3.Request
+import okhttp3.ResponseBody
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 
 class SourceImageHandler {
     private val mapper = jacksonObjectMapper()
@@ -35,7 +37,7 @@ class SourceImageHandler {
                     }
                     val body = it.body
                     ImageResult(
-                        body.bytes(),
+                        readBounded(body),
                         body.contentType()?.toString() ?: "application/octet-stream",
                     )
                 }
@@ -53,6 +55,47 @@ class SourceImageHandler {
                 mapper.writeValueAsString(mapOf("error" to (error.message ?: "Image request failed"))),
             )
         }
+
+    /**
+     * Buffers the response with a hard ceiling instead of `body.bytes()`.
+     *
+     * The URL fetched here is chosen by the source site, and the sidecar runs
+     * with `-Xmx512m`; an unbounded `bytes()` lets one hostile or broken
+     * response OOM the whole JVM and take every other extension down with it.
+     * `Content-Length` is only a hint (it is absent on chunked responses and
+     * attacker-controlled anyway), so the stream is counted as it is read.
+     */
+    private fun readBounded(body: ResponseBody): ByteArray {
+        val declared: Long = body.contentLength()
+        if (declared > MAX_IMAGE_BYTES) {
+            throw IllegalStateException("Source image exceeds $MAX_IMAGE_BYTES bytes")
+        }
+        // Content-Length only sizes the first allocation, and even that is
+        // capped: a lying header must not be able to make us reserve 32 MiB.
+        val initial: Int = declared.coerceIn(CHUNK_BYTES.toLong(), INITIAL_CAPACITY_CAP).toInt()
+        val buffered = ByteArrayOutputStream(initial)
+        val chunk = ByteArray(CHUNK_BYTES)
+        var total = 0L
+        body.byteStream().use { stream ->
+            while (true) {
+                val read = stream.read(chunk)
+                if (read < 0) break
+                total += read
+                if (total > MAX_IMAGE_BYTES) {
+                    throw IllegalStateException("Source image exceeds $MAX_IMAGE_BYTES bytes")
+                }
+                buffered.write(chunk, 0, read)
+            }
+        }
+        return buffered.toByteArray()
+    }
+
+    private companion object {
+        /** Generous for cover art, far below the sidecar's 512 MiB heap. */
+        const val MAX_IMAGE_BYTES: Long = 32L * 1024 * 1024
+        const val CHUNK_BYTES: Int = 64 * 1024
+        const val INITIAL_CAPACITY_CAP: Long = 1L * 1024 * 1024
+    }
 
     private data class SourceImageRequest(
         val data: String,


### PR DESCRIPTION
只读安全审计的落地修复。三条全部落在 `third_party/m_extension_server/overlay/`，`upstream_src/` 保持 pristine（`git diff` 对该目录为空）。

攻击者模型沿用审计结论：监听只绑 `127.0.0.1`、鉴权网关在 route 分发之前且常数时间比较、缺 token fail-closed、所有 route 要 `Authorization` 头 ⇒ DNS rebinding / drive-by CSRF 不成立。剩下的只有 **(A) 本机已能跑进程**、**(B) 敌意/被攻陷的第三方漫画源**。

---

## 1. `/inspect` 在用户同意之前就执行了 APK 代码（主要修复）

**时序才是要害。** `mihon_manager.dart` 的 `_prepareInstallBytes` 里就调 `/inspect`，`mihon_extensions_page.dart` 的信任对话框在那之后才弹——而对话框正文写的是「Third-party extensions execute code with Hibiki permissions…」。**这句警告被显示时已经是过去式**：用户点“取消”，代码早跑完了。

旧路径：`InspectHandler` → `MExtensionServerLoader.invokeWithExtension` → `dex2jar` → `PackageTools.loadExtensionSources` 的 `Class.forName` + `newInstance()`（触发静态初始化 + 构造器）→ `SourceFactory.createSources()`。**用户权限任意代码执行。**

而这次执行是**纯粹的附带损害**：`InspectHandler` 全程只读 `loaded.packageInfo`，`sourceClasses` 来自 manifest 的 `metaData`，**从头到尾没碰过 `loaded.sources`**。

修法是**删代码**：改调 `PackageTools.getPackageInfo(apk)`——apk-parser 读 zip 条目 + JAXP 解析 binary AndroidManifest，不建 ClassLoader、不解析类、不构造对象。`dex2jar` / `extractAssetsFromApk` 一并不必再跑（`/inspect` 从 ~1.1s 的 dex2jar 路径变成纯解析）。

`ApkVerifier` 保留在原位：它证明 APK **自洽签名未被篡改**（完整性），不证明签名者可信——任何人自签都过——所以签名指纹仍旧回传给宿主去比对 store key 与受信任签名表。

**副作用：`ExtensionInstanceCache` 的驻留问题一并消失。** 该缓存**无任何淘汰策略**；旧路径下一个被拒绝安装的恶意扩展，它的实例 + 构造器起的线程会在 sidecar 剩余生命周期一直驻留。现在 `/inspect` 根本不进缓存——比加一条「inspect 不入缓存」的规则更彻底，也不用新增状态。

### 可证伪的证明（不是“我读代码觉得不会执行了”）

**A. 运行时差分实验。** 同一棵 vendored 树、同一份补丁与 overlay，**只把 `InspectHandler.kt` 换成修复前的版本**编出第二个 JAR，两个 sidecar 各自跑在**私有 `-Djava.io.tmpdir`** 下，POST 同一个真实签名扩展（keiyoushi `all.ahottie` v1.6.4，`ExtensionGenerated` 是个 `SourceFactory`）到 `/inspect`：

| | 响应 | `mextensionserver*` 临时目录 | dex2jar 产物 |
|---|---|---|---|
| 修复前 | HTTP 200，同一份 JSON | `tmp-OLD/mextensionserver3301325406176914802` | `extension-0c08c2cb-….jar` |
| 修复后 | HTTP 200，**同一份 JSON** | **NONE** | **NONE** |

那个临时目录由 `MExtensionServerLoader` 这个 `object` 的初始化器创建、由 `dex2jar` 填充，**当且仅当**请求走了以 `Class.forName` + `newInstance` + `createSources()` 收尾的加载路径时才存在。修复后它压根没被创建 ⇒ 加载器类从未初始化过。同时该 jar 在请求结束后**依然在盘上**（只在 `close()` 时删），这也正是上面「无淘汰缓存把被拒绝的扩展留住」的实证。

返回的 `signerSha256 = 9add655a…4da2` 与 keiyoushi 索引 `index.pb` 里该扩展的记录逐字一致 ⇒ **行为等价，只是不再执行代码**。

**B. 静态闭包守卫**（`mihon_vendored_server_guard_test.dart`）。不只扫 handler，而是扫**从 `/inspect` 可达的整个闭包**：`InspectHandler.kt` 不得出现 9 个执行原语中的任何一个，且 `PackageTools.getPackageInfo` 的**函数体**（花括号配对提取）里同样不得出现——后者盯的是上游漂移把执行路径悄悄带回来。带反空转哨兵（函数体 < 200 字符或不含 `ApkParsers.getMetaInfo` 直接红），断言全部打在剥注释后的源码上。

> 刻意**不**收裸 `newInstance`：`DocumentBuilderFactory.newInstance()` 同名，收了就是纯子串假阳（写守卫时实测被它咬了一次）。闭包不因此漏——拿到扩展类的 `Class` 对象只能经 `Class.forName` 或自建 ClassLoader，两条都在列。

### 边界：`/dalvik` 本轮不动

`/dalvik` 同样没有验签、同样走 `invokeWithExtension`，但它是**真正需要加载扩展的路径**，宿主只在用户已接受信任对话框、或显式选择「预览」（`_preview` 的注释已经写明「扩展代码会真跑起来」）之后才走到。它不构成「同意之前」问题，属于另一个范围。

---

## 2. 端口 TOCTOU + 先发 token 后查存活

宿主原先 `bind → 读端口 → close → 把号交给子进程`，随后**直接采信预选值、从不回读实际监听端口**，并把 stdout/stderr 全丢弃（子进程本可以回报端口，通道被主动扔了）。close 与子进程 bind 之间**任何本机进程都能抢占该端口**，宿主接着把 per-process Bearer token 发给陌生人。就绪循环还**每轮先发 Bearer 再查进程死没死**。

一改消灭两个问题：以端口 `0` 启动（`Main.kt:33` 本就支持）→ `MExtensionServerController.start` 拿到 `actualPort` 后往 stdout 打一行机器可读就绪行 → 宿主解析该行、拿到端口**之后**才发第一个带 token 的请求。子进程先 bind 再打印，**打印出的端口在那一刻必然由它持有**。就绪循环的 `_hasExited` 也提到了请求之前。

**就绪行格式**：`HIBIKI_MIHON_READY port=<n>`（`println` + 显式 `System.out.flush()`）。

**宿主侧解析**：`process.stdout` 经 `Utf8Decoder(allowMalformed: true)` + `LineSplitter`，逐行用 `indexOf(prefix)` 定位（**不是 `startsWith`**——logback 与它共用 stdout 且带 ANSI 颜色码，实测就绪行前有两行 INFO），取其后的十进制串并校验 `1..65535`。订阅**永不 cancel**（stdout 必须持续排空，否则管道满了会阻塞 JVM）；进程退出时用 `null` 完成 completer，避免死进程仍要等满 20s。

**token 现在最早在什么时刻发出**：`_readCapabilities()` 的第一次调用，而它在 `_port = readyPort` 之后；`_port` 只可能被子进程自报的值赋出。`_uri()` 在 `_port == null` 时抛 `NOT_STARTED`，所以在就绪行到达之前**不存在任何能把 token 发出去的路径**。实测启动日志：

```
18:54:12.546 [main] INFO  … started on loopback port 2622
HIBIKI_MIHON_READY port=2622
```

附带修掉一个真实可靠性 bug：良性端口撞车原先会让 sidecar 启动失败抛 `START_TIMEOUT`，用户侧表现是「漫画源打不开」。

---

## 3. `/source-image`：只做了 OOM 上限，**没有**做 host 校验

**做了的**：`body.bytes()` 是无上限全量缓冲而 JVM 是 `-Xmx512m`，敌意源返回超大响应即可 OOM 掉 sidecar、连带打死所有扩展。改为边读边计数、32 MiB 硬上限；`Content-Length` 只用来定首次分配且同样封顶（1 MiB），因为它在 chunked 响应上缺失、且本身就是攻击者可控的。

**没做 SSRF host 允许列表，理由如下**（不是漏了，是权衡）：

1. **会 break userspace。** 正确做法只能是 okhttp **network interceptor**（`addInterceptor` 不在重定向后重跑，一个 302 就绕过去），而它必须挂在 `NetworkHelper.client` 上才能覆盖到 `MihonImageProxy.fetch → source.fetchImage(entry.page)` 那条等价面。但那个 client 是**所有扩展共用的基底**——Komga / Suwayomi(Tachidesk) / Cubari 这类自托管源是 Mihon 生态的一等公民，用户配的正是 `127.0.0.1` / 局域网地址。封私网 = 直接打死这批扩展。
2. **威胁模型上收益接近零。** 这是**盲打** SSRF：响应回给 Hibiki app 渲染成封面，不回给恶意站点，**无外带通道**。而 Hibiki 是桌面 app 不是云 VM，`169.254.169.254` 那类 IMDS 目标在用户 PC 上不存在。
3. **同一个原语在页图路径本来就存在且是契约固有的**——「源站点告诉客户端去哪取图」就是 Mihon 的设计。只封 `/source-image` 而不封页图是自欺；两条都封就是上面的 break userspace。

⇒ 结论：**这条不值得做**。真问题是「敌意源能打死 sidecar」，那条已经修了。若日后要做，正确形态是**用户可见的“允许本地/私网源”开关 + network interceptor**，那是产品决策不是本轮补丁，已在 `UPSTREAM` 的安全边界里把「只 bound size，不 bound destination」写清。

---

## 验证

- `flutter analyze`（含 test）：**`No issues found!`**
- 35 条守卫整批：**`FLUTTER TEST VERDICT: PASSED - 225 tests ran`**（结构判据：jsonl 里 suite 装载数 35 = 磁盘列出的 35 份，无缺失/空 suite）
- `test/build` + `test/media/manga` + 两条 manga page 定向：**`PASSED - 603 tests ran`**
- **vendored JAR 真重建过**：`:server:test :server:shadowJar` → `BUILD SUCCESSFUL`，产出 `MExtensionServer-v1.0.5.0-ee55c65.jar`，上游测试全过。并且真跑起来做了上面的差分实验。
- 守卫 9 项变异实测（恢复 loader 调用 / 去掉 `getPackageInfo` / 往 `getPackageInfo` 体里塞 `URLClassLoader` / 两端就绪行前缀漂开 / 恢复 `ServerSocket.bind` / `_hasExited` 挪回 catch / 恢复 `body.bytes()` / 把函数体提取锚点改成不存在 / 在 bind 之前播报端口）——**条条转红**。判据只收紧不放宽。

### 未验证边界（诚实交代）

- 重建用的是本机 `~/.gradle/jdks` 的 Temurin 21.0.11（`build_desktop_runtime.ps1` 依赖 PowerShell **Core** 的 `[IO.Path]::GetRelativePath`，本机只有 Windows PowerShell 5.1，脚本跑不起来）。**脚本本身未在本机执行过**；我按它的语义手工复现了它的四步（拷 upstream_src → `git apply` 带上下文的补丁 → 拷 overlay → `ProductRevision` + `:server:test :server:shadowJar`），产物名与 manifest 的 `ee55c65` 一致。脚本路径本身由 CI 覆盖。
- 差分实验是直接对 sidecar HTTP 打的，**没有**从 Hibiki app UI 端到端走一遍安装流程（那需要桌面真机跑 mihon runtime）。宿主侧的就绪行解析、`_port` 赋值时序由守卫的结构断言 + 上面的真实 stdout 日志覆盖。

https://claude.ai/code/session_01HDLmng2mWroz4ctjieP2HH
