### PR TITLE
fix(rename): W9 漏网两处——lapis 测试断言字面量与 iOS 打包路径

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -1453,7 +1453,7 @@ jobs:
           rm -f "$out_dir"/fushi-*-ios.ipa
           (
             cd "$payload_dir"
-            zip -qry "$GITHUB_WORKSPACE/hibiki/$out_dir/fushi-${BUILD_VERSION_NAME}-ios.ipa" Payload
+            zip -qry "$GITHUB_WORKSPACE/fushi/$out_dir/fushi-${BUILD_VERSION_NAME}-ios.ipa" Payload
           )
       # The single non-blocking `publish` job downloads this artifact and does
       # all Release publishing, so iOS builds in parallel with Windows/macOS and

--- a/packages/fushi_anki/test/lapis_style_preview_test.dart
+++ b/packages/fushi_anki/test/lapis_style_preview_test.dart
@@ -119,7 +119,7 @@ void main() {
         LapisVisualField.primaryDefinition: <String>['id="primary"'],
         LapisVisualField.glossaries: <String>['id="glossaries"'],
         LapisVisualField.dictionaryEntry: <String>['<li data-dictionary='],
-        LapisVisualField.dictionaryName: <String>['<i data-hibiki-lapis-'],
+        LapisVisualField.dictionaryName: <String>['<i data-fushi-lapis-'],
         LapisVisualField.definitionExample: <String>[
           'data-sc-content="example-sentence"',
         ],


### PR DESCRIPTION
W9 重命名 sweep 的两处漏网，互相独立、各 1 行。

## 1. `packages/fushi_anki/test/lapis_style_preview_test.dart:122`

产品代码（`lapis_style_preview.dart` / `lapis_template_preview.dart`）生成的属性早已是 `data-fushi-lapis-targets`，只有这条锚点断言还写着 `<i data-hibiki-lapis-`——因为它是**截断前缀**（不带 `targets`），W9 的替换规则按完整属性名匹配，正好漏过；同文件另外 3 处带 `targets` 的都已改对。

根因在测试侧，不在生成侧：全仓 `grep -rn "data-hibiki-lapis"` 改前只此 1 处命中，产品代码零残留。

这条是 develop 上的**真红**（变异实测：把该行改回旧前缀，`预览携带每个可视字段 selector 所依赖的真实锚点` 立刻失败并报 `预览缺少 dictionary-name 依赖的锚点 <i data-hibiki-lapis-`）。

## 2. `.github/workflows/release-desktop.yml:1456`

app 目录已从 `hibiki/` 改名为 `fushi/`。该 step 的 `working-directory: fushi`，`mkdir -p "$out_dir"` 建的是 `fushi/build/release-artifacts`，下游 `upload-artifact` 也取 `fushi/build/release-artifacts/fushi-*-ios.ipa`；唯独 `zip` 的绝对路径还写 `$GITHUB_WORKSPACE/hibiki/`，指向不存在的目录 → `zip error: Could not create output file`，iOS IPA 产物必然构建失败。

改后 `grep -rn "GITHUB_WORKSPACE/hibiki\|workspace/hibiki" .github/` 零残留；顺带扫的 `cd hibiki` / `hibiki/build` / `working-directory: hibiki` 也无命中。（`.github/` 里剩下的 `hibiki` 字样是 `$RUNNER_TEMP/hibiki-*` 临时目录名、外部资产名 `Magpie-hibiki-slim-x64.zip` 和注释，与路径正确性无关，本 PR 不动。）

## 验证

- `flutter test packages/fushi_anki/test/lapis_style_preview_test.dart --no-pub` → `+8: All tests passed!`，退出码 0（未接管道）。
- yml 无法本地跑；`git diff --check` 干净，路径已与同 step 的 `working-directory` 及下游 upload 路径人工比对一致。

https://claude.ai/code/session_01NX1YJLbT3UWFQYHez9LwmV
