### PR TITLE
fix(reader): 退出链的 WebView 实时探针加上延迟上界，落库永不跳过（TODO-2495）

### DIFF
--- a/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki/navigation.part.dart
@@ -1282,14 +1282,36 @@ extension _ReaderNavigation on _ReaderHibikiPageState {
   // progress (entry cue = allBookCueIdx), so losing it reads as "归零". Await
   // the controller flush inside the still-alive onPause window so the position
   // at background time is written through — mirroring the reader-pos flush.
+  ///
+  /// TODO-2495：这条链的两段性质不同，交给 [flushWithBoundedProbe] 分开对待——
+  /// 实时探针（WebView `evaluateJavascript`，唯一没有延迟上界的一段）限时
+  /// [kReaderExitProbeBudget]，落库（Drift 写）不限时且**永不跳过**。
+  ///
+  /// 根因不是「某一段慢」，而是「一段没有延迟上界的 await 被压在无 UI 反馈的单飞门
+  /// 底下」：本方法被 `onSourcePagePop` → `onWillPop` → `PopScope` 逐层 await，
+  /// `_popInProgress` 在整条链跑完前一直顶着，且只在 `onWillPop()` 返回时才复位——
+  /// 探针挂死就等于返回键永久失效（比 BUG-1273 更糟，那个至少能自愈）。降级口径与
+  /// [_flushAllForProcessExit] 一致：探针超时/抛错就落 debounce 已算好的缓存锚。
+  /// 完整论证见 [flushWithBoundedProbe] 的文档注释。
   Future<void> _syncAndFlushPosition() async {
-    if (_lyricsMode) {
-      _syncPositionFromCurrentCue();
-    } else {
-      await _syncPositionFromWebViewProgress();
-    }
-    await _flushPosition();
-    await _audiobookController?.flushPosition();
+    await flushWithBoundedProbe(
+      probe: () async {
+        if (_lyricsMode) {
+          _syncPositionFromCurrentCue();
+        } else {
+          await _syncPositionFromWebViewProgress();
+        }
+      },
+      persist: () async {
+        await _flushPosition();
+        await _audiobookController?.flushPosition();
+      },
+      probeBudget: kReaderExitProbeBudget,
+      onProbeFailure: (Object error, StackTrace stack) {
+        ErrorLogService.instance
+            .log('ReaderHibiki.syncAndFlushPosition.probe', error, stack);
+      },
+    );
   }
 
   /// 进程退出统一 flush（TODO-086/BUG-191）。**不**调用

--- a/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/reader_hibiki_page.dart
@@ -60,6 +60,7 @@ import 'package:hibiki/src/reader/reader_lyrics_caret_scripts.dart';
 import 'package:hibiki/src/reader/reader_content_styles.dart';
 import 'package:hibiki/src/reader/image_reveal_key.dart';
 import 'package:hibiki/src/reader/reader_resource_sanitizer.dart';
+import 'package:hibiki/src/reader/reader_exit_flush.dart';
 import 'package:hibiki/src/reader/reader_pagination_scripts.dart';
 import 'package:hibiki/src/reader/reader_restore_anchor.dart';
 import 'package:hibiki/src/reader/reader_search_navigation.dart';

--- a/hibiki/lib/src/reader/reader_exit_flush.dart
+++ b/hibiki/lib/src/reader/reader_exit_flush.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+/// 阅读器退出 / 生命周期 flush 链里「实时探针」这一步的延迟预算。
+///
+/// 正常一次 `evaluateJavascript` 往返是个位数毫秒；600ms 给了两个数量级的余量，
+/// 足够盖住「WebView 的 JS 单线程正在跑一次重排/分页、探针排在它后面」这类真实
+/// 慢路径，同时仍稳稳落在「按下返回后多久开始觉得按钮坏了」的感知阈之下。
+/// 预算用满不代表出错，只代表这次退出落的是缓存锚而不是最新一帧的实时锚。
+const Duration kReaderExitProbeBudget = Duration(milliseconds: 600);
+
+/// 阅读器退出 / 生命周期落库链的**延迟契约**：实时探针限时，落库不限时。
+///
+/// 返回 `true` 表示 [probe] 在预算内正常完成（本次落的是实时锚），`false` 表示
+/// 探针超时或抛错、已降级到缓存锚。无论哪种情况 [persist] 都会执行。
+///
+/// 【为什么需要它】
+/// 阅读器的返回是一条全程 await 的串行链，真正的 `nav.pop()` 排在最末：
+/// `PopScope.onPopInvokedWithResult` →（`_popInProgress` 单飞门）→ `onWillPop()`
+/// → `onSourcePagePop()` → `_syncAndFlushPosition()` → `closeMedia()` → `nav.pop()`。
+/// 单飞门在整条链跑完之前一直顶着，期间用户每一次返回（侧滑 / 返回键 / ESC /
+/// 手柄 B）都被静默丢弃，且**没有任何 UI 反馈**；更要命的是门只在 `onWillPop()`
+/// 真正返回时才由 `finally` 复位——链一旦挂死，门就**永久**顶死，用户不重启 app
+/// 就退不出这一页。BUG-1273（await 停播放器）至少还能等播放器停下来自愈，挂死不能。
+///
+/// 链上唯一没有延迟上界的一段是「向 WebView 实时读进度」
+/// （`_syncPositionFromWebViewProgress` 里的 `evaluateJavascript`）：一次平台通道
+/// 往返 + WebView 单线程 JS 求值，排在引擎当前正在跑的重排之后，耗时由引擎决定、
+/// 不由我们决定。本仓已经为这件事记过一次案——进程退出统一 flush
+/// （`_flushAllForProcessExit`）明确**不**调用这个探针，注释原话是「退出期 WebView2
+/// 正在拆除，对它 `evaluateJavascript` 会挂死整个退出」。返回路径调的是同一个探针，
+/// 却一直没有任何上界。这里补上的就是那个上界。
+///
+/// 【为什么限时不等于丢数据】
+/// 这条链上两类步骤性质完全不同，必须分开对待——这也是本函数把它们拆成两个参数的
+/// 全部理由：
+/// - [probe] 是**精度**步骤：不写任何持久层，只把内存里的位置锚刷新得更准；
+/// - [persist] 是**耐久**步骤：Drift 本地写，用户的真实阅读进度落在这里。
+///
+/// 所以探针超时的唯一后果是「这次落的是 debounce 已算好的缓存锚，而不是最新一帧的
+/// 实时锚」——正是 `_flushAllForProcessExit` 一直以来故意采用的降级口径。
+/// [persist] 在探针超时**和**探针抛异常时都照常执行，永不跳过：控制流本身就保证了
+/// 「退出后进度不丢」，不依赖调用方自觉。探针抛异常那一路尤其重要——旧形态里
+/// 探针的异常会沿 `_syncAndFlushPosition` → `onSourcePagePop` 一路逃逸，把它后面的
+/// `_flushPosition()` **和** `_flushReadingStats()` 一起跳过，那才是真的丢进度丢统计。
+///
+/// 超时不取消 [probe]：`Future.timeout` 只是不再等它，底层求值继续跑完并照常写它的
+/// 内存字段（调用方自带 `mounted` 守卫）。这里要的是「不再阻塞用户」，不是「中止求值」。
+Future<bool> flushWithBoundedProbe({
+  required Future<void> Function() probe,
+  required Future<void> Function() persist,
+  required Duration probeBudget,
+  required void Function(Object error, StackTrace stack) onProbeFailure,
+}) async {
+  bool probed = true;
+  try {
+    await probe().timeout(probeBudget);
+  } catch (error, stack) {
+    // 超时（TimeoutException）与探针自身抛错走同一条降级路径：两者对落库的要求
+    // 完全一样（照落缓存锚），分两个分支只会多一个特殊情况。错误交给调用方记录，
+    // 不在这里吞掉。
+    probed = false;
+    onProbeFailure(error, stack);
+  }
+  await persist();
+  return probed;
+}

--- a/hibiki/test/reader/reader_exit_bounded_probe_test.dart
+++ b/hibiki/test/reader/reader_exit_bounded_probe_test.dart
@@ -1,0 +1,206 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/reader/reader_exit_flush.dart';
+
+import '../helpers/source_guard.dart';
+
+/// TODO-2495：阅读器退出链「实时探针限时、落库不限时且永不跳过」的契约。
+///
+/// 背景（为什么这条契约值得钉住）：阅读器返回是一条全程 await 的串行链，
+/// `nav.pop()` 排在最末，外层 `_popInProgress` 单飞门在链跑完前一直顶着，期间每一次
+/// 返回都被静默丢弃、无任何 UI 反馈；门只在 `onWillPop()` 返回时由 `finally` 复位，
+/// 所以链里任何一段挂死 = 返回键**永久**失效（BUG-1273 那次至少能等播放器停下自愈）。
+/// 链上唯一没有延迟上界的一段是向 WebView 实时读进度的 `evaluateJavascript`——同一个
+/// 探针在进程退出路径 (`_flushAllForProcessExit`) 被明确注释成「会挂死整个退出」而
+/// 刻意不调用，返回路径却一直裸 await 它。
+///
+/// 下面第一组是**行为**测试（真跑 [flushWithBoundedProbe] 的控制流），第二组是
+/// **源码**守卫（钉住调用点确实走了这个契约）——行为变异配行为守卫、源码变异配
+/// 源码守卫，两组不互相顶替。
+void main() {
+  group('flushWithBoundedProbe 行为契约', () {
+    test('探针挂死时：不超过预算就放行，且落库照常执行（进度不丢）', () async {
+      final Completer<void> hungProbe = Completer<void>();
+      addTearDown(() {
+        if (!hungProbe.isCompleted) hungProbe.complete();
+      });
+
+      bool persisted = false;
+      final List<Object> failures = <Object>[];
+      final Stopwatch clock = Stopwatch()..start();
+
+      // 预算取小值只为让测试快：契约与具体数值无关，生产值是
+      // kReaderExitProbeBudget。
+      final bool probed = await flushWithBoundedProbe(
+        probe: () => hungProbe.future,
+        persist: () async {
+          persisted = true;
+        },
+        probeBudget: const Duration(milliseconds: 80),
+        onProbeFailure: (Object error, StackTrace stack) => failures.add(error),
+      ).timeout(
+        // 这层 timeout 是**测试脚手架**，不是被测契约的一部分：没有它，一旦
+        // `.timeout` 被拿掉，本用例会挂到整个 suite 超时而不是给出可读的红。
+        const Duration(seconds: 5),
+        onTimeout: () => fail(
+          'flushWithBoundedProbe 在探针挂死时没有返回——探针的延迟上界丢了，'
+          '退出链会被无限期顶住（单飞门永久顶死 = 返回键彻底失效）',
+        ),
+      );
+      clock.stop();
+
+      expect(persisted, isTrue,
+          reason: '探针超时绝不能跳过落库：位置/统计写在 persist 里，跳过就是用户可感知的进度丢失');
+      expect(probed, isFalse, reason: '探针未在预算内完成时必须如实返回 false（本次落的是缓存锚）');
+      expect(failures, hasLength(1),
+          reason: '降级必须上报，不能静默吞掉——超时被吞就没人知道实时锚退化成了缓存锚');
+      expect(failures.single, isA<TimeoutException>());
+      expect(clock.elapsed, lessThan(const Duration(seconds: 2)),
+          reason: '放行时机必须由预算决定，而不是由探针决定');
+
+      // 探针事后完成不得让已经返回的 future 再出岔子（超时不取消探针，只是不再等它）。
+      hungProbe.complete();
+      await Future<void>.delayed(Duration.zero);
+    });
+
+    test('探针抛异常时：落库照常执行（这是旧形态真正丢进度丢统计的那条路）', () async {
+      bool persisted = false;
+      final List<Object> failures = <Object>[];
+
+      final bool probed = await flushWithBoundedProbe(
+        probe: () async => throw StateError('probe blew up'),
+        persist: () async {
+          persisted = true;
+        },
+        probeBudget: const Duration(seconds: 5),
+        onProbeFailure: (Object error, StackTrace stack) => failures.add(error),
+      );
+
+      expect(persisted, isTrue,
+          reason: '探针抛错时落库必须照常跑完。旧形态里这个异常会沿 _syncAndFlushPosition → '
+              'onSourcePagePop 逃逸，把 _flushPosition() 和其后的 _flushReadingStats() '
+              '一起跳过——进度与统计同时丢');
+      expect(probed, isFalse);
+      expect(failures.single, isA<StateError>());
+    });
+
+    test('探针在预算内完成时：先探针后落库，且如实返回 true（BUG-203 的实时锚不能被换掉）', () async {
+      final List<String> order = <String>[];
+      final List<Object> failures = <Object>[];
+
+      final bool probed = await flushWithBoundedProbe(
+        probe: () async {
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+          order.add('probe');
+        },
+        persist: () async {
+          order.add('persist');
+        },
+        probeBudget: const Duration(seconds: 5),
+        onProbeFailure: (Object error, StackTrace stack) => failures.add(error),
+      );
+
+      expect(order, <String>['probe', 'persist'],
+          reason: '实时探针必须在落库之前完成，否则落的还是陈旧缓存锚——正是 BUG-203 '
+              '「退出重进落在前面好几页」的成因');
+      expect(probed, isTrue);
+      expect(failures, isEmpty, reason: '正常路径不得上报失败');
+    });
+
+    test('落库自身的耗时不受预算约束（Drift 写慢不等于可以不写）', () async {
+      bool persisted = false;
+
+      final bool probed = await flushWithBoundedProbe(
+        probe: () async {},
+        persist: () async {
+          // 明显长于预算：落库是耐久步骤，不许被探针预算连坐掐掉。
+          await Future<void>.delayed(const Duration(milliseconds: 120));
+          persisted = true;
+        },
+        probeBudget: const Duration(milliseconds: 10),
+        onProbeFailure: (Object error, StackTrace stack) =>
+            fail('落库耗时不该被记成探针失败：$error'),
+      );
+
+      expect(persisted, isTrue);
+      expect(probed, isTrue);
+    });
+
+    test('生产预算是个正数且量级合理', () {
+      expect(kReaderExitProbeBudget, greaterThan(Duration.zero));
+      expect(
+          kReaderExitProbeBudget, lessThanOrEqualTo(const Duration(seconds: 1)),
+          reason: '预算一旦放到秒级，返回在用户眼里就已经是「按了没反应」了');
+    });
+  });
+
+  group('退出链源码守卫', () {
+    String read(String path) => File(path).readAsStringSync();
+
+    test('_syncAndFlushPosition 必须走限时探针契约，不得裸 await 探针', () {
+      const String path =
+          'lib/src/pages/implementations/reader_hibiki/navigation.part.dart';
+      final String source = maskComments(read(path));
+      final int start = source.indexOf('Future<void> _syncAndFlushPosition()');
+      expect(start, isNonNegative, reason: '找不到 _syncAndFlushPosition');
+      // methodBody 遇箭头函数会静默越界（PR#768 未合），这里的方法体内含箭头函数
+      // （onProbeFailure），必须用 balancedBlockFrom 从声明处配对花括号。
+      final String body =
+          balancedBlockFrom(source, start, what: '_syncAndFlushPosition 方法体');
+
+      expect(body, contains('flushWithBoundedProbe('),
+          reason: '退出/生命周期 flush 必须经 flushWithBoundedProbe 给 WebView 探针加上'
+              '延迟上界；退回裸串行 await 就会重现「按返回毫无反应」（TODO-2495）');
+      expect(body, contains('probeBudget: kReaderExitProbeBudget'),
+          reason: '预算必须用共享常量，避免各调用点各写一个魔数后悄悄放大');
+      expect(body, contains('await _syncPositionFromWebViewProgress()'),
+          reason: 'WebView 实时探针本身不能被删——限时是给它加上界，不是不读它');
+      expect(body.indexOf('probe:'), lessThan(body.indexOf('persist:')),
+          reason: '探针必须挂在 probe 槽、落库必须挂在 persist 槽；两者对调等于给落库'
+              '加了上界、给探针去了上界，恰好把契约反过来');
+      expect(
+          body.indexOf('persist:'), lessThan(body.indexOf('_flushPosition()')),
+          reason: '_flushPosition 是耐久步骤，必须落在 persist 槽内而不是探针槽内');
+    });
+
+    test('flushWithBoundedProbe 自身必须真的有上界，且落库在 try 之外', () {
+      const String path = 'lib/src/reader/reader_exit_flush.dart';
+      final String source = maskComments(read(path));
+      final int start = source.indexOf('Future<bool> flushWithBoundedProbe(');
+      expect(start, isNonNegative);
+      // 该函数是**具名参数**签名，声明之后的第一个 `{` 是参数列表的花括号而不是
+      // 方法体——直接 balancedBlockFrom(start) 会切出参数列表，让下面的断言拿一段
+      // 根本不含实现的文本去比对（一次假红，也可能反过来变成假绿）。把配对起点推到
+      // `) async {` 之后，锚的才是真方法体。
+      final int bodyBrace = source.indexOf(') async {', start);
+      expect(bodyBrace, isNonNegative,
+          reason: '找不到 flushWithBoundedProbe 的方法体起点');
+      final String body = balancedBlockFrom(source, start,
+          openSearchFrom: bodyBrace, what: 'flushWithBoundedProbe 方法体');
+
+      expect(body, contains('.timeout(probeBudget)'),
+          reason: '探针必须真的被 probeBudget 限时——去掉它，整个契约只剩注释');
+      expect(body.indexOf('await persist()'),
+          greaterThan(body.indexOf('} catch (error, stack) {')),
+          reason: '落库必须排在 catch 之后（无条件执行），不能待在 try 里被探针异常带走');
+    });
+
+    test('进程退出 flush 仍不得触碰 WebView 探针', () {
+      const String path =
+          'lib/src/pages/implementations/reader_hibiki/navigation.part.dart';
+      final String source = maskComments(read(path));
+      final int start =
+          source.indexOf('Future<void> _flushAllForProcessExit()');
+      expect(start, isNonNegative);
+      final String body =
+          balancedBlockFrom(source, start, what: '_flushAllForProcessExit 方法体');
+
+      expect(body, isNot(contains('_syncPositionFromWebViewProgress')),
+          reason: '进程退出期 WebView 正在拆除，对它 evaluateJavascript 会挂死整个退出；'
+              '这条路径只能落缓存锚（限时探针也救不了它——退出不能再等一个预算）');
+      expect(body, contains('await _flushPosition()'), reason: '进程退出仍必须把缓存锚写穿');
+    });
+  });
+}

--- a/hibiki/test/reader/reader_exit_bounded_probe_test.dart
+++ b/hibiki/test/reader/reader_exit_bounded_probe_test.dart
@@ -145,8 +145,8 @@ void main() {
       final String source = maskComments(read(path));
       final int start = source.indexOf('Future<void> _syncAndFlushPosition()');
       expect(start, isNonNegative, reason: '找不到 _syncAndFlushPosition');
-      // methodBody 遇箭头函数会静默越界（PR#768 未合），这里的方法体内含箭头函数
-      // （onProbeFailure），必须用 balancedBlockFrom 从声明处配对花括号。
+      // 方法体内含箭头函数（onProbeFailure），用 balancedBlockFrom 从声明处配对
+      // 花括号，切的就是整段方法体。
       final String body =
           balancedBlockFrom(source, start, what: '_syncAndFlushPosition 方法体');
 
@@ -197,7 +197,11 @@ void main() {
       final String body =
           balancedBlockFrom(source, start, what: '_flushAllForProcessExit 方法体');
 
-      expect(body, isNot(contains('_syncPositionFromWebViewProgress')),
+      // 禁止型断言用 containsIdentifier：裸 contains 两个方向都会错——注释里提一句
+      // 这个名字就假红，`_syncPositionFromWebViewProgressV2` 这类更长标识符又会被
+      // 子串误命中。
+      expect(
+          containsIdentifier(body, '_syncPositionFromWebViewProgress'), isFalse,
           reason: '进程退出期 WebView 正在拆除，对它 evaluateJavascript 会挂死整个退出；'
               '这条路径只能落缓存锚（限时探针也救不了它——退出不能再等一个预算）');
       expect(body, contains('await _flushPosition()'), reason: '进程退出仍必须把缓存锚写穿');


### PR DESCRIPTION
## 事实核查（先查证再动手）

| 问题 | 结论 |
|---|---|
| 链在哪 | `PopScope.onPopInvokedWithResult`（`reader_hibiki_page.dart:2727`，单飞门 `:2734`）→ `onWillPop()`（`base_source_page.dart:227`）→ `onSourcePagePop()`（`reader_hibiki_page.dart:2444`）→ `_syncAndFlushPosition()`（`navigation.part.dart:1285`）→ `_flushReadingStats()`（`:1373`）→ `closeMedia()`（`app_model.dart:4318`）→ `nav.pop()` |
| PR#620 摘了什么 | 只摘了 `audiobookSession.stop()`（`0a17c2526` / BUG-1273），改成 `unawaited(...catchError)`。**形态没变**，其余仍是无 UI 反馈的串行 await |
| 各段真实耗时 | `_syncPositionFromWebViewProgress` = 平台通道往返 + WebView 单线程 JS 求值，**无上界**；`_flushPosition` / `_flushReadingStats` / `audiobookController.flushPosition` = Drift 本地写；`closeMedia` **不做任何 DB/文件/网络**，只有 2~3 次平台通道往返（wakelock disable + SystemChrome + Windows desktop_drop） |
| 单飞门防什么 | BUG-782：退出窗口期第二次触发会并发跑第二条 `onWillPop`，首条 pop 掉阅读器后第二条的 `nav.pop()` 会把下层书架也弹掉（连退两级 + closeMedia/自动同步重复执行）。**失效方式**：门只在 `onWillPop()` 返回时由 `finally` 复位——链挂死则门**永久**顶死，返回键彻底失效（BUG-1273 至少能等播放器停下自愈） |

## 根因

不是「某一段慢」，是**一段没有延迟上界的 await 被压在无 UI 反馈的单飞门底下**。

链上唯一无上界的是 `_syncPositionFromWebViewProgress` 里的 `evaluateJavascript`。本仓已为这件事记过一次案：进程退出统一 flush（`_flushAllForProcessExit`，`navigation.part.dart:1295-1299`）明确**不**调用这个探针，注释原话是「退出期 WebView2 正在拆除，对它 `evaluateJavascript` 会挂死整个退出」。返回路径调的是同一个探针，却一直裸 await。

## 改法：按性质分段，不是加超时糊症状

新增 `hibiki/lib/src/reader/reader_exit_flush.dart` 的 `flushWithBoundedProbe`，把链上两类性质不同的步骤拆开：

- **探针**（精度步骤，不写任何持久层，只把内存位置锚刷新得更准）→ 限时 `kReaderExitProbeBudget` = 600ms，超时/抛错降级到 debounce 缓存锚，**与 `_flushAllForProcessExit` 一直以来的降级口径完全一致**；
- **落库**（耐久步骤，Drift 写）→ 不限时、**无条件执行**。

## 「退出后进度不丢、统计不丢」怎么证明

由 `flushWithBoundedProbe` 的**控制流本身**保证，不依赖调用方自觉：`await persist()` 排在 `catch` 之后，超时路径与抛错路径都必然走到。三条行为测试分别钉住超时路径、抛错路径、正常路径。

顺带修掉一条**真的会丢数据**的路径：旧形态里探针抛异常会沿 `_syncAndFlushPosition` → `onSourcePagePop` 一路逃逸，把它后面的 `_flushPosition()` **和** `_flushReadingStats()` 一起跳过——进度与统计同时丢。

## 变异实测（6 次，全红，反向替换还原，`git diff --stat HEAD -- hibiki/lib/` 事后为空）

| # | 变异 | 结果 |
|---|---|---|
| M1 | 去掉 `.timeout(probeBudget)` | 🔴 行为（探针挂死用例）+ 源码守卫 |
| M2 | `await persist()` 挪进 try（探针出错就跳过落库） | 🔴 **超时路径与抛错路径两条行为断言同时红** |
| M3 | 落库提到探针之前 | 🔴 行为（BUG-203 顺序） |
| M4 | 调用点退回旧的裸串行 await | 🔴 源码守卫 |
| M5 | `probe:` / `persist:` 两个槽对调 | 🔴 源码守卫 |
| M6 | 进程退出路径重新调探针 | 🔴 源码守卫（`containsIdentifier` 判据） |

避开的五种假绿：无空操作变异（每条都改真控制流）；无编译失败变异（每次都是 `N tests ran` 的行为红，非 0）；守卫与被守方不共用枚举函数（行为测试直接跑生产函数，源码守卫走共享 `source_guard` 原语）；源码守卫一律先 `maskComments`（本仓注释极详尽，我新写的注释里就同时含 `flushWithBoundedProbe` / `kReaderExitProbeBudget`，不掩码必被兜住）；行为变异配行为守卫、源码变异配源码守卫，两组不互相顶替。

## 验证

- `dart format` 改动文件；`flutter analyze` 全量 → `No issues found!`
- 35 条目录枚举型守卫整批 → `PASSED - 225 tests ran`（与基线 N=225 一致）
- 定向 `test/reader` + `test/media/audiobook` + `test/pages` → `PASSED - 4860 tests ran`；结构判据：装载 762 suite = 磁盘 172+107+483，无静默过滤
- `tests_for_changes.dart` 推导为空（纯 reader Dart 改动，未触发条件加跑）

## 未建 BUG 号

判为**架构脆弱性**而非已咬人的 bug：pop 路径的探针挂死**无用户报告、未复现**（有报告并已修的是 BUG-1273，那一段 PR#620 已摘）。按规则写成测试 + 注释固化，不占号。
