### PR TITLE
fix(test): methodBody 认箭头函数体 + 无体声明 fail loudly (TODO-2726/2727)

### DIFF
--- a/hibiki/test/helpers/source_guard.dart
+++ b/hibiki/test/helpers/source_guard.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 
 // ---------------------------------------------------------------------------
@@ -610,14 +612,107 @@ String maskCommentsAndScriptLines(String source) {
 /// - 命名参数 `foo({required int a})` 的左花括号在参数表里，先把参数表圆括号配对掉；
 /// - 方法体里字符串（含三引号 JS/CSS）与注释中的花括号不参与配对。
 ///
-/// 找不到签名、找不到左花括号、花括号不配对一律 `fail`，绝不返回空串——
-/// 空串会让后续 `contains` 静默变假，是最典型的假绿源。
+/// 找不到签名、找不到方法体、括号不配对一律 `fail`，绝不返回空串也绝不返回**邻居的
+/// 实现**——两者都会让后续 `contains` 静默变假（要求型断言假红 / 禁止型断言假绿），
+/// 是最典型的假绿源。
 /// 被扫描语料的词法族。决定 [methodBody] 用哪套掩码去找签名与配对花括号。
 ///
 /// [SourceLexicon.dart] 同时适用 C++（`//`、`/* */`、单双引号，规则一致；C++ 的
 /// 原始串 `R"(...)"` 不认，目标文件里有就别用结构窗口）。
 /// [SourceLexicon.js] 额外认模板串与正则字面量。
 enum SourceLexicon { dart, js }
+
+/// 方法体的词法形态。
+///
+/// 花括号体与箭头体是 Dart 里**同等合法**的两种函数体，[methodBody] 必须都认：
+/// 只认花括号的旧实现遇到 `T f(a) => expr;` 会跳过参数表后一路 `indexOf('{')` 找到
+/// **下一个声明**的花括号，把邻居的实现当成"该函数的体"返回——不报错、不抛异常。
+/// 那是最危险的假绿形态：窗口凭空变宽，禁止型断言读到邻居的内容而假红，要求型断言
+/// 被邻居的内容喂绿。
+enum MethodBodyForm {
+  /// `T f(a) { … }`
+  brace,
+
+  /// `T f(a) => expr;`（含 `=> switch (x) { … };` 这类体内带花括号的表达式）
+  arrow,
+}
+
+/// 一个方法体的形态与边界（下标都落在**掩码串**上，与原串逐字节对齐）。
+class _MethodBodyBounds {
+  const _MethodBodyBounds(this.form, this.close);
+
+  final MethodBodyForm form;
+
+  /// 收口字符的下标：花括号体是配对上的 `}`，箭头体是深度 0 的 `;`。
+  final int close;
+}
+
+/// 从签名起点 [start] 起，在掩码串 [structural] 上定位方法体的形态与右边界。
+///
+/// 一遍扫描同时替掉旧实现的两段逻辑（"先把参数表圆括号配对掉"与"再 indexOf('{')"）：
+/// 圆/方括号深度 >0 的位置一律跳过，于是命名参数的 `{`、可选位置参数的 `[`、默认值
+/// 里的 `= () => x` 都不会被当成体的起点。深度 0 上先遇到谁就是谁：
+/// - `=>` ⇒ 箭头体，右边界是深度 0 的 `;`（`=> switch (x) { … };` 里的花括号不收口）；
+/// - `{`  ⇒ 花括号体，右边界由配对给出；
+/// - `;`  ⇒ **没有体**（抽象声明 / `external` / 字段声明）⇒ 返回 null 让调用方 `fail`。
+///
+/// 最后一条是本函数存在的另一半理由：旧实现在这里会继续往后找下一个 `{`，同样静默
+/// 返回邻居的实现。
+_MethodBodyBounds? _methodBodyBounds(String structural, int start) {
+  int depth = 0;
+  for (int i = start; i < structural.length; i++) {
+    final String c = structural[i];
+    if (c == '(' || c == '[') {
+      depth++;
+      continue;
+    }
+    if (c == ')' || c == ']') {
+      depth--;
+      continue;
+    }
+    if (depth != 0) continue;
+    if (c == '=' && i + 1 < structural.length && structural[i + 1] == '>') {
+      final int semi = _arrowBodyEnd(structural, i + 2);
+      if (semi < 0) return null;
+      return _MethodBodyBounds(MethodBodyForm.arrow, semi);
+    }
+    if (c == '{') {
+      final int close = _balancedBraceEnd(structural, i);
+      if (close < 0) return null;
+      return _MethodBodyBounds(MethodBodyForm.brace, close);
+    }
+    if (c == ';') return null;
+  }
+  return null;
+}
+
+/// 箭头体的收口：从 [from] 起找**深度 0** 的 `;`，圆/方/花括号内的分号不算。
+///
+/// 花括号也要计深度，否则 `=> switch (x) { 1 => 'a', _ => 'b' };` 里
+/// `case` 体内的分号会提前收口。找不到返回 -1。
+int _arrowBodyEnd(String structural, int from) {
+  int depth = 0;
+  for (int i = from; i < structural.length; i++) {
+    final String c = structural[i];
+    if (c == '(' || c == '[' || c == '{') {
+      depth++;
+      continue;
+    }
+    if (c == ')' || c == ']' || c == '}') {
+      depth--;
+      continue;
+    }
+    if (c == ';' && depth == 0) return i;
+  }
+  return -1;
+}
+
+/// 审计钩子：置位后 [methodBody] 每次调用都往 stdout 打一行
+/// `#MBAUDIT|<form>|<signature>`，用来**反向枚举**全仓有多少守卫锚在箭头函数上。
+///
+/// 只在专门的审计跑里开（`HIBIKI_METHOD_BODY_AUDIT=1`），常规跑零开销、零输出。
+final bool _methodBodyAudit =
+    Platform.environment['HIBIKI_METHOD_BODY_AUDIT'] == '1';
 
 String methodBody(
   String src,
@@ -635,34 +730,74 @@ String methodBody(
   if (start < 0) {
     fail('源码中找不到方法签名（注释内的同名文本不算）：$signature');
   }
-  int bodySearchFrom = start;
-  final int firstBrace = structural.indexOf('{', start);
-  final int paren = structural.indexOf('(', start);
-  if (paren >= 0 && firstBrace >= 0 && paren < firstBrace) {
-    int parenDepth = 0;
-    for (int i = paren; i < structural.length; i++) {
-      if (structural[i] == '(') parenDepth++;
+  final _MethodBodyBounds? bounds = _methodBodyBounds(structural, start);
+  if (_methodBodyAudit) {
+    // ignore: avoid_print
+    print('#MBAUDIT|${bounds?.form.name ?? 'none'}|'
+        '${signature.replaceAll('\n', r'\n')}');
+  }
+  if (bounds == null) {
+    fail('方法签名后找不到可收口的方法体（花括号体不配对 / 箭头体缺分号 / '
+        '这是个没有体的声明）：$signature');
+  }
+  return src.substring(start, bounds.close + 1);
+}
+
+/// 按**函数名**取 [src] 里那个函数的**实现体**原文；`=> expr;` 与 `{ … }` 两种形态
+/// 都认，找不到声明返回 null。
+///
+/// 与 [methodBody] 的分工——两者都不可省：
+/// - [methodBody] 的起点是**签名文本**的首次出现，找不到就 `fail`。适合"我知道这个
+///   方法长什么样、它必须存在"的守卫。
+/// - 本函数只给**名字**，自己在候选里筛掉调用点（`name(` 后面既不是 `=>` 也不是 `{`
+///   的那些），并允许"没有这个函数"是个合法答案（返回 null 由调用方决定怎么报）。
+///   适合"这个中转函数如果存在，它必须先查翻译表"这类**一跳可达**判据——被查的名字
+///   是数据（来自另一处解析出的 callee），写不出固定签名文本。
+///
+/// 返回的是**体本身**：花括号体含 `{}`，箭头体是 `=>` 与 `;` 之间的表达式原文（不含
+/// 两端）。调用方拿它做 [containsIdentifierCall] 之类的可达性判据。
+///
+/// 收口逻辑与 [methodBody] 共用 [_arrowBodyEnd] / [_balancedBraceEnd]：箭头体的
+/// "深度 0 分号"规则只有一份，不会两处各写一遍再慢慢漂开。
+String? topLevelFunctionBody(String src, String name) {
+  final String structural = maskCommentsAndStrings(src);
+  final RegExp declaration = RegExp(
+    r'(?<![A-Za-z0-9_$.])' + RegExp.escape(name) + r'\s*\(',
+  );
+  for (final RegExpMatch match in declaration.allMatches(structural)) {
+    final int open = match.end - 1;
+    int depth = 0;
+    int close = -1;
+    for (int i = open; i < structural.length; i++) {
+      if (structural[i] == '(') depth++;
       if (structural[i] == ')') {
-        parenDepth--;
-        if (parenDepth == 0) {
-          bodySearchFrom = i;
+        depth--;
+        if (depth == 0) {
+          close = i;
           break;
         }
       }
     }
-    if (parenDepth != 0) {
-      fail('方法签名的参数表圆括号不配对：$signature');
+    if (close < 0) continue;
+    int i = close + 1;
+    while (i < structural.length && structural[i].trim().isEmpty) {
+      i++;
     }
+    if (i + 1 < structural.length &&
+        structural[i] == '=' &&
+        structural[i + 1] == '>') {
+      final int semi = _arrowBodyEnd(structural, i + 2);
+      if (semi < 0) return null;
+      return src.substring(i + 2, semi);
+    }
+    if (i < structural.length && structural[i] == '{') {
+      final int end = _balancedBraceEnd(structural, i);
+      if (end < 0) return null;
+      return src.substring(i, end + 1);
+    }
+    // 既不是 `=>` 也不是 `{`：这一处是**调用**而不是声明，继续找下一处。
   }
-  final int open = structural.indexOf('{', bodySearchFrom);
-  if (open < 0) {
-    fail('方法签名后找不到左花括号：$signature');
-  }
-  final int close = _balancedBraceEnd(structural, open);
-  if (close < 0) {
-    fail('方法体花括号不配对：$signature');
-  }
-  return src.substring(start, close + 1);
+  return null;
 }
 
 /// 从 [structural]（已掩码的语料）的左花括号 [open] 起做配对，返回配对上的 `}` 的
@@ -728,6 +863,45 @@ String balancedBlockFrom(
   return src.substring(start, close + 1);
 }
 
+/// 取 [src] 里 `… <name> = <表达式>;` 的**初始化表达式**原文（不含 `=` 与结尾 `;`）。
+///
+/// 字段、顶层常量、方法体里的局部变量都适用。用来把「这个量是怎么来的」这类契约从
+/// **逐字拼写**抬上来：旧写法是
+/// `src.contains('static const int _loopbackRingCapacityMs = 60000;')`，它同时钉死了
+/// 修饰符顺序、空格、类型名和结尾分号 —— `dart format` 重排、加一个 `final`、把常量
+/// 挪进别的类都会让守卫在**实现完全正确**时转红，而真正要守的「这个值等于 native 的
+/// 环容量」一条都没守到。
+///
+/// 拿到表达式后直接断言它的**语义**：值是多少、有没有引用某个不该引用的常量、
+/// 是不是某个构造器。
+///
+/// 只认**赋值**的 `=`：紧跟其后的 `=` 或 `>` 说明这其实是 `==` 比较或 switch 表达式
+/// 的 `=>` 分支，一律跳过——否则 `if (a == name)` 会被当成声明。
+///
+/// 不需要再看 `=` **之前**那个字符：正则要求 `=` 只能隔着空白紧跟 [name]，
+/// `name != x` / `name += 1` / `name >= 2` 里的 `=` 前面隔着 `!` `+` `>`，本来就匹配
+/// 不上。（曾经写过一条 "前一个字符是复合运算符就跳过" 的判断，变异实测证明它
+/// **永远不可达**，删掉了：不可达的判据只会让人误以为这里已经守住了。）
+///
+/// 找不到返回 null（由调用方决定怎么报）。
+String? initializerExpression(String src, String name) {
+  final String structural = maskCommentsAndStrings(src);
+  final RegExp pattern = RegExp(
+    r'(?<![A-Za-z0-9_$.])' + RegExp.escape(name) + r'\s*=',
+  );
+  for (final RegExpMatch match in pattern.allMatches(structural)) {
+    final int eq = match.end - 1;
+    if (eq + 1 < structural.length &&
+        (structural[eq + 1] == '=' || structural[eq + 1] == '>')) {
+      continue;
+    }
+    final int semi = _arrowBodyEnd(structural, eq + 1);
+    if (semi < 0) return null;
+    return src.substring(eq + 1, semi).trim();
+  }
+  return null;
+}
+
 /// 在 [body] 的**代码行**上查找 [needle]，注释里的同名文本不算数。
 ///
 /// 裸 `body.contains('foo()')` 会被注释里的同名字面量喂成假绿——本仓一天抓到过 6 起
@@ -765,6 +939,22 @@ RegExp identifierCall(String name, {bool allowNamedConstructor = true}) {
         (allowNamedConstructor ? r'(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)?' : '') +
         r'(?:\s*<[^>]*>)?\s*\(',
   );
+}
+
+/// [source] 的**代码**里是否出现以独立标识符身份出现的 [name]（不要求它是个调用）。
+///
+/// 禁止型断言（"这个被废弃的常量/字段不许回来"）的标准判据。裸
+/// `src.contains('_galAudioBackMs')` 两个方向都错：
+/// - **假红**：一句解释性注释里提到这个名字（"历史：这里曾有 _galAudioBackMs"）就判红，
+///   而守卫因此永久红——比漏掉更糟，因为下一个人只会把断言删掉；
+/// - **假阳**：`_galAudioBackMsLegacy` 这种更长的标识符含有该子串，正确写法反被判红。
+///
+/// 与 [containsIdentifierCall] 的分工：那个要求后面跟 `(`（是次调用），这个只问
+/// "这个名字作为标识符出现过没有"，字段引用、常量、类型名都算。
+bool containsIdentifier(String source, String name) {
+  return RegExp(
+    r'(?<![A-Za-z0-9_$])' + RegExp.escape(name) + r'(?![A-Za-z0-9_$])',
+  ).hasMatch(maskComments(source));
 }
 
 /// [identifierCall] 的 `contains` 形态：[source] 的**代码**里是否出现以独立标识符

--- a/hibiki/test/helpers/source_guard_lexer_test.dart
+++ b/hibiki/test/helpers/source_guard_lexer_test.dart
@@ -240,6 +240,305 @@ final b = \'\'\'{ js }\'\'\';
     });
   });
 
+  // -------------------------------------------------------------------------
+  // ④' 箭头函数体（TODO-2726）
+  // -------------------------------------------------------------------------
+  //
+  // 这一组语料全部**手写合成**，不读磁盘：判据必须能在「被守文件恰好长成另一个样」
+  // 时仍然点名验证到每一条分支。真实文件既证不了负例（健康仓库里箭头越界不会发生
+  // 两次），也会让「注释把变异兜住」的老陷阱重演。
+  group("④' methodBody 认箭头函数体（TODO-2726：只认花括号会静默返回邻居）", () {
+    /// 越界的**充分必要**语料：箭头函数紧跟一个花括号体的邻居。
+    /// 旧实现在这里会把 `neighbourBody` 整段读进窗口。
+    const String arrowThenBrace = '''
+String alpha(int x) => 'A\$x';
+
+String beta(int x) {
+  return 'neighbourBody';
+}
+''';
+
+    test('箭头体只取到自己的分号，不吞掉紧随其后的花括号邻居', () {
+      final String body = methodBody(arrowThenBrace, 'String alpha(int x)');
+      expect(body.contains("'A"), isTrue, reason: '箭头体自身必须在窗口里');
+      expect(body.trimRight().endsWith(';'), isTrue,
+          reason: '箭头体的右边界是深度 0 的分号');
+      expect(body.contains('neighbourBody'), isFalse,
+          reason: '这正是 TODO-2726：旧实现把邻居 beta 的实现当成 alpha 的体返回');
+    });
+
+    test('=> switch (…) { … }; 里的花括号不提前也不延后收口', () {
+      const String src = '''
+String label(int x) => switch (x) {
+      1 => 'one',
+      _ => 'other',
+    };
+
+String next() {
+  return 'neighbourBody';
+}
+''';
+      final String body = methodBody(src, 'String label(int x)');
+      expect(body.contains("'other'"), isTrue, reason: 'switch 表达式整段都在体内');
+      expect(body.contains('neighbourBody'), isFalse);
+    });
+
+    test('箭头体里实参内的分号不提前收口', () {
+      const String src = '''
+String f() => g('a;b', <int>[1, 2]);
+
+String next() {
+  return 'neighbourBody';
+}
+''';
+      final String body = methodBody(src, 'String f()');
+      expect(body.contains('<int>[1, 2]'), isTrue);
+      expect(body.contains('neighbourBody'), isFalse);
+    });
+
+    test('箭头体里闭包**语句块**的分号不提前收口（真·深度 >0 的分号）', () {
+      // 上一条的 `'a;b'` 在结构串里已被掩成空白，其实**碰不到**深度判断这条分支。
+      // 闭包体里的分号是真的、在花括号深度 1 上——只有这里才验得到「深度 0 才收口」。
+      const String src = '''
+String f() => run(() {
+      final int a = 1;
+      return a.toString();
+    });
+
+String next() {
+  return 'neighbourBody';
+}
+''';
+      final String body = methodBody(src, 'String f()');
+      expect(body.contains('a.toString()'), isTrue, reason: '首个分号收口会把闭包体拦腰截断');
+      expect(body.trimRight().endsWith(');'), isTrue);
+      expect(body.contains('neighbourBody'), isFalse);
+    });
+
+    test('命名参数默认值里的 => 不被当成函数体起点', () {
+      const String src = '''
+Widget wrap({Widget Function() build = _fallback, required Widget child}) {
+  return Padding(padding: EdgeInsets.zero, child: child);
+}
+''';
+      final String body = methodBody(
+        src,
+        'Widget wrap({Widget Function() build = _fallback',
+      );
+      expect(body.contains('Padding('), isTrue,
+          reason: '参数表里的 => 在圆括号深度 >0，不该收口');
+    });
+
+    test('没有体的声明（抽象方法）fail loudly，绝不静默锚到下一个声明', () {
+      const String src = '''
+abstract class A {
+  void target();
+}
+
+class B {
+  void other() {
+    final String s = 'neighbourBody';
+  }
+}
+''';
+      expect(
+        () => methodBody(src, 'void target()'),
+        throwsA(isA<TestFailure>()),
+        reason: '旧实现会一路找到 B.other 的花括号，把邻居的体当成 target 的体',
+      );
+    });
+
+    test('花括号体不受影响（回归）', () {
+      const String src = '''
+String beta(int x) {
+  return 'own';
+}
+
+String next() {
+  return 'neighbourBody';
+}
+''';
+      final String body = methodBody(src, 'String beta(int x)');
+      expect(body.contains("'own'"), isTrue);
+      expect(body.contains('neighbourBody'), isFalse);
+    });
+  });
+
+  group("④'' topLevelFunctionBody：按名字取体，跳过调用点", () {
+    const String src = '''
+String headline({required String reason}) => label(reason);
+
+String label(String code) {
+  switch (code) {
+    case 'x':
+      return 'X';
+  }
+  return code;
+}
+
+void caller() {
+  headline(reason: 'never-part-of-a-body');
+}
+''';
+
+    test('箭头体返回 => 与 ; 之间的表达式，不含邻居', () {
+      final String? body = topLevelFunctionBody(src, 'headline');
+      expect(body, isNotNull);
+      expect(containsIdentifierCall(body!, 'label'), isTrue,
+          reason: '一跳可达判据靠的就是这个窗口');
+      expect(body.contains("case 'x'"), isFalse,
+          reason: '不得读到邻居 label 的 switch 块（PR#762 实测到的那次假绿）');
+    });
+
+    test('花括号体返回含 {} 的整块', () {
+      final String? body = topLevelFunctionBody(src, 'label');
+      expect(body, isNotNull);
+      expect(body!.trimLeft().startsWith('{'), isTrue);
+      expect(body.contains("case 'x'"), isTrue);
+      expect(body.contains('never-part-of-a-body'), isFalse);
+    });
+
+    test('只有调用点没有声明时返回 null，不返回调用方的体', () {
+      const String callsOnly = '''
+void caller() {
+  headline(reason: 'r');
+}
+''';
+      expect(topLevelFunctionBody(callsOnly, 'headline'), isNull);
+    });
+
+    test('调用点排在声明之前时仍锚到声明', () {
+      const String callFirst = '''
+void caller() {
+  headline(reason: 'r');
+}
+
+String headline({required String reason}) => label(reason);
+''';
+      final String? body = topLevelFunctionBody(callFirst, 'headline');
+      expect(body, isNotNull);
+      expect(containsIdentifierCall(body!, 'label'), isTrue);
+    });
+  });
+
+  // 禁止型断言（isFalse）在健康仓库里**永远零命中**：判据自己坏掉时，扫盘那一路
+  // 检验不到。所以判据必须在**手写语料**上单独验证，且与磁盘扫描互不依赖。
+  group('containsIdentifier：禁止型判据的自校验（手写语料，不读磁盘）', () {
+    test('代码里以独立标识符出现 ⇒ 命中', () {
+      expect(
+        containsIdentifier(
+            '  static const int _galAudioBackMs = 8000;', '_galAudioBackMs'),
+        isTrue,
+      );
+      expect(
+        containsIdentifier('final int x = _galAudioBackMs;', '_galAudioBackMs'),
+        isTrue,
+      );
+    });
+
+    test('只出现在注释里 ⇒ 不命中（否则守卫会被一句解释永久判红）', () {
+      expect(
+        containsIdentifier(
+            '// 历史：这里曾有 _galAudioBackMs 同时当两个量用。\nfinal int a = 1;',
+            '_galAudioBackMs'),
+        isFalse,
+      );
+      expect(
+        containsIdentifier('/* _galAudioBackMs */', '_galAudioBackMs'),
+        isFalse,
+      );
+    });
+
+    test('更长的标识符含同名子串 ⇒ 不命中（否则正确写法反被判红）', () {
+      expect(
+        containsIdentifier(
+            'const int _galAudioBackMsLegacy = 1;', '_galAudioBackMs'),
+        isFalse,
+      );
+      expect(
+        containsIdentifier(
+            'const int x_galAudioBackMs = 1;', '_galAudioBackMs'),
+        isFalse,
+      );
+    });
+
+    test('不要求是次调用（与 containsIdentifierCall 的分工）', () {
+      expect(containsIdentifier('a = selectable && !excluded;', 'selectable'),
+          isTrue);
+      expect(
+        containsIdentifierCall('a = selectable && !excluded;', 'selectable'),
+        isFalse,
+      );
+    });
+  });
+
+  group('initializerExpression：取「这个量是怎么来的」而不是逐字拼写', () {
+    test('取到分号前的整段表达式，与修饰符/空格/类型名无关', () {
+      const String src = '''
+class A {
+  static const int cap = 60 * 1000;
+  static const Duration window = Duration(seconds: 20);
+}
+''';
+      expect(initializerExpression(src, 'cap'), '60 * 1000');
+      expect(initializerExpression(src, 'window'), 'Duration(seconds: 20)');
+    });
+
+    test('实参/集合字面量里的分号不提前收口', () {
+      const String src = "final String s = fn('a;b', <int>[1]);";
+      expect(initializerExpression(src, 's'), "fn('a;b', <int>[1])");
+    });
+
+    test('闭包**语句块**里的分号不提前收口（真·深度 >0 的分号）', () {
+      // 上一条的 `'a;b'` 在结构串里已被掩成空白，碰不到深度判断。闭包体里的分号是
+      // 真的、在花括号深度 1 上——只有这里才验得到「深度 0 才收口」。
+      const String src = '''
+final VoidCallback cb = () {
+  count += 1;
+};
+final int tail = 7;
+''';
+      expect(initializerExpression(src, 'cb'), '() {\n  count += 1;\n}');
+    });
+
+    test('`name == x` 是比较，不是声明', () {
+      const String src = '''
+bool f(int name) {
+  if (name == 3) return true;
+  return false;
+}
+''';
+      expect(initializerExpression(src, 'name'), isNull);
+    });
+
+    test('switch 表达式的 `pattern => …` 分支不被当成声明', () {
+      // `v =>` 与 `v =` 只差一个字符，且它出现在真声明**之前**：
+      // 少了这一条，取到的会是那个分支的表达式而不是变量的初始化式。
+      const String src = '''
+void f(int x) {
+  final String s = switch (x) {
+    1 => 'one',
+    v => 'other',
+  };
+  final int v = 9;
+}
+''';
+      expect(initializerExpression(src, 'v'), '9');
+    });
+
+    test('注释里的同名声明不算数', () {
+      const String src = '''
+// 旧值 static const int cap = 8000;
+static const int cap = 60000;
+''';
+      expect(initializerExpression(src, 'cap'), '60000');
+    });
+
+    test('找不到返回 null，不返回空串', () {
+      expect(initializerExpression('const int a = 1;', 'b'), isNull);
+    });
+  });
+
   group('enclosingCall：窗口由括号配对给出，不靠定长/相邻声明', () {
     const String src = '''
     SettingsCustomItem(

--- a/hibiki/test/mining/gal_audio_degrade_track_test.dart
+++ b/hibiki/test/mining/gal_audio_degrade_track_test.dart
@@ -304,19 +304,52 @@ void main() {
     final String panel = File(
       'lib/src/mining/gal_audio_tracks_panel.dart',
     ).readAsStringSync();
+    // 「可选性」这个量本身必须由**后端**算出来。
     expect(
-      panel.contains('galTrackSelectionAffectsCapture(state.audioBackend)'),
-      isTrue,
+      initializerExpression(panel, 'selectionEffective'),
+      'galTrackSelectionAffectsCapture(state.audioBackend)',
       reason: '解释/禁用判据必须是后端，不能再是 audioTracks.isEmpty',
     );
+    // 解释态同理：先看后端，再谈别的。旧断言写的是
+    // `isFalse` + `'state.audioTracks.isEmpty && emptyHint'` —— 那个串在实现里
+    // **从来就不存在**（真实写法是 `... && backendHint == null`），是一条永远零命中
+    // 的禁止型断言：判据自己坏掉时没有任何东西会发现。改成钉可达顺序。
+    final String? hintExpr = initializerExpression(panel, 'backendHint');
+    expect(hintExpr, isNotNull, reason: 'backendHint 改名了：守卫失去锚点');
     expect(
-      panel.contains('state.audioTracks.isEmpty && emptyHint'),
-      isFalse,
-      reason: '列表非空时解释态被跳过，正是 BUG-1102 里整套死控件照常渲染的原因',
+      hintExpr!.trimLeft().startsWith('selectionEffective'),
+      isTrue,
+      reason: '列表空不空只能决定末梢文案；先决条件必须是后端 —— '
+          '反过来就是 BUG-1102 里整套死控件照常渲染的成因',
     );
-    expect(panel.contains('selectable: selectionEffective'), isTrue);
-    expect(panel.contains('enabled: selectable && !excluded'), isTrue,
+    // TODO-2727：下面两条原本是 `panel.contains('selectable: selectionEffective')`
+    // 与 `panel.contains('enabled: selectable && !excluded')` —— 把**参数顺序、空格、
+    // 布尔表达式的书写顺序**全钉进了契约。`!excluded && selectable` 是同一语义的
+    // 合法写法，旧断言会在实现完全正确时转红；反过来把 `selectable:` 换给别的控件
+    // 而字面量恰好还在文件里某处，旧断言又照样绿。
+    //
+    // 改成问「这个值被交给了谁」：轨行拿到的 selectable 就是后端判据本身，
+    // 「设为语音轨」那个按钮的 enabled 必须同时受 selectable 与 excluded 约束。
+    final int tileAt = maskComments(panel).indexOf('GalTrackTile(');
+    expect(tileAt, greaterThanOrEqualTo(0),
+        reason: 'GalTrackTile 改名了：守卫锚点必须跟着改，不能静默失效');
+    final EnclosingCall tile =
+        enclosingCall(panel, tileAt + 'GalTrackTile('.length);
+    expect(tile.name, 'GalTrackTile');
+    expect(namedArgumentValues(tile.text, 'selectable'),
+        <String>['selectionEffective'],
+        reason: '轨行的可选性必须直接来自后端判据 selectionEffective');
+
+    // 「设为语音轨」按钮：用 onTap 认它是哪一个（语义锚），再看它的 enabled 判据。
+    final EnclosingCall selectButton =
+        enclosingCallOf(panel, 'onTap: onSelect');
+    final List<String> enabled =
+        namedArgumentValues(selectButton.text, 'enabled');
+    expect(enabled, hasLength(1), reason: '「设为语音轨」按钮必须显式声明 enabled，缺省即恒可点');
+    expect(containsIdentifier(enabled.single, 'selectable'), isTrue,
         reason: '非引擎 PCM 后端必须禁用「选为语音轨」');
+    expect(containsIdentifier(enabled.single, 'excluded'), isTrue,
+        reason: '已排除为 BGM 的轨不得再被选成语音轨');
     expect(panel.contains('t.game_track_silent_at_cue'), isTrue,
         reason: '此刻没有声音的轨必须标注，而不是和可用轨长一个样');
     // BUG-1165：判据不得再用 clipCount——native 的 clip_count 是全环累计，一条轨
@@ -470,38 +503,74 @@ void main() {
     endpoints.dispose();
   });
 
-  test('BUG-1094 补录窗口与回取上限解耦：常量与错误注释都必须改掉', () {
+  test('BUG-1094 补录窗口与回取上限解耦：两个量各有各的常量，环容量对齐 native 真相源', () {
+    // TODO-2727：这一条原本是六条 `src.contains('<原样抄下来的一行>')`。那批判据
+    // 钉的是**拼写**（修饰符顺序、空格、结尾分号、甚至一整句中文注释），而不是不变式：
+    // - `dart format` 重排、加一个 `final`、把常量挪进别的类 ⇒ 实现完全正确却转红；
+    // - 反过来，只要那些串还在文件里的**任何位置**（哪怕在注释里）就照样绿；
+    // - 其中两条（`kRingSeconds = 60`、`环形缓冲实际保留 60 秒`）钉的干脆就是注释
+    //   内容——等于把断言字面量存在被守文件的注释里，而注释里那个 `:21` 行号今天
+    //   已经指错（真实位置是 `audio_loopback_capture.cpp:22`）。**注释是会漂的，
+    //   它不是真相源**。真相源是 native 那个常量本身，所以下面直接读它对账。
     final String src = File(
       'lib/src/mining/gal_hook_session_controller.dart',
     ).readAsStringSync();
+    final String code = maskComments(src);
+
+    // ① 那个「一个 8000 绑死两个语义」的旧标识符不许回来。
+    //    只扫代码：这是禁止型断言，被一句解释性注释判红比漏掉更糟——守卫会永久红。
+    //    带标识符边界：`_galAudioBackMsLegacy` 这类更长的名字不算命中。
     expect(
-      src.contains('_galAudioBackMs'),
+      containsIdentifier(code, '_galAudioBackMs'),
       isFalse,
       reason: '一个 8000 的常量同时当补录窗口和回取上限，两个语义都被它绑死',
     );
+
+    // ② 环容量常量的**值**必须等于 native 的真相源。
+    //    这是跨语言契约，只有两边一起读才守得住；旧写法钉一行 Dart 字面量 + 一句
+    //    中文注释，native 那边把 kRingSeconds 改成 30 时它一动不动。
+    final String? capacity =
+        initializerExpression(src, '_loopbackRingCapacityMs');
+    expect(capacity, isNotNull, reason: '环容量常量改名了：守卫失去锚点，先修锚点再谈断言');
+    final File nativeFile = File('windows/runner/audio_loopback_capture.cpp');
+    expect(nativeFile.existsSync(), isTrue,
+        reason: 'native loopback 采集源不在了：跨语言契约的真相源必须先修');
+    final RegExpMatch? ring = RegExp(r'kRingSeconds\s*=\s*(\d+)')
+        .firstMatch(maskComments(nativeFile.readAsStringSync()));
+    expect(ring, isNotNull, reason: 'native kRingSeconds 改名了：Dart 侧上限失去依据');
     expect(
-      src.contains('static const int _loopbackRingCapacityMs = 60000;'),
-      isTrue,
+      int.parse(capacity!),
+      int.parse(ring!.group(1)!) * 1000,
+      reason: 'Dart 侧回取上限必须等于 native 环形缓冲的真实容量',
     );
-    expect(src.contains('kRingSeconds = 60'), isTrue,
-        reason: '必须记下环容量的真相源（native audio_loopback_capture.cpp）');
+
+    // ③ 回取长度这个量**是怎么算出来的**：上限是环容量，不是补录窗口。
+    final String finish = methodBody(
+      src,
+      'Future<bool> finishLineRecapture({bool discard = false}) async',
+    );
+    final String? backMs = initializerExpression(finish, 'backMs');
+    expect(backMs, isNotNull, reason: '回取长度不再是一个具名局部量：守卫失去锚点');
     expect(
-      src.contains(
-        'elapsedMs.clamp(_recaptureMinBackMs, _loopbackRingCapacityMs)',
-      ),
+      containsIdentifier(backMs!, '_loopbackRingCapacityMs'),
       isTrue,
       reason: '回取上限应是环的真实容量，不是补录窗口时长',
     );
     expect(
-      src.contains('环形缓冲实际保留 60 秒'),
-      isTrue,
-      reason: '旧注释「8 秒是因为环只有这么长」是错的，必须在原地写清真值',
+      containsIdentifier(backMs, '_recaptureWindow'),
+      isFalse,
+      reason: '回取长度一旦又由补录窗口换算而来，BUG-1094 就原地复活',
     );
+
+    // ④ 补录窗口是自己的时长常量，且不由环容量换算而来。
+    final String? window = initializerExpression(src, '_recaptureWindow');
+    expect(window, isNotNull, reason: '补录窗口常量改名了：守卫失去锚点');
+    expect(containsIdentifierCall(window!, 'Duration'), isTrue,
+        reason: '补录窗口必须是自己的时长常量，不再由回取上限换算而来');
     expect(
-      src.contains(
-          'static const Duration _recaptureWindow = Duration(seconds:'),
-      isTrue,
-      reason: '补录窗口必须是自己的时长常量，不再由回取上限换算而来',
+      containsIdentifier(window, '_loopbackRingCapacityMs'),
+      isFalse,
+      reason: '两个量必须解耦：窗口时长不许再引用环容量',
     );
   });
 
@@ -647,65 +716,18 @@ String _sessionOverviewCardSource() {
 /// 这种 BUG-1100 的原始形态，以及「中转函数自己把翻译那一跳删了」，都落在这一侧。
 bool _routesThroughFallbackLabel(String callee) {
   if (callee == _kFallbackLabel) return true;
-  final String? body = _topLevelFunctionBody(
+  // 用共享原语 [topLevelFunctionBody]：`=> expr;` 与 `{ … }` 两种体都认。
+  // 这里曾有一份私有实现（PR#762），因为当时的 [methodBody] 只认花括号体——
+  // `galHookFallbackHeadline` 是箭头函数，它会跳过参数表后一路找到**下一个**声明的
+  // 花括号（紧随其后的 `galHookFallbackLabel` 那个 switch 块），于是「一跳可达」
+  // 因为读到了邻居的实现而假绿。TODO-2726 把箭头体支持合回共享原语，私有副本删除：
+  // 两份收口逻辑各写一遍只会慢慢漂开。
+  final String? body = topLevelFunctionBody(
     File(_kFailureTextPath).readAsStringSync(),
     callee,
   );
   if (body == null) return false;
   return containsIdentifierCall(body, _kFallbackLabel);
-}
-
-/// 取 [src] 里顶层函数 [name] 的**实现体**原文；`=> expr;` 与 `{ … }` 两种形态都认。
-/// 找不到声明返回 null（失败信息由调用方给，这里不 fail）。
-///
-/// 为什么不能直接用 [methodBody]：它只认花括号体。`galHookFallbackHeadline` 是箭头
-/// 函数，[methodBody] 会跳过参数表后一路找到**下一个**声明的花括号——紧随其后的正是
-/// `galHookFallbackLabel` 那个 switch 块，于是「一跳可达」会因为读到了邻居的实现而
-/// 假绿。窗口锚错时守卫不报错、只是静默守错对象，这是最难发现的一类塌陷。
-String? _topLevelFunctionBody(String src, String name) {
-  final String structural = maskCommentsAndStrings(src);
-  final RegExp declaration = RegExp(
-    r'(?<![A-Za-z0-9_$.])' + RegExp.escape(name) + r'\s*\(',
-  );
-  for (final RegExpMatch match in declaration.allMatches(structural)) {
-    final int open = match.end - 1;
-    int depth = 0;
-    int close = -1;
-    for (int i = open; i < structural.length; i++) {
-      if (structural[i] == '(') depth++;
-      if (structural[i] == ')') {
-        depth--;
-        if (depth == 0) {
-          close = i;
-          break;
-        }
-      }
-    }
-    if (close < 0) continue;
-    int i = close + 1;
-    while (i < structural.length && structural[i].trim().isEmpty) {
-      i++;
-    }
-    if (i + 1 < structural.length &&
-        structural[i] == '=' &&
-        structural[i + 1] == '>') {
-      // 箭头体：收口在**深度 0** 的分号上。`=> switch (x) { … };` 里的花括号、
-      // 以及实参里的分号都不算，否则窗口会在半路截断。
-      int nest = 0;
-      for (int j = i + 2; j < structural.length; j++) {
-        final String c = structural[j];
-        if (c == '(' || c == '[' || c == '{') nest++;
-        if (c == ')' || c == ']' || c == '}') nest--;
-        if (c == ';' && nest == 0) return src.substring(i + 2, j);
-      }
-      return null;
-    }
-    if (i < structural.length && structural[i] == '{') {
-      return balancedBlockFrom(src, i, what: '$name 的实现体');
-    }
-    // 既不是 `=>` 也不是 `{`：这一处是**调用**而不是声明，继续找下一处。
-  }
-  return null;
 }
 
 /// 可控就绪状态 / 可排队台词的引擎 helper 替身。


### PR DESCRIPTION
## 缺陷（TODO-2726）

共享原语 `hibiki/test/helpers/source_guard.dart` 的 `methodBody` **只认花括号体**。
遇到 `T f(a) => expr;` 这种箭头函数，它跳过参数表后一路 `indexOf('{')`，找到**下一个声明**的花括号并当成"该函数的体"返回——**不报错、不抛异常，静默返回邻居的实现**，窗口凭空变宽。

这与 `balancedBlockFrom` 的设计原则直接相悖（那个原语当初就定了「失败要响，不许静默返回空」）。

**已复现**（合成语料）：

```dart
String alpha(int x) => 'A$x';

String beta(int x) {
  switch (x) { case 1: return 'BETA_MARKER'; }
  return '';
}
```

`methodBody(src, 'String alpha(int x)')` 返回的窗口整段包含 `beta` 的 switch 块（含 `BETA_MARKER`）。

## 🔴 影响面：反向枚举结论 = 0，且这个「0」是**测**出来的

给 `methodBody` 加了 `HIBIKI_METHOD_BODY_AUDIT=1` 审计钩子（每次调用打一行 `#MBAUDIT|<form>|<signature>`），跑**全量套件**取运行期真值：

| | |
|---|---|
| 共享原语调用点（静态枚举，已排除 26 份本地影子副本） | **116** |
| 运行期审计到的 (形态, 签名) 去重 | **108** |
| 形态分布 | **brace 134 次；arrow 0；无体声明 0** |

覆盖率对账（结构判据，不是数 `test(` 的算术）：静态字面量签名逐条与运行期审计集合求差，「静态有、审计没打到」的 9 条里 6 条是本 PR 新增的合成语料、3 条是插值签名（`'$eventName', function` 之类，运行期解析成 `'wheel', function(e)` 等，落在审计集合里）。

**结论：此前没有任何守卫经由共享原语在假绿。** 仓库里唯一一处真实的箭头函数锚点是 PR#762 那条 `galHookFallbackHeadline`，而它当时已经**绕开**了 `methodBody`、自建私有实现。

审计钩子保留（常规跑零输出、零开销），下次谁再动这个原语可以一条命令重跑反向枚举。

## 修法：加箭头支持 **且** fail loudly（两者都要）

`methodBody` 改为**一遍扫描**同时定形态与右边界，替掉旧的两段逻辑（先配对参数表圆括号、再 `indexOf('{')`）：

- 圆/方括号深度 >0 一律跳过 ⇒ 命名参数的 `{`、可选位置参数的 `[`、默认值里的 `= () => x` 都不再被当成体的起点；
- 深度 0 上先遇到谁就是谁：`=>` ⇒ 箭头体（右边界是**深度 0** 的 `;`，`=> switch (x) { … };` 里的花括号不收口）；`{` ⇒ 花括号体（配对定界）；`;` ⇒ **没有体**的声明（抽象 / `external` / 字段）⇒ **fail loudly**。

最后一条是修法的另一半：旧实现在这里同样会继续找下一个 `{`，同样静默返回邻居的实现。**现在绝不再有「静默返回错误内容」这条路径。**

### 私有副本合回共享原语

新增 `topLevelFunctionBody(src, name) -> String?`（按**名字**取体、自己筛掉调用点、允许「没有」是合法答案返回 null），`gal_audio_degrade_track_test.dart` 里 PR#762 的 `_topLevelFunctionBody` 删除。箭头体的「深度 0 分号」收口规则现在只有一份（`_arrowBodyEnd`），两处共用，不会再各写一遍慢慢漂开。

另新增两个共享原语，用来把 TODO-2727 的脆锚点抬成结构判据：
- `initializerExpression(src, name)` —— 取 `… name = <表达式>;` 的初始化表达式；
- `containsIdentifier(source, name)` —— 带标识符边界 + 掩注释的禁止型判据（替掉裸 `contains('_foo')`：注释提一句就假红、`_fooLegacy` 就假阳）。

## TODO-2727：同源脆锚点（同一文件内五处）

**BUG-1102**（`gal_audio_tracks_panel.dart`）
- `panel.contains('selectable: selectionEffective')` / `contains('enabled: selectable && !excluded')` ⇒ 改为 `enclosingCall` + `namedArgumentValues` 结构判据。旧写法把**参数顺序、空格、布尔表达式书写顺序**钉进契约：`!excluded && selectable` 是同一语义的合法写法却会转红；反过来把 `selectable:` 换给别的控件、字面量还留在文件里某处又照样绿。
- 顺手修掉一条**永远零命中的禁止型断言**：`contains('state.audioTracks.isEmpty && emptyHint')` isFalse —— 那个串在实现里**从来就不存在**（真实写法是 `… && backendHint == null`）。判据自己坏掉时没有任何东西会发现。改为钉可达顺序（`backendHint` 的初始化式必须以 `selectionEffective` 打头）。

**BUG-1094**（`gal_hook_session_controller.dart`）：六条 `src.contains` ⇒ 四条结构/跨语言判据。

### 🔴 关于「对注释内容做断言」那条（BUG-1094 的 `环形缓冲实际保留 60 秒`）

那一组里有**两条**钉的是注释内容：`src.contains('kRingSeconds = 60')` 与 `src.contains('环形缓冲实际保留 60 秒')` —— 这两个串在实现里**只存在于注释**。

**我的定性：这条不该以「注释契约」的形式守，但它背后的不变式值得守，而且比原来强。**

理由三条：
1. **注释是会漂的，它不是真相源。** 那句注释写着 `audio_loopback_capture.cpp:21`，而 native 常量今天在 **:22** —— 守卫绿着，注释已经指错了。守一句会漂的中文，等于守了个寂寞。
2. **它把断言字面量存在被守文件的注释里**，正是本仓反复踩的那个反模式（变异被注释兜住）的镜像形态：任何**正确的**改写（哪怕改成"环形缓冲真实保留 60 秒"）都会让守卫在实现完全正确时转红。
3. **它想表达的东西有更硬的写法**：真正的不变式是「Dart 侧回取上限 == native 环容量」，这是**跨语言契约**，只有两边一起读才守得住。旧写法钉一行 Dart 字面量 + 一句中文注释，native 那边把 `kRingSeconds` 改成 30 时它一动不动。

所以改成直接读 `windows/runner/audio_loopback_capture.cpp` 的 `kRingSeconds`，与 Dart 侧 `initializerExpression(src, '_loopbackRingCapacityMs')` 对账（`== kRingSeconds * 1000`）。两条注释断言删除，被它们代理的东西现在由真相源本身守着。

## 变异实测：19 条，18 红 1 绿（反向），零无效变异

反向替换还原（**未用 `git checkout --`**）；每条都确认 `N > 0`（无「编译失败导致 0 tests ran」的无效变异）；跑完 `git diff hibiki/lib/` 为空。

| # | 变异 | 结果 |
|---|---|---|
| A1 | `methodBody` 退回只认花括号体 | RED (3 例) |
| A2 | 无体声明不再 fail（退回找下一个花括号） | RED |
| A3 | 箭头体收口不看深度（首个分号即收口） | RED |
| B1 | `topLevelFunctionBody` 退回只认花括号体 | RED (2 例) |
| C1 | `initializerExpression` 删掉整条 `==`/`=>` 判据 | RED |
| C2 | 只排除 `==`，不排除 switch 的 `=>` | RED |
| C3 | 收口不看深度 | RED |
| C4 | `containsIdentifier` 不再掩注释 | RED |
| C5 | `containsIdentifier` 丢掉标识符边界 | RED |
| D1–D5 | 面板 `selectable` / `enabled` / `backendHint` / `selectionEffective` 五种退化 | 全 RED |
| E1–E4 | 环容量与 native 脱钩 / 回取上限由窗口换算 / 窗口由环容量换算 / 旧常量回来 | 全 RED |
| **E5** | **反向：旧常量名只出现在注释里 ⇒ 必须保持绿** | **GREEN（符合预期）** |

**踩到并修掉的两个变异陷阱：**
1. **A3 与 C3 第一轮都存活**——因为「实参里的分号」用的是 `'a;b'`，而字符串在结构串里**已被掩成空白**，压根碰不到深度判断，是**空操作变异**。补了真·深度 >0 的语料（闭包语句块 `() { count += 1; }`）后两条都转红。
2. **C1 第一轮存活**——变异揭示 `initializerExpression` 里那条「`=` 前一个字符是复合运算符就跳过」的判断**永远不可达**（正则要求 `=` 只能隔着空白紧跟 name，`name != x` / `name += 1` 本来就匹配不上）。**删掉了**：不可达的判据只会让人误以为这里已经守住了。

**禁止型断言的判据自校验**（PR#760 范式）：新增 `containsIdentifier` 的四条自校验用例，全部跑在**手写语料**上、与磁盘扫描互不依赖、独立枚举——覆盖「代码里出现 ⇒ 命中」「只在注释里 ⇒ 不命中」「更长标识符含子串 ⇒ 不命中」「不要求是次调用」。健康仓库里禁止型断言永远零命中，判据本身只能这样验。

## 验证

- `dart format`：三个改动文件
- `flutter analyze`（全量含 test）：**`No issues found! (ran in 34.0s)`**
- `dart run tool/flutter_test_failures.dart --no-pub test/tools/ test/helpers/` → **`PASSED - 337 tests ran`**（44 个 suite。其中 `test/helpers/source_guard_lexer_test.dart` **48 → 70 例**，+22 条新自校验 ⇒ 本批基线 **315 → 337，N 增不减**。48 这个基线不是算出来的，是从审计跑的 jsonl 里按 suite 数 `testDone` 事件读出来的。`test/tools/` 单独 **`PASSED - 267 tests ran`**（43 个 suite，本 PR 未增删其中任何用例）。）

  > **关于「35 条整批 / N 基线 225」**：`docs/agent/fast-workflow.md` 里**查无此命令块**——该文件没有任何 35 目标列表，也没有 225 这个数。当前 develop 上 `test/tools/` 已是 43 suite / 267 例、`test/tools/ + test/helpers/` 是 44 suite / 337 例，都对不上 35/225，推测那是若干周前的快照。所以我改用**结构推导的爆炸半径**：共享原语被 **152 个测试文件** import，故直接跑全量套件（下方），并附 guard 目录批次实测数。
- `flutter test test/mining/gal_audio_degrade_track_test.dart` → 10/10
- 全量套件：见下方评论

### ⚠️ develop 上已有的红（与本 PR 无关）

`test/dictionary/popup_touch_copy_actionmode_guard_test.dart` 的
`copy is custom Dart clipboard action and selection is cleared` 在 `origin/develop@595c5a959` 上就是红的（PR#764 `76c04f2f0` 把复制动作挪出了 `contextMenu:` 与 `gestureRecognizers:` 之间的文本窗口）。该文件**只 import `dart:io` 与 `flutter_test`**，与本 PR 零交集。

## 留给后续（本 PR 有意不做）

全仓另有 **26 份本地私有 `methodBody` / `_methodBody` 副本**（25 个测试文件）。逐文件核过被守声明的真实形态后：

- **A 类（花括号配对，遇 arrow 会静默返回邻居）5 份**：`lapis_settings_page_guard_test.dart:28`、`galgame_helper_launch_guard_test.dart:29`、`tag_management_context_menu_source_guard_test.dart:20`、`video_double_tap_seek_guard_test.dart:62`、`video_horizontal_seek_test.dart:97`（另 `video_tags_menu_source_guard_test.dart:20`、`video_subtitle_list_panel_guards_test.dart` 的 `pushAsidePanelBody` 同型）。**此刻锚的全是 brace，没有正在发生的假绿**，但 `_mobileControlsTheme` / `_desktopControlsTheme` / `_buildSeekIndicator` 这种「返回一个构造器」的方法很容易被顺手改成箭头体。
- **C 类（文本 marker）里唯一一条真 arrow 锚点**：`subtitle_import_system_picker_guard_test.dart` 锚 `pickSystemFilePath(`（`real_path_directory_picker.dart:145-149` 确是箭头函数）。窗口靠「下一个 `Future<`」收口，箭头体落在窗内，**没塌**；但窗口多吞了下一函数的 dartdoc 且该 helper 不掩注释——现成的假绿面。**该 helper 还有一条更硬的问题：`if (idx < 0) return '';`**，锚点丢失时返回空串，所有 `contains` 静默变假。

另有两条与箭头无关、**当前就在发生**的窗口假绿（顺带发现，未修）：
- `video_volume_osd_guard_test.dart` 的 `_setDelayMs`（主壳 `:5694`）→ endMarker 落在 `volume_osd.part.dart:111`，窗口横跨主壳后半段 + 十几个 part，三条 `isTrue` 断言实质无窗口约束；
- `reader_sasayaki_payload_source_guard_test.dart` 的 `bridgeSrc.substring(start)` 一直切到文件末尾，无右边界。

这些迁移各自需要独立的变异实测，塞进本 PR 会让爆炸半径失控；**范围纪律优先**，建议单开 TODO。

