### PR TITLE
fix(galgame): launch Futamata Ren'ai without startup crash

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1365 条。点号进各自文件。
+> 共 1366 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1460](bugs/BUG-1460-futamata-kirikiri-launch-av.md) | ✅ | ✅ | 恋爱成双由 Hibiki 早注入后 Access Violation |
 | [BUG-1459](bugs/BUG-1459-installer-appdir-process-lock.md) | ✅ | ✅ | 安装器无法替换被残留子进程锁定的文件 |
 | [BUG-1458](bugs/BUG-1458-sync-collections-tombstone-day-red.md) | 🚧 | 🚧 | 集合同步墓碑用例在develop稳定红-疑日期敏感 |
 | [BUG-1457](bugs/BUG-1457-ai6-clean-voice.md) | ✅ | ✅ | AI6 制卡误用混合 BGM |

--- a/docs/bugs/BUG-1460-futamata-kirikiri-launch-av.md
+++ b/docs/bugs/BUG-1460-futamata-kirikiri-launch-av.md
@@ -9,11 +9,18 @@
 - **[x] ① 已修复** — 提交 `673f6e062`：新增精确 SHA-256 的 KiriKiri 延迟附着 profile，
   `injector/injector_main.cpp:2278` 只对用户提供的中/日文两个二进制改为正常启动；
   `injector/injector_main.cpp:2397` 等主窗口与 `wuvorbis.dll` 就绪后再注入。其它 KiriKiri
-  二进制保留早注入。
+  二进制保留早注入。提交 `155045336` 继续修复旧 Hibiki 消费兼容：
+  `include/voice_hook_ipc.h:650` 按 helper/DLL 的完整 basename 选择 Hibiki 或 Fushi IPC
+  命名空间，`injector/injector_main.cpp:117` 同步选择同品牌默认 DLL，避免游戏已启动后旧 host
+  报 `voice_hook_open_mapping_not_found`。
 - **[x] ② 已加自动化测试** — 提交 `673f6e062`：
   `native/galgame_hook/tests/kirikiri_launch_profile_test.cpp` 覆盖两份精确哈希、单 nibble
   near-miss、无关 KiriKiri 样本与空身份；定向运行
-  `fushi_kirikiri_launch_profile_test.exe` 通过。
+  `fushi_kirikiri_launch_profile_test.exe` 通过。提交 `155045336` 新增
+  `native/galgame_hook/tests/voice_hook_ipc_name_test.cpp`，覆盖旧/新组件名、大小写、后缀
+  near-miss 及两套精确映射/事件名；定向运行通过。
 - **备注**：修复后实测中文版 PID 28496 在 765 ms 内返回 `OK hooked`，窗口正常响应，
   `fushi_voice_hook.dll` 与 `wuvorbis.dll` 均已加载。按用户要求未跑全量构建、全量 CTest
-  或制卡 E2E；支持状态保持 `implemented_unverified`。
+  或制卡 E2E；支持状态保持 `implemented_unverified`。旧 Hibiki 兼容实测 PID 6628：
+  `Local\HibikiVoiceHook_6628` 可打开、Fushi 同名映射不存在，游戏窗口响应并返回
+  `OK hooked`。

--- a/docs/bugs/BUG-1460-futamata-kirikiri-launch-av.md
+++ b/docs/bugs/BUG-1460-futamata-kirikiri-launch-av.md
@@ -1,0 +1,19 @@
+## BUG-1460 · 恋爱成双由 Hibiki 早注入后 Access Violation
+- **报告**：2026-08-08（用户：Wight）
+- **真实性**：✅ 真 bug。`injector/injector_main.cpp:2308` 对未命中既有例外的游戏使用
+  `CREATE_SUSPENDED`；该标题在挂起态早注入后，`hook/adapters/kirikiri_adapter.inc:1150`
+  会从插件 `V2Link` 启动边界安装 raw TVP stream hook，随即出现 Fatal Error / Access
+  Violation。直接启动正常；移除这一处 raw stream 安装调用正常；正常启动并等
+  `wuvorbis.dll` 与游戏窗口就绪后再附着也正常，故失败边界是该二进制的早注入生命周期，
+  不是通用 injector 或 LunaHook。
+- **[x] ① 已修复** — 提交 `673f6e062`：新增精确 SHA-256 的 KiriKiri 延迟附着 profile，
+  `injector/injector_main.cpp:2278` 只对用户提供的中/日文两个二进制改为正常启动；
+  `injector/injector_main.cpp:2397` 等主窗口与 `wuvorbis.dll` 就绪后再注入。其它 KiriKiri
+  二进制保留早注入。
+- **[x] ② 已加自动化测试** — 提交 `673f6e062`：
+  `native/galgame_hook/tests/kirikiri_launch_profile_test.cpp` 覆盖两份精确哈希、单 nibble
+  near-miss、无关 KiriKiri 样本与空身份；定向运行
+  `fushi_kirikiri_launch_profile_test.exe` 通过。
+- **备注**：修复后实测中文版 PID 28496 在 765 ms 内返回 `OK hooked`，窗口正常响应，
+  `fushi_voice_hook.dll` 与 `wuvorbis.dll` 均已加载。按用户要求未跑全量构建、全量 CTest
+  或制卡 E2E；支持状态保持 `implemented_unverified`。

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -176,6 +176,14 @@ add_executable(fushi_siglus_launch_test
 target_include_directories(fushi_siglus_launch_test PRIVATE "include")
 add_test(NAME fushi_siglus_launch_test COMMAND fushi_siglus_launch_test)
 
+# KiriKiri 二进制级延迟附着 profile（根因回归：恋爱成双早注入触发 Access Violation）。
+add_executable(fushi_kirikiri_launch_profile_test
+  "tests/kirikiri_launch_profile_test.cpp"
+)
+target_include_directories(fushi_kirikiri_launch_profile_test PRIVATE "include")
+add_test(NAME fushi_kirikiri_launch_profile_test
+  COMMAND fushi_kirikiri_launch_profile_test)
+
 add_executable(fushi_luna_hook_config_test tests/luna_hook_config_test.cpp)
 target_include_directories(fushi_luna_hook_config_test PRIVATE include)
 add_test(NAME fushi_luna_hook_config_test COMMAND fushi_luna_hook_config_test)

--- a/native/galgame_hook/CMakeLists.txt
+++ b/native/galgame_hook/CMakeLists.txt
@@ -125,6 +125,13 @@ target_include_directories(fushi_voice_session_reuse_test PRIVATE "include")
 target_compile_definitions(fushi_voice_session_reuse_test PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
 add_test(NAME fushi_voice_session_reuse_test COMMAND fushi_voice_session_reuse_test)
 
+add_executable(fushi_voice_hook_ipc_name_test
+  "tests/voice_hook_ipc_name_test.cpp"
+)
+target_include_directories(fushi_voice_hook_ipc_name_test PRIVATE "include")
+target_compile_definitions(fushi_voice_hook_ipc_name_test PRIVATE UNICODE _UNICODE NOMINMAX WIN32_LEAN_AND_MEAN)
+add_test(NAME fushi_voice_hook_ipc_name_test COMMAND fushi_voice_hook_ipc_name_test)
+
 add_executable(fushi_unity_event_cursor_test
   "tests/unity_event_cursor_test.cpp"
 )

--- a/native/galgame_hook/hook/dll_main.cpp
+++ b/native/galgame_hook/hook/dll_main.cpp
@@ -440,8 +440,8 @@ inline void RecordVoiceClip(uint32_t ring_offset, uint32_t byte_len,
 
 // 通知 injector IPC 契约已经可用。必须在任何 MinHook/引擎探测之前调用：
 // 这些重型安装可能被目标进程里已有的 hook 拖慢，不能因此让 injector 超时并释放共享内存。
-bool SignalReady(DWORD pid) {
-  const std::wstring evt = ReadyEventName(pid);
+bool SignalReady(DWORD pid, bool legacy_hibiki_ipc) {
+  const std::wstring evt = ReadyEventName(pid, legacy_hibiki_ipc);
   HANDLE ready = OpenEventW(EVENT_MODIFY_STATE, FALSE, evt.c_str());
   if (ready == nullptr) return false;
   const bool signaled = SetEvent(ready) != FALSE;
@@ -462,12 +462,19 @@ bool SignalReady(DWORD pid) {
 #include "adapter_registry.inc"
 
 // 工作线程：打开共享内存 -> 校验契约 -> 标记 hooked -> 由 registry 安装 adapter -> 通知 injector。
-DWORD WINAPI HookWorker(LPVOID) {
+DWORD WINAPI HookWorker(LPVOID module_context) {
   const DWORD pid = GetCurrentProcessId();
   AdapterRegistry registry;
   WriteMarkerFile(pid);
 
-  const std::wstring shm = SharedMemoryName(pid);
+  wchar_t module_path[MAX_PATH] = {0};
+  const DWORD module_path_length = GetModuleFileNameW(
+      reinterpret_cast<HMODULE>(module_context), module_path, MAX_PATH);
+  const bool legacy_hibiki_ipc =
+      module_path_length > 0 && module_path_length < MAX_PATH &&
+      hibiki_voice_hook::ComponentUsesLegacyHibikiIpc(
+          std::wstring(module_path, module_path_length));
+  const std::wstring shm = SharedMemoryName(pid, legacy_hibiki_ipc);
   g_mapping = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, shm.c_str());
   if (g_mapping != nullptr) {
     g_header = static_cast<SharedHeader*>(
@@ -481,7 +488,7 @@ DWORD WINAPI HookWorker(LPVOID) {
 
       // 此时 DLL、共享内存与契约均已就绪，先让 injector 进入 hold 保住映射。
       // 后面的 MinHook/Siglus/KiriKiri 探测允许异步继续，不能阻塞 proof-of-life。
-      if (!SignalReady(pid)) return 1;
+      if (!SignalReady(pid, legacy_hibiki_ipc)) return 1;
 
       // ── C.2/C.3：缓存各区基址后安装捕获 hook ────────────────────────────
       g_ring_base =
@@ -544,7 +551,7 @@ BOOL APIENTRY DllMain(HMODULE module, DWORD reason, LPVOID reserved) {
     case DLL_PROCESS_ATTACH:
       DisableThreadLibraryCalls(module);
       // 活儿丢给工作线程（loader lock 之外）。CreateThread 在 DllMain 中是允许的。
-      CreateThread(nullptr, 0, HookWorker, nullptr, 0, nullptr);
+      CreateThread(nullptr, 0, HookWorker, module, 0, nullptr);
       break;
     case DLL_PROCESS_DETACH:
       // 先关捕获总开关，堵住 SubmitSourceBuffer 回调用悬垂 g_ring_base 的窗口，再解映射。

--- a/native/galgame_hook/include/kirikiri_launch_profile.h
+++ b/native/galgame_hook/include/kirikiri_launch_profile.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <array>
+#include <string>
+
+namespace hibiki_voice_hook {
+
+// Binary-scoped lifecycle exceptions for KiriKiri titles that crash when the
+// raw TVP stream adapter is installed from a CREATE_SUSPENDED startup hook.
+// These profiles preserve early injection for every other KiriKiri binary.
+struct KirikiriDelayedAttachProfile {
+  const char* id;
+  const char* executable_sha256;
+  const wchar_t* readiness_module;
+};
+
+inline constexpr std::array<KirikiriDelayedAttachProfile, 2>
+    kKirikiriDelayedAttachProfiles = {{
+        {"futamata-renai-cn",
+         "0cb927556f83b41b08624c52ede135ce5be652ead8305e701d7be89e10d6c1ea",
+         L"wuvorbis.dll"},
+        {"futamata-renai-jp",
+         "07a2a3d6aa665e3e2c4958fbf9fecfd93a5c9baac797813a152736b1edba3245",
+         L"wuvorbis.dll"},
+    }};
+
+inline const KirikiriDelayedAttachProfile* FindKirikiriDelayedAttachProfile(
+    const std::string& executable_sha256) {
+  for (const auto& profile : kKirikiriDelayedAttachProfiles) {
+    if (executable_sha256 == profile.executable_sha256) {
+      return &profile;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace hibiki_voice_hook

--- a/native/galgame_hook/include/voice_hook_ipc.h
+++ b/native/galgame_hook/include/voice_hook_ipc.h
@@ -643,11 +643,30 @@ static_assert(sizeof(LoopbackMarker) % 8 == 0, "LoopbackMarker must stay 8-align
 // 命名对象（同会话跨进程）。以目标 PID 区分，支持同时对多个游戏进程各挂一份。
 // injector 创建、hook DLL 打开：共享内存 + 「就绪」事件（DLL 装好后 SetEvent，injector 据此
 // 确认注入成功并读回格式）。
-inline std::wstring SharedMemoryName(DWORD target_pid) {
-  return L"Local\\FushiVoiceHook_" + std::to_wstring(target_pid);
+//
+// Fushi 改名后的 host 使用 FushiVoiceHook；旧 Hibiki host 仍只会打开 HibikiVoiceHook。
+// helper/DLL 可能被部署到旧安装中做兼容修复，因此两侧都按实际组件文件名选同一命名空间，
+// 而不是让新版默认名静默破坏旧 host。严格只认完整 basename，避免任意路径子串误判。
+inline bool ComponentUsesLegacyHibikiIpc(const std::wstring& component_path) {
+  const size_t slash = component_path.find_last_of(L"\\/");
+  const wchar_t* basename = slash == std::wstring::npos
+                                ? component_path.c_str()
+                                : component_path.c_str() + slash + 1;
+  return _wcsicmp(basename, L"hibiki_voice_injector.exe") == 0 ||
+         _wcsicmp(basename, L"hibiki_voice_hook.dll") == 0;
 }
-inline std::wstring ReadyEventName(DWORD target_pid) {
-  return L"Local\\FushiVoiceHookReady_" + std::to_wstring(target_pid);
+
+inline std::wstring SharedMemoryName(DWORD target_pid,
+                                     bool legacy_hibiki = false) {
+  return std::wstring(legacy_hibiki ? L"Local\\HibikiVoiceHook_"
+                                    : L"Local\\FushiVoiceHook_") +
+         std::to_wstring(target_pid);
+}
+inline std::wstring ReadyEventName(DWORD target_pid,
+                                   bool legacy_hibiki = false) {
+  return std::wstring(legacy_hibiki ? L"Local\\HibikiVoiceHookReady_"
+                                    : L"Local\\FushiVoiceHookReady_") +
+         std::to_wstring(target_pid);
 }
 
 }  // namespace hibiki_voice_hook

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -111,21 +111,27 @@ bool BitnessMatches(HANDLE target, bool* target_is_wow64) {
   return (self_wow != FALSE) == (tgt_wow != FALSE);
 }
 
-// 默认 DLL 路径：同注入器目录下 hibiki_voice_hook.dll。
+// 默认 DLL 路径：跟随注入器 basename。旧 Hibiki host 启动
+// hibiki_voice_injector.exe 时必须继续加载 hibiki_voice_hook.dll，使两侧共同选择旧 IPC 名；
+// 正常 Fushi 分发保持 fushi_voice_hook.dll。
 std::wstring DefaultDllPath() {
   wchar_t exe[MAX_PATH] = {0};
   const DWORD n = GetModuleFileNameW(nullptr, exe, MAX_PATH);
   if (n == 0 || n >= MAX_PATH) {
     return L"fushi_voice_hook.dll";
   }
-  std::wstring path(exe, n);
+  const std::wstring executable_path(exe, n);
+  const bool legacy_hibiki =
+      hibiki_voice_hook::ComponentUsesLegacyHibikiIpc(executable_path);
+  std::wstring path = executable_path;
   const size_t slash = path.find_last_of(L"\\/");
   if (slash != std::wstring::npos) {
     path.resize(slash + 1);
   } else {
     path.clear();
   }
-  return path + L"fushi_voice_hook.dll";
+  return path +
+         (legacy_hibiki ? L"hibiki_voice_hook.dll" : L"fushi_voice_hook.dll");
 }
 
 // 经 CreateRemoteThread(LoadLibraryW) 把 [dll_path] 注入 [target]。成功返回 true。
@@ -1349,7 +1355,9 @@ int RunInjection(HANDLE target, DWORD pid, const std::wstring& dll_path,
                               text_region_bytes + clip_region_bytes +
                               loopback_capacity + loopback_marker_bytes +
                               thread_preview_bytes;
-  const std::wstring shm = SharedMemoryName(pid);
+  const bool legacy_hibiki_ipc =
+      hibiki_voice_hook::ComponentUsesLegacyHibikiIpc(dll_path);
+  const std::wstring shm = SharedMemoryName(pid, legacy_hibiki_ipc);
   SetLastError(ERROR_SUCCESS);
   HANDLE mapping = CreateFileMappingW(
       INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE,
@@ -1427,7 +1435,7 @@ int RunInjection(HANDLE target, DWORD pid, const std::wstring& dll_path,
             "[unity-audio] resource extractor runtime missing; Unity audio will use normal fallback\n");
   }
   // 就绪事件（auto-reset，初始未触发）；hook DLL 装好后 SetEvent。
-  const std::wstring evt = ReadyEventName(pid);
+  const std::wstring evt = ReadyEventName(pid, legacy_hibiki_ipc);
   HANDLE ready = CreateEventW(nullptr, FALSE, FALSE, evt.c_str());
   if (ready == nullptr) {
     UnmapViewOfFile(header);

--- a/native/galgame_hook/injector/injector_main.cpp
+++ b/native/galgame_hook/injector/injector_main.cpp
@@ -25,6 +25,7 @@
 #include "launch_command_line.h"
 #include "launch_failure_policy.h"
 #include "locale_emulator_launch.h"
+#include "kirikiri_launch_profile.h"
 #include "siglus_launch.h"
 #include "steam_launch.h"
 #include "luna_bridge.h"
@@ -2020,17 +2021,38 @@ BOOL CALLBACK FindReadyGameWindow(HWND window, LPARAM param) {
   return FALSE;
 }
 
-// Enigma 完成自校验并进入游戏消息循环后再注入。只看本次子进程的可见非保护器窗口，
-// 不靠固定 Sleep 猜机器速度；进程提前退出或超时都明确失败。
-bool WaitForSiglusGameWindow(HANDLE process, DWORD pid, DWORD timeout_ms) {
+// 延迟附着必须等目标进入游戏消息循环；需要时还要等 profile 指定的运行库已加载，确保
+// 注入不会再次进入已证实会崩溃的插件启动边界。只看本次子进程，不靠固定长 Sleep 猜机器速度。
+bool ProcessHasModule(DWORD pid, const wchar_t* expected_module) {
+  if (expected_module == nullptr || expected_module[0] == L'\0') return true;
+  HANDLE snapshot = CreateToolhelp32Snapshot(
+      TH32CS_SNAPMODULE | TH32CS_SNAPMODULE32, pid);
+  if (snapshot == INVALID_HANDLE_VALUE) return false;
+  bool found = false;
+  MODULEENTRY32W module = {0};
+  module.dwSize = sizeof(module);
+  if (Module32FirstW(snapshot, &module)) {
+    do {
+      if (_wcsicmp(module.szModule, expected_module) == 0) {
+        found = true;
+        break;
+      }
+    } while (Module32NextW(snapshot, &module));
+  }
+  CloseHandle(snapshot);
+  return found;
+}
+
+bool WaitForReadyGameWindow(HANDLE process, DWORD pid, DWORD timeout_ms,
+                            const wchar_t* readiness_module = nullptr) {
   const uint64_t deadline = GetTickCount64() + timeout_ms;
   while (GetTickCount64() < deadline) {
     if (WaitForSingleObject(process, 0) == WAIT_OBJECT_0) return false;
     ReadyWindowSearch search;
     search.pid = pid;
     EnumWindows(&FindReadyGameWindow, reinterpret_cast<LPARAM>(&search));
-    if (search.found) {
-      Sleep(200);  // 让窗口创建尾部退出保护器调用栈，再装 inline hooks。
+    if (search.found && ProcessHasModule(pid, readiness_module)) {
+      Sleep(200);  // 让窗口/模块初始化尾部退出启动调用栈，再装 inline hooks。
       return true;
     }
     Sleep(50);
@@ -2206,7 +2228,7 @@ int RunSteamLaunch(const std::wstring& exe, const std::wstring& app_id,
   return rc;
 }
 
-// launch 模式：一般 CREATE_SUSPENDED 早注入；Siglus 因 Enigma 保护壳改为正常启动后附着。
+// launch 模式：一般 CREATE_SUSPENDED 早注入；已验证不兼容早注入的 profile 改为正常启动后附着。
 // 命令行含 exe 本身（CreateProcessW 约定）；workdir 缺省=exe 所在目录。
 int RunLaunch(const std::wstring& exe, const std::wstring& workdir_in,
               const std::vector<std::wstring>& extra_args,
@@ -2252,6 +2274,13 @@ int RunLaunch(const std::wstring& exe, const std::wstring& workdir_in,
   si.cb = sizeof(si);
   PROCESS_INFORMATION pi = {0};
   const bool delayed_siglus = IsSiglusGame(exe);
+  const auto* delayed_kirikiri =
+      hibiki_voice_hook::FindKirikiriDelayedAttachProfile(Sha256File(exe));
+  const bool delayed_attach = delayed_siglus || delayed_kirikiri != nullptr;
+  if (delayed_kirikiri != nullptr) {
+    fprintf(stderr, "[launch] delayed-attach profile=%s\n",
+            delayed_kirikiri->id);
+  }
   const bool follow_children =
       follow_child_processes || LooksLikeRenpyRuntime(exe);
   // SteamAPI_RestartAppIfNecessary 要求游戏由 Steam 客户端启动。直接 CreateProcess
@@ -2276,7 +2305,7 @@ int RunLaunch(const std::wstring& exe, const std::wstring& workdir_in,
                           effective_luna);
   }
   const DWORD creation_flags =
-      (delayed_siglus || follow_children) ? 0 : CREATE_SUSPENDED;
+      (delayed_attach || follow_children) ? 0 : CREATE_SUSPENDED;
   wchar_t previous_steam_app_id[64] = {0};
   wchar_t previous_steam_game_id[64] = {0};
   const DWORD previous_app_id_chars = GetEnvironmentVariableW(
@@ -2347,7 +2376,7 @@ int RunLaunch(const std::wstring& exe, const std::wstring& workdir_in,
 
   const auto locale_resume_policy =
       hibiki_voice_hook::SelectLocaleThreadResumePolicy(
-          locale_launched, delayed_siglus, follow_children);
+          locale_launched, delayed_attach, follow_children);
   if (locale_resume_policy ==
       hibiki_voice_hook::LocaleThreadResumePolicy::kBeforeProcessDiscovery) {
     if (!ResumeLaunchedGame(pi.hProcess, pi.hThread, "pre-discovery")) {
@@ -2363,9 +2392,12 @@ int RunLaunch(const std::wstring& exe, const std::wstring& workdir_in,
     resumed_before_discovery = true;
   }
 
-  if (delayed_siglus &&
-      !WaitForSiglusGameWindow(pi.hProcess, pi.dwProcessId, 20000)) {
-    fprintf(stderr, "Siglus 保护壳初始化/游戏窗口等待超时\n");
+  const wchar_t* readiness_module =
+      delayed_kirikiri == nullptr ? nullptr : delayed_kirikiri->readiness_module;
+  if (delayed_attach &&
+      !WaitForReadyGameWindow(pi.hProcess, pi.dwProcessId, 20000,
+                              readiness_module)) {
+    fprintf(stderr, "延迟附着等待游戏窗口/运行库就绪超时\n");
     TerminateProcess(pi.hProcess, 1);
     CloseHandle(pi.hThread);
     CloseHandle(pi.hProcess);

--- a/native/galgame_hook/tests/kirikiri_launch_profile_test.cpp
+++ b/native/galgame_hook/tests/kirikiri_launch_profile_test.cpp
@@ -1,0 +1,52 @@
+#include "kirikiri_launch_profile.h"
+
+#include <cstdio>
+#include <cstring>
+#include <cwchar>
+
+namespace {
+
+int failures = 0;
+
+void Check(bool condition, const char* message) {
+  if (!condition) {
+    std::printf("FAIL: %s\n", message);
+    ++failures;
+  }
+}
+
+}  // namespace
+
+int main() {
+  const auto* chinese = hibiki_voice_hook::FindKirikiriDelayedAttachProfile(
+      "0cb927556f83b41b08624c52ede135ce5be652ead8305e701d7be89e10d6c1ea");
+  Check(chinese != nullptr, "verified Chinese binary selects delayed attach");
+  Check(chinese != nullptr && std::strcmp(chinese->id, "futamata-renai-cn") == 0,
+        "Chinese binary selects its exact profile");
+  Check(chinese != nullptr &&
+            std::wcscmp(chinese->readiness_module, L"wuvorbis.dll") == 0,
+        "profile waits for the observed decoder module");
+
+  const auto* japanese = hibiki_voice_hook::FindKirikiriDelayedAttachProfile(
+      "07a2a3d6aa665e3e2c4958fbf9fecfd93a5c9baac797813a152736b1edba3245");
+  Check(japanese != nullptr, "verified Japanese binary selects delayed attach");
+  Check(japanese != nullptr && std::strcmp(japanese->id, "futamata-renai-jp") == 0,
+        "Japanese binary selects its exact profile");
+
+  Check(hibiki_voice_hook::FindKirikiriDelayedAttachProfile(
+            "0cb927556f83b41b08624c52ede135ce5be652ead8305e701d7be89e10d6c1eb") ==
+            nullptr,
+        "one-nibble near miss keeps normal KiriKiri early injection");
+  Check(hibiki_voice_hook::FindKirikiriDelayedAttachProfile(
+            "2280110000000000000000000000000000000000000000000000000000000000") ==
+            nullptr,
+        "unrelated KiriKiri sample keeps normal early injection");
+  Check(hibiki_voice_hook::FindKirikiriDelayedAttachProfile("") == nullptr,
+        "missing identity never enables delayed attach");
+
+  if (failures == 0) {
+    std::printf("kirikiri_launch_profile_test: all checks passed\n");
+    return 0;
+  }
+  return 1;
+}

--- a/native/galgame_hook/tests/voice_hook_ipc_name_test.cpp
+++ b/native/galgame_hook/tests/voice_hook_ipc_name_test.cpp
@@ -1,0 +1,27 @@
+#include "voice_hook_ipc.h"
+
+#include <cassert>
+
+int main() {
+  using hibiki_voice_hook::ComponentUsesLegacyHibikiIpc;
+  using hibiki_voice_hook::ReadyEventName;
+  using hibiki_voice_hook::SharedMemoryName;
+
+  assert(ComponentUsesLegacyHibikiIpc(
+      L"D:\\hibiki\\Hibiki\\voice_hook\\x86\\hibiki_voice_injector.exe"));
+  assert(ComponentUsesLegacyHibikiIpc(
+      L"D:\\hibiki\\Hibiki\\voice_hook\\x86\\HIBIKI_VOICE_HOOK.DLL"));
+  assert(!ComponentUsesLegacyHibikiIpc(
+      L"D:\\fushi\\voice_hook\\x86\\fushi_voice_injector.exe"));
+  assert(!ComponentUsesLegacyHibikiIpc(
+      L"D:\\games\\hibiki_voice_hook.dll.backup"));
+  assert(!ComponentUsesLegacyHibikiIpc(L""));
+
+  assert(SharedMemoryName(32464, true) ==
+         L"Local\\HibikiVoiceHook_32464");
+  assert(ReadyEventName(32464, true) ==
+         L"Local\\HibikiVoiceHookReady_32464");
+  assert(SharedMemoryName(32464) == L"Local\\FushiVoiceHook_32464");
+  assert(ReadyEventName(32464) == L"Local\\FushiVoiceHookReady_32464");
+  return 0;
+}


### PR DESCRIPTION
## Summary

- add binary-scoped delayed-attach profiles for the supplied Chinese and Japanese Futamata Ren'ai executables
- wait for the game window and `wuvorbis.dll` before injecting, while preserving early injection for every unrelated KiriKiri binary
- preserve legacy `HibikiVoiceHook` IPC and legacy DLL naming when the helper is deployed under `hibiki_*` component names
- add focused negative coverage for near-miss hashes, unrelated KiriKiri binaries, component-name matching, and both IPC namespaces

## Root cause

The affected KiriKiri title crashes with an access violation when the raw TVP stream adapter is installed from the `CREATE_SUSPENDED` startup boundary. Direct launch followed by delayed attach is stable.

During validation against an older Hibiki installation, two rename-compatibility boundaries were also exposed: the new injector defaults to `fushi_voice_hook.dll`, and the new helper creates `FushiVoiceHook` named mappings while the old host opens `HibikiVoiceHook`. Selecting the DLL and IPC namespace from the exact deployed component basename keeps both old Hibiki and current Fushi layouts consistent.

## User impact

Futamata Ren'ai can launch without the fatal access-violation dialog. Older Hibiki hosts can also consume the patched helper without `hookDllMissing` or `voice_hook_open_mapping_not_found` failures. Other KiriKiri binaries retain the existing early-injection behavior.

## Validation

Per request, no additional local tests or full local build were run for PR submission.

Earlier targeted evidence gathered during diagnosis:

- focused KiriKiri launch-profile test passed
- focused legacy/Fushi IPC-name test passed
- real x86 launch with Japanese locale and LunaHook returned `OK hooked`; the game window remained responsive
- legacy deployment exposed `Local\\HibikiVoiceHook_<pid>` and did not expose the Fushi mapping

Not run: full CTest, x64 matrix, Flutter test suite, or card-creation E2E. Support status remains `implemented_unverified`.
