### PR TITLE
fix(android): 修复启动即闪退——改名后 R8 keep 规则指向失效包名

### DIFF
--- a/fushi/android/app/proguard-rules.pro
+++ b/fushi/android/app/proguard-rules.pro
@@ -5,8 +5,16 @@
 -keep class io.flutter.** { *; }
 -keep class io.flutter.plugins.** { *; }
 
-# Hibiki native channels & providers
--keep class app.hibiki.reader.** { *; }
+# Fushi native channels & providers.
+# This package filter MUST track applicationId / namespace in android/app/build.gradle.
+# The W8 directory rename moved applicationId from app.hibiki.reader to app.fushi.reader
+# but left this keep rule pointing at the old package, so it matched zero classes and
+# every app-side Kotlin/Java class entered R8's optimization surface for the first time.
+# R8 then horizontally merged the anonymous FullTypeReference subclasses that Injekt's
+# reified `addSingleton` / `addSingletonFactory` inline into MihonChannelHandler, which
+# made getGenericSuperclass() stop being a ParameterizedType and crashed
+# MainActivity.onCreate with "TypeReference constructed without actual type information".
+-keep class app.fushi.reader.** { *; }
 
 # audio_service background isolate
 -keep class com.ryanheise.audioservice.** { *; }
@@ -46,3 +54,15 @@
 -keep class androidx.preference.** { *; }
 -keep class androidx.compose.runtime.** { *; }
 -keepattributes *Annotation*,Signature,InnerClasses,EnclosingMethod
+
+# Injekt reflective generics backstop (package-independent, survives future renames).
+# `addSingleton<T>()` / `addSingletonFactory<T>()` are reified inline functions that
+# expand to `object : FullTypeReference<T>() {}` at the call site, and Injekt reads the
+# type argument back out via javaClass.genericSuperclass. R8's horizontal/vertical class
+# merging destroys that superclass signature. allowshrinking+allowobfuscation keeps the
+# classes eligible for removal and renaming (no size regression) while opting them out of
+# class merging and forcing Signature retention -- the same pattern R8 ships for
+# Gson's TypeToken.
+-keep,allowshrinking,allowobfuscation class uy.kohesive.injekt.api.TypeReference
+-keep,allowshrinking,allowobfuscation class uy.kohesive.injekt.api.FullTypeReference
+-keep,allowshrinking,allowobfuscation class * extends uy.kohesive.injekt.api.FullTypeReference

--- a/fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java
+++ b/fushi/android/app/src/main/java/app/fushi/reader/MainActivity.java
@@ -132,7 +132,20 @@ public class MainActivity extends AudioServiceActivity {
         context = MainActivity.this;
         ankiChannelHandler = new AnkiChannelHandler(context);
         ttsChannelHandler = new TtsChannelHandler(context);
-        mihonChannelHandler = new MihonChannelHandler(getApplication());
+        // Manga extensions are an optional subsystem. Its constructor wires up
+        // Injekt, whose reified type resolution is only as sound as the R8 keep
+        // rules (a stale keep rule once made this throw on every launch and
+        // bricked the whole app). Nothing else in Fushi depends on it, so a
+        // failure here degrades to "manga extensions unavailable" instead of
+        // taking down startup: the Dart side already maps an unregistered
+        // channel to MihonRuntimeException('UNAVAILABLE').
+        try {
+            mihonChannelHandler = new MihonChannelHandler(getApplication());
+        } catch (Throwable e) {
+            mihonChannelHandler = null;
+            android.util.Log.e("fushi-mihon",
+                "Mihon runtime init failed; manga extensions disabled this session", e);
+        }
 
         super.onCreate(savedInstanceState);
 
@@ -525,7 +538,9 @@ public class MainActivity extends AudioServiceActivity {
 
         ankiChannelHandler.register(flutterEngine);
         ttsChannelHandler.register(flutterEngine);
-        mihonChannelHandler.register(flutterEngine);
+        if (mihonChannelHandler != null) {
+            mihonChannelHandler.register(flutterEngine);
+        }
 
         new MethodChannel(flutterEngine.getDartExecutor().getBinaryMessenger(), SAF_CHANNEL)
             .setMethodCallHandler((call, result) -> {

--- a/fushi/android/fastlane/Appfile
+++ b/fushi/android/fastlane/Appfile
@@ -1,2 +1,2 @@
 json_key_file("") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
-package_name("app.hibiki.reader") # e.g. com.krausefx.app
+package_name("app.fushi.reader") # e.g. com.krausefx.app

--- a/fushi/test/build/android_app_package_keep_rule_guard_test.dart
+++ b/fushi/test/build/android_app_package_keep_rule_guard_test.dart
@@ -1,0 +1,199 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The Android application identity lives in exactly one place
+/// (`android/app/build.gradle`). Everything that has to name the app package —
+/// most importantly the R8 keep rule that shields the whole app from
+/// obfuscation and class merging — must be derived from it, never hardcoded to
+/// a stale copy.
+///
+/// This guard exists because the W8 `hibiki/` -> `fushi/` rename moved
+/// `applicationId` to `app.fushi.reader` but left
+/// `-keep class app.hibiki.reader.** { *; }` behind in proguard-rules.pro. The
+/// rule then matched zero classes, so every app-side class entered R8's
+/// optimization surface for the first time; R8 merged the anonymous
+/// `FullTypeReference` subclasses that Injekt's reified `addSingleton` /
+/// `addSingletonFactory` inline into `MihonChannelHandler`, `genericSuperclass`
+/// stopped being a `ParameterizedType`, and every launch died in
+/// `MainActivity.onCreate` with
+/// "Internal error: TypeReference constructed without actual type information".
+///
+/// A stale keep rule is invisible: it is valid ProGuard syntax, R8 does not warn
+/// about rules that match nothing, and `flutter analyze` cannot see build config
+/// at all. Only a release build on a real device surfaces it. Hence this guard.
+void main() {
+  final File buildGradle = File('android/app/build.gradle');
+  final File proguard = File('android/app/proguard-rules.pro');
+
+  /// Active (non-comment, non-blank) lines of a ProGuard config.
+  List<String> activeRules(String source) => source
+      .split('\n')
+      .map((String line) => line.trim())
+      .where((String line) => line.isNotEmpty && !line.startsWith('#'))
+      .toList();
+
+  String? singleQuotedValue(String source, String key) {
+    final RegExpMatch? match =
+        RegExp(r'^\s*' + key + r'\s+"([^"]+)"', multiLine: true)
+            .firstMatch(source);
+    return match?.group(1);
+  }
+
+  test('R8 keep rule for the app package tracks applicationId', () {
+    final String gradle = buildGradle.readAsStringSync();
+    final String? applicationId = singleQuotedValue(gradle, 'applicationId');
+    final String? namespace = singleQuotedValue(gradle, 'namespace');
+
+    expect(applicationId, isNotNull,
+        reason: 'android/app/build.gradle must declare applicationId.');
+    expect(namespace, applicationId,
+        reason: 'namespace and applicationId must be the same package, '
+            'otherwise a single keep rule cannot cover the app.');
+
+    final List<String> rules = activeRules(proguard.readAsStringSync());
+
+    expect(
+      rules,
+      contains('-keep class $applicationId.** { *; }'),
+      reason: 'proguard-rules.pro must keep the whole app package '
+          '($applicationId). Without it R8 class-merges the anonymous '
+          'FullTypeReference subclasses Injekt inlines into '
+          'MihonChannelHandler and the app crashes on launch. If the app is '
+          'renamed again, this rule must be renamed in the same commit.',
+    );
+  });
+
+  test('no keep rule still names a stale app.<name>.reader package', () {
+    final String gradle = buildGradle.readAsStringSync();
+    final String applicationId = singleQuotedValue(gradle, 'applicationId')!;
+
+    final RegExp appPackage = RegExp(r'app\.[A-Za-z0-9_]+\.reader');
+    final List<String> stale = <String>[];
+    for (final String rule in activeRules(proguard.readAsStringSync())) {
+      if (!rule.startsWith('-keep')) continue;
+      for (final RegExpMatch match in appPackage.allMatches(rule)) {
+        if (match.group(0) != applicationId) {
+          stale.add(rule);
+        }
+      }
+    }
+
+    expect(
+      stale,
+      isEmpty,
+      reason: 'These keep rules name an app package that is not the current '
+          'applicationId ($applicationId), so they match zero classes and '
+          'silently drop the app out of R8 protection: $stale',
+    );
+  });
+
+  test('Injekt FullTypeReference subclasses are excluded from class merging',
+      () {
+    final List<String> rules = activeRules(proguard.readAsStringSync());
+
+    // Package-independent backstop: even if the app package keep rule is ever
+    // narrowed or the app is renamed again, the reflective-generics classes
+    // Injekt depends on must keep their superclass signature. allowshrinking +
+    // allowobfuscation is deliberate: it keeps them removable and renameable
+    // (no size regression) while opting them out of horizontal/vertical class
+    // merging — the same pattern R8 ships for Gson's TypeToken.
+    const String base = 'uy.kohesive.injekt.api.FullTypeReference';
+    expect(
+      rules,
+      contains('-keep,allowshrinking,allowobfuscation class * extends $base'),
+      reason: 'Subclasses of $base are generated at every reified '
+          'addSingleton/addSingletonFactory call site and are read back via '
+          'javaClass.genericSuperclass. R8 class merging destroys that '
+          'signature.',
+    );
+    expect(
+        rules, contains('-keep,allowshrinking,allowobfuscation class $base'));
+    expect(
+      rules,
+      contains(
+          '-keep,allowshrinking,allowobfuscation class uy.kohesive.injekt.api.TypeReference'),
+    );
+  });
+
+  test('guard premise still holds: release minifies and Injekt is inlined', () {
+    final String gradle = buildGradle.readAsStringSync();
+    expect(
+      gradle,
+      contains('minifyEnabled true'),
+      reason:
+          'If minification is ever disabled, this whole guard is moot — but '
+          'disabling it is a size/startup regression, not a fix. Removing R8 '
+          'must be a deliberate, reviewed decision, not a silent workaround for '
+          'the next keep-rule bug.',
+    );
+
+    final String applicationId = singleQuotedValue(gradle, 'applicationId')!;
+    final File handler = File(
+      'android/app/src/main/kotlin/${applicationId.replaceAll('.', '/')}'
+      '/mihon/MihonChannelHandler.kt',
+    );
+    expect(handler.existsSync(), isTrue,
+        reason: 'MihonChannelHandler must live under the applicationId package '
+            'so the app-wide keep rule covers it.');
+
+    final String source = handler.readAsStringSync();
+    expect(
+      source,
+      contains('uy.kohesive.injekt'),
+      reason: 'If Injekt usage disappears from the app, the FullTypeReference '
+          'keep rules above become dead weight and should be revisited.',
+    );
+    expect(
+      RegExp(r'addSingleton(Factory)?\s*[({]').hasMatch(source),
+      isTrue,
+      reason: 'These reified inline calls are what generate the '
+          'FullTypeReference subclasses the keep rules protect.',
+    );
+  });
+
+  test('an optional manga-extension failure cannot brick MainActivity', () {
+    // Defence in depth for the same crash class. The keep rule above removes
+    // *this* trigger, but MihonChannelHandler's constructor still runs Injekt
+    // wiring on the synchronous onCreate path, so any future failure in that
+    // optional subsystem would again make the app unlaunchable. It must be
+    // contained: construction guarded, field left null, registration skipped.
+    // The Dart side already turns an unregistered channel into
+    // MihonRuntimeException('UNAVAILABLE'), so degrading is a supported state.
+    final String activity =
+        File('android/app/src/main/java/app/fushi/reader/MainActivity.java')
+            .readAsStringSync();
+
+    final int construct = activity.indexOf('new MihonChannelHandler(');
+    expect(construct, isNonNegative);
+
+    final String before = activity.substring(0, construct);
+    final int tryIndex = before.lastIndexOf('try {');
+    final int stmtEnd = before.lastIndexOf(';');
+    expect(
+      tryIndex,
+      greaterThan(stmtEnd),
+      reason: 'new MihonChannelHandler(...) must be the first statement inside '
+          'a try block, otherwise an Injekt/extension-loader failure escapes '
+          'into onCreate and the whole app fails to start.',
+    );
+
+    final int catchIndex = activity.indexOf('catch (Throwable', construct);
+    expect(catchIndex, isNonNegative,
+        reason: 'The guard must catch Throwable: the observed failure was an '
+            'IllegalArgumentException thrown from a static initializer path, '
+            'and R8/linkage failures surface as Errors, not Exceptions.');
+
+    final int register = activity.indexOf('mihonChannelHandler.register(');
+    expect(register, isNonNegative);
+    // Narrow window on purpose: MainActivity null-checks the same field at the
+    // teardown site too, and a whole-file `contains` is satisfied by that
+    // unrelated check even when the register site is left unguarded.
+    expect(
+      activity.substring(register < 120 ? 0 : register - 120, register),
+      contains('mihonChannelHandler != null'),
+      reason: 'If construction was skipped the field is null; registering it '
+          'unconditionally would just move the crash to configureFlutterEngine.',
+    );
+  });
+}


### PR DESCRIPTION
## 根因

W8 目录改名（`b641a30fc`）把 `applicationId` 从 `app.hibiki.reader` 改成 `app.fushi.reader`，
但 `fushi/android/app/proguard-rules.pro` 里的

```
-keep class app.hibiki.reader.** { *; }
```

没跟着改。这条规则从此**匹配零个类**，app 侧全部 Kotlin/Java 类第一次落进 R8 的优化面。
R8 随即把 Injekt 的 reified `addSingleton` / `addSingletonFactory` 在 `MihonChannelHandler`
里内联生成的 `FullTypeReference` 匿名子类做了类合并，`javaClass.genericSuperclass` 不再是
`ParameterizedType`，于是每次启动都在 `MainActivity.onCreate` 抛：

```
java.lang.IllegalArgumentException: Internal error: TypeReference constructed without actual type information
	at uy.kohesive.injekt.api.FullTypeReference.<init>
	at h1.g.registerInjectables
	at h1.o.<init>
	at app.fushi.reader.MainActivity.onCreate
```

崩溃栈里 `MihonChannelHandler` 被混淆成 `h1.o`、匿名模块被混淆成 `h1.g`，而 `MainActivity`
因为在 manifest 里声明所以仍是原名——这正是「app 级 keep 规则已失效」的指纹。

`-keep class uy.kohesive.injekt.**` 只保住了**库**的类，保不住 app 侧内联生成的匿名子类；
R8 对匹配不到任何类的 keep 规则不告警，`flutter analyze` 也看不到构建配置，所以这个洞只有
release 真机启动才暴露。构建链路（AGP / Gradle wrapper / Kotlin / settings.gradle / Injekt 版本）
经逐文件 `git log origin/bridge-hibiki-final..origin/develop` 核对，**除改名外无任何改动**。

## 改动

- keep 规则跟上 `applicationId`；补一条与包名无关的 `FullTypeReference` 兜底
  （`allowshrinking,allowobfuscation`：不阻止缩减/重命名，只退出类合并并保住 `Signature`，
  与 R8 为 Gson `TypeToken` 自带的规则同款），未来再改名不会重蹈覆辙。
- `MainActivity` 的 Mihon 初始化改为容错：漫画扩展是可选子系统，构造失败只降级为
  「扩展不可用」并留 `null`，注册处加 null 判据。Dart 侧本就把未注册通道映射成
  `MihonRuntimeException('UNAVAILABLE')`，属已支持状态。**可选子系统不该有能力让主程序起不来。**
- `fastlane/Appfile` 的 `package_name` 同属改名漏网，一并修正。

## 守卫

`fushi/test/build/android_app_package_keep_rule_guard_test.dart`（5 条）——
从 `build.gradle` **读出 `applicationId` 反推** keep 规则，而不是硬编码包名字符串，
所以下次改名时它会主动报错而不是继续沉默。另断言：不存在指向其它 `app.*.reader` 包的
keep 规则、`FullTypeReference` 兜底存在、release 仍开 minify（防止有人用「关掉 R8」绕过）、
Mihon 初始化被 `try/catch` + null 判据围起来。四处变异实测均能转红。

## 真机验证（OnePlus CPH2747）

修前：`pidof` 空，crash buffer 有 `FATAL EXCEPTION` + `h1.o`/`h1.g` 栈。

修后（`flutter build apk --release --target-platform android-arm64`，与 release.yml
debug 通道同一构建方式）：

- `mapping.txt`：`app.fushi.reader.mihon.MihonChannelHandler -> app.fushi.reader.mihon.MihonChannelHandler:`
  与 `MihonChannelHandler$1 -> MihonChannelHandler$1:`（原为 `h1.o` / `h1.g`）均为恒等映射。
- 安装后进程稳定存活 18s+（pid 11614 不变），`topResumedActivity=app.fushi.reader/.MainActivityDefault`。
- `adb logcat -b crash -d` 零 `FATAL EXCEPTION`。
- 容错日志 `fushi-mihon` **未触发** —— 说明是根因修好了，不是被新加的 catch 掩盖。

`flutter analyze`：`No issues found!`；`flutter test test/build/`：262 passed。
