### PR TITLE
ci(apple): iOS TestFlight 签名上传 + macOS Developer ID 公证

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -42,6 +42,14 @@ on:
       release_name:
         description: 'Optional GitHub Release title.'
         required: false
+      # TestFlight 上传只在手动 beta/formal 发布时发生（见 ios job 的
+      # "Resolve Apple signing mode"）。push 的 debug 通道每次提交都会跑，
+      # 传上去只会白烧 App Store Connect 的处理配额并把构建号推高。
+      upload_testflight:
+        description: 'Upload a signed iOS build to TestFlight (beta/formal only; needs the Apple secrets).'
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: hibiki-release-${{ github.event.release.tag_name || github.event.inputs.tag_name || github.sha }}
@@ -970,6 +978,191 @@ jobs:
           "$target_dir/ffmpeg" -hide_banner -version | head -n 1
           "$target_dir/ffprobe" -hide_banner -version | head -n 1
           ls -lh "$target_dir/ffmpeg" "$target_dir/ffprobe"
+      # ---- Developer ID 签名 + 公证（Gatekeeper）-------------------------
+      # **必须排在上面 Mihon / ffmpeg 两步之后**：那两步往 bundle 里塞可执行文件
+      # 并用 `codesign --force --deep --sign -` 重签整个 app，签在前面的
+      # Developer ID 签名会被那个 ad-hoc 签名整个盖掉。
+      # 每一项 Apple 凭据都是可选的：没有它们（fork，或本仓开发者账号存在之前）
+      # 走原来的 ad-hoc 签名 zip，发布链路绝不硬依赖 Apple 开发者账号。
+      # 有它们时才做 Developer ID 重签 + notarytool 公证 + stapler 装订，
+      # 用户下载 zip 后不再被「已损坏，无法打开」拦住。
+      # 注意：macOS 走的是 Developer ID（App Store 之外分发），不是 TestFlight。
+      # Release.entitlements 已刻意去沙盒（应用内自动更新要写 /Applications），
+      # 上 Mac App Store / macOS TestFlight 需要重新引入沙盒，是另一个决策。
+      - name: Resolve macOS Developer ID signing mode
+        id: signing
+        shell: bash
+        env:
+          MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          SIGN=false
+          if [ -n "$MACOS_DEVELOPER_ID_P12_BASE64" ] && [ -n "$APPLE_TEAM_ID" ]; then
+            SIGN=true
+          fi
+          # 公证要 App Store Connect API key；只签不公证仍然会被 Gatekeeper 拦，
+          # 所以缺 API key 时把签名一起降级，避免产出「签了但过不了」的中间态。
+          NOTARIZE=false
+          if [ "$SIGN" = true ] && [ -n "$APPSTORE_API_KEY_ID" ] \
+             && [ -n "$APPSTORE_API_ISSUER_ID" ] && [ -n "$APPSTORE_API_PRIVATE_KEY" ]; then
+            NOTARIZE=true
+          fi
+          if [ "$SIGN" = true ] && [ "$NOTARIZE" = false ]; then
+            echo "::warning title=macOS notarization skipped::Developer ID cert present but APPSTORE_API_* secrets are missing; falling back to the unsigned ad-hoc zip."
+            SIGN=false
+          fi
+          echo "macos_signed=$SIGN" >> "$GITHUB_OUTPUT"
+          echo "Developer ID signing: $SIGN"
+      - name: Import Developer ID certificate
+        if: steps.signing.outputs.macos_signed == 'true'
+        shell: bash
+        env:
+          MACOS_DEVELOPER_ID_P12_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+          MACOS_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/hibiki-macos-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          P12_PATH="$RUNNER_TEMP/developer-id.p12"
+          printf '%s' "$MACOS_DEVELOPER_ID_P12_BASE64" | base64 --decode > "$P12_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # 6h 自动锁；不设的话默认 5 分钟无操作即锁，长构建中途 codesign 会失败。
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$P12_PATH" -k "$KEYCHAIN_PATH" \
+            -P "${MACOS_DEVELOPER_ID_P12_PASSWORD:-}" \
+            -T /usr/bin/codesign -T /usr/bin/security -f pkcs12 -A
+          rm -f "$P12_PATH"
+          # 没有这一步，codesign 每次用私钥都会弹「允许访问钥匙串」的 UI 授权，
+          # 无人值守的 runner 上直接挂住。
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" > /dev/null
+          # 把临时钥匙串放进搜索列表最前面，同时保留 runner 原有的 login 钥匙串。
+          EXISTING_KEYCHAINS=""
+          while IFS= read -r line; do
+            trimmed="$(printf '%s' "$line" | tr -d '"' | sed 's/^ *//;s/ *$//')"
+            if [ -n "$trimmed" ]; then
+              EXISTING_KEYCHAINS="$EXISTING_KEYCHAINS $trimmed"
+            fi
+          done < <(security list-keychains -d user)
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $EXISTING_KEYCHAINS
+          IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep 'Developer ID Application' | head -n 1 | sed 's/.*) \([0-9A-F]*\) ".*/\1/')"
+          if [ -z "$IDENTITY" ]; then
+            echo "::error title=No Developer ID identity::MACOS_DEVELOPER_ID_P12_BASE64 does not contain a 'Developer ID Application' certificate with its private key."
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+            exit 1
+          fi
+          {
+            echo "MACOS_SIGN_IDENTITY=$IDENTITY"
+            echo "MACOS_KEYCHAIN_PATH=$KEYCHAIN_PATH"
+          } >> "$GITHUB_ENV"
+          echo "Developer ID identity: $IDENTITY"
+      - name: Sign macOS app with Developer ID
+        if: steps.signing.outputs.macos_signed == 'true'
+        working-directory: hibiki
+        shell: bash
+        run: |
+          set -euo pipefail
+          APP="build/macos/Build/Products/Release/hibiki.app"
+          ENTITLEMENTS="macos/Runner/Release.entitlements"
+          JVM_ENTITLEMENTS="$RUNNER_TEMP/mihon-jvm.entitlements"
+          if [ ! -d "$APP" ]; then
+            echo "::error title=macOS app missing::Expected $APP"
+            exit 1
+          fi
+          # 捆绑的 Temurin JDK 21 jlink 镜像（Contents/Resources/mihon_bridge）在
+          # 强化运行时下跑 HotSpot 需要 JIT 和可写可执行内存，还要能加载镜像里那堆
+          # 库。这些 entitlement 只给 JVM 可执行体，不进主 app —— 主 app 是 AOT 的
+          # Flutter，给了纯属白白扩大攻击面。
+          cat > "$JVM_ENTITLEMENTS" <<'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>com.apple.security.cs.allow-jit</key><true/>
+            <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+            <key>com.apple.security.cs.disable-library-validation</key><true/>
+          </dict>
+          </plist>
+          PLIST
+          plutil -lint "$JVM_ENTITLEMENTS"
+          sign_one() {
+            codesign --force --timestamp --options runtime \
+              --keychain "$MACOS_KEYCHAIN_PATH" \
+              --sign "$MACOS_SIGN_IDENTITY" "$@"
+          }
+          # 公证要求 bundle 里**每一个** Mach-O 都带强化运行时 + 安全时间戳，不是
+          # 只有 dylib：Contents/MacOS 下的 ffmpeg/ffprobe、mihon_bridge 里的 JVM
+          # 可执行体同样算，而它们都没有扩展名 —— 所以按 `file` 判定而不是后缀。
+          # 按路径深度倒序，内层先签（codesign 会把内层签名封进外层，顺序反了外层
+          # 立刻失效）。-type f 同时排除了符号链接，jlink 镜像和 framework 里的
+          # 符号链接不能签。
+          MIHON_PREFIX="$APP/Contents/Resources/mihon_bridge/"
+          while IFS= read -r item; do
+            if ! file "$item" | grep -q 'Mach-O'; then
+              continue
+            fi
+            case "$item" in
+              "$MIHON_PREFIX"*)
+                echo "signing (jvm): $item"
+                sign_one --entitlements "$JVM_ENTITLEMENTS" "$item"
+                ;;
+              *)
+                echo "signing: $item"
+                sign_one "$item"
+                ;;
+            esac
+          done < <(find "$APP/Contents" -type f \
+            | awk '{ print gsub(/\//, "/") "\t" $0 }' | sort -rn | cut -f2-)
+          # framework bundle 本身（内层 Mach-O 上一轮已签）。
+          while IFS= read -r -d '' item; do
+            echo "signing bundle: $item"
+            sign_one "$item"
+          done < <(find "$APP/Contents/Frameworks" -maxdepth 1 -name '*.framework' -print0 2>/dev/null)
+          codesign --force --timestamp --options runtime \
+            --entitlements "$ENTITLEMENTS" \
+            --keychain "$MACOS_KEYCHAIN_PATH" \
+            --sign "$MACOS_SIGN_IDENTITY" "$APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
+          codesign --display --entitlements - --verbose=4 "$APP"
+      - name: Notarize and staple macOS app
+        if: steps.signing.outputs.macos_signed == 'true'
+        working-directory: hibiki
+        shell: bash
+        env:
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          APP="build/macos/Build/Products/Release/hibiki.app"
+          KEY_PATH="$RUNNER_TEMP/AuthKey_${APPSTORE_API_KEY_ID}.p8"
+          printf '%s\n' "$APPSTORE_API_PRIVATE_KEY" > "$KEY_PATH"
+          NOTARIZE_ZIP="$RUNNER_TEMP/hibiki-notarize.zip"
+          # 公证服务只吃 zip/dmg/pkg，且必须 ditto 保留 .app 的符号链接与扩展属性。
+          ditto -c -k --keepParent "$APP" "$NOTARIZE_ZIP"
+          set +e
+          xcrun notarytool submit "$NOTARIZE_ZIP" \
+            --key "$KEY_PATH" \
+            --key-id "$APPSTORE_API_KEY_ID" \
+            --issuer "$APPSTORE_API_ISSUER_ID" \
+            --wait --timeout 45m
+          NOTARY_STATUS=$?
+          set -e
+          rm -f "$KEY_PATH" "$NOTARIZE_ZIP"
+          if [ "$NOTARY_STATUS" -ne 0 ]; then
+            echo "::error title=Notarization failed::notarytool exited $NOTARY_STATUS. Run 'xcrun notarytool log <submission-id>' with the same key to see the rejected binaries."
+            exit "$NOTARY_STATUS"
+          fi
+          # 装订票据：装订后用户离线也能通过 Gatekeeper（不装订则每次首启都要联网）。
+          xcrun stapler staple "$APP"
+          xcrun stapler validate "$APP"
+          spctl --assess --type execute --verbose=4 "$APP"
       - name: Prepare macOS app release asset
         working-directory: hibiki
         shell: bash
@@ -1270,6 +1463,206 @@ jobs:
           path: hibiki/build/release-artifacts/hibiki-*-ios.ipa
           if-no-files-found: ignore
           retention-days: 14
+
+      # ---- App Store 签名 + TestFlight ---------------------------------
+      # 上面的未签名 IPA 是 GitHub Release 资产，**保持不变**：老用户用自签工具
+      # （AltStore / Sideloadly 等）侧载的就是它，换成 App Store 签名的包会直接
+      # 打断他们。TestFlight 走的是下面这个额外的、只在手动 beta/formal 发布时
+      # 才产出的签名 IPA，它不进 Release 资产。
+      #
+      # 每一项 Apple 凭据都是可选的：缺任何一项就整段跳过，未签名 IPA 照常发布，
+      # fork 与无账号状态下发布链路不受影响（tool/check_release_policy.ps1 守卫
+      # 也依赖 `flutter build ios --release --no-codesign` 这条路径继续存在）。
+      - name: Resolve Apple signing mode
+        id: signing
+        shell: bash
+        env:
+          IOS_DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+          RELEASE_CHANNEL: ${{ steps.channel.outputs.channel }}
+          INPUT_UPLOAD_TESTFLIGHT: ${{ github.event.inputs.upload_testflight }}
+        run: |
+          set -euo pipefail
+          CREDS=false
+          if [ -n "$IOS_DIST_CERT_P12_BASE64" ] && [ -n "$IOS_PROVISIONING_PROFILE_BASE64" ] \
+             && [ -n "$APPLE_TEAM_ID" ] && [ -n "$APPSTORE_API_KEY_ID" ] \
+             && [ -n "$APPSTORE_API_ISSUER_ID" ] && [ -n "$APPSTORE_API_PRIVATE_KEY" ]; then
+            CREDS=true
+          fi
+          # 只在手动 beta/formal 发布时上传。push 触发的 debug 通道每次提交都会跑，
+          # 传 TestFlight 只会白烧 App Store Connect 的处理配额并把构建号推高，
+          # 而构建号在同一个 CFBundleShortVersionString 下必须单调，浪费不可回收。
+          TESTFLIGHT=false
+          if [ "$CREDS" = true ] && [ "$GITHUB_EVENT_NAME" = workflow_dispatch ] \
+             && { [ "$RELEASE_CHANNEL" = beta ] || [ "$RELEASE_CHANNEL" = formal ]; } \
+             && [ "${INPUT_UPLOAD_TESTFLIGHT:-true}" != false ]; then
+            TESTFLIGHT=true
+          fi
+          if [ "$CREDS" = false ] && [ "$GITHUB_EVENT_NAME" = workflow_dispatch ] \
+             && [ "${INPUT_UPLOAD_TESTFLIGHT:-true}" != false ] \
+             && { [ "$RELEASE_CHANNEL" = beta ] || [ "$RELEASE_CHANNEL" = formal ]; }; then
+            echo "::warning title=TestFlight upload skipped::Apple signing secrets are incomplete. See docs/agent/apple-signing.md for the required secret names."
+          fi
+          echo "testflight=$TESTFLIGHT" >> "$GITHUB_OUTPUT"
+          echo "TestFlight upload: $TESTFLIGHT (channel=$RELEASE_CHANNEL event=$GITHUB_EVENT_NAME creds=$CREDS)"
+      - name: Import iOS distribution certificate
+        if: steps.signing.outputs.testflight == 'true'
+        shell: bash
+        env:
+          IOS_DIST_CERT_P12_BASE64: ${{ secrets.IOS_DIST_CERT_P12_BASE64 }}
+          IOS_DIST_CERT_P12_PASSWORD: ${{ secrets.IOS_DIST_CERT_P12_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/hibiki-ios-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          P12_PATH="$RUNNER_TEMP/ios-distribution.p12"
+          printf '%s' "$IOS_DIST_CERT_P12_BASE64" | base64 --decode > "$P12_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          # 见 macos job：默认 5 分钟无操作即锁，长构建中途 codesign 会失败。
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$P12_PATH" -k "$KEYCHAIN_PATH" \
+            -P "${IOS_DIST_CERT_P12_PASSWORD:-}" \
+            -T /usr/bin/codesign -T /usr/bin/security -f pkcs12 -A
+          rm -f "$P12_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" > /dev/null
+          EXISTING_KEYCHAINS=""
+          while IFS= read -r line; do
+            trimmed="$(printf '%s' "$line" | tr -d '"' | sed 's/^ *//;s/ *$//')"
+            if [ -n "$trimmed" ]; then
+              EXISTING_KEYCHAINS="$EXISTING_KEYCHAINS $trimmed"
+            fi
+          done < <(security list-keychains -d user)
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $EXISTING_KEYCHAINS
+          IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep 'Apple Distribution' | head -n 1 | sed 's/.*) \([0-9A-F]*\) ".*/\1/')"
+          if [ -z "$IDENTITY" ]; then
+            echo "::error title=No Apple Distribution identity::IOS_DIST_CERT_P12_BASE64 does not contain an 'Apple Distribution' certificate with its private key. A 'Apple Development' cert cannot sign an App Store build."
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+            exit 1
+          fi
+          {
+            echo "IOS_SIGN_IDENTITY=$IDENTITY"
+            echo "IOS_KEYCHAIN_PATH=$KEYCHAIN_PATH"
+          } >> "$GITHUB_ENV"
+          echo "Apple Distribution identity: $IDENTITY"
+      - name: Install provisioning profile and signing xcconfig
+        if: steps.signing.outputs.testflight == 'true'
+        shell: bash
+        env:
+          IOS_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          PROFILE_PATH="$RUNNER_TEMP/hibiki.mobileprovision"
+          PROFILE_PLIST="$RUNNER_TEMP/hibiki-profile.plist"
+          printf '%s' "$IOS_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+          # .mobileprovision 是 CMS 签名信封，先解出里面的 plist 才能读字段。
+          security cms -D -i "$PROFILE_PATH" > "$PROFILE_PLIST"
+          PROFILE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$PROFILE_PLIST")"
+          PROFILE_UUID="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$PROFILE_PLIST")"
+          PROFILE_EXPIRY="$(/usr/libexec/PlistBuddy -c 'Print :ExpirationDate' "$PROFILE_PLIST")"
+          APP_ID="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$PROFILE_PLIST")"
+          PROFILE_BUNDLE_ID="${APP_ID#*.}"
+          EXPECTED_BUNDLE_ID="$(sed -n 's/.*PRODUCT_BUNDLE_IDENTIFIER = \(.*\);/\1/p' \
+            hibiki/ios/Runner.xcodeproj/project.pbxproj | grep -v RunnerTests | head -n 1)"
+          if [ "$PROFILE_BUNDLE_ID" != "$EXPECTED_BUNDLE_ID" ]; then
+            echo "::error title=Provisioning profile mismatch::Profile is for '$PROFILE_BUNDLE_ID' but Runner builds '$EXPECTED_BUNDLE_ID'. A wildcard profile cannot be used for App Store distribution."
+            exit 1
+          fi
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
+          # 手动签名设置写进 ios/Flutter/Release.xcconfig（gitignore 之外的模板文件，
+          # 只在 runner 上追加，不入库）。这是 Runner **target** 的 base configuration，
+          # 在 Xcode 的优先级里高于 project 级设置 —— 而 project.pbxproj 恰好在
+          # project 级钉了 CODE_SIGN_IDENTITY[sdk=iphoneos*] = "iPhone Developer"，
+          # CI 钥匙串里没有这张证书。带条件的赋值只能被同样带条件的赋值压过，
+          # 所以两种写法都写一遍。改 pbxproj 或用 xcodebuild 命令行全局覆盖都会
+          # 波及 CocoaPods 的 pod target（use_frameworks! 下它们也要签名），
+          # 这条路径只作用于 Runner 工程。
+          {
+            echo ""
+            echo "// Injected by .github/workflows/release-desktop.yml for the TestFlight build."
+            echo "CODE_SIGN_STYLE = Manual"
+            echo "DEVELOPMENT_TEAM = $APPLE_TEAM_ID"
+            echo "PROVISIONING_PROFILE_SPECIFIER = $PROFILE_NAME"
+            echo "CODE_SIGN_IDENTITY = Apple Distribution"
+            echo "CODE_SIGN_IDENTITY[sdk=iphoneos*] = Apple Distribution"
+            echo "OTHER_CODE_SIGN_FLAGS = \$(inherited) --keychain $IOS_KEYCHAIN_PATH"
+          } >> hibiki/ios/Flutter/Release.xcconfig
+          cat > "$RUNNER_TEMP/ExportOptions.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key><string>app-store-connect</string>
+            <key>destination</key><string>export</string>
+            <key>teamID</key><string>${APPLE_TEAM_ID}</string>
+            <key>signingStyle</key><string>manual</string>
+            <key>signingCertificate</key><string>Apple Distribution</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>${PROFILE_BUNDLE_ID}</key><string>${PROFILE_NAME}</string>
+            </dict>
+            <key>uploadSymbols</key><true/>
+            <key>manageAppVersionAndBuildNumber</key><false/>
+          </dict>
+          </plist>
+          PLIST
+          # heredoc 的缩进由 YAML 块标量统一剥掉，但这个文件是签名链路的唯一入口，
+          # 写坏了报错发生在 xcodebuild 深处，先在这里把格式问题挡下来。
+          plutil -lint "$RUNNER_TEMP/ExportOptions.plist"
+          rm -f "$PROFILE_PATH" "$PROFILE_PLIST"
+          echo "profile: $PROFILE_NAME ($PROFILE_UUID) bundle=$PROFILE_BUNDLE_ID expires=$PROFILE_EXPIRY"
+      - name: Build signed iOS App Store IPA
+        if: steps.signing.outputs.testflight == 'true'
+        working-directory: hibiki
+        run: >-
+          flutter build ipa --release
+          --export-options-plist "$RUNNER_TEMP/ExportOptions.plist"
+          --build-name "${{ steps.channel.outputs.build_version_name }}"
+          --build-number "${{ steps.channel.outputs.release_sequence }}"
+      - name: Upload to TestFlight
+        if: steps.signing.outputs.testflight == 'true'
+        working-directory: hibiki
+        shell: bash
+        env:
+          APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
+          APPSTORE_API_ISSUER_ID: ${{ secrets.APPSTORE_API_ISSUER_ID }}
+          APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          IPA=""
+          while IFS= read -r candidate; do
+            IPA="$candidate"
+            break
+          done < <(find build/ios/ipa -maxdepth 1 -name '*.ipa' -type f)
+          if [ -z "$IPA" ]; then
+            echo "::error title=Signed IPA missing::flutter build ipa produced no .ipa under hibiki/build/ios/ipa"
+            ls -la build/ios/ipa || true
+            exit 1
+          fi
+          echo "uploading $IPA"
+          # altool 只在这几个固定目录里找 --apiKey 对应的 .p8。
+          KEY_DIR="$HOME/.appstoreconnect/private_keys"
+          mkdir -p "$KEY_DIR"
+          KEY_PATH="$KEY_DIR/AuthKey_${APPSTORE_API_KEY_ID}.p8"
+          printf '%s\n' "$APPSTORE_API_PRIVATE_KEY" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
+          cleanup() { rm -f "$KEY_PATH"; }
+          trap cleanup EXIT
+          # 先 validate 再 upload：绝大多数拒收（缺 icon、entitlement 不匹配、
+          # 构建号回退）在 validate 阶段就报出来，比等 App Store Connect 发退信快。
+          xcrun altool --validate-app -f "$IPA" -t ios \
+            --apiKey "$APPSTORE_API_KEY_ID" --apiIssuer "$APPSTORE_API_ISSUER_ID"
+          xcrun altool --upload-app -f "$IPA" -t ios \
+            --apiKey "$APPSTORE_API_KEY_ID" --apiIssuer "$APPSTORE_API_ISSUER_ID"
+          echo "已上传 TestFlight；App Store Connect 处理完成（通常 5-30 分钟）后才会出现在测试员列表里。"
 
   publish:
     needs: [windows, macos, ios]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@
 |---|---|
 | 加功能/修 bug/合并的分级快车道：难度分级、子代理分工、并行时间线、验证分级、**并发伪红判别**、**合并后必跑的目录枚举型守卫清单**、**输出可信 ≠ 结论可信** | [docs/agent/fast-workflow.md](docs/agent/fast-workflow.md) |
 | 5 平台构建 / Melos / bootstrap + 依赖补丁机制 / 发布通道与版本号规则 / galgame helper Windows 随包与在线更新 | [docs/agent/build.md](docs/agent/build.md) |
+| Apple 签名：iOS TestFlight / macOS Developer ID 公证 / 仓库 secrets 清单 / 证书轮换 / 签名排障 | [docs/agent/apple-signing.md](docs/agent/apple-signing.md) |
 | 模拟器集成测试三层架构 / 焦点驱动（禁坐标点击）/ AnkiDroid provisioning / ADB 降级 / DB 查询 / 测试素材 | [docs/agent/integration-testing.md](docs/agent/integration-testing.md) |
 | 持续审查模式 / docs/reviews 报告格式 / 回归记录 | [docs/agent/review-process.md](docs/agent/review-process.md) |
 | 丢快捷键 / 丢鼠标事件：媒体页焦点所有权、`FocusReclaimCause` 分流、WebView 键盘桥 | [docs/agent/focus-ownership.md](docs/agent/focus-ownership.md) |

--- a/docs/agent/apple-signing.md
+++ b/docs/agent/apple-signing.md
@@ -1,0 +1,220 @@
+# Apple 签名与 TestFlight
+
+Hibiki 的 iOS / macOS 发布签名怎么配、怎么轮换、坏了怎么查。
+构建通道与版本号规则见 [build.md](build.md)；这里只讲 Apple 那一侧。
+
+## 两条互不相干的链路
+
+| | iOS | macOS |
+|---|---|---|
+| 分发方式 | TestFlight / App Store | Developer ID（商店之外直接下载） |
+| 证书 | `Apple Distribution` | `Developer ID Application` |
+| 描述文件 | `IOS_APP_STORE` 类型，绑 `app.hibiki.reader` | 不需要 |
+| 后处理 | 上传 App Store Connect 审核处理 | `notarytool` 公证 + `stapler` 装订 |
+| 沙盒 | 不涉及 | **刻意不进 Mac App Store** |
+
+macOS 不上架的原因不是懒：`macos/Runner/Release.entitlements` 已经刻意移除
+`com.apple.security.app-sandbox`，因为应用内自动更新要替换 `/Applications/hibiki.app`，
+沙盒容器写不了那里（决策见 `docs/specs/2026-06-04-all-platform-auto-update-design.md` §5）。
+Mac App Store 强制沙盒，两者不能兼得。Developer ID + 公证是「不上架但不被
+Gatekeeper 拦」的正解。
+
+**不要**为了「统一」把 macOS 也塞进 TestFlight —— 那等于把自动更新废掉。
+
+## 仓库 Secrets 清单
+
+`.github/workflows/release-desktop.yml` 的 `macos` / `ios` job 读这些。
+**每一项都是可选的**：缺任何一项，对应链路整段跳过，未签名 IPA / ad-hoc zip 照常
+发布。fork 和无开发者账号的状态下发布链路完全不受影响。
+
+| Secret | 内容 | 用在哪 |
+|---|---|---|
+| `APPLE_TEAM_ID` | 10 位 Team ID | iOS + macOS |
+| `APPSTORE_API_KEY_ID` | App Store Connect API Key ID | 上传 TestFlight、公证 |
+| `APPSTORE_API_ISSUER_ID` | Issuer ID（UUID，整个团队一个） | 同上 |
+| `APPSTORE_API_PRIVATE_KEY` | `.p8` 私钥全文（PEM 文本，含 BEGIN/END 行） | 同上 |
+| `IOS_DIST_CERT_P12_BASE64` | Apple Distribution 证书 + 私钥的 p12，base64 单行 | iOS |
+| `IOS_DIST_CERT_P12_PASSWORD` | 上面 p12 的导出口令 | iOS |
+| `IOS_PROVISIONING_PROFILE_BASE64` | App Store 描述文件，base64 单行 | iOS |
+| `MACOS_DEVELOPER_ID_P12_BASE64` | Developer ID Application 证书 + 私钥的 p12 | macOS |
+| `MACOS_DEVELOPER_ID_P12_PASSWORD` | 上面 p12 的导出口令 | macOS |
+
+写入/ 轮换统一走 `tool/apple_signing_secrets.sh`，它会先把材料自洽性验一遍再写：
+
+```bash
+tool/apple_signing_secrets.sh \
+  --team-id 8N35BLYGL5 \
+  --asc-key-id <KEYID> --asc-issuer-id <UUID> \
+  --asc-key ~/.appstoreconnect/private_keys/AuthKey_<KEYID>.p8 \
+  --ios-cert ~/.hibiki-apple-signing/ios_distribution.p12 \
+  --ios-cert-password-file ~/.hibiki-apple-signing/ios_distribution.p12.password \
+  --ios-profile ~/.hibiki-apple-signing/hibiki_appstore.mobileprovision
+```
+
+加 `--verify-only` 只验不写。它挡掉的正是那些「CI 跑到 codesign 才炸、报错还毫无
+指向性」的错误：p12 里装的是 Development 证书、描述文件绑的是另一张证书、描述文件
+是 ad-hoc 类型、bundle id 对不上、证书 30 天内到期。
+
+## 首次配置
+
+### 1. App Store Connect API Key
+
+appstoreconnect.apple.com → 用户和访问 → 集成 → App Store Connect API → 团队密钥 →
+新建，角色 **App Manager**。下载的 `.p8` **只能下一次**，丢了只能作废重建。
+页面顶部的 Issuer ID 一并记下。
+
+### 2. 证书、Bundle ID、描述文件
+
+除 Developer ID 外全部可以用 API 建（不用碰 Keychain Access 的 CSR 流程）：
+
+```bash
+# 私钥留在本地，只把 CSR 发给 Apple
+openssl req -new -newkey rsa:2048 -nodes \
+  -keyout ios_distribution.key -out ios_distribution.csr \
+  -subj "/CN=Hibiki iOS Distribution/O=Hibiki/C=US"
+```
+
+然后 `POST /v1/certificates`（`certificateType: DISTRIBUTION`）→
+`POST /v1/bundleIds`（`app.hibiki.reader`，platform `IOS`）→
+`POST /v1/profiles`（`profileType: IOS_APP_STORE`，关联上面两者）。
+返回的证书 subject 里的 `OU=` 就是 Team ID。
+
+把证书和私钥打成 p12 时**要把 WWDR 中间证书一起打进去**，证书链自足，不依赖
+runner 钥匙串里预装了什么：
+
+```bash
+curl -fsSL -o AppleWWDRCAG3.cer https://www.apple.com/certificateauthority/AppleWWDRCAG3.cer
+openssl x509 -inform DER -in AppleWWDRCAG3.cer -out AppleWWDRCAG3.pem
+openssl pkcs12 -export -inkey ios_distribution.key -in ios_distribution.pem \
+  -certfile AppleWWDRCAG3.pem -passout "pass:$P12_PASS" -out ios_distribution.p12
+```
+
+**Developer ID 证书是例外**：Apple 限定只有「账号持有人」能创建，API key 一律
+403 `This operation can only be performed by the Account Holder.`。必须去
+developer.apple.com/account/resources/certificates → **+** → **Developer ID
+Application** → 上传本地生成的 CSR → 下载 `.cer`，再和本地私钥合成 p12。
+
+### 3. App Store Connect 的 App 记录
+
+**API 建不了**（`The resource 'apps' does not allow 'CREATE'`）。必须在
+appstoreconnect.apple.com →「我的 App」→ **+** 手动建，Bundle ID 选
+`app.hibiki.reader`。没有这条记录，`altool --upload-app` 会以
+"No suitable application records were found" 失败。
+
+## 发一版 TestFlight
+
+Actions → **Build Desktop and Apple Release Artifacts** → Run workflow：
+
+- `channel` = `beta`（或 `formal`）
+- `upload_testflight` = true（默认）
+
+**TestFlight 只在手动 `workflow_dispatch` 的 beta / formal 通道上传**。push 触发的
+debug 通道每次提交都会跑，传上去只会白烧 App Store Connect 的处理配额，并且把构建号
+推高 —— 构建号在同一个 `CFBundleShortVersionString` 下必须单调递增，浪费掉不可回收。
+
+上传后 App Store Connect 处理通常 5–30 分钟，之后才出现在测试员列表里。
+
+### GitHub Release 资产不受影响
+
+Release 里挂的 `hibiki-<版本>-ios.ipa` **仍然是未签名包**，走的还是原来的
+`flutter build ios --release --no-codesign` + 手工打 Payload。老用户用 AltStore /
+Sideloadly 自签侧载的就是它，换成 App Store 签名包会直接打断他们。TestFlight 用的是
+另外一次、只在手动 beta/formal 时才发生的签名构建，产物不进 Release 资产。
+
+代价是这种发布下 iOS 会构建两次。可以接受：手动 beta/formal 本来就不频繁。
+
+## 实现要点（改之前先读）
+
+### iOS 签名设置为什么写进 `ios/Flutter/Release.xcconfig`
+
+`Runner.xcodeproj` 在 **project 级**钉了
+`CODE_SIGN_IDENTITY[sdk=iphoneos*] = "iPhone Developer"`，CI 钥匙串里没有这张证书。
+Xcode 的优先级是「命令行 > target 设置 > **target 的 xcconfig** > project 设置」，
+而 `Flutter/Release.xcconfig` 正是 Runner **target** 的 base configuration，
+所以往它追加就能压过 project 级的钉死值。
+
+两个坑：
+
+1. **带条件的赋值只能被同样带条件的赋值压过**。只写 `CODE_SIGN_IDENTITY = ...`
+   压不住 `CODE_SIGN_IDENTITY[sdk=iphoneos*]`，两种写法都要写。
+2. **不要用 `xcodebuild` 命令行传签名设置**。命令行优先级最高，但会同时作用到
+   CocoaPods 的 pod target 上；Hibiki 的 Podfile 用了 `use_frameworks!`，pod
+   target 也要签名，会撞出 "Provisioning profile doesn't match target"。
+   xcconfig 只作用于 Runner 工程，Pods 工程有自己的 xcconfig。
+
+验证方式（不需要完整构建）：
+
+```bash
+cd hibiki/ios
+xcodebuild -project Runner.xcodeproj -target Runner -configuration Release \
+  -sdk iphoneos -showBuildSettings \
+  | grep -E "CODE_SIGN_IDENTITY|CODE_SIGN_STYLE|DEVELOPMENT_TEAM|PROVISIONING_PROFILE_SPECIFIER"
+```
+
+追加 xcconfig 后这里必须显示 `Apple Distribution` / `Manual` / 你的 Team ID /
+描述文件名，显示 `iPhone Developer` 就说明覆盖没生效。
+
+### macOS 是构建后重签，不是构建时签
+
+`flutter build macos` 出的是 ad-hoc 签名的 app，workflow 之后做一遍完整重签。
+三条硬性约束：
+
+**1. 必须排在 Mihon / ffmpeg 打包步骤之后。** 那两步往 bundle 里塞可执行文件并用
+`codesign --force --deep --sign -` 重签整个 app —— 签在它们前面的 Developer ID
+签名会被那个 ad-hoc 签名整个盖掉，而且盖得静悄悄，直到公证被拒才发现。
+
+**2. 签名面是「每一个 Mach-O」，不是「每一个 dylib」。** `Contents/MacOS/` 下的
+`ffmpeg` / `ffprobe`、`Contents/Resources/mihon_bridge/` 里的 JVM 可执行体都算，
+而它们**都没有扩展名** —— 所以按 `file | grep Mach-O` 判定，不能按后缀。按路径深度
+倒序签，内层先签（codesign 会把内层签名封进外层，顺序反了外层立刻失效）；
+`find -type f` 同时排除符号链接，jlink 镜像和 framework 里的符号链接不能签。
+
+**3. `--options runtime` + `--timestamp` 一个都不能少**，这是公证的前提。特别注意
+`macos/Runner.xcodeproj` 里 hoshidicts 的构建脚本用的是 `codesign --timestamp=none`
+的 ad-hoc 签名 —— 重签这一步正是用来覆盖它的。
+
+### 捆绑 JVM 的额外 entitlement
+
+`Contents/Resources/mihon_bridge` 是一个 Temurin JDK 21 的 jlink 镜像
+（`tool/mihon/build_desktop_runtime.sh`）。HotSpot 在强化运行时下需要 JIT、
+可写可执行内存，还要能加载镜像里那堆库，所以这些可执行体单独用一份 entitlements 签：
+
+```
+com.apple.security.cs.allow-jit
+com.apple.security.cs.allow-unsigned-executable-memory
+com.apple.security.cs.disable-library-validation
+```
+
+**只给 JVM，不给主 app**。主 app 是 AOT 编译的 Flutter，不需要其中任何一项，
+给了纯属白白扩大攻击面。JVM 是独立进程、有自己的签名和 entitlements，
+这样切分不会削弱主 app 的强化运行时。
+
+### `ITSAppUsesNonExemptEncryption`
+
+`ios/Runner/Info.plist` 里写了 `false`。不写的话每个 TestFlight 构建都会卡在
+「缺少出口合规信息」，要去网页上手动答问卷才能分发，CI 自动发布就没意义了。
+`false` 的依据是 Hibiki 只用系统 HTTPS/TLS，没有自研或专有加密算法。
+**将来如果引入自研加密（比如端到端加密的互联同步），必须回头改这个值并补交年度
+自分类报告。**
+
+## 排障
+
+| 症状 | 原因 |
+|---|---|
+| `No suitable application records were found` | App Store Connect 里没建 App 记录，或 bundle id 对不上 |
+| `The bundle version must be higher than the previously uploaded version` | 构建号回退了。构建号 = `git rev-list --count HEAD`，检查是不是在旧提交上发布 |
+| `Missing export compliance` 卡住构建 | `ITSAppUsesNonExemptEncryption` 没生效，确认它在 `Info.plist` 顶层 dict 里 |
+| `codesign` 卡住不返回 | 忘了 `security set-key-partition-list`，无人值守 runner 上会等一个永远不来的 UI 授权 |
+| 签名过了但 App Store 校验拒收 | p12 的证书不在描述文件的 `DeveloperCertificates` 里。跑 `tool/apple_signing_secrets.sh --verify-only` 会直接报出来 |
+| 公证失败但看不出原因 | `xcrun notarytool log <submission-id> --key ... --key-id ... --issuer ...` 会逐个列出被拒的二进制 |
+| 公证后 app 启动即崩 | 强化运行时的库校验。先确认 `Contents/Frameworks` 下每个 dylib 都被同一 Team ID 签过；确实需要加载外部未签名库时才考虑 `com.apple.security.cs.disable-library-validation` |
+| `Developer ID` 证书创建 403 | 只有账号持有人能建，API key 不行。走网页端 |
+
+## 轮换
+
+- **分发证书 / Developer ID 证书**：一年到期。到期前重新走「首次配置」第 2 步，
+  再跑一遍 `tool/apple_signing_secrets.sh`。**旧证书不要急着撤销** —— 撤销
+  Developer ID 会让已经发出去的 macOS 包失效。
+- **描述文件**：跟着证书一起换（描述文件绑定证书）。
+- **API Key**：泄露或人员变动时在 App Store Connect 作废重建，然后重写
+  `APPSTORE_API_*` 三个 secret。

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -50,6 +50,25 @@ Android / Windows / macOS / iOS debug/beta workflow 必须使用跨 workflow 统
 - `release-desktop.yml`（Win/mac/iOS）本就无测试步骤，天生快，无需该开关。
 - 平台并行：Android（`release.yml`）与桌面（`release-desktop.yml`）是两条独立 workflow，同时 dispatch 即并行；桌面内部 `apple needs: windows` 是**故意串行**，避免两 job 抢同一 release 上传，勿改。
 
+### Apple 签名与 TestFlight
+
+`release-desktop.yml` 的 `ios` / `macos` job 在仓库 secrets 齐全时额外做 Apple 签名，
+完整清单、首次配置、证书轮换与排障见 [apple-signing.md](apple-signing.md)。这里只记
+影响发布判断的三条：
+
+- **Apple 凭据全部可选**。缺任何一项，对应链路整段跳过，未签名 IPA / ad-hoc macOS zip
+  照常发布 —— fork 和无开发者账号的状态下发布链路完全不受影响。
+- **TestFlight 只在手动 `workflow_dispatch` 的 beta / formal 通道上传**（dispatch 输入
+  `upload_testflight`，默认开）。push 触发的 debug 通道每次提交都会跑，传上去只会白烧
+  App Store Connect 的处理配额并把构建号推高，而构建号在同一语义版本下必须单调，
+  浪费不可回收。
+- **GitHub Release 里的 `hibiki-<版本>-ios.ipa` 仍是未签名包**，走的还是
+  `flutter build ios --release --no-codesign`。老用户自签侧载的就是它，不能换成
+  App Store 签名包。TestFlight 用的是另一次、只在手动 beta/formal 时才发生的签名构建，
+  产物不进 Release 资产 —— 代价是这种发布下 iOS 构建两次。
+- macOS 走 **Developer ID + 公证**，不进 Mac App Store：`Release.entitlements` 已刻意
+  去沙盒以支持应用内自动更新替换 `/Applications/hibiki.app`，商店强制沙盒，两者不可兼得。
+
 ## 版本号与 build number
 
 Flutter 版本号以 `hibiki/pubspec.yaml` 的 `version: X.Y.Z+build` 为准。准备 push 前先判断本轮改动是否影响用户可安装/可分发产物：

--- a/hibiki/ios/Runner/Info.plist
+++ b/hibiki/ios/Runner/Info.plist
@@ -110,5 +110,16 @@
 		</array>
 		<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+		<!--
+			出口合规声明。不写这个键的话，每个上传到 TestFlight 的构建都会卡在
+			「缺少出口合规信息」，必须去 App Store Connect 网页上手动答一遍问卷才
+			能分发给测试员 —— CI 自动发布就没有意义了。
+			false = 不使用「非豁免加密」：Hibiki 只用系统提供的 HTTPS/TLS（同步、
+			词典下载、TMDB/dandanplay 等 API），没有自实现或专有的加密算法，属于
+			Apple 明确列出的豁免范围。若将来引入自研加密（例如端到端加密的互联
+			同步），必须回头改这个值并补交年度自分类报告。
+		-->
+		<key>ITSAppUsesNonExemptEncryption</key>
+		<false/>
 </dict>
 </plist>

--- a/hibiki/pubspec.yaml
+++ b/hibiki/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hibiki
 description: A focused Japanese EPUB reader with popup dictionary and Anki integration.
 publish_to: 'none'
-version: 1.3.1+1203
+version: 1.3.1+1204
 environment:
   sdk: ">=3.5.0 <4.0.0"
   flutter: "^3.41.6"

--- a/hibiki/test/tools/apple_signing_workflow_guard_test.dart
+++ b/hibiki/test/tools/apple_signing_workflow_guard_test.dart
@@ -1,0 +1,163 @@
+// 守卫：release-desktop.yml 的 Apple 签名 / TestFlight 链路不变式。
+//
+// 这条链路的失败模式全是「构建照样绿，但产物错了」，靠人肉 review 挡不住：
+//   1. TestFlight 上传如果误挂到 push 事件上，每次提交都会烧掉一个构建号，而构建号
+//      在同一 CFBundleShortVersionString 下必须单调递增，浪费掉不可回收。
+//   2. GitHub Release 的 iOS 资产必须继续是 no-codesign 包 —— 老用户用 AltStore /
+//      Sideloadly 自签侧载的就是它，换成 App Store 签名包会直接打断他们。
+//   3. macOS 公证要求每个可执行体都带强化运行时 + 安全时间戳。少了任一个，
+//      notarytool 会在几分钟后才拒收，报错还只给 submission id。
+//   4. 无人值守 runner 上少了 set-key-partition-list，codesign 会等一个永远不来的
+//      钥匙串 UI 授权，表现为 job 挂死到超时。
+//
+// 纯 dart:io，不依赖 Flutter 运行时；从 hibiki/ 向上找仓库根。
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+Directory _repoRoot() {
+  var dir = Directory.current;
+  for (var i = 0; i < 6; i++) {
+    if (File('${dir.path}/.github/workflows/release-desktop.yml')
+        .existsSync()) {
+      return dir;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) break;
+    dir = parent;
+  }
+  fail(
+    '找不到含 .github/workflows/release-desktop.yml 的仓库根'
+    '（从 ${Directory.current.path} 向上）',
+  );
+}
+
+void main() {
+  final root = _repoRoot();
+  final workflow = File('${root.path}/.github/workflows/release-desktop.yml');
+  late String content;
+
+  setUpAll(() {
+    expect(workflow.existsSync(), isTrue, reason: '缺 ${workflow.path}');
+    content = workflow.readAsStringSync();
+  });
+
+  test('TestFlight 上传只能由手动 workflow_dispatch 的 beta/formal 触发', () {
+    // 门必须同时含事件判断和通道判断；少任何一半 push 的 debug 通道就会开始上传。
+    expect(
+      content.contains(r'[ "$GITHUB_EVENT_NAME" = workflow_dispatch ]'),
+      isTrue,
+      reason: 'TestFlight 门必须显式要求 workflow_dispatch 事件',
+    );
+    expect(
+      content.contains(r'[ "$RELEASE_CHANNEL" = beta ]'),
+      isTrue,
+      reason: 'TestFlight 门必须限定 beta/formal 通道',
+    );
+    // 上传步骤本身必须挂在门的输出上，不能是 always() 或无条件。
+    expect(
+      content.contains("if: steps.signing.outputs.testflight == 'true'"),
+      isTrue,
+      reason: '上传步骤必须由 signing 步骤的 testflight 输出把关',
+    );
+    expect(
+      RegExp(r'- name: Upload to TestFlight\n\s+if: always\(\)')
+          .hasMatch(content),
+      isFalse,
+      reason: 'TestFlight 上传绝不能是 always()',
+    );
+  });
+
+  test('GitHub Release 的 iOS 资产仍是 no-codesign 包', () {
+    expect(
+      content.contains('flutter build ios --release --no-codesign'),
+      isTrue,
+      reason: '未签名 IPA 是侧载用户的唯一入口，不能被签名包顶掉',
+    );
+    // 上传到 Release 的 artifact 必须来自未签名产物目录，而不是 flutter build ipa
+    // 的输出（build/ios/ipa）。
+    expect(
+      content.contains('path: hibiki/build/release-artifacts/hibiki-*-ios.ipa'),
+      isTrue,
+      reason: 'Release 资产必须来自 release-artifacts/（未签名打包路径）',
+    );
+    expect(
+      content.contains('path: hibiki/build/ios/ipa'),
+      isFalse,
+      reason: 'App Store 签名 IPA 不得作为 Release 资产上传',
+    );
+  });
+
+  test('macOS 签名带强化运行时和安全时间戳', () {
+    // 公证的硬性前提。特别是 macos/Runner.xcodeproj 里 hoshidicts 的构建脚本用的是
+    // `codesign --timestamp=none`，重签这一步就是用来覆盖它的。
+    expect(
+      content.contains('--force --timestamp --options runtime'),
+      isTrue,
+      reason: 'Developer ID 重签必须带 --timestamp --options runtime',
+    );
+    expect(
+      content.contains('xcrun notarytool submit'),
+      isTrue,
+      reason: '签了不公证仍会被 Gatekeeper 拦',
+    );
+    expect(
+      content.contains('xcrun stapler staple'),
+      isTrue,
+      reason: '不装订票据的话用户离线首启会被拦',
+    );
+  });
+
+  test('导入证书后必须放开钥匙串分区列表', () {
+    // 少了这步，无人值守 runner 上 codesign 会等一个永远不来的 UI 授权。
+    // iOS 和 macOS 两个 job 各要一次。
+    final occurrences =
+        'security set-key-partition-list'.allMatches(content).length;
+    expect(
+      occurrences,
+      greaterThanOrEqualTo(2),
+      reason: 'iOS 与 macOS 两条导入路径都必须调用 set-key-partition-list，'
+          '实际出现 $occurrences 次',
+    );
+  });
+
+  test('Apple 凭据缺失时不得让发布链路失败', () {
+    // 每个签名步骤都必须带条件；无条件的签名步骤会让 fork 和无账号状态下的
+    // 发布直接红掉。
+    for (final step in const [
+      'Import iOS distribution certificate',
+      'Install provisioning profile and signing xcconfig',
+      'Build signed iOS App Store IPA',
+      'Upload to TestFlight',
+    ]) {
+      expect(
+        RegExp('- name: ${RegExp.escape(step)}\\n\\s+if: ').hasMatch(content),
+        isTrue,
+        reason: '步骤「$step」必须带 if: 条件',
+      );
+    }
+    for (final step in const [
+      'Import Developer ID certificate',
+      'Sign macOS app with Developer ID',
+      'Notarize and staple macOS app',
+    ]) {
+      expect(
+        RegExp('- name: ${RegExp.escape(step)}\\n\\s+if: ').hasMatch(content),
+        isTrue,
+        reason: '步骤「$step」必须带 if: 条件',
+      );
+    }
+  });
+
+  test('ITSAppUsesNonExemptEncryption 已声明，TestFlight 不卡出口合规', () {
+    final plist =
+        File('${root.path}/hibiki/ios/Runner/Info.plist').readAsStringSync();
+    expect(
+      plist.contains('ITSAppUsesNonExemptEncryption'),
+      isTrue,
+      reason: '不声明的话每个 TestFlight 构建都要网页上手动答出口合规问卷，'
+          'CI 自动发布失去意义',
+    );
+  });
+}

--- a/tool/apple_signing_secrets.sh
+++ b/tool/apple_signing_secrets.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# Apple 签名材料的校验 + 写入 GitHub Secrets。
+#
+# 证书一年一换，描述文件一年一换，密钥可能被撤销重建 —— 每次轮换都要重新走一遍
+# 「验证材料自洽 → 写 7~9 个 secret」。手工做这件事的失败模式全是静默的：p12 里
+# 装的是 Development 证书而不是 Distribution、描述文件绑的是另一张证书、bundle id
+# 拼错一个字母，全都要等 CI 跑到 codesign 才炸，而且报错信息毫无指向性。
+# 这个脚本把这些前置条件在本地一次性挡掉。
+#
+# 用法（只验不写）：
+#   tool/apple_signing_secrets.sh --verify-only \
+#     --asc-key ~/.appstoreconnect/private_keys/AuthKey_XXXX.p8 \
+#     --ios-cert ~/.hibiki-apple-signing/ios_distribution.p12 \
+#     --ios-cert-password-file ~/.hibiki-apple-signing/ios_distribution.p12.password \
+#     --ios-profile ~/.hibiki-apple-signing/hibiki_appstore.mobileprovision
+#
+# 用法（验完写入 GitHub）：去掉 --verify-only，补上 --team-id/--asc-key-id/--asc-issuer-id。
+# macOS Developer ID 材料用 --macos-cert / --macos-cert-password-file 追加，可与 iOS 分两次跑。
+#
+# 完整流程见 docs/agent/apple-signing.md。
+
+set -euo pipefail
+
+REPO="hajisensai/hibiki"
+VERIFY_ONLY=false
+TEAM_ID=""
+ASC_KEY_ID=""
+ASC_ISSUER_ID=""
+ASC_KEY=""
+IOS_CERT=""
+IOS_CERT_PASSWORD=""
+IOS_PROFILE=""
+MACOS_CERT=""
+MACOS_CERT_PASSWORD=""
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAILURES=0
+
+die() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+fail() {
+  echo "  ✗ $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+ok() {
+  echo "  ✓ $*"
+}
+
+read_password_file() {
+  # 口令走文件而不是命令行参数：命令行参数在 ps / shell history 里对同机其它进程可见。
+  [ -f "$1" ] || die "password file not found: $1"
+  cat "$1"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo) REPO="$2"; shift 2 ;;
+    --verify-only) VERIFY_ONLY=true; shift ;;
+    --team-id) TEAM_ID="$2"; shift 2 ;;
+    --asc-key-id) ASC_KEY_ID="$2"; shift 2 ;;
+    --asc-issuer-id) ASC_ISSUER_ID="$2"; shift 2 ;;
+    --asc-key) ASC_KEY="$2"; shift 2 ;;
+    --ios-cert) IOS_CERT="$2"; shift 2 ;;
+    --ios-cert-password-file) IOS_CERT_PASSWORD="$(read_password_file "$2")"; shift 2 ;;
+    --ios-profile) IOS_PROFILE="$2"; shift 2 ;;
+    --macos-cert) MACOS_CERT="$2"; shift 2 ;;
+    --macos-cert-password-file) MACOS_CERT_PASSWORD="$(read_password_file "$2")"; shift 2 ;;
+    -h|--help) sed -n '2,25p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+# ---- 校验 ------------------------------------------------------------------
+
+if [ -n "$TEAM_ID" ]; then
+  echo "team id:"
+  if printf '%s' "$TEAM_ID" | grep -Eq '^[A-Z0-9]{10}$'; then
+    ok "$TEAM_ID"
+  else
+    fail "'$TEAM_ID' 不是 10 位大写字母数字的 Team ID（在 developer.apple.com 的 Membership 页）"
+  fi
+fi
+
+if [ -n "$ASC_ISSUER_ID" ]; then
+  echo "asc issuer id:"
+  if printf '%s' "$ASC_ISSUER_ID" | grep -Eiq '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$'; then
+    ok "$ASC_ISSUER_ID"
+  else
+    fail "'$ASC_ISSUER_ID' 不是 UUID 形态的 Issuer ID"
+  fi
+fi
+
+if [ -n "$ASC_KEY" ]; then
+  echo "asc private key ($ASC_KEY):"
+  [ -f "$ASC_KEY" ] || die "asc key not found: $ASC_KEY"
+  if openssl pkey -in "$ASC_KEY" -noout 2>/dev/null; then
+    ok "可解析的 PKCS#8 私钥"
+  else
+    fail "无法解析：App Store Connect 下载的是 PEM 文本的 .p8，不要转码或改行尾"
+  fi
+  if [ -n "$ASC_KEY_ID" ] && ! printf '%s' "$ASC_KEY" | grep -q "$ASC_KEY_ID"; then
+    echo "  ! 文件名不含 Key ID $ASC_KEY_ID —— 只是提醒，不影响 CI（CI 按 secret 重新落盘）"
+  fi
+fi
+
+# p12 里必须同时有「指定类型的证书」和「它的私钥」，且证书没过期。
+verify_p12() {
+  local label="$1" p12="$2" password="$3" expect_cn="$4"
+  echo "$label ($p12):"
+  [ -f "$p12" ] || die "p12 not found: $p12"
+
+  local certs
+  if ! certs="$(openssl pkcs12 -in "$p12" -passin "pass:$password" -nokeys -clcerts 2>/dev/null)"; then
+    fail "口令错误或文件不是 PKCS#12"
+    return
+  fi
+  local subject
+  subject="$(printf '%s' "$certs" | openssl x509 -noout -subject 2>/dev/null || true)"
+  if printf '%s' "$subject" | grep -q "$expect_cn"; then
+    ok "$subject"
+  else
+    fail "证书不是 '$expect_cn' 类型：$subject"
+    echo "     （Development 证书签不了分发包；Developer ID 与 Apple Distribution 也不能互换）"
+  fi
+
+  local enddate
+  enddate="$(printf '%s' "$certs" | openssl x509 -noout -enddate 2>/dev/null | sed 's/notAfter=//')"
+  if printf '%s' "$certs" | openssl x509 -noout -checkend 0 >/dev/null 2>&1; then
+    ok "有效期至 $enddate"
+    if ! printf '%s' "$certs" | openssl x509 -noout -checkend 2592000 >/dev/null 2>&1; then
+      echo "  ! 30 天内到期（${enddate}），先去 Portal 换新证书再写 secret"
+    fi
+  else
+    fail "证书已于 $enddate 过期"
+  fi
+
+  if openssl pkcs12 -in "$p12" -passin "pass:$password" -nocerts -noout 2>/dev/null; then
+    ok "私钥在包内"
+  else
+    fail "p12 里没有私钥 —— 只导出证书是签不了名的，导出时要选证书下面挂的那把密钥"
+  fi
+
+  if printf '%s' "$(openssl pkcs12 -in "$p12" -passin "pass:$password" -nokeys -cacerts 2>/dev/null)" \
+      | grep -q 'Worldwide Developer Relations'; then
+    ok "带 WWDR 中间证书（证书链自足）"
+  else
+    echo "  ! 不含 WWDR 中间证书。runner 上通常预装了，但打进 p12 更稳"
+  fi
+}
+
+if [ -n "$IOS_CERT" ]; then
+  verify_p12 "ios distribution p12" "$IOS_CERT" "$IOS_CERT_PASSWORD" "Apple Distribution"
+fi
+
+if [ -n "$MACOS_CERT" ]; then
+  verify_p12 "macos developer id p12" "$MACOS_CERT" "$MACOS_CERT_PASSWORD" "Developer ID Application"
+fi
+
+if [ -n "$IOS_PROFILE" ]; then
+  echo "ios provisioning profile ($IOS_PROFILE):"
+  [ -f "$IOS_PROFILE" ] || die "profile not found: $IOS_PROFILE"
+  PROFILE_PLIST="$(mktemp -t hibiki-profile)"
+  trap 'rm -f "$PROFILE_PLIST"' EXIT
+  if ! security cms -D -i "$IOS_PROFILE" > "$PROFILE_PLIST" 2>/dev/null; then
+    fail "不是 CMS 签名的 .mobileprovision"
+  else
+    PROFILE_NAME="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$PROFILE_PLIST")"
+    APP_ID="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:application-identifier' "$PROFILE_PLIST")"
+    PROFILE_BUNDLE_ID="${APP_ID#*.}"
+    ok "name = $PROFILE_NAME"
+
+    EXPECTED_BUNDLE_ID="$(sed -n 's/.*PRODUCT_BUNDLE_IDENTIFIER = \(.*\);/\1/p' \
+      "$REPO_ROOT/hibiki/ios/Runner.xcodeproj/project.pbxproj" | grep -v RunnerTests | head -n 1)"
+    if [ "$PROFILE_BUNDLE_ID" = "$EXPECTED_BUNDLE_ID" ]; then
+      ok "bundle id = ${PROFILE_BUNDLE_ID}（与 Runner.xcodeproj 一致）"
+    else
+      fail "描述文件绑的是 '$PROFILE_BUNDLE_ID'，Runner 构建的是 '$EXPECTED_BUNDLE_ID'"
+      echo "     （通配符描述文件不能用于 App Store 分发）"
+    fi
+
+    # App Store 描述文件不含 ProvisionedDevices；有这个键说明拿错成 ad-hoc/development。
+    if /usr/libexec/PlistBuddy -c 'Print :ProvisionedDevices' "$PROFILE_PLIST" >/dev/null 2>&1; then
+      fail "含 ProvisionedDevices —— 这是 development/ad-hoc 描述文件，不是 App Store 的"
+    else
+      ok "无 ProvisionedDevices（App Store 类型）"
+    fi
+
+    EXPIRY="$(/usr/libexec/PlistBuddy -c 'Print :ExpirationDate' "$PROFILE_PLIST")"
+    ok "有效期至 $EXPIRY"
+
+    # 描述文件里嵌着它授权的证书列表；CI 用的 p12 必须在其中，否则 codesign 过了
+    # 而 App Store 校验会拒。
+    if [ -n "$IOS_CERT" ]; then
+      CERT_DER="$(mktemp -t hibiki-cert)"
+      openssl pkcs12 -in "$IOS_CERT" -passin "pass:$IOS_CERT_PASSWORD" -nokeys -clcerts 2>/dev/null \
+        | openssl x509 -outform DER -out "$CERT_DER" 2>/dev/null || true
+      CERT_FP="$(openssl x509 -inform DER -in "$CERT_DER" -noout -fingerprint -sha1 2>/dev/null \
+        | sed 's/.*=//' | tr -d ':')"
+      MATCHED=false
+      INDEX=0
+      while /usr/libexec/PlistBuddy -c "Print :DeveloperCertificates:$INDEX" "$PROFILE_PLIST" >/dev/null 2>&1; do
+        EMBEDDED="$(mktemp -t hibiki-embedded)"
+        /usr/libexec/PlistBuddy -c "Print :DeveloperCertificates:$INDEX" "$PROFILE_PLIST" > /dev/null
+        plutil -extract "DeveloperCertificates.$INDEX" raw -o - "$PROFILE_PLIST" 2>/dev/null \
+          | base64 --decode > "$EMBEDDED" 2>/dev/null || true
+        EMBEDDED_FP="$(openssl x509 -inform DER -in "$EMBEDDED" -noout -fingerprint -sha1 2>/dev/null \
+          | sed 's/.*=//' | tr -d ':')"
+        rm -f "$EMBEDDED"
+        if [ -n "$EMBEDDED_FP" ] && [ "$EMBEDDED_FP" = "$CERT_FP" ]; then
+          MATCHED=true
+          break
+        fi
+        INDEX=$((INDEX + 1))
+      done
+      rm -f "$CERT_DER"
+      if [ "$MATCHED" = true ]; then
+        ok "描述文件授权了这张分发证书"
+      else
+        fail "描述文件里没有这张分发证书 —— 描述文件和 p12 不是一对，去 Portal 重新生成描述文件并勾选这张证书"
+      fi
+    fi
+  fi
+fi
+
+if [ "$FAILURES" -gt 0 ]; then
+  echo ""
+  echo "APPLE SIGNING VERDICT: FAILED - $FAILURES 项校验未通过，未写入任何 secret"
+  exit 1
+fi
+
+echo ""
+echo "APPLE SIGNING VERDICT: PASSED - 所有提供的材料自洽"
+
+if [ "$VERIFY_ONLY" = true ]; then
+  exit 0
+fi
+
+# ---- 写入 GitHub Secrets ----------------------------------------------------
+
+command -v gh >/dev/null 2>&1 || die "gh CLI 不在 PATH 上"
+
+set_secret() {
+  printf '%s' "$2" | gh secret set "$1" -R "$REPO"
+  echo "  set $1"
+}
+
+echo ""
+echo "writing secrets to $REPO:"
+[ -n "$TEAM_ID" ] && set_secret APPLE_TEAM_ID "$TEAM_ID"
+[ -n "$ASC_KEY_ID" ] && set_secret APPSTORE_API_KEY_ID "$ASC_KEY_ID"
+[ -n "$ASC_ISSUER_ID" ] && set_secret APPSTORE_API_ISSUER_ID "$ASC_ISSUER_ID"
+if [ -n "$ASC_KEY" ]; then
+  gh secret set APPSTORE_API_PRIVATE_KEY -R "$REPO" < "$ASC_KEY"
+  echo "  set APPSTORE_API_PRIVATE_KEY"
+fi
+if [ -n "$IOS_CERT" ]; then
+  set_secret IOS_DIST_CERT_P12_BASE64 "$(base64 -i "$IOS_CERT" | tr -d '\n')"
+  set_secret IOS_DIST_CERT_P12_PASSWORD "$IOS_CERT_PASSWORD"
+fi
+if [ -n "$IOS_PROFILE" ]; then
+  set_secret IOS_PROVISIONING_PROFILE_BASE64 "$(base64 -i "$IOS_PROFILE" | tr -d '\n')"
+fi
+if [ -n "$MACOS_CERT" ]; then
+  set_secret MACOS_DEVELOPER_ID_P12_BASE64 "$(base64 -i "$MACOS_CERT" | tr -d '\n')"
+  set_secret MACOS_DEVELOPER_ID_P12_PASSWORD "$MACOS_CERT_PASSWORD"
+fi
+
+echo ""
+echo "完成。下一步见 docs/agent/apple-signing.md 的「发一版 TestFlight」。"

--- a/tool/check_release_policy.ps1
+++ b/tool/check_release_policy.ps1
@@ -138,6 +138,11 @@ Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'hibiki-*-
 Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'hibiki-*-macos.zip' 'desktop workflow must upload macOS zip assets'
 Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'hibiki-*-ios.ipa' 'desktop workflow must upload iOS IPA assets'
 Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'Publish mirror update manifest (Apple assets)' 'Apple release assets must merge into the update manifest'
+# Apple 签名链路：细粒度不变式由 hibiki/test/tools/apple_signing_workflow_guard_test.dart
+# 守（每个 PR 都跑）。这里只锁发布策略层面的那一条 —— TestFlight 上传绝不能挂到 push
+# 事件上：push 的 debug 通道每次提交都会跑，每次上传都消耗一个不可回收的构建号
+# （同一语义版本下 CFBundleVersion 必须单调递增）。
+Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow '[ "$GITHUB_EVENT_NAME" = workflow_dispatch ]' 'TestFlight upload must be gated on manual workflow_dispatch; a push-triggered upload burns an unrecoverable build number every commit'
 Require-Text '.github/workflows/release-desktop.yml' $desktopWorkflow 'native/galgame_hook/tools/build_distribution.ps1 -RunTests' 'Windows releases must build the bundled offline galgame helper from the in-tree source'
 # BUG-1449: the helper is no longer shipped as zip + sidecar for the runtime to
 # unpack -- that layout left a second copy on disk that had to stay in sync with


### PR DESCRIPTION
## 做了什么

给 CI 接上真实的 Apple 签名，并让手动 beta/formal 发布能自动推 TestFlight。

**Apple 凭据全部可选**：缺任何一项，对应链路整段跳过，未签名 IPA / ad-hoc macOS zip 照常发布。fork 与无开发者账号的状态下发布链路完全不变。

### iOS
- 手动 `workflow_dispatch` 的 beta / formal 通道额外产出一个 App Store 签名 IPA，`xcrun altool` 先 validate 再上传 TestFlight。新增 dispatch 输入 `upload_testflight`（默认开）。
- **push 的 debug 通道不上传** —— 每次提交都跑，上传只会白烧处理配额并推高构建号，而构建号在同一语义版本下必须单调，浪费不可回收。
- **GitHub Release 里的 `hibiki-<版本>-ios.ipa` 仍是 no-codesign 包**，走原路径不变。老用户 AltStore / Sideloadly 自签侧载的就是它，换成 App Store 签名包会直接打断他们。代价是这类发布下 iOS 构建两次。

### macOS
- 构建后**自内向外**重签（先所有 dylib，深度倒序；再 framework bundle；最后 app），带 `--options runtime --timestamp`，覆盖 hoshidicts 构建脚本里 `--timestamp=none` 的 ad-hoc 签名 —— 公证会拒收任何没有安全时间戳的可执行体。
- 然后 `notarytool` 公证 + `stapler` 装订，用户下载 zip 不再被 Gatekeeper 拦。
- 仍**不进 Mac App Store**：`Release.entitlements` 已刻意去沙盒以支持应用内自动更新替换 `/Applications/hibiki.app`，商店强制沙盒，两者不可兼得。

## 关键实现取舍

**iOS 签名设置为什么写进 `ios/Flutter/Release.xcconfig`**

`Runner.xcodeproj` 在 **project 级**钉了 `CODE_SIGN_IDENTITY[sdk=iphoneos*] = "iPhone Developer"`，CI 钥匙串里没这张证书。Xcode 优先级是「命令行 > target 设置 > **target 的 xcconfig** > project 设置」，而 `Flutter/Release.xcconfig` 正是 Runner target 的 base configuration。

两个坑：带条件的赋值只能被同样带条件的赋值压过（两种写法都写了）；不能用 `xcodebuild` 命令行传签名设置——命令行优先级最高但会同时作用到 pod target，`use_frameworks!` 下会撞出 "Provisioning profile doesn't match target"。

已用真实 `xcodebuild -showBuildSettings` 验证覆盖生效（见下）。

## 验证

- `xcodebuild -project Runner.xcodeproj -target Runner -configuration Release -sdk iphoneos -showBuildSettings` 在注入 xcconfig 后实际解析为 `CODE_SIGN_IDENTITY = Apple Distribution` / `CODE_SIGN_STYLE = Manual` / `DEVELOPMENT_TEAM = <team>` / `PROVISIONING_PROFILE_SPECIFIER = Hibiki App Store`，**不是** `iPhone Developer`。
- p12 导入 + `security find-identity` 解析逻辑本地实跑通过（与 workflow 完全同一串命令）。
- 描述文件解析 + bundle id 与 `project.pbxproj` 一致性校验实跑通过。
- `tool/apple_signing_secrets.sh --verify-only` 全项通过，含「描述文件是否授权了这张分发证书」的 SHA-1 指纹比对。
- `flutter analyze`：No issues found。
- 新守卫 + 既有 bash 3.2 可移植性守卫：10 tests passed。

**未验证**：完整的端到端 TestFlight 上传。App Store Connect 的 App 记录还没建（`POST /v1/apps` 被 Apple 拒绝，只能网页端建），在那之前 `altool` 必然以 "No suitable application records were found" 失败。macOS 部分同样未跑过真实公证 —— Developer ID 证书 Apple 限定只有账号持有人能在网页端创建，API key 一律 403。

## 待办（不在本 PR 内）

- [ ] App Store Connect 建 App 记录（bundle ID `app.hibiki.reader`）
- [ ] 网页端建 Developer ID Application 证书，再写 `MACOS_DEVELOPER_ID_P12_*` 两个 secret