### PR TITLE
test(galgame): fix AI6 fixture dialogue selection

### DIFF
--- a/hibiki/test/mining/elf_ai6_pairing_test.dart
+++ b/hibiki/test/mining/elf_ai6_pairing_test.dart
@@ -26,7 +26,9 @@ void main() {
     );
     final Map<String, dynamic> text = events
         .cast<Map<String, dynamic>>()
-        .singleWhere((Map<String, dynamic> event) => event['kind'] == 'text');
+        .singleWhere(
+          (Map<String, dynamic> event) => event['id'] == 'ai6-dialogue',
+        );
     final Map<String, dynamic> resource = events
         .cast<Map<String, dynamic>>()
         .singleWhere(


### PR DESCRIPTION
Post-merge correction for #777. The fixture intentionally contains both a wrong-thread text event and the selected dialogue, so selecting by kind with singleWhere fails. Select the expected dialogue by stable fixture id instead.\n\nValidation: AI6 targeted 8/8; wave targeted 61/61; full flutter analyze clean. CI not awaited per merge-wave instruction.