### PR TITLE
fix(video): 手柄按键不再同时打开右键菜单

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,11 +29,12 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1358 条。点号进各自文件。
+> 共 1359 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
 | [BUG-1454](bugs/BUG-1454-kana-compound-popup-selection.md) | ✅ | ✅ | 查词结果正文含假名词被 ruby 占位文本截断 |
+| [BUG-1453](bugs/BUG-1453-video-gamepad-synthetic-right-click.md) | ✅ | ✅ | 手柄按键同时触发视频动作与右键菜单 |
 | [BUG-1452](bugs/BUG-1452-gal-unselected-thread-implies-audio.md) | ✅ | ✅ | 未选择台词线程时仍显示正在监听与句级音频 |
 | [BUG-1451](bugs/BUG-1451-popup-copy-shortcut-and-context-menu.md) | ✅ | ✅ | 查词弹窗无法复制（Ctrl+C 与右键「复制」都无效） |
 | [BUG-1449](bugs/BUG-1449-gal-helper-bundled-as-plain-files.md) | ✅ | ✅ | helper 改为构建期解压随包，消灭需与本体同步的第二份副本 |

--- a/docs/bugs/BUG-1453-video-gamepad-synthetic-right-click.md
+++ b/docs/bugs/BUG-1453-video-gamepad-synthetic-right-click.md
@@ -1,0 +1,6 @@
+## BUG-1453 · 手柄按键同时触发视频动作与右键菜单
+- **报告**：2026-08-02（用户：手柄 X 已绑定「上一句字幕」，按下却同时打开视频菜单）
+- **真实性**：✅ 真 bug（跨输入源双投递）。手柄链是 Windows `GameInput` → `GamepadService` 60ms 轮询 → `GamepadButtonIntent` → `video_hibiki_page.dart:4469` `_handleVideoGamepadButton` → 注册表 `videoPreviousSubtitle`；菜单链只有 `layout.part.dart:246` `onSecondaryTapUp` → `video_hibiki_page.dart:6862` `_handleSecondaryTap` → `:6886` `_showVideoContextMenu` → `showMenu`。Steam Input 等桌面手柄映射器可把同一次物理 X 同时投递为真实手柄 X 和 Windows 鼠标右键，Flutter 两条事件没有共同 source id；旧实现各自合法消费，故稳定表现为「上一句 + 菜单」。注册表内 X 只有一个视频动作，不是 Hibiki 自己双绑。
+- **[x] ① 已修复** — `video_player_shortcuts.dart:25` 新增 `VideoGamepadSecondaryTapDeduper`：用单调 `Stopwatch` 在 120ms 窄窗口关联同源手柄/右键；视频手柄入口在解析动作前记录真实按钮边沿，右键入口等待 80ms（略大于桌面 poller 的 60ms tick）覆盖 pointer-first 顺序，并在 `showMenu` 前丢弃同源合成右键。独立鼠标右键不与手柄边沿重合，仍正常打开菜单；窗口/全屏共用同一 State 与 wrapper，两种模式同时生效。
+- **[x] ② 已加自动化测试** — `hibiki/test/media/video/video_gamepad_secondary_tap_dedup_test.dart` 覆盖轮询窗口约束、普通鼠标放行、手柄先到、指针先到、窗外独立右键和边界值；`hibiki/test/pages/video_context_menu_test.dart` 源码守卫钉死「等待 → 去重 → showMenu」顺序及手柄记录接线。连同快捷键分派/全屏手柄回归共 29 个聚焦用例通过。
+- **备注**：这是外部桌面映射器没有跨通道来源标识时的输入兼容层；影响仅为真实右键菜单最多延后 80ms。按用户要求未等待完整编译/设备验收；Windows 实体手柄 + 当前桌面映射的原始路径仍待设备复测。

--- a/hibiki/lib/src/media/video/video_player_shortcuts.dart
+++ b/hibiki/lib/src/media/video/video_player_shortcuts.dart
@@ -13,6 +13,38 @@ import 'package:hibiki/src/shortcuts/input_binding.dart' show ModifierKey;
 import 'package:hibiki/src/shortcuts/shortcut_action.dart';
 import 'package:hibiki/src/shortcuts/shortcut_registry.dart';
 
+/// Coalesces a controller button and the synthetic secondary mouse click that
+/// some desktop controller mappers emit for the same physical press.
+///
+/// Steam Input's desktop layout is a common source: Hibiki receives the real
+/// controller button through GameInput, while Windows also receives a right
+/// click through the pointer channel. Neither Flutter event carries a shared
+/// source identifier, so the only reliable app-side boundary is their tightly
+/// correlated arrival time. Real mouse right-clicks outside this narrow window
+/// remain untouched.
+class VideoGamepadSecondaryTapDeduper {
+  /// The desktop gamepad poller ticks every 60 ms. Waiting slightly longer lets
+  /// a pointer-first synthetic click meet its controller half before a menu is
+  /// opened.
+  static const Duration settleDelay = Duration(milliseconds: 80);
+
+  /// Covers either delivery order plus normal UI-thread scheduling jitter.
+  static const Duration coincidenceWindow = Duration(milliseconds: 120);
+
+  Duration? _lastGamepadPressAt;
+
+  void recordGamepadPress(Duration at) {
+    _lastGamepadPressAt = at;
+  }
+
+  bool shouldSuppressSecondaryTap(Duration tapAt) {
+    final Duration? gamepadAt = _lastGamepadPressAt;
+    if (gamepadAt == null) return false;
+    final Duration delta = gamepadAt - tapAt;
+    return delta.abs() <= coincidenceWindow;
+  }
+}
+
 class VideoPlayerShortcutActions {
   const VideoPlayerShortcutActions({
     required this.togglePlayPause,

--- a/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
+++ b/hibiki/lib/src/pages/implementations/video_hibiki_page.dart
@@ -1340,6 +1340,9 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// `FullscreenInheritedWidget` / `VideoStateInheritedWidget`——本页 build 的 context 是
   /// 它们的祖先，传进去会查不到。故捕获一个后代 context 供 Escape/F 快捷键用。
   BuildContext? _videoControlsContext;
+  final Stopwatch _videoInputClock = Stopwatch()..start();
+  final VideoGamepadSecondaryTapDeduper _videoGamepadSecondaryTapDeduper =
+      VideoGamepadSecondaryTapDeduper();
   DateTime? _lastVideoPointerUpAt;
   Offset? _lastVideoPointerUpPosition;
   bool _videoFullscreenTransitioning = false;
@@ -4477,6 +4480,12 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   /// 兜底）；未绑定返回 false，交回 [GamepadService] 的通用兜底（焦点移动等）。
   /// 执行体与键盘快捷键共用 [_buildVideoShortcutActions]，行为完全一致。
   bool _handleVideoGamepadButton(GamepadButton button) {
+    // BUG-1453：Steam Input 等桌面映射可把一次手柄按键同时合成鼠标右键。先记录
+    // 真实手柄边沿，让右键菜单入口把同源 secondary tap 去重；动作是否绑定不影响
+    // 输入来源判定，故记录必须在注册表解析之前。
+    _videoGamepadSecondaryTapDeduper.recordGamepadPress(
+      _videoInputClock.elapsed,
+    );
     final VideoPlayerController? controller = _controller;
     if (controller == null) return false;
     // videoEnterCaret：选词光标激活期，方向/确认/退出等在注册表解析**之前**截获
@@ -6873,6 +6882,28 @@ class _VideoHibikiPageState extends ConsumerState<VideoHibikiPage>
   void _handleSecondaryTap(Offset globalPosition) {
     if (!_isDesktopVideoControls) return;
     if (!_immersiveAllowsFullControls) return;
+    // BUG-1453：桌面手柄映射器可能先投递 synthetic right-click，GameInput 轮询再在
+    // 下一 tick 投递真实按钮。等一个略大于 60 ms poll interval 的有界窗口，再与
+    // [_handleVideoGamepadButton] 记录的边沿合并；真实鼠标右键不与手柄边沿重合，照常弹。
+    final Duration secondaryTapAt = _videoInputClock.elapsed;
+    unawaited(
+      Future<void>.delayed(VideoGamepadSecondaryTapDeduper.settleDelay)
+          .then<void>((_) {
+        if (!mounted ||
+            _videoGamepadSecondaryTapDeduper.shouldSuppressSecondaryTap(
+              secondaryTapAt,
+            )) {
+          return;
+        }
+        _showVideoContextMenu(globalPosition);
+      }),
+    );
+  }
+
+  /// 在 secondary tap / gamepad 双投递去重后，同步解析当前 controls 几何并打开菜单。
+  /// 延迟窗口之后才读取 [BuildContext]，全屏切换或退页时会自然读到最新 context / null，
+  /// 也不让任何 context 跨 async gap 生存。
+  void _showVideoContextMenu(Offset globalPosition) {
     final VideoPlayerController? controller = _controller;
     final BuildContext? ctx = _videoControlsContext;
     if (controller == null || ctx == null || !ctx.mounted) return;

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1198
+version: 1.3.1+1199
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/media/video/video_gamepad_secondary_tap_dedup_test.dart
+++ b/hibiki/test/media/video/video_gamepad_secondary_tap_dedup_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki/src/media/video/video_player_shortcuts.dart';
+
+void main() {
+  group('VideoGamepadSecondaryTapDeduper (BUG-1453)', () {
+    test('settle delay covers one 60ms desktop poll tick', () {
+      expect(
+        VideoGamepadSecondaryTapDeduper.settleDelay,
+        greaterThan(const Duration(milliseconds: 60)),
+      );
+      expect(
+        VideoGamepadSecondaryTapDeduper.settleDelay,
+        lessThanOrEqualTo(
+          VideoGamepadSecondaryTapDeduper.coincidenceWindow,
+        ),
+      );
+    });
+
+    test('allows an ordinary mouse secondary tap', () {
+      final VideoGamepadSecondaryTapDeduper deduper =
+          VideoGamepadSecondaryTapDeduper();
+
+      expect(
+        deduper.shouldSuppressSecondaryTap(const Duration(seconds: 1)),
+        isFalse,
+      );
+    });
+
+    test('suppresses controller-first synthetic right-click', () {
+      final VideoGamepadSecondaryTapDeduper deduper =
+          VideoGamepadSecondaryTapDeduper()
+            ..recordGamepadPress(const Duration(milliseconds: 1000));
+
+      expect(
+        deduper.shouldSuppressSecondaryTap(
+          const Duration(milliseconds: 1060),
+        ),
+        isTrue,
+      );
+    });
+
+    test('suppresses pointer-first synthetic right-click after poll tick', () {
+      final VideoGamepadSecondaryTapDeduper deduper =
+          VideoGamepadSecondaryTapDeduper()
+            ..recordGamepadPress(const Duration(milliseconds: 1060));
+
+      expect(
+        deduper.shouldSuppressSecondaryTap(
+          const Duration(milliseconds: 1000),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not suppress a later independent mouse right-click', () {
+      final VideoGamepadSecondaryTapDeduper deduper =
+          VideoGamepadSecondaryTapDeduper()
+            ..recordGamepadPress(const Duration(milliseconds: 1000));
+
+      expect(
+        deduper.shouldSuppressSecondaryTap(
+          const Duration(milliseconds: 1201),
+        ),
+        isFalse,
+      );
+    });
+
+    test('coincidence boundary is inclusive', () {
+      final VideoGamepadSecondaryTapDeduper deduper =
+          VideoGamepadSecondaryTapDeduper()
+            ..recordGamepadPress(const Duration(milliseconds: 1000));
+
+      expect(
+        deduper.shouldSuppressSecondaryTap(
+          const Duration(milliseconds: 1120),
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/hibiki/test/pages/video_context_menu_test.dart
+++ b/hibiki/test/pages/video_context_menu_test.dart
@@ -17,6 +17,8 @@ void main() {
   // 方法里多一行注释就会把 _focusOwnership.reclaim 断言挤出窗口凭空变红；400 的
   // 窗口只覆盖开头 22%，2000 的窗口反过来越界读进下一个方法（负向断言指向错对象）。
   final String secondaryTap = methodBody(page, 'void _handleSecondaryTap(');
+  final String showContextMenu =
+      methodBody(page, 'void _showVideoContextMenu(');
 
   group('右键菜单触发与门控', () {
     test('视频控制层挂 onSecondaryTapUp（右键触发）', () {
@@ -27,6 +29,28 @@ void main() {
           reason: '右键松手处的 globalPosition 作 showMenu 锚点');
     });
 
+    test('手柄映射器合成的同源右键在 showMenu 前去重（BUG-1453）', () {
+      final int settle = secondaryTap.indexOf(
+        'VideoGamepadSecondaryTapDeduper.settleDelay',
+      );
+      final int suppress = secondaryTap.indexOf(
+        '_videoGamepadSecondaryTapDeduper.shouldSuppressSecondaryTap(',
+      );
+      final int show =
+          secondaryTap.indexOf('_showVideoContextMenu(globalPosition)');
+      expect(settle, greaterThanOrEqualTo(0),
+          reason: '须等待略大于桌面手柄 60ms 轮询周期，让 pointer-first 双投递可合并');
+      expect(suppress, greaterThan(settle), reason: '等待后须按同一输入时钟检查手柄/右键是否同源');
+      expect(show, greaterThan(suppress), reason: '同源去重必须发生在菜单构造之前，不能先闪菜单再关闭');
+      expect(
+        page.contains(
+          '_videoGamepadSecondaryTapDeduper.recordGamepadPress(',
+        ),
+        isTrue,
+        reason: '视频手柄入口须记录真实按钮边沿供右键入口关联',
+      );
+    });
+
     test('右键菜单仅桌面（移动端门控 no-op）', () {
       // _handleSecondaryTap 第一行必是桌面门控，移动端不弹菜单。
       expect(secondaryTap.contains('if (!_isDesktopVideoControls) return;'),
@@ -35,7 +59,7 @@ void main() {
     });
 
     test('菜单锚定 _videoControlsContext（全屏路由内可弹）', () {
-      final String body = secondaryTap;
+      final String body = showContextMenu;
       expect(body.contains('_videoControlsContext'), isTrue,
           reason: 'showMenu 须用 controls 子树 context，全屏路由复用同一 builder 才能弹出');
       expect(body.contains('showMenu<VoidCallback>('), isTrue,
@@ -53,7 +77,7 @@ void main() {
     // showMenu 所用 Overlay 的 RenderBox 坐标系——FittedBox 缩放被 ancestor 变换自动吸收，
     // 与查词浮层 charRect 走同一「锚点跟随真实渲染几何」范式，对任意 scale 自洽无残差。
     test('菜单锚点用 Overlay 相对变换吃掉界面缩放残差（BUG-260）', () {
-      final String body = secondaryTap;
+      final String body = showContextMenu;
       // 取 showMenu 实际使用的 Navigator(rootNavigator:false) 的 Overlay RenderBox。
       expect(
           body.contains('Overlay.of(ctx).context.findRenderObject()'), isTrue,
@@ -71,7 +95,7 @@ void main() {
 
     test('菜单关闭后归还键盘焦点', () {
       expect(
-          secondaryTap.contains(
+          showContextMenu.contains(
               '_focusOwnership.reclaim(FocusReclaimCause.overlayClosed)'),
           isTrue,
           reason: '覆盖层夺焦后不会自动归还，菜单关闭须经 _focusOwnership 归还');

--- a/hibiki/test/pages/video_immersive_mode_levels_guard_test.dart
+++ b/hibiki/test/pages/video_immersive_mode_levels_guard_test.dart
@@ -177,17 +177,23 @@ void main() {
 
   test('TODO-174: locked context menu is available only to full-control mode',
       () {
-    final String body = methodBody(
+    final String handleBody = methodBody(
         pageSrc, 'void _handleSecondaryTap(Offset globalPosition) {');
+    final String showBody = methodBody(
+        pageSrc, 'void _showVideoContextMenu(Offset globalPosition) {');
     final int fullControlsGate =
-        body.indexOf('if (!_immersiveAllowsFullControls) return;');
+        handleBody.indexOf('if (!_immersiveAllowsFullControls) return;');
     expect(fullControlsGate, greaterThanOrEqualTo(0),
         reason:
             'right-click menu exposes full controls and must be gated by immersive mode');
-    final int menuIdx = body.indexOf('showMenu<VoidCallback>(');
-    expect(menuIdx, greaterThan(fullControlsGate),
+    final int delegateIdx =
+        handleBody.indexOf('_showVideoContextMenu(globalPosition);');
+    expect(delegateIdx, greaterThan(fullControlsGate),
         reason:
-            'full-control gate must run before building/showing the context menu');
+            'full-control gate must run before scheduling the context menu');
+    expect(showBody.contains('showMenu<VoidCallback>('), isTrue,
+        reason:
+            'the gated delegate must remain the method that opens the menu');
   });
 
   test('TODO-174: video settings schema exposes the four-mode selector', () {


### PR DESCRIPTION
## 问题

手柄 X 绑定「上一句字幕」后，按一次会同时执行上一句并打开视频右键菜单。

真实链路显示这不是注册表双绑：

- 手柄动作：Windows GameInput → 60ms 手柄轮询 → `GamepadButtonIntent` → `videoPreviousSubtitle`
- 菜单动作：secondary mouse tap → `_handleSecondaryTap` → `showMenu`

Steam Input 等桌面手柄映射器可把同一物理 X 同时投递为真实手柄 X 和 Windows 鼠标右键，而 Flutter 两条事件没有共享 source id，旧代码因而分别合法消费。

## 修复

- 增加视频手柄/secondary tap 去重器，使用单调时钟在 120ms 窄窗口关联同源事件。
- secondary tap 等待 80ms（略大于桌面 poller 的 60ms tick），覆盖「鼠标事件先到、手柄轮询后到」的顺序。
- 同源合成右键在 `showMenu` 前丢弃；独立鼠标右键仍正常打开菜单。
- 窗口与全屏共用同一视频 State，两个模式同时生效。
- 登记 BUG-1453，build 1197 → 1198。

## 验证

- `flutter analyze --no-pub`：通过，0 issue
- 29 个聚焦测试：通过
  - 新增普通鼠标放行、手柄先到、指针先到、窗口边界与 poll tick 约束
  - 视频右键菜单接线/顺序守卫
  - 视频快捷键分派回归
  - 视频全屏手柄分派回归
- `dart run tool/bug.dart check --strict`：通过，BUG 编号跨 ref/worktree 复核无撞号
- `git diff --cached --check`：通过

按用户要求未等待 Windows 完整编译与实体手柄设备验收；原始设备路径仍需后续实机复测。