### PR TITLE
feat(galgame): add launch capture picker and module settings tabs

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1357 条。点号进各自文件。
+> 共 1358 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1454](bugs/BUG-1454-kana-compound-popup-selection.md) | ✅ | ✅ | 查词结果正文含假名词被 ruby 占位文本截断 |
+| [BUG-1452](bugs/BUG-1452-gal-unselected-thread-implies-audio.md) | ✅ | ✅ | 未选择台词线程时仍显示正在监听与句级音频 |
 | [BUG-1451](bugs/BUG-1451-popup-copy-shortcut-and-context-menu.md) | ✅ | ✅ | 查词弹窗无法复制（Ctrl+C 与右键「复制」都无效） |
 | [BUG-1449](bugs/BUG-1449-gal-helper-bundled-as-plain-files.md) | ✅ | ✅ | helper 改为构建期解压随包，消灭需与本体同步的第二份副本 |
 | [BUG-1448](bugs/BUG-1448-gal-helper-version-check-short-circuited.md) | ✅ | ✅ | injector 存在即跳过 ensureInjector，随包新组件永不换入 |

--- a/docs/bugs/BUG-1452-gal-unselected-thread-implies-audio.md
+++ b/docs/bugs/BUG-1452-gal-unselected-thread-implies-audio.md
@@ -1,0 +1,16 @@
+## BUG-1452 · 未选择台词线程时仍显示正在监听与句级音频
+- **报告**：2026-08-02（用户反馈）
+- **真实性**：✅ 真 bug。`texthooker_page.dart:1875-1883`（修复前）仅按
+  `state.isActive` 显示“正在监听”，并无条件拼入音频后端；
+  `home_game_page.dart:249-253`（修复前）同样把活跃会话直接送进带音频信息的详情。
+  两处都没有读取 `selectedTextThreadKey`，因此音频采集源就绪被错误等同为已有可归属的
+  句级音频。
+- **[x] ① 已根因修复** — `ed16401c7`：新增统一的工作台 readiness 判定；引擎会话未选
+  线程时显示“等待选择台词线程”，隐藏“本句音轨”和会话音轨入口。游戏启动后发现候选
+  线程时弹出线程/音轨设置大弹窗，选中线程自动关闭，也可手动关闭。
+- **[x] ② 已加自动化测试** —
+  `hibiki/test/pages/game_shared_readiness_test.dart` 覆盖未选/已选线程状态、WebSocket
+  兼容路径以及弹窗单会话去重；`hibiki/test/pages/home_game_page_test.dart` 覆盖游戏顶部
+  设置页签与诊断页的保留入口。
+- **备注**：真实 Windows 游戏启动、LunaHook 线程发现及音轨试听尚未做设备验收；本 PR
+  按用户要求只完成静态分析与聚焦自动化测试，能力状态为 `implemented_unverified`。

--- a/docs/bugs/BUG-1452-gal-unselected-thread-implies-audio.md
+++ b/docs/bugs/BUG-1452-gal-unselected-thread-implies-audio.md
@@ -5,12 +5,12 @@
   `home_game_page.dart:249-253`（修复前）同样把活跃会话直接送进带音频信息的详情。
   两处都没有读取 `selectedTextThreadKey`，因此音频采集源就绪被错误等同为已有可归属的
   句级音频。
-- **[x] ① 已根因修复** — `ed16401c7`：新增统一的工作台 readiness 判定；引擎会话未选
+- **[x] ① 已根因修复** — `a483436e8`：新增统一的工作台 readiness 判定；引擎会话未选
   线程时显示“等待选择台词线程”，隐藏“本句音轨”和会话音轨入口。游戏启动后发现候选
   线程时弹出线程/音轨设置大弹窗，选中线程自动关闭，也可手动关闭。
 - **[x] ② 已加自动化测试** —
   `hibiki/test/pages/game_shared_readiness_test.dart` 覆盖未选/已选线程状态、WebSocket
-  兼容路径以及弹窗单会话去重；`hibiki/test/pages/home_game_page_test.dart` 覆盖游戏顶部
-  设置页签与诊断页的保留入口。
+  兼容路径、弹窗单会话去重，以及工作台/状态带/音轨入口对 readiness 的真实消费接线；
+  `hibiki/test/pages/home_game_page_test.dart` 覆盖游戏顶部设置页签与诊断页的保留入口。
 - **备注**：真实 Windows 游戏启动、LunaHook 线程发现及音轨试听尚未做设备验收；本 PR
   按用户要求只完成静态分析与聚焦自动化测试，能力状态为 `implemented_unverified`。

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 53091 (3123 per locale)
+/// Strings: 53159 (3127 per locale)
 ///
-/// Built on 2026-08-02 at 16:17 UTC
+/// Built on 2026-08-02 at 16:30 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4201,6 +4201,12 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get manga_tap_zone_paging_subtitle =>
       'Tap the left or right edge of the page to turn';
   String get manga_section_viewing => 'Viewing and page turning';
+  String get game_capture_setup_title => 'Complete capture setup';
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -11374,6 +11380,16 @@ class _StringsAr extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -18614,6 +18630,16 @@ class _StringsDe extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -25869,6 +25895,16 @@ class _StringsEs extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -33136,6 +33172,16 @@ class _StringsFr extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -40332,6 +40378,16 @@ class _StringsId extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -47574,6 +47630,16 @@ class _StringsIt extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -54633,6 +54699,16 @@ class _StringsJa extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -61694,6 +61770,16 @@ class _StringsKo extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -68916,6 +69002,16 @@ class _StringsNl extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -76151,6 +76247,16 @@ class _StringsPtBr extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -83370,6 +83476,16 @@ class _StringsRu extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -90537,6 +90653,16 @@ class _StringsTh extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -97736,6 +97862,16 @@ class _StringsTr extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -104920,6 +105056,16 @@ class _StringsVi extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 // Path: <root>
@@ -111601,6 +111747,14 @@ class _StringsZhCn extends _StringsEn {
   String get manga_tap_zone_paging_subtitle => '点击页面左右边缘翻页';
   @override
   String get manga_section_viewing => '浏览与翻页';
+  @override
+  String get game_capture_setup_title => '完成捕获设置';
+  @override
+  String get game_capture_setup_hint => '请先选择台词线程。Hibiki 只能把音频与所选线程收到的台词配对。';
+  @override
+  String get game_audio_requires_thread => '音频采集源可能已经就绪，但选择线程并收到台词之前，不存在本句音频。';
+  @override
+  String get game_session_waiting_thread => '等待选择台词线程';
 }
 
 // Path: <root>
@@ -118581,6 +118735,16 @@ class _StringsZhHk extends _StringsEn {
       'Tap the left or right edge of the page to turn';
   @override
   String get manga_section_viewing => 'Viewing and page turning';
+  @override
+  String get game_capture_setup_title => 'Complete capture setup';
+  @override
+  String get game_capture_setup_hint =>
+      'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+  @override
+  String get game_audio_requires_thread =>
+      'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+  @override
+  String get game_session_waiting_thread => 'Waiting for a dialogue thread';
 }
 
 /// Flat map(s) containing all translations.
@@ -124987,6 +125151,14 @@ extension on _StringsEn {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -131391,6 +131563,14 @@ extension on _StringsAr {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -137817,6 +137997,14 @@ extension on _StringsDe {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -144242,6 +144430,14 @@ extension on _StringsEs {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -150673,6 +150869,14 @@ extension on _StringsFr {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -157086,6 +157290,14 @@ extension on _StringsId {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -163513,6 +163725,14 @@ extension on _StringsIt {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -169902,6 +170122,14 @@ extension on _StringsJa {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -176295,6 +176523,14 @@ extension on _StringsKo {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -182716,6 +182952,14 @@ extension on _StringsNl {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -189134,6 +189378,14 @@ extension on _StringsPtBr {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -195557,6 +195809,14 @@ extension on _StringsRu {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -201963,6 +202223,14 @@ extension on _StringsTh {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -208378,6 +208646,14 @@ extension on _StringsTr {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -214789,6 +215065,14 @@ extension on _StringsVi {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }
@@ -221146,6 +221430,14 @@ extension on _StringsZhCn {
         return '点击页面左右边缘翻页';
       case 'manga_section_viewing':
         return '浏览与翻页';
+      case 'game_capture_setup_title':
+        return '完成捕获设置';
+      case 'game_capture_setup_hint':
+        return '请先选择台词线程。Hibiki 只能把音频与所选线程收到的台词配对。';
+      case 'game_audio_requires_thread':
+        return '音频采集源可能已经就绪，但选择线程并收到台词之前，不存在本句音频。';
+      case 'game_session_waiting_thread':
+        return '等待选择台词线程';
       default:
         return null;
     }
@@ -227530,6 +227822,14 @@ extension on _StringsZhHk {
         return 'Tap the left or right edge of the page to turn';
       case 'manga_section_viewing':
         return 'Viewing and page turning';
+      case 'game_capture_setup_title':
+        return 'Complete capture setup';
+      case 'game_capture_setup_hint':
+        return 'Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.';
+      case 'game_audio_requires_thread':
+        return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
+      case 'game_session_waiting_thread':
+        return 'Waiting for a dialogue thread';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "包含的源",
   "mihon_extension_preview_read_only": "预览是只读的。安装扩展后才能打开阅读。",
   "selection_copy_empty": "未选中文本。",
-  "video_subtitle_replay": "重播本句"
-,
+  "video_subtitle_replay": "重播本句",
   "manga_ocr_done": "OCR 已完成",
   "settings_destination_manga_summary": "阅读器、OCR 与在线目录",
   "manga_page_animation": "翻页动画",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "在漫画阅读器中用音量加减键翻页",
   "manga_tap_zone_paging": "点击边缘翻页",
   "manga_tap_zone_paging_subtitle": "点击页面左右边缘翻页",
-  "manga_section_viewing": "浏览与翻页"
+  "manga_section_viewing": "浏览与翻页",
+  "game_capture_setup_title": "完成捕获设置",
+  "game_capture_setup_hint": "请先选择台词线程。Hibiki 只能把音频与所选线程收到的台词配对。",
+  "game_audio_requires_thread": "音频采集源可能已经就绪，但选择线程并收到台词之前，不存在本句音频。",
+  "game_session_waiting_thread": "等待选择台词线程"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3108,8 +3108,7 @@
   "mihon_extension_sources_included": "Included sources",
   "mihon_extension_preview_read_only": "Preview is read-only. Install the extension to open and read.",
   "selection_copy_empty": "No text selected.",
-  "video_subtitle_replay": "Replay this line"
-,
+  "video_subtitle_replay": "Replay this line",
   "manga_ocr_done": "OCR complete",
   "settings_destination_manga_summary": "Reader, OCR and online catalog",
   "manga_page_animation": "Page turn animation",
@@ -3122,5 +3121,9 @@
   "manga_volume_key_paging_subtitle": "Use volume up and down to turn pages in the manga reader",
   "manga_tap_zone_paging": "Tap edges to turn pages",
   "manga_tap_zone_paging_subtitle": "Tap the left or right edge of the page to turn",
-  "manga_section_viewing": "Viewing and page turning"
+  "manga_section_viewing": "Viewing and page turning",
+  "game_capture_setup_title": "Complete capture setup",
+  "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
+  "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
+  "game_session_waiting_thread": "Waiting for a dialogue thread"
 }

--- a/hibiki/lib/src/media/manga/manga_library_page.dart
+++ b/hibiki/lib/src/media/manga/manga_library_page.dart
@@ -3,7 +3,9 @@ import 'package:flutter/widgets.dart';
 import 'package:hibiki/src/media/manga/manga_browse_page.dart';
 import 'package:hibiki/src/media/manga/manga_sources_page.dart';
 import 'package:hibiki/src/pages/implementations/media_library_shell.dart';
+import 'package:hibiki/src/pages/implementations/module_settings_view.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/utils.dart';
 
 /// 顶层漫画库页：**恒为三视图**，五个平台完全同构。
@@ -51,6 +53,15 @@ class MangaLibraryPage extends StatelessWidget {
           label: t.library_view_sources,
           builder: (BuildContext context, Widget navigation) =>
               MangaSourcesPage(navigation: navigation),
+        ),
+        MediaLibraryViewSpec(
+          kind: MediaLibraryViewKind.settings,
+          label: t.settings,
+          builder: (BuildContext context, Widget navigation) =>
+              ModuleSettingsView(
+            destinationId: SettingsDestinationId.reading,
+            navigation: navigation,
+          ),
         ),
       ],
     );

--- a/hibiki/lib/src/pages/implementations/downloads_page.dart
+++ b/hibiki/lib/src/pages/implementations/downloads_page.dart
@@ -28,8 +28,6 @@ class DownloadsPage extends ConsumerStatefulWidget {
 }
 
 class _DownloadsPageState extends ConsumerState<DownloadsPage> {
-  late bool _showSettings = widget.initialShowSettings;
-
   /// 漫画「在线目录」入口（统一下载中心：书/漫画获取入口与 torrent 并列）。
   ///
   /// 书架页与书籍导入框的旧入口已收敛到这里，故本页是
@@ -64,59 +62,72 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-        length: 3,
-        child: Scaffold(
-          // BUG-1003：内联下载流程把 apikey/搜番等输入框全放在页面上半部，下载任务折叠区
-          // 贴底、中段结果列表是唯一的 Expanded。默认 resizeToAvoidBottomInset:true 时，
-          // 手机软键盘弹出会压掉 body 高度、顶掉贴底任务区，使其爬到顶部输入框边上（看似
-          // 「下载任务被输入框挤上去」）。关掉 inset 让键盘只覆盖下半部结果/任务区（打字时
-          // 本就不看），顶部输入框保持可见、布局不反流。
-          resizeToAvoidBottomInset: false,
-          appBar: AppBar(
-            title: Text(_showSettings ? t.download_settings : t.nav_downloads),
-            bottom: _showSettings
-                ? null
-                : TabBar(
-                    // BUG-1184：三个 tab 均分宽度时，窄屏 + 大字号下较长的 tab 名
-                    // （英文 Subscriptions）会被裁。可滚动 tab 条按内容取宽，装不下
-                    // 就横向滚动而不是裁字。
-                    isScrollable: true,
-                    tabAlignment: TabAlignment.center,
-                    tabs: <Widget>[
-                      Tab(text: t.download_discover_tab),
-                      Tab(text: t.download_tasks_tab),
-                      Tab(text: t.download_subscriptions_tab),
-                    ],
-                  ),
-            actions: <Widget>[
-              if (!_showSettings)
-                Builder(
-                  // Builder：拿 DefaultTabController 之下的 context，日历页
-                  // 「订阅中」条目点击回跳时能切回订阅 tab（TODO-2487）。
-                  builder: (BuildContext tabContext) => IconButton(
-                    tooltip: t.download_airing_calendar_title,
-                    icon: const Icon(Icons.calendar_month_outlined),
-                    onPressed: () => _openAiringCalendar(tabContext),
-                  ),
+        length: 4,
+        initialIndex: widget.initialShowSettings ? 3 : 0,
+        child: Builder(
+          builder: (BuildContext tabContext) => Scaffold(
+            // BUG-1003：内联下载流程把 apikey/搜番等输入框全放在页面上半部，下载任务折叠区
+            // 贴底、中段结果列表是唯一的 Expanded。默认 resizeToAvoidBottomInset:true 时，
+            // 手机软键盘弹出会压掉 body 高度、顶掉贴底任务区，使其爬到顶部输入框边上（看似
+            // 「下载任务被输入框挤上去」）。关掉 inset 让键盘只覆盖下半部结果/任务区（打字时
+            // 本就不看），顶部输入框保持可见、布局不反流。
+            resizeToAvoidBottomInset: false,
+            appBar: AppBar(
+              title: Text(t.nav_downloads),
+              bottom: TabBar(
+                // BUG-1184：三个 tab 均分宽度时，窄屏 + 大字号下较长的 tab 名
+                // （英文 Subscriptions）会被裁。可滚动 tab 条按内容取宽，装不下
+                // 就横向滚动而不是裁字。
+                isScrollable: true,
+                tabAlignment: TabAlignment.center,
+                tabs: <Widget>[
+                  Tab(text: t.download_discover_tab),
+                  Tab(text: t.download_tasks_tab),
+                  Tab(text: t.download_subscriptions_tab),
+                  Tab(text: t.settings),
+                ],
+              ),
+              actions: <Widget>[
+                IconButton(
+                  tooltip: t.download_airing_calendar_title,
+                  icon: const Icon(Icons.calendar_month_outlined),
+                  onPressed: () => _openAiringCalendar(tabContext),
                 ),
-              if (!_showSettings)
                 IconButton(
                   tooltip: t.manga_online_catalog_title,
                   icon: const Icon(Icons.menu_book_outlined),
                   onPressed: _openMangaCatalog,
                 ),
-              IconButton(
-                // 齿轮已变 ✕ 时语义是「关闭设置」，tooltip 跟着换，不再答非所问。
-                tooltip: _showSettings ? t.dialog_close : t.download_settings,
-                icon:
-                    Icon(_showSettings ? Icons.close : Icons.settings_outlined),
-                onPressed: () => setState(() => _showSettings = !_showSettings),
-              ),
-            ],
-          ),
-          // 齿轮切换：设置面板 vs 番剧下载内联流程（后者自带通用磁力 + 任务列表）。
-          body: _showSettings
-              ? ListView(
+              ],
+            ),
+            // 设置与发现/任务/订阅同属顶部平级页签；不再用右上角齿轮把整页切成
+            // 另一种模式，避免页签导航与正文状态互相覆盖。
+            body: TabBarView(
+              children: <Widget>[
+                AnimeDownloadDialog(
+                  embedded: true,
+                  showTasks: false,
+                  onOpenSettings: () =>
+                      DefaultTabController.of(tabContext).animateTo(3),
+                ),
+                // 任务 tab：漫画目录卷下载队列（有任务才占位）+ torrent 任务，
+                // 统一下载中心的同屏任务视图。
+                Column(
+                  children: <Widget>[
+                    const MokuroMoeTasksSection(),
+                    Expanded(
+                      child: AnimeDownloadDialog(
+                        embedded: true,
+                        tasksOnly: true,
+                        showTasks: false,
+                        onOpenSettings: () =>
+                            DefaultTabController.of(tabContext).animateTo(3),
+                      ),
+                    ),
+                  ],
+                ),
+                const DownloadSubscriptionsPanel(),
+                ListView(
                   padding: const EdgeInsets.all(16),
                   children: <Widget>[
                     // 桌面宽屏限宽 560 居中（对齐全 app 设置面板口径），不再全宽铺开。
@@ -129,34 +140,10 @@ class _DownloadsPageState extends ConsumerState<DownloadsPage> {
                       ),
                     ),
                   ],
-                )
-              : TabBarView(
-                  children: <Widget>[
-                    AnimeDownloadDialog(
-                      embedded: true,
-                      showTasks: false,
-                      onOpenSettings: () =>
-                          setState(() => _showSettings = true),
-                    ),
-                    // 任务 tab：漫画目录卷下载队列（有任务才占位）+ torrent 任务，
-                    // 统一下载中心的同屏任务视图。
-                    Column(
-                      children: <Widget>[
-                        const MokuroMoeTasksSection(),
-                        Expanded(
-                          child: AnimeDownloadDialog(
-                            embedded: true,
-                            tasksOnly: true,
-                            showTasks: false,
-                            onOpenSettings: () =>
-                                setState(() => _showSettings = true),
-                          ),
-                        ),
-                      ],
-                    ),
-                    const DownloadSubscriptionsPanel(),
-                  ],
                 ),
+              ],
+            ),
+          ),
         ));
   }
 }

--- a/hibiki/lib/src/pages/implementations/downloads_page.dart
+++ b/hibiki/lib/src/pages/implementations/downloads_page.dart
@@ -13,7 +13,7 @@ import 'package:hibiki/utils.dart';
 /// 独立「下载」页（顶层底栏 tab）＝统一下载中心：番剧下载流程 **直接内联**
 /// 铺在页面上（搜番 → 选种 → 配字幕 → 推送 + 通用磁力 + 下载任务），任务 tab
 /// 同时列出漫画「在线目录」（mokuro.moe）的卷下载队列；页头另有在线目录入口。
-/// 右上角齿轮切到「下载设置」（后端/限速/上传/做种/内存）。完成后按内容类型
+/// 第四个顶部页签是「下载设置」（后端/限速/上传/做种/内存）。完成后按内容类型
 /// 自动入库（视频→视频库、epub→阅读库，见 AnimeDownloadService；漫画卷→
 /// 书架，见 MokuroMoeDownloadQueue）。
 class DownloadsPage extends ConsumerStatefulWidget {

--- a/hibiki/lib/src/pages/implementations/gal_capture_setup_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/gal_capture_setup_dialog.dart
@@ -36,7 +36,10 @@ class _GalCaptureSetupDialogState extends State<GalCaptureSetupDialog> {
   String? _selectingThreadKey;
   int? _previewingSourcePtr;
   Timer? _previewResetTimer;
+  Future<void> _previewQueue = Future<void>.value();
+  int _previewGeneration = 0;
   bool _autoCloseScheduled = false;
+  bool _dismissRequested = false;
 
   @override
   void initState() {
@@ -46,6 +49,7 @@ class _GalCaptureSetupDialogState extends State<GalCaptureSetupDialog> {
 
   @override
   void dispose() {
+    _previewGeneration++;
     _previewResetTimer?.cancel();
     unawaited(DesktopAudioPlayback.stop());
     super.dispose();
@@ -57,13 +61,22 @@ class _GalCaptureSetupDialogState extends State<GalCaptureSetupDialog> {
     final bool selected = await widget.onSelectThread(thread);
     if (!mounted) return;
     if (selected) {
-      Navigator.of(context).pop();
+      _dismissOnce();
       return;
     }
     setState(() => _selectingThreadKey = null);
   }
 
-  Future<void> _togglePreview(GalAudioTrack track) async {
+  void _requestPreview(GalAudioTrack track) {
+    final int generation = ++_previewGeneration;
+    _previewQueue = _previewQueue.then(
+      (_) => _togglePreview(track, generation),
+    );
+    unawaited(_previewQueue);
+  }
+
+  Future<void> _togglePreview(GalAudioTrack track, int generation) async {
+    if (!mounted || generation != _previewGeneration) return;
     if (_previewingSourcePtr == track.sourcePtr) {
       _previewResetTimer?.cancel();
       setState(() => _previewingSourcePtr = null);
@@ -72,13 +85,21 @@ class _GalCaptureSetupDialogState extends State<GalCaptureSetupDialog> {
     }
     final GalTrackPreview? preview =
         await widget.session.exportTrackPreview(track.sourcePtr);
-    if (!mounted) return;
-    if (preview == null ||
-        !await DesktopAudioPlayback.playFile(preview.filePath)) {
+    if (!mounted || generation != _previewGeneration) return;
+    if (preview == null) {
       HibikiToast.show(msg: t.game_track_preview_failed);
       return;
     }
+    final bool started = await DesktopAudioPlayback.playFile(preview.filePath);
     if (!mounted) return;
+    if (generation != _previewGeneration) {
+      await DesktopAudioPlayback.stop();
+      return;
+    }
+    if (!started) {
+      HibikiToast.show(msg: t.game_track_preview_failed);
+      return;
+    }
     _previewResetTimer?.cancel();
     setState(() => _previewingSourcePtr = track.sourcePtr);
     _previewResetTimer = Timer(
@@ -90,11 +111,18 @@ class _GalCaptureSetupDialogState extends State<GalCaptureSetupDialog> {
   }
 
   void _scheduleAutoClose() {
-    if (_autoCloseScheduled) return;
+    if (_autoCloseScheduled || _dismissRequested) return;
     _autoCloseScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) Navigator.of(context).maybePop();
+      _autoCloseScheduled = false;
+      if (mounted) _dismissOnce();
     });
+  }
+
+  void _dismissOnce() {
+    if (_dismissRequested) return;
+    _dismissRequested = true;
+    Navigator.of(context).maybePop();
   }
 
   @override
@@ -152,7 +180,7 @@ class _GalCaptureSetupDialogState extends State<GalCaptureSetupDialog> {
       ),
       actions: <Widget>[
         TextButton(
-          onPressed: () => Navigator.of(context).pop(),
+          onPressed: _dismissOnce,
           child: Text(t.dialog_close),
         ),
       ],
@@ -262,8 +290,7 @@ class _GalCaptureSetupDialogState extends State<GalCaptureSetupDialog> {
                     state: state,
                     onSelectVoice: widget.session.selectVoiceTrack,
                     onToggleExcluded: widget.session.setTrackExcluded,
-                    onPreviewTrack: (GalAudioTrack track) =>
-                        unawaited(_togglePreview(track)),
+                    onPreviewTrack: _requestPreview,
                     previewingSourcePtr: _previewingSourcePtr,
                   ),
                 ],

--- a/hibiki/lib/src/pages/implementations/gal_capture_setup_dialog.dart
+++ b/hibiki/lib/src/pages/implementations/gal_capture_setup_dialog.dart
@@ -1,0 +1,305 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:hibiki/src/mining/gal_audio_tracks_panel.dart';
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/mining/galgame_audio_source.dart';
+import 'package:hibiki/src/pages/implementations/game_shared.dart';
+import 'package:hibiki/src/sync/texthooker_service.dart';
+import 'package:hibiki/src/utils/misc/desktop_audio_playback.dart';
+import 'package:hibiki/utils.dart';
+
+typedef GalTextThreadSelector = Future<bool> Function(
+  TexthookerTextThread thread,
+);
+
+/// 游戏启动/附着后首次出现候选线程时的捕获设置大弹窗。
+///
+/// 左侧先选台词线程，右侧明确区分「音频采集源已就绪」与「本句已有音频」；引擎 PCM
+/// 模式还可在同一处试听、选语音轨和排除 BGM。选中线程后自动关闭，也保留显式关闭。
+class GalCaptureSetupDialog extends StatefulWidget {
+  const GalCaptureSetupDialog({
+    required this.session,
+    required this.onSelectThread,
+    super.key,
+  });
+
+  final GalHookSessionController session;
+  final GalTextThreadSelector onSelectThread;
+
+  @override
+  State<GalCaptureSetupDialog> createState() => _GalCaptureSetupDialogState();
+}
+
+class _GalCaptureSetupDialogState extends State<GalCaptureSetupDialog> {
+  String? _selectingThreadKey;
+  int? _previewingSourcePtr;
+  Timer? _previewResetTimer;
+  bool _autoCloseScheduled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(widget.session.refreshAudioTracks());
+  }
+
+  @override
+  void dispose() {
+    _previewResetTimer?.cancel();
+    unawaited(DesktopAudioPlayback.stop());
+    super.dispose();
+  }
+
+  Future<void> _selectThread(TexthookerTextThread thread) async {
+    if (_selectingThreadKey != null) return;
+    setState(() => _selectingThreadKey = thread.key);
+    final bool selected = await widget.onSelectThread(thread);
+    if (!mounted) return;
+    if (selected) {
+      Navigator.of(context).pop();
+      return;
+    }
+    setState(() => _selectingThreadKey = null);
+  }
+
+  Future<void> _togglePreview(GalAudioTrack track) async {
+    if (_previewingSourcePtr == track.sourcePtr) {
+      _previewResetTimer?.cancel();
+      setState(() => _previewingSourcePtr = null);
+      await DesktopAudioPlayback.stop();
+      return;
+    }
+    final GalTrackPreview? preview =
+        await widget.session.exportTrackPreview(track.sourcePtr);
+    if (!mounted) return;
+    if (preview == null ||
+        !await DesktopAudioPlayback.playFile(preview.filePath)) {
+      HibikiToast.show(msg: t.game_track_preview_failed);
+      return;
+    }
+    if (!mounted) return;
+    _previewResetTimer?.cancel();
+    setState(() => _previewingSourcePtr = track.sourcePtr);
+    _previewResetTimer = Timer(
+      Duration(milliseconds: preview.durationMs + 300),
+      () {
+        if (mounted) setState(() => _previewingSourcePtr = null);
+      },
+    );
+  }
+
+  void _scheduleAutoClose() {
+    if (_autoCloseScheduled) return;
+    _autoCloseScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) Navigator.of(context).maybePop();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final Size screen = MediaQuery.sizeOf(context);
+    final double dialogHeight = (screen.height * 0.72).clamp(420.0, 680.0);
+    return AlertDialog(
+      title: Text(t.game_capture_setup_title),
+      content: SizedBox(
+        width: 900,
+        height: dialogHeight,
+        child: ListenableBuilder(
+          listenable: widget.session,
+          builder: (BuildContext context, Widget? child) {
+            if (widget.session.selectedTextThreadKey != null) {
+              _scheduleAutoClose();
+            }
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Text(
+                  t.game_capture_setup_hint,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: LayoutBuilder(
+                    builder: (BuildContext context, BoxConstraints box) {
+                      final Widget threads = _buildThreadPane(context);
+                      final Widget audio = _buildAudioPane(context);
+                      if (box.maxWidth >= 760) {
+                        return Row(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: <Widget>[
+                            Expanded(flex: 6, child: threads),
+                            const SizedBox(width: 12),
+                            Expanded(flex: 5, child: audio),
+                          ],
+                        );
+                      }
+                      return Column(
+                        children: <Widget>[
+                          Expanded(flex: 6, child: threads),
+                          const SizedBox(height: 12),
+                          Expanded(flex: 5, child: audio),
+                        ],
+                      );
+                    },
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(t.dialog_close),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildThreadPane(BuildContext context) {
+    final List<TexthookerTextThread> threads = widget.session.textThreads;
+    final Map<String, String> labels = assignThreadDisplayLabels(threads);
+    return HibikiCard(
+      padding: EdgeInsets.zero,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+            child: Text(
+              t.game_text_thread,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: threads.isEmpty
+                ? Center(child: Text(t.game_waiting_for_text))
+                : ListView.builder(
+                    padding: const EdgeInsets.all(8),
+                    itemCount: threads.length,
+                    itemBuilder: (BuildContext context, int index) {
+                      final TexthookerTextThread thread = threads[index];
+                      final bool selecting = _selectingThreadKey == thread.key;
+                      return HibikiListItem(
+                        leading: const Icon(Icons.forum_outlined),
+                        title: Text(
+                          '${labels[thread.key] ?? thread.label} · '
+                          '${thread.observedLineCount}',
+                        ),
+                        subtitle: Text(
+                          texthookerThreadSubtitle(
+                                audioLineCount: thread.audioLineCount,
+                                latestText: thread.displayPreviewText,
+                                audioLabel: t.game_text_thread_audio_count(
+                                  count: thread.audioLineCount,
+                                ),
+                              ) ??
+                              t.game_waiting_for_text,
+                          maxLines: 3,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        trailing: selecting
+                            ? const SizedBox.square(
+                                dimension: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : const Icon(Icons.chevron_right),
+                        onTap: selecting
+                            ? null
+                            : () => unawaited(_selectThread(thread)),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAudioPane(BuildContext context) {
+    final GalHookSessionState state = widget.session.state;
+    final String source = galHookAudioBackendLabel(state.audioBackend);
+    final String? format = state.audioFormat == null
+        ? null
+        : '${state.audioFormat!.sampleRate} Hz · '
+            '${state.audioFormat!.channels} ch · '
+            '${state.audioFormat!.bitsPerSample} bit';
+    return HibikiCard(
+      padding: EdgeInsets.zero,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+            child: Text(
+              t.game_audio_tracks,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+          ),
+          const Divider(height: 1),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(14),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  _AudioSourceSummary(source: source, format: format),
+                  const SizedBox(height: 12),
+                  Text(
+                    t.game_audio_requires_thread,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                        ),
+                  ),
+                  const SizedBox(height: 8),
+                  GalAudioTracksPanel(
+                    state: state,
+                    onSelectVoice: widget.session.selectVoiceTrack,
+                    onToggleExcluded: widget.session.setTrackExcluded,
+                    onPreviewTrack: (GalAudioTrack track) =>
+                        unawaited(_togglePreview(track)),
+                    previewingSourcePtr: _previewingSourcePtr,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AudioSourceSummary extends StatelessWidget {
+  const _AudioSourceSummary({required this.source, required this.format});
+
+  final String source;
+  final String? format;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Icon(Icons.graphic_eq_outlined),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(source, style: Theme.of(context).textTheme.labelLarge),
+              if (format != null)
+                Text(format!, style: Theme.of(context).textTheme.bodySmall),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/hibiki/lib/src/pages/implementations/galgame_home_page.dart
+++ b/hibiki/lib/src/pages/implementations/galgame_home_page.dart
@@ -364,7 +364,6 @@ class _GalgameHomePageState extends ConsumerState<GalgameHomePage> {
               focusIdPrefix: 'game-dashboard-tab',
               onSelectLibrary: widget.onShowLibrary,
               onSelectMonitor: widget.onShowMonitor,
-              onSelectDiagnostics: widget.onShowDiagnostics,
             ),
             actions: <Widget>[
               HibikiIconButton(

--- a/hibiki/lib/src/pages/implementations/game_diagnostics_page.dart
+++ b/hibiki/lib/src/pages/implementations/game_diagnostics_page.dart
@@ -148,6 +148,15 @@ class _GameDiagnosticsPageState extends State<GameDiagnosticsPage> {
                       gameSectionNotifier.value = GameSection.settings,
                 ),
                 actions: <Widget>[
+                  HibikiIconButton(
+                    key: const ValueKey<String>(
+                      'game-diagnostics-back-to-settings',
+                    ),
+                    icon: Icons.arrow_back,
+                    tooltip: t.settings,
+                    onTap: () =>
+                        gameSectionNotifier.value = GameSection.settings,
+                  ),
                   // BUG-1027：「刷新音轨」已就近移入「活跃音轨」卡片标题行；
                   // 页头只保留全局性的清事件动作。
                   HibikiIconButton(

--- a/hibiki/lib/src/pages/implementations/game_diagnostics_page.dart
+++ b/hibiki/lib/src/pages/implementations/game_diagnostics_page.dart
@@ -140,11 +140,12 @@ class _GameDiagnosticsPageState extends State<GameDiagnosticsPage> {
             children: <Widget>[
               HibikiPageHeader.customTitle(
                 title: GameSectionTabs(
-                  selected: GameSection.diagnostics,
+                  selected: GameSection.settings,
                   focusIdPrefix: 'game-diagnostics-tab',
                   onSelectLibrary: widget.onShowLibrary,
                   onSelectMonitor: widget.onShowCapture,
-                  onSelectDiagnostics: () {},
+                  onSelectSettings: () =>
+                      gameSectionNotifier.value = GameSection.settings,
                 ),
                 actions: <Widget>[
                   // BUG-1027：「刷新音轨」已就近移入「活跃音轨」卡片标题行；

--- a/hibiki/lib/src/pages/implementations/game_shared.dart
+++ b/hibiki/lib/src/pages/implementations/game_shared.dart
@@ -6,19 +6,51 @@ import 'package:hibiki/src/sync/texthooker_service.dart';
 import 'package:hibiki/src/sync/texthooker_ws_client.dart';
 import 'package:hibiki/utils.dart';
 
-/// 游戏模块四页（首页 / 库 / 捕获工作台 / 诊断）共享的枚举翻译映射、时间格式与
+/// 游戏模块各页（首页 / 库 / 捕获工作台 / 设置 / 诊断）共享的枚举翻译映射、时间格式与
 /// 子区分段导航。巡检 PR-1 收敛点：此前 `_audioBackendLabel` 三份拷贝、
 /// `_formatTime` 两份拷贝、section tab 行三份拷贝，且多处枚举 `.name`
 /// 直接上屏（camelCase 英文暴露给 17 语言用户）。
 
 /// 游戏页子区。[dashboard] 是游戏模块的默认首屏（游戏首页/仪表盘），排在最前，
 /// 库/工作台/诊断顺延——枚举顺序即 [HomeGamePage] 的 IndexedStack 索引顺序。
-enum GameSection { dashboard, library, monitor, diagnostics }
+enum GameSection { dashboard, library, monitor, diagnostics, settings }
 
 /// App 级游戏页子区导航。默认停在游戏首页（[GameSection.dashboard]）；原生 Hook
 /// 浮窗可在主窗最小化时请求回到捕获工作台（写 [GameSection.monitor]）。
 final ValueNotifier<GameSection> gameSectionNotifier =
     ValueNotifier<GameSection>(GameSection.dashboard);
+
+/// 捕获工作台对用户可宣称的阶段。helper/音频源已启动不等于已经能消费台词：
+/// 引擎会话必须先选定文本线程，之后才可能产生与该线程台词绑定的句级音频。
+enum GalWorkbenchReadiness { idle, waitingForThread, listening }
+
+GalWorkbenchReadiness galWorkbenchReadiness({
+  required GalHookSessionState state,
+  required bool hasEngineSource,
+  required String? selectedTextThreadKey,
+}) {
+  if (!state.isActive) return GalWorkbenchReadiness.idle;
+  if (hasEngineSource && selectedTextThreadKey == null) {
+    return GalWorkbenchReadiness.waitingForThread;
+  }
+  return GalWorkbenchReadiness.listening;
+}
+
+/// 游戏启动后的捕获设置弹窗只在「本轮引擎会话已经发现线程，但用户尚未选定」时出现。
+/// 将判定收敛为纯函数，避免 session/listener 的多次通知重复弹窗。
+bool shouldPromptGalCaptureSetup({
+  required GalHookSessionState state,
+  required bool hasEngineSource,
+  required String? selectedTextThreadKey,
+  required int textThreadCount,
+  required bool sessionAlreadyPrompted,
+}) =>
+    state.sessionStartedAt != null &&
+    state.isActive &&
+    hasEngineSource &&
+    selectedTextThreadKey == null &&
+    textThreadCount > 0 &&
+    !sessionAlreadyPrompted;
 
 /// Hook 会话音频后端的用户可读标签。
 String galHookAudioBackendLabel(GalHookAudioBackend backend) =>
@@ -77,7 +109,10 @@ String formatGameClockTime(DateTime value) {
   return '${two(value.hour)}:${two(value.minute)}:${two(value.second)}';
 }
 
-/// 游戏模块四页共用的胶囊分段导航（首页 / 库 / 捕获工作台 / 诊断）。
+/// 游戏模块共用的胶囊分段导航（首页 / 库 / 捕获工作台 / 设置）。
+///
+/// 兼容性诊断仍可从「设置」进入，但不再占据高频顶部页签；诊断详情打开时顶部
+/// 高亮「设置」，明确它属于配置/排障路径。
 ///
 /// 四个选项是一个焦点停靠点：左右方向键在控件内切换，鼠标和触摸仍可直接点某段。
 /// [focusIdPrefix] 决定稳定 focusId `<prefix>-sections`，各页前缀互不冲突。
@@ -87,7 +122,7 @@ class GameSectionTabs extends StatelessWidget {
     required this.focusIdPrefix,
     required this.onSelectLibrary,
     required this.onSelectMonitor,
-    required this.onSelectDiagnostics,
+    this.onSelectSettings,
     this.onSelectDashboard,
     super.key,
   });
@@ -105,11 +140,16 @@ class GameSectionTabs extends StatelessWidget {
 
   final VoidCallback onSelectLibrary;
   final VoidCallback onSelectMonitor;
-  final VoidCallback onSelectDiagnostics;
+  final VoidCallback? onSelectSettings;
 
   @override
   Widget build(BuildContext context) {
-    const List<GameSection> values = GameSection.values;
+    const List<GameSection> values = <GameSection>[
+      GameSection.dashboard,
+      GameSection.library,
+      GameSection.monitor,
+      GameSection.settings,
+    ];
     void select(GameSection section) {
       switch (section) {
         case GameSection.dashboard:
@@ -123,7 +163,11 @@ class GameSectionTabs extends StatelessWidget {
           onSelectMonitor();
           return;
         case GameSection.diagnostics:
-          onSelectDiagnostics();
+          gameSectionNotifier.value = GameSection.diagnostics;
+          return;
+        case GameSection.settings:
+          (onSelectSettings ??
+              () => gameSectionNotifier.value = GameSection.settings)();
           return;
       }
     }
@@ -149,8 +193,8 @@ class GameSectionTabs extends StatelessWidget {
             label: Text(t.game_capture_workbench),
           ),
           ButtonSegment<GameSection>(
-            value: GameSection.diagnostics,
-            label: Text(t.game_diagnostics),
+            value: GameSection.settings,
+            label: Text(t.settings),
           ),
         ],
         selected: selected,

--- a/hibiki/lib/src/pages/implementations/game_shared.dart
+++ b/hibiki/lib/src/pages/implementations/game_shared.dart
@@ -46,7 +46,13 @@ bool shouldPromptGalCaptureSetup({
   required bool sessionAlreadyPrompted,
 }) =>
     state.sessionStartedAt != null &&
-    state.isActive &&
+    switch (state.phase) {
+      GalHookSessionPhase.waitingSignals ||
+      GalHookSessionPhase.running ||
+      GalHookSessionPhase.degraded =>
+        true,
+      _ => false,
+    } &&
     hasEngineSource &&
     selectedTextThreadKey == null &&
     textThreadCount > 0 &&

--- a/hibiki/lib/src/pages/implementations/home_game_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_game_page.dart
@@ -6,7 +6,9 @@ import 'package:hibiki/src/pages/implementations/game_diagnostics_page.dart';
 import 'package:hibiki/src/pages/implementations/game_shared.dart';
 import 'package:hibiki/src/pages/implementations/game_statistics_page.dart';
 import 'package:hibiki/src/pages/implementations/games_library_page.dart';
+import 'package:hibiki/src/pages/implementations/module_settings_view.dart';
 import 'package:hibiki/src/pages/implementations/texthooker_page.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/utils.dart';
 
 // GameSection / gameSectionNotifier 已迁到 game_shared.dart（三页共享），
@@ -30,6 +32,10 @@ typedef GameDashboardBuilder = Widget Function(
   BuildContext context,
   VoidCallback onShowLibrary,
 );
+typedef GameSettingsBuilder = Widget Function(
+  BuildContext context,
+  Widget navigation,
+);
 
 /// 首页一级「游戏」模块。
 ///
@@ -42,18 +48,21 @@ class HomeGamePage extends StatefulWidget {
     this.monitorBuilder,
     this.libraryBuilder,
     this.dashboardBuilder,
+    this.settingsBuilder,
     this.controller,
   });
 
   final GameMonitorBuilder? monitorBuilder;
   final GameLibraryBuilder? libraryBuilder;
   final GameDashboardBuilder? dashboardBuilder;
+  final GameSettingsBuilder? settingsBuilder;
   final GalHookSessionController? controller;
 
   static const Key dashboardKey = ValueKey<String>('game-dashboard');
   static const Key libraryKey = ValueKey<String>('game-library');
   static const Key monitorKey = ValueKey<String>('game-monitor');
   static const Key diagnosticsKey = ValueKey<String>('game-diagnostics');
+  static const Key settingsKey = ValueKey<String>('game-settings');
 
   /// 库页顶部会话状态带（原两张总览大卡的收敛替身），整条可点进入捕获工作台。
   static const Key captureStatusKey = ValueKey<String>('game-capture-status');
@@ -101,6 +110,7 @@ class _HomeGamePageState extends State<HomeGamePage> {
   void _showLibrary() => _showSection(GameSection.library);
   void _showMonitor() => _showSection(GameSection.monitor);
   void _showDiagnostics() => _showSection(GameSection.diagnostics);
+  void _showSettings() => _showSection(GameSection.settings);
 
   Future<void> _openStatistics() => Navigator.of(context).push(
         MaterialPageRoute<void>(
@@ -149,6 +159,26 @@ class _HomeGamePageState extends State<HomeGamePage> {
               onShowCapture: _showMonitor,
             ),
           ),
+          KeyedSubtree(
+            key: HomeGamePage.settingsKey,
+            child: Builder(
+              builder: (BuildContext context) {
+                final Widget navigation = GameSectionTabs(
+                  selected: GameSection.settings,
+                  focusIdPrefix: 'game-settings-tab',
+                  onSelectDashboard: _showDashboard,
+                  onSelectLibrary: _showLibrary,
+                  onSelectMonitor: _showMonitor,
+                  onSelectSettings: _showSettings,
+                );
+                return widget.settingsBuilder?.call(context, navigation) ??
+                    ModuleSettingsView(
+                      destinationId: SettingsDestinationId.game,
+                      navigation: navigation,
+                    );
+              },
+            ),
+          ),
         ],
       ),
     );
@@ -174,7 +204,7 @@ class _HomeGamePageState extends State<HomeGamePage> {
               onSelectDashboard: _showDashboard,
               onSelectLibrary: _showLibrary,
               onSelectMonitor: _showMonitor,
-              onSelectDiagnostics: _showDiagnostics,
+              onSelectSettings: _showSettings,
             ),
             // 顶部不再放「捕获工作台」图标钮——它与下方 GameSectionTabs 的
             // 「捕获工作台」分段去向完全相同，纯冗余；入口收敛到分段导航 + 状态带。
@@ -190,12 +220,19 @@ class _HomeGamePageState extends State<HomeGamePage> {
                   builder: (BuildContext context, Widget? child) {
                     final GalHookSessionState state = _controller.state;
                     final lines = _controller.lines;
+                    final GalWorkbenchReadiness readiness =
+                        galWorkbenchReadiness(
+                      state: state,
+                      hasEngineSource: _controller.hasEngineSource,
+                      selectedTextThreadKey: _controller.selectedTextThreadKey,
+                    );
                     return Padding(
                       padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
                       child: _CaptureStatusStrip(
                         lineCount: lines.length,
                         latestLine: lines.isEmpty ? null : lines.last.text,
                         state: state,
+                        readiness: readiness,
                         onOpen: _showMonitor,
                       ),
                     );
@@ -232,12 +269,14 @@ class _CaptureStatusStrip extends StatelessWidget {
     required this.lineCount,
     required this.latestLine,
     required this.state,
+    required this.readiness,
     required this.onOpen,
   });
 
   final int lineCount;
   final String? latestLine;
   final GalHookSessionState state;
+  final GalWorkbenchReadiness readiness;
   final VoidCallback onOpen;
 
   @override
@@ -246,11 +285,14 @@ class _CaptureStatusStrip extends StatelessWidget {
     final ColorScheme colors = theme.colorScheme;
     // 有台词、或会话阶段非 idle/error，都算「在捕获」——阶段已 running 但尚未
     // 产出台词时仍显示活动态，而不是回落到「尚未开始」。
-    final bool active = state.isActive || lineCount > 0;
+    final bool active =
+        readiness != GalWorkbenchReadiness.idle || lineCount > 0;
     final Color accent = active ? colors.primary : colors.onSurfaceVariant;
 
     final Widget detail = active
-        ? _buildActiveDetail(theme, colors)
+        ? readiness == GalWorkbenchReadiness.waitingForThread
+            ? _buildWaitingForThreadDetail(theme, colors)
+            : _buildActiveDetail(theme, colors)
         : Text(
             '${t.game_session_idle}  ·  ${t.game_open_capture_workspace}',
             maxLines: 1,
@@ -279,6 +321,33 @@ class _CaptureStatusStrip extends StatelessWidget {
           Icon(Icons.chevron_right, color: colors.onSurfaceVariant, size: 20),
         ],
       ),
+    );
+  }
+
+  Widget _buildWaitingForThreadDetail(
+    ThemeData theme,
+    ColorScheme colors,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        Text(
+          t.game_session_waiting_thread,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.labelLarge,
+        ),
+        const SizedBox(height: 4),
+        Text(
+          t.game_text_thread_unset,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: colors.onSurfaceVariant,
+          ),
+        ),
+      ],
     );
   }
 

--- a/hibiki/lib/src/pages/implementations/home_game_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_game_page.dart
@@ -123,6 +123,7 @@ class _HomeGamePageState extends State<HomeGamePage> {
     final GameMonitorBuilder monitorBuilder = widget.monitorBuilder ??
         (BuildContext context, VoidCallback onShowLibrary) => TexthookerPage(
               embedded: true,
+              captureSetupEnabled: _section == GameSection.monitor,
               onShowLibrary: onShowLibrary,
               onShowDiagnostics: _showDiagnostics,
             );

--- a/hibiki/lib/src/pages/implementations/home_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_page.dart
@@ -24,6 +24,8 @@ import 'package:hibiki/src/sync/sync_auto_trigger.dart';
 import 'package:hibiki/src/media/video/video_book_repository.dart';
 import 'package:hibiki/src/pages/implementations/media_library_shell.dart';
 import 'package:hibiki/src/pages/implementations/media_sources_page.dart';
+import 'package:hibiki/src/pages/implementations/module_settings_view.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/src/media/audiobook/now_listening_mini_bar.dart';
 import 'package:hibiki/src/sync/desktop_lookup_service.dart';
 import 'package:hibiki/pages.dart';
@@ -1085,6 +1087,15 @@ class _HomePageState extends BasePageState<HomePage>
               label: t.library_view_sources,
               builder: (BuildContext context, Widget navigation) =>
                   MediaSourcesPage(mediaKind: 'video', navigation: navigation),
+            ),
+            MediaLibraryViewSpec(
+              kind: MediaLibraryViewKind.settings,
+              label: t.settings,
+              builder: (BuildContext context, Widget navigation) =>
+                  ModuleSettingsView(
+                destinationId: SettingsDestinationId.video,
+                navigation: navigation,
+              ),
             ),
           ],
         );

--- a/hibiki/lib/src/pages/implementations/home_reader_page.dart
+++ b/hibiki/lib/src/pages/implementations/home_reader_page.dart
@@ -4,6 +4,8 @@ import 'package:hibiki/media.dart';
 import 'package:hibiki/pages.dart';
 import 'package:hibiki/src/pages/implementations/media_library_shell.dart';
 import 'package:hibiki/src/pages/implementations/media_sources_page.dart';
+import 'package:hibiki/src/pages/implementations/module_settings_view.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
 import 'package:hibiki/utils.dart';
 
 /// The body content for the Reader tab in the main menu.
@@ -42,6 +44,15 @@ class _HomeReaderPageState extends BaseTabPageState<HomeReaderPage> {
           label: t.library_view_sources,
           builder: (BuildContext context, Widget navigation) =>
               MediaSourcesPage(mediaKind: 'book', navigation: navigation),
+        ),
+        MediaLibraryViewSpec(
+          kind: MediaLibraryViewKind.settings,
+          label: t.settings,
+          builder: (BuildContext context, Widget navigation) =>
+              ModuleSettingsView(
+            destinationId: SettingsDestinationId.reading,
+            navigation: navigation,
+          ),
         ),
       ],
     );

--- a/hibiki/lib/src/pages/implementations/media_library_shell.dart
+++ b/hibiki/lib/src/pages/implementations/media_library_shell.dart
@@ -17,6 +17,9 @@ enum MediaLibraryViewKind {
   /// 来源管理：本地扫描根 + 在线源设置 + 漫画扩展（扩展本身就是「来源」，
   /// 不单开 tab）。
   sources,
+
+  /// 本媒体域的设置。正文投影自全局 settings schema，避免复制第二套配置。
+  settings,
 }
 
 /// 一个视图的声明：显示名 + 内容构建器。

--- a/hibiki/lib/src/pages/implementations/module_settings_view.dart
+++ b/hibiki/lib/src/pages/implementations/module_settings_view.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:hibiki/models.dart';
+import 'package:hibiki/src/settings/cupertino_settings_renderer.dart';
+import 'package:hibiki/src/settings/material_settings_renderer.dart';
+import 'package:hibiki/src/settings/settings_context.dart';
+import 'package:hibiki/src/settings/settings_destination.dart';
+import 'package:hibiki/src/settings/settings_renderer.dart';
+import 'package:hibiki/src/settings/settings_schema.dart';
+import 'package:hibiki/utils.dart';
+
+/// 在媒体/游戏模块自己的顶部页签内嵌一个 schema 设置分类。
+///
+/// 设置项仍来自全局 [buildSettingsSchema]，所以这里不会复制第二套开关、持久化或
+/// 平台门控。外层只负责保留模块的分段导航页头；正文交给与设置主页相同的 renderer。
+class ModuleSettingsView extends ConsumerStatefulWidget {
+  const ModuleSettingsView({
+    required this.destinationId,
+    required this.navigation,
+    super.key,
+  });
+
+  final SettingsDestinationId destinationId;
+  final Widget navigation;
+
+  @override
+  ConsumerState<ModuleSettingsView> createState() => _ModuleSettingsViewState();
+}
+
+class _ModuleSettingsViewState extends ConsumerState<ModuleSettingsView>
+    with SettingsContextHost<ModuleSettingsView> {
+  @override
+  Widget build(BuildContext context) {
+    final AppModel appModel = ref.watch(appProvider);
+    final SettingsContext settingsContext = createSettingsContext(
+      appModel: appModel,
+      ref: ref,
+    );
+    final SettingsDestination destination = buildSettingsSchema(
+      settingsContext,
+    ).firstWhere(
+      (SettingsDestination destination) =>
+          destination.id == widget.destinationId,
+    );
+    final SettingsRenderer renderer = isCupertinoPlatform(context)
+        ? const CupertinoSettingsRenderer()
+        : const MaterialSettingsRenderer();
+
+    return DesktopContentLayout(
+      kind: DesktopContentKind.settings,
+      child: Column(
+        children: <Widget>[
+          if (!isCupertinoPlatform(context))
+            HibikiPageHeader.customTitle(title: widget.navigation),
+          Expanded(
+            child: renderer.buildDetailContent(
+              settingsContext: settingsContext,
+              destination: destination,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/hibiki/lib/src/pages/implementations/module_settings_view.dart
+++ b/hibiki/lib/src/pages/implementations/module_settings_view.dart
@@ -51,8 +51,7 @@ class _ModuleSettingsViewState extends ConsumerState<ModuleSettingsView>
       kind: DesktopContentKind.settings,
       child: Column(
         children: <Widget>[
-          if (!isCupertinoPlatform(context))
-            HibikiPageHeader.customTitle(title: widget.navigation),
+          HibikiPageHeader.customTitle(title: widget.navigation),
           Expanded(
             child: renderer.buildDetailContent(
               settingsContext: settingsContext,

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -71,12 +71,14 @@ class TexthookerPage extends ConsumerStatefulWidget {
   const TexthookerPage({
     super.key,
     this.embedded = false,
+    this.captureSetupEnabled = true,
     this.onShowLibrary,
     this.onShowDiagnostics,
   });
 
   /// 嵌入 [HomeGamePage] 时不再创建第二层 Scaffold/AppBar。
   final bool embedded;
+  final bool captureSetupEnabled;
   final VoidCallback? onShowLibrary;
   final VoidCallback? onShowDiagnostics;
 
@@ -434,6 +436,16 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       }
       _maybeScheduleCaptureSetupDialog();
     });
+  }
+
+  @override
+  void didUpdateWidget(TexthookerPage oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!oldWidget.captureSetupEnabled && widget.captureSetupEnabled) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _maybeScheduleCaptureSetupDialog();
+      });
+    }
   }
 
   /// BUG-1028：开页 seed 常驻隐藏热槽（低内存模式 [DictionaryPopupController.seedWarmSlot]
@@ -1035,7 +1047,11 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   }
 
   void _maybeScheduleCaptureSetupDialog() {
-    if (!mounted || _captureSetupDialogOpen || _captureSetupDialogScheduled) {
+    if (!mounted ||
+        !widget.captureSetupEnabled ||
+        !TickerMode.of(context) ||
+        _captureSetupDialogOpen ||
+        _captureSetupDialogScheduled) {
       return;
     }
     final GalHookSessionState state = _session.state;
@@ -1052,7 +1068,9 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     _captureSetupDialogScheduled = true;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       _captureSetupDialogScheduled = false;
-      if (!mounted) return;
+      if (!mounted || !widget.captureSetupEnabled || !TickerMode.of(context)) {
+        return;
+      }
       final GalHookSessionState latest = _session.state;
       if (latest.sessionStartedAt != sessionStartedAt ||
           !shouldPromptGalCaptureSetup(
@@ -1153,10 +1171,14 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
 
   @override
   Widget build(BuildContext context) {
+    final bool captureSetupVisible = TickerMode.of(context);
     final List<TexthookerTextThread> textThreads = _session.textThreads;
     final String? selectedTextThreadKey = _session.selectedTextThreadKey;
     final List<TexthookerLineEntry> lines = _session.workbenchLines;
     WidgetsBinding.instance.addPostFrameCallback((_) => _syncPopupOverlay());
+    if (captureSetupVisible && widget.captureSetupEnabled) {
+      _maybeScheduleCaptureSetupDialog();
+    }
     if (widget.embedded) {
       final List<Widget> actions =
           _buildToolbarActions(context, embedded: true);

--- a/hibiki/lib/src/pages/implementations/texthooker_page.dart
+++ b/hibiki/lib/src/pages/implementations/texthooker_page.dart
@@ -23,6 +23,7 @@ import 'package:hibiki/src/mining/galgame_hook_code_profile.dart';
 import 'package:hibiki/src/mining/galgame_library.dart';
 import 'package:hibiki/src/mining/window_capture_channel.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_page_mixin.dart';
+import 'package:hibiki/src/pages/implementations/gal_capture_setup_dialog.dart';
 import 'package:hibiki/src/pages/implementations/game_shared.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_controller.dart';
 import 'package:hibiki/src/pages/implementations/dictionary_popup_layer.dart';
@@ -103,6 +104,12 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   /// galgame 引擎-hook 启动的**再入守卫**：一次启动含选文件、位数探测、helper 确认/下载对话框、
   /// 注入会话等多个 await，可持续数秒。没有守卫时重复点击会叠出多个下载确认对话框。
   bool _launchingGalHook = false;
+
+  /// 每个捕获会话只自动弹一次首次设置；手动关闭后不反复打扰。新会话由
+  /// sessionStartedAt 区分，候选线程出现且仍未选中时才弹，避免空白弹窗。
+  DateTime? _captureSetupShownForSession;
+  bool _captureSetupDialogOpen = false;
+  bool _captureSetupDialogScheduled = false;
 
   /// 实时台词列表的筛选维度（全部 / 有音频 / 已制卡 / 已收藏）。与线程下拉正交叠加。
   TexthookerLineFilter _lineFilter = TexthookerLineFilter.all;
@@ -425,6 +432,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       if (mounted && _followLive && _scroll.hasClients) {
         _scroll.jumpTo(_scroll.position.maxScrollExtent);
       }
+      _maybeScheduleCaptureSetupDialog();
     });
   }
 
@@ -944,7 +952,9 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   }
 
   void _onSessionChanged() {
-    if (mounted) setState(() {});
+    if (!mounted) return;
+    setState(() {});
+    _maybeScheduleCaptureSetupDialog();
   }
 
   /// 外部窗口挖矿模式条：展示已绑定窗口标题 + 重选/解绑；未绑定时点击选窗口。
@@ -1015,11 +1025,60 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     setState(() {
       if (!follow && receivedNewLine) _unreadLines++;
     });
+    _maybeScheduleCaptureSetupDialog();
     if (!receivedNewLine || !follow) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_scroll.hasClients) {
         _scroll.jumpTo(_scroll.position.maxScrollExtent);
       }
+    });
+  }
+
+  void _maybeScheduleCaptureSetupDialog() {
+    if (!mounted || _captureSetupDialogOpen || _captureSetupDialogScheduled) {
+      return;
+    }
+    final GalHookSessionState state = _session.state;
+    final DateTime? sessionStartedAt = state.sessionStartedAt;
+    if (!shouldPromptGalCaptureSetup(
+      state: state,
+      hasEngineSource: _session.hasEngineSource,
+      selectedTextThreadKey: _session.selectedTextThreadKey,
+      textThreadCount: _session.textThreads.length,
+      sessionAlreadyPrompted: _captureSetupShownForSession == sessionStartedAt,
+    )) {
+      return;
+    }
+    _captureSetupDialogScheduled = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      _captureSetupDialogScheduled = false;
+      if (!mounted) return;
+      final GalHookSessionState latest = _session.state;
+      if (latest.sessionStartedAt != sessionStartedAt ||
+          !shouldPromptGalCaptureSetup(
+            state: latest,
+            hasEngineSource: _session.hasEngineSource,
+            selectedTextThreadKey: _session.selectedTextThreadKey,
+            textThreadCount: _session.textThreads.length,
+            sessionAlreadyPrompted: false,
+          )) {
+        return;
+      }
+      _captureSetupShownForSession = sessionStartedAt;
+      _captureSetupDialogOpen = true;
+      await showAppDialog<void>(
+        context: context,
+        builder: (BuildContext dialogContext) => GalCaptureSetupDialog(
+          session: _session,
+          onSelectThread: (TexthookerTextThread thread) =>
+              _session.selectTextThread(
+            thread.nativeThreadId,
+            threadKey: thread.key,
+            remember: true,
+          ),
+        ),
+      );
+      _captureSetupDialogOpen = false;
     });
   }
 
@@ -1153,7 +1212,7 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
   /// 清空台词），低频开关收进「更多」菜单。[embedded] 仅决定按钮是否展开文字标签
   /// （页头模式展开、AppBar 模式纯图标），按钮集合与行为调用两模式完全一致。
   ///
-  /// 「兼容性诊断」入口已删——顶部 [GameSectionTabs] 已有同入口，工具栏再放一份纯冗余。
+  /// 「兼容性诊断」入口已删——它收进游戏「设置」，工具栏再放一份纯冗余。
   List<Widget> _buildToolbarActions(
     BuildContext context, {
     required bool embedded,
@@ -1188,7 +1247,9 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
         ),
       // 会话音轨面板直达入口：排除 BGM 是会话级操作，此前只能从「某一句的
       // 选轨对话框」绕进去（先随便找一句才能排除，入口藏反了）。
-      if (Platform.isWindows && state.isActive)
+      if (Platform.isWindows &&
+          state.isActive &&
+          _session.selectedTextThreadKey != null)
         HibikiIconButton(
           icon: Icons.multitrack_audio_outlined,
           tooltip: t.game_audio_tracks,
@@ -1366,7 +1427,6 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
       focusIdPrefix: 'game-capture-tab',
       onSelectLibrary: widget.onShowLibrary!,
       onSelectMonitor: () {},
-      onSelectDiagnostics: widget.onShowDiagnostics!,
     );
   }
 
@@ -1377,6 +1437,11 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
     String? selectedTextThreadKey,
   ) {
     final GalHookSessionState state = _session.state;
+    final GalWorkbenchReadiness readiness = galWorkbenchReadiness(
+      state: state,
+      hasEngineSource: _session.hasEngineSource,
+      selectedTextThreadKey: selectedTextThreadKey,
+    );
     return Column(
       children: <Widget>[
         _buildExperimentalBanner(context),
@@ -1396,14 +1461,20 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                 // 让位）：正文与音频元信息并进本面板，健康状态移到工具栏「更多」→
                 // 对话框（同页签栏的「兼容性诊断」也有完整版），把这块常驻空间还给
                 // 「听 → 判断 → 排除 BGM」这条真正需要反复操作的动线。
-                final Widget lineTracks = _LineTracksCard(
-                  session: _session,
-                  line: _selectedOrLatestLine(lines),
-                );
+                final Widget lineTracks =
+                    readiness == GalWorkbenchReadiness.waitingForThread
+                        ? const _ThreadSelectionRequiredCard()
+                        : _LineTracksCard(
+                            session: _session,
+                            line: _selectedOrLatestLine(lines),
+                          );
                 if (box.maxWidth >= 1280) {
                   return Column(
                     children: <Widget>[
-                      _SessionOverviewCard(state: state),
+                      _SessionOverviewCard(
+                        state: state,
+                        readiness: readiness,
+                      ),
                       const SizedBox(height: 12),
                       Expanded(
                         child: Row(
@@ -1421,7 +1492,10 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                 if (box.maxWidth >= 840) {
                   return Column(
                     children: <Widget>[
-                      _SessionOverviewCard(state: state),
+                      _SessionOverviewCard(
+                        state: state,
+                        readiness: readiness,
+                      ),
                       const SizedBox(height: 12),
                       Expanded(
                         child: Row(
@@ -1441,7 +1515,11 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
                 return Column(
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: <Widget>[
-                    _SessionOverviewCard(state: state, compact: true),
+                    _SessionOverviewCard(
+                      state: state,
+                      readiness: readiness,
+                      compact: true,
+                    ),
                     const SizedBox(height: 12),
                     Expanded(child: live),
                     ExpansionTile(
@@ -1924,13 +2002,20 @@ class _TexthookerPageState extends ConsumerState<TexthookerPage>
 }
 
 class _SessionOverviewCard extends StatelessWidget {
-  const _SessionOverviewCard({required this.state, this.compact = false});
+  const _SessionOverviewCard({
+    required this.state,
+    required this.readiness,
+    this.compact = false,
+  });
 
   final GalHookSessionState state;
+  final GalWorkbenchReadiness readiness;
   final bool compact;
 
   @override
   Widget build(BuildContext context) {
+    final bool waitingForThread =
+        readiness == GalWorkbenchReadiness.waitingForThread;
     final String audio = galHookAudioBackendLabel(state.audioBackend);
     final String phase = galHookSessionPhaseLabel(state.phase);
     final String? format = state.audioFormat == null
@@ -1943,7 +2028,11 @@ class _SessionOverviewCard extends StatelessWidget {
       child: Row(
         children: <Widget>[
           Icon(
-            state.isActive ? Icons.sensors : Icons.sensors_off_outlined,
+            waitingForThread
+                ? Icons.forum_outlined
+                : state.isActive
+                    ? Icons.sensors
+                    : Icons.sensors_off_outlined,
             color: state.isActive
                 ? Theme.of(context).colorScheme.primary
                 : Theme.of(context).colorScheme.outline,
@@ -1954,17 +2043,21 @@ class _SessionOverviewCard extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 Text(
-                  state.isActive
-                      ? t.game_session_listening
-                      : t.game_session_idle,
+                  waitingForThread
+                      ? t.game_session_waiting_thread
+                      : state.isActive
+                          ? t.game_session_listening
+                          : t.game_session_idle,
                   style: Theme.of(context).textTheme.titleSmall,
                 ),
                 const SizedBox(height: 2),
                 Text(
-                  compact
-                      ? '$phase · $audio'
-                      : '$phase · $audio'
-                          '${format == null ? '' : ' · $format'}',
+                  waitingForThread
+                      ? '$phase · ${t.game_text_thread_unset}'
+                      : compact
+                          ? '$phase · $audio'
+                          : '$phase · $audio'
+                              '${format == null ? '' : ' · $format'}',
                   maxLines: compact ? 1 : 2,
                   overflow: TextOverflow.ellipsis,
                   style: Theme.of(context).textTheme.bodySmall,
@@ -2012,14 +2105,57 @@ class _SessionOverviewCard extends StatelessWidget {
             ),
           ),
           _StatusPill(
-            label: state.isDegraded
-                ? t.game_line_audio_fallback
-                : (state.isActive
-                    ? t.game_status_ready
-                    : t.game_status_waiting),
-            ready: state.isActive && !state.isDegraded,
+            label: waitingForThread
+                ? t.game_status_waiting
+                : state.isDegraded
+                    ? t.game_line_audio_fallback
+                    : (state.isActive
+                        ? t.game_status_ready
+                        : t.game_status_waiting),
+            ready: !waitingForThread && state.isActive && !state.isDegraded,
           ),
         ],
+      ),
+    );
+  }
+}
+
+/// 未选台词线程时替代「本句音轨」面板：没有句子身份就不存在可归属的句级音频，
+/// 不能继续展示一个看似已就绪的音轨工作区。
+class _ThreadSelectionRequiredCard extends StatelessWidget {
+  const _ThreadSelectionRequiredCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return HibikiCard(
+      child: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Icon(
+                Icons.multitrack_audio_outlined,
+                size: 40,
+                color: Theme.of(context).colorScheme.outline,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                t.game_session_waiting_thread,
+                style: Theme.of(context).textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 6),
+              Text(
+                t.game_audio_requires_thread,
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/hibiki/test/pages/gal_capture_setup_dialog_lifecycle_guard_test.dart
+++ b/hibiki/test/pages/gal_capture_setup_dialog_lifecycle_guard_test.dart
@@ -1,0 +1,61 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../helpers/source_guard.dart';
+
+void main() {
+  final String source = File(
+    'lib/src/pages/implementations/gal_capture_setup_dialog.dart',
+  ).readAsStringSync();
+
+  test('捕获设置弹窗的所有关闭路径收口到一次性 dismiss', () {
+    final String code = maskComments(source);
+    expect(
+      RegExp(r'Navigator\.of\(context\)\.(?:maybePop|pop)\s*\(')
+          .allMatches(code)
+          .length,
+      1,
+      reason: '选择成功、状态监听和关闭按钮不能各自 pop，否则会弹掉底层页面',
+    );
+
+    final String dismiss = topLevelFunctionBody(source, '_dismissOnce')!;
+    final int guard = dismiss.indexOf('if (_dismissRequested) return;');
+    final int latch = dismiss.indexOf('_dismissRequested = true;');
+    final int pop = dismiss.indexOf('Navigator.of(context).maybePop()');
+    expect(guard, greaterThanOrEqualTo(0));
+    expect(latch, greaterThan(guard));
+    expect(pop, greaterThan(latch));
+
+    expect(
+      containsIdentifierCall(
+        topLevelFunctionBody(source, '_selectThread')!,
+        '_dismissOnce',
+      ),
+      isTrue,
+    );
+    expect(
+      containsIdentifierCall(
+        topLevelFunctionBody(source, '_scheduleAutoClose')!,
+        '_dismissOnce',
+      ),
+      isTrue,
+    );
+    expect(code.contains('onPressed: _dismissOnce'), isTrue);
+  });
+
+  test('音轨试听串行化并以最后一次请求代次裁决', () {
+    final String request = topLevelFunctionBody(source, '_requestPreview')!;
+    final String toggle = topLevelFunctionBody(source, '_togglePreview')!;
+    expect(containsIdentifier(request, '_previewGeneration'), isTrue);
+    expect(containsIdentifier(request, '_previewQueue'), isTrue);
+    expect(containsIdentifierCall(request, '_togglePreview'), isTrue);
+    expect(
+      RegExp(r'generation\s*!=\s*_previewGeneration')
+          .allMatches(maskCommentsAndStrings(toggle))
+          .length,
+      greaterThanOrEqualTo(2),
+      reason: '导出前后都必须拒绝过期请求，异步逆序返回不能覆盖最后一次点击',
+    );
+  });
+}

--- a/hibiki/test/pages/game_shared_readiness_test.dart
+++ b/hibiki/test/pages/game_shared_readiness_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
+import 'package:hibiki/src/pages/implementations/game_shared.dart';
+
+void main() {
+  group('BUG-1452 未选择台词线程时的捕获状态', () {
+    test('空闲会话保持空闲', () {
+      expect(
+        galWorkbenchReadiness(
+          state: const GalHookSessionState(),
+          hasEngineSource: false,
+          selectedTextThreadKey: null,
+        ),
+        GalWorkbenchReadiness.idle,
+      );
+    });
+
+    test('引擎和音频源已启动但未选线程时不能宣称正在监听', () {
+      expect(
+        galWorkbenchReadiness(
+          state: const GalHookSessionState(
+            phase: GalHookSessionPhase.running,
+            audioBackend: GalHookAudioBackend.systemLoopback,
+          ),
+          hasEngineSource: true,
+          selectedTextThreadKey: null,
+        ),
+        GalWorkbenchReadiness.waitingForThread,
+      );
+    });
+
+    test('选定线程后才进入正在监听', () {
+      expect(
+        galWorkbenchReadiness(
+          state: const GalHookSessionState(
+            phase: GalHookSessionPhase.running,
+            audioBackend: GalHookAudioBackend.systemLoopback,
+          ),
+          hasEngineSource: true,
+          selectedTextThreadKey: 'pid:thread:hook',
+        ),
+        GalWorkbenchReadiness.listening,
+      );
+    });
+
+    test('无引擎的 WebSocket 会话维持原有无需选线程的监听语义', () {
+      expect(
+        galWorkbenchReadiness(
+          state: const GalHookSessionState(
+            phase: GalHookSessionPhase.running,
+          ),
+          hasEngineSource: false,
+          selectedTextThreadKey: null,
+        ),
+        GalWorkbenchReadiness.listening,
+      );
+    });
+  });
+
+  group('游戏启动后的捕获设置弹窗', () {
+    const GalHookSessionState active = GalHookSessionState(
+      phase: GalHookSessionPhase.running,
+      sessionStartedAt: null,
+    );
+    final GalHookSessionState launched = active.copyWith(
+      sessionStartedAt: DateTime(2026, 8, 2),
+    );
+
+    test('发现候选线程且尚未选择时提示', () {
+      expect(
+        shouldPromptGalCaptureSetup(
+          state: launched,
+          hasEngineSource: true,
+          selectedTextThreadKey: null,
+          textThreadCount: 2,
+          sessionAlreadyPrompted: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('没有候选、已经选择或本轮已经提示时均不重复弹窗', () {
+      bool prompt({
+        String? selected,
+        int count = 2,
+        bool shown = false,
+      }) =>
+          shouldPromptGalCaptureSetup(
+            state: launched,
+            hasEngineSource: true,
+            selectedTextThreadKey: selected,
+            textThreadCount: count,
+            sessionAlreadyPrompted: shown,
+          );
+
+      expect(prompt(count: 0), isFalse);
+      expect(prompt(selected: 'pid:thread:hook'), isFalse);
+      expect(prompt(shown: true), isFalse);
+    });
+  });
+}

--- a/hibiki/test/pages/game_shared_readiness_test.dart
+++ b/hibiki/test/pages/game_shared_readiness_test.dart
@@ -1,7 +1,11 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:hibiki/src/mining/gal_hook_session_controller.dart';
 import 'package:hibiki/src/pages/implementations/game_shared.dart';
+
+import '../helpers/source_guard.dart';
 
 void main() {
   group('BUG-1452 未选择台词线程时的捕获状态', () {
@@ -97,6 +101,154 @@ void main() {
       expect(prompt(count: 0), isFalse);
       expect(prompt(selected: 'pid:thread:hook'), isFalse);
       expect(prompt(shown: true), isFalse);
+    });
+
+    test('启动早期与停止阶段即使残留候选也不能弹窗', () {
+      for (final GalHookSessionPhase phase in <GalHookSessionPhase>[
+        GalHookSessionPhase.resolving,
+        GalHookSessionPhase.launching,
+        GalHookSessionPhase.attaching,
+        GalHookSessionPhase.injecting,
+        GalHookSessionPhase.stopping,
+      ]) {
+        expect(
+          shouldPromptGalCaptureSetup(
+            state: GalHookSessionState(
+              phase: phase,
+              sessionStartedAt: DateTime(2026, 8, 2),
+            ),
+            hasEngineSource: true,
+            selectedTextThreadKey: null,
+            textThreadCount: 2,
+            sessionAlreadyPrompted: false,
+          ),
+          isFalse,
+          reason: '$phase 尚不能安全选择线程',
+        );
+      }
+    });
+  });
+
+  group('BUG-1452 消费端接线守卫', () {
+    final String texthooker = File(
+      'lib/src/pages/implementations/texthooker_page.dart',
+    ).readAsStringSync();
+    final String homeGame = File(
+      'lib/src/pages/implementations/home_game_page.dart',
+    ).readAsStringSync();
+
+    test('工作台必须消费 readiness 并以等待卡替代句级音轨', () {
+      final String monitor = topLevelFunctionBody(
+        texthooker,
+        '_buildMonitorBody',
+      )!;
+      expect(
+        containsIdentifierCall(monitor, 'galWorkbenchReadiness'),
+        isTrue,
+      );
+      expect(
+        RegExp(
+          r'readiness\s*==\s*GalWorkbenchReadiness\.waitingForThread\s*'
+          r'\?\s*const\s+_ThreadSelectionRequiredCard\(\)\s*'
+          r':\s*_LineTracksCard\s*\(',
+        ).hasMatch(maskCommentsAndStrings(monitor)),
+        isTrue,
+        reason: '未选择线程时不能继续展示“本句音轨”工作区',
+      );
+    });
+
+    test('自动弹窗必须同时受工作台子页与顶层可见性门控', () {
+      final String schedule = topLevelFunctionBody(
+        texthooker,
+        '_maybeScheduleCaptureSetupDialog',
+      )!;
+      expect(containsIdentifier(schedule, 'captureSetupEnabled'), isTrue);
+      expect(containsIdentifierCall(schedule, 'TickerMode.of'), isTrue);
+      final String build = topLevelFunctionBody(texthooker, 'build')!;
+      expect(containsIdentifierCall(build, 'TickerMode.of'), isTrue);
+      expect(
+        containsIdentifierCall(build, '_maybeScheduleCaptureSetupDialog'),
+        isTrue,
+        reason: '从隐藏顶层 tab 回到工作台时必须补调度',
+      );
+
+      final String homeBuild = topLevelFunctionBody(homeGame, 'build')!;
+      expect(
+        RegExp(
+          r'captureSetupEnabled:\s*_section\s*==\s*GameSection\.monitor',
+        ).hasMatch(maskCommentsAndStrings(homeBuild)),
+        isTrue,
+      );
+    });
+
+    test('等待状态必须接进会话标题、状态徽章和音轨入口门控', () {
+      final String searchable = maskComments(texthooker);
+      final int overviewStart = searchable.indexOf(
+        'class _SessionOverviewCard',
+      );
+      expect(overviewStart, greaterThanOrEqualTo(0));
+      final String overview = balancedBlockFrom(
+        texthooker,
+        overviewStart,
+        what: '_SessionOverviewCard 类体',
+      );
+      final String overviewBuild = topLevelFunctionBody(overview, 'build')!;
+      expect(
+        containsIdentifier(overviewBuild, 'waitingForThread'),
+        isTrue,
+      );
+      expect(
+        containsIdentifier(overviewBuild, 'game_session_waiting_thread'),
+        isTrue,
+      );
+      expect(
+        containsIdentifier(overviewBuild, 'game_text_thread_unset'),
+        isTrue,
+      );
+
+      final String toolbar = topLevelFunctionBody(
+        texthooker,
+        '_buildToolbarActions',
+      )!;
+      expect(
+        RegExp(
+          r'state\.isActive\s*&&\s*'
+          r'_session\.selectedTextThreadKey\s*!=\s*null',
+        ).hasMatch(maskCommentsAndStrings(toolbar)),
+        isTrue,
+        reason: '会话级音轨入口必须等到台词线程选定后才出现',
+      );
+    });
+
+    test('游戏库状态带必须消费同一 readiness', () {
+      final String library = topLevelFunctionBody(homeGame, '_buildLibrary')!;
+      expect(
+        containsIdentifierCall(library, 'galWorkbenchReadiness'),
+        isTrue,
+      );
+      expect(
+        RegExp(r'readiness:\s*readiness').hasMatch(
+          maskCommentsAndStrings(library),
+        ),
+        isTrue,
+      );
+
+      final String searchable = maskComments(homeGame);
+      final int stripStart = searchable.indexOf('class _CaptureStatusStrip');
+      expect(stripStart, greaterThanOrEqualTo(0));
+      final String strip = balancedBlockFrom(
+        homeGame,
+        stripStart,
+        what: '_CaptureStatusStrip 类体',
+      );
+      expect(
+        containsIdentifier(strip, 'GalWorkbenchReadiness.waitingForThread'),
+        isTrue,
+      );
+      expect(
+        containsIdentifierCall(strip, '_buildWaitingForThreadDetail'),
+        isTrue,
+      );
     });
   });
 }

--- a/hibiki/test/pages/home_game_page_test.dart
+++ b/hibiki/test/pages/home_game_page_test.dart
@@ -22,6 +22,13 @@ Widget _testLibrary(
 /// setUp 里把 IndexedStack 起始子区切到库（与旧默认行为等价）。
 Widget _stubDashboard(BuildContext _, VoidCallback __) => const SizedBox();
 
+Widget _stubSettings(BuildContext _, Widget navigation) => Column(
+      children: <Widget>[
+        navigation,
+        const Text('game-settings'),
+      ],
+    );
+
 Widget _testMonitorWithSections(
   BuildContext _,
   VoidCallback onShowLibrary,
@@ -34,10 +41,16 @@ Widget _testMonitorWithSections(
           gameSectionNotifier.value = GameSection.dashboard,
       onSelectLibrary: onShowLibrary,
       onSelectMonitor: () {},
-      onSelectDiagnostics: () =>
-          gameSectionNotifier.value = GameSection.diagnostics,
+      onSelectSettings: () => gameSectionNotifier.value = GameSection.settings,
     ),
   );
+}
+
+Future<void> _settleOnLibrary(WidgetTester tester) async {
+  // Flutter 测试在下一例首帧才销毁上一例的 HomeGamePage；它的 dispose 会把全局
+  // section 回落到 dashboard。首帧后再选库，避免测试顺序影响初始子页。
+  gameSectionNotifier.value = GameSection.library;
+  await tester.pump();
 }
 
 void main() {
@@ -59,10 +72,11 @@ void main() {
           monitorBuilder: (_, __) => const SizedBox(),
           libraryBuilder: _testLibrary,
           dashboardBuilder: _stubDashboard,
+          settingsBuilder: _stubSettings,
         ),
       ),
     );
-    await tester.pump();
+    await _settleOnLibrary(tester);
 
     expect(find.textContaining('1'), findsWidgets);
     expect(find.text('テスト台詞'), findsOneWidget);
@@ -78,6 +92,7 @@ void main() {
         home: HomeGamePage(
           libraryBuilder: _testLibrary,
           dashboardBuilder: _stubDashboard,
+          settingsBuilder: _stubSettings,
           monitorBuilder: (_, VoidCallback onShowLibrary) => _TestMonitor(
             onShowLibrary: onShowLibrary,
             onInit: () => initCount++,
@@ -86,7 +101,7 @@ void main() {
         ),
       ),
     );
-    await tester.pump();
+    await _settleOnLibrary(tester);
 
     expect(initCount, 1, reason: 'IndexedStack 在模块存活期只挂载一个工作台 State');
     await tester.ensureVisible(find.byKey(HomeGamePage.captureStatusKey));
@@ -105,7 +120,7 @@ void main() {
     expect(disposeCount, 0);
   });
 
-  testWidgets('800x600 diagnostics section is reachable through managed focus',
+  testWidgets('800x600 top tabs replace diagnostics with settings',
       (WidgetTester tester) async {
     await tester.binding.setSurfaceSize(const Size(800, 600));
     addTearDown(() => tester.binding.setSurfaceSize(null));
@@ -116,11 +131,12 @@ void main() {
             monitorBuilder: _testMonitorWithSections,
             libraryBuilder: _testLibrary,
             dashboardBuilder: _stubDashboard,
+            settingsBuilder: _stubSettings,
           ),
         ),
       ),
     );
-    await tester.pump();
+    await _settleOnLibrary(tester);
 
     final HibikiFocusController controller = HibikiFocusRoot.controllerOf(
       tester.element(find.byType(HomeGamePage)),
@@ -128,25 +144,18 @@ void main() {
     final Finder gameSections =
         find.byType(HibikiAdjustableSegmented<GameSection>);
     expect(gameSections, findsOneWidget);
-    expect(
-      find.descendant(
-        of: gameSections,
-        matching: find.byWidgetPredicate(
-          (Widget widget) =>
-              widget is SingleChildScrollView &&
-              widget.scrollDirection == Axis.horizontal,
-        ),
-      ),
-      findsOneWidget,
-      reason: '800px 页头下完整四分段必须保留真实横滚容器',
-    );
+    expect(find.text(t.game_dashboard), findsOneWidget);
+    expect(find.text(t.game_library), findsOneWidget);
+    expect(find.text(t.game_capture_workbench), findsOneWidget);
+    expect(find.text(t.settings), findsOneWidget,
+        reason: '800px 页头必须完整呈现首页、游戏库、捕获工作台、设置四个分段');
     expect(
       controller.requestById(
         const HibikiFocusId('game-library-tab-sections'),
       ),
       isTrue,
     );
-    await tester.pump();
+    await _settleOnLibrary(tester);
     expect(
       controller.primaryFocusIsManagedTarget,
       isTrue,
@@ -168,6 +177,14 @@ void main() {
     expect(controller.primaryFocusIsManagedTarget, isTrue);
     await driver.adjust(steps: 1);
 
+    expect(find.byKey(HomeGamePage.settingsKey), findsOneWidget);
+    expect(find.text('game-settings'), findsOneWidget);
+    expect(find.text(t.game_diagnostics), findsNothing,
+        reason: '兼容性诊断不得继续占用游戏顶部高频页签');
+
+    // 诊断能力仍保留给设置页导航：程序化入口能进入详情，但顶部高亮设置。
+    gameSectionNotifier.value = GameSection.diagnostics;
+    await tester.pump();
     expect(find.byKey(HomeGamePage.diagnosticsKey), findsOneWidget);
     expect(find.byIcon(Icons.account_tree_outlined), findsOneWidget);
     expect(find.byIcon(Icons.multitrack_audio_outlined), findsOneWidget);
@@ -181,6 +198,7 @@ void main() {
           child: HomeGamePage(
             libraryBuilder: _testLibrary,
             dashboardBuilder: _stubDashboard,
+            settingsBuilder: _stubSettings,
             monitorBuilder: (_, __) => const Text('focused-monitor'),
           ),
         ),
@@ -215,10 +233,11 @@ void main() {
             monitorBuilder: (_, __) => const SizedBox(),
             libraryBuilder: _testLibrary,
             dashboardBuilder: _stubDashboard,
+            settingsBuilder: _stubSettings,
           ),
         ),
       );
-      await tester.pump();
+      await _settleOnLibrary(tester);
       expect(tester.takeException(), isNull);
       expect(find.byKey(HomeGamePage.libraryKey), findsOneWidget);
     });

--- a/hibiki/test/pages/manga_library_page_split_test.dart
+++ b/hibiki/test/pages/manga_library_page_split_test.dart
@@ -11,6 +11,7 @@ import 'package:hibiki/src/media/media_item.dart';
 import 'package:hibiki/src/media/sources/manga_hibiki_source.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/pages/implementations/media_library_shell.dart';
+import 'package:hibiki/src/pages/implementations/module_settings_view.dart';
 import 'package:hibiki/src/pages/implementations/reader_hibiki_history_page.dart';
 
 import '../helpers/source_guard.dart';
@@ -100,6 +101,7 @@ void main() {
           MediaLibraryViewKind.library,
           MediaLibraryViewKind.browse,
           MediaLibraryViewKind.sources,
+          MediaLibraryViewKind.settings,
         ],
       );
       final Widget shelf = shell.views.first.builder(
@@ -114,9 +116,14 @@ void main() {
       );
       // 「来源」视图必须是漫画来源页——本地扫描根 + 扩展 + 在线来源都收在这里。
       expect(
-        shell.views.last.builder(
+        shell.views[2].builder(
             tester.element(find.byType(SizedBox)), const SizedBox.shrink()),
         isA<MangaSourcesPage>(),
+      );
+      expect(
+        shell.views.last.builder(
+            tester.element(find.byType(SizedBox)), const SizedBox.shrink()),
+        isA<ModuleSettingsView>(),
       );
       // 反向锚：普通书架的默认值必须仍是 false，否则漫画会在两边都出现。
       expect(const ReaderHibikiHistoryPage().mangaOnly, isFalse);

--- a/hibiki/test/pages/module_top_settings_tabs_guard_test.dart
+++ b/hibiki/test/pages/module_top_settings_tabs_guard_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  String source(String path) => File(path).readAsStringSync();
+
+  test('书架、漫画、视频和游戏顶部导航都提供设置页', () {
+    for (final String path in <String>[
+      'lib/src/pages/implementations/home_reader_page.dart',
+      'lib/src/media/manga/manga_library_page.dart',
+      'lib/src/pages/implementations/home_page.dart',
+    ]) {
+      expect(
+        source(path).contains('kind: MediaLibraryViewKind.settings'),
+        isTrue,
+        reason: '$path 顶部导航缺少设置页',
+      );
+    }
+
+    final String game = source(
+      'lib/src/pages/implementations/game_shared.dart',
+    );
+    expect(game.contains('value: GameSection.settings'), isTrue);
+    expect(game.contains('value: GameSection.diagnostics'), isFalse,
+        reason: '兼容性诊断不能继续占用游戏顶部高频 tab');
+  });
+
+  test('下载把设置作为第四个顶部 tab，而不是临时齿轮模式', () {
+    final String downloads = source(
+      'lib/src/pages/implementations/downloads_page.dart',
+    );
+    expect(downloads.contains('length: 4'), isTrue);
+    expect(downloads.contains('Tab(text: t.settings)'), isTrue);
+    expect(downloads.contains('child: const TorrentSettingsSection()'), isTrue);
+    expect(downloads.contains('_showSettings'), isFalse);
+  });
+}

--- a/hibiki/test/pages/module_top_settings_tabs_guard_test.dart
+++ b/hibiki/test/pages/module_top_settings_tabs_guard_test.dart
@@ -2,8 +2,69 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
+String _code(String source) => maskCommentsAndStrings(source);
+
+bool _containsCode(String source, String needle) =>
+    containsCodeLine(_code(source), needle);
+
+bool _hasSettingsTab(String source) => RegExp(
+      r'\bTab\s*\(\s*text:\s*t\.settings\s*\)',
+    ).hasMatch(_code(source));
+
 void main() {
   String source(String path) => File(path).readAsStringSync();
+
+  test('设置页签判据忽略注释注入', () {
+    const String commentsOnly = '''
+// kind: MediaLibraryViewKind.settings
+/* value: GameSection.settings
+Tab(text: t.settings)
+child: const TorrentSettingsSection()
+*/
+''';
+    expect(
+      _containsCode(
+        commentsOnly,
+        'kind: MediaLibraryViewKind.settings',
+      ),
+      isFalse,
+    );
+    expect(
+      _containsCode(commentsOnly, 'value: GameSection.settings'),
+      isFalse,
+    );
+    expect(_hasSettingsTab(commentsOnly), isFalse);
+    expect(
+      _containsCode(commentsOnly, 'child: const TorrentSettingsSection()'),
+      isFalse,
+    );
+  });
+
+  test('设置页签判据忽略字符串注入', () {
+    const String stringsOnly = r"""
+const String decoy = '''
+kind: MediaLibraryViewKind.settings
+value: GameSection.settings
+Tab(text: t.settings)
+child: const TorrentSettingsSection()
+''';
+""";
+    expect(
+      _containsCode(stringsOnly, 'kind: MediaLibraryViewKind.settings'),
+      isFalse,
+    );
+    expect(
+      _containsCode(stringsOnly, 'value: GameSection.settings'),
+      isFalse,
+    );
+    expect(_hasSettingsTab(stringsOnly), isFalse);
+    expect(
+      _containsCode(stringsOnly, 'child: const TorrentSettingsSection()'),
+      isFalse,
+    );
+  });
 
   test('书架、漫画、视频和游戏顶部导航都提供设置页', () {
     for (final String path in <String>[
@@ -12,7 +73,7 @@ void main() {
       'lib/src/pages/implementations/home_page.dart',
     ]) {
       expect(
-        source(path).contains('kind: MediaLibraryViewKind.settings'),
+        _containsCode(source(path), 'kind: MediaLibraryViewKind.settings'),
         isTrue,
         reason: '$path 顶部导航缺少设置页',
       );
@@ -21,8 +82,8 @@ void main() {
     final String game = source(
       'lib/src/pages/implementations/game_shared.dart',
     );
-    expect(game.contains('value: GameSection.settings'), isTrue);
-    expect(game.contains('value: GameSection.diagnostics'), isFalse,
+    expect(_containsCode(game, 'value: GameSection.settings'), isTrue);
+    expect(_containsCode(game, 'value: GameSection.diagnostics'), isFalse,
         reason: '兼容性诊断不能继续占用游戏顶部高频 tab');
   });
 
@@ -30,9 +91,54 @@ void main() {
     final String downloads = source(
       'lib/src/pages/implementations/downloads_page.dart',
     );
-    expect(downloads.contains('length: 4'), isTrue);
-    expect(downloads.contains('Tab(text: t.settings)'), isTrue);
-    expect(downloads.contains('child: const TorrentSettingsSection()'), isTrue);
-    expect(downloads.contains('_showSettings'), isFalse);
+    expect(_hasSettingsTab(downloads), isTrue);
+    expect(
+      _containsCode(downloads, 'child: const TorrentSettingsSection()'),
+      isTrue,
+    );
+    expect(containsIdentifier(downloads, '_showSettings'), isFalse);
+
+    final String downloadsCode = _code(downloads);
+    final int subscriptions = downloadsCode.indexOf(
+      'Tab(text: t.download_subscriptions_tab)',
+    );
+    final Match? settings = RegExp(
+      r'\bTab\s*\(\s*text:\s*t\.settings\s*\)',
+    ).firstMatch(downloadsCode);
+    expect(subscriptions, greaterThanOrEqualTo(0));
+    expect(settings, isNotNull);
+    expect(settings!.start, greaterThan(subscriptions));
+  });
+
+  test('模块设置和诊断详情都保留返回模块导航的真实入口', () {
+    final String moduleSettings = source(
+      'lib/src/pages/implementations/module_settings_view.dart',
+    );
+    expect(
+      _containsCode(
+        moduleSettings,
+        'HibikiPageHeader.customTitle(title: widget.navigation)',
+      ),
+      isTrue,
+      reason: '隐藏 Cupertino 外观也不能删掉模块分段导航',
+    );
+
+    final String diagnostics = source(
+      'lib/src/pages/implementations/game_diagnostics_page.dart',
+    );
+    expect(
+      _containsCode(
+        diagnostics,
+        'icon: Icons.arrow_back',
+      ),
+      isTrue,
+      reason: '诊断页高亮设置段时，重选当前段不会回调，必须另有显式返回入口',
+    );
+    expect(
+      RegExp(
+        r'gameSectionNotifier\.value\s*=\s*GameSection\.settings',
+      ).hasMatch(_code(diagnostics)),
+      isTrue,
+    );
   });
 }

--- a/hibiki/test/pages/texthooker_narrow_degrade_reason_guard_test.dart
+++ b/hibiki/test/pages/texthooker_narrow_degrade_reason_guard_test.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../helpers/source_guard.dart';
+
 /// BUG-1110 守卫：窄屏（compact）状态卡不得把降级原因整行藏掉。
 ///
 /// 原实现是 `if (!compact && state.fallbackReason != null)` —— 窗口宽度不足 840px
@@ -21,23 +23,29 @@ void main() {
       'lib/src/pages/implementations/texthooker_page.dart',
     ).readAsStringSync();
 
-    // 抽 _SessionOverviewCard 的类体，避免「整文件命中」把断言蒙混过去。
-    final int start = source.indexOf('class _SessionOverviewCard');
+    // 以类声明的真实代码锚点 + 花括号配对抽体，邻接类增删不会把窗口误扩/截断。
+    final String searchable = maskComments(source);
+    final int start = searchable.indexOf('class _SessionOverviewCard');
     expect(start, greaterThanOrEqualTo(0),
         reason: '找不到 _SessionOverviewCard，测试锚点过期');
-    final int end = source.indexOf('class _LineTracksCard', start);
-    expect(end, greaterThan(start), reason: '找不到类体结束锚点');
-    cardSource = source.substring(start, end);
+    cardSource = balancedBlockFrom(
+      source,
+      start,
+      what: '_SessionOverviewCard 类体',
+    );
   });
 
   test('降级原因不再被 compact 整行丢弃（BUG-1110）', () {
     expect(
-      cardSource.contains('if (state.fallbackReason != null)'),
+      containsCodeLine(cardSource, 'if (state.fallbackReason != null)'),
       isTrue,
       reason: '降级原因的渲染条件必须只看 fallbackReason，不看屏宽',
     );
     expect(
-      cardSource.contains('!compact && state.fallbackReason != null'),
+      containsCodeLine(
+        cardSource,
+        '!compact && state.fallbackReason != null',
+      ),
       isFalse,
       reason: '窄屏藏掉降级原因正是 BUG-1110，不得回退',
     );
@@ -45,7 +53,7 @@ void main() {
 
   test('compact 只收窄行数，不丢弃内容（BUG-1110）', () {
     expect(
-      cardSource.contains('maxLines: compact ? 2 : 3'),
+      containsCodeLine(cardSource, 'maxLines: compact ? 2 : 3'),
       isTrue,
       reason: '降级原因在窄屏应收窄到 2 行，而不是整行消失',
     );
@@ -54,8 +62,10 @@ void main() {
   test('compact 省掉的是次要信息而非诊断线索（BUG-1110）', () {
     // 采样率/声道/位深这类次要信息仍可以在窄屏省掉——这是 compact 的正当用途。
     expect(
-      cardSource
-          .contains("compact\n                      ? '\$phase · \$audio'"),
+      RegExp(
+        r"compact\s*\?\s*'\$phase · \$audio'\s*:\s*'\$phase · \$audio'"
+        r"\s*'\$\{format == null",
+      ).hasMatch(maskComments(cardSource)),
       isTrue,
       reason: 'compact 仍应省掉 format（次要信息），这是它的正当用途',
     );
@@ -63,9 +73,10 @@ void main() {
 
   test('降级徽章与降级原因的显示条件必须对称（BUG-1110）', () {
     // 不对称正是这个 bug 的本质：徽章无条件亮，原因却被藏。
-    final int pill = cardSource.indexOf('_StatusPill(');
+    final String code = maskComments(cardSource);
+    final int pill = code.indexOf('_StatusPill(');
     expect(pill, greaterThanOrEqualTo(0), reason: '找不到 _StatusPill');
-    final String pillSource = cardSource.substring(pill);
+    final String pillSource = code.substring(pill);
     expect(
       pillSource.contains('state.isDegraded'),
       isTrue,

--- a/hibiki/test/pages/texthooker_toolbar_warmslot_guard_test.dart
+++ b/hibiki/test/pages/texthooker_toolbar_warmslot_guard_test.dart
@@ -72,7 +72,7 @@ void main() {
 
     test('嵌入模式删除冗余「兼容性诊断」按钮', () {
       expect(pageSrc.contains('game_open_diagnostics'), isFalse,
-          reason: '顶部 GameSectionTabs 已有诊断入口，工具栏诊断按钮纯冗余，须删');
+          reason: '兼容性诊断已经收进设置页，捕获工具栏不应再放一个高频入口');
     });
   });
 


### PR DESCRIPTION
## Summary

- add module-level Settings top tabs for books, manga, video, games, and downloads; remove Compatibility diagnostics from the game top tab row while retaining it inside Game settings
- distinguish an active audio capture source from a usable dialogue capture: without a selected engine text thread, show Waiting for dialogue thread and suppress sentence/session audio affordances
- after a launched/attached game discovers text-thread candidates, show a large one-per-session setup dialog for choosing the dialogue thread and audio tracks; selecting a thread closes it automatically, while Close remains available
- record BUG-1452 and bump the distributable build number to `1.3.1+1196`

## Validation

- `flutter analyze --no-pub` — passed, no issues
- `dart run tool/i18n_sync.dart --dry-run` — all translation files in sync
- `flutter test test/pages/home_game_page_test.dart --no-pub` — 6 passed
- focused adjacent/guard suite — 33 passed:
  - `test/pages/game_shared_readiness_test.dart`
  - `test/pages/module_top_settings_tabs_guard_test.dart`
  - `test/pages/media_library_shell_test.dart`
  - `test/pages/manga_library_page_split_test.dart`
  - `test/pages/texthooker_toolbar_warmslot_guard_test.dart`
  - `test/pages/home_game_capture_strip_guard_test.dart`
- `dart run tool/bug.dart check --strict` — passed; BUG number unique and index synchronized

## Not run

- no full platform build, real Windows game/LunaHook launch, thread discovery, or audio-track playback acceptance, per request not to wait for compilation acceptance
- Galgame runtime state: `implemented_unverified`
