### PR TITLE
test(ci): 守卫 workflow 路径过滤与 hashFiles 必须指向真实路径

### DIFF
--- a/fushi/test/build/release_workflow_path_filter_guard_test.dart
+++ b/fushi/test/build/release_workflow_path_filter_guard_test.dart
@@ -1,0 +1,241 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// 守卫：workflow 的路径过滤 / `hashFiles()` 必须指向**真实存在**的路径。
+///
+/// 起因（W9 改名收尾）：app 目录从 `hibiki/` 改名成 `fushi/` 之后，
+/// `release.yml` / `release-desktop.yml` 的 push 触发器里那条 `- 'hibiki/**'`
+/// 一度还留着。这类失效**不会报错**——GitHub Actions 对匹配不到任何文件的
+/// paths 过滤项没有任何诊断，结果只是「改 app 代码不再触发发版构建」：
+/// workflow 静静地不跑，跟「没人推代码」长得一模一样。
+/// `hashFiles('hibiki/pubspec.lock')` 更隐蔽：它不报错，只是恒返回同一个
+/// 哈希，缓存 key 退化成常量，命中的永远是第一次存下的那份陈旧缓存。
+///
+/// 两条都是**静默失效**，只能靠「过滤项里写的路径必须真在磁盘上」来钉死。
+/// 所以本守卫不去比对 `hibiki` / `fushi` 这种具体名字（下一次改名它照样过期），
+/// 而是直接拿路径回磁盘上查——目录改名后忘了同步过滤项，这里必红。
+///
+/// ## 为什么本守卫**故意不掩掉 `#` 注释**
+///
+/// 其余 workflow 守卫一律先 `maskHashComments`，本守卫反着来：2026-08-07 起
+/// Fushi 改名过渡期把两条发布 workflow 的整个 `push:` 块**注释掉**了（见文件
+/// 头「暂停 push 自动发布」）。要守的那份 paths 清单此刻就住在注释里，掩掉注释
+/// 等于把守卫的全部对象抹成空白——那正是「静默全绿」。
+///
+/// 掩码换成「按列还原」：`  #   paths:` 去掉 `# ` 前缀后缩进关系与真 YAML 完全
+/// 一致，于是同一套块切分对「启用中」和「注释掉」两种形态都成立。等过渡期结束
+/// 把 `#` 去掉时，守卫无需改一行。
+void main() {
+  /// `flutter test` 的 cwd 是 app 目录本身，取它的名字当「真实 app 目录名」。
+  ///
+  /// 不写死字符串 `'fushi'`：本文件跟着 app 目录一起被 `git mv`，目录再改名时
+  /// 这个值自动跟着变，而 workflow 里的过滤项不会——差异正是要守的东西。
+  final String appDir =
+      Directory.current.uri.pathSegments.where((String s) => s.isNotEmpty).last;
+  final Directory repoRoot = Directory('..');
+  final Directory workflowsDir = Directory('../.github/workflows');
+
+  /// 发布链路的两条 workflow：它们的 push 过滤漏掉 app 目录 = 改代码不出包。
+  const List<String> releaseWorkflows = <String>[
+    'release.yml',
+    'release-desktop.yml',
+  ];
+
+  test('前置：app 目录名解析正确、workflows 目录存在', () {
+    expect(File('../$appDir/pubspec.yaml').existsSync(), isTrue,
+        reason: '从 cwd 推出的 app 目录名是 "$appDir"，但 ../$appDir/pubspec.yaml '
+            '不存在。本守卫的全部断言都建立在这个名字上，先修它。'
+            'cwd=${Directory.current.absolute.path}');
+    expect(workflowsDir.existsSync(), isTrue,
+        reason: 'expected ${workflowsDir.absolute.path}');
+  });
+
+  final List<File> workflows = workflowsDir.existsSync()
+      ? (workflowsDir
+          .listSync()
+          .whereType<File>()
+          .where(
+              (File f) => f.path.endsWith('.yml') || f.path.endsWith('.yaml'))
+          .toList()
+        ..sort((File a, File b) => a.path.compareTo(b.path)))
+      : <File>[];
+
+  /// 每个 workflow 里所有 `paths:` / `paths-ignore:` 清单项（含被注释掉的块）。
+  final List<_FilterEntry> allFilterEntries = <_FilterEntry>[];
+
+  /// workflow 名 -> 它的 push 触发器下的 paths 清单（注释掉的也算）。
+  final Map<String, List<_FilterEntry>> pushPaths =
+      <String, List<_FilterEntry>>{};
+
+  /// `hashFiles('a', 'b')` 里的每个字面量模式。
+  final List<_FilterEntry> hashFilePatterns = <_FilterEntry>[];
+
+  final RegExp hashFilesCall = RegExp(r'hashFiles\(([^)]*)\)');
+  final RegExp quoted = RegExp(r"'([^']*)'");
+  final RegExp filterHeaderPattern =
+      RegExp(r'^(\s*)(paths|paths-ignore):\s*(.*)$');
+  final RegExp listItemPattern = RegExp(r"^\s*-\s*'([^']*)'\s*$");
+  final RegExp triggerPattern = RegExp(r'^(\s*)([a-z_]+):\s*$');
+  final RegExp commentPrefix = RegExp(r'^(\s*)#\s?');
+
+  for (final File workflow in workflows) {
+    final String name = workflow.uri.pathSegments.last;
+    // 按列还原：注释掉的 YAML 去掉 `# ` 前缀后缩进关系与启用态一致。
+    // 缩进用捕获组回填保留，块切分才能沿用同一套缩进比较。
+    final List<String> logical = workflow.readAsLinesSync().map((String l) {
+      // 不能用 `replaceFirst(re, r'$1')`：String.replaceFirst 的替换串是**字面
+      // 量**，不做分组回填，`$1` 会原样写进结果，缩进层级全乱、push 块认不出来。
+      // 本守卫的「扫到了 push 清单」反向锚第一次跑就把这个 bug 抓了出来。
+      final RegExpMatch? m = commentPrefix.firstMatch(l);
+      return m == null ? l : '${m.group(1)!}${l.substring(m.end)}';
+    }).toList();
+
+    for (int i = 0; i < logical.length; i++) {
+      final RegExpMatch? filterHeader = filterHeaderPattern.firstMatch(
+        logical[i],
+      );
+      if (filterHeader != null) {
+        final int indent = filterHeader.group(1)!.length;
+        final String inline = filterHeader.group(3)!.trim();
+        final List<_FilterEntry> entries = <_FilterEntry>[];
+        // 行内形态：`paths: ['fushi/**']`（contributors.yml 就是这么写的）。
+        // `&anchor` / `*alias` 是 YAML 锚点，不含字面量路径。
+        if (inline.isNotEmpty &&
+            !inline.startsWith('&') &&
+            !inline.startsWith('*')) {
+          for (final RegExpMatch m in quoted.allMatches(inline)) {
+            entries.add(_FilterEntry(name, i + 1, m.group(1)!));
+          }
+        }
+        // 块形态：后续缩进更深的 `- '…'` 行。
+        for (int j = i + 1; j < logical.length; j++) {
+          final String line = logical[j];
+          if (line.trim().isEmpty) continue;
+          final int lead = line.length - line.trimLeft().length;
+          if (lead <= indent) break;
+          final RegExpMatch? item = listItemPattern.firstMatch(line);
+          if (item != null) {
+            entries.add(_FilterEntry(name, j + 1, item.group(1)!));
+          }
+        }
+        allFilterEntries.addAll(entries);
+        // 归属：这条 paths 挂在 push: 下面吗？往回找最近一个更浅的触发器名。
+        for (int k = i - 1; k >= 0; k--) {
+          final RegExpMatch? trigger = triggerPattern.firstMatch(logical[k]);
+          if (trigger == null) continue;
+          if (trigger.group(1)!.length >= indent) continue;
+          if (trigger.group(2) == 'push') {
+            pushPaths.putIfAbsent(name, () => <_FilterEntry>[]).addAll(entries);
+          }
+          break;
+        }
+        continue;
+      }
+
+      for (final RegExpMatch call in hashFilesCall.allMatches(logical[i])) {
+        for (final RegExpMatch m in quoted.allMatches(call.group(1)!)) {
+          hashFilePatterns.add(_FilterEntry(name, i + 1, m.group(1)!));
+        }
+      }
+    }
+  }
+
+  test('守卫没跑空：扫到了路径过滤项与 hashFiles 模式', () {
+    expect(workflows, isNotEmpty, reason: '一个 workflow 文件都没扫到');
+    expect(allFilterEntries, isNotEmpty,
+        reason: '一条 paths 过滤项都没扫到，说明块切分坏了或 workflow 改版了；'
+            '此时其余断言全部无意义。');
+    expect(hashFilePatterns, isNotEmpty,
+        reason: '一个 hashFiles() 模式都没扫到——缓存 key 的静默退化正是本守卫'
+            '要防的第二类失效，扫不到就等于没守。');
+  });
+
+  group('发布 workflow 的 push 路径过滤', () {
+    for (final String name in releaseWorkflows) {
+      test('$name 的 push 过滤覆盖真实 app 目录 $appDir/**', () {
+        final List<_FilterEntry> entries = pushPaths[name] ?? <_FilterEntry>[];
+        // 反向锚：清单本身还在，下面那条覆盖断言才有对象可查。
+        expect(entries, isNotEmpty,
+            reason: '$name 里找不到 push 触发器下的 paths 清单（启用态和注释态都没找到）。'
+                'push 触发器被整块删掉了？还是注释格式变了让按列还原失效？'
+                '无论哪种，本守卫已失去锚点，先修守卫再谈绿。');
+
+        final Set<String> globs =
+            entries.map((_FilterEntry e) => e.value).toSet();
+        expect(globs, contains('$appDir/**'),
+            reason: 'push 过滤没覆盖 app 目录 `$appDir/**`：改 app 代码将不再触发 '
+                '$name 的发版构建，而 GitHub 对匹配不到文件的 paths 过滤**零诊断**——'
+                '症状与「没人推代码」完全一致。当前清单：\n'
+                '${entries.map((_FilterEntry e) => "  ${e.where} ${e.value}").join("\n")}');
+      });
+    }
+  });
+
+  test('所有路径过滤项都指向磁盘上真实存在的路径', () {
+    final List<String> offenders = <String>[];
+    for (final _FilterEntry entry in allFilterEntries) {
+      final String? prefix = _literalPrefix(entry.value);
+      if (prefix == null || prefix.isEmpty) continue;
+      final String full = '${repoRoot.path}/$prefix';
+      if (File(full).existsSync() || Directory(full).existsSync()) continue;
+      offenders.add('${entry.where} "${entry.value}" -> 不存在的 $prefix');
+    }
+    expect(offenders, isEmpty,
+        reason: '这些 paths / paths-ignore 过滤项指向的路径在仓库里不存在。目录改名'
+            '（如 W9 的 hibiki/ -> fushi/）后忘了同步过滤项就长这样：workflow 不再被'
+            '触发，而 GitHub 不会给任何提示。逐条改成真实路径：\n'
+            '${offenders.join("\n")}');
+  });
+
+  test('所有 hashFiles() 模式都能匹配到真实文件', () {
+    final List<String> offenders = <String>[];
+    for (final _FilterEntry entry in hashFilePatterns) {
+      final String? prefix = _literalPrefix(entry.value);
+      final String full = '${repoRoot.path}/${prefix ?? ''}';
+      final bool exists = prefix != null &&
+          prefix.isNotEmpty &&
+          (File(full).existsSync() || Directory(full).existsSync());
+      if (!exists) {
+        offenders.add("${entry.where} hashFiles('${entry.value}') -> "
+            '匹配不到任何文件');
+      }
+    }
+    expect(offenders, isEmpty,
+        reason: 'hashFiles() 对匹配不到文件的模式**不报错**：它照常返回一个哈希，'
+            '只是这个哈希恒定不变，于是缓存 key 退化成常量、永远命中第一次存下的'
+            '那份陈旧缓存，而日志上一切正常。这是最难发现的一类改名残留：\n'
+            '${offenders.join("\n")}');
+  });
+}
+
+/// 取 glob 里**不含通配符**的最长前缀路径段（可回磁盘校验的那部分）。
+///
+/// `fushi/**` -> `fushi`；`fushi/android/**/*.gradle*` -> `fushi/android`；
+/// `pubspec.yaml` -> `pubspec.yaml`（整条就是字面量）；`**` -> null（无可查前缀）。
+String? _literalPrefix(String glob) {
+  if (glob.startsWith('!')) return null; // 排除项，不是要求存在的路径。
+  final List<String> kept = <String>[];
+  for (final String segment in glob.split('/')) {
+    if (segment.contains('*') ||
+        segment.contains('?') ||
+        segment.contains('[')) {
+      break;
+    }
+    kept.add(segment);
+  }
+  return kept.isEmpty ? null : kept.join('/');
+}
+
+/// 一条路径过滤项 / hashFiles 模式及其出处。
+class _FilterEntry {
+  const _FilterEntry(this.workflow, this.line, this.value);
+
+  final String workflow;
+
+  /// 1 基行号。
+  final int line;
+  final String value;
+
+  String get where => '$workflow:$line';
+}


### PR DESCRIPTION
## 结论先行：任务前提已过期，代码侧无需改动

任务描述称两条发布 workflow 的 `paths:` 仍写着 `hibiki/**`。**在 `origin/develop` 上不成立**——W8（`4d157d48c refactor(rename)!: W8 CI workflows 路径 hibiki/→fushi/`）已经把两处都改成 `fushi/**`，旁边那段注释也已同步（`release.yml:8` 现在写的是「A version bump lives in fushi/pubspec.yaml (under fushi/**)」）。

另需注意：两条发布 workflow 的整个 `push:` 触发块目前是**被注释掉的**（`3512b2676 ci!: 暂停 push 自动发布（Fushi 过渡期，用户指示）`），所以即便过滤项写错，眼下也不会表现为「改代码不出包」——但过渡期结束把 `#` 去掉时会。

## 全面复核结论：`.github/` 下零处失效引用

逐类扫过（`paths:` / `paths-ignore:` / `working-directory:` / cache `path` 与 `key` / `hashFiles(...)` / artifact 上传下载路径 / 被 run 调用的脚本路径），全部指向真实存在的路径：

- 9 处 `hashFiles()`（`fushi/android/**/*.gradle*`、`fushi/{ios,macos}/Podfile.lock`、`fushi/pubspec.lock` 等）逐条回磁盘校验通过；
- 8 处 `working-directory:` 全部存在；
- 全部 artifact `path:`（含多行 `|` 块）指向 `fushi/build/...`；
- 被 `run:` 调用的 ~30 个脚本/文件路径全部存在（`tool/flutter_test_failures.dart` 与 `tools/run_guards.ps1` 经 `working-directory` 解析后分别是 `fushi/tool/...` 与 `native/galgame_hook/tools/...`，均存在）。

**有意保留、未改动**的 `hibiki` 字样（逐条判断，均非路径）：

| 位置 | 保留理由 |
|---|---|
| `$RUNNER_TEMP/hibiki-{mihon-downloads,macos-signing,ios-payload,ios-signing,notarize}`、`hibiki.mobileprovision` | runner 临时目录/文件名，纯本地、不跨系统契约 |
| `Magpie-hibiki-slim-x64.zip[.sha256]` | 外部仓库 release 资产**真名**，改了就下载不到 |
| `NAME="${NAME:-Hibiki ...}"` 等 release 标题默认值 | 用户可见发布标题，属改名过渡期的产品决策，不在本 PR 范围 |
| `main.yml:243 -dname "CN=Hibiki CI, O=CI, C=US"` | 调试用 keystore 的 DN，无功能影响 |
| `release-desktop.yml` 注释里的 `hibiki.exe` / `hibiki.iss` / `hibiki-0.11.1-...-setup.exe` | **纯散文注释**（真实产物已是 `fushi.exe` / `fushi.iss`，代码路径写的都是 `fushi\build\...`；tag 解析用的是与名字无关的 `-debug.<seq>` 正则）。属改名散文清理批次，本 PR 不动以免与并发 rename PR 冲突 |
| `hibiki-hook#8` / `hajisensai/hibiki-hook` | 历史 issue / 旧独立仓引用，是事实记录 |

## 本 PR 的实质产出：守卫

上面这些结论都是**一次性人工核对**，而这类失效**没有任何自动检测**：GitHub Actions 对匹配不到文件的 `paths` 过滤零诊断；`hashFiles()` 指向不存在的文件也不报错，只是哈希恒定、缓存 key 退化成常量、永远命中第一次存下的陈旧缓存。所以补一条守卫把它变成可回归的：

`fushi/test/build/release_workflow_path_filter_guard_test.dart`（6 条断言）

1. 前置锚：app 目录名从 cwd 推导且 `../<appDir>/pubspec.yaml` 存在；
2. 反向锚：真扫到了 paths 项与 hashFiles 模式（防守卫跑空）；
3. `release.yml` / `release-desktop.yml` 的 push 过滤必须覆盖 `<appDir>/**`（各一条，且先断言清单非空）；
4. 全部 workflow 的 `paths` / `paths-ignore` 项字面量前缀必须真实存在；
5. 全部 `hashFiles()` 模式字面量前缀必须真实存在。

两个设计取舍：

- **不写死 `'fushi'`**：目录名从 `Directory.current` 推导。本测试文件跟着 app 目录一起 `git mv`，下次改名它自动跟着变，而 workflow 里的过滤项不会——差异正是要守的东西。同理不去比对 `hibiki` 这个具体旧名，而是直接拿路径回磁盘查，对任意一次改名都有效。
- **故意不掩掉 `#` 注释**（与其余 workflow 守卫的 `maskHashComments` 纪律相反）：要守的 paths 清单此刻就住在被注释掉的 push 块里，掩注释等于把守卫对象抹成空白 = 静默全绿。改用「按列还原」（去掉 `# ` 前缀后缩进关系与真 YAML 一致），同一套块切分对启用态与注释态都成立，过渡期结束去掉 `#` 时守卫无需改一行。

## 变异实测

**红 1** — 把两处 `- 'fushi/**'` 改回 `- 'hibiki/**'`：

```
00:00 +2 -3: 所有路径过滤项都指向磁盘上真实存在的路径 [E]
  Expected: empty
    Actual: [
              'release-desktop.yml:16 "hibiki/**" -> 不存在的 hibiki',
              'release.yml:17 "hibiki/**" -> 不存在的 hibiki'
            ]
00:00 +3 -3: Some tests failed.
PIPESTATUS=1
```
（另有两条 `push 过滤覆盖真实 app 目录 fushi/**` 同时转红，共 3 红）

**红 2** — 把 `hashFiles('fushi/pubspec.lock')` 改成 `hibiki/`：

```
00:00 +5 -1: 所有 hashFiles() 模式都能匹配到真实文件 [E]
  Expected: empty
    Actual: ['build-multiplatform.yml:862 hashFiles(\'hibiki/pubspec.lock\') -> 匹配不到任何文件']
PIPESTATUS=1
```

两次均以**反向字符串替换**还原（未对未提交文件用 `git checkout --`），还原后 `git diff --stat` 为空 = 逐字节一致。

**绿**（新守卫 + 6 条相邻 workflow 守卫）：

```
00:01 +50: All tests passed!
PIPESTATUS=0
```

守卫写完第一次跑就抓到自己一个真 bug：`String.replaceFirst(re, r'$1')` 的替换串是**字面量**、不做分组回填，`$1` 原样写进结果导致缩进层级全乱、push 块认不出来——被「清单非空」那条反向锚当场判红，已改成 `replaceFirstMapped` 等价写法并在代码里留了成因注释。

## 验证

- `dart format`：0 changed
- `flutter analyze`（全量，含 test）：`No issues found! (ran in 24.3s)`，exit 0
- 定向测试：新守卫 + `workflow_cache_quota` / `workflow_sed_inplace_portability` / `release_workflow_diagnostics` / `release_workflow_bash_portability` / `apple_signing_workflow` / `flutter_test_failure_workflow` 共 50 tests，`All tests passed!`，exit 0

未触碰任何 workflow 文件（`git diff` 对 `.github/` 为空），不影响 develop 上正在跑的桌面构建。

https://claude.ai/code/session_01NX1YJLbT3UWFQYHez9LwmV
