### PR TITLE
fix(ci): 修复 develop 上两处红：C2360 与失效的 helper 载荷守卫

### DIFF
--- a/hibiki/windows/runner/win32_window.cpp
+++ b/hibiki/windows/runner/win32_window.cpp
@@ -286,7 +286,9 @@ Win32Window::MessageHandler(HWND hwnd,
       return 0;
     }
 
-    case WM_ACTIVATE:
+    // Braced: this case declares locals, and without its own scope MSVC rejects
+    // the switch outright (C2360, initialization skipped by a later case label).
+    case WM_ACTIVATE: {
       // WM_ACTIVATE is sent for both sides of an activation hand-off. When an
       // activatable Hibiki auxiliary window (for example the clipboard lookup
       // panel) starts its native move/size loop, the main window receives
@@ -304,6 +306,7 @@ Win32Window::MessageHandler(HWND hwnd,
         SetFocus(child_content_);
       }
       return 0;
+    }
 
     case WM_DISPLAYCHANGE:
       // Display topology / resolution / depth changed (e.g. a monitor came

--- a/tool/check_release_policy.ps1
+++ b/tool/check_release_policy.ps1
@@ -139,11 +139,21 @@ Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'hibiki-*-
 Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'hibiki-*-ios.ipa' 'desktop workflow must upload iOS IPA assets'
 Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'Publish mirror update manifest (Apple assets)' 'Apple release assets must merge into the update manifest'
 Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'native/galgame_hook/tools/build_distribution.ps1 -RunTests' 'Windows releases must build the bundled offline galgame helper from the in-tree source'
-Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'Release\galgame_helper' 'Windows installer payload must contain both helper archives and sidecars'
+# BUG-1449: the helper is no longer shipped as zip + sidecar for the runtime to
+# unpack -- that layout left a second copy on disk that had to stay in sync with
+# the app, and "staying in sync" is exactly what broke in BUG-1448. Both Windows
+# workflows now unpack BOTH architectures into the build output at build time via
+# the shared install_into_bundle.ps1, so helper and app come out of one build.
+# Pin the bundle directory too: the archive-era `<config>\galgame_helper` payload
+# check could not tell Release from Debug, and unpacking into the wrong directory
+# ships an installer with no helper at all while the build stays green.
+# (The anti-regression side -- never copying zips back into galgame_helper/ --
+# lives in hibiki/test/mining/gal_helper_bundled_as_plain_files_test.dart.)
+Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'install_into_bundle.ps1 -BundleDirectory "$PWD\hibiki\build\windows\x64\runner\Release"' 'Windows release payload must unpack both helper architectures into the packaged Release bundle (BUG-1449)'
 
 $multiplatformWorkflow = Read-RepoFile '.github/workflows/build-multiplatform.yml'
 Require-Text '.github/workflows/build-multiplatform.yml' $multiplatformWorkflow 'native/galgame_hook/tools/build_distribution.ps1 -RunTests' 'Windows CI must exercise the same bundled helper build as release'
-Require-Text '.github/workflows/build-multiplatform.yml' $multiplatformWorkflow 'Debug\galgame_helper' 'Windows debug bundle must exercise the offline helper payload layout'
+Require-Text '.github/workflows/build-multiplatform.yml' $multiplatformWorkflow 'install_into_bundle.ps1 -BundleDirectory "$PWD\hibiki\build\windows\x64\runner\Debug"' 'Windows debug bundle must exercise the same build-time helper unpack as release (BUG-1449)'
 
 # BUG-1292: Magpie has no download path left, so the bundled slim archive is the
 # ONLY way window upscaling can ever install. If a Windows workflow stops


### PR DESCRIPTION
develop 上三个 workflow 全红，两个独立根因。

## 1. `win32_window.cpp` C2360 —— build-multiplatform / windows 作业

`case WM_ACTIVATE:` 直接声明了 `child_is_live` / `child_belongs_to_window` 两个 const 局部变量，却没有自己的作用域。MSVC 判 C2360（初始化被后续 case 标签跳过），整个 switch 编译不过：

```
win32_window.cpp(308,5): error C2360: initialization of 'child_belongs_to_window' is skipped by 'case' label
win32_window.cpp(308,5): error C2360: initialization of 'child_is_live' is skipped by 'case' label
win32_window.cpp(316,5): ...（同上两条）
```

同一个 switch 里的 `WM_SIZE` 等分支本来就是加花括号的写法，这条只是漏了。加上花括号即可，行为零改动。

## 2. helper 载荷守卫失效 —— APK build / desktop windows / desktop publish 三个作业

`tool/check_release_policy.ps1` 还在要求两个 workflow 里出现 `Release\galgame_helper` / `Debug\galgame_helper`。但 BUG-1449（`fb2e2ed68`）已经把「随包发 zip + 运行期解压」改成构建期调 `install_into_bundle.ps1` 解压，这两个字面量正是它要消灭的形态 —— `gal_helper_bundled_as_plain_files_test.dart` 反过来**禁止**它们出现在 workflow 里。

两个守卫对同一份文件断言相反，ps1 这侧必然红。三个作业都停在这一步（步骤 3「Validate unified release policy」，之后的步骤全部 skipped，包括打包与发布）。

守卫改为钉住新契约，并且把 bundle 目录一起钉死：旧的 `<config>\galgame_helper` 载荷检查分不出 Release 和 Debug，解压到错目录会发出一个没有 helper 的安装包而构建照样绿。反向不变式（不许把 zip 复制回 `galgame_helper/`）留在 Dart 守卫里，不在这里重复。

## 验证

- **C++ A/B 对照**（`cl /Zs /utf-8` 单文件编译）：修复前精确复现 CI 的 4 条 C2360（exit 2），修复后 exit 0。
- `tool/check_release_policy.ps1` 本地通过（`Release policy guard passed.`，exit 0）。
- `flutter test test/tools/powershell_51_compat_guard_test.dart test/mining/gal_helper_bundled_as_plain_files_test.dart --no-pub` → 7/7 通过。
- 该 run 的 `tests` 作业本身是绿的，单测无回归；红的只有以上两处。

## 说明

本轮不 bump `+build`：这是 CI 修复，不触发发布。

https://claude.ai/code/session_01VawPZEd4LLHXZEMrbAL8tj
