### PR TITLE
fix(installer): Windows 旧名清理下沉到 ssPostInstall，补任务栏死链接（BUG-1460）

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -29,10 +29,11 @@
 
 <!-- BUGS-INDEX:BEGIN（自动生成，勿手改；改完跑 `dart run tool/bug.dart reindex`）-->
 
-> 共 1365 条。点号进各自文件。
+> 共 1366 条。点号进各自文件。
 
 | BUG | 修复 | 测试 | 标题 |
 |---|:--:|:--:|---|
+| [BUG-1460](bugs/BUG-1460-win-installer-legacy-delete-rollback.md) | ✅ | ✅ | Windows 升级中途失败后 app 彻底消失：[InstallDelete] 先删旧名二进制且不可回滚 |
 | [BUG-1459](bugs/BUG-1459-installer-appdir-process-lock.md) | ✅ | ✅ | 安装器无法替换被残留子进程锁定的文件 |
 | [BUG-1458](bugs/BUG-1458-sync-collections-tombstone-day-red.md) | 🚧 | 🚧 | 集合同步墓碑用例在develop稳定红-疑日期敏感 |
 | [BUG-1457](bugs/BUG-1457-ai6-clean-voice.md) | ✅ | ✅ | AI6 制卡误用混合 BGM |

--- a/docs/bugs/BUG-1460-win-installer-legacy-delete-rollback.md
+++ b/docs/bugs/BUG-1460-win-installer-legacy-delete-rollback.md
@@ -1,0 +1,26 @@
+## BUG-1460 · Windows 升级中途失败后 app 彻底消失：[InstallDelete] 先删旧名二进制且不可回滚
+- **报告**：2026-08-08（用户：升级后 app 完全打不开）
+- **真实性**：✅ 真 bug，根因 `fushi/windows/installer/fushi.iss:56-67`（修复前）
+  - 现场证据：注册表 `HKCU\...\Uninstall\{8F2C1A3E-...}_is1` 的 `InstallLocation=D:\APP\Hibiki\`（自定义目录），
+    该目录里 `hibiki.exe` 与 `fushi.exe` **都不存在**，只剩 `unins000.exe`；时间戳显示那次安装只写了
+    `data` / `magpie_bundle` / `mihon_bridge` / `unins000.*`，绝大多数 DLL 还停在前一天 —— 安装跑到一半没完成。
+  - 根因 1：`[InstallDelete]` 在**复制任何新文件之前**执行，且 Inno 明确**不会**在安装失败/取消时回滚这些删除。
+    旧脚本把 `{app}\hibiki.exe` / `hibiki_update_launcher.exe` / `hibiki_torrent_ffi.dll` / `hoshidicts_ffi.dll`
+    放在该段，于是任何一次中途失败的升级都把用户从「还剩个能跑的旧版」变成「一个可执行文件都没有」。
+    这几个旧名文件又都不与新文件同名，「复制前删」本来就没有任何必要性。
+  - 根因 2：旧名快捷方式只清了 `{userdesktop}\Hibiki.lnk` 和 `{group}\Hibiki.lnk`，漏了任务栏固定项
+    `%APPDATA%\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Hibiki.lnk`，它悬空指向
+    已被删除的 `hibiki.exe` —— 用户点任务栏图标毫无反应。
+  - 顺带：Inno 默认 `UsePreviousGroup=yes`，升级时从卸载键读回旧组名 `Hibiki`，`{group}` 解析成
+    `...\Programs\Hibiki`，新建的 Fushi 快捷方式会落进一个叫 Hibiki 的文件夹（实测该目录现在是空的）。
+- **[x] ① 已修复** — 旧名二进制 + 三处旧名快捷方式下沉到 `[Code]` 的 `CurStepChanged` / `ssPostInstall`
+  （新文件全部落地之后才删）；`{app}\galgame_helper` 留在 `[InstallDelete]`（新包同样往 `{app}` 写 helper 组件，
+  必须复制前删，且它不是可执行入口）；补上任务栏固定项清理；`UsePreviousGroup=no` + 清理遗留的
+  `{userprograms}\Hibiki` 程序组。提交见分支 `fix/win-installer-legacy-cleanup`。
+- **[x] ② 已加自动化测试** — 源码扫描守卫 `fushi/test/build/windows_installer_legacy_cleanup_guard_test.dart`
+  （4 条：`[InstallDelete]` 不得再出现旧名；ssPostInstall 必须删四个旧名二进制；ssPostInstall 必须覆盖
+  desktop / group / TaskBar 三处快捷方式；`UsePreviousGroup=no` + 遗留程序组清理）。守卫读的是
+  `CurStepChanged` 过程体并**剥掉 `//` 注释**，把断言字面量塞进注释骗不过它（已变异实测：
+  注释掉任务栏那行仍然转红）。
+- **备注**：平台限制（如实记录）——Windows 不提供程序化「固定到任务栏」的公开接口，所以任务栏那条
+  只能删掉死链接，**无法**自动改指 `fushi.exe`、也无法重新固定；已经丢了固定项的用户需要手动再固定一次。

--- a/fushi/test/build/windows_installer_legacy_cleanup_guard_test.dart
+++ b/fushi/test/build/windows_installer_legacy_cleanup_guard_test.dart
@@ -1,0 +1,167 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 回归守卫：Fushi 改名的「旧名残留清理」必须在 ssPostInstall 执行，
+/// 不得放回 `[InstallDelete]`。
+///
+/// 根因（实测现场）：`[InstallDelete]` 在复制任何新文件**之前**执行，且 Inno
+/// 明确不会在安装失败/取消时回滚这些删除。旧脚本把 `{app}\hibiki.exe` 等旧名
+/// 二进制和旧名快捷方式放在该段，于是一次中途失败的升级把用户从「还剩个能跑的
+/// 旧版」变成「一个可执行文件都没有」——用户机器上 `{app}` 里 hibiki.exe 与
+/// fushi.exe 双双消失，只剩 unins000.exe，任务栏固定项成了死链接。
+///
+/// 修复：这些条目下沉到 `[Code]` 的 `CurStepChanged` / `ssPostInstall`
+/// （新文件全部落地之后），并补上此前从未清理过的任务栏固定项。
+void main() {
+  String readInstallerScript() {
+    final File file = File('windows/installer/fushi.iss');
+    expect(
+      file.existsSync(),
+      isTrue,
+      reason: 'expected Inno Setup script at ${file.absolute.path}',
+    );
+    return file.readAsStringSync();
+  }
+
+  /// 截出 `[Section]` 头之后、下一个 `[Xxx]` 头之前的正文。
+  String sectionBody(String iss, String section) {
+    final int start =
+        iss.indexOf(RegExp(r'^\[' + section + r'\]$', multiLine: true));
+    expect(
+      start,
+      greaterThanOrEqualTo(0),
+      reason: 'installer script must contain a [$section] section',
+    );
+    final String after = iss.substring(start + section.length + 2);
+    final RegExpMatch? next =
+        RegExp(r'^\[[A-Za-z]', multiLine: true).firstMatch(after);
+    return next == null ? after : after.substring(0, next.start);
+  }
+
+  /// `[InstallDelete]` 段里真正生效的指令行（去掉空行与 `;` 注释行）。
+  List<String> directiveLines(String body) => body
+      .split('\n')
+      .map((String line) => line.trim())
+      .where((String line) => line.isNotEmpty && !line.startsWith(';'))
+      .toList();
+
+  /// `CurStepChanged` 的过程体，且**剥掉 `//` 注释**——否则把断言字面量写进
+  /// 注释就能骗过守卫。
+  String curStepChangedCode(String iss) {
+    final RegExp proc = RegExp(
+      r'procedure\s+CurStepChanged\s*\(\s*CurStep\s*:\s*TSetupStep\s*\)\s*;'
+      r'(.*?)\n\s*end\s*;',
+      dotAll: true,
+    );
+    final RegExpMatch? match = proc.firstMatch(iss);
+    expect(
+      match,
+      isNotNull,
+      reason: '必须存在 procedure CurStepChanged(CurStep: TSetupStep); '
+          '旧名清理只能在它的 ssPostInstall 分支里做。',
+    );
+    return match!.group(1)!.split('\n').map((String line) {
+      final int comment = line.indexOf('//');
+      return comment < 0 ? line : line.substring(0, comment);
+    }).join('\n');
+  }
+
+  test('[InstallDelete] no longer deletes legacy binaries or shortcuts', () {
+    final String iss = readInstallerScript();
+    final List<String> lines =
+        directiveLines(sectionBody(iss, 'InstallDelete'));
+
+    expect(
+      lines,
+      isNotEmpty,
+      reason: '[InstallDelete] 至少还要保留 galgame_helper 那条',
+    );
+    for (final String line in lines) {
+      expect(
+        line.toLowerCase().contains('hibiki'),
+        isFalse,
+        reason: '[InstallDelete] 在复制新文件前执行且不可回滚：任何旧名二进制/'
+            '快捷方式的删除都必须挪到 ssPostInstall，否则一次失败的升级会让用户'
+            '连一个可执行文件都不剩。命中行：$line',
+      );
+    }
+    expect(
+      lines.any((String line) => line.contains(r'{app}\galgame_helper')),
+      isTrue,
+      reason: 'galgame_helper 归属 [InstallDelete]（新包同样往 {app} 写 helper '
+          '组件，必须复制前删；且它不是可执行入口，删早了不影响可运行性）',
+    );
+  });
+
+  test('ssPostInstall removes the legacy binaries after files land', () {
+    final String code = curStepChangedCode(readInstallerScript());
+
+    expect(
+      code.contains('if CurStep <> ssPostInstall then'),
+      isTrue,
+      reason: '清理必须门在 ssPostInstall（新文件已全部落地）之后',
+    );
+    const List<String> legacyBinaries = <String>[
+      r"DeleteFile(ExpandConstant('{app}\hibiki.exe'));",
+      r"DeleteFile(ExpandConstant('{app}\hibiki_update_launcher.exe'));",
+      r"DeleteFile(ExpandConstant('{app}\hibiki_torrent_ffi.dll'));",
+      r"DeleteFile(ExpandConstant('{app}\hoshidicts_ffi.dll'));",
+    ];
+    for (final String call in legacyBinaries) {
+      expect(
+        code.contains(call),
+        isTrue,
+        reason: 'ssPostInstall 必须清掉旧名二进制，缺失：$call',
+      );
+    }
+  });
+
+  test('ssPostInstall covers all three legacy shortcut locations', () {
+    final String code = curStepChangedCode(readInstallerScript());
+
+    const Map<String, String> shortcuts = <String, String>{
+      '桌面': r"DeleteFile(ExpandConstant('{userdesktop}\Hibiki.lnk'));",
+      '开始菜单程序组': r"DeleteFile(ExpandConstant('{group}\Hibiki.lnk'));",
+      // Windows 不提供程序化「固定到任务栏」的接口，所以只能删死链接、
+      // 无法自动重新固定；但**不删**就是用户点任务栏图标毫无反应。
+      '任务栏固定项': r"DeleteFile(ExpandConstant('{userappdata}\Microsoft"
+          r"\Internet Explorer\Quick Launch\User Pinned\TaskBar\Hibiki.lnk'));",
+    };
+    shortcuts.forEach((String where, String call) {
+      expect(
+        code.contains(call),
+        isTrue,
+        reason: '旧名快捷方式三处位置必须都在 ssPostInstall 清理，缺「$where」：'
+            '$call',
+      );
+    });
+  });
+
+  test('start menu group is forced back to Fushi and the legacy one cleaned',
+      () {
+    final String iss = readInstallerScript();
+
+    expect(
+      RegExp(r'^UsePreviousGroup=no\s*$', multiLine: true).hasMatch(iss),
+      isTrue,
+      reason: 'Inno 默认 UsePreviousGroup=yes 会从卸载键读回旧组名 Hibiki，'
+          '使 {group} 指向 ...\\Programs\\Hibiki，新建的 Fushi 快捷方式落进一个'
+          '叫 Hibiki 的文件夹。必须显式 UsePreviousGroup=no。',
+    );
+
+    final String code = curStepChangedCode(iss);
+    const List<String> legacyGroup = <String>[
+      r"DeleteFile(ExpandConstant('{userprograms}\Hibiki\Hibiki.lnk'));",
+      r"DeleteFile(ExpandConstant('{userprograms}\Hibiki\Fushi.lnk'));",
+      r"RemoveDir(ExpandConstant('{userprograms}\Hibiki'));",
+    ];
+    for (final String call in legacyGroup) {
+      expect(
+        code.contains(call),
+        isTrue,
+        reason: '遗留的 Programs\\Hibiki 程序组必须清空后移除，缺失：$call',
+      );
+    }
+  });
+}

--- a/fushi/windows/installer/fushi.iss
+++ b/fushi/windows/installer/fushi.iss
@@ -20,6 +20,15 @@ AppPublisher=Fushi
 DefaultDirName={localappdata}\Fushi
 DefaultGroupName=Fushi
 DisableProgramGroupPage=yes
+; Fushi 改名：Inno 默认 UsePreviousGroup=yes，升级时从卸载键里读回上一次的
+; 「Inno Setup: Icon Group」（旧安装写的是 Hibiki），于是 {group} 解析成
+; ...\Programs\Hibiki，新建的 Fushi 快捷方式会落进一个叫 Hibiki 的文件夹里
+; （实测用户机器上 Programs\Hibiki 现在是空目录，正是这条路径的产物）。
+; 关掉它，强制用 DefaultGroupName=Fushi；遗留的 Programs\Hibiki 在
+; CurStepChanged/ssPostInstall 里清理（先删旧 lnk，目录空了才 RemoveDir）。
+; DisableProgramGroupPage=yes 意味着用户从来无法自定义组名，所以这里不存在
+; 「覆盖用户选择」的风险。
+UsePreviousGroup=no
 PrivilegesRequired=lowest
 OutputDir={#OutputDir}
 OutputBaseFilename=fushi-{#AppVersion}-windows-setup
@@ -51,20 +60,17 @@ Name: "videoassoc"; Description: "将 Fushi 加入视频文件的「打开方式
 ; GalgameHelperInstaller 就会拿这份**旧** zip 回填，把安装器刚放好的新组件覆盖成旧的，
 ; 直接复发 BUG-1448 的「组件比本体旧」。删的是上一版留下的归档，不碰用户数据。
 Type: filesandordirs; Name: "{app}\galgame_helper"
-; Fushi 改名：升级时清掉旧名二进制（Inno 不删除未被覆盖的旧文件，不清则
-; hibiki.exe 与 fushi.exe 并存，旧快捷方式还能把旧版拉起来）。
-Type: files; Name: "{app}\hibiki.exe"
-Type: files; Name: "{app}\hibiki_update_launcher.exe"
-; 同理清掉旧名 native 产物（改名前 windows/CMakeLists.txt 装的是 hoshidicts_ffi.dll
-; 与 hibiki_torrent_ffi.dll）。Inno 只覆盖同名文件，改了名的旧 DLL 会永久留在 {app}：
-; 一是纯垃圾，二是 torrent 引擎按名加载「exe 同目录」，留着就等于给「新 DLL 缺失时
-; 静默加载上一版旧 ABI」留了口子。清掉之后 defaultLibraryNames 的旧名回退也随之作废。
-Type: files; Name: "{app}\hibiki_torrent_ffi.dll"
-Type: files; Name: "{app}\hoshidicts_ffi.dll"
-; 旧名快捷方式指向已被删除的 hibiki.exe，一并清掉（桌面图标位置一次性丢失，
-; 换来不留死链接；新名快捷方式按 BUG-1014 规则只建一次）。
-Type: files; Name: "{userdesktop}\Hibiki.lnk"
-Type: files; Name: "{group}\Hibiki.lnk"
+; 归属判据：本段只放「必须在复制前删、且删了不影响可运行性」的条目。
+; 上面 {app}\galgame_helper 两点都满足——新包同样往 {app} 下写 helper 组件，
+; 不先删就会被旧归档回填；而它本身不是可执行入口，删早了不会让 app 打不开。
+;
+; 旧名二进制（hibiki.exe / hibiki_update_launcher.exe / hibiki_torrent_ffi.dll /
+; hoshidicts_ffi.dll）和旧名快捷方式**不在这里**：[InstallDelete] 在复制任何新文件
+; 之前执行，且 Inno 明确不会在安装失败/取消时回滚这些删除。它们又都不与新文件同名，
+; 所以「复制前删」没有任何必要性，却把一次中途失败的升级从「还剩个能跑的旧版」
+; 变成「一个可执行文件都没有」（实测现场：{app} 下 hibiki.exe 与 fushi.exe 双双消失，
+; 只剩 unins000.exe，快捷方式全成死链接）。这些条目已下沉到 [Code] 的
+; CurStepChanged / ssPostInstall，即新文件全部落地之后才执行。
 
 [Files]
 ; 包含 fushi_update_launcher.exe：应用内更新用它等待当前 fushi.exe 退出后再启动 Inno。
@@ -239,6 +245,48 @@ end;
 function ShouldCreateDesktopIcon(): Boolean;
 begin
   Result := not FileExists(ExpandConstant('{userdesktop}\Fushi.lnk'));
+end;
+
+// Fushi 改名的旧名残留清理，全部放在 ssPostInstall（新文件已全部落地之后），
+// 不放 [InstallDelete]：后者在复制前执行，且 Inno 不会在安装失败/取消时回滚删除，
+// 于是任何一次中途失败的升级都会把「还剩个能跑的旧版」变成「一个可执行文件都没有」。
+// ssPostInstall 只有在文件复制成功后才会到达，删旧名二进制不再有这个窗口。
+//
+// 平台限制（如实记录）：Windows 不提供程序化「固定到任务栏」的公开接口，
+// 所以任务栏固定项这里只能删掉指向已消失的 hibiki.exe 的死链接，
+// 无法自动改指 fushi.exe、也无法重新固定；用户需要的话得手动再固定一次。
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep <> ssPostInstall then
+    Exit;
+
+  // 旧名可执行文件：Inno 只覆盖同名文件，改了名的旧 exe 不清就会与 fushi.exe
+  // 并存，旧快捷方式还能把上一版拉起来。
+  DeleteFile(ExpandConstant('{app}\hibiki.exe'));
+  DeleteFile(ExpandConstant('{app}\hibiki_update_launcher.exe'));
+
+  // 旧名 native 产物（改名前 windows/CMakeLists.txt 装的是 hoshidicts_ffi.dll
+  // 与 hibiki_torrent_ffi.dll）。留着一是纯垃圾，二是 torrent 引擎按名加载
+  // 「exe 同目录」，等于给「新 DLL 缺失时静默加载上一版旧 ABI」留口子。
+  DeleteFile(ExpandConstant('{app}\hibiki_torrent_ffi.dll'));
+  DeleteFile(ExpandConstant('{app}\hoshidicts_ffi.dll'));
+
+  // 三处旧名快捷方式全部指向已删除的 hibiki.exe，都是死链接。
+  // 1) 桌面
+  DeleteFile(ExpandConstant('{userdesktop}\Hibiki.lnk'));
+  // 2) 开始菜单程序组（UsePreviousGroup=no 之后 {group} 已是 Fushi 组；
+  //    这条覆盖「旧 lnk 与新组同目录」的情形，遗留的 Hibiki 组另行处理）。
+  DeleteFile(ExpandConstant('{group}\Hibiki.lnk'));
+  // 3) 任务栏固定项——[InstallDelete] 从来没清过它，正是用户实测那个
+  //    「任务栏图标点了没反应」的死链接来源。
+  DeleteFile(ExpandConstant('{userappdata}\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Hibiki.lnk'));
+
+  // 遗留的 Programs\Hibiki 程序组：旧安装留下的 Hibiki.lnk，以及
+  // UsePreviousGroup=yes 时期误建在该组里的 Fushi.lnk。两个都删掉后目录空了才移除
+  // （RemoveDir 只删空目录，用户自己往里放的东西不会被波及）。
+  DeleteFile(ExpandConstant('{userprograms}\Hibiki\Hibiki.lnk'));
+  DeleteFile(ExpandConstant('{userprograms}\Hibiki\Fushi.lnk'));
+  RemoveDir(ExpandConstant('{userprograms}\Hibiki'));
 end;
 
 function InitializeSetup(): Boolean;


### PR DESCRIPTION
## 问题

用户升级后 app 完全打不开。实测现场：

- 注册表 `HKCU\...\Uninstall\{8F2C1A3E-...}_is1` 的 `InstallLocation=D:\APP\Hibiki\`（自定义目录）
- 该目录里 `hibiki.exe` 和 `fushi.exe` **都不存在**，只剩 `unins000.exe` + 三个测试 exe
- 时间戳显示那次安装只写了 `data` / `magpie_bundle` / `mihon_bridge` / `unins000.*`，绝大多数 DLL 还停在前一天 —— 安装**跑到一半没完成**
- 悬空的快捷方式是任务栏固定项：`%APPDATA%\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Hibiki.lnk ==> D:\APP\Hibiki\hibiki.exe`
- `开始菜单\Programs\Hibiki\` 是空文件夹

## 根因 1：`[InstallDelete]` 删旧名二进制的时机错了，且不可回滚

Inno 的 `[InstallDelete]` 在**复制任何新文件之前**执行，而且 Inno 明确**不会**在安装失败/取消时回滚这些删除。旧脚本把这四条放在该段：

```
Type: files; Name: "{app}\hibiki.exe"
Type: files; Name: "{app}\hibiki_update_launcher.exe"
Type: files; Name: "{app}\hibiki_torrent_ffi.dll"
Type: files; Name: "{app}\hoshidicts_ffi.dll"
```

后果：任何一次中途失败的升级都把用户从「还剩个能跑的旧版」变成「一个可执行文件都没有」。而这几个旧名文件**都不与新文件同名**，所以「复制前删」本来就没有任何必要性。

修法：全部下沉到 `[Code]` 的 `CurStepChanged` / `ssPostInstall`（新文件已全部落地之后）。

`{app}\galgame_helper` 保持在 `[InstallDelete]` 不动 —— 判据写在脚本注释里：新包同样往 `{app}` 下写 helper 组件，不先删就会被旧归档回填（BUG-1448/1449）；而它本身不是可执行入口，删早了不会让 app 打不开。两条都满足「必须复制前删 + 删了不影响可运行性」。

## 根因 2：任务栏固定项从来没被清理

`[InstallDelete]` 只清了 `{userdesktop}\Hibiki.lnk` 和 `{group}\Hibiki.lnk`。现在三处（desktop / group / TaskBar）一并在 `ssPostInstall` 删除。

**平台限制（如实记录）**：Windows 不提供程序化「固定到任务栏」的公开接口，所以任务栏那条只能删掉指向已消失 `hibiki.exe` 的死链接，**无法**自动改指 `fushi.exe`、也无法重新固定。已经丢了固定项的用户需要手动再固定一次。

## 顺带：`{group}` / `UsePreviousGroup`

`DefaultGroupName=Fushi`，但 Inno 默认 `UsePreviousGroup=yes`：升级时从卸载键的 `Inno Setup: Icon Group` 读回上一次的组名（旧安装写的是 `Hibiki`），于是 `{group}` 解析成 `...\Programs\Hibiki`，新建的 Fushi 快捷方式会落进一个叫 **Hibiki** 的文件夹。用户机器上 `Programs\Hibiki` 现在是空目录，正是这条路径的产物（`Hibiki.lnk` 被 `[InstallDelete]` 删了，`Fushi.lnk` 因为安装中止没建成）。

判断：**改**。`DisableProgramGroupPage=yes` 意味着用户从来无法自定义组名，所以 `UsePreviousGroup=no` 不存在「覆盖用户选择」的风险，改名后组名就该是 Fushi。同时在 `ssPostInstall` 清理遗留的 `{userprograms}\Hibiki`：删掉 `Hibiki.lnk` 和 `UsePreviousGroup=yes` 时期误建在该组里的 `Fushi.lnk`，然后 `RemoveDir`（只删空目录，用户自己往里放的东西不受影响）。

## 测试

新增源码扫描守卫 `fushi/test/build/windows_installer_legacy_cleanup_guard_test.dart`（4 条）：

1. `[InstallDelete]` 的指令行不得再出现 `hibiki`（旧名二进制/快捷方式）；`galgame_helper` 必须仍在
2. `ssPostInstall` 必须删掉四个旧名二进制，且门在 `if CurStep <> ssPostInstall then Exit;`
3. `ssPostInstall` 必须覆盖 desktop / group / TaskBar 三处快捷方式
4. `UsePreviousGroup=no` + 遗留 `{userprograms}\Hibiki` 程序组清理

守卫读的是 `CurStepChanged` 的过程体并**剥掉 `//` 注释**，把断言字面量塞进注释骗不过它。

**变异实测**（4 个变异全部转红，反向字符串替换还原后字节级比对与预期版本 IDENTICAL）：

| 变异 | 结果 |
|---|---|
| 把 `Type: files; Name: "{app}\hibiki.exe"` 塞回 `[InstallDelete]` | 红 |
| 删掉 `DeleteFile(ExpandConstant('{app}\hoshidicts_ffi.dll'));` | 红 |
| 把任务栏那行 `DeleteFile` 注释掉（字面量仍在文件里） | 红 |
| `UsePreviousGroup=no` 改回 `yes` | 红 |

`flutter test test/build/ --no-pub` → `All tests passed!`（261 tests，exit 0）
`flutter analyze` → `No issues found!`（exit 0）

BUG-1460

https://claude.ai/code/session_01NX1YJLbT3UWFQYHez9LwmV
