### PR TITLE
feat(anki): expose AnkiConnect on Android

### DIFF
--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 53193 (3129 per locale)
+/// Strings: 53227 (3131 per locale)
 ///
-/// Built on 2026-08-02 at 17:23 UTC
+/// Built on 2026-08-02 at 17:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -280,8 +280,6 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get anki_compact_glossaries_hint =>
       'Use compact format for glossary entries';
   String get anki_connect_api_key => 'API Key';
-  String get anki_connect_api_key_hint =>
-      'Leave empty unless AnkiConnect requires a key';
   String get anki_connect_host => 'Host';
   String get anki_connect_port => 'Port';
   String get anki_create_lapis => 'Create Lapis deck';
@@ -4209,7 +4207,13 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -4397,9 +4401,6 @@ class _StringsAr extends _StringsEn {
       'استخدام تنسيق مختصر لإدخالات المعاني';
   @override
   String get anki_connect_api_key => 'مفتاح API';
-  @override
-  String get anki_connect_api_key_hint =>
-      'اتركه فارغًا ما لم يطلب AnkiConnect مفتاحًا';
   @override
   String get anki_connect_host => 'المضيف';
   @override
@@ -11397,7 +11398,16 @@ class _StringsAr extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -11585,9 +11595,6 @@ class _StringsDe extends _StringsEn {
       'Kompaktes Format für Glossareinträge verwenden';
   @override
   String get anki_connect_api_key => 'API-Schlüssel';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Leer lassen, sofern AnkiConnect keinen Schlüssel erfordert';
   @override
   String get anki_connect_host => 'Host';
   @override
@@ -18652,7 +18659,16 @@ class _StringsDe extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -18840,9 +18856,6 @@ class _StringsEs extends _StringsEn {
       'Usar formato compacto para las entradas del glosario';
   @override
   String get anki_connect_api_key => 'Clave de API';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Déjalo vacío salvo que AnkiConnect requiera una clave';
   @override
   String get anki_connect_host => 'Servidor';
   @override
@@ -25922,7 +25935,16 @@ class _StringsEs extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -26110,9 +26132,6 @@ class _StringsFr extends _StringsEn {
       'Utiliser un format compact pour les entrées de glossaire';
   @override
   String get anki_connect_api_key => 'Clé API';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Laisser vide sauf si AnkiConnect requiert une clé';
   @override
   String get anki_connect_host => 'Hôte';
   @override
@@ -33204,7 +33223,16 @@ class _StringsFr extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -33392,9 +33420,6 @@ class _StringsId extends _StringsEn {
       'Gunakan format ringkas untuk entri glosarium';
   @override
   String get anki_connect_api_key => 'Kunci API';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Biarkan kosong kecuali AnkiConnect memerlukan kunci';
   @override
   String get anki_connect_host => 'Host';
   @override
@@ -40415,7 +40440,16 @@ class _StringsId extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -40603,9 +40637,6 @@ class _StringsIt extends _StringsEn {
       'Usa il formato compatto per le voci del glossario';
   @override
   String get anki_connect_api_key => 'Chiave API';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Lascia vuoto a meno che AnkiConnect non richieda una chiave';
   @override
   String get anki_connect_host => 'Host';
   @override
@@ -47672,7 +47703,16 @@ class _StringsIt extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -47858,9 +47898,6 @@ class _StringsJa extends _StringsEn {
   String get anki_compact_glossaries_hint => '釈義をコンパクトな形式で表示';
   @override
   String get anki_connect_api_key => 'APIキー';
-  @override
-  String get anki_connect_api_key_hint =>
-      'AnkiConnectがキーを必要とする場合以外は空欄のままにしてください';
   @override
   String get anki_connect_host => 'ホスト';
   @override
@@ -54746,7 +54783,16 @@ class _StringsJa extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -54932,8 +54978,6 @@ class _StringsKo extends _StringsEn {
   String get anki_compact_glossaries_hint => '용어 해설 항목에 간결한 형식을 사용합니다';
   @override
   String get anki_connect_api_key => 'API 키';
-  @override
-  String get anki_connect_api_key_hint => 'AnkiConnect에 키가 필요하지 않으면 비워 두세요';
   @override
   String get anki_connect_host => '호스트';
   @override
@@ -61822,7 +61866,16 @@ class _StringsKo extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -62010,9 +62063,6 @@ class _StringsNl extends _StringsEn {
       'Compact formaat gebruiken voor woordenlijstvermeldingen';
   @override
   String get anki_connect_api_key => 'API-sleutel';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Laat leeg tenzij AnkiConnect een sleutel vereist';
   @override
   String get anki_connect_host => 'Host';
   @override
@@ -69059,7 +69109,16 @@ class _StringsNl extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -69247,9 +69306,6 @@ class _StringsPtBr extends _StringsEn {
       'Usar formato compacto para entradas do glossário';
   @override
   String get anki_connect_api_key => 'Chave de API';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Deixe em branco, a menos que o AnkiConnect exija uma chave';
   @override
   String get anki_connect_host => 'Host';
   @override
@@ -76309,7 +76365,16 @@ class _StringsPtBr extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -76497,9 +76562,6 @@ class _StringsRu extends _StringsEn {
       'Использовать компактный формат для записей глоссария';
   @override
   String get anki_connect_api_key => 'Ключ API';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Оставьте пустым, если AnkiConnect не требует ключ';
   @override
   String get anki_connect_host => 'Хост';
   @override
@@ -83543,7 +83605,16 @@ class _StringsRu extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -83730,9 +83801,6 @@ class _StringsTh extends _StringsEn {
       'ใช้รูปแบบกะทัดรัดสำหรับรายการอภิธานศัพท์';
   @override
   String get anki_connect_api_key => 'API Key';
-  @override
-  String get anki_connect_api_key_hint =>
-      'ปล่อยว่างไว้ เว้นแต่ AnkiConnect ต้องใช้คีย์';
   @override
   String get anki_connect_host => 'โฮสต์';
   @override
@@ -90725,7 +90793,16 @@ class _StringsTh extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -90913,9 +90990,6 @@ class _StringsTr extends _StringsEn {
       'Sözlükçe girişleri için kompakt biçim kullan';
   @override
   String get anki_connect_api_key => 'API Anahtarı';
-  @override
-  String get anki_connect_api_key_hint =>
-      'AnkiConnect bir anahtar gerektirmediği sürece boş bırakın';
   @override
   String get anki_connect_host => 'Sunucu';
   @override
@@ -97939,7 +98013,16 @@ class _StringsTr extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -98127,9 +98210,6 @@ class _StringsVi extends _StringsEn {
       'Dùng định dạng thu gọn cho các mục giải nghĩa';
   @override
   String get anki_connect_api_key => 'API Key';
-  @override
-  String get anki_connect_api_key_hint =>
-      'Để trống trừ khi AnkiConnect yêu cầu khóa';
   @override
   String get anki_connect_host => 'Máy chủ';
   @override
@@ -105138,7 +105218,16 @@ class _StringsVi extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 // Path: <root>
@@ -105314,8 +105403,6 @@ class _StringsZhCn extends _StringsEn {
   String get anki_compact_glossaries_hint => '使用紧凑格式显示释义';
   @override
   String get anki_connect_api_key => 'API 密钥';
-  @override
-  String get anki_connect_api_key_hint => '若 AnkiConnect 未设置密钥则留空';
   @override
   String get anki_connect_host => '主机';
   @override
@@ -111832,7 +111919,15 @@ class _StringsZhCn extends _StringsEn {
   String get anki_connect_use_on_android => '在 Android 上使用 AnkiConnect';
   @override
   String get anki_connect_use_on_android_hint =>
-      '连接下方主机和端口，而非 AnkiDroid；默认仍使用 AnkiDroid。';
+      '仅在可信网络中使用。AnkiConnect 使用明文 HTTP；请配置匹配的 API key，切换后再刷新牌组与笔记类型。';
+  @override
+  String get anki_connect_api_key_hint => '远程 AnkiConnect 必填；必须与插件中配置的 key 一致';
+  @override
+  String get anki_connect_android_api_key_required =>
+      '请先配置匹配的 AnkiConnect API key，再启用 Android 后端。';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      '无法切换 Anki 后端：${error}';
 }
 
 // Path: <root>
@@ -112018,8 +112113,6 @@ class _StringsZhHk extends _StringsEn {
   String get anki_compact_glossaries_hint => '使用精簡格式顯示釋義';
   @override
   String get anki_connect_api_key => 'API 金鑰';
-  @override
-  String get anki_connect_api_key_hint => '除非 AnkiConnect 需要金鑰，否則留空';
   @override
   String get anki_connect_host => '主機';
   @override
@@ -118827,7 +118920,16 @@ class _StringsZhHk extends _StringsEn {
   String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
   @override
   String get anki_connect_use_on_android_hint =>
-      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+      'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+  @override
+  String get anki_connect_api_key_hint =>
+      'Required for remote AnkiConnect; must match the key configured in the add-on';
+  @override
+  String get anki_connect_android_api_key_required =>
+      'Configure a matching AnkiConnect API key before enabling the Android backend.';
+  @override
+  String anki_connect_backend_switch_failed({required Object error}) =>
+      'Could not switch Anki backend: ${error}';
 }
 
 /// Flat map(s) containing all translations.
@@ -118971,8 +119073,6 @@ extension on _StringsEn {
         return 'Use compact format for glossary entries';
       case 'anki_connect_api_key':
         return 'API Key';
-      case 'anki_connect_api_key_hint':
-        return 'Leave empty unless AnkiConnect requires a key';
       case 'anki_connect_host':
         return 'Host';
       case 'anki_connect_port':
@@ -125245,7 +125345,14 @@ extension on _StringsEn {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -125390,8 +125497,6 @@ extension on _StringsAr {
         return 'استخدام تنسيق مختصر لإدخالات المعاني';
       case 'anki_connect_api_key':
         return 'مفتاح API';
-      case 'anki_connect_api_key_hint':
-        return 'اتركه فارغًا ما لم يطلب AnkiConnect مفتاحًا';
       case 'anki_connect_host':
         return 'المضيف';
       case 'anki_connect_port':
@@ -131661,7 +131766,14 @@ extension on _StringsAr {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -131806,8 +131918,6 @@ extension on _StringsDe {
         return 'Kompaktes Format für Glossareinträge verwenden';
       case 'anki_connect_api_key':
         return 'API-Schlüssel';
-      case 'anki_connect_api_key_hint':
-        return 'Leer lassen, sofern AnkiConnect keinen Schlüssel erfordert';
       case 'anki_connect_host':
         return 'Host';
       case 'anki_connect_port':
@@ -138099,7 +138209,14 @@ extension on _StringsDe {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -138244,8 +138361,6 @@ extension on _StringsEs {
         return 'Usar formato compacto para las entradas del glosario';
       case 'anki_connect_api_key':
         return 'Clave de API';
-      case 'anki_connect_api_key_hint':
-        return 'Déjalo vacío salvo que AnkiConnect requiera una clave';
       case 'anki_connect_host':
         return 'Servidor';
       case 'anki_connect_port':
@@ -144536,7 +144651,14 @@ extension on _StringsEs {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -144681,8 +144803,6 @@ extension on _StringsFr {
         return 'Utiliser un format compact pour les entrées de glossaire';
       case 'anki_connect_api_key':
         return 'Clé API';
-      case 'anki_connect_api_key_hint':
-        return 'Laisser vide sauf si AnkiConnect requiert une clé';
       case 'anki_connect_host':
         return 'Hôte';
       case 'anki_connect_port':
@@ -150979,7 +151099,14 @@ extension on _StringsFr {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -151124,8 +151251,6 @@ extension on _StringsId {
         return 'Gunakan format ringkas untuk entri glosarium';
       case 'anki_connect_api_key':
         return 'Kunci API';
-      case 'anki_connect_api_key_hint':
-        return 'Biarkan kosong kecuali AnkiConnect memerlukan kunci';
       case 'anki_connect_host':
         return 'Host';
       case 'anki_connect_port':
@@ -157404,7 +157529,14 @@ extension on _StringsId {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -157549,8 +157681,6 @@ extension on _StringsIt {
         return 'Usa il formato compatto per le voci del glossario';
       case 'anki_connect_api_key':
         return 'Chiave API';
-      case 'anki_connect_api_key_hint':
-        return 'Lascia vuoto a meno che AnkiConnect non richieda una chiave';
       case 'anki_connect_host':
         return 'Host';
       case 'anki_connect_port':
@@ -163843,7 +163973,14 @@ extension on _StringsIt {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -163988,8 +164125,6 @@ extension on _StringsJa {
         return '釈義をコンパクトな形式で表示';
       case 'anki_connect_api_key':
         return 'APIキー';
-      case 'anki_connect_api_key_hint':
-        return 'AnkiConnectがキーを必要とする場合以外は空欄のままにしてください';
       case 'anki_connect_host':
         return 'ホスト';
       case 'anki_connect_port':
@@ -170244,7 +170379,14 @@ extension on _StringsJa {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -170389,8 +170531,6 @@ extension on _StringsKo {
         return '용어 해설 항목에 간결한 형식을 사용합니다';
       case 'anki_connect_api_key':
         return 'API 키';
-      case 'anki_connect_api_key_hint':
-        return 'AnkiConnect에 키가 필요하지 않으면 비워 두세요';
       case 'anki_connect_host':
         return '호스트';
       case 'anki_connect_port':
@@ -176649,7 +176789,14 @@ extension on _StringsKo {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -176794,8 +176941,6 @@ extension on _StringsNl {
         return 'Compact formaat gebruiken voor woordenlijstvermeldingen';
       case 'anki_connect_api_key':
         return 'API-sleutel';
-      case 'anki_connect_api_key_hint':
-        return 'Laat leeg tenzij AnkiConnect een sleutel vereist';
       case 'anki_connect_host':
         return 'Host';
       case 'anki_connect_port':
@@ -183082,7 +183227,14 @@ extension on _StringsNl {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -183227,8 +183379,6 @@ extension on _StringsPtBr {
         return 'Usar formato compacto para entradas do glossário';
       case 'anki_connect_api_key':
         return 'Chave de API';
-      case 'anki_connect_api_key_hint':
-        return 'Deixe em branco, a menos que o AnkiConnect exija uma chave';
       case 'anki_connect_host':
         return 'Host';
       case 'anki_connect_port':
@@ -189512,7 +189662,14 @@ extension on _StringsPtBr {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -189657,8 +189814,6 @@ extension on _StringsRu {
         return 'Использовать компактный формат для записей глоссария';
       case 'anki_connect_api_key':
         return 'Ключ API';
-      case 'anki_connect_api_key_hint':
-        return 'Оставьте пустым, если AnkiConnect не требует ключ';
       case 'anki_connect_host':
         return 'Хост';
       case 'anki_connect_port':
@@ -195947,7 +196102,14 @@ extension on _StringsRu {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -196092,8 +196254,6 @@ extension on _StringsTh {
         return 'ใช้รูปแบบกะทัดรัดสำหรับรายการอภิธานศัพท์';
       case 'anki_connect_api_key':
         return 'API Key';
-      case 'anki_connect_api_key_hint':
-        return 'ปล่อยว่างไว้ เว้นแต่ AnkiConnect ต้องใช้คีย์';
       case 'anki_connect_host':
         return 'โฮสต์';
       case 'anki_connect_port':
@@ -202365,7 +202525,14 @@ extension on _StringsTh {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -202510,8 +202677,6 @@ extension on _StringsTr {
         return 'Sözlükçe girişleri için kompakt biçim kullan';
       case 'anki_connect_api_key':
         return 'API Anahtarı';
-      case 'anki_connect_api_key_hint':
-        return 'AnkiConnect bir anahtar gerektirmediği sürece boş bırakın';
       case 'anki_connect_host':
         return 'Sunucu';
       case 'anki_connect_port':
@@ -208792,7 +208957,14 @@ extension on _StringsTr {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -208937,8 +209109,6 @@ extension on _StringsVi {
         return 'Dùng định dạng thu gọn cho các mục giải nghĩa';
       case 'anki_connect_api_key':
         return 'API Key';
-      case 'anki_connect_api_key_hint':
-        return 'Để trống trừ khi AnkiConnect yêu cầu khóa';
       case 'anki_connect_host':
         return 'Máy chủ';
       case 'anki_connect_port':
@@ -215215,7 +215385,14 @@ extension on _StringsVi {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }
@@ -215357,8 +215534,6 @@ extension on _StringsZhCn {
         return '使用紧凑格式显示释义';
       case 'anki_connect_api_key':
         return 'API 密钥';
-      case 'anki_connect_api_key_hint':
-        return '若 AnkiConnect 未设置密钥则留空';
       case 'anki_connect_host':
         return '主机';
       case 'anki_connect_port':
@@ -221584,7 +221759,13 @@ extension on _StringsZhCn {
       case 'anki_connect_use_on_android':
         return '在 Android 上使用 AnkiConnect';
       case 'anki_connect_use_on_android_hint':
-        return '连接下方主机和端口，而非 AnkiDroid；默认仍使用 AnkiDroid。';
+        return '仅在可信网络中使用。AnkiConnect 使用明文 HTTP；请配置匹配的 API key，切换后再刷新牌组与笔记类型。';
+      case 'anki_connect_api_key_hint':
+        return '远程 AnkiConnect 必填；必须与插件中配置的 key 一致';
+      case 'anki_connect_android_api_key_required':
+        return '请先配置匹配的 AnkiConnect API key，再启用 Android 后端。';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) => '无法切换 Anki 后端：${error}';
       default:
         return null;
     }
@@ -221729,8 +221910,6 @@ extension on _StringsZhHk {
         return '使用精簡格式顯示釋義';
       case 'anki_connect_api_key':
         return 'API 金鑰';
-      case 'anki_connect_api_key_hint':
-        return '除非 AnkiConnect 需要金鑰，否則留空';
       case 'anki_connect_host':
         return '主機';
       case 'anki_connect_port':
@@ -227980,7 +228159,14 @@ extension on _StringsZhHk {
       case 'anki_connect_use_on_android':
         return 'Use AnkiConnect on Android';
       case 'anki_connect_use_on_android_hint':
-        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
+        return 'Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.';
+      case 'anki_connect_api_key_hint':
+        return 'Required for remote AnkiConnect; must match the key configured in the add-on';
+      case 'anki_connect_android_api_key_required':
+        return 'Configure a matching AnkiConnect API key before enabling the Android backend.';
+      case 'anki_connect_backend_switch_failed':
+        return ({required Object error}) =>
+            'Could not switch Anki backend: ${error}';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -3,7 +3,7 @@
 /// Locales: 17
 /// Strings: 53227 (3131 per locale)
 ///
-/// Built on 2026-08-02 at 17:31 UTC
+/// Built on 2026-08-02 at 17:37 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint

--- a/hibiki/lib/i18n/strings.g.dart
+++ b/hibiki/lib/i18n/strings.g.dart
@@ -1,9 +1,9 @@
 /// Generated file. Do not edit.
 ///
 /// Locales: 17
-/// Strings: 53159 (3127 per locale)
+/// Strings: 53193 (3129 per locale)
 ///
-/// Built on 2026-08-02 at 16:30 UTC
+/// Built on 2026-08-02 at 17:23 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint
@@ -4207,6 +4207,9 @@ class _StringsEn implements BaseTranslations<AppLocale, _StringsEn> {
   String get game_audio_requires_thread =>
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -11390,6 +11393,11 @@ class _StringsAr extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -18640,6 +18648,11 @@ class _StringsDe extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -25905,6 +25918,11 @@ class _StringsEs extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -33182,6 +33200,11 @@ class _StringsFr extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -40388,6 +40411,11 @@ class _StringsId extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -47640,6 +47668,11 @@ class _StringsIt extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -54709,6 +54742,11 @@ class _StringsJa extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -61780,6 +61818,11 @@ class _StringsKo extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -69012,6 +69055,11 @@ class _StringsNl extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -76257,6 +76305,11 @@ class _StringsPtBr extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -83486,6 +83539,11 @@ class _StringsRu extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -90663,6 +90721,11 @@ class _StringsTh extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -97872,6 +97935,11 @@ class _StringsTr extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -105066,6 +105134,11 @@ class _StringsVi extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 // Path: <root>
@@ -111755,6 +111828,11 @@ class _StringsZhCn extends _StringsEn {
   String get game_audio_requires_thread => '音频采集源可能已经就绪，但选择线程并收到台词之前，不存在本句音频。';
   @override
   String get game_session_waiting_thread => '等待选择台词线程';
+  @override
+  String get anki_connect_use_on_android => '在 Android 上使用 AnkiConnect';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      '连接下方主机和端口，而非 AnkiDroid；默认仍使用 AnkiDroid。';
 }
 
 // Path: <root>
@@ -118745,6 +118823,11 @@ class _StringsZhHk extends _StringsEn {
       'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
   @override
   String get game_session_waiting_thread => 'Waiting for a dialogue thread';
+  @override
+  String get anki_connect_use_on_android => 'Use AnkiConnect on Android';
+  @override
+  String get anki_connect_use_on_android_hint =>
+      'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
 }
 
 /// Flat map(s) containing all translations.
@@ -125159,6 +125242,10 @@ extension on _StringsEn {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -131571,6 +131658,10 @@ extension on _StringsAr {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -138005,6 +138096,10 @@ extension on _StringsDe {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -144438,6 +144533,10 @@ extension on _StringsEs {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -150877,6 +150976,10 @@ extension on _StringsFr {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -157298,6 +157401,10 @@ extension on _StringsId {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -163733,6 +163840,10 @@ extension on _StringsIt {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -170130,6 +170241,10 @@ extension on _StringsJa {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -176531,6 +176646,10 @@ extension on _StringsKo {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -182960,6 +183079,10 @@ extension on _StringsNl {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -189386,6 +189509,10 @@ extension on _StringsPtBr {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -195817,6 +195944,10 @@ extension on _StringsRu {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -202231,6 +202362,10 @@ extension on _StringsTh {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -208654,6 +208789,10 @@ extension on _StringsTr {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -215073,6 +215212,10 @@ extension on _StringsVi {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }
@@ -221438,6 +221581,10 @@ extension on _StringsZhCn {
         return '音频采集源可能已经就绪，但选择线程并收到台词之前，不存在本句音频。';
       case 'game_session_waiting_thread':
         return '等待选择台词线程';
+      case 'anki_connect_use_on_android':
+        return '在 Android 上使用 AnkiConnect';
+      case 'anki_connect_use_on_android_hint':
+        return '连接下方主机和端口，而非 AnkiDroid；默认仍使用 AnkiDroid。';
       default:
         return null;
     }
@@ -227830,6 +227977,10 @@ extension on _StringsZhHk {
         return 'The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.';
       case 'game_session_waiting_thread':
         return 'Waiting for a dialogue thread';
+      case 'anki_connect_use_on_android':
+        return 'Use AnkiConnect on Android';
+      case 'anki_connect_use_on_android_hint':
+        return 'Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default.';
       default:
         return null;
     }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings.i18n.json
+++ b/hibiki/lib/i18n/strings.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Compact glossaries",
   "anki_compact_glossaries_hint": "Use compact format for glossary entries",
   "anki_connect_api_key": "API Key",
-  "anki_connect_api_key_hint": "Leave empty unless AnkiConnect requires a key",
   "anki_connect_host": "Host",
   "anki_connect_port": "Port",
   "anki_create_lapis": "Create Lapis deck",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "معاني مختصرة",
   "anki_compact_glossaries_hint": "استخدام تنسيق مختصر لإدخالات المعاني",
   "anki_connect_api_key": "مفتاح API",
-  "anki_connect_api_key_hint": "اتركه فارغًا ما لم يطلب AnkiConnect مفتاحًا",
   "anki_connect_host": "المضيف",
   "anki_connect_port": "المنفذ",
   "anki_create_lapis": "إنشاء مجموعة Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_ar.i18n.json
+++ b/hibiki/lib/i18n/strings_ar.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Kompakte Glossare",
   "anki_compact_glossaries_hint": "Kompaktes Format für Glossareinträge verwenden",
   "anki_connect_api_key": "API-Schlüssel",
-  "anki_connect_api_key_hint": "Leer lassen, sofern AnkiConnect keinen Schlüssel erfordert",
   "anki_connect_host": "Host",
   "anki_connect_port": "Port",
   "anki_create_lapis": "Lapis-Stapel erstellen",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_de.i18n.json
+++ b/hibiki/lib/i18n/strings_de.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_es.i18n.json
+++ b/hibiki/lib/i18n/strings_es.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Glosarios compactos",
   "anki_compact_glossaries_hint": "Usar formato compacto para las entradas del glosario",
   "anki_connect_api_key": "Clave de API",
-  "anki_connect_api_key_hint": "Déjalo vacío salvo que AnkiConnect requiera una clave",
   "anki_connect_host": "Servidor",
   "anki_connect_port": "Puerto",
   "anki_create_lapis": "Crear mazo Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_fr.i18n.json
+++ b/hibiki/lib/i18n/strings_fr.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Glossaires compacts",
   "anki_compact_glossaries_hint": "Utiliser un format compact pour les entrées de glossaire",
   "anki_connect_api_key": "Clé API",
-  "anki_connect_api_key_hint": "Laisser vide sauf si AnkiConnect requiert une clé",
   "anki_connect_host": "Hôte",
   "anki_connect_port": "Port",
   "anki_create_lapis": "Créer un paquet Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_id.i18n.json
+++ b/hibiki/lib/i18n/strings_id.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Glosarium Ringkas",
   "anki_compact_glossaries_hint": "Gunakan format ringkas untuk entri glosarium",
   "anki_connect_api_key": "Kunci API",
-  "anki_connect_api_key_hint": "Biarkan kosong kecuali AnkiConnect memerlukan kunci",
   "anki_connect_host": "Host",
   "anki_connect_port": "Port",
   "anki_create_lapis": "Buat dek Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_it.i18n.json
+++ b/hibiki/lib/i18n/strings_it.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Glossari compatti",
   "anki_compact_glossaries_hint": "Usa il formato compatto per le voci del glossario",
   "anki_connect_api_key": "Chiave API",
-  "anki_connect_api_key_hint": "Lascia vuoto a meno che AnkiConnect non richieda una chiave",
   "anki_connect_host": "Host",
   "anki_connect_port": "Porta",
   "anki_create_lapis": "Crea mazzo Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_ja.i18n.json
+++ b/hibiki/lib/i18n/strings_ja.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "コンパクト釈義",
   "anki_compact_glossaries_hint": "釈義をコンパクトな形式で表示",
   "anki_connect_api_key": "APIキー",
-  "anki_connect_api_key_hint": "AnkiConnectがキーを必要とする場合以外は空欄のままにしてください",
   "anki_connect_host": "ホスト",
   "anki_connect_port": "ポート",
   "anki_create_lapis": "Lapis デッキを作成",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "간결한 용어 해설",
   "anki_compact_glossaries_hint": "용어 해설 항목에 간결한 형식을 사용합니다",
   "anki_connect_api_key": "API 키",
-  "anki_connect_api_key_hint": "AnkiConnect에 키가 필요하지 않으면 비워 두세요",
   "anki_connect_host": "호스트",
   "anki_connect_port": "포트",
   "anki_create_lapis": "Lapis 덱 만들기",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_ko.i18n.json
+++ b/hibiki/lib/i18n/strings_ko.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_nl.i18n.json
+++ b/hibiki/lib/i18n/strings_nl.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Compacte woordenlijsten",
   "anki_compact_glossaries_hint": "Compact formaat gebruiken voor woordenlijstvermeldingen",
   "anki_connect_api_key": "API-sleutel",
-  "anki_connect_api_key_hint": "Laat leeg tenzij AnkiConnect een sleutel vereist",
   "anki_connect_host": "Host",
   "anki_connect_port": "Poort",
   "anki_create_lapis": "Lapis-deck maken",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Glossários compactos",
   "anki_compact_glossaries_hint": "Usar formato compacto para entradas do glossário",
   "anki_connect_api_key": "Chave de API",
-  "anki_connect_api_key_hint": "Deixe em branco, a menos que o AnkiConnect exija uma chave",
   "anki_connect_host": "Host",
   "anki_connect_port": "Porta",
   "anki_create_lapis": "Criar baralho Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_pt-BR.i18n.json
+++ b/hibiki/lib/i18n/strings_pt-BR.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_ru.i18n.json
+++ b/hibiki/lib/i18n/strings_ru.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Компактные глоссарии",
   "anki_compact_glossaries_hint": "Использовать компактный формат для записей глоссария",
   "anki_connect_api_key": "Ключ API",
-  "anki_connect_api_key_hint": "Оставьте пустым, если AnkiConnect не требует ключ",
   "anki_connect_host": "Хост",
   "anki_connect_port": "Порт",
   "anki_create_lapis": "Создать колоду Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "อภิธานศัพท์แบบกะทัดรัด",
   "anki_compact_glossaries_hint": "ใช้รูปแบบกะทัดรัดสำหรับรายการอภิธานศัพท์",
   "anki_connect_api_key": "API Key",
-  "anki_connect_api_key_hint": "ปล่อยว่างไว้ เว้นแต่ AnkiConnect ต้องใช้คีย์",
   "anki_connect_host": "โฮสต์",
   "anki_connect_port": "พอร์ต",
   "anki_create_lapis": "สร้างเด็ค Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_th.i18n.json
+++ b/hibiki/lib/i18n/strings_th.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_tr.i18n.json
+++ b/hibiki/lib/i18n/strings_tr.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Kompakt Sözlükçeler",
   "anki_compact_glossaries_hint": "Sözlükçe girişleri için kompakt biçim kullan",
   "anki_connect_api_key": "API Anahtarı",
-  "anki_connect_api_key_hint": "AnkiConnect bir anahtar gerektirmediği sürece boş bırakın",
   "anki_connect_host": "Sunucu",
   "anki_connect_port": "Bağlantı noktası",
   "anki_create_lapis": "Lapis destesi oluştur",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "Giải nghĩa thu gọn",
   "anki_compact_glossaries_hint": "Dùng định dạng thu gọn cho các mục giải nghĩa",
   "anki_connect_api_key": "API Key",
-  "anki_connect_api_key_hint": "Để trống trừ khi AnkiConnect yêu cầu khóa",
   "anki_connect_host": "Máy chủ",
   "anki_connect_port": "Cổng",
   "anki_create_lapis": "Tạo bộ thẻ Lapis",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_vi.i18n.json
+++ b/hibiki/lib/i18n/strings_vi.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "紧凑释义",
   "anki_compact_glossaries_hint": "使用紧凑格式显示释义",
   "anki_connect_api_key": "API 密钥",
-  "anki_connect_api_key_hint": "若 AnkiConnect 未设置密钥则留空",
   "anki_connect_host": "主机",
   "anki_connect_port": "端口",
   "anki_create_lapis": "创建 Lapis 卡组",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "音频采集源可能已经就绪，但选择线程并收到台词之前，不存在本句音频。",
   "game_session_waiting_thread": "等待选择台词线程",
   "anki_connect_use_on_android": "在 Android 上使用 AnkiConnect",
-  "anki_connect_use_on_android_hint": "连接下方主机和端口，而非 AnkiDroid；默认仍使用 AnkiDroid。"
+  "anki_connect_use_on_android_hint": "仅在可信网络中使用。AnkiConnect 使用明文 HTTP；请配置匹配的 API key，切换后再刷新牌组与笔记类型。",
+  "anki_connect_api_key_hint": "远程 AnkiConnect 必填；必须与插件中配置的 key 一致",
+  "anki_connect_android_api_key_required": "请先配置匹配的 AnkiConnect API key，再启用 Android 后端。",
+  "anki_connect_backend_switch_failed": "无法切换 Anki 后端：$error"
 }

--- a/hibiki/lib/i18n/strings_zh-CN.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-CN.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "完成捕获设置",
   "game_capture_setup_hint": "请先选择台词线程。Hibiki 只能把音频与所选线程收到的台词配对。",
   "game_audio_requires_thread": "音频采集源可能已经就绪，但选择线程并收到台词之前，不存在本句音频。",
-  "game_session_waiting_thread": "等待选择台词线程"
+  "game_session_waiting_thread": "等待选择台词线程",
+  "anki_connect_use_on_android": "在 Android 上使用 AnkiConnect",
+  "anki_connect_use_on_android_hint": "连接下方主机和端口，而非 AnkiDroid；默认仍使用 AnkiDroid。"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -65,7 +65,6 @@
   "anki_compact_glossaries": "精簡釋義",
   "anki_compact_glossaries_hint": "使用精簡格式顯示釋義",
   "anki_connect_api_key": "API 金鑰",
-  "anki_connect_api_key_hint": "除非 AnkiConnect 需要金鑰，否則留空",
   "anki_connect_host": "主機",
   "anki_connect_port": "連接埠",
   "anki_create_lapis": "建立 Lapis 卡組",
@@ -3127,5 +3126,8 @@
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
   "game_session_waiting_thread": "Waiting for a dialogue thread",
   "anki_connect_use_on_android": "Use AnkiConnect on Android",
-  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
+  "anki_connect_use_on_android_hint": "Use only on a trusted network. AnkiConnect uses cleartext HTTP; configure a matching API key, then refresh decks and note types after switching.",
+  "anki_connect_api_key_hint": "Required for remote AnkiConnect; must match the key configured in the add-on",
+  "anki_connect_android_api_key_required": "Configure a matching AnkiConnect API key before enabling the Android backend.",
+  "anki_connect_backend_switch_failed": "Could not switch Anki backend: $error"
 }

--- a/hibiki/lib/i18n/strings_zh-HK.i18n.json
+++ b/hibiki/lib/i18n/strings_zh-HK.i18n.json
@@ -3125,5 +3125,7 @@
   "game_capture_setup_title": "Complete capture setup",
   "game_capture_setup_hint": "Choose the dialogue thread first. Hibiki can only pair audio with lines from the selected thread.",
   "game_audio_requires_thread": "The audio capture source may be ready, but sentence audio does not exist until a thread is selected and a line is received.",
-  "game_session_waiting_thread": "Waiting for a dialogue thread"
+  "game_session_waiting_thread": "Waiting for a dialogue thread",
+  "anki_connect_use_on_android": "Use AnkiConnect on Android",
+  "anki_connect_use_on_android_hint": "Connect to the host and port below instead of AnkiDroid. AnkiDroid remains the default."
 }

--- a/hibiki/lib/src/anki/anki_view_model.dart
+++ b/hibiki/lib/src/anki/anki_view_model.dart
@@ -198,6 +198,13 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
     state = state.copyWith(settings: updated);
   }
 
+  Future<void> updateUseAnkiConnectOnAndroid(bool value) async {
+    final updated = await _repository.updateSettings(
+      (s) => s.copyWith(useAnkiConnectOnAndroid: value),
+    );
+    state = state.copyWith(settings: updated);
+  }
+
   Future<LapisSetupResult> createLapisSetup() async {
     state = state.copyWith(isFetching: true, clearError: true);
     try {

--- a/hibiki/lib/src/anki/anki_view_model.dart
+++ b/hibiki/lib/src/anki/anki_view_model.dart
@@ -179,6 +179,7 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
         ankiConnectHost: endpoint.host,
         // 仅当输入里带了合法端口才覆盖，否则保留用户在端口字段里的既有值。
         ankiConnectPort: endpoint.port ?? s.ankiConnectPort,
+        ankiConnectUseHttps: endpoint.useHttps ?? s.ankiConnectUseHttps,
       ),
     );
     state = state.copyWith(settings: updated);
@@ -200,7 +201,14 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
 
   Future<void> updateUseAnkiConnectOnAndroid(bool value) async {
     final updated = await _repository.updateSettings(
-      (s) => s.copyWith(useAnkiConnectOnAndroid: value),
+      (s) => s.copyWith(
+        useAnkiConnectOnAndroid: value,
+        clearSelectedDeck: true,
+        clearSelectedNoteType: true,
+        availableDecks: const <AnkiDeck>[],
+        availableNoteTypes: const <AnkiNoteType>[],
+        fieldMappings: const <String, String>{},
+      ),
     );
     state = state.copyWith(settings: updated);
   }
@@ -307,21 +315,31 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
   }
 }
 
-/// 把用户敲/粘进 AnkiConnect **主机**字段的自由文本规范化成裸主机 + 可选端口。
+/// 把用户敲/粘进 AnkiConnect **主机**字段的自由文本规范化成裸主机、可选端口与协议。
 ///
-/// AnkiConnect 恒在 `http://host:port` 的根路径，所以 `http://192.168.1.5:48765/`
-/// 之类的完整 URL（或手敲的 `http://host`）不能被拒绝——剥掉 scheme、path/query/
+/// AnkiConnect 使用 HTTP(S) 根路径，所以 `https://anki.example:48765/`
+/// 之类的完整 URL不能被拒绝——保留 HTTP/HTTPS 语义，剥掉 scheme、path/query/
 /// fragment 与 userinfo，并把尾部的数字 `:port` 拆出来交给独立端口字段（留在主机里
 /// 会让 `Uri.parse('http://$host:$port')` 变成 `host:port:port` 破坏请求）。主机原样
 /// 保留（不小写化、不做 IDNA punycode），用户看到的就是自己敲的值。返回的 [port] 仅在
 /// 输入携带 1..65535 合法端口时非 null；非数字尾部（如错误的 IPv6/笔误）原样保留，
 /// 尽力而为不擅自篡改。
 @visibleForTesting
-({String host, int? port}) normalizeAnkiConnectHostInput(String raw) {
+({String host, int? port, bool? useHttps}) normalizeAnkiConnectHostInput(
+  String raw,
+) {
   var s = raw.trim();
-  // 剥掉开头的 "scheme://"。
+  bool? useHttps;
+  // 只接受并保留明确的 HTTP(S) scheme；其它 scheme 不能被静默降级。
   final schemeSep = s.indexOf('://');
-  if (schemeSep >= 0) s = s.substring(schemeSep + 3);
+  if (schemeSep >= 0) {
+    final String scheme = s.substring(0, schemeSep).toLowerCase();
+    if (scheme != 'http' && scheme != 'https') {
+      return (host: '', port: null, useHttps: null);
+    }
+    useHttps = scheme == 'https';
+    s = s.substring(schemeSep + 3);
+  }
   // 在第一个 path / query / fragment 分隔符处截断。
   for (final sep in const ['/', '?', '#']) {
     final cut = s.indexOf(sep);
@@ -346,7 +364,7 @@ class AnkiViewModel extends StateNotifier<AnkiUiState> {
       }
     }
   }
-  return (host: s.trim(), port: port);
+  return (host: s.trim(), port: port, useHttps: useHttps);
 }
 
 enum LapisSetupOutcome { created, alreadyExisted, failed }

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -14,6 +14,7 @@ import 'package:hibiki/src/anki/lapis_template_service.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart'
     show MiningAnimatedFormat, VideoMiningImageMode;
 import 'package:hibiki/src/platform/platform_providers.dart';
+import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki/src/profile/profile_selector.dart';
 
 /// Anki 设置正文（无脚手架）。直接平铺进「制卡」设置 destination 详情页
@@ -49,6 +50,10 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
 
   /// 媒体去重在途标记（扫描/执行互斥防重入）。
   bool _dedupBusy = false;
+
+  /// Android 后端切换包含持久化与 provider 换代，必须串行，避免快速往返点击
+  /// 以 Future 完成顺序覆盖最后一次手势。
+  bool _ankiBackendBusy = false;
 
   @override
   Widget build(BuildContext context) {
@@ -90,7 +95,10 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
                 title: t.anki_connect_use_on_android,
                 subtitle: t.anki_connect_use_on_android_hint,
                 value: settings.useAnkiConnectOnAndroid,
-                onChanged: (bool value) => _updateAndroidAnkiBackend(vm, value),
+                onChanged: _ankiBackendBusy || uiState.isFetching
+                    ? null
+                    : (bool value) =>
+                        _updateAndroidAnkiBackend(vm, settings, value),
               ),
             _AnkiConnectionField(
               label: t.anki_connect_host,
@@ -109,6 +117,7 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
               label: t.anki_connect_api_key,
               value: settings.ankiConnectApiKey,
               hint: t.anki_connect_api_key_hint,
+              obscureText: true,
               onChanged: vm.updateAnkiConnectApiKey,
             ),
           ],
@@ -573,16 +582,46 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
 
   Future<void> _updateAndroidAnkiBackend(
     AnkiViewModel vm,
+    AnkiSettings settings,
     bool useAnkiConnect,
   ) async {
-    await vm.updateUseAnkiConnectOnAndroid(useAnkiConnect);
-    ref
-        .read(platformServicesProvider)
-        .setUseAnkiConnectOnAndroid(useAnkiConnect);
-    // Every mining entry point creates its repository through PlatformServices.
-    // Rebuild the settings repository immediately as well so capability-gated
-    // sections (Lapis/media maintenance) and Refresh use the selected backend.
-    ref.invalidate(ankiRepositoryProvider);
+    if (_ankiBackendBusy) return;
+    if (useAnkiConnect && settings.ankiConnectApiKey.trim().isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(t.anki_connect_android_api_key_required)),
+      );
+      return;
+    }
+    final PlatformServices platformServices =
+        ref.read(platformServicesProvider);
+    final ProviderContainer container = ProviderScope.containerOf(
+      context,
+      listen: false,
+    );
+    setState(() => _ankiBackendBusy = true);
+    try {
+      await vm.updateUseAnkiConnectOnAndroid(useAnkiConnect);
+      platformServices.setUseAnkiConnectOnAndroid(
+        useAnkiConnect,
+        apiKey: settings.ankiConnectApiKey,
+      );
+      // Every mining entry point creates its repository through PlatformServices.
+      // Rebuild the settings repository immediately as well. Switching clears
+      // deck/model data so the target backend cannot consume the previous
+      // backend's synthetic ids; Refresh must repopulate it before mining.
+      container.invalidate(ankiRepositoryProvider);
+    } catch (error) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content:
+                Text(t.anki_connect_backend_switch_failed(error: '$error')),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _ankiBackendBusy = false);
+    }
   }
 
   Widget _buildCreateLapisTile(AnkiUiState uiState, AnkiViewModel vm) {
@@ -1119,6 +1158,7 @@ class _AnkiConnectionField extends StatefulWidget {
     required this.hint,
     required this.onChanged,
     this.keyboardType = TextInputType.text,
+    this.obscureText = false,
   });
 
   final String label;
@@ -1126,6 +1166,7 @@ class _AnkiConnectionField extends StatefulWidget {
   final String hint;
   final ValueChanged<String> onChanged;
   final TextInputType keyboardType;
+  final bool obscureText;
 
   @override
   State<_AnkiConnectionField> createState() => _AnkiConnectionFieldState();
@@ -1163,6 +1204,7 @@ class _AnkiConnectionFieldState extends State<_AnkiConnectionField> {
         controller: _controller,
         focusNode: _focusNode,
         keyboardType: widget.keyboardType,
+        obscureText: widget.obscureText,
         hintText: widget.hint,
         onChanged: widget.onChanged,
       ),

--- a/hibiki/lib/src/pages/implementations/anki_settings_page.dart
+++ b/hibiki/lib/src/pages/implementations/anki_settings_page.dart
@@ -13,6 +13,7 @@ import 'package:hibiki/src/anki/anki_view_model.dart';
 import 'package:hibiki/src/anki/lapis_template_service.dart';
 import 'package:hibiki/src/mining/immersion_mining_request.dart'
     show MiningAnimatedFormat, VideoMiningImageMode;
+import 'package:hibiki/src/platform/platform_providers.dart';
 import 'package:hibiki/src/profile/profile_selector.dart';
 
 /// Anki 设置正文（无脚手架）。直接平铺进「制卡」设置 destination 详情页
@@ -76,31 +77,42 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
         // （见 buildInterconnectDestination）。它的前置条件、目标主机、失效条件全部由互联
         // 决定（未启用互联/未配对时只会让制卡失败），留在这里是一个与本页其余 Anki 本地
         // 配置无关、且在互联关闭时纯死的开关。
-        if (!Platform.isAndroid)
-          AdaptiveSettingsSection(
-            title: 'AnkiConnect',
-            children: [
-              _AnkiConnectionField(
-                label: t.anki_connect_host,
-                value: settings.ankiConnectHost,
-                hint: 'localhost',
-                onChanged: vm.updateAnkiConnectHost,
+        AdaptiveSettingsSection(
+          title: 'AnkiConnect',
+          titlePlacement: Platform.isAndroid
+              ? SettingsSectionTitlePlacement.inside
+              : SettingsSectionTitlePlacement.outside,
+          collapsible: Platform.isAndroid,
+          initiallyExpanded: !Platform.isAndroid,
+          children: [
+            if (Platform.isAndroid)
+              AdaptiveSettingsSwitchRow(
+                title: t.anki_connect_use_on_android,
+                subtitle: t.anki_connect_use_on_android_hint,
+                value: settings.useAnkiConnectOnAndroid,
+                onChanged: (bool value) => _updateAndroidAnkiBackend(vm, value),
               ),
-              _AnkiConnectionField(
-                label: t.anki_connect_port,
-                value: settings.ankiConnectPort.toString(),
-                hint: '8765',
-                keyboardType: TextInputType.number,
-                onChanged: vm.updateAnkiConnectPort,
-              ),
-              _AnkiConnectionField(
-                label: t.anki_connect_api_key,
-                value: settings.ankiConnectApiKey,
-                hint: t.anki_connect_api_key_hint,
-                onChanged: vm.updateAnkiConnectApiKey,
-              ),
-            ],
-          ),
+            _AnkiConnectionField(
+              label: t.anki_connect_host,
+              value: settings.ankiConnectHost,
+              hint: 'localhost',
+              onChanged: vm.updateAnkiConnectHost,
+            ),
+            _AnkiConnectionField(
+              label: t.anki_connect_port,
+              value: settings.ankiConnectPort.toString(),
+              hint: '8765',
+              keyboardType: TextInputType.number,
+              onChanged: vm.updateAnkiConnectPort,
+            ),
+            _AnkiConnectionField(
+              label: t.anki_connect_api_key,
+              value: settings.ankiConnectApiKey,
+              hint: t.anki_connect_api_key_hint,
+              onChanged: vm.updateAnkiConnectApiKey,
+            ),
+          ],
+        ),
         // Lapis 样式客制化：备份 / 恢复 / 字号缩放 / 自定义 CSS / 应用。
         // 仅后端支持读写已存在 note type 时显示（AnkiConnect）；AnkiDroid /
         // AnkiMobile 平台 API 改不了已存在模板（平台边界），整区隐藏。
@@ -557,6 +569,20 @@ class _AnkiSettingsBodyState extends ConsumerState<AnkiSettingsBody> {
           ? null
           : () => vm.fetchConfiguration(),
     );
+  }
+
+  Future<void> _updateAndroidAnkiBackend(
+    AnkiViewModel vm,
+    bool useAnkiConnect,
+  ) async {
+    await vm.updateUseAnkiConnectOnAndroid(useAnkiConnect);
+    ref
+        .read(platformServicesProvider)
+        .setUseAnkiConnectOnAndroid(useAnkiConnect);
+    // Every mining entry point creates its repository through PlatformServices.
+    // Rebuild the settings repository immediately as well so capability-gated
+    // sections (Lapis/media maintenance) and Refresh use the selected backend.
+    ref.invalidate(ankiRepositoryProvider);
   }
 
   Widget _buildCreateLapisTile(AnkiUiState uiState, AnkiViewModel vm) {

--- a/hibiki/lib/src/platform/platform_services.dart
+++ b/hibiki/lib/src/platform/platform_services.dart
@@ -31,7 +31,10 @@ class PlatformServices {
   final PlatformClipboardService clipboard;
   final PlatformPermissionService permission;
   final PlatformDeviceInfoService deviceInfo;
-  final BaseAnkiRepository Function() createAnkiRepository;
+  final BaseAnkiRepository Function() _createDefaultAnkiRepository;
+  final BaseAnkiRepository Function()? _createAndroidAnkiConnectRepository;
+  final bool _isAndroid;
+  bool _useAnkiConnectOnAndroid = false;
 
   /// Typed reference to the Android clipboard impl, when running on Android.
   /// Holding the concrete type here (rather than an `is`/`as` downcast in
@@ -45,9 +48,35 @@ class PlatformServices {
     required this.clipboard,
     required this.permission,
     required this.deviceInfo,
-    required this.createAnkiRepository,
+    required BaseAnkiRepository Function() createAnkiRepository,
+    BaseAnkiRepository Function()? createAndroidAnkiConnectRepository,
+    bool isAndroid = false,
     AndroidClipboardService? androidClipboard,
-  }) : _androidClipboard = androidClipboard;
+  })  : _createDefaultAnkiRepository = createAnkiRepository,
+        _createAndroidAnkiConnectRepository =
+            createAndroidAnkiConnectRepository,
+        _isAndroid = isAndroid,
+        _androidClipboard = androidClipboard,
+        assert(
+          !isAndroid || createAndroidAnkiConnectRepository != null,
+          'Android requires an AnkiConnect repository factory.',
+        );
+
+  /// Creates the active Anki backend. Android keeps AnkiDroid as the upgrade-
+  /// safe default, but may explicitly opt into a reachable AnkiConnect server.
+  BaseAnkiRepository createAnkiRepository() {
+    if (_isAndroid && _useAnkiConnectOnAndroid) {
+      return _createAndroidAnkiConnectRepository!();
+    }
+    return _createDefaultAnkiRepository();
+  }
+
+  bool get useAnkiConnectOnAndroid => _isAndroid && _useAnkiConnectOnAndroid;
+
+  void setUseAnkiConnectOnAndroid(bool value) {
+    if (!_isAndroid) return;
+    _useAnkiConnectOnAndroid = value;
+  }
 
   /// Cross-service wiring that requires async initialisation.
   ///
@@ -55,6 +84,11 @@ class PlatformServices {
   /// after all services are constructed.
   Future<void> init() async {
     await _androidClipboard?.init();
+    if (_isAndroid) {
+      final AnkiSettings settings =
+          await _createDefaultAnkiRepository().loadSettings();
+      _useAnkiConnectOnAndroid = settings.useAnkiConnectOnAndroid;
+    }
   }
 
   /// Constructs the correct service bundle for the current platform.
@@ -70,6 +104,8 @@ class PlatformServices {
         permission: AndroidPermissionService(deviceInfo),
         deviceInfo: deviceInfo,
         createAnkiRepository: AnkiRepository.new,
+        createAndroidAnkiConnectRepository: AnkiConnectRepository.new,
+        isAndroid: true,
         androidClipboard: clipboard,
       );
     }

--- a/hibiki/lib/src/platform/platform_services.dart
+++ b/hibiki/lib/src/platform/platform_services.dart
@@ -73,9 +73,12 @@ class PlatformServices {
 
   bool get useAnkiConnectOnAndroid => _isAndroid && _useAnkiConnectOnAndroid;
 
-  void setUseAnkiConnectOnAndroid(bool value) {
+  void setUseAnkiConnectOnAndroid(
+    bool value, {
+    String apiKey = '',
+  }) {
     if (!_isAndroid) return;
-    _useAnkiConnectOnAndroid = value;
+    _useAnkiConnectOnAndroid = value && apiKey.trim().isNotEmpty;
   }
 
   /// Cross-service wiring that requires async initialisation.
@@ -87,7 +90,16 @@ class PlatformServices {
     if (_isAndroid) {
       final AnkiSettings settings =
           await _createDefaultAnkiRepository().loadSettings();
-      _useAnkiConnectOnAndroid = settings.useAnkiConnectOnAndroid;
+      setUseAnkiConnectOnAndroid(
+        settings.useAnkiConnectOnAndroid,
+        apiKey: settings.ankiConnectApiKey,
+      );
+      if (settings.useAnkiConnectOnAndroid && !_useAnkiConnectOnAndroid) {
+        await _createDefaultAnkiRepository().updateSettings(
+          (AnkiSettings current) =>
+              current.copyWith(useAnkiConnectOnAndroid: false),
+        );
+      }
     }
   }
 

--- a/hibiki/lib/src/profile/profile_keys.dart
+++ b/hibiki/lib/src/profile/profile_keys.dart
@@ -193,6 +193,14 @@ class ProfileKeys {
       duplicateScope: m.containsKey('duplicateScope')
           ? ankiDuplicateScopeFromName(m['duplicateScope'])
           : current.duplicateScope,
+      // Endpoint and API key are device-local connection state, not Profile
+      // content. Applying a Profile must not reset the active backend or its
+      // credentials while PlatformServices still routes to the old value.
+      ankiConnectHost: current.ankiConnectHost,
+      ankiConnectPort: current.ankiConnectPort,
+      ankiConnectApiKey: current.ankiConnectApiKey,
+      ankiConnectUseHttps: current.ankiConnectUseHttps,
+      useAnkiConnectOnAndroid: current.useAnkiConnectOnAndroid,
     );
   }
 

--- a/hibiki/lib/src/profile/profile_view_model.dart
+++ b/hibiki/lib/src/profile/profile_view_model.dart
@@ -2,8 +2,11 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
 
 import 'package:hibiki/src/anki/anki_view_model.dart';
+import 'package:hibiki/src/platform/platform_providers.dart';
+import 'package:hibiki/src/platform/platform_services.dart';
 import 'package:hibiki_core/hibiki_core.dart';
 import 'package:hibiki/src/media/sources/reader_hibiki_source.dart';
 import 'package:hibiki/src/models/app_model.dart';
@@ -312,7 +315,15 @@ final profileViewModelProvider =
   final ProfileDraftCoordinator profileDraftCoordinator =
       ref.watch(profileDraftCoordinatorProvider);
   Future<void> onApplied() async {
-    ref.invalidate(ankiViewModelProvider);
+    final PlatformServices platformServices =
+        ref.read(platformServicesProvider);
+    final AnkiSettings ankiSettings =
+        await ref.read(ankiRepositoryProvider).loadSettings();
+    platformServices.setUseAnkiConnectOnAndroid(
+      ankiSettings.useAnkiConnectOnAndroid,
+      apiKey: ankiSettings.ankiConnectApiKey,
+    );
+    ref.invalidate(ankiRepositoryProvider);
     final appModel = ref.read(appProvider);
     await appModel.refreshPrefCache();
     // TODO-1077: the profile switch replaced the dictionary_metadata table, so

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1202
+version: 1.3.1+1203
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/anki/anki_connect_host_normalize_test.dart
+++ b/hibiki/test/anki/anki_connect_host_normalize_test.dart
@@ -24,6 +24,23 @@ void main() {
       final r = normalizeAnkiConnectHostInput('http://192.168.1.5:48765/foo');
       expect(r.host, '192.168.1.5');
       expect(r.port, 48765);
+      expect(r.useHttps, isFalse);
+    });
+
+    test('https URL 保留安全协议，不静默降级为 HTTP', () {
+      final r = normalizeAnkiConnectHostInput(
+        'https://anki.example.com:443/path',
+      );
+      expect(r.host, 'anki.example.com');
+      expect(r.port, 443);
+      expect(r.useHttps, isTrue);
+    });
+
+    test('非 HTTP(S) scheme 被拒绝', () {
+      final r = normalizeAnkiConnectHostInput('ftp://anki.example.com');
+      expect(r.host, isEmpty);
+      expect(r.port, isNull);
+      expect(r.useHttps, isNull);
     });
 
     test('host:port 拆分到独立端口', () {

--- a/hibiki/test/helpers/fake_platform_services.dart
+++ b/hibiki/test/helpers/fake_platform_services.dart
@@ -102,6 +102,9 @@ PlatformServices fakePlatformServices({
   FakeClipboardService? clipboard,
   FakePermissionService? permission,
   FakeDeviceInfoService? deviceInfo,
+  BaseAnkiRepository Function()? createAnkiRepository,
+  BaseAnkiRepository Function()? createAndroidAnkiConnectRepository,
+  bool isAndroid = false,
 }) {
   return PlatformServices(
     directory: directory ?? FakeDirectoryService(),
@@ -109,6 +112,8 @@ PlatformServices fakePlatformServices({
     clipboard: clipboard ?? FakeClipboardService(),
     permission: permission ?? FakePermissionService(),
     deviceInfo: deviceInfo ?? FakeDeviceInfoService(),
-    createAnkiRepository: AnkiConnectRepository.new,
+    createAnkiRepository: createAnkiRepository ?? AnkiConnectRepository.new,
+    createAndroidAnkiConnectRepository: createAndroidAnkiConnectRepository,
+    isAndroid: isAndroid,
   );
 }

--- a/hibiki/test/platform/android_anki_backend_selection_test.dart
+++ b/hibiki/test/platform/android_anki_backend_selection_test.dart
@@ -33,22 +33,45 @@ void main() {
     expect(source, contains('collapsible: Platform.isAndroid'));
     expect(source, contains('initiallyExpanded: !Platform.isAndroid'));
     expect(source, contains('t.anki_connect_use_on_android'));
+    expect(source, contains('obscureText: true'));
   });
 
-  test('Android can switch to AnkiConnect immediately', () {
+  test('Android can switch to authenticated AnkiConnect immediately', () {
     final services = fakePlatformServices(
       isAndroid: true,
       createAnkiRepository: AnkiRepository.new,
       createAndroidAnkiConnectRepository: AnkiConnectRepository.new,
     );
 
-    services.setUseAnkiConnectOnAndroid(true);
+    services.setUseAnkiConnectOnAndroid(true, apiKey: 'secret');
 
     expect(services.useAnkiConnectOnAndroid, isTrue);
     expect(services.createAnkiRepository(), isA<AnkiConnectRepository>());
   });
 
   test('Android restores the persisted AnkiConnect choice on init', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'hoshi_anki_settings': jsonEncode(
+        const AnkiSettings(
+          useAnkiConnectOnAndroid: true,
+          ankiConnectApiKey: 'secret',
+        ).toJson(),
+      ),
+    });
+    final services = fakePlatformServices(
+      isAndroid: true,
+      createAnkiRepository: AnkiRepository.new,
+      createAndroidAnkiConnectRepository: AnkiConnectRepository.new,
+    );
+
+    await services.init();
+
+    expect(services.useAnkiConnectOnAndroid, isTrue);
+    expect(services.createAnkiRepository(), isA<AnkiConnectRepository>());
+  });
+
+  test('Android fails closed when persisted remote backend has no API key',
+      () async {
     SharedPreferences.setMockInitialValues(<String, Object>{
       'hoshi_anki_settings': jsonEncode(
         const AnkiSettings(useAnkiConnectOnAndroid: true).toJson(),
@@ -62,7 +85,40 @@ void main() {
 
     await services.init();
 
-    expect(services.useAnkiConnectOnAndroid, isTrue);
-    expect(services.createAnkiRepository(), isA<AnkiConnectRepository>());
+    expect(services.useAnkiConnectOnAndroid, isFalse);
+    expect(services.createAnkiRepository(), isA<AnkiRepository>());
+    expect(
+      (await AnkiRepository().loadSettings()).useAnkiConnectOnAndroid,
+      isFalse,
+    );
+  });
+
+  test('backend switch can clear configuration from the previous backend', () {
+    const AnkiSettings configured = AnkiSettings(
+      selectedDeckId: 42,
+      selectedDeckName: 'Old deck',
+      selectedNoteTypeId: 7,
+      selectedNoteTypeName: 'Old model',
+      availableDecks: <AnkiDeck>[AnkiDeck(id: 42, name: 'Old deck')],
+      availableNoteTypes: <AnkiNoteType>[
+        AnkiNoteType(id: 7, name: 'Old model', fields: <String>['Front']),
+      ],
+      fieldMappings: <String, String>{'Front': 'term'},
+    );
+
+    final AnkiSettings cleared = configured.copyWith(
+      clearSelectedDeck: true,
+      clearSelectedNoteType: true,
+      availableDecks: const <AnkiDeck>[],
+      availableNoteTypes: const <AnkiNoteType>[],
+      fieldMappings: const <String, String>{},
+    );
+
+    expect(cleared.selectedDeckId, isNull);
+    expect(cleared.selectedNoteTypeId, isNull);
+    expect(cleared.availableDecks, isEmpty);
+    expect(cleared.availableNoteTypes, isEmpty);
+    expect(cleared.fieldMappings, isEmpty);
+    expect(cleared.isConfigured, isFalse);
   });
 }

--- a/hibiki/test/platform/android_anki_backend_selection_test.dart
+++ b/hibiki/test/platform/android_anki_backend_selection_test.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hibiki_anki/hibiki_anki.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_platform_services.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  test('Android keeps AnkiDroid as the default backend', () {
+    final services = fakePlatformServices(
+      isAndroid: true,
+      createAnkiRepository: AnkiRepository.new,
+      createAndroidAnkiConnectRepository: AnkiConnectRepository.new,
+    );
+
+    expect(services.createAnkiRepository(), isA<AnkiRepository>());
+  });
+
+  test('Android renders AnkiConnect settings collapsed by default', () {
+    final String source = File(
+      'lib/src/pages/implementations/anki_settings_page.dart',
+    ).readAsStringSync();
+
+    expect(source, isNot(contains('if (!Platform.isAndroid)')));
+    expect(source, contains('collapsible: Platform.isAndroid'));
+    expect(source, contains('initiallyExpanded: !Platform.isAndroid'));
+    expect(source, contains('t.anki_connect_use_on_android'));
+  });
+
+  test('Android can switch to AnkiConnect immediately', () {
+    final services = fakePlatformServices(
+      isAndroid: true,
+      createAnkiRepository: AnkiRepository.new,
+      createAndroidAnkiConnectRepository: AnkiConnectRepository.new,
+    );
+
+    services.setUseAnkiConnectOnAndroid(true);
+
+    expect(services.useAnkiConnectOnAndroid, isTrue);
+    expect(services.createAnkiRepository(), isA<AnkiConnectRepository>());
+  });
+
+  test('Android restores the persisted AnkiConnect choice on init', () async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'hoshi_anki_settings': jsonEncode(
+        const AnkiSettings(useAnkiConnectOnAndroid: true).toJson(),
+      ),
+    });
+    final services = fakePlatformServices(
+      isAndroid: true,
+      createAnkiRepository: AnkiRepository.new,
+      createAndroidAnkiConnectRepository: AnkiConnectRepository.new,
+    );
+
+    await services.init();
+
+    expect(services.useAnkiConnectOnAndroid, isTrue);
+    expect(services.createAnkiRepository(), isA<AnkiConnectRepository>());
+  });
+}

--- a/hibiki/test/profile/profile_keys_test.dart
+++ b/hibiki/test/profile/profile_keys_test.dart
@@ -200,6 +200,34 @@ void main() {
 
       expect(result.embedMedia, isTrue);
     });
+
+    test('profile apply preserves device-local AnkiConnect routing and secret',
+        () {
+      const AnkiSettings current = AnkiSettings(
+        ankiConnectHost: '192.168.1.20',
+        ankiConnectPort: 9876,
+        ankiConnectApiKey: 'device-secret',
+        ankiConnectUseHttps: true,
+        useAnkiConnectOnAndroid: true,
+      );
+
+      final AnkiSettings result = ProfileKeys.mapToAnkiSettings(
+        <String, String>{
+          'selectedDeckId': '',
+          'selectedDeckName': '',
+          'selectedNoteTypeId': '',
+          'selectedNoteTypeName': '',
+          'fieldMappings': '{}',
+        },
+        current,
+      );
+
+      expect(result.ankiConnectHost, '192.168.1.20');
+      expect(result.ankiConnectPort, 9876);
+      expect(result.ankiConnectApiKey, 'device-secret');
+      expect(result.ankiConnectUseHttps, isTrue);
+      expect(result.useAnkiConnectOnAndroid, isTrue);
+    });
   });
 
   group('ProfileKeys.isExcludedPref — credentials never enter a snapshot', () {

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -171,6 +171,7 @@ class AnkiSettings {
     this.ankiConnectHost = 'localhost',
     this.ankiConnectPort = 8765,
     this.ankiConnectApiKey = '',
+    this.ankiConnectUseHttps = false,
     this.useAnkiConnectOnAndroid = false,
     this.lapisFontScalePercent = 100,
     this.lapisCustomCss = '',
@@ -212,6 +213,7 @@ class AnkiSettings {
         ankiConnectHost: json['ankiConnectHost'] as String? ?? 'localhost',
         ankiConnectPort: json['ankiConnectPort'] as int? ?? 8765,
         ankiConnectApiKey: json['ankiConnectApiKey'] as String? ?? '',
+        ankiConnectUseHttps: json['ankiConnectUseHttps'] as bool? ?? false,
         useAnkiConnectOnAndroid:
             json['useAnkiConnectOnAndroid'] as bool? ?? false,
         lapisFontScalePercent: json['lapisFontScalePercent'] as int? ?? 100,
@@ -256,6 +258,7 @@ class AnkiSettings {
   final String ankiConnectHost;
   final int ankiConnectPort;
   final String ankiConnectApiKey;
+  final bool ankiConnectUseHttps;
 
   /// Android normally talks to AnkiDroid through its Content Provider. Users
   /// who deliberately run AnkiConnect on another reachable machine can opt in
@@ -334,6 +337,8 @@ class AnkiSettings {
     String? selectedDeckName,
     int? selectedNoteTypeId,
     String? selectedNoteTypeName,
+    bool clearSelectedDeck = false,
+    bool clearSelectedNoteType = false,
     List<AnkiDeck>? availableDecks,
     List<AnkiNoteType>? availableNoteTypes,
     Map<String, String>? fieldMappings,
@@ -348,6 +353,7 @@ class AnkiSettings {
     String? ankiConnectHost,
     int? ankiConnectPort,
     String? ankiConnectApiKey,
+    bool? ankiConnectUseHttps,
     bool? useAnkiConnectOnAndroid,
     int? lapisFontScalePercent,
     String? lapisCustomCss,
@@ -363,10 +369,17 @@ class AnkiSettings {
     bool? mediaDedupAutoDelete,
   }) =>
       AnkiSettings(
-        selectedDeckId: selectedDeckId ?? this.selectedDeckId,
-        selectedDeckName: selectedDeckName ?? this.selectedDeckName,
-        selectedNoteTypeId: selectedNoteTypeId ?? this.selectedNoteTypeId,
-        selectedNoteTypeName: selectedNoteTypeName ?? this.selectedNoteTypeName,
+        selectedDeckId:
+            clearSelectedDeck ? null : (selectedDeckId ?? this.selectedDeckId),
+        selectedDeckName: clearSelectedDeck
+            ? null
+            : (selectedDeckName ?? this.selectedDeckName),
+        selectedNoteTypeId: clearSelectedNoteType
+            ? null
+            : (selectedNoteTypeId ?? this.selectedNoteTypeId),
+        selectedNoteTypeName: clearSelectedNoteType
+            ? null
+            : (selectedNoteTypeName ?? this.selectedNoteTypeName),
         availableDecks: availableDecks ?? this.availableDecks,
         availableNoteTypes: availableNoteTypes ?? this.availableNoteTypes,
         fieldMappings: fieldMappings ?? this.fieldMappings,
@@ -381,6 +394,7 @@ class AnkiSettings {
         ankiConnectHost: ankiConnectHost ?? this.ankiConnectHost,
         ankiConnectPort: ankiConnectPort ?? this.ankiConnectPort,
         ankiConnectApiKey: ankiConnectApiKey ?? this.ankiConnectApiKey,
+        ankiConnectUseHttps: ankiConnectUseHttps ?? this.ankiConnectUseHttps,
         useAnkiConnectOnAndroid:
             useAnkiConnectOnAndroid ?? this.useAnkiConnectOnAndroid,
         lapisFontScalePercent:
@@ -425,6 +439,7 @@ class AnkiSettings {
         'ankiConnectHost': ankiConnectHost,
         'ankiConnectPort': ankiConnectPort,
         'ankiConnectApiKey': ankiConnectApiKey,
+        'ankiConnectUseHttps': ankiConnectUseHttps,
         'useAnkiConnectOnAndroid': useAnkiConnectOnAndroid,
         'lapisFontScalePercent': lapisFontScalePercent,
         'lapisCustomCss': lapisCustomCss,

--- a/packages/hibiki_anki/lib/src/anki_models.dart
+++ b/packages/hibiki_anki/lib/src/anki_models.dart
@@ -171,6 +171,7 @@ class AnkiSettings {
     this.ankiConnectHost = 'localhost',
     this.ankiConnectPort = 8765,
     this.ankiConnectApiKey = '',
+    this.useAnkiConnectOnAndroid = false,
     this.lapisFontScalePercent = 100,
     this.lapisCustomCss = '',
     this.lapisAppliedCssSha,
@@ -211,6 +212,8 @@ class AnkiSettings {
         ankiConnectHost: json['ankiConnectHost'] as String? ?? 'localhost',
         ankiConnectPort: json['ankiConnectPort'] as int? ?? 8765,
         ankiConnectApiKey: json['ankiConnectApiKey'] as String? ?? '',
+        useAnkiConnectOnAndroid:
+            json['useAnkiConnectOnAndroid'] as bool? ?? false,
         lapisFontScalePercent: json['lapisFontScalePercent'] as int? ?? 100,
         lapisCustomCss: json['lapisCustomCss'] as String? ?? '',
         lapisAppliedCssSha: json['lapisAppliedCssSha'] as String?,
@@ -253,6 +256,12 @@ class AnkiSettings {
   final String ankiConnectHost;
   final int ankiConnectPort;
   final String ankiConnectApiKey;
+
+  /// Android normally talks to AnkiDroid through its Content Provider. Users
+  /// who deliberately run AnkiConnect on another reachable machine can opt in
+  /// to the HTTP backend instead. Missing keys stay false so upgrades preserve
+  /// the existing AnkiDroid route.
+  final bool useAnkiConnectOnAndroid;
 
   /// Lapis 卡片字号整体缩放百分比（100 = 原样）。只影响 Hibiki 推送的
   /// styling 用户区段，不写卡片数据。
@@ -339,6 +348,7 @@ class AnkiSettings {
     String? ankiConnectHost,
     int? ankiConnectPort,
     String? ankiConnectApiKey,
+    bool? useAnkiConnectOnAndroid,
     int? lapisFontScalePercent,
     String? lapisCustomCss,
     String? lapisAppliedCssSha,
@@ -371,6 +381,8 @@ class AnkiSettings {
         ankiConnectHost: ankiConnectHost ?? this.ankiConnectHost,
         ankiConnectPort: ankiConnectPort ?? this.ankiConnectPort,
         ankiConnectApiKey: ankiConnectApiKey ?? this.ankiConnectApiKey,
+        useAnkiConnectOnAndroid:
+            useAnkiConnectOnAndroid ?? this.useAnkiConnectOnAndroid,
         lapisFontScalePercent:
             lapisFontScalePercent ?? this.lapisFontScalePercent,
         lapisCustomCss: lapisCustomCss ?? this.lapisCustomCss,
@@ -413,6 +425,7 @@ class AnkiSettings {
         'ankiConnectHost': ankiConnectHost,
         'ankiConnectPort': ankiConnectPort,
         'ankiConnectApiKey': ankiConnectApiKey,
+        'useAnkiConnectOnAndroid': useAnkiConnectOnAndroid,
         'lapisFontScalePercent': lapisFontScalePercent,
         'lapisCustomCss': lapisCustomCss,
         'lapisAppliedCssSha': lapisAppliedCssSha,

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_repository.dart
@@ -487,22 +487,26 @@ class AnkiConnectRepository extends BaseAnkiRepository {
   String _cachedHost = '';
   int _cachedPort = 0;
   String _cachedApiKey = '';
+  bool _cachedUseHttps = false;
 
   AnkiConnectService _serviceForSettings(AnkiSettings settings) {
     if (_fixedService != null) return _fixedService;
     if (_cachedService != null &&
         _cachedHost == settings.ankiConnectHost &&
         _cachedPort == settings.ankiConnectPort &&
-        _cachedApiKey == settings.ankiConnectApiKey) {
+        _cachedApiKey == settings.ankiConnectApiKey &&
+        _cachedUseHttps == settings.ankiConnectUseHttps) {
       return _cachedService!;
     }
     _cachedHost = settings.ankiConnectHost;
     _cachedPort = settings.ankiConnectPort;
     _cachedApiKey = settings.ankiConnectApiKey;
+    _cachedUseHttps = settings.ankiConnectUseHttps;
     _cachedService = AnkiConnectService(
       host: settings.ankiConnectHost,
       port: settings.ankiConnectPort,
       apiKey: settings.ankiConnectApiKey,
+      useHttps: settings.ankiConnectUseHttps,
     );
     return _cachedService!;
   }

--- a/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_service.dart
+++ b/packages/hibiki_anki/lib/src/ankiconnect/ankiconnect_service.dart
@@ -10,6 +10,7 @@ import '../lapis_note_type.dart';
 class AnkiConnectService {
   final String host;
   final int port;
+  final bool useHttps;
 
   /// Whether this endpoint runs on the same machine and can read a local path
   /// passed to AnkiConnect's `storeMediaFile`.
@@ -46,6 +47,7 @@ class AnkiConnectService {
   AnkiConnectService({
     this.host = 'localhost',
     this.port = 8765,
+    this.useHttps = false,
     this.apiKey = '',
     http.Client? client,
     Duration timeout = const Duration(seconds: 10),
@@ -239,7 +241,7 @@ class AnkiConnectService {
 
   Future<http.Response> _post(String body) {
     return _client.post(
-      Uri.parse('http://$host:$port'),
+      Uri.parse('${useHttps ? 'https' : 'http'}://$host:$port'),
       body: body,
       headers: {
         'Content-Type': 'application/json',

--- a/packages/hibiki_anki/lib/src/base_anki_repository.dart
+++ b/packages/hibiki_anki/lib/src/base_anki_repository.dart
@@ -78,7 +78,11 @@ abstract class BaseAnkiRepository {
 
   Future<void> saveSettings(AnkiSettings settings) async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(settingsKey, jsonEncode(settings.toJson()));
+    final bool saved =
+        await prefs.setString(settingsKey, jsonEncode(settings.toJson()));
+    if (!saved) {
+      throw StateError('Failed to persist Anki settings.');
+    }
   }
 
   Future<AnkiSettings> updateSettings(

--- a/packages/hibiki_anki/test/ankiconnect_service_test.dart
+++ b/packages/hibiki_anki/test/ankiconnect_service_test.dart
@@ -70,6 +70,32 @@ void main() {
       expect(url.port, 8765);
     });
 
+    test('preserves an explicitly configured HTTPS endpoint', () async {
+      final issued = <http.Request>[];
+      final client = MockClient((http.Request request) async {
+        issued.add(request);
+        return http.Response(
+          jsonEncode(<String, Object?>{
+            'result': const <String>[],
+            'error': null,
+          }),
+          200,
+        );
+      });
+      final service = AnkiConnectService(
+        host: 'anki.example.com',
+        port: 443,
+        useHttps: true,
+        client: client,
+      );
+
+      await service.getDeckNames();
+
+      expect(issued.single.url.scheme, 'https');
+      expect(issued.single.url.host, 'anki.example.com');
+      expect(issued.single.url.port, 443);
+    });
+
     test('requests use a short connection to avoid stale pooled sockets',
         () async {
       final issued = <http.Request>[];


### PR DESCRIPTION
## 改动

- Android 的制卡设置也显示 AnkiConnect 配置区，并默认折叠
- 增加 Android AnkiDroid / AnkiConnect 显式后端选择，默认仍为 AnkiDroid
- 持久化后端选择，并在切换后立即重建制卡仓库
- 补齐 host、port、API key 配置与 17 种语言资源
- 增加 Android 默认路由、折叠展示、即时切换和重启恢复测试

## 原因

Android 原先不仅隐藏了 AnkiConnect 配置，平台工厂也固定使用 AnkiDroid。仅显示地址输入会形成无效配置，因此本 PR 同时补齐真实后端选择与路由。

## 验证

- `flutter test test/platform/android_anki_backend_selection_test.dart --no-pub`：4 tests passed
- Anki 设置及相邻守卫测试：11 tests passed
- `flutter analyze --no-pub`：No issues found
- `dart analyze lib/src/anki_models.dart`：No issues found
- `dart run tool/i18n_sync.dart --dry-run`：All translation files are in sync

## 未验证

按本轮要求未等待 Android 构建或真机连接验收；远端 AnkiConnect 的设备级连通性留给 CI / 真机验证。