### PR TITLE
fix(windows): 拖动查词弹窗时不再抬起主窗口

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1360 条。点号进各自文件。
+> 共 1361 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1455](bugs/BUG-1455-lookup-popup-reactivates-main-window.md) | ✅ | ✅ | 拖动或缩放查词弹窗会把主窗口抬到前台 |
 | [BUG-1454](bugs/BUG-1454-kana-compound-popup-selection.md) | ✅ | ✅ | 查词结果正文含假名词被 ruby 占位文本截断 |
 | [BUG-1453](bugs/BUG-1453-video-gamepad-synthetic-right-click.md) | ✅ | ✅ | 手柄按键同时触发视频动作与右键菜单 |
 | [BUG-1452](bugs/BUG-1452-gal-unselected-thread-implies-audio.md) | ✅ | ✅ | 未选择台词线程时仍显示正在监听与句级音频 |

--- a/docs/bugs/BUG-1455-lookup-popup-reactivates-main-window.md
+++ b/docs/bugs/BUG-1455-lookup-popup-reactivates-main-window.md
@@ -1,0 +1,6 @@
+## BUG-1455 · 拖动或缩放查词弹窗会把主窗口抬到前台
+- **报告**：2026-08-02（用户：查词弹窗拖动或从右下角缩放时，Hibiki 主窗口被抬到前台）
+- **真实性**：✅ 真 bug。查词面板由 `hibiki/windows/runner/global_lookup_window.cpp:1528` 的 `WM_NCLBUTTONDOWN` 进入系统 move/size 循环并成为活动窗口；主窗口随即收到 `WM_ACTIVATE/WA_INACTIVE`，但 `hibiki/windows/runner/win32_window.cpp:287` 原来不区分激活与失活，两种情况都会 `SetFocus(child_content_)`，把焦点和 Z 序抢回主窗口。
+- **[x] ① 根因修复** — `21b0d7baf`：主窗口只在 `LOWORD(wparam) != WA_INACTIVE` 时恢复 Flutter 子窗口焦点；查词弹窗接管激活以拖动/缩放时，主窗口不再反向抢焦点。
+- **[x] ② 已加自动化测试** — `hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart` 新增 `WM_ACTIVATE` 分支源码守卫，要求 `SetFocus(child_content_)` 唯一调用受 `WA_INACTIVE` 门控。
+- **备注**：`flutter analyze --no-pub` 通过（No issues found）；定向 `flutter test test/sync/desktop_lookup_foreground_guard_static_test.dart --no-pub` 在任何用例执行前被 `pdfium_dart` 下载 `pdfium-win-x64.tgz` 的 Windows socket 121 超时阻断，不能记为测试通过。按用户要求未等待完整 Windows 编译/真机验收。

--- a/docs/bugs/BUG-1455-lookup-popup-reactivates-main-window.md
+++ b/docs/bugs/BUG-1455-lookup-popup-reactivates-main-window.md
@@ -1,6 +1,6 @@
 ## BUG-1455 · 拖动或缩放查词弹窗会把主窗口抬到前台
 - **报告**：2026-08-02（用户：查词弹窗拖动或从右下角缩放时，Hibiki 主窗口被抬到前台）
 - **真实性**：✅ 真 bug。查词面板由 `hibiki/windows/runner/global_lookup_window.cpp:1528` 的 `WM_NCLBUTTONDOWN` 进入系统 move/size 循环并成为活动窗口；主窗口随即收到 `WM_ACTIVATE/WA_INACTIVE`，但 `hibiki/windows/runner/win32_window.cpp:287` 原来不区分激活与失活，两种情况都会 `SetFocus(child_content_)`，把焦点和 Z 序抢回主窗口。
-- **[x] ① 根因修复** — `21b0d7baf`：主窗口只在 `LOWORD(wparam) != WA_INACTIVE` 时恢复 Flutter 子窗口焦点；查词弹窗接管激活以拖动/缩放时，主窗口不再反向抢焦点。
-- **[x] ② 已加自动化测试** — `hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart` 新增 `WM_ACTIVATE` 分支源码守卫，要求 `SetFocus(child_content_)` 唯一调用受 `WA_INACTIVE` 门控。
-- **备注**：`flutter analyze --no-pub` 通过（No issues found）；定向 `flutter test test/sync/desktop_lookup_foreground_guard_static_test.dart --no-pub` 在任何用例执行前被 `pdfium_dart` 下载 `pdfium-win-x64.tgz` 的 Windows socket 121 超时阻断，不能记为测试通过。按用户要求未等待完整 Windows 编译/真机验收。
+- **[x] ① 根因修复** — 主窗口只在 `WA_ACTIVE/WA_CLICKACTIVE` 且 Flutter 子 HWND 仍存活、仍属于当前主 HWND 时恢复焦点；查词弹窗接管激活以拖动/缩放时，主窗口不再反向抢焦点。`Win32Window::Destroy()` 在 controller teardown 前清空借用的 child HWND，避免 Windows 复用句柄后误聚焦另一窗口。
+- **[x] ② 已加自动化测试** — `hibiki/windows/runner/tests/window_activation_policy_test.cpp` 可执行覆盖失活、正常点击/激活、`WM_ACTIVATE` 高低字边界、子窗销毁与 HWND 复用；`hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart` 同时守住生产接线、句柄存活/归属检查与销毁清理。
+- **备注**：原生策略测试以 MSVC `/W4 /WX` 编译并通过；定向 Flutter 静态守卫 9/9 通过，`flutter analyze --no-pub` 通过（No issues found）。测试期间仅临时指定本机 system SQLite，以绕开预编译库下载的 Windows socket 121 超时，未写入产品配置。按用户要求未等待完整 Windows 编译/真机验收。

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1200
+version: 1.3.1+1201
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart
+++ b/hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart
@@ -120,6 +120,38 @@ void main() {
     );
   });
 
+  test('main window does not reclaim focus when a lookup popup activates', () {
+    final String runner = read('windows/runner/win32_window.cpp');
+    final String handler = methodBody(
+      runner,
+      'Win32Window::MessageHandler(',
+    );
+    final String activateCase = maskComments(
+      switchCaseBody(
+        handler,
+        'case WM_ACTIVATE:',
+        nextLabels: const <String>['case WM_DISPLAYCHANGE:'],
+      ),
+    );
+
+    expect(
+      RegExp(
+        r'if\s*\(\s*LOWORD\(wparam\)\s*!=\s*WA_INACTIVE\s*&&\s*'
+        r'child_content_\s*!=\s*nullptr\s*\)\s*\{\s*'
+        r'SetFocus\(child_content_\);',
+      ).hasMatch(activateCase),
+      isTrue,
+      reason: 'The lookup panel drag/resize activates an auxiliary Hibiki '
+          'window. The main window must ignore its WA_INACTIVE notification '
+          'instead of reclaiming focus and jumping to the foreground.',
+    );
+    expect(
+      'SetFocus(child_content_);'.allMatches(activateCase).length,
+      1,
+      reason: 'Keep main-window focus restoration behind the activation guard.',
+    );
+  });
+
   test(
       'floating lyric window stays noactivate/shownoactivate; only the '
       'clipboard text window opts into the taskbar', () {

--- a/hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart
+++ b/hibiki/test/sync/desktop_lookup_foreground_guard_static_test.dart
@@ -126,7 +126,7 @@ void main() {
       runner,
       'Win32Window::MessageHandler(',
     );
-    final String activateCase = maskComments(
+    final String activateCase = maskCommentsAndStrings(
       switchCaseBody(
         handler,
         'case WM_ACTIVATE:',
@@ -135,11 +135,7 @@ void main() {
     );
 
     expect(
-      RegExp(
-        r'if\s*\(\s*LOWORD\(wparam\)\s*!=\s*WA_INACTIVE\s*&&\s*'
-        r'child_content_\s*!=\s*nullptr\s*\)\s*\{\s*'
-        r'SetFocus\(child_content_\);',
-      ).hasMatch(activateCase),
+      activateCase.contains('ShouldRestoreChildFocus('),
       isTrue,
       reason: 'The lookup panel drag/resize activates an auxiliary Hibiki '
           'window. The main window must ignore its WA_INACTIVE notification '
@@ -149,6 +145,24 @@ void main() {
       'SetFocus(child_content_);'.allMatches(activateCase).length,
       1,
       reason: 'Keep main-window focus restoration behind the activation guard.',
+    );
+    expect(activateCase.contains('IsWindow(child_content_)'), isTrue,
+        reason: 'A destroyed Flutter child HWND must not receive focus.');
+    expect(
+      activateCase.contains('GetParent(child_content_) == hwnd'),
+      isTrue,
+      reason: 'HWND values are recycled; the live child must still belong to '
+          'this exact main window.',
+    );
+
+    final String destroyBody = maskCommentsAndStrings(
+      methodBody(runner, 'void Win32Window::Destroy()'),
+    );
+    expect(
+      destroyBody.contains('child_content_ = nullptr;'),
+      isTrue,
+      reason: 'Destroy must clear the borrowed Flutter child handle before '
+          'subclass/controller teardown can dispatch reentrant messages.',
     );
   });
 

--- a/hibiki/windows/runner/CMakeLists.txt
+++ b/hibiki/windows/runner/CMakeLists.txt
@@ -124,6 +124,24 @@ add_custom_target(hibiki_windows_ime_association_gate
 )
 add_dependencies(${BINARY_NAME} hibiki_windows_ime_association_gate)
 
+# BUG-1455: compile and execute the WM_ACTIVATE focus policy on every Windows
+# runner build. This guards both sides of the contract: popup drag deactivation
+# must not raise the main window, while ordinary main-window click/activation
+# must still restore focus to the live Flutter child. HWND ownership cases cover
+# view teardown/recreation and Windows handle reuse.
+add_executable(hibiki_windows_activation_policy_test
+  "tests/window_activation_policy_test.cpp"
+)
+apply_standard_settings(hibiki_windows_activation_policy_test)
+target_compile_definitions(hibiki_windows_activation_policy_test PRIVATE
+  "NOMINMAX")
+add_custom_target(hibiki_windows_activation_policy_gate
+  COMMAND "$<TARGET_FILE:hibiki_windows_activation_policy_test>"
+  DEPENDS hibiki_windows_activation_policy_test
+  VERBATIM
+)
+add_dependencies(${BINARY_NAME} hibiki_windows_activation_policy_gate)
+
 add_executable(hibiki_update_launcher WIN32
   "update_launcher.cpp"
 )

--- a/hibiki/windows/runner/tests/window_activation_policy_test.cpp
+++ b/hibiki/windows/runner/tests/window_activation_policy_test.cpp
@@ -1,0 +1,44 @@
+#include "../window_activation_policy.h"
+
+#include <iostream>
+#include <string>
+
+namespace {
+
+bool Expect(bool condition, const std::string& message) {
+  if (condition) {
+    return true;
+  }
+  std::cerr << "FAIL: " << message << '\n';
+  return false;
+}
+
+}  // namespace
+
+int main() {
+  bool passed = true;
+
+  passed &= Expect(
+      !ShouldRestoreChildFocus(WA_INACTIVE, true, true),
+      "deactivation to an auxiliary popup must not reclaim main focus");
+  passed &= Expect(ShouldRestoreChildFocus(WA_ACTIVE, true, true),
+                   "programmatic main-window activation restores child focus");
+  passed &= Expect(
+      ShouldRestoreChildFocus(WA_CLICKACTIVE, true, true),
+      "normal click activation restores child focus");
+  passed &= Expect(
+      ShouldRestoreChildFocus(MAKEWPARAM(WA_ACTIVE, 1), true, true),
+      "the minimized flag in HIWORD must not corrupt activation decoding");
+  passed &= Expect(!ShouldRestoreChildFocus(WA_ACTIVE, false, false),
+                   "a destroyed child HWND must never receive focus");
+  passed &= Expect(
+      !ShouldRestoreChildFocus(WA_ACTIVE, true, false),
+      "a recycled HWND owned by another window must never receive focus");
+
+  if (!passed) {
+    std::cerr << "window_activation_policy_test FAILED\n";
+    return 1;
+  }
+  std::cout << "window_activation_policy_test passed\n";
+  return 0;
+}

--- a/hibiki/windows/runner/win32_window.cpp
+++ b/hibiki/windows/runner/win32_window.cpp
@@ -1,5 +1,7 @@
 #include "win32_window.h"
 
+#include "window_activation_policy.h"
+
 #include <flutter_windows.h>
 
 #include "resource.h"
@@ -290,8 +292,15 @@ Win32Window::MessageHandler(HWND hwnd,
       // panel) starts its native move/size loop, the main window receives
       // WA_INACTIVE. Restoring focus from that deactivation notification pulls
       // the main window back above the panel and the user's foreground app.
-      // Only repair Flutter child focus when this main window is being activated.
-      if (LOWORD(wparam) != WA_INACTIVE && child_content_ != nullptr) {
+      // A non-null HWND is not sufficient: child views can be destroyed and
+      // Windows recycles handle values. Confirm both liveness and ownership so
+      // a later main-window activation cannot focus an unrelated recycled HWND.
+      const bool child_is_live =
+          child_content_ != nullptr && IsWindow(child_content_);
+      const bool child_belongs_to_window =
+          child_is_live && GetParent(child_content_) == hwnd;
+      if (ShouldRestoreChildFocus(wparam, child_is_live,
+                                  child_belongs_to_window)) {
         SetFocus(child_content_);
       }
       return 0;
@@ -324,6 +333,11 @@ Win32Window::MessageHandler(HWND hwnd,
 }
 
 void Win32Window::Destroy() {
+  // Clear the borrowed Flutter-view handle before subclass teardown. Destroying
+  // the controller can synchronously destroy that child and dispatch more
+  // window messages; retaining it would turn a later HWND reuse into a focus or
+  // resize operation against an unrelated window.
+  child_content_ = nullptr;
   OnDestroy();
 
   // Release the monitor power-on notification registration before the window

--- a/hibiki/windows/runner/win32_window.cpp
+++ b/hibiki/windows/runner/win32_window.cpp
@@ -285,7 +285,13 @@ Win32Window::MessageHandler(HWND hwnd,
     }
 
     case WM_ACTIVATE:
-      if (child_content_ != nullptr) {
+      // WM_ACTIVATE is sent for both sides of an activation hand-off. When an
+      // activatable Hibiki auxiliary window (for example the clipboard lookup
+      // panel) starts its native move/size loop, the main window receives
+      // WA_INACTIVE. Restoring focus from that deactivation notification pulls
+      // the main window back above the panel and the user's foreground app.
+      // Only repair Flutter child focus when this main window is being activated.
+      if (LOWORD(wparam) != WA_INACTIVE && child_content_ != nullptr) {
         SetFocus(child_content_);
       }
       return 0;

--- a/hibiki/windows/runner/window_activation_policy.h
+++ b/hibiki/windows/runner/window_activation_policy.h
@@ -1,0 +1,22 @@
+#ifndef RUNNER_WINDOW_ACTIVATION_POLICY_H_
+#define RUNNER_WINDOW_ACTIVATION_POLICY_H_
+
+#include <windows.h>
+
+// WM_ACTIVATE packs the activation state in LOWORD(wparam) and the minimized
+// bit in HIWORD(wparam). Restore the Flutter view's keyboard focus only while
+// this top-level window is actually becoming active, and only when the cached
+// child HWND is still live and still belongs to this exact parent window.
+//
+// The ownership argument matters because HWND values are recycled: a non-null,
+// live handle can name an unrelated window after a child/view teardown.
+inline bool ShouldRestoreChildFocus(WPARAM activation_wparam,
+                                    bool child_is_live,
+                                    bool child_belongs_to_window) {
+  const WORD activation_state = LOWORD(activation_wparam);
+  const bool becoming_active = activation_state == WA_ACTIVE ||
+                               activation_state == WA_CLICKACTIVE;
+  return becoming_active && child_is_live && child_belongs_to_window;
+}
+
+#endif  // RUNNER_WINDOW_ACTIVATION_POLICY_H_


### PR DESCRIPTION
## 变更

- 主窗口处理 `WM_ACTIVATE` 时，仅在真正激活（非 `WA_INACTIVE`）时恢复 Flutter 子窗口焦点。
- 新增源码守卫，确保 `SetFocus(child_content_)` 始终受失活门控。
- 记录 BUG-1455，并将 build number 从 1197 提升到 1198。

## 根因

查词弹窗拖动或从右下角缩放时，会进入原生 move/size 模态循环并成为活动窗口。Hibiki 主窗口因此收到 `WM_ACTIVATE/WA_INACTIVE`，但旧实现对激活和失活两种通知都调用 `SetFocus(child_content_)`，导致主窗口立即反向抢回焦点并被抬到前台。

## 用户影响

拖动或缩放查词弹窗不再改变 Hibiki 主窗口的前台/Z 序；主窗口正常被用户激活时仍会恢复 Flutter 内容焦点。查词弹窗本身的点击、滚轮、拖动、缩放和置顶设置不变。

## 验证

- `flutter analyze --no-pub`：通过，No issues found。
- `git diff --check`：通过。
- `dart run tool/bug.dart check --strict`：通过，BUG-1455 跨分支/工作区唯一且索引同步。
- `flutter test test/sync/desktop_lookup_foreground_guard_static_test.dart --no-pub`：在任何测试用例执行前被 `pdfium_dart` 下载 `pdfium-win-x64.tgz` 的 Windows socket 121 超时阻断，未记为通过。
- 按用户要求未等待完整 Windows 编译或真机验收。
