### PR TITLE
fix(dictionary): 修复含假名复合词二次查词被截断

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1356 条。点号进各自文件。
+> 共 1357 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1454](bugs/BUG-1454-kana-compound-popup-selection.md) | ✅ | ✅ | 查词结果正文含假名词被 ruby 占位文本截断 |
 | [BUG-1451](bugs/BUG-1451-popup-copy-shortcut-and-context-menu.md) | ✅ | ✅ | 查词弹窗无法复制（Ctrl+C 与右键「复制」都无效） |
 | [BUG-1449](bugs/BUG-1449-gal-helper-bundled-as-plain-files.md) | ✅ | ✅ | helper 改为构建期解压随包，消灭需与本体同步的第二份副本 |
 | [BUG-1448](bugs/BUG-1448-gal-helper-version-check-short-circuited.md) | ✅ | ✅ | injector 存在即跳过 ensureInjector，随包新组件永不换入 |

--- a/docs/bugs/BUG-1454-kana-compound-popup-selection.md
+++ b/docs/bugs/BUG-1454-kana-compound-popup-selection.md
@@ -1,6 +1,6 @@
 ## BUG-1454 · 查词结果正文含假名词被 ruby 占位文本截断
 - **报告**：2026-08-02（用户反馈：结果正文内二次点查 `打ち合わせ` 只打开 `打ち`）
-- **真实性**：✅ 真 bug。运行中 Windows app 的 `/termEntries` 与 `/api/lookup/dictionary` 对原词均返回完整 `打ち合わせ`，排除索引、变形与排序链路。真实词条 DOM 经 `postProcessRuby` 后会在每个基字前插入 `.ruby-reserve` 占宽副本；`hibiki/assets/popup/selection.js` 的 TreeWalker 只排除了 `<rt>/<rp>`，从 `打` 向后扫描实际得到 `打ちあ合わせ`，词典只能命中前缀 `打ち`。浏览器扩展两份 vendored 取词器同源同缺陷。
-- **[x] ① 已修复** — `hibiki/assets/popup/selection.js` 新增统一的 `isIgnoredLookupText` 判定，让查词、整句提取与 ruby 基字解析同时跳过 `<rt>/<rp>` 和布局专用 `.ruby-reserve`；同步 `hibiki/assets/browser_extension/vendor/selection.js`、`tools/browser-extension/vendor/selection.js`，三镜像保持逐字节一致。可见基字与假名仍按原 DOM 顺序组成 `打ち合わせ`，不改后端匹配策略。
+- **真实性**：✅ 真 bug。运行中 Windows app 的 `/termEntries` 与 `/api/lookup/dictionary` 对原词均返回完整 `打ち合わせ`，排除索引、变形与排序链路。真实词条 DOM 经 `postProcessRuby` 后会在每个基字前插入 `.ruby-reserve` 占宽副本；根因在 `hibiki/assets/popup/selection.js:35` 的 TreeWalker 过滤契约只排除了 `<rt>/<rp>`，从 `打` 向后扫描实际得到 `打ちあ合わせ`，词典只能命中前缀 `打ち`。浏览器扩展两份 vendored 取词器同源同缺陷。
+- **[x] ① 已修复** — 提交 `61578b4b3`。`hibiki/assets/popup/selection.js` 新增统一的 `isIgnoredLookupText` 判定，让查词、整句提取与 ruby 基字解析同时跳过 `<rt>/<rp>` 和布局专用 `.ruby-reserve`；同步 `hibiki/assets/browser_extension/vendor/selection.js`、`tools/browser-extension/vendor/selection.js`，三镜像保持逐字节一致。可见基字与假名仍按原 DOM 顺序组成 `打ち合わせ`，不改后端匹配策略。
 - **[x] ② 已加自动化测试** — `test/js/popup_ruby_selection.test.mjs` 用 jsdom 复刻 `postProcessRuby` 后的真实 `打`／`ち`／`合`／`わせ` 分段 DOM。修复前两例稳定红：查询串为 `打ちあ合わせ`、从 `<rt>` 解析出的基字为隐藏 `あ`；修复后断言完整查询与整句均为 `打ち合わせ`、ruby reading 命中回落到可见 `合`。`cd test/js && npm test` 共 20 例全绿。
 - **备注**：按用户要求未等待完整 Flutter 编译或设备验收；本改动为三份纯 JS 资产与行为测试，已完成对应 Node 行为测试及镜像一致性检查。

--- a/docs/bugs/BUG-1454-kana-compound-popup-selection.md
+++ b/docs/bugs/BUG-1454-kana-compound-popup-selection.md
@@ -1,0 +1,6 @@
+## BUG-1454 · 查词结果正文含假名词被 ruby 占位文本截断
+- **报告**：2026-08-02（用户反馈：结果正文内二次点查 `打ち合わせ` 只打开 `打ち`）
+- **真实性**：✅ 真 bug。运行中 Windows app 的 `/termEntries` 与 `/api/lookup/dictionary` 对原词均返回完整 `打ち合わせ`，排除索引、变形与排序链路。真实词条 DOM 经 `postProcessRuby` 后会在每个基字前插入 `.ruby-reserve` 占宽副本；`hibiki/assets/popup/selection.js` 的 TreeWalker 只排除了 `<rt>/<rp>`，从 `打` 向后扫描实际得到 `打ちあ合わせ`，词典只能命中前缀 `打ち`。浏览器扩展两份 vendored 取词器同源同缺陷。
+- **[x] ① 已修复** — `hibiki/assets/popup/selection.js` 新增统一的 `isIgnoredLookupText` 判定，让查词、整句提取与 ruby 基字解析同时跳过 `<rt>/<rp>` 和布局专用 `.ruby-reserve`；同步 `hibiki/assets/browser_extension/vendor/selection.js`、`tools/browser-extension/vendor/selection.js`，三镜像保持逐字节一致。可见基字与假名仍按原 DOM 顺序组成 `打ち合わせ`，不改后端匹配策略。
+- **[x] ② 已加自动化测试** — `test/js/popup_ruby_selection.test.mjs` 用 jsdom 复刻 `postProcessRuby` 后的真实 `打`／`ち`／`合`／`わせ` 分段 DOM。修复前两例稳定红：查询串为 `打ちあ合わせ`、从 `<rt>` 解析出的基字为隐藏 `あ`；修复后断言完整查询与整句均为 `打ち合わせ`、ruby reading 命中回落到可见 `合`。`cd test/js && npm test` 共 20 例全绿。
+- **备注**：按用户要求未等待完整 Flutter 编译或设备验收；本改动为三份纯 JS 资产与行为测试，已完成对应 Node 行为测试及镜像一致性检查。

--- a/hibiki/assets/browser_extension/vendor/selection.js
+++ b/hibiki/assets/browser_extension/vendor/selection.js
@@ -35,11 +35,19 @@ window.hoshiSelection = {
         return !!el?.closest('rt, rp');
     },
 
+    isIgnoredLookupText(node) {
+        const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+        // postProcessRuby inserts a hidden copy of each reading before its base
+        // to reserve inline width. It is layout-only, just like <rt>/<rp>, and
+        // must not leak into mixed kanji/kana lookup scans (打ち合わせ, etc.).
+        return this.isFurigana(node) || !!el?.closest('.ruby-reserve');
+    },
+
     resolveRubyBase(node) {
         const rubyEl = node.parentElement?.closest('ruby');
         if (!rubyEl) return null;
         const walker = document.createTreeWalker(rubyEl, NodeFilter.SHOW_TEXT, {
-            acceptNode: (n) => this.isFurigana(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+            acceptNode: (n) => this.isIgnoredLookupText(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
         });
         const base = walker.nextNode();
         return base ? { node: base, offset: 0 } : null;
@@ -53,7 +61,7 @@ window.hoshiSelection = {
     createWalker(rootNode) {
         const root = rootNode || document.body;
         return document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-            acceptNode: (n) => this.isFurigana(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+            acceptNode: (n) => this.isIgnoredLookupText(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
         });
     },
 

--- a/hibiki/assets/popup/selection.js
+++ b/hibiki/assets/popup/selection.js
@@ -35,11 +35,19 @@ window.hoshiSelection = {
         return !!el?.closest('rt, rp');
     },
 
+    isIgnoredLookupText(node) {
+        const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+        // postProcessRuby inserts a hidden copy of each reading before its base
+        // to reserve inline width. It is layout-only, just like <rt>/<rp>, and
+        // must not leak into mixed kanji/kana lookup scans (打ち合わせ, etc.).
+        return this.isFurigana(node) || !!el?.closest('.ruby-reserve');
+    },
+
     resolveRubyBase(node) {
         const rubyEl = node.parentElement?.closest('ruby');
         if (!rubyEl) return null;
         const walker = document.createTreeWalker(rubyEl, NodeFilter.SHOW_TEXT, {
-            acceptNode: (n) => this.isFurigana(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+            acceptNode: (n) => this.isIgnoredLookupText(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
         });
         const base = walker.nextNode();
         return base ? { node: base, offset: 0 } : null;
@@ -53,7 +61,7 @@ window.hoshiSelection = {
     createWalker(rootNode) {
         const root = rootNode || document.body;
         return document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-            acceptNode: (n) => this.isFurigana(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+            acceptNode: (n) => this.isIgnoredLookupText(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
         });
     },
 

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1197
+version: 1.3.1+1198
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/test/js/popup_ruby_selection.test.mjs
+++ b/test/js/popup_ruby_selection.test.mjs
@@ -1,0 +1,62 @@
+// Popup ruby lookup behavior (jsdom real DOM).
+//
+// postProcessRuby() inserts a visually hidden .ruby-reserve before every ruby
+// base so the reading can reserve horizontal space.  Those layout-only text
+// nodes must never enter lookup scans: in a mixed kanji/kana word such as
+// 打ち合わせ, the hidden あ before 合 otherwise changes the query to
+// 打ちあ合わせ and the dictionary can only match the shorter prefix 打ち.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { JSDOM } from "jsdom";
+import { readFileSync } from "node:fs";
+
+const SELECTION_URL = new URL(
+  "../../hibiki/assets/popup/selection.js",
+  import.meta.url,
+);
+const selectionSrc = readFileSync(SELECTION_URL, "utf8");
+
+function createPopupSelection() {
+  const dom = new JSDOM(
+    `<!DOCTYPE html><body>
+      <div class="glossary-content">
+        <ruby><span class="ruby-unit"><span class="ruby-reserve" aria-hidden="true">う</span><span id="start">打</span><rt>う</rt></span></ruby><span>ち</span><ruby><span class="ruby-unit"><span class="ruby-reserve" aria-hidden="true">あ</span><span>合</span><rt id="second-reading">あ</rt></span></ruby><span>わせ。</span>
+      </div>
+    </body>`,
+    { runScripts: "outside-only" },
+  );
+  const win = dom.window;
+  win.Range.prototype.getClientRects = () => [];
+  win.Range.prototype.getBoundingClientRect = () => ({
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: 0,
+    height: 0,
+  });
+  win.flutter_inappwebview = { callHandler: () => {} };
+  win.eval(selectionSrc);
+  return win;
+}
+
+test("mixed kanji/kana lookup skips ruby-reserve layout text", () => {
+  const win = createPopupSelection();
+  const start = win.document.querySelector("#start").firstChild;
+
+  assert.equal(
+    win.hoshiSelection.selectFromPosition(start, 0, 20),
+    "打ち合わせ",
+  );
+  assert.equal(win.hoshiSelection.getSentence(start, 0), "打ち合わせ。");
+});
+
+test("furigana hit resolves to the visible ruby base, not its reserve", () => {
+  const win = createPopupSelection();
+  const reading = win.document.querySelector("#second-reading").firstChild;
+  const resolved = win.hoshiSelection.resolveRubyBase(reading);
+
+  assert.equal(resolved?.node.textContent, "合");
+});

--- a/tools/browser-extension/vendor/selection.js
+++ b/tools/browser-extension/vendor/selection.js
@@ -35,11 +35,19 @@ window.hoshiSelection = {
         return !!el?.closest('rt, rp');
     },
 
+    isIgnoredLookupText(node) {
+        const el = node.nodeType === Node.TEXT_NODE ? node.parentElement : node;
+        // postProcessRuby inserts a hidden copy of each reading before its base
+        // to reserve inline width. It is layout-only, just like <rt>/<rp>, and
+        // must not leak into mixed kanji/kana lookup scans (打ち合わせ, etc.).
+        return this.isFurigana(node) || !!el?.closest('.ruby-reserve');
+    },
+
     resolveRubyBase(node) {
         const rubyEl = node.parentElement?.closest('ruby');
         if (!rubyEl) return null;
         const walker = document.createTreeWalker(rubyEl, NodeFilter.SHOW_TEXT, {
-            acceptNode: (n) => this.isFurigana(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+            acceptNode: (n) => this.isIgnoredLookupText(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
         });
         const base = walker.nextNode();
         return base ? { node: base, offset: 0 } : null;
@@ -53,7 +61,7 @@ window.hoshiSelection = {
     createWalker(rootNode) {
         const root = rootNode || document.body;
         return document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
-            acceptNode: (n) => this.isFurigana(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
+            acceptNode: (n) => this.isIgnoredLookupText(n) ? NodeFilter.FILTER_REJECT : NodeFilter.FILTER_ACCEPT
         });
     },
 


### PR DESCRIPTION
## 变更
- 修复查词结果正文内二次点查含假名复合词时只命中前缀的问题（复现词：打ち合わせ）。
- 取词扫描统一排除 postProcessRuby 生成的布局专用 .ruby-reserve 文本，并同步 app / 内置扩展 / 扩展源码三份 selection.js。
- 新增 jsdom 行为回归，登记 BUG-1454，版本 build 号升至 1198。

## 根因
ruby 排版会在可见基字前插入隐藏读音副本占宽。旧 TreeWalker 只跳过 rt/rp，扫描真实 DOM 时把隐藏的 あ 拼入查询，得到 打ちあ合わせ，后端因此只能命中 打ち。后端直接查询完整词本身正常。

## 验证
- cd test/js && npm test：20/20 通过；新增用例修复前 2/2 稳定失败、修复后通过。
- 三份 selection.js SHA-256 一致。
- dart run tool/bug.dart check --strict：1357 条、编号唯一、索引同步。
- 按需求未等待完整 Flutter 编译或设备验收。tests_for_changes 推导命令在执行测试前被 pdfium_dart 下载 release-assets.githubusercontent.com 超时阻断，未将其记为通过。