### PR TITLE
test(reader/focus): 钉死翻页 in-flight 期间 wheel-tick 焦点回收频次 (TODO-2617)

### DIFF
--- a/hibiki/test/focus/page_focus_ownership_test.dart
+++ b/hibiki/test/focus/page_focus_ownership_test.dart
@@ -72,6 +72,116 @@ void main() {
     expect(ownership.node.hasFocus, isTrue);
   });
 
+  // ── TODO-2617：高频 reclaim 的代价 ─────────────────────────────────────
+  //
+  // 阅读器的 `onWheelPaginate` 在翻页 in-flight 期间对**每个** wheel tick 都调一次
+  // `reclaim(FocusReclaimCause.gesture)`（BUG-1380 之后；纵向滚轮更是从 TODO-737 起
+  // 就一直如此）。这被判定为**可接受**，前提是下面两条不变量成立——它们不是 Flutter
+  // 的实现细节，而是 [PageFocusOwnership] 对所有高频调用方的承诺：
+  //
+  // ① 节点已持焦时再 reclaim 是**静默 no-op**：不发通知、不换 primaryFocus。
+  //    （`FocusNode._doRequestFocus` 在 `hasPrimaryFocus` 上快返；
+  //     `FocusManager._markNeedsUpdate` 还用 `_haveScheduledUpdate` 合并同帧请求。）
+  // ② reclaim **不做 reveal**：绝不把节点滚进视口。历史上「触屏快速滚动被拉回居中
+  //    某控件」的根因正是被动焦点修复带的 `HibikiFocusScroll.ensureVisible(alignment:
+  //    0.5)`（`focus_repair_touch_no_scroll_test.dart`）。那是 `HibikiFocusController`
+  //    的路径；一旦有人把同样的 reveal 搬进本类，高频 wheel tick 就会当场重演它。
+  //
+  // 任一条被破坏，高频调用方就必须改成去抖——所以这两条测试红了不要放宽，
+  // 要么改回来，要么同时收敛 `onWheelPaginate` 的频次。
+  group('TODO-2617 high-frequency reclaim stays cheap', () {
+    testWidgets('reclaiming again while already focused notifies nobody',
+        (WidgetTester tester) async {
+      final (PageFocusOwnership ownership, _) =
+          await mount(tester, canOwn: (FocusReclaimCause _) => true);
+
+      expect(ownership.reclaim(FocusReclaimCause.gesture), isTrue);
+      await tester.pumpAndSettle();
+      expect(ownership.node.hasPrimaryFocus, isTrue);
+
+      int nodeNotifications = 0;
+      void onNode() => nodeNotifications++;
+      ownership.node.addListener(onNode);
+      addTearDown(() => ownership.node.removeListener(onNode));
+
+      int managerNotifications = 0;
+      void onManager() => managerNotifications++;
+      FocusManager.instance.addListener(onManager);
+      addTearDown(() => FocusManager.instance.removeListener(onManager));
+
+      // **必须逐帧驱动**：真实 wheel tick 相隔 ~60ms（好几帧），不是同一帧内连打。
+      // 同帧内连打是测不出东西的——FocusManager 的 `_haveScheduledUpdate` 会把同批
+      // 请求合并掉，连「reclaim 改成先 unfocus 再 requestFocus」这种写法都测不红。
+      // 只有跨帧调用才让「每次都真的动一下焦点」暴露成可数的通知。
+      for (int i = 0; i < 20; i++) {
+        expect(ownership.reclaim(FocusReclaimCause.gesture), isTrue,
+            reason: '判据通过时 reclaim 仍然「发起了请求」，返回值不因幂等而改变');
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      await tester.pumpAndSettle();
+
+      expect(nodeNotifications, 0,
+          reason: '已持焦的节点被反复 reclaim 不得产生任何焦点变更通知——'
+              '有通知就意味着每个 wheel tick 都在真的动焦点树（Focus widget 逐 tick rebuild）');
+      expect(managerNotifications, 0, reason: 'FocusManager 不得因重复请求而广播焦点变更');
+      expect(ownership.node.hasPrimaryFocus, isTrue,
+          reason: '50 次之后焦点仍稳稳在正文，不存在抖动/让位');
+    });
+
+    testWidgets('repeated reclaim never scrolls the surrounding viewport',
+        (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      final FocusNode node = FocusNode(debugLabel: 'body');
+      final PageFocusOwnership ownership = PageFocusOwnership(
+        node: node,
+        canOwn: (FocusReclaimCause _) => true,
+      );
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(size: Size(800, 600)),
+            child: SingleChildScrollView(
+              controller: controller,
+              child: Column(
+                children: <Widget>[
+                  const SizedBox(height: 2000),
+                  Focus(
+                    focusNode: node,
+                    child: const SizedBox(height: 50, width: 800),
+                  ),
+                  const SizedBox(height: 2000),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      addTearDown(() async {
+        await tester.pumpWidget(const SizedBox.shrink());
+        node.dispose();
+        controller.dispose();
+      });
+
+      // 节点的 box 落在 [2000, 2050]；视口 [1900, 2500] 里它可见但**远离中心**，
+      // 所以任何 `alignment: 0.5` 的 reveal 都会立刻表现为 offset 变化。
+      controller.jumpTo(1900);
+      await tester.pump();
+      final double offsetBefore = controller.offset;
+
+      for (int i = 0; i < 20; i++) {
+        expect(ownership.reclaim(FocusReclaimCause.gesture), isTrue);
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      await tester.pumpAndSettle();
+
+      expect(controller.offset, offsetBefore,
+          reason: '焦点回收不得把视口滚动到节点上——用户正在滑动时这就是「滚一半被拉回去」，'
+              '与 HibikiFocusController 那次触屏回归同一形态');
+      expect(node.hasPrimaryFocus, isTrue);
+    });
+  });
+
   group('guardOverlay', () {
     testWidgets('returns focus after the overlay resolves normally',
         (WidgetTester tester) async {

--- a/hibiki/test/reader/reader_wheel_focus_reclaim_frequency_test.dart
+++ b/hibiki/test/reader/reader_wheel_focus_reclaim_frequency_test.dart
@@ -1,0 +1,220 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
+
+import '../helpers/source_guard.dart';
+import '../pages/reader_hibiki_page_source_corpus.dart';
+
+const Duration _kSettle = Duration(milliseconds: 450);
+
+/// 一段惯性回放的两个计数：用户看到的翻页数，以及 `onWheelPaginate` handler 走到
+/// `_focusOwnership.reclaim(FocusReclaimCause.gesture)` 的次数。
+typedef _BurstCounts = ({int pageTurns, int focusReclaims});
+
+/// 复刻 `onWheelPaginate` handler（`reader_hibiki/webview.part.dart`）的真实判定顺序：
+///   ① 横向 tick 先过 [ReaderWheelGestureGate]；判「属于已认领手势」→ 早退（不 reclaim）。
+///   ② 放行的 tick **先** `_focusOwnership.reclaim(FocusReclaimCause.gesture)`；
+///   ③ 再进 `_paginate`；`_paginationInFlight` 为真时被入口守卫直接丢弃。
+///
+/// ② 与 ① 的先后由源码守卫另行钉死（见本文件下半部分）——本回放器只是**复刻**这个
+/// 顺序，改不了生产代码里的真实位置，所以两条守卫缺一不可。
+_BurstCounts _replayBurst({
+  required ReaderWheelGestureGate gate,
+  required int totalMs,
+  required int tickIntervalMs,
+  required bool Function(int elapsedMs) paginationInFlight,
+}) {
+  final DateTime start = DateTime(2026, 8, 2);
+  int pageTurns = 0;
+  int focusReclaims = 0;
+  for (int elapsed = 0; elapsed <= totalMs; elapsed += tickIntervalMs) {
+    final DateTime now = start.add(Duration(milliseconds: elapsed));
+    final bool inFlight = paginationInFlight(elapsed);
+    if (!gate.shouldStartNewGesture(
+      now: now,
+      settleInterval: _kSettle,
+      canTurnPage: !inFlight,
+    )) {
+      continue;
+    }
+    focusReclaims += 1;
+    if (inFlight) continue;
+    pageTurns += 1;
+  }
+  return (pageTurns: pageTurns, focusReclaims: focusReclaims);
+}
+
+/// 一段 [totalMs] / [tickIntervalMs] 的惯性里一共有多少个 tick（含 0ms 那个）。
+int _tickCount({required int totalMs, required int tickIntervalMs}) =>
+    totalMs ~/ tickIntervalMs + 1;
+
+/// TODO-2617：钉死「翻页 in-flight 期间每个横向 wheel tick 都触发一次
+/// `reclaim(FocusReclaimCause.gesture)`」这个频次，并写清为什么它是**可接受**的。
+///
+/// 由来：BUG-1380 之前，闸门无条件消费手势 token，于是换章加载期整段惯性只有**首个**
+/// tick 能穿过闸门（后续全部早退）；修复把 token 的消费挪到「这一 tick 真能翻页」之后，
+/// 连带效应就是 in-flight 期间**每个** tick 都穿过闸门、都走到 reclaim。
+///
+/// 判定：**无需收敛**（TODO-2617 结论 B），三条依据——
+///
+/// 1. `reclaim` 在节点已持焦时是**幂等快返**：`PageFocusOwnership.reclaim` 的全部动作
+///    是「判据谓词 + `node.requestFocus()`」（`lib/src/focus/page_focus_ownership.dart:88`）；
+///    Flutter 的 `FocusNode._doRequestFocus` 在 `hasPrimaryFocus` 时直接 return
+///    （`packages/flutter/lib/src/widgets/focus_manager.dart`），而即使**没有**持焦，
+///    `FocusManager._markNeedsUpdate` 也用 `_haveScheduledUpdate` 把同一帧内的 N 次请求
+///    合并成一次 `applyFocusChangesIfNeeded` 微任务。没有 rebuild、没有平台通道、
+///    没有逐 tick 的焦点抖动。
+/// 2. 它**不会**重演历史上「触屏滚动被焦点修复拉回」：那条回归的根因是
+///    `HibikiFocusController.ensureFocus()` → `_scheduleReveal` →
+///    `HibikiFocusScroll.ensureVisible(alignment: 0.5)` 的**滚动进视口**动作
+///    （已按 `highlightMode == traditional` 门控，`test/focus/focus_repair_touch_no_scroll_test.dart`）。
+///    `PageFocusOwnership.reclaim` 里没有任何 reveal/滚动，是另一套子系统；
+///    不变量由 `test/focus/page_focus_ownership_test.dart` 的「高频 reclaim 不滚动视口」钉住。
+/// 3. **逐 tick reclaim 不是本次新引入的量级**：handler 的闸门只判
+///    `axis == 'horizontal'`，**纵向**滚轮 tick 自 TODO-737 起就一直绕过闸门、每个 tick
+///    都 reclaim——而纵向滚轮正是桌面端的主路径。横向 in-flight 现在只是**对齐**了这个
+///    早已在跑的基准频率，不是开了新口子。
+void main() {
+  group('TODO-2617 wheel-tick focus reclaim frequency', () {
+    test('a clean horizontal burst reclaims focus exactly once', () {
+      final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+      final _BurstCounts counts = _replayBurst(
+        gate: gate,
+        totalMs: 1500,
+        tickIntervalMs: 60,
+        paginationInFlight: (_) => false,
+      );
+      expect(counts.pageTurns, 1);
+      expect(counts.focusReclaims, 1,
+          reason: '闸门在 reclaim 之上游：一次触控板惯性只认领一次手势，'
+              '所以正常路径下 26 个 tick 只回收一次焦点');
+    });
+
+    test(
+        'a burst fully covered by an in-flight navigation reclaims on every '
+        'tick (accepted: reclaim is idempotent when already focused)', () {
+      final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+      const int totalMs = 600;
+      const int tickIntervalMs = 60;
+      final _BurstCounts counts = _replayBurst(
+        gate: gate,
+        totalMs: totalMs,
+        tickIntervalMs: tickIntervalMs,
+        paginationInFlight: (_) => true,
+      );
+      expect(counts.pageTurns, 0, reason: '整段惯性都撞在换章加载里，一页也翻不动');
+      expect(
+        counts.focusReclaims,
+        _tickCount(totalMs: totalMs, tickIntervalMs: tickIntervalMs),
+        reason: 'BUG-1380 之后 in-flight 期间闸门只查询不认领 ⇒ 每个 tick 都穿过闸门、'
+            '都调一次 reclaim。这是**有意接受**的频次：节点此时已持焦，'
+            'requestFocus 在 hasPrimaryFocus 上快返，且 FocusManager 合并同帧请求。'
+            '若这里退回 1，说明 token 又被翻不动页的 tick 提前吃掉了（BUG-1380 回归）',
+      );
+    });
+
+    test(
+        'a burst that opens during chapter loading reclaims once per swallowed '
+        'tick plus once for the landed turn', () {
+      final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+      // 前 300ms 换章加载在飞（elapsed 0/60/…/300 共 6 个 tick 被丢弃），之后落定。
+      final _BurstCounts counts = _replayBurst(
+        gate: gate,
+        totalMs: 1500,
+        tickIntervalMs: 60,
+        paginationInFlight: (int elapsedMs) => elapsedMs <= 300,
+      );
+      expect(counts.pageTurns, 1, reason: '加载落定后恰好补翻一页（BUG-1380）');
+      expect(counts.focusReclaims, 7,
+          reason: '6 个被 _paginate 丢弃的 in-flight tick 各 reclaim 一次，'
+              '外加真正落地那一次；上界是 tick 数，不随时间无限增长');
+    });
+
+    test('reclaim count never exceeds the tick count of the burst', () {
+      for (final int inFlightUntilMs in <int>[0, 120, 300, 600, 1500]) {
+        final ReaderWheelGestureGate gate = ReaderWheelGestureGate();
+        const int totalMs = 1500;
+        const int tickIntervalMs = 60;
+        final _BurstCounts counts = _replayBurst(
+          gate: gate,
+          totalMs: totalMs,
+          tickIntervalMs: tickIntervalMs,
+          paginationInFlight: (int elapsedMs) => elapsedMs <= inFlightUntilMs,
+        );
+        expect(
+          counts.focusReclaims,
+          lessThanOrEqualTo(
+              _tickCount(totalMs: totalMs, tickIntervalMs: tickIntervalMs)),
+          reason: 'reclaim 频次的上界是输入事件数本身（O(tick)），'
+              '不存在「一个 tick 放大成多次回收」的路径',
+        );
+      }
+    });
+  });
+
+  // ── 源码守卫：回放器复刻的那个顺序，必须真的是生产代码里的顺序 ──────────
+  //
+  // 上面的回放器把「闸门 → reclaim → _paginate」写死在 fixture 里，所以它抓不到
+  // 「有人把 reclaim 挪到闸门之前」这种改法（那会让**每一个** tick 都 reclaim，
+  // 包括已认领手势内的 25 个，频次从 O(手势) 掉到 O(事件)）。这一条由下面的结构
+  // 守卫兜住：窗口由 addJavaScriptHandler 的圆括号配对给出，语料先做词法掩码，
+  // 注释里出现同名符号一律不算数。
+  group('TODO-2617 reclaim stays downstream of the wheel gesture gate', () {
+    late String handlerBody;
+
+    setUpAll(() {
+      final String source = maskCommentsAndScriptLines(readReaderPageSource());
+      final EnclosingCall handler =
+          enclosingCallOf(source, "handlerName: 'onWheelPaginate'");
+      expect(handler.name, endsWith('addJavaScriptHandler'),
+          reason: 'onWheelPaginate 必须仍以 addJavaScriptHandler 的具名实参注册');
+      handlerBody = handler.text;
+    });
+
+    test('the handler reclaims focus exactly once, after the gate early-return',
+        () {
+      expect(
+        containsCodeLine(
+            handlerBody, '_focusOwnership.reclaim(FocusReclaimCause.gesture)'),
+        isTrue,
+        reason: 'BUG-136：滚轮翻页同样把 OS 焦点交给了 WebView，必须夺回来',
+      );
+      expect(
+        '_focusOwnership.reclaim('.allMatches(handlerBody).length,
+        1,
+        reason: '只允许一处回收点。多写一处（例如闸门之前补一个）就把频次从「一次手势一次」'
+            '抬成「一个 tick 一次」，且两处的门控必然漂移——正是 PageFocusOwnership 要消灭的老路',
+      );
+
+      final int gate =
+          handlerBody.indexOf('_pagedWheelGestureGate.shouldStartNewGesture');
+      final int reclaim =
+          handlerBody.indexOf('_focusOwnership.reclaim(FocusReclaimCause');
+      expect(gate, isNonNegative);
+      expect(reclaim, isNonNegative);
+      expect(reclaim, greaterThan(gate),
+          reason: 'reclaim 必须排在手势闸门之后：闸门早退的 tick（已认领手势内的惯性余波）'
+              '不该再回收焦点，否则一次 1.5s 惯性会从 1 次回收变成 26 次');
+    });
+
+    test('the gate branch really early-returns before reaching the reclaim',
+        () {
+      final int gate =
+          handlerBody.indexOf('_pagedWheelGestureGate.shouldStartNewGesture');
+      expect(gate, isNonNegative);
+      // 闸门所在 `if (...)` 的块本体：从条件表达式之后的第一个 `{` 起做花括号配对。
+      final String branch = balancedBlockFrom(
+        handlerBody,
+        gate,
+        what: 'onWheelPaginate 手势闸门分支',
+      );
+      expect(containsCodeLine(branch, 'return;'), isTrue,
+          reason: '闸门判「属于已认领手势」必须直接 return；'
+              '改成继续往下走就等于闸门对 reclaim 频次完全失效');
+      expect(
+        containsCodeLine(branch, '_focusOwnership.reclaim('),
+        isFalse,
+        reason: '回收点不得落进闸门的早退分支里（那是「这一 tick 不处理」的分支）',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## 结论：情况 B —— 无真实代价，**不改行为**，只补可证伪的守卫

PR#695 复核时提出的连带效应：BUG-1380 之后，换章加载在飞的那几百毫秒里，**每个**横向
wheel tick 都会走到 `_focusOwnership.reclaim(FocusReclaimCause.gesture)`（改前只有首个
tick）。沿真实代码路径查完，判为**可接受，不收敛**。

### 依据 1：`reclaim` 每次实际做什么

`PageFocusOwnership.reclaim`（`hibiki/lib/src/focus/page_focus_ownership.dart:88-92`）
的全部动作是「判据谓词 + `node.requestFocus()`」。节点已持焦时：

- `FocusNode._doRequestFocus`（Flutter `widgets/focus_manager.dart:1183-1190`）在
  `hasPrimaryFocus && _markedForFocus in {null, this}` 上**直接 return**，连
  `_markNextFocus` 都不走；
- 即使没持焦，`FocusManager._markNextFocus`（`:1901-1910`）在 `_primaryFocus == node`
  时只把 `_markedForFocus` 清空、**不调度**；`_markNeedsUpdate`（`:1920-1932`）还有
  `_haveScheduledUpdate` 把同帧 N 次请求合并成**一个**微任务；
- `applyFocusChangesIfNeeded`（`:1985`、`:1999`）两道 `previousFocus != _primaryFocus`
  闸，primary 没变就既不脏化节点也不 `notifyListeners()`。

净成本 = 谓词两个布尔 + `_setAsFocusedChildForScope()` 的 remove/add（节点已在末位时
逐元素等价、不可观察）。**0 微任务 / 0 rebuild / 0 平台通道**（`focus_manager.dart`
全文无任何 `SystemChannels` / `TextInput` 调用；阅读器正文节点是裸 `Focus`，不是
`EditableText`）。

### 依据 2：不会重演「触屏滚动被焦点修复拉回」

那条历史回归的根因是**被动焦点修复带的 reveal**：`HibikiFocusController.ensureFocus()`
→ `_scheduleReveal` → `HibikiFocusScroll.ensureVisible(alignment: 0.5)`，已按
`highlightMode == traditional` 门控（`test/focus/focus_repair_touch_no_scroll_test.dart`）。

`PageFocusOwnership.reclaim` 里**没有任何 reveal**，是另一套子系统；且阅读器正文
`_focusNode` 从未注册进 `HibikiFocusController._entries`（reader 全部 part 文件对
`HibikiFocusable` / `HibikiFocusTarget` 零命中），`HibikiFocusRing._onFocusManagerChange`
又要求 primaryFocus **身份变化**才 reveal——重复请求根本不触发通知。三层各自独立地
挡住了重演。

### 依据 3：逐 tick reclaim 不是本次新引入的量级

handler 的闸门条件是 `axis == 'horizontal' && !gate.shouldStartNewGesture(...)`。
**纵向**滚轮 tick 完全绕过闸门，自 TODO-737 起就一直每个 tick 都 reclaim——而纵向滚轮
正是桌面端的主路径。横向 in-flight 现在只是**对齐**了这个早已在跑的基准频率。

### 依据 4：移动端 / 触屏不同源

`_handlePagedWheelTick` 只绑 `wheel`（正文引擎 + spread 文档各一处）。手指滚动按规范不
合成 `WheelEvent`，走的是 `onSwipe`（JS 侧只在 `touchend` / `pointerup` 发一次，
Dart 侧 reclaim 是 O(手势) 而非 O(事件)）。只有外接鼠标 / 触控板能在移动端命中 wheel。

---

## 补的测试（生产代码零改动）

`git diff origin/develop -- hibiki/lib` 为空。

**① `test/reader/reader_wheel_focus_reclaim_frequency_test.dart`（新增）**

- *行为层*：跑**生产** `ReaderWheelGestureGate` 回放整段惯性，同时数翻页数和 reclaim 数——
  干净惯性 26 tick → 1 次回收；in-flight 全覆盖 11 tick → 11 次回收（有意接受，reason
  里写清为什么）；部分覆盖 → 6+1 次；并钉住「回收数上界永远是 tick 数」。
- *结构层*：回放器只是**复刻**顺序，改不了源码里的真实位置，所以另加一条结构守卫——
  `onWheelPaginate` handler 内 `_focusOwnership.reclaim(` **有且仅有一处**，且必须排在
  手势闸门的早退 `return` 之后。窗口由 `enclosingCallOf` 圆括号配对给出，语料先过
  `maskCommentsAndScriptLines` 词法掩码，断言走 `containsCodeLine`（本仓注释极详尽，
  不掩码的话满篇同名文本会把守卫兜住）。

**② `test/focus/page_focus_ownership_test.dart`（新增一组）**

把「高频 reclaim 可接受」的两条前提写成 `PageFocusOwnership` 自身的契约：
跨帧重复 reclaim **零焦点通知**（node + FocusManager 两个计数器）、且**绝不滚动**所在
视口。循环必须**逐帧驱动**（真实 tick 相隔 ~60ms）——同帧内连打会被 FocusManager 合并，
测不出任何东西，注释里写明了这一点。

## 变异实测（6 次，全部反向替换还原，未用 `git checkout --`）

| # | 变异（都在**生产**代码上） | 结果 |
|---|---|---|
| M1 | 闸门 `_lastTickAt = now` 改回无条件写（= 退回「仅首个 tick」） | 🔴 频次用例红：11→1、7→1（4 passed / 2 failed，行为红非编译红） |
| M2 | `reclaim` 挪到闸门 `if` **之前**（= 每个 tick 都发） | 🔴 结构守卫红：`Expected greater than <798> / Actual <689>`（5/1） |
| M5 | 删掉闸门分支里的 `return;` | 🔴 结构守卫红：早退断言 `true→false`（5/1） |
| M6 | handler 里多写一处 `reclaim` | 🔴 结构守卫红：`Expected <1> / Actual <2>`（5/1） |
| M3 | `reclaim` 改成 `node.unfocus(); node.requestFocus();` | 🟢 **存活** |
| M3b | `reclaim` 改成 `node.unfocus(); scheduleMicrotask(node.requestFocus);` | 🔴 计数器红：`Expected <0> / Actual <40>` |
| M4 | `reclaim` 里加 `Scrollable.ensureVisible(ctx, alignment: 0.5)` | 🔴 滚动断言红：`1900.0 → 1725.0` |

**M3 存活是有意保留的结论，不是漏网**：同步 `unfocus()+requestFocus()` 被 Flutter 完整
吸收（`_markedForFocus` 回到 null、不调度更新），它**真的**不是行为变化。M3b 才是能制造
churn 的形态，用它证明计数器有牙。

过程中还踩到并修正了一次**假红**：M3a（`unfocus` + post-frame `requestFocus`）最初红在
`hasPrimaryFocus` 这个**前置断言**（line 100）而不是计数器上——等于计数器仍未被证明。
据此把 fixture 改成「先 `pumpAndSettle` 建立焦点、循环逐帧推进」，M3b 才落在计数器上。

## 验证

- `dart format`：2 files（0 changed，已格式化）
- `flutter analyze`（全量含 test）：`No issues found! (ran in 30.1s)`，exit 0
- 35 条整批：`FLUTTER TEST VERDICT: PASSED - 225 tests ran, all tests passed`，exit 0（N=225 对齐基线）
- 定向 `test/reader` + `test/focus`：`FLUTTER TEST VERDICT: PASSED - 1404 tests ran, all tests passed`，exit 0
- 「跑全了没」用结构判据：JSONL 里 `type=suite` 去重后 reader 171 / focus 17，与磁盘上
  `*_test.dart` 的 171 / 17 逐一对上（188/188），非 grep 数 `test(` 对账
- `hibiki/tool/tests_for_changes.dart` 推导：输出为空 ⇒ 无需额外加跑（两个文件都落在默认整批已覆盖的 Dart 树）

## 顺带发现（本 PR **不动**，留给后续）

`hibiki/lib/src/focus/hibiki_focus_ring.dart:203` 的 `_scheduleEnsureVisible` **缺少**
`if (!widget.enabled) return;` 门控（同类的 `_scheduleRecompute` 在 `:146` 有）。即焦点
导航实验开关关闭时，ring 不画，但「焦点变了就 `ensureVisibleIfHidden`」这条**滚动**路径
仍然是活的，只靠 `highlightMode == traditional` 挡触屏。对本次评估无害（阅读器正文节点
没有 `Scrollable` 祖先、也不触发通知），但它跟历史那条触屏回归是同一类暴露面。
