### PR TITLE
fix(test): 弹窗复制守卫改可达性判据；topLevelFunctionBody 认 async 体 (TODO-2745)

### DIFF
--- a/docs/agent/fast-workflow.md
+++ b/docs/agent/fast-workflow.md
@@ -47,6 +47,13 @@ S/A 级同理裁剪：S 级连 worktree bootstrap 都可 `-SkipBootstrap` 到底
 ## 验证分级细则
 
 - **定向测试** = 改动直接覆盖的 test 文件 + 相邻功能的 test 文件，`flutter test test/<路径> --no-pub`。
+  - 🔴 **别靠脑子想「相邻功能」是哪些，机器能算**：改了 `hibiki/lib/**` 时用
+    `dart run tool/tests_for_changes.dart --include-dart --explain <改的文件…>` 反查
+    「谁在源码里读这个文件」。**`--include-dart` 不加就恒为空**——工具默认把 Dart 树的
+    改动整条过滤掉（`isDefaultBatchCoveredChange`，理由是「整批 35 条 + 定向测试兜底」），
+    而**点名单个生产文件的守卫既不在那 35 条里、也不按功能域取名**，正好落在两道门的缝里。
+    实测漏网：PR#764 收口弹窗复制入口，`test/dictionary/popup_touch_copy_actionmode_guard_test.dart`
+    只被 `test/lookup` 的定向测试擦肩而过，红直接进了 develop（TODO-2745）。
 - **`flutter analyze` 全量在 push 前必跑**（含 test 目录）——它本身只要秒级~1 分钟，而 CI 把 warning 当致命，省这一步只会在 CI 上浪费一轮。
 - **分支 draft PR**：定向测试绿 + 全量 analyze 绿即可 push；全量 test 由 CI 兜底（真单测门是 **Build Release APK 的 Run unit tests**，不是 Build and Test）。声明「修好了」的真机复测门槛**不变**（[integration-testing.md](integration-testing.md)）。
 - **合入 `develop`**：integration owner 本地全量 analyze + 全量 test **不变**（bash 环境跑；别 `| tail` 吞退出码；重叠跑会互抢 `sqlite3.dll`，见下节）。

--- a/hibiki/test/dictionary/popup_touch_copy_actionmode_guard_test.dart
+++ b/hibiki/test/dictionary/popup_touch_copy_actionmode_guard_test.dart
@@ -2,58 +2,232 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
-String _between(String source, String start, String end) {
-  final int startAt = source.indexOf(start);
-  final int endAt = source.indexOf(end, startAt + start.length);
-  if (startAt < 0 || endAt <= startAt) {
-    throw StateError('guard markers missing: $start .. $end');
-  }
-  return source.substring(startAt, endAt);
-}
+import '../helpers/source_guard.dart';
 
+/// BUG-1237：Android 弹窗自定义 ContextMenu 会先 finish 系统 ActionMode，系统默认
+/// 「复制」因此是个死项。修法是**隐藏默认项 + 由 Dart 自己写系统剪贴板**。
+///
+/// ## 为什么判据不能再是「某段文本里有没有 `Clipboard.setData(...)`」
+///
+/// 旧判据是 `_between(src, 'contextMenu: ContextMenu(', 'gestureRecognizers:')`
+/// 切出一个**文本窗口**，再在窗口里找那一串字面量。它守的不是不变式，是「那一行
+/// 写在哪、长什么样」：
+/// - PR#764（BUG-1451）把三条复制入口（Windows 右键 / Windows Ctrl+C / Android 原生
+///   菜单）收口进同一个共享方法，Android 分支不再自己裸调 [_kClipboardWrite]
+///   ——**不变式被保留而且加强了**（三处内联 → 单一入口 + 统一反馈），字面串却搬出了
+///   那个文本窗口，守卫当场转红；
+/// - 右边界 `'gestureRecognizers:'` 更脆：它假设那个命名参数写在 `contextMenu:`
+///   **之后**，参数顺序一换窗口就整个塌掉（原实现直接抛 StateError）。
+///
+/// 本仓这已经是第四次「字面量 / 文本窗口锚点被一次有意重构打断」（PR#762 的
+/// BUG-1100 降级文案、PR#758 的 `SetTimer(` token 禁令、9fd30d281 的 `_gif(` 锚点）。
+///
+/// ## 新判据：可达性
+///
+/// 窗口由**结构**给出（`ContextMenu(` 这一次调用的括号配对），断言问的是真正要守的
+/// 那句话：**Android 那一项「复制」的 action，最终有没有走到 Dart 的
+/// [_kClipboardWrite]？** 直接调算数；调本文件内某个自己写剪贴板的方法（一跳）也算
+/// ——PR#764 的 `_copySelectionToClipboard` 正是这种。
+///
+/// BUG-1237 的原始形态（不提供 Dart 复制项、让它落回被 finish 掉的系统 ActionMode）
+/// 无论重构成哪种形状都拿不到这条可达性。
+///
+/// 三处「绝不静默变绿」：
+/// - `contextMenu: ContextMenu(` 整块没了 → [_contextMenuBlock] 直接 fail；
+/// - 复制项没了 → [enclosingCallOf] 找不到锚点直接 fail；
+/// - 中转方法把写剪贴板那一跳删了 / 换成本文件之外定义的东西 → 解析不到实现体，
+///   判不可达并在失败信息里点名 action 到底调到了谁。
 void main() {
   final String source =
       File('lib/src/pages/implementations/dictionary_popup_webview.dart')
           .readAsStringSync();
-  final String menu =
-      _between(source, 'contextMenu: ContextMenu(', 'gestureRecognizers:');
+  // 窗口在**每条用例内部**才切：`_contextMenuBlock` 里的锚点断言会走 `expect`，
+  // 在 `main()` 体里（测试之外）跑会抛 OutsideTestException —— 那是「整个 suite 装载
+  // 失败、零测试执行」，而不是一条看得懂的红。
+  String contextMenu() => _contextMenuBlock(source);
 
   group('BUG-1237 Android popup actions bypass finished ActionMode', () {
     test('Android hides broken system items while iOS is not expanded', () {
+      final String menu = contextMenu();
+      // 判据抬到「这个命名参数的实参表达式」上：换行、参数顺序、加不加括号都无关。
+      final List<String> hide =
+          namedArgumentValues(menu, 'hideDefaultSystemContextMenuItems');
+      expect(hide, hasLength(1), reason: 'ContextMenuSettings 必须显式声明是否隐藏系统默认项');
       expect(
-        menu,
-        contains('Platform.isAndroid || isWindowsPlatform'),
+        hide.single,
+        contains('Platform.isAndroid'),
+        reason: 'Android 上系统默认项已被 finish 掉的 ActionMode 弄成死项，必须隐藏；'
+            '现在的实参是 `${hide.single}`',
       );
-      expect(menu, contains('if (Platform.isAndroid)'));
+      expect(
+        hide.single,
+        isNot(contains('Platform.isIOS')),
+        reason: 'iOS 原生菜单是好的，不在本 bug 范围内，不得跟着一起隐藏',
+      );
+      expect(
+        _elementPrefix(menu, _copyItem(menu).start),
+        contains('Platform.isAndroid'),
+        reason: '「复制」项是给 Android 补的死项替代，必须 Android 门控',
+      );
     });
 
     test('copy is custom Dart clipboard action and selection is cleared', () {
-      expect(menu, contains('title: t.copy'));
-      expect(menu, contains('Clipboard.setData(ClipboardData(text: text))'));
-      expect(menu, contains('_selectedTextAcrossFrames()'));
-      expect(menu, contains('_clearSelectedTextAcrossFrames()'));
+      final String menu = contextMenu();
+      final EnclosingCall copy = _copyItem(menu);
+      expect(copy.name, 'ContextMenuItem',
+          reason: '「复制」必须是 WebView 上下文菜单的一项，不是别的什么控件');
+
+      final List<String> actions = namedArgumentValues(copy.text, 'action');
+      expect(actions, hasLength(1), reason: '「复制」项必须挂一个 action');
+      final String action = actions.single;
+
+      expect(
+        _clipboardWriterReachedFrom(source, action),
+        isNotNull,
+        reason: 'BUG-1237：Android 的「复制」必须是自定义 Dart 剪贴板动作。'
+            '它现在既没有直接调 $_kClipboardWrite，也没有调用本文件里任何一个'
+            '自己写剪贴板的方法（一跳可达闭包），等于又落回被 finish 掉的系统 '
+            'ActionMode。当前 action 调到、且解析得到实现体的是：'
+            '${_resolvableCallees(source, action)}',
+      );
+
+      expect(containsCodeLine(action, '_selectedTextAcrossFrames()'), isTrue,
+          reason: '选区在同源子 iframe 里，只读顶层文档取不到（BUG-802）');
+      expect(
+          containsCodeLine(action, '_clearSelectedTextAcrossFrames()'), isTrue,
+          reason: '复制完必须清掉选区，否则原生高亮留在页面上');
     });
 
     test('share and web search reuse the common action seam', () {
-      expect(menu, contains('title: t.share'));
-      expect(menu, contains('title: t.selection_web_search'));
+      final String menu = contextMenu();
+      for (final String title in <String>[
+        't.share',
+        't.selection_web_search'
+      ]) {
+        final EnclosingCall item = enclosingCallOf(menu, 'title: $title');
+        expect(item.name, 'ContextMenuItem');
+        expect(_elementPrefix(menu, item.start), contains('Platform.isAndroid'),
+            reason: '$title 项同样是给 Android 补的，必须门控');
+      }
       expect(
-          menu, contains('SelectionExternalActions.instance.shareText(text)'));
+          containsCodeLine(
+              menu, 'SelectionExternalActions.instance.shareText(text)'),
+          isTrue);
       expect(
-          menu, contains('SelectionExternalActions.instance.searchWeb(text)'));
-      expect(menu, contains('t.selection_web_search_unavailable'));
+          containsCodeLine(
+              menu, 'SelectionExternalActions.instance.searchWeb(text)'),
+          isTrue);
+      expect(
+          containsCodeLine(menu, 't.selection_web_search_unavailable'), isTrue);
     });
   });
 
   test('Windows right-click path remains unchanged', () {
-    final String windows = _between(
-      source,
-      'Future<void> _showWindowsContextMenu(',
-      'static String? _cachedStylesJson',
+    // 旧窗口是 `_between(src, 'Future<void> _showWindowsContextMenu(',
+    // 'static String? _cachedStylesJson')`——那个右边界离方法真正的收口有 20 多行，
+    // 中间**恰好**夹着共享写剪贴板方法的实现体，于是 PR#764 收口之后这条断言是
+    // 「碰巧」还绿着的，跟 Android 那条同型、只是还没爆。改成结构窗口 + 同一条
+    // 可达性判据，两侧不再有一处靠运气。
+    final String? windows = topLevelFunctionBody(source, _kWindowsMenu);
+    expect(windows, isNotNull, reason: '找不到 $_kWindowsMenu 的实现体：守卫失去锚点');
+
+    final List<String> disable =
+        namedArgumentValues(source, 'disableContextMenu');
+    expect(disable, hasLength(1));
+    expect(disable.single, contains('isWindowsPlatform'),
+        reason: 'Windows 的 WebView2 原生菜单定位是错的，必须禁掉改走 Flutter showMenu');
+
+    expect(containsCodeLine(windows!, '_selectedTextAcrossFrames()'), isTrue);
+    expect(
+      _clipboardWriterReachedFrom(source, windows),
+      isNotNull,
+      reason: 'Windows 右键「复制」同样必须落到 $_kClipboardWrite；当前调到、'
+          '且解析得到实现体的是：${_resolvableCallees(source, windows)}',
     );
-    expect(source, contains('disableContextMenu: isWindowsPlatform'));
-    expect(windows, contains('_selectedTextAcrossFrames()'));
-    expect(windows, contains('Clipboard.setData(ClipboardData(text: text))'));
-    expect(windows, isNot(contains('SelectionExternalActions')));
+    expect(containsCodeLine(windows, 'SelectionExternalActions'), isFalse,
+        reason: 'Windows 右键菜单只有「查词 / 复制」，不复用移动端的分享 / 网搜外部动作');
   });
+}
+
+// ---------------------------------------------------------------------------
+// 「复制动作必须可达 Dart 剪贴板写入」的契约判据（BUG-1237）
+// ---------------------------------------------------------------------------
+
+/// 剪贴板写入本体：Flutter 侧把文本交给系统剪贴板的唯一 API。
+const String _kClipboardWrite = 'Clipboard.setData';
+
+/// Windows 右键菜单入口。
+const String _kWindowsMenu = '_showWindowsContextMenu';
+
+/// `contextMenu: ContextMenu(...)` 这一次调用的完整原文。
+///
+/// 用括号配对而不是「到 `gestureRecognizers:` 为止」：右边界由结构给出，与后面那个
+/// 命名参数叫什么、写在第几位全部无关。
+String _contextMenuBlock(String src) {
+  const String anchor = 'contextMenu: ContextMenu(';
+  final int at = maskCommentsAndStrings(src).indexOf(anchor);
+  expect(at, greaterThanOrEqualTo(0),
+      reason: 'WebView 的 contextMenu 参数不见了：守卫失去锚点，先修锚点再谈断言');
+  return enclosingCall(src, at + anchor.length).text;
+}
+
+/// 菜单里那一项「复制」的 `ContextMenuItem(...)` 切片。
+EnclosingCall _copyItem(String menu) => enclosingCallOf(menu, 'title: t.copy');
+
+/// 从 [block] 出发，**一跳可达闭包**内第一个真正写剪贴板的落点；不可达返回 null。
+///
+/// 直接调 [_kClipboardWrite] 返回 `'<直接调用>'`；调本文件里某个方法、而那个方法自己
+/// 调 [_kClipboardWrite] 则返回该方法名（PR#764 的 `_copySelectionToClipboard`）。
+/// 除此以外一律不可达——BUG-1237 的原始形态（没有 Dart 复制动作、落回被 finish 掉的
+/// 系统 ActionMode）落在这一侧。
+String? _clipboardWriterReachedFrom(String src, String block) {
+  if (containsIdentifierCall(block, _kClipboardWrite)) return '<直接调用>';
+  for (final String callee in _calleeNames(block)) {
+    final String? body = topLevelFunctionBody(src, callee);
+    if (body == null) continue;
+    if (containsIdentifierCall(body, _kClipboardWrite)) return callee;
+  }
+  return null;
+}
+
+/// [block] 里调用到、且能在 [src] 里解析出实现体的被调方名字（只用于失败信息）。
+List<String> _resolvableCallees(String src, String block) => _calleeNames(block)
+    .where((String name) => topLevelFunctionBody(src, name) != null)
+    .toList();
+
+/// 代码里以独立标识符身份被调用的名字（不含点链——那是别的对象的方法，本文件解析
+/// 不到实现体，也就拿不到可达性）。注释与字符串里的同名文本不算。
+List<String> _calleeNames(String block) {
+  final RegExp call =
+      RegExp(r'(?<![A-Za-z0-9_$.])([A-Za-z_$][A-Za-z0-9_$]*)\s*\(');
+  final Set<String> names = <String>{};
+  for (final RegExpMatch m in call.allMatches(maskCommentsAndStrings(block))) {
+    names.add(m.group(1)!);
+  }
+  // 语言关键字不是被调方，剔掉只是省无谓的解析。
+  names.removeAll(const <String>{'if', 'for', 'while', 'switch', 'catch'});
+  return names.toList()..sort();
+}
+
+/// 列表元素在自己的构造器之前写了什么（`if (Platform.isAndroid)` 这类 collection-if）。
+///
+/// 从 [start] 往回扫到**同级**的 `,` 或列表左括号为止。用深度配对而不是「上一行」：
+/// 前一个元素多包一层括号、或 `dart format` 重排都不影响。
+String _elementPrefix(String list, int start) {
+  final String structural = maskCommentsAndStrings(list);
+  int depth = 0;
+  for (int i = start - 1; i >= 0; i--) {
+    final String c = structural[i];
+    if (c == ')' || c == ']' || c == '}') {
+      depth++;
+      continue;
+    }
+    if (c == '(' || c == '[' || c == '{') {
+      if (depth == 0) return list.substring(i + 1, start);
+      depth--;
+      continue;
+    }
+    if (c == ',' && depth == 0) return list.substring(i + 1, start);
+  }
+  return list.substring(0, start);
 }

--- a/hibiki/test/helpers/source_guard.dart
+++ b/hibiki/test/helpers/source_guard.dart
@@ -743,8 +743,12 @@ String methodBody(
   return src.substring(start, bounds.close + 1);
 }
 
-/// 按**函数名**取 [src] 里那个函数的**实现体**原文；`=> expr;` 与 `{ … }` 两种形态
-/// 都认，找不到声明返回 null。
+/// 按**函数名**取 [src] 里那个函数 / 方法的**实现体**原文；`=> expr;` 与 `{ … }`
+/// 两种形态都认，`async` / `async*` / `sync*` 修饰符会被跳过（见 [_skipAsyncModifier]），
+/// 找不到声明返回 null。
+///
+/// 名字里的 "topLevel" 只说明它不解析类作用域（同名方法取首个声明），**类成员方法
+/// 一样能取**——BUG-1237 的可达性守卫正是拿它取 `_State` 里的私有异步方法。
 ///
 /// 与 [methodBody] 的分工——两者都不可省：
 /// - [methodBody] 的起点是**签名文本**的首次出现，找不到就 `fail`。适合"我知道这个
@@ -779,10 +783,7 @@ String? topLevelFunctionBody(String src, String name) {
       }
     }
     if (close < 0) continue;
-    int i = close + 1;
-    while (i < structural.length && structural[i].trim().isEmpty) {
-      i++;
-    }
+    final int i = _skipAsyncModifier(structural, close + 1);
     if (i + 1 < structural.length &&
         structural[i] == '=' &&
         structural[i + 1] == '>') {
@@ -798,6 +799,40 @@ String? topLevelFunctionBody(String src, String name) {
     // 既不是 `=>` 也不是 `{`：这一处是**调用**而不是声明，继续找下一处。
   }
   return null;
+}
+
+/// 跳过参数表右括号之后的空白，以及 `async` / `async*` / `sync*` 修饰符，返回**体
+/// 起点**（`=>` 或 `{`）的下标。
+///
+/// 为什么必须有它：[topLevelFunctionBody] 是拿「右括号后第一个非空白字符是不是
+/// `=>` / `{`」来分辨**声明**与**调用点**的。异步函数的签名与体之间隔着一个
+/// `async`，于是每一个 `Future<T> f(…) async { … }` 都会被判成调用点、被跳过，
+/// 函数最终解析成 null——而 null 在「一跳可达」判据里的含义是**不可达**，守卫因此
+/// 在实现完全正确时转红（BUG-1237 的可达性守卫就是被这条打出来的）。
+///
+/// 只认 `async` / `sync` 两个词（且必须是完整标识符），不做「跳过任意标识符」：
+/// 后者会让 `if (foo(x)) { … }`、`x = foo(a) as T { …` 这类语境里的调用点被误判成
+/// 声明，把窗口静默锚到别人的花括号上。宁可漏认一种修饰符，不可误认一个调用点。
+int _skipAsyncModifier(String structural, int from) {
+  int i = from;
+  while (i < structural.length && structural[i].trim().isEmpty) {
+    i++;
+  }
+  for (final String keyword in const <String>['async', 'sync']) {
+    if (!structural.startsWith(keyword, i)) continue;
+    final int after = i + keyword.length;
+    if (after < structural.length &&
+        _identifierChar.hasMatch(structural[after])) {
+      continue; // `asyncHelper(` 之类：不是修饰符。
+    }
+    i = after;
+    if (i < structural.length && structural[i] == '*') i++;
+    while (i < structural.length && structural[i].trim().isEmpty) {
+      i++;
+    }
+    break;
+  }
+  return i;
 }
 
 /// 从 [structural]（已掩码的语料）的左花括号 [open] 起做配对，返回配对上的 `}` 的

--- a/hibiki/test/helpers/source_guard_lexer_test.dart
+++ b/hibiki/test/helpers/source_guard_lexer_test.dart
@@ -407,6 +407,70 @@ void caller() {
       expect(topLevelFunctionBody(callsOnly, 'headline'), isNull);
     });
 
+    test('async / async* / sync* 修饰符不得把声明误判成调用点', () {
+      // 「右括号后第一个非空白字符是不是 `=>` / `{`」是本函数分辨声明与调用点的
+      // 唯一判据，而异步函数在两者之间隔着一个 `async`。不跳它 ⇒ 每个
+      // `Future<T> f() async { … }` 都被判成调用点、整个函数解析成 null，
+      // 而 null 在「一跳可达」判据里的含义是**不可达** ⇒ 实现完全正确时守卫转红。
+      const String asyncSrc = '''
+class _State {
+  Future<void> copy(String text) async {
+    await Clipboard.setData(ClipboardData(text: text));
+  }
+
+  Stream<int> ticks() async* {
+    yield 1;
+  }
+
+  Iterable<int> ones() sync* {
+    yield 1;
+  }
+
+  Future<String> read() async => fetch();
+
+  Future<void> caller() async {
+    await copy('x');
+  }
+}
+''';
+      final String? brace = topLevelFunctionBody(asyncSrc, 'copy');
+      expect(brace, isNotNull, reason: 'async 花括号体必须取得到');
+      expect(containsIdentifierCall(brace!, 'Clipboard.setData'), isTrue);
+      expect(brace.contains('yield'), isFalse, reason: '不得越界读到邻居');
+
+      expect(
+          topLevelFunctionBody(asyncSrc, 'ticks')?.contains('yield 1'), isTrue);
+      expect(
+          topLevelFunctionBody(asyncSrc, 'ones')?.contains('yield 1'), isTrue);
+
+      final String? arrow = topLevelFunctionBody(asyncSrc, 'read');
+      expect(arrow, isNotNull, reason: 'async 箭头体必须取得到');
+      expect(containsIdentifierCall(arrow!, 'fetch'), isTrue);
+      expect(arrow.contains('{'), isFalse,
+          reason: 'async 箭头体收口在深度 0 的分号，不得吞掉下一个花括号体');
+    });
+
+    test('只跳 async / sync，不跳任意标识符（调用点不得被误判成声明）', () {
+      // 「跳过右括号后任意标识符」是个诱人但错误的泛化：下面两处都是**调用点**，
+      // 一旦被当成声明，窗口会静默锚到别人的花括号上。
+      const String traps = '''
+void caller() {
+  if (target(1)) {
+    print('not a body');
+  }
+}
+''';
+      expect(topLevelFunctionBody(traps, 'target'), isNull,
+          reason: '`if (target(1)) {` 里的 target 是调用点，不是声明');
+      const String asyncPrefixed = '''
+void caller() {
+  asyncHelper(1);
+}
+''';
+      expect(topLevelFunctionBody(asyncPrefixed, 'asyncHelper'), isNull,
+          reason: '`asyncHelper` 只是以 async 开头的标识符，不是修饰符');
+    });
+
     test('调用点排在声明之前时仍锚到声明', () {
       const String callFirst = '''
 void caller() {


### PR DESCRIPTION
## 修的是什么

develop 上的一条**真红**：`hibiki/test/dictionary/popup_touch_copy_actionmode_guard_test.dart`

```
BUG-1237 ... copy is custom Dart clipboard action
Expected: contains 'Clipboard.setData(ClipboardData(text: text))'
Actual:   'contextMenu: ContextMenu(\n settings: ContextMenuSettings(\n…'
```

**行为没坏，是锚点断了。** PR#764（BUG-1451）把三条复制入口（Windows 右键 / Windows Ctrl+C / Android 原生菜单）收口进共享的 `_copySelectionToClipboard`，Android 分支不再自己裸调 `Clipboard.setData` —— 不变式**被保留而且加强了**，但那串字面量搬出了 `_between(src, 'contextMenu: ContextMenu(', 'gestureRecognizers:')` 这个**文本窗口**。

本仓第四次同型事故（PR#762 的 BUG-1100、PR#758 的 `SetTimer(` 禁令、`9fd30d281` 的 `_gif(` 锚点）。

## 新判据：可达性（照 PR#762 的范式）

| 旧 | 新 |
|---|---|
| `_between(..., 'gestureRecognizers:')` 文本窗口 | `enclosingCall` 按 `ContextMenu(` 的**括号配对**切窗口 |
| `menu.contains('Clipboard.setData(ClipboardData(text: text))')` | 复制项的 `action:` → **一跳可达闭包** → `Clipboard.setData` |
| `menu.contains('Platform.isAndroid \|\| isWindowsPlatform')` | `namedArgumentValues(menu, 'hideDefaultSystemContextMenuItems')` 的实参表达式 |
| `menu.contains('if (Platform.isAndroid)')` | 列表元素在自己构造器之前的**同级前缀**（深度配对回扫） |
| 裸 `contains` | `containsCodeLine` / `containsIdentifierCall`（注释兜不住） |

不变式没有被放宽：**Android popup 的复制必须是自定义 Dart 剪贴板动作，不能落回被 finish 掉的系统 ActionMode**。新判据回答的是「那个 copy handler 最终有没有走到 `Clipboard.setData`」，而不是「某段文本里有没有这个串」。

三处「绝不静默变绿」：整块 `ContextMenu(` 没了 → fail；复制项没了 → `enclosingCallOf` 找不到锚点 fail；中转方法把写剪贴板那一跳删了 → 解析得到实现体但判不可达，失败信息点名它到底调到了谁。

## 顺带修掉一条「碰巧还绿着」的

旧 Windows 断言的窗口是 `'Future<void> _showWindowsContextMenu('` .. `'static String? _cachedStylesJson'` —— 右边界离方法真正的收口有 20 多行，中间**正好夹着** `_copySelectionToClipboard` 的实现体。

实测（把 Windows 右键复制改成不写剪贴板）：**旧守卫的 `Windows right-click path remains unchanged` 照样 PASS**（`+3 -1`，红的只有 Android 那条）。同型、只是还没爆。现在两侧共用同一条可达性判据。

## 共享原语的根因修复

`topLevelFunctionBody`（PR#768 刚落地）靠「右括号后第一个非空白字符是不是 `=>` / `{`」分辨**声明**与**调用点**。异步函数在两者之间隔着一个 `async` ⇒ 每个 `Future<T> f() async { … }` 都被判成调用点、整个函数解析成 **null**，而 null 在「一跳可达」判据里的含义是**不可达** ⇒ 实现完全正确时守卫转红。

新增 `_skipAsyncModifier`：只认 `async` / `sync` **完整标识符**（+ 可选 `*`），**不做**「跳过右括号后任意标识符」的危险泛化 —— 后者会让 `if (target(1)) { … }` 里的调用点被误判成声明，把窗口静默锚到别人的花括号上。

`source_guard_lexer_test.dart` 补 6 条：async 花括号体 / `async*` / `sync*` / async 箭头体（收口在深度 0 分号，不吞下一个体），外加两条负向（`if (target(1)) {`、`asyncHelper(` 不得被判成声明）。

blast radius 有限：`_skipAsyncModifier` 只被 `topLevelFunctionBody` 用，`methodBody` 未动；全仓 `topLevelFunctionBody` 只有 3 个消费者，都已跑绿。

## 变异实测

**每一轮 N 都非零**（`0 tests ran` 不算红）；生产代码在每轮之间用**反向替换**还原，从不 `git checkout --`；最终 `git diff --stat -- lib/` 为空。

| 变异（写回 BUG-1237 原始症状） | 结果 | N |
|---|---|---|
| 删掉整个 Android 「复制」项，靠系统 ActionMode | 🔴 2 error | 4 |
| 复制 action 不再写剪贴板（只 toast） | 🔴 1 error | 4 |
| 共享 `_copySelectionToClipboard` 去掉 `Clipboard.setData` | 🔴 2 error（Android + Windows） | 4 |
| `hideDefaultSystemContextMenuItems` 去掉 `Platform.isAndroid` | 🔴 1 error | 4 |
| Windows 右键复制不再写剪贴板 | 🔴 1 error（**旧守卫此处绿**） | 4 |
| `_skipAsyncModifier` 变成空操作 | 🔴 3 error（lexer 2 + 守卫 2 条可达性） | 76 |

避开的假绿：
- **空操作变异**：每条变异改的字节都落在守卫真正读的那个结构窗口里，失败信息逐条点名了正确的断言；
- **编译失败变异**：全部保持语法合法，每轮 N=4 / 76 恒定；
- **注释兜住**：删复制项那轮，我把 `title: t.copy` 和 `Clipboard.setData(ClipboardData(text: text))` **写进了替换它的注释里**，守卫照样红（失败信息原话：「注释内的同名文本不算」）；不写剪贴板那轮，生产代码里原有的 `// 与 Windows 两条入口收口到同一个 [_copySelectionToClipboard]` 注释也没救它；
- **仪器错配**：这是**源码扫描守卫**，BUG-1237 的不变式是源码级结构契约（单测里驱动不了 Android WebView 的原生 ContextMenu），所以用**源码变异**是对的仪器；
- **共用枚举**：本守卫没有自校验枚举器，不适用。

## `tests_for_changes` 那条：既没改工具，也没加声明——两条备选路都经实测证伪

派单时的前提是「路径字面量的形态没被工具静态提取到」。**实测不成立**：

```
$ dart run tool/tests_for_changes.dart --include-dart --explain lib/src/pages/implementations/dictionary_popup_webview.dart
  test/dictionary/popup_touch_copy_actionmode_guard_test.dart  ← [hibiki/lib/src/pages/implementations/dictionary_popup_webview.dart]
```

提取器**认得**这条。0 命中的真因是 `isDefaultBatchCoveredChange`：`hibiki/lib/` 在 `kDefaultBatchCoveredGlobs` 里，Dart 树的改动默认被整条过滤掉。

加 `// tests-for-changes:` 声明**也没用**（实测过：临时加一行，不带 `--include-dart` 仍然 0）—— `selectTestsForChanges` 先按 `isDefaultBatchCoveredChange` 过滤 `changedFiles`，再同时匹配 `referencedPaths` 与 `declaredGlobs`，两条路被同一道门挡住。**真加了就是假修（死规则）**，所以没加。

改工具的过滤语义也不行：`test/tools/tests_for_changes_guard_test.dart` 有一条 `'Dart 源码树的改动不由本工具输出（默认整批 35 条兜底）'` 明确断言 `isDefaultBatchCoveredChange('hibiki/lib/…') == true`。动它就是改一条别人刚立下的、有守卫的设计契约，超出「修锚点」的范围。

⇒ 选的是**改文档**：`docs/agent/fast-workflow.md` 的「定向测试」定义处补一条，把 `--include-dart` 这个未文档化的逃生口写出来，并点明缝在哪：

> 点名单个生产文件的守卫，既不在 35 条整批里（那批只收目录枚举型），也不按功能域取名（定向测试靠功能域挑）—— 正好落在两道门的缝里。PR#764 只擦肩而过 `test/lookup`，红直接进了 develop。

## 验证

| 门 | 结果 |
|---|---|
| `dart format` | 4 个改动文件 |
| `flutter analyze` 全量（含 test） | `No issues found! (ran in 52.8s)` |
| `test/dictionary` + `test/helpers` + `test/tools` + `test/mining/gal_audio_degrade_track_test.dart` | `PASSED - 605 tests ran` |
| **35 条整批** | `PASSED - 225 tests ran`（基线 225 ✅），装载 suite 数 **35/35**（结构判据） |
| `git diff --stat -- lib/` | 空（变异全部还原） |

> 中途遇到一次并发伪红：`dictionary_peek_title_test.dart` 报 `Cannot close sink while adding stream` / `Connection closed before test suite loaded`（宿主 IPC 崩溃致 suite 装载失败），完成数 598。同一条命令重跑 605 全绿 —— 差的 7 条正是那个被崩掉的 suite。已按分型处置，不是真红。

## 顺带发现、没改的

1. **本守卫的 `share` / `web search` 两项**仍锚在 `SelectionExternalActions.instance.shareText(text)` 这类字面量上。它们现在至少跑在结构窗口 + `containsCodeLine` 上（注释骗不动），但一旦这两条入口也被收口，会重演同一类断裂。没顺手改：超出本次范围，且改法与复制那条完全同构，等真收口时照抄即可。
2. `topLevelFunctionBody` 的名字里的 "topLevel" 已经名不副实（它一直能取类成员方法，本 PR 正是这么用的）。只在 dartdoc 里写清了，没改名 —— 改名会碰 3 个消费者且与本次修复无关。
