### PR TITLE
docs(i18n): 刮削确认框如实描述自动应用判据 (TODO-2566)

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 52853 (3109 per locale)
 ///
-/// Built on 2026-08-02 at 10:06 UTC
+/// Built on 2026-08-02 at 12:05 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4057,7 +4057,7 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_hook_reason_protocol_mismatch =>
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   String get collection_related_title => 'Related works';
   String get collection_relation_prequel => 'Prequel';
   String get collection_relation_sequel => 'Sequel';
@@ -11109,7 +11109,7 @@ class _StringsAr extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -18318,7 +18318,7 @@ class _StringsDe extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -25542,7 +25542,7 @@ class _StringsEs extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -32778,7 +32778,7 @@ class _StringsFr extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -39943,7 +39943,7 @@ class _StringsId extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -47154,7 +47154,7 @@ class _StringsIt extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -54182,7 +54182,7 @@ class _StringsJa extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -61212,7 +61212,7 @@ class _StringsKo extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -68403,7 +68403,7 @@ class _StringsNl extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -75607,7 +75607,7 @@ class _StringsPtBr extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -82795,7 +82795,7 @@ class _StringsRu extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -89931,7 +89931,7 @@ class _StringsTh extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -97099,7 +97099,7 @@ class _StringsTr extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -104252,7 +104252,7 @@ class _StringsVi extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -110923,7 +110923,7 @@ class _StringsZhCn extends _StringsEn {
       '捕获组件与本体版本不一致。组件已内置在 Hibiki 里，不需要单独安装：先彻底关掉游戏再重开一次（游戏进程里可能还挂着上一次注入的旧组件）。若重开后仍提示不一致，说明这份 Hibiki 没带上与之匹配的组件。';
   @override
   String scrape_all_confirm({required Object n}) =>
-      '将按标题匹配库中的 ${n} 个条目。只自动应用唯一的精确匹配；你自己定的封面一律不覆盖（手动设置的本地图、在匹配弹窗里亲手选定的条目、目录里自带的 poster 图），歧义结果留待手动确认。';
+      '将按标题匹配库中的 ${n} 个条目。只自动应用高置信度的匹配——视频按标题与年份、类型等信息综合打分，书籍和游戏则要求标题唯一且完全一致。你自己定的封面一律不覆盖（手动设置的本地图、在匹配弹窗里亲手选定的条目、目录里自带的 poster 图），歧义结果留待手动确认。';
   @override
   String get collection_related_title => '相关作品';
   @override
@@ -117854,7 +117854,7 @@ class _StringsZhHk extends _StringsEn {
       'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
   @override
   String scrape_all_confirm({required Object n}) =>
-      'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+      'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
   @override
   String get collection_related_title => 'Related works';
   @override
@@ -124264,7 +124264,7 @@ extension on _StringsEn {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -130640,7 +130640,7 @@ extension on _StringsAr {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -137038,7 +137038,7 @@ extension on _StringsDe {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -143435,7 +143435,7 @@ extension on _StringsEs {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -149838,7 +149838,7 @@ extension on _StringsFr {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -156223,7 +156223,7 @@ extension on _StringsId {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -162622,7 +162622,7 @@ extension on _StringsIt {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -168983,7 +168983,7 @@ extension on _StringsJa {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -175348,7 +175348,7 @@ extension on _StringsKo {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -181741,7 +181741,7 @@ extension on _StringsNl {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -188131,7 +188131,7 @@ extension on _StringsPtBr {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -194526,7 +194526,7 @@ extension on _StringsRu {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -200904,7 +200904,7 @@ extension on _StringsTh {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -207291,7 +207291,7 @@ extension on _StringsTr {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -213674,7 +213674,7 @@ extension on _StringsVi {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':
@@ -220004,7 +220004,7 @@ extension on _StringsZhCn {
         return '捕获组件与本体版本不一致。组件已内置在 Hibiki 里，不需要单独安装：先彻底关掉游戏再重开一次（游戏进程里可能还挂着上一次注入的旧组件）。若重开后仍提示不一致，说明这份 Hibiki 没带上与之匹配的组件。';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            '将按标题匹配库中的 ${n} 个条目。只自动应用唯一的精确匹配；你自己定的封面一律不覆盖（手动设置的本地图、在匹配弹窗里亲手选定的条目、目录里自带的 poster 图），歧义结果留待手动确认。';
+            '将按标题匹配库中的 ${n} 个条目。只自动应用高置信度的匹配——视频按标题与年份、类型等信息综合打分，书籍和游戏则要求标题唯一且完全一致。你自己定的封面一律不覆盖（手动设置的本地图、在匹配弹窗里亲手选定的条目、目录里自带的 poster 图），歧义结果留待手动确认。';
       case 'collection_related_title':
         return '相关作品';
       case 'collection_relation_prequel':
@@ -226359,7 +226359,7 @@ extension on _StringsZhHk {
         return 'The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.';
       case 'scrape_all_confirm':
         return ({required Object n}) =>
-            'Match all ${n} library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
+            'Match all ${n} library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.';
       case 'collection_related_title':
         return 'Related works';
       case 'collection_relation_prequel':

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "已加入漫画书架",
   "media_source_local_roots": "本地扫描根",
   "game_hook_reason_protocol_mismatch": "捕获组件与本体版本不一致。组件已内置在 Hibiki 里，不需要单独安装：先彻底关掉游戏再重开一次（游戏进程里可能还挂着上一次注入的旧组件）。若重开后仍提示不一致，说明这份 Hibiki 没带上与之匹配的组件。",
-  "scrape_all_confirm": "将按标题匹配库中的 $n 个条目。只自动应用唯一的精确匹配；你自己定的封面一律不覆盖（手动设置的本地图、在匹配弹窗里亲手选定的条目、目录里自带的 poster 图），歧义结果留待手动确认。",
+  "scrape_all_confirm": "将按标题匹配库中的 $n 个条目。只自动应用高置信度的匹配——视频按标题与年份、类型等信息综合打分，书籍和游戏则要求标题唯一且完全一致。你自己定的封面一律不覆盖（手动设置的本地图、在匹配弹窗里亲手选定的条目、目录里自带的 poster 图），歧义结果留待手动确认。",
   "collection_related_title": "相关作品",
   "collection_relation_prequel": "前传",
   "collection_relation_sequel": "续作",

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3017,7 +3017,7 @@
   "mihon_in_bookshelf": "In manga shelf",
   "media_source_local_roots": "Local scan roots",
   "game_hook_reason_protocol_mismatch": "The capture component does not match this Hibiki build. It ships inside Hibiki, so there is nothing to install separately: fully close the game and launch it again, since the game process may still hold the component injected by a previous session. If it still mismatches, this build did not ship a matching component.",
-  "scrape_all_confirm": "Match all $n library items by title. Only a unique exact match is applied automatically; covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
+  "scrape_all_confirm": "Match all $n library items by title. Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title. Covers you chose yourself are never overwritten (local images you set, entries you picked in the match dialog, and poster files placed in the folder), and ambiguous results stay pending for manual review.",
   "collection_related_title": "Related works",
   "collection_relation_prequel": "Prequel",
   "collection_relation_sequel": "Sequel",


### PR DESCRIPTION
## 问题

i18n key `scrape_all_confirm`（刮削确认框正文）里的这句是**假的**：

> 只自动应用**唯一的精确匹配**

这一句**三个库页共用**（书架 / 视频 / 游戏都调 `showScrapeBatchDialog`，`scrape_batch.dart:167` 是唯一使用点），但真实判据是**两套**：

| 路径 | 真实判据 | 证据 |
|---|---|---|
| 视频页 `free`（autoFrame / 无 `cover_meta` 记录）、`rescrapeOnly`（autoScraped） | **只看综合分 high**，不要求唯一、不要求标题精确 | `cover_scraper_service.dart:396-401` 传 `requireUniqueExactTitle: false`；`_applyResolved` `:939-955` 只 gate `MatchConfidence.high`；`match_scorer.dart` `total >= 0.85 && titleScore >= 0.55`，年份/类型/季度/集数是加减分项 |
| 视频页 `legacyStrict`（存量来源未知的 `scraped`） | high **且**唯一归一化精确标题 | `cover_scraper_service.dart:399` + `:946` |
| 书架页 / 游戏库页 | 归一化后精确相等 **+** 全候选唯一，**无任何评分阈值** | `uniqueExactScrapeTitleMatch`（`scrape_title_matcher.dart:7-24`）；`reader_hibiki_history_page.dart:2220` / `games_library_page.dart:401` |

视频页 runner 传 `rescrapeScraped: true`（`home_video_page.dart:1997`），所以 `free` / `rescrapeOnly` 是它的主路径 —— 也就是**大多数视频条目走的是 high 置信度那条**，原文案对它不成立。

属 PR#639 之前的既有偏差（原文案随 `395ad0bc1 feat(media): add manual scrape-all workflows` 一起进来，当时只有书页语义）。

## 改法

**只改判据那一句**，改成同时覆盖两种真实行为：

- 旧 EN：`Only a unique exact match is applied automatically;`
- 新 EN：`Only high-confidence matches are applied automatically — videos are scored on the title together with year, type and other signals, while books and games require a unique exact title.`
- 旧 ZH：`只自动应用唯一的精确匹配；`
- 新 ZH：`只自动应用高置信度的匹配——视频按标题与年份、类型等信息综合打分，书籍和游戏则要求标题唯一且完全一致。`

其余部分（「你自己定的封面一律不覆盖（手动设置的本地图、在匹配弹窗里亲手选定的条目、目录里自带的 poster 图）」「歧义结果留待手动确认」）**经沿代码路径复核准确，原样保留**：三种来源全映射到 `CoverOverwritePolicy.never`（`scraper_types.dart:430-433`），`rescrapeScraped` 开关对 `never` 无效；medium 与 legacyStrict 下的非唯一精确都产出 `ScrapeNeedsConfirm`。

## 零行为变化

只动 17 份 `*.i18n.json` 的 `scrape_all_confirm` **值** + `dart run slang` 重新生成 `strings.g.dart`。**没有碰任何刮削逻辑**（用户明确不要改行为——改判据会明显降低自动刮削命中率）。

- 键数 3109 × 17 份，改前改后不变（脚本内断言 + `i18n_completeness_test` 复核）。
- 非中英的 15 种语言原本就存着英文原文，本次**照英文一并更新**（保持事实正确优先于译文润色）。
- `strings.g.dart` 的 diff 除 17 条字符串外只有 slang 的 build 时间戳行。

## 验证

- `flutter analyze`（全量含 test）：`No issues found! (ran in 51.1s)`
- `test/i18n` 全目录：`FLUTTER TEST VERDICT: PASSED - 22 tests ran`
- 目录枚举型守卫整批 35 条：`FLUTTER TEST VERDICT: PASSED - 225 tests ran`（与 PR#760 后的 N 基线 225 一致）
- `test/media/metadata`（刮削域）：`FLUTTER TEST VERDICT: PASSED - 72 tests ran`
- `tool/tests_for_changes.dart --base=origin/develop`：推导出 0 个必须加跑的测试

## 并发说明

PR#751（漫画设置）同样动了大量 i18n 文件且仍 OPEN。本 PR 只改 `scrape_all_confirm` **一个 key 的值**，冲突面极小，但同文件相邻行有冲突可能，合并顺序上让 #751 先走更省事。
