### PR TITLE
fix(rename): 清掉 W9 改名在脚本/构建配置里的漏网，并加真相源驱动守卫

### DIFF
--- a/.codex-test/tools/adb-ui.ps1
+++ b/.codex-test/tools/adb-ui.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-  Hibiki ADB UI tool - tap, swipe, dump, find without manual adb calls
+  Fushi ADB UI tool - tap, swipe, dump, find without manual adb calls
 .EXAMPLE
   .\adb-ui.ps1 dump              # full UI tree
   .\adb-ui.ps1 dump -Compact     # only interactive/labeled elements
@@ -30,7 +30,7 @@ param(
 
     [string]$Device = "",
     [switch]$Compact,
-    [string]$Package = "app.hibiki.reader"
+    [string]$Package = "app.fushi.reader"
 )
 
 # ─── Device auto-detection ───────────────────────────────────────────────────

--- a/.codex-test/tools/flutter-ui.ps1
+++ b/.codex-test/tools/flutter-ui.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-  Hibiki Flutter UI tool - cross-platform UI element location and interaction
+  Fushi Flutter UI tool - cross-platform UI element location and interaction
   via Flutter VM Service. Equivalent of adb-ui.ps1 for Windows/macOS/Linux/iOS.
 
 .DESCRIPTION

--- a/.codex-test/tools/hibiki-debug.ps1
+++ b/.codex-test/tools/hibiki-debug.ps1
@@ -1,6 +1,6 @@
 ﻿<#
 .SYNOPSIS
-  Hibiki cross-platform debug tool - trigger app events via API calls without mouse/click.
+  Fushi cross-platform debug tool - trigger app events via API calls without mouse/click.
   Supports Android (ADB) and Flutter VM Service (all platforms).
 
 .DESCRIPTION
@@ -46,7 +46,7 @@ param(
     [string]$Backend = 'auto',
 
     [string]$Device = '',
-    [string]$Package = 'app.hibiki.reader',
+    [string]$Package = 'app.fushi.reader',
     [string]$VmUrl = '',
     [switch]$Quiet,
     [switch]$Raw
@@ -505,7 +505,7 @@ function Handle-Prefs {
 
         if (-not $CmdArgs -or $CmdArgs.Count -eq 0) {
             # List preference keys from Drift SQLite
-            $result = Adb-Shell "run-as $Package sqlite3 databases/hibiki.db `"SELECT key FROM preferences ORDER BY key`" 2>&1"
+            $result = Adb-Shell "run-as $Package sqlite3 databases/fushi.db `"SELECT key FROM preferences ORDER BY key`" 2>&1"
             if (-not $result -or $result -like '*Error*') {
                 # Fallback: list SharedPreferences files
                 $result = Adb-Shell "run-as $Package ls shared_prefs/ 2>/dev/null"
@@ -519,12 +519,12 @@ function Handle-Prefs {
         if ($CmdArgs.Count -ge 2) {
             $value = $CmdArgs[1]
             $sql = "INSERT OR REPLACE INTO preferences (key, value) VALUES ('$key', '$value')"
-            $result = Adb-Shell "run-as $Package sqlite3 databases/hibiki.db `"$sql`" 2>&1"
+            $result = Adb-Shell "run-as $Package sqlite3 databases/fushi.db `"$sql`" 2>&1"
             if (-not $result) { $result = "set (restart app to apply)" }
             Format-Event 'android' 'state' 'prefs_set' @{ key = $key; value = $value } $result
         } else {
             $sql = "SELECT value FROM preferences WHERE key='$key'"
-            $result = Adb-Shell "run-as $Package sqlite3 databases/hibiki.db `"$sql`" 2>&1"
+            $result = Adb-Shell "run-as $Package sqlite3 databases/fushi.db `"$sql`" 2>&1"
             if (-not $result) { $result = "(not set)" }
             Format-Event 'android' 'state' 'prefs_get' @{ key = $key } $result
         }
@@ -558,7 +558,7 @@ function Handle-DbQuery {
     }
 
     $escaped = $sql -replace '"', '\"'
-    $result = Adb-Shell "run-as $Package sqlite3 databases/hibiki.db `"$escaped`""
+    $result = Adb-Shell "run-as $Package sqlite3 databases/fushi.db `"$escaped`""
     if (-not $result) { $result = "(empty result)" }
     Format-Event 'android' 'state' 'db_query' @{ sql = $sql } $result
 }
@@ -769,7 +769,7 @@ function Handle-Script {
 }
 
 function Handle-Help {
-    Write-Output "Hibiki Debug Tool - Cross-platform event triggering via API calls"
+    Write-Output "Fushi Debug Tool - Cross-platform event triggering via API calls"
     Write-Output ""
     Write-Output "INTENT COMMANDS (trigger app entry points):"
     Write-Output "  search <text>           WEB_SEARCH intent -> dictionary lookup"
@@ -802,7 +802,7 @@ function Handle-Help {
     Write-Output "  prefs                   List preference files/keys"
     Write-Output "  prefs <key>             Read preference value"
     Write-Output "  prefs <key> <value>     Set preference value"
-    Write-Output "  db-query <sql>          Direct SQLite query on hibiki.db"
+    Write-Output "  db-query <sql>          Direct SQLite query on fushi.db"
     Write-Output ""
     Write-Output "DEBUG:"
     Write-Output "  logcat [filter]         Filtered app logs (PID-based)"
@@ -827,7 +827,7 @@ function Handle-Help {
     Write-Output "OPTIONS:"
     Write-Output "  -Backend android|vm|auto   Force backend (default: auto-detect)"
     Write-Output "  -Device <serial>           ADB device serial"
-    Write-Output "  -Package <id>              App package (default: app.hibiki.reader)"
+    Write-Output "  -Package <id>              App package (default: app.fushi.reader)"
     Write-Output "  -VmUrl <url>               Flutter VM service WebSocket URL"
     Write-Output "  -Quiet                     Suppress formatted output"
     Write-Output "  -Raw                       Return PSObject instead of text"

--- a/.codex-test/tools/p2p-interop.ps1
+++ b/.codex-test/tools/p2p-interop.ps1
@@ -1,21 +1,21 @@
 <#
 .SYNOPSIS
-  Verify Hibiki P2P sync interop between the Windows host (sync server) and a
+  Verify Fushi P2P sync interop between the Windows host (sync server) and a
   connected Android emulator (P2P client), end-to-end over 10.0.2.2.
 
 .DESCRIPTION
   Network/protocol layer verification (the layer the sync settings UI configures) —
   no coordinate clicks, fully scripted per the repo test conventions.
 
-  1) Starts a REAL HibikiSyncServer on the host (hibiki/tool/p2p_host_harness.dart),
+  1) Starts a REAL FushiSyncServer on the host (fushi/tool/p2p_host_harness.dart),
      bound to 0.0.0.0:<Port>, seeded with one book.
   2) From the emulator, hits http://10.0.2.2:<Port> via `nc`:
-       - unauthenticated GET       -> expect HTTP 401 (reached the real Hibiki server)
+       - unauthenticated GET       -> expect HTTP 401 (reached the real Fushi server)
        - authenticated PROPFIND    -> expect HTTP 207 + the seeded "InteropBook"
          (full token-auth + WebDAV listing across the emulator<->host boundary)
   3) Tears the server down. Exit 0 on PASS, 1 on FAIL.
 
-  Pairs with test/sync/hibiki_p2p_roundtrip_test.dart (host-side client<->server
+  Pairs with test/sync/fushi_p2p_roundtrip_test.dart (host-side client<->server
   round-trip). Together they cover the protocol + the emulator<->host network hop.
 
   Real device (not emulator): point the client at the host LAN IP instead of
@@ -36,7 +36,7 @@ param(
 $ErrorActionPreference = 'Stop'
 $proc = $null
 $repoRoot = (& git rev-parse --show-toplevel).Trim()
-$hibikiDir = Join-Path $repoRoot 'hibiki'
+$fushiDir = Join-Path $repoRoot 'fushi'
 
 function Stop-Harness {
     if ($script:proc -and -not $script:proc.HasExited) {
@@ -57,12 +57,12 @@ $emu = $m.Groups[1].Value
 Write-Host "[*] emulator: $emu"
 
 # ── 1) start the host sync server (background) ────────────────────────
-$outFile = Join-Path $env:TEMP 'hibiki_p2p_harness.out'
-$errFile = Join-Path $env:TEMP 'hibiki_p2p_harness.err'
+$outFile = Join-Path $env:TEMP 'fushi_p2p_harness.out'
+$errFile = Join-Path $env:TEMP 'fushi_p2p_harness.err'
 Remove-Item $outFile, $errFile -Force -ErrorAction SilentlyContinue
 $proc = Start-Process -FilePath $Dart `
     -ArgumentList @('run', 'tool/p2p_host_harness.dart', "$Port") `
-    -WorkingDirectory $hibikiDir `
+    -WorkingDirectory $fushiDir `
     -RedirectStandardOutput $outFile -RedirectStandardError $errFile `
     -PassThru -WindowStyle Hidden
 Write-Host "[*] host sync server starting (pid $($proc.Id)) on 0.0.0.0:$Port (dart run may compile first)..."
@@ -85,20 +85,20 @@ Write-Host "[+] server ready on port $Port"
 
 # ── 2) probe from the emulator over 10.0.2.2 ──────────────────────────
 # Requests are pushed as files (real CRLF) to dodge cross-shell quoting issues.
-$auth = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("hibiki:$token"))
+$auth = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("fushi:$token"))
 $reqUnauth = "GET /ttu-reader-data/ HTTP/1.0`r`nHost: h`r`n`r`n"
 $reqAuth = "PROPFIND /ttu-reader-data/ HTTP/1.0`r`nHost: h`r`nAuthorization: Basic $auth`r`nDepth: 1`r`n`r`n"
-$tmpU = Join-Path $env:TEMP 'hibiki_p2p_unauth.txt'
-$tmpA = Join-Path $env:TEMP 'hibiki_p2p_auth.txt'
+$tmpU = Join-Path $env:TEMP 'fushi_p2p_unauth.txt'
+$tmpA = Join-Path $env:TEMP 'fushi_p2p_auth.txt'
 [IO.File]::WriteAllBytes($tmpU, [Text.Encoding]::ASCII.GetBytes($reqUnauth))
 [IO.File]::WriteAllBytes($tmpA, [Text.Encoding]::ASCII.GetBytes($reqAuth))
-& $Adb -s $emu push $tmpU /data/local/tmp/hibiki_p2p_unauth.txt | Out-Null
-& $Adb -s $emu push $tmpA /data/local/tmp/hibiki_p2p_auth.txt | Out-Null
+& $Adb -s $emu push $tmpU /data/local/tmp/fushi_p2p_unauth.txt | Out-Null
+& $Adb -s $emu push $tmpA /data/local/tmp/fushi_p2p_auth.txt | Out-Null
 
 Write-Host "[*] $emu -> http://10.0.2.2:$Port  (unauthenticated, expect 401)"
-$r1 = (& $Adb -s $emu shell "nc -w 5 10.0.2.2 $Port < /data/local/tmp/hibiki_p2p_unauth.txt" 2>&1) -join "`n"
+$r1 = (& $Adb -s $emu shell "nc -w 5 10.0.2.2 $Port < /data/local/tmp/fushi_p2p_unauth.txt" 2>&1) -join "`n"
 Write-Host "[*] $emu -> http://10.0.2.2:$Port  (authenticated PROPFIND, expect 207 + InteropBook)"
-$r2 = (& $Adb -s $emu shell "nc -w 5 10.0.2.2 $Port < /data/local/tmp/hibiki_p2p_auth.txt" 2>&1) -join "`n"
+$r2 = (& $Adb -s $emu shell "nc -w 5 10.0.2.2 $Port < /data/local/tmp/fushi_p2p_auth.txt" 2>&1) -join "`n"
 
 # ── 3) assertions + cleanup ───────────────────────────────────────────
 $ok1 = $r1 -match '\b401\b'
@@ -108,12 +108,12 @@ $status2 = ([regex]::Match($r2, 'HTTP/\S+\s+\d+[^\r\n]*')).Value
 Write-Host "  unauth : $(if ($ok1) { 'OK' } else { 'FAIL' })  ($status1)"
 Write-Host "  authed : $(if ($ok2) { 'OK (207 + InteropBook)' } else { 'FAIL' })  ($status2)"
 
-& $Adb -s $emu shell "rm -f /data/local/tmp/hibiki_p2p_unauth.txt /data/local/tmp/hibiki_p2p_auth.txt" 2>&1 | Out-Null
+& $Adb -s $emu shell "rm -f /data/local/tmp/fushi_p2p_unauth.txt /data/local/tmp/fushi_p2p_auth.txt" 2>&1 | Out-Null
 Remove-Item $tmpU, $tmpA -Force -ErrorAction SilentlyContinue
 Stop-Harness
 
 if ($ok1 -and $ok2) {
-    Write-Host "`n[PASS] emulator <-> Windows-host Hibiki P2P interop verified." -ForegroundColor Green
+    Write-Host "`n[PASS] emulator <-> Windows-host Fushi P2P interop verified." -ForegroundColor Green
     exit 0
 }
 Write-Host "`n[FAIL] interop check failed (see statuses above)." -ForegroundColor Red

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,20 +2,20 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Hibiki (debug)",
+      "name": "Fushi (debug)",
       "type": "dart",
       "request": "launch",
       "program": "fushi/lib/main.dart"
     },
     {
-      "name": "Hibiki (profile)",
+      "name": "Fushi (profile)",
       "type": "dart",
       "request": "launch",
       "program": "fushi/lib/main.dart",
       "flutterMode": "profile"
     },
     {
-      "name": "Hibiki (release)",
+      "name": "Fushi (release)",
       "type": "dart",
       "request": "launch",
       "program": "fushi/lib/main.dart",

--- a/ci/anki-integration-test.sh
+++ b/ci/anki-integration-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# AnkiDroid integration test flow for Hibiki.
+# AnkiDroid integration test flow for Fushi.
 #
 # Verifies the real AddContentApi ContentProvider path end-to-end against a live
 # AnkiDroid install on an emulator/device:
@@ -22,7 +22,7 @@ set -euo pipefail
 ADB="${ADB:-$(command -v adb 2>/dev/null || echo /d/android_sdk/platform-tools/adb)}"
 FLUTTER="${FLUTTER:-$(command -v flutter 2>/dev/null || echo /d/flutter_sdk/flutter_extracted/flutter/bin/flutter)}"
 DEVICE="${DEVICE:-emulator-5554}"
-PKG="${PKG:-app.hibiki.reader}"
+PKG="${PKG:-app.fushi.reader}"
 TARGET="integration_test/anki_integration_test.dart"
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 

--- a/ci/emulator-test.sh
+++ b/ci/emulator-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Hibiki emulator test workflow
+# Fushi emulator test workflow
 # Usage: bash ci/emulator-test.sh [--skip-build] [--skip-push]
 #
 # Prerequisites:
@@ -15,7 +15,7 @@ ADB="${ADB:-$(command -v adb 2>/dev/null || echo /d/android_sdk/platform-tools/a
 EMULATOR="${EMULATOR:-$(command -v emulator 2>/dev/null || echo /d/android_sdk/emulator/emulator)}"
 FLUTTER="${FLUTTER:-$(command -v flutter 2>/dev/null || echo /d/flutter_sdk/flutter_extracted/flutter/bin/flutter)}"
 DEVICE="${DEVICE:-emulator-5554}"
-PKG="${PKG:-app.hibiki.reader}"
+PKG="${PKG:-app.fushi.reader}"
 APK="build/app/outputs/flutter-apk/app-release.apk"
 SCREENSHOT_DIR="../test_screenshots"
 

--- a/ci/integration-test.sh
+++ b/ci/integration-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Fully-automated, EMULATOR-ONLY integration test runner for Hibiki.
+# Fully-automated, EMULATOR-ONLY integration test runner for Fushi.
 #
 # One command: boots/selects an emulator, builds the debug APK once, provisions
 # every prerequisite (AnkiDroid + a collection + permission grant, dictionary
@@ -24,7 +24,7 @@ ADB="${ADB:-$(command -v adb 2>/dev/null || echo /d/android_sdk/platform-tools/a
 EMULATOR="${EMULATOR:-$(command -v emulator 2>/dev/null || echo /d/android_sdk/emulator/emulator)}"
 FLUTTER="${FLUTTER:-$(command -v flutter 2>/dev/null || echo /d/flutter_sdk/flutter_extracted/flutter/bin/flutter)}"
 AVD="${AVD:-}"   # resolved lazily below (boot block) if left empty
-PKG="${PKG:-app.hibiki.reader}"
+PKG="${PKG:-app.fushi.reader}"
 # Dictionary fixture for popup_dictionary / reader_dictionary. Those tests look
 # up basic vocabulary (猫 / 食べる), so the fixture must be a GENERAL J-J/J-C
 # dictionary — a grammar/bunkei dict would return zero results and fail them.
@@ -125,10 +125,10 @@ fi
 
 # ── Pre-install with all runtime perms granted (preserved across flutter
 #    drive's -r reinstall, so the AnkiDroid grant survives the run). ──
-echo ">>> Pre-installing Hibiki with runtime permissions granted..."
+echo ">>> Pre-installing Fushi with runtime permissions granted..."
 MSYS_NO_PATHCONV=1 $ADBD install -r -g "$(win_path "$APK_REL")"
 
-# Re-enable the default launcher activity-alias. Hibiki's runtime icon switcher
+# Re-enable the default launcher activity-alias. Fushi's runtime icon switcher
 # (IconSwitchHelper) disables .MainActivityDefault when the user picks a
 # different launcher icon; a fresh `install -r` can land with that alias still
 # disabled, leaving the app with no enabled LAUNCHER component — `flutter drive`

--- a/ci/lib/provision-ankidroid.sh
+++ b/ci/lib/provision-ankidroid.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
-# Shared AnkiDroid provisioning for Hibiki integration tests.
+# Shared AnkiDroid provisioning for Fushi integration tests.
 #
 # Sourced by ci/anki-integration-test.sh and ci/integration-test.sh so the
-# "install AnkiDroid + create a collection + grant Hibiki the API permission"
+# "install AnkiDroid + create a collection + grant Fushi the API permission"
 # recipe lives in exactly one place (DRY).
 #
 # WHY THIS IS A FIXTURE STEP, NOT A PRODUCT WORKAROUND
 # The AnkiDroid API is gated by the *dangerous* permission
 #   com.ichi2.anki.permission.READ_WRITE_DATABASE
 # which Android grants only after the user taps "Allow" on AnkiDroid's runtime
-# dialog. Hibiki requests it correctly at runtime (AnkiChannelHandler.java
+# dialog. Fushi requests it correctly at runtime (AnkiChannelHandler.java
 # ankiDroid.requestPermission(...)), but an automated `flutter drive` run
 # installs the app fresh and cannot tap that system dialog. We reproduce the
 # *granted* state deterministically: pre-install the APK with `adb install -g`
@@ -18,7 +18,7 @@
 #
 # Required env (set by the caller before sourcing):
 #   ADBD       full "adb -s <serial>" command
-#   PKG        Hibiki application id (app.hibiki.reader)
+#   PKG        Fushi application id (app.fushi.reader)
 # Optional:
 #   ANKI_APK_URL  override the AnkiDroid APK mirror
 
@@ -113,8 +113,8 @@ provision_ankidroid() {
   return 0
 }
 
-# Grant Hibiki the AnkiDroid API permission and verify it stuck. Assumes the
-# Hibiki APK is already installed (with -g). Returns 0 if granted=true.
+# Grant Fushi the AnkiDroid API permission and verify it stuck. Assumes the
+# Fushi APK is already installed (with -g). Returns 0 if granted=true.
 grant_fushi_ankidroid_permission() {
   MSYS_NO_PATHCONV=1 $ADBD shell pm grant "$PKG" "$ANKI_PERM" >/dev/null 2>&1 || true
   local granted

--- a/docs/agent/apple-signing.md
+++ b/docs/agent/apple-signing.md
@@ -27,8 +27,8 @@ Gatekeeper 拦」的正解。
 |---|---|---|
 | iOS | `app.fushi.reader` | App Store / TestFlight 用；旧 `app.hibiki.reader` 已废弃 |
 | macOS | `app.fushi.reader` | 原 `com.example.hibiki` |
-| Android | `app.hibiki.reader` | **不动**：改了等于所有现有用户断更新 |
-| Linux | `com.example.hibiki` | 未在本轮范围内 |
+| Android | `app.fushi.reader` | 新包身份（`android/app/build.gradle` 的 `namespace`/`applicationId` 是唯一真相源）；老包 `app.hibiki.reader` 只作为过渡桥包与迁移探测目标存活 |
+| Linux | `app.fushi.reader` | `linux/CMakeLists.txt` 的 `APPLICATION_ID`（原 `com.example.hibiki`） |
 
 **macOS 换包名是有代价且已被明确接受的决定。** Flutter 的
 `getApplicationSupportDirectory()` 在 macOS 上返回
@@ -38,10 +38,14 @@ Gatekeeper 拦」的正解。
 下选择「不做迁移」。将来若要补迁移，落点是 `lib/src/storage/data_root_migrator.dart`
 旁边新加一条「平台 support 根变更」的一次性搬迁，而不是改 `AppPaths` 的解析逻辑。
 
-Android 的 `applicationId` 保持 `app.hibiki.reader` 是**硬约束**，不是遗漏：Play 商店
-以它作为 app 身份，改了现有用户全部断更新。同理，代码里的 MethodChannel 名
-（`app.hibiki.reader/anki`、`app.hibiki.reader/voice_hook`）只是字符串常量，与任何
-平台的 bundle ID 无关，跟着改毫无收益。
+**Android 换包名同样是有代价且已被明确接受的决定。** 改 `applicationId` 在 Android 上
+等于全新应用：老包 `app.hibiki.reader` 的私有数据目录不共享，Play/侧载更新链路也断。
+方案是**桥包迁移**而不是「不改」——老包出一版带导出器的过渡版，新包 `app.fushi.reader`
+带导入器（`lib/src/migration/`，旧包身份收口在常量 `kHibikiPackageName`），完整决策与
+阶段见 [docs/plans/2026-08-06-rename-fushi-migration.md](../plans/2026-08-06-rename-fushi-migration.md)。
+MethodChannel 前缀已同批切到 `app.fushi.reader/*`（Dart 真相源
+`fushi/lib/src/utils/misc/channel_constants.dart` 的 `FushiChannels._prefix`，Java 侧
+`app.fushi.reader.constants.ChannelNames` 必须同步）。
 
 ## 仓库 Secrets 清单
 

--- a/docs/agent/build.md
+++ b/docs/agent/build.md
@@ -37,8 +37,8 @@ Android / Windows / macOS / iOS debug/beta workflow 必须使用跨 workflow 统
 
 默认 push 只发 debug 通道；beta/test 和 formal 都必须手动触发。任何 push 触发的 GitHub Release 都必须是 prerelease 且 `make_latest: false`，不得创建或更新 Latest/正式 release。
 
-- debug（push 自动）：`main` / `develop` push 会走 `.github/workflows/main.yml` 上传 Actions artifact，并走 `.github/workflows/release.yml` 发布 Android debug GitHub prerelease；同时走 `.github/workflows/release-desktop.yml` 发布 Windows debug installer、macOS app zip、iOS no-codesign IPA。Artifact 名称为 `hibiki-debug-apk-${{ github.sha }}`，Actions artifact APK 文件名为 `hibiki-<version>-<short-sha>-debug.apk`，保留 14 天；Android debug GitHub Release 使用 release-signed debug-channel APK，文件名为 `hibiki-<version>-debug.<seq>-<short-sha>-debug.apk`；Windows debug GitHub Release 使用 Inno Setup installer，文件名为 `hibiki-<version>-debug.<seq>-windows-setup.exe`；macOS 为 `fushi-<version>-debug.<seq>-macos.zip`；iOS 为 `fushi-<version>-debug.<seq>-ios.ipa`。Windows/macOS/iOS 都用同一个 `0.x.y-debug.<seq>` 作为 Flutter `--build-name`，保证安装后的 `PackageInfo.version` 能停止同一 debug release 的重复提示/自动安装。GitHub Release 的 git tag 固定为滚动的 `debug-rolling`（TODO-1049，见上「滚动 debug release」）；客户端版本比较用的版本化 tag 仍为 `v<version>-debug.<seq>+<short-sha>`（写进 manifest `tag` 字段）。同一 commit 的 Android/Windows/macOS/iOS 自动 debug 必须落到同一个 GitHub Release（即同一个 `debug-rolling` 滚动 release），且必须是 prerelease / non-Latest；各客户端必须按本平台资产后缀过滤，不能互相吃错平台资产，也不能等 beta/test 或 formal installer。
-- beta/test（手动）：通过 `.github/workflows/release.yml` 或 `.github/workflows/release-desktop.yml` 的 `workflow_dispatch` 选择 `beta`，或手动发布一个勾选 prerelease 且非 Latest 的 GitHub Release。Android 默认 tag 为 `v<version>-beta.<seq>`，产物包含 `hibiki-<version>-<short-sha>-debug.apk` 与 split ABI release APK `hibiki-<version>-<abi>.apk`；Windows 产物为 `hibiki-<version>-windows-setup.exe`；macOS 产物为 `fushi-<version>-macos.zip`；iOS 产物为 `fushi-<version>-ios.ipa`。如需 Android、Windows、macOS、iOS 合并到同一 beta/test Release，两个手动 workflow 使用同一个 `tag_name`；未指定时，同一 commit 上两条 workflow 的默认 `<seq>` 相同，也会合并到同一 Release。
+- debug（push 自动）：`main` / `develop` push 会走 `.github/workflows/main.yml` 上传 Actions artifact，并走 `.github/workflows/release.yml` 发布 Android debug GitHub prerelease；同时走 `.github/workflows/release-desktop.yml` 发布 Windows debug installer、macOS app zip、iOS no-codesign IPA。Artifact 名称为 `fushi-debug-apk-${{ github.sha }}`，Actions artifact APK 文件名为 `fushi-<version>-<short-sha>-debug.apk`，保留 14 天；Android debug GitHub Release 使用 release-signed debug-channel APK，文件名为 `fushi-<version>-debug.<seq>-<short-sha>-debug.apk`；Windows debug GitHub Release 使用 Inno Setup installer，文件名为 `fushi-<version>-debug.<seq>-windows-setup.exe`；macOS 为 `fushi-<version>-debug.<seq>-macos.zip`；iOS 为 `fushi-<version>-debug.<seq>-ios.ipa`。Windows/macOS/iOS 都用同一个 `0.x.y-debug.<seq>` 作为 Flutter `--build-name`，保证安装后的 `PackageInfo.version` 能停止同一 debug release 的重复提示/自动安装。GitHub Release 的 git tag 固定为滚动的 `debug-rolling`（TODO-1049，见上「滚动 debug release」）；客户端版本比较用的版本化 tag 仍为 `v<version>-debug.<seq>+<short-sha>`（写进 manifest `tag` 字段）。同一 commit 的 Android/Windows/macOS/iOS 自动 debug 必须落到同一个 GitHub Release（即同一个 `debug-rolling` 滚动 release），且必须是 prerelease / non-Latest；各客户端必须按本平台资产后缀过滤，不能互相吃错平台资产，也不能等 beta/test 或 formal installer。
+- beta/test（手动）：通过 `.github/workflows/release.yml` 或 `.github/workflows/release-desktop.yml` 的 `workflow_dispatch` 选择 `beta`，或手动发布一个勾选 prerelease 且非 Latest 的 GitHub Release。Android 默认 tag 为 `v<version>-beta.<seq>`，产物包含 `fushi-<version>-<short-sha>-debug.apk` 与 split ABI release APK `fushi-<version>-<abi>.apk`；Windows 产物为 `fushi-<version>-windows-setup.exe`；macOS 产物为 `fushi-<version>-macos.zip`；iOS 产物为 `fushi-<version>-ios.ipa`。如需 Android、Windows、macOS、iOS 合并到同一 beta/test Release，两个手动 workflow 使用同一个 `tag_name`；未指定时，同一 commit 上两条 workflow 的默认 `<seq>` 相同，也会合并到同一 Release。
 - formal（手动）：通过手动 GitHub Release 或 `workflow_dispatch` 选择 `formal`。默认 tag 为 `v<version>`；Android 产物包含 debug APK 与 split ABI release APK，Windows 产物为 installer，macOS 为 app zip，iOS 为 no-codesign IPA。formal 是唯一允许成为 Latest 的通道。
 - 禁止事项：不要把 push、debug tag、debug APK 或 beta/test workflow 接到 formal/Latest；不要让 push 上传正式 release APK 或发布 formal/Latest；不要把 beta/test 发布成 non-prerelease 或 Latest。
 
@@ -87,7 +87,7 @@ Flutter 版本号以 `fushi/pubspec.yaml` 的 `version: X.Y.Z+build` 为准。�
 GitHub Actions 给每个仓库的缓存配额是**硬上限 10 GB**，超了就按 LRU 静默驱逐。
 驱逐不是洁癖问题：桌面发布 run `30729229450` 变红的最后一环就是 vcpkg 缓存被驱逐
 后冷编 + 拉外部镜像失败。2026-08-02 实测 `gh api
-repos/hajisensai/hibiki/actions/cache/usage` = **10.65 GB / 14 条**，长期在驱逐。
+repos/hajisensai/Fushi/actions/cache/usage` = **10.65 GB / 14 条**，长期在驱逐。
 
 三条铁律（守卫 `fushi/test/build/workflow_cache_quota_guard_test.dart`）：
 
@@ -127,8 +127,8 @@ develop 那条被驱逐，下一个 PR run 就 miss 并在自己的 PR 桶里存
 查用量与逐条明细：
 
 ```bash
-gh api repos/hajisensai/hibiki/actions/cache/usage
-gh api "repos/hajisensai/hibiki/actions/caches?per_page=100"   --jq '.actions_caches[] | "\(.size_in_bytes) \(.ref) \(.key)"' | sort -rn
+gh api repos/hajisensai/Fushi/actions/cache/usage
+gh api "repos/hajisensai/Fushi/actions/caches?per_page=100"   --jq '.actions_caches[] | "\(.size_in_bytes) \(.ref) \(.key)"' | sort -rn
 ```
 
 删存量缓存前先确认没有 in-flight 的 run 在用它（`gh run list --status in_progress`）。
@@ -146,7 +146,7 @@ Flutter 3.44.0 下部分上游依赖未适配，两种补法并存（对个别�
 
 galgame 一键制卡的引擎-hook 注入器（injector.exe + hook.dll + vendored LunaHook/Host DLL）含
 `CreateRemoteThread`/`WriteProcessMemory`。**源码在本仓 `native/galgame_hook/`**（与
-`native/fushidicts/`、`native/fushi_torrent/` 同级）。helper 绝不链接进 `Hibiki.exe`，运行时仍是
+`native/fushidicts/`、`native/fushi_torrent/` 同级）。helper 绝不链接进 `fushi.exe`，运行时仍是
 隔离子进程/DLL；但两架构的校验 zip 随 Windows 主包进入 `galgame_helper/`，从而离线首装可用。
 
 > 历史：这套组件曾整体迁到独立仓库 `hajisensai/hibiki-hook`。迁出的真正根因是 CI——主仓库那份
@@ -174,14 +174,14 @@ galgame 一键制卡的引擎-hook 注入器（injector.exe + hook.dll + vendore
   目录，Inno Setup 的 `recursesubdirs` 将其纳入安装器。`check_release_policy.ps1` 守卫这条链，禁止
   后续“构建仍绿但安装器漏带 helper”。
 - **历史下载 URL**（只服务已经发布的旧客户端；新客户端不再使用）：
-  `https://github.com/hajisensai/hibiki/releases/download/voice-hook-helper/voice_hook_<arch>.zip`（+ `.sha256`）。
+  `https://github.com/hajisensai/Fushi/releases/download/voice-hook-helper/voice_hook_<arch>.zip`（+ `.sha256`）。
 - **老客户端不断供**：已发布版本的 app 把 `hajisensai/hibiki-hook` 编进了常量，会继续从那个仓库取
   helper。**`hajisensai/hibiki-hook` 仓库与其 `voice-hook-helper` release 必须保留、不得删除**
   （Never break userspace）；它只作为老客户端的下载宿主冻结，新开发一律在本仓 `native/galgame_hook/`。
 - **app 端安装**：开 galgame 需要注入器却缺失时，`GalgameHelperInstaller`（`fushi/lib/src/mining/
   galgame_helper_installer.dart`）先读取 exe 同级 `galgame_helper/voice_hook_<arch>.zip` 与侧车，校验
   SHA-256 后解压/换入 `voice_hook/<arch>/`，全程零网络、零下载确认；正式 Windows 主包必须命中此路。
-  开发构建/旧包没有随包归档时提示更新/重新构建 Hibiki，**不回退网络**；已安装版本也没有后台自更新。
+  开发构建/旧包没有随包归档时提示更新/重新构建 Fushi，**不回退网络**；已安装版本也没有后台自更新。
 - **Magpie 同样随包唯一来源**（BUG-1292）：两个 Windows workflow 用
   `tools/build_magpie_slim.ps1` 生成 `Magpie-hibiki-slim-x64.zip` + `.sha256`，放进
   `magpie_bundle/`。`MagpieInstaller` 校验后换入 `magpie/`；ARM64 Windows 走系统 x64 模拟。

--- a/docs/agent/computer-use-testing.md
+++ b/docs/agent/computer-use-testing.md
@@ -29,8 +29,8 @@ Computer Use 流程验证的是「用户真的看见并操作到的 app 状态�
   media_kit（音频 / 视频）初始化需要 DWM 合成的实窗，纯离屏 parked 窗口下
   `initialiseAudioHandler()` 会**永久挂起**（曾实测挂 1 小时）。
 
-**测试与用户的 Hibiki 并存**：测试 exe 在 `FUSHI_TEST_HIDDEN` 下跳过全局单实例互斥量
-（用隔离 WebView2 profile，无锁冲突），故你开着 Hibiki 也能跑、互不干扰
+**测试与用户的 Fushi 并存**：测试 exe 在 `FUSHI_TEST_HIDDEN` 下跳过全局单实例互斥量
+（用隔离 WebView2 profile，无锁冲突），故你开着 Fushi 也能跑、互不干扰
 （见 `windows/runner/main.cpp`）。
 
 **抓图 / 开页助手** `integration_test/helpers/observe_capture.dart`：
@@ -41,8 +41,8 @@ Computer Use 流程验证的是「用户真的看见并操作到的 app 状态�
 
 **确定性开页钩子**（离屏 / 非焦点下焦点驱动激活偶发不触发，故用这些直达；均 debug/profile
 only，`@visibleForTesting`）：`HomePage.debugSelectTab(tab)` 切顶层 tab、
-`ReaderHibikiHistoryPage.debugOpenBook(mediaIdentifier)` 走书卡同路径 openMedia 开书、
-`HomeVideoPage.debugRefreshVideos()` 重查视频列表、`ReaderHibikiPage.debugCaptureWebView`
+`ReaderFushiHistoryPage.debugOpenBook(mediaIdentifier)` 走书卡同路径 openMedia 开书、
+`HomeVideoPage.debugRefreshVideos()` 重查视频列表、`ReaderFushiPage.debugCaptureWebView`
 抓 WebView。
 
 **素材生成器** `integration_test/helpers/media_fixtures.dart` + `library_fixture.dart`：

--- a/docs/agent/external-video-open.md
+++ b/docs/agent/external-video-open.md
@@ -1,8 +1,8 @@
-# 从 app 外用 Hibiki 打开视频（Windows 文件关联 / argv）
+# 从 app 外用 Fushi 打开视频（Windows 文件关联 / argv）
 
-目标：在 Windows 资源管理器里右键视频「打开方式 → Hibiki」、把视频拖到
-`hibiki.exe`、或命令行 `hibiki.exe "<视频>"` → Hibiki 接收路径 → 直接播放
-（`VideoHibikiPage`）+ 把它加入书架视频分区（建 `VideoBook`，外部路径不复制），
+目标：在 Windows 资源管理器里右键视频「打开方式 → Fushi」、把视频拖到
+`fushi.exe`、或命令行 `fushi.exe "<视频>"` → Fushi 接收路径 → 直接播放
+（`VideoFushiPage`）+ 把它加入书架视频分区（建 `VideoBook`，外部路径不复制），
 之后能在书架再次打开。
 
 ## 数据流（argv → Dart → 播放 + 入库）
@@ -20,8 +20,8 @@
    - bookUid 用 `externalVideoBookUid(path)`（规范化路径的 sha1 前 12 位，前缀
      `video/ext/`）——**幂等**：同一文件重复打开复用同条记录、保留进度。
    - 不存在则 `saveVideoBook`（title=文件名，videoPath=外部绝对路径，**不复制**）。
-   - 用全局 `navigatorKey` push `VideoHibikiPage(bookUid, repo)` 播放。
-   - 字幕**无需预解析**：`VideoHibikiPage._init` 在 `subtitleSource` 为空时自动
+   - 用全局 `navigatorKey` push `VideoFushiPage(bookUid, repo)` 播放。
+   - 字幕**无需预解析**：`VideoFushiPage._init` 在 `subtitleSource` 为空时自动
      探测同名 sidecar 字幕（`findSidecarSubtitle`：`.ja.srt > .ja.ass > .srt >
      .ass`）。内嵌字幕轨由 libmpv 渲染。
 4. VideoBook 已入库 → 书架视频分区自动出现该条目，后续可再打开。
@@ -48,25 +48,25 @@
 安装包 `windows/installer/fushi.iss` 含可选 `[Tasks] videoassoc`（默认勾选），
 注册到 **HKCU**（`PrivilegesRequired=lowest`，无需管理员）：
 
-- ProgId `Hibiki.Video` → `shell\open\command = "hibiki.exe" "%1"`。
-- `Applications\hibiki.exe`（让 Hibiki 出现在「打开方式」列表 + 声明 SupportedTypes）。
-- 各扩展名的 `OpenWithProgids` **追加** `Hibiki.Video`（不改系统默认播放器，只在
-  右键「打开方式」里多一个 Hibiki 候选）。
+- ProgId `Fushi.Video` → `shell\open\command = "fushi.exe" "%1"`。
+- `Applications\fushi.exe`（让 Fushi 出现在「打开方式」列表 + 声明 SupportedTypes）。
+- 各扩展名的 `OpenWithProgids` **追加** `Fushi.Video`（不改系统默认播放器，只在
+  右键「打开方式」里多一个 Fushi 候选）。
 
 卸载时 `uninsdeletekey` / `uninsdeletevalue` 清理。
 
 ### 手动注册（不装安装包 / 调试构建）
 
-资源管理器里右键视频 → 打开方式 → 选择其他应用 → 浏览到 `hibiki.exe` → 勾选
+资源管理器里右键视频 → 打开方式 → 选择其他应用 → 浏览到 `fushi.exe` → 勾选
 「始终」即可（argv 路径已能处理）。或命令行直接：
 
 ```
-hibiki.exe "D:\video\Dragon Maid\S01E01.mkv"
+fushi.exe "D:\video\Dragon Maid\S01E01.mkv"
 ```
 
 ## single-instance 转发（TODO-904：已实现）
 
-runner 用 `CreateMutexW(L"HibikiSingleInstanceMutex")` 做**真单实例**（检测
+runner 用 `CreateMutexW(L"FushiSingleInstanceMutex")` 做**真单实例**（检测
 `ERROR_ALREADY_EXISTS`）：app 已开着时再从外部打开一个视频，第二实例**不会**起新
 窗口（避免双实例共享同一 WebView2 userDataFolder 的锁冲突），而是把视频路径**转交**
 给首实例后退出。链路：
@@ -77,7 +77,7 @@ runner 用 `CreateMutexW(L"HibikiSingleInstanceMutex")` 做**真单实例**（�
    路径字节）发给首实例窗口 → 前置窗口 → `return EXIT_SUCCESS`。**无文件参数**（纯
    第二次启动）则只前置 + 退出，不发消息。
 2. 首实例 `flutter_window.cpp::MessageHandler` 收到 `WM_COPYDATA` →
-   `DecodeExternalVideoPath`（magic 不匹配则忽略）→ 经 `app.hibiki/external_video`
+   `DecodeExternalVideoPath`（magic 不匹配则忽略）→ 经 `app.fushi/external_video`
    MethodChannel `InvokeMethod("openExternalVideo", path)` 推给 Dart。
 3. Dart `_FushiReaderAppState._handleExternalVideoChannel`（`main.dart`，仅 Windows
    注册）：做与首启 argv 等价的校验（`isSupportedVideoFile` + `File.existsSync`），
@@ -86,10 +86,10 @@ runner 用 `CreateMutexW(L"HibikiSingleInstanceMutex")` 做**真单实例**（�
 
 守卫：`test/native/windows_single_instance_guard_static_test.dart`（转交链路源码扫描）。
 WM_COPYDATA 真实跨进程行为 headless 测不到，须真机验证（app 已开 → 双击/右键用
-Hibiki 打开另一个视频 → 复用已开窗口打开播放页，不起第二进程）。
+Fushi 打开另一个视频 → 复用已开窗口打开播放页，不起第二进程）。
 
 ## 验证
 
 - 纯函数测试：`test/media/video/external_video_test.dart`
   （`isSupportedVideoFile` / `externalVideoBookUid` / `firstExternalVideoArg`）。
-- 真机：`hibiki.exe "<某视频绝对路径>"` 启动应自动打开播放页 + 书架出现条目。
+- 真机：`fushi.exe "<某视频绝对路径>"` 启动应自动打开播放页 + 书架出现条目。

--- a/docs/agent/fast-workflow.md
+++ b/docs/agent/fast-workflow.md
@@ -146,7 +146,7 @@ Get-CimInstance Win32_Process |
 | `test/sync/desktop_lookup_foreground_guard_static_test.dart` | `lib/src` 全树 | 抢前台/任务栏闪烁只能走单一封装 |
 | `test/storage/documents_whitelist_guard_test.dart` | `lib` 全树 | 新增 documents 子目录必须进迁移白名单 |
 | `test/storage/path_rebase_coverage_guard_test.dart` | `lib` 全树（pref 扫描） | 新增路径形 pref / DB 列必须双向登记 |
-| `test/focus/focus_architecture_static_test.dart` | `lib/src` 全树 | 焦点滚动必须走 `HibikiFocusScroll` |
+| `test/focus/focus_architecture_static_test.dart` | `lib/src` 全树 | 焦点滚动必须走 `FushiFocusScroll` |
 | `test/lookup/auto_read_surface_coverage_guard_test.dart` | `lib` 全树 | 每个 `searchDictionary(` 调用点须声明接不接自动朗读 |
 | `test/pages/lookup_overlay_dialog_gate_guard_test.dart` | `lib` 全树 | 查词浮层每个子项都能走到对话框隐藏计数 |
 | `test/shortcuts/shortcut_channel_wiring_guard_test.dart` | `lib` 全树 | 开放的输入通道必须真有解析入口 |
@@ -160,9 +160,9 @@ Get-CimInstance Win32_Process |
 | `test/media/video/real_path_directory_picker_test.dart` | `lib` 全树 | 生产代码不得用 iOS `FileType.audio` |
 | `test/ios/info_plist_media_permission_guard_test.dart` | `lib` 全树（作谓词） | 用了相机/相册/音频就必须有 `Info.plist` 声明 |
 | `test/i18n/i18n_completeness_test.dart` | `lib/i18n` 全部 17 份 | 17 语言 key 完整、无孤儿、插值一致 |
-| `test/pages/reader_hibiki_page_source_corpus_test.dart` | `reader_hibiki/` part 目录枚举 | 合并语料覆盖每个 part（漏登记会让 90+ 条守卫真空通过） |
+| `test/pages/reader_fushi_page_source_corpus_test.dart` | `reader_fushi/` part 目录枚举 | 合并语料覆盖每个 part（漏登记会让 90+ 条守卫真空通过） |
 | `test/pages/reader_history_source_corpus_test.dart` | `reader_history/` part 目录枚举 | 同上，书架页语料 |
-| `test/pages/video_hibiki_page_source_corpus_test.dart` | `video_hibiki/` part 目录枚举 | 同上，视频页语料 |
+| `test/pages/video_fushi_page_source_corpus_test.dart` | `video_fushi/` part 目录枚举 | 同上，视频页语料 |
 | `test/sync/sync_settings_schema_source_corpus_test.dart` | `sync_settings_schema/` part 目录枚举 | 同上，同步设置 schema 语料 |
 
 一条命令跑完，**当前基线 225 tests**（2026-08-02，`origin/develop@b4ed5d8f7` 实测）——比争论「这条该不该跑」便宜得多，所以**不要挑，整批跑**：
@@ -198,9 +198,9 @@ cd fushi && dart run tool/flutter_test_failures.dart --no-pub \
   test/media/drag_drop/drag_drop_platform_guard_test.dart test/media/media_cover_write_guard_test.dart \
   test/media/sources/book_history_split_guard_test.dart test/media/video/real_path_directory_picker_test.dart \
   test/ios/info_plist_media_permission_guard_test.dart test/i18n/i18n_completeness_test.dart \
-  test/pages/reader_hibiki_page_source_corpus_test.dart \
+  test/pages/reader_fushi_page_source_corpus_test.dart \
   test/pages/reader_history_source_corpus_test.dart \
-  test/pages/video_hibiki_page_source_corpus_test.dart \
+  test/pages/video_fushi_page_source_corpus_test.dart \
   test/sync/sync_settings_schema_source_corpus_test.dart
 ```
 
@@ -326,7 +326,7 @@ dart run tool/flutter_test_failures.dart --no-pub \
 
 | # | 原语 | 撞上的签名形态 | 后果 | 结局 |
 |---|---|---|---|---|
-| ① | `methodBody` | **箭头函数体** `Foo bar() => …;` | 找不到 `{`，配对扫描越界，读到**下一个声明**——守卫在一段完全无关的源码上做断言 | PR#768 已修（`291d42af0`），并加了 `HIBIKI_METHOD_BODY_AUDIT=1` 反向枚举全仓有多少守卫锚在箭头体上 |
+| ① | `methodBody` | **箭头函数体** `Foo bar() => …;` | 找不到 `{`，配对扫描越界，读到**下一个声明**——守卫在一段完全无关的源码上做断言 | PR#768 已修（`291d42af0`），并加了 `FUSHI_METHOD_BODY_AUDIT=1` 反向枚举全仓有多少守卫锚在箭头体上 |
 | ② | `balancedBlockFrom` | **具名参数签名** `void f({required A a}) {` | 从声明处找第一个 `{`，抓到的是**参数列表**的花括号，切出来的「方法体」其实是一串参数 | PR#771 绕开（`test/reader/reader_exit_bounded_probe_test.dart` 里留了注释说明为什么不能直接 `balancedBlockFrom(start)`） |
 | ③ | `topLevelFunctionBody` | **`async` / `async*` / `sync*` 体** | 右括号后第一个非空白字符不是 `{` 而是 `a`，被判成调用点、解析成 `null` ⇒ **实现正确时守卫转红** | PR#772 已修（`73eabe331`） |
 
@@ -384,7 +384,7 @@ grep    "FLUTTER TEST VERDICT" /tmp/blast_run.log           # 逐行看，别只
 ```bash
 BR=develop                                    # 换成你要核的分支名
 git ls-remote origin "refs/heads/$BR"
-gh api "repos/hajisensai/hibiki/git/ref/heads/$BR" --jq .object.sha
+gh api "repos/hajisensai/Fushi/git/ref/heads/$BR" --jq .object.sha
 git rev-parse HEAD                            # 再拿它和「你以为推上去的那个东西」比对
 ```
 
@@ -422,7 +422,7 @@ gh run list --branch develop --limit 20 \
   --json databaseId,headSha,workflowName,createdAt,status,conclusion
 SHA=$(gh run list --branch develop --limit 1 --json headSha --jq '.[0].headSha')
 gh api -H "Accept: application/vnd.github.raw" \
-  "repos/hajisensai/hibiki/contents/.github/workflows/main.yml?ref=$SHA" | head -40
+  "repos/hajisensai/Fushi/contents/.github/workflows/main.yml?ref=$SHA" | head -40
 ```
 
 ### 判「测试跑全了没」是结构问题，不是算术问题
@@ -441,7 +441,7 @@ gh api -H "Accept: application/vnd.github.raw" \
 
 ## 三条零散硬规矩（各自有实测出处）
 
-**① 改共用文案之前，先枚举它的全部使用点。** i18n key 不属于「某个页面」，属于**所有 import 了那个 widget 的页面**。实例：`scrape_all_confirm` 在 `fushi/lib/src/media/metadata/scrape_batch.dart` 里只出现一次，但 `ScrapeBatchDialog` 被 `home_video_page.dart` / `reader_hibiki_history_page.dart` / `games_library_page.dart` **三页共用**——只沿视频页那条路径验证「文案是否如实」，等于把同一句谎话原样搬到书架页和游戏库页。改之前先跑一遍：
+**① 改共用文案之前，先枚举它的全部使用点。** i18n key 不属于「某个页面」，属于**所有 import 了那个 widget 的页面**。实例：`scrape_all_confirm` 在 `fushi/lib/src/media/metadata/scrape_batch.dart` 里只出现一次，但 `ScrapeBatchDialog` 被 `home_video_page.dart` / `reader_fushi_history_page.dart` / `games_library_page.dart` **三页共用**——只沿视频页那条路径验证「文案是否如实」，等于把同一句谎话原样搬到书架页和游戏库页。改之前先跑一遍：
 
 ```bash
 cd fushi

--- a/docs/agent/focus-ownership.md
+++ b/docs/agent/focus-ownership.md
@@ -23,7 +23,7 @@
 
 守卫 `fushi/test/focus/media_page_focus_ownership_guard_test.dart` 禁止媒体页出现**任何形式**的 `requestFocus`（按裸 token 扫、按文件放行——`FocusScope.of(context).requestFocus(node)` 和经局部变量中转同样拦得住）。**别为了省事绕过它**：统一之前视频页 29 处、阅读器页 28 处补丁各带一套略有出入的门控，新增一个覆盖层就漏一处归还（BUG-1167 即此），这是回不去的老路。
 
-唯一豁免：整个 `reader_hibiki/caret.part.dart`——popup header ↔ 正文之间的焦点来回是**页面内部**焦点转移（两个都归 Flutter 的节点之间搬运），不是「从原生控件手里夺回」。
+唯一豁免：整个 `reader_fushi/caret.part.dart`——popup header ↔ 正文之间的焦点来回是**页面内部**焦点转移（两个都归 Flutter 的节点之间搬运），不是「从原生控件手里夺回」。
 
 ## cause 不是装饰，判据真的按它分流
 

--- a/docs/agent/galgame-hooking.md
+++ b/docs/agent/galgame-hooking.md
@@ -1,12 +1,12 @@
 # Galgame Hook 引擎适配 SOP
 
-本流程用于 Hibiki 的日语学习制卡功能：从用户本地、合法取得的游戏中采集当前文本、逐句语音和画面，供用户制作 Anki 卡片。它不用于复制或分发游戏内容。
+本流程用于 Fushi 的日语学习制卡功能：从用户本地、合法取得的游戏中采集当前文本、逐句语音和画面，供用户制作 Anki 卡片。它不用于复制或分发游戏内容。
 
 总设计见 [design.md](../specs/galgame-mining/design.md)，阶段计划与完成证据见 [engine-adapter-plan.md](../specs/galgame-mining/engine-adapter-plan.md)，当前支持状态以 `native/galgame_hook/engine-support.yaml` 为唯一真相源。
 
 ## 1. 边界与开工条件
 
-- native 采集组件在本仓 `native/galgame_hook/`（源码已合仓）。**进程/链接边界不变且是硬规则：绝不链接进 `Hibiki.exe`**。`tools/build_distribution.ps1` 单独构建 `voice_hook_<arch>.zip`；两架构 zip + `.sha256` 随 Windows 主包进入 `galgame_helper/` 供离线首装，同时由根 `.github/workflows/voice-hook-helper.yml` 发布供旧包与后台更新。app 校验后解压到 `voice_hook/<arch>/`，helper 仍以隔离子进程/DLL 运行。
+- native 采集组件在本仓 `native/galgame_hook/`（源码已合仓）。**进程/链接边界不变且是硬规则：绝不链接进 `fushi.exe`**。`tools/build_distribution.ps1` 单独构建 `voice_hook_<arch>.zip`；两架构 zip + `.sha256` 随 Windows 主包进入 `galgame_helper/` 供离线首装，同时由根 `.github/workflows/voice-hook-helper.yml` 发布供旧包与后台更新。app 校验后解压到 `voice_hook/<arch>/`，helper 仍以隔离子进程/DLL 运行。
 - 合仓的依据：迁出独立仓库的真正根因是「主仓库那份 workflow 不在默认分支、无法 workflow_dispatch」，合仓后 workflow 就在 develop 上，问题消失；而「必被杀软报毒」经实测证伪（Defender 签名 1.455.357.0 对全部文件与 zip 零检出，同轮 EICAR 阳性对照正常报出，见 hibiki-hook#8）。国产杀软未验证，若被拦按误报处理。
 - 消费端（IPC 消费、文本与音频配对、制卡 UI）与 native 采集实现现在同仓，**改 IPC 契约必须两侧在同一个 PR 里落地**——这正是合仓要消除的版本不同步。引擎支持矩阵唯一真相源是 `native/galgame_hook/docs/engine-support.md`（由同目录 `engine-support.yaml` 自动生成），不得另存副本。
 - 一引擎一任务、一独立 worktree；批量引擎任务只负责排队和汇总，不在同一实现任务里交叉试错。worktree 先运行 `tool/setup_worktree.ps1`，并按根 `CLAUDE.md` 登记 ownership。
@@ -79,7 +79,7 @@ powershell -ExecutionPolicy Bypass -File tool/galhook.ps1 probe 'D:\Games\Title\
 引擎 id 使用小写字母、数字和下划线：
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File tool/galhook.ps1 new example_engine --fushi-root 'C:\src\hibiki'
+powershell -ExecutionPolicy Bypass -File tool/galhook.ps1 new example_engine --fushi-root 'C:\src\Fushi'
 ```
 
 命令会拒绝覆盖已有文件，并生成或注册：
@@ -111,7 +111,7 @@ fixture 包含 `config`、按时间排序的 `events` 和 `expected`。至少覆
 
 不要把真实台词、语音字节或可还原游戏内容放进 fixture。失败时修 profile、adapter 或公共配对状态机，不通过延时、重试、吞异常或 fixture 特判绕过。
 
-## 6. native 与 Hibiki 验证门
+## 6. native 与 Fushi 验证门
 
 在 `native/galgame_hook/` 下至少执行：
 
@@ -129,7 +129,7 @@ cmake --build build-x86 --config Release
 ctest --test-dir build-x86 -C Release --output-on-failure
 ```
 
-若改动 Hibiki 的 Dart/Flutter 消费端，则在 `fushi/` 下按根规则执行 `dart format .`、相关定向测试，再执行完整 `flutter test` 与 `flutter analyze`。工具自身崩溃要原样记录，不能当作代码通过；可补充 `dart analyze` 的有效结果，但不能伪装成完整 analyze。
+若改动 Fushi 的 Dart/Flutter 消费端，则在 `fushi/` 下按根规则执行 `dart format .`、相关定向测试，再执行完整 `flutter test` 与 `flutter analyze`。工具自身崩溃要原样记录，不能当作代码通过；可补充 `dart analyze` 的有效结果，但不能伪装成完整 analyze。
 
 任何必需命令、双架构构建、replay、定向测试或完整测试被跳过、崩溃或因环境阻塞时，逐项记录命令和原因；该能力只能停在 `implemented_unverified`。Loopback 通过只证明降级链可用，不能替代引擎 Hook、逐句配对或纯人声验证。
 
@@ -150,4 +150,4 @@ ctest --test-dir build-x86 -C Release --output-on-failure
 
 ## 8. 提交与交接
 
-native 能力、Hibiki 消费端和进度文档可按审查边界拆提交，但同一 IPC 契约变更必须在一个 PR 内同时落两侧；不要把无行为变化重构与能力扩展混成一个提交。交接报告列出主仓提交哈希、全部验证命令、真实样本证据、仍未验证项和后续候选。许可方面，文本优先复用隔离运行的 LunaHook（GPLv3）；资源格式可参考 GARbro（MIT），保留必要署名与许可证；禁止 vendoring NonCommercial 或其他受限许可的二进制和数据。
+native 能力、Fushi 消费端和进度文档可按审查边界拆提交，但同一 IPC 契约变更必须在一个 PR 内同时落两侧；不要把无行为变化重构与能力扩展混成一个提交。交接报告列出主仓提交哈希、全部验证命令、真实样本证据、仍未验证项和后续候选。许可方面，文本优先复用隔离运行的 LunaHook（GPLv3）；资源格式可参考 GARbro（MIT），保留必要署名与许可证；禁止 vendoring NonCommercial 或其他受限许可的二进制和数据。

--- a/docs/agent/integration-testing.md
+++ b/docs/agent/integration-testing.md
@@ -12,13 +12,13 @@
 |------|------|------|----------|
 | **编排（推荐）** | `ci/integration-test.sh` | 选/启模拟器 + 构建 + provision + 跑全部目标 + 汇总 | 一键全自动跑集成测试 |
 | **文件操作** | `ci/emulator-test.sh` | 推送素材、授权限、触发 MediaScanner | 仅需准备素材时 |
-| **状态验证** | `run-as app.hibiki.reader sqlite3 files/hibiki.db` | 直查 `hibiki.db` | 导入结果、配置持久化、cue 数量、Profile |
+| **状态验证** | `run-as app.fushi.reader sqlite3 files/fushi.db` | 直查 `fushi.db` | 导入结果、配置持久化、cue 数量、Profile |
 | **UI 交互** | `flutter drive` 集成测试 | CJK 搜索、阅读器翻页、划词查词 | 单独跑某个目标 |
 
 ### 关键约束
 
 - ADB 脚本（`ci/*.sh`）**不得**向 Flutter 文本框输入 CJK——`input text` 在 Android 上不支持 Unicode，`settext.jar` 找不到 Flutter 的 EditText。CJK 文字输入只能通过 `tester.enterText()` 在 Flutter 集成测试里完成。
-- 导入验证优先用 DB 查询（`run-as app.hibiki.reader sqlite3 files/hibiki.db`），不依赖 UI dump 匹配文字。
+- 导入验证优先用 DB 查询（`run-as app.fushi.reader sqlite3 files/fushi.db`），不依赖 UI dump 匹配文字。
 - **UI 交互一律焦点驱动，禁止坐标点击。** Flutter 集成测试操作真 app **只发框架级合成按键**（`tester.sendKeyEvent`，经 `FocusDriver`），绝不用 `tester.tap` / 坐标点击，也不用 ADB 截图猜坐标 `input tap`——点击依赖精确屏幕位置，布局/滚动/缩放/平台一变就错位易错；焦点+键位置无关且三端一致。详见下方「焦点驱动操作」。
 - adb 用 Android SDK 自带的 `platform-tools/adb`（`$ANDROID_HOME` 下；确保版本够新），不要依赖 PATH 里可能过时的 adb。
 - 需要新增测试流程时，先判断属于哪一层，不要在错误的层做事。
@@ -94,7 +94,7 @@ bash ci/anki-integration-test.sh --skip-build # 复用已构建的 app-debug.apk
 
 脚本覆盖（对应 `integration_test/anki_integration_test.dart`）：`fetchConfiguration()` 返回真实 decks/note types、`isDuplicate()`、`mineEntry()` add-or-duplicate。
 
-**为什么需要独立脚本（关键约束）：** AnkiDroid API 受 *dangerous* 权限 `com.ichi2.anki.permission.READ_WRITE_DATABASE` 管控，Android 只在用户点了 AnkiDroid 运行时弹窗「Allow」后才授予。Hibiki 在运行时正确发起请求（`AnkiChannelHandler.java` 的 `ankiDroid.requestPermission(...)`），但自动化 `flutter drive` 每次全新安装且无法点系统弹窗，于是 fresh-install 一律返回 `AnkiFetchError`。脚本用 `adb install -g`（授予全部运行时权限 = 等价用户点 Allow）预装 APK，`flutter drive` 的 `-r` 重装会**保留**该授权，从而确定性复现已授权状态。这是测试夹具步骤，**不是**产品代码里的绕过。
+**为什么需要独立脚本（关键约束）：** AnkiDroid API 受 *dangerous* 权限 `com.ichi2.anki.permission.READ_WRITE_DATABASE` 管控，Android 只在用户点了 AnkiDroid 运行时弹窗「Allow」后才授予。Fushi 在运行时正确发起请求（`AnkiChannelHandler.java` 的 `ankiDroid.requestPermission(...)`），但自动化 `flutter drive` 每次全新安装且无法点系统弹窗，于是 fresh-install 一律返回 `AnkiFetchError`。脚本用 `adb install -g`（授予全部运行时权限 = 等价用户点 Allow）预装 APK，`flutter drive` 的 `-r` 重装会**保留**该授权，从而确定性复现已授权状态。这是测试夹具步骤，**不是**产品代码里的绕过。
 
 `adb install -g` 不可省略：`flutter drive` 收尾会卸载 app，下一次运行是全新安装、无授权——所以每轮都要先 `-g` 预装。脚本已做幂等处理。`ci/anki-integration-test.sh` 的 provision 逻辑被 `ci/integration-test.sh` 经 `ci/lib/provision-ankidroid.sh` 复用。
 

--- a/docs/agent/reader-debugging.md
+++ b/docs/agent/reader-debugging.md
@@ -4,16 +4,16 @@
 
 ## 当前阅读器构成
 
-- 页面：`fushi/lib/src/pages/implementations/reader_hibiki_page.dart`，类 `ReaderHibikiPage`（3242 行主体 + `reader_hibiki/` 下 8 个域 part 文件 `audiobook` / `caret` / `chrome` / `lookup` / `lyrics` / `mining` / `navigation` / `webview`，共 9583 行：WebView 拦截 + JS 分页引擎 + 有声书同步）。
-- source：`fushi/lib/src/media/sources/reader_hibiki_source.dart`，类 `ReaderHibikiSource`。
+- 页面：`fushi/lib/src/pages/implementations/reader_fushi_page.dart`，类 `ReaderFushiPage`（3242 行主体 + `reader_fushi/` 下 8 个域 part 文件 `audiobook` / `caret` / `chrome` / `lookup` / `lyrics` / `mining` / `navigation` / `webview`，共 9583 行：WebView 拦截 + JS 分页引擎 + 有声书同步）。
+- source：`fushi/lib/src/media/sources/reader_fushi_source.dart`，类 `ReaderFushiSource`。
 - JS / CSS：`fushi/lib/src/reader/` 下 `reader_pagination_scripts.dart`、`reader_content_styles.dart`、`reader_selection_scripts.dart`、`reader_caret_scripts.dart`。
-- **JS 桥接全局叫 `window.fushiReader`**（2026-08 已从旧名 hoshiReader 改名；`window.hoshiCaret` 等其余 hoshi 前缀运行时符号待后续批次）；字级焦点用 `window.hoshiCaret` + Dart `ReaderCaretRouter`。
+- **JS 桥接全局叫 `window.fushiReader`**（2026-08 已从旧名 hoshiReader 改名；其余 hoshi 前缀运行时符号已在 W5 批次清完）；字级焦点用 `window.fushiCaret` + Dart `ReaderCaretRouter`。
 - 当前阅读器问题**不要**去上游 ttu fork 仓库改。
 
 ## TTU 命名残留 vs 迁移代码
 
 - `reader_ttu` key、`setTtu*` 方法、`ttuBookId` 列、`ttu_*` i18n 只是**旧数据兼容残留**，不代表还有 TTU 阅读器。改这些 key/方法名前，必须先确认是否会破坏旧书籍、偏好、书签、阅读位置或迁移。
-- 旧 TTU 迁移代码已移除（develop `90c37b472`：`TtuMigrationServer`、`TtuIdbReader`、`assets/ttu-ebook-reader` 均已删除）。当前阅读器渲染/交互问题按 reader_hibiki 路径修。
+- 旧 TTU 迁移代码已移除（develop `90c37b472`：`TtuMigrationServer`、`TtuIdbReader`、`assets/ttu-ebook-reader` 均已删除）。当前阅读器渲染/交互问题按 reader_fushi 路径修。
 
 ## 调试约定
 
@@ -26,7 +26,7 @@
 
 ## 平台特例
 
-- **Windows WebView2** 阅读器/字级焦点本身不坏；caret 测试失败常因书架里残留 lyrics-mode 旧书 → seed/打开一本全新分页书（`book_entry_hoshi://book/<id>`）复测。
+- **Windows WebView2** 阅读器/字级焦点本身不坏；caret 测试失败常因书架里残留 lyrics-mode 旧书 → seed/打开一本全新分页书（`book_entry_fushi://book/<id>`）复测。
 - 桌面端 debug 跑断言（release 不报），注意 `Expanded`-in-trailing 类布局陷阱。
 
 ## 手工验证清单

--- a/docs/agent/shortcuts-inventory.md
+++ b/docs/agent/shortcuts-inventory.md
@@ -1,4 +1,4 @@
-# Hibiki 快捷键清单（TODO-048a 统计）
+# Fushi 快捷键清单（TODO-048a 统计）
 
 > ⚠️ **2026-08-02 增补：「返回上一级」已统一，本文与之冲突的行以本段为准。**
 >
@@ -21,7 +21,7 @@
 > 绑定行为**；发现的冲突/重复/缺失列在末尾「待优化」，改绑定属行为变更，须用户确认。
 >
 > 快捷键分两类来源：
-> 1. **可配置注册表**（`ShortcutAction` + `ShortcutDefaults` + `HibikiShortcutRegistry`，
+> 1. **可配置注册表**（`ShortcutAction` + `ShortcutDefaults` + `FushiShortcutRegistry`，
 >    用户可在「快捷键设置」页改键）—— reader / home / global / audiobook 四个 scope。
 > 2. **硬编码**（视频播放器、全局 Esc/方向键焦点、有声书 Space 覆写、阅读方向翻页覆写）
 >    —— 不进注册表，用户改不了。
@@ -85,7 +85,7 @@
 ### 2a. 视频播放器（`video_player_shortcuts.dart` `buildVideoPlayerShortcuts`）
 
 > **这一节属 TODO-048b（视频组）的优化对象，本任务只统计不改。** 当前是 asbplayer 风格
-> 硬编码键，CallbackShortcuts 安装在 video 页（`video_hibiki_page.dart:1697`）。
+> 硬编码键，CallbackShortcuts 安装在 video 页（`video_fushi_page.dart:1697`）。
 
 | 键 | 功能 |
 |---|---|
@@ -106,7 +106,7 @@
 | S | 截图 |
 | F | 切换全屏 |
 | Esc | 退出（逐级：控件编辑→字幕列表→剧集列表→侧栏→沉浸锁→全屏→浮层→退页）。**现由 universal 的 globalBack 驱动**，不再是 video 组的 videoEscape |
-| B | 切换字幕模糊（`video_hibiki_page.dart:3305`，内层 CallbackShortcuts，asbplayer 同款） |
+| B | 切换字幕模糊（`video_fushi_page.dart:3305`，内层 CallbackShortcuts，asbplayer 同款） |
 
 ### 2b. 全局焦点/导航（`global_navigation.dart`，仅实验性焦点导航开启时）
 
@@ -149,8 +149,8 @@ readerDismissDict 关栈顶弹窗 / 全局 Navigator pop / 手柄 B）。
 
 > 后加的第四条绑定通道（键盘 / 手柄 / 鼠标按钮 / **滚轮**）。滚轮绑定不经
 > `resolveKeyboard` 或页面派发：弹窗内容是 WebView，滚轮事件先到它的 JS，故
-> `popup_settings_injection` 把绑定序列化成 `window.__hoshiEntryWheelBindings` 注入给
-> `popup.js`，命中即调 `hoshiFocusDictionaryEntryMove`（TODO-1325 #5 part1 的词条焦点）。
+> `popup_settings_injection` 把绑定序列化成 `window.__fushiEntryWheelBindings` 注入给
+> `popup.js`，命中即调 `fushiFocusDictionaryEntryMove`（TODO-1325 #5 part1 的词条焦点）。
 > 浏览器扩展没有注入通道，吃 popup.js 里的同款默认值。
 
 | 动作 | 默认绑定 | 说明 |

--- a/fushi/android/app/build.gradle
+++ b/fushi/android/app/build.gradle
@@ -197,7 +197,7 @@ android {
 
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
-            def appName = "hibiki"
+            def appName = "fushi"
             def buildType = variant.buildType.name
             def architecture = output.getFilter(com.android.build.OutputFile.ABI)
             def newName

--- a/fushi/android/app/proguard-rules.pro
+++ b/fushi/android/app/proguard-rules.pro
@@ -44,7 +44,7 @@
 -keep class mihon.core.common.extensions.** { *; }
 -keep class uy.kohesive.injekt.** { *; }
 # Third-party extension bytecode calls these host libraries dynamically, so
-# R8 cannot infer the reachable API surface from Hibiki itself.
+# R8 cannot infer the reachable API surface from Fushi itself.
 -keep class okhttp3.** { *; }
 -keep class okio.** { *; }
 -keep class org.jsoup.** { *; }

--- a/fushi/android/fastlane/Fastfile
+++ b/fushi/android/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :android do
   # HBK-AUDIT-025: this lane was unadapted fastlane example boilerplate — it
   # published to fastlane/fastlane, had a `verson_name` typo, and uploaded
   # nonexistent iOS/gem assets. Rewritten to build the real split-per-abi
-  # Hibiki APKs and (optionally) publish them to this repo. The primary deploy
+  # Fushi APKs and (optionally) publish them to this repo. The primary deploy
   # path is GitHub Actions (.github/workflows/release.yml); this lane is a
   # local convenience and is NOT wired into CI.
   desc "Build split-per-abi release APKs and publish a GitHub release."
@@ -31,7 +31,7 @@ platform :android do
     set_github_release(
       repository_name: "hajisensai/fushi",
       api_token: ENV["GITHUB_TOKEN"],
-      name: "Hibiki #{version_name}",
+      name: "Fushi #{version_name}",
       tag_name: version_name,
       description: (File.read("../../CHANGELOG.md") rescue "No changelog provided"),
       commitish: "main",

--- a/fushi/ios/Runner.xcodeproj/project.pbxproj
+++ b/fushi/ios/Runner.xcodeproj/project.pbxproj
@@ -404,7 +404,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
-				FUSHIDICTS_BUILD_DIR = "$(PROJECT_DIR)/Flutter/ephemeral/hoshidicts/$(CONFIGURATION)-$(PLATFORM_NAME)";
+				FUSHIDICTS_BUILD_DIR = "$(PROJECT_DIR)/Flutter/ephemeral/fushidicts/$(CONFIGURATION)-$(PLATFORM_NAME)";
 				FUSHIDICTS_MERGED_ARCHIVE = "$(FUSHIDICTS_BUILD_DIR)/libfushidicts_ffi_merged.a";
 				FUSHIDICTS_SOURCE_DIR = "$(PROJECT_DIR)/../../native/fushidicts";
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -541,7 +541,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
-				FUSHIDICTS_BUILD_DIR = "$(PROJECT_DIR)/Flutter/ephemeral/hoshidicts/$(CONFIGURATION)-$(PLATFORM_NAME)";
+				FUSHIDICTS_BUILD_DIR = "$(PROJECT_DIR)/Flutter/ephemeral/fushidicts/$(CONFIGURATION)-$(PLATFORM_NAME)";
 				FUSHIDICTS_MERGED_ARCHIVE = "$(FUSHIDICTS_BUILD_DIR)/libfushidicts_ffi_merged.a";
 				FUSHIDICTS_SOURCE_DIR = "$(PROJECT_DIR)/../../native/fushidicts";
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -572,7 +572,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
-				FUSHIDICTS_BUILD_DIR = "$(PROJECT_DIR)/Flutter/ephemeral/hoshidicts/$(CONFIGURATION)-$(PLATFORM_NAME)";
+				FUSHIDICTS_BUILD_DIR = "$(PROJECT_DIR)/Flutter/ephemeral/fushidicts/$(CONFIGURATION)-$(PLATFORM_NAME)";
 				FUSHIDICTS_MERGED_ARCHIVE = "$(FUSHIDICTS_BUILD_DIR)/libfushidicts_ffi_merged.a";
 				FUSHIDICTS_SOURCE_DIR = "$(PROJECT_DIR)/../../native/fushidicts";
 				INFOPLIST_FILE = Runner/Info.plist;

--- a/fushi/linux/CMakeLists.txt
+++ b/fushi/linux/CMakeLists.txt
@@ -4,10 +4,10 @@ project(runner LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "hibiki")
+set(BINARY_NAME "fushi")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.hibiki")
+set(APPLICATION_ID "app.fushi.reader")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/fushi/linux/runner/my_application.cc
+++ b/fushi/linux/runner/my_application.cc
@@ -45,11 +45,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "hibiki");
+    gtk_header_bar_set_title(header_bar, "Fushi");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "hibiki");
+    gtk_window_set_title(window, "Fushi");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/fushi/test/build/rename_residue_build_config_guard_test.dart
+++ b/fushi/test/build/rename_residue_build_config_guard_test.dart
@@ -1,0 +1,328 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fushi 改名收尾守卫（构建/打包/运维**脚本与配置**面）。
+//
+// 与 test/tools/fushi_rename_guard_test.dart 的分工：那条守卫扫 Dart 代码位与
+// native 路径形态；这条扫**脚本和构建配置**——旧代号在这类文件里失效时既不会让
+// flutter analyze 红、也不会让 flutter test 红、更不会让编译失败，只在真机运行、
+// 发版或本地跑脚本时炸。实际发生过的三批：
+//   * proguard-rules.pro 的 -keep class <旧包名>.**：R8 对匹配零个类的 keep
+//     规则不告警 → release 包启动即闪退（见 android_app_package_keep_rule_guard_test）；
+//   * run.sh / run.ps1 / 根 .bat 指向已被 git mv 掉的旧应用目录；
+//   * ci/*.sh 的 PKG 默认值、tool/*_sweep.sh 的 REPO 默认值仍是旧身份 →
+//     adb / gh 全部打空。
+//
+// 三条禁模式全部**真相源驱动**，不硬编码新身份：
+//   A. applicationId：从 android/app/build.gradle 读出唯一真值，扫描面里出现的
+//      每个 app.<x>.reader 字面量都必须等于它。
+//   B. GitHub 仓库 slug：从 lib/src/utils/misc/update_checker_release.dart 的
+//      kGitHubRepo 读出（app 自身查更新用的那一个），扫描面里出现的每个
+//      <owner>/<repo> 都必须是同一个仓库（大小写不敏感，GitHub 本身如此）。
+//   C. 旧代号词根：构建/打包配置里不得再出现 hibiki / hoshi。
+//
+// 白名单一条一个理由，且带**过期豁免检测**：某条豁免不再有真实命中时测试转红，
+// 逼着连豁免一起删掉，防止白名单退化成永久盲区。
+// ---------------------------------------------------------------------------
+
+/// 一条豁免：文件路径后缀 + 只在**该行**同时匹配 [context] 时才放行。
+///
+/// 行级 context 是刻意的：整文件豁免会让同一文件里**新长出来**的失效引用也一起
+/// 静默通过，那正是这套守卫要防的事。
+class _Exemption {
+  const _Exemption({
+    required this.pathSuffix,
+    required this.context,
+    required this.reason,
+  });
+
+  /// 归一（正斜杠）路径后缀。
+  final String pathSuffix;
+
+  /// 命中所在**整行**必须匹配的上下文；null = 整文件豁免（只给旧名清理脚本）。
+  final RegExp? context;
+
+  final String reason;
+}
+
+/// 扫描面：目录（按扩展名过滤）或单文件，路径相对 fushi/（flutter test 的 cwd）。
+class _ScanRoot {
+  const _ScanRoot(this.path, {this.extensions});
+
+  final String path;
+
+  /// null = 单文件；否则只收这些扩展名。
+  final Set<String>? extensions;
+}
+
+/// 构建 / 打包 / 平台工程配置：产物身份就在这里定，A/B/C 三条都扫。
+const List<_ScanRoot> _buildConfigRoots = <_ScanRoot>[
+  _ScanRoot('android/app/build.gradle'),
+  _ScanRoot('android/app/proguard-rules.pro'),
+  _ScanRoot('android/app/src/main/AndroidManifest.xml'),
+  _ScanRoot('android/fastlane/Fastfile'),
+  _ScanRoot('linux/CMakeLists.txt'),
+  _ScanRoot('linux/runner/my_application.cc'),
+  _ScanRoot('windows/CMakeLists.txt'),
+  _ScanRoot('windows/installer/fushi.iss'),
+  _ScanRoot('ios/Runner.xcodeproj/project.pbxproj'),
+  _ScanRoot('macos/Runner/Configs/AppInfo.xcconfig'),
+  _ScanRoot('../melos.yaml'),
+];
+
+/// 运维 / 测试 / 发布脚本：只扫 A（应用身份）与 B（仓库身份）——这两条是「打空」
+/// 的根源；C 不扫，因为这些脚本里合法存在大量外部真名（Magpie 资产、临时目录、
+/// 远端 Mac 克隆根等），逐条豁免只会把守卫变成豁免表。
+const List<_ScanRoot> _scriptRoots = <_ScanRoot>[
+  _ScanRoot('../ci', extensions: <String>{'.sh'}),
+  _ScanRoot('../tool', extensions: <String>{'.sh', '.ps1', '.py'}),
+  _ScanRoot('../tools', extensions: <String>{'.sh', '.ps1'}),
+  _ScanRoot('../scripts', extensions: <String>{'.py'}),
+  _ScanRoot('../.codex-test/tools', extensions: <String>{'.ps1'}),
+  _ScanRoot('tool', extensions: <String>{'.ps1', '.sh'}),
+  _ScanRoot('../run.sh'),
+  _ScanRoot('../run.ps1'),
+];
+
+/// A：非当前 applicationId 的 app.<x>.reader 字面量。
+final List<_Exemption> _appIdExemptions = <_Exemption>[
+  _Exemption(
+    pathSuffix: 'android/app/src/main/AndroidManifest.xml',
+    context: null,
+    reason: 'queries/package 声明的是**旧包**：Android 11+ 包可见性下，迁移导入器要 '
+        'getPackageInfo 查到老包才能探测/拉起/引导卸载。这里写新包名等于自己查自己。',
+  ),
+  _Exemption(
+    pathSuffix: 'android/app/proguard-rules.pro',
+    context: null,
+    reason: 'keep 规则上方记载「旧包名 keep 规则匹配零个类 → R8 混淆全 app → 启动即'
+        '闪退」的根因叙述，旧包名是叙述本体；规则本身由 '
+        'android_app_package_keep_rule_guard_test 从 build.gradle 反推校验。',
+  ),
+];
+
+/// B：owner 相同但仓库不是当前仓库的 slug。
+final List<_Exemption> _repoSlugExemptions = <_Exemption>[
+  _Exemption(
+    pathSuffix: 'tools/build_magpie_slim.ps1',
+    context: null,
+    reason: 'hajisensai/Magpie 是外部 fork 仓库真名（slim 包从它的 release 下载），'
+        '与本仓改名无关。',
+  ),
+];
+
+/// C：构建/打包配置里的旧代号词根。
+final List<_Exemption> _legacyWordExemptions = <_Exemption>[
+  _Exemption(
+    pathSuffix: 'android/app/src/main/AndroidManifest.xml',
+    context: null,
+    reason: '同 A：queries 的旧包声明与其说明注释。',
+  ),
+  _Exemption(
+    pathSuffix: 'android/app/proguard-rules.pro',
+    context: null,
+    reason: '同 A：keep 规则的根因叙述注释。',
+  ),
+  _Exemption(
+    pathSuffix: 'windows/installer/fushi.iss',
+    context: null,
+    reason: '安装器的**旧名清理**段：删旧 exe / 旧快捷方式 / 旧 ProgID / 旧互斥量，'
+        '旧字面量正是这件事本身。其正确性由 '
+        'windows_installer_legacy_cleanup_guard_test 单独守。',
+  ),
+  _Exemption(
+    pathSuffix: 'windows/CMakeLists.txt',
+    context: RegExp('Magpie-hibiki-slim'),
+    reason: 'Magpie-hibiki-slim-x64.zip 是外部 fork 仓库的 release 资产真名（随包'
+        '归档），不是本仓产物名。',
+  ),
+];
+
+/// listSync 在 Windows 上回 \ 分隔的路径；豁免表与报错统一用正斜杠。
+String _normalize(String path) => path.replaceAll(Platform.pathSeparator, '/');
+
+Iterable<File> _filesOf(List<_ScanRoot> roots) sync* {
+  for (final _ScanRoot root in roots) {
+    if (root.extensions == null) {
+      final File file = File(root.path);
+      if (!file.existsSync()) {
+        throw StateError('扫描面缺失：${root.path}（文件被改名/移动了？请同步更新本守卫——'
+            '静默跳过等于把这个文件永久移出守卫范围）');
+      }
+      yield file;
+      continue;
+    }
+    final Directory dir = Directory(root.path);
+    if (!dir.existsSync()) {
+      throw StateError('扫描根缺失：${root.path}（目录被改名/移动了？请同步更新本守卫——'
+          '静默跳过等于把整棵目录永久移出守卫范围）');
+    }
+    yield* dir.listSync(recursive: true).whereType<File>().where((File f) {
+      final String path = _normalize(f.path);
+      final int dot = path.lastIndexOf('.');
+      return dot >= 0 && root.extensions!.contains(path.substring(dot));
+    });
+  }
+}
+
+/// 一次命中：文件、行号、整行文本（行级 context 判定用）、匹配串。
+class _Hit {
+  const _Hit(this.path, this.line, this.text, this.match);
+
+  final String path;
+  final int line;
+  final String text;
+  final String match;
+
+  @override
+  String toString() => '$path:$line -> $match    | $text';
+}
+
+List<_Hit> _collect(Iterable<File> files, RegExp pattern,
+    {bool Function(String match)? isViolation}) {
+  final List<_Hit> hits = <_Hit>[];
+  for (final File f in files) {
+    final String path = _normalize(f.path);
+    final List<String> lines = f.readAsStringSync().split('\n');
+    for (int i = 0; i < lines.length; i++) {
+      for (final RegExpMatch m in pattern.allMatches(lines[i])) {
+        final String matched = m.group(0)!;
+        if (isViolation != null && !isViolation(matched)) continue;
+        hits.add(_Hit(path, i + 1, lines[i].trim(), matched));
+      }
+    }
+  }
+  return hits;
+}
+
+/// 按豁免表分流：违规清单 + 每条豁免的真实命中数（过期检测用）。
+class _Partition {
+  const _Partition(this.violations, this.exemptionHits);
+
+  final List<_Hit> violations;
+  final List<int> exemptionHits;
+}
+
+_Partition _partition(List<_Hit> hits, List<_Exemption> exemptions) {
+  final List<_Hit> violations = <_Hit>[];
+  final List<int> counts = List<int>.filled(exemptions.length, 0);
+  for (final _Hit hit in hits) {
+    bool exempted = false;
+    for (int i = 0; i < exemptions.length; i++) {
+      final _Exemption e = exemptions[i];
+      if (!hit.path.endsWith(e.pathSuffix)) continue;
+      if (e.context != null && !e.context!.hasMatch(hit.text)) continue;
+      counts[i]++;
+      exempted = true;
+      break;
+    }
+    if (!exempted) violations.add(hit);
+  }
+  return _Partition(violations, counts);
+}
+
+void _expectNoStaleExemptions(
+    List<_Exemption> exemptions, List<int> counts, String label) {
+  final List<String> stale = <String>[];
+  for (int i = 0; i < exemptions.length; i++) {
+    if (counts[i] != 0) continue;
+    final _Exemption e = exemptions[i];
+    final String ctx = e.context == null ? '' : ' / ${e.context!.pattern}';
+    stale.add('[$label] ${e.pathSuffix}$ctx（已无真实命中）'
+        '\n        原豁免理由：${e.reason}');
+  }
+  expect(stale, isEmpty,
+      reason: '白名单条目已无真实命中，请连同豁免一起删掉（防止豁免退化成盲区）：\n'
+          '${stale.join('\n')}');
+}
+
+String _requiredMatch(File file, RegExp pattern, String what) {
+  final RegExpMatch? m = pattern.firstMatch(file.readAsStringSync());
+  if (m == null) {
+    throw StateError('真相源 ${_normalize(file.path)} 里读不到 $what——它被改格式/挪走了？'
+        '本守卫的全部断言都从它反推，读不到就必须停下来修守卫，而不是放行。');
+  }
+  return m.group(1)!;
+}
+
+void main() {
+  // ---- 真相源 ----------------------------------------------------------
+  final String applicationId = _requiredMatch(
+    File('android/app/build.gradle'),
+    RegExp(r'^\s*applicationId\s+"([^"]+)"', multiLine: true),
+    'applicationId',
+  );
+  final String repoSlug = _requiredMatch(
+    File('lib/src/utils/misc/update_checker_release.dart'),
+    RegExp(r"kGitHubRepo\s*=\s*'([^']+)'"),
+    'kGitHubRepo',
+  );
+  final String repoOwner = repoSlug.split('/').first;
+  final String repoName = repoSlug.split('/').last;
+
+  late final List<File> buildConfigFiles;
+  late final List<File> scriptFiles;
+
+  setUpAll(() {
+    buildConfigFiles = _filesOf(_buildConfigRoots).toList();
+    scriptFiles = _filesOf(_scriptRoots).toList();
+  });
+
+  test('真相源自洽：applicationId 是 app.<brand>.reader，且与仓库名同 brand', () {
+    // 三条禁模式都靠这两个真值反推；它们自己变形了守卫就失去意义。
+    expect(
+        RegExp(r'^app\.[A-Za-z0-9_]+\.reader$').hasMatch(applicationId), isTrue,
+        reason: 'applicationId 形态变了（当前 $applicationId），A 条的正则窗口需要同步。');
+    expect(repoSlug.split('/'), hasLength(2),
+        reason: 'kGitHubRepo 必须是 owner/repo（当前 $repoSlug）。');
+    expect(applicationId.split('.')[1].toLowerCase(), repoName.toLowerCase(),
+        reason: 'applicationId 的品牌段（${applicationId.split('.')[1]}）与 GitHub 仓库名'
+            '（$repoName）不一致——改名只做了一半，或本守卫的真相源选错了。');
+  });
+
+  test('A：脚本与构建配置里不得出现失效的 app.<x>.reader 包名', () {
+    final List<_Hit> hits = _collect(
+      <File>[...buildConfigFiles, ...scriptFiles],
+      RegExp(r'app\.[A-Za-z0-9_]+\.reader'),
+      isViolation: (String m) => m != applicationId,
+    );
+    final _Partition result = _partition(hits, _appIdExemptions);
+    expect(result.violations, isEmpty,
+        reason: '这些位置命名的应用包不是当前 applicationId（$applicationId）。adb '
+            'run-as / pm / am、MethodChannel 前缀、R8 keep 规则都按包名精确匹配，'
+            '错一个字就是「不报错但一个都匹配不到」：\n'
+            '${result.violations.join('\n')}');
+    _expectNoStaleExemptions(_appIdExemptions, result.exemptionHits, 'A');
+  });
+
+  test('B：脚本与构建配置里的 GitHub 仓库 slug 必须是当前仓库', () {
+    final List<_Hit> hits = _collect(
+      <File>[...buildConfigFiles, ...scriptFiles],
+      RegExp('$repoOwner/[A-Za-z0-9_.-]+'),
+      isViolation: (String m) =>
+          m.split('/').last.toLowerCase() != repoName.toLowerCase(),
+    );
+    final _Partition result = _partition(hits, _repoSlugExemptions);
+    expect(result.violations, isEmpty,
+        reason: '这些位置引用的仓库不是当前仓库（$repoSlug）。gh / curl 打到改名前的 '
+            'slug 只会拿到 404 或重定向，发版与巡检脚本会静默空跑：\n'
+            '${result.violations.join('\n')}');
+    _expectNoStaleExemptions(_repoSlugExemptions, result.exemptionHits, 'B');
+  });
+
+  test('C：构建/打包配置里不得残留旧代号词根', () {
+    final List<_Hit> hits = _collect(
+      buildConfigFiles,
+      RegExp('hibiki|hoshi', caseSensitive: false),
+    );
+    final _Partition result = _partition(hits, _legacyWordExemptions);
+    expect(result.violations, isEmpty,
+        reason: '产物名、二进制名、窗口标题、application id、安装器与 workspace 元数据'
+            '都在这些文件里定；旧代号留在这里不会让编译或测试红，只会让发出去的包'
+            '带着旧身份。如属冻结契约/外部真名，请按「文件 + 行级 context」加豁免'
+            '并写理由：\n${result.violations.join('\n')}');
+    _expectNoStaleExemptions(_legacyWordExemptions, result.exemptionHits, 'C');
+  });
+}

--- a/fushi/tool/run_windows_itest.ps1
+++ b/fushi/tool/run_windows_itest.ps1
@@ -1,7 +1,7 @@
-# Runs a Hibiki Windows integration test in an isolated background runner.
+# Runs a Fushi Windows integration test in an isolated background runner.
 #
-# The script never touches user-owned Hibiki instances (e.g.
-# D:\APP\Hibiki\fushi.exe) or IDE dart/flutter processes: those are only recorded
+# The script never touches user-owned Fushi instances (e.g.
+# D:\APP\Fushi\fushi.exe) or IDE dart/flutter processes: those are only recorded
 # as evidence. It DOES reap stale TEST-RUNNER processes from a previous crashed run
 # of this same runner, scoped strictly to this worktree's build\windows\x64\runner
 # path (a stuck prior runner locks the build/debug port -> "Unable to start the
@@ -360,7 +360,7 @@ $runnerInfoPath = Join-Path $EvidenceDir "runner-info.json"
   "[itest] runId=$RunId",
   "[itest] target=$Target",
   "[itest] evidenceDir=$EvidenceDir",
-  "[itest] user Hibiki instances before=$($before.Count)",
+  "[itest] user Fushi instances before=$($before.Count)",
   "[itest] command=$commandLine",
   "[itest] pubCache=$RealPubCache",
   "[itest] proxy=$(if ([string]::IsNullOrWhiteSpace($EffectiveProxy)) { '(none)' } else { $EffectiveProxy })",
@@ -371,7 +371,7 @@ $runnerInfoPath = Join-Path $EvidenceDir "runner-info.json"
 # Reap stale TEST-RUNNER processes left by a PREVIOUS crashed run of THIS runner.
 # Scope is strictly this worktree's build\windows\x64\runner path (isTestRunner is
 # set by exact path-prefix match in Get-FushiProcessSnapshot), so this NEVER kills
-# the user's installed Hibiki (e.g. D:\APP\Hibiki\fushi.exe) or IDE dart/flutter
+# the user's installed Fushi (e.g. D:\APP\Fushi\fushi.exe) or IDE dart/flutter
 # processes. A stuck prior test-runner locks the build output / debug port and is a
 # known cause of "Unable to start the app on the device". Never hand-kill by name.
 if (-not $DryRun) {

--- a/fushi/windows/CMakeLists.txt
+++ b/fushi/windows/CMakeLists.txt
@@ -104,7 +104,7 @@ install(TARGETS fushidicts_ffi RUNTIME DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
   COMPONENT Runtime)
 
 # === 内置 libtorrent 引擎（可选，vendored 预编译）===
-# hibiki_torrent 依赖 libtorrent+boost+openssl（vcpkg 首次源码编译约 40min），
+# fushi_torrent 依赖 libtorrent+boost+openssl（vcpkg 首次源码编译约 40min），
 # 不能强制每台构建机装 vcpkg。故采用 vendored 预编译：由
 # native/fushi_torrent/build_windows_dll.ps1 事先产出 4 个 DLL 到
 # prebuilt/windows-x64/，这里「有则拷、无则跳」——目录不存在时 flutter build
@@ -125,7 +125,7 @@ foreach(_dll ${FUSHI_TORRENT_DLLS})
 endforeach()
 
 # === galgame hook helper 随包归档（可选，本地/CI 事先构建）===
-# helper（injector exe + hook DLL）**绝不链接进 Hibiki.exe**，它以隔离子进程/DLL
+# helper（injector exe + hook DLL）**绝不链接进 fushi.exe**，它以隔离子进程/DLL
 # 运行，随主包分发的是两架构 zip + sha256 侧车，app 校验后解压到 voice_hook/<arch>/。
 # 运行期定位是「exe 同级的 galgame_helper/」（galgame_helper_installer.dart 的
 # _bundledDirectory）。

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,5 +1,5 @@
 name: fushi_workspace
-repository: https://github.com/hajisensai/hibiki
+repository: https://github.com/hajisensai/Fushi
 
 packages:
   - packages/*
@@ -28,7 +28,7 @@ scripts:
   dev:
     run: |
       cd fushi && flutter run
-    description: Run Hibiki in debug mode
+    description: Run Fushi in debug mode
 
   build:android:
     run: |

--- a/run.ps1
+++ b/run.ps1
@@ -1,4 +1,4 @@
-# Launch the Hibiki Flutter app in debug mode (PowerShell).
+# Launch the Fushi Flutter app in debug mode (PowerShell).
 #
 # Usage (from the repo root):
 #   .\run.ps1                    # run on Windows desktop (default)
@@ -13,7 +13,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 $Root = $PSScriptRoot
-$AppDir = Join-Path $Root "hibiki"
+$AppDir = Join-Path $Root "fushi"
 
 $Flutter = $env:FLUTTER_BIN
 if (-not $Flutter) {

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Launch the Hibiki Flutter app in debug mode (bash / git-bash).
+# Launch the Fushi Flutter app in debug mode (bash / git-bash).
 #
 # Usage (from the repo root):
 #   ./run.sh                   # run on Windows desktop (default)
@@ -10,7 +10,7 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-APP_DIR="$ROOT/hibiki"
+APP_DIR="$ROOT/fushi"
 
 FLUTTER="${FLUTTER_BIN:-}"
 if [[ -z "$FLUTTER" ]]; then

--- a/scripts/gh_download_stats.py
+++ b/scripts/gh_download_stats.py
@@ -2,7 +2,7 @@
 """GitHub Release 下载统计脚本。
 
 用法:
-    python gh_download_stats.py                          # 默认 hajisensai/hibiki
+    python gh_download_stats.py                          # 默认 hajisensai/Fushi
     python gh_download_stats.py owner/repo               # 指定仓库
     python gh_download_stats.py owner/repo --token TOKEN  # 带 token（私有仓库 / 提高限额）
 """
@@ -13,7 +13,7 @@ import sys
 from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 
-DEFAULT_REPO = "hajisensai/hibiki"
+DEFAULT_REPO = "hajisensai/Fushi"
 API_BASE = "https://api.github.com"
 
 
@@ -83,7 +83,7 @@ def print_stats(releases: list[dict], repo: str) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="GitHub Release 下载统计")
-    parser.add_argument("repo", nargs="?", default=DEFAULT_REPO, help="owner/repo（默认 hajisensai/hibiki）")
+    parser.add_argument("repo", nargs="?", default=DEFAULT_REPO, help="owner/repo（默认 hajisensai/Fushi）")
     parser.add_argument("--token", "-t", help="GitHub personal access token（私有仓库必须）")
     args = parser.parse_args()
 

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hibiki-js-behavior-tests",
+  "name": "fushi-js-behavior-tests",
   "version": "1.0.0",
   "private": true,
   "type": "module",

--- a/tool/apple_signing_secrets.sh
+++ b/tool/apple_signing_secrets.sh
@@ -21,7 +21,7 @@
 
 set -euo pipefail
 
-REPO="hajisensai/hibiki"
+REPO="hajisensai/Fushi"
 VERIFY_ONLY=false
 TEAM_ID=""
 ASC_KEY_ID=""
@@ -163,7 +163,7 @@ fi
 if [ -n "$IOS_PROFILE" ]; then
   echo "ios provisioning profile ($IOS_PROFILE):"
   [ -f "$IOS_PROFILE" ] || die "profile not found: $IOS_PROFILE"
-  PROFILE_PLIST="$(mktemp -t hibiki-profile)"
+  PROFILE_PLIST="$(mktemp -t fushi-profile)"
   trap 'rm -f "$PROFILE_PLIST"' EXIT
   if ! security cms -D -i "$IOS_PROFILE" > "$PROFILE_PLIST" 2>/dev/null; then
     fail "不是 CMS 签名的 .mobileprovision"
@@ -195,7 +195,7 @@ if [ -n "$IOS_PROFILE" ]; then
     # 描述文件里嵌着它授权的证书列表；CI 用的 p12 必须在其中，否则 codesign 过了
     # 而 App Store 校验会拒。
     if [ -n "$IOS_CERT" ]; then
-      CERT_DER="$(mktemp -t hibiki-cert)"
+      CERT_DER="$(mktemp -t fushi-cert)"
       openssl pkcs12 -in "$IOS_CERT" -passin "pass:$IOS_CERT_PASSWORD" -nokeys -clcerts 2>/dev/null \
         | openssl x509 -outform DER -out "$CERT_DER" 2>/dev/null || true
       CERT_FP="$(openssl x509 -inform DER -in "$CERT_DER" -noout -fingerprint -sha1 2>/dev/null \
@@ -203,7 +203,7 @@ if [ -n "$IOS_PROFILE" ]; then
       MATCHED=false
       INDEX=0
       while /usr/libexec/PlistBuddy -c "Print :DeveloperCertificates:$INDEX" "$PROFILE_PLIST" >/dev/null 2>&1; do
-        EMBEDDED="$(mktemp -t hibiki-embedded)"
+        EMBEDDED="$(mktemp -t fushi-embedded)"
         /usr/libexec/PlistBuddy -c "Print :DeveloperCertificates:$INDEX" "$PROFILE_PLIST" > /dev/null
         plutil -extract "DeveloperCertificates.$INDEX" raw -o - "$PROFILE_PLIST" 2>/dev/null \
           | base64 --decode > "$EMBEDDED" 2>/dev/null || true

--- a/tool/bootstrap.ps1
+++ b/tool/bootstrap.ps1
@@ -110,7 +110,7 @@ function Test-PubDevReachable {
         $request.Method = 'HEAD'
         $request.Timeout = $TimeoutSec * 1000
         $request.ReadWriteTimeout = $TimeoutSec * 1000
-        $request.UserAgent = 'hibiki-bootstrap'
+        $request.UserAgent = 'fushi-bootstrap'
         if ($ProxyUrl) {
             $request.Proxy = New-Object Net.WebProxy($ProxyUrl, $true)
         }

--- a/tool/ci_sweep.sh
+++ b/tool/ci_sweep.sh
@@ -11,7 +11,7 @@
 #                                      #   判真红/修复等判断类工作留给值班会话）
 # --file 的 DB **锚定脚本所在仓库根**（$0/../.vibe-coxswain/board.db 的绝对路径，
 # VIBE_COXSWAIN_DB 显式设置时才让位），并要求 DB 已存在——绝不静默新建空库落板。
-# 环境变量：CI_SWEEP_REPO（默认 hajisensai/hibiki）/ CI_SWEEP_SELF（默认 hajisensai）
+# 环境变量：CI_SWEEP_REPO（默认 hajisensai/Fushi）/ CI_SWEEP_SELF（默认 hajisensai）
 #           CI_SWEEP_DAYS（默认 3，只看窗口内的失败）/ CI_SWEEP_LIMIT（默认 50）
 # 去重键 = 「workflow@branch」（标题前缀 token）：同一 workflow 在同一分支反复红，
 # 活跃 todo 在板上就不重复落；修好关单后再红 = 新落一条（回归，应有新单）。
@@ -25,7 +25,7 @@ for arg in "$@"; do
   esac
 done
 
-REPO="${CI_SWEEP_REPO:-hajisensai/hibiki}"
+REPO="${CI_SWEEP_REPO:-hajisensai/Fushi}"
 SELF="${CI_SWEEP_SELF:-hajisensai}"
 DAYS="${CI_SWEEP_DAYS:-3}"
 LIMIT="${CI_SWEEP_LIMIT:-50}"

--- a/tool/ffmpeg-min/smoke-test.sh
+++ b/tool/ffmpeg-min/smoke-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Behavioral contract for Hibiki's minimal desktop FFmpeg.
+# Behavioral contract for Fushi's minimal desktop FFmpeg.
 #
 # A full host FFmpeg generates tiny representative inputs. The minimal binary
 # must then execute the same argument shapes used by desktop_audio_clipper.dart
@@ -47,7 +47,7 @@ assert_log_contains() {
 cat >"$WORK/sub.srt" <<'EOF'
 1
 00:00:00,100 --> 00:00:01,400
-Hibiki minimal FFmpeg smoke test.
+Fushi minimal FFmpeg smoke test.
 EOF
 
 cat >"$WORK/sub.ass" <<'EOF'
@@ -62,7 +62,7 @@ Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
-Dialogue: 0,0:00:00.10,0:00:01.40,Default,,0,0,0,,Hibiki ASS smoke test.
+Dialogue: 0,0:00:00.10,0:00:01.40,Default,,0,0,0,,Fushi ASS smoke test.
 EOF
 
 echo "[ffmpeg-min-smoke] generating representative inputs in $WORK"
@@ -298,7 +298,7 @@ run "$FIXTURE_FFMPEG" -hide_banner -loglevel error -i "$WORK/clip.mp4" -f null -
 
 echo "[ffmpeg-min-smoke] verifying movtext encoder + soft-subtitle clip mux"
 # Clip export muxes the subtitle the user is actually watching into the exported
-# .mp4 as a soft subtitle stream. The cues live in Dart memory (Hibiki renders
+# .mp4 as a soft subtitle stream. The cues live in Dart memory (Fushi renders
 # subtitles in a Flutter overlay, not via libmpv), so they are written out as a
 # temporary SRT and fed to ffmpeg as a second input -- which needs the srt
 # demuxer + subrip decoder on the way in, and the movtext ENCODER on the way out
@@ -350,9 +350,9 @@ fi
 run "$FIXTURE_FFMPEG" -hide_banner -loglevel error -y \
   -f lavfi -i "sine=frequency=440:duration=1" \
   -c:a aac \
-  -metadata title="Hibiki Probe Title" \
-  -metadata artist="Hibiki Probe Artist" \
-  -metadata album="Hibiki Probe Album" \
+  -metadata title="Fushi Probe Title" \
+  -metadata artist="Fushi Probe Artist" \
+  -metadata album="Fushi Probe Album" \
   "$WORK/tagged.m4a"
 "$FFPROBE_MIN" -v quiet -print_format json -show_format \
   "$WORK/tagged.m4a" >"$WORK/tags.json" 2>"$WORK/tags.err" || {
@@ -361,8 +361,8 @@ run "$FIXTURE_FFMPEG" -hide_banner -loglevel error -y \
   exit 1
 }
 assert_nonempty "$WORK/tags.json"
-assert_log_contains "$WORK/tags.json" "Hibiki Probe Title"
-assert_log_contains "$WORK/tags.json" "Hibiki Probe Artist"
+assert_log_contains "$WORK/tags.json" "Fushi Probe Title"
+assert_log_contains "$WORK/tags.json" "Fushi Probe Artist"
 
 # Shape 2: font attachment enumeration -- _enumerateFontAttachments()
 # (fushi/lib/src/media/video/subtitle_embedded_fonts.dart). `-select_streams t`

--- a/tool/gen_star_history_svg.py
+++ b/tool/gen_star_history_svg.py
@@ -10,7 +10,7 @@ runtime and used only for API Authorization headers.
 
 Usage:
     GITHUB_TOKEN=... python tool/gen_star_history_svg.py \
-        --repo hajisensai/hibiki --out docs/assets/star-history.svg
+        --repo hajisensai/Fushi --out docs/assets/star-history.svg
 """
 
 from __future__ import annotations
@@ -257,8 +257,8 @@ def main(argv: List[str]) -> int:
     parser = argparse.ArgumentParser(description="Generate a star-history SVG.")
     parser.add_argument(
         "--repo",
-        default=os.environ.get("STAR_HISTORY_REPO", "hajisensai/hibiki"),
-        help="owner/name of the repository (default: hajisensai/hibiki)",
+        default=os.environ.get("STAR_HISTORY_REPO", "hajisensai/Fushi"),
+        help="owner/name of the repository (default: hajisensai/Fushi)",
     )
     parser.add_argument(
         "--out",

--- a/tool/pr_sweep.sh
+++ b/tool/pr_sweep.sh
@@ -12,7 +12,7 @@
 # --file 的 DB **锚定脚本所在仓库根**（$0/../.vibe-coxswain/board.db 的绝对路径，
 # VIBE_COXSWAIN_DB 显式设置时才让位），并要求 DB 已存在——绝不静默新建空库落板
 # （错 cwd 落错库还报成功是对抗审查抓过的 major）。
-# 环境变量：PR_SWEEP_REPO（默认 hajisensai/hibiki）/ PR_SWEEP_BASE（默认 develop）
+# 环境变量：PR_SWEEP_REPO（默认 hajisensai/Fushi）/ PR_SWEEP_BASE（默认 develop）
 #           PR_SWEEP_SELF（默认 hajisensai）/ PR_SWEEP_LIMIT（默认 40）
 # 输出供值班 PM 与看板对照：「自动处理」区每行都应有对应 todo（按 PR 号/分支名
 # grep 看板），没有就建（--file 已自动建）；「外部 PR」区只读不动。
@@ -55,7 +55,7 @@ for arg in "$@"; do
   esac
 done
 
-REPO="${PR_SWEEP_REPO:-hajisensai/hibiki}"
+REPO="${PR_SWEEP_REPO:-hajisensai/Fushi}"
 BASE="${PR_SWEEP_BASE:-develop}"
 SELF="${PR_SWEEP_SELF:-hajisensai}"
 LIMIT="${PR_SWEEP_LIMIT:-40}"

--- a/tool/proxy_env.sh
+++ b/tool/proxy_env.sh
@@ -15,7 +15,7 @@
 # 用法：在脚本开头 `source "$(dirname "${BASH_SOURCE[0]}")/proxy_env.sh"`，
 # 它只导出 HTTPS_PROXY / HTTP_PROXY，不产生任何输出（除非 FUSHI_PROXY_VERBOSE=1）。
 
-hibiki_resolve_proxy() {
+fushi_resolve_proxy() {
   # 1) 调用方已设
   if [ -n "${HTTPS_PROXY:-}" ] || [ -n "${HTTP_PROXY:-}" ] || [ -n "${ALL_PROXY:-}" ]; then
     _fushi_proxy="${HTTPS_PROXY:-${HTTP_PROXY:-$ALL_PROXY}}"
@@ -64,7 +64,7 @@ hibiki_resolve_proxy() {
   return 0
 }
 
-hibiki_resolve_proxy
+fushi_resolve_proxy
 if [ -n "${_fushi_proxy:-}" ]; then
   export HTTPS_PROXY="$_fushi_proxy"
   export HTTP_PROXY="${HTTP_PROXY:-$_fushi_proxy}"

--- a/tool/publish_update_manifest.sh
+++ b/tool/publish_update_manifest.sh
@@ -29,7 +29,7 @@
 #   NOTES             release notes / body
 #   RELEASE_SEQUENCE  monotonic git rev-list count (NOT a workflow run-number)
 #   VERSION           normalized version (build_version_name)
-#   REPO              owner/repo, e.g. hajisensai/hibiki
+#   REPO              owner/repo, e.g. hajisensai/Fushi
 #   GITHUB_TOKEN      token with contents:write on REPO
 #   ARTIFACTS_DIR     dir holding the built release assets for THIS platform
 #   ASSET_GLOB        glob (relative to ARTIFACTS_DIR) of this platform's assets

--- a/tool/reader_pitch_headless/package.json
+++ b/tool/reader_pitch_headless/package.json
@@ -2,7 +2,7 @@
   "name": "reader-pitch-headless",
   "version": "1.0.0",
   "private": true,
-  "description": "Headless Chrome probe for Hibiki vertical reader pagination column-period geometry (BUG-405 regression tool).",
+  "description": "Headless Chrome probe for Fushi vertical reader pagination column-period geometry (BUG-405 regression tool).",
   "type": "commonjs",
   "scripts": {
     "probe": "node band_period_probe.js"

--- a/启动Hibiki最新版.bat
+++ b/启动Hibiki最新版.bat
@@ -1,9 +1,9 @@
 @echo off
 setlocal enabledelayedexpansion
-title Hibiki Launcher
+title Fushi Launcher
 
 rem ============================================================
-rem  Hibiki smart launcher
+rem  Fushi smart launcher
 rem  Compare git HEAD with last-built commit:
 rem    - updated / never built -> pub get + release build, then run
 rem    - already latest         -> just run the existing exe
@@ -11,9 +11,9 @@ rem  Force clean rebuild: pass argument "clean"
 rem ============================================================
 
 set "REPO=D:\APP\vs_claude_code\hibiki"
-set "APP=%REPO%\hibiki"
+set "APP=%REPO%\fushi"
 set "FLUTTER=D:\flutter_sdk\flutter_extracted\flutter\bin\flutter.bat"
-set "EXE=%APP%\build\windows\x64\runner\Release\hibiki.exe"
+set "EXE=%APP%\build\windows\x64\runner\Release\fushi.exe"
 set "STAMP=%APP%\build\.last_built_commit"
 
 cd /d "%APP%"


### PR DESCRIPTION
## 背景

W9「Hibiki→Fushi」改名 sweep 已经漏了至少三批，共同模式是：字符串藏在**配置 / 脚本 / 构建规则**里，改名工具只改了代码符号和目录名。这类失效**不会让编译红、不会让 `flutter analyze` 红、不会让单测红**，只在运行时或发版时炸（最狠的一次是 proguard keep 规则指向失效包名 → R8 混淆全 app → release 包启动即闪退）。

本 PR 做一次系统性复核 + 修掉剩余漏网 + 加一条针对这类文件的守卫。**未触碰 `.github/`**（另有 agent 在改）。

## 修了什么

### A. 脚本自身打空（`adb` / `gh` / `cd` 全部失效）

| 位置 | 症状 |
|---|---|
| `ci/emulator-test.sh:18`、`ci/integration-test.sh:27`、`ci/anki-integration-test.sh:25`、`ci/lib/provision-ankidroid.sh:21` | `PKG` 默认值仍是 `app.hibiki.reader` → `adb install/uninstall`、`am start -n $PKG/.MainActivity`、`pm enable "$PKG/.MainActivityDefault"` 全部指向不存在的包 |
| `run.sh:13`、`run.ps1:16` | `APP_DIR = $ROOT/hibiki`，该目录已 `git mv` 成 `fushi/` → 脚本直接 `cd` 失败 |
| `启动Hibiki最新版.bat` | 同上，且 `EXE=...\Release\hibiki.exe`（真名已是 `fushi.exe`） |
| `tool/apple_signing_secrets.sh:24`、`tool/ci_sweep.sh:28`、`tool/pr_sweep.sh:58`、`tool/publish_update_manifest.sh`、`tool/gen_star_history_svg.py`、`scripts/gh_download_stats.py`、`melos.yaml:2` | 仓库 slug 仍是 `hajisensai/hibiki`（真名 `hajisensai/Fushi`）→ `gh` 打 404/重定向 |
| `.codex-test/tools/*.ps1` | 默认 `$Package`、`sqlite3 databases/hibiki.db`（真名 `fushi.db`）、`$repoRoot/hibiki` 应用目录 |

### B. 构建/打包配置产出旧身份

- `fushi/linux/CMakeLists.txt`：`BINARY_NAME "hibiki"` / `APPLICATION_ID "com.example.hibiki"`（Windows 侧已是 `fushi`）；`linux/runner/my_application.cc` 窗口标题同批。仓库内无任何消费方按名取 linux 产物，release 也不出 linux 包，改名零破坏。
- `fushi/android/app/build.gradle:200`：`def appName = "hibiki"` → APK 输出名前缀。
- `fushi/ios/Runner.xcodeproj/project.pbxproj`：`FUSHIDICTS_BUILD_DIR = .../ephemeral/hoshidicts/...`（macOS 侧 `AppInfo.xcconfig` 已是 `ephemeral/fushidicts`），三处。
- `fushi/windows/CMakeLists.txt` / `proguard-rules.pro` 里的陈旧注释（`hibiki_torrent 依赖`、`绝不链接进 Hibiki.exe`）。

### C. `docs/agent/` 里已失效的操作指引

- **`apple-signing.md` 与真相源相反**：写着「Android `applicationId` 保持 `app.hibiki.reader` 是硬约束、不动」，而 `android/app/build.gradle:143` 早已是 `app.fushi.reader`，MethodChannel 前缀也已切 `app.fushi.reader/*`。照这份文档「修」会把 develop 改回闪退状态。已按桥包迁移方案重写并链到 `docs/plans/2026-08-06-rename-fushi-migration.md`。
- **`fast-workflow.md` 列的守卫命令指向不存在的文件**：`test/pages/reader_hibiki_page_source_corpus_test.dart` / `video_hibiki_page_source_corpus_test.dart`（真名 `*_fushi_*`）。
- `external-video-open.md` 的 ProgId `Hibiki.Video` / `hibiki.exe` 与 `fushi.iss` 实际注册的 `Fushi.Video` / `fushi.exe` 相反。
- `integration-testing.md` 的 `run-as app.hibiki.reader sqlite3 files/hibiki.db`。
- 一批已改名符号：`ReaderHibikiPage`/`ReaderHibikiSource`/`VideoHibikiPage`/`ReaderHibikiHistoryPage`/`HibikiFocusScroll`/`HibikiShortcutRegistry`/`HibikiSingleInstanceMutex`/`HIBIKI_METHOD_BODY_AUDIT`/`__hoshiEntryWheelBindings`/`hoshiFocusDictionaryEntryMove`/`app.hibiki/external_video`（逐个对着代码核过真名）。
- `build.md` 的产物名（真相源 `release.yml` / `release-desktop.yml` 早已产出 `fushi-*.apk` / `fushi-*-windows-setup.exe`）与 `repos/hajisensai/hibiki` API 示例。

## 有意保留（复核后判定不改）

- `AndroidManifest.xml` 的 `<queries><package android:name="app.hibiki.reader" />`：Android 11+ 包可见性，迁移导入器要查**旧包**。
- `lib/src/migration/migration_target_channel.dart` 的 `kHibikiPackageName`、`fushi_core` 的 `legacyHibikiDatabaseFileName` 等迁移常量。
- `fushi.iss` 的旧名清理段（删旧 exe / 快捷方式 / ProgID / 互斥量）——旧字面量正是这件事本身。
- 外部真名：`hajisensai/Magpie` + `magpie-hibiki` tag + `Magpie-hibiki-slim-*.zip`、`hajisensai/hibiki-hook` 仓库与其 release、Firebase `project_id: hibiki-reader`、`~/dev/hibiki`（远端 Mac 克隆根）、`~/.hibiki-apple-signing/`。
- 部署身份：`services/log-backend/cf-worker/wrangler.toml` 的 worker 名 + D1 `hibiki-logs`、`systemd/hibiki-logs.service`——改了等于把用户已部署的服务改名。
- 临时目录名 `$RUNNER_TEMP/hibiki-mihon-*` 等（workflow 显式传参，无功能耦合）。
- `.mailmap` 的 `pm@hibiki.local`（git 历史事实）。
- `README.md` / `README.zh-CN.md` / 根 `CLAUDE.md` / `AGENTS.md` / `docs/static-assets/hibiki-*.png`：**整篇产品名改名 + 截图资产改名，属独立批次**，不塞进本 PR。

## 守卫

新增 `fushi/test/build/rename_residue_build_config_guard_test.dart`，三条禁模式**全部真相源驱动**（照抄 `android_app_package_keep_rule_guard_test` 的反推思路，不硬编码新身份）：

- **A**：从 `android/app/build.gradle` 读 `applicationId`，扫描面里每个 `app.<x>.reader` 都必须等于它。
- **B**：从 `lib/src/utils/misc/update_checker_release.dart` 的 `kGitHubRepo` 读仓库 slug，扫描面里每个 `<owner>/<repo>` 都必须是同一个仓库（大小写不敏感）。
- **C**：构建/打包配置里不得残留 `hibiki` / `hoshi` 词根。

扫描面覆盖上面三类漏网的所在地（`ci/`、`tool/`、`tools/`、`scripts/`、`.codex-test/tools/`、`run.*`、以及 android/linux/windows/ios/macos 五套构建配置 + `melos.yaml`）。白名单按 **「文件 + 行级 context」** 收口（不是整文件放行）、每条写理由，并带**过期豁免检测**：某条豁免不再有真实命中时转红，逼着连豁免一起删。另有一条自洽测试锁「applicationId 品牌段 == 仓库名」，防止真相源自己漂开。

### 变异实测（四轮，红/绿都实跑）

| 变异 | 结果 |
|---|---|
| `ci/emulator-test.sh` PKG 改回旧包名 | **A 红**：`../ci/emulator-test.sh:18 -> app.hibiki.reader` |
| `tool/pr_sweep.sh` REPO 改回 `hajisensai/hibiki` | **B 红**：`../tool/pr_sweep.sh:58 -> hajisensai/hibiki` |
| `linux/CMakeLists.txt` BINARY_NAME 改回 `"hibiki"` | **C 红**：`linux/CMakeLists.txt:7 -> hibiki` |
| **在已有白名单行的文件里另加一行旧名**（`windows/CMakeLists.txt` 追加 `# ... hoshidicts ... hibiki_shim.dll`） | **C 红**：`windows/CMakeLists.txt:194`（证明行级 context 白名单没变成整文件盲区——这正是上一轮「变异后守卫仍绿」的坑） |
| 删掉被豁免的真实命中（`AndroidManifest.xml` 的 `<package app.hibiki.reader/>`） | **A 红（过期豁免检测）**：`[A] android/app/src/main/AndroidManifest.xml（已无真实命中）` |

全部用反向字符串替换还原（**未对未提交文件用 `git checkout --`**），还原后 `git diff --stat` 对 `AndroidManifest.xml` 为空、其余回到修复态。

## 验证

- `flutter analyze`（全量，含 test）：`No issues found! (ran in 20.5s)`，exit 0。
- `flutter test test/build test/tools test/native test/dictionary/fushidicts_ios_packaging_guard_test.dart --no-pub`：`All tests passed!`，**566 tests**，exit 0（未接管道判绿）。
- 4 个改动的 `ci/*.sh` + 5 个改动的 `tool/*.sh` 全部 `bash -n` 通过；改动的 `.py` 用 `ast.parse` 校验、`.json` 用 `json.load` 校验。
- `git diff --cached --check` 干净；全量扫过改动文件无 NUL/FF 等控制字符污染，`.bat` 的 CRLF 保持不变。
